### PR TITLE
fix: allow to unset global hotkeys

### DIFF
--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -149,12 +149,19 @@ func (a *App) Run() error {
 		return fmt.Errorf("failed to register hotkeys: %w", err)
 	}
 
-	a.logger.Info("GoVim is running. Press hotkeys to activate modes.")
+	a.logger.Info("GoVim is running")
 	fmt.Println("✓ GoVim is running")
-	fmt.Printf("  Hint mode (direct): %s\n", a.config.Hotkeys.ActivateHintMode)
-	fmt.Printf("  Hint mode (with actions): %s\n", a.config.Hotkeys.ActivateHintModeWithActions)
-	fmt.Printf("  Scroll mode: %s\n", a.config.Hotkeys.ActivateScrollMode)
-	fmt.Printf("  Exit mode: Escape (hardcoded)\n")
+
+	// Print configured hotkeys
+	if key := strings.TrimSpace(a.config.Hotkeys.ActivateHintMode); key != "" {
+		fmt.Printf("  Hint mode (direct): %s\n", key)
+	}
+	if key := strings.TrimSpace(a.config.Hotkeys.ActivateHintModeWithActions); key != "" {
+		fmt.Printf("  Hint mode (with actions): %s\n", key)
+	}
+	if key := strings.TrimSpace(a.config.Hotkeys.ActivateScrollMode); key != "" {
+		fmt.Printf("  Scroll mode: %s\n", key)
+	}
 
 	// Wait for interrupt signal with force-quit support
 	sigChan := make(chan os.Signal, 1)
@@ -196,31 +203,41 @@ func (a *App) Run() error {
 // registerHotkeys registers all global hotkeys
 func (a *App) registerHotkeys() error {
 	// Hint mode hotkey (direct click)
-	a.logger.Info("Registering hint mode hotkey", zap.String("key", a.config.Hotkeys.ActivateHintMode))
-	if _, err := a.hotkeyManager.Register(a.config.Hotkeys.ActivateHintMode, func() {
-		a.activateHintMode(false)
-	}); err != nil {
-		return fmt.Errorf("failed to register hint mode hotkey: %w", err)
+	if key := strings.TrimSpace(a.config.Hotkeys.ActivateHintMode); key != "" {
+		a.logger.Info("Registering hint mode hotkey", zap.String("key", key))
+		if _, err := a.hotkeyManager.Register(key, func() {
+			a.activateHintMode(false)
+		}); err != nil {
+			return fmt.Errorf("failed to register hint mode hotkey: %w", err)
+		}
 	}
 
 	// Hint mode with actions hotkey
-	a.logger.Info("Registering hint mode with actions hotkey", zap.String("key", a.config.Hotkeys.ActivateHintModeWithActions))
-	if _, err := a.hotkeyManager.Register(a.config.Hotkeys.ActivateHintModeWithActions, func() {
-		a.activateHintMode(true)
-	}); err != nil {
-		return fmt.Errorf("failed to register hint mode with actions hotkey: %w", err)
+	if key := strings.TrimSpace(a.config.Hotkeys.ActivateHintModeWithActions); key != "" {
+		a.logger.Info("Registering hint mode with actions hotkey", zap.String("key", key))
+		if _, err := a.hotkeyManager.Register(key, func() {
+			a.activateHintMode(true)
+		}); err != nil {
+			return fmt.Errorf("failed to register hint mode with actions hotkey: %w", err)
+		}
 	}
 
 	// Scroll mode hotkey
-	if _, err := a.hotkeyManager.Register(a.config.Hotkeys.ActivateScrollMode, a.activateScrollMode); err != nil {
-		return fmt.Errorf("failed to register scroll mode hotkey: %w", err)
+	if key := strings.TrimSpace(a.config.Hotkeys.ActivateScrollMode); key != "" {
+		a.logger.Info("Registering scroll mode hotkey", zap.String("key", key))
+		if _, err := a.hotkeyManager.Register(key, a.activateScrollMode); err != nil {
+			return fmt.Errorf("failed to register scroll mode hotkey: %w", err)
+		}
 	}
 
 	// Note: Escape key for exiting modes is hardcoded in handleKeyPress, not registered as global hotkey
 
 	// Reload config hotkey
-	if _, err := a.hotkeyManager.Register(a.config.Hotkeys.ReloadConfig, a.reloadConfig); err != nil {
-		a.logger.Warn("Failed to register reload config hotkey", zap.Error(err))
+	if key := strings.TrimSpace(a.config.Hotkeys.ReloadConfig); key != "" {
+		a.logger.Info("Registering reload config hotkey", zap.String("key", key))
+		if _, err := a.hotkeyManager.Register(key, a.reloadConfig); err != nil {
+			a.logger.Warn("Failed to register reload config hotkey", zap.Error(err))
+		}
 	}
 
 	return nil

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -1,5 +1,8 @@
 # GoVim Configuration
-# Copy to: ~/Library/Application Support/govim/config.toml
+# Copy to:
+#   - macOS: ~/Library/Application Support/govim/config.toml
+#   - XDG: ~/.config/govim/config.toml
+#   - Custom location: specify with --config flag
 
 [general]
 hint_characters = "asdfghjkl"
@@ -66,7 +69,11 @@ additional_bundles = [
 ]
 
 [hotkeys]
+# all hotkeys can be disabled by either setting the key to "" or just commenting it out
+
+# Activate hint mode (direct click)
 activate_hint_mode = "Cmd+Shift+Space"
+
 # Activate hint mode with action selection (choose click type after typing hint)
 activate_hint_mode_with_actions = "Cmd+Shift+A"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,10 +123,10 @@ func DefaultConfig() *Config {
 			},
 		},
 		Hotkeys: HotkeysConfig{
-			ActivateHintMode:            "Cmd+Shift+Space",
-			ActivateHintModeWithActions: "Cmd+Shift+A",
-			ActivateScrollMode:          "Cmd+Shift+J",
-			ReloadConfig:                "Cmd+Shift+R",
+			ActivateHintMode:            "",
+			ActivateHintModeWithActions: "",
+			ActivateScrollMode:          "",
+			ReloadConfig:                "",
 		},
 		Scroll: ScrollConfig{
 			ScrollSpeed:            50,
@@ -461,7 +461,7 @@ func (c *Config) Save(path string) error {
 // validateHotkey validates a hotkey string format
 func validateHotkey(hotkey, fieldName string) error {
 	if strings.TrimSpace(hotkey) == "" {
-		return fmt.Errorf("%s cannot be empty", fieldName)
+		return nil // Allow empty hotkey to disable the action
 	}
 
 	// Hotkey format: [Modifier+]*Key


### PR DESCRIPTION
Probably not everyone wants all of the hotkey registered.
