### PR TITLE
fix: auto deregister hotkeys when focused app is excluded

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -18,7 +18,7 @@ hint_characters = "asdfghjkl"
 accessibility_check_on_start = true
 
 # Applications to exclude from GoVim functionality
-# GoVim will do nothing when these applications are focused
+# GoVim will do nothing when these applications are focused and pass through everything back to the os
 # Use bundle IDs to identify applications. To find an app's bundle ID:
 # osascript -e 'id of app "AppName"'
 # Examples:


### PR DESCRIPTION
We have double check for excluded app. If an app is excluded, when we
focus on that app, it will try to deregister all the hotkeys, so that we
can use the hotkey for something else, and auto register back when focus
on non-excluded app. If that didn't work, mode activation also checks
for it as a second guard.
