### PR TITLE
fix: improve large list traversal with progressive checks

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -39,12 +39,12 @@ clickable_roles = [
     "AXCheckBox",
     "AXRadioButton",
     "AXPopUpButton",
-    "AXMenuItem",
-    "AXMenuBarItem",
-    "AXDockItem",
     "AXLink",
     "AXTextField",
     "AXTextArea",
+    "AXMenuItem", # for menubar hints - TODO: this should be injected when enabled, but now we need to put it here
+    "AXMenuBarItem", # for menubar hints - TODO: this should be injected when enabled, but now we need to put it here
+    "AXDockItem", # for dock hints - TODO: this should be injected when enabled, but now we need to put it here
 ]
 
 # Global accessibility roles that are treated as scrollable

--- a/internal/accessibility/query.go
+++ b/internal/accessibility/query.go
@@ -150,6 +150,7 @@ func GetDockClickableElements() ([]*TreeNode, error) {
 	defer dock.Release()
 
 	opts := DefaultTreeOptions()
+	opts.IncludeOutOfBounds = true
 	opts.MaxDepth = 8
 	opts.FilterFunc = func(info *ElementInfo) bool {
 		if info.Size.X < 6 || info.Size.Y < 6 {

--- a/internal/accessibility/tree.go
+++ b/internal/accessibility/tree.go
@@ -1,8 +1,10 @@
 package accessibility
 
 import (
-	"context"
-	"sync"
+	"image"
+
+	"github.com/y3owk1n/govim/internal/logger"
+	"go.uber.org/zap"
 )
 
 // TreeNode represents a node in the accessibility tree
@@ -15,18 +17,17 @@ type TreeNode struct {
 
 // TreeOptions configures tree traversal
 type TreeOptions struct {
-	MaxDepth         int
-	IncludeInvisible bool
-	FilterFunc       func(*ElementInfo) bool
-	MaxConcurrent    int
+	MaxDepth           int
+	FilterFunc         func(*ElementInfo) bool
+	IncludeOutOfBounds bool
 }
 
 // DefaultTreeOptions returns default tree traversal options
 func DefaultTreeOptions() TreeOptions {
 	return TreeOptions{
-		MaxDepth:      10,
-		MaxConcurrent: 10,
-		FilterFunc:    nil,
+		MaxDepth:           10,
+		FilterFunc:         nil,
+		IncludeOutOfBounds: false,
 	}
 }
 
@@ -41,34 +42,82 @@ func BuildTree(root *Element, opts TreeOptions) (*TreeNode, error) {
 		return nil, err
 	}
 
+	// Calculate window bounds for spatial filtering
+	windowBounds := image.Rect(
+		info.Position.X,
+		info.Position.Y,
+		info.Position.X+info.Size.X,
+		info.Position.Y+info.Size.Y,
+	)
+
+	// Add padding to catch elements slightly outside
+	windowBounds = expandRectangle(windowBounds, 50)
+
 	node := &TreeNode{
 		Element: root,
 		Info:    info,
 	}
 
 	if opts.MaxDepth > 0 {
-		buildTreeRecursive(node, 1, opts)
+		buildTreeRecursive(node, 1, opts, windowBounds)
 	}
 
 	return node, nil
 }
 
-func buildTreeRecursive(parent *TreeNode, depth int, opts TreeOptions) {
+func buildTreeRecursive(parent *TreeNode, depth int, opts TreeOptions, windowBounds image.Rectangle) {
 	if depth >= opts.MaxDepth {
 		return
 	}
-
 	children, err := parent.Element.GetChildren()
 	if err != nil || len(children) == 0 {
 		return
 	}
 
-	parent.Children = make([]*TreeNode, 0, len(children))
+	totalChildren := len(children)
 
-	for _, child := range children {
+	// Smart sampling for large containers
+	indicesToCheck := getIndicesToCheck(totalChildren, parent.Info.Role)
+
+	// Print sampling stats for large containers
+	if totalChildren > 50 {
+		logger.Debug("Sampling",
+			zap.String("role", parent.Info.Role),
+			zap.Int("total_children", totalChildren),
+			zap.Int("indices_to_check", len(indicesToCheck)),
+			zap.Float64("percent", float64(len(indicesToCheck))/float64(totalChildren)*100),
+		)
+	}
+
+	parent.Children = make([]*TreeNode, 0, len(indicesToCheck))
+
+	checkedCount := 0
+	addedCount := 0
+
+	for _, idx := range indicesToCheck {
+		if idx >= len(children) {
+			continue
+		}
+		child := children[idx]
 		info, err := child.GetInfo()
 		if err != nil {
 			continue
+		}
+
+		checkedCount++
+
+		// Skip elements that are completely outside the window bounds
+		// UNLESS IncludeOutOfBounds is true
+		if !opts.IncludeOutOfBounds {
+			elementRect := image.Rect(
+				info.Position.X,
+				info.Position.Y,
+				info.Position.X+info.Size.X,
+				info.Position.Y+info.Size.Y,
+			)
+			if !elementRect.Overlaps(windowBounds) {
+				continue
+			}
 		}
 
 		// Apply filter if provided
@@ -82,90 +131,85 @@ func buildTreeRecursive(parent *TreeNode, depth int, opts TreeOptions) {
 			Parent:   parent,
 			Children: []*TreeNode{},
 		}
-
 		parent.Children = append(parent.Children, childNode)
-		buildTreeRecursive(childNode, depth+1, opts)
+		addedCount++
+		buildTreeRecursive(childNode, depth+1, opts, windowBounds)
+	}
+
+	// Summary for this container
+	if totalChildren > 50 {
+		logger.Debug("Result: ",
+			zap.Int("checked_count", checkedCount),
+			zap.Int("added_count", addedCount),
+			zap.Int("skipped_count", totalChildren-checkedCount),
+		)
 	}
 }
 
-// BuildTreeConcurrent builds an accessibility tree using concurrent traversal
-func BuildTreeConcurrent(root *Element, opts TreeOptions) (*TreeNode, error) {
-	if root == nil {
-		return nil, nil
+// getIndicesToCheck returns which indices to check based on container type and size
+func getIndicesToCheck(totalChildren int, role string) []int {
+	// For non-list containers, check all children
+	if role != "AXList" && role != "AXTable" && role != "AXOutline" {
+		indices := make([]int, totalChildren)
+		for i := range indices {
+			indices[i] = i
+		}
+		return indices
 	}
 
-	info, err := root.GetInfo()
-	if err != nil {
-		return nil, err
+	// For small lists, check everything
+	if totalChildren <= 50 {
+		indices := make([]int, totalChildren)
+		for i := range indices {
+			indices[i] = i
+		}
+		return indices
 	}
 
-	node := &TreeNode{
-		Element: root,
-		Info:    info,
+	// For very large lists (>1000), be MUCH more conservative
+	if totalChildren > 1000 {
+		indices := make([]int, 0, 50)
+
+		// First 20 items
+		for i := 0; i < 20 && i < totalChildren; i++ {
+			indices = append(indices, i)
+		}
+
+		// Sample every 100th item in the middle (or every 5% of total, whichever is larger)
+		step := max(100, totalChildren/20)
+		for i := 20; i < totalChildren-20; i += step {
+			indices = append(indices, i)
+		}
+
+		// Last 20 items
+		start := max(totalChildren-20, 20)
+		for i := start; i < totalChildren; i++ {
+			indices = append(indices, i)
+		}
+
+		return indices
 	}
 
-	if opts.MaxDepth > 0 {
-		ctx := context.Background()
-		sem := make(chan struct{}, opts.MaxConcurrent)
-		var wg sync.WaitGroup
+	// For medium lists (50-1000), use the original strategy
+	indices := make([]int, 0, 100)
 
-		buildTreeConcurrentRecursive(ctx, node, 1, opts, sem, &wg)
-		wg.Wait()
+	// First 30
+	for i := 0; i < 30 && i < totalChildren; i++ {
+		indices = append(indices, i)
 	}
 
-	return node, nil
-}
-
-func buildTreeConcurrentRecursive(ctx context.Context, parent *TreeNode, depth int, opts TreeOptions, sem chan struct{}, wg *sync.WaitGroup) {
-	if depth >= opts.MaxDepth {
-		return
+	// Sample middle (every 10th)
+	for i := 30; i < totalChildren-20; i += 10 {
+		indices = append(indices, i)
 	}
 
-	children, err := parent.Element.GetChildren()
-	if err != nil || len(children) == 0 {
-		return
+	// Last 20
+	start := max(totalChildren-20, 30)
+	for i := start; i < totalChildren; i++ {
+		indices = append(indices, i)
 	}
 
-	parent.Children = make([]*TreeNode, 0, len(children))
-	var mu sync.Mutex
-
-	for _, child := range children {
-		wg.Add(1)
-		go func(child *Element) {
-			defer wg.Done()
-
-			// Acquire semaphore
-			select {
-			case sem <- struct{}{}:
-				defer func() { <-sem }()
-			case <-ctx.Done():
-				return
-			}
-
-			info, err := child.GetInfo()
-			if err != nil {
-				return
-			}
-
-			// Apply filter if provided
-			if opts.FilterFunc != nil && !opts.FilterFunc(info) {
-				return
-			}
-
-			childNode := &TreeNode{
-				Element:  child,
-				Info:     info,
-				Parent:   parent,
-				Children: []*TreeNode{},
-			}
-
-			mu.Lock()
-			parent.Children = append(parent.Children, childNode)
-			mu.Unlock()
-
-			buildTreeConcurrentRecursive(ctx, childNode, depth+1, opts, sem, wg)
-		}(child)
-	}
+	return indices
 }
 
 // FindClickableElements finds all clickable elements in the tree


### PR DESCRIPTION
This change should make apps that has large list (e.g. Mail.app) works
faster and just try to walk through visible children (guessing) without
going through the full list (in my case it can be 30k items without any
filtering in the app)
