### PR TITLE
feat: add notification center hints (configurable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,12 +319,13 @@ ctrl - s : scroll
 
 Read more about [CLI Usage](#%EF%B8%8F-cli-usage).
 
-#### Enable Menu Bar and Dock Hints
+#### Enable Menu Bar Dock and Notification Center Hints
 
 ```toml
 [general]
 include_menubar_hints = true
 include_dock_hints = true  # Also includes Mission Control
+include_nc_hints = true # Notification popups
 ```
 
 #### Restore cursor after click action

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -423,6 +423,16 @@ func (a *App) activateHintMode(withActions bool) {
 		}
 	}
 
+	// Optionally include Notification Center elements
+	if a.config.General.IncludeNCHints {
+		if ncElems, derr := accessibility.GetNCClickableElements(); derr == nil {
+			elements = append(elements, ncElems...)
+			a.logger.Debug("Included nc elements", zap.Int("count", len(ncElems)))
+		} else {
+			a.logger.Warn("Failed to get nc elements", zap.Error(derr))
+		}
+	}
+
 	if len(elements) == 0 {
 		a.logger.Warn("No clickable elements found")
 		return

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -28,6 +28,8 @@ excluded_apps = []
 include_menubar_hints = false
 # Show hints on the Dock (includes mission control)
 include_dock_hints = false
+# Show hints on the Notification Center
+include_nc_hints = false
 
 # Restore cursor position after action
 # Restore cursor position after left click

--- a/internal/accessibility/query.go
+++ b/internal/accessibility/query.go
@@ -189,3 +189,32 @@ func GetDockClickableElements() ([]*TreeNode, error) {
 	}
 	return tree.FindClickableElements(), nil
 }
+
+// GetNCClickableElements returns clickable elements from the Notification Center
+func GetNCClickableElements() ([]*TreeNode, error) {
+	nc := GetApplicationByBundleID("com.apple.notificationcenterui")
+	if nc == nil {
+		return []*TreeNode{}, nil
+	}
+	defer nc.Release()
+
+	opts := DefaultTreeOptions()
+	opts.IncludeOutOfBounds = true
+	opts.CheckOcclusion = false
+	opts.MaxDepth = 8
+	opts.FilterFunc = func(info *ElementInfo) bool {
+		if info.Size.X < 6 || info.Size.Y < 6 {
+			return false
+		}
+		return true
+	}
+
+	tree, err := BuildTree(nc, opts)
+	if err != nil {
+		return nil, err
+	}
+	if tree == nil {
+		return []*TreeNode{}, nil
+	}
+	return tree.FindClickableElements(), nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ type GeneralConfig struct {
 	ExcludedApps               []string `toml:"excluded_apps"`
 	IncludeMenubarHints        bool     `toml:"include_menubar_hints"`
 	IncludeDockHints           bool     `toml:"include_dock_hints"`
+	IncludeNCHints             bool     `toml:"include_nc_hints"`
 	RestorePosAfterLeftClick   bool     `toml:"restore_pos_after_left_click"`
 	RestorePosAfterRightClick  bool     `toml:"restore_pos_after_right_click"`
 	RestorePosAfterMiddleClick bool     `toml:"restore_pos_after_middle_click"`
@@ -108,6 +109,7 @@ func DefaultConfig() *Config {
 			ExcludedApps:               []string{},
 			IncludeMenubarHints:        false,
 			IncludeDockHints:           false,
+			IncludeNCHints:             false,
 			RestorePosAfterLeftClick:   false,
 			RestorePosAfterRightClick:  false,
 			RestorePosAfterMiddleClick: false,


### PR DESCRIPTION
Hints in the actual notification center are already included previously,
this is specifically for hints when a notification popup on screen.
