### PR TITLE
feat: allow to bypass heuristic checks for scrollable and clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,49 @@ excluded_apps = [
 osascript -e 'id of app "AppName"'
 ```
 
+#### Global Role Configuration
+
+You can customize clickable/scrollable roles for all apps.
+
+```toml
+[accessibility]
+
+# These are the defaults, feel free to remove or add more as you see fit
+clickable_roles = [
+    "AXButton",
+    "AXComboBox",
+    "AXCheckBox",
+    "AXRadioButton",
+    "AXLink",
+    "AXPopUpButton",
+    "AXTextField",
+    "AXSlider",
+    "AXTabButton",
+    "AXSwitch",
+    "AXDisclosureTriangle",
+    "AXTextArea",
+    "AXMenuButton",
+    "AXMenuItem",
+    "AXCell",
+    "AXRow",
+]
+
+# There are predefined heuristics checks for if an element should be clickable or not.
+# Skip role checking for clickable elements (all elements will be considered clickable)
+# Enable this if you know what you're doing
+ignore_clickable_check = false
+
+# These are the defaults, feel free to remove or add more as you see fit
+scrollable_roles = [
+    "AXScrollArea",
+]
+
+# There are predefined heuristics checks for if an element is scrollable or not.
+# Skip role checking for scrollable elements (all elements will be considered scrollable)
+# Enable this if you know what you're doing
+ignore_scrollable_check = false
+```
+
 #### Per-App Role Configuration
 
 Customize clickable/scrollable roles for specific apps. This is useful when certain apps use non-standard UI elements.

--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -80,6 +80,9 @@ func NewApp(cfg *config.Config) (*App, error) {
 		}
 	}
 
+	// Set global config
+	config.SetGlobal(cfg)
+
 	// Apply clickable and scrollable roles from config
 	log.Info("Applying clickable roles",
 		zap.Int("count", len(cfg.Accessibility.ClickableRoles)),

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -75,12 +75,22 @@ clickable_roles = [
     "AXRow",
 ]
 
+# There are predefined heuristics checks for if an element should be clickable or not.
+# Skip role checking for clickable elements (all elements will be considered clickable)
+# Enable this if you know what you're doing
+ignore_clickable_check = false
+
 # Global accessibility roles that are treated as scrollable
 # These roles will be used for ALL applications
 # Users can add or remove roles as needed
 scrollable_roles = [
     "AXScrollArea",
 ]
+
+# There are predefined heuristics checks for if an element is scrollable or not.
+# Skip role checking for scrollable elements (all elements will be considered scrollable)
+# Enable this if you know what you're doing
+ignore_scrollable_check = false
 
 # Per-app role configurations
 # These allow you to add additional clickable/scrollable roles for specific applications

--- a/internal/accessibility/element.go
+++ b/internal/accessibility/element.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"unsafe"
 
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/logger"
 	"go.uber.org/zap"
 )
@@ -472,6 +473,11 @@ func (e *Element) IsClickable() bool {
 		return false
 	}
 
+	// If ignore_clickable_check is enabled in config, return true
+	if cfg := config.Global(); cfg != nil && cfg.Accessibility.IgnoreClickableCheck {
+		return true
+	}
+
 	info := globalCache.Get(e)
 	if info == nil {
 		var err error
@@ -488,7 +494,7 @@ func (e *Element) IsClickable() bool {
 	clickableRolesMu.RUnlock()
 
 	if ok {
-		// Also verify it actually has scroll capability
+		// Also verify it actually has click action
 		result := C.hasClickAction(e.ref)
 		return result == 1
 	}
@@ -500,6 +506,11 @@ func (e *Element) IsClickable() bool {
 func (e *Element) IsScrollable() bool {
 	if e.ref == nil {
 		return false
+	}
+
+	// If ignore_scrollable_check is enabled in config, return true
+	if cfg := config.Global(); cfg != nil && cfg.Accessibility.IgnoreScrollableCheck {
+		return true
 	}
 
 	info := globalCache.Get(e)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,8 @@ type AccessibilityConfig struct {
 	AccessibilityCheckOnStart bool                `toml:"accessibility_check_on_start"`
 	ClickableRoles            []string            `toml:"clickable_roles"`
 	ScrollableRoles           []string            `toml:"scrollable_roles"`
+	IgnoreClickableCheck      bool                `toml:"ignore_clickable_check"`
+	IgnoreScrollableCheck     bool                `toml:"ignore_scrollable_check"`
 	AdditionalAXSupport       AdditionalAXSupport `toml:"additional_ax_support"`
 	AppConfigs                []AppConfig         `toml:"app_configs"`
 }

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -1,0 +1,13 @@
+package config
+
+var globalConfig *Config
+
+// SetGlobal sets the global configuration that can be accessed from anywhere
+func SetGlobal(cfg *Config) {
+	globalConfig = cfg
+}
+
+// Global returns the global configuration
+func Global() *Config {
+	return globalConfig
+}


### PR DESCRIPTION
This allows user to just blindly show all roles as hints without even
checking.
