### PR TITLE
feat: implement restore cursor after escape mode

### DIFF
--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"image"
 	"os"
 	"strings"
 
@@ -75,6 +76,10 @@ type App struct {
 	hintOverlayNeedsRefresh bool
 	hotkeyRefreshPending    bool
 	idleScrollLastKey       string // Track last scroll key in idle mode for gg support
+
+	initialCursorPos      image.Point
+	initialScreenBounds   image.Rectangle
+	cursorRestoreCaptured bool
 }
 
 // NewApp creates a new application instance.

--- a/configs/author-config.toml
+++ b/configs/author-config.toml
@@ -1,3 +1,6 @@
+[general]
+restore_cursor_position = true
+
 [hotkeys]
 "Ctrl+F" = "grid"
 "Ctrl+S" = "action scroll"

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -12,6 +12,9 @@ excluded_apps = []
 # Whether to check for accessibility permissions on startup
 accessibility_check_on_start = true
 
+# Whether to restore cursor position after exiting modes
+restore_cursor_position = false
+
 [hotkeys]
 # Hotkey bindings - key = action
 # Supported modifiers: Cmd, Ctrl, Alt, Shift, Option

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -87,7 +87,14 @@ excluded_apps = [
     "com.microsoft.rdc.macos",
 ]
 accessibility_check_on_start = true
+restore_cursor_position = true
 ```
+
+**Cursor restoration:**
+
+- When `restore_cursor_position = true`, the cursor returns to its original coordinates after exiting any mode.
+- Handles screen resolution changes by restoring proportionally within the current active screen.
+- Default is `false` if omitted.
 
 **Finding Bundle IDs:**
 
@@ -415,6 +422,7 @@ A full configuration example:
 [general]
 excluded_apps = ["com.apple.Terminal", "com.googlecode.iterm2"]
 accessibility_check_on_start = true
+restore_cursor_position = false
 
 [hints]
 enabled = true

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -263,6 +263,26 @@ TOML configuration parsing and validation.
 - Validate configuration
 - Provide defaults
 
+#### Cursor Position Restoration
+
+**Overview:**
+- Stores the initial cursor coordinates and screen bounds when entering a mode.
+- Restores the cursor on exit if enabled via `general.restore_cursor_position`.
+- Adjusts for screen resolution/origin changes by mapping the original position proportionally to the current active screen.
+
+**Key points:**
+- Config flag: `general.restore_cursor_position` (default `true`).
+- Entry points: `activateHintModeInternal`, `activateGridMode` capture once per activation.
+- Exit path: `exitMode` restores and clears state.
+
+**Usage example (config API):**
+```go
+cfg := config.Global()
+if cfg != nil && cfg.General.RestoreCursorPosition {
+    // restoration is enabled
+}
+```
+
 #### `internal/cli`
 
 Cobra-based CLI commands.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,8 @@ type Config struct {
 // GeneralConfig represents general application configuration.
 type GeneralConfig struct {
 	ExcludedApps              []string `toml:"excluded_apps"`
-	AccessibilityCheckOnStart bool     `toml:"accessibility_check_on_start"` // Moved from AccessibilityConfig
+	AccessibilityCheckOnStart bool     `toml:"accessibility_check_on_start"`
+	RestoreCursorPosition     bool     `toml:"restore_cursor_position"`
 }
 
 // AppConfig represents application-specific configuration.
@@ -160,6 +161,7 @@ func DefaultConfig() *Config {
 		General: GeneralConfig{
 			ExcludedApps:              []string{},
 			AccessibilityCheckOnStart: true,
+			RestoreCursorPosition:     false,
 		},
 		Hotkeys: HotkeysConfig{
 			Bindings: map[string]string{
@@ -212,7 +214,7 @@ func DefaultConfig() *Config {
 			},
 			IgnoreClickableCheck: false,
 
-			AppConfigs: []AppConfig{}, // Moved from AccessibilityConfig
+			AppConfigs: []AppConfig{},
 
 			AdditionalAXSupport: AdditionalAXSupport{
 				Enable:                    false,


### PR DESCRIPTION
This enables user to always restore to the cursor position that they are
at before activating the mode. It is at least useful for me.
