### PR TITLE
fix: ensure clean scroll context when switching mode

### DIFF
--- a/internal/app/actions.go
+++ b/internal/app/actions.go
@@ -35,6 +35,9 @@ func isKnownAction(action string) bool {
 // startInteractiveScroll initiates interactive scrolling mode with visual feedback.
 func (a *App) startInteractiveScroll() {
 	a.cursor.SkipNextRestore()
+	// Reset scroll context before exiting current mode to ensure clean state transition
+	a.scrollCtx.SetIsActive(false)
+	a.scrollCtx.SetLastKey("")
 	a.exitMode()
 
 	if a.overlayManager != nil {
@@ -52,7 +55,7 @@ func (a *App) startInteractiveScroll() {
 		a.eventTap.Enable()
 	}
 
-	a.scrollCtx.SetIsActive(true) // Use scroll context setter instead of direct field access
+	a.scrollCtx.SetIsActive(true)
 
 	a.logger.Info("Interactive scroll activated")
 	a.logger.Info("Use j/k to scroll, Ctrl+D/U for half-page, g/G for top/bottom, Esc to exit")

--- a/internal/app/modes_common.go
+++ b/internal/app/modes_common.go
@@ -28,7 +28,7 @@ func (a *App) handleKeyPress(key string) {
 			}
 			a.scrollCtx.SetIsActive(
 				false,
-			) // Use scroll context setter instead of direct field access
+			)
 			a.scrollCtx.SetLastKey("") // Reset scroll state
 			return
 		}
@@ -36,7 +36,7 @@ func (a *App) handleKeyPress(key string) {
 		// If it's not a scroll key, it will just be ignored
 		lastKey := a.scrollCtx.LastKey
 		a.handleGenericScrollKey(key, &lastKey)
-		a.scrollCtx.SetLastKey(lastKey) // Use scroll context setter instead of direct field access
+		a.scrollCtx.SetLastKey(lastKey)
 		return
 	}
 
@@ -355,8 +355,10 @@ func (a *App) handleCursorRestoration() {
 		accessibility.MoveMouseToPoint(target)
 	}
 	a.cursor.Reset()
-	a.scrollCtx.SetIsActive(false) // Use scroll context setter instead of direct field access
-	a.scrollCtx.SetLastKey("")     // Reset scroll context last key
+	// Always reset scroll context regardless of whether we performed cursor restoration
+	// This ensures proper state cleanup when switching between modes
+	a.scrollCtx.SetIsActive(false)
+	a.scrollCtx.SetLastKey("")
 }
 
 func getModeString(mode Mode) string {
@@ -417,7 +419,7 @@ func (a *App) shouldRestoreCursorOnExit() bool {
 	if !a.cursor.IsCaptured() {
 		return false
 	}
-	if a.scrollCtx.IsActive { // Use scroll context instead of AppState
+	if a.scrollCtx.GetIsActive() { // Use scroll context instead of AppState
 		return false
 	}
 	return a.cursor.ShouldRestore()

--- a/internal/app/modes_grid.go
+++ b/internal/app/modes_grid.go
@@ -27,6 +27,15 @@ func (a *App) activateGridMode() {
 		return
 	}
 
+	// Handle scroll context if active
+	if a.scrollCtx.GetIsActive() {
+		// Reset scroll context to ensure clean transition
+		a.scrollCtx.SetIsActive(false)
+		a.scrollCtx.SetLastKey("")
+		// Also reset the skip restore flag since we're transitioning from scroll to grid mode
+		a.cursor.Reset()
+	}
+
 	a.captureInitialCursorPosition()
 
 	action := domain.ActionMoveMouse

--- a/internal/app/modes_hints.go
+++ b/internal/app/modes_hints.go
@@ -53,6 +53,15 @@ func (a *App) activateHintModeInternal(preserveActionMode bool) {
 		return
 	}
 
+	// Handle scroll context if active
+	if a.scrollCtx.GetIsActive() {
+		// Reset scroll context to ensure clean transition
+		a.scrollCtx.SetIsActive(false)
+		a.scrollCtx.SetLastKey("")
+		// Also reset the skip restore flag since we're transitioning from scroll to hint mode
+		a.cursor.Reset()
+	}
+
 	a.captureInitialCursorPosition()
 
 	action := domain.ActionMoveMouse


### PR DESCRIPTION
This fixes a bug when we have the following sequence, cursor dont
restore:

1. Enter scroll mode
2. Enter grid/hint mode without <esc>
3. Move the mouse to some other position
4. Press <esc>
