### PR TITLE
feat(cli): add --action flag for hints and grid commands

### DIFF
--- a/configs/author-config.toml
+++ b/configs/author-config.toml
@@ -2,7 +2,8 @@
 restore_cursor_position = true
 
 [hotkeys]
-"Ctrl+F" = "grid"
+"Ctrl+F" = "grid -a left_click"
+"Ctrl+G" = "grid"
 "Ctrl+S" = "action scroll"
 
 [hints]

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -23,6 +23,10 @@ restore_cursor_position = false
 "Cmd+Shift+G" = "grid"
 "Cmd+Shift+S" = "action scroll"
 
+# To get direct action after label selection, see `docs/CLI.md` for details
+# "Cmd+Shift+Space" = "hints --action left_click"
+# "Cmd+Shift+G" = "grid --action left_click"
+
 # There are more that can be added, see `docs/CLI.md` for details
 # "Cmd+Shift+L" = "action left_click"
 # "Cmd+Shift+R" = "action right_click"

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -120,12 +120,69 @@ neru action scroll
 
 ## Hint / Grid Commands
 
-Calling `neru hints` or `neru grid` will move the mousue cursor to the selection location, and you can perform actions anytime later.
+### Basic Usage
+
+Move the mouse cursor to a selection location:
 
 ```bash
-neru hints # activate hint mode
-neru grid # activate grid mode
+neru hints  # activate hint mode
+neru grid   # activate grid mode
 ```
+
+After selecting a location, you can perform actions later using the action mode (press `Tab` to toggle).
+
+### Direct Action Execution
+
+Execute an action immediately upon selection without using action mode:
+
+```bash
+# Hints with action
+neru hints --action left_click
+neru hints --action right_click
+neru hints -a middle_click  # short form
+
+# Grid with action
+neru grid --action left_click
+neru grid --action right_click
+neru grid -a middle_click  # short form
+```
+
+**Available actions:**
+
+- `left_click` - Left click at selected position
+- `right_click` - Right click at selected position
+- `middle_click` - Middle click at selected position
+- `mouse_up` - Mouse up at selected position
+- `mouse_down` - Mouse down at selected position
+
+**Behavior with `--action` flag:**
+
+- Tab key is disabled (no action mode toggle)
+- Action executes automatically when you select a hint/grid location
+- Mode exits immediately after action execution
+- For grid mode, action executes after final subgrid selection
+
+**Workflow example:**
+
+```bash
+# Right-click workflow
+neru hints --action right_click
+# 1. Hints overlay appears
+# 2. Type hint label (e.g., "aa")
+# 3. Mouse moves to position
+# 4. Right click executes automatically
+# 5. Mode exits
+
+# Grid workflow
+neru grid --action left_click
+# 1. Grid overlay appears
+# 2. Select main grid cell
+# 3. Select subgrid position
+# 4. Left click executes automatically
+# 5. Mode exits
+```
+
+---
 
 ## Scroll Actions
 
@@ -272,11 +329,15 @@ Instead of Neru's built-in hotkeys, use external hotkey managers:
 ```bash
 # ~/.config/skhd/skhdrc
 
-# Neru hotkeys
+# Neru hotkeys - basic
 ctrl - f : neru hints
 ctrl - g : neru grid
 ctrl - s : neru action scroll
-ctrl - r : neru action right_click
+
+# Neru hotkeys - with actions
+ctrl - r : neru hints --action right_click
+ctrl - m : neru hints --action middle_click
+ctrl + shift - r : neru grid --action right_click
 
 # Toggle Neru
 ctrl + alt - n : ~/scripts/toggle-neru.sh

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -60,7 +60,7 @@ func (a *App) handleStop(_ ipc.Command) ipc.Response {
 	return ipc.Response{Success: true, Message: "neru stopped", Code: ipc.CodeOK}
 }
 
-func (a *App) handleHints(_ ipc.Command) ipc.Response {
+func (a *App) handleHints(cmd ipc.Command) ipc.Response {
 	if !a.state.IsEnabled() {
 		return ipc.Response{
 			Success: false,
@@ -76,12 +76,18 @@ func (a *App) handleHints(_ ipc.Command) ipc.Response {
 		}
 	}
 
-	a.ActivateMode(domain.ModeHints)
+	// Extract action parameter if provided
+	var action *string
+	if len(cmd.Args) > 1 {
+		action = &cmd.Args[1]
+	}
+
+	a.modes.ActivateModeWithAction(domain.ModeHints, action)
 
 	return ipc.Response{Success: true, Message: "hint mode activated", Code: ipc.CodeOK}
 }
 
-func (a *App) handleGrid(_ ipc.Command) ipc.Response {
+func (a *App) handleGrid(cmd ipc.Command) ipc.Response {
 	if !a.state.IsEnabled() {
 		return ipc.Response{
 			Success: false,
@@ -97,7 +103,13 @@ func (a *App) handleGrid(_ ipc.Command) ipc.Response {
 		}
 	}
 
-	a.ActivateMode(domain.ModeGrid)
+	// Extract action parameter if provided
+	var action *string
+	if len(cmd.Args) > 1 {
+		action = &cmd.Args[1]
+	}
+
+	a.modes.ActivateModeWithAction(domain.ModeGrid, action)
 
 	return ipc.Response{Success: true, Message: "grid mode activated", Code: ipc.CodeOK}
 }

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -12,7 +12,8 @@ import (
 	"go.uber.org/zap"
 )
 
-func (h *Handler) activateGridMode() {
+// activateGridModeWithAction activates grid mode with optional action parameter.
+func (h *Handler) activateGridModeWithAction(action *string) {
 	// Validate mode activation
 	err := h.validateModeActivation("grid", h.Config.Grid.Enabled)
 	if err != nil {
@@ -23,8 +24,8 @@ func (h *Handler) activateGridMode() {
 	// Prepare for mode activation (reset scroll, capture cursor)
 	h.prepareForModeActivation()
 
-	action := domain.ActionMoveMouse
-	actionString := domain.GetActionString(action)
+	actionEnum := domain.ActionMoveMouse
+	actionString := domain.GetActionString(actionEnum)
 	h.Logger.Info("Activating grid mode", zap.String("action", actionString))
 
 	h.ExitMode()
@@ -41,6 +42,12 @@ func (h *Handler) activateGridMode() {
 			zap.String("action", actionString),
 			zap.String("screen_bounds", fmt.Sprintf("%+v", bridge.GetActiveScreenBounds())))
 		return
+	}
+
+	// Store pending action if provided
+	h.Grid.Context.SetPendingAction(action)
+	if action != nil {
+		h.Logger.Info("Grid mode activated with pending action", zap.String("action", *action))
 	}
 
 	h.SetModeGrid()

--- a/internal/cli/grid.go
+++ b/internal/cli/grid.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/infra/logger"
 )
 
@@ -12,14 +15,31 @@ var gridCmd = &cobra.Command{
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return requiresRunningInstance()
 	},
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		logger.Debug("Launching grid mode")
+
+		action, _ := cmd.Flags().GetString("action")
+		if action != "" {
+			// Validate action
+			if !domain.IsKnownActionName(domain.ActionName(action)) {
+				return fmt.Errorf(
+					"invalid action: %s. Supported actions: left_click, right_click, middle_click, mouse_up, mouse_down",
+					action,
+				)
+			}
+		}
+
 		var params []string
 		params = append(params, "grid")
+		if action != "" {
+			params = append(params, action)
+		}
 		return sendCommand("grid", params)
 	},
 }
 
 func init() {
+	gridCmd.Flags().
+		StringP("action", "a", "", "Action to perform on grid selection (left_click, right_click, middle_click, mouse_up, mouse_down)")
 	rootCmd.AddCommand(gridCmd)
 }

--- a/internal/cli/hints.go
+++ b/internal/cli/hints.go
@@ -1,25 +1,45 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/infra/logger"
 )
 
 var hintsCmd = &cobra.Command{
 	Use:   "hints",
-	Short: "Launch hints mode in left click mode",
+	Short: "Launch hints mode",
 	Long:  `Activate hint mode for direct clicking on UI elements.`,
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return requiresRunningInstance()
 	},
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		logger.Debug("Launching hints mode")
+
+		action, _ := cmd.Flags().GetString("action")
+		if action != "" {
+			// Validate action
+			if !domain.IsKnownActionName(domain.ActionName(action)) {
+				return fmt.Errorf(
+					"invalid action: %s. Supported actions: left_click, right_click, middle_click, mouse_up, mouse_down",
+					action,
+				)
+			}
+		}
+
 		var params []string
 		params = append(params, "hints")
+		if action != "" {
+			params = append(params, action)
+		}
 		return sendCommand("hints", params)
 	},
 }
 
 func init() {
+	hintsCmd.Flags().
+		StringP("action", "a", "", "Action to perform on hint selection (left_click, right_click, middle_click, mouse_up, mouse_down)")
 	rootCmd.AddCommand(hintsCmd)
 }

--- a/internal/domain/converters.go
+++ b/internal/domain/converters.go
@@ -35,3 +35,25 @@ func GetActionString(action Action) string {
 		return UnknownAction
 	}
 }
+
+// GetActionFromString converts a string to its Action representation.
+func GetActionFromString(actionStr string) (Action, bool) {
+	switch actionStr {
+	case "left_click":
+		return ActionLeftClick, true
+	case "right_click":
+		return ActionRightClick, true
+	case "mouse_up":
+		return ActionMouseUp, true
+	case "mouse_down":
+		return ActionMouseDown, true
+	case "middle_click":
+		return ActionMiddleClick, true
+	case "move_mouse":
+		return ActionMoveMouse, true
+	case "scroll":
+		return ActionScroll, true
+	default:
+		return ActionMoveMouse, false
+	}
+}

--- a/internal/features/grid/context.go
+++ b/internal/features/grid/context.go
@@ -2,9 +2,10 @@ package grid
 
 // Context holds the state and context for grid mode operations.
 type Context struct {
-	GridInstance **Grid
-	GridOverlay  **Overlay
-	InActionMode bool
+	GridInstance  **Grid
+	GridOverlay   **Overlay
+	InActionMode  bool
+	PendingAction *string
 }
 
 // SetGridInstance sets the grid instance.
@@ -47,9 +48,20 @@ func (c *Context) GetInActionMode() bool {
 	return c.InActionMode
 }
 
+// SetPendingAction sets the action to execute when grid selection is complete.
+func (c *Context) SetPendingAction(action *string) {
+	c.PendingAction = action
+}
+
+// GetPendingAction returns the pending action to execute.
+func (c *Context) GetPendingAction() *string {
+	return c.PendingAction
+}
+
 // Reset resets the grid context to its initial state.
 func (c *Context) Reset() {
 	c.GridInstance = nil
 	c.GridOverlay = nil
 	c.InActionMode = false
+	c.PendingAction = nil
 }

--- a/internal/features/grid/manager.go
+++ b/internal/features/grid/manager.go
@@ -160,7 +160,8 @@ func (m *Manager) handleLabelLengthReached() (image.Point, bool) {
 					m.onShowSub(cell)
 				}
 
-				return image.Point{X: center.X, Y: center.Y}, true
+				// Return false for completion since we're entering subgrid, not completing selection
+				return image.Point{X: center.X, Y: center.Y}, false
 			}
 		}
 	}

--- a/internal/features/hints/context.go
+++ b/internal/features/hints/context.go
@@ -2,8 +2,9 @@ package hints
 
 // Context holds the state and context for hint mode operations.
 type Context struct {
-	SelectedHint *Hint
-	InActionMode bool
+	SelectedHint  *Hint
+	InActionMode  bool
+	PendingAction *string
 }
 
 // SetSelectedHint sets the currently selected hint.
@@ -26,8 +27,19 @@ func (c *Context) GetInActionMode() bool {
 	return c.InActionMode
 }
 
+// SetPendingAction sets the action to execute when a hint is selected.
+func (c *Context) SetPendingAction(action *string) {
+	c.PendingAction = action
+}
+
+// GetPendingAction returns the pending action to execute.
+func (c *Context) GetPendingAction() *string {
+	return c.PendingAction
+}
+
 // Reset resets the hints context to its initial state.
 func (c *Context) Reset() {
 	c.SelectedHint = nil
 	c.InActionMode = false
+	c.PendingAction = nil
 }


### PR DESCRIPTION
Add --action flag to hints and grid CLI commands to execute actions
automatically upon selection without requiring tab key or action mode.

Supported actions: left_click, right_click, middle_click, mouse_up,
mouse_down

Features:
- CLI: Added --action/-a flag with validation for hints and grid
commands
- Domain: Added GetActionFromString converter for action name parsing
- Context: Added PendingAction field to hints and grid contexts
- IPC: Updated handlers to extract and pass action parameter
- Modes: Implemented action execution on selection and mode exit
- Tab key: Disabled when pending action is set
- Grid: Fixed action timing to execute after subgrid selection, not main
grid
