### PR TITLE
fix(hints): prevent cursor restoration during hint mode transitions

### DIFF
--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -55,7 +55,14 @@ func (h *Handler) activateHintModeInternal(preserveActionMode bool, action *stri
 	h.Logger.Info("Activating hint mode", zap.String("action", actionString))
 
 	if !preserveActionMode {
-		h.ExitMode()
+		// Skip cursor restoration when transitioning within hint mode
+		if h.State.CurrentMode() == domain.ModeHints {
+			h.performModeSpecificCleanup()
+			h.performCommonCleanup()
+			// Skip cursor restoration
+		} else {
+			h.ExitMode()
+		}
 	}
 
 	if actionString == domain.UnknownAction {


### PR DESCRIPTION
When restore_cursor is enabled, the first completed hint label would
move the mouse to the target position but then immediately restore
the cursor to its initial position, while subsequent hints worked
correctly.

This happened because activateHintModeInternal was calling ExitMode()
during transitions within hint mode, which triggered unwanted cursor
restoration. The fix checks if we're already in hint mode and performs
only the necessary cleanup without restoring the cursor.

The change ensures consistent behavior for all hint completions while
preserving the intended cursor restoration when exiting hint mode
completely.

Fixes the inconsistent cursor behavior in hint mode when restore_cursor
is enabled.
