### PR TITLE
feat(config): remove subgrid_enabled option and make subgrid always enabled

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -103,9 +103,6 @@ additional_firefox_bundles = []
 # Whether to enable grid mode
 enabled = true
 
-# Whether to enable subgrid precision mode
-subgrid_enabled = true
-
 # Characters to use for grid labels
 characters = "abcdefghijklmnpqrstuvwxyz"
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -272,7 +272,6 @@ border_color = "#abe9b3"
 ```toml
 [grid]
 live_match_update = true    # Highlight matches as you type
-subgrid_enabled = true      # Show 3x3 precision layer after selection
 hide_unmatched = true       # Hide non-matching cells while typing
 
 # Subgrid keys (requires at least 9 characters)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,8 +101,7 @@ type HintsConfig struct {
 
 // GridConfig defines the visual and behavioral settings for grid mode.
 type GridConfig struct {
-	Enabled        bool `toml:"enabled"`
-	SubgridEnabled bool `toml:"subgrid_enabled"`
+	Enabled bool `toml:"enabled"`
 
 	Characters   string `toml:"characters"`
 	SublayerKeys string `toml:"sublayer_keys"`
@@ -286,8 +285,7 @@ func DefaultConfig() *Config {
 			},
 		},
 		Grid: GridConfig{
-			Enabled:        true,
-			SubgridEnabled: true,
+			Enabled: true,
 
 			Characters:   "abcdefghijklmnpqrstuvwxyz",
 			SublayerKeys: "abcdefghijklmnpqrstuvwxyz",

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -162,20 +162,18 @@ func (c *Config) validateGrid() error {
 		return err
 	}
 
-	if c.Grid.SubgridEnabled {
-		// Validate sublayer keys length (fallback to grid.characters) for 3x3 subgrid
-		keys := strings.TrimSpace(c.Grid.SublayerKeys)
-		if keys == "" {
-			keys = c.Grid.Characters
-		}
-		// Subgrid is always 3x3, requiring at least 9 characters
-		const required = 9
-		if len([]rune(keys)) < required {
-			return fmt.Errorf(
-				"grid.sublayer_keys must contain at least %d characters for 3x3 subgrid selection",
-				required,
-			)
-		}
+	// Validate sublayer keys length (fallback to grid.characters) for 3x3 subgrid
+	keys := strings.TrimSpace(c.Grid.SublayerKeys)
+	if keys == "" {
+		keys = c.Grid.Characters
+	}
+	// Subgrid is always 3x3, requiring at least 9 characters
+	const required = 9
+	if len([]rune(keys)) < required {
+		return fmt.Errorf(
+			"grid.sublayer_keys must contain at least %d characters for 3x3 subgrid selection",
+			required,
+		)
 	}
 	return nil
 }

--- a/internal/features/grid/doc.go
+++ b/internal/features/grid/doc.go
@@ -29,7 +29,7 @@
 //   - characters: Customizable character set for main grid labels
 //   - sublayer_keys: Character set for subgrid labels
 //   - Visual appearance: Colors, fonts, border styles, opacity
-//   - Behavior settings: subgrid_enabled, live_match_update, hide_unmatched
+//   - Behavior settings: live_match_update, hide_unmatched
 //
 // Advantages:
 // The grid approach is more reliable than accessibility-based hints because it doesn't


### PR DESCRIPTION
- Removed subgrid_enabled configuration option from GridConfig struct
- Updated default config file to remove subgrid_enabled setting
- Modified validation logic to always validate subgrid settings
- Updated documentation to reflect that subgrid is always enabled
- Updated grid package documentation

This change simplifies the configuration by making the subgrid feature
always available, which improves usability and reduces configuration
complexity.
