### PR TITLE
fix(grid): move mouse to cell center when showing subgrid

### DIFF
--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/features/grid"
+	infra "github.com/y3owk1n/neru/internal/infra/accessibility"
 	"github.com/y3owk1n/neru/internal/infra/bridge"
 	"github.com/y3owk1n/neru/internal/ui/coordinates"
 	"go.uber.org/zap"
@@ -176,6 +177,9 @@ func (h *Handler) initializeGridManager(gridInstance *grid.Grid) {
 				h.Logger.Warn("Attempted to show subgrid for nil cell")
 				return
 			}
+
+			// Move mouse to center of cell before showing subgrid
+			infra.MoveMouseToPoint(cell.Center)
 
 			// Draw 3x3 subgrid inside selected cell
 			h.Renderer.ShowSubgrid(cell)


### PR DESCRIPTION
When users complete typing a main grid label (e.g., 'ABC'), the mouse
cursor now immediately moves to the center of the selected cell before
showing the subgrid for more precise positioning.

This provides immediate visual feedback and improves the user experience
by confirming the selection before proceeding to the subgrid selection
phase.

The change is made in the onShowSub callback which is triggered when
entering subgrid mode, ensuring that the mouse moves to the center of
the cell in both regular grid mode and when using the --action flag.
