### PR TITLE
fix(modes): reset cursor state when exiting scroll mode via ESC

### DIFF
--- a/internal/app/modes/common.go
+++ b/internal/app/modes/common.go
@@ -23,6 +23,9 @@ func (h *Handler) HandleKeyPress(key string) {
 			}
 			h.Scroll.Context.SetIsActive(false)
 			h.Scroll.Context.SetLastKey("")
+			// Reset cursor state when exiting scroll mode to ensure proper cursor restoration
+			// in subsequent modes
+			h.Cursor.Reset()
 			return
 		}
 		// Try to handle scroll keys with generic handler using persistent state.


### PR DESCRIPTION
When exiting scroll mode via the ESC key, the cursor state was not being
properly reset, which caused subsequent hint/grid modes to incorrectly
skip cursor restoration due to the skipRestoreOnce flag remaining set.

This fix ensures that when explicitly exiting scroll mode via ESC, the
cursor state is properly reset by calling h.Cursor.Reset(), allowing
subsequent modes to restore the cursor as expected.

Fixes cursor restoration issue when transitioning from scroll mode to
hint/grid modes via explicit ESC exit.
