### PR TITLE
fix: remove all `GetScrollableElements`

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -160,7 +160,7 @@ include_nc_hints = false
 
 ### Accessibility Configuration
 
-Define which UI elements are clickable or scrollable:
+Define which UI elements are clickable:
 
 ```toml
 [hints]
@@ -478,7 +478,6 @@ include_menubar_hints = false
 include_dock_hints = false
 include_nc_hints = false
 clickable_roles = ["AXButton", "AXLink", "AXTextField", "AXCheckBox"]
-scrollable_roles = ["AXWebArea", "AXScrollArea", "AXTable"]
 ignore_clickable_check = false
 
 [[hints.app_configs]]

--- a/internal/adapter/accessibility/adapter.go
+++ b/internal/adapter/accessibility/adapter.go
@@ -114,29 +114,6 @@ func (a *Adapter) GetClickableElements(
 	return elements, nil
 }
 
-// GetScrollableElements retrieves all scrollable UI elements.
-func (a *Adapter) GetScrollableElements(context context.Context) ([]*element.Element, error) {
-	// Check context
-	select {
-	case <-context.Done():
-		return nil, context.Err()
-	default:
-	}
-
-	a.logger.Debug("Getting scrollable elements")
-
-	// Get focused app
-	focusedApp, focusedAppErr := a.client.GetFocusedApplication()
-	if focusedAppErr != nil {
-		return nil, errors.New(errors.CodeAccessibilityFailed, "failed to get focused app")
-	}
-	defer focusedApp.Release()
-
-	a.logger.Debug("Scrollable elements not yet implemented")
-
-	return []*element.Element{}, nil
-}
-
 // PerformAction executes an action on the specified element.
 func (a *Adapter) PerformAction(
 	context context.Context,

--- a/internal/adapter/accessibility/metrics_decorator.go
+++ b/internal/adapter/accessibility/metrics_decorator.go
@@ -49,16 +49,6 @@ func (d *MetricsDecorator) GetClickableElements(
 	return elements, elementsErr
 }
 
-// GetScrollableElements implements ports.AccessibilityPort.
-func (d *MetricsDecorator) GetScrollableElements(ctx context.Context) ([]*element.Element, error) {
-	defer d.recordDuration("accessibility_get_scrollable_elements_duration", time.Now())
-
-	elements, elementsErr := d.next.GetScrollableElements(ctx)
-	d.recordError("accessibility_get_scrollable_elements", elementsErr)
-
-	return elements, elementsErr
-}
-
 // PerformAction implements ports.AccessibilityPort.
 func (d *MetricsDecorator) PerformAction(
 	context context.Context,

--- a/internal/application/ports/accessibility.go
+++ b/internal/application/ports/accessibility.go
@@ -18,9 +18,6 @@ type AccessibilityPort interface {
 	// GetClickableElements retrieves all clickable UI elements matching the filter.
 	GetClickableElements(ctx context.Context, filter ElementFilter) ([]*element.Element, error)
 
-	// GetScrollableElements retrieves all scrollable UI elements.
-	GetScrollableElements(ctx context.Context) ([]*element.Element, error)
-
 	// PerformAction executes an action on the specified element.
 	PerformAction(ctx context.Context, elem *element.Element, actionType action.Type) error
 

--- a/internal/application/ports/mocks/accessibility.go
+++ b/internal/application/ports/mocks/accessibility.go
@@ -12,7 +12,6 @@ import (
 // MockAccessibilityPort is a mock implementation of ports.AccessibilityPort.
 type MockAccessibilityPort struct {
 	GetClickableElementsFunc  func(context.Context, ports.ElementFilter) ([]*element.Element, error)
-	GetScrollableElementsFunc func(context.Context) ([]*element.Element, error)
 	PerformActionFunc         func(context.Context, *element.Element, action.Type) error
 	GetFocusedAppBundleIDFunc func(context.Context) (string, error)
 	IsAppExcludedFunc         func(context.Context, string) bool
@@ -39,17 +38,6 @@ func (m *MockAccessibilityPort) GetClickableElements(
 ) ([]*element.Element, error) {
 	if m.GetClickableElementsFunc != nil {
 		return m.GetClickableElementsFunc(context, filter)
-	}
-
-	return nil, nil
-}
-
-// GetScrollableElements implements ports.AccessibilityPort.
-func (m *MockAccessibilityPort) GetScrollableElements(
-	context context.Context,
-) ([]*element.Element, error) {
-	if m.GetScrollableElementsFunc != nil {
-		return m.GetScrollableElementsFunc(context)
 	}
 
 	return nil, nil

--- a/internal/infra/accessibility/query.go
+++ b/internal/infra/accessibility/query.go
@@ -80,8 +80,6 @@ func GetClickableElements() ([]*TreeNode, error) {
 	return elements, nil
 }
 
-// GetScrollableElements retrieves all scrollable UI elements in the frontmost window.
-
 // GetMenuBarClickableElements retrieves clickable UI elements from the focused application's menu bar.
 func GetMenuBarClickableElements() ([]*TreeNode, error) {
 	logger.Debug("Getting clickable elements for menu bar")


### PR DESCRIPTION
We don't need it anymore, we are scrolling based on cursor position and
using mousewheel API
