### PR TITLE
test(hints): add regression test for style configuration

### DIFF
--- a/internal/adapter/overlay/adapter_test.go
+++ b/internal/adapter/overlay/adapter_test.go
@@ -1,10 +1,11 @@
-package overlay
+package overlay_test
 
 import (
 	"context"
 	"testing"
 	"unsafe"
 
+	"github.com/y3owk1n/neru/internal/adapter/overlay"
 	"github.com/y3owk1n/neru/internal/config"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
 	"github.com/y3owk1n/neru/internal/features/action"
@@ -15,43 +16,51 @@ import (
 	"go.uber.org/zap"
 )
 
-// mockManager is a mock implementation of uiOverlay.ManagerInterface
+// mockManager is a mock implementation of uiOverlay.ManagerInterface.
 type mockManager struct {
 	hintOverlay *hints.Overlay
 	lastStyle   hints.StyleMode
 }
 
-func (m *mockManager) Show()                     {}
-func (m *mockManager) Hide()                     {}
-func (m *mockManager) Clear()                    {}
-func (m *mockManager) ResizeToActiveScreenSync() {}
-func (m *mockManager) SwitchTo(next uiOverlay.Mode) {}
+func (m *mockManager) Show()                                           {}
+func (m *mockManager) Hide()                                           {}
+func (m *mockManager) Clear()                                          {}
+func (m *mockManager) ResizeToActiveScreenSync()                       {}
+func (m *mockManager) SwitchTo(next uiOverlay.Mode)                    {}
 func (m *mockManager) Subscribe(fn func(uiOverlay.StateChange)) uint64 { return 0 }
 func (m *mockManager) Unsubscribe(id uint64)                           {}
 func (m *mockManager) Destroy()                                        {}
 func (m *mockManager) Mode() uiOverlay.Mode                            { return uiOverlay.ModeIdle }
 func (m *mockManager) WindowPtr() unsafe.Pointer                       { return nil }
 
-func (m *mockManager) UseHintOverlay(o *hints.Overlay)   { m.hintOverlay = o }
-func (m *mockManager) UseGridOverlay(o *grid.Overlay)    {}
+func (m *mockManager) UseHintOverlay(o *hints.Overlay)    { m.hintOverlay = o }
+func (m *mockManager) UseGridOverlay(o *grid.Overlay)     {}
 func (m *mockManager) UseActionOverlay(o *action.Overlay) {}
 func (m *mockManager) UseScrollOverlay(o *scroll.Overlay) {}
 
-func (m *mockManager) HintOverlay() *hints.Overlay     { return m.hintOverlay }
-func (m *mockManager) GridOverlay() *grid.Overlay      { return nil }
-func (m *mockManager) ActionOverlay() *action.Overlay  { return nil }
-func (m *mockManager) ScrollOverlay() *scroll.Overlay  { return nil }
+func (m *mockManager) HintOverlay() *hints.Overlay    { return m.hintOverlay }
+func (m *mockManager) GridOverlay() *grid.Overlay     { return nil }
+func (m *mockManager) ActionOverlay() *action.Overlay { return nil }
+func (m *mockManager) ScrollOverlay() *scroll.Overlay { return nil }
 
 func (m *mockManager) DrawHintsWithStyle(hs []*hints.Hint, style hints.StyleMode) error {
 	m.lastStyle = style
+
 	return nil
 }
 func (m *mockManager) DrawActionHighlight(x, y, w, h int) {}
 func (m *mockManager) DrawScrollHighlight(x, y, w, h int) {}
-func (m *mockManager) DrawGrid(g *domainGrid.Grid, input string, style grid.Style) error { return nil }
-func (m *mockManager) UpdateGridMatches(prefix string)                                   {}
-func (m *mockManager) ShowSubgrid(cell *domainGrid.Cell, style grid.Style)               {}
-func (m *mockManager) SetHideUnmatched(hide bool)                                        {}
+
+func (m *mockManager) DrawGrid(
+	g *domainGrid.Grid,
+	input string,
+	style grid.Style,
+) error {
+	return nil
+}
+func (m *mockManager) UpdateGridMatches(prefix string)                     {}
+func (m *mockManager) ShowSubgrid(cell *domainGrid.Cell, style grid.Style) {}
+func (m *mockManager) SetHideUnmatched(hide bool)                          {}
 
 func TestShowHints_PassesCorrectStyle(t *testing.T) {
 	// Setup
@@ -59,9 +68,9 @@ func TestShowHints_PassesCorrectStyle(t *testing.T) {
 		BackgroundColor: "#123456",
 		TextColor:       "#abcdef",
 	}
-	
+
 	logger := zap.NewNop()
-	
+
 	// Create a real hints.Overlay (but with nil window) to hold the config
 	// We use NewOverlayWithWindow with nil pointer which is safe for just holding config
 	hintOverlay, err := hints.NewOverlayWithWindow(cfg, logger, nil)
@@ -73,7 +82,7 @@ func TestShowHints_PassesCorrectStyle(t *testing.T) {
 		hintOverlay: hintOverlay,
 	}
 
-	adapter := NewAdapter(mock, logger)
+	adapter := overlay.NewAdapter(mock, logger)
 
 	// Execute
 	// Pass empty hints list as we only care about style passing
@@ -86,6 +95,7 @@ func TestShowHints_PassesCorrectStyle(t *testing.T) {
 	if mock.lastStyle.BackgroundColor() != "#123456" {
 		t.Errorf("Expected BackgroundColor #123456, got %s", mock.lastStyle.BackgroundColor())
 	}
+
 	if mock.lastStyle.TextColor() != "#abcdef" {
 		t.Errorf("Expected TextColor #abcdef, got %s", mock.lastStyle.TextColor())
 	}


### PR DESCRIPTION
Adds a unit test to `internal/adapter/overlay` to verify that
`ShowHints`
correctly retrieves the current configuration from the overlay and
passes
a populated `StyleMode` to the drawing function. This prevents
regression
of the bug where empty styles were being applied, causing cache
corruption.
