### PR TITLE
test: convert integration tests to use real components

### DIFF
--- a/internal/adapter/accessibility/adapter_integration_test.go
+++ b/internal/adapter/accessibility/adapter_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package accessibility_test
 

--- a/internal/adapter/eventtap/adapter_integration_test.go
+++ b/internal/adapter/eventtap/adapter_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package eventtap_test
 

--- a/internal/adapter/hotkey/adapter_integration_test.go
+++ b/internal/adapter/hotkey/adapter_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package hotkey_test
 

--- a/internal/adapter/ipc/adapter_integration_test.go
+++ b/internal/adapter/ipc/adapter_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package ipc_test
 

--- a/internal/adapter/overlay/adapter_integration_test.go
+++ b/internal/adapter/overlay/adapter_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package overlay_test
 

--- a/internal/app/integration_test.go
+++ b/internal/app/integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package app_test
 


### PR DESCRIPTION
- Add build tags to separate integration tests from unit tests
- Replace mock hotkey manager with real hotkeys infra
- Ensure integration tests test actual system interactions
