### PR TITLE
fix(logger): add consoleWriter parameter to Init for output control

### DIFF
--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -31,6 +31,7 @@ func initializeLogger(config *config.Config) (*zap.Logger, error) {
 		config.Logging.MaxFileSize,
 		config.Logging.MaxBackups,
 		config.Logging.MaxAge,
+		nil,
 	)
 	if initConfigErr != nil {
 		return nil, derrors.Wrap(initConfigErr, derrors.CodeInternal, "failed to initialize logger")

--- a/internal/infra/logger/logger.go
+++ b/internal/infra/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,6 +33,7 @@ func Init(
 	structured bool,
 	disableFileLogging bool,
 	maxFileSize, maxBackups, maxAge int,
+	consoleWriter io.Writer,
 ) error {
 	logFileMu.Lock()
 	defer logFileMu.Unlock()
@@ -83,9 +85,14 @@ func Init(
 	// Create console encoder
 	consoleEncoder := zapcore.NewConsoleEncoder(consoleEncoderConfig)
 
+	// Determine console writer
+	if consoleWriter == nil {
+		consoleWriter = os.Stdout
+	}
+
 	// Create cores slice
 	cores := []zapcore.Core{
-		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), level),
+		zapcore.NewCore(consoleEncoder, zapcore.AddSync(consoleWriter), level),
 	}
 
 	// Add file logging if not disabled

--- a/internal/infra/logger/logger_bench_test.go
+++ b/internal/infra/logger/logger_bench_test.go
@@ -12,7 +12,7 @@ func BenchmarkDebugLogging(b *testing.B) {
 	tempDir := b.TempDir()
 	logPath := filepath.Join(tempDir, "bench.log")
 
-	_ = plogger.Init("debug", logPath, false, false, 100, 3, 7)
+	_ = plogger.Init("debug", logPath, false, false, 100, 3, 7, nil)
 
 	defer func() {
 		_ = plogger.Close()
@@ -27,7 +27,7 @@ func BenchmarkInfoLogging(b *testing.B) {
 	tempDir := b.TempDir()
 	logPath := filepath.Join(tempDir, "bench.log")
 
-	_ = plogger.Init("info", logPath, false, false, 100, 3, 7)
+	_ = plogger.Init("info", logPath, false, false, 100, 3, 7, nil)
 
 	defer plogger.Close() //nolint:errcheck
 
@@ -40,7 +40,7 @@ func BenchmarkStructuredLogging(b *testing.B) {
 	tempDir := b.TempDir()
 	logPath := filepath.Join(tempDir, "bench.log")
 
-	_ = plogger.Init("info", logPath, true, false, 100, 3, 7)
+	_ = plogger.Init("info", logPath, true, false, 100, 3, 7, nil)
 
 	defer plogger.Close() //nolint:errcheck
 

--- a/internal/infra/logger/logger_test.go
+++ b/internal/infra/logger/logger_test.go
@@ -1,6 +1,7 @@
 package logger_test
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -82,6 +83,7 @@ func TestInit(t *testing.T) {
 				testCase.maxFileSize,
 				testCase.maxBackups,
 				testCase.maxAge,
+				nil,
 			)
 
 			if (initErr != nil) != testCase.wantErr {
@@ -119,7 +121,7 @@ func TestLoggingFunctions(t *testing.T) {
 	tempDir := t.TempDir()
 	logPath := filepath.Join(tempDir, "test.log")
 
-	initErr := logger.Init("debug", logPath, false, false, 10, 3, 7)
+	initErr := logger.Init("debug", logPath, false, false, 10, 3, 7, nil)
 	if initErr != nil {
 		t.Fatalf("Init() failed: %v", initErr)
 	}
@@ -175,7 +177,7 @@ func TestLoggingFunctions(t *testing.T) {
 
 func TestWith(t *testing.T) {
 	// Initialize logger
-	err := logger.Init("info", "", false, true, 10, 3, 7)
+	err := logger.Init("info", "", false, true, 10, 3, 7, nil)
 	if err != nil {
 		t.Fatalf("Init() failed: %v", err)
 	}
@@ -199,7 +201,7 @@ func TestSync(t *testing.T) {
 	tempDir := t.TempDir()
 	logPath := filepath.Join(tempDir, "test.log")
 
-	initErr := logger.Init("info", logPath, false, false, 10, 3, 7)
+	initErr := logger.Init("info", logPath, false, false, 10, 3, 7, nil)
 	if initErr != nil {
 		t.Fatalf("Init() failed: %v", initErr)
 	}
@@ -219,7 +221,7 @@ func TestClose(t *testing.T) {
 	tempDir := t.TempDir()
 	logPath := filepath.Join(tempDir, "test.log")
 
-	initErr := logger.Init("info", logPath, false, false, 10, 3, 7)
+	initErr := logger.Init("info", logPath, false, false, 10, 3, 7, nil)
 	if initErr != nil {
 		t.Fatalf("Init() failed: %v", initErr)
 	}
@@ -252,7 +254,7 @@ func TestLogLevels(t *testing.T) {
 			tempDir := t.TempDir()
 			logPath := filepath.Join(tempDir, "test.log")
 
-			initErr := logger.Init(testCase.logLevel, logPath, false, false, 10, 3, 7)
+			initErr := logger.Init(testCase.logLevel, logPath, false, false, 10, 3, 7, nil)
 			if initErr != nil {
 				t.Fatalf("Init() failed: %v", initErr)
 			}
@@ -275,7 +277,7 @@ func TestFileRotation(t *testing.T) {
 	logPath := filepath.Join(tempDir, "test.log")
 
 	// Initialize with small max size for testing
-	initErr := logger.Init("info", logPath, false, false, 1, 2, 1)
+	initErr := logger.Init("info", logPath, false, false, 1, 2, 1, io.Discard)
 	if initErr != nil {
 		t.Fatalf("Init() failed: %v", initErr)
 	}


### PR DESCRIPTION
- Allows suppressing console logging in tests by passing io.Discard
- Reduces noise in `TestFileRotation` output
