### PR TITLE
fix(scroll): improve responsiveness of scroll mode activation

### DIFF
--- a/internal/app/modes/scroll.go
+++ b/internal/app/modes/scroll.go
@@ -17,6 +17,14 @@ func (h *Handler) StartInteractiveScroll() {
 	h.Scroll.Context.SetLastKey("")
 	h.ExitMode()
 
+	// Enable event tap early to capture key presses immediately
+	if h.EnableEventTap != nil {
+		h.EnableEventTap()
+	}
+
+	// Set scroll context active before showing overlay
+	h.Scroll.Context.SetIsActive(true)
+
 	ctx := context.Background()
 
 	showScrollOverlayErr := h.ScrollService.ShowScrollOverlay(ctx)
@@ -24,14 +32,8 @@ func (h *Handler) StartInteractiveScroll() {
 		h.Logger.Error("Failed to show scroll overlay", zap.Error(showScrollOverlayErr))
 	}
 
-	if h.EnableEventTap != nil {
-		h.EnableEventTap()
-	}
-
-	h.Scroll.Context.SetIsActive(true)
-
 	h.Logger.Info("Interactive scroll activated")
-	h.Logger.Info("Use j/k to scroll, Ctrl+D/U for half-page, g/G for top/bottom, Esc to exit")
+	h.Logger.Info("Use j/k to scroll, g/G for top/bottom, Esc to exit")
 }
 
 // handleGenericScrollKey handles scroll keys in a generic way.


### PR DESCRIPTION
Reorder operations in StartInteractiveScroll to enable event tap
earlier and set scroll context active before showing overlay,
fixing timing issue where immediate key presses after hotkey
were not registered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll mode overlay initialization sequence to activate context before display.
  * Removed duplicate event tap enablement calls for improved efficiency.

* **Documentation**
  * Updated keyboard shortcut help message in scroll mode to display j/k and g/G navigation keys and Esc for exit, while removing Ctrl+D/U references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->