### PR TITLE
fix(overlay): clear overlay when switching from scroll to hints/grid mode

### DIFF
--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -26,6 +26,9 @@ func (h *Handler) activateGridModeWithAction(action *string) {
 	actionString := domain.ActionString(actionEnum)
 
 	h.ExitMode()
+	// Clear any previous overlay content (e.g., scroll highlights) before drawing grid.
+	// This prevents scroll highlights from persisting when switching from scroll mode to grid mode.
+	h.OverlayManager.Clear()
 
 	h.AppState.SetGridOverlayNeedsRefresh(false)
 

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -85,6 +85,9 @@ func (h *Handler) activateHintModeInternal(preserveActionMode bool, action *stri
 	// Always resize overlay to the active screen (where mouse is) before collecting elements.
 	// This ensures proper positioning when switching between multiple displays.
 	h.OverlayManager.ResizeToActiveScreenSync()
+	// Clear any previous overlay content (e.g., scroll highlights) before drawing hints.
+	// This prevents scroll highlights from persisting when switching from scroll mode to hints mode.
+	h.OverlayManager.Clear()
 	h.AppState.SetHintOverlayNeedsRefresh(false)
 
 	// Use new HintService to show hints


### PR DESCRIPTION
When switching from scroll mode to hints or grid mode without exiting scroll first,
the scroll overlay highlights would persist alongside the new mode's overlay.
This fix ensures the overlay is cleared before drawing new content to prevent
visual artifacts from mode transitions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved visual elements (such as scroll highlights) remaining visible when switching between different display modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->