### PR TITLE
chore: bump flake to 1.10.5 [skip ci]

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       ];
 
       # Update this to your latest release version
-      latestVersion = "1.10.4";
+      latestVersion = "1.10.5";
 
       # Function to build package with specific version
       makeNeruPackage =

--- a/package.nix
+++ b/package.nix
@@ -21,13 +21,13 @@ if useZip then
       {
         "aarch64-darwin" = {
           url = "https://github.com/y3owk1n/neru/releases/download/v${version}/neru-darwin-arm64.zip";
-          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.10.4/neru-darwin-arm64.zip)`
-          sha256 = "sha256-C4p6Q3BNW2cjY9A3JWiAD4nWxFCmdJmajnPO9usJYEs=";
+          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.10.5/neru-darwin-arm64.zip)`
+          sha256 = "sha256-csOpFycb2U+/Wy9xXBfctVBd9rN56mzFCAOfVup+39A=";
         };
         "x86_64-darwin" = {
           url = "https://github.com/y3owk1n/neru/releases/download/v${version}/neru-darwin-amd64.zip";
-          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.10.4/neru-darwin-amd64.zip)`
-          sha256 = "sha256-Hssomemsj19d1hi0FnXgldwQbZ8+GV+bigs4AKkqHDE=";
+          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.10.5/neru-darwin-amd64.zip)`
+          sha256 = "sha256-oJ0uBiFTX1c2A2UW4ZTJP42AGqx9dW6DIOzme6Vz6O8=";
         };
       }
       .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.10.5 with refreshed build configurations for macOS platforms

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->