### PR TITLE
refactor(domain): extract common functionality into base structs

### DIFF
--- a/internal/app/components/grid/context.go
+++ b/internal/app/components/grid/context.go
@@ -4,12 +4,45 @@ import (
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 )
 
-// Context holds the state and context for grid mode operations.
-type Context struct {
-	gridInstance  **domainGrid.Grid
-	gridOverlay   **Overlay
+// baseContext provides common functionality for mode component contexts.
+// It contains shared state fields used across different mode contexts.
+type baseContext struct {
 	inActionMode  bool
 	pendingAction *string
+}
+
+// SetInActionMode sets whether the mode is in action mode.
+func (c *baseContext) SetInActionMode(inActionMode bool) {
+	c.inActionMode = inActionMode
+}
+
+// InActionMode returns whether the mode is in action mode.
+func (c *baseContext) InActionMode() bool {
+	return c.inActionMode
+}
+
+// SetPendingAction sets the action to execute when mode selection is complete.
+func (c *baseContext) SetPendingAction(action *string) {
+	c.pendingAction = action
+}
+
+// PendingAction returns the pending action to execute.
+func (c *baseContext) PendingAction() *string {
+	return c.pendingAction
+}
+
+// Reset resets the base context to its initial state.
+func (c *baseContext) Reset() {
+	c.inActionMode = false
+	c.pendingAction = nil
+}
+
+// Context holds the state and context for grid mode operations.
+type Context struct {
+	baseContext
+
+	gridInstance **domainGrid.Grid
+	gridOverlay  **Overlay
 }
 
 // SetGridInstance sets the grid instance.
@@ -42,30 +75,9 @@ func (c *Context) GridOverlay() **Overlay {
 	return c.gridOverlay
 }
 
-// SetInActionMode sets whether grid mode is in action mode.
-func (c *Context) SetInActionMode(inActionMode bool) {
-	c.inActionMode = inActionMode
-}
-
-// InActionMode returns whether grid mode is in action mode.
-func (c *Context) InActionMode() bool {
-	return c.inActionMode
-}
-
-// SetPendingAction sets the action to execute when grid selection is complete.
-func (c *Context) SetPendingAction(action *string) {
-	c.pendingAction = action
-}
-
-// PendingAction returns the pending action to execute.
-func (c *Context) PendingAction() *string {
-	return c.pendingAction
-}
-
 // Reset resets the grid context to its initial state.
 func (c *Context) Reset() {
 	c.gridInstance = nil
 	c.gridOverlay = nil
-	c.inActionMode = false
-	c.pendingAction = nil
+	c.baseContext.Reset()
 }

--- a/internal/app/components/hints/context.go
+++ b/internal/app/components/hints/context.go
@@ -4,13 +4,46 @@ import (
 	domainHint "github.com/y3owk1n/neru/internal/core/domain/hint"
 )
 
-// Context holds the state and context for hint mode operations.
-type Context struct {
-	manager       *domainHint.Manager
-	router        *domainHint.Router
-	hints         *domainHint.Collection
+// baseContext provides common functionality for mode component contexts.
+// It contains shared state fields used across different mode contexts.
+type baseContext struct {
 	inActionMode  bool
 	pendingAction *string
+}
+
+// SetInActionMode sets whether the mode is in action mode.
+func (c *baseContext) SetInActionMode(inActionMode bool) {
+	c.inActionMode = inActionMode
+}
+
+// InActionMode returns whether the mode is in action mode.
+func (c *baseContext) InActionMode() bool {
+	return c.inActionMode
+}
+
+// SetPendingAction sets the action to execute when mode selection is complete.
+func (c *baseContext) SetPendingAction(action *string) {
+	c.pendingAction = action
+}
+
+// PendingAction returns the pending action to execute.
+func (c *baseContext) PendingAction() *string {
+	return c.pendingAction
+}
+
+// Reset resets the base context to its initial state.
+func (c *baseContext) Reset() {
+	c.inActionMode = false
+	c.pendingAction = nil
+}
+
+// Context holds the state and context for hint mode operations.
+type Context struct {
+	baseContext
+
+	manager *domainHint.Manager
+	router  *domainHint.Router
+	hints   *domainHint.Collection
 }
 
 // SetManager sets the domain hint manager.
@@ -46,32 +79,11 @@ func (c *Context) Hints() *domainHint.Collection {
 	return c.hints
 }
 
-// SetInActionMode sets whether hint mode is in action mode.
-func (c *Context) SetInActionMode(inActionMode bool) {
-	c.inActionMode = inActionMode
-}
-
-// InActionMode returns whether hint mode is in action mode.
-func (c *Context) InActionMode() bool {
-	return c.inActionMode
-}
-
-// SetPendingAction sets the action to execute when a hint is selected.
-func (c *Context) SetPendingAction(action *string) {
-	c.pendingAction = action
-}
-
-// PendingAction returns the pending action to execute.
-func (c *Context) PendingAction() *string {
-	return c.pendingAction
-}
-
 // Reset resets the hints context to its initial state.
 func (c *Context) Reset() {
 	if c.manager != nil {
 		c.manager.Reset()
 	}
 
-	c.inActionMode = false
-	c.pendingAction = nil
+	c.baseContext.Reset()
 }

--- a/internal/core/domain/types.go
+++ b/internal/core/domain/types.go
@@ -1,0 +1,25 @@
+package domain
+
+import "go.uber.org/zap"
+
+// BaseManager provides common functionality for domain managers.
+// It contains shared fields and methods used across different domain managers.
+type BaseManager struct {
+	currentInput string
+	Logger       *zap.Logger
+}
+
+// SetCurrentInput sets the current input string.
+func (m *BaseManager) SetCurrentInput(input string) {
+	m.currentInput = input
+}
+
+// CurrentInput returns the current input string.
+func (m *BaseManager) CurrentInput() string {
+	return m.currentInput
+}
+
+// Reset resets the base manager to its initial state.
+func (m *BaseManager) Reset() {
+	m.currentInput = ""
+}


### PR DESCRIPTION
- Add BaseManager struct in core/domain/types.go with currentInput and Logger fields
- Add baseContext struct in app/components contexts with inActionMode and pendingAction fields
- Update grid and hint managers to embed BaseManager
- Update grid and hint contexts to embed baseContext
- Remove duplicated fields and methods from individual structs
