### PR TITLE
feat(nix): add launchd configuration options to home-manager module

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -150,13 +150,15 @@ Use the home-manager module for user-specific installation:
 - `services.neru.package` - Package to use (default: `pkgs.neru` for latest version) or `pkgs.neru-source` for building from source
 - `services.neru.config` - Inline TOML configuration (default: uses `configs/default-config.toml`)
 - `services.neru.configFile` - Path to existing config file (default: `null`, takes precedence over `config`)
+- `services.neru.launchd.enable` - Enable the launchd agent (default: `true`)
+- `services.neru.launchd.keepAlive` - Keep the launchd service alive (default: `true`)
 
 The module automatically:
 
 - Installs Neru in user environment
 - Creates `~/.config/neru/config.toml` (or uses your `configFile`)
-- Creates a launchd user agent
-- Configures the agent to run at login with `KeepAlive = true` and `RunAtLoad = true`
+- Creates a launchd user agent (if `launchd.enable` is `true`)
+- Configures the agent to run at login with `KeepAlive` (if `launchd.keepAlive` is `true`) and `RunAtLoad = true`
 - Installs shell completions for bash, fish, and zsh
 
 ### Option 3: Using as an Overlay Only


### PR DESCRIPTION
- Add launchd.enable option to control launchd agent creation
- Add launchd.keepAlive option to control service persistence
- Update installation docs to document new options


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `services.neru.launchd.enable` configuration option to control macOS launchd agent activation (default enabled).
  * Added `services.neru.launchd.keepAlive` configuration option to control service persistence (default enabled).
  * Service logs now redirect to `/tmp/neru.log` and `/tmp/neru.err.log`.

* **Documentation**
  * Updated installation guide with new launchd configuration options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->