### PR TITLE
chore: bump flake to 1.12.0 [skip ci]

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       ];
 
       # Update this to your latest release version
-      latestVersion = "1.11.1";
+      latestVersion = "1.12.0";
 
       # Function to build package with specific version
       makeNeruPackage =

--- a/package.nix
+++ b/package.nix
@@ -21,13 +21,13 @@ if useZip then
       {
         "aarch64-darwin" = {
           url = "https://github.com/y3owk1n/neru/releases/download/v${version}/neru-darwin-arm64.zip";
-          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.11.1/neru-darwin-arm64.zip)`
-          sha256 = "sha256-f+fQhLjLfz3G2mTj5LW1uk/Cm7k/U6pjg6LXZ58Unic=";
+          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.12.0/neru-darwin-arm64.zip)`
+          sha256 = "sha256-3/p7WXs7hf5eqGoKghlea2n2pt6X8tTiCUU2sV0IDRg=";
         };
         "x86_64-darwin" = {
           url = "https://github.com/y3owk1n/neru/releases/download/v${version}/neru-darwin-amd64.zip";
-          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.11.1/neru-darwin-amd64.zip)`
-          sha256 = "sha256-T4dzIiQqAycMTipuwBOFCEU4iopCxPWWMcRl07FZ6zc=";
+          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.12.0/neru-darwin-amd64.zip)`
+          sha256 = "sha256-As6rulQ5ClPk7mYTErTgTfWekjiESG1cFKcDVFjHavg=";
         };
       }
       .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated version to 1.12.0.
  * Updated macOS builds and checksums for both Apple Silicon and Intel architectures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->