### PR TITLE
chore: bump flake to 1.12.2

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       ];
 
       # Update this to your latest release version
-      latestVersion = "1.12.1";
+      latestVersion = "1.12.2";
 
       # Function to build package with specific version
       makeNeruPackage =

--- a/package.nix
+++ b/package.nix
@@ -21,13 +21,13 @@ if useZip then
       {
         "aarch64-darwin" = {
           url = "https://github.com/y3owk1n/neru/releases/download/v${version}/neru-darwin-arm64.zip";
-          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.12.1/neru-darwin-arm64.zip)`
-          sha256 = "sha256-eT8luSXPCn9uT2JPjoWB81WlcwY2CGgCHf38N2Q6MSQ=";
+          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.12.2/neru-darwin-arm64.zip)`
+          sha256 = "sha256-g9LA9ckkdEx+FVs76sDPBat2bEgoLK0rE7u7tsypCyk=";
         };
         "x86_64-darwin" = {
           url = "https://github.com/y3owk1n/neru/releases/download/v${version}/neru-darwin-amd64.zip";
-          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.12.1/neru-darwin-amd64.zip)`
-          sha256 = "sha256-qEUqwgFdIKMywyUv1nCpL2aZId5kqrJ8Ja6+kf3j/8Y=";
+          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.12.2/neru-darwin-amd64.zip)`
+          sha256 = "sha256-WNzwN+IcuC+NytRs5A64jhMTBMaEvj3dXvw9yaP1yf4=";
         };
       }
       .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 1.12.2
  * Updated build checksums for Darwin platforms (aarch64 and x86_64) to reflect new release data

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->