### PR TITLE
chore: bump flake to 1.12.3

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       ];
 
       # Update this to your latest release version
-      latestVersion = "1.12.2";
+      latestVersion = "1.12.3";
 
       # Function to build package with specific version
       makeNeruPackage =

--- a/package.nix
+++ b/package.nix
@@ -21,13 +21,13 @@ if useZip then
       {
         "aarch64-darwin" = {
           url = "https://github.com/y3owk1n/neru/releases/download/v${version}/neru-darwin-arm64.zip";
-          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.12.2/neru-darwin-arm64.zip)`
-          sha256 = "sha256-g9LA9ckkdEx+FVs76sDPBat2bEgoLK0rE7u7tsypCyk=";
+          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.12.3/neru-darwin-arm64.zip)`
+          sha256 = "sha256-TlMXonU+Aol2vx0w0pjLJeN5XsLvlFJegJQ4+7D6jkw=";
         };
         "x86_64-darwin" = {
           url = "https://github.com/y3owk1n/neru/releases/download/v${version}/neru-darwin-amd64.zip";
-          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.12.2/neru-darwin-amd64.zip)`
-          sha256 = "sha256-WNzwN+IcuC+NytRs5A64jhMTBMaEvj3dXvw9yaP1yf4=";
+          # run `nix hash convert --hash-algo sha256 (nix-prefetch-url --unpack https://github.com/y3owk1n/neru/releases/download/v1.12.3/neru-darwin-amd64.zip)`
+          sha256 = "sha256-yZJC2nrLAOKrQjd9aK7f7hcYq2NzSJzlNi3XJSuOoLU=";
         };
       }
       .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 1.12.3 with corresponding build configuration and verification hash updates for supported platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->