### PR TITLE
refactor(bridge): extract magic numbers into named constants

### DIFF
--- a/internal/core/infra/bridge/accessibility_constants.h
+++ b/internal/core/infra/bridge/accessibility_constants.h
@@ -1,0 +1,47 @@
+//
+//  accessibility_constants.h
+//  Neru
+//
+//  Copyright © 2025 Neru. All rights reserved.
+//
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#pragma mark - Mouse Timing Constants
+
+/// Delay between mouse down and mouse up events during a click (seconds)
+static const CFTimeInterval kNeruMouseClickDownUpDelay = 0.008;
+
+/// Delay after click processing before restoring cursor (seconds)
+static const CFTimeInterval kNeruMouseClickProcessingDelay = 0.05;
+
+/// Delay after mouse move to allow event processing (seconds)
+static const CFTimeInterval kNeruMouseMoveDelay = 0.01;
+
+/// Delay between steps during smooth mouse movement (seconds)
+static const CFTimeInterval kNeruSmoothMoveStepDelay = 0.001;
+
+#pragma mark - Click Detection Constants
+
+/// Maximum time between clicks to be considered a multi-click sequence (milliseconds)
+static const CFTimeInterval kNeruDoubleClickIntervalMs = 500.0;
+
+/// Maximum distance between clicks to be considered at the same position (points)
+static const CGFloat kNeruDoubleClickDistancePoints = 5.0;
+
+#pragma mark - Visibility Constants
+
+/// Inset from element edges when sampling visibility points (points)
+static const CGFloat kNeruVisibilityInsetPoints = 2.0;
+
+/// Minimum number of visible sample points to consider element visible
+static const int kNeruMinVisibleSamplePoints = 2;
+
+#ifdef __cplusplus
+}
+#endif

--- a/internal/core/infra/bridge/accessibility_visibility.m
+++ b/internal/core/infra/bridge/accessibility_visibility.m
@@ -6,6 +6,7 @@
 //
 
 #import "accessibility_visibility.h"
+#import "accessibility_constants.h"
 #import <Cocoa/Cocoa.h>
 
 #pragma mark - Visibility Functions
@@ -46,7 +47,7 @@ bool isPointVisible(CGPoint point, pid_t elementPid) {
 /// @return true if element is occluded, false otherwise
 static bool isElementOccluded(CGRect elementRect, pid_t elementPid) {
 	// Sample 5 points: center and 4 corners (slightly inset)
-	CGFloat inset = 2.0; // Inset from edges to avoid border issues
+	CGFloat inset = kNeruVisibilityInsetPoints;
 
 	CGPoint samplePoints[5] = {
 	    // Center
@@ -67,7 +68,7 @@ static bool isElementOccluded(CGRect elementRect, pid_t elementPid) {
 	for (int i = 0; i < 5; i++) {
 		if (isPointVisible(samplePoints[i], elementPid)) {
 			visiblePoints++;
-			if (visiblePoints >= 2) {
+			if (visiblePoints >= kNeruMinVisibleSamplePoints) {
 				return false; // Not occluded
 			}
 		}


### PR DESCRIPTION
Replace hardcoded magic numbers in accessibility modules with
well-named constants for improved maintainability:

- kNeruMouseClickDownUpDelay (0.008s)
- kNeruMouseClickProcessingDelay (0.05s)
- kNeruDoubleClickIntervalMs (500ms)
- kNeruDoubleClickDistancePoints (5.0pts)
- kNeruVisibilityInsetPoints (2.0pts)

All timing-related values are now centralized in
accessibility_constants.h with descriptive names and units in the
constant names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal updates to the accessibility infrastructure layer, consolidating timing and distance parameters for mouse input handling and visibility detection into centralized constants for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->