### PR TITLE
fix(hints): prevent stale hints from displaying during label refresh

### DIFF
--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -69,7 +69,9 @@ func (h *Handler) activateHintModeInternal(preserveActionMode bool, action *stri
 		// Handle mode transitions: if already in hints mode, do partial cleanup to preserve state;
 		// otherwise exit completely to reset all state
 		if h.appState.CurrentMode() == domain.ModeHints {
-			h.performModeSpecificCleanup()
+			// During refresh, only clear overlay but do NOT reset manager state
+			// Calling Reset() would trigger callback with stale hints before new hints are set
+			h.overlayManager.Clear()
 			h.performCommonCleanup()
 			// Skip cursor restoration to maintain position during hint mode transitions
 		} else {


### PR DESCRIPTION
When refreshing hints after a label was satisfied, the manager.Reset()
call during cleanup would immediately trigger the callback with the old
hint collection before the new collection was set. This caused the
overlay to display stale hints while the manager was using the new
hints, leading to mismatched label positions when the first key was
pressed.

Skip the full manager reset during hint refresh. Only clear the overlay
display while preserving the manager state, then immediately update to
the new hint collection. This ensures the overlay and manager stay in
sync.

Fixes the issue where "all labels change" when pressing the first key
on a refreshed hint set. Closes #325

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/326">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
