### PR TITLE
refactor(bridge): consolidate arrow key handling and use named constants

### DIFF
--- a/internal/core/infra/bridge/eventtap.m
+++ b/internal/core/infra/bridge/eventtap.m
@@ -151,66 +151,41 @@ CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 				}
 			}
 
-			// Special handling for delete/backspace key (keycode 51) without modifiers
-			if (keyCode == 51) {
+			// Special handling for delete/backspace key without modifiers
+			if (keyCode == kKeyCodeDelete) {
 				if (context->callback) {
 					context->callback("\x7f", context->userData);
 				}
 				return NULL;
 			}
 
-			// Special handling for escape key (keycode 53) without modifiers
-			if (keyCode == 53) {
+			// Special handling for escape key without modifiers
+			if (keyCode == kKeyCodeEscape) {
 				if (context->callback) {
 					context->callback("\x1b", context->userData);
 				}
 				return NULL;
 			}
 
-			// Handle arrow keys and special keys without modifiers
-			switch (keyCode) {
-			case 126: // Up arrow
-				if (context->callback) {
-					context->callback("Up", context->userData);
+			// Handle arrow keys and special keys without modifiers using lookup table
+			{
+				static const struct {
+					CGKeyCode code;
+					const char *name;
+				} specialKeys[] = {
+				    {kKeyCodeUp, "Up"},       {kKeyCodeDown, "Down"},     {kKeyCodeLeft, "Left"},
+				    {kKeyCodeRight, "Right"}, {kKeyCodePageUp, "PageUp"}, {kKeyCodePageDown, "PageDown"},
+				    {kKeyCodeHome, "Home"},   {kKeyCodeEnd, "End"},
+				};
+
+				for (size_t i = 0; i < sizeof(specialKeys) / sizeof(specialKeys[0]); i++) {
+					if (keyCode == specialKeys[i].code) {
+						if (context->callback) {
+							context->callback(specialKeys[i].name, context->userData);
+						}
+						return NULL;
+					}
 				}
-				return NULL;
-			case 125: // Down arrow
-				if (context->callback) {
-					context->callback("Down", context->userData);
-				}
-				return NULL;
-			case 123: // Left arrow
-				if (context->callback) {
-					context->callback("Left", context->userData);
-				}
-				return NULL;
-			case 124: // Right arrow
-				if (context->callback) {
-					context->callback("Right", context->userData);
-				}
-				return NULL;
-			case 116: // PageUp
-				if (context->callback) {
-					context->callback("PageUp", context->userData);
-				}
-				return NULL;
-			case 121: // PageDown
-				if (context->callback) {
-					context->callback("PageDown", context->userData);
-				}
-				return NULL;
-			case 115: // Home
-				if (context->callback) {
-					context->callback("Home", context->userData);
-				}
-				return NULL;
-			case 119: // End
-				if (context->callback) {
-					context->callback("End", context->userData);
-				}
-				return NULL;
-			default:
-				break;
 			}
 
 			// Map key code to character directly using US QWERTY layout


### PR DESCRIPTION
- Replace repetitive switch-case with lookup table for special keys
- Use kKeyCode* constants instead of magic numbers (51, 53, 123-126,
etc.)
- Consolidate Up/Down/Left/Right/ PageUp/PageDown/Home/End handling
- Apply constants to delete (kKeyCodeDelete) and escape (kKeyCodeEscape)
keys

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/350">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
