### PR TITLE
fix(ui): offset odd border widths for nicer grid rendering

### DIFF
--- a/internal/core/infra/bridge/overlay.m
+++ b/internal/core/infra/bridge/overlay.m
@@ -435,7 +435,15 @@ static inline BOOL rectsEqual(NSRect a, NSRect b, CGFloat epsilon) {
 			borderColor = self.gridMatchedBorderColor;
 		}
 		[borderColor setStroke];
-		NSBezierPath *borderPath = [NSBezierPath bezierPathWithRect:cellRect];
+
+		NSRect borderRect = cellRect;
+		// For odd border widths (like 1.0), offset by 0.5 to ensure crisp lines
+		// and proper overlap at shared edges.
+		if ((int)self.gridBorderWidth % 2 == 1) {
+			borderRect = NSOffsetRect(cellRect, 0.5, -0.5);
+		}
+
+		NSBezierPath *borderPath = [NSBezierPath bezierPathWithRect:borderRect];
 		[borderPath setLineWidth:self.gridBorderWidth];
 		[borderPath stroke];
 


### PR DESCRIPTION
This PR fixes blurry grid cell borders when using odd-pixel border widths (like 1px).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/353">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
