### PR TITLE
fix(systray): copy version to use popup instead of osascript notif

### DIFF
--- a/internal/app/components/systray/systray.go
+++ b/internal/app/components/systray/systray.go
@@ -216,7 +216,7 @@ func (c *Component) handleVersionCopy() {
 	if writeToClipboardErr != nil {
 		c.logger.Error("Error copying version to clipboard", zap.Error(writeToClipboardErr))
 	} else {
-		bridge.ShowNotification("Neru", "Version copied to clipboard")
+		bridge.ShowSuccessAlert("✅ Copied Successfully", "Version copied to clipboard")
 	}
 }
 

--- a/internal/core/infra/bridge/alert.h
+++ b/internal/core/infra/bridge/alert.h
@@ -24,4 +24,10 @@ int showConfigValidationErrorAlert(const char *errorMessage, const char *configP
 /// @param message The notification message
 void showNotification(const char *title, const char *message);
 
+/// Show a success alert popup with a title and message
+/// Uses NSAlert to display a native modal dialog
+/// @param title The alert title
+/// @param message The alert message
+void showSuccessAlert(const char *title, const char *message);
+
 #endif /* ALERT_H */

--- a/internal/core/infra/bridge/bridge.go
+++ b/internal/core/infra/bridge/bridge.go
@@ -285,3 +285,19 @@ func ShowNotification(title, message string) {
 
 	C.showNotification(cTitle, cMessage)
 }
+
+// ShowSuccessAlert displays a native macOS success alert popup with the given title and message.
+func ShowSuccessAlert(title, message string) {
+	log := getLogger()
+	log.Debug("Bridge: Showing success alert",
+		zap.String("title", title),
+		zap.String("message", message))
+
+	cTitle := C.CString(title)
+	defer C.free(unsafe.Pointer(cTitle)) //nolint:nlreturn
+
+	cMessage := C.CString(message)
+	defer C.free(unsafe.Pointer(cMessage)) //nolint:nlreturn
+
+	C.showSuccessAlert(cTitle, cMessage)
+}


### PR DESCRIPTION
This PR uses the validation error popup to notify about the version copied instead of osascripts.

https://github.com/user-attachments/assets/5526b3a0-5f63-475e-868e-71a643e55b89

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
