### PR TITLE
chore: bump go to 1.25.5 plus small fixes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,9 +10,9 @@ jobs:
     release-please:
         strategy:
             matrix:
-                go: ["1.25.2"]
+                go: ["1.25.5"]
                 os: [macos-latest]
-                just: ["1.43.1"]
+                just: ["1.46.0"]
         runs-on: ${{ matrix.os }}
         steps:
             # Create a release using the release-please action.

--- a/devbox.json
+++ b/devbox.json
@@ -1,15 +1,15 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
   "packages": [
-    "go@1.25.2",
-    "gopls@0.20.0",
     "gotools@0.34.0",
-    "golangci-lint@2.6.2",
     "gofumpt@0.9.2",
     "golines@0.13.0",
-    "just@1.43.1",
-    "just-lsp@0.2.8",
     "nixd@2.8.2",
-    "nixfmt@1.2.0"
+    "nixfmt@1.2.0",
+    "go@1.25.5",
+    "gopls@0.21.0",
+    "golangci-lint@2.8.0",
+    "just@1.46.0",
+    "just-lsp@0.3.2"
   ]
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -5,51 +5,51 @@
       "last_modified": "2025-12-01T17:53:29Z",
       "resolved": "github:NixOS/nixpkgs/8c29968b3a942f2903f90797f9623737c215737c?lastModified=1764611609"
     },
-    "go@1.25.2": {
-      "last_modified": "2025-10-22T20:59:19Z",
-      "resolved": "github:NixOS/nixpkgs/01b6809f7f9d1183a2b3e081f0a1e6f8f415cb09#go",
+    "go@1.25.5": {
+      "last_modified": "2026-01-23T17:20:52Z",
+      "resolved": "github:NixOS/nixpkgs/a1bab9e494f5f4939442a57a58d0449a109593fe#go",
       "source": "devbox-search",
-      "version": "1.25.2",
+      "version": "1.25.5",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/nkhf1yv637cp91y79zap7jxmm98v8pvj-go-1.25.2",
+              "path": "/nix/store/wh88zz6r1ihcp2mm7ys1f2anp8aga6n2-go-1.25.5",
               "default": true
             }
           ],
-          "store_path": "/nix/store/nkhf1yv637cp91y79zap7jxmm98v8pvj-go-1.25.2"
+          "store_path": "/nix/store/wh88zz6r1ihcp2mm7ys1f2anp8aga6n2-go-1.25.5"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/p1d8jb1k4db3aiqwyp8b1kw4mja3qygx-go-1.25.2",
+              "path": "/nix/store/k3knzdi0v21bf2m7vcxpdy1jnqg1h0zk-go-1.25.5",
               "default": true
             }
           ],
-          "store_path": "/nix/store/p1d8jb1k4db3aiqwyp8b1kw4mja3qygx-go-1.25.2"
+          "store_path": "/nix/store/k3knzdi0v21bf2m7vcxpdy1jnqg1h0zk-go-1.25.5"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/xvwacgkf3x446qq3mdsh3v13f8935wa3-go-1.25.2",
+              "path": "/nix/store/bwdahzajhqd5x14dbvkqww5f1wpsxif3-go-1.25.5",
               "default": true
             }
           ],
-          "store_path": "/nix/store/xvwacgkf3x446qq3mdsh3v13f8935wa3-go-1.25.2"
+          "store_path": "/nix/store/bwdahzajhqd5x14dbvkqww5f1wpsxif3-go-1.25.5"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/k1kn1c59ss7nq6agdppzq3krwmi3xqy4-go-1.25.2",
+              "path": "/nix/store/zzvsjgylnphvhms3lgr2qlwdxmc68z66-go-1.25.5",
               "default": true
             }
           ],
-          "store_path": "/nix/store/k1kn1c59ss7nq6agdppzq3krwmi3xqy4-go-1.25.2"
+          "store_path": "/nix/store/zzvsjgylnphvhms3lgr2qlwdxmc68z66-go-1.25.5"
         }
       }
     },
@@ -101,51 +101,51 @@
         }
       }
     },
-    "golangci-lint@2.6.2": {
-      "last_modified": "2025-11-23T21:50:36Z",
-      "resolved": "github:NixOS/nixpkgs/ee09932cedcef15aaf476f9343d1dea2cb77e261#golangci-lint",
+    "golangci-lint@2.8.0": {
+      "last_modified": "2026-01-23T17:20:52Z",
+      "resolved": "github:NixOS/nixpkgs/a1bab9e494f5f4939442a57a58d0449a109593fe#golangci-lint",
       "source": "devbox-search",
-      "version": "2.6.2",
+      "version": "2.8.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/yvnfabxmnwmig8ralc22has0kpk7gbkn-golangci-lint-2.6.2",
+              "path": "/nix/store/ci7qq9jsgk0v1f0pzs7kb0v9rk5zwyck-golangci-lint-2.8.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/yvnfabxmnwmig8ralc22has0kpk7gbkn-golangci-lint-2.6.2"
+          "store_path": "/nix/store/ci7qq9jsgk0v1f0pzs7kb0v9rk5zwyck-golangci-lint-2.8.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/jfhvpym9967m3rf8shlcmlarfbf73cpj-golangci-lint-2.6.2",
+              "path": "/nix/store/ly2sk4i2qj8gfb0l7m5sxvyv7c8rn273-golangci-lint-2.8.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/jfhvpym9967m3rf8shlcmlarfbf73cpj-golangci-lint-2.6.2"
+          "store_path": "/nix/store/ly2sk4i2qj8gfb0l7m5sxvyv7c8rn273-golangci-lint-2.8.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/bg84ksi4vm63c7m39yj6y1ga9n64n3mp-golangci-lint-2.6.2",
+              "path": "/nix/store/r1m8175dhby0agi1r43ic2scrphsjnlb-golangci-lint-2.8.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/bg84ksi4vm63c7m39yj6y1ga9n64n3mp-golangci-lint-2.6.2"
+          "store_path": "/nix/store/r1m8175dhby0agi1r43ic2scrphsjnlb-golangci-lint-2.8.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/3kn873p4cpk0yhz7y0qvwpnn1h885a40-golangci-lint-2.6.2",
+              "path": "/nix/store/kj9ibnlg1p3macpcw8lm4rhpcwgfjal1-golangci-lint-2.8.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/3kn873p4cpk0yhz7y0qvwpnn1h885a40-golangci-lint-2.6.2"
+          "store_path": "/nix/store/kj9ibnlg1p3macpcw8lm4rhpcwgfjal1-golangci-lint-2.8.0"
         }
       }
     },
@@ -197,51 +197,51 @@
         }
       }
     },
-    "gopls@0.20.0": {
-      "last_modified": "2025-11-23T21:50:36Z",
-      "resolved": "github:NixOS/nixpkgs/ee09932cedcef15aaf476f9343d1dea2cb77e261#gopls",
+    "gopls@0.21.0": {
+      "last_modified": "2026-01-23T17:20:52Z",
+      "resolved": "github:NixOS/nixpkgs/a1bab9e494f5f4939442a57a58d0449a109593fe#gopls",
       "source": "devbox-search",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/w5smfrhma5vh908wgqbqba02i701msd8-gopls-0.20.0",
+              "path": "/nix/store/6v1b50zvb6jw5dji6a48l3di2gf52dqm-gopls-0.21.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/w5smfrhma5vh908wgqbqba02i701msd8-gopls-0.20.0"
+          "store_path": "/nix/store/6v1b50zvb6jw5dji6a48l3di2gf52dqm-gopls-0.21.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/1dl6cm3zydwvlxy0dc7wxm793cfm5c9x-gopls-0.20.0",
+              "path": "/nix/store/qkzgz3l3yv3m409rjswffmkjx615ivsz-gopls-0.21.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/1dl6cm3zydwvlxy0dc7wxm793cfm5c9x-gopls-0.20.0"
+          "store_path": "/nix/store/qkzgz3l3yv3m409rjswffmkjx615ivsz-gopls-0.21.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/q5h6pc3fkanj7vsrbqbwvi6gllzf9182-gopls-0.20.0",
+              "path": "/nix/store/h0m9cqbzvzcnrbz0l87r2jm60fkwy4qq-gopls-0.21.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/q5h6pc3fkanj7vsrbqbwvi6gllzf9182-gopls-0.20.0"
+          "store_path": "/nix/store/h0m9cqbzvzcnrbz0l87r2jm60fkwy4qq-gopls-0.21.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/nak76gf936fzwimbfv1052cqq29lvmpm-gopls-0.20.0",
+              "path": "/nix/store/3bfgzysvkjwf4rdpbnn4jb4ly21m1khd-gopls-0.21.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/nak76gf936fzwimbfv1052cqq29lvmpm-gopls-0.20.0"
+          "store_path": "/nix/store/3bfgzysvkjwf4rdpbnn4jb4ly21m1khd-gopls-0.21.0"
         }
       }
     },
@@ -293,135 +293,135 @@
         }
       }
     },
-    "just-lsp@0.2.8": {
-      "last_modified": "2025-11-23T21:50:36Z",
-      "resolved": "github:NixOS/nixpkgs/ee09932cedcef15aaf476f9343d1dea2cb77e261#just-lsp",
+    "just-lsp@0.3.2": {
+      "last_modified": "2026-01-23T17:20:52Z",
+      "resolved": "github:NixOS/nixpkgs/a1bab9e494f5f4939442a57a58d0449a109593fe#just-lsp",
       "source": "devbox-search",
-      "version": "0.2.8",
+      "version": "0.3.2",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/3hrbf120fg4k5kcv4b6kcf07mib5q163-just-lsp-0.2.8",
+              "path": "/nix/store/9zvnajikdll286dlq4yqq7r6q8v9xsx6-just-lsp-0.3.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/3hrbf120fg4k5kcv4b6kcf07mib5q163-just-lsp-0.2.8"
+          "store_path": "/nix/store/9zvnajikdll286dlq4yqq7r6q8v9xsx6-just-lsp-0.3.2"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/pry7k04vjpc30rqwkrf8dhfmg7l29zvc-just-lsp-0.2.8",
+              "path": "/nix/store/ssqz6kchv257lw5cxxxjx8myzyydbmg5-just-lsp-0.3.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/pry7k04vjpc30rqwkrf8dhfmg7l29zvc-just-lsp-0.2.8"
+          "store_path": "/nix/store/ssqz6kchv257lw5cxxxjx8myzyydbmg5-just-lsp-0.3.2"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/yzaagq4zm2hjl4jsq5bjs07rw91ihi2f-just-lsp-0.2.8",
+              "path": "/nix/store/gjvi51alg59b6ygbmyh68irpxambfdiz-just-lsp-0.3.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/yzaagq4zm2hjl4jsq5bjs07rw91ihi2f-just-lsp-0.2.8"
+          "store_path": "/nix/store/gjvi51alg59b6ygbmyh68irpxambfdiz-just-lsp-0.3.2"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/x3d57p7hy25zn8rb78kqy6fzgggv9s2q-just-lsp-0.2.8",
+              "path": "/nix/store/pcjfmaxh1m4wqmjbimkk2bdv67v6mwma-just-lsp-0.3.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/x3d57p7hy25zn8rb78kqy6fzgggv9s2q-just-lsp-0.2.8"
+          "store_path": "/nix/store/pcjfmaxh1m4wqmjbimkk2bdv67v6mwma-just-lsp-0.3.2"
         }
       }
     },
-    "just@1.43.1": {
-      "last_modified": "2025-11-23T21:50:36Z",
-      "resolved": "github:NixOS/nixpkgs/ee09932cedcef15aaf476f9343d1dea2cb77e261#just",
+    "just@1.46.0": {
+      "last_modified": "2026-01-23T17:20:52Z",
+      "resolved": "github:NixOS/nixpkgs/a1bab9e494f5f4939442a57a58d0449a109593fe#just",
       "source": "devbox-search",
-      "version": "1.43.1",
+      "version": "1.46.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/g6cidwix7lzzb0i5lpisvb7gx051qsc1-just-1.43.1",
+              "path": "/nix/store/kms72z6m9ny9xc8jran5xapikqsbhm5q-just-1.46.0",
               "default": true
             },
             {
               "name": "man",
-              "path": "/nix/store/y8ggbr7rq06mpqsdckpdsxzhjkspw63g-just-1.43.1-man",
+              "path": "/nix/store/faqgfslw33szczc60xvbsddag1vpm6qg-just-1.46.0-man",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/g2z02i3a2z17h9cmx04sp7zpzzgzkqh8-just-1.43.1-doc"
+              "path": "/nix/store/db99chhg7z1p8x4kqsnf4hna33yab8jd-just-1.46.0-doc"
             }
           ],
-          "store_path": "/nix/store/g6cidwix7lzzb0i5lpisvb7gx051qsc1-just-1.43.1"
+          "store_path": "/nix/store/kms72z6m9ny9xc8jran5xapikqsbhm5q-just-1.46.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ni4jn8rsn0h49lng7hdq6584zc4gpy9l-just-1.43.1",
+              "path": "/nix/store/84hs79g4rgwpd8vpvrsnibmfh2qk08fq-just-1.46.0",
               "default": true
             },
             {
               "name": "man",
-              "path": "/nix/store/59aflmjxv0qbkaqzmjni4yydg873dl5v-just-1.43.1-man",
+              "path": "/nix/store/jcrjba1fjd86vdbh8iwj37cbw0ngn26v-just-1.46.0-man",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/99qn6axss3rk7c681rkhj9zza0ax2i74-just-1.43.1-doc"
+              "path": "/nix/store/x29kkagia2b2hw20qj0m5r256cvi3fk7-just-1.46.0-doc"
             }
           ],
-          "store_path": "/nix/store/ni4jn8rsn0h49lng7hdq6584zc4gpy9l-just-1.43.1"
+          "store_path": "/nix/store/84hs79g4rgwpd8vpvrsnibmfh2qk08fq-just-1.46.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/aa9459rdk1lzj2yd27csaasn9hb98ckr-just-1.43.1",
+              "path": "/nix/store/dj01bb0rk1czx6wdymfswh4as56xsbkw-just-1.46.0",
               "default": true
             },
             {
               "name": "man",
-              "path": "/nix/store/j67aa2bj6ssz61x4bh0ga0z1qzzv3prp-just-1.43.1-man",
+              "path": "/nix/store/svaa8vdlzdgbm5plfk3bvyawnvkj7x36-just-1.46.0-man",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/kqx5lgjwpaipi7whnydwkl72alwvn5jz-just-1.43.1-doc"
+              "path": "/nix/store/40bl31lv2wy1p7yfafzzh1wip3pc0iga-just-1.46.0-doc"
             }
           ],
-          "store_path": "/nix/store/aa9459rdk1lzj2yd27csaasn9hb98ckr-just-1.43.1"
+          "store_path": "/nix/store/dj01bb0rk1czx6wdymfswh4as56xsbkw-just-1.46.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/kkmg0vkp9y4jp9yqgzrml0fgac9lfcyq-just-1.43.1",
+              "path": "/nix/store/n4g7fjn0b4m0rfjaqw2y4czvz6za1iwr-just-1.46.0",
               "default": true
             },
             {
               "name": "man",
-              "path": "/nix/store/ib17hahpg1vpgh1ll0r7nb6rkmilpiil-just-1.43.1-man",
+              "path": "/nix/store/7cjc376r94pkwnlcvaqrna8k8q2spvkc-just-1.46.0-man",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/idyx9h5gmcnzzqbjb50nwf30i4g1050v-just-1.43.1-doc"
+              "path": "/nix/store/db447q0xh3xdhaz8b8mc6k02sl2ckgdc-just-1.46.0-doc"
             }
           ],
-          "store_path": "/nix/store/kkmg0vkp9y4jp9yqgzrml0fgac9lfcyq-just-1.43.1"
+          "store_path": "/nix/store/n4g7fjn0b4m0rfjaqw2y4czvz6za1iwr-just-1.46.0"
         }
       }
     },

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -101,7 +101,7 @@ devbox shell
 
 Devbox automatically installs and manages:
 
-- Go 1.25.2
+- Go 1.25.5
 - gopls (Go language server)
 - gotools, gofumpt, golines (Go formatting tools)
 - golangci-lint (linter)
@@ -713,7 +713,7 @@ Configuration management:
 3. Implement infrastructure in `internal/core/infra/`
 4. Add components in `internal/app/components/`
 5. Implement the `Mode` interface in `internal/app/modes/` (see `HintsMode`, `GridMode`, `ScrollMode` for examples)
-   - See also `QuadGridMode` for recursive quadrant navigation
+    - See also `QuadGridMode` for recursive quadrant navigation
 6. Register mode in the Handler's mode map in `internal/app/modes/handler.go`
 
 **Actions:**

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -260,7 +260,7 @@ The latest version of Neru requires Go 1.25 or later. If you're using stable nix
 package = pkgs.neru-source.overrideAttrs (_: {
   postPatch = ''
      substituteInPlace go.mod \
-       --replace-fail "go 1.25.2" "go 1.24.9"
+       --replace-fail "go 1.25.5" "go 1.24.9"
 
      # Verify it worked
      echo "=== go.mod after patch ==="

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/y3owk1n/neru
 
-go 1.25.2
+go 1.25.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/internal/app/services/services_integration_test.go
+++ b/internal/app/services/services_integration_test.go
@@ -71,7 +71,10 @@ func TestHintServiceIntegration(t *testing.T) {
 				if overlay.IsVisible() {
 					t.Logf("Overlay is visible after finding %d hints (expected)", len(hints))
 				} else {
-					t.Logf("Overlay is not visible after finding %d hints (unexpected but non-failing)", len(hints))
+					t.Logf(
+						"Overlay is not visible after finding %d hints (unexpected but non-failing)",
+						len(hints),
+					)
 				}
 			}
 		}

--- a/internal/cli/cliutil/util.go
+++ b/internal/cli/cliutil/util.go
@@ -167,7 +167,11 @@ func (f *OutputFormatter) PrintStatus(cmd *cobra.Command, data any) error {
 		// Fallback to JSON output
 		jsonData, jsonDataErr := json.MarshalIndent(data, "  ", "  ")
 		if jsonDataErr != nil {
-			return derrors.Wrap(jsonDataErr, derrors.CodeSerializationFailed, "failed to marshal status data")
+			return derrors.Wrap(
+				jsonDataErr,
+				derrors.CodeSerializationFailed,
+				"failed to marshal status data",
+			)
 		}
 
 		cmd.Println(string(jsonData))

--- a/internal/core/domain/grid/grid.go
+++ b/internal/core/domain/grid/grid.go
@@ -179,7 +179,12 @@ func NewGridWithLabels(
 		zap.Int("height", height))
 
 	if gridCacheEnabled {
-		if cells, ok := gridCache.get(uppercaseChars, strings.ToUpper(rowLabels), strings.ToUpper(colLabels), bounds); ok {
+		if cells, ok := gridCache.get(
+			uppercaseChars,
+			strings.ToUpper(rowLabels),
+			strings.ToUpper(colLabels),
+			bounds,
+		); ok {
 			logger.Debug("Grid cache hit",
 				zap.Int("cell_count", len(cells)))
 

--- a/internal/core/errors/doc.go
+++ b/internal/core/errors/doc.go
@@ -1,6 +1,6 @@
-// Package errors provides domain-specific error types and utilities.
+// Package derrors provides domain-specific error types and utilities.
 //
 // This package implements a structured error handling system with error codes,
 // wrapping, and context information. It follows Go 1.13+ error handling patterns
 // with errors.Is and errors.As support.
-package errors
+package derrors

--- a/internal/core/errors/errors.go
+++ b/internal/core/errors/errors.go
@@ -1,4 +1,4 @@
-package errors
+package derrors
 
 import (
 	"errors"

--- a/internal/core/errors/errors_bench_test.go
+++ b/internal/core/errors/errors_bench_test.go
@@ -1,4 +1,4 @@
-package errors_test
+package derrors_test
 
 import (
 	"testing"

--- a/internal/core/errors/errors_test.go
+++ b/internal/core/errors/errors_test.go
@@ -1,4 +1,4 @@
-package errors_test
+package derrors_test
 
 import (
 	"errors"


### PR DESCRIPTION
This PR bumps Go from 1.25.2 to 1.25.5 along with several dev tools (just, gopls, golangci-lint, just-lsp). These version pins are updated across go.mod, devbox.json, CI, and documentation.

Two small fixes are included:
- The internal error package at internal/core/errors is renamed from package errors to package derrors, aligning the package declaration with the import alias already used everywhere errors.go:1
- The golangci-lint upgrade (2.6.2 → 2.8.0) enforces stricter line-length rules, causing a few long function calls to be wrapped into multi-line form

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
