### PR TITLE
refactor: clean up timer.Stop() usage for consistency and lint compliance

### DIFF
--- a/internal/app/components/overlayutil/util.go
+++ b/internal/app/components/overlayutil/util.go
@@ -196,7 +196,6 @@ func (c *CallbackManager) handleResizeCallback(callbackID uint64, done chan stru
 
 	select {
 	case <-done:
-		timer.Stop() // Stop timer immediately on success
 		// Callback received, normal cleanup already handled in callback
 		if c.logger != nil {
 			c.logger.Debug(
@@ -218,7 +217,6 @@ func (c *CallbackManager) handleResizeCallback(callbackID uint64, done chan stru
 		}
 	case <-c.cancelCh:
 		// Manager is being cleaned up, clean up this callback
-		timer.Stop()
 		c.callbackMu.Lock()
 		delete(c.callbackMap, callbackID)
 		c.callbackMu.Unlock()

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -402,14 +402,13 @@ func (a *App) waitForShutdown() error {
 
 	select {
 	case <-done:
-		timer.Stop() // Stop timer immediately on success
+		timer.Stop()
 		a.logger.Info("Graceful shutdown completed")
 
 		signal.Stop(sigChan)
 
 		return nil
 	case <-sigChan:
-		timer.Stop() // Stop timer on second signal
 		a.logger.Warn("Received second signal, forcing shutdown")
 		a.logger.Info("⚠️  Force quitting...")
 		os.Exit(1)

--- a/internal/core/infra/ipc/ipc.go
+++ b/internal/core/infra/ipc/ipc.go
@@ -184,7 +184,6 @@ func (s *Server) Stop() error {
 
 	select {
 	case <-done:
-		timer.Stop() // Stop timer immediately on success
 		// All connections closed successfully
 	case <-timer.C:
 		// Timeout waiting for connections to close


### PR DESCRIPTION
Replace redundant timer.Stop() calls with proper patterns:

- ipc.go: remove explicit stop after defer (safe, no exits)
- overlayutil/util.go: remove explicit stops after defer (safe, no exits)
- lifecycle.go: use explicit stop in success path, defer incompatible with os.Exit()

The defer pattern works well except when os.Exit() is present, which
bypasses defers. In those cases, explicit stops are used only where
they actually execute.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
