### PR TITLE
fix(overlayutil): release callback ID on timeout and cancel paths

### DIFF
--- a/internal/app/components/overlayutil/util.go
+++ b/internal/app/components/overlayutil/util.go
@@ -53,11 +53,13 @@ func init() {
 func releaseCallbackID(callbackID uint64) {
 	// Check if ID is actually allocated before releasing (guards against double-release)
 	allocatedCallbackIDsMu.Lock()
+
 	if !allocatedCallbackIDs[callbackID] {
 		allocatedCallbackIDsMu.Unlock()
 		// ID is not allocated, nothing to release
 		return
 	}
+
 	delete(allocatedCallbackIDs, callbackID)
 	allocatedCallbackIDsMu.Unlock()
 
@@ -150,7 +152,9 @@ func (c *CallbackManager) StartResizeOperation(callbackFunc func(uint64)) {
 
 	// Mark ID as allocated to guard against double-release
 	allocatedCallbackIDsMu.Lock()
+
 	allocatedCallbackIDs[callbackID] = true
+
 	allocatedCallbackIDsMu.Unlock()
 
 	// Store channel in instance map


### PR DESCRIPTION
Previously, the timeout path (<-timer.C) and cancel path (<-c.cancelCh) in
handleResizeCallback only deleted the callback from callbackMap but failed
to return the callbackID to freeCallbackIDs or remove it from
callbackManagerRegistry. This caused a resource leak where callback IDs
would be permanently lost from the pool.

This fix:
- Extracts cleanup logic into releaseCallbackID helper function
- Updates CompleteGlobalCallback to use the helper
- Adds releaseCallbackID calls to both timeout and cancel paths in
  handleResizeCallback

Fixes issue where repeated timeouts could exhaust the 1024 available IDs
and trigger a panic.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
