### PR TITLE
fix(accessibility): use shortest TTL for cleanup interval

### DIFF
--- a/internal/core/infra/accessibility/cache.go
+++ b/internal/core/infra/accessibility/cache.go
@@ -276,7 +276,9 @@ func (c *InfoCache) Stop() {
 
 // cleanupLoop runs a periodic cleanup process to remove expired cache entries.
 func (c *InfoCache) cleanupLoop() {
-	ticker := time.NewTicker(c.ttl / CacheCleanupDivisor) // Cleanup at half the TTL interval
+	// Use shortest TTL (dynamic elements) for cleanup interval to ensure
+	// prompt cleanup of expired items regardless of cache-level TTL setting
+	ticker := time.NewTicker(DynamicElementTTL / CacheCleanupDivisor)
 	defer ticker.Stop()
 
 	for {


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
