### PR TITLE
fix(systray): ensure NSApplication runs on main thread to prevent SIGTRAP

### DIFF
--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -7,6 +7,7 @@ import (
 	_ "net/http/pprof" // Register pprof handlers
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/y3owk1n/neru/internal/app"
 	"github.com/y3owk1n/neru/internal/cli"
@@ -17,6 +18,9 @@ import (
 )
 
 func main() {
+	// Lock to main thread for macOS Cocoa - must be called before any goroutines
+	runtime.LockOSThread()
+
 	cli.LaunchFunc = LaunchDaemon
 
 	cli.Execute()

--- a/internal/core/infra/systray/systray.go
+++ b/internal/core/infra/systray/systray.go
@@ -10,7 +10,6 @@ package systray
 import "C"
 
 import (
-	"runtime"
 	"sync"
 	"unsafe"
 )
@@ -70,7 +69,6 @@ func (m *MenuItem) Hidden() bool {
 
 // Run starts the system tray loop. It must be called from the main thread.
 func Run(onReadyFunc, onExitFunc func()) {
-	runtime.LockOSThread()
 	onReady = onReadyFunc
 	onExit = onExitFunc
 	C.nativeLoop()
@@ -79,7 +77,6 @@ func Run(onReadyFunc, onExitFunc func()) {
 // RunHeadless starts the system tray loop without a status icon.
 // It must be called from the main thread.
 func RunHeadless(onReadyFunc, onExitFunc func()) {
-	runtime.LockOSThread()
 	onReady = onReadyFunc
 	onExit = onExitFunc
 	C.nativeLoopHeadless()


### PR DESCRIPTION
Move runtime.LockOSThread() to the start of main() before any goroutines are spawned. This prevents a race condition where the Go scheduler could migrate the main goroutine to a non-main OS thread, causing macOS to raise SIGTRAP when initializing NSApplication in the systray.

Remove redundant LockOSThread() calls from systray.Run() and systray.RunHeadless() as the thread is now locked at program start.

Fixes intermittent crashes during launch when the systray initializes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
