### PR TITLE
fix(keymap): fix thread safety issues — use-after-free, MRC memory leaks, and TIS main-thread requirement

### DIFF
--- a/internal/core/infra/bridge/keymap.m
+++ b/internal/core/infra/bridge/keymap.m
@@ -567,14 +567,11 @@ static void handleKeyboardLayoutChanged(CFNotificationCenterRef center, void *ob
 /// Flag for tracking layout maps initialization status (atomic for thread safety)
 static atomic_bool gLayoutMapsInitialized = false;
 
-/// Register notification observer (called once)
+/// Register notification observer (called once from initializeKeyMaps)
 static void registerLayoutChangeObserver(void) {
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		CFNotificationCenterAddObserver(CFNotificationCenterGetDistributedCenter(), NULL, handleKeyboardLayoutChanged,
-		                                kTISNotifySelectedKeyboardInputSourceChanged, NULL,
-		                                CFNotificationSuspensionBehaviorDeliverImmediately);
-	});
+	CFNotificationCenterAddObserver(CFNotificationCenterGetDistributedCenter(), NULL, handleKeyboardLayoutChanged,
+	                                kTISNotifySelectedKeyboardInputSourceChanged, NULL,
+	                                CFNotificationSuspensionBehaviorDeliverImmediately);
 }
 
 static void initializeKeyMaps(void) {


### PR DESCRIPTION
Fix three categories of thread safety and memory management issues in keymap.m:

### 1. Use-after-free in public functions

Public functions (keyNameToCode, keyCodeToName, keyCodeToCharacter, etc.) read a global dictionary pointer under gKeymapLock, released the lock, then used the dictionary. A concurrent buildLayoutMaps rebuild could free the old dictionary in between. Fixed by adding [[map retain] autorelease] while holding the lock so the dictionary stays valid until the current autorelease pool drains.

### 2. MRC memory leaks on layout rebuild

buildLayoutMaps() overwrites global dictionary pointers (e.g. gKeyNameToCodeMap = [nameToCode copy]) without releasing the previous values. Under MRC, this leaks the old dictionaries on every keyboard layout change. Fixed by adding [gXxx release] before each reassignment in all three code paths (no input source, no layout data, and successful layout).

### 3. TIS APIs called from background threads

TISCopyCurrentKeyboardLayoutInputSource and related TIS APIs must run on the main thread. Previously, buildLayoutMaps() ran inside dispatch_once during the first call to any public function, which could execute on any thread (e.g. the event tap callback thread).

Fixed by splitting initialization into two phases:
- initializeKeyMaps (dispatch_once): lock creation, special key tables, and registering the layout-change observer — all thread-safe operations.
- ensureLayoutMapsInitialized: ensures buildLayoutMaps() runs exactly once on the main thread. If called from main, builds directly. If called from a background thread, dispatches to main queue and polls an atomic flag with a 5-second timeout.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
