### PR TITLE
feat(systray): add version-aware docs URL with fallback to main

### DIFF
--- a/internal/app/components/systray/systray.go
+++ b/internal/app/components/systray/systray.go
@@ -3,6 +3,7 @@ package systray
 import (
 	"context"
 	"os/exec"
+	"strings"
 	"sync/atomic"
 
 	"github.com/atotto/clipboard"
@@ -243,7 +244,7 @@ func (c *Component) handleEvents() {
 			}()
 		case <-c.mDocsConfig.ClickedCh:
 			go func() {
-				err := exec.CommandContext(c.ctx, "/usr/bin/open", "https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md").
+				err := exec.CommandContext(c.ctx, "/usr/bin/open", DocsURL("docs/CONFIGURATION.md", cli.Version)).
 					Run()
 				if err != nil {
 					c.logger.Error("Failed to open configuration docs", zap.Error(err))
@@ -251,7 +252,7 @@ func (c *Component) handleEvents() {
 			}()
 		case <-c.mDocsCLI.ClickedCh:
 			go func() {
-				err := exec.CommandContext(c.ctx, "/usr/bin/open", "https://github.com/y3owk1n/neru/blob/main/docs/CLI.md").
+				err := exec.CommandContext(c.ctx, "/usr/bin/open", DocsURL("docs/CLI.md", cli.Version)).
 					Run()
 				if err != nil {
 					c.logger.Error("Failed to open CLI docs", zap.Error(err))
@@ -293,6 +294,51 @@ func (c *Component) handleEvents() {
 			c.updateScreenShareMenuItem(c.latestScreenShareState.Load())
 		}
 	}
+}
+
+const docsVersionSegments = 3
+
+// DocsURL returns the documentation URL for a given path and version.
+func DocsURL(path, version string) string {
+	tag := extractDocsTag(version)
+	if tag == "" {
+		tag = "main"
+	}
+
+	return "https://github.com/y3owk1n/neru/blob/" + tag + "/" + path
+}
+
+func extractDocsTag(version string) string {
+	if version == "" {
+		return ""
+	}
+
+	if !strings.HasPrefix(version, "v") {
+		return ""
+	}
+
+	if idx := strings.Index(version, "-"); idx != -1 {
+		version = version[:idx]
+	}
+
+	parts := strings.Split(version[1:], ".")
+	if len(parts) != docsVersionSegments {
+		return ""
+	}
+
+	for _, part := range parts {
+		if part == "" {
+			return ""
+		}
+
+		for _, ch := range part {
+			if ch < '0' || ch > '9' {
+				return ""
+			}
+		}
+	}
+
+	return version
 }
 
 // handleVersionCopy copies the version to clipboard.

--- a/internal/app/components/systray/systray_test.go
+++ b/internal/app/components/systray/systray_test.go
@@ -2,6 +2,7 @@ package systray_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/app/components/systray"
@@ -91,5 +92,66 @@ func TestComponent_OnExit(t *testing.T) {
 
 	if !mockApp.cleanupCalled {
 		t.Error("Cleanup not called on exit")
+	}
+}
+
+func TestDocsURLUsesVersionTagOrMain(t *testing.T) {
+	testCases := []struct {
+		name       string
+		version    string
+		path       string
+		wantSuffix string
+	}{
+		{
+			name:       "empty version falls back to main",
+			version:    "",
+			path:       "docs/CLI.md",
+			wantSuffix: "/main/docs/CLI.md",
+		},
+		{
+			name:       "non semver falls back to main",
+			version:    "dev",
+			path:       "docs/CLI.md",
+			wantSuffix: "/main/docs/CLI.md",
+		},
+		{
+			name:       "valid release tag",
+			version:    "v1.19.0",
+			path:       "docs/CLI.md",
+			wantSuffix: "/v1.19.0/docs/CLI.md",
+		},
+		{
+			name:       "git describe with commits",
+			version:    "v1.19.0-3-gabcdef0",
+			path:       "docs/CONFIGURATION.md",
+			wantSuffix: "/v1.19.0/docs/CONFIGURATION.md",
+		},
+		{
+			name:       "git describe dirty state",
+			version:    "v1.19.0-dirty",
+			path:       "docs/CLI.md",
+			wantSuffix: "/v1.19.0/docs/CLI.md",
+		},
+		{
+			name:       "invalid semver segments",
+			version:    "v1.2",
+			path:       "docs/CLI.md",
+			wantSuffix: "/main/docs/CLI.md",
+		},
+		{
+			name:       "non numeric segment",
+			version:    "v1.2.x",
+			path:       "docs/CLI.md",
+			wantSuffix: "/main/docs/CLI.md",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			url := systray.DocsURL(testCase.path, testCase.version)
+			if !strings.HasSuffix(url, testCase.wantSuffix) {
+				t.Errorf("docs URL = %q, want suffix %q", url, testCase.wantSuffix)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR added support for version-aware docs in systray. This can avoid issue where users are referring to the wrong documentation (e.g. docs in main branch). Though it probably wont help alot, but at least I tried.

- Add DocsURL function that generates GitHub URLs based on version tag
- Use version tag for released versions, fallback to 'main' for dev builds
- Support git describe formats (v1.19.0-3-gabcdef0, v1.19.0-dirty)
- Refactor to inject version parameter for testability

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
