### PR TITLE
fix(overlay): switch to layer-backed rendering with Retina/multi-monitor support

### DIFF
--- a/internal/core/infra/bridge/overlay.m
+++ b/internal/core/infra/bridge/overlay.m
@@ -66,7 +66,6 @@ static inline BOOL rectsEqual(NSRect a, NSRect b, CGFloat epsilon) {
 		[self setWantsLayer:YES];
 		self.layer.opaque = NO;
 		self.layer.backgroundColor = [[NSColor clearColor] CGColor];
-		CGFloat initialScale = [NSScreen mainScreen].backingScaleFactor;
 		self.layer.contentsScale = [self currentBackingScaleFactor];
 
 		_hints = [NSMutableArray arrayWithCapacity:100];     // Pre-size for typical hint count


### PR DESCRIPTION
Switch OverlayView from drawRect:-based rendering to CALayer-backed rendering for improved compositing performance and correct high-DPI display handling.

## Changes

- Enable layer-backed view via setWantsLayer:YES with transparent layer configuration
- Move drawing logic from drawRect: to drawLayer:inContext: for layer-based rendering
  - Clear context with CGContextClearRect to prevent ghost artifacts between redraws
  - Wrap CGContextRef in NSGraphicsContext for AppKit drawing compatibility
- Keep empty drawRect: stub so AppKit recognizes the view as having custom drawing content (required for setNeedsDisplay:YES to trigger layer redisplay)
- Add setFrame: override to update contentsScale using the window's actual screen (not mainScreen) when the overlay is resized/repositioned
- Add viewDidChangeBackingProperties override (Apple-recommended callback) to update contentsScale when the view moves between screens with different backing scale factors
- Remove redundant saveGraphicsState/restoreGraphicsState from drawGridCells (now handled at the drawLayer:inContext: level)

## Why

- GPU-accelerated compositing via Core Animation layer backing
- Correct Retina rendering on multi-monitor setups with mixed DPI (e.g., Retina + non-Retina) by tracking the actual screen's backingScaleFactor
- Prevents ghost artifacts from stale layer content when overlay content changes
- Backward compatible — drawRect: stub ensures existing setNeedsDisplay: call sites continue to work

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
