### PR TITLE
fix(overlay): use NSPanel with non-activating style to prevent focus stealing

### DIFF
--- a/internal/core/infra/bridge/overlay.m
+++ b/internal/core/infra/bridge/overlay.m
@@ -475,7 +475,7 @@ static inline BOOL rectsEqual(NSRect a, NSRect b, CGFloat epsilon) {
 #pragma mark - Overlay Window Controller Interface
 
 @interface OverlayWindowController : NSObject
-@property(nonatomic, strong) NSWindow *window;         ///< Window instance
+@property(nonatomic, strong) NSPanel *window;          ///< Panel instance (non-activating overlay)
 @property(nonatomic, strong) OverlayView *overlayView; ///< Overlay view instance
 @property(nonatomic, assign) NSInteger sharingType;    ///< Current window sharing type
 @property(nonatomic, assign) BOOL sharingTypeExplicit; ///< Whether sharingType was explicitly configured


### PR DESCRIPTION
Switch the overlay window from NSWindow to NSPanel with NSWindowStyleMaskNonactivatingPanel so the overlay no longer steals focus from other applications when displayed.

## Changes
- Use NSPanel instead of NSWindow in createWindow. The panel is created with NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel, which prevents the overlay from activating the app when shown.
- Set hidesOnDeactivate:NO to ensure the panel remains visible even when the app loses focus (overriding NSPanel's default of YES).
- Remove all makeKeyAndOrderFront: calls from NeruShowOverlayWindow, NeruResizeOverlayToMainScreen, NeruResizeOverlayToActiveScreen, and NeruResizeOverlayToActiveScreenWithCallback. These calls would attempt to make the window key (focused), which contradicts the non-activating panel behavior. The overlay already uses orderFrontRegardless to bring itself to the front without stealing focus.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
