### PR TITLE
fix(overlay): include size in hint dicts and use position as center directly

### DIFF
--- a/internal/core/infra/bridge/overlay.m
+++ b/internal/core/infra/bridge/overlay.m
@@ -838,7 +838,6 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 			NSMutableDictionary *hintDict = [NSMutableDictionary dictionaryWithDictionary:@{
 				@"label" : @(hint.label),
 				@"position" : [NSValue valueWithPoint:NSPointFromCGPoint(hint.position)],
-				@"size" : [NSValue valueWithSize:CGSizeMake(hint.size.width, hint.size.height)],
 				@"matchedPrefixLength" : @(hint.matchedPrefixLength),
 				@"showArrow" : @(style.showArrow)
 			}];
@@ -854,7 +853,6 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 			NSMutableDictionary *hintDict = [NSMutableDictionary dictionaryWithDictionary:@{
 				@"label" : @(hint.label),
 				@"position" : [NSValue valueWithPoint:NSPointFromCGPoint(hint.position)],
-				@"size" : [NSValue valueWithSize:CGSizeMake(hint.size.width, hint.size.height)],
 				@"matchedPrefixLength" : @(hint.matchedPrefixLength),
 				@"showArrow" : @(style.showArrow)
 			}];
@@ -933,7 +931,6 @@ void NeruDrawIncrementHints(OverlayWindow window, HintData *hintsToAdd, int addC
 			NSMutableDictionary *hintDict = [NSMutableDictionary dictionaryWithDictionary:@{
 				@"label" : hint.label ? @(hint.label) : @"",
 				@"position" : [NSValue valueWithPoint:NSPointFromCGPoint(hint.position)],
-				@"size" : [NSValue valueWithSize:CGSizeMake(hint.size.width, hint.size.height)],
 				@"matchedPrefixLength" : @(hint.matchedPrefixLength),
 				@"showArrow" : @(style.showArrow)
 			}];


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
