### PR TITLE
fix(overlay): cache parsed hex colors to eliminate redundant parsing

### DIFF
--- a/internal/core/infra/bridge/overlay.m
+++ b/internal/core/infra/bridge/overlay.m
@@ -146,6 +146,7 @@ static inline BOOL rectsEqual(NSRect a, NSRect b, CGFloat epsilon) {
 		self.layer.contentsScale = [self currentBackingScaleFactor];
 
 		_colorCache = [[NSCache alloc] init];
+		_colorCache.countLimit = 64;
 
 		_hints = [NSMutableArray arrayWithCapacity:100];     // Pre-size for typical hint count
 		_gridCells = [NSMutableArray arrayWithCapacity:100]; // Pre-size for typical grid size


### PR DESCRIPTION
- Add NSCache to store parsed NSColor objects by normalized hex string
- Normalize cache keys (lowercase, trim whitespace, expand 3→6 chars)
- Check cache before parsing in colorFromHex:defaultColor:
- Eliminates redundant hex parsing during style application in
  NeruDrawIncrementHints and NeruDrawIncrementGrid

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
