### PR TITLE
fix(bridge): avoid temporary NSString allocation in prefix matching loops

### DIFF
--- a/internal/core/infra/bridge/overlay.m
+++ b/internal/core/infra/bridge/overlay.m
@@ -1398,14 +1398,10 @@ void NeruUpdateGridMatchPrefix(OverlayWindow window, const char *prefix) {
 		NSUInteger idx = 0;
 		for (GridCellItem *cellItem in view.gridCells) {
 			NSString *label = cellItem.label ?: @"";
-			BOOL newIsMatched = NO;
-			int newMatchedPrefixLength = 0;
-			if (prefixLen > 0) {
-				newIsMatched = [label hasPrefix:prefixStr];
-				if (newIsMatched) {
-					newMatchedPrefixLength = (int)prefixLen;
-				}
-			}
+
+			BOOL newIsMatched = (prefixLen > 0 && [label hasPrefix:prefixStr]);
+			int newMatchedPrefixLength = newIsMatched ? (int)prefixLen : 0;
+
 			BOOL changed =
 			    (cellItem.isMatched != newIsMatched || cellItem.matchedPrefixLength != newMatchedPrefixLength);
 			if (cellItem.isMatched != newIsMatched) {


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
