### PR TITLE
fix(bridge): use NSSet for O(1) lookup in NeruDrawIncrementGrid removal pass

### DIFF
--- a/internal/core/infra/bridge/overlay.m
+++ b/internal/core/infra/bridge/overlay.m
@@ -8,14 +8,6 @@
 #import "overlay.h"
 #import <Cocoa/Cocoa.h>
 
-#pragma mark - Helper Functions
-
-/// Compare two rectangles with epsilon for floating point precision
-static inline BOOL rectsEqual(NSRect a, NSRect b, CGFloat epsilon) {
-	return fabs(a.origin.x - b.origin.x) < epsilon && fabs(a.origin.y - b.origin.y) < epsilon &&
-	       fabs(a.size.width - b.size.width) < epsilon && fabs(a.size.height - b.size.height) < epsilon;
-}
-
 #pragma mark - HintItem Class
 
 @interface HintItem : NSObject


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
