### PR TITLE
fix(gc): replace runtime.ReadMemStats with runtime/metrics to avoid STW pause

### DIFF
--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -163,11 +163,15 @@ func (a *App) adaptiveGC() bool {
 			zap.Bool("aggressive_mode", true))
 		runtime.GC()
 
+		// Re-read metrics after GC to get the actual post-GC heap size
+		postGCHeapAlloc, _ := readMemMetrics()
+		postGCHeapAllocMB := postGCHeapAlloc / BytesPerMB
+
 		// Exit aggressive mode if memory drops below low threshold
-		if heapAllocMB < lowThresholdMB {
+		if postGCHeapAllocMB < lowThresholdMB {
 			a.gcAggressiveMode = false
 			a.logger.Debug("Exiting aggressive GC mode",
-				zap.Uint64("heap_alloc_mb", heapAllocMB))
+				zap.Uint64("heap_alloc_mb", postGCHeapAllocMB))
 		}
 
 		return true


### PR DESCRIPTION
runtime.ReadMemStats is a stop-the-world operation that collects 60+
fields, but adaptiveGC only uses HeapAlloc and NextGC. Switch to
runtime/metrics.Read which reads individual counters from lock-free
atomics without pausing all goroutines.

Metric mapping:
- /memory/classes/heap/objects:bytes → MemStats.HeapAlloc
- /gc/heap/goal:bytes → MemStats.NextGC

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
