### PR TITLE
fix(tree): add sync.Pool for TreeNode to reduce GC pressure

### DIFF
--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -41,18 +41,15 @@ func getTreeNode(elem *Element, info *ElementInfo, parent *TreeNode, childrenCap
 	_node.element = elem
 	_node.info = info
 	_node.parent = parent
-	// When childrenCap > 0 the caller knows an initial capacity upfront
-	// (e.g. the root node). Reuse the pooled backing array when it is
-	// large enough; otherwise allocate a fresh slice.
-	// When childrenCap == 0 the caller will set the children slice later
-	// (e.g. buildChildrenSequential/Parallel), so leave whatever the
-	// pool provided — putTreeNode already reset it to [:0].
-	if childrenCap > 0 {
-		if cap(_node.children) >= childrenCap {
-			_node.children = _node.children[:0]
-		} else {
-			_node.children = make([]*TreeNode, 0, childrenCap)
-		}
+	// Reuse the pooled backing array when it is large enough for the
+	// requested capacity; otherwise allocate a fresh slice.
+	// When childrenCap == 0 the children slice is still explicitly reset
+	// to [:0] (or nil→[:0]) so the node is always in a clean state —
+	// callers are not required to overwrite children before use.
+	if cap(_node.children) >= childrenCap {
+		_node.children = _node.children[:0]
+	} else {
+		_node.children = make([]*TreeNode, 0, childrenCap)
 	}
 
 	return _node


### PR DESCRIPTION
During tree building, hundreds of TreeNode structs are allocated per
activation and released shortly after processClickableNodes extracts
the kept elements. These short-lived allocations create unnecessary
GC pressure.

Add a treeNodePool (sync.Pool) with getTreeNode/putTreeNode helpers,
following the existing elementSlicePool pattern in adapter.go:

- Pool TreeNode structs with a reset function that nils out element,
  info, and parent fields to prevent retaining references
- Reuse the children slice backing array across lifecycles
- Use post-order tree walk in Release to safely recycle nodes
  (children must be visited before their parent is cleared)

All three allocation sites (BuildTree root, buildChildrenSequential,
buildChildrenParallel) now use getTreeNode. Released non-kept nodes
are returned to the pool via putTreeNode in the Release method.
Kept nodes (wrapped in InfraNode) are never pooled.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
