### PR TITLE
fix(bridge): cancel pending enable block in disableEventTap

### DIFF
--- a/internal/core/infra/bridge/eventtap.m
+++ b/internal/core/infra/bridge/eventtap.m
@@ -450,6 +450,12 @@ void disableEventTap(EventTap tap) {
 
 	// Disable on main thread to avoid races
 	dispatch_async(dispatch_get_main_queue(), ^{
+		// Cancel any pending enable block
+		if (context->pendingEnableBlock) {
+			dispatch_block_cancel(context->pendingEnableBlock);
+			context->pendingEnableBlock = nil;
+		}
+
 		CGEventTapEnable(context->eventTap, false);
 	});
 }


### PR DESCRIPTION
Prevents event tap from being re-enabled after a rapid enable/disable
sequence. When Disable is called within 150ms of Enable, the pending
delayed enable block would still fire, leaving the event tap enabled
while the adapter reports disabled state.

This caused keystrokes to be captured and swallowed in Idle mode.

Fixes #452 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
