### PR TITLE
fix(bridge): add mutex to protect global logger from data races

### DIFF
--- a/internal/core/infra/bridge/logger_wrapper.go
+++ b/internal/core/infra/bridge/logger_wrapper.go
@@ -1,6 +1,10 @@
 package bridge
 
-import "go.uber.org/zap"
+import (
+	"sync"
+
+	"go.uber.org/zap"
+)
 
 type loggingBridge struct {
 	logger *zap.Logger
@@ -33,20 +37,30 @@ func (b *loggingBridge) Error(msg string, fields ...zap.Field) {
 var (
 	bridgeLogger *zap.Logger
 	log          *loggingBridge
+	logMu        sync.RWMutex
 )
 
 // InitializeLogger sets the global logger instance for the bridge package.
 func InitializeLogger(logger *zap.Logger) {
+	logMu.Lock()
+	defer logMu.Unlock()
+
 	bridgeLogger = logger
 	log = &loggingBridge{logger: logger}
 }
 
 // Logger returns the global logger instance for the bridge package.
 func Logger() *zap.Logger {
+	logMu.RLock()
+	defer logMu.RUnlock()
+
 	return bridgeLogger
 }
 
 func getLogger() *loggingBridge {
+	logMu.RLock()
+	defer logMu.RUnlock()
+
 	if log == nil {
 		return &loggingBridge{}
 	}


### PR DESCRIPTION
Add sync.RWMutex to synchronize access to bridgeLogger and log global
variables. This fixes data races that can occur when InitializeLogger()
is called while other goroutines (e.g., startup goroutine or C
callbacks) concurrently call getLogger() or Logger().

The race condition can happen during startup because cmd/neru/main.go
launches a goroutine that calls bridge.ShowConfigValidationError()
before app.New() completes initialization. It can also occur at
runtime when //export callbacks are invoked from any thread.

Fixes #456 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
