### PR TITLE
fix: also support `-c` and `--config` for launch command

### DIFF
--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -17,7 +17,5 @@ var LaunchCmd = &cobra.Command{
 }
 
 func init() {
-	LaunchCmd.Flags().StringVarP(&configPath, "config", "c", "", "config file path")
-
 	RootCmd.AddCommand(LaunchCmd)
 }


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
