### PR TITLE
fix: eliminate duplicate configSnapshot() in app activation path

### DIFF
--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -402,14 +402,13 @@ func (a *App) handleAppActivation(bundleID string) {
 
 	if cfg.Hints.Enabled {
 		if cfg.Hints.AdditionalAXSupport.Enable {
-			a.handleAdditionalAccessibility(bundleID)
+			a.handleAdditionalAccessibility(bundleID, cfg)
 		}
 	}
 }
 
 // handleAdditionalAccessibility configures accessibility support for Electron/Chromium/Firefox applications.
-func (a *App) handleAdditionalAccessibility(bundleID string) {
-	cfg := a.configSnapshot()
+func (a *App) handleAdditionalAccessibility(bundleID string, cfg *config.Config) {
 	config := cfg.Hints.AdditionalAXSupport
 
 	if electron.ShouldEnableElectronSupport(bundleID, config.AdditionalElectronBundles) {


### PR DESCRIPTION
Pass the already-captured config to handleAdditionalAccessibility instead of taking a second snapshot. This ensures the Enable check and bundle ID lists come from the same config version, avoiding a theoretical race condition during config reload.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
