### PR TITLE
fix(cursor): increase post-click processing delay to 75ms for slow apps

### DIFF
--- a/internal/core/infra/bridge/accessibility_constants.h
+++ b/internal/core/infra/bridge/accessibility_constants.h
@@ -18,7 +18,7 @@ extern "C" {
 static const CFTimeInterval kNeruMouseClickDownUpDelay = 0.008;
 
 /// Delay after click processing before restoring cursor (seconds)
-static const CFTimeInterval kNeruMouseClickProcessingDelay = 0.05;
+static const CFTimeInterval kNeruMouseClickProcessingDelay = 0.075;
 
 /// Delay after mouse move to allow event processing (seconds)
 static const CFTimeInterval kNeruMouseMoveDelay = 0.01;


### PR DESCRIPTION
Increase kNeruMouseClickProcessingDelay from 50ms to 75ms to give slow
applications (Electron, web views) enough time to process the mouseUp
event before cursor restoration/centering moves the cursor away.

Hopefully fixes #511

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
