### PR TITLE
fix(docs): `backspace` is not supported for `reset_key` for now

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -201,7 +201,7 @@ sublayer_keys = "abcdefghijklmnpqrstuvwxyz"
 # Single-character key to reset/clear grid input during grid mode
 # While in grid mode, pressing this key clears your current input and starts over
 # Useful for correcting mistakes while selecting grid coordinates
-# Common choices: "," (comma), "." (period), "r" (r key), "backspace"
+# Common choices: "," (comma), "." (period), "r" (r key)
 # Note: Cannot be the same as any grid character to avoid conflicts
 reset_key = " "
 


### PR DESCRIPTION
Fixes #518

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
