### PR TITLE
feat(hotkeys): support function keys F13 through F20

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -853,6 +853,14 @@ func isValidScrollKeyName(key string) bool {
 		"F10":       true,
 		"F11":       true,
 		"F12":       true,
+		"F13":       true,
+		"F14":       true,
+		"F15":       true,
+		"F16":       true,
+		"F17":       true,
+		"F18":       true,
+		"F19":       true,
+		"F20":       true,
 	}
 
 	if validKeys[key] {

--- a/internal/config/validators_config_test.go
+++ b/internal/config/validators_config_test.go
@@ -1052,6 +1052,18 @@ func TestConfig_ValidateScrollKeyBindings(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid function key out of supported range",
+			config: func() config.Config {
+				cfg := config.DefaultConfig()
+				cfg.Scroll.KeyBindings = map[string][]string{
+					"scroll_up": {"F21"},
+				}
+
+				return *cfg
+			}(),
+			wantErr: true,
+		},
+		{
 			name: "valid single-letter keys",
 			config: func() config.Config {
 				cfg := config.DefaultConfig()
@@ -1116,6 +1128,14 @@ func TestConfig_ValidateScrollKeyBindings(t *testing.T) {
 						"F10",
 						"F11",
 						"F12",
+						"F13",
+						"F14",
+						"F15",
+						"F16",
+						"F17",
+						"F18",
+						"F19",
+						"F20",
 					},
 					"page_up": {
 						"Cmd+Up",

--- a/internal/core/infra/bridge/keymap.h
+++ b/internal/core/infra/bridge/keymap.h
@@ -97,6 +97,14 @@ typedef NS_ENUM(uint16_t, KeyCode) {
 	kKeyCodeF10 = 109,
 	kKeyCodeF11 = 103,
 	kKeyCodeF12 = 111,
+	kKeyCodeF13 = 105,
+	kKeyCodeF14 = 107,
+	kKeyCodeF15 = 113,
+	kKeyCodeF16 = 106,
+	kKeyCodeF17 = 64,
+	kKeyCodeF18 = 79,
+	kKeyCodeF19 = 80,
+	kKeyCodeF20 = 90,
 
 	// Numpad
 	kKeyCodeNumpadDot = 65,

--- a/internal/core/infra/bridge/keymap.m
+++ b/internal/core/infra/bridge/keymap.m
@@ -585,6 +585,14 @@ static void initializeSpecialKeyMaps(void) {
 		@"F10" : @(kKeyCodeF10),
 		@"F11" : @(kKeyCodeF11),
 		@"F12" : @(kKeyCodeF12),
+		@"F13" : @(kKeyCodeF13),
+		@"F14" : @(kKeyCodeF14),
+		@"F15" : @(kKeyCodeF15),
+		@"F16" : @(kKeyCodeF16),
+		@"F17" : @(kKeyCodeF17),
+		@"F18" : @(kKeyCodeF18),
+		@"F19" : @(kKeyCodeF19),
+		@"F20" : @(kKeyCodeF20),
 	} copy];
 
 	NSMutableDictionary<NSNumber *, NSString *> *codeToName =


### PR DESCRIPTION
## Summary
- add bridge keycode constants for F13 through F20
- extend macOS special key-name mapping so hotkey parsing resolves F13..F20
- allow F13..F20 in scroll keybinding validation
- add config validation tests for accepted F13..F20 and rejected F21

## Explanation 
Most keyboards have at least one key that is rarely used (for example, End on my keyboard).
With Karabiner, you can remap that key to something like F20.

This gives you a dedicated hotkey that won't conflict with other shortcuts and can be used safely without worrying about accidental overlaps.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
