### PR TITLE
fix(build): ad-hoc codesign app bundle in justfile, CI release workflow and nix

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,6 +56,9 @@ jobs:
                   cp resources/icon.icns build/arm64/Neru.app/Contents/Resources/icon.icns
                   sed "s/VERSION/${{ steps.release.outputs.tag_name }}/g" resources/Info.plist.template > build/arm64/Neru.app/Contents/Info.plist
 
+                  # Ad-hoc codesign to preserve accessibility permissions across updates
+                  codesign --force --deep --sign - build/arm64/Neru.app
+
                   # Copy binary to distribution folder
                   mkdir -p build/arm64/bin
                   cp bin/neru-darwin-arm64 build/arm64/bin/neru
@@ -75,6 +78,9 @@ jobs:
                   chmod +x build/amd64/Neru.app/Contents/MacOS/Neru
                   cp resources/icon.icns build/amd64/Neru.app/Contents/Resources/icon.icns
                   sed "s/VERSION/${{ steps.release.outputs.tag_name }}/g" resources/Info.plist.template > build/amd64/Neru.app/Contents/Info.plist
+
+                  # Ad-hoc codesign to preserve accessibility permissions across updates
+                  codesign --force --deep --sign - build/amd64/Neru.app
 
                   # Copy binary to distribution folder
                   mkdir -p build/amd64/bin

--- a/justfile
+++ b/justfile
@@ -58,6 +58,8 @@ bundle: release
 
     sed "s/VERSION/{{ VERSION }}/g" resources/Info.plist.template > build/Neru.app/Contents/Info.plist
 
+    codesign --force --deep --sign - build/Neru.app
+
     @echo "✓ Bundle complete: build/Neru.app"
 
 # Run tests

--- a/package.nix
+++ b/package.nix
@@ -143,6 +143,8 @@ else
 
       sed "s|VERSION|${finalAttrs.version}|g" $SRC_PLIST > $out/Applications/Neru.app/Contents/Info.plist
 
+      /usr/bin/codesign --force --deep --sign - $out/Applications/Neru.app || echo "⚠️  codesign skipped (sandbox or missing tool)"
+
       echo "✅ Neru.app bundle created at $out/Applications/Neru.app"
     '';
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds adhoc codesign to the build process, including nix. Hopefully we don't have to regrant accessibility on every updates.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
