### PR TITLE
fix: normalize key aliases (enter, backspace, esc) in modifier combo bindings

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -210,25 +210,32 @@ func StripModifierPrefixes(key string) string {
 	return modifierPrefixReplacer.Replace(key)
 }
 
-// keyAliasReplacer normalizes key name aliases in the key part of compound key strings.
-// Operates on already-lowercased strings. Only replaces the final segment (after the
-// last "+") to avoid mangling modifier names.
-var keyAliasReplacer = strings.NewReplacer(
-	"+enter", "+return",
-	"+backspace", "+delete",
-	"+esc", "+escape",
-)
+// comboKeyAliases maps alias key names to their canonical forms.
+// Used by normalizeKeyAliasesInCombo to resolve the final segment of compound keys.
+var comboKeyAliases = map[string]string{
+	"enter":     "return",
+	"backspace": "delete",
+	"esc":       "escape",
+}
 
 // normalizeKeyAliasesInCombo resolves key name aliases inside modifier combos.
 // e.g. "shift+enter" → "shift+return", "cmd+backspace" → "cmd+delete".
 // Only applies to compound keys (containing "+"); bare keys are handled by the
 // switch in NormalizeKeyForComparison.
+// Splits on the last "+" and only normalizes the final segment to avoid mangling
+// modifier names or canonical forms that share a prefix (e.g. "escape" vs "esc").
 func normalizeKeyAliasesInCombo(key string) string {
-	if !strings.Contains(key, "+") {
+	idx := strings.LastIndex(key, "+")
+	if idx < 0 {
 		return key
 	}
 
-	return keyAliasReplacer.Replace(key)
+	prefix, suffix := key[:idx+1], key[idx+1:]
+	if canonical, ok := comboKeyAliases[suffix]; ok {
+		return prefix + canonical
+	}
+
+	return key
 }
 
 // normalizeFullwidthChars converts fullwidth CJK characters (U+FF01-U+FF5E)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -676,6 +676,22 @@ func TestNormalizeKeyForComparison_ModifierComboAliases(t *testing.T) {
 			input:    "Cmd+L",
 			expected: "cmd+l",
 		},
+		// Canonical forms must pass through unchanged (regression: +esc prefix of +escape)
+		{
+			name:     "Ctrl+Escape stays ctrl+escape",
+			input:    "Ctrl+Escape",
+			expected: "ctrl+escape",
+		},
+		{
+			name:     "Shift+Return stays shift+return",
+			input:    "Shift+Return",
+			expected: "shift+return",
+		},
+		{
+			name:     "Cmd+Delete stays cmd+delete",
+			input:    "Cmd+Delete",
+			expected: "cmd+delete",
+		},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

`NormalizeKeyForComparison` already normalizes bare key aliases like `Enter` → `return`, `Backspace` → `delete`, and `Esc` → `escape` via its switch statement. However, when these aliases appear after a modifier (e.g., `Shift+Enter`, `Cmd+Backspace`, `Ctrl+Esc```), the switch doesn't match because the full string includes the modifier prefix.

This means user config like `"Shift+Enter"` normalizes to `"shift+enter"` but the event tap produces `"shift+return"`, so the binding never fires.

This PR adds `normalizeKeyAliasesInCombo`, which resolves key name aliases in the final segment of compound key strings:
- `+enter` → `+return`
- `+backspace` → `+delete`
- `+esc` → `+escape`

The function only applies to compound keys (containing `+`); bare keys continue to be handled by the existing switch.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Fixes #587

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
