### PR TITLE
fix: support simultaneous modifier key taps for sticky modifiers

### DIFF
--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -89,7 +89,7 @@ type Handler struct {
 	modeSession                uint64
 
 	// Pending modifier key for tap detection (down/up without intervening keys)
-	pendingModifierKey     string
+	pendingModifierKeys    map[string]bool
 	modifierDetectionArmed bool // true once all modifiers have been released after mode entry
 
 	// Indicator polling (shared by all modes)

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -15,7 +15,7 @@ func (h *Handler) HandleKeyPress(key string) {
 	// Cancel any pending modifier toggle if a non-modifier key is pressed
 	// This handles the case where Shift+L is pressed - the modifier tap
 	// is canceled when L comes in
-	if h.pendingModifierKey != "" && !strings.HasPrefix(key, modifierTogglePrefix) {
+	if len(h.pendingModifierKeys) > 0 && !strings.HasPrefix(key, modifierTogglePrefix) {
 		h.cancelPendingModifierToggle()
 	}
 

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -20,7 +20,9 @@ func (h *Handler) executeActionAtPoint(action *string, point image.Point) {
 		return
 	}
 
-	h.logger.Info("Executing pending action", zap.String("action", *action))
+	h.logger.Info("Executing pending action",
+		zap.String("action", *action),
+		zap.String("modifiers", h.stickyModifiers().String()))
 
 	ctx := context.Background()
 

--- a/internal/app/modes/modifier_toggle.go
+++ b/internal/app/modes/modifier_toggle.go
@@ -87,7 +87,11 @@ func (h *Handler) handleModifierToggle(key string) bool {
 	normalizedKey := strings.ToLower(key)
 
 	if isDown {
-		h.pendingModifierKey = normalizedKey
+		if h.pendingModifierKeys == nil {
+			h.pendingModifierKeys = make(map[string]bool)
+		}
+
+		h.pendingModifierKeys[normalizedKey] = true
 		h.logger.Debug("Modifier key down", zap.String("key", normalizedKey))
 
 		return true
@@ -95,16 +99,15 @@ func (h *Handler) handleModifierToggle(key string) bool {
 
 	// Key up — toggle only if the matching down is still pending.
 	expectedDown := strings.TrimSuffix(normalizedKey, "_up") + "_down"
-	if h.pendingModifierKey != expectedDown {
+	if !h.pendingModifierKeys[expectedDown] {
 		h.logger.Debug("Modifier key up ignored (no matching pending down)",
 			zap.String("key", key),
-			zap.String("pending", h.pendingModifierKey))
-		h.pendingModifierKey = ""
+			zap.Any("pending", h.pendingModifierKeys))
 
 		return true
 	}
 
-	h.pendingModifierKey = ""
+	delete(h.pendingModifierKeys, expectedDown)
 
 	newModifiers := h.modifierState.Toggle(mod)
 	h.logger.Debug("Sticky modifier toggled",
@@ -115,8 +118,8 @@ func (h *Handler) handleModifierToggle(key string) bool {
 }
 
 func (h *Handler) cancelPendingModifierToggle() {
-	if h.pendingModifierKey != "" {
-		h.pendingModifierKey = ""
+	if len(h.pendingModifierKeys) > 0 {
+		h.pendingModifierKeys = nil
 		h.logger.Debug("Modifier tap canceled")
 	}
 }

--- a/internal/app/modes/modifier_toggle_test.go
+++ b/internal/app/modes/modifier_toggle_test.go
@@ -4,7 +4,11 @@ package modes
 import (
 	"testing"
 
+	"go.uber.org/zap"
+
+	configpkg "github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
+	"github.com/y3owk1n/neru/internal/core/domain/state"
 )
 
 func TestParseModifierEvent(t *testing.T) {
@@ -71,5 +75,179 @@ func TestParseModifierEvent(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+// newTestHandler creates a minimal Handler suitable for testing handleModifierToggle.
+// The handler has sticky modifiers enabled and detection already armed.
+func newTestHandler() *Handler {
+	return &Handler{
+		logger:                 zap.NewNop(),
+		modifierState:          state.NewModifierState(),
+		modifierDetectionArmed: true,
+		config: &configpkg.Config{
+			StickyModifiers: configpkg.StickyModifiersConfig{
+				Enabled: true,
+			},
+		},
+	}
+}
+
+func TestHandleModifierToggle_SingleModifier(t *testing.T) {
+	testHandler := newTestHandler()
+	// Shift↓ → Shift↑ should toggle Shift on.
+	testHandler.handleModifierToggle("__modifier_shift_down")
+	testHandler.handleModifierToggle("__modifier_shift_up")
+
+	if got := testHandler.modifierState.Current(); got != action.ModShift {
+		t.Errorf("Expected ModShift after single tap, got %v", got)
+	}
+	// Shift↓ → Shift↑ again should toggle Shift off.
+	testHandler.handleModifierToggle("__modifier_shift_down")
+	testHandler.handleModifierToggle("__modifier_shift_up")
+
+	if got := testHandler.modifierState.Current(); got != 0 {
+		t.Errorf("Expected 0 after double tap, got %v", got)
+	}
+}
+
+func TestHandleModifierToggle_SimultaneousTwoModifiers(t *testing.T) {
+	testHandler := newTestHandler()
+	// Simulate pressing Cmd and Shift at the same time:
+	// Cmd↓ → Shift↓ → Cmd↑ → Shift↑
+	testHandler.handleModifierToggle("__modifier_cmd_down")
+	testHandler.handleModifierToggle("__modifier_shift_down")
+	testHandler.handleModifierToggle("__modifier_cmd_up")
+	testHandler.handleModifierToggle("__modifier_shift_up")
+	got := testHandler.modifierState.Current()
+
+	want := action.ModCmd | action.ModShift
+	if got != want {
+		t.Errorf(
+			"Expected Cmd+Shift (%v) after simultaneous press, got %v",
+			want,
+			got,
+		)
+	}
+}
+
+func TestHandleModifierToggle_SimultaneousThreeModifiers(t *testing.T) {
+	testHandler := newTestHandler()
+	// Simulate pressing Cmd+Shift+Alt at the same time:
+	// Cmd↓ → Shift↓ → Alt↓ → Cmd↑ → Shift↑ → Alt↑
+	testHandler.handleModifierToggle("__modifier_cmd_down")
+	testHandler.handleModifierToggle("__modifier_shift_down")
+	testHandler.handleModifierToggle("__modifier_alt_down")
+	testHandler.handleModifierToggle("__modifier_cmd_up")
+	testHandler.handleModifierToggle("__modifier_shift_up")
+	testHandler.handleModifierToggle("__modifier_alt_up")
+	got := testHandler.modifierState.Current()
+
+	want := action.ModCmd | action.ModShift | action.ModAlt
+	if got != want {
+		t.Errorf(
+			"Expected Cmd+Shift+Alt (%v) after simultaneous press, got %v",
+			want,
+			got,
+		)
+	}
+}
+
+func TestHandleModifierToggle_SimultaneousFourModifiers(t *testing.T) {
+	testHandler := newTestHandler()
+	// Simulate pressing all four modifiers simultaneously:
+	// Cmd↓ → Shift↓ → Alt↓ → Ctrl↓ → Cmd↑ → Shift↑ → Alt↑ → Ctrl↑
+	testHandler.handleModifierToggle("__modifier_cmd_down")
+	testHandler.handleModifierToggle("__modifier_shift_down")
+	testHandler.handleModifierToggle("__modifier_alt_down")
+	testHandler.handleModifierToggle("__modifier_ctrl_down")
+	testHandler.handleModifierToggle("__modifier_cmd_up")
+	testHandler.handleModifierToggle("__modifier_shift_up")
+	testHandler.handleModifierToggle("__modifier_alt_up")
+	testHandler.handleModifierToggle("__modifier_ctrl_up")
+	got := testHandler.modifierState.Current()
+
+	want := action.ModCmd | action.ModShift | action.ModAlt | action.ModCtrl
+	if got != want {
+		t.Errorf(
+			"Expected all four modifiers (%v) after simultaneous press, got %v",
+			want,
+			got,
+		)
+	}
+}
+
+func TestHandleModifierToggle_SimultaneousReleaseOrderReversed(t *testing.T) {
+	testHandler := newTestHandler()
+	// Release order reversed from press order:
+	// Cmd↓ → Shift↓ → Alt↓ → Alt↑ → Shift↑ → Cmd↑
+	testHandler.handleModifierToggle("__modifier_cmd_down")
+	testHandler.handleModifierToggle("__modifier_shift_down")
+	testHandler.handleModifierToggle("__modifier_alt_down")
+	testHandler.handleModifierToggle("__modifier_alt_up")
+	testHandler.handleModifierToggle("__modifier_shift_up")
+	testHandler.handleModifierToggle("__modifier_cmd_up")
+	got := testHandler.modifierState.Current()
+
+	want := action.ModCmd | action.ModShift | action.ModAlt
+	if got != want {
+		t.Errorf(
+			"Expected Cmd+Shift+Alt (%v) with reversed release order, got %v",
+			want,
+			got,
+		)
+	}
+}
+
+func TestHandleModifierToggle_RegularKeyCancelsAllPending(t *testing.T) {
+	testHandler := newTestHandler()
+	// Cmd↓ → Shift↓ → (regular key cancels) → Cmd↑ → Shift↑
+	// Neither should toggle because a regular key intervened.
+	testHandler.handleModifierToggle("__modifier_cmd_down")
+	testHandler.handleModifierToggle("__modifier_shift_down")
+	testHandler.cancelPendingModifierToggle() // simulates regular key press
+	testHandler.handleModifierToggle("__modifier_cmd_up")
+	testHandler.handleModifierToggle("__modifier_shift_up")
+
+	if got := testHandler.modifierState.Current(); got != 0 {
+		t.Errorf("Expected 0 after regular key canceled pending, got %v", got)
+	}
+}
+
+func TestHandleModifierToggle_DisabledConfig(t *testing.T) {
+	testHandler := newTestHandler()
+	testHandler.config.StickyModifiers.Enabled = false
+
+	handled := testHandler.handleModifierToggle("__modifier_shift_down")
+	if handled {
+		t.Error("Expected handleModifierToggle to return false when disabled")
+	}
+}
+
+func TestHandleModifierToggle_ArmingMechanism(t *testing.T) {
+	testHandler := newTestHandler()
+	testHandler.modifierDetectionArmed = false
+	// Down events while disarmed should be consumed but not toggle.
+	testHandler.handleModifierToggle("__modifier_cmd_down")
+
+	if got := testHandler.modifierState.Current(); got != 0 {
+		t.Errorf("Expected 0 while disarmed, got %v", got)
+	}
+	// First up event arms detection.
+	testHandler.handleModifierToggle("__modifier_cmd_up")
+
+	if !testHandler.modifierDetectionArmed {
+		t.Error("Expected detection to be armed after first key-up")
+	}
+
+	if got := testHandler.modifierState.Current(); got != 0 {
+		t.Errorf("Expected 0 (arming up should not toggle), got %v", got)
+	}
+	// Now a clean tap should work.
+	testHandler.handleModifierToggle("__modifier_shift_down")
+	testHandler.handleModifierToggle("__modifier_shift_up")
+
+	if got := testHandler.modifierState.Current(); got != action.ModShift {
+		t.Errorf("Expected ModShift after armed tap, got %v", got)
 	}
 }

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -269,7 +269,8 @@ func (a *Adapter) PerformActionAtPoint(
 	a.logger.Info("Performing action at point",
 		zap.String("action", actionType.String()),
 		zap.Int("x", point.X),
-		zap.Int("y", point.Y))
+		zap.Int("y", point.Y),
+		zap.String("modifiers", modifiers.String()))
 
 	restoreCursor := a.getRestoreCursor()
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes a bug where pressing multiple modifier keys simultaneously (e.g., Cmd+Option+Shift) while in a navigation mode results in zero or only one sticky modifier being toggled instead of all of them.

Also added more logs and regression tests for this issue.

TLDR: Now you can press multiple modifier keys simultaneously while in a navigation mode and all of them will be toggled.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Fixes #591

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
