### PR TITLE
perf(hints): skip debounce for same-count updates and prevent stale callbacks

### DIFF
--- a/internal/core/domain/hint/manager.go
+++ b/internal/core/domain/hint/manager.go
@@ -78,7 +78,10 @@ func (m *Manager) SetUpdateCallback(callback func([]*Interface)) {
 }
 
 // SetHints updates the current hint collection and resets the input state.
+// The caller MUST hold externalMu (when set) — see assertExternalMuHeld.
 func (m *Manager) SetHints(hints *Collection) {
+	m.assertExternalMuHeld("SetHints")
+
 	// Cancel any pending debounced updates
 	if m.debounceTimer != nil {
 		m.debounceTimer.Stop()
@@ -114,7 +117,10 @@ func (m *Manager) SetHints(hints *Collection) {
 }
 
 // Reset clears the current input.
+// The caller MUST hold externalMu (when set) — see assertExternalMuHeld.
 func (m *Manager) Reset() {
+	m.assertExternalMuHeld("Reset")
+
 	// Cancel any pending debounced updates
 	if m.debounceTimer != nil {
 		m.debounceTimer.Stop()
@@ -318,6 +324,23 @@ func (m *Manager) SetBackspaceKey(key string) {
 	m.backspaceKey = key
 }
 
+// assertExternalMuHeld is a debug assertion verifying that the caller holds
+// externalMu (when set). Methods that invoke the onUpdate callback
+// synchronously (SetHints, Reset, immediateUpdate) must be called while
+// the caller holds externalMu to protect shared state (e.g., screen bounds,
+// overlay manager) accessed by the callback.
+//
+// TryLock succeeds only if the mutex is NOT held — meaning the caller
+// forgot to lock it, which would cause a data race on shared state.
+func (m *Manager) assertExternalMuHeld(caller string) {
+	if m.externalMu != nil {
+		if m.externalMu.TryLock() {
+			m.externalMu.Unlock()
+			panic("hint.Manager." + caller + ": caller must hold externalMu")
+		}
+	}
+}
+
 // immediateUpdate invokes the update callback synchronously, canceling any
 // pending debounced update. Use this for cheap updates (e.g., prefix color
 // changes) where the 50ms debounce delay would feel sluggish.
@@ -334,16 +357,7 @@ func (m *Manager) SetBackspaceKey(key string) {
 // callback contract ever changes to store or defer processing of the
 // slice, a defensive copy must be added here.
 func (m *Manager) immediateUpdate(hints []*Interface) {
-	// Debug assertion: if externalMu is set, the caller must already hold it.
-	// TryLock succeeds only if the mutex is NOT held — meaning the caller
-	// forgot to lock it, which would cause a data race on shared state.
-	if m.externalMu != nil {
-		if m.externalMu.TryLock() {
-			m.externalMu.Unlock()
-
-			panic("hint.Manager.immediateUpdate: caller must hold externalMu")
-		}
-	}
+	m.assertExternalMuHeld("immediateUpdate")
 
 	// Cancel any pending debounced update so it doesn't fire stale data.
 	if m.debounceTimer != nil {

--- a/internal/core/domain/hint/manager_test.go
+++ b/internal/core/domain/hint/manager_test.go
@@ -201,6 +201,52 @@ func TestManager_ImmediateUpdatePanicsWithoutExternalMu(t *testing.T) {
 	manager.HandleInput("A")
 }
 
+func TestManager_SetHintsPanicsWithoutExternalMu(t *testing.T) {
+	// SetHints invokes the onUpdate callback synchronously, so the caller
+	// must hold externalMu. Verify the assertion fires when it is NOT held.
+	var mut sync.Mutex
+
+	elem, _ := element.NewElement(element.ID("1"), image.Rect(0, 0, 10, 10), element.RoleButton)
+	h1, _ := hint.NewHint("AA", elem, image.Point{0, 0})
+	collection := hint.NewCollection([]*hint.Interface{h1})
+	manager := hint.NewManager(logger.Get(), &mut, "")
+	manager.SetUpdateCallback(func(_ []*hint.Interface) {})
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("Expected panic when SetHints called without holding externalMu")
+		}
+	}()
+	// Calling SetHints WITHOUT holding mut should panic.
+	manager.SetHints(collection)
+}
+
+func TestManager_ResetPanicsWithoutExternalMu(t *testing.T) {
+	// Reset invokes the onUpdate callback synchronously, so the caller
+	// must hold externalMu. Verify the assertion fires when it is NOT held.
+	var mut sync.Mutex
+
+	elem, _ := element.NewElement(element.ID("1"), image.Rect(0, 0, 10, 10), element.RoleButton)
+	h1, _ := hint.NewHint("AA", elem, image.Point{0, 0})
+	collection := hint.NewCollection([]*hint.Interface{h1})
+	manager := hint.NewManager(logger.Get(), &mut, "")
+	manager.SetUpdateCallback(func(_ []*hint.Interface) {})
+	// SetHints must be called while holding externalMu.
+	mut.Lock()
+	manager.SetHints(collection)
+	mut.Unlock()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("Expected panic when Reset called without holding externalMu")
+		}
+	}()
+	// Calling Reset WITHOUT holding mut should panic.
+	manager.Reset()
+}
+
 func TestManager_ImmediateUpdateSucceedsWithExternalMu(t *testing.T) {
 	// Mirror the production call pattern: hold externalMu, then call
 	// HandleInput. The immediate-update path should succeed without panic.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR optimizes hint overlay updates and fixes correctness issues in the debounce mechanism.

### Performance: skip debounce for cheap updates

Previously, every `onUpdate` callback in the hint manager was debounced (50ms) to batch expensive structural redraws. But many keystrokes only change which prefix characters are highlighted — the hint **count** stays the same. The 50ms delay on these cheap color-only updates felt sluggish.

This PR introduces a **count-based heuristic**: if the filtered hint count didn't change between keystrokes, the update is dispatched synchronously via `immediateUpdate`; otherwise it goes through the debounced path as before. A `lastFilteredLen` field caches the previous count to avoid a redundant `FilterByPrefix` call.

### Correctness: generation counter to prevent stale callbacks

The new immediate path introduced a race: a pending debounced timer could fire after a synchronous update and overwrite it with stale data. A monotonically increasing `updateGen` counter solves this — the debounced timer captures the generation at scheduling time and skips its callback if a newer update has occurred since. The exact-match path also bumps the generation and cancels pending timers to prevent stale callbacks after the caller acts on a match (e.g., exits hint mode).

### Correctness: `debouncedUpdate` lock pattern fix

The debounced callback now releases `m.mu` before invoking `onUpdate`, preventing a potential deadlock if the callback ever re-enters a `m.mu`-protected method (e.g., `SetUpdateCallback`). This matches the pattern used by `immediateUpdate`, `SetHints`, and `Reset`.

### Safety: `assertExternalMuHeld` runtime assertion

Methods that invoke `onUpdate` synchronously (`SetHints`, `Reset`, `immediateUpdate`) now assert at runtime that the caller holds `externalMu` (when set). This catches missing lock acquisitions early and prevents data races on shared state (e.g., screen bounds, overlay manager) accessed by the callback.


## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

### Key design decisions

- **Count-based heuristic is safe** because `Collection` is immutable after creation — the underlying hint set cannot change between keystrokes. Typing can only narrow (or maintain) the set; backspacing can only widen (or maintain) it.
- **`immediateUpdate` does not copy the hints slice** because the callback executes synchronously — the slice is consumed before returning. If the callback contract ever changes to store or defer processing of the slice, a defensive copy must be added.
- **`assertExternalMuHeld` uses `TryLock`**: if `TryLock` succeeds, the lock was *not* held by the caller, so it panics. This is a debug-only assertion with no production overhead when `externalMu` is nil.

### New tests

- Panic tests verifying `SetHints`, `Reset`, and `HandleInput` (via `immediateUpdate`) panic when `externalMu` is set but not held
- Success test verifying `HandleInput` with `externalMu` held triggers `immediateUpdate` without panic
- Repeated no-match test verifying consecutive invalid keystrokes use `immediateUpdate` (synchronous) rather than `debouncedUpdate`


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
