### PR TITLE
test(cli): cover all registered root and action subcommands

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -30,6 +30,22 @@ func getActionCmd(name string) *cobra.Command {
 	return nil
 }
 
+// Helper to get a subcommand of a named root command.
+func getSubCmd(parentName, childName string) *cobra.Command {
+	parent := getCmd(parentName)
+	if parent == nil {
+		return nil
+	}
+
+	for _, cmd := range parent.Commands() {
+		if cmd.Use == childName {
+			return cmd
+		}
+	}
+
+	return nil
+}
+
 func TestBuildSimpleCommand(t *testing.T) {
 	cmd := cli.BuildSimpleCommand("test", "short desc", "long desc", "action")
 
@@ -166,8 +182,14 @@ func TestCommandExecutionWithoutDaemon(t *testing.T) {
 		{"action_mouse_up", getActionCmd("mouse_up"), true},
 		{"action_mouse_down", getActionCmd("mouse_down"), true},
 		{"action_middle_click", getActionCmd("middle_click"), true},
+		{"action_move_mouse", getActionCmd("move_mouse"), true},
+		{"action_move_mouse_relative", getActionCmd("move_mouse_relative"), true},
 		{"status", getCmd("status"), true},
 		{"doctor", getCmd("doctor"), true}, // doctor returns silentError when daemon is down
+		{"toggle-screen-share", getCmd("toggle-screen-share"), true},
+		{"recursive_grid", getCmd("recursive_grid"), true},
+		{"config_dump", getSubCmd("config", "dump"), true},
+		{"config_reload", getSubCmd("config", "reload"), true},
 	}
 
 	for _, testCase := range tests {
@@ -188,6 +210,14 @@ func TestCommandExecutionWithoutDaemon(t *testing.T) {
 			}
 		})
 	}
+
+	// NOTE: services subcommands (install, uninstall, start, stop,
+	// restart, status) are intentionally excluded from this test.
+	// On macOS they invoke launchctl and may succeed, fail, or cause
+	// real side-effects (e.g. install writes a plist and loads a
+	// launchd service). On other platforms they return
+	// CodeNotSupported. Their registration is already verified by
+	// TestCommandInitialization.
 }
 
 func TestLaunchCommandExecution(t *testing.T) {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

`TestCommandInitialization` only checked a subset of registered commands and silently ignored any command not in the expected map. This meant new commands added via `RootCmd.AddCommand()` or `ActionCmd.AddCommand()` would never fail the test.

This PR:

- Adds missing root commands to the expected map: `config`, `services`, `toggle-screen-share`, `recursive_grid`
- Adds missing action subcommands: `move_mouse`, `move_mouse_relative`
- Adds a reverse check that fails the test if any registered command is not in the expected map, preventing this gap from recurring

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
