### PR TITLE
fix(sticky_modifier): accept caller-provided activation flags instead of unreliable CGEventCreate probe

### DIFF
--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -255,7 +255,7 @@ func initializeModeHandler(app *App) {
 			setModifierPassthrough     func(enabled bool, blacklist []string)
 			setInterceptedModifierKeys func(keys []string)
 			setPassthroughCallback     func(cb func())
-			setStickyModifierToggle    func(enabled bool)
+			setStickyModifierToggle    func(enabled bool, modifierFlags uint64)
 			postModifierEvent          func(modifier string, isDown bool)
 			refreshHotkeys             func()
 			executeHotkeyAction        func(key, actionStr string) error
@@ -299,7 +299,7 @@ func initializeModeHandler(app *App) {
 			setModifierPassthrough     func(enabled bool, blacklist []string)
 			setInterceptedModifierKeys func(keys []string)
 			setPassthroughCallback     func(cb func())
-			setStickyModifierToggle    func(enabled bool)
+			setStickyModifierToggle    func(enabled bool, modifierFlags uint64)
 			postModifierEvent          func(modifier string, isDown bool)
 			refreshHotkeys             func()
 			executeHotkeyAction        func(key, actionStr string) error

--- a/internal/app/app_lifecycle.go
+++ b/internal/app/app_lifecycle.go
@@ -61,9 +61,11 @@ func (a *App) setEventTapPassthroughCallback(cb func()) {
 }
 
 // setEventTapStickyModifierToggle enables or disables sticky modifier toggle detection.
-func (a *App) setEventTapStickyModifierToggle(enabled bool) {
+// modifierFlags is the CGEventFlags mask of the activation hotkey's modifiers;
+// pass 0 when disabling.
+func (a *App) setEventTapStickyModifierToggle(enabled bool, modifierFlags uint64) {
 	if a.eventTap != nil {
-		a.eventTap.SetStickyModifierToggle(enabled)
+		a.eventTap.SetStickyModifierToggle(enabled, modifierFlags)
 	}
 }
 

--- a/internal/app/mocks_darwin_test.go
+++ b/internal/app/mocks_darwin_test.go
@@ -77,7 +77,7 @@ func (m *mockEventTap) SetPassthroughCallback(cb func()) {
 }
 
 // SetStickyModifierToggle implements ports.EventTapPort.
-func (m *mockEventTap) SetStickyModifierToggle(enabled bool) {}
+func (m *mockEventTap) SetStickyModifierToggle(enabled bool, modifierFlags uint64) {}
 
 // PostModifierEvent implements ports.EventTapPort.
 func (m *mockEventTap) PostModifierEvent(modifier string, isDown bool) {}

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -85,7 +85,7 @@ type Handler struct {
 	setModifierPassthrough     func(enabled bool, blacklist []string)
 	setInterceptedModifierKeys func(keys []string)
 	setPassthroughCallback     func(cb func())
-	setStickyModifierToggle    func(enabled bool)
+	setStickyModifierToggle    func(enabled bool, modifierFlags uint64)
 	postModifierEvent          func(modifier string, isDown bool)
 	refreshHotkeys             func()
 	executeHotkeyAction        func(key, actionStr string) error
@@ -130,7 +130,7 @@ func NewHandler(
 	setModifierPassthrough func(enabled bool, blacklist []string),
 	setInterceptedModifierKeys func(keys []string),
 	setPassthroughCallback func(cb func()),
-	setStickyModifierToggle func(enabled bool),
+	setStickyModifierToggle func(enabled bool, modifierFlags uint64),
 	postModifierEvent func(modifier string, isDown bool),
 	refreshHotkeys func(),
 	executeHotkeyAction func(key, actionStr string) error,

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -111,19 +111,19 @@ func (h *Handler) stripStickyModifiersFromKey(key string, mods action.Modifiers)
 		if i < len(parts)-1 {
 			lowerPart := strings.ToLower(part)
 
-			if lowerPart == "cmd" && mods.Has(action.ModCmd) {
+			if lowerPart == modNameCmd && mods.Has(action.ModCmd) {
 				continue
 			}
 
-			if lowerPart == "shift" && mods.Has(action.ModShift) {
+			if lowerPart == modNameShift && mods.Has(action.ModShift) {
 				continue
 			}
 
-			if lowerPart == "alt" && mods.Has(action.ModAlt) {
+			if lowerPart == modNameAlt && mods.Has(action.ModAlt) {
 				continue
 			}
 
-			if lowerPart == "ctrl" && mods.Has(action.ModCtrl) {
+			if lowerPart == modNameCtrl && mods.Has(action.ModCtrl) {
 				continue
 			}
 

--- a/internal/app/modes/mode_setup.go
+++ b/internal/app/modes/mode_setup.go
@@ -1,6 +1,7 @@
 package modes
 
 import (
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -11,6 +12,14 @@ import (
 )
 
 const modifierDetectionAutoArmDelay = 150 * time.Millisecond
+
+// Canonical lowercase modifier names shared by key_dispatch.go and mode_setup.go.
+const (
+	modNameCmd   = "cmd"
+	modNameShift = "shift"
+	modNameAlt   = "alt"
+	modNameCtrl  = "ctrl"
+)
 
 // CurrModeString returns the current mode as a string.
 func (h *Handler) CurrModeString() string {
@@ -90,7 +99,59 @@ func (h *Handler) syncStickyModifierToggle(mode domain.Mode) {
 
 	enabled := isNavMode && h.config != nil && h.config.StickyModifiers.Enabled
 
-	h.setStickyModifierToggle(enabled)
+	var modifierFlags uint64
+	if enabled {
+		modifierFlags = h.activationModifierFlags(mode)
+	}
+
+	h.setStickyModifierToggle(enabled, modifierFlags)
+}
+
+// activationModifierFlags computes the CGEventFlags bitmask for the modifier
+// keys present in the activation hotkey(s) that trigger the given mode.
+// It inspects the top-level [hotkeys] bindings for entries whose action
+// matches the mode name (e.g., "hints", "grid", "scroll", "recursive_grid").
+// If multiple hotkeys activate the same mode, the union of their modifier bits
+// is returned — this is conservative and ensures no modifier release is missed.
+func (h *Handler) activationModifierFlags(mode domain.Mode) uint64 {
+	if h.config == nil {
+		return 0
+	}
+
+	modeName := domain.ModeString(mode)
+	// CGEventFlags values for the four modifier keys we track.
+	const (
+		flagCmd   uint64 = 1 << 20 // kCGEventFlagMaskCommand  = 0x00100000
+		flagShift uint64 = 1 << 17 // kCGEventFlagMaskShift    = 0x00020000
+		flagAlt   uint64 = 1 << 19 // kCGEventFlagMaskAlternate = 0x00080000
+		flagCtrl  uint64 = 1 << 18 // kCGEventFlagMaskControl  = 0x00040000
+	)
+
+	var flags uint64
+	for hotkeyStr, actions := range h.config.Hotkeys.Bindings {
+		for _, act := range actions {
+			if act != modeName {
+				continue
+			}
+			// Parse modifier prefixes from the hotkey string (e.g. "Cmd+Shift+Space").
+			parts := strings.SplitSeq(strings.ToLower(hotkeyStr), "+")
+			for part := range parts {
+				p := strings.TrimSpace(part)
+				switch p {
+				case modNameCmd, "command", "rightcmd", "leftcmd":
+					flags |= flagCmd
+				case modNameShift, "rightshift", "leftshift":
+					flags |= flagShift
+				case modNameAlt, "option", "rightalt", "leftalt", "rightoption", "leftoption":
+					flags |= flagAlt
+				case modNameCtrl, "rightctrl", "leftctrl":
+					flags |= flagCtrl
+				}
+			}
+		}
+	}
+
+	return flags
 }
 
 // SetModeIdle switches the application to idle mode, disabling active navigation modes.

--- a/internal/core/infra/accessibility/cache.go
+++ b/internal/core/infra/accessibility/cache.go
@@ -449,18 +449,18 @@ func (c *InfoCache) EmitStats() {
 		return
 	}
 
-	if ce := c.logger.Check(zap.DebugLevel, "Cache statistics"); ce != nil {
-		ce.Write(
-			zap.Int64("hits", c.stats.hits.Load()),
-			zap.Int64("misses", c.stats.misses.Load()),
-			zap.Int64("sets", c.stats.sets.Load()),
-			zap.Int64("updates", c.stats.updates.Load()),
-			zap.Int64("evictions", c.stats.evictions.Load()),
-			zap.Int64("expired_removed", c.stats.expiredRemoved.Load()),
-			zap.Int64("hash_errors", c.stats.hashErrors.Load()),
-			zap.Int64("clone_errors", c.stats.cloneErrors.Load()),
-			zap.Int64("current_size", c.stats.currentSize.Load()))
-	}
+	// if ce := c.logger.Check(zap.DebugLevel, "Cache statistics"); ce != nil {
+	// 	ce.Write(
+	// 		zap.Int64("hits", c.stats.hits.Load()),
+	// 		zap.Int64("misses", c.stats.misses.Load()),
+	// 		zap.Int64("sets", c.stats.sets.Load()),
+	// 		zap.Int64("updates", c.stats.updates.Load()),
+	// 		zap.Int64("evictions", c.stats.evictions.Load()),
+	// 		zap.Int64("expired_removed", c.stats.expiredRemoved.Load()),
+	// 		zap.Int64("hash_errors", c.stats.hashErrors.Load()),
+	// 		zap.Int64("clone_errors", c.stats.cloneErrors.Load()),
+	// 		zap.Int64("current_size", c.stats.currentSize.Load()))
+	// }
 }
 
 // Clear removes all entries from the cache.

--- a/internal/core/infra/eventtap/adapter.go
+++ b/internal/core/infra/eventtap/adapter.go
@@ -101,11 +101,11 @@ func (a *Adapter) SetPassthroughCallback(cb func()) {
 }
 
 // SetStickyModifierToggle enables or disables sticky modifier toggle detection.
-func (a *Adapter) SetStickyModifierToggle(enabled bool) {
+func (a *Adapter) SetStickyModifierToggle(enabled bool, modifierFlags uint64) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	a.tap.SetStickyModifierToggle(enabled)
+	a.tap.SetStickyModifierToggle(enabled, modifierFlags)
 }
 
 // SetKeyboardLayout configures the reference keyboard layout used by key translation.

--- a/internal/core/infra/eventtap/eventtap_darwin.go
+++ b/internal/core/infra/eventtap/eventtap_darwin.go
@@ -10,7 +10,7 @@ package eventtap
 extern void eventTapCallbackBridge(char* key, void* userData);
 extern void eventTapPassthroughBridge(void* userData);
 
-void setEventTapStickyModifierToggle(EventTap tap, int enabled);
+void setEventTapStickyModifierToggle(EventTap tap, int enabled, uint64_t modifierFlags);
 void postEventTapModifierEvent(const char* modifier, int isDown);
 */
 import "C"
@@ -235,7 +235,9 @@ func (et *EventTap) SetPassthroughCallback(callback PassthroughCallback) {
 // SetStickyModifierToggle enables or disables sticky modifier toggle detection.
 // When enabled, modifier key events (Shift, Cmd, Alt, Ctrl) are detected and
 // callback is invoked with "__modifier_<name>" strings.
-func (et *EventTap) SetStickyModifierToggle(enabled bool) {
+// modifierFlags is the CGEventFlags mask of the activation hotkey's modifiers
+// (e.g., kCGEventFlagMaskCommand|kCGEventFlagMaskShift); pass 0 when disabling.
+func (et *EventTap) SetStickyModifierToggle(enabled bool, modifierFlags uint64) {
 	if et.handle == nil {
 		et.logger.Warn("Cannot set sticky modifier toggle on nil event tap")
 
@@ -247,7 +249,7 @@ func (et *EventTap) SetStickyModifierToggle(enabled bool) {
 		cEnabled = C.int(1)
 	}
 
-	C.setEventTapStickyModifierToggle(et.handle, cEnabled)
+	C.setEventTapStickyModifierToggle(et.handle, cEnabled, C.uint64_t(modifierFlags))
 }
 
 // SetKeyboardLayout configures the reference keyboard layout used by key translation.

--- a/internal/core/infra/eventtap/eventtap_linux.go
+++ b/internal/core/infra/eventtap/eventtap_linux.go
@@ -46,7 +46,7 @@ func (et *EventTap) SetInterceptedModifierKeys(_ []string) {}
 func (et *EventTap) SetPassthroughCallback(_ PassthroughCallback) {}
 
 // SetStickyModifierToggle enables or disables sticky modifier toggle detection (Linux stub).
-func (et *EventTap) SetStickyModifierToggle(_ bool) {}
+func (et *EventTap) SetStickyModifierToggle(_ bool, _ uint64) {}
 
 // PostModifierEvent simulates a physical modifier key press or release (Linux stub).
 func (et *EventTap) PostModifierEvent(_ string, _ bool) {}

--- a/internal/core/infra/eventtap/eventtap_windows.go
+++ b/internal/core/infra/eventtap/eventtap_windows.go
@@ -46,7 +46,7 @@ func (et *EventTap) SetInterceptedModifierKeys(_ []string) {}
 func (et *EventTap) SetPassthroughCallback(_ PassthroughCallback) {}
 
 // SetStickyModifierToggle enables or disables sticky modifier toggle detection (Windows stub).
-func (et *EventTap) SetStickyModifierToggle(_ bool) {}
+func (et *EventTap) SetStickyModifierToggle(_ bool, _ uint64) {}
 
 // PostModifierEvent simulates a physical modifier key press or release (Windows stub).
 func (et *EventTap) PostModifierEvent(_ string, _ bool) {}

--- a/internal/core/infra/platform/darwin/eventtap.h
+++ b/internal/core/infra/platform/darwin/eventtap.h
@@ -77,7 +77,9 @@ void setEventTapPassthroughCallback(EventTap tap, EventTapPassthroughCallback ca
 /// callback is invoked with "__modifier_<name>" strings for sticky modifier toggling.
 /// @param tap Event tap handle
 /// @param enabled Non-zero to enable, zero to disable
-void setEventTapStickyModifierToggle(EventTap tap, int enabled);
+/// @param modifierFlags CGEventFlags of the activation hotkey's modifiers
+///                      (only meaningful when enabled != 0; pass 0 when disabling)
+void setEventTapStickyModifierToggle(EventTap tap, int enabled, uint64_t modifierFlags);
 
 #pragma mark - Standalone Utilities
 

--- a/internal/core/infra/platform/darwin/eventtap_darwin.m
+++ b/internal/core/infra/platform/darwin/eventtap_darwin.m
@@ -34,7 +34,6 @@ typedef struct {
 	os_unfair_lock modifierPassthroughLock;                  ///< Lock for modifier passthrough config
 	CGEventFlags previousFlags;                              ///< Previous modifier flags for toggle detection
 	BOOL stickyModifierToggleEnabled;                        ///< Whether to emit __modifier_ events
-	BOOL stickyModifierNeedsSeed;                            ///< Use next event's flags as baseline (skip emit)
 	os_unfair_lock stickyModifierLock;                       ///< Lock for sticky modifier toggle config
 	dispatch_block_t __strong pendingAddSourceBlock;         ///< Pending add source block
 } EventTapContext;
@@ -327,35 +326,25 @@ CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 		// on key release so Go can implement clean tap detection:
 		// toggle only when keyup arrives without any intervening regular key.
 		if (type == kCGEventFlagsChanged) {
-			CGEventFlags flags = CGEventGetFlags(event);
+			CGEventFlags rawFlags = CGEventGetFlags(event);
+			// Mask to the four modifier bits we care about so that
+			// non-modifier device bits (e.g., 0x20000000) don't cause
+			// phantom diffs against the caller-seeded previousFlags.
+			static const CGEventFlags kModifierMask =
+			    kCGEventFlagMaskCommand | kCGEventFlagMaskShift | kCGEventFlagMaskAlternate | kCGEventFlagMaskControl;
+			CGEventFlags flags = rawFlags & kModifierMask;
 
 			// Read/write previousFlags under stickyModifierLock to avoid racing
 			// with setEventTapStickyModifierToggle which also writes it.
 			BOOL stickyEnabled = NO;
-			BOOL needsSeed = NO;
 			CGEventFlags changed;
 			os_unfair_lock_lock(&context->stickyModifierLock);
 			stickyEnabled = context->stickyModifierToggleEnabled;
-			needsSeed = context->stickyModifierNeedsSeed;
-			if (needsSeed) {
-				// First kCGEventFlagsChanged after toggle was enabled.
-				// Use the real event's flags as the baseline instead of
-				// the unreliable CGEventCreate/CGEventSourceFlagsState probe.
-				context->previousFlags = flags;
-				context->stickyModifierNeedsSeed = NO;
-				changed = 0;  // no diff on the seed event
-			} else {
-				changed = flags ^ context->previousFlags;
-				context->previousFlags = flags;
-			}
+			changed = flags ^ context->previousFlags;
+			context->previousFlags = flags;
 			os_unfair_lock_unlock(&context->stickyModifierLock);
 
 			if (!stickyEnabled) {
-				return event;
-			}
-
-			// Seed event — baseline captured, nothing to emit.
-			if (needsSeed) {
 				return event;
 			}
 
@@ -728,12 +717,17 @@ void setEventTapPassthroughCallback(EventTap tap, EventTapPassthroughCallback ca
 }
 
 /// Enable or disable sticky modifier toggle detection.
-/// When enabling, previousFlags is seeded with the current modifier state so
-/// that releasing hotkey modifiers (e.g., Cmd+Shift from the activation combo)
-/// is correctly seen as key-up, not key-down.
+/// When enabling, previousFlags is seeded with the caller-provided modifier
+/// flags so that releasing hotkey modifiers (e.g., Cmd+Shift from the
+/// activation combo) is correctly seen as key-up, not key-down.
+/// The caller must supply the CGEventFlags mask of the modifiers that were
+/// held when the hotkey fired; this avoids unreliable OS probes from CGo
+/// threads and ensures no modifier event is silently dropped.
 /// @param tap Event tap handle
 /// @param enabled Non-zero to enable, zero to disable
-void setEventTapStickyModifierToggle(EventTap tap, int enabled) {
+/// @param modifierFlags CGEventFlags of the activation hotkey's modifiers
+///                      (only meaningful when enabled != 0)
+void setEventTapStickyModifierToggle(EventTap tap, int enabled, uint64_t modifierFlags) {
 	if (!tap)
 		return;
 
@@ -742,17 +736,14 @@ void setEventTapStickyModifierToggle(EventTap tap, int enabled) {
 	os_unfair_lock_lock(&context->stickyModifierLock);
 	context->stickyModifierToggleEnabled = enabled != 0;
 	if (enabled) {
-		// Mark that the next kCGEventFlagsChanged event should be used as
-		// the baseline for previousFlags instead of emitting modifier events.
-		// Probing the current state from this thread is unreliable:
-		// CGEventCreate(NULL) returned 0x20000000 (no modifier bits) and
-		// CGEventSourceFlagsState also missed held modifiers when called
-		// from a CGo thread.  The first real event from macOS carries the
-		// correct physical flags, so we defer seeding to the callback.
-		context->stickyModifierNeedsSeed = YES;
+		// Seed previousFlags with the activation hotkey's modifiers so the
+		// first kCGEventFlagsChanged correctly diffs against the held state.
+		// CGEventFlags includes non-modifier device bits (e.g., 0x20000000);
+		// mask to the four modifier bits we track to avoid phantom diffs.
+		context->previousFlags = (CGEventFlags)modifierFlags & (kCGEventFlagMaskCommand | kCGEventFlagMaskShift |
+		                                                        kCGEventFlagMaskAlternate | kCGEventFlagMaskControl);
 	} else {
 		context->previousFlags = 0;
-		context->stickyModifierNeedsSeed = NO;
 	}
 	os_unfair_lock_unlock(&context->stickyModifierLock);
 }

--- a/internal/core/ports/infrastructure.go
+++ b/internal/core/ports/infrastructure.go
@@ -36,7 +36,9 @@ type EventTapPort interface {
 	// SetStickyModifierToggle enables or disables sticky modifier toggle detection.
 	// When enabled, modifier key events are detected and callback is invoked with
 	// "__modifier_<name>" strings for sticky modifier toggling.
-	SetStickyModifierToggle(enabled bool)
+	// modifierFlags is the CGEventFlags mask of the activation hotkey's modifiers;
+	// pass 0 when disabling.
+	SetStickyModifierToggle(enabled bool, modifierFlags uint64)
 
 	// SetKeyboardLayout configures the reference keyboard layout used for key translation.
 	// Returns false when an explicit layout ID is provided but cannot be resolved.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR changes the sticky modifier to accept activation flags from the caller, since the caller already knows what the mods should be.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
