### PR TITLE
fix: anchor sticky modifiers to virtual cursor in grid modes

### DIFF
--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -93,6 +93,7 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 				}
 				showModeInd := h.shouldShowModeIndicator(h.appState.CurrentMode())
 				stickyEnabled := h.stickyModifiersEnabled()
+				stickyPoint := h.stickyIndicatorAnchorLocked(image.Pt(cursorX, cursorY))
 				h.mu.Unlock()
 
 				// Mode indicator: show and draw when enabled, hide otherwise.
@@ -115,7 +116,6 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 							stickyInd.Show()
 						}
 
-						stickyPoint := h.stickyIndicatorAnchor(image.Pt(cursorX, cursorY))
 						h.drawStickyModifiersIndicator(stickyPoint.X, stickyPoint.Y)
 					} else if stickyInd := h.overlayManager.StickyModifiersOverlay(); stickyInd != nil {
 						stickyInd.Clear()
@@ -185,10 +185,7 @@ func (h *Handler) shouldShowModeIndicator(mode domain.Mode) bool {
 	return h.modeIndicatorEnabled(mode)
 }
 
-func (h *Handler) stickyIndicatorAnchor(cursorPoint image.Point) image.Point {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
+func (h *Handler) stickyIndicatorAnchorLocked(cursorPoint image.Point) image.Point {
 	switch h.appState.CurrentMode() {
 	case domain.ModeGrid:
 		if h.grid == nil || h.grid.Context == nil || h.grid.Context.CursorFollowSelection() {

--- a/internal/app/modes/indicator_polling_test.go
+++ b/internal/app/modes/indicator_polling_test.go
@@ -29,7 +29,7 @@ func TestStickyIndicatorAnchor_UsesGridSelectionWhenCursorFollowDisabled(t *test
 	handler.grid.Context.SetCursorFollowSelection(false)
 	handler.grid.Context.SetSelectionPoint(image.Pt(40, 60))
 
-	got := handler.stickyIndicatorAnchor(image.Pt(10, 20))
+	got := handler.stickyIndicatorAnchorLocked(image.Pt(10, 20))
 
 	want := image.Pt(40, 60)
 	if got != want {
@@ -52,7 +52,7 @@ func TestStickyIndicatorAnchor_UsesRecursiveGridSelectionWhenCursorFollowDisable
 	handler.recursiveGrid.Context.SetCursorFollowSelection(false)
 	handler.recursiveGrid.Context.SetSelectionPoint(image.Pt(75, 25))
 
-	got := handler.stickyIndicatorAnchor(image.Pt(10, 20))
+	got := handler.stickyIndicatorAnchorLocked(image.Pt(10, 20))
 
 	want := image.Pt(75, 25)
 	if got != want {
@@ -75,7 +75,7 @@ func TestStickyIndicatorAnchor_UsesCursorWhenGridFollowsSelection(t *testing.T) 
 	handler.grid.Context.SetCursorFollowSelection(true)
 	handler.grid.Context.SetSelectionPoint(image.Pt(40, 60))
 
-	got := handler.stickyIndicatorAnchor(image.Pt(10, 20))
+	got := handler.stickyIndicatorAnchorLocked(image.Pt(10, 20))
 
 	want := image.Pt(10, 20)
 	if got != want {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR renders the sticky modifier indicator at the active virtual selection point in `grid` and `recursive-grid` when cursor-follow-selection is disabled.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Fixes #670

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
