### PR TITLE
fix(hints): guard visible rows lookup against zero-count results

### DIFF
--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -292,6 +292,10 @@ func (e *Element) Children(cache *InfoCache) ([]*Element, error) {
 	}
 
 	if rawChildren == nil || count == 0 {
+		if rawChildren != nil {
+			C.free(rawChildren)
+		}
+
 		return nil, nil
 	}
 	defer C.free(rawChildren) //nolint:nlreturn
@@ -415,6 +419,10 @@ func AllWindows() ([]*Element, error) {
 	var count C.int
 	windows := C.getAllWindows(&count)
 	if windows == nil || count == 0 {
+		if windows != nil {
+			C.free(unsafe.Pointer(windows))
+		}
+
 		return []*Element{}, nil
 	}
 	defer C.free(unsafe.Pointer(windows)) //nolint:nlreturn


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR Tightens the macOS accessibility child lookup for list-like roles in `element_darwin.go`.

For `AXList`, `AXTable`, and `AXOutline`, we try `getVisibleRows` first. This change only uses that result when the returned pointer is non-nil and the row count is greater than zero; otherwise it falls back to the normal `getChildren` path.

This avoids treating an empty visible-rows result as a valid child source and helps preserve expected element discovery behavior for list/table/outline containers.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to #688

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
