### PR TITLE
fix: use `primary` modifier instead of `cmd` for cross platform

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -35,10 +35,10 @@ text = "#E8EEFF"
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#hotkeys
 # See https://github.com/y3owk1n/neru/blob/main/docs/CLI.md
 [hotkeys]
-"Cmd+Shift+Space" = "hints"
-"Cmd+Shift+G" = "grid"
-"Cmd+Shift+C" = "recursive_grid"
-"Cmd+Shift+S" = "scroll"
+"Primary+Shift+Space" = "hints"
+"Primary+Shift+G" = "grid"
+"Primary+Shift+C" = "recursive_grid"
+"Primary+Shift+S" = "scroll"
 
 # Hint mode
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#hint-mode

--- a/configs/grid-only-config.toml
+++ b/configs/grid-only-config.toml
@@ -1,8 +1,8 @@
 # Neru Configuration - Grid Only Mode
 
 [hotkeys]
-"Cmd+Shift+Space" = "grid"
-"Cmd+Shift+S" = "scroll"
+"Primary+Shift+Space" = "grid"
+"Primary+Shift+S" = "scroll"
 
 [hints]
 enabled = false

--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -1,8 +1,8 @@
 # Neru Configuration - Hints Only Mode
 
 [hotkeys]
-"Cmd+Shift+Space" = "hints"
-"Cmd+Shift+S" = "scroll"
+"Primary+Shift+Space" = "hints"
+"Primary+Shift+S" = "scroll"
 
 [hints]
 enabled = true
@@ -41,12 +41,12 @@ ignore_clickable_check = false
 # Application-specific configurations for customizing hint behavior per app
 # Each entry allows overriding clickable roles and clickable check behavior for specific bundle IDs
 # [[hints.app_configs]]
-# bundle_id = "com.google.Chrome"
+# bundle_id = "net.imput.helium"
 # additional_clickable_roles = ["AXTabGroup"]
 # ignore_clickable_check = false
 #
 # [hints.app_configs.hotkeys]
-# "Return" = ["action left_click", "exec sleep 0.5", "hints"]
+# "Return" = ["action left_click", "exec sleep 3.5", "hints"]
 
 [hints.additional_ax_support]
 enable = true

--- a/configs/recursive-grid-only-config.toml
+++ b/configs/recursive-grid-only-config.toml
@@ -1,8 +1,8 @@
 # Neru Configuration - Recursive Grid Only Mode
 
 [hotkeys]
-"Cmd+Shift+Space" = "recursive_grid"
-"Cmd+Shift+S" = "scroll"
+"Primary+Shift+Space" = "recursive_grid"
+"Primary+Shift+S" = "scroll"
 
 [hints]
 enabled = false

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -50,7 +50,7 @@ New to Neru? Follow these steps in order:
     neru status
     ```
 
-4. **Try hint mode** (press the default hotkey `Cmd+Shift+Space`, or run):
+4. **Try hint mode** (press the default hotkey `Primary+Shift+Space`, or run):
 
     ```
     neru hints

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -107,8 +107,8 @@ To **remove** a single default binding without affecting the rest, use the `__di
 
 ```toml
 [hotkeys]
-"Cmd+Shift+S" = "__disabled__"   # removes the default scroll hotkey
-"Ctrl+Space"  = "hints"          # adds a new binding; other defaults remain
+"Primary+Shift+S" = "__disabled__"   # removes the default scroll hotkey
+"Ctrl+Space"      = "hints"          # adds a new binding; other defaults remain
 ```
 
 ### Syntax
@@ -132,7 +132,7 @@ Bind multiple actions to a single hotkey using an array. Actions are executed se
 ```toml
 [hotkeys]
 "PageUp" = ["action go_top", "action page_down"]
-"Cmd+Shift+D" = ["hints", "exec echo 'hints activated'"]
+"Primary+Shift+D" = ["hints", "exec echo 'hints activated'"]
 ```
 
 Both `[hotkeys]` and `[<mode>.hotkeys]` support this array syntax.
@@ -172,7 +172,7 @@ To remove a single default binding, use `__disabled__`:
 
 [scroll.hotkeys]
 "gg" = "action go_top"
-"Cmd+Shift+T" = "exec open -a Terminal"
+"Primary+Shift+T" = "exec open -a Terminal"
 ```
 
 ### Supported actions
@@ -362,8 +362,8 @@ Runtime cursor behavior is chosen per invocation rather than in config:
 
 ```toml
 [hotkeys]
-"Cmd+Shift+G" = "grid --cursor-selection-mode follow"
-"Cmd+Alt+G"   = "grid --cursor-selection-mode hold"
+"Primary+Shift+G" = "grid --cursor-selection-mode follow"
+"Primary+Alt+G"   = "grid --cursor-selection-mode hold"
 ```
 
 Default grid hotkeys include ``"`" = "toggle-cursor-follow-selection"`` so you can flip cursor follow behavior mid-session.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -79,13 +79,13 @@ Use the nix-darwin module for system-wide installation:
 
             # Optional: Inline configuration
             services.neru.config = ''
-[hotkeys]
+              [hotkeys]
               "Primary+Shift+Space" = "hints left_click"
               "Primary+Shift+G" = "grid left_click"
 
-             [general]
-             excluded_apps = ["com.apple.Terminal"]
-           '';
+              [general]
+              excluded_apps = ["com.apple.Terminal"]
+            '';
          }
        ];
      };
@@ -218,15 +218,15 @@ Use the home-manager module for user-specific installation on macOS or Linux:
            # services.neru.package = pkgs.neru; # This will use the latest version
            # services.neru.package = pkgs.neru-source; # This will build from source
 
-# Option A: Inline configuration
-            services.neru.config = ''
+           # Option A: Inline configuration
+           services.neru.config = ''
               [hotkeys]
               "Primary+Shift+Space" = "hints left_click"
               "Primary+Shift+G" = "grid left_click"
 
               [general]
               excluded_apps = ["com.apple.Terminal"]
-            '';
+           '';
 
            # Option B: Use existing config file (takes precedence)
            # services.neru.configFile = ./path/to/config.toml;
@@ -369,12 +369,12 @@ Or with home-manager:
 ```nix
 {
   services.neru.enable = true;
-services.neru.config = ''
-      [hotkeys]
-      "Primary+;" = "hints left_click"
-      "Primary+'" = "grid left_click"
-      "Primary+Shift+S" = "scroll"
-   '';
+  services.neru.config = ''
+     [hotkeys]
+     "Primary+;" = "hints left_click"
+     "Primary+'" = "grid left_click"
+     "Primary+Shift+S" = "scroll"
+  '';
 }
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -79,9 +79,9 @@ Use the nix-darwin module for system-wide installation:
 
             # Optional: Inline configuration
             services.neru.config = ''
-             [hotkeys]
-             "Cmd+Shift+Space" = "hints left_click"
-             "Cmd+Shift+G" = "grid left_click"
+[hotkeys]
+              "Primary+Shift+Space" = "hints left_click"
+              "Primary+Shift+G" = "grid left_click"
 
              [general]
              excluded_apps = ["com.apple.Terminal"]
@@ -185,7 +185,7 @@ The module automatically:
 > **Linux always builds from source.** There are no official pre-built Linux release artifacts yet. On Linux, `pkgs.neru` is equivalent to `pkgs.neru-source` — both build from source. If your nixpkgs doesn't ship a recent enough Go version, see [Patch Go Version](#patch-go-version) below.
 
 > [!WARNING]
-> **Default config uses macOS hotkeys.** The built-in default configuration ships with `Cmd+Shift+…` hotkeys, which map to the Super/Meta key on Linux. Linux users should override the `[hotkeys]` section with `Ctrl+…` shortcuts (as shown in the example above) or use the cross-platform `Primary` modifier, which maps to Cmd on macOS and Ctrl on Linux.
+> **Default config uses cross-platform hotkeys.** The built-in default configuration uses the `Primary+…` modifier, which maps to Cmd on macOS and Ctrl on Linux.
 
 ### Option 3: home-manager Module (User-Level)
 
@@ -218,15 +218,15 @@ Use the home-manager module for user-specific installation on macOS or Linux:
            # services.neru.package = pkgs.neru; # This will use the latest version
            # services.neru.package = pkgs.neru-source; # This will build from source
 
-           # Option A: Inline configuration
-           services.neru.config = ''
-             [hotkeys]
-             "Cmd+Shift+Space" = "hints left_click"
-             "Cmd+Shift+G" = "grid left_click"
+# Option A: Inline configuration
+            services.neru.config = ''
+              [hotkeys]
+              "Primary+Shift+Space" = "hints left_click"
+              "Primary+Shift+G" = "grid left_click"
 
-             [general]
-             excluded_apps = ["com.apple.Terminal"]
-           '';
+              [general]
+              excluded_apps = ["com.apple.Terminal"]
+            '';
 
            # Option B: Use existing config file (takes precedence)
            # services.neru.configFile = ./path/to/config.toml;
@@ -304,7 +304,7 @@ The module automatically:
 > **Linux always builds from source.** On Linux, `pkgs.neru` is equivalent to `pkgs.neru-source` — there are no official pre-built Linux release artifacts yet. If your nixpkgs doesn't ship a recent enough Go version, see [Patch Go Version](#patch-go-version) below.
 
 > [!WARNING]
-> **Default config uses macOS hotkeys.** If you don't provide an inline `config` or `configFile`, the module uses the built-in default which has `Cmd+Shift+…` hotkeys (Super/Meta on Linux). Linux users should override the `[hotkeys]` section with `Ctrl+…` or `Primary+…` shortcuts. The `Primary` modifier maps to Cmd on macOS and Ctrl on Linux.
+> **Default config uses cross-platform hotkeys.** The built-in default uses the `Primary+…` modifier, which maps to Cmd on macOS and Ctrl on Linux.
 
 ### Option 4: Using as an Overlay Only
 
@@ -369,12 +369,12 @@ Or with home-manager:
 ```nix
 {
   services.neru.enable = true;
-  services.neru.config = ''
-     [hotkeys]
-     "Cmd+;" = "hints left_click"
-     "Cmd+'" = "grid left_click"
-     "Cmd+Shift+S" = "scroll"
-  '';
+services.neru.config = ''
+      [hotkeys]
+      "Primary+;" = "hints left_click"
+      "Primary+'" = "grid left_click"
+      "Primary+Shift+S" = "scroll"
+   '';
 }
 ```
 

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -24,11 +24,11 @@
 
 Hints mode that clicks automatically when you finish typing a label — similar to Vimium in a browser.
 
-> **Note:** The default hotkey for Hints mode is `Cmd+Shift+Space`. The snippet below rebinds that same key to auto-click on select, so you are _replacing_ the default hints behaviour, not adding a new one. Bind it to a separate key if you want both.
+> **Note:** The default hotkey for Hints mode is `Primary+Shift+Space`. The snippet below rebinds that same key to auto-click on select, so you are _replacing_ the default hints behaviour, not adding a new one. Bind it to a separate key if you want both.
 
 ```toml
 [hotkeys]
-"Cmd+Shift+Space" = "hints --action left_click"
+"Primary+Shift+Space" = "hints --action left_click"
 ```
 
 ## Homerow Action Clicks
@@ -39,7 +39,7 @@ Homerow-style `Return` click actions via mode `hotkeys`:
 [hints.hotkeys]
 "Enter" = "action left_click" # press twice quickly for double-click, three times for triple-click
 "Shift+Enter" = "action right_click"
-"Cmd+Enter" = "action middle_click"
+"Primary+Enter" = "action middle_click"
 ```
 
 ## Auto-Exit After Click
@@ -60,7 +60,7 @@ The old `restore_cursor_position` config field was removed. Compose the same beh
 
 ```toml
 [hotkeys]
-"Cmd+Shift+Space" = ["action save_cursor_pos", "hints"] # add the save cursor pos action before launch hints
+"Primary+Shift+Space" = ["action save_cursor_pos", "hints"] # add the save cursor pos action before launch hints
 
 [hints.hotkeys]
 "Enter" = ["action left_click", "idle", "action restore_cursor_pos"]
@@ -105,8 +105,8 @@ Some menus disappear as soon as the pointer leaves them. For grid and recursive-
 
 ```toml
 [hotkeys]
-"Cmd+Shift+G" = "grid --cursor-selection-mode hold"
-"Cmd+Shift+C" = "recursive_grid --cursor-selection-mode hold"
+"Primary+Shift+G" = "grid --cursor-selection-mode hold"
+"Primary+Shift+C" = "recursive_grid --cursor-selection-mode hold"
 ```
 
 Grid and recursive-grid now include this toggle in the default config, bound to backtick:
@@ -255,8 +255,8 @@ The `--action` flag on hints mode is not limited to `left_click`. You can pass o
 
 ```toml
 [hotkeys]
-"Cmd+Shift+Space" = "hints --action left_click"   # click
-"Cmd+Shift+R"     = "hints --action right_click"  # context menu
+"Primary+Shift+Space" = "hints --action left_click"   # click
+"Primary+Shift+R"     = "hints --action right_click"  # context menu
 ```
 
 Useful for apps where you frequently need a right-click menu (e.g. Finder, VS Code file tree) without moving your hands to the mouse.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -273,7 +273,7 @@ osascript -e 'id of app "AppName"'
 
 ```toml
 [hotkeys]
-"Cmd+Shift+Space" = ""  # Disable default
+"Primary+Shift+Space" = ""  # Disable default
 "Ctrl+Alt+Space" = "hints"  # Use different combo
 ```
 
@@ -381,7 +381,7 @@ neru launch  # Uses defaults if no config file
 mkdir -p ~/.config/neru
 cat > ~/.config/neru/config.toml << EOF
 [hotkeys]
-"Cmd+Shift+Space" = "hints"
+"Primary+Shift+Space" = "hints"
 
 [logging]
 log_level = "debug"
@@ -572,11 +572,11 @@ background_color = "#FFFGG"   # Invalid hex
 
 ```toml
 # Correct:
-"Cmd+Shift+Space" = "hints"
+"Primary+Shift+Space" = "hints"
 
 # Incorrect:
-"Cmd-Shift-Space" = "hints"  # Use +, not -
-"CMD+SHIFT+SPACE" = "hints"  # Use proper case
+"Primary-Shift-Space" = "hints"  # Use +, not -
+"PRIMARY+SHIFT+SPACE" = "hints"  # Use proper case
 ```
 
 ---

--- a/internal/cli/config_init.go
+++ b/internal/cli/config_init.go
@@ -17,9 +17,9 @@ Use the global --config flag to write to a custom path instead.
 This copies the fully-commented default configuration to get you started.
 If a config file already exists, use --force to overwrite it.
 After running this command, start Neru with 'neru launch' and try:
-  Cmd+Shift+C      Recursive Grid mode (recommended)
-  Cmd+Shift+Space   Hints mode
-  Cmd+Shift+S       Scroll mode
+  Primary+Shift+C      Recursive Grid mode (recommended)
+  Primary+Shift+Space   Hints mode
+  Primary+Shift+S       Scroll mode
   Escape            Exit any mode`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		force, _ := cmd.Flags().GetBool("force")
@@ -56,9 +56,9 @@ func runConfigInit(cmd *cobra.Command, force bool) error {
 	cmd.Println("")
 	cmd.Println("Quick start:")
 	cmd.Println("  1. Start Neru:          neru launch")
-	cmd.Println("  2. Try Recursive Grid:  Cmd+Shift+C")
-	cmd.Println("  3. Try Hints mode:      Cmd+Shift+Space")
-	cmd.Println("  4. Try Scroll mode:     Cmd+Shift+S")
+	cmd.Println("  2. Try Recursive Grid:  Primary+Shift+C")
+	cmd.Println("  3. Try Hints mode:      Primary+Shift+Space")
+	cmd.Println("  4. Try Scroll mode:     Primary+Shift+S")
 	cmd.Println("  5. Exit any mode:       Escape")
 	cmd.Println("")
 	cmd.Println("Edit the config file to customize hotkeys, colors, and behavior.")

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -234,10 +234,10 @@ func newDefaultConfig() *Config {
 		Theme: defaultThemeConfig(),
 		Hotkeys: HotkeysConfig{
 			Bindings: map[string][]string{
-				"Cmd+Shift+Space": {"hints"},
-				"Cmd+Shift+G":     {"grid"},
-				"Cmd+Shift+C":     {"recursive_grid"},
-				"Cmd+Shift+S":     {"scroll"},
+				"Primary+Shift+Space": {"hints"},
+				"Primary+Shift+G":     {"grid"},
+				"Primary+Shift+C":     {"recursive_grid"},
+				"Primary+Shift+S":     {"scroll"},
 			},
 		},
 		Hints: HintsConfig{


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR update default hotkeys and documentation to use the cross-platform `Primary` modifier instead of macOS-specific `Cmd`. This ensures the defaults work identically across macOS, Linux, and Windows without requiring users to override hotkeys.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Fixes #700

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
