### PR TITLE
feat: add `super` and `meta` modifier as `cmd` alias

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -115,9 +115,11 @@ To **remove** a single default binding without affecting the rest, use the `__di
 
 **Format:** `"Modifier1+Modifier2+Key" = "action"`
 
-**Modifiers:** `Cmd`, `Ctrl`, `Alt` / `Option`, `Shift`, `Primary` (case-insensitive).
+**Modifiers:** `Cmd`, `Ctrl`, `Alt` / `Option`, `Shift`, `Primary`, `Super`, `Meta` (case-insensitive).
 
 `Primary` is a cross-platform alias that resolves to `Cmd` on macOS and `Ctrl` on Linux/Windows. Use this for hotkeys you want to work identically across platforms without changes.
+
+`Super` and `Meta` are aliases for `Cmd`. Linux users familiar with the Super key can use `Super+…` in their configs — it maps to the Command modifier internally.
 
 **Actions can be:**
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -242,7 +242,7 @@ neru status
 "Ctrl+F" = "hints"  # Try this instead
 
 # 4. Verify syntax is correct
-# Modifiers: Cmd, Ctrl, Alt/Option, Shift
+# Modifiers: Cmd, Ctrl, Alt/Option, Shift, Primary, Super, Meta
 # Format: "Mod1+Mod2+Key" = "action"
 ```
 

--- a/internal/app/services/stickyindicator/service.go
+++ b/internal/app/services/stickyindicator/service.go
@@ -2,6 +2,7 @@ package stickyindicator
 
 import (
 	"context"
+	"runtime"
 
 	"go.uber.org/zap"
 
@@ -51,6 +52,16 @@ func (s *Service) UpdateIndicatorPosition(x, y int, symbols string) {
 	s.overlay.DrawStickyModifiersIndicator(x, y, symbols)
 }
 
+// cmdSymbol returns the platform-appropriate symbol for the Command / Super modifier.
+// On macOS this is "⌘"; on Linux it is "❖" (the Super/Windows key symbol).
+func cmdSymbol() string {
+	if runtime.GOOS == "darwin" {
+		return "⌘"
+	}
+
+	return "❖"
+}
+
 // ModifierSymbolsString converts a Modifiers bitmask to a display string.
 func ModifierSymbolsString(mods action.Modifiers) string {
 	if mods == 0 {
@@ -59,7 +70,7 @@ func ModifierSymbolsString(mods action.Modifiers) string {
 
 	var symbols string
 	if mods.Has(action.ModCmd) {
-		symbols += "⌘"
+		symbols += cmdSymbol()
 	}
 
 	if mods.Has(action.ModShift) {

--- a/internal/app/services/stickyindicator/service_test.go
+++ b/internal/app/services/stickyindicator/service_test.go
@@ -1,6 +1,7 @@
 package stickyindicator_test
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/app/services/stickyindicator"
@@ -8,18 +9,25 @@ import (
 )
 
 func TestModifierSymbolsString(t *testing.T) {
+	// The display symbol for ModCmd is platform-dependent:
+	// "⌘" on macOS, "❖" on Linux.
+	cmdSym := "❖"
+	if runtime.GOOS == "darwin" {
+		cmdSym = "⌘"
+	}
+
 	tests := []struct {
 		name string
 		mods action.Modifiers
 		want string
 	}{
 		{"none", 0, ""},
-		{"cmd", action.ModCmd, "⌘"},
+		{"cmd", action.ModCmd, cmdSym},
 		{"shift", action.ModShift, "⇧"},
 		{"alt", action.ModAlt, "⌥"},
 		{"ctrl", action.ModCtrl, "⌃"},
-		{"cmd+shift", action.ModCmd | action.ModShift, "⌘⇧"},
-		{"all", action.ModCmd | action.ModShift | action.ModAlt | action.ModCtrl, "⌘⇧⌥⌃"},
+		{"cmd+shift", action.ModCmd | action.ModShift, cmdSym + "⇧"},
+		{"all", action.ModCmd | action.ModShift | action.ModAlt | action.ModCtrl, cmdSym + "⇧⌥⌃"},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -231,7 +231,7 @@ func BuildActionCommand(
 	}
 
 	cmd.Flags().StringVar(&modifier, "modifier", "",
-		"Comma-separated modifier keys to hold during action (cmd, shift, alt, option, ctrl)")
+		"Comma-separated modifier keys to hold during action (cmd, super, meta, shift, alt, option, ctrl)")
 
 	if allowTargetOverride {
 		cmd.Flags().BoolVar(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -257,7 +257,7 @@ func normalizeModifierTokenForOS(token, goos string) string {
 	switch strings.TrimSpace(strings.ToLower(token)) {
 	case "primary":
 		return primaryModifierTokenForOS(goos)
-	case modifierNameCmd, "command", "rightcmd", "leftcmd":
+	case modifierNameCmd, "command", "super", "meta", "rightcmd", "leftcmd":
 		return modifierNameCmd
 	case modifierNameCtrl, "control", "rightctrl", "leftctrl":
 		return modifierNameCtrl

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -311,10 +311,6 @@ func normalizeModifierAliasesInCombo(key, goos string) string {
 	return strings.Join(parts, "+")
 }
 
-func displayModifierToken(token string) string {
-	return displayModifierTokenForOS(token, runtime.GOOS)
-}
-
 func displayModifierTokenForOS(token, goos string) string {
 	switch token {
 	case modifierNameCmd:
@@ -348,7 +344,7 @@ func canonicalHotkeyForOS(hotkey, goos string) string {
 	parts := strings.Split(hotkey, "+")
 
 	for idx := range len(parts) - 1 {
-		parts[idx] = displayModifierToken(normalizeModifierTokenForOS(parts[idx], goos))
+		parts[idx] = displayModifierTokenForOS(normalizeModifierTokenForOS(parts[idx], goos), goos)
 	}
 
 	last := strings.TrimSpace(parts[len(parts)-1])

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -312,9 +312,17 @@ func normalizeModifierAliasesInCombo(key, goos string) string {
 }
 
 func displayModifierToken(token string) string {
+	return displayModifierTokenForOS(token, runtime.GOOS)
+}
+
+func displayModifierTokenForOS(token, goos string) string {
 	switch token {
 	case modifierNameCmd:
-		return "Cmd"
+		if goos == "darwin" {
+			return "Cmd"
+		}
+
+		return "Super"
 	case modifierNameCtrl:
 		return "Ctrl"
 	case modifierNameAlt:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -645,6 +645,16 @@ func TestCanonicalHotkeyForPlatform(t *testing.T) {
 			input:    "Primary+enter",
 			expected: map[bool]string{true: "Cmd+Enter", false: "Ctrl+Enter"}[isDarwinRuntime],
 		},
+		{
+			name:     "super alias becomes platform cmd token",
+			input:    "Super+Space",
+			expected: map[bool]string{true: "Cmd+Space", false: "Super+Space"}[isDarwinRuntime],
+		},
+		{
+			name:     "meta alias becomes platform cmd token",
+			input:    "Meta+Space",
+			expected: map[bool]string{true: "Cmd+Space", false: "Super+Space"}[isDarwinRuntime],
+		},
 	}
 
 	for _, testCase := range tests {

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -14,6 +14,8 @@ var validModifiers = map[string]bool{
 	"Primary":     true,
 	"Cmd":         true,
 	"Command":     true,
+	"Super":       true,
+	"Meta":        true,
 	"Ctrl":        true,
 	"Control":     true,
 	"Alt":         true,

--- a/internal/config/validators_hotkey_test.go
+++ b/internal/config/validators_hotkey_test.go
@@ -76,10 +76,16 @@ func TestValidateHotkey(t *testing.T) {
 			wantErr:   true,
 		},
 		{
-			name:      "invalid modifier",
+			name:      "valid Super modifier",
 			hotkey:    "Super+Space",
 			fieldName: "test_hotkey",
-			wantErr:   true,
+			wantErr:   false,
+		},
+		{
+			name:      "valid Meta modifier",
+			hotkey:    "Meta+Space",
+			fieldName: "test_hotkey",
+			wantErr:   false,
 		},
 		{
 			name:      "empty key",

--- a/internal/core/domain/action/modifiers.go
+++ b/internal/core/domain/action/modifiers.go
@@ -84,6 +84,17 @@ func (m Modifiers) Has(other Modifiers) bool {
 	return m&other == other
 }
 
+// cmdDisplayName returns the platform-appropriate display name for the
+// Command / Super modifier. On macOS the key is "Cmd" (⌘); on Linux it
+// is commonly called "Super".
+func cmdDisplayName() string {
+	if runtime.GOOS == "darwin" {
+		return "Cmd"
+	}
+
+	return "Super"
+}
+
 // String returns a human-readable representation (e.g. "Cmd+Shift").
 func (m Modifiers) String() string {
 	if m == 0 {
@@ -92,7 +103,7 @@ func (m Modifiers) String() string {
 
 	var parts []string
 	if m.Has(ModCmd) {
-		parts = append(parts, "Cmd")
+		parts = append(parts, cmdDisplayName())
 	}
 
 	if m.Has(ModShift) {

--- a/internal/core/domain/action/modifiers.go
+++ b/internal/core/domain/action/modifiers.go
@@ -25,6 +25,8 @@ const (
 var modifierNames = map[string]Modifiers{
 	"cmd":     ModCmd,
 	"command": ModCmd,
+	"super":   ModCmd,
+	"meta":    ModCmd,
 	"shift":   ModShift,
 	"alt":     ModAlt,
 	"option":  ModAlt,
@@ -66,7 +68,7 @@ func ParseModifiers(input string) (Modifiers, error) {
 		if !ok {
 			return 0, derrors.Newf(
 				derrors.CodeInvalidInput,
-				"unknown modifier %q (valid: primary, cmd, shift, alt, option, ctrl)",
+				"unknown modifier %q (valid: primary, cmd, super, meta, shift, alt, option, ctrl)",
 				part,
 			)
 		}

--- a/internal/core/domain/action/modifiers_test.go
+++ b/internal/core/domain/action/modifiers_test.go
@@ -32,7 +32,7 @@ func TestParseModifiers(t *testing.T) {
 		{name: "case insensitive", input: "CMD,Shift", want: action.ModCmd | action.ModShift},
 		{name: "whitespace trimmed", input: " cmd , shift ", want: action.ModCmd | action.ModShift},
 		{name: "duplicate modifiers", input: "cmd,cmd", want: action.ModCmd},
-		{name: "unknown modifier", input: "cmd,super", wantErr: true},
+		{name: "unknown modifier", input: "cmd,whatever", wantErr: true},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/core/domain/action/modifiers_test.go
+++ b/internal/core/domain/action/modifiers_test.go
@@ -1,6 +1,7 @@
 package action_test
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/core/domain/action"
@@ -71,18 +72,25 @@ func TestModifiers_Has(t *testing.T) {
 }
 
 func TestModifiers_String(t *testing.T) {
+	// The display name for ModCmd is platform-dependent:
+	// "Cmd" on macOS, "Super" on Linux.
+	cmdName := "Super"
+	if runtime.GOOS == "darwin" {
+		cmdName = "Cmd"
+	}
+
 	tests := []struct {
 		name string
 		mods action.Modifiers
 		want string
 	}{
 		{"zero", 0, ""},
-		{"cmd only", action.ModCmd, "Cmd"},
-		{"cmd+shift", action.ModCmd | action.ModShift, "Cmd+Shift"},
+		{"cmd only", action.ModCmd, cmdName},
+		{"cmd+shift", action.ModCmd | action.ModShift, cmdName + "+Shift"},
 		{
 			"all",
 			action.ModCmd | action.ModShift | action.ModAlt | action.ModCtrl,
-			"Cmd+Shift+Alt+Ctrl",
+			cmdName + "+Shift+Alt+Ctrl",
 		},
 	}
 	for _, testCase := range tests {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds support for using `super` and `meta` key in keybindings. Internally it is just an alias for `cmd` on macos.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Fixes #702 

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
