### PR TITLE
feat(move_monitor): consolidate monitor movement and actions

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -410,22 +410,21 @@ neru action move_mouse_relative --dx 10 --dy -5
 On multi-monitor setups, `move_monitor` moves the cursor to another display. If a mode overlay (`hints`, `grid`, `recursive_grid`) is active when the action is invoked, the overlay follows the cursor onto the new monitor so the mode can continue there without re-activating.
 
 ```
-neru action move_monitor "DELL U2720Q"                  # Move to named monitor
-neru action move_monitor "Built-in Retina Display"     # Move to specific display
-neru action move_monitor cycle                          # Move to next monitor
-neru action move_monitor cycle --previous               # Move to previous monitor
+neru action move_monitor                                    # Cycle to next monitor
+neru action move_monitor --previous                         # Cycle to previous monitor
+neru action move_monitor --name "DELL U2720Q"               # Move to named monitor
+neru action move_monitor --name "Built-in Retina Display"   # Move to specific display
 ```
 
-| Argument      | Description                                              |
-| ------------- | -------------------------------------------------------- |
-| `<name>`      | Move directly to a specific monitor by name             |
-| `cycle`       | Cycle through monitors (default: next)                  |
-| `--previous`  | With `cycle`, move to the previous monitor instead      |
+| Flag         | Description                                           |
+| ------------ | ----------------------------------------------------- |
+| `--name`     | Move directly to a specific monitor by name           |
+| `--previous` | Cycle to the previous monitor instead of the next one |
 
 > [!NOTE]
 > Monitor names are the display names reported by macOS (e.g. "Built-in Retina Display", "DELL U2720Q"). Find yours in **System Settings → Displays**. If you use an incorrect name, the error message will list all available names.
 
-Bind it to a hotkey in `config.toml` (e.g. `"Alt+Tab" = "action move_monitor cycle"`) to cycle between displays without leaving the keyboard.
+Bind it to a hotkey in `config.toml` (e.g. `"Alt+Tab" = "action move_monitor"`) to cycle between displays without leaving the keyboard.
 
 ---
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -386,13 +386,6 @@ neru action move_mouse --center --x 50 --y -30    # Center with offset
 neru action move_mouse --center --x 100            # Single-axis offset (y defaults to 0)
 ```
 
-**Named monitor:**
-
-```
-neru action move_mouse --center --monitor "DELL U2720Q"
-neru action move_mouse --center --monitor "Built-in Retina Display" --x 50 --y -30
-```
-
 **Relative movement:**
 
 ```
@@ -401,37 +394,38 @@ neru action move_mouse_relative --dx 10 --dy -5
 
 **`move_mouse` flag reference:**
 
-| Flag               | Description                                                  |
-| ------------------ | ------------------------------------------------------------ |
-| `--x <px>`         | Absolute X coordinate, or X offset when used with `--center` |
-| `--y <px>`         | Absolute Y coordinate, or Y offset when used with `--center` |
-| `--center`         | Move to the center of the active screen                      |
-| `--monitor <name>` | Target a named display (requires `--center`)                 |
-| `--selection`      | Explicitly use the active mode selection                     |
-| `--bare`           | Force current-cursor targeting even when a selection exists  |
-
-> [!TIP]
-> Monitor names are the display names reported by macOS (e.g. "Built-in Retina Display", "DELL U2720Q"). Find yours in **System Settings → Displays**. If you use an incorrect name, the error message will list all available names.
+| Flag          | Description                                                  |
+| ------------- | ------------------------------------------------------------ |
+| `--x <px>`    | Absolute X coordinate, or X offset when used with `--center` |
+| `--y <px>`    | Absolute Y coordinate, or Y offset when used with `--center` |
+| `--center`    | Move to the center of the active screen                      |
+| `--selection` | Explicitly use the active mode selection                     |
+| `--bare`      | Force current-cursor targeting even when a selection exists  |
 
 > [!TIP]
 > Point-targeted actions prefer the active mode selection by default. Use `--bare` when you want `left_click`, `right_click`, `middle_click`, `mouse_down`, `mouse_up`, `move_mouse`, or scroll actions to ignore the selection and use the current cursor position instead.
 
 ### Moving monitors
 
-On multi-monitor setups, `move_monitor` moves the cursor to the center of another display. If a mode overlay (`hints`, `grid`, `recursive_grid`) is active when the action is invoked, the overlay follows the cursor onto the new monitor so the mode can continue there without re-activating.
+On multi-monitor setups, `move_monitor` moves the cursor to another display. If a mode overlay (`hints`, `grid`, `recursive_grid`) is active when the action is invoked, the overlay follows the cursor onto the new monitor so the mode can continue there without re-activating.
 
 ```
-neru action move_monitor                              # next monitor
-neru action move_monitor --previous                   # previous monitor
+neru action move_monitor "DELL U2720Q"                  # Move to named monitor
+neru action move_monitor "Built-in Retina Display"     # Move to specific display
+neru action move_monitor cycle                          # Move to next monitor
+neru action move_monitor cycle --previous               # Move to previous monitor
 ```
 
-| Flag         | Description                                              |
-| ------------ | -------------------------------------------------------- |
-| `--previous` | Cycle backwards through the monitor list (default: next) |
+| Argument      | Description                                              |
+| ------------- | -------------------------------------------------------- |
+| `<name>`      | Move directly to a specific monitor by name             |
+| `cycle`       | Cycle through monitors (default: next)                  |
+| `--previous`  | With `cycle`, move to the previous monitor instead      |
 
-To jump directly to a specific display by name, use `move_mouse --center --monitor` instead (see [Named monitor](#named-monitor)).
+> [!NOTE]
+> Monitor names are the display names reported by macOS (e.g. "Built-in Retina Display", "DELL U2720Q"). Find yours in **System Settings → Displays**. If you use an incorrect name, the error message will list all available names.
 
-Bind it to a hotkey in `config.toml` (e.g. `"Alt+Tab" = "action move_monitor"`) to switch the active mode between displays without leaving the keyboard.
+Bind it to a hotkey in `config.toml` (e.g. `"Alt+Tab" = "action move_monitor cycle"`) to cycle between displays without leaving the keyboard.
 
 ---
 

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -14,7 +14,6 @@
 - [Give Browser Content Time To Load Before Refreshing Hints](#give-browser-content-time-to-load-before-refreshing-hints)
 - [Checking the Accessibility Tree on macOS](#checking-the-accessibility-tree-on-macos)
 - [Running a Custom Configuration via App Bundle](#running-a-custom-configuration-via-app-bundle)
-- [Cycling Between Different Monitors](#cycling-between-different-monitors)
 - [Triggering Neru Actions from External Tools](#triggering-neru-actions-from-external-tools)
 - [Combining Hints with Other Actions](#combining-hints-with-other-actions)
 
@@ -182,55 +181,6 @@ open -a neru --args launch -c /absolute/path/to/your/config
 > **Note:** `~` expansion does not work here — use the full absolute path.
 
 This is useful for testing a config before committing it to your dotfiles, or for keeping separate profiles (e.g. a lighter config when presenting or screen-sharing).
-
-## Cycling Between Different Monitors
-
-- Neru shows the mode overlay based on the current cursor position
-- To show the overlay on another monitor, move your cursor there first
-- Neru provides a base action command for this: `neru action move_mouse --center --monitor <monitor-name>`
-
-### Example: Cycle Between Monitors
-
-1. Create a bash script, e.g. `/path/cycle-monitor.sh`:
-
-```bash
-#!/usr/bin/env bash
-STATE_FILE="${HOME}/.neru_monitor_cycle"
-
-# Auto-detect monitors from system
-mapfile -t MONITORS < <(system_profiler SPDisplaysDataType | grep -E "^\s{8}[A-Za-z].*:$" | sed 's/://g' | sed 's/^[[:space:]]*//')
-
-if [[ ${#MONITORS[@]} -eq 0 ]]; then
-    echo "No monitors detected." >&2
-    exit 1
-fi
-
-# Read current index, default to 0
-current=0
-if [[ -f "$STATE_FILE" ]]; then
-    current=$(cat "$STATE_FILE")
-fi
-
-# Cycle to next
-next=$(((current + 1) % ${#MONITORS[@]}))
-
-# Move mouse to center of next monitor
-neru action move_mouse --center --monitor "${MONITORS[$next]}"
-
-echo "$next" > "$STATE_FILE"
-echo "Moved to: ${MONITORS[$next]}"
-```
-
-1. Make it executable, then bind it to a hotkey:
-
-```bash
-chmod +x /path/cycle-monitor.sh
-```
-
-```toml
-[hotkeys]
-"Alt+Z" = "exec bash /path/cycle-monitor.sh"
-```
 
 ## Triggering Neru Actions from External Tools
 

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -131,6 +131,47 @@ func hotkeyModifiersFromKey(key string) action.Modifiers {
 	return mods
 }
 
+func splitArgs(input string) []string {
+	var args []string
+
+	var current strings.Builder
+
+	inSingleQuote := false
+	inDoubleQuote := false
+
+	for _, char := range input {
+		switch char {
+		case '\'':
+			if !inDoubleQuote {
+				inSingleQuote = !inSingleQuote
+			} else {
+				current.WriteRune(char)
+			}
+		case '"':
+			if !inSingleQuote {
+				inDoubleQuote = !inDoubleQuote
+			} else {
+				current.WriteRune(char)
+			}
+		case ' ':
+			if inSingleQuote || inDoubleQuote {
+				current.WriteRune(char)
+			} else if current.Len() > 0 {
+				args = append(args, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(char)
+		}
+	}
+
+	if current.Len() > 0 {
+		args = append(args, current.String())
+	}
+
+	return args
+}
+
 // executeHotkeyAction executes a hotkey action, which can be either a shell command or an IPC command.
 func (a *App) executeHotkeyAction(key, actionStr string) error {
 	actionStr = strings.TrimSpace(actionStr)
@@ -139,7 +180,7 @@ func (a *App) executeHotkeyAction(key, actionStr string) error {
 		return a.executeShellCommand(key, actionStr)
 	}
 
-	actionParts := strings.Split(actionStr, " ")
+	actionParts := splitArgs(actionStr)
 	actionStr = actionParts[0]
 	params := actionParts[1:]
 

--- a/internal/app/hotkeys_test.go
+++ b/internal/app/hotkeys_test.go
@@ -54,3 +54,89 @@ func TestHotkeyModifiersFromKey(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitArgs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "plain split, no quotes",
+			input: `action move_monitor --previous`,
+			want:  []string{"action", "move_monitor", "--previous"},
+		},
+		{
+			name:  "double-quoted monitor name with space",
+			input: `action move_monitor --name "DELL U2720Q"`,
+			want:  []string{"action", "move_monitor", "--name", "DELL U2720Q"},
+		},
+		{
+			name:  "single-quoted monitor name",
+			input: `action move_monitor --name 'Built-in Retina Display'`,
+			want:  []string{"action", "move_monitor", "--name", "Built-in Retina Display"},
+		},
+		{
+			name:  "equals form with double quotes",
+			input: `action move_monitor --name="DELL U2720Q"`,
+			want:  []string{"action", "move_monitor", "--name=DELL U2720Q"},
+		},
+		{
+			name:  "single quote literal inside double quotes",
+			input: `action move_monitor --name "It's a Monitor"`,
+			want:  []string{"action", "move_monitor", "--name", "It's a Monitor"},
+		},
+		{
+			name:  "unclosed single quote is treated as closed token",
+			input: `action move_monitor --name 'DELL`,
+			want:  []string{"action", "move_monitor", "--name", "DELL"},
+		},
+		{
+			name:  "unclosed double quote is treated as closed token",
+			input: `action move_monitor --name "DELL`,
+			want:  []string{"action", "move_monitor", "--name", "DELL"},
+		},
+		{
+			name:  "empty string returns empty slice",
+			input: ``,
+			want:  []string{},
+		},
+		{
+			name:  "multiple spaces are collapsed",
+			input: `action   move_monitor   --previous`,
+			want:  []string{"action", "move_monitor", "--previous"},
+		},
+		{
+			name:  "trailing space produces trailing empty token ignored",
+			input: `action move_monitor --previous `,
+			want:  []string{"action", "move_monitor", "--previous"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := splitArgs(testCase.input)
+			if len(got) != len(testCase.want) {
+				t.Fatalf(
+					"splitArgs(%q) returned %d args, want %d: %v",
+					testCase.input,
+					len(got),
+					len(testCase.want),
+					got,
+				)
+			}
+
+			for idx := range got {
+				if got[idx] != testCase.want[idx] {
+					t.Fatalf(
+						"splitArgs(%q)[%d] = %q, want %q",
+						testCase.input,
+						idx,
+						got[idx],
+						testCase.want[idx],
+					)
+				}
+			}
+		})
+	}
+}

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -910,6 +910,16 @@ func (h *IPCControllerActions) handleMoveMonitorAction(
 		}
 	}
 
+	if parsed.hasMonitorName {
+		if parsed.usePrevious {
+			return ipc.Response{
+				Success: false,
+				Message: "--previous cannot be used with --name",
+				Code:    ipc.CodeInvalidInput,
+			}
+		}
+	}
+
 	if h.modesHandler == nil {
 		return ipc.Response{
 			Success: false,
@@ -919,14 +929,6 @@ func (h *IPCControllerActions) handleMoveMonitorAction(
 	}
 
 	if parsed.hasMonitorName {
-		if parsed.usePrevious {
-			return ipc.Response{
-				Success: false,
-				Message: "--previous cannot be used with --name",
-				Code:    ipc.CodeInvalidInput,
-			}
-		}
-
 		h.logger.Info("Moving to monitor by name via IPC",
 			zap.String("monitor", parsed.monitorName),
 		)

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -73,8 +73,8 @@ type parsedActionArgs struct {
 	useSelection   bool
 	useBare        bool
 	monitorName    string
+	hasMonitorName bool
 	usePrevious    bool
-	cycle          bool
 	modifierStr    string
 }
 
@@ -200,15 +200,18 @@ func parseActionArgs(rawArgs []string) (parsedActionArgs, bool) {
 			parsed.useBare = true
 		case arg == "--previous":
 			parsed.usePrevious = true
-		case arg == "cycle":
-			parsed.cycle = true
-		case !strings.HasPrefix(arg, "--"):
-			arg = strings.Trim(arg, "\"")
-			if parsed.monitorName == "" {
-				parsed.monitorName = arg
-			} else {
+		case strings.HasPrefix(arg, "--name") && (arg == "--name" || arg[len("--name")] == '='):
+			val, newIdx, ok := extractStringFlag(rawArgs, idx, "--name")
+			idx = newIdx
+
+			if !ok || val == "" {
 				parseErr = true
+
+				break
 			}
+
+			parsed.monitorName = val
+			parsed.hasMonitorName = true
 		default:
 			if strings.HasPrefix(arg, "--") {
 				parseErr = true
@@ -306,10 +309,10 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 		}
 	}
 
-	if parsed.usePrevious || parsed.cycle {
+	if parsed.usePrevious || parsed.hasMonitorName {
 		return ipc.Response{
 			Success: false,
-			Message: "--previous and cycle are only supported with move_monitor",
+			Message: "--previous and --name are only supported with move_monitor",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}
@@ -695,8 +698,8 @@ func (h *IPCControllerActions) handleBackspaceAction(parsed parsedActionArgs) ip
 
 func hasUnsupportedFlags(parsed parsedActionArgs) bool {
 	return parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
-		parsed.hasCenter || parsed.monitorName != "" || parsed.modifierStr != "" ||
-		parsed.useSelection || parsed.useBare || parsed.usePrevious || parsed.cycle
+		parsed.hasCenter || parsed.hasMonitorName || parsed.modifierStr != "" ||
+		parsed.useSelection || parsed.useBare || parsed.usePrevious
 }
 
 func (h *IPCControllerActions) resolveMouseActionPoint(
@@ -892,6 +895,7 @@ func (h *IPCControllerActions) handleRestoreCursorPosAction(
 
 // handleMoveMonitorAction moves the cursor (and any active mode overlay)
 // to a specific monitor by name, or cycles to the next/previous monitor.
+// Without --name, cycles to the next monitor (use --previous to go backwards).
 func (h *IPCControllerActions) handleMoveMonitorAction(
 	ctx context.Context,
 	parsed parsedActionArgs,
@@ -914,7 +918,15 @@ func (h *IPCControllerActions) handleMoveMonitorAction(
 		}
 	}
 
-	if parsed.monitorName != "" {
+	if parsed.hasMonitorName {
+		if parsed.usePrevious {
+			return ipc.Response{
+				Success: false,
+				Message: "--previous cannot be used with --name",
+				Code:    ipc.CodeInvalidInput,
+			}
+		}
+
 		h.logger.Info("Moving to monitor by name via IPC",
 			zap.String("monitor", parsed.monitorName),
 		)
@@ -937,38 +949,30 @@ func (h *IPCControllerActions) handleMoveMonitorAction(
 		}
 	}
 
-	if parsed.cycle {
-		direction := modes.MonitorDirectionNext
-		if parsed.usePrevious {
-			direction = modes.MonitorDirectionPrevious
-		}
+	direction := modes.MonitorDirectionNext
+	if parsed.usePrevious {
+		direction = modes.MonitorDirectionPrevious
+	}
 
-		h.logger.Info("Cycling monitor via IPC",
-			zap.Bool("previous", parsed.usePrevious),
-		)
+	h.logger.Info("Cycling monitor via IPC",
+		zap.Bool("previous", parsed.usePrevious),
+	)
 
-		err := h.modesHandler.MoveMonitor(ctx, direction)
-		if err != nil {
-			h.logger.Error("Failed to cycle monitor", zap.Error(err))
-
-			return ipc.Response{
-				Success: false,
-				Message: "failed to cycle monitor: " + err.Error(),
-				Code:    ipc.CodeActionFailed,
-			}
-		}
+	err := h.modesHandler.MoveMonitor(ctx, direction)
+	if err != nil {
+		h.logger.Error("Failed to cycle monitor", zap.Error(err))
 
 		return ipc.Response{
-			Success: true,
-			Message: "move_monitor performed",
-			Code:    ipc.CodeOK,
+			Success: false,
+			Message: "failed to cycle monitor: " + err.Error(),
+			Code:    ipc.CodeActionFailed,
 		}
 	}
 
 	return ipc.Response{
-		Success: false,
-		Message: "move_monitor requires a monitor name or 'cycle'",
-		Code:    ipc.CodeInvalidInput,
+		Success: true,
+		Message: "move_monitor performed",
+		Code:    ipc.CodeOK,
 	}
 }
 
@@ -989,11 +993,11 @@ func (h *IPCControllerActions) handleScrollAction(
 
 	// Reject flags that are not applicable to scroll actions.
 	if parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
-		parsed.hasCenter || parsed.monitorName != "" || parsed.modifierStr != "" ||
-		parsed.usePrevious || parsed.cycle {
+		parsed.hasCenter || parsed.hasMonitorName || parsed.modifierStr != "" ||
+		parsed.usePrevious {
 		return ipc.Response{
 			Success: false,
-			Message: "scroll actions do not support --x/--y/--dx/--dy/--center/--modifier/--previous/cycle flags",
+			Message: "scroll actions do not support --x/--y/--dx/--dy/--center/--name/--modifier/--previous flags",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -73,8 +73,8 @@ type parsedActionArgs struct {
 	useSelection   bool
 	useBare        bool
 	monitorName    string
-	hasMonitor     bool
 	usePrevious    bool
+	cycle          bool
 	modifierStr    string
 }
 
@@ -200,18 +200,15 @@ func parseActionArgs(rawArgs []string) (parsedActionArgs, bool) {
 			parsed.useBare = true
 		case arg == "--previous":
 			parsed.usePrevious = true
-		case strings.HasPrefix(arg, "--monitor") && (arg == "--monitor" || arg[len("--monitor")] == '='):
-			val, newIdx, ok := extractStringFlag(rawArgs, idx, "--monitor")
-			idx = newIdx
-
-			if !ok || val == "" {
+		case arg == "cycle":
+			parsed.cycle = true
+		case !strings.HasPrefix(arg, "--"):
+			arg = strings.Trim(arg, "\"")
+			if parsed.monitorName == "" {
+				parsed.monitorName = arg
+			} else {
 				parseErr = true
-
-				break
 			}
-
-			parsed.monitorName = val
-			parsed.hasMonitor = true
 		default:
 			if strings.HasPrefix(arg, "--") {
 				parseErr = true
@@ -296,25 +293,15 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 	// 3. Reject --x/--y mixed with --dx/--dy (always invalid).
 	// 4. Reject --center mixed with --dx/--dy (center uses --x/--y as offsets, not deltas).
 	// 5. Reject --center on non-move_mouse actions.
-	// 6. Reject --monitor without --center (monitor targeting requires center mode).
-	// 7. Reject --selection mixed with explicit move targeting.
-	// 8. Require --x AND --y when --center is absent for move_mouse.
+	// 6. Reject --selection mixed with explicit move targeting.
+	// 7. Require --x AND --y when --center is absent for move_mouse.
 	// Note: --center with --x/--y is intentionally allowed — x/y act as offsets from center.
-	// Note: --monitor on non-move_mouse is caught by step 5 (if --center present) or step 6 (if absent).
 
 	if !isMoveMouse && !isMoveMouseRelative &&
 		(parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY) {
 		return ipc.Response{
 			Success: false,
 			Message: "--x/--y/--dx/--dy flags are only supported with move_mouse or move_mouse_relative",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if parsed.usePrevious {
-		return ipc.Response{
-			Success: false,
-			Message: "--previous is only supported with move_monitor",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}
@@ -360,14 +347,6 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 		}
 	}
 
-	if parsed.hasMonitor && !parsed.hasCenter {
-		return ipc.Response{
-			Success: false,
-			Message: "--monitor requires --center",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
 	if parsed.useSelection && parsed.useBare {
 		return ipc.Response{
 			Success: false,
@@ -393,10 +372,10 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 	}
 
 	if parsed.useSelection &&
-		(parsed.hasCenter || parsed.hasMonitor || parsed.hasX || parsed.hasY) {
+		(parsed.hasCenter || parsed.hasX || parsed.hasY) {
 		return ipc.Response{
 			Success: false,
-			Message: "--selection cannot be combined with --x, --y, --center, or --monitor",
+			Message: "--selection cannot be combined with --x, --y, or --center",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}
@@ -421,41 +400,6 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 		}
 
 		offsetX, offsetY := parsed.xVal, parsed.yVal
-
-		if parsed.hasMonitor {
-			h.logger.Info("Moving mouse to center of monitor via IPC",
-				zap.String("monitor", parsed.monitorName),
-				zap.Int("offsetX", offsetX),
-				zap.Int("offsetY", offsetY),
-			)
-
-			err := h.actionService.MoveMouseToCenterOfMonitor(
-				ctx,
-				parsed.monitorName,
-				offsetX,
-				offsetY,
-			)
-			if err != nil {
-				h.logger.Error("Failed to move mouse to center of monitor", zap.Error(err))
-
-				return ipc.Response{
-					Success: false,
-					Message: "failed to perform action: " + err.Error(),
-					Code:    ipc.CodeActionFailed,
-				}
-			}
-
-			if h.modesHandler != nil &&
-				shouldClearSelectionAfterMoveMouse(parsed, false) {
-				h.modesHandler.ClearCurrentSelectionPoint()
-			}
-
-			return ipc.Response{
-				Success: true,
-				Message: actionName + " performed",
-				Code:    ipc.CodeOK,
-			}
-		}
 
 		h.logger.Info("Moving mouse to center via IPC",
 			zap.Int("offsetX", offsetX),
@@ -743,8 +687,8 @@ func (h *IPCControllerActions) handleBackspaceAction(parsed parsedActionArgs) ip
 
 func hasUnsupportedFlags(parsed parsedActionArgs) bool {
 	return parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
-		parsed.hasCenter || parsed.hasMonitor || parsed.modifierStr != "" ||
-		parsed.useSelection || parsed.useBare || parsed.usePrevious
+		parsed.hasCenter || parsed.monitorName != "" || parsed.modifierStr != "" ||
+		parsed.useSelection || parsed.useBare
 }
 
 func (h *IPCControllerActions) resolveMouseActionPoint(
@@ -939,17 +883,17 @@ func (h *IPCControllerActions) handleRestoreCursorPosAction(
 }
 
 // handleMoveMonitorAction moves the cursor (and any active mode overlay)
-// to the next or previous connected monitor.
+// to a specific monitor by name, or cycles to the next/previous monitor.
 func (h *IPCControllerActions) handleMoveMonitorAction(
 	ctx context.Context,
 	parsed parsedActionArgs,
 ) ipc.Response {
 	if parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
-		parsed.hasCenter || parsed.hasMonitor || parsed.modifierStr != "" ||
+		parsed.hasCenter || parsed.modifierStr != "" ||
 		parsed.useSelection || parsed.useBare {
 		return ipc.Response{
 			Success: false,
-			Message: "move_monitor only supports --previous; use move_mouse --center --monitor to target a named display",
+			Message: "move_monitor does not support these flags",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}
@@ -962,30 +906,63 @@ func (h *IPCControllerActions) handleMoveMonitorAction(
 		}
 	}
 
-	direction := modes.MonitorDirectionNext
-	if parsed.usePrevious {
-		direction = modes.MonitorDirectionPrevious
-	}
+	if parsed.monitorName != "" {
+		h.logger.Info("Moving to monitor by name via IPC",
+			zap.String("monitor", parsed.monitorName),
+			zap.Int("offsetX", parsed.xVal),
+			zap.Int("offsetY", parsed.yVal),
+		)
 
-	h.logger.Info("Moving monitor via IPC",
-		zap.Bool("previous", parsed.usePrevious),
-	)
+		err := h.modesHandler.MoveMonitorByName(ctx, parsed.monitorName, parsed.xVal, parsed.yVal)
+		if err != nil {
+			h.logger.Error("Failed to move to monitor by name", zap.Error(err))
 
-	err := h.modesHandler.MoveMonitor(ctx, direction)
-	if err != nil {
-		h.logger.Error("Failed to move monitor", zap.Error(err))
+			return ipc.Response{
+				Success: false,
+				Message: "failed to move to monitor: " + err.Error(),
+				Code:    ipc.CodeActionFailed,
+			}
+		}
 
 		return ipc.Response{
-			Success: false,
-			Message: "failed to move monitor: " + err.Error(),
-			Code:    ipc.CodeActionFailed,
+			Success: true,
+			Message: "move_monitor performed",
+			Code:    ipc.CodeOK,
+		}
+	}
+
+	if parsed.cycle {
+		direction := modes.MonitorDirectionNext
+		if parsed.usePrevious {
+			direction = modes.MonitorDirectionPrevious
+		}
+
+		h.logger.Info("Cycling monitor via IPC",
+			zap.Bool("previous", parsed.usePrevious),
+		)
+
+		err := h.modesHandler.MoveMonitor(ctx, direction)
+		if err != nil {
+			h.logger.Error("Failed to cycle monitor", zap.Error(err))
+
+			return ipc.Response{
+				Success: false,
+				Message: "failed to cycle monitor: " + err.Error(),
+				Code:    ipc.CodeActionFailed,
+			}
+		}
+
+		return ipc.Response{
+			Success: true,
+			Message: "move_monitor performed",
+			Code:    ipc.CodeOK,
 		}
 	}
 
 	return ipc.Response{
-		Success: true,
-		Message: "move_monitor performed",
-		Code:    ipc.CodeOK,
+		Success: false,
+		Message: "move_monitor requires a monitor name or 'cycle'",
+		Code:    ipc.CodeInvalidInput,
 	}
 }
 
@@ -1006,18 +983,10 @@ func (h *IPCControllerActions) handleScrollAction(
 
 	// Reject flags that are not applicable to scroll actions.
 	if parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
-		parsed.hasCenter || parsed.hasMonitor || parsed.modifierStr != "" {
+		parsed.hasCenter || parsed.monitorName != "" || parsed.modifierStr != "" {
 		return ipc.Response{
 			Success: false,
-			Message: "scroll actions do not support --x/--y/--dx/--dy/--center/--monitor/--modifier flags",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if parsed.usePrevious {
-		return ipc.Response{
-			Success: false,
-			Message: "--previous is only supported with move_monitor",
+			Message: "scroll actions do not support --x/--y/--dx/--dy/--center/--modifier flags",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -306,6 +306,14 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 		}
 	}
 
+	if parsed.usePrevious || parsed.cycle {
+		return ipc.Response{
+			Success: false,
+			Message: "--previous and cycle are only supported with move_monitor",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
 	if modifiers != 0 && !isMouseButton {
 		return ipc.Response{
 			Success: false,
@@ -688,7 +696,7 @@ func (h *IPCControllerActions) handleBackspaceAction(parsed parsedActionArgs) ip
 func hasUnsupportedFlags(parsed parsedActionArgs) bool {
 	return parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
 		parsed.hasCenter || parsed.monitorName != "" || parsed.modifierStr != "" ||
-		parsed.useSelection || parsed.useBare
+		parsed.useSelection || parsed.useBare || parsed.usePrevious || parsed.cycle
 }
 
 func (h *IPCControllerActions) resolveMouseActionPoint(
@@ -983,10 +991,11 @@ func (h *IPCControllerActions) handleScrollAction(
 
 	// Reject flags that are not applicable to scroll actions.
 	if parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
-		parsed.hasCenter || parsed.monitorName != "" || parsed.modifierStr != "" {
+		parsed.hasCenter || parsed.monitorName != "" || parsed.modifierStr != "" ||
+		parsed.usePrevious || parsed.cycle {
 		return ipc.Response{
 			Success: false,
-			Message: "scroll actions do not support --x/--y/--dx/--dy/--center/--modifier flags",
+			Message: "scroll actions do not support --x/--y/--dx/--dy/--center/--modifier/--previous/cycle flags",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -917,11 +917,9 @@ func (h *IPCControllerActions) handleMoveMonitorAction(
 	if parsed.monitorName != "" {
 		h.logger.Info("Moving to monitor by name via IPC",
 			zap.String("monitor", parsed.monitorName),
-			zap.Int("offsetX", parsed.xVal),
-			zap.Int("offsetY", parsed.yVal),
 		)
 
-		err := h.modesHandler.MoveMonitorByName(ctx, parsed.monitorName, parsed.xVal, parsed.yVal)
+		err := h.modesHandler.MoveMonitorByName(ctx, parsed.monitorName)
 		if err != nil {
 			h.logger.Error("Failed to move to monitor by name", zap.Error(err))
 

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -55,7 +55,7 @@ func TestParseActionArgs_PreviousFlag(t *testing.T) {
 	}
 }
 
-func TestHandleAction_MoveMonitorRejectsMonitorFlag(t *testing.T) {
+func TestHandleAction_MoveMonitorRejectsUnsupportedFlags_X(t *testing.T) {
 	controller := &IPCControllerActions{
 		appState: state.NewAppState(),
 		logger:   zap.NewNop(),
@@ -188,12 +188,12 @@ func TestHandleAction_PreviousRejectedOnNonMoveMonitor(t *testing.T) {
 		t.Fatal("handleAction(left_click --previous) expected failure")
 	}
 
-	if resp.Message != "--previous and cycle are only supported with move_monitor" {
+	if resp.Message != "--previous and --name are only supported with move_monitor" {
 		t.Fatalf("unexpected error message: %q", resp.Message)
 	}
 }
 
-func TestHandleAction_CycleRejectedOnNonMoveMonitor(t *testing.T) {
+func TestHandleAction_NameRejectedOnNonMoveMonitor(t *testing.T) {
 	controller := &IPCControllerActions{
 		appState: state.NewAppState(),
 		logger:   zap.NewNop(),
@@ -201,11 +201,11 @@ func TestHandleAction_CycleRejectedOnNonMoveMonitor(t *testing.T) {
 
 	resp := controller.handleAction(context.Background(), ipc.Command{
 		Action: "action",
-		Args:   []string{"reset", "cycle"},
+		Args:   []string{"reset", "--name=DELL"},
 	})
 
 	if resp.Success {
-		t.Fatal("handleAction(reset cycle) expected failure")
+		t.Fatal("handleAction(reset --name) expected failure")
 	}
 
 	if resp.Message != "reset does not support action flags" {
@@ -235,8 +235,44 @@ func TestHandleAction_PreviousRejectedOnScrollAction(t *testing.T) {
 		t.Fatal("handleAction(scroll_down --previous) expected failure")
 	}
 
-	if resp.Message != "scroll actions do not support --x/--y/--dx/--dy/--center/--modifier/--previous/cycle flags" {
+	if resp.Message != "scroll actions do not support --x/--y/--dx/--dy/--center/--name/--modifier/--previous flags" {
 		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
+func TestParseActionArgs_NameFlag(t *testing.T) {
+	parsed, parseErr := parseActionArgs([]string{"--name=DELL U2720Q"})
+	if parseErr {
+		t.Fatal("parseActionArgs() unexpected parse error for --name")
+	}
+
+	if !parsed.hasMonitorName {
+		t.Fatal("parseActionArgs() expected hasMonitorName to be true")
+	}
+
+	if parsed.monitorName != "DELL U2720Q" {
+		t.Fatalf(
+			"parseActionArgs() expected monitorName to be 'DELL U2720Q', got %q",
+			parsed.monitorName,
+		)
+	}
+}
+
+func TestParseActionArgs_NameFlagSpaceForm(t *testing.T) {
+	parsed, parseErr := parseActionArgs([]string{"--name", "Built-in Retina Display"})
+	if parseErr {
+		t.Fatal("parseActionArgs() unexpected parse error for --name space form")
+	}
+
+	if !parsed.hasMonitorName {
+		t.Fatal("parseActionArgs() expected hasMonitorName to be true")
+	}
+
+	if parsed.monitorName != "Built-in Retina Display" {
+		t.Fatalf(
+			"parseActionArgs() expected monitorName to be 'Built-in Retina Display', got %q",
+			parsed.monitorName,
+		)
 	}
 }
 

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestParseActionArgs_MoveMouseFlags(t *testing.T) {
-	parsed, parseErr := parseActionArgs([]string{"--center", "--monitor=Built-in Retina Display"})
+	parsed, parseErr := parseActionArgs([]string{"--center", "--x=100", "--y=200"})
 	if parseErr {
 		t.Fatal("parseActionArgs() unexpected parse error")
 	}
@@ -24,8 +24,12 @@ func TestParseActionArgs_MoveMouseFlags(t *testing.T) {
 		t.Fatal("parseActionArgs() expected hasCenter to be true")
 	}
 
-	if !parsed.hasMonitor {
-		t.Fatal("parseActionArgs() expected hasMonitor to be true")
+	if parsed.xVal != 100 {
+		t.Fatalf("parseActionArgs() expected xVal to be 100, got %d", parsed.xVal)
+	}
+
+	if parsed.yVal != 200 {
+		t.Fatalf("parseActionArgs() expected yVal to be 200, got %d", parsed.yVal)
 	}
 }
 
@@ -51,26 +55,6 @@ func TestParseActionArgs_PreviousFlag(t *testing.T) {
 	}
 }
 
-func TestHandleAction_PreviousRejectedOnNonMoveMonitor(t *testing.T) {
-	controller := &IPCControllerActions{
-		appState: state.NewAppState(),
-		logger:   zap.NewNop(),
-	}
-
-	resp := controller.handleAction(context.Background(), ipc.Command{
-		Action: "action",
-		Args:   []string{"left_click", "--previous"},
-	})
-
-	if resp.Success {
-		t.Fatal("handleAction(left_click --previous) expected failure")
-	}
-
-	if resp.Message != "--previous is only supported with move_monitor" {
-		t.Fatalf("unexpected error message: %q", resp.Message)
-	}
-}
-
 func TestHandleAction_MoveMonitorRejectsMonitorFlag(t *testing.T) {
 	controller := &IPCControllerActions{
 		appState: state.NewAppState(),
@@ -79,14 +63,14 @@ func TestHandleAction_MoveMonitorRejectsMonitorFlag(t *testing.T) {
 
 	resp := controller.handleAction(context.Background(), ipc.Command{
 		Action: "action",
-		Args:   []string{"move_monitor", "--monitor=foo"},
+		Args:   []string{"move_monitor", "--x=100"},
 	})
 
 	if resp.Success {
-		t.Fatal("handleAction(move_monitor --monitor) expected failure")
+		t.Fatal("handleAction(move_monitor --x) expected failure")
 	}
 
-	if resp.Message != "move_monitor only supports --previous; use move_mouse --center --monitor to target a named display" {
+	if resp.Message != "move_monitor does not support these flags" {
 		t.Fatalf("unexpected error message: %q", resp.Message)
 	}
 }
@@ -106,34 +90,7 @@ func TestHandleAction_MoveMonitorRejectsUnsupportedFlags(t *testing.T) {
 		t.Fatal("handleAction(move_monitor --selection) expected failure")
 	}
 
-	if resp.Message != "move_monitor only supports --previous; use move_mouse --center --monitor to target a named display" {
-		t.Fatalf("unexpected error message: %q", resp.Message)
-	}
-}
-
-func TestHandleAction_PreviousRejectedOnScrollAction(t *testing.T) {
-	controller := &IPCControllerActions{
-		appState: state.NewAppState(),
-		logger:   zap.NewNop(),
-		scrollService: services.NewScrollService(
-			&portmocks.MockAccessibilityPort{},
-			&portmocks.MockOverlayPort{},
-			&portmocks.SystemMock{},
-			config.ScrollConfig{ScrollStep: 10, ScrollStepHalf: 20, ScrollStepFull: 30},
-			zap.NewNop(),
-		),
-	}
-
-	resp := controller.handleAction(context.Background(), ipc.Command{
-		Action: "action",
-		Args:   []string{"scroll_down", "--previous"},
-	})
-
-	if resp.Success {
-		t.Fatal("handleAction(scroll_down --previous) expected failure")
-	}
-
-	if resp.Message != "--previous is only supported with move_monitor" {
+	if resp.Message != "move_monitor does not support these flags" {
 		t.Fatalf("unexpected error message: %q", resp.Message)
 	}
 }
@@ -240,12 +197,6 @@ func TestShouldClearSelectionAfterMoveMouse(t *testing.T) {
 		{
 			name:             "center move clears selection",
 			parsed:           parsedActionArgs{hasCenter: true},
-			targetsSelection: false,
-			want:             true,
-		},
-		{
-			name:             "monitor center move clears selection",
-			parsed:           parsedActionArgs{hasCenter: true, hasMonitor: true},
 			targetsSelection: false,
 			want:             true,
 		},

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -173,6 +173,73 @@ func TestHandleAction_ScrollSelectionWithoutActiveSelectionErrors(t *testing.T) 
 	}
 }
 
+func TestHandleAction_PreviousRejectedOnNonMoveMonitor(t *testing.T) {
+	controller := &IPCControllerActions{
+		appState: state.NewAppState(),
+		logger:   zap.NewNop(),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: "action",
+		Args:   []string{"left_click", "--previous"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(left_click --previous) expected failure")
+	}
+
+	if resp.Message != "--previous and cycle are only supported with move_monitor" {
+		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
+func TestHandleAction_CycleRejectedOnNonMoveMonitor(t *testing.T) {
+	controller := &IPCControllerActions{
+		appState: state.NewAppState(),
+		logger:   zap.NewNop(),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: "action",
+		Args:   []string{"reset", "cycle"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(reset cycle) expected failure")
+	}
+
+	if resp.Message != "reset does not support action flags" {
+		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
+func TestHandleAction_PreviousRejectedOnScrollAction(t *testing.T) {
+	controller := &IPCControllerActions{
+		appState: state.NewAppState(),
+		logger:   zap.NewNop(),
+		scrollService: services.NewScrollService(
+			&portmocks.MockAccessibilityPort{},
+			&portmocks.MockOverlayPort{},
+			&portmocks.SystemMock{},
+			config.ScrollConfig{ScrollStep: 10, ScrollStepHalf: 20, ScrollStepFull: 30},
+			zap.NewNop(),
+		),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: "action",
+		Args:   []string{"scroll_down", "--previous"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(scroll_down --previous) expected failure")
+	}
+
+	if resp.Message != "scroll actions do not support --x/--y/--dx/--dy/--center/--modifier/--previous/cycle flags" {
+		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
 func TestShouldClearSelectionAfterMoveMouse(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -29,7 +29,7 @@ const (
 // active, refreshes it onto the new monitor.
 //
 // To jump to a specific named display, use
-// `move_monitor <monitor-name>` instead.
+// `move_monitor --name <monitor-name>` instead.
 func (h *Handler) MoveMonitor(
 	ctx context.Context,
 	direction MonitorDirection,

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -29,7 +29,7 @@ const (
 // active, refreshes it onto the new monitor.
 //
 // To jump to a specific named display, use
-// `move_mouse --center --monitor=<name>` instead.
+// `move_monitor <monitor-name>` instead.
 func (h *Handler) MoveMonitor(
 	ctx context.Context,
 	direction MonitorDirection,
@@ -94,6 +94,72 @@ func (h *Handler) MoveMonitor(
 	)
 
 	h.refreshActiveModeOnNewScreen(ctx, targetBounds)
+
+	return nil
+}
+
+// MoveMonitorByName moves the cursor to a specific monitor by name.
+// If the mode overlay is active, it refreshes onto the new monitor.
+func (h *Handler) MoveMonitorByName(
+	ctx context.Context,
+	monitorName string,
+	offsetX, offsetY int,
+) error {
+	h.moveMonitorMu.Lock()
+	defer h.moveMonitorMu.Unlock()
+
+	if h.system == nil {
+		return derrors.New(derrors.CodeNotSupported, "system port unavailable")
+	}
+
+	if h.actionService == nil {
+		return derrors.New(derrors.CodeActionFailed, "action service not available")
+	}
+
+	names, err := h.system.ScreenNames(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(names) == 0 {
+		return derrors.New(derrors.CodeInvalidInput, "no monitors detected")
+	}
+
+	bounds, found, err := h.system.ScreenBoundsByName(ctx, monitorName)
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		return derrors.Newf(derrors.CodeInvalidInput, "monitor not found: %s", monitorName)
+	}
+
+	center := image.Point{
+		X: bounds.Min.X + bounds.Dx()/2 + offsetX,
+		Y: bounds.Min.Y + bounds.Dy()/2 + offsetY,
+	}
+
+	hasActiveOverlay := h.appState.CurrentMode() != domain.ModeIdle
+	if hasActiveOverlay && h.overlayManager != nil {
+		h.overlayManager.Hide()
+	}
+
+	err = h.actionService.MoveCursorToPointAndWait(ctx, center, true)
+	if err != nil {
+		if hasActiveOverlay && h.overlayManager != nil {
+			h.overlayManager.Show()
+		}
+
+		return err
+	}
+
+	h.logger.Info("Moved cursor to monitor by name",
+		zap.String("monitor", monitorName),
+		zap.Int("x", center.X),
+		zap.Int("y", center.Y),
+	)
+
+	h.refreshActiveModeOnNewScreen(ctx, bounds)
 
 	return nil
 }

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -131,7 +131,12 @@ func (h *Handler) MoveMonitorByName(
 	}
 
 	if !found {
-		return derrors.Newf(derrors.CodeInvalidInput, "monitor not found: %s", monitorName)
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"monitor not found: %s, available: %s",
+			monitorName,
+			strings.Join(names, ", "),
+		)
 	}
 
 	center := image.Point{

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -103,7 +103,6 @@ func (h *Handler) MoveMonitor(
 func (h *Handler) MoveMonitorByName(
 	ctx context.Context,
 	monitorName string,
-	offsetX, offsetY int,
 ) error {
 	h.moveMonitorMu.Lock()
 	defer h.moveMonitorMu.Unlock()
@@ -140,8 +139,8 @@ func (h *Handler) MoveMonitorByName(
 	}
 
 	center := image.Point{
-		X: bounds.Min.X + bounds.Dx()/2 + offsetX,
-		Y: bounds.Min.Y + bounds.Dy()/2 + offsetY,
+		X: bounds.Min.X + bounds.Dx()/2,
+		Y: bounds.Min.Y + bounds.Dy()/2,
 	}
 
 	hasActiveOverlay := h.appState.CurrentMode() != domain.ModeIdle

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -256,7 +256,6 @@ func BuildMoveMouseCommand() *cobra.Command {
 	var (
 		targetX, targetY int
 		center           bool
-		monitor          string
 		selection        bool
 		bare             bool
 	)
@@ -268,37 +267,17 @@ func BuildMoveMouseCommand() *cobra.Command {
 Coordinates are relative to the current display.
 When --center is used, the cursor moves to the center of the active screen.
 If --x and --y are also provided with --center, they act as offsets from center.
-When --monitor is used with --center, the cursor moves to the center of the
-named monitor instead of the active screen. Monitor names are matched
-case-insensitively against the localized display names reported by macOS
-(e.g. "Built-in Retina Display", "DELL U2720Q"). Without coordinates,
-move_mouse targets the active mode selection by default when one exists.
+Without coordinates, move_mouse targets the active mode selection by default when one exists.
 Use --bare to force current-cursor targeting.`,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			return requiresRunningInstance()
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			hasMonitor := cmd.Flags().Changed("monitor")
-
-			if hasMonitor && monitor == "" {
-				return derrors.New(
-					derrors.CodeInvalidInput,
-					"--monitor value must not be empty",
-				)
-			}
-
-			if hasMonitor && !center {
-				return derrors.New(
-					derrors.CodeInvalidInput,
-					"--monitor requires --center",
-				)
-			}
-
 			if selection &&
-				(center || hasMonitor || cmd.Flags().Changed("x") || cmd.Flags().Changed("y")) {
+				(center || cmd.Flags().Changed("x") || cmd.Flags().Changed("y")) {
 				return derrors.New(
 					derrors.CodeInvalidInput,
-					"--selection cannot be combined with --x, --y, --center, or --monitor",
+					"--selection cannot be combined with --x, --y, or --center",
 				)
 			}
 
@@ -322,10 +301,6 @@ Use --bare to force current-cursor targeting.`,
 
 			if center {
 				args = append(args, "--center")
-			}
-
-			if hasMonitor {
-				args = append(args, "--monitor="+monitor)
 			}
 
 			if cmd.Flags().Changed("x") {
@@ -357,8 +332,6 @@ Use --bare to force current-cursor targeting.`,
 		BoolVar(&selection, "selection", false, "Explicitly move to the active mode selection")
 	cmd.Flags().
 		BoolVar(&bare, "bare", false, "Use the current cursor position when no explicit target is provided")
-	cmd.Flags().StringVar(&monitor, "monitor", "",
-		"Target monitor by display name (requires --center); e.g. \"Built-in Retina Display\"")
 
 	return cmd
 }
@@ -407,37 +380,53 @@ func BuildScrollActionCommand(use, short, long string) *cobra.Command {
 }
 
 // BuildMoveMonitorCommand creates a move_monitor cobra command that moves the
-// cursor (and any active overlay) to the next or previous monitor.
-//
-// To jump to a specific named display, use
-// `neru action move_mouse --center --monitor=<name>` instead.
+// cursor (and any active overlay) to a specific monitor by name, or cycles
+// through monitors.
 func BuildMoveMonitorCommand() *cobra.Command {
 	var usePrevious bool
 
 	cmd := &cobra.Command{
 		Use:   "move_monitor",
 		Short: "Move cursor and overlay to another monitor",
-		Long: `Move the cursor, and any active mode overlay (hints/grid/recursive-grid), to the next or previous connected monitor.
+		Long: `Move the cursor, and any active mode overlay (hints/grid/recursive-grid), to another monitor.
 
-By default the cursor advances to the next monitor in the list returned by the operating system. Use --previous to step backwards.
+Usage:
+  - move_monitor <monitor-name>  Move to a specific monitor by name
+  - move_monitor cycle           Move to the next monitor
+  - move_monitor cycle --previous  Move to the previous monitor
 
-To jump directly to a named display, use "neru action move_mouse --center --monitor=<name>" instead.`,
+Monitor names are matched case-insensitively against the localized display names
+reported by macOS (e.g. "Built-in Retina Display", "DELL U2720Q").`,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			return requiresRunningInstance()
 		},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			args := []string{"move_monitor"}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			actionArgs := []string{"move_monitor"}
 
-			if usePrevious {
-				args = append(args, "--previous")
+			if len(args) == 0 {
+				return derrors.New(
+					derrors.CodeInvalidInput,
+					"move_monitor requires a monitor name or 'cycle'",
+				)
 			}
 
-			return sendCommand(cmd, "action", args)
+			arg := args[0]
+
+			if arg == "cycle" {
+				actionArgs = append(actionArgs, "cycle")
+				if usePrevious {
+					actionArgs = append(actionArgs, "--previous")
+				}
+			} else {
+				actionArgs = append(actionArgs, arg)
+			}
+
+			return sendCommand(cmd, "action", actionArgs)
 		},
 	}
 
 	cmd.Flags().
-		BoolVar(&usePrevious, "previous", false, "Cycle to the previous monitor instead of the next one")
+		BoolVar(&usePrevious, "previous", false, "With 'cycle', move to the previous monitor instead of the next one")
 
 	return cmd
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -383,50 +383,59 @@ func BuildScrollActionCommand(use, short, long string) *cobra.Command {
 // cursor (and any active overlay) to a specific monitor by name, or cycles
 // through monitors.
 func BuildMoveMonitorCommand() *cobra.Command {
-	var usePrevious bool
+	var (
+		monitorName string
+		usePrevious bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "move_monitor",
 		Short: "Move cursor and overlay to another monitor",
 		Long: `Move the cursor, and any active mode overlay (hints/grid/recursive-grid), to another monitor.
 
-Usage:
-  - move_monitor <monitor-name>  Move to a specific monitor by name
-  - move_monitor cycle           Move to the next monitor
-  - move_monitor cycle --previous  Move to the previous monitor
+By default, cycles to the next monitor. Use --previous to cycle backwards.
+Use --name to jump directly to a specific display by name.
 
 Monitor names are matched case-insensitively against the localized display names
 reported by macOS (e.g. "Built-in Retina Display", "DELL U2720Q").`,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			return requiresRunningInstance()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			actionArgs := []string{"move_monitor"}
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			hasName := cmd.Flags().Changed("name")
 
-			if len(args) == 0 {
+			if hasName && monitorName == "" {
 				return derrors.New(
 					derrors.CodeInvalidInput,
-					"move_monitor requires a monitor name or 'cycle'",
+					"--name value must not be empty",
 				)
 			}
 
-			arg := args[0]
+			if hasName && usePrevious {
+				return derrors.New(
+					derrors.CodeInvalidInput,
+					"--previous cannot be used with --name",
+				)
+			}
 
-			if arg == "cycle" {
-				actionArgs = append(actionArgs, "cycle")
-				if usePrevious {
-					actionArgs = append(actionArgs, "--previous")
-				}
-			} else {
-				actionArgs = append(actionArgs, arg)
+			actionArgs := []string{"move_monitor"}
+
+			if hasName {
+				actionArgs = append(actionArgs, "--name="+monitorName)
+			}
+
+			if usePrevious {
+				actionArgs = append(actionArgs, "--previous")
 			}
 
 			return sendCommand(cmd, "action", actionArgs)
 		},
 	}
 
+	cmd.Flags().StringVar(&monitorName, "name", "",
+		"Target monitor by display name (e.g. \"Built-in Retina Display\")")
 	cmd.Flags().
-		BoolVar(&usePrevious, "previous", false, "With 'cycle', move to the previous monitor instead of the next one")
+		BoolVar(&usePrevious, "previous", false, "Cycle to the previous monitor instead of the next one")
 
 	return cmd
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR consolidates all monitor movement functionality into the `move_monitor` action, removing the `--monitor` flag from `move_mouse --center`.

New cli usage:

```bash
neru action move_monitor                                    # cycle next (default)
neru action move_monitor --previous                         # cycle previous
neru action move_monitor --name "DELL U2720Q"               # jump to named monitor
neru action move_monitor --name "Built-in Retina Display"   # jump to named monitor
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Fixes #705

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/y3owk1n/neru/pull/706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
