### PR TITLE
fix(sticky_modifier): prevent from misfiring on multi-modifier hotkey activation

### DIFF
--- a/internal/app/modes/modifier_toggle.go
+++ b/internal/app/modes/modifier_toggle.go
@@ -16,8 +16,11 @@ const modifierTogglePrefix = "__modifier_"
 // before we commit a sticky toggle. If a regular key arrives in this window,
 // the tap is treated as part of a combo instead of a sticky toggle.
 const (
-	modifierToggleDebounce              = 50 * time.Millisecond
-	activationModifierSuppressionWindow = 300 * time.Millisecond
+	modifierToggleDebounce = 50 * time.Millisecond
+	// Keep launch-hotkey modifiers suppressed long enough that users can
+	// comfortably hold Cmd/Shift after entering a mode without their eventual
+	// release being reinterpreted as a fresh sticky-modifier tap.
+	activationModifierSuppressionWindow = 2 * time.Second
 )
 
 var modifierToggleMap = map[string]action.Modifiers{

--- a/internal/core/infra/platform/darwin/eventtap_darwin.m
+++ b/internal/core/infra/platform/darwin/eventtap_darwin.m
@@ -346,6 +346,7 @@ CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 			detectionArmed = context->stickyModifierDetectionArmed;
 			if (!detectionArmed && stickyFlags == 0) {
 				context->stickyModifierDetectionArmed = YES;
+				context->modifierChordFlags = 0;
 			}
 			os_unfair_lock_unlock(&context->stickyModifierLock);
 
@@ -770,14 +771,9 @@ void setEventTapStickyModifierToggle(EventTap tap, int enabled) {
 	os_unfair_lock_lock(&context->stickyModifierLock);
 	context->stickyModifierToggleEnabled = enabled != 0;
 	if (enabled) {
-		// Seed previousFlags with the current modifier state so the upcoming
-		// modifier changes are compared against the live session state.
-		// Also mark any modifiers already held at activation time as chord state
-		// so their release cannot be misclassified as a fresh sticky tap when a
-		// mode is launched from a multi-modifier global hotkey.
 		context->previousFlags = CGEventSourceFlagsState(kCGEventSourceStateCombinedSessionState);
-		context->modifierChordFlags = context->previousFlags & kStickyModifierMask;
-		context->stickyModifierDetectionArmed = (context->modifierChordFlags == 0);
+		context->modifierChordFlags = 0;
+		context->stickyModifierDetectionArmed = (context->previousFlags & kStickyModifierMask) == 0;
 	} else {
 		context->previousFlags = 0;
 		context->modifierChordFlags = 0;

--- a/internal/core/infra/platform/darwin/eventtap_darwin.m
+++ b/internal/core/infra/platform/darwin/eventtap_darwin.m
@@ -34,6 +34,7 @@ typedef struct {
 	os_unfair_lock modifierPassthroughLock;                  ///< Lock for modifier passthrough config
 	CGEventFlags previousFlags;                              ///< Previous modifier flags for toggle detection
 	CGEventFlags modifierChordFlags;    ///< Modifiers used in a key chord and not eligible for sticky on release
+	BOOL stickyModifierDetectionArmed;  ///< Whether sticky modifier callbacks are armed for this mode session
 	BOOL stickyModifierToggleEnabled;   ///< Whether to emit __modifier_ events
 	os_unfair_lock stickyModifierLock;  ///< Lock for sticky modifier toggle config
 	dispatch_block_t __strong pendingAddSourceBlock;  ///< Pending add source block
@@ -41,6 +42,9 @@ typedef struct {
 
 /// Global event tap context for layout-change rebuild (single instance expected)
 static EventTapContext *gEventTapContext = nil;
+
+static const CGEventFlags kStickyModifierMask =
+    kCGEventFlagMaskCommand | kCGEventFlagMaskShift | kCGEventFlagMaskAlternate | kCGEventFlagMaskControl;
 
 static inline NSUInteger hotkeyLookupKey(CGKeyCode keyCode, CGEventFlags flags) {
 	uint8_t modifiers = 0;
@@ -328,18 +332,32 @@ CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 		// toggle only when keyup arrives without any intervening regular key.
 		if (type == kCGEventFlagsChanged) {
 			CGEventFlags flags = CGEventGetFlags(event);
+			CGEventFlags stickyFlags = flags & kStickyModifierMask;
 
 			// Read/write previousFlags under stickyModifierLock to avoid racing
 			// with setEventTapStickyModifierToggle which also writes it.
 			BOOL stickyEnabled = NO;
+			BOOL detectionArmed = NO;
 			CGEventFlags changed;
 			os_unfair_lock_lock(&context->stickyModifierLock);
 			stickyEnabled = context->stickyModifierToggleEnabled;
 			changed = flags ^ context->previousFlags;
 			context->previousFlags = flags;
+			detectionArmed = context->stickyModifierDetectionArmed;
+			if (!detectionArmed && stickyFlags == 0) {
+				context->stickyModifierDetectionArmed = YES;
+			}
 			os_unfair_lock_unlock(&context->stickyModifierLock);
 
 			if (!stickyEnabled) {
+				return event;
+			}
+
+			// Ignore modifier changes from the launch chord until the keyboard
+			// reaches a clean slate with no physical modifiers held. This makes
+			// multi-modifier hotkey activation reliable even if the user keeps
+			// holding Cmd/Shift for a while after the mode appears.
+			if (!detectionArmed) {
 				return event;
 			}
 
@@ -548,6 +566,7 @@ EventTap createEventTap(EventTapCallback callback, void *userData) {
 	context->passthroughUnboundedModifiers = NO;
 	context->previousFlags = 0;
 	context->modifierChordFlags = 0;
+	context->stickyModifierDetectionArmed = NO;
 	context->stickyModifierToggleEnabled = NO;
 	context->stickyModifierLock = OS_UNFAIR_LOCK_INIT;
 
@@ -753,11 +772,16 @@ void setEventTapStickyModifierToggle(EventTap tap, int enabled) {
 	if (enabled) {
 		// Seed previousFlags with the current modifier state so the upcoming
 		// modifier changes are compared against the live session state.
+		// Also mark any modifiers already held at activation time as chord state
+		// so their release cannot be misclassified as a fresh sticky tap when a
+		// mode is launched from a multi-modifier global hotkey.
 		context->previousFlags = CGEventSourceFlagsState(kCGEventSourceStateCombinedSessionState);
-		context->modifierChordFlags = 0;
+		context->modifierChordFlags = context->previousFlags & kStickyModifierMask;
+		context->stickyModifierDetectionArmed = (context->modifierChordFlags == 0);
 	} else {
 		context->previousFlags = 0;
 		context->modifierChordFlags = 0;
+		context->stickyModifierDetectionArmed = NO;
 	}
 	os_unfair_lock_unlock(&context->stickyModifierLock);
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes an issue where releasing modifiers held during a multi-modifier global hotkey activation would incorrectly trigger sticky modifier toggle behavior. When a user enters a mode via a hotkey (e.g., Cmd+Shift+Space) while still holding Cmd+Shift, their release of those keys after the mode appears would be misinterpreted as fresh sticky modifier taps.

**Root cause**: The event tap was not accounting for modifiers already held when the mode was activated—these were indistinguishable from new modifier keypresses after mode entry.

**Solution**: Added detection state that tracks whether the user arrived at a mode with modifiers held (from the activation hotkey chord). The system now:

1. Arms sticky modifier detection only after all modifiers are released
2. Tracks which modifiers were held at activation time as "chord state"
3. Ignores their release from being classified as fresh sticky taps
4. Increased the activation suppression window from 300ms to 2 seconds to handle slower users

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
