### PR TITLE
chore(ci,nightly): upsert nightly release instead of creating it all the time

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,7 +69,9 @@ jobs:
 
                       gh release edit nightly \
                         --target "${GITHUB_SHA}" \
-                        --notes-file "${NOTES_FILE}"
+                        --notes-file "${NOTES_FILE}" \
+                        --prerelease \
+                        --latest=false
                   else
                       gh release create nightly \
                         --target "${GITHUB_SHA}" \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,7 @@ jobs:
                   echo "macos_bundle_version=${TIMESTAMP}" >> "$GITHUB_OUTPUT"
                   echo "macos_short_version=0.0.0" >> "$GITHUB_OUTPUT"
 
-            - name: Recreate nightly release
+            - name: Ensure nightly release exists
               env:
                   GH_TOKEN: ${{ github.token }}
               run: |
@@ -65,28 +65,18 @@ jobs:
                   If nightly regresses, please include the commit above when filing an issue so we can narrow it down faster.
                   EOF
 
-                  gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
+                  if gh release view nightly &>/dev/null; then
 
-                  for attempt in 1 2 3; do
-                    gh release create nightly \
-                      --target "${GITHUB_SHA}" \
-                      --title "Neru Nightly" \
-                      --notes-file "${NOTES_FILE}" \
-                      --prerelease \
-                      --latest=false && break
-                    if [ "${attempt}" -eq 3 ]; then
-                      echo "All ${attempt} attempts to create release failed, giving up."
-                      exit 1
-                    fi
-                    echo "Attempt ${attempt} failed, retrying in 5s..."
-                    sleep 5
-                  done
-
-                  DRAFT="$(gh release view nightly --json isDraft --jq '.isDraft')"
-
-                  if [ "${DRAFT}" = "true" ]; then
-                    echo "Release is in draft state, fixing..."
-                    gh release edit nightly --draft=false
+                      gh release edit nightly \
+                        --target "${GITHUB_SHA}" \
+                        --notes-file "${NOTES_FILE}"
+                  else
+                      gh release create nightly \
+                        --target "${GITHUB_SHA}" \
+                        --title "Neru Nightly" \
+                        --notes-file "${NOTES_FILE}" \
+                        --prerelease \
+                        --latest=false
                   fi
 
     publish-nightly-artifacts:


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR changes the nightly release workflow to use an upsert pattern instead of deleting and recreating the release every run.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
