### PR TITLE
feat(recursive-grid): add training mode

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -150,6 +150,11 @@ max_depth = 10                              # Maximum recursion levels (1–20)
 enabled = false                            # Opt in to native depth transition animation on supported platforms
 duration_ms = 180                          # Recursive-grid animation duration in milliseconds
 
+[recursive_grid.training]
+enabled = true                             # Allow `neru recursive_grid --training` and the systray training entry
+hits_to_hide = 3                           # Hide a cell label after this many correct answers
+penalty_on_error = 1                       # Hits removed from the current target after a wrong key
+
 [recursive_grid.hotkeys]
 "Escape" = "idle"
 "`" = "toggle-cursor-follow-selection"

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,11 +4,21 @@ import (
 	"context"
 
 	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/app/modes"
 )
 
 // ActivateMode activates the specified mode.
 func (a *App) ActivateMode(mode Mode) {
 	a.modes.ActivateMode(mode)
+}
+
+// ActivateRecursiveGridTraining starts recursive-grid training mode using the
+// configured top-level recursive-grid layout.
+func (a *App) ActivateRecursiveGridTraining() {
+	a.modes.ActivateModeWithOptions(ModeRecursiveGrid, modes.ModeActivationOptions{
+		Training: true,
+	})
 }
 
 // IsFocusedAppExcluded checks if the focused app is excluded.

--- a/internal/app/app_getters.go
+++ b/internal/app/app_getters.go
@@ -58,6 +58,13 @@ func (a *App) RecursiveGridEnabled() bool {
 	return cfg != nil && cfg.RecursiveGrid.Enabled
 }
 
+// RecursiveGridTrainingEnabled returns true if recursive-grid training is enabled.
+func (a *App) RecursiveGridTrainingEnabled() bool {
+	cfg := a.configSnapshot()
+
+	return cfg != nil && cfg.RecursiveGrid.Enabled && cfg.RecursiveGrid.Training.Enabled
+}
+
 // Config returns the application configuration.
 func (a *App) Config() *config.Config {
 	return a.configSnapshot()

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -23,10 +23,11 @@ type Mode = domain.Mode
 
 // Mode constants from domain package.
 const (
-	ModeIdle   = domain.ModeIdle
-	ModeHints  = domain.ModeHints
-	ModeGrid   = domain.ModeGrid
-	ModeScroll = domain.ModeScroll
+	ModeIdle          = domain.ModeIdle
+	ModeHints         = domain.ModeHints
+	ModeGrid          = domain.ModeGrid
+	ModeRecursiveGrid = domain.ModeRecursiveGrid
+	ModeScroll        = domain.ModeScroll
 )
 
 // SystrayComponent defines the interface for systray functionality.

--- a/internal/app/components/recursivegrid/overlay_darwin.go
+++ b/internal/app/components/recursivegrid/overlay_darwin.go
@@ -375,8 +375,8 @@ func (o *Overlay) DrawRecursiveGrid(
 		subKeyKeys:                  o.getOrCacheLabel(subKeyKeysUpper),
 	}
 
-	shouldAnimate := o.Config().Animation.Enabled && o.hasLast && depth != o.lastDepth &&
-		!o.lastBounds.Empty()
+	shouldAnimate := o.Config().Animation.Enabled && matchedIndex < 0 &&
+		o.hasLast && depth != o.lastDepth && !o.lastBounds.Empty()
 	transitionDurationSeconds := float64(o.Config().Animation.DurationMS) / millisecondsPerSecond
 	if shouldAnimate {
 		C.NeruAnimateRecursiveGridTransition(

--- a/internal/app/components/recursivegrid/overlay_darwin.go
+++ b/internal/app/components/recursivegrid/overlay_darwin.go
@@ -233,6 +233,7 @@ func (o *Overlay) DrawRecursiveGrid(
 	nextKeys string,
 	nextGridCols int,
 	nextGridRows int,
+	matchedIndex int,
 	style Style,
 	virtualPointer VirtualPointerState,
 ) error {
@@ -319,12 +320,16 @@ func (o *Overlay) DrawRecursiveGrid(
 				labelStr = string(keyRunes[idx])
 			}
 			label := strings.ToUpper(labelStr)
+			matchedPrefixLength := 0
+			if idx == matchedIndex && label != "" {
+				matchedPrefixLength = len([]rune(label))
+			}
 			cells[idx] = C.GridCell{
 				label:               o.getOrCacheLabel(label),
 				bounds:              o.rectToCRect(cell),
-				isMatched:           C.int(0),
+				isMatched:           C.int(boolToInt(idx == matchedIndex)),
 				isSubgrid:           C.int(0),
-				matchedPrefixLength: C.int(0),
+				matchedPrefixLength: C.int(matchedPrefixLength),
 			}
 		}
 	}
@@ -338,9 +343,9 @@ func (o *Overlay) DrawRecursiveGrid(
 		cached.BgColor = unsafe.Pointer(C.CString(style.HighlightColor()))
 		cached.LabelBgColor = unsafe.Pointer(C.CString(style.LabelBackgroundColor()))
 		cached.TextColor = unsafe.Pointer(C.CString(style.TextColor()))
-		cached.MatchedTextColor = unsafe.Pointer(C.CString(style.TextColor()))
-		cached.MatchedBgColor = unsafe.Pointer(C.CString(style.HighlightColor()))
-		cached.MatchedBorderColor = unsafe.Pointer(C.CString(style.LineColor()))
+		cached.MatchedTextColor = unsafe.Pointer(C.CString(style.MatchedTextColor()))
+		cached.MatchedBgColor = unsafe.Pointer(C.CString(style.MatchedBackgroundColor()))
+		cached.MatchedBorderColor = unsafe.Pointer(C.CString(style.MatchedBorderColor()))
 		cached.BorderColor = unsafe.Pointer(C.CString(style.LineColor()))
 		cached.SubKeyTextColor = unsafe.Pointer(C.CString(style.SubKeyPreviewTextColor()))
 	})
@@ -488,6 +493,9 @@ type Style struct {
 	lineColor                       string
 	lineWidth                       int
 	highlightColor                  string
+	matchedTextColor                string
+	matchedBackgroundColor          string
+	matchedBorderColor              string
 	textColor                       string
 	fontSize                        int
 	fontFamily                      string
@@ -516,6 +524,21 @@ func (s Style) LineWidth() int {
 // HighlightColor returns the highlight color.
 func (s Style) HighlightColor() string {
 	return s.highlightColor
+}
+
+// MatchedTextColor returns the emphasized text color for the active target cell.
+func (s Style) MatchedTextColor() string {
+	return s.matchedTextColor
+}
+
+// MatchedBackgroundColor returns the emphasized background color for the active target cell.
+func (s Style) MatchedBackgroundColor() string {
+	return s.matchedBackgroundColor
+}
+
+// MatchedBorderColor returns the emphasized border color for the active target cell.
+func (s Style) MatchedBorderColor() string {
+	return s.matchedBorderColor
 }
 
 // TextColor returns the text color.
@@ -599,6 +622,21 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 			config.RecursiveGridHighlightColorLight,
 			config.RecursiveGridHighlightColorDark,
 		),
+		matchedTextColor: pickThemedColor(
+			theme,
+			config.GridMatchedTextColorLight,
+			config.GridMatchedTextColorDark,
+		),
+		matchedBackgroundColor: pickThemedColor(
+			theme,
+			config.GridMatchedBackgroundColorLight,
+			config.GridMatchedBackgroundColorDark,
+		),
+		matchedBorderColor: pickThemedColor(
+			theme,
+			config.GridMatchedBorderColorLight,
+			config.GridMatchedBorderColorDark,
+		),
 		textColor: cfg.UI.TextColor.ForTheme(
 			theme,
 			config.RecursiveGridTextColorLight,
@@ -625,4 +663,12 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 			config.RecursiveGridSubKeyPreviewTextColorDark,
 		),
 	}
+}
+
+func pickThemedColor(theme config.ThemeProvider, light, dark string) string {
+	if theme != nil && theme.IsDarkMode() {
+		return dark
+	}
+
+	return light
 }

--- a/internal/app/components/recursivegrid/training.go
+++ b/internal/app/components/recursivegrid/training.go
@@ -13,6 +13,7 @@ type TrainingResult int
 
 const (
 	TrainingResultIgnored TrainingResult = iota
+	TrainingResultAdvanceDepth
 	TrainingResultCorrect
 	TrainingResultWrong
 	TrainingResultCompleted
@@ -20,48 +21,98 @@ const (
 
 // TrainingSession stores the lightweight state needed for recursive-grid
 // memorization drills without changing the normal recursive-grid manager.
+//
+// When second-depth training is enabled, each drill is a pair:
+// 1. choose the highlighted top-level cell
+// 2. choose the highlighted second-depth cell inside it
+//
+// Progress is tracked per pair. A top-level label is hidden only after all
+// second-depth targets inside that cell are learned.
 type TrainingSession struct {
-	keys           []rune
-	normalizedKeys []string
-	hits           []int
-	hitsToHide     int
-	penaltyOnError int
-	targetIndex    int
-	lastTarget     int
-	rng            *rand.Rand
-	active         bool
+	firstKeys                 []rune
+	firstNormalizedKeys       []string
+	secondKeys                []rune
+	secondNormalizedKeys      []string
+	hits                      [][]int
+	hitsToHide                int
+	penaltyOnError            int
+	targetFirstIndex          int
+	targetSecondIndex         int
+	lastFirstIndex            int
+	lastSecondIndex           int
+	secondDepthTrainingActive bool
+	inSecondDepth             bool
+	rng                       *rand.Rand
+	active                    bool
 }
 
-// NewTrainingSession creates a new training session from the configured top-level key layout.
-func NewTrainingSession(keys string, hitsToHide, penaltyOnError int) *TrainingSession {
-	keyRunes := []rune(keys)
-	normalizedKeys := make([]string, len(keyRunes))
-	for idx, keyRune := range keyRunes {
-		normalizedKeys[idx] = strings.ToLower(
+// NewTrainingSession creates a new training session from the configured recursive-grid layouts.
+func NewTrainingSession(
+	firstKeys string,
+	secondKeys string,
+	secondDepthTrainingActive bool,
+	hitsToHide int,
+	penaltyOnError int,
+) *TrainingSession {
+	firstRunes := []rune(firstKeys)
+	firstNormalized := normalizeTrainingKeys(firstRunes)
+
+	secondRunes := []rune(secondKeys)
+	secondNormalized := normalizeTrainingKeys(secondRunes)
+
+	if !secondDepthTrainingActive || len(secondRunes) == 0 {
+		secondDepthTrainingActive = false
+		secondRunes = []rune{' '}
+		secondNormalized = []string{""}
+	}
+
+	hits := make([][]int, len(firstRunes))
+	for idx := range hits {
+		hits[idx] = make([]int, len(secondRunes))
+	}
+
+	session := &TrainingSession{
+		firstKeys:                 firstRunes,
+		firstNormalizedKeys:       firstNormalized,
+		secondKeys:                secondRunes,
+		secondNormalizedKeys:      secondNormalized,
+		hits:                      hits,
+		hitsToHide:                hitsToHide,
+		penaltyOnError:            penaltyOnError,
+		targetFirstIndex:          -1,
+		targetSecondIndex:         -1,
+		lastFirstIndex:            -1,
+		lastSecondIndex:           -1,
+		secondDepthTrainingActive: secondDepthTrainingActive,
+		rng:                       rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec
+		active:                    true,
+	}
+
+	session.selectNextTargetPair()
+
+	return session
+}
+
+func normalizeTrainingKeys(keys []rune) []string {
+	normalized := make([]string, len(keys))
+	for idx, keyRune := range keys {
+		normalized[idx] = strings.ToLower(
 			configpkg.NormalizeKeyForComparison(string(keyRune)),
 		)
 	}
 
-	session := &TrainingSession{
-		keys:           keyRunes,
-		normalizedKeys: normalizedKeys,
-		hits:           make([]int, len(keyRunes)),
-		hitsToHide:     hitsToHide,
-		penaltyOnError: penaltyOnError,
-		targetIndex:    -1,
-		lastTarget:     -1,
-		rng:            rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec
-		active:         true,
-	}
-
-	session.selectNextTarget()
-
-	return session
+	return normalized
 }
 
 // Active reports whether the session is still in progress.
 func (s *TrainingSession) Active() bool {
 	return s != nil && s.active
+}
+
+// InSecondDepth reports whether the session is currently waiting for the
+// second step of the current drill.
+func (s *TrainingSession) InSecondDepth() bool {
+	return s != nil && s.inSecondDepth
 }
 
 // Reset restarts the session while preserving the configured training rules.
@@ -70,14 +121,19 @@ func (s *TrainingSession) Reset() {
 		return
 	}
 
-	for idx := range s.hits {
-		s.hits[idx] = 0
+	for firstIdx := range s.hits {
+		for secondIdx := range s.hits[firstIdx] {
+			s.hits[firstIdx][secondIdx] = 0
+		}
 	}
 
 	s.active = true
-	s.targetIndex = -1
-	s.lastTarget = -1
-	s.selectNextTarget()
+	s.inSecondDepth = false
+	s.targetFirstIndex = -1
+	s.targetSecondIndex = -1
+	s.lastFirstIndex = -1
+	s.lastSecondIndex = -1
+	s.selectNextTargetPair()
 }
 
 // HandleKey validates a key press against the active training target.
@@ -87,106 +143,218 @@ func (s *TrainingSession) HandleKey(key string) TrainingResult {
 	}
 
 	normalized := strings.ToLower(configpkg.NormalizeKeyForComparison(key))
-	if normalized == "" || s.targetIndex < 0 || s.targetIndex >= len(s.normalizedKeys) {
+	if normalized == "" {
 		return TrainingResultIgnored
 	}
 
-	if normalized == s.normalizedKeys[s.targetIndex] {
-		s.hits[s.targetIndex]++
-		s.lastTarget = s.targetIndex
-		s.selectNextTarget()
-		if !s.active {
-			return TrainingResultCompleted
+	if s.inSecondDepth {
+		if s.targetSecondIndex < 0 || s.targetSecondIndex >= len(s.secondNormalizedKeys) {
+			return TrainingResultIgnored
 		}
 
-		return TrainingResultCorrect
-	}
+		if normalized != s.secondNormalizedKeys[s.targetSecondIndex] {
+			s.applyPenalty()
 
-	if s.penaltyOnError > 0 {
-		s.hits[s.targetIndex] -= s.penaltyOnError
-		if s.hits[s.targetIndex] < 0 {
-			s.hits[s.targetIndex] = 0
+			return TrainingResultWrong
 		}
+
+		return s.completeCurrentTarget()
 	}
 
-	return TrainingResultWrong
+	if s.targetFirstIndex < 0 || s.targetFirstIndex >= len(s.firstNormalizedKeys) {
+		return TrainingResultIgnored
+	}
+
+	if normalized != s.firstNormalizedKeys[s.targetFirstIndex] {
+		s.applyPenalty()
+
+		return TrainingResultWrong
+	}
+
+	if s.secondDepthTrainingActive {
+		s.inSecondDepth = true
+
+		return TrainingResultAdvanceDepth
+	}
+
+	return s.completeCurrentTarget()
 }
 
-// TargetIndex returns the active target index, or -1 if training is complete.
+func (s *TrainingSession) completeCurrentTarget() TrainingResult {
+	s.hits[s.targetFirstIndex][s.targetSecondIndex]++
+	s.inSecondDepth = false
+	s.lastFirstIndex = s.targetFirstIndex
+	s.lastSecondIndex = s.targetSecondIndex
+	s.selectNextTargetPair()
+	if !s.active {
+		return TrainingResultCompleted
+	}
+
+	return TrainingResultCorrect
+}
+
+func (s *TrainingSession) applyPenalty() {
+	if s.penaltyOnError <= 0 || s.targetFirstIndex < 0 || s.targetSecondIndex < 0 {
+		return
+	}
+
+	s.hits[s.targetFirstIndex][s.targetSecondIndex] -= s.penaltyOnError
+	if s.hits[s.targetFirstIndex][s.targetSecondIndex] < 0 {
+		s.hits[s.targetFirstIndex][s.targetSecondIndex] = 0
+	}
+}
+
+// TargetIndex returns the active target index for the current step, or -1 if training is complete.
 func (s *TrainingSession) TargetIndex() int {
 	if s == nil {
 		return -1
 	}
 
-	return s.targetIndex
+	if s.inSecondDepth {
+		return s.targetSecondIndex
+	}
+
+	return s.targetFirstIndex
 }
 
-// OverlayKeys returns the configured keys with learned cells replaced by spaces
-// so the existing recursive-grid overlay can render them as hidden labels.
+// OverlayKeys returns the configured keys for the current training step with
+// learned labels replaced by spaces so the existing recursive-grid overlay can
+// render them as hidden labels.
 func (s *TrainingSession) OverlayKeys() string {
 	if s == nil {
 		return ""
 	}
 
-	overlayKeys := make([]rune, len(s.keys))
-	copy(overlayKeys, s.keys)
+	if s.inSecondDepth {
+		return s.secondDepthOverlayKeys()
+	}
 
-	for idx := range overlayKeys {
-		if s.hits[idx] >= s.hitsToHide {
-			overlayKeys[idx] = ' '
+	return s.firstDepthOverlayKeys()
+}
+
+func (s *TrainingSession) firstDepthOverlayKeys() string {
+	overlayKeys := make([]rune, len(s.firstKeys))
+	copy(overlayKeys, s.firstKeys)
+
+	for firstIdx := range overlayKeys {
+		if s.firstDepthLearned(firstIdx) {
+			overlayKeys[firstIdx] = ' '
 		}
 	}
 
 	return string(overlayKeys)
 }
 
-// Progress returns the number of learned cells and total cells.
+func (s *TrainingSession) secondDepthOverlayKeys() string {
+	overlayKeys := make([]rune, len(s.secondKeys))
+	copy(overlayKeys, s.secondKeys)
+
+	for secondIdx := range overlayKeys {
+		if s.hits[s.targetFirstIndex][secondIdx] >= s.hitsToHide {
+			overlayKeys[secondIdx] = ' '
+		}
+	}
+
+	return string(overlayKeys)
+}
+
+func (s *TrainingSession) firstDepthLearned(firstIdx int) bool {
+	if firstIdx < 0 || firstIdx >= len(s.hits) {
+		return false
+	}
+
+	for _, hits := range s.hits[firstIdx] {
+		if hits < s.hitsToHide {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Progress returns the number of learned drills and total drills.
 func (s *TrainingSession) Progress() (int, int) {
 	if s == nil {
 		return 0, 0
 	}
 
 	learned := 0
-	for _, hits := range s.hits {
-		if hits >= s.hitsToHide {
-			learned++
+	total := 0
+	for firstIdx := range s.hits {
+		for secondIdx := range s.hits[firstIdx] {
+			total++
+			if s.hits[firstIdx][secondIdx] >= s.hitsToHide {
+				learned++
+			}
 		}
 	}
 
-	return learned, len(s.hits)
+	return learned, total
 }
 
-func (s *TrainingSession) selectNextTarget() {
+func (s *TrainingSession) selectNextTargetPair() {
 	if s == nil {
 		return
 	}
 
-	candidates := make([]int, 0, len(s.hits))
-	for idx, hits := range s.hits {
-		if hits < s.hitsToHide {
-			candidates = append(candidates, idx)
+	firstCandidates := make([]int, 0, len(s.hits))
+	for firstIdx := range s.hits {
+		if !s.firstDepthLearned(firstIdx) {
+			firstCandidates = append(firstCandidates, firstIdx)
 		}
 	}
 
-	if len(candidates) == 0 {
-		s.targetIndex = -1
+	if len(firstCandidates) == 0 {
+		s.targetFirstIndex = -1
+		s.targetSecondIndex = -1
 		s.active = false
+		s.inSecondDepth = false
 
 		return
 	}
 
-	if len(candidates) > 1 && s.lastTarget >= 0 {
-		filtered := candidates[:0]
-		for _, idx := range candidates {
-			if idx != s.lastTarget {
+	if len(firstCandidates) > 1 && s.lastFirstIndex >= 0 {
+		filtered := firstCandidates[:0]
+		for _, idx := range firstCandidates {
+			if idx != s.lastFirstIndex {
 				filtered = append(filtered, idx)
 			}
 		}
 
 		if len(filtered) > 0 {
-			candidates = filtered
+			firstCandidates = filtered
 		}
 	}
 
-	s.targetIndex = candidates[s.rng.Intn(len(candidates))]
+	s.targetFirstIndex = firstCandidates[s.rng.Intn(len(firstCandidates))]
+	s.targetSecondIndex = s.selectSecondTarget(s.targetFirstIndex)
+	s.inSecondDepth = false
+}
+
+func (s *TrainingSession) selectSecondTarget(firstIdx int) int {
+	secondCandidates := make([]int, 0, len(s.hits[firstIdx]))
+	for secondIdx, hits := range s.hits[firstIdx] {
+		if hits < s.hitsToHide {
+			secondCandidates = append(secondCandidates, secondIdx)
+		}
+	}
+
+	if len(secondCandidates) == 0 {
+		return -1
+	}
+
+	if len(secondCandidates) > 1 && firstIdx == s.lastFirstIndex && s.lastSecondIndex >= 0 {
+		filtered := secondCandidates[:0]
+		for _, idx := range secondCandidates {
+			if idx != s.lastSecondIndex {
+				filtered = append(filtered, idx)
+			}
+		}
+
+		if len(filtered) > 0 {
+			secondCandidates = filtered
+		}
+	}
+
+	return secondCandidates[s.rng.Intn(len(secondCandidates))]
 }

--- a/internal/app/components/recursivegrid/training.go
+++ b/internal/app/components/recursivegrid/training.go
@@ -1,0 +1,192 @@
+package recursivegrid
+
+import (
+	"math/rand"
+	"strings"
+	"time"
+
+	configpkg "github.com/y3owk1n/neru/internal/config"
+)
+
+// TrainingResult describes the outcome of a training key press.
+type TrainingResult int
+
+const (
+	TrainingResultIgnored TrainingResult = iota
+	TrainingResultCorrect
+	TrainingResultWrong
+	TrainingResultCompleted
+)
+
+// TrainingSession stores the lightweight state needed for recursive-grid
+// memorization drills without changing the normal recursive-grid manager.
+type TrainingSession struct {
+	keys           []rune
+	normalizedKeys []string
+	hits           []int
+	hitsToHide     int
+	penaltyOnError int
+	targetIndex    int
+	lastTarget     int
+	rng            *rand.Rand
+	active         bool
+}
+
+// NewTrainingSession creates a new training session from the configured top-level key layout.
+func NewTrainingSession(keys string, hitsToHide, penaltyOnError int) *TrainingSession {
+	keyRunes := []rune(keys)
+	normalizedKeys := make([]string, len(keyRunes))
+	for idx, keyRune := range keyRunes {
+		normalizedKeys[idx] = strings.ToLower(
+			configpkg.NormalizeKeyForComparison(string(keyRune)),
+		)
+	}
+
+	session := &TrainingSession{
+		keys:           keyRunes,
+		normalizedKeys: normalizedKeys,
+		hits:           make([]int, len(keyRunes)),
+		hitsToHide:     hitsToHide,
+		penaltyOnError: penaltyOnError,
+		targetIndex:    -1,
+		lastTarget:     -1,
+		rng:            rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec
+		active:         true,
+	}
+
+	session.selectNextTarget()
+
+	return session
+}
+
+// Active reports whether the session is still in progress.
+func (s *TrainingSession) Active() bool {
+	return s != nil && s.active
+}
+
+// Reset restarts the session while preserving the configured training rules.
+func (s *TrainingSession) Reset() {
+	if s == nil {
+		return
+	}
+
+	for idx := range s.hits {
+		s.hits[idx] = 0
+	}
+
+	s.active = true
+	s.targetIndex = -1
+	s.lastTarget = -1
+	s.selectNextTarget()
+}
+
+// HandleKey validates a key press against the active training target.
+func (s *TrainingSession) HandleKey(key string) TrainingResult {
+	if s == nil || !s.active {
+		return TrainingResultIgnored
+	}
+
+	normalized := strings.ToLower(configpkg.NormalizeKeyForComparison(key))
+	if normalized == "" || s.targetIndex < 0 || s.targetIndex >= len(s.normalizedKeys) {
+		return TrainingResultIgnored
+	}
+
+	if normalized == s.normalizedKeys[s.targetIndex] {
+		s.hits[s.targetIndex]++
+		s.lastTarget = s.targetIndex
+		s.selectNextTarget()
+		if !s.active {
+			return TrainingResultCompleted
+		}
+
+		return TrainingResultCorrect
+	}
+
+	if s.penaltyOnError > 0 {
+		s.hits[s.targetIndex] -= s.penaltyOnError
+		if s.hits[s.targetIndex] < 0 {
+			s.hits[s.targetIndex] = 0
+		}
+	}
+
+	return TrainingResultWrong
+}
+
+// TargetIndex returns the active target index, or -1 if training is complete.
+func (s *TrainingSession) TargetIndex() int {
+	if s == nil {
+		return -1
+	}
+
+	return s.targetIndex
+}
+
+// OverlayKeys returns the configured keys with learned cells replaced by spaces
+// so the existing recursive-grid overlay can render them as hidden labels.
+func (s *TrainingSession) OverlayKeys() string {
+	if s == nil {
+		return ""
+	}
+
+	overlayKeys := make([]rune, len(s.keys))
+	copy(overlayKeys, s.keys)
+
+	for idx := range overlayKeys {
+		if s.hits[idx] >= s.hitsToHide {
+			overlayKeys[idx] = ' '
+		}
+	}
+
+	return string(overlayKeys)
+}
+
+// Progress returns the number of learned cells and total cells.
+func (s *TrainingSession) Progress() (int, int) {
+	if s == nil {
+		return 0, 0
+	}
+
+	learned := 0
+	for _, hits := range s.hits {
+		if hits >= s.hitsToHide {
+			learned++
+		}
+	}
+
+	return learned, len(s.hits)
+}
+
+func (s *TrainingSession) selectNextTarget() {
+	if s == nil {
+		return
+	}
+
+	candidates := make([]int, 0, len(s.hits))
+	for idx, hits := range s.hits {
+		if hits < s.hitsToHide {
+			candidates = append(candidates, idx)
+		}
+	}
+
+	if len(candidates) == 0 {
+		s.targetIndex = -1
+		s.active = false
+
+		return
+	}
+
+	if len(candidates) > 1 && s.lastTarget >= 0 {
+		filtered := candidates[:0]
+		for _, idx := range candidates {
+			if idx != s.lastTarget {
+				filtered = append(filtered, idx)
+			}
+		}
+
+		if len(filtered) > 0 {
+			candidates = filtered
+		}
+	}
+
+	s.targetIndex = candidates[s.rng.Intn(len(candidates))]
+}

--- a/internal/app/components/recursivegrid/training_test.go
+++ b/internal/app/components/recursivegrid/training_test.go
@@ -1,0 +1,81 @@
+package recursivegrid
+
+import "testing"
+
+func TestTrainingSessionWrongAnswerAppliesPenaltyAndHidesLearnedKeys(t *testing.T) {
+	session := NewTrainingSession("u", 2, 1)
+
+	if result := session.HandleKey("u"); result != TrainingResultCorrect {
+		t.Fatalf("first correct key result = %v, want %v", result, TrainingResultCorrect)
+	}
+
+	learned, total := session.Progress()
+	if learned != 0 || total != 1 {
+		t.Fatalf("progress after one hit = (%d, %d), want (0, 1)", learned, total)
+	}
+
+	if got := session.OverlayKeys(); got != "u" {
+		t.Fatalf("overlay keys after one hit = %q, want %q", got, "u")
+	}
+
+	if result := session.HandleKey("x"); result != TrainingResultWrong {
+		t.Fatalf("wrong key result = %v, want %v", result, TrainingResultWrong)
+	}
+
+	learned, total = session.Progress()
+	if learned != 0 || total != 1 {
+		t.Fatalf("progress after penalty = (%d, %d), want (0, 1)", learned, total)
+	}
+
+	if got := session.OverlayKeys(); got != "u" {
+		t.Fatalf("overlay keys after penalty = %q, want %q", got, "u")
+	}
+}
+
+func TestTrainingSessionCompleteAndReset(t *testing.T) {
+	session := NewTrainingSession("u", 2, 1)
+
+	if result := session.HandleKey("u"); result != TrainingResultCorrect {
+		t.Fatalf("first correct key result = %v, want %v", result, TrainingResultCorrect)
+	}
+
+	if result := session.HandleKey("u"); result != TrainingResultCompleted {
+		t.Fatalf("second correct key result = %v, want %v", result, TrainingResultCompleted)
+	}
+
+	if session.Active() {
+		t.Fatal("session should be inactive after completion")
+	}
+
+	if got := session.TargetIndex(); got != -1 {
+		t.Fatalf("target index after completion = %d, want -1", got)
+	}
+
+	if got := session.OverlayKeys(); got != " " {
+		t.Fatalf("overlay keys after completion = %q, want %q", got, " ")
+	}
+
+	learned, total := session.Progress()
+	if learned != 1 || total != 1 {
+		t.Fatalf("progress after completion = (%d, %d), want (1, 1)", learned, total)
+	}
+
+	session.Reset()
+
+	if !session.Active() {
+		t.Fatal("session should be active after reset")
+	}
+
+	if got := session.TargetIndex(); got != 0 {
+		t.Fatalf("target index after reset = %d, want 0", got)
+	}
+
+	if got := session.OverlayKeys(); got != "u" {
+		t.Fatalf("overlay keys after reset = %q, want %q", got, "u")
+	}
+
+	learned, total = session.Progress()
+	if learned != 0 || total != 1 {
+		t.Fatalf("progress after reset = (%d, %d), want (0, 1)", learned, total)
+	}
+}

--- a/internal/app/components/recursivegrid/training_test.go
+++ b/internal/app/components/recursivegrid/training_test.go
@@ -2,45 +2,60 @@ package recursivegrid
 
 import "testing"
 
-func TestTrainingSessionWrongAnswerAppliesPenaltyAndHidesLearnedKeys(t *testing.T) {
-	session := NewTrainingSession("u", 2, 1)
+func TestTrainingSessionSecondDepthWrongAnswerAppliesPenalty(t *testing.T) {
+	session := NewTrainingSession("u", "i", true, 2, 1)
 
-	if result := session.HandleKey("u"); result != TrainingResultCorrect {
-		t.Fatalf("first correct key result = %v, want %v", result, TrainingResultCorrect)
+	if result := session.HandleKey("u"); result != TrainingResultAdvanceDepth {
+		t.Fatalf("first-step result = %v, want %v", result, TrainingResultAdvanceDepth)
+	}
+
+	if !session.InSecondDepth() {
+		t.Fatal("session should be waiting for the second-depth key")
+	}
+
+	if got := session.OverlayKeys(); got != "i" {
+		t.Fatalf("second-depth overlay keys = %q, want %q", got, "i")
+	}
+
+	if result := session.HandleKey("x"); result != TrainingResultWrong {
+		t.Fatalf("wrong second-depth result = %v, want %v", result, TrainingResultWrong)
+	}
+
+	if !session.InSecondDepth() {
+		t.Fatal("session should stay in second-depth mode after a wrong answer")
 	}
 
 	learned, total := session.Progress()
 	if learned != 0 || total != 1 {
-		t.Fatalf("progress after one hit = (%d, %d), want (0, 1)", learned, total)
-	}
-
-	if got := session.OverlayKeys(); got != "u" {
-		t.Fatalf("overlay keys after one hit = %q, want %q", got, "u")
-	}
-
-	if result := session.HandleKey("x"); result != TrainingResultWrong {
-		t.Fatalf("wrong key result = %v, want %v", result, TrainingResultWrong)
-	}
-
-	learned, total = session.Progress()
-	if learned != 0 || total != 1 {
-		t.Fatalf("progress after penalty = (%d, %d), want (0, 1)", learned, total)
-	}
-
-	if got := session.OverlayKeys(); got != "u" {
-		t.Fatalf("overlay keys after penalty = %q, want %q", got, "u")
+		t.Fatalf("progress after wrong second-depth key = (%d, %d), want (0, 1)", learned, total)
 	}
 }
 
-func TestTrainingSessionCompleteAndReset(t *testing.T) {
-	session := NewTrainingSession("u", 2, 1)
+func TestTrainingSessionSecondDepthCompleteAndReset(t *testing.T) {
+	session := NewTrainingSession("u", "i", true, 2, 1)
 
-	if result := session.HandleKey("u"); result != TrainingResultCorrect {
-		t.Fatalf("first correct key result = %v, want %v", result, TrainingResultCorrect)
+	if result := session.HandleKey("u"); result != TrainingResultAdvanceDepth {
+		t.Fatalf("first-step result = %v, want %v", result, TrainingResultAdvanceDepth)
 	}
 
-	if result := session.HandleKey("u"); result != TrainingResultCompleted {
-		t.Fatalf("second correct key result = %v, want %v", result, TrainingResultCompleted)
+	if result := session.HandleKey("i"); result != TrainingResultCorrect {
+		t.Fatalf("first drill completion result = %v, want %v", result, TrainingResultCorrect)
+	}
+
+	if session.InSecondDepth() {
+		t.Fatal("session should return to top-level view after a completed drill")
+	}
+
+	if got := session.OverlayKeys(); got != "u" {
+		t.Fatalf("top-level overlay after one learned hit = %q, want %q", got, "u")
+	}
+
+	if result := session.HandleKey("u"); result != TrainingResultAdvanceDepth {
+		t.Fatalf("second first-step result = %v, want %v", result, TrainingResultAdvanceDepth)
+	}
+
+	if result := session.HandleKey("i"); result != TrainingResultCompleted {
+		t.Fatalf("second drill completion result = %v, want %v", result, TrainingResultCompleted)
 	}
 
 	if session.Active() {
@@ -52,7 +67,7 @@ func TestTrainingSessionCompleteAndReset(t *testing.T) {
 	}
 
 	if got := session.OverlayKeys(); got != " " {
-		t.Fatalf("overlay keys after completion = %q, want %q", got, " ")
+		t.Fatalf("top-level overlay after completion = %q, want %q", got, " ")
 	}
 
 	learned, total := session.Progress()
@@ -66,16 +81,31 @@ func TestTrainingSessionCompleteAndReset(t *testing.T) {
 		t.Fatal("session should be active after reset")
 	}
 
+	if session.InSecondDepth() {
+		t.Fatal("session should restart at the top-level view")
+	}
+
 	if got := session.TargetIndex(); got != 0 {
 		t.Fatalf("target index after reset = %d, want 0", got)
 	}
 
 	if got := session.OverlayKeys(); got != "u" {
-		t.Fatalf("overlay keys after reset = %q, want %q", got, "u")
+		t.Fatalf("top-level overlay after reset = %q, want %q", got, "u")
+	}
+}
+
+func TestTrainingSessionSingleDepthFallbackStillWorks(t *testing.T) {
+	session := NewTrainingSession("u", "", false, 2, 1)
+
+	if result := session.HandleKey("u"); result != TrainingResultCorrect {
+		t.Fatalf("single-depth first result = %v, want %v", result, TrainingResultCorrect)
 	}
 
-	learned, total = session.Progress()
-	if learned != 0 || total != 1 {
-		t.Fatalf("progress after reset = (%d, %d), want (0, 1)", learned, total)
+	if session.InSecondDepth() {
+		t.Fatal("single-depth fallback should never enter second-depth mode")
+	}
+
+	if result := session.HandleKey("u"); result != TrainingResultCompleted {
+		t.Fatalf("single-depth completion result = %v, want %v", result, TrainingResultCompleted)
 	}
 }

--- a/internal/app/components/systray/systray.go
+++ b/internal/app/components/systray/systray.go
@@ -19,10 +19,12 @@ type AppInterface interface {
 	HintsEnabled() bool
 	GridEnabled() bool
 	RecursiveGridEnabled() bool
+	RecursiveGridTrainingEnabled() bool
 	IsEnabled() bool
 	SetEnabled(enabled bool)
 	ToggleEnabled()
 	ActivateMode(mode domain.Mode)
+	ActivateRecursiveGridTraining()
 	GetConfigPath() string
 	ReloadConfig(ctx context.Context, configPath string) error
 	// OnEnabledStateChanged is called when the enabled state changes externally
@@ -49,23 +51,24 @@ type Component struct {
 	cancel context.CancelFunc
 
 	// Menu items
-	mVersionCopy       *systray.MenuItem
-	mToggleDisable     *systray.MenuItem
-	mToggleEnable      *systray.MenuItem
-	mToggleScreenShare *systray.MenuItem
-	mModes             *systray.MenuItem
-	mHints             *systray.MenuItem
-	mGrid              *systray.MenuItem
-	mRecursiveGrid     *systray.MenuItem
-	mReloadConfig      *systray.MenuItem
-	mHelp              *systray.MenuItem
-	mSourceCode        *systray.MenuItem
-	mDocsConfig        *systray.MenuItem
-	mDocsCLI           *systray.MenuItem
-	mReportBug         *systray.MenuItem
-	mFeatureRequest    *systray.MenuItem
-	mDiscuss           *systray.MenuItem
-	mQuit              *systray.MenuItem
+	mVersionCopy        *systray.MenuItem
+	mToggleDisable      *systray.MenuItem
+	mToggleEnable       *systray.MenuItem
+	mToggleScreenShare  *systray.MenuItem
+	mModes              *systray.MenuItem
+	mHints              *systray.MenuItem
+	mGrid               *systray.MenuItem
+	mRecursiveGrid      *systray.MenuItem
+	mRecursiveGridTrain *systray.MenuItem
+	mReloadConfig       *systray.MenuItem
+	mHelp               *systray.MenuItem
+	mSourceCode         *systray.MenuItem
+	mDocsConfig         *systray.MenuItem
+	mDocsCLI            *systray.MenuItem
+	mReportBug          *systray.MenuItem
+	mFeatureRequest     *systray.MenuItem
+	mDiscuss            *systray.MenuItem
+	mQuit               *systray.MenuItem
 
 	// State update signaling (thread-safe communication)
 	stateUpdateSignal              chan struct{} // Signal that state changed
@@ -160,6 +163,12 @@ func (c *Component) OnReady() {
 		c.mRecursiveGrid.Disable()
 	}
 
+	c.mRecursiveGridTrain = c.mModes.AddSubMenuItem("Recursive Grid Training")
+	if !c.app.RecursiveGridTrainingEnabled() {
+		c.mRecursiveGridTrain.SetTitle("Recursive Grid Training: Disabled")
+		c.mRecursiveGridTrain.Disable()
+	}
+
 	systray.AddSeparator()
 
 	c.mReloadConfig = systray.AddMenuItem("Reload Config")
@@ -240,6 +249,8 @@ func (c *Component) handleEvents() {
 			c.app.ActivateMode(domain.ModeGrid)
 		case <-c.mRecursiveGrid.ClickedCh:
 			c.app.ActivateMode(domain.ModeRecursiveGrid)
+		case <-c.mRecursiveGridTrain.ClickedCh:
+			c.app.ActivateRecursiveGridTraining()
 		case <-c.mReloadConfig.ClickedCh:
 			c.handleReloadConfig()
 		case <-c.mSourceCode.ClickedCh:

--- a/internal/app/components/systray/systray_test.go
+++ b/internal/app/components/systray/systray_test.go
@@ -15,9 +15,11 @@ type mockApp struct {
 	hintsEnabled         bool
 	gridEnabled          bool
 	recursiveGridEnabled bool
+	trainingEnabled      bool
 	isEnabled            bool
 	hiddenForScreenShare bool
 	activatedMode        domain.Mode
+	trainingActivated    bool
 	configPath           string
 	reloadCalled         bool
 	enabledCallback      func(bool)
@@ -26,15 +28,19 @@ type mockApp struct {
 func (m *mockApp) HintsEnabled() bool         { return m.hintsEnabled }
 func (m *mockApp) GridEnabled() bool          { return m.gridEnabled }
 func (m *mockApp) RecursiveGridEnabled() bool { return m.recursiveGridEnabled }
-func (m *mockApp) IsEnabled() bool            { return m.isEnabled }
+func (m *mockApp) RecursiveGridTrainingEnabled() bool {
+	return m.trainingEnabled
+}
+func (m *mockApp) IsEnabled() bool { return m.isEnabled }
 func (m *mockApp) SetEnabled(enabled bool) {
 	m.isEnabled = enabled
 	if m.enabledCallback != nil {
 		m.enabledCallback(enabled)
 	}
 }
-func (m *mockApp) ActivateMode(mode domain.Mode) { m.activatedMode = mode }
-func (m *mockApp) GetConfigPath() string         { return m.configPath }
+func (m *mockApp) ActivateMode(mode domain.Mode)  { m.activatedMode = mode }
+func (m *mockApp) ActivateRecursiveGridTraining() { m.trainingActivated = true }
+func (m *mockApp) GetConfigPath() string          { return m.configPath }
 func (m *mockApp) ReloadConfig(ctx context.Context, configPath string) error {
 	m.reloadCalled = true
 

--- a/internal/app/components/types.go
+++ b/internal/app/components/types.go
@@ -120,9 +120,10 @@ func (s *StickyIndicatorComponent) UpdateConfig(cfg *config.Config, _ *zap.Logge
 
 // RecursiveGridComponent encapsulates all recursive-grid-related functionality.
 type RecursiveGridComponent struct {
-	Manager *domainRecursiveGrid.Manager
-	Overlay *recursivegrid.Overlay
-	Context *recursivegrid.Context
+	Manager  *domainRecursiveGrid.Manager
+	Overlay  *recursivegrid.Overlay
+	Context  *recursivegrid.Context
+	Training *recursivegrid.TrainingSession
 }
 
 // UpdateConfig updates the recursive-grid component with new configuration.

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -139,6 +139,7 @@ type ModeActivationOptions struct {
 	Action                *string
 	Repeat                bool
 	CursorFollowSelection *bool
+	Training              bool
 }
 
 // extractModeOptions extracts and validates the optional action and repeat
@@ -173,6 +174,18 @@ func (h *IPCControllerModes) extractModeOptions(
 		switch {
 		case arg == "--repeat" || arg == "-r":
 			opts.Repeat = true
+		case arg == "--training":
+			if cmd.Action != "recursive_grid" {
+				resp := ipc.Response{
+					Success: false,
+					Message: "--training is only supported by recursive_grid",
+					Code:    ipc.CodeInvalidInput,
+				}
+
+				return opts, &resp
+			}
+
+			opts.Training = true
 		case strings.HasPrefix(arg, "--action="):
 			actionArg := strings.TrimPrefix(arg, "--action=")
 			opts.Action = &actionArg
@@ -299,6 +312,16 @@ func (h *IPCControllerModes) extractModeOptions(
 		return opts, &resp
 	}
 
+	if opts.Training && opts.Action != nil {
+		resp := ipc.Response{
+			Success: false,
+			Message: "--training cannot be combined with an action",
+			Code:    ipc.CodeInvalidInput,
+		}
+
+		return opts, &resp
+	}
+
 	return opts, nil
 }
 
@@ -354,9 +377,15 @@ func (h *IPCControllerModes) handleRecursiveGrid(_ context.Context, cmd ipc.Comm
 		Action:                opts.Action,
 		Repeat:                opts.Repeat,
 		CursorFollowSelection: opts.CursorFollowSelection,
+		Training:              opts.Training,
 	})
 
-	return ipc.Response{Success: true, Message: "recursive-grid mode activated", Code: ipc.CodeOK}
+	message := "recursive-grid mode activated"
+	if opts.Training {
+		message = "recursive-grid training activated"
+	}
+
+	return ipc.Response{Success: true, Message: message, Code: ipc.CodeOK}
 }
 
 func (h *IPCControllerModes) handleScroll(_ context.Context, _ ipc.Command) ipc.Response {

--- a/internal/app/mocks_darwin_test.go
+++ b/internal/app/mocks_darwin_test.go
@@ -135,10 +135,12 @@ func (m *mockIPCServer) IsRunning() bool {
 
 // mockOverlayManager is a mock implementation of OverlayManager for testing.
 type mockOverlayManager struct {
-	mu        sync.RWMutex
-	mode      overlay.Mode
-	visible   bool
-	subsCount uint64
+	mu                      sync.RWMutex
+	mode                    overlay.Mode
+	visible                 bool
+	subsCount               uint64
+	lastHideUnmatched       bool
+	setHideUnmatchedInvoked int
 }
 
 // Show implements OverlayManager.
@@ -246,6 +248,7 @@ func (m *mockOverlayManager) DrawRecursiveGrid(
 	_ string,
 	_ int,
 	_ int,
+	_ int,
 	_ recursivegrid.Style,
 	_ recursivegrid.VirtualPointerState,
 ) error {
@@ -253,8 +256,13 @@ func (m *mockOverlayManager) DrawRecursiveGrid(
 }
 func (m *mockOverlayManager) UpdateGridMatches(_ string)                   {}
 func (m *mockOverlayManager) ShowSubgrid(_ *domainGrid.Cell, _ grid.Style) {}
-func (m *mockOverlayManager) SetHideUnmatched(_ bool)                      {}
-func (m *mockOverlayManager) SetSharingType(_ bool)                        {}
+func (m *mockOverlayManager) SetHideUnmatched(hide bool) {
+	m.mu.Lock()
+	m.lastHideUnmatched = hide
+	m.setHideUnmatchedInvoked++
+	m.mu.Unlock()
+}
+func (m *mockOverlayManager) SetSharingType(_ bool) {}
 
 type mockHotkeyService struct {
 	mu         sync.RWMutex

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -100,6 +100,12 @@ func (h *Handler) cleanupGridMode() {
 		h.grid.Overlay.HideVirtualPointer()
 	}
 
+	if h.renderer != nil {
+		// Grid mode toggles a shared native overlay flag. Reset it during cleanup
+		// so other modes do not accidentally render with grid filtering enabled.
+		h.renderer.SetHideUnmatched(false)
+	}
+
 	h.clearAndHideOverlay()
 }
 

--- a/internal/app/modes/generic_mode.go
+++ b/internal/app/modes/generic_mode.go
@@ -61,6 +61,7 @@ func (m *GenericMode) Activate(opts ModeActivationOptions) {
 				opts.Action,
 				opts.Repeat,
 				opts.CursorFollowSelection,
+				opts.Training,
 			)
 		case domain.ModeScroll:
 			m.handler.StartInteractiveScroll()

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -505,6 +505,13 @@ func (h *Handler) ResetCurrentMode() {
 		}
 	case domain.ModeRecursiveGrid:
 		if h.recursiveGrid != nil && h.recursiveGrid.Manager != nil {
+			if h.recursiveGrid.Training != nil && h.recursiveGrid.Training.Active() {
+				h.recursiveGrid.Training.Reset()
+				h.updateRecursiveGridOverlay()
+
+				return
+			}
+
 			h.recursiveGrid.Manager.Reset()
 
 			center := h.recursiveGrid.Manager.CurrentCenter()
@@ -552,6 +559,14 @@ func (h *Handler) BackspaceCurrentMode() {
 			h.grid.Manager.HandleBackspace()
 		}
 	case domain.ModeRecursiveGrid:
+		if h.recursiveGrid != nil && h.recursiveGrid.Manager != nil &&
+			h.recursiveGrid.Training != nil && h.recursiveGrid.Training.Active() {
+			h.recursiveGrid.Training.Reset()
+			h.updateRecursiveGridOverlay()
+
+			return
+		}
+
 		if h.recursiveGrid != nil && h.recursiveGrid.Manager != nil &&
 			h.recursiveGrid.Manager.Backtrack() {
 			center := h.recursiveGrid.Manager.CurrentCenter()

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -506,6 +506,7 @@ func (h *Handler) ResetCurrentMode() {
 	case domain.ModeRecursiveGrid:
 		if h.recursiveGrid != nil && h.recursiveGrid.Manager != nil {
 			if h.recursiveGrid.Training != nil && h.recursiveGrid.Training.Active() {
+				h.recursiveGrid.Manager.Reset()
 				h.recursiveGrid.Training.Reset()
 				h.updateRecursiveGridOverlay()
 
@@ -561,6 +562,7 @@ func (h *Handler) BackspaceCurrentMode() {
 	case domain.ModeRecursiveGrid:
 		if h.recursiveGrid != nil && h.recursiveGrid.Manager != nil &&
 			h.recursiveGrid.Training != nil && h.recursiveGrid.Training.Active() {
+			h.recursiveGrid.Manager.Reset()
 			h.recursiveGrid.Training.Reset()
 			h.updateRecursiveGridOverlay()
 

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -20,6 +20,7 @@ type ModeActivationOptions struct {
 	Action                *string
 	Repeat                bool
 	CursorFollowSelection *bool
+	Training              bool
 }
 
 const (

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -160,7 +160,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 
 	h.logger.Info("Recursive-grid mode activated", zap.String("action", actionString))
 	if training {
-		h.logger.Info("Press the highlighted recursive-grid key, space/backspace to restart, escape to exit")
+		h.logger.Info("Press the highlighted top-level key, then the highlighted second-depth key; space/backspace restarts, escape exits")
 	} else {
 		h.logger.Info("Press u/i/j/k to select cells, backspace to backtrack, escape to exit")
 	}
@@ -233,7 +233,28 @@ func (h *Handler) handleRecursiveGridKey(key string) {
 		switch result {
 		case componentrecursivegrid.TrainingResultIgnored:
 			return
+		case componentrecursivegrid.TrainingResultAdvanceDepth:
+			center, completed := h.recursiveGrid.Manager.HandleInput(key)
+			if completed {
+				h.logger.Warn("Recursive-grid training could not enter second depth; keeping top-level view")
+			} else if h.recursiveGrid.Context != nil {
+				absoluteCenter := coordinates.ConvertToAbsoluteCoordinates(center, h.screenBounds)
+				h.recursiveGrid.Context.SetSelectionPoint(absoluteCenter)
+			}
+			h.updateRecursiveGridOverlay()
+
+			return
 		case componentrecursivegrid.TrainingResultCorrect:
+			if h.recursiveGrid.Manager.CurrentDepth() > 0 &&
+				h.recursiveGrid.Manager.Backtrack() &&
+				h.recursiveGrid.Context != nil {
+				absoluteCenter := coordinates.ConvertToAbsoluteCoordinates(
+					h.recursiveGrid.Manager.CurrentCenter(),
+					h.screenBounds,
+				)
+				h.recursiveGrid.Context.SetSelectionPoint(absoluteCenter)
+			}
+
 			learned, total := h.recursiveGridTrainingProgress()
 			h.logger.Info("Recursive-grid training progress",
 				zap.Int("learned", learned),
@@ -246,6 +267,10 @@ func (h *Handler) handleRecursiveGridKey(key string) {
 
 			return
 		case componentrecursivegrid.TrainingResultCompleted:
+			if h.recursiveGrid.Manager.CurrentDepth() > 0 {
+				h.recursiveGrid.Manager.Backtrack()
+			}
+
 			learned, total := h.recursiveGridTrainingProgress()
 			h.updateRecursiveGridOverlay()
 			if h.system != nil {
@@ -397,8 +422,12 @@ func (h *Handler) initializeRecursiveGridTrainingSession(training bool) {
 		return
 	}
 
+	secondDepthTrainingActive := h.recursiveGrid.Manager.CanDivide()
+
 	h.recursiveGrid.Training = componentrecursivegrid.NewTrainingSession(
 		h.recursiveGrid.Manager.Keys(),
+		h.recursiveGrid.Manager.KeysForDepth(1),
+		secondDepthTrainingActive,
 		h.config.RecursiveGrid.Training.HitsToHide,
 		h.config.RecursiveGrid.Training.PenaltyOnError,
 	)

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -2,6 +2,7 @@ package modes
 
 import (
 	"context"
+	"fmt"
 	"image"
 
 	"go.uber.org/zap"
@@ -21,6 +22,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 	actionStr *string,
 	repeat bool,
 	cursorFollowSelection *bool,
+	training bool,
 ) {
 	// Detect refresh before validation so we can do partial cleanup on re-activation.
 	isRefresh := h.appState.CurrentMode() == domain.ModeRecursiveGrid
@@ -31,6 +33,17 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 		action.TypeMoveMouse,
 	)
 	if !ok {
+		if isRefresh {
+			h.exitModeLocked()
+		}
+
+		return
+	}
+
+	if training && !h.config.RecursiveGrid.Training.Enabled {
+		h.logger.Warn("Recursive-grid training activation failed",
+			zap.String("reason", "training disabled in config"))
+
 		if isRefresh {
 			h.exitModeLocked()
 		}
@@ -52,6 +65,11 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 	}
 
 	h.overlayManager.Clear()
+	if h.renderer != nil {
+		// Grid mode uses a shared native overlay flag to hide unmatched cells.
+		// Reset it here so recursive-grid and training never inherit that state.
+		h.renderer.SetHideUnmatched(false)
+	}
 
 	h.appState.SetRecursiveGridOverlayNeedsRefresh(false)
 
@@ -73,24 +91,27 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 	// Initialize recursive-grid manager
 	h.initializeRecursiveGridManager(normalizedBounds)
 
-	cursorShouldFollow := resolveCursorFollowSelection(
-		domain.ModeRecursiveGrid,
-		cursorFollowSelection,
-	)
+	cursorShouldFollow := false
+	if !training {
+		cursorShouldFollow = resolveCursorFollowSelection(
+			domain.ModeRecursiveGrid,
+			cursorFollowSelection,
+		)
 
-	// Move cursor to center of initial grid
-	if h.recursiveGrid.Manager != nil {
-		center := h.recursiveGrid.Manager.CurrentGrid().CurrentCenter()
+		// Move cursor to center of initial grid
+		if h.recursiveGrid.Manager != nil {
+			center := h.recursiveGrid.Manager.CurrentGrid().CurrentCenter()
 
-		absoluteCenter := coordinates.ConvertToAbsoluteCoordinates(center, h.screenBounds)
-		if h.recursiveGrid.Context != nil {
-			h.recursiveGrid.Context.SetSelectionPoint(absoluteCenter)
-		}
+			absoluteCenter := coordinates.ConvertToAbsoluteCoordinates(center, h.screenBounds)
+			if h.recursiveGrid.Context != nil {
+				h.recursiveGrid.Context.SetSelectionPoint(absoluteCenter)
+			}
 
-		if cursorShouldFollow {
-			err := h.actionService.MoveCursorToPoint(context.Background(), absoluteCenter)
-			if err != nil {
-				h.logger.Warn("Failed to move cursor to initial center", zap.Error(err))
+			if cursorShouldFollow {
+				err := h.actionService.MoveCursorToPoint(context.Background(), absoluteCenter)
+				if err != nil {
+					h.logger.Warn("Failed to move cursor to initial center", zap.Error(err))
+				}
 			}
 		}
 	}
@@ -98,10 +119,18 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 	// Draw initial recursive-grid
 	// Store pending action and repeat flag if provided
 	if h.recursiveGrid.Context != nil {
-		h.recursiveGrid.Context.SetPendingAction(actionStr)
-		h.recursiveGrid.Context.SetRepeat(repeat)
+		if training {
+			h.recursiveGrid.Context.SetPendingAction(nil)
+			h.recursiveGrid.Context.SetRepeat(false)
+			h.recursiveGrid.Context.ClearSelectionPoint()
+		} else {
+			h.recursiveGrid.Context.SetPendingAction(actionStr)
+			h.recursiveGrid.Context.SetRepeat(repeat)
+		}
+
 		h.recursiveGrid.Context.SetCursorFollowSelection(cursorShouldFollow)
 	}
+	h.initializeRecursiveGridTrainingSession(training)
 
 	// Draw initial recursive-grid
 	h.updateRecursiveGridOverlay()
@@ -116,6 +145,13 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 		)
 	}
 
+	if training {
+		learned, total := h.recursiveGridTrainingProgress()
+		h.logger.Info("Recursive-grid training activated",
+			zap.Int("learned", learned),
+			zap.Int("total", total))
+	}
+
 	// Only set mode and enable event tap on initial activation;
 	// during refresh these are already in the correct state.
 	if !isRefresh {
@@ -123,7 +159,11 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 	}
 
 	h.logger.Info("Recursive-grid mode activated", zap.String("action", actionString))
-	h.logger.Info("Press u/i/j/k to select cells, backspace to backtrack, escape to exit")
+	if training {
+		h.logger.Info("Press the highlighted recursive-grid key, space/backspace to restart, escape to exit")
+	} else {
+		h.logger.Info("Press u/i/j/k to select cells, backspace to backtrack, escape to exit")
+	}
 
 	h.startIndicatorPolling(domain.ModeRecursiveGrid)
 }
@@ -188,6 +228,41 @@ func (h *Handler) handleRecursiveGridKey(key string) {
 		return
 	}
 
+	if h.recursiveGrid.Training != nil && h.recursiveGrid.Training.Active() {
+		result := h.recursiveGrid.Training.HandleKey(key)
+		switch result {
+		case componentrecursivegrid.TrainingResultIgnored:
+			return
+		case componentrecursivegrid.TrainingResultCorrect:
+			learned, total := h.recursiveGridTrainingProgress()
+			h.logger.Info("Recursive-grid training progress",
+				zap.Int("learned", learned),
+				zap.Int("total", total))
+			h.updateRecursiveGridOverlay()
+
+			return
+		case componentrecursivegrid.TrainingResultWrong:
+			h.updateRecursiveGridOverlay()
+
+			return
+		case componentrecursivegrid.TrainingResultCompleted:
+			learned, total := h.recursiveGridTrainingProgress()
+			h.updateRecursiveGridOverlay()
+			if h.system != nil {
+				h.system.ShowNotification(
+					"Neru",
+					fmt.Sprintf("Recursive-grid training complete (%d/%d)", learned, total),
+				)
+			}
+			h.logger.Info("Recursive-grid training complete",
+				zap.Int("learned", learned),
+				zap.Int("total", total))
+			h.exitModeLocked()
+
+			return
+		}
+	}
+
 	// Process the key through the manager
 	center, completed := h.recursiveGrid.Manager.HandleInput(key)
 
@@ -216,6 +291,7 @@ func (h *Handler) handleRecursiveGridKey(key string) {
 					pendingAction,
 					repeat,
 					&cursorFollowSelection,
+					false,
 				)
 			},
 		)
@@ -261,15 +337,26 @@ func (h *Handler) updateRecursiveGridOverlay() {
 		nextRows = nextLayout.GridRows
 	}
 
+	keys := manager.Keys()
+	matchedIndex := -1
+	if session := h.recursiveGrid.Training; session != nil && session.Active() {
+		keys = session.OverlayKeys()
+		matchedIndex = session.TargetIndex()
+		nextKeys = ""
+		nextCols = 0
+		nextRows = 0
+	}
+
 	err := h.renderer.DrawRecursiveGrid(
 		manager.CurrentBounds(),
 		currentDepth,
-		manager.Keys(),
+		keys,
 		manager.GridCols(),
 		manager.GridRows(),
 		nextKeys,
 		nextCols,
 		nextRows,
+		matchedIndex,
 		h.currentRecursiveGridVirtualPointerState(),
 	)
 	if err != nil {
@@ -281,6 +368,7 @@ func (h *Handler) updateRecursiveGridOverlay() {
 func (h *Handler) cleanupRecursiveGridMode() {
 	if h.recursiveGrid != nil {
 		h.recursiveGrid.Context.Reset()
+		h.recursiveGrid.Training = nil
 
 		if h.recursiveGrid.Manager != nil {
 			h.recursiveGrid.Manager.Reset()
@@ -296,4 +384,30 @@ func (h *Handler) cleanupRecursiveGridMode() {
 	}
 
 	h.clearAndHideOverlay()
+}
+
+func (h *Handler) initializeRecursiveGridTrainingSession(training bool) {
+	if h.recursiveGrid == nil {
+		return
+	}
+
+	if !training {
+		h.recursiveGrid.Training = nil
+
+		return
+	}
+
+	h.recursiveGrid.Training = componentrecursivegrid.NewTrainingSession(
+		h.recursiveGrid.Manager.Keys(),
+		h.config.RecursiveGrid.Training.HitsToHide,
+		h.config.RecursiveGrid.Training.PenaltyOnError,
+	)
+}
+
+func (h *Handler) recursiveGridTrainingProgress() (int, int) {
+	if h.recursiveGrid == nil || h.recursiveGrid.Training == nil {
+		return 0, 0
+	}
+
+	return h.recursiveGrid.Training.Progress()
 }

--- a/internal/app/modes/recursive_grid_mode.go
+++ b/internal/app/modes/recursive_grid_mode.go
@@ -17,6 +17,7 @@ func NewRecursiveGridMode(handler *Handler) *RecursiveGridMode {
 				opts.Action,
 				opts.Repeat,
 				opts.CursorFollowSelection,
+				opts.Training,
 			)
 		},
 		HandleKeyFunc: func(handler *Handler, key string) {

--- a/internal/app/modes/recursive_grid_test.go
+++ b/internal/app/modes/recursive_grid_test.go
@@ -182,3 +182,69 @@ func TestCleanupGridModeResetsHideUnmatched(t *testing.T) {
 		t.Fatal("expected grid cleanup to disable hide unmatched")
 	}
 }
+
+func TestResetCurrentMode_RecursiveGridTrainingReturnsToTopLevel(t *testing.T) {
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeRecursiveGrid)
+
+	handler := &Handler{
+		appState: appState,
+		config: &config.Config{
+			RecursiveGrid: config.RecursiveGridConfig{
+				Enabled:       true,
+				GridCols:      2,
+				GridRows:      2,
+				Keys:          "uijk",
+				MinSizeWidth:  25,
+				MinSizeHeight: 25,
+				MaxDepth:      10,
+				Training: config.RecursiveGridTrainingConfig{
+					Enabled:        true,
+					HitsToHide:     3,
+					PenaltyOnError: 1,
+				},
+				Hotkeys: map[string]config.StringOrStringArray{},
+				UI:      config.RecursiveGridUI{},
+			},
+		},
+		logger: zap.NewNop(),
+		renderer: ui.NewOverlayRenderer(
+			&overlaypkg.NoOpManager{},
+			hintscomponent.StyleMode{},
+			gridcomponent.Style{},
+			componentrecursivegrid.Style{},
+		),
+		recursiveGrid: &components.RecursiveGridComponent{
+			Context: &componentrecursivegrid.Context{},
+		},
+		screenBounds: image.Rect(0, 0, 100, 100),
+	}
+
+	handler.initializeRecursiveGridManager(image.Rect(0, 0, 100, 100))
+	handler.recursiveGrid.Training = componentrecursivegrid.NewTrainingSession("uijk", "uijk", true, 3, 1)
+	targetKey := string([]rune("uijk")[handler.recursiveGrid.Training.TargetIndex()])
+
+	if result := handler.recursiveGrid.Training.HandleKey(targetKey); result != componentrecursivegrid.TrainingResultAdvanceDepth {
+		t.Fatalf("first training step result = %v, want %v", result, componentrecursivegrid.TrainingResultAdvanceDepth)
+	}
+
+	handler.recursiveGrid.Manager.HandleInput(targetKey)
+
+	if got := handler.recursiveGrid.Manager.CurrentDepth(); got != 1 {
+		t.Fatalf("manager depth before reset = %d, want 1", got)
+	}
+
+	handler.ResetCurrentMode()
+
+	if got := handler.recursiveGrid.Manager.CurrentDepth(); got != 0 {
+		t.Fatalf("manager depth after reset = %d, want 0", got)
+	}
+
+	if handler.recursiveGrid.Training == nil || !handler.recursiveGrid.Training.Active() {
+		t.Fatal("training session should remain active after reset")
+	}
+
+	if handler.recursiveGrid.Training.InSecondDepth() {
+		t.Fatal("training session should return to top-level after reset")
+	}
+}

--- a/internal/app/modes/recursive_grid_test.go
+++ b/internal/app/modes/recursive_grid_test.go
@@ -21,6 +21,17 @@ import (
 	overlaypkg "github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
+type recordingOverlayManager struct {
+	overlaypkg.NoOpManager
+	lastHideUnmatched       bool
+	setHideUnmatchedInvoked int
+}
+
+func (m *recordingOverlayManager) SetHideUnmatched(hide bool) {
+	m.lastHideUnmatched = hide
+	m.setHideUnmatchedInvoked++
+}
+
 func TestHandleRecursiveGridKey_CompleteSelectionDoesNotMoveWhenCursorFollowSelectionDisabled(
 	t *testing.T,
 ) {
@@ -141,5 +152,33 @@ func TestResetCurrentMode_RecursiveGridPreservesHoldMode(t *testing.T) {
 
 	if selection != (image.Point{X: 50, Y: 50}) {
 		t.Fatalf("stored selection after reset = %v, want (50,50)", selection)
+	}
+}
+
+func TestCleanupGridModeResetsHideUnmatched(t *testing.T) {
+	overlayManager := &recordingOverlayManager{}
+
+	handler := &Handler{
+		overlayManager: overlayManager,
+		grid: &components.GridComponent{
+			Context: &gridcomponent.Context{},
+		},
+		logger: zap.NewNop(),
+		renderer: ui.NewOverlayRenderer(
+			overlayManager,
+			hintscomponent.StyleMode{},
+			gridcomponent.Style{},
+			componentrecursivegrid.Style{},
+		),
+	}
+
+	handler.cleanupGridMode()
+
+	if overlayManager.setHideUnmatchedInvoked == 0 {
+		t.Fatal("expected grid cleanup to reset hide unmatched")
+	}
+
+	if overlayManager.lastHideUnmatched {
+		t.Fatal("expected grid cleanup to disable hide unmatched")
 	}
 }

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -12,11 +12,12 @@ import (
 
 // ModeConfig holds configuration for creating a mode command.
 type ModeConfig struct {
-	Name       string
-	Short      string
-	Long       string
-	ActionDesc string   // Description for the action flag (e.g., "hint selection" or "grid selection")
-	Aliases    []string // Optional CLI aliases (e.g., "recursive-grid" for "recursive_grid")
+	Name               string
+	Short              string
+	Long               string
+	ActionDesc         string   // Description for the action flag (e.g., "hint selection" or "grid selection")
+	Aliases            []string // Optional CLI aliases (e.g., "recursive-grid" for "recursive_grid")
+	EnableTrainingFlag bool
 }
 
 // BuildModeCommand creates a CLI command for a navigation mode (hints, grid, etc.).
@@ -45,10 +46,25 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				return err
 			}
 
+			trainingFlag := false
+			if config.EnableTrainingFlag {
+				trainingFlag, err = cmd.Flags().GetBool("training")
+				if err != nil {
+					return err
+				}
+			}
+
 			if repeatFlag && actionFlag == "" {
 				return derrors.New(
 					derrors.CodeInvalidInput,
 					"--repeat requires --action",
+				)
+			}
+
+			if trainingFlag && actionFlag != "" {
+				return derrors.New(
+					derrors.CodeInvalidInput,
+					"--training cannot be combined with --action",
 				)
 			}
 
@@ -113,6 +129,10 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				params = append(params, "--cursor-selection-mode="+cursorSelectionMode)
 			}
 
+			if trainingFlag {
+				params = append(params, "--training")
+			}
+
 			return sendCommand(cmd, config.Name, params)
 		},
 	}
@@ -135,6 +155,13 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 		"",
 		"How the real cursor should behave during selection: follow or hold",
 	)
+	if config.EnableTrainingFlag {
+		cmd.Flags().Bool(
+			"training",
+			false,
+			"Start recursive-grid memorization training using the configured recursive_grid layout",
+		)
+	}
 
 	return cmd
 }

--- a/internal/cli/recursive_grid.go
+++ b/internal/cli/recursive_grid.go
@@ -2,9 +2,10 @@ package cli
 
 // RecursiveGridCmd is the CLI recursive_grid command.
 var RecursiveGridCmd = BuildModeCommand(ModeConfig{
-	Name:    "recursive_grid",
-	Aliases: []string{"recursive-grid"},
-	Short:   "Activate recursive-grid navigation mode",
+	Name:               "recursive_grid",
+	Aliases:            []string{"recursive-grid"},
+	Short:              "Activate recursive-grid navigation mode",
+	EnableTrainingFlag: true,
 	Long: `Recursive-grid mode provides recursive cell-based navigation.
 
 The screen is divided into NxN cells (default 2x2, keys: u,i,j,k).
@@ -22,6 +23,7 @@ Navigation:
 
 Examples:
   neru recursive_grid                                  # Start recursive-grid mode
+  neru recursive_grid --training                       # Start recursive-grid training
   neru recursive_grid --action click                   # Start with pending click action
   neru recursive_grid --action left_click --repeat     # Click and restart mode`,
 	ActionDesc: "recursive-grid selection",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -624,6 +624,14 @@ type RecursiveGridAnimationConfig struct {
 	DurationMS int  `json:"durationMs" toml:"duration_ms"`
 }
 
+// RecursiveGridTrainingConfig defines lightweight memorization training settings
+// for the top-level recursive-grid layout.
+type RecursiveGridTrainingConfig struct {
+	Enabled        bool `json:"enabled"         toml:"enabled"`
+	HitsToHide     int  `json:"hitsToHide"      toml:"hits_to_hide"`
+	PenaltyOnError int  `json:"penaltyOnError"  toml:"penalty_on_error"`
+}
+
 // RecursiveGridConfig defines the visual and behavioral settings for recursive-grid mode.
 type RecursiveGridConfig struct {
 	Enabled bool `json:"enabled" toml:"enabled"`
@@ -636,9 +644,10 @@ type RecursiveGridConfig struct {
 	Keys string          `json:"keys" toml:"keys"`
 	UI   RecursiveGridUI `json:"ui"   toml:"ui"`
 	// Behavior
-	MinSizeWidth  int `json:"minSizeWidth"  toml:"min_size_width"`  // Default: 25
-	MinSizeHeight int `json:"minSizeHeight" toml:"min_size_height"` // Default: 25
-	MaxDepth      int `json:"maxDepth"      toml:"max_depth"`       // Default: 10
+	MinSizeWidth  int                         `json:"minSizeWidth"  toml:"min_size_width"`  // Default: 25
+	MinSizeHeight int                         `json:"minSizeHeight" toml:"min_size_height"` // Default: 25
+	MaxDepth      int                         `json:"maxDepth"      toml:"max_depth"`       // Default: 10
+	Training      RecursiveGridTrainingConfig `json:"training" toml:"training"`
 	// Per-depth overrides for grid dimensions and keys.
 	// Depths not listed here use the top-level GridCols/GridRows/Keys.
 	Layers []RecursiveGridLayerConfig `json:"layers" toml:"layers"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -198,6 +198,12 @@ const (
 	// DefaultRecursiveGridSubKeyPreviewAutohideMultiplier is the default minimum cell size multiplier
 	// for sub-key preview autohide. Set to 0 to disable autohide.
 	DefaultRecursiveGridSubKeyPreviewAutohideMultiplier = 1.5
+	// DefaultRecursiveGridTrainingHitsToHide is the default number of correct hits
+	// required before a training cell label is hidden.
+	DefaultRecursiveGridTrainingHitsToHide = 3
+	// DefaultRecursiveGridTrainingPenaltyOnError is the default number of hits removed
+	// from the current target after a wrong training answer.
+	DefaultRecursiveGridTrainingPenaltyOnError = 1
 	// DefaultStickyModifiersTapMaxDuration is the default maximum hold duration (ms)
 	// for a modifier key press to be considered a "tap" for sticky toggle.
 	// If held longer than this, the release will not toggle the sticky modifier.
@@ -378,6 +384,11 @@ func newDefaultConfig() *Config {
 			MinSizeWidth:  DefaultRecursiveGridMinSizeWidth,
 			MinSizeHeight: DefaultRecursiveGridMinSizeHeight,
 			MaxDepth:      DefaultRecursiveGridMaxDepth,
+			Training: RecursiveGridTrainingConfig{
+				Enabled:        true,
+				HitsToHide:     DefaultRecursiveGridTrainingHitsToHide,
+				PenaltyOnError: DefaultRecursiveGridTrainingPenaltyOnError,
+			},
 		},
 		VirtualPointer: VirtualPointerConfig{
 			Enabled: true,

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -576,6 +576,20 @@ func (c *Config) ValidateRecursiveGrid() error {
 		)
 	}
 
+	if c.RecursiveGrid.Training.HitsToHide < 1 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"recursive_grid.training.hits_to_hide must be >= 1",
+		)
+	}
+
+	if c.RecursiveGrid.Training.PenaltyOnError < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"recursive_grid.training.penalty_on_error must be non-negative",
+		)
+	}
+
 	expectedKeys := c.RecursiveGrid.GridCols * c.RecursiveGrid.GridRows
 	if utf8.RuneCountInString(c.RecursiveGrid.Keys) != expectedKeys {
 		return derrors.Newf(

--- a/internal/config/validators_recursive_grid_test.go
+++ b/internal/config/validators_recursive_grid_test.go
@@ -109,3 +109,25 @@ func TestConfigValidateRecursiveGrid_InvalidAnimationDuration(t *testing.T) {
 		t.Fatal("ValidateRecursiveGrid() expected error for negative animation duration")
 	}
 }
+
+func TestConfigValidateRecursiveGrid_InvalidTrainingHitsToHide(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RecursiveGrid.Enabled = true
+	cfg.RecursiveGrid.Training.HitsToHide = 0
+
+	err := cfg.ValidateRecursiveGrid()
+	if err == nil {
+		t.Fatal("ValidateRecursiveGrid() expected error for hits_to_hide < 1")
+	}
+}
+
+func TestConfigValidateRecursiveGrid_InvalidTrainingPenaltyOnError(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RecursiveGrid.Enabled = true
+	cfg.RecursiveGrid.Training.PenaltyOnError = -1
+
+	err := cfg.ValidateRecursiveGrid()
+	if err == nil {
+		t.Fatal("ValidateRecursiveGrid() expected error for penalty_on_error < 0")
+	}
+}

--- a/internal/ui/overlay/manager_darwin.go
+++ b/internal/ui/overlay/manager_darwin.go
@@ -363,6 +363,7 @@ func (m *Manager) DrawRecursiveGrid(
 	nextKeys string,
 	nextGridCols int,
 	nextGridRows int,
+	matchedIndex int,
 	style recursivegrid.Style,
 	virtualPointer recursivegrid.VirtualPointerState,
 ) error {
@@ -378,6 +379,7 @@ func (m *Manager) DrawRecursiveGrid(
 		nextKeys,
 		nextGridCols,
 		nextGridRows,
+		matchedIndex,
 		style,
 		virtualPointer,
 	)

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -472,6 +472,7 @@ func (m *Manager) DrawRecursiveGrid(
 	nextKeys string,
 	nextGridCols int,
 	nextGridRows int,
+	matchedIndex int,
 	style recursivegrid.Style,
 	virtualPointer recursivegrid.VirtualPointerState,
 ) error {
@@ -479,11 +480,11 @@ func (m *Manager) DrawRecursiveGrid(
 	defer m.renderMu.Unlock()
 
 	if m.x11 != nil {
-		m.x11.DrawRecursiveGrid(bounds, depth, keys, gridCols, gridRows, style, virtualPointer)
+		m.x11.DrawRecursiveGrid(bounds, depth, keys, gridCols, gridRows, matchedIndex, style, virtualPointer)
 
 		return nil
 	} else if m.wlroots != nil {
-		m.wlroots.DrawRecursiveGrid(bounds, depth, keys, gridCols, gridRows, style, virtualPointer)
+		m.wlroots.DrawRecursiveGrid(bounds, depth, keys, gridCols, gridRows, matchedIndex, style, virtualPointer)
 
 		return nil
 	}
@@ -491,6 +492,7 @@ func (m *Manager) DrawRecursiveGrid(
 	_ = nextKeys
 	_ = nextGridCols
 	_ = nextGridRows
+	_ = matchedIndex
 
 	return derrors.New(
 		derrors.CodeNotSupported,

--- a/internal/ui/overlay/manager_linux_wayland.go
+++ b/internal/ui/overlay/manager_linux_wayland.go
@@ -50,6 +50,7 @@ func (o *wlrootsOverlay) DrawRecursiveGrid(
 	string,
 	int,
 	int,
+	int,
 	recursivegridcomponent.Style,
 	recursivegridcomponent.VirtualPointerState,
 ) {

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -806,6 +806,7 @@ func (o *wlrootsOverlay) DrawRecursiveGrid(
 	keys string,
 	gridCols int,
 	gridRows int,
+	_ int,
 	style recursivegridcomponent.Style,
 	virtualPointer recursivegridcomponent.VirtualPointerState,
 ) {

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -314,6 +314,7 @@ func (o *x11Overlay) DrawRecursiveGrid(
 	keys string,
 	gridCols int,
 	gridRows int,
+	_ int,
 	style recursivegridcomponent.Style,
 	virtualPointer recursivegridcomponent.VirtualPointerState,
 ) {

--- a/internal/ui/overlay/manager_linux_x11_nocgo.go
+++ b/internal/ui/overlay/manager_linux_x11_nocgo.go
@@ -41,6 +41,7 @@ func (o *x11Overlay) DrawRecursiveGrid(
 	string,
 	int,
 	int,
+	int,
 	recursivegridcomponent.Style,
 	recursivegridcomponent.VirtualPointerState,
 ) {

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -137,6 +137,7 @@ func (m *Manager) DrawRecursiveGrid(
 	_ string,
 	_ int,
 	_ int,
+	_ int,
 	_ recursivegrid.Style,
 	_ recursivegrid.VirtualPointerState,
 ) error {

--- a/internal/ui/overlay/types.go
+++ b/internal/ui/overlay/types.go
@@ -148,6 +148,7 @@ func (n *NoOpManager) DrawRecursiveGrid(
 	nextKeys string,
 	nextGridCols int,
 	nextGridRows int,
+	matchedIndex int,
 	style recursivegrid.Style,
 	virtualPointer recursivegrid.VirtualPointerState,
 ) error {
@@ -218,6 +219,7 @@ type ManagerInterface interface {
 		nextKeys string,
 		nextGridCols int,
 		nextGridRows int,
+		matchedIndex int,
 		style recursivegrid.Style,
 		virtualPointer recursivegrid.VirtualPointerState,
 	) error

--- a/internal/ui/renderer.go
+++ b/internal/ui/renderer.go
@@ -103,6 +103,7 @@ func (r *OverlayRenderer) DrawRecursiveGrid(
 	nextKeys string,
 	nextGridCols int,
 	nextGridRows int,
+	matchedIndex int,
 	virtualPointer recursivegrid.VirtualPointerState,
 ) error {
 	return r.manager.DrawRecursiveGrid(
@@ -114,6 +115,7 @@ func (r *OverlayRenderer) DrawRecursiveGrid(
 		nextKeys,
 		nextGridCols,
 		nextGridRows,
+		matchedIndex,
 		r.recursiveGridStyle,
 		virtualPointer,
 	)


### PR DESCRIPTION
## Summary
This PR adds a lightweight recursive-grid training mode for memorizing the top-level recursive-grid key layout without changing Neru's existing architecture or normal recursive-grid behavior.

The feature is intentionally small in scope:
- it reuses the existing recursive-grid mode and overlay
- it is available from both the CLI and the systray
- it reads all recursive-grid layout data from user config
- training-specific integers fall back to defaults when not present
- it does not introduce a new subsystem, persistence layer, timer engine, or broad refactor

## User-facing functionality
Users can now start training in two ways:
- `neru recursive_grid --training`
- Systray -> `Activate Modes` -> `Recursive Grid Training`

Training behavior:
- uses the configured top-level `[recursive_grid]` layout (`grid_cols`, `grid_rows`, `keys`)
- chooses one target cell at a time and highlights it in the overlay
- expects the user to press the configured key for that highlighted cell
- increments the target cell's training progress on a correct answer
- applies a configurable penalty on a wrong answer
- hides labels for cells that have reached the configured learning threshold
- finishes automatically when all cells reach the threshold
- supports restart via `Space` or `Backspace`
- exits via `Escape`
- shows a completion notification when training is finished

## Configuration
This PR adds a new nested config block:

```toml
[recursive_grid.training]
enabled = true
hits_to_hide = 3
penalty_on_error = 1
```

Behavior details:
- `enabled`: enables the training entry points
- `hits_to_hide`: number of correct answers needed before a cell label is hidden
- `penalty_on_error`: number of hits removed from the active target after a wrong answer

Default values are wired into `DefaultConfig()` so missing integer values fall back correctly.
Validation rejects:
- `hits_to_hide < 1`
- `penalty_on_error < 0`

## What was done in code
### 1. Added training state for recursive-grid
- introduced a small `TrainingSession` in `internal/app/components/recursivegrid/training.go`
- stores per-cell hit counts, current target, last target, and the configured rules
- avoids immediate repeats where possible
- exposes overlay-ready keys so learned cells can be rendered as hidden labels

### 2. Integrated training into the existing recursive-grid mode
- extended recursive-grid activation to accept a `training` flag
- starts a training session only when the flag is enabled in config
- keeps normal recursive-grid behavior unchanged when training is not active
- routes recursive-grid key presses through the training session when active
- exits the mode automatically on training completion
- resets training cleanly on restart/backspace and during mode cleanup

### 3. Added CLI and IPC support
- added `--training` to the `recursive_grid` CLI command
- rejects invalid combinations such as `--training` with `--action`
- passes the option through IPC so the daemon can activate training mode
- returns a training-specific activation message from the IPC handler

### 4. Added systray support
- added a dedicated `Recursive Grid Training` systray menu item
- disables the menu entry when recursive-grid training is disabled in config
- added `App` interface methods to query training availability and trigger activation

### 5. Updated overlay rendering for training
- extended recursive-grid draw calls to accept a `matchedIndex`
- marks the active training cell as matched so the current target is visually emphasized
- hides next-depth preview during training because the exercise is for the top-level layout only
- uses stronger matched colors for the active training cell
- fixed shared overlay state leakage by resetting `hideUnmatched` when entering recursive-grid/training and when cleaning up grid mode

### 6. Added tests
- config validation tests for the new training settings
- unit tests for `TrainingSession` behavior
- systray test updates for the new training action
- recursive-grid mode tests covering the overlay-state reset and existing recursive-grid behavior affected by the change

## Scope and non-goals
This PR intentionally does not add:
- timer-based training windows
- marathon / zen / reinforcement modes
- persistence of training progress
- architectural refactors
- changes to the normal recursive-grid navigation flow beyond the optional training path

## Verification
I verified the feature with focused Go test runs:
- `go test ./internal/app/components/recursivegrid`
- `go test ./internal/app/modes -run 'TestCleanupGridModeResetsHideUnmatched|TestResetCurrentMode_RecursiveGridPreservesHoldMode|TestHandleRecursiveGridKey_CompleteSelectionDoesNotMoveWhenCursorFollowSelectionDisabled'`
- `go test ./internal/app -run '^$'`
- `go test ./internal/cli -run '^$'`
