### PR TITLE
fix: make Linux indicators follow cursor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,120 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Neru** (練る — "to refine through practice") is a keyboard-driven navigation tool for macOS, Linux, and Windows. It lets users navigate the screen and interact with UI elements (click, scroll, drag) using only keyboard input.
+
+- **Language:** Go 1.26.1+ with Objective-C for macOS native APIs
+- **Build tool:** [Just](https://github.com/casey/just) (`justfile` at root)
+- **macOS:** Fully stable; **Linux:** X11 and Wayland (wlroots); **Windows:** Stub/foundations only
+
+## Common Commands
+
+```bash
+# Build
+just build              # Development build → ./bin/neru
+just release            # Release build (optimized, stripped)
+
+# Test
+just test               # All unit tests
+just test-unit          # Unit tests only
+just test-integration   # Integration tests (platform-specific)
+just test-foundation    # Cross-platform foundation tests
+just test-race          # Tests with race detector
+
+# Lint & Format
+just lint               # golangci-lint + clang-format check
+just fmt                # Format Go (goimports, gofumpt, golines) + Objective-C
+just fmt-check          # Check formatting without modifying
+just vet                # go vet
+
+# Pre-commit checklist
+just fmt && just lint && just test && just build
+
+# Other
+just clean              # Remove build artifacts
+just deps               # Download and tidy dependencies
+just bundle             # Create macOS .app bundle
+just generate-all-protocols  # Fetch Wayland protocol XMLs and generate bindings
+```
+
+### Running a single test
+
+```bash
+go test ./internal/core/domain/grid/... -run TestGridSubdivide
+```
+
+## Architecture
+
+Neru uses **Hexagonal (Ports & Adapters) architecture** with strict layer separation:
+
+```
+cmd/neru/             → Entry point
+internal/
+  app/                → Application layer: orchestration, use cases
+    modes/            → Navigation mode implementations (Hints, Grid, Scroll, RecursiveGrid)
+    services/         → Business logic services (HintService, GridService, etc.)
+    components/       → UI components per mode
+  core/
+    domain/           → Pure business logic, no external deps
+      action/         → Action definitions
+      element/        → UI element representation
+      grid/           → Grid subdivision algorithms
+      hint/           → Hint generation
+      state/          → App state, cursor state, modifier state
+    ports/            → Interface contracts (AccessibilityPort, OverlayPort, etc.)
+    infra/            → Concrete platform implementations
+      platform/
+        darwin/       → macOS (Accessibility API, EventTap, Hotkeys, Overlay)
+        linux/        → X11 / Wayland adapters
+        windows/      → Stubs
+      ipc/            → Unix socket IPC
+      eventtap/       → Global keyboard capture
+  ui/overlay/         → Overlay renderer and coordinate system
+  config/             → TOML config loading and validation
+  cli/                → Cobra-based CLI commands
+```
+
+### Navigation Modes
+
+All four modes implement `Mode` interface (`HandleKey`, `HandleActionKey`, `Activate`, `Exit`, `ToggleActionMode`, `ModeType`). The central orchestrator is `internal/app/modes/handler.go`.
+
+1. **Hints** — Overlay labels on clickable elements via macOS Accessibility APIs
+2. **Grid** — Universal coordinate grid, subdivide by typing letters
+3. **Scroll** — Vim-style scrolling (`j`/`k`, `gg`/`G`, `d`/`u`)
+4. **Recursive Grid** — Iteratively subdivides a grid cell (recommended default)
+
+### IPC
+
+Daemon and CLI communicate via Unix sockets. `neru launch` starts the daemon; other commands send messages over IPC with a 5-second timeout.
+
+## Cross-Platform Rules
+
+- **Darwin isolation:** Non-darwin code must never import `internal/core/infra/platform/darwin`. Enforced by `golangci-lint` depguard.
+- **Build tags:** All OS-specific files use `//go:build darwin`, `//go:build linux`, or `//go:build windows`.
+- **Modifier naming:** Use "Primary" (Cmd on macOS, Ctrl on Linux/Windows) in cross-platform contexts.
+- **Unimplemented paths:** Return `errors.CodeNotSupported` for features not yet implemented on a platform.
+- **CGO:** Required on macOS (Objective-C bridge) and Linux native backends; disabled by default on Windows.
+
+## Testing Conventions
+
+- Unit tests: `*_test.go` with no build tags
+- Integration tests: `*_integration_darwin_test.go` / `*_integration_linux_test.go` tagged `//go:build integration && <os>`
+- Core domain logic uses table-driven tests
+
+## Code Standards
+
+- Godoc comments on all exported symbols
+- Use the custom error package in `internal/core/errors/` with proper wrapping
+- Objective-C files formatted with clang-format (enforced in CI on macOS)
+- Full standards in `docs/CODING_STANDARDS.md`
+
+## Key Docs
+
+- `docs/DEVELOPMENT.md` — Build, debug, contribute
+- `docs/ARCHITECTURE.md` — System design and cross-platform patterns
+- `docs/CROSS_PLATFORM.md` — Linux/Windows contributor guide
+- `docs/CONFIGURATION.md` — Full TOML config reference
+- `docs/CODING_STANDARDS.md` — Code style requirements

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -246,28 +246,6 @@ func (h *Handler) shouldShowModeIndicator(mode domain.Mode) bool {
 }
 
 func (h *Handler) modeIndicatorAnchorLocked(cursorPoint image.Point) image.Point {
-	switch h.appState.CurrentMode() {
-	case domain.ModeGrid:
-		if h.grid == nil || h.grid.Context == nil {
-			return cursorPoint
-		}
-
-		if selectionPoint, ok := h.grid.Context.SelectionPoint(); ok {
-			return selectionPoint
-		}
-	case domain.ModeRecursiveGrid:
-		if h.recursiveGrid == nil || h.recursiveGrid.Context == nil {
-			return cursorPoint
-		}
-
-		if selectionPoint, ok := h.recursiveGrid.Context.SelectionPoint(); ok {
-			return selectionPoint
-		}
-	case domain.ModeIdle:
-	case domain.ModeHints:
-	case domain.ModeScroll:
-	}
-
 	return cursorPoint
 }
 

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -172,6 +172,9 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 
 						stickyInd.Clear()
 						stickyInd.Hide()
+						if h.stickyIndicatorService != nil {
+							h.stickyIndicatorService.UpdateIndicatorPosition(0, 0, "")
+						}
 					}
 				}
 			}

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -100,9 +100,9 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 				}
 				showModeInd := h.shouldShowModeIndicator(h.appState.CurrentMode())
 				stickyEnabled := h.stickyModifiersEnabled()
-				stickyPoint := h.stickyIndicatorAnchorLocked(image.Pt(cursorX, cursorY))
-
 				cursorPt := image.Pt(cursorX, cursorY)
+				modePoint := h.modeIndicatorAnchorLocked(cursorPt)
+				stickyPoint := h.stickyIndicatorAnchorLocked(cursorPt)
 
 				if !cursorPt.In(h.screenBounds) && h.system != nil {
 					boundsCtx, boundsCancel := context.WithTimeout(ctx, indicatorPollTimeout)
@@ -135,8 +135,8 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 
 				h.mu.Unlock()
 
-				localCursorX := cursorX - screenOrigin.X
-				localCursorY := cursorY - screenOrigin.Y
+				localModeX := modePoint.X - screenOrigin.X
+				localModeY := modePoint.Y - screenOrigin.Y
 				localStickyX := stickyPoint.X - screenOrigin.X
 				localStickyY := stickyPoint.Y - screenOrigin.Y
 
@@ -146,7 +146,7 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 						ind.Show()
 					}
 
-					h.modeIndicatorService.UpdateIndicatorPosition(localCursorX, localCursorY)
+					h.modeIndicatorService.UpdateIndicatorPosition(localModeX, localModeY)
 				} else if ind := h.overlayManager.ModeIndicatorOverlay(); ind != nil {
 					ind.Clear()
 					ind.Hide()
@@ -243,6 +243,32 @@ func (h *Handler) modeIndicatorEnabled(mode domain.Mode) bool {
 
 func (h *Handler) shouldShowModeIndicator(mode domain.Mode) bool {
 	return h.modeIndicatorEnabled(mode)
+}
+
+func (h *Handler) modeIndicatorAnchorLocked(cursorPoint image.Point) image.Point {
+	switch h.appState.CurrentMode() {
+	case domain.ModeGrid:
+		if h.grid == nil || h.grid.Context == nil {
+			return cursorPoint
+		}
+
+		if selectionPoint, ok := h.grid.Context.SelectionPoint(); ok {
+			return selectionPoint
+		}
+	case domain.ModeRecursiveGrid:
+		if h.recursiveGrid == nil || h.recursiveGrid.Context == nil {
+			return cursorPoint
+		}
+
+		if selectionPoint, ok := h.recursiveGrid.Context.SelectionPoint(); ok {
+			return selectionPoint
+		}
+	case domain.ModeIdle:
+	case domain.ModeHints:
+	case domain.ModeScroll:
+	}
+
+	return cursorPoint
 }
 
 func (h *Handler) stickyIndicatorAnchorLocked(cursorPoint image.Point) image.Point {

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -172,9 +172,6 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 
 						stickyInd.Clear()
 						stickyInd.Hide()
-						if h.stickyIndicatorService != nil {
-							h.stickyIndicatorService.UpdateIndicatorPosition(0, 0, "")
-						}
 					}
 				}
 			}

--- a/internal/app/modes/indicator_polling_test.go
+++ b/internal/app/modes/indicator_polling_test.go
@@ -37,6 +37,72 @@ func TestStickyIndicatorAnchor_UsesGridSelectionWhenCursorFollowDisabled(t *test
 	}
 }
 
+func TestModeIndicatorAnchor_UsesGridSelectionWhenAvailable(t *testing.T) {
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeGrid)
+
+	handler := &Handler{
+		appState: appState,
+		logger:   zap.NewNop(),
+		grid: &components.GridComponent{
+			Context: &gridcomponent.Context{},
+		},
+	}
+
+	handler.grid.Context.SetCursorFollowSelection(true)
+	handler.grid.Context.SetSelectionPoint(image.Pt(40, 60))
+
+	got := handler.modeIndicatorAnchorLocked(image.Pt(10, 20))
+
+	want := image.Pt(40, 60)
+	if got != want {
+		t.Fatalf("modeIndicatorAnchor() = %v, want %v", got, want)
+	}
+}
+
+func TestModeIndicatorAnchor_UsesRecursiveGridSelectionWhenAvailable(t *testing.T) {
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeRecursiveGrid)
+
+	handler := &Handler{
+		appState: appState,
+		logger:   zap.NewNop(),
+		recursiveGrid: &components.RecursiveGridComponent{
+			Context: &recursivegridcomponent.Context{},
+		},
+	}
+
+	handler.recursiveGrid.Context.SetCursorFollowSelection(true)
+	handler.recursiveGrid.Context.SetSelectionPoint(image.Pt(75, 25))
+
+	got := handler.modeIndicatorAnchorLocked(image.Pt(10, 20))
+
+	want := image.Pt(75, 25)
+	if got != want {
+		t.Fatalf("modeIndicatorAnchor() = %v, want %v", got, want)
+	}
+}
+
+func TestModeIndicatorAnchor_UsesCursorWhenSelectionUnavailable(t *testing.T) {
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeGrid)
+
+	handler := &Handler{
+		appState: appState,
+		logger:   zap.NewNop(),
+		grid: &components.GridComponent{
+			Context: &gridcomponent.Context{},
+		},
+	}
+
+	got := handler.modeIndicatorAnchorLocked(image.Pt(10, 20))
+
+	want := image.Pt(10, 20)
+	if got != want {
+		t.Fatalf("modeIndicatorAnchor() = %v, want %v", got, want)
+	}
+}
+
 func TestStickyIndicatorAnchor_UsesRecursiveGridSelectionWhenCursorFollowDisabled(t *testing.T) {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeRecursiveGrid)

--- a/internal/app/modes/indicator_polling_test.go
+++ b/internal/app/modes/indicator_polling_test.go
@@ -37,7 +37,7 @@ func TestStickyIndicatorAnchor_UsesGridSelectionWhenCursorFollowDisabled(t *test
 	}
 }
 
-func TestModeIndicatorAnchor_UsesGridSelectionWhenAvailable(t *testing.T) {
+func TestModeIndicatorAnchor_UsesCursorInGridMode_IgnoresSelection(t *testing.T) {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeGrid)
 
@@ -49,18 +49,19 @@ func TestModeIndicatorAnchor_UsesGridSelectionWhenAvailable(t *testing.T) {
 		},
 	}
 
-	handler.grid.Context.SetCursorFollowSelection(true)
+	handler.grid.Context.SetCursorFollowSelection(false)
 	handler.grid.Context.SetSelectionPoint(image.Pt(40, 60))
 
 	got := handler.modeIndicatorAnchorLocked(image.Pt(10, 20))
 
-	want := image.Pt(40, 60)
+	// Mode indicator always follows the cursor, not the selection point.
+	want := image.Pt(10, 20)
 	if got != want {
 		t.Fatalf("modeIndicatorAnchor() = %v, want %v", got, want)
 	}
 }
 
-func TestModeIndicatorAnchor_UsesRecursiveGridSelectionWhenAvailable(t *testing.T) {
+func TestModeIndicatorAnchor_UsesCursorInRecursiveGridMode_IgnoresSelection(t *testing.T) {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeRecursiveGrid)
 
@@ -72,12 +73,12 @@ func TestModeIndicatorAnchor_UsesRecursiveGridSelectionWhenAvailable(t *testing.
 		},
 	}
 
-	handler.recursiveGrid.Context.SetCursorFollowSelection(true)
+	handler.recursiveGrid.Context.SetCursorFollowSelection(false)
 	handler.recursiveGrid.Context.SetSelectionPoint(image.Pt(75, 25))
 
 	got := handler.modeIndicatorAnchorLocked(image.Pt(10, 20))
 
-	want := image.Pt(75, 25)
+	want := image.Pt(10, 20)
 	if got != want {
 		t.Fatalf("modeIndicatorAnchor() = %v, want %v", got, want)
 	}

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -30,6 +30,7 @@ typedef struct NeruWlrootsClient NeruWlrootsClient;
 
 // Forward declare the cursor init function
 static void neru_wlr_init_cursor(NeruWlrootsClient *c);
+static int neru_wlr_probe_cursor(NeruWlrootsClient *c, int timeout_ms);
 
 typedef struct {
 	int x;
@@ -72,10 +73,9 @@ typedef struct NeruWlrootsClient {
 	NeruWaylandScreen screens[NERU_MAX_OUTPUTS];
 	int nr_screens;
 
-	// Cursor position cache (updated ONLY by neru_wlr_move_absolute).
-	// Wayland has no protocol to query global pointer position, so we must
-	// track it client-side. Pointer enter/motion events give surface-local
-	// coords that are meaningless for global tracking.
+	// Cursor position cache.
+	// Wayland has no direct protocol to query global pointer position. We keep
+	// a cache updated by virtual-pointer moves and best-effort probe surfaces.
 	int cursor_x;
 	int cursor_y;
 	int cursor_initialized;
@@ -91,7 +91,7 @@ static void neru_wlr_pointer_enter(void *data,
 	wl_fixed_t sx, wl_fixed_t sy)
 {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->cursor_initialized == 0) {
+	if (c) {
 		// During discovery phase, record the global pointer location based on
 		// which screen triggered the enter event and surface-local coordinates.
 		for (int i = 0; i < c->nr_screens; i++) {
@@ -119,11 +119,8 @@ static void neru_wlr_pointer_motion(void *data,
 	uint32_t time,
 	wl_fixed_t sx, wl_fixed_t sy)
 {
-	// No-op. Motion events give surface-local coords which would corrupt
-	// the global cursor position tracked via neru_wlr_move_absolute.
-	// This was the root cause of the "stale cache" bug: poll_cursor()
-	// dispatched events which triggered this handler, overwriting the
-	// correctly-set global position with meaningless surface-local coords.
+	// No-op. Motion coordinates are surface-local and we only use pointer_enter
+	// on temporary discovery surfaces to refresh the global cursor cache.
 	(void)data; (void)pointer; (void)time; (void)sx; (void)sy;
 }
 
@@ -454,33 +451,24 @@ static void neru_wlr_disconnect(NeruWlrootsClient *c) {
 	free(c);
 }
 
-// Initialize cursor position to the center of the screen containing the
-// cursor (or first screen). Wayland has no protocol to query global
-// pointer position, so we initialize to the center and then track
-// position purely client-side via neru_wlr_move_absolute (matching
-// warpd's pattern where ptr.x/ptr.y are only set by way_mouse_move).
-static void neru_wlr_init_cursor(NeruWlrootsClient *c) {
-	if (!c || c->cursor_initialized) return;
-
-	// Use Warpd's cursor discovery trick: create invisible full-screen layer-shell surfaces
-	// across all outputs, wiggle the virtual pointer, and capture the pointer_enter event.
-	if (!c->layer_shell || !c->compositor || !c->pointer || !c->vptr || c->nr_screens == 0) {
-		// Fallback to screen center
-		c->cursor_x = c->screens[0].x + c->screens[0].w / 2;
-		c->cursor_y = c->screens[0].y + c->screens[0].h / 2;
-		c->cursor_initialized = 1;
-		return;
+static int neru_wlr_discover_cursor(NeruWlrootsClient *c, int timeout_ms, int nudge_virtual_pointer) {
+	if (!c || !c->layer_shell || !c->compositor || !c->pointer || c->nr_screens == 0) {
+		return 0;
 	}
 
+	int previous_x = c->cursor_x;
+	int previous_y = c->cursor_y;
+	int previous_initialized = c->cursor_initialized;
 	struct zwlr_layer_surface_v1 *layer_surfaces[NERU_MAX_OUTPUTS] = {0};
 
 	for (int i = 0; i < c->nr_screens; i++) {
 		c->screens[i].discovery_surface = wl_compositor_create_surface(c->compositor);
-		// Do not set input region, allowing it to intercept pointer events
+		if (!c->screens[i].discovery_surface) continue;
 		layer_surfaces[i] = zwlr_layer_shell_v1_get_layer_surface(
 			c->layer_shell, c->screens[i].discovery_surface, c->screens[i].wl_output,
 			ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY, "neru_discovery"
 		);
+		if (!layer_surfaces[i]) continue;
 		zwlr_layer_surface_v1_set_size(layer_surfaces[i], c->screens[i].w, c->screens[i].h);
 		zwlr_layer_surface_v1_set_anchor(layer_surfaces[i],
 			ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
@@ -491,19 +479,25 @@ static void neru_wlr_init_cursor(NeruWlrootsClient *c) {
 
 	wl_display_roundtrip(c->display);
 
-	// Animate the pointer to force an enter event
-	zwlr_virtual_pointer_v1_motion(c->vptr, 0, wl_fixed_from_int(1), wl_fixed_from_int(1));
-	zwlr_virtual_pointer_v1_frame(c->vptr);
-	wl_display_flush(c->display);
+	if (nudge_virtual_pointer && c->vptr) {
+		// If the compositor doesn't emit enter on surface map, nudge the virtual
+		// pointer once to trigger discovery.
+		zwlr_virtual_pointer_v1_motion(c->vptr, 0, wl_fixed_from_int(1), wl_fixed_from_int(1));
+		zwlr_virtual_pointer_v1_frame(c->vptr);
+		wl_display_flush(c->display);
+	}
 
-	// Poll until initialized or timeout (~50ms)
+	if (timeout_ms < 1) timeout_ms = 1;
 	struct pollfd pfd = { .fd = wl_display_get_fd(c->display), .events = POLLIN };
-	for (int attempts = 0; attempts < 5 && c->cursor_initialized == 0; attempts++) {
+	int attempts = timeout_ms / 10;
+	if (attempts < 1) attempts = 1;
+	for (int i = 0; i < attempts; i++) {
 		if (poll(&pfd, 1, 10) > 0) {
 			wl_display_dispatch(c->display);
 		} else {
 			wl_display_dispatch_pending(c->display);
 		}
+		if (c->cursor_initialized) break;
 	}
 
 	// Destroy discovery surfaces
@@ -516,12 +510,33 @@ static void neru_wlr_init_cursor(NeruWlrootsClient *c) {
 	}
 	wl_display_flush(c->display);
 
-	// Fallback if discovery failed
-	if (c->cursor_initialized == 0) {
-		c->cursor_x = c->screens[0].x + c->screens[0].w / 2;
-		c->cursor_y = c->screens[0].y + c->screens[0].h / 2;
+	if (!c->cursor_initialized && previous_initialized) {
+		c->cursor_x = previous_x;
+		c->cursor_y = previous_y;
 		c->cursor_initialized = 1;
 	}
+
+	return c->cursor_initialized;
+}
+
+// Initialize cursor position to a discovered value when possible. If discovery
+// fails, fallback to the center of the first screen.
+static void neru_wlr_init_cursor(NeruWlrootsClient *c) {
+	if (!c || c->cursor_initialized) return;
+
+	if (neru_wlr_discover_cursor(c, 50, 1)) {
+		return;
+	}
+
+	if (c->nr_screens <= 0) return;
+	c->cursor_x = c->screens[0].x + c->screens[0].w / 2;
+	c->cursor_y = c->screens[0].y + c->screens[0].h / 2;
+	c->cursor_initialized = 1;
+}
+
+// Refresh cursor cache by briefly mapping temporary discovery surfaces.
+static int neru_wlr_probe_cursor(NeruWlrootsClient *c, int timeout_ms) {
+	return neru_wlr_discover_cursor(c, timeout_ms, 0);
 }
 
 // ---------- Input injection ----------
@@ -672,6 +687,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 	"unsafe"
 
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
@@ -683,6 +699,8 @@ const (
 	wlrootsScreenNameBufferSize = 128
 	wlrootsDefaultWidth         = 1920
 	wlrootsDefaultHeight        = 1080
+	wlrootsCursorProbeInterval  = 120 * time.Millisecond
+	wlrootsCursorProbeTimeout   = 12 * time.Millisecond
 )
 
 type wlrootsScreen struct {
@@ -693,9 +711,10 @@ type wlrootsScreen struct {
 type wlrootsState struct {
 	mu sync.RWMutex
 
-	client  *C.NeruWlrootsClient
-	screens []wlrootsScreen
-	ready   bool
+	client          *C.NeruWlrootsClient
+	screens         []wlrootsScreen
+	ready           bool
+	lastCursorProbe time.Time
 }
 
 var globalWlrootsState = &wlrootsState{}
@@ -733,9 +752,8 @@ func ensureWlrootsState() error {
 		)
 	}
 
-	// Initialize cursor position to screen center. Wayland has no
-	// protocol to query global pointer position, so we track it
-	// client-side via move_absolute only (matching warpd's pattern).
+	// Initialize cursor position using discovery surfaces (with fallback to
+	// first-screen center when discovery is unavailable).
 	C.neru_wlr_init_cursor(client)
 
 	// Populate screen list from the client.
@@ -785,6 +803,7 @@ func ensureWlrootsState() error {
 	globalWlrootsState.client = client
 	globalWlrootsState.screens = screens
 	globalWlrootsState.ready = true
+	globalWlrootsState.lastCursorProbe = time.Now()
 
 	return nil
 }
@@ -855,22 +874,21 @@ func wlrootsCursorPosition() (image.Point, error) {
 		return image.Point{}, err
 	}
 
-	globalWlrootsState.mu.RLock()
-	defer globalWlrootsState.mu.RUnlock()
+	globalWlrootsState.mu.Lock()
+	defer globalWlrootsState.mu.Unlock()
 
 	return wlrootsCursorPositionLocked()
 }
 
-// wlrootsCursorPositionLocked returns cursor position while holding at least RLock.
+// wlrootsCursorPositionLocked returns cursor position while holding globalWlrootsState.mu.
 func wlrootsCursorPositionLocked() (image.Point, error) {
 	client := globalWlrootsState.client
 	if client == nil {
 		return image.Point{}, nil
 	}
 
-	// Cursor position is tracked purely client-side via move_absolute.
-	// No need to poll Wayland events — doing so previously triggered
-	// the pointer motion handler which corrupted the position cache.
+	probeCursorPositionLocked(client)
+
 	var posX, posY C.int
 	initialized := C.neru_wlr_get_cursor(client, &posX, &posY) //nolint:nlreturn
 
@@ -889,6 +907,25 @@ func wlrootsCursorPositionLocked() (image.Point, error) {
 	}
 
 	return image.Point{X: int(posX), Y: int(posY)}, nil
+}
+
+func probeCursorPositionLocked(client *C.NeruWlrootsClient) {
+	if client == nil {
+		return
+	}
+
+	if !globalWlrootsState.lastCursorProbe.IsZero() &&
+		time.Since(globalWlrootsState.lastCursorProbe) < wlrootsCursorProbeInterval {
+		return
+	}
+
+	globalWlrootsState.lastCursorProbe = time.Now()
+	timeoutMillis := C.int(wlrootsCursorProbeTimeout / time.Millisecond)
+	if timeoutMillis < 1 {
+		timeoutMillis = 1
+	}
+
+	C.neru_wlr_probe_cursor(client, timeoutMillis)
 }
 
 func wlrootsMoveCursorToPoint(point image.Point) error {

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
@@ -74,8 +74,8 @@ func wlrootsButtonRelease(button int) error {
 	)
 }
 
-func wlrootsScroll(axis, direction int) error {
-	_, _ = axis, direction
+func wlrootsScroll(axis, delta, discrete int) error {
+	_, _, _ = axis, delta, discrete
 
 	return derrors.New(
 		derrors.CodeNotSupported,

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -82,6 +82,11 @@ type Manager struct {
 
 	keyboardCaptureEnabled bool
 
+	modeIndicatorX11     *x11Overlay
+	stickyModifiersX11   *x11Overlay
+	modeIndicatorWlroots *wlrootsOverlay
+	stickyWlroots        *wlrootsOverlay
+
 	hintOverlay            *hints.Overlay
 	gridOverlay            *grid.Overlay
 	modeIndicatorOverlay   *modeindicator.Overlay
@@ -111,8 +116,16 @@ func NewOverlayManager(logger *zap.Logger) *Manager {
 	switch manager.backend {
 	case linuxOverlayBackendX11:
 		manager.x11 = newX11Overlay(logger)
+		if manager.x11 != nil {
+			manager.modeIndicatorX11 = newX11Overlay(logger)
+			manager.stickyModifiersX11 = newX11Overlay(logger)
+		}
 	case linuxOverlayBackendWaylandWlroots:
 		manager.wlroots = newWlrootsOverlay(logger)
+		if manager.wlroots != nil {
+			manager.modeIndicatorWlroots = newPassiveWlrootsOverlay(logger)
+			manager.stickyWlroots = newPassiveWlrootsOverlay(logger)
+		}
 
 		// Share renderMu with the wlroots overlay so the keyboard poller
 		// serializes wl_display access with the rendering path. The Wayland
@@ -174,6 +187,7 @@ func (m *Manager) Hide() {
 
 	m.stickyBadgeVisible = false
 	m.stickyBadgeRect = image.Rectangle{}
+	m.hideIndicatorLayersLocked()
 }
 
 // SetKeyboardCaptureEnabled controls whether the Wayland overlay requests
@@ -206,6 +220,7 @@ func (m *Manager) Clear() {
 
 	m.stickyBadgeVisible = false
 	m.stickyBadgeRect = image.Rectangle{}
+	m.clearIndicatorLayersLocked()
 }
 
 // ResizeToActiveScreen resizes the overlay to the active screen.
@@ -218,6 +233,8 @@ func (m *Manager) ResizeToActiveScreen() {
 	} else if m.wlroots != nil {
 		m.wlroots.Resize()
 	}
+
+	m.resizeIndicatorLayersLocked()
 }
 
 // SwitchTo switches to a new mode.
@@ -234,6 +251,12 @@ func (m *Manager) SwitchTo(next Mode) {
 	m.mode = next
 
 	m.mu.Unlock()
+
+	if next == ModeIdle {
+		m.renderMu.Lock()
+		m.hideIndicatorLayersLocked()
+		m.renderMu.Unlock()
+	}
 
 	m.publish(StateChange{prev: prev, next: next})
 }
@@ -268,8 +291,16 @@ func (m *Manager) Destroy() {
 	m.renderMu.Lock()
 	x11 := m.x11
 	wlroots := m.wlroots
+	modeIndicatorX11 := m.modeIndicatorX11
+	stickyModifiersX11 := m.stickyModifiersX11
+	modeIndicatorWlroots := m.modeIndicatorWlroots
+	stickyWlroots := m.stickyWlroots
 	m.x11 = nil
 	m.wlroots = nil
+	m.modeIndicatorX11 = nil
+	m.stickyModifiersX11 = nil
+	m.modeIndicatorWlroots = nil
+	m.stickyWlroots = nil
 	m.renderMu.Unlock()
 
 	if x11 != nil {
@@ -278,6 +309,22 @@ func (m *Manager) Destroy() {
 
 	if wlroots != nil {
 		wlroots.Destroy()
+	}
+
+	if modeIndicatorX11 != nil {
+		modeIndicatorX11.Destroy()
+	}
+
+	if stickyModifiersX11 != nil {
+		stickyModifiersX11.Destroy()
+	}
+
+	if modeIndicatorWlroots != nil {
+		modeIndicatorWlroots.Destroy()
+	}
+
+	if stickyWlroots != nil {
+		stickyWlroots.Destroy()
 	}
 }
 
@@ -422,25 +469,26 @@ func (m *Manager) DrawModeIndicator(posX, posY int) {
 	m.renderMu.Lock()
 	defer m.renderMu.Unlock()
 
-	if m.x11 != nil {
-		m.x11.DrawBadge(posX, posY, label, colors, style)
-	} else if m.wlroots != nil {
-		m.wlroots.DrawBadge(posX, posY, label, colors, style)
+	if m.modeIndicatorX11 != nil {
+		drawX11BadgeLayer(m.modeIndicatorX11, posX, posY, label, colors, style)
+	} else if m.modeIndicatorWlroots != nil {
+		drawWlrootsBadgeLayer(m.modeIndicatorWlroots, posX, posY, label, colors, style)
 	}
 }
 
 // DrawStickyModifiersIndicator draws the sticky modifiers indicator overlay.
 func (m *Manager) DrawStickyModifiersIndicator(posX, posY int, symbols string) {
-	if m.stickyModifiersOverlay == nil {
+	if symbols == "" {
+		m.renderMu.Lock()
+		defer m.renderMu.Unlock()
+
+		m.clearStickyBadgeLocked()
+		m.hideStickyIndicatorLayerLocked()
+
 		return
 	}
 
-	m.renderMu.Lock()
-	defer m.renderMu.Unlock()
-
-	if symbols == "" {
-		m.clearStickyBadgeLocked()
-
+	if m.stickyModifiersOverlay == nil {
 		return
 	}
 
@@ -449,6 +497,9 @@ func (m *Manager) DrawStickyModifiersIndicator(posX, posY int, symbols string) {
 		return
 	}
 
+	m.renderMu.Lock()
+	defer m.renderMu.Unlock()
+
 	m.clearStickyBadgeLocked()
 	m.stickyBadgeRect = expandRect(
 		badgeBounds(posX, posY, symbols, style),
@@ -456,10 +507,10 @@ func (m *Manager) DrawStickyModifiersIndicator(posX, posY int, symbols string) {
 	)
 	m.stickyBadgeVisible = true
 
-	if m.x11 != nil {
-		m.x11.DrawBadge(posX, posY, symbols, colors, style)
-	} else if m.wlroots != nil {
-		m.wlroots.DrawBadge(posX, posY, symbols, colors, style)
+	if m.stickyModifiersX11 != nil {
+		drawX11BadgeLayer(m.stickyModifiersX11, posX, posY, symbols, colors, style)
+	} else if m.stickyWlroots != nil {
+		drawWlrootsBadgeLayer(m.stickyWlroots, posX, posY, symbols, colors, style)
 	}
 }
 
@@ -617,6 +668,99 @@ func (m *Manager) clearStickyBadgeLocked() {
 
 	m.stickyBadgeVisible = false
 	m.stickyBadgeRect = image.Rectangle{}
+}
+
+func drawX11BadgeLayer(
+	layer *x11Overlay,
+	posX,
+	posY int,
+	text string,
+	colors overlayColors,
+	style overlayBadgeStyle,
+) {
+	if layer == nil || text == "" {
+		return
+	}
+
+	layer.Clear()
+	layer.DrawBadge(posX, posY, text, colors, style)
+	layer.Show()
+}
+
+func drawWlrootsBadgeLayer(
+	layer *wlrootsOverlay,
+	posX,
+	posY int,
+	text string,
+	colors overlayColors,
+	style overlayBadgeStyle,
+) {
+	if layer == nil || text == "" {
+		return
+	}
+
+	layer.Clear()
+	layer.DrawBadge(posX, posY, text, colors, style)
+}
+
+func (m *Manager) clearIndicatorLayersLocked() {
+	if m.modeIndicatorX11 != nil {
+		m.modeIndicatorX11.Clear()
+	}
+	if m.stickyModifiersX11 != nil {
+		m.stickyModifiersX11.Clear()
+	}
+	if m.modeIndicatorWlroots != nil {
+		m.modeIndicatorWlroots.Clear()
+	}
+	if m.stickyWlroots != nil {
+		m.stickyWlroots.Clear()
+	}
+}
+
+func (m *Manager) hideIndicatorLayersLocked() {
+	if m.modeIndicatorX11 != nil {
+		m.modeIndicatorX11.Clear()
+		m.modeIndicatorX11.Hide()
+	}
+	if m.stickyModifiersX11 != nil {
+		m.stickyModifiersX11.Clear()
+		m.stickyModifiersX11.Hide()
+	}
+	if m.modeIndicatorWlroots != nil {
+		m.modeIndicatorWlroots.Clear()
+		m.modeIndicatorWlroots.Hide()
+	}
+	if m.stickyWlroots != nil {
+		m.stickyWlroots.Clear()
+		m.stickyWlroots.Hide()
+	}
+}
+
+func (m *Manager) hideStickyIndicatorLayerLocked() {
+	if m.stickyModifiersX11 != nil {
+		m.stickyModifiersX11.Clear()
+		m.stickyModifiersX11.Hide()
+	}
+	if m.stickyWlroots != nil {
+		m.stickyWlroots.Clear()
+		m.stickyWlroots.Hide()
+	}
+}
+
+func (m *Manager) resizeIndicatorLayersLocked() {
+	if m.modeIndicatorX11 != nil {
+		m.modeIndicatorX11.Resize()
+	}
+	if m.stickyModifiersX11 != nil {
+		m.stickyModifiersX11.Resize()
+	}
+	if m.modeIndicatorWlroots != nil {
+		m.modeIndicatorWlroots.Resize()
+	}
+	if m.stickyWlroots != nil {
+		m.stickyWlroots.Resize()
+	}
 }
 
 func (m *Manager) publish(change StateChange) {

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -728,13 +728,14 @@ func (m *Manager) hideIndicatorLayersLocked() {
 		m.stickyModifiersX11.Clear()
 		m.stickyModifiersX11.Hide()
 	}
+	// Use HideContent instead of Hide for Wayland indicator layers: commit a
+	// transparent buffer without destroying surfaces, so the next draw skips
+	// setup_buffers and its blocking compositor roundtrip.
 	if m.modeIndicatorWlroots != nil {
-		m.modeIndicatorWlroots.Clear()
-		m.modeIndicatorWlroots.Hide()
+		m.modeIndicatorWlroots.HideContent()
 	}
 	if m.stickyWlroots != nil {
-		m.stickyWlroots.Clear()
-		m.stickyWlroots.Hide()
+		m.stickyWlroots.HideContent()
 	}
 }
 
@@ -744,8 +745,7 @@ func (m *Manager) hideStickyIndicatorLayerLocked() {
 		m.stickyModifiersX11.Hide()
 	}
 	if m.stickyWlroots != nil {
-		m.stickyWlroots.Clear()
-		m.stickyWlroots.Hide()
+		m.stickyWlroots.HideContent()
 	}
 }
 

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -700,6 +700,7 @@ func drawWlrootsBadgeLayer(
 	}
 
 	layer.Clear()
+	// DrawBadge flushes and shows wlroots layer surfaces internally.
 	layer.DrawBadge(posX, posY, text, colors, style)
 }
 

--- a/internal/ui/overlay/manager_linux_wayland.go
+++ b/internal/ui/overlay/manager_linux_wayland.go
@@ -43,6 +43,7 @@ func (o *wlrootsOverlay) Show()                                                 
 func (o *wlrootsOverlay) Hide()                                                  {}
 func (o *wlrootsOverlay) Clear()                                                 {}
 func (o *wlrootsOverlay) ClearRect(image.Rectangle)                              {}
+func (o *wlrootsOverlay) HideContent()                                           {}
 func (o *wlrootsOverlay) Resize()                                                {}
 func (o *wlrootsOverlay) Destroy()                                               {}
 func (o *wlrootsOverlay) UpdateGridMatches(string)                               {}

--- a/internal/ui/overlay/manager_linux_wayland.go
+++ b/internal/ui/overlay/manager_linux_wayland.go
@@ -28,6 +28,11 @@ func newWlrootsOverlay(logger *zap.Logger) *wlrootsOverlay {
 	return nil
 }
 
+func newPassiveWlrootsOverlay(logger *zap.Logger) *wlrootsOverlay {
+	_ = logger
+	return nil
+}
+
 func (o *wlrootsOverlay) setDisplayMu(_ *sync.Mutex) {}
 func (o *wlrootsOverlay) startPoller()               {}
 func (o *wlrootsOverlay) Healthy() bool              { return false }
@@ -58,3 +63,4 @@ func (o *wlrootsOverlay) DrawRecursiveGrid(
 ) {
 }
 func (o *wlrootsOverlay) DrawBadge(int, int, string, overlayColors, overlayBadgeStyle) {}
+func (o *wlrootsOverlay) setKeyboardCaptureEnabled(bool)                              {}

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -579,6 +579,23 @@ static void neru_wayland_overlay_set_keyboard_capture(
     wl_display_roundtrip(overlay->display);
 }
 
+// Detach buffers from surfaces without destroying them.
+// Hides the overlay visually while keeping all surfaces and buffers allocated,
+// so the next DrawBadge call can reuse them without a compositor roundtrip.
+static void neru_wayland_overlay_detach(NeruWaylandOverlay *overlay) {
+    if (!overlay) return;
+    int any = 0;
+    for (int i = 0; i < overlay->nr_screens; i++) {
+        NeruWaylandOverlayScreen *scr = &overlay->screens[i];
+        if (scr->wl_surface) {
+            wl_surface_attach(scr->wl_surface, NULL, 0, 0);
+            wl_surface_commit(scr->wl_surface);
+            any = 1;
+        }
+    }
+    if (any) wl_display_flush(overlay->display);
+}
+
 static void neru_wayland_overlay_clear(NeruWaylandOverlay *overlay) {
     if (!overlay) return;
     for (int i = 0; i < overlay->nr_screens; i++) {
@@ -859,6 +876,16 @@ func (o *wlrootsOverlay) ClearRect(rect image.Rectangle) {
 			C.double(rect.Dy()),
 		)
 		C.neru_wayland_overlay_flush(o.raw)
+	}
+}
+
+// HideContent makes the overlay transparent without destroying surfaces.
+// Unlike Hide(), surfaces and buffers remain allocated so the next DrawBadge
+// call skips setup_buffers and its blocking wl_display_roundtrip.
+func (o *wlrootsOverlay) HideContent() {
+	if o != nil && o.raw != nil {
+		C.neru_wayland_overlay_clear(o.raw)
+		C.neru_wayland_overlay_detach(o.raw)
 	}
 }
 

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -56,6 +56,7 @@ typedef struct {
     int nr_screens;
 
     int configured;
+    int keyboard_interactive;
     int keyboard_interactivity_set;
 
     int event_fd;
@@ -362,14 +363,17 @@ static const struct wl_seat_listener seat_listener = {
     .name = neru_seat_name,
 };
 
-static NeruWaylandOverlay* neru_wayland_overlay_new(void) {
+static NeruWaylandOverlay* neru_wayland_overlay_new(int keyboard_interactive) {
     NeruWaylandOverlay *overlay = calloc(1, sizeof(NeruWaylandOverlay));
     if (!overlay) return NULL;
+    overlay->keyboard_interactive = keyboard_interactive;
 
-    // EXCLUSIVE by default for keyboard capture fallback
-    // SetKeyboardCaptureEnabled can change it to NONE when not needed
-    overlay->keyboard_interactivity_set =
-        ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
+    // Interactive overlays start with EXCLUSIVE so keyboard events are received.
+    // Passive indicator overlays always use NONE — they must not take keyboard focus.
+    // SetKeyboardCaptureEnabled can change it at runtime for the main overlay only.
+    overlay->keyboard_interactivity_set = keyboard_interactive
+        ? ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE
+        : ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
 
     overlay->display = wl_display_connect(NULL);
     if (!overlay->display) {
@@ -394,17 +398,20 @@ static NeruWaylandOverlay* neru_wayland_overlay_new(void) {
     }
     wl_display_roundtrip(overlay->display); // get screen sizes
 
-    // Setup seat listener for keyboard
-    if (overlay->wl_seat) {
+    // Setup seat listener for keyboard only on the primary interactive
+    // overlay. Passive indicator layers must not take keyboard focus.
+    if (overlay->keyboard_interactive && overlay->wl_seat) {
         wl_seat_add_listener(overlay->wl_seat, &seat_listener, overlay);
         wl_display_roundtrip(overlay->display);
     }
 
-    // Setup xkb context
-    overlay->xkb_ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (overlay->keyboard_interactive) {
+        // Setup xkb context
+        overlay->xkb_ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    }
 
     // Try to get keyboard immediately and set up listener
-    if (overlay->wl_seat) {
+    if (overlay->keyboard_interactive && overlay->wl_seat) {
         struct wl_keyboard *kb = wl_seat_get_keyboard(overlay->wl_seat);
         if (kb) {
             wl_keyboard_add_listener(kb, &keyboard_listener, overlay);
@@ -464,8 +471,6 @@ static void neru_wayland_overlay_setup_buffers(NeruWaylandOverlay *overlay) {
             ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT | ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM);
         zwlr_layer_surface_v1_set_exclusive_zone(scr->layer_surface, -1);
 
-        // Request exclusive keyboard interactivity when overlay is shown
-        // This tells the compositor to send keyboard events to this surface
         zwlr_layer_surface_v1_set_keyboard_interactivity(
             scr->layer_surface,
             overlay->keyboard_interactivity_set
@@ -765,6 +770,8 @@ type wlrootsOverlay struct {
 
 	stopCh chan struct{} // signals keyboardPoller to exit
 	doneCh chan struct{} // closed when keyboardPoller has exited
+
+	pollerStarted bool
 }
 
 func init() {
@@ -772,7 +779,15 @@ func init() {
 }
 
 func newWlrootsOverlay(logger *zap.Logger) *wlrootsOverlay {
-	raw := C.neru_wayland_overlay_new()
+	return newWlrootsOverlayWithKeyboard(logger, true)
+}
+
+func newPassiveWlrootsOverlay(logger *zap.Logger) *wlrootsOverlay {
+	return newWlrootsOverlayWithKeyboard(logger, false)
+}
+
+func newWlrootsOverlayWithKeyboard(logger *zap.Logger, keyboardInteractive bool) *wlrootsOverlay {
+	raw := C.neru_wayland_overlay_new(C.int(boolToInt(keyboardInteractive)))
 	if raw == nil {
 		return nil
 	}
@@ -792,6 +807,14 @@ func newWlrootsOverlay(logger *zap.Logger) *wlrootsOverlay {
 	// race: the poller reads displayMu on every iteration.
 
 	return overlay
+}
+
+func boolToInt(value bool) int {
+	if value {
+		return 1
+	}
+
+	return 0
 }
 
 func (o *wlrootsOverlay) Healthy() bool {
@@ -850,8 +873,11 @@ func (o *wlrootsOverlay) Destroy() {
 
 	// Signal the poller goroutine to stop and wait for it to exit
 	// before freeing the C struct, preventing a use-after-free.
-	close(o.stopCh)
-	<-o.doneCh
+	if o.pollerStarted {
+		close(o.stopCh)
+		<-o.doneCh
+		o.pollerStarted = false
+	}
 
 	C.neru_wayland_overlay_destroy(o.raw)
 	o.raw = nil
@@ -1100,6 +1126,11 @@ func (o *wlrootsOverlay) setKeyboardCaptureEnabled(enabled bool) {
 // startPoller launches the keyboard polling goroutine.
 // Must be called after setDisplayMu so the poller has a valid mutex.
 func (o *wlrootsOverlay) startPoller() {
+	if o == nil || o.pollerStarted {
+		return
+	}
+
+	o.pollerStarted = true
 	go o.keyboardPoller()
 }
 


### PR DESCRIPTION
## Summary
- render Linux mode and sticky modifier indicators on dedicated overlay layers
- clear and redraw indicator layers independently so cursor polling can move badges without trails
- keep wlroots indicator layers passive so they do not steal keyboard focus

Fixes #699.
Related to #698: this covers the Linux sticky indicator rendering piece, but not full sticky modifier input support.

## Tests
- go test ./internal/app/modes ./internal/ui/overlay ./internal/core/infra/overlay
- GOOS=linux CGO_ENABLED=0 go test -exec=true ./...