### PR TITLE
feat: support sticky modifiers on supported linux backends

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -626,6 +626,19 @@ enabled = true
 tap_max_duration = 300
 ```
 
+On Linux, the sticky modifier indicator renders the symbols `❖⇧⌥⌃`. If they
+appear as `[][][][]`, the selected font does not include those glyphs. Set
+`sticky_modifiers.ui.font_family` to a font on your system that can display
+those characters.
+
+```toml
+[sticky_modifiers.ui]
+font_family = "Your installed symbol-capable font"
+```
+
+You can quickly test a candidate font by pasting `❖⇧⌥⌃` into a text editor and
+checking whether it renders correctly.
+
 ---
 
 ## Theme Palette
@@ -744,6 +757,10 @@ defaults read com.apple.HIToolbox AppleEnabledInputSources
 ## Font Configuration
 
 Use `font_family` in any UI section (`hints.ui`, `grid.ui`, `recursive_grid.ui`, `mode_indicator.ui`, `sticky_modifiers.ui`). An empty string uses the system default.
+
+If the sticky modifier indicator shows `[][][][]` on Linux, your current font is
+missing the modifier glyphs `❖⇧⌥⌃`. Set `sticky_modifiers.ui.font_family` to a
+font installed on your system that renders those symbols correctly.
 
 ---
 

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -343,3 +343,20 @@ If the setup is correct, Neru should log:
 ```text
 Using Wayland evdev keyboard capture
 ```
+
+### Sticky modifier indicator shows `[][][][]`
+
+The sticky modifier overlay uses Unicode modifier symbols on Linux:
+`❖⇧⌥⌃`. If you see square boxes instead, the configured font does not include
+those glyphs.
+
+Set a font explicitly in your config:
+
+```toml
+[sticky_modifiers.ui]
+font_family = "Your installed symbol-capable font"
+```
+
+An empty `font_family` uses the system default, which may not have the required
+symbol coverage. A quick way to verify a candidate font is to paste `❖⇧⌥⌃` into
+a text editor and confirm the symbols render there first.

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -24,6 +24,44 @@ Neru provides native Linux support through two display server backends:
 
 ---
 
+## Wayland Keyboard Capture Permissions
+
+On wlroots-based Wayland compositors, Neru uses direct `evdev` keyboard capture
+during active modes so modified clicks like `Ctrl+click` and sticky modifiers
+work reliably against the app underneath the overlay.
+
+This requires permission to open and grab `/dev/input/event*` keyboard devices.
+On many distros those devices are owned by `root:input` with mode `0660`, so
+your user must be in the `input` group.
+
+```bash
+sudo usermod -aG input "$USER"
+```
+
+Then fully log out and back in, or reboot, and confirm:
+
+```bash
+id
+```
+
+You should see `input` in the printed group list.
+
+> **Security note:** Membership in `input` allows reading system-wide keyboard
+> events. If that access is too broad for your environment, use a tighter
+> distro-specific `udev`/ACL setup instead of the group-based approach.
+
+When the backend is active, Neru logs:
+
+```text
+Using Wayland evdev keyboard capture
+```
+
+If Neru cannot access the devices, it falls back to overlay-focused keyboard
+capture. Basic mode navigation still works, but modified clicks and sticky
+modifier behavior may be degraded under Wayland.
+
+---
+
 ## Using nix home manager
 
 Below is a minimal single flake with home manager setup.
@@ -207,11 +245,15 @@ bind = $mod SHIFT, S, exec, neru scroll
 ```kdl
 // ~/.config/niri/config.kdl
 binds {
-    Mod+Shift+H { spawn-sh "neru hints"; }
-    Mod+Shift+G { spawn-sh "neru grid"; }
-    Mod+Shift+S { spawn-sh "neru scroll"; }
+    Mod+Shift+H repeat=false { spawn-sh "neru hints"; }
+    Mod+Shift+G repeat=false { spawn-sh "neru grid"; }
+    Mod+Shift+S repeat=false { spawn-sh "neru scroll"; }
+    Mod+Shift+R repeat=false { spawn-sh "neru recursive_grid"; }
 }
 ```
+
+`niri` binds repeat by default. Use `repeat=false` for Neru mode launchers so
+holding the activation key does not continuously relaunch the mode.
 
 ### 2. Application Exclusions
 
@@ -253,6 +295,10 @@ systemctl --user enable --now neru
 2. **Accessibility (AT-SPI)**: Full AT-SPI integration for clickable element discovery (hints mode) is currently unavailable natively under Wayland without relying on experimental plugins. Grid mode and scroll mode both work perfectly without AT-SPI.
 3. **Dark mode / Theme polling detection**: Not yet implemented. Output will fall back to default theme definitions.
 4. **Notifications**: Desktop notifications (`org.freedesktop.Notifications`) will log to stdout/file instead of pushing to DBus.
+5. **Wayland modified clicks need evdev access**: On wlroots compositors, reliable
+   modified pointer actions depend on the `evdev` keyboard-capture path described
+   above. Without `/dev/input/event*` access, Neru falls back to a less capable
+   overlay-focused path.
 
 ---
 
@@ -273,4 +319,27 @@ Check that `WAYLAND_DISPLAY` is set correctly and the Wayland socket permissions
 ```bash
 echo $WAYLAND_DISPLAY
 wl-info  # from wayland-utils package
+```
+
+### "Wayland evdev capture unavailable; falling back to overlay keyboard focus"
+
+Neru could not open and grab the keyboard devices needed for reliable Wayland
+modifier handling.
+
+Common fix:
+
+```bash
+sudo usermod -aG input "$USER"
+```
+
+Then log out and back in, and confirm:
+
+```bash
+id
+```
+
+If the setup is correct, Neru should log:
+
+```text
+Using Wayland evdev keyboard capture
 ```

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -117,6 +117,13 @@ func (h *Handler) performCommonCleanup() {
 	h.hotkeyLastKey = ""
 	h.hotkeyLastKeyTime = 0
 
+	// Release synthetic sticky modifiers before disabling the Wayland event tap.
+	// The evdev-backed tap restores overlay keyboard focus during shutdown; if
+	// we post modifier key-up events after that handoff, the overlay can receive
+	// the release instead of the target app and leave the app "stuck" with the
+	// modifier still logically held.
+	h.clearStickyModifiers()
+
 	if h.disableEventTap != nil {
 		h.disableEventTap()
 	}

--- a/internal/app/modes/cleanup_test.go
+++ b/internal/app/modes/cleanup_test.go
@@ -1,0 +1,55 @@
+//nolint:testpackage // Tests private cleanup ordering.
+package modes
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	configpkg "github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/domain/action"
+	"github.com/y3owk1n/neru/internal/core/domain/state"
+	"github.com/y3owk1n/neru/internal/ui/overlay"
+)
+
+func TestPerformCommonCleanup_ReleasesStickyModifiersBeforeDisablingEventTap(t *testing.T) {
+	t.Parallel()
+
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeHints)
+
+	var callOrder []string
+
+	handler := &Handler{
+		logger:         zap.NewNop(),
+		config:         &configpkg.Config{},
+		appState:       appState,
+		modifierState:  state.NewModifierState(),
+		overlayManager: &overlay.NoOpManager{},
+		disableEventTap: func() {
+			callOrder = append(callOrder, "disable")
+		},
+		postModifierEvent: func(modifier string, isDown bool) {
+			callOrder = append(callOrder, modifier)
+			if isDown {
+				t.Fatalf("unexpected modifier down for %s during cleanup", modifier)
+			}
+		},
+	}
+
+	handler.modifierState.Toggle(action.ModCtrl)
+	handler.performCommonCleanup()
+
+	if len(callOrder) < 2 {
+		t.Fatalf("expected modifier release and disable callbacks, got %v", callOrder)
+	}
+
+	if callOrder[0] != "ctrl" || callOrder[1] != "disable" {
+		t.Fatalf("cleanup order = %v, want [ctrl disable ...]", callOrder)
+	}
+
+	if got := handler.modifierState.Current(); got != 0 {
+		t.Fatalf("modifierState.Current() = %v, want 0", got)
+	}
+}

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -156,7 +156,11 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 						h.drawStickyModifiersIndicator(localStickyX, localStickyY)
 					} else if stickyInd := h.overlayManager.StickyModifiersOverlay(); stickyInd != nil {
 						if h.stickyIndicatorService != nil {
-							h.stickyIndicatorService.UpdateIndicatorPosition(localStickyX, localStickyY, "")
+							h.stickyIndicatorService.UpdateIndicatorPosition(
+								localStickyX,
+								localStickyY,
+								"",
+							)
 						}
 
 						stickyInd.Clear()

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -155,6 +155,10 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 
 						h.drawStickyModifiersIndicator(localStickyX, localStickyY)
 					} else if stickyInd := h.overlayManager.StickyModifiersOverlay(); stickyInd != nil {
+						if h.stickyIndicatorService != nil {
+							h.stickyIndicatorService.UpdateIndicatorPosition(localStickyX, localStickyY, "")
+						}
+
 						stickyInd.Clear()
 						stickyInd.Hide()
 					}

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -13,6 +13,14 @@ import (
 
 const hotkeySequenceTimeout = 500 * time.Millisecond
 
+const (
+	keyPartCmd    = "cmd"
+	keyPartShift  = "shift"
+	keyPartAlt    = "alt"
+	keyPartCtrl   = "ctrl"
+	keyPartOption = "option"
+)
+
 // HandleKeyPress dispatches key events by current mode.
 func (h *Handler) HandleKeyPress(key string) {
 	h.mu.Lock()
@@ -89,23 +97,23 @@ func (h *Handler) stripStickyModifiersFromKey(key string, mods action.Modifiers)
 		if i < len(parts)-1 {
 			lowerPart := strings.ToLower(part)
 
-			if lowerPart == "cmd" && mods.Has(action.ModCmd) {
+			if lowerPart == keyPartCmd && mods.Has(action.ModCmd) {
 				continue
 			}
 
-			if lowerPart == "shift" && mods.Has(action.ModShift) {
+			if lowerPart == keyPartShift && mods.Has(action.ModShift) {
 				continue
 			}
 
-			if lowerPart == "alt" && mods.Has(action.ModAlt) {
+			if lowerPart == keyPartAlt && mods.Has(action.ModAlt) {
 				continue
 			}
 
-			if lowerPart == "ctrl" && mods.Has(action.ModCtrl) {
+			if lowerPart == keyPartCtrl && mods.Has(action.ModCtrl) {
 				continue
 			}
 
-			if lowerPart == "option" && mods.Has(action.ModAlt) {
+			if lowerPart == keyPartOption && mods.Has(action.ModAlt) {
 				continue
 			}
 		}

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -51,19 +51,10 @@ func (h *Handler) HandleKeyPress(key string) {
 	}
 
 	// Check for per-mode hotkeys before mode-specific handling.
-	// Try the raw key first to preserve explicit modifier combos, then the
-	// stripped key so sticky-held modifiers do not break plain bindings.
+	// If sticky modifiers were stripped, resolve bindings with the stripped key
+	// only. Sticky modifiers are for the next action, not Neru's own navigation
+	// keys; using rawKey here would make a sticky Ctrl turn "c" into "Ctrl+c".
 	if rawKey != key {
-		savedLastKey := h.hotkeyLastKey
-		savedLastKeyTime := h.hotkeyLastKeyTime
-
-		if h.handleHotkey(rawKey, bundleID) {
-			return
-		}
-
-		h.hotkeyLastKey = savedLastKey
-		h.hotkeyLastKeyTime = savedLastKeyTime
-
 		if h.handleHotkey(key, bundleID) {
 			return
 		}

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage // These tests validate unexported handler behavior directly.
 package modes
 
 import (

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -1,0 +1,73 @@
+package modes
+
+import (
+	"image"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	configpkg "github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/domain/action"
+	"github.com/y3owk1n/neru/internal/core/domain/state"
+)
+
+type recordingMode struct {
+	keys chan string
+}
+
+func (m *recordingMode) Activate(ModeActivationOptions) {}
+func (m *recordingMode) HandleKey(key string)           { m.keys <- key }
+func (m *recordingMode) Exit()                          {}
+func (m *recordingMode) ModeType() domain.Mode          { return domain.ModeRecursiveGrid }
+
+func TestHandleKeyPressUsesStickyStrippedKeyForBindings(t *testing.T) {
+	t.Parallel()
+
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeRecursiveGrid)
+
+	mode := &recordingMode{keys: make(chan string, 1)}
+	hotkeyActions := make(chan string, 1)
+
+	handler := &Handler{
+		config: &configpkg.Config{
+			RecursiveGrid: configpkg.RecursiveGridConfig{
+				Hotkeys: map[string]configpkg.StringOrStringArray{
+					"Ctrl+C": {"exit"},
+				},
+			},
+		},
+		logger:        zap.NewNop(),
+		appState:      appState,
+		modifierState: state.NewModifierState(),
+		modes: map[domain.Mode]Mode{
+			domain.ModeRecursiveGrid: mode,
+		},
+		screenBounds: image.Rect(0, 0, 100, 100),
+		executeHotkeyAction: func(_, actionStr string) error {
+			hotkeyActions <- actionStr
+
+			return nil
+		},
+	}
+	handler.modifierState.Toggle(action.ModCtrl)
+
+	handler.HandleKeyPress("Ctrl+c")
+
+	select {
+	case got := <-mode.keys:
+		if got != "c" {
+			t.Fatalf("mode key = %q, want %q", got, "c")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stripped mode key")
+	}
+
+	select {
+	case got := <-hotkeyActions:
+		t.Fatalf("sticky modifier leaked into hotkey action %q", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/internal/core/infra/accessibility/element_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/accessibility/element_linux_wayland_wlroots_cgo.go
@@ -104,6 +104,7 @@ func wlrootsLeftMouseUpAtPoint(point image.Point, modifiers action.Modifiers) er
 			return err
 		}
 	}
+
 	defer func() {
 		_ = wlrootsReleaseModifiers(modifiers)
 	}()
@@ -133,6 +134,7 @@ func wlrootsClickButtonAtPoint(
 	if err != nil {
 		return err
 	}
+
 	defer func() {
 		_ = wlrootsReleaseModifiers(modifiers)
 	}()
@@ -151,27 +153,34 @@ func wlrootsClickButtonAtPoint(
 
 func wlrootsPressModifiers(modifiers action.Modifiers) error {
 	if modifiers.Has(action.ModShift) {
-		if err := linux.WlrootsModifierEvent("shift", true); err != nil {
+		err := linux.WlrootsModifierEvent("shift", true)
+		if err != nil {
 			return err
 		}
 	}
+
 	if modifiers.Has(action.ModCtrl) {
-		if err := linux.WlrootsModifierEvent("ctrl", true); err != nil {
+		err := linux.WlrootsModifierEvent("ctrl", true)
+		if err != nil {
 			_ = linux.WlrootsModifierEvent("shift", false)
 
 			return err
 		}
 	}
+
 	if modifiers.Has(action.ModAlt) {
-		if err := linux.WlrootsModifierEvent("alt", true); err != nil {
+		err := linux.WlrootsModifierEvent("alt", true)
+		if err != nil {
 			_ = linux.WlrootsModifierEvent("ctrl", false)
 			_ = linux.WlrootsModifierEvent("shift", false)
 
 			return err
 		}
 	}
+
 	if modifiers.Has(action.ModCmd) {
-		if err := linux.WlrootsModifierEvent("cmd", true); err != nil {
+		err := linux.WlrootsModifierEvent("cmd", true)
+		if err != nil {
 			_ = linux.WlrootsModifierEvent("alt", false)
 			_ = linux.WlrootsModifierEvent("ctrl", false)
 			_ = linux.WlrootsModifierEvent("shift", false)
@@ -185,8 +194,10 @@ func wlrootsPressModifiers(modifiers action.Modifiers) error {
 
 func wlrootsReleaseModifiers(modifiers action.Modifiers) error {
 	var firstErr error
+
 	release := func(modifier string) {
-		if err := linux.WlrootsModifierEvent(modifier, false); err != nil && firstErr == nil {
+		err := linux.WlrootsModifierEvent(modifier, false)
+		if err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -194,12 +205,15 @@ func wlrootsReleaseModifiers(modifiers action.Modifiers) error {
 	if modifiers.Has(action.ModCmd) {
 		release("cmd")
 	}
+
 	if modifiers.Has(action.ModAlt) {
 		release("alt")
 	}
+
 	if modifiers.Has(action.ModCtrl) {
 		release("ctrl")
 	}
+
 	if modifiers.Has(action.ModShift) {
 		release("shift")
 	}

--- a/internal/core/infra/accessibility/element_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/accessibility/element_linux_wayland_wlroots_cgo.go
@@ -13,8 +13,9 @@ import (
 )
 
 type wlrootsPointerState struct {
-	mu        sync.RWMutex
-	mouseDown bool
+	mu                 sync.RWMutex
+	mouseDown          bool
+	mouseDownModifiers action.Modifiers
 }
 
 var globalWlrootsPointerState = &wlrootsPointerState{}
@@ -53,20 +54,7 @@ func wlrootsLeftClickAtPoint(
 	restoreCursor bool,
 	modifiers action.Modifiers,
 ) error {
-	_ = modifiers // modifier injection not yet supported on Wayland
-
-	original := wlrootsCurrentCursorPosition()
-
-	err := linux.WlrootsClick(point, linux.WlrBtnLeft)
-	if err != nil {
-		return err
-	}
-
-	if restoreCursor {
-		_ = linux.WlrootsMoveCursorToPoint(original)
-	}
-
-	return nil
+	return wlrootsClickButtonAtPoint(point, restoreCursor, modifiers, linux.WlrBtnLeft)
 }
 
 func wlrootsRightClickAtPoint(
@@ -74,20 +62,7 @@ func wlrootsRightClickAtPoint(
 	restoreCursor bool,
 	modifiers action.Modifiers,
 ) error {
-	_ = modifiers
-
-	original := wlrootsCurrentCursorPosition()
-
-	err := linux.WlrootsClick(point, linux.WlrBtnRight)
-	if err != nil {
-		return err
-	}
-
-	if restoreCursor {
-		_ = linux.WlrootsMoveCursorToPoint(original)
-	}
-
-	return nil
+	return wlrootsClickButtonAtPoint(point, restoreCursor, modifiers, linux.WlrBtnRight)
 }
 
 func wlrootsMiddleClickAtPoint(
@@ -95,39 +70,43 @@ func wlrootsMiddleClickAtPoint(
 	restoreCursor bool,
 	modifiers action.Modifiers,
 ) error {
-	_ = modifiers
+	return wlrootsClickButtonAtPoint(point, restoreCursor, modifiers, linux.WlrBtnMiddle)
+}
 
-	original := wlrootsCurrentCursorPosition()
-
-	err := linux.WlrootsClick(point, linux.WlrBtnMiddle)
+func wlrootsLeftMouseDownAtPoint(point image.Point, modifiers action.Modifiers) error {
+	err := wlrootsPressModifiers(modifiers)
 	if err != nil {
 		return err
 	}
 
-	if restoreCursor {
-		_ = linux.WlrootsMoveCursorToPoint(original)
-	}
-
-	return nil
-}
-
-func wlrootsLeftMouseDownAtPoint(point image.Point, modifiers action.Modifiers) error {
-	_ = modifiers
-
-	err := linux.WlrootsButtonEvent(point, linux.WlrBtnLeft, true)
+	err = linux.WlrootsButtonEvent(point, linux.WlrBtnLeft, true)
 	if err != nil {
+		_ = wlrootsReleaseModifiers(modifiers)
+
 		return err
 	}
 
 	globalWlrootsPointerState.mu.Lock()
 	globalWlrootsPointerState.mouseDown = true
+	globalWlrootsPointerState.mouseDownModifiers = modifiers
 	globalWlrootsPointerState.mu.Unlock()
 
 	return nil
 }
 
 func wlrootsLeftMouseUpAtPoint(point image.Point, modifiers action.Modifiers) error {
-	_ = modifiers
+	heldModifiers, hadMouseDown := wlrootsMouseDownModifiers()
+	if hadMouseDown {
+		modifiers = heldModifiers
+	} else {
+		err := wlrootsPressModifiers(modifiers)
+		if err != nil {
+			return err
+		}
+	}
+	defer func() {
+		_ = wlrootsReleaseModifiers(modifiers)
+	}()
 
 	err := linux.WlrootsButtonEvent(point, linux.WlrBtnLeft, false)
 	if err != nil {
@@ -136,22 +115,123 @@ func wlrootsLeftMouseUpAtPoint(point image.Point, modifiers action.Modifiers) er
 
 	globalWlrootsPointerState.mu.Lock()
 	globalWlrootsPointerState.mouseDown = false
+	globalWlrootsPointerState.mouseDownModifiers = 0
 	globalWlrootsPointerState.mu.Unlock()
 
 	return nil
 }
 
+func wlrootsClickButtonAtPoint(
+	point image.Point,
+	restoreCursor bool,
+	modifiers action.Modifiers,
+	button int,
+) error {
+	original := wlrootsCurrentCursorPosition()
+
+	err := wlrootsPressModifiers(modifiers)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = wlrootsReleaseModifiers(modifiers)
+	}()
+
+	err = linux.WlrootsClick(point, button)
+	if err != nil {
+		return err
+	}
+
+	if restoreCursor {
+		_ = linux.WlrootsMoveCursorToPoint(original)
+	}
+
+	return nil
+}
+
+func wlrootsPressModifiers(modifiers action.Modifiers) error {
+	if modifiers.Has(action.ModShift) {
+		if err := linux.WlrootsModifierEvent("shift", true); err != nil {
+			return err
+		}
+	}
+	if modifiers.Has(action.ModCtrl) {
+		if err := linux.WlrootsModifierEvent("ctrl", true); err != nil {
+			_ = linux.WlrootsModifierEvent("shift", false)
+
+			return err
+		}
+	}
+	if modifiers.Has(action.ModAlt) {
+		if err := linux.WlrootsModifierEvent("alt", true); err != nil {
+			_ = linux.WlrootsModifierEvent("ctrl", false)
+			_ = linux.WlrootsModifierEvent("shift", false)
+
+			return err
+		}
+	}
+	if modifiers.Has(action.ModCmd) {
+		if err := linux.WlrootsModifierEvent("cmd", true); err != nil {
+			_ = linux.WlrootsModifierEvent("alt", false)
+			_ = linux.WlrootsModifierEvent("ctrl", false)
+			_ = linux.WlrootsModifierEvent("shift", false)
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+func wlrootsReleaseModifiers(modifiers action.Modifiers) error {
+	var firstErr error
+	release := func(modifier string) {
+		if err := linux.WlrootsModifierEvent(modifier, false); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	if modifiers.Has(action.ModCmd) {
+		release("cmd")
+	}
+	if modifiers.Has(action.ModAlt) {
+		release("alt")
+	}
+	if modifiers.Has(action.ModCtrl) {
+		release("ctrl")
+	}
+	if modifiers.Has(action.ModShift) {
+		release("shift")
+	}
+
+	return firstErr
+}
+
 func wlrootsLeftMouseUp() error {
+	modifiers, hadMouseDown := wlrootsMouseDownModifiers()
+
 	err := linux.WlrootsButtonRelease(linux.WlrBtnLeft)
 	if err != nil {
 		return err
 	}
 
+	if hadMouseDown {
+		_ = wlrootsReleaseModifiers(modifiers)
+	}
+
 	globalWlrootsPointerState.mu.Lock()
 	globalWlrootsPointerState.mouseDown = false
+	globalWlrootsPointerState.mouseDownModifiers = 0
 	globalWlrootsPointerState.mu.Unlock()
 
 	return nil
+}
+
+func wlrootsMouseDownModifiers() (action.Modifiers, bool) {
+	globalWlrootsPointerState.mu.RLock()
+	defer globalWlrootsPointerState.mu.RUnlock()
+
+	return globalWlrootsPointerState.mouseDownModifiers, globalWlrootsPointerState.mouseDown
 }
 
 // wlrootsScrollScale and wlrootsScrollMaxEvents mirror the X11 scroll

--- a/internal/core/infra/accessibility/element_linux_x11_cgo.go
+++ b/internal/core/infra/accessibility/element_linux_x11_cgo.go
@@ -526,13 +526,13 @@ func x11PressModifiers(display *C.Display, modifiers action.Modifiers) {
 		C.neru_ax_press_modifier(display, C.XK_Alt_L)
 	}
 	if modifiers.Has(action.ModCmd) {
-		C.neru_ax_press_modifier(display, C.XK_Meta_L)
+		C.neru_ax_press_modifier(display, C.XK_Super_L)
 	}
 }
 
 func x11ReleaseModifiers(display *C.Display, modifiers action.Modifiers) {
 	if modifiers.Has(action.ModCmd) {
-		C.neru_ax_release_modifier(display, C.XK_Meta_L)
+		C.neru_ax_release_modifier(display, C.XK_Super_L)
 	}
 	if modifiers.Has(action.ModAlt) {
 		C.neru_ax_release_modifier(display, C.XK_Alt_L)

--- a/internal/core/infra/eventtap/eventtap_darwin.go
+++ b/internal/core/infra/eventtap/eventtap_darwin.go
@@ -234,7 +234,7 @@ func (et *EventTap) SetPassthroughCallback(callback PassthroughCallback) {
 
 // SetStickyModifierToggle enables or disables sticky modifier toggle detection.
 // When enabled, modifier key events (Shift, Cmd, Alt, Ctrl) are detected and
-// callback is invoked with "__modifier_<name>" strings.
+// callback is invoked with "__modifier_<name>_down/up" strings.
 func (et *EventTap) SetStickyModifierToggle(enabled bool) {
 	if et.handle == nil {
 		et.logger.Warn("Cannot set sticky modifier toggle on nil event tap")

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -216,7 +216,7 @@ func (et *EventTap) rememberSyntheticModifierEvent(modifier string, isDown bool)
 	et.mu.Lock()
 	defer et.mu.Unlock()
 
-	pending := et.syntheticModifierEvents[:0]
+	pending := make([]pendingSyntheticModifierEvent, 0, len(et.syntheticModifierEvents))
 	for _, event := range et.syntheticModifierEvents {
 		if now.Before(event.expiresAt) {
 			pending = append(pending, event)
@@ -236,7 +236,7 @@ func (et *EventTap) consumeSyntheticModifierEvent(modifier string, isDown bool) 
 	et.mu.Lock()
 	defer et.mu.Unlock()
 
-	pending := et.syntheticModifierEvents[:0]
+	pending := make([]pendingSyntheticModifierEvent, 0, len(et.syntheticModifierEvents))
 	consumed := false
 
 	for _, event := range et.syntheticModifierEvents {

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -137,6 +137,7 @@ func (et *EventTap) PostModifierEvent(modifier string, isDown bool) {
 	}
 
 	et.rememberSyntheticModifierEvent(modifier, isDown)
+
 	if !postLinuxModifierEvent(modifier, isDown) {
 		et.consumeSyntheticModifierEvent(modifier, isDown)
 	}
@@ -183,14 +184,14 @@ func (et *EventTap) stickyToggleEnabled() bool {
 
 func canonicalLinuxModifier(modifier string) string {
 	switch strings.ToLower(strings.TrimSpace(modifier)) {
-	case "cmd", "command", "super", "meta":
-		return "cmd"
-	case "shift":
-		return "shift"
-	case "alt", "option":
-		return "alt"
-	case "ctrl", "control":
-		return "ctrl"
+	case evdevModifierCmd, "command", "super", "meta":
+		return evdevModifierCmd
+	case evdevModifierShift:
+		return evdevModifierShift
+	case evdevModifierAlt, "option":
+		return evdevModifierAlt
+	case evdevModifierCtrl, "control":
+		return evdevModifierCtrl
 	default:
 		return ""
 	}
@@ -223,11 +224,12 @@ func (et *EventTap) rememberSyntheticModifierEvent(modifier string, isDown bool)
 		}
 	}
 
-	et.syntheticModifierEvents = append(pending, pendingSyntheticModifierEvent{
+	pending = append(pending, pendingSyntheticModifierEvent{
 		modifier:  modifier,
 		isDown:    isDown,
 		expiresAt: now.Add(syntheticModifierSuppressionWindow),
 	})
+	et.syntheticModifierEvents = pending
 }
 
 func (et *EventTap) consumeSyntheticModifierEvent(modifier string, isDown bool) bool {

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -17,6 +18,14 @@ type (
 	PassthroughCallback func()
 )
 
+type pendingSyntheticModifierEvent struct {
+	modifier  string
+	isDown    bool
+	expiresAt time.Time
+}
+
+const syntheticModifierSuppressionWindow = 250 * time.Millisecond
+
 // EventTap intercepts keyboard events on Linux.
 type EventTap struct {
 	logger *zap.Logger
@@ -27,6 +36,8 @@ type EventTap struct {
 	hotkeys              []string
 	stickyModifierToggle bool
 	enabled              bool
+
+	syntheticModifierEvents []pendingSyntheticModifierEvent
 
 	stopCh chan struct{}
 	doneCh chan struct{}
@@ -119,7 +130,17 @@ func (et *EventTap) SetStickyModifierToggle(enabled bool) {
 }
 
 // PostModifierEvent posts a modifier key event.
-func (et *EventTap) PostModifierEvent(_ string, _ bool) {}
+func (et *EventTap) PostModifierEvent(modifier string, isDown bool) {
+	modifier = canonicalLinuxModifier(modifier)
+	if modifier == "" {
+		return
+	}
+
+	et.rememberSyntheticModifierEvent(modifier, isDown)
+	if !postLinuxModifierEvent(modifier, isDown) {
+		et.consumeSyntheticModifierEvent(modifier, isDown)
+	}
+}
 
 // SetKeyboardLayout sets the keyboard layout.
 func (et *EventTap) SetKeyboardLayout(_ string) bool { return true }
@@ -158,6 +179,83 @@ func (et *EventTap) stickyToggleEnabled() bool {
 	defer et.mu.RUnlock()
 
 	return et.stickyModifierToggle
+}
+
+func canonicalLinuxModifier(modifier string) string {
+	switch strings.ToLower(strings.TrimSpace(modifier)) {
+	case "cmd", "command", "super", "meta":
+		return "cmd"
+	case "shift":
+		return "shift"
+	case "alt", "option":
+		return "alt"
+	case "ctrl", "control":
+		return "ctrl"
+	default:
+		return ""
+	}
+}
+
+func linuxModifierToggleEvent(modifier string, isDown bool) string {
+	modifier = canonicalLinuxModifier(modifier)
+	if modifier == "" {
+		return ""
+	}
+
+	suffix := "up"
+	if isDown {
+		suffix = "down"
+	}
+
+	return "__modifier_" + modifier + "_" + suffix
+}
+
+func (et *EventTap) rememberSyntheticModifierEvent(modifier string, isDown bool) {
+	now := time.Now()
+
+	et.mu.Lock()
+	defer et.mu.Unlock()
+
+	pending := et.syntheticModifierEvents[:0]
+	for _, event := range et.syntheticModifierEvents {
+		if now.Before(event.expiresAt) {
+			pending = append(pending, event)
+		}
+	}
+
+	et.syntheticModifierEvents = append(pending, pendingSyntheticModifierEvent{
+		modifier:  modifier,
+		isDown:    isDown,
+		expiresAt: now.Add(syntheticModifierSuppressionWindow),
+	})
+}
+
+func (et *EventTap) consumeSyntheticModifierEvent(modifier string, isDown bool) bool {
+	now := time.Now()
+
+	et.mu.Lock()
+	defer et.mu.Unlock()
+
+	pending := et.syntheticModifierEvents[:0]
+	consumed := false
+
+	for _, event := range et.syntheticModifierEvents {
+		if !now.Before(event.expiresAt) {
+			continue
+		}
+
+		if !consumed && event.modifier == modifier && event.isDown == isDown {
+			consumed = true
+
+			continue
+		}
+
+		pending = append(pending, event)
+	}
+
+	et.syntheticModifierEvents = pending
+
+	return consumed
 }
 
 func normalizeLinuxKey(key string) string {

--- a/internal/core/infra/eventtap/eventtap_linux_common_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common_test.go
@@ -1,0 +1,52 @@
+//go:build linux
+
+package eventtap
+
+import "testing"
+
+func TestLinuxModifierToggleEventCanonicalizes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		modifier string
+		isDown   bool
+		want     string
+	}{
+		{name: "shift down", modifier: "shift", isDown: true, want: "__modifier_shift_down"},
+		{name: "control alias up", modifier: "control", isDown: false, want: "__modifier_ctrl_up"},
+		{name: "super alias down", modifier: "super", isDown: true, want: "__modifier_cmd_down"},
+		{name: "option alias up", modifier: "option", isDown: false, want: "__modifier_alt_up"},
+		{name: "unknown", modifier: "fn", isDown: true, want: ""},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := linuxModifierToggleEvent(testCase.modifier, testCase.isDown)
+			if got != testCase.want {
+				t.Fatalf("linuxModifierToggleEvent(%q, %t) = %q, want %q",
+					testCase.modifier,
+					testCase.isDown,
+					got,
+					testCase.want)
+			}
+		})
+	}
+}
+
+func TestSyntheticModifierSuppressionConsumesOnce(t *testing.T) {
+	t.Parallel()
+
+	eventTap := NewEventTap(nil, nil)
+	eventTap.rememberSyntheticModifierEvent("shift", true)
+
+	if !eventTap.consumeSyntheticModifierEvent("shift", true) {
+		t.Fatal("expected first matching synthetic event to be consumed")
+	}
+
+	if eventTap.consumeSyntheticModifierEvent("shift", true) {
+		t.Fatal("expected synthetic event to be consumed only once")
+	}
+}

--- a/internal/core/infra/eventtap/eventtap_linux_common_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common_test.go
@@ -1,5 +1,6 @@
 //go:build linux
 
+//nolint:testpackage // These tests validate unexported Linux eventtap helpers directly.
 package eventtap
 
 import "testing"

--- a/internal/core/infra/eventtap/eventtap_linux_nocgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_nocgo.go
@@ -9,3 +9,7 @@ func (et *EventTap) runWayland() {
 func (et *EventTap) runX11() {
 	close(et.doneCh)
 }
+
+func postLinuxModifierEvent(_ string, _ bool) bool {
+	return false
+}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland.go
@@ -43,6 +43,7 @@ func (et *EventTap) runWayland() {
 			if key == "" {
 				continue
 			}
+
 			if strings.HasPrefix(key, "__modifier_") && !et.stickyToggleEnabled() {
 				continue
 			}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland.go
@@ -47,6 +47,10 @@ func (et *EventTap) runWayland() {
 			if strings.HasPrefix(key, "__modifier_") && !et.stickyToggleEnabled() {
 				continue
 			}
+			// Note: consumeSyntheticModifierEvent is intentionally NOT called here.
+			// On Wayland, PostModifierEvent drives zwp_virtual_keyboard_v1_modifiers
+			// which sets modifier state directly without producing wl_keyboard.key
+			// events. Therefore synthetic modifier events never arrive in keyCh.
 
 			et.dispatchKey(key)
 		}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland.go
@@ -4,6 +4,7 @@ package eventtap
 
 import (
 	"os"
+	"strings"
 
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
@@ -36,6 +37,9 @@ func (et *EventTap) runWayland() {
 
 			key = normalizeLinuxKey(key)
 			if key == "" {
+				continue
+			}
+			if strings.HasPrefix(key, "__modifier_") && !et.stickyToggleEnabled() {
 				continue
 			}
 

--- a/internal/core/infra/eventtap/eventtap_linux_wayland.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland.go
@@ -16,6 +16,10 @@ func (et *EventTap) runWayland() {
 		return
 	}
 
+	if et.runWaylandEvdev() {
+		return
+	}
+
 	mgr := overlay.Get()
 	if mgr == nil {
 		return

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -63,7 +63,15 @@ import (
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
-var errWaylandEvdevUnavailable = errors.New("wayland evdev capture unavailable")
+const (
+	waylandEvdevEventBufferSize           = 128
+	waylandEvdevModifierReleasePollPeriod = 5 * time.Millisecond
+)
+
+var (
+	errWaylandEvdevUnavailable = errors.New("wayland evdev capture unavailable")
+	errWaylandEvdevGrabFailed  = errors.New("wayland evdev grab failed")
+)
 
 type waylandEvdevEvent struct {
 	eventType uint16
@@ -93,7 +101,7 @@ func newWaylandEvdevCapture() (*waylandEvdevCapture, error) {
 
 	capture := &waylandEvdevCapture{
 		files:  make([]*os.File, 0, len(paths)),
-		events: make(chan waylandEvdevEvent, 128),
+		events: make(chan waylandEvdevEvent, waylandEvdevEventBufferSize),
 	}
 
 	for _, path := range paths {
@@ -102,8 +110,8 @@ func newWaylandEvdevCapture() (*waylandEvdevCapture, error) {
 			continue
 		}
 
-		fd := C.int(file.Fd())                 //nolint:nlreturn
-		if C.neru_evdev_is_keyboard(fd) == 0 { //nolint:nlreturn
+		fd := C.int(file.Fd())
+		if C.neru_evdev_is_keyboard(fd) == 0 {
 			_ = file.Close()
 
 			continue
@@ -122,6 +130,20 @@ func newWaylandEvdevCapture() (*waylandEvdevCapture, error) {
 	return capture, nil
 }
 
+func (capture *waylandEvdevCapture) Close() {
+	if capture == nil {
+		return
+	}
+
+	capture.closeOnce.Do(func() {
+		capture.ungrabAll()
+
+		for _, file := range capture.files {
+			_ = file.Close()
+		}
+	})
+}
+
 func (capture *waylandEvdevCapture) startReaders() {
 	for _, file := range capture.files {
 		capture.done.Add(1)
@@ -138,7 +160,7 @@ func (capture *waylandEvdevCapture) startReaders() {
 func (capture *waylandEvdevCapture) readLoop(file *os.File) {
 	defer capture.done.Done()
 
-	fd := C.int(file.Fd()) //nolint:nlreturn
+	fd := C.int(file.Fd())
 
 	for {
 		var inputEvent C.struct_input_event
@@ -162,11 +184,11 @@ func (capture *waylandEvdevCapture) grabAll() error {
 	}
 
 	for _, file := range capture.files {
-		fd := C.int(file.Fd())             //nolint:nlreturn
-		if C.neru_evdev_grab(fd, 1) != 0 { //nolint:nlreturn
+		fd := C.int(file.Fd())
+		if C.neru_evdev_grab(fd, 1) != 0 {
 			capture.ungrabAll()
 
-			return fmt.Errorf("failed to grab %s", file.Name())
+			return fmt.Errorf("%w: %s", errWaylandEvdevGrabFailed, file.Name())
 		}
 	}
 
@@ -181,7 +203,7 @@ func (capture *waylandEvdevCapture) ungrabAll() {
 	}
 
 	for _, file := range capture.files {
-		fd := C.int(file.Fd()) //nolint:nlreturn
+		fd := C.int(file.Fd())
 		C.neru_evdev_grab(fd, 0)
 	}
 
@@ -205,30 +227,16 @@ func (capture *waylandEvdevCapture) modifierKeysHeld() bool {
 	}
 
 	for _, file := range capture.files {
-		fd := C.int(file.Fd()) //nolint:nlreturn
+		fd := C.int(file.Fd())
 
 		for _, code := range modifierCodes {
-			if C.neru_evdev_key_down(fd, C.uint(code)) != 0 { //nolint:nlreturn
+			if C.neru_evdev_key_down(fd, C.uint(code)) != 0 {
 				return true
 			}
 		}
 	}
 
 	return false
-}
-
-func (capture *waylandEvdevCapture) Close() {
-	if capture == nil {
-		return
-	}
-
-	capture.closeOnce.Do(func() {
-		capture.ungrabAll()
-
-		for _, file := range capture.files {
-			_ = file.Close()
-		}
-	})
 }
 
 func (et *EventTap) runWaylandEvdev() bool {
@@ -267,10 +275,11 @@ func (et *EventTap) runWaylandEvdev() bool {
 		default:
 		}
 
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(waylandEvdevModifierReleasePollPeriod)
 	}
 
-	if grabErr := capture.grabAll(); grabErr != nil {
+	grabErr := capture.grabAll()
+	if grabErr != nil {
 		if et.logger != nil {
 			et.logger.Warn(
 				"Failed to grab Wayland evdev keyboards; falling back to overlay keyboard focus",

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -1,0 +1,388 @@
+//go:build linux && cgo
+
+package eventtap
+
+/*
+#include <errno.h>
+#include <linux/input.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+static int neru_evdev_grab(int fd, int grab) {
+	return ioctl(fd, EVIOCGRAB, grab);
+}
+
+static int neru_evdev_key_down(int fd, unsigned int keycode) {
+	unsigned long key_bits[(KEY_MAX + 8 * sizeof(unsigned long)) / (8 * sizeof(unsigned long))];
+	memset(key_bits, 0, sizeof(key_bits));
+
+	if (ioctl(fd, EVIOCGKEY(sizeof(key_bits)), key_bits) < 0) {
+		return 0;
+	}
+
+	return (key_bits[keycode / (8 * sizeof(unsigned long))] >>
+		(keycode % (8 * sizeof(unsigned long)))) & 1UL;
+}
+
+static int neru_evdev_is_keyboard(int fd) {
+	unsigned long key_bits[(KEY_MAX + 8 * sizeof(unsigned long)) / (8 * sizeof(unsigned long))];
+	memset(key_bits, 0, sizeof(key_bits));
+
+	if (ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(key_bits)), key_bits) < 0) {
+		return 0;
+	}
+
+	#define NERU_TEST_KEY(bits, key) \
+		((bits[(key) / (8 * sizeof(unsigned long))] >> ((key) % (8 * sizeof(unsigned long)))) & 1UL)
+
+	return NERU_TEST_KEY(key_bits, KEY_Q) &&
+		NERU_TEST_KEY(key_bits, KEY_W) &&
+		NERU_TEST_KEY(key_bits, KEY_E) &&
+		NERU_TEST_KEY(key_bits, KEY_R) &&
+		NERU_TEST_KEY(key_bits, KEY_SPACE) &&
+		NERU_TEST_KEY(key_bits, KEY_ENTER);
+}
+
+static ssize_t neru_evdev_read_event(int fd, struct input_event *event) {
+	return read(fd, event, sizeof(struct input_event));
+}
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/ui/overlay"
+)
+
+var errWaylandEvdevUnavailable = errors.New("wayland evdev capture unavailable")
+
+type waylandEvdevEvent struct {
+	eventType uint16
+	code      uint16
+	value     int32
+}
+
+type waylandEvdevKeyState struct {
+	modifiers evdevModifierState
+	pressed   map[uint16]bool
+}
+
+type waylandEvdevCapture struct {
+	files  []*os.File
+	events chan waylandEvdevEvent
+
+	closeOnce sync.Once
+	done      sync.WaitGroup
+	grabbed   bool
+}
+
+func newWaylandEvdevCapture() (*waylandEvdevCapture, error) {
+	paths, err := filepath.Glob("/dev/input/event*")
+	if err != nil {
+		return nil, err
+	}
+
+	capture := &waylandEvdevCapture{
+		files:  make([]*os.File, 0, len(paths)),
+		events: make(chan waylandEvdevEvent, 128),
+	}
+
+	for _, path := range paths {
+		file, openErr := os.Open(path)
+		if openErr != nil {
+			continue
+		}
+
+		fd := C.int(file.Fd())                 //nolint:nlreturn
+		if C.neru_evdev_is_keyboard(fd) == 0 { //nolint:nlreturn
+			_ = file.Close()
+
+			continue
+		}
+
+		capture.files = append(capture.files, file)
+	}
+
+	if len(capture.files) == 0 {
+		return nil, fmt.Errorf(
+			"%w: no keyboard /dev/input/event* devices could be opened",
+			errWaylandEvdevUnavailable,
+		)
+	}
+
+	return capture, nil
+}
+
+func (capture *waylandEvdevCapture) startReaders() {
+	for _, file := range capture.files {
+		capture.done.Add(1)
+
+		go capture.readLoop(file)
+	}
+
+	go func() {
+		capture.done.Wait()
+		close(capture.events)
+	}()
+}
+
+func (capture *waylandEvdevCapture) readLoop(file *os.File) {
+	defer capture.done.Done()
+
+	fd := C.int(file.Fd()) //nolint:nlreturn
+
+	for {
+		var inputEvent C.struct_input_event
+
+		readResult := C.neru_evdev_read_event(fd, &inputEvent)
+		if readResult <= 0 {
+			return
+		}
+
+		capture.events <- waylandEvdevEvent{
+			eventType: uint16(inputEvent._type),
+			code:      uint16(inputEvent.code),
+			value:     int32(inputEvent.value),
+		}
+	}
+}
+
+func (capture *waylandEvdevCapture) grabAll() error {
+	if capture == nil || capture.grabbed {
+		return nil
+	}
+
+	for _, file := range capture.files {
+		fd := C.int(file.Fd())             //nolint:nlreturn
+		if C.neru_evdev_grab(fd, 1) != 0 { //nolint:nlreturn
+			capture.ungrabAll()
+
+			return fmt.Errorf("failed to grab %s", file.Name())
+		}
+	}
+
+	capture.grabbed = true
+
+	return nil
+}
+
+func (capture *waylandEvdevCapture) ungrabAll() {
+	if capture == nil || !capture.grabbed {
+		return
+	}
+
+	for _, file := range capture.files {
+		fd := C.int(file.Fd()) //nolint:nlreturn
+		C.neru_evdev_grab(fd, 0)
+	}
+
+	capture.grabbed = false
+}
+
+func (capture *waylandEvdevCapture) modifierKeysHeld() bool {
+	if capture == nil {
+		return false
+	}
+
+	modifierCodes := []uint16{
+		evdevKeyLeftShift,
+		evdevKeyRightShift,
+		evdevKeyLeftCtrl,
+		evdevKeyRightCtrl,
+		evdevKeyLeftAlt,
+		evdevKeyRightAlt,
+		evdevKeyLeftMeta,
+		evdevKeyRightMeta,
+	}
+
+	for _, file := range capture.files {
+		fd := C.int(file.Fd()) //nolint:nlreturn
+
+		for _, code := range modifierCodes {
+			if C.neru_evdev_key_down(fd, C.uint(code)) != 0 { //nolint:nlreturn
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (capture *waylandEvdevCapture) Close() {
+	if capture == nil {
+		return
+	}
+
+	capture.closeOnce.Do(func() {
+		capture.ungrabAll()
+
+		for _, file := range capture.files {
+			_ = file.Close()
+		}
+	})
+}
+
+func (et *EventTap) runWaylandEvdev() bool {
+	capture, err := newWaylandEvdevCapture()
+	if err != nil {
+		if et.logger != nil {
+			level := et.logger.Info
+			if !errors.Is(err, errWaylandEvdevUnavailable) {
+				level = et.logger.Warn
+			}
+
+			level(
+				"Wayland evdev capture unavailable; falling back to overlay keyboard focus",
+				zap.Error(err),
+			)
+		}
+
+		return false
+	}
+	defer capture.Close()
+
+	manager := overlay.Get()
+	keyboardCaptureDisabled := false
+	if manager != nil {
+		defer func() {
+			if keyboardCaptureDisabled {
+				manager.SetKeyboardCaptureEnabled(true)
+			}
+		}()
+	}
+
+	for capture.modifierKeysHeld() {
+		select {
+		case <-et.stopCh:
+			return true
+		default:
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if grabErr := capture.grabAll(); grabErr != nil {
+		if et.logger != nil {
+			et.logger.Warn(
+				"Failed to grab Wayland evdev keyboards; falling back to overlay keyboard focus",
+				zap.Error(grabErr),
+			)
+		}
+
+		return false
+	}
+
+	capture.startReaders()
+
+	if manager != nil {
+		manager.SetKeyboardCaptureEnabled(false)
+		keyboardCaptureDisabled = true
+	}
+
+	if et.logger != nil {
+		et.logger.Info(
+			"Using Wayland evdev keyboard capture",
+			zap.Int("devices", len(capture.files)),
+		)
+	}
+
+	state := waylandEvdevKeyState{
+		pressed: make(map[uint16]bool),
+	}
+
+	for {
+		select {
+		case <-et.stopCh:
+			return true
+		case event, ok := <-capture.events:
+			if !ok {
+				return true
+			}
+
+			et.handleWaylandEvdevEvent(&state, event)
+		}
+	}
+}
+
+func (et *EventTap) handleWaylandEvdevEvent(
+	state *waylandEvdevKeyState,
+	event waylandEvdevEvent,
+) {
+	if event.eventType != evdevEventKey {
+		return
+	}
+
+	if modifier := evdevModifierName(event.code); modifier != "" {
+		if event.value == evdevValueRepeat {
+			return
+		}
+
+		isDown := event.value == evdevValuePress
+		state.trackKey(event.code, isDown)
+		state.modifiers.update(modifier, isDown)
+
+		if et.consumeSyntheticModifierEvent(modifier, isDown) {
+			return
+		}
+
+		if et.stickyToggleEnabled() {
+			et.dispatchKey(linuxModifierToggleEvent(modifier, isDown))
+		}
+
+		return
+	}
+
+	switch event.value {
+	case evdevValuePress:
+		state.trackKey(event.code, true)
+	case evdevValueRelease:
+		state.trackKey(event.code, false)
+
+		return
+	case evdevValueRepeat:
+		if !state.pressed[event.code] {
+			return
+		}
+	default:
+		return
+	}
+
+	key := evdevKeyName(event.code)
+	if key == "" {
+		return
+	}
+
+	key = normalizeLinuxKey(state.modifiers.prefix() + key)
+	if key == "" {
+		return
+	}
+
+	et.dispatchKey(key)
+}
+
+func (state *waylandEvdevKeyState) trackKey(code uint16, isDown bool) {
+	if state == nil {
+		return
+	}
+
+	if state.pressed == nil {
+		state.pressed = make(map[uint16]bool)
+	}
+
+	if isDown {
+		state.pressed[code] = true
+
+		return
+	}
+
+	delete(state.pressed, code)
+}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -272,10 +272,8 @@ func (et *EventTap) runWaylandEvdev() bool {
 		select {
 		case <-et.stopCh:
 			return true
-		default:
+		case <-time.After(waylandEvdevModifierReleasePollPeriod):
 		}
-
-		time.Sleep(waylandEvdevModifierReleasePollPeriod)
 	}
 
 	grabErr := capture.grabAll()

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
@@ -69,6 +69,17 @@ const (
 	evdevKeySpace      uint16 = 57
 	evdevKeyCapsLock   uint16 = 58
 	evdevKeyF1         uint16 = 59
+	evdevKeyF2         uint16 = 60
+	evdevKeyF3         uint16 = 61
+	evdevKeyF4         uint16 = 62
+	evdevKeyF5         uint16 = 63
+	evdevKeyF6         uint16 = 64
+	evdevKeyF7         uint16 = 65
+	evdevKeyF8         uint16 = 66
+	evdevKeyF9         uint16 = 67
+	evdevKeyF10        uint16 = 68
+	evdevKeyF11        uint16 = 87
+	evdevKeyF12        uint16 = 88
 	evdevKeyRightCtrl  uint16 = 97
 	evdevKeyRightAlt   uint16 = 100
 	evdevKeyHome       uint16 = 102
@@ -109,6 +120,18 @@ const (
 	evdevKeyNamePageUp    = "PageUp"
 	evdevKeyNamePageDown  = "PageDown"
 	evdevKeyNameInsert    = "Insert"
+	evdevKeyNameF1        = "F1"
+	evdevKeyNameF2        = "F2"
+	evdevKeyNameF3        = "F3"
+	evdevKeyNameF4        = "F4"
+	evdevKeyNameF5        = "F5"
+	evdevKeyNameF6        = "F6"
+	evdevKeyNameF7        = "F7"
+	evdevKeyNameF8        = "F8"
+	evdevKeyNameF9        = "F9"
+	evdevKeyNameF10       = "F10"
+	evdevKeyNameF11       = "F11"
+	evdevKeyNameF12       = "F12"
 )
 
 var evdevModifierNames = map[uint16]string{
@@ -143,6 +166,18 @@ var evdevKeyNames = map[uint16]string{
 	evdevKeyR:          "r",
 	evdevKeyS:          "s",
 	evdevKeyT:          "t",
+	evdevKeyF1:         evdevKeyNameF1,
+	evdevKeyF2:         evdevKeyNameF2,
+	evdevKeyF3:         evdevKeyNameF3,
+	evdevKeyF4:         evdevKeyNameF4,
+	evdevKeyF5:         evdevKeyNameF5,
+	evdevKeyF6:         evdevKeyNameF6,
+	evdevKeyF7:         evdevKeyNameF7,
+	evdevKeyF8:         evdevKeyNameF8,
+	evdevKeyF9:         evdevKeyNameF9,
+	evdevKeyF10:        evdevKeyNameF10,
+	evdevKeyF11:        evdevKeyNameF11,
+	evdevKeyF12:        evdevKeyNameF12,
 	evdevKeyU:          "u",
 	evdevKeyV:          "v",
 	evdevKeyW:          "w",
@@ -188,22 +223,27 @@ var evdevKeyNames = map[uint16]string{
 }
 
 type evdevModifierState struct {
-	shift bool
-	ctrl  bool
-	alt   bool
-	cmd   bool
+	shift int
+	ctrl  int
+	alt   int
+	cmd   int
 }
 
 func (s *evdevModifierState) update(modifier string, isDown bool) {
+	delta := 1
+	if !isDown {
+		delta = -1
+	}
+
 	switch modifier {
 	case evdevModifierShift:
-		s.shift = isDown
+		s.shift += delta
 	case evdevModifierCtrl:
-		s.ctrl = isDown
+		s.ctrl += delta
 	case evdevModifierAlt:
-		s.alt = isDown
+		s.alt += delta
 	case evdevModifierCmd:
-		s.cmd = isDown
+		s.cmd += delta
 	}
 }
 
@@ -214,19 +254,19 @@ func (s *evdevModifierState) prefix() string {
 
 	var prefix strings.Builder
 
-	if s.shift {
+	if s.shift > 0 {
 		prefix.WriteString(evdevPrefixShift)
 	}
 
-	if s.ctrl {
+	if s.ctrl > 0 {
 		prefix.WriteString(evdevPrefixCtrl)
 	}
 
-	if s.alt {
+	if s.alt > 0 {
 		prefix.WriteString(evdevPrefixAlt)
 	}
 
-	if s.cmd {
+	if s.cmd > 0 {
 		prefix.WriteString(evdevPrefixCmd)
 	}
 

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
@@ -1,0 +1,271 @@
+//go:build linux
+
+package eventtap
+
+import "strings"
+
+const (
+	evdevEventKey uint16 = 0x01
+
+	evdevValueRelease int32 = 0
+	evdevValuePress   int32 = 1
+	evdevValueRepeat  int32 = 2
+
+	evdevKeyEsc        uint16 = 1
+	evdevKey1          uint16 = 2
+	evdevKey2          uint16 = 3
+	evdevKey3          uint16 = 4
+	evdevKey4          uint16 = 5
+	evdevKey5          uint16 = 6
+	evdevKey6          uint16 = 7
+	evdevKey7          uint16 = 8
+	evdevKey8          uint16 = 9
+	evdevKey9          uint16 = 10
+	evdevKey0          uint16 = 11
+	evdevKeyMinus      uint16 = 12
+	evdevKeyEqual      uint16 = 13
+	evdevKeyBackspace  uint16 = 14
+	evdevKeyTab        uint16 = 15
+	evdevKeyQ          uint16 = 16
+	evdevKeyW          uint16 = 17
+	evdevKeyE          uint16 = 18
+	evdevKeyR          uint16 = 19
+	evdevKeyT          uint16 = 20
+	evdevKeyY          uint16 = 21
+	evdevKeyU          uint16 = 22
+	evdevKeyI          uint16 = 23
+	evdevKeyO          uint16 = 24
+	evdevKeyP          uint16 = 25
+	evdevKeyLeftBrace  uint16 = 26
+	evdevKeyRightBrace uint16 = 27
+	evdevKeyEnter      uint16 = 28
+	evdevKeyLeftCtrl   uint16 = 29
+	evdevKeyA          uint16 = 30
+	evdevKeyS          uint16 = 31
+	evdevKeyD          uint16 = 32
+	evdevKeyF          uint16 = 33
+	evdevKeyG          uint16 = 34
+	evdevKeyH          uint16 = 35
+	evdevKeyJ          uint16 = 36
+	evdevKeyK          uint16 = 37
+	evdevKeyL          uint16 = 38
+	evdevKeySemicolon  uint16 = 39
+	evdevKeyApostrophe uint16 = 40
+	evdevKeyGrave      uint16 = 41
+	evdevKeyLeftShift  uint16 = 42
+	evdevKeyBackslash  uint16 = 43
+	evdevKeyZ          uint16 = 44
+	evdevKeyX          uint16 = 45
+	evdevKeyC          uint16 = 46
+	evdevKeyV          uint16 = 47
+	evdevKeyB          uint16 = 48
+	evdevKeyN          uint16 = 49
+	evdevKeyM          uint16 = 50
+	evdevKeyComma      uint16 = 51
+	evdevKeyDot        uint16 = 52
+	evdevKeySlash      uint16 = 53
+	evdevKeyRightShift uint16 = 54
+	evdevKeyLeftAlt    uint16 = 56
+	evdevKeySpace      uint16 = 57
+	evdevKeyCapsLock   uint16 = 58
+	evdevKeyF1         uint16 = 59
+	evdevKeyRightCtrl  uint16 = 97
+	evdevKeyRightAlt   uint16 = 100
+	evdevKeyHome       uint16 = 102
+	evdevKeyUp         uint16 = 103
+	evdevKeyPageUp     uint16 = 104
+	evdevKeyLeft       uint16 = 105
+	evdevKeyRight      uint16 = 106
+	evdevKeyEnd        uint16 = 107
+	evdevKeyDown       uint16 = 108
+	evdevKeyPageDown   uint16 = 109
+	evdevKeyInsert     uint16 = 110
+	evdevKeyDelete     uint16 = 111
+	evdevKeyLeftMeta   uint16 = 125
+	evdevKeyRightMeta  uint16 = 126
+)
+
+type evdevModifierState struct {
+	shift bool
+	ctrl  bool
+	alt   bool
+	cmd   bool
+}
+
+func (s *evdevModifierState) update(modifier string, isDown bool) {
+	switch modifier {
+	case "shift":
+		s.shift = isDown
+	case "ctrl":
+		s.ctrl = isDown
+	case "alt":
+		s.alt = isDown
+	case "cmd":
+		s.cmd = isDown
+	}
+}
+
+func (s evdevModifierState) prefix() string {
+	var prefix strings.Builder
+
+	if s.shift {
+		prefix.WriteString("Shift+")
+	}
+	if s.ctrl {
+		prefix.WriteString("Ctrl+")
+	}
+	if s.alt {
+		prefix.WriteString("Alt+")
+	}
+	if s.cmd {
+		prefix.WriteString("Cmd+")
+	}
+
+	return prefix.String()
+}
+
+func evdevModifierName(code uint16) string {
+	switch code {
+	case evdevKeyLeftShift, evdevKeyRightShift:
+		return "shift"
+	case evdevKeyLeftCtrl, evdevKeyRightCtrl:
+		return "ctrl"
+	case evdevKeyLeftAlt, evdevKeyRightAlt:
+		return "alt"
+	case evdevKeyLeftMeta, evdevKeyRightMeta:
+		return "cmd"
+	default:
+		return ""
+	}
+}
+
+func evdevKeyName(code uint16) string {
+	switch code {
+	case evdevKeyA:
+		return "a"
+	case evdevKeyB:
+		return "b"
+	case evdevKeyC:
+		return "c"
+	case evdevKeyD:
+		return "d"
+	case evdevKeyE:
+		return "e"
+	case evdevKeyF:
+		return "f"
+	case evdevKeyG:
+		return "g"
+	case evdevKeyH:
+		return "h"
+	case evdevKeyI:
+		return "i"
+	case evdevKeyJ:
+		return "j"
+	case evdevKeyK:
+		return "k"
+	case evdevKeyL:
+		return "l"
+	case evdevKeyM:
+		return "m"
+	case evdevKeyN:
+		return "n"
+	case evdevKeyO:
+		return "o"
+	case evdevKeyP:
+		return "p"
+	case evdevKeyQ:
+		return "q"
+	case evdevKeyR:
+		return "r"
+	case evdevKeyS:
+		return "s"
+	case evdevKeyT:
+		return "t"
+	case evdevKeyU:
+		return "u"
+	case evdevKeyV:
+		return "v"
+	case evdevKeyW:
+		return "w"
+	case evdevKeyX:
+		return "x"
+	case evdevKeyY:
+		return "y"
+	case evdevKeyZ:
+		return "z"
+	case evdevKey1:
+		return "1"
+	case evdevKey2:
+		return "2"
+	case evdevKey3:
+		return "3"
+	case evdevKey4:
+		return "4"
+	case evdevKey5:
+		return "5"
+	case evdevKey6:
+		return "6"
+	case evdevKey7:
+		return "7"
+	case evdevKey8:
+		return "8"
+	case evdevKey9:
+		return "9"
+	case evdevKey0:
+		return "0"
+	case evdevKeyMinus:
+		return "-"
+	case evdevKeyEqual:
+		return "="
+	case evdevKeyLeftBrace:
+		return "["
+	case evdevKeyRightBrace:
+		return "]"
+	case evdevKeyBackslash:
+		return "\\"
+	case evdevKeySemicolon:
+		return ";"
+	case evdevKeyApostrophe:
+		return "'"
+	case evdevKeyGrave:
+		return "`"
+	case evdevKeyComma:
+		return ","
+	case evdevKeyDot:
+		return "."
+	case evdevKeySlash:
+		return "/"
+	case evdevKeyEnter:
+		return "Return"
+	case evdevKeySpace:
+		return "Space"
+	case evdevKeyTab:
+		return "Tab"
+	case evdevKeyEsc:
+		return "Escape"
+	case evdevKeyBackspace:
+		return "Backspace"
+	case evdevKeyDelete:
+		return "Delete"
+	case evdevKeyLeft:
+		return "Left"
+	case evdevKeyRight:
+		return "Right"
+	case evdevKeyUp:
+		return "Up"
+	case evdevKeyDown:
+		return "Down"
+	case evdevKeyHome:
+		return "Home"
+	case evdevKeyEnd:
+		return "End"
+	case evdevKeyPageUp:
+		return "PageUp"
+	case evdevKeyPageDown:
+		return "PageDown"
+	case evdevKeyInsert:
+		return "Insert"
+	default:
+		return ""
+	}
+}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
@@ -83,7 +83,109 @@ const (
 	evdevKeyDelete     uint16 = 111
 	evdevKeyLeftMeta   uint16 = 125
 	evdevKeyRightMeta  uint16 = 126
+
+	evdevModifierShift = "shift"
+	evdevModifierCtrl  = "ctrl"
+	evdevModifierAlt   = "alt"
+	evdevModifierCmd   = "cmd"
+
+	evdevPrefixShift = "Shift+"
+	evdevPrefixCtrl  = "Ctrl+"
+	evdevPrefixAlt   = "Alt+"
+	evdevPrefixCmd   = "Cmd+"
+
+	evdevKeyNameReturn    = "Return"
+	evdevKeyNameSpace     = "Space"
+	evdevKeyNameTab       = "Tab"
+	evdevKeyNameEscape    = "Escape"
+	evdevKeyNameBackspace = "Backspace"
+	evdevKeyNameDelete    = "Delete"
+	evdevKeyNameLeft      = "Left"
+	evdevKeyNameRight     = "Right"
+	evdevKeyNameUp        = "Up"
+	evdevKeyNameDown      = "Down"
+	evdevKeyNameHome      = "Home"
+	evdevKeyNameEnd       = "End"
+	evdevKeyNamePageUp    = "PageUp"
+	evdevKeyNamePageDown  = "PageDown"
+	evdevKeyNameInsert    = "Insert"
 )
+
+var evdevModifierNames = map[uint16]string{
+	evdevKeyLeftShift:  evdevModifierShift,
+	evdevKeyRightShift: evdevModifierShift,
+	evdevKeyLeftCtrl:   evdevModifierCtrl,
+	evdevKeyRightCtrl:  evdevModifierCtrl,
+	evdevKeyLeftAlt:    evdevModifierAlt,
+	evdevKeyRightAlt:   evdevModifierAlt,
+	evdevKeyLeftMeta:   evdevModifierCmd,
+	evdevKeyRightMeta:  evdevModifierCmd,
+}
+
+var evdevKeyNames = map[uint16]string{
+	evdevKeyA:          "a",
+	evdevKeyB:          "b",
+	evdevKeyC:          "c",
+	evdevKeyD:          "d",
+	evdevKeyE:          "e",
+	evdevKeyF:          "f",
+	evdevKeyG:          "g",
+	evdevKeyH:          "h",
+	evdevKeyI:          "i",
+	evdevKeyJ:          "j",
+	evdevKeyK:          "k",
+	evdevKeyL:          "l",
+	evdevKeyM:          "m",
+	evdevKeyN:          "n",
+	evdevKeyO:          "o",
+	evdevKeyP:          "p",
+	evdevKeyQ:          "q",
+	evdevKeyR:          "r",
+	evdevKeyS:          "s",
+	evdevKeyT:          "t",
+	evdevKeyU:          "u",
+	evdevKeyV:          "v",
+	evdevKeyW:          "w",
+	evdevKeyX:          "x",
+	evdevKeyY:          "y",
+	evdevKeyZ:          "z",
+	evdevKey1:          "1",
+	evdevKey2:          "2",
+	evdevKey3:          "3",
+	evdevKey4:          "4",
+	evdevKey5:          "5",
+	evdevKey6:          "6",
+	evdevKey7:          "7",
+	evdevKey8:          "8",
+	evdevKey9:          "9",
+	evdevKey0:          "0",
+	evdevKeyMinus:      "-",
+	evdevKeyEqual:      "=",
+	evdevKeyLeftBrace:  "[",
+	evdevKeyRightBrace: "]",
+	evdevKeyBackslash:  "\\",
+	evdevKeySemicolon:  ";",
+	evdevKeyApostrophe: "'",
+	evdevKeyGrave:      "`",
+	evdevKeyComma:      ",",
+	evdevKeyDot:        ".",
+	evdevKeySlash:      "/",
+	evdevKeyEnter:      evdevKeyNameReturn,
+	evdevKeySpace:      evdevKeyNameSpace,
+	evdevKeyTab:        evdevKeyNameTab,
+	evdevKeyEsc:        evdevKeyNameEscape,
+	evdevKeyBackspace:  evdevKeyNameBackspace,
+	evdevKeyDelete:     evdevKeyNameDelete,
+	evdevKeyLeft:       evdevKeyNameLeft,
+	evdevKeyRight:      evdevKeyNameRight,
+	evdevKeyUp:         evdevKeyNameUp,
+	evdevKeyDown:       evdevKeyNameDown,
+	evdevKeyHome:       evdevKeyNameHome,
+	evdevKeyEnd:        evdevKeyNameEnd,
+	evdevKeyPageUp:     evdevKeyNamePageUp,
+	evdevKeyPageDown:   evdevKeyNamePageDown,
+	evdevKeyInsert:     evdevKeyNameInsert,
+}
 
 type evdevModifierState struct {
 	shift bool
@@ -94,178 +196,47 @@ type evdevModifierState struct {
 
 func (s *evdevModifierState) update(modifier string, isDown bool) {
 	switch modifier {
-	case "shift":
+	case evdevModifierShift:
 		s.shift = isDown
-	case "ctrl":
+	case evdevModifierCtrl:
 		s.ctrl = isDown
-	case "alt":
+	case evdevModifierAlt:
 		s.alt = isDown
-	case "cmd":
+	case evdevModifierCmd:
 		s.cmd = isDown
 	}
 }
 
-func (s evdevModifierState) prefix() string {
+func (s *evdevModifierState) prefix() string {
+	if s == nil {
+		return ""
+	}
+
 	var prefix strings.Builder
 
 	if s.shift {
-		prefix.WriteString("Shift+")
+		prefix.WriteString(evdevPrefixShift)
 	}
+
 	if s.ctrl {
-		prefix.WriteString("Ctrl+")
+		prefix.WriteString(evdevPrefixCtrl)
 	}
+
 	if s.alt {
-		prefix.WriteString("Alt+")
+		prefix.WriteString(evdevPrefixAlt)
 	}
+
 	if s.cmd {
-		prefix.WriteString("Cmd+")
+		prefix.WriteString(evdevPrefixCmd)
 	}
 
 	return prefix.String()
 }
 
 func evdevModifierName(code uint16) string {
-	switch code {
-	case evdevKeyLeftShift, evdevKeyRightShift:
-		return "shift"
-	case evdevKeyLeftCtrl, evdevKeyRightCtrl:
-		return "ctrl"
-	case evdevKeyLeftAlt, evdevKeyRightAlt:
-		return "alt"
-	case evdevKeyLeftMeta, evdevKeyRightMeta:
-		return "cmd"
-	default:
-		return ""
-	}
+	return evdevModifierNames[code]
 }
 
 func evdevKeyName(code uint16) string {
-	switch code {
-	case evdevKeyA:
-		return "a"
-	case evdevKeyB:
-		return "b"
-	case evdevKeyC:
-		return "c"
-	case evdevKeyD:
-		return "d"
-	case evdevKeyE:
-		return "e"
-	case evdevKeyF:
-		return "f"
-	case evdevKeyG:
-		return "g"
-	case evdevKeyH:
-		return "h"
-	case evdevKeyI:
-		return "i"
-	case evdevKeyJ:
-		return "j"
-	case evdevKeyK:
-		return "k"
-	case evdevKeyL:
-		return "l"
-	case evdevKeyM:
-		return "m"
-	case evdevKeyN:
-		return "n"
-	case evdevKeyO:
-		return "o"
-	case evdevKeyP:
-		return "p"
-	case evdevKeyQ:
-		return "q"
-	case evdevKeyR:
-		return "r"
-	case evdevKeyS:
-		return "s"
-	case evdevKeyT:
-		return "t"
-	case evdevKeyU:
-		return "u"
-	case evdevKeyV:
-		return "v"
-	case evdevKeyW:
-		return "w"
-	case evdevKeyX:
-		return "x"
-	case evdevKeyY:
-		return "y"
-	case evdevKeyZ:
-		return "z"
-	case evdevKey1:
-		return "1"
-	case evdevKey2:
-		return "2"
-	case evdevKey3:
-		return "3"
-	case evdevKey4:
-		return "4"
-	case evdevKey5:
-		return "5"
-	case evdevKey6:
-		return "6"
-	case evdevKey7:
-		return "7"
-	case evdevKey8:
-		return "8"
-	case evdevKey9:
-		return "9"
-	case evdevKey0:
-		return "0"
-	case evdevKeyMinus:
-		return "-"
-	case evdevKeyEqual:
-		return "="
-	case evdevKeyLeftBrace:
-		return "["
-	case evdevKeyRightBrace:
-		return "]"
-	case evdevKeyBackslash:
-		return "\\"
-	case evdevKeySemicolon:
-		return ";"
-	case evdevKeyApostrophe:
-		return "'"
-	case evdevKeyGrave:
-		return "`"
-	case evdevKeyComma:
-		return ","
-	case evdevKeyDot:
-		return "."
-	case evdevKeySlash:
-		return "/"
-	case evdevKeyEnter:
-		return "Return"
-	case evdevKeySpace:
-		return "Space"
-	case evdevKeyTab:
-		return "Tab"
-	case evdevKeyEsc:
-		return "Escape"
-	case evdevKeyBackspace:
-		return "Backspace"
-	case evdevKeyDelete:
-		return "Delete"
-	case evdevKeyLeft:
-		return "Left"
-	case evdevKeyRight:
-		return "Right"
-	case evdevKeyUp:
-		return "Up"
-	case evdevKeyDown:
-		return "Down"
-	case evdevKeyHome:
-		return "Home"
-	case evdevKeyEnd:
-		return "End"
-	case evdevKeyPageUp:
-		return "PageUp"
-	case evdevKeyPageDown:
-		return "PageDown"
-	case evdevKeyInsert:
-		return "Insert"
-	default:
-		return ""
-	}
+	return evdevKeyNames[code]
 }

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
@@ -1,5 +1,6 @@
 //go:build linux
 
+//nolint:testpackage // These tests validate unexported evdev translation helpers directly.
 package eventtap
 
 import "testing"

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
@@ -1,0 +1,120 @@
+//go:build linux
+
+package eventtap
+
+import "testing"
+
+func TestEvdevModifierName(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		code uint16
+		want string
+	}{
+		{code: evdevKeyLeftShift, want: "shift"},
+		{code: evdevKeyRightCtrl, want: "ctrl"},
+		{code: evdevKeyLeftAlt, want: "alt"},
+		{code: evdevKeyRightMeta, want: "cmd"},
+		{code: evdevKeyA, want: ""},
+	}
+
+	for _, testCase := range testCases {
+		if got := evdevModifierName(testCase.code); got != testCase.want {
+			t.Fatalf("evdevModifierName(%d) = %q, want %q", testCase.code, got, testCase.want)
+		}
+	}
+}
+
+func TestEvdevKeyName(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		code uint16
+		want string
+	}{
+		{code: evdevKeyA, want: "a"},
+		{code: evdevKeySlash, want: "/"},
+		{code: evdevKeyEnter, want: "Return"},
+		{code: evdevKeyBackspace, want: "Backspace"},
+		{code: evdevKeyLeft, want: "Left"},
+		{code: evdevKeyF1, want: ""},
+	}
+
+	for _, testCase := range testCases {
+		if got := evdevKeyName(testCase.code); got != testCase.want {
+			t.Fatalf("evdevKeyName(%d) = %q, want %q", testCase.code, got, testCase.want)
+		}
+	}
+}
+
+func TestEvdevModifierStatePrefix(t *testing.T) {
+	t.Parallel()
+
+	state := evdevModifierState{}
+	state.update("ctrl", true)
+	state.update("shift", true)
+	state.update("cmd", true)
+
+	if got := state.prefix(); got != "Shift+Ctrl+Cmd+" {
+		t.Fatalf("prefix() = %q, want %q", got, "Shift+Ctrl+Cmd+")
+	}
+
+	state.update("ctrl", false)
+
+	if got := state.prefix(); got != "Shift+Cmd+" {
+		t.Fatalf("prefix() after ctrl release = %q, want %q", got, "Shift+Cmd+")
+	}
+}
+
+func TestHandleWaylandEvdevEvent_IgnoresRepeatWithoutPress(t *testing.T) {
+	t.Parallel()
+
+	var got []string
+
+	eventTap := NewEventTap(func(key string) {
+		got = append(got, key)
+	}, nil)
+
+	state := waylandEvdevKeyState{
+		pressed: make(map[uint16]bool),
+	}
+
+	eventTap.handleWaylandEvdevEvent(&state, waylandEvdevEvent{
+		eventType: evdevEventKey,
+		code:      evdevKeyU,
+		value:     evdevValueRepeat,
+	})
+
+	if len(got) != 0 {
+		t.Fatalf("got keys %v, want none", got)
+	}
+}
+
+func TestHandleWaylandEvdevEvent_AllowsRepeatAfterPress(t *testing.T) {
+	t.Parallel()
+
+	var got []string
+
+	eventTap := NewEventTap(func(key string) {
+		got = append(got, key)
+	}, nil)
+
+	state := waylandEvdevKeyState{
+		pressed: make(map[uint16]bool),
+	}
+
+	eventTap.handleWaylandEvdevEvent(&state, waylandEvdevEvent{
+		eventType: evdevEventKey,
+		code:      evdevKeyU,
+		value:     evdevValuePress,
+	})
+	eventTap.handleWaylandEvdevEvent(&state, waylandEvdevEvent{
+		eventType: evdevEventKey,
+		code:      evdevKeyU,
+		value:     evdevValueRepeat,
+	})
+
+	if len(got) != 2 || got[0] != "u" || got[1] != "u" {
+		t.Fatalf("got keys %v, want [u u]", got)
+	}
+}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
@@ -38,7 +38,7 @@ func TestEvdevKeyName(t *testing.T) {
 		{code: evdevKeyEnter, want: "Return"},
 		{code: evdevKeyBackspace, want: "Backspace"},
 		{code: evdevKeyLeft, want: "Left"},
-		{code: evdevKeyF1, want: ""},
+		{code: evdevKeyF1, want: "F1"},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/core/infra/eventtap/eventtap_linux_x11.go
+++ b/internal/core/infra/eventtap/eventtap_linux_x11.go
@@ -221,11 +221,7 @@ func x11ModifierName(keysym C.KeySym) string {
 
 func postLinuxModifierEvent(modifier string, isDown bool) bool {
 	if os.Getenv("WAYLAND_DISPLAY") != "" {
-		if isDown {
-			return false
-		}
-
-		return linux.WlrootsModifierEvent(modifier, false) == nil
+		return linux.WlrootsModifierEvent(modifier, isDown) == nil
 	}
 
 	if os.Getenv("DISPLAY") == "" {

--- a/internal/core/infra/eventtap/eventtap_linux_x11.go
+++ b/internal/core/infra/eventtap/eventtap_linux_x11.go
@@ -83,6 +83,8 @@ import (
 	"os"
 	"time"
 	"unsafe"
+
+	"github.com/y3owk1n/neru/internal/core/infra/platform/linux"
 )
 
 const (
@@ -218,7 +220,11 @@ func x11ModifierName(keysym C.KeySym) string {
 }
 
 func postLinuxModifierEvent(modifier string, isDown bool) bool {
-	if os.Getenv("WAYLAND_DISPLAY") != "" || os.Getenv("DISPLAY") == "" {
+	if os.Getenv("WAYLAND_DISPLAY") != "" {
+		return linux.WlrootsModifierEvent(modifier, isDown) == nil
+	}
+
+	if os.Getenv("DISPLAY") == "" {
 		return false
 	}
 

--- a/internal/core/infra/eventtap/eventtap_linux_x11.go
+++ b/internal/core/infra/eventtap/eventtap_linux_x11.go
@@ -132,8 +132,8 @@ func (et *EventTap) runX11() {
 		}
 
 		var event C.XEvent
-		eventType := C.neru_eventtap_next(display, &event)
-		if eventType != C.KeyPress && eventType != C.KeyRelease { //nolint:nlreturn
+		eventType := C.neru_eventtap_next(display, &event) //nolint:nlreturn
+		if eventType != C.KeyPress && eventType != C.KeyRelease {
 			continue
 		}
 
@@ -207,13 +207,13 @@ func x11KeysymName(keysym C.KeySym) string {
 func x11ModifierName(keysym C.KeySym) string {
 	switch keysym {
 	case C.XK_Shift_L, C.XK_Shift_R:
-		return "shift"
+		return evdevModifierShift
 	case C.XK_Control_L, C.XK_Control_R:
-		return "ctrl"
+		return evdevModifierCtrl
 	case C.XK_Alt_L, C.XK_Alt_R:
-		return "alt"
+		return evdevModifierAlt
 	case C.XK_Super_L, C.XK_Super_R, C.XK_Meta_L, C.XK_Meta_R:
-		return "cmd"
+		return evdevModifierCmd
 	default:
 		return ""
 	}

--- a/internal/core/infra/eventtap/eventtap_linux_x11.go
+++ b/internal/core/infra/eventtap/eventtap_linux_x11.go
@@ -221,7 +221,11 @@ func x11ModifierName(keysym C.KeySym) string {
 
 func postLinuxModifierEvent(modifier string, isDown bool) bool {
 	if os.Getenv("WAYLAND_DISPLAY") != "" {
-		return linux.WlrootsModifierEvent(modifier, isDown) == nil
+		if isDown {
+			return false
+		}
+
+		return linux.WlrootsModifierEvent(modifier, false) == nil
 	}
 
 	if os.Getenv("DISPLAY") == "" {

--- a/internal/core/infra/eventtap/eventtap_linux_x11.go
+++ b/internal/core/infra/eventtap/eventtap_linux_x11.go
@@ -3,11 +3,13 @@
 package eventtap
 
 /*
-#cgo linux pkg-config: x11
+#cgo linux pkg-config: x11 xtst
+#include <X11/extensions/XTest.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/keysym.h>
 #include <stdlib.h>
+#include <string.h>
 
 static Display* neru_eventtap_open(void) {
 	return XOpenDisplay(NULL);
@@ -43,12 +45,42 @@ static int neru_eventtap_next(Display *display, XEvent *event) {
 	XNextEvent(display, event);
 	return event->type;
 }
+
+static KeySym neru_eventtap_modifier_keysym(const char *modifier) {
+	if (strcmp(modifier, "shift") == 0) return XK_Shift_L;
+	if (strcmp(modifier, "ctrl") == 0) return XK_Control_L;
+	if (strcmp(modifier, "alt") == 0) return XK_Alt_L;
+	if (strcmp(modifier, "cmd") == 0) return XK_Super_L;
+	return NoSymbol;
+}
+
+static int neru_eventtap_post_modifier(const char *modifier, int is_down) {
+	Display *display = neru_eventtap_open();
+	if (display == NULL) return 0;
+
+	KeySym keysym = neru_eventtap_modifier_keysym(modifier);
+	if (keysym == NoSymbol) {
+		neru_eventtap_close(display);
+		return 0;
+	}
+
+	KeyCode keycode = XKeysymToKeycode(display, keysym);
+	if (keycode == 0) {
+		neru_eventtap_close(display);
+		return 0;
+	}
+
+	int ok = XTestFakeKeyEvent(display, keycode, is_down ? True : False, CurrentTime);
+	XFlush(display);
+	neru_eventtap_close(display);
+
+	return ok;
+}
 */
 import "C"
 
 import (
 	"os"
-	"strings"
 	"time"
 	"unsafe"
 )
@@ -98,7 +130,8 @@ func (et *EventTap) runX11() {
 		}
 
 		var event C.XEvent
-		if C.neru_eventtap_next(display, &event) != C.KeyPress { //nolint:nlreturn
+		eventType := C.neru_eventtap_next(display, &event)
+		if eventType != C.KeyPress && eventType != C.KeyRelease { //nolint:nlreturn
 			continue
 		}
 
@@ -113,6 +146,23 @@ func (et *EventTap) runX11() {
 			nil, //nolint:nlreturn
 		)
 
+		if modifier := x11ModifierName(keysym); modifier != "" {
+			isDown := eventType == C.KeyPress
+			if et.consumeSyntheticModifierEvent(modifier, isDown) {
+				continue
+			}
+
+			if et.stickyToggleEnabled() {
+				et.dispatchKey(linuxModifierToggleEvent(modifier, isDown))
+			}
+
+			continue
+		}
+
+		if eventType != C.KeyPress {
+			continue
+		}
+
 		var key string
 		if length > 0 {
 			key = C.GoStringN(&buffer[0], length)
@@ -120,9 +170,6 @@ func (et *EventTap) runX11() {
 			key = x11KeysymName(keysym)
 		}
 		key = normalizeLinuxKey(key)
-		if strings.HasPrefix(key, "__modifier_") && !et.stickyToggleEnabled() {
-			continue
-		}
 
 		if key != "" {
 			et.dispatchKey(key)
@@ -150,15 +197,38 @@ func x11KeysymName(keysym C.KeySym) string {
 		return "Up"
 	case C.XK_Down:
 		return "Down"
-	case C.XK_Shift_L, C.XK_Shift_R:
-		return "__modifier_shift"
-	case C.XK_Control_L, C.XK_Control_R:
-		return "__modifier_ctrl"
-	case C.XK_Alt_L, C.XK_Alt_R:
-		return "__modifier_alt"
-	case C.XK_Super_L, C.XK_Super_R, C.XK_Meta_L, C.XK_Meta_R:
-		return "__modifier_cmd"
 	default:
 		return ""
 	}
+}
+
+func x11ModifierName(keysym C.KeySym) string {
+	switch keysym {
+	case C.XK_Shift_L, C.XK_Shift_R:
+		return "shift"
+	case C.XK_Control_L, C.XK_Control_R:
+		return "ctrl"
+	case C.XK_Alt_L, C.XK_Alt_R:
+		return "alt"
+	case C.XK_Super_L, C.XK_Super_R, C.XK_Meta_L, C.XK_Meta_R:
+		return "cmd"
+	default:
+		return ""
+	}
+}
+
+func postLinuxModifierEvent(modifier string, isDown bool) bool {
+	if os.Getenv("WAYLAND_DISPLAY") != "" || os.Getenv("DISPLAY") == "" {
+		return false
+	}
+
+	cModifier := C.CString(modifier)
+	defer C.free(unsafe.Pointer(cModifier)) //nolint:nlreturn
+
+	cDown := C.int(0)
+	if isDown {
+		cDown = C.int(1)
+	}
+
+	return C.neru_eventtap_post_modifier(cModifier, cDown) != 0
 }

--- a/internal/core/infra/eventtap/eventtap_linux_x11.go
+++ b/internal/core/infra/eventtap/eventtap_linux_x11.go
@@ -55,6 +55,9 @@ static KeySym neru_eventtap_modifier_keysym(const char *modifier) {
 }
 
 static int neru_eventtap_post_modifier(const char *modifier, int is_down) {
+	// Open a fresh Display connection per call to ensure thread-safety isolation
+	// from the grab Display used by runX11(). XLib is not thread-safe without
+	// XInitThreads, so we avoid sharing the grab connection for XTest injection.
 	Display *display = neru_eventtap_open();
 	if (display == NULL) return 0;
 

--- a/internal/core/infra/platform/darwin/eventtap.h
+++ b/internal/core/infra/platform/darwin/eventtap.h
@@ -74,7 +74,7 @@ void setEventTapPassthroughCallback(EventTap tap, EventTapPassthroughCallback ca
 
 /// Enable or disable sticky modifier toggle detection.
 /// When enabled, modifier key events (Shift, Cmd, Alt, Ctrl) are detected and
-/// callback is invoked with "__modifier_<name>" strings for sticky modifier toggling.
+/// callback is invoked with "__modifier_<name>_down/up" strings for sticky modifier toggling.
 /// @param tap Event tap handle
 /// @param enabled Non-zero to enable, zero to disable
 void setEventTapStickyModifierToggle(EventTap tap, int enabled);

--- a/internal/core/infra/platform/linux/system_linux_wayland.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland.go
@@ -39,3 +39,8 @@ func WlrootsButtonRelease(button int) error {
 func WlrootsScroll(axis, delta int) error {
 	return wlrootsScroll(axis, delta)
 }
+
+// WlrootsModifierEvent presses or releases a virtual keyboard modifier.
+func WlrootsModifierEvent(modifier string, isDown bool) error {
+	return wlrootsModifierEvent(modifier, isDown)
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland.go
@@ -7,6 +7,8 @@ import "image"
 // Exported wrappers for wlroots input injection.
 // These delegate to the build-tagged (cgo/nocgo) implementations.
 
+var globalWlrootsModifierDispatcher = newWlrootsModifierDispatcher(wlrootsModifierEvent)
+
 // WlrootsMoveCursorToPoint moves the virtual pointer to an absolute position.
 func WlrootsMoveCursorToPoint(point image.Point) error {
 	return wlrootsMoveCursorToPoint(point)
@@ -42,5 +44,5 @@ func WlrootsScroll(axis, delta int) error {
 
 // WlrootsModifierEvent presses or releases a virtual keyboard modifier.
 func WlrootsModifierEvent(modifier string, isDown bool) error {
-	return wlrootsModifierEvent(modifier, isDown)
+	return globalWlrootsModifierDispatcher.event(modifier, isDown)
 }

--- a/internal/core/infra/platform/linux/system_linux_wayland_modifiers.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_modifiers.go
@@ -1,0 +1,62 @@
+//go:build linux
+
+package linux
+
+import "sync"
+
+// wlrootsModifierDispatcher deduplicates overlapping synthetic modifier usage.
+// Sticky modifiers keep a virtual key held across navigation, while individual
+// clicks may temporarily request the same modifier for a single pointer action.
+// We only emit the physical key transition when the first holder appears or the
+// last holder releases it.
+type wlrootsModifierDispatcher struct {
+	mu     sync.Mutex
+	counts map[string]int
+	send   func(modifier string, isDown bool) error
+}
+
+func newWlrootsModifierDispatcher(
+	send func(modifier string, isDown bool) error,
+) *wlrootsModifierDispatcher {
+	return &wlrootsModifierDispatcher{
+		counts: make(map[string]int),
+		send:   send,
+	}
+}
+
+func (d *wlrootsModifierDispatcher) event(modifier string, isDown bool) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	count := d.counts[modifier]
+
+	if isDown {
+		if count == 0 {
+			if err := d.send(modifier, true); err != nil {
+				return err
+			}
+		}
+
+		d.counts[modifier] = count + 1
+
+		return nil
+	}
+
+	if count == 0 {
+		return d.send(modifier, false)
+	}
+
+	if count > 1 {
+		d.counts[modifier] = count - 1
+
+		return nil
+	}
+
+	if err := d.send(modifier, false); err != nil {
+		return err
+	}
+
+	delete(d.counts, modifier)
+
+	return nil
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland_modifiers.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_modifiers.go
@@ -32,7 +32,8 @@ func (d *wlrootsModifierDispatcher) event(modifier string, isDown bool) error {
 
 	if isDown {
 		if count == 0 {
-			if err := d.send(modifier, true); err != nil {
+			err := d.send(modifier, true)
+			if err != nil {
 				return err
 			}
 		}
@@ -52,7 +53,8 @@ func (d *wlrootsModifierDispatcher) event(modifier string, isDown bool) error {
 		return nil
 	}
 
-	if err := d.send(modifier, false); err != nil {
+	err := d.send(modifier, false)
+	if err != nil {
 		return err
 	}
 

--- a/internal/core/infra/platform/linux/system_linux_wayland_modifiers_test.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_modifiers_test.go
@@ -1,0 +1,128 @@
+//go:build linux
+
+package linux
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestWlrootsModifierDispatcherDeduplicatesNestedUsage(t *testing.T) {
+	t.Parallel()
+
+	type event struct {
+		modifier string
+		isDown   bool
+	}
+
+	var events []event
+
+	dispatcher := newWlrootsModifierDispatcher(func(modifier string, isDown bool) error {
+		events = append(events, event{modifier: modifier, isDown: isDown})
+
+		return nil
+	})
+
+	if err := dispatcher.event("ctrl", true); err != nil {
+		t.Fatalf("first down error = %v", err)
+	}
+
+	if err := dispatcher.event("ctrl", true); err != nil {
+		t.Fatalf("nested down error = %v", err)
+	}
+
+	if err := dispatcher.event("ctrl", false); err != nil {
+		t.Fatalf("nested up error = %v", err)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("event count after nested release = %d, want 1", len(events))
+	}
+
+	if err := dispatcher.event("ctrl", false); err != nil {
+		t.Fatalf("final up error = %v", err)
+	}
+
+	want := []event{
+		{modifier: "ctrl", isDown: true},
+		{modifier: "ctrl", isDown: false},
+	}
+
+	if len(events) != len(want) {
+		t.Fatalf("final event count = %d, want %d", len(events), len(want))
+	}
+
+	for index, got := range events {
+		if got != want[index] {
+			t.Fatalf("event[%d] = %+v, want %+v", index, got, want[index])
+		}
+	}
+}
+
+func TestWlrootsModifierDispatcherRetriesFailedFinalRelease(t *testing.T) {
+	t.Parallel()
+
+	failRelease := true
+	releaseAttempts := 0
+
+	dispatcher := newWlrootsModifierDispatcher(func(modifier string, isDown bool) error {
+		if modifier != "ctrl" {
+			t.Fatalf("modifier = %q, want ctrl", modifier)
+		}
+
+		if !isDown {
+			releaseAttempts++
+			if failRelease {
+				failRelease = false
+
+				return errors.New("release failed")
+			}
+		}
+
+		return nil
+	})
+
+	if err := dispatcher.event("ctrl", true); err != nil {
+		t.Fatalf("down error = %v", err)
+	}
+
+	if err := dispatcher.event("ctrl", false); err == nil {
+		t.Fatal("first up error = nil, want failure")
+	}
+
+	if err := dispatcher.event("ctrl", false); err != nil {
+		t.Fatalf("retry up error = %v", err)
+	}
+
+	if releaseAttempts != 2 {
+		t.Fatalf("release attempts = %d, want 2", releaseAttempts)
+	}
+}
+
+func TestWlrootsModifierDispatcherAllowsCleanupReleaseWithoutTrackedDown(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+
+	dispatcher := newWlrootsModifierDispatcher(func(modifier string, isDown bool) error {
+		calls++
+
+		if modifier != "ctrl" {
+			t.Fatalf("modifier = %q, want ctrl", modifier)
+		}
+
+		if isDown {
+			t.Fatal("unexpected down event during cleanup release test")
+		}
+
+		return nil
+	})
+
+	if err := dispatcher.event("ctrl", false); err != nil {
+		t.Fatalf("cleanup release error = %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("cleanup release calls = %d, want 1", calls)
+	}
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland_modifiers_test.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_modifiers_test.go
@@ -1,11 +1,14 @@
 //go:build linux
 
+//nolint:testpackage // These tests exercise unexported dispatcher helpers directly.
 package linux
 
 import (
 	"errors"
 	"testing"
 )
+
+var errReleaseFailed = errors.New("release failed")
 
 func TestWlrootsModifierDispatcherDeduplicatesNestedUsage(t *testing.T) {
 	t.Parallel()
@@ -23,15 +26,18 @@ func TestWlrootsModifierDispatcherDeduplicatesNestedUsage(t *testing.T) {
 		return nil
 	})
 
-	if err := dispatcher.event("ctrl", true); err != nil {
+	err := dispatcher.event("ctrl", true)
+	if err != nil {
 		t.Fatalf("first down error = %v", err)
 	}
 
-	if err := dispatcher.event("ctrl", true); err != nil {
+	err = dispatcher.event("ctrl", true)
+	if err != nil {
 		t.Fatalf("nested down error = %v", err)
 	}
 
-	if err := dispatcher.event("ctrl", false); err != nil {
+	err = dispatcher.event("ctrl", false)
+	if err != nil {
 		t.Fatalf("nested up error = %v", err)
 	}
 
@@ -39,7 +45,8 @@ func TestWlrootsModifierDispatcherDeduplicatesNestedUsage(t *testing.T) {
 		t.Fatalf("event count after nested release = %d, want 1", len(events))
 	}
 
-	if err := dispatcher.event("ctrl", false); err != nil {
+	err = dispatcher.event("ctrl", false)
+	if err != nil {
 		t.Fatalf("final up error = %v", err)
 	}
 
@@ -72,25 +79,29 @@ func TestWlrootsModifierDispatcherRetriesFailedFinalRelease(t *testing.T) {
 
 		if !isDown {
 			releaseAttempts++
+
 			if failRelease {
 				failRelease = false
 
-				return errors.New("release failed")
+				return errReleaseFailed
 			}
 		}
 
 		return nil
 	})
 
-	if err := dispatcher.event("ctrl", true); err != nil {
+	err := dispatcher.event("ctrl", true)
+	if err != nil {
 		t.Fatalf("down error = %v", err)
 	}
 
-	if err := dispatcher.event("ctrl", false); err == nil {
+	err = dispatcher.event("ctrl", false)
+	if err == nil {
 		t.Fatal("first up error = nil, want failure")
 	}
 
-	if err := dispatcher.event("ctrl", false); err != nil {
+	err = dispatcher.event("ctrl", false)
+	if err != nil {
 		t.Fatalf("retry up error = %v", err)
 	}
 
@@ -118,7 +129,8 @@ func TestWlrootsModifierDispatcherAllowsCleanupReleaseWithoutTrackedDown(t *test
 		return nil
 	})
 
-	if err := dispatcher.event("ctrl", false); err != nil {
+	err := dispatcher.event("ctrl", false)
+	if err != nil {
 		t.Fatalf("cleanup release error = %v", err)
 	}
 

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -611,7 +611,11 @@ static int neru_wlr_modifier_event(NeruWlrootsClient *c, const char *modifier, i
 	}
 
 	zwp_virtual_keyboard_v1_modifiers(c->vkeyboard, c->depressed_mods, 0, 0, 0);
-	wl_display_roundtrip(c->display);
+	// Use flush instead of roundtrip: fire-and-forget is sufficient because
+	// Wayland message ordering guarantees the modifier state is applied before
+	// the next pointer button event from the same client. A roundtrip blocks
+	// concurrent cursor position queries waiting on the global mutex.
+	wl_display_flush(c->display);
 
 	return 1;
 }

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -224,6 +224,12 @@ static int neru_wlr_setup_virtual_keyboard(NeruWlrootsClient *c) {
 	c->xkb_ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 	if (!c->xkb_ctx) return 0;
 
+	// US pc105 layout is intentionally hardcoded:
+	// 1) Modifier index resolution (Shift/Ctrl/Alt/Logo) is layout-independent.
+	// 2) The keymap is sent to the compositor but Neru only uses it to inject
+	//    synthetic key events; actual key symbols are resolved via xkbcommon
+	//    in the overlay-keyboard path, so the virtual layout never appears
+	//    to the user.
 	struct xkb_rule_names names = {
 		.rules = "evdev",
 		.model = "pc105",

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -3,15 +3,20 @@
 package linux
 
 /*
-#cgo linux pkg-config: wayland-client
+#cgo linux pkg-config: wayland-client xkbcommon
 #cgo linux CFLAGS: -DWLR_CPLUSPLUS
 #include <wayland-client.h>
+#include <xkbcommon/xkbcommon.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
 #include <stdlib.h>
 #include <string.h>
-#include <poll.h>
+#include <unistd.h>
 
 // Include wlroots protocol headers relative to this package.
 #include "wlr_protocol/virtual-pointer.h"
+#include "wlr_protocol/virtual-keyboard.h"
 #include "wlr_protocol/xdg-output.h"
 #include "wlr_protocol/layer-shell.h"
 #include "wlr_protocol/xdg-shell.h"
@@ -51,7 +56,18 @@ typedef struct NeruWlrootsClient {
 
 	struct zwlr_virtual_pointer_manager_v1 *vptr_mgr;
 	struct zwlr_virtual_pointer_v1 *vptr;
+	struct zwp_virtual_keyboard_manager_v1 *vkeyboard_mgr;
+	struct zwp_virtual_keyboard_v1 *vkeyboard;
+	int vkeyboard_ready;
 	struct zxdg_output_manager_v1 *xdg_output_mgr;
+
+	struct xkb_context *xkb_ctx;
+	struct xkb_keymap *xkb_keymap;
+	uint32_t mod_shift;
+	uint32_t mod_ctrl;
+	uint32_t mod_alt;
+	uint32_t mod_logo;
+	uint32_t depressed_mods;
 
 	NeruWaylandScreen screens[NERU_MAX_OUTPUTS];
 	int nr_screens;
@@ -171,6 +187,83 @@ static const struct wl_pointer_listener neru_wlr_pointer_listener = {
 	.axis_discrete = neru_wlr_pointer_axis_discrete,
 };
 
+static int neru_wlr_create_keymap_fd(const char *keymap, size_t size) {
+	char template[] = "/tmp/neru-vkbd-keymap-XXXXXX";
+	int fd = mkstemp(template);
+	if (fd < 0) return -1;
+
+	unlink(template);
+
+	size_t written = 0;
+	while (written < size) {
+		ssize_t ret = write(fd, keymap + written, size - written);
+		if (ret < 0) {
+			if (errno == EINTR) continue;
+			close(fd);
+			return -1;
+		}
+		written += (size_t)ret;
+	}
+
+	if (lseek(fd, 0, SEEK_SET) < 0) {
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+static uint32_t neru_wlr_mod_mask(xkb_mod_index_t idx) {
+	if (idx == XKB_MOD_INVALID || idx >= 32) return 0;
+	return 1u << idx;
+}
+
+static int neru_wlr_setup_virtual_keyboard(NeruWlrootsClient *c) {
+	if (!c || !c->vkeyboard) return 0;
+
+	c->xkb_ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	if (!c->xkb_ctx) return 0;
+
+	struct xkb_rule_names names = {
+		.rules = "evdev",
+		.model = "pc105",
+		.layout = "us",
+		.variant = NULL,
+		.options = NULL,
+	};
+
+	c->xkb_keymap = xkb_keymap_new_from_names(
+		c->xkb_ctx,
+		&names,
+		XKB_KEYMAP_COMPILE_NO_FLAGS
+	);
+	if (!c->xkb_keymap) return 0;
+
+	char *keymap = xkb_keymap_get_as_string(c->xkb_keymap, XKB_KEYMAP_FORMAT_TEXT_V1);
+	if (!keymap) return 0;
+
+	size_t size = strlen(keymap) + 1;
+	int fd = neru_wlr_create_keymap_fd(keymap, size);
+	if (fd < 0) {
+		free(keymap);
+		return 0;
+	}
+
+	zwp_virtual_keyboard_v1_keymap(c->vkeyboard, WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1, fd, (uint32_t)size);
+	close(fd);
+	free(keymap);
+
+	c->mod_shift = neru_wlr_mod_mask(xkb_keymap_mod_get_index(c->xkb_keymap, XKB_MOD_NAME_SHIFT));
+	c->mod_ctrl = neru_wlr_mod_mask(xkb_keymap_mod_get_index(c->xkb_keymap, XKB_MOD_NAME_CTRL));
+	c->mod_alt = neru_wlr_mod_mask(xkb_keymap_mod_get_index(c->xkb_keymap, XKB_MOD_NAME_ALT));
+	c->mod_logo = neru_wlr_mod_mask(xkb_keymap_mod_get_index(c->xkb_keymap, XKB_MOD_NAME_LOGO));
+
+	wl_display_flush(c->display);
+	c->vkeyboard_ready = 1;
+
+	return 1;
+}
+
 // ---------- xdg_output listener ----------
 
 static void neru_xdg_output_logical_position(void *data,
@@ -238,6 +331,9 @@ static void neru_wlr_registry_global(void *data,
 	if (strcmp(interface, "zwlr_virtual_pointer_manager_v1") == 0) {
 		c->vptr_mgr = wl_registry_bind(registry, name,
 			&zwlr_virtual_pointer_manager_v1_interface, 1);
+	} else if (strcmp(interface, "zwp_virtual_keyboard_manager_v1") == 0) {
+		c->vkeyboard_mgr = wl_registry_bind(registry, name,
+			&zwp_virtual_keyboard_manager_v1_interface, 1);
 	} else if (strcmp(interface, "wl_compositor") == 0) {
 		c->compositor = wl_registry_bind(registry, name,
 			&wl_compositor_interface, 4);
@@ -303,6 +399,12 @@ static NeruWlrootsClient* neru_wlr_connect(void) {
 			c->vptr_mgr, c->seat);
 	}
 
+	if (c->vkeyboard_mgr && c->seat) {
+		c->vkeyboard = zwp_virtual_keyboard_manager_v1_create_virtual_keyboard(
+			c->vkeyboard_mgr, c->seat);
+		neru_wlr_setup_virtual_keyboard(c);
+	}
+
 	// Initialize xdg_output for each screen.
 	if (c->xdg_output_mgr) {
 		for (int i = 0; i < c->nr_screens; i++) {
@@ -325,6 +427,15 @@ static void neru_wlr_disconnect(NeruWlrootsClient *c) {
 
 	if (c->vptr) {
 		zwlr_virtual_pointer_v1_destroy(c->vptr);
+	}
+	if (c->vkeyboard) {
+		zwp_virtual_keyboard_v1_destroy(c->vkeyboard);
+	}
+	if (c->xkb_keymap) {
+		xkb_keymap_unref(c->xkb_keymap);
+	}
+	if (c->xkb_ctx) {
+		xkb_context_unref(c->xkb_ctx);
 	}
 	for (int i = 0; i < c->nr_screens; i++) {
 		if (c->screens[i].xdg_output) {
@@ -479,6 +590,47 @@ static int neru_wlr_scroll(NeruWlrootsClient *c, int axis, int delta) {
 	return 1;
 }
 
+static uint32_t neru_wlr_modifier_mask(NeruWlrootsClient *c, const char *modifier) {
+	if (strcmp(modifier, "shift") == 0) return c->mod_shift;
+	if (strcmp(modifier, "ctrl") == 0) return c->mod_ctrl;
+	if (strcmp(modifier, "alt") == 0) return c->mod_alt;
+	if (strcmp(modifier, "cmd") == 0) return c->mod_logo;
+	return 0;
+}
+
+static uint32_t neru_wlr_modifier_keycode(const char *modifier) {
+	if (strcmp(modifier, "shift") == 0) return 42;  // KEY_LEFTSHIFT
+	if (strcmp(modifier, "ctrl") == 0) return 29;   // KEY_LEFTCTRL
+	if (strcmp(modifier, "alt") == 0) return 56;    // KEY_LEFTALT
+	if (strcmp(modifier, "cmd") == 0) return 125;   // KEY_LEFTMETA
+	return 0;
+}
+
+static int neru_wlr_modifier_event(NeruWlrootsClient *c, const char *modifier, int is_down) {
+	if (!c || !c->vkeyboard || !c->vkeyboard_ready) return 0;
+
+	uint32_t keycode = neru_wlr_modifier_keycode(modifier);
+	uint32_t mask = neru_wlr_modifier_mask(c, modifier);
+	if (keycode == 0 || mask == 0) return 0;
+
+	if (is_down) {
+		c->depressed_mods |= mask;
+	} else {
+		c->depressed_mods &= ~mask;
+	}
+
+	zwp_virtual_keyboard_v1_key(
+		c->vkeyboard,
+		0,
+		keycode,
+		is_down ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED
+	);
+	zwp_virtual_keyboard_v1_modifiers(c->vkeyboard, c->depressed_mods, 0, 0, 0);
+	wl_display_flush(c->display);
+
+	return 1;
+}
+
 static int neru_wlr_get_cursor(NeruWlrootsClient *c, int *x, int *y) {
 	if (!c) return 0;
 	*x = c->cursor_x;
@@ -508,6 +660,10 @@ static int neru_wlr_screen_info(NeruWlrootsClient *c, int idx,
 static int neru_wlr_has_virtual_pointer(NeruWlrootsClient *c) {
 	return c && c->vptr != NULL;
 }
+
+static int neru_wlr_has_virtual_keyboard(NeruWlrootsClient *c) {
+	return c && c->vkeyboard != NULL && c->vkeyboard_ready;
+}
 */
 import "C"
 
@@ -517,6 +673,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"unsafe"
 
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	// Blank-import to link the wayland-scanner generated protocol objects.
@@ -863,6 +1020,43 @@ func wlrootsScroll(axis, delta int) error {
 		return derrors.New(
 			derrors.CodeActionFailed,
 			"failed to perform wlroots scroll event",
+		)
+	}
+
+	return nil
+}
+
+func wlrootsModifierEvent(modifier string, isDown bool) error {
+	err := ensureWlrootsState()
+	if err != nil {
+		return err
+	}
+
+	globalWlrootsState.mu.Lock()
+	client := globalWlrootsState.client
+	defer globalWlrootsState.mu.Unlock()
+
+	if C.neru_wlr_has_virtual_keyboard(client) == 0 { //nolint:nlreturn
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"Wayland compositor does not support zwp_virtual_keyboard_manager_v1 protocol; "+
+				"this protocol is required for sticky modifier key injection on Wayland",
+		)
+	}
+
+	cModifier := C.CString(modifier)
+	defer C.free(unsafe.Pointer(cModifier)) //nolint:nlreturn
+
+	cDown := C.int(0)
+	if isDown {
+		cDown = C.int(1)
+	}
+
+	if C.neru_wlr_modifier_event(client, cModifier, cDown) == 0 { //nolint:nlreturn
+		return derrors.Newf(
+			derrors.CodeActionFailed,
+			"failed to post wlroots modifier event %q",
+			modifier,
 		)
 	}
 

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -598,20 +598,11 @@ static uint32_t neru_wlr_modifier_mask(NeruWlrootsClient *c, const char *modifie
 	return 0;
 }
 
-static uint32_t neru_wlr_modifier_keycode(const char *modifier) {
-	if (strcmp(modifier, "shift") == 0) return 42;  // KEY_LEFTSHIFT
-	if (strcmp(modifier, "ctrl") == 0) return 29;   // KEY_LEFTCTRL
-	if (strcmp(modifier, "alt") == 0) return 56;    // KEY_LEFTALT
-	if (strcmp(modifier, "cmd") == 0) return 125;   // KEY_LEFTMETA
-	return 0;
-}
-
 static int neru_wlr_modifier_event(NeruWlrootsClient *c, const char *modifier, int is_down) {
 	if (!c || !c->vkeyboard || !c->vkeyboard_ready) return 0;
 
-	uint32_t keycode = neru_wlr_modifier_keycode(modifier);
 	uint32_t mask = neru_wlr_modifier_mask(c, modifier);
-	if (keycode == 0 || mask == 0) return 0;
+	if (mask == 0) return 0;
 
 	if (is_down) {
 		c->depressed_mods |= mask;
@@ -619,14 +610,8 @@ static int neru_wlr_modifier_event(NeruWlrootsClient *c, const char *modifier, i
 		c->depressed_mods &= ~mask;
 	}
 
-	zwp_virtual_keyboard_v1_key(
-		c->vkeyboard,
-		0,
-		keycode,
-		is_down ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED
-	);
 	zwp_virtual_keyboard_v1_modifiers(c->vkeyboard, c->depressed_mods, 0, 0, 0);
-	wl_display_flush(c->display);
+	wl_display_roundtrip(c->display);
 
 	return 1;
 }

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
@@ -83,6 +83,15 @@ func wlrootsScroll(axis, direction int) error {
 	)
 }
 
+func wlrootsModifierEvent(modifier string, isDown bool) error {
+	_, _ = modifier, isDown
+
+	return derrors.New(
+		derrors.CodeNotSupported,
+		"wlroots backend requires CGO-enabled Linux builds",
+	)
+}
+
 // Button constants matching the CGo version.
 const (
 	WlrBtnLeft   = 0x110

--- a/internal/core/infra/platform/linux/wlr_protocol/virtual-keyboard.c
+++ b/internal/core/infra/platform/linux/wlr_protocol/virtual-keyboard.c
@@ -1,0 +1,50 @@
+/* Minimal client protocol metadata for virtual-keyboard-unstable-v1. */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include "wayland-util.h"
+
+#ifndef __has_attribute
+# define __has_attribute(x) 0
+#endif
+
+#if (__has_attribute(visibility) || defined(__GNUC__) && __GNUC__ >= 4)
+#define WL_PRIVATE __attribute__ ((visibility("hidden")))
+#else
+#define WL_PRIVATE
+#endif
+
+extern const struct wl_interface wl_seat_interface;
+extern const struct wl_interface zwp_virtual_keyboard_v1_interface;
+
+static const struct wl_interface *virtual_keyboard_unstable_v1_types[] = {
+	&wl_seat_interface,
+	&zwp_virtual_keyboard_v1_interface,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+};
+
+static const struct wl_message zwp_virtual_keyboard_v1_requests[] = {
+	{ "keymap", "uhu", virtual_keyboard_unstable_v1_types + 2 },
+	{ "key", "uuu", virtual_keyboard_unstable_v1_types + 2 },
+	{ "modifiers", "uuuu", virtual_keyboard_unstable_v1_types + 2 },
+	{ "destroy", "", virtual_keyboard_unstable_v1_types + 2 },
+};
+
+WL_PRIVATE const struct wl_interface zwp_virtual_keyboard_v1_interface = {
+	"zwp_virtual_keyboard_v1", 1,
+	4, zwp_virtual_keyboard_v1_requests,
+	0, NULL,
+};
+
+static const struct wl_message zwp_virtual_keyboard_manager_v1_requests[] = {
+	{ "create_virtual_keyboard", "on", virtual_keyboard_unstable_v1_types + 0 },
+};
+
+WL_PRIVATE const struct wl_interface zwp_virtual_keyboard_manager_v1_interface = {
+	"zwp_virtual_keyboard_manager_v1", 1,
+	1, zwp_virtual_keyboard_manager_v1_requests,
+	0, NULL,
+};

--- a/internal/core/infra/platform/linux/wlr_protocol/virtual-keyboard.h
+++ b/internal/core/infra/platform/linux/wlr_protocol/virtual-keyboard.h
@@ -1,0 +1,86 @@
+/* Minimal client protocol declarations for virtual-keyboard-unstable-v1. */
+
+#ifndef VIRTUAL_KEYBOARD_UNSTABLE_V1_CLIENT_PROTOCOL_H
+#define VIRTUAL_KEYBOARD_UNSTABLE_V1_CLIENT_PROTOCOL_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include "wayland-client.h"
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+struct wl_seat;
+struct zwp_virtual_keyboard_manager_v1;
+struct zwp_virtual_keyboard_v1;
+
+extern const struct wl_interface zwp_virtual_keyboard_manager_v1_interface;
+extern const struct wl_interface zwp_virtual_keyboard_v1_interface;
+
+#ifndef ZWP_VIRTUAL_KEYBOARD_V1_ERROR_ENUM
+#define ZWP_VIRTUAL_KEYBOARD_V1_ERROR_ENUM
+enum zwp_virtual_keyboard_v1_error {
+	ZWP_VIRTUAL_KEYBOARD_V1_ERROR_NO_KEYMAP = 0,
+};
+#endif /* ZWP_VIRTUAL_KEYBOARD_V1_ERROR_ENUM */
+
+#ifndef ZWP_VIRTUAL_KEYBOARD_MANAGER_V1_ERROR_ENUM
+#define ZWP_VIRTUAL_KEYBOARD_MANAGER_V1_ERROR_ENUM
+enum zwp_virtual_keyboard_manager_v1_error {
+	ZWP_VIRTUAL_KEYBOARD_MANAGER_V1_ERROR_UNAUTHORIZED = 0,
+};
+#endif /* ZWP_VIRTUAL_KEYBOARD_MANAGER_V1_ERROR_ENUM */
+
+#define ZWP_VIRTUAL_KEYBOARD_V1_KEYMAP 0
+#define ZWP_VIRTUAL_KEYBOARD_V1_KEY 1
+#define ZWP_VIRTUAL_KEYBOARD_V1_MODIFIERS 2
+#define ZWP_VIRTUAL_KEYBOARD_V1_DESTROY 3
+
+#define ZWP_VIRTUAL_KEYBOARD_MANAGER_V1_CREATE_VIRTUAL_KEYBOARD 0
+
+static inline void
+zwp_virtual_keyboard_v1_keymap(struct zwp_virtual_keyboard_v1 *zwp_virtual_keyboard_v1, uint32_t format, int32_t fd, uint32_t size)
+{
+	wl_proxy_marshal((struct wl_proxy *) zwp_virtual_keyboard_v1,
+			 ZWP_VIRTUAL_KEYBOARD_V1_KEYMAP, format, fd, size);
+}
+
+static inline void
+zwp_virtual_keyboard_v1_key(struct zwp_virtual_keyboard_v1 *zwp_virtual_keyboard_v1, uint32_t time, uint32_t key, uint32_t state)
+{
+	wl_proxy_marshal((struct wl_proxy *) zwp_virtual_keyboard_v1,
+			 ZWP_VIRTUAL_KEYBOARD_V1_KEY, time, key, state);
+}
+
+static inline void
+zwp_virtual_keyboard_v1_modifiers(struct zwp_virtual_keyboard_v1 *zwp_virtual_keyboard_v1, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group)
+{
+	wl_proxy_marshal((struct wl_proxy *) zwp_virtual_keyboard_v1,
+			 ZWP_VIRTUAL_KEYBOARD_V1_MODIFIERS, mods_depressed, mods_latched, mods_locked, group);
+}
+
+static inline void
+zwp_virtual_keyboard_v1_destroy(struct zwp_virtual_keyboard_v1 *zwp_virtual_keyboard_v1)
+{
+	wl_proxy_marshal((struct wl_proxy *) zwp_virtual_keyboard_v1,
+			 ZWP_VIRTUAL_KEYBOARD_V1_DESTROY);
+	wl_proxy_destroy((struct wl_proxy *) zwp_virtual_keyboard_v1);
+}
+
+static inline struct zwp_virtual_keyboard_v1 *
+zwp_virtual_keyboard_manager_v1_create_virtual_keyboard(struct zwp_virtual_keyboard_manager_v1 *zwp_virtual_keyboard_manager_v1, struct wl_seat *seat)
+{
+	struct wl_proxy *id;
+
+	id = wl_proxy_marshal_constructor((struct wl_proxy *) zwp_virtual_keyboard_manager_v1,
+			 ZWP_VIRTUAL_KEYBOARD_MANAGER_V1_CREATE_VIRTUAL_KEYBOARD, &zwp_virtual_keyboard_v1_interface, seat, NULL);
+
+	return (struct zwp_virtual_keyboard_v1 *) id;
+}
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif

--- a/internal/core/ports/infrastructure.go
+++ b/internal/core/ports/infrastructure.go
@@ -35,7 +35,7 @@ type EventTapPort interface {
 
 	// SetStickyModifierToggle enables or disables sticky modifier toggle detection.
 	// When enabled, modifier key events are detected and callback is invoked with
-	// "__modifier_<name>" strings for sticky modifier toggling.
+	// "__modifier_<name>_down/up" strings for sticky modifier toggling.
 	SetStickyModifierToggle(enabled bool)
 
 	// SetKeyboardLayout configures the reference keyboard layout used for key translation.

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -84,6 +84,9 @@ type Manager struct {
 	modeIndicatorOverlay   *modeindicator.Overlay
 	recursiveGridOverlay   *recursivegrid.Overlay
 	stickyModifiersOverlay *stickyindicator.Overlay
+
+	stickyBadgeRect    image.Rectangle
+	stickyBadgeVisible bool
 }
 
 var (
@@ -164,6 +167,9 @@ func (m *Manager) Hide() {
 	} else if m.wlroots != nil {
 		m.wlroots.Hide()
 	}
+
+	m.stickyBadgeVisible = false
+	m.stickyBadgeRect = image.Rectangle{}
 }
 
 // Clear clears the overlay content.
@@ -176,6 +182,9 @@ func (m *Manager) Clear() {
 	} else if m.wlroots != nil {
 		m.wlroots.Clear()
 	}
+
+	m.stickyBadgeVisible = false
+	m.stickyBadgeRect = image.Rectangle{}
 }
 
 // ResizeToActiveScreen resizes the overlay to the active screen.
@@ -401,7 +410,16 @@ func (m *Manager) DrawModeIndicator(posX, posY int) {
 
 // DrawStickyModifiersIndicator draws the sticky modifiers indicator overlay.
 func (m *Manager) DrawStickyModifiersIndicator(posX, posY int, symbols string) {
-	if m.stickyModifiersOverlay == nil || symbols == "" {
+	if m.stickyModifiersOverlay == nil {
+		return
+	}
+
+	m.renderMu.Lock()
+	defer m.renderMu.Unlock()
+
+	if symbols == "" {
+		m.clearStickyBadgeLocked()
+
 		return
 	}
 
@@ -410,14 +428,30 @@ func (m *Manager) DrawStickyModifiersIndicator(posX, posY int, symbols string) {
 		return
 	}
 
-	m.renderMu.Lock()
-	defer m.renderMu.Unlock()
+	m.clearStickyBadgeLocked()
+	m.stickyBadgeRect = expandRect(badgeBounds(posX, posY, symbols, style), 3)
+	m.stickyBadgeVisible = true
 
 	if m.x11 != nil {
 		m.x11.DrawBadge(posX, posY, symbols, colors, style)
 	} else if m.wlroots != nil {
 		m.wlroots.DrawBadge(posX, posY, symbols, colors, style)
 	}
+}
+
+func (m *Manager) clearStickyBadgeLocked() {
+	if !m.stickyBadgeVisible {
+		return
+	}
+
+	if m.x11 != nil {
+		m.x11.ClearRect(m.stickyBadgeRect)
+	} else if m.wlroots != nil {
+		m.wlroots.ClearRect(m.stickyBadgeRect)
+	}
+
+	m.stickyBadgeVisible = false
+	m.stickyBadgeRect = image.Rectangle{}
 }
 
 // DrawGrid draws the grid overlay.
@@ -735,6 +769,34 @@ func estimateTextWidth(text string, fontSize float64) int {
 
 func estimateTextHeight(fontSize float64) int {
 	return int(math.Ceil(fontSize * textHeightMultiplier))
+}
+
+func badgeBounds(posX, posY int, text string, style overlayBadgeStyle) image.Rectangle {
+	fontSize := style.fontSize
+	if fontSize <= 0 {
+		fontSize = 14
+	}
+
+	paddingX := resolveAutoPadding(fontSize, style.paddingX, true)
+	paddingY := resolveAutoPadding(fontSize, style.paddingY, false)
+	width := estimateTextWidth(text, fontSize) + paddingX*paddingMultiplier
+	height := estimateTextHeight(fontSize) + paddingY*paddingMultiplier
+
+	return image.Rect(
+		posX+style.offsetX,
+		posY+style.offsetY,
+		posX+style.offsetX+width,
+		posY+style.offsetY+height,
+	)
+}
+
+func expandRect(rect image.Rectangle, amount int) image.Rectangle {
+	return image.Rect(
+		rect.Min.X-amount,
+		rect.Min.Y-amount,
+		rect.Max.X+amount,
+		rect.Max.Y+amount,
+	)
 }
 
 func centeredRect(cell image.Rectangle, width, height int) image.Rectangle {

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -49,6 +49,7 @@ const (
 	centeredRectHalf                       = 0.5
 	paddingMultiplier                      = 2
 	subKeyPreviewPaddingBottom             = 4
+	stickyBadgeClearPadding                = 3
 )
 
 type linuxOverlayBackend string
@@ -449,7 +450,10 @@ func (m *Manager) DrawStickyModifiersIndicator(posX, posY int, symbols string) {
 	}
 
 	m.clearStickyBadgeLocked()
-	m.stickyBadgeRect = expandRect(badgeBounds(posX, posY, symbols, style), 3)
+	m.stickyBadgeRect = expandRect(
+		badgeBounds(posX, posY, symbols, style),
+		stickyBadgeClearPadding,
+	)
 	m.stickyBadgeVisible = true
 
 	if m.x11 != nil {
@@ -457,21 +461,6 @@ func (m *Manager) DrawStickyModifiersIndicator(posX, posY int, symbols string) {
 	} else if m.wlroots != nil {
 		m.wlroots.DrawBadge(posX, posY, symbols, colors, style)
 	}
-}
-
-func (m *Manager) clearStickyBadgeLocked() {
-	if !m.stickyBadgeVisible {
-		return
-	}
-
-	if m.x11 != nil {
-		m.x11.ClearRect(m.stickyBadgeRect)
-	} else if m.wlroots != nil {
-		m.wlroots.ClearRect(m.stickyBadgeRect)
-	}
-
-	m.stickyBadgeVisible = false
-	m.stickyBadgeRect = image.Rectangle{}
 }
 
 // DrawGrid draws the grid overlay.
@@ -614,6 +603,21 @@ func (m *Manager) SetHideUnmatched(hide bool) {
 
 // SetSharingType is a no-op on Linux.
 func (m *Manager) SetSharingType(_ bool) {}
+
+func (m *Manager) clearStickyBadgeLocked() {
+	if !m.stickyBadgeVisible {
+		return
+	}
+
+	if m.x11 != nil {
+		m.x11.ClearRect(m.stickyBadgeRect)
+	} else if m.wlroots != nil {
+		m.wlroots.ClearRect(m.stickyBadgeRect)
+	}
+
+	m.stickyBadgeVisible = false
+	m.stickyBadgeRect = image.Rectangle{}
+}
 
 func (m *Manager) publish(change StateChange) {
 	m.mu.RLock()

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -79,6 +79,8 @@ type Manager struct {
 	x11     *x11Overlay
 	wlroots *wlrootsOverlay
 
+	keyboardCaptureEnabled bool
+
 	hintOverlay            *hints.Overlay
 	gridOverlay            *grid.Overlay
 	modeIndicatorOverlay   *modeindicator.Overlay
@@ -98,10 +100,11 @@ var (
 // NewOverlayManager creates a new overlay Manager.
 func NewOverlayManager(logger *zap.Logger) *Manager {
 	manager := &Manager{
-		logger:  logger,
-		mode:    ModeIdle,
-		subs:    make(map[uint64]func(StateChange), initialSubscriberCapacity),
-		backend: detectLinuxOverlayBackend(),
+		logger:                 logger,
+		mode:                   ModeIdle,
+		subs:                   make(map[uint64]func(StateChange), initialSubscriberCapacity),
+		backend:                detectLinuxOverlayBackend(),
+		keyboardCaptureEnabled: true,
 	}
 
 	switch manager.backend {
@@ -170,6 +173,23 @@ func (m *Manager) Hide() {
 
 	m.stickyBadgeVisible = false
 	m.stickyBadgeRect = image.Rectangle{}
+}
+
+// SetKeyboardCaptureEnabled controls whether the Wayland overlay requests
+// exclusive keyboard focus or remains keyboard-passive.
+func (m *Manager) SetKeyboardCaptureEnabled(enabled bool) {
+	if m == nil {
+		return
+	}
+
+	m.renderMu.Lock()
+	defer m.renderMu.Unlock()
+
+	m.keyboardCaptureEnabled = enabled
+
+	if m.wlroots != nil {
+		m.wlroots.setKeyboardCaptureEnabled(enabled)
+	}
 }
 
 // Clear clears the overlay content.

--- a/internal/ui/overlay/manager_linux_wayland.go
+++ b/internal/ui/overlay/manager_linux_wayland.go
@@ -19,7 +19,9 @@ import (
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 )
 
-type wlrootsOverlay struct{}
+type wlrootsOverlay struct {
+	sublayerKeys string
+}
 
 func newWlrootsOverlay(logger *zap.Logger) *wlrootsOverlay {
 	_ = logger
@@ -35,6 +37,7 @@ func (o *wlrootsOverlay) WindowPtr() unsafe.Pointer {
 func (o *wlrootsOverlay) Show()                                                  {}
 func (o *wlrootsOverlay) Hide()                                                  {}
 func (o *wlrootsOverlay) Clear()                                                 {}
+func (o *wlrootsOverlay) ClearRect(image.Rectangle)                              {}
 func (o *wlrootsOverlay) Resize()                                                {}
 func (o *wlrootsOverlay) Destroy()                                               {}
 func (o *wlrootsOverlay) UpdateGridMatches(string)                               {}

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -280,17 +280,15 @@ static void neru_keyboard_key(void *data, struct wl_keyboard *keyboard,
     xkb_keysym_t keysym = xkb_state_key_get_one_sym(overlay->xkb_state, key + 8);
     const char *modifier_name = neru_modifier_name_from_keysym(keysym);
     if (modifier_name) {
-        if (state == WL_KEYBOARD_KEY_STATE_PRESSED || state == WL_KEYBOARD_KEY_STATE_RELEASED) {
-            char modifier_key[64] = {0};
-            snprintf(
-                modifier_key,
-                sizeof(modifier_key),
-                "__modifier_%s_%s",
-                modifier_name,
-                state == WL_KEYBOARD_KEY_STATE_PRESSED ? "down" : "up"
-            );
-            neru_key_ring_push(modifier_key);
-        }
+        char modifier_key[64] = {0};
+        snprintf(
+            modifier_key,
+            sizeof(modifier_key),
+            "__modifier_%s_%s",
+            modifier_name,
+            state == WL_KEYBOARD_KEY_STATE_PRESSED ? "down" : "up"
+        );
+        neru_key_ring_push(modifier_key);
 
         return;
     }
@@ -572,6 +570,24 @@ static void neru_wayland_overlay_clear(NeruWaylandOverlay *overlay) {
     }
 }
 
+static void neru_wayland_overlay_clear_rect(NeruWaylandOverlay *overlay, double x, double y, double width, double height) {
+    if (!overlay || width <= 0 || height <= 0) return;
+    for (int i = 0; i < overlay->nr_screens; i++) {
+        NeruWaylandOverlayScreen *scr = &overlay->screens[i];
+        if (!scr->cr) continue;
+
+        double scr_x = x - scr->x;
+        double scr_y = y - scr->y;
+
+        cairo_t *cr = scr->cr;
+        cairo_save(cr);
+        cairo_set_operator(cr, CAIRO_OPERATOR_CLEAR);
+        cairo_rectangle(cr, scr_x, scr_y, width, height);
+        cairo_fill(cr);
+        cairo_restore(cr);
+    }
+}
+
 static void neru_wayland_overlay_flush(NeruWaylandOverlay *overlay) {
     neru_wayland_overlay_show(overlay);
 }
@@ -795,6 +811,19 @@ func (o *wlrootsOverlay) Clear() {
 	}
 }
 
+func (o *wlrootsOverlay) ClearRect(rect image.Rectangle) {
+	if o != nil && o.raw != nil && !rect.Empty() {
+		C.neru_wayland_overlay_clear_rect(
+			o.raw,
+			C.double(rect.Min.X),
+			C.double(rect.Min.Y),
+			C.double(rect.Dx()),
+			C.double(rect.Dy()),
+		)
+		C.neru_wayland_overlay_flush(o.raw)
+	}
+}
+
 func (o *wlrootsOverlay) Resize() {
 	// Wayland layer shells auto-resize
 }
@@ -939,16 +968,7 @@ func (o *wlrootsOverlay) DrawBadge(
 		fontSize = 14
 	}
 
-	paddingX := resolveAutoPadding(fontSize, style.paddingX, true)
-	paddingY := resolveAutoPadding(fontSize, style.paddingY, false)
-	width := estimateTextWidth(text, fontSize) + paddingX*paddingMultiplier
-	height := estimateTextHeight(fontSize) + paddingY*paddingMultiplier
-	rect := image.Rect(
-		posX+style.offsetX,
-		posY+style.offsetY,
-		posX+style.offsetX+width,
-		posY+style.offsetY+height,
-	)
+	rect := badgeBounds(posX, posY, text, style)
 
 	o.drawRect(rect, colors.background, colors.border, max(style.borderWidth, 1))
 	o.drawTextCentered(text, rect, style.fontFamily, fontSize, colors.text)

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -82,8 +82,6 @@ static struct {
     int count;
 } key_ring = { .head = 0, .tail = 0, .count = 0 };
 
-static volatile int keyboard_enter_received = 0;
-
 static void neru_key_ring_push(const char *key) {
     if (!key || key[0] == '\0' || key_ring.count >= NERU_KEY_RING_CAP) return;
 
@@ -111,16 +109,6 @@ static const char* neru_modifier_name_from_keysym(xkb_keysym_t keysym) {
         default:
             return NULL;
     }
-}
-
-//export neruWaylandOverlayOnKey
-static void neruWaylandOverlayOnKey(const char *key) {
-    (void)key; // unused — keyboard events go through neru_keyboard_key
-}
-
-//export neruWaylandOverlayOnEnter
-static void neruWaylandOverlayOnEnter(void) {
-    keyboard_enter_received = 1;
 }
 
 // Create anonymous shared memory
@@ -265,9 +253,7 @@ static void neru_keyboard_keymap(void *data, struct wl_keyboard *keyboard,
 }
 
 static void neru_keyboard_enter(void *data, struct wl_keyboard *keyboard,
-    uint32_t serial, struct wl_surface *surface, struct wl_array *keys) {
-    keyboard_enter_received = 1;
-}
+    uint32_t serial, struct wl_surface *surface, struct wl_array *keys) {}
 
 static void neru_keyboard_leave(void *data, struct wl_keyboard *keyboard,
     uint32_t serial, struct wl_surface *surface) {}
@@ -380,6 +366,9 @@ static NeruWaylandOverlay* neru_wayland_overlay_new(void) {
     NeruWaylandOverlay *overlay = calloc(1, sizeof(NeruWaylandOverlay));
     if (!overlay) return NULL;
 
+    overlay->keyboard_interactivity_set =
+        ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
+
     overlay->display = wl_display_connect(NULL);
     if (!overlay->display) {
         free(overlay);
@@ -475,8 +464,10 @@ static void neru_wayland_overlay_setup_buffers(NeruWaylandOverlay *overlay) {
 
         // Request exclusive keyboard interactivity when overlay is shown
         // This tells the compositor to send keyboard events to this surface
-        zwlr_layer_surface_v1_set_keyboard_interactivity(scr->layer_surface,
-            ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE);
+        zwlr_layer_surface_v1_set_keyboard_interactivity(
+            scr->layer_surface,
+            overlay->keyboard_interactivity_set
+        );
 
         zwlr_layer_surface_v1_add_listener(scr->layer_surface, &layer_surface_listener, overlay);
         wl_surface_commit(scr->wl_surface);
@@ -555,6 +546,30 @@ static void neru_wayland_overlay_hide(NeruWaylandOverlay *overlay) {
         }
     }
     wl_display_flush(overlay->display);
+}
+
+static void neru_wayland_overlay_set_keyboard_capture(
+    NeruWaylandOverlay *overlay,
+    int enabled
+) {
+    if (!overlay) return;
+
+    overlay->keyboard_interactivity_set = enabled
+        ? ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE
+        : ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
+
+    for (int i = 0; i < overlay->nr_screens; i++) {
+        NeruWaylandOverlayScreen *scr = &overlay->screens[i];
+        if (!scr->layer_surface || !scr->wl_surface) continue;
+
+        zwlr_layer_surface_v1_set_keyboard_interactivity(
+            scr->layer_surface,
+            overlay->keyboard_interactivity_set
+        );
+        wl_surface_commit(scr->wl_surface);
+    }
+
+    wl_display_roundtrip(overlay->display);
 }
 
 static void neru_wayland_overlay_clear(NeruWaylandOverlay *overlay) {
@@ -699,14 +714,12 @@ static const char* neruWaylandOverlayGetKey(NeruWaylandOverlay *overlay) {
     return neru_wayland_overlay_get_key(overlay);
 }
 
-//export neruWaylandOverlayCheckEnter
-static int neruWaylandOverlayCheckEnter(NeruWaylandOverlay *overlay) {
-    (void)overlay;
-    if (keyboard_enter_received) {
-        keyboard_enter_received = 0;
-        return 1;
-    }
-    return 0;
+//export neruWaylandOverlaySetKeyboardCapture
+static void neruWaylandOverlaySetKeyboardCapture(
+    NeruWaylandOverlay *overlay,
+    int enabled
+) {
+    neru_wayland_overlay_set_keyboard_capture(overlay, enabled);
 }
 */
 import "C"
@@ -1067,6 +1080,19 @@ func (o *wlrootsOverlay) keyboardPoller() {
 			time.Sleep(pollInterval)
 		}
 	}
+}
+
+func (o *wlrootsOverlay) setKeyboardCaptureEnabled(enabled bool) {
+	if o == nil || o.raw == nil {
+		return
+	}
+
+	cEnabled := C.int(0)
+	if enabled {
+		cEnabled = 1
+	}
+
+	C.neruWaylandOverlaySetKeyboardCapture(o.raw, cEnabled)
 }
 
 // startPoller launches the keyboard polling goroutine.

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -6,6 +6,7 @@ package overlay
 #cgo linux pkg-config: wayland-client cairo xkbcommon
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
+#include <xkbcommon/xkbcommon-keysyms.h>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -14,6 +15,7 @@ package overlay
 #include <errno.h>
 #include <cairo/cairo.h>
 #include <poll.h>
+#include <stdio.h>
 
 #include "../../core/infra/platform/linux/wlr_protocol/xdg-shell.h"
 #include "../../core/infra/platform/linux/wlr_protocol/layer-shell.h"
@@ -81,6 +83,35 @@ static struct {
 } key_ring = { .head = 0, .tail = 0, .count = 0 };
 
 static volatile int keyboard_enter_received = 0;
+
+static void neru_key_ring_push(const char *key) {
+    if (!key || key[0] == '\0' || key_ring.count >= NERU_KEY_RING_CAP) return;
+
+    snprintf(key_ring.keys[key_ring.head], sizeof(key_ring.keys[0]), "%s", key);
+    key_ring.head = (key_ring.head + 1) % NERU_KEY_RING_CAP;
+    key_ring.count++;
+}
+
+static const char* neru_modifier_name_from_keysym(xkb_keysym_t keysym) {
+    switch (keysym) {
+        case XKB_KEY_Shift_L:
+        case XKB_KEY_Shift_R:
+            return "shift";
+        case XKB_KEY_Control_L:
+        case XKB_KEY_Control_R:
+            return "ctrl";
+        case XKB_KEY_Alt_L:
+        case XKB_KEY_Alt_R:
+            return "alt";
+        case XKB_KEY_Super_L:
+        case XKB_KEY_Super_R:
+        case XKB_KEY_Meta_L:
+        case XKB_KEY_Meta_R:
+            return "cmd";
+        default:
+            return NULL;
+    }
+}
 
 //export neruWaylandOverlayOnKey
 static void neruWaylandOverlayOnKey(const char *key) {
@@ -244,49 +275,66 @@ static void neru_keyboard_leave(void *data, struct wl_keyboard *keyboard,
 static void neru_keyboard_key(void *data, struct wl_keyboard *keyboard,
     uint32_t serial, uint32_t time, uint32_t key, uint32_t state) {
     NeruWaylandOverlay *overlay = (NeruWaylandOverlay *)data;
-    if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
-        char buf[64] = {0};
+    if (!overlay->xkb_state) return;
 
-        if (overlay->xkb_state) {
-            xkb_keysym_t keysym = xkb_state_key_get_one_sym(overlay->xkb_state, key + 8);
-            xkb_keysym_get_name(keysym, buf, sizeof(buf));
+    xkb_keysym_t keysym = xkb_state_key_get_one_sym(overlay->xkb_state, key + 8);
+    const char *modifier_name = neru_modifier_name_from_keysym(keysym);
+    if (modifier_name) {
+        if (state == WL_KEYBOARD_KEY_STATE_PRESSED || state == WL_KEYBOARD_KEY_STATE_RELEASED) {
+            char modifier_key[64] = {0};
+            snprintf(
+                modifier_key,
+                sizeof(modifier_key),
+                "__modifier_%s_%s",
+                modifier_name,
+                state == WL_KEYBOARD_KEY_STATE_PRESSED ? "down" : "up"
+            );
+            neru_key_ring_push(modifier_key);
+        }
 
-            // Check modifiers - build standard macOS-style modifier prefix
-            char mod_prefix[64] = "";
-            if (xkb_state_mod_name_is_active(overlay->xkb_state, XKB_MOD_NAME_SHIFT, XKB_STATE_MODS_EFFECTIVE) > 0) strcat(mod_prefix, "Shift+");
-            if (xkb_state_mod_name_is_active(overlay->xkb_state, XKB_MOD_NAME_CTRL, XKB_STATE_MODS_EFFECTIVE) > 0) strcat(mod_prefix, "Ctrl+");
-            if (xkb_state_mod_name_is_active(overlay->xkb_state, XKB_MOD_NAME_ALT, XKB_STATE_MODS_EFFECTIVE) > 0) strcat(mod_prefix, "Alt+");
-            if (xkb_state_mod_name_is_active(overlay->xkb_state, XKB_MOD_NAME_LOGO, XKB_STATE_MODS_EFFECTIVE) > 0) strcat(mod_prefix, "Cmd+");
+        return;
+    }
 
-            char utf8_buf[64] = {0};
-            xkb_state_key_get_utf8(overlay->xkb_state, key + 8, utf8_buf, sizeof(utf8_buf));
+    if (state != WL_KEYBOARD_KEY_STATE_PRESSED) {
+        return;
+    }
 
-            char *final_key = buf; // Fallback to keysym name
+    char buf[64] = {0};
+    xkb_keysym_get_name(keysym, buf, sizeof(buf));
 
-            // If the utf8 string is exactly 1 printable ascii character (and not space), use it!
-            // This properly handles characters like ',' or '.' which xkb_keysym_get_name translates to "comma"/"period".
-            if (utf8_buf[0] != '\0' && utf8_buf[1] == '\0' && utf8_buf[0] > 32 && utf8_buf[0] <= 126) {
-                final_key = utf8_buf;
-                // If it's a letter, lowercase it for consistency so Shift+l doesn't become Shift+L
-                if (final_key[0] >= 'A' && final_key[0] <= 'Z') {
-                    final_key[0] = final_key[0] + 32;
-                }
-            } else if (buf[0]) {
-                // Otherwise format the keysym name
-                for (int i = 0; buf[i]; i++) {
-                    if (buf[i] >= 'A' && buf[i] <= 'Z') {
-                        buf[i] = buf[i] + 32;
-                    }
-                }
-            }
+    // Check modifiers - build standard macOS-style modifier prefix
+    char mod_prefix[64] = "";
+    if (xkb_state_mod_name_is_active(overlay->xkb_state, XKB_MOD_NAME_SHIFT, XKB_STATE_MODS_EFFECTIVE) > 0) strcat(mod_prefix, "Shift+");
+    if (xkb_state_mod_name_is_active(overlay->xkb_state, XKB_MOD_NAME_CTRL, XKB_STATE_MODS_EFFECTIVE) > 0) strcat(mod_prefix, "Ctrl+");
+    if (xkb_state_mod_name_is_active(overlay->xkb_state, XKB_MOD_NAME_ALT, XKB_STATE_MODS_EFFECTIVE) > 0) strcat(mod_prefix, "Alt+");
+    if (xkb_state_mod_name_is_active(overlay->xkb_state, XKB_MOD_NAME_LOGO, XKB_STATE_MODS_EFFECTIVE) > 0) strcat(mod_prefix, "Cmd+");
 
-            if (final_key[0] && key_ring.count < NERU_KEY_RING_CAP) {
-                snprintf(key_ring.keys[key_ring.head], sizeof(key_ring.keys[0]),
-                         "%s%s", mod_prefix, final_key);
-                key_ring.head = (key_ring.head + 1) % NERU_KEY_RING_CAP;
-                key_ring.count++;
+    char utf8_buf[64] = {0};
+    xkb_state_key_get_utf8(overlay->xkb_state, key + 8, utf8_buf, sizeof(utf8_buf));
+
+    char *final_key = buf; // Fallback to keysym name
+
+    // If the utf8 string is exactly 1 printable ascii character (and not space), use it!
+    // This properly handles characters like ',' or '.' which xkb_keysym_get_name translates to "comma"/"period".
+    if (utf8_buf[0] != '\0' && utf8_buf[1] == '\0' && utf8_buf[0] > 32 && utf8_buf[0] <= 126) {
+        final_key = utf8_buf;
+        // If it's a letter, lowercase it for consistency so Shift+l doesn't become Shift+L
+        if (final_key[0] >= 'A' && final_key[0] <= 'Z') {
+            final_key[0] = final_key[0] + 32;
+        }
+    } else if (buf[0]) {
+        // Otherwise format the keysym name
+        for (int i = 0; buf[i]; i++) {
+            if (buf[i] >= 'A' && buf[i] <= 'Z') {
+                buf[i] = buf[i] + 32;
             }
         }
+    }
+
+    if (final_key[0]) {
+        char full_key[128] = {0};
+        snprintf(full_key, sizeof(full_key), "%s%s", mod_prefix, final_key);
+        neru_key_ring_push(full_key);
     }
 }
 

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -131,6 +131,21 @@ static void neru_x11_overlay_clear(NeruX11Overlay *overlay) {
 	XFlush(overlay->display);
 }
 
+static void neru_x11_overlay_clear_rect(NeruX11Overlay *overlay, int x, int y, int width, int height) {
+	if (overlay == NULL || width <= 0 || height <= 0) {
+		return;
+	}
+
+	cairo_save(overlay->cr);
+	cairo_set_operator(overlay->cr, CAIRO_OPERATOR_CLEAR);
+	cairo_rectangle(overlay->cr, x, y, width, height);
+	cairo_fill(overlay->cr);
+	cairo_restore(overlay->cr);
+	cairo_surface_flush(overlay->surface);
+	XClearArea(overlay->display, overlay->window, x, y, (unsigned int)width, (unsigned int)height, False);
+	XFlush(overlay->display);
+}
+
 static void neru_x11_overlay_resize(NeruX11Overlay *overlay) {
 	int width = DisplayWidth(overlay->display, overlay->screen);
 	int height = DisplayHeight(overlay->display, overlay->screen);
@@ -260,6 +275,18 @@ func (o *x11Overlay) Hide() {
 func (o *x11Overlay) Clear() {
 	if o != nil && o.raw != nil {
 		C.neru_x11_overlay_clear(o.raw)
+	}
+}
+
+func (o *x11Overlay) ClearRect(rect image.Rectangle) {
+	if o != nil && o.raw != nil && !rect.Empty() {
+		C.neru_x11_overlay_clear_rect(
+			o.raw,
+			C.int(rect.Min.X),
+			C.int(rect.Min.Y),
+			C.int(rect.Dx()),
+			C.int(rect.Dy()),
+		)
 	}
 }
 
@@ -402,16 +429,7 @@ func (o *x11Overlay) DrawBadge(
 		fontSize = 14
 	}
 
-	paddingX := resolveAutoPadding(fontSize, style.paddingX, true)
-	paddingY := resolveAutoPadding(fontSize, style.paddingY, false)
-	width := estimateTextWidth(text, fontSize) + paddingX*paddingMultiplier
-	height := estimateTextHeight(fontSize) + paddingY*paddingMultiplier
-	rect := image.Rect(
-		posX+style.offsetX,
-		posY+style.offsetY,
-		posX+style.offsetX+width,
-		posY+style.offsetY+height,
-	)
+	rect := badgeBounds(posX, posY, text, style)
 
 	o.drawRect(rect, colors.background, colors.border, max(style.borderWidth, 1))
 	o.drawTextCentered(text, rect, style.fontFamily, fontSize, colors.text)

--- a/internal/ui/overlay/manager_linux_x11_nocgo.go
+++ b/internal/ui/overlay/manager_linux_x11_nocgo.go
@@ -14,7 +14,9 @@ import (
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 )
 
-type x11Overlay struct{}
+type x11Overlay struct {
+	sublayerKeys string
+}
 
 func newX11Overlay(logger *zap.Logger) *x11Overlay {
 	_ = logger
@@ -26,6 +28,7 @@ func (o *x11Overlay) WindowPtr() unsafe.Pointer                              { r
 func (o *x11Overlay) Show()                                                  {}
 func (o *x11Overlay) Hide()                                                  {}
 func (o *x11Overlay) Clear()                                                 {}
+func (o *x11Overlay) ClearRect(image.Rectangle)                              {}
 func (o *x11Overlay) Resize()                                                {}
 func (o *x11Overlay) Destroy()                                               {}
 func (o *x11Overlay) UpdateGridMatches(string)                               {}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds support for sticky modifier just like macOS variant, however in order to support modified clicks, we are required to switch our implementation with utilizing `evdev`, but this also mean that user has to add them self into the input group.

Note that we also have a fallback when input detection failed, it will just use the normal overlay input implementation, where normal click will work fine, but not modified clicks.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Fixes #698

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A