### PR TITLE
refactor: migrate to Go 1.26+ `errors.AsType` API

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -97,8 +97,7 @@ func Execute() {
 	executeErr := RootCmd.Execute()
 	if executeErr != nil {
 		// If the command already printed detailed output, don't repeat it.
-		var silent *silentError
-		if !errors.As(executeErr, &silent) {
+		if _, ok := errors.AsType[*silentError](executeErr); !ok {
 			fmt.Fprintln(os.Stderr, executeErr)
 		}
 

--- a/internal/core/errors/doc.go
+++ b/internal/core/errors/doc.go
@@ -1,6 +1,6 @@
 // Package derrors provides domain-specific error types and utilities.
 //
 // This package implements a structured error handling system with error codes,
-// wrapping, and context information. It follows Go 1.13+ error handling patterns
-// with errors.Is and errors.As support.
+// wrapping, and context information. It follows Go 1.26+ error handling patterns
+// with errors.Is and errors.AsType support.
 package derrors

--- a/internal/core/errors/errors.go
+++ b/internal/core/errors/errors.go
@@ -194,8 +194,7 @@ func Wrapf(err error, code Code, format string, args ...any) *Error {
 
 // IsCode checks if an error has the specified error code.
 func IsCode(err error, code Code) bool {
-	var domainErr *Error
-	if errors.As(err, &domainErr) {
+	if domainErr, ok := errors.AsType[*Error](err); ok {
 		return domainErr.code == code
 	}
 
@@ -204,8 +203,7 @@ func IsCode(err error, code Code) bool {
 
 // GetCode extracts the error code from an error, or returns CodeInternal if not a domain error.
 func GetCode(err error) Code {
-	var domainErr *Error
-	if errors.As(err, &domainErr) {
+	if domainErr, ok := errors.AsType[*Error](err); ok {
 		return domainErr.code
 	}
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR updates the `derrors` package to use Go 1.26+'s new `errors.AsType` API instead of the legacy `errors.As` pattern.

This affects the `IsCode` and `GetCode` functions in the errors package, and updates the CLI's silent error handling.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

The new `errors.AsType` API provides better type safety and compile-time checking compared to the traditional `errors.As` approach.
