### PR TITLE
chore: remove `repeat=false` from docs, not needed anymore

### DIFF
--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -245,15 +245,12 @@ bind = $mod SHIFT, S, exec, neru scroll
 ```kdl
 // ~/.config/niri/config.kdl
 binds {
-    Mod+Shift+H repeat=false { spawn-sh "neru hints"; }
-    Mod+Shift+G repeat=false { spawn-sh "neru grid"; }
-    Mod+Shift+S repeat=false { spawn-sh "neru scroll"; }
-    Mod+Shift+R repeat=false { spawn-sh "neru recursive_grid"; }
+    Mod+Shift+H { spawn-sh "neru hints"; }
+    Mod+Shift+G { spawn-sh "neru grid"; }
+    Mod+Shift+S { spawn-sh "neru scroll"; }
+    Mod+Shift+R { spawn-sh "neru recursive_grid"; }
 }
 ```
-
-`niri` binds repeat by default. Use `repeat=false` for Neru mode launchers so
-holding the activation key does not continuously relaunch the mode.
 
 ### 2. Application Exclusions
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR removes the unneeded `repeat=false` for niri config. I initially thought it is needed, but turns out it's not.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [ ] Code formatted (`just fmt`)
- [ ] Linters pass (`just lint`)
- [ ] Tests pass (`just test`)
- [ ] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
