### PR TITLE
feat(linux): add `uinput` scroll support as first detection layer

### DIFF
--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -182,6 +182,11 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 // stopIndicatorPolling stops the indicator polling goroutine and cleans up
 // both mode indicator and sticky modifiers indicator overlays.
 func (h *Handler) stopIndicatorPolling() {
+	// Restore keyboard capture if uinput scroll was active.
+	if m := overlay.Get(); m != nil && eventtap.IsUinputScrollAvailable() {
+		m.SetKeyboardCaptureEnabled(true)
+	}
+
 	// Signal stop first.
 	if h.indicatorStopCh != nil {
 		close(h.indicatorStopCh)

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
 const (
@@ -25,6 +26,11 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 	// indicator is enabled for this mode.
 	if h.config == nil || (!h.modeIndicatorEnabled(mode) && !h.stickyModifiersEnabled()) {
 		return
+	}
+	// Disable exclusive keyboard so scroll events pass through to applications
+	// when indicator overlays are shown
+	if m := overlay.Get(); m != nil {
+		m.SetKeyboardCaptureEnabled(false)
 	}
 	// Ensure the mode indicator overlay covers the correct screen before
 	// the goroutine starts drawing. Scroll and hints modes already call

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/infra/eventtap"
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
@@ -28,8 +29,8 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 		return
 	}
 	// Disable exclusive keyboard so scroll events pass through to applications
-	// when indicator overlays are shown
-	if m := overlay.Get(); m != nil {
+	// when indicator overlays are shown, but only if uinput scroll is active
+	if m := overlay.Get(); m != nil && eventtap.IsUinputScrollAvailable() {
 		m.SetKeyboardCaptureEnabled(false)
 	}
 	// Ensure the mode indicator overlay covers the correct screen before

--- a/internal/core/infra/accessibility/element_linux.go
+++ b/internal/core/infra/accessibility/element_linux.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
+	"github.com/y3owk1n/neru/internal/core/infra/eventtap"
 	"github.com/y3owk1n/neru/internal/core/infra/platform"
 )
 
@@ -404,6 +405,68 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 	}
 
 	if currentLinuxBackend() == linuxBackendWayland {
+		// Scale factor: similar to X11 backend's scaling.
+		// Each uinput event scrolls ~1 line, so we scale delta to
+		// get number of scroll events.
+		const (
+			scrollScale     = 30
+			maxScrollEvents = 50
+		)
+
+		if deltaY != 0 {
+			numEvents := abs(deltaY) / scrollScale
+			if numEvents == 0 {
+				numEvents = 1
+			}
+
+			if numEvents > maxScrollEvents {
+				numEvents = maxScrollEvents
+			}
+
+			axis := 0
+
+			value := 1
+			if deltaY < 0 {
+				value = -1
+			}
+
+			for range numEvents {
+				scrollErr := eventtap.ScrollDeviceScroll(axis, value)
+				if scrollErr != nil {
+					return scrollErr
+				}
+			}
+
+			return nil
+		}
+
+		if deltaX != 0 {
+			numEvents := abs(deltaX) / scrollScale
+			if numEvents == 0 {
+				numEvents = 1
+			}
+
+			if numEvents > maxScrollEvents {
+				numEvents = maxScrollEvents
+			}
+
+			axis := 1
+
+			value := 1
+			if deltaX < 0 {
+				value = -1
+			}
+
+			for range numEvents {
+				scrollErr := eventtap.ScrollDeviceScroll(axis, value)
+				if scrollErr != nil {
+					return scrollErr
+				}
+			}
+
+			return nil
+		}
+
 		return wlrootsScrollAtCursor(deltaX, deltaY)
 	}
 

--- a/internal/core/infra/accessibility/element_linux.go
+++ b/internal/core/infra/accessibility/element_linux.go
@@ -413,6 +413,8 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 			maxScrollEvents = 50
 		)
 
+		uinputOk := true
+
 		if deltaY != 0 {
 			numEvents := abs(deltaY) / scrollScale
 			if numEvents == 0 {
@@ -430,7 +432,7 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 				value = -1
 			}
 
-			uinputErr := func() error {
+			err := func() error {
 				for range numEvents {
 					err := eventtap.ScrollDeviceScroll(axis, value)
 					if err != nil {
@@ -440,12 +442,12 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 
 				return nil
 			}()
-			if uinputErr == nil {
-				return nil
+			if err != nil {
+				uinputOk = false
 			}
 		}
 
-		if deltaX != 0 {
+		if deltaX != 0 && uinputOk {
 			numEvents := abs(deltaX) / scrollScale
 			if numEvents == 0 {
 				numEvents = 1
@@ -462,7 +464,7 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 				value = -1
 			}
 
-			uinputErr := func() error {
+			err := func() error {
 				for range numEvents {
 					err := eventtap.ScrollDeviceScroll(axis, value)
 					if err != nil {
@@ -472,9 +474,13 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 
 				return nil
 			}()
-			if uinputErr == nil {
-				return nil
+			if err != nil {
+				uinputOk = false
 			}
+		}
+
+		if uinputOk {
+			return nil
 		}
 
 		return wlrootsScrollAtCursor(deltaX, deltaY)

--- a/internal/core/infra/accessibility/element_linux.go
+++ b/internal/core/infra/accessibility/element_linux.go
@@ -479,7 +479,7 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 			}
 		}
 
-		if yDone && xDone {
+		if (deltaY == 0 || yDone) && (deltaX == 0 || xDone) {
 			return nil
 		}
 

--- a/internal/core/infra/accessibility/element_linux.go
+++ b/internal/core/infra/accessibility/element_linux.go
@@ -487,6 +487,7 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 		if yDone {
 			remainY = 0
 		}
+
 		if xDone {
 			remainX = 0
 		}

--- a/internal/core/infra/accessibility/element_linux.go
+++ b/internal/core/infra/accessibility/element_linux.go
@@ -413,7 +413,7 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 			maxScrollEvents = 50
 		)
 
-		uinputOk := true
+		yDone, xDone := false, false
 
 		if deltaY != 0 {
 			numEvents := abs(deltaY) / scrollScale
@@ -442,12 +442,12 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 
 				return nil
 			}()
-			if err != nil {
-				uinputOk = false
+			if err == nil {
+				yDone = true
 			}
 		}
 
-		if deltaX != 0 && uinputOk {
+		if deltaX != 0 {
 			numEvents := abs(deltaX) / scrollScale
 			if numEvents == 0 {
 				numEvents = 1
@@ -474,16 +474,24 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 
 				return nil
 			}()
-			if err != nil {
-				uinputOk = false
+			if err == nil {
+				xDone = true
 			}
 		}
 
-		if uinputOk {
+		if yDone && xDone {
 			return nil
 		}
 
-		return wlrootsScrollAtCursor(deltaX, deltaY)
+		remainX, remainY := deltaX, deltaY
+		if yDone {
+			remainY = 0
+		}
+		if xDone {
+			remainX = 0
+		}
+
+		return wlrootsScrollAtCursor(remainX, remainY)
 	}
 
 	return nil

--- a/internal/core/infra/accessibility/element_linux.go
+++ b/internal/core/infra/accessibility/element_linux.go
@@ -430,14 +430,17 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 				value = -1
 			}
 
-			for range numEvents {
-				scrollErr := eventtap.ScrollDeviceScroll(axis, value)
-				if scrollErr != nil {
-					return scrollErr
+			uinputErr := func() error {
+				for range numEvents {
+					if err := eventtap.ScrollDeviceScroll(axis, value); err != nil {
+						return err
+					}
 				}
+				return nil
+			}()
+			if uinputErr == nil {
+				return nil
 			}
-
-			return nil
 		}
 
 		if deltaX != 0 {
@@ -457,14 +460,17 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 				value = -1
 			}
 
-			for range numEvents {
-				scrollErr := eventtap.ScrollDeviceScroll(axis, value)
-				if scrollErr != nil {
-					return scrollErr
+			uinputErr := func() error {
+				for range numEvents {
+					if err := eventtap.ScrollDeviceScroll(axis, value); err != nil {
+						return err
+					}
 				}
+				return nil
+			}()
+			if uinputErr == nil {
+				return nil
 			}
-
-			return nil
 		}
 
 		return wlrootsScrollAtCursor(deltaX, deltaY)

--- a/internal/core/infra/accessibility/element_linux.go
+++ b/internal/core/infra/accessibility/element_linux.go
@@ -432,10 +432,12 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 
 			uinputErr := func() error {
 				for range numEvents {
-					if err := eventtap.ScrollDeviceScroll(axis, value); err != nil {
+					err := eventtap.ScrollDeviceScroll(axis, value)
+					if err != nil {
 						return err
 					}
 				}
+
 				return nil
 			}()
 			if uinputErr == nil {
@@ -462,10 +464,12 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 
 			uinputErr := func() error {
 				for range numEvents {
-					if err := eventtap.ScrollDeviceScroll(axis, value); err != nil {
+					err := eventtap.ScrollDeviceScroll(axis, value)
+					if err != nil {
 						return err
 					}
 				}
+
 				return nil
 			}()
 			if uinputErr == nil {

--- a/internal/core/infra/accessibility/element_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/accessibility/element_linux_wayland_wlroots_cgo.go
@@ -279,12 +279,15 @@ func wlrootsScrollAtCursor(deltaX, deltaY int) error {
 		// Application convention: positive deltaY = scroll up.
 		// Negate to convert between the two conventions.
 		step := -wlrootsScrollStep
+
+		discreteStep := 1
 		if deltaY < 0 {
 			step = wlrootsScrollStep
+			discreteStep = -1
 		}
 
 		for range events {
-			err := linux.WlrootsScroll(0, step)
+			err := linux.WlrootsScroll(0, step, discreteStep)
 			if err != nil {
 				return err
 			}
@@ -299,12 +302,15 @@ func wlrootsScrollAtCursor(deltaX, deltaY int) error {
 		events := wlrootsScrollEvents(deltaX)
 
 		step := wlrootsScrollStep
+
+		discreteStep := 1
 		if deltaX < 0 {
 			step = -wlrootsScrollStep
+			discreteStep = -1
 		}
 
 		for range events {
-			err := linux.WlrootsScroll(1, step)
+			err := linux.WlrootsScroll(1, step, discreteStep)
 			if err != nil {
 				return err
 			}

--- a/internal/core/infra/eventtap/eventtap_darwin.go
+++ b/internal/core/infra/eventtap/eventtap_darwin.go
@@ -447,3 +447,8 @@ func eventTapPassthroughBridge(_ unsafe.Pointer) {
 		}
 	}
 }
+
+// IsUinputScrollAvailable returns false on Darwin.
+func IsUinputScrollAvailable() bool {
+	return false
+}

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
 type (
@@ -64,6 +66,20 @@ func (et *EventTap) Enable() {
 	et.doneCh = make(chan struct{})
 	et.enabled = true
 	et.mu.Unlock()
+
+	// Initialize uinput scroll device on Enable for Wayland backends.
+	// If successful, scroll events will go directly to applications
+	// via the virtual device, bypassing the overlay.
+	go func() {
+		_, err := getUinputScrollFd()
+		if err == nil {
+			// Scroll device created - disable exclusive keyboard
+			// so scroll events pass through to active application
+			if m := overlay.Get(); m != nil {
+				m.SetKeyboardCaptureEnabled(false)
+			}
+		}
+	}()
 
 	go et.run()
 }

--- a/internal/core/infra/eventtap/eventtap_linux_nocgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_nocgo.go
@@ -19,3 +19,7 @@ func postLinuxModifierEvent(_ string, _ bool) bool {
 func getUinputScrollFd() (int, error) {
 	return 0, errors.New("uinput scroll unavailable (no CGO)")
 }
+
+func ScrollDeviceScroll(_, _ int) error {
+	return errors.New("uinput scroll unavailable (no CGO)")
+}

--- a/internal/core/infra/eventtap/eventtap_linux_nocgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_nocgo.go
@@ -2,6 +2,8 @@
 
 package eventtap
 
+import "errors"
+
 func (et *EventTap) runWayland() {
 	close(et.doneCh)
 }
@@ -12,4 +14,8 @@ func (et *EventTap) runX11() {
 
 func postLinuxModifierEvent(_ string, _ bool) bool {
 	return false
+}
+
+func getUinputScrollFd() (int, error) {
+	return 0, errors.New("uinput scroll unavailable (no CGO)")
 }

--- a/internal/core/infra/eventtap/eventtap_linux_nocgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_nocgo.go
@@ -23,3 +23,8 @@ func getUinputScrollFd() (int, error) {
 func ScrollDeviceScroll(_, _ int) error {
 	return errors.New("uinput scroll unavailable (no CGO)")
 }
+
+// IsUinputScrollAvailable returns false when CGO is disabled.
+func IsUinputScrollAvailable() bool {
+	return false
+}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -76,8 +76,14 @@ static int neru_uinput_create_scroll(int *out_fd) {
 	usetup.id.vendor = 0x1234;
 	usetup.id.product = 0x5678;
 	strcpy(usetup.name, "neru-scroll");
-	ioctl(fd, UI_DEV_SETUP, &usetup);
-	ioctl(fd, UI_DEV_CREATE);
+	if (ioctl(fd, UI_DEV_SETUP, &usetup) < 0) {
+		close(fd);
+		return 0;
+	}
+	if (ioctl(fd, UI_DEV_CREATE) < 0) {
+		close(fd);
+		return 0;
+	}
 
 	*out_fd = fd;
 	return 1;
@@ -450,9 +456,9 @@ func (state *waylandEvdevKeyState) trackKey(code uint16, isDown bool) {
 }
 
 var (
-	uinputScrollFd     int
-	uinputScrollInited bool
-	errUinputScroll    error
+	uinputScrollOnce sync.Once
+	uinputScrollFd   int
+	errUinputScroll  error
 )
 
 func initUinputScroll() error {
@@ -461,21 +467,14 @@ func initUinputScroll() error {
 		return fmt.Errorf("%w", errUinputScrollUnavailable)
 	}
 	uinputScrollFd = int(fd)
-	uinputScrollInited = true
 
 	return nil
 }
 
 func getUinputScrollFd() (int, error) {
-	if uinputScrollInited {
-		if errUinputScroll != nil {
-			return 0, errUinputScroll
-		}
-
-		return uinputScrollFd, nil
-	}
-	uinputScrollInited = true
-	errUinputScroll = initUinputScroll()
+	uinputScrollOnce.Do(func() {
+		errUinputScroll = initUinputScroll()
+	})
 	if errUinputScroll != nil {
 		return 0, errUinputScroll
 	}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -503,8 +503,9 @@ func getUinputScrollFd() (int, error) {
 	return uinputScrollFd, nil
 }
 
+// IsUinputScrollAvailable returns true if uinput scroll is available.
 func IsUinputScrollAvailable() bool {
-	getUinputScrollFd()
+	_, _ = getUinputScrollFd() //nolint:errcheck // we only care about errUinputScroll
 
 	return errUinputScroll == nil
 }

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -3,8 +3,13 @@
 package eventtap
 
 /*
+#cgo linux pkg-config: wayland-client
+#cgo linux CFLAGS: -DWLR_CPLUSPLUS
+#cgo !darwin LDFLAGS: -lrt
 #include <errno.h>
+#include <fcntl.h>
 #include <linux/input.h>
+#include <linux/uinput.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
@@ -47,6 +52,54 @@ static int neru_evdev_is_keyboard(int fd) {
 static ssize_t neru_evdev_read_event(int fd, struct input_event *event) {
 	return read(fd, event, sizeof(struct input_event));
 }
+
+static int neru_uinput_create_scroll(int *out_fd) {
+	int fd = open("/dev/uinput", O_RDWR);
+	if (fd < 0) {
+		fd = open("/dev/input/uinput", O_RDWR);
+	}
+	if (fd < 0) {
+		return 0;
+	}
+
+	struct input_event ev;
+	memset(&ev, 0, sizeof(ev));
+	ioctl(fd, UI_SET_EVBIT, EV_REL);
+	ioctl(fd, UI_SET_RELBIT, REL_WHEEL);
+	ioctl(fd, UI_SET_RELBIT, REL_HWHEEL);
+	ioctl(fd, UI_SET_RELBIT, REL_WHEEL_HI_RES);
+	ioctl(fd, UI_SET_RELBIT, REL_HWHEEL_HI_RES);
+
+	struct uinput_setup usetup;
+	memset(&usetup, 0, sizeof(usetup));
+	usetup.id.bustype = BUS_USB;
+	usetup.id.vendor = 0x1234;
+	usetup.id.product = 0x5678;
+	strcpy(usetup.name, "neru-scroll");
+	ioctl(fd, UI_DEV_SETUP, &usetup);
+	ioctl(fd, UI_DEV_CREATE);
+
+	*out_fd = fd;
+	return 1;
+}
+
+static int neru_uinput_scroll(int fd, int axis, int value) {
+	struct input_event ev;
+	memset(&ev, 0, sizeof(ev));
+
+	ev.type = EV_REL;
+	ev.code = (axis == 0) ? REL_WHEEL_HI_RES : REL_HWHEEL_HI_RES;
+	ev.value = value * 120;
+	ssize_t w1 = write(fd, &ev, sizeof(ev));
+
+	memset(&ev, 0, sizeof(ev));
+	ev.type = EV_SYN;
+	ev.code = SYN_REPORT;
+	ev.value = 0;
+	ssize_t w2 = write(fd, &ev, sizeof(ev));
+
+	return (w1 == sizeof(ev) && w2 == sizeof(ev)) ? 1 : 0;
+}
 */
 import "C"
 
@@ -71,6 +124,8 @@ const (
 var (
 	errWaylandEvdevUnavailable = errors.New("wayland evdev capture unavailable")
 	errWaylandEvdevGrabFailed  = errors.New("wayland evdev grab failed")
+	errUinputScrollUnavailable = errors.New("uinput scroll device unavailable")
+	errUinputScrollSend        = errors.New("failed to send uinput scroll event")
 )
 
 type waylandEvdevEvent struct {
@@ -392,4 +447,51 @@ func (state *waylandEvdevKeyState) trackKey(code uint16, isDown bool) {
 	}
 
 	delete(state.pressed, code)
+}
+
+var (
+	uinputScrollFd     int
+	uinputScrollInited bool
+	errUinputScroll    error
+)
+
+func initUinputScroll() error {
+	var fd C.int
+	if C.neru_uinput_create_scroll(&fd) == 0 {
+		return fmt.Errorf("%w", errUinputScrollUnavailable)
+	}
+	uinputScrollFd = int(fd)
+	uinputScrollInited = true
+
+	return nil
+}
+
+func getUinputScrollFd() (int, error) {
+	if uinputScrollInited {
+		if errUinputScroll != nil {
+			return 0, errUinputScroll
+		}
+
+		return uinputScrollFd, nil
+	}
+	uinputScrollInited = true
+	errUinputScroll = initUinputScroll()
+	if errUinputScroll != nil {
+		return 0, errUinputScroll
+	}
+
+	return uinputScrollFd, nil
+}
+
+// ScrollDeviceScroll sends a scroll event via the uinput virtual device.
+func ScrollDeviceScroll(axis, value int) error {
+	fd, err := getUinputScrollFd()
+	if err != nil {
+		return err
+	}
+	if C.neru_uinput_scroll(C.int(fd), C.int(axis), C.int(value)) == 0 {
+		return fmt.Errorf("%w", errUinputScrollSend)
+	}
+
+	return nil
 }

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -3,9 +3,6 @@
 package eventtap
 
 /*
-#cgo linux pkg-config: wayland-client
-#cgo linux CFLAGS: -DWLR_CPLUSPLUS
-#cgo !darwin LDFLAGS: -lrt
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/input.h>

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -59,8 +59,6 @@ static int neru_uinput_create_scroll(int *out_fd) {
 		return 0;
 	}
 
-	struct input_event ev;
-	memset(&ev, 0, sizeof(ev));
 	if (ioctl(fd, UI_SET_EVBIT, EV_REL) < 0) {
 		close(fd);
 		return 0;

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -99,12 +99,18 @@ static int neru_uinput_scroll(int fd, int axis, int value) {
 	ssize_t w1 = write(fd, &ev, sizeof(ev));
 
 	memset(&ev, 0, sizeof(ev));
+	ev.type = EV_REL;
+	ev.code = (axis == 0) ? REL_WHEEL : REL_HWHEEL;
+	ev.value = value;
+	ssize_t w2 = write(fd, &ev, sizeof(ev));
+
+	memset(&ev, 0, sizeof(ev));
 	ev.type = EV_SYN;
 	ev.code = SYN_REPORT;
 	ev.value = 0;
-	ssize_t w2 = write(fd, &ev, sizeof(ev));
+	ssize_t w3 = write(fd, &ev, sizeof(ev));
 
-	return (w1 == sizeof(ev) && w2 == sizeof(ev)) ? 1 : 0;
+	return (w1 == sizeof(ev) && w2 == sizeof(ev) && w3 == sizeof(ev)) ? 1 : 0;
 }
 */
 import "C"

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -64,11 +64,26 @@ static int neru_uinput_create_scroll(int *out_fd) {
 
 	struct input_event ev;
 	memset(&ev, 0, sizeof(ev));
-	ioctl(fd, UI_SET_EVBIT, EV_REL);
-	ioctl(fd, UI_SET_RELBIT, REL_WHEEL);
-	ioctl(fd, UI_SET_RELBIT, REL_HWHEEL);
-	ioctl(fd, UI_SET_RELBIT, REL_WHEEL_HI_RES);
-	ioctl(fd, UI_SET_RELBIT, REL_HWHEEL_HI_RES);
+	if (ioctl(fd, UI_SET_EVBIT, EV_REL) < 0) {
+		close(fd);
+		return 0;
+	}
+	if (ioctl(fd, UI_SET_RELBIT, REL_WHEEL) < 0) {
+		close(fd);
+		return 0;
+	}
+	if (ioctl(fd, UI_SET_RELBIT, REL_HWHEEL) < 0) {
+		close(fd);
+		return 0;
+	}
+	if (ioctl(fd, UI_SET_RELBIT, REL_WHEEL_HI_RES) < 0) {
+		close(fd);
+		return 0;
+	}
+	if (ioctl(fd, UI_SET_RELBIT, REL_HWHEEL_HI_RES) < 0) {
+		close(fd);
+		return 0;
+	}
 
 	struct uinput_setup usetup;
 	memset(&usetup, 0, sizeof(usetup));

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -503,6 +503,12 @@ func getUinputScrollFd() (int, error) {
 	return uinputScrollFd, nil
 }
 
+func IsUinputScrollAvailable() bool {
+	getUinputScrollFd()
+
+	return errUinputScroll == nil
+}
+
 // ScrollDeviceScroll sends a scroll event via the uinput virtual device.
 func ScrollDeviceScroll(axis, value int) error {
 	fd, err := getUinputScrollFd()

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -505,7 +505,7 @@ func getUinputScrollFd() (int, error) {
 
 // IsUinputScrollAvailable returns true if uinput scroll is available.
 func IsUinputScrollAvailable() bool {
-	_, _ = getUinputScrollFd() //nolint:errcheck // we only care about errUinputScroll
+	_, _ = getUinputScrollFd()
 
 	return errUinputScroll == nil
 }

--- a/internal/core/infra/eventtap/eventtap_windows.go
+++ b/internal/core/infra/eventtap/eventtap_windows.go
@@ -65,3 +65,8 @@ func (et *EventTap) EnableWithContext(_ context.Context) error { return nil }
 
 // DisableWithContext disables the event tap with context (Windows stub).
 func (et *EventTap) DisableWithContext(_ context.Context) error { return nil }
+
+// IsUinputScrollAvailable returns false on Windows.
+func IsUinputScrollAvailable() bool {
+	return false
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland.go
@@ -36,10 +36,11 @@ func WlrootsButtonRelease(button int) error {
 
 // WlrootsScroll sends a scroll event. axis: 0=vertical, 1=horizontal.
 // delta is in logical pixels (positive = down/right, negative = up/left).
+// discrete is the discrete step count (e.g., +/-1 per logical scroll click).
 // Each call emits a single Wayland axis event; callers should loop for
 // larger scroll distances.
-func WlrootsScroll(axis, delta int) error {
-	return wlrootsScroll(axis, delta)
+func WlrootsScroll(axis, delta, discrete int) error {
+	return wlrootsScroll(axis, delta, discrete)
 }
 
 // WlrootsModifierEvent presses or releases a virtual keyboard modifier.

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -588,11 +588,12 @@ static int neru_wlr_scroll(NeruWlrootsClient *c, int axis, int delta, int discre
 
 	// axis: 0 = vertical, 1 = horizontal
 	zwlr_virtual_pointer_v1_axis_source(c->vptr, 0); // WL_POINTER_AXIS_SOURCE_WHEEL
-	zwlr_virtual_pointer_v1_axis(c->vptr, 0, (uint32_t)axis, wl_fixed_from_int(delta));
-	// axis_discrete helps Hyprland and other compositors properly handle scroll events.
-	// discrete should be +/-1 per logical scroll step.
+	// Send axis_discrete instead of axis when discrete is available, as per Wayland spec.
+	// Sending both may cause compositors to accumulate both values (double-scroll).
 	if (discrete != 0) {
 		zwlr_virtual_pointer_v1_axis_discrete(c->vptr, 0, (uint32_t)axis, wl_fixed_from_int(delta), discrete);
+	} else {
+		zwlr_virtual_pointer_v1_axis(c->vptr, 0, (uint32_t)axis, wl_fixed_from_int(delta));
 	}
 	zwlr_virtual_pointer_v1_frame(c->vptr);
 	wl_display_flush(c->display);

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -583,14 +583,17 @@ static int neru_wlr_click(NeruWlrootsClient *c, int button) {
 	return 1;
 }
 
-static int neru_wlr_scroll(NeruWlrootsClient *c, int axis, int delta) {
+static int neru_wlr_scroll(NeruWlrootsClient *c, int axis, int delta, int discrete) {
 	if (!c || !c->vptr) return 0;
 
 	// axis: 0 = vertical, 1 = horizontal
 	zwlr_virtual_pointer_v1_axis_source(c->vptr, 0); // WL_POINTER_AXIS_SOURCE_WHEEL
-	zwlr_virtual_pointer_v1_axis(c->vptr, 0,
-		(uint32_t)axis,
-		wl_fixed_from_int(delta));
+	zwlr_virtual_pointer_v1_axis(c->vptr, 0, (uint32_t)axis, wl_fixed_from_int(delta));
+	// axis_discrete helps Hyprland and other compositors properly handle scroll events.
+	// discrete should be +/-1 per logical scroll step.
+	if (discrete != 0) {
+		zwlr_virtual_pointer_v1_axis_discrete(c->vptr, 0, (uint32_t)axis, wl_fixed_from_int(delta), discrete);
+	}
 	zwlr_virtual_pointer_v1_frame(c->vptr);
 	wl_display_flush(c->display);
 	return 1;
@@ -1001,7 +1004,10 @@ func wlrootsButtonRelease(button int) error {
 }
 
 // wlrootsScroll sends a scroll event on the virtual pointer.
-func wlrootsScroll(axis, delta int) error {
+// axis: 0 = vertical, 1 = horizontal.
+// delta: pixel delta for the axis event.
+// discrete: discrete step count (e.g., +/-1 per logical scroll click).
+func wlrootsScroll(axis, delta, discrete int) error {
 	err := ensureWlrootsState()
 	if err != nil {
 		return err
@@ -1011,7 +1017,8 @@ func wlrootsScroll(axis, delta int) error {
 	client := globalWlrootsState.client
 	defer globalWlrootsState.mu.Unlock()
 
-	if C.neru_wlr_scroll(client, C.int(axis), C.int(delta)) == 0 { //nolint:nlreturn
+	res := C.neru_wlr_scroll(client, C.int(axis), C.int(delta), C.int(discrete)) //nolint:nlreturn
+	if res == 0 {
 		return derrors.New(
 			derrors.CodeActionFailed,
 			"failed to perform wlroots scroll event",

--- a/internal/ui/overlay/manager_darwin.go
+++ b/internal/ui/overlay/manager_darwin.go
@@ -169,6 +169,9 @@ func (m *Manager) ResizeToActiveScreen() {
 	}
 }
 
+// SetKeyboardCaptureEnabled is a no-op on Darwin.
+func (m *Manager) SetKeyboardCaptureEnabled(_ bool) {}
+
 // SwitchTo transitions the overlay to the specified mode and notifies subscribers.
 func (m *Manager) SwitchTo(next Mode) {
 	m.mu.Lock()

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -366,6 +366,8 @@ static NeruWaylandOverlay* neru_wayland_overlay_new(void) {
     NeruWaylandOverlay *overlay = calloc(1, sizeof(NeruWaylandOverlay));
     if (!overlay) return NULL;
 
+    // EXCLUSIVE by default for keyboard capture fallback
+    // SetKeyboardCaptureEnabled can change it to NONE when not needed
     overlay->keyboard_interactivity_set =
         ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
 

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -157,3 +157,6 @@ func (m *Manager) SetHideUnmatched(_ bool) {}
 
 // SetSharingType sets the sharing type (Windows stub).
 func (m *Manager) SetSharingType(_ bool) {}
+
+// SetKeyboardCaptureEnabled is a no-op on Windows.
+func (m *Manager) SetKeyboardCaptureEnabled(_ bool) {}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds uinput based scrolling support for Wayland compositors. Previously we are solely relying on overlay keyboard interactivity plus empty region input, which works for niri and sway, but not hyprland.

With uinput based scrolling implementation, we can finally support scrolling in hyprland properly. The implementation is very similar to how we made mouse clicking support for hyprland as well.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to #696

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/a07ff3d4-6d5d-418a-9127-969dfa546de5

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
