### PR TITLE
fix: use proper cert for adhoc code signing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,3 +93,6 @@ jobs:
             macos_short_version: ${{ needs.prepare-nightly-release.outputs.macos_short_version }}
         secrets:
             upload_token: ${{ github.token }}
+            NERU_P12_BASE64: ${{ secrets.NERU_P12_BASE64 }}
+            NERU_P12_PASSWORD: ${{ secrets.NERU_P12_PASSWORD }}
+            NERU_CERT_NAME: ${{ secrets.NERU_CERT_NAME }}

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -68,7 +68,7 @@ jobs:
             -S apple-tool:,apple: \
             -s \
             -k "$KEYCHAIN_PASSWORD" \
-            "$KEYCHAIN" >/dev/null 2>&1
+            "$KEYCHAIN"
 
           security default-keychain -s "$KEYCHAIN"
           security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)
@@ -176,7 +176,7 @@ jobs:
             -S apple-tool:,apple: \
             -s \
             -k "$KEYCHAIN_PASSWORD" \
-            "$KEYCHAIN" >/dev/null 2>&1
+            "$KEYCHAIN"
 
           security default-keychain -s "$KEYCHAIN"
           security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -48,6 +48,7 @@ jobs:
           CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
         run: |
           CERT_PATH=$(mktemp /tmp/cert.neru-cert.p12)
+          echo "CERT_PATH=$CERT_PATH" >> $GITHUB_ENV
           echo "$P12_BASE64" | base64 --decode > "$CERT_PATH"
 
           KEYCHAIN="build.keychain"
@@ -74,8 +75,6 @@ jobs:
 
           security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$CERT_NAME" \
             || { echo "ERROR: Signing identity '$CERT_NAME' not found in keychain"; exit 1; }
-
-          echo "CERT_PATH=$CERT_PATH" >> $GITHUB_ENV
 
       - name: Build neru darwin arm64 artifact
         run: just release-ci-darwin arm64 ${{ inputs.version_override }}
@@ -157,6 +156,7 @@ jobs:
           CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
         run: |
           CERT_PATH=$(mktemp /tmp/cert.neru-cert.p12)
+          echo "CERT_PATH=$CERT_PATH" >> $GITHUB_ENV
           echo "$P12_BASE64" | base64 --decode > "$CERT_PATH"
 
           KEYCHAIN="build.keychain"
@@ -183,8 +183,6 @@ jobs:
 
           security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$CERT_NAME" \
             || { echo "ERROR: Signing identity '$CERT_NAME' not found in keychain"; exit 1; }
-
-          echo "CERT_PATH=$CERT_PATH" >> $GITHUB_ENV
 
       - name: Build neru darwin amd64 artifact
         run: just release-ci-darwin amd64 ${{ inputs.version_override }}

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -1,327 +1,337 @@
 on:
-    workflow_call:
-        inputs:
-            release_tag:
-                required: true
-                type: string
-            version_override:
-                required: true
-                type: string
-            macos_bundle_version:
-                required: true
-                type: string
-            macos_short_version:
-                required: true
-                type: string
-        secrets:
-            upload_token:
-                required: false
+  workflow_call:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+      version_override:
+        required: true
+        type: string
+      macos_bundle_version:
+        required: true
+        type: string
+      macos_short_version:
+        required: true
+        type: string
+    secrets:
+      upload_token:
+        required: false
+      NERU_P12_64_BASE64:
+        required: false
+      NERU_P12_PASSWORD:
+        required: false
+      NERU_CERT_NAME:
+        required: false
 
 name: publish-artifacts
 
 jobs:
-    build-darwin-arm64-artifacts:
-        runs-on: macos-latest
-        permissions:
-            contents: write
-        steps:
-            - uses: actions/checkout@v6
+  build-darwin-arm64-artifacts:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
 
-            - uses: actions/setup-go@v6
-              with:
-                  go-version: "1.26.1"
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.1"
 
-            - uses: extractions/setup-just@v4
-              with:
-                  just-version: "1.46.0"
+      - uses: extractions/setup-just@v4
+        with:
+          just-version: "1.46.0"
 
-            - name: Import signing certificate
-              env:
-                  P12_BASE64: ${{ secrets.NERU_P12_BASE64 }}
-                  P12_PASSWORD: ${{ secrets.NERU_P12_PASSWORD }}
-                  CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
-              run: |
-                  echo "$P12_BASE64" | base64 --decode > cert.p12
+      - name: Import signing certificate
+        env:
+          P12_BASE64: ${{ secrets.NERU_P12_BASE64 }}
+          P12_PASSWORD: ${{ secrets.NERU_P12_PASSWORD }}
+          CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
+        run: |
+          echo "$P12_BASE64" | base64 --decode > cert.p12
 
-                  KEYCHAIN="build.keychain"
-                  KEYCHAIN_PASSWORD="temp123"
+          KEYCHAIN="build.keychain"
+          KEYCHAIN_PASSWORD="temp123"
 
-                  security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-                  security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
 
-                  security import cert.p12 \
-                    -k "$KEYCHAIN" \
-                    -P "$P12_PASSWORD" \
-                    -A \
-                    -T /usr/bin/codesign
+          security import cert.p12 \
+            -k "$KEYCHAIN" \
+            -P "$P12_PASSWORD" \
+            -A \
+            -T /usr/bin/codesign
 
-                  security set-key-partition-list \
-                    -S apple-tool:,apple: \
-                    -s \
-                    -k "$KEYCHAIN_PASSWORD" \
-                    "$KEYCHAIN" >/dev/null 2>&1
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN" >/dev/null 2>&1
 
-                  security list-keychains -d user -s "$KEYCHAIN"
-                  security find-identity -v -p codesigning "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN"
+          security find-identity -v -p codesigning "$KEYCHAIN"
 
-            - name: Build neru darwin arm64 artifact
-              run: just release-ci-darwin arm64 ${{ inputs.version_override }}
+      - name: Build neru darwin arm64 artifact
+        run: just release-ci-darwin arm64 ${{ inputs.version_override }}
 
-            - name: Bundle neru-darwin-arm64
-              run: |
-                  mkdir -p build/arm64/Neru.app/Contents/{MacOS,Resources}
-                  cp bin/neru-darwin-arm64 build/arm64/Neru.app/Contents/MacOS/neru
-                  chmod +x build/arm64/Neru.app/Contents/MacOS/neru
-                  cp resources/icon.icns build/arm64/Neru.app/Contents/Resources/icon.icns
+      - name: Bundle neru-darwin-arm64
+        env:
+          CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
+        run: |
+          mkdir -p build/arm64/Neru.app/Contents/{MacOS,Resources}
+          cp bin/neru-darwin-arm64 build/arm64/Neru.app/Contents/MacOS/neru
+          chmod +x build/arm64/Neru.app/Contents/MacOS/neru
+          cp resources/icon.icns build/arm64/Neru.app/Contents/Resources/icon.icns
 
-                  sed \
-                    -e "s/BUNDLE_VERSION/${{ inputs.macos_bundle_version }}/g" \
-                    -e "s/SHORT_VERSION/${{ inputs.macos_short_version }}/g" \
-                    -e "s/BUILD_ID/${{ inputs.version_override }}/g" \
-                    resources/Info.plist.template > build/arm64/Neru.app/Contents/Info.plist
+          sed \
+            -e "s/BUNDLE_VERSION/${{ inputs.macos_bundle_version }}/g" \
+            -e "s/SHORT_VERSION/${{ inputs.macos_short_version }}/g" \
+            -e "s/BUILD_ID/${{ inputs.version_override }}/g" \
+            resources/Info.plist.template > build/arm64/Neru.app/Contents/Info.plist
 
-                  codesign --force --deep \
-                    --keychain build.keychain \
-                    --sign "${{ secrets.NERU_CERT_NAME }}" \
-                    --timestamp=none \
-                    build/arm64/Neru.app
+          codesign --force --deep \
+            --keychain build.keychain \
+            --sign "$CERT_NAME" \
+            --timestamp=none \
+            build/arm64/Neru.app
 
-                  mkdir -p build/arm64/bin
-                  cp bin/neru-darwin-arm64 build/arm64/bin/neru
-                  chmod +x build/arm64/bin/neru
+          mkdir -p build/arm64/bin
+          cp bin/neru-darwin-arm64 build/arm64/bin/neru
+          chmod +x build/arm64/bin/neru
 
-                  cd build/arm64
-                  zip -r ../../neru-darwin-arm64.zip bin Neru.app
-                  cd ../..
+          cd build/arm64
+          zip -r ../../neru-darwin-arm64.zip bin Neru.app
+          cd ../..
 
-            - name: Generate darwin arm64 checksum
-              run: |
-                  shasum -a 256 neru-darwin-arm64.zip | awk '{print $1}' > neru-darwin-arm64.zip.sha256
-                  ls -l neru-darwin-arm64.zip neru-darwin-arm64.zip.sha256
+      - name: Generate darwin arm64 checksum
+        run: |
+          shasum -a 256 neru-darwin-arm64.zip | awk '{print $1}' > neru-darwin-arm64.zip.sha256
+          ls -l neru-darwin-arm64.zip neru-darwin-arm64.zip.sha256
 
-            - name: Upload darwin arm64 release artifacts
-              env:
-                  GH_TOKEN: ${{ secrets.upload_token || github.token }}
-              run: |
-                  gh release upload "${{ inputs.release_tag }}" neru-darwin-arm64.zip neru-darwin-arm64.zip.sha256 --clobber
+      - name: Upload darwin arm64 release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.upload_token || github.token }}
+        run: |
+          gh release upload "${{ inputs.release_tag }}" neru-darwin-arm64.zip neru-darwin-arm64.zip.sha256 --clobber
 
-            - name: Cleanup signing keychain
-              if: always()
-              run: |
-                  KEYCHAIN="build-$GITHUB_JOB.keychain"
+      - name: Cleanup signing keychain
+        if: always()
+        run: |
+          KEYCHAIN="build.keychain"
 
-                  echo "Restoring login keychain..."
-                  security list-keychains -d user -s ~/Library/Keychains/login.keychain-db || true
+          echo "Restoring login keychain..."
+          security list-keychains -d user -s ~/Library/Keychains/login.keychain-db || true
 
-                  echo "Deleting temp keychain..."
-                  security delete-keychain "$KEYCHAIN" || true
+          echo "Deleting temp keychain..."
+          security delete-keychain "$KEYCHAIN" || true
 
-                  rm -f cert.p12 || true
+          rm -f cert.p12 || true
 
-                  echo "Cleanup done"
+          echo "Cleanup done"
 
-    build-darwin-amd64-artifacts:
-        runs-on: macos-15-intel
-        permissions:
-            contents: write
-        steps:
-            - uses: actions/checkout@v6
+  build-darwin-amd64-artifacts:
+    runs-on: macos-15-intel
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
 
-            - uses: actions/setup-go@v6
-              with:
-                  go-version: "1.26.1"
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.1"
 
-            - uses: extractions/setup-just@v4
-              with:
-                  just-version: "1.46.0"
+      - uses: extractions/setup-just@v4
+        with:
+          just-version: "1.46.0"
 
-            - name: Import signing certificate
-              env:
-                  P12_BASE64: ${{ secrets.NERU_P12_BASE64 }}
-                  P12_PASSWORD: ${{ secrets.NERU_P12_PASSWORD }}
-                  CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
-              run: |
-                  echo "$P12_BASE64" | base64 --decode > cert.p12
+      - name: Import signing certificate
+        env:
+          P12_BASE64: ${{ secrets.NERU_P12_BASE64 }}
+          P12_PASSWORD: ${{ secrets.NERU_P12_PASSWORD }}
+          CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
+        run: |
+          echo "$P12_BASE64" | base64 --decode > cert.p12
 
-                  KEYCHAIN="build.keychain"
-                  KEYCHAIN_PASSWORD="temp123"
+          KEYCHAIN="build.keychain"
+          KEYCHAIN_PASSWORD="temp123"
 
-                  security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-                  security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
 
-                  security import cert.p12 \
-                    -k "$KEYCHAIN" \
-                    -P "$P12_PASSWORD" \
-                    -A \
-                    -T /usr/bin/codesign
+          security import cert.p12 \
+            -k "$KEYCHAIN" \
+            -P "$P12_PASSWORD" \
+            -A \
+            -T /usr/bin/codesign
 
-                  security set-key-partition-list \
-                    -S apple-tool:,apple: \
-                    -s \
-                    -k "$KEYCHAIN_PASSWORD" \
-                    "$KEYCHAIN" >/dev/null 2>&1
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN" >/dev/null 2>&1
 
-                  security list-keychains -d user -s "$KEYCHAIN"
-                  security find-identity -v -p codesigning "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN"
+          security find-identity -v -p codesigning "$KEYCHAIN"
 
-            - name: Build neru darwin amd64 artifact
-              run: just release-ci-darwin amd64 ${{ inputs.version_override }}
+      - name: Build neru darwin amd64 artifact
+        run: just release-ci-darwin amd64 ${{ inputs.version_override }}
 
-            - name: Bundle neru-darwin-amd64
-              run: |
-                  mkdir -p build/amd64/Neru.app/Contents/{MacOS,Resources}
-                  cp bin/neru-darwin-amd64 build/amd64/Neru.app/Contents/MacOS/neru
-                  chmod +x build/amd64/Neru.app/Contents/MacOS/neru
-                  cp resources/icon.icns build/amd64/Neru.app/Contents/Resources/icon.icns
+      - name: Bundle neru-darwin-amd64
+        env:
+          CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
+        run: |
+          mkdir -p build/amd64/Neru.app/Contents/{MacOS,Resources}
+          cp bin/neru-darwin-amd64 build/amd64/Neru.app/Contents/MacOS/neru
+          chmod +x build/amd64/Neru.app/Contents/MacOS/neru
+          cp resources/icon.icns build/amd64/Neru.app/Contents/Resources/icon.icns
 
-                  sed \
-                    -e "s/BUNDLE_VERSION/${{ inputs.macos_bundle_version }}/g" \
-                    -e "s/SHORT_VERSION/${{ inputs.macos_short_version }}/g" \
-                    -e "s/BUILD_ID/${{ inputs.version_override }}/g" \
-                    resources/Info.plist.template > build/amd64/Neru.app/Contents/Info.plist
+          sed \
+            -e "s/BUNDLE_VERSION/${{ inputs.macos_bundle_version }}/g" \
+            -e "s/SHORT_VERSION/${{ inputs.macos_short_version }}/g" \
+            -e "s/BUILD_ID/${{ inputs.version_override }}/g" \
+            resources/Info.plist.template > build/amd64/Neru.app/Contents/Info.plist
 
-                  codesign --force --deep \
-                    --keychain build.keychain \
-                    --sign "${{ secrets.NERU_CERT_NAME }}" \
-                    --timestamp=none \
-                    build/amd64/Neru.app
+          codesign --force --deep \
+            --keychain build.keychain \
+            --sign "$CERT_NAME" \
+            --timestamp=none \
+            build/amd64/Neru.app
 
-                  mkdir -p build/amd64/bin
-                  cp bin/neru-darwin-amd64 build/amd64/bin/neru
-                  chmod +x build/amd64/bin/neru
+          mkdir -p build/amd64/bin
+          cp bin/neru-darwin-amd64 build/amd64/bin/neru
+          chmod +x build/amd64/bin/neru
 
-                  cd build/amd64
-                  zip -r ../../neru-darwin-amd64.zip bin Neru.app
-                  cd ../..
+          cd build/amd64
+          zip -r ../../neru-darwin-amd64.zip bin Neru.app
+          cd ../..
 
-            - name: Generate darwin amd64 checksum
-              run: |
-                  shasum -a 256 neru-darwin-amd64.zip | awk '{print $1}' > neru-darwin-amd64.zip.sha256
-                  ls -l neru-darwin-amd64.zip neru-darwin-amd64.zip.sha256
+      - name: Generate darwin amd64 checksum
+        run: |
+          shasum -a 256 neru-darwin-amd64.zip | awk '{print $1}' > neru-darwin-amd64.zip.sha256
+          ls -l neru-darwin-amd64.zip neru-darwin-amd64.zip.sha256
 
-            - name: Upload darwin amd64 release artifacts
-              env:
-                  GH_TOKEN: ${{ secrets.upload_token || github.token }}
-              run: |
-                  gh release upload "${{ inputs.release_tag }}" neru-darwin-amd64.zip neru-darwin-amd64.zip.sha256 --clobber
+      - name: Upload darwin amd64 release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.upload_token || github.token }}
+        run: |
+          gh release upload "${{ inputs.release_tag }}" neru-darwin-amd64.zip neru-darwin-amd64.zip.sha256 --clobber
 
-            - name: Cleanup signing keychain
-              if: always()
-              run: |
-                  KEYCHAIN="build-$GITHUB_JOB.keychain"
+      - name: Cleanup signing keychain
+        if: always()
+        run: |
+          KEYCHAIN="build.keychain"
 
-                  echo "Restoring login keychain..."
-                  security list-keychains -d user -s ~/Library/Keychains/login.keychain-db || true
+          echo "Restoring login keychain..."
+          security list-keychains -d user -s ~/Library/Keychains/login.keychain-db || true
 
-                  echo "Deleting temp keychain..."
-                  security delete-keychain "$KEYCHAIN" || true
+          echo "Deleting temp keychain..."
+          security delete-keychain "$KEYCHAIN" || true
 
-                  rm -f cert.p12 || true
+          rm -f cert.p12 || true
 
-                  echo "Cleanup done"
+          echo "Cleanup done"
 
-    build-linux-amd64-artifacts:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: write
-        steps:
-            - uses: actions/checkout@v6
+  build-linux-amd64-artifacts:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
 
-            - name: Install Linux build dependencies
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install -y \
-                    libcairo2-dev \
-                    libwayland-dev \
-                    libx11-dev \
-                    libxtst-dev \
-                    libxrandr-dev \
-                    libxinerama-dev \
-                    libxfixes-dev \
-                    libxkbcommon-dev \
-                    wayland-protocols
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcairo2-dev \
+            libwayland-dev \
+            libx11-dev \
+            libxtst-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxfixes-dev \
+            libxkbcommon-dev \
+            wayland-protocols
 
-            - uses: actions/setup-go@v6
-              with:
-                  go-version: "1.26.1"
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.1"
 
-            - uses: extractions/setup-just@v4
-              with:
-                  just-version: "1.46.0"
+      - uses: extractions/setup-just@v4
+        with:
+          just-version: "1.46.0"
 
-            - name: Build neru linux amd64 artifact
-              run: just release-ci-linux amd64 ${{ inputs.version_override }}
+      - name: Build neru linux amd64 artifact
+        run: just release-ci-linux amd64 ${{ inputs.version_override }}
 
-            - name: Bundle neru-linux-amd64
-              run: |
-                  mkdir -p build/linux-amd64/bin
-                  cp bin/neru-linux-amd64 build/linux-amd64/bin/neru
-                  chmod +x build/linux-amd64/bin/neru
+      - name: Bundle neru-linux-amd64
+        run: |
+          mkdir -p build/linux-amd64/bin
+          cp bin/neru-linux-amd64 build/linux-amd64/bin/neru
+          chmod +x build/linux-amd64/bin/neru
 
-                  cd build/linux-amd64
-                  zip -r ../../neru-linux-amd64.zip bin
-                  cd ../..
+          cd build/linux-amd64
+          zip -r ../../neru-linux-amd64.zip bin
+          cd ../..
 
-            - name: Generate linux amd64 checksum
-              run: |
-                  sha256sum neru-linux-amd64.zip | awk '{print $1}' > neru-linux-amd64.zip.sha256
-                  ls -l neru-linux-amd64.zip neru-linux-amd64.zip.sha256
+      - name: Generate linux amd64 checksum
+        run: |
+          sha256sum neru-linux-amd64.zip | awk '{print $1}' > neru-linux-amd64.zip.sha256
+          ls -l neru-linux-amd64.zip neru-linux-amd64.zip.sha256
 
-            - name: Upload linux amd64 release artifacts
-              env:
-                  GH_TOKEN: ${{ secrets.upload_token || github.token }}
-              run: |
-                  gh release upload "${{ inputs.release_tag }}" neru-linux-amd64.zip neru-linux-amd64.zip.sha256 --clobber
+      - name: Upload linux amd64 release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.upload_token || github.token }}
+        run: |
+          gh release upload "${{ inputs.release_tag }}" neru-linux-amd64.zip neru-linux-amd64.zip.sha256 --clobber
 
-    build-linux-arm64-artifacts:
-        runs-on: ubuntu-24.04-arm
-        permissions:
-            contents: write
-        steps:
-            - uses: actions/checkout@v6
+  build-linux-arm64-artifacts:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
 
-            - name: Install Linux build dependencies
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install -y \
-                    libcairo2-dev \
-                    libwayland-dev \
-                    libx11-dev \
-                    libxtst-dev \
-                    libxrandr-dev \
-                    libxinerama-dev \
-                    libxfixes-dev \
-                    libxkbcommon-dev \
-                    wayland-protocols
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcairo2-dev \
+            libwayland-dev \
+            libx11-dev \
+            libxtst-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxfixes-dev \
+            libxkbcommon-dev \
+            wayland-protocols
 
-            - uses: actions/setup-go@v6
-              with:
-                  go-version: "1.26.1"
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.1"
 
-            - uses: extractions/setup-just@v4
-              with:
-                  just-version: "1.46.0"
+      - uses: extractions/setup-just@v4
+        with:
+          just-version: "1.46.0"
 
-            - name: Build neru linux arm64 artifact
-              run: just release-ci-linux arm64 ${{ inputs.version_override }}
+      - name: Build neru linux arm64 artifact
+        run: just release-ci-linux arm64 ${{ inputs.version_override }}
 
-            - name: Bundle neru-linux-arm64
-              run: |
-                  mkdir -p build/linux-arm64/bin
-                  cp bin/neru-linux-arm64 build/linux-arm64/bin/neru
-                  chmod +x build/linux-arm64/bin/neru
+      - name: Bundle neru-linux-arm64
+        run: |
+          mkdir -p build/linux-arm64/bin
+          cp bin/neru-linux-arm64 build/linux-arm64/bin/neru
+          chmod +x build/linux-arm64/bin/neru
 
-                  cd build/linux-arm64
-                  zip -r ../../neru-linux-arm64.zip bin
-                  cd ../..
+          cd build/linux-arm64
+          zip -r ../../neru-linux-arm64.zip bin
+          cd ../..
 
-            - name: Generate linux arm64 checksum
-              run: |
-                  sha256sum neru-linux-arm64.zip | awk '{print $1}' > neru-linux-arm64.zip.sha256
-                  ls -l neru-linux-arm64.zip neru-linux-arm64.zip.sha256
+      - name: Generate linux arm64 checksum
+        run: |
+          sha256sum neru-linux-arm64.zip | awk '{print $1}' > neru-linux-arm64.zip.sha256
+          ls -l neru-linux-arm64.zip neru-linux-arm64.zip.sha256
 
-            - name: Upload linux arm64 release artifacts
-              env:
-                  GH_TOKEN: ${{ secrets.upload_token || github.token }}
-              run: |
-                  gh release upload "${{ inputs.release_tag }}" neru-linux-arm64.zip neru-linux-arm64.zip.sha256 --clobber
+      - name: Upload linux arm64 release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.upload_token || github.token }}
+        run: |
+          gh release upload "${{ inputs.release_tag }}" neru-linux-arm64.zip neru-linux-arm64.zip.sha256 --clobber

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -67,7 +67,7 @@ jobs:
             -k "$KEYCHAIN_PASSWORD" \
             "$KEYCHAIN" >/dev/null 2>&1
 
-          security list-keychains -d user -s "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
           security find-identity -v -p codesigning "$KEYCHAIN"
 
       - name: Build neru darwin arm64 artifact
@@ -169,7 +169,7 @@ jobs:
             -k "$KEYCHAIN_PASSWORD" \
             "$KEYCHAIN" >/dev/null 2>&1
 
-          security list-keychains -d user -s "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
           security find-identity -v -p codesigning "$KEYCHAIN"
 
       - name: Build neru darwin amd64 artifact

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -47,7 +47,8 @@ jobs:
           P12_PASSWORD: ${{ secrets.NERU_P12_PASSWORD }}
           CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
         run: |
-          echo "$P12_BASE64" | base64 --decode > cert.p12
+          CERT_PATH=$(mktemp /tmp/cert.neru-cert.p12)
+          echo "$P12_BASE64" | base64 --decode > "$CERT_PATH"
 
           KEYCHAIN="build.keychain"
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
@@ -56,7 +57,7 @@ jobs:
           security set-keychain-settings -lut 7200 "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
 
-          security import cert.p12 \
+          security import "$CERT_PATH" \
             -k "$KEYCHAIN" \
             -P "$P12_PASSWORD" \
             -A \
@@ -73,6 +74,8 @@ jobs:
 
           security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$CERT_NAME" \
             || { echo "ERROR: Signing identity '$CERT_NAME' not found in keychain"; exit 1; }
+
+          echo "CERT_PATH=$CERT_PATH" >> $GITHUB_ENV
 
       - name: Build neru darwin arm64 artifact
         run: just release-ci-darwin arm64 ${{ inputs.version_override }}
@@ -128,7 +131,7 @@ jobs:
           echo "Deleting temp keychain..."
           security delete-keychain "$KEYCHAIN" || true
 
-          rm -f cert.p12 || true
+          rm -f "$CERT_PATH" || true
 
           echo "Cleanup done"
 
@@ -153,7 +156,8 @@ jobs:
           P12_PASSWORD: ${{ secrets.NERU_P12_PASSWORD }}
           CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
         run: |
-          echo "$P12_BASE64" | base64 --decode > cert.p12
+          CERT_PATH=$(mktemp /tmp/cert.neru-cert.p12)
+          echo "$P12_BASE64" | base64 --decode > "$CERT_PATH"
 
           KEYCHAIN="build.keychain"
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
@@ -162,7 +166,7 @@ jobs:
           security set-keychain-settings -lut 7200 "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
 
-          security import cert.p12 \
+          security import "$CERT_PATH" \
             -k "$KEYCHAIN" \
             -P "$P12_PASSWORD" \
             -A \
@@ -179,6 +183,8 @@ jobs:
 
           security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$CERT_NAME" \
             || { echo "ERROR: Signing identity '$CERT_NAME' not found in keychain"; exit 1; }
+
+          echo "CERT_PATH=$CERT_PATH" >> $GITHUB_ENV
 
       - name: Build neru darwin amd64 artifact
         run: just release-ci-darwin amd64 ${{ inputs.version_override }}
@@ -234,7 +240,7 @@ jobs:
           echo "Deleting temp keychain..."
           security delete-keychain "$KEYCHAIN" || true
 
-          rm -f cert.p12 || true
+          rm -f "$CERT_PATH" || true
 
           echo "Cleanup done"
 

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -35,6 +35,35 @@ jobs:
               with:
                   just-version: "1.46.0"
 
+            - name: Import signing certificate
+              env:
+                  P12_BASE64: ${{ secrets.NERU_P12_BASE64 }}
+                  P12_PASSWORD: ${{ secrets.NERU_P12_PASSWORD }}
+                  CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
+              run: |
+                  echo "$P12_BASE64" | base64 --decode > cert.p12
+
+                  KEYCHAIN="build.keychain"
+                  KEYCHAIN_PASSWORD="temp123"
+
+                  security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+                  security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+                  security import cert.p12 \
+                    -k "$KEYCHAIN" \
+                    -P "$P12_PASSWORD" \
+                    -A \
+                    -T /usr/bin/codesign
+
+                  security set-key-partition-list \
+                    -S apple-tool:,apple: \
+                    -s \
+                    -k "$KEYCHAIN_PASSWORD" \
+                    "$KEYCHAIN" >/dev/null 2>&1
+
+                  security list-keychains -d user -s "$KEYCHAIN"
+                  security find-identity -v -p codesigning "$KEYCHAIN"
+
             - name: Build neru darwin arm64 artifact
               run: just release-ci-darwin arm64 ${{ inputs.version_override }}
 
@@ -44,14 +73,18 @@ jobs:
                   cp bin/neru-darwin-arm64 build/arm64/Neru.app/Contents/MacOS/neru
                   chmod +x build/arm64/Neru.app/Contents/MacOS/neru
                   cp resources/icon.icns build/arm64/Neru.app/Contents/Resources/icon.icns
+
                   sed \
                     -e "s/BUNDLE_VERSION/${{ inputs.macos_bundle_version }}/g" \
                     -e "s/SHORT_VERSION/${{ inputs.macos_short_version }}/g" \
                     -e "s/BUILD_ID/${{ inputs.version_override }}/g" \
                     resources/Info.plist.template > build/arm64/Neru.app/Contents/Info.plist
 
-                  # Ad-hoc codesign to preserve accessibility permissions across updates
-                  codesign --force --deep --sign - build/arm64/Neru.app
+                  codesign --force --deep \
+                    --keychain build.keychain \
+                    --sign "${{ secrets.NERU_CERT_NAME }}" \
+                    --timestamp=none \
+                    build/arm64/Neru.app
 
                   mkdir -p build/arm64/bin
                   cp bin/neru-darwin-arm64 build/arm64/bin/neru
@@ -72,6 +105,21 @@ jobs:
               run: |
                   gh release upload "${{ inputs.release_tag }}" neru-darwin-arm64.zip neru-darwin-arm64.zip.sha256 --clobber
 
+            - name: Cleanup signing keychain
+              if: always()
+              run: |
+                  KEYCHAIN="build-$GITHUB_JOB.keychain"
+
+                  echo "Restoring login keychain..."
+                  security list-keychains -d user -s ~/Library/Keychains/login.keychain-db || true
+
+                  echo "Deleting temp keychain..."
+                  security delete-keychain "$KEYCHAIN" || true
+
+                  rm -f cert.p12 || true
+
+                  echo "Cleanup done"
+
     build-darwin-amd64-artifacts:
         runs-on: macos-15-intel
         permissions:
@@ -87,6 +135,35 @@ jobs:
               with:
                   just-version: "1.46.0"
 
+            - name: Import signing certificate
+              env:
+                  P12_BASE64: ${{ secrets.NERU_P12_BASE64 }}
+                  P12_PASSWORD: ${{ secrets.NERU_P12_PASSWORD }}
+                  CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
+              run: |
+                  echo "$P12_BASE64" | base64 --decode > cert.p12
+
+                  KEYCHAIN="build.keychain"
+                  KEYCHAIN_PASSWORD="temp123"
+
+                  security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+                  security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+                  security import cert.p12 \
+                    -k "$KEYCHAIN" \
+                    -P "$P12_PASSWORD" \
+                    -A \
+                    -T /usr/bin/codesign
+
+                  security set-key-partition-list \
+                    -S apple-tool:,apple: \
+                    -s \
+                    -k "$KEYCHAIN_PASSWORD" \
+                    "$KEYCHAIN" >/dev/null 2>&1
+
+                  security list-keychains -d user -s "$KEYCHAIN"
+                  security find-identity -v -p codesigning "$KEYCHAIN"
+
             - name: Build neru darwin amd64 artifact
               run: just release-ci-darwin amd64 ${{ inputs.version_override }}
 
@@ -96,14 +173,18 @@ jobs:
                   cp bin/neru-darwin-amd64 build/amd64/Neru.app/Contents/MacOS/neru
                   chmod +x build/amd64/Neru.app/Contents/MacOS/neru
                   cp resources/icon.icns build/amd64/Neru.app/Contents/Resources/icon.icns
+
                   sed \
                     -e "s/BUNDLE_VERSION/${{ inputs.macos_bundle_version }}/g" \
                     -e "s/SHORT_VERSION/${{ inputs.macos_short_version }}/g" \
                     -e "s/BUILD_ID/${{ inputs.version_override }}/g" \
                     resources/Info.plist.template > build/amd64/Neru.app/Contents/Info.plist
 
-                  # Ad-hoc codesign to preserve accessibility permissions across updates
-                  codesign --force --deep --sign - build/amd64/Neru.app
+                  codesign --force --deep \
+                    --keychain build.keychain \
+                    --sign "${{ secrets.NERU_CERT_NAME }}" \
+                    --timestamp=none \
+                    build/amd64/Neru.app
 
                   mkdir -p build/amd64/bin
                   cp bin/neru-darwin-amd64 build/amd64/bin/neru
@@ -123,6 +204,21 @@ jobs:
                   GH_TOKEN: ${{ secrets.upload_token || github.token }}
               run: |
                   gh release upload "${{ inputs.release_tag }}" neru-darwin-amd64.zip neru-darwin-amd64.zip.sha256 --clobber
+
+            - name: Cleanup signing keychain
+              if: always()
+              run: |
+                  KEYCHAIN="build-$GITHUB_JOB.keychain"
+
+                  echo "Restoring login keychain..."
+                  security list-keychains -d user -s ~/Library/Keychains/login.keychain-db || true
+
+                  echo "Deleting temp keychain..."
+                  security delete-keychain "$KEYCHAIN" || true
+
+                  rm -f cert.p12 || true
+
+                  echo "Cleanup done"
 
     build-linux-amd64-artifacts:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -50,7 +50,7 @@ jobs:
           echo "$P12_BASE64" | base64 --decode > cert.p12
 
           KEYCHAIN="build.keychain"
-          KEYCHAIN_PASSWORD="temp123"
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
@@ -152,7 +152,7 @@ jobs:
           echo "$P12_BASE64" | base64 --decode > cert.p12
 
           KEYCHAIN="build.keychain"
-          KEYCHAIN_PASSWORD="temp123"
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -104,6 +104,12 @@ jobs:
           cp bin/neru-darwin-arm64 build/arm64/bin/neru
           chmod +x build/arm64/bin/neru
 
+          codesign --force \
+            --keychain build.keychain \
+            --sign "$CERT_NAME" \
+            --timestamp=none \
+            build/arm64/bin/neru
+
           cd build/arm64
           zip -r ../../neru-darwin-arm64.zip bin Neru.app
           cd ../..
@@ -211,6 +217,12 @@ jobs:
           mkdir -p build/amd64/bin
           cp bin/neru-darwin-amd64 build/amd64/bin/neru
           chmod +x build/amd64/bin/neru
+
+          codesign --force \
+            --keychain build.keychain \
+            --sign "$CERT_NAME" \
+            --timestamp=none \
+            build/amd64/bin/neru
 
           cd build/amd64
           zip -r ../../neru-darwin-amd64.zip bin Neru.app

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -53,6 +53,7 @@ jobs:
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 7200 "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
 
           security import cert.p12 \
@@ -67,8 +68,11 @@ jobs:
             -k "$KEYCHAIN_PASSWORD" \
             "$KEYCHAIN" >/dev/null 2>&1
 
+          security default-keychain -s "$KEYCHAIN"
           security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
-          security find-identity -v -p codesigning "$KEYCHAIN"
+
+          security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$CERT_NAME" \
+            || { echo "ERROR: Signing identity '$CERT_NAME' not found in keychain"; exit 1; }
 
       - name: Build neru darwin arm64 artifact
         run: just release-ci-darwin arm64 ${{ inputs.version_override }}
@@ -155,6 +159,7 @@ jobs:
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 7200 "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
 
           security import cert.p12 \
@@ -169,8 +174,11 @@ jobs:
             -k "$KEYCHAIN_PASSWORD" \
             "$KEYCHAIN" >/dev/null 2>&1
 
+          security default-keychain -s "$KEYCHAIN"
           security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
-          security find-identity -v -p codesigning "$KEYCHAIN"
+
+          security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$CERT_NAME" \
+            || { echo "ERROR: Signing identity '$CERT_NAME' not found in keychain"; exit 1; }
 
       - name: Build neru darwin amd64 artifact
         run: just release-ci-darwin amd64 ${{ inputs.version_override }}

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -47,7 +47,7 @@ jobs:
           P12_PASSWORD: ${{ secrets.NERU_P12_PASSWORD }}
           CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
         run: |
-          CERT_PATH=$(mktemp /tmp/cert.neru-cert.p12)
+          CERT_PATH=$(mktemp /tmp/cert.neru-cert.XXXXXX.p12)
           echo "CERT_PATH=$CERT_PATH" >> $GITHUB_ENV
           echo "$P12_BASE64" | base64 --decode > "$CERT_PATH"
 
@@ -155,7 +155,7 @@ jobs:
           P12_PASSWORD: ${{ secrets.NERU_P12_PASSWORD }}
           CERT_NAME: ${{ secrets.NERU_CERT_NAME }}
         run: |
-          CERT_PATH=$(mktemp /tmp/cert.neru-cert.p12)
+          CERT_PATH=$(mktemp /tmp/cert.neru-cert.XXXXXX.p12)
           echo "CERT_PATH=$CERT_PATH" >> $GITHUB_ENV
           echo "$P12_BASE64" | base64 --decode > "$CERT_PATH"
 

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -17,11 +17,11 @@ on:
       upload_token:
         required: false
       NERU_P12_BASE64:
-        required: false
+        required: true
       NERU_P12_PASSWORD:
-        required: false
+        required: true
       NERU_CERT_NAME:
-        required: false
+        required: true
 
 name: publish-artifacts
 

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -16,7 +16,7 @@ on:
     secrets:
       upload_token:
         required: false
-      NERU_P12_64_BASE64:
+      NERU_P12_BASE64:
         required: false
       NERU_P12_PASSWORD:
         required: false

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -69,7 +69,7 @@ jobs:
             "$KEYCHAIN" >/dev/null 2>&1
 
           security default-keychain -s "$KEYCHAIN"
-          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)
 
           security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$CERT_NAME" \
             || { echo "ERROR: Signing identity '$CERT_NAME' not found in keychain"; exit 1; }
@@ -175,7 +175,7 @@ jobs:
             "$KEYCHAIN" >/dev/null 2>&1
 
           security default-keychain -s "$KEYCHAIN"
-          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)
 
           security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$CERT_NAME" \
             || { echo "ERROR: Signing identity '$CERT_NAME' not found in keychain"; exit 1; }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,7 +43,14 @@ jobs:
         with:
             release_tag: ${{ needs.release-please.outputs.tag_name }}
             version_override: ${{ needs.release-please.outputs.tag_name }}
-            macos_bundle_version: ${{ needs.prepare-release-macos-version.outputs.macos_bundle_version }}
-            macos_short_version: ${{ needs.prepare-release-macos-version.outputs.macos_short_version }}
+            macos_bundle_version: ${{
+                needs.prepare-release-macos-version.outputs.macos_bundle_version
+                }}
+            macos_short_version: ${{
+                needs.prepare-release-macos-version.outputs.macos_short_version
+                }}
         secrets:
             upload_token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+            NERU_P12_BASE64: ${{ secrets.NERU_P12_BASE64 }}
+            NERU_P12_PASSWORD: ${{ secrets.NERU_P12_PASSWORD }}
+            NERU_CERT_NAME: ${{ secrets.NERU_CERT_NAME }}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a more proper adhoc code signing flow with references from yabai and warpd. Hopefully it will reduce the need to re-allow accessibility permissions.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to #737

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [ ] Code formatted (`just fmt`)
- [ ] Linters pass (`just lint`)
- [ ] Tests pass (`just test`)
- [ ] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
