### PR TITLE
fix: preserve hint action hotkeys with sticky modifiers

### DIFF
--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -14,11 +14,12 @@ import (
 const hotkeySequenceTimeout = 500 * time.Millisecond
 
 const (
-	keyPartCmd    = "cmd"
-	keyPartShift  = "shift"
-	keyPartAlt    = "alt"
-	keyPartCtrl   = "ctrl"
-	keyPartOption = "option"
+	keyPartCmd         = "cmd"
+	keyPartShift       = "shift"
+	keyPartAlt         = "alt"
+	keyPartCtrl        = "ctrl"
+	keyPartOption      = "option"
+	hotkeyActionPrefix = "action "
 )
 
 // HandleKeyPress dispatches key events by current mode.
@@ -63,6 +64,10 @@ func (h *Handler) HandleKeyPress(key string) {
 	// only. Sticky modifiers are for the next action, not Neru's own navigation
 	// keys; using rawKey here would make a sticky Ctrl turn "c" into "Ctrl+c".
 	if rawKey != key {
+		if h.handleRawHintsActionHotkey(rawKey, bundleID) {
+			return
+		}
+
 		if h.handleHotkey(key, bundleID) {
 			return
 		}
@@ -184,6 +189,34 @@ func (h *Handler) handleHotkey(key, bundleID string) bool {
 	}
 
 	return false
+}
+
+func (h *Handler) handleRawHintsActionHotkey(rawKey, bundleID string) bool {
+	if h.executeHotkeyAction == nil || h.appState.CurrentMode() != domain.ModeHints {
+		return false
+	}
+
+	hotkeys := h.config.HotkeysForModeAndApp(domain.ModeString(domain.ModeHints), bundleID)
+	if len(hotkeys) == 0 {
+		return false
+	}
+
+	bindKey, actions, ok := findHotkeyMatch(hotkeys, config.NormalizeKeyForComparison(rawKey))
+	if !ok || !startsWithModeAction(actions) {
+		return false
+	}
+
+	h.dispatchHotkeyActions(domain.ModeString(domain.ModeHints), bindKey, rawKey, actions)
+
+	return true
+}
+
+func startsWithModeAction(actions []string) bool {
+	if len(actions) == 0 {
+		return false
+	}
+
+	return strings.HasPrefix(strings.TrimSpace(actions[0]), hotkeyActionPrefix)
 }
 
 func findHotkeyMatch(

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -202,7 +202,7 @@ func (h *Handler) handleRawHintsActionHotkey(rawKey, bundleID string) bool {
 	}
 
 	bindKey, actions, ok := findHotkeyMatch(hotkeys, config.NormalizeKeyForComparison(rawKey))
-	if !ok || !startsWithModeAction(actions) {
+	if !ok || !containsModeAction(actions) {
 		return false
 	}
 
@@ -211,12 +211,14 @@ func (h *Handler) handleRawHintsActionHotkey(rawKey, bundleID string) bool {
 	return true
 }
 
-func startsWithModeAction(actions []string) bool {
-	if len(actions) == 0 {
-		return false
+func containsModeAction(actions []string) bool {
+	for _, actionStr := range actions {
+		if strings.HasPrefix(strings.TrimSpace(actionStr), hotkeyActionPrefix) {
+			return true
+		}
 	}
 
-	return strings.HasPrefix(strings.TrimSpace(actions[0]), hotkeyActionPrefix)
+	return false
 }
 
 func findHotkeyMatch(

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -138,7 +138,7 @@ func TestHandleKeyPressUsesRawHintActionHotkeyWhenStickyShiftStripped(t *testing
 	}
 }
 
-func TestHandleKeyPressUsesRawHintActionHotkeyWithFollowUpActions(t *testing.T) {
+func TestHandleKeyPressUsesRawHintActionHotkeyWithActionAfterModeAction(t *testing.T) {
 	t.Parallel()
 
 	appState := state.NewAppState()
@@ -151,7 +151,7 @@ func TestHandleKeyPressUsesRawHintActionHotkeyWithFollowUpActions(t *testing.T) 
 		config: &configpkg.Config{
 			Hints: configpkg.HintsConfig{
 				Hotkeys: map[string]configpkg.StringOrStringArray{
-					"Shift+L": {"action left_click", "idle"},
+					"Shift+L": {"idle", "action left_click"},
 				},
 			},
 		},
@@ -182,7 +182,7 @@ func TestHandleKeyPressUsesRawHintActionHotkeyWithFollowUpActions(t *testing.T) 
 
 	handler.HandleKeyPress("Shift+L")
 
-	for _, want := range []string{"action left_click", "idle"} {
+	for _, want := range []string{"idle", "action left_click"} {
 		select {
 		case got := <-hotkeyActions:
 			if got != want {

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -2,17 +2,22 @@
 package modes
 
 import (
+	"context"
 	"image"
 	"testing"
 	"time"
 
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/app/services"
 	configpkg "github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
+	portmocks "github.com/y3owk1n/neru/internal/core/ports/mocks"
 )
+
+const testSafariBundleID = "com.apple.Safari"
 
 type recordingMode struct {
 	keys chan string
@@ -69,6 +74,196 @@ func TestHandleKeyPressUsesStickyStrippedKeyForBindings(t *testing.T) {
 	select {
 	case got := <-hotkeyActions:
 		t.Fatalf("sticky modifier leaked into hotkey action %q", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestHandleKeyPressUsesRawHintActionHotkeyWhenStickyShiftStripped(t *testing.T) {
+	t.Parallel()
+
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeHints)
+
+	mode := &recordingMode{keys: make(chan string, 1)}
+	hotkeyActions := make(chan string, 1)
+
+	handler := &Handler{
+		config: &configpkg.Config{
+			Hints: configpkg.HintsConfig{
+				Hotkeys: map[string]configpkg.StringOrStringArray{
+					"Shift+L": {"action left_click"},
+				},
+			},
+		},
+		logger:        zap.NewNop(),
+		appState:      appState,
+		modifierState: state.NewModifierState(),
+		actionService: services.NewActionService(
+			&portmocks.MockAccessibilityPort{
+				FocusedAppBundleIDFunc: func(context.Context) (string, error) {
+					return testSafariBundleID, nil
+				},
+			},
+			&portmocks.MockOverlayPort{},
+			&portmocks.SystemMock{},
+			zap.NewNop(),
+		),
+		modes: map[domain.Mode]Mode{
+			domain.ModeHints: mode,
+		},
+		screenBounds: image.Rect(0, 0, 100, 100),
+		executeHotkeyAction: func(_, actionStr string) error {
+			hotkeyActions <- actionStr
+
+			return nil
+		},
+	}
+	handler.modifierState.Toggle(action.ModShift)
+
+	handler.HandleKeyPress("Shift+L")
+
+	select {
+	case got := <-hotkeyActions:
+		if got != "action left_click" {
+			t.Fatalf("hotkey action = %q, want %q", got, "action left_click")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for raw hint action hotkey")
+	}
+
+	select {
+	case got := <-mode.keys:
+		t.Fatalf("mode-specific key handler received %q, want hotkey to consume input", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestHandleKeyPressUsesRawHintActionHotkeyWithFollowUpActions(t *testing.T) {
+	t.Parallel()
+
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeHints)
+
+	mode := &recordingMode{keys: make(chan string, 1)}
+	hotkeyActions := make(chan string, 2)
+
+	handler := &Handler{
+		config: &configpkg.Config{
+			Hints: configpkg.HintsConfig{
+				Hotkeys: map[string]configpkg.StringOrStringArray{
+					"Shift+L": {"action left_click", "idle"},
+				},
+			},
+		},
+		logger:        zap.NewNop(),
+		appState:      appState,
+		modifierState: state.NewModifierState(),
+		actionService: services.NewActionService(
+			&portmocks.MockAccessibilityPort{
+				FocusedAppBundleIDFunc: func(context.Context) (string, error) {
+					return "com.apple.Safari", nil
+				},
+			},
+			&portmocks.MockOverlayPort{},
+			&portmocks.SystemMock{},
+			zap.NewNop(),
+		),
+		modes: map[domain.Mode]Mode{
+			domain.ModeHints: mode,
+		},
+		screenBounds: image.Rect(0, 0, 100, 100),
+		executeHotkeyAction: func(_, actionStr string) error {
+			hotkeyActions <- actionStr
+
+			return nil
+		},
+	}
+	handler.modifierState.Toggle(action.ModShift)
+
+	handler.HandleKeyPress("Shift+L")
+
+	for _, want := range []string{"action left_click", "idle"} {
+		select {
+		case got := <-hotkeyActions:
+			if got != want {
+				t.Fatalf("hotkey action = %q, want %q", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for hotkey action %q", want)
+		}
+	}
+
+	select {
+	case got := <-mode.keys:
+		t.Fatalf("mode-specific key handler received %q, want hotkey to consume input", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestHandleKeyPressHonorsDisabledAppHintActionOverride(t *testing.T) {
+	t.Parallel()
+
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeHints)
+
+	mode := &recordingMode{keys: make(chan string, 1)}
+	hotkeyActions := make(chan string, 1)
+
+	handler := &Handler{
+		config: &configpkg.Config{
+			Hints: configpkg.HintsConfig{
+				Hotkeys: map[string]configpkg.StringOrStringArray{
+					"Shift+L": {"action left_click"},
+				},
+				AppConfigs: []configpkg.AppConfig{
+					{
+						BundleID: testSafariBundleID,
+						Hotkeys: map[string]configpkg.StringOrStringArray{
+							"Shift+L": {configpkg.DisabledSentinel},
+						},
+					},
+				},
+			},
+		},
+		logger:        zap.NewNop(),
+		appState:      appState,
+		modifierState: state.NewModifierState(),
+		actionService: services.NewActionService(
+			&portmocks.MockAccessibilityPort{
+				FocusedAppBundleIDFunc: func(context.Context) (string, error) {
+					return testSafariBundleID, nil
+				},
+			},
+			&portmocks.MockOverlayPort{},
+			&portmocks.SystemMock{},
+			zap.NewNop(),
+		),
+		modes: map[domain.Mode]Mode{
+			domain.ModeHints: mode,
+		},
+		screenBounds: image.Rect(0, 0, 100, 100),
+		executeHotkeyAction: func(_, actionStr string) error {
+			hotkeyActions <- actionStr
+
+			return nil
+		},
+	}
+	handler.modifierState.Toggle(action.ModShift)
+
+	handler.HandleKeyPress("Shift+L")
+
+	select {
+	case got := <-mode.keys:
+		if got != "L" {
+			t.Fatalf("mode key = %q, want %q", got, "L")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stripped mode key")
+	}
+
+	select {
+	case got := <-hotkeyActions:
+		t.Fatalf("disabled app override still dispatched hotkey action %q", got)
 	case <-time.After(50 * time.Millisecond):
 	}
 }


### PR DESCRIPTION
## Summary
- Preserve raw hint-mode action hotkeys like `Shift+L` when sticky modifiers strip the key before mode handling.
- Keep stripped-key behavior for normal mode navigation so sticky modifiers do not leak into bindings like `Ctrl+C`.
- Add regression coverage for hint action hotkeys, multi-action bindings, app-specific disabled overrides, and sticky modifier stripping.

## Verification
- `go test ./internal/app/modes ...`
- `just fmt && just lint && just test && just build`