### PR TITLE
feat: prompt for macOS accessibility permission on startup

### DIFF
--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -76,6 +76,8 @@ func LaunchDaemon(configPath string) {
 		configResult = handleConfigOnboarding(service, configResult)
 	}
 
+	handleAccessibilityPermissionStartup(configResult.Config)
+
 	app, appErr := app.New(
 		app.WithConfig(configResult.Config),
 		app.WithConfigPath(configResult.ConfigPath),
@@ -162,4 +164,18 @@ func promptConfigInit(configPath string) bool {
 	os.Exit(1)
 
 	return false
+}
+
+func handleAccessibilityPermissionStartup(cfg *config.Config) {
+	if !platform.IsDarwin() || cfg == nil || !cfg.General.AccessibilityCheckOnStart {
+		return
+	}
+
+	if platform.CheckAccessibilityPermissions() {
+		return
+	}
+
+	if platform.ShowAccessibilityPermissionStartupAlert() == platform.AccessibilityPermissionStartupQuit {
+		os.Exit(0)
+	}
 }

--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -175,6 +175,20 @@ func handleAccessibilityPermissionStartup(cfg *config.Config) {
 		return
 	}
 
+	if !cli.IsRunningFromAppBundle() {
+		fmt.Fprintf(os.Stderr, "⚠️  Accessibility permission not granted.\n")
+		fmt.Fprintf(
+			os.Stderr,
+			"Grant Neru access in System Settings → Privacy & Security → Accessibility.\n",
+		)
+		fmt.Fprintf(
+			os.Stderr,
+			"Launch Neru from the app bundle for the guided permission prompt.\n",
+		)
+
+		return
+	}
+
 	if platform.ShowAccessibilityPermissionStartupAlert() == platform.AccessibilityPermissionStartupQuit {
 		os.Exit(0)
 	}

--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -58,11 +58,6 @@ func initializeAccessibility(cfg *config.Config, logger *zap.Logger) error {
 			logger.Info("⚠️  Neru requires Accessibility permissions to function.")
 			logger.Info("Please go to: System Settings → Privacy & Security → Accessibility")
 			logger.Info("and enable Neru.")
-
-			return derrors.New(
-				derrors.CodeAccessibilityDenied,
-				"accessibility permissions not granted - please enable in System Preferences",
-			)
 		}
 	}
 

--- a/internal/core/infra/platform/darwin/accessibility.go
+++ b/internal/core/infra/platform/darwin/accessibility.go
@@ -19,6 +19,12 @@ func CheckAccessibilityPermissions() bool {
 	return C.checkAccessibilityPermissions() != 0
 }
 
+// RequestAccessibilityPermissions asks macOS to start the accessibility
+// permission flow and returns whether permission is granted afterward.
+func RequestAccessibilityPermissions() bool {
+	return C.requestAccessibilityPermissions() != 0
+}
+
 // FocusedApplicationPID returns the PID of the currently focused application.
 func FocusedApplicationPID() (int, error) {
 	ref := C.getFocusedApplication()

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -31,6 +31,10 @@ typedef struct {
 /// @return 1 if permissions are granted, 0 otherwise
 int checkAccessibilityPermissions(void);
 
+/// Request accessibility permissions from macOS
+/// @return 1 if permissions are granted after the request, 0 otherwise
+int requestAccessibilityPermissions(void);
+
 #pragma mark - Application Functions
 
 /// Get system-wide accessibility element

--- a/internal/core/infra/platform/darwin/accessibility_permissions_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_permissions_darwin.m
@@ -27,8 +27,9 @@ static BOOL resetAccessibilityPermissionDecision(void) {
 
 		int status = [task terminationStatus];
 		if (status != 0) {
-			NSLog(@"Neru: tccutil reset Accessibility %@ exited with status %d; system permission dialog may not appear",
-			      bundleID, status);
+			NSLog(
+			    @"Neru: tccutil reset Accessibility %@ exited with status %d; system permission dialog may not appear",
+			    bundleID, status);
 			return NO;
 		}
 	} @catch (NSException *exception) {

--- a/internal/core/infra/platform/darwin/accessibility_permissions_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_permissions_darwin.m
@@ -11,7 +11,7 @@
 
 #pragma mark - Permission Functions
 
-static void resetAccessibilityPermissionDecision(void) {
+static BOOL resetAccessibilityPermissionDecision(void) {
 	NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
 	if (bundleID == nil || [bundleID length] == 0) {
 		bundleID = @"com.y3owk1n.neru";
@@ -24,9 +24,19 @@ static void resetAccessibilityPermissionDecision(void) {
 	@try {
 		[task launch];
 		[task waitUntilExit];
+
+		int status = [task terminationStatus];
+		if (status != 0) {
+			NSLog(@"Neru: tccutil reset Accessibility %@ exited with status %d; system permission dialog may not appear",
+			      bundleID, status);
+			return NO;
+		}
 	} @catch (NSException *exception) {
 		NSLog(@"Neru: failed to reset Accessibility permission decision: %@", exception);
+		return NO;
 	}
+
+	return YES;
 }
 
 /// Check if accessibility permissions are granted
@@ -42,7 +52,9 @@ int checkAccessibilityPermissions(void) {
 /// @return 1 if permissions are granted after the request, 0 otherwise
 int requestAccessibilityPermissions(void) {
 	@autoreleasepool {
-		resetAccessibilityPermissionDecision();
+		if (!resetAccessibilityPermissionDecision()) {
+			NSLog(@"Neru: continuing with Accessibility permission request after reset failure");
+		}
 
 		NSDictionary *options = @{(__bridge id)kAXTrustedCheckOptionPrompt : @YES};
 		Boolean trusted = AXIsProcessTrustedWithOptions((__bridge CFDictionaryRef)options);

--- a/internal/core/infra/platform/darwin/accessibility_permissions_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_permissions_darwin.m
@@ -11,10 +11,39 @@
 
 #pragma mark - Permission Functions
 
+static void resetAccessibilityPermissionDecision(void) {
+	NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
+	if (bundleID == nil || [bundleID length] == 0) {
+		bundleID = @"com.y3owk1n.neru";
+	}
+
+	NSTask *task = [[NSTask alloc] init];
+	task.launchPath = @"/usr/bin/tccutil";
+	task.arguments = @[ @"reset", @"Accessibility", bundleID ];
+
+	@try {
+		[task launch];
+		[task waitUntilExit];
+	} @catch (NSException *exception) {
+		NSLog(@"Neru: failed to reset Accessibility permission decision: %@", exception);
+	}
+}
+
 /// Check if accessibility permissions are granted
 /// @return 1 if permissions are granted, 0 otherwise
 int checkAccessibilityPermissions(void) {
 	@autoreleasepool {
+		Boolean trusted = AXIsProcessTrusted();
+		return trusted ? 1 : 0;
+	}
+}
+
+/// Request accessibility permissions from macOS
+/// @return 1 if permissions are granted after the request, 0 otherwise
+int requestAccessibilityPermissions(void) {
+	@autoreleasepool {
+		resetAccessibilityPermissionDecision();
+
 		NSDictionary *options = @{(__bridge id)kAXTrustedCheckOptionPrompt : @YES};
 		Boolean trusted = AXIsProcessTrustedWithOptions((__bridge CFDictionaryRef)options);
 		return trusted ? 1 : 0;

--- a/internal/core/infra/platform/darwin/alert.go
+++ b/internal/core/infra/platform/darwin/alert.go
@@ -15,6 +15,9 @@ type ConfigOnboardingChoice int
 // ConfigValidationChoice represents the user's choice in the config validation error alert.
 type ConfigValidationChoice int
 
+// AccessibilityPermissionStartupChoice represents the user's choice in the startup permission alert.
+type AccessibilityPermissionStartupChoice int
+
 const (
 	// ConfigOnboardingCreate indicates the user chose to create a config file.
 	ConfigOnboardingCreate ConfigOnboardingChoice = 1
@@ -27,6 +30,11 @@ const (
 	ConfigValidationOK ConfigValidationChoice = 1
 	// ConfigValidationCopyPath indicates the user clicked Copy Path.
 	ConfigValidationCopyPath ConfigValidationChoice = 2
+
+	// AccessibilityPermissionStartupGranted indicates accessibility permission is granted.
+	AccessibilityPermissionStartupGranted AccessibilityPermissionStartupChoice = 1
+	// AccessibilityPermissionStartupQuit indicates the user chose to quit.
+	AccessibilityPermissionStartupQuit AccessibilityPermissionStartupChoice = 2
 )
 
 // ShowConfigValidationError displays a native macOS alert for configuration validation errors.
@@ -55,4 +63,10 @@ func ShowConfigOnboardingAlert(configPath string) ConfigOnboardingChoice {
 	defer C.free(unsafe.Pointer(cPath)) //nolint:nlreturn
 
 	return ConfigOnboardingChoice(C.showConfigOnboardingAlert(cPath))
+}
+
+// ShowAccessibilityPermissionStartupAlert displays the macOS startup guidance for granting
+// accessibility permission.
+func ShowAccessibilityPermissionStartupAlert() AccessibilityPermissionStartupChoice {
+	return AccessibilityPermissionStartupChoice(C.showAccessibilityPermissionStartupAlert())
 }

--- a/internal/core/infra/platform/darwin/alert.h
+++ b/internal/core/infra/platform/darwin/alert.h
@@ -23,6 +23,11 @@ int showConfigValidationErrorAlert(const char *errorMessage, const char *configP
 /// @return 1 if user clicked Create Config, 2 if user clicked Use Defaults, 3 if user clicked Quit
 int showConfigOnboardingAlert(const char *configPath);
 
+/// Show the startup accessibility permission guidance alert.
+/// The alert lets the user request permission and then dismiss it with Done.
+/// @return 1 if permission is granted, 2 if the user chose Quit.
+int showAccessibilityPermissionStartupAlert(void);
+
 /// Show a macOS notification with a title and message.
 /// Uses UNUserNotificationCenter when running as an app bundle, logs to console otherwise.
 /// @note This function is asynchronous — it returns immediately before the

--- a/internal/core/infra/platform/darwin/alert_darwin.m
+++ b/internal/core/infra/platform/darwin/alert_darwin.m
@@ -173,7 +173,7 @@ static int showAccessibilityPermissionStartupAlertOnMainThread(void) {
 		alert.messageText = @"Accessibility Permission Needed";
 		alert.informativeText =
 		    @"Neru needs Accessibility permission to work. Click Request Permission to open the macOS permission "
-		    @"flow, grant access in System Settings, then return here and click Start Neru.";
+		    @"flow, grant access in System Settings, then return here and click Granted, Start Neru.";
 		alert.alertStyle = NSAlertStyleWarning;
 		alert.icon = [NSImage imageNamed:NSImageNameCaution];
 

--- a/internal/core/infra/platform/darwin/alert_darwin.m
+++ b/internal/core/infra/platform/darwin/alert_darwin.m
@@ -5,6 +5,7 @@
 //  Copyright © 2025 Neru. All rights reserved.
 //
 
+#import "accessibility.h"
 #import "alert.h"
 
 #import <Cocoa/Cocoa.h>
@@ -15,6 +16,7 @@
 
 static int showAlertOnMainThread(const char *errorMessage, const char *configPath);
 static int showOnboardingAlertOnMainThread(const char *configPath);
+static int showAccessibilityPermissionStartupAlertOnMainThread(void);
 
 #pragma mark - Alert Functions
 
@@ -145,6 +147,57 @@ static int showOnboardingAlertOnMainThread(const char *configPath) {
 	}
 
 	return 0;
+}
+
+/// Show the startup accessibility permission guidance alert.
+int showAccessibilityPermissionStartupAlert(void) {
+	@autoreleasepool {
+		__block int result = 0;
+
+		if ([NSThread isMainThread]) {
+			result = showAccessibilityPermissionStartupAlertOnMainThread();
+		} else {
+			dispatch_sync(dispatch_get_main_queue(), ^{
+				result = showAccessibilityPermissionStartupAlertOnMainThread();
+			});
+		}
+
+		return result;
+	}
+}
+
+/// Internal function to show the accessibility permission alert on main thread.
+static int showAccessibilityPermissionStartupAlertOnMainThread(void) {
+	while (checkAccessibilityPermissions() != 1) {
+		NSAlert *alert = [[NSAlert alloc] init];
+		alert.messageText = @"Accessibility Permission Needed";
+		alert.informativeText =
+		    @"Neru needs Accessibility permission to work. Click Request Permission to open the macOS permission "
+		    @"flow, grant access in System Settings, then return here and click Start Neru.";
+		alert.alertStyle = NSAlertStyleWarning;
+		alert.icon = [NSImage imageNamed:NSImageNameCaution];
+
+		[alert addButtonWithTitle:@"Request Permission"];
+		[alert addButtonWithTitle:@"Granted, Start Neru"];
+		[alert addButtonWithTitle:@"Quit"];
+
+		[[alert window] setLevel:NSFloatingWindowLevel];
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+		[[alert window] center];
+		[[alert window] makeKeyAndOrderFront:nil];
+		[NSApp activateIgnoringOtherApps:YES];
+
+		NSModalResponse response = [alert runModal];
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
+		if (response == NSAlertFirstButtonReturn) {
+			requestAccessibilityPermissions();
+		} else if (response == NSAlertThirdButtonReturn) {
+			return 2;
+		}
+	}
+
+	return 1;
 }
 
 #pragma mark - Notification Delegate

--- a/internal/core/infra/platform/factory.go
+++ b/internal/core/infra/platform/factory.go
@@ -21,4 +21,7 @@ const (
 
 	ConfigValidationOK       = 1
 	ConfigValidationCopyPath = 2
+
+	AccessibilityPermissionStartupGranted = 1
+	AccessibilityPermissionStartupQuit    = 2
 )

--- a/internal/core/infra/platform/factory_darwin.go
+++ b/internal/core/infra/platform/factory_darwin.go
@@ -21,3 +21,13 @@ func ShowConfigOnboardingAlert(configPath string) int {
 func ShowConfigValidationErrorAlert(errorMessage, configPath string) int {
 	return int(darwin.ShowConfigValidationError(errorMessage, configPath))
 }
+
+// CheckAccessibilityPermissions checks macOS accessibility permission without prompting.
+func CheckAccessibilityPermissions() bool {
+	return darwin.CheckAccessibilityPermissions()
+}
+
+// ShowAccessibilityPermissionStartupAlert displays the macOS startup permission guidance.
+func ShowAccessibilityPermissionStartupAlert() int {
+	return int(darwin.ShowAccessibilityPermissionStartupAlert())
+}

--- a/internal/core/infra/platform/factory_linux.go
+++ b/internal/core/infra/platform/factory_linux.go
@@ -28,3 +28,13 @@ func ShowConfigOnboardingAlert(_ string) int {
 func ShowConfigValidationErrorAlert(_, _ string) int {
 	return ConfigValidationOK
 }
+
+// CheckAccessibilityPermissions is always true on Linux for startup gating.
+func CheckAccessibilityPermissions() bool {
+	return true
+}
+
+// ShowAccessibilityPermissionStartupAlert is a no-op on Linux.
+func ShowAccessibilityPermissionStartupAlert() int {
+	return AccessibilityPermissionStartupGranted
+}

--- a/internal/core/infra/platform/factory_other.go
+++ b/internal/core/infra/platform/factory_other.go
@@ -23,3 +23,13 @@ func ShowConfigOnboardingAlert(_ string) int {
 func ShowConfigValidationErrorAlert(_, _ string) int {
 	return ConfigValidationOK
 }
+
+// CheckAccessibilityPermissions is always true on unsupported platforms for startup gating.
+func CheckAccessibilityPermissions() bool {
+	return true
+}
+
+// ShowAccessibilityPermissionStartupAlert is a no-op on unsupported platforms.
+func ShowAccessibilityPermissionStartupAlert() int {
+	return AccessibilityPermissionStartupGranted
+}

--- a/internal/core/infra/platform/factory_windows.go
+++ b/internal/core/infra/platform/factory_windows.go
@@ -21,3 +21,13 @@ func ShowConfigOnboardingAlert(_ string) int {
 func ShowConfigValidationErrorAlert(_, _ string) int {
 	return ConfigValidationOK
 }
+
+// CheckAccessibilityPermissions is always true on Windows for startup gating.
+func CheckAccessibilityPermissions() bool {
+	return true
+}
+
+// ShowAccessibilityPermissionStartupAlert is a no-op on Windows.
+func ShowAccessibilityPermissionStartupAlert() int {
+	return AccessibilityPermissionStartupGranted
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a macOS startup accessibility permission flow before Neru finishes launching. Previously we just blindly requesting for permissions, now we show a native alert with options to request permission, continue once granted, or quit.

Benefit of this is that we can also eliminate the confusion of "I had given permission previously, but it keeps popping up to request again" issue. When you click `request permission`, under the hood, we will try to reset the permission, so at least it wont be as confusing that it shows `granted`.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to #737

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

<img width="327" height="409" alt="image" src="https://github.com/user-attachments/assets/85b51ee5-1e9f-4c3d-8f53-18c2d790ae22" />

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
