### PR TITLE
chore(nix): remove prerestart in modules

### DIFF
--- a/darwin-module.nix
+++ b/darwin-module.nix
@@ -30,21 +30,6 @@ in
     lib.mkIf (cfg.enable) {
       environment.systemPackages = [ cfg.package ];
 
-      # Quit the running Neru app before the launchd agent is restarted.
-      # When launched via `open -W -a`, launchd only manages the `open` wrapper;
-      # the actual Neru process must be terminated explicitly so the new version
-      # starts after `darwin-rebuild switch`.
-      #
-      # nix-darwin runs all activationScripts before reloading launchd agents,
-      # so this is guaranteed to execute before the agent plist is updated.
-      system.activationScripts.preNeruRestart.text = ''
-        if /usr/bin/pgrep -xq neru 2>/dev/null; then
-          /usr/bin/osascript -e 'tell application "Neru" to quit' 2>/dev/null || true
-          sleep 1
-          /usr/bin/pkill -x neru 2>/dev/null || true
-        fi
-      '';
-
       launchd.user.agents.neru = {
         command =
           "/usr/bin/open -W -a ${cfg.package}/Applications/Neru.app --args launch"

--- a/home-module.nix
+++ b/home-module.nix
@@ -106,24 +106,6 @@ in
     xdg.configFile."neru/config.toml" =
       if cfg.configFile != null then { source = cfg.configFile; } else { text = cfg.config; };
 
-    # Quit the running Neru app before the launchd agent is restarted.
-    # When launched via `open -W -a`, launchd only manages the `open` wrapper;
-    # the actual Neru process must be terminated explicitly so the new version
-    # starts after `home-manager switch`.
-    #
-    # NOTE: home-manager has no dedicated "reloadLaunchd" DAG entry on macOS.
-    # We anchor before "reloadSystemd" (a no-op on darwin) to run late in the
-    # activation sequence, before launchd picks up the updated plist.
-    home.activation.neruPreRestart = lib.mkIf pkgs.stdenv.isDarwin (
-      lib.hm.dag.entryBefore [ "reloadSystemd" ] ''
-        if /usr/bin/pgrep -xq neru 2>/dev/null; then
-          /usr/bin/osascript -e 'tell application "Neru" to quit' 2>/dev/null || true
-          sleep 1
-          /usr/bin/pkill -x neru 2>/dev/null || true
-        fi
-      ''
-    );
-
     # Launch agent for macOS
     launchd.agents.neru = lib.mkIf pkgs.stdenv.isDarwin {
       enable = cfg.launchd.enable;
@@ -147,6 +129,7 @@ in
         ThrottleInterval = 10;
       };
     };
+
     # Systemd user service for Linux
     systemd.user.services.neru = lib.mkIf (pkgs.stdenv.isLinux && cfg.systemd.enable) {
       Unit = {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR removes the flaky `preRestart` in darwin and home module. The reason why it was there is because our launch
agents are running the .app and not the binary, so when a restart is needed, it won't work properly. But even with this
implementation, it feels flaky.

User should manually restart the app or doing a `pkill` at system activation instead in their config.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [ ] Code formatted (`just fmt`)
- [ ] Linters pass (`just lint`)
- [ ] Tests pass (`just test`)
- [ ] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
