### PR TITLE
fix: strict filtering for Chromium/Electron apps

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1395,6 +1395,33 @@ func (c *HintsConfig) buildRolesMap(bundleID string) map[string]struct{} {
 	return rolesMap
 }
 
+// MatchesAdditionalBundle checks if a bundle ID matches any user-provided additional bundles.
+// It supports both exact matches and wildcard patterns (ending with *).
+func MatchesAdditionalBundle(bundleID string, additionalBundles []string) bool {
+	if bundleID == "" || len(additionalBundles) == 0 {
+		return false
+	}
+
+	lower := strings.ToLower(bundleID)
+
+	for _, candidate := range additionalBundles {
+		trimmed := strings.ToLower(strings.TrimSpace(candidate))
+		if trimmed == "" {
+			continue
+		}
+
+		if prefix, found := strings.CutSuffix(trimmed, "*"); found {
+			if strings.HasPrefix(lower, prefix) {
+				return true
+			}
+		} else if lower == trimmed {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsAllLetters checks if a string contains only letters (a-z, A-Z).
 func IsAllLetters(keyStr string) bool {
 	for _, r := range keyStr {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1402,7 +1402,7 @@ func MatchesAdditionalBundle(bundleID string, additionalBundles []string) bool {
 		return false
 	}
 
-	lower := strings.ToLower(bundleID)
+	lower := strings.ToLower(strings.TrimSpace(bundleID))
 
 	for _, candidate := range additionalBundles {
 		trimmed := strings.ToLower(strings.TrimSpace(candidate))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1434,3 +1434,29 @@ func IsAllLetters(keyStr string) bool {
 
 	return len(keyStr) > 0
 }
+
+// KnownChromiumBundles contains known Chromium-based application bundle identifiers.
+// These applications benefit from AXEnhancedUserInterface accessibility improvements.
+var KnownChromiumBundles = []string{
+	"net.imput.helium",
+	"com.google.Chrome",
+	"com.brave.Browser",
+	"company.thebrowser.Browser",
+}
+
+// KnownFirefoxBundles contains known Firefox-based application bundle identifiers.
+// These applications benefit from AXEnhancedUserInterface accessibility improvements.
+var KnownFirefoxBundles = []string{
+	"org.mozilla.firefox",
+	"app.zen-browser.zen",
+}
+
+// KnownElectronBundles contains known Electron-based application bundle identifiers.
+// These applications require manual accessibility attribute toggling to work properly.
+var KnownElectronBundles = []string{
+	"com.microsoft.VSCode",
+	"com.exafunction.windsurf",
+	"com.tinyspeck.slackmacgap",
+	"com.spotify.client",
+	"md.obsidian",
+}

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -90,7 +90,11 @@ func (a *Adapter) addMenubarElements(
 
 	// Get additional menubar targets
 	for _, bundleID := range filter.AdditionalMenubarTargets {
-		additionalNodes, err := a.client.ClickableElementsFromBundleID(bundleID, menubarRoles)
+		additionalNodes, err := a.client.ClickableElementsFromBundleID(
+			bundleID,
+			menubarRoles,
+			false,
+		)
 		if err != nil {
 			a.logger.Warn("Failed to get additional menubar elements",
 				zap.String("bundle_id", bundleID),
@@ -202,7 +206,7 @@ func (a *Adapter) addNotificationCenterElements(
 
 	a.logger.Debug("Adding notification center elements")
 
-	ncNodes, ncNodesErr := a.client.ClickableElementsFromBundleID(ncBundleID, nil)
+	ncNodes, ncNodesErr := a.client.ClickableElementsFromBundleID(ncBundleID, nil, false)
 	if ncNodesErr != nil {
 		a.logger.Warn("Failed to get notification center elements", zap.Error(ncNodesErr))
 

--- a/internal/core/infra/accessibility/client.go
+++ b/internal/core/infra/accessibility/client.go
@@ -23,7 +23,11 @@ type AXClient interface {
 	ApplicationByBundleID(bundleID string) (AXApp, error)
 	ClickableNodes(root AXElement, includeOffscreen bool, roles []string) ([]AXNode, error)
 	MenuBarClickableElements() ([]AXNode, error)
-	ClickableElementsFromBundleID(bundleID string, roles []string) ([]AXNode, error)
+	ClickableElementsFromBundleID(
+		bundleID string,
+		roles []string,
+		strictFiltering bool,
+	) ([]AXNode, error)
 	ActiveScreenBounds() image.Rectangle
 
 	// Actions

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -443,28 +443,13 @@ func isLikelyChromiumOrElectron(bundleID string) bool {
 
 	lower := strings.ToLower(bundleID)
 
-	chromiumBundles := []string{
-		"net.imput.helium",
-		"com.google.Chrome",
-		"com.brave.Browser",
-		"company.thebrowser.Browser",
-	}
-
-	electronBundles := []string{
-		"com.microsoft.VSCode",
-		"com.exafunction.windsurf",
-		"com.tinyspeck.slackmacgap",
-		"com.spotify.client",
-		"md.obsidian",
-	}
-
-	for _, b := range chromiumBundles {
+	for _, b := range config.KnownChromiumBundles {
 		if strings.EqualFold(b, lower) {
 			return true
 		}
 	}
 
-	for _, b := range electronBundles {
+	for _, b := range config.KnownElectronBundles {
 		if strings.EqualFold(b, lower) {
 			return true
 		}

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -477,14 +477,12 @@ func isUserConfiguredChromiumElectron(bundleID string, configProvider config.Pro
 		return false
 	}
 
-	lower := strings.ToLower(bundleID)
-
-	additionalChromium := cfg.Hints.AdditionalAXSupport.AdditionalChromiumBundles
-	if config.MatchesAdditionalBundle(lower, additionalChromium) {
+	chromiumBundles := cfg.Hints.AdditionalAXSupport.AdditionalChromiumBundles
+	if config.MatchesAdditionalBundle(bundleID, chromiumBundles) {
 		return true
 	}
 
-	additionallyElectron := cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles
+	electronBundles := cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles
 
-	return config.MatchesAdditionalBundle(lower, additionallyElectron)
+	return config.MatchesAdditionalBundle(bundleID, electronBundles)
 }

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -474,7 +474,8 @@ func isLikelyChromiumOrElectron(bundleID string) bool {
 }
 
 // isUserConfiguredChromiumElectron checks if the bundle ID matches user-configured
-// additional Chromium/Electron bundles from config.
+// additional Chromium/Electron bundles from config. Supports exact matches and
+// wildcard patterns (ending with *).
 func isUserConfiguredChromiumElectron(bundleID string, configProvider config.Provider) bool {
 	if bundleID == "" || configProvider == nil {
 		return false
@@ -488,18 +489,11 @@ func isUserConfiguredChromiumElectron(bundleID string, configProvider config.Pro
 	lower := strings.ToLower(bundleID)
 
 	additionalChromium := cfg.Hints.AdditionalAXSupport.AdditionalChromiumBundles
-	for _, b := range additionalChromium {
-		if strings.EqualFold(strings.TrimSpace(b), lower) {
-			return true
-		}
+	if config.MatchesAdditionalBundle(lower, additionalChromium) {
+		return true
 	}
 
-	additionalElectron := cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles
-	for _, b := range additionalElectron {
-		if strings.EqualFold(strings.TrimSpace(b), lower) {
-			return true
-		}
-	}
+	additionallyElectron := cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles
 
-	return false
+	return config.MatchesAdditionalBundle(lower, additionallyElectron)
 }

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -93,7 +93,8 @@ func (c *InfraAXClient) ClickableNodes(
 
 	// Enable strict filtering for Chromium/Electron apps which have noisy DOM trees
 	bundleID := element.BundleIdentifier()
-	if isLikelyChromiumOrElectron(bundleID) {
+	if isLikelyChromiumOrElectron(bundleID) ||
+		isUserConfiguredChromiumElectron(bundleID, c.configProvider) {
 		opts.SetStrictFiltering(true)
 	}
 
@@ -464,6 +465,37 @@ func isLikelyChromiumOrElectron(bundleID string) bool {
 
 	for _, b := range electronBundles {
 		if strings.EqualFold(b, lower) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isUserConfiguredChromiumElectron checks if the bundle ID matches user-configured
+// additional Chromium/Electron bundles from config.
+func isUserConfiguredChromiumElectron(bundleID string, configProvider config.Provider) bool {
+	if bundleID == "" || configProvider == nil {
+		return false
+	}
+
+	cfg := configProvider.Get()
+	if cfg == nil {
+		return false
+	}
+
+	lower := strings.ToLower(bundleID)
+
+	additionalChromium := cfg.Hints.AdditionalAXSupport.AdditionalChromiumBundles
+	for _, b := range additionalChromium {
+		if strings.EqualFold(strings.TrimSpace(b), lower) {
+			return true
+		}
+	}
+
+	additionalElectron := cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles
+	for _, b := range additionalElectron {
+		if strings.EqualFold(strings.TrimSpace(b), lower) {
 			return true
 		}
 	}

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -96,6 +96,14 @@ func (c *InfraAXClient) ClickableNodes(
 	if isLikelyChromiumOrElectron(bundleID) ||
 		isUserConfiguredChromiumElectron(bundleID, c.configProvider) {
 		opts.SetStrictFiltering(true)
+
+		if includeOffscreen {
+			c.logger.Debug(
+				"strict filtering requires includeOutOfBounds=false, overriding user preference",
+				zap.String("bundle_id", bundleID),
+			)
+		}
+
 		opts.SetIncludeOutOfBounds(false) // strict filtering requires bound checks to be active
 	}
 

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -3,6 +3,7 @@ package accessibility
 import (
 	"fmt"
 	"image"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -90,6 +91,12 @@ func (c *InfraAXClient) ClickableNodes(
 	opts.SetCache(c.cache)
 	opts.SetIncludeOutOfBounds(includeOffscreen)
 
+	// Enable strict filtering for Chromium/Electron apps which have noisy DOM trees
+	bundleID := element.BundleIdentifier()
+	if isLikelyChromiumOrElectron(bundleID) {
+		opts.SetStrictFiltering(true)
+	}
+
 	if cfg := currentConfig(c.configProvider); cfg != nil {
 		opts.SetMaxDepth(cfg.Hints.MaxDepth)
 		opts.SetParallelThreshold(cfg.Hints.ParallelThreshold)
@@ -168,6 +175,7 @@ func (c *InfraAXClient) MenuBarClickableElements() ([]AXNode, error) {
 func (c *InfraAXClient) ClickableElementsFromBundleID(
 	bundleID string,
 	roles []string,
+	strictFiltering bool,
 ) ([]AXNode, error) {
 	nodes, nodesErr := ClickableElementsFromBundleID(
 		bundleID,
@@ -175,6 +183,7 @@ func (c *InfraAXClient) ClickableElementsFromBundleID(
 		c.logger,
 		c.cache,
 		c.configProvider,
+		strictFiltering,
 	)
 	if nodesErr != nil {
 		return nil, derrors.Wrap(
@@ -421,4 +430,43 @@ func (n *InfraNode) Release() {
 	if n.node != nil && n.node.Element() != nil {
 		n.node.Element().Release()
 	}
+}
+
+// isLikelyChromiumOrElectron returns true if the bundle ID matches known Chromium/Electron apps.
+// This is duplicated from electron package to avoid import cycle.
+func isLikelyChromiumOrElectron(bundleID string) bool {
+	if bundleID == "" {
+		return false
+	}
+
+	lower := strings.ToLower(bundleID)
+
+	chromiumBundles := []string{
+		"net.imput.helium",
+		"com.google.Chrome",
+		"com.brave.Browser",
+		"company.thebrowser.Browser",
+	}
+
+	electronBundles := []string{
+		"com.microsoft.VSCode",
+		"com.exafunction.windsurf",
+		"com.tinyspeck.slackmacgap",
+		"com.spotify.client",
+		"md.obsidian",
+	}
+
+	for _, b := range chromiumBundles {
+		if strings.EqualFold(b, lower) {
+			return true
+		}
+	}
+
+	for _, b := range electronBundles {
+		if strings.EqualFold(b, lower) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -96,6 +96,7 @@ func (c *InfraAXClient) ClickableNodes(
 	if isLikelyChromiumOrElectron(bundleID) ||
 		isUserConfiguredChromiumElectron(bundleID, c.configProvider) {
 		opts.SetStrictFiltering(true)
+		opts.SetIncludeOutOfBounds(false) // strict filtering requires bound checks to be active
 	}
 
 	if cfg := currentConfig(c.configProvider); cfg != nil {

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -441,16 +441,14 @@ func isLikelyChromiumOrElectron(bundleID string) bool {
 		return false
 	}
 
-	lower := strings.ToLower(bundleID)
-
 	for _, b := range config.KnownChromiumBundles {
-		if strings.EqualFold(b, lower) {
+		if strings.EqualFold(b, bundleID) {
 			return true
 		}
 	}
 
 	for _, b := range config.KnownElectronBundles {
-		if strings.EqualFold(b, lower) {
+		if strings.EqualFold(b, bundleID) {
 			return true
 		}
 	}

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -98,7 +98,7 @@ func (c *InfraAXClient) ClickableNodes(
 		opts.SetStrictFiltering(true)
 
 		if includeOffscreen {
-			c.logger.Debug(
+			c.logger.Warn(
 				"strict filtering requires includeOutOfBounds=false, overriding user preference",
 				zap.String("bundle_id", bundleID),
 			)

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -449,6 +449,8 @@ func isLikelyChromiumOrElectron(bundleID string) bool {
 		return false
 	}
 
+	bundleID = strings.TrimSpace(bundleID)
+
 	for _, b := range config.KnownChromiumBundles {
 		if strings.EqualFold(b, bundleID) {
 			return true

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -77,6 +77,7 @@ func (m *MockAXClient) MenuBarClickableElements() ([]AXNode, error) {
 func (m *MockAXClient) ClickableElementsFromBundleID(
 	bundleID string,
 	roles []string,
+	strictFiltering bool,
 ) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastCalledBundleID = bundleID

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -100,6 +100,10 @@ func ClickableElementsFromBundleID(
 	opts.SetIncludeOutOfBounds(true)
 	opts.SetStrictFiltering(strictFiltering)
 
+	if strictFiltering {
+		opts.SetIncludeOutOfBounds(false)
+	}
+
 	if cfg := currentConfig(configProvider); cfg != nil {
 		opts.SetMaxDepth(cfg.Hints.MaxDepth)
 		opts.SetParallelThreshold(cfg.Hints.ParallelThreshold)

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -81,6 +81,7 @@ func ClickableElementsFromBundleID(
 	logger *zap.Logger,
 	cache *InfoCache,
 	configProvider config.Provider,
+	strictFiltering bool,
 ) ([]*TreeNode, error) {
 	logger.Debug("Getting clickable elements for bundle ID",
 		zap.String("bundle_id", bundleID),
@@ -97,6 +98,7 @@ func ClickableElementsFromBundleID(
 	opts := DefaultTreeOptions(logger)
 	opts.SetCache(cache)
 	opts.SetIncludeOutOfBounds(true)
+	opts.SetStrictFiltering(strictFiltering)
 
 	if cfg := currentConfig(configProvider); cfg != nil {
 		opts.SetMaxDepth(cfg.Hints.MaxDepth)

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -97,12 +97,8 @@ func ClickableElementsFromBundleID(
 
 	opts := DefaultTreeOptions(logger)
 	opts.SetCache(cache)
-	opts.SetIncludeOutOfBounds(true)
 	opts.SetStrictFiltering(strictFiltering)
-
-	if strictFiltering {
-		opts.SetIncludeOutOfBounds(false)
-	}
+	opts.SetIncludeOutOfBounds(!strictFiltering)
 
 	if cfg := currentConfig(configProvider); cfg != nil {
 		opts.SetMaxDepth(cfg.Hints.MaxDepth)

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -148,6 +148,7 @@ type TreeOptions struct {
 	maxDepth           int
 	logger             *zap.Logger
 	stats              *treeStats
+	strictFiltering    bool // Apply strict filtering for Chromium/Electron DOM trees
 }
 
 // FilterFunc returns the filter function.
@@ -190,6 +191,11 @@ func (o *TreeOptions) Stats() *treeStats {
 	return o.stats
 }
 
+// StrictFiltering returns whether strict filtering is enabled for Chromium/Electron.
+func (o *TreeOptions) StrictFiltering() bool {
+	return o.strictFiltering
+}
+
 // SetFilterFunc sets the filter function.
 func (o *TreeOptions) SetFilterFunc(fn func(*ElementInfo) bool) {
 	o.filterFunc = fn
@@ -213,6 +219,11 @@ func (o *TreeOptions) SetMaxDepth(depth int) {
 // SetParallelThreshold sets the threshold for parallel child processing.
 func (o *TreeOptions) SetParallelThreshold(threshold int) {
 	o.parallelThreshold = threshold
+}
+
+// SetStrictFiltering sets whether to apply strict filtering for Chromium/Electron DOM trees.
+func (o *TreeOptions) SetStrictFiltering(strict bool) {
+	o.strictFiltering = strict
 }
 
 // DefaultTreeOptions returns default tree traversal options.
@@ -575,6 +586,11 @@ func buildChildrenParallel(
 	}
 }
 
+// minElementSize is the minimum size threshold for elements.
+// Elements smaller than this are filtered out as noise (especially in Chromium DOM trees).
+// This matches similar filtering in tools like Glyphlow.
+const minElementSize = 15
+
 // shouldIncludeElement combines all filtering logic into one function.
 func shouldIncludeElement(
 	info *ElementInfo,
@@ -591,8 +607,31 @@ func shouldIncludeElement(
 			}
 		}
 
-		// For non-zero sized elements, check if they overlap with window bounds
-		if elementRect.Dx() > 0 && elementRect.Dy() > 0 {
+		// Strict filtering: only apply for Chromium/Electron apps with noisy DOM trees
+		// For native apps like Safari, we trust the semantic tree to not have noise
+		if opts.strictFiltering && elementRect.Dx() > 0 && elementRect.Dy() > 0 {
+			// Filter out tiny elements that are likely noise in Chromium DOM trees.
+			// This is especially important for web content where the DOM can have
+			// thousands of tiny placeholder/structure elements.
+			// Filter if either dimension is too small (not just both)
+			if elementRect.Dx() < minElementSize || elementRect.Dy() < minElementSize {
+				// Only filter if it's not a known important role
+				if !interactiveLeafRoles[info.Role()] && info.Role() != "AXLink" {
+					return false
+				}
+			}
+
+			// Filter elements whose center is outside window bounds (overflowing elements)
+			halfWidth := elementRect.Dx() / 2  //nolint:mnd
+			halfHeight := elementRect.Dy() / 2 //nolint:mnd
+			centerX := elementRect.Min.X + halfWidth
+			centerY := elementRect.Min.Y + halfHeight
+			if centerX < windowBounds.Min.X || centerX > windowBounds.Max.X ||
+				centerY < windowBounds.Min.Y || centerY > windowBounds.Max.Y {
+				return false
+			}
+		} else if elementRect.Dx() > 0 && elementRect.Dy() > 0 {
+			// For non-strict filtering, only check basic overlap
 			if !elementRect.Overlaps(windowBounds) {
 				return false
 			}

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -616,7 +616,7 @@ func shouldIncludeElement(
 			// Filter if either dimension is too small (not just both)
 			if elementRect.Dx() < minElementSize || elementRect.Dy() < minElementSize {
 				// Only filter if it's not a known important role
-				if !interactiveLeafRoles[info.Role()] && info.Role() != "AXLink" {
+				if !interactiveLeafRoles[info.Role()] {
 					return false
 				}
 			}

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -622,13 +622,16 @@ func shouldIncludeElement(
 			}
 
 			// Filter elements whose center is outside window bounds (overflowing elements)
+			// But keep interactive roles (buttons, links, etc.) even if at edges
 			halfWidth := elementRect.Dx() / 2  //nolint:mnd
 			halfHeight := elementRect.Dy() / 2 //nolint:mnd
 			centerX := elementRect.Min.X + halfWidth
 			centerY := elementRect.Min.Y + halfHeight
 			if centerX < windowBounds.Min.X || centerX > windowBounds.Max.X ||
 				centerY < windowBounds.Min.Y || centerY > windowBounds.Max.Y {
-				return false
+				if !interactiveLeafRoles[info.Role()] {
+					return false
+				}
 			}
 		} else if elementRect.Dx() > 0 && elementRect.Dy() > 0 {
 			// For non-strict filtering, only check basic overlap

--- a/internal/core/infra/accessibility/tree_linux.go
+++ b/internal/core/infra/accessibility/tree_linux.go
@@ -58,6 +58,9 @@ func (o *TreeOptions) SetMaxDepth(depth int) {}
 // SetParallelThreshold is a Linux stub.
 func (o *TreeOptions) SetParallelThreshold(threshold int) {}
 
+// SetStrictFiltering is a Linux stub.
+func (o *TreeOptions) SetStrictFiltering(strict bool) {}
+
 // BuildTree builds the accessibility tree for the specified root element (Linux stub).
 func BuildTree(_ *Element, _ TreeOptions) (*TreeNode, error) {
 	return &TreeNode{}, nil

--- a/internal/core/infra/accessibility/tree_windows.go
+++ b/internal/core/infra/accessibility/tree_windows.go
@@ -58,6 +58,9 @@ func (o *TreeOptions) SetMaxDepth(depth int) {}
 // SetParallelThreshold is a Windows stub.
 func (o *TreeOptions) SetParallelThreshold(threshold int) {}
 
+// SetStrictFiltering is a Windows stub.
+func (o *TreeOptions) SetStrictFiltering(strict bool) {}
+
 // BuildTree builds the accessibility tree for the specified root element (Windows stub).
 func BuildTree(_ *Element, _ TreeOptions) (*TreeNode, error) {
 	return &TreeNode{}, nil

--- a/internal/core/infra/electron/electron.go
+++ b/internal/core/infra/electron/electron.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/infra/accessibility"
 )
 
@@ -194,7 +195,7 @@ func ShouldEnableElectronSupport(bundleID string, additionalBundles []string) bo
 		return false
 	}
 
-	if matchesAdditionalBundle(bundleID, additionalBundles) {
+	if config.MatchesAdditionalBundle(bundleID, additionalBundles) {
 		return true
 	}
 
@@ -210,7 +211,7 @@ func ShouldEnableChromiumSupport(bundleID string, additionalBundles []string) bo
 		return false
 	}
 
-	if matchesAdditionalBundle(bundleID, additionalBundles) {
+	if config.MatchesAdditionalBundle(bundleID, additionalBundles) {
 		return true
 	}
 
@@ -226,7 +227,7 @@ func ShouldEnableFirefoxSupport(bundleID string, additionalBundles []string) boo
 		return false
 	}
 
-	if matchesAdditionalBundle(bundleID, additionalBundles) {
+	if config.MatchesAdditionalBundle(bundleID, additionalBundles) {
 		return true
 	}
 
@@ -279,32 +280,6 @@ func IsLikelyFirefoxBundle(bundleID string) bool {
 
 	for _, exact := range KnownFirefoxBundles {
 		if strings.EqualFold(strings.TrimSpace(exact), lower) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// matchesAdditionalBundle checks if a bundle ID matches any user-provided additional bundles.
-// It supports both exact matches and wildcard patterns (ending with *).
-func matchesAdditionalBundle(bundleID string, additionalBundles []string) bool {
-	if len(additionalBundles) == 0 {
-		return false
-	}
-
-	lower := strings.ToLower(strings.TrimSpace(bundleID))
-	for _, candidate := range additionalBundles {
-		trimmed := strings.ToLower(strings.TrimSpace(candidate))
-		if trimmed == "" {
-			continue
-		}
-
-		if prefix, found := strings.CutSuffix(trimmed, "*"); found {
-			if strings.HasPrefix(lower, prefix) {
-				return true
-			}
-		} else if lower == trimmed {
 			return true
 		}
 	}

--- a/internal/core/infra/electron/electron.go
+++ b/internal/core/infra/electron/electron.go
@@ -125,17 +125,19 @@ func ensureAccessibility(
 	// Try setting AXManualAccessibility first - this is the preferred method for newer Electron/Chromium
 	// versions as it doesn't have the "screen reader active" side effects.
 	// Ref: https://github.com/electron/electron/issues/7206
-	_ = platformSetApplicationAttribute(pid, electronAttributeName, true)
+	amaSuccess := platformSetApplicationAttribute(pid, electronAttributeName, true)
 
 	// Also set AXEnhancedUserInterface - this is the classic way to enable accessibility
 	// and is needed for older Chromium versions.
-	success := platformSetApplicationAttribute(pid, enhancedAttributeName, true)
+	euiSuccess := platformSetApplicationAttribute(pid, enhancedAttributeName, true)
 
-	if !success {
-		logger.Warn("Failed to enable AXEnhancedUserInterface", zap.String("bundle_id", bundleID))
+	if !amaSuccess && !euiSuccess {
+		logger.Warn("Failed to enable accessibility attributes", zap.String("bundle_id", bundleID))
+
+		return false
 	}
 
-	// Mark as enabled even if only one succeeded, to avoid retrying
+	// Mark as enabled only if at least one succeeded, to avoid retrying failed attempts
 	pidsMu.Lock()
 
 	enabledPIDs[pid] = struct{}{}

--- a/internal/core/infra/electron/electron.go
+++ b/internal/core/infra/electron/electron.go
@@ -122,14 +122,20 @@ func ensureAccessibility(
 		return true
 	}
 
+	// Try setting AXManualAccessibility first - this is the preferred method for newer Electron/Chromium
+	// versions as it doesn't have the "screen reader active" side effects.
+	// Ref: https://github.com/electron/electron/issues/7206
+	_ = platformSetApplicationAttribute(pid, electronAttributeName, true)
+
+	// Also set AXEnhancedUserInterface - this is the classic way to enable accessibility
+	// and is needed for older Chromium versions.
 	success := platformSetApplicationAttribute(pid, enhancedAttributeName, true)
 
 	if !success {
 		logger.Warn("Failed to enable AXEnhancedUserInterface", zap.String("bundle_id", bundleID))
-
-		return false
 	}
 
+	// Mark as enabled even if only one succeeded, to avoid retrying
 	pidsMu.Lock()
 
 	enabledPIDs[pid] = struct{}{}

--- a/internal/core/infra/electron/electron.go
+++ b/internal/core/infra/electron/electron.go
@@ -161,15 +161,6 @@ func EnsureFirefoxAccessibility(bundleID string, logger *zap.Logger) bool {
 	return ensureAccessibility(bundleID, firefoxEnabledPIDs, &firefoxPIDsMu, logger)
 }
 
-// KnownChromiumBundles is an alias to config.KnownChromiumBundles for backward compatibility.
-var KnownChromiumBundles = config.KnownChromiumBundles
-
-// KnownFirefoxBundles is an alias to config.KnownFirefoxBundles for backward compatibility.
-var KnownFirefoxBundles = config.KnownFirefoxBundles
-
-// KnownElectronBundles is an alias to config.KnownElectronBundles for backward compatibility.
-var KnownElectronBundles = config.KnownElectronBundles
-
 // ShouldEnableElectronSupport determines if the provided bundle identifier
 // should have Electron accessibility manually toggled based on defaults and
 // user-specified overrides.
@@ -227,7 +218,7 @@ func IsLikelyElectronBundle(bundleID string) bool {
 		return false
 	}
 
-	for _, exact := range KnownElectronBundles {
+	for _, exact := range config.KnownElectronBundles {
 		if strings.EqualFold(strings.TrimSpace(exact), lower) {
 			return true
 		}
@@ -244,7 +235,7 @@ func IsLikelyChromiumBundle(bundleID string) bool {
 		return false
 	}
 
-	for _, exact := range KnownChromiumBundles {
+	for _, exact := range config.KnownChromiumBundles {
 		if strings.EqualFold(strings.TrimSpace(exact), lower) {
 			return true
 		}
@@ -261,7 +252,7 @@ func IsLikelyFirefoxBundle(bundleID string) bool {
 		return false
 	}
 
-	for _, exact := range KnownFirefoxBundles {
+	for _, exact := range config.KnownFirefoxBundles {
 		if strings.EqualFold(strings.TrimSpace(exact), lower) {
 			return true
 		}

--- a/internal/core/infra/electron/electron.go
+++ b/internal/core/infra/electron/electron.go
@@ -81,13 +81,15 @@ func EnsureElectronAccessibility(bundleID string, logger *zap.Logger) bool {
 	return true
 }
 
-// ensureAccessibility enables AXEnhancedUserInterface for the specified application.
+// ensureAccessibility enables accessibility attributes for the specified application.
 // This is a generic function used by both Chromium and Firefox accessibility enablers.
+// setManualAccessibility controls whether to also set AXManualAccessibility (Electron/Chromium only).
 func ensureAccessibility(
 	bundleID string,
 	enabledPIDs map[int]struct{},
 	pidsMu *sync.Mutex,
 	logger *zap.Logger,
+	setManualAccessibility bool,
 ) bool {
 	if logger == nil {
 		logger = zap.NewNop()
@@ -123,11 +125,14 @@ func ensureAccessibility(
 		return true
 	}
 
-	// Try setting AXManualAccessibility first - this is the preferred method for newer Electron/Chromium
-	// versions as it doesn't have the "screen reader active" side effects.
-	// For Firefox this is typically a no-op but we attempt it for consistency.
+	// Set AXManualAccessibility for Electron/Chromium apps (not for Firefox).
+	// This is the preferred method for newer Electron/Chromium versions as it doesn't
+	// have the "screen reader active" side effects.
 	// Ref: https://github.com/electron/electron/issues/7206
-	amaSuccess := platformSetApplicationAttribute(pid, electronAttributeName, true)
+	var amaSuccess bool
+	if setManualAccessibility {
+		amaSuccess = platformSetApplicationAttribute(pid, electronAttributeName, true)
+	}
 
 	// Also set AXEnhancedUserInterface - this is the classic way to enable accessibility
 	// and is needed for older Chromium versions / Firefox.
@@ -152,13 +157,13 @@ func ensureAccessibility(
 // EnsureChromiumAccessibility enables AXEnhancedUserInterface for Chromium-based applications.
 // This improves accessibility support for Chromium browsers and applications.
 func EnsureChromiumAccessibility(bundleID string, logger *zap.Logger) bool {
-	return ensureAccessibility(bundleID, chromiumEnabledPIDs, &chromiumPIDsMu, logger)
+	return ensureAccessibility(bundleID, chromiumEnabledPIDs, &chromiumPIDsMu, logger, true)
 }
 
 // EnsureFirefoxAccessibility enables AXEnhancedUserInterface for Firefox-based applications.
 // This improves accessibility support for Firefox browsers and applications.
 func EnsureFirefoxAccessibility(bundleID string, logger *zap.Logger) bool {
-	return ensureAccessibility(bundleID, firefoxEnabledPIDs, &firefoxPIDsMu, logger)
+	return ensureAccessibility(bundleID, firefoxEnabledPIDs, &firefoxPIDsMu, logger, false)
 }
 
 // ShouldEnableElectronSupport determines if the provided bundle identifier

--- a/internal/core/infra/electron/electron.go
+++ b/internal/core/infra/electron/electron.go
@@ -125,11 +125,12 @@ func ensureAccessibility(
 
 	// Try setting AXManualAccessibility first - this is the preferred method for newer Electron/Chromium
 	// versions as it doesn't have the "screen reader active" side effects.
+	// For Firefox this is typically a no-op but we attempt it for consistency.
 	// Ref: https://github.com/electron/electron/issues/7206
 	amaSuccess := platformSetApplicationAttribute(pid, electronAttributeName, true)
 
 	// Also set AXEnhancedUserInterface - this is the classic way to enable accessibility
-	// and is needed for older Chromium versions.
+	// and is needed for older Chromium versions / Firefox.
 	euiSuccess := platformSetApplicationAttribute(pid, enhancedAttributeName, true)
 
 	if !amaSuccess && !euiSuccess {

--- a/internal/core/infra/electron/electron.go
+++ b/internal/core/infra/electron/electron.go
@@ -161,32 +161,14 @@ func EnsureFirefoxAccessibility(bundleID string, logger *zap.Logger) bool {
 	return ensureAccessibility(bundleID, firefoxEnabledPIDs, &firefoxPIDsMu, logger)
 }
 
-// KnownChromiumBundles contains known Chromium-based application bundle identifiers.
-// These applications benefit from AXEnhancedUserInterface accessibility improvements.
-var KnownChromiumBundles = []string{
-	"net.imput.helium",
-	"com.google.Chrome",
-	"com.brave.Browser",
-	"company.thebrowser.Browser",
-}
+// KnownChromiumBundles is an alias to config.KnownChromiumBundles for backward compatibility.
+var KnownChromiumBundles = config.KnownChromiumBundles
 
-// KnownFirefoxBundles contains known Firefox-based application bundle identifiers.
-// These applications benefit from AXEnhancedUserInterface accessibility improvements.
-var KnownFirefoxBundles = []string{
-	"org.mozilla.firefox",
-	"app.zen-browser.zen",
-}
+// KnownFirefoxBundles is an alias to config.KnownFirefoxBundles for backward compatibility.
+var KnownFirefoxBundles = config.KnownFirefoxBundles
 
-// KnownElectronBundles contains known Electron-based application bundle identifiers.
-// These applications require manual accessibility attribute toggling to work properly.
-var KnownElectronBundles = []string{
-	// electrons
-	"com.microsoft.VSCode",
-	"com.exafunction.windsurf",
-	"com.tinyspeck.slackmacgap",
-	"com.spotify.client",
-	"md.obsidian",
-}
+// KnownElectronBundles is an alias to config.KnownElectronBundles for backward compatibility.
+var KnownElectronBundles = config.KnownElectronBundles
 
 // ShouldEnableElectronSupport determines if the provided bundle identifier
 // should have Electron accessibility manually toggled based on defaults and


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds conditional strict filtering that only applies to Chromium/Electron apps:

1. Filters elements smaller than 15px in either dimension (DOM noise)
2. Filters elements whose center is outside window bounds (overflowing elements)
3. Adds `AXManualAccessibility` attribute alongside `AXEnhancedUserInterface` for better browser support, probably...

Tested on [this long page as benchmark](https://nix-darwin.github.io/nix-darwin/manual/)

Pre-PR:

- Safari - around 40 elements
- Brave - around 1200+ elements

Post-PR:

- Safari - around 40 elements
- Brave - around 40 elements

Neru should now be extremely fast in handling hints on long pages.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/b1e6bfe7-bafe-429c-bc5d-5ffdc0cbada6

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->
