### PR TITLE
fix: ensure global hotkeys are canonicalized before event tap registration

### DIFF
--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -22,15 +22,15 @@ import (
 )
 
 // initializeLogger initializes the application logger with the given configuration.
-func initializeLogger(config *config.Config) (*zap.Logger, error) {
+func initializeLogger(cfg *config.Config) (*zap.Logger, error) {
 	initConfigErr := logger.Init(
-		config.Logging.LogLevel,
-		config.Logging.LogFile,
-		config.Logging.StructuredLogging,
-		config.Logging.DisableFileLogging,
-		config.Logging.MaxFileSize,
-		config.Logging.MaxBackups,
-		config.Logging.MaxAge,
+		cfg.Logging.LogLevel,
+		cfg.Logging.LogFile,
+		cfg.Logging.StructuredLogging,
+		cfg.Logging.DisableFileLogging,
+		cfg.Logging.MaxFileSize,
+		cfg.Logging.MaxBackups,
+		cfg.Logging.MaxAge,
 		nil,
 	)
 	if initConfigErr != nil {
@@ -189,9 +189,9 @@ func initializeServices(
 }
 
 // processHotkeyBindings processes and filters hotkey bindings from configuration.
-func processHotkeyBindings(config *config.Config, logger *zap.Logger) []string {
-	keys := make([]string, 0, len(config.Hotkeys.Bindings))
-	for key, actions := range config.Hotkeys.Bindings {
+func processHotkeyBindings(cfg *config.Config, logger *zap.Logger) []string {
+	keys := make([]string, 0, len(cfg.Hotkeys.Bindings))
+	for key, actions := range cfg.Hotkeys.Bindings {
 		// Skip empty keys or empty action arrays
 		if strings.TrimSpace(key) == "" || len(actions) == 0 {
 			logger.Warn(
@@ -203,19 +203,21 @@ func processHotkeyBindings(config *config.Config, logger *zap.Logger) []string {
 			continue
 		}
 
-		if actionsReferenceDisabledMode(actions, config) {
+		if actionsReferenceDisabledMode(actions, cfg) {
 			continue
 		}
 
-		keys = append(keys, key)
+		// Canonicalize the key to convert "Primary" to platform-specific modifier ("Cmd" on macOS)
+		canonicalKey := config.CanonicalHotkeyForPlatform(key)
+		keys = append(keys, canonicalKey)
 	}
 
 	return keys
 }
 
 // configureEventTapHotkeys configures the event tap with hotkeys from the configuration.
-func (a *App) configureEventTapHotkeys(config *config.Config, logger *zap.Logger) {
-	layoutID := strings.TrimSpace(config.General.KBLayoutToUse)
+func (a *App) configureEventTapHotkeys(cfg *config.Config, logger *zap.Logger) {
+	layoutID := strings.TrimSpace(cfg.General.KBLayoutToUse)
 
 	layoutResolved := a.eventTap.SetKeyboardLayout(layoutID)
 	if layoutID != "" && !layoutResolved {
@@ -223,7 +225,7 @@ func (a *App) configureEventTapHotkeys(config *config.Config, logger *zap.Logger
 			zap.String("layout_id", layoutID))
 	}
 
-	keys := processHotkeyBindings(config, logger)
+	keys := processHotkeyBindings(cfg, logger)
 
 	// Log hotkey registration status
 	if len(keys) == 0 {

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -191,7 +191,8 @@ func findHotkeyMatch(
 	normalizedKey string,
 ) (string, []string, bool) {
 	for bindKey, actions := range hotkeys {
-		if config.NormalizeKeyForComparison(bindKey) == normalizedKey {
+		normalizedBindKey := config.NormalizeKeyForComparison(bindKey)
+		if normalizedBindKey == normalizedKey {
 			return bindKey, actions, true
 		}
 	}

--- a/internal/app/modes/passthrough.go
+++ b/internal/app/modes/passthrough.go
@@ -97,7 +97,7 @@ func (h *Handler) modeModifierKeys(mode domain.Mode, bundleID string) []string {
 
 		seen[normalized] = struct{}{}
 
-		keys = append(keys, trimmed)
+		keys = append(keys, normalized)
 	}
 
 	// Append hotkey keys for the current mode so the event tap

--- a/internal/app/modes/passthrough.go
+++ b/internal/app/modes/passthrough.go
@@ -43,7 +43,7 @@ func (h *Handler) syncModifierPassthrough(mode domain.Mode) {
 			// so the event tap consumes them instead of passing them through.
 			hotkeys := h.config.HotkeysForModeAndApp(domain.ModeString(mode), bundleID)
 			for key := range hotkeys {
-				blacklist = append(blacklist, key)
+				blacklist = append(blacklist, configpkg.NormalizeKeyForComparison(key))
 			}
 		}
 

--- a/internal/app/modes/passthrough_test.go
+++ b/internal/app/modes/passthrough_test.go
@@ -23,7 +23,7 @@ func TestModeModifierKeys_HintsIncludesModifierHotkeys(t *testing.T) {
 	handler := &Handler{config: cfg}
 
 	got := handler.modeModifierKeys(domain.ModeHints, "")
-	want := []string{"Alt+K", "Cmd+L"}
+	want := []string{"alt+k", "cmd+l"}
 
 	if !slices.Equal(got, want) {
 		t.Fatalf("modeModifierKeys(ModeHints) = %v, want %v", got, want)
@@ -42,7 +42,7 @@ func TestModeModifierKeys_ScrollIncludesOnlyModifierHotkeys(t *testing.T) {
 	handler := &Handler{config: cfg}
 
 	got := handler.modeModifierKeys(domain.ModeScroll, "")
-	want := []string{"Cmd+Down", "Cmd+Up"}
+	want := []string{"cmd+down", "cmd+up"}
 
 	if !slices.Equal(got, want) {
 		t.Fatalf("modeModifierKeys(ModeScroll) = %v, want %v", got, want)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes a bug where certain modifier combinations in global hotkeys would not work correctly when used in navigation modes.

The root cause was that global hotkeys using modifier aliases (e.g., Primary+Shift+G for Grid mode) were being registered with the event tap without converting the alias to the platform-specific modifier. The event tap didn't recognize "Primary" as a modifier, causing it to be misinterpreted with incorrect modifiers. This created a collision where the event tap would intercept and pass through key events that shouldn't be intercepted, breaking mode-specific hotkey handling.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #751

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/36d87976-ca47-43c1-b020-11296271904a

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->
