### PR TITLE
fix: ensure eventtap and passthrough blacklist resolves the same

### DIFF
--- a/internal/app/modes/passthrough.go
+++ b/internal/app/modes/passthrough.go
@@ -43,7 +43,7 @@ func (h *Handler) syncModifierPassthrough(mode domain.Mode) {
 			// so the event tap consumes them instead of passing them through.
 			hotkeys := h.config.HotkeysForModeAndApp(domain.ModeString(mode), bundleID)
 			for key := range hotkeys {
-				blacklist = append(blacklist, configpkg.NormalizeKeyForComparison(key))
+				blacklist = append(blacklist, configpkg.CanonicalHotkeyForPlatform(key))
 			}
 		}
 
@@ -90,7 +90,7 @@ func (h *Handler) modeModifierKeys(mode domain.Mode, bundleID string) []string {
 			return
 		}
 
-		normalized := configpkg.NormalizeKeyForComparison(trimmed)
+		normalized := configpkg.CanonicalHotkeyForPlatform(trimmed)
 		if _, exists := seen[normalized]; exists {
 			return
 		}

--- a/internal/app/modes/passthrough_test.go
+++ b/internal/app/modes/passthrough_test.go
@@ -23,7 +23,7 @@ func TestModeModifierKeys_HintsIncludesModifierHotkeys(t *testing.T) {
 	handler := &Handler{config: cfg}
 
 	got := handler.modeModifierKeys(domain.ModeHints, "")
-	want := []string{"alt+k", "cmd+l"}
+	want := []string{"Alt+K", "Cmd+L"}
 
 	if !slices.Equal(got, want) {
 		t.Fatalf("modeModifierKeys(ModeHints) = %v, want %v", got, want)
@@ -42,7 +42,7 @@ func TestModeModifierKeys_ScrollIncludesOnlyModifierHotkeys(t *testing.T) {
 	handler := &Handler{config: cfg}
 
 	got := handler.modeModifierKeys(domain.ModeScroll, "")
-	want := []string{"cmd+down", "cmd+up"}
+	want := []string{"Cmd+Down", "Cmd+Up"}
 
 	if !slices.Equal(got, want) {
 		t.Fatalf("modeModifierKeys(ModeScroll) = %v, want %v", got, want)

--- a/internal/app/modes/passthrough_test.go
+++ b/internal/app/modes/passthrough_test.go
@@ -23,7 +23,10 @@ func TestModeModifierKeys_HintsIncludesModifierHotkeys(t *testing.T) {
 	handler := &Handler{config: cfg}
 
 	got := handler.modeModifierKeys(domain.ModeHints, "")
-	want := []string{"Alt+K", "Cmd+L"}
+	want := []string{
+		config.CanonicalHotkeyForPlatform("Alt+K"),
+		config.CanonicalHotkeyForPlatform("Cmd+L"),
+	}
 
 	if !slices.Equal(got, want) {
 		t.Fatalf("modeModifierKeys(ModeHints) = %v, want %v", got, want)
@@ -42,7 +45,10 @@ func TestModeModifierKeys_ScrollIncludesOnlyModifierHotkeys(t *testing.T) {
 	handler := &Handler{config: cfg}
 
 	got := handler.modeModifierKeys(domain.ModeScroll, "")
-	want := []string{"Cmd+Down", "Cmd+Up"}
+	want := []string{
+		config.CanonicalHotkeyForPlatform("Cmd+Down"),
+		config.CanonicalHotkeyForPlatform("Cmd+Up"),
+	}
 
 	if !slices.Equal(got, want) {
 		t.Fatalf("modeModifierKeys(ModeScroll) = %v, want %v", got, want)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes a regression introduced in #752. We have to ensure the key formatting is consistent between them.

After the fix, configuration like this will work correctly:

```toml
[recursive_grid]
# ... config omitted

[recursive_grid.hotkeys]
# ... config omitted
"Ctrl+C" = "idle"
"Ctrl+J" = "action scroll_down"
"Ctrl+K" = "action scroll_up"
"Ctrl+H" = "action scroll_left"
"Ctrl+L" = "action scroll_right"
```

Previously, all the modifiers hotkeys were ignored and pass through directly to macOS.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
