### PR TITLE
fix: ditch `open` and purely run the binary for services

### DIFF
--- a/internal/cli/services_darwin.go
+++ b/internal/cli/services_darwin.go
@@ -197,7 +197,7 @@ func stopService() error {
 }
 
 func restartService() error {
-	// Stop the service and the Neru app process.
+	// Stop the service.
 	_ = stopService()
 
 	// Always attempt to start

--- a/internal/cli/services_darwin.go
+++ b/internal/cli/services_darwin.go
@@ -10,10 +10,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"syscall"
-	"time"
 )
 
 const (
@@ -22,49 +19,7 @@ const (
 	plistFile       = launchAgentsDir + "/" + serviceLabel + ".plist"
 )
 
-// plistTemplateAppBundle is used when the binary is inside a .app bundle.
-// It launches via /usr/bin/open so macOS associates accessibility permissions
-// with the app bundle rather than the raw binary.
-const plistTemplateAppBundle = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>com.y3owk1n.neru</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>/usr/bin/open</string>
-        <string>-W</string>
-        <string>-a</string>
-        <string>NERU_APP_PATH</string>
-        <string>--args</string>
-        <string>launch</string>
-    </array>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>KeepAlive</key>
-    <true/>
-    <key>StandardErrorPath</key>
-    <string>/tmp/neru.err.log</string>
-    <key>ProcessType</key>
-    <string>Interactive</string>
-    <key>LimitLoadToSessionType</key>
-    <string>Aqua</string>
-    <key>Nice</key>
-    <integer>-10</integer>
-    <key>ThrottleInterval</key>
-    <integer>10</integer>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-    </dict>
-</dict>
-</plist>`
-
-// plistTemplateBinary is used when the binary is a standalone executable
-// (not inside a .app bundle). It invokes the binary directly.
-const plistTemplateBinary = `<?xml version="1.0" encoding="UTF-8"?>
+const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -115,44 +70,6 @@ func getBinaryPath() (string, error) {
 	return filepath.EvalSymlinks(execPath)
 }
 
-// findAppBundle locates a Neru.app bundle relative to the resolved binary path.
-// It checks two locations:
-//  1. The binary is inside the bundle: <prefix>/Neru.app/Contents/MacOS/neru
-//     → walk up 3 levels.
-//  2. The binary is a sibling: <prefix>/bin/neru with the bundle at
-//     <prefix>/Applications/Neru.app (typical Nix / Homebrew layout).
-//
-// Returns the .app path and true if a valid bundle is found, or ("", false).
-func findAppBundle(binPath string) (string, bool) {
-	// Case 1: binary lives inside the .app bundle.
-	ancestor := filepath.Dir(filepath.Dir(filepath.Dir(binPath)))
-	if strings.HasSuffix(ancestor, ".app") && isValidAppBundle(ancestor) {
-		return ancestor, true
-	}
-
-	// Case 2: binary is at <prefix>/bin/neru; bundle is at <prefix>/Applications/Neru.app.
-	prefix := filepath.Dir(filepath.Dir(binPath)) // <prefix>/bin/neru → <prefix>
-
-	sibling := filepath.Join(prefix, "Applications", "Neru.app")
-	if isValidAppBundle(sibling) {
-		return sibling, true
-	}
-
-	return "", false
-}
-
-// isValidAppBundle returns true when path ends with ".app" and contains
-// a Contents/MacOS directory.
-func isValidAppBundle(path string) bool {
-	if !strings.HasSuffix(path, ".app") {
-		return false
-	}
-
-	info, err := os.Stat(filepath.Join(path, "Contents", "MacOS"))
-
-	return err == nil && info.IsDir()
-}
-
 func isServiceLoaded() bool {
 	cmd := exec.CommandContext(context.Background(), "launchctl", "list", serviceLabel)
 
@@ -170,15 +87,7 @@ func installService() error {
 		return fmt.Errorf("failed to get binary path: %w", err)
 	}
 
-	// When an .app bundle is available, use `open -W -a` so macOS associates
-	// accessibility permissions with the bundle rather than the raw binary.
-	// Otherwise invoke the binary directly.
-	var plistContent string
-	if appPath, ok := findAppBundle(binPath); ok {
-		plistContent = strings.ReplaceAll(plistTemplateAppBundle, "NERU_APP_PATH", appPath)
-	} else {
-		plistContent = strings.ReplaceAll(plistTemplateBinary, "NERU_BINARY_PATH", binPath)
-	}
+	plistContent := strings.ReplaceAll(plistTemplate, "NERU_BINARY_PATH", binPath)
 
 	// Expand launchAgentsDir
 	expandedDir, err := expandPath(launchAgentsDir)
@@ -236,41 +145,6 @@ func installService() error {
 	return nil
 }
 
-// quitNeruApp gracefully terminates a running Neru app process.
-// When the service uses `open -W -a`, launchd only manages the `open` wrapper;
-// the actual Neru process is a separate Launch Services process that must be
-// stopped explicitly.
-func quitNeruApp() {
-	// Try graceful quit via osascript first (respects the app's shutdown handler).
-	quit := exec.CommandContext(context.Background(),
-		"osascript", "-e", `tell application "Neru" to quit`)
-	_ = quit.Run()
-
-	// Give the app a moment to shut down gracefully, then force-kill if needed.
-	time.Sleep(1 * time.Second)
-	killNeruProcesses()
-}
-
-// killNeruProcesses sends SIGTERM to all processes named "neru" except the
-// current process. This avoids the CLI killing itself when running commands
-// like `neru service stop` or `neru service uninstall`.
-func killNeruProcesses() {
-	out, err := exec.CommandContext(context.Background(), "pgrep", "-x", "neru").Output()
-	if err != nil {
-		return
-	}
-
-	self := os.Getpid()
-	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
-		pid, err := strconv.Atoi(strings.TrimSpace(line))
-		if err != nil || pid == self {
-			continue
-		}
-
-		_ = syscall.Kill(pid, syscall.SIGTERM)
-	}
-}
-
 func uninstallService() error {
 	expandedPlist, err := expandPath(plistFile)
 	if err != nil {
@@ -290,9 +164,6 @@ func uninstallService() error {
 		"gui/"+currentUser.Uid+"/"+serviceLabel,
 	)
 	_ = cmd.Run() // Ignore error if not loaded
-
-	// Ensure the Neru app process is also terminated (it may outlive `open -W`).
-	quitNeruApp()
 
 	// Remove plist
 	err = os.Remove(expandedPlist)
@@ -321,9 +192,6 @@ func stopService() error {
 	if err != nil {
 		return fmt.Errorf("failed to stop service: %w", err)
 	}
-
-	// Ensure the Neru app process is also terminated (it may outlive `open -W`).
-	quitNeruApp()
 
 	return nil
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR removes the bundle check that runs `open` for services. This makes it more consistent with our nix related launch agents implemenattion.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
