### PR TITLE
fix: always run alert UI regardless of binary or bundle

### DIFF
--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/app"
-	"github.com/y3owk1n/neru/internal/cli"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/infra/platform"
 )
@@ -103,10 +102,8 @@ func handleConfigValidationError(result *config.LoadResult) {
 	fmt.Fprintf(os.Stderr, "Config file: %s\n", cfgPath)
 	fmt.Fprintf(os.Stderr, "Please fix the configuration and relaunch Neru.\n")
 
-	if cli.IsRunningFromAppBundle() {
-		absPath, _ := filepath.Abs(cfgPath)
-		_ = platform.ShowConfigValidationErrorAlert(errMsg, absPath)
-	}
+	absPath, _ := filepath.Abs(cfgPath)
+	_ = platform.ShowConfigValidationErrorAlert(errMsg, absPath)
 
 	os.Exit(1)
 }
@@ -137,31 +134,25 @@ func handleConfigOnboarding(
 }
 
 func promptConfigInit(configPath string) bool {
-	if cli.IsRunningFromAppBundle() {
-		absPath, _ := filepath.Abs(configPath)
+	absPath, _ := filepath.Abs(configPath)
 
-		choice := platform.ShowConfigOnboardingAlert(absPath)
-		switch choice {
-		case platform.ConfigOnboardingCreate:
-			return true
-		case platform.ConfigOnboardingQuit:
-			os.Exit(0)
-		case platform.ConfigOnboardingDefaults:
-			return false
-		default:
-			fmt.Fprintf(
-				os.Stderr,
-				"Unexpected onboarding alert response (%d), continuing with defaults\n",
-				choice,
-			)
+	choice := platform.ShowConfigOnboardingAlert(absPath)
+	switch choice {
+	case platform.ConfigOnboardingCreate:
+		return true
+	case platform.ConfigOnboardingQuit:
+		os.Exit(0)
+	case platform.ConfigOnboardingDefaults:
+		return false
+	default:
+		fmt.Fprintf(
+			os.Stderr,
+			"Unexpected onboarding alert response (%d), continuing with defaults\n",
+			choice,
+		)
 
-			return false
-		}
+		return false
 	}
-
-	fmt.Fprintf(os.Stderr, "No config file found. Create one with: neru config init\n")
-
-	os.Exit(1)
 
 	return false
 }
@@ -172,20 +163,6 @@ func handleAccessibilityPermissionStartup(cfg *config.Config) {
 	}
 
 	if platform.CheckAccessibilityPermissions() {
-		return
-	}
-
-	if !cli.IsRunningFromAppBundle() {
-		fmt.Fprintf(os.Stderr, "⚠️  Accessibility permission not granted.\n")
-		fmt.Fprintf(
-			os.Stderr,
-			"Grant Neru access in System Settings → Privacy & Security → Accessibility.\n",
-		)
-		fmt.Fprintf(
-			os.Stderr,
-			"Launch Neru from the app bundle for the guided permission prompt.\n",
-		)
-
 		return
 	}
 

--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -94,7 +94,7 @@ func LaunchDaemon(configPath string) {
 }
 
 // handleConfigValidationError shows a validation error and exits.
-// From an app bundle it displays a native alert; from a terminal it prints to stderr.
+// Always displays a native alert (on supported platforms) in addition to printing to stderr.
 func handleConfigValidationError(result *config.LoadResult) {
 	errMsg := result.ValidationError.Error()
 	cfgPath := result.ConfigPath


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR removes the bundle/cli check that previously will just print on console if running via cli. Alerts are not something that specifically requires bundle or not, so I think this is not really needed.

Showing alerts on GUI provides a better UX too. And also ensure that when using it with `services` without direct access to the console, things are not hidden behind the scene.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
