### PR TITLE
feat: add `sleep` action for reliability

### DIFF
--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -46,7 +46,7 @@ ignore_clickable_check = false
 # ignore_clickable_check = false
 #
 # [hints.app_configs.hotkeys]
-# "Return" = ["action left_click", "exec sleep 3.5", "hints"]
+# "Return" = ["action left_click", "action sleep 3.5", "hints"]
 
 [hints.additional_ax_support]
 enable = true

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -385,6 +385,28 @@ Supported key names:
 
 Linux and Windows currently return a not-supported error for this command.
 
+### Sleep
+
+The `sleep` action pauses action execution for a specified duration. This is useful in hotkey arrays to add delays between actions, allowing the target app time to process events:
+
+```
+neru action sleep 0.2          # Sleep for 0.2 seconds
+neru action sleep 500ms        # Sleep for 500 milliseconds
+neru action sleep 1.5s        # Sleep for 1.5 seconds
+```
+
+In config hotkey arrays:
+
+```
+"Return" = ["action left_click", "action sleep 0.2", "hints"]
+```
+
+Valid duration formats:
+- Plain numbers are seconds: `0.2`, `1`, `2.5`
+- Explicit unit: `100ms`, `500ms`, `1s`, `2s`
+
+This runs synchronously in Neru's action pipeline, unlike `exec sleep` which spawns a subprocess with unreliable timing.
+
 ### Mode-Aware Actions
 
 These actions depend on the current mode and are primarily useful inside `hotkeys` arrays.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -183,7 +183,7 @@ To remove a single default binding, use `__disabled__`:
 All actions from `[hotkeys]` work here, plus these mode-specific ones:
 
 - Mode commands: `idle`, `hints`, `grid`, `recursive_grid`, `scroll`
-- Action subcommands: `action left_click`, `action scroll_down`, `action feed`, `action reset`, `action backspace`, `action wait_for_mode_exit`, `action save_cursor_pos`, `action restore_cursor_pos`
+- Action subcommands: `action left_click`, `action scroll_down`, `action feed`, `action sleep`, `action reset`, `action backspace`, `action wait_for_mode_exit`, `action save_cursor_pos`, `action restore_cursor_pos`
 - Root toggle commands: `toggle-screen-share`, `toggle-cursor-follow-selection`
 - Shell commands: `exec ...`
 
@@ -199,7 +199,7 @@ All actions from `[hotkeys]` work here, plus these mode-specific ones:
 bundle_id = "net.imput.helium"
 
 [hints.app_configs.hotkeys]
-"Return" = ["action left_click", "exec sleep 0.8", "hints"]
+"Return" = ["action left_click", "action sleep 0.8", "hints"]
 "Shift+L" = "__disabled__"
 ```
 
@@ -271,8 +271,10 @@ multi-key sequences, and platform behavior.
 ```toml
 [hints.hotkeys]
 "Enter" = ["action save_cursor_pos", "idle", "action wait_for_mode_exit", "action restore_cursor_pos"]
-"Return" = ["action left_click", "exec sleep 0.5", "hints"]
+"Return" = ["action left_click", "action sleep 0.5", "hints"]
 ```
+
+See [CLI Usage: Feed Keys](CLI.md#feed-keys) for syntax and supported actions.
 
 ---
 

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -95,7 +95,7 @@ On some apps (e.g. Discord), it requires you to wait for a bit after clicking be
 ```toml
 [recursive_grid.hotkeys]
 # Click, sleep for a bit, and then only reset (that moves the cursor to center in recursive grid mode)
-"Ctrl+J" = ["action left_click", "exec sleep 0.05", "action reset"]
+"Ctrl+J" = ["action left_click", "action sleep 0.05", "action reset"]
 ```
 
 ## Target Menus Without Moving the Real Cursor
@@ -150,7 +150,7 @@ Some browser-like apps need a short delay after a click so the page content can 
 bundle_id = "net.imput.helium"
 
 [hints.app_configs.hotkeys]
-"Return" = ["action left_click", "exec sleep 0.8", "hints"]
+"Return" = ["action left_click", "action sleep 0.8", "hints"]
 "Shift+L" = "__disabled__"
 ```
 

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -588,15 +588,19 @@ func (h *IPCControllerActions) handleFeedAction(args []string) ipc.Response {
 }
 
 func (h *IPCControllerActions) handleSleepAction(args []string) ipc.Response {
-	var durationStr string
-
-	for _, arg := range args {
-		arg = strings.TrimSpace(arg)
+	durationStr := ""
+	for idx := 0; idx < len(args); idx++ {
+		arg := strings.TrimSpace(args[idx])
 		if after, ok := strings.CutPrefix(arg, "--duration="); ok {
 			durationStr = after
 		} else if arg == "--duration" {
-			continue
-		} else if !strings.HasPrefix(arg, "--") && arg != "" {
+			val, newIdx, ok := extractStringFlag(args, idx, "--duration")
+			idx = newIdx
+
+			if ok && val != "" {
+				durationStr = val
+			}
+		} else if !strings.HasPrefix(arg, "--") && arg != "" && durationStr == "" {
 			durationStr = arg
 		}
 	}

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -78,7 +78,6 @@ type parsedActionArgs struct {
 	hasMonitorName bool
 	usePrevious    bool
 	modifierStr    string
-	duration       string
 }
 
 func shouldClearSelectionAfterMoveMouse(parsed parsedActionArgs, targetsSelection bool) bool {
@@ -215,17 +214,6 @@ func parseActionArgs(rawArgs []string) (parsedActionArgs, bool) {
 
 			parsed.monitorName = val
 			parsed.hasMonitorName = true
-		case strings.HasPrefix(arg, "--duration") && (arg == "--duration" || arg[len("--duration")] == '='):
-			val, newIdx, ok := extractStringFlag(rawArgs, idx, "--duration")
-			idx = newIdx
-
-			if !ok || val == "" {
-				parseErr = true
-
-				break
-			}
-
-			parsed.duration = val
 		default:
 			if strings.HasPrefix(arg, "--") {
 				parseErr = true

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -78,6 +78,7 @@ type parsedActionArgs struct {
 	hasMonitorName bool
 	usePrevious    bool
 	modifierStr    string
+	duration       string
 }
 
 func shouldClearSelectionAfterMoveMouse(parsed parsedActionArgs, targetsSelection bool) bool {
@@ -214,6 +215,17 @@ func parseActionArgs(rawArgs []string) (parsedActionArgs, bool) {
 
 			parsed.monitorName = val
 			parsed.hasMonitorName = true
+		case strings.HasPrefix(arg, "--duration") && (arg == "--duration" || arg[len("--duration")] == '='):
+			val, newIdx, ok := extractStringFlag(rawArgs, idx, "--duration")
+			idx = newIdx
+
+			if !ok || val == "" {
+				parseErr = true
+
+				break
+			}
+
+			parsed.duration = val
 		default:
 			if strings.HasPrefix(arg, "--") {
 				parseErr = true
@@ -237,6 +249,10 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 
 	if action.IsFeedAction(actionName) {
 		return h.handleFeedAction(cmd.Args[1:])
+	}
+
+	if action.Name(actionName) == action.NameSleep {
+		return h.handleSleepAction(cmd.Args[1:])
 	}
 
 	parsed, parseErr := parseActionArgs(cmd.Args[1:])
@@ -581,6 +597,73 @@ func (h *IPCControllerActions) handleFeedAction(args []string) ipc.Response {
 		Message: "feed performed",
 		Code:    ipc.CodeOK,
 	}
+}
+
+func (h *IPCControllerActions) handleSleepAction(args []string) ipc.Response {
+	var durationStr string
+
+	for _, arg := range args {
+		arg = strings.TrimSpace(arg)
+		if after, ok := strings.CutPrefix(arg, "--duration="); ok {
+			durationStr = after
+		} else if arg == "--duration" {
+			continue
+		} else if !strings.HasPrefix(arg, "--") && arg != "" {
+			durationStr = arg
+		}
+	}
+
+	duration, err := parseSleepDuration(durationStr)
+	if err != nil {
+		return ipc.Response{
+			Success: false,
+			Message: err.Error(),
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	h.logger.Debug("sleep action sleeping", zap.Duration("duration", duration))
+	time.Sleep(duration)
+
+	return ipc.Response{
+		Success: true,
+		Message: "sleep performed",
+		Code:    ipc.CodeOK,
+	}
+}
+
+func parseSleepDuration(durationStr string) (time.Duration, error) {
+	if durationStr == "" {
+		return 0, derrors.New(
+			derrors.CodeInvalidInput,
+			"sleep requires a duration (e.g., 0.2s, 200ms)",
+		)
+	}
+
+	duration, err := strconv.ParseFloat(durationStr, 64)
+	if err != nil {
+		return 0, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"invalid sleep duration %q: %v",
+			durationStr,
+			err,
+		)
+	}
+
+	if duration <= 0 {
+		return 0, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"sleep duration must be positive, got %s",
+			durationStr,
+		)
+	}
+
+	if durationStr[len(durationStr)-1] == 'm' && len(durationStr) >= 2 &&
+		durationStr[len(durationStr)-2] == 'm' {
+		return time.Duration(duration * float64(time.Millisecond)), nil
+	}
+
+	return time.Duration(duration * float64(time.Second)), nil
 }
 
 func (h *IPCControllerActions) handleMoveMouseAction(

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -640,17 +640,29 @@ func parseSleepDuration(durationStr string) (time.Duration, error) {
 		)
 	}
 
-	duration, err := strconv.ParseFloat(durationStr, 64)
+	duration, err := time.ParseDuration(durationStr)
+	if err == nil {
+		if duration <= 0 {
+			return 0, derrors.Newf(
+				derrors.CodeInvalidInput,
+				"sleep duration must be positive, got %s",
+				durationStr,
+			)
+		}
+
+		return duration, nil
+	}
+
+	secs, err := strconv.ParseFloat(durationStr, 64)
 	if err != nil {
 		return 0, derrors.Newf(
 			derrors.CodeInvalidInput,
-			"invalid sleep duration %q: %v",
+			"invalid sleep duration %q: expected a number (seconds) or a duration string such as 200ms or 1.5s",
 			durationStr,
-			err,
 		)
 	}
 
-	if duration <= 0 {
+	if secs <= 0 {
 		return 0, derrors.Newf(
 			derrors.CodeInvalidInput,
 			"sleep duration must be positive, got %s",
@@ -658,12 +670,7 @@ func parseSleepDuration(durationStr string) (time.Duration, error) {
 		)
 	}
 
-	if durationStr[len(durationStr)-1] == 'm' && len(durationStr) >= 2 &&
-		durationStr[len(durationStr)-2] == 'm' {
-		return time.Duration(duration * float64(time.Millisecond)), nil
-	}
-
-	return time.Duration(duration * float64(time.Second)), nil
+	return time.Duration(secs * float64(time.Second)), nil
 }
 
 func (h *IPCControllerActions) handleMoveMouseAction(

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -4,6 +4,7 @@ package app
 import (
 	"context"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -330,6 +331,96 @@ func TestShouldClearSelectionAfterMoveMouse(t *testing.T) {
 			got := shouldClearSelectionAfterMoveMouse(testCase.parsed, testCase.targetsSelection)
 			if got != testCase.want {
 				t.Fatalf("shouldClearSelectionAfterMoveMouse() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestParseSleepDuration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantValid bool
+		wantNS    time.Duration
+	}{
+		{
+			name:      "bare number seconds",
+			input:     "0.2",
+			wantValid: true,
+			wantNS:    200 * time.Millisecond,
+		},
+		{
+			name:      "integer seconds",
+			input:     "1",
+			wantValid: true,
+			wantNS:    1 * time.Second,
+		},
+		{
+			name:      "float seconds",
+			input:     "1.5",
+			wantValid: true,
+			wantNS:    1500 * time.Millisecond,
+		},
+		{
+			name:      "milliseconds",
+			input:     "500ms",
+			wantValid: true,
+			wantNS:    500 * time.Millisecond,
+		},
+		{
+			name:      "seconds with s suffix",
+			input:     "2s",
+			wantValid: true,
+			wantNS:    2 * time.Second,
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			wantValid: false,
+			wantNS:    0,
+		},
+		{
+			name:      "zero duration",
+			input:     "0",
+			wantValid: false,
+			wantNS:    0,
+		},
+		{
+			name:      "negative duration",
+			input:     "-1s",
+			wantValid: false,
+			wantNS:    0,
+		},
+		{
+			name:      "invalid string",
+			input:     "invalid",
+			wantValid: false,
+			wantNS:    0,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseSleepDuration(testCase.input)
+			if testCase.wantValid && err != nil {
+				t.Fatalf("parseSleepDuration(%q) unexpected error: %v", testCase.input, err)
+			}
+
+			if !testCase.wantValid && err == nil {
+				t.Fatalf("parseSleepDuration(%q) expected error, got nil", testCase.input)
+			}
+
+			if got != testCase.wantNS {
+				t.Fatalf(
+					"parseSleepDuration(%q) = %v, want %v",
+					testCase.input,
+					got,
+					testCase.wantNS,
+				)
 			}
 		})
 	}

--- a/internal/core/domain/action/action.go
+++ b/internal/core/domain/action/action.go
@@ -163,6 +163,8 @@ const (
 	NamePageUp Name = "page_up"
 	// NamePageDown represents the page-down action.
 	NamePageDown Name = "page_down"
+	// NameSleep pauses action execution for a specified duration.
+	NameSleep Name = "sleep"
 
 	// PrefixExec is the prefix for shell command actions.
 	PrefixExec = "exec"
@@ -251,7 +253,7 @@ func IsKnownName(name Name) bool {
 		NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
 		NameScrollUp, NameScrollDown, NameScrollLeft, NameScrollRight,
 		NameGoTop, NameGoBottom, NamePageUp, NamePageDown,
-		NameMoveMonitor, NameFeed:
+		NameMoveMonitor, NameFeed, NameSleep:
 		return true
 	default:
 		return false
@@ -274,7 +276,7 @@ func IsScrollSubAction(name string) bool {
 		NameMouseDown, NameMouseUp,
 		NameMoveMouse, NameMoveMouseRelative, NameScroll,
 		NameReset, NameBackspace, NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
-		NameMoveMonitor, NameFeed:
+		NameMoveMonitor, NameFeed, NameSleep:
 		return false
 	default:
 		return false
@@ -335,7 +337,8 @@ func (n Name) ToType() (Type, error) {
 		NameSaveCursorPos,
 		NameRestoreCursorPos,
 		NameMoveMonitor,
-		NameFeed:
+		NameFeed,
+		NameSleep:
 		return 0, derrors.Newf(derrors.CodeInvalidInput, "action name not executable: %s", n)
 	default:
 		return 0, derrors.Newf(derrors.CodeInvalidInput, "unknown action name: %s", n)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds `neru action sleep` that pauses action execution for a given duration.

Previously the docs suggested to do `neru exec sleep`, but it will always create a subprocess, and the timing might be unreliable and can race with the current pipeline.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
