### PR TITLE
feat(grid,recursive_grid): add `app_configs.hotkey` overrides

### DIFF
--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -38,15 +38,16 @@ clickable_roles = [
 ]
 ignore_clickable_check = false
 
-# Application-specific configurations for customizing hint behavior per app
-# Each entry allows overriding clickable roles and clickable check behavior for specific bundle IDs
+## Application-specific configurations for customizing hint behavior per app
+## Each entry allows overriding clickable roles and clickable check behavior for specific bundle IDs
 # [[hints.app_configs]]
-# bundle_id = "net.imput.helium"
+# bundle_id = "com.brave.Browser"
 # additional_clickable_roles = ["AXTabGroup"]
 # ignore_clickable_check = false
-#
-# [hints.app_configs.hotkeys]
-# "Return" = ["action left_click", "action sleep 3.5", "hints"]
+# hotkeys = {
+# 	"Return" = "action left_click",
+# 	"Shift+L" = "__disabled__"
+# }
 
 [hints.additional_ax_support]
 enable = true

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -14,7 +14,7 @@ Neru uses TOML for configuration. No config file is required — Neru works out 
 - [Hotkeys](#hotkeys)
 - [Per-Mode Custom Hotkeys](#per-mode-custom-hotkeys)
 - [Action Commands and Primitives](#action-commands-and-primitives)
-  - [Feed keys](#feed-keys)
+    - [Feed keys](#feed-keys)
 - [General Settings](#general-settings)
 - [Hint Mode](#hint-mode)
 - [Grid Mode](#grid-mode)
@@ -187,23 +187,31 @@ All actions from `[hotkeys]` work here, plus these mode-specific ones:
 - Root toggle commands: `toggle-screen-share`, `toggle-cursor-follow-selection`
 - Shell commands: `exec ...`
 
-### Per-App Hint Hotkey Overrides
+### Per-App Hotkey Overrides
 
-`[[hints.app_configs]]` overrides `[hints.hotkeys]` bindings for a specific app bundle ID. App hotkeys are merged on top of `[hints.hotkeys]`; missing keys inherit the global binding; `__disabled__` removes an inherited binding for that app only.
+`[[<mode>.app_configs]]` overrides `<mode>.hotkeys` bindings for a specific app bundle ID. App hotkeys are merged on top of global mode hotkeys; missing keys inherit the global binding; `__disabled__` removes an inherited binding for that app only.
+
+This works for `hints`, `grid`, and `recursive_grid` modes:
 
 ```toml
 [hints.hotkeys]
 "Return" = ["action left_click", "hints"]
 
 [[hints.app_configs]]
-bundle_id = "net.imput.helium"
+bundle_id = "com.brave.Browser"
+hotkeys = {
+	"Return" = "action left_click",
+	"Shift+L" = "__disabled__"
+}
 
-[hints.app_configs.hotkeys]
-"Return" = ["action left_click", "action sleep 0.8", "hints"]
-"Shift+L" = "__disabled__"
+[[grid.app_configs]]
+bundle_id = "com.brave.Browser"
+hotkeys = { "Return" = "action left_click" }
+
+[[recursive_grid.app_configs]]
+bundle_id = "com.brave.Browser"
+hotkeys = { "u" = "action left_click" }
 ```
-
-This is useful for apps that need different hint follow-up behavior, such as browser-like shells that need a short pause before hints are refreshed.
 
 ### Priority order
 
@@ -412,6 +420,23 @@ Runtime cursor behavior is chosen per invocation rather than in config:
 
 Default grid hotkeys include ``"`" = "toggle-cursor-follow-selection"`` so you can flip cursor follow behavior mid-session.
 
+### Per-App Config Overrides
+
+`[[grid.app_configs]]` allows you to override hotkeys for specific apps:
+
+| Field       | Type   | Description                              |
+| ----------- | ------ | ---------------------------------------- |
+| `bundle_id` | string | App bundle ID (e.g. "com.brave.Browser") |
+| `hotkeys`   | map    | Per-app hotkey overrides (see below)     |
+
+```toml
+[[grid.app_configs]]
+bundle_id = "com.brave.Browser"
+hotkeys = { "Return" = "action left_click" }
+```
+
+See [Per-App Hotkey Overrides](#per-app-hotkey-overrides) for how per-app hotkey overrides work.
+
 ### UI Options
 
 | Option                     | Type   | Default | Description                          |
@@ -459,6 +484,23 @@ Recursive grid narrows the active area with each keypress for precise cursor pla
 | `layers`          | array  | `[]`     | Optional per-depth layout overrides              |
 
 Like `grid`, recursive-grid uses `--cursor-selection-mode follow|hold` at launch time. Default hotkeys also include ``"`" = "toggle-cursor-follow-selection"``.
+
+### Per-App Config Overrides
+
+`[[recursive_grid.app_configs]]` allows you to override hotkeys for specific apps:
+
+| Field       | Type   | Description                              |
+| ----------- | ------ | ---------------------------------------- |
+| `bundle_id` | string | App bundle ID (e.g. "com.brave.Browser") |
+| `hotkeys`   | map    | Per-app hotkey overrides (see below)     |
+
+```toml
+[[recursive_grid.app_configs]]
+bundle_id = "com.brave.Browser"
+hotkeys = { "Return" = "action left_click" }
+```
+
+See [Per-App Hotkey Overrides](#per-app-hotkey-overrides) for how per-app hotkey overrides work.
 
 ### Animation Options
 

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -146,12 +146,11 @@ ctrl - r : neru hints --action right_click
 Some browser-like apps need a short delay after a click so the page content can finish updating before Neru refreshes hints. Override just that app's hint hotkeys:
 
 ```toml
-[[hints.app_configs]]
-bundle_id = "net.imput.helium"
-
-[hints.app_configs.hotkeys]
-"Return" = ["action left_click", "action sleep 0.8", "hints"]
-"Shift+L" = "__disabled__"
+bundle_id = "com.brave.Browser"
+hotkeys = {
+	"Return" = ["action left_click", "action sleep 0.8", "hints"],
+	"Shift+L" = "__disabled__"
+}
 ```
 
 This merges on top of `[hints.hotkeys]`, so only the keys listed here change for Helium. Everything else keeps using your normal hint bindings.

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -146,6 +146,7 @@ ctrl - r : neru hints --action right_click
 Some browser-like apps need a short delay after a click so the page content can finish updating before Neru refreshes hints. Override just that app's hint hotkeys:
 
 ```toml
+[[hints.app_configs]]
 bundle_id = "com.brave.Browser"
 hotkeys = {
 	"Return" = ["action left_click", "action sleep 0.8", "hints"],
@@ -153,7 +154,19 @@ hotkeys = {
 }
 ```
 
-This merges on top of `[hints.hotkeys]`, so only the keys listed here change for Helium. Everything else keeps using your normal hint bindings.
+This merges on top of `[hints.hotkeys]`, so only the keys listed here change for Brave Browser. Everything else keeps using your normal hint bindings.
+
+You can use the same pattern for grid and recursive_grid modes:
+
+```toml
+[[grid.app_configs]]
+bundle_id = "com.brave.Browser"
+hotkeys = { "Return" = "action left_click" }
+
+[[recursive_grid.app_configs]]
+bundle_id = "com.brave.Browser"
+hotkeys = { "u" = "action left_click" }
+```
 
 ## Checking the Accessibility Tree on macOS
 

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -54,8 +54,23 @@ func (h *Handler) HandleKeyPress(key string) {
 	// Resolve the focused app bundle ID once so that both handleHotkey calls
 	// (rawKey and stripped key) share the same snapshot.
 	var bundleID string
-	if h.appState.CurrentMode() == domain.ModeHints && h.config.Hints.HasAppHotkeyOverrides() {
-		bundleID = h.focusedBundleID()
+
+	currentMode := h.appState.CurrentMode()
+	switch currentMode {
+	case domain.ModeHints:
+		if h.config.Hints.HasAppHotkeyOverrides() {
+			bundleID = h.focusedBundleID()
+		}
+	case domain.ModeGrid:
+		if h.config.Grid.HasAppHotkeyOverrides() {
+			bundleID = h.focusedBundleID()
+		}
+	case domain.ModeRecursiveGrid:
+		if h.config.RecursiveGrid.HasAppHotkeyOverrides() {
+			bundleID = h.focusedBundleID()
+		}
+	case domain.ModeIdle, domain.ModeScroll:
+		// No app hotkey overrides for these modes
 	}
 
 	// Check for per-mode hotkeys before mode-specific handling.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -586,6 +586,8 @@ type GridConfig struct {
 	PrewarmEnabled  bool   `json:"prewarmEnabled"  toml:"prewarm_enabled"`
 	EnableGC        bool   `json:"enableGc"        toml:"enable_gc"`
 
+	AppConfigs []AppConfig `json:"appConfigs" toml:"app_configs"`
+
 	Hotkeys map[string]StringOrStringArray `json:"hotkeys" toml:"-"`
 }
 
@@ -642,6 +644,8 @@ type RecursiveGridConfig struct {
 	// Per-depth overrides for grid dimensions and keys.
 	// Depths not listed here use the top-level GridCols/GridRows/Keys.
 	Layers []RecursiveGridLayerConfig `json:"layers" toml:"layers"`
+
+	AppConfigs []AppConfig `json:"appConfigs" toml:"app_configs"`
 
 	Hotkeys map[string]StringOrStringArray `json:"hotkeys" toml:"-"`
 }
@@ -1163,17 +1167,26 @@ func (c *Config) HotkeysForMode(modeName string) map[string]StringOrStringArray 
 
 // HotkeysForModeAndApp returns the effective per-mode hotkeys map for the given mode
 // and focused app bundle ID. For modes without app-specific overrides, it returns the
-// base mode hotkeys unchanged. Hints mode supports per-app hotkey overrides through
-// [[hints.app_configs]].
+// base mode hotkeys unchanged. Hints, Grid, and RecursiveGrid modes support
+// per-app hotkey overrides through [[<mode>.app_configs]].
 func (c *Config) HotkeysForModeAndApp(
 	modeName, bundleID string,
 ) map[string]StringOrStringArray {
 	base := c.baseHotkeysForMode(modeName)
-	if modeName != modeNameHints || bundleID == "" {
+	if bundleID == "" {
 		return base
 	}
 
-	appConfig := c.Hints.AppConfigForBundleID(bundleID)
+	var appConfig *AppConfig
+	switch modeName {
+	case modeNameHints:
+		appConfig = c.Hints.AppConfigForBundleID(bundleID)
+	case modeNameGrid:
+		appConfig = c.Grid.AppConfigForBundleID(bundleID)
+	case modeNameRecursiveGrid:
+		appConfig = c.RecursiveGrid.AppConfigForBundleID(bundleID)
+	}
+
 	if appConfig == nil || len(appConfig.Hotkeys) == 0 {
 		return base
 	}
@@ -1216,8 +1229,54 @@ func (c *HintsConfig) HasAppHotkeyOverrides() bool {
 	return false
 }
 
+// HasAppHotkeyOverrides reports whether any [[grid.app_configs]] entry has a
+// non-empty Hotkeys map.
+func (c *GridConfig) HasAppHotkeyOverrides() bool {
+	for idx := range c.AppConfigs {
+		if len(c.AppConfigs[idx].Hotkeys) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HasAppHotkeyOverrides reports whether any [[recursive_grid.app_configs]] entry has a
+// non-empty Hotkeys map.
+func (c *RecursiveGridConfig) HasAppHotkeyOverrides() bool {
+	for idx := range c.AppConfigs {
+		if len(c.AppConfigs[idx].Hotkeys) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 // AppConfigForBundleID returns the matching hints app config for the given bundle ID.
 func (c *HintsConfig) AppConfigForBundleID(bundleID string) *AppConfig {
+	for idx := range c.AppConfigs {
+		if c.AppConfigs[idx].BundleID == bundleID {
+			return &c.AppConfigs[idx]
+		}
+	}
+
+	return nil
+}
+
+// AppConfigForBundleID returns the matching grid app config for the given bundle ID.
+func (c *GridConfig) AppConfigForBundleID(bundleID string) *AppConfig {
+	for idx := range c.AppConfigs {
+		if c.AppConfigs[idx].BundleID == bundleID {
+			return &c.AppConfigs[idx]
+		}
+	}
+
+	return nil
+}
+
+// AppConfigForBundleID returns the matching recursive grid app config for the given bundle ID.
+func (c *RecursiveGridConfig) AppConfigForBundleID(bundleID string) *AppConfig {
 	for idx := range c.AppConfigs {
 		if c.AppConfigs[idx].BundleID == bundleID {
 			return &c.AppConfigs[idx]

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -14,6 +14,56 @@ import (
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
 
+// validateAppConfigsHotkeys validates hotkeys in app_configs sections from raw config.
+func validateAppConfigsHotkeys(
+	logger *zap.Logger,
+	modeName string,
+	raw map[string]any,
+) *LoadResult {
+	var appConfigsRaw []any
+	switch ac := raw["app_configs"].(type) {
+	case []any:
+		appConfigsRaw = ac
+	case []map[string]any:
+		for i := range ac {
+			appConfigsRaw = append(appConfigsRaw, ac[i])
+		}
+	default:
+		return nil
+	}
+
+	for idx, entry := range appConfigsRaw {
+		appMap, isMap := entry.(map[string]any)
+		if !isMap {
+			continue
+		}
+
+		hotkeysRaw, hasHotkeys := appMap["hotkeys"]
+		if !hasHotkeys {
+			continue
+		}
+
+		err := validateRawHotkeyTable(
+			fmt.Sprintf("%s.app_configs[%d].hotkeys", modeName, idx),
+			hotkeysRaw,
+		)
+		if err != nil {
+			result := &LoadResult{
+				ValidationError: err,
+				Config:          DefaultConfig(),
+			}
+			logger.Warn("Duplicate normalized app hotkey in config",
+				zap.String("mode", modeName),
+				zap.Int("app_config_index", idx),
+				zap.Error(err))
+
+			return result
+		}
+	}
+
+	return nil
+}
+
 // findNormalizedMapKey returns the existing map key in m whose normalized form
 // matches the normalized form of rawKey. If no match is found it returns rawKey
 // itself so callers can use the result directly.
@@ -402,56 +452,24 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 	}
 
 	if hintsRaw, ok := raw["hints"].(map[string]any); ok {
-		switch appConfigsRaw := hintsRaw["app_configs"].(type) {
-		case []any:
-			for idx, entry := range appConfigsRaw {
-				appMap, isMap := entry.(map[string]any)
-				if !isMap {
-					continue
-				}
+		if result := validateAppConfigsHotkeys(s.logger, "hints", hintsRaw); result != nil {
+			return result
+		}
+	}
 
-				hotkeysRaw, hasHotkeys := appMap["hotkeys"]
-				if !hasHotkeys {
-					continue
-				}
+	if gridRaw, ok := raw["grid"].(map[string]any); ok {
+		if result := validateAppConfigsHotkeys(s.logger, "grid", gridRaw); result != nil {
+			return result
+		}
+	}
 
-				err = validateRawHotkeyTable(
-					fmt.Sprintf("hints.app_configs[%d].hotkeys", idx),
-					hotkeysRaw,
-				)
-				if err != nil {
-					configResult.ValidationError = err
-					configResult.Config = DefaultConfig()
-
-					s.logger.Warn("Duplicate normalized app hotkey in config",
-						zap.Int("app_config_index", idx),
-						zap.Error(configResult.ValidationError))
-
-					return configResult
-				}
-			}
-		case []map[string]any:
-			for idx, appMap := range appConfigsRaw {
-				hotkeysRaw, ok := appMap["hotkeys"]
-				if !ok {
-					continue
-				}
-
-				err = validateRawHotkeyTable(
-					fmt.Sprintf("hints.app_configs[%d].hotkeys", idx),
-					hotkeysRaw,
-				)
-				if err != nil {
-					configResult.ValidationError = err
-					configResult.Config = DefaultConfig()
-
-					s.logger.Warn("Duplicate normalized app hotkey in config",
-						zap.Int("app_config_index", idx),
-						zap.Error(configResult.ValidationError))
-
-					return configResult
-				}
-			}
+	if recursiveGridRaw, ok := raw["recursive_grid"].(map[string]any); ok {
+		if result := validateAppConfigsHotkeys(
+			s.logger,
+			"recursive_grid",
+			recursiveGridRaw,
+		); result != nil {
+			return result
 		}
 	}
 

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -160,30 +160,30 @@ func (c *Config) ValidateHints() error {
 	return nil
 }
 
-// ValidateAppConfigs validates per-app hint configuration.
-func (c *Config) ValidateAppConfigs() error {
-	seen := make(map[string]struct{}, len(c.Hints.AppConfigs))
-	for idx, appConfig := range c.Hints.AppConfigs {
+// validateAppConfigs validates per-app configuration for a given mode.
+func validateAppConfigs(modeName string, appConfigs []AppConfig) error {
+	seen := make(map[string]struct{}, len(appConfigs))
+	for idx, appConfig := range appConfigs {
 		if strings.TrimSpace(appConfig.BundleID) == "" {
 			return derrors.Newf(
 				derrors.CodeInvalidConfig,
-				"hints.app_configs[%d].bundle_id cannot be empty",
-				idx,
+				"%s.app_configs[%d].bundle_id cannot be empty",
+				modeName, idx,
 			)
 		}
 
 		if _, ok := seen[appConfig.BundleID]; ok {
 			return derrors.Newf(
 				derrors.CodeInvalidConfig,
-				"duplicate hints.app_configs bundle_id: %s",
-				appConfig.BundleID,
+				"duplicate %s.app_configs bundle_id: %s",
+				modeName, appConfig.BundleID,
 			)
 		}
 
 		seen[appConfig.BundleID] = struct{}{}
 
 		err := validateHotkeyTable(
-			fmt.Sprintf("hints.app_configs[%d].hotkeys", idx),
+			fmt.Sprintf("%s.app_configs[%d].hotkeys", modeName, idx),
 			appConfig.Hotkeys,
 		)
 		if err != nil {
@@ -192,6 +192,11 @@ func (c *Config) ValidateAppConfigs() error {
 	}
 
 	return nil
+}
+
+// ValidateAppConfigs validates per-app hint configuration.
+func (c *Config) ValidateAppConfigs() error {
+	return validateAppConfigs("hints", c.Hints.AppConfigs)
 }
 
 // ValidateGrid validates the grid configuration.
@@ -242,6 +247,11 @@ func (c *Config) ValidateGrid() error {
 
 	if c.Grid.UI.BorderWidth < 0 {
 		return derrors.New(derrors.CodeInvalidConfig, "grid.ui.border_width must be non-negative")
+	}
+
+	err = validateAppConfigs("grid", c.Grid.AppConfigs)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -638,6 +648,11 @@ func (c *Config) ValidateRecursiveGrid() error {
 
 	if c.RecursiveGrid.UI.FontSize < 1 {
 		return derrors.New(derrors.CodeInvalidConfig, "recursive_grid.ui.font_size must be >= 1")
+	}
+
+	err = validateAppConfigs("recursive_grid", c.RecursiveGrid.AppConfigs)
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR extends the existing `app_configs` override mechanism to `grid` and `recursive_grid` modes.

Now use can specify or override certain hotkeys for certain app only, .eg.:

```toml
[[recursive_grid.app_configs]]
bundle_id = "com.brave.Browser"
hotkeys = {
	"1" = ["action right_click", "action sleep 0.1", "action feed o p e n enter m d a enter"],
	"2" = ["action right_click", "action sleep 0.1", "action feed o p e n enter s k b enter"],
	"3" = ["action right_click", "action sleep 0.1", "action feed o p e n enter t r a enter"],
	"4" = ["action right_click", "action sleep 0.1", "action feed o p e n enter m a d enter"],
	"5" = ["action right_click", "action sleep 0.1", "action feed o p e n enter w a k enter"],
}
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
