### PR TITLE
feat(cli): add `--window` flag for `move_mouse` command

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -441,6 +441,7 @@ neru action right_click --modifier alt         # Alt+right-click
 neru action move_mouse --x 500 --y 300
 neru action move_mouse                         # Move to the active mode selection
 neru action move_mouse --bare                  # Use current-cursor targeting explicitly
+neru action move_mouse --window                # Move to the center of the focused window
 ```
 
 **Screen center:**
@@ -449,6 +450,13 @@ neru action move_mouse --bare                  # Use current-cursor targeting ex
 neru action move_mouse --center
 neru action move_mouse --center --x 50 --y -30    # Center with offset
 neru action move_mouse --center --x 100            # Single-axis offset (y defaults to 0)
+```
+
+**Focused window:**
+
+```
+neru action move_mouse --window                  # Move to center of focused window
+neru action move_mouse --window --x -50 --y 50  # Offset from window center
 ```
 
 **Relative movement:**
@@ -461,9 +469,10 @@ neru action move_mouse_relative --dx 10 --dy -5
 
 | Flag          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
-| `--x <px>`    | Absolute X coordinate, or X offset when used with `--center` |
-| `--y <px>`    | Absolute Y coordinate, or Y offset when used with `--center` |
+| `--x <px>`    | Absolute X coordinate, or X offset when used with `--center` or `--window` |
+| `--y <px>`    | Absolute Y coordinate, or Y offset when used with `--center` or `--window` |
 | `--center`    | Move to the center of the active screen                      |
+| `--window`    | Move to the center of the focused window                   |
 | `--selection` | Explicitly use the active mode selection                     |
 | `--bare`      | Force current-cursor targeting even when a selection exists  |
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -457,6 +457,7 @@ neru action move_mouse --center --x 100            # Single-axis offset (y defau
 ```
 neru action move_mouse --window                  # Move to center of focused window
 neru action move_mouse --window --x -50 --y 50  # Offset from window center
+neru action move_mouse --window --x 100          # Single-axis offset (y defaults to 0)
 ```
 
 **Relative movement:**

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -72,6 +72,7 @@ type parsedActionArgs struct {
 	hasX, hasY     bool
 	hasDX, hasDY   bool
 	hasCenter      bool
+	hasWindow      bool
 	useSelection   bool
 	useBare        bool
 	monitorName    string
@@ -87,6 +88,7 @@ func shouldClearSelectionAfterMoveMouse(parsed parsedActionArgs, targetsSelectio
 
 	return (parsed.hasX && parsed.hasY) ||
 		parsed.hasCenter ||
+		parsed.hasWindow ||
 		(parsed.hasDX && parsed.hasDY) ||
 		parsed.useBare
 }
@@ -196,6 +198,8 @@ func parseActionArgs(rawArgs []string) (parsedActionArgs, bool) {
 			parsed.hasDY = true
 		case arg == "--center":
 			parsed.hasCenter = true
+		case arg == "--window":
+			parsed.hasWindow = true
 		case arg == "--selection":
 			parsed.useSelection = true
 		case arg == "--bare":
@@ -360,10 +364,34 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 		}
 	}
 
+	if parsed.hasWindow && (parsed.hasDX || parsed.hasDY) {
+		return ipc.Response{
+			Success: false,
+			Message: "use either --window or --dx/--dy, not both",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
 	if parsed.hasCenter && !isMoveMouse {
 		return ipc.Response{
 			Success: false,
 			Message: "--center is only supported with move_mouse",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	if parsed.hasWindow && !isMoveMouse {
+		return ipc.Response{
+			Success: false,
+			Message: "--window is only supported with move_mouse",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	if parsed.hasCenter && parsed.hasWindow {
+		return ipc.Response{
+			Success: false,
+			Message: "--center and --window cannot be used together",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}
@@ -393,10 +421,10 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 	}
 
 	if parsed.useSelection &&
-		(parsed.hasCenter || parsed.hasX || parsed.hasY) {
+		(parsed.hasCenter || parsed.hasWindow || parsed.hasX || parsed.hasY) {
 		return ipc.Response{
 			Success: false,
-			Message: "--selection cannot be combined with --x, --y, or --center",
+			Message: "--selection cannot be combined with --x, --y, --center, or --window",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}
@@ -430,6 +458,45 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 		err := h.actionService.MoveMouseToCenter(ctx, offsetX, offsetY)
 		if err != nil {
 			h.logger.Error("Failed to move mouse to center", zap.Error(err))
+
+			return ipc.Response{
+				Success: false,
+				Message: "failed to perform action: " + err.Error(),
+				Code:    ipc.CodeActionFailed,
+			}
+		}
+
+		if h.modesHandler != nil &&
+			shouldClearSelectionAfterMoveMouse(parsed, false) {
+			h.modesHandler.ClearCurrentSelectionPoint()
+		}
+
+		return ipc.Response{
+			Success: true,
+			Message: actionName + " performed",
+			Code:    ipc.CodeOK,
+		}
+	}
+
+	if isMoveMouse && parsed.hasWindow {
+		if h.actionService == nil {
+			return ipc.Response{
+				Success: false,
+				Message: "action service not available",
+				Code:    ipc.CodeActionFailed,
+			}
+		}
+
+		offsetX, offsetY := parsed.xVal, parsed.yVal
+
+		h.logger.Info("Moving mouse to window center via IPC",
+			zap.Int("offsetX", offsetX),
+			zap.Int("offsetY", offsetY),
+		)
+
+		err := h.actionService.MoveMouseToCenterOfWindow(ctx, offsetX, offsetY)
+		if err != nil {
+			h.logger.Error("Failed to move mouse to window center", zap.Error(err))
 
 			return ipc.Response{
 				Success: false,
@@ -788,7 +855,7 @@ func (h *IPCControllerActions) resolveMoveMousePoint(
 
 	return image.Point{}, &ipc.Response{
 		Success: false,
-		Message: "move_mouse requires --x and --y flags, --center, active selection, or --bare",
+		Message: "move_mouse requires --x and --y flags, --center, --window, active selection, or --bare",
 		Code:    ipc.CodeInvalidInput,
 	}
 }

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -429,7 +429,7 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 		}
 	}
 
-	if isMoveMouse && !parsed.hasCenter &&
+	if isMoveMouse && !parsed.hasCenter && !parsed.hasWindow &&
 		!parsed.useSelection &&
 		((parsed.hasX && !parsed.hasY) || (!parsed.hasX && parsed.hasY)) {
 		return ipc.Response{

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -34,6 +34,25 @@ func TestParseActionArgs_MoveMouseFlags(t *testing.T) {
 	}
 }
 
+func TestParseActionArgs_MoveMouseWindowFlag(t *testing.T) {
+	parsed, parseErr := parseActionArgs([]string{"--window", "--x=50", "--y=50"})
+	if parseErr {
+		t.Fatal("parseActionArgs() unexpected parse error")
+	}
+
+	if !parsed.hasWindow {
+		t.Fatal("parseActionArgs() expected hasWindow to be true")
+	}
+
+	if parsed.xVal != 50 {
+		t.Fatalf("parseActionArgs() expected xVal to be 50, got %d", parsed.xVal)
+	}
+
+	if parsed.yVal != 50 {
+		t.Fatalf("parseActionArgs() expected yVal to be 50, got %d", parsed.yVal)
+	}
+}
+
 func TestParseActionArgs_SelectionFlag(t *testing.T) {
 	parsed, parseErr := parseActionArgs([]string{"--selection"})
 	if parseErr {
@@ -122,7 +141,7 @@ func TestHandleAction_MoveMouseWithoutTargetingOrSelectionErrors(t *testing.T) {
 		t.Fatal("handleAction(move_mouse) expected failure without explicit target or selection")
 	}
 
-	if resp.Message != "move_mouse requires --x and --y flags, --center, active selection, or --bare" {
+	if resp.Message != "move_mouse requires --x and --y flags, --center, --window, active selection, or --bare" {
 		t.Fatalf("unexpected error message: %q", resp.Message)
 	}
 }
@@ -143,6 +162,46 @@ func TestHandleAction_MoveMouseSelectionWithoutActiveSelectionErrors(t *testing.
 	}
 
 	if resp.Message != "--selection requires an active mode selection" {
+		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
+func TestHandleAction_MoveMouseRejectsCenterAndWindow(t *testing.T) {
+	controller := &IPCControllerActions{
+		appState: state.NewAppState(),
+		logger:   zap.NewNop(),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: "action",
+		Args:   []string{"move_mouse", "--center", "--window"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(move_mouse --center --window) expected failure")
+	}
+
+	if resp.Message != "--center and --window cannot be used together" {
+		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
+func TestHandleAction_MoveMouseRejectsWindowAndDX(t *testing.T) {
+	controller := &IPCControllerActions{
+		appState: state.NewAppState(),
+		logger:   zap.NewNop(),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: "action",
+		Args:   []string{"move_mouse", "--window", "--dx=10", "--dy=10"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(move_mouse --window --dx) expected failure")
+	}
+
+	if resp.Message != "use either --window or --dx/--dy, not both" {
 		t.Fatalf("unexpected error message: %q", resp.Message)
 	}
 }
@@ -301,6 +360,12 @@ func TestShouldClearSelectionAfterMoveMouse(t *testing.T) {
 		{
 			name:             "center move clears selection",
 			parsed:           parsedActionArgs{hasCenter: true},
+			targetsSelection: false,
+			want:             true,
+		},
+		{
+			name:             "window move clears selection",
+			parsed:           parsedActionArgs{hasWindow: true},
 			targetsSelection: false,
 			want:             true,
 		},

--- a/internal/app/services/action_service.go
+++ b/internal/app/services/action_service.go
@@ -287,6 +287,40 @@ func (s *ActionService) MoveMouseToCenterOfMonitor(
 	)
 }
 
+// MoveMouseToCenterOfWindow moves the mouse cursor to the center of the currently
+// focused window, optionally offset by the given delta values.
+func (s *ActionService) MoveMouseToCenterOfWindow(
+	ctx context.Context,
+	offsetX, offsetY int,
+) error {
+	bounds, found, err := s.system.FocusedWindowBounds(ctx)
+	if err != nil {
+		s.logger.Error("Failed to get focused window bounds", zap.Error(err))
+
+		return core.WrapAccessibilityFailed(err, "get focused window bounds")
+	}
+
+	if !found {
+		return derrors.New(
+			derrors.CodeAccessibilityFailed,
+			"no focused window found",
+		)
+	}
+
+	centerX := bounds.Min.X + bounds.Dx()/2 //nolint:mnd
+	centerY := bounds.Min.Y + bounds.Dy()/2 //nolint:mnd
+	target := image.Point{X: centerX + offsetX, Y: centerY + offsetY}
+
+	return s.moveMouseWithBounds(
+		ctx,
+		target,
+		bounds,
+		false,
+		zap.Int("offsetX", offsetX),
+		zap.Int("offsetY", offsetY),
+	)
+}
+
 // moveMouseWithBounds clamps target to the given screen bounds and moves the cursor.
 // This is the shared implementation used by MoveMouseTo and MoveMouseToCenter to
 // avoid duplicating clamp-and-move logic.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -255,6 +255,7 @@ func BuildMoveMouseCommand() *cobra.Command {
 	var (
 		targetX, targetY int
 		center           bool
+		window           bool
 		selection        bool
 		bare             bool
 	)
@@ -265,7 +266,8 @@ func BuildMoveMouseCommand() *cobra.Command {
 		Long: `Move the mouse cursor to the specified absolute position.
 Coordinates are relative to the current display.
 When --center is used, the cursor moves to the center of the active screen.
-If --x and --y are also provided with --center, they act as offsets from center.
+When --window is used, the cursor moves to the center of the focused window.
+If --x and --y are also provided with --center or --window, they act as offsets from center.
 Without coordinates, move_mouse targets the active mode selection by default when one exists.
 Use --bare to force current-cursor targeting.`,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
@@ -273,10 +275,10 @@ Use --bare to force current-cursor targeting.`,
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if selection &&
-				(center || cmd.Flags().Changed("x") || cmd.Flags().Changed("y")) {
+				(center || window || cmd.Flags().Changed("x") || cmd.Flags().Changed("y")) {
 				return derrors.New(
 					derrors.CodeInvalidInput,
-					"--selection cannot be combined with --x, --y, or --center",
+					"--selection cannot be combined with --x, --y, --center, or --window",
 				)
 			}
 
@@ -287,7 +289,14 @@ Use --bare to force current-cursor targeting.`,
 				)
 			}
 
-			if !center && !selection &&
+			if center && window {
+				return derrors.New(
+					derrors.CodeInvalidInput,
+					"--center and --window cannot be used together",
+				)
+			}
+
+			if !center && !window && !selection &&
 				((cmd.Flags().Changed("x") && !cmd.Flags().Changed("y")) ||
 					(!cmd.Flags().Changed("x") && cmd.Flags().Changed("y"))) {
 				return derrors.New(
@@ -300,6 +309,10 @@ Use --bare to force current-cursor targeting.`,
 
 			if center {
 				args = append(args, "--center")
+			}
+
+			if window {
+				args = append(args, "--window")
 			}
 
 			if cmd.Flags().Changed("x") {
@@ -327,6 +340,8 @@ Use --bare to force current-cursor targeting.`,
 	cmd.Flags().
 		IntVar(&targetY, "y", 0, "Y coordinate (pixels); with --center, vertical offset (default 0)")
 	cmd.Flags().BoolVar(&center, "center", false, "Move to the center of the active screen")
+	cmd.Flags().
+		BoolVar(&window, "window", false, "Move to the center of the focused window")
 	cmd.Flags().
 		BoolVar(&selection, "selection", false, "Explicitly move to the active mode selection")
 	cmd.Flags().

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -161,6 +161,10 @@ void **getAllWindows(int *count);
 /// @return Frontmost window reference
 void *getFrontmostWindow(void);
 
+/// Get the frame (position + size) of the focused window
+/// @return Window frame rectangle, or CGRectZero if no window is found
+CGRect getFocusedWindowFrame(void);
+
 /// Get application name
 /// @param app Application reference
 /// @return Application name string

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -150,6 +150,67 @@ void *getFrontmostWindow(void) {
 	}
 }
 
+/// Get the frame (position + size) of the focused window
+/// @return Window frame rectangle, or CGRectZero if no window is found
+CGRect getFocusedWindowFrame(void) {
+	@autoreleasepool {
+		void *windowRef = getFrontmostWindow();
+		if (!windowRef)
+			return CGRectZero;
+
+		AXUIElementRef window = (AXUIElementRef)windowRef;
+
+		CFArrayRef attributes = CFArrayCreate(
+		    NULL,
+		    (const void **)(CFTypeRef[]){
+		        kAXPositionAttribute,
+		        kAXSizeAttribute,
+		    },
+		    2, &kCFTypeArrayCallBacks);
+
+		if (!attributes) {
+			CFRelease(window);
+			return CGRectZero;
+		}
+
+		CFArrayRef values = NULL;
+		AXError error = AXUIElementCopyMultipleAttributeValues(window, attributes, 0, &values);
+		CFRelease(attributes);
+
+		if (error != kAXErrorSuccess || !values) {
+			CFRelease(window);
+			return CGRectZero;
+		}
+
+		CGRect frame = CGRectZero;
+		CFIndex count = CFArrayGetCount(values);
+
+		if (count > 0) {
+			CFTypeRef positionValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 0);
+			if (positionValue && CFGetTypeID(positionValue) == AXValueGetTypeID()) {
+				CGPoint point;
+				if (AXValueGetValue((AXValueRef)positionValue, kAXValueCGPointType, &point)) {
+					frame.origin = point;
+				}
+			}
+		}
+
+		if (count > 1) {
+			CFTypeRef sizeValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 1);
+			if (sizeValue && CFGetTypeID(sizeValue) == AXValueGetTypeID()) {
+				CGSize size;
+				if (AXValueGetValue((AXValueRef)sizeValue, kAXValueCGSizeType, &size)) {
+					frame.size = size;
+				}
+			}
+		}
+
+		CFRelease(values);
+		CFRelease(window);
+		return frame;
+	}
+}
+
 /// Get application name
 /// @param app Application reference
 /// @return Application name string

--- a/internal/core/infra/platform/darwin/screen.go
+++ b/internal/core/infra/platform/darwin/screen.go
@@ -89,3 +89,22 @@ func ScreenBoundsByName(name string) (image.Rectangle, bool) {
 func IsMissionControlActive() bool {
 	return bool(C.isMissionControlActive())
 }
+
+// FocusedWindowBounds returns the bounds of the focused (frontmost) window.
+// Returns the bounds and true if a window was found, or a zero rectangle and
+// false if no focused window exists (e.g. the desktop is focused).
+func FocusedWindowBounds() (image.Rectangle, bool) {
+	rect := C.getFocusedWindowFrame()
+
+	// CGRectZero means no window was found.
+	if rect.size.width == 0 && rect.size.height == 0 {
+		return image.Rectangle{}, false
+	}
+
+	return image.Rect(
+		int(rect.origin.x),
+		int(rect.origin.y),
+		int(rect.origin.x+rect.size.width),
+		int(rect.origin.y+rect.size.height),
+	), true
+}

--- a/internal/core/infra/platform/darwin/system.go
+++ b/internal/core/infra/platform/darwin/system.go
@@ -91,6 +91,15 @@ func (s *SystemAdapter) ScreenNames(ctx context.Context) ([]string, error) {
 	return ScreenNames(), nil
 }
 
+// FocusedWindowBounds returns the bounds of the currently focused window on macOS.
+func (s *SystemAdapter) FocusedWindowBounds(
+	ctx context.Context,
+) (image.Rectangle, bool, error) {
+	bounds, found := FocusedWindowBounds()
+
+	return bounds, found, nil
+}
+
 // MoveCursorToPoint moves the mouse cursor to the specified point on macOS.
 func (s *SystemAdapter) MoveCursorToPoint(
 	ctx context.Context,

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -174,6 +174,17 @@ func (s *SystemAdapter) ScreenNames(ctx context.Context) ([]string, error) {
 	)
 }
 
+// FocusedWindowBounds returns the bounds of the currently focused window on Linux.
+// TODO(linux): implement using AT-SPI or wmctrl.
+func (s *SystemAdapter) FocusedWindowBounds(
+	ctx context.Context,
+) (image.Rectangle, bool, error) {
+	return image.Rectangle{}, false, derrors.New(
+		derrors.CodeNotSupported,
+		"FocusedWindowBounds not yet implemented on linux backend "+s.backend,
+	)
+}
+
 // MoveCursorToPoint moves the mouse cursor to the specified point on Linux.
 // TODO(linux): implement using XTest (X11) or libinput (Wayland).
 func (s *SystemAdapter) MoveCursorToPoint(

--- a/internal/core/infra/platform/windows/system.go
+++ b/internal/core/infra/platform/windows/system.go
@@ -140,6 +140,17 @@ func (s *SystemAdapter) ScreenNames(ctx context.Context) ([]string, error) {
 	)
 }
 
+// FocusedWindowBounds returns the bounds of the currently focused window on Windows.
+// TODO(windows): implement using GetForegroundWindow + GetWindowRect.
+func (s *SystemAdapter) FocusedWindowBounds(
+	ctx context.Context,
+) (image.Rectangle, bool, error) {
+	return image.Rectangle{}, false, derrors.New(
+		derrors.CodeNotSupported,
+		"FocusedWindowBounds not yet implemented on windows",
+	)
+}
+
 // MoveCursorToPoint moves the mouse cursor to the specified point on Windows.
 // TODO(windows): implement using SetCursorPos (user32.dll).
 func (s *SystemAdapter) MoveCursorToPoint(

--- a/internal/core/ports/accessibility_test.go
+++ b/internal/core/ports/accessibility_test.go
@@ -198,6 +198,12 @@ func (m *mockScreenManager) ScreenNames(ctx context.Context) ([]string, error) {
 	return nil, nil
 }
 
+func (m *mockScreenManager) FocusedWindowBounds(
+	ctx context.Context,
+) (image.Rectangle, bool, error) {
+	return image.Rect(0, 0, 800, 600), true, nil
+}
+
 func (m *mockScreenManager) MoveCursorToPoint(
 	ctx context.Context,
 	point image.Point,

--- a/internal/core/ports/mocks/system.go
+++ b/internal/core/ports/mocks/system.go
@@ -18,6 +18,7 @@ type SystemMock struct {
 	ScreenBoundsFunc                func(ctx context.Context) (image.Rectangle, error)
 	ScreenBoundsByNameFunc          func(ctx context.Context, name string) (image.Rectangle, bool, error)
 	ScreenNamesFunc                 func(ctx context.Context) ([]string, error)
+	FocusedWindowBoundsFunc         func(ctx context.Context) (image.Rectangle, bool, error)
 	MoveCursorToPointFunc           func(ctx context.Context, point image.Point, bypassSmooth bool) error
 	WaitForCursorIdleFunc           func(ctx context.Context) error
 	CursorPositionFunc              func(ctx context.Context) (image.Point, error)
@@ -113,6 +114,17 @@ func (m *SystemMock) ScreenNames(ctx context.Context) ([]string, error) {
 	}
 
 	return nil, nil
+}
+
+// FocusedWindowBounds is a mock implementation.
+func (m *SystemMock) FocusedWindowBounds(
+	ctx context.Context,
+) (image.Rectangle, bool, error) {
+	if m.FocusedWindowBoundsFunc != nil {
+		return m.FocusedWindowBoundsFunc(ctx)
+	}
+
+	return image.Rectangle{}, false, nil
 }
 
 // MoveCursorToPoint is a mock implementation.

--- a/internal/core/ports/system.go
+++ b/internal/core/ports/system.go
@@ -19,6 +19,11 @@ type ScreenManagement interface {
 	// Returns nil or an empty slice when no screens are detected.
 	ScreenNames(ctx context.Context) ([]string, error)
 
+	// FocusedWindowBounds returns the bounds of the currently focused window.
+	// Returns the bounds and true if a window was found, or a zero rectangle
+	// and false if no focused window exists (e.g. the desktop is focused).
+	FocusedWindowBounds(ctx context.Context) (image.Rectangle, bool, error)
+
 	// MoveCursorToPoint moves the mouse cursor to the specified point.
 	// If bypassSmooth is true, smooth cursor configuration is bypassed.
 	MoveCursorToPoint(ctx context.Context, point image.Point, bypassSmooth bool) error


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds `--window` flag to `action move_mouse` command. This allows to move the cursor position to the center of the focused window.

```bash
neru action move_mouse --window
neru action move_mouse --window --x 100 --y 100
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

https://github.com/y3owk1n/neru/discussions/577#discussioncomment-16801729

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/41df5cce-0ee5-44cf-a7e0-99426409a3f8

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
