### PR TITLE
fix(hints): ensure menubar item adhere to strictFiltering

### DIFF
--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -65,7 +65,7 @@ func (a *Adapter) addMenubarElements(
 	menubarRoles[len(originalRoles)] = "AXMenuBarItem"
 
 	// Get menubar elements
-	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements()
+	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements(false)
 	if menubarNodesErr != nil {
 		a.logger.Warn("Failed to get menubar elements", zap.Error(menubarNodesErr))
 	} else {

--- a/internal/core/infra/accessibility/client.go
+++ b/internal/core/infra/accessibility/client.go
@@ -22,7 +22,7 @@ type AXClient interface {
 	FocusedApplication() (AXApp, error)
 	ApplicationByBundleID(bundleID string) (AXApp, error)
 	ClickableNodes(root AXElement, includeOffscreen bool, roles []string) ([]AXNode, error)
-	MenuBarClickableElements() ([]AXNode, error)
+	MenuBarClickableElements(strictFiltering bool) ([]AXNode, error)
 	ClickableElementsFromBundleID(
 		bundleID string,
 		roles []string,

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -159,8 +159,15 @@ func (c *InfraAXClient) ApplicationByBundleID(bundleID string) (AXApp, error) {
 }
 
 // MenuBarClickableElements returns clickable elements in the menu bar.
-func (c *InfraAXClient) MenuBarClickableElements() ([]AXNode, error) {
-	nodes, nodesErr := MenuBarClickableElements(c.logger, c.cache, c.configProvider)
+func (c *InfraAXClient) MenuBarClickableElements(
+	strictFiltering bool,
+) ([]AXNode, error) {
+	nodes, nodesErr := MenuBarClickableElements(
+		c.logger,
+		c.cache,
+		c.configProvider,
+		strictFiltering,
+	)
 	if nodesErr != nil {
 		return nil, derrors.Wrap(
 			nodesErr,

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -40,7 +40,8 @@ type MockAXClient struct {
 	LastCalledBundleID         string
 	LastClickableNodesRoles    []string
 	LastBundleRoles            []string
-	ClickableNodesRolesHistory [][]string
+	LastMenuBarStrictFiltering bool
+	ClickableNodesRolesHistory  [][]string
 }
 
 // FrontmostWindow returns the configured frontmost window or error.
@@ -70,6 +71,10 @@ func (m *MockAXClient) ClickableNodes(_ AXElement, _ bool, roles []string) ([]AX
 
 // MenuBarClickableElements returns the configured menu bar nodes or error.
 func (m *MockAXClient) MenuBarClickableElements(strictFiltering bool) ([]AXNode, error) {
+	m.mu.Lock()
+	m.LastMenuBarStrictFiltering = strictFiltering
+	m.mu.Unlock()
+
 	return m.MockMenuBarNodes, m.MockMenuBarNodesErr
 }
 

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -41,7 +41,7 @@ type MockAXClient struct {
 	LastClickableNodesRoles    []string
 	LastBundleRoles            []string
 	LastMenuBarStrictFiltering bool
-	ClickableNodesRolesHistory  [][]string
+	ClickableNodesRolesHistory [][]string
 }
 
 // FrontmostWindow returns the configured frontmost window or error.

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -69,7 +69,7 @@ func (m *MockAXClient) ClickableNodes(_ AXElement, _ bool, roles []string) ([]AX
 }
 
 // MenuBarClickableElements returns the configured menu bar nodes or error.
-func (m *MockAXClient) MenuBarClickableElements() ([]AXNode, error) {
+func (m *MockAXClient) MenuBarClickableElements(strictFiltering bool) ([]AXNode, error) {
 	return m.MockMenuBarNodes, m.MockMenuBarNodesErr
 }
 

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -11,6 +11,7 @@ func MenuBarClickableElements(
 	logger *zap.Logger,
 	cache *InfoCache,
 	configProvider config.Provider,
+	strictFiltering bool,
 ) ([]*TreeNode, error) {
 	logger.Debug("Getting clickable elements for menu bar")
 
@@ -32,6 +33,8 @@ func MenuBarClickableElements(
 
 	opts := DefaultTreeOptions(logger)
 	opts.SetCache(cache)
+	opts.SetStrictFiltering(strictFiltering)
+	opts.SetIncludeOutOfBounds(!strictFiltering)
 
 	if cfg := currentConfig(configProvider); cfg != nil {
 		opts.SetMaxDepth(cfg.Hints.MaxDepth)

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -359,7 +359,6 @@ var interactiveLeafRoles = map[string]bool{
 	"AXDisclosureTriangle": true,
 	"AXTextArea":           true,
 	"AXMenuButton":         true,
-	"AXMenuItem":           true,
 }
 
 func buildTreeRecursive(


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes the issue where on macOS menubar items are not showing hint labels.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

<img width="542" height="388" alt="Screenshot 2026-05-06 at 10 39 32 PM" src="https://github.com/user-attachments/assets/0bbab0fa-cda5-4749-b76d-95dbd51967c8" />

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
