### PR TITLE
fix(hints): include `AXPopover` windows

### DIFF
--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -184,9 +184,12 @@ func (a *Adapter) ClickableElements(
 				windowsToProcess = append(windowsToProcess, frontmost)
 
 				// Add popover windows (siblings to the main window)
+				// Release non-popover windows to avoid leaks
 				for _, w := range allWindows {
 					if w.Role() == "AXPopover" {
 						windowsToProcess = append(windowsToProcess, w)
+					} else {
+						w.Release()
 					}
 				}
 

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -193,12 +193,6 @@ func (a *Adapter) ClickableElements(
 					}
 				}
 
-				if len(windowsToProcess) == 0 {
-					frontmost.Release()
-
-					return []*element.Element{}, nil
-				}
-
 				var allElements []*element.Element
 				for _, window := range windowsToProcess {
 					clickableNodes, clickableNodesErr := a.client.ClickableNodes(

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -158,27 +158,74 @@ func (a *Adapter) ClickableElements(
 	}
 
 	if !missionControlActive {
-		// Query frontmost window
+		// Query frontmost window AND popover windows (not all windows)
+		// AXPopover windows are siblings to the main window, so we need to get them separately
 		waitGroup.Add(1)
 
 		go func() {
-			collectElements("frontmost window", func() ([]*element.Element, error) {
-				frontmostWindow, frontmostWindowErr := a.client.FrontmostWindow()
-				if frontmostWindowErr != nil {
-					return nil, frontmostWindowErr
-				}
-				defer frontmostWindow.Release()
-
-				clickableNodes, clickableNodesErr := a.client.ClickableNodes(
-					frontmostWindow,
-					filter.IncludeOffscreen,
-					stringRoles(filter.Roles),
-				)
-				if clickableNodesErr != nil {
-					return nil, clickableNodesErr
+			collectElements("windows", func() ([]*element.Element, error) {
+				// Get frontmost window (the main/focused window)
+				frontmost, frontmostErr := a.client.FrontmostWindow()
+				if frontmostErr != nil {
+					return nil, frontmostErr
 				}
 
-				return a.processClickableNodes(ctx, clickableNodes, filter)
+				// Get all windows to find popovers
+				allWindows, allWindowsErr := a.client.AllWindows()
+				if allWindowsErr != nil {
+					frontmost.Release()
+
+					return nil, allWindowsErr
+				}
+
+				// Collect windows to process: frontmost + any AXPopover
+				var windowsToProcess []AXWindow
+
+				windowsToProcess = append(windowsToProcess, frontmost)
+
+				// Add popover windows (siblings to the main window)
+				for _, w := range allWindows {
+					if w.Role() == "AXPopover" {
+						windowsToProcess = append(windowsToProcess, w)
+					}
+				}
+
+				if len(windowsToProcess) == 0 {
+					frontmost.Release()
+
+					return []*element.Element{}, nil
+				}
+
+				var allElements []*element.Element
+				for _, window := range windowsToProcess {
+					clickableNodes, clickableNodesErr := a.client.ClickableNodes(
+						window,
+						filter.IncludeOffscreen,
+						stringRoles(filter.Roles),
+					)
+					if clickableNodesErr != nil {
+						window.Release()
+
+						continue
+					}
+
+					windowElements, processErr := a.processClickableNodes(
+						ctx,
+						clickableNodes,
+						filter,
+					)
+					if processErr != nil {
+						window.Release()
+
+						continue
+					}
+
+					allElements = append(allElements, windowElements...)
+
+					window.Release()
+				}
+
+				return allElements, nil
 			})
 		}()
 	}

--- a/internal/core/infra/accessibility/adapter_test.go
+++ b/internal/core/infra/accessibility/adapter_test.go
@@ -413,9 +413,11 @@ func TestAdapter_ClickableRoles(t *testing.T) {
 
 func TestAdapter_RolePassing(t *testing.T) {
 	logger := zap.NewNop()
+	mockWindow := &accessibility.MockWindow{}
 	mockClient := &accessibility.MockAXClient{
 		MockPermissions:     true,
-		MockFrontmostWindow: &accessibility.MockWindow{},
+		MockFrontmostWindow: mockWindow,
+		MockAllWindows:      []accessibility.AXWindow{mockWindow},
 	}
 
 	initialRoles := []string{"AXButton"}

--- a/internal/core/infra/accessibility/client.go
+++ b/internal/core/infra/accessibility/client.go
@@ -7,18 +7,21 @@ import (
 )
 
 // AXElement represents a generic accessibility element.
-//
-//nolint:iface // Intentionally small interface for future extension
 type AXElement interface {
 	Release()
 }
 
+// AXWindow represents a window element.
+type AXWindow interface {
+	AXElement
+	Role() string
+}
+
 // AXClient defines the interface for accessibility operations.
-//
-//nolint:interfacebloat // Facade interface for accessibility operations
 type AXClient interface {
 	// Window and App operations
 	FrontmostWindow() (AXWindow, error)
+	AllWindows() ([]AXWindow, error)
 	FocusedApplication() (AXApp, error)
 	ApplicationByBundleID(bundleID string) (AXApp, error)
 	ClickableNodes(root AXElement, includeOffscreen bool, roles []string) ([]AXNode, error)
@@ -49,13 +52,6 @@ type AXClient interface {
 
 	// Cache
 	ClearCache()
-}
-
-// AXWindow represents a window element.
-//
-//nolint:iface // Intentionally small interface for future extension
-type AXWindow interface {
-	AXElement
 }
 
 // AXAppInfo contains information about an application.

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -56,6 +56,21 @@ func (c *InfraAXClient) FrontmostWindow() (AXWindow, error) {
 	return &InfraWindow{element: window}, nil
 }
 
+// AllWindows returns all windows of the focused application.
+func (c *InfraAXClient) AllWindows() ([]AXWindow, error) {
+	windows, err := AllWindows()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]AXWindow, len(windows))
+	for i, w := range windows {
+		result[i] = &InfraWindow{element: w}
+	}
+
+	return result, nil
+}
+
 // FocusedApplication returns the focused application.
 func (c *InfraAXClient) FocusedApplication() (AXApp, error) {
 	app := FocusedApplication()
@@ -325,6 +340,18 @@ func (c *InfraAXClient) ClearCache() {
 // InfraWindow wraps an Window.
 type InfraWindow struct {
 	element *Element
+}
+
+// Role returns the window role (e.g., "AXWindow", "AXPopover").
+func (w *InfraWindow) Role() string {
+	if w.element != nil {
+		info, err := w.element.Info()
+		if err == nil && info != nil {
+			return info.Role()
+		}
+	}
+
+	return ""
 }
 
 // Release releases the Window.

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -13,6 +13,8 @@ type MockAXClient struct {
 
 	MockFrontmostWindow    AXWindow
 	MockFrontmostWindowErr error
+	MockAllWindows         []AXWindow
+	MockAllWindowsErr      error
 
 	MockFocusedApp    AXApp
 	MockFocusedAppErr error
@@ -47,6 +49,11 @@ type MockAXClient struct {
 // FrontmostWindow returns the configured frontmost window or error.
 func (m *MockAXClient) FrontmostWindow() (AXWindow, error) {
 	return m.MockFrontmostWindow, m.MockFrontmostWindowErr
+}
+
+// AllWindows returns the configured windows or error.
+func (m *MockAXClient) AllWindows() ([]AXWindow, error) {
+	return m.MockAllWindows, m.MockAllWindowsErr
 }
 
 // FocusedApplication returns the configured focused application or error.
@@ -159,6 +166,9 @@ type MockWindow struct{}
 
 // Release is a no-op.
 func (w *MockWindow) Release() {}
+
+// Role returns "AXWindow".
+func (w *MockWindow) Role() string { return "AXWindow" }
 
 // MockApp is a mock implementation of AXApp.
 type MockApp struct {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes an issue where hints are not displayed within `AXPopover` windows (e.g. Apple Music)

The problem is that `AXPopover` are not the child of `AXWindow` but it's sibling. And our tree starts from `AXWindow` for the frontmost window. Now we will collect all the windows and only process `AXPopover` root and the frontmost `AXWindow`.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

<img width="964" height="624" alt="Screenshot 2026-05-06 at 11 00 33 PM" src="https://github.com/user-attachments/assets/06b6445e-a4cd-4901-b465-cf709633caf8" />

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
