### PR TITLE
fix(hints): remove `AXTextField` from leaf roles so that finder search works

### DIFF
--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -352,7 +352,6 @@ var interactiveLeafRoles = map[string]bool{
 	"AXRadioButton":        true,
 	"AXLink":               true,
 	"AXPopUpButton":        true,
-	"AXTextField":          true,
 	"AXSlider":             true,
 	"AXTabButton":          true,
 	"AXSwitch":             true,


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR removes `AXTextField` from the `interactiveLeafRoles`. This is required for search popup to be able to show hints label in `Finder.app` specifically.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

<img width="554" height="434" alt="Screenshot 2026-05-06 at 11 25 53 PM" src="https://github.com/user-attachments/assets/d75feeaf-d83c-4062-9138-2f784d7a662a" />

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
