### PR TITLE
chore: remove `AXMenuButton`

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -70,7 +70,6 @@ clickable_roles = [
     "AXSwitch",
     "AXDisclosureTriangle",
     "AXTextArea",
-    "AXMenuButton",
     "AXMenuItem",
     "AXCell",
     "AXRow",

--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -31,7 +31,6 @@ clickable_roles = [
     "AXSwitch",
     "AXDisclosureTriangle",
     "AXTextArea",
-    "AXMenuButton",
     "AXMenuItem",
     "AXCell",
     "AXRow",

--- a/internal/config/config_darwin.go
+++ b/internal/config/config_darwin.go
@@ -23,7 +23,7 @@ func applyPlatformDefaults(cfg *Config) {
 		"AXSwitch",
 		"AXDisclosureTriangle",
 		"AXTextArea",
-		"AXMenuButton",
+		"AXMenuItem",
 		"AXCell",
 		"AXRow",
 	)

--- a/internal/config/config_darwin.go
+++ b/internal/config/config_darwin.go
@@ -24,7 +24,6 @@ func applyPlatformDefaults(cfg *Config) {
 		"AXDisclosureTriangle",
 		"AXTextArea",
 		"AXMenuButton",
-		"AXMenuItem",
 		"AXCell",
 		"AXRow",
 	)

--- a/internal/core/domain/element/element.go
+++ b/internal/core/domain/element/element.go
@@ -22,7 +22,6 @@ const (
 	RoleCheckBox           Role = "AXCheckBox"
 	RoleRadioButton        Role = "AXRadioButton"
 	RoleMenuItem           Role = "AXMenuItem"
-	RoleMenuButton         Role = "AXMenuButton"
 	RolePopUpButton        Role = "AXPopUpButton"
 	RoleTabButton          Role = "AXTabButton"
 	RoleSlider             Role = "AXSlider"

--- a/internal/core/infra/accessibility/cache.go
+++ b/internal/core/infra/accessibility/cache.go
@@ -96,7 +96,6 @@ var staticRoles = map[string]bool{
 	"AXButton":             true,
 	"AXLink":               true,
 	"AXMenuItem":           true,
-	"AXMenuButton":         true,
 	"AXPopUpButton":        true,
 	"AXTabButton":          true,
 	"AXCheckBox":           true,

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -357,7 +357,6 @@ var interactiveLeafRoles = map[string]bool{
 	"AXSwitch":             true,
 	"AXDisclosureTriangle": true,
 	"AXTextArea":           true,
-	"AXMenuButton":         true,
 }
 
 func buildTreeRecursive(


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR cleanups all `AXMenuButton`, no idea why it's here, don't think it is a valid role. Nothing should happen after this change.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
