### PR TITLE
fix(cli): properly support comma-separated values for `--role` and `--text` flags

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -253,17 +253,14 @@ neru hints --role AXLink --text docs
 # Multiple roles/values - comma-separated for convenience
 neru hints --role AXButton,AXLink --text save,cancel
 
-# Escaped comma to match literal comma in text/role name
-neru hints --role AXButton\,label --text a\,b
-
 # With repeat - filter persists on re-activation
 neru hints --text next --action left_click --repeat
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--role` | Filter by AX role. Comma-separated for multiple (e.g., `--role AXButton,AXLink`). Use `\,` to escape literal comma. |
-| `--text` | Filter elements by text content (title, description, or value). Case-insensitive substring match. Comma-separated for OR match (matches any). Use `\,` to escape literal comma. |
+| `--role` | Filter by AX role. Comma-separated for multiple (e.g., `--role AXButton,AXLink`). |
+| `--text` | Filter elements by text content (title, description, or value). Case-insensitive substring match. Comma-separated for OR match (matches any). |
 
 The filter is preserved across repeat activations, making it easy to click multiple elements of the same type in succession.
 
@@ -459,7 +456,7 @@ neru action left_click --modifier cmd,shift    # Cmd+Shift+click
 neru action right_click --modifier alt         # Alt+right-click
 ```
 
-**Valid modifiers:** `cmd` (or `command`), `shift`, `alt` (or `option`), `ctrl` (or `control`). Combine with commas. Use `\,` to escape a literal comma in the modifier name (rare).
+**Valid modifiers:** `cmd` (or `command`), `shift`, `alt` (or `option`), `ctrl` (or `control`). Combine with commas: `--modifier cmd,shift`.
 
 ### Mouse movement
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -250,8 +250,11 @@ neru hints --role AXButton --text submit
 # Show only links with "docs" in title/description/value
 neru hints --role AXLink --text docs
 
-# Multiple roles + text filter
-neru hints --role AXButton --role AXLink --text save
+# Multiple roles/values - comma-separated for convenience
+neru hints --role AXButton,AXLink --text save,cancel
+
+# Escaped comma to match literal comma in text/role name
+neru hints --role AXButton\,label --text a\,b
 
 # With repeat - filter persists on re-activation
 neru hints --text next --action left_click --repeat
@@ -259,8 +262,8 @@ neru hints --text next --action left_click --repeat
 
 | Flag | Description |
 |------|-------------|
-| `--role` | Filter by AX role (can be repeated). Overrides configured clickable roles. |
-| `--text` | Filter elements by text content (title, description, or value). Case-insensitive substring match. |
+| `--role` | Filter by AX role. Comma-separated for multiple (e.g., `--role AXButton,AXLink`). Use `\,` to escape literal comma. |
+| `--text` | Filter elements by text content (title, description, or value). Case-insensitive substring match. Comma-separated for OR match (matches any). Use `\,` to escape literal comma. |
 
 The filter is preserved across repeat activations, making it easy to click multiple elements of the same type in succession.
 
@@ -456,7 +459,7 @@ neru action left_click --modifier cmd,shift    # Cmd+Shift+click
 neru action right_click --modifier alt         # Alt+right-click
 ```
 
-**Valid modifiers:** `cmd` (or `command`), `shift`, `alt` (or `option`), `ctrl` (or `control`). Combine with commas: `--modifier cmd,shift`.
+**Valid modifiers:** `cmd` (or `command`), `shift`, `alt` (or `option`), `ctrl` (or `control`). Combine with commas. Use `\,` to escape a literal comma in the modifier name (rare).
 
 ### Mouse movement
 

--- a/internal/app/components/hints/context.go
+++ b/internal/app/components/hints/context.go
@@ -11,7 +11,7 @@ type baseContext struct {
 	repeat                bool
 	cursorFollowSelection bool
 	filterRoles           []string
-	filterTextContains    string
+	filterTextContains    []string
 }
 
 // SetPendingAction sets the action to execute when mode selection is complete.
@@ -57,7 +57,7 @@ func (c *baseContext) Reset() {
 	c.repeat = false
 	c.cursorFollowSelection = false
 	c.filterRoles = nil
-	c.filterTextContains = ""
+	c.filterTextContains = nil
 }
 
 // SetFilterRoles sets the filter roles for hint mode.
@@ -71,12 +71,12 @@ func (c *baseContext) FilterRoles() []string {
 }
 
 // SetFilterTextContains sets the filter text for hint mode.
-func (c *baseContext) SetFilterTextContains(text string) {
-	c.filterTextContains = text
+func (c *baseContext) SetFilterTextContains(texts []string) {
+	c.filterTextContains = texts
 }
 
 // FilterTextContains returns the filter text.
-func (c *baseContext) FilterTextContains() string {
+func (c *baseContext) FilterTextContains() []string {
 	return c.filterTextContains
 }
 

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -147,7 +147,8 @@ func parseActionArgs(rawArgs []string) (parsedActionArgs, bool) {
 				break
 			}
 
-			parsed.modifierStr = val
+			parts := parseCSVWithEscape(val)
+			parsed.modifierStr = strings.Join(parts, ",")
 		case strings.HasPrefix(arg, "--x") && (arg == "--x" || arg[len("--x")] == '='):
 			val, newIdx, ok := extractIntFlag(rawArgs, idx, "--x")
 			idx = newIdx

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -147,8 +147,7 @@ func parseActionArgs(rawArgs []string) (parsedActionArgs, bool) {
 				break
 			}
 
-			parts := parseCSVWithEscape(val)
-			parsed.modifierStr = strings.Join(parts, ",")
+			parsed.modifierStr = val
 		case strings.HasPrefix(arg, "--x") && (arg == "--x" || arg[len("--x")] == '='):
 			val, newIdx, ok := extractIntFlag(rawArgs, idx, "--x")
 			idx = newIdx

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -126,6 +126,121 @@ func TestParseActionArgs_BareFlag(t *testing.T) {
 	}
 }
 
+func TestParseActionArgs_ModifierCSV(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantModStr string
+	}{
+		{
+			name:       "single modifier",
+			args:       []string{"--modifier=cmd"},
+			wantModStr: "cmd",
+		},
+		{
+			name:       "comma-separated modifiers",
+			args:       []string{"--modifier=cmd,shift"},
+			wantModStr: "cmd,shift",
+		},
+		{
+			name:       "escaped comma",
+			args:       []string{"--modifier=cmd\\,shift"},
+			wantModStr: "cmd,shift",
+		},
+		{
+			name:       "all modifiers",
+			args:       []string{"--modifier=cmd,shift,alt,ctrl"},
+			wantModStr: "cmd,shift,alt,ctrl",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			parsed, parseErr := parseActionArgs(testCase.args)
+			if parseErr {
+				t.Fatalf("parseActionArgs() unexpected parse error: %v", parseErr)
+			}
+
+			if parsed.modifierStr != testCase.wantModStr {
+				t.Fatalf(
+					"parseActionArgs() expected modifierStr %q, got %q",
+					testCase.wantModStr,
+					parsed.modifierStr,
+				)
+			}
+		})
+	}
+}
+
+func TestParseCSVWithEscape(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty",
+			input: "",
+			want:  []string{""},
+		},
+		{
+			name:  "single value",
+			input: "foo",
+			want:  []string{"foo"},
+		},
+		{
+			name:  "comma-separated",
+			input: "foo,bar,baz",
+			want:  []string{"foo", "bar", "baz"},
+		},
+		{
+			name:  "escaped comma",
+			input: "foo\\,bar",
+			want:  []string{"foo,bar"},
+		},
+		{
+			name:  "mixed escaped and regular",
+			input: "foo,bar\\,baz,qux",
+			want:  []string{"foo", "bar,baz", "qux"},
+		},
+		{
+			name:  "multiple escaped",
+			input: "a\\,b\\,c",
+			want:  []string{"a,b,c"},
+		},
+		{
+			name:  "trailing comma",
+			input: "foo,",
+			want:  []string{"foo", ""},
+		},
+		{
+			name:  "leading comma",
+			input: ",foo",
+			want:  []string{"", "foo"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := parseCSVWithEscape(testCase.input)
+
+			if len(got) != len(testCase.want) {
+				t.Fatalf(
+					"parseCSVWithEscape() returned %d elements, want %d",
+					len(got),
+					len(testCase.want),
+				)
+			}
+
+			for i := range got {
+				if got[i] != testCase.want[i] {
+					t.Fatalf("parseCSVWithEscape()[%d] = %q, want %q", i, got[i], testCase.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestHandleAction_MoveMouseWithoutTargetingOrSelectionErrors(t *testing.T) {
 	controller := &IPCControllerActions{
 		appState: state.NewAppState(),

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -143,11 +143,6 @@ func TestParseActionArgs_ModifierCSV(t *testing.T) {
 			wantModStr: "cmd,shift",
 		},
 		{
-			name:       "escaped comma",
-			args:       []string{"--modifier=cmd\\,shift"},
-			wantModStr: "cmd,shift",
-		},
-		{
 			name:       "all modifiers",
 			args:       []string{"--modifier=cmd,shift,alt,ctrl"},
 			wantModStr: "cmd,shift,alt,ctrl",
@@ -172,7 +167,7 @@ func TestParseActionArgs_ModifierCSV(t *testing.T) {
 	}
 }
 
-func TestParseCSVWithEscape(t *testing.T) {
+func TestParseCSV(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
@@ -181,7 +176,7 @@ func TestParseCSVWithEscape(t *testing.T) {
 		{
 			name:  "empty",
 			input: "",
-			want:  []string{""},
+			want:  nil,
 		},
 		{
 			name:  "single value",
@@ -192,21 +187,6 @@ func TestParseCSVWithEscape(t *testing.T) {
 			name:  "comma-separated",
 			input: "foo,bar,baz",
 			want:  []string{"foo", "bar", "baz"},
-		},
-		{
-			name:  "escaped comma",
-			input: "foo\\,bar",
-			want:  []string{"foo,bar"},
-		},
-		{
-			name:  "mixed escaped and regular",
-			input: "foo,bar\\,baz,qux",
-			want:  []string{"foo", "bar,baz", "qux"},
-		},
-		{
-			name:  "multiple escaped",
-			input: "a\\,b\\,c",
-			want:  []string{"a,b,c"},
 		},
 		{
 			name:  "trailing comma",
@@ -222,19 +202,15 @@ func TestParseCSVWithEscape(t *testing.T) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			got := parseCSVWithEscape(testCase.input)
+			got := parseCSV(testCase.input)
 
 			if len(got) != len(testCase.want) {
-				t.Fatalf(
-					"parseCSVWithEscape() returned %d elements, want %d",
-					len(got),
-					len(testCase.want),
-				)
+				t.Fatalf("parseCSV() returned %d elements, want %d", len(got), len(testCase.want))
 			}
 
 			for i := range got {
 				if got[i] != testCase.want[i] {
-					t.Fatalf("parseCSVWithEscape()[%d] = %q, want %q", i, got[i], testCase.want[i])
+					t.Fatalf("parseCSV()[%d] = %q, want %q", i, got[i], testCase.want[i])
 				}
 			}
 		})

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -13,6 +13,36 @@ import (
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
 )
 
+func parseCSVWithEscape(input string) []string {
+	var result []string
+
+	var current strings.Builder
+
+	escaped := false
+
+	for i := range len(input) {
+		char := rune(input[i])
+
+		switch {
+		case escaped:
+			current.WriteRune(char)
+
+			escaped = false
+		case char == '\\':
+			escaped = true
+		case char == ',':
+			result = append(result, current.String())
+			current.Reset()
+		default:
+			current.WriteRune(char)
+		}
+	}
+
+	result = append(result, current.String())
+
+	return result
+}
+
 // IPCControllerLifecycle handles lifecycle-related IPC commands.
 type IPCControllerLifecycle struct {
 	appState *state.AppState
@@ -140,7 +170,7 @@ type ModeActivationOptions struct {
 	Repeat                bool
 	CursorFollowSelection *bool
 	FilterRoles           []string
-	FilterTextContains    string
+	FilterTextContains    []string
 }
 
 // extractModeOptions extracts and validates the optional action and repeat
@@ -236,7 +266,8 @@ func (h *IPCControllerModes) extractModeOptions(
 				return opts, &resp
 			}
 		case strings.HasPrefix(arg, "--role="):
-			opts.FilterRoles = append(opts.FilterRoles, strings.TrimPrefix(arg, "--role="))
+			roles := parseCSVWithEscape(strings.TrimPrefix(arg, "--role="))
+			opts.FilterRoles = append(opts.FilterRoles, roles...)
 		case arg == "--role":
 			if startIdx+1 >= len(cmd.Args) {
 				resp := ipc.Response{
@@ -249,9 +280,11 @@ func (h *IPCControllerModes) extractModeOptions(
 			}
 
 			startIdx++
-			opts.FilterRoles = append(opts.FilterRoles, cmd.Args[startIdx])
+			roles := parseCSVWithEscape(cmd.Args[startIdx])
+			opts.FilterRoles = append(opts.FilterRoles, roles...)
 		case strings.HasPrefix(arg, "--text="):
-			opts.FilterTextContains = strings.TrimPrefix(arg, "--text=")
+			texts := parseCSVWithEscape(strings.TrimPrefix(arg, "--text="))
+			opts.FilterTextContains = append(opts.FilterTextContains, texts...)
 		case arg == "--text":
 			if startIdx+1 >= len(cmd.Args) {
 				resp := ipc.Response{
@@ -264,7 +297,8 @@ func (h *IPCControllerModes) extractModeOptions(
 			}
 
 			startIdx++
-			opts.FilterTextContains = cmd.Args[startIdx]
+			texts := parseCSVWithEscape(cmd.Args[startIdx])
+			opts.FilterTextContains = append(opts.FilterTextContains, texts...)
 		case opts.Action == nil:
 			actionArg := arg
 			opts.Action = &actionArg

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -248,10 +248,10 @@ func (h *IPCControllerModes) extractModeOptions(
 				opts.FilterRoles,
 				parseCSV(strings.TrimPrefix(arg, "--role="))...)
 		case arg == "--role":
-			if startIdx+1 >= len(cmd.Args) {
+			if startIdx+1 >= len(cmd.Args) || cmd.Args[startIdx+1] == "--role" {
 				resp := ipc.Response{
 					Success: false,
-					Message: "--role requires a value",
+					Message: "--role requires a value (use comma-separated: --role=AXButton,AXLink)",
 					Code:    ipc.CodeInvalidInput,
 				}
 
@@ -264,10 +264,10 @@ func (h *IPCControllerModes) extractModeOptions(
 			texts := parseCSV(strings.TrimPrefix(arg, "--text="))
 			opts.FilterTextContains = append(opts.FilterTextContains, texts...)
 		case arg == "--text":
-			if startIdx+1 >= len(cmd.Args) {
+			if startIdx+1 >= len(cmd.Args) || cmd.Args[startIdx+1] == "--text" {
 				resp := ipc.Response{
 					Success: false,
-					Message: "--text requires a value",
+					Message: "--text requires a value (use comma-separated: --text=foo,bar)",
 					Code:    ipc.CodeInvalidInput,
 				}
 

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -13,34 +13,12 @@ import (
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
 )
 
-func parseCSVWithEscape(input string) []string {
-	var result []string
-
-	var current strings.Builder
-
-	escaped := false
-
-	for i := range len(input) {
-		char := rune(input[i])
-
-		switch {
-		case escaped:
-			current.WriteRune(char)
-
-			escaped = false
-		case char == '\\':
-			escaped = true
-		case char == ',':
-			result = append(result, current.String())
-			current.Reset()
-		default:
-			current.WriteRune(char)
-		}
+func parseCSV(input string) []string {
+	if input == "" {
+		return nil
 	}
 
-	result = append(result, current.String())
-
-	return result
+	return strings.Split(input, ",")
 }
 
 // IPCControllerLifecycle handles lifecycle-related IPC commands.
@@ -266,8 +244,9 @@ func (h *IPCControllerModes) extractModeOptions(
 				return opts, &resp
 			}
 		case strings.HasPrefix(arg, "--role="):
-			roles := parseCSVWithEscape(strings.TrimPrefix(arg, "--role="))
-			opts.FilterRoles = append(opts.FilterRoles, roles...)
+			opts.FilterRoles = append(
+				opts.FilterRoles,
+				parseCSV(strings.TrimPrefix(arg, "--role="))...)
 		case arg == "--role":
 			if startIdx+1 >= len(cmd.Args) {
 				resp := ipc.Response{
@@ -280,10 +259,9 @@ func (h *IPCControllerModes) extractModeOptions(
 			}
 
 			startIdx++
-			roles := parseCSVWithEscape(cmd.Args[startIdx])
-			opts.FilterRoles = append(opts.FilterRoles, roles...)
+			opts.FilterRoles = append(opts.FilterRoles, parseCSV(cmd.Args[startIdx])...)
 		case strings.HasPrefix(arg, "--text="):
-			texts := parseCSVWithEscape(strings.TrimPrefix(arg, "--text="))
+			texts := parseCSV(strings.TrimPrefix(arg, "--text="))
 			opts.FilterTextContains = append(opts.FilterTextContains, texts...)
 		case arg == "--text":
 			if startIdx+1 >= len(cmd.Args) {
@@ -297,7 +275,7 @@ func (h *IPCControllerModes) extractModeOptions(
 			}
 
 			startIdx++
-			texts := parseCSVWithEscape(cmd.Args[startIdx])
+			texts := parseCSV(cmd.Args[startIdx])
 			opts.FilterTextContains = append(opts.FilterTextContains, texts...)
 		case opts.Action == nil:
 			actionArg := arg

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -21,7 +21,7 @@ type ModeActivationOptions struct {
 	Repeat                bool
 	CursorFollowSelection *bool
 	FilterRoles           []string
-	FilterTextContains    string
+	FilterTextContains    []string
 }
 
 const (
@@ -101,7 +101,7 @@ func (h *Handler) activateHintModeWithAction(
 	repeat bool,
 	cursorFollowSelection *bool,
 	filterRoles []string,
-	filterTextContains string,
+	filterTextContains []string,
 ) {
 	h.activateHintModeInternal(
 		false,
@@ -130,7 +130,7 @@ func (h *Handler) activateHintModeInternal(
 	actionStr *string,
 	cursorFollowSelection *bool,
 	filterRoles []string,
-	filterTextContains string,
+	filterTextContains []string,
 ) {
 	// Detect refresh before validation so we can clean up on failure
 	isRefresh := !preserveActionMode && h.appState.CurrentMode() == domain.ModeHints

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -46,7 +46,7 @@ func NewHintService(
 func (s *HintService) ShowHints(
 	ctx context.Context,
 	filterRoles []string,
-	filterTextContains string,
+	filterTextContains []string,
 ) ([]*hint.Interface, error) {
 	s.logger.Info("Showing hints")
 
@@ -97,13 +97,18 @@ func (s *HintService) ShowHints(
 	filter.IncludeNotificationCenter = cfg.IncludeNCHints
 	filter.IncludeStageManager = cfg.IncludeStageManagerHints
 
-	// Apply text filter if provided
-	if filterTextContains != "" {
-		filter.TitleContains = filterTextContains
-		filter.DescriptionContains = filterTextContains
-		filter.ValueContains = filterTextContains
+	// Apply text filter if provided (OR match - element matches if any text contains match)
+	if len(filterTextContains) > 0 {
+		filter.TitleContains = filterTextContains[0]
+		filter.DescriptionContains = filterTextContains[0]
+
+		filter.ValueContains = filterTextContains[0]
+		if len(filterTextContains) > 1 {
+			filter.TextContainsList = filterTextContains[1:]
+		}
+
 		s.logger.Debug("Applying text filter",
-			zap.String("text", filterTextContains))
+			zap.Strings("text", filterTextContains))
 	}
 
 	// Get clickable elements

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -88,6 +88,10 @@ func (s *HintService) ShowHints(
 
 	filter.Roles = make([]element.Role, 0, len(roles))
 	for _, role := range roles {
+		if role == "" {
+			continue
+		}
+
 		filter.Roles = append(filter.Roles, element.Role(role))
 	}
 

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -270,7 +270,7 @@ func TestHintService_ShowHints(t *testing.T) {
 			ctx := context.Background()
 
 			// Act
-			hints, hintsErr := service.ShowHints(ctx, nil, "")
+			hints, hintsErr := service.ShowHints(ctx, nil, nil)
 
 			// Assert
 			if testCase.wantErr && hintsErr == nil {

--- a/internal/app/services/services_integration_darwin_test.go
+++ b/internal/app/services/services_integration_darwin_test.go
@@ -67,7 +67,7 @@ func TestHintServiceIntegration(t *testing.T) {
 
 	t.Run("ShowHints integration", func(t *testing.T) {
 		// This tests the full pipeline: accessibility -> hint generation -> overlay
-		hints, err := hintService.ShowHints(ctx, nil, "")
+		hints, err := hintService.ShowHints(ctx, nil, nil)
 
 		// Check that the service doesn't panic and returns some result
 		// In different environments, this may succeed or fail based on permissions/elements

--- a/internal/core/infra/accessibility/adapter_filtering.go
+++ b/internal/core/infra/accessibility/adapter_filtering.go
@@ -73,6 +73,9 @@ func (a *Adapter) MatchesFilter(
 
 		value := element.Value()
 		for _, text := range filter.TextContainsList {
+			if text == "" {
+				continue
+			}
 			textLower := strings.ToLower(text)
 			if (title != "" && strings.Contains(strings.ToLower(title), textLower)) ||
 				(description != "" && strings.Contains(strings.ToLower(description), textLower)) ||

--- a/internal/core/infra/accessibility/adapter_filtering.go
+++ b/internal/core/infra/accessibility/adapter_filtering.go
@@ -76,6 +76,7 @@ func (a *Adapter) MatchesFilter(
 			if text == "" {
 				continue
 			}
+
 			textLower := strings.ToLower(text)
 			if (title != "" && strings.Contains(strings.ToLower(title), textLower)) ||
 				(description != "" && strings.Contains(strings.ToLower(description), textLower)) ||

--- a/internal/core/infra/accessibility/adapter_filtering.go
+++ b/internal/core/infra/accessibility/adapter_filtering.go
@@ -65,10 +65,29 @@ func (a *Adapter) MatchesFilter(
 		}
 	}
 
+	// Check any of the additional text substrings match (OR logic)
+	textListMatched := false
+	if len(filter.TextContainsList) > 0 {
+		title := element.Title()
+		description := element.Description()
+
+		value := element.Value()
+		for _, text := range filter.TextContainsList {
+			textLower := strings.ToLower(text)
+			if (title != "" && strings.Contains(strings.ToLower(title), textLower)) ||
+				(description != "" && strings.Contains(strings.ToLower(description), textLower)) ||
+				(value != "" && strings.Contains(strings.ToLower(value), textLower)) {
+				textListMatched = true
+
+				break
+			}
+		}
+	}
+
 	// Match if any of title, description, or value matches (OR logic)
 	if filter.TitleContains != "" || filter.DescriptionContains != "" ||
-		filter.ValueContains != "" {
-		if !titleMatched && !descMatched && !valueMatched {
+		filter.ValueContains != "" || len(filter.TextContainsList) > 0 {
+		if !titleMatched && !descMatched && !valueMatched && !textListMatched {
 			return false
 		}
 	}

--- a/internal/core/ports/accessibility.go
+++ b/internal/core/ports/accessibility.go
@@ -110,6 +110,12 @@ type ElementFilter struct {
 
 	// ValueContains filters elements whose value contains this substring (case-insensitive).
 	ValueContains string
+
+	// TextContainsList is a list of additional text substrings to match against (OR logic).
+	// This is used when multiple text matches are needed - elements matching any of these
+	// will be included. The first string should be set in TitleContains, DescriptionContains,
+	// and ValueContains, with additional strings in this list.
+	TextContainsList []string
 }
 
 // DefaultElementFilter returns a filter with sensible defaults.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds proper support for comma separated values in `--role`, `--text` flags.

Usage:

```bash
neru hints --role AXButton,AXLink
neru hints --text next,prev,back,forward
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
