### PR TITLE
fix(config): replace default launcher hotkeys on rebind

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ Full walkthrough: [Installation Guide →](docs/INSTALLATION.md)
 
 All hotkeys are remappable. See [Configuration Reference →](docs/CONFIGURATION.md#hotkeys)
 
-> **Note:** Adding any custom hotkey replaces all defaults. Re-declare every hotkey you want to keep.
-
 ---
 
 ## Configuration

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -95,6 +95,7 @@ Global hotkeys trigger Neru navigation modes from anywhere on screen.
 
 > [!TIP]
 > User-defined hotkeys are **merged on top of defaults**. You only need to define the bindings you want to add or change — all other defaults are preserved.
+> When you rebind a built-in launcher action (`hints`, `grid`, `recursive_grid`, `scroll`) to a new single hotkey, Neru removes the default launcher for that action automatically.
 
 ### Merging behavior
 
@@ -108,8 +109,9 @@ To **remove** a single default binding without affecting the rest, use the `__di
 
 ```toml
 [hotkeys]
-"Primary+Shift+S" = "__disabled__"   # removes the default scroll hotkey
-"Ctrl+Space"      = "hints"          # adds a new binding; other defaults remain
+"Primary+Shift+S"         = "__disabled__"   # removes the default scroll hotkey
+"Ctrl+Space"              = "hints"          # adds a new binding; other defaults remain
+"Cmd+Shift+Option+Ctrl+G" = "grid"           # rebinds grid to Hyper+G: default Primary+Shift+G is removed
 ```
 
 ### Syntax

--- a/internal/config/config_integration_test.go
+++ b/internal/config/config_integration_test.go
@@ -203,6 +203,37 @@ bundle_id = "com.apple.Safari"
 		}
 	})
 
+	t.Run("Global Hotkey Rebind With Flags Replaces Default Launcher", func(t *testing.T) {
+		configContent := `
+[hotkeys]
+"Cmd+Shift+Option+Ctrl+X" = "recursive_grid --cursor-selection-mode hold"
+`
+
+		writeConfigFile(t, configPath, configContent, 0o644)
+
+		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+
+		loadResult := service.LoadWithValidation(configPath)
+		if loadResult.ValidationError != nil {
+			t.Fatalf("Config validation failed: %v", loadResult.ValidationError)
+		}
+
+		if _, exists := loadResult.Config.Hotkeys.Bindings["Primary+Shift+C"]; exists {
+			t.Fatal(
+				"expected default recursive_grid hotkey to be removed when recursively rebound with flags",
+			)
+		}
+
+		actions, exists := loadResult.Config.Hotkeys.Bindings["Cmd+Shift+Option+Ctrl+X"]
+		if !exists || len(actions) != 1 ||
+			actions[0] != "recursive_grid --cursor-selection-mode hold" {
+			t.Fatalf(
+				"expected flagged recursive_grid hotkey, got %v",
+				loadResult.Config.Hotkeys.Bindings,
+			)
+		}
+	})
+
 	t.Run("Global Multi Action Hotkey Keeps Default Launcher", func(t *testing.T) {
 		configContent := `
 [hotkeys]

--- a/internal/config/config_integration_test.go
+++ b/internal/config/config_integration_test.go
@@ -174,6 +174,69 @@ bundle_id = "com.apple.Safari"
 		}
 	})
 
+	t.Run("Global Hotkey Rebind Replaces Default Launcher", func(t *testing.T) {
+		configContent := `
+[hotkeys]
+"Cmd+Shift+Option+Ctrl+G" = "grid"
+`
+
+		writeConfigFile(t, configPath, configContent, 0o644)
+
+		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+
+		loadResult := service.LoadWithValidation(configPath)
+		if loadResult.ValidationError != nil {
+			t.Fatalf("Config validation failed: %v", loadResult.ValidationError)
+		}
+
+		if _, exists := loadResult.Config.Hotkeys.Bindings["Primary+Shift+G"]; exists {
+			t.Fatal("expected default grid hotkey to be removed when grid is rebound")
+		}
+
+		actions, exists := loadResult.Config.Hotkeys.Bindings["Cmd+Shift+Option+Ctrl+G"]
+		if !exists || len(actions) != 1 || actions[0] != "grid" {
+			t.Fatalf("expected rebound grid hotkey, got %v", loadResult.Config.Hotkeys.Bindings)
+		}
+
+		if _, exists := loadResult.Config.Hotkeys.Bindings["Primary+Shift+Space"]; !exists {
+			t.Fatal("expected unrelated default hotkeys to remain")
+		}
+	})
+
+	t.Run("Global Multi Action Hotkey Keeps Default Launcher", func(t *testing.T) {
+		configContent := `
+[hotkeys]
+"Cmd+Shift+Option+Ctrl+T" = ["action save_cursor_pos", "hints"]
+`
+
+		writeConfigFile(t, configPath, configContent, 0o644)
+
+		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+
+		loadResult := service.LoadWithValidation(configPath)
+		if loadResult.ValidationError != nil {
+			t.Fatalf("Config validation failed: %v", loadResult.ValidationError)
+		}
+
+		actions, exists := loadResult.Config.Hotkeys.Bindings["Cmd+Shift+Option+Ctrl+T"]
+		if !exists || len(actions) != 2 ||
+			actions[0] != "action save_cursor_pos" ||
+			actions[1] != hintsCommand {
+			t.Fatalf(
+				"expected multi-action hotkey to be added, got %v",
+				loadResult.Config.Hotkeys.Bindings,
+			)
+		}
+
+		defaultActions, defaultExists := loadResult.Config.Hotkeys.Bindings["Primary+Shift+Space"]
+		if !defaultExists || len(defaultActions) != 1 || defaultActions[0] != hintsCommand {
+			t.Fatalf(
+				"expected default hints hotkey to remain, got %v",
+				loadResult.Config.Hotkeys.Bindings,
+			)
+		}
+	})
+
 	t.Run("Config File Permissions", func(t *testing.T) {
 		// Test that config files with restrictive permissions can still be read
 		configContent := `

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -78,6 +78,57 @@ func findNormalizedMapKey[V any](m map[string]V, rawKey string) string {
 	return rawKey
 }
 
+func isBuiltInGlobalModeAction(actions []string) (string, bool) {
+	if len(actions) != 1 {
+		return "", false
+	}
+
+	switch actions[0] {
+	case modeNameHints, modeNameGrid, modeNameRecursiveGrid, modeNameScroll:
+		return actions[0], true
+	default:
+		return "", false
+	}
+}
+
+func removeBindingsForSingleAction(bindings map[string][]string, action string) {
+	for key, existingActions := range bindings {
+		existingAction, ok := isBuiltInGlobalModeAction(existingActions)
+		if ok && existingAction == action {
+			delete(bindings, key)
+		}
+	}
+}
+
+func parseRawHotkeyActions(fieldName string, value any) ([]string, error) {
+	switch val := value.(type) {
+	case string:
+		return []string{val}, nil
+	case []any:
+		actions := make([]string, 0, len(val))
+		for _, actionValue := range val {
+			actionStr, ok := actionValue.(string)
+			if !ok {
+				return nil, derrors.Newf(
+					derrors.CodeInvalidConfig,
+					"%s must be a string or array of strings",
+					fieldName,
+				)
+			}
+
+			actions = append(actions, actionStr)
+		}
+
+		return actions, nil
+	default:
+		return nil, derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"%s must be a string or array of strings",
+			fieldName,
+		)
+	}
+}
+
 func validateRawHotkeyTable(fieldName string, rawTable any) error {
 	hotkeyMap, ok := rawTable.(map[string]any)
 	if !ok {
@@ -279,6 +330,28 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 				return configResult
 			}
 
+			// Rebinding a built-in mode action should replace its default
+			// launcher instead of adding an extra alias.
+			reboundDefaults := make(map[string]struct{})
+			for key, value := range hotMap {
+				actions, actionsErr := parseRawHotkeyActions("hotkeys."+key, value)
+				if actionsErr != nil {
+					continue
+				}
+
+				if len(actions) == 1 && actions[0] == DisabledSentinel {
+					continue
+				}
+
+				if action, ok := isBuiltInGlobalModeAction(actions); ok {
+					reboundDefaults[action] = struct{}{}
+				}
+			}
+
+			for action := range reboundDefaults {
+				removeBindingsForSingleAction(configResult.Config.Hotkeys.Bindings, action)
+			}
+
 			// Merge user entries on top of defaults (already populated by DefaultConfig).
 			for key, value := range hotMap {
 				// Find the existing default key that normalizes to the same value
@@ -287,61 +360,9 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 					configResult.Config.Hotkeys.Bindings, key,
 				)
 
-				switch _val := value.(type) {
-				case string:
-					if _val == DisabledSentinel {
-						if _, exists := configResult.Config.Hotkeys.Bindings[canonicalKey]; !exists {
-							s.logger.Warn("__disabled__ used for key that is not a default binding",
-								zap.String("key", key))
-						}
-
-						delete(configResult.Config.Hotkeys.Bindings, canonicalKey)
-					} else {
-						// Remove old casing before inserting with user's casing.
-						delete(configResult.Config.Hotkeys.Bindings, canonicalKey)
-						configResult.Config.Hotkeys.Bindings[key] = []string{_val}
-					}
-				case []any:
-					actions := make([]string, 0, len(_val))
-					for _, a := range _val {
-						actionStr, ok := a.(string)
-						if !ok {
-							configResult.ValidationError = derrors.Newf(
-								derrors.CodeInvalidConfig,
-								"hotkeys.%s must be a string or array of strings",
-								key,
-							)
-							configResult.Config = DefaultConfig()
-							s.logger.Warn("Invalid hotkey configuration",
-								zap.String("key", key),
-								zap.Any("value", value),
-								zap.Error(configResult.ValidationError))
-
-							return configResult
-						}
-
-						actions = append(actions, actionStr)
-					}
-
-					// Handle __disabled__ sentinel in array form for consistency
-					// with per-mode hotkeys.
-					if len(actions) == 1 && actions[0] == DisabledSentinel {
-						if _, exists := configResult.Config.Hotkeys.Bindings[canonicalKey]; !exists {
-							s.logger.Warn("__disabled__ used for key that is not a default binding",
-								zap.String("key", key))
-						}
-
-						delete(configResult.Config.Hotkeys.Bindings, canonicalKey)
-					} else {
-						delete(configResult.Config.Hotkeys.Bindings, canonicalKey)
-						configResult.Config.Hotkeys.Bindings[key] = actions
-					}
-				default:
-					configResult.ValidationError = derrors.Newf(
-						derrors.CodeInvalidConfig,
-						"hotkeys.%s must be a string or array of strings",
-						key,
-					)
+				actions, actionsErr := parseRawHotkeyActions("hotkeys."+key, value)
+				if actionsErr != nil {
+					configResult.ValidationError = actionsErr
 					configResult.Config = DefaultConfig()
 					s.logger.Warn("Invalid hotkey configuration",
 						zap.String("key", key),
@@ -349,6 +370,20 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 						zap.Error(configResult.ValidationError))
 
 					return configResult
+				}
+
+				// Handle __disabled__ sentinel in array form for consistency
+				// with per-mode hotkeys.
+				if len(actions) == 1 && actions[0] == DisabledSentinel {
+					if _, exists := configResult.Config.Hotkeys.Bindings[canonicalKey]; !exists {
+						s.logger.Warn("__disabled__ used for key that is not a default binding",
+							zap.String("key", key))
+					}
+
+					delete(configResult.Config.Hotkeys.Bindings, canonicalKey)
+				} else {
+					delete(configResult.Config.Hotkeys.Bindings, canonicalKey)
+					configResult.Config.Hotkeys.Bindings[key] = actions
 				}
 			}
 		}

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -79,6 +79,7 @@ func findNormalizedMapKey[V any](m map[string]V, rawKey string) string {
 	return rawKey
 }
 
+// isBuiltInGlobalModeAction matches single built-in global mode commands.
 func isBuiltInGlobalModeAction(actions []string) (string, bool) {
 	if len(actions) != 1 {
 		return "", false
@@ -97,6 +98,7 @@ func isBuiltInGlobalModeAction(actions []string) (string, bool) {
 	}
 }
 
+// removeBindingsForSingleAction removes bindings for one built-in mode action.
 func removeBindingsForSingleAction(bindings map[string][]string, action string) {
 	for key, existingActions := range bindings {
 		existingAction, ok := isBuiltInGlobalModeAction(existingActions)
@@ -106,6 +108,7 @@ func removeBindingsForSingleAction(bindings map[string][]string, action string) 
 	}
 }
 
+// parseRawHotkeyActions parses a raw TOML hotkey value into actions.
 func parseRawHotkeyActions(fieldName string, value any) ([]string, error) {
 	switch val := value.(type) {
 	case string:

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -333,11 +333,15 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 			// Rebinding a built-in mode action should replace its default
 			// launcher instead of adding an extra alias.
 			reboundDefaults := make(map[string]struct{})
+
+			parsedHotkeyActions := make(map[string][]string, len(hotMap))
 			for key, value := range hotMap {
 				actions, actionsErr := parseRawHotkeyActions("hotkeys."+key, value)
 				if actionsErr != nil {
 					continue
 				}
+
+				parsedHotkeyActions[key] = actions
 
 				if len(actions) == 1 && actions[0] == DisabledSentinel {
 					continue
@@ -360,9 +364,30 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 					configResult.Config.Hotkeys.Bindings, key,
 				)
 
-				actions, actionsErr := parseRawHotkeyActions("hotkeys."+key, value)
-				if actionsErr != nil {
+				actions, ok := parsedHotkeyActions[key]
+				if !ok {
+					actionsErr := derrors.Newf(
+						derrors.CodeInvalidConfig,
+						"hotkeys.%s must be a string or array of strings",
+						key,
+					)
+
 					configResult.ValidationError = actionsErr
+					configResult.Config = DefaultConfig()
+					s.logger.Warn("Invalid hotkey configuration",
+						zap.String("key", key),
+						zap.Any("value", value),
+						zap.Error(configResult.ValidationError))
+
+					return configResult
+				}
+
+				if len(actions) == 0 {
+					configResult.ValidationError = derrors.Newf(
+						derrors.CodeInvalidConfig,
+						"hotkeys.%s must not be empty",
+						key,
+					)
 					configResult.Config = DefaultConfig()
 					s.logger.Warn("Invalid hotkey configuration",
 						zap.String("key", key),

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/BurntSushi/toml"
@@ -83,9 +84,14 @@ func isBuiltInGlobalModeAction(actions []string) (string, bool) {
 		return "", false
 	}
 
-	switch actions[0] {
+	parts := strings.Fields(strings.TrimSpace(actions[0]))
+	if len(parts) == 0 {
+		return "", false
+	}
+
+	switch parts[0] {
 	case modeNameHints, modeNameGrid, modeNameRecursiveGrid, modeNameScroll:
-		return actions[0], true
+		return parts[0], true
 	default:
 		return "", false
 	}


### PR DESCRIPTION
## Description



- adjust global hotkey merge behavior so rebinding a built-in launcher action replaces its default launcher instead of adding a second active binding.

- keeps merge-on-top-of-defaults semantics for [hotkeys], but makes single-action rebinds for hints, grid, recursive_grid, and scroll behave like users expect. 
- refactors raw hotkey action parsing into a shared helper and adds integration coverage for the new behavior.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

 ## Additional Context

This intentionally changes only top-level global hotkey launcher behavior.  Per-mode hotkeys still use the existing merge semantics, and explicit  __disabled__ handling is unchanged.

