### PR TITLE
fix(linux,wayland): explicitly enable keyboard interactivity on overlay when evdev fallback

### DIFF
--- a/internal/core/infra/eventtap/eventtap_linux_wayland.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland.go
@@ -25,6 +25,12 @@ func (et *EventTap) runWayland() {
 		return
 	}
 
+	// Enable keyboard capture on overlay when falling back from evdev.
+	// When evdev grab fails (e.g., compositor already grabbed devices),
+	// we need to explicitly request keyboard focus from the compositor.
+	mgr.SetKeyboardCaptureEnabled(true)
+	defer mgr.SetKeyboardCaptureEnabled(false)
+
 	keyCh := mgr.WaylandKeyboardChannel()
 	if keyCh == nil {
 		return

--- a/internal/core/infra/eventtap/eventtap_linux_wayland.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland.go
@@ -25,16 +25,16 @@ func (et *EventTap) runWayland() {
 		return
 	}
 
+	keyCh := mgr.WaylandKeyboardChannel()
+	if keyCh == nil {
+		return
+	}
+
 	// Enable keyboard capture on overlay when falling back from evdev.
 	// When evdev grab fails (e.g., compositor already grabbed devices),
 	// we need to explicitly request keyboard focus from the compositor.
 	mgr.SetKeyboardCaptureEnabled(true)
 	defer mgr.SetKeyboardCaptureEnabled(false)
-
-	keyCh := mgr.WaylandKeyboardChannel()
-	if keyCh == nil {
-		return
-	}
 
 	for {
 		select {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

There are cases where different compositors has different implicit handling on keyboard interactivity. This PR adds explicit keyboard focus for overlay when grabbing keyboard fails.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to #774 

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A