### PR TITLE
fix(linux,wayland): do not fallback evdev on first grab fail, try others

### DIFF
--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -144,6 +144,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -314,40 +315,54 @@ func (capture *waylandEvdevCapture) grabAll() error {
 	}
 
 	var grabbedFiles []*os.File
+	var failedFiles []string
+
 	for _, file := range capture.files {
 		fd := C.int(file.Fd())
 		if C.neru_evdev_grab(fd, 1) != 0 {
-			for _, f := range grabbedFiles {
-				C.neru_evdev_grab(C.int(f.Fd()), 0)
-			}
+			failedFiles = append(failedFiles, file.Name())
 
-			virtualFile := capture.findVirtualDevice()
-			if virtualFile != nil {
-				kfd := C.int(virtualFile.Fd())
-				if C.neru_evdev_grab(kfd, 1) != 0 {
-					_ = virtualFile.Close()
-				} else {
-					for _, f := range capture.files {
-						_ = f.Close()
-					}
-
-					capture.files = []*os.File{virtualFile}
-					capture.grabbed = true
-
-					return nil
-				}
-			}
-
-			for _, f := range capture.files {
-				_ = f.Close()
-			}
-
-			return fmt.Errorf("%w: %s", errWaylandEvdevGrabFailed, file.Name())
+			continue
 		}
 
 		grabbedFiles = append(grabbedFiles, file)
 	}
 
+	if len(grabbedFiles) == 0 {
+		for _, f := range capture.files {
+			_ = f.Close()
+		}
+
+		virtualFile := capture.findVirtualDevice()
+		if virtualFile != nil {
+			kfd := C.int(virtualFile.Fd())
+			if C.neru_evdev_grab(kfd, 1) != 0 {
+				_ = virtualFile.Close()
+			} else {
+				capture.files = []*os.File{virtualFile}
+				capture.grabbed = true
+
+				return nil
+			}
+		}
+
+		return fmt.Errorf(
+			"%w: all keyboards failed to grab (tried: %v)",
+			errWaylandEvdevGrabFailed,
+			failedFiles,
+		)
+	}
+
+	var remainingFiles []*os.File
+	for _, file := range capture.files {
+		if !slices.Contains(grabbedFiles, file) {
+			_ = file.Close()
+		} else {
+			remainingFiles = append(remainingFiles, file)
+		}
+	}
+
+	capture.files = remainingFiles
 	capture.grabbed = true
 
 	return nil

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -206,13 +206,14 @@ type waylandEvdevKeyState struct {
 type waylandEvdevCapture struct {
 	files  []*os.File
 	events chan waylandEvdevEvent
+	logger *zap.Logger
 
 	closeOnce sync.Once
 	done      sync.WaitGroup
 	grabbed   bool
 }
 
-func newWaylandEvdevCapture() (*waylandEvdevCapture, error) {
+func newWaylandEvdevCapture(logger *zap.Logger) (*waylandEvdevCapture, error) {
 	paths, err := filepath.Glob("/dev/input/event*")
 	if err != nil {
 		return nil, err
@@ -221,6 +222,7 @@ func newWaylandEvdevCapture() (*waylandEvdevCapture, error) {
 	capture := &waylandEvdevCapture{
 		files:  make([]*os.File, 0, len(paths)),
 		events: make(chan waylandEvdevEvent, waylandEvdevEventBufferSize),
+		logger: logger,
 	}
 
 	for _, path := range paths {
@@ -353,6 +355,13 @@ func (capture *waylandEvdevCapture) grabAll() error {
 		)
 	}
 
+	if capture.logger != nil && len(failedFiles) > 0 {
+		capture.logger.Warn(
+			"Partial keyboard grab failure; some keyboards not captured",
+			zap.Strings("failed", failedFiles),
+		)
+	}
+
 	var remainingFiles []*os.File
 	for _, file := range capture.files {
 		if !slices.Contains(grabbedFiles, file) {
@@ -443,7 +452,7 @@ func (capture *waylandEvdevCapture) modifierKeysHeld() bool {
 }
 
 func (et *EventTap) runWaylandEvdev() bool {
-	capture, err := newWaylandEvdevCapture()
+	capture, err := newWaylandEvdevCapture(et.logger)
 	if err != nil {
 		if et.logger != nil {
 			level := et.logger.Info


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR try all keyboards and continue on failure. Previously, it will fall through to evdev fallback when the first keyboard grab failed. Maybe it'll help in certain cases. 

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to #774 

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
