### PR TITLE
feat(hints): add native IME text input session plus improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1
+	golang.org/x/text v0.14.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN8
 go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=
 go.uber.org/zap v1.27.1/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -20,6 +20,7 @@ import (
 	eventtapadapter "github.com/y3owk1n/neru/internal/core/infra/eventtap"
 	ipcadapter "github.com/y3owk1n/neru/internal/core/infra/ipc"
 	"github.com/y3owk1n/neru/internal/core/infra/platform"
+	textinputadapter "github.com/y3owk1n/neru/internal/core/infra/textinput"
 	"github.com/y3owk1n/neru/internal/ui"
 )
 
@@ -58,6 +59,10 @@ func initializeInfrastructure(app *App) error {
 	// Initialize hotkey service if not provided
 	if app.hotkeyManager == nil {
 		app.hotkeyManager = initializeHotkeyService(logger)
+	}
+
+	if app.textInput == nil {
+		app.textInput = textinputadapter.NewAdapter(textinputadapter.NewTextInput(logger), logger)
 	}
 
 	return nil
@@ -344,6 +349,7 @@ func initializeModeHandler(app *App) {
 		deps.callbacks.postModifierEvent,
 		deps.callbacks.refreshHotkeys,
 		deps.callbacks.executeHotkeyAction,
+		app.textInput,
 		app.systemPort,
 	)
 }

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -51,6 +51,7 @@ type App struct {
 	overlayManager OverlayManager
 	hotkeyManager  HotkeyService
 	eventTap       ports.EventTapPort
+	textInput      ports.TextInputPort
 	ipcServer      ports.IPCPort
 	appWatcher     Watcher
 

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -62,6 +62,7 @@ func (h *Handler) clearAndHideOverlay() {
 
 // cleanupHintsMode handles cleanup for hints mode.
 func (h *Handler) cleanupHintsMode() {
+	h.stopHintSearchTextInputLocked()
 	h.hints.Context.Reset()
 	h.cycleHintIndex = -1
 

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -62,7 +62,7 @@ func (h *Handler) clearAndHideOverlay() {
 
 // cleanupHintsMode handles cleanup for hints mode.
 func (h *Handler) cleanupHintsMode() {
-	h.stopHintSearchTextInputLocked()
+	h.stopHintSearchTextInputLocked(false)
 	h.hints.Context.Reset()
 	h.cycleHintIndex = -1
 

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -735,7 +735,7 @@ func (h *Handler) startHintSearchLocked() error {
 		return derrors.New(derrors.CodeActionFailed, "hints not available")
 	}
 
-	h.stopHintSearchTextInputLocked()
+	h.stopHintSearchTextInputLocked(true)
 	h.hints.Context.SetSearchQuery("")
 	h.hints.Context.SetSearchActive(true)
 	h.hints.Context.SetVisibleHints(h.hints.Context.SourceHints())
@@ -800,7 +800,7 @@ func (h *Handler) startHintSearchLocked() error {
 	return nil
 }
 
-func (h *Handler) stopHintSearchTextInputLocked() {
+func (h *Handler) stopHintSearchTextInputLocked(keepEventTapDisabled bool) {
 	if h.hintSearchTextInputActive && h.textInput != nil {
 		_ = h.textInput.StopHintSearchSession(context.Background())
 	}
@@ -808,11 +808,13 @@ func (h *Handler) stopHintSearchTextInputLocked() {
 	h.hintSearchTextInputActive = false
 
 	if h.hintSearchEventTapDisabled && h.enableEventTap != nil &&
-		h.appState.CurrentMode() == domain.ModeHints {
+		h.appState.CurrentMode() == domain.ModeHints && !keepEventTapDisabled {
 		h.enableEventTap()
 	}
 
-	h.hintSearchEventTapDisabled = false
+	if !keepEventTapDisabled {
+		h.hintSearchEventTapDisabled = false
+	}
 }
 
 func (h *Handler) focusedBundleID() string {

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -776,11 +776,19 @@ func (h *Handler) startHintSearchLocked() error {
 					h.mu.Lock()
 					defer h.mu.Unlock()
 
+					if h.appState.CurrentMode() != domain.ModeHints {
+						return
+					}
+
 					h.confirmHintSearch()
 				},
 				OnCancel: func() {
 					h.mu.Lock()
 					defer h.mu.Unlock()
+
+					if h.appState.CurrentMode() != domain.ModeHints {
+						return
+					}
 
 					h.cancelHintSearch()
 				},

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -95,6 +95,10 @@ type Handler struct {
 	hotkeyLastKey              string
 	hotkeyLastKeyTime          int64
 
+	textInput                  ports.TextInputPort
+	hintSearchTextInputActive  bool
+	hintSearchEventTapDisabled bool
+
 	// Pending modifier taps waiting to be committed after a short "no follow-up"
 	// window. A regular key press cancels all pending taps.
 	pendingModifierKeys   map[action.Modifiers]time.Time
@@ -147,6 +151,7 @@ func NewHandler(
 	postModifierEvent func(modifier string, isDown bool),
 	refreshHotkeys func(),
 	executeHotkeyAction func(key, actionStr string) error,
+	textInput ports.TextInputPort,
 	systemPort ports.SystemPort,
 ) *Handler {
 	// Initialize screen bounds for coordinate conversion.
@@ -192,6 +197,7 @@ func NewHandler(
 		postModifierEvent:          postModifierEvent,
 		refreshHotkeys:             refreshHotkeys,
 		executeHotkeyAction:        executeHotkeyAction,
+		textInput:                  textInput,
 		themeProvider:              systemPort,
 		system:                     systemPort,
 		cycleHintIndex:             -1,
@@ -729,13 +735,84 @@ func (h *Handler) startHintSearchLocked() error {
 		return derrors.New(derrors.CodeActionFailed, "hints not available")
 	}
 
+	h.stopHintSearchTextInputLocked()
 	h.hints.Context.SetSearchQuery("")
 	h.hints.Context.SetSearchActive(true)
 	h.hints.Context.SetVisibleHints(h.hints.Context.SourceHints())
 	h.cycleHintIndex = -1
 	h.drawHintSearchInput()
 
+	if h.textInput != nil {
+		searchFrame := h.searchInputFrame()
+		position := searchFrame.Position()
+		height := estimatedSearchInputHeight(h.config.Hints.SearchInputUI)
+		textInputFrame := ports.TextInputFrame{
+			X:      position.X,
+			Y:      position.Y,
+			Width:  searchFrame.Width(),
+			Height: height,
+		}
+
+		started, _ := h.textInput.StartHintSearchSession(
+			context.Background(),
+			ports.TextInputCallbacks{
+				OnQueryChanged: func(query string) {
+					h.mu.Lock()
+					defer h.mu.Unlock()
+
+					if h.appState.CurrentMode() != domain.ModeHints || h.hints == nil ||
+						h.hints.Context == nil {
+						return
+					}
+
+					if !h.hints.Context.SearchActive() {
+						return
+					}
+
+					h.hints.Context.SetSearchQuery(query)
+					h.applyHintSearchFilter()
+				},
+				OnConfirm: func() {
+					h.mu.Lock()
+					defer h.mu.Unlock()
+
+					h.confirmHintSearch()
+				},
+				OnCancel: func() {
+					h.mu.Lock()
+					defer h.mu.Unlock()
+
+					h.cancelHintSearch()
+				},
+			},
+			textInputFrame,
+		)
+
+		if started {
+			h.hintSearchTextInputActive = true
+			if h.disableEventTap != nil {
+				h.disableEventTap()
+				h.hintSearchEventTapDisabled = true
+			}
+		}
+	}
+
 	return nil
+}
+
+func (h *Handler) stopHintSearchTextInputLocked() {
+	if h.hintSearchTextInputActive && h.textInput != nil {
+		_ = h.textInput.StopHintSearchSession(context.Background())
+	}
+
+	h.hintSearchTextInputActive = false
+
+	if h.hintSearchEventTapDisabled && h.enableEventTap != nil &&
+		h.appState.CurrentMode() == domain.ModeHints {
+		h.enableEventTap()
+	}
+
+	h.hintSearchEventTapDisabled = false
 }
 
 func (h *Handler) focusedBundleID() string {

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -818,9 +818,6 @@ func (h *Handler) stopHintSearchTextInputLocked(keepEventTapDisabled bool) {
 	if h.hintSearchEventTapDisabled && h.enableEventTap != nil &&
 		h.appState.CurrentMode() == domain.ModeHints && !keepEventTapDisabled {
 		h.enableEventTap()
-	}
-
-	if !keepEventTapDisabled {
 		h.hintSearchEventTapDisabled = false
 	}
 }

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -216,6 +216,8 @@ func (h *Handler) confirmHintSearch() {
 		return
 	}
 
+	h.stopHintSearchTextInputLocked()
+
 	ctx := h.hints.Context
 	ctx.SetSearchActive(false)
 	h.overlayManager.HideHintSearchInput()
@@ -235,6 +237,8 @@ func (h *Handler) cancelHintSearch() {
 	if h.hints == nil || h.hints.Context == nil {
 		return
 	}
+
+	h.stopHintSearchTextInputLocked()
 
 	ctx := h.hints.Context
 	ctx.SetSearchQuery("")

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -216,7 +216,7 @@ func (h *Handler) confirmHintSearch() {
 		return
 	}
 
-	h.stopHintSearchTextInputLocked()
+	h.stopHintSearchTextInputLocked(false)
 
 	ctx := h.hints.Context
 	ctx.SetSearchActive(false)
@@ -238,7 +238,7 @@ func (h *Handler) cancelHintSearch() {
 		return
 	}
 
-	h.stopHintSearchTextInputLocked()
+	h.stopHintSearchTextInputLocked(false)
 
 	ctx := h.hints.Context
 	ctx.SetSearchQuery("")

--- a/internal/core/domain/hint/hint.go
+++ b/internal/core/domain/hint/hint.go
@@ -296,18 +296,15 @@ func (c *Collection) FilterByText(query string) *Collection {
 	return NewCollection(filtered)
 }
 
-var (
-	searchCaser       = cases.Fold()
-	searchTransformer = transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
-)
-
 func normalizeForSearch(s string) string {
 	if s == "" {
 		return ""
 	}
 
+	searchCaser := cases.Fold()
 	folded := searchCaser.String(s)
 
+	searchTransformer := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
 	normalized, _, err := transform.String(searchTransformer, folded)
 	if err != nil {
 		return folded

--- a/internal/core/domain/hint/hint.go
+++ b/internal/core/domain/hint/hint.go
@@ -5,6 +5,12 @@ import (
 	"image"
 	"sort"
 	"strings"
+	"unicode"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 
 	"github.com/y3owk1n/neru/internal/core/domain/element"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
@@ -271,7 +277,7 @@ func (c *Collection) FilterByText(query string) *Collection {
 		return c
 	}
 
-	normalizedQuery := strings.ToLower(query)
+	normalizedQuery := normalizeForSearch(query)
 	filtered := make([]*Interface, 0, len(c.hints))
 
 	for _, hint := range c.hints {
@@ -280,14 +286,34 @@ func (c *Collection) FilterByText(query string) *Collection {
 			continue
 		}
 
-		if strings.Contains(strings.ToLower(elem.Title()), normalizedQuery) ||
-			strings.Contains(strings.ToLower(elem.Description()), normalizedQuery) ||
-			strings.Contains(strings.ToLower(elem.Value()), normalizedQuery) {
+		if strings.Contains(normalizeForSearch(elem.Title()), normalizedQuery) ||
+			strings.Contains(normalizeForSearch(elem.Description()), normalizedQuery) ||
+			strings.Contains(normalizeForSearch(elem.Value()), normalizedQuery) {
 			filtered = append(filtered, hint)
 		}
 	}
 
 	return NewCollection(filtered)
+}
+
+var (
+	searchCaser       = cases.Fold()
+	searchTransformer = transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+)
+
+func normalizeForSearch(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	folded := searchCaser.String(s)
+
+	normalized, _, err := transform.String(searchTransformer, folded)
+	if err != nil {
+		return folded
+	}
+
+	return normalized
 }
 
 // Count returns the number of hints in the collection.

--- a/internal/core/domain/hint/hint.go
+++ b/internal/core/domain/hint/hint.go
@@ -296,15 +296,16 @@ func (c *Collection) FilterByText(query string) *Collection {
 	return NewCollection(filtered)
 }
 
-func normalizeForSearch(s string) string {
-	if s == "" {
+func normalizeForSearch(text string) string {
+	if text == "" {
 		return ""
 	}
 
 	searchCaser := cases.Fold()
-	folded := searchCaser.String(s)
+	folded := searchCaser.String(text)
 
 	searchTransformer := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+
 	normalized, _, err := transform.String(searchTransformer, folded)
 	if err != nil {
 		return folded

--- a/internal/core/domain/hint/hint_test.go
+++ b/internal/core/domain/hint/hint_test.go
@@ -160,6 +160,38 @@ func TestHint_Methods(t *testing.T) {
 	}
 }
 
+func TestCollection_FilterByText_Normalizes(t *testing.T) {
+	cafeElem, _ := element.NewElement(
+		"cafe",
+		image.Rect(10, 10, 50, 50),
+		element.RoleButton,
+		element.WithTitle("Café"),
+	)
+	cafeHint, _ := hint.NewHint("AA", cafeElem, image.Point{X: 30, Y: 30})
+
+	cjkElem, _ := element.NewElement(
+		"cjk",
+		image.Rect(10, 10, 50, 50),
+		element.RoleButton,
+		element.WithTitle("你好"), //nolint:gosmopolitan
+	)
+	cjkHint, _ := hint.NewHint("AB", cjkElem, image.Point{X: 30, Y: 30})
+
+	collection := hint.NewCollection([]*hint.Interface{cafeHint, cjkHint})
+
+	if got := collection.FilterByText("cafe").Count(); got != 1 {
+		t.Fatalf("FilterByText(%q) = %d, want 1", "cafe", got)
+	}
+
+	if got := collection.FilterByText("CAFÉ").Count(); got != 1 {
+		t.Fatalf("FilterByText(%q) = %d, want 1", "CAFÉ", got)
+	}
+
+	if got := collection.FilterByText("你好").Count(); got != 1 { //nolint:gosmopolitan
+		t.Fatalf("FilterByText(%q) = %d, want 1", "你好", got) //nolint:gosmopolitan
+	}
+}
+
 func TestAlphabetGenerator_Generate(t *testing.T) {
 	generator, generatorErr := hint.NewAlphabetGenerator("asdf")
 	if generatorErr != nil {

--- a/internal/core/infra/platform/darwin/textinput.h
+++ b/internal/core/infra/platform/darwin/textinput.h
@@ -1,0 +1,21 @@
+#ifndef TEXTINPUT_H
+#define TEXTINPUT_H
+
+#import <Foundation/Foundation.h>
+
+typedef void (*TextInputQueryCallback)(const char *query, void *userData);
+typedef void (*TextInputControlCallback)(void *userData);
+
+int NeruStartHintSearchTextInput(
+    TextInputQueryCallback queryCallback,
+    TextInputControlCallback confirmCallback,
+    TextInputControlCallback cancelCallback,
+    int x,
+    int y,
+    int width,
+    int height,
+    void *userData);
+
+void NeruStopHintSearchTextInput(void);
+
+#endif

--- a/internal/core/infra/platform/darwin/textinput_darwin.m
+++ b/internal/core/infra/platform/darwin/textinput_darwin.m
@@ -84,16 +84,6 @@
 	[super keyDown:event];
 }
 
-- (BOOL)becomeFirstResponder {
-	BOOL result = [super becomeFirstResponder];
-	return result;
-}
-
-- (BOOL)resignFirstResponder {
-	BOOL result = [super resignFirstResponder];
-	return result;
-}
-
 @end
 
 static NeruTextInputPanel *gPanel = nil;

--- a/internal/core/infra/platform/darwin/textinput_darwin.m
+++ b/internal/core/infra/platform/darwin/textinput_darwin.m
@@ -221,7 +221,7 @@ int NeruStartHintSearchTextInput(
 
 	void (^work)(void) = ^{
 		startOnMainThread(queryCallback, confirmCallback, cancelCallback, x, y, width, height, userData);
-		started = 1;
+		started = (gPanel != nil) ? 1 : 0;
 	};
 
 	if ([NSThread isMainThread]) {

--- a/internal/core/infra/platform/darwin/textinput_darwin.m
+++ b/internal/core/infra/platform/darwin/textinput_darwin.m
@@ -112,6 +112,12 @@ static void startOnMainThread(
 	NSRect rect = NSMakeRect(originX, originY, finalWidth, finalHeight);
 
 	if (gPanel) {
+		// Callbacks are always the same Go bridge function pointers across sessions;
+		// refresh them here in case that assumption ever changes.
+		gTextView.queryCallback = queryCallback;
+		gTextView.confirmCallback = confirmCallback;
+		gTextView.cancelCallback = cancelCallback;
+		gTextView.userData = userData;
 		[gTextView setString:@""];
 		[gTextView notifyQueryChanged];
 		[gPanel setFrame:rect display:NO];

--- a/internal/core/infra/platform/darwin/textinput_darwin.m
+++ b/internal/core/infra/platform/darwin/textinput_darwin.m
@@ -1,0 +1,250 @@
+#import "textinput.h"
+
+#import <Cocoa/Cocoa.h>
+
+@interface NeruTextInputPanel : NSPanel
+@end
+
+@implementation NeruTextInputPanel
+
+- (BOOL)canBecomeKeyWindow {
+	return YES;
+}
+
+- (BOOL)canBecomeMainWindow {
+	return YES;
+}
+
+@end
+
+@interface NeruTextInputView : NSTextView
+@property(nonatomic, assign) TextInputQueryCallback queryCallback;
+@property(nonatomic, assign) TextInputControlCallback confirmCallback;
+@property(nonatomic, assign) TextInputControlCallback cancelCallback;
+@property(nonatomic, assign) void *userData;
+@end
+
+@implementation NeruTextInputView
+
+- (void)notifyQueryChanged {
+	if (!self.queryCallback) {
+		return;
+	}
+
+	NSString *str = self.string ?: @"";
+	const char *cstr = [str UTF8String];
+	if (!cstr) {
+		cstr = "";
+	}
+	self.queryCallback(cstr, self.userData);
+}
+
+- (void)didChangeText {
+	[super didChangeText];
+	[self notifyQueryChanged];
+}
+
+- (void)setMarkedText:(id)string selectedRange:(NSRange)selectedRange replacementRange:(NSRange)replacementRange {
+	[super setMarkedText:string selectedRange:selectedRange replacementRange:replacementRange];
+	[self notifyQueryChanged];
+}
+
+- (void)insertText:(id)string replacementRange:(NSRange)replacementRange {
+	[super insertText:string replacementRange:replacementRange];
+	[self notifyQueryChanged];
+}
+
+- (void)keyDown:(NSEvent *)event {
+	unsigned short keyCode = event.keyCode;
+
+	if (keyCode == 53) {
+		if ([self hasMarkedText]) {
+			[super keyDown:event];
+			return;
+		}
+
+		if (self.cancelCallback) {
+			self.cancelCallback(self.userData);
+		}
+		return;
+	}
+
+	if (keyCode == 36 || keyCode == 76) {
+		if ([self hasMarkedText]) {
+			[super keyDown:event];
+			return;
+		}
+
+		if (self.confirmCallback) {
+			self.confirmCallback(self.userData);
+		}
+		return;
+	}
+
+	[super keyDown:event];
+}
+
+- (BOOL)becomeFirstResponder {
+	BOOL result = [super becomeFirstResponder];
+	return result;
+}
+
+- (BOOL)resignFirstResponder {
+	BOOL result = [super resignFirstResponder];
+	return result;
+}
+
+@end
+
+static NeruTextInputPanel *gPanel = nil;
+static NeruTextInputView *gTextView = nil;
+static NSRunningApplication *gPreviousApp = nil;
+
+static NSScreen *activeScreen(void) {
+	NSPoint mouseLoc = [NSEvent mouseLocation];
+	for (NSScreen *screen in [NSScreen screens]) {
+		if (NSPointInRect(mouseLoc, screen.frame)) {
+			return screen;
+		}
+	}
+	return [NSScreen mainScreen];
+}
+
+static void startOnMainThread(
+    TextInputQueryCallback queryCallback, TextInputControlCallback confirmCallback,
+    TextInputControlCallback cancelCallback, int x, int y, int width, int height, void *userData) {
+	NSScreen *screen = activeScreen();
+	NSRect screenFrame = screen ? screen.frame : NSMakeRect(0, 0, 0, 0);
+	CGFloat finalWidth = width > 0 ? (CGFloat)width : 16.0;
+	CGFloat finalHeight = height > 0 ? (CGFloat)height : 16.0;
+	CGFloat originX = screenFrame.origin.x + (CGFloat)x;
+	CGFloat originY = screenFrame.origin.y + (screenFrame.size.height - (CGFloat)y - finalHeight);
+	NSRect rect = NSMakeRect(originX, originY, finalWidth, finalHeight);
+
+	if (gPanel) {
+		[gTextView setString:@""];
+		[gTextView notifyQueryChanged];
+		[gPanel setFrame:rect display:NO];
+		[gTextView setFrame:NSMakeRect(0, 0, finalWidth, finalHeight)];
+		[gPanel orderFront:nil];
+		[gPanel makeKeyWindow];
+		return;
+	}
+
+	gPreviousApp = [NSWorkspace sharedWorkspace].frontmostApplication;
+
+#if defined(MAC_OS_X_VERSION_14_0) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_14_0
+	if (@available(macOS 14.0, *)) {
+		[NSApp activate];
+	} else {
+		[NSApp activateIgnoringOtherApps:YES];
+	}
+#else
+	[NSApp activateIgnoringOtherApps:YES];
+#endif
+
+	NeruTextInputPanel *panel = [[NeruTextInputPanel alloc] initWithContentRect:rect
+	                                                                  styleMask:NSWindowStyleMaskBorderless
+	                                                                    backing:NSBackingStoreBuffered
+	                                                                      defer:NO];
+
+	[panel setReleasedWhenClosed:NO];
+	[panel setOpaque:NO];
+	[panel setBackgroundColor:[NSColor clearColor]];
+	[panel setHasShadow:NO];
+	[panel setAlphaValue:0.01];
+	[panel setLevel:NSScreenSaverWindowLevel];
+	[panel setIgnoresMouseEvents:YES];
+	[panel setHidesOnDeactivate:NO];
+	[panel setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorStationary |
+	                             NSWindowCollectionBehaviorIgnoresCycle |
+	                             NSWindowCollectionBehaviorFullScreenAuxiliary];
+
+	NeruTextInputView *textView = [[NeruTextInputView alloc] initWithFrame:NSMakeRect(0, 0, finalWidth, finalHeight)];
+	[textView setEditable:YES];
+	[textView setSelectable:YES];
+	[textView setRichText:NO];
+	[textView setImportsGraphics:NO];
+	[textView setAllowsUndo:NO];
+	[textView setAutomaticQuoteSubstitutionEnabled:NO];
+	[textView setAutomaticDashSubstitutionEnabled:NO];
+	[textView setAutomaticTextReplacementEnabled:NO];
+	[textView setAutomaticSpellingCorrectionEnabled:NO];
+	[textView setContinuousSpellCheckingEnabled:NO];
+	[textView setGrammarCheckingEnabled:NO];
+	[textView setTextContainerInset:NSMakeSize(0, 0)];
+
+	textView.queryCallback = queryCallback;
+	textView.confirmCallback = confirmCallback;
+	textView.cancelCallback = cancelCallback;
+	textView.userData = userData;
+
+	[panel setContentView:textView];
+	[panel makeKeyAndOrderFront:nil];
+	[panel makeFirstResponder:textView];
+
+	gPanel = panel;
+	gTextView = textView;
+}
+
+static void stopOnMainThread(void) {
+	if (!gPanel) {
+		return;
+	}
+
+	if ([gTextView hasMarkedText]) {
+		[gTextView.inputContext discardMarkedText];
+	}
+	[gTextView setString:@""];
+	[gTextView notifyQueryChanged];
+
+	[gPanel orderOut:nil];
+	[gPanel close];
+
+	gPanel = nil;
+	gTextView = nil;
+
+	if (gPreviousApp && !gPreviousApp.terminated) {
+#if defined(MAC_OS_X_VERSION_14_0) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_14_0
+		if (@available(macOS 14.0, *)) {
+			[gPreviousApp activate];
+		} else {
+			[gPreviousApp activateWithOptions:NSApplicationActivateIgnoringOtherApps];
+		}
+#else
+		[gPreviousApp activateWithOptions:NSApplicationActivateIgnoringOtherApps];
+#endif
+	}
+	gPreviousApp = nil;
+}
+
+int NeruStartHintSearchTextInput(
+    TextInputQueryCallback queryCallback, TextInputControlCallback confirmCallback,
+    TextInputControlCallback cancelCallback, int x, int y, int width, int height, void *userData) {
+	__block int started = 0;
+
+	void (^work)(void) = ^{
+		startOnMainThread(queryCallback, confirmCallback, cancelCallback, x, y, width, height, userData);
+		started = 1;
+	};
+
+	if ([NSThread isMainThread]) {
+		work();
+	} else {
+		dispatch_sync(dispatch_get_main_queue(), work);
+	}
+
+	return started;
+}
+
+void NeruStopHintSearchTextInput(void) {
+	void (^work)(void) = ^{
+		stopOnMainThread();
+	};
+
+	if ([NSThread isMainThread]) {
+		work();
+	} else {
+		dispatch_async(dispatch_get_main_queue(), work);
+	}
+}

--- a/internal/core/infra/platform/darwin/textinput_darwin.m
+++ b/internal/core/infra/platform/darwin/textinput_darwin.m
@@ -245,6 +245,6 @@ void NeruStopHintSearchTextInput(void) {
 	if ([NSThread isMainThread]) {
 		work();
 	} else {
-		dispatch_async(dispatch_get_main_queue(), work);
+		dispatch_sync(dispatch_get_main_queue(), work);
 	}
 }

--- a/internal/core/infra/textinput/adapter.go
+++ b/internal/core/infra/textinput/adapter.go
@@ -12,10 +12,9 @@ import (
 
 // Adapter implements the TextInputPort using the native TextInput.
 type Adapter struct {
-	input   *TextInput
-	logger  *zap.Logger
-	mu      sync.RWMutex
-	running bool
+	input  *TextInput
+	logger *zap.Logger
+	mu     sync.RWMutex
 }
 
 // NewAdapter creates a new Adapter with the given TextInput and logger.
@@ -39,12 +38,7 @@ func (a *Adapter) StartHintSearchSession(
 		return false, nil
 	}
 
-	started, err := a.input.StartHintSearchSession(ctx, callbacks, frame)
-	if started {
-		a.running = true
-	}
-
-	return started, err
+	return a.input.StartHintSearchSession(ctx, callbacks, frame)
 }
 
 // StopHintSearchSession stops the native hint search session.
@@ -55,8 +49,6 @@ func (a *Adapter) StopHintSearchSession(ctx context.Context) error {
 	if a.input == nil {
 		return nil
 	}
-
-	a.running = false
 
 	return a.input.StopHintSearchSession(ctx)
 }

--- a/internal/core/infra/textinput/adapter.go
+++ b/internal/core/infra/textinput/adapter.go
@@ -1,0 +1,62 @@
+// Package textinput provides an adapter and stub for native text input.
+package textinput
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+// Adapter implements the TextInputPort using the native TextInput.
+type Adapter struct {
+	input   *TextInput
+	logger  *zap.Logger
+	mu      sync.RWMutex
+	running bool
+}
+
+// NewAdapter creates a new Adapter with the given TextInput and logger.
+func NewAdapter(input *TextInput, logger *zap.Logger) *Adapter {
+	return &Adapter{
+		input:  input,
+		logger: logger,
+	}
+}
+
+// StartHintSearchSession starts the native hint search session.
+func (a *Adapter) StartHintSearchSession(
+	ctx context.Context,
+	callbacks ports.TextInputCallbacks,
+	frame ports.TextInputFrame,
+) (bool, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.input == nil {
+		return false, nil
+	}
+
+	started, err := a.input.StartHintSearchSession(ctx, callbacks, frame)
+	if started {
+		a.running = true
+	}
+
+	return started, err
+}
+
+// StopHintSearchSession stops the native hint search session.
+func (a *Adapter) StopHintSearchSession(ctx context.Context) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.input == nil {
+		return nil
+	}
+
+	a.running = false
+
+	return a.input.StopHintSearchSession(ctx)
+}

--- a/internal/core/infra/textinput/textinput_darwin.go
+++ b/internal/core/infra/textinput/textinput_darwin.go
@@ -16,6 +16,7 @@ import "C"
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	"go.uber.org/zap"
@@ -28,6 +29,10 @@ type TextInput struct {
 	logger    *zap.Logger
 	callbacks ports.TextInputCallbacks
 	mu        sync.RWMutex
+
+	querySeq        uint64
+	lastExecutedSeq uint64
+	callbackMu      sync.Mutex
 }
 
 var (
@@ -95,6 +100,8 @@ func textInputQueryBridge(query *C.char, _ unsafe.Pointer) {
 		return
 	}
 
+	seq := atomic.AddUint64(&textInput.querySeq, 1)
+
 	queryStr := ""
 	if query != nil {
 		queryStr = C.GoString(query)
@@ -108,7 +115,17 @@ func textInputQueryBridge(query *C.char, _ unsafe.Pointer) {
 		return
 	}
 
-	go callback(queryStr)
+	go func(s uint64, q string) {
+		textInput.callbackMu.Lock()
+		defer textInput.callbackMu.Unlock()
+
+		if s < textInput.lastExecutedSeq {
+			return
+		}
+		textInput.lastExecutedSeq = s
+
+		callback(q)
+	}(seq, queryStr)
 }
 
 //export textInputConfirmBridge

--- a/internal/core/infra/textinput/textinput_darwin.go
+++ b/internal/core/infra/textinput/textinput_darwin.go
@@ -115,16 +115,16 @@ func textInputQueryBridge(query *C.char, _ unsafe.Pointer) {
 		return
 	}
 
-	go func(s uint64, q string) {
+	go func(seq uint64, query string) {
 		textInput.callbackMu.Lock()
 		defer textInput.callbackMu.Unlock()
 
-		if s < textInput.lastExecutedSeq {
+		if seq < textInput.lastExecutedSeq {
 			return
 		}
-		textInput.lastExecutedSeq = s
+		textInput.lastExecutedSeq = seq
 
-		callback(q)
+		callback(query)
 	}(seq, queryStr)
 }
 

--- a/internal/core/infra/textinput/textinput_darwin.go
+++ b/internal/core/infra/textinput/textinput_darwin.go
@@ -1,0 +1,154 @@
+//go:build darwin
+
+package textinput
+
+/*
+#cgo CFLAGS: -x objective-c
+#include "../platform/darwin/textinput.h"
+#include <stdlib.h>
+
+extern void textInputQueryBridge(char* query, void* userData);
+extern void textInputConfirmBridge(void* userData);
+extern void textInputCancelBridge(void* userData);
+*/
+import "C"
+
+import (
+	"context"
+	"sync"
+	"unsafe"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+// TextInput manages the macOS native text input session.
+type TextInput struct {
+	logger    *zap.Logger
+	callbacks ports.TextInputCallbacks
+	mu        sync.RWMutex
+}
+
+var (
+	globalTextInput   *TextInput
+	globalTextInputMu sync.RWMutex
+)
+
+// NewTextInput creates a new TextInput instance.
+func NewTextInput(logger *zap.Logger) *TextInput {
+	textInput := &TextInput{logger: logger}
+
+	globalTextInputMu.Lock()
+	globalTextInput = textInput
+	globalTextInputMu.Unlock()
+
+	return textInput
+}
+
+// StartHintSearchSession starts the native hint search session.
+func (t *TextInput) StartHintSearchSession(
+	_ context.Context,
+	callbacks ports.TextInputCallbacks,
+	frame ports.TextInputFrame,
+) (bool, error) {
+	t.mu.Lock()
+	t.callbacks = callbacks
+	t.mu.Unlock()
+
+	started := C.NeruStartHintSearchTextInput(
+		C.TextInputQueryCallback(C.textInputQueryBridge),
+		C.TextInputControlCallback(C.textInputConfirmBridge),
+		C.TextInputControlCallback(C.textInputCancelBridge),
+		C.int(frame.X),
+		C.int(frame.Y),
+		C.int(frame.Width),
+		C.int(frame.Height),
+		nil,
+	)
+
+	if started == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// StopHintSearchSession stops the native hint search session.
+func (t *TextInput) StopHintSearchSession(_ context.Context) error {
+	C.NeruStopHintSearchTextInput()
+
+	t.mu.Lock()
+	t.callbacks = ports.TextInputCallbacks{}
+	t.mu.Unlock()
+
+	return nil
+}
+
+//export textInputQueryBridge
+func textInputQueryBridge(query *C.char, _ unsafe.Pointer) {
+	globalTextInputMu.RLock()
+	textInput := globalTextInput
+	globalTextInputMu.RUnlock()
+
+	if textInput == nil {
+		return
+	}
+
+	queryStr := ""
+	if query != nil {
+		queryStr = C.GoString(query)
+	}
+
+	textInput.mu.RLock()
+	callback := textInput.callbacks.OnQueryChanged
+	textInput.mu.RUnlock()
+
+	if callback == nil {
+		return
+	}
+
+	go callback(queryStr)
+}
+
+//export textInputConfirmBridge
+func textInputConfirmBridge(_ unsafe.Pointer) {
+	globalTextInputMu.RLock()
+	textInput := globalTextInput
+	globalTextInputMu.RUnlock()
+
+	if textInput == nil {
+		return
+	}
+
+	textInput.mu.RLock()
+	callback := textInput.callbacks.OnConfirm
+	textInput.mu.RUnlock()
+
+	if callback == nil {
+		return
+	}
+
+	go callback()
+}
+
+//export textInputCancelBridge
+func textInputCancelBridge(_ unsafe.Pointer) {
+	globalTextInputMu.RLock()
+	textInput := globalTextInput
+	globalTextInputMu.RUnlock()
+
+	if textInput == nil {
+		return
+	}
+
+	textInput.mu.RLock()
+	callback := textInput.callbacks.OnCancel
+	textInput.mu.RUnlock()
+
+	if callback == nil {
+		return
+	}
+
+	go callback()
+}

--- a/internal/core/infra/textinput/textinput_darwin.go
+++ b/internal/core/infra/textinput/textinput_darwin.go
@@ -146,7 +146,12 @@ func textInputConfirmBridge(_ unsafe.Pointer) {
 		return
 	}
 
-	go callback()
+	go func() {
+		textInput.callbackMu.Lock()
+		defer textInput.callbackMu.Unlock()
+
+		callback()
+	}()
 }
 
 //export textInputCancelBridge
@@ -167,5 +172,10 @@ func textInputCancelBridge(_ unsafe.Pointer) {
 		return
 	}
 
-	go callback()
+	go func() {
+		textInput.callbackMu.Lock()
+		defer textInput.callbackMu.Unlock()
+
+		callback()
+	}()
 }

--- a/internal/core/infra/textinput/textinput_darwin.go
+++ b/internal/core/infra/textinput/textinput_darwin.go
@@ -81,11 +81,11 @@ func (t *TextInput) StartHintSearchSession(
 
 // StopHintSearchSession stops the native hint search session.
 func (t *TextInput) StopHintSearchSession(_ context.Context) error {
-	C.NeruStopHintSearchTextInput()
-
 	t.mu.Lock()
 	t.callbacks = ports.TextInputCallbacks{}
 	t.mu.Unlock()
+
+	C.NeruStopHintSearchTextInput()
 
 	return nil
 }

--- a/internal/core/infra/textinput/textinput_stub.go
+++ b/internal/core/infra/textinput/textinput_stub.go
@@ -10,14 +10,17 @@ import (
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
+// TextInput is a stub implementation for platforms without native text input.
 type TextInput struct {
 	logger *zap.Logger
 }
 
+// NewTextInput creates a new stub TextInput instance.
 func NewTextInput(logger *zap.Logger) *TextInput {
 	return &TextInput{logger: logger}
 }
 
+// StartHintSearchSession does nothing on non-supported platforms and returns false.
 func (t *TextInput) StartHintSearchSession(
 	_ context.Context,
 	_ ports.TextInputCallbacks,
@@ -26,6 +29,7 @@ func (t *TextInput) StartHintSearchSession(
 	return false, nil
 }
 
+// StopHintSearchSession does nothing on non-supported platforms.
 func (t *TextInput) StopHintSearchSession(_ context.Context) error {
 	return nil
 }

--- a/internal/core/infra/textinput/textinput_stub.go
+++ b/internal/core/infra/textinput/textinput_stub.go
@@ -1,0 +1,31 @@
+//go:build !darwin
+
+package textinput
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+type TextInput struct {
+	logger *zap.Logger
+}
+
+func NewTextInput(logger *zap.Logger) *TextInput {
+	return &TextInput{logger: logger}
+}
+
+func (t *TextInput) StartHintSearchSession(
+	_ context.Context,
+	_ ports.TextInputCallbacks,
+	_ ports.TextInputFrame,
+) (bool, error) {
+	return false, nil
+}
+
+func (t *TextInput) StopHintSearchSession(_ context.Context) error {
+	return nil
+}

--- a/internal/core/ports/textinput.go
+++ b/internal/core/ports/textinput.go
@@ -1,0 +1,28 @@
+package ports
+
+import "context"
+
+// TextInputCallbacks holds callbacks for the native text input.
+type TextInputCallbacks struct {
+	OnQueryChanged func(query string)
+	OnConfirm      func()
+	OnCancel       func()
+}
+
+// TextInputFrame defines the bounding box for the text input.
+type TextInputFrame struct {
+	X      int
+	Y      int
+	Width  int
+	Height int
+}
+
+// TextInputPort defines the interface for native text input capabilities.
+type TextInputPort interface {
+	StartHintSearchSession(
+		ctx context.Context,
+		callbacks TextInputCallbacks,
+		frame TextInputFrame,
+	) (bool, error)
+	StopHintSearchSession(ctx context.Context) error
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -162,7 +162,7 @@ else
     # `nix-shell -p go --run 'go mod vendor'`
     # `nix hash path vendor`
     # `rm -rf vendor`
-    vendorHash = "sha256-VQFqWNlZV7ap2zNvkqjzmfjkqBTejMX3pqyEFAAVQVI=";
+    vendorHash = "sha256-SCZUfw5Fx9k2jLTKmD42cXldJJuwwbz5pgQPVU6niLU=";
 
     ldflags = [
       "-s"


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a full multilingual text input (including IME composition) for the hints-mode search.

Previously, typing in the hints search relied on the macOS event-tap, which explicitly bypassed Input Method Editors (IMEs), making it impossible to type in languages like Japanese, Chinese, or Korean.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/d10f3a83-7c41-4f47-addf-1a95d606af31

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
