### PR TITLE
fix(config): remove default launcher keybinds if mode is disabled

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -114,6 +114,15 @@ To **remove** a single default binding without affecting the rest, use the `__di
 "Cmd+Shift+Option+Ctrl+G" = "grid"           # rebinds grid to Hyper+G: default Primary+Shift+G is removed
 ```
 
+**Automatically disabled:** When a mode is disabled (`enabled = false`), its default launcher hotkey is automatically removed:
+
+```toml
+[hints]
+enabled = false  # automatically removes Primary+Shift+Space -> hints from global hotkeys
+```
+
+This prevents stale keybindings from remaining in the config when a mode is no longer in use.
+
 ### Syntax
 
 **Format:** `"Modifier1+Modifier2+Key" = "action"`

--- a/internal/config/config_integration_test.go
+++ b/internal/config/config_integration_test.go
@@ -268,6 +268,88 @@ bundle_id = "com.apple.Safari"
 		}
 	})
 
+	t.Run("Disabled Mode Removes Default Launcher", func(t *testing.T) {
+		configContent := `
+[hints]
+enabled = false
+`
+
+		writeConfigFile(t, configPath, configContent, 0o644)
+
+		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+
+		loadResult := service.LoadWithValidation(configPath)
+		if loadResult.ValidationError != nil {
+			t.Fatalf("Config validation failed: %v", loadResult.ValidationError)
+		}
+
+		if _, exists := loadResult.Config.Hotkeys.Bindings["Primary+Shift+Space"]; exists {
+			t.Fatal("expected hints launcher to be removed when hints is disabled")
+		}
+
+		if _, exists := loadResult.Config.Hotkeys.Bindings["Primary+Shift+G"]; !exists {
+			t.Fatal("expected unrelated launcher hotkeys to remain")
+		}
+	})
+
+	t.Run("Multiple Disabled Modes Remove Launchers", func(t *testing.T) {
+		configContent := `
+[hints]
+enabled = false
+
+[grid]
+enabled = false
+`
+
+		writeConfigFile(t, configPath, configContent, 0o644)
+
+		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+
+		loadResult := service.LoadWithValidation(configPath)
+		if loadResult.ValidationError != nil {
+			t.Fatalf("Config validation failed: %v", loadResult.ValidationError)
+		}
+
+		if _, exists := loadResult.Config.Hotkeys.Bindings["Primary+Shift+Space"]; exists {
+			t.Fatal("expected hints launcher to be removed when hints is disabled")
+		}
+
+		if _, exists := loadResult.Config.Hotkeys.Bindings["Primary+Shift+G"]; exists {
+			t.Fatal("expected grid launcher to be removed when grid is disabled")
+		}
+
+		if _, exists := loadResult.Config.Hotkeys.Bindings["Primary+Shift+C"]; !exists {
+			t.Fatal("expected unrelated launcher hotkeys to remain")
+		}
+	})
+
+	t.Run("Disabled Mode With Rebound Launcher", func(t *testing.T) {
+		configContent := `
+[hints]
+enabled = false
+
+[hotkeys]
+"Primary+Shift+Space" = "grid"
+`
+
+		writeConfigFile(t, configPath, configContent, 0o644)
+
+		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+
+		loadResult := service.LoadWithValidation(configPath)
+		if loadResult.ValidationError != nil {
+			t.Fatalf("Config validation failed: %v", loadResult.ValidationError)
+		}
+
+		actions, exists := loadResult.Config.Hotkeys.Bindings["Primary+Shift+Space"]
+		if !exists || len(actions) != 1 || actions[0] != "grid" {
+			t.Fatalf(
+				"expected rebound launcher to replace disabled mode launcher, got %v",
+				loadResult.Config.Hotkeys.Bindings,
+			)
+		}
+	})
+
 	t.Run("Config File Permissions", func(t *testing.T) {
 		// Test that config files with restrictive permissions can still be read
 		configContent := `

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -120,7 +120,7 @@ func removeLauncherBindingsForDisabledModes(cfg *Config) {
 	for key, actions := range cfg.Hotkeys.Bindings {
 		if len(actions) == 1 {
 			if action, ok := isBuiltInGlobalModeAction(actions); ok {
-				if modeEnabled := modeActions[action]; ok && !modeEnabled {
+				if modeEnabled, found := modeActions[action]; found && !modeEnabled {
 					delete(cfg.Hotkeys.Bindings, key)
 				}
 			}

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -108,6 +108,26 @@ func removeBindingsForSingleAction(bindings map[string][]string, action string) 
 	}
 }
 
+// removeLauncherBindingsForDisabledModes removes launcher keybindings for modes
+// that are explicitly disabled in the config.
+func removeLauncherBindingsForDisabledModes(cfg *Config) {
+	modeActions := map[string]bool{
+		modeNameHints:         cfg.Hints.Enabled,
+		modeNameGrid:          cfg.Grid.Enabled,
+		modeNameRecursiveGrid: cfg.RecursiveGrid.Enabled,
+	}
+
+	for key, actions := range cfg.Hotkeys.Bindings {
+		if len(actions) == 1 {
+			if action, ok := isBuiltInGlobalModeAction(actions); ok {
+				if modeEnabled := modeActions[action]; ok && !modeEnabled {
+					delete(cfg.Hotkeys.Bindings, key)
+				}
+			}
+		}
+	}
+}
+
 // parseRawHotkeyActions parses a raw TOML hotkey value into actions.
 func parseRawHotkeyActions(fieldName string, value any) ([]string, error) {
 	switch val := value.(type) {
@@ -554,6 +574,8 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 	}
 
 	s.logger.Info("Configuration loaded successfully")
+
+	removeLauncherBindingsForDisabledModes(configResult.Config)
 
 	return configResult
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR automatically removes default launcher keybinds if a mode is explicitly disabled.

Previously, users had to manually set the launcher to `__disabled__` when a mode is disabled.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Follows #778
Closes #787

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
