### PR TITLE
feat: add mouse action indicator

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -200,6 +200,25 @@ enabled = true
 [virtual_pointer.ui]
 size = 3
 
+# Mouse action indicator (macOS)
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#mouse-action-indicator
+[mouse_action_indicator]
+enabled = false                             # Disabled by default
+actions = ["left_click", "right_click", "middle_click", "mouse_down", "mouse_up"]
+
+[mouse_action_indicator.ui]
+size = 36
+border_width = 2
+shape = "circle"                            # circle or square
+
+[mouse_action_indicator.animation]
+duration_ms = 260
+start_scale = 0.55
+end_scale = 1.35
+start_opacity = 0.85
+end_opacity = 0.0
+easing = "ease_out"                         # linear, ease_in, ease_out, ease_in_out
+
 # Scroll mode
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#scroll-mode
 [scroll]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -873,7 +873,7 @@ actions = ["left_click", "right_click", "middle_click"]
 [mouse_action_indicator.ui]
 size = 36
 border_width = 2
-background_color = "#5B8CFFFF"
+background_color = "#FF5B8CFF"
 border_color = "#5B8CFF"
 shape = "circle" # circle or square
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -21,6 +21,7 @@ Neru uses TOML for configuration. No config file is required — Neru works out 
 - [Recursive Grid Mode](#recursive-grid-mode)
 - [Scroll Mode](#scroll-mode)
 - [Virtual Pointer](#virtual-pointer)
+- [Mouse Action Indicator](#mouse-action-indicator)
 - [Mode Indicator](#mode-indicator)
 - [Sticky Modifiers](#sticky-modifiers)
 - [Theme Palette](#theme-palette)
@@ -847,6 +848,43 @@ background_color = { light = "#FF0000AA", dark = "#00FF00AA" }
 ```
 
 When a color is omitted or set to empty, Neru uses its built-in theme-aware defaults. Colors update in real time when you switch system themes.
+
+---
+
+## Mouse Action Indicator
+
+Mouse action indicators show a transient visual marker where a mouse button action happened. This is useful for CLI-triggered actions too, so the macOS implementation uses its own temporary window instead of relying on an active mode overlay.
+
+> [!NOTE]
+> Currently rendered on **macOS only**. Other platforms accept the config and no-op.
+
+| Option    | Type     | Default                                                                 | Description                              |
+| --------- | -------- | ----------------------------------------------------------------------- | ---------------------------------------- |
+| `enabled` | bool     | `false`                                                                 | Enable mouse action indicators           |
+| `actions` | string[] | all mouse button actions                                                | Actions that should show the indicator   |
+| `ui`      | table    | see below                                                               | Visual styling                           |
+| `animation` | table  | see below                                                               | Animation timing and interpolation       |
+
+```toml
+[mouse_action_indicator]
+enabled = true
+actions = ["left_click", "right_click", "middle_click"]
+
+[mouse_action_indicator.ui]
+size = 36
+border_width = 2
+background_color = "#5B8CFFFF"
+border_color = "#5B8CFF"
+shape = "circle" # circle or square
+
+[mouse_action_indicator.animation]
+duration_ms = 260
+start_scale = 0.55
+end_scale = 1.35
+start_opacity = 0.85
+end_opacity = 0.0
+easing = "ease_out" # linear, ease_in, ease_out, ease_in_out
+```
 
 ---
 

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -135,6 +135,10 @@ func (a *App) updateServiceConfigs(cfg *config.Config) {
 	if a.scrollService != nil {
 		a.scrollService.UpdateConfig(cfg.Scroll)
 	}
+
+	if a.actionService != nil {
+		a.actionService.UpdateConfig(cfg.MouseAction)
+	}
 }
 
 func (a *App) updateControllerConfigs(cfg *config.Config) {

--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -161,6 +161,7 @@ func initializeServices(
 		systemPort,
 		logger,
 	)
+	actionService.UpdateConfig(cfg.MouseAction)
 
 	// Scroll Service - manages scrolling operations
 	scrollService := services.NewScrollService(

--- a/internal/app/mocks_darwin_test.go
+++ b/internal/app/mocks_darwin_test.go
@@ -16,6 +16,7 @@ import (
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 	"github.com/y3owk1n/neru/internal/core/infra/appwatcher"
 	"github.com/y3owk1n/neru/internal/core/infra/hotkeys"
+	"github.com/y3owk1n/neru/internal/core/ports"
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
@@ -228,6 +229,12 @@ func (m *mockOverlayManager) DrawHintsWithStyle(
 }
 func (m *mockOverlayManager) DrawModeIndicator(_, _ int)                      {}
 func (m *mockOverlayManager) DrawStickyModifiersIndicator(_, _ int, _ string) {}
+
+func (m *mockOverlayManager) DrawMouseActionIndicator(
+	_ image.Point,
+	_ ports.MouseActionIndicatorStyle,
+) {
+}
 
 func (m *mockOverlayManager) DrawGrid(
 	_ *domainGrid.Grid,

--- a/internal/app/services/action_service.go
+++ b/internal/app/services/action_service.go
@@ -3,10 +3,13 @@ package services
 import (
 	"context"
 	"image"
+	"slices"
 	"strings"
+	"sync"
 
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	"github.com/y3owk1n/neru/internal/core/domain/element"
@@ -18,7 +21,9 @@ import (
 type ActionService struct {
 	BaseService
 
-	logger *zap.Logger
+	configMu sync.RWMutex
+	config   config.MouseActionConfig
+	logger   *zap.Logger
 }
 
 // NewActionService creates a new action service.
@@ -30,8 +35,17 @@ func NewActionService(
 ) *ActionService {
 	return &ActionService{
 		BaseService: NewBaseService(accessibility, overlay, system),
+		config:      config.DefaultConfig().MouseAction,
 		logger:      logger,
 	}
+}
+
+// UpdateConfig updates the mouse action indicator configuration.
+func (s *ActionService) UpdateConfig(cfg config.MouseActionConfig) {
+	s.configMu.Lock()
+	defer s.configMu.Unlock()
+
+	s.config = cfg
 }
 
 // ExecuteAction performs the specified action on the given element.
@@ -89,7 +103,19 @@ func (s *ActionService) PerformActionAtPoint(
 		return core.WrapActionFailed(performActionErr, actionType.String()+" at point")
 	}
 
+	s.drawMouseActionIndicator(point, actionType)
+
 	return nil
+}
+
+func mouseActionIndicatorIncludes(actions []string, actionType action.Type) bool {
+	if len(actions) == 0 {
+		return actionType.IsMouseButton()
+	}
+
+	actionName := actionType.String()
+
+	return slices.Contains(actions, actionName)
 }
 
 // IsFocusedAppExcluded checks if the currently focused application is in the exclusion list.
@@ -319,6 +345,44 @@ func (s *ActionService) MoveMouseToCenterOfWindow(
 		zap.Int("offsetX", offsetX),
 		zap.Int("offsetY", offsetY),
 	)
+}
+
+func (s *ActionService) drawMouseActionIndicator(point image.Point, actionType action.Type) {
+	cfg := s.mouseActionConfig()
+	if !cfg.Enabled || !mouseActionIndicatorIncludes(cfg.Actions, actionType) {
+		return
+	}
+
+	style := ports.MouseActionIndicatorStyle{
+		Size:        cfg.UI.Size,
+		BorderWidth: cfg.UI.BorderWidth,
+		BackgroundColor: cfg.UI.BackgroundColor.ForTheme(
+			s.system,
+			config.MouseActionBackgroundColorLight,
+			config.MouseActionBackgroundColorDark,
+		),
+		BorderColor: cfg.UI.BorderColor.ForTheme(
+			s.system,
+			config.MouseActionBorderColorLight,
+			config.MouseActionBorderColorDark,
+		),
+		Shape:        cfg.UI.Shape,
+		DurationMS:   cfg.Animation.DurationMS,
+		StartScale:   cfg.Animation.StartScale,
+		EndScale:     cfg.Animation.EndScale,
+		StartOpacity: cfg.Animation.StartOpacity,
+		EndOpacity:   cfg.Animation.EndOpacity,
+		Easing:       cfg.Animation.Easing,
+	}
+
+	s.overlay.DrawMouseActionIndicator(point, style)
+}
+
+func (s *ActionService) mouseActionConfig() config.MouseActionConfig {
+	s.configMu.RLock()
+	defer s.configMu.RUnlock()
+
+	return s.config
 }
 
 // moveMouseWithBounds clamps target to the given screen bounds and moves the cursor.

--- a/internal/app/services/action_service.go
+++ b/internal/app/services/action_service.go
@@ -109,10 +109,6 @@ func (s *ActionService) PerformActionAtPoint(
 }
 
 func mouseActionIndicatorIncludes(actions []string, actionType action.Type) bool {
-	if len(actions) == 0 {
-		return actionType.IsMouseButton()
-	}
-
 	actionName := actionType.String()
 
 	return slices.Contains(actions, actionName)

--- a/internal/app/services/action_service_test.go
+++ b/internal/app/services/action_service_test.go
@@ -8,7 +8,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/app/services"
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
+	"github.com/y3owk1n/neru/internal/core/ports"
 	portmocks "github.com/y3owk1n/neru/internal/core/ports/mocks"
 )
 
@@ -57,6 +59,63 @@ func TestPerformActionAtPoint_ParsesAndDispatches(t *testing.T) {
 
 	if !called {
 		t.Fatal("expected PerformActionAtPoint to be called")
+	}
+}
+
+func TestPerformActionAtPoint_DrawsMouseActionIndicatorWhenEnabled(t *testing.T) {
+	ctx := context.Background()
+
+	acc := &portmocks.MockAccessibilityPort{
+		PerformActionAtPointFunc: func(
+			context.Context,
+			action.Type,
+			image.Point,
+			action.Modifiers,
+		) error {
+			return nil
+		},
+	}
+
+	var (
+		gotPoint image.Point
+		gotStyle ports.MouseActionIndicatorStyle
+	)
+
+	drawn := false
+	overlay := &portmocks.MockOverlayPort{
+		DrawMouseActionIndicatorFunc: func(
+			point image.Point,
+			style ports.MouseActionIndicatorStyle,
+		) {
+			drawn = true
+			gotPoint = point
+			gotStyle = style
+		},
+	}
+
+	service := services.NewActionService(acc, overlay, &portmocks.SystemMock{}, zap.NewNop())
+	cfg := config.DefaultConfig().MouseAction
+	cfg.Enabled = true
+	cfg.Actions = []string{"left_click"}
+	service.UpdateConfig(cfg)
+
+	point := image.Point{X: 10, Y: 20}
+
+	err := service.PerformActionAtPoint(ctx, "left_click", point, 0)
+	if err != nil {
+		t.Fatalf("PerformActionAtPoint() error = %v", err)
+	}
+
+	if !drawn {
+		t.Fatal("expected mouse action indicator to be drawn")
+	}
+
+	if gotPoint != point {
+		t.Fatalf("unexpected indicator point: %v", gotPoint)
+	}
+
+	if gotStyle.Size != cfg.UI.Size || gotStyle.DurationMS != cfg.Animation.DurationMS {
+		t.Fatalf("unexpected indicator style: %+v", gotStyle)
 	}
 }
 

--- a/internal/app/services/action_service_test.go
+++ b/internal/app/services/action_service_test.go
@@ -119,6 +119,86 @@ func TestPerformActionAtPoint_DrawsMouseActionIndicatorWhenEnabled(t *testing.T)
 	}
 }
 
+func TestPerformActionAtPoint_DoesNotDrawMouseActionIndicatorWhenDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	acc := &portmocks.MockAccessibilityPort{
+		PerformActionAtPointFunc: func(
+			context.Context,
+			action.Type,
+			image.Point,
+			action.Modifiers,
+		) error {
+			return nil
+		},
+	}
+
+	drawn := false
+	overlay := &portmocks.MockOverlayPort{
+		DrawMouseActionIndicatorFunc: func(
+			image.Point,
+			ports.MouseActionIndicatorStyle,
+		) {
+			drawn = true
+		},
+	}
+
+	service := services.NewActionService(acc, overlay, &portmocks.SystemMock{}, zap.NewNop())
+	cfg := config.DefaultConfig().MouseAction
+	cfg.Enabled = false
+	cfg.Actions = []string{"left_click"}
+	service.UpdateConfig(cfg)
+
+	err := service.PerformActionAtPoint(ctx, "left_click", image.Point{X: 10, Y: 20}, 0)
+	if err != nil {
+		t.Fatalf("PerformActionAtPoint() error = %v", err)
+	}
+
+	if drawn {
+		t.Fatal("expected mouse action indicator NOT to be drawn when disabled")
+	}
+}
+
+func TestPerformActionAtPoint_DoesNotDrawMouseActionIndicatorForUnlistedAction(t *testing.T) {
+	ctx := context.Background()
+
+	acc := &portmocks.MockAccessibilityPort{
+		PerformActionAtPointFunc: func(
+			context.Context,
+			action.Type,
+			image.Point,
+			action.Modifiers,
+		) error {
+			return nil
+		},
+	}
+
+	drawn := false
+	overlay := &portmocks.MockOverlayPort{
+		DrawMouseActionIndicatorFunc: func(
+			image.Point,
+			ports.MouseActionIndicatorStyle,
+		) {
+			drawn = true
+		},
+	}
+
+	service := services.NewActionService(acc, overlay, &portmocks.SystemMock{}, zap.NewNop())
+	cfg := config.DefaultConfig().MouseAction
+	cfg.Enabled = true
+	cfg.Actions = []string{"left_click"}
+	service.UpdateConfig(cfg)
+
+	err := service.PerformActionAtPoint(ctx, "right_click", image.Point{X: 10, Y: 20}, 0)
+	if err != nil {
+		t.Fatalf("PerformActionAtPoint() error = %v", err)
+	}
+
+	if drawn {
+		t.Fatal("expected mouse action indicator NOT to be drawn for unlisted action")
+	}
+}
+
 func TestPerformActionAtPoint_InvalidAction(t *testing.T) {
 	service := newTestActionService(&portmocks.MockAccessibilityPort{}, &portmocks.SystemMock{})
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -393,6 +393,7 @@ type Config struct {
 	Grid            GridConfig            `json:"grid"            toml:"grid"`
 	RecursiveGrid   RecursiveGridConfig   `json:"recursiveGrid"   toml:"recursive_grid"`
 	VirtualPointer  VirtualPointerConfig  `json:"virtualPointer"  toml:"virtual_pointer"`
+	MouseAction     MouseActionConfig     `json:"mouseAction"     toml:"mouse_action_indicator"`
 	Scroll          ScrollConfig          `json:"scroll"          toml:"scroll"`
 	ModeIndicator   ModeIndicatorConfig   `json:"modeIndicator"   toml:"mode_indicator"`
 	StickyModifiers StickyModifiersConfig `json:"stickyModifiers" toml:"sticky_modifiers"`
@@ -681,6 +682,33 @@ type VirtualPointerConfig struct {
 	UI      VirtualPointerUI `json:"ui"      toml:"ui"`
 }
 
+// MouseActionUI defines the visual settings for mouse action indicators.
+type MouseActionUI struct {
+	Size            int    `json:"size"            toml:"size"`
+	BorderWidth     int    `json:"borderWidth"     toml:"border_width"`
+	BackgroundColor Color  `json:"backgroundColor" toml:"background_color"`
+	BorderColor     Color  `json:"borderColor"     toml:"border_color"`
+	Shape           string `json:"shape"           toml:"shape"`
+}
+
+// MouseActionAnimation defines animation settings for mouse action indicators.
+type MouseActionAnimation struct {
+	DurationMS   int     `json:"durationMs"   toml:"duration_ms"`
+	StartScale   float64 `json:"startScale"   toml:"start_scale"`
+	EndScale     float64 `json:"endScale"     toml:"end_scale"`
+	StartOpacity float64 `json:"startOpacity" toml:"start_opacity"`
+	EndOpacity   float64 `json:"endOpacity"   toml:"end_opacity"`
+	Easing       string  `json:"easing"       toml:"easing"`
+}
+
+// MouseActionConfig defines settings for transient mouse action indicators.
+type MouseActionConfig struct {
+	Enabled   bool                 `json:"enabled"   toml:"enabled"`
+	Actions   []string             `json:"actions"   toml:"actions"`
+	UI        MouseActionUI        `json:"ui"        toml:"ui"`
+	Animation MouseActionAnimation `json:"animation" toml:"animation"`
+}
+
 // AllKeysIncludingLayers returns a combined string of all unique keys from the
 // top-level config and all layers. Used for conflict validation.
 func (c *RecursiveGridConfig) AllKeysIncludingLayers() string {
@@ -816,6 +844,11 @@ func (c *Config) Validate() error {
 	}
 
 	err = c.ValidateVirtualPointer()
+	if err != nil {
+		return err
+	}
+
+	err = c.ValidateMouseAction()
 	if err != nil {
 		return err
 	}

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -206,6 +206,20 @@ const (
 	DefaultRecursiveGridFontSize = 10
 	// DefaultVirtualPointerSize is the default virtual pointer dot radius in points.
 	DefaultVirtualPointerSize = 3
+	// DefaultMouseActionIndicatorSize is the default mouse action indicator diameter in points.
+	DefaultMouseActionIndicatorSize = 36
+	// DefaultMouseActionIndicatorBorderWidth is the default mouse action indicator border width.
+	DefaultMouseActionIndicatorBorderWidth = 2
+	// DefaultMouseActionIndicatorDurationMS is the default mouse action indicator animation duration.
+	DefaultMouseActionIndicatorDurationMS = 260
+	// DefaultMouseActionIndicatorStartScale is the default starting scale for mouse action indicators.
+	DefaultMouseActionIndicatorStartScale = 0.55
+	// DefaultMouseActionIndicatorEndScale is the default ending scale for mouse action indicators.
+	DefaultMouseActionIndicatorEndScale = 1.35
+	// DefaultMouseActionIndicatorStartOpacity is the default starting opacity for mouse action indicators.
+	DefaultMouseActionIndicatorStartOpacity = 0.85
+	// DefaultMouseActionIndicatorEndOpacity is the default ending opacity for mouse action indicators.
+	DefaultMouseActionIndicatorEndOpacity = 0.0
 	// DefaultRecursiveGridLabelBackgroundPaddingX preserves automatic horizontal badge padding.
 	DefaultRecursiveGridLabelBackgroundPaddingX = -1
 	// DefaultRecursiveGridLabelBackgroundPaddingY preserves automatic vertical badge padding.
@@ -426,6 +440,31 @@ func newDefaultConfig() *Config {
 			UI: VirtualPointerUI{
 				Size:  DefaultVirtualPointerSize,
 				Color: Color{},
+			},
+		},
+		MouseAction: MouseActionConfig{
+			Enabled: false,
+			Actions: []string{
+				"left_click",
+				"right_click",
+				"middle_click",
+				"mouse_down",
+				"mouse_up",
+			},
+			UI: MouseActionUI{
+				Size:            DefaultMouseActionIndicatorSize,
+				BorderWidth:     DefaultMouseActionIndicatorBorderWidth,
+				BackgroundColor: Color{},
+				BorderColor:     Color{},
+				Shape:           "circle",
+			},
+			Animation: MouseActionAnimation{
+				DurationMS:   DefaultMouseActionIndicatorDurationMS,
+				StartScale:   DefaultMouseActionIndicatorStartScale,
+				EndScale:     DefaultMouseActionIndicatorEndScale,
+				StartOpacity: DefaultMouseActionIndicatorStartOpacity,
+				EndOpacity:   DefaultMouseActionIndicatorEndOpacity,
+				Easing:       "ease_out",
 			},
 		},
 		ModeIndicator: ModeIndicatorConfig{

--- a/internal/config/theme_palette.go
+++ b/internal/config/theme_palette.go
@@ -102,6 +102,15 @@ var (
 	// ModeIndicatorBorderColorDark is the fallback dark border color for the mode indicator.
 	ModeIndicatorBorderColorDark = solidRGBHex(defaultThemeDarkAccent)
 
+	// MouseActionBackgroundColorLight is the fallback light fill color for mouse action indicators.
+	MouseActionBackgroundColorLight = applyAlpha(defaultThemeLightAccentAlt, "30")
+	// MouseActionBackgroundColorDark is the fallback dark fill color for mouse action indicators.
+	MouseActionBackgroundColorDark = applyAlpha(defaultThemeDarkAccentAlt, "40")
+	// MouseActionBorderColorLight is the fallback light border color for mouse action indicators.
+	MouseActionBorderColorLight = solidRGBHex(defaultThemeLightAccentAlt)
+	// MouseActionBorderColorDark is the fallback dark border color for mouse action indicators.
+	MouseActionBorderColorDark = solidRGBHex(defaultThemeDarkAccentAlt)
+
 	// StickyModifiersBackgroundColorLight is the fallback light background color for sticky modifiers.
 	StickyModifiersBackgroundColorLight = applyAlpha(defaultThemeLightSurface, "F2")
 	// StickyModifiersBackgroundColorDark is the fallback dark background color for sticky modifiers.
@@ -273,6 +282,13 @@ func (c *Config) ResolveThemeDefaults() {
 	))
 	mergeColorWithDefault(&c.ModeIndicator.UI.BorderColor, solidThemedColor(
 		c.Theme.Light.Accent, c.Theme.Dark.Accent,
+	))
+
+	mergeColorWithDefault(&c.MouseAction.UI.BackgroundColor, themedColor(
+		c.Theme.Light.AccentAlt, c.Theme.Dark.AccentAlt, "30",
+	))
+	mergeColorWithDefault(&c.MouseAction.UI.BorderColor, solidThemedColor(
+		c.Theme.Light.AccentAlt, c.Theme.Dark.AccentAlt,
 	))
 
 	mergeColorWithDefault(&c.StickyModifiers.UI.BackgroundColor, themedColor(

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -780,10 +780,10 @@ func (c *Config) ValidateMouseAction() error {
 		)
 	}
 
-	if c.MouseAction.Animation.DurationMS < 0 {
+	if c.MouseAction.Animation.DurationMS < 1 {
 		return derrors.New(
 			derrors.CodeInvalidConfig,
-			"mouse_action_indicator.animation.duration_ms must be non-negative",
+			"mouse_action_indicator.animation.duration_ms must be >= 1",
 		)
 	}
 

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -752,10 +752,6 @@ func (c *Config) ValidateVirtualPointer() error {
 
 // ValidateMouseAction validates mouse action indicator configuration.
 func (c *Config) ValidateMouseAction() error {
-	if !c.MouseAction.Enabled {
-		return nil
-	}
-
 	err := validateColors([]colorField{
 		{c.MouseAction.UI.BackgroundColor, "mouse_action_indicator.ui.background_color"},
 		{c.MouseAction.UI.BorderColor, "mouse_action_indicator.ui.border_color"},

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -811,6 +811,13 @@ func (c *Config) ValidateMouseAction() error {
 		)
 	}
 
+	if len(c.MouseAction.Actions) == 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"mouse_action_indicator.actions must contain at least one mouse button action",
+		)
+	}
+
 	for index, actionName := range c.MouseAction.Actions {
 		actionType, parseErr := action.ParseType(actionName)
 		if parseErr != nil || !actionType.IsMouseButton() {

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -750,6 +750,89 @@ func (c *Config) ValidateVirtualPointer() error {
 	return nil
 }
 
+// ValidateMouseAction validates mouse action indicator configuration.
+func (c *Config) ValidateMouseAction() error {
+	if !c.MouseAction.Enabled {
+		return nil
+	}
+
+	err := validateColors([]colorField{
+		{c.MouseAction.UI.BackgroundColor, "mouse_action_indicator.ui.background_color"},
+		{c.MouseAction.UI.BorderColor, "mouse_action_indicator.ui.border_color"},
+	})
+	if err != nil {
+		return err
+	}
+
+	if c.MouseAction.UI.Size < 1 {
+		return derrors.New(derrors.CodeInvalidConfig, "mouse_action_indicator.ui.size must be >= 1")
+	}
+
+	if c.MouseAction.UI.BorderWidth < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"mouse_action_indicator.ui.border_width must be >= 0",
+		)
+	}
+
+	switch c.MouseAction.UI.Shape {
+	case "", "circle", "square":
+	default:
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"mouse_action_indicator.ui.shape must be circle or square",
+		)
+	}
+
+	if c.MouseAction.Animation.DurationMS < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"mouse_action_indicator.animation.duration_ms must be non-negative",
+		)
+	}
+
+	if c.MouseAction.Animation.StartScale < 0 || c.MouseAction.Animation.EndScale < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"mouse_action_indicator.animation scales must be non-negative",
+		)
+	}
+
+	if !validOpacity(c.MouseAction.Animation.StartOpacity) ||
+		!validOpacity(c.MouseAction.Animation.EndOpacity) {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"mouse_action_indicator.animation opacity values must be between 0 and 1",
+		)
+	}
+
+	switch c.MouseAction.Animation.Easing {
+	case "", "linear", "ease_in", "ease_out", "ease_in_out":
+	default:
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"mouse_action_indicator.animation.easing must be linear, ease_in, ease_out, or ease_in_out",
+		)
+	}
+
+	for index, actionName := range c.MouseAction.Actions {
+		actionType, parseErr := action.ParseType(actionName)
+		if parseErr != nil || !actionType.IsMouseButton() {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"mouse_action_indicator.actions[%d] must be a mouse button action",
+				index,
+			)
+		}
+	}
+
+	return nil
+}
+
+func validOpacity(value float64) bool {
+	return value >= 0 && value <= 1
+}
+
 func validateHotkeyActionString(actionStr string) error {
 	trimmed := strings.TrimSpace(actionStr)
 	if trimmed == "" {

--- a/internal/config/validators_mouse_action_test.go
+++ b/internal/config/validators_mouse_action_test.go
@@ -1,0 +1,29 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+func TestValidateMouseAction(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.MouseAction.Enabled = true
+	cfg.MouseAction.Actions = []string{"left_click", "mouse_down"}
+
+	err := cfg.ValidateMouseAction()
+	if err != nil {
+		t.Fatalf("ValidateMouseAction() error = %v", err)
+	}
+}
+
+func TestValidateMouseActionRejectsNonMouseButtonAction(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.MouseAction.Enabled = true
+	cfg.MouseAction.Actions = []string{"scroll"}
+
+	err := cfg.ValidateMouseAction()
+	if err == nil {
+		t.Fatal("expected invalid mouse action indicator action to fail")
+	}
+}

--- a/internal/config/validators_mouse_action_test.go
+++ b/internal/config/validators_mouse_action_test.go
@@ -27,3 +27,93 @@ func TestValidateMouseActionRejectsNonMouseButtonAction(t *testing.T) {
 		t.Fatal("expected invalid mouse action indicator action to fail")
 	}
 }
+
+func TestValidateMouseAction_RejectsInvalidFieldsWhenDisabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*config.Config)
+	}{
+		{
+			name: "size too small",
+			setup: func(c *config.Config) {
+				c.MouseAction.Enabled = false
+				c.MouseAction.Actions = []string{"left_click"}
+				c.MouseAction.UI.Size = 0
+			},
+		},
+		{
+			name: "duration too small",
+			setup: func(c *config.Config) {
+				c.MouseAction.Enabled = false
+				c.MouseAction.Actions = []string{"left_click"}
+				c.MouseAction.Animation.DurationMS = 0
+			},
+		},
+		{
+			name: "invalid easing",
+			setup: func(c *config.Config) {
+				c.MouseAction.Enabled = false
+				c.MouseAction.Actions = []string{"left_click"}
+				c.MouseAction.Animation.Easing = "bogus"
+			},
+		},
+		{
+			name: "invalid shape",
+			setup: func(c *config.Config) {
+				c.MouseAction.Enabled = false
+				c.MouseAction.Actions = []string{"left_click"}
+				c.MouseAction.UI.Shape = "hexagon"
+			},
+		},
+		{
+			name: "negative start scale",
+			setup: func(c *config.Config) {
+				c.MouseAction.Enabled = false
+				c.MouseAction.Actions = []string{"left_click"}
+				c.MouseAction.Animation.StartScale = -1
+			},
+		},
+		{
+			name: "invalid opacity",
+			setup: func(c *config.Config) {
+				c.MouseAction.Enabled = false
+				c.MouseAction.Actions = []string{"left_click"}
+				c.MouseAction.Animation.StartOpacity = 1.5
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			tt.setup(cfg)
+
+			err := cfg.ValidateMouseAction()
+			if err == nil {
+				t.Fatal("expected validation to fail for disabled mouse action with invalid config")
+			}
+		})
+	}
+}
+
+func TestValidateMouseAction_RejectsEmptyActions(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.MouseAction.Enabled = true
+	cfg.MouseAction.Actions = []string{}
+
+	err := cfg.ValidateMouseAction()
+	if err == nil {
+		t.Fatal("expected validation to fail for empty actions")
+	}
+}
+
+func TestValidateMouseAction_RejectsEmptyActionsWhenDisabled(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.MouseAction.Enabled = false
+	cfg.MouseAction.Actions = []string{}
+
+	err := cfg.ValidateMouseAction()
+	if err == nil {
+		t.Fatal("expected validation to fail for empty actions even when disabled")
+	}
+}

--- a/internal/core/infra/overlay/adapter.go
+++ b/internal/core/infra/overlay/adapter.go
@@ -2,6 +2,7 @@ package overlay
 
 import (
 	"context"
+	"image"
 
 	"go.uber.org/zap"
 
@@ -129,6 +130,14 @@ func (a *Adapter) DrawModeIndicator(x, y int) {
 // DrawStickyModifiersIndicator draws the sticky modifiers indicator at the specified position.
 func (a *Adapter) DrawStickyModifiersIndicator(x, y int, symbols string) {
 	a.manager.DrawStickyModifiersIndicator(x, y, symbols)
+}
+
+// DrawMouseActionIndicator draws a transient mouse action indicator.
+func (a *Adapter) DrawMouseActionIndicator(
+	point image.Point,
+	style ports.MouseActionIndicatorStyle,
+) {
+	a.manager.DrawMouseActionIndicator(point, style)
 }
 
 // Hide removes all overlays from the screen.

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -114,6 +114,7 @@ typedef struct {
 	double startOpacity;    ///< Initial opacity
 	double endOpacity;      ///< Final opacity
 	char *easing;           ///< linear, ease_in, ease_out, or ease_in_out
+	int hideInScreenShare;  ///< Hide panel from screen sharing (1 = hidden, 0 = visible)
 } MouseActionIndicatorStyle;
 
 /// Callback type for async operations

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -101,6 +101,21 @@ typedef struct {
 	char *fillColor;  ///< Fill color
 } CursorIndicatorStyle;
 
+/// Mouse action indicator style configuration
+typedef struct {
+	int size;               ///< Indicator diameter in points
+	int borderWidth;        ///< Border width in points
+	char *backgroundColor;  ///< Fill color
+	char *borderColor;      ///< Stroke color
+	char *shape;            ///< circle or square
+	int durationMS;         ///< Animation duration in milliseconds
+	double startScale;      ///< Initial transform scale
+	double endScale;        ///< Final transform scale
+	double startOpacity;    ///< Initial opacity
+	double endOpacity;      ///< Final opacity
+	char *easing;           ///< linear, ease_in, ease_out, or ease_in_out
+} MouseActionIndicatorStyle;
+
 /// Callback type for async operations
 /// @param context Context pointer
 typedef void (*ResizeCompletionCallback)(void *context);
@@ -239,5 +254,10 @@ void NeruShowCursorIndicator(OverlayWindow window, CGPoint position, CursorIndic
 /// Hide the virtual cursor indicator
 /// @param window Overlay window handle
 void NeruHideCursorIndicator(OverlayWindow window);
+
+/// Show a transient mouse action indicator in its own overlay window.
+/// @param position Global cursor position in Quartz coordinates
+/// @param style Indicator style
+void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle style);
 
 #endif  // OVERLAY_H

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -2925,10 +2925,10 @@ static NSColor *NeruColorFromHexString(NSString *hexString, NSColor *defaultColo
 		return defaultColor;
 	}
 
-	return [NSColor colorWithCalibratedRed:(CGFloat)red / 255.0
-	                                 green:(CGFloat)green / 255.0
-	                                  blue:(CGFloat)blue / 255.0
-	                                 alpha:(CGFloat)alpha / 255.0];
+	return [NSColor colorWithRed:(CGFloat)red / 255.0
+	                       green:(CGFloat)green / 255.0
+	                        blue:(CGFloat)blue / 255.0
+	                       alpha:(CGFloat)alpha / 255.0];
 }
 
 static CAMediaTimingFunction *NeruTimingFunction(NSString *easing) {

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -2986,7 +2986,8 @@ void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle st
 		}
 		CGFloat size = MAX(style.size, 1);
 		CGFloat endScale = style.endScale > 0 ? style.endScale : 1.0;
-		CGFloat canvasSize = ceil(size * MAX(endScale, 1.0) + MAX(style.borderWidth, 0) * 4.0);
+		CGFloat maxScale = MAX(style.startScale > 0 ? style.startScale : 1.0, MAX(endScale, 1.0));
+		CGFloat canvasSize = ceil(size * maxScale + MAX(style.borderWidth, 0) * 4.0);
 		NSPoint center = NeruAppKitPointFromQuartzPoint(position);
 		NSRect frame = NSMakeRect(center.x - canvasSize / 2.0, center.y - canvasSize / 2.0, canvasSize, canvasSize);
 

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -9,6 +9,7 @@
 
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/QuartzCore.h>
+#import <stdatomic.h>
 
 #pragma mark - HintItem Class
 
@@ -2970,6 +2971,9 @@ static NSPoint NeruAppKitPointFromQuartzPoint(CGPoint point) {
 /// Show a transient mouse action indicator in its own overlay window.
 /// @param position Global cursor position in Quartz coordinates
 /// @param style Indicator style
+static _Atomic int _NeruMouseActionPanelCount = 0;
+static const int _NeruMaxMouseActionPanels = 10;
+
 void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle style) {
 	NSString *backgroundHex = style.backgroundColor ? @(style.backgroundColor) : nil;
 	NSString *borderHex = style.borderColor ? @(style.borderColor) : nil;
@@ -2977,6 +2981,9 @@ void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle st
 	NSString *easing = style.easing ? @(style.easing) : @"ease_out";
 
 	dispatch_async(dispatch_get_main_queue(), ^{
+		if (atomic_load(&_NeruMouseActionPanelCount) >= _NeruMaxMouseActionPanels) {
+			return;
+		}
 		CGFloat size = MAX(style.size, 1);
 		CGFloat endScale = style.endScale > 0 ? style.endScale : 1.0;
 		CGFloat canvasSize = ceil(size * MAX(endScale, 1.0) + MAX(style.borderWidth, 0) * 4.0);
@@ -3000,6 +3007,7 @@ void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle st
 		[panel setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorStationary |
 		                             NSWindowCollectionBehaviorFullScreenAuxiliary |
 		                             NSWindowCollectionBehaviorIgnoresCycle];
+		atomic_fetch_add(&_NeruMouseActionPanelCount, 1);
 
 		NSView *view = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, canvasSize, canvasSize)];
 		view.wantsLayer = YES;
@@ -3046,6 +3054,7 @@ void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle st
 		    dispatch_time(DISPATCH_TIME_NOW, (int64_t)(duration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
 			    [panel orderOut:nil];
 			    [panel close];
+			    atomic_fetch_add(&_NeruMouseActionPanelCount, -1);
 		    });
 	});
 }

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -3004,7 +3004,7 @@ void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle st
 		[panel setIgnoresMouseEvents:YES];
 		[panel setAcceptsMouseMovedEvents:NO];
 		[panel setHasShadow:NO];
-		[panel setSharingType:NSWindowSharingReadOnly];
+		[panel setSharingType:style.hideInScreenShare ? NSWindowSharingNone : NSWindowSharingReadOnly];
 		[panel setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorStationary |
 		                             NSWindowCollectionBehaviorFullScreenAuxiliary |
 		                             NSWindowCollectionBehaviorIgnoresCycle];

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -3031,7 +3031,7 @@ void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle st
 
 		[panel orderFrontRegardless];
 
-		CFTimeInterval duration = MAX(style.durationMS, 0) / 1000.0;
+		CFTimeInterval duration = MAX(style.durationMS, 1) / 1000.0;
 		CAMediaTimingFunction *timing = NeruTimingFunction(easing);
 
 		CABasicAnimation *scaleAnimation = [CABasicAnimation animationWithKeyPath:@"transform.scale"];

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -2894,3 +2894,158 @@ void NeruHideCursorIndicator(OverlayWindow window) {
 		[controller.overlayView setNeedsDisplayInRect:dirtyRect];
 	});
 }
+
+static NSColor *NeruColorFromHexString(NSString *hexString, NSColor *defaultColor) {
+	if (!hexString || hexString.length == 0)
+		return defaultColor;
+
+	NSString *hex =
+	    [hexString stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"#"]];
+	unsigned int alpha = 255;
+	unsigned int red = 255;
+	unsigned int green = 255;
+	unsigned int blue = 255;
+
+	if (hex.length == 8) {
+		[[NSScanner scannerWithString:[hex substringWithRange:NSMakeRange(0, 2)]] scanHexInt:&alpha];
+		[[NSScanner scannerWithString:[hex substringWithRange:NSMakeRange(2, 2)]] scanHexInt:&red];
+		[[NSScanner scannerWithString:[hex substringWithRange:NSMakeRange(4, 2)]] scanHexInt:&green];
+		[[NSScanner scannerWithString:[hex substringWithRange:NSMakeRange(6, 2)]] scanHexInt:&blue];
+	} else if (hex.length == 6) {
+		[[NSScanner scannerWithString:[hex substringWithRange:NSMakeRange(0, 2)]] scanHexInt:&red];
+		[[NSScanner scannerWithString:[hex substringWithRange:NSMakeRange(2, 2)]] scanHexInt:&green];
+		[[NSScanner scannerWithString:[hex substringWithRange:NSMakeRange(4, 2)]] scanHexInt:&blue];
+	} else if (hex.length == 3) {
+		unichar r = [hex characterAtIndex:0];
+		unichar g = [hex characterAtIndex:1];
+		unichar b = [hex characterAtIndex:2];
+		NSString *expanded = [NSString stringWithFormat:@"%C%C%C%C%C%C", r, r, g, g, b, b];
+		return NeruColorFromHexString(expanded, defaultColor);
+	} else {
+		return defaultColor;
+	}
+
+	return [NSColor colorWithCalibratedRed:(CGFloat)red / 255.0
+	                                 green:(CGFloat)green / 255.0
+	                                  blue:(CGFloat)blue / 255.0
+	                                 alpha:(CGFloat)alpha / 255.0];
+}
+
+static CAMediaTimingFunction *NeruTimingFunction(NSString *easing) {
+	if ([easing isEqualToString:@"linear"])
+		return [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
+	if ([easing isEqualToString:@"ease_in"])
+		return [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseIn];
+	if ([easing isEqualToString:@"ease_in_out"])
+		return [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+
+	return [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+}
+
+static NSPoint NeruAppKitPointFromQuartzPoint(CGPoint point) {
+	CGDirectDisplayID displayID = 0;
+	uint32_t displayCount = 0;
+	CGGetDisplaysWithPoint(point, 1, &displayID, &displayCount);
+
+	if (displayCount == 0) {
+		NSRect mainFrame = [NSScreen mainScreen].frame;
+		return NSMakePoint(point.x, NSMaxY(mainFrame) - point.y);
+	}
+
+	CGRect displayBounds = CGDisplayBounds(displayID);
+	for (NSScreen *screen in [NSScreen screens]) {
+		NSNumber *screenNumber = screen.deviceDescription[@"NSScreenNumber"];
+		if (screenNumber.unsignedIntValue != displayID)
+			continue;
+
+		CGFloat localX = point.x - displayBounds.origin.x;
+		CGFloat localY = point.y - displayBounds.origin.y;
+		return NSMakePoint(screen.frame.origin.x + localX, NSMaxY(screen.frame) - localY);
+	}
+
+	NSRect mainFrame = [NSScreen mainScreen].frame;
+	return NSMakePoint(point.x, NSMaxY(mainFrame) - point.y);
+}
+
+/// Show a transient mouse action indicator in its own overlay window.
+/// @param position Global cursor position in Quartz coordinates
+/// @param style Indicator style
+void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle style) {
+	NSString *backgroundHex = style.backgroundColor ? @(style.backgroundColor) : nil;
+	NSString *borderHex = style.borderColor ? @(style.borderColor) : nil;
+	NSString *shape = style.shape ? @(style.shape) : @"circle";
+	NSString *easing = style.easing ? @(style.easing) : @"ease_out";
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		CGFloat size = MAX(style.size, 1);
+		CGFloat endScale = style.endScale > 0 ? style.endScale : 1.0;
+		CGFloat canvasSize = ceil(size * MAX(endScale, 1.0) + MAX(style.borderWidth, 0) * 4.0);
+		NSPoint center = NeruAppKitPointFromQuartzPoint(position);
+		NSRect frame = NSMakeRect(center.x - canvasSize / 2.0, center.y - canvasSize / 2.0, canvasSize, canvasSize);
+
+		NSPanel *panel =
+		    [[NSPanel alloc] initWithContentRect:frame
+		                               styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
+		                                 backing:NSBackingStoreBuffered
+		                                   defer:NO];
+		[panel setHidesOnDeactivate:NO];
+		[panel setReleasedWhenClosed:NO];
+		[panel setLevel:kCGMaximumWindowLevel];
+		[panel setOpaque:NO];
+		[panel setBackgroundColor:[NSColor clearColor]];
+		[panel setIgnoresMouseEvents:YES];
+		[panel setAcceptsMouseMovedEvents:NO];
+		[panel setHasShadow:NO];
+		[panel setSharingType:NSWindowSharingReadOnly];
+		[panel setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorStationary |
+		                             NSWindowCollectionBehaviorFullScreenAuxiliary |
+		                             NSWindowCollectionBehaviorIgnoresCycle];
+
+		NSView *view = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, canvasSize, canvasSize)];
+		view.wantsLayer = YES;
+		view.layer.backgroundColor = NSColor.clearColor.CGColor;
+		[panel setContentView:view];
+
+		CGRect indicatorRect = CGRectMake((canvasSize - size) / 2.0, (canvasSize - size) / 2.0, size, size);
+		CGFloat cornerRadius = [shape isEqualToString:@"square"] ? MAX(size * 0.18, 2.0) : size / 2.0;
+
+		CAShapeLayer *layer = [CAShapeLayer layer];
+		layer.frame = view.bounds;
+		CGPathRef path = CGPathCreateWithRoundedRect(indicatorRect, cornerRadius, cornerRadius, NULL);
+		layer.path = path;
+		CGPathRelease(path);
+		layer.fillColor = NeruColorFromHexString(backgroundHex, [NSColor clearColor]).CGColor;
+		layer.strokeColor = NeruColorFromHexString(borderHex, [NSColor whiteColor]).CGColor;
+		layer.lineWidth = MAX(style.borderWidth, 0);
+		layer.opacity = style.startOpacity;
+		[view.layer addSublayer:layer];
+
+		[panel orderFrontRegardless];
+
+		CFTimeInterval duration = MAX(style.durationMS, 0) / 1000.0;
+		CAMediaTimingFunction *timing = NeruTimingFunction(easing);
+
+		CABasicAnimation *scaleAnimation = [CABasicAnimation animationWithKeyPath:@"transform.scale"];
+		scaleAnimation.fromValue = @(style.startScale);
+		scaleAnimation.toValue = @(style.endScale);
+		scaleAnimation.duration = duration;
+		scaleAnimation.timingFunction = timing;
+
+		CABasicAnimation *opacityAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
+		opacityAnimation.fromValue = @(style.startOpacity);
+		opacityAnimation.toValue = @(style.endOpacity);
+		opacityAnimation.duration = duration;
+		opacityAnimation.timingFunction = timing;
+
+		layer.transform = CATransform3DMakeScale(style.endScale, style.endScale, 1.0);
+		layer.opacity = style.endOpacity;
+		[layer addAnimation:scaleAnimation forKey:@"mouseActionScale"];
+		[layer addAnimation:opacityAnimation forKey:@"mouseActionOpacity"];
+
+		dispatch_after(
+		    dispatch_time(DISPATCH_TIME_NOW, (int64_t)(duration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+			    [panel orderOut:nil];
+			    [panel close];
+		    });
+	});
+}

--- a/internal/core/ports/mocks/overlay.go
+++ b/internal/core/ports/mocks/overlay.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"image"
 
 	"github.com/y3owk1n/neru/internal/core/domain/hint"
 	"github.com/y3owk1n/neru/internal/core/ports"
@@ -16,6 +17,7 @@ type MockOverlayPort struct {
 	DrawModeIndicatorFunc func(x, y int)
 	// DrawStickyModifiersIndicatorFunc mocks DrawStickyModifiersIndicator.
 	DrawStickyModifiersIndicatorFunc func(x, y int, symbols string)
+	DrawMouseActionIndicatorFunc     func(point image.Point, style ports.MouseActionIndicatorStyle)
 	HideFunc                         func(context.Context) error
 	IsVisibleFunc                    func() bool
 	RefreshFunc                      func(context.Context) error
@@ -65,6 +67,16 @@ func (m *MockOverlayPort) DrawModeIndicator(x, y int) {
 func (m *MockOverlayPort) DrawStickyModifiersIndicator(x, y int, symbols string) {
 	if m.DrawStickyModifiersIndicatorFunc != nil {
 		m.DrawStickyModifiersIndicatorFunc(x, y, symbols)
+	}
+}
+
+// DrawMouseActionIndicator implements ports.OverlayPort.
+func (m *MockOverlayPort) DrawMouseActionIndicator(
+	point image.Point,
+	style ports.MouseActionIndicatorStyle,
+) {
+	if m.DrawMouseActionIndicatorFunc != nil {
+		m.DrawMouseActionIndicatorFunc(point, style)
 	}
 }
 

--- a/internal/core/ports/overlay.go
+++ b/internal/core/ports/overlay.go
@@ -2,6 +2,7 @@ package ports
 
 import (
 	"context"
+	"image"
 
 	"github.com/y3owk1n/neru/internal/core/domain/hint"
 )
@@ -39,6 +40,21 @@ type OverlayVisibility interface {
 	Refresh(ctx context.Context) error
 }
 
+// MouseActionIndicatorStyle configures a transient mouse action indicator.
+type MouseActionIndicatorStyle struct {
+	Size            int
+	BorderWidth     int
+	BackgroundColor string
+	BorderColor     string
+	Shape           string
+	DurationMS      int
+	StartScale      float64
+	EndScale        float64
+	StartOpacity    float64
+	EndOpacity      float64
+	Easing          string
+}
+
 // OverlayPort defines the interface for managing UI overlays.
 // Implementations handle the platform-specific rendering of hints and grids.
 type OverlayPort interface {
@@ -58,6 +74,9 @@ type OverlayPort interface {
 
 	// DrawStickyModifiersIndicator draws the sticky modifiers indicator at the specified position.
 	DrawStickyModifiersIndicator(x, y int, symbols string)
+
+	// DrawMouseActionIndicator draws a transient indicator for a mouse action.
+	DrawMouseActionIndicator(point image.Point, style MouseActionIndicatorStyle)
 
 	// Hide hides the overlay.s from the screen.
 	Hide(ctx context.Context) error

--- a/internal/core/ports/overlay.go
+++ b/internal/core/ports/overlay.go
@@ -42,17 +42,18 @@ type OverlayVisibility interface {
 
 // MouseActionIndicatorStyle configures a transient mouse action indicator.
 type MouseActionIndicatorStyle struct {
-	Size            int
-	BorderWidth     int
-	BackgroundColor string
-	BorderColor     string
-	Shape           string
-	DurationMS      int
-	StartScale      float64
-	EndScale        float64
-	StartOpacity    float64
-	EndOpacity      float64
-	Easing          string
+	Size              int
+	BorderWidth       int
+	BackgroundColor   string
+	BorderColor       string
+	Shape             string
+	DurationMS        int
+	StartScale        float64
+	EndScale          float64
+	StartOpacity      float64
+	EndOpacity        float64
+	Easing            string
+	HideInScreenShare bool
 }
 
 // OverlayPort defines the interface for managing UI overlays.

--- a/internal/ui/overlay/manager_darwin.go
+++ b/internal/ui/overlay/manager_darwin.go
@@ -5,6 +5,7 @@ package overlay
 /*
 #cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../../core/infra/platform/darwin/overlay.h"
+#include <stdlib.h>
 */
 import "C"
 
@@ -369,6 +370,39 @@ func (m *Manager) DrawStickyModifiersIndicator(xCoordinate, yCoordinate int, sym
 	}
 
 	m.stickyModifiersOverlay.Draw(xCoordinate, yCoordinate, symbols)
+}
+
+// DrawMouseActionIndicator renders a transient mouse action indicator in its own native window.
+func (m *Manager) DrawMouseActionIndicator(
+	point image.Point,
+	style ports.MouseActionIndicatorStyle,
+) {
+	backgroundColor := C.CString(style.BackgroundColor)
+	borderColor := C.CString(style.BorderColor)
+	shape := C.CString(style.Shape)
+	easing := C.CString(style.Easing)
+
+	defer C.free(unsafe.Pointer(backgroundColor)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(borderColor))     //nolint:nlreturn
+	defer C.free(unsafe.Pointer(shape))           //nolint:nlreturn
+	defer C.free(unsafe.Pointer(easing))          //nolint:nlreturn
+
+	C.NeruShowMouseActionIndicator(
+		C.CGPoint{x: C.double(point.X), y: C.double(point.Y)},
+		C.MouseActionIndicatorStyle{
+			size:            C.int(style.Size),
+			borderWidth:     C.int(style.BorderWidth),
+			backgroundColor: backgroundColor,
+			borderColor:     borderColor,
+			shape:           shape,
+			durationMS:      C.int(style.DurationMS),
+			startScale:      C.double(style.StartScale),
+			endScale:        C.double(style.EndScale),
+			startOpacity:    C.double(style.StartOpacity),
+			endOpacity:      C.double(style.EndOpacity),
+			easing:          easing,
+		},
+	)
 }
 
 // DrawGrid renders a grid with the specified style using the grid overlay renderer.

--- a/internal/ui/overlay/manager_darwin.go
+++ b/internal/ui/overlay/manager_darwin.go
@@ -36,14 +36,23 @@ const (
 	NSWindowSharingReadOnly = 1
 )
 
+func boolToInt(v bool) int {
+	if v {
+		return 1
+	}
+
+	return 0
+}
+
 // Manager manages multiple overlay windows.
 type Manager struct {
-	window C.OverlayWindow
-	logger *zap.Logger
-	mu     sync.RWMutex
-	mode   Mode
-	subs   map[uint64]func(StateChange)
-	nextID uint64
+	window            C.OverlayWindow
+	logger            *zap.Logger
+	mu                sync.RWMutex
+	mode              Mode
+	subs              map[uint64]func(StateChange)
+	nextID            uint64
+	hideInScreenShare bool
 
 	// Overlay renderers
 	hintOverlay            *hints.Overlay
@@ -377,6 +386,10 @@ func (m *Manager) DrawMouseActionIndicator(
 	point image.Point,
 	style ports.MouseActionIndicatorStyle,
 ) {
+	m.mu.RLock()
+	hideInScreenShare := m.hideInScreenShare
+	m.mu.RUnlock()
+
 	backgroundColor := C.CString(style.BackgroundColor)
 	borderColor := C.CString(style.BorderColor)
 	shape := C.CString(style.Shape)
@@ -390,17 +403,18 @@ func (m *Manager) DrawMouseActionIndicator(
 	C.NeruShowMouseActionIndicator(
 		C.CGPoint{x: C.double(point.X), y: C.double(point.Y)},
 		C.MouseActionIndicatorStyle{
-			size:            C.int(style.Size),
-			borderWidth:     C.int(style.BorderWidth),
-			backgroundColor: backgroundColor,
-			borderColor:     borderColor,
-			shape:           shape,
-			durationMS:      C.int(style.DurationMS),
-			startScale:      C.double(style.StartScale),
-			endScale:        C.double(style.EndScale),
-			startOpacity:    C.double(style.StartOpacity),
-			endOpacity:      C.double(style.EndOpacity),
-			easing:          easing,
+			size:              C.int(style.Size),
+			borderWidth:       C.int(style.BorderWidth),
+			backgroundColor:   backgroundColor,
+			borderColor:       borderColor,
+			shape:             shape,
+			durationMS:        C.int(style.DurationMS),
+			startScale:        C.double(style.StartScale),
+			endScale:          C.double(style.EndScale),
+			startOpacity:      C.double(style.StartOpacity),
+			endOpacity:        C.double(style.EndOpacity),
+			easing:            easing,
+			hideInScreenShare: C.int(boolToInt(style.HideInScreenShare || hideInScreenShare)),
 		},
 	)
 }
@@ -492,6 +506,8 @@ func (m *Manager) SetHideUnmatched(hide bool) {
 func (m *Manager) SetSharingType(hide bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	m.hideInScreenShare = hide
 
 	sharingType := C.int(NSWindowSharingReadOnly)
 	if hide {

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -617,36 +617,6 @@ func (m *Manager) SetHideUnmatched(hide bool) {
 // SetSharingType is a no-op on Linux.
 func (m *Manager) SetSharingType(_ bool) {}
 
-func (m *Manager) clearStickyBadgeLocked() {
-	if !m.stickyBadgeVisible {
-		return
-	}
-
-	if m.x11 != nil {
-		m.x11.ClearRect(m.stickyBadgeRect)
-	} else if m.wlroots != nil {
-		m.wlroots.ClearRect(m.stickyBadgeRect)
-	}
-
-	m.stickyBadgeVisible = false
-	m.stickyBadgeRect = image.Rectangle{}
-}
-
-func (m *Manager) publish(change StateChange) {
-	m.mu.RLock()
-
-	subs := make([]func(StateChange), 0, len(m.subs))
-	for _, fn := range m.subs {
-		subs = append(subs, fn)
-	}
-
-	m.mu.RUnlock()
-
-	for _, fn := range subs {
-		fn(change)
-	}
-}
-
 // detectLinuxOverlayBackend delegates to the canonical
 // platform.DetectLinuxBackend so that compositor-family detection (GNOME, KDE,
 // wlroots, etc.) is consistent across all layers.
@@ -682,6 +652,36 @@ type overlayBadgeStyle struct {
 
 // DrawMouseActionIndicator is a macOS-only renderer; Linux currently stubs it.
 func (m *Manager) DrawMouseActionIndicator(_ image.Point, _ ports.MouseActionIndicatorStyle) {}
+
+func (m *Manager) clearStickyBadgeLocked() {
+	if !m.stickyBadgeVisible {
+		return
+	}
+
+	if m.x11 != nil {
+		m.x11.ClearRect(m.stickyBadgeRect)
+	} else if m.wlroots != nil {
+		m.wlroots.ClearRect(m.stickyBadgeRect)
+	}
+
+	m.stickyBadgeVisible = false
+	m.stickyBadgeRect = image.Rectangle{}
+}
+
+func (m *Manager) publish(change StateChange) {
+	m.mu.RLock()
+
+	subs := make([]func(StateChange), 0, len(m.subs))
+	for _, fn := range m.subs {
+		subs = append(subs, fn)
+	}
+
+	m.mu.RUnlock()
+
+	for _, fn := range subs {
+		fn(change)
+	}
+}
 
 func resolveModeIndicatorAppearance(
 	mode string,

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -680,6 +680,9 @@ type overlayBadgeStyle struct {
 	offsetY     int
 }
 
+// DrawMouseActionIndicator is a macOS-only renderer; Linux currently stubs it.
+func (m *Manager) DrawMouseActionIndicator(_ image.Point, _ ports.MouseActionIndicatorStyle) {}
+
 func resolveModeIndicatorAppearance(
 	mode string,
 	overlay *modeindicator.Overlay,

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -135,6 +135,9 @@ func (m *Manager) DrawModeIndicator(_, _ int) {}
 // DrawStickyModifiersIndicator draws the sticky modifiers indicator (Windows stub).
 func (m *Manager) DrawStickyModifiersIndicator(_, _ int, _ string) {}
 
+// DrawMouseActionIndicator draws a mouse action indicator (Windows stub).
+func (m *Manager) DrawMouseActionIndicator(_ image.Point, _ ports.MouseActionIndicatorStyle) {}
+
 // DrawGrid draws the grid (Windows stub).
 func (m *Manager) DrawGrid(_ *domainGrid.Grid, _ string, _ grid.Style) error {
 	return derrors.New(derrors.CodeNotSupported, "overlay grid not implemented on windows")

--- a/internal/ui/overlay/types.go
+++ b/internal/ui/overlay/types.go
@@ -142,6 +142,13 @@ func (n *NoOpManager) DrawModeIndicator(x, y int) {}
 // DrawStickyModifiersIndicator is a no-op implementation.
 func (n *NoOpManager) DrawStickyModifiersIndicator(x, y int, symbols string) {}
 
+// DrawMouseActionIndicator is a no-op implementation.
+func (n *NoOpManager) DrawMouseActionIndicator(
+	point image.Point,
+	style ports.MouseActionIndicatorStyle,
+) {
+}
+
 // DrawGrid is a no-op implementation.
 func (n *NoOpManager) DrawGrid(
 	g *domainGrid.Grid,
@@ -228,6 +235,7 @@ type ManagerInterface interface {
 	HideHintSearchInput()
 	DrawModeIndicator(x, y int)
 	DrawStickyModifiersIndicator(x, y int, symbols string)
+	DrawMouseActionIndicator(point image.Point, style ports.MouseActionIndicatorStyle)
 	DrawGrid(g *domainGrid.Grid, input string, style grid.Style) error
 	DrawRecursiveGrid(
 		bounds image.Rectangle,


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a configurable, opt-in mouse action indicator for click-style actions (`left_click`, `right_click`, `middle_click`, `mouse_down`, `mouse_up`). Linux and Windows paths are stubbed/no-op.

```toml
[mouse_action_indicator]
enabled = false
actions = ["left_click", "right_click", "middle_click", "mouse_down", "mouse_up"]

[mouse_action_indicator.ui]
size = 36
border_width = 2
background_color = "#5B8CFFFF"
border_color = "#5B8CFF"
shape = "circle"

[mouse_action_indicator.animation]
duration_ms = 260
start_scale = 0.55
end_scale = 1.35
start_opacity = 0.85
end_opacity = 0.0
easing = "ease_out"
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/97490685-2062-491c-be28-0d252e5b01e7

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
