### PR TITLE
fix(hints): add capability to search text on subtree

### DIFF
--- a/internal/core/domain/element/element.go
+++ b/internal/core/domain/element/element.go
@@ -40,6 +40,7 @@ type Element struct {
 	title       string
 	description string
 	value       string
+	searchText  string
 }
 
 // NewElement creates a new element with validation.
@@ -97,6 +98,13 @@ func WithValue(val string) Option {
 	}
 }
 
+// WithSearchText sets additional searchable text associated with the element.
+func WithSearchText(text string) Option {
+	return func(e *Element) {
+		e.searchText = text
+	}
+}
+
 // ID returns the element ID.
 func (e *Element) ID() ID {
 	return e.id
@@ -130,6 +138,11 @@ func (e *Element) Description() string {
 // Value returns the element value.
 func (e *Element) Value() string {
 	return e.value
+}
+
+// SearchText returns additional searchable text associated with the element.
+func (e *Element) SearchText() string {
+	return e.searchText
 }
 
 // Center returns the center point of the element.

--- a/internal/core/domain/hint/hint.go
+++ b/internal/core/domain/hint/hint.go
@@ -288,7 +288,8 @@ func (c *Collection) FilterByText(query string) *Collection {
 
 		if strings.Contains(normalizeForSearch(elem.Title()), normalizedQuery) ||
 			strings.Contains(normalizeForSearch(elem.Description()), normalizedQuery) ||
-			strings.Contains(normalizeForSearch(elem.Value()), normalizedQuery) {
+			strings.Contains(normalizeForSearch(elem.Value()), normalizedQuery) ||
+			strings.Contains(normalizeForSearch(elem.SearchText()), normalizedQuery) {
 			filtered = append(filtered, hint)
 		}
 	}

--- a/internal/core/domain/hint/hint_test.go
+++ b/internal/core/domain/hint/hint_test.go
@@ -192,6 +192,22 @@ func TestCollection_FilterByText_Normalizes(t *testing.T) {
 	}
 }
 
+func TestCollection_FilterByText_SearchesAdditionalText(t *testing.T) {
+	rowElem, _ := element.NewElement(
+		"note-row",
+		image.Rect(10, 10, 100, 50),
+		element.Role("AXRow"),
+		element.WithSearchText("Quarterly planning notes"),
+	)
+	rowHint, _ := hint.NewHint("AA", rowElem, image.Point{X: 30, Y: 30})
+
+	collection := hint.NewCollection([]*hint.Interface{rowHint})
+
+	if got := collection.FilterByText("planning").Count(); got != 1 {
+		t.Fatalf("FilterByText(%q) = %d, want 1", "planning", got)
+	}
+}
+
 func TestAlphabetGenerator_Generate(t *testing.T) {
 	generator, generatorErr := hint.NewAlphabetGenerator("asdf")
 	if generatorErr != nil {

--- a/internal/core/infra/accessibility/adapter_conversion.go
+++ b/internal/core/infra/accessibility/adapter_conversion.go
@@ -23,6 +23,11 @@ func (a *Adapter) convertToDomainElement(node AXNode) (*element.Element, error) 
 	// Determine if clickable
 	isClickable := node.IsClickable()
 
+	searchText := ""
+	if provider, ok := node.(interface{ SearchText() string }); ok {
+		searchText = provider.SearchText()
+	}
+
 	// Create element with options
 	domElement, elementErr := element.NewElement(
 		elementID,
@@ -32,6 +37,7 @@ func (a *Adapter) convertToDomainElement(node AXNode) (*element.Element, error) 
 		element.WithTitle(node.Title()),
 		element.WithDescription(node.Description()),
 		element.WithValue(node.Value()),
+		element.WithSearchText(searchText),
 	)
 	if elementErr != nil {
 		return nil, derrors.Wrap(

--- a/internal/core/infra/accessibility/adapter_filtering.go
+++ b/internal/core/infra/accessibility/adapter_filtering.go
@@ -10,32 +10,32 @@ import (
 
 // MatchesFilter checks if an element matches the given filter criteria.
 func (a *Adapter) MatchesFilter(
-	element *element.Element,
+	elem *element.Element,
 	filter ports.ElementFilter,
 ) bool {
 	// Check minimum size
-	bounds := element.Bounds()
+	bounds := elem.Bounds()
 	if bounds.Dx() < filter.MinSize.X || bounds.Dy() < filter.MinSize.Y {
 		return false
 	}
 
 	// Check role inclusion
 	if len(filter.Roles) > 0 {
-		found := slices.Contains(filter.Roles, element.Role())
+		found := slices.Contains(filter.Roles, elem.Role())
 		if !found {
 			return false
 		}
 	}
 
 	// Check role exclusion
-	if slices.Contains(filter.ExcludeRoles, element.Role()) {
+	if slices.Contains(filter.ExcludeRoles, elem.Role()) {
 		return false
 	}
 
 	// Check title contains filter
 	titleMatched := false
 	if filter.TitleContains != "" {
-		title := element.Title()
+		title := elem.Title()
 		if title != "" &&
 			strings.Contains(strings.ToLower(title), strings.ToLower(filter.TitleContains)) {
 			titleMatched = true
@@ -45,7 +45,7 @@ func (a *Adapter) MatchesFilter(
 	// Check description contains filter
 	descMatched := false
 	if filter.DescriptionContains != "" {
-		description := element.Description()
+		description := elem.Description()
 		if description != "" &&
 			strings.Contains(
 				strings.ToLower(description),
@@ -58,7 +58,7 @@ func (a *Adapter) MatchesFilter(
 	// Check value contains filter
 	valueMatched := false
 	if filter.ValueContains != "" {
-		value := element.Value()
+		value := textForFilter(elem)
 		if value != "" &&
 			strings.Contains(strings.ToLower(value), strings.ToLower(filter.ValueContains)) {
 			valueMatched = true
@@ -68,10 +68,10 @@ func (a *Adapter) MatchesFilter(
 	// Check any of the additional text substrings match (OR logic)
 	textListMatched := false
 	if len(filter.TextContainsList) > 0 {
-		title := element.Title()
-		description := element.Description()
+		title := elem.Title()
+		description := elem.Description()
 
-		value := element.Value()
+		value := textForFilter(elem)
 		for _, text := range filter.TextContainsList {
 			if text == "" {
 				continue
@@ -97,4 +97,19 @@ func (a *Adapter) MatchesFilter(
 	}
 
 	return true
+}
+
+func textForFilter(elem *element.Element) string {
+	value := elem.Value()
+
+	searchText := elem.SearchText()
+	if searchText == "" {
+		return value
+	}
+
+	if value == "" {
+		return searchText
+	}
+
+	return value + " " + searchText
 }

--- a/internal/core/infra/accessibility/adapter_test.go
+++ b/internal/core/infra/accessibility/adapter_test.go
@@ -239,11 +239,30 @@ func TestAdapter_MatchesFilter(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "match by extra search text",
+			filter: ports.ElementFilter{
+				ValueContains: "notes",
+			},
+			want: true,
+		},
 	}
+
+	elemWithSearchText, _ := element.NewElement(
+		element.ID("test-id-with-search-text"),
+		image.Rect(0, 0, 100, 100),
+		element.RoleButton,
+		element.WithSearchText("Apple Notes row"),
+	)
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			got := adapter.MatchesFilter(elem, testCase.filter)
+			testElem := elem
+			if testCase.name == "match by extra search text" {
+				testElem = elemWithSearchText
+			}
+
+			got := adapter.MatchesFilter(testElem, testCase.filter)
 			if got != testCase.want {
 				t.Errorf("matchesFilter() = %v, want %v", got, testCase.want)
 			}

--- a/internal/core/infra/accessibility/adapter_test.go
+++ b/internal/core/infra/accessibility/adapter_test.go
@@ -213,41 +213,6 @@ func TestAdapter_MatchesFilter(t *testing.T) {
 		element.RoleButton,
 	)
 
-	tests := []struct {
-		name   string
-		filter ports.ElementFilter
-		want   bool
-	}{
-		{
-			name: "match by role",
-			filter: ports.ElementFilter{
-				Roles: []element.Role{element.RoleButton},
-			},
-			want: true,
-		},
-		{
-			name: "no match by role",
-			filter: ports.ElementFilter{
-				Roles: []element.Role{element.RoleLink},
-			},
-			want: false,
-		},
-		{
-			name: "match by min size",
-			filter: ports.ElementFilter{
-				MinSize: image.Point{X: 50, Y: 50},
-			},
-			want: true,
-		},
-		{
-			name: "match by extra search text",
-			filter: ports.ElementFilter{
-				ValueContains: "notes",
-			},
-			want: true,
-		},
-	}
-
 	elemWithSearchText, _ := element.NewElement(
 		element.ID("test-id-with-search-text"),
 		image.Rect(0, 0, 100, 100),
@@ -255,14 +220,49 @@ func TestAdapter_MatchesFilter(t *testing.T) {
 		element.WithSearchText("Apple Notes row"),
 	)
 
+	tests := []struct {
+		name   string
+		elem   *element.Element
+		filter ports.ElementFilter
+		want   bool
+	}{
+		{
+			name: "match by role",
+			elem: elem,
+			filter: ports.ElementFilter{
+				Roles: []element.Role{element.RoleButton},
+			},
+			want: true,
+		},
+		{
+			name: "no match by role",
+			elem: elem,
+			filter: ports.ElementFilter{
+				Roles: []element.Role{element.RoleLink},
+			},
+			want: false,
+		},
+		{
+			name: "match by min size",
+			elem: elem,
+			filter: ports.ElementFilter{
+				MinSize: image.Point{X: 50, Y: 50},
+			},
+			want: true,
+		},
+		{
+			name: "match by extra search text",
+			elem: elemWithSearchText,
+			filter: ports.ElementFilter{
+				ValueContains: "notes",
+			},
+			want: true,
+		},
+	}
+
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			testElem := elem
-			if testCase.name == "match by extra search text" {
-				testElem = elemWithSearchText
-			}
-
-			got := adapter.MatchesFilter(testElem, testCase.filter)
+			got := adapter.MatchesFilter(testCase.elem, testCase.filter)
 			if got != testCase.want {
 				t.Errorf("matchesFilter() = %v, want %v", got, testCase.want)
 			}

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -99,6 +99,7 @@ type ElementInfo struct {
 	title           string
 	description     string
 	value           string
+	searchText      string
 	role            string
 	roleDescription string
 	isEnabled       bool
@@ -129,6 +130,11 @@ func (ei *ElementInfo) Description() string {
 // Value returns the element value.
 func (ei *ElementInfo) Value() string {
 	return ei.value
+}
+
+// SearchText returns extra searchable text collected from descendant elements.
+func (ei *ElementInfo) SearchText() string {
+	return ei.searchText
 }
 
 // Role returns the element role.

--- a/internal/core/infra/accessibility/element_linux.go
+++ b/internal/core/infra/accessibility/element_linux.go
@@ -41,6 +41,7 @@ type ElementInfo struct {
 	title           string
 	description     string
 	value           string
+	searchText      string
 	role            string
 	roleDescription string
 	isEnabled       bool
@@ -62,6 +63,9 @@ func (ei *ElementInfo) Description() string { return ei.description }
 
 // Value returns the element value.
 func (ei *ElementInfo) Value() string { return ei.value }
+
+// SearchText returns extra searchable text collected from descendant elements.
+func (ei *ElementInfo) SearchText() string { return ei.searchText }
 
 // Role returns the element role.
 func (ei *ElementInfo) Role() string { return ei.role }

--- a/internal/core/infra/accessibility/element_windows.go
+++ b/internal/core/infra/accessibility/element_windows.go
@@ -60,6 +60,7 @@ type ElementInfo struct {
 	title           string
 	description     string
 	value           string
+	searchText      string
 	role            string
 	roleDescription string
 	isEnabled       bool
@@ -81,6 +82,9 @@ func (ei *ElementInfo) Description() string { return ei.description }
 
 // Value returns the element value.
 func (ei *ElementInfo) Value() string { return ei.value }
+
+// SearchText returns extra searchable text collected from descendant elements.
+func (ei *ElementInfo) SearchText() string { return ei.searchText }
 
 // Role returns the element role.
 func (ei *ElementInfo) Role() string { return ei.role }

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -155,6 +155,7 @@ func (c *InfraAXClient) ClickableNodes(
 	for i, node := range clickableNodes {
 		clickableNodesResult[i] = &InfraNode{
 			node:           node,
+			clickable:      true,
 			cache:          c.cache,
 			configProvider: c.configProvider,
 		}
@@ -195,6 +196,7 @@ func (c *InfraAXClient) MenuBarClickableElements(
 	for index, node := range nodes {
 		nodesResult[index] = &InfraNode{
 			node:           node,
+			clickable:      true,
 			cache:          c.cache,
 			configProvider: c.configProvider,
 		}
@@ -229,6 +231,7 @@ func (c *InfraAXClient) ClickableElementsFromBundleID(
 	for index, node := range nodes {
 		nodesResult[index] = &InfraNode{
 			node:           node,
+			clickable:      true,
 			cache:          c.cache,
 			configProvider: c.configProvider,
 		}
@@ -402,6 +405,7 @@ func (a *InfraApp) Info() (*AXAppInfo, error) {
 // InfraNode wraps an TreeNode.
 type InfraNode struct {
 	node           *TreeNode
+	clickable      bool
 	cache          *InfoCache
 	configProvider config.Provider
 }
@@ -469,8 +473,21 @@ func (n *InfraNode) Value() string {
 	return n.node.Info().Value()
 }
 
+// SearchText returns additional text collected from the node subtree.
+func (n *InfraNode) SearchText() string {
+	if n.node == nil || n.node.Info() == nil {
+		return ""
+	}
+
+	return n.node.Info().SearchText()
+}
+
 // IsClickable returns true if the node is clickable.
 func (n *InfraNode) IsClickable() bool {
+	if n.clickable {
+		return true
+	}
+
 	if n.node == nil || n.node.Element() == nil {
 		return false
 	}

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -196,6 +196,8 @@ type MockNode struct {
 	MockRole        string
 	MockTitle       string
 	MockDescription string
+	MockValue       string
+	MockSearchText  string
 	MockClickable   bool
 }
 
@@ -222,6 +224,16 @@ func (n *MockNode) Title() string {
 // Description returns the configured description.
 func (n *MockNode) Description() string {
 	return n.MockDescription
+}
+
+// Value returns the configured value.
+func (n *MockNode) Value() string {
+	return n.MockValue
+}
+
+// SearchText returns the configured search text.
+func (n *MockNode) SearchText() string {
+	return n.MockSearchText
 }
 
 // IsClickable returns the configured clickable state.

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -189,6 +189,8 @@ func (a *MockApp) Info() (*AXAppInfo, error) {
 	return a.MockInfo, nil
 }
 
+var _ AXNode = (*MockNode)(nil)
+
 // MockNode is a mock implementation of AXNode.
 type MockNode struct {
 	MockID          string

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -728,7 +728,7 @@ func (n *TreeNode) collectSearchText() string {
 	var builder strings.Builder
 	seen := make(map[string]struct{})
 
-	n.walkTree(func(node *TreeNode) bool {
+	n.walkTreeDescendants(func(node *TreeNode) bool {
 		if node == nil || node.info == nil {
 			return true
 		}
@@ -749,6 +749,15 @@ func (n *TreeNode) walkTree(visit func(*TreeNode) bool) {
 		return
 	}
 
+	for _, child := range n.children {
+		child.walkTree(visit)
+	}
+}
+
+// walkTreeDescendants walks only the descendants (children and their subtrees),
+// excluding the root node itself. Used for collecting text from child elements
+// without including the root's own text fields.
+func (n *TreeNode) walkTreeDescendants(visit func(*TreeNode) bool) {
 	for _, child := range n.children {
 		child.walkTree(visit)
 	}

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -12,6 +12,7 @@ import "C"
 
 import (
 	"image"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -654,6 +655,7 @@ func (n *TreeNode) FindClickableElements(
 	var result []*TreeNode
 	n.walkTree(func(node *TreeNode) bool {
 		if node.element.IsClickable(node.info, allowedRoles, cache, configProvider) {
+			node.info.searchText = node.collectSearchText()
 			result = append(result, node)
 		}
 
@@ -661,6 +663,22 @@ func (n *TreeNode) FindClickableElements(
 	})
 
 	return result
+}
+
+func appendSearchText(builder *strings.Builder, seen map[string]struct{}, text string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	if _, ok := seen[text]; ok {
+		return
+	}
+
+	if builder.Len() > 0 {
+		builder.WriteByte(' ')
+	}
+	builder.WriteString(text)
+	seen[text] = struct{}{}
 }
 
 // Release releases the AXUIElementRef for every node in the subtree except
@@ -704,6 +722,25 @@ func (n *TreeNode) Release(keep map[*Element]struct{}) {
 
 		putTreeNode(node)
 	})
+}
+
+func (n *TreeNode) collectSearchText() string {
+	var builder strings.Builder
+	seen := make(map[string]struct{})
+
+	n.walkTree(func(node *TreeNode) bool {
+		if node == nil || node.info == nil {
+			return true
+		}
+
+		appendSearchText(&builder, seen, node.info.Title())
+		appendSearchText(&builder, seen, node.info.Description())
+		appendSearchText(&builder, seen, node.info.Value())
+
+		return true
+	})
+
+	return builder.String()
 }
 
 // walkTree walks the tree in pre-order and calls the visitor function for each node.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a `searchText` field to elements that enables searching by text collected from descendant nodes.

This allows us to search for elements where the text is in it's child element, say table row cells. This issue is very common on macOS native apps.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
