### PR TITLE
feat(hints): add boundary highlights for targeted elements

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -121,7 +121,7 @@ width = 320                                 # Search input width in pixels
 [hints.boundary_highlight]
 enabled = false                             # Draw a subtle outline around each target element
 border_width = 1
-border_radius = 4
+border_radius = -1                          # -1 = auto pill
 
 # Grid mode
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#grid-mode

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -118,6 +118,11 @@ x_offset = 0                                # Offset from the selected position 
 y_offset = 24                               # Offset from the selected position on the active screen
 width = 320                                 # Search input width in pixels
 
+[hints.boundary_highlight]
+enabled = false                             # Draw a subtle outline around each target element
+border_width = 1
+border_radius = 4
+
 # Grid mode
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#grid-mode
 [grid]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -417,6 +417,24 @@ matched_text_color = "#0B2377"
 border_color = "#0B2377"
 ```
 
+Optional target boundary highlights can make dense or ambiguous hint layouts
+easier to read. They are off by default to keep hints mode quiet.
+
+| Option             | Type  | Default | Description                         |
+| ------------------ | ----- | ------- | ----------------------------------- |
+| `enabled`          | bool  | `false` | Draw target element boundaries      |
+| `border_width`     | int   | `1`     | Boundary stroke width in pixels     |
+| `border_radius`    | int   | `4`     | Boundary corner radius              |
+| `background_color` | color | derived | Very subtle target fill color       |
+| `border_color`     | color | derived | Target boundary stroke color        |
+
+```toml
+[hints.boundary_highlight]
+enabled = false
+border_width = 1
+border_radius = 4
+```
+
 The search input uses `[hints.search_input_ui]` with the same visual options as
 `[hints.ui]`, except `matched_text_color`. It also supports active-screen
 placement:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -420,19 +420,19 @@ border_color = "#0B2377"
 Optional target boundary highlights can make dense or ambiguous hint layouts
 easier to read. They are off by default to keep hints mode quiet.
 
-| Option             | Type  | Default | Description                         |
-| ------------------ | ----- | ------- | ----------------------------------- |
-| `enabled`          | bool  | `false` | Draw target element boundaries      |
-| `border_width`     | int   | `1`     | Boundary stroke width in pixels     |
-| `border_radius`    | int   | `4`     | Boundary corner radius              |
-| `background_color` | color | derived | Very subtle target fill color       |
-| `border_color`     | color | derived | Target boundary stroke color        |
+| Option             | Type  | Default | Description                              |
+| ------------------ | ----- | ------- | ---------------------------------------- |
+| `enabled`          | bool  | `false` | Draw target element boundaries          |
+| `border_width`     | int   | `1`     | Boundary stroke width in pixels         |
+| `border_radius`    | int   | `-1`    | Boundary corner radius (-1 = auto pill) |
+| `background_color` | color | derived | Very subtle target fill color           |
+| `border_color`     | color | derived | Target boundary stroke color            |
 
 ```toml
 [hints.boundary_highlight]
 enabled = false
 border_width = 1
-border_radius = 4
+border_radius = -1
 ```
 
 The search input uses `[hints.search_input_ui]` with the same visual options as

--- a/internal/app/components/hints/overlay_darwin.go
+++ b/internal/app/components/hints/overlay_darwin.go
@@ -40,6 +40,14 @@ var (
 	hintPoolOnce sync.Once
 )
 
+func boolToInt(v bool) int {
+	if v {
+		return 1
+	}
+
+	return 0
+}
+
 // Overlay manages the rendering of hint overlays using native platform APIs.
 type Overlay struct {
 	window C.OverlayWindow
@@ -72,16 +80,21 @@ type Overlay struct {
 
 // StyleMode represents the visual styling configuration for hint overlays.
 type StyleMode struct {
-	fontSize         int
-	fontFamily       string
-	borderRadius     int
-	paddingX         int
-	paddingY         int
-	borderWidth      int
-	backgroundColor  string
-	textColor        string
-	matchedTextColor string
-	borderColor      string
+	fontSize                 int
+	fontFamily               string
+	borderRadius             int
+	paddingX                 int
+	paddingY                 int
+	borderWidth              int
+	backgroundColor          string
+	textColor                string
+	matchedTextColor         string
+	borderColor              string
+	boundaryHighlightEnabled bool
+	boundaryBorderWidth      int
+	boundaryBorderRadius     int
+	boundaryBackgroundColor  string
+	boundaryBorderColor      string
 }
 
 // FontSize returns the font size.
@@ -133,6 +146,21 @@ func (s StyleMode) MatchedTextColor() string {
 func (s StyleMode) BorderColor() string {
 	return s.borderColor
 }
+
+// BoundaryHighlightEnabled returns whether target boundaries are drawn behind hints.
+func (s StyleMode) BoundaryHighlightEnabled() bool { return s.boundaryHighlightEnabled }
+
+// BoundaryBorderWidth returns the target boundary stroke width.
+func (s StyleMode) BoundaryBorderWidth() int { return s.boundaryBorderWidth }
+
+// BoundaryBorderRadius returns the target boundary corner radius.
+func (s StyleMode) BoundaryBorderRadius() int { return s.boundaryBorderRadius }
+
+// BoundaryBackgroundColor returns the target boundary fill color.
+func (s StyleMode) BoundaryBackgroundColor() string { return s.boundaryBackgroundColor }
+
+// BoundaryBorderColor returns the target boundary stroke color.
+func (s StyleMode) BoundaryBorderColor() string { return s.boundaryBorderColor }
 
 // initPools initializes the object pools once.
 func initPools() {
@@ -329,6 +357,19 @@ func BuildStyle(cfg config.HintsConfig, theme config.ThemeProvider) StyleMode {
 			config.HintsBorderColorLight,
 			config.HintsBorderColorDark,
 		),
+		boundaryHighlightEnabled: cfg.BoundaryHighlight.Enabled,
+		boundaryBorderWidth:      cfg.BoundaryHighlight.BorderWidth,
+		boundaryBorderRadius:     cfg.BoundaryHighlight.BorderRadius,
+		boundaryBackgroundColor: cfg.BoundaryHighlight.BackgroundColor.ForTheme(
+			theme,
+			config.HintsBoundaryBackgroundColorLight,
+			config.HintsBoundaryBackgroundColorDark,
+		),
+		boundaryBorderColor: cfg.BoundaryHighlight.BorderColor.ForTheme(
+			theme,
+			config.HintsBoundaryBorderColorLight,
+			config.HintsBoundaryBorderColorDark,
+		),
 	}
 
 	return style
@@ -505,12 +546,14 @@ func (o *Overlay) drawHintsInternal(hints []*Hint, style StyleMode, showArrow bo
 	}
 
 	// Use cached style strings to avoid repeated allocations
-	cachedStyle := o.styleCache.Get(func(s *overlayutil.CachedStyle) {
-		s.FontFamily = unsafe.Pointer(C.CString(style.FontFamily()))
-		s.BgColor = unsafe.Pointer(C.CString(style.BackgroundColor()))
-		s.TextColor = unsafe.Pointer(C.CString(style.TextColor()))
-		s.MatchedTextColor = unsafe.Pointer(C.CString(style.MatchedTextColor()))
-		s.BorderColor = unsafe.Pointer(C.CString(style.BorderColor()))
+	cachedStyle := o.styleCache.Get(func(_cachedStyle *overlayutil.CachedStyle) {
+		_cachedStyle.FontFamily = unsafe.Pointer(C.CString(style.FontFamily()))
+		_cachedStyle.BgColor = unsafe.Pointer(C.CString(style.BackgroundColor()))
+		_cachedStyle.TextColor = unsafe.Pointer(C.CString(style.TextColor()))
+		_cachedStyle.MatchedTextColor = unsafe.Pointer(C.CString(style.MatchedTextColor()))
+		_cachedStyle.BorderColor = unsafe.Pointer(C.CString(style.BorderColor()))
+		_cachedStyle.BoundaryBgColor = unsafe.Pointer(C.CString(style.BoundaryBackgroundColor()))
+		_cachedStyle.BoundaryBorderColor = unsafe.Pointer(C.CString(style.BoundaryBorderColor()))
 	})
 
 	arrowFlag := 0
@@ -519,17 +562,22 @@ func (o *Overlay) drawHintsInternal(hints []*Hint, style StyleMode, showArrow bo
 	}
 
 	finalStyle := C.HintStyle{
-		fontSize:         C.int(style.FontSize()),
-		fontFamily:       (*C.char)(cachedStyle.FontFamily),
-		backgroundColor:  (*C.char)(cachedStyle.BgColor),
-		textColor:        (*C.char)(cachedStyle.TextColor),
-		matchedTextColor: (*C.char)(cachedStyle.MatchedTextColor),
-		borderColor:      (*C.char)(cachedStyle.BorderColor),
-		borderRadius:     C.int(style.BorderRadius()),
-		borderWidth:      C.int(style.BorderWidth()),
-		paddingX:         C.int(style.PaddingX()),
-		paddingY:         C.int(style.PaddingY()),
-		showArrow:        C.int(arrowFlag),
+		fontSize:                 C.int(style.FontSize()),
+		fontFamily:               (*C.char)(cachedStyle.FontFamily),
+		backgroundColor:          (*C.char)(cachedStyle.BgColor),
+		textColor:                (*C.char)(cachedStyle.TextColor),
+		matchedTextColor:         (*C.char)(cachedStyle.MatchedTextColor),
+		borderColor:              (*C.char)(cachedStyle.BorderColor),
+		borderRadius:             C.int(style.BorderRadius()),
+		borderWidth:              C.int(style.BorderWidth()),
+		paddingX:                 C.int(style.PaddingX()),
+		paddingY:                 C.int(style.PaddingY()),
+		showArrow:                C.int(arrowFlag),
+		boundaryHighlightEnabled: C.int(boolToInt(style.BoundaryHighlightEnabled())),
+		boundaryBorderWidth:      C.int(style.BoundaryBorderWidth()),
+		boundaryBorderRadius:     C.int(style.BoundaryBorderRadius()),
+		boundaryBackgroundColor:  (*C.char)(cachedStyle.BoundaryBgColor),
+		boundaryBorderColor:      (*C.char)(cachedStyle.BoundaryBorderColor),
 	}
 
 	// Draw hints
@@ -746,12 +794,18 @@ func (o *Overlay) drawHintsIncrementalStructural(
 	}
 
 	// Get style strings
-	cachedStyle := o.styleCache.Get(func(s *overlayutil.CachedStyle) {
-		s.FontFamily = unsafe.Pointer(C.CString(currentStyle.FontFamily()))
-		s.BgColor = unsafe.Pointer(C.CString(currentStyle.BackgroundColor()))
-		s.TextColor = unsafe.Pointer(C.CString(currentStyle.TextColor()))
-		s.MatchedTextColor = unsafe.Pointer(C.CString(currentStyle.MatchedTextColor()))
-		s.BorderColor = unsafe.Pointer(C.CString(currentStyle.BorderColor()))
+	cachedStyle := o.styleCache.Get(func(_cachedStyle *overlayutil.CachedStyle) {
+		_cachedStyle.FontFamily = unsafe.Pointer(C.CString(currentStyle.FontFamily()))
+		_cachedStyle.BgColor = unsafe.Pointer(C.CString(currentStyle.BackgroundColor()))
+		_cachedStyle.TextColor = unsafe.Pointer(C.CString(currentStyle.TextColor()))
+		_cachedStyle.MatchedTextColor = unsafe.Pointer(C.CString(currentStyle.MatchedTextColor()))
+		_cachedStyle.BorderColor = unsafe.Pointer(C.CString(currentStyle.BorderColor()))
+		_cachedStyle.BoundaryBgColor = unsafe.Pointer(
+			C.CString(currentStyle.BoundaryBackgroundColor()),
+		)
+		_cachedStyle.BoundaryBorderColor = unsafe.Pointer(
+			C.CString(currentStyle.BoundaryBorderColor()),
+		)
 	})
 
 	arrowFlag := 0
@@ -760,17 +814,22 @@ func (o *Overlay) drawHintsIncrementalStructural(
 	}
 
 	finalStyle := C.HintStyle{
-		fontSize:         C.int(currentStyle.FontSize()),
-		fontFamily:       (*C.char)(cachedStyle.FontFamily),
-		backgroundColor:  (*C.char)(cachedStyle.BgColor),
-		textColor:        (*C.char)(cachedStyle.TextColor),
-		matchedTextColor: (*C.char)(cachedStyle.MatchedTextColor),
-		borderColor:      (*C.char)(cachedStyle.BorderColor),
-		borderRadius:     C.int(currentStyle.BorderRadius()),
-		borderWidth:      C.int(currentStyle.BorderWidth()),
-		paddingX:         C.int(currentStyle.PaddingX()),
-		paddingY:         C.int(currentStyle.PaddingY()),
-		showArrow:        C.int(arrowFlag),
+		fontSize:                 C.int(currentStyle.FontSize()),
+		fontFamily:               (*C.char)(cachedStyle.FontFamily),
+		backgroundColor:          (*C.char)(cachedStyle.BgColor),
+		textColor:                (*C.char)(cachedStyle.TextColor),
+		matchedTextColor:         (*C.char)(cachedStyle.MatchedTextColor),
+		borderColor:              (*C.char)(cachedStyle.BorderColor),
+		borderRadius:             C.int(currentStyle.BorderRadius()),
+		borderWidth:              C.int(currentStyle.BorderWidth()),
+		paddingX:                 C.int(currentStyle.PaddingX()),
+		paddingY:                 C.int(currentStyle.PaddingY()),
+		showArrow:                C.int(arrowFlag),
+		boundaryHighlightEnabled: C.int(boolToInt(currentStyle.BoundaryHighlightEnabled())),
+		boundaryBorderWidth:      C.int(currentStyle.BoundaryBorderWidth()),
+		boundaryBorderRadius:     C.int(currentStyle.BoundaryBorderRadius()),
+		boundaryBackgroundColor:  (*C.char)(cachedStyle.BoundaryBgColor),
+		boundaryBorderColor:      (*C.char)(cachedStyle.BoundaryBorderColor),
 	}
 
 	// Call incremental C API

--- a/internal/app/components/hints/overlay_linux_common.go
+++ b/internal/app/components/hints/overlay_linux_common.go
@@ -12,16 +12,21 @@ import (
 
 // StyleMode represents the visual styling configuration for hint overlays.
 type StyleMode struct {
-	fontSize         int
-	fontFamily       string
-	borderRadius     int
-	paddingX         int
-	paddingY         int
-	borderWidth      int
-	backgroundColor  string
-	textColor        string
-	matchedTextColor string
-	borderColor      string
+	fontSize                 int
+	fontFamily               string
+	borderRadius             int
+	paddingX                 int
+	paddingY                 int
+	borderWidth              int
+	backgroundColor          string
+	textColor                string
+	matchedTextColor         string
+	borderColor              string
+	boundaryHighlightEnabled bool
+	boundaryBorderWidth      int
+	boundaryBorderRadius     int
+	boundaryBackgroundColor  string
+	boundaryBorderColor      string
 }
 
 // FontSize returns the font size.
@@ -53,6 +58,21 @@ func (s StyleMode) MatchedTextColor() string { return s.matchedTextColor }
 
 // BorderColor returns the border color.
 func (s StyleMode) BorderColor() string { return s.borderColor }
+
+// BoundaryHighlightEnabled returns whether target boundaries are drawn behind hints.
+func (s StyleMode) BoundaryHighlightEnabled() bool { return s.boundaryHighlightEnabled }
+
+// BoundaryBorderWidth returns the target boundary stroke width.
+func (s StyleMode) BoundaryBorderWidth() int { return s.boundaryBorderWidth }
+
+// BoundaryBorderRadius returns the target boundary corner radius.
+func (s StyleMode) BoundaryBorderRadius() int { return s.boundaryBorderRadius }
+
+// BoundaryBackgroundColor returns the target boundary fill color.
+func (s StyleMode) BoundaryBackgroundColor() string { return s.boundaryBackgroundColor }
+
+// BoundaryBorderColor returns the target boundary stroke color.
+func (s StyleMode) BoundaryBorderColor() string { return s.boundaryBorderColor }
 
 // Overlay manages the rendering of hint overlays using native platform APIs (Linux stub).
 type Overlay struct {
@@ -137,6 +157,19 @@ func BuildStyle(cfg config.HintsConfig, theme config.ThemeProvider) StyleMode {
 			theme,
 			config.HintsBorderColorLight,
 			config.HintsBorderColorDark,
+		),
+		boundaryHighlightEnabled: cfg.BoundaryHighlight.Enabled,
+		boundaryBorderWidth:      cfg.BoundaryHighlight.BorderWidth,
+		boundaryBorderRadius:     cfg.BoundaryHighlight.BorderRadius,
+		boundaryBackgroundColor: cfg.BoundaryHighlight.BackgroundColor.ForTheme(
+			theme,
+			config.HintsBoundaryBackgroundColorLight,
+			config.HintsBoundaryBackgroundColorDark,
+		),
+		boundaryBorderColor: cfg.BoundaryHighlight.BorderColor.ForTheme(
+			theme,
+			config.HintsBoundaryBorderColorLight,
+			config.HintsBoundaryBorderColorDark,
 		),
 	}
 }

--- a/internal/app/components/hints/overlay_windows.go
+++ b/internal/app/components/hints/overlay_windows.go
@@ -12,16 +12,21 @@ import (
 
 // StyleMode represents the visual styling configuration for hint overlays.
 type StyleMode struct {
-	fontSize         int
-	fontFamily       string
-	borderRadius     int
-	paddingX         int
-	paddingY         int
-	borderWidth      int
-	backgroundColor  string
-	textColor        string
-	matchedTextColor string
-	borderColor      string
+	fontSize                 int
+	fontFamily               string
+	borderRadius             int
+	paddingX                 int
+	paddingY                 int
+	borderWidth              int
+	backgroundColor          string
+	textColor                string
+	matchedTextColor         string
+	borderColor              string
+	boundaryHighlightEnabled bool
+	boundaryBorderWidth      int
+	boundaryBorderRadius     int
+	boundaryBackgroundColor  string
+	boundaryBorderColor      string
 }
 
 // FontSize returns the font size.
@@ -53,6 +58,21 @@ func (s StyleMode) MatchedTextColor() string { return s.matchedTextColor }
 
 // BorderColor returns the border color.
 func (s StyleMode) BorderColor() string { return s.borderColor }
+
+// BoundaryHighlightEnabled returns whether target boundaries are drawn behind hints.
+func (s StyleMode) BoundaryHighlightEnabled() bool { return s.boundaryHighlightEnabled }
+
+// BoundaryBorderWidth returns the target boundary stroke width.
+func (s StyleMode) BoundaryBorderWidth() int { return s.boundaryBorderWidth }
+
+// BoundaryBorderRadius returns the target boundary corner radius.
+func (s StyleMode) BoundaryBorderRadius() int { return s.boundaryBorderRadius }
+
+// BoundaryBackgroundColor returns the target boundary fill color.
+func (s StyleMode) BoundaryBackgroundColor() string { return s.boundaryBackgroundColor }
+
+// BoundaryBorderColor returns the target boundary stroke color.
+func (s StyleMode) BoundaryBorderColor() string { return s.boundaryBorderColor }
 
 // Overlay manages the rendering of hint overlays using native platform APIs (Windows stub).
 type Overlay struct {
@@ -111,5 +131,45 @@ func (o *Overlay) Config() config.HintsConfig {
 
 // BuildStyle builds the hints style from the configuration (Windows stub).
 func BuildStyle(cfg config.HintsConfig, theme config.ThemeProvider) StyleMode {
-	return StyleMode{}
+	return StyleMode{
+		fontSize:     cfg.UI.FontSize,
+		fontFamily:   cfg.UI.FontFamily,
+		borderRadius: cfg.UI.BorderRadius,
+		paddingX:     cfg.UI.PaddingX,
+		paddingY:     cfg.UI.PaddingY,
+		borderWidth:  cfg.UI.BorderWidth,
+		backgroundColor: cfg.UI.BackgroundColor.ForTheme(
+			theme,
+			config.HintsBackgroundColorLight,
+			config.HintsBackgroundColorDark,
+		),
+		textColor: cfg.UI.TextColor.ForTheme(
+			theme,
+			config.HintsTextColorLight,
+			config.HintsTextColorDark,
+		),
+		matchedTextColor: cfg.UI.MatchedTextColor.ForTheme(
+			theme,
+			config.HintsMatchedTextColorLight,
+			config.HintsMatchedTextColorDark,
+		),
+		borderColor: cfg.UI.BorderColor.ForTheme(
+			theme,
+			config.HintsBorderColorLight,
+			config.HintsBorderColorDark,
+		),
+		boundaryHighlightEnabled: cfg.BoundaryHighlight.Enabled,
+		boundaryBorderWidth:      cfg.BoundaryHighlight.BorderWidth,
+		boundaryBorderRadius:     cfg.BoundaryHighlight.BorderRadius,
+		boundaryBackgroundColor: cfg.BoundaryHighlight.BackgroundColor.ForTheme(
+			theme,
+			config.HintsBoundaryBackgroundColorLight,
+			config.HintsBoundaryBackgroundColorDark,
+		),
+		boundaryBorderColor: cfg.BoundaryHighlight.BorderColor.ForTheme(
+			theme,
+			config.HintsBoundaryBorderColorLight,
+			config.HintsBoundaryBorderColorDark,
+		),
+	}
 }

--- a/internal/app/components/overlayutil/style_cache.go
+++ b/internal/app/components/overlayutil/style_cache.go
@@ -10,16 +10,18 @@ import (
 // CachedStyle holds pointers to C strings for style properties.
 // Fields are unsafe.Pointer to avoid C type dependency across packages.
 type CachedStyle struct {
-	FontFamily         unsafe.Pointer
-	BgColor            unsafe.Pointer
-	LabelBgColor       unsafe.Pointer
-	TextColor          unsafe.Pointer
-	MatchedTextColor   unsafe.Pointer
-	BorderColor        unsafe.Pointer
-	MatchedBgColor     unsafe.Pointer
-	MatchedBorderColor unsafe.Pointer
-	HighlightColor     unsafe.Pointer
-	SubKeyTextColor    unsafe.Pointer
+	FontFamily          unsafe.Pointer
+	BgColor             unsafe.Pointer
+	LabelBgColor        unsafe.Pointer
+	TextColor           unsafe.Pointer
+	MatchedTextColor    unsafe.Pointer
+	BorderColor         unsafe.Pointer
+	MatchedBgColor      unsafe.Pointer
+	MatchedBorderColor  unsafe.Pointer
+	HighlightColor      unsafe.Pointer
+	SubKeyTextColor     unsafe.Pointer
+	BoundaryBgColor     unsafe.Pointer
+	BoundaryBorderColor unsafe.Pointer
 }
 
 // StyleCache manages caching of C strings for styles to reduce allocations.
@@ -89,4 +91,8 @@ func (c *StyleCache) freeLocked() {
 	c.style.HighlightColor = nil
 	native.FreeCString(c.style.SubKeyTextColor)
 	c.style.SubKeyTextColor = nil
+	native.FreeCString(c.style.BoundaryBgColor)
+	c.style.BoundaryBgColor = nil
+	native.FreeCString(c.style.BoundaryBorderColor)
+	c.style.BoundaryBorderColor = nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -534,6 +534,15 @@ type HintsUI struct {
 	BorderColor      Color  `json:"borderColor"      toml:"border_color"`
 }
 
+// BoundaryHighlightUI defines the optional target boundary highlight for hints mode.
+type BoundaryHighlightUI struct {
+	Enabled         bool  `json:"enabled"         toml:"enabled"`
+	BorderWidth     int   `json:"borderWidth"     toml:"border_width"`
+	BorderRadius    int   `json:"borderRadius"    toml:"border_radius"`
+	BorderColor     Color `json:"borderColor"     toml:"border_color"`
+	BackgroundColor Color `json:"backgroundColor" toml:"background_color"`
+}
+
 // SearchInputUI defines the visual/appearance settings for hints text search.
 type SearchInputUI struct {
 	FontSize        int    `json:"fontSize"        toml:"font_size"`
@@ -553,12 +562,13 @@ type SearchInputUI struct {
 
 // HintsConfig defines the visual and behavioral settings for hints mode.
 type HintsConfig struct {
-	Enabled           bool          `json:"enabled"           toml:"enabled"`
-	HintCharacters    string        `json:"hintCharacters"    toml:"hint_characters"`
-	MaxDepth          int           `json:"maxDepth"          toml:"max_depth"`
-	ParallelThreshold int           `json:"parallelThreshold" toml:"parallel_threshold"`
-	UI                HintsUI       `json:"ui"                toml:"ui"`
-	SearchInputUI     SearchInputUI `json:"searchInputUi"     toml:"search_input_ui"`
+	Enabled           bool                `json:"enabled"           toml:"enabled"`
+	HintCharacters    string              `json:"hintCharacters"    toml:"hint_characters"`
+	MaxDepth          int                 `json:"maxDepth"          toml:"max_depth"`
+	ParallelThreshold int                 `json:"parallelThreshold" toml:"parallel_threshold"`
+	UI                HintsUI             `json:"ui"                toml:"ui"`
+	SearchInputUI     SearchInputUI       `json:"searchInputUi"     toml:"search_input_ui"`
+	BoundaryHighlight BoundaryHighlightUI `json:"boundaryHighlight" toml:"boundary_highlight"`
 
 	IncludeMenubarHints           bool     `json:"includeMenubarHints"           toml:"include_menubar_hints"`
 	AdditionalMenubarHintsTargets []string `json:"additionalMenubarHintsTargets" toml:"additional_menubar_hints_targets"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -11,6 +11,8 @@ const (
 	DefaultHintPaddingX = -1
 	// DefaultHintPaddingY is the default vertical padding for hints (-1 = auto).
 	DefaultHintPaddingY = -1
+	// DefaultHintBoundaryBorderRadius is the default radius for hint target boundaries.
+	DefaultHintBoundaryBorderRadius = 4
 
 	// DefaultSearchInputYOffset is the default Y offset for search input.
 	DefaultSearchInputYOffset = 24
@@ -326,6 +328,13 @@ func newDefaultConfig() *Config {
 				BackgroundColor: Color{},
 				TextColor:       Color{},
 				BorderColor:     Color{},
+			},
+			BoundaryHighlight: BoundaryHighlightUI{
+				Enabled:         false,
+				BorderWidth:     1,
+				BorderRadius:    DefaultHintBoundaryBorderRadius,
+				BorderColor:     Color{},
+				BackgroundColor: Color{},
 			},
 
 			IncludeMenubarHints:           false,

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -12,7 +12,7 @@ const (
 	// DefaultHintPaddingY is the default vertical padding for hints (-1 = auto).
 	DefaultHintPaddingY = -1
 	// DefaultHintBoundaryBorderRadius is the default radius for hint target boundaries.
-	DefaultHintBoundaryBorderRadius = 4
+	DefaultHintBoundaryBorderRadius = -1
 	// DefaultHintBoundaryBorderWidth is the default stroke width for hint target boundaries.
 	DefaultHintBoundaryBorderWidth = 1
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -13,6 +13,8 @@ const (
 	DefaultHintPaddingY = -1
 	// DefaultHintBoundaryBorderRadius is the default radius for hint target boundaries.
 	DefaultHintBoundaryBorderRadius = 4
+	// DefaultHintBoundaryBorderWidth is the default stroke width for hint target boundaries.
+	DefaultHintBoundaryBorderWidth = 1
 
 	// DefaultSearchInputYOffset is the default Y offset for search input.
 	DefaultSearchInputYOffset = 24
@@ -331,7 +333,7 @@ func newDefaultConfig() *Config {
 			},
 			BoundaryHighlight: BoundaryHighlightUI{
 				Enabled:         false,
-				BorderWidth:     1,
+				BorderWidth:     DefaultHintBoundaryBorderWidth,
 				BorderRadius:    DefaultHintBoundaryBorderRadius,
 				BorderColor:     Color{},
 				BackgroundColor: Color{},

--- a/internal/config/theme_palette.go
+++ b/internal/config/theme_palette.go
@@ -49,7 +49,7 @@ var (
 	// HintsBoundaryBorderColorLight is the fallback light stroke color for hint target boundaries.
 	HintsBoundaryBorderColorLight = applyAlpha(defaultThemeLightAccent, "73")
 	// HintsBoundaryBorderColorDark is the fallback dark stroke color for hint target boundaries.
-	HintsBoundaryBorderColorDark = applyAlpha(defaultThemeDarkAccentAlt, "8C")
+	HintsBoundaryBorderColorDark = applyAlpha(defaultThemeDarkAccentAlt, "73")
 
 	// GridBackgroundColorLight is the fallback light background color for grid cells.
 	GridBackgroundColorLight = applyAlpha(defaultThemeLightSurface, "99")

--- a/internal/config/theme_palette.go
+++ b/internal/config/theme_palette.go
@@ -42,6 +42,14 @@ var (
 	HintsBorderColorLight = solidRGBHex(defaultThemeLightAccent)
 	// HintsBorderColorDark is the fallback dark border color for hints.
 	HintsBorderColorDark = solidRGBHex(defaultThemeDarkAccent)
+	// HintsBoundaryBackgroundColorLight is the fallback light fill color for hint target boundaries.
+	HintsBoundaryBackgroundColorLight = applyAlpha(defaultThemeLightAccent, "14")
+	// HintsBoundaryBackgroundColorDark is the fallback dark fill color for hint target boundaries.
+	HintsBoundaryBackgroundColorDark = applyAlpha(defaultThemeDarkAccentAlt, "1F")
+	// HintsBoundaryBorderColorLight is the fallback light stroke color for hint target boundaries.
+	HintsBoundaryBorderColorLight = applyAlpha(defaultThemeLightAccent, "73")
+	// HintsBoundaryBorderColorDark is the fallback dark stroke color for hint target boundaries.
+	HintsBoundaryBorderColorDark = applyAlpha(defaultThemeDarkAccentAlt, "8C")
 
 	// GridBackgroundColorLight is the fallback light background color for grid cells.
 	GridBackgroundColorLight = applyAlpha(defaultThemeLightSurface, "99")
@@ -230,6 +238,12 @@ func (c *Config) ResolveThemeDefaults() {
 	))
 	mergeColorWithDefault(&c.Hints.SearchInputUI.BorderColor, solidThemedColor(
 		c.Theme.Light.Accent, c.Theme.Dark.Accent,
+	))
+	mergeColorWithDefault(&c.Hints.BoundaryHighlight.BackgroundColor, themedColor(
+		c.Theme.Light.Accent, c.Theme.Dark.AccentAlt, "1A",
+	))
+	mergeColorWithDefault(&c.Hints.BoundaryHighlight.BorderColor, themedColor(
+		c.Theme.Light.Accent, c.Theme.Dark.AccentAlt, "73",
 	))
 
 	mergeColorWithDefault(&c.Grid.UI.BackgroundColor, themedColor(

--- a/internal/config/theme_palette.go
+++ b/internal/config/theme_palette.go
@@ -45,7 +45,7 @@ var (
 	// HintsBoundaryBackgroundColorLight is the fallback light fill color for hint target boundaries.
 	HintsBoundaryBackgroundColorLight = applyAlpha(defaultThemeLightAccent, "14")
 	// HintsBoundaryBackgroundColorDark is the fallback dark fill color for hint target boundaries.
-	HintsBoundaryBackgroundColorDark = applyAlpha(defaultThemeDarkAccentAlt, "1F")
+	HintsBoundaryBackgroundColorDark = applyAlpha(defaultThemeDarkAccentAlt, "1A")
 	// HintsBoundaryBorderColorLight is the fallback light stroke color for hint target boundaries.
 	HintsBoundaryBorderColorLight = applyAlpha(defaultThemeLightAccent, "73")
 	// HintsBoundaryBorderColorDark is the fallback dark stroke color for hint target boundaries.

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -122,6 +122,8 @@ func (c *Config) ValidateHints() error {
 		{c.Hints.SearchInputUI.BackgroundColor, "hints.search_input_ui.background_color"},
 		{c.Hints.SearchInputUI.TextColor, "hints.search_input_ui.text_color"},
 		{c.Hints.SearchInputUI.BorderColor, "hints.search_input_ui.border_color"},
+		{c.Hints.BoundaryHighlight.BackgroundColor, "hints.boundary_highlight.background_color"},
+		{c.Hints.BoundaryHighlight.BorderColor, "hints.boundary_highlight.border_color"},
 	})
 	if err != nil {
 		return err
@@ -181,6 +183,22 @@ func (c *Config) ValidateHints() error {
 			derrors.CodeInvalidConfig,
 			"hints.search_input_ui.border_width must be non-negative",
 		)
+	}
+
+	if c.Hints.BoundaryHighlight.BorderWidth < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.boundary_highlight.border_width must be non-negative",
+		)
+	}
+
+	err = validateMinValue(
+		c.Hints.BoundaryHighlight.BorderRadius,
+		0,
+		"hints.boundary_highlight.border_radius",
+	)
+	if err != nil {
+		return err
 	}
 
 	switch c.Hints.SearchInputUI.Position {

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -194,7 +194,7 @@ func (c *Config) ValidateHints() error {
 
 	err = validateMinValue(
 		c.Hints.BoundaryHighlight.BorderRadius,
-		0,
+		-1,
 		"hints.boundary_highlight.border_radius",
 	)
 	if err != nil {

--- a/internal/config/validators_hints_test.go
+++ b/internal/config/validators_hints_test.go
@@ -16,3 +16,21 @@ func TestValidateHints_EnabledRequiresClickableRoles(t *testing.T) {
 		t.Fatal("ValidateHints() expected error when enabled and clickable_roles is empty")
 	}
 }
+
+func TestValidateHints_BoundaryHighlightGeometry(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Hints.BoundaryHighlight.BorderWidth = -1
+
+	err := cfg.ValidateHints()
+	if err == nil {
+		t.Fatal("ValidateHints() expected error for negative boundary border width")
+	}
+
+	cfg = config.DefaultConfig()
+	cfg.Hints.BoundaryHighlight.BorderRadius = -1
+
+	err = cfg.ValidateHints()
+	if err == nil {
+		t.Fatal("ValidateHints() expected error for negative boundary border radius")
+	}
+}

--- a/internal/config/validators_hints_test.go
+++ b/internal/config/validators_hints_test.go
@@ -30,7 +30,7 @@ func TestValidateHints_BoundaryHighlightGeometry(t *testing.T) {
 	cfg.Hints.BoundaryHighlight.BorderRadius = -1
 
 	err = cfg.ValidateHints()
-	if err == nil {
-		t.Fatal("ValidateHints() expected error for negative boundary border radius")
+	if err != nil {
+		t.Fatalf("ValidateHints() expected no error for -1 (auto) border radius, got %v", err)
 	}
 }

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -18,17 +18,22 @@ typedef void *OverlayWindow;
 
 /// Hint style configuration
 typedef struct {
-	int fontSize;            ///< Font size
-	char *fontFamily;        ///< Font family
-	char *backgroundColor;   ///< Background color
-	char *textColor;         ///< Text color
-	char *matchedTextColor;  ///< Matched text color
-	char *borderColor;       ///< Border color
-	int borderRadius;        ///< Border radius (-1 = auto)
-	int borderWidth;         ///< Border width
-	int paddingX;            ///< Horizontal padding (-1 = auto)
-	int paddingY;            ///< Vertical padding (-1 = auto)
-	int showArrow;           ///< Show arrow (0 = no arrow, 1 = show arrow)
+	int fontSize;                   ///< Font size
+	char *fontFamily;               ///< Font family
+	char *backgroundColor;          ///< Background color
+	char *textColor;                ///< Text color
+	char *matchedTextColor;         ///< Matched text color
+	char *borderColor;              ///< Border color
+	int borderRadius;               ///< Border radius (-1 = auto)
+	int borderWidth;                ///< Border width
+	int paddingX;                   ///< Horizontal padding (-1 = auto)
+	int paddingY;                   ///< Vertical padding (-1 = auto)
+	int showArrow;                  ///< Show arrow (0 = no arrow, 1 = show arrow)
+	int boundaryHighlightEnabled;   ///< Draw target boundary highlight (0 = off, 1 = on)
+	int boundaryBorderWidth;        ///< Target boundary border width
+	int boundaryBorderRadius;       ///< Target boundary corner radius
+	char *boundaryBackgroundColor;  ///< Target boundary fill color
+	char *boundaryBorderColor;      ///< Target boundary stroke color
 } HintStyle;
 
 /// Hint data

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -16,6 +16,7 @@
 @interface HintItem : NSObject
 @property(nonatomic, copy) NSString *label;
 @property(nonatomic, assign) CGPoint position;
+@property(nonatomic, assign) CGSize size;
 @property(nonatomic, assign) int matchedPrefixLength;
 @property(nonatomic, assign) BOOL showArrow;
 @end
@@ -117,25 +118,30 @@ static const CGFloat kHintArrowGap = 1.0;
 #pragma mark - Overlay View Interface
 
 @interface OverlayView : NSView
-@property(nonatomic, strong) NSMutableArray<HintItem *> *hints;    ///< Hints array
-@property(nonatomic, strong) NSFont *hintFont;                     ///< Hint font
-@property(nonatomic, strong) NSColor *hintTextColor;               ///< Hint text color
-@property(nonatomic, strong) NSColor *hintMatchedTextColor;        ///< Hint matched text color
-@property(nonatomic, strong) NSColor *hintBackgroundColor;         ///< Hint background color
-@property(nonatomic, strong) NSColor *hintBorderColor;             ///< Hint border color
-@property(nonatomic, assign) CGFloat hintBorderRadius;             ///< Hint border radius
-@property(nonatomic, assign) CGFloat hintBorderWidth;              ///< Hint border width
-@property(nonatomic, assign) CGFloat hintPaddingX;                 ///< Hint horizontal padding
-@property(nonatomic, assign) CGFloat hintPaddingY;                 ///< Hint vertical padding
-@property(nonatomic, strong) SearchInputItem *searchInput;         ///< Active hints search input
-@property(nonatomic, strong) NSFont *searchInputFont;              ///< Search input font
-@property(nonatomic, strong) NSColor *searchInputTextColor;        ///< Search input text color
-@property(nonatomic, strong) NSColor *searchInputBackgroundColor;  ///< Search input background color
-@property(nonatomic, strong) NSColor *searchInputBorderColor;      ///< Search input border color
-@property(nonatomic, assign) CGFloat searchInputBorderRadius;      ///< Search input border radius
-@property(nonatomic, assign) CGFloat searchInputBorderWidth;       ///< Search input border width
-@property(nonatomic, assign) CGFloat searchInputPaddingX;          ///< Search input horizontal padding
-@property(nonatomic, assign) CGFloat searchInputPaddingY;          ///< Search input vertical padding
+@property(nonatomic, strong) NSMutableArray<HintItem *> *hints;     ///< Hints array
+@property(nonatomic, strong) NSFont *hintFont;                      ///< Hint font
+@property(nonatomic, strong) NSColor *hintTextColor;                ///< Hint text color
+@property(nonatomic, strong) NSColor *hintMatchedTextColor;         ///< Hint matched text color
+@property(nonatomic, strong) NSColor *hintBackgroundColor;          ///< Hint background color
+@property(nonatomic, strong) NSColor *hintBorderColor;              ///< Hint border color
+@property(nonatomic, strong) NSColor *hintBoundaryBackgroundColor;  ///< Target boundary fill color
+@property(nonatomic, strong) NSColor *hintBoundaryBorderColor;      ///< Target boundary stroke color
+@property(nonatomic, assign) CGFloat hintBorderRadius;              ///< Hint border radius
+@property(nonatomic, assign) CGFloat hintBorderWidth;               ///< Hint border width
+@property(nonatomic, assign) CGFloat hintPaddingX;                  ///< Hint horizontal padding
+@property(nonatomic, assign) CGFloat hintPaddingY;                  ///< Hint vertical padding
+@property(nonatomic, assign) BOOL hintBoundaryHighlightEnabled;     ///< Draw target boundary highlight
+@property(nonatomic, assign) CGFloat hintBoundaryBorderWidth;       ///< Target boundary stroke width
+@property(nonatomic, assign) CGFloat hintBoundaryBorderRadius;      ///< Target boundary corner radius
+@property(nonatomic, strong) SearchInputItem *searchInput;          ///< Active hints search input
+@property(nonatomic, strong) NSFont *searchInputFont;               ///< Search input font
+@property(nonatomic, strong) NSColor *searchInputTextColor;         ///< Search input text color
+@property(nonatomic, strong) NSColor *searchInputBackgroundColor;   ///< Search input background color
+@property(nonatomic, strong) NSColor *searchInputBorderColor;       ///< Search input border color
+@property(nonatomic, assign) CGFloat searchInputBorderRadius;       ///< Search input border radius
+@property(nonatomic, assign) CGFloat searchInputBorderWidth;        ///< Search input border width
+@property(nonatomic, assign) CGFloat searchInputPaddingX;           ///< Search input horizontal padding
+@property(nonatomic, assign) CGFloat searchInputPaddingY;           ///< Search input vertical padding
 
 @property(nonatomic, strong) NSMutableArray<GridCellItem *> *gridCells;         ///< Grid cells array
 @property(nonatomic, strong) NSArray<GridCellItem *> *transitionFromGridCells;  ///< Previous grid cells for animation
@@ -282,8 +288,13 @@ static const CGFloat kHintArrowGap = 1.0;
 		_hintMatchedTextColor = [NSColor systemBlueColor];
 		_hintBackgroundColor = [[NSColor colorWithRed:1.0 green:0.84 blue:0.0 alpha:1.0] colorWithAlphaComponent:0.95];
 		_hintBorderColor = [NSColor blackColor];
+		_hintBoundaryBackgroundColor = [[NSColor systemBlueColor] colorWithAlphaComponent:0.08];
+		_hintBoundaryBorderColor = [[NSColor systemBlueColor] colorWithAlphaComponent:0.45];
 		_hintBorderRadius = -1.0;
 		_hintBorderWidth = 1.0;
+		_hintBoundaryHighlightEnabled = NO;
+		_hintBoundaryBorderWidth = 1.0;
+		_hintBoundaryBorderRadius = 4.0;
 		_hintPaddingX = -1.0;
 		_hintPaddingY = -1.0;
 		_searchInput = nil;
@@ -698,24 +709,35 @@ static const CGFloat kHintArrowGap = 1.0;
 	NSColor *defaultText = [NSColor blackColor];
 	NSColor *defaultMatchedText = [NSColor systemBlueColor];
 	NSColor *defaultBorder = [NSColor blackColor];
+	NSColor *defaultBoundaryBackground = [[NSColor systemBlueColor] colorWithAlphaComponent:0.08];
+	NSColor *defaultBoundaryBorder = [[NSColor systemBlueColor] colorWithAlphaComponent:0.45];
 
 	// Parse hex color strings
 	NSString *backgroundHex = style.backgroundColor ? [NSString stringWithUTF8String:style.backgroundColor] : nil;
 	NSString *textHex = style.textColor ? [NSString stringWithUTF8String:style.textColor] : nil;
 	NSString *matchedTextHex = style.matchedTextColor ? [NSString stringWithUTF8String:style.matchedTextColor] : nil;
 	NSString *borderHex = style.borderColor ? [NSString stringWithUTF8String:style.borderColor] : nil;
+	NSString *boundaryBackgroundHex =
+	    style.boundaryBackgroundColor ? [NSString stringWithUTF8String:style.boundaryBackgroundColor] : nil;
+	NSString *boundaryBorderHex =
+	    style.boundaryBorderColor ? [NSString stringWithUTF8String:style.boundaryBorderColor] : nil;
 
 	// Apply colors
 	self.hintBackgroundColor = [self colorFromHex:backgroundHex defaultColor:defaultBg];
 	self.hintTextColor = [self colorFromHex:textHex defaultColor:defaultText];
 	self.hintMatchedTextColor = [self colorFromHex:matchedTextHex defaultColor:defaultMatchedText];
 	self.hintBorderColor = [self colorFromHex:borderHex defaultColor:defaultBorder];
+	self.hintBoundaryBackgroundColor = [self colorFromHex:boundaryBackgroundHex defaultColor:defaultBoundaryBackground];
+	self.hintBoundaryBorderColor = [self colorFromHex:boundaryBorderHex defaultColor:defaultBoundaryBorder];
 
 	// Apply geometry properties
 	self.hintBorderRadius = style.borderRadius;
 	self.hintBorderWidth = style.borderWidth >= 0 ? style.borderWidth : 1.0;
 	self.hintPaddingX = style.paddingX;
 	self.hintPaddingY = style.paddingY;
+	self.hintBoundaryHighlightEnabled = style.boundaryHighlightEnabled ? YES : NO;
+	self.hintBoundaryBorderWidth = style.boundaryBorderWidth >= 0 ? style.boundaryBorderWidth : 1.0;
+	self.hintBoundaryBorderRadius = style.boundaryBorderRadius >= 0 ? style.boundaryBorderRadius : 4.0;
 }
 
 /// Create color from hex string
@@ -1000,6 +1022,16 @@ static const CGFloat kHintArrowGap = 1.0;
 		}
 	}
 
+	if (self.hintBoundaryHighlightEnabled && hint.size.width > 0.0 && hint.size.height > 0.0) {
+		CGFloat boundaryX = position.x - hint.size.width / 2.0;
+		CGFloat boundaryY = screenHeight - position.y - hint.size.height / 2.0;
+		CGFloat boundaryExpand = ceil(self.hintBoundaryBorderWidth / 2.0) + 1.0;
+		NSRect boundaryRect = NSMakeRect(
+		    boundaryX - boundaryExpand, boundaryY - boundaryExpand, hint.size.width + boundaryExpand * 2.0,
+		    hint.size.height + boundaryExpand * 2.0);
+		hintRect = NSUnionRect(hintRect, boundaryRect);
+	}
+
 	return hintRect;
 }
 
@@ -1161,6 +1193,12 @@ static const CGFloat kHintArrowGap = 1.0;
 		CGFloat flippedY = screenHeight - tooltipY - boxHeight;
 		CGFloat flippedElementCenterY = screenHeight - elementCenterY;
 		NSRect hintRect = NSMakeRect(tooltipX, flippedY, boxWidth, boxHeight);
+		NSRect boundaryRect = NSZeroRect;
+		if (self.hintBoundaryHighlightEnabled && hint.size.width > 0.0 && hint.size.height > 0.0) {
+			boundaryRect = NSMakeRect(
+			    position.x - hint.size.width / 2.0, screenHeight - position.y - hint.size.height / 2.0, hint.size.width,
+			    hint.size.height);
+		}
 
 		// Skip hints outside the dirty region
 		if (filterByRect) {
@@ -1170,8 +1208,30 @@ static const CGFloat kHintArrowGap = 1.0;
 			if (showArrow && flippedElementCenterY > NSMaxY(testRect)) {
 				testRect.size.height = flippedElementCenterY + 1.0 - testRect.origin.y;
 			}
+			if (!NSIsEmptyRect(boundaryRect)) {
+				CGFloat boundaryExpand = ceil(self.hintBoundaryBorderWidth / 2.0) + 1.0;
+				NSRect boundaryTestRect = NSMakeRect(
+				    boundaryRect.origin.x - boundaryExpand, boundaryRect.origin.y - boundaryExpand,
+				    boundaryRect.size.width + boundaryExpand * 2.0, boundaryRect.size.height + boundaryExpand * 2.0);
+				testRect = NSUnionRect(testRect, boundaryTestRect);
+			}
 			if (!NSIntersectsRect(testRect, dirtyRect))
 				continue;
+		}
+
+		if (!NSIsEmptyRect(boundaryRect)) {
+			CGFloat boundaryRadius =
+			    MIN(self.hintBoundaryBorderRadius, MIN(boundaryRect.size.width, boundaryRect.size.height) / 2.0);
+			NSBezierPath *boundaryPath = [NSBezierPath bezierPathWithRoundedRect:boundaryRect
+			                                                             xRadius:boundaryRadius
+			                                                             yRadius:boundaryRadius];
+			[self.hintBoundaryBackgroundColor setFill];
+			[boundaryPath fill];
+			if (self.hintBoundaryBorderWidth > 0.0) {
+				[self.hintBoundaryBorderColor setStroke];
+				[boundaryPath setLineWidth:self.hintBoundaryBorderWidth];
+				[boundaryPath stroke];
+			}
 		}
 
 		// Draw background and border
@@ -1874,6 +1934,10 @@ static inline void free_hint_style_strings(const HintStyle *style) {
 		free((void *)style->matchedTextColor);
 	if (style->borderColor)
 		free((void *)style->borderColor);
+	if (style->boundaryBackgroundColor)
+		free((void *)style->boundaryBackgroundColor);
+	if (style->boundaryBorderColor)
+		free((void *)style->boundaryBorderColor);
 }
 
 static inline void free_search_input_style_strings(const SearchInputStyle *style) {
@@ -1920,6 +1984,7 @@ static NSMutableArray<HintItem *> *buildHintItems(HintData *hints, int count, BO
 		HintItem *hintItem = [[HintItem alloc] init];
 		hintItem.label = hint.label ? @(hint.label) : @"";
 		hintItem.position = hint.position;
+		hintItem.size = hint.size;
 		hintItem.matchedPrefixLength = hint.matchedPrefixLength;
 		hintItem.showArrow = showArrow;
 		[hintItems addObject:hintItem];
@@ -1955,11 +2020,16 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 		    .paddingX = style.paddingX,
 		    .paddingY = style.paddingY,
 		    .showArrow = style.showArrow,
+		    .boundaryHighlightEnabled = style.boundaryHighlightEnabled,
+		    .boundaryBorderWidth = style.boundaryBorderWidth,
+		    .boundaryBorderRadius = style.boundaryBorderRadius,
 		    .fontFamily = safe_strdup(style.fontFamily),
 		    .backgroundColor = safe_strdup(style.backgroundColor),
 		    .textColor = safe_strdup(style.textColor),
 		    .matchedTextColor = safe_strdup(style.matchedTextColor),
-		    .borderColor = safe_strdup(style.borderColor)};
+		    .borderColor = safe_strdup(style.borderColor),
+		    .boundaryBackgroundColor = safe_strdup(style.boundaryBackgroundColor),
+		    .boundaryBorderColor = safe_strdup(style.boundaryBorderColor)};
 
 		dispatch_async(dispatch_get_main_queue(), ^{
 			[controller.overlayView.hints removeAllObjects];
@@ -2142,10 +2212,15 @@ void NeruDrawIncrementHints(
 	NSString *textHex = style.textColor ? @(style.textColor) : nil;
 	NSString *matchedTextHex = style.matchedTextColor ? @(style.matchedTextColor) : nil;
 	NSString *borderHex = style.borderColor ? @(style.borderColor) : nil;
+	NSString *boundaryBgHex = style.boundaryBackgroundColor ? @(style.boundaryBackgroundColor) : nil;
+	NSString *boundaryBorderHex = style.boundaryBorderColor ? @(style.boundaryBorderColor) : nil;
 	int borderRadius = style.borderRadius;
 	int borderWidth = style.borderWidth;
 	int paddingX = style.paddingX;
 	int paddingY = style.paddingY;
+	int boundaryHighlightEnabled = style.boundaryHighlightEnabled;
+	int boundaryBorderWidth = style.boundaryBorderWidth;
+	int boundaryBorderRadius = style.boundaryBorderRadius;
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		// Apply font — only re-create when family or size changed
@@ -2183,12 +2258,25 @@ void NeruDrawIncrementHints(
 			controller.overlayView.hintBorderColor = [controller.overlayView colorFromHex:borderHex
 			                                                                 defaultColor:[NSColor blackColor]];
 		}
+		if (boundaryBgHex) {
+			NSColor *defaultBoundaryBg = [[NSColor systemBlueColor] colorWithAlphaComponent:0.08];
+			controller.overlayView.hintBoundaryBackgroundColor =
+			    [controller.overlayView colorFromHex:boundaryBgHex defaultColor:defaultBoundaryBg];
+		}
+		if (boundaryBorderHex) {
+			NSColor *defaultBoundaryBorder = [[NSColor systemBlueColor] colorWithAlphaComponent:0.45];
+			controller.overlayView.hintBoundaryBorderColor =
+			    [controller.overlayView colorFromHex:boundaryBorderHex defaultColor:defaultBoundaryBorder];
+		}
 
 		// Apply geometry properties
 		controller.overlayView.hintBorderRadius = borderRadius;
 		controller.overlayView.hintBorderWidth = borderWidth >= 0 ? borderWidth : 1.0;
 		controller.overlayView.hintPaddingX = paddingX;
 		controller.overlayView.hintPaddingY = paddingY;
+		controller.overlayView.hintBoundaryHighlightEnabled = boundaryHighlightEnabled ? YES : NO;
+		controller.overlayView.hintBoundaryBorderWidth = boundaryBorderWidth >= 0 ? boundaryBorderWidth : 1.0;
+		controller.overlayView.hintBoundaryBorderRadius = boundaryBorderRadius >= 0 ? boundaryBorderRadius : 4.0;
 
 		// Remove hints matching the given positions
 		if (positionsToRemoveArray && [positionsToRemoveArray count] > 0) {

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -1001,6 +1001,21 @@ func (o *wlrootsOverlay) DrawHints(
 	C.neru_wayland_overlay_setup_buffers(o.raw)
 	o.Clear()
 	for _, hint := range hintsSlice {
+		if style.BoundaryHighlightEnabled() {
+			boundary := image.Rect(
+				hint.Position().X-hint.Size().X/2,
+				hint.Position().Y-hint.Size().Y/2,
+				hint.Position().X+hint.Size().X/2,
+				hint.Position().Y+hint.Size().Y/2,
+			)
+			o.drawRect(
+				boundary,
+				parseHexColor(style.BoundaryBackgroundColor()),
+				parseHexColor(style.BoundaryBorderColor()),
+				float64(max(style.BoundaryBorderWidth(), 0)),
+			)
+		}
+
 		bounds := image.Rect(
 			hint.Position().X,
 			hint.Position().Y,

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -443,6 +443,21 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 
 	o.Clear()
 	for _, hint := range hintsSlice {
+		if style.BoundaryHighlightEnabled() {
+			boundary := image.Rect(
+				hint.Position().X-hint.Size().X/2,
+				hint.Position().Y-hint.Size().Y/2,
+				hint.Position().X+hint.Size().X/2,
+				hint.Position().Y+hint.Size().Y/2,
+			)
+			o.drawRect(
+				boundary,
+				parseHexColor(style.BoundaryBackgroundColor()),
+				parseHexColor(style.BoundaryBorderColor()),
+				float64(max(style.BoundaryBorderWidth(), 0)),
+			)
+		}
+
 		bounds := image.Rect(
 			hint.Position().X,
 			hint.Position().Y,


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds an optional boundary highlights for elements in hint mode, for ease of readability and scanning. Default disabled.

```toml
[hints.boundary_highlight]
enabled = true
border_width = 1
border_radius = -1
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/42179f90-06e8-4ccf-9a7f-12bdddad911a

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
