### PR TITLE
fix(hints): cap hint generation when elements exceed key combinations

### DIFF
--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -131,6 +131,16 @@ func (s *HintService) ShowHints(
 
 	s.logger.Info("Found clickable elements", zap.Int("count", len(elements)))
 
+	maxHints := gen.MaxHints()
+	if maxHints > 0 && len(elements) > maxHints {
+		s.logger.Warn(
+			"Clickable element count exceeds available hint key combinations; showing as many as possible",
+			zap.Int("element_count", len(elements)),
+			zap.Int("max_hints", maxHints),
+			zap.Int("omitted_count", len(elements)-maxHints),
+		)
+	}
+
 	// Generate hints
 	hints, elementsErr := gen.Generate(ctx, elements)
 	if elementsErr != nil {

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -244,6 +244,37 @@ func TestHintService_ShowHints(t *testing.T) {
 			wantErr:       false,
 			wantHintCount: 3,
 		},
+		{
+			name: "too many elements shows max hints without error",
+			setupMocks: func(acc *mocks.MockAccessibilityPort, _ *mocks.MockOverlayPort) {
+				acc.ClickableElementsFunc = func(_ context.Context, _ ports.ElementFilter) ([]*element.Element, error) {
+					elements := make([]*element.Element, 10)
+
+					for index := range elements {
+						elements[index] = mustNewElement(
+							fmt.Sprintf("elem%d", index),
+							image.Rect(index*10, index*10, index*10+40, index*10+40),
+						)
+					}
+
+					return elements, nil
+				}
+			},
+			setupGen: func() hint.Generator {
+				gen, _ := hint.NewAlphabetGenerator("as")
+
+				return gen
+			},
+			wantErr:       false,
+			wantHintCount: 8,
+			checkHints: func(t *testing.T, hints []*hint.Interface) {
+				t.Helper()
+
+				if len(hints) != 8 {
+					t.Errorf("Expected 8 hints, got %d", len(hints))
+				}
+			},
+		},
 	}
 
 	for _, testCase := range tests {

--- a/internal/core/domain/hint/alphabet_generator.go
+++ b/internal/core/domain/hint/alphabet_generator.go
@@ -96,15 +96,6 @@ func (g *AlphabetGenerator) Generate(
 		return nil, nil
 	}
 
-	if len(elements) > g.maxHints {
-		return nil, derrors.Newf(
-			derrors.CodeHintGenerationFailed,
-			"too many elements: %d exceeds maximum %d",
-			len(elements),
-			g.maxHints,
-		)
-	}
-
 	// Check context cancellation
 	select {
 	case <-ctx.Done():
@@ -130,6 +121,10 @@ func (g *AlphabetGenerator) Generate(
 		// Then X (left to right)
 		return boundI.Min.X < boundJ.Min.X
 	})
+
+	if len(sorted) > g.maxHints {
+		sorted = sorted[:g.maxHints]
+	}
 
 	// Generate labels (with caching)
 	labels := g.generateLabels(len(sorted))

--- a/internal/core/domain/hint/hint_test.go
+++ b/internal/core/domain/hint/hint_test.go
@@ -292,7 +292,7 @@ func TestAlphabetGenerator_TooManyElements(t *testing.T) {
 	for index := range elements {
 		elements[index], _ = element.NewElement(
 			element.ID("elem-"+string(rune('0'+index))),
-			image.Rect(0, 0, 50, 50),
+			image.Rect(index*10, index*10, index*10+50, index*10+50),
 			element.RoleButton,
 		)
 	}

--- a/internal/core/domain/hint/hint_test.go
+++ b/internal/core/domain/hint/hint_test.go
@@ -285,9 +285,9 @@ func TestAlphabetGenerator_MaxHints(t *testing.T) {
 }
 
 func TestAlphabetGenerator_TooManyElements(t *testing.T) {
-	generator, _ := hint.NewAlphabetGenerator("as") // Max 6 hints (2 + 2*2)
+	generator, _ := hint.NewAlphabetGenerator("as") // Max 8 hints (2^3)
 
-	// Try to generate 10 hints
+	// Try to generate more hints than the key combinations can label.
 	elements := make([]*element.Element, 10)
 	for index := range elements {
 		elements[index], _ = element.NewElement(
@@ -299,9 +299,22 @@ func TestAlphabetGenerator_TooManyElements(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, generateErr := generator.Generate(ctx, elements)
-	if generateErr == nil {
-		t.Error("Generate() expected error for too many elements, got nil")
+	hints, generateErr := generator.Generate(ctx, elements)
+	if generateErr != nil {
+		t.Fatalf("Generate() unexpected error for too many elements: %v", generateErr)
+	}
+
+	if len(hints) != generator.MaxHints() {
+		t.Fatalf("Generate() returned %d hints, want max %d", len(hints), generator.MaxHints())
+	}
+
+	for _, generatedHint := range hints {
+		if generatedHint.Element().ID() == "elem-8" || generatedHint.Element().ID() == "elem-9" {
+			t.Fatalf(
+				"Generate() included an element beyond max hint capacity: %s",
+				generatedHint.Element().ID(),
+			)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR updates hints mode so it no longer hard errors when the number of available hints exceeds the possible key combinations.

Instead, hint generation now caps the generated hints to the maximum labelable count, while the hint service logs a warning with the total element count, max hint capacity, and omitted count. This lets hints mode show as much as it can instead of failing entirely.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
