### PR TITLE
feat(hints): add native PIP support for mac

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -56,6 +56,7 @@ additional_menubar_hints_targets = [
 include_dock_hints = false
 include_nc_hints = false
 include_stage_manager_hints = false
+include_pip_hints = false
 detect_mission_control = false
 clickable_roles = [
     "AXButton",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -338,6 +338,7 @@ You can also start hints mode with the search input shown immediately by using t
 | `include_dock_hints`               | bool   | `false`       | Show hints on Dock items                             |
 | `include_nc_hints`                 | bool   | `false`       | Show hints in Notification Center                    |
 | `include_stage_manager_hints`      | bool   | `false`       | Show hints in Stage Manager                          |
+| `include_pip_hints`                | bool   | `false`       | Show hints on macOS Picture in Picture controls      |
 | `detect_mission_control`           | bool   | `false`       | Auto-disable hints when in Mission Control           |
 | `additional_menubar_hints_targets` | array  | see defaults  | Extra menubar bundle IDs                             |
 | `clickable_roles`                  | array  | see defaults  | AX roles that generate hints                         |

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -100,6 +100,7 @@ func (s *HintService) ShowHints(
 	filter.IncludeDock = cfg.IncludeDockHints
 	filter.IncludeNotificationCenter = cfg.IncludeNCHints
 	filter.IncludeStageManager = cfg.IncludeStageManagerHints
+	filter.IncludePIP = cfg.IncludePIPHints
 
 	// Apply text filter if provided (OR match - element matches if any text contains match)
 	if len(filterTextContains) > 0 {
@@ -214,7 +215,8 @@ func (s *HintService) UpdateConfig(config config.HintsConfig) {
 		zap.Bool("include_menubar", config.IncludeMenubarHints),
 		zap.Bool("include_dock", config.IncludeDockHints),
 		zap.Bool("include_nc", config.IncludeNCHints),
-		zap.Bool("include_stage_manager", config.IncludeStageManagerHints))
+		zap.Bool("include_stage_manager", config.IncludeStageManagerHints),
+		zap.Bool("include_pip", config.IncludePIPHints))
 }
 
 // UpdateGenerator updates the hint generator.

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -183,6 +183,14 @@ func TestHintService_ShowHints(t *testing.T) {
 						t.Error("IncludeNotificationCenter should be true based on config")
 					}
 
+					if !filter.IncludeStageManager {
+						t.Error("IncludeStageManager should be true based on config")
+					}
+
+					if !filter.IncludePIP {
+						t.Error("IncludePIP should be true based on config")
+					}
+
 					return testElements, nil
 				}
 			},
@@ -196,6 +204,7 @@ func TestHintService_ShowHints(t *testing.T) {
 				IncludeDockHints:         true,
 				IncludeNCHints:           true,
 				IncludeStageManagerHints: true,
+				IncludePIPHints:          true,
 			},
 			wantErr:       false,
 			wantHintCount: 3,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -575,6 +575,7 @@ type HintsConfig struct {
 	IncludeDockHints              bool     `json:"includeDockHints"              toml:"include_dock_hints"`
 	IncludeNCHints                bool     `json:"includeNcHints"                toml:"include_nc_hints"`
 	IncludeStageManagerHints      bool     `json:"includeStageManagerHints"      toml:"include_stage_manager_hints"`
+	IncludePIPHints               bool     `json:"includePipHints"               toml:"include_pip_hints"`
 	DetectMissionControl          bool     `json:"detectMissionControl"          toml:"detect_mission_control"`
 
 	ClickableRoles       []string `json:"clickableRoles"       toml:"clickable_roles"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -344,6 +344,7 @@ func newDefaultConfig() *Config {
 			IncludeDockHints:              false,
 			IncludeNCHints:                false,
 			IncludeStageManagerHints:      false,
+			IncludePIPHints:               false,
 			DetectMissionControl:          false,
 
 			ClickableRoles: []string{},

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -231,7 +231,7 @@ func (a *Adapter) ClickableElements(
 	// AdditionalMenubarTargets only produces elements when IncludeMenubar is true
 	hasAdditionalTargets := filter.IncludeMenubar && len(filter.AdditionalMenubarTargets) > 0
 	if filter.IncludeMenubar || filter.IncludeDock || filter.IncludeStageManager ||
-		filter.IncludeNotificationCenter || hasAdditionalTargets {
+		filter.IncludeNotificationCenter || filter.IncludePIP || hasAdditionalTargets {
 		waitGroup.Add(1)
 
 		go func() {

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -23,7 +23,8 @@ func (a *Adapter) addSupplementaryElements(
 		zap.Bool("include_menubar", filter.IncludeMenubar),
 		zap.Bool("include_dock", filter.IncludeDock),
 		zap.Bool("include_nc", filter.IncludeNotificationCenter),
-		zap.Bool("include_stage_manager", filter.IncludeStageManager))
+		zap.Bool("include_stage_manager", filter.IncludeStageManager),
+		zap.Bool("include_pip", filter.IncludePIP))
 
 	// Add menubar elements
 	if !missionControlActive && filter.IncludeMenubar {
@@ -43,6 +44,12 @@ func (a *Adapter) addSupplementaryElements(
 	// Add stage manager elements
 	if filter.IncludeStageManager {
 		elements = a.addStageManagerElements(ctx, elements)
+	}
+
+	// Add Picture in Picture elements. Safari PiP is owned by PIPAgent and
+	// cannot be discovered from the currently focused app because it is not focusable.
+	if filter.IncludePIP {
+		elements = a.addPIPElements(ctx, elements)
 	}
 
 	return elements
@@ -287,6 +294,39 @@ func (a *Adapter) addStageManagerElements(
 	}
 
 	a.logger.Debug("Included window manager elements", zap.Int("count", len(wmNodes)))
+
+	return elements
+}
+
+// addPIPElements adds macOS Picture in Picture controls from PIPAgent.
+func (a *Adapter) addPIPElements(
+	_ context.Context,
+	elements []*element.Element,
+) []*element.Element {
+	const pipBundleID = "com.apple.PIPAgent"
+
+	pipNodes, pipNodesErr := a.client.ClickableElementsFromBundleID(pipBundleID, nil, false)
+	if pipNodesErr != nil {
+		a.logger.Warn("Failed to get Picture in Picture elements", zap.Error(pipNodesErr))
+
+		return elements
+	}
+
+	for _, node := range pipNodes {
+		element, elementErr := a.convertToDomainElement(node)
+
+		node.Release()
+
+		if elementErr != nil {
+			a.logger.Warn("Failed to convert Picture in Picture element", zap.Error(elementErr))
+
+			continue
+		}
+
+		elements = append(elements, element)
+	}
+
+	a.logger.Debug("Included Picture in Picture elements", zap.Int("count", len(pipNodes)))
 
 	return elements
 }

--- a/internal/core/infra/accessibility/adapter_test.go
+++ b/internal/core/infra/accessibility/adapter_test.go
@@ -554,7 +554,7 @@ func TestAdapter_RolePassing(t *testing.T) {
 
 		if mockClient.LastBundleRoles != nil {
 			t.Errorf(
-				"Expected PIP query to use configured clickable roles, got: %v",
+				"Expected PIP query to pass nil roles (no role restriction), got: %v",
 				mockClient.LastBundleRoles,
 			)
 		}

--- a/internal/core/infra/accessibility/adapter_test.go
+++ b/internal/core/infra/accessibility/adapter_test.go
@@ -534,4 +534,29 @@ func TestAdapter_RolePassing(t *testing.T) {
 			)
 		}
 	})
+
+	t.Run("Picture in Picture Elements", func(t *testing.T) {
+		mockClient.LastCalledBundleID = ""
+		mockClient.LastBundleRoles = nil
+
+		filter := ports.ElementFilter{
+			IncludePIP: true,
+		}
+
+		_, _ = adapter.ClickableElements(ctx, filter)
+
+		if mockClient.LastCalledBundleID != "com.apple.PIPAgent" {
+			t.Errorf(
+				"Expected PIP supplementary query to use com.apple.PIPAgent, got: %q",
+				mockClient.LastCalledBundleID,
+			)
+		}
+
+		if mockClient.LastBundleRoles != nil {
+			t.Errorf(
+				"Expected PIP query to use configured clickable roles, got: %v",
+				mockClient.LastBundleRoles,
+			)
+		}
+	})
 }

--- a/internal/core/ports/accessibility.go
+++ b/internal/core/ports/accessibility.go
@@ -102,6 +102,11 @@ type ElementFilter struct {
 	// Platform equivalents on Linux/Windows are not yet mapped.
 	IncludeStageManager bool
 
+	// IncludePIP includes Picture in Picture controls.
+	// On macOS this queries com.apple.PIPAgent.
+	// Platform equivalents on Linux/Windows are not yet mapped.
+	IncludePIP bool
+
 	// TitleContains filters elements whose title contains this substring (case-insensitive).
 	TitleContains string
 
@@ -128,5 +133,6 @@ func DefaultElementFilter() ElementFilter {
 		IncludeDock:               false,
 		IncludeNotificationCenter: false,
 		IncludeStageManager:       false,
+		IncludePIP:                false,
 	}
 }

--- a/internal/core/ports/accessibility_test.go
+++ b/internal/core/ports/accessibility_test.go
@@ -45,6 +45,10 @@ func TestDefaultElementFilter(t *testing.T) {
 		t.Error("Expected IncludeStageManager to be false by default")
 	}
 
+	if filter.IncludePIP {
+		t.Error("Expected IncludePIP to be false by default")
+	}
+
 	// Check that slices are initialized
 	if filter.Roles != nil {
 		t.Error("Expected Roles to be nil by default")
@@ -66,6 +70,8 @@ func TestElementFilterStruct(t *testing.T) {
 		AdditionalMenubarTargets:  []string{"com.example.app"},
 		IncludeDock:               true,
 		IncludeNotificationCenter: true,
+		IncludeStageManager:       true,
+		IncludePIP:                true,
 	}
 
 	if len(filter.Roles) != 1 || filter.Roles[0] != element.RoleButton {
@@ -102,6 +108,14 @@ func TestElementFilterStruct(t *testing.T) {
 
 	if !filter.IncludeNotificationCenter {
 		t.Error("Expected IncludeNotificationCenter to be true")
+	}
+
+	if !filter.IncludeStageManager {
+		t.Error("Expected IncludeStageManager to be true")
+	}
+
+	if !filter.IncludePIP {
+		t.Error("Expected IncludePIP to be true")
 	}
 }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds opt-in hints support for PIP controls in mac by treating `com.apple.PIPAgent` as a supplementary accessibility source. This lets hints mode discover PiP controls even though the PiP window is not normally focusable like standard app windows.

```toml
[hints]
include_pip_hints = true # default is disabled
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

<img width="1455" height="742" alt="Screenshot 2026-05-13 at 11 25 59 AM" src="https://github.com/user-attachments/assets/094dfdc5-2f5f-47fa-b3fc-9fe26eab4071" />

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
