### PR TITLE
perf(hints): reduce AX work during hints activation

### DIFF
--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -251,8 +251,9 @@ func (h *Handler) RefreshHintsForScreenChange(
 	filterRoles := h.hints.Context.FilterRoles()
 	filterTextContains := h.hints.Context.FilterTextContains()
 
-	// Show hints with filters preserved
-	domainHints, showHintsErr := hintService.ShowHints(ctx, filterRoles, filterTextContains)
+	// Generate hints with filters preserved; SetHints below performs the
+	// single redraw after active-screen filtering.
+	domainHints, showHintsErr := hintService.GenerateHints(ctx, filterRoles, filterTextContains)
 	if showHintsErr != nil {
 		h.logger.Error("Failed to refresh hints after screen change", zap.Error(showHintsErr))
 		h.exitModeLocked()

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -192,8 +192,6 @@ func (h *Handler) activateHintModeInternal(
 	}
 
 	h.screenBounds = activeScreenBounds
-	h.overlayManager.ResizeToActiveScreen()
-
 	// Clear any previous overlay content (e.g., scroll highlights) before drawing hints.
 	// This prevents scroll highlights from persisting when switching from scroll mode to hints mode.
 	h.overlayManager.Clear()
@@ -215,8 +213,9 @@ func (h *Handler) activateHintModeInternal(
 	ctx, cancel := context.WithTimeout(context.Background(), HintTimeout)
 	defer cancel()
 
-	// Get hints from service
-	domainHints, domainHintsErr := h.hintService.ShowHints(ctx, filterRoles, filterTextContains)
+	// Get hints from service. Drawing is intentionally deferred until after
+	// active-screen filtering so activation performs one full overlay render.
+	domainHints, domainHintsErr := h.hintService.GenerateHints(ctx, filterRoles, filterTextContains)
 	if domainHintsErr != nil {
 		h.logger.Error(
 			"Failed to show hints",
@@ -293,14 +292,6 @@ func (h *Handler) activateHintModeInternal(
 		h.hints.Context.SetManager(manager)
 	}
 
-	h.hints.Context.SetRouter(domainHint.NewRouter(h.hints.Context.Manager(), h.logger))
-
-	h.hints.Context.SetHints(hintCollection)
-
-	if actionStr != nil {
-		h.logger.Info("Hints mode activated with pending action", zap.String("action", *actionStr))
-	}
-
 	// Only set mode and enable event tap on initial activation;
 	// during refresh these are already in the correct state.
 	if !isRefresh {
@@ -311,6 +302,15 @@ func (h *Handler) activateHintModeInternal(
 		// app-specific hotkey overrides for the new app are correctly
 		// intercepted instead of being passed through to macOS.
 		h.syncModifierPassthrough(domain.ModeHints)
+	}
+
+	h.hints.Context.SetRouter(domainHint.NewRouter(h.hints.Context.Manager(), h.logger))
+
+	h.hints.Context.SetHints(hintCollection)
+	h.overlayManager.Show()
+
+	if actionStr != nil {
+		h.logger.Info("Hints mode activated with pending action", zap.String("action", *actionStr))
 	}
 
 	h.logger.Info("Hints mode activated")

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -376,7 +376,7 @@ func (h *Handler) refreshHintsForMonitorMove(
 	filterRoles := h.hints.Context.FilterRoles()
 	filterTextContains := h.hints.Context.FilterTextContains()
 
-	domainHints, err := h.hintService.ShowHints(ctx, filterRoles, filterTextContains)
+	domainHints, err := h.hintService.GenerateHints(ctx, filterRoles, filterTextContains)
 	if err != nil {
 		h.logger.Error(
 			"Failed to refresh hints after monitor move",

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -50,6 +50,36 @@ func (s *HintService) ShowHints(
 ) ([]*hint.Interface, error) {
 	s.logger.Info("Showing hints")
 
+	hints, err := s.GenerateHints(ctx, filterRoles, filterTextContains)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(hints) == 0 {
+		return hints, nil
+	}
+
+	// Display hints
+	showHintsErr := s.overlay.ShowHints(ctx, hints)
+	if showHintsErr != nil {
+		s.logger.Error("Failed to show hints overlay", zap.Error(showHintsErr))
+
+		return nil, core.WrapOverlayFailed(showHintsErr, "show hints")
+	}
+
+	s.logger.Info("Hints displayed successfully")
+
+	return hints, nil
+}
+
+// GenerateHints collects clickable elements and generates labels without drawing
+// them. Mode handlers use this to filter and position hints before the first
+// render, avoiding an extra full overlay draw during activation.
+func (s *HintService) GenerateHints(
+	ctx context.Context,
+	filterRoles []string,
+	filterTextContains []string,
+) ([]*hint.Interface, error) {
 	s.mu.RLock()
 	cfg := s.config
 	gen := s.generator
@@ -151,16 +181,6 @@ func (s *HintService) ShowHints(
 	}
 
 	s.logger.Info("Generated hints", zap.Int("count", len(hints)))
-
-	// Display hints
-	showHintsErr := s.overlay.ShowHints(ctx, hints)
-	if showHintsErr != nil {
-		s.logger.Error("Failed to show hints overlay", zap.Error(showHintsErr))
-
-		return nil, core.WrapOverlayFailed(showHintsErr, "show hints")
-	}
-
-	s.logger.Info("Hints displayed successfully")
 
 	return hints, nil
 }

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -164,33 +164,18 @@ func (a *Adapter) ClickableElements(
 
 		go func() {
 			collectElements("windows", func() ([]*element.Element, error) {
-				// Get frontmost window (the main/focused window)
-				frontmost, frontmostErr := a.client.FrontmostWindow()
-				if frontmostErr != nil {
-					return nil, frontmostErr
+				windowsToProcess, windowsErr := a.client.FrontmostAndPopoverWindows()
+				if windowsErr != nil {
+					return nil, windowsErr
 				}
 
-				// Get all windows to find popovers
-				allWindows, allWindowsErr := a.client.AllWindows()
-				if allWindowsErr != nil {
-					frontmost.Release()
-
-					return nil, allWindowsErr
-				}
-
-				// Collect windows to process: frontmost + any AXPopover
-				var windowsToProcess []AXWindow
-
-				windowsToProcess = append(windowsToProcess, frontmost)
-
-				// Add popover windows (siblings to the main window)
-				// Release non-popover windows to avoid leaks
-				for _, w := range allWindows {
-					if w.Role() == "AXPopover" {
-						windowsToProcess = append(windowsToProcess, w)
-					} else {
-						w.Release()
+				if len(windowsToProcess) == 0 {
+					frontmost, frontmostErr := a.client.FrontmostWindow()
+					if frontmostErr != nil {
+						return nil, frontmostErr
 					}
+
+					windowsToProcess = []AXWindow{frontmost}
 				}
 
 				var allElements []*element.Element

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -2,6 +2,7 @@ package accessibility
 
 import (
 	"context"
+	"sync"
 
 	"go.uber.org/zap"
 
@@ -26,30 +27,63 @@ func (a *Adapter) addSupplementaryElements(
 		zap.Bool("include_stage_manager", filter.IncludeStageManager),
 		zap.Bool("include_pip", filter.IncludePIP))
 
-	// Add menubar elements
-	if !missionControlActive && filter.IncludeMenubar {
-		elements = a.addMenubarElements(ctx, elements, filter)
+	type supplementarySource struct {
+		enabled bool
+		load    func() []*element.Element
 	}
 
-	// Add dock elements
-	if filter.IncludeDock {
-		elements = a.addDockElements(ctx, elements)
+	sources := []supplementarySource{
+		{
+			enabled: !missionControlActive && filter.IncludeMenubar,
+			load: func() []*element.Element {
+				return a.addMenubarElements(ctx, nil, filter)
+			},
+		},
+		{
+			enabled: filter.IncludeDock,
+			load: func() []*element.Element {
+				return a.addDockElements(ctx, nil)
+			},
+		},
+		{
+			enabled: missionControlActive && filter.IncludeNotificationCenter,
+			load: func() []*element.Element {
+				return a.addNotificationCenterElements(ctx, nil)
+			},
+		},
+		{
+			enabled: filter.IncludeStageManager,
+			load: func() []*element.Element {
+				return a.addStageManagerElements(ctx, nil)
+			},
+		},
+		{
+			// Safari PiP is owned by PIPAgent and cannot be discovered from
+			// the currently focused app because it is not focusable.
+			enabled: filter.IncludePIP,
+			load: func() []*element.Element {
+				return a.addPIPElements(ctx, nil)
+			},
+		},
 	}
 
-	// Add notification center elements (only when Mission Control is active)
-	if missionControlActive && filter.IncludeNotificationCenter {
-		elements = a.addNotificationCenterElements(ctx, elements)
+	results := make([][]*element.Element, len(sources))
+
+	var waitGroup sync.WaitGroup
+	for index, source := range sources {
+		if !source.enabled {
+			continue
+		}
+
+		waitGroup.Go(func() {
+			results[index] = source.load()
+		})
 	}
 
-	// Add stage manager elements
-	if filter.IncludeStageManager {
-		elements = a.addStageManagerElements(ctx, elements)
-	}
+	waitGroup.Wait()
 
-	// Add Picture in Picture elements. Safari PiP is owned by PIPAgent and
-	// cannot be discovered from the currently focused app because it is not focusable.
-	if filter.IncludePIP {
-		elements = a.addPIPElements(ctx, elements)
+	for _, sourceElements := range results {
+		elements = append(elements, sourceElements...)
 	}
 
 	return elements

--- a/internal/core/infra/accessibility/client.go
+++ b/internal/core/infra/accessibility/client.go
@@ -22,6 +22,7 @@ type AXClient interface {
 	// Window and App operations
 	FrontmostWindow() (AXWindow, error)
 	AllWindows() ([]AXWindow, error)
+	FrontmostAndPopoverWindows() ([]AXWindow, error)
 	FocusedApplication() (AXApp, error)
 	ApplicationByBundleID(bundleID string) (AXApp, error)
 	ClickableNodes(root AXElement, includeOffscreen bool, roles []string) ([]AXNode, error)

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -678,11 +678,11 @@ func (e *Element) IsClickable(
 		clickableRolesMu.RUnlock()
 	}
 
-	if isRoleAllowed {
-		if ignoreClickableCheck {
-			return true
-		}
+	if ignoreClickableCheck {
+		return true
+	}
 
+	if isRoleAllowed {
 		// Also verify it actually has click action
 		result := C.hasClickAction(e.ref) //nolint:nlreturn
 

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -462,6 +462,31 @@ func AllWindows() ([]*Element, error) {
 	return result, nil
 }
 
+// FrontmostAndPopoverWindows returns the frontmost window plus focused-app
+// popover windows in a single native query.
+func FrontmostAndPopoverWindows() ([]*Element, error) {
+	var count C.int
+	windows := C.getFrontmostAndPopoverWindows(&count)
+	if windows == nil || count == 0 {
+		if windows != nil {
+			C.free(unsafe.Pointer(windows))
+		}
+
+		return []*Element{}, nil
+	}
+	defer C.free(unsafe.Pointer(windows)) //nolint:nlreturn
+
+	countInt := int(count)
+	windowSlice := (*[1 << 30]unsafe.Pointer)(unsafe.Pointer(windows))[:countInt:countInt]
+	result := make([]*Element, countInt)
+
+	for index := range result {
+		result[index] = &Element{ref: windowSlice[index]}
+	}
+
+	return result, nil
+}
+
 // FrontmostWindow returns the frontmost window.
 func FrontmostWindow() *Element {
 	ref := C.getFrontmostWindow()
@@ -618,17 +643,10 @@ func (e *Element) IsClickable(
 	allowedRoles map[string]struct{},
 	cache *InfoCache,
 	configProvider config.Provider,
+	ignoreClickableCheck bool,
 ) bool {
 	if e.ref == nil {
 		return false
-	}
-
-	if cfg := currentConfig(configProvider); cfg != nil {
-		// Check if clickable check should be ignored for this app
-		bundleID := e.BundleIdentifier()
-		if cfg.ShouldIgnoreClickableCheckForApp(bundleID) {
-			return true
-		}
 	}
 
 	// If info is not provided, try to get it
@@ -661,6 +679,10 @@ func (e *Element) IsClickable(
 	}
 
 	if isRoleAllowed {
+		if ignoreClickableCheck {
+			return true
+		}
+
 		// Also verify it actually has click action
 		result := C.hasClickAction(e.ref) //nolint:nlreturn
 

--- a/internal/core/infra/accessibility/element_linux.go
+++ b/internal/core/infra/accessibility/element_linux.go
@@ -205,6 +205,9 @@ func (e *Element) Clone() (*Element, error) { return &Element{}, nil }
 // AllWindows returns all windows (Linux stub).
 func AllWindows() ([]*Element, error) { return []*Element{}, nil }
 
+// FrontmostAndPopoverWindows returns frontmost/popover windows (Linux stub).
+func FrontmostAndPopoverWindows() ([]*Element, error) { return []*Element{}, nil }
+
 // FrontmostWindow returns the frontmost window.
 func FrontmostWindow() *Element {
 	if currentLinuxBackend() == linuxBackendWayland {
@@ -529,6 +532,7 @@ func (e *Element) IsClickable(
 	_ map[string]struct{},
 	_ *InfoCache,
 	_ config.Provider,
+	_ bool,
 ) bool {
 	return false
 }

--- a/internal/core/infra/accessibility/element_windows.go
+++ b/internal/core/infra/accessibility/element_windows.go
@@ -41,6 +41,7 @@ func (e *Element) IsClickable(
 	_ map[string]struct{},
 	_ *InfoCache,
 	_ config.Provider,
+	_ bool,
 ) bool {
 	return false
 }
@@ -123,6 +124,9 @@ func ElementAtPosition(x, y int) *Element { return nil }
 
 // AllWindows returns all windows (stub).
 func AllWindows() ([]*Element, error) { return []*Element{}, nil }
+
+// FrontmostAndPopoverWindows returns frontmost/popover windows (Windows stub).
+func FrontmostAndPopoverWindows() ([]*Element, error) { return []*Element{}, nil }
 
 // FrontmostWindow returns the frontmost window (stub).
 func FrontmostWindow() *Element { return nil }

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -71,6 +71,21 @@ func (c *InfraAXClient) AllWindows() ([]AXWindow, error) {
 	return result, nil
 }
 
+// FrontmostAndPopoverWindows returns the frontmost window plus popovers.
+func (c *InfraAXClient) FrontmostAndPopoverWindows() ([]AXWindow, error) {
+	windows, err := FrontmostAndPopoverWindows()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]AXWindow, len(windows))
+	for i, w := range windows {
+		result[i] = &InfraWindow{element: w}
+	}
+
+	return result, nil
+}
+
 // FocusedApplication returns the focused application.
 func (c *InfraAXClient) FocusedApplication() (AXApp, error) {
 	app := FocusedApplication()
@@ -144,7 +159,17 @@ func (c *InfraAXClient) ClickableNodes(
 		}
 	}
 
-	clickableNodes := tree.FindClickableElements(allowedRoles, c.cache, c.configProvider)
+	ignoreClickableCheck := false
+	if cfg := currentConfig(c.configProvider); cfg != nil {
+		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(bundleID)
+	}
+
+	clickableNodes := tree.FindClickableElements(
+		allowedRoles,
+		c.cache,
+		c.configProvider,
+		ignoreClickableCheck,
+	)
 
 	// Release tree nodes that are not part of the result to avoid
 	// leaking CFRetain'd AXUIElementRefs from getChildren/getVisibleRows.
@@ -492,7 +517,7 @@ func (n *InfraNode) IsClickable() bool {
 		return false
 	}
 
-	return n.node.Element().IsClickable(n.node.Info(), nil, n.cache, n.configProvider)
+	return n.node.Element().IsClickable(n.node.Info(), nil, n.cache, n.configProvider, false)
 }
 
 // Release releases the underlying AXUIElementRef held by this node.

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -59,7 +59,8 @@ func (m *MockAXClient) AllWindows() ([]AXWindow, error) {
 }
 
 // FrontmostAndPopoverWindows returns configured hint windows or falls back to
-// the frontmost/all-windows mock fields.
+// the frontmost window. When neither is configured, returns empty to match
+// production semantics (focused window + popover siblings, not arbitrary windows).
 func (m *MockAXClient) FrontmostAndPopoverWindows() ([]AXWindow, error) {
 	if m.MockHintWindows != nil || m.MockHintWindowsErr != nil {
 		return m.MockHintWindows, m.MockHintWindowsErr
@@ -69,7 +70,7 @@ func (m *MockAXClient) FrontmostAndPopoverWindows() ([]AXWindow, error) {
 		return []AXWindow{m.MockFrontmostWindow}, m.MockFrontmostWindowErr
 	}
 
-	return m.MockAllWindows, m.MockAllWindowsErr
+	return nil, nil
 }
 
 // FocusedApplication returns the configured focused application or error.

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -15,6 +15,8 @@ type MockAXClient struct {
 	MockFrontmostWindowErr error
 	MockAllWindows         []AXWindow
 	MockAllWindowsErr      error
+	MockHintWindows        []AXWindow
+	MockHintWindowsErr     error
 
 	MockFocusedApp    AXApp
 	MockFocusedAppErr error
@@ -53,6 +55,20 @@ func (m *MockAXClient) FrontmostWindow() (AXWindow, error) {
 
 // AllWindows returns the configured windows or error.
 func (m *MockAXClient) AllWindows() ([]AXWindow, error) {
+	return m.MockAllWindows, m.MockAllWindowsErr
+}
+
+// FrontmostAndPopoverWindows returns configured hint windows or falls back to
+// the frontmost/all-windows mock fields.
+func (m *MockAXClient) FrontmostAndPopoverWindows() ([]AXWindow, error) {
+	if m.MockHintWindows != nil || m.MockHintWindowsErr != nil {
+		return m.MockHintWindows, m.MockHintWindowsErr
+	}
+
+	if m.MockFrontmostWindow != nil {
+		return []AXWindow{m.MockFrontmostWindow}, m.MockFrontmostWindowErr
+	}
+
 	return m.MockAllWindows, m.MockAllWindowsErr
 }
 

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -66,7 +66,18 @@ func MenuBarClickableElements(
 	// Add menubar specific role
 	allowedRoles["AXMenuBarItem"] = struct{}{}
 
-	elements := tree.FindClickableElements(allowedRoles, cache, configProvider)
+	ignoreClickableCheck := false
+	if cfg := currentConfig(configProvider); cfg != nil {
+		focusedBundleID := app.BundleIdentifier()
+		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(focusedBundleID)
+	}
+
+	elements := tree.FindClickableElements(
+		allowedRoles,
+		cache,
+		configProvider,
+		ignoreClickableCheck,
+	)
 
 	// Release tree nodes that are not part of the result to avoid
 	// leaking CFRetain'd AXUIElementRefs from getChildren/getVisibleRows.
@@ -131,7 +142,17 @@ func ClickableElementsFromBundleID(
 		}
 	}
 
-	elements := tree.FindClickableElements(allowedRoles, cache, configProvider)
+	ignoreClickableCheck := false
+	if cfg := currentConfig(configProvider); cfg != nil {
+		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(bundleID)
+	}
+
+	elements := tree.FindClickableElements(
+		allowedRoles,
+		cache,
+		configProvider,
+		ignoreClickableCheck,
+	)
 
 	// Release tree nodes that are not part of the result to avoid
 	// leaking CFRetain'd AXUIElementRefs from getChildren/getVisibleRows.

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -651,10 +651,17 @@ func (n *TreeNode) FindClickableElements(
 	allowedRoles map[string]struct{},
 	cache *InfoCache,
 	configProvider config.Provider,
+	ignoreClickableCheck bool,
 ) []*TreeNode {
 	var result []*TreeNode
 	n.walkTree(func(node *TreeNode) bool {
-		if node.element.IsClickable(node.info, allowedRoles, cache, configProvider) {
+		if node.element.IsClickable(
+			node.info,
+			allowedRoles,
+			cache,
+			configProvider,
+			ignoreClickableCheck,
+		) {
 			node.info.searchText = node.collectSearchText()
 			result = append(result, node)
 		}

--- a/internal/core/infra/accessibility/tree_linux.go
+++ b/internal/core/infra/accessibility/tree_linux.go
@@ -30,6 +30,7 @@ func (n *TreeNode) FindClickableElements(
 	keptRoles map[string]struct{},
 	cache any,
 	configProvider config.Provider,
+	ignoreClickableCheck bool,
 ) []*TreeNode {
 	return nil
 }

--- a/internal/core/infra/accessibility/tree_windows.go
+++ b/internal/core/infra/accessibility/tree_windows.go
@@ -30,6 +30,7 @@ func (n *TreeNode) FindClickableElements(
 	keptRoles map[string]struct{},
 	cache any,
 	configProvider config.Provider,
+	ignoreClickableCheck bool,
 ) []*TreeNode {
 	return nil
 }

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -159,6 +159,11 @@ int areElementsEqual(void *element1, void *element2);
 /// @return Array of window references
 void **getAllWindows(int *count);
 
+/// Get the focused window plus AXPopover windows of the focused application
+/// @param count Output parameter for number of returned windows
+/// @return Array of retained window references. Caller frees the array and releases refs.
+void **getFrontmostAndPopoverWindows(int *count);
+
 /// Get frontmost window
 /// @return Frontmost window reference
 void *getFrontmostWindow(void);

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -80,6 +80,126 @@ void **getAllWindows(int *count) {
 	}
 }
 
+/// Get focused window plus popover windows of the focused application.
+/// This keeps hint activation on one focused-app lookup and avoids asking Go
+/// to fetch each window role separately just to discover AXPopover siblings.
+void **getFrontmostAndPopoverWindows(int *count) {
+	if (!count)
+		return NULL;
+
+	@autoreleasepool {
+		*count = 0;
+
+		AXUIElementRef focusedApp = (AXUIElementRef)getFocusedApplication();
+		AXUIElementRef appRef = focusedApp;
+		bool shouldReleaseAppRef = false;
+
+		if (!appRef) {
+			NSRunningApplication *front = [NSWorkspace sharedWorkspace].frontmostApplication;
+			if (!front)
+				return NULL;
+
+			appRef = AXUIElementCreateApplication(front.processIdentifier);
+			if (!appRef)
+				return NULL;
+
+			shouldReleaseAppRef = true;
+		}
+
+		AXUIElementRef focusedWindow = NULL;
+		AXUIElementCopyAttributeValue(appRef, kAXFocusedWindowAttribute, (CFTypeRef *)&focusedWindow);
+
+		CFTypeRef windowsValue = NULL;
+		CFArrayRef windows = NULL;
+		CFIndex windowCount = 0;
+		if (AXUIElementCopyAttributeValue(appRef, kAXWindowsAttribute, &windowsValue) == kAXErrorSuccess &&
+		    windowsValue && CFGetTypeID(windowsValue) == CFArrayGetTypeID()) {
+			windows = (CFArrayRef)windowsValue;
+			windowCount = CFArrayGetCount(windows);
+		}
+
+		CFIndex capacity = (focusedWindow ? 1 : 0) + windowCount;
+		if (capacity == 0) {
+			if (windowsValue)
+				CFRelease(windowsValue);
+			if (focusedWindow)
+				CFRelease(focusedWindow);
+			if (shouldReleaseAppRef && appRef)
+				CFRelease(appRef);
+			else if (focusedApp)
+				CFRelease(focusedApp);
+			return NULL;
+		}
+
+		void **result = (void **)malloc(capacity * sizeof(void *));
+		if (!result) {
+			if (windowsValue)
+				CFRelease(windowsValue);
+			if (focusedWindow)
+				CFRelease(focusedWindow);
+			if (shouldReleaseAppRef && appRef)
+				CFRelease(appRef);
+			else if (focusedApp)
+				CFRelease(focusedApp);
+			return NULL;
+		}
+
+		if (focusedWindow) {
+			result[*count] = (void *)focusedWindow;
+			(*count)++;
+		} else if (windowCount > 0) {
+			AXUIElementRef firstWindow = (AXUIElementRef)CFArrayGetValueAtIndex(windows, 0);
+			if (firstWindow) {
+				CFRetain(firstWindow);
+				result[*count] = (void *)firstWindow;
+				(*count)++;
+			}
+		}
+
+		for (CFIndex i = 0; i < windowCount; i++) {
+			AXUIElementRef window = (AXUIElementRef)CFArrayGetValueAtIndex(windows, i);
+			if (!window)
+				continue;
+
+			if (focusedWindow && CFEqual(window, focusedWindow))
+				continue;
+			if (!focusedWindow && i == 0)
+				continue;
+
+			CFTypeRef roleValue = NULL;
+			if (AXUIElementCopyAttributeValue(window, kAXRoleAttribute, &roleValue) != kAXErrorSuccess || !roleValue) {
+				continue;
+			}
+
+			bool isPopover = CFGetTypeID(roleValue) == CFStringGetTypeID() &&
+			                 CFStringCompare((CFStringRef)roleValue, CFSTR("AXPopover"), 0) == kCFCompareEqualTo;
+			CFRelease(roleValue);
+
+			if (!isPopover)
+				continue;
+
+			CFRetain(window);
+			result[*count] = (void *)window;
+			(*count)++;
+		}
+
+		if (windowsValue)
+			CFRelease(windowsValue);
+
+		if (shouldReleaseAppRef && appRef)
+			CFRelease(appRef);
+		else if (focusedApp)
+			CFRelease(focusedApp);
+
+		if (*count == 0) {
+			free(result);
+			return NULL;
+		}
+
+		return result;
+	}
+}
+
 /// Get frontmost window
 /// @return Frontmost window reference
 void *getFrontmostWindow(void) {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR improves hints mode activation latency by cutting duplicate work in the AX-heavy path, the following are the paths that I optimised.

- Separates hint generation from overlay drawing so activation filters to the active screen before the first render.
- Avoids an extra full overlay draw during hints activation, screen-change refresh, and monitor-move refresh.
- Queries frontmost window plus popovers through one call instead of separate frontmost/all-window/role calls.
- Runs supplementary AX sources concurrently while preserving stable result ordering.
- Avoids per-candidate bundle ID lookups when deciding whether to skip clickability checks.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
