### PR TITLE
refactor: removed unneeded `accessibility_check_on_start`

### DIFF
--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -75,7 +75,7 @@ func LaunchDaemon(configPath string) {
 		configResult = handleConfigOnboarding(service, configResult)
 	}
 
-	handleAccessibilityPermissionStartup(configResult.Config)
+	handleAccessibilityPermissionStartup()
 
 	app, appErr := app.New(
 		app.WithConfig(configResult.Config),
@@ -157,8 +157,8 @@ func promptConfigInit(configPath string) bool {
 	return false
 }
 
-func handleAccessibilityPermissionStartup(cfg *config.Config) {
-	if !platform.IsDarwin() || cfg == nil || !cfg.General.AccessibilityCheckOnStart {
+func handleAccessibilityPermissionStartup() {
+	if !platform.IsDarwin() {
 		return
 	}
 

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -8,7 +8,6 @@
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#general-settings
 [general]
 excluded_apps = []                           # Bundle IDs to ignore (e.g. "com.apple.Terminal")
-accessibility_check_on_start = true          # Verify AX permissions on launch
 kb_layout_to_use = ""                        # Force a keyboard layout InputSourceID (empty = auto)
 passthrough_unbounded_keys = false           # Let unbound Cmd/Ctrl/Alt shortcuts reach macOS
 should_exit_after_passthrough = false        # Exit the current mode after a shortcut is passed through

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -305,7 +305,6 @@ Core behaviour settings that affect all Neru functionality.
 | Option                                 | Type   | Default | Description                                            |
 | -------------------------------------- | ------ | ------- | ------------------------------------------------------ |
 | `excluded_apps`                        | array  | `[]`    | Bundle IDs where Neru won't activate                   |
-| `accessibility_check_on_start`         | bool   | `true`  | Verify accessibility permissions on launch             |
 | `kb_layout_to_use`                     | string | `""`    | Optional InputSourceID for layout mapping              |
 | `hide_overlay_in_screen_share`         | bool   | `false` | Hide overlay in screen sharing apps                    |
 | `passthrough_unbounded_keys`           | bool   | `false` | Let unbound modifier shortcuts pass through            |

--- a/internal/app/app_initialization_integration_darwin_test.go
+++ b/internal/app/app_initialization_integration_darwin_test.go
@@ -20,7 +20,6 @@ func TestAppInitializationWithRealComponentsIntegration(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Hints.Enabled = true
 	cfg.Grid.Enabled = true
-	cfg.General.AccessibilityCheckOnStart = false // Skip OS permission checks
 
 	// Initialize the app with real components but mock the problematic ones
 	application, err := app.New(
@@ -79,7 +78,6 @@ func TestAppInitializationWithRealComponentsIntegration(t *testing.T) {
 		cfg2 := config.DefaultConfig()
 		cfg2.Hints.Enabled = true
 		cfg2.Grid.Enabled = false
-		cfg2.General.AccessibilityCheckOnStart = false
 
 		application2, err := app.New(
 			app.WithConfig(cfg2),
@@ -112,7 +110,6 @@ func TestAppInitialization_Systray(t *testing.T) {
 	t.Run("Systray Enabled (Default)", func(t *testing.T) {
 		cfg := config.DefaultConfig()
 		cfg.Systray.Enabled = true // Explicitly set, though default is true
-		cfg.General.AccessibilityCheckOnStart = false
 
 		appInstance, err := app.New(
 			app.WithConfig(cfg),
@@ -135,7 +132,6 @@ func TestAppInitialization_Systray(t *testing.T) {
 	t.Run("Systray Disabled", func(t *testing.T) {
 		cfg := config.DefaultConfig()
 		cfg.Systray.Enabled = false
-		cfg.General.AccessibilityCheckOnStart = false
 
 		appInstance, err := app.New(
 			app.WithConfig(cfg),

--- a/internal/app/app_lifecycle_integration_darwin_test.go
+++ b/internal/app/app_lifecycle_integration_darwin_test.go
@@ -59,7 +59,6 @@ func runTestAppInitializationIntegration(t *testing.T, ctx context.Context) {
 	cfg := config.DefaultConfig()
 	cfg.Hints.Enabled = true
 	cfg.Grid.Enabled = true
-	cfg.General.AccessibilityCheckOnStart = false // Skip OS permission checks
 
 	// Test that app initialization completes within reasonable time
 	done := make(chan initResult, 1)
@@ -128,7 +127,6 @@ func TestApp_ModeTransitions(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Hints.Enabled = true
 	cfg.Grid.Enabled = true
-	cfg.General.AccessibilityCheckOnStart = false // Disable OS check
 
 	// Create app with timeout protection
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/app/grid_mode_integration_darwin_test.go
+++ b/internal/app/grid_mode_integration_darwin_test.go
@@ -20,7 +20,6 @@ func TestGridModeEndToEnd(t *testing.T) {
 	// Create config with grid enabled
 	cfg := config.DefaultConfig()
 	cfg.Grid.Enabled = true
-	cfg.General.AccessibilityCheckOnStart = false
 
 	// Initialize the app with real components but mock the problematic ones
 	application, err := app.New(

--- a/internal/app/hotkey_integration_darwin_test.go
+++ b/internal/app/hotkey_integration_darwin_test.go
@@ -20,7 +20,6 @@ func TestHotkeyIntegration(t *testing.T) {
 	mockHotkeys := &mockHotkeyService{}
 
 	cfg := config.DefaultConfig()
-	cfg.General.AccessibilityCheckOnStart = false
 
 	application, err := app.New(
 		app.WithConfig(cfg),

--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -50,17 +50,6 @@ func initializeOverlayManager(logger *zap.Logger) OverlayManager {
 
 // initializeAccessibility checks and configures accessibility permissions and settings.
 func initializeAccessibility(cfg *config.Config, logger *zap.Logger) error {
-	if cfg.General.AccessibilityCheckOnStart {
-		if !accessibilityAdapter.CheckAccessibilityPermissions() {
-			logger.Warn(
-				"Accessibility permissions not granted. Please grant permissions in System Settings.",
-			)
-			logger.Info("⚠️  Neru requires Accessibility permissions to function.")
-			logger.Info("Please go to: System Settings → Privacy & Security → Accessibility")
-			logger.Info("and enable Neru.")
-		}
-	}
-
 	// Apply clickable roles if hints are enabled
 	if cfg.Hints.Enabled {
 		logger.Info("Applying clickable roles",

--- a/internal/app/lifecycle_integration_darwin_test.go
+++ b/internal/app/lifecycle_integration_darwin_test.go
@@ -20,7 +20,6 @@ func TestAppLifecycleIntegration(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Hints.Enabled = true
 	cfg.Grid.Enabled = true
-	cfg.General.AccessibilityCheckOnStart = false
 
 	// Create app
 	application, err := app.New(

--- a/internal/app/passthrough_integration_darwin_test.go
+++ b/internal/app/passthrough_integration_darwin_test.go
@@ -17,7 +17,7 @@ func TestExitAfterPassthroughIntegration(t *testing.T) {
 	}
 
 	cfg := config.DefaultConfig()
-	cfg.General.AccessibilityCheckOnStart = false
+
 	cfg.General.PassthroughUnboundedKeys = true
 	cfg.General.ShouldExitAfterPassthrough = true
 
@@ -52,7 +52,7 @@ func TestStalePassthroughCallbackDoesNotExitNewModeIntegration(t *testing.T) {
 	}
 
 	cfg := config.DefaultConfig()
-	cfg.General.AccessibilityCheckOnStart = false
+
 	cfg.General.PassthroughUnboundedKeys = true
 	cfg.General.ShouldExitAfterPassthrough = true
 

--- a/internal/app/scroll_mode_integration_darwin_test.go
+++ b/internal/app/scroll_mode_integration_darwin_test.go
@@ -19,7 +19,6 @@ func TestScrollModeEndToEnd(t *testing.T) {
 
 	// Create config with scroll mode enabled (scroll mode doesn't have a specific enable flag)
 	cfg := config.DefaultConfig()
-	cfg.General.AccessibilityCheckOnStart = false
 
 	// Initialize the app with real components but mock the problematic ones
 	application, err := app.New(

--- a/internal/app/services/services_integration_darwin_test.go
+++ b/internal/app/services/services_integration_darwin_test.go
@@ -42,7 +42,6 @@ func TestHintServiceIntegration(t *testing.T) {
 	// Create real adapters (they will be initialized with real infra)
 	cfg := config.DefaultConfig()
 	cfg.Hints.Enabled = true
-	cfg.General.AccessibilityCheckOnStart = false
 
 	// Initialize real adapters like the app does
 	accAdapter, overlay, systemPort := initializeRealAdapters(t, cfg, logger)
@@ -130,7 +129,6 @@ func TestActionServiceIntegration(t *testing.T) {
 	logger := logger.Get()
 
 	cfg := config.DefaultConfig()
-	cfg.General.AccessibilityCheckOnStart = false
 
 	accAdapter, overlayAdapter, systemPort := initializeRealAdapters(t, cfg, logger)
 
@@ -200,7 +198,6 @@ func TestGridServiceIntegration(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.Grid.Enabled = true
-	cfg.General.AccessibilityCheckOnStart = false
 
 	// Initialize real adapters
 	_, overlay, systemPort := initializeRealAdapters(t, cfg, logger)
@@ -234,7 +231,6 @@ func TestScrollServiceIntegration(t *testing.T) {
 	logger := logger.Get()
 
 	cfg := config.DefaultConfig()
-	cfg.General.AccessibilityCheckOnStart = false
 
 	// Initialize real adapters
 	accAdapter, overlay, systemPort := initializeRealAdapters(t, cfg, logger)

--- a/internal/app/workflow_integration_darwin_test.go
+++ b/internal/app/workflow_integration_darwin_test.go
@@ -27,7 +27,6 @@ func TestFullUserWorkflowIntegration(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Hints.Enabled = true
 	cfg.Grid.Enabled = true
-	cfg.General.AccessibilityCheckOnStart = false // Skip OS permission checks
 
 	// Initialize the app with real components but mock problematic ones
 	application, err := app.New(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -422,7 +422,6 @@ type ThemeConfig struct {
 // GeneralConfig defines general application-wide settings.
 type GeneralConfig struct {
 	ExcludedApps                      []string `json:"excludedApps"                      toml:"excluded_apps"`
-	AccessibilityCheckOnStart         bool     `json:"accessibilityCheckOnStart"         toml:"accessibility_check_on_start"`
 	PassthroughUnboundedKeys          bool     `json:"passthroughUnboundedKeys"          toml:"passthrough_unbounded_keys"`
 	ShouldExitAfterPassthrough        bool     `json:"shouldExitAfterPassthrough"        toml:"should_exit_after_passthrough"`
 	PassthroughUnboundedKeysBlacklist []string `json:"passthroughUnboundedKeysBlacklist" toml:"passthrough_unbounded_keys_blacklist"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -266,7 +266,6 @@ func newDefaultConfig() *Config {
 	return &Config{
 		General: GeneralConfig{
 			ExcludedApps:                      []string{},
-			AccessibilityCheckOnStart:         true,
 			PassthroughUnboundedKeys:          false,
 			ShouldExitAfterPassthrough:        false,
 			PassthroughUnboundedKeysBlacklist: []string{},

--- a/internal/config/config_integration_test.go
+++ b/internal/config/config_integration_test.go
@@ -40,7 +40,6 @@ func TestConfigFileOperationsIntegration(t *testing.T) {
 		// Create a test config file with custom settings
 		configContent := `
 [general]
-accessibility_check_on_start = false
 excluded_apps = ["com.apple.finder", "com.test.app"]
 
 [hints]


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR removes all the references to `accessibility_check_on_start` config option. This was introduced in the early days of the project, and it is no longer needed anymore now.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
