### PR TITLE
feat(hints): add support for screen capture thumbnail

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -56,6 +56,7 @@ include_dock_hints = false
 include_nc_hints = false
 include_stage_manager_hints = false
 include_pip_hints = false
+include_screen_capture_hints = false
 detect_mission_control = false
 clickable_roles = [
     "AXButton",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -338,6 +338,7 @@ You can also start hints mode with the search input shown immediately by using t
 | `include_nc_hints`                 | bool   | `false`       | Show hints in Notification Center                    |
 | `include_stage_manager_hints`      | bool   | `false`       | Show hints in Stage Manager                          |
 | `include_pip_hints`                | bool   | `false`       | Show hints on macOS Picture in Picture controls      |
+| `include_screen_capture_hints`     | bool   | `false`       | Show hints on macOS Screen Capture controls          |
 | `detect_mission_control`           | bool   | `false`       | Auto-disable hints when in Mission Control           |
 | `additional_menubar_hints_targets` | array  | see defaults  | Extra menubar bundle IDs                             |
 | `clickable_roles`                  | array  | see defaults  | AX roles that generate hints                         |
@@ -390,19 +391,19 @@ osascript -e 'id of app "Safari"'
 
 ### UI Options
 
-| Option               | Type   | Default | Description                          |
-| -------------------- | ------ | ------- | ------------------------------------ |
-| `font_size`          | int    | `10`    | Font size in points                  |
-| `font_family`        | string | `""`    | Font family (empty = system default) |
-| `border_radius`      | int    | `-1`    | Corner radius (-1 = auto)            |
-| `padding_x`          | int    | `-1`    | Horizontal padding (-1 = auto)       |
-| `padding_y`          | int    | `-1`    | Vertical padding (-1 = auto)         |
-| `border_width`       | int    | `1`     | Border width in pixels               |
-| `placement`          | string | `bottom` | Label placement relative to target  |
-| `background_color`   | color  | derived | Background color with alpha          |
-| `text_color`         | color  | derived | Text color                           |
-| `matched_text_color` | color  | derived | Text color for matched characters    |
-| `border_color`       | color  | derived | Border color                         |
+| Option               | Type   | Default  | Description                          |
+| -------------------- | ------ | -------- | ------------------------------------ |
+| `font_size`          | int    | `10`     | Font size in points                  |
+| `font_family`        | string | `""`     | Font family (empty = system default) |
+| `border_radius`      | int    | `-1`     | Corner radius (-1 = auto)            |
+| `padding_x`          | int    | `-1`     | Horizontal padding (-1 = auto)       |
+| `padding_y`          | int    | `-1`     | Vertical padding (-1 = auto)         |
+| `border_width`       | int    | `1`      | Border width in pixels               |
+| `placement`          | string | `bottom` | Label placement relative to target   |
+| `background_color`   | color  | derived  | Background color with alpha          |
+| `text_color`         | color  | derived  | Text color                           |
+| `matched_text_color` | color  | derived  | Text color for matched characters    |
+| `border_color`       | color  | derived  | Border color                         |
 
 Valid placements: `top`, `center`, `bottom`.
 
@@ -424,8 +425,8 @@ border_color = "#0B2377"
 Optional target boundary highlights can make dense or ambiguous hint layouts
 easier to read. They are off by default to keep hints mode quiet.
 
-| Option             | Type  | Default | Description                              |
-| ------------------ | ----- | ------- | ---------------------------------------- |
+| Option             | Type  | Default | Description                             |
+| ------------------ | ----- | ------- | --------------------------------------- |
 | `enabled`          | bool  | `false` | Draw target element boundaries          |
 | `border_width`     | int   | `1`     | Boundary stroke width in pixels         |
 | `border_radius`    | int   | `-1`    | Boundary corner radius (-1 = auto pill) |
@@ -443,12 +444,12 @@ The search input uses `[hints.search_input_ui]` with the same visual options as
 `[hints.ui]`, except `matched_text_color`. It also supports active-screen
 placement:
 
-| Option     | Type   | Default         | Description                                      |
-| ---------- | ------ | --------------- | ------------------------------------------------ |
-| `position` | string | `"bottom_center"` | Anchor on active screen                          |
-| `x_offset` | int    | `0`            | Horizontal offset from the anchor                |
-| `y_offset` | int    | `24`           | Vertical offset from the anchor                  |
-| `width`    | int    | `320`          | Search input width in pixels                     |
+| Option     | Type   | Default           | Description                       |
+| ---------- | ------ | ----------------- | --------------------------------- |
+| `position` | string | `"bottom_center"` | Anchor on active screen           |
+| `x_offset` | int    | `0`               | Horizontal offset from the anchor |
+| `y_offset` | int    | `24`              | Vertical offset from the anchor   |
+| `width`    | int    | `320`             | Search input width in pixels      |
 
 Valid positions: `top_left`, `top_center`, `top_right`, `center`,
 `bottom_left`, `bottom_center`, `bottom_right`.
@@ -880,12 +881,12 @@ Mouse action indicators show a transient visual marker where a mouse button acti
 > [!NOTE]
 > Currently rendered on **macOS only**. Other platforms accept the config and no-op.
 
-| Option    | Type     | Default                                                                 | Description                              |
-| --------- | -------- | ----------------------------------------------------------------------- | ---------------------------------------- |
-| `enabled` | bool     | `false`                                                                 | Enable mouse action indicators           |
-| `actions` | string[] | all mouse button actions                                                | Actions that should show the indicator   |
-| `ui`      | table    | see below                                                               | Visual styling                           |
-| `animation` | table  | see below                                                               | Animation timing and interpolation       |
+| Option      | Type     | Default                  | Description                            |
+| ----------- | -------- | ------------------------ | -------------------------------------- |
+| `enabled`   | bool     | `false`                  | Enable mouse action indicators         |
+| `actions`   | string[] | all mouse button actions | Actions that should show the indicator |
+| `ui`        | table    | see below                | Visual styling                         |
+| `animation` | table    | see below                | Animation timing and interpolation     |
 
 ```toml
 [mouse_action_indicator]

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -131,6 +131,7 @@ func (s *HintService) GenerateHints(
 	filter.IncludeNotificationCenter = cfg.IncludeNCHints
 	filter.IncludeStageManager = cfg.IncludeStageManagerHints
 	filter.IncludePIP = cfg.IncludePIPHints
+	filter.IncludeScreenCapture = cfg.IncludeScreenCaptureHints
 
 	// Apply text filter if provided (OR match - element matches if any text contains match)
 	if len(filterTextContains) > 0 {
@@ -236,7 +237,8 @@ func (s *HintService) UpdateConfig(config config.HintsConfig) {
 		zap.Bool("include_dock", config.IncludeDockHints),
 		zap.Bool("include_nc", config.IncludeNCHints),
 		zap.Bool("include_stage_manager", config.IncludeStageManagerHints),
-		zap.Bool("include_pip", config.IncludePIPHints))
+		zap.Bool("include_pip", config.IncludePIPHints),
+		zap.Bool("include_screen_capture", config.IncludeScreenCaptureHints))
 }
 
 // UpdateGenerator updates the hint generator.

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -191,6 +191,10 @@ func TestHintService_ShowHints(t *testing.T) {
 						t.Error("IncludePIP should be true based on config")
 					}
 
+					if !filter.IncludeScreenCapture {
+						t.Error("IncludeScreenCapture should be true based on config")
+					}
+
 					return testElements, nil
 				}
 			},
@@ -200,11 +204,12 @@ func TestHintService_ShowHints(t *testing.T) {
 				return gen
 			},
 			config: config.HintsConfig{
-				IncludeMenubarHints:      true,
-				IncludeDockHints:         true,
-				IncludeNCHints:           true,
-				IncludeStageManagerHints: true,
-				IncludePIPHints:          true,
+				IncludeMenubarHints:       true,
+				IncludeDockHints:          true,
+				IncludeNCHints:            true,
+				IncludeStageManagerHints:  true,
+				IncludePIPHints:           true,
+				IncludeScreenCaptureHints: true,
 			},
 			wantErr:       false,
 			wantHintCount: 3,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -576,6 +576,7 @@ type HintsConfig struct {
 	IncludeNCHints                bool     `json:"includeNcHints"                toml:"include_nc_hints"`
 	IncludeStageManagerHints      bool     `json:"includeStageManagerHints"      toml:"include_stage_manager_hints"`
 	IncludePIPHints               bool     `json:"includePipHints"               toml:"include_pip_hints"`
+	IncludeScreenCaptureHints     bool     `json:"includeScreenCaptureHints"     toml:"include_screen_capture_hints"`
 	DetectMissionControl          bool     `json:"detectMissionControl"          toml:"detect_mission_control"`
 
 	ClickableRoles       []string `json:"clickableRoles"       toml:"clickable_roles"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -345,6 +345,7 @@ func newDefaultConfig() *Config {
 			IncludeNCHints:                false,
 			IncludeStageManagerHints:      false,
 			IncludePIPHints:               false,
+			IncludeScreenCaptureHints:     false,
 			DetectMissionControl:          false,
 
 			ClickableRoles: []string{},

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -216,7 +216,7 @@ func (a *Adapter) ClickableElements(
 	// AdditionalMenubarTargets only produces elements when IncludeMenubar is true
 	hasAdditionalTargets := filter.IncludeMenubar && len(filter.AdditionalMenubarTargets) > 0
 	if filter.IncludeMenubar || filter.IncludeDock || filter.IncludeStageManager ||
-		filter.IncludeNotificationCenter || filter.IncludePIP || hasAdditionalTargets {
+		filter.IncludeNotificationCenter || filter.IncludePIP || filter.IncludeScreenCapture || hasAdditionalTargets {
 		waitGroup.Add(1)
 
 		go func() {

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -371,7 +371,7 @@ func (a *Adapter) addPIPElements(
 	return elements
 }
 
-// addScreenCaptureElements makes the screenpacture small ui clickable.
+// addScreenCaptureElements makes the screencapture small ui clickable.
 func (a *Adapter) addScreenCaptureElements(
 	_ context.Context,
 	elements []*element.Element,

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -25,7 +25,8 @@ func (a *Adapter) addSupplementaryElements(
 		zap.Bool("include_dock", filter.IncludeDock),
 		zap.Bool("include_nc", filter.IncludeNotificationCenter),
 		zap.Bool("include_stage_manager", filter.IncludeStageManager),
-		zap.Bool("include_pip", filter.IncludePIP))
+		zap.Bool("include_pip", filter.IncludePIP),
+		zap.Bool("include_screen_capture", filter.IncludeScreenCapture))
 
 	type supplementarySource struct {
 		enabled bool

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -65,6 +65,12 @@ func (a *Adapter) addSupplementaryElements(
 				return a.addPIPElements(ctx, nil)
 			},
 		},
+		{
+			enabled: filter.IncludeScreenCapture,
+			load: func() []*element.Element {
+				return a.addScreenCaptureElements(ctx, nil)
+			},
+		},
 	}
 
 	results := make([][]*element.Element, len(sources))
@@ -361,6 +367,43 @@ func (a *Adapter) addPIPElements(
 	}
 
 	a.logger.Debug("Included Picture in Picture elements", zap.Int("count", len(pipNodes)))
+
+	return elements
+}
+
+// addScreenCaptureElements makes the screenpacture small ui clickable.
+func (a *Adapter) addScreenCaptureElements(
+	_ context.Context,
+	elements []*element.Element,
+) []*element.Element {
+	const screenCaptureBundleID = "com.apple.screencaptureui"
+
+	screenCaptureNodes, screenCaptureNodesErr := a.client.ClickableElementsFromBundleID(
+		screenCaptureBundleID,
+		nil,
+		false,
+	)
+	if screenCaptureNodesErr != nil {
+		a.logger.Warn("Failed to get Screen Capture elements", zap.Error(screenCaptureNodesErr))
+
+		return elements
+	}
+
+	for _, node := range screenCaptureNodes {
+		element, elementErr := a.convertToDomainElement(node)
+
+		node.Release()
+
+		if elementErr != nil {
+			a.logger.Warn("Failed to convert Screen Capture element", zap.Error(elementErr))
+
+			continue
+		}
+
+		elements = append(elements, element)
+	}
+
+	a.logger.Debug("Included Screen Capture elements", zap.Int("count", len(screenCaptureNodes)))
 
 	return elements
 }

--- a/internal/core/infra/accessibility/adapter_test.go
+++ b/internal/core/infra/accessibility/adapter_test.go
@@ -559,4 +559,29 @@ func TestAdapter_RolePassing(t *testing.T) {
 			)
 		}
 	})
+
+	t.Run("Screen Capture Elements", func(t *testing.T) {
+		mockClient.LastCalledBundleID = ""
+		mockClient.LastBundleRoles = nil
+
+		filter := ports.ElementFilter{
+			IncludeScreenCapture: true,
+		}
+
+		_, _ = adapter.ClickableElements(ctx, filter)
+
+		if mockClient.LastCalledBundleID != "com.apple.screencaptureui" {
+			t.Errorf(
+				"Expected Screen Capture supplementary query to use com.apple.screencaptureui, got: %q",
+				mockClient.LastCalledBundleID,
+			)
+		}
+
+		if mockClient.LastBundleRoles != nil {
+			t.Errorf(
+				"Expected Screen Capture query to pass nil roles (no role restriction), got: %v",
+				mockClient.LastBundleRoles,
+			)
+		}
+	})
 }

--- a/internal/core/ports/accessibility.go
+++ b/internal/core/ports/accessibility.go
@@ -107,6 +107,11 @@ type ElementFilter struct {
 	// Platform equivalents on Linux/Windows are not yet mapped.
 	IncludePIP bool
 
+	// IncludeScreenCapture includes screen capture controls.
+	// On macOS this queries com.apple.screencaptureui.
+	// Platform equivalents on Linux/Windows are not yet mapped.
+	IncludeScreenCapture bool
+
 	// TitleContains filters elements whose title contains this substring (case-insensitive).
 	TitleContains string
 
@@ -134,5 +139,6 @@ func DefaultElementFilter() ElementFilter {
 		IncludeNotificationCenter: false,
 		IncludeStageManager:       false,
 		IncludePIP:                false,
+		IncludeScreenCapture:      false,
 	}
 }

--- a/internal/core/ports/accessibility_test.go
+++ b/internal/core/ports/accessibility_test.go
@@ -49,6 +49,10 @@ func TestDefaultElementFilter(t *testing.T) {
 		t.Error("Expected IncludePIP to be false by default")
 	}
 
+	if filter.IncludeScreenCapture {
+		t.Error("Expected IncludeScreenCapture to be false by default")
+	}
+
 	// Check that slices are initialized
 	if filter.Roles != nil {
 		t.Error("Expected Roles to be nil by default")
@@ -72,6 +76,7 @@ func TestElementFilterStruct(t *testing.T) {
 		IncludeNotificationCenter: true,
 		IncludeStageManager:       true,
 		IncludePIP:                true,
+		IncludeScreenCapture:      true,
 	}
 
 	if len(filter.Roles) != 1 || filter.Roles[0] != element.RoleButton {
@@ -116,6 +121,10 @@ func TestElementFilterStruct(t *testing.T) {
 
 	if !filter.IncludePIP {
 		t.Error("Expected IncludePIP to be true")
+	}
+
+	if !filter.IncludeScreenCapture {
+		t.Error("Expected IncludeScreenCapture to be true")
 	}
 }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a new opt-in flag to include hints for the small thumbnail after a screen capture is done natively.

```toml
[hints]
include_screen_capture_hints = true # default: false
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/31ca1a46-ac17-47a7-b694-38709e0237de

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
