### PR TITLE
feat(hints): add neru own bundle to menubar targets

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -51,6 +51,7 @@ additional_menubar_hints_targets = [
     "com.apple.TextInputMenuAgent",
     "com.apple.controlcenter",
     "com.apple.systemuiserver",
+	"com.y3owk1n.neru",
 ]
 include_dock_hints = false
 include_nc_hints = false

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -51,7 +51,7 @@ additional_menubar_hints_targets = [
     "com.apple.TextInputMenuAgent",
     "com.apple.controlcenter",
     "com.apple.systemuiserver",
-	"com.y3owk1n.neru",
+    "com.y3owk1n.neru",
 ]
 include_dock_hints = false
 include_nc_hints = false

--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -16,10 +16,10 @@ include_pip_hints = false
 include_screen_capture_hints = false
 detect_mission_control = false             # Skip frontmost window hints when Mission Control is active
 additional_menubar_hints_targets = [
-	"com.apple.TextInputMenuAgent",
-	"com.apple.controlcenter",
-	"com.apple.systemuiserver",
-	"com.y3owk1n.neru",
+    "com.apple.TextInputMenuAgent",
+    "com.apple.controlcenter",
+    "com.apple.systemuiserver",
+    "com.y3owk1n.neru",
 ]
 clickable_roles = [
     "AXButton",

--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -12,8 +12,8 @@ include_menubar_hints = true               # Show hints on menubar
 include_dock_hints = true                  # Show hints on Dock and Mission Control
 include_nc_hints = true                    # Show hints on Notification Center
 include_stage_manager_hints = true         # Include stage manager items in hints
-include_pip_hints = false
-include_screen_capture_hints = false
+include_pip_hints = true
+include_screen_capture_hints = true
 detect_mission_control = false             # Skip frontmost window hints when Mission Control is active
 additional_menubar_hints_targets = [
     "com.apple.TextInputMenuAgent",

--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -12,11 +12,14 @@ include_menubar_hints = true               # Show hints on menubar
 include_dock_hints = true                  # Show hints on Dock and Mission Control
 include_nc_hints = true                    # Show hints on Notification Center
 include_stage_manager_hints = true         # Include stage manager items in hints
+include_pip_hints = false
+include_screen_capture_hints = false
 detect_mission_control = false             # Skip frontmost window hints when Mission Control is active
 additional_menubar_hints_targets = [
-  "com.apple.TextInputMenuAgent",
-  "com.apple.controlcenter",
-  "com.apple.systemuiserver",
+	"com.apple.TextInputMenuAgent",
+	"com.apple.controlcenter",
+	"com.apple.systemuiserver",
+	"com.y3owk1n.neru",
 ]
 clickable_roles = [
     "AXButton",

--- a/internal/config/config_darwin.go
+++ b/internal/config/config_darwin.go
@@ -8,6 +8,7 @@ func applyPlatformDefaults(cfg *Config) {
 		"com.apple.TextInputMenuAgent",
 		"com.apple.controlcenter",
 		"com.apple.systemuiserver",
+		"com.y3owk1n.neru",
 	)
 
 	cfg.Hints.ClickableRoles = append(cfg.Hints.ClickableRoles,


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds Neru own bundle to the additional menubar target list, so that when in hints mode, neru menubar icon can get labels.

Note that this only works within bundle, running it via bin will not work.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
