### PR TITLE
perf(hints): optimise AX API calls

### DIFF
--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -112,10 +112,14 @@ func (s *HintService) GenerateHints(
 	}
 
 	if shouldClearCache {
-		s.accessibility.ClearCache()
 		s.lastFocusedAppBundleID = bundleID
 	}
 	s.mu.Unlock()
+
+	// Clear cache outside the lock to avoid lock-ordering dependency with cache's internal mutex.
+	if shouldClearCache {
+		s.accessibility.ClearCache()
+	}
 
 	// Use filterRoles if provided, otherwise use configured roles
 	var roles []string

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -81,10 +81,10 @@ func (s *HintService) GenerateHints(
 	filterRoles []string,
 	filterTextContains []string,
 ) ([]*hint.Interface, error) {
-	s.mu.RLock()
+	s.mu.Lock()
 	cfg := s.config
 	gen := s.generator
-	s.mu.RUnlock()
+	s.mu.Unlock()
 
 	filter := ports.DefaultElementFilter()
 
@@ -102,6 +102,8 @@ func (s *HintService) GenerateHints(
 	// which significantly speeds up repeated activations in the same app.
 	// Cache still auto-expires based on TTL (30s for static elements).
 	shouldClearCache := true
+
+	s.mu.Lock()
 	if s.lastFocusedAppBundleID != "" && s.lastFocusedAppBundleID == bundleID {
 		shouldClearCache = false
 
@@ -113,6 +115,7 @@ func (s *HintService) GenerateHints(
 		s.accessibility.ClearCache()
 		s.lastFocusedAppBundleID = bundleID
 	}
+	s.mu.Unlock()
 
 	// Use filterRoles if provided, otherwise use configured roles
 	var roles []string

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -81,10 +81,10 @@ func (s *HintService) GenerateHints(
 	filterRoles []string,
 	filterTextContains []string,
 ) ([]*hint.Interface, error) {
-	s.mu.Lock()
+	s.mu.RLock()
 	cfg := s.config
 	gen := s.generator
-	s.mu.Unlock()
+	s.mu.RUnlock()
 
 	filter := ports.DefaultElementFilter()
 

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -18,10 +18,11 @@ import (
 type HintService struct {
 	BaseService
 
-	mu        sync.RWMutex
-	generator hint.Generator
-	config    config.HintsConfig
-	logger    *zap.Logger
+	mu                     sync.RWMutex
+	generator              hint.Generator
+	config                 config.HintsConfig
+	logger                 *zap.Logger
+	lastFocusedAppBundleID string
 }
 
 // NewHintService creates a new hint service with the given dependencies.
@@ -85,12 +86,6 @@ func (s *HintService) GenerateHints(
 	gen := s.generator
 	s.mu.RUnlock()
 
-	// Clear the accessibility cache before querying elements to ensure fresh
-	// position data. Without this, elements that moved due to scrolling would
-	// retain their stale pre-scroll positions from the cache (StaticElementTTL
-	// is 30s), causing hint labels to appear at wrong locations.
-	s.accessibility.ClearCache()
-
 	filter := ports.DefaultElementFilter()
 
 	// Populate filter with configuration
@@ -100,6 +95,23 @@ func (s *HintService) GenerateHints(
 			"Failed to get focused app bundle ID for hints roles",
 			zap.Error(bundleIDErr),
 		)
+	}
+
+	// Smart cache clearing: only clear if focused app changed
+	// This avoids clearing cache when user is still in same app (e.g., scrolling)
+	// which significantly speeds up repeated activations in the same app.
+	// Cache still auto-expires based on TTL (30s for static elements).
+	shouldClearCache := true
+	if s.lastFocusedAppBundleID != "" && s.lastFocusedAppBundleID == bundleID {
+		shouldClearCache = false
+
+		s.logger.Debug("Skipping cache clear - same app as last activation",
+			zap.String("bundle_id", bundleID))
+	}
+
+	if shouldClearCache {
+		s.accessibility.ClearCache()
+		s.lastFocusedAppBundleID = bundleID
 	}
 
 	// Use filterRoles if provided, otherwise use configured roles

--- a/internal/core/infra/accessibility/cache.go
+++ b/internal/core/infra/accessibility/cache.go
@@ -512,6 +512,10 @@ func (c *InfoCache) SetClickable(elem *Element, isClickable bool) {
 					heap.Fix(&c.expirationQueue, cached.heapIndex)
 				}
 			}
+			// If cached.info is nil, the element is not yet in the info cache
+			// (Set was never called). SetClickable only stores the result for
+			// elements that already have an info entry; the next IsClickable
+			// call will re-run hasClickAction.
 
 			return
 		}

--- a/internal/core/infra/accessibility/cache.go
+++ b/internal/core/infra/accessibility/cache.go
@@ -53,6 +53,7 @@ type cacheStats struct {
 // CachedInfo wraps ElementInfo with an expiration timestamp and LRU tracking for caching.
 type CachedInfo struct {
 	info        *ElementInfo
+	isClickable *bool // nil = not computed, true/false = cached result
 	expiresAt   time.Time
 	key         uint64
 	elementRef  *Element      // Retained reference for equality checks
@@ -440,6 +441,81 @@ func (c *InfoCache) Size() int {
 // Stats returns the current cache statistics.
 func (c *InfoCache) Stats() *cacheStats {
 	return c.stats
+}
+
+// GetClickable returns the cached isClickable result for an element.
+// Returns nil if not cached or expired.
+func (c *InfoCache) GetClickable(elem *Element) *bool {
+	if elem == nil {
+		return nil
+	}
+
+	hash, err := elem.Hash()
+	if err != nil {
+		return nil
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.stopped {
+		return nil
+	}
+
+	bucket, exists := c.data[hash]
+	if !exists {
+		return nil
+	}
+
+	for _, cached := range bucket {
+		if elem.Equal(cached.elementRef) {
+			if time.Now().After(cached.expiresAt) {
+				return nil
+			}
+
+			return cached.isClickable
+		}
+	}
+
+	return nil
+}
+
+// SetClickable caches the isClickable result for an element.
+// Uses the same TTL logic as Set for the info to keep them in sync.
+func (c *InfoCache) SetClickable(elem *Element, isClickable bool) {
+	if elem == nil {
+		return
+	}
+
+	hash, err := elem.Hash()
+	if err != nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.stopped {
+		return
+	}
+
+	c.drainPromotions()
+
+	bucket := c.data[hash]
+	for _, cached := range bucket {
+		if elem.Equal(cached.elementRef) {
+			if cached.info != nil {
+				cached.isClickable = &isClickable
+
+				cached.expiresAt = time.Now().Add(c.getTTL(cached.info))
+				if cached.heapIndex >= 0 {
+					heap.Fix(&c.expirationQueue, cached.heapIndex)
+				}
+			}
+
+			return
+		}
+	}
 }
 
 // EmitStats logs aggregate cache statistics at debug level.

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -57,6 +57,10 @@ var knownInteractiveRoles = map[string]struct{}{
 	"AXSlider":             {},
 	"AXIncrementor":        {},
 	"AXColorWell":          {},
+	"AXSearchField":        {},
+	"AXToolbarButton":      {},
+	"AXMenuButton":         {},
+	"AXToggle":             {},
 }
 
 var (
@@ -718,8 +722,20 @@ func (e *Element) IsClickable(
 			}
 		}
 
+		// Try cache for isClickable result (only when using default roles)
+		if cache != nil && len(allowedRoles) == 0 && !ignoreClickableCheck {
+			if cached := cache.GetClickable(e); cached != nil {
+				return *cached
+			}
+		}
+
 		// Slow path: ambiguous or custom roles need full native verification
 		result := C.hasClickAction(e.ref) //nolint:nlreturn
+
+		// Cache the result for future lookups (only when using default roles)
+		if cache != nil && len(allowedRoles) == 0 && !ignoreClickableCheck {
+			cache.SetClickable(e, result == 1)
+		}
 
 		return result == 1
 	}

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -549,15 +549,13 @@ int hasClickAction(void *element) {
 	if (role)
 		CFRelease(role);
 
-	// Visibility check: compute center+pid once and use for both focusable and final check
+	// Visibility check: compute center+pid for each code path that needs it
 	CGPoint center;
 	pid_t pid;
-	bool hasCenterAndPid = false;
 
 	// For focusable elements, check visibility
 	if (isFocusable) {
 		if (getElementCenter((void *)axElement, &center) && AXUIElementGetPid(axElement, &pid) == kAXErrorSuccess) {
-			hasCenterAndPid = true;
 			return isPointVisible(center, pid) ? 1 : 0;
 		}
 		return 0;

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -450,8 +450,9 @@ int hasClickAction(void *element) {
 	        kAXHiddenAttribute,
 	        kAXEnabledAttribute,
 	        kAXRoleAttribute,
+	        kAXFocusableAttribute,
 	    },
-	    3, &kCFTypeArrayCallBacks);
+	    4, &kCFTypeArrayCallBacks);
 
 	if (!initialAttrs)
 		return 0;
@@ -462,6 +463,7 @@ int hasClickAction(void *element) {
 
 	bool isHidden = false;
 	bool isEnabled = true;
+	bool isFocusable = false;
 	CFStringRef role = NULL;
 
 	if (batchError == kAXErrorSuccess && initialValues) {
@@ -486,6 +488,13 @@ int hasClickAction(void *element) {
 			if (roleVal && CFGetTypeID(roleVal) == CFStringGetTypeID()) {
 				role = (CFStringRef)roleVal;
 				CFRetain(role);
+			}
+		}
+
+		if (count > 3 && isEnabled && !isHidden) {
+			CFTypeRef focusableVal = (CFTypeRef)CFArrayGetValueAtIndex(initialValues, 3);
+			if (focusableVal && CFGetTypeID(focusableVal) == CFBooleanGetTypeID()) {
+				isFocusable = CFBooleanGetValue((CFBooleanRef)focusableVal);
 			}
 		}
 
@@ -527,28 +536,7 @@ int hasClickAction(void *element) {
 		return 1;
 	}
 
-	// Focusable and enabled controls are clickable
-	CFBooleanRef focusable = NULL;
-	if (AXUIElementCopyAttributeValue(axElement, kAXFocusableAttribute, (CFTypeRef *)&focusable) == kAXErrorSuccess &&
-	    focusable) {
-		if (CFBooleanGetValue(focusable)) {
-			CFRelease(focusable);
-
-			CGPoint center;
-			pid_t pid;
-			bool visible = true;
-			if (getElementCenter((void *)axElement, &center) && AXUIElementGetPid(axElement, &pid) == kAXErrorSuccess) {
-				visible = isPointVisible(center, pid);
-			}
-
-			if (role)
-				CFRelease(role);
-			return visible ? 1 : 0;
-		}
-		CFRelease(focusable);
-	}
-
-	// Role-specific fallback for links
+	// Role-specific fallback for links - no visibility check needed
 	if (role && CFStringCompare(role, kAXLinkRole, 0) == kCFCompareEqualTo) {
 		CFTypeRef urlAttr = NULL;
 		if (AXUIElementCopyAttributeValue(axElement, kAXURLAttribute, &urlAttr) == kAXErrorSuccess && urlAttr) {
@@ -561,9 +549,21 @@ int hasClickAction(void *element) {
 	if (role)
 		CFRelease(role);
 
-	// Final check: visible bounding box and not occluded
+	// Visibility check: compute center+pid once and use for both focusable and final check
 	CGPoint center;
 	pid_t pid;
+	bool hasCenterAndPid = false;
+
+	// For focusable elements, check visibility
+	if (isFocusable) {
+		if (getElementCenter((void *)axElement, &center) && AXUIElementGetPid(axElement, &pid) == kAXErrorSuccess) {
+			hasCenterAndPid = true;
+			return isPointVisible(center, pid) ? 1 : 0;
+		}
+		return 0;
+	}
+
+	// Final check for other elements: visible bounding box and not occluded
 	if (getElementCenter((void *)axElement, &center) && AXUIElementGetPid(axElement, &pid) == kAXErrorSuccess) {
 		return isPointVisible(center, pid) ? 1 : 0;
 	}

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -106,17 +106,42 @@ void **getFrontmostAndPopoverWindows(int *count) {
 			shouldReleaseAppRef = true;
 		}
 
-		AXUIElementRef focusedWindow = NULL;
-		AXUIElementCopyAttributeValue(appRef, kAXFocusedWindowAttribute, (CFTypeRef *)&focusedWindow);
+		// Batch fetch focused window and all windows in a single AX call
+		CFArrayRef windowAttrs = CFArrayCreate(
+		    NULL,
+		    (CFTypeRef[]){
+		        kAXFocusedWindowAttribute,
+		        kAXWindowsAttribute,
+		    },
+		    2, &kCFTypeArrayCallBacks);
 
+		CFArrayRef windowValues = NULL;
+		AXError batchError = AXUIElementCopyMultipleAttributeValues(appRef, windowAttrs, 0, &windowValues);
+		CFRelease(windowAttrs);
+
+		AXUIElementRef focusedWindow = NULL;
 		CFTypeRef windowsValue = NULL;
 		CFArrayRef windows = NULL;
 		CFIndex windowCount = 0;
-		if (AXUIElementCopyAttributeValue(appRef, kAXWindowsAttribute, &windowsValue) == kAXErrorSuccess &&
-		    windowsValue && CFGetTypeID(windowsValue) == CFArrayGetTypeID()) {
-			windows = (CFArrayRef)windowsValue;
-			windowCount = CFArrayGetCount(windows);
+
+		if (batchError == kAXErrorSuccess && windowValues && CFArrayGetCount(windowValues) >= 2) {
+			CFTypeRef focusedVal = (CFTypeRef)CFArrayGetValueAtIndex(windowValues, 0);
+			if (focusedVal) {
+				focusedWindow = (AXUIElementRef)focusedVal;
+				CFRetain(focusedWindow);
+			}
+
+			CFTypeRef windowsVal = (CFTypeRef)CFArrayGetValueAtIndex(windowValues, 1);
+			if (windowsVal && CFGetTypeID(windowsVal) == CFArrayGetTypeID()) {
+				windowsValue = windowsVal;
+				CFRetain(windowsValue);
+				windows = (CFArrayRef)windowsValue;
+				windowCount = CFArrayGetCount(windows);
+			}
 		}
+
+		if (windowValues)
+			CFRelease(windowValues);
 
 		CFIndex capacity = (focusedWindow ? 1 : 0) + windowCount;
 		if (capacity == 0) {
@@ -222,49 +247,66 @@ void *getFrontmostWindow(void) {
 			shouldReleaseAppRef = true;
 		}
 
-		// Try focused window attribute first (fast path)
+		// Batch fetch focused window and all windows in a single AX call
+		CFArrayRef windowAttrs = CFArrayCreate(
+		    NULL,
+		    (CFTypeRef[]){
+		        kAXFocusedWindowAttribute,
+		        kAXWindowsAttribute,
+		    },
+		    2, &kCFTypeArrayCallBacks);
+
+		CFArrayRef windowValues = NULL;
+		AXError batchError = AXUIElementCopyMultipleAttributeValues(appRef, windowAttrs, 0, &windowValues);
+		CFRelease(windowAttrs);
+
 		AXUIElementRef window = NULL;
-		AXError error = AXUIElementCopyAttributeValue(appRef, kAXFocusedWindowAttribute, (CFTypeRef *)&window);
+		CFArrayRef windows = NULL;
+
+		if (batchError == kAXErrorSuccess && windowValues && CFArrayGetCount(windowValues) >= 2) {
+			CFTypeRef focusedVal = (CFTypeRef)CFArrayGetValueAtIndex(windowValues, 0);
+			if (focusedVal) {
+				window = (AXUIElementRef)focusedVal;
+				CFRetain(window);
+			}
+
+			CFTypeRef windowsVal = (CFTypeRef)CFArrayGetValueAtIndex(windowValues, 1);
+			if (windowsVal && CFGetTypeID(windowsVal) == CFArrayGetTypeID()) {
+				windows = (CFArrayRef)windowsVal;
+				CFRetain(windows);
+			}
+		}
+
+		if (windowValues)
+			CFRelease(windowValues);
 
 		if (shouldReleaseAppRef && appRef) {
 			CFRelease(appRef);
 		}
 
-		if (error == kAXErrorSuccess && window) {
+		if (window) {
 			if (focusedApp)
 				CFRelease(focusedApp);
+			if (windows)
+				CFRelease(windows);
 			return (void *)window;
 		}
 
-		// Fallback: try the application's windows list and return the first entry
-		if (focusedApp) {
-			pid_t pid;
-			if (AXUIElementGetPid(focusedApp, &pid) == kAXErrorSuccess) {
-				AXUIElementRef appFromPid = AXUIElementCreateApplication(pid);
-				if (appFromPid) {
-					CFTypeRef windowsValue = NULL;
-					if (AXUIElementCopyAttributeValue(appFromPid, kAXWindowsAttribute, &windowsValue) ==
-					        kAXErrorSuccess &&
-					    windowsValue && CFGetTypeID(windowsValue) == CFArrayGetTypeID()) {
-						CFArrayRef windows = (CFArrayRef)windowsValue;
-						if (CFArrayGetCount(windows) > 0) {
-							AXUIElementRef firstWindow = (AXUIElementRef)CFArrayGetValueAtIndex(windows, 0);
-							CFRetain(firstWindow);
-							CFRelease(windowsValue);
-							CFRelease(appFromPid);
-							CFRelease(focusedApp);
-							return (void *)firstWindow;
-						}
-					}
-
-					if (windowsValue)
-						CFRelease(windowsValue);
-					CFRelease(appFromPid);
-				}
-			}
-
-			CFRelease(focusedApp);
+		// Fallback: use first window from the windows list
+		if (windows && CFArrayGetCount(windows) > 0) {
+			AXUIElementRef firstWindow = (AXUIElementRef)CFArrayGetValueAtIndex(windows, 0);
+			CFRetain(firstWindow);
+			CFRelease(windows);
+			if (focusedApp)
+				CFRelease(focusedApp);
+			return (void *)firstWindow;
 		}
+
+		if (windows)
+			CFRelease(windows);
+
+		if (focusedApp)
+			CFRelease(focusedApp);
 
 		return NULL;
 	}

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -126,7 +126,7 @@ void **getFrontmostAndPopoverWindows(int *count) {
 
 		if (batchError == kAXErrorSuccess && windowValues && CFArrayGetCount(windowValues) >= 2) {
 			CFTypeRef focusedVal = (CFTypeRef)CFArrayGetValueAtIndex(windowValues, 0);
-			if (focusedVal) {
+			if (focusedVal && CFGetTypeID(focusedVal) != CFNullGetTypeID()) {
 				focusedWindow = (AXUIElementRef)focusedVal;
 				CFRetain(focusedWindow);
 			}
@@ -265,7 +265,7 @@ void *getFrontmostWindow(void) {
 
 		if (batchError == kAXErrorSuccess && windowValues && CFArrayGetCount(windowValues) >= 2) {
 			CFTypeRef focusedVal = (CFTypeRef)CFArrayGetValueAtIndex(windowValues, 0);
-			if (focusedVal) {
+			if (focusedVal && CFGetTypeID(focusedVal) != CFNullGetTypeID()) {
 				window = (AXUIElementRef)focusedVal;
 				CFRetain(window);
 			}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds more optimisation to AX API calls and manually benchmarking them against Homerow.

- more AX API batching
- more caching

It's now pretty fast, not faster than Homerow, but pretty fast and very usable. Note that on Neru, i have enabled all supplementary targets, and we are have more checks compared to Homerow, e.g. stage manager, notification center, menubar items, screen capture ui, pip players and so on, that does not exist in homerow checks. 

Check out the video below.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/e00366c6-41a0-4d90-ae58-2194fe111efc

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
