### PR TITLE
fix(hints): add popovers, sheets and menus into interactive leaf elements

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -61,6 +61,7 @@ include_screen_capture_hints = false
 detect_mission_control = false
 clickable_roles = [
     "AXButton",
+	"AXMenuButton",
     "AXComboBox",
     "AXCheckBox",
     "AXRadioButton",

--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -23,6 +23,7 @@ additional_menubar_hints_targets = [
 ]
 clickable_roles = [
     "AXButton",
+	"AXMenuButton",
     "AXComboBox",
     "AXCheckBox",
     "AXRadioButton",

--- a/internal/config/config_darwin.go
+++ b/internal/config/config_darwin.go
@@ -13,6 +13,7 @@ func applyPlatformDefaults(cfg *Config) {
 
 	cfg.Hints.ClickableRoles = append(cfg.Hints.ClickableRoles,
 		"AXButton",
+		"AXMenuButton",
 		"AXComboBox",
 		"AXCheckBox",
 		"AXRadioButton",

--- a/internal/core/domain/element/element.go
+++ b/internal/core/domain/element/element.go
@@ -22,6 +22,7 @@ const (
 	RoleCheckBox           Role = "AXCheckBox"
 	RoleRadioButton        Role = "AXRadioButton"
 	RoleMenuItem           Role = "AXMenuItem"
+	RoleMenuButton         Role = "AXMenuButton"
 	RolePopUpButton        Role = "AXPopUpButton"
 	RoleTabButton          Role = "AXTabButton"
 	RoleSlider             Role = "AXSlider"

--- a/internal/core/domain/element/element.go
+++ b/internal/core/domain/element/element.go
@@ -29,6 +29,7 @@ const (
 	RoleSwitch             Role = "AXSwitch"
 	RoleDisclosureTriangle Role = "AXDisclosureTriangle"
 	RoleTextArea           Role = "AXTextArea"
+	RoleComboBox           Role = "AXComboBox"
 	RolePopover            Role = "AXPopover"
 	RoleSheet              Role = "AXSheet"
 	RoleMenu               Role = "AXMenu"

--- a/internal/core/domain/element/element.go
+++ b/internal/core/domain/element/element.go
@@ -35,6 +35,22 @@ const (
 	RoleMenu               Role = "AXMenu"
 	RoleSGTMenu            Role = "SGTMenu"
 	RoleList               Role = "AXList"
+	RoleHeading            Role = "AXHeading"
+	RoleMenuBarItem        Role = "AXMenuBarItem"
+	RoleMenuBar            Role = "AXMenuBar"
+	RoleCell               Role = "AXCell"
+	RoleRow                Role = "AXRow"
+	RoleDockItem           Role = "AXDockItem"
+	RoleIncrementor        Role = "AXIncrementor"
+	RoleColorWell          Role = "AXColorWell"
+	RoleSearchField        Role = "AXSearchField"
+	RoleToolbarButton      Role = "AXToolbarButton"
+	RoleToggle             Role = "AXToggle"
+	RoleTable              Role = "AXTable"
+	RoleOutline            Role = "AXOutline"
+	RoleApplication        Role = "AXApplication"
+	RoleWindow             Role = "AXWindow"
+	RoleTabGroup           Role = "AXTabGroup"
 )
 
 // Element represents a UI element in the accessibility tree.

--- a/internal/core/domain/element/element.go
+++ b/internal/core/domain/element/element.go
@@ -29,6 +29,11 @@ const (
 	RoleSwitch             Role = "AXSwitch"
 	RoleDisclosureTriangle Role = "AXDisclosureTriangle"
 	RoleTextArea           Role = "AXTextArea"
+	RolePopover            Role = "AXPopover"
+	RoleSheet              Role = "AXSheet"
+	RoleMenu               Role = "AXMenu"
+	RoleSGTMenu            Role = "SGTMenu"
+	RoleList               Role = "AXList"
 )
 
 // Element represents a UI element in the accessibility tree.

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -24,7 +24,7 @@ func (a *Adapter) addMenubarElements(
 	originalRoles := a.client.ClickableRoles()
 	menubarRoles := make([]string, len(originalRoles)+1)
 	copy(menubarRoles, originalRoles)
-	menubarRoles[len(originalRoles)] = "AXMenuBarItem"
+	menubarRoles[len(originalRoles)] = string(element.RoleMenuBarItem)
 
 	// Get menubar elements
 	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements(false)
@@ -128,7 +128,7 @@ func (a *Adapter) addDockElements(
 	originalRoles := a.client.ClickableRoles()
 	dockRoles := make([]string, len(originalRoles)+1)
 	copy(dockRoles, originalRoles)
-	dockRoles[len(originalRoles)] = "AXDockItem"
+	dockRoles[len(originalRoles)] = string(element.RoleDockItem)
 
 	// Get dock application by bundle ID
 	dockApp, dockAppErr := a.client.ApplicationByBundleID(dockBundleID)
@@ -147,7 +147,7 @@ func (a *Adapter) addDockElements(
 		return elements
 	}
 
-	if appInfo.Role != "AXApplication" {
+	if appInfo.Role != string(element.RoleApplication) {
 		a.logger.Warn("Got incorrect element for dock, expected AXApplication",
 			zap.String("actual_role", appInfo.Role),
 			zap.String("title", appInfo.Title))
@@ -245,7 +245,7 @@ func (a *Adapter) addStageManagerElements(
 		return elements
 	}
 
-	if appInfo.Role != "AXApplication" {
+	if appInfo.Role != string(element.RoleApplication) {
 		a.logger.Warn("Got incorrect element for window manager, expected AXApplication",
 			zap.String("actual_role", appInfo.Role),
 			zap.String("title", appInfo.Title))

--- a/internal/core/infra/accessibility/cache.go
+++ b/internal/core/infra/accessibility/cache.go
@@ -97,6 +97,7 @@ var staticRoles = map[string]bool{
 	"AXButton":             true,
 	"AXLink":               true,
 	"AXMenuItem":           true,
+	"AXMenuButton":         true,
 	"AXPopUpButton":        true,
 	"AXTabButton":          true,
 	"AXCheckBox":           true,

--- a/internal/core/infra/accessibility/cache.go
+++ b/internal/core/infra/accessibility/cache.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
 )
 
 const (
@@ -93,22 +95,22 @@ func (h *expirationHeap) Pop() any {
 }
 
 // staticRoles defines roles that should use longer (static) TTL.
-var staticRoles = map[string]bool{
-	"AXButton":             true,
-	"AXLink":               true,
-	"AXMenuItem":           true,
-	"AXMenuButton":         true,
-	"AXPopUpButton":        true,
-	"AXTabButton":          true,
-	"AXCheckBox":           true,
-	"AXRadioButton":        true,
-	"AXSwitch":             true,
-	"AXDisclosureTriangle": true,
-	"AXComboBox":           true,
-	"AXSlider":             true,
-	"AXStaticText":         true,
-	"AXImage":              true,
-	"AXHeading":            true,
+var staticRoles = map[element.Role]bool{
+	element.RoleButton:             true,
+	element.RoleLink:               true,
+	element.RoleMenuItem:           true,
+	element.RoleMenuButton:         true,
+	element.RolePopUpButton:        true,
+	element.RoleTabButton:          true,
+	element.RoleCheckBox:           true,
+	element.RoleRadioButton:        true,
+	element.RoleSwitch:             true,
+	element.RoleDisclosureTriangle: true,
+	element.RoleComboBox:           true,
+	element.RoleSlider:             true,
+	element.RoleStaticText:         true,
+	element.RoleImage:              true,
+	element.RoleHeading:            true,
 }
 
 // isStaticElement determines if an element should use static (longer) TTL based on its role.
@@ -117,7 +119,7 @@ func isStaticElement(info *ElementInfo) bool {
 		return false
 	}
 
-	return staticRoles[info.Role()]
+	return staticRoles[element.Role(info.Role())]
 }
 
 // InfoCache implements a thread-safe time-to-live cache for element information.

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
+	"github.com/y3owk1n/neru/internal/core/domain/element"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/infra/platform/darwin"
 )
@@ -39,28 +40,28 @@ var (
 // to verify clickability. When an element has one of these roles and is
 // enabled, we can confidently skip the native verification. This eliminates
 // hundreds of CGo calls per activation for typical web pages.
-var knownInteractiveRoles = map[string]struct{}{
-	"AXButton":             {},
-	"AXLink":               {},
-	"AXMenuItem":           {},
-	"AXMenuBarItem":        {},
-	"AXPopUpButton":        {},
-	"AXTabButton":          {},
-	"AXCheckBox":           {},
-	"AXRadioButton":        {},
-	"AXSwitch":             {},
-	"AXDisclosureTriangle": {},
-	"AXComboBox":           {},
-	"AXDockItem":           {},
-	"AXTextField":          {},
-	"AXTextArea":           {},
-	"AXSlider":             {},
-	"AXIncrementor":        {},
-	"AXColorWell":          {},
-	"AXSearchField":        {},
-	"AXToolbarButton":      {},
-	"AXMenuButton":         {},
-	"AXToggle":             {},
+var knownInteractiveRoles = map[element.Role]struct{}{
+	element.RoleButton:             {},
+	element.RoleLink:               {},
+	element.RoleMenuItem:           {},
+	element.RoleMenuBarItem:        {},
+	element.RolePopUpButton:        {},
+	element.RoleTabButton:          {},
+	element.RoleCheckBox:           {},
+	element.RoleRadioButton:        {},
+	element.RoleSwitch:             {},
+	element.RoleDisclosureTriangle: {},
+	element.RoleComboBox:           {},
+	element.RoleDockItem:           {},
+	element.RoleTextField:          {},
+	element.RoleTextArea:           {},
+	element.RoleSlider:             {},
+	element.RoleIncrementor:        {},
+	element.RoleColorWell:          {},
+	element.RoleSearchField:        {},
+	element.RoleToolbarButton:      {},
+	element.RoleMenuButton:         {},
+	element.RoleToggle:             {},
 }
 
 var (
@@ -328,7 +329,7 @@ func (e *Element) Children(cache *InfoCache) ([]*Element, error) {
 
 	if info != nil {
 		switch info.Role() {
-		case "AXList", "AXTable", "AXOutline":
+		case string(element.RoleList), string(element.RoleTable), string(element.RoleOutline):
 			ptr := unsafe.Pointer(C.getVisibleRows(e.ref, &count)) //nolint:nlreturn
 			if ptr != nil && count > 0 {
 				rawChildren = ptr
@@ -717,7 +718,7 @@ func (e *Element) IsClickable(
 		// call which makes up to 5 AX API round-trips. The isEnabled
 		// flag was already fetched during tree building via getElementInfo.
 		if info != nil && info.IsEnabled() {
-			if _, known := knownInteractiveRoles[info.Role()]; known {
+			if _, known := knownInteractiveRoles[element.Role(info.Role())]; known {
 				return true
 			}
 		}

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -4,6 +4,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain/element"
 )
 
 // MenuBarClickableElements retrieves clickable UI elements from the focused application's menu bar.
@@ -64,7 +65,7 @@ func MenuBarClickableElements(
 	}
 
 	// Add menubar specific role
-	allowedRoles["AXMenuBarItem"] = struct{}{}
+	allowedRoles[string(element.RoleMenuBarItem)] = struct{}{}
 
 	ignoreClickableCheck := false
 	if cfg := currentConfig(configProvider); cfg != nil {

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain/element"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
 
@@ -366,12 +367,12 @@ var interactiveLeafRoles = map[string]bool{
 // parent is an interactive leaf (e.g., a button that opens a popover).
 // This set is checked to ensure we don't stop traversal at buttons/menus
 // that trigger popovers, sheets, or menus.
-var importantContainerRoles = map[string]bool{
-	"AXPopover": true,
-	"AXSheet":   true,
-	"AXMenu":    true,
-	"SGTMenu":   true,
-	"AXList":    true,
+var importantContainerRoles = map[element.Role]bool{
+	element.RolePopover: true,
+	element.RoleSheet:   true,
+	element.RoleMenu:    true,
+	element.RoleSGTMenu: true,
+	element.RoleList:    true,
 }
 
 func buildTreeRecursive(
@@ -417,7 +418,7 @@ func buildTreeRecursive(
 				if childInfo == nil {
 					childInfo, _ = child.Info()
 				}
-				if childInfo != nil && importantContainerRoles[childInfo.Role()] {
+				if childInfo != nil && importantContainerRoles[element.Role(childInfo.Role())] {
 					hasImportantContainer = true
 
 					break

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -417,6 +417,7 @@ func buildTreeRecursive(
 				childInfo := opts.cache.Get(child)
 				if childInfo == nil {
 					childInfo, _ = child.Info()
+					opts.cache.Set(child, childInfo)
 				}
 				if childInfo != nil && importantContainerRoles[element.Role(childInfo.Role())] {
 					hasImportantContainer = true

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -372,6 +372,7 @@ var importantContainerRoles = map[element.Role]bool{
 	element.RoleMenu:    true,
 	element.RoleSGTMenu: true,
 	element.RoleList:    true,
+	element.RoleButton:  true,
 }
 
 func buildTreeRecursive(

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -348,6 +348,7 @@ var nonInteractiveRoles = map[string]bool{
 // Roles that are themselves interactive (leaf nodes).
 var interactiveLeafRoles = map[string]bool{
 	"AXButton":             true,
+	"AXMenuButton":         true,
 	"AXComboBox":           true,
 	"AXCheckBox":           true,
 	"AXRadioButton":        true,
@@ -358,6 +359,19 @@ var interactiveLeafRoles = map[string]bool{
 	"AXSwitch":             true,
 	"AXDisclosureTriangle": true,
 	"AXTextArea":           true,
+	"AXTextField":          true,
+}
+
+// Roles that can contain important interactive children even when their
+// parent is an interactive leaf (e.g., a button that opens a popover).
+// This set is checked to ensure we don't stop traversal at buttons/menus
+// that trigger popovers, sheets, or menus.
+var importantContainerRoles = map[string]bool{
+	"AXPopover": true,
+	"AXSheet":   true,
+	"AXMenu":    true,
+	"SGTMenu":   true,
+	"AXList":    true,
 }
 
 func buildTreeRecursive(
@@ -389,13 +403,35 @@ func buildTreeRecursive(
 		return
 	}
 
-	// Don't traverse deeper into interactive leaf elements
+	// Don't traverse deeper into interactive leaf elements,
+	// unless they have important container children (e.g., popovers, sheets, menus).
+	// This handles cases like a toolbar button that opens a popover.
 	if interactiveLeafRoles[parent.info.Role()] {
-		if opts.stats != nil {
-			opts.stats.stoppedAtLeaf.Add(1)
-		}
+		children, childrenErr := parent.element.Children(opts.cache)
+		hasImportantContainer := false
+		if childrenErr == nil && len(children) > 0 {
+			for _, child := range children {
+				childInfo := opts.cache.Get(child)
+				if childInfo == nil {
+					childInfo, _ = child.Info()
+				}
+				if childInfo != nil && importantContainerRoles[childInfo.Role()] {
+					hasImportantContainer = true
 
-		return
+					break
+				}
+			}
+		}
+		for _, child := range children {
+			child.Release()
+		}
+		if !hasImportantContainer {
+			if opts.stats != nil {
+				opts.stats.stoppedAtLeaf.Add(1)
+			}
+
+			return
+		}
 	}
 
 	children, err := parent.element.Children(opts.cache)

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -430,7 +430,14 @@ func buildTreeRecursive(
 				child.Release()
 			}
 			if opts.stats != nil {
-				opts.stats.stoppedAtLeaf.Add(1)
+				switch {
+				case childrenErr != nil:
+					opts.stats.childrenErrors.Add(1)
+				case len(children) == 0:
+					opts.stats.noChildren.Add(1)
+				default:
+					opts.stats.stoppedAtLeaf.Add(1)
+				}
 			}
 
 			return

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -352,7 +352,6 @@ var interactiveLeafRoles = map[element.Role]bool{
 	element.RoleMenuButton:         true,
 	element.RoleComboBox:           true,
 	element.RoleCheckBox:           true,
-	element.RoleRadioButton:        true,
 	element.RoleLink:               true,
 	element.RolePopUpButton:        true,
 	element.RoleSlider:             true,
@@ -360,6 +359,8 @@ var interactiveLeafRoles = map[element.Role]bool{
 	element.RoleSwitch:             true,
 	element.RoleDisclosureTriangle: true,
 	element.RoleTextArea:           true,
+	element.RoleTextField:          true,
+	// element.RoleRadioButton:        true, // in safari, url bar is radio button, but has nested button in it...
 }
 
 // Roles that can contain important interactive children even when their
@@ -372,7 +373,6 @@ var importantContainerRoles = map[element.Role]bool{
 	element.RoleMenu:    true,
 	element.RoleSGTMenu: true,
 	element.RoleList:    true,
-	element.RoleButton:  true,
 }
 
 func buildTreeRecursive(

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -406,8 +406,10 @@ func buildTreeRecursive(
 	// Don't traverse deeper into interactive leaf elements,
 	// unless they have important container children (e.g., popovers, sheets, menus).
 	// This handles cases like a toolbar button that opens a popover.
+	var children []*Element
 	if interactiveLeafRoles[parent.info.Role()] {
-		children, childrenErr := parent.element.Children(opts.cache)
+		var childrenErr error
+		children, childrenErr = parent.element.Children(opts.cache)
 		hasImportantContainer := false
 		if childrenErr == nil && len(children) > 0 {
 			for _, child := range children {
@@ -422,29 +424,31 @@ func buildTreeRecursive(
 				}
 			}
 		}
-		for _, child := range children {
-			child.Release()
-		}
 		if !hasImportantContainer {
+			for _, child := range children {
+				child.Release()
+			}
 			if opts.stats != nil {
 				opts.stats.stoppedAtLeaf.Add(1)
 			}
 
 			return
 		}
-	}
-
-	children, err := parent.element.Children(opts.cache)
-	if err != nil || len(children) == 0 {
-		if opts.stats != nil {
-			if err != nil {
-				opts.stats.childrenErrors.Add(1)
-			} else {
-				opts.stats.noChildren.Add(1)
+		// Reuse children slice for traversal below, skip the second Children() call.
+	} else {
+		var err error
+		children, err = parent.element.Children(opts.cache)
+		if err != nil || len(children) == 0 {
+			if opts.stats != nil {
+				if err != nil {
+					opts.stats.childrenErrors.Add(1)
+				} else {
+					opts.stats.noChildren.Add(1)
+				}
 			}
-		}
 
-		return
+			return
+		}
 	}
 
 	// Decide whether to parallelize

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -341,26 +341,26 @@ func BuildTree(root *Element, opts TreeOptions) (*TreeNode, error) {
 }
 
 // Roles that typically don't contain interactive elements.
-var nonInteractiveRoles = map[string]bool{
-	"AXStaticText": true,
-	"AXImage":      true,
+var nonInteractiveRoles = map[element.Role]bool{
+	element.RoleStaticText: true,
+	element.RoleImage:      true,
 }
 
 // Roles that are themselves interactive (leaf nodes).
-var interactiveLeafRoles = map[string]bool{
-	"AXButton":             true,
-	"AXMenuButton":         true,
-	"AXComboBox":           true,
-	"AXCheckBox":           true,
-	"AXRadioButton":        true,
-	"AXLink":               true,
-	"AXPopUpButton":        true,
-	"AXSlider":             true,
-	"AXTabButton":          true,
-	"AXSwitch":             true,
-	"AXDisclosureTriangle": true,
-	"AXTextArea":           true,
-	"AXTextField":          true,
+var interactiveLeafRoles = map[element.Role]bool{
+	element.RoleButton:             true,
+	element.RoleMenuButton:         true,
+	element.RoleComboBox:           true,
+	element.RoleCheckBox:           true,
+	element.RoleRadioButton:        true,
+	element.RoleLink:               true,
+	element.RolePopUpButton:        true,
+	element.RoleSlider:             true,
+	element.RoleTabButton:          true,
+	element.RoleSwitch:             true,
+	element.RoleDisclosureTriangle: true,
+	element.RoleTextArea:           true,
+	element.RoleTextField:          true,
 }
 
 // Roles that can contain important interactive children even when their
@@ -396,7 +396,7 @@ func buildTreeRecursive(
 	}
 
 	// Early exit for roles that can't have interactive children
-	if nonInteractiveRoles[parent.info.Role()] {
+	if nonInteractiveRoles[element.Role(parent.info.Role())] {
 		if opts.stats != nil {
 			opts.stats.skippedNonInteractive.Add(1)
 		}
@@ -408,7 +408,7 @@ func buildTreeRecursive(
 	// unless they have important container children (e.g., popovers, sheets, menus).
 	// This handles cases like a toolbar button that opens a popover.
 	var children []*Element
-	if interactiveLeafRoles[parent.info.Role()] {
+	if interactiveLeafRoles[element.Role(parent.info.Role())] {
 		var childrenErr error
 		children, childrenErr = parent.element.Children(opts.cache)
 		hasImportantContainer := false
@@ -641,7 +641,7 @@ func shouldIncludeElement(
 
 		// Filter out zero-sized interactive elements (they're broken/invalid)
 		if elementRect.Dx() == 0 || elementRect.Dy() == 0 {
-			if interactiveLeafRoles[info.Role()] {
+			if interactiveLeafRoles[element.Role(info.Role())] {
 				return false
 			}
 		}
@@ -655,7 +655,7 @@ func shouldIncludeElement(
 			// Filter if either dimension is too small (not just both)
 			if elementRect.Dx() < minElementSize || elementRect.Dy() < minElementSize {
 				// Only filter if it's not a known important role
-				if !interactiveLeafRoles[info.Role()] {
+				if !interactiveLeafRoles[element.Role(info.Role())] {
 					return false
 				}
 			}
@@ -668,7 +668,7 @@ func shouldIncludeElement(
 			centerY := elementRect.Min.Y + halfHeight
 			if centerX < windowBounds.Min.X || centerX > windowBounds.Max.X ||
 				centerY < windowBounds.Min.Y || centerY > windowBounds.Max.Y {
-				if !interactiveLeafRoles[info.Role()] {
+				if !interactiveLeafRoles[element.Role(info.Role())] {
 					return false
 				}
 			}

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -360,7 +360,6 @@ var interactiveLeafRoles = map[element.Role]bool{
 	element.RoleSwitch:             true,
 	element.RoleDisclosureTriangle: true,
 	element.RoleTextArea:           true,
-	element.RoleTextField:          true,
 }
 
 // Roles that can contain important interactive children even when their


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds several roles in a new important container roles that will traverse through even if the parents is interactive leaf and should stop.

The reason of this PR is to fix some elements that are not fully make sense in terms of the tree. E.g.

- Finder.app share button opens up a popover
- Finder.app (...) button
- Probably more...

This change should allow more common buttons across native macOS apps to be able to get hint labels.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
