### PR TITLE
fix(hints): improve mission control detection

### DIFF
--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -174,8 +174,9 @@ func (a *Adapter) ClickableElements(
 
 					clickableNodes, clickableNodesErr := a.client.ClickableNodes(
 						window,
-						filter.IncludeOffscreen,
 						stringRoles(filter.Roles),
+						filter.StrictFiltering,
+						false,
 					)
 					if clickableNodesErr != nil {
 						window.Release()
@@ -237,8 +238,8 @@ func (a *Adapter) ClickableElements(
 		}()
 	}
 
-	// Notification Center (only when Mission Control is active)
-	if missionControlActive && filter.IncludeNotificationCenter {
+	// Notification Center
+	if !missionControlActive && filter.IncludeNotificationCenter {
 		waitGroup.Add(1)
 
 		go func() {
@@ -249,7 +250,7 @@ func (a *Adapter) ClickableElements(
 	}
 
 	// Stage Manager
-	if filter.IncludeStageManager {
+	if !missionControlActive && filter.IncludeStageManager {
 		waitGroup.Add(1)
 
 		go func() {
@@ -260,7 +261,7 @@ func (a *Adapter) ClickableElements(
 	}
 
 	// PIP
-	if filter.IncludePIP {
+	if !missionControlActive && filter.IncludePIP {
 		waitGroup.Add(1)
 
 		go func() {
@@ -271,7 +272,7 @@ func (a *Adapter) ClickableElements(
 	}
 
 	// Screen Capture
-	if filter.IncludeScreenCapture {
+	if !missionControlActive && filter.IncludeScreenCapture {
 		waitGroup.Add(1)
 
 		go func() {

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -27,7 +27,7 @@ func (a *Adapter) addMenubarElements(
 	menubarRoles[len(originalRoles)] = string(element.RoleMenuBarItem)
 
 	// Get menubar elements
-	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements(false)
+	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements(false, false)
 	if menubarNodesErr != nil {
 		a.logger.Warn("Failed to get menubar elements", zap.Error(menubarNodesErr))
 	} else {
@@ -62,6 +62,7 @@ func (a *Adapter) addMenubarElements(
 			additionalNodes, err := a.client.ClickableElementsFromBundleID(
 				bundleID,
 				menubarRoles,
+				false,
 				false,
 			)
 			if err != nil {
@@ -156,7 +157,7 @@ func (a *Adapter) addDockElements(
 	}
 
 	// Build tree and find clickable elements
-	dockNodes, dockNodesErr := a.client.ClickableNodes(dockApp, true, dockRoles)
+	dockNodes, dockNodesErr := a.client.ClickableNodes(dockApp, dockRoles, false, true)
 	if dockNodesErr != nil {
 		a.logger.Warn("Failed to get dock elements", zap.Error(dockNodesErr))
 
@@ -194,6 +195,7 @@ func (a *Adapter) addNotificationCenterElements(
 	ncNodes, ncNodesErr := a.client.ClickableElementsFromBundleID(
 		ncBundleID,
 		nil,
+		false,
 		false,
 	)
 	if ncNodesErr != nil {
@@ -254,7 +256,7 @@ func (a *Adapter) addStageManagerElements(
 	}
 
 	// Build tree and find clickable elements
-	wmNodes, wmNodesErr := a.client.ClickableNodes(wmApp, true, nil)
+	wmNodes, wmNodesErr := a.client.ClickableNodes(wmApp, nil, false, false)
 	if wmNodesErr != nil {
 		a.logger.Warn("Failed to get window manager elements", zap.Error(wmNodesErr))
 
@@ -290,6 +292,7 @@ func (a *Adapter) addPIPElements(
 	pipNodes, pipNodesErr := a.client.ClickableElementsFromBundleID(
 		pipBundleID,
 		nil,
+		false,
 		false,
 	)
 	if pipNodesErr != nil {
@@ -327,6 +330,7 @@ func (a *Adapter) addScreenCaptureElements(
 	screenCaptureNodes, screenCaptureNodesErr := a.client.ClickableElementsFromBundleID(
 		screenCaptureBundleID,
 		nil,
+		false,
 		false,
 	)
 	if screenCaptureNodesErr != nil {

--- a/internal/core/infra/accessibility/client.go
+++ b/internal/core/infra/accessibility/client.go
@@ -27,14 +27,16 @@ type AXClient interface {
 	ApplicationByBundleID(bundleID string) (AXApp, error)
 	ClickableNodes(
 		root AXElement,
-		includeOffscreen bool,
 		roles []string,
+		strictFiltering bool,
+		bypassCache bool,
 	) ([]AXNode, error)
-	MenuBarClickableElements(strictFiltering bool) ([]AXNode, error)
+	MenuBarClickableElements(strictFiltering bool, bypassCache bool) ([]AXNode, error)
 	ClickableElementsFromBundleID(
 		bundleID string,
 		roles []string,
 		strictFiltering bool,
+		bypassCache bool,
 	) ([]AXNode, error)
 	ActiveScreenBounds() image.Rectangle
 

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -99,8 +99,9 @@ func (c *InfraAXClient) FocusedApplication() (AXApp, error) {
 // ClickableNodes returns clickable nodes for the given root element.
 func (c *InfraAXClient) ClickableNodes(
 	root AXElement,
-	includeOffscreen bool,
 	roles []string,
+	strictFiltering bool,
+	bypassCache bool,
 ) ([]AXNode, error) {
 	var element *Element
 
@@ -119,21 +120,14 @@ func (c *InfraAXClient) ClickableNodes(
 
 	opts := DefaultTreeOptions(c.logger)
 	opts.SetCache(c.cache)
-	opts.SetIncludeOutOfBounds(includeOffscreen)
+	opts.SetStrictFiltering(strictFiltering)
+	opts.SetIncludeOutOfBounds(!strictFiltering)
 
 	// Enable strict filtering for Chromium/Electron apps which have noisy DOM trees
 	bundleID := element.BundleIdentifier()
 	if isLikelyChromiumOrElectron(bundleID) ||
 		isUserConfiguredChromiumElectron(bundleID, c.configProvider) {
 		opts.SetStrictFiltering(true)
-
-		if includeOffscreen {
-			c.logger.Warn(
-				"strict filtering requires includeOutOfBounds=false, overriding user preference",
-				zap.String("bundle_id", bundleID),
-			)
-		}
-
 		opts.SetIncludeOutOfBounds(false) // strict filtering requires bound checks to be active
 	}
 
@@ -162,6 +156,10 @@ func (c *InfraAXClient) ClickableNodes(
 	ignoreClickableCheck := false
 	if cfg := currentConfig(c.configProvider); cfg != nil {
 		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(bundleID)
+	}
+
+	if bypassCache {
+		c.cache.Clear()
 	}
 
 	clickableNodes := tree.FindClickableElements(
@@ -202,12 +200,14 @@ func (c *InfraAXClient) ApplicationByBundleID(bundleID string) (AXApp, error) {
 // MenuBarClickableElements returns clickable elements in the menu bar.
 func (c *InfraAXClient) MenuBarClickableElements(
 	strictFiltering bool,
+	bypassCache bool,
 ) ([]AXNode, error) {
 	nodes, nodesErr := MenuBarClickableElements(
 		c.logger,
 		c.cache,
 		c.configProvider,
 		strictFiltering,
+		bypassCache,
 	)
 	if nodesErr != nil {
 		return nil, derrors.Wrap(
@@ -235,6 +235,7 @@ func (c *InfraAXClient) ClickableElementsFromBundleID(
 	bundleID string,
 	roles []string,
 	strictFiltering bool,
+	bypassCache bool,
 ) ([]AXNode, error) {
 	nodes, nodesErr := ClickableElementsFromBundleID(
 		bundleID,
@@ -243,6 +244,7 @@ func (c *InfraAXClient) ClickableElementsFromBundleID(
 		c.cache,
 		c.configProvider,
 		strictFiltering,
+		bypassCache,
 	)
 	if nodesErr != nil {
 		return nil, derrors.Wrap(

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -162,7 +162,9 @@ func (c *InfraAXClient) ClickableNodes(
 	}
 
 	var cache *InfoCache
-	if !bypassCache {
+	if bypassCache {
+		cache = NewInfoCache(c.logger)
+	} else {
 		cache = c.cache
 	}
 

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -119,7 +119,10 @@ func (c *InfraAXClient) ClickableNodes(
 	}
 
 	opts := DefaultTreeOptions(c.logger)
-	opts.SetCache(c.cache)
+	if !bypassCache {
+		opts.SetCache(c.cache)
+	}
+
 	opts.SetStrictFiltering(strictFiltering)
 	opts.SetIncludeOutOfBounds(!strictFiltering)
 

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -119,7 +119,9 @@ func (c *InfraAXClient) ClickableNodes(
 	}
 
 	opts := DefaultTreeOptions(c.logger)
-	if !bypassCache {
+	if bypassCache {
+		opts.SetCache(NewInfoCache(c.logger))
+	} else {
 		opts.SetCache(c.cache)
 	}
 

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -158,13 +158,14 @@ func (c *InfraAXClient) ClickableNodes(
 		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(bundleID)
 	}
 
-	if bypassCache {
-		c.cache.Clear()
+	var cache *InfoCache
+	if !bypassCache {
+		cache = c.cache
 	}
 
 	clickableNodes := tree.FindClickableElements(
 		allowedRoles,
-		c.cache,
+		cache,
 		c.configProvider,
 		ignoreClickableCheck,
 	)
@@ -179,7 +180,7 @@ func (c *InfraAXClient) ClickableNodes(
 		clickableNodesResult[i] = &InfraNode{
 			node:           node,
 			clickable:      true,
-			cache:          c.cache,
+			cache:          cache,
 			configProvider: c.configProvider,
 		}
 	}

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -118,13 +118,15 @@ func (c *InfraAXClient) ClickableNodes(
 		return nil, derrors.New(derrors.CodeInvalidInput, "element is nil")
 	}
 
-	opts := DefaultTreeOptions(c.logger)
+	var cache *InfoCache
 	if bypassCache {
-		opts.SetCache(NewInfoCache(c.logger))
+		cache = NewInfoCache(c.logger)
 	} else {
-		opts.SetCache(c.cache)
+		cache = c.cache
 	}
 
+	opts := DefaultTreeOptions(c.logger)
+	opts.SetCache(cache)
 	opts.SetStrictFiltering(strictFiltering)
 	opts.SetIncludeOutOfBounds(!strictFiltering)
 
@@ -161,13 +163,6 @@ func (c *InfraAXClient) ClickableNodes(
 	ignoreClickableCheck := false
 	if cfg := currentConfig(c.configProvider); cfg != nil {
 		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(bundleID)
-	}
-
-	var cache *InfoCache
-	if bypassCache {
-		cache = NewInfoCache(c.logger)
-	} else {
-		cache = c.cache
 	}
 
 	clickableNodes := tree.FindClickableElements(

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -86,8 +86,9 @@ func (m *MockAXClient) ApplicationByBundleID(_ string) (AXApp, error) {
 // ClickableNodes returns the configured clickable nodes or error.
 func (m *MockAXClient) ClickableNodes(
 	_ AXElement,
-	_ bool,
 	roles []string,
+	_ bool,
+	_ bool,
 ) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastClickableNodesRoles = roles
@@ -98,7 +99,7 @@ func (m *MockAXClient) ClickableNodes(
 }
 
 // MenuBarClickableElements returns the configured menu bar nodes or error.
-func (m *MockAXClient) MenuBarClickableElements(strictFiltering bool) ([]AXNode, error) {
+func (m *MockAXClient) MenuBarClickableElements(strictFiltering bool, _ bool) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastMenuBarStrictFiltering = strictFiltering
 	m.mu.Unlock()
@@ -111,6 +112,7 @@ func (m *MockAXClient) ClickableElementsFromBundleID(
 	bundleID string,
 	roles []string,
 	strictFiltering bool,
+	_ bool,
 ) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastCalledBundleID = bundleID

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -34,7 +34,10 @@ func MenuBarClickableElements(
 	defer menubar.Release()
 
 	opts := DefaultTreeOptions(logger)
-	opts.SetCache(cache)
+	if !bypassCache {
+		opts.SetCache(cache)
+	}
+
 	opts.SetStrictFiltering(strictFiltering)
 	opts.SetIncludeOutOfBounds(!strictFiltering)
 
@@ -117,7 +120,10 @@ func ClickableElementsFromBundleID(
 	defer app.Release()
 
 	opts := DefaultTreeOptions(logger)
-	opts.SetCache(cache)
+	if !bypassCache {
+		opts.SetCache(cache)
+	}
+
 	opts.SetStrictFiltering(strictFiltering)
 	opts.SetIncludeOutOfBounds(!strictFiltering)
 

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -13,6 +13,7 @@ func MenuBarClickableElements(
 	cache *InfoCache,
 	configProvider config.Provider,
 	strictFiltering bool,
+	bypassCache bool,
 ) ([]*TreeNode, error) {
 	logger.Debug("Getting clickable elements for menu bar")
 
@@ -73,6 +74,10 @@ func MenuBarClickableElements(
 		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(focusedBundleID)
 	}
 
+	if bypassCache {
+		cache.Clear()
+	}
+
 	elements := tree.FindClickableElements(
 		allowedRoles,
 		cache,
@@ -97,6 +102,7 @@ func ClickableElementsFromBundleID(
 	cache *InfoCache,
 	configProvider config.Provider,
 	strictFiltering bool,
+	bypassCache bool,
 ) ([]*TreeNode, error) {
 	logger.Debug("Getting clickable elements for bundle ID",
 		zap.String("bundle_id", bundleID),
@@ -146,6 +152,10 @@ func ClickableElementsFromBundleID(
 	ignoreClickableCheck := false
 	if cfg := currentConfig(configProvider); cfg != nil {
 		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(bundleID)
+	}
+
+	if bypassCache {
+		cache.Clear()
 	}
 
 	elements := tree.FindClickableElements(

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -34,7 +34,9 @@ func MenuBarClickableElements(
 	defer menubar.Release()
 
 	opts := DefaultTreeOptions(logger)
-	if !bypassCache {
+	if bypassCache {
+		opts.SetCache(NewInfoCache(logger))
+	} else {
 		opts.SetCache(cache)
 	}
 
@@ -120,7 +122,9 @@ func ClickableElementsFromBundleID(
 	defer app.Release()
 
 	opts := DefaultTreeOptions(logger)
-	if !bypassCache {
+	if bypassCache {
+		opts.SetCache(NewInfoCache(logger))
+	} else {
 		opts.SetCache(cache)
 	}
 

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -75,7 +75,7 @@ func MenuBarClickableElements(
 	}
 
 	if bypassCache {
-		cache.Clear()
+		cache = nil
 	}
 
 	elements := tree.FindClickableElements(
@@ -155,7 +155,7 @@ func ClickableElementsFromBundleID(
 	}
 
 	if bypassCache {
-		cache.Clear()
+		cache = nil
 	}
 
 	elements := tree.FindClickableElements(

--- a/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
@@ -165,6 +165,7 @@ static bool detectMissionControlActive(void) {
 		CFIndex count = CFArrayGetCount(windowList);
 		int fullscreenDockWindows = 0;
 		int highLayerDockWindows = 0;
+		int anyHighLayerDockWindows = 0;
 		BOOL missionControlAppVisible = NO;
 
 		for (CFIndex i = 0; i < count; i++) {
@@ -183,6 +184,16 @@ static bool detectMissionControlActive(void) {
 				CFStringRef windowName = (CFStringRef)CFDictionaryGetValue(windowInfo, kCGWindowName);
 				CFDictionaryRef bounds = (CFDictionaryRef)CFDictionaryGetValue(windowInfo, kCGWindowBounds);
 				CFNumberRef windowLayer = (CFNumberRef)CFDictionaryGetValue(windowInfo, kCGWindowLayer);
+
+				int layer = 0;
+				if (windowLayer) {
+					CFNumberGetValue(windowLayer, kCFNumberIntType, &layer);
+				}
+
+				// Count any Dock window at layers 18-20 (only exist during Mission Control)
+				if (layer >= 18 && layer <= 20) {
+					anyHighLayerDockWindows++;
+				}
 
 				if (bounds) {
 					double x = 0, y = 0, w = 0, h = 0;
@@ -214,10 +225,6 @@ static bool detectMissionControlActive(void) {
 
 					// Window must have no name (Mission Control Dock windows are unnamed)
 					bool hasNoName = (!windowName || CFStringGetLength(windowName) == 0);
-					int layer = 0;
-					if (windowLayer) {
-						CFNumberGetValue(windowLayer, kCFNumberIntType, &layer);
-					}
 
 					if (isFullscreen && hasNoName && windowLayer) {
 						fullscreenDockWindows++;
@@ -233,13 +240,16 @@ static bool detectMissionControlActive(void) {
 
 		// Detection logic:
 		// 1. If Mission Control app window is visible, definitely MC
-		// 2. Otherwise, check for multiple fullscreen Dock windows:
+		// 2. If any Dock windows exist at layers 18-20, definitely MC (these layers only appear during MC)
+		// 3. Otherwise, check for multiple fullscreen Dock windows:
 		//    - Mission Control with single space: 2 windows (layers 18 and 20)
 		//    - Mission Control with multiple spaces: 3+ windows
 		int minRequired = 2;
 		BOOL result = NO;
 
 		if (missionControlAppVisible) {
+			result = YES;
+		} else if (anyHighLayerDockWindows >= minRequired) {
 			result = YES;
 		} else if (fullscreenDockWindows >= minRequired && highLayerDockWindows >= minRequired) {
 			result = YES;

--- a/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
@@ -171,8 +171,6 @@ static bool detectMissionControlActive(void) {
 			}
 
 			if (ownerName && CFStringCompare(ownerName, CFSTR("Dock"), 0) == kCFCompareEqualTo) {
-				CFStringRef windowName = (CFStringRef)CFDictionaryGetValue(windowInfo, kCGWindowName);
-				CFDictionaryRef bounds = (CFDictionaryRef)CFDictionaryGetValue(windowInfo, kCGWindowBounds);
 				CFNumberRef windowLayer = (CFNumberRef)CFDictionaryGetValue(windowInfo, kCGWindowLayer);
 
 				int layer = 0;

--- a/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
@@ -154,17 +154,7 @@ static bool detectMissionControlActive(void) {
 			return false;
 		}
 
-		// Store all screen sizes for proper multi-monitor detection.
-		// This ensures we detect Mission Control windows on screens of any size.
-		NSMutableArray *screenSizes = [NSMutableArray arrayWithCapacity:screens.count];
-		for (NSScreen *screen in screens) {
-			NSValue *sizeValue = [NSValue valueWithSize:screen.frame.size];
-			[screenSizes addObject:sizeValue];
-		}
-
 		CFIndex count = CFArrayGetCount(windowList);
-		int fullscreenDockWindows = 0;
-		int highLayerDockWindows = 0;
 		int anyHighLayerDockWindows = 0;
 		BOOL missionControlAppVisible = NO;
 
@@ -194,45 +184,6 @@ static bool detectMissionControlActive(void) {
 				if (layer >= 18 && layer <= 20) {
 					anyHighLayerDockWindows++;
 				}
-
-				if (bounds) {
-					double x = 0, y = 0, w = 0, h = 0;
-					CFNumberRef xValue = (CFNumberRef)CFDictionaryGetValue(bounds, CFSTR("X"));
-					CFNumberRef yValue = (CFNumberRef)CFDictionaryGetValue(bounds, CFSTR("Y"));
-					CFNumberRef wValue = (CFNumberRef)CFDictionaryGetValue(bounds, CFSTR("Width"));
-					CFNumberRef hValue = (CFNumberRef)CFDictionaryGetValue(bounds, CFSTR("Height"));
-
-					if (xValue)
-						CFNumberGetValue(xValue, kCFNumberDoubleType, &x);
-					if (yValue)
-						CFNumberGetValue(yValue, kCFNumberDoubleType, &y);
-					if (wValue)
-						CFNumberGetValue(wValue, kCFNumberDoubleType, &w);
-					if (hValue)
-						CFNumberGetValue(hValue, kCFNumberDoubleType, &h);
-
-					// Check if window is fullscreen on ANY connected monitor.
-					// This is crucial for multi-monitor setups with different resolutions.
-					bool isFullscreen = false;
-					for (NSValue *sizeValue in screenSizes) {
-						CGSize screenSize = sizeValue.sizeValue;
-						// Allow 5% tolerance for window size variations
-						if (w >= screenSize.width * 0.95 && h >= screenSize.height * 0.95) {
-							isFullscreen = true;
-							break;
-						}
-					}
-
-					// Window must have no name (Mission Control Dock windows are unnamed)
-					bool hasNoName = (!windowName || CFStringGetLength(windowName) == 0);
-
-					if (isFullscreen && hasNoName && windowLayer) {
-						fullscreenDockWindows++;
-						if (layer >= 18 && layer <= 20) {
-							highLayerDockWindows++;
-						}
-					}
-				}
 			}
 		}
 
@@ -240,18 +191,14 @@ static bool detectMissionControlActive(void) {
 
 		// Detection logic:
 		// 1. If Mission Control app window is visible, definitely MC
-		// 2. If any Dock windows exist at layers 18-20, definitely MC (these layers only appear during MC)
-		// 3. Otherwise, check for multiple fullscreen Dock windows:
-		//    - Mission Control with single space: 2 windows (layers 18 and 20)
-		//    - Mission Control with multiple spaces: 3+ windows
+		// 2. If any Dock windows exist at layers 18-20, definitely MC
+		//    (these layers only appear during MC)
 		int minRequired = 2;
 		BOOL result = NO;
 
 		if (missionControlAppVisible) {
 			result = YES;
 		} else if (anyHighLayerDockWindows >= minRequired) {
-			result = YES;
-		} else if (fullscreenDockWindows >= minRequired && highLayerDockWindows >= minRequired) {
 			result = YES;
 		}
 

--- a/internal/core/ports/accessibility.go
+++ b/internal/core/ports/accessibility.go
@@ -75,6 +75,9 @@ type ElementFilter struct {
 	// IncludeOffscreen includes elements outside the visible screen area.
 	IncludeOffscreen bool
 
+	// StrictFiltering enables strict filtering.
+	StrictFiltering bool
+
 	// MinSize specifies the minimum element size to include.
 	MinSize image.Point
 

--- a/internal/core/ports/accessibility.go
+++ b/internal/core/ports/accessibility.go
@@ -72,9 +72,6 @@ type ElementFilter struct {
 	// Roles specifies which accessibility roles to include.
 	Roles []element.Role
 
-	// IncludeOffscreen includes elements outside the visible screen area.
-	IncludeOffscreen bool
-
 	// StrictFiltering enables strict filtering.
 	StrictFiltering bool
 
@@ -134,7 +131,6 @@ type ElementFilter struct {
 // DefaultElementFilter returns a filter with sensible defaults.
 func DefaultElementFilter() ElementFilter {
 	return ElementFilter{
-		IncludeOffscreen:          false,
 		MinSize:                   image.Point{X: 1, Y: 1},
 		IncludeMenubar:            false,
 		AdditionalMenubarTargets:  []string{},

--- a/internal/core/ports/accessibility_test.go
+++ b/internal/core/ports/accessibility_test.go
@@ -13,10 +13,6 @@ func TestDefaultElementFilter(t *testing.T) {
 	filter := ports.DefaultElementFilter()
 
 	// Check default values
-	if filter.IncludeOffscreen {
-		t.Error("Expected IncludeOffscreen to be false by default")
-	}
-
 	expectedMinSize := image.Point{X: 1, Y: 1}
 	if filter.MinSize != expectedMinSize {
 		t.Errorf("Expected MinSize to be %v, got %v", expectedMinSize, filter.MinSize)
@@ -67,7 +63,6 @@ func TestElementFilterStruct(t *testing.T) {
 	// Test that we can create and modify an ElementFilter
 	filter := ports.ElementFilter{
 		Roles:                     []element.Role{element.RoleButton},
-		IncludeOffscreen:          true,
 		MinSize:                   image.Point{X: 10, Y: 10},
 		ExcludeRoles:              []element.Role{element.RoleStaticText},
 		IncludeMenubar:            true,
@@ -81,10 +76,6 @@ func TestElementFilterStruct(t *testing.T) {
 
 	if len(filter.Roles) != 1 || filter.Roles[0] != element.RoleButton {
 		t.Errorf("Expected Roles to contain button role, got %v", filter.Roles)
-	}
-
-	if !filter.IncludeOffscreen {
-		t.Error("Expected IncludeOffscreen to be true")
 	}
 
 	if filter.MinSize.X != 10 || filter.MinSize.Y != 10 {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR improves the detection for our mission control state. Previously when you hover over the top bar in mission control, it will exit our detection... flawed.

- added a new check that counts any dock window at layer 18 - 20 as mission control
- added a new bypass cache for mission control hints

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/97102f98-76e0-46ce-8de2-8a89d2096daa

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
