### PR TITLE
fix(hints): improve notification center hints

### DIFF
--- a/internal/core/domain/element/element.go
+++ b/internal/core/domain/element/element.go
@@ -51,6 +51,10 @@ const (
 	RoleApplication        Role = "AXApplication"
 	RoleWindow             Role = "AXWindow"
 	RoleTabGroup           Role = "AXTabGroup"
+	RoleGroup              Role = "AXGroup"
+	RoleScrollArea         Role = "AXScrollArea"
+	RoleSplitGroup         Role = "AXSplitGroup"
+	RoleUnknown            Role = "AXUnknown"
 )
 
 // Element represents a UI element in the accessibility tree.

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -192,11 +192,17 @@ func (a *Adapter) addNotificationCenterElements(
 
 	a.logger.Debug("Adding notification center elements")
 
+	// Lots of notification roles are AXGroup, so we need to enable it here
+	originalRoles := a.client.ClickableRoles()
+	ncRoles := make([]string, len(originalRoles)+1)
+	copy(ncRoles, originalRoles)
+	ncRoles[len(originalRoles)] = string(element.RoleGroup)
+
 	ncNodes, ncNodesErr := a.client.ClickableElementsFromBundleID(
 		ncBundleID,
-		nil,
+		ncRoles,
 		false,
-		false,
+		true,
 	)
 	if ncNodesErr != nil {
 		a.logger.Warn("Failed to get notification center elements", zap.Error(ncNodesErr))

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -514,6 +514,7 @@ int hasClickAction(void *element) {
 		for (CFIndex i = 0; i < count; i++) {
 			CFStringRef action = (CFStringRef)CFArrayGetValueAtIndex(actions, i);
 			if (CFStringCompare(action, kAXPressAction, 0) == kCFCompareEqualTo ||
+			    CFStringCompare(action, CFSTR("AXScrollToVisible"), 0) == kCFCompareEqualTo ||
 			    CFStringCompare(action, CFSTR("AXShowMenu"), 0) == kCFCompareEqualTo ||
 			    CFStringCompare(action, CFSTR("AXConfirm"), 0) == kCFCompareEqualTo ||
 			    CFStringCompare(action, CFSTR("AXPick"), 0) == kCFCompareEqualTo ||
@@ -525,6 +526,18 @@ int hasClickAction(void *element) {
 			}
 		}
 		CFRelease(actions);
+	}
+
+	// Exclude known container/structural roles
+	// We exclude it here instead of on golang side because we still need to ensure if it has certain AXAction first
+	// above.
+	if (role) {
+		if (CFStringCompare(role, kAXScrollAreaRole, 0) == kCFCompareEqualTo ||
+		    CFStringCompare(role, kAXGroupRole, 0) == kCFCompareEqualTo ||
+		    CFStringCompare(role, kAXSplitGroupRole, 0) == kCFCompareEqualTo) {
+			CFRelease(role);
+			return 0;
+		}
 	}
 
 	// Some elements support AXPress even if not listed in action names


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds more clickable elements to the notification center, but this requires some workaround as follows:

- include `AXGroup` elements, as they are mainly not buttons
- need to bypass the cache, else weird thing happens. Normally this is fast, so i think it's fine to not using cache
- also include `AXScrollToVisible` action as clickable heuristic, this is the only indicator, and i think it's fine to include this for every other heuristic too

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/b7711580-98cf-4ed7-a2a2-9f75845baced

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
