### PR TITLE
feat(hints): add `AXGenericElement` to default clickable role

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -76,6 +76,7 @@ clickable_roles = [
     "AXMenuItem",
     "AXCell",
     "AXRow",
+	"AXGenericElement",
 ]
 ignore_clickable_check = false
 

--- a/internal/config/config_darwin.go
+++ b/internal/config/config_darwin.go
@@ -28,5 +28,6 @@ func applyPlatformDefaults(cfg *Config) {
 		"AXMenuItem",
 		"AXCell",
 		"AXRow",
+		"AXGenericElement",
 	)
 }

--- a/internal/core/domain/element/element.go
+++ b/internal/core/domain/element/element.go
@@ -55,6 +55,7 @@ const (
 	RoleScrollArea         Role = "AXScrollArea"
 	RoleSplitGroup         Role = "AXSplitGroup"
 	RoleUnknown            Role = "AXUnknown"
+	RoleGenericElement     Role = "AXGenericElement"
 )
 
 // Element represents a UI element in the accessibility tree.

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -332,7 +332,6 @@ var interactiveLeafRoles = map[element.Role]bool{
 	element.RoleDisclosureTriangle: true,
 	element.RoleTextArea:           true,
 	element.RoleTextField:          true,
-	element.RoleGenericElement:     true,
 	// element.RoleRadioButton:        true, // in safari, url bar is radio button, but has nested button in it...
 }
 

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -332,6 +332,7 @@ var interactiveLeafRoles = map[element.Role]bool{
 	element.RoleDisclosureTriangle: true,
 	element.RoleTextArea:           true,
 	element.RoleTextField:          true,
+	element.RoleGenericElement:     true,
 	// element.RoleRadioButton:        true, // in safari, url bar is radio button, but has nested button in it...
 }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds `AXGenericElement` to the clickable role defaults. This enables some hints on weather.app.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/84afafce-f1aa-4fc1-a973-baa5601cae26

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
