### PR TITLE
fix(hints): add explicit `includeOutOfBounds`

### DIFF
--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -176,6 +176,7 @@ func (a *Adapter) ClickableElements(
 						window,
 						stringRoles(filter.Roles),
 						filter.StrictFiltering,
+						filter.IncludeOutOfBounds,
 					)
 					if clickableNodesErr != nil {
 						window.Release()

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -27,7 +27,7 @@ func (a *Adapter) addMenubarElements(
 	menubarRoles[len(originalRoles)] = string(element.RoleMenuBarItem)
 
 	// Get menubar elements
-	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements(false)
+	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements(false, false)
 	if menubarNodesErr != nil {
 		a.logger.Warn("Failed to get menubar elements", zap.Error(menubarNodesErr))
 	} else {
@@ -63,6 +63,7 @@ func (a *Adapter) addMenubarElements(
 				bundleID,
 				menubarRoles,
 				false,
+				true,
 			)
 			if err != nil {
 				a.logger.Warn("Failed to get additional menubar elements",
@@ -156,7 +157,7 @@ func (a *Adapter) addDockElements(
 	}
 
 	// Build tree and find clickable elements
-	dockNodes, dockNodesErr := a.client.ClickableNodes(dockApp, dockRoles, false)
+	dockNodes, dockNodesErr := a.client.ClickableNodes(dockApp, dockRoles, false, true)
 	if dockNodesErr != nil {
 		a.logger.Warn("Failed to get dock elements", zap.Error(dockNodesErr))
 
@@ -201,6 +202,7 @@ func (a *Adapter) addNotificationCenterElements(
 		ncBundleID,
 		ncRoles,
 		false,
+		true,
 	)
 	if ncNodesErr != nil {
 		a.logger.Warn("Failed to get notification center elements", zap.Error(ncNodesErr))
@@ -260,7 +262,7 @@ func (a *Adapter) addStageManagerElements(
 	}
 
 	// Build tree and find clickable elements
-	wmNodes, wmNodesErr := a.client.ClickableNodes(wmApp, nil, false)
+	wmNodes, wmNodesErr := a.client.ClickableNodes(wmApp, nil, false, true)
 	if wmNodesErr != nil {
 		a.logger.Warn("Failed to get window manager elements", zap.Error(wmNodesErr))
 
@@ -297,6 +299,7 @@ func (a *Adapter) addPIPElements(
 		pipBundleID,
 		nil,
 		false,
+		true,
 	)
 	if pipNodesErr != nil {
 		a.logger.Warn("Failed to get Picture in Picture elements", zap.Error(pipNodesErr))
@@ -334,6 +337,7 @@ func (a *Adapter) addScreenCaptureElements(
 		screenCaptureBundleID,
 		nil,
 		false,
+		true,
 	)
 	if screenCaptureNodesErr != nil {
 		a.logger.Warn("Failed to get Screen Capture elements", zap.Error(screenCaptureNodesErr))

--- a/internal/core/infra/accessibility/client.go
+++ b/internal/core/infra/accessibility/client.go
@@ -29,12 +29,14 @@ type AXClient interface {
 		root AXElement,
 		roles []string,
 		strictFiltering bool,
+		includeOutOfBounds bool,
 	) ([]AXNode, error)
-	MenuBarClickableElements(strictFiltering bool) ([]AXNode, error)
+	MenuBarClickableElements(strictFiltering bool, includeOutOfBounds bool) ([]AXNode, error)
 	ClickableElementsFromBundleID(
 		bundleID string,
 		roles []string,
 		strictFiltering bool,
+		includeOutOfBounds bool,
 	) ([]AXNode, error)
 	ActiveScreenBounds() image.Rectangle
 

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -88,6 +88,7 @@ func (c *InfraAXClient) ClickableNodes(
 	root AXElement,
 	roles []string,
 	strictFiltering bool,
+	includeOutOfBounds bool,
 ) ([]AXNode, error) {
 	var element *Element
 
@@ -106,7 +107,7 @@ func (c *InfraAXClient) ClickableNodes(
 
 	opts := DefaultTreeOptions(c.logger)
 	opts.SetStrictFiltering(strictFiltering)
-	opts.SetIncludeOutOfBounds(!strictFiltering)
+	opts.SetIncludeOutOfBounds(includeOutOfBounds)
 
 	// Enable strict filtering for Chromium/Electron apps which have noisy DOM trees
 	bundleID := element.BundleIdentifier()
@@ -179,11 +180,13 @@ func (c *InfraAXClient) ApplicationByBundleID(bundleID string) (AXApp, error) {
 // MenuBarClickableElements returns clickable elements in the menu bar.
 func (c *InfraAXClient) MenuBarClickableElements(
 	strictFiltering bool,
+	includeOutOfBounds bool,
 ) ([]AXNode, error) {
 	nodes, nodesErr := MenuBarClickableElements(
 		c.logger,
 		c.configProvider,
 		strictFiltering,
+		includeOutOfBounds,
 	)
 	if nodesErr != nil {
 		return nil, derrors.Wrap(
@@ -210,6 +213,7 @@ func (c *InfraAXClient) ClickableElementsFromBundleID(
 	bundleID string,
 	roles []string,
 	strictFiltering bool,
+	includeOutOfBounds bool,
 ) ([]AXNode, error) {
 	nodes, nodesErr := ClickableElementsFromBundleID(
 		bundleID,
@@ -217,6 +221,7 @@ func (c *InfraAXClient) ClickableElementsFromBundleID(
 		c.logger,
 		c.configProvider,
 		strictFiltering,
+		includeOutOfBounds,
 	)
 	if nodesErr != nil {
 		return nil, derrors.Wrap(

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -41,11 +41,16 @@ type MockAXClient struct {
 
 	MockMissionControlActive bool
 
-	LastCalledBundleID         string
-	LastClickableNodesRoles    []string
-	LastBundleRoles            []string
-	LastMenuBarStrictFiltering bool
-	ClickableNodesRolesHistory [][]string
+	LastCalledBundleID                   string
+	LastClickableNodesRoles              []string
+	LastClickableNodesStrictFiltering    bool
+	LastClickableNodesIncludeOutOfBounds bool
+	LastBundleRoles                      []string
+	LastBundleStrictFiltering            bool
+	LastBundleIncludeOutOfBounds         bool
+	LastMenuBarStrictFiltering           bool
+	LastMenuBarIncludeOutOfBounds        bool
+	ClickableNodesRolesHistory           [][]string
 }
 
 // FrontmostWindow returns the configured frontmost window or error.
@@ -87,11 +92,13 @@ func (m *MockAXClient) ApplicationByBundleID(_ string) (AXApp, error) {
 func (m *MockAXClient) ClickableNodes(
 	_ AXElement,
 	roles []string,
-	_ bool,
-	_ bool,
+	strictFiltering bool,
+	includeOutOfBounds bool,
 ) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastClickableNodesRoles = roles
+	m.LastClickableNodesStrictFiltering = strictFiltering
+	m.LastClickableNodesIncludeOutOfBounds = includeOutOfBounds
 	m.ClickableNodesRolesHistory = append(m.ClickableNodesRolesHistory, roles)
 	m.mu.Unlock()
 
@@ -105,6 +112,7 @@ func (m *MockAXClient) MenuBarClickableElements(
 ) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastMenuBarStrictFiltering = strictFiltering
+	m.LastMenuBarIncludeOutOfBounds = includeOutOfBounds
 	m.mu.Unlock()
 
 	return m.MockMenuBarNodes, m.MockMenuBarNodesErr
@@ -120,6 +128,8 @@ func (m *MockAXClient) ClickableElementsFromBundleID(
 	m.mu.Lock()
 	m.LastCalledBundleID = bundleID
 	m.LastBundleRoles = roles
+	m.LastBundleStrictFiltering = strictFiltering
+	m.LastBundleIncludeOutOfBounds = includeOutOfBounds
 	m.mu.Unlock()
 
 	return m.MockBundleNodes, m.MockBundleNodesErr

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -88,6 +88,7 @@ func (m *MockAXClient) ClickableNodes(
 	_ AXElement,
 	roles []string,
 	_ bool,
+	_ bool,
 ) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastClickableNodesRoles = roles
@@ -98,7 +99,10 @@ func (m *MockAXClient) ClickableNodes(
 }
 
 // MenuBarClickableElements returns the configured menu bar nodes or error.
-func (m *MockAXClient) MenuBarClickableElements(strictFiltering bool) ([]AXNode, error) {
+func (m *MockAXClient) MenuBarClickableElements(
+	strictFiltering bool,
+	includeOutOfBounds bool,
+) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastMenuBarStrictFiltering = strictFiltering
 	m.mu.Unlock()
@@ -111,6 +115,7 @@ func (m *MockAXClient) ClickableElementsFromBundleID(
 	bundleID string,
 	roles []string,
 	strictFiltering bool,
+	includeOutOfBounds bool,
 ) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastCalledBundleID = bundleID

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -12,6 +12,7 @@ func MenuBarClickableElements(
 	logger *zap.Logger,
 	configProvider config.Provider,
 	strictFiltering bool,
+	includeOutOfBounds bool,
 ) ([]*TreeNode, error) {
 	logger.Debug("Getting clickable elements for menu bar")
 
@@ -34,7 +35,7 @@ func MenuBarClickableElements(
 	opts := DefaultTreeOptions(logger)
 
 	opts.SetStrictFiltering(strictFiltering)
-	opts.SetIncludeOutOfBounds(!strictFiltering)
+	opts.SetIncludeOutOfBounds(includeOutOfBounds)
 
 	if cfg := currentConfig(configProvider); cfg != nil {
 		opts.SetMaxDepth(cfg.Hints.MaxDepth)
@@ -94,6 +95,7 @@ func ClickableElementsFromBundleID(
 	logger *zap.Logger,
 	configProvider config.Provider,
 	strictFiltering bool,
+	includeOutOfBounds bool,
 ) ([]*TreeNode, error) {
 	logger.Debug("Getting clickable elements for bundle ID",
 		zap.String("bundle_id", bundleID),
@@ -110,7 +112,7 @@ func ClickableElementsFromBundleID(
 	opts := DefaultTreeOptions(logger)
 
 	opts.SetStrictFiltering(strictFiltering)
-	opts.SetIncludeOutOfBounds(!strictFiltering)
+	opts.SetIncludeOutOfBounds(includeOutOfBounds)
 
 	if cfg := currentConfig(configProvider); cfg != nil {
 		opts.SetMaxDepth(cfg.Hints.MaxDepth)

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -221,6 +221,7 @@ func (o *TreeOptions) SetStrictFiltering(strict bool) {
 func DefaultTreeOptions(logger *zap.Logger) TreeOptions {
 	return TreeOptions{
 		filterFunc:         nil,
+		strictFiltering:    false,
 		includeOutOfBounds: false,
 		parallelThreshold:  config.DefaultParallelThreshold,
 		maxParallelDepth:   config.DefaultMaxParallelDepth,

--- a/internal/core/ports/accessibility.go
+++ b/internal/core/ports/accessibility.go
@@ -66,6 +66,9 @@ type ElementFilter struct {
 	// StrictFiltering enables strict filtering.
 	StrictFiltering bool
 
+	// IncludeOutOfBounds enables including elements outside the screen bounds.
+	IncludeOutOfBounds bool
+
 	// MinSize specifies the minimum element size to include.
 	MinSize image.Point
 
@@ -123,6 +126,8 @@ type ElementFilter struct {
 func DefaultElementFilter() ElementFilter {
 	return ElementFilter{
 		MinSize:                   image.Point{X: 1, Y: 1},
+		StrictFiltering:           false,
+		IncludeOutOfBounds:        false,
 		IncludeMenubar:            false,
 		AdditionalMenubarTargets:  []string{},
 		IncludeDock:               false,


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds explicit `includeOutOfBounds` for more control and to prevent some nonsense hints.

Previously we are assuming that it is the opposite of `strictFiltering`, but after some testing, that's not the case.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
