### PR TITLE
fix(hints): better widget detection

### DIFF
--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -432,6 +432,7 @@ static CFStringRef kAXLinkRole = CFSTR("AXLink");
 static CFStringRef kAXCheckboxRole = CFSTR("AXCheckBox");
 static CFStringRef kAXFocusableAttribute = CFSTR("AXFocusable");
 static CFStringRef kAXVisibleAttribute = CFSTR("AXVisible");
+static CFStringRef kAXWidgetIdentifierPrefix = CFSTR("widget-local:");
 
 #pragma mark - Click Action Functions
 
@@ -497,9 +498,10 @@ int hasClickAction(void *element) {
 				isFocusable = CFBooleanGetValue((CFBooleanRef)value);
 			}
 
-			// AXIdentifier (locale-safe: checks for the `widget-local:` prefix used by all macOS widgets)
+			// AXIdentifier: checks for the `widget-local:` prefix (internal Apple convention,
+			// verified on macOS 14/15) used by all macOS Notification Center and desktop widgets.
 			else if (attr == kAXIdentifierAttribute && CFGetTypeID(value) == CFStringGetTypeID()) {
-				isWidget = CFStringHasPrefix((CFStringRef)value, CFSTR("widget-local:"));
+				isWidget = CFStringHasPrefix((CFStringRef)value, kAXWidgetIdentifierPrefix);
 			}
 		}
 
@@ -550,8 +552,7 @@ int hasClickAction(void *element) {
 		if (CFStringCompare(role, kAXScrollAreaRole, 0) == kCFCompareEqualTo ||
 		    CFStringCompare(role, kAXGroupRole, 0) == kCFCompareEqualTo ||
 		    CFStringCompare(role, kAXSplitGroupRole, 0) == kCFCompareEqualTo) {
-			// Override: macOS widgets (Notification Center, desktop) use AXGroup but are
-			// inherently interactive. Detected via locale-safe AXIdentifier `widget-local:` prefix.
+			// Override: macOS widgets use AXGroup but are inherently interactive.
 			if (isWidget) {
 				if (hasEnabledAttribute && explicitlyDisabled) {
 					CFRelease(role);

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -445,7 +445,7 @@ int hasClickAction(void *element) {
 	AXUIElementRef axElement = (AXUIElementRef)element;
 
 	CFTypeRef attrs[] = {
-	    kAXHiddenAttribute, kAXEnabledAttribute, kAXRoleAttribute, kAXFocusableAttribute, kAXRoleDescriptionAttribute};
+	    kAXHiddenAttribute, kAXEnabledAttribute, kAXRoleAttribute, kAXFocusableAttribute, kAXIdentifierAttribute};
 
 	CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 5, &kCFTypeArrayCallBacks);
 
@@ -497,9 +497,9 @@ int hasClickAction(void *element) {
 				isFocusable = CFBooleanGetValue((CFBooleanRef)value);
 			}
 
-			// AXRoleDescription
-			else if (attr == kAXRoleDescriptionAttribute && CFGetTypeID(value) == CFStringGetTypeID()) {
-				isWidget = (CFStringCompare((CFStringRef)value, CFSTR("widget"), 0) == kCFCompareEqualTo);
+			// AXIdentifier (locale-safe: checks for the `widget-local:` prefix used by all macOS widgets)
+			else if (attr == kAXIdentifierAttribute && CFGetTypeID(value) == CFStringGetTypeID()) {
+				isWidget = CFStringHasPrefix((CFStringRef)value, CFSTR("widget-local:"));
 			}
 		}
 
@@ -550,8 +550,8 @@ int hasClickAction(void *element) {
 		if (CFStringCompare(role, kAXScrollAreaRole, 0) == kCFCompareEqualTo ||
 		    CFStringCompare(role, kAXGroupRole, 0) == kCFCompareEqualTo ||
 		    CFStringCompare(role, kAXSplitGroupRole, 0) == kCFCompareEqualTo) {
-			// Override: macOS Notification Center widgets, desktop widgets, etc. use AXGroup
-			// but are inherently interactive elements that respond to clicks.
+			// Override: macOS widgets (Notification Center, desktop) use AXGroup but are
+			// inherently interactive. Detected via locale-safe AXIdentifier `widget-local:` prefix.
 			if (isWidget) {
 				CFRelease(role);
 				return 1;

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -444,9 +444,10 @@ int hasClickAction(void *element) {
 
 	AXUIElementRef axElement = (AXUIElementRef)element;
 
-	CFTypeRef attrs[] = {kAXHiddenAttribute, kAXEnabledAttribute, kAXRoleAttribute, kAXFocusableAttribute};
+	CFTypeRef attrs[] = {
+	    kAXHiddenAttribute, kAXEnabledAttribute, kAXRoleAttribute, kAXFocusableAttribute, kAXRoleDescriptionAttribute};
 
-	CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 4, &kCFTypeArrayCallBacks);
+	CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 5, &kCFTypeArrayCallBacks);
 
 	if (!attrArray)
 		return 0;
@@ -461,12 +462,13 @@ int hasClickAction(void *element) {
 	bool explicitlyDisabled = false;
 	bool hasEnabledAttribute = false;
 	bool isFocusable = false;
+	bool isWidget = false;
 	CFStringRef role = NULL;
 
 	if (err == kAXErrorSuccess && values) {
 		CFIndex count = CFArrayGetCount(values);
 
-		for (CFIndex i = 0; i < count && i < 4; i++) {
+		for (CFIndex i = 0; i < count && i < 5; i++) {
 			CFTypeRef value = CFArrayGetValueAtIndex(values, i);
 			CFTypeRef attr = attrs[i];
 
@@ -494,6 +496,11 @@ int hasClickAction(void *element) {
 			else if (attr == kAXFocusableAttribute && CFGetTypeID(value) == CFBooleanGetTypeID()) {
 				isFocusable = CFBooleanGetValue((CFBooleanRef)value);
 			}
+
+			// AXRoleDescription
+			else if (attr == kAXRoleDescriptionAttribute && CFGetTypeID(value) == CFStringGetTypeID()) {
+				isWidget = (CFStringCompare((CFStringRef)value, CFSTR("widget"), 0) == kCFCompareEqualTo);
+			}
 		}
 
 		CFRelease(values);
@@ -514,7 +521,6 @@ int hasClickAction(void *element) {
 				continue;
 
 			if (CFStringCompare(action, kAXPressAction, 0) == kCFCompareEqualTo ||
-			    CFStringCompare(action, CFSTR("AXScrollToVisible"), 0) == kCFCompareEqualTo ||
 			    CFStringCompare(action, CFSTR("AXShowMenu"), 0) == kCFCompareEqualTo ||
 			    CFStringCompare(action, CFSTR("AXConfirm"), 0) == kCFCompareEqualTo ||
 			    CFStringCompare(action, CFSTR("AXPick"), 0) == kCFCompareEqualTo ||
@@ -544,6 +550,13 @@ int hasClickAction(void *element) {
 		if (CFStringCompare(role, kAXScrollAreaRole, 0) == kCFCompareEqualTo ||
 		    CFStringCompare(role, kAXGroupRole, 0) == kCFCompareEqualTo ||
 		    CFStringCompare(role, kAXSplitGroupRole, 0) == kCFCompareEqualTo) {
+			// Override: macOS Notification Center widgets, desktop widgets, etc. use AXGroup
+			// but are inherently interactive elements that respond to clicks.
+			if (isWidget) {
+				CFRelease(role);
+				return 1;
+			}
+
 			CFRelease(role);
 			return 0;
 		}

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -553,6 +553,10 @@ int hasClickAction(void *element) {
 			// Override: macOS widgets (Notification Center, desktop) use AXGroup but are
 			// inherently interactive. Detected via locale-safe AXIdentifier `widget-local:` prefix.
 			if (isWidget) {
+				if (hasEnabledAttribute && explicitlyDisabled) {
+					CFRelease(role);
+					return 0;
+				}
 				CFRelease(role);
 				return 1;
 			}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR implements a better widget detection that previously relies on just `AXScrollToVisible` which is fragile and creates other noises.

In this implementation, we grab the `AXRoleDescription` and verify if it's `widget`, if yes, set it as clickable.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
