### PR TITLE
feat(hotkey): repeat global hotkey actions while held automatically

### DIFF
--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -41,6 +41,7 @@ func (a *App) prepareForConfigUpdate() {
 
 	if a.appState.HotkeysRegistered() {
 		a.logger.Info("Unregistering current hotkeys before reload")
+		a.stopAllHotkeyRepeats()
 		a.hotkeyManager.UnregisterAll()
 		a.appState.SetHotkeysRegistered(false)
 	}

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -451,6 +451,7 @@ func initializeShutdownChannel(app *App) {
 func cleanupInfrastructure(app *App) {
 	// Clean up hotkey service
 	if app.hotkeyManager != nil {
+		app.stopAllHotkeyRepeats()
 		app.hotkeyManager.UnregisterAll()
 		app.hotkeyManager = nil
 	}

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -66,6 +66,9 @@ type App struct {
 	// concurrent writers (theme change observer, IPC config reload, systray reload).
 	configMu sync.RWMutex
 
+	hotkeyRepeatMu      sync.Mutex
+	hotkeyRepeatCancels map[string]context.CancelFunc
+
 	// New Architecture Services
 	hintService            *services.HintService
 	gridService            *services.GridService

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -140,17 +140,25 @@ func (a *App) dispatchHotkeyActions(key string, actions []string) {
 }
 
 func (a *App) startHotkeyRepeat(key string, actions []string) {
-	a.stopHotkeyRepeat(key)
-
 	ctx, cancel := context.WithCancel(context.Background())
 
 	a.hotkeyRepeatMu.Lock()
+
+	oldCancel := a.hotkeyRepeatCancels[key]
+	if oldCancel != nil {
+		delete(a.hotkeyRepeatCancels, key)
+	}
+
 	if a.hotkeyRepeatCancels == nil {
 		a.hotkeyRepeatCancels = make(map[string]context.CancelFunc)
 	}
 
 	a.hotkeyRepeatCancels[key] = cancel
 	a.hotkeyRepeatMu.Unlock()
+
+	if oldCancel != nil {
+		oldCancel()
+	}
 
 	go func() {
 		defer func() {

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -232,7 +232,7 @@ func (a *App) hotkeyActionsRepeatWhileHeld(actions []string) bool {
 		return false
 	}
 
-	switch action.Name(parts[1]) {
+	switch action.Name(parts[1]) { //nolint:exhaustive
 	case action.NameScrollUp,
 		action.NameScrollDown,
 		action.NameScrollLeft,
@@ -241,29 +241,9 @@ func (a *App) hotkeyActionsRepeatWhileHeld(actions []string) bool {
 		action.NamePageDown,
 		action.NameMoveMouseRelative:
 		return true
-	case action.NameLeftClick,
-		action.NameRightClick,
-		action.NameMiddleClick,
-		action.NameMouseDown,
-		action.NameMouseUp,
-		action.NameMoveMouse,
-		action.NameScroll,
-		action.NameReset,
-		action.NameBackspace,
-		action.NameWaitForModeExit,
-		action.NameSaveCursorPos,
-		action.NameRestoreCursorPos,
-		action.NameMoveMonitor,
-		action.NameFeed,
-		action.NameGoTop,
-		action.NameGoBottom,
-		action.NameSleep,
-		action.NameCycleHint,
-		action.NameSearchHints:
+	default:
 		return false
 	}
-
-	return false
 }
 
 func hotkeyModifiersFromKey(key string) action.Modifiers {

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os/exec"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -12,6 +13,11 @@ import (
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+const (
+	globalHotkeyRepeatInitialDelay = 250 * time.Millisecond
+	globalHotkeyRepeatInterval     = 50 * time.Millisecond
 )
 
 // actionsReferenceDisabledMode reports whether any action in the list
@@ -70,35 +76,23 @@ func (a *App) registerHotkeys() {
 
 		var registerHotkeyErr error
 
-		_, registerHotkeyErr = a.hotkeyManager.Register(bindKey, func() {
-			// Run handler in separate goroutine so the hotkey callback returns quickly.
-			go func() {
-				defer func() {
-					if r := recover(); r != nil {
-						a.logger.Error(
-							"panic in hotkey handler",
-							zap.Any("recover", r),
-							zap.String("key", bindKey),
-						)
-					}
-				}()
+		if releaseManager, ok := a.hotkeyManager.(HotkeyReleaseService); ok &&
+			a.hotkeyActionsRepeatWhileHeld(bindActions) {
+			_, registerHotkeyErr = releaseManager.RegisterWithRelease(
+				bindKey,
+				func() {
+					a.startHotkeyRepeat(bindKey, bindActions)
+				},
+				func() {
+					a.stopHotkeyRepeat(bindKey)
+				},
+			)
+		} else {
+			_, registerHotkeyErr = a.hotkeyManager.Register(bindKey, func() {
+				a.dispatchHotkeyActionsAsync(bindKey, bindActions)
+			})
+		}
 
-				for _, actionStr := range bindActions {
-					trimmedAction := strings.TrimSpace(actionStr)
-					if trimmedAction == "" {
-						continue
-					}
-
-					executeHotkeyActionErr := a.executeHotkeyAction(bindKey, trimmedAction)
-					if executeHotkeyActionErr != nil {
-						a.logger.Error("hotkey action failed",
-							zap.String("key", bindKey),
-							zap.String("action", trimmedAction),
-							zap.Error(executeHotkeyActionErr))
-					}
-				}
-			}()
-		})
 		if registerHotkeyErr != nil {
 			a.logger.Error(
 				"Failed to register hotkey binding",
@@ -110,6 +104,158 @@ func (a *App) registerHotkeys() {
 			continue
 		}
 	}
+}
+
+func (a *App) dispatchHotkeyActionsAsync(key string, actions []string) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				a.logger.Error(
+					"panic in hotkey handler",
+					zap.Any("recover", r),
+					zap.String("key", key),
+				)
+			}
+		}()
+
+		a.dispatchHotkeyActions(key, actions)
+	}()
+}
+
+func (a *App) dispatchHotkeyActions(key string, actions []string) {
+	for _, actionStr := range actions {
+		trimmedAction := strings.TrimSpace(actionStr)
+		if trimmedAction == "" {
+			continue
+		}
+
+		executeHotkeyActionErr := a.executeHotkeyAction(key, trimmedAction)
+		if executeHotkeyActionErr != nil {
+			a.logger.Error("hotkey action failed",
+				zap.String("key", key),
+				zap.String("action", trimmedAction),
+				zap.Error(executeHotkeyActionErr))
+		}
+	}
+}
+
+func (a *App) startHotkeyRepeat(key string, actions []string) {
+	a.stopHotkeyRepeat(key)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	a.hotkeyRepeatMu.Lock()
+	if a.hotkeyRepeatCancels == nil {
+		a.hotkeyRepeatCancels = make(map[string]context.CancelFunc)
+	}
+
+	a.hotkeyRepeatCancels[key] = cancel
+	a.hotkeyRepeatMu.Unlock()
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				a.logger.Error(
+					"panic in repeating hotkey handler",
+					zap.Any("recover", r),
+					zap.String("key", key),
+				)
+			}
+		}()
+
+		a.dispatchHotkeyActions(key, actions)
+
+		initialTimer := time.NewTimer(globalHotkeyRepeatInitialDelay)
+		defer initialTimer.Stop()
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-initialTimer.C:
+		}
+
+		ticker := time.NewTicker(globalHotkeyRepeatInterval)
+		defer ticker.Stop()
+
+		for {
+			a.dispatchHotkeyActions(key, actions)
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+}
+
+func (a *App) stopHotkeyRepeat(key string) {
+	a.hotkeyRepeatMu.Lock()
+
+	cancel := a.hotkeyRepeatCancels[key]
+	if cancel != nil {
+		delete(a.hotkeyRepeatCancels, key)
+	}
+	a.hotkeyRepeatMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (a *App) stopAllHotkeyRepeats() {
+	a.hotkeyRepeatMu.Lock()
+	cancels := a.hotkeyRepeatCancels
+	a.hotkeyRepeatCancels = nil
+	a.hotkeyRepeatMu.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+}
+
+func (a *App) hotkeyActionsRepeatWhileHeld(actions []string) bool {
+	if len(actions) != 1 {
+		return false
+	}
+
+	parts := splitArgs(strings.TrimSpace(actions[0]))
+	if len(parts) < 2 || parts[0] != "action" {
+		return false
+	}
+
+	switch action.Name(parts[1]) {
+	case action.NameScrollUp,
+		action.NameScrollDown,
+		action.NameScrollLeft,
+		action.NameScrollRight,
+		action.NamePageUp,
+		action.NamePageDown,
+		action.NameMoveMouseRelative:
+		return true
+	case action.NameLeftClick,
+		action.NameRightClick,
+		action.NameMiddleClick,
+		action.NameMouseDown,
+		action.NameMouseUp,
+		action.NameMoveMouse,
+		action.NameScroll,
+		action.NameReset,
+		action.NameBackspace,
+		action.NameWaitForModeExit,
+		action.NameSaveCursorPos,
+		action.NameRestoreCursorPos,
+		action.NameMoveMonitor,
+		action.NameFeed,
+		action.NameGoTop,
+		action.NameGoBottom,
+		action.NameSleep,
+		action.NameCycleHint,
+		action.NameSearchHints:
+		return false
+	}
+
+	return false
 }
 
 func hotkeyModifiersFromKey(key string) action.Modifiers {
@@ -261,6 +407,7 @@ func (a *App) refreshHotkeysForAppOrCurrent(bundleID string) {
 	if !a.appState.IsEnabled() {
 		if a.appState.HotkeysRegistered() {
 			a.logger.Debug("Neru disabled; unregistering hotkeys")
+			a.stopAllHotkeyRepeats()
 			a.hotkeyManager.UnregisterAll()
 			a.appState.SetHotkeysRegistered(false)
 		}
@@ -288,6 +435,7 @@ func (a *App) refreshHotkeysForAppOrCurrent(bundleID string) {
 		if a.appState.HotkeysRegistered() {
 			a.logger.Info("Focused app excluded; unregistering global hotkeys",
 				zap.String("bundle_id", bundleID))
+			a.stopAllHotkeyRepeats()
 			a.hotkeyManager.UnregisterAll()
 			a.appState.SetHotkeysRegistered(false)
 		}

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -144,13 +144,13 @@ func (a *App) startHotkeyRepeat(key string, actions []string) {
 
 	a.hotkeyRepeatMu.Lock()
 
+	if a.hotkeyRepeatCancels == nil {
+		a.hotkeyRepeatCancels = make(map[string]context.CancelFunc)
+	}
+
 	oldCancel := a.hotkeyRepeatCancels[key]
 	if oldCancel != nil {
 		delete(a.hotkeyRepeatCancels, key)
-	}
-
-	if a.hotkeyRepeatCancels == nil {
-		a.hotkeyRepeatCancels = make(map[string]context.CancelFunc)
 	}
 
 	a.hotkeyRepeatCancels[key] = cancel

--- a/internal/app/hotkeys_test.go
+++ b/internal/app/hotkeys_test.go
@@ -140,3 +140,68 @@ func TestSplitArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestHotkeyActionsRepeatWhileHeld(t *testing.T) {
+	app := &App{}
+
+	tests := []struct {
+		name    string
+		actions []string
+		want    bool
+	}{
+		{
+			name:    "scroll down repeats",
+			actions: []string{"action scroll_down"},
+			want:    true,
+		},
+		{
+			name:    "page down repeats",
+			actions: []string{"action page_down"},
+			want:    true,
+		},
+		{
+			name:    "relative mouse movement repeats",
+			actions: []string{"action move_mouse_relative --dx=0 --dy=10"},
+			want:    true,
+		},
+		{
+			name:    "mode launcher does not repeat",
+			actions: []string{"scroll"},
+			want:    false,
+		},
+		{
+			name:    "absolute terminal scroll does not repeat",
+			actions: []string{"action go_bottom"},
+			want:    false,
+		},
+		{
+			name:    "click does not repeat",
+			actions: []string{"action left_click"},
+			want:    false,
+		},
+		{
+			name:    "exec does not repeat",
+			actions: []string{"exec echo hello"},
+			want:    false,
+		},
+		{
+			name:    "chains do not repeat",
+			actions: []string{"action scroll_down", "action scroll_down"},
+			want:    false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := app.hotkeyActionsRepeatWhileHeld(testCase.actions)
+			if got != testCase.want {
+				t.Fatalf(
+					"hotkeyActionsRepeatWhileHeld(%v) = %v, want %v",
+					testCase.actions,
+					got,
+					testCase.want,
+				)
+			}
+		})
+	}
+}

--- a/internal/app/interfaces.go
+++ b/internal/app/interfaces.go
@@ -19,6 +19,15 @@ type HotkeyService interface {
 	UnregisterAll()
 }
 
+// HotkeyReleaseService is implemented by hotkey backends that can report release events.
+type HotkeyReleaseService interface {
+	RegisterWithRelease(
+		keyString string,
+		pressCallback hotkeys.Callback,
+		releaseCallback hotkeys.Callback,
+	) (hotkeys.HotkeyID, error)
+}
+
 // OverlayManager defines the interface for overlay window management.
 type OverlayManager = overlay.ManagerInterface
 

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -536,6 +536,7 @@ func (a *App) Cleanup() {
 		}
 
 		if a.hotkeyManager != nil {
+			a.stopAllHotkeyRepeats()
 			a.hotkeyManager.UnregisterAll()
 		}
 

--- a/internal/core/infra/hotkeys/manager_darwin.go
+++ b/internal/core/infra/hotkeys/manager_darwin.go
@@ -18,10 +18,15 @@ type HotkeyID int
 // Callback defines the function signature for hotkey event handlers.
 type Callback func()
 
+type callbackPair struct {
+	press   Callback
+	release Callback
+}
+
 // Manager handles the registration, unregistration, and dispatching of global hotkeys.
 // It maintains a mapping of hotkey IDs to their corresponding callback functions.
 type Manager struct {
-	callbacks map[HotkeyID]Callback
+	callbacks map[HotkeyID]callbackPair
 	mu        sync.RWMutex
 	logger    *zap.Logger
 	nextID    HotkeyID
@@ -31,7 +36,7 @@ type Manager struct {
 // The manager is ready to register hotkeys immediately after creation.
 func NewManager(logger *zap.Logger) *Manager {
 	manager := &Manager{
-		callbacks: make(map[HotkeyID]Callback),
+		callbacks: make(map[HotkeyID]callbackPair),
 		logger:    logger,
 		nextID:    1,
 	}
@@ -43,6 +48,15 @@ func NewManager(logger *zap.Logger) *Manager {
 // The keyString parameter should follow the format "Cmd+Shift+X" or similar modifier combinations.
 // Returns the assigned HotkeyID and an error if registration fails.
 func (m *Manager) Register(keyString string, callback Callback) (HotkeyID, error) {
+	return m.RegisterWithRelease(keyString, callback, nil)
+}
+
+// RegisterWithRelease adds a new global hotkey with press and optional release callbacks.
+func (m *Manager) RegisterWithRelease(
+	keyString string,
+	pressCallback Callback,
+	releaseCallback Callback,
+) (HotkeyID, error) {
 	m.logger.Debug("Registering hotkey", zap.String("key", keyString))
 
 	m.mu.Lock()
@@ -85,7 +99,10 @@ func (m *Manager) Register(keyString string, callback Callback) (HotkeyID, error
 	}
 
 	// Store callback
-	m.callbacks[hotkeyID] = callback
+	m.callbacks[hotkeyID] = callbackPair{
+		press:   pressCallback,
+		release: releaseCallback,
+	}
 
 	m.logger.Info("Registered hotkey",
 		zap.String("key", keyString),
@@ -118,25 +135,37 @@ func (m *Manager) UnregisterAll() {
 
 	darwin.UnregisterAllHotkeys()
 
-	m.callbacks = make(map[HotkeyID]Callback)
+	m.callbacks = make(map[HotkeyID]callbackPair)
 
 	m.logger.Info("Unregistered all hotkeys")
 }
 
 // handleCallback processes hotkey events received from the C callback darwin.
 // It looks up the appropriate callback function and executes it in a goroutine.
-func (m *Manager) handleCallback(hotkeyID HotkeyID) {
+func (m *Manager) handleCallback(hotkeyID HotkeyID, eventKind darwin.HotkeyEventKind) {
 	m.logger.Debug("Handling hotkey callback", zap.Int("id", int(hotkeyID)))
 
 	m.mu.RLock()
-	callback, ok := m.callbacks[hotkeyID]
+	callbacks, ok := m.callbacks[hotkeyID]
 	m.mu.RUnlock()
 
-	if ok && callback != nil {
-		m.logger.Debug("Hotkey pressed", zap.Int("id", int(hotkeyID)))
-		callback()
-	} else {
+	if !ok {
 		m.logger.Debug("No callback registered for hotkey", zap.Int("id", int(hotkeyID)))
+
+		return
+	}
+
+	switch eventKind {
+	case darwin.HotkeyEventReleased:
+		if callbacks.release != nil {
+			m.logger.Debug("Hotkey released", zap.Int("id", int(hotkeyID)))
+			callbacks.release()
+		}
+	case darwin.HotkeyEventPressed:
+		if callbacks.press != nil {
+			m.logger.Debug("Hotkey pressed", zap.Int("id", int(hotkeyID)))
+			callbacks.press()
+		}
 	}
 }
 
@@ -158,11 +187,13 @@ func SetGlobalManager(manager *Manager) {
 
 	// Set the handler in the darwin package
 	if manager != nil {
-		darwin.SetHotkeyHandler(func(hotkeyID int) {
+		darwin.SetHotkeyHandler(func(hotkeyID int, eventKind darwin.HotkeyEventKind) {
 			if globalManager != nil {
-				globalManager.logger.Debug("Hotkey callback bridge called", zap.Int("id", hotkeyID))
+				globalManager.logger.Debug("Hotkey callback bridge called",
+					zap.Int("id", hotkeyID),
+					zap.Int("event_kind", int(eventKind)))
 
-				go globalManager.handleCallback(HotkeyID(hotkeyID))
+				go globalManager.handleCallback(HotkeyID(hotkeyID), eventKind)
 			}
 		})
 	} else {

--- a/internal/core/infra/platform/darwin/bridge.go
+++ b/internal/core/infra/platform/darwin/bridge.go
@@ -8,7 +8,7 @@ package darwin
 #include "appwatcher.h"
 #include <stdlib.h>
 
-extern void hotkeyCallbackBridge(int hotkeyId, void* userData);
+extern void hotkeyCallbackBridge(int hotkeyId, int eventKind, void* userData);
 
 void startAppWatcher();
 void stopAppWatcher();
@@ -98,8 +98,18 @@ func ParseKeyString(keyString string) (int, int, bool) {
 	return int(keyCode), int(modifiers), success
 }
 
+// HotkeyEventKind describes whether a global hotkey was pressed or released.
+type HotkeyEventKind int
+
+const (
+	// HotkeyEventPressed is emitted when a registered hotkey is pressed.
+	HotkeyEventPressed HotkeyEventKind = 1
+	// HotkeyEventReleased is emitted when a registered hotkey is released.
+	HotkeyEventReleased HotkeyEventKind = 2
+)
+
 // HotkeyHandler defines the signature for hotkey event handlers.
-type HotkeyHandler func(hotkeyID int)
+type HotkeyHandler func(hotkeyID int, eventKind HotkeyEventKind)
 
 var (
 	hotkeyHandler   HotkeyHandler
@@ -121,13 +131,13 @@ func GetHotkeyCallbackBridge() unsafe.Pointer {
 }
 
 //export hotkeyCallbackBridge
-func hotkeyCallbackBridge(hotkeyID C.int, _ unsafe.Pointer) {
+func hotkeyCallbackBridge(hotkeyID C.int, eventKind C.int, _ unsafe.Pointer) {
 	hotkeyHandlerMu.RLock()
 	handler := hotkeyHandler
 	hotkeyHandlerMu.RUnlock()
 
 	if handler != nil {
-		handler(int(hotkeyID))
+		handler(int(hotkeyID), HotkeyEventKind(eventKind))
 	}
 }
 

--- a/internal/core/infra/platform/darwin/hotkeys.h
+++ b/internal/core/infra/platform/darwin/hotkeys.h
@@ -14,8 +14,9 @@
 
 /// Hotkey callback type
 /// @param hotkeyId Hotkey identifier
+/// @param eventKind Event kind (1 = pressed, 2 = released)
 /// @param userData User data pointer
-typedef void (*HotkeyCallback)(int hotkeyId, void *userData);
+typedef void (*HotkeyCallback)(int hotkeyId, int eventKind, void *userData);
 
 /// Modifier keys
 typedef enum {

--- a/internal/core/infra/platform/darwin/hotkeys_darwin.m
+++ b/internal/core/infra/platform/darwin/hotkeys_darwin.m
@@ -22,6 +22,9 @@ static NSMutableDictionary *hotkeyCallbacks = nil;
 static EventHandlerRef eventHandlerRef = NULL;
 static dispatch_queue_t hotkeyQueue = nil;
 
+static const int HotkeyEventPressed = 1;
+static const int HotkeyEventReleased = 2;
+
 #pragma mark - Storage Functions
 
 /// Initialize storage
@@ -33,10 +36,12 @@ static void initializeStorage(void) {
 		hotkeyQueue = dispatch_queue_create("com.neru.hotkeys", DISPATCH_QUEUE_SERIAL);
 
 		// Install event handler only once
-		EventTypeSpec eventType;
-		eventType.eventClass = kEventClassKeyboard;
-		eventType.eventKind = kEventHotKeyPressed;
-		InstallApplicationEventHandler(&hotkeyHandler, 1, &eventType, NULL, &eventHandlerRef);
+		EventTypeSpec eventTypes[2];
+		eventTypes[0].eventClass = kEventClassKeyboard;
+		eventTypes[0].eventKind = kEventHotKeyPressed;
+		eventTypes[1].eventClass = kEventClassKeyboard;
+		eventTypes[1].eventKind = kEventHotKeyReleased;
+		InstallApplicationEventHandler(&hotkeyHandler, 2, eventTypes, NULL, &eventHandlerRef);
 	});
 }
 
@@ -52,6 +57,8 @@ static OSStatus hotkeyHandler(EventHandlerCallRef nextHandler, EventRef event, v
 	GetEventParameter(event, kEventParamDirectObject, typeEventHotKeyID, NULL, sizeof(hotkeyID), NULL, &hotkeyID);
 
 	int hotkeyId = (int)hotkeyID.id;
+	UInt32 eventKind = GetEventKind(event);
+	int callbackEventKind = eventKind == kEventHotKeyReleased ? HotkeyEventReleased : HotkeyEventPressed;
 
 	// Thread-safe callback retrieval
 	__block HotkeyCallback callback = NULL;
@@ -68,7 +75,7 @@ static OSStatus hotkeyHandler(EventHandlerCallRef nextHandler, EventRef event, v
 
 	// Invoke callback outside the lock
 	if (callback) {
-		callback(hotkeyId, callbackUserData);
+		callback(hotkeyId, callbackEventKind, callbackUserData);
 	}
 
 	return noErr;


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds automatic hold-repeat support for repeatable global hotkey actions on macOS, but with certain restrictions that we think that it is worth repeating:

- The repeatable action needs to be one of `action scroll_xxx`, `action page_xxx`, or `action move_mouse_relative ...`
- The repeatable action is binded to global hotkey as a string

```toml
# these repeats...
[hotkeys]
"Primary+Alt+J" = "action scroll_down"
"Primary+Alt+K" = "action scroll_up"
"Primary+Alt+Down" = "action page_down"
"Primary+Alt+L" = "action move_mouse_relative --dx=10 --dy=0"

# these DOES NOT repeat....
"Primary+Alt+J" = ["action scroll_down", "hints", "action scroll_down"]
"Primary+Alt+J" = ["action scroll_down", "action scroll_down"]
"Primary+Alt+J" = "hints"
"Primary+Alt+J" = "action left_click"
"Primary+Alt+J" = "exec echo hi"
```

This change does not introduce any breaking changes nor config changes, it should just work as it is.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #816

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

The implementation uses Carbon hotkey release events instead of relying on the Quartz event tap. That keeps idle global hotkey repeat tied to the same backend that already owns global hotkey activation.

Repeat support is intentionally conservative and only applies to single bindings whose action naturally behaves like native key repeat. New actions that are expected to repeat needs to be explicitly added into the list.
