### PR TITLE
perf(hints): improve hint visibility checking

### DIFF
--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -693,11 +693,28 @@ func (e *Element) IsClickable(
 	if isRoleAllowed {
 		// Fast path: known-interactive roles (AXButton, AXLink, etc.)
 		// that are enabled don't need the expensive hasClickAction() CGo
-		// call which makes up to 5 AX API round-trips. The isEnabled
-		// flag was already fetched during tree building via getElementInfo.
+		// call which makes up to 5 AX API round-trips. We still verify
+		// actual hit-test visibility so hidden or scroll-clipped elements
+		// cannot get hints just because their role is known.
 		if info != nil && info.IsEnabled() {
 			if _, known := knownInteractiveRoles[element.Role(info.Role())]; known {
-				return true
+				// in mission control, let's skip it for good
+				if IsMissionControlActive() {
+					return true
+				}
+
+				// Skip visibility check for known problematic system apps
+				// (e.g. PiP windows, screen capture thumbnails) where AX hit-testing
+				// may incorrectly report elements as obscured.
+				if isExcludedBundleID(info.PID()) {
+					return true
+				}
+
+				center := C.CGPoint{
+					x: C.double(info.Position().X + info.Size().X/2),
+					y: C.double(info.Position().Y + info.Size().Y/2),
+				}
+				return C.isElementVisibleAtPoint(e.ref, center) == 1 //nolint:nlreturn
 			}
 		}
 
@@ -708,6 +725,51 @@ func (e *Element) IsClickable(
 	}
 
 	return false
+}
+
+var (
+	pidBundleCache    = map[int]string{}
+	pidBundleCacheMu  sync.RWMutex
+	excludedBundleIDs = map[string]struct{}{
+		"com.apple.PIPAgent":        {},
+		"com.apple.screencaptureui": {},
+		"com.apple.dock":            {},
+	}
+)
+
+// isExcludedBundleID checks if the process with the given PID belongs to a
+// bundle ID that should skip the expensive visibility check. Results are
+// cached by PID to avoid redundant Cocoa lookups.
+func isExcludedBundleID(pid int) bool {
+	pidBundleCacheMu.RLock()
+	b, ok := pidBundleCache[pid]
+	pidBundleCacheMu.RUnlock()
+
+	if ok {
+		_, excluded := excludedBundleIDs[b]
+
+		return excluded
+	}
+
+	cBundleID := C.getBundleIDForPID(C.int(pid))
+	if cBundleID == nil {
+		pidBundleCacheMu.Lock()
+		pidBundleCache[pid] = ""
+		pidBundleCacheMu.Unlock()
+
+		return false
+	}
+
+	bundleID := C.GoString(cBundleID)
+	C.freeString(cBundleID)
+
+	pidBundleCacheMu.Lock()
+	pidBundleCache[pid] = bundleID
+	pidBundleCacheMu.Unlock()
+
+	_, excluded := excludedBundleIDs[bundleID]
+
+	return excluded
 }
 
 // IsMissionControlActive checks if Mission Control is currently active.

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -719,7 +719,7 @@ func (e *Element) IsClickable(
 		}
 
 		// Slow path: ambiguous or custom roles need full native verification
-		result := C.hasClickAction(e.ref) //nolint:nlreturn
+		result := C.hasClickAction(e.ref, C.bool(isExcludedBundleID(info.PID()))) //nolint:nlreturn
 
 		return result == 1
 	}

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -727,6 +727,10 @@ func (e *Element) IsClickable(
 	return false
 }
 
+// pidBundleCache maps PID → bundle identifier to avoid repeated Cocoa lookups.
+// NOTE: PIDs are reused by macOS. The cache intentionally omits negative results
+// (empty bundleID) so that a reused PID is always re-queried rather than
+// inheriting a stale excluded mapping from a previous process.
 var (
 	pidBundleCache    = map[int]string{}
 	pidBundleCacheMu  sync.RWMutex
@@ -753,10 +757,6 @@ func isExcludedBundleID(pid int) bool {
 
 	cBundleID := C.getBundleIDForPID(C.int(pid))
 	if cBundleID == nil {
-		pidBundleCacheMu.Lock()
-		pidBundleCache[pid] = ""
-		pidBundleCacheMu.Unlock()
-
 		return false
 	}
 

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -667,6 +667,10 @@ func (e *Element) IsClickable(
 		return false
 	}
 
+	// Mission Control state is constant across a single hint scan; hoist
+	// the CGo round-trip to avoid calling it per element in the fast path.
+	missionControlActive := IsMissionControlActive()
+
 	// If info is not provided, try to get it
 	if info == nil {
 		var infoErr error
@@ -699,7 +703,7 @@ func (e *Element) IsClickable(
 		if info != nil && info.IsEnabled() {
 			if _, known := knownInteractiveRoles[element.Role(info.Role())]; known {
 				// in mission control, let's skip it for good
-				if IsMissionControlActive() {
+				if missionControlActive {
 					return true
 				}
 

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -735,9 +735,10 @@ var (
 	pidBundleCache    = map[int]string{}
 	pidBundleCacheMu  sync.RWMutex
 	excludedBundleIDs = map[string]struct{}{
-		"com.apple.PIPAgent":        {},
-		"com.apple.screencaptureui": {},
-		"com.apple.dock":            {},
+		"com.apple.PIPAgent":             {},
+		"com.apple.screencaptureui":      {},
+		"com.apple.dock":                 {},
+		"com.apple.notificationcenterui": {},
 	}
 )
 

--- a/internal/core/infra/platform/darwin/accessibility.go
+++ b/internal/core/infra/platform/darwin/accessibility.go
@@ -96,7 +96,7 @@ func HasClickAction(element unsafe.Pointer) bool {
 		return false
 	}
 
-	result := C.hasClickAction(element) != 0 //nolint:nlreturn
+	result := C.hasClickAction(element, false) != 0 //nolint:nlreturn
 
 	return result
 }

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -115,8 +115,9 @@ void postMouseMoveEvent(CGPoint position, CGEventType eventType);
 
 /// Check if element has click action
 /// @param element Element reference
+/// @param skipVisCheck If true, skip the expensive hit-test visibility check
 /// @return 1 if element is clickable, 0 otherwise
-int hasClickAction(void *element);
+int hasClickAction(void *element, bool skipVisCheck);
 
 /// Fast visibility check using a pre-computed center point (avoids redundant AX position fetch)
 /// @param element Element reference

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -118,6 +118,17 @@ void postMouseMoveEvent(CGPoint position, CGEventType eventType);
 /// @return 1 if element is clickable, 0 otherwise
 int hasClickAction(void *element);
 
+/// Check if element is actually visible at its click point
+/// @param element Element reference
+/// @return 1 if element or one of its descendants is hit-test visible, 0 otherwise
+int isElementActuallyVisible(void *element);
+
+/// Fast visibility check using a pre-computed center point (avoids redundant AX position fetch)
+/// @param element Element reference
+/// @param center Pre-computed center point (from ElementInfo — already fetched during tree building)
+/// @return 1 if element or one of its descendants is hit-test visible at the given point, 0 otherwise
+int isElementVisibleAtPoint(void *element, CGPoint center);
+
 /// Set focus to element
 /// @param element Element reference
 /// @return 1 on success, 0 on failure
@@ -181,6 +192,11 @@ char *getApplicationName(void *app);
 /// @param app Application reference
 /// @return Bundle identifier string
 char *getBundleIdentifier(void *app);
+
+/// Get bundle identifier from PID directly (avoids creating an AX element ref)
+/// @param pid Process identifier
+/// @return Bundle identifier string, or NULL if not found
+char *getBundleIDForPID(int pid);
 
 /// Set application attribute
 /// @param pid Process identifier

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -118,11 +118,6 @@ void postMouseMoveEvent(CGPoint position, CGEventType eventType);
 /// @return 1 if element is clickable, 0 otherwise
 int hasClickAction(void *element);
 
-/// Check if element is actually visible at its click point
-/// @param element Element reference
-/// @return 1 if element or one of its descendants is hit-test visible, 0 otherwise
-int isElementActuallyVisible(void *element);
-
 /// Fast visibility check using a pre-computed center point (avoids redundant AX position fetch)
 /// @param element Element reference
 /// @param center Pre-computed center point (from ElementInfo — already fetched during tree building)

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -473,7 +473,8 @@ static bool elementOrAncestorMatches(AXUIElementRef element, AXUIElementRef targ
 /// Caller should compute center from ElementInfo (already fetched during tree building).
 /// @param element Element reference
 /// @param center Pre-computed center point
-/// @return 1 if the element itself is the hit-test result at the point, or the result is a descendant of the element, 0 otherwise
+/// @return 1 if the element itself is the hit-test result at the point, or the result is a descendant of the element, 0
+/// otherwise
 int isElementVisibleAtPoint(void *element, CGPoint center) {
 	if (!element)
 		return 0;

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -508,8 +508,8 @@ int hasClickAction(void *element, bool skipVisCheck) {
 
 	AXUIElementRef axElement = (AXUIElementRef)element;
 
-	CFTypeRef attrs[] = {kAXHiddenAttribute,    kAXEnabledAttribute,    kAXRoleAttribute,
-	                     kAXIdentifierAttribute, kAXVisibleAttribute};
+	CFTypeRef attrs[] = {
+	    kAXHiddenAttribute, kAXEnabledAttribute, kAXRoleAttribute, kAXIdentifierAttribute, kAXVisibleAttribute};
 
 	CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 5, &kCFTypeArrayCallBacks);
 

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -500,44 +500,6 @@ static bool elementOrAncestorMatches(AXUIElementRef element, AXUIElementRef targ
 	return false;
 }
 
-/// Check if element is actually visible at its click point
-/// @param element Element reference
-/// @return 1 if element or one of its descendants is hit-test visible, 0 otherwise
-int isElementActuallyVisible(void *element) {
-	if (!element) {
-		return 0;
-	}
-
-	AXUIElementRef axElement = (AXUIElementRef)element;
-	if (elementBooleanAttributeIsTrue(axElement, kAXHiddenAttribute) ||
-	    elementBooleanAttributeIsFalse(axElement, kAXVisibleAttribute)) {
-		return 0;
-	}
-
-	CGPoint center;
-	if (!getElementCenter(element, &center)) {
-		return 0;
-	}
-
-	AXUIElementRef systemWide = AXUIElementCreateSystemWide();
-	if (!systemWide) {
-		return 0;
-	}
-
-	AXUIElementRef hitElement = NULL;
-	AXError error = AXUIElementCopyElementAtPosition(systemWide, center.x, center.y, &hitElement);
-	CFRelease(systemWide);
-
-	if (error != kAXErrorSuccess || !hitElement) {
-		return 0;
-	}
-
-	bool visible = elementOrAncestorMatches(hitElement, axElement);
-	CFRelease(hitElement);
-
-	return visible ? 1 : 0;
-}
-
 /// Fast visibility check using a pre-computed center point
 /// Skips hidden/visible attribute checks (caller handles those) and position fetch.
 /// Caller should compute center from ElementInfo (already fetched during tree building).

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -436,7 +436,6 @@ static CFStringRef kAXWidgetIdentifierPrefix = CFSTR("widget-local:");
 
 #pragma mark - Click Action Functions
 
-
 static bool elementOrAncestorMatches(AXUIElementRef element, AXUIElementRef target) {
 	if (!element || !target) {
 		return false;
@@ -474,7 +473,7 @@ static bool elementOrAncestorMatches(AXUIElementRef element, AXUIElementRef targ
 /// Caller should compute center from ElementInfo (already fetched during tree building).
 /// @param element Element reference
 /// @param center Pre-computed center point
-/// @return 1 if element or one of its descendants is hit-test visible at the given point, 0 otherwise
+/// @return 1 if the element itself is the hit-test result at the point, or the result is a descendant of the element, 0 otherwise
 int isElementVisibleAtPoint(void *element, CGPoint center) {
 	if (!element)
 		return 0;

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -500,17 +500,18 @@ int isElementVisibleAtPoint(void *element, CGPoint center) {
 
 /// Check if element has click action
 /// @param element Element reference
+/// @param skipVisCheck If true, skip the expensive hit-test visibility check
 /// @return 1 if element is clickable, 0 otherwise
-int hasClickAction(void *element) {
+int hasClickAction(void *element, bool skipVisCheck) {
 	if (!element)
 		return 0;
 
 	AXUIElementRef axElement = (AXUIElementRef)element;
 
 	CFTypeRef attrs[] = {kAXHiddenAttribute,    kAXEnabledAttribute,    kAXRoleAttribute,
-	                     kAXFocusableAttribute, kAXIdentifierAttribute, kAXVisibleAttribute};
+	                     kAXIdentifierAttribute, kAXVisibleAttribute};
 
-	CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 6, &kCFTypeArrayCallBacks);
+	CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 5, &kCFTypeArrayCallBacks);
 
 	if (!attrArray)
 		return 0;
@@ -525,14 +526,13 @@ int hasClickAction(void *element) {
 	bool isVisible = true;  // default visible when attribute not available
 	bool explicitlyDisabled = false;
 	bool hasEnabledAttribute = false;
-	bool isFocusable = false;
 	bool isWidget = false;
 	CFStringRef role = NULL;
 
 	if (err == kAXErrorSuccess && values) {
 		CFIndex count = CFArrayGetCount(values);
 
-		for (CFIndex i = 0; i < count && i < 6; i++) {
+		for (CFIndex i = 0; i < count && i < 5; i++) {
 			CFTypeRef value = CFArrayGetValueAtIndex(values, i);
 			CFTypeRef attr = attrs[i];
 
@@ -554,11 +554,6 @@ int hasClickAction(void *element) {
 			else if (attr == kAXRoleAttribute && CFGetTypeID(value) == CFStringGetTypeID()) {
 				role = (CFStringRef)value;
 				CFRetain(role);
-			}
-
-			// AXFocusable
-			else if (attr == kAXFocusableAttribute && CFGetTypeID(value) == CFBooleanGetTypeID()) {
-				isFocusable = CFBooleanGetValue((CFBooleanRef)value);
 			}
 
 			// AXIdentifier: checks for the `widget-local:` prefix (internal Apple convention,
@@ -660,19 +655,10 @@ int hasClickAction(void *element) {
 	// Visibility check: hit-test at center to filter obscured/scroll-clipped elements.
 	// Uses parent-walk (isElementVisibleAtPoint) instead of PID check (isPointVisible)
 	// to catch elements covered by sibling views within the same app.
-	// Skip for known problematic system apps where AX hit-testing is unreliable.
-	pid_t pid = 0;
-	if (AXUIElementGetPid(axElement, &pid) == kAXErrorSuccess) {
-		char *bundleID = getBundleIDForPID((int)pid);
-		if (bundleID) {
-			bool excluded = strcmp(bundleID, "com.apple.PIPAgent") == 0 ||
-			                strcmp(bundleID, "com.apple.screencaptureui") == 0 ||
-			                strcmp(bundleID, "com.apple.dock") == 0;
-			freeString(bundleID);
-			if (excluded)
-				return 1;
-		}
-	}
+	// skipVisCheck is set by the Go caller for known problematic system apps
+	// (e.g. PiP windows, screen capture thumbnails) where AX hit-testing is unreliable.
+	if (skipVisCheck)
+		return 1;
 
 	CGPoint center;
 	if (getElementCenter((void *)axElement, &center)) {

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -436,6 +436,137 @@ static CFStringRef kAXWidgetIdentifierPrefix = CFSTR("widget-local:");
 
 #pragma mark - Click Action Functions
 
+static bool elementBooleanAttributeIsFalse(AXUIElementRef element, CFStringRef attribute) {
+	CFTypeRef value = NULL;
+	AXError error = AXUIElementCopyAttributeValue(element, attribute, &value);
+	if (error != kAXErrorSuccess || !value) {
+		return false;
+	}
+
+	bool result = false;
+	if (CFGetTypeID(value) == CFBooleanGetTypeID()) {
+		result = !CFBooleanGetValue((CFBooleanRef)value);
+	}
+
+	CFRelease(value);
+	return result;
+}
+
+static bool elementBooleanAttributeIsTrue(AXUIElementRef element, CFStringRef attribute) {
+	CFTypeRef value = NULL;
+	AXError error = AXUIElementCopyAttributeValue(element, attribute, &value);
+	if (error != kAXErrorSuccess || !value) {
+		return false;
+	}
+
+	bool result = false;
+	if (CFGetTypeID(value) == CFBooleanGetTypeID()) {
+		result = CFBooleanGetValue((CFBooleanRef)value);
+	}
+
+	CFRelease(value);
+	return result;
+}
+
+static bool elementOrAncestorMatches(AXUIElementRef element, AXUIElementRef target) {
+	if (!element || !target) {
+		return false;
+	}
+
+	AXUIElementRef current = element;
+	CFRetain(current);
+
+	for (int depth = 0; current && depth < 64; depth++) {
+		if (CFEqual(current, target)) {
+			CFRelease(current);
+			return true;
+		}
+
+		AXUIElementRef parent = NULL;
+		AXError error = AXUIElementCopyAttributeValue(current, kAXParentAttribute, (CFTypeRef *)&parent);
+		CFRelease(current);
+
+		if (error != kAXErrorSuccess || !parent) {
+			return false;
+		}
+
+		current = parent;
+	}
+
+	if (current) {
+		CFRelease(current);
+	}
+
+	return false;
+}
+
+/// Check if element is actually visible at its click point
+/// @param element Element reference
+/// @return 1 if element or one of its descendants is hit-test visible, 0 otherwise
+int isElementActuallyVisible(void *element) {
+	if (!element) {
+		return 0;
+	}
+
+	AXUIElementRef axElement = (AXUIElementRef)element;
+	if (elementBooleanAttributeIsTrue(axElement, kAXHiddenAttribute) ||
+	    elementBooleanAttributeIsFalse(axElement, kAXVisibleAttribute)) {
+		return 0;
+	}
+
+	CGPoint center;
+	if (!getElementCenter(element, &center)) {
+		return 0;
+	}
+
+	AXUIElementRef systemWide = AXUIElementCreateSystemWide();
+	if (!systemWide) {
+		return 0;
+	}
+
+	AXUIElementRef hitElement = NULL;
+	AXError error = AXUIElementCopyElementAtPosition(systemWide, center.x, center.y, &hitElement);
+	CFRelease(systemWide);
+
+	if (error != kAXErrorSuccess || !hitElement) {
+		return 0;
+	}
+
+	bool visible = elementOrAncestorMatches(hitElement, axElement);
+	CFRelease(hitElement);
+
+	return visible ? 1 : 0;
+}
+
+/// Fast visibility check using a pre-computed center point
+/// Skips hidden/visible attribute checks (caller handles those) and position fetch.
+/// Caller should compute center from ElementInfo (already fetched during tree building).
+/// @param element Element reference
+/// @param center Pre-computed center point
+/// @return 1 if element or one of its descendants is hit-test visible at the given point, 0 otherwise
+int isElementVisibleAtPoint(void *element, CGPoint center) {
+	if (!element)
+		return 0;
+
+	AXUIElementRef axElement = (AXUIElementRef)element;
+
+	AXUIElementRef systemWide = AXUIElementCreateSystemWide();
+	if (!systemWide)
+		return 0;
+
+	AXUIElementRef hitElement = NULL;
+	AXError error = AXUIElementCopyElementAtPosition(systemWide, center.x, center.y, &hitElement);
+	CFRelease(systemWide);
+
+	if (error != kAXErrorSuccess || !hitElement)
+		return 0;
+
+	bool visible = elementOrAncestorMatches(hitElement, axElement);
+	CFRelease(hitElement);
+
+	return visible ? 1 : 0;
+}
+
 /// Check if element has click action
 /// @param element Element reference
 /// @return 1 if element is clickable, 0 otherwise
@@ -445,10 +576,10 @@ int hasClickAction(void *element) {
 
 	AXUIElementRef axElement = (AXUIElementRef)element;
 
-	CFTypeRef attrs[] = {
-	    kAXHiddenAttribute, kAXEnabledAttribute, kAXRoleAttribute, kAXFocusableAttribute, kAXIdentifierAttribute};
+	CFTypeRef attrs[] = {kAXHiddenAttribute,    kAXEnabledAttribute,    kAXRoleAttribute,
+	                     kAXFocusableAttribute, kAXIdentifierAttribute, kAXVisibleAttribute};
 
-	CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 5, &kCFTypeArrayCallBacks);
+	CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 6, &kCFTypeArrayCallBacks);
 
 	if (!attrArray)
 		return 0;
@@ -460,6 +591,7 @@ int hasClickAction(void *element) {
 	CFRelease(attrArray);
 
 	bool isHidden = false;
+	bool isVisible = true;  // default visible when attribute not available
 	bool explicitlyDisabled = false;
 	bool hasEnabledAttribute = false;
 	bool isFocusable = false;
@@ -469,7 +601,7 @@ int hasClickAction(void *element) {
 	if (err == kAXErrorSuccess && values) {
 		CFIndex count = CFArrayGetCount(values);
 
-		for (CFIndex i = 0; i < count && i < 5; i++) {
+		for (CFIndex i = 0; i < count && i < 6; i++) {
 			CFTypeRef value = CFArrayGetValueAtIndex(values, i);
 			CFTypeRef attr = attrs[i];
 
@@ -503,12 +635,17 @@ int hasClickAction(void *element) {
 			else if (attr == kAXIdentifierAttribute && CFGetTypeID(value) == CFStringGetTypeID()) {
 				isWidget = CFStringHasPrefix((CFStringRef)value, kAXWidgetIdentifierPrefix);
 			}
+
+			// AXVisible
+			else if (attr == kAXVisibleAttribute && CFGetTypeID(value) == CFBooleanGetTypeID()) {
+				isVisible = CFBooleanGetValue((CFBooleanRef)value);
+			}
 		}
 
 		CFRelease(values);
 	}
 
-	if (isHidden)
+	if (isHidden || !isVisible)
 		return 0;
 
 	// Explicit actions are the strongest signal, so we check for them first
@@ -589,21 +726,12 @@ int hasClickAction(void *element) {
 	if (role)
 		CFRelease(role);
 
-	// Visibility check: compute center+pid for each code path that needs it
+	// Visibility check: hit-test at center to filter obscured/scroll-clipped elements.
+	// Uses parent-walk (isElementVisibleAtPoint) instead of PID check (isPointVisible)
+	// to catch elements covered by sibling views within the same app.
 	CGPoint center;
-	pid_t pid;
-
-	// For focusable elements, check visibility
-	if (isFocusable) {
-		if (getElementCenter((void *)axElement, &center) && AXUIElementGetPid(axElement, &pid) == kAXErrorSuccess) {
-			return isPointVisible(center, pid) ? 1 : 0;
-		}
-		return 0;
-	}
-
-	// Final check for other elements: visible bounding box and not occluded
-	if (getElementCenter((void *)axElement, &center) && AXUIElementGetPid(axElement, &pid) == kAXErrorSuccess) {
-		return isPointVisible(center, pid) ? 1 : 0;
+	if (getElementCenter((void *)axElement, &center)) {
+		return isElementVisibleAtPoint((void *)axElement, center);
 	}
 
 	return 0;

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -436,37 +436,6 @@ static CFStringRef kAXWidgetIdentifierPrefix = CFSTR("widget-local:");
 
 #pragma mark - Click Action Functions
 
-static bool elementBooleanAttributeIsFalse(AXUIElementRef element, CFStringRef attribute) {
-	CFTypeRef value = NULL;
-	AXError error = AXUIElementCopyAttributeValue(element, attribute, &value);
-	if (error != kAXErrorSuccess || !value) {
-		return false;
-	}
-
-	bool result = false;
-	if (CFGetTypeID(value) == CFBooleanGetTypeID()) {
-		result = !CFBooleanGetValue((CFBooleanRef)value);
-	}
-
-	CFRelease(value);
-	return result;
-}
-
-static bool elementBooleanAttributeIsTrue(AXUIElementRef element, CFStringRef attribute) {
-	CFTypeRef value = NULL;
-	AXError error = AXUIElementCopyAttributeValue(element, attribute, &value);
-	if (error != kAXErrorSuccess || !value) {
-		return false;
-	}
-
-	bool result = false;
-	if (CFGetTypeID(value) == CFBooleanGetTypeID()) {
-		result = CFBooleanGetValue((CFBooleanRef)value);
-	}
-
-	CFRelease(value);
-	return result;
-}
 
 static bool elementOrAncestorMatches(AXUIElementRef element, AXUIElementRef target) {
 	if (!element || !target) {

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -483,7 +483,7 @@ int isElementVisibleAtPoint(void *element, CGPoint center) {
 
 	AXUIElementRef systemWide = AXUIElementCreateSystemWide();
 	if (!systemWide)
-		return 0;
+		return 1;  // Assume visible if system-wide ref cannot be created (mirrors isPointVisible)
 
 	AXUIElementRef hitElement = NULL;
 	AXError error = AXUIElementCopyElementAtPosition(systemWide, center.x, center.y, &hitElement);
@@ -660,6 +660,20 @@ int hasClickAction(void *element) {
 	// Visibility check: hit-test at center to filter obscured/scroll-clipped elements.
 	// Uses parent-walk (isElementVisibleAtPoint) instead of PID check (isPointVisible)
 	// to catch elements covered by sibling views within the same app.
+	// Skip for known problematic system apps where AX hit-testing is unreliable.
+	pid_t pid = 0;
+	if (AXUIElementGetPid(axElement, &pid) == kAXErrorSuccess) {
+		char *bundleID = getBundleIDForPID((int)pid);
+		if (bundleID) {
+			bool excluded = strcmp(bundleID, "com.apple.PIPAgent") == 0 ||
+			                strcmp(bundleID, "com.apple.screencaptureui") == 0 ||
+			                strcmp(bundleID, "com.apple.dock") == 0;
+			freeString(bundleID);
+			if (excluded)
+				return 1;
+		}
+	}
+
 	CGPoint center;
 	if (getElementCenter((void *)axElement, &center)) {
 		return isElementVisibleAtPoint((void *)axElement, center);

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -420,3 +420,20 @@ char *getBundleIdentifier(void *app) {
 		return cfStringToCString((__bridge CFStringRef)bundleId);
 	}
 }
+
+/// Get bundle identifier from PID directly
+/// @param pid Process identifier
+/// @return Bundle identifier string, or NULL if not found
+char *getBundleIDForPID(int pid) {
+	@autoreleasepool {
+		NSRunningApplication *runningApp = [NSRunningApplication runningApplicationWithProcessIdentifier:(pid_t)pid];
+		if (!runningApp)
+			return NULL;
+
+		NSString *bundleId = [runningApp bundleIdentifier];
+		if (!bundleId)
+			return NULL;
+
+		return cfStringToCString((__bridge CFStringRef)bundleId);
+	}
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR optimises the hint visibility checking mechanism by:

- slightly reducing AX calls
- ensure hints are visible instead of just show it if it's clickable element (e.g. within a scroll container)
- added mission control by pass, because the above check are too strict and mission control window thumbnail doesn't show hints anymore and requires a bypass.
- added bundle based exclusion, similar to mission control, mostly on elements that are not within the window, e.g. screen capture thumbnail, native pip window.

Overall i think this change doesn't slow down our hint activation, but reduces a lot of unneeded noises.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
