### PR TITLE
fix(hotkey): eliminate initial repeat delay for held-key actions

### DIFF
--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	globalHotkeyRepeatInitialDelay = 250 * time.Millisecond
+	globalHotkeyRepeatInitialDelay = 50 * time.Millisecond
 	globalHotkeyRepeatInterval     = 50 * time.Millisecond
 )
 
@@ -232,18 +232,7 @@ func (a *App) hotkeyActionsRepeatWhileHeld(actions []string) bool {
 		return false
 	}
 
-	switch action.Name(parts[1]) { //nolint:exhaustive
-	case action.NameScrollUp,
-		action.NameScrollDown,
-		action.NameScrollLeft,
-		action.NameScrollRight,
-		action.NamePageUp,
-		action.NamePageDown,
-		action.NameMoveMouseRelative:
-		return true
-	default:
-		return false
-	}
+	return action.IsHeldRepeatAction(action.Name(parts[1]))
 }
 
 func hotkeyModifiersFromKey(key string) action.Modifiers {

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -108,6 +108,7 @@ func (h *Handler) cleanupGridMode() {
 // performCommonCleanup handles common cleanup logic for all modes.
 func (h *Handler) performCommonCleanup() {
 	h.stopIndicatorPolling()
+	h.stopHeldRepeatLocked()
 	h.overlayManager.Clear()
 
 	// Stop any pending hints refresh timer to prevent re-activation after exit

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -122,6 +122,12 @@ type Handler struct {
 
 	// Cycle hint state
 	cycleHintIndex int
+
+	// heldRepeatingKey tracks which key is currently held for custom repeat.
+	// When non-empty, macOS native key-down events for this key are suppressed
+	// and a custom goroutine drives the repeat at heldRepeatInterval.
+	heldRepeatingKey    string
+	heldRepeatingCancel context.CancelFunc
 }
 
 // NewHandler creates a new mode handler.
@@ -836,4 +842,15 @@ func (h *Handler) focusedBundleID() string {
 	}
 
 	return bundleID
+}
+
+// stopHeldRepeatLocked cancels any running held-key repeat goroutine.
+// Caller must hold h.mu.
+func (h *Handler) stopHeldRepeatLocked() {
+	if h.heldRepeatingCancel != nil {
+		h.heldRepeatingCancel()
+		h.heldRepeatingCancel = nil
+	}
+
+	h.heldRepeatingKey = ""
 }

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -52,8 +52,18 @@ func (h *Handler) HandleKeyPress(key string) {
 
 	// Suppress macOS native key repeats when a custom held-key repeat is active.
 	// The custom goroutine handles repeat dispatch at heldRepeatInterval.
-	if h.heldRepeatingKey != "" && key == h.heldRepeatingKey {
-		return
+	// heldRepeatingKey stores the sticky-stripped key, so we strip before comparing.
+	if h.heldRepeatingKey != "" {
+		suppressKey := key
+
+		activeMods := h.stickyModifiers()
+		if activeMods != 0 && !strings.HasPrefix(suppressKey, modifierTogglePrefix) {
+			suppressKey = h.stripStickyModifiersFromKey(suppressKey, activeMods)
+		}
+
+		if suppressKey == h.heldRepeatingKey {
+			return
+		}
 	}
 
 	if h.appState.CurrentMode() == domain.ModeHints &&

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -115,13 +115,17 @@ func (h *Handler) HandleKeyPress(key string) {
 	// only. Sticky modifiers are for the next action, not Neru's own navigation
 	// keys; using rawKey here would make a sticky Ctrl turn "c" into "Ctrl+c".
 	if rawKey != key {
-		if h.handleHotkey(key, bundleID) {
-			h.maybeStartHeldRepeatLocked(key, bundleID)
+		if actions, ok := h.handleHotkey(key, bundleID); ok {
+			if len(actions) > 0 {
+				h.maybeStartHeldRepeatLocked(key, actions)
+			}
 
 			return
 		}
-	} else if h.handleHotkey(rawKey, bundleID) {
-		h.maybeStartHeldRepeatLocked(rawKey, bundleID)
+	} else if actions, ok := h.handleHotkey(rawKey, bundleID); ok {
+		if len(actions) > 0 {
+			h.maybeStartHeldRepeatLocked(rawKey, actions)
+		}
 
 		return
 	}
@@ -182,19 +186,21 @@ func (h *Handler) stripStickyModifiersFromKey(key string, mods action.Modifiers)
 
 // handleHotkey checks if the key matches a hotkeys binding for the
 // current mode. If matched, it executes the action (IPC command or shell command)
-// using the same logic as top-level hotkeys. Returns true if the key was consumed.
+// using the same logic as top-level hotkeys. Returns the matched actions along
+// with true if the key was consumed; returns nil, true for sequence starts (Phase 3)
+// where no action is dispatched yet.
 // Caller must hold h.mu. The bundleID is the focused app's bundle identifier,
 // resolved once by the caller to avoid redundant accessibility IPC calls.
-func (h *Handler) handleHotkey(key, bundleID string) bool {
+func (h *Handler) handleHotkey(key, bundleID string) ([]string, bool) {
 	if h.executeHotkeyAction == nil {
-		return false
+		return nil, false
 	}
 
 	currentModeName := domain.ModeString(h.appState.CurrentMode())
 
 	hotkeys := h.config.HotkeysForModeAndApp(currentModeName, bundleID)
 	if len(hotkeys) == 0 {
-		return false
+		return nil, false
 	}
 
 	normalizedKey := config.NormalizeKeyForComparison(key)
@@ -213,7 +219,7 @@ func (h *Handler) handleHotkey(key, bundleID string) bool {
 			); ok {
 				h.dispatchHotkeyActions(currentModeName, bindKey, key, actions)
 
-				return true
+				return actions, true
 			}
 		}
 
@@ -228,7 +234,7 @@ func (h *Handler) handleHotkey(key, bundleID string) bool {
 	if bindKey, actions, ok := findHotkeyMatch(hotkeys, normalizedKey); ok {
 		h.dispatchHotkeyActions(currentModeName, bindKey, key, actions)
 
-		return true
+		return actions, true
 	}
 
 	// Phase 3: start a new sequence for two-letter bindings.
@@ -236,10 +242,10 @@ func (h *Handler) handleHotkey(key, bundleID string) bool {
 		h.hotkeyLastKey = normalizedKey
 		h.hotkeyLastKeyTime = time.Now().UnixNano()
 
-		return true
+		return nil, true
 	}
 
-	return false
+	return nil, false
 }
 
 func findHotkeyMatch(
@@ -349,20 +355,16 @@ func (h *Handler) dispatchHotkeyActions(
 	}()
 }
 
-// maybeStartHeldRepeatLocked starts a custom repeat goroutine if the matched
-// hotkey action is a held-repeatable action (scroll, page, mouse move).
+// maybeStartHeldRepeatLocked starts a custom repeat goroutine if the given
+// actions are held-repeatable (scroll, page, mouse move).
+// actions is the already-resolved action list from handleHotkey.
 // Caller must hold h.mu.
-func (h *Handler) maybeStartHeldRepeatLocked(key, bundleID string) {
+func (h *Handler) maybeStartHeldRepeatLocked(key string, actions []string) {
 	if h.heldRepeatingCancel != nil {
 		return
 	}
 
-	currentModeName := domain.ModeString(h.appState.CurrentMode())
-	hotkeys := h.config.HotkeysForModeAndApp(currentModeName, bundleID)
-	normalizedKey := config.NormalizeKeyForComparison(key)
-
-	if _, actions, ok := findHotkeyMatch(hotkeys, normalizedKey); ok &&
-		isHeldRepeatAction(actions) {
+	if isHeldRepeatAction(actions) {
 		h.startHeldRepeatLocked(key, actions)
 	}
 }

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -125,16 +125,16 @@ func (h *Handler) HandleKeyPress(key string) {
 	// only. Sticky modifiers are for the next action, not Neru's own navigation
 	// keys; using rawKey here would make a sticky Ctrl turn "c" into "Ctrl+c".
 	if rawKey != key {
-		if actions, ok := h.handleHotkey(key, bundleID); ok {
+		if actions, bindKey, ok := h.handleHotkey(key, bundleID); ok {
 			if len(actions) > 0 {
-				h.maybeStartHeldRepeatLocked(key, actions)
+				h.maybeStartHeldRepeatLocked(key, bindKey, actions)
 			}
 
 			return
 		}
-	} else if actions, ok := h.handleHotkey(rawKey, bundleID); ok {
+	} else if actions, bindKey, ok := h.handleHotkey(rawKey, bundleID); ok {
 		if len(actions) > 0 {
-			h.maybeStartHeldRepeatLocked(rawKey, actions)
+			h.maybeStartHeldRepeatLocked(rawKey, bindKey, actions)
 		}
 
 		return
@@ -201,16 +201,18 @@ func (h *Handler) stripStickyModifiersFromKey(key string, mods action.Modifiers)
 // where no action is dispatched yet.
 // Caller must hold h.mu. The bundleID is the focused app's bundle identifier,
 // resolved once by the caller to avoid redundant accessibility IPC calls.
-func (h *Handler) handleHotkey(key, bundleID string) ([]string, bool) {
+func (h *Handler) handleHotkey(key, bundleID string) (
+	[]string, string, bool,
+) {
 	if h.executeHotkeyAction == nil {
-		return nil, false
+		return nil, "", false
 	}
 
 	currentModeName := domain.ModeString(h.appState.CurrentMode())
 
 	hotkeys := h.config.HotkeysForModeAndApp(currentModeName, bundleID)
 	if len(hotkeys) == 0 {
-		return nil, false
+		return nil, "", false
 	}
 
 	normalizedKey := config.NormalizeKeyForComparison(key)
@@ -223,13 +225,13 @@ func (h *Handler) handleHotkey(key, bundleID string) ([]string, bool) {
 		h.hotkeyLastKeyTime = 0
 
 		if pendingAt > 0 && time.Since(time.Unix(0, pendingAt)) <= hotkeySequenceTimeout {
-			if bindKey, actions, ok := findHotkeySequenceMatch(
+			if bindKey, act, ok := findHotkeySequenceMatch(
 				hotkeys,
 				pending+normalizedKey,
 			); ok {
-				h.dispatchHotkeyActions(currentModeName, bindKey, key, actions)
+				h.dispatchHotkeyActions(currentModeName, bindKey, key, act)
 
-				return actions, true
+				return act, bindKey, true
 			}
 		}
 
@@ -241,10 +243,10 @@ func (h *Handler) handleHotkey(key, bundleID string) ([]string, bool) {
 	}
 
 	// Phase 2: direct single-key match.
-	if bindKey, actions, ok := findHotkeyMatch(hotkeys, normalizedKey); ok {
-		h.dispatchHotkeyActions(currentModeName, bindKey, key, actions)
+	if bindKey, act, ok := findHotkeyMatch(hotkeys, normalizedKey); ok {
+		h.dispatchHotkeyActions(currentModeName, bindKey, key, act)
 
-		return actions, true
+		return act, bindKey, true
 	}
 
 	// Phase 3: start a new sequence for two-letter bindings.
@@ -252,10 +254,10 @@ func (h *Handler) handleHotkey(key, bundleID string) ([]string, bool) {
 		h.hotkeyLastKey = normalizedKey
 		h.hotkeyLastKeyTime = time.Now().UnixNano()
 
-		return nil, true
+		return nil, "", true
 	}
 
-	return nil, false
+	return nil, "", false
 }
 
 func findHotkeyMatch(
@@ -368,21 +370,23 @@ func (h *Handler) dispatchHotkeyActions(
 // maybeStartHeldRepeatLocked starts a custom repeat goroutine if the given
 // actions are held-repeatable (scroll, page, mouse move).
 // actions is the already-resolved action list from handleHotkey.
+// bindKey is the normalised config-binding key (for consistent logging).
 // Caller must hold h.mu.
-func (h *Handler) maybeStartHeldRepeatLocked(key string, actions []string) {
+func (h *Handler) maybeStartHeldRepeatLocked(key, bindKey string, actions []string) {
 	if h.heldRepeatingCancel != nil {
 		return
 	}
 
 	if isHeldRepeatAction(actions) {
-		h.startHeldRepeatLocked(key, actions)
+		h.startHeldRepeatLocked(key, bindKey, actions)
 	}
 }
 
 // startHeldRepeatLocked launches a goroutine that dispatches the held-key
 // action at heldRepeatInterval until the key-up event arrives.
+// bindKey is the normalised config-binding key (for consistent logging).
 // Caller must hold h.mu.
-func (h *Handler) startHeldRepeatLocked(key string, actions []string) {
+func (h *Handler) startHeldRepeatLocked(key, bindKey string, actions []string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	h.heldRepeatingKey = key
 	h.heldRepeatingCancel = cancel
@@ -392,7 +396,7 @@ func (h *Handler) startHeldRepeatLocked(key string, actions []string) {
 			if r := recover(); r != nil {
 				h.logger.Error("panic in held repeat handler",
 					zap.Any("recover", r),
-					zap.String("key", key))
+					zap.String("key", bindKey))
 			}
 		}()
 
@@ -410,10 +414,10 @@ func (h *Handler) startHeldRepeatLocked(key string, actions []string) {
 						continue
 					}
 
-					err := h.executeHotkeyAction(key, trimmedAction)
+					err := h.executeHotkeyAction(bindKey, trimmedAction)
 					if err != nil {
 						h.logger.Error("Held repeat action failed",
-							zap.String("key", key),
+							zap.String("key", bindKey),
 							zap.String("action", trimmedAction),
 							zap.Error(err))
 					}

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -391,6 +391,8 @@ func (h *Handler) startHeldRepeatLocked(key, bindKey string, actions []string) {
 	h.heldRepeatingKey = key
 	h.heldRepeatingCancel = cancel
 
+	capturedActions := append([]string(nil), actions...)
+
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -408,7 +410,7 @@ func (h *Handler) startHeldRepeatLocked(key, bindKey string, actions []string) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				for _, actionStr := range actions {
+				for _, actionStr := range capturedActions {
 					trimmedAction := strings.TrimSpace(actionStr)
 					if trimmedAction == "" {
 						continue

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -32,10 +32,19 @@ func (h *Handler) HandleKeyPress(key string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	// Handle key-up events for held-key repeat suppression
+	// Handle key-up events for held-key repeat suppression.
+	// The eventtap emits modifier-free key names on key-up, so we compare
+	// only the base key name (last segment after "+") case-insensitively.
 	if releasedKey, ok := strings.CutPrefix(key, keyUpPrefix); ok {
-		if releasedKey == h.heldRepeatingKey {
-			h.stopHeldRepeatLocked()
+		if h.heldRepeatingKey != "" {
+			baseHeld := h.heldRepeatingKey
+			if i := strings.LastIndex(baseHeld, "+"); i >= 0 {
+				baseHeld = baseHeld[i+1:]
+			}
+
+			if strings.EqualFold(releasedKey, baseHeld) {
+				h.stopHeldRepeatLocked()
+			}
 		}
 
 		return

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -434,7 +434,7 @@ func isHeldRepeatAction(actions []string) bool {
 		return false
 	}
 
-	parts := strings.Fields(strings.TrimSpace(actions[0]))
+	parts := strings.SplitN(strings.TrimSpace(actions[0]), " ", 3) //nolint:mnd
 	if len(parts) < 2 || parts[0] != "action" {
 		return false
 	}

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -1,6 +1,7 @@
 package modes
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -11,7 +12,12 @@ import (
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 )
 
-const hotkeySequenceTimeout = 500 * time.Millisecond
+const (
+	hotkeySequenceTimeout = 500 * time.Millisecond
+	heldRepeatInterval    = 50 * time.Millisecond
+)
+
+const keyUpPrefix = "__keyup_"
 
 const (
 	keyPartCmd    = "cmd"
@@ -25,6 +31,21 @@ const (
 func (h *Handler) HandleKeyPress(key string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
+	// Handle key-up events for held-key repeat suppression
+	if releasedKey, ok := strings.CutPrefix(key, keyUpPrefix); ok {
+		if releasedKey == h.heldRepeatingKey {
+			h.stopHeldRepeatLocked()
+		}
+
+		return
+	}
+
+	// Suppress macOS native key repeats when a custom held-key repeat is active.
+	// The custom goroutine handles repeat dispatch at heldRepeatInterval.
+	if h.heldRepeatingKey != "" && key == h.heldRepeatingKey {
+		return
+	}
 
 	if h.appState.CurrentMode() == domain.ModeHints &&
 		h.hints != nil && h.hints.Context != nil && h.hints.Context.SearchActive() {
@@ -86,9 +107,13 @@ func (h *Handler) HandleKeyPress(key string) {
 	// keys; using rawKey here would make a sticky Ctrl turn "c" into "Ctrl+c".
 	if rawKey != key {
 		if h.handleHotkey(key, bundleID) {
+			h.maybeStartHeldRepeatLocked(key, bundleID)
+
 			return
 		}
 	} else if h.handleHotkey(rawKey, bundleID) {
+		h.maybeStartHeldRepeatLocked(rawKey, bundleID)
+
 		return
 	}
 
@@ -313,4 +338,81 @@ func (h *Handler) dispatchHotkeyActions(
 			}
 		}
 	}()
+}
+
+// maybeStartHeldRepeatLocked starts a custom repeat goroutine if the matched
+// hotkey action is a held-repeatable action (scroll, page, mouse move).
+// Caller must hold h.mu.
+func (h *Handler) maybeStartHeldRepeatLocked(key, bundleID string) {
+	if h.heldRepeatingCancel != nil {
+		return
+	}
+
+	currentModeName := domain.ModeString(h.appState.CurrentMode())
+	hotkeys := h.config.HotkeysForModeAndApp(currentModeName, bundleID)
+	normalizedKey := config.NormalizeKeyForComparison(key)
+
+	if _, actions, ok := findHotkeyMatch(hotkeys, normalizedKey); ok &&
+		isHeldRepeatAction(actions) {
+		h.startHeldRepeatLocked(key, actions)
+	}
+}
+
+// startHeldRepeatLocked launches a goroutine that dispatches the held-key
+// action at heldRepeatInterval until the key-up event arrives.
+// Caller must hold h.mu.
+func (h *Handler) startHeldRepeatLocked(key string, actions []string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	h.heldRepeatingKey = key
+	h.heldRepeatingCancel = cancel
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				h.logger.Error("panic in held repeat handler",
+					zap.Any("recover", r),
+					zap.String("key", key))
+			}
+		}()
+
+		ticker := time.NewTicker(heldRepeatInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				for _, actionStr := range actions {
+					trimmedAction := strings.TrimSpace(actionStr)
+					if trimmedAction == "" {
+						continue
+					}
+
+					err := h.executeHotkeyAction(key, trimmedAction)
+					if err != nil {
+						h.logger.Error("Held repeat action failed",
+							zap.String("key", key),
+							zap.String("action", trimmedAction),
+							zap.Error(err))
+					}
+				}
+			}
+		}
+	}()
+}
+
+// isHeldRepeatAction reports whether the action list contains a single
+// held-repeatable action (scroll, page, or relative mouse move).
+func isHeldRepeatAction(actions []string) bool {
+	if len(actions) != 1 {
+		return false
+	}
+
+	parts := strings.Fields(strings.TrimSpace(actions[0]))
+	if len(parts) < 2 || parts[0] != "action" {
+		return false
+	}
+
+	return action.IsHeldRepeatAction(action.Name(parts[1]))
 }

--- a/internal/app/modes/scroll_mode.go
+++ b/internal/app/modes/scroll_mode.go
@@ -20,6 +20,7 @@ func NewScrollMode(handler *Handler) *ScrollMode {
 		},
 		ExitFunc: func(handler *Handler) {
 			handler.stopIndicatorPolling()
+			handler.stopHeldRepeatLocked()
 
 			handler.clearAndHideOverlay()
 

--- a/internal/core/domain/action/action.go
+++ b/internal/core/domain/action/action.go
@@ -297,6 +297,20 @@ func IsScrollSubAction(name string) bool {
 	}
 }
 
+// IsHeldRepeatAction reports whether the action name supports held-key repeat
+// (fires repeatedly while the key is held, with no initial delay).
+// Currently applies to scroll, page, and relative mouse move actions.
+func IsHeldRepeatAction(name Name) bool {
+	switch name { //nolint:exhaustive
+	case NameScrollUp, NameScrollDown, NameScrollLeft, NameScrollRight,
+		NamePageUp, NamePageDown,
+		NameMoveMouseRelative:
+		return true
+	default:
+		return false
+	}
+}
+
 // ToName converts a Type to its corresponding Name.
 func (t Type) ToName() Name {
 	switch t {

--- a/internal/core/infra/platform/darwin/eventtap_darwin.m
+++ b/internal/core/infra/platform/darwin/eventtap_darwin.m
@@ -536,6 +536,19 @@ CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 			return event;
 		}
 
+		if (type == kCGEventKeyUp) {
+			CGKeyCode keyCode = (CGKeyCode)CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
+			NSString *keyName = specialKeyName(keyCode);
+			if (!keyName) {
+				keyName = keyCodeToCharacter(keyCode, 0);
+			}
+			if (keyName && context->callback) {
+				NSString *keyUpStr = [NSString stringWithFormat:@"__keyup_%@", keyName];
+				context->callback([keyUpStr UTF8String], context->userData);
+			}
+			return event;
+		}
+
 		return event;
 	}
 }
@@ -581,7 +594,7 @@ EventTap createEventTap(EventTapCallback callback, void *userData) {
 	context->pendingAddSourceBlock = nil;
 
 	// Create the event tap
-	CGEventMask eventMask = (1 << kCGEventKeyDown) | (1 << kCGEventFlagsChanged);
+	CGEventMask eventMask = (1 << kCGEventKeyDown) | (1 << kCGEventKeyUp) | (1 << kCGEventFlagsChanged);
 	context->eventTap = CGEventTapCreate(
 	    kCGSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionDefault, eventMask, eventTapCallback, context);
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR override the macOS native key repeat initial delay ("Delay Until Repeat")
for held-key actions such as scroll, page, and relative mouse move.

- for global hotkeys, the initial delay is reduced from 250ms to 50ms
- for mode-level hotkeys, added a custom held-key repeat system to do the same thing

Both of these still share the same list of actions, and no configuration needed.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
