### PR TITLE
fix(hints): eliminate hidden elements and simplify filtering

### DIFF
--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -175,8 +175,6 @@ func (a *Adapter) ClickableElements(
 					clickableNodes, clickableNodesErr := a.client.ClickableNodes(
 						window,
 						stringRoles(filter.Roles),
-						filter.StrictFiltering,
-						filter.IncludeOutOfBounds,
 					)
 					if clickableNodesErr != nil {
 						window.Release()

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -27,7 +27,7 @@ func (a *Adapter) addMenubarElements(
 	menubarRoles[len(originalRoles)] = string(element.RoleMenuBarItem)
 
 	// Get menubar elements
-	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements(false, true)
+	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements()
 	if menubarNodesErr != nil {
 		a.logger.Warn("Failed to get menubar elements", zap.Error(menubarNodesErr))
 	} else {
@@ -62,8 +62,6 @@ func (a *Adapter) addMenubarElements(
 			additionalNodes, err := a.client.ClickableElementsFromBundleID(
 				bundleID,
 				menubarRoles,
-				false,
-				true,
 			)
 			if err != nil {
 				a.logger.Warn("Failed to get additional menubar elements",
@@ -157,7 +155,7 @@ func (a *Adapter) addDockElements(
 	}
 
 	// Build tree and find clickable elements
-	dockNodes, dockNodesErr := a.client.ClickableNodes(dockApp, dockRoles, false, true)
+	dockNodes, dockNodesErr := a.client.ClickableNodes(dockApp, dockRoles)
 	if dockNodesErr != nil {
 		a.logger.Warn("Failed to get dock elements", zap.Error(dockNodesErr))
 
@@ -201,8 +199,6 @@ func (a *Adapter) addNotificationCenterElements(
 	ncNodes, ncNodesErr := a.client.ClickableElementsFromBundleID(
 		ncBundleID,
 		ncRoles,
-		false,
-		true,
 	)
 	if ncNodesErr != nil {
 		a.logger.Warn("Failed to get notification center elements", zap.Error(ncNodesErr))
@@ -262,7 +258,7 @@ func (a *Adapter) addStageManagerElements(
 	}
 
 	// Build tree and find clickable elements
-	wmNodes, wmNodesErr := a.client.ClickableNodes(wmApp, nil, false, true)
+	wmNodes, wmNodesErr := a.client.ClickableNodes(wmApp, nil)
 	if wmNodesErr != nil {
 		a.logger.Warn("Failed to get window manager elements", zap.Error(wmNodesErr))
 
@@ -298,8 +294,6 @@ func (a *Adapter) addPIPElements(
 	pipNodes, pipNodesErr := a.client.ClickableElementsFromBundleID(
 		pipBundleID,
 		nil,
-		false,
-		true,
 	)
 	if pipNodesErr != nil {
 		a.logger.Warn("Failed to get Picture in Picture elements", zap.Error(pipNodesErr))
@@ -336,8 +330,6 @@ func (a *Adapter) addScreenCaptureElements(
 	screenCaptureNodes, screenCaptureNodesErr := a.client.ClickableElementsFromBundleID(
 		screenCaptureBundleID,
 		nil,
-		false,
-		true,
 	)
 	if screenCaptureNodesErr != nil {
 		a.logger.Warn("Failed to get Screen Capture elements", zap.Error(screenCaptureNodesErr))

--- a/internal/core/infra/accessibility/client.go
+++ b/internal/core/infra/accessibility/client.go
@@ -28,15 +28,11 @@ type AXClient interface {
 	ClickableNodes(
 		root AXElement,
 		roles []string,
-		strictFiltering bool,
-		includeOutOfBounds bool,
 	) ([]AXNode, error)
-	MenuBarClickableElements(strictFiltering bool, includeOutOfBounds bool) ([]AXNode, error)
+	MenuBarClickableElements() ([]AXNode, error)
 	ClickableElementsFromBundleID(
 		bundleID string,
 		roles []string,
-		strictFiltering bool,
-		includeOutOfBounds bool,
 	) ([]AXNode, error)
 	ActiveScreenBounds() image.Rectangle
 

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -721,45 +721,30 @@ func isExcludedOrUnsafe(bundleID string, configProvider config.Provider) bool {
 		return true
 	}
 
+	if isLikelyChromiumOrElectron(bundleID) {
+		return true
+	}
+
 	if configProvider == nil {
 		return false
 	}
 
 	cfg := configProvider.Get()
-
 	if cfg == nil {
 		return false
 	}
 
-	mergedChromiumBundles := config.KnownChromiumBundles
-	mergedChromiumBundles = append(
-		mergedChromiumBundles,
-		cfg.Hints.AdditionalAXSupport.AdditionalChromiumBundles...)
-
-	mergedElectronBundles := config.KnownElectronBundles
-	mergedElectronBundles = append(
-		mergedElectronBundles,
-		cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles...)
-
-	return matchesAnyFold(bundleID, mergedChromiumBundles) ||
-		matchesAnyFold(bundleID, mergedElectronBundles)
-}
-
-// matchesAnyFold returns true if s matches any entry in the list
-// (case-insensitive, trimmed).
-func matchesAnyFold(bundleID string, list []string) bool {
-	bundleID = strings.TrimSpace(bundleID)
-	if bundleID == "" {
-		return false
+	if config.MatchesAdditionalBundle(
+		bundleID,
+		cfg.Hints.AdditionalAXSupport.AdditionalChromiumBundles,
+	) {
+		return true
 	}
 
-	for _, entry := range list {
-		if strings.EqualFold(strings.TrimSpace(entry), bundleID) {
-			return true
-		}
-	}
-
-	return false
+	return config.MatchesAdditionalBundle(
+		bundleID,
+		cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles,
+	)
 }
 
 // isExcludedBundleID checks if the process with the given PID belongs to a

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -35,35 +35,6 @@ var (
 	clickableRolesMu sync.RWMutex
 )
 
-// knownInteractiveRoles are roles that are inherently interactive and don't
-// need the expensive hasClickAction() CGo call (up to 5 AX API round-trips)
-// to verify clickability. When an element has one of these roles and is
-// enabled, we can confidently skip the native verification. This eliminates
-// hundreds of CGo calls per activation for typical web pages.
-var knownInteractiveRoles = map[element.Role]struct{}{
-	element.RoleButton:             {},
-	element.RoleLink:               {},
-	element.RoleMenuItem:           {},
-	element.RoleMenuBarItem:        {},
-	element.RolePopUpButton:        {},
-	element.RoleTabButton:          {},
-	element.RoleCheckBox:           {},
-	element.RoleRadioButton:        {},
-	element.RoleSwitch:             {},
-	element.RoleDisclosureTriangle: {},
-	element.RoleComboBox:           {},
-	element.RoleDockItem:           {},
-	element.RoleTextField:          {},
-	element.RoleTextArea:           {},
-	element.RoleSlider:             {},
-	element.RoleIncrementor:        {},
-	element.RoleColorWell:          {},
-	element.RoleSearchField:        {},
-	element.RoleToolbarButton:      {},
-	element.RoleMenuButton:         {},
-	element.RoleToggle:             {},
-}
-
 var (
 	errSetFocusNil = derrors.New(
 		derrors.CodeAccessibilityFailed,
@@ -134,6 +105,8 @@ type ElementInfo struct {
 	roleDescription string
 	isEnabled       bool
 	isFocused       bool
+	isHidden        bool
+	isVisible       bool
 	pid             int
 }
 
@@ -185,6 +158,18 @@ func (ei *ElementInfo) IsEnabled() bool {
 // IsFocused returns whether the element is focused.
 func (ei *ElementInfo) IsFocused() bool {
 	return ei.isFocused
+}
+
+// IsHidden returns whether the element is AX-hidden
+// (e.g. CSS visibility:hidden, or the element is in an offscreen menu).
+func (ei *ElementInfo) IsHidden() bool {
+	return ei.isHidden
+}
+
+// IsVisible returns whether the element is AX-visible.
+// When the AXVisible attribute is not supported, returns true (default).
+func (ei *ElementInfo) IsVisible() bool {
+	return ei.isVisible
 }
 
 // PID returns the process ID.
@@ -276,6 +261,8 @@ func (e *Element) Info() (*ElementInfo, error) {
 		},
 		isEnabled: bool(cInfo.isEnabled),
 		isFocused: bool(cInfo.isFocused),
+		isHidden:  bool(cInfo.isHidden),
+		isVisible: bool(cInfo.isVisible),
 		pid:       int(cInfo.pid),
 	}
 
@@ -667,10 +654,6 @@ func (e *Element) IsClickable(
 		return false
 	}
 
-	// Mission Control state is constant across a single hint scan; hoist
-	// the CGo round-trip to avoid calling it per element in the fast path.
-	missionControlActive := IsMissionControlActive()
-
 	// If info is not provided, try to get it
 	if info == nil {
 		var infoErr error
@@ -695,35 +678,15 @@ func (e *Element) IsClickable(
 	}
 
 	if isRoleAllowed {
-		// Fast path: known-interactive roles (AXButton, AXLink, etc.)
-		// that are enabled don't need the expensive hasClickAction() CGo
-		// call which makes up to 5 AX API round-trips. We still verify
-		// actual hit-test visibility so hidden or scroll-clipped elements
-		// cannot get hints just because their role is known.
-		if info != nil && info.IsEnabled() {
-			if _, known := knownInteractiveRoles[element.Role(info.Role())]; known {
-				// in mission control, let's skip it for good
-				if missionControlActive {
-					return true
-				}
-
-				// Skip visibility check for known problematic system apps
-				// (e.g. PiP windows, screen capture thumbnails) where AX hit-testing
-				// may incorrectly report elements as obscured.
-				if isExcludedBundleID(info.PID()) {
-					return true
-				}
-
-				center := C.CGPoint{
-					x: C.double(info.Position().X + info.Size().X/2),
-					y: C.double(info.Position().Y + info.Size().Y/2),
-				}
-				return C.isElementVisibleAtPoint(e.ref, center) == 1 //nolint:nlreturn
-			}
-		}
-
-		// Slow path: ambiguous or custom roles need full native verification
-		result := C.hasClickAction(e.ref, C.bool(isExcludedBundleID(info.PID()))) //nolint:nlreturn
+		// hasClickAction handles all checks internally:
+		// 1. AXHidden/AXVisible attribute check (quick reject)
+		// 2. Clickability checks: AXActionNames → role exclusion → AXPress
+		//    description → link+URL (no early returns, accumulate result)
+		// 3. Hit-test visibility as final gate for ALL clickable results
+		result := C.hasClickAction(
+			e.ref,
+			C.bool(isExcludedBundleID(info.PID(), configProvider)), // nolint:nlreturn
+		)
 
 		return result == 1
 	}
@@ -746,18 +709,69 @@ var (
 	}
 )
 
+// isExcludedOrUnsafe checks whether the given bundle ID should skip the
+// hit-test visibility check — either because it is a known system bundle
+// where the check is not needed (excludedBundleIDs), or because AX hit-testing
+// is unreliable for that app (e.g. Chromium/Electron apps render UI in GPU
+// surfaces that don't expose fine-grained AX hit-testing).
+// Uses config.Known*Bundles as the source of truth (shared with the electron
+// package) rather than duplicating or importing electron directly.
+func isExcludedOrUnsafe(bundleID string, configProvider config.Provider) bool {
+	if _, excluded := excludedBundleIDs[bundleID]; excluded {
+		return true
+	}
+
+	if configProvider == nil {
+		return false
+	}
+
+	cfg := configProvider.Get()
+
+	if cfg == nil {
+		return false
+	}
+
+	mergedChromiumBundles := config.KnownChromiumBundles
+	mergedChromiumBundles = append(
+		mergedChromiumBundles,
+		cfg.Hints.AdditionalAXSupport.AdditionalChromiumBundles...)
+
+	mergedElectronBundles := config.KnownElectronBundles
+	mergedElectronBundles = append(
+		mergedElectronBundles,
+		cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles...)
+
+	return matchesAnyFold(bundleID, mergedChromiumBundles) ||
+		matchesAnyFold(bundleID, mergedElectronBundles)
+}
+
+// matchesAnyFold returns true if s matches any entry in the list
+// (case-insensitive, trimmed).
+func matchesAnyFold(bundleID string, list []string) bool {
+	bundleID = strings.TrimSpace(bundleID)
+	if bundleID == "" {
+		return false
+	}
+
+	for _, entry := range list {
+		if strings.EqualFold(strings.TrimSpace(entry), bundleID) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // isExcludedBundleID checks if the process with the given PID belongs to a
 // bundle ID that should skip the expensive visibility check. Results are
 // cached by PID to avoid redundant Cocoa lookups.
-func isExcludedBundleID(pid int) bool {
+func isExcludedBundleID(pid int, configProvider config.Provider) bool {
 	pidBundleCacheMu.RLock()
 	b, ok := pidBundleCache[pid]
 	pidBundleCacheMu.RUnlock()
 
 	if ok {
-		_, excluded := excludedBundleIDs[b]
-
-		return excluded
+		return isExcludedOrUnsafe(b, configProvider)
 	}
 
 	cBundleID := C.getBundleIDForPID(C.int(pid))
@@ -772,9 +786,7 @@ func isExcludedBundleID(pid int) bool {
 	pidBundleCache[pid] = bundleID
 	pidBundleCacheMu.Unlock()
 
-	_, excluded := excludedBundleIDs[bundleID]
-
-	return excluded
+	return isExcludedOrUnsafe(bundleID, configProvider)
 }
 
 // IsMissionControlActive checks if Mission Control is currently active.

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -3,7 +3,6 @@ package accessibility
 import (
 	"fmt"
 	"image"
-	"strings"
 
 	"go.uber.org/zap"
 
@@ -477,51 +476,4 @@ func (n *InfraNode) Release() {
 	if n.node != nil && n.node.Element() != nil {
 		n.node.Element().Release()
 	}
-}
-
-// isLikelyChromiumOrElectron returns true if the bundle ID matches known Chromium/Electron apps.
-// This is duplicated from electron package to avoid import cycle.
-func isLikelyChromiumOrElectron(bundleID string) bool {
-	if bundleID == "" {
-		return false
-	}
-
-	bundleID = strings.TrimSpace(bundleID)
-
-	for _, b := range config.KnownChromiumBundles {
-		if strings.EqualFold(b, bundleID) {
-			return true
-		}
-	}
-
-	for _, b := range config.KnownElectronBundles {
-		if strings.EqualFold(b, bundleID) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// isUserConfiguredChromiumElectron checks if the bundle ID matches user-configured
-// additional Chromium/Electron bundles from config. Supports exact matches and
-// wildcard patterns (ending with *).
-func isUserConfiguredChromiumElectron(bundleID string, configProvider config.Provider) bool {
-	if bundleID == "" || configProvider == nil {
-		return false
-	}
-
-	cfg := configProvider.Get()
-	if cfg == nil {
-		return false
-	}
-
-	chromiumBundles := cfg.Hints.AdditionalAXSupport.AdditionalChromiumBundles
-	if config.MatchesAdditionalBundle(bundleID, chromiumBundles) {
-		return true
-	}
-
-	electronBundles := cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles
-
-	return config.MatchesAdditionalBundle(bundleID, electronBundles)
 }

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -87,8 +87,6 @@ func (c *InfraAXClient) FocusedApplication() (AXApp, error) {
 func (c *InfraAXClient) ClickableNodes(
 	root AXElement,
 	roles []string,
-	strictFiltering bool,
-	includeOutOfBounds bool,
 ) ([]AXNode, error) {
 	var element *Element
 
@@ -106,16 +104,7 @@ func (c *InfraAXClient) ClickableNodes(
 	}
 
 	opts := DefaultTreeOptions(c.logger)
-	opts.SetStrictFiltering(strictFiltering)
-	opts.SetIncludeOutOfBounds(includeOutOfBounds)
-
-	// Enable strict filtering for Chromium/Electron apps which have noisy DOM trees
-	bundleID := element.BundleIdentifier()
-	if isLikelyChromiumOrElectron(bundleID) ||
-		isUserConfiguredChromiumElectron(bundleID, c.configProvider) {
-		opts.SetStrictFiltering(true)
-		opts.SetIncludeOutOfBounds(false) // strict filtering requires bound checks to be active
-	}
+	opts.SetConfigProvider(c.configProvider)
 
 	if cfg := currentConfig(c.configProvider); cfg != nil {
 		opts.SetMaxDepth(cfg.Hints.MaxDepth)
@@ -141,7 +130,7 @@ func (c *InfraAXClient) ClickableNodes(
 
 	ignoreClickableCheck := false
 	if cfg := currentConfig(c.configProvider); cfg != nil {
-		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(bundleID)
+		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(element.BundleIdentifier())
 	}
 
 	clickableNodes := tree.FindClickableElements(
@@ -178,15 +167,10 @@ func (c *InfraAXClient) ApplicationByBundleID(bundleID string) (AXApp, error) {
 }
 
 // MenuBarClickableElements returns clickable elements in the menu bar.
-func (c *InfraAXClient) MenuBarClickableElements(
-	strictFiltering bool,
-	includeOutOfBounds bool,
-) ([]AXNode, error) {
+func (c *InfraAXClient) MenuBarClickableElements() ([]AXNode, error) {
 	nodes, nodesErr := MenuBarClickableElements(
 		c.logger,
 		c.configProvider,
-		strictFiltering,
-		includeOutOfBounds,
 	)
 	if nodesErr != nil {
 		return nil, derrors.Wrap(
@@ -212,16 +196,12 @@ func (c *InfraAXClient) MenuBarClickableElements(
 func (c *InfraAXClient) ClickableElementsFromBundleID(
 	bundleID string,
 	roles []string,
-	strictFiltering bool,
-	includeOutOfBounds bool,
 ) ([]AXNode, error) {
 	nodes, nodesErr := ClickableElementsFromBundleID(
 		bundleID,
 		roles,
 		c.logger,
 		c.configProvider,
-		strictFiltering,
-		includeOutOfBounds,
 	)
 	if nodesErr != nil {
 		return nil, derrors.Wrap(

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -41,16 +41,10 @@ type MockAXClient struct {
 
 	MockMissionControlActive bool
 
-	LastCalledBundleID                   string
-	LastClickableNodesRoles              []string
-	LastClickableNodesStrictFiltering    bool
-	LastClickableNodesIncludeOutOfBounds bool
-	LastBundleRoles                      []string
-	LastBundleStrictFiltering            bool
-	LastBundleIncludeOutOfBounds         bool
-	LastMenuBarStrictFiltering           bool
-	LastMenuBarIncludeOutOfBounds        bool
-	ClickableNodesRolesHistory           [][]string
+	LastCalledBundleID         string
+	LastClickableNodesRoles    []string
+	LastBundleRoles            []string
+	ClickableNodesRolesHistory [][]string
 }
 
 // FrontmostWindow returns the configured frontmost window or error.
@@ -92,13 +86,9 @@ func (m *MockAXClient) ApplicationByBundleID(_ string) (AXApp, error) {
 func (m *MockAXClient) ClickableNodes(
 	_ AXElement,
 	roles []string,
-	strictFiltering bool,
-	includeOutOfBounds bool,
 ) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastClickableNodesRoles = roles
-	m.LastClickableNodesStrictFiltering = strictFiltering
-	m.LastClickableNodesIncludeOutOfBounds = includeOutOfBounds
 	m.ClickableNodesRolesHistory = append(m.ClickableNodesRolesHistory, roles)
 	m.mu.Unlock()
 
@@ -106,15 +96,7 @@ func (m *MockAXClient) ClickableNodes(
 }
 
 // MenuBarClickableElements returns the configured menu bar nodes or error.
-func (m *MockAXClient) MenuBarClickableElements(
-	strictFiltering bool,
-	includeOutOfBounds bool,
-) ([]AXNode, error) {
-	m.mu.Lock()
-	m.LastMenuBarStrictFiltering = strictFiltering
-	m.LastMenuBarIncludeOutOfBounds = includeOutOfBounds
-	m.mu.Unlock()
-
+func (m *MockAXClient) MenuBarClickableElements() ([]AXNode, error) {
 	return m.MockMenuBarNodes, m.MockMenuBarNodesErr
 }
 
@@ -122,14 +104,10 @@ func (m *MockAXClient) MenuBarClickableElements(
 func (m *MockAXClient) ClickableElementsFromBundleID(
 	bundleID string,
 	roles []string,
-	strictFiltering bool,
-	includeOutOfBounds bool,
 ) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastCalledBundleID = bundleID
 	m.LastBundleRoles = roles
-	m.LastBundleStrictFiltering = strictFiltering
-	m.LastBundleIncludeOutOfBounds = includeOutOfBounds
 	m.mu.Unlock()
 
 	return m.MockBundleNodes, m.MockBundleNodesErr

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -31,6 +31,7 @@ func MenuBarClickableElements(
 	defer menubar.Release()
 
 	opts := DefaultTreeOptions(logger)
+	opts.SetConfigProvider(configProvider)
 
 	if cfg := currentConfig(configProvider); cfg != nil {
 		opts.SetMaxDepth(cfg.Hints.MaxDepth)
@@ -103,6 +104,7 @@ func ClickableElementsFromBundleID(
 	defer app.Release()
 
 	opts := DefaultTreeOptions(logger)
+	opts.SetConfigProvider(configProvider)
 
 	if cfg := currentConfig(configProvider); cfg != nil {
 		opts.SetMaxDepth(cfg.Hints.MaxDepth)

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -11,8 +11,6 @@ import (
 func MenuBarClickableElements(
 	logger *zap.Logger,
 	configProvider config.Provider,
-	strictFiltering bool,
-	includeOutOfBounds bool,
 ) ([]*TreeNode, error) {
 	logger.Debug("Getting clickable elements for menu bar")
 
@@ -33,9 +31,6 @@ func MenuBarClickableElements(
 	defer menubar.Release()
 
 	opts := DefaultTreeOptions(logger)
-
-	opts.SetStrictFiltering(strictFiltering)
-	opts.SetIncludeOutOfBounds(includeOutOfBounds)
 
 	if cfg := currentConfig(configProvider); cfg != nil {
 		opts.SetMaxDepth(cfg.Hints.MaxDepth)
@@ -94,8 +89,6 @@ func ClickableElementsFromBundleID(
 	roles []string,
 	logger *zap.Logger,
 	configProvider config.Provider,
-	strictFiltering bool,
-	includeOutOfBounds bool,
 ) ([]*TreeNode, error) {
 	logger.Debug("Getting clickable elements for bundle ID",
 		zap.String("bundle_id", bundleID),
@@ -110,9 +103,6 @@ func ClickableElementsFromBundleID(
 	defer app.Release()
 
 	opts := DefaultTreeOptions(logger)
-
-	opts.SetStrictFiltering(strictFiltering)
-	opts.SetIncludeOutOfBounds(includeOutOfBounds)
 
 	if cfg := currentConfig(configProvider); cfg != nil {
 		opts.SetMaxDepth(cfg.Hints.MaxDepth)

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -39,6 +39,18 @@ func rectFromInfo(info *ElementInfo) image.Rectangle {
 	)
 }
 
+// screenBoundsOrRect returns the active screen bounds when the provided rect is
+// empty; otherwise returns the rect unchanged. This ensures that tree builders
+// for all sources (main window, supplementary) always have meaningful clip
+// bounds even when the root element has no position/size (e.g. an AXApplication).
+func screenBoundsOrRect(r image.Rectangle) image.Rectangle {
+	if r.Empty() {
+		return platformActiveScreenBounds()
+	}
+
+	return r
+}
+
 // treeNodePool is a pool of TreeNode structs to reduce GC pressure during
 // tree building. Hundreds of nodes are allocated per activation and released
 // shortly after processClickableNodes extracts the kept elements.
@@ -142,24 +154,19 @@ func (n *TreeNode) AddChild(child *TreeNode) {
 
 // TreeOptions configures accessibility tree traversal behavior and filtering.
 type TreeOptions struct {
-	filterFunc         func(*ElementInfo) bool
-	includeOutOfBounds bool
-	parallelThreshold  int
-	maxParallelDepth   int
-	maxDepth           int
-	logger             *zap.Logger
-	stats              *treeStats
-	strictFiltering    bool // Apply strict filtering for Chromium/Electron DOM trees
+	filterFunc        func(*ElementInfo) bool
+	parallelThreshold int
+	maxParallelDepth  int
+	maxDepth          int
+	logger            *zap.Logger
+	stats             *treeStats
+	bundleID          string          // Bundle ID for auto-detecting Chromium/Electron strict filtering
+	configProvider    config.Provider // For checking user-configured Chromium/Electron bundles
 }
 
 // FilterFunc returns the filter function.
 func (o *TreeOptions) FilterFunc() func(*ElementInfo) bool {
 	return o.filterFunc
-}
-
-// IncludeOutOfBounds returns whether to include out of bounds elements.
-func (o *TreeOptions) IncludeOutOfBounds() bool {
-	return o.includeOutOfBounds
 }
 
 // ParallelThreshold returns the parallel threshold.
@@ -187,19 +194,19 @@ func (o *TreeOptions) Stats() *treeStats {
 	return o.stats
 }
 
-// StrictFiltering returns whether strict filtering is enabled for Chromium/Electron.
-func (o *TreeOptions) StrictFiltering() bool {
-	return o.strictFiltering
+// SetBundleID sets the bundle ID for auto-detecting Chromium/Electron strict filtering.
+func (o *TreeOptions) SetBundleID(bundleID string) {
+	o.bundleID = bundleID
+}
+
+// SetConfigProvider sets the config provider for checking user-configured Chromium/Electron bundles.
+func (o *TreeOptions) SetConfigProvider(cp config.Provider) {
+	o.configProvider = cp
 }
 
 // SetFilterFunc sets the filter function.
 func (o *TreeOptions) SetFilterFunc(fn func(*ElementInfo) bool) {
 	o.filterFunc = fn
-}
-
-// SetIncludeOutOfBounds sets whether to include out of bounds elements.
-func (o *TreeOptions) SetIncludeOutOfBounds(include bool) {
-	o.includeOutOfBounds = include
 }
 
 // SetMaxDepth sets the max depth for tree traversal.
@@ -212,21 +219,14 @@ func (o *TreeOptions) SetParallelThreshold(threshold int) {
 	o.parallelThreshold = threshold
 }
 
-// SetStrictFiltering sets whether to apply strict filtering for Chromium/Electron DOM trees.
-func (o *TreeOptions) SetStrictFiltering(strict bool) {
-	o.strictFiltering = strict
-}
-
 // DefaultTreeOptions returns default tree traversal options.
 func DefaultTreeOptions(logger *zap.Logger) TreeOptions {
 	return TreeOptions{
-		filterFunc:         nil,
-		strictFiltering:    false,
-		includeOutOfBounds: false,
-		parallelThreshold:  config.DefaultParallelThreshold,
-		maxParallelDepth:   config.DefaultMaxParallelDepth,
-		maxDepth:           config.DefaultMaxDepth,
-		logger:             logger,
+		filterFunc:        nil,
+		parallelThreshold: config.DefaultParallelThreshold,
+		maxParallelDepth:  config.DefaultMaxParallelDepth,
+		maxDepth:          config.DefaultMaxDepth,
+		logger:            logger,
 	}
 }
 
@@ -283,8 +283,20 @@ func BuildTree(root *Element, opts TreeOptions) (*TreeNode, error) {
 
 	stats := &treeStats{}
 
-	// Calculate window bounds for spatial filtering
-	windowBounds := rectFromInfo(info)
+	// Calculate window bounds for spatial filtering.
+	// Fall back to active screen bounds when the root element has no
+	// position/size (e.g. an AXApplication for supplementary sources).
+	// For AXMenuBar, always use screen bounds since dropdown menus
+	// render below the bar itself and would be clipped otherwise.
+	windowBounds := screenBoundsOrRect(rectFromInfo(info))
+	if info.Role() == string(element.RoleMenuBar) {
+		windowBounds = platformActiveScreenBounds()
+	}
+
+	// Auto-detect Chromium/Electron from root element's bundle ID for strict filtering.
+	if opts.bundleID == "" {
+		opts.bundleID = root.BundleIdentifier()
+	}
 
 	node := getTreeNode(root, info, nil, config.DefaultChildrenCapacity)
 
@@ -353,7 +365,7 @@ func buildTreeRecursive(
 	parent *TreeNode,
 	depth int,
 	opts TreeOptions,
-	windowBounds image.Rectangle,
+	clipBounds image.Rectangle,
 ) {
 	if opts.stats != nil {
 		opts.stats.nodesVisited.Add(1)
@@ -375,6 +387,14 @@ func buildTreeRecursive(
 			opts.stats.skippedNonInteractive.Add(1)
 		}
 
+		return
+	}
+
+	// Don't traverse children of AX-hidden parents. This handles
+	// CSS visibility:hidden / opacity:0 inheritance in web content
+	// where the parent is marked hidden but children are not
+	// individually flagged. Also skip AXVisible=false elements.
+	if parent.info != nil && (parent.info.IsHidden() || !parent.info.IsVisible()) {
 		return
 	}
 
@@ -438,9 +458,9 @@ func buildTreeRecursive(
 		len(children) >= opts.parallelThreshold
 
 	if shouldParallelize {
-		buildChildrenParallel(parent, children, depth, opts, windowBounds)
+		buildChildrenParallel(parent, children, depth, opts, clipBounds)
 	} else {
-		buildChildrenSequential(parent, children, depth, opts, windowBounds)
+		buildChildrenSequential(parent, children, depth, opts, clipBounds)
 	}
 }
 
@@ -449,7 +469,7 @@ func buildChildrenSequential(
 	children []*Element,
 	depth int,
 	opts TreeOptions,
-	windowBounds image.Rectangle,
+	clipBounds image.Rectangle,
 ) {
 	// First pass: count valid children and collect their info
 	type childData struct {
@@ -469,7 +489,7 @@ func buildChildrenSequential(
 			continue
 		}
 
-		if !shouldIncludeElement(info, opts, windowBounds) {
+		if !shouldIncludeElement(info, opts, clipBounds) {
 			if opts.stats != nil {
 				opts.stats.filteredOut.Add(1)
 			}
@@ -493,7 +513,26 @@ func buildChildrenSequential(
 		childNode := getTreeNode(data.element, data.info, parent, 0)
 
 		parent.children = append(parent.children, childNode)
-		buildTreeRecursive(childNode, depth+1, opts, windowBounds)
+
+		newClipBounds := clipBounds
+		if element.Role(data.info.Role()) == element.RoleScrollArea {
+			childRect := rectFromInfo(data.info)
+			if childRect.Dx() > 0 && childRect.Dy() > 0 {
+				newClipBounds = childRect.Intersect(clipBounds)
+				if ce := opts.Logger().
+					Check(zap.DebugLevel, "Scroll area detected, tightening clip bounds"); ce != nil {
+					ce.Write(
+						zap.String("role", data.info.Role()),
+						zap.Int("clip_x", newClipBounds.Min.X),
+						zap.Int("clip_y", newClipBounds.Min.Y),
+						zap.Int("clip_w", newClipBounds.Dx()),
+						zap.Int("clip_h", newClipBounds.Dy()),
+					)
+				}
+			}
+		}
+
+		buildTreeRecursive(childNode, depth+1, opts, newClipBounds)
 	}
 
 	if opts.stats != nil {
@@ -506,7 +545,7 @@ func buildChildrenParallel(
 	children []*Element,
 	depth int,
 	opts TreeOptions,
-	windowBounds image.Rectangle,
+	clipBounds image.Rectangle,
 ) {
 	// Pre-allocate result slice with exact capacity
 	type childResult struct {
@@ -522,7 +561,7 @@ func buildChildrenParallel(
 	// Process children in parallel
 	for index, child := range children {
 		waitGroup.Add(1)
-		go func(idx int, elem *Element) {
+		go func(idx int, elem *Element, bounds image.Rectangle) {
 			defer waitGroup.Done()
 
 			info, err := elem.Info()
@@ -538,7 +577,7 @@ func buildChildrenParallel(
 				return
 			}
 
-			if !shouldIncludeElement(info, opts, windowBounds) {
+			if !shouldIncludeElement(info, opts, bounds) {
 				if opts.stats != nil {
 					opts.stats.filteredOut.Add(1)
 				}
@@ -552,11 +591,29 @@ func buildChildrenParallel(
 
 			childNode := getTreeNode(elem, info, parent, 0)
 
+			newClipBounds := bounds
+			if element.Role(info.Role()) == element.RoleScrollArea {
+				childRect := rectFromInfo(info)
+				if childRect.Dx() > 0 && childRect.Dy() > 0 {
+					newClipBounds = childRect.Intersect(bounds)
+					if ce := opts.Logger().
+						Check(zap.DebugLevel, "Parallel scroll area detected, tightening clip bounds"); ce != nil {
+						ce.Write(
+							zap.String("role", info.Role()),
+							zap.Int("clip_x", newClipBounds.Min.X),
+							zap.Int("clip_y", newClipBounds.Min.Y),
+							zap.Int("clip_w", newClipBounds.Dx()),
+							zap.Int("clip_h", newClipBounds.Dy()),
+						)
+					}
+				}
+			}
+
 			// Recursively build (this may spawn more goroutines at deeper levels)
-			buildTreeRecursive(childNode, depth+1, opts, windowBounds)
+			buildTreeRecursive(childNode, depth+1, opts, newClipBounds)
 
 			results <- childResult{node: childNode, index: idx}
-		}(index, child)
+		}(index, child, clipBounds)
 	}
 
 	// Close results channel when all goroutines complete
@@ -600,50 +657,76 @@ func buildChildrenParallel(
 const minElementSize = 15
 
 // shouldIncludeElement combines all filtering logic into one function.
+//
+// The clip-bounds overlap check is always applied so that ALL tree sources —
+// including supplementary ones (dock, menubar, PIP, etc.) — benefit from
+// spatial filtering against their respective clip bounds. Supplementary sources
+// historically passed includeOutOfBounds=true to bypass this check, which let
+// in off-screen elements from those sources.
 func shouldIncludeElement(
 	info *ElementInfo,
 	opts TreeOptions,
-	windowBounds image.Rectangle,
+	clipBounds image.Rectangle,
 ) bool {
-	if !opts.includeOutOfBounds {
-		elementRect := rectFromInfo(info)
+	elementRect := rectFromInfo(info)
 
-		// Filter out zero-sized interactive elements (they're broken/invalid)
-		if elementRect.Dx() == 0 || elementRect.Dy() == 0 {
-			if interactiveLeafRoles[element.Role(info.Role())] {
+	// Clip bounds check: always filter elements completely outside the
+	// visible area. This handles both window-level clipping (main window
+	// tree) and scroll-container clipping (AXScrollArea viewport), as well
+	// as screen-level clipping for supplementary sources where clip bounds
+	// fall back to the active screen bounds when the root rect is empty.
+	if elementRect.Dx() > 0 && elementRect.Dy() > 0 {
+		if !elementRect.Overlaps(clipBounds) {
+			if ce := opts.Logger().
+				Check(zap.DebugLevel, "Element filtered by clip bounds"); ce != nil {
+				ce.Write(
+					zap.String("role", info.Role()),
+					zap.Int("elem_x", elementRect.Min.X),
+					zap.Int("elem_y", elementRect.Min.Y),
+					zap.Int("elem_w", elementRect.Dx()),
+					zap.Int("elem_h", elementRect.Dy()),
+					zap.Int("clip_x", clipBounds.Min.X),
+					zap.Int("clip_y", clipBounds.Min.Y),
+					zap.Int("clip_w", clipBounds.Dx()),
+					zap.Int("clip_h", clipBounds.Dy()),
+				)
+			}
+
+			return false
+		}
+	}
+
+	// Filter out zero-sized interactive elements (they're broken/invalid)
+	if elementRect.Dx() == 0 || elementRect.Dy() == 0 {
+		if interactiveLeafRoles[element.Role(info.Role())] {
+			return false
+		}
+	}
+
+	// Strict filtering: auto-enabled for Chromium/Electron apps with noisy DOM trees
+	// For native apps like Safari, we trust the semantic tree to not have noise
+	if isChromiumOrElectron(opts.bundleID, opts.configProvider) && elementRect.Dx() > 0 &&
+		elementRect.Dy() > 0 {
+		// Filter out tiny elements that are likely noise in Chromium DOM trees.
+		// This is especially important for web content where the DOM can have
+		// thousands of tiny placeholder/structure elements.
+		// Filter if either dimension is too small (not just both)
+		if elementRect.Dx() < minElementSize || elementRect.Dy() < minElementSize {
+			// Only filter if it's not a known important role
+			if !interactiveLeafRoles[element.Role(info.Role())] {
 				return false
 			}
 		}
 
-		// Strict filtering: only apply for Chromium/Electron apps with noisy DOM trees
-		// For native apps like Safari, we trust the semantic tree to not have noise
-		if opts.strictFiltering && elementRect.Dx() > 0 && elementRect.Dy() > 0 {
-			// Filter out tiny elements that are likely noise in Chromium DOM trees.
-			// This is especially important for web content where the DOM can have
-			// thousands of tiny placeholder/structure elements.
-			// Filter if either dimension is too small (not just both)
-			if elementRect.Dx() < minElementSize || elementRect.Dy() < minElementSize {
-				// Only filter if it's not a known important role
-				if !interactiveLeafRoles[element.Role(info.Role())] {
-					return false
-				}
-			}
-
-			// Filter elements whose center is outside window bounds (overflowing elements)
-			// But keep interactive roles (buttons, links, etc.) even if at edges
-			halfWidth := elementRect.Dx() / 2  //nolint:mnd
-			halfHeight := elementRect.Dy() / 2 //nolint:mnd
-			centerX := elementRect.Min.X + halfWidth
-			centerY := elementRect.Min.Y + halfHeight
-			if centerX < windowBounds.Min.X || centerX > windowBounds.Max.X ||
-				centerY < windowBounds.Min.Y || centerY > windowBounds.Max.Y {
-				if !interactiveLeafRoles[element.Role(info.Role())] {
-					return false
-				}
-			}
-		} else if elementRect.Dx() > 0 && elementRect.Dy() > 0 {
-			// For non-strict filtering, only check basic overlap
-			if !elementRect.Overlaps(windowBounds) {
+		// Filter elements whose center is outside clip bounds (overflowing/scroll-clipped elements)
+		// But keep interactive roles (buttons, links, etc.) even if at edges
+		halfWidth := elementRect.Dx() / 2  //nolint:mnd
+		halfHeight := elementRect.Dy() / 2 //nolint:mnd
+		centerX := elementRect.Min.X + halfWidth
+		centerY := elementRect.Min.Y + halfHeight
+		if centerX < clipBounds.Min.X || centerX > clipBounds.Max.X ||
+			centerY < clipBounds.Min.Y || centerY > clipBounds.Max.Y {
+			if !interactiveLeafRoles[element.Role(info.Role())] {
 				return false
 			}
 		}
@@ -787,4 +870,14 @@ func (n *TreeNode) walkTreePostOrder(visit func(*TreeNode)) {
 		child.walkTreePostOrder(visit)
 	}
 	visit(n)
+}
+
+// isChromiumOrElectron returns true if the bundle ID matches known Chromium/Electron apps
+// or user-configured additional bundles.
+func isChromiumOrElectron(bundleID string, configProvider config.Provider) bool {
+	if isLikelyChromiumOrElectron(bundleID) {
+		return true
+	}
+
+	return isUserConfiguredChromiumElectron(bundleID, configProvider)
 }

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -881,3 +881,50 @@ func isChromiumOrElectron(bundleID string, configProvider config.Provider) bool 
 
 	return isUserConfiguredChromiumElectron(bundleID, configProvider)
 }
+
+// isLikelyChromiumOrElectron returns true if the bundle ID matches known Chromium/Electron apps.
+// This is duplicated from electron package to avoid import cycle.
+func isLikelyChromiumOrElectron(bundleID string) bool {
+	if bundleID == "" {
+		return false
+	}
+
+	bundleID = strings.TrimSpace(bundleID)
+
+	for _, b := range config.KnownChromiumBundles {
+		if strings.EqualFold(b, bundleID) {
+			return true
+		}
+	}
+
+	for _, b := range config.KnownElectronBundles {
+		if strings.EqualFold(b, bundleID) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isUserConfiguredChromiumElectron checks if the bundle ID matches user-configured
+// additional Chromium/Electron bundles from config. Supports exact matches and
+// wildcard patterns (ending with *).
+func isUserConfiguredChromiumElectron(bundleID string, configProvider config.Provider) bool {
+	if bundleID == "" || configProvider == nil {
+		return false
+	}
+
+	cfg := configProvider.Get()
+	if cfg == nil {
+		return false
+	}
+
+	chromiumBundles := cfg.Hints.AdditionalAXSupport.AdditionalChromiumBundles
+	if config.MatchesAdditionalBundle(bundleID, chromiumBundles) {
+		return true
+	}
+
+	electronBundles := cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles
+
+	return config.MatchesAdditionalBundle(bundleID, electronBundles)
+}

--- a/internal/core/infra/accessibility/tree_linux.go
+++ b/internal/core/infra/accessibility/tree_linux.go
@@ -49,17 +49,14 @@ func DefaultTreeOptions(logger *zap.Logger) TreeOptions { return TreeOptions{} }
 // SetCache is a Linux stub.
 func (o *TreeOptions) SetCache(cache any) {}
 
-// SetIncludeOutOfBounds is a Linux stub.
-func (o *TreeOptions) SetIncludeOutOfBounds(include bool) {}
-
 // SetMaxDepth is a Linux stub.
 func (o *TreeOptions) SetMaxDepth(depth int) {}
 
 // SetParallelThreshold is a Linux stub.
 func (o *TreeOptions) SetParallelThreshold(threshold int) {}
 
-// SetStrictFiltering is a Linux stub.
-func (o *TreeOptions) SetStrictFiltering(strict bool) {}
+// SetBundleID is a Linux stub.
+func (o *TreeOptions) SetBundleID(bundleID string) {}
 
 // BuildTree builds the accessibility tree for the specified root element (Linux stub).
 func BuildTree(_ *Element, _ TreeOptions) (*TreeNode, error) {

--- a/internal/core/infra/accessibility/tree_linux.go
+++ b/internal/core/infra/accessibility/tree_linux.go
@@ -58,6 +58,9 @@ func (o *TreeOptions) SetParallelThreshold(threshold int) {}
 // SetBundleID is a Linux stub.
 func (o *TreeOptions) SetBundleID(bundleID string) {}
 
+// SetConfigProvider is a Linux stub.
+func (o *TreeOptions) SetConfigProvider(cp config.Provider) {}
+
 // BuildTree builds the accessibility tree for the specified root element (Linux stub).
 func BuildTree(_ *Element, _ TreeOptions) (*TreeNode, error) {
 	return &TreeNode{}, nil

--- a/internal/core/infra/accessibility/tree_windows.go
+++ b/internal/core/infra/accessibility/tree_windows.go
@@ -49,17 +49,14 @@ func DefaultTreeOptions(logger *zap.Logger) TreeOptions { return TreeOptions{} }
 // SetCache is a Windows stub.
 func (o *TreeOptions) SetCache(cache any) {}
 
-// SetIncludeOutOfBounds is a Windows stub.
-func (o *TreeOptions) SetIncludeOutOfBounds(include bool) {}
-
 // SetMaxDepth is a Windows stub.
 func (o *TreeOptions) SetMaxDepth(depth int) {}
 
 // SetParallelThreshold is a Windows stub.
 func (o *TreeOptions) SetParallelThreshold(threshold int) {}
 
-// SetStrictFiltering is a Windows stub.
-func (o *TreeOptions) SetStrictFiltering(strict bool) {}
+// SetBundleID is a Windows stub.
+func (o *TreeOptions) SetBundleID(bundleID string) {}
 
 // BuildTree builds the accessibility tree for the specified root element (Windows stub).
 func BuildTree(_ *Element, _ TreeOptions) (*TreeNode, error) {

--- a/internal/core/infra/accessibility/tree_windows.go
+++ b/internal/core/infra/accessibility/tree_windows.go
@@ -58,6 +58,9 @@ func (o *TreeOptions) SetParallelThreshold(threshold int) {}
 // SetBundleID is a Windows stub.
 func (o *TreeOptions) SetBundleID(bundleID string) {}
 
+// SetConfigProvider is a Windows stub.
+func (o *TreeOptions) SetConfigProvider(cp config.Provider) {}
+
 // BuildTree builds the accessibility tree for the specified root element (Windows stub).
 func BuildTree(_ *Element, _ TreeOptions) (*TreeNode, error) {
 	return &TreeNode{}, nil

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -25,6 +25,8 @@ typedef struct {
 	bool isEnabled;         ///< Whether element is enabled
 	bool isFocused;         ///< Whether element is focused
 	int pid;                ///< Process identifier
+	bool isHidden;          ///< Whether element is AX-hidden (CSS visibility:hidden etc.)
+	bool isVisible;         ///< Whether element is AX-visible (default true when unsupported)
 } ElementInfo;
 
 #pragma mark - Permission Functions

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -111,6 +111,10 @@ ElementInfo *getElementInfo(void *element) {
 		if (!info)
 			return NULL;
 
+		info->isVisible = true;  // default visible when attribute not available
+
+		static CFStringRef kVisibleAttr = CFSTR("AXVisible");
+
 		CFArrayRef attributes = CFArrayCreate(
 		    NULL,
 		    (const void **)(CFTypeRef[]){
@@ -123,8 +127,10 @@ ElementInfo *getElementInfo(void *element) {
 		        kAXRoleDescriptionAttribute,
 		        kAXEnabledAttribute,
 		        kAXFocusedAttribute,
+		        kAXHiddenAttribute,
+		        kVisibleAttr,
 		    },
-		    9, &kCFTypeArrayCallBacks);
+		    11, &kCFTypeArrayCallBacks);
 
 		if (!attributes) {
 			free(info);
@@ -143,7 +149,7 @@ ElementInfo *getElementInfo(void *element) {
 			return info;
 		}
 
-		// With option=0, values always has exactly 7 entries (one per requested attribute).
+		// With option=0, values always has exactly 11 entries (one per requested attribute).
 		// Slots for unsupported/errored attributes hold an AX error placeholder (CFNumber),
 		// which the CFGetTypeID checks below will correctly reject.
 		CFTypeRef positionValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 0);
@@ -195,6 +201,16 @@ ElementInfo *getElementInfo(void *element) {
 		CFTypeRef focusedValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 8);
 		if (focusedValue && CFGetTypeID(focusedValue) == CFBooleanGetTypeID()) {
 			info->isFocused = CFBooleanGetValue((CFBooleanRef)focusedValue);
+		}
+
+		CFTypeRef hiddenValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 9);
+		if (hiddenValue && CFGetTypeID(hiddenValue) == CFBooleanGetTypeID()) {
+			info->isHidden = CFBooleanGetValue((CFBooleanRef)hiddenValue);
+		}
+
+		CFTypeRef visibleValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 10);
+		if (visibleValue && CFGetTypeID(visibleValue) == CFBooleanGetTypeID()) {
+			info->isVisible = CFBooleanGetValue((CFBooleanRef)visibleValue);
 		}
 
 		CFRelease(values);
@@ -498,6 +514,44 @@ int isElementVisibleAtPoint(void *element, CGPoint center) {
 	return visible ? 1 : 0;
 }
 
+/// Get element frame (AXPosition + AXSize) via batch attribute fetch.
+static bool getElementFrame(AXUIElementRef element, CGRect *outFrame) {
+	if (!element || !outFrame)
+		return false;
+
+	CFTypeRef attrs[] = {kAXPositionAttribute, kAXSizeAttribute};
+	CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 2, &kCFTypeArrayCallBacks);
+	if (!attrArray)
+		return false;
+
+	CFArrayRef values = NULL;
+	AXError err = AXUIElementCopyMultipleAttributeValues(element, attrArray, 0, &values);
+	CFRelease(attrArray);
+
+	if (err != kAXErrorSuccess || !values || CFArrayGetCount(values) < 2) {
+		if (values)
+			CFRelease(values);
+		return false;
+	}
+
+	CGPoint position = CGPointZero;
+	CGSize size = CGSizeZero;
+
+	CFTypeRef posRef = CFArrayGetValueAtIndex(values, 0);
+	if (posRef && CFGetTypeID(posRef) == AXValueGetTypeID())
+		AXValueGetValue((AXValueRef)posRef, kAXValueCGPointType, &position);
+
+	CFTypeRef sizeRef = CFArrayGetValueAtIndex(values, 1);
+	if (sizeRef && CFGetTypeID(sizeRef) == AXValueGetTypeID())
+		AXValueGetValue((AXValueRef)sizeRef, kAXValueCGSizeType, &size);
+
+	CFRelease(values);
+
+	outFrame->origin = position;
+	outFrame->size = size;
+	return true;
+}
+
 /// Check if element has click action
 /// @param element Element reference
 /// @param skipVisCheck If true, skip the expensive hit-test visibility check
@@ -539,31 +593,17 @@ int hasClickAction(void *element, bool skipVisCheck) {
 			if (!value)
 				continue;
 
-			// AXHidden
 			if (attr == kAXHiddenAttribute && CFGetTypeID(value) == CFBooleanGetTypeID()) {
 				isHidden = CFBooleanGetValue((CFBooleanRef)value);
-			}
-
-			// AXEnabled
-			else if (attr == kAXEnabledAttribute && CFGetTypeID(value) == CFBooleanGetTypeID()) {
+			} else if (attr == kAXEnabledAttribute && CFGetTypeID(value) == CFBooleanGetTypeID()) {
 				hasEnabledAttribute = true;
 				explicitlyDisabled = !CFBooleanGetValue((CFBooleanRef)value);
-			}
-
-			// AXRole
-			else if (attr == kAXRoleAttribute && CFGetTypeID(value) == CFStringGetTypeID()) {
+			} else if (attr == kAXRoleAttribute && CFGetTypeID(value) == CFStringGetTypeID()) {
 				role = (CFStringRef)value;
 				CFRetain(role);
-			}
-
-			// AXIdentifier: checks for the `widget-local:` prefix (internal Apple convention,
-			// verified on macOS 14/15) used by all macOS Notification Center and desktop widgets.
-			else if (attr == kAXIdentifierAttribute && CFGetTypeID(value) == CFStringGetTypeID()) {
+			} else if (attr == kAXIdentifierAttribute && CFGetTypeID(value) == CFStringGetTypeID()) {
 				isWidget = CFStringHasPrefix((CFStringRef)value, kAXWidgetIdentifierPrefix);
-			}
-
-			// AXVisible
-			else if (attr == kAXVisibleAttribute && CFGetTypeID(value) == CFBooleanGetTypeID()) {
+			} else if (attr == kAXVisibleAttribute && CFGetTypeID(value) == CFBooleanGetTypeID()) {
 				isVisible = CFBooleanGetValue((CFBooleanRef)value);
 			}
 		}
@@ -573,6 +613,22 @@ int hasClickAction(void *element, bool skipVisCheck) {
 
 	if (isHidden || !isVisible)
 		return 0;
+
+	// Pre-compute center for visibility hit-test.
+	// getElementCenter fetches AXPosition + AXSize in one batch call.
+	// Done once here so that every return-1 path below can use it without
+	// repeating the fetch (and without fetching it at all for excluded bundles).
+	CGPoint visCenter = CGPointZero;
+	bool hasVisCenter = false;
+	if (!skipVisCheck) {
+		hasVisCenter = getElementCenter((void *)axElement, &visCenter);
+	}
+
+	// visHit returns true when (a) skipVisCheck is set (excluded bundles),
+	// (b) the center could not be determined (conservatively assume visible),
+	// or (c) the hit-test at the element's center confirms it or a descendant
+	// is rendered at that point.
+#define visHit (!skipVisCheck && hasVisCenter ? isElementVisibleAtPoint((void *)axElement, visCenter) : 1)
 
 	// Explicit actions are the strongest signal, so we check for them first
 	CFArrayRef actions = NULL;
@@ -592,8 +648,13 @@ int hasClickAction(void *element, bool skipVisCheck) {
 			    CFStringCompare(action, CFSTR("AXRaise"), 0) == kCFCompareEqualTo) {
 				CFRelease(actions);
 
-				// If element is explicitly disabled, it is not clickable
 				if (hasEnabledAttribute && explicitlyDisabled) {
+					if (role)
+						CFRelease(role);
+					return 0;
+				}
+
+				if (!visHit) {
 					if (role)
 						CFRelease(role);
 					return 0;
@@ -609,18 +670,21 @@ int hasClickAction(void *element, bool skipVisCheck) {
 	}
 
 	// Exclude known container/structural roles
-	// We exclude it here instead of on golang side because we still need to ensure if it has certain AXAction first
-	// above.
 	if (role) {
 		if (CFStringCompare(role, kAXScrollAreaRole, 0) == kCFCompareEqualTo ||
 		    CFStringCompare(role, kAXGroupRole, 0) == kCFCompareEqualTo ||
 		    CFStringCompare(role, kAXSplitGroupRole, 0) == kCFCompareEqualTo) {
-			// Override: macOS widgets use AXGroup but are inherently interactive.
 			if (isWidget) {
 				if (hasEnabledAttribute && explicitlyDisabled) {
 					CFRelease(role);
 					return 0;
 				}
+
+				if (!visHit) {
+					CFRelease(role);
+					return 0;
+				}
+
 				CFRelease(role);
 				return 1;
 			}
@@ -634,16 +698,29 @@ int hasClickAction(void *element, bool skipVisCheck) {
 	CFStringRef pressDesc = NULL;
 	if (AXUIElementCopyActionDescription(axElement, kAXPressAction, &pressDesc) == kAXErrorSuccess && pressDesc) {
 		CFRelease(pressDesc);
+
+		if (!visHit) {
+			if (role)
+				CFRelease(role);
+			return 0;
+		}
+
 		if (role)
 			CFRelease(role);
 		return 1;
 	}
 
-	// Role-specific fallback for links - no visibility check needed
+	// Role-specific fallback for links
 	if (role && CFStringCompare(role, kAXLinkRole, 0) == kCFCompareEqualTo) {
 		CFTypeRef urlAttr = NULL;
 		if (AXUIElementCopyAttributeValue(axElement, kAXURLAttribute, &urlAttr) == kAXErrorSuccess && urlAttr) {
 			CFRelease(urlAttr);
+
+			if (!visHit) {
+				CFRelease(role);
+				return 0;
+			}
+
 			CFRelease(role);
 			return 1;
 		}
@@ -653,19 +730,16 @@ int hasClickAction(void *element, bool skipVisCheck) {
 		CFRelease(role);
 
 	// Visibility check: hit-test at center to filter obscured/scroll-clipped elements.
-	// Uses parent-walk (isElementVisibleAtPoint) instead of PID check (isPointVisible)
-	// to catch elements covered by sibling views within the same app.
-	// skipVisCheck is set by the Go caller for known problematic system apps
-	// (e.g. PiP windows, screen capture thumbnails) where AX hit-testing is unreliable.
 	if (skipVisCheck)
 		return 1;
 
-	CGPoint center;
-	if (getElementCenter((void *)axElement, &center)) {
-		return isElementVisibleAtPoint((void *)axElement, center);
+	if (hasVisCenter) {
+		return isElementVisibleAtPoint((void *)axElement, visCenter);
 	}
 
 	return 0;
+
+#undef visHit
 }
 
 #pragma mark - Attribute Functions

--- a/internal/core/ports/accessibility.go
+++ b/internal/core/ports/accessibility.go
@@ -63,12 +63,6 @@ type ElementFilter struct {
 	// Roles specifies which accessibility roles to include.
 	Roles []element.Role
 
-	// StrictFiltering enables strict filtering.
-	StrictFiltering bool
-
-	// IncludeOutOfBounds enables including elements outside the screen bounds.
-	IncludeOutOfBounds bool
-
 	// MinSize specifies the minimum element size to include.
 	MinSize image.Point
 
@@ -126,8 +120,6 @@ type ElementFilter struct {
 func DefaultElementFilter() ElementFilter {
 	return ElementFilter{
 		MinSize:                   image.Point{X: 1, Y: 1},
-		StrictFiltering:           false,
-		IncludeOutOfBounds:        false,
 		IncludeMenubar:            false,
 		AdditionalMenubarTargets:  []string{},
 		IncludeDock:               false,


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR is my best effort to eliminate hidden element hints on screen. This will make activation hint slower, but i'll optimise it next.

- Remove hints on invisible elements that previously showed incorrectly
- Remove `IncludeOutOfBounds` and `StrictFiltering` config options — filtering is now automatic
- Chromium/Electron apps get strict filtering automatically; native apps like Safari do not need it
- Simplified interface by removing `strictFiltering` parameter from all accessibility query methods

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
