### PR TITLE
perf(hints): faster hints activation

### DIFF
--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -24,12 +24,13 @@ func (h *Handler) activateGridModeWithAction(
 	// Detect refresh before validation so we can do partial cleanup on re-activation.
 	isRefresh := h.appState.CurrentMode() == domain.ModeGrid
 
-	actionEnum, ok := h.activateModeBase(
+	actionEnum, activated := h.activateModeBase(
 		domain.ModeNameGrid,
 		h.config.Grid.Enabled,
 		action.TypeMoveMouse,
+		"",
 	)
-	if !ok {
+	if !activated {
 		if isRefresh {
 			h.exitModeLocked()
 		}

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -259,7 +259,7 @@ func (h *Handler) RefreshHintsForScreenChange(
 
 	// Generate hints with filters preserved; SetHints below performs the
 	// single redraw after active-screen filtering.
-	domainHints, showHintsErr := hintService.GenerateHints(ctx, filterRoles, filterTextContains)
+	domainHints, showHintsErr := hintService.GenerateHints(ctx, filterRoles, filterTextContains, "")
 	if showHintsErr != nil {
 		h.logger.Error("Failed to refresh hints after screen change", zap.Error(showHintsErr))
 		h.exitModeLocked()

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -138,12 +138,23 @@ func (h *Handler) activateHintModeInternal(
 		h.cycleHintIndex = -1
 	}
 
-	actionEnum, ok := h.activateModeBase(
+	// Fetch bundle ID once to avoid repeated AX calls across validation and hint generation
+	ctx, cancel := context.WithTimeout(context.Background(), HintTimeout)
+	defer cancel()
+
+	bundleID, bundleIDErr := h.actionService.FocusedAppBundleID(ctx)
+	if bundleIDErr != nil {
+		h.logger.Debug("Failed to get focused app bundle ID for validation",
+			zap.Error(bundleIDErr))
+	}
+
+	actionEnum, activated := h.activateModeBase(
 		domain.ModeNameHints,
 		h.config.Hints.Enabled,
 		action.TypeMoveMouse,
+		bundleID,
 	)
-	if !ok {
+	if !activated {
 		// If validation fails during a refresh (e.g., secure input activated,
 		// focused app became excluded), exit cleanly instead of leaving stale
 		// hints on the overlay.
@@ -209,13 +220,14 @@ func (h *Handler) activateHintModeInternal(
 		h.hints.Context.SetStartWithSearch(search)
 	}
 
-	// Use new HintService to show hints
-	ctx, cancel := context.WithTimeout(context.Background(), HintTimeout)
-	defer cancel()
-
 	// Get hints from service. Drawing is intentionally deferred until after
 	// active-screen filtering so activation performs one full overlay render.
-	domainHints, domainHintsErr := h.hintService.GenerateHints(ctx, filterRoles, filterTextContains)
+	domainHints, domainHintsErr := h.hintService.GenerateHints(
+		ctx,
+		filterRoles,
+		filterTextContains,
+		bundleID,
+	)
 	if domainHintsErr != nil {
 		h.logger.Error(
 			"Failed to show hints",

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -138,11 +138,13 @@ func (h *Handler) activateHintModeInternal(
 		h.cycleHintIndex = -1
 	}
 
-	// Fetch bundle ID once to avoid repeated AX calls across validation and hint generation
-	ctx, cancel := context.WithTimeout(context.Background(), HintTimeout)
-	defer cancel()
+	// Fetch bundle ID once to avoid repeated AX calls across validation and hint generation.
+	// Use a dedicated short timeout so slow AX doesn't erode the hint generation budget.
+	bundleCtx, bundleCancel := context.WithTimeout(context.Background(), 1*time.Second)
+	bundleID, bundleIDErr := h.actionService.FocusedAppBundleID(bundleCtx)
 
-	bundleID, bundleIDErr := h.actionService.FocusedAppBundleID(ctx)
+	bundleCancel()
+
 	if bundleIDErr != nil {
 		h.logger.Debug("Failed to get focused app bundle ID for validation",
 			zap.Error(bundleIDErr))
@@ -222,6 +224,9 @@ func (h *Handler) activateHintModeInternal(
 
 	// Get hints from service. Drawing is intentionally deferred until after
 	// active-screen filtering so activation performs one full overlay render.
+	ctx, cancel := context.WithTimeout(context.Background(), HintTimeout)
+	defer cancel()
+
 	domainHints, domainHintsErr := h.hintService.GenerateHints(
 		ctx,
 		filterRoles,

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -138,23 +138,13 @@ func (h *Handler) activateHintModeInternal(
 		h.cycleHintIndex = -1
 	}
 
-	// Fetch bundle ID once to avoid repeated AX calls across validation and hint generation.
-	// Use a dedicated short timeout so slow AX doesn't erode the hint generation budget.
-	bundleCtx, bundleCancel := context.WithTimeout(context.Background(), 1*time.Second)
-	bundleID, bundleIDErr := h.actionService.FocusedAppBundleID(bundleCtx)
-
-	bundleCancel()
-
-	if bundleIDErr != nil {
-		h.logger.Debug("Failed to get focused app bundle ID for validation",
-			zap.Error(bundleIDErr))
-	}
-
+	// Defer bundle ID fetch until after validation (secure input check) to avoid
+	// unnecessary AX calls when a password field is focused.
 	actionEnum, activated := h.activateModeBase(
 		domain.ModeNameHints,
 		h.config.Hints.Enabled,
 		action.TypeMoveMouse,
-		bundleID,
+		"",
 	)
 	if !activated {
 		// If validation fails during a refresh (e.g., secure input activated,
@@ -220,6 +210,19 @@ func (h *Handler) activateHintModeInternal(
 		h.hints.Context.SetFilterRoles(filterRoles)
 		h.hints.Context.SetFilterTextContains(filterTextContains)
 		h.hints.Context.SetStartWithSearch(search)
+	}
+
+	// Fetch bundle ID for hint generation. Validation already passed (secure input check,
+	// exclusion check), so this is the only call. Use a dedicated short timeout so slow
+	// AX doesn't erode the hint generation budget.
+	bundleCtx, bundleCancel := context.WithTimeout(context.Background(), 1*time.Second)
+	bundleID, bundleIDErr := h.actionService.FocusedAppBundleID(bundleCtx)
+
+	bundleCancel()
+
+	if bundleIDErr != nil {
+		h.logger.Debug("Failed to get focused app bundle ID for hint generation",
+			zap.Error(bundleIDErr))
 	}
 
 	// Get hints from service. Drawing is intentionally deferred until after

--- a/internal/app/modes/mode_setup.go
+++ b/internal/app/modes/mode_setup.go
@@ -89,9 +89,10 @@ func (h *Handler) activateModeBase(
 	modeName string,
 	enabled bool,
 	actionEnum action.Type,
+	bundleID string,
 ) (action.Type, bool) {
 	// Validate mode activation
-	err := h.validateModeActivation(modeName, enabled)
+	err := h.validateModeActivation(bundleID, modeName, enabled)
 	if err != nil {
 		h.logger.Warn(modeName+" mode activation failed", zap.Error(err))
 

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -376,7 +376,7 @@ func (h *Handler) refreshHintsForMonitorMove(
 	filterRoles := h.hints.Context.FilterRoles()
 	filterTextContains := h.hints.Context.FilterTextContains()
 
-	domainHints, err := h.hintService.GenerateHints(ctx, filterRoles, filterTextContains)
+	domainHints, err := h.hintService.GenerateHints(ctx, filterRoles, filterTextContains, "")
 	if err != nil {
 		h.logger.Error(
 			"Failed to refresh hints after monitor move",

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -25,12 +25,13 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 	// Detect refresh before validation so we can do partial cleanup on re-activation.
 	isRefresh := h.appState.CurrentMode() == domain.ModeRecursiveGrid
 
-	actionEnum, ok := h.activateModeBase(
+	actionEnum, activated := h.activateModeBase(
 		domain.ModeNameRecursiveGrid,
 		h.config.RecursiveGrid.Enabled,
 		action.TypeMoveMouse,
+		"",
 	)
-	if !ok {
+	if !activated {
 		if isRefresh {
 			h.exitModeLocked()
 		}

--- a/internal/app/modes/validation.go
+++ b/internal/app/modes/validation.go
@@ -16,7 +16,8 @@ const (
 
 // validateModeActivation performs common validation checks before mode activation.
 // Returns an error if the mode cannot be activated.
-func (h *Handler) validateModeActivation(modeName string, modeEnabled bool) error {
+// If bundleID is non-empty, it is used directly for exclusion check (skips AX call).
+func (h *Handler) validateModeActivation(bundleID string, modeName string, modeEnabled bool) error {
 	// Check for secure input mode first - this is a macOS security feature
 	// that blocks keyboard events when password fields are focused.
 	// On non-macOS platforms IsSecureInputEnabled always returns false.
@@ -48,15 +49,20 @@ func (h *Handler) validateModeActivation(modeName string, modeEnabled bool) erro
 	}
 
 	// Check if focused app is excluded
-	// Use a short timeout context for this check
-	context, cancel := context.WithTimeout(context.Background(), ValidationTimeout)
-	defer cancel()
+	if bundleID != "" {
+		if h.actionService.IsAppExcluded(bundleID) {
+			return derrors.New(derrors.CodeInvalidInput, "focused app is excluded")
+		}
+	} else {
+		context, cancel := context.WithTimeout(context.Background(), ValidationTimeout)
+		defer cancel()
 
-	isExcluded, isExcludedErr := h.actionService.IsFocusedAppExcluded(context)
-	if isExcludedErr != nil {
-		h.logger.Warn("Failed to check if app is excluded", zap.Error(isExcludedErr))
-	} else if isExcluded {
-		return derrors.New(derrors.CodeInvalidInput, "focused app is excluded")
+		isExcluded, isExcludedErr := h.actionService.IsFocusedAppExcluded(context)
+		if isExcludedErr != nil {
+			h.logger.Warn("Failed to check if app is excluded", zap.Error(isExcludedErr))
+		} else if isExcluded {
+			return derrors.New(derrors.CodeInvalidInput, "focused app is excluded")
+		}
 	}
 
 	return nil

--- a/internal/app/services/action_service.go
+++ b/internal/app/services/action_service.go
@@ -134,6 +134,11 @@ func (s *ActionService) FocusedAppBundleID(ctx context.Context) (string, error) 
 	return s.accessibility.FocusedAppBundleID(ctx)
 }
 
+// IsAppExcluded checks if the given bundle ID is in the exclusion list.
+func (s *ActionService) IsAppExcluded(bundleID string) bool {
+	return s.accessibility.IsAppExcluded(context.Background(), bundleID)
+}
+
 // MoveCursorToElement moves the cursor to the center of the specified element.
 func (s *ActionService) MoveCursorToElement(
 	ctx context.Context,

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -50,7 +50,7 @@ func (s *HintService) ShowHints(
 ) ([]*hint.Interface, error) {
 	s.logger.Info("Showing hints")
 
-	hints, err := s.GenerateHints(ctx, filterRoles, filterTextContains)
+	hints, err := s.GenerateHints(ctx, filterRoles, filterTextContains, "")
 	if err != nil {
 		return nil, err
 	}
@@ -75,10 +75,12 @@ func (s *HintService) ShowHints(
 // GenerateHints collects clickable elements and generates labels without drawing
 // them. Mode handlers use this to filter and position hints before the first
 // render, avoiding an extra full overlay draw during activation.
+// If bundleID is non-empty, it is used directly (skips AX call).
 func (s *HintService) GenerateHints(
 	ctx context.Context,
 	filterRoles []string,
 	filterTextContains []string,
+	bundleID string,
 ) ([]*hint.Interface, error) {
 	s.mu.RLock()
 	cfg := s.config
@@ -88,12 +90,16 @@ func (s *HintService) GenerateHints(
 	filter := ports.DefaultElementFilter()
 
 	// Populate filter with configuration
-	bundleID, bundleIDErr := s.accessibility.FocusedAppBundleID(ctx)
-	if bundleIDErr != nil {
-		s.logger.Debug(
-			"Failed to get focused app bundle ID for hints roles",
-			zap.Error(bundleIDErr),
-		)
+	if bundleID == "" {
+		var bundleIDErr error
+
+		bundleID, bundleIDErr = s.accessibility.FocusedAppBundleID(ctx)
+		if bundleIDErr != nil {
+			s.logger.Debug(
+				"Failed to get focused app bundle ID for hints roles",
+				zap.Error(bundleIDErr),
+			)
+		}
 	}
 
 	// Use filterRoles if provided, otherwise use configured roles

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -175,6 +175,7 @@ func (a *Adapter) ClickableElements(
 					clickableNodes, clickableNodesErr := a.client.ClickableNodes(
 						window,
 						stringRoles(filter.Roles),
+						0,
 					)
 					if clickableNodesErr != nil {
 						window.Release()

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -10,6 +10,17 @@ import (
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
+const (
+	// dockTreeDepth limits tree depth for the flat dock hierarchy (AXApplication → AXDockItem).
+	dockTreeDepth = 5
+	// stageManagerTreeDepth limits tree depth for the WindowManager app.
+	stageManagerTreeDepth = 4
+	// flatAppTreeDepth limits tree depth for simple single-window apps like PIP and screen capture.
+	flatAppTreeDepth = 3
+	// menubarTreeDepth limits tree depth for the menu bar (AXMenuBar → AXMenuBarItem → AXMenuItem).
+	menubarTreeDepth = 3
+)
+
 // addMenubarElements adds menubar clickable elements.
 // Temporarily modifies clickable roles to include AXMenuBarItem, collects menubar elements,
 // and processes additional menubar targets from configuration.
@@ -27,7 +38,7 @@ func (a *Adapter) addMenubarElements(
 	menubarRoles[len(originalRoles)] = string(element.RoleMenuBarItem)
 
 	// Get menubar elements
-	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements()
+	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements(menubarTreeDepth)
 	if menubarNodesErr != nil {
 		a.logger.Warn("Failed to get menubar elements", zap.Error(menubarNodesErr))
 	} else {
@@ -62,6 +73,7 @@ func (a *Adapter) addMenubarElements(
 			additionalNodes, err := a.client.ClickableElementsFromBundleID(
 				bundleID,
 				menubarRoles,
+				0,
 			)
 			if err != nil {
 				a.logger.Warn("Failed to get additional menubar elements",
@@ -155,7 +167,7 @@ func (a *Adapter) addDockElements(
 	}
 
 	// Build tree and find clickable elements
-	dockNodes, dockNodesErr := a.client.ClickableNodes(dockApp, dockRoles)
+	dockNodes, dockNodesErr := a.client.ClickableNodes(dockApp, dockRoles, dockTreeDepth)
 	if dockNodesErr != nil {
 		a.logger.Warn("Failed to get dock elements", zap.Error(dockNodesErr))
 
@@ -199,6 +211,7 @@ func (a *Adapter) addNotificationCenterElements(
 	ncNodes, ncNodesErr := a.client.ClickableElementsFromBundleID(
 		ncBundleID,
 		ncRoles,
+		0,
 	)
 	if ncNodesErr != nil {
 		a.logger.Warn("Failed to get notification center elements", zap.Error(ncNodesErr))
@@ -258,7 +271,7 @@ func (a *Adapter) addStageManagerElements(
 	}
 
 	// Build tree and find clickable elements
-	wmNodes, wmNodesErr := a.client.ClickableNodes(wmApp, nil)
+	wmNodes, wmNodesErr := a.client.ClickableNodes(wmApp, nil, stageManagerTreeDepth)
 	if wmNodesErr != nil {
 		a.logger.Warn("Failed to get window manager elements", zap.Error(wmNodesErr))
 
@@ -294,6 +307,7 @@ func (a *Adapter) addPIPElements(
 	pipNodes, pipNodesErr := a.client.ClickableElementsFromBundleID(
 		pipBundleID,
 		nil,
+		flatAppTreeDepth,
 	)
 	if pipNodesErr != nil {
 		a.logger.Warn("Failed to get Picture in Picture elements", zap.Error(pipNodesErr))
@@ -330,6 +344,7 @@ func (a *Adapter) addScreenCaptureElements(
 	screenCaptureNodes, screenCaptureNodesErr := a.client.ClickableElementsFromBundleID(
 		screenCaptureBundleID,
 		nil,
+		flatAppTreeDepth,
 	)
 	if screenCaptureNodesErr != nil {
 		a.logger.Warn("Failed to get Screen Capture elements", zap.Error(screenCaptureNodesErr))

--- a/internal/core/infra/accessibility/client.go
+++ b/internal/core/infra/accessibility/client.go
@@ -28,11 +28,13 @@ type AXClient interface {
 	ClickableNodes(
 		root AXElement,
 		roles []string,
+		maxDepth int,
 	) ([]AXNode, error)
-	MenuBarClickableElements() ([]AXNode, error)
+	MenuBarClickableElements(maxDepth int) ([]AXNode, error)
 	ClickableElementsFromBundleID(
 		bundleID string,
 		roles []string,
+		maxDepth int,
 	) ([]AXNode, error)
 	ActiveScreenBounds() image.Rectangle
 

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -100,6 +100,7 @@ type ElementInfo struct {
 	title           string
 	description     string
 	value           string
+	identifier      string
 	searchText      string
 	role            string
 	roleDescription string
@@ -107,7 +108,9 @@ type ElementInfo struct {
 	isFocused       bool
 	isHidden        bool
 	isVisible       bool
+	hasEnabledAttr  bool
 	pid             int
+	skipHitTest     bool
 }
 
 // Position returns the element position.
@@ -133,6 +136,11 @@ func (ei *ElementInfo) Description() string {
 // Value returns the element value.
 func (ei *ElementInfo) Value() string {
 	return ei.value
+}
+
+// Identifier returns the element identifier.
+func (ei *ElementInfo) Identifier() string {
+	return ei.identifier
 }
 
 // SearchText returns extra searchable text collected from descendant elements.
@@ -259,11 +267,12 @@ func (e *Element) Info() (*ElementInfo, error) {
 			X: int(cInfo.size.width),
 			Y: int(cInfo.size.height),
 		},
-		isEnabled: bool(cInfo.isEnabled),
-		isFocused: bool(cInfo.isFocused),
-		isHidden:  bool(cInfo.isHidden),
-		isVisible: bool(cInfo.isVisible),
-		pid:       int(cInfo.pid),
+		isEnabled:      bool(cInfo.isEnabled),
+		hasEnabledAttr: bool(cInfo.hasEnabledAttribute),
+		isFocused:      bool(cInfo.isFocused),
+		isHidden:       bool(cInfo.isHidden),
+		isVisible:      bool(cInfo.isVisible),
+		pid:            int(cInfo.pid),
 	}
 
 	if cInfo.title != nil {
@@ -274,6 +283,9 @@ func (e *Element) Info() (*ElementInfo, error) {
 	}
 	if cInfo.value != nil {
 		info.value = C.GoString(cInfo.value)
+	}
+	if cInfo.identifier != nil {
+		info.identifier = C.GoString(cInfo.identifier)
 	}
 	if cInfo.role != nil {
 		info.role = C.GoString(cInfo.role)
@@ -286,7 +298,7 @@ func (e *Element) Info() (*ElementInfo, error) {
 }
 
 // Children returns all child elements of this element.
-func (e *Element) Children() ([]*Element, error) {
+func (e *Element) Children(role string) ([]*Element, error) {
 	if e.ref == nil {
 		return nil, errGetChildrenNil
 	}
@@ -294,31 +306,20 @@ func (e *Element) Children() ([]*Element, error) {
 	var count C.int
 	var rawChildren unsafe.Pointer
 
-	info, err := e.Info()
-	if err != nil {
-		return nil, derrors.Wrap(
-			err,
-			derrors.CodeAccessibilityFailed,
-			"failed to get element info",
-		)
-	}
-
-	if info != nil {
-		switch info.Role() {
-		case string(element.RoleList), string(element.RoleTable), string(element.RoleOutline):
-			ptr := unsafe.Pointer(C.getVisibleRows(e.ref, &count)) //nolint:nlreturn
-			if ptr != nil && count > 0 {
-				rawChildren = ptr
-			} else {
-				if ptr != nil {
-					C.free(ptr)
-				}
-
-				rawChildren = unsafe.Pointer(C.getChildren(e.ref, &count)) //nolint:nlreturn
+	switch role {
+	case string(element.RoleList), string(element.RoleTable), string(element.RoleOutline):
+		ptr := unsafe.Pointer(C.getVisibleRows(e.ref, &count)) //nolint:nlreturn
+		if ptr != nil && count > 0 {
+			rawChildren = ptr
+		} else {
+			if ptr != nil {
+				C.free(ptr)
 			}
-		default:
+
 			rawChildren = unsafe.Pointer(C.getChildren(e.ref, &count)) //nolint:nlreturn
 		}
+	default:
+		rawChildren = unsafe.Pointer(C.getChildren(e.ref, &count)) //nolint:nlreturn
 	}
 
 	if rawChildren == nil || count == 0 {
@@ -332,7 +333,6 @@ func (e *Element) Children() ([]*Element, error) {
 
 	countInt := int(count)
 	childSlice := (*[1 << 30]unsafe.Pointer)(rawChildren)[:countInt:countInt]
-	// Pre-allocate and directly create elements
 	children := make([]*Element, countInt)
 	for i := range children {
 		children[i] = &Element{ref: childSlice[i]}
@@ -683,9 +683,27 @@ func (e *Element) IsClickable(
 		// 2. Clickability checks: AXActionNames → role exclusion → AXPress
 		//    description → link+URL (no early returns, accumulate result)
 		// 3. Hit-test visibility as final gate for ALL clickable results
+		cRole := C.CString(info.Role())
+
+		defer C.free(unsafe.Pointer(cRole)) //nolint:nlreturn
+
+		centerX := C.double(info.Position().X + info.Size().X/2)
+		centerY := C.double(info.Position().Y + info.Size().Y/2)
+
+		// Skip hit-test for Chromium/Electron apps (noisy DOM) OR for nodes
+		// within the original window clip bounds (non-scroll areas).
+		skipVisCheck := isExcludedBundleID(info.PID(), configProvider) || info.skipHitTest
+
 		result := C.hasClickAction(
 			e.ref,
-			C.bool(isExcludedBundleID(info.PID(), configProvider)), // nolint:nlreturn
+			C.bool(skipVisCheck),
+			C.bool(info.isHidden),
+			C.bool(info.isVisible),
+			C.bool(info.isEnabled),
+			C.bool(info.hasEnabledAttr),
+			cRole,
+			centerX,
+			centerY, //nolint:nlreturn
 		)
 
 		return result == 1

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -694,6 +694,8 @@ func (e *Element) IsClickable(
 		// within the original window clip bounds (non-scroll areas).
 		skipVisCheck := isExcludedBundleID(info.PID(), configProvider) || info.skipHitTest
 
+		isWidget := strings.HasPrefix(info.Identifier(), "widget-local:")
+
 		result := C.hasClickAction(
 			e.ref,
 			C.bool(skipVisCheck),
@@ -702,6 +704,7 @@ func (e *Element) IsClickable(
 			C.bool(info.isEnabled),
 			C.bool(info.hasEnabledAttr),
 			cRole,
+			C.bool(isWidget),
 			centerX,
 			centerY, //nolint:nlreturn
 		)

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -83,9 +83,11 @@ func (c *InfraAXClient) FocusedApplication() (AXApp, error) {
 }
 
 // ClickableNodes returns clickable nodes for the given root element.
+// If maxDepth is > 0, it overrides the configured tree depth.
 func (c *InfraAXClient) ClickableNodes(
 	root AXElement,
 	roles []string,
+	maxDepth int,
 ) ([]AXNode, error) {
 	var element *Element
 
@@ -106,7 +108,12 @@ func (c *InfraAXClient) ClickableNodes(
 	opts.SetConfigProvider(c.configProvider)
 
 	if cfg := currentConfig(c.configProvider); cfg != nil {
-		opts.SetMaxDepth(cfg.Hints.MaxDepth)
+		depth := cfg.Hints.MaxDepth
+		if maxDepth > 0 {
+			depth = maxDepth
+		}
+
+		opts.SetMaxDepth(depth)
 		opts.SetParallelThreshold(cfg.Hints.ParallelThreshold)
 	}
 
@@ -166,10 +173,12 @@ func (c *InfraAXClient) ApplicationByBundleID(bundleID string) (AXApp, error) {
 }
 
 // MenuBarClickableElements returns clickable elements in the menu bar.
-func (c *InfraAXClient) MenuBarClickableElements() ([]AXNode, error) {
+// If maxDepth is > 0, it overrides the configured tree depth.
+func (c *InfraAXClient) MenuBarClickableElements(maxDepth int) ([]AXNode, error) {
 	nodes, nodesErr := MenuBarClickableElements(
 		c.logger,
 		c.configProvider,
+		maxDepth,
 	)
 	if nodesErr != nil {
 		return nil, derrors.Wrap(
@@ -192,15 +201,18 @@ func (c *InfraAXClient) MenuBarClickableElements() ([]AXNode, error) {
 }
 
 // ClickableElementsFromBundleID returns clickable elements for the application with the given bundle ID.
+// If maxDepth is > 0, it overrides the configured tree depth for flat supplementary sources.
 func (c *InfraAXClient) ClickableElementsFromBundleID(
 	bundleID string,
 	roles []string,
+	maxDepth int,
 ) ([]AXNode, error) {
 	nodes, nodesErr := ClickableElementsFromBundleID(
 		bundleID,
 		roles,
 		c.logger,
 		c.configProvider,
+		maxDepth,
 	)
 	if nodesErr != nil {
 		return nil, derrors.Wrap(

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -102,6 +102,7 @@ func (m *MockAXClient) MenuBarClickableElements(maxDepth int) ([]AXNode, error) 
 	m.mu.Lock()
 	m.LastCalledMaxDepth = maxDepth
 	m.mu.Unlock()
+
 	return m.MockMenuBarNodes, m.MockMenuBarNodesErr
 }
 

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -86,6 +86,7 @@ func (m *MockAXClient) ApplicationByBundleID(_ string) (AXApp, error) {
 func (m *MockAXClient) ClickableNodes(
 	_ AXElement,
 	roles []string,
+	_ int,
 ) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastClickableNodesRoles = roles
@@ -96,7 +97,7 @@ func (m *MockAXClient) ClickableNodes(
 }
 
 // MenuBarClickableElements returns the configured menu bar nodes or error.
-func (m *MockAXClient) MenuBarClickableElements() ([]AXNode, error) {
+func (m *MockAXClient) MenuBarClickableElements(_ int) ([]AXNode, error) {
 	return m.MockMenuBarNodes, m.MockMenuBarNodesErr
 }
 
@@ -104,6 +105,7 @@ func (m *MockAXClient) MenuBarClickableElements() ([]AXNode, error) {
 func (m *MockAXClient) ClickableElementsFromBundleID(
 	bundleID string,
 	roles []string,
+	maxDepth int,
 ) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastCalledBundleID = bundleID

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -42,6 +42,7 @@ type MockAXClient struct {
 	MockMissionControlActive bool
 
 	LastCalledBundleID         string
+	LastCalledMaxDepth         int
 	LastClickableNodesRoles    []string
 	LastBundleRoles            []string
 	ClickableNodesRolesHistory [][]string
@@ -97,7 +98,10 @@ func (m *MockAXClient) ClickableNodes(
 }
 
 // MenuBarClickableElements returns the configured menu bar nodes or error.
-func (m *MockAXClient) MenuBarClickableElements(_ int) ([]AXNode, error) {
+func (m *MockAXClient) MenuBarClickableElements(maxDepth int) ([]AXNode, error) {
+	m.mu.Lock()
+	m.LastCalledMaxDepth = maxDepth
+	m.mu.Unlock()
 	return m.MockMenuBarNodes, m.MockMenuBarNodesErr
 }
 
@@ -109,6 +113,7 @@ func (m *MockAXClient) ClickableElementsFromBundleID(
 ) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastCalledBundleID = bundleID
+	m.LastCalledMaxDepth = maxDepth
 	m.LastBundleRoles = roles
 	m.mu.Unlock()
 

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -8,9 +8,11 @@ import (
 )
 
 // MenuBarClickableElements retrieves clickable UI elements from the focused application's menu bar.
+// If maxDepth is > 0, it overrides the configured tree depth.
 func MenuBarClickableElements(
 	logger *zap.Logger,
 	configProvider config.Provider,
+	maxDepth int,
 ) ([]*TreeNode, error) {
 	logger.Debug("Getting clickable elements for menu bar")
 
@@ -34,7 +36,12 @@ func MenuBarClickableElements(
 	opts.SetConfigProvider(configProvider)
 
 	if cfg := currentConfig(configProvider); cfg != nil {
-		opts.SetMaxDepth(cfg.Hints.MaxDepth)
+		depth := cfg.Hints.MaxDepth
+		if maxDepth > 0 {
+			depth = maxDepth
+		}
+
+		opts.SetMaxDepth(depth)
 		opts.SetParallelThreshold(cfg.Hints.ParallelThreshold)
 	}
 
@@ -85,11 +92,13 @@ func MenuBarClickableElements(
 }
 
 // ClickableElementsFromBundleID retrieves clickable UI elements from the application identified by bundle ID.
+// If maxDepth is > 0, it overrides the configured tree depth (useful for flat supplementary sources).
 func ClickableElementsFromBundleID(
 	bundleID string,
 	roles []string,
 	logger *zap.Logger,
 	configProvider config.Provider,
+	maxDepth int,
 ) ([]*TreeNode, error) {
 	logger.Debug("Getting clickable elements for bundle ID",
 		zap.String("bundle_id", bundleID),
@@ -107,7 +116,12 @@ func ClickableElementsFromBundleID(
 	opts.SetConfigProvider(configProvider)
 
 	if cfg := currentConfig(configProvider); cfg != nil {
-		opts.SetMaxDepth(cfg.Hints.MaxDepth)
+		depth := cfg.Hints.MaxDepth
+		if maxDepth > 0 {
+			depth = maxDepth
+		}
+
+		opts.SetMaxDepth(depth)
 		opts.SetParallelThreshold(cfg.Hints.ParallelThreshold)
 	}
 

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -622,7 +622,7 @@ func buildChildrenParallel(
 			}
 
 			// Recursively build (this may spawn more goroutines at deeper levels)
-			buildTreeRecursive(childNode, depth+1, opts, newClipBounds, windowBounds)
+			buildTreeRecursive(childNode, depth+1, opts, newClipBounds, winBounds)
 
 			results <- childResult{node: childNode, index: idx}
 		}(index, child, clipBounds, windowBounds)

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -513,14 +513,15 @@ func buildChildrenSequential(
 
 	// Second pass: create nodes and recurse
 	for _, data := range validChildren {
-		childNode := getTreeNode(data.element, data.info, parent, 0)
-
-		parent.children = append(parent.children, childNode)
-
 		// Skip hit-test for elements within the original window bounds
 		// (not in a scroll area). These elements are guaranteed visible
 		// by the AX tree — only scroll areas can have off-screen children.
+		// Must be set before getTreeNode to avoid relying on pointer aliasing.
 		data.info.skipHitTest = clipBounds == windowBounds
+
+		childNode := getTreeNode(data.element, data.info, parent, 0)
+
+		parent.children = append(parent.children, childNode)
 
 		newClipBounds := clipBounds
 		if element.Role(data.info.Role()) == element.RoleScrollArea {

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -301,7 +301,8 @@ func BuildTree(root *Element, opts TreeOptions) (*TreeNode, error) {
 	node := getTreeNode(root, info, nil, config.DefaultChildrenCapacity)
 
 	opts.stats = stats
-	buildTreeRecursive(node, 1, opts, windowBounds)
+	buildTreeRecursive(node, 1, opts, windowBounds, windowBounds)
+	accumulateSearchText(node)
 
 	if ce := opts.Logger().Check(zap.DebugLevel, "Tree build completed"); ce != nil {
 		ce.Write(
@@ -366,6 +367,7 @@ func buildTreeRecursive(
 	depth int,
 	opts TreeOptions,
 	clipBounds image.Rectangle,
+	windowBounds image.Rectangle,
 ) {
 	if opts.stats != nil {
 		opts.stats.nodesVisited.Add(1)
@@ -404,7 +406,7 @@ func buildTreeRecursive(
 	var children []*Element
 	if interactiveLeafRoles[element.Role(parent.info.Role())] {
 		var childrenErr error
-		children, childrenErr = parent.element.Children()
+		children, childrenErr = parent.element.Children(parent.info.Role())
 		hasImportantContainer := false
 		if childrenErr == nil && len(children) > 0 {
 			for _, child := range children {
@@ -439,7 +441,7 @@ func buildTreeRecursive(
 		// Reuse children slice for traversal below, skip the second Children() call.
 	} else {
 		var err error
-		children, err = parent.element.Children()
+		children, err = parent.element.Children(parent.info.Role())
 		if err != nil || len(children) == 0 {
 			if opts.stats != nil {
 				if err != nil {
@@ -458,9 +460,9 @@ func buildTreeRecursive(
 		len(children) >= opts.parallelThreshold
 
 	if shouldParallelize {
-		buildChildrenParallel(parent, children, depth, opts, clipBounds)
+		buildChildrenParallel(parent, children, depth, opts, clipBounds, windowBounds)
 	} else {
-		buildChildrenSequential(parent, children, depth, opts, clipBounds)
+		buildChildrenSequential(parent, children, depth, opts, clipBounds, windowBounds)
 	}
 }
 
@@ -470,6 +472,7 @@ func buildChildrenSequential(
 	depth int,
 	opts TreeOptions,
 	clipBounds image.Rectangle,
+	windowBounds image.Rectangle,
 ) {
 	// First pass: count valid children and collect their info
 	type childData struct {
@@ -514,6 +517,11 @@ func buildChildrenSequential(
 
 		parent.children = append(parent.children, childNode)
 
+		// Skip hit-test for elements within the original window bounds
+		// (not in a scroll area). These elements are guaranteed visible
+		// by the AX tree — only scroll areas can have off-screen children.
+		data.info.skipHitTest = clipBounds == windowBounds
+
 		newClipBounds := clipBounds
 		if element.Role(data.info.Role()) == element.RoleScrollArea {
 			childRect := rectFromInfo(data.info)
@@ -532,7 +540,7 @@ func buildChildrenSequential(
 			}
 		}
 
-		buildTreeRecursive(childNode, depth+1, opts, newClipBounds)
+		buildTreeRecursive(childNode, depth+1, opts, newClipBounds, windowBounds)
 	}
 
 	if opts.stats != nil {
@@ -546,6 +554,7 @@ func buildChildrenParallel(
 	depth int,
 	opts TreeOptions,
 	clipBounds image.Rectangle,
+	windowBounds image.Rectangle,
 ) {
 	// Pre-allocate result slice with exact capacity
 	type childResult struct {
@@ -561,7 +570,7 @@ func buildChildrenParallel(
 	// Process children in parallel
 	for index, child := range children {
 		waitGroup.Add(1)
-		go func(idx int, elem *Element, bounds image.Rectangle) {
+		go func(idx int, elem *Element, bounds, winBounds image.Rectangle) {
 			defer waitGroup.Done()
 
 			info, err := elem.Info()
@@ -591,6 +600,9 @@ func buildChildrenParallel(
 
 			childNode := getTreeNode(elem, info, parent, 0)
 
+			// Skip hit-test for elements within the original window bounds
+			info.skipHitTest = bounds == winBounds
+
 			newClipBounds := bounds
 			if element.Role(info.Role()) == element.RoleScrollArea {
 				childRect := rectFromInfo(info)
@@ -610,10 +622,10 @@ func buildChildrenParallel(
 			}
 
 			// Recursively build (this may spawn more goroutines at deeper levels)
-			buildTreeRecursive(childNode, depth+1, opts, newClipBounds)
+			buildTreeRecursive(childNode, depth+1, opts, newClipBounds, windowBounds)
 
 			results <- childResult{node: childNode, index: idx}
-		}(index, child, clipBounds)
+		}(index, child, clipBounds, windowBounds)
 	}
 
 	// Close results channel when all goroutines complete
@@ -740,6 +752,7 @@ func shouldIncludeElement(
 }
 
 // FindClickableElements finds all clickable elements in the tree.
+// Search text is already accumulated during tree building via accumulateSearchText.
 func (n *TreeNode) FindClickableElements(
 	allowedRoles map[string]struct{},
 	configProvider config.Provider,
@@ -753,8 +766,6 @@ func (n *TreeNode) FindClickableElements(
 			configProvider,
 			ignoreClickableCheck,
 		) {
-			node.info.searchText = node.collectSearchText()
-
 			result = append(result, node)
 		}
 
@@ -778,6 +789,35 @@ func appendSearchText(builder *strings.Builder, seen map[string]struct{}, text s
 	}
 	builder.WriteString(text)
 	seen[text] = struct{}{}
+}
+
+// accumulateSearchText performs a single post-order walk over the tree to
+// collect text from each node's subtree. This replaces the previous approach
+// where collectSearchText was called separately for each clickable element,
+// which resulted in O(n*m) descendant walks.
+func accumulateSearchText(root *TreeNode) {
+	root.walkTreePostOrder(func(node *TreeNode) {
+		if node.info == nil {
+			return
+		}
+
+		var builder strings.Builder
+		seen := make(map[string]struct{})
+
+		// Collect text from this node itself
+		appendSearchText(&builder, seen, node.info.Title())
+		appendSearchText(&builder, seen, node.info.Description())
+		appendSearchText(&builder, seen, node.info.Value())
+
+		// Merge text from children (already computed since this is post-order)
+		for _, child := range node.children {
+			if child.info != nil && child.info.searchText != "" {
+				appendSearchText(&builder, seen, child.info.searchText)
+			}
+		}
+
+		node.info.searchText = builder.String()
+	})
 }
 
 // Release releases the AXUIElementRef for every node in the subtree except
@@ -823,40 +863,12 @@ func (n *TreeNode) Release(keep map[*Element]struct{}) {
 	})
 }
 
-func (n *TreeNode) collectSearchText() string {
-	var builder strings.Builder
-	seen := make(map[string]struct{})
-
-	n.walkTreeDescendants(func(node *TreeNode) bool {
-		if node == nil || node.info == nil {
-			return true
-		}
-
-		appendSearchText(&builder, seen, node.info.Title())
-		appendSearchText(&builder, seen, node.info.Description())
-		appendSearchText(&builder, seen, node.info.Value())
-
-		return true
-	})
-
-	return builder.String()
-}
-
 // walkTree walks the tree in pre-order and calls the visitor function for each node.
 func (n *TreeNode) walkTree(visit func(*TreeNode) bool) {
 	if !visit(n) {
 		return
 	}
 
-	for _, child := range n.children {
-		child.walkTree(visit)
-	}
-}
-
-// walkTreeDescendants walks only the descendants (children and their subtrees),
-// excluding the root node itself. Used for collecting text from child elements
-// without including the root's own text fields.
-func (n *TreeNode) walkTreeDescendants(visit func(*TreeNode) bool) {
 	for _, child := range n.children {
 		child.walkTree(visit)
 	}

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -599,10 +599,12 @@ func buildChildrenParallel(
 				return
 			}
 
-			childNode := getTreeNode(elem, info, parent, 0)
-
 			// Skip hit-test for elements within the original window bounds
+			// (not in a scroll area). Must be set before getTreeNode to avoid
+			// relying on pointer aliasing.
 			info.skipHitTest = bounds == winBounds
+
+			childNode := getTreeNode(elem, info, parent, 0)
 
 			newClipBounds := bounds
 			if element.Role(info.Role()) == element.RoleScrollArea {

--- a/internal/core/infra/platform/darwin/accessibility.go
+++ b/internal/core/infra/platform/darwin/accessibility.go
@@ -105,6 +105,7 @@ func HasClickAction(element unsafe.Pointer) bool {
 		true,
 		true,
 		nil,
+		false,
 		0,
 		0, //nolint:nlreturn
 	) != 0

--- a/internal/core/infra/platform/darwin/accessibility.go
+++ b/internal/core/infra/platform/darwin/accessibility.go
@@ -99,7 +99,7 @@ func HasClickAction(element unsafe.Pointer) bool {
 
 	clickable := C.hasClickAction(
 		element,
-		true,  // skipVisCheck: no pre-computed center available in this simplified wrapper
+		true, // skipVisCheck: no pre-computed center available in this simplified wrapper
 		false,
 		true,
 		true,

--- a/internal/core/infra/platform/darwin/accessibility.go
+++ b/internal/core/infra/platform/darwin/accessibility.go
@@ -91,14 +91,25 @@ func ApplicationBundleIDByPID(pid int) (string, error) {
 }
 
 // HasClickAction checks if the accessibility element has a click action.
+// Uses default assumptions for pre-fetched attributes (not hidden, visible, enabled).
 func HasClickAction(element unsafe.Pointer) bool {
 	if element == nil {
 		return false
 	}
 
-	result := C.hasClickAction(element, false) != 0 //nolint:nlreturn
+	clickable := C.hasClickAction(
+		element,
+		false,
+		false,
+		true,
+		true,
+		true,
+		nil,
+		0,
+		0, //nolint:nlreturn
+	) != 0
 
-	return result
+	return clickable
 }
 
 // SetApplicationAttribute sets an attribute on an application by its PID.

--- a/internal/core/infra/platform/darwin/accessibility.go
+++ b/internal/core/infra/platform/darwin/accessibility.go
@@ -99,7 +99,7 @@ func HasClickAction(element unsafe.Pointer) bool {
 
 	clickable := C.hasClickAction(
 		element,
-		false,
+		true,  // skipVisCheck: no pre-computed center available in this simplified wrapper
 		false,
 		true,
 		true,

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -15,18 +15,20 @@
 
 /// Structure containing information about an accessibility element
 typedef struct {
-	CGPoint position;       ///< Element position
-	CGSize size;            ///< Element size
-	char *title;            ///< Element title
-	char *description;      ///< Element description
-	char *value;            ///< Element value
-	char *role;             ///< Element role
-	char *roleDescription;  ///< Element role description
-	bool isEnabled;         ///< Whether element is enabled
-	bool isFocused;         ///< Whether element is focused
-	int pid;                ///< Process identifier
-	bool isHidden;          ///< Whether element is AX-hidden (CSS visibility:hidden etc.)
-	bool isVisible;         ///< Whether element is AX-visible (default true when unsupported)
+	CGPoint position;          ///< Element position
+	CGSize size;               ///< Element size
+	char *title;               ///< Element title
+	char *description;         ///< Element description
+	char *value;               ///< Element value
+	char *identifier;          ///< Element identifier (for widget detection)
+	char *role;                ///< Element role
+	char *roleDescription;     ///< Element role description
+	bool isEnabled;            ///< Whether element is enabled
+	bool hasEnabledAttribute;  ///< Whether element supports AXEnabled attribute
+	bool isFocused;            ///< Whether element is focused
+	int pid;                   ///< Process identifier
+	bool isHidden;             ///< Whether element is AX-hidden (CSS visibility:hidden etc.)
+	bool isVisible;            ///< Whether element is AX-visible (default true when unsupported)
 } ElementInfo;
 
 #pragma mark - Permission Functions
@@ -118,8 +120,17 @@ void postMouseMoveEvent(CGPoint position, CGEventType eventType);
 /// Check if element has click action
 /// @param element Element reference
 /// @param skipVisCheck If true, skip the expensive hit-test visibility check
+/// @param preHidden Pre-fetched AXHidden value (from ElementInfo)
+/// @param preVisible Pre-fetched AXVisible value (from ElementInfo)
+/// @param preEnabled Pre-fetched AXEnabled value (from ElementInfo)
+/// @param hasEnabledAttr Whether AXEnabled attribute exists on this element
+/// @param preRole Pre-fetched AXRole value (from ElementInfo, caller retains)
+/// @param centerX Pre-computed center X (from ElementInfo position + size)
+/// @param centerY Pre-computed center Y (from ElementInfo position + size)
 /// @return 1 if element is clickable, 0 otherwise
-int hasClickAction(void *element, bool skipVisCheck);
+int hasClickAction(
+    void *element, bool skipVisCheck, bool preHidden, bool preVisible, bool preEnabled, bool hasEnabledAttr,
+    const char *preRole, double centerX, double centerY);
 
 /// Fast visibility check using a pre-computed center point (avoids redundant AX position fetch)
 /// @param element Element reference

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -125,12 +125,13 @@ void postMouseMoveEvent(CGPoint position, CGEventType eventType);
 /// @param preEnabled Pre-fetched AXEnabled value (from ElementInfo)
 /// @param hasEnabledAttr Whether AXEnabled attribute exists on this element
 /// @param preRole Pre-fetched AXRole value (from ElementInfo, caller retains)
+/// @param preIsWidget Pre-computed widget flag (from ElementInfo identifier)
 /// @param centerX Pre-computed center X (from ElementInfo position + size)
 /// @param centerY Pre-computed center Y (from ElementInfo position + size)
 /// @return 1 if element is clickable, 0 otherwise
 int hasClickAction(
     void *element, bool skipVisCheck, bool preHidden, bool preVisible, bool preEnabled, bool hasEnabledAttr,
-    const char *preRole, double centerX, double centerY);
+    const char *preRole, bool preIsWidget, double centerX, double centerY);
 
 /// Fast visibility check using a pre-computed center point (avoids redundant AX position fetch)
 /// @param element Element reference

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -9,6 +9,7 @@
 #import "accessibility_visibility.h"
 
 #import <Cocoa/Cocoa.h>
+#include <pthread.h>
 
 #pragma mark - Element Accessor Functions
 
@@ -123,6 +124,7 @@ ElementInfo *getElementInfo(void *element) {
 		        kAXTitleAttribute,
 		        kAXDescriptionAttribute,
 		        kAXValueAttribute,
+		        kAXIdentifierAttribute,
 		        kAXRoleAttribute,
 		        kAXRoleDescriptionAttribute,
 		        kAXEnabledAttribute,
@@ -130,7 +132,7 @@ ElementInfo *getElementInfo(void *element) {
 		        kAXHiddenAttribute,
 		        kVisibleAttr,
 		    },
-		    11, &kCFTypeArrayCallBacks);
+		    12, &kCFTypeArrayCallBacks);
 
 		if (!attributes) {
 			free(info);
@@ -149,7 +151,7 @@ ElementInfo *getElementInfo(void *element) {
 			return info;
 		}
 
-		// With option=0, values always has exactly 11 entries (one per requested attribute).
+		// With option=0, values always has exactly 12 entries (one per requested attribute).
 		// Slots for unsupported/errored attributes hold an AX error placeholder (CFNumber),
 		// which the CFGetTypeID checks below will correctly reject.
 		CFTypeRef positionValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 0);
@@ -183,32 +185,38 @@ ElementInfo *getElementInfo(void *element) {
 			info->value = cfStringToCString((CFStringRef)valueValue);
 		}
 
-		CFTypeRef roleValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 5);
+		CFTypeRef identifierValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 5);
+		if (identifierValue && CFGetTypeID(identifierValue) == CFStringGetTypeID()) {
+			info->identifier = cfStringToCString((CFStringRef)identifierValue);
+		}
+
+		CFTypeRef roleValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 6);
 		if (roleValue && CFGetTypeID(roleValue) == CFStringGetTypeID()) {
 			info->role = cfStringToCString((CFStringRef)roleValue);
 		}
 
-		CFTypeRef roleDescValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 6);
+		CFTypeRef roleDescValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 7);
 		if (roleDescValue && CFGetTypeID(roleDescValue) == CFStringGetTypeID()) {
 			info->roleDescription = cfStringToCString((CFStringRef)roleDescValue);
 		}
 
-		CFTypeRef enabledValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 7);
+		CFTypeRef enabledValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 8);
 		if (enabledValue && CFGetTypeID(enabledValue) == CFBooleanGetTypeID()) {
 			info->isEnabled = CFBooleanGetValue((CFBooleanRef)enabledValue);
+			info->hasEnabledAttribute = true;
 		}
 
-		CFTypeRef focusedValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 8);
+		CFTypeRef focusedValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 9);
 		if (focusedValue && CFGetTypeID(focusedValue) == CFBooleanGetTypeID()) {
 			info->isFocused = CFBooleanGetValue((CFBooleanRef)focusedValue);
 		}
 
-		CFTypeRef hiddenValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 9);
+		CFTypeRef hiddenValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 10);
 		if (hiddenValue && CFGetTypeID(hiddenValue) == CFBooleanGetTypeID()) {
 			info->isHidden = CFBooleanGetValue((CFBooleanRef)hiddenValue);
 		}
 
-		CFTypeRef visibleValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 10);
+		CFTypeRef visibleValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 11);
 		if (visibleValue && CFGetTypeID(visibleValue) == CFBooleanGetTypeID()) {
 			info->isVisible = CFBooleanGetValue((CFBooleanRef)visibleValue);
 		}
@@ -236,12 +244,38 @@ void freeElementInfo(ElementInfo *info) {
 		free(info->description);
 	if (info->value)
 		free(info->value);
+	if (info->identifier)
+		free(info->identifier);
 	if (info->role)
 		free(info->role);
 	if (info->roleDescription)
 		free(info->roleDescription);
 
 	free(info);
+}
+
+#pragma mark - Cached System-Wide Element
+
+static AXUIElementRef cachedSystemWideElement = NULL;
+static pthread_mutex_t systemWideMutex = PTHREAD_MUTEX_INITIALIZER;
+
+static AXUIElementRef getCachedSystemWideElement(void) {
+	pthread_mutex_lock(&systemWideMutex);
+	if (!cachedSystemWideElement) {
+		cachedSystemWideElement = AXUIElementCreateSystemWide();
+	}
+	CFRetain(cachedSystemWideElement);
+	pthread_mutex_unlock(&systemWideMutex);
+	return cachedSystemWideElement;
+}
+
+static void releaseCachedSystemWideElement(void) {
+	pthread_mutex_lock(&systemWideMutex);
+	if (cachedSystemWideElement) {
+		CFRelease(cachedSystemWideElement);
+		cachedSystemWideElement = NULL;
+	}
+	pthread_mutex_unlock(&systemWideMutex);
 }
 
 #pragma mark - Position Functions
@@ -497,9 +531,9 @@ int isElementVisibleAtPoint(void *element, CGPoint center) {
 
 	AXUIElementRef axElement = (AXUIElementRef)element;
 
-	AXUIElementRef systemWide = AXUIElementCreateSystemWide();
+	AXUIElementRef systemWide = getCachedSystemWideElement();
 	if (!systemWide)
-		return 1;  // Assume visible if system-wide ref cannot be created (mirrors isPointVisible)
+		return 1;
 
 	AXUIElementRef hitElement = NULL;
 	AXError error = AXUIElementCopyElementAtPosition(systemWide, center.x, center.y, &hitElement);
@@ -555,80 +589,29 @@ static bool getElementFrame(AXUIElementRef element, CGRect *outFrame) {
 /// Check if element has click action
 /// @param element Element reference
 /// @param skipVisCheck If true, skip the expensive hit-test visibility check
+/// @param preHidden Pre-fetched AXHidden value
+/// @param preVisible Pre-fetched AXVisible value
+/// @param preEnabled Pre-fetched AXEnabled value
+/// @param hasEnabledAttr Whether AXEnabled attribute exists on this element
+/// @param preRole Pre-fetched AXRole as C string
+/// @param centerX Pre-computed center X (from ElementInfo)
+/// @param centerY Pre-computed center Y (from ElementInfo)
 /// @return 1 if element is clickable, 0 otherwise
-int hasClickAction(void *element, bool skipVisCheck) {
+int hasClickAction(
+    void *element, bool skipVisCheck, bool preHidden, bool preVisible, bool preEnabled, bool hasEnabledAttr,
+    const char *preRole, double centerX, double centerY) {
 	if (!element)
 		return 0;
 
 	AXUIElementRef axElement = (AXUIElementRef)element;
 
-	CFTypeRef attrs[] = {
-	    kAXHiddenAttribute, kAXEnabledAttribute, kAXRoleAttribute, kAXIdentifierAttribute, kAXVisibleAttribute};
-
-	CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 5, &kCFTypeArrayCallBacks);
-
-	if (!attrArray)
+	if (preHidden || !preVisible)
 		return 0;
 
-	CFArrayRef values = NULL;
+	// Use pre-computed center from ElementInfo (no redundant AX call).
+	CGPoint visCenter = CGPointMake(centerX, centerY);
 
-	AXError err = AXUIElementCopyMultipleAttributeValues(axElement, attrArray, 0, &values);
-
-	CFRelease(attrArray);
-
-	bool isHidden = false;
-	bool isVisible = true;  // default visible when attribute not available
-	bool explicitlyDisabled = false;
-	bool hasEnabledAttribute = false;
-	bool isWidget = false;
-	CFStringRef role = NULL;
-
-	if (err == kAXErrorSuccess && values) {
-		CFIndex count = CFArrayGetCount(values);
-
-		for (CFIndex i = 0; i < count && i < 5; i++) {
-			CFTypeRef value = CFArrayGetValueAtIndex(values, i);
-			CFTypeRef attr = attrs[i];
-
-			if (!value)
-				continue;
-
-			if (attr == kAXHiddenAttribute && CFGetTypeID(value) == CFBooleanGetTypeID()) {
-				isHidden = CFBooleanGetValue((CFBooleanRef)value);
-			} else if (attr == kAXEnabledAttribute && CFGetTypeID(value) == CFBooleanGetTypeID()) {
-				hasEnabledAttribute = true;
-				explicitlyDisabled = !CFBooleanGetValue((CFBooleanRef)value);
-			} else if (attr == kAXRoleAttribute && CFGetTypeID(value) == CFStringGetTypeID()) {
-				role = (CFStringRef)value;
-				CFRetain(role);
-			} else if (attr == kAXIdentifierAttribute && CFGetTypeID(value) == CFStringGetTypeID()) {
-				isWidget = CFStringHasPrefix((CFStringRef)value, kAXWidgetIdentifierPrefix);
-			} else if (attr == kAXVisibleAttribute && CFGetTypeID(value) == CFBooleanGetTypeID()) {
-				isVisible = CFBooleanGetValue((CFBooleanRef)value);
-			}
-		}
-
-		CFRelease(values);
-	}
-
-	if (isHidden || !isVisible)
-		return 0;
-
-	// Pre-compute center for visibility hit-test.
-	// getElementCenter fetches AXPosition + AXSize in one batch call.
-	// Done once here so that every return-1 path below can use it without
-	// repeating the fetch (and without fetching it at all for excluded bundles).
-	CGPoint visCenter = CGPointZero;
-	bool hasVisCenter = false;
-	if (!skipVisCheck) {
-		hasVisCenter = getElementCenter((void *)axElement, &visCenter);
-	}
-
-	// visHit returns true when (a) skipVisCheck is set (excluded bundles),
-	// (b) the center could not be determined (conservatively assume visible),
-	// or (c) the hit-test at the element's center confirms it or a descendant
-	// is rendered at that point.
-#define visHit (!skipVisCheck && hasVisCenter ? isElementVisibleAtPoint((void *)axElement, visCenter) : 1)
+#define visHit (!skipVisCheck ? isElementVisibleAtPoint((void *)axElement, visCenter) : 1)
 
 	// Explicit actions are the strongest signal, so we check for them first
 	CFArrayRef actions = NULL;
@@ -648,20 +631,12 @@ int hasClickAction(void *element, bool skipVisCheck) {
 			    CFStringCompare(action, CFSTR("AXRaise"), 0) == kCFCompareEqualTo) {
 				CFRelease(actions);
 
-				if (hasEnabledAttribute && explicitlyDisabled) {
-					if (role)
-						CFRelease(role);
+				if (hasEnabledAttr && !preEnabled)
 					return 0;
-				}
 
-				if (!visHit) {
-					if (role)
-						CFRelease(role);
+				if (!visHit)
 					return 0;
-				}
 
-				if (role)
-					CFRelease(role);
 				return 1;
 			}
 		}
@@ -669,27 +644,33 @@ int hasClickAction(void *element, bool skipVisCheck) {
 		CFRelease(actions);
 	}
 
-	// Exclude known container/structural roles
-	if (role) {
-		if (CFStringCompare(role, kAXScrollAreaRole, 0) == kCFCompareEqualTo ||
-		    CFStringCompare(role, kAXGroupRole, 0) == kCFCompareEqualTo ||
-		    CFStringCompare(role, kAXSplitGroupRole, 0) == kCFCompareEqualTo) {
+	// Exclude known container/structural roles unless they are widgets
+	if (preRole) {
+		bool isScrollArea = strcmp(preRole, "AXScrollArea") == 0;
+		bool isGroup = strcmp(preRole, "AXGroup") == 0;
+		bool isSplitGroup = strcmp(preRole, "AXSplitGroup") == 0;
+
+		if (isScrollArea || isGroup || isSplitGroup) {
+			// Check if it's a widget by looking at the identifier attribute
+			CFStringRef identifier = NULL;
+			bool isWidget = false;
+			if (AXUIElementCopyAttributeValue(axElement, kAXIdentifierAttribute, (CFTypeRef *)&identifier) ==
+			        kAXErrorSuccess &&
+			    identifier) {
+				isWidget = CFStringHasPrefix(identifier, kAXWidgetIdentifierPrefix);
+				CFRelease(identifier);
+			}
+
 			if (isWidget) {
-				if (hasEnabledAttribute && explicitlyDisabled) {
-					CFRelease(role);
+				if (hasEnabledAttr && !preEnabled)
 					return 0;
-				}
 
-				if (!visHit) {
-					CFRelease(role);
+				if (!visHit)
 					return 0;
-				}
 
-				CFRelease(role);
 				return 1;
 			}
 
-			CFRelease(role);
 			return 0;
 		}
 	}
@@ -699,45 +680,31 @@ int hasClickAction(void *element, bool skipVisCheck) {
 	if (AXUIElementCopyActionDescription(axElement, kAXPressAction, &pressDesc) == kAXErrorSuccess && pressDesc) {
 		CFRelease(pressDesc);
 
-		if (!visHit) {
-			if (role)
-				CFRelease(role);
+		if (!visHit)
 			return 0;
-		}
 
-		if (role)
-			CFRelease(role);
 		return 1;
 	}
 
 	// Role-specific fallback for links
-	if (role && CFStringCompare(role, kAXLinkRole, 0) == kCFCompareEqualTo) {
+	if (preRole && strcmp(preRole, "AXLink") == 0) {
 		CFTypeRef urlAttr = NULL;
 		if (AXUIElementCopyAttributeValue(axElement, kAXURLAttribute, &urlAttr) == kAXErrorSuccess && urlAttr) {
 			CFRelease(urlAttr);
 
-			if (!visHit) {
-				CFRelease(role);
+			if (!visHit)
 				return 0;
-			}
 
-			CFRelease(role);
 			return 1;
 		}
 	}
 
-	if (role)
-		CFRelease(role);
-
 	// Visibility check: hit-test at center to filter obscured/scroll-clipped elements.
-	if (skipVisCheck)
-		return 1;
-
-	if (hasVisCenter) {
+	if (!skipVisCheck) {
 		return isElementVisibleAtPoint((void *)axElement, visCenter);
 	}
 
-	return 0;
+	return 1;
 
 #undef visHit
 }

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -264,7 +264,9 @@ static AXUIElementRef getCachedSystemWideElement(void) {
 	if (!cachedSystemWideElement) {
 		cachedSystemWideElement = AXUIElementCreateSystemWide();
 	}
-	CFRetain(cachedSystemWideElement);
+	if (cachedSystemWideElement) {
+		CFRetain(cachedSystemWideElement);
+	}
 	pthread_mutex_unlock(&systemWideMutex);
 	return cachedSystemWideElement;
 }

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -474,8 +474,6 @@ void **getVisibleRows(void *element, int *count) {
 static CFStringRef kAXLinkRole = CFSTR("AXLink");
 static CFStringRef kAXCheckboxRole = CFSTR("AXCheckBox");
 static CFStringRef kAXFocusableAttribute = CFSTR("AXFocusable");
-static CFStringRef kAXVisibleAttribute = CFSTR("AXVisible");
-static CFStringRef kAXWidgetIdentifierPrefix = CFSTR("widget-local:");
 
 #pragma mark - Click Action Functions
 
@@ -592,7 +590,7 @@ static bool getElementFrame(AXUIElementRef element, CGRect *outFrame) {
 /// @return 1 if element is clickable, 0 otherwise
 int hasClickAction(
     void *element, bool skipVisCheck, bool preHidden, bool preVisible, bool preEnabled, bool hasEnabledAttr,
-    const char *preRole, double centerX, double centerY) {
+    const char *preRole, bool preIsWidget, double centerX, double centerY) {
 	if (!element)
 		return 0;
 
@@ -644,17 +642,7 @@ int hasClickAction(
 		bool isSplitGroup = strcmp(preRole, "AXSplitGroup") == 0;
 
 		if (isScrollArea || isGroup || isSplitGroup) {
-			// Check if it's a widget by looking at the identifier attribute
-			CFStringRef identifier = NULL;
-			bool isWidget = false;
-			if (AXUIElementCopyAttributeValue(axElement, kAXIdentifierAttribute, (CFTypeRef *)&identifier) ==
-			        kAXErrorSuccess &&
-			    identifier) {
-				isWidget = CFStringHasPrefix(identifier, kAXWidgetIdentifierPrefix);
-				CFRelease(identifier);
-			}
-
-			if (isWidget) {
+			if (preIsWidget) {
 				if (hasEnabledAttr && !preEnabled)
 					return 0;
 

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -269,15 +269,6 @@ static AXUIElementRef getCachedSystemWideElement(void) {
 	return cachedSystemWideElement;
 }
 
-static void releaseCachedSystemWideElement(void) {
-	pthread_mutex_lock(&systemWideMutex);
-	if (cachedSystemWideElement) {
-		CFRelease(cachedSystemWideElement);
-		cachedSystemWideElement = NULL;
-	}
-	pthread_mutex_unlock(&systemWideMutex);
-}
-
 #pragma mark - Position Functions
 
 /// Get element at screen position


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR follow up the performance regression introduced in #821, by making the hints activation speed almost on par to homerow.

- Batch-fetch all element attributes in one AX API call instead of multiple round-trips
- Pre-compute center point and visibility flags once, reuse across clickability checks
- Cache the system-wide AX element reference to avoid recreating it on every hit-test
- Accumulate search text in a single tree walk instead of per-element walks
- Pre-fetch bundle ID once per mode activation and pass it through the chain
- Added explicit tree depth limit for menubar/dock/stage-manager/PIP that has shallow depth

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Follow up of #821

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

Quick video side by side with homerow:

https://github.com/user-attachments/assets/5be4b263-2163-4c62-a109-accd831b1fd1

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
