### PR TITLE
feat(scroll,cli): add `--steps` flag for overrides

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -362,10 +362,10 @@ neru action mouse_down          # Hold mouse button
 neru action mouse_up            # Release mouse button
 neru action save_cursor_pos     # Save current cursor position
 neru action restore_cursor_pos     # Restore saved cursor position
-neru action scroll_up           # Scroll up at cursor
-neru action scroll_down         # Scroll down at cursor
-neru action scroll_left         # Scroll left at cursor
-neru action scroll_right        # Scroll right at cursor
+neru action scroll_up           # Scroll up at cursor (--steps to override)
+neru action scroll_down         # Scroll down at cursor (--steps to override)
+neru action scroll_left         # Scroll left at cursor (--steps to override)
+neru action scroll_right        # Scroll right at cursor (--steps to override)
 neru action page_up             # Half-page up at cursor
 neru action page_down           # Half-page down at cursor
 neru action go_top              # Jump to top at cursor
@@ -505,6 +505,24 @@ neru action move_mouse_relative --dx 10 --dy -5
 | `--window`    | Move to the center of the focused window                   |
 | `--selection` | Explicitly use the active mode selection                     |
 | `--bare`      | Force current-cursor targeting even when a selection exists  |
+
+**Scroll action flags:**
+
+`scroll_up`, `scroll_down`, `scroll_left`, and `scroll_right` support these flags:
+
+| Flag            | Description                                                               |
+| --------------- | ------------------------------------------------------------------------- |
+| `--steps <px>`  | Override the scroll step amount (pixels); configured default is used when omitted |
+| `--selection`   | Explicitly use the active mode selection as the target point              |
+| `--bare`        | Use the current cursor position even when a mode selection exists         |
+
+`page_up`, `page_down`, `go_top`, and `go_bottom` support only `--selection` and `--bare`.
+
+```
+neru action scroll_down              # Scroll down 50px (configured default)
+neru action scroll_down --steps 200  # Scroll down 200px
+neru action scroll_left --steps 100  # Scroll left 100px
+```
 
 > [!TIP]
 > Point-targeted actions prefer the active mode selection by default. Use `--bare` when you want `left_click`, `right_click`, `middle_click`, `mouse_down`, `mouse_up`, `move_mouse`, or scroll actions to ignore the selection and use the current cursor position instead.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -267,6 +267,10 @@ All one-shot actions are exposed through `action` subcommands and are valid in c
 
 > [!TIP]
 > Point-targeted actions prefer the current mode selection by default. Use the `--bare` flag (e.g. `"action left_click --bare"`) to ignore the selection and target the current cursor position instead.
+>
+> `scroll_up`, `scroll_down`, `scroll_left`, and `scroll_right` also support a `--steps` flag
+> (e.g. `"action scroll_down --steps 200"`) to override the configured `scroll_step` for a
+> single invocation. `page_up`, `page_down`, `go_top`, and `go_bottom` do not support `--steps`.
 
 ### Feed keys
 

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -80,6 +80,8 @@ type parsedActionArgs struct {
 	usePrevious    bool
 	useBackward    bool
 	modifierStr    string
+	stepsOverride  int
+	hasSteps       bool
 }
 
 func shouldClearSelectionAfterMoveMouse(parsed parsedActionArgs, targetsSelection bool) bool {
@@ -221,6 +223,18 @@ func parseActionArgs(rawArgs []string) (parsedActionArgs, bool) {
 
 			parsed.monitorName = val
 			parsed.hasMonitorName = true
+		case strings.HasPrefix(arg, "--steps") && (arg == "--steps" || arg[len("--steps")] == '='):
+			val, newIdx, ok := extractIntFlag(rawArgs, idx, "--steps")
+			idx = newIdx
+
+			if !ok || val <= 0 {
+				parseErr = true
+
+				break
+			}
+
+			parsed.stepsOverride = val
+			parsed.hasSteps = true
 		default:
 			if strings.HasPrefix(arg, "--") {
 				parseErr = true
@@ -1322,6 +1336,14 @@ func (h *IPCControllerActions) handleScrollAction(
 		}
 	}
 
+	if parsed.hasSteps && amount != services.ScrollAmountChar {
+		return ipc.Response{
+			Success: false,
+			Message: "--steps is only supported with scroll_up, scroll_down, scroll_left, and scroll_right",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
 	h.logger.Info("Performing scroll action via IPC",
 		zap.String("action", actionName),
 		zap.Int("direction", int(direction)),
@@ -1366,7 +1388,7 @@ func (h *IPCControllerActions) handleScrollAction(
 		}
 	}
 
-	scrollErr := h.scrollService.Scroll(ctx, direction, amount)
+	scrollErr := h.scrollService.Scroll(ctx, direction, amount, parsed.stepsOverride)
 	if scrollErr != nil {
 		h.logger.Error("Scroll action failed", zap.Error(scrollErr),
 			zap.String("action", actionName))

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -126,6 +126,50 @@ func TestParseActionArgs_BareFlag(t *testing.T) {
 	}
 }
 
+func TestParseActionArgs_StepsFlagEqualsForm(t *testing.T) {
+	parsed, parseErr := parseActionArgs([]string{"--steps=100"})
+	if parseErr {
+		t.Fatal("parseActionArgs() unexpected parse error for --steps=100")
+	}
+
+	if !parsed.hasSteps {
+		t.Fatal("parseActionArgs() expected hasSteps to be true")
+	}
+
+	if parsed.stepsOverride != 100 {
+		t.Fatalf("parseActionArgs() expected stepsOverride to be 100, got %d", parsed.stepsOverride)
+	}
+}
+
+func TestParseActionArgs_StepsFlagSpaceForm(t *testing.T) {
+	parsed, parseErr := parseActionArgs([]string{"--steps", "200"})
+	if parseErr {
+		t.Fatal("parseActionArgs() unexpected parse error for --steps 200")
+	}
+
+	if !parsed.hasSteps {
+		t.Fatal("parseActionArgs() expected hasSteps to be true")
+	}
+
+	if parsed.stepsOverride != 200 {
+		t.Fatalf("parseActionArgs() expected stepsOverride to be 200, got %d", parsed.stepsOverride)
+	}
+}
+
+func TestParseActionArgs_StepsFlagRejectsZero(t *testing.T) {
+	_, parseErr := parseActionArgs([]string{"--steps=0"})
+	if !parseErr {
+		t.Fatal("parseActionArgs() expected parse error for --steps=0")
+	}
+}
+
+func TestParseActionArgs_StepsFlagRejectsNegative(t *testing.T) {
+	_, parseErr := parseActionArgs([]string{"--steps=-10"})
+	if !parseErr {
+		t.Fatal("parseActionArgs() expected parse error for --steps=-10")
+	}
+}
+
 func TestParseActionArgs_ModifierCSV(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/app/services/scroll_service.go
+++ b/internal/app/services/scroll_service.go
@@ -62,13 +62,15 @@ func NewScrollService(
 }
 
 // Scroll performs a scrolling operation in the specified direction and magnitude.
+// If stepOverride is > 0, it overrides the configured scroll step for this invocation.
 func (s *ScrollService) Scroll(
 	ctx context.Context,
 	direction ScrollDirection,
 	amount ScrollAmount,
+	stepOverride int,
 ) error {
 	s.mu.RLock()
-	deltaX, deltaY := s.calculateDelta(direction, amount)
+	deltaX, deltaY := s.calculateDelta(direction, amount, stepOverride)
 	s.mu.RUnlock()
 
 	s.logger.Debug("Scrolling",
@@ -104,19 +106,28 @@ func (s *ScrollService) UpdateConfig(config config.ScrollConfig) {
 }
 
 // calculateDelta computes the scroll delta values based on direction and magnitude.
-func (s *ScrollService) calculateDelta(direction ScrollDirection, amount ScrollAmount) (int, int) {
+// If stepOverride is > 0, it takes precedence over the configured value.
+func (s *ScrollService) calculateDelta(
+	direction ScrollDirection,
+	amount ScrollAmount,
+	stepOverride int,
+) (int, int) {
 	var (
 		deltaX, deltaY int
 		baseScroll     int
 	)
 
-	switch amount {
-	case ScrollAmountChar:
-		baseScroll = s.config.ScrollStep
-	case ScrollAmountHalfPage:
-		baseScroll = s.config.ScrollStepHalf
-	case ScrollAmountEnd:
-		baseScroll = s.config.ScrollStepFull
+	if stepOverride > 0 {
+		baseScroll = stepOverride
+	} else {
+		switch amount {
+		case ScrollAmountChar:
+			baseScroll = s.config.ScrollStep
+		case ScrollAmountHalfPage:
+			baseScroll = s.config.ScrollStepHalf
+		case ScrollAmountEnd:
+			baseScroll = s.config.ScrollStepFull
+		}
 	}
 
 	switch direction {

--- a/internal/app/services/scroll_service_test.go
+++ b/internal/app/services/scroll_service_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestScrollService_Scroll(t *testing.T) {
 	tests := []struct {
-		name       string
-		direction  services.ScrollDirection
-		amount     services.ScrollAmount
-		setupMocks func(*mocks.MockAccessibilityPort)
-		wantErr    bool
+		name         string
+		direction    services.ScrollDirection
+		amount       services.ScrollAmount
+		stepOverride int
+		setupMocks   func(*mocks.MockAccessibilityPort)
+		wantErr      bool
 	}{
 		{
 			name:      "scroll down char",
@@ -127,6 +128,104 @@ func TestScrollService_Scroll(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:         "step override down",
+			direction:    services.ScrollDirectionDown,
+			amount:       services.ScrollAmountChar,
+			stepOverride: 99,
+			setupMocks: func(acc *mocks.MockAccessibilityPort) {
+				acc.ScrollFunc = func(_ context.Context, _, deltaY int) error {
+					if deltaY != -99 {
+						t.Errorf("Expected deltaY -99 for step override down, got %d", deltaY)
+					}
+
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:         "step override up",
+			direction:    services.ScrollDirectionUp,
+			amount:       services.ScrollAmountChar,
+			stepOverride: 77,
+			setupMocks: func(acc *mocks.MockAccessibilityPort) {
+				acc.ScrollFunc = func(_ context.Context, _, deltaY int) error {
+					if deltaY != 77 {
+						t.Errorf("Expected deltaY 77 for step override up, got %d", deltaY)
+					}
+
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:         "step override left",
+			direction:    services.ScrollDirectionLeft,
+			amount:       services.ScrollAmountChar,
+			stepOverride: 42,
+			setupMocks: func(acc *mocks.MockAccessibilityPort) {
+				acc.ScrollFunc = func(_ context.Context, deltaX, _ int) error {
+					if deltaX != 42 {
+						t.Errorf("Expected deltaX 42 for step override left, got %d", deltaX)
+					}
+
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:         "step override right",
+			direction:    services.ScrollDirectionRight,
+			amount:       services.ScrollAmountChar,
+			stepOverride: 33,
+			setupMocks: func(acc *mocks.MockAccessibilityPort) {
+				acc.ScrollFunc = func(_ context.Context, deltaX, _ int) error {
+					if deltaX != -33 {
+						t.Errorf("Expected deltaX -33 for step override right, got %d", deltaX)
+					}
+
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:         "step override takes precedence over half page config",
+			direction:    services.ScrollDirectionDown,
+			amount:       services.ScrollAmountHalfPage,
+			stepOverride: 5,
+			setupMocks: func(acc *mocks.MockAccessibilityPort) {
+				acc.ScrollFunc = func(_ context.Context, _, deltaY int) error {
+					// Should use stepOverride (5), not config.ScrollStepHalf (30)
+					if deltaY != -5 {
+						t.Errorf("Expected deltaY -5 for step override, got %d", deltaY)
+					}
+
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:         "step override takes precedence over full page config",
+			direction:    services.ScrollDirectionUp,
+			amount:       services.ScrollAmountEnd,
+			stepOverride: 8,
+			setupMocks: func(acc *mocks.MockAccessibilityPort) {
+				acc.ScrollFunc = func(_ context.Context, _, deltaY int) error {
+					// Should use stepOverride (8), not config.ScrollStepFull (50)
+					if deltaY != 8 {
+						t.Errorf("Expected deltaY 8 for step override, got %d", deltaY)
+					}
+
+					return nil
+				}
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, testCase := range tests {
@@ -153,7 +252,7 @@ func TestScrollService_Scroll(t *testing.T) {
 			)
 			ctx := context.Background()
 
-			scrollErr := service.Scroll(ctx, testCase.direction, testCase.amount, 0)
+			scrollErr := service.Scroll(ctx, testCase.direction, testCase.amount, testCase.stepOverride)
 
 			if (scrollErr != nil) != testCase.wantErr {
 				t.Errorf("Scroll() error = %v, wantErr %v", scrollErr, testCase.wantErr)

--- a/internal/app/services/scroll_service_test.go
+++ b/internal/app/services/scroll_service_test.go
@@ -153,7 +153,7 @@ func TestScrollService_Scroll(t *testing.T) {
 			)
 			ctx := context.Background()
 
-			scrollErr := service.Scroll(ctx, testCase.direction, testCase.amount)
+			scrollErr := service.Scroll(ctx, testCase.direction, testCase.amount, 0)
 
 			if (scrollErr != nil) != testCase.wantErr {
 				t.Errorf("Scroll() error = %v, wantErr %v", scrollErr, testCase.wantErr)

--- a/internal/app/services/scroll_service_test.go
+++ b/internal/app/services/scroll_service_test.go
@@ -252,7 +252,12 @@ func TestScrollService_Scroll(t *testing.T) {
 			)
 			ctx := context.Background()
 
-			scrollErr := service.Scroll(ctx, testCase.direction, testCase.amount, testCase.stepOverride)
+			scrollErr := service.Scroll(
+				ctx,
+				testCase.direction,
+				testCase.amount,
+				testCase.stepOverride,
+			)
 
 			if (scrollErr != nil) != testCase.wantErr {
 				t.Errorf("Scroll() error = %v, wantErr %v", scrollErr, testCase.wantErr)

--- a/internal/app/services/services_integration_darwin_test.go
+++ b/internal/app/services/services_integration_darwin_test.go
@@ -245,6 +245,7 @@ func TestScrollServiceIntegration(t *testing.T) {
 			ctx,
 			services.ScrollDirectionDown,
 			services.ScrollAmountHalfPage,
+			0,
 		)
 		if err != nil {
 			t.Logf("Scroll failed (expected in some environments): %v", err)

--- a/internal/cli/action.go
+++ b/internal/cli/action.go
@@ -129,6 +129,7 @@ var ActionScrollUpCmd = BuildScrollActionCommand(
 	"scroll_up",
 	"Scroll up",
 	`Scroll up at the active selection when available, otherwise at the current cursor location.`,
+	true,
 )
 
 // ActionScrollDownCmd scrolls down at the current cursor position.
@@ -136,6 +137,7 @@ var ActionScrollDownCmd = BuildScrollActionCommand(
 	"scroll_down",
 	"Scroll down",
 	`Scroll down at the active selection when available, otherwise at the current cursor location.`,
+	true,
 )
 
 // ActionScrollLeftCmd scrolls left at the current cursor position.
@@ -143,6 +145,7 @@ var ActionScrollLeftCmd = BuildScrollActionCommand(
 	"scroll_left",
 	"Scroll left",
 	`Scroll left at the active selection when available, otherwise at the current cursor location.`,
+	true,
 )
 
 // ActionScrollRightCmd scrolls right at the current cursor position.
@@ -150,6 +153,7 @@ var ActionScrollRightCmd = BuildScrollActionCommand(
 	"scroll_right",
 	"Scroll right",
 	`Scroll right at the active selection when available, otherwise at the current cursor location.`,
+	true,
 )
 
 // ActionGoTopCmd scrolls to the top of the page.
@@ -157,6 +161,7 @@ var ActionGoTopCmd = BuildScrollActionCommand(
 	"go_top",
 	"Scroll to top of page",
 	`Scroll to the top of the page at the active selection when available, otherwise at the current cursor location.`,
+	false,
 )
 
 // ActionGoBottomCmd scrolls to the bottom of the page.
@@ -164,6 +169,7 @@ var ActionGoBottomCmd = BuildScrollActionCommand(
 	"go_bottom",
 	"Scroll to bottom of page",
 	`Scroll to the bottom of the page at the active selection when available, otherwise at the current cursor location.`,
+	false,
 )
 
 // ActionPageUpCmd scrolls up by half a page.
@@ -171,6 +177,7 @@ var ActionPageUpCmd = BuildScrollActionCommand(
 	"page_up",
 	"Scroll up by half page",
 	`Scroll up by half a page at the active selection when available, otherwise at the current cursor location.`,
+	false,
 )
 
 // ActionPageDownCmd scrolls down by half a page.
@@ -178,6 +185,7 @@ var ActionPageDownCmd = BuildScrollActionCommand(
 	"page_down",
 	"Scroll down by half page",
 	`Scroll down by half a page at the active selection when available, otherwise at the current cursor location.`,
+	false,
 )
 
 // ActionCycleHintCmd cycles through visible hints in hints mode.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -351,10 +352,12 @@ Use --bare to force current-cursor targeting.`,
 }
 
 // BuildScrollActionCommand creates a scroll action cobra command.
-func BuildScrollActionCommand(use, short, long string) *cobra.Command {
+// If supportSteps is true, a --steps flag is added to override the scroll step amount.
+func BuildScrollActionCommand(use, short, long string, supportSteps bool) *cobra.Command {
 	var (
 		selection bool
 		bare      bool
+		steps     int
 	)
 
 	cmd := &cobra.Command{
@@ -381,6 +384,10 @@ func BuildScrollActionCommand(use, short, long string) *cobra.Command {
 				args = append(args, "--bare")
 			}
 
+			if supportSteps && steps > 0 {
+				args = append(args, "--steps", strconv.Itoa(steps))
+			}
+
 			return sendCommand(cmd, "action", args)
 		},
 	}
@@ -389,6 +396,11 @@ func BuildScrollActionCommand(use, short, long string) *cobra.Command {
 		BoolVar(&selection, "selection", false, "Explicitly use the active mode selection as the target point")
 	cmd.Flags().
 		BoolVar(&bare, "bare", false, "Use the current cursor position even when a mode selection exists")
+
+	if supportSteps {
+		cmd.Flags().
+			IntVar(&steps, "steps", 0, "Override the scroll step amount (pixels); configured default is used when omitted")
+	}
 
 	return cmd
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -384,8 +384,17 @@ func BuildScrollActionCommand(use, short, long string, supportSteps bool) *cobra
 				args = append(args, "--bare")
 			}
 
-			if supportSteps && steps > 0 {
-				args = append(args, "--steps", strconv.Itoa(steps))
+			if supportSteps {
+				if cmd.Flags().Changed("steps") && steps <= 0 {
+					return derrors.New(
+						derrors.CodeInvalidInput,
+						"--steps must be a positive integer",
+					)
+				}
+
+				if steps > 0 {
+					args = append(args, "--steps", strconv.Itoa(steps))
+				}
 			}
 
 			return sendCommand(cmd, "action", args)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a `--steps` flag to the `scroll_up`, `scroll_down`, `scroll_left`, and `scroll_right` actions that lets users override the configured `scroll_step` for a single invocation.

- configured default is preserved when the flag is omitted
- `page_*` and `go_*` actions do not support the flag

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to #816
Closes #820

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

The initial idea of consolidating all the scroll actions into a single `action scroll --x <pixel> --y <pixel>` was considered, but it will cause extreme issue for our newly implemented `repeat scrolling` mechanism. So no no..
