### PR TITLE
perf(hints): add `max_parallel_depth` option and bump to 10

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -46,6 +46,7 @@ enabled = true
 hint_characters = "asdfghjkl"               # Characters used for hint labels
 max_depth = 50                              # Max accessibility tree depth (0 = unlimited)
 parallel_threshold = 20                     # Min children to trigger parallel tree building
+max_parallel_depth = 20                     # Max tree depth to parallelize
 include_menubar_hints = false
 additional_menubar_hints_targets = [
     "com.apple.TextInputMenuAgent",

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -46,7 +46,7 @@ enabled = true
 hint_characters = "asdfghjkl"               # Characters used for hint labels
 max_depth = 50                              # Max accessibility tree depth (0 = unlimited)
 parallel_threshold = 20                     # Min children to trigger parallel tree building
-max_parallel_depth = 20                     # Max tree depth to parallelize
+max_parallel_depth = 10                     # Max tree depth to parallelize (≥ 1)
 include_menubar_hints = false
 additional_menubar_hints_targets = [
     "com.apple.TextInputMenuAgent",

--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -8,7 +8,7 @@
 enabled = true
 max_depth = 50
 parallel_threshold = 20
-max_parallel_depth = 20
+max_parallel_depth = 10
 include_menubar_hints = true               # Show hints on menubar
 include_dock_hints = true                  # Show hints on Dock and Mission Control
 include_nc_hints = true                    # Show hints on Notification Center

--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -8,6 +8,7 @@
 enabled = true
 max_depth = 50
 parallel_threshold = 20
+max_parallel_depth = 20
 include_menubar_hints = true               # Show hints on menubar
 include_dock_hints = true                  # Show hints on Dock and Mission Control
 include_nc_hints = true                    # Show hints on Notification Center

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -337,6 +337,7 @@ You can also start hints mode with the search input shown immediately by using t
 | `hint_characters`                  | string | `"asdfghjkl"` | Characters used for labels                           |
 | `max_depth`                        | int    | `50`          | Max accessibility tree depth (0 = unlimited)         |
 | `parallel_threshold`               | int    | `20`          | Min children to trigger parallel tree building (≥ 1) |
+| `max_parallel_depth`               | int    | `20`          | Max tree depth to parallelize (≥ 1)                  |
 | `include_menubar_hints`            | bool   | `false`       | Show hints on menubar items                          |
 | `include_dock_hints`               | bool   | `false`       | Show hints on Dock items                             |
 | `include_nc_hints`                 | bool   | `false`       | Show hints in Notification Center                    |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -337,7 +337,7 @@ You can also start hints mode with the search input shown immediately by using t
 | `hint_characters`                  | string | `"asdfghjkl"` | Characters used for labels                           |
 | `max_depth`                        | int    | `50`          | Max accessibility tree depth (0 = unlimited)         |
 | `parallel_threshold`               | int    | `20`          | Min children to trigger parallel tree building (≥ 1) |
-| `max_parallel_depth`               | int    | `20`          | Max tree depth to parallelize (≥ 1)                  |
+| `max_parallel_depth`               | int    | `10`          | Max tree depth to parallelize (≥ 1)                  |
 | `include_menubar_hints`            | bool   | `false`       | Show hints on menubar items                          |
 | `include_dock_hints`               | bool   | `false`       | Show hints on Dock items                             |
 | `include_nc_hints`                 | bool   | `false`       | Show hints in Notification Center                    |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -566,6 +566,7 @@ type HintsConfig struct {
 	HintCharacters    string              `json:"hintCharacters"    toml:"hint_characters"`
 	MaxDepth          int                 `json:"maxDepth"          toml:"max_depth"`
 	ParallelThreshold int                 `json:"parallelThreshold" toml:"parallel_threshold"`
+	MaxParallelDepth  int                 `json:"maxParallelDepth"  toml:"max_parallel_depth"`
 	UI                HintsUI             `json:"ui"                toml:"ui"`
 	SearchInputUI     SearchInputUI       `json:"searchInputUi"     toml:"search_input_ui"`
 	BoundaryHighlight BoundaryHighlightUI `json:"boundaryHighlight" toml:"boundary_highlight"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -100,6 +100,8 @@ const (
 	DefaultParallelThreshold = 20
 	// DefaultMaxParallelDepth is the default max parallel depth.
 	DefaultMaxParallelDepth = 20
+	// MaxParallelDepthCap is the maximum allowed value for max_parallel_depth.
+	MaxParallelDepthCap = 50
 
 	// DefaultMaxDepth is the default max depth for accessibility tree traversal.
 	DefaultMaxDepth = 50

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -99,7 +99,7 @@ const (
 	// DefaultParallelThreshold is the default parallel threshold.
 	DefaultParallelThreshold = 20
 	// DefaultMaxParallelDepth is the default max parallel depth.
-	DefaultMaxParallelDepth = 4
+	DefaultMaxParallelDepth = 20
 
 	// DefaultMaxDepth is the default max depth for accessibility tree traversal.
 	DefaultMaxDepth = 50
@@ -286,6 +286,7 @@ func newDefaultConfig() *Config {
 			HintCharacters:    "asdfghjkl",
 			MaxDepth:          DefaultMaxDepth,
 			ParallelThreshold: DefaultParallelThreshold,
+			MaxParallelDepth:  DefaultMaxParallelDepth,
 			Hotkeys: map[string]StringOrStringArray{
 				"Escape":    {"idle"},
 				"/":         {"action search_hints"},

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -99,7 +99,7 @@ const (
 	// DefaultParallelThreshold is the default parallel threshold.
 	DefaultParallelThreshold = 20
 	// DefaultMaxParallelDepth is the default max parallel depth.
-	DefaultMaxParallelDepth = 20
+	DefaultMaxParallelDepth = 10
 	// MaxParallelDepthCap is the maximum allowed value for max_parallel_depth.
 	MaxParallelDepthCap = 50
 

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -238,6 +238,11 @@ func (c *Config) ValidateHints() error {
 		return err
 	}
 
+	err = validateMinValue(c.Hints.MaxParallelDepth, 1, "hints.max_parallel_depth")
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -246,7 +246,8 @@ func (c *Config) ValidateHints() error {
 	if c.Hints.MaxParallelDepth > MaxParallelDepthCap {
 		return derrors.Newf(
 			derrors.CodeInvalidConfig,
-			"hints.max_parallel_depth must not exceed 50",
+			"hints.max_parallel_depth must not exceed %d",
+			MaxParallelDepthCap,
 		)
 	}
 

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -243,6 +243,21 @@ func (c *Config) ValidateHints() error {
 		return err
 	}
 
+	if c.Hints.MaxParallelDepth > MaxParallelDepthCap {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"hints.max_parallel_depth must not exceed 50",
+		)
+	}
+
+	if c.Hints.MaxDepth > 0 && c.Hints.MaxParallelDepth > c.Hints.MaxDepth {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"hints.max_parallel_depth (%d) must not exceed hints.max_depth (%d)",
+			c.Hints.MaxParallelDepth, c.Hints.MaxDepth,
+		)
+	}
+
 	return nil
 }
 

--- a/internal/config/validators_hints_test.go
+++ b/internal/config/validators_hints_test.go
@@ -61,3 +61,60 @@ func TestValidateHints_UIPlacement(t *testing.T) {
 		t.Fatal("ValidateHints() expected error for invalid hints.ui.placement")
 	}
 }
+
+func TestValidateHints_MaxParallelDepth_WithinCap(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Hints.MaxParallelDepth = 50
+
+	err := cfg.ValidateHints()
+	if err != nil {
+		t.Fatalf("ValidateHints() expected no error for max_parallel_depth=50, got %v", err)
+	}
+}
+
+func TestValidateHints_MaxParallelDepth_ExceedsCap(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Hints.MaxParallelDepth = 51
+
+	err := cfg.ValidateHints()
+	if err == nil {
+		t.Fatal("ValidateHints() expected error for max_parallel_depth=51 exceeding cap")
+	}
+}
+
+func TestValidateHints_MaxParallelDepth_ExceedsMaxDepth(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Hints.MaxDepth = 10
+	cfg.Hints.MaxParallelDepth = 15
+
+	err := cfg.ValidateHints()
+	if err == nil {
+		t.Fatal("ValidateHints() expected error for max_parallel_depth=15 exceeding max_depth=10")
+	}
+}
+
+func TestValidateHints_MaxParallelDepth_ZeroMaxDepth(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Hints.MaxDepth = 0
+	cfg.Hints.MaxParallelDepth = 40
+
+	err := cfg.ValidateHints()
+	if err != nil {
+		t.Fatalf(
+			"ValidateHints() expected no error for max_parallel_depth=40 with unlimited max_depth, got %v",
+			err,
+		)
+	}
+}
+
+func TestValidateHints_MaxParallelDepth_DefaultValid(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := cfg.ValidateHints()
+	if err != nil {
+		t.Fatalf(
+			"ValidateHints() expected no error for default config (max_parallel_depth=20, max_depth=50), got %v",
+			err,
+		)
+	}
+}

--- a/internal/config/validators_hints_test.go
+++ b/internal/config/validators_hints_test.go
@@ -113,7 +113,7 @@ func TestValidateHints_MaxParallelDepth_DefaultValid(t *testing.T) {
 	err := cfg.ValidateHints()
 	if err != nil {
 		t.Fatalf(
-			"ValidateHints() expected no error for default config (max_parallel_depth=20, max_depth=50), got %v",
+			"ValidateHints() expected no error for default config (max_parallel_depth=10, max_depth=50), got %v",
 			err,
 		)
 	}

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -115,6 +115,7 @@ func (c *InfraAXClient) ClickableNodes(
 
 		opts.SetMaxDepth(depth)
 		opts.SetParallelThreshold(cfg.Hints.ParallelThreshold)
+		opts.SetMaxParallelDepth(cfg.Hints.MaxParallelDepth)
 	}
 
 	tree, treeErr := BuildTree(element, opts)

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -43,6 +43,7 @@ func MenuBarClickableElements(
 
 		opts.SetMaxDepth(depth)
 		opts.SetParallelThreshold(cfg.Hints.ParallelThreshold)
+		opts.SetMaxParallelDepth(cfg.Hints.MaxParallelDepth)
 	}
 
 	tree, err := BuildTree(menubar, opts)
@@ -123,6 +124,7 @@ func ClickableElementsFromBundleID(
 
 		opts.SetMaxDepth(depth)
 		opts.SetParallelThreshold(cfg.Hints.ParallelThreshold)
+		opts.SetMaxParallelDepth(cfg.Hints.MaxParallelDepth)
 	}
 
 	tree, err := BuildTree(app, opts)

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -219,6 +219,11 @@ func (o *TreeOptions) SetParallelThreshold(threshold int) {
 	o.parallelThreshold = threshold
 }
 
+// SetMaxParallelDepth sets the max depth for parallel child processing.
+func (o *TreeOptions) SetMaxParallelDepth(depth int) {
+	o.maxParallelDepth = depth
+}
+
 // DefaultTreeOptions returns default tree traversal options.
 func DefaultTreeOptions(logger *zap.Logger) TreeOptions {
 	return TreeOptions{

--- a/internal/core/infra/accessibility/tree_linux.go
+++ b/internal/core/infra/accessibility/tree_linux.go
@@ -55,6 +55,9 @@ func (o *TreeOptions) SetMaxDepth(depth int) {}
 // SetParallelThreshold is a Linux stub.
 func (o *TreeOptions) SetParallelThreshold(threshold int) {}
 
+// SetMaxParallelDepth is a Linux stub.
+func (o *TreeOptions) SetMaxParallelDepth(depth int) {}
+
 // SetBundleID is a Linux stub.
 func (o *TreeOptions) SetBundleID(bundleID string) {}
 

--- a/internal/core/infra/accessibility/tree_windows.go
+++ b/internal/core/infra/accessibility/tree_windows.go
@@ -55,6 +55,9 @@ func (o *TreeOptions) SetMaxDepth(depth int) {}
 // SetParallelThreshold is a Windows stub.
 func (o *TreeOptions) SetParallelThreshold(threshold int) {}
 
+// SetMaxParallelDepth is a Windows stub.
+func (o *TreeOptions) SetMaxParallelDepth(depth int) {}
+
 // SetBundleID is a Windows stub.
 func (o *TreeOptions) SetBundleID(bundleID string) {}
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR exposes the `max_parallel_depth` hardcoded value (previously `4`) to be configurable in config. And also bump it to `10`.

What it does is that it will decides how deep the tree that should be considered to run in parallel, but more overhead cost on the host machine.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
