### PR TITLE
perf(hints): reduce AX roundtrips plus parallel tree workers

### DIFF
--- a/internal/core/domain/element/element.go
+++ b/internal/core/domain/element/element.go
@@ -56,6 +56,7 @@ const (
 	RoleSplitGroup         Role = "AXSplitGroup"
 	RoleUnknown            Role = "AXUnknown"
 	RoleGenericElement     Role = "AXGenericElement"
+	RoleMenuExtra          Role = "AXMenuExtra"
 )
 
 // Element represents a UI element in the accessibility tree.

--- a/internal/core/domain/element/element.go
+++ b/internal/core/domain/element/element.go
@@ -56,7 +56,14 @@ const (
 	RoleSplitGroup         Role = "AXSplitGroup"
 	RoleUnknown            Role = "AXUnknown"
 	RoleGenericElement     Role = "AXGenericElement"
-	RoleMenuExtra          Role = "AXMenuExtra"
+)
+
+// Subrole represents the accessibility subrole of an element.
+type Subrole string
+
+// Common accessibility subroles.
+const (
+	SubroleMenuExtra Subrole = "AXMenuExtra"
 )
 
 // Element represents a UI element in the accessibility tree.

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -33,9 +33,10 @@ func (a *Adapter) addMenubarElements(
 
 	// Create local allowed roles including AXMenuBarItem for additional targets
 	originalRoles := a.client.ClickableRoles()
-	menubarRoles := make([]string, len(originalRoles)+1)
+	menubarRoles := make([]string, len(originalRoles)+2) //nolint:mnd
 	copy(menubarRoles, originalRoles)
 	menubarRoles[len(originalRoles)] = string(element.RoleMenuBarItem)
+	menubarRoles[len(originalRoles)+1] = string(element.RoleMenu)
 
 	// Get menubar elements
 	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements(menubarTreeDepth)

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -112,6 +112,7 @@ type ElementInfo struct {
 	isVisible         bool
 	hasPressAction    bool
 	hasShowMenuAction bool
+	preActionsFetched bool
 	pid               int
 	skipHitTest       bool
 }
@@ -292,6 +293,7 @@ func (e *Element) Info() (*ElementInfo, error) {
 		isVisible:         bool(cInfo.isVisible),
 		hasPressAction:    bool(cInfo.hasPressAction),
 		hasShowMenuAction: bool(cInfo.hasShowMenuAction),
+		preActionsFetched: bool(cInfo.preActionsFetched),
 		pid:               int(cInfo.pid),
 	}
 
@@ -731,7 +733,8 @@ func (e *Element) IsClickable(
 			centerX,
 			centerY,
 			C.bool(info.hasPressAction),
-			C.bool(info.hasShowMenuAction), //nolint:nlreturn
+			C.bool(info.hasShowMenuAction),
+			C.bool(info.preActionsFetched), //nolint:nlreturn
 		)
 
 		return result == 1

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -103,6 +103,7 @@ type ElementInfo struct {
 	identifier        string
 	searchText        string
 	role              string
+	subrole           string
 	roleDescription   string
 	isEnabled         bool
 	hasEnabledAttr    bool
@@ -153,6 +154,11 @@ func (ei *ElementInfo) SearchText() string {
 // Role returns the element role.
 func (ei *ElementInfo) Role() string {
 	return ei.role
+}
+
+// Subrole returns the element subrole.
+func (ei *ElementInfo) Subrole() string {
+	return ei.subrole
 }
 
 // RoleDescription returns the element role description.
@@ -303,6 +309,9 @@ func (e *Element) Info() (*ElementInfo, error) {
 	}
 	if cInfo.role != nil {
 		info.role = C.GoString(cInfo.role)
+	}
+	if cInfo.subrole != nil {
+		info.subrole = C.GoString(cInfo.subrole)
 	}
 	if cInfo.roleDescription != nil {
 		info.roleDescription = C.GoString(cInfo.roleDescription)

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -95,22 +95,24 @@ func ClickableRoles() []string {
 
 // ElementInfo contains metadata and positioning information for a UI element.
 type ElementInfo struct {
-	position        image.Point
-	size            image.Point
-	title           string
-	description     string
-	value           string
-	identifier      string
-	searchText      string
-	role            string
-	roleDescription string
-	isEnabled       bool
-	isFocused       bool
-	isHidden        bool
-	isVisible       bool
-	hasEnabledAttr  bool
-	pid             int
-	skipHitTest     bool
+	position          image.Point
+	size              image.Point
+	title             string
+	description       string
+	value             string
+	identifier        string
+	searchText        string
+	role              string
+	roleDescription   string
+	isEnabled         bool
+	hasEnabledAttr    bool
+	isFocused         bool
+	isHidden          bool
+	isVisible         bool
+	hasPressAction    bool
+	hasShowMenuAction bool
+	pid               int
+	skipHitTest       bool
 }
 
 // Position returns the element position.
@@ -178,6 +180,16 @@ func (ei *ElementInfo) IsHidden() bool {
 // When the AXVisible attribute is not supported, returns true (default).
 func (ei *ElementInfo) IsVisible() bool {
 	return ei.isVisible
+}
+
+// HasPressAction returns whether the element has AXPress action.
+func (ei *ElementInfo) HasPressAction() bool {
+	return ei.hasPressAction
+}
+
+// HasShowMenuAction returns whether the element has AXShowMenu action.
+func (ei *ElementInfo) HasShowMenuAction() bool {
+	return ei.hasShowMenuAction
 }
 
 // PID returns the process ID.
@@ -267,12 +279,14 @@ func (e *Element) Info() (*ElementInfo, error) {
 			X: int(cInfo.size.width),
 			Y: int(cInfo.size.height),
 		},
-		isEnabled:      bool(cInfo.isEnabled),
-		hasEnabledAttr: bool(cInfo.hasEnabledAttribute),
-		isFocused:      bool(cInfo.isFocused),
-		isHidden:       bool(cInfo.isHidden),
-		isVisible:      bool(cInfo.isVisible),
-		pid:            int(cInfo.pid),
+		isEnabled:         bool(cInfo.isEnabled),
+		hasEnabledAttr:    bool(cInfo.hasEnabledAttribute),
+		isFocused:         bool(cInfo.isFocused),
+		isHidden:          bool(cInfo.isHidden),
+		isVisible:         bool(cInfo.isVisible),
+		hasPressAction:    bool(cInfo.hasPressAction),
+		hasShowMenuAction: bool(cInfo.hasShowMenuAction),
+		pid:               int(cInfo.pid),
 	}
 
 	if cInfo.title != nil {
@@ -706,7 +720,9 @@ func (e *Element) IsClickable(
 			cRole,
 			C.bool(isWidget),
 			centerX,
-			centerY, //nolint:nlreturn
+			centerY,
+			C.bool(info.hasPressAction),
+			C.bool(info.hasShowMenuAction), //nolint:nlreturn
 		)
 
 		return result == 1

--- a/internal/core/infra/accessibility/element_linux.go
+++ b/internal/core/infra/accessibility/element_linux.go
@@ -43,6 +43,7 @@ type ElementInfo struct {
 	value           string
 	searchText      string
 	role            string
+	subrole         string
 	roleDescription string
 	isEnabled       bool
 	isFocused       bool
@@ -69,6 +70,9 @@ func (ei *ElementInfo) SearchText() string { return ei.searchText }
 
 // Role returns the element role.
 func (ei *ElementInfo) Role() string { return ei.role }
+
+// Subrole returns the element subrole.
+func (ei *ElementInfo) Subrole() string { return ei.subrole }
 
 // RoleDescription returns the element role description.
 func (ei *ElementInfo) RoleDescription() string { return ei.roleDescription }

--- a/internal/core/infra/accessibility/element_windows.go
+++ b/internal/core/infra/accessibility/element_windows.go
@@ -62,6 +62,7 @@ type ElementInfo struct {
 	value           string
 	searchText      string
 	role            string
+	subrole         string
 	roleDescription string
 	isEnabled       bool
 	isFocused       bool
@@ -88,6 +89,9 @@ func (ei *ElementInfo) SearchText() string { return ei.searchText }
 
 // Role returns the element role.
 func (ei *ElementInfo) Role() string { return ei.role }
+
+// Subrole returns the element subrole.
+func (ei *ElementInfo) Subrole() string { return ei.subrole }
 
 // RoleDescription returns the element role description.
 func (ei *ElementInfo) RoleDescription() string { return ei.roleDescription }

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -1,6 +1,8 @@
 package accessibility
 
 import (
+	"slices"
+
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
@@ -116,6 +118,10 @@ func ClickableElementsFromBundleID(
 	opts := DefaultTreeOptions(logger)
 	opts.SetConfigProvider(configProvider)
 
+	if slices.Contains(roles, string(element.RoleMenuBarItem)) {
+		opts.SetFilterFunc(isAdditionalMenuBarElement)
+	}
+
 	if cfg := currentConfig(configProvider); cfg != nil {
 		depth := cfg.Hints.MaxDepth
 		if maxDepth > 0 {
@@ -170,6 +176,18 @@ func ClickableElementsFromBundleID(
 		zap.Int("count", len(elements)))
 
 	return elements, nil
+}
+
+func isAdditionalMenuBarElement(info *ElementInfo) bool {
+	//nolint:exhaustive
+	switch element.Role(info.Role()) {
+	case element.RoleMenuBar, element.RoleMenu, element.RoleMenuItem:
+		return true
+	case element.RoleMenuBarItem:
+		return info.Subrole() == "AXMenuExtra"
+	default:
+		return false
+	}
 }
 
 // releaseTreeExcept releases all AXUIElementRefs in the tree except those

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -184,7 +184,7 @@ func isAdditionalMenuBarElement(info *ElementInfo) bool {
 	case element.RoleMenuBar, element.RoleMenu, element.RoleMenuItem:
 		return true
 	case element.RoleMenuBarItem:
-		return info.Subrole() == "AXMenuExtra"
+		return info.Subrole() == string(element.RoleMenuExtra)
 	default:
 		return false
 	}

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -184,7 +184,7 @@ func isAdditionalMenuBarElement(info *ElementInfo) bool {
 	case element.RoleMenuBar, element.RoleMenu, element.RoleMenuItem:
 		return true
 	case element.RoleMenuBarItem:
-		return info.Subrole() == string(element.RoleMenuExtra)
+		return info.Subrole() == string(element.SubroleMenuExtra)
 	default:
 		return false
 	}

--- a/internal/core/infra/accessibility/query_test.go
+++ b/internal/core/infra/accessibility/query_test.go
@@ -1,0 +1,47 @@
+//nolint:testpackage
+package accessibility
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+)
+
+func TestIsAdditionalMenuBarElement(t *testing.T) {
+	tests := []struct {
+		name string
+		info *ElementInfo
+		want bool
+	}{
+		{
+			name: "allows menu bar container",
+			info: &ElementInfo{
+				role: string(element.RoleMenuBar),
+			},
+			want: true,
+		},
+		{
+			name: "allows menu extras",
+			info: &ElementInfo{
+				role:    string(element.RoleMenuBarItem),
+				subrole: "AXMenuExtra",
+			},
+			want: true,
+		},
+		{
+			name: "rejects normal app menu bar items",
+			info: &ElementInfo{
+				role: string(element.RoleMenuBarItem),
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAdditionalMenuBarElement(tt.info); got != tt.want {
+				t.Fatalf("isAdditionalMenuBarElement() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/core/infra/accessibility/query_test.go
+++ b/internal/core/infra/accessibility/query_test.go
@@ -35,6 +35,20 @@ func TestIsAdditionalMenuBarElement(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "allows menu container",
+			info: &ElementInfo{
+				role: string(element.RoleMenu),
+			},
+			want: true,
+		},
+		{
+			name: "allows menu items",
+			info: &ElementInfo{
+				role: string(element.RoleMenuItem),
+			},
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/core/infra/accessibility/query_test.go
+++ b/internal/core/infra/accessibility/query_test.go
@@ -24,7 +24,7 @@ func TestIsAdditionalMenuBarElement(t *testing.T) {
 			name: "allows menu extras",
 			info: &ElementInfo{
 				role:    string(element.RoleMenuBarItem),
-				subrole: string(element.RoleMenuExtra),
+				subrole: string(element.SubroleMenuExtra),
 			},
 			want: true,
 		},

--- a/internal/core/infra/accessibility/query_test.go
+++ b/internal/core/infra/accessibility/query_test.go
@@ -24,7 +24,7 @@ func TestIsAdditionalMenuBarElement(t *testing.T) {
 			name: "allows menu extras",
 			info: &ElementInfo{
 				role:    string(element.RoleMenuBarItem),
-				subrole: "AXMenuExtra",
+				subrole: string(element.RoleMenuExtra),
 			},
 			want: true,
 		},

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -12,6 +12,7 @@ import "C"
 
 import (
 	"image"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -90,6 +91,11 @@ func getTreeNode(elem *Element, info *ElementInfo, parent *TreeNode, childrenCap
 // this threshold have their backing array discarded to avoid holding
 // disproportionately large allocations in the pool indefinitely.
 const maxPooledChildrenCap = 64
+
+// maxConcurrentTreeWorkers caps the number of goroutines used for parallel
+// tree building. This prevents goroutine explosion when a node has hundreds
+// of children and limits concurrent AX calls competing for the same XPC channel.
+const maxConcurrentTreeWorkers = 8
 
 // putTreeNode clears all references in the node and returns it to the pool.
 func putTreeNode(node *TreeNode) {
@@ -367,6 +373,17 @@ var importantContainerRoles = map[element.Role]bool{
 	element.RoleList:    true,
 }
 
+// Roles that commonly spawn important container children (popovers, sheets, menus).
+// Only for these parent roles do we fetch children to check for important containers
+// when the parent is itself an interactive leaf. This avoids wasting Info() calls
+// on children of leaf roles that never contain important containers.
+var leafRolesWithImportantChildren = map[element.Role]bool{
+	element.RoleButton:      true,
+	element.RoleMenuButton:  true,
+	element.RolePopUpButton: true,
+	element.RoleLink:        true,
+}
+
 func buildTreeRecursive(
 	parent *TreeNode,
 	depth int,
@@ -410,6 +427,14 @@ func buildTreeRecursive(
 	// This handles cases like a toolbar button that opens a popover.
 	var children []*Element
 	if interactiveLeafRoles[element.Role(parent.info.Role())] {
+		if !leafRolesWithImportantChildren[element.Role(parent.info.Role())] {
+			if opts.stats != nil {
+				opts.stats.stoppedAtLeaf.Add(1)
+			}
+
+			return
+		}
+
 		var childrenErr error
 		children, childrenErr = parent.element.Children(parent.info.Role())
 		hasImportantContainer := false
@@ -562,95 +587,89 @@ func buildChildrenParallel(
 	clipBounds image.Rectangle,
 	windowBounds image.Rectangle,
 ) {
-	// Pre-allocate result slice with exact capacity
+	// Use a bounded worker pool to avoid goroutine explosion and limit
+	// concurrent AX calls competing for the same XPC channel.
+	numWorkers := min(
+		runtime.GOMAXPROCS(0),
+		maxConcurrentTreeWorkers,
+	)
+
+	type childTask struct {
+		elem   *Element
+		index  int
+		bounds image.Rectangle
+		winBnd image.Rectangle
+	}
+
 	type childResult struct {
 		node  *TreeNode
 		index int
-		err   error
 	}
 
-	// Use buffered channel sized to number of children
+	tasks := make(chan childTask, len(children))
 	results := make(chan childResult, len(children))
+
+	// Launch fixed number of workers
 	var waitGroup sync.WaitGroup
+	for range numWorkers {
+		waitGroup.Go(func() {
+			for task := range tasks {
+				info, err := task.elem.Info()
+				if err != nil {
+					if opts.stats != nil {
+						opts.stats.childErrors.Add(1)
+					}
+					task.elem.Release()
 
-	// Process children in parallel
-	for index, child := range children {
-		waitGroup.Add(1)
-		go func(idx int, elem *Element, bounds, winBounds image.Rectangle) {
-			defer waitGroup.Done()
-
-			info, err := elem.Info()
-			if err != nil {
-				if opts.stats != nil {
-					opts.stats.childErrors.Add(1)
+					continue
 				}
 
-				elem.Release()
+				if !shouldIncludeElement(info, opts, task.bounds) {
+					if opts.stats != nil {
+						opts.stats.filteredOut.Add(1)
+					}
+					task.elem.Release()
 
-				results <- childResult{node: nil, index: idx, err: err}
-
-				return
-			}
-
-			if !shouldIncludeElement(info, opts, bounds) {
-				if opts.stats != nil {
-					opts.stats.filteredOut.Add(1)
+					continue
 				}
 
-				elem.Release()
+				info.skipHitTest = task.bounds == task.winBnd
 
-				results <- childResult{node: nil, index: idx}
+				childNode := getTreeNode(task.elem, info, parent, 0)
 
-				return
-			}
-
-			// Skip hit-test for elements within the original window bounds
-			// (not in a scroll area). Must be set before getTreeNode to avoid
-			// relying on pointer aliasing.
-			info.skipHitTest = bounds == winBounds
-
-			childNode := getTreeNode(elem, info, parent, 0)
-
-			newClipBounds := bounds
-			if element.Role(info.Role()) == element.RoleScrollArea {
-				childRect := rectFromInfo(info)
-				if childRect.Dx() > 0 && childRect.Dy() > 0 {
-					newClipBounds = childRect.Intersect(bounds)
-					if ce := opts.Logger().
-						Check(zap.DebugLevel, "Parallel scroll area detected, tightening clip bounds"); ce != nil {
-						ce.Write(
-							zap.String("role", info.Role()),
-							zap.Int("clip_x", newClipBounds.Min.X),
-							zap.Int("clip_y", newClipBounds.Min.Y),
-							zap.Int("clip_w", newClipBounds.Dx()),
-							zap.Int("clip_h", newClipBounds.Dy()),
-						)
+				newClipBounds := task.bounds
+				if element.Role(info.Role()) == element.RoleScrollArea {
+					childRect := rectFromInfo(info)
+					if childRect.Dx() > 0 && childRect.Dy() > 0 {
+						newClipBounds = childRect.Intersect(task.bounds)
 					}
 				}
+
+				buildTreeRecursive(childNode, depth+1, opts, newClipBounds, task.winBnd)
+				results <- childResult{node: childNode, index: task.index}
 			}
-
-			// Recursively build (this may spawn more goroutines at deeper levels)
-			buildTreeRecursive(childNode, depth+1, opts, newClipBounds, winBounds)
-
-			results <- childResult{node: childNode, index: idx}
-		}(index, child, clipBounds, windowBounds)
+		})
 	}
 
-	// Close results channel when all goroutines complete
+	// Feed tasks to workers
+	for index, child := range children {
+		tasks <- childTask{elem: child, index: index, bounds: clipBounds, winBnd: windowBounds}
+	}
+	close(tasks)
+
+	// Wait for workers to finish, then close results
 	go func() {
 		waitGroup.Wait()
 		close(results)
 	}()
 
-	// Pre-allocate collection slice with exact capacity
+	// Collect results preserving original order
 	collected := make([]*TreeNode, len(children))
 	validCount := 0
 
 	for result := range results {
-		if result.node != nil {
-			collected[result.index] = result.node
-			validCount++
-		}
+		collected[result.index] = result.node
+		validCount++
 	}
 
 	// Reuse the pooled backing array when it has enough room.

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -378,10 +378,13 @@ var importantContainerRoles = map[element.Role]bool{
 // when the parent is itself an interactive leaf. This avoids wasting Info() calls
 // on children of leaf roles that never contain important containers.
 var leafRolesWithImportantChildren = map[element.Role]bool{
-	element.RoleButton:      true,
-	element.RoleMenuButton:  true,
-	element.RolePopUpButton: true,
-	element.RoleLink:        true,
+	element.RoleButton:             true,
+	element.RoleMenuButton:         true,
+	element.RolePopUpButton:        true,
+	element.RoleLink:               true,
+	element.RoleComboBox:           true, // dropdown AXMenu
+	element.RoleDisclosureTriangle: true, // reveals children when expanded
+	element.RoleGenericElement:     true, // catch-all — could contain anything
 }
 
 func buildTreeRecursive(

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -645,6 +645,16 @@ func buildChildrenParallel(
 					childRect := rectFromInfo(info)
 					if childRect.Dx() > 0 && childRect.Dy() > 0 {
 						newClipBounds = childRect.Intersect(task.bounds)
+						if ce := opts.Logger().
+							Check(zap.DebugLevel, "Scroll area detected, tightening clip bounds"); ce != nil {
+							ce.Write(
+								zap.String("role", info.Role()),
+								zap.Int("clip_x", newClipBounds.Min.X),
+								zap.Int("clip_y", newClipBounds.Min.Y),
+								zap.Int("clip_w", newClipBounds.Dx()),
+								zap.Int("clip_h", newClipBounds.Dy()),
+							)
+						}
 					}
 				}
 

--- a/internal/core/infra/accessibility/tree_linux.go
+++ b/internal/core/infra/accessibility/tree_linux.go
@@ -64,6 +64,9 @@ func (o *TreeOptions) SetBundleID(bundleID string) {}
 // SetConfigProvider is a Linux stub.
 func (o *TreeOptions) SetConfigProvider(cp config.Provider) {}
 
+// SetFilterFunc is a Linux stub.
+func (o *TreeOptions) SetFilterFunc(fn func(*ElementInfo) bool) {}
+
 // BuildTree builds the accessibility tree for the specified root element (Linux stub).
 func BuildTree(_ *Element, _ TreeOptions) (*TreeNode, error) {
 	return &TreeNode{}, nil

--- a/internal/core/infra/accessibility/tree_windows.go
+++ b/internal/core/infra/accessibility/tree_windows.go
@@ -64,6 +64,9 @@ func (o *TreeOptions) SetBundleID(bundleID string) {}
 // SetConfigProvider is a Windows stub.
 func (o *TreeOptions) SetConfigProvider(cp config.Provider) {}
 
+// SetFilterFunc is a Windows stub.
+func (o *TreeOptions) SetFilterFunc(fn func(*ElementInfo) bool) {}
+
 // BuildTree builds the accessibility tree for the specified root element (Windows stub).
 func BuildTree(_ *Element, _ TreeOptions) (*TreeNode, error) {
 	return &TreeNode{}, nil

--- a/internal/core/infra/platform/darwin/accessibility.go
+++ b/internal/core/infra/platform/darwin/accessibility.go
@@ -109,6 +109,7 @@ func HasClickAction(element unsafe.Pointer) bool {
 		0,     // centerX
 		0,     // centerY
 		false, // preHasPressAction
+		false, // preHasShowMenuAction
 		false, //nolint:nlreturn
 	) != 0
 

--- a/internal/core/infra/platform/darwin/accessibility.go
+++ b/internal/core/infra/platform/darwin/accessibility.go
@@ -99,15 +99,17 @@ func HasClickAction(element unsafe.Pointer) bool {
 
 	clickable := C.hasClickAction(
 		element,
-		true, // skipVisCheck: no pre-computed center available in this simplified wrapper
-		false,
-		true,
-		true,
-		true,
-		nil,
-		false,
-		0,
-		0, //nolint:nlreturn
+		true,  // skipVisCheck: no pre-computed center available in this simplified wrapper
+		false, // preHidden
+		true,  // preVisible
+		true,  // preEnabled
+		true,  // hasEnabledAttr
+		nil,   // preRole
+		false, // preIsWidget
+		0,     // centerX
+		0,     // centerY
+		false, // preHasPressAction
+		false, //nolint:nlreturn
 	) != 0
 
 	return clickable

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -22,6 +22,7 @@ typedef struct {
 	char *value;               ///< Element value
 	char *identifier;          ///< Element identifier (for widget detection)
 	char *role;                ///< Element role
+	char *subrole;             ///< Element subrole
 	char *roleDescription;     ///< Element role description
 	bool isEnabled;            ///< Whether element is enabled
 	bool hasEnabledAttribute;  ///< Whether element supports AXEnabled attribute

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -29,6 +29,8 @@ typedef struct {
 	int pid;                   ///< Process identifier
 	bool isHidden;             ///< Whether element is AX-hidden (CSS visibility:hidden etc.)
 	bool isVisible;            ///< Whether element is AX-visible (default true when unsupported)
+	bool hasPressAction;       ///< Whether element has AXPress action (pre-fetched)
+	bool hasShowMenuAction;    ///< Whether element has AXShowMenu action (pre-fetched)
 } ElementInfo;
 
 #pragma mark - Permission Functions
@@ -128,10 +130,13 @@ void postMouseMoveEvent(CGPoint position, CGEventType eventType);
 /// @param preIsWidget Pre-computed widget flag (from ElementInfo identifier)
 /// @param centerX Pre-computed center X (from ElementInfo position + size)
 /// @param centerY Pre-computed center Y (from ElementInfo position + size)
+/// @param preHasPressAction Pre-fetched AXPress action flag (from ElementInfo)
+/// @param preHasShowMenuAction Pre-fetched AXShowMenu action flag (from ElementInfo)
 /// @return 1 if element is clickable, 0 otherwise
 int hasClickAction(
     void *element, bool skipVisCheck, bool preHidden, bool preVisible, bool preEnabled, bool hasEnabledAttr,
-    const char *preRole, bool preIsWidget, double centerX, double centerY);
+    const char *preRole, bool preIsWidget, double centerX, double centerY, bool preHasPressAction,
+    bool preHasShowMenuAction);
 
 /// Fast visibility check using a pre-computed center point (avoids redundant AX position fetch)
 /// @param element Element reference

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -32,6 +32,7 @@ typedef struct {
 	bool isVisible;            ///< Whether element is AX-visible (default true when unsupported)
 	bool hasPressAction;       ///< Whether element has AXPress action (pre-fetched)
 	bool hasShowMenuAction;    ///< Whether element has AXShowMenu action (pre-fetched)
+	bool preActionsFetched;    ///< Whether actions were successfully pre-fetched
 } ElementInfo;
 
 #pragma mark - Permission Functions
@@ -85,11 +86,6 @@ void freeElementInfo(ElementInfo *info);
 /// @return Element reference
 void *getElementAtPosition(CGPoint position);
 
-/// Get number of child elements
-/// @param element Element reference
-/// @return Number of children
-int getChildrenCount(void *element);
-
 /// Get child elements
 /// @param element Element reference
 /// @param count Output parameter for number of children
@@ -133,11 +129,12 @@ void postMouseMoveEvent(CGPoint position, CGEventType eventType);
 /// @param centerY Pre-computed center Y (from ElementInfo position + size)
 /// @param preHasPressAction Pre-fetched AXPress action flag (from ElementInfo)
 /// @param preHasShowMenuAction Pre-fetched AXShowMenu action flag (from ElementInfo)
+/// @param preActionsFetched Whether action names were successfully pre-fetched
 /// @return 1 if element is clickable, 0 otherwise
 int hasClickAction(
     void *element, bool skipVisCheck, bool preHidden, bool preVisible, bool preEnabled, bool hasEnabledAttr,
     const char *preRole, bool preIsWidget, double centerX, double centerY, bool preHasPressAction,
-    bool preHasShowMenuAction);
+    bool preHasShowMenuAction, bool preActionsFetched);
 
 /// Fast visibility check using a pre-computed center point (avoids redundant AX position fetch)
 /// @param element Element reference

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -126,13 +126,14 @@ ElementInfo *getElementInfo(void *element) {
 		        kAXValueAttribute,
 		        kAXIdentifierAttribute,
 		        kAXRoleAttribute,
+		        kAXSubroleAttribute,
 		        kAXRoleDescriptionAttribute,
 		        kAXEnabledAttribute,
 		        kAXFocusedAttribute,
 		        kAXHiddenAttribute,
 		        kVisibleAttr,
 		    },
-		    12, &kCFTypeArrayCallBacks);
+		    13, &kCFTypeArrayCallBacks);
 
 		if (!attributes) {
 			free(info);
@@ -151,7 +152,7 @@ ElementInfo *getElementInfo(void *element) {
 			return info;
 		}
 
-		// With option=0, values always has exactly 12 entries (one per requested attribute).
+		// With option=0, values always has exactly 13 entries (one per requested attribute).
 		// Slots for unsupported/errored attributes hold an AX error placeholder (CFNumber),
 		// which the CFGetTypeID checks below will correctly reject.
 		CFTypeRef positionValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 0);
@@ -195,28 +196,33 @@ ElementInfo *getElementInfo(void *element) {
 			info->role = cfStringToCString((CFStringRef)roleValue);
 		}
 
-		CFTypeRef roleDescValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 7);
+		CFTypeRef subroleValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 7);
+		if (subroleValue && CFGetTypeID(subroleValue) == CFStringGetTypeID()) {
+			info->subrole = cfStringToCString((CFStringRef)subroleValue);
+		}
+
+		CFTypeRef roleDescValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 8);
 		if (roleDescValue && CFGetTypeID(roleDescValue) == CFStringGetTypeID()) {
 			info->roleDescription = cfStringToCString((CFStringRef)roleDescValue);
 		}
 
-		CFTypeRef enabledValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 8);
+		CFTypeRef enabledValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 9);
 		if (enabledValue && CFGetTypeID(enabledValue) == CFBooleanGetTypeID()) {
 			info->isEnabled = CFBooleanGetValue((CFBooleanRef)enabledValue);
 			info->hasEnabledAttribute = true;
 		}
 
-		CFTypeRef focusedValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 9);
+		CFTypeRef focusedValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 10);
 		if (focusedValue && CFGetTypeID(focusedValue) == CFBooleanGetTypeID()) {
 			info->isFocused = CFBooleanGetValue((CFBooleanRef)focusedValue);
 		}
 
-		CFTypeRef hiddenValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 10);
+		CFTypeRef hiddenValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 11);
 		if (hiddenValue && CFGetTypeID(hiddenValue) == CFBooleanGetTypeID()) {
 			info->isHidden = CFBooleanGetValue((CFBooleanRef)hiddenValue);
 		}
 
-		CFTypeRef visibleValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 11);
+		CFTypeRef visibleValue = (CFTypeRef)CFArrayGetValueAtIndex(values, 12);
 		if (visibleValue && CFGetTypeID(visibleValue) == CFBooleanGetTypeID()) {
 			info->isVisible = CFBooleanGetValue((CFBooleanRef)visibleValue);
 		}
@@ -271,6 +277,8 @@ void freeElementInfo(ElementInfo *info) {
 		free(info->identifier);
 	if (info->role)
 		free(info->role);
+	if (info->subrole)
+		free(info->subrole);
 	if (info->roleDescription)
 		free(info->roleDescription);
 

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -390,7 +390,6 @@ int getElementCenter(void *element, CGPoint *outPoint) {
 
 #pragma mark - Child Element Functions
 
-
 /// Get child elements
 /// @param element Element reference
 /// @param count Output parameter for number of children

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -223,6 +223,29 @@ ElementInfo *getElementInfo(void *element) {
 
 		CFRelease(values);
 
+		// Pre-fetch action names to eliminate a separate AX call during clickability checks.
+		// This is done after the batched attribute fetch since action names are only needed
+		// for interactive elements, but the cost is negligible for non-interactive ones.
+		CFArrayRef actionNames = NULL;
+		if (AXUIElementCopyActionNames(axElement, &actionNames) == kAXErrorSuccess && actionNames) {
+			CFIndex actionCount = CFArrayGetCount(actionNames);
+			for (CFIndex i = 0; i < actionCount; i++) {
+				CFStringRef action = (CFStringRef)CFArrayGetValueAtIndex(actionNames, i);
+				if (!action)
+					continue;
+				if (CFStringCompare(action, kAXPressAction, 0) == kCFCompareEqualTo ||
+				    CFStringCompare(action, CFSTR("AXConfirm"), 0) == kCFCompareEqualTo ||
+				    CFStringCompare(action, CFSTR("AXPick"), 0) == kCFCompareEqualTo ||
+				    CFStringCompare(action, CFSTR("AXRaise"), 0) == kCFCompareEqualTo) {
+					info->hasPressAction = true;
+				}
+				if (CFStringCompare(action, CFSTR("AXShowMenu"), 0) == kCFCompareEqualTo) {
+					info->hasShowMenuAction = true;
+				}
+			}
+			CFRelease(actionNames);
+		}
+
 		pid_t pid;
 		if (AXUIElementGetPid(axElement, &pid) == kAXErrorSuccess) {
 			info->pid = pid;
@@ -366,21 +389,21 @@ int getChildrenCount(void *element) {
 		return 0;
 
 	AXUIElementRef axElement = (AXUIElementRef)element;
+	CFIndex childCount = 0;
+
+	if (AXUIElementGetAttributeValueCount(axElement, kAXChildrenAttribute, &childCount) == kAXErrorSuccess) {
+		return (int)childCount;
+	}
+
+	// Fallback: use direct copy if count query is unsupported.
 	CFTypeRef childrenValue = NULL;
-
-	if (AXUIElementCopyAttributeValue(axElement, kAXChildrenAttribute, &childrenValue) != kAXErrorSuccess) {
-		return 0;
-	}
-
-	if (CFGetTypeID(childrenValue) != CFArrayGetTypeID()) {
+	if (AXUIElementCopyAttributeValue(axElement, kAXChildrenAttribute, &childrenValue) == kAXErrorSuccess &&
+	    childrenValue && CFGetTypeID(childrenValue) == CFArrayGetTypeID()) {
+		childCount = CFArrayGetCount((CFArrayRef)childrenValue);
 		CFRelease(childrenValue);
-		return 0;
 	}
 
-	CFIndex count = CFArrayGetCount((CFArrayRef)childrenValue);
-	CFRelease(childrenValue);
-
-	return (int)count;
+	return (int)childCount;
 }
 
 /// Get child elements
@@ -392,37 +415,65 @@ void **getChildren(void *element, int *count) {
 		return NULL;
 
 	AXUIElementRef axElement = (AXUIElementRef)element;
-	CFTypeRef childrenValue = NULL;
 
-	if (AXUIElementCopyAttributeValue(axElement, kAXChildrenAttribute, &childrenValue) != kAXErrorSuccess) {
+	// Prefer AXUIElementGetAttributeValueCount + AXUIElementCopyAttributeValues
+	// for better handling of large child arrays, but fall back to
+	// AXUIElementCopyAttributeValue if the count query is unsupported.
+	CFArrayRef children = NULL;
+	CFIndex childCount = 0;
+	if (AXUIElementGetAttributeValueCount(axElement, kAXChildrenAttribute, &childCount) == kAXErrorSuccess &&
+	    childCount > 0) {
+		AXUIElementCopyAttributeValues(axElement, kAXChildrenAttribute, 0, childCount, &children);
+	}
+
+	// Fallback: if ranged fetch failed or returned nothing, try the direct copy.
+	if (!children) {
+		CFTypeRef childrenValue = NULL;
+		if (AXUIElementCopyAttributeValue(axElement, kAXChildrenAttribute, &childrenValue) != kAXErrorSuccess) {
+			*count = 0;
+			return NULL;
+		}
+
+		if (CFGetTypeID(childrenValue) != CFArrayGetTypeID()) {
+			CFRelease(childrenValue);
+			*count = 0;
+			return NULL;
+		}
+
+		children = (CFArrayRef)childrenValue;
+	}
+
+	if (CFGetTypeID(children) != CFArrayGetTypeID()) {
+		CFRelease(children);
 		*count = 0;
 		return NULL;
 	}
 
-	if (CFGetTypeID(childrenValue) != CFArrayGetTypeID()) {
-		CFRelease(childrenValue);
+	// Always use the actual array count — the pre-fetched count may be stale
+	// if the target app's AX tree changed between the two calls.
+	CFIndex actualCount = CFArrayGetCount(children);
+	if (actualCount == 0) {
+		CFRelease(children);
 		*count = 0;
 		return NULL;
 	}
 
-	CFArrayRef children = (CFArrayRef)childrenValue;
-	CFIndex childCount = CFArrayGetCount(children);
-	*count = (int)childCount;
+	*count = (int)actualCount;
 
-	void **result = (void **)malloc(childCount * sizeof(void *));
+	void **result = (void **)malloc(actualCount * sizeof(void *));
 	if (!result) {
-		CFRelease(childrenValue);
+		CFRelease(children);
 		*count = 0;
 		return NULL;
 	}
 
-	for (CFIndex i = 0; i < childCount; i++) {
+	for (CFIndex i = 0; i < actualCount; i++) {
 		AXUIElementRef child = (AXUIElementRef)CFArrayGetValueAtIndex(children, i);
 		CFRetain(child);
 		result[i] = (void *)child;
 	}
 
-	CFRelease(childrenValue);
+	CFRelease(children);
 	return result;
 }
 
@@ -435,26 +486,55 @@ void **getVisibleRows(void *element, int *count) {
 		return NULL;
 
 	AXUIElementRef axElement = (AXUIElementRef)element;
-	CFTypeRef rowsValue = NULL;
 
-	if (AXUIElementCopyAttributeValue(axElement, kAXVisibleRowsAttribute, &rowsValue) != kAXErrorSuccess) {
+	CFIndex rowCount = 0;
+	bool useRanged =
+	    (AXUIElementGetAttributeValueCount(axElement, kAXVisibleRowsAttribute, &rowCount) == kAXErrorSuccess &&
+	     rowCount > 0);
+
+	CFArrayRef rows = NULL;
+	if (useRanged) {
+		AXUIElementCopyAttributeValues(axElement, kAXVisibleRowsAttribute, 0, rowCount, &rows);
+	}
+
+	// Fallback: if ranged fetch failed, try the direct copy.
+	if (!rows) {
+		CFTypeRef rowsValue = NULL;
+		if (AXUIElementCopyAttributeValue(axElement, kAXVisibleRowsAttribute, &rowsValue) != kAXErrorSuccess) {
+			*count = 0;
+			return NULL;
+		}
+
+		if (CFGetTypeID(rowsValue) != CFArrayGetTypeID()) {
+			CFRelease(rowsValue);
+			*count = 0;
+			return NULL;
+		}
+
+		rows = (CFArrayRef)rowsValue;
+		rowCount = CFArrayGetCount(rows);
+		if (rowCount == 0) {
+			CFRelease(rows);
+			*count = 0;
+			return NULL;
+		}
+	}
+
+	if (CFGetTypeID(rows) != CFArrayGetTypeID()) {
+		CFRelease(rows);
 		*count = 0;
 		return NULL;
 	}
 
-	if (CFGetTypeID(rowsValue) != CFArrayGetTypeID()) {
-		CFRelease(rowsValue);
-		*count = 0;
-		return NULL;
+	if (rowCount == 0) {
+		rowCount = CFArrayGetCount(rows);
 	}
 
-	CFArrayRef rows = (CFArrayRef)rowsValue;
-	CFIndex rowCount = CFArrayGetCount(rows);
 	*count = (int)rowCount;
 
 	void **result = (void **)malloc(rowCount * sizeof(void *));
 	if (!result) {
-		CFRelease(rowsValue);
+		CFRelease(rows);
 		*count = 0;
 		return NULL;
 	}
@@ -465,7 +545,7 @@ void **getVisibleRows(void *element, int *count) {
 		result[i] = (void *)row;
 	}
 
-	CFRelease(rowsValue);
+	CFRelease(rows);
 	return result;
 }
 
@@ -485,7 +565,10 @@ static bool elementOrAncestorMatches(AXUIElementRef element, AXUIElementRef targ
 	AXUIElementRef current = element;
 	CFRetain(current);
 
-	for (int depth = 0; current && depth < 64; depth++) {
+	// Limit parent chain walk to 16 levels. Most UI hierarchies are shallow
+	// enough that the target (or a descendant) is found well before this.
+	// 64 was excessive and caused unnecessary AX calls for obscured elements.
+	for (int depth = 0; current && depth < 16; depth++) {
 		if (CFEqual(current, target)) {
 			CFRelease(current);
 			return true;
@@ -590,7 +673,8 @@ static bool getElementFrame(AXUIElementRef element, CGRect *outFrame) {
 /// @return 1 if element is clickable, 0 otherwise
 int hasClickAction(
     void *element, bool skipVisCheck, bool preHidden, bool preVisible, bool preEnabled, bool hasEnabledAttr,
-    const char *preRole, bool preIsWidget, double centerX, double centerY) {
+    const char *preRole, bool preIsWidget, double centerX, double centerY, bool preHasPressAction,
+    bool preHasShowMenuAction) {
 	if (!element)
 		return 0;
 
@@ -604,7 +688,21 @@ int hasClickAction(
 
 #define visHit (!skipVisCheck ? isElementVisibleAtPoint((void *)axElement, visCenter) : 1)
 
+	// Use pre-fetched action flags from ElementInfo (eliminates AXUIElementCopyActionNames call).
 	// Explicit actions are the strongest signal, so we check for them first
+	if (preHasPressAction || preHasShowMenuAction) {
+		if (hasEnabledAttr && !preEnabled)
+			return 0;
+
+		if (!visHit)
+			return 0;
+
+		return 1;
+	}
+
+	// Fall back to fetching action names when pre-fetch was unavailable or
+	// did not match AXPress/AXShowMenu. Check all known click actions here
+	// so that a transient pre-fetch failure does not cause false negatives.
 	CFArrayRef actions = NULL;
 	if (AXUIElementCopyActionNames(axElement, &actions) == kAXErrorSuccess && actions) {
 		CFIndex count = CFArrayGetCount(actions);

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -107,7 +107,7 @@ static bool shouldPrefetchActions(const char *role) {
 	       strcmp(role, "AXMenuItem") == 0 || strcmp(role, "AXMenuButton") == 0 || strcmp(role, "AXPopUpButton") == 0 ||
 	       strcmp(role, "AXTabButton") == 0 || strcmp(role, "AXComboBox") == 0 || strcmp(role, "AXSlider") == 0 ||
 	       strcmp(role, "AXSwitch") == 0 || strcmp(role, "AXDisclosureTriangle") == 0 ||
-	       strcmp(role, "AXGenericElement") == 0 || strcmp(role, "AXCell") == 0 || strcmp(role, "AXMenuExtra") == 0;
+	       strcmp(role, "AXGenericElement") == 0 || strcmp(role, "AXCell") == 0 || strcmp(role, "AXMenuBarItem") == 0;
 }
 
 /// Get element information using batched attribute queries

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -415,65 +415,37 @@ void **getChildren(void *element, int *count) {
 		return NULL;
 
 	AXUIElementRef axElement = (AXUIElementRef)element;
+	CFTypeRef childrenValue = NULL;
 
-	// Prefer AXUIElementGetAttributeValueCount + AXUIElementCopyAttributeValues
-	// for better handling of large child arrays, but fall back to
-	// AXUIElementCopyAttributeValue if the count query is unsupported.
-	CFArrayRef children = NULL;
-	CFIndex childCount = 0;
-	if (AXUIElementGetAttributeValueCount(axElement, kAXChildrenAttribute, &childCount) == kAXErrorSuccess &&
-	    childCount > 0) {
-		AXUIElementCopyAttributeValues(axElement, kAXChildrenAttribute, 0, childCount, &children);
-	}
-
-	// Fallback: if ranged fetch failed or returned nothing, try the direct copy.
-	if (!children) {
-		CFTypeRef childrenValue = NULL;
-		if (AXUIElementCopyAttributeValue(axElement, kAXChildrenAttribute, &childrenValue) != kAXErrorSuccess) {
-			*count = 0;
-			return NULL;
-		}
-
-		if (CFGetTypeID(childrenValue) != CFArrayGetTypeID()) {
-			CFRelease(childrenValue);
-			*count = 0;
-			return NULL;
-		}
-
-		children = (CFArrayRef)childrenValue;
-	}
-
-	if (CFGetTypeID(children) != CFArrayGetTypeID()) {
-		CFRelease(children);
+	if (AXUIElementCopyAttributeValue(axElement, kAXChildrenAttribute, &childrenValue) != kAXErrorSuccess) {
 		*count = 0;
 		return NULL;
 	}
 
-	// Always use the actual array count — the pre-fetched count may be stale
-	// if the target app's AX tree changed between the two calls.
-	CFIndex actualCount = CFArrayGetCount(children);
-	if (actualCount == 0) {
-		CFRelease(children);
+	if (CFGetTypeID(childrenValue) != CFArrayGetTypeID()) {
+		CFRelease(childrenValue);
 		*count = 0;
 		return NULL;
 	}
 
-	*count = (int)actualCount;
+	CFArrayRef children = (CFArrayRef)childrenValue;
+	CFIndex childCount = CFArrayGetCount(children);
+	*count = (int)childCount;
 
-	void **result = (void **)malloc(actualCount * sizeof(void *));
+	void **result = (void **)malloc(childCount * sizeof(void *));
 	if (!result) {
-		CFRelease(children);
+		CFRelease(childrenValue);
 		*count = 0;
 		return NULL;
 	}
 
-	for (CFIndex i = 0; i < actualCount; i++) {
+	for (CFIndex i = 0; i < childCount; i++) {
 		AXUIElementRef child = (AXUIElementRef)CFArrayGetValueAtIndex(children, i);
 		CFRetain(child);
 		result[i] = (void *)child;
 	}
 
-	CFRelease(children);
+	CFRelease(childrenValue);
 	return result;
 }
 
@@ -486,60 +458,26 @@ void **getVisibleRows(void *element, int *count) {
 		return NULL;
 
 	AXUIElementRef axElement = (AXUIElementRef)element;
+	CFTypeRef rowsValue = NULL;
 
-	CFIndex rowCount = 0;
-	bool useRanged =
-	    (AXUIElementGetAttributeValueCount(axElement, kAXVisibleRowsAttribute, &rowCount) == kAXErrorSuccess &&
-	     rowCount > 0);
-
-	CFArrayRef rows = NULL;
-	if (useRanged) {
-		AXUIElementCopyAttributeValues(axElement, kAXVisibleRowsAttribute, 0, rowCount, &rows);
-	}
-
-	// Fallback: if ranged fetch failed, try the direct copy.
-	if (!rows) {
-		CFTypeRef rowsValue = NULL;
-		if (AXUIElementCopyAttributeValue(axElement, kAXVisibleRowsAttribute, &rowsValue) != kAXErrorSuccess) {
-			*count = 0;
-			return NULL;
-		}
-
-		if (CFGetTypeID(rowsValue) != CFArrayGetTypeID()) {
-			CFRelease(rowsValue);
-			*count = 0;
-			return NULL;
-		}
-
-		rows = (CFArrayRef)rowsValue;
-		rowCount = CFArrayGetCount(rows);
-		if (rowCount == 0) {
-			CFRelease(rows);
-			*count = 0;
-			return NULL;
-		}
-	}
-
-	if (CFGetTypeID(rows) != CFArrayGetTypeID()) {
-		CFRelease(rows);
+	if (AXUIElementCopyAttributeValue(axElement, kAXVisibleRowsAttribute, &rowsValue) != kAXErrorSuccess) {
 		*count = 0;
 		return NULL;
 	}
 
-	// Always use the actual array count — the pre-fetched count may be stale
-	// if the target app's AX tree changed between the two calls.
-	rowCount = CFArrayGetCount(rows);
-	if (rowCount == 0) {
-		CFRelease(rows);
+	if (CFGetTypeID(rowsValue) != CFArrayGetTypeID()) {
+		CFRelease(rowsValue);
 		*count = 0;
 		return NULL;
 	}
 
+	CFArrayRef rows = (CFArrayRef)rowsValue;
+	CFIndex rowCount = CFArrayGetCount(rows);
 	*count = (int)rowCount;
 
 	void **result = (void **)malloc(rowCount * sizeof(void *));
 	if (!result) {
-		CFRelease(rows);
+		CFRelease(rowsValue);
 		*count = 0;
 		return NULL;
 	}
@@ -550,7 +488,7 @@ void **getVisibleRows(void *element, int *count) {
 		result[i] = (void *)row;
 	}
 
-	CFRelease(rows);
+	CFRelease(rowsValue);
 	return result;
 }
 

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -526,8 +526,13 @@ void **getVisibleRows(void *element, int *count) {
 		return NULL;
 	}
 
+	// Always use the actual array count — the pre-fetched count may be stale
+	// if the target app's AX tree changed between the two calls.
+	rowCount = CFArrayGetCount(rows);
 	if (rowCount == 0) {
-		rowCount = CFArrayGetCount(rows);
+		CFRelease(rows);
+		*count = 0;
+		return NULL;
 	}
 
 	*count = (int)rowCount;

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -234,6 +234,7 @@ ElementInfo *getElementInfo(void *element) {
 		// for interactive elements, but the cost is negligible for non-interactive ones.
 		CFArrayRef actionNames = NULL;
 		if (AXUIElementCopyActionNames(axElement, &actionNames) == kAXErrorSuccess && actionNames) {
+			info->preActionsFetched = true;
 			CFIndex actionCount = CFArrayGetCount(actionNames);
 			for (CFIndex i = 0; i < actionCount; i++) {
 				CFStringRef action = (CFStringRef)CFArrayGetValueAtIndex(actionNames, i);
@@ -389,32 +390,6 @@ int getElementCenter(void *element, CGPoint *outPoint) {
 
 #pragma mark - Child Element Functions
 
-/// Get number of child elements
-/// @param element Element reference
-/// @return Number of children
-int getChildrenCount(void *element) {
-	if (!element)
-		return 0;
-
-	AXUIElementRef axElement = (AXUIElementRef)element;
-	CFIndex childCount = 0;
-
-	if (AXUIElementGetAttributeValueCount(axElement, kAXChildrenAttribute, &childCount) == kAXErrorSuccess) {
-		return (int)childCount;
-	}
-
-	// Fallback: use direct copy if count query is unsupported.
-	CFTypeRef childrenValue = NULL;
-	if (AXUIElementCopyAttributeValue(axElement, kAXChildrenAttribute, &childrenValue) == kAXErrorSuccess &&
-	    childrenValue) {
-		if (CFGetTypeID(childrenValue) == CFArrayGetTypeID()) {
-			childCount = CFArrayGetCount((CFArrayRef)childrenValue);
-		}
-		CFRelease(childrenValue);
-	}
-
-	return (int)childCount;
-}
 
 /// Get child elements
 /// @param element Element reference
@@ -623,11 +598,12 @@ static bool getElementFrame(AXUIElementRef element, CGRect *outFrame) {
 /// @param preRole Pre-fetched AXRole as C string
 /// @param centerX Pre-computed center X (from ElementInfo)
 /// @param centerY Pre-computed center Y (from ElementInfo)
+/// @param preActionsFetched Whether action names were successfully pre-fetched
 /// @return 1 if element is clickable, 0 otherwise
 int hasClickAction(
     void *element, bool skipVisCheck, bool preHidden, bool preVisible, bool preEnabled, bool hasEnabledAttr,
     const char *preRole, bool preIsWidget, double centerX, double centerY, bool preHasPressAction,
-    bool preHasShowMenuAction) {
+    bool preHasShowMenuAction, bool preActionsFetched) {
 	if (!element)
 		return 0;
 
@@ -653,37 +629,39 @@ int hasClickAction(
 		return 1;
 	}
 
-	// Fall back to fetching action names when pre-fetch was unavailable or
-	// did not match AXPress/AXShowMenu. Check all known click actions here
-	// so that a transient pre-fetch failure does not cause false negatives.
-	CFArrayRef actions = NULL;
-	if (AXUIElementCopyActionNames(axElement, &actions) == kAXErrorSuccess && actions) {
-		CFIndex count = CFArrayGetCount(actions);
+	if (!preActionsFetched) {
+		// Fall back to fetching action names when pre-fetch was unavailable or
+		// did not match AXPress/AXShowMenu. Check all known click actions here
+		// so that a transient pre-fetch failure does not cause false negatives.
+		CFArrayRef actions = NULL;
+		if (AXUIElementCopyActionNames(axElement, &actions) == kAXErrorSuccess && actions) {
+			CFIndex count = CFArrayGetCount(actions);
 
-		for (CFIndex i = 0; i < count; i++) {
-			CFStringRef action = (CFStringRef)CFArrayGetValueAtIndex(actions, i);
+			for (CFIndex i = 0; i < count; i++) {
+				CFStringRef action = (CFStringRef)CFArrayGetValueAtIndex(actions, i);
 
-			if (!action)
-				continue;
+				if (!action)
+					continue;
 
-			if (CFStringCompare(action, kAXPressAction, 0) == kCFCompareEqualTo ||
-			    CFStringCompare(action, CFSTR("AXShowMenu"), 0) == kCFCompareEqualTo ||
-			    CFStringCompare(action, CFSTR("AXConfirm"), 0) == kCFCompareEqualTo ||
-			    CFStringCompare(action, CFSTR("AXPick"), 0) == kCFCompareEqualTo ||
-			    CFStringCompare(action, CFSTR("AXRaise"), 0) == kCFCompareEqualTo) {
-				CFRelease(actions);
+				if (CFStringCompare(action, kAXPressAction, 0) == kCFCompareEqualTo ||
+				    CFStringCompare(action, CFSTR("AXShowMenu"), 0) == kCFCompareEqualTo ||
+				    CFStringCompare(action, CFSTR("AXConfirm"), 0) == kCFCompareEqualTo ||
+				    CFStringCompare(action, CFSTR("AXPick"), 0) == kCFCompareEqualTo ||
+				    CFStringCompare(action, CFSTR("AXRaise"), 0) == kCFCompareEqualTo) {
+					CFRelease(actions);
 
-				if (hasEnabledAttr && !preEnabled)
-					return 0;
+					if (hasEnabledAttr && !preEnabled)
+						return 0;
 
-				if (!visHit)
-					return 0;
+					if (!visHit)
+						return 0;
 
-				return 1;
+					return 1;
+				}
 			}
-		}
 
-		CFRelease(actions);
+			CFRelease(actions);
+		}
 	}
 
 	// Exclude known container/structural roles unless they are widgets

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -406,8 +406,10 @@ int getChildrenCount(void *element) {
 	// Fallback: use direct copy if count query is unsupported.
 	CFTypeRef childrenValue = NULL;
 	if (AXUIElementCopyAttributeValue(axElement, kAXChildrenAttribute, &childrenValue) == kAXErrorSuccess &&
-	    childrenValue && CFGetTypeID(childrenValue) == CFArrayGetTypeID()) {
-		childCount = CFArrayGetCount((CFArrayRef)childrenValue);
+	    childrenValue) {
+		if (CFGetTypeID(childrenValue) == CFArrayGetTypeID()) {
+			childCount = CFArrayGetCount((CFArrayRef)childrenValue);
+		}
 		CFRelease(childrenValue);
 	}
 

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -99,6 +99,17 @@ void *getApplicationByBundleId(const char *bundle_id) {
 
 #pragma mark - Element Information Functions
 
+static bool shouldPrefetchActions(const char *role) {
+	if (!role)
+		return false;
+
+	return strcmp(role, "AXButton") == 0 || strcmp(role, "AXLink") == 0 || strcmp(role, "AXCheckBox") == 0 ||
+	       strcmp(role, "AXMenuItem") == 0 || strcmp(role, "AXMenuButton") == 0 || strcmp(role, "AXPopUpButton") == 0 ||
+	       strcmp(role, "AXTabButton") == 0 || strcmp(role, "AXComboBox") == 0 || strcmp(role, "AXSlider") == 0 ||
+	       strcmp(role, "AXSwitch") == 0 || strcmp(role, "AXDisclosureTriangle") == 0 ||
+	       strcmp(role, "AXGenericElement") == 0 || strcmp(role, "AXCell") == 0 || strcmp(role, "AXMenuExtra") == 0;
+}
+
 /// Get element information using batched attribute queries
 /// @param element Element reference
 /// @return Element information structure
@@ -230,10 +241,11 @@ ElementInfo *getElementInfo(void *element) {
 		CFRelease(values);
 
 		// Pre-fetch action names to eliminate a separate AX call during clickability checks.
-		// This is done after the batched attribute fetch since action names are only needed
-		// for interactive elements, but the cost is negligible for non-interactive ones.
+		// We only perform this pre-fetch for interactive roles to save synchronous XPC
+		// round-trips for elements that are almost certainly non-interactive (e.g. AXStaticText, AXGroup).
 		CFArrayRef actionNames = NULL;
-		if (AXUIElementCopyActionNames(axElement, &actionNames) == kAXErrorSuccess && actionNames) {
+		if (shouldPrefetchActions(info->role) &&
+		    AXUIElementCopyActionNames(axElement, &actionNames) == kAXErrorSuccess && actionNames) {
 			info->preActionsFetched = true;
 			CFIndex actionCount = CFArrayGetCount(actionNames);
 			for (CFIndex i = 0; i < actionCount; i++) {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR is yet another performance improvement for hints tree generation, it's now as fast as homerow i would say.

Multiple optimization were made:

- prefetch action names to avoid additional round trips
- skip traversal if the children have nothing important
- replaced unbounded goroutine per children with fixed 8 worker task queues. This is to prevent goroutine explosion and limits AX calls.
- reduce hit-test parent walks to 16 levels

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
