### PR TITLE
fix: resolve memory leaks in animations, overlays and indicators

### DIFF
--- a/internal/app/components/hints/context.go
+++ b/internal/app/components/hints/context.go
@@ -177,7 +177,7 @@ func (c *Context) SearchActive() bool {
 // Reset resets the hints context to its initial state.
 func (c *Context) Reset() {
 	if c.manager != nil {
-		c.manager.Reset()
+		c.manager.Clear()
 	}
 
 	c.hints = nil

--- a/internal/core/domain/hint/manager.go
+++ b/internal/core/domain/hint/manager.go
@@ -148,6 +148,28 @@ func (m *Manager) Reset() {
 	}
 }
 
+// Clear releases session-scoped hint state without invoking the update
+// callback. It is intended for mode teardown, where the overlay has already
+// been cleared by the caller and retaining the previous collection would keep
+// every generated hint and domain element alive until the next activation.
+func (m *Manager) Clear() {
+	m.assertExternalMuHeld("Clear")
+
+	if m.debounceTimer != nil {
+		m.debounceTimer.Stop()
+		m.debounceTimer = nil
+	}
+
+	m.mu.Lock()
+	m.updateGen++
+	m.mu.Unlock()
+
+	m.hints = nil
+	m.cachedFilteredHints = nil
+	m.lastFilteredLen = 0
+	m.SetCurrentInput("")
+}
+
 // HandleInput processes an input character and returns the matched hint if an exact match is found.
 // Handles backspace for input correction, filters hints by prefix, and detects exact matches.
 // Returns (hint, true) if exact match found, (nil, false) otherwise.

--- a/internal/core/domain/hint/manager_test.go
+++ b/internal/core/domain/hint/manager_test.go
@@ -96,6 +96,26 @@ func TestManager_Backspace(t *testing.T) {
 	}
 }
 
+func TestManager_ClearReleasesSessionState(t *testing.T) {
+	elem, _ := element.NewElement(element.ID("1"), image.Rect(0, 0, 10, 10), element.RoleButton)
+	h1, _ := hint.NewHint("AA", elem, image.Point{0, 0})
+	h2, _ := hint.NewHint("AB", elem, image.Point{0, 0})
+	collection := hint.NewCollection([]*hint.Interface{h1, h2})
+	manager := hint.NewManager(logger.Get(), nil)
+	manager.SetHints(collection)
+
+	manager.HandleInput("A")
+	manager.Clear()
+
+	if manager.CurrentInput() != "" {
+		t.Errorf("Expected input to be cleared, got %q", manager.CurrentInput())
+	}
+
+	if filtered := manager.FilteredHints(); filtered != nil {
+		t.Fatalf("Expected no filtered hints after Clear(), got %d", len(filtered))
+	}
+}
+
 func TestHintManager_RouterIntegration(t *testing.T) {
 	logger := logger.Get()
 

--- a/internal/core/infra/platform/darwin/accessibility_element_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_element_darwin.m
@@ -156,6 +156,8 @@ ElementInfo *getElementInfo(void *element) {
 		CFRelease(attributes);
 
 		if (error != kAXErrorSuccess || !values) {
+			if (values)
+				CFRelease(values);
 			pid_t pid;
 			if (AXUIElementGetPid(axElement, &pid) == kAXErrorSuccess) {
 				info->pid = pid;
@@ -364,6 +366,8 @@ int getElementCenter(void *element, CGPoint *outPoint) {
 	CFRelease(attributes);
 
 	if (error != kAXErrorSuccess || !values) {
+		if (values)
+			CFRelease(values);
 		return 0;
 	}
 

--- a/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
@@ -90,6 +90,8 @@ CGRect getScrollBounds(void *element) {
 	CFRelease(attributes);
 
 	if (error != kAXErrorSuccess || !values) {
+		if (values)
+			CFRelease(values);
 		return rect;
 	}
 
@@ -125,14 +127,16 @@ CGRect getScrollBounds(void *element) {
 /// @param deltaY Vertical scroll amount
 /// @return 1 on success, 0 on failure
 int scrollAtPoint(CGPoint pos, int deltaX, int deltaY) {
-	CGEventRef scrollEvent = CGEventCreateScrollWheelEvent(NULL, kCGScrollEventUnitPixel, 2, deltaY, deltaX);
-	if (!scrollEvent)
-		return 0;
+	@autoreleasepool {
+		CGEventRef scrollEvent = CGEventCreateScrollWheelEvent(NULL, kCGScrollEventUnitPixel, 2, deltaY, deltaX);
+		if (!scrollEvent)
+			return 0;
 
-	CGEventSetLocation(scrollEvent, pos);
-	CGEventPost(kCGHIDEventTap, scrollEvent);
-	CFRelease(scrollEvent);
-	return 1;
+		CGEventSetLocation(scrollEvent, pos);
+		CGEventPost(kCGHIDEventTap, scrollEvent);
+		CFRelease(scrollEvent);
+		return 1;
+	}
 }
 
 #pragma mark - Mission Control Detection Functions

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -265,10 +265,9 @@ void *getFrontmostWindow(void) {
 		    },
 		    2, &kCFTypeArrayCallBacks);
 		if (!windowAttrs) {
-			if (shouldReleaseAppRef && appRef) {
+			if (shouldReleaseAppRef && appRef)
 				CFRelease(appRef);
-			}
-			if (focusedApp)
+			else if (focusedApp)
 				CFRelease(focusedApp);
 			return NULL;
 		}

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -114,6 +114,13 @@ void **getFrontmostAndPopoverWindows(int *count) {
 		        kAXWindowsAttribute,
 		    },
 		    2, &kCFTypeArrayCallBacks);
+		if (!windowAttrs) {
+			if (shouldReleaseAppRef && appRef)
+				CFRelease(appRef);
+			else if (focusedApp)
+				CFRelease(focusedApp);
+			return NULL;
+		}
 
 		CFArrayRef windowValues = NULL;
 		AXError batchError = AXUIElementCopyMultipleAttributeValues(appRef, windowAttrs, 0, &windowValues);
@@ -193,6 +200,8 @@ void **getFrontmostAndPopoverWindows(int *count) {
 
 			CFTypeRef roleValue = NULL;
 			if (AXUIElementCopyAttributeValue(window, kAXRoleAttribute, &roleValue) != kAXErrorSuccess || !roleValue) {
+				if (roleValue)
+					CFRelease(roleValue);
 				continue;
 			}
 
@@ -255,6 +264,14 @@ void *getFrontmostWindow(void) {
 		        kAXWindowsAttribute,
 		    },
 		    2, &kCFTypeArrayCallBacks);
+		if (!windowAttrs) {
+			if (shouldReleaseAppRef && appRef) {
+				CFRelease(appRef);
+			}
+			if (focusedApp)
+				CFRelease(focusedApp);
+			return NULL;
+		}
 
 		CFArrayRef windowValues = NULL;
 		AXError batchError = AXUIElementCopyMultipleAttributeValues(appRef, windowAttrs, 0, &windowValues);
@@ -340,6 +357,8 @@ CGRect getFocusedWindowFrame(void) {
 		CFRelease(attributes);
 
 		if (error != kAXErrorSuccess || !values) {
+			if (values)
+				CFRelease(values);
 			CFRelease(window);
 			return CGRectZero;
 		}

--- a/internal/core/infra/platform/darwin/hotkeys_darwin.m
+++ b/internal/core/infra/platform/darwin/hotkeys_darwin.m
@@ -53,29 +53,31 @@ static void initializeStorage(void) {
 /// @param userData User data pointer
 /// @return OSStatus
 static OSStatus hotkeyHandler(EventHandlerCallRef nextHandler, EventRef event, void *userData) {
-	EventHotKeyID hotkeyID;
-	GetEventParameter(event, kEventParamDirectObject, typeEventHotKeyID, NULL, sizeof(hotkeyID), NULL, &hotkeyID);
+	@autoreleasepool {
+		EventHotKeyID hotkeyID;
+		GetEventParameter(event, kEventParamDirectObject, typeEventHotKeyID, NULL, sizeof(hotkeyID), NULL, &hotkeyID);
 
-	int hotkeyId = (int)hotkeyID.id;
-	UInt32 eventKind = GetEventKind(event);
-	int callbackEventKind = eventKind == kEventHotKeyReleased ? HotkeyEventReleased : HotkeyEventPressed;
+		int hotkeyId = (int)hotkeyID.id;
+		UInt32 eventKind = GetEventKind(event);
+		int callbackEventKind = eventKind == kEventHotKeyReleased ? HotkeyEventReleased : HotkeyEventPressed;
 
-	// Thread-safe callback retrieval
-	__block HotkeyCallback callback = NULL;
-	__block void *callbackUserData = NULL;
+		// Thread-safe callback retrieval
+		__block HotkeyCallback callback = NULL;
+		__block void *callbackUserData = NULL;
 
-	dispatch_sync(hotkeyQueue, ^{
-		NSNumber *key = @(hotkeyId);
-		NSDictionary *callbackInfo = hotkeyCallbacks[key];
-		if (callbackInfo) {
-			callback = [callbackInfo[@"callback"] pointerValue];
-			callbackUserData = [callbackInfo[@"userData"] pointerValue];
+		dispatch_sync(hotkeyQueue, ^{
+			NSNumber *key = @(hotkeyId);
+			NSDictionary *callbackInfo = hotkeyCallbacks[key];
+			if (callbackInfo) {
+				callback = [callbackInfo[@"callback"] pointerValue];
+				callbackUserData = [callbackInfo[@"userData"] pointerValue];
+			}
+		});
+
+		// Invoke callback outside the lock
+		if (callback) {
+			callback(hotkeyId, callbackEventKind, callbackUserData);
 		}
-	});
-
-	// Invoke callback outside the lock
-	if (callback) {
-		callback(hotkeyId, callbackEventKind, callbackUserData);
 	}
 
 	return noErr;

--- a/internal/core/infra/platform/darwin/mouse_animator.go
+++ b/internal/core/infra/platform/darwin/mouse_animator.go
@@ -18,28 +18,58 @@ import (
 const (
 	minAnimationDuration = 10 // Minimum animation duration in ms
 	minStepDelay         = 1  // Minimum delay between steps in ms
-	drainTimeoutBufferMs = 50 // Extra grace period while draining a canceled animation.
 )
 
+type cursorAnimationDone struct {
+	ch   chan struct{}
+	once sync.Once
+}
+
+func newCursorAnimationDone() *cursorAnimationDone {
+	return &cursorAnimationDone{ch: make(chan struct{})}
+}
+
+func (d *cursorAnimationDone) close() {
+	if d == nil {
+		return
+	}
+
+	d.once.Do(func() {
+		close(d.ch)
+	})
+}
+
+type cursorRequest struct {
+	end              image.Point
+	steps            int
+	eventType        uint32
+	maxDuration      int
+	durationPerPixel float64
+	done             *cursorAnimationDone
+}
+
 type smoothCursorAnimator struct {
-	cancel context.CancelFunc
-	done   chan struct{}
-	gen    uint64
 	mu     sync.Mutex
+	reqCh  chan cursorRequest
+	stopCh chan struct{}
+	done   *cursorAnimationDone
 }
 
 var cursorAnimator smoothCursorAnimator
 
 func (a *smoothCursorAnimator) stop() {
 	a.mu.Lock()
-	cancel := a.cancel
-	a.gen++
-	a.cancel = nil
+	stopCh := a.stopCh
+	done := a.done
+	a.reqCh = nil
+	a.stopCh = nil
 	a.done = nil
 	a.mu.Unlock()
 
-	if cancel != nil {
-		cancel()
+	done.close()
+
+	if stopCh != nil {
+		close(stopCh)
 	}
 }
 
@@ -53,7 +83,7 @@ func (a *smoothCursorAnimator) wait(ctx context.Context) error {
 	}
 
 	select {
-	case <-done:
+	case <-done.ch:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -61,33 +91,6 @@ func (a *smoothCursorAnimator) wait(ctx context.Context) error {
 }
 
 func (a *smoothCursorAnimator) animateTo(end image.Point, steps int, eventType uint32) {
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
-	a.mu.Lock()
-	prevCancel := a.cancel
-	prevDone := a.done
-	a.gen++
-	gen := a.gen
-	a.cancel = cancel
-	a.done = done
-	a.mu.Unlock()
-
-	if prevCancel != nil {
-		prevCancel()
-	}
-
-	a.waitForPreviousAnimation(prevDone)
-
-	a.mu.Lock()
-	if a.gen != gen || a.done != done {
-		a.mu.Unlock()
-		close(done)
-		cancel()
-
-		return
-	}
-	a.mu.Unlock()
-
 	cfg := currentConfig()
 	maxDuration := 200
 	durationPerPixel := 0.1
@@ -96,103 +99,143 @@ func (a *smoothCursorAnimator) animateTo(end image.Point, steps int, eventType u
 		durationPerPixel = cfg.SmoothCursor.DurationPerPixel
 	}
 
-	go func(runGen uint64) {
-		defer close(done)
-		defer cancel()
-		defer a.clearIfCurrent(runGen, done)
-		start := CursorPosition()
-		distance := math.Hypot(float64(end.X-start.X), float64(end.Y-start.Y))
+	done := newCursorAnimationDone()
+	req := cursorRequest{
+		end:              end,
+		steps:            steps,
+		eventType:        eventType,
+		maxDuration:      maxDuration,
+		durationPerPixel: durationPerPixel,
+		done:             done,
+	}
 
-		duration := math.Min(float64(maxDuration), distance*durationPerPixel)
-		if duration < minAnimationDuration {
-			duration = minAnimationDuration
+	reqCh := a.ensureWorker(done)
+	select {
+	case reqCh <- req:
+	default:
+		select {
+		case dropped := <-reqCh:
+			dropped.done.close()
+		default:
 		}
-
-		actualSteps := steps
-		if actualSteps <= 0 {
-			actualSteps = 10
-		}
-
-		// Reduce steps so total time stays within the computed duration.
-		// Without this, a high step count with a short duration would be
-		// inflated by the minStepDelay floor (e.g. 100 steps × 1ms = 100ms
-		// even when the adaptive duration is only 10ms).
-		maxSteps := max(int(duration/float64(minStepDelay)), 1)
-		if actualSteps > maxSteps {
-			actualSteps = maxSteps
-		}
-
-		stepDelayMs := max(int(math.Round(duration/float64(actualSteps))), minStepDelay)
-
-		stepDelay := time.Duration(stepDelayMs) * time.Millisecond
-
-		for step := 1; step <= actualSteps; step++ {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			progress := float64(step) / float64(actualSteps)
-			intermediate := image.Point{
-				X: int(float64(start.X) + float64(end.X-start.X)*progress),
-				Y: int(float64(start.Y) + float64(end.Y-start.Y)*progress),
-			}
-
-			pos := C.CGPoint{x: C.double(intermediate.X), y: C.double(intermediate.Y)}
-			C.postMouseMoveEvent(pos, C.CGEventType(eventType))
-
-			if step < actualSteps {
-				// Use a timer so that context cancellation interrupts the
-				// wait immediately instead of blocking until the full
-				// stepDelay elapses.
-				timer := time.NewTimer(stepDelay)
-				select {
-				case <-ctx.Done():
-					timer.Stop()
-
-					return
-				case <-timer.C:
-				}
-			}
-		}
-	}(gen)
+		reqCh <- req
+	}
 }
 
-func (a *smoothCursorAnimator) clearIfCurrent(
-	gen uint64,
-	done chan struct{},
-) {
+func (a *smoothCursorAnimator) ensureWorker(done *cursorAnimationDone) chan cursorRequest {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if a.gen == gen && a.done == done {
-		a.cancel = nil
-		a.done = nil
+	a.done = done
+
+	if a.reqCh != nil {
+		return a.reqCh
 	}
+
+	reqCh := make(chan cursorRequest, 1)
+	stopCh := make(chan struct{})
+	a.reqCh = reqCh
+	a.stopCh = stopCh
+
+	go a.run(reqCh, stopCh)
+
+	return reqCh
 }
 
-func (a *smoothCursorAnimator) waitForPreviousAnimation(prevDone chan struct{}) {
-	if prevDone == nil {
-		return
-	}
-
-	timeout := previousAnimationDrainTimeout()
-	timer := time.NewTimer(timeout)
+func (a *smoothCursorAnimator) run(reqCh <-chan cursorRequest, stopCh <-chan struct{}) {
+	timer := time.NewTimer(time.Hour)
+	stopAndDrainTimer(timer)
 	defer timer.Stop()
 
-	select {
-	case <-prevDone:
-	case <-timer.C:
+	for {
+		select {
+		case <-stopCh:
+			return
+		case req := <-reqCh:
+			a.runRequest(req, reqCh, stopCh, timer)
+		}
 	}
 }
 
-func previousAnimationDrainTimeout() time.Duration {
-	cfg := currentConfig()
-	maxDurationMs := 200
-	if cfg != nil && cfg.SmoothCursor.MaxDuration > 0 {
-		maxDurationMs = cfg.SmoothCursor.MaxDuration
+func (a *smoothCursorAnimator) runRequest(
+	req cursorRequest,
+	reqCh <-chan cursorRequest,
+	stopCh <-chan struct{},
+	timer *time.Timer,
+) {
+restart:
+	start := CursorPosition()
+	distance := math.Hypot(float64(req.end.X-start.X), float64(req.end.Y-start.Y))
+
+	duration := math.Min(float64(req.maxDuration), distance*req.durationPerPixel)
+	if duration < minAnimationDuration {
+		duration = minAnimationDuration
 	}
 
-	return time.Duration(maxDurationMs+drainTimeoutBufferMs) * time.Millisecond
+	actualSteps := req.steps
+	if actualSteps <= 0 {
+		actualSteps = 10
+	}
+
+	maxSteps := max(int(duration/float64(minStepDelay)), 1)
+	if actualSteps > maxSteps {
+		actualSteps = maxSteps
+	}
+
+	stepDelayMs := max(int(math.Round(duration/float64(actualSteps))), minStepDelay)
+	stepDelay := time.Duration(stepDelayMs) * time.Millisecond
+
+	for step := 1; step <= actualSteps; step++ {
+		select {
+		case <-stopCh:
+			req.done.close()
+
+			return
+		case nextReq := <-reqCh:
+			req.done.close()
+			req = nextReq
+
+			goto restart
+		default:
+		}
+
+		progress := float64(step) / float64(actualSteps)
+		intermediate := image.Point{
+			X: int(float64(start.X) + float64(req.end.X-start.X)*progress),
+			Y: int(float64(start.Y) + float64(req.end.Y-start.Y)*progress),
+		}
+
+		pos := C.CGPoint{x: C.double(intermediate.X), y: C.double(intermediate.Y)}
+		C.postMouseMoveEvent(pos, C.CGEventType(req.eventType))
+
+		if step < actualSteps {
+			timer.Reset(stepDelay)
+			select {
+			case <-stopCh:
+				stopAndDrainTimer(timer)
+				req.done.close()
+
+				return
+			case nextReq := <-reqCh:
+				stopAndDrainTimer(timer)
+				req.done.close()
+				req = nextReq
+
+				goto restart
+			case <-timer.C:
+			}
+		}
+	}
+
+	req.done.close()
+	a.clearDoneIfCurrent(req.done)
+}
+
+func (a *smoothCursorAnimator) clearDoneIfCurrent(done *cursorAnimationDone) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.done == done {
+		a.done = nil
+	}
 }

--- a/internal/core/infra/platform/darwin/mouse_animator.go
+++ b/internal/core/infra/platform/darwin/mouse_animator.go
@@ -64,13 +64,13 @@ func (a *smoothCursorAnimator) stop() {
 	a.reqCh = nil
 	a.stopCh = nil
 	a.done = nil
-	a.mu.Unlock()
-
-	done.close()
 
 	if stopCh != nil {
 		close(stopCh)
 	}
+	a.mu.Unlock()
+
+	done.close()
 }
 
 func (a *smoothCursorAnimator) wait(ctx context.Context) error {

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -365,6 +365,11 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	return self;
 }
 
+- (void)dealloc {
+	[self.gridTransitionTimer invalidate];
+	self.gridTransitionTimer = nil;
+}
+
 /// Return the backing scale factor for the current screen, with fallbacks.
 /// Uses the window's actual screen (not mainScreen) to ensure correct rendering
 /// when the overlay moves between displays with different scale factors
@@ -1780,16 +1785,12 @@ void NeruDestroyOverlayWindow(OverlayWindow window) {
 	if (!window)
 		return;
 
-	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
-	if ([NSThread isMainThread]) {
-		[controller.window close];
-		CFRelease(window);  // Balance the CFBridgingRetain from createOverlayWindow
-	} else {
-		dispatch_async(dispatch_get_main_queue(), ^{
+	dispatch_async(dispatch_get_main_queue(), ^{
+		@autoreleasepool {
+			OverlayWindowController *controller = CFBridgingRelease(window);
 			[controller.window close];
-			CFRelease(window);  // Balance the CFBridgingRetain from createOverlayWindow
-		});
-	}
+		}
+	});
 }
 
 /// Show overlay window
@@ -1801,17 +1802,19 @@ void NeruShowOverlayWindow(OverlayWindow window) {
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		[controller.window setLevel:kCGMaximumWindowLevel];
-		[controller.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
-		                                         NSWindowCollectionBehaviorStationary |
-		                                         NSWindowCollectionBehaviorIgnoresCycle |
-		                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
+		@autoreleasepool {
+			[controller.window setLevel:kCGMaximumWindowLevel];
+			[controller.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
+			                                         NSWindowCollectionBehaviorStationary |
+			                                         NSWindowCollectionBehaviorIgnoresCycle |
+			                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
 
-		[controller.window setIsVisible:YES];
-		[controller.window orderFrontRegardless];
-		[controller.window display];
+			[controller.window setIsVisible:YES];
+			[controller.window orderFrontRegardless];
+			[controller.window display];
 
-		[controller.overlayView setNeedsDisplay:YES];
+			[controller.overlayView setNeedsDisplay:YES];
+		}
 	});
 }
 
@@ -1827,7 +1830,9 @@ void NeruHideOverlayWindow(OverlayWindow window) {
 		[controller.window orderOut:nil];
 	} else {
 		dispatch_async(dispatch_get_main_queue(), ^{
-			[controller.window orderOut:nil];
+			@autoreleasepool {
+				[controller.window orderOut:nil];
+			}
 		});
 	}
 }
@@ -1850,13 +1855,15 @@ void NeruClearOverlay(OverlayWindow window) {
 		[controller.overlayView setNeedsDisplay:YES];
 	} else {
 		dispatch_async(dispatch_get_main_queue(), ^{
-			[controller.overlayView cancelGridTransition];
-			[controller.overlayView cancelCursorIndicatorTransition];
-			[controller.overlayView.hints removeAllObjects];
-			[controller.overlayView.gridCells removeAllObjects];
-			controller.overlayView.searchInput = nil;
-			controller.overlayView.cursorIndicatorVisible = NO;
-			[controller.overlayView setNeedsDisplay:YES];
+			@autoreleasepool {
+				[controller.overlayView cancelGridTransition];
+				[controller.overlayView cancelCursorIndicatorTransition];
+				[controller.overlayView.hints removeAllObjects];
+				[controller.overlayView.gridCells removeAllObjects];
+				controller.overlayView.searchInput = nil;
+				controller.overlayView.cursorIndicatorVisible = NO;
+				[controller.overlayView setNeedsDisplay:YES];
+			}
 		});
 	}
 }
@@ -1869,32 +1876,36 @@ void NeruResizeOverlayToMainScreen(OverlayWindow window) {
 
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 	dispatch_async(dispatch_get_main_queue(), ^{
-		NSScreen *mainScreen = [NSScreen mainScreen];
-		if (!mainScreen)
-			return;
+		@autoreleasepool {
+			NSScreen *mainScreen = [NSScreen mainScreen];
+			if (!mainScreen)
+				return;
 
-		NSRect screenFrame = [mainScreen frame];
-		[controller.window setFrame:screenFrame display:YES];
+			NSRect screenFrame = [mainScreen frame];
+			[controller.window setFrame:screenFrame display:YES];
 
-		NSRect viewFrame = NSMakeRect(0, 0, screenFrame.size.width, screenFrame.size.height);
-		[controller.overlayView setFrame:viewFrame];
-		[controller.overlayView setNeedsDisplay:YES];
+			NSRect viewFrame = NSMakeRect(0, 0, screenFrame.size.width, screenFrame.size.height);
+			[controller.overlayView setFrame:viewFrame];
+			[controller.overlayView setNeedsDisplay:YES];
 
-		// Force reset window state to handle "stuck" windows after full-screen transitions
-		[controller.window orderOut:nil];
-		[controller.window setLevel:kCGMaximumWindowLevel];
-		[controller.window setCollectionBehavior:NSWindowCollectionBehaviorDefault];
+			// Force reset window state to handle "stuck" windows after full-screen transitions
+			[controller.window orderOut:nil];
+			[controller.window setLevel:kCGMaximumWindowLevel];
+			[controller.window setCollectionBehavior:NSWindowCollectionBehaviorDefault];
 
-		// Use a separate dispatch to ensure the window server processes the orderOut and state reset
-		// before we bring the window back. This helps break the association with the previous space.
-		dispatch_async(dispatch_get_main_queue(), ^{
-			[controller.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
-			                                         NSWindowCollectionBehaviorStationary |
-			                                         NSWindowCollectionBehaviorIgnoresCycle |
-			                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
-			[controller.window setIsVisible:YES];
-			[controller.window orderFrontRegardless];
-		});
+			// Use a separate dispatch to ensure the window server processes the orderOut and state reset
+			// before we bring the window back. This helps break the association with the previous space.
+			dispatch_async(dispatch_get_main_queue(), ^{
+				@autoreleasepool {
+					[controller.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
+					                                         NSWindowCollectionBehaviorStationary |
+					                                         NSWindowCollectionBehaviorIgnoresCycle |
+					                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
+					[controller.window setIsVisible:YES];
+					[controller.window orderFrontRegardless];
+				}
+			});
+		}
 	});
 }
 
@@ -1906,41 +1917,45 @@ void NeruResizeOverlayToActiveScreen(OverlayWindow window) {
 
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 	dispatch_async(dispatch_get_main_queue(), ^{
-		NSPoint mouseLoc = [NSEvent mouseLocation];
+		@autoreleasepool {
+			NSPoint mouseLoc = [NSEvent mouseLocation];
 
-		// Find the screen containing the mouse cursor
-		NSScreen *activeScreen = nil;
-		for (NSScreen *screen in [NSScreen screens]) {
-			if (NSPointInRect(mouseLoc, screen.frame)) {
-				activeScreen = screen;
-				break;
+			// Find the screen containing the mouse cursor
+			NSScreen *activeScreen = nil;
+			for (NSScreen *screen in [NSScreen screens]) {
+				if (NSPointInRect(mouseLoc, screen.frame)) {
+					activeScreen = screen;
+					break;
+				}
 			}
+			if (!activeScreen)
+				activeScreen = [NSScreen mainScreen];
+			if (!activeScreen)
+				return;
+
+			NSRect screenFrame = [activeScreen frame];
+			[controller.window setFrame:screenFrame display:YES];
+
+			NSRect viewFrame = NSMakeRect(0, 0, screenFrame.size.width, screenFrame.size.height);
+			[controller.overlayView setFrame:viewFrame];
+			[controller.overlayView setNeedsDisplay:YES];
+
+			// Force reset window state to handle "stuck" windows after full-screen transitions
+			[controller.window orderOut:nil];
+			[controller.window setLevel:kCGMaximumWindowLevel];
+			[controller.window setCollectionBehavior:NSWindowCollectionBehaviorDefault];
+
+			dispatch_async(dispatch_get_main_queue(), ^{
+				@autoreleasepool {
+					[controller.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
+					                                         NSWindowCollectionBehaviorStationary |
+					                                         NSWindowCollectionBehaviorIgnoresCycle |
+					                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
+					[controller.window setIsVisible:YES];
+					[controller.window orderFrontRegardless];
+				}
+			});
 		}
-		if (!activeScreen)
-			activeScreen = [NSScreen mainScreen];
-		if (!activeScreen)
-			return;
-
-		NSRect screenFrame = [activeScreen frame];
-		[controller.window setFrame:screenFrame display:YES];
-
-		NSRect viewFrame = NSMakeRect(0, 0, screenFrame.size.width, screenFrame.size.height);
-		[controller.overlayView setFrame:viewFrame];
-		[controller.overlayView setNeedsDisplay:YES];
-
-		// Force reset window state to handle "stuck" windows after full-screen transitions
-		[controller.window orderOut:nil];
-		[controller.window setLevel:kCGMaximumWindowLevel];
-		[controller.window setCollectionBehavior:NSWindowCollectionBehaviorDefault];
-
-		dispatch_async(dispatch_get_main_queue(), ^{
-			[controller.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
-			                                         NSWindowCollectionBehaviorStationary |
-			                                         NSWindowCollectionBehaviorIgnoresCycle |
-			                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
-			[controller.window setIsVisible:YES];
-			[controller.window orderFrontRegardless];
-		});
 	});
 }
 
@@ -1958,47 +1973,51 @@ void NeruResizeOverlayToActiveScreenWithCallback(
 
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 	dispatch_async(dispatch_get_main_queue(), ^{
-		NSPoint mouseLoc = [NSEvent mouseLocation];
+		@autoreleasepool {
+			NSPoint mouseLoc = [NSEvent mouseLocation];
 
-		// Find the screen containing the mouse cursor
-		NSScreen *activeScreen = nil;
-		for (NSScreen *screen in [NSScreen screens]) {
-			if (NSPointInRect(mouseLoc, screen.frame)) {
-				activeScreen = screen;
-				break;
+			// Find the screen containing the mouse cursor
+			NSScreen *activeScreen = nil;
+			for (NSScreen *screen in [NSScreen screens]) {
+				if (NSPointInRect(mouseLoc, screen.frame)) {
+					activeScreen = screen;
+					break;
+				}
 			}
+			if (!activeScreen)
+				activeScreen = [NSScreen mainScreen];
+			if (!activeScreen) {
+				if (callback)
+					callback(context);
+				return;
+			}
+
+			NSRect screenFrame = [activeScreen frame];
+			[controller.window setFrame:screenFrame display:YES];
+
+			NSRect viewFrame = NSMakeRect(0, 0, screenFrame.size.width, screenFrame.size.height);
+			[controller.overlayView setFrame:viewFrame];
+			[controller.overlayView setNeedsDisplay:YES];
+
+			// Force reset window state to handle "stuck" windows after full-screen transitions
+			[controller.window orderOut:nil];
+			[controller.window setLevel:kCGMaximumWindowLevel];
+			[controller.window setCollectionBehavior:NSWindowCollectionBehaviorDefault];
+
+			dispatch_async(dispatch_get_main_queue(), ^{
+				@autoreleasepool {
+					[controller.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
+					                                         NSWindowCollectionBehaviorStationary |
+					                                         NSWindowCollectionBehaviorIgnoresCycle |
+					                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
+					[controller.window setIsVisible:YES];
+					[controller.window orderFrontRegardless];
+
+					if (callback)
+						callback(context);
+				}
+			});
 		}
-		if (!activeScreen)
-			activeScreen = [NSScreen mainScreen];
-		if (!activeScreen) {
-			if (callback)
-				callback(context);
-			return;
-		}
-
-		NSRect screenFrame = [activeScreen frame];
-		[controller.window setFrame:screenFrame display:YES];
-
-		NSRect viewFrame = NSMakeRect(0, 0, screenFrame.size.width, screenFrame.size.height);
-		[controller.overlayView setFrame:viewFrame];
-		[controller.overlayView setNeedsDisplay:YES];
-
-		// Force reset window state to handle "stuck" windows after full-screen transitions
-		[controller.window orderOut:nil];
-		[controller.window setLevel:kCGMaximumWindowLevel];
-		[controller.window setCollectionBehavior:NSWindowCollectionBehaviorDefault];
-
-		dispatch_async(dispatch_get_main_queue(), ^{
-			[controller.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
-			                                         NSWindowCollectionBehaviorStationary |
-			                                         NSWindowCollectionBehaviorIgnoresCycle |
-			                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
-			[controller.window setIsVisible:YES];
-			[controller.window orderFrontRegardless];
-
-			if (callback)
-				callback(context);
-		});
 	});
 }
 
@@ -2095,7 +2114,8 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 		OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
 		// Build hint items upfront — safe from any thread
-		NSMutableArray<HintItem *> *hintItems = buildHintItems(hints, count, style.showArrow ? YES : NO, style.placement);
+		NSMutableArray<HintItem *> *hintItems =
+		    buildHintItems(hints, count, style.showArrow ? YES : NO, style.placement);
 
 		if ([NSThread isMainThread]) {
 			[controller.overlayView.hints removeAllObjects];
@@ -2190,19 +2210,21 @@ void NeruDrawHintSearchInput(OverlayWindow window, SearchInputData input, Search
 	    .borderColor = safe_strdup(style.borderColor)};
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		NSRect oldRect = [controller.overlayView boundingRectForSearchInput];
-		controller.overlayView.searchInput = item;
-		applySearchInputStyle(controller.overlayView, styleCopy);
-		NSRect newRect = [controller.overlayView boundingRectForSearchInput];
+		@autoreleasepool {
+			NSRect oldRect = [controller.overlayView boundingRectForSearchInput];
+			controller.overlayView.searchInput = item;
+			applySearchInputStyle(controller.overlayView, styleCopy);
+			NSRect newRect = [controller.overlayView boundingRectForSearchInput];
 
-		controller.overlayView.fullRedraw = NO;
-		if (!NSIsEmptyRect(oldRect)) {
-			[controller.overlayView setNeedsDisplayInRect:oldRect];
+			controller.overlayView.fullRedraw = NO;
+			if (!NSIsEmptyRect(oldRect)) {
+				[controller.overlayView setNeedsDisplayInRect:oldRect];
+			}
+			if (!NSIsEmptyRect(newRect)) {
+				[controller.overlayView setNeedsDisplayInRect:newRect];
+			}
+			free_search_input_style_strings(&styleCopy);
 		}
-		if (!NSIsEmptyRect(newRect)) {
-			[controller.overlayView setNeedsDisplayInRect:newRect];
-		}
-		free_search_input_style_strings(&styleCopy);
 	});
 }
 
@@ -2212,11 +2234,13 @@ void NeruHideHintSearchInput(OverlayWindow window) {
 
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 	dispatch_async(dispatch_get_main_queue(), ^{
-		NSRect oldRect = [controller.overlayView boundingRectForSearchInput];
-		controller.overlayView.searchInput = nil;
-		if (!NSIsEmptyRect(oldRect)) {
-			controller.overlayView.fullRedraw = NO;
-			[controller.overlayView setNeedsDisplayInRect:oldRect];
+		@autoreleasepool {
+			NSRect oldRect = [controller.overlayView boundingRectForSearchInput];
+			controller.overlayView.searchInput = nil;
+			if (!NSIsEmptyRect(oldRect)) {
+				controller.overlayView.fullRedraw = NO;
+				[controller.overlayView setNeedsDisplayInRect:oldRect];
+			}
 		}
 	});
 }
@@ -2234,30 +2258,32 @@ void NeruUpdateHintMatchPrefix(OverlayWindow window, const char *prefix) {
 	NSString *prefixStr = prefix ? @(prefix) : @"";
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		BOOL anyInvalidated = NO;
-		NSUInteger prefixLen = [prefixStr length];
+		@autoreleasepool {
+			BOOL anyInvalidated = NO;
+			NSUInteger prefixLen = [prefixStr length];
 
-		for (HintItem *hintItem in controller.overlayView.hints) {
-			NSString *label = hintItem.label ?: @"";
-			int newMatchedPrefixLength = 0;
-			if (prefixLen > 0 && [label hasPrefix:prefixStr]) {
-				newMatchedPrefixLength = (int)prefixLen;
-			}
+			for (HintItem *hintItem in controller.overlayView.hints) {
+				NSString *label = hintItem.label ?: @"";
+				int newMatchedPrefixLength = 0;
+				if (prefixLen > 0 && [label hasPrefix:prefixStr]) {
+					newMatchedPrefixLength = (int)prefixLen;
+				}
 
-			// Only invalidate if the match state actually changed
-			if (hintItem.matchedPrefixLength != newMatchedPrefixLength) {
-				hintItem.matchedPrefixLength = newMatchedPrefixLength;
-				NSRect dirtyRect = [controller.overlayView boundingRectForHint:hintItem];
-				if (!NSIsEmptyRect(dirtyRect)) {
-					[controller.overlayView setNeedsDisplayInRect:dirtyRect];
-					anyInvalidated = YES;
+				// Only invalidate if the match state actually changed
+				if (hintItem.matchedPrefixLength != newMatchedPrefixLength) {
+					hintItem.matchedPrefixLength = newMatchedPrefixLength;
+					NSRect dirtyRect = [controller.overlayView boundingRectForHint:hintItem];
+					if (!NSIsEmptyRect(dirtyRect)) {
+						[controller.overlayView setNeedsDisplayInRect:dirtyRect];
+						anyInvalidated = YES;
+					}
 				}
 			}
-		}
 
-		if (anyInvalidated) {
-			// Signal partial redraw mode so drawLayer:inContext: uses the clip box
-			controller.overlayView.fullRedraw = NO;
+			if (anyInvalidated) {
+				// Signal partial redraw mode so drawLayer:inContext: uses the clip box
+				controller.overlayView.fullRedraw = NO;
+			}
 		}
 	});
 }
@@ -2316,110 +2342,112 @@ void NeruDrawIncrementHints(
 	int boundaryBorderRadius = style.boundaryBorderRadius;
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		// Apply font — only re-create when family or size changed
-		BOOL hintFamilyChanged =
-		    (fontFamily != controller.overlayView.cachedHintFontFamily &&
-		     ![fontFamily isEqualToString:controller.overlayView.cachedHintFontFamily]);
-		if (hintFamilyChanged || fontSize != controller.overlayView.cachedHintFontSize) {
-			NSFont *font = nil;
-			if (fontFamily && [fontFamily length] > 0) {
-				font = [controller.overlayView resolveFont:fontFamily size:fontSize bold:YES];
-			}
-			if (!font)
-				font = [NSFont boldSystemFontOfSize:fontSize];
-			controller.overlayView.hintFont = font;
-			controller.overlayView.cachedHintFontFamily = fontFamily;
-			controller.overlayView.cachedHintFontSize = fontSize;
-		}
-
-		// Apply colors
-		if (bgHex) {
-			NSColor *defaultBg = [[NSColor colorWithRed:1.0 green:0.84 blue:0.0
-			                                      alpha:1.0] colorWithAlphaComponent:0.95];
-			controller.overlayView.hintBackgroundColor = [controller.overlayView colorFromHex:bgHex
-			                                                                     defaultColor:defaultBg];
-		}
-		if (textHex) {
-			controller.overlayView.hintTextColor = [controller.overlayView colorFromHex:textHex
-			                                                               defaultColor:[NSColor blackColor]];
-		}
-		if (matchedTextHex) {
-			controller.overlayView.hintMatchedTextColor =
-			    [controller.overlayView colorFromHex:matchedTextHex defaultColor:[NSColor systemBlueColor]];
-		}
-		if (borderHex) {
-			controller.overlayView.hintBorderColor = [controller.overlayView colorFromHex:borderHex
-			                                                                 defaultColor:[NSColor blackColor]];
-		}
-		if (boundaryBgHex) {
-			NSColor *defaultBoundaryBg = [[NSColor systemBlueColor] colorWithAlphaComponent:0.08];
-			controller.overlayView.hintBoundaryBackgroundColor =
-			    [controller.overlayView colorFromHex:boundaryBgHex defaultColor:defaultBoundaryBg];
-		}
-		if (boundaryBorderHex) {
-			NSColor *defaultBoundaryBorder = [[NSColor systemBlueColor] colorWithAlphaComponent:0.45];
-			controller.overlayView.hintBoundaryBorderColor =
-			    [controller.overlayView colorFromHex:boundaryBorderHex defaultColor:defaultBoundaryBorder];
-		}
-
-		// Apply geometry properties
-		controller.overlayView.hintBorderRadius = borderRadius;
-		controller.overlayView.hintBorderWidth = borderWidth >= 0 ? borderWidth : 1.0;
-		controller.overlayView.hintPaddingX = paddingX;
-		controller.overlayView.hintPaddingY = paddingY;
-		controller.overlayView.hintBoundaryHighlightEnabled = boundaryHighlightEnabled ? YES : NO;
-		controller.overlayView.hintBoundaryBorderWidth = boundaryBorderWidth >= 0 ? boundaryBorderWidth : 1.0;
-		controller.overlayView.hintBoundaryBorderRadius = boundaryBorderRadius >= 0 ? boundaryBorderRadius : 4.0;
-
-		// Remove hints matching the given positions
-		if (positionsToRemoveArray && [positionsToRemoveArray count] > 0) {
-			// Build a set of position keys for O(1) lookup
-			NSMutableSet *positionsToRemoveSet = [NSMutableSet setWithCapacity:[positionsToRemoveArray count]];
-			for (NSValue *removePositionValue in positionsToRemoveArray) {
-				NSPoint removePosition = [removePositionValue pointValue];
-				NSString *key = [NSString stringWithFormat:@"%.6f,%.6f", removePosition.x, removePosition.y];
-				[positionsToRemoveSet addObject:key];
-			}
-
-			NSMutableArray<HintItem *> *hintsToKeep =
-			    [NSMutableArray arrayWithCapacity:[controller.overlayView.hints count]];
-			for (HintItem *hintItem in controller.overlayView.hints) {
-				NSPoint hintPosition = hintItem.position;
-				NSString *hintKey = [NSString stringWithFormat:@"%.6f,%.6f", hintPosition.x, hintPosition.y];
-				if (![positionsToRemoveSet containsObject:hintKey]) {
-					[hintsToKeep addObject:hintItem];
+		@autoreleasepool {
+			// Apply font — only re-create when family or size changed
+			BOOL hintFamilyChanged =
+			    (fontFamily != controller.overlayView.cachedHintFontFamily &&
+			     ![fontFamily isEqualToString:controller.overlayView.cachedHintFontFamily]);
+			if (hintFamilyChanged || fontSize != controller.overlayView.cachedHintFontSize) {
+				NSFont *font = nil;
+				if (fontFamily && [fontFamily length] > 0) {
+					font = [controller.overlayView resolveFont:fontFamily size:fontSize bold:YES];
 				}
-			}
-			controller.overlayView.hints = hintsToKeep;
-		}
-
-		// Add or update hints
-		if (hintItemsToAdd && [hintItemsToAdd count] > 0) {
-			// Build lookup map for existing hints by position for O(1) access
-			NSMutableDictionary *hintsByPosition =
-			    [NSMutableDictionary dictionaryWithCapacity:[controller.overlayView.hints count]];
-			for (HintItem *hintItem in controller.overlayView.hints) {
-				NSPoint pos = hintItem.position;
-				NSString *key = [NSString stringWithFormat:@"%.6f,%.6f", pos.x, pos.y];
-				hintsByPosition[key] = hintItem;
+				if (!font)
+					font = [NSFont boldSystemFontOfSize:fontSize];
+				controller.overlayView.hintFont = font;
+				controller.overlayView.cachedHintFontFamily = fontFamily;
+				controller.overlayView.cachedHintFontSize = fontSize;
 			}
 
-			for (HintItem *newHintItem in hintItemsToAdd) {
-				NSPoint newPosition = newHintItem.position;
-				NSString *key = [NSString stringWithFormat:@"%.6f,%.6f", newPosition.x, newPosition.y];
-				HintItem *existingHint = hintsByPosition[key];
-				if (existingHint) {
-					NSUInteger index = [controller.overlayView.hints indexOfObjectIdenticalTo:existingHint];
-					if (index != NSNotFound) {
-						controller.overlayView.hints[index] = newHintItem;
+			// Apply colors
+			if (bgHex) {
+				NSColor *defaultBg = [[NSColor colorWithRed:1.0 green:0.84 blue:0.0
+				                                      alpha:1.0] colorWithAlphaComponent:0.95];
+				controller.overlayView.hintBackgroundColor = [controller.overlayView colorFromHex:bgHex
+				                                                                     defaultColor:defaultBg];
+			}
+			if (textHex) {
+				controller.overlayView.hintTextColor = [controller.overlayView colorFromHex:textHex
+				                                                               defaultColor:[NSColor blackColor]];
+			}
+			if (matchedTextHex) {
+				controller.overlayView.hintMatchedTextColor =
+				    [controller.overlayView colorFromHex:matchedTextHex defaultColor:[NSColor systemBlueColor]];
+			}
+			if (borderHex) {
+				controller.overlayView.hintBorderColor = [controller.overlayView colorFromHex:borderHex
+				                                                                 defaultColor:[NSColor blackColor]];
+			}
+			if (boundaryBgHex) {
+				NSColor *defaultBoundaryBg = [[NSColor systemBlueColor] colorWithAlphaComponent:0.08];
+				controller.overlayView.hintBoundaryBackgroundColor =
+				    [controller.overlayView colorFromHex:boundaryBgHex defaultColor:defaultBoundaryBg];
+			}
+			if (boundaryBorderHex) {
+				NSColor *defaultBoundaryBorder = [[NSColor systemBlueColor] colorWithAlphaComponent:0.45];
+				controller.overlayView.hintBoundaryBorderColor =
+				    [controller.overlayView colorFromHex:boundaryBorderHex defaultColor:defaultBoundaryBorder];
+			}
+
+			// Apply geometry properties
+			controller.overlayView.hintBorderRadius = borderRadius;
+			controller.overlayView.hintBorderWidth = borderWidth >= 0 ? borderWidth : 1.0;
+			controller.overlayView.hintPaddingX = paddingX;
+			controller.overlayView.hintPaddingY = paddingY;
+			controller.overlayView.hintBoundaryHighlightEnabled = boundaryHighlightEnabled ? YES : NO;
+			controller.overlayView.hintBoundaryBorderWidth = boundaryBorderWidth >= 0 ? boundaryBorderWidth : 1.0;
+			controller.overlayView.hintBoundaryBorderRadius = boundaryBorderRadius >= 0 ? boundaryBorderRadius : 4.0;
+
+			// Remove hints matching the given positions
+			if (positionsToRemoveArray && [positionsToRemoveArray count] > 0) {
+				// Build a set of position keys for O(1) lookup
+				NSMutableSet *positionsToRemoveSet = [NSMutableSet setWithCapacity:[positionsToRemoveArray count]];
+				for (NSValue *removePositionValue in positionsToRemoveArray) {
+					NSPoint removePosition = [removePositionValue pointValue];
+					NSString *key = [NSString stringWithFormat:@"%.6f,%.6f", removePosition.x, removePosition.y];
+					[positionsToRemoveSet addObject:key];
+				}
+
+				NSMutableArray<HintItem *> *hintsToKeep =
+				    [NSMutableArray arrayWithCapacity:[controller.overlayView.hints count]];
+				for (HintItem *hintItem in controller.overlayView.hints) {
+					NSPoint hintPosition = hintItem.position;
+					NSString *hintKey = [NSString stringWithFormat:@"%.6f,%.6f", hintPosition.x, hintPosition.y];
+					if (![positionsToRemoveSet containsObject:hintKey]) {
+						[hintsToKeep addObject:hintItem];
 					}
-				} else {
-					[controller.overlayView.hints addObject:newHintItem];
+				}
+				controller.overlayView.hints = hintsToKeep;
+			}
+
+			// Add or update hints
+			if (hintItemsToAdd && [hintItemsToAdd count] > 0) {
+				// Build lookup map for existing hints by position for O(1) access
+				NSMutableDictionary *hintsByPosition =
+				    [NSMutableDictionary dictionaryWithCapacity:[controller.overlayView.hints count]];
+				for (HintItem *hintItem in controller.overlayView.hints) {
+					NSPoint pos = hintItem.position;
+					NSString *key = [NSString stringWithFormat:@"%.6f,%.6f", pos.x, pos.y];
+					hintsByPosition[key] = hintItem;
+				}
+
+				for (HintItem *newHintItem in hintItemsToAdd) {
+					NSPoint newPosition = newHintItem.position;
+					NSString *key = [NSString stringWithFormat:@"%.6f,%.6f", newPosition.x, newPosition.y];
+					HintItem *existingHint = hintsByPosition[key];
+					if (existingHint) {
+						NSUInteger index = [controller.overlayView.hints indexOfObjectIdenticalTo:existingHint];
+						if (index != NSNotFound) {
+							controller.overlayView.hints[index] = newHintItem;
+						}
+					} else {
+						[controller.overlayView.hints addObject:newHintItem];
+					}
 				}
 			}
-		}
 
-		[controller.overlayView setNeedsDisplay:YES];
+			[controller.overlayView setNeedsDisplay:YES];
+		}
 	});
 }
 
@@ -2521,72 +2549,74 @@ void NeruDrawGridCells(OverlayWindow window, GridCell *cells, int count, GridCel
 	}
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		// Apply font — only re-create when family or size changed
-		BOOL gridFamilyChanged =
-		    (fontFamily != controller.overlayView.cachedGridFontFamily &&
-		     ![fontFamily isEqualToString:controller.overlayView.cachedGridFontFamily]);
-		if (gridFamilyChanged || fontSize != controller.overlayView.cachedGridFontSize) {
-			NSFont *font = nil;
-			if (fontFamily && [fontFamily length] > 0) {
-				font = [controller.overlayView resolveFont:fontFamily size:fontSize bold:NO];
+		@autoreleasepool {
+			// Apply font — only re-create when family or size changed
+			BOOL gridFamilyChanged =
+			    (fontFamily != controller.overlayView.cachedGridFontFamily &&
+			     ![fontFamily isEqualToString:controller.overlayView.cachedGridFontFamily]);
+			if (gridFamilyChanged || fontSize != controller.overlayView.cachedGridFontSize) {
+				NSFont *font = nil;
+				if (fontFamily && [fontFamily length] > 0) {
+					font = [controller.overlayView resolveFont:fontFamily size:fontSize bold:NO];
+				}
+				if (!font)
+					font = [NSFont systemFontOfSize:fontSize];
+				controller.overlayView.gridFont = font;
+				controller.overlayView.cachedGridFontFamily = fontFamily;
+				controller.overlayView.cachedGridFontSize = fontSize;
 			}
-			if (!font)
-				font = [NSFont systemFontOfSize:fontSize];
-			controller.overlayView.gridFont = font;
-			controller.overlayView.cachedGridFontFamily = fontFamily;
-			controller.overlayView.cachedGridFontSize = fontSize;
-		}
 
-		// Apply colors
-		controller.overlayView.gridBackgroundColor = [controller.overlayView colorFromHex:bgHex
-		                                                                     defaultColor:[NSColor whiteColor]];
-		controller.overlayView.gridLabelBackgroundColor = [controller.overlayView
-		    colorFromHex:labelBgHex
-		    defaultColor:[[NSColor colorWithRed:1.0 green:0.84 blue:0.0 alpha:1.0] colorWithAlphaComponent:0.8]];
-		controller.overlayView.gridTextColor = [controller.overlayView colorFromHex:textHex
-		                                                               defaultColor:[NSColor blackColor]];
-		controller.overlayView.gridMatchedTextColor = [controller.overlayView colorFromHex:matchedTextHex
-		                                                                      defaultColor:[NSColor blueColor]];
-		controller.overlayView.gridMatchedBackgroundColor = [controller.overlayView colorFromHex:matchedBgHex
-		                                                                            defaultColor:[NSColor blueColor]];
-		controller.overlayView.gridMatchedBorderColor = [controller.overlayView colorFromHex:matchedBorderHex
-		                                                                        defaultColor:[NSColor blueColor]];
-		controller.overlayView.gridBorderColor = [controller.overlayView colorFromHex:borderHex
-		                                                                 defaultColor:[NSColor grayColor]];
+			// Apply colors
+			controller.overlayView.gridBackgroundColor = [controller.overlayView colorFromHex:bgHex
+			                                                                     defaultColor:[NSColor whiteColor]];
+			controller.overlayView.gridLabelBackgroundColor = [controller.overlayView
+			    colorFromHex:labelBgHex
+			    defaultColor:[[NSColor colorWithRed:1.0 green:0.84 blue:0.0 alpha:1.0] colorWithAlphaComponent:0.8]];
+			controller.overlayView.gridTextColor = [controller.overlayView colorFromHex:textHex
+			                                                               defaultColor:[NSColor blackColor]];
+			controller.overlayView.gridMatchedTextColor = [controller.overlayView colorFromHex:matchedTextHex
+			                                                                      defaultColor:[NSColor blueColor]];
+			controller.overlayView.gridMatchedBackgroundColor =
+			    [controller.overlayView colorFromHex:matchedBgHex defaultColor:[NSColor blueColor]];
+			controller.overlayView.gridMatchedBorderColor = [controller.overlayView colorFromHex:matchedBorderHex
+			                                                                        defaultColor:[NSColor blueColor]];
+			controller.overlayView.gridBorderColor = [controller.overlayView colorFromHex:borderHex
+			                                                                 defaultColor:[NSColor grayColor]];
 
-		// Apply geometry and layout properties
-		controller.overlayView.gridBorderWidth = borderWidth > 0 ? borderWidth : 1.0;
-		controller.overlayView.gridDrawLabelBackground = drawLabelBackground;
-		controller.overlayView.gridLabelBackgroundPaddingX = labelBackgroundPaddingX;
-		controller.overlayView.gridLabelBackgroundPaddingY = labelBackgroundPaddingY;
-		controller.overlayView.gridLabelBackgroundBorderRadius = labelBackgroundBorderRadius;
-		controller.overlayView.gridLabelBackgroundBorderWidth = labelBackgroundBorderWidth;
+			// Apply geometry and layout properties
+			controller.overlayView.gridBorderWidth = borderWidth > 0 ? borderWidth : 1.0;
+			controller.overlayView.gridDrawLabelBackground = drawLabelBackground;
+			controller.overlayView.gridLabelBackgroundPaddingX = labelBackgroundPaddingX;
+			controller.overlayView.gridLabelBackgroundPaddingY = labelBackgroundPaddingY;
+			controller.overlayView.gridLabelBackgroundBorderRadius = labelBackgroundBorderRadius;
+			controller.overlayView.gridLabelBackgroundBorderWidth = labelBackgroundBorderWidth;
 
-		// Apply sub-key preview settings
-		controller.overlayView.gridDrawSubKeyPreview = drawSubKeyPreview;
-		controller.overlayView.gridSubKeyCols = subKeyGridCols;
-		controller.overlayView.gridSubKeyRows = subKeyGridRows;
-		controller.overlayView.gridSubKeyLabels = subKeyLabels;
-		if (drawSubKeyPreview) {
-			if (subKeyFontSize != controller.overlayView.cachedGridSubKeyFontSize) {
-				controller.overlayView.gridSubKeyFont = [NSFont systemFontOfSize:subKeyFontSize];
-				controller.overlayView.cachedGridSubKeyFontSize = subKeyFontSize;
+			// Apply sub-key preview settings
+			controller.overlayView.gridDrawSubKeyPreview = drawSubKeyPreview;
+			controller.overlayView.gridSubKeyCols = subKeyGridCols;
+			controller.overlayView.gridSubKeyRows = subKeyGridRows;
+			controller.overlayView.gridSubKeyLabels = subKeyLabels;
+			if (drawSubKeyPreview) {
+				if (subKeyFontSize != controller.overlayView.cachedGridSubKeyFontSize) {
+					controller.overlayView.gridSubKeyFont = [NSFont systemFontOfSize:subKeyFontSize];
+					controller.overlayView.cachedGridSubKeyFontSize = subKeyFontSize;
+				}
+				controller.overlayView.gridSubKeyAutohideMultiplier = subKeyAutohideMultiplier;
+				controller.overlayView.gridSubKeyTextColor = [controller.overlayView colorFromHex:subKeyTextHex
+				                                                                     defaultColor:[NSColor grayColor]];
 			}
-			controller.overlayView.gridSubKeyAutohideMultiplier = subKeyAutohideMultiplier;
-			controller.overlayView.gridSubKeyTextColor = [controller.overlayView colorFromHex:subKeyTextHex
-			                                                                     defaultColor:[NSColor grayColor]];
+
+			// Sync cached color references
+			controller.overlayView.cachedGridTextColor = controller.overlayView.gridTextColor;
+			controller.overlayView.cachedGridMatchedTextColor = controller.overlayView.gridMatchedTextColor;
+
+			// Replace cell data and redisplay
+			[controller.overlayView cancelGridTransition];
+			[controller.overlayView cancelCursorIndicatorTransition];
+			[controller.overlayView.gridCells removeAllObjects];
+			[controller.overlayView.gridCells addObjectsFromArray:cellItems];
+			[controller.overlayView setNeedsDisplay:YES];
 		}
-
-		// Sync cached color references
-		controller.overlayView.cachedGridTextColor = controller.overlayView.gridTextColor;
-		controller.overlayView.cachedGridMatchedTextColor = controller.overlayView.gridMatchedTextColor;
-
-		// Replace cell data and redisplay
-		[controller.overlayView cancelGridTransition];
-		[controller.overlayView cancelCursorIndicatorTransition];
-		[controller.overlayView.gridCells removeAllObjects];
-		[controller.overlayView.gridCells addObjectsFromArray:cellItems];
-		[controller.overlayView setNeedsDisplay:YES];
 	});
 }
 
@@ -2647,61 +2677,63 @@ void NeruAnimateRecursiveGridTransition(
 	}
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		BOOL gridFamilyChanged =
-		    (fontFamily != controller.overlayView.cachedGridFontFamily &&
-		     ![fontFamily isEqualToString:controller.overlayView.cachedGridFontFamily]);
-		if (gridFamilyChanged || fontSize != controller.overlayView.cachedGridFontSize) {
-			NSFont *font = nil;
-			if (fontFamily && [fontFamily length] > 0) {
-				font = [controller.overlayView resolveFont:fontFamily size:fontSize bold:NO];
+		@autoreleasepool {
+			BOOL gridFamilyChanged =
+			    (fontFamily != controller.overlayView.cachedGridFontFamily &&
+			     ![fontFamily isEqualToString:controller.overlayView.cachedGridFontFamily]);
+			if (gridFamilyChanged || fontSize != controller.overlayView.cachedGridFontSize) {
+				NSFont *font = nil;
+				if (fontFamily && [fontFamily length] > 0) {
+					font = [controller.overlayView resolveFont:fontFamily size:fontSize bold:NO];
+				}
+				if (!font) {
+					font = [NSFont systemFontOfSize:fontSize];
+				}
+				controller.overlayView.gridFont = font;
+				controller.overlayView.cachedGridFontFamily = fontFamily;
+				controller.overlayView.cachedGridFontSize = fontSize;
 			}
-			if (!font) {
-				font = [NSFont systemFontOfSize:fontSize];
+
+			controller.overlayView.gridBackgroundColor = [controller.overlayView colorFromHex:bgHex
+			                                                                     defaultColor:[NSColor whiteColor]];
+			controller.overlayView.gridLabelBackgroundColor = [controller.overlayView
+			    colorFromHex:labelBgHex
+			    defaultColor:[[NSColor colorWithRed:1.0 green:0.84 blue:0.0 alpha:1.0] colorWithAlphaComponent:0.8]];
+			controller.overlayView.gridTextColor = [controller.overlayView colorFromHex:textHex
+			                                                               defaultColor:[NSColor blackColor]];
+			controller.overlayView.gridMatchedTextColor = [controller.overlayView colorFromHex:matchedTextHex
+			                                                                      defaultColor:[NSColor blueColor]];
+			controller.overlayView.gridMatchedBackgroundColor =
+			    [controller.overlayView colorFromHex:matchedBgHex defaultColor:[NSColor blueColor]];
+			controller.overlayView.gridMatchedBorderColor = [controller.overlayView colorFromHex:matchedBorderHex
+			                                                                        defaultColor:[NSColor blueColor]];
+			controller.overlayView.gridBorderColor = [controller.overlayView colorFromHex:borderHex
+			                                                                 defaultColor:[NSColor grayColor]];
+
+			controller.overlayView.gridBorderWidth = borderWidth > 0 ? borderWidth : 1.0;
+			controller.overlayView.gridDrawLabelBackground = drawLabelBackground;
+			controller.overlayView.gridLabelBackgroundPaddingX = labelBackgroundPaddingX;
+			controller.overlayView.gridLabelBackgroundPaddingY = labelBackgroundPaddingY;
+			controller.overlayView.gridLabelBackgroundBorderRadius = labelBackgroundBorderRadius;
+			controller.overlayView.gridLabelBackgroundBorderWidth = labelBackgroundBorderWidth;
+			controller.overlayView.gridDrawSubKeyPreview = drawSubKeyPreview;
+			controller.overlayView.gridSubKeyCols = subKeyGridCols;
+			controller.overlayView.gridSubKeyRows = subKeyGridRows;
+			controller.overlayView.gridSubKeyLabels = subKeyLabels;
+			if (drawSubKeyPreview) {
+				if (subKeyFontSize != controller.overlayView.cachedGridSubKeyFontSize) {
+					controller.overlayView.gridSubKeyFont = [NSFont systemFontOfSize:subKeyFontSize];
+					controller.overlayView.cachedGridSubKeyFontSize = subKeyFontSize;
+				}
+				controller.overlayView.gridSubKeyAutohideMultiplier = subKeyAutohideMultiplier;
+				controller.overlayView.gridSubKeyTextColor = [controller.overlayView colorFromHex:subKeyTextHex
+				                                                                     defaultColor:[NSColor grayColor]];
 			}
-			controller.overlayView.gridFont = font;
-			controller.overlayView.cachedGridFontFamily = fontFamily;
-			controller.overlayView.cachedGridFontSize = fontSize;
+
+			controller.overlayView.cachedGridTextColor = controller.overlayView.gridTextColor;
+			controller.overlayView.cachedGridMatchedTextColor = controller.overlayView.gridMatchedTextColor;
+			[controller.overlayView startGridTransitionToCells:cellItems duration:duration];
 		}
-
-		controller.overlayView.gridBackgroundColor = [controller.overlayView colorFromHex:bgHex
-		                                                                     defaultColor:[NSColor whiteColor]];
-		controller.overlayView.gridLabelBackgroundColor = [controller.overlayView
-		    colorFromHex:labelBgHex
-		    defaultColor:[[NSColor colorWithRed:1.0 green:0.84 blue:0.0 alpha:1.0] colorWithAlphaComponent:0.8]];
-		controller.overlayView.gridTextColor = [controller.overlayView colorFromHex:textHex
-		                                                               defaultColor:[NSColor blackColor]];
-		controller.overlayView.gridMatchedTextColor = [controller.overlayView colorFromHex:matchedTextHex
-		                                                                      defaultColor:[NSColor blueColor]];
-		controller.overlayView.gridMatchedBackgroundColor = [controller.overlayView colorFromHex:matchedBgHex
-		                                                                            defaultColor:[NSColor blueColor]];
-		controller.overlayView.gridMatchedBorderColor = [controller.overlayView colorFromHex:matchedBorderHex
-		                                                                        defaultColor:[NSColor blueColor]];
-		controller.overlayView.gridBorderColor = [controller.overlayView colorFromHex:borderHex
-		                                                                 defaultColor:[NSColor grayColor]];
-
-		controller.overlayView.gridBorderWidth = borderWidth > 0 ? borderWidth : 1.0;
-		controller.overlayView.gridDrawLabelBackground = drawLabelBackground;
-		controller.overlayView.gridLabelBackgroundPaddingX = labelBackgroundPaddingX;
-		controller.overlayView.gridLabelBackgroundPaddingY = labelBackgroundPaddingY;
-		controller.overlayView.gridLabelBackgroundBorderRadius = labelBackgroundBorderRadius;
-		controller.overlayView.gridLabelBackgroundBorderWidth = labelBackgroundBorderWidth;
-		controller.overlayView.gridDrawSubKeyPreview = drawSubKeyPreview;
-		controller.overlayView.gridSubKeyCols = subKeyGridCols;
-		controller.overlayView.gridSubKeyRows = subKeyGridRows;
-		controller.overlayView.gridSubKeyLabels = subKeyLabels;
-		if (drawSubKeyPreview) {
-			if (subKeyFontSize != controller.overlayView.cachedGridSubKeyFontSize) {
-				controller.overlayView.gridSubKeyFont = [NSFont systemFontOfSize:subKeyFontSize];
-				controller.overlayView.cachedGridSubKeyFontSize = subKeyFontSize;
-			}
-			controller.overlayView.gridSubKeyAutohideMultiplier = subKeyAutohideMultiplier;
-			controller.overlayView.gridSubKeyTextColor = [controller.overlayView colorFromHex:subKeyTextHex
-			                                                                     defaultColor:[NSColor grayColor]];
-		}
-
-		controller.overlayView.cachedGridTextColor = controller.overlayView.gridTextColor;
-		controller.overlayView.cachedGridMatchedTextColor = controller.overlayView.gridMatchedTextColor;
-		[controller.overlayView startGridTransitionToCells:cellItems duration:duration];
 	});
 }
 
@@ -2718,77 +2750,79 @@ void NeruUpdateGridMatchPrefix(OverlayWindow window, const char *prefix) {
 	NSString *prefixStr = prefix ? @(prefix) : @"";
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		OverlayView *view = controller.overlayView;
-		NSUInteger cellCount = [view.gridCells count];
-		if (cellCount == 0)
-			return;
+		@autoreleasepool {
+			OverlayView *view = controller.overlayView;
+			NSUInteger cellCount = [view.gridCells count];
+			if (cellCount == 0)
+				return;
 
-		NSUInteger prefixLen = [prefixStr length];
-		BOOL anyMatchStateChanged = NO;
+			NSUInteger prefixLen = [prefixStr length];
+			BOOL anyMatchStateChanged = NO;
 
-		// First pass: update all cells and track which ones changed.
-		// Use a stack-allocated array for small counts, heap for large.
-		BOOL stackFlags[256];
-		BOOL *changedFlags = cellCount <= 256 ? stackFlags : (BOOL *)calloc(cellCount, sizeof(BOOL));
-		NSUInteger changedCount = 0;
-		NSUInteger idx = 0;
+			// First pass: update all cells and track which ones changed.
+			// Use a stack-allocated array for small counts, heap for large.
+			BOOL stackFlags[256];
+			BOOL *changedFlags = cellCount <= 256 ? stackFlags : (BOOL *)calloc(cellCount, sizeof(BOOL));
+			NSUInteger changedCount = 0;
+			NSUInteger idx = 0;
 
-		for (GridCellItem *cellItem in view.gridCells) {
-			NSString *label = cellItem.label ?: @"";
-			BOOL newIsMatched = (prefixLen > 0 && [label hasPrefix:prefixStr]);
-			int newMatchedPrefixLength = newIsMatched ? (int)prefixLen : 0;
-			BOOL changed =
-			    (cellItem.isMatched != newIsMatched || cellItem.matchedPrefixLength != newMatchedPrefixLength);
+			for (GridCellItem *cellItem in view.gridCells) {
+				NSString *label = cellItem.label ?: @"";
+				BOOL newIsMatched = (prefixLen > 0 && [label hasPrefix:prefixStr]);
+				int newMatchedPrefixLength = newIsMatched ? (int)prefixLen : 0;
+				BOOL changed =
+				    (cellItem.isMatched != newIsMatched || cellItem.matchedPrefixLength != newMatchedPrefixLength);
 
-			if (cellItem.isMatched != newIsMatched) {
-				anyMatchStateChanged = YES;
-			}
-			if (changed) {
-				cellItem.isMatched = newIsMatched;
-				cellItem.matchedPrefixLength = newMatchedPrefixLength;
-				changedFlags[idx] = YES;
-				changedCount++;
-			} else {
-				changedFlags[idx] = NO;
-			}
-			idx++;
-		}
-
-		if (changedCount == 0) {
-			if (changedFlags != stackFlags)
-				free(changedFlags);
-			return;
-		}
-
-		// If hideUnmatched is active and cells toggled visibility, a full redraw is needed
-		if (view.hideUnmatched && anyMatchStateChanged) {
-			if (changedFlags != stackFlags)
-				free(changedFlags);
-			view.fullRedraw = YES;
-			[view setNeedsDisplay:YES];
-			return;
-		}
-
-		// Second pass: partial redraw — only invalidate changed cells
-		BOOL anyInvalidated = NO;
-		idx = 0;
-		for (GridCellItem *cellItem in view.gridCells) {
-			if (changedFlags[idx]) {
-				NSRect dirtyRect = [view screenRectForGridCell:cellItem];
-				if (!NSIsEmptyRect(dirtyRect)) {
-					[view setNeedsDisplayInRect:dirtyRect];
-					anyInvalidated = YES;
+				if (cellItem.isMatched != newIsMatched) {
+					anyMatchStateChanged = YES;
 				}
+				if (changed) {
+					cellItem.isMatched = newIsMatched;
+					cellItem.matchedPrefixLength = newMatchedPrefixLength;
+					changedFlags[idx] = YES;
+					changedCount++;
+				} else {
+					changedFlags[idx] = NO;
+				}
+				idx++;
 			}
-			idx++;
-		}
 
-		if (changedFlags != stackFlags)
-			free(changedFlags);
+			if (changedCount == 0) {
+				if (changedFlags != stackFlags)
+					free(changedFlags);
+				return;
+			}
 
-		if (anyInvalidated) {
-			// Signal partial redraw mode so drawLayer:inContext: uses the clip box
-			view.fullRedraw = NO;
+			// If hideUnmatched is active and cells toggled visibility, a full redraw is needed
+			if (view.hideUnmatched && anyMatchStateChanged) {
+				if (changedFlags != stackFlags)
+					free(changedFlags);
+				view.fullRedraw = YES;
+				[view setNeedsDisplay:YES];
+				return;
+			}
+
+			// Second pass: partial redraw — only invalidate changed cells
+			BOOL anyInvalidated = NO;
+			idx = 0;
+			for (GridCellItem *cellItem in view.gridCells) {
+				if (changedFlags[idx]) {
+					NSRect dirtyRect = [view screenRectForGridCell:cellItem];
+					if (!NSIsEmptyRect(dirtyRect)) {
+						[view setNeedsDisplayInRect:dirtyRect];
+						anyInvalidated = YES;
+					}
+				}
+				idx++;
+			}
+
+			if (changedFlags != stackFlags)
+				free(changedFlags);
+
+			if (anyInvalidated) {
+				// Signal partial redraw mode so drawLayer:inContext: uses the clip box
+				view.fullRedraw = NO;
+			}
 		}
 	});
 }
@@ -2806,7 +2840,9 @@ void NeruSetOverlayLevel(OverlayWindow window, int level) {
 		[controller.window setLevel:level];
 	} else {
 		dispatch_async(dispatch_get_main_queue(), ^{
-			[controller.window setLevel:level];
+			@autoreleasepool {
+				[controller.window setLevel:level];
+			}
 		});
 	}
 }
@@ -2821,8 +2857,10 @@ void NeruSetHideUnmatched(OverlayWindow window, int hide) {
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		controller.overlayView.hideUnmatched = hide ? YES : NO;
-		[controller.overlayView setNeedsDisplay:YES];
+		@autoreleasepool {
+			controller.overlayView.hideUnmatched = hide ? YES : NO;
+			[controller.overlayView setNeedsDisplay:YES];
+		}
 	});
 }
 
@@ -2836,8 +2874,10 @@ void NeruSetOverlaySharingType(OverlayWindow window, int sharingType) {
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		controller.sharingType = sharingType;
-		[controller.window setSharingType:sharingType];
+		@autoreleasepool {
+			controller.sharingType = sharingType;
+			[controller.window setSharingType:sharingType];
+		}
 	});
 }
 
@@ -2895,127 +2935,130 @@ void NeruDrawIncrementGrid(
 	CGFloat labelBackgroundBorderWidth = style.labelBackgroundBorderWidth;
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		// Apply font — only re-create when family or size changed
-		BOOL gridFamilyChanged =
-		    (fontFamily != controller.overlayView.cachedGridFontFamily &&
-		     ![fontFamily isEqualToString:controller.overlayView.cachedGridFontFamily]);
-		if (gridFamilyChanged || fontSize != controller.overlayView.cachedGridFontSize) {
-			NSFont *font = nil;
-			if (fontFamily && [fontFamily length] > 0) {
-				font = [controller.overlayView resolveFont:fontFamily size:fontSize bold:NO];
-			}
-			if (!font)
-				font = [NSFont systemFontOfSize:fontSize];
-			controller.overlayView.gridFont = font;
-			controller.overlayView.cachedGridFontFamily = fontFamily;
-			controller.overlayView.cachedGridFontSize = fontSize;
-		}
-
-		// Apply color updates if provided
-		if (bgHex) {
-			controller.overlayView.gridBackgroundColor = [controller.overlayView colorFromHex:bgHex
-			                                                                     defaultColor:[NSColor whiteColor]];
-		}
-		if (labelBgHex) {
-			controller.overlayView.gridLabelBackgroundColor = [controller.overlayView
-			    colorFromHex:labelBgHex
-			    defaultColor:[[NSColor colorWithRed:1.0 green:0.84 blue:0.0 alpha:1.0] colorWithAlphaComponent:0.8]];
-		}
-		if (textHex) {
-			controller.overlayView.gridTextColor = [controller.overlayView colorFromHex:textHex
-			                                                               defaultColor:[NSColor blackColor]];
-		}
-		if (matchedTextHex) {
-			controller.overlayView.gridMatchedTextColor = [controller.overlayView colorFromHex:matchedTextHex
-			                                                                      defaultColor:[NSColor blueColor]];
-		}
-		if (matchedBgHex) {
-			controller.overlayView.gridMatchedBackgroundColor =
-			    [controller.overlayView colorFromHex:matchedBgHex defaultColor:[NSColor blueColor]];
-		}
-		if (matchedBorderHex) {
-			controller.overlayView.gridMatchedBorderColor = [controller.overlayView colorFromHex:matchedBorderHex
-			                                                                        defaultColor:[NSColor blueColor]];
-		}
-		if (borderHex) {
-			controller.overlayView.gridBorderColor = [controller.overlayView colorFromHex:borderHex
-			                                                                 defaultColor:[NSColor grayColor]];
-		}
-
-		// Apply geometry and layout properties unconditionally.
-		// Previously borderWidth was gated behind the color guard and would be
-		// skipped if only borderWidth changed without any color properties.
-		if (borderWidth > 0) {
-			controller.overlayView.gridBorderWidth = borderWidth;
-		}
-		controller.overlayView.gridDrawLabelBackground = drawLabelBackground;
-		controller.overlayView.gridLabelBackgroundPaddingX = labelBackgroundPaddingX;
-		controller.overlayView.gridLabelBackgroundPaddingY = labelBackgroundPaddingY;
-		controller.overlayView.gridLabelBackgroundBorderRadius = labelBackgroundBorderRadius;
-		controller.overlayView.gridLabelBackgroundBorderWidth = labelBackgroundBorderWidth;
-
-		// Sync cached color references
-		controller.overlayView.cachedGridTextColor = controller.overlayView.gridTextColor;
-		controller.overlayView.cachedGridMatchedTextColor = controller.overlayView.gridMatchedTextColor;
-		[controller.overlayView cancelGridTransition];
-		[controller.overlayView cancelCursorIndicatorTransition];
-
-		// Remove cells matching the given bounds
-		if (boundsToRemove && [boundsToRemove count] > 0) {
-			// Build a set of bounds keys for O(1) lookup
-			NSMutableSet *boundsToRemoveSet = [NSMutableSet setWithCapacity:[boundsToRemove count]];
-			for (NSValue *removeBoundsValue in boundsToRemove) {
-				NSRect removeBounds = [removeBoundsValue rectValue];
-				NSString *key =
-				    [NSString stringWithFormat:@"%.6f,%.6f,%.6f,%.6f", removeBounds.origin.x, removeBounds.origin.y,
-				                               removeBounds.size.width, removeBounds.size.height];
-				[boundsToRemoveSet addObject:key];
-			}
-
-			NSMutableArray<GridCellItem *> *cellsToKeep =
-			    [NSMutableArray arrayWithCapacity:[controller.overlayView.gridCells count]];
-			for (GridCellItem *cellItem in controller.overlayView.gridCells) {
-				NSRect cellBounds = cellItem.bounds;
-				NSString *cellKey =
-				    [NSString stringWithFormat:@"%.6f,%.6f,%.6f,%.6f", cellBounds.origin.x, cellBounds.origin.y,
-				                               cellBounds.size.width, cellBounds.size.height];
-				if (![boundsToRemoveSet containsObject:cellKey]) {
-					[cellsToKeep addObject:cellItem];
+		@autoreleasepool {
+			// Apply font — only re-create when family or size changed
+			BOOL gridFamilyChanged =
+			    (fontFamily != controller.overlayView.cachedGridFontFamily &&
+			     ![fontFamily isEqualToString:controller.overlayView.cachedGridFontFamily]);
+			if (gridFamilyChanged || fontSize != controller.overlayView.cachedGridFontSize) {
+				NSFont *font = nil;
+				if (fontFamily && [fontFamily length] > 0) {
+					font = [controller.overlayView resolveFont:fontFamily size:fontSize bold:NO];
 				}
-			}
-			controller.overlayView.gridCells = cellsToKeep;
-		}
-
-		// Add or update cells
-		if (cellItemsToAdd && [cellItemsToAdd count] > 0) {
-			// Build lookup map for existing cells by bounds for O(1) access
-			NSMutableDictionary *cellsByBounds =
-			    [NSMutableDictionary dictionaryWithCapacity:[controller.overlayView.gridCells count]];
-			for (GridCellItem *cellItem in controller.overlayView.gridCells) {
-				NSRect bounds = cellItem.bounds;
-				NSString *key = [NSString stringWithFormat:@"%.6f,%.6f,%.6f,%.6f", bounds.origin.x, bounds.origin.y,
-				                                           bounds.size.width, bounds.size.height];
-				cellsByBounds[key] = cellItem;
+				if (!font)
+					font = [NSFont systemFontOfSize:fontSize];
+				controller.overlayView.gridFont = font;
+				controller.overlayView.cachedGridFontFamily = fontFamily;
+				controller.overlayView.cachedGridFontSize = fontSize;
 			}
 
-			for (GridCellItem *newCellItem in cellItemsToAdd) {
-				NSRect newBounds = newCellItem.bounds;
-				NSString *key =
-				    [NSString stringWithFormat:@"%.6f,%.6f,%.6f,%.6f", newBounds.origin.x, newBounds.origin.y,
-				                               newBounds.size.width, newBounds.size.height];
-				GridCellItem *existingCell = cellsByBounds[key];
-				if (existingCell) {
-					NSUInteger index = [controller.overlayView.gridCells indexOfObjectIdenticalTo:existingCell];
-					if (index != NSNotFound) {
-						controller.overlayView.gridCells[index] = newCellItem;
+			// Apply color updates if provided
+			if (bgHex) {
+				controller.overlayView.gridBackgroundColor = [controller.overlayView colorFromHex:bgHex
+				                                                                     defaultColor:[NSColor whiteColor]];
+			}
+			if (labelBgHex) {
+				controller.overlayView.gridLabelBackgroundColor =
+				    [controller.overlayView colorFromHex:labelBgHex
+				                            defaultColor:[[NSColor colorWithRed:1.0 green:0.84 blue:0.0
+				                                                          alpha:1.0] colorWithAlphaComponent:0.8]];
+			}
+			if (textHex) {
+				controller.overlayView.gridTextColor = [controller.overlayView colorFromHex:textHex
+				                                                               defaultColor:[NSColor blackColor]];
+			}
+			if (matchedTextHex) {
+				controller.overlayView.gridMatchedTextColor = [controller.overlayView colorFromHex:matchedTextHex
+				                                                                      defaultColor:[NSColor blueColor]];
+			}
+			if (matchedBgHex) {
+				controller.overlayView.gridMatchedBackgroundColor =
+				    [controller.overlayView colorFromHex:matchedBgHex defaultColor:[NSColor blueColor]];
+			}
+			if (matchedBorderHex) {
+				controller.overlayView.gridMatchedBorderColor =
+				    [controller.overlayView colorFromHex:matchedBorderHex defaultColor:[NSColor blueColor]];
+			}
+			if (borderHex) {
+				controller.overlayView.gridBorderColor = [controller.overlayView colorFromHex:borderHex
+				                                                                 defaultColor:[NSColor grayColor]];
+			}
+
+			// Apply geometry and layout properties unconditionally.
+			// Previously borderWidth was gated behind the color guard and would be
+			// skipped if only borderWidth changed without any color properties.
+			if (borderWidth > 0) {
+				controller.overlayView.gridBorderWidth = borderWidth;
+			}
+			controller.overlayView.gridDrawLabelBackground = drawLabelBackground;
+			controller.overlayView.gridLabelBackgroundPaddingX = labelBackgroundPaddingX;
+			controller.overlayView.gridLabelBackgroundPaddingY = labelBackgroundPaddingY;
+			controller.overlayView.gridLabelBackgroundBorderRadius = labelBackgroundBorderRadius;
+			controller.overlayView.gridLabelBackgroundBorderWidth = labelBackgroundBorderWidth;
+
+			// Sync cached color references
+			controller.overlayView.cachedGridTextColor = controller.overlayView.gridTextColor;
+			controller.overlayView.cachedGridMatchedTextColor = controller.overlayView.gridMatchedTextColor;
+			[controller.overlayView cancelGridTransition];
+			[controller.overlayView cancelCursorIndicatorTransition];
+
+			// Remove cells matching the given bounds
+			if (boundsToRemove && [boundsToRemove count] > 0) {
+				// Build a set of bounds keys for O(1) lookup
+				NSMutableSet *boundsToRemoveSet = [NSMutableSet setWithCapacity:[boundsToRemove count]];
+				for (NSValue *removeBoundsValue in boundsToRemove) {
+					NSRect removeBounds = [removeBoundsValue rectValue];
+					NSString *key =
+					    [NSString stringWithFormat:@"%.6f,%.6f,%.6f,%.6f", removeBounds.origin.x, removeBounds.origin.y,
+					                               removeBounds.size.width, removeBounds.size.height];
+					[boundsToRemoveSet addObject:key];
+				}
+
+				NSMutableArray<GridCellItem *> *cellsToKeep =
+				    [NSMutableArray arrayWithCapacity:[controller.overlayView.gridCells count]];
+				for (GridCellItem *cellItem in controller.overlayView.gridCells) {
+					NSRect cellBounds = cellItem.bounds;
+					NSString *cellKey =
+					    [NSString stringWithFormat:@"%.6f,%.6f,%.6f,%.6f", cellBounds.origin.x, cellBounds.origin.y,
+					                               cellBounds.size.width, cellBounds.size.height];
+					if (![boundsToRemoveSet containsObject:cellKey]) {
+						[cellsToKeep addObject:cellItem];
 					}
-				} else {
-					[controller.overlayView.gridCells addObject:newCellItem];
+				}
+				controller.overlayView.gridCells = cellsToKeep;
+			}
+
+			// Add or update cells
+			if (cellItemsToAdd && [cellItemsToAdd count] > 0) {
+				// Build lookup map for existing cells by bounds for O(1) access
+				NSMutableDictionary *cellsByBounds =
+				    [NSMutableDictionary dictionaryWithCapacity:[controller.overlayView.gridCells count]];
+				for (GridCellItem *cellItem in controller.overlayView.gridCells) {
+					NSRect bounds = cellItem.bounds;
+					NSString *key = [NSString stringWithFormat:@"%.6f,%.6f,%.6f,%.6f", bounds.origin.x, bounds.origin.y,
+					                                           bounds.size.width, bounds.size.height];
+					cellsByBounds[key] = cellItem;
+				}
+
+				for (GridCellItem *newCellItem in cellItemsToAdd) {
+					NSRect newBounds = newCellItem.bounds;
+					NSString *key =
+					    [NSString stringWithFormat:@"%.6f,%.6f,%.6f,%.6f", newBounds.origin.x, newBounds.origin.y,
+					                               newBounds.size.width, newBounds.size.height];
+					GridCellItem *existingCell = cellsByBounds[key];
+					if (existingCell) {
+						NSUInteger index = [controller.overlayView.gridCells indexOfObjectIdenticalTo:existingCell];
+						if (index != NSNotFound) {
+							controller.overlayView.gridCells[index] = newCellItem;
+						}
+					} else {
+						[controller.overlayView.gridCells addObject:newCellItem];
+					}
 				}
 			}
-		}
 
-		[controller.overlayView setNeedsDisplay:YES];
+			[controller.overlayView setNeedsDisplay:YES];
+		}
 	});
 }
 
@@ -3033,22 +3076,24 @@ void NeruShowCursorIndicator(OverlayWindow window, CGPoint position, CursorIndic
 	NSString *fillHex = style.fillColor ? @(style.fillColor) : nil;
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		NSPoint nextPosition = NSMakePoint(position.x, position.y);
-		if (controller.overlayView.gridTransitionActive && controller.overlayView.cursorIndicatorVisible) {
-			controller.overlayView.cursorIndicatorFromPosition =
-			    [controller.overlayView currentCursorIndicatorPosition];
-			controller.overlayView.cursorIndicatorToPosition = nextPosition;
-			controller.overlayView.cursorIndicatorTransitionActive = YES;
-		} else {
-			[controller.overlayView cancelCursorIndicatorTransition];
-		}
+		@autoreleasepool {
+			NSPoint nextPosition = NSMakePoint(position.x, position.y);
+			if (controller.overlayView.gridTransitionActive && controller.overlayView.cursorIndicatorVisible) {
+				controller.overlayView.cursorIndicatorFromPosition =
+				    [controller.overlayView currentCursorIndicatorPosition];
+				controller.overlayView.cursorIndicatorToPosition = nextPosition;
+				controller.overlayView.cursorIndicatorTransitionActive = YES;
+			} else {
+				[controller.overlayView cancelCursorIndicatorTransition];
+			}
 
-		controller.overlayView.cursorIndicatorVisible = YES;
-		controller.overlayView.cursorIndicatorPosition = nextPosition;
-		controller.overlayView.cursorIndicatorRadius = radius;
-		controller.overlayView.cursorIndicatorFillColor = [controller.overlayView colorFromHex:fillHex
-		                                                                          defaultColor:[NSColor whiteColor]];
-		[controller.overlayView setNeedsDisplay:YES];
+			controller.overlayView.cursorIndicatorVisible = YES;
+			controller.overlayView.cursorIndicatorPosition = nextPosition;
+			controller.overlayView.cursorIndicatorRadius = radius;
+			controller.overlayView.cursorIndicatorFillColor =
+			    [controller.overlayView colorFromHex:fillHex defaultColor:[NSColor whiteColor]];
+			[controller.overlayView setNeedsDisplay:YES];
+		}
 	});
 }
 
@@ -3061,19 +3106,21 @@ void NeruHideCursorIndicator(OverlayWindow window) {
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		if (!controller.overlayView.cursorIndicatorVisible)
-			return;
+		@autoreleasepool {
+			if (!controller.overlayView.cursorIndicatorVisible)
+				return;
 
-		NSRect dirtyRect = [controller.overlayView cursorIndicatorRect];
-		[controller.overlayView cancelCursorIndicatorTransition];
-		controller.overlayView.cursorIndicatorVisible = NO;
-		if (NSIsEmptyRect(dirtyRect)) {
-			[controller.overlayView setNeedsDisplay:YES];
-			return;
+			NSRect dirtyRect = [controller.overlayView cursorIndicatorRect];
+			[controller.overlayView cancelCursorIndicatorTransition];
+			controller.overlayView.cursorIndicatorVisible = NO;
+			if (NSIsEmptyRect(dirtyRect)) {
+				[controller.overlayView setNeedsDisplay:YES];
+				return;
+			}
+
+			controller.overlayView.fullRedraw = NO;
+			[controller.overlayView setNeedsDisplayInRect:dirtyRect];
 		}
-
-		controller.overlayView.fullRedraw = NO;
-		[controller.overlayView setNeedsDisplayInRect:dirtyRect];
 	});
 }
 
@@ -3154,6 +3201,8 @@ static NSPoint NeruAppKitPointFromQuartzPoint(CGPoint point) {
 /// @param style Indicator style
 static _Atomic int _NeruMouseActionPanelCount = 0;
 static const int _NeruMaxMouseActionPanels = 10;
+static NSMutableSet *_NeruMouseActionPanels;
+static dispatch_once_t _NeruMouseActionPanelsOnceToken;
 
 void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle style) {
 	NSString *backgroundHex = style.backgroundColor ? @(style.backgroundColor) : nil;
@@ -3161,82 +3210,99 @@ void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle st
 	NSString *shape = style.shape ? @(style.shape) : @"circle";
 	NSString *easing = style.easing ? @(style.easing) : @"ease_out";
 
+	dispatch_once(&_NeruMouseActionPanelsOnceToken, ^{
+		_NeruMouseActionPanels = [NSMutableSet set];
+	});
+
 	dispatch_async(dispatch_get_main_queue(), ^{
-		if (atomic_load(&_NeruMouseActionPanelCount) >= _NeruMaxMouseActionPanels) {
-			return;
+		@autoreleasepool {
+			if (atomic_load(&_NeruMouseActionPanelCount) >= _NeruMaxMouseActionPanels) {
+				return;
+			}
+			CGFloat size = MAX(style.size, 1);
+			CGFloat endScale = style.endScale > 0 ? style.endScale : 1.0;
+			CGFloat maxScale = MAX(style.startScale > 0 ? style.startScale : 1.0, MAX(endScale, 1.0));
+			CGFloat canvasSize = ceil(size * maxScale + MAX(style.borderWidth, 0) * 4.0);
+			NSPoint center = NeruAppKitPointFromQuartzPoint(position);
+			NSRect frame = NSMakeRect(center.x - canvasSize / 2.0, center.y - canvasSize / 2.0, canvasSize, canvasSize);
+
+			NSPanel *panel =
+			    [[NSPanel alloc] initWithContentRect:frame
+			                               styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
+			                                 backing:NSBackingStoreBuffered
+			                                   defer:NO];
+			[panel setHidesOnDeactivate:NO];
+			[panel setReleasedWhenClosed:NO];
+			[panel setLevel:kCGMaximumWindowLevel];
+			[panel setOpaque:NO];
+			[panel setBackgroundColor:[NSColor clearColor]];
+			[panel setIgnoresMouseEvents:YES];
+			[panel setAcceptsMouseMovedEvents:NO];
+			[panel setHasShadow:NO];
+			[panel setSharingType:style.hideInScreenShare ? NSWindowSharingNone : NSWindowSharingReadOnly];
+			[panel setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
+			                             NSWindowCollectionBehaviorStationary |
+			                             NSWindowCollectionBehaviorFullScreenAuxiliary |
+			                             NSWindowCollectionBehaviorIgnoresCycle];
+			atomic_fetch_add(&_NeruMouseActionPanelCount, 1);
+			[_NeruMouseActionPanels addObject:panel];
+
+			NSView *view = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, canvasSize, canvasSize)];
+			view.wantsLayer = YES;
+			view.layer.backgroundColor = NSColor.clearColor.CGColor;
+			[panel setContentView:view];
+
+			CGRect indicatorRect = CGRectMake((canvasSize - size) / 2.0, (canvasSize - size) / 2.0, size, size);
+			CGFloat cornerRadius = [shape isEqualToString:@"square"] ? MAX(size * 0.18, 2.0) : size / 2.0;
+
+			CAShapeLayer *layer = [CAShapeLayer layer];
+			layer.frame = view.bounds;
+			CGPathRef path = CGPathCreateWithRoundedRect(indicatorRect, cornerRadius, cornerRadius, NULL);
+			layer.path = path;
+			CGPathRelease(path);
+			layer.fillColor = NeruColorFromHexString(backgroundHex, [NSColor clearColor]).CGColor;
+			layer.strokeColor = NeruColorFromHexString(borderHex, [NSColor whiteColor]).CGColor;
+			layer.lineWidth = MAX(style.borderWidth, 0);
+			layer.opacity = style.startOpacity;
+			[view.layer addSublayer:layer];
+
+			[panel orderFrontRegardless];
+
+			CFTimeInterval duration = MAX(style.durationMS, 1) / 1000.0;
+			CAMediaTimingFunction *timing = NeruTimingFunction(easing);
+
+			CABasicAnimation *scaleAnimation = [CABasicAnimation animationWithKeyPath:@"transform.scale"];
+			scaleAnimation.fromValue = @(style.startScale);
+			scaleAnimation.toValue = @(style.endScale);
+			scaleAnimation.duration = duration;
+			scaleAnimation.timingFunction = timing;
+
+			CABasicAnimation *opacityAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
+			opacityAnimation.fromValue = @(style.startOpacity);
+			opacityAnimation.toValue = @(style.endOpacity);
+			opacityAnimation.duration = duration;
+			opacityAnimation.timingFunction = timing;
+
+			layer.transform = CATransform3DMakeScale(style.endScale, style.endScale, 1.0);
+			layer.opacity = style.endOpacity;
+			[layer addAnimation:scaleAnimation forKey:@"mouseActionScale"];
+			[layer addAnimation:opacityAnimation forKey:@"mouseActionOpacity"];
+
+			__weak NSPanel *weakPanel = panel;
+			dispatch_after(
+			    dispatch_time(DISPATCH_TIME_NOW, (int64_t)(duration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+				    @autoreleasepool {
+					    NSPanel *strongPanel = weakPanel;
+					    if (!strongPanel)
+						    return;
+					    [strongPanel.contentView.layer removeAllAnimations];
+					    [strongPanel setContentView:nil];
+					    [strongPanel orderOut:nil];
+					    [strongPanel close];
+					    [_NeruMouseActionPanels removeObject:strongPanel];
+					    atomic_fetch_add(&_NeruMouseActionPanelCount, -1);
+				    }
+			    });
 		}
-		CGFloat size = MAX(style.size, 1);
-		CGFloat endScale = style.endScale > 0 ? style.endScale : 1.0;
-		CGFloat maxScale = MAX(style.startScale > 0 ? style.startScale : 1.0, MAX(endScale, 1.0));
-		CGFloat canvasSize = ceil(size * maxScale + MAX(style.borderWidth, 0) * 4.0);
-		NSPoint center = NeruAppKitPointFromQuartzPoint(position);
-		NSRect frame = NSMakeRect(center.x - canvasSize / 2.0, center.y - canvasSize / 2.0, canvasSize, canvasSize);
-
-		NSPanel *panel =
-		    [[NSPanel alloc] initWithContentRect:frame
-		                               styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
-		                                 backing:NSBackingStoreBuffered
-		                                   defer:NO];
-		[panel setHidesOnDeactivate:NO];
-		[panel setReleasedWhenClosed:NO];
-		[panel setLevel:kCGMaximumWindowLevel];
-		[panel setOpaque:NO];
-		[panel setBackgroundColor:[NSColor clearColor]];
-		[panel setIgnoresMouseEvents:YES];
-		[panel setAcceptsMouseMovedEvents:NO];
-		[panel setHasShadow:NO];
-		[panel setSharingType:style.hideInScreenShare ? NSWindowSharingNone : NSWindowSharingReadOnly];
-		[panel setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorStationary |
-		                             NSWindowCollectionBehaviorFullScreenAuxiliary |
-		                             NSWindowCollectionBehaviorIgnoresCycle];
-		atomic_fetch_add(&_NeruMouseActionPanelCount, 1);
-
-		NSView *view = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, canvasSize, canvasSize)];
-		view.wantsLayer = YES;
-		view.layer.backgroundColor = NSColor.clearColor.CGColor;
-		[panel setContentView:view];
-
-		CGRect indicatorRect = CGRectMake((canvasSize - size) / 2.0, (canvasSize - size) / 2.0, size, size);
-		CGFloat cornerRadius = [shape isEqualToString:@"square"] ? MAX(size * 0.18, 2.0) : size / 2.0;
-
-		CAShapeLayer *layer = [CAShapeLayer layer];
-		layer.frame = view.bounds;
-		CGPathRef path = CGPathCreateWithRoundedRect(indicatorRect, cornerRadius, cornerRadius, NULL);
-		layer.path = path;
-		CGPathRelease(path);
-		layer.fillColor = NeruColorFromHexString(backgroundHex, [NSColor clearColor]).CGColor;
-		layer.strokeColor = NeruColorFromHexString(borderHex, [NSColor whiteColor]).CGColor;
-		layer.lineWidth = MAX(style.borderWidth, 0);
-		layer.opacity = style.startOpacity;
-		[view.layer addSublayer:layer];
-
-		[panel orderFrontRegardless];
-
-		CFTimeInterval duration = MAX(style.durationMS, 1) / 1000.0;
-		CAMediaTimingFunction *timing = NeruTimingFunction(easing);
-
-		CABasicAnimation *scaleAnimation = [CABasicAnimation animationWithKeyPath:@"transform.scale"];
-		scaleAnimation.fromValue = @(style.startScale);
-		scaleAnimation.toValue = @(style.endScale);
-		scaleAnimation.duration = duration;
-		scaleAnimation.timingFunction = timing;
-
-		CABasicAnimation *opacityAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
-		opacityAnimation.fromValue = @(style.startOpacity);
-		opacityAnimation.toValue = @(style.endOpacity);
-		opacityAnimation.duration = duration;
-		opacityAnimation.timingFunction = timing;
-
-		layer.transform = CATransform3DMakeScale(style.endScale, style.endScale, 1.0);
-		layer.opacity = style.endOpacity;
-		[layer addAnimation:scaleAnimation forKey:@"mouseActionScale"];
-		[layer addAnimation:opacityAnimation forKey:@"mouseActionOpacity"];
-
-		dispatch_after(
-		    dispatch_time(DISPATCH_TIME_NOW, (int64_t)(duration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-			    [panel orderOut:nil];
-			    [panel close];
-			    atomic_fetch_add(&_NeruMouseActionPanelCount, -1);
-		    });
 	});
 }

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -2144,12 +2144,14 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 			    .boundaryBorderColor = safe_strdup(style.boundaryBorderColor)};
 
 			dispatch_async(dispatch_get_main_queue(), ^{
-				[controller.overlayView.hints removeAllObjects];
-				[controller.overlayView applyStyle:styleCopy];
-				[controller.overlayView.hints addObjectsFromArray:hintItems];
-				[controller.overlayView setNeedsDisplay:YES];
+				@autoreleasepool {
+					[controller.overlayView.hints removeAllObjects];
+					[controller.overlayView applyStyle:styleCopy];
+					[controller.overlayView.hints addObjectsFromArray:hintItems];
+					[controller.overlayView setNeedsDisplay:YES];
 
-				free_hint_style_strings(&styleCopy);
+					free_hint_style_strings(&styleCopy);
+				}
 			});
 		}
 	}

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -2091,45 +2091,47 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 	if (!window || !hints)
 		return;
 
-	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
+	@autoreleasepool {
+		OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
-	// Build hint items upfront — safe from any thread
-	NSMutableArray<HintItem *> *hintItems = buildHintItems(hints, count, style.showArrow ? YES : NO, style.placement);
+		// Build hint items upfront — safe from any thread
+		NSMutableArray<HintItem *> *hintItems = buildHintItems(hints, count, style.showArrow ? YES : NO, style.placement);
 
-	if ([NSThread isMainThread]) {
-		[controller.overlayView.hints removeAllObjects];
-		[controller.overlayView applyStyle:style];
-		[controller.overlayView.hints addObjectsFromArray:hintItems];
-		[controller.overlayView setNeedsDisplay:YES];
-	} else {
-		// Copy style strings before crossing the thread boundary
-		HintStyle styleCopy = {
-		    .fontSize = style.fontSize,
-		    .borderRadius = style.borderRadius,
-		    .borderWidth = style.borderWidth,
-		    .paddingX = style.paddingX,
-		    .paddingY = style.paddingY,
-		    .showArrow = style.showArrow,
-		    .placement = style.placement,
-		    .boundaryHighlightEnabled = style.boundaryHighlightEnabled,
-		    .boundaryBorderWidth = style.boundaryBorderWidth,
-		    .boundaryBorderRadius = style.boundaryBorderRadius,
-		    .fontFamily = safe_strdup(style.fontFamily),
-		    .backgroundColor = safe_strdup(style.backgroundColor),
-		    .textColor = safe_strdup(style.textColor),
-		    .matchedTextColor = safe_strdup(style.matchedTextColor),
-		    .borderColor = safe_strdup(style.borderColor),
-		    .boundaryBackgroundColor = safe_strdup(style.boundaryBackgroundColor),
-		    .boundaryBorderColor = safe_strdup(style.boundaryBorderColor)};
-
-		dispatch_async(dispatch_get_main_queue(), ^{
+		if ([NSThread isMainThread]) {
 			[controller.overlayView.hints removeAllObjects];
-			[controller.overlayView applyStyle:styleCopy];
+			[controller.overlayView applyStyle:style];
 			[controller.overlayView.hints addObjectsFromArray:hintItems];
 			[controller.overlayView setNeedsDisplay:YES];
+		} else {
+			// Copy style strings before crossing the thread boundary
+			HintStyle styleCopy = {
+			    .fontSize = style.fontSize,
+			    .borderRadius = style.borderRadius,
+			    .borderWidth = style.borderWidth,
+			    .paddingX = style.paddingX,
+			    .paddingY = style.paddingY,
+			    .showArrow = style.showArrow,
+			    .placement = style.placement,
+			    .boundaryHighlightEnabled = style.boundaryHighlightEnabled,
+			    .boundaryBorderWidth = style.boundaryBorderWidth,
+			    .boundaryBorderRadius = style.boundaryBorderRadius,
+			    .fontFamily = safe_strdup(style.fontFamily),
+			    .backgroundColor = safe_strdup(style.backgroundColor),
+			    .textColor = safe_strdup(style.textColor),
+			    .matchedTextColor = safe_strdup(style.matchedTextColor),
+			    .borderColor = safe_strdup(style.borderColor),
+			    .boundaryBackgroundColor = safe_strdup(style.boundaryBackgroundColor),
+			    .boundaryBorderColor = safe_strdup(style.boundaryBorderColor)};
 
-			free_hint_style_strings(&styleCopy);
-		});
+			dispatch_async(dispatch_get_main_queue(), ^{
+				[controller.overlayView.hints removeAllObjects];
+				[controller.overlayView applyStyle:styleCopy];
+				[controller.overlayView.hints addObjectsFromArray:hintItems];
+				[controller.overlayView setNeedsDisplay:YES];
+
+				free_hint_style_strings(&styleCopy);
+			});
+		}
 	}
 }
 

--- a/internal/core/infra/platform/darwin/scroll_animator.go
+++ b/internal/core/infra/platform/darwin/scroll_animator.go
@@ -8,7 +8,6 @@ package darwin
 import "C"
 
 import (
-	"context"
 	"math"
 	"sync"
 	"time"
@@ -17,29 +16,33 @@ import (
 const (
 	minScrollAnimationDuration = 10 // Minimum animation duration in ms
 	minScrollStepDelay         = 1  // Minimum delay between steps in ms
-	scrollDrainTimeoutBufferMs = 50 // Extra grace period while draining a canceled animation.
 	easeOutCubicExponent       = 3  // Exponent for ease-out cubic easing
 )
 
+type scrollRequest struct {
+	deltaX, deltaY   int
+	steps            int
+	maxDuration      int
+	durationPerPixel float64
+}
+
 type scrollAnimator struct {
-	cancel context.CancelFunc
-	done   chan struct{}
-	gen    uint64
 	mu     sync.Mutex
+	reqCh  chan scrollRequest
+	stopCh chan struct{}
 }
 
 var scrollAnim scrollAnimator
 
 func (a *scrollAnimator) stop() {
 	a.mu.Lock()
-	cancel := a.cancel
-	a.gen++
-	a.cancel = nil
-	a.done = nil
+	stopCh := a.stopCh
+	a.reqCh = nil
+	a.stopCh = nil
 	a.mu.Unlock()
 
-	if cancel != nil {
-		cancel()
+	if stopCh != nil {
+		close(stopCh)
 	}
 }
 
@@ -49,132 +52,141 @@ func (a *scrollAnimator) animate(
 	maxDuration int,
 	durationPerPixel float64,
 ) {
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
-	a.mu.Lock()
-	prevCancel := a.cancel
-	prevDone := a.done
-	a.gen++
-	gen := a.gen
-	a.cancel = cancel
-	a.done = done
-	a.mu.Unlock()
-
-	if prevCancel != nil {
-		prevCancel()
+	req := scrollRequest{
+		deltaX:           deltaX,
+		deltaY:           deltaY,
+		steps:            steps,
+		maxDuration:      maxDuration,
+		durationPerPixel: durationPerPixel,
 	}
 
-	a.waitForPreviousAnimation(prevDone)
-
-	a.mu.Lock()
-	if a.gen != gen || a.done != done {
-		a.mu.Unlock()
-		close(done)
-		cancel()
-
-		return
+	reqCh := a.ensureWorker()
+	select {
+	case reqCh <- req:
+	default:
+		select {
+		case <-reqCh:
+		default:
+		}
+		reqCh <- req
 	}
-	a.mu.Unlock()
-
-	go func(runGen uint64) {
-		defer close(done)
-		defer cancel()
-		defer a.clearIfCurrent(runGen, done)
-
-		magnitude := math.Hypot(float64(deltaX), float64(deltaY))
-		if magnitude == 0 {
-			return
-		}
-
-		duration := math.Min(float64(maxDuration), magnitude*durationPerPixel)
-		if duration < minScrollAnimationDuration {
-			duration = minScrollAnimationDuration
-		}
-
-		actualSteps := steps
-		if actualSteps <= 0 {
-			actualSteps = 12
-		}
-
-		maxSteps := max(int(duration/float64(minScrollStepDelay)), 1)
-		if actualSteps > maxSteps {
-			actualSteps = maxSteps
-		}
-
-		stepDelayMs := max(int(math.Round(duration/float64(actualSteps))), minScrollStepDelay)
-
-		stepDelay := time.Duration(stepDelayMs) * time.Millisecond
-
-		var prevX, prevY int
-
-		for step := 1; step <= actualSteps; step++ {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			cursorPos := CursorPosition()
-			cgPos := C.CGPoint{x: C.double(cursorPos.X), y: C.double(cursorPos.Y)}
-
-			t := float64(step) / float64(actualSteps)
-			eased := 1 - math.Pow(1-t, easeOutCubicExponent)
-
-			targetX := int(math.Round(float64(deltaX) * eased))
-			targetY := int(math.Round(float64(deltaY) * eased))
-
-			chunkX := targetX - prevX
-			chunkY := targetY - prevY
-			prevX = targetX
-			prevY = targetY
-
-			C.scrollAtPoint(cgPos, C.int(chunkX), C.int(chunkY))
-
-			if step < actualSteps {
-				timer := time.NewTimer(stepDelay)
-				select {
-				case <-ctx.Done():
-					timer.Stop()
-
-					return
-				case <-timer.C:
-				}
-			}
-		}
-	}(gen)
 }
 
-func (a *scrollAnimator) clearIfCurrent(gen uint64, done chan struct{}) {
+func (a *scrollAnimator) ensureWorker() chan scrollRequest {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if a.gen == gen && a.done == done {
-		a.cancel = nil
-		a.done = nil
+	if a.reqCh != nil {
+		return a.reqCh
+	}
+
+	reqCh := make(chan scrollRequest, 1)
+	stopCh := make(chan struct{})
+	a.reqCh = reqCh
+	a.stopCh = stopCh
+
+	go a.run(reqCh, stopCh)
+
+	return reqCh
+}
+
+func (a *scrollAnimator) run(reqCh <-chan scrollRequest, stopCh <-chan struct{}) {
+	timer := time.NewTimer(time.Hour)
+	stopAndDrainTimer(timer)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		case req := <-reqCh:
+			a.runRequest(req, reqCh, stopCh, timer)
+		}
 	}
 }
 
-func (a *scrollAnimator) waitForPreviousAnimation(prevDone chan struct{}) {
-	if prevDone == nil {
+func (a *scrollAnimator) runRequest(
+	req scrollRequest,
+	reqCh <-chan scrollRequest,
+	stopCh <-chan struct{},
+	timer *time.Timer,
+) {
+restart:
+	magnitude := math.Hypot(float64(req.deltaX), float64(req.deltaY))
+	if magnitude == 0 {
 		return
 	}
 
-	timeout := previousScrollAnimationDrainTimeout()
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
+	duration := math.Min(float64(req.maxDuration), magnitude*req.durationPerPixel)
+	if duration < minScrollAnimationDuration {
+		duration = minScrollAnimationDuration
+	}
 
-	select {
-	case <-prevDone:
-	case <-timer.C:
+	actualSteps := req.steps
+	if actualSteps <= 0 {
+		actualSteps = 12
+	}
+
+	maxSteps := max(int(duration/float64(minScrollStepDelay)), 1)
+	if actualSteps > maxSteps {
+		actualSteps = maxSteps
+	}
+
+	stepDelayMs := max(int(math.Round(duration/float64(actualSteps))), minScrollStepDelay)
+
+	stepDelay := time.Duration(stepDelayMs) * time.Millisecond
+
+	var prevX, prevY int
+
+	for step := 1; step <= actualSteps; step++ {
+		select {
+		case <-stopCh:
+			return
+		case req = <-reqCh:
+			goto restart
+		default:
+		}
+
+		cursorPos := CursorPosition()
+		cgPos := C.CGPoint{x: C.double(cursorPos.X), y: C.double(cursorPos.Y)}
+
+		t := float64(step) / float64(actualSteps)
+		eased := 1 - math.Pow(1-t, easeOutCubicExponent)
+
+		targetX := int(math.Round(float64(req.deltaX) * eased))
+		targetY := int(math.Round(float64(req.deltaY) * eased))
+
+		chunkX := targetX - prevX
+		chunkY := targetY - prevY
+		prevX = targetX
+		prevY = targetY
+
+		C.scrollAtPoint(cgPos, C.int(chunkX), C.int(chunkY))
+
+		if step < actualSteps {
+			timer.Reset(stepDelay)
+			select {
+			case <-stopCh:
+				stopAndDrainTimer(timer)
+
+				return
+			case req = <-reqCh:
+				stopAndDrainTimer(timer)
+
+				goto restart
+			case <-timer.C:
+			}
+		}
 	}
 }
 
-func previousScrollAnimationDrainTimeout() time.Duration {
-	cfg := currentConfig()
-	maxDurationMs := 180
-	if cfg != nil && cfg.SmoothScroll.MaxDuration >= 0 {
-		maxDurationMs = cfg.SmoothScroll.MaxDuration
+func stopAndDrainTimer(timer *time.Timer) {
+	if timer.Stop() {
+		return
 	}
 
-	return time.Duration(maxDurationMs+scrollDrainTimeoutBufferMs) * time.Millisecond
+	select {
+	case <-timer.C:
+	default:
+	}
 }

--- a/internal/core/infra/platform/darwin/scroll_animator.go
+++ b/internal/core/infra/platform/darwin/scroll_animator.go
@@ -39,11 +39,11 @@ func (a *scrollAnimator) stop() {
 	stopCh := a.stopCh
 	a.reqCh = nil
 	a.stopCh = nil
-	a.mu.Unlock()
 
 	if stopCh != nil {
 		close(stopCh)
 	}
+	a.mu.Unlock()
 }
 
 func (a *scrollAnimator) animate(


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fix some progressive memory leaks during normal usage:

- goroutine leak race conditions for animators (cursor, scroll)
- mouse action indicator nspanel leaks
- added missing autoreleasepool in our `dispatch_async` calls
- added missing `-dealloc` for overlays
- added safe cleanup for window destructions

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
