### PR TITLE
perf: optimize overlays memory usage

### DIFF
--- a/internal/app/components/modeindicator/overlay_darwin.go
+++ b/internal/app/components/modeindicator/overlay_darwin.go
@@ -30,6 +30,12 @@ const (
 	// defaultIndicatorHeight is the default height for the mode indicator.
 	defaultIndicatorHeight = 20
 
+	// indicatorWindowWidth is the width of the small overlay window for the mode indicator.
+	// Generous enough to accommodate the badge with any reasonable offset.
+	indicatorWindowWidth = 300
+	// indicatorWindowHeight is the height of the small overlay window for the mode indicator.
+	indicatorWindowHeight = 150
+
 	// NSWindowSharingNone represents NSWindowSharingNone (0) - hidden from screen sharing.
 	NSWindowSharingNone = 0
 	// NSWindowSharingReadOnly represents NSWindowSharingReadOnly (1) - visible in screen sharing.
@@ -147,25 +153,12 @@ func (o *Overlay) Clear() {
 	C.NeruClearOverlay(o.window)
 }
 
-// ResizeToActiveScreen adjusts the overlay window size with callback notification.
-// Falls back to a non-callback resize if the callback ID pool is exhausted.
+// ResizeToActiveScreen is a no-op for mode indicator overlays.
+// Mode indicator windows are small and positioned dynamically by DrawModeIndicator
+// using NeruPositionOverlay, so full-screen resizing is unnecessary.
+// This avoids allocating a full-screen backing store (~47MB on Retina).
 func (o *Overlay) ResizeToActiveScreen() {
-	started := o.callbackManager.StartResizeOperation(func(callbackID uint64, generation uint64) {
-		// Pass callback ID and generation as opaque pointer context for C callback.
-		// Uses CallbackIDToPointer to convert in a way that go vet accepts.
-		contextPtr := overlayutil.CallbackIDToPointer(callbackID, generation)
-
-		C.NeruResizeOverlayToActiveScreenWithCallback(
-			o.window,
-			(C.ResizeCompletionCallback)(C.resizeModeIndicatorCompletionCallback),
-			contextPtr,
-		)
-	})
-	if !started {
-		// Pool exhausted — fall back to non-callback resize so the overlay
-		// is still moved to the correct screen.
-		C.NeruResizeOverlayToActiveScreen(o.window)
-	}
+	// No-op: positioning is handled dynamically in DrawModeIndicator.
 }
 
 // DrawModeIndicator draws a mode label at the specified position.
@@ -175,6 +168,10 @@ func (o *Overlay) ResizeToActiveScreen() {
 // allowing users to customize (or hide) each mode's indicator text.
 // The caller is responsible for calling Show() once before the first draw
 // (e.g. in startModeIndicatorPolling) rather than showing every tick.
+//
+// xCoordinate and yCoordinate are absolute Quartz screen coordinates.
+// The overlay positions a small window around the indicator badge
+// instead of using a full-screen window, saving ~47MB of backing store.
 //
 // IMPORTANT: This method must only be called from a single goroutine at a
 // time. The shared styleCache is invalidated and repopulated based on the
@@ -215,12 +212,25 @@ func (o *Overlay) DrawModeIndicator(mode string, xCoordinate, yCoordinate int) {
 
 	label := o.getOrCacheLabel(labelText)
 
-	// Create a single hint for the indicator
+	// Position the small window centered on the indicator's absolute position.
+	// This avoids a full-screen backing store (~47MB on Retina).
+	indicatorAbsX := xCoordinate + xOffset
+	indicatorAbsY := yCoordinate + yOffset
+	C.NeruPositionOverlayRelative(
+		o.window,
+		C.double(indicatorAbsX),
+		C.double(indicatorAbsY),
+		C.double(indicatorWindowWidth),
+		C.double(indicatorWindowHeight),
+	)
+
+	// Create a single hint for the indicator.
+	// Position is at the center of the small window (in Quartz top-left coords).
 	hint := C.HintData{
 		label: label,
 		position: C.CGPoint{
-			x: C.double(xCoordinate + xOffset),
-			y: C.double(yCoordinate + yOffset),
+			x: C.double(indicatorWindowWidth / 2),  //nolint:mnd
+			y: C.double(indicatorWindowHeight / 2), //nolint:mnd
 		},
 		size: C.CGSize{
 			// Size is not strictly needed for just drawing the label, but providing reasonable defaults

--- a/internal/app/components/stickyindicator/overlay_darwin.go
+++ b/internal/app/components/stickyindicator/overlay_darwin.go
@@ -27,6 +27,11 @@ const (
 	stickyIndicatorWidth  = 60
 	stickyIndicatorHeight = 20
 
+	// stickyWindowWidth is the width of the small overlay window for the sticky indicator.
+	stickyWindowWidth = 300
+	// stickyWindowHeight is the height of the small overlay window for the sticky indicator.
+	stickyWindowHeight = 150
+
 	// NSWindowSharingNone represents NSWindowSharingNone (0) - hidden from screen sharing.
 	NSWindowSharingNone = 0
 	// NSWindowSharingReadOnly represents NSWindowSharingReadOnly (1) - visible in screen sharing.
@@ -119,23 +124,18 @@ func (o *Overlay) Clear() {
 	C.NeruClearOverlay(o.window)
 }
 
-// ResizeToActiveScreen adjusts the overlay window size with callback notification.
-// Falls back to a non-callback resize if the callback ID pool is exhausted.
+// ResizeToActiveScreen is a no-op for sticky indicator overlays.
+// Sticky indicator windows are small and positioned dynamically by Draw
+// using NeruPositionOverlay, so full-screen resizing is unnecessary.
+// This avoids allocating a full-screen backing store (~47MB on Retina).
 func (o *Overlay) ResizeToActiveScreen() {
-	started := o.callbackManager.StartResizeOperation(func(callbackID uint64, generation uint64) {
-		contextPtr := overlayutil.CallbackIDToPointer(callbackID, generation)
-		C.NeruResizeOverlayToActiveScreenWithCallback(
-			o.window,
-			(C.ResizeCompletionCallback)(C.resizeStickyIndicatorCompletionCallback),
-			contextPtr,
-		)
-	})
-	if !started {
-		C.NeruResizeOverlayToActiveScreen(o.window)
-	}
+	// No-op: positioning is handled dynamically in Draw.
 }
 
 // Draw draws the sticky modifier symbols near the specified cursor position.
+// xCoordinate and yCoordinate are absolute Quartz screen coordinates.
+// The overlay positions a small window around the indicator badge
+// instead of using a full-screen window, saving ~47MB of backing store.
 // X/Y offsets from uiConfig are applied internally (under configMu) to match
 // the mode indicator pattern. The caller must call Show() before Draw() for
 // the content to be visible.
@@ -199,11 +199,24 @@ func (o *Overlay) Draw(xCoordinate, yCoordinate int, symbols string) {
 		)
 	})
 
+	// Position the small window centered on the indicator's absolute position.
+	// This avoids a full-screen backing store (~47MB on Retina).
+	indicatorAbsX := xCoordinate + xOffset
+	indicatorAbsY := yCoordinate + yOffset
+	C.NeruPositionOverlayRelative(
+		o.window,
+		C.double(indicatorAbsX),
+		C.double(indicatorAbsY),
+		C.double(stickyWindowWidth),
+		C.double(stickyWindowHeight),
+	)
+
+	// Position is at the center of the small window (in Quartz top-left coords).
 	hint := C.HintData{
 		label: label,
 		position: C.CGPoint{
-			x: C.double(xCoordinate + xOffset),
-			y: C.double(yCoordinate + yOffset),
+			x: C.double(stickyWindowWidth / 2),  //nolint:mnd
+			y: C.double(stickyWindowHeight / 2), //nolint:mnd
 		},
 		size: C.CGSize{
 			width:  stickyIndicatorWidth,

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -131,14 +131,7 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 					}
 				}
 
-				screenOrigin := h.screenBounds.Min
-
 				h.mu.Unlock()
-
-				localCursorX := cursorX - screenOrigin.X
-				localCursorY := cursorY - screenOrigin.Y
-				localStickyX := stickyPoint.X - screenOrigin.X
-				localStickyY := stickyPoint.Y - screenOrigin.Y
 
 				// Mode indicator: show and draw when enabled, hide otherwise.
 				if showModeInd {
@@ -146,7 +139,7 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 						ind.Show()
 					}
 
-					h.modeIndicatorService.UpdateIndicatorPosition(localCursorX, localCursorY)
+					h.modeIndicatorService.UpdateIndicatorPosition(cursorX, cursorY)
 				} else if ind := h.overlayManager.ModeIndicatorOverlay(); ind != nil {
 					ind.Clear()
 					ind.Hide()
@@ -160,12 +153,12 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 							stickyInd.Show()
 						}
 
-						h.drawStickyModifiersIndicator(localStickyX, localStickyY)
+						h.drawStickyModifiersIndicator(stickyPoint.X, stickyPoint.Y)
 					} else if stickyInd := h.overlayManager.StickyModifiersOverlay(); stickyInd != nil {
 						if h.stickyIndicatorService != nil {
 							h.stickyIndicatorService.UpdateIndicatorPosition(
-								localStickyX,
-								localStickyY,
+								stickyPoint.X,
+								stickyPoint.Y,
 								"",
 							)
 						}

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -273,12 +273,12 @@ void NeruHideCursorIndicator(OverlayWindow window);
 void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle style);
 
 /// Position and resize overlay window to a specific rect centered on a point.
-/// Uses screen-local (relative to active screen top-left) coordinates for the center point.
+/// Uses absolute Quartz coordinates for the center point.
 /// @param window Overlay window handle
-/// @param localX Local X position relative to active screen top-left
-/// @param localY Local Y position relative to active screen top-left
+/// @param absoluteX Absolute Quartz X coordinate
+/// @param absoluteY Absolute Quartz Y coordinate
 /// @param width Window width in points
 /// @param height Window height in points
-void NeruPositionOverlayRelative(OverlayWindow window, double localX, double localY, double width, double height);
+void NeruPositionOverlayRelative(OverlayWindow window, double absoluteX, double absoluteY, double width, double height);
 
 #endif  // OVERLAY_H

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -272,4 +272,13 @@ void NeruHideCursorIndicator(OverlayWindow window);
 /// @param style Indicator style
 void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle style);
 
+/// Position and resize overlay window to a specific rect centered on a point.
+/// Uses screen-local (relative to active screen top-left) coordinates for the center point.
+/// @param window Overlay window handle
+/// @param localX Local X position relative to active screen top-left
+/// @param localY Local Y position relative to active screen top-left
+/// @param width Window width in points
+/// @param height Window height in points
+void NeruPositionOverlayRelative(OverlayWindow window, double localX, double localY, double width, double height);
+
 #endif  // OVERLAY_H

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -1736,13 +1736,12 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 
 /// Create window
 - (void)createWindow {
-	NSScreen *mainScreen = [NSScreen mainScreen];
-	NSRect screenFrame = [mainScreen frame];
+	NSRect initialRect = NSMakeRect(0, 0, 1, 1);
 
 	// Use NSPanel for better floating overlay behavior.
 	// Non-activating panel won't steal focus from other apps.
 	NSPanel *panel =
-	    [[NSPanel alloc] initWithContentRect:screenFrame
+	    [[NSPanel alloc] initWithContentRect:initialRect
 	                               styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
 	                                 backing:NSBackingStoreBuffered
 	                                   defer:NO];
@@ -1776,7 +1775,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	[self.window setSharingType:self.sharingType];
 
 	// Create and attach overlay view
-	NSRect viewFrame = NSMakeRect(0, 0, screenFrame.size.width, screenFrame.size.height);
+	NSRect viewFrame = NSMakeRect(0, 0, 1, 1);
 	self.overlayView = [[OverlayView alloc] initWithFrame:viewFrame];
 	[self.window setContentView:self.overlayView];
 }

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -5,6 +5,7 @@
 //  Copyright © 2025 Neru. All rights reserved.
 //
 
+#import "accessibility.h"
 #import "overlay.h"
 
 #import <Cocoa/Cocoa.h>
@@ -221,6 +222,8 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 /// Cached parsed colors keyed by normalized hex string
 @property(nonatomic, strong) NSCache *colorCache;
 
+- (void)clearContent;
+
 /// When YES, drawLayer:inContext: clears the full bounds and redraws everything.
 /// When NO, only the dirty region (clip box) is cleared and items intersecting it are redrawn.
 /// Defaults to YES; set to NO by match-prefix-only updates that use setNeedsDisplayInRect:.
@@ -368,6 +371,22 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 - (void)dealloc {
 	[self.gridTransitionTimer invalidate];
 	self.gridTransitionTimer = nil;
+}
+
+- (void)clearContent {
+	[self cancelGridTransition];
+	[self cancelCursorIndicatorTransition];
+	[self.hints removeAllObjects];
+	[self.gridCells removeAllObjects];
+	self.searchInput = nil;
+	self.cursorIndicatorVisible = NO;
+	[self.colorCache removeAllObjects];
+	[[self.cachedHintAttributedString mutableString] setString:@""];
+	[[self.cachedHintMeasureString mutableString] setString:@""];
+	[[self.cachedSearchInputAttributedString mutableString] setString:@""];
+	[[self.cachedGridCellAttributedString mutableString] setString:@""];
+	[[self.cachedGridSubKeyAttributedString mutableString] setString:@""];
+	[self setNeedsDisplay:YES];
 }
 
 /// Return the backing scale factor for the current screen, with fallbacks.
@@ -1828,10 +1847,17 @@ void NeruHideOverlayWindow(OverlayWindow window) {
 
 	if ([NSThread isMainThread]) {
 		[controller.window orderOut:nil];
+		// Shrink to 1x1 to release the large backing store (saves ~47MB per
+		// Retina-resolution full-screen window). The next resize/show call
+		// will restore the proper frame before the window becomes visible.
+		[controller.window setFrame:NSMakeRect(0, 0, 1, 1) display:NO];
+		[controller.overlayView setFrame:NSMakeRect(0, 0, 1, 1)];
 	} else {
 		dispatch_async(dispatch_get_main_queue(), ^{
 			@autoreleasepool {
 				[controller.window orderOut:nil];
+				[controller.window setFrame:NSMakeRect(0, 0, 1, 1) display:NO];
+				[controller.overlayView setFrame:NSMakeRect(0, 0, 1, 1)];
 			}
 		});
 	}
@@ -1846,23 +1872,11 @@ void NeruClearOverlay(OverlayWindow window) {
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
 	if ([NSThread isMainThread]) {
-		[controller.overlayView cancelGridTransition];
-		[controller.overlayView cancelCursorIndicatorTransition];
-		[controller.overlayView.hints removeAllObjects];
-		[controller.overlayView.gridCells removeAllObjects];
-		controller.overlayView.searchInput = nil;
-		controller.overlayView.cursorIndicatorVisible = NO;
-		[controller.overlayView setNeedsDisplay:YES];
+		[controller.overlayView clearContent];
 	} else {
 		dispatch_async(dispatch_get_main_queue(), ^{
 			@autoreleasepool {
-				[controller.overlayView cancelGridTransition];
-				[controller.overlayView cancelCursorIndicatorTransition];
-				[controller.overlayView.hints removeAllObjects];
-				[controller.overlayView.gridCells removeAllObjects];
-				controller.overlayView.searchInput = nil;
-				controller.overlayView.cursorIndicatorVisible = NO;
-				[controller.overlayView setNeedsDisplay:YES];
+				[controller.overlayView clearContent];
 			}
 		});
 	}
@@ -3196,6 +3210,36 @@ static NSPoint NeruAppKitPointFromQuartzPoint(CGPoint point) {
 
 	NSRect mainFrame = [NSScreen mainScreen].frame;
 	return NSMakePoint(point.x, NSMaxY(mainFrame) - point.y);
+}
+
+/// Position and resize overlay window to a specific rect centered on a point.
+/// Converts screen-local (relative to active screen top-left) coordinates to absolute
+/// Quartz coordinates, then to AppKit (bottom-left origin) for correct multi-monitor placement.
+/// Used by small indicator overlays (mode indicator, sticky modifiers) to avoid full-screen backing stores.
+/// @param window Overlay window handle
+/// @param localX Local X position relative to active screen top-left
+/// @param localY Local Y position relative to active screen top-left
+/// @param width Window width in points
+/// @param height Window height in points
+void NeruPositionOverlayRelative(OverlayWindow window, double localX, double localY, double width, double height) {
+	if (!window)
+		return;
+
+	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		@autoreleasepool {
+			CGRect screenBounds = getActiveScreenBounds();
+			double absoluteX = screenBounds.origin.x + localX;
+			double absoluteY = screenBounds.origin.y + localY;
+			NSPoint appKitCenter = NeruAppKitPointFromQuartzPoint(CGPointMake(absoluteX, absoluteY));
+			NSRect frame = NSMakeRect(appKitCenter.x - width / 2.0, appKitCenter.y - height / 2.0, width, height);
+
+			[controller.window setFrame:frame display:NO];
+			NSRect viewFrame = NSMakeRect(0, 0, width, height);
+			[controller.overlayView setFrame:viewFrame];
+		}
+	});
 }
 
 /// Show a transient mouse action indicator in its own overlay window.

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -3213,15 +3213,14 @@ static NSPoint NeruAppKitPointFromQuartzPoint(CGPoint point) {
 }
 
 /// Position and resize overlay window to a specific rect centered on a point.
-/// Converts screen-local (relative to active screen top-left) coordinates to absolute
-/// Quartz coordinates, then to AppKit (bottom-left origin) for correct multi-monitor placement.
+/// Converts absolute Quartz coordinates directly to AppKit (bottom-left origin) for correct multi-monitor placement.
 /// Used by small indicator overlays (mode indicator, sticky modifiers) to avoid full-screen backing stores.
 /// @param window Overlay window handle
-/// @param localX Local X position relative to active screen top-left
-/// @param localY Local Y position relative to active screen top-left
+/// @param absoluteX Absolute Quartz X position
+/// @param absoluteY Absolute Quartz Y position
 /// @param width Window width in points
 /// @param height Window height in points
-void NeruPositionOverlayRelative(OverlayWindow window, double localX, double localY, double width, double height) {
+void NeruPositionOverlayRelative(OverlayWindow window, double absoluteX, double absoluteY, double width, double height) {
 	if (!window)
 		return;
 
@@ -3229,9 +3228,6 @@ void NeruPositionOverlayRelative(OverlayWindow window, double localX, double loc
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		@autoreleasepool {
-			CGRect screenBounds = getActiveScreenBounds();
-			double absoluteX = screenBounds.origin.x + localX;
-			double absoluteY = screenBounds.origin.y + localY;
 			NSPoint appKitCenter = NeruAppKitPointFromQuartzPoint(CGPointMake(absoluteX, absoluteY));
 			NSRect frame = NSMakeRect(appKitCenter.x - width / 2.0, appKitCenter.y - height / 2.0, width, height);
 

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -1716,6 +1716,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 @property(nonatomic, strong) OverlayView *overlayView;  ///< Overlay view instance
 @property(nonatomic, assign) NSInteger sharingType;     ///< Current window sharing type
 @property(nonatomic, assign) BOOL sharingTypeExplicit;  ///< Whether sharingType was explicitly configured
+@property(nonatomic, assign) BOOL shouldBeVisible;      ///< Whether the window should currently be visible on screen
 @end
 
 #pragma mark - Overlay Window Controller Implementation
@@ -1727,6 +1728,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 - (instancetype)init {
 	self = [super init];
 	if (self) {
+		_shouldBeVisible = NO;
 		[self createWindow];
 	}
 	return self;
@@ -1822,17 +1824,25 @@ void NeruShowOverlayWindow(OverlayWindow window) {
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		@autoreleasepool {
+			controller.shouldBeVisible = YES;
+
 			[controller.window setLevel:kCGMaximumWindowLevel];
 			[controller.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
 			                                         NSWindowCollectionBehaviorStationary |
 			                                         NSWindowCollectionBehaviorIgnoresCycle |
 			                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
 
-			[controller.window setIsVisible:YES];
-			[controller.window orderFrontRegardless];
-			[controller.window display];
+			NSRect frame = controller.window.frame;
+			// Only display/order front if the window frame is larger than 1x1.
+			// This prevents a brief 1x1 pixel flash at the top-left screen origin
+			// when reactivating shrunken overlays.
+			if (frame.size.width > 1.0 || frame.size.height > 1.0) {
+				[controller.window setIsVisible:YES];
+				[controller.window orderFrontRegardless];
+				[controller.window display];
 
-			[controller.overlayView setNeedsDisplay:YES];
+				[controller.overlayView setNeedsDisplay:YES];
+			}
 		}
 	});
 }
@@ -1846,6 +1856,7 @@ void NeruHideOverlayWindow(OverlayWindow window) {
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
 	if ([NSThread isMainThread]) {
+		controller.shouldBeVisible = NO;
 		[controller.window orderOut:nil];
 		// Shrink to 1x1 to release the large backing store (saves ~47MB per
 		// Retina-resolution full-screen window). The next resize/show call
@@ -1855,6 +1866,7 @@ void NeruHideOverlayWindow(OverlayWindow window) {
 	} else {
 		dispatch_async(dispatch_get_main_queue(), ^{
 			@autoreleasepool {
+				controller.shouldBeVisible = NO;
 				[controller.window orderOut:nil];
 				[controller.window setFrame:NSMakeRect(0, 0, 1, 1) display:NO];
 				[controller.overlayView setFrame:NSMakeRect(0, 0, 1, 1)];
@@ -1915,8 +1927,10 @@ void NeruResizeOverlayToMainScreen(OverlayWindow window) {
 					                                         NSWindowCollectionBehaviorStationary |
 					                                         NSWindowCollectionBehaviorIgnoresCycle |
 					                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
-					[controller.window setIsVisible:YES];
-					[controller.window orderFrontRegardless];
+					if (controller.shouldBeVisible) {
+						[controller.window setIsVisible:YES];
+						[controller.window orderFrontRegardless];
+					}
 				}
 			});
 		}
@@ -1965,8 +1979,10 @@ void NeruResizeOverlayToActiveScreen(OverlayWindow window) {
 					                                         NSWindowCollectionBehaviorStationary |
 					                                         NSWindowCollectionBehaviorIgnoresCycle |
 					                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
-					[controller.window setIsVisible:YES];
-					[controller.window orderFrontRegardless];
+					if (controller.shouldBeVisible) {
+						[controller.window setIsVisible:YES];
+						[controller.window orderFrontRegardless];
+					}
 				}
 			});
 		}
@@ -2024,8 +2040,10 @@ void NeruResizeOverlayToActiveScreenWithCallback(
 					                                         NSWindowCollectionBehaviorStationary |
 					                                         NSWindowCollectionBehaviorIgnoresCycle |
 					                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
-					[controller.window setIsVisible:YES];
-					[controller.window orderFrontRegardless];
+					if (controller.shouldBeVisible) {
+						[controller.window setIsVisible:YES];
+						[controller.window orderFrontRegardless];
+					}
 
 					if (callback)
 						callback(context);
@@ -3234,6 +3252,13 @@ void NeruPositionOverlayRelative(OverlayWindow window, double absoluteX, double 
 			[controller.window setFrame:frame display:NO];
 			NSRect viewFrame = NSMakeRect(0, 0, width, height);
 			[controller.overlayView setFrame:viewFrame];
+
+			if (controller.shouldBeVisible) {
+				[controller.window setIsVisible:YES];
+				[controller.window orderFrontRegardless];
+				[controller.window display];
+				[controller.overlayView setNeedsDisplay:YES];
+			}
 		}
 	});
 }

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -3238,7 +3238,8 @@ static NSPoint NeruAppKitPointFromQuartzPoint(CGPoint point) {
 /// @param absoluteY Absolute Quartz Y position
 /// @param width Window width in points
 /// @param height Window height in points
-void NeruPositionOverlayRelative(OverlayWindow window, double absoluteX, double absoluteY, double width, double height) {
+void NeruPositionOverlayRelative(
+    OverlayWindow window, double absoluteX, double absoluteY, double width, double height) {
 	if (!window)
 		return;
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR optimizes the memory footprint of the macOS overlay system.

- replaced the full-screen NSPanel structures for the Mode Indicator and Sticky Modifiers overlays with dynamically sized 300x150 panels positioned relative to the cursor or selection points
- updated NeruHideOverlayWindow to shrink hidden overlay windows to 1x1 point immediately after they are ordered out
- added clearContent on OverlayView to purge the hex color parser cache and empty cached mutable attributed strings immediately upon mode deactivation

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
