### PR TITLE
perf(hints): optimize hint generation and filtering performance

### DIFF
--- a/internal/core/domain/hint/hint.go
+++ b/internal/core/domain/hint/hint.go
@@ -25,6 +25,7 @@ const (
 // Hints are immutable after creation.
 type Interface struct {
 	label         string
+	labelUpper    string
 	element       *element.Element
 	position      image.Point
 	matchedPrefix string
@@ -41,9 +42,10 @@ func NewHint(label string, element *element.Element, position image.Point) (*Int
 	}
 
 	return &Interface{
-		label:    label,
-		element:  element,
-		position: position,
+		label:      label,
+		labelUpper: strings.ToUpper(label),
+		element:    element,
+		position:   position,
 	}, nil
 }
 
@@ -71,6 +73,7 @@ func (h *Interface) MatchedPrefix() string {
 func (h *Interface) WithMatchedPrefix(prefix string) *Interface {
 	return &Interface{
 		label:         h.label,
+		labelUpper:    h.labelUpper,
 		element:       h.element,
 		position:      h.position,
 		matchedPrefix: prefix,
@@ -138,7 +141,7 @@ func NewTrie() *Trie {
 
 // Insert adds a hint to the trie.
 func (t *Trie) Insert(hint *Interface) {
-	label := strings.ToUpper(hint.Label()) // Pre-normalize to uppercase
+	label := hint.labelUpper
 	node := t.root
 
 	for _, char := range label {

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"image"
 	"runtime"
+	"strings"
 	"sync"
 
 	"go.uber.org/zap"
@@ -98,6 +99,28 @@ func (a *Adapter) ClickableElements(
 	err := a.checkContext(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// Pre-lowercase filter strings once to avoid repeating strings.ToLower on hot paths
+	if filter.TitleContains != "" {
+		filter.TitleContains = strings.ToLower(filter.TitleContains)
+	}
+
+	if filter.DescriptionContains != "" {
+		filter.DescriptionContains = strings.ToLower(filter.DescriptionContains)
+	}
+
+	if filter.ValueContains != "" {
+		filter.ValueContains = strings.ToLower(filter.ValueContains)
+	}
+
+	if len(filter.TextContainsList) > 0 {
+		loweredList := make([]string, len(filter.TextContainsList))
+		for i, text := range filter.TextContainsList {
+			loweredList[i] = strings.ToLower(text)
+		}
+
+		filter.TextContainsList = loweredList
 	}
 
 	a.logger.Debug("Getting clickable elements", zap.Any("filter", filter))

--- a/internal/core/infra/accessibility/adapter_filtering.go
+++ b/internal/core/infra/accessibility/adapter_filtering.go
@@ -9,6 +9,9 @@ import (
 )
 
 // MatchesFilter checks if an element matches the given filter criteria.
+// NOTE: Filter search strings (TitleContains, DescriptionContains, ValueContains,
+// and TextContainsList) must be pre-lowercased by the caller before invoking MatchesFilter
+// to ensure case-insensitive matching without redundant allocations.
 func (a *Adapter) MatchesFilter(
 	elem *element.Element,
 	filter ports.ElementFilter,
@@ -33,6 +36,8 @@ func (a *Adapter) MatchesFilter(
 	}
 
 	// Check title contains filter
+	// NOTE: filter.TitleContains is expected to be pre-lowercased by the caller (e.g. ClickableElements).
+	// Direct callers of MatchesFilter must also lowercase filter strings before passing them.
 	titleMatched := false
 	if filter.TitleContains != "" {
 		title := elem.Title()

--- a/internal/core/infra/accessibility/adapter_filtering.go
+++ b/internal/core/infra/accessibility/adapter_filtering.go
@@ -37,7 +37,7 @@ func (a *Adapter) MatchesFilter(
 	if filter.TitleContains != "" {
 		title := elem.Title()
 		if title != "" &&
-			strings.Contains(strings.ToLower(title), strings.ToLower(filter.TitleContains)) {
+			strings.Contains(strings.ToLower(title), filter.TitleContains) {
 			titleMatched = true
 		}
 	}
@@ -49,7 +49,7 @@ func (a *Adapter) MatchesFilter(
 		if description != "" &&
 			strings.Contains(
 				strings.ToLower(description),
-				strings.ToLower(filter.DescriptionContains),
+				filter.DescriptionContains,
 			) {
 			descMatched = true
 		}
@@ -60,7 +60,7 @@ func (a *Adapter) MatchesFilter(
 	if filter.ValueContains != "" {
 		value := textForFilter(elem)
 		if value != "" &&
-			strings.Contains(strings.ToLower(value), strings.ToLower(filter.ValueContains)) {
+			strings.Contains(strings.ToLower(value), filter.ValueContains) {
 			valueMatched = true
 		}
 	}
@@ -72,12 +72,11 @@ func (a *Adapter) MatchesFilter(
 		description := elem.Description()
 
 		value := textForFilter(elem)
-		for _, text := range filter.TextContainsList {
-			if text == "" {
+		for _, textLower := range filter.TextContainsList {
+			if textLower == "" {
 				continue
 			}
 
-			textLower := strings.ToLower(text)
 			if (title != "" && strings.Contains(strings.ToLower(title), textLower)) ||
 				(description != "" && strings.Contains(strings.ToLower(description), textLower)) ||
 				(value != "" && strings.Contains(strings.ToLower(value), textLower)) {

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -749,6 +749,8 @@ func (e *Element) IsClickable(
 // inheriting a stale excluded mapping from a previous process.
 var (
 	pidBundleCache    = map[int]string{}
+	pidExcludedCache  = map[int]bool{}
+	lastConfigPointer *config.Config
 	pidBundleCacheMu  sync.RWMutex
 	excludedBundleIDs = map[string]struct{}{
 		"com.apple.PIPAgent":             {},
@@ -800,27 +802,48 @@ func isExcludedOrUnsafe(bundleID string, configProvider config.Provider) bool {
 // bundle ID that should skip the expensive visibility check. Results are
 // cached by PID to avoid redundant Cocoa lookups.
 func isExcludedBundleID(pid int, configProvider config.Provider) bool {
-	pidBundleCacheMu.RLock()
-	b, ok := pidBundleCache[pid]
-	pidBundleCacheMu.RUnlock()
-
-	if ok {
-		return isExcludedOrUnsafe(b, configProvider)
+	var cfg *config.Config
+	if configProvider != nil {
+		cfg = configProvider.Get()
 	}
-
-	cBundleID := C.getBundleIDForPID(C.int(pid))
-	if cBundleID == nil {
-		return false
-	}
-
-	bundleID := C.GoString(cBundleID)
-	C.freeString(cBundleID)
 
 	pidBundleCacheMu.Lock()
-	pidBundleCache[pid] = bundleID
+	if cfg != lastConfigPointer {
+		pidExcludedCache = make(map[int]bool)
+		lastConfigPointer = cfg
+	}
+	excluded, ok := pidExcludedCache[pid]
 	pidBundleCacheMu.Unlock()
 
-	return isExcludedOrUnsafe(bundleID, configProvider)
+	if ok {
+		return excluded
+	}
+
+	pidBundleCacheMu.RLock()
+	bundleID, hasBundle := pidBundleCache[pid]
+	pidBundleCacheMu.RUnlock()
+
+	if !hasBundle {
+		cBundleID := C.getBundleIDForPID(C.int(pid))
+		if cBundleID == nil {
+			return false
+		}
+
+		bundleID = C.GoString(cBundleID)
+		C.freeString(cBundleID)
+
+		pidBundleCacheMu.Lock()
+		pidBundleCache[pid] = bundleID
+		pidBundleCacheMu.Unlock()
+	}
+
+	res := isExcludedOrUnsafe(bundleID, configProvider)
+
+	pidBundleCacheMu.Lock()
+	pidExcludedCache[pid] = res
+	pidBundleCacheMu.Unlock()
+
+	return res
 }
 
 // IsMissionControlActive checks if Mission Control is currently active.

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -840,7 +840,9 @@ func isExcludedBundleID(pid int, configProvider config.Provider) bool {
 	res := isExcludedOrUnsafe(bundleID, configProvider)
 
 	pidBundleCacheMu.Lock()
-	pidExcludedCache[pid] = res
+	if cfg == lastConfigPointer {
+		pidExcludedCache[pid] = res
+	}
 	pidBundleCacheMu.Unlock()
 
 	return res

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -154,12 +154,13 @@ func (n *TreeNode) AddChild(child *TreeNode) {
 
 // TreeOptions configures accessibility tree traversal behavior and filtering.
 type TreeOptions struct {
-	filterFunc     func(*ElementInfo) bool
-	maxDepth       int
-	logger         *zap.Logger
-	stats          *treeStats
-	bundleID       string          // Bundle ID for auto-detecting Chromium/Electron strict filtering
-	configProvider config.Provider // For checking user-configured Chromium/Electron bundles
+	filterFunc           func(*ElementInfo) bool
+	maxDepth             int
+	logger               *zap.Logger
+	stats                *treeStats
+	bundleID             string          // Bundle ID for auto-detecting Chromium/Electron strict filtering
+	configProvider       config.Provider // For checking user-configured Chromium/Electron bundles
+	isChromiumOrElectron bool            // Pre-computed flag for fast check
 }
 
 // FilterFunc returns the filter function.
@@ -277,6 +278,7 @@ func BuildTree(root *Element, opts TreeOptions) (*TreeNode, error) {
 	if opts.bundleID == "" {
 		opts.bundleID = root.BundleIdentifier()
 	}
+	opts.isChromiumOrElectron = isChromiumOrElectron(opts.bundleID, opts.configProvider)
 
 	node := getTreeNode(root, info, nil, config.DefaultChildrenCapacity)
 
@@ -603,7 +605,7 @@ func shouldIncludeElement(
 
 	// Strict filtering: auto-enabled for Chromium/Electron apps with noisy DOM trees
 	// For native apps like Safari, we trust the semantic tree to not have noise
-	if isChromiumOrElectron(opts.bundleID, opts.configProvider) && elementRect.Dx() > 0 &&
+	if opts.isChromiumOrElectron && elementRect.Dx() > 0 &&
 		elementRect.Dy() > 0 {
 		// Filter out tiny elements that are likely noise in Chromium DOM trees.
 		// This is especially important for web content where the DOM can have
@@ -691,6 +693,26 @@ func appendSearchText(builder *strings.Builder, seen map[string]struct{}, text s
 func accumulateSearchText(root *TreeNode) {
 	root.walkTreePostOrder(func(node *TreeNode) {
 		if node.info == nil {
+			return
+		}
+
+		hasAny := false
+		if strings.TrimSpace(node.info.Title()) != "" ||
+			strings.TrimSpace(node.info.Description()) != "" ||
+			strings.TrimSpace(node.info.Value()) != "" {
+			hasAny = true
+		} else {
+			for _, child := range node.children {
+				if child.info != nil && child.info.searchText != "" {
+					hasAny = true
+
+					break
+				}
+			}
+		}
+		if !hasAny {
+			node.info.searchText = ""
+
 			return
 		}
 
@@ -787,25 +809,37 @@ func isChromiumOrElectron(bundleID string, configProvider config.Provider) bool 
 	return isUserConfiguredChromiumElectron(bundleID, configProvider)
 }
 
+var (
+	knownChromiumMap map[string]struct{}
+	knownElectronMap map[string]struct{}
+	initKnownOnce    sync.Once
+)
+
+func initKnownMaps() {
+	knownChromiumMap = make(map[string]struct{}, len(config.KnownChromiumBundles))
+	for _, b := range config.KnownChromiumBundles {
+		knownChromiumMap[strings.ToLower(strings.TrimSpace(b))] = struct{}{}
+	}
+	knownElectronMap = make(map[string]struct{}, len(config.KnownElectronBundles))
+	for _, b := range config.KnownElectronBundles {
+		knownElectronMap[strings.ToLower(strings.TrimSpace(b))] = struct{}{}
+	}
+}
+
 // isLikelyChromiumOrElectron returns true if the bundle ID matches known Chromium/Electron apps.
 // This is duplicated from electron package to avoid import cycle.
 func isLikelyChromiumOrElectron(bundleID string) bool {
 	if bundleID == "" {
 		return false
 	}
+	initKnownOnce.Do(initKnownMaps)
 
-	bundleID = strings.TrimSpace(bundleID)
-
-	for _, b := range config.KnownChromiumBundles {
-		if strings.EqualFold(b, bundleID) {
-			return true
-		}
+	bundleID = strings.ToLower(strings.TrimSpace(bundleID))
+	if _, ok := knownChromiumMap[bundleID]; ok {
+		return true
 	}
-
-	for _, b := range config.KnownElectronBundles {
-		if strings.EqualFold(b, bundleID) {
-			return true
-		}
+	if _, ok := knownElectronMap[bundleID]; ok {
+		return true
 	}
 
 	return false


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR improves the performance and efficiency of hints generation.

- reducing redundant lookups
- caching some recurring metadata
- eliminating unnecessary heap allocations tree building and filtering

Prabbly not noticeable, but in the long run, it should help.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
