### PR TITLE
perf(hints): early exit on out of bounds child on chromium or electron

### DIFF
--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -225,6 +225,7 @@ type treeStats struct {
 	childrenErrors        atomic.Int64
 	sequentialBatches     atomic.Int64
 	maxDepthSeen          atomic.Int64
+	outOfBoundsSkipped    atomic.Int64
 }
 
 // recordDepth atomically updates the max depth seen.
@@ -300,6 +301,7 @@ func BuildTree(root *Element, opts TreeOptions) (*TreeNode, error) {
 			zap.Int64("no_children", stats.noChildren.Load()),
 			zap.Int64("children_errors", stats.childrenErrors.Load()),
 			zap.Int64("sequential_batches", stats.sequentialBatches.Load()),
+			zap.Int64("out_of_bounds_skipped", stats.outOfBoundsSkipped.Load()),
 			zap.Int64("max_depth_seen", stats.maxDepthSeen.Load()),
 		)
 	}
@@ -460,6 +462,35 @@ func buildTreeRecursive(
 
 			return
 		}
+	}
+
+	// Early exit if element is out of window bounds
+	// and only targeted on Chromium/Electron apps.
+	// They tend to over fetch children and is extremely noisy.
+	//
+	// Example, try this site: https://nix-darwin.github.io/nix-darwin/manual/
+	elementRect := rectFromInfo(parent.info)
+	if !elementRect.Overlaps(windowBounds) && opts.isChromiumOrElectron {
+		if opts.stats != nil {
+			opts.stats.outOfBoundsSkipped.Add(1)
+		}
+
+		for _, child := range children {
+			child.Release()
+		}
+		if ce := opts.logger.Check(
+			zap.DebugLevel,
+			"Out-of-bounds element, skipping subtree",
+		); ce != nil {
+			ce.Write(
+				zap.Int("children", len(children)),
+				zap.Int("depth", depth),
+				zap.String("parent_role", parent.info.Role()),
+				zap.String("parent_title", parent.info.Title()),
+			)
+		}
+
+		return
 	}
 
 	// Process children sequentially to avoid goroutine/thread explosion

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -401,6 +401,35 @@ func buildTreeRecursive(
 		return
 	}
 
+	// Early exit if element is out of window bounds
+	// and only targeted on Chromium/Electron apps.
+	// They tend to over fetch children and is extremely noisy.
+	//
+	// This check is intentionally placed before the Children() call to avoid
+	// expensive AXAPI round-trips for off-screen subtrees — the majority of
+	// noise on long Chromium pages comes from elements outside the viewport.
+	//
+	// Example, try this site: https://nix-darwin.github.io/nix-darwin/manual/
+	elementRect := rectFromInfo(parent.info)
+	if !elementRect.Overlaps(windowBounds) && opts.isChromiumOrElectron {
+		if opts.stats != nil {
+			opts.stats.outOfBoundsSkipped.Add(1)
+		}
+
+		if ce := opts.logger.Check(
+			zap.DebugLevel,
+			"Out-of-bounds element, skipping subtree",
+		); ce != nil {
+			ce.Write(
+				zap.Int("depth", depth),
+				zap.String("parent_role", parent.info.Role()),
+				zap.String("parent_title", parent.info.Title()),
+			)
+		}
+
+		return
+	}
+
 	// Don't traverse deeper into interactive leaf elements,
 	// unless they have important container children (e.g., popovers, sheets, menus).
 	// This handles cases like a toolbar button that opens a popover.
@@ -462,35 +491,6 @@ func buildTreeRecursive(
 
 			return
 		}
-	}
-
-	// Early exit if element is out of window bounds
-	// and only targeted on Chromium/Electron apps.
-	// They tend to over fetch children and is extremely noisy.
-	//
-	// Example, try this site: https://nix-darwin.github.io/nix-darwin/manual/
-	elementRect := rectFromInfo(parent.info)
-	if !elementRect.Overlaps(windowBounds) && opts.isChromiumOrElectron {
-		if opts.stats != nil {
-			opts.stats.outOfBoundsSkipped.Add(1)
-		}
-
-		for _, child := range children {
-			child.Release()
-		}
-		if ce := opts.logger.Check(
-			zap.DebugLevel,
-			"Out-of-bounds element, skipping subtree",
-		); ce != nil {
-			ce.Write(
-				zap.Int("children", len(children)),
-				zap.Int("depth", depth),
-				zap.String("parent_role", parent.info.Role()),
-				zap.String("parent_title", parent.info.Title()),
-			)
-		}
-
-		return
 	}
 
 	// Process children sequentially to avoid goroutine/thread explosion


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR improves the hint activation speed on Chromium browsers (also maybe some electron apps), especially on loooooong pages (e.g. https://nix-darwin.github.io/nix-darwin/manual/).

I added an early out-of-bounds early exit and to not further traverse when it's not visible. Previously, we traverse everything and filter it out, which is still heavy.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
