### PR TITLE
fix(hints): ensure ctx cancellation for chaining calls

### DIFF
--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -147,6 +147,12 @@ func (a *Adapter) ClickableElements(
 	collectElements := func(sourceName string, queryFunc func() ([]*element.Element, error)) {
 		defer waitGroup.Done()
 
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		elements, err := queryFunc()
 		if err != nil {
 			mutex.Lock()
@@ -176,13 +182,13 @@ func (a *Adapter) ClickableElements(
 
 		go func() {
 			collectElements("windows", func() ([]*element.Element, error) {
-				windowsToProcess, windowsErr := a.client.FrontmostAndPopoverWindows()
+				windowsToProcess, windowsErr := a.client.FrontmostAndPopoverWindows(ctx)
 				if windowsErr != nil {
 					return nil, windowsErr
 				}
 
 				if len(windowsToProcess) == 0 {
-					frontmost, frontmostErr := a.client.FrontmostWindow()
+					frontmost, frontmostErr := a.client.FrontmostWindow(ctx)
 					if frontmostErr != nil {
 						return nil, frontmostErr
 					}
@@ -204,6 +210,7 @@ func (a *Adapter) ClickableElements(
 					defer func() { <-windowSem }()
 
 					clickableNodes, clickableNodesErr := a.client.ClickableNodes(
+						ctx,
 						window,
 						stringRoles(filter.Roles),
 						0,
@@ -314,8 +321,18 @@ func (a *Adapter) ClickableElements(
 		}()
 	}
 
-	// Wait for all queries to complete
-	waitGroup.Wait()
+	// Wait for all queries to complete or context to be canceled
+	done := make(chan struct{})
+	go func() {
+		waitGroup.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		return nil, derrors.Wrap(ctx.Err(), derrors.CodeContextCanceled, "operation canceled")
+	}
 
 	if firstError != nil {
 		return nil, firstError
@@ -431,7 +448,7 @@ func (a *Adapter) FocusedAppBundleID(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	focusedApp, focusedAppErr := a.client.FocusedApplication()
+	focusedApp, focusedAppErr := a.client.FocusedApplication(ctx)
 	if focusedAppErr != nil {
 		return "", derrors.New(derrors.CodeAccessibilityFailed, "failed to get focused application")
 	}

--- a/internal/core/infra/accessibility/adapter_supplementary.go
+++ b/internal/core/infra/accessibility/adapter_supplementary.go
@@ -25,7 +25,7 @@ const (
 // Temporarily modifies clickable roles to include AXMenuBarItem, collects menubar elements,
 // and processes additional menubar targets from configuration.
 func (a *Adapter) addMenubarElements(
-	_ context.Context,
+	ctx context.Context,
 	elements []*element.Element,
 	filter ports.ElementFilter,
 ) []*element.Element {
@@ -39,7 +39,7 @@ func (a *Adapter) addMenubarElements(
 	menubarRoles[len(originalRoles)+1] = string(element.RoleMenu)
 
 	// Get menubar elements
-	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements(menubarTreeDepth)
+	menubarNodes, menubarNodesErr := a.client.MenuBarClickableElements(ctx, menubarTreeDepth)
 	if menubarNodesErr != nil {
 		a.logger.Warn("Failed to get menubar elements", zap.Error(menubarNodesErr))
 	} else {
@@ -72,6 +72,7 @@ func (a *Adapter) addMenubarElements(
 			defer waitGroup.Done()
 
 			additionalNodes, err := a.client.ClickableElementsFromBundleID(
+				ctx,
 				bundleID,
 				menubarRoles,
 				0,
@@ -131,7 +132,7 @@ func (a *Adapter) addMenubarElements(
 // Temporarily modifies clickable roles to include AXDockItem, finds the dock application,
 // validates it, and collects clickable elements from the dock tree.
 func (a *Adapter) addDockElements(
-	_ context.Context,
+	ctx context.Context,
 	elements []*element.Element,
 ) []*element.Element {
 	const dockBundleID = "com.apple.dock"
@@ -143,7 +144,7 @@ func (a *Adapter) addDockElements(
 	dockRoles[len(originalRoles)] = string(element.RoleDockItem)
 
 	// Get dock application by bundle ID
-	dockApp, dockAppErr := a.client.ApplicationByBundleID(dockBundleID)
+	dockApp, dockAppErr := a.client.ApplicationByBundleID(ctx, dockBundleID)
 	if dockAppErr != nil || dockApp == nil {
 		a.logger.Debug("Dock application not found")
 
@@ -168,7 +169,7 @@ func (a *Adapter) addDockElements(
 	}
 
 	// Build tree and find clickable elements
-	dockNodes, dockNodesErr := a.client.ClickableNodes(dockApp, dockRoles, dockTreeDepth)
+	dockNodes, dockNodesErr := a.client.ClickableNodes(ctx, dockApp, dockRoles, dockTreeDepth)
 	if dockNodesErr != nil {
 		a.logger.Warn("Failed to get dock elements", zap.Error(dockNodesErr))
 
@@ -196,7 +197,7 @@ func (a *Adapter) addDockElements(
 
 // addNotificationCenterElements adds notification center clickable elements.
 func (a *Adapter) addNotificationCenterElements(
-	_ context.Context,
+	ctx context.Context,
 	elements []*element.Element,
 ) []*element.Element {
 	const ncBundleID = "com.apple.notificationcenterui"
@@ -210,6 +211,7 @@ func (a *Adapter) addNotificationCenterElements(
 	ncRoles[len(originalRoles)] = string(element.RoleGroup)
 
 	ncNodes, ncNodesErr := a.client.ClickableElementsFromBundleID(
+		ctx,
 		ncBundleID,
 		ncRoles,
 		0,
@@ -241,13 +243,13 @@ func (a *Adapter) addNotificationCenterElements(
 
 // addStageManagerElements adds stage manager center clickable elements.
 func (a *Adapter) addStageManagerElements(
-	_ context.Context,
+	ctx context.Context,
 	elements []*element.Element,
 ) []*element.Element {
 	const wmBundleID = "com.apple.WindowManager"
 
 	// Get window manager application by bundle ID
-	wmApp, wmAppErr := a.client.ApplicationByBundleID(wmBundleID)
+	wmApp, wmAppErr := a.client.ApplicationByBundleID(ctx, wmBundleID)
 	if wmAppErr != nil || wmApp == nil {
 		a.logger.Debug("Window manager application not found")
 
@@ -272,7 +274,7 @@ func (a *Adapter) addStageManagerElements(
 	}
 
 	// Build tree and find clickable elements
-	wmNodes, wmNodesErr := a.client.ClickableNodes(wmApp, nil, stageManagerTreeDepth)
+	wmNodes, wmNodesErr := a.client.ClickableNodes(ctx, wmApp, nil, stageManagerTreeDepth)
 	if wmNodesErr != nil {
 		a.logger.Warn("Failed to get window manager elements", zap.Error(wmNodesErr))
 
@@ -300,12 +302,13 @@ func (a *Adapter) addStageManagerElements(
 
 // addPIPElements adds macOS Picture in Picture controls from PIPAgent.
 func (a *Adapter) addPIPElements(
-	_ context.Context,
+	ctx context.Context,
 	elements []*element.Element,
 ) []*element.Element {
 	const pipBundleID = "com.apple.PIPAgent"
 
 	pipNodes, pipNodesErr := a.client.ClickableElementsFromBundleID(
+		ctx,
 		pipBundleID,
 		nil,
 		flatAppTreeDepth,
@@ -337,12 +340,13 @@ func (a *Adapter) addPIPElements(
 
 // addScreenCaptureElements makes the screencapture small ui clickable.
 func (a *Adapter) addScreenCaptureElements(
-	_ context.Context,
+	ctx context.Context,
 	elements []*element.Element,
 ) []*element.Element {
 	const screenCaptureBundleID = "com.apple.screencaptureui"
 
 	screenCaptureNodes, screenCaptureNodesErr := a.client.ClickableElementsFromBundleID(
+		ctx,
 		screenCaptureBundleID,
 		nil,
 		flatAppTreeDepth,

--- a/internal/core/infra/accessibility/client.go
+++ b/internal/core/infra/accessibility/client.go
@@ -1,6 +1,7 @@
 package accessibility
 
 import (
+	"context"
 	"image"
 
 	"github.com/y3owk1n/neru/internal/core/domain/action"
@@ -20,18 +21,20 @@ type AXWindow interface {
 // AXClient defines the interface for accessibility operations.
 type AXClient interface {
 	// Window and App operations
-	FrontmostWindow() (AXWindow, error)
-	AllWindows() ([]AXWindow, error)
-	FrontmostAndPopoverWindows() ([]AXWindow, error)
-	FocusedApplication() (AXApp, error)
-	ApplicationByBundleID(bundleID string) (AXApp, error)
+	FrontmostWindow(ctx context.Context) (AXWindow, error)
+	AllWindows(ctx context.Context) ([]AXWindow, error)
+	FrontmostAndPopoverWindows(ctx context.Context) ([]AXWindow, error)
+	FocusedApplication(ctx context.Context) (AXApp, error)
+	ApplicationByBundleID(ctx context.Context, bundleID string) (AXApp, error)
 	ClickableNodes(
+		ctx context.Context,
 		root AXElement,
 		roles []string,
 		maxDepth int,
 	) ([]AXNode, error)
-	MenuBarClickableElements(maxDepth int) ([]AXNode, error)
+	MenuBarClickableElements(ctx context.Context, maxDepth int) ([]AXNode, error)
 	ClickableElementsFromBundleID(
+		ctx context.Context,
 		bundleID string,
 		roles []string,
 		maxDepth int,

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -91,10 +91,9 @@ func (c *InfraAXClient) ClickableNodes(
 	roles []string,
 	maxDepth int,
 ) ([]AXNode, error) {
-	element := c.extractElement(root)
-
-	if element == nil {
-		return nil, derrors.New(derrors.CodeInvalidInput, "element is nil")
+	element, extractErr := c.extractElement(root)
+	if extractErr != nil {
+		return nil, extractErr
 	}
 
 	opts, allowedRoles, ignoreClickableCheck := c.buildClickableOpts(element, roles, maxDepth)
@@ -303,14 +302,22 @@ func (c *InfraAXClient) IsMissionControlActive() bool {
 }
 
 // extractElement returns the raw *Element from an AXElement wrapper.
-func (c *InfraAXClient) extractElement(root AXElement) *Element {
+func (c *InfraAXClient) extractElement(root AXElement) (*Element, error) {
 	switch elementType := root.(type) {
 	case *InfraWindow:
-		return elementType.element
+		if elementType.element == nil {
+			return nil, derrors.New(derrors.CodeInvalidInput, "element is nil")
+		}
+
+		return elementType.element, nil
 	case *InfraApp:
-		return elementType.element
+		if elementType.element == nil {
+			return nil, derrors.New(derrors.CodeInvalidInput, "element is nil")
+		}
+
+		return elementType.element, nil
 	default:
-		return nil
+		return nil, derrors.New(derrors.CodeInvalidInput, "invalid element type")
 	}
 }
 

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -1,6 +1,7 @@
 package accessibility
 
 import (
+	"context"
 	"fmt"
 	"image"
 
@@ -33,7 +34,7 @@ func NewInfraAXClient(
 }
 
 // FrontmostWindow returns the frontmost window.
-func (c *InfraAXClient) FrontmostWindow() (AXWindow, error) {
+func (c *InfraAXClient) FrontmostWindow(_ context.Context) (AXWindow, error) {
 	window := FrontmostWindow()
 	if window == nil {
 		return nil, derrors.New(derrors.CodeAccessibilityFailed, "failed to get frontmost window")
@@ -43,7 +44,7 @@ func (c *InfraAXClient) FrontmostWindow() (AXWindow, error) {
 }
 
 // AllWindows returns all windows of the focused application.
-func (c *InfraAXClient) AllWindows() ([]AXWindow, error) {
+func (c *InfraAXClient) AllWindows(_ context.Context) ([]AXWindow, error) {
 	windows, err := AllWindows()
 	if err != nil {
 		return nil, err
@@ -58,7 +59,7 @@ func (c *InfraAXClient) AllWindows() ([]AXWindow, error) {
 }
 
 // FrontmostAndPopoverWindows returns the frontmost window plus popovers.
-func (c *InfraAXClient) FrontmostAndPopoverWindows() ([]AXWindow, error) {
+func (c *InfraAXClient) FrontmostAndPopoverWindows(_ context.Context) ([]AXWindow, error) {
 	windows, err := FrontmostAndPopoverWindows()
 	if err != nil {
 		return nil, err
@@ -73,7 +74,7 @@ func (c *InfraAXClient) FrontmostAndPopoverWindows() ([]AXWindow, error) {
 }
 
 // FocusedApplication returns the focused application.
-func (c *InfraAXClient) FocusedApplication() (AXApp, error) {
+func (c *InfraAXClient) FocusedApplication(_ context.Context) (AXApp, error) {
 	app := FocusedApplication()
 	if app == nil {
 		return nil, derrors.New(derrors.CodeAccessibilityFailed, "failed to get focused app")
@@ -85,57 +86,26 @@ func (c *InfraAXClient) FocusedApplication() (AXApp, error) {
 // ClickableNodes returns clickable nodes for the given root element.
 // If maxDepth is > 0, it overrides the configured tree depth.
 func (c *InfraAXClient) ClickableNodes(
+	ctx context.Context,
 	root AXElement,
 	roles []string,
 	maxDepth int,
 ) ([]AXNode, error) {
-	var element *Element
-
-	switch elementType := root.(type) {
-	case *InfraWindow:
-		element = elementType.element
-	case *InfraApp:
-		element = elementType.element
-	default:
-		return nil, derrors.New(derrors.CodeInvalidInput, "invalid element type")
-	}
+	element := c.extractElement(root)
 
 	if element == nil {
 		return nil, derrors.New(derrors.CodeInvalidInput, "element is nil")
 	}
 
-	opts := DefaultTreeOptions(c.logger)
-	opts.SetConfigProvider(c.configProvider)
+	opts, allowedRoles, ignoreClickableCheck := c.buildClickableOpts(element, roles, maxDepth)
 
-	if cfg := currentConfig(c.configProvider); cfg != nil {
-		depth := cfg.Hints.MaxDepth
-		if maxDepth > 0 {
-			depth = maxDepth
-		}
-
-		opts.SetMaxDepth(depth)
-	}
-
-	tree, treeErr := BuildTree(element, opts)
+	tree, treeErr := BuildTree(ctx, element, opts)
 	if treeErr != nil {
 		return nil, derrors.Wrap(
 			treeErr,
 			derrors.CodeAccessibilityFailed,
 			"failed to build accessibility tree",
 		)
-	}
-
-	var allowedRoles map[string]struct{}
-	if len(roles) > 0 {
-		allowedRoles = make(map[string]struct{}, len(roles))
-		for _, role := range roles {
-			allowedRoles[role] = struct{}{}
-		}
-	}
-
-	ignoreClickableCheck := false
-	if cfg := currentConfig(c.configProvider); cfg != nil {
-		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(element.BundleIdentifier())
 	}
 
 	clickableNodes := tree.FindClickableElements(
@@ -162,7 +132,7 @@ func (c *InfraAXClient) ClickableNodes(
 }
 
 // ApplicationByBundleID returns the application with the given bundle ID.
-func (c *InfraAXClient) ApplicationByBundleID(bundleID string) (AXApp, error) {
+func (c *InfraAXClient) ApplicationByBundleID(_ context.Context, bundleID string) (AXApp, error) {
 	app := ApplicationByBundleID(bundleID)
 	if app == nil {
 		return nil, derrors.New(derrors.CodeAccessibilityFailed, "application not found")
@@ -173,8 +143,12 @@ func (c *InfraAXClient) ApplicationByBundleID(bundleID string) (AXApp, error) {
 
 // MenuBarClickableElements returns clickable elements in the menu bar.
 // If maxDepth is > 0, it overrides the configured tree depth.
-func (c *InfraAXClient) MenuBarClickableElements(maxDepth int) ([]AXNode, error) {
+func (c *InfraAXClient) MenuBarClickableElements(
+	ctx context.Context,
+	maxDepth int,
+) ([]AXNode, error) {
 	nodes, nodesErr := MenuBarClickableElements(
+		ctx,
 		c.logger,
 		c.configProvider,
 		maxDepth,
@@ -202,11 +176,13 @@ func (c *InfraAXClient) MenuBarClickableElements(maxDepth int) ([]AXNode, error)
 // ClickableElementsFromBundleID returns clickable elements for the application with the given bundle ID.
 // If maxDepth is > 0, it overrides the configured tree depth for flat supplementary sources.
 func (c *InfraAXClient) ClickableElementsFromBundleID(
+	ctx context.Context,
 	bundleID string,
 	roles []string,
 	maxDepth int,
 ) ([]AXNode, error) {
 	nodes, nodesErr := ClickableElementsFromBundleID(
+		ctx,
 		bundleID,
 		roles,
 		c.logger,
@@ -324,6 +300,53 @@ func (c *InfraAXClient) ClickableRoles() []string {
 // IsMissionControlActive checks if Mission Control is currently active.
 func (c *InfraAXClient) IsMissionControlActive() bool {
 	return IsMissionControlActive()
+}
+
+// extractElement returns the raw *Element from an AXElement wrapper.
+func (c *InfraAXClient) extractElement(root AXElement) *Element {
+	switch elementType := root.(type) {
+	case *InfraWindow:
+		return elementType.element
+	case *InfraApp:
+		return elementType.element
+	default:
+		return nil
+	}
+}
+
+// buildClickableOpts constructs tree options, allowed roles, and the
+// ignore-clickable flag for the given element and role list.
+func (c *InfraAXClient) buildClickableOpts(
+	element *Element,
+	roles []string,
+	maxDepth int,
+) (TreeOptions, map[string]struct{}, bool) {
+	opts := DefaultTreeOptions(c.logger)
+	opts.SetConfigProvider(c.configProvider)
+
+	if cfg := currentConfig(c.configProvider); cfg != nil {
+		depth := cfg.Hints.MaxDepth
+		if maxDepth > 0 {
+			depth = maxDepth
+		}
+
+		opts.SetMaxDepth(depth)
+	}
+
+	var allowedRoles map[string]struct{}
+	if len(roles) > 0 {
+		allowedRoles = make(map[string]struct{}, len(roles))
+		for _, role := range roles {
+			allowedRoles[role] = struct{}{}
+		}
+	}
+
+	ignoreClickableCheck := false
+	if cfg := currentConfig(c.configProvider); cfg != nil {
+		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(element.BundleIdentifier())
+	}
+
+	return opts, allowedRoles, ignoreClickableCheck
 }
 
 // Wrappers

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -1,6 +1,7 @@
 package accessibility
 
 import (
+	"context"
 	"image"
 	"sync"
 
@@ -49,19 +50,19 @@ type MockAXClient struct {
 }
 
 // FrontmostWindow returns the configured frontmost window or error.
-func (m *MockAXClient) FrontmostWindow() (AXWindow, error) {
+func (m *MockAXClient) FrontmostWindow(_ context.Context) (AXWindow, error) {
 	return m.MockFrontmostWindow, m.MockFrontmostWindowErr
 }
 
 // AllWindows returns the configured windows or error.
-func (m *MockAXClient) AllWindows() ([]AXWindow, error) {
+func (m *MockAXClient) AllWindows(_ context.Context) ([]AXWindow, error) {
 	return m.MockAllWindows, m.MockAllWindowsErr
 }
 
 // FrontmostAndPopoverWindows returns configured hint windows or falls back to
 // the frontmost window. When neither is configured, returns empty to match
 // production semantics (focused window + popover siblings, not arbitrary windows).
-func (m *MockAXClient) FrontmostAndPopoverWindows() ([]AXWindow, error) {
+func (m *MockAXClient) FrontmostAndPopoverWindows(_ context.Context) ([]AXWindow, error) {
 	if m.MockHintWindows != nil || m.MockHintWindowsErr != nil {
 		return m.MockHintWindows, m.MockHintWindowsErr
 	}
@@ -74,17 +75,18 @@ func (m *MockAXClient) FrontmostAndPopoverWindows() ([]AXWindow, error) {
 }
 
 // FocusedApplication returns the configured focused application or error.
-func (m *MockAXClient) FocusedApplication() (AXApp, error) {
+func (m *MockAXClient) FocusedApplication(_ context.Context) (AXApp, error) {
 	return m.MockFocusedApp, m.MockFocusedAppErr
 }
 
 // ApplicationByBundleID returns the configured application by bundle ID or error.
-func (m *MockAXClient) ApplicationByBundleID(_ string) (AXApp, error) {
+func (m *MockAXClient) ApplicationByBundleID(_ context.Context, _ string) (AXApp, error) {
 	return m.MockFocusedApp, m.MockFocusedAppErr // Reuse focused app for simplicity or add specific field
 }
 
 // ClickableNodes returns the configured clickable nodes or error.
 func (m *MockAXClient) ClickableNodes(
+	_ context.Context,
 	_ AXElement,
 	roles []string,
 	_ int,
@@ -98,7 +100,7 @@ func (m *MockAXClient) ClickableNodes(
 }
 
 // MenuBarClickableElements returns the configured menu bar nodes or error.
-func (m *MockAXClient) MenuBarClickableElements(maxDepth int) ([]AXNode, error) {
+func (m *MockAXClient) MenuBarClickableElements(_ context.Context, maxDepth int) ([]AXNode, error) {
 	m.mu.Lock()
 	m.LastCalledMaxDepth = maxDepth
 	m.mu.Unlock()
@@ -108,6 +110,7 @@ func (m *MockAXClient) MenuBarClickableElements(maxDepth int) ([]AXNode, error) 
 
 // ClickableElementsFromBundleID returns the configured nodes for bundle ID or error.
 func (m *MockAXClient) ClickableElementsFromBundleID(
+	_ context.Context,
 	bundleID string,
 	roles []string,
 	maxDepth int,

--- a/internal/core/infra/accessibility/query.go
+++ b/internal/core/infra/accessibility/query.go
@@ -1,6 +1,7 @@
 package accessibility
 
 import (
+	"context"
 	"slices"
 
 	"go.uber.org/zap"
@@ -12,6 +13,7 @@ import (
 // MenuBarClickableElements retrieves clickable UI elements from the focused application's menu bar.
 // If maxDepth is > 0, it overrides the configured tree depth.
 func MenuBarClickableElements(
+	ctx context.Context,
 	logger *zap.Logger,
 	configProvider config.Provider,
 	maxDepth int,
@@ -46,7 +48,7 @@ func MenuBarClickableElements(
 		opts.SetMaxDepth(depth)
 	}
 
-	tree, err := BuildTree(menubar, opts)
+	tree, err := BuildTree(ctx, menubar, opts)
 	if err != nil {
 		logger.Error("Failed to build tree for menu bar", zap.Error(err))
 
@@ -95,6 +97,7 @@ func MenuBarClickableElements(
 // ClickableElementsFromBundleID retrieves clickable UI elements from the application identified by bundle ID.
 // If maxDepth is > 0, it overrides the configured tree depth (useful for flat supplementary sources).
 func ClickableElementsFromBundleID(
+	ctx context.Context,
 	bundleID string,
 	roles []string,
 	logger *zap.Logger,
@@ -129,7 +132,7 @@ func ClickableElementsFromBundleID(
 		opts.SetMaxDepth(depth)
 	}
 
-	tree, err := BuildTree(app, opts)
+	tree, err := BuildTree(ctx, app, opts)
 	if err != nil {
 		logger.Error("Failed to build tree for application",
 			zap.String("bundle_id", bundleID),

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -298,6 +298,20 @@ func BuildTree(ctx context.Context, root *Element, opts TreeOptions) (*TreeNode,
 
 	opts.stats = stats
 	buildTreeRecursive(ctx, node, 1, opts, windowBounds, windowBounds)
+
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			node.Element().Release()
+			return nil, derrors.Wrap(
+				ctx.Err(),
+				derrors.CodeContextCanceled,
+				"tree build cancelled mid-traversal",
+			)
+		default:
+		}
+	}
+
 	accumulateSearchText(node)
 
 	if ce := opts.Logger().Check(zap.DebugLevel, "Tree build completed"); ce != nil {

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -244,16 +244,14 @@ func (s *treeStats) recordDepth(depth int) {
 
 // BuildTree constructs an accessibility tree starting from the specified root element.
 func BuildTree(ctx context.Context, root *Element, opts TreeOptions) (*TreeNode, error) {
-	if ctx != nil {
-		select {
-		case <-ctx.Done():
-			return nil, derrors.Wrap(
-				ctx.Err(),
-				derrors.CodeContextCanceled,
-				"operation canceled before tree build",
-			)
-		default:
-		}
+	select {
+	case <-ctx.Done():
+		return nil, derrors.Wrap(
+			ctx.Err(),
+			derrors.CodeContextCanceled,
+			"operation canceled before tree build",
+		)
+	default:
 	}
 
 	if root == nil {
@@ -299,18 +297,16 @@ func BuildTree(ctx context.Context, root *Element, opts TreeOptions) (*TreeNode,
 	opts.stats = stats
 	buildTreeRecursive(ctx, node, 1, opts, windowBounds, windowBounds)
 
-	if ctx != nil {
-		select {
-		case <-ctx.Done():
-			node.Element().Release()
+	select {
+	case <-ctx.Done():
+		node.Element().Release()
 
-			return nil, derrors.Wrap(
-				ctx.Err(),
-				derrors.CodeContextCanceled,
-				"tree build canceled mid-traversal",
-			)
-		default:
-		}
+		return nil, derrors.Wrap(
+			ctx.Err(),
+			derrors.CodeContextCanceled,
+			"tree build canceled mid-traversal",
+		)
+	default:
 	}
 
 	accumulateSearchText(node)
@@ -399,12 +395,10 @@ func buildTreeRecursive(
 	clipBounds image.Rectangle,
 	windowBounds image.Rectangle,
 ) {
-	if ctx != nil {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
+	select {
+	case <-ctx.Done():
+		return
+	default:
 	}
 
 	if opts.stats != nil {
@@ -553,19 +547,17 @@ func buildChildrenSequential(
 	validChildren := make([]childData, 0, len(children))
 
 	for index, child := range children {
-		if ctx != nil {
-			select {
-			case <-ctx.Done():
-				for _, vc := range validChildren {
-					vc.element.Release()
-				}
-				for _, remaining := range children[index:] {
-					remaining.Release()
-				}
-
-				return
-			default:
+		select {
+		case <-ctx.Done():
+			for _, vc := range validChildren {
+				vc.element.Release()
 			}
+			for _, remaining := range children[index:] {
+				remaining.Release()
+			}
+
+			return
+		default:
 		}
 
 		info, err := child.Info()

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -11,6 +11,7 @@ package accessibility
 import "C"
 
 import (
+	"context"
 	"image"
 	"strings"
 	"sync"
@@ -242,7 +243,19 @@ func (s *treeStats) recordDepth(depth int) {
 }
 
 // BuildTree constructs an accessibility tree starting from the specified root element.
-func BuildTree(root *Element, opts TreeOptions) (*TreeNode, error) {
+func BuildTree(ctx context.Context, root *Element, opts TreeOptions) (*TreeNode, error) {
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return nil, derrors.Wrap(
+				ctx.Err(),
+				derrors.CodeContextCanceled,
+				"operation canceled before tree build",
+			)
+		default:
+		}
+	}
+
 	if root == nil {
 		if ce := opts.Logger().
 			Check(zap.DebugLevel, "BuildTree called with nil root element"); ce != nil {
@@ -284,7 +297,7 @@ func BuildTree(root *Element, opts TreeOptions) (*TreeNode, error) {
 	node := getTreeNode(root, info, nil, config.DefaultChildrenCapacity)
 
 	opts.stats = stats
-	buildTreeRecursive(node, 1, opts, windowBounds, windowBounds)
+	buildTreeRecursive(ctx, node, 1, opts, windowBounds, windowBounds)
 	accumulateSearchText(node)
 
 	if ce := opts.Logger().Check(zap.DebugLevel, "Tree build completed"); ce != nil {
@@ -364,12 +377,21 @@ var leafRolesWithImportantChildren = map[element.Role]bool{
 }
 
 func buildTreeRecursive(
+	ctx context.Context,
 	parent *TreeNode,
 	depth int,
 	opts TreeOptions,
 	clipBounds image.Rectangle,
 	windowBounds image.Rectangle,
 ) {
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+	}
+
 	if opts.stats != nil {
 		opts.stats.nodesVisited.Add(1)
 		opts.stats.recordDepth(depth)
@@ -496,10 +518,11 @@ func buildTreeRecursive(
 	// Process children sequentially to avoid goroutine/thread explosion
 	// from nested parallel tree building. Concurrency is controlled at
 	// the ClickableElements level (maxConcurrentWindows = 4).
-	buildChildrenSequential(parent, children, depth, opts, clipBounds, windowBounds)
+	buildChildrenSequential(ctx, parent, children, depth, opts, clipBounds, windowBounds)
 }
 
 func buildChildrenSequential(
+	ctx context.Context,
 	parent *TreeNode,
 	children []*Element,
 	depth int,
@@ -514,7 +537,22 @@ func buildChildrenSequential(
 	}
 	validChildren := make([]childData, 0, len(children))
 
-	for _, child := range children {
+	for index, child := range children {
+		if ctx != nil {
+			select {
+			case <-ctx.Done():
+				for _, vc := range validChildren {
+					vc.element.Release()
+				}
+				for _, remaining := range children[index:] {
+					remaining.Release()
+				}
+
+				return
+			default:
+			}
+		}
+
 		info, err := child.Info()
 		if err != nil {
 			if opts.stats != nil {
@@ -574,7 +612,7 @@ func buildChildrenSequential(
 			}
 		}
 
-		buildTreeRecursive(childNode, depth+1, opts, newClipBounds, windowBounds)
+		buildTreeRecursive(ctx, childNode, depth+1, opts, newClipBounds, windowBounds)
 	}
 
 	if opts.stats != nil {

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -303,10 +303,11 @@ func BuildTree(ctx context.Context, root *Element, opts TreeOptions) (*TreeNode,
 		select {
 		case <-ctx.Done():
 			node.Element().Release()
+
 			return nil, derrors.Wrap(
 				ctx.Err(),
 				derrors.CodeContextCanceled,
-				"tree build cancelled mid-traversal",
+				"tree build canceled mid-traversal",
 			)
 		default:
 		}

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -299,7 +299,7 @@ func BuildTree(ctx context.Context, root *Element, opts TreeOptions) (*TreeNode,
 
 	select {
 	case <-ctx.Done():
-		node.Element().Release()
+		releaseTreeExcept(node, nil)
 
 		return nil, derrors.Wrap(
 			ctx.Err(),

--- a/internal/core/infra/accessibility/tree_linux.go
+++ b/internal/core/infra/accessibility/tree_linux.go
@@ -3,6 +3,7 @@
 package accessibility
 
 import (
+	"context"
 	"image"
 
 	"go.uber.org/zap"
@@ -62,7 +63,7 @@ func (o *TreeOptions) SetConfigProvider(cp config.Provider) {}
 func (o *TreeOptions) SetFilterFunc(fn func(*ElementInfo) bool) {}
 
 // BuildTree builds the accessibility tree for the specified root element (Linux stub).
-func BuildTree(_ *Element, _ TreeOptions) (*TreeNode, error) {
+func BuildTree(_ context.Context, _ *Element, _ TreeOptions) (*TreeNode, error) {
 	return &TreeNode{}, nil
 }
 

--- a/internal/core/infra/accessibility/tree_windows.go
+++ b/internal/core/infra/accessibility/tree_windows.go
@@ -3,6 +3,7 @@
 package accessibility
 
 import (
+	"context"
 	"image"
 
 	"go.uber.org/zap"
@@ -62,7 +63,7 @@ func (o *TreeOptions) SetConfigProvider(cp config.Provider) {}
 func (o *TreeOptions) SetFilterFunc(fn func(*ElementInfo) bool) {}
 
 // BuildTree builds the accessibility tree for the specified root element (Windows stub).
-func BuildTree(_ *Element, _ TreeOptions) (*TreeNode, error) {
+func BuildTree(_ context.Context, _ *Element, _ TreeOptions) (*TreeNode, error) {
 	return &TreeNode{}, nil
 }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes the issue where repeated hints invocation does not cancel any in-flight AX tree building.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
