### PR TITLE
perf(hints): skip AX hit tests for webkit apps

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -96,10 +96,11 @@ ignore_clickable_check = false
 "Right" = "action move_mouse_relative --dx=10 --dy=0"
 
 [hints.additional_ax_support]
-enable = false                              # Enable enhanced AX for Electron/Chromium/Firefox apps
+enable = false                              # Enable enhanced AX for Electron/Chromium/Firefox/WebKit apps
 additional_electron_bundles = []
 additional_chromium_bundles = []
 additional_firefox_bundles = []
+additional_webkit_bundles = []
 
 [hints.ui]
 font_size = 10

--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -57,6 +57,7 @@ enable = true
 additional_electron_bundles = []
 additional_chromium_bundles = []
 additional_firefox_bundles = []
+additional_webkit_bundles = []
 
 [grid]
 enabled = false

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -376,7 +376,7 @@ See [Per-App Hotkey Overrides](#per-app-hint-hotkey-overrides) for how per-app h
 
 ### Additional Accessibility Support
 
-Enable framework-specific accessibility support for improved hint detection in Electron, Chromium, and Firefox apps:
+Enable framework-specific accessibility support for improved hint detection in Electron, Chromium, Firefox, and WebKit-based apps:
 
 ```toml
 [hints.additional_ax_support]
@@ -384,6 +384,7 @@ enable = true
 additional_electron_bundles = []
 additional_chromium_bundles = []
 additional_firefox_bundles = []
+additional_webkit_bundles = []
 ```
 
 To find a bundle ID:

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -346,13 +346,16 @@ func (h *Handler) activateHintModeInternal(
 	h.overlayManager.ResizeToActiveScreen()
 	h.overlayManager.Show()
 
-	debugElapsed(h.logger, hintGenStart, "Hints mode fully activated")
-
 	if actionStr != nil {
-		h.logger.Info("Hints mode activated with pending action", zap.String("action", *actionStr))
+		h.logger.Info("Hints mode activated",
+			zap.String("action", *actionStr),
+			zap.Duration("elapsed", time.Since(hintGenStart)),
+		)
+	} else {
+		h.logger.Info("Hints mode activated",
+			zap.Duration("elapsed", time.Since(hintGenStart)),
+		)
 	}
-
-	h.logger.Info("Hints mode activated")
 
 	if search {
 		err := h.startHintSearchLocked()

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -15,6 +15,14 @@ import (
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
+// debugTime returns a timestamp for measuring elapsed time.
+func debugTime() time.Time { return time.Now() }
+
+// debugElapsed logs the duration since start with the given message.
+func debugElapsed(logger *zap.Logger, start time.Time, msg string, fields ...zap.Field) {
+	logger.Debug(msg, append(fields, zap.Duration("elapsed_ms", time.Since(start)))...)
+}
+
 // ModeActivationOptions configures a mode activation request.
 type ModeActivationOptions struct {
 	Action                *string
@@ -230,6 +238,8 @@ func (h *Handler) activateHintModeInternal(
 	ctx, cancel := context.WithTimeout(context.Background(), HintTimeout)
 	defer cancel()
 
+	hintGenStart := debugTime()
+
 	domainHints, domainHintsErr := h.hintService.GenerateHints(
 		ctx,
 		filterRoles,
@@ -250,7 +260,14 @@ func (h *Handler) activateHintModeInternal(
 		return
 	}
 
+	debugElapsed(h.logger, hintGenStart, "GenerateHints completed",
+		zap.Int("total_hints", len(domainHints)))
+
 	filteredHints := filterHintsForScreen(domainHints, activeScreenBounds)
+
+	debugElapsed(h.logger, hintGenStart, "FilterHintsForScreen completed",
+		zap.Int("after_filter", len(filteredHints)),
+		zap.Int("before_filter", len(domainHints)))
 
 	h.logger.Debug("Filtered hints by screen",
 		zap.Int("total_hints", len(domainHints)),
@@ -326,9 +343,13 @@ func (h *Handler) activateHintModeInternal(
 
 	h.hints.Context.SetRouter(domainHint.NewRouter(h.hints.Context.Manager(), h.logger))
 
+	debugElapsed(h.logger, hintGenStart, "Manager.SetHints completed")
+
 	h.hints.Context.SetHints(hintCollection)
 	h.overlayManager.ResizeToActiveScreen()
 	h.overlayManager.Show()
+
+	debugElapsed(h.logger, hintGenStart, "Hints mode fully activated")
 
 	if actionStr != nil {
 		h.logger.Info("Hints mode activated with pending action", zap.String("action", *actionStr))

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -15,9 +15,6 @@ import (
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
-// debugTime returns a timestamp for measuring elapsed time.
-func debugTime() time.Time { return time.Now() }
-
 // debugElapsed logs the duration since start with the given message.
 func debugElapsed(logger *zap.Logger, start time.Time, msg string, fields ...zap.Field) {
 	logger.Debug(msg, append(fields, zap.Duration("elapsed", time.Since(start)))...)
@@ -238,7 +235,7 @@ func (h *Handler) activateHintModeInternal(
 	ctx, cancel := context.WithTimeout(context.Background(), HintTimeout)
 	defer cancel()
 
-	hintGenStart := debugTime()
+	hintGenStart := time.Now()
 
 	domainHints, domainHintsErr := h.hintService.GenerateHints(
 		ctx,

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -20,7 +20,7 @@ func debugTime() time.Time { return time.Now() }
 
 // debugElapsed logs the duration since start with the given message.
 func debugElapsed(logger *zap.Logger, start time.Time, msg string, fields ...zap.Field) {
-	logger.Debug(msg, append(fields, zap.Duration("elapsed_ms", time.Since(start)))...)
+	logger.Debug(msg, append(fields, zap.Duration("elapsed", time.Since(start)))...)
 }
 
 // ModeActivationOptions configures a mode activation request.

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -235,7 +235,7 @@ func (h *Handler) activateHintModeInternal(
 	ctx, cancel := context.WithTimeout(context.Background(), HintTimeout)
 	defer cancel()
 
-	hintGenStart := time.Now()
+	activationStart := time.Now()
 
 	domainHints, domainHintsErr := h.hintService.GenerateHints(
 		ctx,
@@ -257,12 +257,12 @@ func (h *Handler) activateHintModeInternal(
 		return
 	}
 
-	debugElapsed(h.logger, hintGenStart, "GenerateHints completed",
+	debugElapsed(h.logger, activationStart, "GenerateHints completed",
 		zap.Int("total_hints", len(domainHints)))
 
 	filteredHints := filterHintsForScreen(domainHints, activeScreenBounds)
 
-	debugElapsed(h.logger, hintGenStart, "FilterHintsForScreen completed",
+	debugElapsed(h.logger, activationStart, "FilterHintsForScreen completed",
 		zap.Int("after_filter", len(filteredHints)),
 		zap.Int("before_filter", len(domainHints)))
 
@@ -340,7 +340,7 @@ func (h *Handler) activateHintModeInternal(
 
 	h.hints.Context.SetRouter(domainHint.NewRouter(h.hints.Context.Manager(), h.logger))
 
-	debugElapsed(h.logger, hintGenStart, "Manager.SetHints completed")
+	debugElapsed(h.logger, activationStart, "Manager.SetHints completed")
 
 	h.hints.Context.SetHints(hintCollection)
 	h.overlayManager.ResizeToActiveScreen()
@@ -349,11 +349,11 @@ func (h *Handler) activateHintModeInternal(
 	if actionStr != nil {
 		h.logger.Info("Hints mode activated",
 			zap.String("action", *actionStr),
-			zap.Duration("elapsed", time.Since(hintGenStart)),
+			zap.Duration("elapsed", time.Since(activationStart)),
 		)
 	} else {
 		h.logger.Info("Hints mode activated",
-			zap.Duration("elapsed", time.Since(hintGenStart)),
+			zap.Duration("elapsed", time.Since(activationStart)),
 		)
 	}
 

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -152,7 +152,7 @@ func (s *HintService) GenerateHints(
 	axStart := time.Now()
 	elements, elementsErr := s.accessibility.ClickableElements(ctx, filter)
 	s.logger.Debug("TIMING: ClickableElements",
-		zap.Duration("elapsed_ms", time.Since(axStart)),
+		zap.Duration("elapsed", time.Since(axStart)),
 		zap.Int("element_count", len(elements)),
 		zap.Error(elementsErr))
 
@@ -184,7 +184,7 @@ func (s *HintService) GenerateHints(
 	genStart := time.Now()
 	hints, elementsErr := gen.Generate(ctx, elements)
 	s.logger.Debug("TIMING: HintGenerator.Generate",
-		zap.Duration("elapsed_ms", time.Since(genStart)),
+		zap.Duration("elapsed", time.Since(genStart)),
 		zap.Int("element_count", len(elements)),
 		zap.Int("hint_count", len(hints)),
 		zap.Error(elementsErr))

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -148,7 +149,13 @@ func (s *HintService) GenerateHints(
 	}
 
 	// Get clickable elements
+	axStart := time.Now()
 	elements, elementsErr := s.accessibility.ClickableElements(ctx, filter)
+	s.logger.Debug("TIMING: ClickableElements",
+		zap.Duration("elapsed_ms", time.Since(axStart)),
+		zap.Int("element_count", len(elements)),
+		zap.Error(elementsErr))
+
 	if elementsErr != nil {
 		s.logger.Error("Failed to get clickable elements", zap.Error(elementsErr))
 
@@ -174,7 +181,14 @@ func (s *HintService) GenerateHints(
 	}
 
 	// Generate hints
+	genStart := time.Now()
 	hints, elementsErr := gen.Generate(ctx, elements)
+	s.logger.Debug("TIMING: HintGenerator.Generate",
+		zap.Duration("elapsed_ms", time.Since(genStart)),
+		zap.Int("element_count", len(elements)),
+		zap.Int("hint_count", len(hints)),
+		zap.Error(elementsErr))
+
 	if elementsErr != nil {
 		s.logger.Error("Failed to generate hints", zap.Error(elementsErr))
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -780,6 +780,7 @@ type AdditionalAXSupport struct {
 	AdditionalElectronBundles []string `json:"additionalElectronBundles" toml:"additional_electron_bundles"`
 	AdditionalChromiumBundles []string `json:"additionalChromiumBundles" toml:"additional_chromium_bundles"`
 	AdditionalFirefoxBundles  []string `json:"additionalFirefoxBundles"  toml:"additional_firefox_bundles"`
+	AdditionalWebKitBundles   []string `json:"additionalWebKitBundles"   toml:"additional_webkit_bundles"`
 }
 
 // SystrayConfig defines system tray settings.
@@ -1595,4 +1596,13 @@ var KnownElectronBundles = []string{
 	"com.tinyspeck.slackmacgap",
 	"com.spotify.client",
 	"md.obsidian",
+	"com.hnc.discord",
+	"com.openai.codex",
+	"com.google.antigravity",
+}
+
+// KnownWebKitBundles contains known WebKit-based application bundle identifiers.
+// These applications skip hit-test visibility checks to avoid slow AX API calls.
+var KnownWebKitBundles = []string{
+	"com.apple.Safari",
 }

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -353,6 +353,7 @@ func newDefaultConfig() *Config {
 				AdditionalElectronBundles: []string{},
 				AdditionalChromiumBundles: []string{},
 				AdditionalFirefoxBundles:  []string{},
+				AdditionalWebKitBundles:   []string{},
 			},
 		},
 		Grid: GridConfig{

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -352,12 +352,12 @@ func (a *Adapter) ClickableElements(
 	elapsed := time.Since(adapterStart)
 	a.logger.Info("Total elements collected",
 		zap.Int("count", len(allElements)),
-		zap.Duration("total_ms", elapsed))
+		zap.Duration("total", elapsed))
 
 	// Log warning if collection took too long
 	if elapsed > 2*time.Second {
 		a.logger.Warn("TIMING: ClickableElements took too long",
-			zap.Duration("elapsed_ms", elapsed),
+			zap.Duration("elapsed", elapsed),
 			zap.Int("element_count", len(allElements)),
 		)
 	}
@@ -550,7 +550,7 @@ func (a *Adapter) processClickableNodes(
 	processStart := time.Now()
 	defer func() {
 		a.logger.Debug("TIMING: processClickableNodes",
-			zap.Duration("elapsed_ms", time.Since(processStart)),
+			zap.Duration("elapsed", time.Since(processStart)),
 			zap.Int("node_count", len(clickableNodes)),
 		)
 	}()

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -124,6 +125,8 @@ func (a *Adapter) ClickableElements(
 	}
 
 	a.logger.Debug("Getting clickable elements", zap.Any("filter", filter))
+
+	adapterStart := time.Now()
 
 	var (
 		waitGroup sync.WaitGroup
@@ -346,7 +349,18 @@ func (a *Adapter) ClickableElements(
 		)
 	}
 
-	a.logger.Info("Total elements collected", zap.Int("count", len(allElements)))
+	elapsed := time.Since(adapterStart)
+	a.logger.Info("Total elements collected",
+		zap.Int("count", len(allElements)),
+		zap.Duration("total_ms", elapsed))
+
+	// Log warning if collection took too long
+	if elapsed > 2*time.Second {
+		a.logger.Warn("TIMING: ClickableElements took too long",
+			zap.Duration("elapsed_ms", elapsed),
+			zap.Int("element_count", len(allElements)),
+		)
+	}
 
 	return allElements, nil
 }
@@ -531,6 +545,14 @@ func (a *Adapter) processClickableNodes(
 		}
 
 		elementSlicePool.Put(elementsPtr)
+	}()
+
+	processStart := time.Now()
+	defer func() {
+		a.logger.Debug("TIMING: processClickableNodes",
+			zap.Duration("elapsed_ms", time.Since(processStart)),
+			zap.Int("node_count", len(clickableNodes)),
+		)
 	}()
 
 	// Concurrent processing for large number of nodes

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -776,6 +776,10 @@ func isExcludedOrUnsafe(bundleID string, configProvider config.Provider) bool {
 		return true
 	}
 
+	if isLikelyWebKit(bundleID) {
+		return true
+	}
+
 	if configProvider == nil {
 		return false
 	}
@@ -792,9 +796,16 @@ func isExcludedOrUnsafe(bundleID string, configProvider config.Provider) bool {
 		return true
 	}
 
-	return config.MatchesAdditionalBundle(
+	if config.MatchesAdditionalBundle(
 		bundleID,
 		cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles,
+	) {
+		return true
+	}
+
+	return config.MatchesAdditionalBundle(
+		bundleID,
+		cfg.Hints.AdditionalAXSupport.AdditionalWebKitBundles,
 	)
 }
 
@@ -810,6 +821,7 @@ func isExcludedBundleID(pid int, configProvider config.Provider) bool {
 	pidBundleCacheMu.Lock()
 	if cfg != lastConfigPointer {
 		pidExcludedCache = make(map[int]bool)
+		pidBundleCache = make(map[int]string)
 		lastConfigPointer = cfg
 	}
 	excluded, ok := pidExcludedCache[pid]

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -162,7 +162,7 @@ type TreeOptions struct {
 	stats                *treeStats
 	bundleID             string          // Bundle ID for auto-detecting Chromium/Electron strict filtering
 	configProvider       config.Provider // For checking user-configured Chromium/Electron bundles
-	isChromiumOrElectron bool            // Pre-computed flag for fast check (includes WebKit)
+	isChromiumOrElectron bool            // Pre-computed flag for fast check
 	isWebKit             bool            // Pre-computed flag for WebKit-based apps
 }
 

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -980,7 +980,6 @@ func isWebKit(bundleID string, configProvider config.Provider) bool {
 	}
 
 	// Check known WebKit bundles (Safari, Safari Technology Preview, etc.)
-	bundleID = strings.ToLower(strings.TrimSpace(bundleID))
 	if config.MatchesAdditionalBundle(bundleID, config.KnownWebKitBundles) {
 		return true
 	}

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -161,7 +162,8 @@ type TreeOptions struct {
 	stats                *treeStats
 	bundleID             string          // Bundle ID for auto-detecting Chromium/Electron strict filtering
 	configProvider       config.Provider // For checking user-configured Chromium/Electron bundles
-	isChromiumOrElectron bool            // Pre-computed flag for fast check
+	isChromiumOrElectron bool            // Pre-computed flag for fast check (includes WebKit)
+	isWebKit             bool            // Pre-computed flag for WebKit-based apps
 }
 
 // FilterFunc returns the filter function.
@@ -276,6 +278,8 @@ func BuildTree(ctx context.Context, root *Element, opts TreeOptions) (*TreeNode,
 
 	stats := &treeStats{}
 
+	buildStart := time.Now()
+
 	// Calculate window bounds for spatial filtering.
 	// Fall back to active screen bounds when the root element has no
 	// position/size (e.g. an AXApplication for supplementary sources).
@@ -291,6 +295,7 @@ func BuildTree(ctx context.Context, root *Element, opts TreeOptions) (*TreeNode,
 		opts.bundleID = root.BundleIdentifier()
 	}
 	opts.isChromiumOrElectron = isChromiumOrElectron(opts.bundleID, opts.configProvider)
+	opts.isWebKit = isWebKit(opts.bundleID, opts.configProvider)
 
 	node := getTreeNode(root, info, nil, config.DefaultChildrenCapacity)
 
@@ -310,6 +315,20 @@ func BuildTree(ctx context.Context, root *Element, opts TreeOptions) (*TreeNode,
 	}
 
 	accumulateSearchText(node)
+
+	buildElapsed := time.Since(buildStart)
+	if ce := opts.Logger().Check(zap.DebugLevel, "TIMING: BuildTree"); ce != nil {
+		ce.Write(
+			zap.Duration("elapsed_ms", buildElapsed),
+			zap.Int64("nodes_visited", stats.nodesVisited.Load()),
+			zap.Int64("max_depth_seen", stats.maxDepthSeen.Load()),
+			zap.Int64("skipped_non_interactive", stats.skippedNonInteractive.Load()),
+			zap.String("root_role", info.Role()),
+			zap.Int("pid", info.PID()),
+			zap.Bool("is_chromium_electron", opts.isChromiumOrElectron),
+			zap.Bool("is_webkit", opts.isWebKit),
+		)
+	}
 
 	if ce := opts.Logger().Check(zap.DebugLevel, "Tree build completed"); ce != nil {
 		ce.Write(
@@ -442,7 +461,7 @@ func buildTreeRecursive(
 	//
 	// Example, try this site: https://nix-darwin.github.io/nix-darwin/manual/
 	elementRect := rectFromInfo(parent.info)
-	if !elementRect.Overlaps(windowBounds) && opts.isChromiumOrElectron {
+	if !elementRect.Overlaps(windowBounds) && (opts.isChromiumOrElectron || opts.isWebKit) {
 		if opts.stats != nil {
 			opts.stats.outOfBoundsSkipped.Add(1)
 		}
@@ -680,7 +699,7 @@ func shouldIncludeElement(
 	}
 
 	// Strict filtering: auto-enabled for Chromium/Electron apps with noisy DOM trees
-	// For native apps like Safari, we trust the semantic tree to not have noise
+	// WebKit-based apps (Safari) have clean trees that don't need this aggressive filtering
 	if opts.isChromiumOrElectron && elementRect.Dx() > 0 &&
 		elementRect.Dy() > 0 {
 		// Filter out tiny elements that are likely noise in Chromium DOM trees.
@@ -921,6 +940,15 @@ func isLikelyChromiumOrElectron(bundleID string) bool {
 	return false
 }
 
+// isLikelyWebKit returns true if the bundle ID matches known WebKit-based apps.
+func isLikelyWebKit(bundleID string) bool {
+	if bundleID == "" {
+		return false
+	}
+
+	return config.MatchesAdditionalBundle(bundleID, config.KnownWebKitBundles)
+}
+
 // isUserConfiguredChromiumElectron checks if the bundle ID matches user-configured
 // additional Chromium/Electron bundles from config. Supports exact matches and
 // wildcard patterns (ending with *).
@@ -942,4 +970,33 @@ func isUserConfiguredChromiumElectron(bundleID string, configProvider config.Pro
 	electronBundles := cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles
 
 	return config.MatchesAdditionalBundle(bundleID, electronBundles)
+}
+
+// isWebKit returns true if the bundle ID matches known WebKit-based app bundle
+// identifiers or user-configured additional WebKit bundles.
+func isWebKit(bundleID string, configProvider config.Provider) bool {
+	if bundleID == "" {
+		return false
+	}
+
+	// Check known WebKit bundles (Safari, Safari Technology Preview, etc.)
+	bundleID = strings.ToLower(strings.TrimSpace(bundleID))
+	if config.MatchesAdditionalBundle(bundleID, config.KnownWebKitBundles) {
+		return true
+	}
+
+	// Check user-configured additional WebKit bundles
+	if configProvider == nil {
+		return false
+	}
+
+	cfg := configProvider.Get()
+	if cfg == nil {
+		return false
+	}
+
+	return config.MatchesAdditionalBundle(
+		bundleID,
+		cfg.Hints.AdditionalAXSupport.AdditionalWebKitBundles,
+	)
 }

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -451,9 +451,10 @@ func buildTreeRecursive(
 		return
 	}
 
-	// Early exit if element is out of window bounds
-	// and only targeted on Chromium/Electron apps.
-	// They tend to over fetch children and is extremely noisy.
+	// Early exit if element is out of window bounds.
+	// Targeted at Chromium/Electron apps (noisy DOM trees with many off-screen
+	// elements) and WebKit-based apps (e.g. Safari, where skipping off-screen
+	// subtrees avoids expensive AXAPI round-trips).
 	//
 	// This check is intentionally placed before the Children() call to avoid
 	// expensive AXAPI round-trips for off-screen subtrees — the majority of

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -319,7 +319,7 @@ func BuildTree(ctx context.Context, root *Element, opts TreeOptions) (*TreeNode,
 	buildElapsed := time.Since(buildStart)
 	if ce := opts.Logger().Check(zap.DebugLevel, "TIMING: BuildTree"); ce != nil {
 		ce.Write(
-			zap.Duration("elapsed_ms", buildElapsed),
+			zap.Duration("elapsed", buildElapsed),
 			zap.Int64("nodes_visited", stats.nodesVisited.Load()),
 			zap.Int64("max_depth_seen", stats.maxDepthSeen.Load()),
 			zap.Int64("skipped_non_interactive", stats.skippedNonInteractive.Load()),


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds webkit apps to a similar hit test exclusion mechanism like chromium or electron.

```toml
# the default is just safari browrser (com.apple.Safari)
[hints.additional_ax_support]
enable = true
additional_webkit_bundles = [] # here to add more webkit apps
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
