### PR TITLE
feat(hints): mission control notifications and actions

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -342,7 +342,9 @@ You can also start hints mode with the search input shown immediately by using t
 | `include_stage_manager_hints`      | bool   | `false`       | Show hints in Stage Manager                          |
 | `include_pip_hints`                | bool   | `false`       | Show hints on macOS Picture in Picture controls      |
 | `include_screen_capture_hints`     | bool   | `false`       | Show hints on macOS Screen Capture controls          |
-| `detect_mission_control`           | bool   | `false`       | Auto-disable hints when in Mission Control           |
+| `detect_mission_control`           | bool   | `false`       | Enable Mission Control state detection               |
+| `on_mission_control_activated`    | string | `"idle"`      | Action to execute when Mission Control opens         |
+| `on_mission_control_deactivated`  | string | `"idle"`      | Action to execute when Mission Control closes        |
 | `additional_menubar_hints_targets` | array  | see defaults  | Extra menubar bundle IDs                             |
 | `clickable_roles`                  | array  | see defaults  | AX roles that generate hints                         |
 | `ignore_clickable_check`           | bool   | `false`       | Skip clickability heuristic                          |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -343,8 +343,8 @@ You can also start hints mode with the search input shown immediately by using t
 | `include_pip_hints`                | bool   | `false`       | Show hints on macOS Picture in Picture controls      |
 | `include_screen_capture_hints`     | bool   | `false`       | Show hints on macOS Screen Capture controls          |
 | `detect_mission_control`           | bool   | `false`       | Enable Mission Control state detection               |
-| `on_mission_control_activated`    | string | `"idle"`      | Action to execute when Mission Control opens         |
-| `on_mission_control_deactivated`  | string | `"idle"`      | Action to execute when Mission Control closes        |
+| `on_mission_control_activated`    | string | `nil`         | Action to execute when Mission Control opens         |
+| `on_mission_control_deactivated`  | string | `nil`         | Action to execute when Mission Control closes        |
 | `additional_menubar_hints_targets` | array  | see defaults  | Extra menubar bundle IDs                             |
 | `clickable_roles`                  | array  | see defaults  | AX roles that generate hints                         |
 | `ignore_clickable_check`           | bool   | `false`       | Skip clickability heuristic                          |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -474,7 +474,7 @@ detect_mission_control = true
 ```
 
 > [!NOTE]
-> `detect_mission_control` is only working on macOS 26.x (tahoe). Do not enable this if your macOS version is below Tahoe (26.x) at all cost!
+> Mission Control detection uses `CGWindowListCopyWindowInfo` to check for Dock overlay windows. It works on macOS 14+ (Sonoma) and 15+ (Sequoia/Tahoe). On macOS 13 and earlier, it looks for a "Mission Control" app window instead.
 
 ---
 

--- a/internal/app/interfaces.go
+++ b/internal/app/interfaces.go
@@ -39,6 +39,8 @@ type Watcher interface {
 	OnDeactivate(callback appwatcher.AppCallback)
 	OnTerminate(callback appwatcher.AppCallback)
 	OnScreenParametersChanged(callback func())
+	OnMissionControlActivated(callback func())
+	OnMissionControlDeactivated(callback func())
 }
 
 // ModeService defines the common interface for mode-specific services.

--- a/internal/app/interfaces.go
+++ b/internal/app/interfaces.go
@@ -41,6 +41,7 @@ type Watcher interface {
 	OnScreenParametersChanged(callback func())
 	OnMissionControlActivated(callback func())
 	OnMissionControlDeactivated(callback func())
+	SetMCDetection(enabled bool)
 }
 
 // ModeService defines the common interface for mode-specific services.

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/infra/appwatcher"
 	"github.com/y3owk1n/neru/internal/core/infra/electron"
 	"github.com/y3owk1n/neru/internal/core/infra/logger"
 	"github.com/y3owk1n/neru/internal/core/infra/systray"
@@ -195,9 +196,41 @@ func (a *App) setupAppWatcherCallbacks() {
 		a.handleScreenParametersChange()
 	})
 
+	// Watch for Mission Control activated events
+	a.appWatcher.OnMissionControlActivated(func() {
+		cfg := a.configSnapshot()
+		if len(cfg.Hints.OnMissionControlActivated) > 0 && cfg.Hints.DetectMissionControl {
+			a.logger.Info("Mission Control activated: executing actions",
+				zap.Strings("actions", cfg.Hints.OnMissionControlActivated))
+			a.dispatchHotkeyActionsAsync(
+				"mission_control_activated",
+				cfg.Hints.OnMissionControlActivated,
+			)
+		}
+	})
+
+	// Watch for Mission Control deactivated events
+	a.appWatcher.OnMissionControlDeactivated(func() {
+		cfg := a.configSnapshot()
+		if len(cfg.Hints.OnMissionControlDeactivated) > 0 && cfg.Hints.DetectMissionControl {
+			a.logger.Info("Mission Control deactivated: executing actions",
+				zap.Strings("actions", cfg.Hints.OnMissionControlDeactivated))
+			a.dispatchHotkeyActionsAsync(
+				"mission_control_deactivated",
+				cfg.Hints.OnMissionControlDeactivated,
+			)
+		}
+	})
+
 	// Watch for macOS theme changes (Dark Mode / Light Mode) to update
 	// theme-aware label colors without requiring restart.
 	a.setupThemeObserver()
+
+	// Gate Mission Control detection at all levels using config
+	cfg := a.configSnapshot()
+	if w, ok := a.appWatcher.(*appwatcher.Watcher); ok {
+		w.SetMCDetection(cfg.Hints.DetectMissionControl)
+	}
 }
 
 // handleScreenParametersChange responds to display configuration changes by updating overlays.

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
-	"github.com/y3owk1n/neru/internal/core/infra/appwatcher"
 	"github.com/y3owk1n/neru/internal/core/infra/electron"
 	"github.com/y3owk1n/neru/internal/core/infra/logger"
 	"github.com/y3owk1n/neru/internal/core/infra/systray"
@@ -227,10 +226,7 @@ func (a *App) setupAppWatcherCallbacks() {
 	a.setupThemeObserver()
 
 	// Gate Mission Control detection at all levels using config
-	cfg := a.configSnapshot()
-	if w, ok := a.appWatcher.(*appwatcher.Watcher); ok {
-		w.SetMCDetection(cfg.Hints.DetectMissionControl)
-	}
+	a.appWatcher.SetMCDetection(a.configSnapshot().Hints.DetectMissionControl)
 }
 
 // handleScreenParametersChange responds to display configuration changes by updating overlays.

--- a/internal/app/mocks_darwin_test.go
+++ b/internal/app/mocks_darwin_test.go
@@ -324,3 +324,5 @@ func (m *mockAppWatcher) OnActivate(_ appwatcher.AppCallback)   {}
 func (m *mockAppWatcher) OnDeactivate(_ appwatcher.AppCallback) {}
 func (m *mockAppWatcher) OnTerminate(_ appwatcher.AppCallback)  {}
 func (m *mockAppWatcher) OnScreenParametersChanged(_ func())    {}
+func (m *mockAppWatcher) OnMissionControlActivated(_ func())    {}
+func (m *mockAppWatcher) OnMissionControlDeactivated(_ func())  {}

--- a/internal/app/mocks_darwin_test.go
+++ b/internal/app/mocks_darwin_test.go
@@ -326,3 +326,4 @@ func (m *mockAppWatcher) OnTerminate(_ appwatcher.AppCallback)  {}
 func (m *mockAppWatcher) OnScreenParametersChanged(_ func())    {}
 func (m *mockAppWatcher) OnMissionControlActivated(_ func())    {}
 func (m *mockAppWatcher) OnMissionControlDeactivated(_ func())  {}
+func (m *mockAppWatcher) SetMCDetection(_ bool)                 {}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -569,14 +569,16 @@ type HintsConfig struct {
 	SearchInputUI     SearchInputUI       `json:"searchInputUi"     toml:"search_input_ui"`
 	BoundaryHighlight BoundaryHighlightUI `json:"boundaryHighlight" toml:"boundary_highlight"`
 
-	IncludeMenubarHints           bool     `json:"includeMenubarHints"           toml:"include_menubar_hints"`
-	AdditionalMenubarHintsTargets []string `json:"additionalMenubarHintsTargets" toml:"additional_menubar_hints_targets"`
-	IncludeDockHints              bool     `json:"includeDockHints"              toml:"include_dock_hints"`
-	IncludeNCHints                bool     `json:"includeNcHints"                toml:"include_nc_hints"`
-	IncludeStageManagerHints      bool     `json:"includeStageManagerHints"      toml:"include_stage_manager_hints"`
-	IncludePIPHints               bool     `json:"includePipHints"               toml:"include_pip_hints"`
-	IncludeScreenCaptureHints     bool     `json:"includeScreenCaptureHints"     toml:"include_screen_capture_hints"`
-	DetectMissionControl          bool     `json:"detectMissionControl"          toml:"detect_mission_control"`
+	IncludeMenubarHints           bool                `json:"includeMenubarHints"           toml:"include_menubar_hints"`
+	AdditionalMenubarHintsTargets []string            `json:"additionalMenubarHintsTargets" toml:"additional_menubar_hints_targets"`
+	IncludeDockHints              bool                `json:"includeDockHints"              toml:"include_dock_hints"`
+	IncludeNCHints                bool                `json:"includeNcHints"                toml:"include_nc_hints"`
+	IncludeStageManagerHints      bool                `json:"includeStageManagerHints"      toml:"include_stage_manager_hints"`
+	IncludePIPHints               bool                `json:"includePipHints"               toml:"include_pip_hints"`
+	IncludeScreenCaptureHints     bool                `json:"includeScreenCaptureHints"     toml:"include_screen_capture_hints"`
+	DetectMissionControl          bool                `json:"detectMissionControl"          toml:"detect_mission_control"`
+	OnMissionControlActivated     StringOrStringArray `json:"onMissionControlActivated"     toml:"on_mission_control_activated"`
+	OnMissionControlDeactivated   StringOrStringArray `json:"onMissionControlDeactivated"   toml:"on_mission_control_deactivated"`
 
 	ClickableRoles       []string `json:"clickableRoles"       toml:"clickable_roles"`
 	IgnoreClickableCheck bool     `json:"ignoreClickableCheck" toml:"ignore_clickable_check"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -341,6 +341,8 @@ func newDefaultConfig() *Config {
 			IncludePIPHints:               false,
 			IncludeScreenCaptureHints:     false,
 			DetectMissionControl:          false,
+			OnMissionControlActivated:     nil,
+			OnMissionControlDeactivated:   nil,
 
 			ClickableRoles: []string{},
 

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -241,6 +241,14 @@ func (c *Config) ValidateHints() error {
 		)
 	}
 
+	if c.Hints.DetectMissionControl && !c.Hints.IncludeDockHints {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"hints.detect_mission_control requires hints.include_dock_hints = true "+
+				"(dock windows are the only element source available during Mission Control)",
+		)
+	}
+
 	for idx, actionStr := range c.Hints.OnMissionControlActivated {
 		trimmed := strings.TrimSpace(actionStr)
 		if trimmed == "" {

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -233,6 +233,14 @@ func (c *Config) ValidateHints() error {
 		return err
 	}
 
+	if (len(c.Hints.OnMissionControlActivated) > 0 || len(c.Hints.OnMissionControlDeactivated) > 0) &&
+		!c.Hints.DetectMissionControl {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"hints.on_mission_control_activated/deactivated requires hints.detect_mission_control = true",
+		)
+	}
+
 	for idx, actionStr := range c.Hints.OnMissionControlActivated {
 		trimmed := strings.TrimSpace(actionStr)
 		if trimmed == "" {

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -233,6 +233,48 @@ func (c *Config) ValidateHints() error {
 		return err
 	}
 
+	for idx, actionStr := range c.Hints.OnMissionControlActivated {
+		trimmed := strings.TrimSpace(actionStr)
+		if trimmed == "" {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"hints.on_mission_control_activated[%d] cannot be empty",
+				idx,
+			)
+		}
+
+		err := validateHotkeyActionString(trimmed)
+		if err != nil {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"hints.on_mission_control_activated[%d]: %v",
+				idx,
+				err,
+			)
+		}
+	}
+
+	for idx, actionStr := range c.Hints.OnMissionControlDeactivated {
+		trimmed := strings.TrimSpace(actionStr)
+		if trimmed == "" {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"hints.on_mission_control_deactivated[%d] cannot be empty",
+				idx,
+			)
+		}
+
+		err := validateHotkeyActionString(trimmed)
+		if err != nil {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"hints.on_mission_control_deactivated[%d]: %v",
+				idx,
+				err,
+			)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/core/infra/appwatcher/platform_darwin.go
+++ b/internal/core/infra/appwatcher/platform_darwin.go
@@ -15,3 +15,7 @@ func platformStartWatcher() {
 func platformStopWatcher() {
 	darwin.StopAppWatcher()
 }
+
+func platformSetMCDetection(enabled bool) {
+	darwin.SetDetectMissionControlEnabled(enabled)
+}

--- a/internal/core/infra/appwatcher/platform_other.go
+++ b/internal/core/infra/appwatcher/platform_other.go
@@ -5,3 +5,4 @@ package appwatcher
 func platformRegisterWatcher(_ *Watcher) {}
 func platformStartWatcher()              {}
 func platformStopWatcher()               {}
+func platformSetMCDetection(_ bool)      {}

--- a/internal/core/infra/appwatcher/watcher.go
+++ b/internal/core/infra/appwatcher/watcher.go
@@ -201,17 +201,13 @@ func (w *Watcher) HandleScreenParametersChanged() {
 // HandleMissionControlActivated processes Mission Control activation events from the platform layer.
 func (w *Watcher) HandleMissionControlActivated() {
 	w.mu.RLock()
-	enabled := w.mcDetection
-	w.mu.RUnlock()
+	defer w.mu.RUnlock()
 
-	if !enabled {
+	if !w.mcDetection {
 		return
 	}
 
 	w.logger.Debug("App watcher: Mission Control activated")
-
-	w.mu.RLock()
-	defer w.mu.RUnlock()
 
 	for _, callback := range w.mcActivatedCallbacks {
 		callback()
@@ -221,17 +217,13 @@ func (w *Watcher) HandleMissionControlActivated() {
 // HandleMissionControlDeactivated processes Mission Control deactivation events from the platform layer.
 func (w *Watcher) HandleMissionControlDeactivated() {
 	w.mu.RLock()
-	enabled := w.mcDetection
-	w.mu.RUnlock()
+	defer w.mu.RUnlock()
 
-	if !enabled {
+	if !w.mcDetection {
 		return
 	}
 
 	w.logger.Debug("App watcher: Mission Control deactivated")
-
-	w.mu.RLock()
-	defer w.mu.RUnlock()
 
 	for _, callback := range w.mcDeactivatedCallbacks {
 		callback()

--- a/internal/core/infra/appwatcher/watcher.go
+++ b/internal/core/infra/appwatcher/watcher.go
@@ -17,12 +17,15 @@ type AppCallback func(appName string, bundleID string)
 type Watcher struct {
 	mu sync.RWMutex
 	// Callbacks for different events
-	launchCallbacks       []AppCallback
-	terminateCallbacks    []AppCallback
-	activateCallbacks     []AppCallback
-	deactivateCallbacks   []AppCallback
-	screenChangeCallbacks []func()
-	logger                *zap.Logger
+	launchCallbacks        []AppCallback
+	terminateCallbacks     []AppCallback
+	activateCallbacks      []AppCallback
+	deactivateCallbacks    []AppCallback
+	screenChangeCallbacks  []func()
+	mcActivatedCallbacks   []func()
+	mcDeactivatedCallbacks []func()
+	logger                 *zap.Logger
+	mcDetection            bool
 }
 
 // NewWatcher creates and initializes a new application watcher instance.
@@ -49,6 +52,16 @@ func (w *Watcher) Start() {
 func (w *Watcher) Stop() {
 	w.logger.Debug("App watcher: Stopping")
 	platformStopWatcher()
+}
+
+// SetMCDetection enables or disables Mission Control detection at all levels.
+// When disabled, no timer, window scans, or callbacks are active.
+func (w *Watcher) SetMCDetection(enabled bool) {
+	w.mu.Lock()
+	w.mcDetection = enabled
+	w.mu.Unlock()
+
+	platformSetMCDetection(enabled)
 }
 
 // OnLaunch registers a callback for application launch events.
@@ -94,6 +107,22 @@ func (w *Watcher) OnScreenParametersChanged(callback func()) {
 	defer w.mu.Unlock()
 
 	w.screenChangeCallbacks = append(w.screenChangeCallbacks, callback)
+}
+
+// OnMissionControlActivated registers a callback for when Mission Control is activated.
+func (w *Watcher) OnMissionControlActivated(callback func()) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.mcActivatedCallbacks = append(w.mcActivatedCallbacks, callback)
+}
+
+// OnMissionControlDeactivated registers a callback for when Mission Control is deactivated.
+func (w *Watcher) OnMissionControlDeactivated(callback func()) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.mcDeactivatedCallbacks = append(w.mcDeactivatedCallbacks, callback)
 }
 
 // HandleLaunch processes application launch events from the platform layer.
@@ -165,6 +194,46 @@ func (w *Watcher) HandleScreenParametersChanged() {
 	defer w.mu.RUnlock()
 
 	for _, callback := range w.screenChangeCallbacks {
+		callback()
+	}
+}
+
+// HandleMissionControlActivated processes Mission Control activation events from the platform layer.
+func (w *Watcher) HandleMissionControlActivated() {
+	w.mu.RLock()
+	enabled := w.mcDetection
+	w.mu.RUnlock()
+
+	if !enabled {
+		return
+	}
+
+	w.logger.Debug("App watcher: Mission Control activated")
+
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	for _, callback := range w.mcActivatedCallbacks {
+		callback()
+	}
+}
+
+// HandleMissionControlDeactivated processes Mission Control deactivation events from the platform layer.
+func (w *Watcher) HandleMissionControlDeactivated() {
+	w.mu.RLock()
+	enabled := w.mcDetection
+	w.mu.RUnlock()
+
+	if !enabled {
+		return
+	}
+
+	w.logger.Debug("App watcher: Mission Control deactivated")
+
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	for _, callback := range w.mcDeactivatedCallbacks {
 		callback()
 	}
 }

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -277,6 +277,13 @@ int performLeftMouseUpAtCursor(void);
 /// @return true if Mission Control is active, false otherwise
 bool isMissionControlActive(void);
 
+/// Update the cached Mission Control state and trigger transition callbacks
+void updateMissionControlState(void);
+
+/// Enable or disable Mission Control detection.
+/// When disabled, no timer, window scans, or callbacks are active.
+void setDetectMissionControlEnabled(bool enabled);
+
 /// Get main screen bounds
 /// @return Main screen bounds rectangle
 CGRect getMainScreenBounds(void);

--- a/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
@@ -353,7 +353,9 @@ static void initializeMissionControlDetection(void) {
 ///
 /// @return true if Mission Control is active, false otherwise
 bool isMissionControlActive(void) {
-	initializeMissionControlDetection();
+	if (isDetectionEnabled()) {
+		initializeMissionControlDetection();
+	}
 
 	// Return cached state if still valid
 	if (isCacheValid()) {

--- a/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
@@ -13,7 +13,7 @@
 
 // State tracking for Mission Control detection
 static bool g_missionControlActive = false;
-static bool g_mcDetectionEnabled = YES;               // Default to enabled for backward compatibility
+static bool g_mcDetectionEnabled = NO;                // Default to disabled — must be opted in via config
 static CFAbsoluteTime g_lastDetectionTime = 0;        // Use CFAbsoluteTime (double) instead of NSDate
 static NSTimeInterval g_detectionCacheTimeout = 0.5;  // Cache for 500ms
 static id g_spaceChangeObserver = nil;
@@ -217,7 +217,14 @@ static bool detectMissionControlActive(void) {
 
 /// Enable or disable Mission Control detection.
 /// When disabled, the timer and window scans are completely inactive.
-void setDetectMissionControlEnabled(bool enabled) { g_mcDetectionEnabled = enabled; }
+/// When enabled, kicks off lazy initialization of the detection system if
+/// it hasn't been started yet.
+void setDetectMissionControlEnabled(bool enabled) {
+	g_mcDetectionEnabled = enabled;
+	if (enabled && g_detectionQueue == NULL) {
+		updateMissionControlState();
+	}
+}
 
 /// Update the cached Mission Control state on the detection queue
 void updateMissionControlState(void) {
@@ -283,6 +290,10 @@ static void initializeMissionControlDetection(void) {
 			    g_detectionTimer, dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), 1 * NSEC_PER_SEC,
 			    500 * NSEC_PER_MSEC);
 			dispatch_source_set_event_handler(g_detectionTimer, ^{
+				if (!g_mcDetectionEnabled) {
+					return;
+				}
+
 				bool oldState = getCachedMissionControlState();
 				bool newState = detectMissionControlActive();
 				setCachedMissionControlState(newState);
@@ -302,6 +313,10 @@ static void initializeMissionControlDetection(void) {
 
 		// Perform initial detection silently
 		dispatch_async(g_detectionQueue, ^{
+			if (!g_mcDetectionEnabled) {
+				return;
+			}
+
 			bool newState = detectMissionControlActive();
 			setCachedMissionControlState(newState);
 		});

--- a/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
@@ -51,6 +51,23 @@ static void setCachedMissionControlState(bool state) {
 	os_unfair_lock_unlock(&g_stateLock);
 }
 
+/// Thread-safe getter for the detection enabled flag
+/// @return true if detection is enabled
+static bool isDetectionEnabled(void) {
+	os_unfair_lock_lock(&g_stateLock);
+	bool result = g_mcDetectionEnabled;
+	os_unfair_lock_unlock(&g_stateLock);
+	return result;
+}
+
+/// Thread-safe setter for the detection enabled flag
+/// @param enabled New enabled state
+static void setDetectionEnabled(bool enabled) {
+	os_unfair_lock_lock(&g_stateLock);
+	g_mcDetectionEnabled = enabled;
+	os_unfair_lock_unlock(&g_stateLock);
+}
+
 /// Thread-safe cache validity check
 /// @return true if cache is still valid
 static bool isCacheValid(void) {
@@ -220,7 +237,7 @@ static bool detectMissionControlActive(void) {
 /// When enabled, kicks off lazy initialization of the detection system if
 /// it hasn't been started yet.
 void setDetectMissionControlEnabled(bool enabled) {
-	g_mcDetectionEnabled = enabled;
+	setDetectionEnabled(enabled);
 	if (enabled && g_detectionQueue == NULL) {
 		updateMissionControlState();
 	}
@@ -228,7 +245,7 @@ void setDetectMissionControlEnabled(bool enabled) {
 
 /// Update the cached Mission Control state on the detection queue
 void updateMissionControlState(void) {
-	if (!g_mcDetectionEnabled) {
+	if (!isDetectionEnabled()) {
 		setCachedMissionControlState(false);
 		return;
 	}
@@ -290,7 +307,7 @@ static void initializeMissionControlDetection(void) {
 			    g_detectionTimer, dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), 1 * NSEC_PER_SEC,
 			    500 * NSEC_PER_MSEC);
 			dispatch_source_set_event_handler(g_detectionTimer, ^{
-				if (!g_mcDetectionEnabled) {
+				if (!isDetectionEnabled()) {
 					return;
 				}
 
@@ -313,7 +330,7 @@ static void initializeMissionControlDetection(void) {
 
 		// Perform initial detection silently
 		dispatch_async(g_detectionQueue, ^{
-			if (!g_mcDetectionEnabled) {
+			if (!isDetectionEnabled()) {
 				return;
 			}
 

--- a/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
@@ -13,17 +13,24 @@
 
 // State tracking for Mission Control detection
 static bool g_missionControlActive = false;
+static bool g_mcDetectionEnabled = YES;               // Default to enabled for backward compatibility
 static CFAbsoluteTime g_lastDetectionTime = 0;        // Use CFAbsoluteTime (double) instead of NSDate
 static NSTimeInterval g_detectionCacheTimeout = 0.5;  // Cache for 500ms
 static id g_spaceChangeObserver = nil;
 static dispatch_queue_t g_detectionQueue = nil;
+static dispatch_source_t g_detectionTimer = nil;
 
 // Lock for thread-safe access to shared state
 static os_unfair_lock g_stateLock = OS_UNFAIR_LOCK_INIT;
 
-// Forward declaration
-static void updateMissionControlState(void);
+// External callback declarations
+extern void handleMissionControlActivated(void);
+extern void handleMissionControlDeactivated(void);
+
+// Forward declarations
+void updateMissionControlState(void);
 static bool detectMissionControlActive(void);
+static void initializeMissionControlDetection(void);
 
 /// Thread-safe getter for cached Mission Control state
 /// @return true if Mission Control is active
@@ -142,7 +149,10 @@ int scrollAtPoint(CGPoint pos, int deltaX, int deltaY) {
 #pragma mark - Mission Control Detection Functions
 
 /// Internal function to detect Mission Control state using window enumeration
-/// This is the actual detection logic that looks for Dock windows
+/// Detects MC across multiple macOS versions by checking for:
+///   1. "Mission Control" app windows (macOS 13 and earlier)
+///   2. Dock overlay windows at elevated layers (macOS 14 Sonoma, layers ~18-20)
+///   3. Dock overlay windows at broader ranges (macOS 15 Sequoia/Tahoe)
 /// @return true if Mission Control is active, false otherwise
 static bool detectMissionControlActive(void) {
 	@autoreleasepool {
@@ -151,16 +161,9 @@ static bool detectMissionControlActive(void) {
 			return false;
 		}
 
-		// Get all screens for multi-monitor detection
-		NSArray *screens = [NSScreen screens];
-		if (!screens || screens.count == 0) {
-			CFRelease(windowList);
-			return false;
-		}
-
 		CFIndex count = CFArrayGetCount(windowList);
-		int anyHighLayerDockWindows = 0;
-		BOOL missionControlAppVisible = NO;
+		int dockHighLayerWindows = 0;
+		int dockOverlayWindows = 0;
 
 		for (CFIndex i = 0; i < count; i++) {
 			CFDictionaryRef windowInfo = (CFDictionaryRef)CFArrayGetValueAtIndex(windowList, i);
@@ -168,51 +171,82 @@ static bool detectMissionControlActive(void) {
 				continue;
 
 			CFStringRef ownerName = (CFStringRef)CFDictionaryGetValue(windowInfo, kCGWindowOwnerName);
+			if (!ownerName)
+				continue;
 
-			// Check if Mission Control app is visible
-			if (ownerName && CFStringCompare(ownerName, CFSTR("Mission Control"), 0) == kCFCompareEqualTo) {
-				missionControlAppVisible = YES;
+			// Check if Mission Control app is visible (macOS 13 and earlier)
+			if (CFStringCompare(ownerName, CFSTR("Mission Control"), 0) == kCFCompareEqualTo) {
+				CFRelease(windowList);
+				return YES;
 			}
 
-			if (ownerName && CFStringCompare(ownerName, CFSTR("Dock"), 0) == kCFCompareEqualTo) {
-				CFNumberRef windowLayer = (CFNumberRef)CFDictionaryGetValue(windowInfo, kCGWindowLayer);
+			if (CFStringCompare(ownerName, CFSTR("Dock"), 0) != kCFCompareEqualTo)
+				continue;
 
-				int layer = 0;
-				if (windowLayer) {
-					CFNumberGetValue(windowLayer, kCFNumberIntType, &layer);
+			CFNumberRef windowLayer = (CFNumberRef)CFDictionaryGetValue(windowInfo, kCGWindowLayer);
+			if (!windowLayer)
+				continue;
+
+			int layer = 0;
+			CFNumberGetValue(windowLayer, kCFNumberIntType, &layer);
+
+			// Layers 18-20: Dock MC overlays on macOS 14 Sonoma
+			if (layer >= 18 && layer <= 20) {
+				dockHighLayerWindows++;
+				if (dockHighLayerWindows >= 2) {
+					CFRelease(windowList);
+					return YES;
 				}
+			}
 
-				// Count any Dock window at layers 18-20 (only exist during Mission Control)
-				if (layer >= 18 && layer <= 20) {
-					anyHighLayerDockWindows++;
+			// Layers 14-25: broader range covering macOS 15 Sequoia/Tahoe
+			// where the window manager may use different layers
+			if (layer >= 14 && layer <= 25) {
+				dockOverlayWindows++;
+				if (dockOverlayWindows >= 3) {
+					CFRelease(windowList);
+					return YES;
 				}
 			}
 		}
 
 		CFRelease(windowList);
-
-		// Detection logic:
-		// 1. If Mission Control app window is visible, definitely MC
-		// 2. If any Dock windows exist at layers 18-20, definitely MC
-		//    (these layers only appear during MC)
-		int minRequired = 2;
-		BOOL result = NO;
-
-		if (missionControlAppVisible) {
-			result = YES;
-		} else if (anyHighLayerDockWindows >= minRequired) {
-			result = YES;
-		}
-
-		return result;
+		return NO;
 	}
 }
 
+/// Enable or disable Mission Control detection.
+/// When disabled, the timer and window scans are completely inactive.
+void setDetectMissionControlEnabled(bool enabled) { g_mcDetectionEnabled = enabled; }
+
 /// Update the cached Mission Control state on the detection queue
-static void updateMissionControlState(void) {
+void updateMissionControlState(void) {
+	if (!g_mcDetectionEnabled) {
+		setCachedMissionControlState(false);
+		return;
+	}
+
+	if (g_detectionQueue == NULL) {
+		initializeMissionControlDetection();
+		if (g_detectionQueue == NULL) {
+			return;
+		}
+	}
+
 	dispatch_async(g_detectionQueue, ^{
+		bool oldState = getCachedMissionControlState();
 		bool newState = detectMissionControlActive();
 		setCachedMissionControlState(newState);
+
+		if (oldState != newState) {
+			dispatch_async(dispatch_get_main_queue(), ^{
+				if (newState) {
+					handleMissionControlActivated();
+				} else {
+					handleMissionControlDeactivated();
+				}
+			});
+		}
 	});
 }
 
@@ -225,23 +259,53 @@ static void spaceDidChangeNotification(NSNotification *notification) {
 
 /// Initialize Mission Control detection system.
 /// Sets up notification observer and initial state.
-/// Note: Called via dispatch_async from isMissionControlActive, so initialization
-/// is already guarded by the caller's dispatch_once.
 static void initializeMissionControlDetection(void) {
-	g_detectionQueue = dispatch_queue_create("com.neru.missioncontrol.detection", DISPATCH_QUEUE_SERIAL);
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		g_detectionQueue = dispatch_queue_create("com.neru.missioncontrol.detection", DISPATCH_QUEUE_SERIAL);
 
-	// Set up space change notification observer
-	NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
-	NSNotificationCenter *center = [workspace notificationCenter];
-	g_spaceChangeObserver = [center addObserverForName:NSWorkspaceActiveSpaceDidChangeNotification
-	                                            object:nil
-	                                             queue:[NSOperationQueue mainQueue]
-	                                        usingBlock:^(NSNotification *note) {
-		                                        spaceDidChangeNotification(note);
-	                                        }];
+		// Set up space change notification observer
+		NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
+		NSNotificationCenter *center = [workspace notificationCenter];
+		g_spaceChangeObserver = [center addObserverForName:NSWorkspaceActiveSpaceDidChangeNotification
+		                                            object:nil
+		                                             queue:[NSOperationQueue mainQueue]
+		                                        usingBlock:^(NSNotification *note) {
+			                                        spaceDidChangeNotification(note);
+		                                        }];
 
-	// Perform initial detection
-	updateMissionControlState();
+		// Set up a periodic detection timer to handle the case where no
+		// notification fires when MC opens (macOS 15+ Tahoe). This runs on
+		// the background detection queue — fast path when state hasn't changed.
+		g_detectionTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, g_detectionQueue);
+		if (g_detectionTimer) {
+			dispatch_source_set_timer(
+			    g_detectionTimer, dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), 1 * NSEC_PER_SEC,
+			    500 * NSEC_PER_MSEC);
+			dispatch_source_set_event_handler(g_detectionTimer, ^{
+				bool oldState = getCachedMissionControlState();
+				bool newState = detectMissionControlActive();
+				setCachedMissionControlState(newState);
+
+				if (oldState != newState) {
+					dispatch_async(dispatch_get_main_queue(), ^{
+						if (newState) {
+							handleMissionControlActivated();
+						} else {
+							handleMissionControlDeactivated();
+						}
+					});
+				}
+			});
+			dispatch_resume(g_detectionTimer);
+		}
+
+		// Perform initial detection silently
+		dispatch_async(g_detectionQueue, ^{
+			bool newState = detectMissionControlActive();
+			setCachedMissionControlState(newState);
+		});
+	});
 }
 
 #pragma mark - Screen Functions
@@ -257,15 +321,7 @@ static void initializeMissionControlDetection(void) {
 ///
 /// @return true if Mission Control is active, false otherwise
 bool isMissionControlActive(void) {
-	// Initialize on first call — must be on main thread for NSNotificationCenter.
-	// Use dispatch_async to avoid deadlock in test environments where the main queue
-	// might be blocked. The notification observer is set up asynchronously.
-	static dispatch_once_t initToken;
-	dispatch_once(&initToken, ^{
-		dispatch_async(dispatch_get_main_queue(), ^{
-			initializeMissionControlDetection();
-		});
-	});
+	initializeMissionControlDetection();
 
 	// Return cached state if still valid
 	if (isCacheValid()) {

--- a/internal/core/infra/platform/darwin/appwatcher.go
+++ b/internal/core/infra/platform/darwin/appwatcher.go
@@ -14,4 +14,6 @@ type AppWatcherInterface interface {
 	HandleActivate(appName, bundleID string)
 	HandleDeactivate(appName, bundleID string)
 	HandleScreenParametersChanged()
+	HandleMissionControlActivated()
+	HandleMissionControlDeactivated()
 }

--- a/internal/core/infra/platform/darwin/appwatcher_darwin.m
+++ b/internal/core/infra/platform/darwin/appwatcher_darwin.m
@@ -5,6 +5,7 @@
 //  Copyright © 2025 Neru. All rights reserved.
 //
 
+#import "accessibility.h"
 #import "appwatcher.h"
 
 #import <Cocoa/Cocoa.h>
@@ -112,6 +113,8 @@ extern void handleScreenParametersChanged(void);
 				free(bundleIDCopy);
 			});
 		}
+
+		updateMissionControlState();
 	}
 }
 
@@ -136,6 +139,8 @@ extern void handleScreenParametersChanged(void);
 			free(appNameCopy);
 			free(bundleIDCopy);
 		});
+
+		updateMissionControlState();
 	}
 }
 
@@ -236,6 +241,10 @@ void startAppWatcher(void) {
 		                                         selector:@selector(screenParametersDidChange:)
 		                                             name:NSApplicationDidChangeScreenParametersNotification
 		                                           object:nil];
+
+		// Eagerly initialize Mission Control detection so the 1s polling timer
+		// and space-change observer are active before the user interacts with MC.
+		updateMissionControlState();
 	});
 }
 

--- a/internal/core/infra/platform/darwin/appwatcher_darwin.m
+++ b/internal/core/infra/platform/darwin/appwatcher_darwin.m
@@ -242,8 +242,11 @@ void startAppWatcher(void) {
 		                                             name:NSApplicationDidChangeScreenParametersNotification
 		                                           object:nil];
 
-		// Eagerly initialize Mission Control detection so the 1s polling timer
-		// and space-change observer are active before the user interacts with MC.
+		// Synchronize the cached Mission Control state at startup.
+		// If detection is disabled (the default), this is a cheap no-op that
+		// resets the cache to false.  When detection is later enabled via
+		// setDetectMissionControlEnabled, the queue, timer, and space-change
+		// observer are initialized lazily at that point.
 		updateMissionControlState();
 	});
 }

--- a/internal/core/infra/platform/darwin/bridge.go
+++ b/internal/core/infra/platform/darwin/bridge.go
@@ -6,25 +6,29 @@ package darwin
 #include "hotkeys.h"
 #include "theme.h"
 #include "appwatcher.h"
+#include <stdbool.h>
 #include <stdlib.h>
 
 extern void hotkeyCallbackBridge(int hotkeyId, int eventKind, void* userData);
 
 void startAppWatcher();
 void stopAppWatcher();
+void setDetectMissionControlEnabled(bool enabled);
 */
 import "C"
 
 import (
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	"go.uber.org/zap"
 )
 
 var (
-	appWatcher   AppWatcherInterface
-	appWatcherMu sync.RWMutex
+	appWatcher         AppWatcherInterface
+	appWatcherMu       sync.RWMutex
+	mcDetectionEnabled atomic.Bool
 )
 
 // AppWatcher returns the global application watcher instance.
@@ -152,6 +156,14 @@ func SetAppWatcher(watcher AppWatcherInterface) {
 	appWatcher = watcher
 }
 
+// SetDetectMissionControlEnabled enables or disables Mission Control detection.
+// When disabled, the entire detection pipeline is gated at the ObjC level —
+// no timer, no window scans, and no callbacks to the Go bridge.
+func SetDetectMissionControlEnabled(enabled bool) {
+	mcDetectionEnabled.Store(enabled)
+	C.setDetectMissionControlEnabled(C.bool(enabled))
+}
+
 // StartAppWatcher begins monitoring application lifecycle events.
 func StartAppWatcher() {
 	log := getLogger()
@@ -253,6 +265,44 @@ func handleScreenParametersChanged() {
 	}
 }
 
+//export handleMissionControlActivated
+func handleMissionControlActivated() {
+	if !mcDetectionEnabled.Load() {
+		return
+	}
+
+	log := getLogger()
+	log.Debug("Darwin: handleMissionControlActivated called")
+
+	appWatcherMu.RLock()
+	watcher := appWatcher
+	appWatcherMu.RUnlock()
+
+	if watcher != nil {
+		log.Debug("Darwin: Forwarding Mission Control activated event")
+		go watcher.HandleMissionControlActivated()
+	}
+}
+
+//export handleMissionControlDeactivated
+func handleMissionControlDeactivated() {
+	if !mcDetectionEnabled.Load() {
+		return
+	}
+
+	log := getLogger()
+	log.Debug("Darwin: handleMissionControlDeactivated called")
+
+	appWatcherMu.RLock()
+	watcher := appWatcher
+	appWatcherMu.RUnlock()
+
+	if watcher != nil {
+		log.Debug("Darwin: Forwarding Mission Control deactivated event")
+		go watcher.HandleMissionControlDeactivated()
+	}
+}
+
 // HandleAppLaunch simulates an app launch event for testing.
 func HandleAppLaunch(appName, bundleID string) {
 	cName := C.CString(appName)
@@ -296,4 +346,14 @@ func HandleAppDeactivate(appName, bundleID string) {
 // HandleScreenParametersChanged simulates a screen parameters changed event for testing.
 func HandleScreenParametersChanged() {
 	handleScreenParametersChanged()
+}
+
+// HandleMissionControlActivated simulates a Mission Control activation event for testing.
+func HandleMissionControlActivated() {
+	handleMissionControlActivated()
+}
+
+// HandleMissionControlDeactivated simulates a Mission Control deactivation event for testing.
+func HandleMissionControlDeactivated() {
+	handleMissionControlDeactivated()
 }

--- a/internal/core/infra/platform/darwin/bridge_test.go
+++ b/internal/core/infra/platform/darwin/bridge_test.go
@@ -15,11 +15,13 @@ import (
 
 // MockAppWatcher implements AppWatcher for testing.
 type MockAppWatcher struct {
-	launchCalls       []AppEvent
-	terminateCalls    []AppEvent
-	activateCalls     []AppEvent
-	deactivateCalls   []AppEvent
-	screenChangeCalls atomic.Int64
+	launchCalls        []AppEvent
+	terminateCalls     []AppEvent
+	activateCalls      []AppEvent
+	deactivateCalls    []AppEvent
+	screenChangeCalls  atomic.Int64
+	mcActivatedCalls   atomic.Int64
+	mcDeactivatedCalls atomic.Int64
 }
 
 // AppEvent represents an app event.
@@ -46,6 +48,14 @@ func (m *MockAppWatcher) HandleDeactivate(appName, bundleID string) {
 
 func (m *MockAppWatcher) HandleScreenParametersChanged() {
 	m.screenChangeCalls.Add(1)
+}
+
+func (m *MockAppWatcher) HandleMissionControlActivated() {
+	m.mcActivatedCalls.Add(1)
+}
+
+func (m *MockAppWatcher) HandleMissionControlDeactivated() {
+	m.mcDeactivatedCalls.Add(1)
 }
 
 func TestInitializeLogger(t *testing.T) {
@@ -115,6 +125,12 @@ func TestCallbacks(t *testing.T) {
 	mock := &MockAppWatcher{}
 	darwin.SetAppWatcher(mock)
 
+	// Enable Mission Control detection so the handlers forward events
+	darwin.SetDetectMissionControlEnabled(true)
+	t.Cleanup(func() {
+		darwin.SetDetectMissionControlEnabled(false)
+	})
+
 	t.Run("HandleAppLaunch", func(t *testing.T) {
 		darwin.HandleAppLaunch("TestApp", "com.test.app")
 
@@ -163,6 +179,28 @@ func TestCallbacks(t *testing.T) {
 
 		if got := mock.screenChangeCalls.Load(); got != 1 {
 			t.Errorf("Expected 1 screen change call, got %d", got)
+		}
+	})
+
+	t.Run("HandleMissionControlActivated", func(t *testing.T) {
+		darwin.HandleMissionControlActivated()
+
+		// The handler is dispatched in a goroutine, so wait briefly for it to complete.
+		time.Sleep(50 * time.Millisecond)
+
+		if got := mock.mcActivatedCalls.Load(); got != 1 {
+			t.Errorf("Expected 1 mission control activated call, got %d", got)
+		}
+	})
+
+	t.Run("HandleMissionControlDeactivated", func(t *testing.T) {
+		darwin.HandleMissionControlDeactivated()
+
+		// The handler is dispatched in a goroutine, so wait briefly for it to complete.
+		time.Sleep(50 * time.Millisecond)
+
+		if got := mock.mcDeactivatedCalls.Load(); got != 1 {
+			t.Errorf("Expected 1 mission control deactivated call, got %d", got)
 		}
 	})
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR enables automatic action dispatch when mission control is activated or deactivated.

Note! This is very hacky as macOS does not provide an official way for this detection. Use it on your own risk.

For example, the following will launch hints when mission control is activated, and exit when deactivated:

```toml
[hints]
detect_mission_control = true
on_mission_control_activated = "hints --action left_click"
on_mission_control_deactivated = "idle"
```

- Note that `on_mission_control_*` only works if `detect_mission_control` is set to `true`.
- `on_mission_control_*` are nil by default. Meaning does nothing, and it's fully opt-in basis. User has to decide what to do with that.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Follow up for #837

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/6e2cd8d5-ddee-4c74-8d0f-5164a89b5576

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
