### PR TITLE
fix: preserve mode flags on mode refresh

### DIFF
--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -149,7 +149,7 @@ type ModeActivationOptions struct {
 	CursorFollowSelection *bool
 	FilterRoles           []string
 	FilterTextContains    []string
-	Search                bool
+	Search                *bool
 }
 
 // extractModeOptions extracts and validates the optional action and repeat
@@ -185,7 +185,8 @@ func (h *IPCControllerModes) extractModeOptions(
 		case arg == "--repeat" || arg == "-r":
 			opts.Repeat = true
 		case arg == "--search" || arg == "-s":
-			opts.Search = true
+			searchTrue := true
+			opts.Search = &searchTrue
 		case strings.HasPrefix(arg, "--action="):
 			actionArg := strings.TrimPrefix(arg, "--action=")
 			opts.Action = &actionArg

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -145,7 +145,7 @@ func (h *IPCControllerModes) modesUnavailableResponse() ipc.Response {
 // ModeActivationOptions holds the parsed options for activating a navigation mode.
 type ModeActivationOptions struct {
 	Action                *string
-	Repeat                bool
+	Repeat                *bool
 	CursorFollowSelection *bool
 	FilterRoles           []string
 	FilterTextContains    []string
@@ -183,7 +183,8 @@ func (h *IPCControllerModes) extractModeOptions(
 
 		switch {
 		case arg == "--repeat" || arg == "-r":
-			opts.Repeat = true
+			repeatTrue := true
+			opts.Repeat = &repeatTrue
 		case arg == "--search" || arg == "-s":
 			searchTrue := true
 			opts.Search = &searchTrue
@@ -337,7 +338,7 @@ func (h *IPCControllerModes) extractModeOptions(
 		}
 	}
 
-	if opts.Repeat && opts.Action == nil {
+	if opts.Repeat != nil && *opts.Repeat && opts.Action == nil {
 		resp := ipc.Response{
 			Success: false,
 			Message: "--repeat requires an action",

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -18,7 +18,7 @@ import (
 // activateGridModeWithAction activates grid mode with optional action parameter.
 func (h *Handler) activateGridModeWithAction(
 	actionStr *string,
-	repeat bool,
+	repeat *bool,
 	cursorFollowSelection *bool,
 ) {
 	// Detect refresh before validation so we can do partial cleanup on re-activation.
@@ -94,12 +94,16 @@ func (h *Handler) activateGridModeWithAction(
 			h.grid.Context.SetPendingAction(actionStr)
 		}
 
+		if repeat != nil {
+			h.grid.Context.SetRepeat(*repeat)
+		}
+
 		if cursorFollowSelection != nil {
 			h.grid.Context.SetCursorFollowSelection(*cursorFollowSelection)
 		}
 	} else {
 		h.grid.Context.SetPendingAction(actionStr)
-		h.grid.Context.SetRepeat(repeat)
+		h.grid.Context.SetRepeat(repeat != nil && *repeat)
 		h.grid.Context.SetCursorFollowSelection(resolveCursorFollowSelection(
 			domain.ModeGrid,
 			cursorFollowSelection,
@@ -112,7 +116,7 @@ func (h *Handler) activateGridModeWithAction(
 	if actionStr != nil {
 		h.logger.Info("Grid mode activated with pending action",
 			zap.String("action", *actionStr),
-			zap.Bool("repeat", repeat))
+			zap.Bool("repeat", repeat != nil && *repeat))
 	}
 
 	// Only set mode and enable event tap on initial activation;

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -89,12 +89,23 @@ func (h *Handler) activateGridModeWithAction(
 	h.overlayManager.Show()
 
 	// Store pending action and repeat flag if provided
-	h.grid.Context.SetPendingAction(actionStr)
-	h.grid.Context.SetRepeat(repeat)
-	h.grid.Context.SetCursorFollowSelection(resolveCursorFollowSelection(
-		domain.ModeGrid,
-		cursorFollowSelection,
-	))
+	if isRefresh {
+		if actionStr != nil {
+			h.grid.Context.SetPendingAction(actionStr)
+		}
+
+		if cursorFollowSelection != nil {
+			h.grid.Context.SetCursorFollowSelection(*cursorFollowSelection)
+		}
+	} else {
+		h.grid.Context.SetPendingAction(actionStr)
+		h.grid.Context.SetRepeat(repeat)
+		h.grid.Context.SetCursorFollowSelection(resolveCursorFollowSelection(
+			domain.ModeGrid,
+			cursorFollowSelection,
+		))
+	}
+
 	h.grid.Context.ClearSelectionPoint()
 	h.refreshGridVirtualPointerLocked()
 

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -253,6 +253,14 @@ func (h *Handler) RefreshHintsForScreenChange(
 		}
 	}
 
+	// Escape any active IME search session before refreshing hints on the new
+	// screen. The old IME session is bound to the previous screen and loses
+	// focus during the space transition, causing subsequent keystrokes to be
+	// forwarded to the frontmost app instead.
+	if h.hints != nil && h.hints.Context != nil && h.hints.Context.SearchActive() {
+		h.cancelHintSearch()
+	}
+
 	// Get current filter options from context
 	filterRoles := h.hints.Context.FilterRoles()
 	filterTextContains := h.hints.Context.FilterTextContains()
@@ -711,7 +719,7 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 		startWithSearch := h.hints.Context.StartWithSearch()
 
 		h.executeActionAtPoint(pendingAction, center, true, func() {
-			h.activateHintModeInternal(nil, nil, filterRoles, filterTextContains, startWithSearch)
+			h.activateHintModeInternal(nil, nil, filterRoles, filterTextContains, &startWithSearch)
 
 			// Restore state so subsequent cycles continue to execute the action
 			if h.appState.CurrentMode() == domain.ModeHints &&

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -206,15 +206,37 @@ func (h *Handler) activateHintModeInternal(
 	h.appState.SetHintOverlayNeedsRefresh(false)
 
 	if h.hints != nil && h.hints.Context != nil {
-		h.hints.Context.SetPendingAction(actionStr)
-		h.hints.Context.SetRepeat(false)
-		h.hints.Context.SetCursorFollowSelection(resolveCursorFollowSelection(
-			domain.ModeHints,
-			cursorFollowSelection,
-		))
-		h.hints.Context.SetFilterRoles(filterRoles)
-		h.hints.Context.SetFilterTextContains(filterTextContains)
-		h.hints.Context.SetStartWithSearch(search)
+		if isRefresh {
+			// On refresh preserve existing context flags for any field not
+			// explicitly provided. This prevents configured action strings
+			// (e.g. space change → MC callback → "hints" with no args) from
+			// overwriting the user's custom --action flag.
+			if actionStr != nil {
+				h.hints.Context.SetPendingAction(actionStr)
+			}
+
+			if cursorFollowSelection != nil {
+				h.hints.Context.SetCursorFollowSelection(*cursorFollowSelection)
+			}
+
+			if filterRoles != nil {
+				h.hints.Context.SetFilterRoles(filterRoles)
+			}
+
+			if filterTextContains != nil {
+				h.hints.Context.SetFilterTextContains(filterTextContains)
+			}
+		} else {
+			h.hints.Context.SetPendingAction(actionStr)
+			h.hints.Context.SetRepeat(false)
+			h.hints.Context.SetCursorFollowSelection(resolveCursorFollowSelection(
+				domain.ModeHints,
+				cursorFollowSelection,
+			))
+			h.hints.Context.SetFilterRoles(filterRoles)
+			h.hints.Context.SetFilterTextContains(filterTextContains)
+			h.hints.Context.SetStartWithSearch(search)
+		}
 	}
 
 	// Fetch bundle ID for hint generation. Validation already passed (secure input check,

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -27,7 +27,7 @@ type ModeActivationOptions struct {
 	CursorFollowSelection *bool
 	FilterRoles           []string
 	FilterTextContains    []string
-	Search                bool
+	Search                *bool
 }
 
 const (
@@ -108,7 +108,7 @@ func (h *Handler) activateHintModeWithAction(
 	cursorFollowSelection *bool,
 	filterRoles []string,
 	filterTextContains []string,
-	search bool,
+	search *bool,
 ) {
 	h.activateHintModeInternal(
 		action,
@@ -133,7 +133,7 @@ func (h *Handler) activateHintModeInternal(
 	cursorFollowSelection *bool,
 	filterRoles []string,
 	filterTextContains []string,
-	search bool,
+	search *bool,
 ) {
 	// Detect refresh before validation so we can clean up on failure
 	isRefresh := h.appState.CurrentMode() == domain.ModeHints
@@ -141,6 +141,13 @@ func (h *Handler) activateHintModeInternal(
 	// Reset cycle index on refresh since the hint list is regenerated
 	if isRefresh {
 		h.cycleHintIndex = -1
+	}
+
+	// On refresh, properly escape the active IME and clear search state first.
+	// This prevents the IME from becoming orphaned/unfocused during screen/space
+	// transitions where the OS moves focus to the frontmost app.
+	if isRefresh && h.hints != nil && h.hints.Context != nil && h.hints.Context.SearchActive() {
+		h.cancelHintSearch()
 	}
 
 	// Defer bundle ID fetch until after validation (secure input check) to avoid
@@ -226,6 +233,10 @@ func (h *Handler) activateHintModeInternal(
 			if filterTextContains != nil {
 				h.hints.Context.SetFilterTextContains(filterTextContains)
 			}
+
+			if search != nil {
+				h.hints.Context.SetStartWithSearch(*search)
+			}
 		} else {
 			h.hints.Context.SetPendingAction(actionStr)
 			h.hints.Context.SetRepeat(false)
@@ -235,7 +246,7 @@ func (h *Handler) activateHintModeInternal(
 			))
 			h.hints.Context.SetFilterRoles(filterRoles)
 			h.hints.Context.SetFilterTextContains(filterTextContains)
-			h.hints.Context.SetStartWithSearch(search)
+			h.hints.Context.SetStartWithSearch(search != nil && *search)
 		}
 	}
 
@@ -379,7 +390,7 @@ func (h *Handler) activateHintModeInternal(
 		)
 	}
 
-	if search {
+	if search != nil && *search {
 		err := h.startHintSearchLocked()
 		if err != nil {
 			h.logger.Error("Failed to start hint search on activation", zap.Error(err))

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -23,7 +23,7 @@ func debugElapsed(logger *zap.Logger, start time.Time, msg string, fields ...zap
 // ModeActivationOptions configures a mode activation request.
 type ModeActivationOptions struct {
 	Action                *string
-	Repeat                bool
+	Repeat                *bool
 	CursorFollowSelection *bool
 	FilterRoles           []string
 	FilterTextContains    []string
@@ -104,7 +104,7 @@ func filterHintsForScreen(
 // activateHintModeWithAction activates hint mode with optional action parameter.
 func (h *Handler) activateHintModeWithAction(
 	action *string,
-	repeat bool,
+	repeat *bool,
 	cursorFollowSelection *bool,
 	filterRoles []string,
 	filterTextContains []string,
@@ -119,7 +119,7 @@ func (h *Handler) activateHintModeWithAction(
 	)
 
 	// Store repeat flag after activation so the context is already initialized.
-	if repeat && h.hints != nil && h.hints.Context != nil {
+	if repeat != nil && *repeat && h.hints != nil && h.hints.Context != nil {
 		h.hints.Context.SetRepeat(true)
 	}
 }

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -387,7 +387,7 @@ func (h *Handler) handleGridModeKey(key string) {
 			pendingAction,
 			repeat, // Re-activate grid mode when --repeat is set
 			func() {
-				h.activateGridModeWithAction(pendingAction, repeat, &cursorFollowSelection)
+				h.activateGridModeWithAction(pendingAction, &repeat, &cursorFollowSelection)
 			},
 		)
 	} else if targetPoint := gridKeyResult.TargetPoint(); !targetPoint.Eq(image.Point{}) {

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -136,7 +136,7 @@ func (h *Handler) handleHintsModeKey(key string) {
 					&cursorFollowSelection,
 					filterRoles,
 					filterTextContains,
-					startWithSearch,
+					&startWithSearch,
 				)
 				// Restore repeat and action on the fresh context so subsequent
 				// selections continue the repeat cycle.

--- a/internal/app/modes/passthrough.go
+++ b/internal/app/modes/passthrough.go
@@ -184,7 +184,7 @@ func (h *Handler) handlePassthroughLocked(mode domain.Mode, session uint64) {
 		filterRoles := h.hints.Context.FilterRoles()
 		filterTextContains := h.hints.Context.FilterTextContains()
 		startWithSearch := h.hints.Context.StartWithSearch()
-		h.activateHintModeInternal(nil, nil, filterRoles, filterTextContains, startWithSearch)
+		h.activateHintModeInternal(nil, nil, filterRoles, filterTextContains, &startWithSearch)
 	})
 	h.refreshHintsTimer = timer
 }

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -19,7 +19,7 @@ import (
 // activateRecursiveGridModeWithAction activates recursive-grid mode with optional action parameter.
 func (h *Handler) activateRecursiveGridModeWithAction(
 	actionStr *string,
-	repeat bool,
+	repeat *bool,
 	cursorFollowSelection *bool,
 ) {
 	// Detect refresh before validation so we can do partial cleanup on re-activation.
@@ -109,12 +109,16 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 				h.recursiveGrid.Context.SetPendingAction(actionStr)
 			}
 
+			if repeat != nil {
+				h.recursiveGrid.Context.SetRepeat(*repeat)
+			}
+
 			if cursorFollowSelection != nil {
 				h.recursiveGrid.Context.SetCursorFollowSelection(*cursorFollowSelection)
 			}
 		} else {
 			h.recursiveGrid.Context.SetPendingAction(actionStr)
-			h.recursiveGrid.Context.SetRepeat(repeat)
+			h.recursiveGrid.Context.SetRepeat(repeat != nil && *repeat)
 			h.recursiveGrid.Context.SetCursorFollowSelection(cursorShouldFollow)
 		}
 	}
@@ -129,7 +133,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 		h.logger.Info(
 			"Recursive-grid mode activated with pending action",
 			zap.String("action", *actionStr),
-			zap.Bool("repeat", repeat),
+			zap.Bool("repeat", repeat != nil && *repeat),
 		)
 	}
 
@@ -231,7 +235,7 @@ func (h *Handler) handleRecursiveGridKey(key string) {
 			func() {
 				h.activateRecursiveGridModeWithAction(
 					pendingAction,
-					repeat,
+					&repeat,
 					&cursorFollowSelection,
 				)
 			},

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -74,10 +74,15 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 	// Initialize recursive-grid manager
 	h.initializeRecursiveGridManager(normalizedBounds)
 
-	cursorShouldFollow := resolveCursorFollowSelection(
-		domain.ModeRecursiveGrid,
-		cursorFollowSelection,
-	)
+	var cursorShouldFollow bool
+	if isRefresh && cursorFollowSelection == nil && h.recursiveGrid.Context != nil {
+		cursorShouldFollow = h.recursiveGrid.Context.CursorFollowSelection()
+	} else {
+		cursorShouldFollow = resolveCursorFollowSelection(
+			domain.ModeRecursiveGrid,
+			cursorFollowSelection,
+		)
+	}
 
 	// Move cursor to center of initial grid
 	if h.recursiveGrid.Manager != nil {

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -99,9 +99,19 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 	// Draw initial recursive-grid
 	// Store pending action and repeat flag if provided
 	if h.recursiveGrid.Context != nil {
-		h.recursiveGrid.Context.SetPendingAction(actionStr)
-		h.recursiveGrid.Context.SetRepeat(repeat)
-		h.recursiveGrid.Context.SetCursorFollowSelection(cursorShouldFollow)
+		if isRefresh {
+			if actionStr != nil {
+				h.recursiveGrid.Context.SetPendingAction(actionStr)
+			}
+
+			if cursorFollowSelection != nil {
+				h.recursiveGrid.Context.SetCursorFollowSelection(*cursorFollowSelection)
+			}
+		} else {
+			h.recursiveGrid.Context.SetPendingAction(actionStr)
+			h.recursiveGrid.Context.SetRepeat(repeat)
+			h.recursiveGrid.Context.SetCursorFollowSelection(cursorShouldFollow)
+		}
 	}
 
 	// Draw initial recursive-grid


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes an issue where when you launch a mode with certain flag, and then do something that causes screen resize and relaunch automatically, it does not preserve all the flags initially.

After this fix, it should work as the following:

- launch a mode with say `hints --action left_click`
- switch to another space
- neru will automatically relaunch the hints, but now all the flags previously are not loss

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
