### PR TITLE
feat(hints): configurable visibility check for noise reduction

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -78,6 +78,7 @@ clickable_roles = [
 	"AXGenericElement",
 ]
 ignore_clickable_check = false
+visible_check_enabled = false
 
 [hints.hotkeys]
 "Escape" = "idle"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -374,7 +374,7 @@ Default search hotkey:
 bundle_id = "com.apple.Safari"
 additional_clickable_roles = ["AXLink"]
 ignore_clickable_check = true
-visible_check_enabled = false
+visible_check_enabled = true
 ```
 
 See [Per-App Hotkey Overrides](#per-app-hint-hotkey-overrides) for how per-app hotkey overrides work.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -331,23 +331,24 @@ You can also start hints mode with the search input shown immediately by using t
 
 ### Options
 
-| Option                             | Type   | Default       | Description                                          |
-| ---------------------------------- | ------ | ------------- | ---------------------------------------------------- |
-| `enabled`                          | bool   | `true`        | Enable/disable hints mode                            |
-| `hint_characters`                  | string | `"asdfghjkl"` | Characters used for labels                           |
-| `max_depth`                        | int    | `50`          | Max accessibility tree depth (0 = unlimited)         |
-| `include_menubar_hints`            | bool   | `false`       | Show hints on menubar items                          |
-| `include_dock_hints`               | bool   | `false`       | Show hints on Dock items                             |
-| `include_nc_hints`                 | bool   | `false`       | Show hints in Notification Center                    |
-| `include_stage_manager_hints`      | bool   | `false`       | Show hints in Stage Manager                          |
-| `include_pip_hints`                | bool   | `false`       | Show hints on macOS Picture in Picture controls      |
-| `include_screen_capture_hints`     | bool   | `false`       | Show hints on macOS Screen Capture controls          |
-| `detect_mission_control`           | bool   | `false`       | Enable Mission Control state detection               |
-| `on_mission_control_activated`    | string | `nil`         | Action to execute when Mission Control opens         |
-| `on_mission_control_deactivated`  | string | `nil`         | Action to execute when Mission Control closes        |
-| `additional_menubar_hints_targets` | array  | see defaults  | Extra menubar bundle IDs                             |
-| `clickable_roles`                  | array  | see defaults  | AX roles that generate hints                         |
-| `ignore_clickable_check`           | bool   | `false`       | Skip clickability heuristic                          |
+| Option                             | Type   | Default       | Description                                                                                                                                     |
+| ---------------------------------- | ------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                          | bool   | `true`        | Enable/disable hints mode                                                                                                                       |
+| `hint_characters`                  | string | `"asdfghjkl"` | Characters used for labels                                                                                                                      |
+| `max_depth`                        | int    | `50`          | Max accessibility tree depth (0 = unlimited)                                                                                                    |
+| `include_menubar_hints`            | bool   | `false`       | Show hints on menubar items                                                                                                                     |
+| `include_dock_hints`               | bool   | `false`       | Show hints on Dock items                                                                                                                        |
+| `include_nc_hints`                 | bool   | `false`       | Show hints in Notification Center                                                                                                               |
+| `include_stage_manager_hints`      | bool   | `false`       | Show hints in Stage Manager                                                                                                                     |
+| `include_pip_hints`                | bool   | `false`       | Show hints on macOS Picture in Picture controls                                                                                                 |
+| `include_screen_capture_hints`     | bool   | `false`       | Show hints on macOS Screen Capture controls                                                                                                     |
+| `detect_mission_control`           | bool   | `false`       | Enable Mission Control state detection                                                                                                          |
+| `on_mission_control_activated`     | string | `nil`         | Action to execute when Mission Control opens                                                                                                    |
+| `on_mission_control_deactivated`   | string | `nil`         | Action to execute when Mission Control closes                                                                                                   |
+| `additional_menubar_hints_targets` | array  | see defaults  | Extra menubar bundle IDs                                                                                                                        |
+| `clickable_roles`                  | array  | see defaults  | AX roles that generate hints                                                                                                                    |
+| `ignore_clickable_check`           | bool   | `false`       | Skip clickability heuristic                                                                                                                     |
+| `visible_check_enabled`            | bool   | `false`       | Enable visibility hit-test for elements (this uses expensive AX api, it will cause tree traversing slower if enabled, but get less noisy hints) |
 
 Default search hotkey:
 
@@ -365,6 +366,7 @@ Default search hotkey:
 | `bundle_id`                  | string | App bundle ID (e.g. "com.apple.Safari")  |
 | `additional_clickable_roles` | array  | Extra AX roles to treat as clickable     |
 | `ignore_clickable_check`     | bool   | Skip clickability heuristic for this app |
+| `visible_check_enabled`      | bool   | Enable visibility hit-test for this app  |
 | `hotkeys`                    | map    | Per-app hotkey overrides (see below)     |
 
 ```toml
@@ -372,6 +374,7 @@ Default search hotkey:
 bundle_id = "com.apple.Safari"
 additional_clickable_roles = ["AXLink"]
 ignore_clickable_check = true
+visible_check_enabled = false
 ```
 
 See [Per-App Hotkey Overrides](#per-app-hint-hotkey-overrides) for how per-app hotkey overrides work.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -491,6 +491,7 @@ type AppConfig struct {
 	BundleID             string                         `json:"bundleId"             toml:"bundle_id"`
 	AdditionalClickable  []string                       `json:"additionalClickable"  toml:"additional_clickable_roles"`
 	IgnoreClickableCheck bool                           `json:"ignoreClickableCheck" toml:"ignore_clickable_check"`
+	VisibleCheckEnabled  bool                           `json:"visibleCheckEnabled"  toml:"visible_check_enabled"`
 	Hotkeys              map[string]StringOrStringArray `json:"hotkeys"              toml:"hotkeys"`
 }
 
@@ -582,6 +583,7 @@ type HintsConfig struct {
 
 	ClickableRoles       []string `json:"clickableRoles"       toml:"clickable_roles"`
 	IgnoreClickableCheck bool     `json:"ignoreClickableCheck" toml:"ignore_clickable_check"`
+	VisibleCheckEnabled  bool     `json:"visibleCheckEnabled"  toml:"visible_check_enabled"`
 
 	AppConfigs []AppConfig `json:"appConfigs" toml:"app_configs"`
 
@@ -1403,6 +1405,18 @@ func (c *Config) ShouldIgnoreClickableCheckForApp(bundleID string) bool {
 
 	// Fall back to global ignore_clickable_check
 	return c.Hints.IgnoreClickableCheck
+}
+
+// ShouldEnableVisibleCheckForApp returns whether the visibility hit-test check should be performed
+// for a specific app bundle ID. It first checks for app-specific configuration, then falls back
+// to the global setting. Default is false (visibility check skipped).
+func (c *Config) ShouldEnableVisibleCheckForApp(bundleID string) bool {
+	appConfig := c.Hints.AppConfigForBundleID(bundleID)
+	if appConfig != nil {
+		return appConfig.VisibleCheckEnabled
+	}
+
+	return c.Hints.VisibleCheckEnabled
 }
 
 // rolesMapToSlice converts a roles map to a slice.

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -347,6 +347,7 @@ func newDefaultConfig() *Config {
 			ClickableRoles: []string{},
 
 			IgnoreClickableCheck: false,
+			VisibleCheckEnabled:  false,
 
 			AppConfigs: []AppConfig{},
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -356,6 +356,123 @@ func TestConfig_AppConfigIgnoreClickableCheck(t *testing.T) {
 	}
 }
 
+func TestConfig_AppConfigVisibleCheckEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *config.Config
+		bundleID string
+		want     bool
+	}{
+		{
+			name: "no app configs",
+			config: &config.Config{
+				Hints: config.HintsConfig{},
+			},
+			bundleID: "com.example.app",
+			want:     false,
+		},
+		{
+			name: "app config with matching bundle ID and visible check true",
+			config: &config.Config{
+				Hints: config.HintsConfig{
+					AppConfigs: []config.AppConfig{
+						{
+							BundleID:            "com.example.app",
+							VisibleCheckEnabled: true,
+						},
+					},
+				},
+			},
+			bundleID: "com.example.app",
+			want:     true,
+		},
+		{
+			name: "app config with matching bundle ID and visible check false",
+			config: &config.Config{
+				Hints: config.HintsConfig{
+					AppConfigs: []config.AppConfig{
+						{
+							BundleID:            "com.example.app",
+							VisibleCheckEnabled: false,
+						},
+					},
+				},
+			},
+			bundleID: "com.example.app",
+			want:     false,
+		},
+		{
+			name: "app config with non-matching bundle ID",
+			config: &config.Config{
+				Hints: config.HintsConfig{
+					AppConfigs: []config.AppConfig{
+						{
+							BundleID:            "com.other.app",
+							VisibleCheckEnabled: true,
+						},
+					},
+				},
+			},
+			bundleID: "com.example.app",
+			want:     false,
+		},
+		{
+			name: "multiple app configs, one matching",
+			config: &config.Config{
+				Hints: config.HintsConfig{
+					AppConfigs: []config.AppConfig{
+						{
+							BundleID:            "com.other.app",
+							VisibleCheckEnabled: true,
+						},
+						{
+							BundleID:            "com.example.app",
+							VisibleCheckEnabled: true,
+						},
+					},
+				},
+			},
+			bundleID: "com.example.app",
+			want:     true,
+		},
+		{
+			name: "global visible check enabled true",
+			config: &config.Config{
+				Hints: config.HintsConfig{
+					VisibleCheckEnabled: true,
+				},
+			},
+			bundleID: "com.example.app",
+			want:     true,
+		},
+		{
+			name: "app config overrides global visible check",
+			config: &config.Config{
+				Hints: config.HintsConfig{
+					VisibleCheckEnabled: true, // global true
+					AppConfigs: []config.AppConfig{
+						{
+							BundleID:            "com.example.app",
+							VisibleCheckEnabled: false, // app-specific false
+						},
+					},
+				},
+			},
+			bundleID: "com.example.app",
+			want:     false, // app-specific should take precedence
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := testCase.config.ShouldEnableVisibleCheckForApp(testCase.bundleID)
+			if got != testCase.want {
+				t.Errorf("ShouldEnableVisibleCheckForApp() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
 func TestConfig_HotkeysForModeAndApp(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Hints.Hotkeys["Return"] = config.StringOrStringArray{"action left_click", "hints"}

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -747,14 +747,33 @@ func (e *Element) IsClickable(
 // (empty bundleID) so that a reused PID is always re-queried rather than
 // inheriting a stale mapping from a previous process.
 var (
-	pidBundleCache   = map[int]string{}
-	pidBundleCacheMu sync.RWMutex
+	pidBundleCache       = map[int]string{}
+	pidVisibleCheckCache = map[int]bool{}
+	lastConfigPointer    *config.Config
+	pidBundleCacheMu     sync.RWMutex
 )
 
 // resolveVisibleCheckEnabled checks the config to determine if the visibility
 // hit-test should be performed for the given PID. Returns true if the visibility
 // check should run, false to skip it.
 func resolveVisibleCheckEnabled(pid int, configProvider config.Provider) bool {
+	var cfg *config.Config
+	if configProvider != nil {
+		cfg = configProvider.Get()
+	}
+
+	pidBundleCacheMu.Lock()
+	if cfg != lastConfigPointer {
+		pidVisibleCheckCache = make(map[int]bool)
+		lastConfigPointer = cfg
+	}
+	enabled, ok := pidVisibleCheckCache[pid]
+	pidBundleCacheMu.Unlock()
+
+	if ok {
+		return enabled
+	}
+
 	pidBundleCacheMu.RLock()
 	bundleID, hasBundle := pidBundleCache[pid]
 	pidBundleCacheMu.RUnlock()
@@ -773,16 +792,19 @@ func resolveVisibleCheckEnabled(pid int, configProvider config.Provider) bool {
 		pidBundleCacheMu.Unlock()
 	}
 
-	if bundleID == "" || configProvider == nil {
+	if bundleID == "" || cfg == nil {
 		return false
 	}
 
-	cfg := configProvider.Get()
-	if cfg == nil {
-		return false
-	}
+	res := cfg.ShouldEnableVisibleCheckForApp(bundleID)
 
-	return cfg.ShouldEnableVisibleCheckForApp(bundleID)
+	pidBundleCacheMu.Lock()
+	if cfg == lastConfigPointer {
+		pidVisibleCheckCache[pid] = res
+	}
+	pidBundleCacheMu.Unlock()
+
+	return res
 }
 
 // IsMissionControlActive checks if Mission Control is currently active.

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -765,6 +765,7 @@ func resolveVisibleCheckEnabled(pid int, configProvider config.Provider) bool {
 	pidBundleCacheMu.Lock()
 	if cfg != lastConfigPointer {
 		pidVisibleCheckCache = make(map[int]bool)
+		pidBundleCache = make(map[int]string)
 		lastConfigPointer = cfg
 	}
 	enabled, ok := pidVisibleCheckCache[pid]

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -114,7 +114,6 @@ type ElementInfo struct {
 	hasShowMenuAction bool
 	preActionsFetched bool
 	pid               int
-	skipHitTest       bool
 }
 
 // Position returns the element position.
@@ -715,9 +714,9 @@ func (e *Element) IsClickable(
 		centerX := C.double(info.Position().X + info.Size().X/2)
 		centerY := C.double(info.Position().Y + info.Size().Y/2)
 
-		// Skip hit-test for Chromium/Electron apps (noisy DOM) OR for nodes
-		// within the original window clip bounds (non-scroll areas).
-		skipVisCheck := isExcludedBundleID(info.PID(), configProvider) || info.skipHitTest
+		// Resolve visibility check from config (per-app override, then global).
+		// visible_check_enabled defaults to false, meaning skipVisCheck is true by default.
+		skipVisCheck := !resolveVisibleCheckEnabled(info.PID(), configProvider)
 
 		isWidget := strings.HasPrefix(info.Identifier(), "widget-local:")
 
@@ -746,91 +745,16 @@ func (e *Element) IsClickable(
 // pidBundleCache maps PID → bundle identifier to avoid repeated Cocoa lookups.
 // NOTE: PIDs are reused by macOS. The cache intentionally omits negative results
 // (empty bundleID) so that a reused PID is always re-queried rather than
-// inheriting a stale excluded mapping from a previous process.
+// inheriting a stale mapping from a previous process.
 var (
-	pidBundleCache    = map[int]string{}
-	pidExcludedCache  = map[int]bool{}
-	lastConfigPointer *config.Config
-	pidBundleCacheMu  sync.RWMutex
-	excludedBundleIDs = map[string]struct{}{
-		"com.apple.PIPAgent":             {},
-		"com.apple.screencaptureui":      {},
-		"com.apple.dock":                 {},
-		"com.apple.notificationcenterui": {},
-	}
+	pidBundleCache   = map[int]string{}
+	pidBundleCacheMu sync.RWMutex
 )
 
-// isExcludedOrUnsafe checks whether the given bundle ID should skip the
-// hit-test visibility check — either because it is a known system bundle
-// where the check is not needed (excludedBundleIDs), or because AX hit-testing
-// is unreliable for that app (e.g. Chromium/Electron apps render UI in GPU
-// surfaces that don't expose fine-grained AX hit-testing).
-// Uses config.Known*Bundles as the source of truth (shared with the electron
-// package) rather than duplicating or importing electron directly.
-func isExcludedOrUnsafe(bundleID string, configProvider config.Provider) bool {
-	if _, excluded := excludedBundleIDs[bundleID]; excluded {
-		return true
-	}
-
-	if isLikelyChromiumOrElectron(bundleID) {
-		return true
-	}
-
-	if isLikelyWebKit(bundleID) {
-		return true
-	}
-
-	if configProvider == nil {
-		return false
-	}
-
-	cfg := configProvider.Get()
-	if cfg == nil {
-		return false
-	}
-
-	if config.MatchesAdditionalBundle(
-		bundleID,
-		cfg.Hints.AdditionalAXSupport.AdditionalChromiumBundles,
-	) {
-		return true
-	}
-
-	if config.MatchesAdditionalBundle(
-		bundleID,
-		cfg.Hints.AdditionalAXSupport.AdditionalElectronBundles,
-	) {
-		return true
-	}
-
-	return config.MatchesAdditionalBundle(
-		bundleID,
-		cfg.Hints.AdditionalAXSupport.AdditionalWebKitBundles,
-	)
-}
-
-// isExcludedBundleID checks if the process with the given PID belongs to a
-// bundle ID that should skip the expensive visibility check. Results are
-// cached by PID to avoid redundant Cocoa lookups.
-func isExcludedBundleID(pid int, configProvider config.Provider) bool {
-	var cfg *config.Config
-	if configProvider != nil {
-		cfg = configProvider.Get()
-	}
-
-	pidBundleCacheMu.Lock()
-	if cfg != lastConfigPointer {
-		pidExcludedCache = make(map[int]bool)
-		pidBundleCache = make(map[int]string)
-		lastConfigPointer = cfg
-	}
-	excluded, ok := pidExcludedCache[pid]
-	pidBundleCacheMu.Unlock()
-
-	if ok {
-		return excluded
-	}
-
+// resolveVisibleCheckEnabled checks the config to determine if the visibility
+// hit-test should be performed for the given PID. Returns true if the visibility
+// check should run, false to skip it.
+func resolveVisibleCheckEnabled(pid int, configProvider config.Provider) bool {
 	pidBundleCacheMu.RLock()
 	bundleID, hasBundle := pidBundleCache[pid]
 	pidBundleCacheMu.RUnlock()
@@ -849,15 +773,16 @@ func isExcludedBundleID(pid int, configProvider config.Provider) bool {
 		pidBundleCacheMu.Unlock()
 	}
 
-	res := isExcludedOrUnsafe(bundleID, configProvider)
-
-	pidBundleCacheMu.Lock()
-	if cfg == lastConfigPointer {
-		pidExcludedCache[pid] = res
+	if bundleID == "" || configProvider == nil {
+		return false
 	}
-	pidBundleCacheMu.Unlock()
 
-	return res
+	cfg := configProvider.Get()
+	if cfg == nil {
+		return false
+	}
+
+	return cfg.ShouldEnableVisibleCheckForApp(bundleID)
 }
 
 // IsMissionControlActive checks if Mission Control is currently active.

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -611,12 +611,6 @@ func buildChildrenSequential(
 
 	// Second pass: create nodes and recurse
 	for _, data := range validChildren {
-		// Skip hit-test for elements within the original window bounds
-		// (not in a scroll area). These elements are guaranteed visible
-		// by the AX tree — only scroll areas can have off-screen children.
-		// Must be set before getTreeNode to avoid relying on pointer aliasing.
-		data.info.skipHitTest = clipBounds == windowBounds
-
 		childNode := getTreeNode(data.element, data.info, parent, 0)
 
 		parent.children = append(parent.children, childNode)
@@ -652,13 +646,6 @@ func buildChildrenSequential(
 // This matches similar filtering in tools like Glyphlow.
 const minElementSize = 15
 
-// shouldIncludeElement combines all filtering logic into one function.
-//
-// The clip-bounds overlap check is always applied so that ALL tree sources —
-// including supplementary ones (dock, menubar, PIP, etc.) — benefit from
-// spatial filtering against their respective clip bounds. Supplementary sources
-// historically passed includeOutOfBounds=true to bypass this check, which let
-// in off-screen elements from those sources.
 func shouldIncludeElement(
 	info *ElementInfo,
 	opts TreeOptions,
@@ -666,66 +653,31 @@ func shouldIncludeElement(
 ) bool {
 	elementRect := rectFromInfo(info)
 
-	// Clip bounds check: always filter elements completely outside the
-	// visible area. This handles both window-level clipping (main window
-	// tree) and scroll-container clipping (AXScrollArea viewport), as well
-	// as screen-level clipping for supplementary sources where clip bounds
-	// fall back to the active screen bounds when the root rect is empty.
-	if elementRect.Dx() > 0 && elementRect.Dy() > 0 {
-		if !elementRect.Overlaps(clipBounds) {
-			if ce := opts.Logger().
-				Check(zap.DebugLevel, "Element filtered by clip bounds"); ce != nil {
-				ce.Write(
-					zap.String("role", info.Role()),
-					zap.Int("elem_x", elementRect.Min.X),
-					zap.Int("elem_y", elementRect.Min.Y),
-					zap.Int("elem_w", elementRect.Dx()),
-					zap.Int("elem_h", elementRect.Dy()),
-					zap.Int("clip_x", clipBounds.Min.X),
-					zap.Int("clip_y", clipBounds.Min.Y),
-					zap.Int("clip_w", clipBounds.Dx()),
-					zap.Int("clip_h", clipBounds.Dy()),
-				)
-			}
-
-			return false
-		}
-	}
-
-	// Filter out zero-sized interactive elements (they're broken/invalid)
 	if elementRect.Dx() == 0 || elementRect.Dy() == 0 {
-		if interactiveLeafRoles[element.Role(info.Role())] {
-			return false
-		}
+		return false
 	}
 
-	// Strict filtering: auto-enabled for Chromium/Electron apps with noisy DOM trees
-	// WebKit-based apps (Safari) have clean trees that don't need this aggressive filtering
-	if opts.isChromiumOrElectron && elementRect.Dx() > 0 &&
-		elementRect.Dy() > 0 {
-		// Filter out tiny elements that are likely noise in Chromium DOM trees.
-		// This is especially important for web content where the DOM can have
-		// thousands of tiny placeholder/structure elements.
-		// Filter if either dimension is too small (not just both)
-		if elementRect.Dx() < minElementSize || elementRect.Dy() < minElementSize {
-			// Only filter if it's not a known important role
-			if !interactiveLeafRoles[element.Role(info.Role())] {
-				return false
-			}
+	if !elementRect.Overlaps(clipBounds) {
+		if ce := opts.Logger().
+			Check(zap.DebugLevel, "Element filtered by clip bounds"); ce != nil {
+			ce.Write(
+				zap.String("role", info.Role()),
+				zap.Int("elem_x", elementRect.Min.X),
+				zap.Int("elem_y", elementRect.Min.Y),
+				zap.Int("elem_w", elementRect.Dx()),
+				zap.Int("elem_h", elementRect.Dy()),
+				zap.Int("clip_x", clipBounds.Min.X),
+				zap.Int("clip_y", clipBounds.Min.Y),
+				zap.Int("clip_w", clipBounds.Dx()),
+				zap.Int("clip_h", clipBounds.Dy()),
+			)
 		}
 
-		// Filter elements whose center is outside clip bounds (overflowing/scroll-clipped elements)
-		// But keep interactive roles (buttons, links, etc.) even if at edges
-		halfWidth := elementRect.Dx() / 2  //nolint:mnd
-		halfHeight := elementRect.Dy() / 2 //nolint:mnd
-		centerX := elementRect.Min.X + halfWidth
-		centerY := elementRect.Min.Y + halfHeight
-		if centerX < clipBounds.Min.X || centerX > clipBounds.Max.X ||
-			centerY < clipBounds.Min.Y || centerY > clipBounds.Max.Y {
-			if !interactiveLeafRoles[element.Role(info.Role())] {
-				return false
-			}
-		}
+		return false
+	}
+
+	if elementRect.Dx() < minElementSize || elementRect.Dy() < minElementSize {
+		return false
 	}
 
 	if opts.filterFunc != nil && !opts.filterFunc(info) {

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -643,9 +643,13 @@ func buildChildrenSequential(
 
 // minElementSize is the minimum size threshold for elements.
 // Elements smaller than this are filtered out as noise (especially in Chromium DOM trees).
-// This matches similar filtering in tools like Glyphlow.
 const minElementSize = 15
 
+// shouldIncludeElement combines all filtering logic into one function.
+//
+// The clip-bounds overlap check is always applied so that ALL tree sources —
+// including supplementary ones (dock, menubar, PIP, etc.) — benefit from
+// spatial filtering against their respective clip bounds.
 func shouldIncludeElement(
 	info *ElementInfo,
 	opts TreeOptions,
@@ -653,31 +657,66 @@ func shouldIncludeElement(
 ) bool {
 	elementRect := rectFromInfo(info)
 
-	if elementRect.Dx() == 0 || elementRect.Dy() == 0 {
-		return false
+	// Clip bounds check: always filter elements completely outside the
+	// visible area. This handles both window-level clipping (main window
+	// tree) and scroll-container clipping (AXScrollArea viewport), as well
+	// as screen-level clipping for supplementary sources where clip bounds
+	// fall back to the active screen bounds when the root rect is empty.
+	if elementRect.Dx() > 0 && elementRect.Dy() > 0 {
+		if !elementRect.Overlaps(clipBounds) {
+			if ce := opts.Logger().
+				Check(zap.DebugLevel, "Element filtered by clip bounds"); ce != nil {
+				ce.Write(
+					zap.String("role", info.Role()),
+					zap.Int("elem_x", elementRect.Min.X),
+					zap.Int("elem_y", elementRect.Min.Y),
+					zap.Int("elem_w", elementRect.Dx()),
+					zap.Int("elem_h", elementRect.Dy()),
+					zap.Int("clip_x", clipBounds.Min.X),
+					zap.Int("clip_y", clipBounds.Min.Y),
+					zap.Int("clip_w", clipBounds.Dx()),
+					zap.Int("clip_h", clipBounds.Dy()),
+				)
+			}
+
+			return false
+		}
 	}
 
-	if !elementRect.Overlaps(clipBounds) {
-		if ce := opts.Logger().
-			Check(zap.DebugLevel, "Element filtered by clip bounds"); ce != nil {
-			ce.Write(
-				zap.String("role", info.Role()),
-				zap.Int("elem_x", elementRect.Min.X),
-				zap.Int("elem_y", elementRect.Min.Y),
-				zap.Int("elem_w", elementRect.Dx()),
-				zap.Int("elem_h", elementRect.Dy()),
-				zap.Int("clip_x", clipBounds.Min.X),
-				zap.Int("clip_y", clipBounds.Min.Y),
-				zap.Int("clip_w", clipBounds.Dx()),
-				zap.Int("clip_h", clipBounds.Dy()),
-			)
+	// Filter out zero-sized interactive elements (they're broken/invalid)
+	if elementRect.Dx() == 0 || elementRect.Dy() == 0 {
+		if interactiveLeafRoles[element.Role(info.Role())] {
+			return false
+		}
+	}
+
+	// Strict filtering: auto-enabled for Chromium/Electron apps with noisy DOM trees
+	// WebKit-based apps (Safari) have clean trees that don't need this aggressive filtering
+	if opts.isChromiumOrElectron && elementRect.Dx() > 0 &&
+		elementRect.Dy() > 0 {
+		// Filter out tiny elements that are likely noise in Chromium DOM trees.
+		// This is especially important for web content where the DOM can have
+		// thousands of tiny placeholder/structure elements.
+		// Filter if either dimension is too small (not just both)
+		if elementRect.Dx() < minElementSize || elementRect.Dy() < minElementSize {
+			// Only filter if it's not a known important role
+			if !interactiveLeafRoles[element.Role(info.Role())] {
+				return false
+			}
 		}
 
-		return false
-	}
-
-	if elementRect.Dx() < minElementSize || elementRect.Dy() < minElementSize {
-		return false
+		// Filter elements whose center is outside clip bounds (overflowing/scroll-clipped elements)
+		// But keep interactive roles (buttons, links, etc.) even if at edges
+		halfWidth := elementRect.Dx() / 2  //nolint:mnd
+		halfHeight := elementRect.Dy() / 2 //nolint:mnd
+		centerX := elementRect.Min.X + halfWidth
+		centerY := elementRect.Min.Y + halfHeight
+		if centerX < clipBounds.Min.X || centerX > clipBounds.Max.X ||
+			centerY < clipBounds.Min.Y || centerY > clipBounds.Max.Y {
+			if !interactiveLeafRoles[element.Role(info.Role())] {
+				return false
+			}
+		}
 	}
 
 	if opts.filterFunc != nil && !opts.filterFunc(info) {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR introduces a configurable `visible_check_enabled` option (defaulting to `false`) for both global and per-app config overrides. This controls whether the expensive AX API hit-test check is performed to determine element visibility.

This check helps in the following scenarios (also check out the screen shots below):

- On webkit, there's no way to filter out out of bounds elements within a css based scroll container, this will clear them out, since its not clickable anyway.
- Best effort to ensure non conventional web based popups or dropdown wont collide with elements underneath it

Note:

- I think this is useful for webkit based browsers, e.g. Safari.
- Upon my unscientific testing, this is not needed for chromium or firefox based browsers.
- Recommended to only enable this on certain app bundle that you want to have this check. That's why default is off.

```toml
[hints]
visible_check_enabled = false

[[hints.app_configs]]
bundle_id = "com.apple.Safari"
visible_check_enabled = true
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

On safari (GitHub):

Without visible check:
<img width="659" height="455" alt="Screenshot 2026-05-23 at 9 41 29 PM" src="https://github.com/user-attachments/assets/78945048-5c28-4294-af88-775ca9f0002b" />

With visible check:
<img width="659" height="455" alt="Screenshot 2026-05-23 at 9 41 54 PM" src="https://github.com/user-attachments/assets/03c6b742-5b61-4037-927c-1fbb32c7f9ff" />

On safari (some video site)

Without visible check:
<img width="424" height="967" alt="Screenshot 2026-05-23 at 9 40 58 PM" src="https://github.com/user-attachments/assets/9e1d158a-deca-4fb0-a607-9930e688e0cc" />

With visible check:
<img width="424" height="967" alt="Screenshot 2026-05-23 at 9 40 14 PM" src="https://github.com/user-attachments/assets/66e855c4-16ea-4120-a012-cb77b89c4c54" />

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

The visibility check uses the expensive AX API which can slow down tree traversal on large UI layouts. Making it opt-in improves default performance while retaining the capability for apps that benefit from cleaner (less noisy) accessibility trees.
