### PR TITLE
fix(cli): expose missing `--role` and `--text` flag on cli

### DIFF
--- a/internal/cli/hints.go
+++ b/internal/cli/hints.go
@@ -2,11 +2,12 @@ package cli
 
 // HintsCmd is the CLI hints command.
 var HintsCmd = BuildModeCommand(ModeConfig{
-	Name:          "hints",
-	Short:         "Launch hints mode",
-	Long:          `Activate hint mode for direct clicking on UI elements.`,
-	ActionDesc:    "hint selection",
-	SupportSearch: true,
+	Name:             "hints",
+	Short:            "Launch hints mode",
+	Long:             `Activate hint mode for direct clicking on UI elements.`,
+	ActionDesc:       "hint selection",
+	SupportSearch:    true,
+	SupportFiltering: true,
 })
 
 func init() {

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -12,12 +12,13 @@ import (
 
 // ModeConfig holds configuration for creating a mode command.
 type ModeConfig struct {
-	Name          string
-	Short         string
-	Long          string
-	ActionDesc    string   // Description for the action flag (e.g., "hint selection" or "grid selection")
-	Aliases       []string // Optional CLI aliases (e.g., "recursive-grid" for "recursive_grid")
-	SupportSearch bool     // Whether this mode supports the --search flag
+	Name             string
+	Short            string
+	Long             string
+	ActionDesc       string   // Description for the action flag (e.g., "hint selection" or "grid selection")
+	Aliases          []string // Optional CLI aliases (e.g., "recursive-grid" for "recursive_grid")
+	SupportSearch    bool     // Whether this mode supports the --search flag
+	SupportFiltering bool     // Whether this mode supports --role and --text filter flags
 }
 
 // BuildModeCommand creates a CLI command for a navigation mode (hints, grid, etc.).
@@ -44,6 +45,19 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 			var searchFlag bool
 			if config.SupportSearch {
 				searchFlag, err = cmd.Flags().GetBool("search")
+				if err != nil {
+					return err
+				}
+			}
+
+			var roleFlag, textFlag string
+			if config.SupportFiltering {
+				roleFlag, err = cmd.Flags().GetString("role")
+				if err != nil {
+					return err
+				}
+
+				textFlag, err = cmd.Flags().GetString("text")
 				if err != nil {
 					return err
 				}
@@ -114,6 +128,14 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				params = append(params, "--search")
 			}
 
+			if roleFlag != "" {
+				params = append(params, "--role="+roleFlag)
+			}
+
+			if textFlag != "" {
+				params = append(params, "--text="+textFlag)
+			}
+
 			if cursorSelectionMode != "" {
 				if cursorSelectionMode != modes.CursorSelectionModeFollow &&
 					cursorSelectionMode != modes.CursorSelectionModeHold {
@@ -155,6 +177,19 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 			"s",
 			false,
 			"Show search input when the mode is activated",
+		)
+	}
+
+	if config.SupportFiltering {
+		cmd.Flags().String(
+			"role",
+			"",
+			"Filter by AX role (comma-separated: AXButton,AXLink)",
+		)
+		cmd.Flags().String(
+			"text",
+			"",
+			"Filter elements by text content (comma-separated, case-insensitive substring match)",
 		)
 	}
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR exposes missing `--text` and `--role` flag for `hints` in the cobra cli. Previously it works within IPC but not direct cobra cli.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
