### PR TITLE
feat(scroll): add similar `<mode>.app_configs` with overridables

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -199,7 +199,7 @@ Multi-key alphabetic sequences (e.g. `gg`) use a 500ms timeout.
 
 #### Per-App Hotkey Overrides
 
-`[[<mode>.app_configs]]` overrides `<mode>.hotkeys` for specific apps. Supported for `hints`, `grid`, and `recursive_grid`. App hotkeys merge on top of mode hotkeys; `__disabled__` removes an inherited binding.
+`[[<mode>.app_configs]]` overrides `<mode>.hotkeys` for specific apps. Supported for `hints`, `grid`, `recursive_grid`, and `scroll`. App hotkeys merge on top of mode hotkeys; `__disabled__` removes an inherited binding.
 
 ```toml
 [[hints.app_configs]]
@@ -604,6 +604,26 @@ Keyboard-driven scrolling.
 "d"       = "action page_down"
 "PageDown"= "action page_down"
 ```
+
+### Per-App Config
+
+| Field              | Type   | Description                                           |
+| ------------------ | ------ | ----------------------------------------------------- |
+| `bundle_id`        | string | App bundle ID                                         |
+| `scroll_step`      | int    | Optional app-specific scroll step override            |
+| `scroll_step_half` | int    | Optional app-specific scroll step half override       |
+| `scroll_step_full` | int    | Optional app-specific scroll step full override       |
+| `hotkeys`          | map    | [per-app hotkey overrides](#per-app-hotkey-overrides) |
+
+```toml
+[[scroll.app_configs]]
+bundle_id = "com.apple.Safari"
+scroll_step = 25
+scroll_step_half = 200
+scroll_step_full = 1000
+hotkeys = { "k" = "action scroll_up", "j" = "action scroll_down" }
+```
+
 
 ---
 

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -116,7 +116,11 @@ func (h *Handler) HandleKeyPress(key string) {
 		if h.config.RecursiveGrid.HasAppHotkeyOverrides() {
 			bundleID = h.focusedBundleID()
 		}
-	case domain.ModeIdle, domain.ModeScroll:
+	case domain.ModeScroll:
+		if h.config.Scroll.HasAppHotkeyOverrides() {
+			bundleID = h.focusedBundleID()
+		}
+	case domain.ModeIdle:
 		// No app hotkey overrides for these modes
 	}
 

--- a/internal/app/services/scroll_service.go
+++ b/internal/app/services/scroll_service.go
@@ -127,20 +127,23 @@ func (s *ScrollService) calculateDelta(
 		configSnapshot := s.config
 		s.mu.RUnlock()
 
-		bundleID, err := s.accessibility.FocusedAppBundleID(ctx)
+		// Only perform IPC lookup if there are app-specific overrides configured
+		if len(configSnapshot.AppConfigs) > 0 {
+			bundleID, err := s.accessibility.FocusedAppBundleID(ctx)
 
-		if err == nil && bundleID != "" {
-			if appConfig := configSnapshot.AppConfigForBundleID(bundleID); appConfig != nil {
-				if appConfig.ScrollStep != nil {
-					scrollStep = *appConfig.ScrollStep
-				}
+			if err == nil && bundleID != "" {
+				if appConfig := configSnapshot.AppConfigForBundleID(bundleID); appConfig != nil {
+					if appConfig.ScrollStep != nil {
+						scrollStep = *appConfig.ScrollStep
+					}
 
-				if appConfig.ScrollStepHalf != nil {
-					scrollStepHalf = *appConfig.ScrollStepHalf
-				}
+					if appConfig.ScrollStepHalf != nil {
+						scrollStepHalf = *appConfig.ScrollStepHalf
+					}
 
-				if appConfig.ScrollStepFull != nil {
-					scrollStepFull = *appConfig.ScrollStepFull
+					if appConfig.ScrollStepFull != nil {
+						scrollStepFull = *appConfig.ScrollStepFull
+					}
 				}
 			}
 		}

--- a/internal/app/services/scroll_service.go
+++ b/internal/app/services/scroll_service.go
@@ -69,9 +69,7 @@ func (s *ScrollService) Scroll(
 	amount ScrollAmount,
 	stepOverride int,
 ) error {
-	s.mu.RLock()
 	deltaX, deltaY := s.calculateDelta(ctx, direction, amount, stepOverride)
-	s.mu.RUnlock()
 
 	s.logger.Debug("Scrolling",
 		zap.Int("dir", int(direction)),
@@ -121,14 +119,18 @@ func (s *ScrollService) calculateDelta(
 	if stepOverride > 0 {
 		baseScroll = stepOverride
 	} else {
+		// Snapshot config under lock, then release before IPC call
+		s.mu.RLock()
 		scrollStep := s.config.ScrollStep
 		scrollStepHalf := s.config.ScrollStepHalf
 		scrollStepFull := s.config.ScrollStepFull
+		configSnapshot := s.config
+		s.mu.RUnlock()
 
 		bundleID, err := s.accessibility.FocusedAppBundleID(ctx)
 
 		if err == nil && bundleID != "" {
-			if appConfig := s.config.AppConfigForBundleID(bundleID); appConfig != nil {
+			if appConfig := configSnapshot.AppConfigForBundleID(bundleID); appConfig != nil {
 				if appConfig.ScrollStep != nil {
 					scrollStep = *appConfig.ScrollStep
 				}

--- a/internal/app/services/scroll_service.go
+++ b/internal/app/services/scroll_service.go
@@ -70,7 +70,7 @@ func (s *ScrollService) Scroll(
 	stepOverride int,
 ) error {
 	s.mu.RLock()
-	deltaX, deltaY := s.calculateDelta(direction, amount, stepOverride)
+	deltaX, deltaY := s.calculateDelta(ctx, direction, amount, stepOverride)
 	s.mu.RUnlock()
 
 	s.logger.Debug("Scrolling",
@@ -108,6 +108,7 @@ func (s *ScrollService) UpdateConfig(config config.ScrollConfig) {
 // calculateDelta computes the scroll delta values based on direction and magnitude.
 // If stepOverride is > 0, it takes precedence over the configured value.
 func (s *ScrollService) calculateDelta(
+	ctx context.Context,
 	direction ScrollDirection,
 	amount ScrollAmount,
 	stepOverride int,
@@ -120,13 +121,35 @@ func (s *ScrollService) calculateDelta(
 	if stepOverride > 0 {
 		baseScroll = stepOverride
 	} else {
+		scrollStep := s.config.ScrollStep
+		scrollStepHalf := s.config.ScrollStepHalf
+		scrollStepFull := s.config.ScrollStepFull
+
+		bundleID, err := s.accessibility.FocusedAppBundleID(ctx)
+
+		if err == nil && bundleID != "" {
+			if appConfig := s.config.AppConfigForBundleID(bundleID); appConfig != nil {
+				if appConfig.ScrollStep != nil {
+					scrollStep = *appConfig.ScrollStep
+				}
+
+				if appConfig.ScrollStepHalf != nil {
+					scrollStepHalf = *appConfig.ScrollStepHalf
+				}
+
+				if appConfig.ScrollStepFull != nil {
+					scrollStepFull = *appConfig.ScrollStepFull
+				}
+			}
+		}
+
 		switch amount {
 		case ScrollAmountChar:
-			baseScroll = s.config.ScrollStep
+			baseScroll = scrollStep
 		case ScrollAmountHalfPage:
-			baseScroll = s.config.ScrollStepHalf
+			baseScroll = scrollStepHalf
 		case ScrollAmountEnd:
-			baseScroll = s.config.ScrollStepFull
+			baseScroll = scrollStepFull
 		}
 	}
 

--- a/internal/app/services/scroll_service_test.go
+++ b/internal/app/services/scroll_service_test.go
@@ -18,6 +18,7 @@ func TestScrollService_Scroll(t *testing.T) {
 		amount       services.ScrollAmount
 		stepOverride int
 		setupMocks   func(*mocks.MockAccessibilityPort)
+		setupConfig  func(*config.ScrollConfig)
 		wantErr      bool
 	}{
 		{
@@ -226,18 +227,54 @@ func TestScrollService_Scroll(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:      "scroll down with app override",
+			direction: services.ScrollDirectionDown,
+			amount:    services.ScrollAmountChar,
+			setupConfig: func(c *config.ScrollConfig) {
+				step := 25
+				half := 200
+				full := 1000
+				c.AppConfigs = []config.AppConfig{
+					{
+						BundleID:       "com.apple.Safari",
+						ScrollStep:     &step,
+						ScrollStepHalf: &half,
+						ScrollStepFull: &full,
+					},
+				}
+			},
+			setupMocks: func(acc *mocks.MockAccessibilityPort) {
+				acc.FocusedAppBundleIDFunc = func(_ context.Context) (string, error) {
+					return "com.apple.Safari", nil
+				}
+				acc.ScrollFunc = func(_ context.Context, _, deltaY int) error {
+					// Safari scroll_step is overridden to 25, so Down is -25
+					if deltaY != -25 {
+						t.Errorf("Expected deltaY -25 for Safari app override, got %d", deltaY)
+					}
+
+					return nil
+				}
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			mockAcc := &mocks.MockAccessibilityPort{}
 			mockOverlay := &mocks.MockOverlayPort{}
-			config := config.ScrollConfig{
+			cfg := config.ScrollConfig{
 				ScrollStep:     10,
 				ScrollStepHalf: 30,
 				ScrollStepFull: 50,
 			}
 			logger := logger.Get()
+
+			if testCase.setupConfig != nil {
+				testCase.setupConfig(&cfg)
+			}
 
 			if testCase.setupMocks != nil {
 				testCase.setupMocks(mockAcc)
@@ -247,7 +284,7 @@ func TestScrollService_Scroll(t *testing.T) {
 				mockAcc,
 				mockOverlay,
 				&mocks.SystemMock{},
-				config,
+				cfg,
 				logger,
 			)
 			ctx := context.Background()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -492,6 +492,9 @@ type AppConfig struct {
 	AdditionalClickable  []string                       `json:"additionalClickable"  toml:"additional_clickable_roles"`
 	IgnoreClickableCheck bool                           `json:"ignoreClickableCheck" toml:"ignore_clickable_check"`
 	VisibleCheckEnabled  bool                           `json:"visibleCheckEnabled"  toml:"visible_check_enabled"`
+	ScrollStep           *int                           `json:"scrollStep"           toml:"scroll_step,omitempty"`
+	ScrollStepHalf       *int                           `json:"scrollStepHalf"       toml:"scroll_step_half,omitempty"`
+	ScrollStepFull       *int                           `json:"scrollStepFull"       toml:"scroll_step_full,omitempty"`
 	Hotkeys              map[string]StringOrStringArray `json:"hotkeys"              toml:"hotkeys"`
 }
 
@@ -516,6 +519,8 @@ type ScrollConfig struct {
 	ScrollStep     int `json:"scrollStep"     toml:"scroll_step"`
 	ScrollStepHalf int `json:"scrollStepHalf" toml:"scroll_step_half"`
 	ScrollStepFull int `json:"scrollStepFull" toml:"scroll_step_full"`
+
+	AppConfigs []AppConfig `json:"appConfigs" toml:"app_configs"`
 
 	Hotkeys map[string]StringOrStringArray `json:"hotkeys" toml:"-"`
 }
@@ -1249,7 +1254,7 @@ func (c *Config) HotkeysForMode(modeName string) map[string]StringOrStringArray 
 
 // HotkeysForModeAndApp returns the effective per-mode hotkeys map for the given mode
 // and focused app bundle ID. For modes without app-specific overrides, it returns the
-// base mode hotkeys unchanged. Hints, Grid, and RecursiveGrid modes support
+// base mode hotkeys unchanged. Hints, Grid, RecursiveGrid, and Scroll modes support
 // per-app hotkey overrides through [[<mode>.app_configs]].
 func (c *Config) HotkeysForModeAndApp(
 	modeName, bundleID string,
@@ -1267,6 +1272,8 @@ func (c *Config) HotkeysForModeAndApp(
 		appConfig = c.Grid.AppConfigForBundleID(bundleID)
 	case modeNameRecursiveGrid:
 		appConfig = c.RecursiveGrid.AppConfigForBundleID(bundleID)
+	case modeNameScroll:
+		appConfig = c.Scroll.AppConfigForBundleID(bundleID)
 	}
 
 	if appConfig == nil || len(appConfig.Hotkeys) == 0 {
@@ -1335,6 +1342,18 @@ func (c *RecursiveGridConfig) HasAppHotkeyOverrides() bool {
 	return false
 }
 
+// HasAppHotkeyOverrides reports whether any [[scroll.app_configs]] entry has a
+// non-empty Hotkeys map.
+func (c *ScrollConfig) HasAppHotkeyOverrides() bool {
+	for idx := range c.AppConfigs {
+		if len(c.AppConfigs[idx].Hotkeys) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 // AppConfigForBundleID returns the matching hints app config for the given bundle ID.
 func (c *HintsConfig) AppConfigForBundleID(bundleID string) *AppConfig {
 	for idx := range c.AppConfigs {
@@ -1359,6 +1378,17 @@ func (c *GridConfig) AppConfigForBundleID(bundleID string) *AppConfig {
 
 // AppConfigForBundleID returns the matching recursive grid app config for the given bundle ID.
 func (c *RecursiveGridConfig) AppConfigForBundleID(bundleID string) *AppConfig {
+	for idx := range c.AppConfigs {
+		if c.AppConfigs[idx].BundleID == bundleID {
+			return &c.AppConfigs[idx]
+		}
+	}
+
+	return nil
+}
+
+// AppConfigForBundleID returns the matching scroll app config for the given bundle ID.
+func (c *ScrollConfig) AppConfigForBundleID(bundleID string) *AppConfig {
 	for idx := range c.AppConfigs {
 		if c.AppConfigs[idx].BundleID == bundleID {
 			return &c.AppConfigs[idx]
@@ -1484,6 +1514,11 @@ func (c *Config) ValidateScroll() error {
 	}
 
 	err = validateMinValue(c.Scroll.ScrollStepFull, 1, "scroll.scroll_step_full")
+	if err != nil {
+		return err
+	}
+
+	err = validateScrollAppConfigs("scroll", c.Scroll.AppConfigs)
 	if err != nil {
 		return err
 	}

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -530,6 +530,7 @@ func newDefaultConfig() *Config {
 			ScrollStep:     DefaultScrollStep,
 			ScrollStepHalf: DefaultScrollStepHalf,
 			ScrollStepFull: DefaultScrollStepFull,
+			AppConfigs:     []AppConfig{},
 			Hotkeys: map[string]StringOrStringArray{
 				"Escape":   {"idle"},
 				"k":        {"action scroll_up"},

--- a/internal/config/config_integration_test.go
+++ b/internal/config/config_integration_test.go
@@ -173,6 +173,60 @@ bundle_id = "com.apple.Safari"
 		}
 	})
 
+	t.Run("Scroll App Config Overrides Loading", func(t *testing.T) {
+		configContent := `
+[scroll]
+scroll_step = 100
+
+[[scroll.app_configs]]
+bundle_id = "com.apple.Safari"
+scroll_step = 25
+scroll_step_half = 200
+scroll_step_full = 1000
+
+[scroll.app_configs.hotkeys]
+"Return" = ["action scroll_down"]
+"k" = "__disabled__"
+`
+
+		writeConfigFile(t, configPath, configContent, 0o644)
+
+		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+
+		loadResult := service.LoadWithValidation(configPath)
+		if loadResult.ValidationError != nil {
+			t.Fatalf("Config validation failed: %v", loadResult.ValidationError)
+		}
+
+		cfg := loadResult.Config
+
+		appCfg := cfg.Scroll.AppConfigForBundleID("com.apple.Safari")
+		if appCfg == nil {
+			t.Fatal("expected Safari app config to be present")
+		}
+
+		if appCfg.ScrollStep == nil || *appCfg.ScrollStep != 25 {
+			t.Errorf("expected app scroll_step override 25, got %v", appCfg.ScrollStep)
+		}
+
+		if appCfg.ScrollStepHalf == nil || *appCfg.ScrollStepHalf != 200 {
+			t.Errorf("expected app scroll_step_half override 200, got %v", appCfg.ScrollStepHalf)
+		}
+
+		if appCfg.ScrollStepFull == nil || *appCfg.ScrollStepFull != 1000 {
+			t.Errorf("expected app scroll_step_full override 1000, got %v", appCfg.ScrollStepFull)
+		}
+
+		got := cfg.HotkeysForModeAndApp("scroll", "com.apple.Safari")
+		if actions := got["Return"]; len(actions) != 1 || actions[0] != "action scroll_down" {
+			t.Fatalf("expected app-specific Return override, got %v", actions)
+		}
+
+		if _, exists := got["k"]; exists {
+			t.Fatal("expected app-specific __disabled__ to remove inherited k binding")
+		}
+	})
+
 	t.Run("Global Hotkey Rebind Replaces Default Launcher", func(t *testing.T) {
 		configContent := `
 [hotkeys]

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -562,6 +562,12 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 		}
 	}
 
+	if scrollRaw, ok := raw["scroll"].(map[string]any); ok {
+		if result := validateAppConfigsHotkeys(s.logger, "scroll", scrollRaw); result != nil {
+			return result
+		}
+	}
+
 	validateErr := configResult.Config.Validate()
 	if validateErr != nil {
 		configResult.ValidationError = core.WrapConfigFailed(validateErr, "validate configuration")

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -328,6 +328,73 @@ func validateAppConfigs(modeName string, appConfigs []AppConfig) error {
 	return nil
 }
 
+// validateScrollAppConfigs validates per-app scroll configuration.
+func validateScrollAppConfigs(modeName string, appConfigs []AppConfig) error {
+	seen := make(map[string]struct{}, len(appConfigs))
+	for idx, appConfig := range appConfigs {
+		if strings.TrimSpace(appConfig.BundleID) == "" {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%s.app_configs[%d].bundle_id cannot be empty",
+				modeName, idx,
+			)
+		}
+
+		if _, ok := seen[appConfig.BundleID]; ok {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"duplicate %s.app_configs bundle_id: %s",
+				modeName, appConfig.BundleID,
+			)
+		}
+
+		seen[appConfig.BundleID] = struct{}{}
+
+		err := validateHotkeyTable(
+			fmt.Sprintf("%s.app_configs[%d].hotkeys", modeName, idx),
+			appConfig.Hotkeys,
+		)
+		if err != nil {
+			return err
+		}
+
+		if appConfig.ScrollStep != nil {
+			err = validateMinValue(
+				*appConfig.ScrollStep,
+				1,
+				fmt.Sprintf("%s.app_configs[%d].scroll_step", modeName, idx),
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		if appConfig.ScrollStepHalf != nil {
+			err = validateMinValue(
+				*appConfig.ScrollStepHalf,
+				1,
+				fmt.Sprintf("%s.app_configs[%d].scroll_step_half", modeName, idx),
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		if appConfig.ScrollStepFull != nil {
+			err = validateMinValue(
+				*appConfig.ScrollStepFull,
+				1,
+				fmt.Sprintf("%s.app_configs[%d].scroll_step_full", modeName, idx),
+			)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 // ValidateAppConfigs validates per-app hint configuration.
 func (c *Config) ValidateAppConfigs() error {
 	return validateAppConfigs("hints", c.Hints.AppConfigs)
@@ -543,6 +610,20 @@ func (c *Config) checkHotkeysConflicts() error {
 				appConfig.BundleID,
 			),
 			c.HotkeysForModeAndApp(modeNameHints, appConfig.BundleID),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	for idx, appConfig := range c.Scroll.AppConfigs {
+		err := checkHotkeyConflicts(
+			fmt.Sprintf(
+				"scroll.hotkeys merged with scroll.app_configs[%d] (%s)",
+				idx,
+				appConfig.BundleID,
+			),
+			c.HotkeysForModeAndApp(modeNameScroll, appConfig.BundleID),
 		)
 		if err != nil {
 			return err

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -344,11 +344,6 @@ func validateAppConfigsWithCallback(
 	return nil
 }
 
-// validateAppConfigs validates per-app configuration for a given mode.
-func validateAppConfigs(modeName string, appConfigs []AppConfig) error {
-	return validateAppConfigsWithCallback(modeName, appConfigs, nil)
-}
-
 // rejectScrollFields creates a field validator that rejects scroll-specific fields.
 // Used for non-scroll modes (hints, grid, recursive_grid) to catch accidental configuration.
 func rejectScrollFields(modeName string) AppConfigFieldValidator {
@@ -417,7 +412,8 @@ func rejectHintsFields(modeName string) AppConfigFieldValidator {
 // Used for grid and recursive_grid modes.
 func rejectModeSpecificFields(modeName string) AppConfigFieldValidator {
 	return func(idx int, appConfig *AppConfig) error {
-		if err := rejectScrollFields(modeName)(idx, appConfig); err != nil {
+		err := rejectScrollFields(modeName)(idx, appConfig)
+		if err != nil {
 			return err
 		}
 
@@ -429,7 +425,8 @@ func rejectModeSpecificFields(modeName string) AppConfigFieldValidator {
 func validateScrollAppConfigs(modeName string, appConfigs []AppConfig) error {
 	scrollFieldValidator := func(idx int, appConfig *AppConfig) error {
 		// First, reject hints fields
-		if err := rejectHintsFields(modeName)(idx, appConfig); err != nil {
+		err := rejectHintsFields(modeName)(idx, appConfig)
+		if err != nil {
 			return err
 		}
 
@@ -528,7 +525,11 @@ func (c *Config) ValidateGrid() error {
 		return derrors.New(derrors.CodeInvalidConfig, "grid.ui.border_width must be non-negative")
 	}
 
-	err = validateAppConfigsWithCallback("grid", c.Grid.AppConfigs, rejectModeSpecificFields("grid"))
+	err = validateAppConfigsWithCallback(
+		"grid",
+		c.Grid.AppConfigs,
+		rejectModeSpecificFields("grid"),
+	)
 	if err != nil {
 		return err
 	}
@@ -963,7 +964,11 @@ func (c *Config) ValidateRecursiveGrid() error {
 		return derrors.New(derrors.CodeInvalidConfig, "recursive_grid.ui.font_size must be >= 1")
 	}
 
-	err = validateAppConfigsWithCallback("recursive_grid", c.RecursiveGrid.AppConfigs, rejectModeSpecificFields("recursive_grid"))
+	err = validateAppConfigsWithCallback(
+		"recursive_grid",
+		c.RecursiveGrid.AppConfigs,
+		rejectModeSpecificFields("recursive_grid"),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -294,8 +294,16 @@ func (c *Config) ValidateHints() error {
 	return nil
 }
 
-// validateAppConfigs validates per-app configuration for a given mode.
-func validateAppConfigs(modeName string, appConfigs []AppConfig) error {
+// AppConfigFieldValidator is a callback for validating mode-specific fields in AppConfig.
+// It's called for each app config after common validation passes.
+type AppConfigFieldValidator func(idx int, appConfig *AppConfig) error
+
+// validateAppConfigsWithCallback validates per-app configuration with optional field-level validation.
+func validateAppConfigsWithCallback(
+	modeName string,
+	appConfigs []AppConfig,
+	fieldValidator AppConfigFieldValidator,
+) error {
 	seen := make(map[string]struct{}, len(appConfigs))
 	for idx, appConfig := range appConfigs {
 		if strings.TrimSpace(appConfig.BundleID) == "" {
@@ -322,44 +330,30 @@ func validateAppConfigs(modeName string, appConfigs []AppConfig) error {
 		)
 		if err != nil {
 			return err
+		}
+
+		// Call mode-specific field validator if provided
+		if fieldValidator != nil {
+			err = fieldValidator(idx, &appConfig)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
 	return nil
 }
 
+// validateAppConfigs validates per-app configuration for a given mode.
+func validateAppConfigs(modeName string, appConfigs []AppConfig) error {
+	return validateAppConfigsWithCallback(modeName, appConfigs, nil)
+}
+
 // validateScrollAppConfigs validates per-app scroll configuration.
 func validateScrollAppConfigs(modeName string, appConfigs []AppConfig) error {
-	seen := make(map[string]struct{}, len(appConfigs))
-	for idx, appConfig := range appConfigs {
-		if strings.TrimSpace(appConfig.BundleID) == "" {
-			return derrors.Newf(
-				derrors.CodeInvalidConfig,
-				"%s.app_configs[%d].bundle_id cannot be empty",
-				modeName, idx,
-			)
-		}
-
-		if _, ok := seen[appConfig.BundleID]; ok {
-			return derrors.Newf(
-				derrors.CodeInvalidConfig,
-				"duplicate %s.app_configs bundle_id: %s",
-				modeName, appConfig.BundleID,
-			)
-		}
-
-		seen[appConfig.BundleID] = struct{}{}
-
-		err := validateHotkeyTable(
-			fmt.Sprintf("%s.app_configs[%d].hotkeys", modeName, idx),
-			appConfig.Hotkeys,
-		)
-		if err != nil {
-			return err
-		}
-
+	scrollFieldValidator := func(idx int, appConfig *AppConfig) error {
 		if appConfig.ScrollStep != nil {
-			err = validateMinValue(
+			err := validateMinValue(
 				*appConfig.ScrollStep,
 				1,
 				fmt.Sprintf("%s.app_configs[%d].scroll_step", modeName, idx),
@@ -370,7 +364,7 @@ func validateScrollAppConfigs(modeName string, appConfigs []AppConfig) error {
 		}
 
 		if appConfig.ScrollStepHalf != nil {
-			err = validateMinValue(
+			err := validateMinValue(
 				*appConfig.ScrollStepHalf,
 				1,
 				fmt.Sprintf("%s.app_configs[%d].scroll_step_half", modeName, idx),
@@ -381,7 +375,7 @@ func validateScrollAppConfigs(modeName string, appConfigs []AppConfig) error {
 		}
 
 		if appConfig.ScrollStepFull != nil {
-			err = validateMinValue(
+			err := validateMinValue(
 				*appConfig.ScrollStepFull,
 				1,
 				fmt.Sprintf("%s.app_configs[%d].scroll_step_full", modeName, idx),
@@ -390,9 +384,11 @@ func validateScrollAppConfigs(modeName string, appConfigs []AppConfig) error {
 				return err
 			}
 		}
+
+		return nil
 	}
 
-	return nil
+	return validateAppConfigsWithCallback(modeName, appConfigs, scrollFieldValidator)
 }
 
 // ValidateAppConfigs validates per-app hint configuration.

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -381,9 +381,59 @@ func rejectScrollFields(modeName string) AppConfigFieldValidator {
 	}
 }
 
+// rejectHintsFields creates a field validator that rejects hints-specific fields.
+// Used for non-hints modes (grid, recursive_grid) to catch accidental configuration.
+func rejectHintsFields(modeName string) AppConfigFieldValidator {
+	return func(idx int, appConfig *AppConfig) error {
+		if len(appConfig.AdditionalClickable) > 0 {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%s.app_configs[%d].additional_clickable_roles is only valid for hints mode",
+				modeName, idx,
+			)
+		}
+
+		if appConfig.IgnoreClickableCheck {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%s.app_configs[%d].ignore_clickable_check is only valid for hints mode",
+				modeName, idx,
+			)
+		}
+
+		if appConfig.VisibleCheckEnabled {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%s.app_configs[%d].visible_check_enabled is only valid for hints mode",
+				modeName, idx,
+			)
+		}
+
+		return nil
+	}
+}
+
+// rejectModeSpecificFields creates a combined validator that rejects both scroll and hints fields.
+// Used for grid and recursive_grid modes.
+func rejectModeSpecificFields(modeName string) AppConfigFieldValidator {
+	return func(idx int, appConfig *AppConfig) error {
+		if err := rejectScrollFields(modeName)(idx, appConfig); err != nil {
+			return err
+		}
+
+		return rejectHintsFields(modeName)(idx, appConfig)
+	}
+}
+
 // validateScrollAppConfigs validates per-app scroll configuration.
 func validateScrollAppConfigs(modeName string, appConfigs []AppConfig) error {
 	scrollFieldValidator := func(idx int, appConfig *AppConfig) error {
+		// First, reject hints fields
+		if err := rejectHintsFields(modeName)(idx, appConfig); err != nil {
+			return err
+		}
+
+		// Then validate scroll fields
 		if appConfig.ScrollStep != nil {
 			err := validateMinValue(
 				*appConfig.ScrollStep,
@@ -478,7 +528,7 @@ func (c *Config) ValidateGrid() error {
 		return derrors.New(derrors.CodeInvalidConfig, "grid.ui.border_width must be non-negative")
 	}
 
-	err = validateAppConfigsWithCallback("grid", c.Grid.AppConfigs, rejectScrollFields("grid"))
+	err = validateAppConfigsWithCallback("grid", c.Grid.AppConfigs, rejectModeSpecificFields("grid"))
 	if err != nil {
 		return err
 	}
@@ -913,7 +963,7 @@ func (c *Config) ValidateRecursiveGrid() error {
 		return derrors.New(derrors.CodeInvalidConfig, "recursive_grid.ui.font_size must be >= 1")
 	}
 
-	err = validateAppConfigsWithCallback("recursive_grid", c.RecursiveGrid.AppConfigs, rejectScrollFields("recursive_grid"))
+	err = validateAppConfigsWithCallback("recursive_grid", c.RecursiveGrid.AppConfigs, rejectModeSpecificFields("recursive_grid"))
 	if err != nil {
 		return err
 	}

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -349,6 +349,38 @@ func validateAppConfigs(modeName string, appConfigs []AppConfig) error {
 	return validateAppConfigsWithCallback(modeName, appConfigs, nil)
 }
 
+// rejectScrollFields creates a field validator that rejects scroll-specific fields.
+// Used for non-scroll modes (hints, grid, recursive_grid) to catch accidental configuration.
+func rejectScrollFields(modeName string) AppConfigFieldValidator {
+	return func(idx int, appConfig *AppConfig) error {
+		if appConfig.ScrollStep != nil {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%s.app_configs[%d].scroll_step is only valid for scroll mode",
+				modeName, idx,
+			)
+		}
+
+		if appConfig.ScrollStepHalf != nil {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%s.app_configs[%d].scroll_step_half is only valid for scroll mode",
+				modeName, idx,
+			)
+		}
+
+		if appConfig.ScrollStepFull != nil {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%s.app_configs[%d].scroll_step_full is only valid for scroll mode",
+				modeName, idx,
+			)
+		}
+
+		return nil
+	}
+}
+
 // validateScrollAppConfigs validates per-app scroll configuration.
 func validateScrollAppConfigs(modeName string, appConfigs []AppConfig) error {
 	scrollFieldValidator := func(idx int, appConfig *AppConfig) error {
@@ -393,7 +425,7 @@ func validateScrollAppConfigs(modeName string, appConfigs []AppConfig) error {
 
 // ValidateAppConfigs validates per-app hint configuration.
 func (c *Config) ValidateAppConfigs() error {
-	return validateAppConfigs("hints", c.Hints.AppConfigs)
+	return validateAppConfigsWithCallback("hints", c.Hints.AppConfigs, rejectScrollFields("hints"))
 }
 
 // ValidateGrid validates the grid configuration.
@@ -446,7 +478,7 @@ func (c *Config) ValidateGrid() error {
 		return derrors.New(derrors.CodeInvalidConfig, "grid.ui.border_width must be non-negative")
 	}
 
-	err = validateAppConfigs("grid", c.Grid.AppConfigs)
+	err = validateAppConfigsWithCallback("grid", c.Grid.AppConfigs, rejectScrollFields("grid"))
 	if err != nil {
 		return err
 	}
@@ -881,7 +913,7 @@ func (c *Config) ValidateRecursiveGrid() error {
 		return derrors.New(derrors.CodeInvalidConfig, "recursive_grid.ui.font_size must be >= 1")
 	}
 
-	err = validateAppConfigs("recursive_grid", c.RecursiveGrid.AppConfigs)
+	err = validateAppConfigsWithCallback("recursive_grid", c.RecursiveGrid.AppConfigs, rejectScrollFields("recursive_grid"))
 	if err != nil {
 		return err
 	}

--- a/internal/config/validators_config_test.go
+++ b/internal/config/validators_config_test.go
@@ -92,6 +92,66 @@ func TestConfigValidateScroll_OnlyStepValidation(t *testing.T) {
 	}
 }
 
+func TestConfigValidateScroll_AppConfigs(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	// Valid scroll app configs
+	cfg.Scroll.AppConfigs = []config.AppConfig{
+		{
+			BundleID: "com.apple.Safari",
+			Hotkeys: map[string]config.StringOrStringArray{
+				"k": {"action scroll_up"},
+			},
+		},
+	}
+
+	err := cfg.ValidateScroll()
+	if err != nil {
+		t.Fatalf("ValidateScroll() unexpected error: %v", err)
+	}
+
+	// Invalid: Empty BundleID
+	cfg.Scroll.AppConfigs = []config.AppConfig{
+		{
+			BundleID: "",
+		},
+	}
+
+	err = cfg.ValidateScroll()
+	if err == nil {
+		t.Fatal("ValidateScroll() expected error for empty bundle_id, got nil")
+	}
+
+	// Invalid: Duplicate BundleID
+	cfg.Scroll.AppConfigs = []config.AppConfig{
+		{
+			BundleID: "com.apple.Safari",
+		},
+		{
+			BundleID: "com.apple.Safari",
+		},
+	}
+
+	err = cfg.ValidateScroll()
+	if err == nil {
+		t.Fatal("ValidateScroll() expected error for duplicate bundle_id, got nil")
+	}
+
+	// Invalid: scroll_step = 0 in app config
+	zero := 0
+	cfg.Scroll.AppConfigs = []config.AppConfig{
+		{
+			BundleID:   "com.apple.Safari",
+			ScrollStep: &zero,
+		},
+	}
+
+	err = cfg.ValidateScroll()
+	if err == nil {
+		t.Fatal("ValidateScroll() expected error for scroll_step = 0 in app config, got nil")
+	}
+}
+
 func TestConfigValidateHints_AsciiHintChars(t *testing.T) {
 	cfg := config.DefaultConfig()
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds similar functionality to other `<mode>.app_configs` overrides. Now user can have per-app scroll speed or even hotkeys if they want to.

Example:

```toml
[scroll]
scroll_step = 100

[[scroll.app_configs]]
bundle_id = "com.hnc.Discord"
scroll_step = 500
hotkeys = {
	"1" = "action scroll_up --steps 20",
	"2" = "action scroll_down --steps 20"
}
```

- Global scroll steps is set to 100px
- When in Discord app, the following applies:
  - Scroll steps is set to 500px (default j,k,h,l will scroll fast)
  - Additional hotkeys are set for 1,2 (default 1,2 will scroll at 20px, extremely slow)
  - Nothing here affect anything other than Discord in this case

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
