### PR TITLE
fix: rename variable to ctx to avoid package shadowing

### DIFF
--- a/internal/app/modes/validation.go
+++ b/internal/app/modes/validation.go
@@ -54,10 +54,10 @@ func (h *Handler) validateModeActivation(bundleID string, modeName string, modeE
 			return derrors.New(derrors.CodeInvalidInput, "focused app is excluded")
 		}
 	} else {
-		context, cancel := context.WithTimeout(context.Background(), ValidationTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), ValidationTimeout)
 		defer cancel()
 
-		isExcluded, isExcludedErr := h.actionService.IsFocusedAppExcluded(context)
+		isExcluded, isExcludedErr := h.actionService.IsFocusedAppExcluded(ctx)
 		if isExcludedErr != nil {
 			h.logger.Warn("Failed to check if app is excluded", zap.Error(isExcludedErr))
 		} else if isExcluded {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR rename the local variable `context` to `ctx` in `validateModeActivation` to
avoid shadowing the standard library `context` package. The shadowing made it
impossible to reference `context.Context` or any other type from that package
within scope.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
