### PR TITLE
fix: prevent goroutine leak on context cancellation in `processClickableNodesConcurrent`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/text v0.37.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -616,7 +616,6 @@ func (a *Adapter) processClickableNodesConcurrent(
 
 	type result struct {
 		elements []*element.Element
-		err      error
 	}
 
 	results := make(chan result, numWorkers)
@@ -650,8 +649,6 @@ func (a *Adapter) processClickableNodesConcurrent(
 						remaining.Release()
 					}
 
-					results <- result{err: ctx.Err()}
-
 					return
 				}
 
@@ -684,11 +681,11 @@ func (a *Adapter) processClickableNodesConcurrent(
 	allElements := make([]*element.Element, 0, len(nodes)/EstimatedFilteringRatio)
 
 	for res := range results {
-		if res.err != nil {
-			return nil, res.err
-		}
-
 		allElements = append(allElements, res.elements...)
+	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 
 	return allElements, nil

--- a/internal/core/infra/accessibility/adapter_concurrent_test.go
+++ b/internal/core/infra/accessibility/adapter_concurrent_test.go
@@ -1,0 +1,129 @@
+//nolint:testpackage
+package accessibility
+
+import (
+	"context"
+	"image"
+	"testing"
+
+	"go.uber.org/goleak"
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func TestProcessClickableNodesConcurrent_CancelledBeforeStart(t *testing.T) {
+	logger := zap.NewNop()
+	adapter := NewAdapter(logger, nil, nil, &MockAXClient{}, false)
+
+	nodeCount := ConcurrentProcessingThreshold + 50
+
+	nodes := make([]AXNode, nodeCount)
+	for i := range nodeCount {
+		nodes[i] = &MockNode{
+			MockID:     "test-id",
+			MockBounds: image.Rect(0, 0, 100, 100),
+			MockRole:   "AXButton",
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := adapter.processClickableNodesConcurrent(ctx, nodes, ports.ElementFilter{})
+	if err == nil {
+		t.Fatal("expected error from canceled context, got nil")
+	}
+
+	if result != nil {
+		t.Fatal("expected nil result on cancellation, got non-nil slice")
+	}
+}
+
+func TestProcessClickableNodesConcurrent_CancelledMidProcessing(t *testing.T) {
+	logger := zap.NewNop()
+	adapter := NewAdapter(logger, nil, nil, &MockAXClient{}, false)
+
+	// Use enough nodes that workers are busy when cancellation arrives
+	nodeCount := ConcurrentProcessingThreshold * 4
+
+	nodes := make([]AXNode, nodeCount)
+	for i := range nodeCount {
+		nodes[i] = &MockNode{
+			MockID:     "test-id",
+			MockBounds: image.Rect(0, 0, 100, 100),
+			MockRole:   "AXButton",
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := adapter.processClickableNodesConcurrent(ctx, nodes, ports.ElementFilter{})
+	if err == nil {
+		t.Fatal("expected error from canceled context, got nil")
+	}
+
+	if result != nil {
+		t.Fatal("expected nil result on cancellation, got non-nil slice")
+	}
+}
+
+func TestProcessClickableNodesConcurrent_HappyPath(t *testing.T) {
+	logger := zap.NewNop()
+	adapter := NewAdapter(logger, nil, nil, &MockAXClient{}, false)
+
+	nodeCount := ConcurrentProcessingThreshold + 50
+
+	nodes := make([]AXNode, nodeCount)
+	for i := range nodeCount {
+		nodes[i] = &MockNode{
+			MockID:     "test-id",
+			MockBounds: image.Rect(0, 0, 100, 100),
+			MockRole:   "AXButton",
+		}
+	}
+
+	ctx := context.Background()
+
+	result, err := adapter.processClickableNodesConcurrent(ctx, nodes, ports.ElementFilter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != nodeCount {
+		t.Fatalf("expected %d elements, got %d", nodeCount, len(result))
+	}
+}
+
+func TestProcessClickableNodesConcurrent_BelowThreshold(t *testing.T) {
+	logger := zap.NewNop()
+	adapter := NewAdapter(logger, nil, nil, &MockAXClient{}, false)
+
+	// Below the concurrent processing threshold — tests the sequential path
+	nodeCount := ConcurrentProcessingThreshold - 10
+
+	nodes := make([]AXNode, nodeCount)
+	for i := range nodeCount {
+		nodes[i] = &MockNode{
+			MockID:     "test-id",
+			MockBounds: image.Rect(0, 0, 100, 100),
+			MockRole:   "AXButton",
+		}
+	}
+
+	ctx := context.Background()
+
+	result, err := adapter.processClickableNodes(ctx, nodes, ports.ElementFilter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != nodeCount {
+		t.Fatalf("expected %d elements, got %d", nodeCount, len(result))
+	}
+}

--- a/internal/core/infra/accessibility/adapter_concurrent_test.go
+++ b/internal/core/infra/accessibility/adapter_concurrent_test.go
@@ -4,11 +4,13 @@ package accessibility
 import (
 	"context"
 	"image"
+	"sync"
 	"testing"
 
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/core/domain/element"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
@@ -44,15 +46,40 @@ func TestProcessClickableNodesConcurrent_CancelledBeforeStart(t *testing.T) {
 	}
 }
 
+// signalNode wraps MockNode and closes the started channel on the first Bounds() call,
+// providing a deterministic handshake that a worker has begun processing a node.
+type signalNode struct {
+	MockNode
+
+	started chan struct{}
+	once    sync.Once
+}
+
+func (n *signalNode) Bounds() image.Rectangle {
+	n.once.Do(func() { close(n.started) })
+
+	return n.MockBounds
+}
+
 func TestProcessClickableNodesConcurrent_CancelledMidProcessing(t *testing.T) {
 	logger := zap.NewNop()
 	adapter := NewAdapter(logger, nil, nil, &MockAXClient{}, false)
 
-	// Use enough nodes that workers are busy when cancellation arrives
 	nodeCount := ConcurrentProcessingThreshold * 4
+	started := make(chan struct{})
+
+	// First node is a signalNode so we know when a worker starts processing
+	// after the context check passes at idx=0.
+	baseNode := &MockNode{
+		MockID:     "test-id",
+		MockBounds: image.Rect(0, 0, 100, 100),
+		MockRole:   "AXButton",
+	}
 
 	nodes := make([]AXNode, nodeCount)
-	for i := range nodeCount {
+
+	nodes[0] = &signalNode{MockNode: *baseNode, started: started}
+	for i := 1; i < nodeCount; i++ {
 		nodes[i] = &MockNode{
 			MockID:     "test-id",
 			MockBounds: image.Rect(0, 0, 100, 100),
@@ -61,9 +88,25 @@ func TestProcessClickableNodesConcurrent_CancelledMidProcessing(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+
+	var (
+		result []*element.Element
+		err    error
+	)
+
+	done := make(chan struct{})
+	go func() {
+		result, err = adapter.processClickableNodesConcurrent(ctx, nodes, ports.ElementFilter{})
+
+		close(done)
+	}()
+
+	// Wait for a worker to begin processing a node, then cancel mid-flight.
+	<-started
 	cancel()
 
-	result, err := adapter.processClickableNodesConcurrent(ctx, nodes, ports.ElementFilter{})
+	<-done
+
 	if err == nil {
 		t.Fatal("expected error from canceled context, got nil")
 	}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -162,7 +162,7 @@ else
     # `nix-shell -p go --run 'go mod vendor'`
     # `nix hash path vendor`
     # `rm -rf vendor`
-    vendorHash = "sha256-/sAoUAnue3j0c7XSlQLIPte9OV6uVqveWtOF9VA7uyc=";
+    vendorHash = "sha256-IWaHYe9XKq/3l0KRNx3g5evGLgfeRJZ4VKk0MVA/B4Q=";
 
     ldflags = [
       "-s"


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes a goroutine leak in `processClickableNodesConcurrent`. Previously, when
a worker detected context cancellation it sent an error result to the channel
and returned. The collector returned immediately on the first error, orphaning
the remaining workers — they continued processing their chunks unnecessarily
until completion.

The fix makes workers return immediately on cancellation (without sending to
the channel), and the collector reads all results before checking
`ctx.Err()` after the loop. The unused `err` field in the local `result` struct
was also removed.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
