### PR TITLE
fix(darwin): protect clickState `performLeftClickAtPosition`

### DIFF
--- a/internal/core/infra/accessibility/adapter_concurrent_test.go
+++ b/internal/core/infra/accessibility/adapter_concurrent_test.go
@@ -46,17 +46,20 @@ func TestProcessClickableNodesConcurrent_CancelledBeforeStart(t *testing.T) {
 	}
 }
 
-// signalNode wraps MockNode and closes the started channel on the first Bounds() call,
-// providing a deterministic handshake that a worker has begun processing a node.
-type signalNode struct {
+// holdNode blocks on Bounds() until released, guaranteeing a worker is
+// mid-processing when we cancel the context.
+type holdNode struct {
 	MockNode
 
-	started chan struct{}
+	started chan struct{} // closed on first Bounds() call
+	release chan struct{} // close to unblock
 	once    sync.Once
 }
 
-func (n *signalNode) Bounds() image.Rectangle {
+func (n *holdNode) Bounds() image.Rectangle {
 	n.once.Do(func() { close(n.started) })
+
+	<-n.release
 
 	return n.MockBounds
 }
@@ -67,9 +70,10 @@ func TestProcessClickableNodesConcurrent_CancelledMidProcessing(t *testing.T) {
 
 	nodeCount := ConcurrentProcessingThreshold * 4
 	started := make(chan struct{})
+	release := make(chan struct{})
 
-	// First node is a signalNode so we know when a worker starts processing
-	// after the context check passes at idx=0.
+	// First node is a holdNode that blocks until we release it, ensuring
+	// the worker is still running when we cancel the context.
 	baseNode := &MockNode{
 		MockID:     "test-id",
 		MockBounds: image.Rect(0, 0, 100, 100),
@@ -78,7 +82,7 @@ func TestProcessClickableNodesConcurrent_CancelledMidProcessing(t *testing.T) {
 
 	nodes := make([]AXNode, nodeCount)
 
-	nodes[0] = &signalNode{MockNode: *baseNode, started: started}
+	nodes[0] = &holdNode{MockNode: *baseNode, started: started, release: release}
 	for i := 1; i < nodeCount; i++ {
 		nodes[i] = &MockNode{
 			MockID:     "test-id",
@@ -101,9 +105,13 @@ func TestProcessClickableNodesConcurrent_CancelledMidProcessing(t *testing.T) {
 		close(done)
 	}()
 
-	// Wait for a worker to begin processing a node, then cancel mid-flight.
+	// Wait for a worker to begin processing a node, then cancel mid-flight
+	// while the worker is still blocked on Bounds().
 	<-started
 	cancel()
+
+	// Release the blocked worker so it can observe the canceled context.
+	close(release)
 
 	<-done
 

--- a/internal/core/infra/platform/darwin/accessibility_mouse_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_mouse_darwin.m
@@ -10,6 +10,7 @@
 #import "accessibility_visibility.h"
 
 #import <Cocoa/Cocoa.h>
+#import <os/lock.h>
 #include <sys/time.h>
 
 #pragma mark - Mouse Functions
@@ -130,6 +131,10 @@ static struct {
 	int clickCount;                ///< Current click count
 } clickState = {0};
 
+/// Lock guarding clickState — performLeftClickAtPosition may be called
+/// from concurrent goroutines via the CGo bridge.
+static os_unfair_lock clickStateLock = OS_UNFAIR_LOCK_INIT;
+
 /// Get current time in milliseconds
 /// @return Current time in milliseconds
 static long long getCurrentTimeMs(void) {
@@ -154,6 +159,8 @@ int performLeftClickAtPosition(CGPoint position, bool restoreCursor, CGEventFlag
 	}
 
 	// Determine click count (single, double, triple...)
+	os_unfair_lock_lock(&clickStateLock);
+
 	long long currentTime = getCurrentTimeMs();
 	long long lastTime = (long long)clickState.lastClickTime.tv_sec * 1000 + clickState.lastClickTime.tv_usec / 1000;
 	long long timeDiff = currentTime - lastTime;
@@ -171,6 +178,8 @@ int performLeftClickAtPosition(CGPoint position, bool restoreCursor, CGEventFlag
 	// Update click state
 	clickState.lastPosition = position;
 	gettimeofday(&clickState.lastClickTime, NULL);
+
+	os_unfair_lock_unlock(&clickStateLock);
 
 	moveMouseWithType(position, kCGEventMouseMoved);
 
@@ -190,8 +199,13 @@ int performLeftClickAtPosition(CGPoint position, bool restoreCursor, CGEventFlag
 	// Set modifier flags and click count
 	CGEventSetFlags(down, flags);
 	CGEventSetFlags(up, flags);
-	CGEventSetIntegerValueField(down, kCGMouseEventClickState, clickState.clickCount);
-	CGEventSetIntegerValueField(up, kCGMouseEventClickState, clickState.clickCount);
+
+	os_unfair_lock_lock(&clickStateLock);
+	int clickCount = clickState.clickCount;
+	os_unfair_lock_unlock(&clickStateLock);
+
+	CGEventSetIntegerValueField(down, kCGMouseEventClickState, clickCount);
+	CGEventSetIntegerValueField(up, kCGMouseEventClickState, clickCount);
 
 	// Post mouse down and allow a short moment before posting mouse up to ensure
 	// the system attributes the down/up pair to the target location.

--- a/internal/core/infra/platform/darwin/accessibility_mouse_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_mouse_darwin.m
@@ -167,6 +167,7 @@ int performLeftClickAtPosition(CGPoint position, bool restoreCursor, CGEventFlag
 	double distance =
 	    sqrt(pow(position.x - clickState.lastPosition.x, 2) + pow(position.y - clickState.lastPosition.y, 2));
 
+	int clickCount;
 	if (timeDiff < kNeruDoubleClickIntervalMs && distance < kNeruDoubleClickDistancePoints) {
 		// Same location, quick succession — increment click count
 		clickState.clickCount++;
@@ -174,6 +175,8 @@ int performLeftClickAtPosition(CGPoint position, bool restoreCursor, CGEventFlag
 		// New click sequence
 		clickState.clickCount = 1;
 	}
+
+	clickCount = clickState.clickCount;
 
 	// Update click state
 	clickState.lastPosition = position;
@@ -199,10 +202,6 @@ int performLeftClickAtPosition(CGPoint position, bool restoreCursor, CGEventFlag
 	// Set modifier flags and click count
 	CGEventSetFlags(down, flags);
 	CGEventSetFlags(up, flags);
-
-	os_unfair_lock_lock(&clickStateLock);
-	int clickCount = clickState.clickCount;
-	os_unfair_lock_unlock(&clickStateLock);
 
 	CGEventSetIntegerValueField(down, kCGMouseEventClickState, clickCount);
 	CGEventSetIntegerValueField(up, kCGMouseEventClickState, clickCount);

--- a/internal/core/infra/platform/darwin/accessibility_mouse_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_mouse_darwin.m
@@ -167,7 +167,6 @@ int performLeftClickAtPosition(CGPoint position, bool restoreCursor, CGEventFlag
 	double distance =
 	    sqrt(pow(position.x - clickState.lastPosition.x, 2) + pow(position.y - clickState.lastPosition.y, 2));
 
-	int clickCount;
 	if (timeDiff < kNeruDoubleClickIntervalMs && distance < kNeruDoubleClickDistancePoints) {
 		// Same location, quick succession — increment click count
 		clickState.clickCount++;
@@ -176,12 +175,11 @@ int performLeftClickAtPosition(CGPoint position, bool restoreCursor, CGEventFlag
 		clickState.clickCount = 1;
 	}
 
-	clickCount = clickState.clickCount;
-
 	// Update click state
 	clickState.lastPosition = position;
 	gettimeofday(&clickState.lastClickTime, NULL);
 
+	int clickCount = clickState.clickCount;
 	os_unfair_lock_unlock(&clickStateLock);
 
 	moveMouseWithType(position, kCGEventMouseMoved);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR add a static `os_unfair_lock` alongside `clickState` and locked the two critical sections:

1. The read-decide-write cycle (compute timing/distance, update click count and position/time state)
2. The read of `clickCount` used for CGEvent click-state fields

The lock is never held across run-loop or event-posting calls.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
