### PR TITLE
refactor: replace error string concatenation with fmt.Sprintf in IPC responses

### DIFF
--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"image"
 	"strconv"
 	"strings"
@@ -666,7 +667,7 @@ func (h *IPCControllerActions) handleFeedAction(args []string) ipc.Response {
 
 			return ipc.Response{
 				Success: false,
-				Message: "failed to feed key " + key + ": " + err.Error(),
+				Message: fmt.Sprintf("failed to feed key %s: %s", key, err.Error()),
 				Code:    code,
 			}
 		}

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"go.uber.org/zap"
@@ -303,8 +304,12 @@ func (h *IPCControllerModes) extractModeOptions(
 		if !action.IsKnownName(action.Name(*opts.Action)) {
 			resp := ipc.Response{
 				Success: false,
-				Message: "invalid action: " + *opts.Action + ". Supported actions: " + action.SupportedNamesString(),
-				Code:    ipc.CodeInvalidInput,
+				Message: fmt.Sprintf(
+					"invalid action: %s. Supported actions: %s",
+					*opts.Action,
+					action.SupportedNamesString(),
+				),
+				Code: ipc.CodeInvalidInput,
 			}
 
 			return opts, &resp
@@ -316,8 +321,12 @@ func (h *IPCControllerModes) extractModeOptions(
 		if action.IsScrollSubAction(*opts.Action) {
 			resp := ipc.Response{
 				Success: false,
-				Message: "scroll sub-action \"" + *opts.Action + "\" cannot be used as a mode action; use 'action " + *opts.Action + "' instead",
-				Code:    ipc.CodeInvalidInput,
+				Message: fmt.Sprintf(
+					"scroll sub-action %q cannot be used as a mode action; use 'action %s' instead",
+					*opts.Action,
+					*opts.Action,
+				),
+				Code: ipc.CodeInvalidInput,
 			}
 
 			return opts, &resp
@@ -330,8 +339,12 @@ func (h *IPCControllerModes) extractModeOptions(
 			action.IsRestoreCursorPosAction(*opts.Action) {
 			resp := ipc.Response{
 				Success: false,
-				Message: "mode action \"" + *opts.Action + "\" is not allowed; use 'action " + *opts.Action + "' instead",
-				Code:    ipc.CodeInvalidInput,
+				Message: fmt.Sprintf(
+					"mode action %q is not allowed; use 'action %s' instead",
+					*opts.Action,
+					*opts.Action,
+				),
+				Code: ipc.CodeInvalidInput,
 			}
 
 			return opts, &resp


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR replaces all string concatenation with `fmt.Sprintf` calls.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
