### PR TITLE
refactor: use proper stored struct context

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"context"
-
 	"go.uber.org/zap"
 )
 
@@ -13,10 +11,7 @@ func (a *App) ActivateMode(mode Mode) {
 
 // IsFocusedAppExcluded checks if the focused app is excluded.
 func (a *App) IsFocusedAppExcluded() bool {
-	// Use ActionService to check exclusion
-	ctx := context.Background()
-
-	excluded, excludedErr := a.actionService.IsFocusedAppExcluded(ctx)
+	excluded, excludedErr := a.actionService.IsFocusedAppExcluded(a.ctx)
 	if excludedErr != nil {
 		a.logger.Warn("Failed to check exclusion", zap.Error(excludedErr))
 

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -129,7 +129,7 @@ func (a *App) updateServiceConfigs(cfg *config.Config) {
 		if genErr != nil {
 			a.logger.Error("Failed to create hint generator during reload", zap.Error(genErr))
 		} else {
-			a.hintService.UpdateGenerator(context.Background(), newGen)
+			a.hintService.UpdateGenerator(a.ctx, newGen)
 		}
 	}
 

--- a/internal/app/app_initialization.go
+++ b/internal/app/app_initialization.go
@@ -1,13 +1,15 @@
 package app
 
 import (
+	"context"
+
 	"github.com/y3owk1n/neru/internal/config"
 )
 
 // New creates a new App instance with the provided options.
 // It applies sensible defaults and allows customization through functional options.
 func New(opts ...Option) (*App, error) {
-	app := &App{}
+	app := &App{ctx: context.Background()}
 
 	// Apply all options
 	for _, opt := range opts {

--- a/internal/app/app_initialization.go
+++ b/internal/app/app_initialization.go
@@ -9,7 +9,8 @@ import (
 // New creates a new App instance with the provided options.
 // It applies sensible defaults and allows customization through functional options.
 func New(opts ...Option) (*App, error) {
-	app := &App{ctx: context.Background()}
+	ctx, cancel := context.WithCancel(context.Background())
+	app := &App{ctx: ctx, cancel: cancel}
 
 	// Apply all options
 	for _, opt := range opts {

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/app/components"
@@ -496,8 +498,12 @@ func cleanupUIComponents(app *App) {
 func cleanupEventTapAndIPC(app *App) {
 	// Clean up IPC server
 	if app.ipcServer != nil {
-		// Try to stop the server gracefully
-		stopErr := app.ipcServer.Stop(app.ctx)
+		// Try to stop the server gracefully.
+		// Use a fresh context since app.ctx may already be canceled.
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), StopTimeout)
+		defer stopCancel()
+
+		stopErr := app.ipcServer.Stop(stopCtx)
 		if stopErr != nil {
 			app.logger.Error("Failed to stop IPC server during cleanup", zap.Error(stopErr))
 		}

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"context"
-
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/app/components"
@@ -498,7 +496,7 @@ func cleanupEventTapAndIPC(app *App) {
 	// Clean up IPC server
 	if app.ipcServer != nil {
 		// Try to stop the server gracefully
-		stopErr := app.ipcServer.Stop(context.Background())
+		stopErr := app.ipcServer.Stop(app.ctx)
 		if stopErr != nil {
 			app.logger.Error("Failed to stop IPC server during cleanup", zap.Error(stopErr))
 		}

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -320,6 +320,7 @@ func initializeModeHandler(app *App) {
 	}
 
 	app.modes = modes.NewHandler(
+		app.ctx,
 		deps.config,
 		deps.logger,
 		deps.appState,

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -501,9 +501,11 @@ func cleanupEventTapAndIPC(app *App) {
 		// Try to stop the server gracefully.
 		// Use a fresh context since app.ctx may already be canceled.
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), StopTimeout)
-		defer stopCancel()
 
 		stopErr := app.ipcServer.Stop(stopCtx)
+
+		stopCancel()
+
 		if stopErr != nil {
 			app.logger.Error("Failed to stop IPC server during cleanup", zap.Error(stopErr))
 		}

--- a/internal/app/app_lifecycle.go
+++ b/internal/app/app_lifecycle.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+
 	"go.uber.org/zap"
 )
 
@@ -25,7 +27,9 @@ func (a *App) enableEventTap() {
 
 func (a *App) disableEventTap() {
 	if a.eventTap != nil {
-		err := a.eventTap.Disable(a.ctx)
+		// Use Background context since this may be called during cleanup,
+		// after a.ctx has already been canceled.
+		err := a.eventTap.Disable(context.Background())
 		if err != nil {
 			if a.logger != nil {
 				a.logger.Error("Failed to disable event tap", zap.Error(err))

--- a/internal/app/app_lifecycle.go
+++ b/internal/app/app_lifecycle.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"context"
-
 	"go.uber.org/zap"
 )
 
@@ -16,7 +14,7 @@ func (a *App) DisableEventTap() { a.disableEventTap() }
 
 func (a *App) enableEventTap() {
 	if a.eventTap != nil {
-		err := a.eventTap.Enable(context.Background())
+		err := a.eventTap.Enable(a.ctx)
 		if err != nil {
 			if a.logger != nil {
 				a.logger.Error("Failed to enable event tap", zap.Error(err))
@@ -27,7 +25,7 @@ func (a *App) enableEventTap() {
 
 func (a *App) disableEventTap() {
 	if a.eventTap != nil {
-		err := a.eventTap.Disable(context.Background())
+		err := a.eventTap.Disable(a.ctx)
 		if err != nil {
 			if a.logger != nil {
 				a.logger.Error("Failed to disable event tap", zap.Error(err))

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -39,6 +39,7 @@ type SystrayComponent interface {
 // App represents the main application instance containing all state and dependencies.
 type App struct {
 	ctx        context.Context //nolint:containedctx // Root context for all App operations
+	cancel     context.CancelFunc
 	config     *config.Config
 	ConfigPath string
 	logger     *zap.Logger

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -38,6 +38,7 @@ type SystrayComponent interface {
 
 // App represents the main application instance containing all state and dependencies.
 type App struct {
+	ctx        context.Context //nolint:containedctx // Root context for all App operations
 	config     *config.Config
 	ConfigPath string
 	logger     *zap.Logger

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -140,7 +140,7 @@ func (a *App) dispatchHotkeyActions(key string, actions []string) {
 }
 
 func (a *App) startHotkeyRepeat(key string, actions []string) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(a.ctx)
 
 	a.hotkeyRepeatMu.Lock()
 
@@ -319,7 +319,7 @@ func (a *App) executeHotkeyAction(key, actionStr string) error {
 	}
 
 	ipcResponse := a.ipcController.HandleCommand(
-		context.Background(),
+		a.ctx,
 		ipc.Command{Action: actionStr, Args: params},
 	)
 	if !ipcResponse.Success {
@@ -350,7 +350,7 @@ func (a *App) executeShellCommand(key, actionStr string) error {
 		zap.String("cmd", cmdString),
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), domain.ShellCommandTimeout)
+	ctx, cancel := context.WithTimeout(a.ctx, domain.ShellCommandTimeout)
 	defer cancel()
 
 	command := exec.CommandContext(ctx, "/bin/bash", "-lc", cmdString) //nolint:gosec
@@ -394,7 +394,7 @@ func (a *App) refreshHotkeysForAppOrCurrent(bundleID string) {
 
 	if bundleID == "" {
 		// Use ActionService to get focused bundle ID
-		ctx := context.Background()
+		ctx := a.ctx
 
 		var bundleIDErr error
 

--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"strings"
 
 	"go.uber.org/zap"
@@ -225,7 +224,7 @@ func (a *App) configureEventTapHotkeys(cfg *config.Config, logger *zap.Logger) {
 	a.eventTap.SetHotkeys(keys)
 
 	// Use Background context as this is a synchronous cleanup operation
-	err := a.eventTap.Disable(context.Background())
+	err := a.eventTap.Disable(a.ctx)
 	if err != nil {
 		logger.Warn("Failed to disable event tap after setting hotkeys", zap.Error(err))
 	}

--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -223,7 +223,6 @@ func (a *App) configureEventTapHotkeys(cfg *config.Config, logger *zap.Logger) {
 
 	a.eventTap.SetHotkeys(keys)
 
-	// Use Background context as this is a synchronous cleanup operation
 	err := a.eventTap.Disable(a.ctx)
 	if err != nil {
 		logger.Warn("Failed to disable event tap after setting hotkeys", zap.Error(err))

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -586,6 +586,10 @@ func (a *App) Stop() {
 func (a *App) Cleanup() {
 	a.cleanupOnce.Do(func() {
 		a.logger.Info("Cleaning up")
+		// Cancel root context to signal shutdown to all operations
+		if a.cancel != nil {
+			a.cancel()
+		}
 		// Cancel background GC if running
 		if a.gcCancel != nil {
 			a.gcCancel()

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -25,6 +25,8 @@ const (
 	MaxExecDisplayLength = 30
 	// SystrayQuitTimeout is the timeout for systray quit.
 	SystrayQuitTimeout = 10 * time.Second
+	// StopTimeout is the timeout for IPC server stop during cleanup.
+	StopTimeout = 5 * time.Second
 	// GCTickerInterval is the interval for garbage collection.
 	GCTickerInterval = 5 * time.Minute
 
@@ -599,9 +601,15 @@ func (a *App) Cleanup() {
 		// Stop theme observer: nil the handler first so any in-flight KVO callback
 		// (between the async dispatch and actual observer removal) is a no-op.
 		a.stopThemeObserver()
-		// Stop IPC server first to prevent new requests
+		// Stop IPC server first to prevent new requests.
+		// Use a fresh context instead of a.ctx since the root context was
+		// canceled above; a canceled context would cause Stop() to fail
+		// immediately before it can complete graceful teardown.
 		if a.ipcServer != nil {
-			stopServerErr := a.ipcServer.Stop(a.ctx)
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), StopTimeout)
+			defer stopCancel()
+
+			stopServerErr := a.ipcServer.Stop(stopCtx)
 			if stopServerErr != nil {
 				a.logger.Error("Failed to stop IPC server", zap.Error(stopServerErr))
 			}

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -54,7 +54,7 @@ const (
 func (a *App) Run() error {
 	a.logger.Info("Starting Neru")
 
-	err := a.ipcServer.Start(context.Background())
+	err := a.ipcServer.Start(a.ctx)
 	if err != nil {
 		a.logger.Error("Failed to start IPC server", zap.Error(err))
 
@@ -76,7 +76,7 @@ func (a *App) Run() error {
 	cfg := a.configSnapshot()
 
 	if cfg.Grid.EnableGC {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(a.ctx)
 		a.gcCancel = cancel
 
 		go func() {
@@ -274,7 +274,7 @@ func (a *App) processScreenChange() {
 		a.logger.Info("Screen parameters changed; adjusting overlays")
 	}
 
-	ctx := context.Background()
+	ctx := a.ctx
 
 	cfg := a.configSnapshot()
 
@@ -597,7 +597,7 @@ func (a *App) Cleanup() {
 		a.stopThemeObserver()
 		// Stop IPC server first to prevent new requests
 		if a.ipcServer != nil {
-			stopServerErr := a.ipcServer.Stop(context.Background())
+			stopServerErr := a.ipcServer.Stop(a.ctx)
 			if stopServerErr != nil {
 				a.logger.Error("Failed to stop IPC server", zap.Error(stopServerErr))
 			}

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -607,9 +607,11 @@ func (a *App) Cleanup() {
 		// immediately before it can complete graceful teardown.
 		if a.ipcServer != nil {
 			stopCtx, stopCancel := context.WithTimeout(context.Background(), StopTimeout)
-			defer stopCancel()
 
 			stopServerErr := a.ipcServer.Stop(stopCtx)
+
+			stopCancel()
+
 			if stopServerErr != nil {
 				a.logger.Error("Failed to stop IPC server", zap.Error(stopServerErr))
 			}

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -1,7 +1,6 @@
 package modes
 
 import (
-	"context"
 	"image"
 	"strings"
 
@@ -136,7 +135,7 @@ func (h *Handler) createGridInstance() *domainGrid.Grid {
 	var screenBounds image.Rectangle
 
 	if h.system != nil {
-		b, err := h.system.ScreenBounds(context.Background())
+		b, err := h.system.ScreenBounds(h.ctx)
 		if err == nil {
 			screenBounds = b
 		} else if !derrors.IsNotSupported(err) {
@@ -187,7 +186,7 @@ func (h *Handler) initializeGridManager(gridInstance *domainGrid.Grid) {
 		var screenBounds image.Rectangle
 
 		if h.system != nil {
-			b, err := h.system.ScreenBounds(context.Background())
+			b, err := h.system.ScreenBounds(h.ctx)
 			if err == nil {
 				screenBounds = b
 			} else if !derrors.IsNotSupported(err) {
@@ -276,7 +275,7 @@ func (h *Handler) initializeGridManager(gridInstance *domainGrid.Grid) {
 			}
 
 			// Move mouse to center of cell before showing subgrid for better UX
-			ctx := context.Background()
+			ctx := h.ctx
 
 			// Convert cell center from window-local to screen-absolute coordinates
 			absoluteCenter := coordinates.ConvertToAbsoluteCoordinates(

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -123,6 +123,11 @@ type Handler struct {
 	// Cycle hint state
 	cycleHintIndex int
 
+	// Base context for Handler methods. Initialized from context.Background() in
+	// NewHandler; overridden by the App with a cancellable context during startup
+	// so all Handler operations observe app-level cancellation.
+	ctx context.Context //nolint:containedctx
+
 	// heldRepeatingKey tracks which key is currently held for custom repeat.
 	// When non-empty, macOS native key-down events for this key are suppressed
 	// and a custom goroutine drives the repeat at heldRepeatInterval.
@@ -176,6 +181,7 @@ func NewHandler(
 	}
 
 	handler := &Handler{
+		ctx:                        context.Background(),
 		config:                     config,
 		logger:                     logger,
 		appState:                   appState,
@@ -245,7 +251,7 @@ func (h *Handler) RefreshHintsForScreenChange(
 	// Re-read screen bounds under the lock so the onUpdate callback
 	// uses coordinates that match the resized overlay.
 	if h.system != nil {
-		b, err := h.system.ScreenBounds(context.Background())
+		b, err := h.system.ScreenBounds(ctx)
 		if err == nil {
 			h.screenBounds = b
 		} else if !derrors.IsNotSupported(err) {
@@ -374,7 +380,7 @@ func (h *Handler) RefreshRecursiveGridForScreenChange() bool {
 	// Re-read screen bounds under the lock so the overlay uses coordinates
 	// that match the resized window.
 	if h.system != nil {
-		b, err := h.system.ScreenBounds(context.Background())
+		b, err := h.system.ScreenBounds(h.ctx)
 		if err == nil {
 			h.screenBounds = b
 		} else if !derrors.IsNotSupported(err) {
@@ -574,7 +580,7 @@ func (h *Handler) ResetCurrentMode() {
 			}
 
 			err := h.actionService.MoveCursorToPoint(
-				context.Background(),
+				h.ctx,
 				absoluteCenter,
 			)
 			if err != nil {
@@ -624,7 +630,7 @@ func (h *Handler) BackspaceCurrentMode() {
 			}
 
 			err := h.actionService.MoveCursorToPoint(
-				context.Background(),
+				h.ctx,
 				absoluteCenter,
 			)
 			if err != nil {
@@ -769,7 +775,7 @@ func (h *Handler) startHintSearchLocked() error {
 		}
 
 		started, _ := h.textInput.StartHintSearchSession(
-			context.Background(),
+			h.ctx,
 			ports.TextInputCallbacks{
 				OnQueryChanged: func(query string) {
 					h.mu.Lock()
@@ -825,7 +831,7 @@ func (h *Handler) startHintSearchLocked() error {
 
 func (h *Handler) stopHintSearchTextInputLocked(keepEventTapDisabled bool) {
 	if h.hintSearchTextInputActive && h.textInput != nil {
-		_ = h.textInput.StopHintSearchSession(context.Background())
+		_ = h.textInput.StopHintSearchSession(h.ctx)
 	}
 
 	h.hintSearchTextInputActive = false
@@ -842,7 +848,7 @@ func (h *Handler) focusedBundleID() string {
 		return ""
 	}
 
-	bundleID, err := h.actionService.FocusedAppBundleID(context.Background())
+	bundleID, err := h.actionService.FocusedAppBundleID(h.ctx)
 	if err != nil {
 		h.logger.Debug("Failed to get focused app bundle ID for mode hotkeys", zap.Error(err))
 

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -831,7 +831,9 @@ func (h *Handler) startHintSearchLocked() error {
 
 func (h *Handler) stopHintSearchTextInputLocked(keepEventTapDisabled bool) {
 	if h.hintSearchTextInputActive && h.textInput != nil {
-		_ = h.textInput.StopHintSearchSession(h.ctx)
+		// Use Background context since this may be called during cleanup,
+		// after h.ctx has already been canceled.
+		_ = h.textInput.StopHintSearchSession(context.Background())
 	}
 
 	h.hintSearchTextInputActive = false

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -137,6 +137,7 @@ type Handler struct {
 
 // NewHandler creates a new mode handler.
 func NewHandler(
+	ctx context.Context,
 	config *configpkg.Config,
 	logger *zap.Logger,
 	appState *state.AppState,
@@ -181,7 +182,7 @@ func NewHandler(
 	}
 
 	handler := &Handler{
-		ctx:                        context.Background(),
+		ctx:                        ctx,
 		config:                     config,
 		logger:                     logger,
 		appState:                   appState,

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -123,9 +123,8 @@ type Handler struct {
 	// Cycle hint state
 	cycleHintIndex int
 
-	// Base context for Handler methods. Initialized from context.Background() in
-	// NewHandler; overridden by the App with a cancellable context during startup
-	// so all Handler operations observe app-level cancellation.
+	// Base context for Handler methods. Injected by the App via NewHandler so
+	// all Handler operations observe app-level cancellation.
 	ctx context.Context //nolint:containedctx
 
 	// heldRepeatingKey tracks which key is currently held for custom repeat.

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -198,7 +198,7 @@ func (h *Handler) activateHintModeInternal(
 	var activeScreenBounds image.Rectangle
 
 	if h.system != nil {
-		b, err := h.system.ScreenBounds(context.Background())
+		b, err := h.system.ScreenBounds(h.ctx)
 		if err == nil {
 			activeScreenBounds = b
 		} else if !derrors.IsNotSupported(err) {
@@ -253,7 +253,7 @@ func (h *Handler) activateHintModeInternal(
 	// Fetch bundle ID for hint generation. Validation already passed (secure input check,
 	// exclusion check), so this is the only call. Use a dedicated short timeout so slow
 	// AX doesn't erode the hint generation budget.
-	bundleCtx, bundleCancel := context.WithTimeout(context.Background(), 1*time.Second)
+	bundleCtx, bundleCancel := context.WithTimeout(h.ctx, 1*time.Second)
 	bundleID, bundleIDErr := h.actionService.FocusedAppBundleID(bundleCtx)
 
 	bundleCancel()
@@ -265,7 +265,7 @@ func (h *Handler) activateHintModeInternal(
 
 	// Get hints from service. Drawing is intentionally deferred until after
 	// active-screen filtering so activation performs one full overlay render.
-	ctx, cancel := context.WithTimeout(context.Background(), HintTimeout)
+	ctx, cancel := context.WithTimeout(h.ctx, HintTimeout)
 	defer cancel()
 
 	activationStart := time.Now()

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -57,7 +57,7 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 	go func() {
 		defer close(doneCh)
 		// Create a cancellable context bound to the stop channel.
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(h.ctx)
 		defer cancel()
 		// Monitor stopCh to cancel context immediately if the polling operation hangs.
 		go func() {

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -391,7 +391,7 @@ func (h *Handler) maybeStartHeldRepeatLocked(key, bindKey string, actions []stri
 // bindKey is the normalised config-binding key (for consistent logging).
 // Caller must hold h.mu.
 func (h *Handler) startHeldRepeatLocked(key, bindKey string, actions []string) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(h.ctx)
 	h.heldRepeatingKey = key
 	h.heldRepeatingCancel = cancel
 

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -1,7 +1,6 @@
 package modes
 
 import (
-	"context"
 	"image"
 	"time"
 	"unicode/utf8"
@@ -34,7 +33,7 @@ func (h *Handler) executeActionAtPoint(
 		zap.String("modifiers", h.stickyModifiers().String()),
 		zap.Bool("repeat", repeat))
 
-	ctx := context.Background()
+	ctx := h.ctx
 
 	performActionErr := h.actionService.PerformActionAtPoint(
 		ctx,
@@ -80,7 +79,7 @@ func (h *Handler) moveCursorAndHandleAction(
 	shouldReActivate bool,
 	reActivateFunc func(),
 ) {
-	ctx := context.Background()
+	ctx := h.ctx
 
 	moveCursorErr := h.actionService.MoveCursorToPoint(ctx, point)
 	if moveCursorErr != nil {
@@ -224,7 +223,7 @@ func (h *Handler) confirmHintSearch() {
 
 	if visibleHints := ctx.Hints(); visibleHints != nil && visibleHints.Count() >= 1 {
 		go func() {
-			_ = h.CycleHint(context.Background(), false)
+			_ = h.CycleHint(h.ctx, false)
 		}()
 	} else {
 		h.cancelHintSearch()
@@ -400,7 +399,7 @@ func (h *Handler) handleGridModeKey(key string) {
 			return
 		}
 
-		moveCursorErr := h.actionService.MoveCursorToPoint(context.Background(), absolutePoint)
+		moveCursorErr := h.actionService.MoveCursorToPoint(h.ctx, absolutePoint)
 		if moveCursorErr != nil {
 			h.logger.Error("Failed to move cursor", zap.Error(moveCursorErr))
 		}

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -1,7 +1,6 @@
 package modes
 
 import (
-	"context"
 	"image"
 
 	"go.uber.org/zap"
@@ -60,7 +59,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 	var screenBounds image.Rectangle
 
 	if h.system != nil {
-		b, err := h.system.ScreenBounds(context.Background())
+		b, err := h.system.ScreenBounds(h.ctx)
 		if err == nil {
 			screenBounds = b
 		} else if !derrors.IsNotSupported(err) {
@@ -94,7 +93,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 		}
 
 		if cursorShouldFollow {
-			err := h.actionService.MoveCursorToPoint(context.Background(), absoluteCenter)
+			err := h.actionService.MoveCursorToPoint(h.ctx, absoluteCenter)
 			if err != nil {
 				h.logger.Warn("Failed to move cursor to initial center", zap.Error(err))
 			}
@@ -201,7 +200,7 @@ func (h *Handler) initializeRecursiveGridManager(screenBounds image.Rectangle) {
 
 // handleRecursiveGridKey handles key processing for recursive-grid mode.
 func (h *Handler) handleRecursiveGridKey(key string) {
-	ctx := context.Background()
+	ctx := h.ctx
 
 	if h.recursiveGrid == nil || h.recursiveGrid.Manager == nil {
 		h.logger.Warn("Recursive-grid manager is nil - ignoring key press")

--- a/internal/app/modes/selection.go
+++ b/internal/app/modes/selection.go
@@ -1,7 +1,6 @@
 package modes
 
 import (
-	"context"
 	"image"
 
 	"go.uber.org/zap"
@@ -99,7 +98,7 @@ func (h *Handler) ToggleCursorFollowSelection() (bool, bool) {
 
 		if enabled {
 			if target, ok := h.grid.Context.SelectionPoint(); ok && h.actionService != nil {
-				moveCursorErr := h.actionService.MoveCursorToPoint(context.Background(), target)
+				moveCursorErr := h.actionService.MoveCursorToPoint(h.ctx, target)
 				if moveCursorErr != nil {
 					h.logger.Error("Failed to move cursor", zap.Error(moveCursorErr))
 				}
@@ -119,7 +118,7 @@ func (h *Handler) ToggleCursorFollowSelection() (bool, bool) {
 		if enabled {
 			if target, ok := h.recursiveGrid.Context.SelectionPoint(); ok &&
 				h.actionService != nil {
-				moveCursorErr := h.actionService.MoveCursorToPoint(context.Background(), target)
+				moveCursorErr := h.actionService.MoveCursorToPoint(h.ctx, target)
 				if moveCursorErr != nil {
 					h.logger.Error("Failed to move cursor", zap.Error(moveCursorErr))
 				}

--- a/internal/app/modes/validation.go
+++ b/internal/app/modes/validation.go
@@ -50,11 +50,11 @@ func (h *Handler) validateModeActivation(bundleID string, modeName string, modeE
 
 	// Check if focused app is excluded
 	if bundleID != "" {
-		if h.actionService.IsAppExcluded(bundleID) {
+		if h.actionService.IsAppExcluded(h.ctx, bundleID) {
 			return derrors.New(derrors.CodeInvalidInput, "focused app is excluded")
 		}
 	} else {
-		ctx, cancel := context.WithTimeout(context.Background(), ValidationTimeout)
+		ctx, cancel := context.WithTimeout(h.ctx, ValidationTimeout)
 		defer cancel()
 
 		isExcluded, isExcludedErr := h.actionService.IsFocusedAppExcluded(ctx)

--- a/internal/app/services/action_service.go
+++ b/internal/app/services/action_service.go
@@ -135,8 +135,8 @@ func (s *ActionService) FocusedAppBundleID(ctx context.Context) (string, error) 
 }
 
 // IsAppExcluded checks if the given bundle ID is in the exclusion list.
-func (s *ActionService) IsAppExcluded(bundleID string) bool {
-	return s.accessibility.IsAppExcluded(context.Background(), bundleID)
+func (s *ActionService) IsAppExcluded(ctx context.Context, bundleID string) bool {
+	return s.accessibility.IsAppExcluded(ctx, bundleID)
 }
 
 // MoveCursorToElement moves the cursor to the center of the specified element.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR replaces `context.Background()` usage with a stored `ctx` field on the `Handler` and `App` structs, enabling all operations to observe app-level cancellation.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
