### PR TITLE
perf(darwin): replace layout map init busy-wait with NSCondition

### DIFF
--- a/internal/core/infra/platform/darwin/keymap_darwin.m
+++ b/internal/core/infra/platform/darwin/keymap_darwin.m
@@ -798,6 +798,33 @@ static void handleKeyboardLayoutChanged(
 /// Flag for tracking layout maps initialization status (atomic for thread safety)
 static atomic_bool gLayoutMapsInitialized = false;
 
+/// Waiters block here until the first layout map build completes (main thread).
+static NSCondition *gLayoutInitCondition = nil;
+
+static void markLayoutMapsInitialized(void) {
+	if (atomic_exchange_explicit(&gLayoutMapsInitialized, true, memory_order_acq_rel)) {
+		return;
+	}
+	[gLayoutInitCondition lock];
+	[gLayoutInitCondition broadcast];
+	[gLayoutInitCondition unlock];
+}
+
+static void waitForLayoutMapsInitialized(NSTimeInterval timeoutSeconds) {
+	if (atomic_load_explicit(&gLayoutMapsInitialized, memory_order_acquire)) {
+		return;
+	}
+
+	NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeoutSeconds];
+	[gLayoutInitCondition lock];
+	while (!atomic_load_explicit(&gLayoutMapsInitialized, memory_order_acquire)) {
+		if (![gLayoutInitCondition waitUntilDate:deadline]) {
+			break;
+		}
+	}
+	[gLayoutInitCondition unlock];
+}
+
 /// Register notification observer (called once from initializeKeyMaps)
 static void registerLayoutChangeObserver(void) {
 	CFNotificationCenterAddObserver(
@@ -809,6 +836,7 @@ static void initializeKeyMaps(void) {
 	static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{
 		gKeymapLock = [[NSLock alloc] init];
+		gLayoutInitCondition = [[NSCondition alloc] init];
 
 		initializeSpecialKeyMaps();
 
@@ -830,14 +858,14 @@ static void ensureLayoutMapsInitialized(void) {
 	dispatch_once(&layoutOnceToken, ^{
 		if ([NSThread isMainThread]) {
 			buildLayoutMaps();
-			atomic_store_explicit(&gLayoutMapsInitialized, true, memory_order_release);
+			markLayoutMapsInitialized();
 		} else {
 			// Dispatch to main thread to build layout maps
 			dispatch_async(dispatch_get_main_queue(), ^{
 				// Guard against double execution if the main thread already ran it
 				if (!atomic_load_explicit(&gLayoutMapsInitialized, memory_order_acquire)) {
 					buildLayoutMaps();
-					atomic_store_explicit(&gLayoutMapsInitialized, true, memory_order_release);
+					markLayoutMapsInitialized();
 				}
 			});
 		}
@@ -847,20 +875,11 @@ static void ensureLayoutMapsInitialized(void) {
 	// to avoid deadlock (the async block is queued behind us).
 	if (!atomic_load_explicit(&gLayoutMapsInitialized, memory_order_acquire) && [NSThread isMainThread]) {
 		buildLayoutMaps();
-		atomic_store_explicit(&gLayoutMapsInitialized, true, memory_order_release);
+		markLayoutMapsInitialized();
 		return;
 	}
 
-	// Poll with timeout for all waiters.
-	// Allows multiple concurrent background threads to proceed once
-	// initialization is complete, rather than timing out individually.
-	dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC);
-	while (!atomic_load_explicit(&gLayoutMapsInitialized, memory_order_acquire)) {
-		if (dispatch_time(DISPATCH_TIME_NOW, 0) >= timeout) {
-			break;  // Timeout reached
-		}
-		[NSThread sleepForTimeInterval:0.001];  // 1ms sleep to avoid busy-wait
-	}
+	waitForLayoutMapsInitialized(5.0);
 }
 
 #pragma mark - Public Functions
@@ -1083,7 +1102,7 @@ int setReferenceKeyboardLayout(const char *inputSourceID) {
 		[gKeymapLock unlock];
 
 		buildLayoutMaps();
-		atomic_store_explicit(&gLayoutMapsInitialized, true, memory_order_release);
+		markLayoutMapsInitialized();
 
 		[gKeymapLock lock];
 		configuredResolved = gConfiguredInputSourceResolved;

--- a/internal/core/infra/platform/darwin/keymap_darwin.m
+++ b/internal/core/infra/platform/darwin/keymap_darwin.m
@@ -815,6 +815,11 @@ static void waitForLayoutMapsInitialized(NSTimeInterval timeoutSeconds) {
 		return;
 	}
 
+	NSCAssert(gLayoutInitCondition != nil, @"waitForLayoutMapsInitialized called before initializeKeyMaps");
+	if (!gLayoutInitCondition) {
+		return;
+	}
+
 	NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeoutSeconds];
 	[gLayoutInitCondition lock];
 	while (!atomic_load_explicit(&gLayoutMapsInitialized, memory_order_acquire)) {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR replaces the 1ms polling loop in `ensureLayoutMapsInitialized` with `NSCondition-based waiting`. Background threads now block on `waitForLayoutMapsInitialized` until the main-thread layout build finishes (or the existing 5s timeout elapses), instead of waking every millisecond for up to 5 seconds.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

NSCondition was chosen over a dispatch semaphore so multiple concurrent background waiters can be released with a single broadcast when initialization completes. Timeout and main-thread deadlock avoidance behavior are unchanged from the previous implementation.
