### PR TITLE
refactor: unify app watcher event dispatch helpers

### DIFF
--- a/internal/core/infra/appwatcher/watcher.go
+++ b/internal/core/infra/appwatcher/watcher.go
@@ -128,78 +128,78 @@ func (w *Watcher) OnMissionControlDeactivated(callback func()) {
 // HandleLaunch processes application launch events from the platform layer.
 // It dispatches the event to all registered launch callbacks.
 func (w *Watcher) HandleLaunch(appName, bundleID string) {
-	w.logger.Debug("App watcher: Application launched",
-		zap.String("app_name", appName),
-		zap.String("bundle_id", bundleID))
-
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-
-	for _, callback := range w.launchCallbacks {
-		callback(appName, bundleID)
-	}
+	w.dispatchAppEvent("App watcher: Application launched", appName, bundleID,
+		func(w *Watcher) []AppCallback { return w.launchCallbacks })
 }
 
 // HandleTerminate processes application termination events from the platform layer.
 // It dispatches the event to all registered termination callbacks.
 func (w *Watcher) HandleTerminate(appName, bundleID string) {
-	w.logger.Debug("App watcher: Application terminated",
-		zap.String("app_name", appName),
-		zap.String("bundle_id", bundleID))
-
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-
-	for _, callback := range w.terminateCallbacks {
-		callback(appName, bundleID)
-	}
+	w.dispatchAppEvent("App watcher: Application terminated", appName, bundleID,
+		func(w *Watcher) []AppCallback { return w.terminateCallbacks })
 }
 
 // HandleActivate processes application activation events from the platform layer.
 // It dispatches the event to all registered activation callbacks.
 func (w *Watcher) HandleActivate(appName, bundleID string) {
-	w.logger.Debug("App watcher: Application activated",
-		zap.String("app_name", appName),
-		zap.String("bundle_id", bundleID))
-
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-
-	for _, callback := range w.activateCallbacks {
-		callback(appName, bundleID)
-	}
+	w.dispatchAppEvent("App watcher: Application activated", appName, bundleID,
+		func(w *Watcher) []AppCallback { return w.activateCallbacks })
 }
 
 // HandleDeactivate processes application deactivation events from the platform layer.
 // It dispatches the event to all registered deactivation callbacks.
 func (w *Watcher) HandleDeactivate(appName, bundleID string) {
-	w.logger.Debug("App watcher: Application deactivated",
+	w.dispatchAppEvent("App watcher: Application deactivated", appName, bundleID,
+		func(w *Watcher) []AppCallback { return w.deactivateCallbacks })
+}
+
+// HandleScreenParametersChanged processes screen parameter change events from the platform layer.
+// It dispatches the event to all registered screen change callbacks.
+func (w *Watcher) HandleScreenParametersChanged() {
+	w.dispatchVoidEvent("App watcher: Screen parameters changed",
+		func(w *Watcher) []func() { return w.screenChangeCallbacks })
+}
+
+// HandleMissionControlActivated processes Mission Control activation events from the platform layer.
+func (w *Watcher) HandleMissionControlActivated() {
+	w.dispatchMCEvent("App watcher: Mission Control activated",
+		func(w *Watcher) []func() { return w.mcActivatedCallbacks })
+}
+
+// HandleMissionControlDeactivated processes Mission Control deactivation events from the platform layer.
+func (w *Watcher) HandleMissionControlDeactivated() {
+	w.dispatchMCEvent("App watcher: Mission Control deactivated",
+		func(w *Watcher) []func() { return w.mcDeactivatedCallbacks })
+}
+
+func (w *Watcher) dispatchAppEvent(
+	logMsg, appName, bundleID string,
+	callbacks func(*Watcher) []AppCallback,
+) {
+	w.logger.Debug(logMsg,
 		zap.String("app_name", appName),
 		zap.String("bundle_id", bundleID))
 
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
-	for _, callback := range w.deactivateCallbacks {
+	for _, callback := range callbacks(w) {
 		callback(appName, bundleID)
 	}
 }
 
-// HandleScreenParametersChanged processes screen parameter change events from the platform layer.
-// It dispatches the event to all registered screen change callbacks.
-func (w *Watcher) HandleScreenParametersChanged() {
-	w.logger.Debug("App watcher: Screen parameters changed")
+func (w *Watcher) dispatchVoidEvent(logMsg string, callbacks func(*Watcher) []func()) {
+	w.logger.Debug(logMsg)
 
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
-	for _, callback := range w.screenChangeCallbacks {
+	for _, callback := range callbacks(w) {
 		callback()
 	}
 }
 
-// HandleMissionControlActivated processes Mission Control activation events from the platform layer.
-func (w *Watcher) HandleMissionControlActivated() {
+func (w *Watcher) dispatchMCEvent(logMsg string, callbacks func(*Watcher) []func()) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
@@ -207,25 +207,9 @@ func (w *Watcher) HandleMissionControlActivated() {
 		return
 	}
 
-	w.logger.Debug("App watcher: Mission Control activated")
+	w.logger.Debug(logMsg)
 
-	for _, callback := range w.mcActivatedCallbacks {
-		callback()
-	}
-}
-
-// HandleMissionControlDeactivated processes Mission Control deactivation events from the platform layer.
-func (w *Watcher) HandleMissionControlDeactivated() {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-
-	if !w.mcDetection {
-		return
-	}
-
-	w.logger.Debug("App watcher: Mission Control deactivated")
-
-	for _, callback := range w.mcDeactivatedCallbacks {
+	for _, callback := range callbacks(w) {
 		callback()
 	}
 }

--- a/internal/core/infra/platform/darwin/bridge.go
+++ b/internal/core/infra/platform/darwin/bridge.go
@@ -174,91 +174,105 @@ func StopAppWatcher() {
 	C.stopAppWatcher()
 }
 
-//export handleAppLaunch
-func handleAppLaunch(appName *C.char, bundleID *C.char) {
-	log := getLogger()
-	log.Debug("Darwin: handleAppLaunch called")
-
+func currentAppWatcher() AppWatcherInterface {
 	appWatcherMu.RLock()
 	watcher := appWatcher
 	appWatcherMu.RUnlock()
 
-	if watcher != nil {
-		log.Debug("Darwin: Forwarding app launch event",
-			zap.String("app_name", C.GoString(appName)),
-			zap.String("bundle_id", C.GoString(bundleID)))
+	return watcher
+}
 
-		watcher.HandleLaunch(C.GoString(appName), C.GoString(bundleID))
+func dispatchAppWatcherAppEvent(
+	handlerName, forwardMsg string,
+	appName, bundleID *C.char,
+	forward func(AppWatcherInterface, string, string),
+) {
+	log := getLogger()
+	log.Debug("Darwin: " + handlerName + " called")
+
+	watcher := currentAppWatcher()
+	if watcher == nil {
+		return
 	}
+
+	name := C.GoString(appName)
+	id := C.GoString(bundleID)
+	log.Debug("Darwin: "+forwardMsg,
+		zap.String("app_name", name),
+		zap.String("bundle_id", id))
+	forward(watcher, name, id)
+}
+
+func dispatchAppWatcherVoidEvent(
+	handlerName, forwardMsg string,
+	async bool,
+	forward func(AppWatcherInterface),
+) {
+	log := getLogger()
+	log.Debug("Darwin: " + handlerName + " called")
+
+	watcher := currentAppWatcher()
+	if watcher == nil {
+		return
+	}
+
+	log.Debug("Darwin: " + forwardMsg)
+	if async {
+		go forward(watcher)
+
+		return
+	}
+
+	forward(watcher)
+}
+
+//export handleAppLaunch
+func handleAppLaunch(appName *C.char, bundleID *C.char) {
+	dispatchAppWatcherAppEvent("handleAppLaunch", "Forwarding app launch event", appName, bundleID,
+		func(w AppWatcherInterface, name, id string) { w.HandleLaunch(name, id) })
 }
 
 //export handleAppTerminate
 func handleAppTerminate(appName *C.char, bundleID *C.char) {
-	log := getLogger()
-	log.Debug("Darwin: handleAppTerminate called")
-
-	appWatcherMu.RLock()
-	watcher := appWatcher
-	appWatcherMu.RUnlock()
-
-	if watcher != nil {
-		log.Debug("Darwin: Forwarding app termination event",
-			zap.String("app_name", C.GoString(appName)),
-			zap.String("bundle_id", C.GoString(bundleID)))
-
-		watcher.HandleTerminate(C.GoString(appName), C.GoString(bundleID))
-	}
+	dispatchAppWatcherAppEvent(
+		"handleAppTerminate",
+		"Forwarding app termination event",
+		appName,
+		bundleID,
+		func(w AppWatcherInterface, name, id string) { w.HandleTerminate(name, id) },
+	)
 }
 
 //export handleAppActivate
 func handleAppActivate(appName *C.char, bundleID *C.char) {
-	log := getLogger()
-	log.Debug("Darwin: handleAppActivate called")
-
-	appWatcherMu.RLock()
-	watcher := appWatcher
-	appWatcherMu.RUnlock()
-
-	if watcher != nil {
-		log.Debug("Darwin: Forwarding app activation event",
-			zap.String("app_name", C.GoString(appName)),
-			zap.String("bundle_id", C.GoString(bundleID)))
-
-		watcher.HandleActivate(C.GoString(appName), C.GoString(bundleID))
-	}
+	dispatchAppWatcherAppEvent(
+		"handleAppActivate",
+		"Forwarding app activation event",
+		appName,
+		bundleID,
+		func(w AppWatcherInterface, name, id string) { w.HandleActivate(name, id) },
+	)
 }
 
 //export handleAppDeactivate
 func handleAppDeactivate(appName *C.char, bundleID *C.char) {
-	log := getLogger()
-	log.Debug("Darwin: handleAppDeactivate called")
-
-	appWatcherMu.RLock()
-	watcher := appWatcher
-	appWatcherMu.RUnlock()
-
-	if watcher != nil {
-		log.Debug("Darwin: Forwarding app deactivation event",
-			zap.String("app_name", C.GoString(appName)),
-			zap.String("bundle_id", C.GoString(bundleID)))
-
-		watcher.HandleDeactivate(C.GoString(appName), C.GoString(bundleID))
-	}
+	dispatchAppWatcherAppEvent(
+		"handleAppDeactivate",
+		"Forwarding app deactivation event",
+		appName,
+		bundleID,
+		func(w AppWatcherInterface, name, id string) { w.HandleDeactivate(name, id) },
+	)
 }
 
 //export handleScreenParametersChanged
 func handleScreenParametersChanged() {
-	log := getLogger()
-	log.Debug("Darwin: handleScreenParametersChanged called")
-
-	appWatcherMu.RLock()
-	watcher := appWatcher
-	appWatcherMu.RUnlock()
-
-	if watcher != nil {
-		log.Debug("Darwin: Forwarding screen parameters changed event")
-		go watcher.HandleScreenParametersChanged()
-	}
+	dispatchAppWatcherVoidEvent(
+		"handleScreenParametersChanged",
+		"Forwarding screen parameters changed event",
+		true,
+		func(w AppWatcherInterface) { w.HandleScreenParametersChanged() },
+	)
 }
 
 //export handleMissionControlActivated
@@ -267,17 +281,12 @@ func handleMissionControlActivated() {
 		return
 	}
 
-	log := getLogger()
-	log.Debug("Darwin: handleMissionControlActivated called")
-
-	appWatcherMu.RLock()
-	watcher := appWatcher
-	appWatcherMu.RUnlock()
-
-	if watcher != nil {
-		log.Debug("Darwin: Forwarding Mission Control activated event")
-		go watcher.HandleMissionControlActivated()
-	}
+	dispatchAppWatcherVoidEvent(
+		"handleMissionControlActivated",
+		"Forwarding Mission Control activated event",
+		true,
+		func(w AppWatcherInterface) { w.HandleMissionControlActivated() },
+	)
 }
 
 //export handleMissionControlDeactivated
@@ -286,17 +295,12 @@ func handleMissionControlDeactivated() {
 		return
 	}
 
-	log := getLogger()
-	log.Debug("Darwin: handleMissionControlDeactivated called")
-
-	appWatcherMu.RLock()
-	watcher := appWatcher
-	appWatcherMu.RUnlock()
-
-	if watcher != nil {
-		log.Debug("Darwin: Forwarding Mission Control deactivated event")
-		go watcher.HandleMissionControlDeactivated()
-	}
+	dispatchAppWatcherVoidEvent(
+		"handleMissionControlDeactivated",
+		"Forwarding Mission Control deactivated event",
+		true,
+		func(w AppWatcherInterface) { w.HandleMissionControlDeactivated() },
+	)
 }
 
 // HandleAppLaunch simulates an app launch event for testing.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR consolidates duplicated event-dispatch boilerplate in the app watcher pipeline:

- **Darwin bridge** (`internal/core/infra/platform/darwin/bridge.go`): Seven nearly identical C-exported handlers now delegate to `currentAppWatcher`, `dispatchAppWatcherAppEvent`, and `dispatchAppWatcherVoidEvent` for RLock/copy/forward, logging, and optional async dispatch.
- **App watcher** (`internal/core/infra/appwatcher/watcher.go`): Six `Handle*` methods now delegate to `dispatchAppEvent`, `dispatchVoidEvent`, and `dispatchMCEvent` for the shared RLock + callback iteration pattern.

No behavior change: same logging, locking semantics (callbacks invoked while holding the lock), async `go` dispatch for screen/MC bridge events, and Mission Control gating at both layers.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
