### PR TITLE
refactor(mocks): rename SystemMock to MockSystemPort

### DIFF
--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -348,7 +348,7 @@ func TestHandleAction_ScrollSelectionWithoutActiveSelectionErrors(t *testing.T) 
 		scrollService: services.NewScrollService(
 			&portmocks.MockAccessibilityPort{},
 			&portmocks.MockOverlayPort{},
-			&portmocks.SystemMock{},
+			&portmocks.MockSystemPort{},
 			config.ScrollConfig{ScrollStep: 10, ScrollStepHalf: 20, ScrollStepFull: 30},
 			zap.NewNop(),
 		),
@@ -415,7 +415,7 @@ func TestHandleAction_PreviousRejectedOnScrollAction(t *testing.T) {
 		scrollService: services.NewScrollService(
 			&portmocks.MockAccessibilityPort{},
 			&portmocks.MockOverlayPort{},
-			&portmocks.SystemMock{},
+			&portmocks.MockSystemPort{},
 			config.ScrollConfig{ScrollStep: 10, ScrollStepHalf: 20, ScrollStepFull: 30},
 			zap.NewNop(),
 		),

--- a/internal/app/ipc_capabilities_test.go
+++ b/internal/app/ipc_capabilities_test.go
@@ -20,7 +20,7 @@ func TestIPCController_StatusIncludesCapabilities(t *testing.T) {
 	appState := state.NewAppState()
 	logger := zap.NewNop()
 	configService := config.NewService(cfg, "", logger, nil)
-	system := &portmocks.SystemMock{
+	system := &portmocks.MockSystemPort{
 		CapabilitiesFunc: func() ports.PlatformCapabilities {
 			return ports.PlatformCapabilities{
 				Platform: "testos",
@@ -103,7 +103,7 @@ func TestIPCController_HealthMarksStubCapabilitiesUnhealthy(t *testing.T) {
 	appState := state.NewAppState()
 	logger := zap.NewNop()
 	configService := config.NewService(cfg, "", logger, nil)
-	system := &portmocks.SystemMock{
+	system := &portmocks.MockSystemPort{
 		CapabilitiesFunc: func() ports.PlatformCapabilities {
 			return ports.PlatformCapabilities{
 				Platform: "testos",

--- a/internal/app/modes/grid_test.go
+++ b/internal/app/modes/grid_test.go
@@ -55,7 +55,7 @@ func TestHandleGridModeKey_CompleteSelectionDoesNotMoveWhenCursorFollowSelection
 		actionService: services.NewActionService(
 			&portmocks.MockAccessibilityPort{},
 			&portmocks.MockOverlayPort{},
-			&portmocks.SystemMock{
+			&portmocks.MockSystemPort{
 				MoveCursorToPointFunc: func(_ context.Context, _ image.Point, _ bool) error {
 					moveCount++
 
@@ -112,7 +112,7 @@ func TestHandleGridModeKey_EnteringSubgridDoesNotMoveWhenCursorFollowSelectionDi
 		actionService: services.NewActionService(
 			&portmocks.MockAccessibilityPort{},
 			&portmocks.MockOverlayPort{},
-			&portmocks.SystemMock{
+			&portmocks.MockSystemPort{
 				MoveCursorToPointFunc: func(_ context.Context, _ image.Point, _ bool) error {
 					moveCount++
 

--- a/internal/app/modes/recursive_grid_test.go
+++ b/internal/app/modes/recursive_grid_test.go
@@ -45,7 +45,7 @@ func TestHandleRecursiveGridKey_CompleteSelectionDoesNotMoveWhenCursorFollowSele
 		actionService: services.NewActionService(
 			&portmocks.MockAccessibilityPort{},
 			&portmocks.MockOverlayPort{},
-			&portmocks.SystemMock{
+			&portmocks.MockSystemPort{
 				MoveCursorToPointFunc: func(_ context.Context, _ image.Point, _ bool) error {
 					moveCount++
 
@@ -104,7 +104,7 @@ func TestResetCurrentMode_RecursiveGridPreservesHoldMode(t *testing.T) {
 		actionService: services.NewActionService(
 			&portmocks.MockAccessibilityPort{},
 			&portmocks.MockOverlayPort{},
-			&portmocks.SystemMock{
+			&portmocks.MockSystemPort{
 				MoveCursorToPointFunc: func(_ context.Context, _ image.Point, _ bool) error {
 					moveCount++
 

--- a/internal/app/modes/selection_test.go
+++ b/internal/app/modes/selection_test.go
@@ -56,7 +56,7 @@ func TestToggleCursorFollowSelection_UpdatesOnlySupportedModes(t *testing.T) {
 		actionService: services.NewActionService(
 			&portmocks.MockAccessibilityPort{},
 			&portmocks.MockOverlayPort{},
-			&portmocks.SystemMock{},
+			&portmocks.MockSystemPort{},
 			zap.NewNop(),
 		),
 		hints: &components.HintsComponent{
@@ -102,7 +102,7 @@ func TestToggleCursorFollowSelection_MovesCursorToStoredGridSelectionWhenEnablin
 		actionService: services.NewActionService(
 			&portmocks.MockAccessibilityPort{},
 			&portmocks.MockOverlayPort{},
-			&portmocks.SystemMock{
+			&portmocks.MockSystemPort{
 				MoveCursorToPointFunc: func(_ context.Context, point image.Point, _ bool) error {
 					moved = append(moved, point)
 
@@ -144,7 +144,7 @@ func TestToggleCursorFollowSelection_DoesNotMoveCursorWhenDisabling(t *testing.T
 		actionService: services.NewActionService(
 			&portmocks.MockAccessibilityPort{},
 			&portmocks.MockOverlayPort{},
-			&portmocks.SystemMock{
+			&portmocks.MockSystemPort{
 				MoveCursorToPointFunc: func(_ context.Context, _ image.Point, _ bool) error {
 					moveCount++
 
@@ -188,7 +188,7 @@ func TestToggleCursorFollowSelection_MovesCursorToStoredRecursiveGridSelectionWh
 		actionService: services.NewActionService(
 			&portmocks.MockAccessibilityPort{},
 			&portmocks.MockOverlayPort{},
-			&portmocks.SystemMock{
+			&portmocks.MockSystemPort{
 				MoveCursorToPointFunc: func(_ context.Context, point image.Point, _ bool) error {
 					moved = append(moved, point)
 

--- a/internal/app/services/action_service_test.go
+++ b/internal/app/services/action_service_test.go
@@ -16,7 +16,7 @@ import (
 
 func newTestActionService(
 	acc *portmocks.MockAccessibilityPort,
-	sys *portmocks.SystemMock,
+	sys *portmocks.MockSystemPort,
 ) *services.ActionService {
 	return services.NewActionService(acc, &portmocks.MockOverlayPort{}, sys, zap.NewNop())
 }
@@ -45,7 +45,7 @@ func TestPerformActionAtPoint_ParsesAndDispatches(t *testing.T) {
 			return nil
 		},
 	}
-	service := newTestActionService(acc, &portmocks.SystemMock{})
+	service := newTestActionService(acc, &portmocks.MockSystemPort{})
 
 	err := service.PerformActionAtPoint(
 		ctx,
@@ -93,7 +93,7 @@ func TestPerformActionAtPoint_DrawsMouseActionIndicatorWhenEnabled(t *testing.T)
 		},
 	}
 
-	service := services.NewActionService(acc, overlay, &portmocks.SystemMock{}, zap.NewNop())
+	service := services.NewActionService(acc, overlay, &portmocks.MockSystemPort{}, zap.NewNop())
 	cfg := config.DefaultConfig().MouseAction
 	cfg.Enabled = true
 	cfg.Actions = []string{"left_click"}
@@ -143,7 +143,7 @@ func TestPerformActionAtPoint_DoesNotDrawMouseActionIndicatorWhenDisabled(t *tes
 		},
 	}
 
-	service := services.NewActionService(acc, overlay, &portmocks.SystemMock{}, zap.NewNop())
+	service := services.NewActionService(acc, overlay, &portmocks.MockSystemPort{}, zap.NewNop())
 	cfg := config.DefaultConfig().MouseAction
 	cfg.Enabled = false
 	cfg.Actions = []string{"left_click"}
@@ -183,7 +183,7 @@ func TestPerformActionAtPoint_DoesNotDrawMouseActionIndicatorForUnlistedAction(t
 		},
 	}
 
-	service := services.NewActionService(acc, overlay, &portmocks.SystemMock{}, zap.NewNop())
+	service := services.NewActionService(acc, overlay, &portmocks.MockSystemPort{}, zap.NewNop())
 	cfg := config.DefaultConfig().MouseAction
 	cfg.Enabled = true
 	cfg.Actions = []string{"left_click"}
@@ -200,7 +200,7 @@ func TestPerformActionAtPoint_DoesNotDrawMouseActionIndicatorForUnlistedAction(t
 }
 
 func TestPerformActionAtPoint_InvalidAction(t *testing.T) {
-	service := newTestActionService(&portmocks.MockAccessibilityPort{}, &portmocks.SystemMock{})
+	service := newTestActionService(&portmocks.MockAccessibilityPort{}, &portmocks.MockSystemPort{})
 
 	err := service.PerformActionAtPoint(context.Background(), "not_real", image.Point{}, 0)
 	if err == nil {
@@ -215,7 +215,7 @@ func TestMoveMouseTo_ClampsToScreenBounds(t *testing.T) {
 
 	waitCalled := false
 
-	sys := &portmocks.SystemMock{
+	sys := &portmocks.MockSystemPort{
 		ScreenBoundsFunc: func(context.Context) (image.Rectangle, error) {
 			return image.Rect(0, 0, 100, 100), nil
 		},
@@ -251,7 +251,7 @@ func TestMoveMouseRelative_UsesCurrentCursorPosition(t *testing.T) {
 
 	var moved image.Point
 
-	sys := &portmocks.SystemMock{
+	sys := &portmocks.MockSystemPort{
 		CursorPositionFunc: func(context.Context) (image.Point, error) {
 			return image.Point{X: 40, Y: 40}, nil
 		},
@@ -282,7 +282,7 @@ func TestMoveCursorToPointAndWait_WaitsForCursorIdle(t *testing.T) {
 	moved := false
 	waitCalled := false
 
-	sys := &portmocks.SystemMock{
+	sys := &portmocks.MockSystemPort{
 		MoveCursorToPointFunc: func(_ context.Context, p image.Point, _ bool) error {
 			moved = true
 

--- a/internal/app/services/grid_service_test.go
+++ b/internal/app/services/grid_service_test.go
@@ -48,7 +48,7 @@ func TestGridService_ShowGrid(t *testing.T) {
 				testCase.setupMocks(mockOverlay)
 			}
 
-			service := services.NewGridService(mockOverlay, &mocks.SystemMock{}, logger)
+			service := services.NewGridService(mockOverlay, &mocks.MockSystemPort{}, logger)
 			ctx := context.Background()
 
 			showGridErr := service.ShowGrid(ctx)
@@ -98,7 +98,7 @@ func TestGridService_HideGrid(t *testing.T) {
 				testCase.setupMocks(mockOverlay)
 			}
 
-			service := services.NewGridService(mockOverlay, &mocks.SystemMock{}, logger)
+			service := services.NewGridService(mockOverlay, &mocks.MockSystemPort{}, logger)
 			ctx := context.Background()
 
 			hideGridErr := service.HideGrid(ctx)

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -306,7 +306,7 @@ func TestHintService_ShowHints(t *testing.T) {
 			service := services.NewHintService(
 				mockAcc,
 				mockOverlay,
-				&mocks.SystemMock{},
+				&mocks.MockSystemPort{},
 				generator,
 				testCase.config,
 				logger,
@@ -380,7 +380,7 @@ func TestHintService_HideHints(t *testing.T) {
 			service := services.NewHintService(
 				mockAcc,
 				mockOverlay,
-				&mocks.SystemMock{},
+				&mocks.MockSystemPort{},
 				generator,
 				config.HintsConfig{},
 				logger,
@@ -453,7 +453,7 @@ func TestHintService_RefreshHints(t *testing.T) {
 			service := services.NewHintService(
 				mockAcc,
 				mockOverlay,
-				&mocks.SystemMock{},
+				&mocks.MockSystemPort{},
 				generator,
 				config.HintsConfig{},
 				logger,
@@ -484,7 +484,7 @@ func TestHintService_UpdateGenerator(t *testing.T) {
 	service := services.NewHintService(
 		mockAcc,
 		mockOverlay,
-		&mocks.SystemMock{},
+		&mocks.MockSystemPort{},
 		initialGen,
 		config.HintsConfig{},
 		logger,
@@ -508,7 +508,7 @@ func TestHintService_Health(t *testing.T) {
 	service := services.NewHintService(
 		mockAcc,
 		mockOverlay,
-		&mocks.SystemMock{},
+		&mocks.MockSystemPort{},
 		generator,
 		config.HintsConfig{},
 		logger,

--- a/internal/app/services/scroll_service_test.go
+++ b/internal/app/services/scroll_service_test.go
@@ -283,7 +283,7 @@ func TestScrollService_Scroll(t *testing.T) {
 			service := services.NewScrollService(
 				mockAcc,
 				mockOverlay,
-				&mocks.SystemMock{},
+				&mocks.MockSystemPort{},
 				cfg,
 				logger,
 			)
@@ -346,7 +346,7 @@ func TestScrollService_Hide(t *testing.T) {
 			service := services.NewScrollService(
 				mockAcc,
 				mockOverlay,
-				&mocks.SystemMock{},
+				&mocks.MockSystemPort{},
 				config,
 				logger,
 			)
@@ -377,7 +377,7 @@ func TestScrollService_UpdateConfig(t *testing.T) {
 	service := services.NewScrollService(
 		mockAcc,
 		mockOverlay,
-		&mocks.SystemMock{},
+		&mocks.MockSystemPort{},
 		initialConfig,
 		logger,
 	)

--- a/internal/core/infra/overlay/adapter_test.go
+++ b/internal/core/infra/overlay/adapter_test.go
@@ -42,7 +42,7 @@ func TestAdapterHealth_ReturnsNilForHeadlessOverlayManager(t *testing.T) {
 	adapter := overlay.NewAdapter(
 		&uioverlay.NoOpManager{},
 		&overlayTestThemeProvider{},
-		&portmocks.SystemMock{},
+		&portmocks.MockSystemPort{},
 		zap.NewNop(),
 	)
 
@@ -56,7 +56,7 @@ func TestAdapterHealth_ReturnsNilForSupportedOverlayManager(t *testing.T) {
 	adapter := overlay.NewAdapter(
 		&supportedManager{},
 		&overlayTestThemeProvider{},
-		&portmocks.SystemMock{},
+		&portmocks.MockSystemPort{},
 		zap.NewNop(),
 	)
 
@@ -70,7 +70,7 @@ func TestAdapterHealth_ReturnsNotSupportedForStubOverlayManager(t *testing.T) {
 	adapter := overlay.NewAdapter(
 		&stubManager{},
 		&overlayTestThemeProvider{},
-		&portmocks.SystemMock{},
+		&portmocks.MockSystemPort{},
 		zap.NewNop(),
 	)
 

--- a/internal/core/ports/mocks/accessibility.go
+++ b/internal/core/ports/mocks/accessibility.go
@@ -11,7 +11,7 @@ import (
 
 // MockAccessibilityPort is a mock implementation of ports.AccessibilityPort.
 // Note: ScreenBounds, MoveCursorToPoint, CursorPosition, and CheckPermissions
-// were removed from AccessibilityPort and moved to SystemPort. Use SystemMock
+// were removed from AccessibilityPort and moved to SystemPort. Use MockSystemPort
 // for those operations.
 type MockAccessibilityPort struct {
 	HealthFunc               func(context.Context) error

--- a/internal/core/ports/mocks/system.go
+++ b/internal/core/ports/mocks/system.go
@@ -7,8 +7,8 @@ import (
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
-// SystemMock is a mock implementation of ports.SystemPort.
-type SystemMock struct {
+// MockSystemPort is a mock implementation of ports.SystemPort.
+type MockSystemPort struct {
 	ConfigDirFunc                   func() (string, error)
 	UserDataDirFunc                 func() (string, error)
 	LogDirFunc                      func() (string, error)
@@ -33,7 +33,7 @@ type SystemMock struct {
 }
 
 // ConfigDir is a mock implementation.
-func (m *SystemMock) ConfigDir() (string, error) {
+func (m *MockSystemPort) ConfigDir() (string, error) {
 	if m.ConfigDirFunc != nil {
 		return m.ConfigDirFunc()
 	}
@@ -42,7 +42,7 @@ func (m *SystemMock) ConfigDir() (string, error) {
 }
 
 // UserDataDir is a mock implementation.
-func (m *SystemMock) UserDataDir() (string, error) {
+func (m *MockSystemPort) UserDataDir() (string, error) {
 	if m.UserDataDirFunc != nil {
 		return m.UserDataDirFunc()
 	}
@@ -51,7 +51,7 @@ func (m *SystemMock) UserDataDir() (string, error) {
 }
 
 // LogDir is a mock implementation.
-func (m *SystemMock) LogDir() (string, error) {
+func (m *MockSystemPort) LogDir() (string, error) {
 	if m.LogDirFunc != nil {
 		return m.LogDirFunc()
 	}
@@ -60,7 +60,7 @@ func (m *SystemMock) LogDir() (string, error) {
 }
 
 // FocusedApplicationPID is a mock implementation.
-func (m *SystemMock) FocusedApplicationPID(ctx context.Context) (int, error) {
+func (m *MockSystemPort) FocusedApplicationPID(ctx context.Context) (int, error) {
 	if m.FocusedAppPIDFunc != nil {
 		return m.FocusedAppPIDFunc(ctx)
 	}
@@ -69,7 +69,7 @@ func (m *SystemMock) FocusedApplicationPID(ctx context.Context) (int, error) {
 }
 
 // ApplicationNameByPID is a mock implementation.
-func (m *SystemMock) ApplicationNameByPID(ctx context.Context, pid int) (string, error) {
+func (m *MockSystemPort) ApplicationNameByPID(ctx context.Context, pid int) (string, error) {
 	if m.AppNameByPIDFunc != nil {
 		return m.AppNameByPIDFunc(ctx, pid)
 	}
@@ -78,7 +78,7 @@ func (m *SystemMock) ApplicationNameByPID(ctx context.Context, pid int) (string,
 }
 
 // ApplicationBundleIDByPID is a mock implementation.
-func (m *SystemMock) ApplicationBundleIDByPID(ctx context.Context, pid int) (string, error) {
+func (m *MockSystemPort) ApplicationBundleIDByPID(ctx context.Context, pid int) (string, error) {
 	if m.AppBundleIDByPIDFunc != nil {
 		return m.AppBundleIDByPIDFunc(ctx, pid)
 	}
@@ -87,7 +87,7 @@ func (m *SystemMock) ApplicationBundleIDByPID(ctx context.Context, pid int) (str
 }
 
 // ScreenBounds is a mock implementation.
-func (m *SystemMock) ScreenBounds(ctx context.Context) (image.Rectangle, error) {
+func (m *MockSystemPort) ScreenBounds(ctx context.Context) (image.Rectangle, error) {
 	if m.ScreenBoundsFunc != nil {
 		return m.ScreenBoundsFunc(ctx)
 	}
@@ -96,7 +96,7 @@ func (m *SystemMock) ScreenBounds(ctx context.Context) (image.Rectangle, error) 
 }
 
 // ScreenBoundsByName is a mock implementation.
-func (m *SystemMock) ScreenBoundsByName(
+func (m *MockSystemPort) ScreenBoundsByName(
 	ctx context.Context,
 	name string,
 ) (image.Rectangle, bool, error) {
@@ -108,7 +108,7 @@ func (m *SystemMock) ScreenBoundsByName(
 }
 
 // ScreenNames is a mock implementation.
-func (m *SystemMock) ScreenNames(ctx context.Context) ([]string, error) {
+func (m *MockSystemPort) ScreenNames(ctx context.Context) ([]string, error) {
 	if m.ScreenNamesFunc != nil {
 		return m.ScreenNamesFunc(ctx)
 	}
@@ -117,7 +117,7 @@ func (m *SystemMock) ScreenNames(ctx context.Context) ([]string, error) {
 }
 
 // FocusedWindowBounds is a mock implementation.
-func (m *SystemMock) FocusedWindowBounds(
+func (m *MockSystemPort) FocusedWindowBounds(
 	ctx context.Context,
 ) (image.Rectangle, bool, error) {
 	if m.FocusedWindowBoundsFunc != nil {
@@ -128,7 +128,7 @@ func (m *SystemMock) FocusedWindowBounds(
 }
 
 // MoveCursorToPoint is a mock implementation.
-func (m *SystemMock) MoveCursorToPoint(
+func (m *MockSystemPort) MoveCursorToPoint(
 	ctx context.Context,
 	point image.Point,
 	bypassSmooth bool,
@@ -141,7 +141,7 @@ func (m *SystemMock) MoveCursorToPoint(
 }
 
 // WaitForCursorIdle is a mock implementation.
-func (m *SystemMock) WaitForCursorIdle(ctx context.Context) error {
+func (m *MockSystemPort) WaitForCursorIdle(ctx context.Context) error {
 	if m.WaitForCursorIdleFunc != nil {
 		return m.WaitForCursorIdleFunc(ctx)
 	}
@@ -150,7 +150,7 @@ func (m *SystemMock) WaitForCursorIdle(ctx context.Context) error {
 }
 
 // CursorPosition is a mock implementation.
-func (m *SystemMock) CursorPosition(ctx context.Context) (image.Point, error) {
+func (m *MockSystemPort) CursorPosition(ctx context.Context) (image.Point, error) {
 	if m.CursorPositionFunc != nil {
 		return m.CursorPositionFunc(ctx)
 	}
@@ -159,7 +159,7 @@ func (m *SystemMock) CursorPosition(ctx context.Context) (image.Point, error) {
 }
 
 // CheckPermissions is a mock implementation.
-func (m *SystemMock) CheckPermissions(ctx context.Context) error {
+func (m *MockSystemPort) CheckPermissions(ctx context.Context) error {
 	if m.CheckPermissionsFunc != nil {
 		return m.CheckPermissionsFunc(ctx)
 	}
@@ -168,7 +168,7 @@ func (m *SystemMock) CheckPermissions(ctx context.Context) error {
 }
 
 // IsDarkMode is a mock implementation.
-func (m *SystemMock) IsDarkMode() bool {
+func (m *MockSystemPort) IsDarkMode() bool {
 	if m.IsDarkModeFunc != nil {
 		return m.IsDarkModeFunc()
 	}
@@ -177,7 +177,7 @@ func (m *SystemMock) IsDarkMode() bool {
 }
 
 // IsSecureInputEnabled is a mock implementation.
-func (m *SystemMock) IsSecureInputEnabled() bool {
+func (m *MockSystemPort) IsSecureInputEnabled() bool {
 	if m.IsSecureInputEnabledFunc != nil {
 		return m.IsSecureInputEnabledFunc()
 	}
@@ -186,14 +186,14 @@ func (m *SystemMock) IsSecureInputEnabled() bool {
 }
 
 // ShowSecureInputNotification is a mock implementation.
-func (m *SystemMock) ShowSecureInputNotification() {
+func (m *MockSystemPort) ShowSecureInputNotification() {
 	if m.ShowSecureInputNotificationFunc != nil {
 		m.ShowSecureInputNotificationFunc()
 	}
 }
 
 // ShowAlert is a mock implementation.
-func (m *SystemMock) ShowAlert(ctx context.Context, title, message string) error {
+func (m *MockSystemPort) ShowAlert(ctx context.Context, title, message string) error {
 	if m.ShowAlertFunc != nil {
 		return m.ShowAlertFunc(ctx, title, message)
 	}
@@ -202,14 +202,14 @@ func (m *SystemMock) ShowAlert(ctx context.Context, title, message string) error
 }
 
 // ShowNotification is a mock implementation.
-func (m *SystemMock) ShowNotification(title, message string) {
+func (m *MockSystemPort) ShowNotification(title, message string) {
 	if m.ShowNotificationFunc != nil {
 		m.ShowNotificationFunc(title, message)
 	}
 }
 
 // Capabilities is a mock implementation.
-func (m *SystemMock) Capabilities() ports.PlatformCapabilities {
+func (m *MockSystemPort) Capabilities() ports.PlatformCapabilities {
 	if m.CapabilitiesFunc != nil {
 		return m.CapabilitiesFunc()
 	}
@@ -218,7 +218,7 @@ func (m *SystemMock) Capabilities() ports.PlatformCapabilities {
 }
 
 // Health is a mock implementation.
-func (m *SystemMock) Health(ctx context.Context) error {
+func (m *MockSystemPort) Health(ctx context.Context) error {
 	if m.HealthFunc != nil {
 		return m.HealthFunc(ctx)
 	}
@@ -226,4 +226,4 @@ func (m *SystemMock) Health(ctx context.Context) error {
 	return nil
 }
 
-var _ ports.SystemPort = (*SystemMock)(nil)
+var _ ports.SystemPort = (*MockSystemPort)(nil)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR renames `SystemMock` to `MockSystemPort` in `internal/core/ports/mocks/` so all port mocks follow the same `Mock{Port}Port` naming pattern (`MockAccessibilityPort`, `MockConfigPort`, `MockOverlayPort`, `MockSystemPort`).

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
