### PR TITLE
refactor(errors): move error wrap helpers into core/errors

### DIFF
--- a/internal/app/services/action_service.go
+++ b/internal/app/services/action_service.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
-	"github.com/y3owk1n/neru/internal/core"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	"github.com/y3owk1n/neru/internal/core/domain/element"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
@@ -65,7 +64,7 @@ func (s *ActionService) ExecuteAction(
 			zap.Error(performActionErr),
 			zap.String("action", actionType.String()))
 
-		return core.WrapActionFailed(performActionErr, actionType.String())
+		return derrors.WrapActionFailed(performActionErr, actionType.String())
 	}
 
 	s.logger.Info("Action executed successfully",
@@ -85,7 +84,7 @@ func (s *ActionService) PerformActionAtPoint(
 	// Parse action string to domain type
 	actionType, actionTypeErr := action.ParseType(actionString)
 	if actionTypeErr != nil {
-		return core.WrapConfigFailed(actionTypeErr, "validate action type")
+		return derrors.WrapConfigFailed(actionTypeErr, "validate action type")
 	}
 
 	s.logger.Info("Performing action at point",
@@ -100,7 +99,7 @@ func (s *ActionService) PerformActionAtPoint(
 			zap.Error(performActionErr),
 			zap.String("action", actionType.String()))
 
-		return core.WrapActionFailed(performActionErr, actionType.String()+" at point")
+		return derrors.WrapActionFailed(performActionErr, actionType.String()+" at point")
 	}
 
 	s.drawMouseActionIndicator(point, actionType)
@@ -118,7 +117,7 @@ func mouseActionIndicatorIncludes(actions []string, actionType action.Type) bool
 func (s *ActionService) IsFocusedAppExcluded(ctx context.Context) (bool, error) {
 	bundleID, bundleIDErr := s.accessibility.FocusedAppBundleID(ctx)
 	if bundleIDErr != nil {
-		return false, core.WrapAccessibilityFailed(bundleIDErr, "get focused app bundle ID")
+		return false, derrors.WrapAccessibilityFailed(bundleIDErr, "get focused app bundle ID")
 	}
 
 	isExcluded := s.accessibility.IsAppExcluded(ctx, bundleID)
@@ -194,7 +193,7 @@ func (s *ActionService) MoveMouseTo(
 	if err != nil {
 		s.logger.Error("Failed to get screen bounds", zap.Error(err))
 
-		return core.WrapAccessibilityFailed(err, "get screen bounds")
+		return derrors.WrapAccessibilityFailed(err, "get screen bounds")
 	}
 
 	shouldBypass := len(bypassSmooth) > 0 && bypassSmooth[0]
@@ -218,7 +217,7 @@ func (s *ActionService) MoveMouseRelative(
 	if err != nil {
 		s.logger.Error("Failed to get cursor position", zap.Error(err))
 
-		return core.WrapAccessibilityFailed(err, "get cursor position")
+		return derrors.WrapAccessibilityFailed(err, "get cursor position")
 	}
 
 	shouldBypass := len(bypassSmooth) > 0 && bypassSmooth[0]
@@ -244,7 +243,7 @@ func (s *ActionService) MoveMouseToCenter(ctx context.Context, offsetX, offsetY 
 	if err != nil {
 		s.logger.Error("Failed to get screen bounds", zap.Error(err))
 
-		return core.WrapAccessibilityFailed(err, "get screen bounds")
+		return derrors.WrapAccessibilityFailed(err, "get screen bounds")
 	}
 
 	centerX := screenBounds.Min.X + screenBounds.Dx()/2 //nolint:mnd
@@ -275,7 +274,7 @@ func (s *ActionService) MoveMouseToCenterOfMonitor(
 	if err != nil {
 		s.logger.Error("Failed to get screen bounds by name", zap.Error(err))
 
-		return core.WrapAccessibilityFailed(err, "get screen bounds by name")
+		return derrors.WrapAccessibilityFailed(err, "get screen bounds by name")
 	}
 
 	if !found {
@@ -324,7 +323,7 @@ func (s *ActionService) MoveMouseToCenterOfWindow(
 	if err != nil {
 		s.logger.Error("Failed to get focused window bounds", zap.Error(err))
 
-		return core.WrapAccessibilityFailed(err, "get focused window bounds")
+		return derrors.WrapAccessibilityFailed(err, "get focused window bounds")
 	}
 
 	if !found {

--- a/internal/app/services/base_service.go
+++ b/internal/app/services/base_service.go
@@ -3,7 +3,7 @@ package services
 import (
 	"context"
 
-	"github.com/y3owk1n/neru/internal/core"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
@@ -42,7 +42,7 @@ func (s *BaseService) Health(ctx context.Context) map[string]error {
 func (s *BaseService) HideOverlay(ctx context.Context, operation string) error {
 	err := s.overlay.Hide(ctx)
 	if err != nil {
-		return core.WrapOverlayFailed(err, operation)
+		return derrors.WrapOverlayFailed(err, operation)
 	}
 
 	return nil

--- a/internal/app/services/grid_service.go
+++ b/internal/app/services/grid_service.go
@@ -5,7 +5,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/y3owk1n/neru/internal/core"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
@@ -37,7 +37,7 @@ func (s *GridService) ShowGrid(ctx context.Context) error {
 	if showGridErr != nil {
 		s.logger.Error("Failed to show grid overlay", zap.Error(showGridErr))
 
-		return core.WrapOverlayFailed(showGridErr, "show grid")
+		return derrors.WrapOverlayFailed(showGridErr, "show grid")
 	}
 
 	s.logger.Info("Grid displayed successfully")

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -8,9 +8,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
-	"github.com/y3owk1n/neru/internal/core"
 	"github.com/y3owk1n/neru/internal/core/domain/element"
 	"github.com/y3owk1n/neru/internal/core/domain/hint"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
@@ -65,7 +65,7 @@ func (s *HintService) ShowHints(
 	if showHintsErr != nil {
 		s.logger.Error("Failed to show hints overlay", zap.Error(showHintsErr))
 
-		return nil, core.WrapOverlayFailed(showHintsErr, "show hints")
+		return nil, derrors.WrapOverlayFailed(showHintsErr, "show hints")
 	}
 
 	s.logger.Info("Hints displayed successfully")
@@ -159,7 +159,7 @@ func (s *HintService) GenerateHints(
 	if elementsErr != nil {
 		s.logger.Error("Failed to get clickable elements", zap.Error(elementsErr))
 
-		return nil, core.WrapAccessibilityFailed(elementsErr, "get clickable elements")
+		return nil, derrors.WrapAccessibilityFailed(elementsErr, "get clickable elements")
 	}
 
 	if len(elements) == 0 {
@@ -192,7 +192,7 @@ func (s *HintService) GenerateHints(
 	if elementsErr != nil {
 		s.logger.Error("Failed to generate hints", zap.Error(elementsErr))
 
-		return nil, core.WrapInternalFailed(elementsErr, "generate hints")
+		return nil, derrors.WrapInternalFailed(elementsErr, "generate hints")
 	}
 
 	s.logger.Info("Generated hints", zap.Int("count", len(hints)))
@@ -230,7 +230,7 @@ func (s *HintService) RefreshHints(ctx context.Context) error {
 	if refreshOverlayErr != nil {
 		s.logger.Error("Failed to refresh overlay", zap.Error(refreshOverlayErr))
 
-		return core.WrapOverlayFailed(refreshOverlayErr, "refresh hints")
+		return derrors.WrapOverlayFailed(refreshOverlayErr, "refresh hints")
 	}
 
 	s.logger.Info("Hints refreshed successfully")

--- a/internal/app/services/modeindicator/service.go
+++ b/internal/app/services/modeindicator/service.go
@@ -5,7 +5,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/y3owk1n/neru/internal/core"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
@@ -38,7 +37,7 @@ func (s *Service) GetCursorPosition(ctx context.Context) (int, int, error) {
 
 	point, err := s.system.CursorPosition(ctx)
 	if err != nil {
-		return 0, 0, core.WrapAccessibilityFailed(err, "get cursor position")
+		return 0, 0, derrors.WrapAccessibilityFailed(err, "get cursor position")
 	}
 
 	return point.X, point.Y, nil

--- a/internal/app/services/scroll_service.go
+++ b/internal/app/services/scroll_service.go
@@ -7,7 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
-	"github.com/y3owk1n/neru/internal/core"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
@@ -79,7 +79,7 @@ func (s *ScrollService) Scroll(
 
 	scrollErr := s.accessibility.Scroll(ctx, deltaX, deltaY)
 	if scrollErr != nil {
-		return core.WrapActionFailed(scrollErr, "scroll")
+		return derrors.WrapActionFailed(scrollErr, "scroll")
 	}
 
 	return nil

--- a/internal/app/services/stickyindicator/service.go
+++ b/internal/app/services/stickyindicator/service.go
@@ -6,7 +6,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/y3owk1n/neru/internal/core"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/ports"
@@ -40,7 +39,7 @@ func (s *Service) GetCursorPosition(ctx context.Context) (int, int, error) {
 
 	point, err := s.system.CursorPosition(ctx)
 	if err != nil {
-		return 0, 0, core.WrapAccessibilityFailed(err, "get cursor position")
+		return 0, 0, derrors.WrapAccessibilityFailed(err, "get cursor position")
 	}
 
 	return point.X, point.Y, nil

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"go.uber.org/zap"
 
-	"github.com/y3owk1n/neru/internal/core"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
 
@@ -285,7 +284,10 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 		configResult.Config = DefaultConfig()
 
 		if explicitPath {
-			configResult.ValidationError = core.WrapConfigFailed(statErr, "config file not found")
+			configResult.ValidationError = derrors.WrapConfigFailed(
+				statErr,
+				"config file not found",
+			)
 		} else {
 			s.logger.Info("Config file not found, using default configuration")
 			// Clear ConfigPath for auto-discovered missing files
@@ -304,7 +306,7 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 
 	_, decodeErr := toml.DecodeFile(configResult.ConfigPath, &raw)
 	if decodeErr != nil {
-		configResult.ValidationError = core.WrapConfigFailed(decodeErr, "parse config file")
+		configResult.ValidationError = derrors.WrapConfigFailed(decodeErr, "parse config file")
 		configResult.Config = DefaultConfig()
 
 		return configResult
@@ -313,7 +315,7 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 	// Decode into typed config struct (separate pass for validation)
 	_, err := toml.DecodeFile(configResult.ConfigPath, configResult.Config)
 	if err != nil {
-		configResult.ValidationError = core.WrapConfigFailed(err, "parse config file")
+		configResult.ValidationError = derrors.WrapConfigFailed(err, "parse config file")
 		configResult.Config = DefaultConfig()
 
 		return configResult
@@ -570,7 +572,10 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 
 	validateErr := configResult.Config.Validate()
 	if validateErr != nil {
-		configResult.ValidationError = core.WrapConfigFailed(validateErr, "validate configuration")
+		configResult.ValidationError = derrors.WrapConfigFailed(
+			validateErr,
+			"validate configuration",
+		)
 		configResult.Config = DefaultConfig()
 
 		s.logger.Warn("Configuration validation failed",
@@ -718,7 +723,7 @@ func (s *Service) Reload(ctx context.Context, path string) error {
 		// Check if context was canceled during send
 		select {
 		case <-ctx.Done():
-			return core.WrapContextCanceled(ctx, "notify config watchers")
+			return derrors.WrapContextCanceled(ctx, "notify config watchers")
 		default:
 		}
 	}

--- a/internal/config/service_app.go
+++ b/internal/config/service_app.go
@@ -5,7 +5,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/y3owk1n/neru/internal/core"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
 
 // ReloadWithAppContext reloads configuration with app-specific context and side effects.
@@ -36,7 +36,7 @@ func (s *Service) ReloadWithAppContext(
 			)
 		}
 
-		return loadResult, core.WrapConfigFailed(loadResult.ValidationError, "validate config")
+		return loadResult, derrors.WrapConfigFailed(loadResult.ValidationError, "validate config")
 	}
 
 	// Update the service with the new config
@@ -52,7 +52,7 @@ func (s *Service) ReloadWithAppContext(
 		select {
 		case watcher <- loadResult.Config:
 		case <-ctx.Done():
-			return loadResult, core.WrapContextCanceled(ctx, "notify config watchers")
+			return loadResult, derrors.WrapContextCanceled(ctx, "notify config watchers")
 		default:
 			// Skip if watcher is not ready
 		}

--- a/internal/core/errors/helpers.go
+++ b/internal/core/errors/helpers.go
@@ -1,75 +1,71 @@
-package core
+package derrors
 
 import (
 	"context"
 	"errors"
 	"fmt"
-
-	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
-
-// Error handling helpers for common error wrapping patterns
 
 // WrapContextCanceled wraps a context.Canceled error with a standardized message.
 func WrapContextCanceled(ctx context.Context, operation string) error {
 	if errors.Is(ctx.Err(), context.Canceled) {
-		return derrors.Wrap(ctx.Err(), derrors.CodeContextCanceled,
+		return Wrap(ctx.Err(), CodeContextCanceled,
 			operation+" canceled")
 	}
 
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return derrors.Wrap(ctx.Err(), derrors.CodeContextCanceled,
+		return Wrap(ctx.Err(), CodeContextCanceled,
 			operation+" timed out")
 	}
 
-	return derrors.Wrap(ctx.Err(), derrors.CodeContextCanceled,
+	return Wrap(ctx.Err(), CodeContextCanceled,
 		fmt.Sprintf("%s failed: %s", operation, ctx.Err().Error()))
 }
 
 // WrapActionFailed wraps an action-related error with a standardized message.
 func WrapActionFailed(err error, action string) error {
-	return derrors.Wrap(err, derrors.CodeActionFailed,
+	return Wrap(err, CodeActionFailed,
 		fmt.Sprintf("failed to perform %s action", action))
 }
 
 // WrapOverlayFailed wraps an overlay-related error with a standardized message.
 func WrapOverlayFailed(err error, operation string) error {
-	return derrors.Wrap(err, derrors.CodeOverlayFailed,
+	return Wrap(err, CodeOverlayFailed,
 		fmt.Sprintf("overlay %s failed", operation))
 }
 
 // WrapIPCFailed wraps an IPC-related error with a standardized message.
 func WrapIPCFailed(err error, operation string) error {
-	return derrors.Wrap(err, derrors.CodeIPCFailed,
+	return Wrap(err, CodeIPCFailed,
 		fmt.Sprintf("IPC %s failed", operation))
 }
 
 // WrapSerializationFailed wraps a serialization-related error with a standardized message.
 func WrapSerializationFailed(err error, operation string) error {
-	return derrors.Wrap(err, derrors.CodeSerializationFailed,
+	return Wrap(err, CodeSerializationFailed,
 		fmt.Sprintf("serialization %s failed", operation))
 }
 
 // WrapAccessibilityFailed wraps an accessibility-related error with a standardized message.
 func WrapAccessibilityFailed(err error, operation string) error {
-	return derrors.Wrap(err, derrors.CodeAccessibilityFailed,
+	return Wrap(err, CodeAccessibilityFailed,
 		fmt.Sprintf("accessibility %s failed", operation))
 }
 
 // WrapConfigFailed wraps a configuration-related error with a standardized message.
 func WrapConfigFailed(err error, operation string) error {
-	return derrors.Wrap(err, derrors.CodeInvalidConfig,
+	return Wrap(err, CodeInvalidConfig,
 		fmt.Sprintf("configuration %s failed", operation))
 }
 
 // WrapIOFailed wraps an I/O-related error with a standardized message.
 func WrapIOFailed(err error, operation string) error {
-	return derrors.Wrap(err, derrors.CodeConfigIOFailed,
+	return Wrap(err, CodeConfigIOFailed,
 		fmt.Sprintf("I/O %s failed", operation))
 }
 
 // WrapInternalFailed wraps an internal error with a standardized message.
 func WrapInternalFailed(err error, operation string) error {
-	return derrors.Wrap(err, derrors.CodeInternal,
+	return Wrap(err, CodeInternal,
 		fmt.Sprintf("internal %s failed", operation))
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR moves domain error wrapping helpers from `internal/core/error_helpers.go` into `internal/core/errors/helpers.go` so they live alongside error types and codes in the `derrors` package.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
