### PR TITLE
refactor(hint): return errors when externalMu is not held

### DIFF
--- a/internal/app/components/hints/context.go
+++ b/internal/app/components/hints/context.go
@@ -127,12 +127,15 @@ func (c *Context) Router() *domainHint.Router {
 
 // SetHints sets the current hint collection.
 func (c *Context) SetHints(hints *domainHint.Collection) error {
-	c.hints = hints
-
-	c.sourceHints = hints
 	if c.manager != nil {
-		return c.manager.SetHints(hints)
+		err := c.manager.SetHints(hints)
+		if err != nil {
+			return err
+		}
 	}
+
+	c.hints = hints
+	c.sourceHints = hints
 
 	return nil
 }
@@ -140,10 +143,14 @@ func (c *Context) SetHints(hints *domainHint.Collection) error {
 // SetVisibleHints sets the currently selectable hint collection without
 // replacing the original source collection used by search cancellation.
 func (c *Context) SetVisibleHints(hints *domainHint.Collection) error {
-	c.hints = hints
 	if c.manager != nil {
-		return c.manager.SetHints(hints)
+		err := c.manager.SetHints(hints)
+		if err != nil {
+			return err
+		}
 	}
+
+	c.hints = hints
 
 	return nil
 }

--- a/internal/app/components/hints/context.go
+++ b/internal/app/components/hints/context.go
@@ -187,11 +187,9 @@ func (c *Context) SearchActive() bool {
 
 // Reset resets the hints context to its initial state.
 func (c *Context) Reset() error {
+	var err error
 	if c.manager != nil {
-		err := c.manager.Clear()
-		if err != nil {
-			return err
-		}
+		err = c.manager.Clear()
 	}
 
 	c.hints = nil
@@ -200,5 +198,5 @@ func (c *Context) Reset() error {
 	c.searchActive = false
 	c.baseContext.Reset()
 
-	return nil
+	return err
 }

--- a/internal/app/components/hints/context.go
+++ b/internal/app/components/hints/context.go
@@ -126,22 +126,26 @@ func (c *Context) Router() *domainHint.Router {
 }
 
 // SetHints sets the current hint collection.
-func (c *Context) SetHints(hints *domainHint.Collection) {
+func (c *Context) SetHints(hints *domainHint.Collection) error {
 	c.hints = hints
 
 	c.sourceHints = hints
 	if c.manager != nil {
-		c.manager.SetHints(hints)
+		return c.manager.SetHints(hints)
 	}
+
+	return nil
 }
 
 // SetVisibleHints sets the currently selectable hint collection without
 // replacing the original source collection used by search cancellation.
-func (c *Context) SetVisibleHints(hints *domainHint.Collection) {
+func (c *Context) SetVisibleHints(hints *domainHint.Collection) error {
 	c.hints = hints
 	if c.manager != nil {
-		c.manager.SetHints(hints)
+		return c.manager.SetHints(hints)
 	}
+
+	return nil
 }
 
 // Hints returns the current hint collection.
@@ -175,9 +179,12 @@ func (c *Context) SearchActive() bool {
 }
 
 // Reset resets the hints context to its initial state.
-func (c *Context) Reset() {
+func (c *Context) Reset() error {
 	if c.manager != nil {
-		c.manager.Clear()
+		err := c.manager.Clear()
+		if err != nil {
+			return err
+		}
 	}
 
 	c.hints = nil
@@ -185,4 +192,6 @@ func (c *Context) Reset() {
 	c.searchQuery = ""
 	c.searchActive = false
 	c.baseContext.Reset()
+
+	return nil
 }

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -63,7 +63,12 @@ func (h *Handler) clearAndHideOverlay() {
 // cleanupHintsMode handles cleanup for hints mode.
 func (h *Handler) cleanupHintsMode() {
 	h.stopHintSearchTextInputLocked(false)
-	h.hints.Context.Reset()
+
+	resetErr := h.hints.Context.Reset()
+	if resetErr != nil {
+		h.logger.Error("Failed to reset hints context", zap.Error(resetErr))
+	}
+
 	h.cycleHintIndex = -1
 
 	h.clearAndHideOverlay()

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -298,7 +298,14 @@ func (h *Handler) RefreshHintsForScreenChange(
 		return false
 	}
 
-	h.hints.Context.SetHints(domainHint.NewCollection(filtered))
+	setHintsErr := h.hints.Context.SetHints(
+		domainHint.NewCollection(filtered),
+	)
+	if setHintsErr != nil {
+		h.logger.Error("Failed to refresh hints for screen change", zap.Error(setHintsErr))
+
+		return false
+	}
 
 	return true
 }
@@ -600,7 +607,10 @@ func (h *Handler) BackspaceCurrentMode() {
 	switch h.appState.CurrentMode() {
 	case domain.ModeHints:
 		if h.hints != nil && h.hints.Context != nil && h.hints.Context.Manager() != nil {
-			h.hints.Context.Manager().HandleBackspace()
+			backspaceErr := h.hints.Context.Manager().HandleBackspace()
+			if backspaceErr != nil {
+				h.logger.Error("Hint backspace failed", zap.Error(backspaceErr))
+			}
 		}
 
 		h.cycleHintIndex = -1
@@ -759,7 +769,14 @@ func (h *Handler) startHintSearchLocked() error {
 	h.stopHintSearchTextInputLocked(true)
 	h.hints.Context.SetSearchQuery("")
 	h.hints.Context.SetSearchActive(true)
-	h.hints.Context.SetVisibleHints(h.hints.Context.SourceHints())
+
+	setHintsErr := h.hints.Context.SetVisibleHints(
+		h.hints.Context.SourceHints(),
+	)
+	if setHintsErr != nil {
+		return setHintsErr
+	}
+
 	h.cycleHintIndex = -1
 	h.drawHintSearchInput()
 

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -375,7 +375,11 @@ func (h *Handler) activateHintModeInternal(
 
 	debugElapsed(h.logger, activationStart, "Manager.SetHints completed")
 
-	h.hints.Context.SetHints(hintCollection)
+	setHintsErr := h.hints.Context.SetHints(hintCollection)
+	if setHintsErr != nil {
+		h.logger.Error("Failed to set hints in manager", zap.Error(setHintsErr))
+	}
+
 	h.overlayManager.ResizeToActiveScreen()
 	h.overlayManager.Show()
 

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -378,6 +378,9 @@ func (h *Handler) activateHintModeInternal(
 	setHintsErr := h.hints.Context.SetHints(hintCollection)
 	if setHintsErr != nil {
 		h.logger.Error("Failed to set hints in manager", zap.Error(setHintsErr))
+		h.exitModeLocked()
+
+		return
 	}
 
 	h.overlayManager.ResizeToActiveScreen()

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -120,7 +120,12 @@ func TestHandleKeyPressRoutesAllKeysToHintSearch(t *testing.T) {
 	handler.mu.Lock()
 	manager := domainhint.NewManager(handler.logger, &handler.mu)
 	handler.hints.Context.SetManager(manager)
-	handler.hints.Context.SetHints(collection)
+
+	err := handler.hints.Context.SetHints(collection)
+	if err != nil {
+		t.Fatalf("SetHints: %v", err)
+	}
+
 	handler.hints.Context.SetSearchActive(true)
 	handler.mu.Unlock()
 

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -108,7 +108,12 @@ func (h *Handler) handleHintsModeKey(key string) {
 		return
 	}
 
-	hintKeyResult := h.hints.Context.Router().RouteKey(key)
+	hintKeyResult, routeErr := h.hints.Context.Router().RouteKey(key)
+	if routeErr != nil {
+		h.logger.Error("Hint key routing failed", zap.Error(routeErr))
+
+		return
+	}
 
 	// Hint input processed by router; if exact match, perform action
 	if hintKeyResult.ExactHint() != nil {
@@ -205,7 +210,12 @@ func (h *Handler) applyHintSearchFilter() {
 	}
 
 	filteredHints := sourceHints.FilterByText(ctx.SearchQuery())
-	ctx.SetVisibleHints(filteredHints)
+
+	setHintsErr := ctx.SetVisibleHints(filteredHints)
+	if setHintsErr != nil {
+		h.logger.Error("Failed to apply hint search filter", zap.Error(setHintsErr))
+	}
+
 	h.drawHintSearchInput()
 	h.cycleHintIndex = -1
 }
@@ -244,7 +254,10 @@ func (h *Handler) cancelHintSearch() {
 	ctx.SetSearchActive(false)
 
 	if sourceHints := ctx.SourceHints(); sourceHints != nil {
-		ctx.SetVisibleHints(sourceHints)
+		setHintsErr := ctx.SetVisibleHints(sourceHints)
+		if setHintsErr != nil {
+			h.logger.Error("Failed to restore hints after search cancel", zap.Error(setHintsErr))
+		}
 	}
 
 	h.overlayManager.HideHintSearchInput()

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -412,7 +412,11 @@ func (h *Handler) refreshHintsForMonitorMove(
 	}
 
 	hintCollection := domainHint.NewCollection(filtered)
-	h.hints.Context.SetHints(hintCollection)
+
+	setHintsErr := h.hints.Context.SetHints(hintCollection)
+	if setHintsErr != nil {
+		h.logger.Error("Failed to set hints after monitor move", zap.Error(setHintsErr))
+	}
 
 	h.overlayManager.Show()
 }

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -416,6 +416,9 @@ func (h *Handler) refreshHintsForMonitorMove(
 	setHintsErr := h.hints.Context.SetHints(hintCollection)
 	if setHintsErr != nil {
 		h.logger.Error("Failed to set hints after monitor move", zap.Error(setHintsErr))
+		h.exitModeLocked()
+
+		return
 	}
 
 	h.overlayManager.Show()

--- a/internal/core/domain/hint/errors.go
+++ b/internal/core/domain/hint/errors.go
@@ -1,0 +1,8 @@
+package hint
+
+import "errors"
+
+// ErrExternalMuNotHeld indicates a Manager method that invokes onUpdate
+// synchronously was called without holding the external mutex passed to
+// NewManager.
+var ErrExternalMuNotHeld = errors.New("caller must hold externalMu")

--- a/internal/core/domain/hint/manager.go
+++ b/internal/core/domain/hint/manager.go
@@ -1,6 +1,7 @@
 package hint
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -72,9 +73,12 @@ func (m *Manager) SetUpdateCallback(callback func([]*Interface)) {
 }
 
 // SetHints updates the current hint collection and resets the input state.
-// The caller MUST hold externalMu (when set) — see assertExternalMuHeld.
-func (m *Manager) SetHints(hints *Collection) {
-	m.assertExternalMuHeld("SetHints")
+// The caller MUST hold externalMu (when set) — see requireExternalMuHeld.
+func (m *Manager) SetHints(hints *Collection) error {
+	err := m.requireExternalMuHeld("SetHints")
+	if err != nil {
+		return err
+	}
 
 	// Cancel any pending debounced updates
 	if m.debounceTimer != nil {
@@ -108,12 +112,17 @@ func (m *Manager) SetHints(hints *Collection) {
 			callback(hints.All())
 		}
 	}
+
+	return nil
 }
 
 // Reset clears the current input.
-// The caller MUST hold externalMu (when set) — see assertExternalMuHeld.
-func (m *Manager) Reset() {
-	m.assertExternalMuHeld("Reset")
+// The caller MUST hold externalMu (when set) — see requireExternalMuHeld.
+func (m *Manager) Reset() error {
+	err := m.requireExternalMuHeld("Reset")
+	if err != nil {
+		return err
+	}
 
 	// Cancel any pending debounced updates
 	if m.debounceTimer != nil {
@@ -146,14 +155,19 @@ func (m *Manager) Reset() {
 			callback(m.hints.All())
 		}
 	}
+
+	return nil
 }
 
 // Clear releases session-scoped hint state without invoking the update
 // callback. It is intended for mode teardown, where the overlay has already
 // been cleared by the caller and retaining the previous collection would keep
 // every generated hint and domain element alive until the next activation.
-func (m *Manager) Clear() {
-	m.assertExternalMuHeld("Clear")
+func (m *Manager) Clear() error {
+	err := m.requireExternalMuHeld("Clear")
+	if err != nil {
+		return err
+	}
 
 	if m.debounceTimer != nil {
 		m.debounceTimer.Stop()
@@ -168,15 +182,17 @@ func (m *Manager) Clear() {
 	m.cachedFilteredHints = nil
 	m.lastFilteredLen = 0
 	m.SetCurrentInput("")
+
+	return nil
 }
 
 // HandleInput processes an input character and returns the matched hint if an exact match is found.
 // Handles backspace for input correction, filters hints by prefix, and detects exact matches.
 // Returns (hint, true) if exact match found, (nil, false) otherwise.
 // Maintains input state and triggers overlay updates for filtered hints.
-func (m *Manager) HandleInput(key string) (*Interface, bool) {
+func (m *Manager) HandleInput(key string) (*Interface, bool, error) {
 	if m.hints == nil {
-		return nil, false
+		return nil, false, nil
 	}
 
 	if m.Logger != nil {
@@ -187,7 +203,7 @@ func (m *Manager) HandleInput(key string) (*Interface, bool) {
 
 	// Ignore non-single-character keys
 	if len(key) != 1 {
-		return nil, false
+		return nil, false, nil
 	}
 
 	prevLen := m.lastFilteredLen
@@ -214,13 +230,16 @@ func (m *Manager) HandleInput(key string) (*Interface, bool) {
 			// immediately since only text colors change. Otherwise
 			// debounce to batch the structural redraw.
 			if allLen == prevLen {
-				m.immediateUpdate(m.hints.All())
+				err := m.immediateUpdate(m.hints.All())
+				if err != nil {
+					return nil, false, err
+				}
 			} else {
 				m.debouncedUpdate(m.hints.All())
 			}
 		}
 
-		return nil, false
+		return nil, false, nil
 	}
 
 	// Update matched prefix for all filtered hints using cached buffer
@@ -256,7 +275,7 @@ func (m *Manager) HandleInput(key string) (*Interface, bool) {
 
 		m.lastFilteredLen = len(filtered)
 
-		return m.cachedFilteredHints[0], true
+		return m.cachedFilteredHints[0], true, nil
 	}
 
 	m.lastFilteredLen = len(filtered)
@@ -271,12 +290,15 @@ func (m *Manager) HandleInput(key string) (*Interface, bool) {
 	// (or maintain) it. If Collection ever gains mutation methods, this
 	// assumption must be revisited.
 	if len(filtered) == prevLen {
-		m.immediateUpdate(m.cachedFilteredHints)
+		err := m.immediateUpdate(m.cachedFilteredHints)
+		if err != nil {
+			return nil, false, err
+		}
 	} else {
 		m.debouncedUpdate(m.cachedFilteredHints)
 	}
 
-	return nil, false
+	return nil, false, nil
 }
 
 // FilteredHints returns hints filtered by the current input.
@@ -294,7 +316,7 @@ func (m *Manager) FilteredHints() []*Interface {
 
 // HandleBackspace applies the same input-correction behavior used when
 // backspace is pressed during HandleInput.
-func (m *Manager) HandleBackspace() {
+func (m *Manager) HandleBackspace() error {
 	if len(m.CurrentInput()) > 0 {
 		prevLen := m.lastFilteredLen
 		m.SetCurrentInput(m.CurrentInput()[:len(m.CurrentInput())-1])
@@ -321,34 +343,41 @@ func (m *Manager) HandleBackspace() {
 			// changed (same count), update immediately — the overlay only
 			// needs to repaint text colors which is very cheap.
 			if len(filtered) == prevLen {
-				m.immediateUpdate(m.cachedFilteredHints)
+				err := m.immediateUpdate(m.cachedFilteredHints)
+				if err != nil {
+					return err
+				}
 			} else {
 				m.debouncedUpdate(m.cachedFilteredHints)
 			}
 		}
 
-		return
+		return nil
 	}
 
 	// Reset to show all hints if backspacing from empty input
-	m.Reset()
+	return m.Reset()
 }
 
-// assertExternalMuHeld is a debug assertion verifying that the caller holds
-// externalMu (when set). Methods that invoke the onUpdate callback
-// synchronously (SetHints, Reset, immediateUpdate) must be called while
-// the caller holds externalMu to protect shared state (e.g., screen bounds,
-// overlay manager) accessed by the callback.
+// requireExternalMuHeld verifies that the caller holds externalMu (when set).
+// Methods that invoke the onUpdate callback synchronously (SetHints, Reset,
+// immediateUpdate) must be called while the caller holds externalMu to protect
+// shared state (e.g., screen bounds, overlay manager) accessed by the callback.
 //
-// TryLock succeeds only if the mutex is NOT held — meaning the caller
-// forgot to lock it, which would cause a data race on shared state.
-func (m *Manager) assertExternalMuHeld(caller string) {
-	if m.externalMu != nil {
-		if m.externalMu.TryLock() {
-			m.externalMu.Unlock()
-			panic("hint.Manager." + caller + ": caller must hold externalMu")
-		}
+// TryLock succeeds only if the mutex is NOT held — meaning the caller forgot
+// to lock it, which would cause a data race on shared state.
+func (m *Manager) requireExternalMuHeld(caller string) error {
+	if m.externalMu == nil {
+		return nil
 	}
+
+	if m.externalMu.TryLock() {
+		m.externalMu.Unlock()
+
+		return fmt.Errorf("hint.Manager.%s: %w", caller, ErrExternalMuNotHeld)
+	}
+
+	return nil
 }
 
 // immediateUpdate invokes the update callback synchronously, canceling any
@@ -359,15 +388,18 @@ func (m *Manager) assertExternalMuHeld(caller string) {
 // (whose timer goroutine acquires externalMu itself), immediateUpdate runs in
 // the caller's goroutine and relies on the caller already holding the lock to
 // protect shared state (e.g., screen bounds, overlay manager) accessed by the
-// callback. A debug assertion verifies this at runtime.
+// callback. requireExternalMuHeld verifies the lock is held when externalMu is set.
 //
 // Unlike debouncedUpdate, this does NOT copy the hints slice because the
 // callback executes synchronously in the caller's goroutine — the slice
 // is consumed (iterated to build overlay hints) before returning. If the
 // callback contract ever changes to store or defer processing of the
 // slice, a defensive copy must be added here.
-func (m *Manager) immediateUpdate(hints []*Interface) {
-	m.assertExternalMuHeld("immediateUpdate")
+func (m *Manager) immediateUpdate(hints []*Interface) error {
+	err := m.requireExternalMuHeld("immediateUpdate")
+	if err != nil {
+		return err
+	}
 
 	// Cancel any pending debounced update so it doesn't fire stale data.
 	if m.debounceTimer != nil {
@@ -386,6 +418,8 @@ func (m *Manager) immediateUpdate(hints []*Interface) {
 	if callback != nil {
 		callback(hints)
 	}
+
+	return nil
 }
 
 // debouncedUpdate schedules a debounced update of the overlay.

--- a/internal/core/domain/hint/manager_test.go
+++ b/internal/core/domain/hint/manager_test.go
@@ -2,6 +2,7 @@ package hint_test
 
 import (
 	"context"
+	"errors"
 	"image"
 	"sync"
 	"testing"
@@ -19,8 +20,13 @@ func TestManager_Filtering(t *testing.T) {
 	h3, _ := hint.NewHint("AC", element, image.Point{0, 0})
 
 	collection := hint.NewCollection([]*hint.Interface{h1, h2, h3})
+
 	manager := hint.NewManager(logger.Get(), nil)
-	manager.SetHints(collection)
+
+	err := manager.SetHints(collection)
+	if err != nil {
+		t.Fatalf("SetHints: %v", err)
+	}
 
 	tests := []struct {
 		name        string
@@ -37,7 +43,10 @@ func TestManager_Filtering(t *testing.T) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			manager.Reset()
+			err := manager.Reset()
+			if err != nil {
+				t.Fatalf("Reset: %v", err)
+			}
 
 			var (
 				match *hint.Interface
@@ -45,7 +54,12 @@ func TestManager_Filtering(t *testing.T) {
 			)
 
 			for _, char := range testCase.input {
-				match, found = manager.HandleInput(string(char))
+				var err error
+
+				match, found, err = manager.HandleInput(string(char))
+				if err != nil {
+					t.Fatalf("HandleInput: %v", err)
+				}
 			}
 
 			filtered := manager.FilteredHints()
@@ -74,18 +88,29 @@ func TestManager_Backspace(t *testing.T) {
 	element, _ := element.NewElement(element.ID("1"), image.Rect(0, 0, 10, 10), element.RoleButton)
 	h1, _ := hint.NewHint("AA", element, image.Point{0, 0})
 	collection := hint.NewCollection([]*hint.Interface{h1})
+
 	manager := hint.NewManager(logger.Get(), nil)
-	manager.SetHints(collection)
+
+	err := manager.SetHints(collection)
+	if err != nil {
+		t.Fatalf("SetHints: %v", err)
+	}
 
 	// Type 'A'
-	manager.HandleInput("A")
+	_, _, err = manager.HandleInput("A")
+	if err != nil {
+		t.Fatalf("HandleInput: %v", err)
+	}
 
 	if len(manager.FilteredHints()) != 1 {
 		t.Error("Expected 1 hint after 'A'")
 	}
 
 	// Backspace via explicit API (backspace is driven by hotkeys, not HandleInput)
-	manager.HandleBackspace()
+	err = manager.HandleBackspace()
+	if err != nil {
+		t.Fatalf("HandleBackspace: %v", err)
+	}
 
 	if len(manager.FilteredHints()) != 1 {
 		t.Error("Expected 1 hint after Backspace")
@@ -101,11 +126,23 @@ func TestManager_ClearReleasesSessionState(t *testing.T) {
 	h1, _ := hint.NewHint("AA", elem, image.Point{0, 0})
 	h2, _ := hint.NewHint("AB", elem, image.Point{0, 0})
 	collection := hint.NewCollection([]*hint.Interface{h1, h2})
-	manager := hint.NewManager(logger.Get(), nil)
-	manager.SetHints(collection)
 
-	manager.HandleInput("A")
-	manager.Clear()
+	manager := hint.NewManager(logger.Get(), nil)
+
+	err := manager.SetHints(collection)
+	if err != nil {
+		t.Fatalf("SetHints: %v", err)
+	}
+
+	_, _, err = manager.HandleInput("A")
+	if err != nil {
+		t.Fatalf("HandleInput: %v", err)
+	}
+
+	err = manager.Clear()
+	if err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
 
 	if manager.CurrentInput() != "" {
 		t.Errorf("Expected input to be cleared, got %q", manager.CurrentInput())
@@ -147,11 +184,18 @@ func TestHintManager_RouterIntegration(t *testing.T) {
 	hints := hint.NewCollection(hintInterfaces)
 
 	// Set hints in manager
-	hintManager.SetHints(hints)
+	err = hintManager.SetHints(hints)
+	if err != nil {
+		t.Fatalf("SetHints: %v", err)
+	}
 
 	t.Run("Hint manager and router integration", func(t *testing.T) {
 		// Router no longer handles mode exit keys.
-		result := hintRouter.RouteKey("escape")
+		result, err := hintRouter.RouteKey("escape")
+		if err != nil {
+			t.Fatalf("RouteKey: %v", err)
+		}
+
 		if result.ExactHint() != nil {
 			t.Error("Expected no exact match on escape in hint router")
 		}
@@ -166,7 +210,10 @@ func TestHintManager_RouterIntegration(t *testing.T) {
 		})
 
 		// Reset should trigger callback
-		hintManager.Reset()
+		err := hintManager.Reset()
+		if err != nil {
+			t.Fatalf("Reset: %v", err)
+		}
 
 		if !callbackCalled {
 			t.Error("Expected callback to be called on reset")
@@ -191,10 +238,9 @@ func TestCollection_Empty(t *testing.T) {
 	}
 }
 
-func TestManager_ImmediateUpdatePanicsWithoutExternalMu(t *testing.T) {
+func TestManager_ImmediateUpdateRequiresExternalMu(t *testing.T) {
 	// When externalMu is set, HandleInput's immediate-update path must be
-	// called while the caller holds externalMu. This test verifies the
-	// runtime assertion fires when the lock is NOT held.
+	// called while the caller holds externalMu.
 	var mut sync.Mutex
 
 	elem, _ := element.NewElement(element.ID("1"), image.Rect(0, 0, 10, 10), element.RoleButton)
@@ -203,26 +249,23 @@ func TestManager_ImmediateUpdatePanicsWithoutExternalMu(t *testing.T) {
 	collection := hint.NewCollection([]*hint.Interface{h1, h2})
 	manager := hint.NewManager(logger.Get(), &mut)
 	manager.SetUpdateCallback(func(_ []*hint.Interface) {})
-	// SetHints must be called while holding externalMu (mirrors production).
 	mut.Lock()
-	manager.SetHints(collection)
+
+	err := manager.SetHints(collection)
+	if err != nil {
+		t.Fatalf("SetHints: %v", err)
+	}
 	mut.Unlock()
-	// Calling HandleInput WITHOUT holding mu should panic on the
-	// immediate-update path (same count → immediateUpdate).
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("Expected panic when immediateUpdate called without holding externalMu")
-		}
-	}()
+
 	// "A" narrows to 2 hints (AA, AB) — same count as the full set (2),
-	// so this triggers immediateUpdate which should panic.
-	manager.HandleInput("A")
+	// so this triggers immediateUpdate which should fail without the lock.
+	_, _, err = manager.HandleInput("A")
+	if !errors.Is(err, hint.ErrExternalMuNotHeld) {
+		t.Fatalf("HandleInput without externalMu: got %v, want %v", err, hint.ErrExternalMuNotHeld)
+	}
 }
 
-func TestManager_SetHintsPanicsWithoutExternalMu(t *testing.T) {
-	// SetHints invokes the onUpdate callback synchronously, so the caller
-	// must hold externalMu. Verify the assertion fires when it is NOT held.
+func TestManager_SetHintsRequiresExternalMu(t *testing.T) {
 	var mut sync.Mutex
 
 	elem, _ := element.NewElement(element.ID("1"), image.Rect(0, 0, 10, 10), element.RoleButton)
@@ -231,19 +274,13 @@ func TestManager_SetHintsPanicsWithoutExternalMu(t *testing.T) {
 	manager := hint.NewManager(logger.Get(), &mut)
 	manager.SetUpdateCallback(func(_ []*hint.Interface) {})
 
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("Expected panic when SetHints called without holding externalMu")
-		}
-	}()
-	// Calling SetHints WITHOUT holding mut should panic.
-	manager.SetHints(collection)
+	err := manager.SetHints(collection)
+	if !errors.Is(err, hint.ErrExternalMuNotHeld) {
+		t.Fatalf("SetHints without externalMu: got %v, want %v", err, hint.ErrExternalMuNotHeld)
+	}
 }
 
-func TestManager_ResetPanicsWithoutExternalMu(t *testing.T) {
-	// Reset invokes the onUpdate callback synchronously, so the caller
-	// must hold externalMu. Verify the assertion fires when it is NOT held.
+func TestManager_ResetRequiresExternalMu(t *testing.T) {
 	var mut sync.Mutex
 
 	elem, _ := element.NewElement(element.ID("1"), image.Rect(0, 0, 10, 10), element.RoleButton)
@@ -251,19 +288,18 @@ func TestManager_ResetPanicsWithoutExternalMu(t *testing.T) {
 	collection := hint.NewCollection([]*hint.Interface{h1})
 	manager := hint.NewManager(logger.Get(), &mut)
 	manager.SetUpdateCallback(func(_ []*hint.Interface) {})
-	// SetHints must be called while holding externalMu.
 	mut.Lock()
-	manager.SetHints(collection)
+
+	err := manager.SetHints(collection)
+	if err != nil {
+		t.Fatalf("SetHints: %v", err)
+	}
 	mut.Unlock()
 
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("Expected panic when Reset called without holding externalMu")
-		}
-	}()
-	// Calling Reset WITHOUT holding mut should panic.
-	manager.Reset()
+	err = manager.Reset()
+	if !errors.Is(err, hint.ErrExternalMuNotHeld) {
+		t.Fatalf("Reset without externalMu: got %v, want %v", err, hint.ErrExternalMuNotHeld)
+	}
 }
 
 func TestManager_ImmediateUpdateSucceedsWithExternalMu(t *testing.T) {
@@ -282,10 +318,16 @@ func TestManager_ImmediateUpdateSucceedsWithExternalMu(t *testing.T) {
 		callbackCalled = true
 	})
 	mut.Lock()
-	manager.SetHints(collection)
+
+	err := manager.SetHints(collection)
+	if err != nil {
+		t.Fatalf("SetHints: %v", err)
+	}
 	// "A" narrows to 2 hints (AA, AB) — same count → immediateUpdate.
-	// Caller holds mu, so the assertion should pass.
-	manager.HandleInput("A")
+	_, _, err = manager.HandleInput("A")
+	if err != nil {
+		t.Fatalf("HandleInput: %v", err)
+	}
 	mut.Unlock()
 
 	if !callbackCalled {
@@ -310,17 +352,27 @@ func TestManager_NoMatchRepeatedUsesImmediateUpdate(t *testing.T) {
 		callCount++
 	})
 	mut.Lock()
-	manager.SetHints(collection)
+
+	err := manager.SetHints(collection)
+	if err != nil {
+		t.Fatalf("SetHints: %v", err)
+	}
 	// First invalid key "X" → no match, resets to full set (count 2).
 	// Previous count was 2 (from SetHints), so same count → immediateUpdate.
-	manager.HandleInput("X")
+	_, _, err = manager.HandleInput("X")
+	if err != nil {
+		t.Fatalf("HandleInput: %v", err)
+	}
 
 	if callCount != 2 { // 1 from SetHints + 1 from HandleInput("X")
 		t.Errorf("Expected 2 callback calls after first invalid key, got %d", callCount)
 	}
 	// Second invalid key "Z" → no match again, full set (count 2).
 	// Previous count was 2, same count → immediateUpdate (synchronous).
-	manager.HandleInput("Z")
+	_, _, err = manager.HandleInput("Z")
+	if err != nil {
+		t.Fatalf("HandleInput: %v", err)
+	}
 
 	if callCount != 3 { // +1 synchronous callback
 		t.Errorf("Expected 3 callback calls after second invalid key, got %d", callCount)
@@ -352,10 +404,18 @@ func TestManager_AcceptsNonLetterCharacters(t *testing.T) {
 
 	// Set hints
 	collection := hint.NewCollection(hintInterfaces)
-	hintManager.SetHints(collection)
+
+	err = hintManager.SetHints(collection)
+	if err != nil {
+		t.Fatalf("SetHints: %v", err)
+	}
 
 	// Test that letters are accepted and complete for single-char hints
-	matchedHint, complete := hintManager.HandleInput("a")
+	matchedHint, complete, err := hintManager.HandleInput("a")
+	if err != nil {
+		t.Fatalf("HandleInput: %v", err)
+	}
+
 	if !complete {
 		t.Error("Expected complete after single letter matching hint")
 	}
@@ -364,10 +424,17 @@ func TestManager_AcceptsNonLetterCharacters(t *testing.T) {
 		t.Error("Expected hint to be returned")
 	}
 
-	hintManager.Reset()
+	err = hintManager.Reset()
+	if err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
 
 	// Test that numbers are accepted and complete for single-char hints
-	matchedHint2, complete2 := hintManager.HandleInput("1")
+	matchedHint2, complete2, err := hintManager.HandleInput("1")
+	if err != nil {
+		t.Fatalf("HandleInput: %v", err)
+	}
+
 	if !complete2 {
 		t.Error("Expected complete after single number matching hint")
 	}
@@ -376,10 +443,17 @@ func TestManager_AcceptsNonLetterCharacters(t *testing.T) {
 		t.Error("Expected hint to be returned")
 	}
 
-	hintManager.Reset()
+	err = hintManager.Reset()
+	if err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
 
 	// Test that symbols are accepted and complete for single-char hints
-	matchedHint3, complete3 := hintManager.HandleInput("!")
+	matchedHint3, complete3, err := hintManager.HandleInput("!")
+	if err != nil {
+		t.Fatalf("HandleInput: %v", err)
+	}
+
 	if !complete3 {
 		t.Error("Expected complete after single symbol matching hint")
 	}
@@ -388,7 +462,10 @@ func TestManager_AcceptsNonLetterCharacters(t *testing.T) {
 		t.Error("Expected hint to be returned")
 	}
 
-	hintManager.Reset()
+	err = hintManager.Reset()
+	if err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
 
 	// Note: Unicode characters like é and emoji are rejected at config validation level
 	// so they won't be present in hint_characters, making this test unnecessary

--- a/internal/core/domain/hint/router.go
+++ b/internal/core/domain/hint/router.go
@@ -32,9 +32,13 @@ func NewRouter(manager *Manager, logger *zap.Logger) *Router {
 }
 
 // RouteKey processes a key press and returns the routing result.
-func (r *Router) RouteKey(key string) RouteResult {
+func (r *Router) RouteKey(key string) (RouteResult, error) {
 	// Process input through manager
-	hint, exactMatch := r.manager.HandleInput(key)
+	hint, exactMatch, err := r.manager.HandleInput(key)
+	if err != nil {
+		return RouteResult{}, err
+	}
+
 	if exactMatch {
 		if r.Logger != nil {
 			r.Logger.Debug("Hints router: Exact hint match found",
@@ -43,9 +47,9 @@ func (r *Router) RouteKey(key string) RouteResult {
 
 		return RouteResult{
 			exactHint: hint,
-		}
+		}, nil
 	}
 
 	// No exact match, continue in hint mode
-	return RouteResult{}
+	return RouteResult{}, nil
 }

--- a/internal/core/domain/hint/router_test.go
+++ b/internal/core/domain/hint/router_test.go
@@ -39,7 +39,10 @@ func TestRouter_RouteKey(t *testing.T) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			result := router.RouteKey(testCase.key)
+			result, err := router.RouteKey(testCase.key)
+			if err != nil {
+				t.Fatalf("RouteKey: %v", err)
+			}
 
 			if (result.ExactHint() != nil) != testCase.wantExact {
 				t.Errorf(
@@ -65,17 +68,27 @@ func TestRouter_WithHints(t *testing.T) {
 	h2, _ := hint.NewHint("AC", elem2, image.Point{X: 15, Y: 15})
 
 	collection := hint.NewCollection([]*hint.Interface{h1, h2})
-	manager.SetHints(collection)
+
+	err := manager.SetHints(collection)
+	if err != nil {
+		t.Fatalf("SetHints: %v", err)
+	}
 
 	// Test partial match - typing "A" should not complete yet
-	result := router.RouteKey("a")
+	result, err := router.RouteKey("a")
+	if err != nil {
+		t.Fatalf("RouteKey: %v", err)
+	}
 
 	if result.ExactHint() != nil {
 		t.Error("Should not have exact hint match for partial input 'a'")
 	}
 
 	// Test exact match - typing "AB" should complete
-	result = router.RouteKey("b")
+	result, err = router.RouteKey("b")
+	if err != nil {
+		t.Fatalf("RouteKey: %v", err)
+	}
 
 	if result.ExactHint() == nil {
 		t.Error("Should have exact hint match for 'ab'")
@@ -86,16 +99,27 @@ func TestRouter_WithHints(t *testing.T) {
 	}
 
 	// Reset and test another partial/exact sequence
-	manager.SetHints(collection) // Reset input state
+	err = manager.SetHints(collection) // Reset input state
+	if err != nil {
+		t.Fatalf("SetHints: %v", err)
+	}
 
 	// Type "A" again (partial)
-	result = router.RouteKey("a")
+	result, err = router.RouteKey("a")
+	if err != nil {
+		t.Fatalf("RouteKey: %v", err)
+	}
+
 	if result.ExactHint() != nil {
 		t.Error("Should not have exact hint match for partial input 'a' (second time)")
 	}
 
 	// Type "C" to complete "AC"
-	result = router.RouteKey("c")
+	result, err = router.RouteKey("c")
+	if err != nil {
+		t.Fatalf("RouteKey: %v", err)
+	}
+
 	if result.ExactHint() == nil {
 		t.Error("Should have exact hint match for 'ac'")
 	}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR replaces the hint manager’s `TryLock/panic` invariant check with explicit error returns, which more aligns with Go conventions.

When NewManager is given an externalMu, synchronous paths (SetHints, Reset, Clear, immediateUpdate) must be called while that mutex is held. Callers that skip the lock now get ErrExternalMuNotHeld instead of a runtime panic. debouncedUpdate is unchanged: the timer goroutine still acquires externalMu before invoking onUpdate.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
