### PR TITLE
fix(darwin): harden CGo callback singletons with generation-stamped slots

### DIFF
--- a/internal/core/infra/platform/darwin/bridge.go
+++ b/internal/core/infra/platform/darwin/bridge.go
@@ -167,17 +167,14 @@ func dispatchAppWatcherAppEvent(
 	log := getLogger()
 	log.Debug("Darwin: " + handlerName + " called")
 
-	name := C.GoString(appName)
-	bundleIDValue := C.GoString(bundleID)
-
-	dispatch := func(watcher AppWatcherInterface) {
+	appWatcherSlot.withValid(func(watcher AppWatcherInterface) {
+		name := C.GoString(appName)
+		bundleIDValue := C.GoString(bundleID)
 		log.Debug("Darwin: "+forwardMsg,
 			zap.String("app_name", name),
 			zap.String("bundle_id", bundleIDValue))
 		forward(watcher, name, bundleIDValue)
-	}
-
-	appWatcherSlot.withValid(dispatch)
+	})
 }
 
 func dispatchAppWatcherVoidEvent(

--- a/internal/core/infra/platform/darwin/bridge.go
+++ b/internal/core/infra/platform/darwin/bridge.go
@@ -14,7 +14,6 @@ extern void hotkeyCallbackBridge(int hotkeyId, int eventKind, void* userData);
 import "C"
 
 import (
-	"sync"
 	"sync/atomic"
 	"unsafe"
 
@@ -22,17 +21,13 @@ import (
 )
 
 var (
-	appWatcher         AppWatcherInterface
-	appWatcherMu       sync.RWMutex
+	appWatcherSlot     cgoSlot[AppWatcherInterface]
 	mcDetectionEnabled atomic.Bool
 )
 
 // AppWatcher returns the global application watcher instance.
 func AppWatcher() AppWatcherInterface {
-	appWatcherMu.RLock()
-	defer appWatcherMu.RUnlock()
-
-	return appWatcher
+	return appWatcherSlot.Get()
 }
 
 // RegisterHotkey registers a global hotkey on macOS.
@@ -111,16 +106,11 @@ const (
 // HotkeyHandler defines the signature for hotkey event handlers.
 type HotkeyHandler func(hotkeyID int, eventKind HotkeyEventKind)
 
-var (
-	hotkeyHandler   HotkeyHandler
-	hotkeyHandlerMu sync.RWMutex
-)
+var hotkeyHandlerSlot cgoSlot[HotkeyHandler]
 
 // SetHotkeyHandler sets the global hotkey event handler.
 func SetHotkeyHandler(handler HotkeyHandler) {
-	hotkeyHandlerMu.Lock()
-	defer hotkeyHandlerMu.Unlock()
-	hotkeyHandler = handler
+	hotkeyHandlerSlot.Set(handler)
 }
 
 // GetHotkeyCallbackBridge returns a pointer to the C hotkey callback bridge function.
@@ -132,13 +122,11 @@ func GetHotkeyCallbackBridge() unsafe.Pointer {
 
 //export hotkeyCallbackBridge
 func hotkeyCallbackBridge(hotkeyID C.int, eventKind C.int, _ unsafe.Pointer) {
-	hotkeyHandlerMu.RLock()
-	handler := hotkeyHandler
-	hotkeyHandlerMu.RUnlock()
-
-	if handler != nil {
-		handler(int(hotkeyID), HotkeyEventKind(eventKind))
-	}
+	id := int(hotkeyID)
+	kind := HotkeyEventKind(eventKind)
+	hotkeyHandlerSlot.withValid(func(handler HotkeyHandler) {
+		handler(id, kind)
+	})
 }
 
 // SetAppWatcher configures the application watcher implementation.
@@ -146,10 +134,7 @@ func SetAppWatcher(watcher AppWatcherInterface) {
 	log := getLogger()
 	log.Debug("Darwin: Setting app watcher")
 
-	appWatcherMu.Lock()
-	defer appWatcherMu.Unlock()
-
-	appWatcher = watcher
+	appWatcherSlot.Set(watcher)
 }
 
 // SetDetectMissionControlEnabled enables or disables Mission Control detection.
@@ -174,14 +159,6 @@ func StopAppWatcher() {
 	C.NeruStopAppWatcher()
 }
 
-func currentAppWatcher() AppWatcherInterface {
-	appWatcherMu.RLock()
-	watcher := appWatcher
-	appWatcherMu.RUnlock()
-
-	return watcher
-}
-
 func dispatchAppWatcherAppEvent(
 	handlerName, forwardMsg string,
 	appName, bundleID *C.char,
@@ -190,17 +167,17 @@ func dispatchAppWatcherAppEvent(
 	log := getLogger()
 	log.Debug("Darwin: " + handlerName + " called")
 
-	watcher := currentAppWatcher()
-	if watcher == nil {
-		return
+	name := C.GoString(appName)
+	bundleIDValue := C.GoString(bundleID)
+
+	dispatch := func(watcher AppWatcherInterface) {
+		log.Debug("Darwin: "+forwardMsg,
+			zap.String("app_name", name),
+			zap.String("bundle_id", bundleIDValue))
+		forward(watcher, name, bundleIDValue)
 	}
 
-	name := C.GoString(appName)
-	id := C.GoString(bundleID)
-	log.Debug("Darwin: "+forwardMsg,
-		zap.String("app_name", name),
-		zap.String("bundle_id", id))
-	forward(watcher, name, id)
+	appWatcherSlot.withValid(dispatch)
 }
 
 func dispatchAppWatcherVoidEvent(
@@ -211,19 +188,18 @@ func dispatchAppWatcherVoidEvent(
 	log := getLogger()
 	log.Debug("Darwin: " + handlerName + " called")
 
-	watcher := currentAppWatcher()
-	if watcher == nil {
-		return
+	dispatch := func(watcher AppWatcherInterface) {
+		log.Debug("Darwin: " + forwardMsg)
+		forward(watcher)
 	}
 
-	log.Debug("Darwin: " + forwardMsg)
 	if async {
-		go forward(watcher)
+		appWatcherSlot.withValidAsync(dispatch)
 
 		return
 	}
 
-	forward(watcher)
+	appWatcherSlot.withValid(dispatch)
 }
 
 //export handleAppLaunch

--- a/internal/core/infra/platform/darwin/bridge_test.go
+++ b/internal/core/infra/platform/darwin/bridge_test.go
@@ -117,6 +117,23 @@ func TestSetAppWatcher(t *testing.T) {
 	}
 }
 
+func TestAppWatcherDispatchDroppedAfterClear(t *testing.T) {
+	darwin.InitializeLogger(zap.NewNop())
+
+	mock := &MockAppWatcher{}
+	darwin.SetAppWatcher(mock)
+	darwin.SetAppWatcher(nil)
+
+	darwin.HandleAppLaunch("TestApp", "com.test.app")
+
+	if len(mock.launchCalls) != 0 {
+		t.Fatalf(
+			"expected no dispatch after SetAppWatcher(nil), got %d calls",
+			len(mock.launchCalls),
+		)
+	}
+}
+
 func TestCallbacks(t *testing.T) {
 	// Initialize logger
 	darwin.InitializeLogger(zap.NewNop())
@@ -124,6 +141,9 @@ func TestCallbacks(t *testing.T) {
 	// Setup mock watcher
 	mock := &MockAppWatcher{}
 	darwin.SetAppWatcher(mock)
+	t.Cleanup(func() {
+		darwin.SetAppWatcher(nil)
+	})
 
 	// Enable Mission Control detection so the handlers forward events
 	darwin.SetDetectMissionControlEnabled(true)

--- a/internal/core/infra/platform/darwin/cgo_slot.go
+++ b/internal/core/infra/platform/darwin/cgo_slot.go
@@ -42,9 +42,6 @@ func isEmptyValue[T any](v T) bool {
 	}
 
 	kind := reflected.Kind()
-	if kind == reflect.Invalid {
-		return true
-	}
 
 	if kind == reflect.Chan || kind == reflect.Func || kind == reflect.Interface ||
 		kind == reflect.Map || kind == reflect.Pointer || kind == reflect.Slice {

--- a/internal/core/infra/platform/darwin/cgo_slot.go
+++ b/internal/core/infra/platform/darwin/cgo_slot.go
@@ -1,0 +1,112 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"reflect"
+	"sync"
+	"sync/atomic"
+)
+
+// cgoSlot holds a process-global target for C-exported callbacks. macOS bridges
+// register a single Go handler, so tests and multiple App lifetimes share this
+// slot. Each Set bumps a generation counter so sync and async dispatches can
+// ignore events after clear (nil) or replacement.
+type cgoSlot[T any] struct {
+	mu     sync.RWMutex
+	target T
+	gen    atomic.Uint64
+}
+
+func (s *cgoSlot[T]) zero() T {
+	var z T
+
+	return z
+}
+
+func (s *cgoSlot[T]) isZero(v T) bool {
+	return isEmptyValue(v)
+}
+
+// isEmptyValue reports whether v is unset. Typed nil interfaces are handled
+// before reflect (ValueOf(nil) is invalid). Function types use IsNil; other
+// scalars use IsZero.
+func isEmptyValue[T any](v T) bool {
+	if any(v) == nil {
+		return true
+	}
+
+	reflected := reflect.ValueOf(v)
+	if !reflected.IsValid() {
+		return true
+	}
+
+	kind := reflected.Kind()
+	if kind == reflect.Invalid {
+		return true
+	}
+
+	if kind == reflect.Chan || kind == reflect.Func || kind == reflect.Interface ||
+		kind == reflect.Map || kind == reflect.Pointer || kind == reflect.Slice {
+		return reflected.IsNil()
+	}
+
+	return reflected.IsZero()
+}
+
+// Set replaces the slot target and invalidates in-flight dispatches.
+func (s *cgoSlot[T]) Set(target T) {
+	s.mu.Lock()
+	s.target = target
+	s.gen.Add(1)
+	s.mu.Unlock()
+}
+
+// Get returns the current target without generation checking.
+func (s *cgoSlot[T]) Get() T {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.target
+}
+
+func (s *cgoSlot[T]) snapshot() (T, uint64, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.isZero(s.target) {
+		return s.zero(), 0, false
+	}
+
+	return s.target, s.gen.Load(), true
+}
+
+func (s *cgoSlot[T]) stillValid(gen uint64) bool {
+	return s.gen.Load() == gen
+}
+
+// withValid invokes callback with the current target when the snapshot is still valid.
+func (s *cgoSlot[T]) withValid(callback func(T)) {
+	target, gen, ok := s.snapshot()
+	if !ok || !s.stillValid(gen) {
+		return
+	}
+
+	callback(target)
+}
+
+// withValidAsync invokes callback in a new goroutine when the snapshot is still valid.
+func (s *cgoSlot[T]) withValidAsync(callback func(T)) {
+	target, gen, ok := s.snapshot()
+	if !ok || !s.stillValid(gen) {
+		return
+	}
+
+	go func() {
+		if !s.stillValid(gen) {
+			return
+		}
+
+		callback(target)
+	}()
+}

--- a/internal/core/infra/platform/darwin/cgo_slot.go
+++ b/internal/core/infra/platform/darwin/cgo_slot.go
@@ -6,8 +6,6 @@ import (
 	"reflect"
 	"sync"
 	"sync/atomic"
-
-	"github.com/y3owk1n/neru/internal/config"
 )
 
 // cgoSlot holds a process-global target for C-exported callbacks. macOS bridges
@@ -35,18 +33,8 @@ func (s *cgoSlot[T]) isZero(v T) bool {
 // scalars use IsZero.
 func isEmptyValue[T any](v T) bool {
 	valueAsAny := any(v)
-
-	switch typed := valueAsAny.(type) {
-	case nil:
+	if valueAsAny == nil {
 		return true
-	case AppWatcherInterface:
-		return typed == nil
-	case config.Provider:
-		return typed == nil
-	case HotkeyHandler:
-		return typed == nil
-	case func(bool):
-		return typed == nil
 	}
 
 	reflected := reflect.ValueOf(valueAsAny)

--- a/internal/core/infra/platform/darwin/cgo_slot.go
+++ b/internal/core/infra/platform/darwin/cgo_slot.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"sync"
 	"sync/atomic"
+
+	"github.com/y3owk1n/neru/internal/config"
 )
 
 // cgoSlot holds a process-global target for C-exported callbacks. macOS bridges
@@ -32,11 +34,22 @@ func (s *cgoSlot[T]) isZero(v T) bool {
 // before reflect (ValueOf(nil) is invalid). Function types use IsNil; other
 // scalars use IsZero.
 func isEmptyValue[T any](v T) bool {
-	if any(v) == nil {
+	valueAsAny := any(v)
+
+	switch typed := valueAsAny.(type) {
+	case nil:
 		return true
+	case AppWatcherInterface:
+		return typed == nil
+	case config.Provider:
+		return typed == nil
+	case HotkeyHandler:
+		return typed == nil
+	case func(bool):
+		return typed == nil
 	}
 
-	reflected := reflect.ValueOf(v)
+	reflected := reflect.ValueOf(valueAsAny)
 	if !reflected.IsValid() {
 		return true
 	}

--- a/internal/core/infra/platform/darwin/cgo_slot_test.go
+++ b/internal/core/infra/platform/darwin/cgo_slot_test.go
@@ -1,0 +1,117 @@
+//go:build darwin
+
+//nolint:testpackage // tests unexported cgoSlot internals
+package darwin
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCgoSlotInterfaceNilDoesNotPanic(t *testing.T) {
+	type handler interface {
+		Handle()
+	}
+
+	var slot cgoSlot[handler]
+
+	slot.Set(nil)
+
+	if _, _, ok := slot.snapshot(); ok {
+		t.Fatal("expected empty snapshot for nil interface")
+	}
+}
+
+func TestCgoSlotFuncZeroDoesNotPanic(t *testing.T) {
+	var slot cgoSlot[func()]
+
+	slot.Set(func() {})
+
+	if _, _, ok := slot.snapshot(); !ok {
+		t.Fatal("expected active snapshot for non-nil func")
+	}
+
+	slot.Set(nil)
+
+	if _, _, ok := slot.snapshot(); ok {
+		t.Fatal("expected empty snapshot after nil func clear")
+	}
+}
+
+func TestCgoSlotSetInvalidatesPriorSnapshot(t *testing.T) {
+	var slot cgoSlot[int]
+
+	slot.Set(1)
+
+	_, gen, ok := slot.snapshot()
+	if !ok {
+		t.Fatal("expected snapshot")
+	}
+
+	slot.Set(0)
+
+	if slot.stillValid(gen) {
+		t.Fatal("expected generation to be invalid after clear")
+	}
+}
+
+func TestCgoSlotWithValidAsyncRejectsStaleGeneration(t *testing.T) {
+	var (
+		slot  cgoSlot[int]
+		calls atomic.Int32
+	)
+
+	slot.Set(1)
+
+	_, gen, ok := slot.snapshot()
+	if !ok {
+		t.Fatal("expected snapshot")
+	}
+
+	slot.Set(0)
+
+	go func() {
+		if !slot.stillValid(gen) {
+			return
+		}
+
+		calls.Add(1)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("expected stale async dispatch to be dropped, got %d calls", got)
+	}
+}
+
+func TestCgoSlotConcurrentSetAndDispatch(t *testing.T) {
+	var (
+		slot    cgoSlot[int]
+		okCalls atomic.Int32
+	)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		for i := 1; i <= 100; i++ {
+			slot.withValid(func(v int) {
+				if v == i {
+					okCalls.Add(1)
+				}
+			})
+		}
+	}()
+
+	for i := 1; i <= 100; i++ {
+		slot.Set(i)
+	}
+
+	<-done
+
+	if okCalls.Load() == 0 {
+		t.Fatal("expected at least one valid dispatch under concurrent set")
+	}
+}

--- a/internal/core/infra/platform/darwin/cgo_slot_test.go
+++ b/internal/core/infra/platform/darwin/cgo_slot_test.go
@@ -63,26 +63,16 @@ func TestCgoSlotWithValidAsyncRejectsStaleGeneration(t *testing.T) {
 	)
 
 	slot.Set(1)
-
-	_, gen, ok := slot.snapshot()
-	if !ok {
-		t.Fatal("expected snapshot")
-	}
-
 	slot.Set(0)
 
-	go func() {
-		if !slot.stillValid(gen) {
-			return
-		}
-
+	slot.withValidAsync(func(_ int) {
 		calls.Add(1)
-	}()
+	})
 
 	time.Sleep(20 * time.Millisecond)
 
 	if got := calls.Load(); got != 0 {
-		t.Fatalf("expected stale async dispatch to be dropped, got %d calls", got)
+		t.Fatalf("expected withValidAsync to drop dispatch after Set(0), got %d calls", got)
 	}
 }
 

--- a/internal/core/infra/platform/darwin/cgo_slot_test.go
+++ b/internal/core/infra/platform/darwin/cgo_slot_test.go
@@ -4,6 +4,7 @@
 package darwin
 
 import (
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -81,6 +82,7 @@ func TestCgoSlotConcurrentSetAndDispatch(t *testing.T) {
 	var (
 		slot      cgoSlot[int]
 		calls     atomic.Int32
+		staleSeen atomic.Int32
 		waitGroup sync.WaitGroup
 	)
 
@@ -93,12 +95,25 @@ func TestCgoSlotConcurrentSetAndDispatch(t *testing.T) {
 		go func() {
 			defer waitGroup.Done()
 
-			for range 20 {
-				slot.withValid(func(v int) {
-					if v != 0 {
-						calls.Add(1)
-					}
-				})
+			for range 200 {
+				value, generation, ok := slot.snapshot()
+				if !ok {
+					continue
+				}
+
+				// Encourage interleaving so concurrent Set(0)/Set(1) updates can
+				// invalidate this snapshot before stillValid checks it.
+				runtime.Gosched()
+
+				if !slot.stillValid(generation) {
+					staleSeen.Add(1)
+
+					continue
+				}
+
+				if value != 0 {
+					calls.Add(1)
+				}
 			}
 		}()
 	}
@@ -106,8 +121,9 @@ func TestCgoSlotConcurrentSetAndDispatch(t *testing.T) {
 	go func() {
 		defer waitGroup.Done()
 
-		for range 100 {
+		for range 400 {
 			slot.Set(1)
+			slot.Set(0)
 		}
 	}()
 
@@ -115,5 +131,9 @@ func TestCgoSlotConcurrentSetAndDispatch(t *testing.T) {
 
 	if calls.Load() == 0 {
 		t.Fatal("expected at least one dispatch while slot holds a value")
+	}
+
+	if staleSeen.Load() == 0 {
+		t.Fatal("expected at least one stale snapshot invalidated by concurrent clear")
 	}
 }

--- a/internal/core/infra/platform/darwin/cgo_slot_test.go
+++ b/internal/core/infra/platform/darwin/cgo_slot_test.go
@@ -4,6 +4,7 @@
 package darwin
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -78,30 +79,41 @@ func TestCgoSlotWithValidAsyncRejectsStaleGeneration(t *testing.T) {
 
 func TestCgoSlotConcurrentSetAndDispatch(t *testing.T) {
 	var (
-		slot    cgoSlot[int]
-		okCalls atomic.Int32
+		slot      cgoSlot[int]
+		calls     atomic.Int32
+		waitGroup sync.WaitGroup
 	)
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
+	slot.Set(1)
 
-		for i := 1; i <= 100; i++ {
-			slot.withValid(func(v int) {
-				if v == i {
-					okCalls.Add(1)
-				}
-			})
+	const dispatchers = 50
+	waitGroup.Add(dispatchers + 1)
+
+	for range dispatchers {
+		go func() {
+			defer waitGroup.Done()
+
+			for range 20 {
+				slot.withValid(func(v int) {
+					if v != 0 {
+						calls.Add(1)
+					}
+				})
+			}
+		}()
+	}
+
+	go func() {
+		defer waitGroup.Done()
+
+		for range 100 {
+			slot.Set(1)
 		}
 	}()
 
-	for i := 1; i <= 100; i++ {
-		slot.Set(i)
-	}
+	waitGroup.Wait()
 
-	<-done
-
-	if okCalls.Load() == 0 {
-		t.Fatal("expected at least one valid dispatch under concurrent set")
+	if calls.Load() == 0 {
+		t.Fatal("expected at least one dispatch while slot holds a value")
 	}
 }

--- a/internal/core/infra/platform/darwin/config_provider.go
+++ b/internal/core/infra/platform/darwin/config_provider.go
@@ -2,32 +2,21 @@
 
 package darwin
 
-import (
-	"sync"
+import "github.com/y3owk1n/neru/internal/config"
 
-	"github.com/y3owk1n/neru/internal/config"
-)
-
-var (
-	configProviderMu sync.RWMutex
-	configProvider   config.Provider
-)
+var configProviderSlot cgoSlot[config.Provider]
 
 // SetConfigProvider updates the runtime config provider used by mouse helpers.
 func SetConfigProvider(provider config.Provider) {
-	configProviderMu.Lock()
-	defer configProviderMu.Unlock()
-
-	configProvider = provider
+	configProviderSlot.Set(provider)
 }
 
 func currentConfig() *config.Config {
-	configProviderMu.RLock()
-	defer configProviderMu.RUnlock()
+	var cfg *config.Config
 
-	if configProvider == nil {
-		return nil
-	}
+	configProviderSlot.withValid(func(provider config.Provider) {
+		cfg = provider.Get()
+	})
 
-	return configProvider.Get()
+	return cfg
 }

--- a/internal/core/infra/platform/darwin/theme.go
+++ b/internal/core/infra/platform/darwin/theme.go
@@ -7,25 +7,16 @@ package darwin
 */
 import "C"
 
-import (
-	"sync"
-)
-
 // IsDarkMode returns true if macOS Dark Mode is currently active.
 func IsDarkMode() bool {
 	return C.NeruIsDarkMode() != 0
 }
 
-var (
-	themeHandler   func(bool)
-	themeHandlerMu sync.RWMutex
-)
+var themeHandlerSlot cgoSlot[func(bool)]
 
 // SetThemeChangeHandler sets the callback function to be called when the system theme changes.
 func SetThemeChangeHandler(handler func(bool)) {
-	themeHandlerMu.Lock()
-	defer themeHandlerMu.Unlock()
-	themeHandler = handler
+	themeHandlerSlot.Set(handler)
 }
 
 // StartThemeObserver starts observing macOS theme changes.
@@ -40,11 +31,8 @@ func StopThemeObserver() {
 
 //export handleThemeChanged
 func handleThemeChanged(isDark C.int) {
-	themeHandlerMu.RLock()
-	handler := themeHandler
-	themeHandlerMu.RUnlock()
-
-	if handler != nil {
-		go handler(isDark != 0)
-	}
+	dark := isDark != 0
+	themeHandlerSlot.withValidAsync(func(handler func(bool)) {
+		handler(dark)
+	})
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR introduces a generic `cgoSlot[T]` helper that bumps a generation counter on every `Set` (including clear). Sync and async dispatches snapshot target + generation and drop the call if the slot was cleared or replaced before invocation.

Affected call sites:

- `bridge.go` — app watcher and hotkey handler dispatch
- `theme.go` — theme change handler dispatch
- `config_provider.go` — runtime config provider lookup

Also adds tests for slot invalidation, nil interface/func safety, and post-clear app watcher dispatch.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
