### PR TITLE
feat(hints): add `vision` detection strategy

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -43,6 +43,7 @@ text = "#E8EEFF"
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#hints
 [hints]
 enabled = true
+strategy = "axtree"                          # Element detection: "axtree" (AX API) or "vision" (Vision Framework)
 hint_characters = "asdfghjkl"               # Characters used for hint labels
 max_depth = 50                              # Max accessibility tree depth (0 = unlimited)
 include_menubar_hints = false

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -87,7 +87,7 @@ neru recursive_grid --action middle_click          # Middle-click via recursive 
 
 ### Hints Mode
 
-Uses macOS Accessibility APIs to label clickable UI elements with short overlay labels.
+Labels clickable UI elements with short overlay labels. Uses either the macOS Accessibility API (`axtree`) or Vision Framework (`vision`) to discover elements. Default is `axtree`.
 
 ```bash
 neru hints
@@ -95,6 +95,7 @@ neru hints
 
 neru hints --search                                # Start with search input active
 neru hints --action left_click --repeat            # Click multiple elements in succession
+neru hints --strategy vision                       # Use Vision Framework for element detection
 
 # Filtering
 neru hints --role AXButton --text submit           # Show only buttons containing "submit"
@@ -110,6 +111,7 @@ neru hints --text next --action left_click --repeat   # Filter persists across r
 | `--search, -s`            | bool   | Start with search input active.                                                                                              |
 | `--role`                  | string | Filter by AX role. Comma-separated for multiple (e.g. `--role AXButton,AXLink`).                                             |
 | `--text`                  | string | Filter elements by text content (title, description, value). Case-insensitive substring match. Comma-separated for OR match. |
+| `--strategy`              | string | Element detection strategy: `axtree` (macOS AX API, default) or `vision` (Vision Framework). Overrides config for this invocation. |
 
 The filter is preserved across repeat activations.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -312,7 +312,7 @@ Explicit component colors override theme derivation. Omitted colors inherit from
 
 ## [hints]
 
-Uses macOS Accessibility APIs to label clickable UI elements with short overlay labels.
+Labels clickable UI elements with short overlay labels. By default uses the macOS Accessibility API (`axtree` strategy). Optionally uses Vision Framework (`vision` strategy) for apps with poor AX trees — detects elements via screen capture + text/rectangle recognition scoped to the focused window.
 
 Press `/` to text-search elements. `Space` for multi-word queries. `Return` confirms filtered hints (first is auto-selected). `Escape` cancels search.
 
@@ -323,6 +323,7 @@ Start with search visible: `neru hints --search` (see [CLI.md](CLI.md#hints-mode
 | Option                             | Type         | Default                 | Description                                               |
 | ---------------------------------- | ------------ | ----------------------- | --------------------------------------------------------- |
 | `enabled`                          | bool         | `true`                  | Enable/disable hints mode                                 |
+| `strategy`                         | string       | `"axtree"`              | Element detection strategy: `"axtree"` (macOS Accessibility API) or `"vision"` (Vision Framework). Vision mode detects the frontmost window content via screen capture + text/rectangle recognition while still using AX for system elements (menubar, dock, NC). Overridable per-app via `[hints.app_configs]`. |
 | `hint_characters`                  | string       | `"asdfghjkl"`           | Characters used for labels                                |
 | `max_depth`                        | int          | `50`                    | Max accessibility tree depth (0 = unlimited)              |
 | `include_menubar_hints`            | bool         | `false`                 | Show hints on menubar items                               |
@@ -423,6 +424,7 @@ Find bundle IDs: `osascript -e 'id of app "Safari"'`
 | Field                        | Type   | Description                                           |
 | ---------------------------- | ------ | ----------------------------------------------------- |
 | `bundle_id`                  | string | App bundle ID                                         |
+| `strategy`                   | string | Override element detection strategy for this app (`"axtree"` or `"vision"`). Empty string = use global `hints.strategy`. |
 | `additional_clickable_roles` | array  | Extra AX roles to treat as clickable                  |
 | `ignore_clickable_check`     | bool   | Skip clickability heuristic for this app              |
 | `visible_check_enabled`      | bool   | Enable visibility hit-test for this app               |
@@ -431,6 +433,7 @@ Find bundle IDs: `osascript -e 'id of app "Safari"'`
 ```toml
 [[hints.app_configs]]
 bundle_id = "com.apple.Safari"
+strategy = "vision"
 additional_clickable_roles = ["AXLink"]
 ignore_clickable_check = true
 visible_check_enabled = true

--- a/internal/app/components/hints/context.go
+++ b/internal/app/components/hints/context.go
@@ -13,6 +13,7 @@ type baseContext struct {
 	filterRoles           []string
 	filterTextContains    []string
 	startWithSearch       bool
+	strategyOverride      string
 }
 
 // SetPendingAction sets the action to execute when mode selection is complete.
@@ -60,6 +61,7 @@ func (c *baseContext) Reset() {
 	c.filterRoles = nil
 	c.filterTextContains = nil
 	c.startWithSearch = false
+	c.strategyOverride = ""
 }
 
 // SetFilterRoles sets the filter roles for hint mode.
@@ -90,6 +92,16 @@ func (c *baseContext) SetStartWithSearch(search bool) {
 // StartWithSearch returns whether the mode was initially activated with search.
 func (c *baseContext) StartWithSearch() bool {
 	return c.startWithSearch
+}
+
+// SetStrategyOverride stores the session hint collection strategy override.
+func (c *baseContext) SetStrategyOverride(strategy string) {
+	c.strategyOverride = strategy
+}
+
+// StrategyOverride returns the session hint collection strategy override.
+func (c *baseContext) StrategyOverride() string {
+	return c.strategyOverride
 }
 
 // Context holds the state and context for hint mode operations.

--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -16,6 +16,7 @@ import (
 	"github.com/y3owk1n/neru/internal/core/infra/hotkeys"
 	"github.com/y3owk1n/neru/internal/core/infra/logger"
 	overlayAdapter "github.com/y3owk1n/neru/internal/core/infra/overlay"
+	visionAdapter "github.com/y3owk1n/neru/internal/core/infra/vision"
 	"github.com/y3owk1n/neru/internal/core/ports"
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
@@ -123,6 +124,9 @@ func initializeServices(
 		)
 	}
 
+	// Vision adapter - vision-based element detection (optional, used on "vision" strategy)
+	visionPort := visionAdapter.NewAdapter(logger)
+
 	// Hint Service - orchestrates hint generation and display
 	hintService := services.NewHintService(
 		accAdapter,
@@ -131,6 +135,7 @@ func initializeServices(
 		hintGen,
 		cfg.Hints,
 		logger,
+		visionPort,
 	)
 
 	// Grid Service - manages grid-based navigation overlays

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -151,6 +151,7 @@ type ModeActivationOptions struct {
 	FilterRoles           []string
 	FilterTextContains    []string
 	Search                *bool
+	Strategy              *string
 }
 
 // extractModeOptions extracts and validates the optional action and repeat
@@ -283,6 +284,44 @@ func (h *IPCControllerModes) extractModeOptions(
 			startIdx++
 			texts := parseCSV(cmd.Args[startIdx])
 			opts.FilterTextContains = append(opts.FilterTextContains, texts...)
+		case strings.HasPrefix(arg, "--strategy="):
+			strategyVal := strings.TrimPrefix(arg, "--strategy=")
+			if !isValidStrategy(strategyVal) {
+				resp := ipc.Response{
+					Success: false,
+					Message: "invalid --strategy value: must be 'axtree' or 'vision'",
+					Code:    ipc.CodeInvalidInput,
+				}
+
+				return opts, &resp
+			}
+
+			opts.Strategy = &strategyVal
+		case arg == "--strategy":
+			if startIdx+1 >= len(cmd.Args) {
+				resp := ipc.Response{
+					Success: false,
+					Message: "--strategy requires a value: axtree or vision",
+					Code:    ipc.CodeInvalidInput,
+				}
+
+				return opts, &resp
+			}
+
+			startIdx++
+
+			strategyVal := cmd.Args[startIdx]
+			if !isValidStrategy(strategyVal) {
+				resp := ipc.Response{
+					Success: false,
+					Message: "invalid --strategy value: must be 'axtree' or 'vision'",
+					Code:    ipc.CodeInvalidInput,
+				}
+
+				return opts, &resp
+			}
+
+			opts.Strategy = &strategyVal
 		case opts.Action == nil:
 			actionArg := arg
 			opts.Action = &actionArg
@@ -381,6 +420,7 @@ func (h *IPCControllerModes) handleHints(_ context.Context, cmd ipc.Command) ipc
 		FilterRoles:           opts.FilterRoles,
 		FilterTextContains:    opts.FilterTextContains,
 		Search:                opts.Search,
+		Strategy:              opts.Strategy,
 	})
 
 	return ipc.Response{Success: true, Message: "hints mode activated", Code: ipc.CodeOK}
@@ -471,6 +511,12 @@ func (h *IPCControllerModes) handleToggleCursorFollowSelection(
 		Message: "cursor_follow_selection " + state,
 		Code:    ipc.CodeOK,
 	}
+}
+
+// isValidStrategy checks that the given strategy value is one of the accepted
+// values: "axtree" (default), "vision".
+func isValidStrategy(v string) bool {
+	return v == "axtree" || v == "vision"
 }
 
 // IPCControllerOverlay handles overlay-related IPC commands.

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/app/modes"
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
@@ -516,7 +517,7 @@ func (h *IPCControllerModes) handleToggleCursorFollowSelection(
 // isValidStrategy checks that the given strategy value is one of the accepted
 // values: "axtree" (default), "vision".
 func isValidStrategy(v string) bool {
-	return v == "axtree" || v == "vision"
+	return v == config.StrategyAXTree || v == config.StrategyVision
 }
 
 // IPCControllerOverlay handles overlay-related IPC commands.

--- a/internal/app/modes/generic_mode.go
+++ b/internal/app/modes/generic_mode.go
@@ -52,6 +52,7 @@ func (m *GenericMode) Activate(opts ModeActivationOptions) {
 				opts.FilterRoles,
 				opts.FilterTextContains,
 				opts.Search,
+				opts.Strategy,
 			)
 		case domain.ModeGrid:
 			m.handler.activateGridModeWithAction(

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -276,6 +276,7 @@ func (h *Handler) RefreshHintsForScreenChange(
 	// Get current filter options from context
 	filterRoles := h.hints.Context.FilterRoles()
 	filterTextContains := h.hints.Context.FilterTextContains()
+	strategyOverride := h.hints.Context.StrategyOverride()
 
 	// Generate hints with filters preserved; SetHints below performs the
 	// single redraw after active-screen filtering.
@@ -284,7 +285,7 @@ func (h *Handler) RefreshHintsForScreenChange(
 		filterRoles,
 		filterTextContains,
 		"",
-		"",
+		strategyOverride,
 	)
 	if showHintsErr != nil {
 		h.logger.Error("Failed to refresh hints after screen change", zap.Error(showHintsErr))
@@ -745,6 +746,7 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 		filterRoles := h.hints.Context.FilterRoles()
 		filterTextContains := h.hints.Context.FilterTextContains()
 		startWithSearch := h.hints.Context.StartWithSearch()
+		strategyOverride := h.hints.Context.StrategyOverride()
 
 		h.executeActionAtPoint(pendingAction, center, true, func() {
 			h.activateHintModeInternal(
@@ -753,7 +755,7 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 				filterRoles,
 				filterTextContains,
 				&startWithSearch,
-				nil,
+				&strategyOverride,
 			)
 
 			// Restore state so subsequent cycles continue to execute the action
@@ -765,6 +767,7 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 				h.hints.Context.SetFilterRoles(filterRoles)
 				h.hints.Context.SetFilterTextContains(filterTextContains)
 				h.hints.Context.SetStartWithSearch(startWithSearch)
+				h.hints.Context.SetStrategyOverride(strategyOverride)
 			}
 		})
 	}

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -279,7 +279,13 @@ func (h *Handler) RefreshHintsForScreenChange(
 
 	// Generate hints with filters preserved; SetHints below performs the
 	// single redraw after active-screen filtering.
-	domainHints, showHintsErr := hintService.GenerateHints(ctx, filterRoles, filterTextContains, "")
+	domainHints, showHintsErr := hintService.GenerateHints(
+		ctx,
+		filterRoles,
+		filterTextContains,
+		"",
+		"",
+	)
 	if showHintsErr != nil {
 		h.logger.Error("Failed to refresh hints after screen change", zap.Error(showHintsErr))
 		h.exitModeLocked()
@@ -741,7 +747,14 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 		startWithSearch := h.hints.Context.StartWithSearch()
 
 		h.executeActionAtPoint(pendingAction, center, true, func() {
-			h.activateHintModeInternal(nil, nil, filterRoles, filterTextContains, &startWithSearch)
+			h.activateHintModeInternal(
+				nil,
+				nil,
+				filterRoles,
+				filterTextContains,
+				&startWithSearch,
+				nil,
+			)
 
 			// Restore state so subsequent cycles continue to execute the action
 			if h.appState.CurrentMode() == domain.ModeHints &&

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -28,6 +28,7 @@ type ModeActivationOptions struct {
 	FilterRoles           []string
 	FilterTextContains    []string
 	Search                *bool
+	Strategy              *string
 }
 
 const (
@@ -109,6 +110,7 @@ func (h *Handler) activateHintModeWithAction(
 	filterRoles []string,
 	filterTextContains []string,
 	search *bool,
+	strategy *string,
 ) {
 	h.activateHintModeInternal(
 		action,
@@ -116,6 +118,7 @@ func (h *Handler) activateHintModeWithAction(
 		filterRoles,
 		filterTextContains,
 		search,
+		strategy,
 	)
 
 	// Store repeat flag after activation so the context is already initialized.
@@ -134,6 +137,7 @@ func (h *Handler) activateHintModeInternal(
 	filterRoles []string,
 	filterTextContains []string,
 	search *bool,
+	strategyOverride *string,
 ) {
 	// Detect refresh before validation so we can clean up on failure
 	isRefresh := h.appState.CurrentMode() == domain.ModeHints
@@ -270,11 +274,17 @@ func (h *Handler) activateHintModeInternal(
 
 	activationStart := time.Now()
 
+	strategyVal := ""
+	if strategyOverride != nil {
+		strategyVal = *strategyOverride
+	}
+
 	domainHints, domainHintsErr := h.hintService.GenerateHints(
 		ctx,
 		filterRoles,
 		filterTextContains,
 		bundleID,
+		strategyVal,
 	)
 	if domainHintsErr != nil {
 		h.logger.Error(
@@ -386,9 +396,12 @@ func (h *Handler) activateHintModeInternal(
 	h.overlayManager.ResizeToActiveScreen()
 	h.overlayManager.Show()
 
+	strategy := h.config.Hints.StrategyForApp(bundleID)
+
 	fields := []zap.Field{
 		zap.Duration("elapsed", time.Since(activationStart)),
 		zap.Int("hint_count", len(domainHints)),
+		zap.String("strategy", strategy),
 	}
 	if actionStr != nil {
 		fields = append(fields, zap.String("action", *actionStr))

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -397,6 +397,9 @@ func (h *Handler) activateHintModeInternal(
 	h.overlayManager.Show()
 
 	strategy := h.config.Hints.StrategyForApp(bundleID)
+	if strategyOverride != nil && *strategyOverride != "" {
+		strategy = *strategyOverride
+	}
 
 	fields := []zap.Field{
 		zap.Duration("elapsed", time.Since(activationStart)),

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -241,6 +241,10 @@ func (h *Handler) activateHintModeInternal(
 			if search != nil {
 				h.hints.Context.SetStartWithSearch(*search)
 			}
+
+			if strategyOverride != nil {
+				h.hints.Context.SetStrategyOverride(*strategyOverride)
+			}
 		} else {
 			h.hints.Context.SetPendingAction(actionStr)
 			h.hints.Context.SetRepeat(false)
@@ -251,6 +255,12 @@ func (h *Handler) activateHintModeInternal(
 			h.hints.Context.SetFilterRoles(filterRoles)
 			h.hints.Context.SetFilterTextContains(filterTextContains)
 			h.hints.Context.SetStartWithSearch(search != nil && *search)
+
+			if strategyOverride != nil {
+				h.hints.Context.SetStrategyOverride(*strategyOverride)
+			} else {
+				h.hints.Context.SetStrategyOverride("")
+			}
 		}
 	}
 
@@ -275,7 +285,9 @@ func (h *Handler) activateHintModeInternal(
 	activationStart := time.Now()
 
 	strategyVal := ""
-	if strategyOverride != nil {
+	if h.hints != nil && h.hints.Context != nil {
+		strategyVal = h.hints.Context.StrategyOverride()
+	} else if strategyOverride != nil {
 		strategyVal = *strategyOverride
 	}
 
@@ -397,8 +409,8 @@ func (h *Handler) activateHintModeInternal(
 	h.overlayManager.Show()
 
 	strategy := h.config.Hints.StrategyForApp(bundleID)
-	if strategyOverride != nil && *strategyOverride != "" {
-		strategy = *strategyOverride
+	if strategyVal != "" {
+		strategy = strategyVal
 	}
 
 	fields := []zap.Field{

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -128,6 +128,7 @@ func (h *Handler) handleHintsModeKey(key string) {
 		filterRoles := h.hints.Context.FilterRoles()
 		filterTextContains := h.hints.Context.FilterTextContains()
 		startWithSearch := h.hints.Context.StartWithSearch()
+		strategyOverride := h.hints.Context.StrategyOverride()
 
 		h.moveCursorAndHandleAction(
 			center,
@@ -141,7 +142,7 @@ func (h *Handler) handleHintsModeKey(key string) {
 					filterRoles,
 					filterTextContains,
 					&startWithSearch,
-					nil,
+					&strategyOverride,
 				)
 				// Restore repeat and action on the fresh context so subsequent
 				// selections continue the repeat cycle.
@@ -154,6 +155,7 @@ func (h *Handler) handleHintsModeKey(key string) {
 					h.hints.Context.SetFilterRoles(filterRoles)
 					h.hints.Context.SetFilterTextContains(filterTextContains)
 					h.hints.Context.SetStartWithSearch(startWithSearch)
+					h.hints.Context.SetStrategyOverride(strategyOverride)
 				}
 			},
 		)

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -141,6 +141,7 @@ func (h *Handler) handleHintsModeKey(key string) {
 					filterRoles,
 					filterTextContains,
 					&startWithSearch,
+					nil,
 				)
 				// Restore repeat and action on the fresh context so subsequent
 				// selections continue the repeat cycle.

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -375,8 +375,15 @@ func (h *Handler) refreshHintsForMonitorMove(
 
 	filterRoles := h.hints.Context.FilterRoles()
 	filterTextContains := h.hints.Context.FilterTextContains()
+	strategyOverride := h.hints.Context.StrategyOverride()
 
-	domainHints, err := h.hintService.GenerateHints(ctx, filterRoles, filterTextContains, "", "")
+	domainHints, err := h.hintService.GenerateHints(
+		ctx,
+		filterRoles,
+		filterTextContains,
+		"",
+		strategyOverride,
+	)
 	if err != nil {
 		h.logger.Error(
 			"Failed to refresh hints after monitor move",

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -376,7 +376,7 @@ func (h *Handler) refreshHintsForMonitorMove(
 	filterRoles := h.hints.Context.FilterRoles()
 	filterTextContains := h.hints.Context.FilterTextContains()
 
-	domainHints, err := h.hintService.GenerateHints(ctx, filterRoles, filterTextContains, "")
+	domainHints, err := h.hintService.GenerateHints(ctx, filterRoles, filterTextContains, "", "")
 	if err != nil {
 		h.logger.Error(
 			"Failed to refresh hints after monitor move",

--- a/internal/app/modes/passthrough.go
+++ b/internal/app/modes/passthrough.go
@@ -184,7 +184,7 @@ func (h *Handler) handlePassthroughLocked(mode domain.Mode, session uint64) {
 		filterRoles := h.hints.Context.FilterRoles()
 		filterTextContains := h.hints.Context.FilterTextContains()
 		startWithSearch := h.hints.Context.StartWithSearch()
-		h.activateHintModeInternal(nil, nil, filterRoles, filterTextContains, &startWithSearch)
+		h.activateHintModeInternal(nil, nil, filterRoles, filterTextContains, &startWithSearch, nil)
 	})
 	h.refreshHintsTimer = timer
 }

--- a/internal/app/modes/passthrough.go
+++ b/internal/app/modes/passthrough.go
@@ -184,7 +184,15 @@ func (h *Handler) handlePassthroughLocked(mode domain.Mode, session uint64) {
 		filterRoles := h.hints.Context.FilterRoles()
 		filterTextContains := h.hints.Context.FilterTextContains()
 		startWithSearch := h.hints.Context.StartWithSearch()
-		h.activateHintModeInternal(nil, nil, filterRoles, filterTextContains, &startWithSearch, nil)
+		strategyOverride := h.hints.Context.StrategyOverride()
+		h.activateHintModeInternal(
+			nil,
+			nil,
+			filterRoles,
+			filterTextContains,
+			&startWithSearch,
+			&strategyOverride,
+		)
 	})
 	h.refreshHintsTimer = timer
 }

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"time"
 
@@ -15,7 +16,8 @@ import (
 )
 
 // HintService orchestrates hint generation and display.
-// It coordinates between the accessibility system, hint generator, and overlay.
+// It coordinates between the accessibility system, vision detection,
+// hint generator, and overlay.
 type HintService struct {
 	BaseService
 
@@ -23,6 +25,7 @@ type HintService struct {
 	generator hint.Generator
 	config    config.HintsConfig
 	logger    *zap.Logger
+	vision    ports.VisionPort
 }
 
 // NewHintService creates a new hint service with the given dependencies.
@@ -33,6 +36,7 @@ func NewHintService(
 	generator hint.Generator,
 	config config.HintsConfig,
 	logger *zap.Logger,
+	vision ports.VisionPort,
 ) *HintService {
 	if logger == nil {
 		logger = zap.NewNop()
@@ -43,6 +47,7 @@ func NewHintService(
 		generator:   generator,
 		config:      config,
 		logger:      logger.Named("service.hints"),
+		vision:      vision,
 	}
 }
 
@@ -55,7 +60,7 @@ func (s *HintService) ShowHints(
 ) ([]*hint.Interface, error) {
 	s.logger.Debug("Showing hints")
 
-	hints, err := s.GenerateHints(ctx, filterRoles, filterTextContains, "")
+	hints, err := s.GenerateHints(ctx, filterRoles, filterTextContains, "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -81,11 +86,13 @@ func (s *HintService) ShowHints(
 // them. Mode handlers use this to filter and position hints before the first
 // render, avoiding an extra full overlay draw during activation.
 // If bundleID is non-empty, it is used directly (skips AX call).
+// If strategyOverride is non-empty, it overrides the config-derived strategy.
 func (s *HintService) GenerateHints(
 	ctx context.Context,
 	filterRoles []string,
 	filterTextContains []string,
 	bundleID string,
+	strategyOverride string,
 ) ([]*hint.Interface, error) {
 	s.mu.RLock()
 	cfg := s.config
@@ -152,18 +159,26 @@ func (s *HintService) GenerateHints(
 			zap.Int("term_count", len(filterTextContains)))
 	}
 
-	// Get clickable elements
-	axStart := time.Now()
-	elements, elementsErr := s.accessibility.ClickableElements(ctx, filter)
-	s.logger.Debug("TIMING: ClickableElements",
-		zap.Duration("elapsed", time.Since(axStart)),
-		zap.Int("element_count", len(elements)),
-		zap.Error(elementsErr))
+	// Determine strategy for the frontmost app (override takes precedence)
+	strategy := cfg.StrategyForApp(bundleID)
+	if strategyOverride != "" {
+		strategy = strategyOverride
+	}
 
-	if elementsErr != nil {
-		s.logger.Error("Failed to get clickable elements", zap.Error(elementsErr))
+	var (
+		elements []*element.Element
+		genErr   error
+	)
 
-		return nil, derrors.WrapAccessibilityFailed(elementsErr, "get clickable elements")
+	switch strategy {
+	case config.StrategyVision:
+		elements = s.generateHintsVision(ctx, bundleID, filter)
+	default:
+		elements, genErr = s.generateHintsAX(ctx, filter)
+	}
+
+	if genErr != nil {
+		return nil, genErr
 	}
 
 	if len(elements) == 0 {
@@ -274,4 +289,112 @@ func (s *HintService) UpdateGenerator(_ context.Context, generator hint.Generato
 	s.generator = generator
 
 	s.logger.Debug("Hint generator updated")
+}
+
+// generateHintsAX collects elements using the AX tree (default strategy).
+func (s *HintService) generateHintsAX(
+	ctx context.Context,
+	filter ports.ElementFilter,
+) ([]*element.Element, error) {
+	axStart := time.Now()
+	elements, err := s.accessibility.ClickableElements(ctx, filter)
+	s.logger.Debug("TIMING: ClickableElements (axtree)",
+		zap.Duration("elapsed", time.Since(axStart)),
+		zap.Int("element_count", len(elements)),
+		zap.Error(err))
+
+	if err != nil {
+		s.logger.Error("Failed to get clickable elements via AX", zap.Error(err))
+
+		return nil, derrors.WrapAccessibilityFailed(err, "get clickable elements")
+	}
+
+	return elements, nil
+}
+
+// generateHintsVision collects window elements via vision detection and
+// supplementary elements (menubar, dock, etc.) via AX. This hybrid approach
+// ensures system UI is always detected while the frontmost window content
+// uses vision-based detection for apps with poor AX trees.
+func (s *HintService) generateHintsVision(
+	ctx context.Context,
+	_ string,
+	filter ports.ElementFilter,
+) []*element.Element {
+	// Collect supplementary elements (menubar, dock, NC, etc.) via AX.
+	// These are system-level components that vision should not attempt to detect.
+	var allElements []*element.Element
+
+	supplementStart := time.Now()
+	supplementFilter := filter
+	supplementFilter.Roles = nil               // no role filtering for supplementary elements
+	supplementFilter.SkipWindowElements = true // vision handles the window
+
+	supplementElements, err := s.accessibility.ClickableElements(ctx, supplementFilter)
+	if err != nil {
+		s.logger.Debug("Failed to get supplementary elements via AX", zap.Error(err))
+	} else {
+		allElements = append(allElements, supplementElements...)
+	}
+
+	s.logger.Debug("TIMING: Supplementary elements (AX)",
+		zap.Duration("elapsed", time.Since(supplementStart)),
+		zap.Int("count", len(supplementElements)))
+
+	// Get focused window bounds for vision detection
+	windowBounds, found, boundsErr := s.system.FocusedWindowBounds(ctx)
+	if boundsErr != nil || !found {
+		s.logger.Debug(
+			"No focused window bounds, falling back to full screen",
+			zap.Error(boundsErr),
+		)
+
+		windowBounds, boundsErr = s.system.ScreenBounds(ctx)
+		if boundsErr != nil {
+			s.logger.Error("Failed to get screen bounds for vision detection", zap.Error(boundsErr))
+
+			return allElements
+		}
+	}
+
+	// Detect window elements via vision
+	visionStart := time.Now()
+	windowElements, visionErr := s.vision.DetectElements(ctx, windowBounds)
+	s.logger.Debug("TIMING: Window elements (vision)",
+		zap.Duration("elapsed", time.Since(visionStart)),
+		zap.Int("count", len(windowElements)),
+		zap.Error(visionErr))
+
+	if visionErr != nil {
+		s.logger.Error("Failed to detect elements via vision", zap.Error(visionErr))
+
+		// Fall back to AX for window elements if vision fails
+		axStart := time.Now()
+		fallbackElements, fallbackErr := s.accessibility.ClickableElements(ctx, filter)
+		s.logger.Debug("TIMING: Fallback elements (AX)",
+			zap.Duration("elapsed", time.Since(axStart)),
+			zap.Int("count", len(fallbackElements)),
+			zap.Error(fallbackErr))
+
+		if fallbackErr == nil {
+			allElements = append(allElements, fallbackElements...)
+		}
+
+		return allElements
+	}
+
+	// Filter vision-detected elements by configured roles
+	for _, element := range windowElements {
+		if len(filter.Roles) == 0 {
+			allElements = append(allElements, element)
+
+			continue
+		}
+
+		if slices.Contains(filter.Roles, element.Role()) {
+			allElements = append(allElements, element)
+		}
+	}
+
+	return allElements
 }

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -341,6 +341,12 @@ func (s *HintService) generateHintsVision(
 		zap.Duration("elapsed", time.Since(supplementStart)),
 		zap.Int("count", len(supplementElements)))
 
+	if s.vision == nil {
+		s.logger.Warn("Vision strategy selected but vision port is unavailable")
+
+		return allElements
+	}
+
 	// Get focused window bounds for vision detection
 	windowBounds, found, boundsErr := s.system.FocusedWindowBounds(ctx)
 	if boundsErr != nil || !found {

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -370,7 +370,16 @@ func (s *HintService) generateHintsVision(
 
 		// Fall back to AX for window elements if vision fails
 		axStart := time.Now()
-		fallbackElements, fallbackErr := s.accessibility.ClickableElements(ctx, filter)
+		fallbackFilter := filter
+		fallbackFilter.IncludeMenubar = false
+		fallbackFilter.AdditionalMenubarTargets = nil
+		fallbackFilter.IncludeDock = false
+		fallbackFilter.IncludeNotificationCenter = false
+		fallbackFilter.IncludeStageManager = false
+		fallbackFilter.IncludePIP = false
+		fallbackFilter.IncludeScreenCapture = false
+
+		fallbackElements, fallbackErr := s.accessibility.ClickableElements(ctx, fallbackFilter)
 		s.logger.Debug("TIMING: Fallback elements (AX)",
 			zap.Duration("elapsed", time.Since(axStart)),
 			zap.Int("count", len(fallbackElements)),

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -563,6 +563,56 @@ func TestHintService_GenerateHintsVisionFallbackDoesNotDuplicateSupplementaryEle
 	}
 }
 
+func TestHintService_GenerateHintsVisionWithNilPortReturnsSupplementaryElements(
+	t *testing.T,
+) {
+	supplementElement := mustNewElement("menubar", image.Rect(10, 0, 60, 20))
+
+	mockAcc := &mocks.MockAccessibilityPort{}
+	mockAcc.ClickableElementsFunc = func(
+		_ context.Context,
+		filter ports.ElementFilter,
+	) ([]*element.Element, error) {
+		if !filter.SkipWindowElements {
+			t.Error("nil vision port should not trigger window AX collection")
+		}
+
+		return []*element.Element{supplementElement}, nil
+	}
+
+	generator, _ := hint.NewAlphabetGenerator("asdf")
+	service := services.NewHintService(
+		mockAcc,
+		&mocks.MockOverlayPort{},
+		&mocks.MockSystemPort{},
+		generator,
+		config.HintsConfig{
+			IncludeMenubarHints: true,
+		},
+		logger.Get(),
+		nil,
+	)
+
+	hints, err := service.GenerateHints(
+		context.Background(),
+		nil,
+		nil,
+		"com.example.app",
+		config.StrategyVision,
+	)
+	if err != nil {
+		t.Fatalf("GenerateHints() unexpected error: %v", err)
+	}
+
+	if len(hints) != 1 {
+		t.Fatalf("GenerateHints() returned %d hints, want 1", len(hints))
+	}
+
+	if hints[0].Element().ID() != supplementElement.ID() {
+		t.Errorf("hint element = %q, want %q", hints[0].Element().ID(), supplementElement.ID())
+	}
+}
+
 func TestHintService_UpdateGenerator(t *testing.T) {
 	mockAcc := &mocks.MockAccessibilityPort{}
 	mockOverlay := &mocks.MockOverlayPort{}

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -310,6 +310,7 @@ func TestHintService_ShowHints(t *testing.T) {
 				generator,
 				testCase.config,
 				logger,
+				nil,
 			)
 
 			ctx := context.Background()
@@ -384,6 +385,7 @@ func TestHintService_HideHints(t *testing.T) {
 				generator,
 				config.HintsConfig{},
 				logger,
+				nil,
 			)
 
 			ctx := context.Background()
@@ -457,6 +459,7 @@ func TestHintService_RefreshHints(t *testing.T) {
 				generator,
 				config.HintsConfig{},
 				logger,
+				nil,
 			)
 
 			ctx := context.Background()
@@ -488,6 +491,7 @@ func TestHintService_UpdateGenerator(t *testing.T) {
 		initialGen,
 		config.HintsConfig{},
 		logger,
+		nil,
 	)
 
 	// Update with new generator
@@ -512,6 +516,7 @@ func TestHintService_Health(t *testing.T) {
 		generator,
 		config.HintsConfig{},
 		logger,
+		nil,
 	)
 
 	// Setup mocks

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -476,6 +476,93 @@ func TestHintService_RefreshHints(t *testing.T) {
 	}
 }
 
+func TestHintService_GenerateHintsVisionFallbackDoesNotDuplicateSupplementaryElements(
+	t *testing.T,
+) {
+	supplementElement := mustNewElement("menubar", image.Rect(10, 0, 60, 20))
+	windowElement := mustNewElement("window", image.Rect(10, 40, 60, 90))
+
+	var fallbackFilter ports.ElementFilter
+
+	mockAcc := &mocks.MockAccessibilityPort{}
+	mockAcc.ClickableElementsFunc = func(
+		_ context.Context,
+		filter ports.ElementFilter,
+	) ([]*element.Element, error) {
+		if filter.SkipWindowElements {
+			return []*element.Element{supplementElement}, nil
+		}
+
+		fallbackFilter = filter
+
+		return []*element.Element{windowElement}, nil
+	}
+
+	mockSystem := &mocks.MockSystemPort{}
+	mockSystem.FocusedWindowBoundsFunc = func(context.Context) (image.Rectangle, bool, error) {
+		return image.Rect(0, 0, 200, 200), true, nil
+	}
+
+	generator, _ := hint.NewAlphabetGenerator("asdf")
+	service := services.NewHintService(
+		mockAcc,
+		&mocks.MockOverlayPort{},
+		mockSystem,
+		generator,
+		config.HintsConfig{
+			IncludeMenubarHints:           true,
+			AdditionalMenubarHintsTargets: []string{"Clock"},
+			IncludeDockHints:              true,
+			IncludeNCHints:                true,
+			IncludeStageManagerHints:      true,
+			IncludePIPHints:               true,
+			IncludeScreenCaptureHints:     true,
+		},
+		logger.Get(),
+		&mockVisionPort{
+			detectErr: derrors.New(derrors.CodeBridgeFailed, "vision failed"),
+		},
+	)
+
+	hints, err := service.GenerateHints(
+		context.Background(),
+		nil,
+		nil,
+		"com.example.app",
+		config.StrategyVision,
+	)
+	if err != nil {
+		t.Fatalf("GenerateHints() unexpected error: %v", err)
+	}
+
+	if len(hints) != 2 {
+		t.Fatalf("GenerateHints() returned %d hints, want 2", len(hints))
+	}
+
+	seen := map[element.ID]int{}
+	for _, generatedHint := range hints {
+		seen[generatedHint.Element().ID()]++
+	}
+
+	if seen[supplementElement.ID()] != 1 {
+		t.Errorf("supplementary element count = %d, want 1", seen[supplementElement.ID()])
+	}
+
+	if seen[windowElement.ID()] != 1 {
+		t.Errorf("window element count = %d, want 1", seen[windowElement.ID()])
+	}
+
+	if fallbackFilter.IncludeMenubar ||
+		len(fallbackFilter.AdditionalMenubarTargets) != 0 ||
+		fallbackFilter.IncludeDock ||
+		fallbackFilter.IncludeNotificationCenter ||
+		fallbackFilter.IncludeStageManager ||
+		fallbackFilter.IncludePIP ||
+		fallbackFilter.IncludeScreenCapture {
+		t.Errorf("fallback filter should disable supplementary sources: %+v", fallbackFilter)
+	}
+}
+
 func TestHintService_UpdateGenerator(t *testing.T) {
 	mockAcc := &mocks.MockAccessibilityPort{}
 	mockOverlay := &mocks.MockOverlayPort{}
@@ -561,4 +648,23 @@ func mustNewElement(id string, bounds image.Rectangle) *element.Element {
 	}
 
 	return element
+}
+
+type mockVisionPort struct {
+	detectErr error
+}
+
+func (m *mockVisionPort) DetectElements(
+	context.Context,
+	image.Rectangle,
+) ([]*element.Element, error) {
+	return nil, m.detectErr
+}
+
+func (m *mockVisionPort) CaptureScreen(context.Context) (*image.RGBA, error) {
+	return nil, derrors.New(derrors.CodeBridgeFailed, "capture screen not implemented")
+}
+
+func (m *mockVisionPort) Health(context.Context) error {
+	return nil
 }

--- a/internal/app/services/services_integration_darwin_test.go
+++ b/internal/app/services/services_integration_darwin_test.go
@@ -60,6 +60,7 @@ func TestHintServiceIntegration(t *testing.T) {
 		hintGen,
 		cfg.Hints,
 		logger,
+		nil,
 	)
 
 	ctx := context.Background()

--- a/internal/cli/hints.go
+++ b/internal/cli/hints.go
@@ -8,6 +8,7 @@ var HintsCmd = BuildModeCommand(ModeConfig{
 	ActionDesc:       "hint selection",
 	SupportSearch:    true,
 	SupportFiltering: true,
+	SupportStrategy:  true,
 })
 
 func init() {

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -19,6 +19,7 @@ type ModeConfig struct {
 	Aliases          []string // Optional CLI aliases (e.g., "recursive-grid" for "recursive_grid")
 	SupportSearch    bool     // Whether this mode supports the --search flag
 	SupportFiltering bool     // Whether this mode supports --role and --text filter flags
+	SupportStrategy  bool     // Whether this mode supports the --strategy flag
 }
 
 // BuildModeCommand creates a CLI command for a navigation mode (hints, grid, etc.).
@@ -58,6 +59,14 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				}
 
 				textFlag, err = cmd.Flags().GetString("text")
+				if err != nil {
+					return err
+				}
+			}
+
+			var strategyFlag string
+			if config.SupportStrategy {
+				strategyFlag, err = cmd.Flags().GetString("strategy")
 				if err != nil {
 					return err
 				}
@@ -148,6 +157,10 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				params = append(params, "--cursor-selection-mode="+cursorSelectionMode)
 			}
 
+			if strategyFlag != "" {
+				params = append(params, "--strategy="+strategyFlag)
+			}
+
 			return sendCommand(cmd, config.Name, params)
 		},
 	}
@@ -190,6 +203,14 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 			"text",
 			"",
 			"Filter elements by text content (comma-separated, case-insensitive substring match)",
+		)
+	}
+
+	if config.SupportStrategy {
+		cmd.Flags().String(
+			"strategy",
+			"",
+			"Element detection strategy: axtree (macOS AX API) or vision (Vision Framework)",
 		)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -489,6 +489,7 @@ type StickyModifiersConfig struct {
 // AppConfig defines application-specific settings for role customization.
 type AppConfig struct {
 	BundleID             string                         `json:"bundleId"             toml:"bundle_id"`
+	Strategy             string                         `json:"strategy"             toml:"strategy"`
 	AdditionalClickable  []string                       `json:"additionalClickable"  toml:"additional_clickable_roles"`
 	IgnoreClickableCheck bool                           `json:"ignoreClickableCheck" toml:"ignore_clickable_check"`
 	VisibleCheckEnabled  bool                           `json:"visibleCheckEnabled"  toml:"visible_check_enabled"`
@@ -566,9 +567,16 @@ type SearchInputUI struct {
 	BorderColor     Color  `json:"borderColor"     toml:"border_color"`
 }
 
+// Strategy constants for element detection.
+const (
+	StrategyAXTree = "axtree"
+	StrategyVision = "vision"
+)
+
 // HintsConfig defines the visual and behavioral settings for hints mode.
 type HintsConfig struct {
 	Enabled           bool                `json:"enabled"           toml:"enabled"`
+	Strategy          string              `json:"strategy"          toml:"strategy"`
 	HintCharacters    string              `json:"hintCharacters"    toml:"hint_characters"`
 	MaxDepth          int                 `json:"maxDepth"          toml:"max_depth"`
 	UI                HintsUI             `json:"ui"                toml:"ui"`
@@ -1545,6 +1553,17 @@ func (c *HintsConfig) ClickableRolesForApp(bundleID string) []string {
 	rolesMap := c.buildRolesMap(bundleID)
 
 	return rolesMapToSlice(rolesMap)
+}
+
+// StrategyForApp returns the element detection strategy for the given bundle ID.
+// Falls back to the global HintsConfig.Strategy if no app-specific override is set.
+func (c *HintsConfig) StrategyForApp(bundleID string) string {
+	appConfig := c.AppConfigForBundleID(bundleID)
+	if appConfig != nil && appConfig.Strategy != "" {
+		return appConfig.Strategy
+	}
+
+	return c.Strategy
 }
 
 // buildRolesMap builds a map of clickable roles for the given bundle ID.

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -278,6 +278,7 @@ func newDefaultConfig() *Config {
 		},
 		Hints: HintsConfig{
 			Enabled:        true,
+			Strategy:       StrategyAXTree,
 			HintCharacters: "asdfghjkl",
 			MaxDepth:       DefaultMaxDepth,
 			Hotkeys: map[string]StringOrStringArray{

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -291,6 +291,16 @@ func (c *Config) ValidateHints() error {
 		}
 	}
 
+	switch c.Hints.Strategy {
+	case StrategyAXTree, StrategyVision, "":
+	default:
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"hints.strategy must be %q or %q",
+			StrategyAXTree, StrategyVision,
+		)
+	}
+
 	return nil
 }
 

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -482,7 +482,23 @@ func validateScrollAppConfigs(modeName string, appConfigs []AppConfig) error {
 
 // ValidateAppConfigs validates per-app hint configuration.
 func (c *Config) ValidateAppConfigs() error {
-	return validateAppConfigsWithCallback("hints", c.Hints.AppConfigs, rejectScrollFields("hints"))
+	return validateAppConfigsWithCallback("hints", c.Hints.AppConfigs, func(idx int, appConfig *AppConfig) error {
+		if err := rejectScrollFields("hints")(idx, appConfig); err != nil {
+			return err
+		}
+
+		switch appConfig.Strategy {
+		case StrategyAXTree, StrategyVision, "":
+		default:
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"hints.app_configs[%d].strategy must be %q or %q",
+				idx, StrategyAXTree, StrategyVision,
+			)
+		}
+
+		return nil
+	})
 }
 
 // ValidateGrid validates the grid configuration.

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -482,23 +482,28 @@ func validateScrollAppConfigs(modeName string, appConfigs []AppConfig) error {
 
 // ValidateAppConfigs validates per-app hint configuration.
 func (c *Config) ValidateAppConfigs() error {
-	return validateAppConfigsWithCallback("hints", c.Hints.AppConfigs, func(idx int, appConfig *AppConfig) error {
-		if err := rejectScrollFields("hints")(idx, appConfig); err != nil {
-			return err
-		}
+	return validateAppConfigsWithCallback(
+		"hints",
+		c.Hints.AppConfigs,
+		func(idx int, appConfig *AppConfig) error {
+			err := rejectScrollFields("hints")(idx, appConfig)
+			if err != nil {
+				return err
+			}
 
-		switch appConfig.Strategy {
-		case StrategyAXTree, StrategyVision, "":
-		default:
-			return derrors.Newf(
-				derrors.CodeInvalidConfig,
-				"hints.app_configs[%d].strategy must be %q or %q",
-				idx, StrategyAXTree, StrategyVision,
-			)
-		}
+			switch appConfig.Strategy {
+			case StrategyAXTree, StrategyVision, "":
+			default:
+				return derrors.Newf(
+					derrors.CodeInvalidConfig,
+					"hints.app_configs[%d].strategy must be %q or %q",
+					idx, StrategyAXTree, StrategyVision,
+				)
+			}
 
-		return nil
-	})
+			return nil
+		},
+	)
 }
 
 // ValidateGrid validates the grid configuration.

--- a/internal/core/domain/element/element.go
+++ b/internal/core/domain/element/element.go
@@ -66,8 +66,8 @@ const (
 	SubroleMenuExtra Subrole = "AXMenuExtra"
 )
 
-// Element represents a UI element in the accessibility tree.
-// It is immutable after creation to ensure thread safety.
+// Element represents a UI element in the accessibility tree (or detected
+// via vision). It is immutable after creation to ensure thread safety.
 type Element struct {
 	id          ID
 	bounds      image.Rectangle
@@ -77,6 +77,7 @@ type Element struct {
 	description string
 	value       string
 	searchText  string
+	visionOnly  bool
 }
 
 // NewElement creates a new element with validation.
@@ -141,6 +142,15 @@ func WithSearchText(text string) Option {
 	}
 }
 
+// WithVisionOnly marks the element as detected via vision rather than
+// the accessibility tree. Vision-only elements have no AX reference and
+// actions must always use coordinate-based clicks (PerformActionAtPoint).
+func WithVisionOnly() Option {
+	return func(e *Element) {
+		e.visionOnly = true
+	}
+}
+
 // ID returns the element ID.
 func (e *Element) ID() ID {
 	return e.id
@@ -179,6 +189,13 @@ func (e *Element) Value() string {
 // SearchText returns additional searchable text associated with the element.
 func (e *Element) SearchText() string {
 	return e.searchText
+}
+
+// IsVisionOnly returns true if the element was detected via vision rather
+// than the accessibility tree. Vision-only elements have no AX reference;
+// actions must use coordinate-based clicks (PerformActionAtPoint).
+func (e *Element) IsVisionOnly() bool {
+	return e.visionOnly
 }
 
 // Center returns the center point of the element.

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -186,7 +186,7 @@ func (a *Adapter) ClickableElements(
 		a.logger.Debug("Collected elements from "+sourceName, zap.Int("count", len(elements)))
 	}
 
-	if !missionControlActive {
+	if !missionControlActive && !filter.SkipWindowElements {
 		// Query frontmost window AND popover windows
 		waitGroup.Add(1)
 

--- a/internal/core/infra/platform/darwin/cgo_flags.go
+++ b/internal/core/infra/platform/darwin/cgo_flags.go
@@ -4,6 +4,6 @@ package darwin
 
 /*
 #cgo CFLAGS: -x objective-c -fobjc-arc
-#cgo LDFLAGS: -framework Foundation -framework AppKit -framework Carbon -framework CoreGraphics -framework ApplicationServices -framework UserNotifications -framework QuartzCore
+#cgo LDFLAGS: -framework Foundation -framework AppKit -framework Carbon -framework CoreGraphics -framework ApplicationServices -framework UserNotifications -framework QuartzCore -framework Vision
 */
 import "C"

--- a/internal/core/infra/platform/darwin/vision.h
+++ b/internal/core/infra/platform/darwin/vision.h
@@ -15,11 +15,12 @@ typedef struct {
 	int count;
 } VisionResult;
 
-// Captures the main display and runs Vision Framework detection.
-// Returns detected regions (text, rectangles) for the full screen.
+// Captures the display containing the given rect and runs Vision Framework
+// detection. On multi-monitor setups this ensures the display with the
+// focused window is captured, not just the primary display.
+// Returns detected regions (text, rectangles) for the captured display.
 // Caller must call NeruFreeVisionResult() on the returned pointer.
-// The screenBounds parameter is reserved for future cropping.
-VisionResult *NeruDetectElements(CGRect screenBounds);
+VisionResult *NeruDetectElements(CGRect detectionRect);
 
 // Captures raw screen pixels for the main display.
 // Returns a CGImageRef (caller must CFRelease).

--- a/internal/core/infra/platform/darwin/vision.h
+++ b/internal/core/infra/platform/darwin/vision.h
@@ -1,0 +1,29 @@
+#import <CoreGraphics/CoreGraphics.h>
+
+typedef struct {
+	double x;
+	double y;
+	double width;
+	double height;
+	double score;
+	char *label;  // text label if recognized, empty otherwise
+	int isText;   // 1 if this region was detected as text
+} VisionRegion;
+
+typedef struct {
+	VisionRegion *regions;
+	int count;
+} VisionResult;
+
+// Captures the main display and runs Vision Framework detection.
+// Returns detected regions (text, rectangles) for the full screen.
+// Caller must call NeruFreeVisionResult() on the returned pointer.
+// The screenBounds parameter is reserved for future cropping.
+VisionResult *NeruDetectElements(CGRect screenBounds);
+
+// Captures raw screen pixels for the main display.
+// Returns a CGImageRef (caller must CFRelease).
+CGImageRef NeruCaptureScreen(void);
+
+// Frees a VisionResult previously returned by NeruDetectElements.
+void NeruFreeVisionResult(VisionResult *result);

--- a/internal/core/infra/platform/darwin/vision_darwin.m
+++ b/internal/core/infra/platform/darwin/vision_darwin.m
@@ -1,0 +1,149 @@
+#import "vision.h"
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+#import <Vision/Vision.h>
+
+static CGImageRef captureScreen(void) {
+	CGDirectDisplayID display = CGMainDisplayID();
+	CGImageRef image = CGDisplayCreateImage(display);
+	return image;
+}
+
+static NSArray<VNRectangleObservation *> *detectRectangles(CGImageRef image) {
+	VNDetectRectanglesRequest *request = [[VNDetectRectanglesRequest alloc] init];
+	request.maximumObservations = 100;
+	request.minimumSize = 0.01;
+	request.minimumAspectRatio = 0.3;
+	request.maximumAspectRatio = 10.0;
+
+	VNImageRequestHandler *handler = [[VNImageRequestHandler alloc] initWithCGImage:image options:@{}];
+	NSError *error = nil;
+	[handler performRequests:@[ request ] error:&error];
+	if (error) {
+		return @[];
+	}
+	return request.results ?: @[];
+}
+
+static NSArray<VNRecognizedTextObservation *> *detectText(CGImageRef image) {
+	VNRecognizeTextRequest *request = [[VNRecognizeTextRequest alloc] init];
+	request.recognitionLevel = VNRequestTextRecognitionLevelFast;
+	request.usesLanguageCorrection = NO;
+
+	VNImageRequestHandler *handler = [[VNImageRequestHandler alloc] initWithCGImage:image options:@{}];
+	NSError *error = nil;
+	[handler performRequests:@[ request ] error:&error];
+	if (error) {
+		return @[];
+	}
+	return request.results ?: @[];
+}
+
+static CGRect visionRectToCGRect(CGRect imageBounds, CGRect normalizedRect) {
+	CGFloat x = normalizedRect.origin.x * imageBounds.size.width;
+	CGFloat y = (1.0 - normalizedRect.origin.y - normalizedRect.size.height) * imageBounds.size.height;
+	CGFloat w = normalizedRect.size.width * imageBounds.size.width;
+	CGFloat h = normalizedRect.size.height * imageBounds.size.height;
+	return CGRectMake(x, y, w, h);
+}
+
+VisionResult *NeruDetectElements(CGRect screenBounds) {
+	@autoreleasepool {
+		CGImageRef image = captureScreen();
+		if (!image) {
+			VisionResult *result = malloc(sizeof(VisionResult));
+			result->regions = NULL;
+			result->count = 0;
+			return result;
+		}
+
+		CGFloat imgW = (CGFloat)CGImageGetWidth(image);
+		CGFloat imgH = (CGFloat)CGImageGetHeight(image);
+		CGRect imgRect = CGRectMake(0, 0, imgW, imgH);
+
+		// Run Vision requests in parallel using dispatch group
+		dispatch_group_t group = dispatch_group_create();
+		__block NSArray<VNRectangleObservation *> *rects = nil;
+		__block NSArray<VNRecognizedTextObservation *> *texts = nil;
+
+		dispatch_group_async(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+			rects = detectRectangles(image);
+		});
+		dispatch_group_async(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+			texts = detectText(image);
+		});
+		dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+
+		// Build region list from all observations
+		NSMutableArray *regionList = [NSMutableArray array];
+
+		// Add detected rectangles
+		for (VNRectangleObservation *obs in rects) {
+			CGRect r = [obs boundingBox];
+			CGRect pixelRect = visionRectToCGRect(imgRect, r);
+			[regionList addObject:@{
+				@"x" : @(pixelRect.origin.x),
+				@"y" : @(pixelRect.origin.y),
+				@"w" : @(pixelRect.size.width),
+				@"h" : @(pixelRect.size.height),
+				@"score" : @(obs.confidence),
+				@"isText" : @(0),
+				@"label" : @""
+			}];
+		}
+
+		// Add detected text regions
+		for (VNRecognizedTextObservation *obs in texts) {
+			CGRect r = [obs boundingBox];
+			CGRect pixelRect = visionRectToCGRect(imgRect, r);
+			VNRecognizedText *top = [[obs topCandidates:1] firstObject];
+			NSString *text = top ? top.string : @"";
+			[regionList addObject:@{
+				@"x" : @(pixelRect.origin.x),
+				@"y" : @(pixelRect.origin.y),
+				@"w" : @(pixelRect.size.width),
+				@"h" : @(pixelRect.size.height),
+				@"score" : @(obs.confidence),
+				@"isText" : @(1),
+				@"label" : text ?: @""
+			}];
+		}
+
+		// Build C result
+		VisionResult *result = malloc(sizeof(VisionResult));
+		result->count = (int)[regionList count];
+		result->regions = malloc(sizeof(VisionRegion) * result->count);
+
+		for (int i = 0; i < result->count; i++) {
+			NSDictionary *dict = regionList[i];
+			result->regions[i].x = [dict[@"x"] doubleValue];
+			result->regions[i].y = [dict[@"y"] doubleValue];
+			result->regions[i].width = [dict[@"w"] doubleValue];
+			result->regions[i].height = [dict[@"h"] doubleValue];
+			result->regions[i].score = [dict[@"score"] doubleValue];
+			result->regions[i].isText = [dict[@"isText"] intValue];
+			NSString *labelStr = dict[@"label"];
+			result->regions[i].label = labelStr ? strdup([labelStr UTF8String]) : NULL;
+		}
+
+		CGImageRelease(image);
+		return result;
+	}
+}
+
+CGImageRef NeruCaptureScreen(void) { return captureScreen(); }
+
+void NeruFreeVisionResult(VisionResult *result) {
+	if (result) {
+		if (result->regions) {
+			for (int i = 0; i < result->count; i++) {
+				if (result->regions[i].label) {
+					free(result->regions[i].label);
+				}
+			}
+			free(result->regions);
+		}
+		free(result);
+	}
+}

--- a/internal/core/infra/platform/darwin/vision_darwin.m
+++ b/internal/core/infra/platform/darwin/vision_darwin.m
@@ -4,6 +4,13 @@
 #import <Foundation/Foundation.h>
 #import <Vision/Vision.h>
 
+static VisionResult *emptyVisionResult(void) {
+	VisionResult *result = malloc(sizeof(VisionResult));
+	result->regions = NULL;
+	result->count = 0;
+	return result;
+}
+
 static NSArray<VNRectangleObservation *> *detectRectangles(CGImageRef image) {
 	VNDetectRectanglesRequest *request = [[VNDetectRectanglesRequest alloc] init];
 	request.maximumObservations = 100;
@@ -59,10 +66,7 @@ VisionResult *NeruDetectElements(CGRect screenBounds) {
 
 		CGImageRef image = CGDisplayCreateImage(display);
 		if (!image) {
-			VisionResult *result = malloc(sizeof(VisionResult));
-			result->regions = NULL;
-			result->count = 0;
-			return result;
+			return emptyVisionResult();
 		}
 
 		CGFloat imgW = (CGFloat)CGImageGetWidth(image);
@@ -88,13 +92,22 @@ VisionResult *NeruDetectElements(CGRect screenBounds) {
 		__block NSArray<VNRectangleObservation *> *rects = nil;
 		__block NSArray<VNRecognizedTextObservation *> *texts = nil;
 
+		CFRetain(image);
 		dispatch_group_async(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
 			rects = detectRectangles(image);
 		});
 		dispatch_group_async(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
 			texts = detectText(image);
 		});
-		dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+		dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC);
+		if (dispatch_group_wait(group, timeout) != 0) {
+			dispatch_group_notify(group, dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+				CGImageRelease(image);
+			});
+			CGImageRelease(image);
+			return emptyVisionResult();
+		}
+		CGImageRelease(image);
 
 		// Build region list from all observations
 		NSMutableArray *regionList = [NSMutableArray array];

--- a/internal/core/infra/platform/darwin/vision_darwin.m
+++ b/internal/core/infra/platform/darwin/vision_darwin.m
@@ -4,12 +4,6 @@
 #import <Foundation/Foundation.h>
 #import <Vision/Vision.h>
 
-static CGImageRef captureScreen(void) {
-	CGDirectDisplayID display = CGMainDisplayID();
-	CGImageRef image = CGDisplayCreateImage(display);
-	return image;
-}
-
 static NSArray<VNRectangleObservation *> *detectRectangles(CGImageRef image) {
 	VNDetectRectanglesRequest *request = [[VNDetectRectanglesRequest alloc] init];
 	request.maximumObservations = 100;
@@ -50,7 +44,20 @@ static CGRect visionRectToCGRect(CGRect imageBounds, CGRect normalizedRect) {
 
 VisionResult *NeruDetectElements(CGRect screenBounds) {
 	@autoreleasepool {
-		CGImageRef image = captureScreen();
+		// Resolve which display contains the window
+		CGDirectDisplayID displays[32];
+		uint32_t displayCount;
+		CGError err = CGGetDisplaysWithRect(screenBounds, 32, displays, &displayCount);
+		CGDirectDisplayID display;
+		if (err != kCGErrorSuccess || displayCount == 0) {
+			display = CGMainDisplayID();
+		} else {
+			display = displays[0];
+		}
+
+		CGRect displayBounds = CGDisplayBounds(display);
+
+		CGImageRef image = CGDisplayCreateImage(display);
 		if (!image) {
 			VisionResult *result = malloc(sizeof(VisionResult));
 			result->regions = NULL;
@@ -60,7 +67,21 @@ VisionResult *NeruDetectElements(CGRect screenBounds) {
 
 		CGFloat imgW = (CGFloat)CGImageGetWidth(image);
 		CGFloat imgH = (CGFloat)CGImageGetHeight(image);
+
+		// Compute scale from the actual image pixels vs display bounds (points).
+		// CGDisplayPixelsWide can return point-count on some systems, so we rely
+		// on the captured image for the true pixel resolution.
+		CGFloat scaleX = imgW / displayBounds.size.width;
+		CGFloat scaleY = imgH / displayBounds.size.height;
+
 		CGRect imgRect = CGRectMake(0, 0, imgW, imgH);
+
+		// Vision coordinates are relative to the image (top-left origin, pixels).
+		// visionRectToCGRect converts to bottom-left position within the image.
+		// We then scale from pixels to points and offset by the display's
+		// global origin to get global top-left-origin screen coordinates.
+		CGFloat originX = displayBounds.origin.x;
+		CGFloat originY = displayBounds.origin.y;
 
 		// Run Vision requests in parallel using dispatch group
 		dispatch_group_t group = dispatch_group_create();
@@ -83,10 +104,10 @@ VisionResult *NeruDetectElements(CGRect screenBounds) {
 			CGRect r = [obs boundingBox];
 			CGRect pixelRect = visionRectToCGRect(imgRect, r);
 			[regionList addObject:@{
-				@"x" : @(pixelRect.origin.x),
-				@"y" : @(pixelRect.origin.y),
-				@"w" : @(pixelRect.size.width),
-				@"h" : @(pixelRect.size.height),
+				@"x" : @(originX + pixelRect.origin.x / scaleX),
+				@"y" : @(originY + pixelRect.origin.y / scaleY),
+				@"w" : @(pixelRect.size.width / scaleX),
+				@"h" : @(pixelRect.size.height / scaleY),
 				@"score" : @(obs.confidence),
 				@"isText" : @(0),
 				@"label" : @""
@@ -100,10 +121,10 @@ VisionResult *NeruDetectElements(CGRect screenBounds) {
 			VNRecognizedText *top = [[obs topCandidates:1] firstObject];
 			NSString *text = top ? top.string : @"";
 			[regionList addObject:@{
-				@"x" : @(pixelRect.origin.x),
-				@"y" : @(pixelRect.origin.y),
-				@"w" : @(pixelRect.size.width),
-				@"h" : @(pixelRect.size.height),
+				@"x" : @(originX + pixelRect.origin.x / scaleX),
+				@"y" : @(originY + pixelRect.origin.y / scaleY),
+				@"w" : @(pixelRect.size.width / scaleX),
+				@"h" : @(pixelRect.size.height / scaleY),
 				@"score" : @(obs.confidence),
 				@"isText" : @(1),
 				@"label" : text ?: @""
@@ -132,7 +153,7 @@ VisionResult *NeruDetectElements(CGRect screenBounds) {
 	}
 }
 
-CGImageRef NeruCaptureScreen(void) { return captureScreen(); }
+CGImageRef NeruCaptureScreen(void) { return CGDisplayCreateImage(CGMainDisplayID()); }
 
 void NeruFreeVisionResult(VisionResult *result) {
 	if (result) {

--- a/internal/core/infra/vision/adapter.go
+++ b/internal/core/infra/vision/adapter.go
@@ -1,0 +1,32 @@
+// Package vision provides vision-based element detection using the
+// macOS Vision Framework. It implements ports.VisionPort with a
+// heuristic classifier for role assignment.
+package vision
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+// Adapter implements ports.VisionPort using the macOS Vision Framework.
+// On non-darwin platforms the implementation is a no-op stub.
+//
+// The adapter captures screenshots of the frontmost window and runs
+// Vision Framework requests (text recognition, rectangle detection,
+// saliency) to detect interactive UI elements. The results are passed
+// through a heuristic classifier to assign roles and confidence scores.
+type Adapter struct {
+	logger *zap.Logger
+}
+
+// NewAdapter creates a new Vision Framework adapter.
+func NewAdapter(logger *zap.Logger) ports.VisionPort {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &Adapter{
+		logger: logger.Named("infra.vision"),
+	}
+}

--- a/internal/core/infra/vision/adapter_darwin.go
+++ b/internal/core/infra/vision/adapter_darwin.go
@@ -164,7 +164,7 @@ func (a *Adapter) CaptureScreen(_ context.Context) (*image.RGBA, error) {
 		8, // bits per component
 		C.size_t(bytesPerRow),
 		colorSpace,
-		C.kCGImageAlphaPremultipliedFirst|C.kCGBitmapByteOrder32Little, //nolint:nlreturn
+		C.kCGImageAlphaPremultipliedLast, //nolint:nlreturn
 	)
 
 	if uintptr(ctx) == 0 {

--- a/internal/core/infra/vision/adapter_darwin.go
+++ b/internal/core/infra/vision/adapter_darwin.go
@@ -1,0 +1,209 @@
+//go:build darwin
+
+package vision
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Vision -framework CoreGraphics -framework Foundation
+#include "../platform/darwin/vision.h"
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"unsafe"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	_ "github.com/y3owk1n/neru/internal/core/infra/platform/darwin" // ensure darwin CGo .m files are compiled
+)
+
+const bytesPerPixel = 4
+
+// DetectElements captures a screenshot of the main display and runs Vision
+// Framework detection (text recognition + rectangle detection). Results are
+// merged via non-maximum suppression and classified by the heuristic classifier.
+func (a *Adapter) DetectElements(
+	ctx context.Context,
+	screenBounds image.Rectangle,
+) ([]*element.Element, error) {
+	select {
+	case <-ctx.Done():
+		return nil, derrors.Wrap(ctx.Err(), derrors.CodeContextCanceled, "operation canceled")
+	default:
+	}
+
+	// Convert screen bounds to CGRect
+	cgRect := C.CGRect{
+		origin: C.CGPoint{x: C.double(screenBounds.Min.X), y: C.double(screenBounds.Min.Y)},
+		size:   C.CGSize{width: C.double(screenBounds.Dx()), height: C.double(screenBounds.Dy())},
+	}
+
+	result := C.NeruDetectElements(cgRect)
+	if result == nil {
+		return nil, nil
+	}
+
+	defer C.NeruFreeVisionResult(result) //nolint:nlreturn
+
+	count := int(result.count)
+	if count == 0 {
+		return nil, nil
+	}
+
+	// Convert C regions to Go DetectedRegions
+	regions := make([]DetectedRegion, 0, count)
+	cRegions := (*[1 << 30]C.VisionRegion)(unsafe.Pointer(result.regions))[:count:count]
+
+	for _, cRegion := range cRegions {
+		region := DetectedRegion{
+			Bounds: image.Rectangle{
+				Min: image.Point{X: int(cRegion.x), Y: int(cRegion.y)},
+				Max: image.Point{
+					X: int(cRegion.x + cRegion.width),
+					Y: int(cRegion.y + cRegion.height),
+				},
+			},
+			Score:  float64(cRegion.score),
+			IsText: cRegion.isText != 0,
+		}
+		if cRegion.label != nil {
+			region.Label = C.GoString(cRegion.label)
+		}
+		regions = append(regions, region)
+	}
+
+	// Merge overlapping regions via NMS
+	merged := MergeRegions(regions)
+
+	// Filter regions outside the window bounds
+	windowElements := make([]DetectedRegion, 0, len(merged))
+	for _, region := range merged {
+		if region.Bounds.Overlaps(screenBounds) {
+			windowElements = append(windowElements, region)
+		}
+	}
+
+	// Classify and convert to domain elements
+	classifier := regionClassifier{}
+	elements := make([]*element.Element, 0, len(windowElements))
+
+	for _, region := range windowElements {
+		if region.Bounds.Empty() {
+			continue
+		}
+
+		role, clickable := classifier.Classify(region)
+
+		opts := []element.Option{
+			element.WithVisionOnly(),
+		}
+		if clickable {
+			opts = append(opts, element.WithClickable(true))
+		}
+		if region.Label != "" {
+			opts = append(opts, element.WithTitle(region.Label))
+			opts = append(opts, element.WithSearchText(region.Label))
+		}
+
+		elem, err := element.NewElement(
+			element.ID("vision-"+regionBoundsKey(region.Bounds)),
+			region.Bounds,
+			element.Role(role),
+			opts...,
+		)
+		if err != nil {
+			a.logger.Debug("Skipping invalid vision region", zap.Error(err))
+
+			continue
+		}
+
+		elements = append(elements, elem)
+	}
+
+	a.logger.Debug("Vision detection complete",
+		zap.Int("raw_regions", count),
+		zap.Int("merged_elements", len(elements)),
+	)
+
+	return elements, nil
+}
+
+// CaptureScreen captures the current screen image for the primary display.
+func (a *Adapter) CaptureScreen(_ context.Context) (*image.RGBA, error) {
+	cgImage := C.NeruCaptureScreen()
+	if uintptr(cgImage) == 0 {
+		return nil, derrors.New(derrors.CodeInternal, "failed to capture screen")
+	}
+
+	defer C.CGImageRelease(cgImage) //nolint:nlreturn
+
+	width := int(C.CGImageGetWidth(cgImage))   //nolint:nlreturn
+	height := int(C.CGImageGetHeight(cgImage)) //nolint:nlreturn
+
+	if width == 0 || height == 0 {
+		return nil, derrors.New(derrors.CodeInternal, "captured screen image has zero size")
+	}
+
+	bytesPerRow := width * bytesPerPixel
+	buf := make([]byte, height*bytesPerRow)
+
+	colorSpace := C.CGColorSpaceCreateDeviceRGB()
+
+	defer C.CGColorSpaceRelease(colorSpace) //nolint:nlreturn
+
+	ctx := C.CGBitmapContextCreate(
+		unsafe.Pointer(&buf[0]),
+		C.size_t(width),
+		C.size_t(height),
+		8, // bits per component
+		C.size_t(bytesPerRow),
+		colorSpace,
+		C.kCGImageAlphaPremultipliedFirst|C.kCGBitmapByteOrder32Little, //nolint:nlreturn
+	)
+
+	if uintptr(ctx) == 0 {
+		return nil, derrors.New(derrors.CodeInternal, "failed to create bitmap context")
+	}
+	defer C.CGContextRelease(ctx) //nolint:nlreturn
+
+	// Draw the captured image into our context
+	C.CGContextDrawImage(ctx, C.CGRect{
+		origin: C.CGPoint{x: 0, y: 0},
+		size:   C.CGSize{width: C.double(width), height: C.double(height)},
+	}, cgImage)
+
+	// Create RGBA image
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	copy(img.Pix, buf)
+
+	return img, nil
+}
+
+// Health checks whether Vision Framework is available.
+func (a *Adapter) Health(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return derrors.Wrap(ctx.Err(), derrors.CodeContextCanceled, "operation canceled")
+	default:
+	}
+
+	// Quick smoke test: attempt a screen capture
+	_, err := a.CaptureScreen(ctx)
+	if err != nil {
+		return derrors.Wrap(err, derrors.CodeInternal, "vision framework health check failed")
+	}
+
+	return nil
+}
+
+// regionBoundsKey returns a deterministic string key for a rectangle,
+// used as element ID for vision-detected elements.
+func regionBoundsKey(r image.Rectangle) string {
+	return fmt.Sprintf("%d-%d-%d-%d", r.Min.X, r.Min.Y, r.Max.X, r.Max.Y)
+}

--- a/internal/core/infra/vision/adapter_other.go
+++ b/internal/core/infra/vision/adapter_other.go
@@ -1,0 +1,26 @@
+//go:build !darwin
+
+package vision
+
+import (
+	"context"
+	"image"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+)
+
+// DetectElements is a no-op stub on non-darwin platforms.
+func (a *Adapter) DetectElements(_ context.Context, _ image.Rectangle) ([]*element.Element, error) {
+	return nil, derrors.New(derrors.CodeNotSupported, "vision detection is only supported on macOS")
+}
+
+// CaptureScreen is a no-op stub on non-darwin platforms.
+func (a *Adapter) CaptureScreen(_ context.Context) (*image.RGBA, error) {
+	return nil, derrors.New(derrors.CodeNotSupported, "screen capture is only supported on macOS")
+}
+
+// Health reports not-supported on non-darwin platforms.
+func (a *Adapter) Health(_ context.Context) error {
+	return derrors.New(derrors.CodeNotSupported, "vision framework is only available on macOS")
+}

--- a/internal/core/infra/vision/classifier.go
+++ b/internal/core/infra/vision/classifier.go
@@ -1,0 +1,21 @@
+package vision
+
+// TestClassifier is a pure-Go classifier used in testing and as a fallback
+// when no Core ML model is available. It classifies regions using geometric
+// heuristics only (see regionClassifier).
+//
+// A real Core ML classifier can be swapped in later by implementing the
+// same interface and loading a .mlpackage from disk.
+type TestClassifier struct {
+	classifier regionClassifier
+}
+
+// NewTestClassifier creates a new test/fallback classifier.
+func NewTestClassifier() *TestClassifier {
+	return &TestClassifier{}
+}
+
+// Classify delegates to the heuristic region classifier.
+func (tc *TestClassifier) Classify(region DetectedRegion) (string, bool) {
+	return tc.classifier.Classify(region)
+}

--- a/internal/core/infra/vision/classifier_test.go
+++ b/internal/core/infra/vision/classifier_test.go
@@ -1,0 +1,188 @@
+//go:build !darwin || darwin
+
+package vision //nolint:testpackage // uses unexported regionClassifier
+
+import (
+	"image"
+	"testing"
+)
+
+func TestRegionClassifier_Button(t *testing.T) {
+	classifier := &regionClassifier{}
+
+	// A typical button: 120x30, centered text, high saliency
+	region := DetectedRegion{
+		Bounds: image.Rect(100, 100, 220, 130),
+		Score:  0.8,
+		IsText: true,
+		Label:  "Submit",
+	}
+
+	role, clickable := classifier.Classify(region)
+	if role != roleButton {
+		t.Errorf("expected AXButton, got %s", role)
+	}
+
+	if !clickable {
+		t.Errorf("expected clickable")
+	}
+}
+
+func TestRegionClassifier_Link(t *testing.T) {
+	classifier := &regionClassifier{}
+
+	// A link: wide and short text
+	region := DetectedRegion{
+		Bounds: image.Rect(50, 200, 300, 230),
+		Score:  0.6,
+		IsText: true,
+		Label:  "Click here for more information",
+	}
+
+	role, clickable := classifier.Classify(region)
+	if role != "AXLink" {
+		t.Errorf("expected AXLink, got %s", role)
+	}
+
+	if !clickable {
+		t.Errorf("expected clickable")
+	}
+}
+
+func TestRegionClassifier_StaticText(t *testing.T) {
+	classifier := &regionClassifier{}
+
+	// Tall narrow text block (aspect ratio < 1.2) with low score — not a button
+	region := DetectedRegion{
+		Bounds: image.Rect(10, 10, 40, 60),
+		Score:  0.2,
+		IsText: true,
+		Label:  "Hi",
+	}
+
+	role, clickable := classifier.Classify(region)
+	if role != "AXStaticText" {
+		t.Errorf("expected AXStaticText, got %s", role)
+	}
+
+	if clickable {
+		t.Errorf("expected non-clickable")
+	}
+}
+
+func TestRegionClassifier_SmallToolbarIcon(t *testing.T) {
+	classifier := &regionClassifier{}
+
+	// A 32x32 square icon: not a checkbox (too big), not a large image.
+	// Should be clickable via the button heuristic.
+	region := DetectedRegion{
+		Bounds: image.Rect(0, 0, 32, 32),
+		Score:  0.4,
+		IsText: false,
+	}
+
+	role, clickable := classifier.Classify(region)
+	if role != "AXButton" {
+		t.Errorf("expected AXButton for small icon, got %s", role)
+	}
+
+	if !clickable {
+		t.Errorf("expected clickable for small icon")
+	}
+}
+
+func TestRegionClassifier_LargeImage(t *testing.T) {
+	classifier := &regionClassifier{}
+
+	// A 64x64 region is large enough to be an actual image, not an icon.
+	// Falls through checkbox and button heuristics due to size.
+	region := DetectedRegion{
+		Bounds: image.Rect(0, 0, 64, 64),
+		Score:  0.5,
+		IsText: false,
+	}
+
+	role, clickable := classifier.Classify(region)
+	if role != "AXImage" {
+		t.Errorf("expected AXImage, got %s", role)
+	}
+
+	if clickable {
+		t.Errorf("expected non-clickable")
+	}
+}
+
+func TestRegionClassifier_SmallCheckbox(t *testing.T) {
+	classifier := &regionClassifier{}
+
+	region := DetectedRegion{
+		Bounds: image.Rect(10, 10, 26, 26),
+		Score:  0.3,
+		IsText: false,
+	}
+
+	role, clickable := classifier.Classify(region)
+	if role != "AXCheckBox" {
+		t.Errorf("expected AXCheckBox, got %s", role)
+	}
+
+	if !clickable {
+		t.Errorf("expected clickable")
+	}
+}
+
+func TestMergeRegions_NonOverlapping(t *testing.T) {
+	regions := []DetectedRegion{
+		{Bounds: image.Rect(0, 0, 50, 50), Score: 0.9},
+		{Bounds: image.Rect(100, 0, 150, 50), Score: 0.8},
+	}
+
+	merged := MergeRegions(regions)
+	if len(merged) != 2 {
+		t.Errorf("expected 2 regions, got %d", len(merged))
+	}
+}
+
+func TestMergeRegions_Overlapping(t *testing.T) {
+	regions := []DetectedRegion{
+		{Bounds: image.Rect(0, 0, 100, 100), Score: 0.9},
+		{Bounds: image.Rect(10, 10, 90, 90), Score: 0.5}, // high IoU with first
+	}
+
+	merged := MergeRegions(regions)
+	if len(merged) != 1 {
+		t.Errorf("expected 1 merged region, got %d", len(merged))
+	}
+}
+
+func TestMergeRegions_PartialOverlap(t *testing.T) {
+	regions := []DetectedRegion{
+		{Bounds: image.Rect(0, 0, 50, 50), Score: 0.9},
+		{Bounds: image.Rect(30, 30, 80, 80), Score: 0.8}, // partial overlap
+	}
+
+	merged := MergeRegions(regions)
+	if len(merged) != 2 {
+		t.Errorf("expected 2 regions for partial overlap, got %d", len(merged))
+	}
+}
+
+func TestTestClassifier(t *testing.T) {
+	testClassifier := NewTestClassifier()
+
+	region := DetectedRegion{
+		Bounds: image.Rect(100, 100, 200, 130),
+		Score:  0.7,
+		IsText: true,
+		Label:  "OK",
+	}
+
+	role, clickable := testClassifier.Classify(region)
+	if role == "" {
+		t.Errorf("expected non-empty role")
+	}
+	// Should classify as button (aspect ratio ~3.3, score 0.7, text)
+	if role != "AXButton" || !clickable {
+		t.Errorf("expected AXButton/clickable, got %s/%v", role, clickable)
+	}
+}

--- a/internal/core/infra/vision/heuristics.go
+++ b/internal/core/infra/vision/heuristics.go
@@ -1,0 +1,163 @@
+package vision
+
+import (
+	"image"
+	"math"
+)
+
+// DetectedRegion represents a region of interest identified by a Vision
+// Framework request. Multiple requests (text, rectangles, saliency) produce
+// overlapping regions that are merged into a single element.
+type DetectedRegion struct {
+	Bounds   image.Rectangle
+	Label    string
+	Score    float64
+	Role     string
+	IsText   bool
+	IsButton bool
+}
+
+// regionClassifier applies geometric and saliency heuristics to assign
+// roles to detected regions. It is the first-pass classifier used on all
+// platforms; a Core ML model can be swapped in later for improved accuracy.
+type regionClassifier struct{}
+
+const roleButton = "AXButton"
+
+const buttonIconMaxSize = 48 // max dimension (px) for near-square regions to be considered buttons/icons
+
+// Classify assigns a role to a detected region based on its geometry and
+// saliency score. Returns the role string and whether the region is considered
+// clickable.
+func (c *regionClassifier) Classify(region DetectedRegion) (string, bool) {
+	bounds := region.Bounds
+	width := float64(bounds.Dx())
+	height := float64(bounds.Dy())
+
+	if width <= 0 || height <= 0 {
+		return "AXUnknown", false
+	}
+
+	aspectRatio := width / height
+
+	switch {
+	case region.IsText && isLikelyButton(aspectRatio, region.Score, width, height):
+		return roleButton, true
+	case region.IsText && isLikelyLink(aspectRatio, width, height):
+		return "AXLink", true
+	case region.IsText:
+		return "AXStaticText", false
+	case isLikelyCheckBox(aspectRatio, width, height):
+		return "AXCheckBox", true
+	case isLikelyButton(aspectRatio, region.Score, width, height):
+		return roleButton, true
+	case isLikelyImage(aspectRatio, width, height):
+		return "AXImage", false
+	default:
+		if region.Score > 0.5 { //nolint:mnd
+			return roleButton, true
+		}
+
+		return "AXGenericElement", false
+	}
+}
+
+// isLikelyButton checks aspect ratio and saliency to guess "button".
+// Buttons and toolbar icons are typically 0.8:1 to 8:1 width:height
+// (square-ish to wide) with decent saliency. For near-square regions,
+// size is constrained to avoid catching large images.
+func isLikelyButton(aspectRatio, score, width, height float64) bool {
+	if aspectRatio < 0.8 || aspectRatio > 8.0 || score < 0.3 {
+		return false
+	}
+
+	// Near-square regions: limit size to avoid classifying images as buttons
+	if aspectRatio >= 0.8 && aspectRatio <= 1.5 {
+		return max(width, height) <= buttonIconMaxSize
+	}
+
+	return true
+}
+
+// isLikelyLink checks for long, narrow text (links).
+func isLikelyLink(aspectRatio, w, h float64) bool {
+	return aspectRatio > 5.0 && h < 40 && w > 50
+}
+
+// isLikelyImage checks for near-square regions that are large enough to be
+// actual images rather than buttons or icons. Images ≥ 48px in both dimensions
+// with near-square aspect are classified as non-interactive.
+func isLikelyImage(aspectRatio, w, h float64) bool {
+	return aspectRatio >= 0.8 && aspectRatio <= 1.5 && w >= 48 && h >= 48
+}
+
+// isLikelyCheckBox checks for small square-ish regions (< 32px in both dims).
+func isLikelyCheckBox(aspectRatio, w, h float64) bool {
+	return aspectRatio >= 0.8 && aspectRatio <= 1.5 && w < 32 && h < 32
+}
+
+// MergeRegions merges overlapping regions using non-maximum suppression.
+// Regions with higher scores suppress lower-scoring overlaps (IoU > 0.5).
+func MergeRegions(regions []DetectedRegion) []DetectedRegion {
+	if len(regions) == 0 {
+		return nil
+	}
+
+	// Sort by score descending
+	sorted := make([]DetectedRegion, len(regions))
+	copy(sorted, regions)
+	sortRegionsByScore(sorted)
+
+	var result []DetectedRegion
+	for len(sorted) > 0 {
+		best := sorted[0]
+		sorted = sorted[1:]
+
+		var remaining []DetectedRegion
+		for _, r := range sorted {
+			iou := intersectionOverUnion(best.Bounds, r.Bounds)
+			if iou < 0.5 { //nolint:mnd
+				remaining = append(remaining, r)
+			}
+		}
+
+		sorted = remaining
+
+		result = append(result, best)
+	}
+
+	return result
+}
+
+// intersectionOverUnion computes the IoU of two rectangles.
+func intersectionOverUnion(pointA, pointB image.Rectangle) float64 {
+	intersection := pointA.Intersect(pointB)
+	if intersection.Empty() {
+		return 0
+	}
+
+	intersectArea := float64(intersection.Dx() * intersection.Dy())
+
+	unionArea := float64(pointA.Dx()*pointA.Dy()) + float64(pointB.Dx()*pointB.Dy()) - intersectArea
+	if unionArea <= 0 {
+		return 0
+	}
+
+	return math.Round(intersectArea/unionArea*100) / 100 //nolint:mnd
+}
+
+// sortRegionsByScore sorts regions descending by Score using a simple
+// insertion sort (n is typically very small, < 100).
+func sortRegionsByScore(regions []DetectedRegion) {
+	for i := 1; i < len(regions); i++ {
+		key := regions[i]
+
+		insertPos := i - 1
+		for insertPos >= 0 && regions[insertPos].Score < key.Score {
+			regions[insertPos+1] = regions[insertPos]
+			insertPos--
+		}
+
+		regions[insertPos+1] = key
+	}
+}

--- a/internal/core/infra/vision/heuristics.go
+++ b/internal/core/infra/vision/heuristics.go
@@ -9,12 +9,10 @@ import (
 // Framework request. Multiple requests (text, rectangles, saliency) produce
 // overlapping regions that are merged into a single element.
 type DetectedRegion struct {
-	Bounds   image.Rectangle
-	Label    string
-	Score    float64
-	Role     string
-	IsText   bool
-	IsButton bool
+	Bounds image.Rectangle
+	Label  string
+	Score  float64
+	IsText bool
 }
 
 // regionClassifier applies geometric and saliency heuristics to assign

--- a/internal/core/ports/accessibility.go
+++ b/internal/core/ports/accessibility.go
@@ -63,6 +63,12 @@ type ElementFilter struct {
 	// Roles specifies which accessibility roles to include.
 	Roles []element.Role
 
+	// SkipWindowElements skips querying the frontmost window for elements.
+	// When true, only supplementary elements (menubar, dock, NC, etc.) are
+	// collected. Used by the vision strategy where the frontmost window
+	// is detected via Vision Framework instead of the AX tree.
+	SkipWindowElements bool
+
 	// MinSize specifies the minimum element size to include.
 	MinSize image.Point
 

--- a/internal/core/ports/vision.go
+++ b/internal/core/ports/vision.go
@@ -1,0 +1,31 @@
+package ports
+
+import (
+	"context"
+	"image"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+)
+
+// VisionPort defines the interface for vision-based element detection using
+// macOS Vision Framework (or platform equivalents). Implementations capture
+// screenshots and detect UI elements via text recognition, rectangle detection,
+// and saliency analysis.
+//
+// Only used when hints.strategy is set to "vision" for the frontmost window.
+// System-level components (menubar, dock, notification center, etc.) always
+// use the AX tree regardless of strategy.
+type VisionPort interface {
+	HealthCheck
+
+	// DetectElements captures a screenshot of the frontmost window and returns
+	// detected interactive elements. The screenBounds parameter constrains
+	// detection to the window region. Implementations use Vision Framework
+	// requests (text recognition, rectangle detection, saliency) and a
+	// heuristic classifier to assign element roles.
+	DetectElements(ctx context.Context, screenBounds image.Rectangle) ([]*element.Element, error)
+
+	// CaptureScreen returns the current screen image for the primary display.
+	// Used by DetectElements internally, but exposed for testing or inspection.
+	CaptureScreen(ctx context.Context) (*image.RGBA, error)
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR introduces a new `strategy` field in `hints` configuration that allow user to choose between `axtree` or `vision`, and can be overriden in `app_configs`.

Using `vision` will enable Neru to use the macOS Vision Framework with some heuristics to provide labels for the focused app. Few things to note:

- Default is always `axtree`, override it as you wish, preferably only for certain apps like Zed Editor.
- This is not always **accurate** and **less reliable** than an actual AX tree. Consider this as best effort supports.
- All supplement targets are always using `axtree` strategy, this only targets on focused window.
- Heuristics are hardcoded into Neru, contribute changes if you have enhancement to be made.

**How to use it?**

1. Use the `strategy` field in `hints` configuration.

This will enable the `vision` strategy for all focused app (probably not a good idea).

```toml
[hints]
enabled = true
strategy = "vision" # default is "axtree"
```

App specific configuration is more recommended as incremental opt-in.

```toml
[hints]
enabled = true
strategy = "axtree" # default is "axtree"

[[hints.app_configs]]
bundle_id = "dev.zed.Zed"
strategy = "vision" # only Zed Editor will use "vision", the rest will use "axtree"
```

2. Invoke via cli directly.

```bash
neru hints --strategy <strategy>

neru hints --strategy vision # run with "vision" strategy
neru hints --strategy axtree # run with "axtree" strategy
```

These cli can be bounded into your global hotkey or anywhere just like every other command, user decide.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/ce075199-e5ef-4f8b-bf37-9ba3d1625b7f

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
