### PR TITLE
feat(hints,vision): make vision options fully configurable

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -130,6 +130,27 @@ enabled = false                             # Draw a subtle outline around each 
 border_width = 1
 border_radius = -1                          # -1 = auto pill
 
+[hints.vision]
+detect_text = true                           # Enable text detection via Vision framework
+detect_rectangles = true                     # Enable rectangle detection via Vision framework
+request_timeout_ms = 5000                    # Timeout for Vision requests in milliseconds
+minimum_confidence = 0.0                     # Minimum confidence threshold for keeping vision observations
+merge_iou_threshold = 0.5                    # Overlap threshold (Intersection over Union) for merging redundant boxes
+rectangle_max_candidates = 100               # Maximum number of rectangle candidate observations to track
+rectangle_min_size = 0.01                    # Minimum size of detected rectangles (0.01 = 1% of screen/window width/height)
+rectangle_min_aspect = 0.3                   # Minimum aspect ratio (width/height) for rectangles
+rectangle_max_aspect = 10.0                  # Maximum aspect ratio (width/height) for rectangles
+button_min_confidence = 0.3                  # Minimum confidence for button classification
+button_min_aspect = 0.8                      # Minimum aspect ratio for button elements
+button_max_aspect = 8.0                      # Maximum aspect ratio for button elements
+button_icon_max_size = 48                    # Maximum width/height for square button/icon elements (px)
+link_min_aspect = 5.0                        # Minimum aspect ratio for text link elements
+link_max_height = 40                         # Maximum height for link elements (px)
+link_min_width = 50                          # Minimum width for link elements (px)
+image_min_size = 48                          # Minimum width/height for image elements (px)
+checkbox_max_size = 32                       # Maximum width/height for checkbox elements (px)
+generic_clickable_min_confidence = 0.5       # Minimum confidence for generic clickable classification
+
 # Grid mode
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#grid
 [grid]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -419,6 +419,55 @@ additional_webkit_bundles    = []
 
 Find bundle IDs: `osascript -e 'id of app "Safari"'`
 
+### Vision
+
+Tunable settings for Vision-based hint detection (only used when `hints.strategy` or the app-specific `strategy` override is set to `"vision"`).
+
+| Option | Type | Default | Description |
+| ------------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| `detect_text` | bool | `true` | Enable text detection via the Vision framework. |
+| `detect_rectangles` | bool | `true` | Enable rectangle detection via the Vision framework. |
+| `request_timeout_ms` | int | `5000` | Timeout in milliseconds for Vision framework analysis requests. |
+| `minimum_confidence` | float | `0.0` | Minimum confidence score (0.0 to 1.0) for keeping Vision framework observations. |
+| `merge_iou_threshold` | float | `0.5` | Intersection-over-Union (IoU) overlap threshold for merging redundant overlapping bounding boxes. |
+| `rectangle_max_candidates` | int | `100` | Maximum number of rectangle candidate observations to evaluate. |
+| `rectangle_min_size` | float | `0.01` | Minimum normalized size of detected rectangles (e.g. `0.01` is 1% of screen/window dimensions). |
+| `rectangle_min_aspect` | float | `0.3` | Minimum aspect ratio (width/height) for rectangle elements. |
+| `rectangle_max_aspect` | float | `10.0` | Maximum aspect ratio (width/height) for rectangle elements. |
+| `button_min_confidence` | float | `0.3` | Minimum confidence score threshold for classifying a rectangle as a button. |
+| `button_min_aspect` | float | `0.8` | Minimum aspect ratio for button elements. |
+| `button_max_aspect` | float | `8.0` | Maximum aspect ratio for button elements. |
+| `button_icon_max_size` | int | `48` | Maximum width/height in pixels for square button or icon elements. |
+| `link_min_aspect` | float | `5.0` | Minimum aspect ratio for text link elements. |
+| `link_max_height` | int | `40` | Maximum height in pixels for text link elements. |
+| `link_min_width` | int | `50` | Minimum width in pixels for text link elements. |
+| `image_min_size` | int | `48` | Minimum width/height in pixels for image elements. |
+| `checkbox_max_size` | int | `32` | Maximum width/height in pixels for checkbox elements. |
+| `generic_clickable_min_confidence` | float | `0.5` | Minimum confidence threshold for generic clickable elements. |
+
+```toml
+[hints.vision]
+detect_text = true
+detect_rectangles = true
+request_timeout_ms = 5000
+minimum_confidence = 0.0
+merge_iou_threshold = 0.5
+rectangle_max_candidates = 100
+rectangle_min_size = 0.01
+rectangle_min_aspect = 0.3
+rectangle_max_aspect = 10.0
+button_min_confidence = 0.3
+button_min_aspect = 0.8
+button_max_aspect = 8.0
+button_icon_max_size = 48
+link_min_aspect = 5.0
+link_max_height = 40
+link_min_width = 50
+image_min_size = 48
+checkbox_max_size = 32
+generic_clickable_min_confidence = 0.5
+```
+
 ### Per-App Config
 
 | Field                        | Type   | Description                                           |

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -365,7 +365,7 @@ func (s *HintService) generateHintsVision(
 
 	// Detect window elements via vision
 	visionStart := time.Now()
-	windowElements, visionErr := s.vision.DetectElements(ctx, windowBounds)
+	windowElements, visionErr := s.vision.DetectElements(ctx, windowBounds, s.config.Vision)
 	s.logger.Debug("TIMING: Window elements (vision)",
 		zap.Duration("elapsed", time.Since(visionStart)),
 		zap.Int("count", len(windowElements)),
@@ -373,27 +373,6 @@ func (s *HintService) generateHintsVision(
 
 	if visionErr != nil {
 		s.logger.Error("Failed to detect elements via vision", zap.Error(visionErr))
-
-		// Fall back to AX for window elements if vision fails
-		axStart := time.Now()
-		fallbackFilter := filter
-		fallbackFilter.IncludeMenubar = false
-		fallbackFilter.AdditionalMenubarTargets = nil
-		fallbackFilter.IncludeDock = false
-		fallbackFilter.IncludeNotificationCenter = false
-		fallbackFilter.IncludeStageManager = false
-		fallbackFilter.IncludePIP = false
-		fallbackFilter.IncludeScreenCapture = false
-
-		fallbackElements, fallbackErr := s.accessibility.ClickableElements(ctx, fallbackFilter)
-		s.logger.Debug("TIMING: Fallback elements (AX)",
-			zap.Duration("elapsed", time.Since(axStart)),
-			zap.Int("count", len(fallbackElements)),
-			zap.Error(fallbackErr))
-
-		if fallbackErr == nil {
-			allElements = append(allElements, fallbackElements...)
-		}
 
 		return allElements
 	}

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -476,26 +476,24 @@ func TestHintService_RefreshHints(t *testing.T) {
 	}
 }
 
-func TestHintService_GenerateHintsVisionFallbackDoesNotDuplicateSupplementaryElements(
+func TestHintService_GenerateHintsVisionCombinesSupplementaryAndWindowElements(
 	t *testing.T,
 ) {
 	supplementElement := mustNewElement("menubar", image.Rect(10, 0, 60, 20))
 	windowElement := mustNewElement("window", image.Rect(10, 40, 60, 90))
-
-	var fallbackFilter ports.ElementFilter
 
 	mockAcc := &mocks.MockAccessibilityPort{}
 	mockAcc.ClickableElementsFunc = func(
 		_ context.Context,
 		filter ports.ElementFilter,
 	) ([]*element.Element, error) {
-		if filter.SkipWindowElements {
-			return []*element.Element{supplementElement}, nil
+		if !filter.SkipWindowElements {
+			t.Error("accessibility should not collect window elements when using vision strategy")
+
+			return nil, nil
 		}
 
-		fallbackFilter = filter
-
-		return []*element.Element{windowElement}, nil
+		return []*element.Element{supplementElement}, nil
 	}
 
 	mockSystem := &mocks.MockSystemPort{}
@@ -510,6 +508,7 @@ func TestHintService_GenerateHintsVisionFallbackDoesNotDuplicateSupplementaryEle
 		mockSystem,
 		generator,
 		config.HintsConfig{
+			ClickableRoles:                []string{string(element.RoleButton)},
 			IncludeMenubarHints:           true,
 			AdditionalMenubarHintsTargets: []string{"Clock"},
 			IncludeDockHints:              true,
@@ -520,7 +519,7 @@ func TestHintService_GenerateHintsVisionFallbackDoesNotDuplicateSupplementaryEle
 		},
 		logger.Get(),
 		&mockVisionPort{
-			detectErr: derrors.New(derrors.CodeBridgeFailed, "vision failed"),
+			detectedElements: []*element.Element{windowElement},
 		},
 	)
 
@@ -550,16 +549,6 @@ func TestHintService_GenerateHintsVisionFallbackDoesNotDuplicateSupplementaryEle
 
 	if seen[windowElement.ID()] != 1 {
 		t.Errorf("window element count = %d, want 1", seen[windowElement.ID()])
-	}
-
-	if fallbackFilter.IncludeMenubar ||
-		len(fallbackFilter.AdditionalMenubarTargets) != 0 ||
-		fallbackFilter.IncludeDock ||
-		fallbackFilter.IncludeNotificationCenter ||
-		fallbackFilter.IncludeStageManager ||
-		fallbackFilter.IncludePIP ||
-		fallbackFilter.IncludeScreenCapture {
-		t.Errorf("fallback filter should disable supplementary sources: %+v", fallbackFilter)
 	}
 }
 
@@ -701,14 +690,20 @@ func mustNewElement(id string, bounds image.Rectangle) *element.Element {
 }
 
 type mockVisionPort struct {
-	detectErr error
+	detectedElements []*element.Element
+	detectErr        error
 }
 
 func (m *mockVisionPort) DetectElements(
 	context.Context,
 	image.Rectangle,
+	config.HintsVisionConfig,
 ) ([]*element.Element, error) {
-	return nil, m.detectErr
+	if m.detectErr != nil {
+		return nil, m.detectErr
+	}
+
+	return m.detectedElements, nil
 }
 
 func (m *mockVisionPort) CaptureScreen(context.Context) (*image.RGBA, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -567,6 +567,30 @@ type SearchInputUI struct {
 	BorderColor     Color  `json:"borderColor"     toml:"border_color"`
 }
 
+// HintsVisionConfig defines tunable settings for vision-based hint detection.
+type HintsVisionConfig struct {
+	DetectText             bool    `json:"detectText"             toml:"detect_text"`
+	DetectRectangles       bool    `json:"detectRectangles"       toml:"detect_rectangles"`
+	RequestTimeoutMS       int     `json:"requestTimeoutMs"       toml:"request_timeout_ms"`
+	MinimumConfidence      float64 `json:"minimumConfidence"      toml:"minimum_confidence"`
+	MergeIOUThreshold      float64 `json:"mergeIouThreshold"      toml:"merge_iou_threshold"`
+	RectangleMaxCandidates int     `json:"rectangleMaxCandidates" toml:"rectangle_max_candidates"`
+	RectangleMinSize       float64 `json:"rectangleMinSize"       toml:"rectangle_min_size"`
+	RectangleMinAspect     float64 `json:"rectangleMinAspect"     toml:"rectangle_min_aspect"`
+	RectangleMaxAspect     float64 `json:"rectangleMaxAspect"     toml:"rectangle_max_aspect"`
+
+	ButtonMinConfidence           float64 `json:"buttonMinConfidence"           toml:"button_min_confidence"`
+	ButtonMinAspect               float64 `json:"buttonMinAspect"               toml:"button_min_aspect"`
+	ButtonMaxAspect               float64 `json:"buttonMaxAspect"               toml:"button_max_aspect"`
+	ButtonIconMaxSize             int     `json:"buttonIconMaxSize"             toml:"button_icon_max_size"`
+	LinkMinAspect                 float64 `json:"linkMinAspect"                 toml:"link_min_aspect"`
+	LinkMaxHeight                 int     `json:"linkMaxHeight"                 toml:"link_max_height"`
+	LinkMinWidth                  int     `json:"linkMinWidth"                  toml:"link_min_width"`
+	ImageMinSize                  int     `json:"imageMinSize"                  toml:"image_min_size"`
+	CheckboxMaxSize               int     `json:"checkboxMaxSize"               toml:"checkbox_max_size"`
+	GenericClickableMinConfidence float64 `json:"genericClickableMinConfidence" toml:"generic_clickable_min_confidence"`
+}
+
 // Strategy constants for element detection.
 const (
 	StrategyAXTree = "axtree"
@@ -582,6 +606,7 @@ type HintsConfig struct {
 	UI                HintsUI             `json:"ui"                toml:"ui"`
 	SearchInputUI     SearchInputUI       `json:"searchInputUi"     toml:"search_input_ui"`
 	BoundaryHighlight BoundaryHighlightUI `json:"boundaryHighlight" toml:"boundary_highlight"`
+	Vision            HintsVisionConfig   `json:"vision"            toml:"vision"`
 
 	IncludeMenubarHints           bool                `json:"includeMenubarHints"           toml:"include_menubar_hints"`
 	AdditionalMenubarHintsTargets []string            `json:"additionalMenubarHintsTargets" toml:"additional_menubar_hints_targets"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -15,6 +15,40 @@ const (
 	DefaultHintBoundaryBorderRadius = -1
 	// DefaultHintBoundaryBorderWidth is the default stroke width for hint target boundaries.
 	DefaultHintBoundaryBorderWidth = 1
+	// DefaultVisionRequestTimeoutMS is the default Vision request timeout.
+	DefaultVisionRequestTimeoutMS = 5000
+	// DefaultVisionMinimumConfidence keeps all Vision observations by default.
+	DefaultVisionMinimumConfidence = 0.0
+	// DefaultVisionMergeIOUThreshold is the default overlap threshold for non-maximum suppression.
+	DefaultVisionMergeIOUThreshold = 0.5
+	// DefaultVisionRectangleMaxCandidates is the default maximum rectangle observations.
+	DefaultVisionRectangleMaxCandidates = 100
+	// DefaultVisionRectangleMinSize is the default minimum normalized rectangle size.
+	DefaultVisionRectangleMinSize = 0.01
+	// DefaultVisionRectangleMinAspect is the default minimum rectangle aspect ratio.
+	DefaultVisionRectangleMinAspect = 0.3
+	// DefaultVisionRectangleMaxAspect is the default maximum rectangle aspect ratio.
+	DefaultVisionRectangleMaxAspect = 10.0
+	// DefaultVisionButtonMinConfidence is the default button confidence threshold.
+	DefaultVisionButtonMinConfidence = 0.3
+	// DefaultVisionButtonMinAspect is the default minimum button aspect ratio.
+	DefaultVisionButtonMinAspect = 0.8
+	// DefaultVisionButtonMaxAspect is the default maximum button aspect ratio.
+	DefaultVisionButtonMaxAspect = 8.0
+	// DefaultVisionButtonIconMaxSize is the default max square button/icon size.
+	DefaultVisionButtonIconMaxSize = 48
+	// DefaultVisionLinkMinAspect is the default minimum link aspect ratio.
+	DefaultVisionLinkMinAspect = 5.0
+	// DefaultVisionLinkMaxHeight is the default maximum link text height.
+	DefaultVisionLinkMaxHeight = 40
+	// DefaultVisionLinkMinWidth is the default minimum link text width.
+	DefaultVisionLinkMinWidth = 50
+	// DefaultVisionImageMinSize is the default minimum size for image classification.
+	DefaultVisionImageMinSize = 48
+	// DefaultVisionCheckboxMaxSize is the default maximum size for checkbox classification.
+	DefaultVisionCheckboxMaxSize = 32
+	// DefaultVisionGenericClickableMinConfidence is the default generic clickable confidence threshold.
+	DefaultVisionGenericClickableMinConfidence = 0.5
 
 	// DefaultSearchInputYOffset is the default Y offset for search input.
 	DefaultSearchInputYOffset = 24
@@ -332,6 +366,27 @@ func newDefaultConfig() *Config {
 				BorderRadius:    DefaultHintBoundaryBorderRadius,
 				BorderColor:     Color{},
 				BackgroundColor: Color{},
+			},
+			Vision: HintsVisionConfig{
+				DetectText:                    true,
+				DetectRectangles:              true,
+				RequestTimeoutMS:              DefaultVisionRequestTimeoutMS,
+				MinimumConfidence:             DefaultVisionMinimumConfidence,
+				MergeIOUThreshold:             DefaultVisionMergeIOUThreshold,
+				RectangleMaxCandidates:        DefaultVisionRectangleMaxCandidates,
+				RectangleMinSize:              DefaultVisionRectangleMinSize,
+				RectangleMinAspect:            DefaultVisionRectangleMinAspect,
+				RectangleMaxAspect:            DefaultVisionRectangleMaxAspect,
+				ButtonMinConfidence:           DefaultVisionButtonMinConfidence,
+				ButtonMinAspect:               DefaultVisionButtonMinAspect,
+				ButtonMaxAspect:               DefaultVisionButtonMaxAspect,
+				ButtonIconMaxSize:             DefaultVisionButtonIconMaxSize,
+				LinkMinAspect:                 DefaultVisionLinkMinAspect,
+				LinkMaxHeight:                 DefaultVisionLinkMaxHeight,
+				LinkMinWidth:                  DefaultVisionLinkMinWidth,
+				ImageMinSize:                  DefaultVisionImageMinSize,
+				CheckboxMaxSize:               DefaultVisionCheckboxMaxSize,
+				GenericClickableMinConfidence: DefaultVisionGenericClickableMinConfidence,
 			},
 
 			IncludeMenubarHints:           false,

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -339,7 +339,7 @@ func validateHintsVisionConfig(vision HintsVisionConfig) error {
 		return err
 	}
 
-	err = validateUnitFloat(
+	err = validatePositiveUnitFloat(
 		"hints.vision.merge_iou_threshold",
 		vision.MergeIOUThreshold,
 	)
@@ -355,7 +355,7 @@ func validateHintsVisionConfig(vision HintsVisionConfig) error {
 		return err
 	}
 
-	err = validateUnitFloat(
+	err = validatePositiveUnitFloat(
 		"hints.vision.button_min_confidence",
 		vision.ButtonMinConfidence,
 	)
@@ -363,7 +363,7 @@ func validateHintsVisionConfig(vision HintsVisionConfig) error {
 		return err
 	}
 
-	err = validateUnitFloat(
+	err = validatePositiveUnitFloat(
 		"hints.vision.generic_clickable_min_confidence",
 		vision.GenericClickableMinConfidence,
 	)
@@ -411,6 +411,18 @@ func validateUnitFloat(name string, value float64) error {
 		return derrors.Newf(
 			derrors.CodeInvalidConfig,
 			"%s must be between 0 and 1",
+			name,
+		)
+	}
+
+	return nil
+}
+
+func validatePositiveUnitFloat(name string, value float64) error {
+	if value <= 0 || value > 1 {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"%s must be between 0 (exclusive) and 1 (inclusive)",
 			name,
 		)
 	}

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -301,6 +301,120 @@ func (c *Config) ValidateHints() error {
 		)
 	}
 
+	err = validateHintsVisionConfig(c.Hints.Vision)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateHintsVisionConfig(vision HintsVisionConfig) error {
+	if !vision.DetectText && !vision.DetectRectangles {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.vision must enable detect_text or detect_rectangles",
+		)
+	}
+
+	if vision.RequestTimeoutMS <= 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.vision.request_timeout_ms must be greater than 0",
+		)
+	}
+
+	if vision.RectangleMaxCandidates <= 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.vision.rectangle_max_candidates must be greater than 0",
+		)
+	}
+
+	err := validateUnitFloat(
+		"hints.vision.minimum_confidence",
+		vision.MinimumConfidence,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = validateUnitFloat(
+		"hints.vision.merge_iou_threshold",
+		vision.MergeIOUThreshold,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = validateUnitFloat(
+		"hints.vision.rectangle_min_size",
+		vision.RectangleMinSize,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = validateUnitFloat(
+		"hints.vision.button_min_confidence",
+		vision.ButtonMinConfidence,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = validateUnitFloat(
+		"hints.vision.generic_clickable_min_confidence",
+		vision.GenericClickableMinConfidence,
+	)
+	if err != nil {
+		return err
+	}
+
+	if vision.RectangleMinAspect <= 0 || vision.RectangleMaxAspect <= 0 ||
+		vision.RectangleMinAspect > vision.RectangleMaxAspect {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.vision rectangle aspect limits must be > 0 and min <= max",
+		)
+	}
+
+	if vision.ButtonMinAspect <= 0 || vision.ButtonMaxAspect <= 0 ||
+		vision.ButtonMinAspect > vision.ButtonMaxAspect {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.vision button aspect limits must be > 0 and min <= max",
+		)
+	}
+
+	if vision.ButtonIconMaxSize <= 0 || vision.LinkMaxHeight <= 0 ||
+		vision.LinkMinWidth <= 0 || vision.ImageMinSize <= 0 ||
+		vision.CheckboxMaxSize <= 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.vision size thresholds must be greater than 0",
+		)
+	}
+
+	if vision.LinkMinAspect <= 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.vision.link_min_aspect must be greater than 0",
+		)
+	}
+
+	return nil
+}
+
+func validateUnitFloat(name string, value float64) error {
+	if value < 0 || value > 1 {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"%s must be between 0 and 1",
+			name,
+		)
+	}
+
 	return nil
 }
 

--- a/internal/config/validators_hints_test.go
+++ b/internal/config/validators_hints_test.go
@@ -61,3 +61,41 @@ func TestValidateHints_UIPlacement(t *testing.T) {
 		t.Fatal("ValidateHints() expected error for invalid hints.ui.placement")
 	}
 }
+
+func TestValidateHints_PositiveUnitFloat(t *testing.T) {
+	// merge_iou_threshold cannot be 0
+	cfg := config.DefaultConfig()
+	cfg.Hints.Vision.MergeIOUThreshold = 0.0
+
+	err := cfg.ValidateHints()
+	if err == nil {
+		t.Fatal("ValidateHints() expected error for 0.0 merge_iou_threshold")
+	}
+
+	// button_min_confidence cannot be 0
+	cfg = config.DefaultConfig()
+	cfg.Hints.Vision.ButtonMinConfidence = 0.0
+
+	err = cfg.ValidateHints()
+	if err == nil {
+		t.Fatal("ValidateHints() expected error for 0.0 button_min_confidence")
+	}
+
+	// generic_clickable_min_confidence cannot be 0
+	cfg = config.DefaultConfig()
+	cfg.Hints.Vision.GenericClickableMinConfidence = 0.0
+
+	err = cfg.ValidateHints()
+	if err == nil {
+		t.Fatal("ValidateHints() expected error for 0.0 generic_clickable_min_confidence")
+	}
+
+	// but minimum_confidence CAN be 0
+	cfg = config.DefaultConfig()
+	cfg.Hints.Vision.MinimumConfidence = 0.0
+
+	err = cfg.ValidateHints()
+	if err != nil {
+		t.Fatalf("ValidateHints() expected no error for 0.0 minimum_confidence, got %v", err)
+	}
+}

--- a/internal/core/infra/platform/darwin/vision.h
+++ b/internal/core/infra/platform/darwin/vision.h
@@ -15,12 +15,20 @@ typedef struct {
 	int count;
 } VisionResult;
 
+typedef struct {
+	int requestTimeoutMS;
+	int rectangleMaxCandidates;
+	double rectangleMinSize;
+	double rectangleMinAspect;
+	double rectangleMaxAspect;
+} NeruVisionConfig;
+
 // Captures the display containing the given rect and runs Vision Framework
 // detection. On multi-monitor setups this ensures the display with the
 // focused window is captured, not just the primary display.
 // Returns detected regions (text, rectangles) for the captured display.
 // Caller must call NeruFreeVisionResult() on the returned pointer.
-VisionResult *NeruDetectElements(CGRect detectionRect);
+VisionResult *NeruDetectElements(CGRect detectionRect, NeruVisionConfig config);
 
 // Captures raw screen pixels for the main display.
 // Returns a CGImageRef (caller must CFRelease).

--- a/internal/core/infra/platform/darwin/vision.h
+++ b/internal/core/infra/platform/darwin/vision.h
@@ -16,6 +16,8 @@ typedef struct {
 } VisionResult;
 
 typedef struct {
+	int detectText;
+	int detectRectangles;
 	int requestTimeoutMS;
 	int rectangleMaxCandidates;
 	double rectangleMinSize;

--- a/internal/core/infra/platform/darwin/vision_darwin.m
+++ b/internal/core/infra/platform/darwin/vision_darwin.m
@@ -137,12 +137,12 @@ static CGImageRef captureDisplayImage(CGDirectDisplayID displayID) {
 	return createDisplayImage(displayID);
 }
 
-static NSArray<VNRectangleObservation *> *detectRectangles(CGImageRef image) {
+static NSArray<VNRectangleObservation *> *detectRectangles(CGImageRef image, NeruVisionConfig config) {
 	VNDetectRectanglesRequest *request = [[VNDetectRectanglesRequest alloc] init];
-	request.maximumObservations = 100;
-	request.minimumSize = 0.01;
-	request.minimumAspectRatio = 0.3;
-	request.maximumAspectRatio = 10.0;
+	request.maximumObservations = config.rectangleMaxCandidates;
+	request.minimumSize = config.rectangleMinSize;
+	request.minimumAspectRatio = config.rectangleMinAspect;
+	request.maximumAspectRatio = config.rectangleMaxAspect;
 
 	VNImageRequestHandler *handler = [[VNImageRequestHandler alloc] initWithCGImage:image options:@{}];
 	NSError *error = nil;
@@ -175,7 +175,7 @@ static CGRect visionRectToCGRect(CGRect imageBounds, CGRect normalizedRect) {
 	return CGRectMake(x, y, w, h);
 }
 
-VisionResult *NeruDetectElements(CGRect screenBounds) {
+VisionResult *NeruDetectElements(CGRect screenBounds, NeruVisionConfig config) {
 	@autoreleasepool {
 		// Resolve which display contains the window
 		CGDirectDisplayID displays[32];
@@ -201,6 +201,7 @@ VisionResult *NeruDetectElements(CGRect screenBounds) {
 		// Compute scale from the actual image pixels vs display bounds (points).
 		// CGDisplayPixelsWide can return point-count on some systems, so we rely
 		// on the captured image for the true pixel resolution.
+		// Scale handles high DPI / retina screens.
 		CGFloat scaleX = imgW / displayBounds.size.width;
 		CGFloat scaleY = imgH / displayBounds.size.height;
 
@@ -220,12 +221,12 @@ VisionResult *NeruDetectElements(CGRect screenBounds) {
 
 		CFRetain(image);
 		dispatch_group_async(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-			rects = detectRectangles(image);
+			rects = detectRectangles(image, config);
 		});
 		dispatch_group_async(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
 			texts = detectText(image);
 		});
-		dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC);
+		dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)config.requestTimeoutMS * 1000000LL);
 		if (dispatch_group_wait(group, timeout) != 0) {
 			dispatch_group_notify(group, dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
 				CGImageRelease(image);

--- a/internal/core/infra/platform/darwin/vision_darwin.m
+++ b/internal/core/infra/platform/darwin/vision_darwin.m
@@ -220,12 +220,16 @@ VisionResult *NeruDetectElements(CGRect screenBounds, NeruVisionConfig config) {
 		__block NSArray<VNRecognizedTextObservation *> *texts = nil;
 
 		CFRetain(image);
-		dispatch_group_async(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-			rects = detectRectangles(image, config);
-		});
-		dispatch_group_async(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-			texts = detectText(image);
-		});
+		if (config.detectRectangles) {
+			dispatch_group_async(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+				rects = detectRectangles(image, config);
+			});
+		}
+		if (config.detectText) {
+			dispatch_group_async(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+				texts = detectText(image);
+			});
+		}
 		dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)config.requestTimeoutMS * 1000000LL);
 		if (dispatch_group_wait(group, timeout) != 0) {
 			dispatch_group_notify(group, dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{

--- a/internal/core/infra/vision/adapter_darwin.go
+++ b/internal/core/infra/vision/adapter_darwin.go
@@ -46,7 +46,19 @@ func (a *Adapter) DetectElements(
 		size:   C.CGSize{width: C.double(screenBounds.Dx()), height: C.double(screenBounds.Dy())},
 	}
 
+	var detectText C.int
+	if cfg.DetectText {
+		detectText = 1
+	}
+
+	var detectRectangles C.int
+	if cfg.DetectRectangles {
+		detectRectangles = 1
+	}
+
 	cCfg := C.NeruVisionConfig{
+		detectText:             detectText,
+		detectRectangles:       detectRectangles,
 		requestTimeoutMS:       C.int(cfg.RequestTimeoutMS),
 		rectangleMaxCandidates: C.int(cfg.RectangleMaxCandidates),
 		rectangleMinSize:       C.double(cfg.RectangleMinSize),

--- a/internal/core/infra/vision/adapter_darwin.go
+++ b/internal/core/infra/vision/adapter_darwin.go
@@ -18,6 +18,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain/element"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	_ "github.com/y3owk1n/neru/internal/core/infra/platform/darwin" // ensure darwin CGo .m files are compiled
@@ -31,6 +32,7 @@ const bytesPerPixel = 4
 func (a *Adapter) DetectElements(
 	ctx context.Context,
 	screenBounds image.Rectangle,
+	cfg config.HintsVisionConfig,
 ) ([]*element.Element, error) {
 	select {
 	case <-ctx.Done():
@@ -44,7 +46,15 @@ func (a *Adapter) DetectElements(
 		size:   C.CGSize{width: C.double(screenBounds.Dx()), height: C.double(screenBounds.Dy())},
 	}
 
-	result := C.NeruDetectElements(cgRect)
+	cCfg := C.NeruVisionConfig{
+		requestTimeoutMS:       C.int(cfg.RequestTimeoutMS),
+		rectangleMaxCandidates: C.int(cfg.RectangleMaxCandidates),
+		rectangleMinSize:       C.double(cfg.RectangleMinSize),
+		rectangleMinAspect:     C.double(cfg.RectangleMinAspect),
+		rectangleMaxAspect:     C.double(cfg.RectangleMaxAspect),
+	}
+
+	result := C.NeruDetectElements(cgRect, cCfg)
 	if result == nil {
 		return nil, nil
 	}
@@ -61,6 +71,17 @@ func (a *Adapter) DetectElements(
 	cRegions := (*[1 << 30]C.VisionRegion)(unsafe.Pointer(result.regions))[:count:count]
 
 	for _, cRegion := range cRegions {
+		isText := cRegion.isText != 0
+		if isText && !cfg.DetectText {
+			continue
+		}
+		if !isText && !cfg.DetectRectangles {
+			continue
+		}
+		if float64(cRegion.score) < cfg.MinimumConfidence {
+			continue
+		}
+
 		region := DetectedRegion{
 			Bounds: image.Rectangle{
 				Min: image.Point{X: int(cRegion.x), Y: int(cRegion.y)},
@@ -70,7 +91,7 @@ func (a *Adapter) DetectElements(
 				},
 			},
 			Score:  float64(cRegion.score),
-			IsText: cRegion.isText != 0,
+			IsText: isText,
 		}
 		if cRegion.label != nil {
 			region.Label = C.GoString(cRegion.label)
@@ -79,7 +100,7 @@ func (a *Adapter) DetectElements(
 	}
 
 	// Merge overlapping regions via NMS
-	merged := MergeRegions(regions)
+	merged := MergeRegions(regions, cfg.MergeIOUThreshold)
 
 	// Filter regions outside the window bounds
 	windowElements := make([]DetectedRegion, 0, len(merged))
@@ -90,7 +111,7 @@ func (a *Adapter) DetectElements(
 	}
 
 	// Classify and convert to domain elements
-	classifier := regionClassifier{}
+	classifier := regionClassifier{cfg: cfg}
 	elements := make([]*element.Element, 0, len(windowElements))
 
 	for _, region := range windowElements {

--- a/internal/core/infra/vision/adapter_other.go
+++ b/internal/core/infra/vision/adapter_other.go
@@ -6,12 +6,17 @@ import (
 	"context"
 	"image"
 
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain/element"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
 
 // DetectElements is a no-op stub on non-darwin platforms.
-func (a *Adapter) DetectElements(_ context.Context, _ image.Rectangle) ([]*element.Element, error) {
+func (a *Adapter) DetectElements(
+	_ context.Context,
+	_ image.Rectangle,
+	_ config.HintsVisionConfig,
+) ([]*element.Element, error) {
 	return nil, derrors.New(derrors.CodeNotSupported, "vision detection is only supported on macOS")
 }
 

--- a/internal/core/infra/vision/classifier_test.go
+++ b/internal/core/infra/vision/classifier_test.go
@@ -137,7 +137,7 @@ func TestMergeRegions_NonOverlapping(t *testing.T) {
 		{Bounds: image.Rect(100, 0, 150, 50), Score: 0.8},
 	}
 
-	merged := MergeRegions(regions)
+	merged := MergeRegions(regions, 0.5)
 	if len(merged) != 2 {
 		t.Errorf("expected 2 regions, got %d", len(merged))
 	}
@@ -149,7 +149,7 @@ func TestMergeRegions_Overlapping(t *testing.T) {
 		{Bounds: image.Rect(10, 10, 90, 90), Score: 0.5}, // high IoU with first
 	}
 
-	merged := MergeRegions(regions)
+	merged := MergeRegions(regions, 0.5)
 	if len(merged) != 1 {
 		t.Errorf("expected 1 merged region, got %d", len(merged))
 	}
@@ -161,7 +161,7 @@ func TestMergeRegions_PartialOverlap(t *testing.T) {
 		{Bounds: image.Rect(30, 30, 80, 80), Score: 0.8}, // partial overlap
 	}
 
-	merged := MergeRegions(regions)
+	merged := MergeRegions(regions, 0.5)
 	if len(merged) != 2 {
 		t.Errorf("expected 2 regions for partial overlap, got %d", len(merged))
 	}

--- a/internal/core/infra/vision/heuristics.go
+++ b/internal/core/infra/vision/heuristics.go
@@ -3,6 +3,8 @@ package vision
 import (
 	"image"
 	"math"
+
+	"github.com/y3owk1n/neru/internal/config"
 )
 
 // DetectedRegion represents a region of interest identified by a Vision
@@ -18,11 +20,11 @@ type DetectedRegion struct {
 // regionClassifier applies geometric and saliency heuristics to assign
 // roles to detected regions. It is the first-pass classifier used on all
 // platforms; a Core ML model can be swapped in later for improved accuracy.
-type regionClassifier struct{}
+type regionClassifier struct {
+	cfg config.HintsVisionConfig
+}
 
 const roleButton = "AXButton"
-
-const buttonIconMaxSize = 48 // max dimension (px) for near-square regions to be considered buttons/icons
 
 // Classify assigns a role to a detected region based on its geometry and
 // saliency score. Returns the role string and whether the region is considered
@@ -39,20 +41,25 @@ func (c *regionClassifier) Classify(region DetectedRegion) (string, bool) {
 	aspectRatio := width / height
 
 	switch {
-	case region.IsText && isLikelyButton(aspectRatio, region.Score, width, height):
+	case region.IsText && c.isLikelyButton(aspectRatio, region.Score, width, height):
 		return roleButton, true
-	case region.IsText && isLikelyLink(aspectRatio, width, height):
+	case region.IsText && c.isLikelyLink(aspectRatio, width, height):
 		return "AXLink", true
 	case region.IsText:
 		return "AXStaticText", false
-	case isLikelyCheckBox(aspectRatio, width, height):
+	case c.isLikelyCheckBox(aspectRatio, width, height):
 		return "AXCheckBox", true
-	case isLikelyButton(aspectRatio, region.Score, width, height):
+	case c.isLikelyButton(aspectRatio, region.Score, width, height):
 		return roleButton, true
-	case isLikelyImage(aspectRatio, width, height):
+	case c.isLikelyImage(aspectRatio, width, height):
 		return "AXImage", false
 	default:
-		if region.Score > 0.5 { //nolint:mnd
+		minConf := 0.5
+		if c.cfg.GenericClickableMinConfidence > 0 {
+			minConf = c.cfg.GenericClickableMinConfidence
+		}
+
+		if region.Score > minConf {
 			return roleButton, true
 		}
 
@@ -64,41 +71,92 @@ func (c *regionClassifier) Classify(region DetectedRegion) (string, bool) {
 // Buttons and toolbar icons are typically 0.8:1 to 8:1 width:height
 // (square-ish to wide) with decent saliency. For near-square regions,
 // size is constrained to avoid catching large images.
-func isLikelyButton(aspectRatio, score, width, height float64) bool {
-	if aspectRatio < 0.8 || aspectRatio > 8.0 || score < 0.3 {
+func (c *regionClassifier) isLikelyButton(aspectRatio, score, width, height float64) bool {
+	minAspect := 0.8
+	if c.cfg.ButtonMinAspect > 0 {
+		minAspect = c.cfg.ButtonMinAspect
+	}
+
+	maxAspect := 8.0
+	if c.cfg.ButtonMaxAspect > 0 {
+		maxAspect = c.cfg.ButtonMaxAspect
+	}
+
+	minConf := 0.3
+	if c.cfg.ButtonMinConfidence > 0 {
+		minConf = c.cfg.ButtonMinConfidence
+	}
+
+	maxIconSize := 48
+	if c.cfg.ButtonIconMaxSize > 0 {
+		maxIconSize = c.cfg.ButtonIconMaxSize
+	}
+
+	if aspectRatio < minAspect || aspectRatio > maxAspect || score < minConf {
 		return false
 	}
 
 	// Near-square regions: limit size to avoid classifying images as buttons
-	if aspectRatio >= 0.8 && aspectRatio <= 1.5 {
-		return max(width, height) <= buttonIconMaxSize
+	if aspectRatio >= minAspect && aspectRatio <= 1.5 {
+		return max(width, height) <= float64(maxIconSize)
 	}
 
 	return true
 }
 
 // isLikelyLink checks for long, narrow text (links).
-func isLikelyLink(aspectRatio, w, h float64) bool {
-	return aspectRatio > 5.0 && h < 40 && w > 50
+func (c *regionClassifier) isLikelyLink(aspectRatio, width, height float64) bool {
+	minAspect := 5.0
+	if c.cfg.LinkMinAspect > 0 {
+		minAspect = c.cfg.LinkMinAspect
+	}
+
+	maxHeight := 40
+	if c.cfg.LinkMaxHeight > 0 {
+		maxHeight = c.cfg.LinkMaxHeight
+	}
+
+	minWidth := 50
+	if c.cfg.LinkMinWidth > 0 {
+		minWidth = c.cfg.LinkMinWidth
+	}
+
+	return aspectRatio > minAspect && height < float64(maxHeight) && width > float64(minWidth)
 }
 
 // isLikelyImage checks for near-square regions that are large enough to be
-// actual images rather than buttons or icons. Images ≥ 48px in both dimensions
+// actual images rather than buttons or icons. Images >= 48px in both dimensions
 // with near-square aspect are classified as non-interactive.
-func isLikelyImage(aspectRatio, w, h float64) bool {
-	return aspectRatio >= 0.8 && aspectRatio <= 1.5 && w >= 48 && h >= 48
+func (c *regionClassifier) isLikelyImage(aspectRatio, width, height float64) bool {
+	minSize := 48
+	if c.cfg.ImageMinSize > 0 {
+		minSize = c.cfg.ImageMinSize
+	}
+
+	return aspectRatio >= 0.8 && aspectRatio <= 1.5 && width >= float64(minSize) &&
+		height >= float64(minSize)
 }
 
 // isLikelyCheckBox checks for small square-ish regions (< 32px in both dims).
-func isLikelyCheckBox(aspectRatio, w, h float64) bool {
-	return aspectRatio >= 0.8 && aspectRatio <= 1.5 && w < 32 && h < 32
+func (c *regionClassifier) isLikelyCheckBox(aspectRatio, width, height float64) bool {
+	maxSize := 32
+	if c.cfg.CheckboxMaxSize > 0 {
+		maxSize = c.cfg.CheckboxMaxSize
+	}
+
+	return aspectRatio >= 0.8 && aspectRatio <= 1.5 && width < float64(maxSize) &&
+		height < float64(maxSize)
 }
 
 // MergeRegions merges overlapping regions using non-maximum suppression.
-// Regions with higher scores suppress lower-scoring overlaps (IoU > 0.5).
-func MergeRegions(regions []DetectedRegion) []DetectedRegion {
+// Regions with higher scores suppress lower-scoring overlaps (IoU > iouThreshold).
+func MergeRegions(regions []DetectedRegion, iouThreshold float64) []DetectedRegion {
 	if len(regions) == 0 {
 		return nil
+	}
+
+	if iouThreshold <= 0 {
+		iouThreshold = 0.5
 	}
 
 	// Sort by score descending
@@ -114,7 +172,7 @@ func MergeRegions(regions []DetectedRegion) []DetectedRegion {
 		var remaining []DetectedRegion
 		for _, r := range sorted {
 			iou := intersectionOverUnion(best.Bounds, r.Bounds)
-			if iou < 0.5 { //nolint:mnd
+			if iou < iouThreshold {
 				remaining = append(remaining, r)
 			}
 		}

--- a/internal/core/ports/vision.go
+++ b/internal/core/ports/vision.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"image"
 
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain/element"
 )
 
@@ -23,7 +24,11 @@ type VisionPort interface {
 	// detection to the window region. Implementations use Vision Framework
 	// requests (text recognition, rectangle detection, saliency) and a
 	// heuristic classifier to assign element roles.
-	DetectElements(ctx context.Context, screenBounds image.Rectangle) ([]*element.Element, error)
+	DetectElements(
+		ctx context.Context,
+		screenBounds image.Rectangle,
+		cfg config.HintsVisionConfig,
+	) ([]*element.Element, error)
 
 	// CaptureScreen returns the current screen image for the primary display.
 	// Used by DetectElements internally, but exposed for testing or inspection.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fully wires up the `[hints.vision]` configuration parameters to take all vision parameters configurable.

```toml
[hints.vision]
detect_text = true                           # Enable text detection via Vision framework
detect_rectangles = true                     # Enable rectangle detection via Vision framework
request_timeout_ms = 5000                    # Timeout for Vision requests in milliseconds
minimum_confidence = 0.0                     # Minimum confidence threshold for keeping vision observations
merge_iou_threshold = 0.5                    # Overlap threshold (Intersection over Union) for merging redundant boxes
rectangle_max_candidates = 100               # Maximum number of rectangle candidate observations to track
rectangle_min_size = 0.01                    # Minimum size of detected rectangles (0.01 = 1% of screen/window width/height)
rectangle_min_aspect = 0.3                   # Minimum aspect ratio (width/height) for rectangles
rectangle_max_aspect = 10.0                  # Maximum aspect ratio (width/height) for rectangles
button_min_confidence = 0.3                  # Minimum confidence for button classification
button_min_aspect = 0.8                      # Minimum aspect ratio for button elements
button_max_aspect = 8.0                      # Maximum aspect ratio for button elements
button_icon_max_size = 48                    # Maximum width/height for square button/icon elements (px)
link_min_aspect = 5.0                        # Minimum aspect ratio for text link elements
link_max_height = 40                         # Maximum height for link elements (px)
link_min_width = 50                          # Minimum width for link elements (px)
image_min_size = 48                          # Minimum width/height for image elements (px)
checkbox_max_size = 32                       # Maximum width/height for checkbox elements (px)
generic_clickable_min_confidence = 0.5       # Minimum confidence for generic clickable classification
```

User can fine tuned them as they wish.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
