### PR TITLE
fix(hotkeys): ensure consistent initialdelay with interval for repeat

### DIFF
--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -186,12 +186,11 @@ func (a *App) startHotkeyRepeat(key string, actions []string) {
 		defer ticker.Stop()
 
 		for {
-			a.dispatchHotkeyActions(key, actions)
-
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
+				a.dispatchHotkeyActions(key, actions)
 			}
 		}
 	}()

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	hotkeySequenceTimeout = 500 * time.Millisecond
-	heldRepeatInterval    = 50 * time.Millisecond
+	hotkeySequenceTimeout  = 500 * time.Millisecond
+	heldRepeatInitialDelay = 50 * time.Millisecond
+	heldRepeatInterval     = 50 * time.Millisecond
 )
 
 const keyUpPrefix = "__keyup_"
@@ -405,6 +406,15 @@ func (h *Handler) startHeldRepeatLocked(key, bindKey string, actions []string) {
 					zap.String("key", bindKey))
 			}
 		}()
+
+		initialTimer := time.NewTimer(heldRepeatInitialDelay)
+		defer initialTimer.Stop()
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-initialTimer.C:
+		}
 
 		ticker := time.NewTicker(heldRepeatInterval)
 		defer ticker.Stop()


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR ensures the consistency of global repeat and eventtap repeat, with 50ms each for intervals and initial delay.

This should be good enough to prevent double activation, but still smooth enough without that initial bump.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #871

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
