### PR TITLE
fix: ensure screen capture permission flow consistency

### DIFF
--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -348,6 +348,7 @@ func initializeModeHandler(app *App) {
 		deps.callbacks.postModifierEvent,
 		deps.callbacks.refreshHotkeys,
 		deps.callbacks.executeHotkeyAction,
+		app.Quit,
 		app.textInput,
 		app.systemPort,
 	)

--- a/internal/app/components/systray/systray.go
+++ b/internal/app/components/systray/systray.go
@@ -36,6 +36,8 @@ type AppInterface interface {
 	ToggleOverlayHiddenForScreenShare() bool
 	OnScreenShareStateChanged(callback func(bool)) uint64
 	OffScreenShareStateChanged(id uint64)
+	// Quit triggers a graceful shutdown of the application.
+	Quit()
 }
 
 // Component encapsulates systray functionality.
@@ -293,7 +295,7 @@ func (c *Component) handleEvents() {
 		case <-c.mToggleScreenShare.ClickedCh:
 			c.handleToggleScreenShare()
 		case <-c.mQuit.ClickedCh:
-			systray.Quit()
+			c.app.Quit()
 
 			return
 		case <-c.stateUpdateSignal:

--- a/internal/app/components/systray/systray_test.go
+++ b/internal/app/components/systray/systray_test.go
@@ -63,6 +63,7 @@ func (m *mockApp) OnScreenShareStateChanged(callback func(bool)) uint64 {
 	return 0
 }
 func (m *mockApp) OffScreenShareStateChanged(id uint64) {}
+func (m *mockApp) Quit()                                {}
 
 func TestNewComponent(t *testing.T) {
 	logger := zaptest.NewLogger(t)

--- a/internal/app/initialization_platform_darwin.go
+++ b/internal/app/initialization_platform_darwin.go
@@ -6,9 +6,15 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/core/infra/platform/darwin"
+	infrasystray "github.com/y3owk1n/neru/internal/core/infra/systray"
 )
 
 // initializePlatformLogger sets up the platform-specific logger.
 func initializePlatformLogger(logger *zap.Logger) {
 	darwin.InitializeLogger(logger)
+}
+
+// platformQuit triggers the platform-specific quit mechanism.
+func platformQuit() {
+	infrasystray.Quit()
 }

--- a/internal/app/initialization_platform_linux.go
+++ b/internal/app/initialization_platform_linux.go
@@ -6,3 +6,6 @@ import "go.uber.org/zap"
 
 // initializePlatformLogger is a no-op on Linux.
 func initializePlatformLogger(_ *zap.Logger) {}
+
+// platformQuit is a no-op on Linux.
+func platformQuit() {}

--- a/internal/app/initialization_platform_windows.go
+++ b/internal/app/initialization_platform_windows.go
@@ -6,3 +6,6 @@ import "go.uber.org/zap"
 
 // initializePlatformLogger is a no-op on Windows.
 func initializePlatformLogger(_ *zap.Logger) {}
+
+// platformQuit is a no-op on Windows.
+func platformQuit() {}

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -574,6 +574,12 @@ func (a *App) Stop() {
 	})
 }
 
+// Quit triggers a graceful shutdown of the application.
+func (a *App) Quit() {
+	a.Stop()
+	platformQuit()
+}
+
 // Cleanup cleans up resources. It is safe to call multiple times; only the
 // first invocation performs the actual teardown.
 func (a *App) Cleanup() {

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -90,6 +90,7 @@ type Handler struct {
 	postModifierEvent          func(modifier string, isDown bool)
 	refreshHotkeys             func()
 	executeHotkeyAction        func(key, actionStr string) error
+	shutdown                   func()
 	refreshHintsTimer          *time.Timer
 	modeSession                uint64
 	hotkeyLastKey              string
@@ -162,6 +163,7 @@ func NewHandler(
 	postModifierEvent func(modifier string, isDown bool),
 	refreshHotkeys func(),
 	executeHotkeyAction func(key, actionStr string) error,
+	shutdown func(),
 	textInput ports.TextInputPort,
 	systemPort ports.SystemPort,
 ) *Handler {
@@ -215,6 +217,7 @@ func NewHandler(
 		postModifierEvent:          postModifierEvent,
 		refreshHotkeys:             refreshHotkeys,
 		executeHotkeyAction:        executeHotkeyAction,
+		shutdown:                   shutdown,
 		textInput:                  textInput,
 		themeProvider:              systemPort,
 		system:                     systemPort,

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -303,6 +303,8 @@ func (h *Handler) activateHintModeInternal(
 			choice := platform.ShowScreenCapturePermissionAlert()
 			if choice == platform.ScreenCapturePermissionStartupQuit {
 				h.shutdown()
+
+				return
 			}
 
 			if choice == platform.ScreenCapturePermissionStartupCancel {

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -8,10 +8,12 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/app/components/hints"
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	domainHint "github.com/y3owk1n/neru/internal/core/domain/hint"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	"github.com/y3owk1n/neru/internal/core/infra/platform"
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
@@ -291,6 +293,26 @@ func (h *Handler) activateHintModeInternal(
 		strategyVal = *strategyOverride
 	}
 
+	strategy := h.config.Hints.StrategyForApp(bundleID)
+	if strategyVal != "" {
+		strategy = strategyVal
+	}
+
+	if strategy == config.StrategyVision {
+		if !platform.CheckScreenCapturePermissions() {
+			choice := platform.ShowScreenCapturePermissionAlert()
+			if choice == platform.ScreenCapturePermissionStartupQuit {
+				h.shutdown()
+			}
+
+			if choice == platform.ScreenCapturePermissionStartupCancel {
+				h.exitModeLocked()
+
+				return
+			}
+		}
+	}
+
 	domainHints, domainHintsErr := h.hintService.GenerateHints(
 		ctx,
 		filterRoles,
@@ -407,11 +429,6 @@ func (h *Handler) activateHintModeInternal(
 
 	h.overlayManager.ResizeToActiveScreen()
 	h.overlayManager.Show()
-
-	strategy := h.config.Hints.StrategyForApp(bundleID)
-	if strategyVal != "" {
-		strategy = strategyVal
-	}
 
 	fields := []zap.Field{
 		zap.Duration("elapsed", time.Since(activationStart)),

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -298,21 +298,16 @@ func (h *Handler) activateHintModeInternal(
 		strategy = strategyVal
 	}
 
-	if strategy == config.StrategyVision {
-		if !platform.CheckScreenCapturePermissions() {
-			choice := platform.ShowScreenCapturePermissionAlert()
-			if choice == platform.ScreenCapturePermissionStartupQuit {
-				h.shutdown()
+	var permissionOk bool
 
-				return
-			}
-
-			if choice == platform.ScreenCapturePermissionStartupCancel {
-				h.exitModeLocked()
-
-				return
-			}
-		}
+	activeScreenBounds, bundleID, strategy, permissionOk = h.ensureScreenCapturePermissionsLocked(
+		activeScreenBounds,
+		bundleID,
+		strategy,
+		strategyVal,
+	)
+	if !permissionOk {
+		return
 	}
 
 	domainHints, domainHintsErr := h.hintService.GenerateHints(
@@ -451,4 +446,80 @@ func (h *Handler) activateHintModeInternal(
 	}
 
 	h.startIndicatorPolling(domain.ModeHints)
+}
+
+// ensureScreenCapturePermissionsLocked checks and requests screen capture permissions.
+// It releases h.mu during the modal prompt to avoid blocking other threads.
+// Returns the updated activeScreenBounds, bundleID, strategy, and whether it is safe to proceed.
+func (h *Handler) ensureScreenCapturePermissionsLocked(
+	activeScreenBounds image.Rectangle,
+	bundleID string,
+	strategy string,
+	strategyVal string,
+) (image.Rectangle, string, string, bool) {
+	if strategy != config.StrategyVision {
+		return activeScreenBounds, bundleID, strategy, true
+	}
+
+	if platform.CheckScreenCapturePermissions() {
+		return activeScreenBounds, bundleID, strategy, true
+	}
+
+	session := h.modeSession
+	h.mu.Unlock()
+
+	choice := platform.ShowScreenCapturePermissionAlert()
+
+	h.mu.Lock()
+
+	// Check if state changed while we were unlocked.
+	if h.ctx.Err() != nil || h.modeSession != session {
+		h.logger.Debug(
+			"Aborting hint mode activation: state changed or context canceled while waiting for permission dialog",
+		)
+
+		return activeScreenBounds, bundleID, strategy, false
+	}
+
+	if choice == platform.ScreenCapturePermissionStartupQuit {
+		h.shutdown()
+
+		return activeScreenBounds, bundleID, strategy, false
+	}
+
+	if choice == platform.ScreenCapturePermissionStartupCancel {
+		h.exitModeLocked()
+
+		return activeScreenBounds, bundleID, strategy, false
+	}
+
+	// Re-read screen bounds under the lock in case they changed while the modal was open.
+	if h.system != nil {
+		b, err := h.system.ScreenBounds(h.ctx)
+		if err == nil {
+			activeScreenBounds = b
+			h.screenBounds = activeScreenBounds
+		}
+	}
+
+	// Re-fetch bundle ID under the lock since the focused app might have changed while the modal was open.
+	bundleCtx, bundleCancel := context.WithTimeout(h.ctx, 1*time.Second)
+	newBundleID, bundleIDErr := h.actionService.FocusedAppBundleID(bundleCtx)
+
+	bundleCancel()
+
+	if bundleIDErr == nil {
+		bundleID = newBundleID
+	} else {
+		h.logger.Debug("Failed to re-fetch focused app bundle ID for hint generation",
+			zap.Error(bundleIDErr))
+	}
+
+	// Re-evaluate strategy in case the focused app changed.
+	strategy = h.config.Hints.StrategyForApp(bundleID)
+	if strategyVal != "" {
+		strategy = strategyVal
+	}
+
+	return activeScreenBounds, bundleID, strategy, true
 }

--- a/internal/core/infra/platform/darwin/screencapture.go
+++ b/internal/core/infra/platform/darwin/screencapture.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package darwin
+
+/*
+#include "screencapture.h"
+*/
+import "C"
+
+// CheckScreenCapturePermissions checks if the application has screen recording permission.
+func CheckScreenCapturePermissions() bool {
+	return C.NeruCheckScreenCapturePermissions() != 0
+}
+
+// RequestScreenCapturePermissions requests screen recording permission from macOS.
+func RequestScreenCapturePermissions() bool {
+	return C.NeruRequestScreenCapturePermissions() != 0
+}
+
+// ShowScreenCapturePermissionAlert displays the macOS screen recording permission guidance.
+func ShowScreenCapturePermissionAlert() int {
+	return int(C.NeruShowScreenCapturePermissionAlert())
+}

--- a/internal/core/infra/platform/darwin/screencapture.h
+++ b/internal/core/infra/platform/darwin/screencapture.h
@@ -1,0 +1,8 @@
+#ifndef SCREENCAPTURE_H
+#define SCREENCAPTURE_H
+
+int NeruCheckScreenCapturePermissions(void);
+int NeruRequestScreenCapturePermissions(void);
+int NeruShowScreenCapturePermissionAlert(void);
+
+#endif /* SCREENCAPTURE_H */

--- a/internal/core/infra/platform/darwin/screencapture_permissions_darwin.m
+++ b/internal/core/infra/platform/darwin/screencapture_permissions_darwin.m
@@ -130,7 +130,7 @@ static int showScreenCapturePermissionAlertOnMainThread(void) {
 
 /// Show the startup screen capture permission guidance alert.
 /// The alert lets the user request permission and then dismiss it with Granted.
-/// @return 1 if permission is granted, 2 if the user chose Quit.
+/// @return 1 if permission is granted, 2 if the user cancelled (exit mode), 3 if the user chose Quit/Restart.
 int NeruShowScreenCapturePermissionAlert(void) {
 	@autoreleasepool {
 		__block int result = 0;

--- a/internal/core/infra/platform/darwin/screencapture_permissions_darwin.m
+++ b/internal/core/infra/platform/darwin/screencapture_permissions_darwin.m
@@ -1,0 +1,148 @@
+//
+//  screencapture_permissions_darwin.m
+//  Neru
+//
+//  Copyright © 2026 Neru. All rights reserved.
+//
+
+#import "screencapture.h"
+
+#import <Cocoa/Cocoa.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+#pragma mark - Permission Functions
+
+static BOOL resetScreenCapturePermissionDecision(void) {
+	NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
+	if (bundleID == nil || [bundleID length] == 0) {
+		bundleID = @"com.y3owk1n.neru";
+	}
+
+	NSTask *task = [[NSTask alloc] init];
+	task.launchPath = @"/usr/bin/tccutil";
+	task.arguments = @[ @"reset", @"ScreenCapture", bundleID ];
+
+	@try {
+		[task launch];
+		[task waitUntilExit];
+
+		int status = [task terminationStatus];
+		if (status != 0) {
+			NSLog(
+			    @"Neru: tccutil reset ScreenCapture %@ exited with status %d; system permission dialog may not appear",
+			    bundleID, status);
+			return NO;
+		}
+	} @catch (NSException *exception) {
+		NSLog(@"Neru: failed to reset ScreenCapture permission decision: %@", exception);
+		return NO;
+	}
+
+	return YES;
+}
+
+/// Check if screen capture permissions are granted
+/// @return 1 if permissions are granted, 0 otherwise
+int NeruCheckScreenCapturePermissions(void) {
+	@autoreleasepool {
+		if (@available(macOS 10.15, *)) {
+			return CGPreflightScreenCaptureAccess() ? 1 : 0;
+		}
+		return 1;
+	}
+}
+
+/// Request screen capture permissions from macOS
+/// @return 1 if permissions are granted after the request, 0 otherwise
+int NeruRequestScreenCapturePermissions(void) {
+	@autoreleasepool {
+		if (!resetScreenCapturePermissionDecision()) {
+			NSLog(@"Neru: continuing with ScreenCapture permission request after reset failure");
+		}
+
+		if (@available(macOS 10.15, *)) {
+			return CGRequestScreenCaptureAccess() ? 1 : 0;
+		}
+		return 1;
+	}
+}
+
+#pragma mark - Alert Functions
+
+static int showScreenCapturePermissionAlertOnMainThread(void) {
+	while (NeruCheckScreenCapturePermissions() != 1) {
+		NSAlert *alert = [[NSAlert alloc] init];
+		alert.messageText = @"Screen Recording Permission Needed";
+		alert.informativeText =
+		    @"Neru needs Screen Recording permission to capture the screen for text recognition.\n\n"
+		     "Click 'Request Permission' to open System Settings, enable Neru, then return here and click 'I've "
+		     "Granted It'.\n\n"
+		     "Note: macOS requires restarting Neru after granting screen recording permission for it to take effect.";
+		alert.alertStyle = NSAlertStyleWarning;
+		alert.icon = [NSImage imageNamed:NSImageNameCaution];
+
+		[alert addButtonWithTitle:@"Request Permission"];
+		[alert addButtonWithTitle:@"I've Granted It"];
+		[alert addButtonWithTitle:@"Cancel"];
+
+		[[alert window] setLevel:NSFloatingWindowLevel];
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+		[[alert window] center];
+		[[alert window] makeKeyAndOrderFront:nil];
+		[NSApp activateIgnoringOtherApps:YES];
+
+		NSModalResponse response = [alert runModal];
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
+		if (response == NSAlertFirstButtonReturn) {
+			NeruRequestScreenCapturePermissions();
+		} else if (response == NSAlertSecondButtonReturn) {
+			if (NeruCheckScreenCapturePermissions() == 1) {
+				return 1;  // Granted
+			} else {
+				// Show a confirmation alert explaining the restart requirement
+				NSAlert *restartAlert = [[NSAlert alloc] init];
+				restartAlert.messageText = @"Neru Restart Required";
+				restartAlert.informativeText =
+				    @"macOS requires restarting Neru for Screen Recording permissions to take effect.\n\n"
+				     "Neru will now quit. Please relaunch the application.";
+				restartAlert.alertStyle = NSAlertStyleInformational;
+				[restartAlert addButtonWithTitle:@"Quit Neru"];
+
+				[[restartAlert window] setLevel:NSFloatingWindowLevel];
+				[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+				[[restartAlert window] center];
+				[[restartAlert window] makeKeyAndOrderFront:nil];
+				[NSApp activateIgnoringOtherApps:YES];
+
+				[restartAlert runModal];
+				[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
+				return 3;  // Restart/Quit
+			}
+		} else if (response == NSAlertThirdButtonReturn) {
+			return 2;  // Cancel/Exit mode
+		}
+	}
+
+	return 1;  // Granted
+}
+
+/// Show the startup screen capture permission guidance alert.
+/// The alert lets the user request permission and then dismiss it with Granted.
+/// @return 1 if permission is granted, 2 if the user chose Quit.
+int NeruShowScreenCapturePermissionAlert(void) {
+	@autoreleasepool {
+		__block int result = 0;
+
+		if ([NSThread isMainThread]) {
+			result = showScreenCapturePermissionAlertOnMainThread();
+		} else {
+			dispatch_sync(dispatch_get_main_queue(), ^{
+				result = showScreenCapturePermissionAlertOnMainThread();
+			});
+		}
+
+		return result;
+	}
+}

--- a/internal/core/infra/platform/factory.go
+++ b/internal/core/infra/platform/factory.go
@@ -24,4 +24,8 @@ const (
 
 	AccessibilityPermissionStartupGranted = 1
 	AccessibilityPermissionStartupQuit    = 2
+
+	ScreenCapturePermissionStartupGranted = 1
+	ScreenCapturePermissionStartupCancel  = 2
+	ScreenCapturePermissionStartupQuit    = 3
 )

--- a/internal/core/infra/platform/factory_darwin.go
+++ b/internal/core/infra/platform/factory_darwin.go
@@ -31,3 +31,13 @@ func CheckAccessibilityPermissions() bool {
 func ShowAccessibilityPermissionStartupAlert() int {
 	return int(darwin.ShowAccessibilityPermissionStartupAlert())
 }
+
+// CheckScreenCapturePermissions checks macOS screen recording permission without prompting.
+func CheckScreenCapturePermissions() bool {
+	return darwin.CheckScreenCapturePermissions()
+}
+
+// ShowScreenCapturePermissionAlert displays the macOS screen recording permission guidance.
+func ShowScreenCapturePermissionAlert() int {
+	return darwin.ShowScreenCapturePermissionAlert()
+}

--- a/internal/core/infra/platform/factory_linux.go
+++ b/internal/core/infra/platform/factory_linux.go
@@ -38,3 +38,13 @@ func CheckAccessibilityPermissions() bool {
 func ShowAccessibilityPermissionStartupAlert() int {
 	return AccessibilityPermissionStartupGranted
 }
+
+// CheckScreenCapturePermissions is always true on Linux.
+func CheckScreenCapturePermissions() bool {
+	return true
+}
+
+// ShowScreenCapturePermissionAlert is a no-op on Linux.
+func ShowScreenCapturePermissionAlert() int {
+	return ScreenCapturePermissionStartupGranted
+}

--- a/internal/core/infra/platform/factory_other.go
+++ b/internal/core/infra/platform/factory_other.go
@@ -33,3 +33,13 @@ func CheckAccessibilityPermissions() bool {
 func ShowAccessibilityPermissionStartupAlert() int {
 	return AccessibilityPermissionStartupGranted
 }
+
+// CheckScreenCapturePermissions is always true on unsupported platforms.
+func CheckScreenCapturePermissions() bool {
+	return true
+}
+
+// ShowScreenCapturePermissionAlert is a no-op on unsupported platforms.
+func ShowScreenCapturePermissionAlert() int {
+	return ScreenCapturePermissionStartupGranted
+}

--- a/internal/core/infra/platform/factory_windows.go
+++ b/internal/core/infra/platform/factory_windows.go
@@ -31,3 +31,13 @@ func CheckAccessibilityPermissions() bool {
 func ShowAccessibilityPermissionStartupAlert() int {
 	return AccessibilityPermissionStartupGranted
 }
+
+// CheckScreenCapturePermissions is always true on Windows.
+func CheckScreenCapturePermissions() bool {
+	return true
+}
+
+// ShowScreenCapturePermissionAlert is a no-op on Windows.
+func ShowScreenCapturePermissionAlert() int {
+	return ScreenCapturePermissionStartupGranted
+}

--- a/resources/Info.plist.template
+++ b/resources/Info.plist.template
@@ -45,7 +45,7 @@
 	<key>NSAccessibilityUsageDescription</key>
 	<string>Neru needs Accessibility access to inspect and interact with user interface elements for keyboard-driven navigation.</string>
 
-	<key>NSScreenCaptureDescription</key>
+	<key>NSScreenCaptureUsageDescription</key>
 	<string>Neru may capture screen content for vision-based element detection to enhance navigation accuracy.</string>
 </dict>
 </plist>

--- a/resources/Info.plist.template
+++ b/resources/Info.plist.template
@@ -36,19 +36,16 @@
 	<key>NeruBuildID</key>
 	<string>BUILD_ID</string>
 
-	<key>CSResourcesFileMapped</key>
-	<true/>
-
 	<key>NSHighResolutionCapable</key>
 	<true/>
 
 	<key>LSUIElement</key>
 	<true/>
 
-	<key>NSAppleEventsUsageDescription</key>
-	<string>Used for automation</string>
-
 	<key>NSAccessibilityUsageDescription</key>
-	<string>Requires accessibility access</string>
+	<string>Neru needs Accessibility access to inspect and interact with user interface elements for keyboard-driven navigation.</string>
+
+	<key>NSScreenCaptureDescription</key>
+	<string>Neru may capture screen content for vision-based element detection to enhance navigation accuracy.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR ensure our screen capture permission flow are similar to our accessibility permission flow to not confuse anyone else.

- This flow will only be ran when user activates `vision hints`. Nothing else in neru needs screen recording permission except vision due to OCR.
- The flow is `check permission` -> `request permission` -> `reset permission` -> `exit`. (Manual restart is required)

The most important part is the `reset permission` step. Because we do not have any codesign with developer account, it won't persist and will causes mismatch where it's enabled, but it still keep requesting. Reset makes thing easier and less confusing.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/2449eb28-8314-4abd-8178-a93209c5237e

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
