### PR TITLE
feat(default-config): promote 3x3 recursive grid to default grid

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -186,16 +186,16 @@ border_width = 1
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#recursive_grid
 [recursive_grid]
 enabled = true
-grid_cols = 2                               # Number of columns (>= 1)
-grid_rows = 2                               # Number of rows (>= 1)
-keys = "uijk"                               # Cell selection keys (must be grid_cols * grid_rows chars)
+grid_cols = 3                               # Number of columns (>= 1)
+grid_rows = 3                               # Number of rows (>= 1)
+keys = "rtyfghvbn"                          # Cell selection keys (must be grid_cols * grid_rows chars)
 min_size_width = 25                         # Stop subdividing below this width (px)
 min_size_height = 25                        # Stop subdividing below this height (px)
 max_depth = 10                              # Maximum recursion levels (1–20)
 
 [recursive_grid.animation]
-enabled = false                            # Opt in to native depth transition animation on supported platforms
-duration_ms = 180                          # Recursive-grid animation duration in milliseconds
+enabled = true                              # Opt out from native depth transition animation on supported platforms
+duration_ms = 50                            # Recursive-grid animation duration in milliseconds
 
 [recursive_grid.hotkeys]
 "Escape" = "idle"

--- a/configs/recursive-grid-only-config.toml
+++ b/configs/recursive-grid-only-config.toml
@@ -12,13 +12,13 @@ enabled = false
 
 [recursive_grid]
 enabled = true
-grid_cols = 2
-grid_rows = 2
-keys = "uijk"
+grid_cols = 3
+grid_rows = 3
+keys = "rtyfghvbn"
 
 [recursive_grid.animation]
-enabled = false
-duration_ms = 180
+enabled = true
+duration_ms = 50
 
 [recursive_grid.ui]
 # Add rounded label backgrounds behind recursive-grid letters

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -553,9 +553,9 @@ Cursor behavior: `neru recursive_grid --cursor-selection-mode follow|hold` (see 
 | Option            | Type   | Default  | Description                                                      |
 | ----------------- | ------ | -------- | ---------------------------------------------------------------- |
 | `enabled`         | bool   | `true`   | Enable/disable mode                                              |
-| `grid_cols`       | int    | `2`      | Columns (≥ 1; total cells ≥ 2)                                   |
-| `grid_rows`       | int    | `2`      | Rows (≥ 1; total cells ≥ 2)                                      |
-| `keys`            | string | `"uijk"` | Cell selection keys (must be `grid_cols × grid_rows` characters) |
+| `grid_cols`       | int    | `3`      | Columns (≥ 1; total cells ≥ 2)                                   |
+| `grid_rows`       | int    | `3`      | Rows (≥ 1; total cells ≥ 2)                                      |
+| `keys`            | string | `"rtyfghvbn"` | Cell selection keys (must be `grid_cols × grid_rows` characters) |
 | `min_size_width`  | int    | `25`     | Minimum cell width in pixels                                     |
 | `min_size_height` | int    | `25`     | Minimum cell height in pixels                                    |
 | `max_depth`       | int    | `10`     | Maximum recursion levels (1–20)                                  |
@@ -584,8 +584,8 @@ layers = [
 
 | Option        | Type | Default | Description                                     |
 | ------------- | ---- | ------- | ----------------------------------------------- |
-| `enabled`     | bool | `false` | Native depth transitions on supported platforms |
-| `duration_ms` | int  | `180`   | Transition duration in milliseconds             |
+| `enabled`     | bool | `true` | Native depth transitions on supported platforms |
+| `duration_ms` | int  | `50`   | Transition duration in milliseconds             |
 
 ### UI
 

--- a/internal/app/components/recursivegrid/overlay_darwin.go
+++ b/internal/app/components/recursivegrid/overlay_darwin.go
@@ -267,7 +267,7 @@ func (o *Overlay) DrawRecursiveGrid(
 		gridCols = recursivegrid.DefaultGridCols
 		gridRows = recursivegrid.DefaultGridRows
 		keyCount = gridCols * gridRows
-		keys = "uijk"
+		keys = recursivegrid.DefaultKeys
 	}
 
 	// Validate keys length matches grid dimensions

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -232,7 +232,7 @@ const (
 	// DefaultRecursiveGridMinTotalCells is the minimum allowed total cells.
 	DefaultRecursiveGridMinTotalCells = 2
 	// DefaultRecursiveGridAnimationDurationMS is the default native recursive-grid transition duration in milliseconds.
-	DefaultRecursiveGridAnimationDurationMS = 180
+	DefaultRecursiveGridAnimationDurationMS = 50
 	// DefaultRecursiveGridLineWidth is the default line width for grid lines.
 	DefaultRecursiveGridLineWidth = 1
 	// DefaultRecursiveGridFontSize is the default font size for cell labels.
@@ -456,13 +456,13 @@ func newDefaultConfig() *Config {
 		RecursiveGrid: RecursiveGridConfig{
 			Enabled: true,
 			Animation: RecursiveGridAnimationConfig{
-				Enabled:    false,
+				Enabled:    true,
 				DurationMS: DefaultRecursiveGridAnimationDurationMS,
 			},
-			GridCols: 2, //nolint:mnd
-			GridRows: 2, //nolint:mnd
+			GridCols: 3, //nolint:mnd
+			GridRows: 3, //nolint:mnd
 
-			Keys: "uijk", // warpd convention: u=TL, i=TR, j=BL, k=BR
+			Keys: "rtyfghvbn", // 3x3 grid: left-to-right, top-to-bottom
 			Hotkeys: map[string]StringOrStringArray{
 				"Escape":    {"idle"},
 				"`":         {"toggle-cursor-follow-selection"},

--- a/internal/config/validators_recursive_grid_test.go
+++ b/internal/config/validators_recursive_grid_test.go
@@ -14,9 +14,9 @@ const (
 func TestConfigValidateRecursiveGrid_Valid(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.RecursiveGrid.Enabled = true
-	cfg.RecursiveGrid.GridCols = 2
-	cfg.RecursiveGrid.GridRows = 2
-	cfg.RecursiveGrid.Keys = "uijk"
+	cfg.RecursiveGrid.GridCols = 3
+	cfg.RecursiveGrid.GridRows = 3
+	cfg.RecursiveGrid.Keys = "rtyfghvbn"
 
 	err := cfg.ValidateRecursiveGrid()
 	if err != nil {
@@ -83,11 +83,11 @@ func TestConfigValidateRecursiveGrid_SmallMinSizeAllowed(t *testing.T) {
 	}
 }
 
-func TestDefaultConfigRecursiveGridAnimationDisabled(t *testing.T) {
+func TestDefaultConfigRecursiveGridAnimationEnabled(t *testing.T) {
 	cfg := config.DefaultConfig()
 
-	if cfg.RecursiveGrid.Animation.Enabled {
-		t.Fatal("DefaultConfig() recursive_grid.animation.enabled should default to false")
+	if !cfg.RecursiveGrid.Animation.Enabled {
+		t.Fatal("DefaultConfig() recursive_grid.animation.enabled should default to true")
 	}
 
 	if cfg.RecursiveGrid.Animation.DurationMS != config.DefaultRecursiveGridAnimationDurationMS {

--- a/internal/core/domain/recursivegrid/doc.go
+++ b/internal/core/domain/recursivegrid/doc.go
@@ -8,7 +8,7 @@
 //   - Configurable dimensions: Supports both square (NxN) and non-square (CxR) grids
 //   - Configurable limits: Minimum size and maximum depth constraints
 //   - Backtracking: Support for undoing selections via backspace
-//   - warpd-compatible: Uses u/i/j/k key mapping by default (top-left, top-right, bottom-left, bottom-right)
+//   - Configurable key mapping: 3×3 grid mapping by default ("rtyfghvbn")
 //
 // Basic Usage:
 //
@@ -27,7 +27,7 @@
 //	// Create a manager with callbacks
 //	manager := recursivegrid.NewManager(
 //	    bounds,
-//	    "uijk",                    // Key mapping
+//	    "rtyfghvbn",               // Key mapping (3×3 default)
 //	    func() { /* update overlay */ },
 //	    func(point) { /* selection complete */ },
 //	    logger,
@@ -37,7 +37,8 @@
 //	point, completed := manager.HandleInput("u")
 //
 // Key Mapping:
-//   - Default: u (top-left), i (top-right), j (bottom-left), k (bottom-right)
+//   - Default: r (top-left), t (top-mid), y (top-right), f (mid-left), g (center),
+//     h (mid-right), v (bottom-left), b (bottom-mid), n (bottom-right)
 //   - Customizable via N-character string (where N = grid_cols * grid_rows)
 //
 // Exit Conditions:

--- a/internal/core/domain/recursivegrid/manager.go
+++ b/internal/core/domain/recursivegrid/manager.go
@@ -16,7 +16,7 @@ type Manager struct {
 	domain.BaseManager
 
 	grid       *RecursiveGrid
-	keys       string            // Default key mapping (e.g., "uijk")
+	keys       string            // Default key mapping (e.g., "rtyfghvbn")
 	depthKeys  map[int]string    // Per-depth key overrides (sparse)
 	gridCols   int               // Default number of grid columns
 	gridRows   int               // Default number of grid rows
@@ -24,7 +24,7 @@ type Manager struct {
 	onComplete func(image.Point) // Callback when selection is complete
 }
 
-// NewManager creates a recursive-grid manager with default dimensions (2×2)
+// NewManager creates a recursive-grid manager with default dimensions (3×3)
 // and default size/depth limits. Used primarily in tests.
 func NewManager(
 	screenBounds image.Rectangle,
@@ -62,10 +62,10 @@ func NewManagerWithLayers(
 	logger *zap.Logger,
 ) *Manager {
 	// Use default grid dimensions if either is invalid (< 1) or if the grid
-	// is degenerate (1×1 cannot subdivide). Reset both to 2x2 for consistency.
+	// is degenerate (1×1 cannot subdivide). Reset both to default for consistency.
 	if gridCols < MinGridDimension || gridRows < MinGridDimension ||
 		gridCols*gridRows < 2 {
-		logger.Warn("Invalid grid dimensions, using default 2x2",
+		logger.Warn("Invalid grid dimensions, using default",
 			zap.Int("provided_cols", gridCols),
 			zap.Int("provided_rows", gridRows))
 		gridCols = DefaultGridCols

--- a/internal/core/domain/recursivegrid/manager_test.go
+++ b/internal/core/domain/recursivegrid/manager_test.go
@@ -16,14 +16,14 @@ func TestNewManager(t *testing.T) {
 
 	manager := recursivegrid.NewManager(
 		bounds,
-		"uijk",
+		"rtyfghvbn",
 		func(image.Point) {},
 		func(point image.Point) {},
 		logger,
 	)
 
 	assert.NotNil(t, manager, "Manager should not be nil")
-	assert.Equal(t, "uijk", manager.Keys(), "Keys should be set")
+	assert.Equal(t, "rtyfghvbn", manager.Keys(), "Keys should be set")
 }
 
 func TestNewManagerDefaultKeys(t *testing.T) {
@@ -51,9 +51,15 @@ func TestManagerHandleInputCellSelection(t *testing.T) {
 	logger := zap.NewNop()
 
 	updateCalled := false
-	manager := recursivegrid.NewManager(
+	manager := recursivegrid.NewManagerWithLayers(
 		bounds,
 		"uijk",
+		25,
+		25,
+		10,
+		2,
+		2,
+		nil, nil,
 		func(image.Point) { updateCalled = true },
 		nil,
 		logger,
@@ -72,9 +78,15 @@ func TestManagerHandleInputEscapeKey(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
 	logger := zap.NewNop()
 
-	manager := recursivegrid.NewManager(
+	manager := recursivegrid.NewManagerWithLayers(
 		bounds,
 		"uijk",
+		25,
+		25,
+		10,
+		2,
+		2,
+		nil, nil,
 		nil,
 		nil,
 		logger,
@@ -90,9 +102,15 @@ func TestManagerReset(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
 	logger := zap.NewNop()
 
-	manager := recursivegrid.NewManager(
+	manager := recursivegrid.NewManagerWithLayers(
 		bounds,
 		"uijk",
+		25,
+		25,
+		10,
+		2,
+		2,
+		nil, nil,
 		nil,
 		nil,
 		logger,
@@ -115,9 +133,15 @@ func TestManagerHandleInputBacktrack(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
 	logger := zap.NewNop()
 
-	manager := recursivegrid.NewManager(
+	manager := recursivegrid.NewManagerWithLayers(
 		bounds,
 		"uijk",
+		25,
+		25,
+		10,
+		2,
+		2,
+		nil, nil,
 		nil,
 		nil,
 		logger,
@@ -142,9 +166,15 @@ func TestManagerHandleInputUnmappedKey(t *testing.T) {
 	logger := zap.NewNop()
 
 	updateCalled := false
-	manager := recursivegrid.NewManager(
+	manager := recursivegrid.NewManagerWithLayers(
 		bounds,
 		"uijk",
+		25,
+		25,
+		10,
+		2,
+		2,
+		nil, nil,
 		func(image.Point) { updateCalled = true },
 		nil,
 		logger,
@@ -281,8 +311,8 @@ func TestManagerWithLayers_InvalidColsOnly_FallsBack(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
 	logger := zap.NewNop()
 	// gridCols=0 is invalid (< MinGridDimension), so both dimensions are
-	// reset to DefaultGridCols×DefaultGridRows (2×2).
-	// "uijk" has 4 keys == 2*2, so no further fallback is needed.
+	// reset to DefaultGridCols×DefaultGridRows (default).
+	// provided keys match default dimensions, so no further fallback is needed.
 	manager := recursivegrid.NewManagerWithLayers(
 		bounds,
 		"uijk",
@@ -296,9 +326,9 @@ func TestManagerWithLayers_InvalidColsOnly_FallsBack(t *testing.T) {
 		nil,
 		logger,
 	)
-	// After fallback, should use default 2x2 with default keys
-	assert.Equal(t, 2, manager.GridCols())
-	assert.Equal(t, 2, manager.GridRows())
+	// After fallback, should use default dimensions with default keys
+	assert.Equal(t, recursivegrid.DefaultGridCols, manager.GridCols())
+	assert.Equal(t, recursivegrid.DefaultGridRows, manager.GridRows())
 	assert.Equal(t, recursivegrid.DefaultKeys, manager.Keys())
 }
 
@@ -327,8 +357,8 @@ func TestManagerWithLayers_SingleColumnValid(t *testing.T) {
 func TestManagerWithLayers_1x1_FallsBack(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
 	logger := zap.NewNop()
-	// 1×1 is degenerate (cannot subdivide), so both dimensions fall back to 2×2.
-	// "a" has 1 key ≠ 2*2=4, so keys also fall back to DefaultKeys "uijk".
+	// 1×1 is degenerate (cannot subdivide), so both dimensions fall back to default.
+	// "a" has 1 key ≠ expected, so keys also fall back to DefaultKeys.
 	manager := recursivegrid.NewManagerWithLayers(
 		bounds,
 		"a",
@@ -342,8 +372,8 @@ func TestManagerWithLayers_1x1_FallsBack(t *testing.T) {
 		nil,
 		logger,
 	)
-	assert.Equal(t, 2, manager.GridCols())
-	assert.Equal(t, 2, manager.GridRows())
+	assert.Equal(t, recursivegrid.DefaultGridCols, manager.GridCols())
+	assert.Equal(t, recursivegrid.DefaultGridRows, manager.GridRows())
 	assert.Equal(t, recursivegrid.DefaultKeys, manager.Keys())
 }
 
@@ -351,8 +381,8 @@ func TestManagerWithLayers_InvalidRowsOnly_FallsBack(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
 	logger := zap.NewNop()
 	// gridRows=0 is invalid (< MinGridDimension), so both dimensions are
-	// reset to DefaultGridCols×DefaultGridRows (2×2).
-	// "uijk" has 4 keys == 2*2, so no further fallback is needed.
+	// reset to DefaultGridCols×DefaultGridRows (default).
+	// provided keys match default dimensions, so no further fallback is needed.
 	manager := recursivegrid.NewManagerWithLayers(
 		bounds,
 		"uijk",
@@ -366,8 +396,8 @@ func TestManagerWithLayers_InvalidRowsOnly_FallsBack(t *testing.T) {
 		nil,
 		logger,
 	)
-	assert.Equal(t, 2, manager.GridCols())
-	assert.Equal(t, 2, manager.GridRows())
+	assert.Equal(t, recursivegrid.DefaultGridCols, manager.GridCols())
+	assert.Equal(t, recursivegrid.DefaultGridRows, manager.GridRows())
 	assert.Equal(t, recursivegrid.DefaultKeys, manager.Keys())
 }
 
@@ -502,9 +532,15 @@ func TestManagerHandleInput_KeyToCellLiteralSpaceKey(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
 	logger := zap.NewNop()
 	// Use a key mapping that contains a literal space character (" ") as one of the 4 keys.
-	manager := recursivegrid.NewManager(
+	manager := recursivegrid.NewManagerWithLayers(
 		bounds,
 		"ui k", // keys: u=0, i=1, ' '=2, k=3
+		25,
+		25,
+		10,
+		2,
+		2,
+		nil, nil,
 		func(image.Point) {},
 		nil,
 		logger,
@@ -521,9 +557,15 @@ func TestManagerHandleInput_KeyToCellLiteralSpaceKey(t *testing.T) {
 func TestManagerHandleInput_KeyToCellNormalizesFullwidthChars(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
 	logger := zap.NewNop()
-	manager := recursivegrid.NewManager(
+	manager := recursivegrid.NewManagerWithLayers(
 		bounds,
 		"uijk",
+		25,
+		25,
+		10,
+		2,
+		2,
+		nil, nil,
 		func(image.Point) {},
 		nil,
 		logger,
@@ -541,9 +583,15 @@ func TestHandleInput_ValidMultibyteKeys(t *testing.T) {
 	keys := "€abc" // 4 runes, valid length
 	logger := zap.NewNop()
 	screenBounds := image.Rect(0, 0, 100, 100)
-	manager := recursivegrid.NewManager(
+	manager := recursivegrid.NewManagerWithLayers(
 		screenBounds,
 		keys,
+		25,
+		25,
+		10,
+		2,
+		2,
+		nil, nil,
 		nil,
 		nil,
 		logger,

--- a/internal/core/domain/recursivegrid/recursive_grid.go
+++ b/internal/core/domain/recursivegrid/recursive_grid.go
@@ -8,13 +8,13 @@ const (
 	// MinGridDimension is the minimum allowed value for grid columns or rows.
 	MinGridDimension = 1
 	// DefaultGridCols is the default recursive-grid column count.
-	DefaultGridCols = 2
+	DefaultGridCols = 3
 	// DefaultGridRows is the default recursive-grid row count.
-	DefaultGridRows = 2
+	DefaultGridRows = 3
 )
 
 // Cell represents the index of a cell in the grid.
-// For 2x2 grids: 0=TL, 1=TR, 2=BL, 3=BR (named constants below).
+// For 3x3 grids: 0=TL, 1=TM, 2=TR, 3=ML, 4=MM, 5=MR, 6=BL, 7=BM, 8=BR (named constants below are only for 2x2).
 // For CxR grids: indices 0 to (C*R-1) are ordered left-to-right, top-to-bottom.
 // The named constants (TopLeft, TopRight, etc.) are only meaningful for 2x2 grids.
 type Cell int
@@ -30,8 +30,8 @@ const (
 	BottomRight
 )
 
-// DefaultKeys is the default key mapping for cells (warpd convention).
-const DefaultKeys = "uijk"
+// DefaultKeys is the default key mapping for cells (3x3 grid, left-to-right top-to-bottom).
+const DefaultKeys = "rtyfghvbn"
 
 // DepthLayout defines the grid dimensions for a specific recursion depth.
 type DepthLayout struct {
@@ -54,7 +54,7 @@ type RecursiveGrid struct {
 }
 
 // NewRecursiveGrid creates a new recursive-grid starting with the given screen bounds
-// using the default 2×2 grid dimensions and no per-depth overrides.
+// using the default 3×3 grid dimensions and no per-depth overrides.
 func NewRecursiveGrid(
 	screenBounds image.Rectangle,
 	minSizeWidth,

--- a/internal/core/domain/recursivegrid/recursive_grid_test.go
+++ b/internal/core/domain/recursivegrid/recursive_grid_test.go
@@ -19,12 +19,12 @@ func TestNewRecursiveGrid(t *testing.T) {
 
 func TestDivide(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
-	grid := recursivegrid.NewRecursiveGrid(bounds, 25, 25, 10)
+	grid := recursivegrid.NewRecursiveGridWithLayers(bounds, 25, 25, 10, 2, 2, nil)
 
 	cells := grid.Divide()
 
 	// Verify 4 cells
-	assert.Len(t, cells, 4, "Should have 4 cells")
+	assert.Len(t, cells, 4, "Should have 4 cells for 2x2 grid")
 
 	// Verify top-left cell
 	expectedTL := image.Rect(0, 0, 50, 50)
@@ -65,7 +65,7 @@ func TestDivide(t *testing.T) {
 
 func TestSelectCell(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
-	grid := recursivegrid.NewRecursiveGrid(bounds, 25, 25, 10)
+	grid := recursivegrid.NewRecursiveGridWithLayers(bounds, 25, 25, 10, 2, 2, nil)
 
 	// Select top-left
 	center, completed := grid.SelectCell(recursivegrid.TopLeft)
@@ -90,10 +90,10 @@ func TestSelectCell(t *testing.T) {
 func TestSelectCellCompletion(t *testing.T) {
 	// Create a small grid where one selection reaches minimum size
 	// With bounds 50x50 and minSize 25:
-	// - First division creates 25x25 cells
+	// - First division creates 25x25 cells (for 2x2 grid)
 	// - 25/2 = 12 < 25, so CanDivide returns false after first selection
 	bounds := image.Rect(0, 0, 50, 50)
-	grid := recursivegrid.NewRecursiveGrid(bounds, 25, 25, 10)
+	grid := recursivegrid.NewRecursiveGridWithLayers(bounds, 25, 25, 10, 2, 2, nil)
 
 	// Select top-left - bounds narrow to (0,0)-(25,25), but NOT completed yet.
 	// The user gets one more selection at this final depth.
@@ -155,18 +155,20 @@ func TestCanDivide(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			grid := recursivegrid.NewRecursiveGrid(tt.bounds, tt.minSize, tt.minSize, tt.maxDepth)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			grid := recursivegrid.NewRecursiveGridWithLayers(
+				testCase.bounds, testCase.minSize, testCase.minSize, testCase.maxDepth, 2, 2, nil,
+			)
 			result := grid.CanDivide()
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, testCase.expected, result)
 		})
 	}
 }
 
 func TestBacktrack(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
-	grid := recursivegrid.NewRecursiveGrid(bounds, 25, 25, 10)
+	grid := recursivegrid.NewRecursiveGridWithLayers(bounds, 25, 25, 10, 2, 2, nil)
 
 	// Make a selection
 	grid.SelectCell(recursivegrid.TopLeft)
@@ -185,7 +187,7 @@ func TestBacktrack(t *testing.T) {
 
 func TestReset(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
-	grid := recursivegrid.NewRecursiveGrid(bounds, 25, 25, 10)
+	grid := recursivegrid.NewRecursiveGridWithLayers(bounds, 25, 25, 10, 2, 2, nil)
 
 	// Make some selections
 	grid.SelectCell(recursivegrid.TopLeft)
@@ -200,7 +202,7 @@ func TestReset(t *testing.T) {
 
 func TestCurrentCenter(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
-	grid := recursivegrid.NewRecursiveGrid(bounds, 25, 25, 10)
+	grid := recursivegrid.NewRecursiveGridWithLayers(bounds, 25, 25, 10, 2, 2, nil)
 
 	center := grid.CurrentCenter()
 	expected := image.Point{X: 50, Y: 50}
@@ -215,7 +217,7 @@ func TestCurrentCenter(t *testing.T) {
 
 func TestCellBounds(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
-	grid := recursivegrid.NewRecursiveGrid(bounds, 25, 25, 10)
+	grid := recursivegrid.NewRecursiveGridWithLayers(bounds, 25, 25, 10, 2, 2, nil)
 
 	tl := grid.CellBounds(recursivegrid.TopLeft)
 	expected := image.Rect(0, 0, 50, 50)
@@ -228,7 +230,7 @@ func TestCellBounds(t *testing.T) {
 
 func TestCellCenter(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
-	grid := recursivegrid.NewRecursiveGrid(bounds, 25, 25, 10)
+	grid := recursivegrid.NewRecursiveGridWithLayers(bounds, 25, 25, 10, 2, 2, nil)
 
 	center := grid.CellCenter(recursivegrid.TopRight)
 	expected := image.Point{X: 75, Y: 25}
@@ -325,7 +327,7 @@ func TestGridDimensionAccessors(t *testing.T) {
 func TestRemapToNewBounds_PreservesDepthAndHistory(t *testing.T) {
 	// Start with a 100×100 grid, select top-left twice to build history.
 	bounds := image.Rect(0, 0, 100, 100)
-	grid := recursivegrid.NewRecursiveGrid(bounds, 10, 10, 10)
+	grid := recursivegrid.NewRecursiveGridWithLayers(bounds, 10, 10, 10, 2, 2, nil)
 	// Depth 0 → 1: currentBounds narrows to (0,0)-(50,50)
 	grid.SelectCell(recursivegrid.TopLeft)
 	// Depth 1 → 2: currentBounds narrows to (0,0)-(25,25)
@@ -356,7 +358,7 @@ func TestRemapToNewBounds_PreservesDepthAndHistory(t *testing.T) {
 func TestRemapToNewBounds_NonOriginScreen(t *testing.T) {
 	// Simulate a screen that doesn't start at (0,0), e.g., a secondary monitor.
 	oldBounds := image.Rect(0, 0, 1000, 500)
-	grid := recursivegrid.NewRecursiveGrid(oldBounds, 10, 10, 10)
+	grid := recursivegrid.NewRecursiveGridWithLayers(oldBounds, 10, 10, 10, 2, 2, nil)
 	// Select bottom-right: currentBounds → (500,250)-(1000,500)
 	grid.SelectCell(recursivegrid.BottomRight)
 	// Remap to a new screen with different origin and size.
@@ -371,7 +373,7 @@ func TestRemapToNewBounds_RoundTripMinimizesDrift(t *testing.T) {
 	// With rounding, drift should be ≤1px per coordinate; without rounding
 	// (truncation) the error can be larger.
 	bounds := image.Rect(0, 0, 1920, 1080)
-	grid := recursivegrid.NewRecursiveGrid(bounds, 10, 10, 20)
+	grid := recursivegrid.NewRecursiveGridWithLayers(bounds, 10, 10, 20, 2, 2, nil)
 	// Build some depth so history has non-trivial coordinates.
 	grid.SelectCell(recursivegrid.BottomRight) // (960,540)-(1920,1080)
 	grid.SelectCell(recursivegrid.TopLeft)     // (960,540)-(1440,810)
@@ -409,7 +411,7 @@ func TestRemapToNewBounds_ZeroOldBounds(t *testing.T) {
 
 func TestIsComplete(t *testing.T) {
 	bounds := image.Rect(0, 0, 100, 100)
-	grid := recursivegrid.NewRecursiveGrid(bounds, 25, 25, 10)
+	grid := recursivegrid.NewRecursiveGridWithLayers(bounds, 25, 25, 10, 2, 2, nil)
 
 	assert.False(t, grid.IsComplete(), "Should not be complete initially")
 


### PR DESCRIPTION
As discussed earlier, 2x2 feels "depressing" when you see it for the
first time. And labels feel like a more advanced solution for the
problem. Tho @y3owk1n and many experienced users switch from them for
recursive grid.

This is a step in the direction that will help people to love recursive
grid ~~and forget labels~~.

Keys Justification:

I picked `rtyfghvbn` keys because they are physically a square in the
middle of keyboard. Placed just right, so you can use both of your hands
to pick them.

In my opinion it is the most newbie-friendly approach. But it's not the
most efficient for sure. For experienced user it is more preferrable to
use keys like `asdf jkl;`. Because they are all on homerow! And you
never need to move anywhere to click.

But it needs additional explanation and probably not the best fit for
newbies.

---

On animation part: I can revert it if you don't agree with that. But I
think again that it's more user-friendly and will give some joy to a
modern soy dev (I'm using this myself, lol). Feel free to ask me to
revert this if you don't agree.
