### PR TITLE
feat(scroll,systray,cli): add `invert_scroll` for direction inversion

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -258,6 +258,7 @@ easing = "ease_out"                         # linear, ease_in, ease_out, ease_in
 scroll_step = 50                            # Pixels per j/k press
 scroll_step_half = 500                      # Pixels for d/u (half page)
 scroll_step_full = 1000000                  # Pixels for gg/G (top/bottom)
+invert_scroll = false                       # Invert scroll direction (for tools like Mos)
 
 [scroll.hotkeys]
 "Escape" = "idle"

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -179,7 +179,17 @@ neru scroll
 ```bash
 neru toggle-screen-share                  # Toggle overlay visibility during screen sharing
 neru toggle-cursor-follow-selection       # Toggle cursor-follow-selection in active hints/grid/recursive-grid session
+neru toggle-scroll-invert                 # Toggle scroll direction inversion
 ```
+
+### Scroll Invert
+
+Toggles whether vertical and horizontal scroll deltas are inverted at runtime.
+Useful when using tools like [Mos](https://github.com/Caldis/Mos) that reverse
+synthetic scroll events. Also configurable via `invert_scroll` in
+[CONFIGURATION.md](CONFIGURATION.md#scroll) and accessible via systray menu.
+
+- State resets to the configured `invert_scroll` value on daemon restart
 
 ### Screen Sharing
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -639,6 +639,7 @@ Keyboard-driven scrolling.
 | `scroll_step`      | int  | `50`      | Pixels per line scroll action      |
 | `scroll_step_half` | int  | `500`     | Pixels per half-page action        |
 | `scroll_step_full` | int  | `1000000` | Pixels for top/bottom jump actions |
+| `invert_scroll`    | bool | `false`   | Invert scroll direction (useful when using tools like Mos that reverse synthetic scroll events) |
 
 ### Default Hotkeys
 

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -93,6 +93,7 @@ func (a *App) reconfigureRuntimeFromConfig(cfg *config.Config) {
 	a.updateServiceConfigs(cfg)
 	a.updateControllerConfigs(cfg)
 	a.syncScreenShareConfig(cfg)
+	a.syncScrollInvertConfig(cfg)
 }
 
 func (a *App) updateComponentConfigs(cfg *config.Config) {
@@ -155,5 +156,26 @@ func (a *App) updateControllerConfigs(cfg *config.Config) {
 func (a *App) syncScreenShareConfig(cfg *config.Config) {
 	if a.appState.IsHiddenForScreenShare() != cfg.General.HideOverlayInScreenShare {
 		a.appState.SetHiddenForScreenShare(cfg.General.HideOverlayInScreenShare)
+	}
+}
+
+func (a *App) syncScrollInvertConfig(cfg *config.Config) {
+	if a.appState.IsScrollInverted() != cfg.Scroll.InvertScroll {
+		a.appState.SetScrollInverted(cfg.Scroll.InvertScroll)
+		a.syncScrollInvertToService(cfg.Scroll.InvertScroll)
+	}
+}
+
+// syncInitialConfigToAppState syncs configuration values to AppState during startup.
+// This ensures AppState reflects the config file values before any runtime toggles.
+func syncInitialConfigToAppState(app *App) {
+	cfg := app.configSnapshot()
+
+	if app.appState.IsHiddenForScreenShare() != cfg.General.HideOverlayInScreenShare {
+		app.appState.SetHiddenForScreenShare(cfg.General.HideOverlayInScreenShare)
+	}
+
+	if app.appState.IsScrollInverted() != cfg.Scroll.InvertScroll {
+		app.appState.SetScrollInverted(cfg.Scroll.InvertScroll)
 	}
 }

--- a/internal/app/app_getters.go
+++ b/internal/app/app_getters.go
@@ -170,3 +170,39 @@ func (a *App) OnScreenShareStateChanged(callback func(bool)) uint64 {
 func (a *App) OffScreenShareStateChanged(id uint64) {
 	a.appState.OffScreenShareStateChanged(id)
 }
+
+// IsScrollInverted returns whether scroll direction inversion is enabled.
+func (a *App) IsScrollInverted() bool {
+	return a.appState.IsScrollInverted()
+}
+
+// SetScrollInverted sets whether scroll direction inversion is enabled.
+func (a *App) SetScrollInverted(inverted bool) {
+	a.appState.SetScrollInverted(inverted)
+	a.syncScrollInvertToService(inverted)
+}
+
+// ToggleScrollInvert toggles the scroll direction inversion and returns the new state.
+func (a *App) ToggleScrollInvert() bool {
+	newState := a.appState.ToggleScrollInverted()
+	a.syncScrollInvertToService(newState)
+
+	return newState
+}
+
+// OnScrollInvertStateChanged registers a callback for when the scroll invert state changes.
+func (a *App) OnScrollInvertStateChanged(callback func(bool)) uint64 {
+	return a.appState.OnScrollInvertStateChanged(callback)
+}
+
+// OffScrollInvertStateChanged unsubscribes a callback by ID.
+func (a *App) OffScrollInvertStateChanged(id uint64) {
+	a.appState.OffScrollInvertStateChanged(id)
+}
+
+// syncScrollInvertToService syncs the scroll invert state from AppState to the scroll service.
+func (a *App) syncScrollInvertToService(inverted bool) {
+	if a.scrollService != nil {
+		a.scrollService.SetInvertScroll(inverted)
+	}
+}

--- a/internal/app/app_initialization.go
+++ b/internal/app/app_initialization.go
@@ -98,6 +98,9 @@ func initializeApp(app *App) (*App, error) {
 	initializeApplicationState(app)
 	// Application state doesn't need cleanup as it's just in-memory objects
 
+	// Sync initial config values to AppState
+	syncInitialConfigToAppState(app)
+
 	// Phase 4: Initialize UI components
 	err = initializeUIComponents(app)
 	if err != nil {

--- a/internal/app/components/systray/systray.go
+++ b/internal/app/components/systray/systray.go
@@ -36,6 +36,12 @@ type AppInterface interface {
 	ToggleOverlayHiddenForScreenShare() bool
 	OnScreenShareStateChanged(callback func(bool)) uint64
 	OffScreenShareStateChanged(id uint64)
+	// Scroll invert toggle
+	IsScrollInverted() bool
+	SetScrollInverted(inverted bool)
+	ToggleScrollInvert() bool
+	OnScrollInvertStateChanged(callback func(bool)) uint64
+	OffScrollInvertStateChanged(id uint64)
 	// Quit triggers a graceful shutdown of the application.
 	Quit()
 }
@@ -51,45 +57,50 @@ type Component struct {
 	cancel context.CancelFunc
 
 	// Menu items
-	mVersionCopy       *systray.MenuItem
-	mToggleDisable     *systray.MenuItem
-	mToggleEnable      *systray.MenuItem
-	mToggleScreenShare *systray.MenuItem
-	mModes             *systray.MenuItem
-	mHints             *systray.MenuItem
-	mGrid              *systray.MenuItem
-	mRecursiveGrid     *systray.MenuItem
-	mReloadConfig      *systray.MenuItem
-	mHelp              *systray.MenuItem
-	mSourceCode        *systray.MenuItem
-	mDocsConfig        *systray.MenuItem
-	mDocsCLI           *systray.MenuItem
-	mReportBug         *systray.MenuItem
-	mFeatureRequest    *systray.MenuItem
-	mDiscuss           *systray.MenuItem
-	mQuit              *systray.MenuItem
+	mVersionCopy        *systray.MenuItem
+	mToggleDisable      *systray.MenuItem
+	mToggleEnable       *systray.MenuItem
+	mToggleScreenShare  *systray.MenuItem
+	mToggleScrollInvert *systray.MenuItem
+	mModes              *systray.MenuItem
+	mHints              *systray.MenuItem
+	mGrid               *systray.MenuItem
+	mRecursiveGrid      *systray.MenuItem
+	mReloadConfig       *systray.MenuItem
+	mHelp               *systray.MenuItem
+	mSourceCode         *systray.MenuItem
+	mDocsConfig         *systray.MenuItem
+	mDocsCLI            *systray.MenuItem
+	mReportBug          *systray.MenuItem
+	mFeatureRequest     *systray.MenuItem
+	mDiscuss            *systray.MenuItem
+	mQuit               *systray.MenuItem
 
 	// State update signaling (thread-safe communication)
-	stateUpdateSignal              chan struct{} // Signal that state changed
-	latestState                    atomic.Bool   // Latest enabled state
-	screenShareUpdateSignal        chan struct{} // Signal for screen share state changes
-	latestScreenShareState         atomic.Bool   // Latest screen share hide state
-	chanClosed                     atomic.Bool
-	enabledStateSubscriptionID     uint64 // ID for unsubscribing on cleanup
-	screenShareStateSubscriptionID uint64 // ID for screen share state unsubscription
+	stateUpdateSignal               chan struct{} // Signal that state changed
+	latestState                     atomic.Bool   // Latest enabled state
+	screenShareUpdateSignal         chan struct{} // Signal for screen share state changes
+	latestScreenShareState          atomic.Bool   // Latest screen share hide state
+	scrollInvertUpdateSignal        chan struct{} // Signal for scroll invert state changes
+	latestScrollInvertState         atomic.Bool   // Latest scroll invert state
+	chanClosed                      atomic.Bool
+	enabledStateSubscriptionID      uint64 // ID for unsubscribing on cleanup
+	screenShareStateSubscriptionID  uint64 // ID for screen share state unsubscription
+	scrollInvertStateSubscriptionID uint64 // ID for scroll invert state unsubscription
 }
 
 // NewComponent creates a new systray component.
 func NewComponent(app AppInterface, system ports.SystemPort, logger *zap.Logger) *Component {
 	ctx, cancel := context.WithCancel(context.Background())
 	component := &Component{
-		app:                     app,
-		system:                  system,
-		logger:                  logger,
-		ctx:                     ctx,
-		cancel:                  cancel,
-		stateUpdateSignal:       make(chan struct{}, 1),
-		screenShareUpdateSignal: make(chan struct{}, 1),
+		app:                      app,
+		system:                   system,
+		logger:                   logger,
+		ctx:                      ctx,
+		cancel:                   cancel,
+		stateUpdateSignal:        make(chan struct{}, 1),
+		screenShareUpdateSignal:  make(chan struct{}, 1),
+		scrollInvertUpdateSignal: make(chan struct{}, 1),
 	}
 
 	// Register callback immediately for enabled state changes
@@ -119,6 +130,22 @@ func NewComponent(app AppInterface, system ports.SystemPort, logger *zap.Logger)
 
 		select {
 		case component.screenShareUpdateSignal <- struct{}{}:
+		default:
+			// Signal already pending, state will be read when processed
+		}
+	})
+
+	// Register callback for scroll invert state changes
+	component.scrollInvertStateSubscriptionID = app.OnScrollInvertStateChanged(func(inverted bool) {
+		// Don't send if channel is closed
+		if component.chanClosed.Load() {
+			return
+		}
+		// Store latest state and signal update
+		component.latestScrollInvertState.Store(inverted)
+
+		select {
+		case component.scrollInvertUpdateSignal <- struct{}{}:
 		default:
 			// Signal already pending, state will be read when processed
 		}
@@ -173,6 +200,9 @@ func (c *Component) OnReady() {
 	systray.AddSeparator()
 
 	c.mToggleScreenShare = systray.AddMenuItem("Screen Share: Visible")
+	c.mToggleScrollInvert = systray.AddMenuItem("Scroll Invert: Off")
+
+	systray.AddSeparator()
 
 	c.mQuit = systray.AddMenuItem("Quit")
 
@@ -196,6 +226,7 @@ func (c *Component) OnExit() {
 	c.cancel()               // Signal event goroutine to stop
 	c.app.OffEnabledStateChanged(c.enabledStateSubscriptionID)
 	c.app.OffScreenShareStateChanged(c.screenShareStateSubscriptionID)
+	c.app.OffScrollInvertStateChanged(c.scrollInvertStateSubscriptionID)
 }
 
 // Close cleans up systray component resources.
@@ -206,6 +237,7 @@ func (c *Component) Close() {
 	c.cancel()               // Signal event goroutine to stop
 	c.app.OffEnabledStateChanged(c.enabledStateSubscriptionID)
 	c.app.OffScreenShareStateChanged(c.screenShareStateSubscriptionID)
+	c.app.OffScrollInvertStateChanged(c.scrollInvertStateSubscriptionID)
 }
 
 // updateMenuItems updates the systray menu items based on the current enabled state.
@@ -294,6 +326,8 @@ func (c *Component) handleEvents() {
 			}()
 		case <-c.mToggleScreenShare.ClickedCh:
 			c.handleToggleScreenShare()
+		case <-c.mToggleScrollInvert.ClickedCh:
+			c.handleToggleScrollInvert()
 		case <-c.mQuit.ClickedCh:
 			c.app.Quit()
 
@@ -302,6 +336,8 @@ func (c *Component) handleEvents() {
 			c.updateMenuItems(c.latestState.Load())
 		case <-c.screenShareUpdateSignal:
 			c.updateScreenShareMenuItem(c.latestScreenShareState.Load())
+		case <-c.scrollInvertUpdateSignal:
+			c.updateScrollInvertMenuItem(c.latestScrollInvertState.Load())
 		}
 	}
 }
@@ -355,5 +391,29 @@ func (c *Component) updateScreenShareMenuItem(hidden bool) {
 		c.mToggleScreenShare.SetTitle("Screen Share: Hidden")
 	} else {
 		c.mToggleScreenShare.SetTitle("Screen Share: Visible")
+	}
+}
+
+// handleToggleScrollInvert toggles the scroll direction inversion.
+func (c *Component) handleToggleScrollInvert() {
+	// Atomically toggle - the callback will update the menu item
+	newState := c.app.ToggleScrollInvert()
+
+	status := "off"
+	if newState {
+		status = "on"
+	}
+
+	if c.system != nil {
+		c.system.ShowNotification("Neru", "Scroll invert: "+status)
+	}
+}
+
+// updateScrollInvertMenuItem updates the scroll invert menu item text based on state.
+func (c *Component) updateScrollInvertMenuItem(inverted bool) {
+	if inverted {
+		c.mToggleScrollInvert.SetTitle("Scroll Invert: On")
+	} else {
+		c.mToggleScrollInvert.SetTitle("Scroll Invert: Off")
 	}
 }

--- a/internal/app/components/systray/systray_test.go
+++ b/internal/app/components/systray/systray_test.go
@@ -17,6 +17,7 @@ type mockApp struct {
 	recursiveGridEnabled bool
 	isEnabled            bool
 	hiddenForScreenShare bool
+	scrollInverted       bool
 	activatedMode        domain.Mode
 	configPath           string
 	reloadCalled         bool
@@ -63,7 +64,17 @@ func (m *mockApp) OnScreenShareStateChanged(callback func(bool)) uint64 {
 	return 0
 }
 func (m *mockApp) OffScreenShareStateChanged(id uint64) {}
-func (m *mockApp) Quit()                                {}
+func (m *mockApp) IsScrollInverted() bool               { return m.scrollInverted }
+func (m *mockApp) SetScrollInverted(inverted bool)      { m.scrollInverted = inverted }
+func (m *mockApp) ToggleScrollInvert() bool {
+	newState := !m.scrollInverted
+	m.scrollInverted = newState
+
+	return newState
+}
+func (m *mockApp) OnScrollInvertStateChanged(callback func(bool)) uint64 { return 0 }
+func (m *mockApp) OffScrollInvertStateChanged(id uint64)                 {}
+func (m *mockApp) Quit()                                                 {}
 
 func TestNewComponent(t *testing.T) {
 	logger := zaptest.NewLogger(t)

--- a/internal/app/ipc_controller.go
+++ b/internal/app/ipc_controller.go
@@ -161,4 +161,8 @@ func (c *IPCController) registerHandlers(cfg *config.Config) {
 	// Register overlay handler
 	overlayHandler := NewIPCControllerOverlay(c.AppState, c.Logger)
 	overlayHandler.RegisterHandlers(c.Handlers)
+
+	// Register scroll handler
+	scrollHandler := NewIPCControllerScroll(c.AppState, c.ScrollService, c.Logger)
+	scrollHandler.RegisterHandlers(c.Handlers)
 }

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/app/modes"
+	"github.com/y3owk1n/neru/internal/app/services"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
@@ -558,5 +559,56 @@ func (h *IPCControllerOverlay) handleToggleScreenShare(
 		Message: "screen share visibility: " + status,
 		Code:    ipc.CodeOK,
 		Data:    map[string]bool{"hidden": newState},
+	}
+}
+
+// IPCControllerScroll handles scroll-related IPC commands.
+type IPCControllerScroll struct {
+	appState      *state.AppState
+	scrollService *services.ScrollService
+	logger        *zap.Logger
+}
+
+// NewIPCControllerScroll creates a new scroll command handler.
+func NewIPCControllerScroll(
+	appState *state.AppState,
+	scrollService *services.ScrollService,
+	logger *zap.Logger,
+) *IPCControllerScroll {
+	return &IPCControllerScroll{
+		appState:      appState,
+		scrollService: scrollService,
+		logger:        logger,
+	}
+}
+
+// RegisterHandlers registers scroll command handlers.
+func (h *IPCControllerScroll) RegisterHandlers(
+	handlers map[string]func(context.Context, ipc.Command) ipc.Response,
+) {
+	handlers[domain.CommandToggleScrollInvert] = h.handleToggleScrollInvert
+}
+
+func (h *IPCControllerScroll) handleToggleScrollInvert(
+	_ context.Context,
+	_ ipc.Command,
+) ipc.Response {
+	// Atomically toggle to avoid check-then-act race
+	newState := h.appState.ToggleScrollInverted()
+
+	if h.scrollService != nil {
+		h.scrollService.SetInvertScroll(newState)
+	}
+
+	status := "off"
+	if newState {
+		status = "on"
+	}
+
+	return ipc.Response{
+		Success: true,
+		Message: "scroll invert: " + status,
+		Code:    ipc.CodeOK,
+		Data:    map[string]bool{"inverted": newState},
 	}
 }

--- a/internal/app/services/scroll_service.go
+++ b/internal/app/services/scroll_service.go
@@ -138,17 +138,18 @@ func (s *ScrollService) calculateDelta(
 		invertScroll   bool
 	)
 
+	// Snapshot config under lock, then release before IPC call
+	s.mu.RLock()
+	scrollStep := s.config.ScrollStep
+	scrollStepHalf := s.config.ScrollStepHalf
+	scrollStepFull := s.config.ScrollStepFull
+	invertScroll = s.config.InvertScroll
+	configSnapshot := s.config
+	s.mu.RUnlock()
+
 	if stepOverride > 0 {
 		baseScroll = stepOverride
 	} else {
-		// Snapshot config under lock, then release before IPC call
-		s.mu.RLock()
-		scrollStep := s.config.ScrollStep
-		scrollStepHalf := s.config.ScrollStepHalf
-		scrollStepFull := s.config.ScrollStepFull
-		invertScroll = s.config.InvertScroll
-		configSnapshot := s.config
-		s.mu.RUnlock()
 
 		// Only perform IPC lookup if there are app-specific overrides configured
 		if len(configSnapshot.AppConfigs) > 0 {

--- a/internal/app/services/scroll_service.go
+++ b/internal/app/services/scroll_service.go
@@ -150,7 +150,6 @@ func (s *ScrollService) calculateDelta(
 	if stepOverride > 0 {
 		baseScroll = stepOverride
 	} else {
-
 		// Only perform IPC lookup if there are app-specific overrides configured
 		if len(configSnapshot.AppConfigs) > 0 {
 			bundleID, err := s.accessibility.FocusedAppBundleID(ctx)

--- a/internal/app/services/scroll_service.go
+++ b/internal/app/services/scroll_service.go
@@ -107,6 +107,23 @@ func (s *ScrollService) UpdateConfig(config config.ScrollConfig) {
 		zap.Int("scroll_step_full", config.ScrollStepFull))
 }
 
+// IsScrollInverted returns whether scroll direction inversion is currently enabled.
+func (s *ScrollService) IsScrollInverted() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.config.InvertScroll
+}
+
+// SetInvertScroll sets the scroll direction inversion state.
+func (s *ScrollService) SetInvertScroll(inverted bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.config.InvertScroll = inverted
+	s.logger.Debug("Scroll invert set", zap.Bool("invert_scroll", s.config.InvertScroll))
+}
+
 // calculateDelta computes the scroll delta values based on direction and magnitude.
 // If stepOverride is > 0, it takes precedence over the configured value.
 func (s *ScrollService) calculateDelta(
@@ -118,6 +135,7 @@ func (s *ScrollService) calculateDelta(
 	var (
 		deltaX, deltaY int
 		baseScroll     int
+		invertScroll   bool
 	)
 
 	if stepOverride > 0 {
@@ -128,6 +146,7 @@ func (s *ScrollService) calculateDelta(
 		scrollStep := s.config.ScrollStep
 		scrollStepHalf := s.config.ScrollStepHalf
 		scrollStepFull := s.config.ScrollStepFull
+		invertScroll = s.config.InvertScroll
 		configSnapshot := s.config
 		s.mu.RUnlock()
 
@@ -171,6 +190,11 @@ func (s *ScrollService) calculateDelta(
 		deltaX = baseScroll
 	case ScrollDirectionRight:
 		deltaX = -baseScroll
+	}
+
+	if invertScroll {
+		deltaX = -deltaX
+		deltaY = -deltaY
 	}
 
 	return deltaX, deltaY

--- a/internal/app/services/scroll_service_test.go
+++ b/internal/app/services/scroll_service_test.go
@@ -228,6 +228,78 @@ func TestScrollService_Scroll(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:      "invert scroll down becomes up",
+			direction: services.ScrollDirectionDown,
+			amount:    services.ScrollAmountChar,
+			setupConfig: func(c *config.ScrollConfig) {
+				c.InvertScroll = true
+			},
+			setupMocks: func(acc *mocks.MockAccessibilityPort) {
+				acc.ScrollFunc = func(_ context.Context, _, deltaY int) error {
+					if deltaY <= 0 {
+						t.Errorf("Expected positive deltaY (inverted from down), got %d", deltaY)
+					}
+
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:      "invert scroll up becomes down",
+			direction: services.ScrollDirectionUp,
+			amount:    services.ScrollAmountChar,
+			setupConfig: func(c *config.ScrollConfig) {
+				c.InvertScroll = true
+			},
+			setupMocks: func(acc *mocks.MockAccessibilityPort) {
+				acc.ScrollFunc = func(_ context.Context, _, deltaY int) error {
+					if deltaY >= 0 {
+						t.Errorf("Expected negative deltaY (inverted from up), got %d", deltaY)
+					}
+
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:      "invert scroll left becomes right",
+			direction: services.ScrollDirectionLeft,
+			amount:    services.ScrollAmountChar,
+			setupConfig: func(c *config.ScrollConfig) {
+				c.InvertScroll = true
+			},
+			setupMocks: func(acc *mocks.MockAccessibilityPort) {
+				acc.ScrollFunc = func(_ context.Context, deltaX, _ int) error {
+					if deltaX >= 0 {
+						t.Errorf("Expected negative deltaX (inverted from left), got %d", deltaX)
+					}
+
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:      "invert scroll right becomes left",
+			direction: services.ScrollDirectionRight,
+			amount:    services.ScrollAmountChar,
+			setupConfig: func(c *config.ScrollConfig) {
+				c.InvertScroll = true
+			},
+			setupMocks: func(acc *mocks.MockAccessibilityPort) {
+				acc.ScrollFunc = func(_ context.Context, deltaX, _ int) error {
+					if deltaX <= 0 {
+						t.Errorf("Expected positive deltaX (inverted from right), got %d", deltaX)
+					}
+
+					return nil
+				}
+			},
+			wantErr: false,
+		},
+		{
 			name:      "scroll down with app override",
 			direction: services.ScrollDirectionDown,
 			amount:    services.ScrollAmountChar,

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -114,6 +114,7 @@ func TestCommandInitialization(t *testing.T) {
 		"services":                       false,
 		"toggle-screen-share":            false,
 		"toggle-cursor-follow-selection": false,
+		"toggle-scroll-invert":           false,
 		"recursive_grid":                 false,
 	}
 

--- a/internal/cli/toggle_scroll_invert.go
+++ b/internal/cli/toggle_scroll_invert.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"github.com/y3owk1n/neru/internal/core/domain"
+)
+
+// ToggleScrollInvertCmd toggles the scroll direction inversion setting.
+var ToggleScrollInvertCmd = BuildSimpleCommand(
+	"toggle-scroll-invert",
+	"Toggle scroll direction inversion",
+	`Toggle whether scroll direction is inverted at runtime.
+Useful when using tools like Mos that reverse synthetic scroll events.
+The change is immediate and does not persist across restarts.`,
+	domain.CommandToggleScrollInvert,
+)
+
+func init() {
+	RootCmd.AddCommand(ToggleScrollInvertCmd)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -521,6 +521,8 @@ type ScrollConfig struct {
 	ScrollStepHalf int `json:"scrollStepHalf" toml:"scroll_step_half"`
 	ScrollStepFull int `json:"scrollStepFull" toml:"scroll_step_full"`
 
+	InvertScroll bool `json:"invertScroll" toml:"invert_scroll"`
+
 	AppConfigs []AppConfig `json:"appConfigs" toml:"app_configs"`
 
 	Hotkeys map[string]StringOrStringArray `json:"hotkeys" toml:"-"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -68,6 +68,9 @@ const (
 	// DefaultGridFontSize is the default font size for grid.
 	DefaultGridFontSize = 10
 
+	// DefaultScrollInvert is the default scroll inversion setting.
+	DefaultScrollInvert = false
+
 	// DefaultScrollStep is the default scroll step.
 	DefaultScrollStep = 50
 	// DefaultScrollStepHalf is the default scroll step half.
@@ -586,6 +589,7 @@ func newDefaultConfig() *Config {
 			ScrollStep:     DefaultScrollStep,
 			ScrollStepHalf: DefaultScrollStepHalf,
 			ScrollStepFull: DefaultScrollStepFull,
+			InvertScroll:   DefaultScrollInvert,
 			AppConfigs:     []AppConfig{},
 			Hotkeys: map[string]StringOrStringArray{
 				"Escape":   {"idle"},

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -1269,7 +1269,8 @@ func validateHotkeyActionString(actionStr string) error {
 
 	switch cmd {
 	case "idle", "hints", "grid", "scroll", "recursive_grid",
-		"toggle-screen-share", "toggle-cursor-follow-selection":
+		"toggle-screen-share", "toggle-cursor-follow-selection",
+		"toggle-scroll-invert":
 		return nil
 	default:
 		return derrors.Newf(derrors.CodeInvalidConfig, "unknown command: %s", trimmed)

--- a/internal/core/domain/domain_constants.go
+++ b/internal/core/domain/domain_constants.go
@@ -34,6 +34,7 @@ const (
 	CommandHealth                      = "health"
 	CommandToggleScreenShare           = "toggle-screen-share"
 	CommandToggleCursorFollowSelection = "toggle-cursor-follow-selection"
+	CommandToggleScrollInvert          = "toggle-scroll-invert"
 )
 
 // Mode-related constants.

--- a/internal/core/domain/state/app_state.go
+++ b/internal/core/domain/state/app_state.go
@@ -15,14 +15,16 @@ type AppState struct {
 	enabled              bool
 	currentMode          domain.Mode
 	hiddenForScreenShare bool
+	scrollInverted       bool
 
 	// Callbacks - stored as map for O(1) unsubscribe
-	// Note: Both callback maps share a single nextCallbackID counter to ensure
+	// Note: All callback maps share a single nextCallbackID counter to ensure
 	// globally unique subscription IDs. Each Off* method only unsubscribes from
 	// its corresponding map, so misdirected unsubscribes are safely ignored.
-	enabledStateCallbacks     map[uint64]func(bool)
-	screenShareStateCallbacks map[uint64]func(bool)
-	nextCallbackID            uint64
+	enabledStateCallbacks      map[uint64]func(bool)
+	screenShareStateCallbacks  map[uint64]func(bool)
+	scrollInvertStateCallbacks map[uint64]func(bool)
+	nextCallbackID             uint64
 
 	// Operational flags
 	hotkeysRegistered                bool
@@ -37,12 +39,14 @@ type AppState struct {
 // NewAppState creates a new AppState with default values.
 func NewAppState() *AppState {
 	return &AppState{
-		enabled:                   true,
-		currentMode:               domain.ModeIdle,
-		hiddenForScreenShare:      false,
-		enabledStateCallbacks:     make(map[uint64]func(bool)),
-		screenShareStateCallbacks: make(map[uint64]func(bool)),
-		nextCallbackID:            1, // Start at 1 so 0 can be used as nil sentinel
+		enabled:                    true,
+		currentMode:                domain.ModeIdle,
+		hiddenForScreenShare:       false,
+		scrollInverted:             false,
+		enabledStateCallbacks:      make(map[uint64]func(bool)),
+		screenShareStateCallbacks:  make(map[uint64]func(bool)),
+		scrollInvertStateCallbacks: make(map[uint64]func(bool)),
+		nextCallbackID:             1, // Start at 1 so 0 can be used as nil sentinel
 	}
 }
 
@@ -230,6 +234,91 @@ func (s *AppState) OnScreenShareStateChanged(callback func(bool)) uint64 {
 func (s *AppState) OffScreenShareStateChanged(id uint64) {
 	s.mu.Lock()
 	delete(s.screenShareStateCallbacks, id)
+	s.mu.Unlock()
+}
+
+// IsScrollInverted returns whether scroll direction inversion is enabled.
+func (s *AppState) IsScrollInverted() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.scrollInverted
+}
+
+// SetScrollInverted sets whether scroll direction inversion is enabled.
+func (s *AppState) SetScrollInverted(inverted bool) {
+	s.mu.Lock()
+	oldInverted := s.scrollInverted
+	s.scrollInverted = inverted
+
+	callbacks := make([]func(bool), 0, len(s.scrollInvertStateCallbacks))
+	for _, cb := range s.scrollInvertStateCallbacks {
+		callbacks = append(callbacks, cb)
+	}
+
+	s.mu.Unlock()
+
+	if oldInverted != inverted {
+		for _, callback := range callbacks {
+			if callback != nil {
+				go callback(inverted)
+			}
+		}
+	}
+}
+
+// ToggleScrollInverted atomically toggles the scroll invert state and notifies callbacks.
+// This avoids the check-then-act race of calling IsScrollInverted() + SetScrollInverted().
+func (s *AppState) ToggleScrollInverted() bool {
+	s.mu.Lock()
+	oldInverted := s.scrollInverted
+	s.scrollInverted = !oldInverted
+	newInverted := s.scrollInverted
+
+	// Copy callbacks to slice for iteration outside lock
+	callbacks := make([]func(bool), 0, len(s.scrollInvertStateCallbacks))
+	for _, cb := range s.scrollInvertStateCallbacks {
+		callbacks = append(callbacks, cb)
+	}
+
+	s.mu.Unlock()
+
+	// State always changes in a toggle, notify all callbacks
+	for _, callback := range callbacks {
+		if callback != nil {
+			go callback(newInverted)
+		}
+	}
+
+	return newInverted
+}
+
+// OnScrollInvertStateChanged registers a callback for when the scroll invert state changes.
+// Returns a subscription ID that can be used to unsubscribe later.
+func (s *AppState) OnScrollInvertStateChanged(callback func(bool)) uint64 {
+	if callback == nil {
+		return 0
+	}
+
+	s.mu.Lock()
+
+	nextCallbackID := s.nextCallbackID
+	s.nextCallbackID++
+	s.scrollInvertStateCallbacks[nextCallbackID] = callback
+	currentState := s.scrollInverted
+
+	s.mu.Unlock()
+
+	// Fire initial callback via goroutine for consistency with SetScrollInverted
+	go callback(currentState)
+
+	return nextCallbackID
+}
+
+// OffScrollInvertStateChanged unsubscribes a callback using the ID returned by OnScrollInvertStateChanged.
+func (s *AppState) OffScrollInvertStateChanged(id uint64) {
+	s.mu.Lock()
+	delete(s.scrollInvertStateCallbacks, id)
 	s.mu.Unlock()
 }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds scroll direction inversion support to compensate other tools like Mos that intercept and modify synthetic scroll events, which causes Neru's scroll action inverted.

It provides 3 ways to invert scroll direction:

### Set `[scroll.invert_scroll]` to `true` in your config file

The default is `false`. This settings is persistent and will be applied on every Neru startup.

### Enable it from Neru`s systray menu

This only affect runtime behavior, not persistent.

### Enable it via cli `neru toggle-scroll-invert`

This only affect runtime behavior, not persistent.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #732

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

<img width="334" height="293" alt="image" src="https://github.com/user-attachments/assets/68671050-7d4e-426f-80a3-2490edf1616f" />

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
