### PR TITLE
feat(cli): add `focus_window` action to cycle window on active space

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -72,7 +72,7 @@ neru idle                                  # Cancel active navigation mode
 | `--repeat, -r`            | bool   | Re-activate mode after action (requires `--action`)                                                                                       |
 | `--cursor-selection-mode` | string | `follow` (cursor follows selection) or `hold` (cursor stays)                                                                              |
 
-Not allowed as `--action`: `reset`, `backspace`, `search_hints`, `cycle_hint`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos`, and scroll sub-actions (`scroll_up`, `page_down`, `go_top`, etc.).
+Not allowed as `--action`: `reset`, `backspace`, `search_hints`, `cycle_hint`, `focus_window`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos`, and scroll sub-actions (`scroll_up`, `page_down`, `go_top`, etc.).
 
 > The `--action` flag is most useful in hints mode (Vimium-style). In grid/recursive-grid, prefer composing behavior in per-mode hotkeys: `["action left_click", "idle"]`.
 
@@ -363,6 +363,29 @@ neru action move_monitor --name "DELL U2720Q" # Move to named monitor
 | `--previous` | Cycle to previous monitor      |
 
 Find monitor names in **System Settings → Displays**.
+
+### Window Focus
+
+Cycles keyboard focus through all focusable windows on the current Space. Filters out minimized, hidden, and off-space windows.
+
+```bash
+neru action focus_window                        # Focus next window
+neru action focus_window --backward             # Focus previous window
+```
+
+| Flag         | Description                              |
+| ------------ | ---------------------------------------- |
+| `--backward` | Cycle to the previous window instead of next |
+
+Windows are enumerated across all running applications. Only windows with role `AXWindow` that are visible, not minimized, and on the active space are included.
+
+Bind to hotkeys for quick window switching:
+
+```toml
+[global.hotkeys]
+"Primary+Tab"       = "action focus_window"
+"Primary+Shift+Tab" = "action focus_window --backward"
+```
 
 ### Delay
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -231,10 +231,11 @@ All actions available in hotkeys. These also work as `neru action <name>` — se
 | Delay       | `sleep <duration>` — plain numbers are seconds (`0.5`), explicit units: `500ms`, `1s` |
 | Mode        | `reset`, `backspace`                                          |
 | Composition | `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos` |
+| Focus       | `focus_window`, `focus_window --backward`                     |
 
 - Use `--bare` (e.g. `"action left_click --bare"`) to target the cursor position instead of the current mode selection (see [CLI.md](CLI.md#clicks))
 - `scroll_up` / `scroll_down` support `--steps` (e.g. `"action scroll_down --steps 200"`) to override `scroll_step` (see [CLI.md](CLI.md#scrolling))
-- `reset`, `backspace`, `search_hints`, `cycle_hint`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, and `restore_cursor_pos` are not valid mode `--action` values — use `neru action ...` or in hotkeys as `"action ..."`
+- `reset`, `backspace`, `search_hints`, `cycle_hint`, `focus_window`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, and `restore_cursor_pos` are not valid mode `--action` values — use `neru action ...` or in hotkeys as `"action ..."`
 
 #### Feed Keys
 

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -312,6 +312,10 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 		return h.handleSearchHintsAction(parsed)
 	}
 
+	if action.IsFocusWindowAction(actionName) {
+		return h.handleFocusWindowAction(ctx, parsed)
+	}
+
 	modifiers, modErr := action.ParseModifiers(parsed.modifierStr)
 	if modErr != nil {
 		return ipc.Response{

--- a/internal/app/ipc_actions_darwin.go
+++ b/internal/app/ipc_actions_darwin.go
@@ -1,0 +1,109 @@
+//go:build darwin
+
+package app
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/infra/accessibility"
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+func (h *IPCControllerActions) handleFocusWindowAction(
+	ctx context.Context,
+	parsed parsedActionArgs,
+) ipc.Response {
+	if parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
+		parsed.hasCenter || parsed.hasWindow || parsed.useSelection ||
+		parsed.useBare || parsed.hasMonitorName || parsed.usePrevious ||
+		parsed.modifierStr != "" || parsed.hasSteps {
+		return ipc.Response{
+			Success: false,
+			Message: "focus_window does not support these flags",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	h.logger.Debug("Cycling window focus via IPC",
+		zap.Bool("backward", parsed.useBackward),
+	)
+
+	windows, err := accessibility.AllFocusableWindowsOnActiveSpace()
+	if err != nil {
+		h.logger.Error("Failed to get focusable windows", zap.Error(err))
+
+		return ipc.Response{
+			Success: false,
+			Message: "failed to get focusable windows: " + err.Error(),
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	if len(windows) == 0 {
+		return ipc.Response{
+			Success: false,
+			Message: "no focusable windows found on the active space",
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	defer accessibility.ReleaseAll(windows)
+
+	// Find the currently focused window index using FrontmostWindow
+	// (which uses kAXFocusedWindowAttribute on the app element) rather than
+	// per-window IsFocused(), since kAXFocusedAttribute on window elements
+	// is unreliable across applications.
+	frontmost := accessibility.FrontmostWindow()
+
+	var currentIndex int
+	if frontmost != nil {
+		for i, w := range windows {
+			if w.Equal(frontmost) {
+				currentIndex = i
+
+				break
+			}
+		}
+
+		frontmost.Release()
+	}
+
+	// Default to the first window if none is detected as focused.
+	var targetIndex int
+	if parsed.useBackward {
+		targetIndex = currentIndex - 1
+		if targetIndex < 0 {
+			targetIndex = len(windows) - 1
+		}
+	} else {
+		targetIndex = currentIndex + 1
+		if targetIndex >= len(windows) {
+			targetIndex = 0
+		}
+	}
+
+	h.logger.Debug("Focusing window",
+		zap.Int("currentIndex", currentIndex),
+		zap.Int("targetIndex", targetIndex),
+		zap.Int("totalWindows", len(windows)),
+	)
+
+	activateErr := windows[targetIndex].ActivateWindow()
+	if activateErr != nil {
+		h.logger.Error("Failed to activate window", zap.Error(activateErr))
+
+		return ipc.Response{
+			Success: false,
+			Message: "failed to activate window: " + activateErr.Error(),
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	return ipc.Response{
+		Success: true,
+		Message: "focus_window performed",
+		Code:    ipc.CodeOK,
+	}
+}

--- a/internal/app/ipc_actions_darwin.go
+++ b/internal/app/ipc_actions_darwin.go
@@ -57,7 +57,7 @@ func (h *IPCControllerActions) handleFocusWindowAction(
 	// is unreliable across applications.
 	frontmost := accessibility.FrontmostWindow()
 
-	var currentIndex int
+	currentIndex := -1
 	if frontmost != nil {
 		for i, w := range windows {
 			if w.Equal(frontmost) {
@@ -70,7 +70,6 @@ func (h *IPCControllerActions) handleFocusWindowAction(
 		frontmost.Release()
 	}
 
-	// Default to the first window if none is detected as focused.
 	var targetIndex int
 	if parsed.useBackward {
 		targetIndex = currentIndex - 1

--- a/internal/app/ipc_actions_other.go
+++ b/internal/app/ipc_actions_other.go
@@ -1,0 +1,24 @@
+//go:build !darwin
+
+package app
+
+import (
+	"context"
+
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+func (h *IPCControllerActions) handleFocusWindowAction(
+	_ context.Context,
+	_ parsedActionArgs,
+) ipc.Response {
+	return ipc.Response{
+		Success: false,
+		Message: derrors.New(
+			derrors.CodeNotSupported,
+			"focus_window is only supported on macOS",
+		).Error(),
+		Code: ipc.CodeActionFailed,
+	}
+}

--- a/internal/cli/action.go
+++ b/internal/cli/action.go
@@ -22,6 +22,7 @@ Available subcommands:
                     go_top, go_bottom, page_up, page_down
   Mouse movement:   move_mouse, move_mouse_relative, move_monitor
   Mode control:     reset, backspace, wait_for_mode_exit, cycle_hint
+  Window control:   focus_window
   Cursor saving:    save_cursor_pos, restore_cursor_pos
   Key injection:    feed
 
@@ -246,6 +247,9 @@ at the current cursor location.`,
 	false,
 )
 
+// ActionFocusWindowCmd cycles window focus on the active space.
+var ActionFocusWindowCmd = BuildFocusWindowCommand()
+
 // ActionCycleHintCmd cycles through visible hints in hints mode.
 var ActionCycleHintCmd = BuildCycleHintCommand()
 
@@ -273,6 +277,7 @@ func init() {
 	ActionCmd.AddCommand(ActionPageUpCmd)
 	ActionCmd.AddCommand(ActionPageDownCmd)
 	ActionCmd.AddCommand(ActionCycleHintCmd)
+	ActionCmd.AddCommand(ActionFocusWindowCmd)
 
 	RootCmd.AddCommand(ActionCmd)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -160,6 +160,7 @@ func TestCommandInitialization(t *testing.T) {
 		"page_down":           false,
 		"move_monitor":        false,
 		"cycle_hint":          false,
+		"focus_window":        false,
 	}
 
 	for _, cmd := range cli.ActionCmd.Commands() {
@@ -217,6 +218,7 @@ func TestCommandExecutionWithoutDaemon(t *testing.T) {
 		{"action_page_up", getActionCmd("page_up"), true},
 		{"action_page_down", getActionCmd("page_down"), true},
 		{"action_move_monitor", getActionCmd("move_monitor"), true},
+		{"action_focus_window", getActionCmd("focus_window"), true},
 		{"status", getCmd("status"), true},
 		{"doctor", getCmd("doctor"), true}, // doctor returns silentError when daemon is down
 		{"toggle-screen-share", getCmd("toggle-screen-share"), true},

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -512,6 +512,39 @@ Positive values move right/down, negative values move left/up.`,
 	return cmd
 }
 
+// BuildFocusWindowCommand creates a focus_window cobra command that cycles
+// window focus through all focusable windows on the active space.
+func BuildFocusWindowCommand() *cobra.Command {
+	var backward bool
+
+	cmd := &cobra.Command{
+		Use:   "focus_window",
+		Short: "Cycle focus through windows on the active space",
+		Long: `Cycle keyboard focus through all focusable windows on the current space.
+
+Cycles forward through windows (or backward with --backward), wrapping at the
+end. Only windows that are focusable (not minimized, not hidden) and on the
+current space are included.`,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return requiresRunningInstance()
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			actionArgs := []string{"focus_window"}
+
+			if backward {
+				actionArgs = append(actionArgs, "--backward")
+			}
+
+			return sendCommand(cmd, "action", actionArgs)
+		},
+	}
+
+	cmd.Flags().
+		BoolVar(&backward, "backward", false, "Cycle to the previous window instead of the next one")
+
+	return cmd
+}
+
 // BuildCycleHintCommand creates a cycle_hint cobra command that cycles through visible hints.
 func BuildCycleHintCommand() *cobra.Command {
 	var backward bool

--- a/internal/core/domain/action/action.go
+++ b/internal/core/domain/action/action.go
@@ -169,6 +169,8 @@ const (
 	NameCycleHint Name = "cycle_hint"
 	// NameSearchHints starts text filtering in hints mode.
 	NameSearchHints Name = "search_hints"
+	// NameFocusWindow cycles focus to the next/previous window on the active space.
+	NameFocusWindow Name = "focus_window"
 
 	// PrefixExec is the prefix for shell command actions.
 	PrefixExec = "exec"
@@ -249,6 +251,11 @@ func IsSearchHintsAction(name string) bool {
 	return Name(name) == NameSearchHints
 }
 
+// IsFocusWindowAction reports whether the given action is focus_window.
+func IsFocusWindowAction(name string) bool {
+	return Name(name) == NameFocusWindow
+}
+
 // IsKnownName determines whether the specified action name is recognized by the
 // application. This is a superset of the names in knownNames — it also includes
 // scroll sub-actions (scroll_up, page_down, etc.) which are IPC/CLI-only.
@@ -267,7 +274,8 @@ func IsKnownName(name Name) bool {
 		NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
 		NameScrollUp, NameScrollDown, NameScrollLeft, NameScrollRight,
 		NameGoTop, NameGoBottom, NamePageUp, NamePageDown,
-		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints:
+		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints,
+		NameFocusWindow:
 		return true
 	default:
 		return false
@@ -290,7 +298,8 @@ func IsScrollSubAction(name string) bool {
 		NameMouseDown, NameMouseUp,
 		NameMoveMouse, NameMoveMouseRelative, NameScroll,
 		NameReset, NameBackspace, NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
-		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints:
+		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints,
+		NameFocusWindow:
 		return false
 	default:
 		return false
@@ -368,7 +377,8 @@ func (n Name) ToType() (Type, error) {
 		NameFeed,
 		NameSleep,
 		NameCycleHint,
-		NameSearchHints:
+		NameSearchHints,
+		NameFocusWindow:
 		return 0, derrors.Newf(derrors.CodeInvalidInput, "action name not executable: %s", n)
 	default:
 		return 0, derrors.Newf(derrors.CodeInvalidInput, "unknown action name: %s", n)

--- a/internal/core/infra/accessibility/element_darwin.go
+++ b/internal/core/infra/accessibility/element_darwin.go
@@ -365,6 +365,21 @@ func (e *Element) Children(role string) ([]*Element, error) {
 	return children, nil
 }
 
+// ActivateWindow brings the window's application to the foreground and sets
+// keyboard focus on the window.
+func (e *Element) ActivateWindow() error {
+	if e.ref == nil {
+		return errSetFocusNil
+	}
+
+	result := C.NeruActivateWindow(e.ref) //nolint:nlreturn
+	if result == 0 {
+		return errSetFocusFailed
+	}
+
+	return nil
+}
+
 // SetFocus sets focus to the element.
 func (e *Element) SetFocus() error {
 	if e.ref == nil {
@@ -473,6 +488,32 @@ func (e *Element) Clone() (*Element, error) {
 func AllWindows() ([]*Element, error) {
 	var count C.int
 	windows := C.NeruGetAllWindows(&count)
+	if windows == nil || count == 0 {
+		if windows != nil {
+			C.free(unsafe.Pointer(windows))
+		}
+
+		return []*Element{}, nil
+	}
+	defer C.free(unsafe.Pointer(windows)) //nolint:nlreturn
+
+	countInt := int(count)
+	windowSlice := (*[1 << 30]unsafe.Pointer)(unsafe.Pointer(windows))[:countInt:countInt]
+	result := make([]*Element, countInt)
+
+	for index := range result {
+		result[index] = &Element{ref: windowSlice[index]}
+	}
+
+	return result, nil
+}
+
+// AllFocusableWindowsOnActiveSpace returns all focusable windows on the active
+// space across all running applications. Filters out minimized, hidden, and
+// off-space windows.
+func AllFocusableWindowsOnActiveSpace() ([]*Element, error) {
+	var count C.int
+	windows := C.NeruGetAllFocusableWindowsOnActiveSpace(&count)
 	if windows == nil || count == 0 {
 		if windows != nil {
 			C.free(unsafe.Pointer(windows))

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -178,6 +178,12 @@ int NeruAreElementsEqual(void *element1, void *element2);
 
 #pragma mark - Window Functions
 
+/// Get all focusable windows on the active space across all running applications.
+/// Filters out non-focusable windows (minimized, hidden, off-space, non-window roles).
+/// @param count Output parameter for number of windows
+/// @return Array of window element references. Caller frees the array and releases refs.
+void **NeruGetAllFocusableWindowsOnActiveSpace(int *count);
+
 /// Get all windows of focused application
 /// @param count Output parameter for number of windows
 /// @return Array of window references
@@ -191,6 +197,11 @@ void **NeruGetFrontmostAndPopoverWindows(int *count);
 /// Get frontmost window
 /// @return Frontmost window reference
 void *NeruGetFrontmostWindow(void);
+
+/// Activate a window: brings its application to the foreground and sets focus.
+/// @param window Window element reference
+/// @return 1 on success, 0 on failure
+int NeruActivateWindow(void *window);
 
 /// Get the frame (position + size) of the focused window
 /// @return Window frame rectangle, or CGRectZero if no window is found

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -328,6 +328,172 @@ void *NeruGetFrontmostWindow(void) {
 	}
 }
 
+/// Get all focusable windows on the active space across all running applications.
+/// Filters out non-focusable windows (minimized, hidden, off-space, non-window roles).
+/// @param count Output parameter for number of windows
+/// @return Array of window element references
+void **NeruGetAllFocusableWindowsOnActiveSpace(int *count) {
+	if (!count)
+		return NULL;
+
+	@autoreleasepool {
+		*count = 0;
+
+		NSArray *runningApps = [NSWorkspace sharedWorkspace].runningApplications;
+		CFMutableArrayRef windowsCollector = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+		if (!windowsCollector)
+			return NULL;
+
+		for (NSRunningApplication *app in runningApps) {
+			if (app.activationPolicy != NSApplicationActivationPolicyRegular)
+				continue;
+
+			pid_t pid = app.processIdentifier;
+			AXUIElementRef appElement = AXUIElementCreateApplication(pid);
+			if (!appElement)
+				continue;
+
+			CFTypeRef windowsValue = NULL;
+			AXError error = AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute, &windowsValue);
+			if (error != kAXErrorSuccess || !windowsValue) {
+				CFRelease(appElement);
+				continue;
+			}
+
+			if (CFGetTypeID(windowsValue) != CFArrayGetTypeID()) {
+				CFRelease(windowsValue);
+				CFRelease(appElement);
+				continue;
+			}
+
+			CFArrayRef windows = (CFArrayRef)windowsValue;
+			CFIndex windowCount = CFArrayGetCount(windows);
+
+			for (CFIndex i = 0; i < windowCount; i++) {
+				AXUIElementRef window = (AXUIElementRef)CFArrayGetValueAtIndex(windows, i);
+				if (!window)
+					continue;
+
+				// Batch-fetch attributes for efficiency
+				CFStringRef attrs[] = {
+				    kAXRoleAttribute,
+				    kAXMinimizedAttribute,
+				    kAXHiddenAttribute,
+				    CFSTR("AXWindowIsOnActiveSpace"),
+				};
+				CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 4, &kCFTypeArrayCallBacks);
+				if (!attrArray)
+					continue;
+
+				CFArrayRef values = NULL;
+				AXError batchError = AXUIElementCopyMultipleAttributeValues(window, attrArray, 0, &values);
+				CFRelease(attrArray);
+
+				if (batchError != kAXErrorSuccess || !values) {
+					if (values)
+						CFRelease(values);
+					continue;
+				}
+
+				bool shouldInclude = false;
+
+				// role: must be AXWindow
+				if (CFArrayGetCount(values) > 0) {
+					CFTypeRef roleVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 0);
+					if (roleVal && CFGetTypeID(roleVal) == CFStringGetTypeID() &&
+					    CFStringCompare((CFStringRef)roleVal, CFSTR("AXWindow"), 0) == kCFCompareEqualTo) {
+						shouldInclude = true;
+					}
+				}
+
+				// minimized: exclude if true
+				if (shouldInclude && CFArrayGetCount(values) > 1) {
+					CFTypeRef minVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 1);
+					if (minVal && CFGetTypeID(minVal) == CFBooleanGetTypeID() &&
+					    CFBooleanGetValue((CFBooleanRef)minVal)) {
+						shouldInclude = false;
+					}
+				}
+
+				// hidden: exclude if true
+				if (shouldInclude && CFArrayGetCount(values) > 2) {
+					CFTypeRef hiddenVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 2);
+					if (hiddenVal && CFGetTypeID(hiddenVal) == CFBooleanGetTypeID() &&
+					    CFBooleanGetValue((CFBooleanRef)hiddenVal)) {
+						shouldInclude = false;
+					}
+				}
+
+				// on active space: exclude if false or unsupported
+				if (shouldInclude && CFArrayGetCount(values) > 3) {
+					CFTypeRef spaceVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 3);
+					if (spaceVal && CFGetTypeID(spaceVal) == CFBooleanGetTypeID() &&
+					    !CFBooleanGetValue((CFBooleanRef)spaceVal)) {
+						shouldInclude = false;
+					}
+				}
+
+				CFRelease(values);
+
+				if (shouldInclude) {
+					CFArrayAppendValue(windowsCollector, window);
+				}
+			}
+
+			CFRelease(windowsValue);
+			CFRelease(appElement);
+		}
+
+		CFIndex total = CFArrayGetCount(windowsCollector);
+		if (total == 0) {
+			CFRelease(windowsCollector);
+			return NULL;
+		}
+
+		void **result = (void **)malloc(total * sizeof(void *));
+		if (!result) {
+			CFRelease(windowsCollector);
+			return NULL;
+		}
+
+		for (CFIndex i = 0; i < total; i++) {
+			result[i] = (void *)CFArrayGetValueAtIndex(windowsCollector, i);
+			CFRetain(result[i]);
+		}
+
+		CFRelease(windowsCollector);
+		*count = (int)total;
+		return result;
+	}
+}
+
+/// Activate a window: brings its application to the foreground and sets
+/// keyboard focus on the window.
+/// @param window Window element reference
+/// @return 1 on success, 0 on failure
+int NeruActivateWindow(void *window) {
+	if (!window)
+		return 0;
+
+	@autoreleasepool {
+		AXUIElementRef axWindow = (AXUIElementRef)window;
+
+		pid_t pid;
+		if (AXUIElementGetPid(axWindow, &pid) != kAXErrorSuccess)
+			return 0;
+
+		NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
+		if (!app)
+			return 0;
+
+		[app activateWithOptions:NSApplicationActivateIgnoringOtherApps];
+
+		AXError error = AXUIElementSetAttributeValue(axWindow, kAXFocusedAttribute, kCFBooleanTrue);
+
+		return (error == kAXErrorSuccess) ? 1 : 0;
+	}
+}
+
 /// Get the frame (position + size) of the focused window
 /// @return Window frame rectangle, or CGRectZero if no window is found
 CGRect NeruGetFocusedWindowFrame(void) {

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -409,12 +409,10 @@ void **NeruGetAllFocusableWindowsOnActiveSpace(int *count) {
 					continue;
 
 				CFArrayRef values = NULL;
-				AXError batchError = AXUIElementCopyMultipleAttributeValues(window, attrArray, 0, &values);
+				AXUIElementCopyMultipleAttributeValues(window, attrArray, 0, &values);
 				CFRelease(attrArray);
 
-				if (batchError != kAXErrorSuccess || !values) {
-					if (values)
-						CFRelease(values);
+				if (!values) {
 					continue;
 				}
 
@@ -551,13 +549,14 @@ int NeruActivateWindow(void *window) {
 		// Set kAXMainAttribute to make it the main window of the application
 		AXUIElementSetAttributeValue(axWindow, kAXMainAttribute, kCFBooleanTrue);
 
-		// Set kAXFocusedAttribute to give it keyboard focus
-		AXError error = AXUIElementSetAttributeValue(axWindow, kAXFocusedAttribute, kCFBooleanTrue);
+		// Set kAXFocusedAttribute to give it keyboard focus (best-effort; not
+		// all apps expose this as a writable attribute).
+		AXUIElementSetAttributeValue(axWindow, kAXFocusedAttribute, kCFBooleanTrue);
 
 		// Perform AXRaise action to bring the window to the front
-		AXUIElementPerformAction(axWindow, kAXRaiseAction);
+		AXError raiseError = AXUIElementPerformAction(axWindow, kAXRaiseAction);
 
-		return (error == kAXErrorSuccess) ? 1 : 0;
+		return (raiseError == kAXErrorSuccess) ? 1 : 0;
 	}
 }
 

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -347,6 +347,8 @@ void **NeruGetAllFocusableWindowsOnActiveSpace(int *count) {
 		for (NSRunningApplication *app in runningApps) {
 			if (app.activationPolicy != NSApplicationActivationPolicyRegular)
 				continue;
+			if (app.hidden)
+				continue;
 
 			pid_t pid = app.processIdentifier;
 			AXUIElementRef appElement = AXUIElementCreateApplication(pid);
@@ -378,10 +380,9 @@ void **NeruGetAllFocusableWindowsOnActiveSpace(int *count) {
 				CFStringRef attrs[] = {
 				    kAXRoleAttribute,
 				    kAXMinimizedAttribute,
-				    kAXHiddenAttribute,
 				    CFSTR("AXWindowIsOnActiveSpace"),
 				};
-				CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 4, &kCFTypeArrayCallBacks);
+				CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 3, &kCFTypeArrayCallBacks);
 				if (!attrArray)
 					continue;
 
@@ -415,18 +416,9 @@ void **NeruGetAllFocusableWindowsOnActiveSpace(int *count) {
 					}
 				}
 
-				// hidden: exclude if true
-				if (shouldInclude && CFArrayGetCount(values) > 2) {
-					CFTypeRef hiddenVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 2);
-					if (hiddenVal && CFGetTypeID(hiddenVal) == CFBooleanGetTypeID() &&
-					    CFBooleanGetValue((CFBooleanRef)hiddenVal)) {
-						shouldInclude = false;
-					}
-				}
-
 				// on active space: exclude if false or unsupported
-				if (shouldInclude && CFArrayGetCount(values) > 3) {
-					CFTypeRef spaceVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 3);
+				if (shouldInclude && CFArrayGetCount(values) > 2) {
+					CFTypeRef spaceVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 2);
 					if (spaceVal && CFGetTypeID(spaceVal) == CFBooleanGetTypeID() &&
 					    !CFBooleanGetValue((CFBooleanRef)spaceVal)) {
 						shouldInclude = false;

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -328,6 +328,20 @@ void *NeruGetFrontmostWindow(void) {
 	}
 }
 
+static CGPoint getWindowPosition(AXUIElementRef window) {
+	CFTypeRef positionValue = NULL;
+	if (AXUIElementCopyAttributeValue(window, kAXPositionAttribute, &positionValue) == kAXErrorSuccess &&
+	    positionValue) {
+		CGPoint point = CGPointZero;
+		if (CFGetTypeID(positionValue) == AXValueGetTypeID()) {
+			AXValueGetValue((AXValueRef)positionValue, kAXValueCGPointType, &point);
+		}
+		CFRelease(positionValue);
+		return point;
+	}
+	return CGPointZero;
+}
+
 /// Get all focusable windows on the active space across all running applications.
 /// Filters out non-focusable windows (minimized, hidden, off-space, non-window roles).
 /// @param count Output parameter for number of windows
@@ -339,7 +353,15 @@ void **NeruGetAllFocusableWindowsOnActiveSpace(int *count) {
 	@autoreleasepool {
 		*count = 0;
 
-		NSArray *runningApps = [NSWorkspace sharedWorkspace].runningApplications;
+		NSArray *runningApps = [[NSWorkspace sharedWorkspace].runningApplications
+		    sortedArrayUsingComparator:^NSComparisonResult(NSRunningApplication *obj1, NSRunningApplication *obj2) {
+			    if (obj1.processIdentifier < obj2.processIdentifier) {
+				    return NSOrderedAscending;
+			    } else if (obj1.processIdentifier > obj2.processIdentifier) {
+				    return NSOrderedDescending;
+			    }
+			    return NSOrderedSame;
+		    }];
 		CFMutableArrayRef windowsCollector = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
 		if (!windowsCollector)
 			return NULL;
@@ -442,6 +464,35 @@ void **NeruGetAllFocusableWindowsOnActiveSpace(int *count) {
 			return NULL;
 		}
 
+		// Sort the collected windows stably by screen coordinates (y-coordinate first, then x-coordinate)
+		NSArray *sortedWindows =
+		    [(__bridge NSArray *)windowsCollector sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
+			    AXUIElementRef w1 = (__bridge AXUIElementRef)obj1;
+			    AXUIElementRef w2 = (__bridge AXUIElementRef)obj2;
+
+			    CGPoint p1 = getWindowPosition(w1);
+			    CGPoint p2 = getWindowPosition(w2);
+
+			    if (p1.y < p2.y)
+				    return NSOrderedAscending;
+			    if (p1.y > p2.y)
+				    return NSOrderedDescending;
+			    if (p1.x < p2.x)
+				    return NSOrderedAscending;
+			    if (p1.x > p2.x)
+				    return NSOrderedDescending;
+
+			    pid_t pid1 = 0, pid2 = 0;
+			    AXUIElementGetPid(w1, &pid1);
+			    AXUIElementGetPid(w2, &pid2);
+			    if (pid1 < pid2)
+				    return NSOrderedAscending;
+			    if (pid1 > pid2)
+				    return NSOrderedDescending;
+
+			    return NSOrderedSame;
+		    }];
+
 		void **result = (void **)malloc(total * sizeof(void *));
 		if (!result) {
 			CFRelease(windowsCollector);
@@ -449,7 +500,7 @@ void **NeruGetAllFocusableWindowsOnActiveSpace(int *count) {
 		}
 
 		for (CFIndex i = 0; i < total; i++) {
-			result[i] = (void *)CFArrayGetValueAtIndex(windowsCollector, i);
+			result[i] = (void *)(__bridge AXUIElementRef)sortedWindows[i];
 			CFRetain(result[i]);
 		}
 
@@ -480,7 +531,14 @@ int NeruActivateWindow(void *window) {
 
 		[app activateWithOptions:NSApplicationActivateIgnoringOtherApps];
 
+		// Set kAXMainAttribute to make it the main window of the application
+		AXUIElementSetAttributeValue(axWindow, kAXMainAttribute, kCFBooleanTrue);
+
+		// Set kAXFocusedAttribute to give it keyboard focus
 		AXError error = AXUIElementSetAttributeValue(axWindow, kAXFocusedAttribute, kCFBooleanTrue);
+
+		// Perform AXRaise action to bring the window to the front
+		AXUIElementPerformAction(axWindow, kAXRaiseAction);
 
 		return (error == kAXErrorSuccess) ? 1 : 0;
 	}

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -464,14 +464,32 @@ void **NeruGetAllFocusableWindowsOnActiveSpace(int *count) {
 			return NULL;
 		}
 
+		// Pre-compute window positions and PIDs to avoid O(N log N) IPC calls during sorting
+		NSMutableDictionary<NSValue *, NSValue *> *positions = [NSMutableDictionary dictionaryWithCapacity:total];
+		NSMutableDictionary<NSValue *, NSNumber *> *pids = [NSMutableDictionary dictionaryWithCapacity:total];
+		for (CFIndex i = 0; i < total; i++) {
+			AXUIElementRef w = (AXUIElementRef)CFArrayGetValueAtIndex(windowsCollector, i);
+			CGPoint pos = getWindowPosition(w);
+			positions[[NSValue valueWithPointer:w]] = [NSValue valueWithBytes:&pos objCType:@encode(CGPoint)];
+
+			pid_t pid = 0;
+			AXUIElementGetPid(w, &pid);
+			pids[[NSValue valueWithPointer:w]] = @(pid);
+		}
+
 		// Sort the collected windows stably by screen coordinates (y-coordinate first, then x-coordinate)
 		NSArray *sortedWindows =
 		    [(__bridge NSArray *)windowsCollector sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
 			    AXUIElementRef w1 = (__bridge AXUIElementRef)obj1;
 			    AXUIElementRef w2 = (__bridge AXUIElementRef)obj2;
 
-			    CGPoint p1 = getWindowPosition(w1);
-			    CGPoint p2 = getWindowPosition(w2);
+			    NSValue *key1 = [NSValue valueWithPointer:w1];
+			    NSValue *key2 = [NSValue valueWithPointer:w2];
+
+			    CGPoint p1 = CGPointZero;
+			    CGPoint p2 = CGPointZero;
+			    [positions[key1] getValue:&p1];
+			    [positions[key2] getValue:&p2];
 
 			    if (p1.y < p2.y)
 				    return NSOrderedAscending;
@@ -482,9 +500,8 @@ void **NeruGetAllFocusableWindowsOnActiveSpace(int *count) {
 			    if (p1.x > p2.x)
 				    return NSOrderedDescending;
 
-			    pid_t pid1 = 0, pid2 = 0;
-			    AXUIElementGetPid(w1, &pid1);
-			    AXUIElementGetPid(w2, &pid2);
+			    int pid1 = [pids[key1] intValue];
+			    int pid2 = [pids[key2] intValue];
 			    if (pid1 < pid2)
 				    return NSOrderedAscending;
 			    if (pid1 > pid2)

--- a/internal/core/infra/platform/darwin/accessibility_window_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_window_darwin.m
@@ -438,7 +438,7 @@ void **NeruGetAllFocusableWindowsOnActiveSpace(int *count) {
 					}
 				}
 
-				// on active space: exclude if false or unsupported
+				// on active space: exclude if false (gracefully include if unsupported)
 				if (shouldInclude && CFArrayGetCount(values) > 2) {
 					CFTypeRef spaceVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 2);
 					if (spaceVal && CFGetTypeID(spaceVal) == CFBooleanGetTypeID() &&


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a new action cli `focus_window` to cycle through and focus on any focusable windows on the current space.

It will filter out minimized, hidden, and off-space windows.

Usage:

```bash
neru action focus_window # cycle forward
neru action focus_window --backward # cycle backward
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/705a160b-d615-4a80-b991-dca99c3b6bed

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
