### PR TITLE
fix(overlay,indicator): revert #832 optimisation that causes regression

### DIFF
--- a/internal/app/components/modeindicator/overlay_darwin.go
+++ b/internal/app/components/modeindicator/overlay_darwin.go
@@ -30,12 +30,6 @@ const (
 	// defaultIndicatorHeight is the default height for the mode indicator.
 	defaultIndicatorHeight = 20
 
-	// indicatorWindowWidth is the width of the small overlay window for the mode indicator.
-	// Generous enough to accommodate the badge with any reasonable offset.
-	indicatorWindowWidth = 300
-	// indicatorWindowHeight is the height of the small overlay window for the mode indicator.
-	indicatorWindowHeight = 150
-
 	// NSWindowSharingNone represents NSWindowSharingNone (0) - hidden from screen sharing.
 	NSWindowSharingNone = 0
 	// NSWindowSharingReadOnly represents NSWindowSharingReadOnly (1) - visible in screen sharing.
@@ -155,12 +149,25 @@ func (o *Overlay) Clear() {
 	C.NeruClearOverlay(o.window)
 }
 
-// ResizeToActiveScreen is a no-op for mode indicator overlays.
-// Mode indicator windows are small and positioned dynamically by DrawModeIndicator
-// using NeruPositionOverlay, so full-screen resizing is unnecessary.
-// This avoids allocating a full-screen backing store (~47MB on Retina).
+// ResizeToActiveScreen adjusts the overlay window size with callback notification.
+// Falls back to a non-callback resize if the callback ID pool is exhausted.
 func (o *Overlay) ResizeToActiveScreen() {
-	// No-op: positioning is handled dynamically in DrawModeIndicator.
+	started := o.callbackManager.StartResizeOperation(func(callbackID uint64, generation uint64) {
+		// Pass callback ID and generation as opaque pointer context for C callback.
+		// Uses CallbackIDToPointer to convert in a way that go vet accepts.
+		contextPtr := overlayutil.CallbackIDToPointer(callbackID, generation)
+
+		C.NeruResizeOverlayToActiveScreenWithCallback(
+			o.window,
+			(C.ResizeCompletionCallback)(C.resizeModeIndicatorCompletionCallback),
+			contextPtr,
+		)
+	})
+	if !started {
+		// Pool exhausted — fall back to non-callback resize so the overlay
+		// is still moved to the correct screen.
+		C.NeruResizeOverlayToActiveScreen(o.window)
+	}
 }
 
 // DrawModeIndicator draws a mode label at the specified position.
@@ -170,10 +177,6 @@ func (o *Overlay) ResizeToActiveScreen() {
 // allowing users to customize (or hide) each mode's indicator text.
 // The caller is responsible for calling Show() once before the first draw
 // (e.g. in startModeIndicatorPolling) rather than showing every tick.
-//
-// xCoordinate and yCoordinate are absolute Quartz screen coordinates.
-// The overlay positions a small window around the indicator badge
-// instead of using a full-screen window, saving ~47MB of backing store.
 //
 // IMPORTANT: This method must only be called from a single goroutine at a
 // time. The shared styleCache is invalidated and repopulated based on the
@@ -214,25 +217,12 @@ func (o *Overlay) DrawModeIndicator(mode string, xCoordinate, yCoordinate int) {
 
 	label := o.getOrCacheLabel(labelText)
 
-	// Position the small window centered on the indicator's absolute position.
-	// This avoids a full-screen backing store (~47MB on Retina).
-	indicatorAbsX := xCoordinate + xOffset
-	indicatorAbsY := yCoordinate + yOffset
-	C.NeruPositionOverlayRelative(
-		o.window,
-		C.double(indicatorAbsX),
-		C.double(indicatorAbsY),
-		C.double(indicatorWindowWidth),
-		C.double(indicatorWindowHeight),
-	)
-
-	// Create a single hint for the indicator.
-	// Position is at the center of the small window (in Quartz top-left coords).
+	// Create a single hint for the indicator
 	hint := C.HintData{
 		label: label,
 		position: C.CGPoint{
-			x: C.double(indicatorWindowWidth / 2),  //nolint:mnd
-			y: C.double(indicatorWindowHeight / 2), //nolint:mnd
+			x: C.double(xCoordinate + xOffset),
+			y: C.double(yCoordinate + yOffset),
 		},
 		size: C.CGSize{
 			// Size is not strictly needed for just drawing the label, but providing reasonable defaults

--- a/internal/app/components/stickyindicator/overlay_darwin.go
+++ b/internal/app/components/stickyindicator/overlay_darwin.go
@@ -27,11 +27,6 @@ const (
 	stickyIndicatorWidth  = 60
 	stickyIndicatorHeight = 20
 
-	// stickyWindowWidth is the width of the small overlay window for the sticky indicator.
-	stickyWindowWidth = 300
-	// stickyWindowHeight is the height of the small overlay window for the sticky indicator.
-	stickyWindowHeight = 150
-
 	// NSWindowSharingNone represents NSWindowSharingNone (0) - hidden from screen sharing.
 	NSWindowSharingNone = 0
 	// NSWindowSharingReadOnly represents NSWindowSharingReadOnly (1) - visible in screen sharing.
@@ -126,18 +121,23 @@ func (o *Overlay) Clear() {
 	C.NeruClearOverlay(o.window)
 }
 
-// ResizeToActiveScreen is a no-op for sticky indicator overlays.
-// Sticky indicator windows are small and positioned dynamically by Draw
-// using NeruPositionOverlay, so full-screen resizing is unnecessary.
-// This avoids allocating a full-screen backing store (~47MB on Retina).
+// ResizeToActiveScreen adjusts the overlay window size with callback notification.
+// Falls back to a non-callback resize if the callback ID pool is exhausted.
 func (o *Overlay) ResizeToActiveScreen() {
-	// No-op: positioning is handled dynamically in Draw.
+	started := o.callbackManager.StartResizeOperation(func(callbackID uint64, generation uint64) {
+		contextPtr := overlayutil.CallbackIDToPointer(callbackID, generation)
+		C.NeruResizeOverlayToActiveScreenWithCallback(
+			o.window,
+			(C.ResizeCompletionCallback)(C.resizeStickyIndicatorCompletionCallback),
+			contextPtr,
+		)
+	})
+	if !started {
+		C.NeruResizeOverlayToActiveScreen(o.window)
+	}
 }
 
 // Draw draws the sticky modifier symbols near the specified cursor position.
-// xCoordinate and yCoordinate are absolute Quartz screen coordinates.
-// The overlay positions a small window around the indicator badge
-// instead of using a full-screen window, saving ~47MB of backing store.
 // X/Y offsets from uiConfig are applied internally (under configMu) to match
 // the mode indicator pattern. The caller must call Show() before Draw() for
 // the content to be visible.
@@ -201,24 +201,11 @@ func (o *Overlay) Draw(xCoordinate, yCoordinate int, symbols string) {
 		)
 	})
 
-	// Position the small window centered on the indicator's absolute position.
-	// This avoids a full-screen backing store (~47MB on Retina).
-	indicatorAbsX := xCoordinate + xOffset
-	indicatorAbsY := yCoordinate + yOffset
-	C.NeruPositionOverlayRelative(
-		o.window,
-		C.double(indicatorAbsX),
-		C.double(indicatorAbsY),
-		C.double(stickyWindowWidth),
-		C.double(stickyWindowHeight),
-	)
-
-	// Position is at the center of the small window (in Quartz top-left coords).
 	hint := C.HintData{
 		label: label,
 		position: C.CGPoint{
-			x: C.double(stickyWindowWidth / 2),  //nolint:mnd
-			y: C.double(stickyWindowHeight / 2), //nolint:mnd
+			x: C.double(xCoordinate + xOffset),
+			y: C.double(yCoordinate + yOffset),
 		},
 		size: C.CGSize{
 			width:  stickyIndicatorWidth,

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -131,7 +131,14 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 					}
 				}
 
+				screenOrigin := h.screenBounds.Min
+
 				h.mu.Unlock()
+
+				localCursorX := cursorX - screenOrigin.X
+				localCursorY := cursorY - screenOrigin.Y
+				localStickyX := stickyPoint.X - screenOrigin.X
+				localStickyY := stickyPoint.Y - screenOrigin.Y
 
 				// Mode indicator: show and draw when enabled, hide otherwise.
 				if showModeInd {
@@ -139,7 +146,7 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 						ind.Show()
 					}
 
-					h.modeIndicatorService.UpdateIndicatorPosition(cursorX, cursorY)
+					h.modeIndicatorService.UpdateIndicatorPosition(localCursorX, localCursorY)
 				} else if ind := h.overlayManager.ModeIndicatorOverlay(); ind != nil {
 					ind.Clear()
 					ind.Hide()
@@ -153,12 +160,12 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 							stickyInd.Show()
 						}
 
-						h.drawStickyModifiersIndicator(stickyPoint.X, stickyPoint.Y)
+						h.drawStickyModifiersIndicator(localStickyX, localStickyY)
 					} else if stickyInd := h.overlayManager.StickyModifiersOverlay(); stickyInd != nil {
 						if h.stickyIndicatorService != nil {
 							h.stickyIndicatorService.UpdateIndicatorPosition(
-								stickyPoint.X,
-								stickyPoint.Y,
+								localStickyX,
+								localStickyY,
 								"",
 							)
 						}

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -272,13 +272,4 @@ void NeruHideCursorIndicator(OverlayWindow window);
 /// @param style Indicator style
 void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle style);
 
-/// Position and resize overlay window to a specific rect centered on a point.
-/// Uses absolute Quartz coordinates for the center point.
-/// @param window Overlay window handle
-/// @param absoluteX Absolute Quartz X coordinate
-/// @param absoluteY Absolute Quartz Y coordinate
-/// @param width Window width in points
-/// @param height Window height in points
-void NeruPositionOverlayRelative(OverlayWindow window, double absoluteX, double absoluteY, double width, double height);
-
 #endif  // OVERLAY_H

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -5,7 +5,6 @@
 //  Copyright © 2025 Neru. All rights reserved.
 //
 
-#import "accessibility.h"
 #import "overlay.h"
 
 #import <Cocoa/Cocoa.h>
@@ -222,8 +221,6 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 /// Cached parsed colors keyed by normalized hex string
 @property(nonatomic, strong) NSCache *colorCache;
 
-- (void)clearContent;
-
 /// When YES, drawLayer:inContext: clears the full bounds and redraws everything.
 /// When NO, only the dirty region (clip box) is cleared and items intersecting it are redrawn.
 /// Defaults to YES; set to NO by match-prefix-only updates that use setNeedsDisplayInRect:.
@@ -371,22 +368,6 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 - (void)dealloc {
 	[self.gridTransitionTimer invalidate];
 	self.gridTransitionTimer = nil;
-}
-
-- (void)clearContent {
-	[self cancelGridTransition];
-	[self cancelCursorIndicatorTransition];
-	[self.hints removeAllObjects];
-	[self.gridCells removeAllObjects];
-	self.searchInput = nil;
-	self.cursorIndicatorVisible = NO;
-	[self.colorCache removeAllObjects];
-	[[self.cachedHintAttributedString mutableString] setString:@""];
-	[[self.cachedHintMeasureString mutableString] setString:@""];
-	[[self.cachedSearchInputAttributedString mutableString] setString:@""];
-	[[self.cachedGridCellAttributedString mutableString] setString:@""];
-	[[self.cachedGridSubKeyAttributedString mutableString] setString:@""];
-	[self setNeedsDisplay:YES];
 }
 
 /// Return the backing scale factor for the current screen, with fallbacks.
@@ -1712,7 +1693,6 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 @property(nonatomic, strong) OverlayView *overlayView;  ///< Overlay view instance
 @property(nonatomic, assign) NSInteger sharingType;     ///< Current window sharing type
 @property(nonatomic, assign) BOOL sharingTypeExplicit;  ///< Whether sharingType was explicitly configured
-@property(nonatomic, assign) BOOL shouldBeVisible;      ///< Whether the window should currently be visible on screen
 @end
 
 #pragma mark - Overlay Window Controller Implementation
@@ -1724,7 +1704,6 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 - (instancetype)init {
 	self = [super init];
 	if (self) {
-		_shouldBeVisible = NO;
 		[self createWindow];
 	}
 	return self;
@@ -1732,12 +1711,13 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 
 /// Create window
 - (void)createWindow {
-	NSRect initialRect = NSMakeRect(0, 0, 1, 1);
+	NSScreen *mainScreen = [NSScreen mainScreen];
+	NSRect screenFrame = [mainScreen frame];
 
 	// Use NSPanel for better floating overlay behavior.
 	// Non-activating panel won't steal focus from other apps.
 	NSPanel *panel =
-	    [[NSPanel alloc] initWithContentRect:initialRect
+	    [[NSPanel alloc] initWithContentRect:screenFrame
 	                               styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
 	                                 backing:NSBackingStoreBuffered
 	                                   defer:NO];
@@ -1771,7 +1751,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	[self.window setSharingType:self.sharingType];
 
 	// Create and attach overlay view
-	NSRect viewFrame = NSMakeRect(0, 0, 1, 1);
+	NSRect viewFrame = NSMakeRect(0, 0, screenFrame.size.width, screenFrame.size.height);
 	self.overlayView = [[OverlayView alloc] initWithFrame:viewFrame];
 	[self.window setContentView:self.overlayView];
 }
@@ -1819,25 +1799,17 @@ void NeruShowOverlayWindow(OverlayWindow window) {
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		@autoreleasepool {
-			controller.shouldBeVisible = YES;
-
 			[controller.window setLevel:kCGMaximumWindowLevel];
 			[controller.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
 			                                         NSWindowCollectionBehaviorStationary |
 			                                         NSWindowCollectionBehaviorIgnoresCycle |
 			                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
 
-			NSRect frame = controller.window.frame;
-			// Only display/order front if the window frame is larger than 1x1.
-			// This prevents a brief 1x1 pixel flash at the top-left screen origin
-			// when reactivating shrunken overlays.
-			if (frame.size.width > 1.0 || frame.size.height > 1.0) {
-				[controller.window setIsVisible:YES];
-				[controller.window orderFrontRegardless];
-				[controller.window display];
+			[controller.window setIsVisible:YES];
+			[controller.window orderFrontRegardless];
+			[controller.window display];
 
-				[controller.overlayView setNeedsDisplay:YES];
-			}
+			[controller.overlayView setNeedsDisplay:YES];
 		}
 	});
 }
@@ -1851,21 +1823,10 @@ void NeruHideOverlayWindow(OverlayWindow window) {
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
 	if ([NSThread isMainThread]) {
-		controller.shouldBeVisible = NO;
 		[controller.window orderOut:nil];
-		// Shrink to 1x1 to release the large backing store (saves ~47MB per
-		// Retina-resolution full-screen window). The next resize/show call
-		// will restore the proper frame before the window becomes visible.
-		[controller.window setFrame:NSMakeRect(0, 0, 1, 1) display:NO];
-		[controller.overlayView setFrame:NSMakeRect(0, 0, 1, 1)];
 	} else {
 		dispatch_async(dispatch_get_main_queue(), ^{
-			@autoreleasepool {
-				controller.shouldBeVisible = NO;
-				[controller.window orderOut:nil];
-				[controller.window setFrame:NSMakeRect(0, 0, 1, 1) display:NO];
-				[controller.overlayView setFrame:NSMakeRect(0, 0, 1, 1)];
-			}
+			[controller.window orderOut:nil];
 		});
 	}
 }
@@ -1879,11 +1840,23 @@ void NeruClearOverlay(OverlayWindow window) {
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
 	if ([NSThread isMainThread]) {
-		[controller.overlayView clearContent];
+		[controller.overlayView cancelGridTransition];
+		[controller.overlayView cancelCursorIndicatorTransition];
+		[controller.overlayView.hints removeAllObjects];
+		[controller.overlayView.gridCells removeAllObjects];
+		controller.overlayView.searchInput = nil;
+		controller.overlayView.cursorIndicatorVisible = NO;
+		[controller.overlayView setNeedsDisplay:YES];
 	} else {
 		dispatch_async(dispatch_get_main_queue(), ^{
 			@autoreleasepool {
-				[controller.overlayView clearContent];
+				[controller.overlayView cancelGridTransition];
+				[controller.overlayView cancelCursorIndicatorTransition];
+				[controller.overlayView.hints removeAllObjects];
+				[controller.overlayView.gridCells removeAllObjects];
+				controller.overlayView.searchInput = nil;
+				controller.overlayView.cursorIndicatorVisible = NO;
+				[controller.overlayView setNeedsDisplay:YES];
 			}
 		});
 	}
@@ -1922,10 +1895,8 @@ void NeruResizeOverlayToMainScreen(OverlayWindow window) {
 					                                         NSWindowCollectionBehaviorStationary |
 					                                         NSWindowCollectionBehaviorIgnoresCycle |
 					                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
-					if (controller.shouldBeVisible) {
-						[controller.window setIsVisible:YES];
-						[controller.window orderFrontRegardless];
-					}
+					[controller.window setIsVisible:YES];
+					[controller.window orderFrontRegardless];
 				}
 			});
 		}
@@ -1974,10 +1945,8 @@ void NeruResizeOverlayToActiveScreen(OverlayWindow window) {
 					                                         NSWindowCollectionBehaviorStationary |
 					                                         NSWindowCollectionBehaviorIgnoresCycle |
 					                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
-					if (controller.shouldBeVisible) {
-						[controller.window setIsVisible:YES];
-						[controller.window orderFrontRegardless];
-					}
+					[controller.window setIsVisible:YES];
+					[controller.window orderFrontRegardless];
 				}
 			});
 		}
@@ -2035,10 +2004,8 @@ void NeruResizeOverlayToActiveScreenWithCallback(
 					                                         NSWindowCollectionBehaviorStationary |
 					                                         NSWindowCollectionBehaviorIgnoresCycle |
 					                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
-					if (controller.shouldBeVisible) {
-						[controller.window setIsVisible:YES];
-						[controller.window orderFrontRegardless];
-					}
+					[controller.window setIsVisible:YES];
+					[controller.window orderFrontRegardless];
 
 					if (callback)
 						callback(context);
@@ -3223,40 +3190,6 @@ static NSPoint NeruAppKitPointFromQuartzPoint(CGPoint point) {
 
 	NSRect mainFrame = [NSScreen mainScreen].frame;
 	return NSMakePoint(point.x, NSMaxY(mainFrame) - point.y);
-}
-
-/// Position and resize overlay window to a specific rect centered on a point.
-/// Converts absolute Quartz coordinates directly to AppKit (bottom-left origin) for correct multi-monitor placement.
-/// Used by small indicator overlays (mode indicator, sticky modifiers) to avoid full-screen backing stores.
-/// @param window Overlay window handle
-/// @param absoluteX Absolute Quartz X position
-/// @param absoluteY Absolute Quartz Y position
-/// @param width Window width in points
-/// @param height Window height in points
-void NeruPositionOverlayRelative(
-    OverlayWindow window, double absoluteX, double absoluteY, double width, double height) {
-	if (!window)
-		return;
-
-	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
-
-	dispatch_async(dispatch_get_main_queue(), ^{
-		@autoreleasepool {
-			NSPoint appKitCenter = NeruAppKitPointFromQuartzPoint(CGPointMake(absoluteX, absoluteY));
-			NSRect frame = NSMakeRect(appKitCenter.x - width / 2.0, appKitCenter.y - height / 2.0, width, height);
-
-			[controller.window setFrame:frame display:NO];
-			NSRect viewFrame = NSMakeRect(0, 0, width, height);
-			[controller.overlayView setFrame:viewFrame];
-
-			if (controller.shouldBeVisible) {
-				[controller.window setIsVisible:YES];
-				[controller.window orderFrontRegardless];
-				[controller.window display];
-				[controller.overlayView setNeedsDisplay:YES];
-			}
-		}
-	});
 }
 
 /// Show a transient mouse action indicator in its own overlay window.

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -1693,6 +1693,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 @property(nonatomic, strong) OverlayView *overlayView;  ///< Overlay view instance
 @property(nonatomic, assign) NSInteger sharingType;     ///< Current window sharing type
 @property(nonatomic, assign) BOOL sharingTypeExplicit;  ///< Whether sharingType was explicitly configured
+@property(nonatomic, assign) BOOL shouldBeVisible;      ///< Whether the window should currently be visible on screen
 @end
 
 #pragma mark - Overlay Window Controller Implementation
@@ -1704,6 +1705,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 - (instancetype)init {
 	self = [super init];
 	if (self) {
+		_shouldBeVisible = NO;
 		[self createWindow];
 	}
 	return self;
@@ -1799,6 +1801,8 @@ void NeruShowOverlayWindow(OverlayWindow window) {
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		@autoreleasepool {
+			controller.shouldBeVisible = YES;
+
 			[controller.window setLevel:kCGMaximumWindowLevel];
 			[controller.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
 			                                         NSWindowCollectionBehaviorStationary |
@@ -1823,10 +1827,14 @@ void NeruHideOverlayWindow(OverlayWindow window) {
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
 	if ([NSThread isMainThread]) {
+		controller.shouldBeVisible = NO;
 		[controller.window orderOut:nil];
 	} else {
 		dispatch_async(dispatch_get_main_queue(), ^{
-			[controller.window orderOut:nil];
+			@autoreleasepool {
+				controller.shouldBeVisible = NO;
+				[controller.window orderOut:nil];
+			}
 		});
 	}
 }
@@ -1846,6 +1854,12 @@ void NeruClearOverlay(OverlayWindow window) {
 		[controller.overlayView.gridCells removeAllObjects];
 		controller.overlayView.searchInput = nil;
 		controller.overlayView.cursorIndicatorVisible = NO;
+		[controller.overlayView.colorCache removeAllObjects];
+		[[controller.overlayView.cachedHintAttributedString mutableString] setString:@""];
+		[[controller.overlayView.cachedHintMeasureString mutableString] setString:@""];
+		[[controller.overlayView.cachedSearchInputAttributedString mutableString] setString:@""];
+		[[controller.overlayView.cachedGridCellAttributedString mutableString] setString:@""];
+		[[controller.overlayView.cachedGridSubKeyAttributedString mutableString] setString:@""];
 		[controller.overlayView setNeedsDisplay:YES];
 	} else {
 		dispatch_async(dispatch_get_main_queue(), ^{
@@ -1856,6 +1870,12 @@ void NeruClearOverlay(OverlayWindow window) {
 				[controller.overlayView.gridCells removeAllObjects];
 				controller.overlayView.searchInput = nil;
 				controller.overlayView.cursorIndicatorVisible = NO;
+				[controller.overlayView.colorCache removeAllObjects];
+				[[controller.overlayView.cachedHintAttributedString mutableString] setString:@""];
+				[[controller.overlayView.cachedHintMeasureString mutableString] setString:@""];
+				[[controller.overlayView.cachedSearchInputAttributedString mutableString] setString:@""];
+				[[controller.overlayView.cachedGridCellAttributedString mutableString] setString:@""];
+				[[controller.overlayView.cachedGridSubKeyAttributedString mutableString] setString:@""];
 				[controller.overlayView setNeedsDisplay:YES];
 			}
 		});
@@ -1895,8 +1915,10 @@ void NeruResizeOverlayToMainScreen(OverlayWindow window) {
 					                                         NSWindowCollectionBehaviorStationary |
 					                                         NSWindowCollectionBehaviorIgnoresCycle |
 					                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
-					[controller.window setIsVisible:YES];
-					[controller.window orderFrontRegardless];
+					if (controller.shouldBeVisible) {
+						[controller.window setIsVisible:YES];
+						[controller.window orderFrontRegardless];
+					}
 				}
 			});
 		}
@@ -1945,8 +1967,10 @@ void NeruResizeOverlayToActiveScreen(OverlayWindow window) {
 					                                         NSWindowCollectionBehaviorStationary |
 					                                         NSWindowCollectionBehaviorIgnoresCycle |
 					                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
-					[controller.window setIsVisible:YES];
-					[controller.window orderFrontRegardless];
+					if (controller.shouldBeVisible) {
+						[controller.window setIsVisible:YES];
+						[controller.window orderFrontRegardless];
+					}
 				}
 			});
 		}
@@ -2004,8 +2028,10 @@ void NeruResizeOverlayToActiveScreenWithCallback(
 					                                         NSWindowCollectionBehaviorStationary |
 					                                         NSWindowCollectionBehaviorIgnoresCycle |
 					                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
-					[controller.window setIsVisible:YES];
-					[controller.window orderFrontRegardless];
+					if (controller.shouldBeVisible) {
+						[controller.window setIsVisible:YES];
+						[controller.window orderFrontRegardless];
+					}
 
 					if (callback)
 						callback(context);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR reverts #832, which switched the mode indicator and sticky modifier overlays from full-screen windows (covering the active screen) to small 300x150 windows positioned dynamically each tick. The optimization saved some memory of backing store per Retina display but introduced a regression on multi-monitor setups where the mode indicator flickers between positions near the edge where two displays meet.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #886

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/9f169f3d-4ad0-4568-83b9-29068a73bf03

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
