### PR TITLE
fix(overlay): use dispatch_sync with main thread check for window destruction

### DIFF
--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -1783,12 +1783,18 @@ void NeruDestroyOverlayWindow(OverlayWindow window) {
 	if (!window)
 		return;
 
-	dispatch_async(dispatch_get_main_queue(), ^{
+	void (^destroyBlock)(void) = ^{
 		@autoreleasepool {
 			OverlayWindowController *controller = CFBridgingRelease(window);
 			[controller.window close];
 		}
-	});
+	};
+
+	if ([NSThread isMainThread]) {
+		destroyBlock();
+	} else {
+		dispatch_sync(dispatch_get_main_queue(), destroyBlock);
+	}
 }
 
 /// Show overlay window


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR replace `dispatch_async` with a synchronous block that checks if already on
the main thread, avoiding potential use-after-free by ensuring the window
controller is fully deallocated before returning.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
