### PR TITLE
feat(config,hotkey,cli): make `exec` shell configurable

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -13,6 +13,8 @@ passthrough_unbounded_keys = false           # Let unbound Cmd/Ctrl/Alt shortcut
 should_exit_after_passthrough = false        # Exit the current mode after a shortcut is passed through
 passthrough_unbounded_keys_blacklist = []    # Shortcuts to still consume when passthrough is on
 hide_overlay_in_screen_share = false         # Hide overlay from screen sharing apps
+exec_shell = "/bin/bash"                     # Shell used for exec commands (e.g. "/bin/dash", "/bin/zsh")
+exec_shell_args = ["-lc"]                    # Shell arguments, where the last argument will be the command string
 
 # Theme palette
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#theme

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -270,6 +270,8 @@ See [CLI.md](CLI.md#feed-keys) for syntax, supported key names, and platform beh
 | `passthrough_unbounded_keys`           | bool   | `false` | Let unbound Cmd/Ctrl/Alt shortcuts pass through     |
 | `should_exit_after_passthrough`        | bool   | `false` | Exit mode after a passthrough shortcut              |
 | `passthrough_unbounded_keys_blacklist` | array  | `[]`    | Shortcuts to keep consumed when passthrough is on   |
+| `exec_shell`                           | string | `"/bin/bash"` | Shell binary used for `exec` hotkey commands |
+| `exec_shell_args`                      | array  | `["-lc"]` | Shell arguments; command string is appended last |
 
 Find available `kb_layout_to_use` IDs on macOS:
 

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -352,7 +352,15 @@ func (a *App) executeShellCommand(key, actionStr string) error {
 	ctx, cancel := context.WithTimeout(a.ctx, domain.ShellCommandTimeout)
 	defer cancel()
 
-	command := exec.CommandContext(ctx, "/bin/bash", "-lc", cmdString) //nolint:gosec
+	cfg := a.configSnapshot()
+	shell := cfg.General.ExecShell
+	shellArgs := cfg.General.ExecShellArgs
+
+	args := make([]string, 0, len(shellArgs)+1)
+	args = append(args, shellArgs...)
+	args = append(args, cmdString)
+
+	command := exec.CommandContext(ctx, shell, args...) //nolint:gosec
 
 	commandOutput, commandErr := command.CombinedOutput()
 	if commandErr != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -427,6 +427,8 @@ type GeneralConfig struct {
 	PassthroughUnboundedKeysBlacklist []string `json:"passthroughUnboundedKeysBlacklist" toml:"passthrough_unbounded_keys_blacklist"`
 	HideOverlayInScreenShare          bool     `json:"hideOverlayInScreenShare"          toml:"hide_overlay_in_screen_share"`
 	KBLayoutToUse                     string   `json:"kbLayoutToUse"                     toml:"kb_layout_to_use"`
+	ExecShell                         string   `json:"execShell"                         toml:"exec_shell"`
+	ExecShellArgs                     []string `json:"execShellArgs"                     toml:"exec_shell_args"`
 }
 
 // ModeIndicatorUI defines the visual/appearance settings for the mode indicator.
@@ -1034,6 +1036,21 @@ func (c *Config) ValidateGeneral() error {
 				key,
 			)
 		}
+	}
+
+	if c.General.ExecShell == "" {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"general.exec_shell cannot be empty",
+		)
+	}
+
+	if !strings.HasPrefix(c.General.ExecShell, "/") {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"general.exec_shell must be an absolute path (got: %q)",
+			c.General.ExecShell,
+		)
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1053,6 +1053,13 @@ func (c *Config) ValidateGeneral() error {
 		)
 	}
 
+	if len(c.General.ExecShellArgs) == 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"general.exec_shell_args cannot be empty",
+		)
+	}
+
 	return nil
 }
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -102,6 +102,10 @@ const (
 	// DefaultExecShell is the default shell used for exec commands.
 	DefaultExecShell = "/bin/bash"
 
+	// DefaultExecShellFlag is the shell flag that causes the shell to read
+	// commands from the following string argument (e.g. "-c" or "-lc").
+	DefaultExecShellFlag = "-lc"
+
 	// DefaultSmoothCursorSteps is the default smooth cursor steps.
 	DefaultSmoothCursorSteps = 10
 
@@ -307,7 +311,7 @@ func newDefaultConfig() *Config {
 			HideOverlayInScreenShare:          false,
 			KBLayoutToUse:                     "",
 			ExecShell:                         DefaultExecShell,
-			ExecShellArgs:                     []string{"-lc"},
+			ExecShellArgs:                     []string{DefaultExecShellFlag},
 		},
 		Theme: defaultThemeConfig(),
 		Hotkeys: HotkeysConfig{

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -99,6 +99,9 @@ const (
 	// DefaultMaxAge is the default max age for logs (30 days).
 	DefaultMaxAge = 30
 
+	// DefaultExecShell is the default shell used for exec commands.
+	DefaultExecShell = "/bin/bash"
+
 	// DefaultSmoothCursorSteps is the default smooth cursor steps.
 	DefaultSmoothCursorSteps = 10
 
@@ -303,6 +306,8 @@ func newDefaultConfig() *Config {
 			PassthroughUnboundedKeysBlacklist: []string{},
 			HideOverlayInScreenShare:          false,
 			KBLayoutToUse:                     "",
+			ExecShell:                         DefaultExecShell,
+			ExecShellArgs:                     []string{"-lc"},
 		},
 		Theme: defaultThemeConfig(),
 		Hotkeys: HotkeysConfig{

--- a/internal/config/config_defaults_test.go
+++ b/internal/config/config_defaults_test.go
@@ -54,9 +54,11 @@ func TestDefaultConfig(t *testing.T) {
 			)
 		}
 
-		if len(cfg.General.ExecShellArgs) != 1 || cfg.General.ExecShellArgs[0] != "-lc" {
+		if len(cfg.General.ExecShellArgs) != 1 ||
+			cfg.General.ExecShellArgs[0] != config.DefaultExecShellFlag {
 			t.Errorf(
-				"Expected General.ExecShellArgs to be [\"-lc\"], got %v",
+				"Expected General.ExecShellArgs to be [%q], got %v",
+				config.DefaultExecShellFlag,
 				cfg.General.ExecShellArgs,
 			)
 		}

--- a/internal/config/config_defaults_test.go
+++ b/internal/config/config_defaults_test.go
@@ -45,6 +45,23 @@ func TestDefaultConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("General Exec Shell Defaults", func(t *testing.T) {
+		if cfg.General.ExecShell != config.DefaultExecShell {
+			t.Errorf(
+				"Expected General.ExecShell to be %q, got %q",
+				config.DefaultExecShell,
+				cfg.General.ExecShell,
+			)
+		}
+
+		if len(cfg.General.ExecShellArgs) != 1 || cfg.General.ExecShellArgs[0] != "-lc" {
+			t.Errorf(
+				"Expected General.ExecShellArgs to be [\"-lc\"], got %v",
+				cfg.General.ExecShellArgs,
+			)
+		}
+	})
+
 	t.Run("Grid Defaults", func(t *testing.T) {
 		if got := cfg.Grid.Hotkeys["`"]; len(got) != 1 ||
 			got[0] != "toggle-cursor-follow-selection" {

--- a/internal/config/validators_general_test.go
+++ b/internal/config/validators_general_test.go
@@ -18,6 +18,7 @@ func TestConfig_ValidateGeneral(t *testing.T) {
 				General: config.GeneralConfig{
 					KBLayoutToUse: "com.apple.keylayout.ABC",
 					ExecShell:     "/bin/bash",
+					ExecShellArgs: []string{"-lc"},
 				},
 			},
 			wantErr: false,
@@ -28,6 +29,7 @@ func TestConfig_ValidateGeneral(t *testing.T) {
 				General: config.GeneralConfig{
 					KBLayoutToUse: "   ",
 					ExecShell:     "/bin/bash",
+					ExecShellArgs: []string{"-lc"},
 				},
 			},
 			wantErr: true,
@@ -38,6 +40,7 @@ func TestConfig_ValidateGeneral(t *testing.T) {
 				General: config.GeneralConfig{
 					PassthroughUnboundedKeysBlacklist: []string{"Cmd+W", "Ctrl+Space"},
 					ExecShell:                         "/bin/bash",
+					ExecShellArgs:                     []string{"-lc"},
 				},
 			},
 			wantErr: false,
@@ -48,6 +51,7 @@ func TestConfig_ValidateGeneral(t *testing.T) {
 				General: config.GeneralConfig{
 					PassthroughUnboundedKeysBlacklist: []string{"Shift+Tab"},
 					ExecShell:                         "/bin/bash",
+					ExecShellArgs:                     []string{"-lc"},
 				},
 			},
 			wantErr: true,
@@ -56,7 +60,8 @@ func TestConfig_ValidateGeneral(t *testing.T) {
 			name: "exec_shell is empty - invalid",
 			config: config.Config{
 				General: config.GeneralConfig{
-					ExecShell: "",
+					ExecShell:     "",
+					ExecShellArgs: []string{"-lc"},
 				},
 			},
 			wantErr: true,
@@ -65,7 +70,8 @@ func TestConfig_ValidateGeneral(t *testing.T) {
 			name: "exec_shell is relative path - invalid",
 			config: config.Config{
 				General: config.GeneralConfig{
-					ExecShell: "bash",
+					ExecShell:     "bash",
+					ExecShellArgs: []string{"-lc"},
 				},
 			},
 			wantErr: true,
@@ -74,10 +80,21 @@ func TestConfig_ValidateGeneral(t *testing.T) {
 			name: "exec_shell is absolute path - valid",
 			config: config.Config{
 				General: config.GeneralConfig{
-					ExecShell: "/usr/local/bin/fish",
+					ExecShell:     "/usr/local/bin/fish",
+					ExecShellArgs: []string{"-lc"},
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "exec_shell_args is empty - invalid",
+			config: config.Config{
+				General: config.GeneralConfig{
+					ExecShell:     "/bin/bash",
+					ExecShellArgs: []string{},
+				},
+			},
+			wantErr: true,
 		},
 	}
 

--- a/internal/config/validators_general_test.go
+++ b/internal/config/validators_general_test.go
@@ -17,6 +17,7 @@ func TestConfig_ValidateGeneral(t *testing.T) {
 			config: config.Config{
 				General: config.GeneralConfig{
 					KBLayoutToUse: "com.apple.keylayout.ABC",
+					ExecShell:     "/bin/bash",
 				},
 			},
 			wantErr: false,
@@ -26,6 +27,7 @@ func TestConfig_ValidateGeneral(t *testing.T) {
 			config: config.Config{
 				General: config.GeneralConfig{
 					KBLayoutToUse: "   ",
+					ExecShell:     "/bin/bash",
 				},
 			},
 			wantErr: true,
@@ -35,6 +37,7 @@ func TestConfig_ValidateGeneral(t *testing.T) {
 			config: config.Config{
 				General: config.GeneralConfig{
 					PassthroughUnboundedKeysBlacklist: []string{"Cmd+W", "Ctrl+Space"},
+					ExecShell:                         "/bin/bash",
 				},
 			},
 			wantErr: false,
@@ -44,9 +47,37 @@ func TestConfig_ValidateGeneral(t *testing.T) {
 			config: config.Config{
 				General: config.GeneralConfig{
 					PassthroughUnboundedKeysBlacklist: []string{"Shift+Tab"},
+					ExecShell:                         "/bin/bash",
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "exec_shell is empty - invalid",
+			config: config.Config{
+				General: config.GeneralConfig{
+					ExecShell: "",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "exec_shell is relative path - invalid",
+			config: config.Config{
+				General: config.GeneralConfig{
+					ExecShell: "bash",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "exec_shell is absolute path - valid",
+			config: config.Config{
+				General: config.GeneralConfig{
+					ExecShell: "/usr/local/bin/fish",
+				},
+			},
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR allows configuration for the shell to run `neru exec`, defaults to `/bin/bash`.

If you prefer a light weight shell, try `/bin/dash`, or prefer other syntax, just set it accordingly.

```toml
[general]
exec_shell = "/bin/bash"
exec_shell_args = ["-lc"]
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
