### PR TITLE
feat(linux): detect dark mode via xdg portal + kdeglobals

### DIFF
--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -304,7 +304,7 @@ systemctl --user enable --now neru
 
 1. **Wayland global hotkeys**: Must be configured in the compositor, not in Neru's config. See [Hotkey Configuration](#1-hotkey-configuration).
 2. **Accessibility (AT-SPI)**: Full AT-SPI integration for clickable element discovery (hints mode) is currently unavailable natively under Wayland without relying on experimental plugins. Grid mode and scroll mode both work perfectly without AT-SPI.
-3. **Dark mode / Theme polling detection**: Not yet implemented. Output will fall back to default theme definitions.
+3. **Dark mode detection**: Detected via the `org.freedesktop.appearance` xdg-desktop-portal interface, with a `~/.config/kdeglobals` fallback, so `neru doctor` reports the current color scheme on any desktop that ships a portal. Restyling overlays to match the detected theme is not yet wired up.
 4. **Notifications**: Desktop notifications (`org.freedesktop.Notifications`) will log to stdout/file instead of pushing to DBus.
 5. **Wayland modified clicks need evdev access**: On wlroots compositors, reliable
    modified pointer actions depend on the `evdev` keyboard-capture path described

--- a/internal/app/ipc_info.go
+++ b/internal/app/ipc_info.go
@@ -22,6 +22,13 @@ import (
 // healthNotInitialized is the status string for components that were not initialized.
 const healthNotInitialized = "not initialized"
 
+// detailSuffix marks informational sibling keys in capabilitiesMap (e.g.
+// "dark_mode_detection_detail"). Any key ending in this suffix carries
+// free-form prose for the `neru doctor` metadata header and is deliberately
+// excluded from the component health-row loop, which only understands the
+// supported/stub/headless/ok vocabulary.
+const detailSuffix = "_detail"
+
 // IPCControllerInfo handles info and config-related IPC commands.
 type IPCControllerInfo struct {
 	configService *config.Service
@@ -254,11 +261,9 @@ func (h *IPCControllerInfo) handleHealth(ctx context.Context, _ ipc.Command) ipc
 	}
 
 	for key, value := range capabilities {
-		// Skip informational sibling fields (e.g. dark_mode_detection_detail).
-		// These are surfaced through the metadata header in `neru doctor`, not
-		// as component health rows, and their values are free-form prose that
-		// doesn't fit the supported/stub/headless/ok vocabulary.
-		if strings.HasSuffix(key, "_detail") {
+		// Skip informational sibling fields (e.g. dark_mode_detection_detail);
+		// see detailSuffix for the contract.
+		if strings.HasSuffix(key, detailSuffix) {
 			continue
 		}
 
@@ -381,7 +386,7 @@ func capabilitiesMap(capabilities ports.PlatformCapabilities) map[string]any {
 	// description there, so gate on platform to keep it out of their output.
 	if detail := capabilities.DarkModeDetection.Detail; detail != "" &&
 		strings.HasPrefix(capabilities.Platform, "linux") {
-		out["dark_mode_detection_detail"] = detail
+		out["dark_mode_detection"+detailSuffix] = detail
 	}
 
 	return out

--- a/internal/app/ipc_info.go
+++ b/internal/app/ipc_info.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"go.uber.org/zap"
@@ -253,6 +254,14 @@ func (h *IPCControllerInfo) handleHealth(ctx context.Context, _ ipc.Command) ipc
 	}
 
 	for key, value := range capabilities {
+		// Skip informational sibling fields (e.g. dark_mode_detection_detail).
+		// These are surfaced through the metadata header in `neru doctor`, not
+		// as component health rows, and their values are free-form prose that
+		// doesn't fit the supported/stub/headless/ok vocabulary.
+		if strings.HasSuffix(key, "_detail") {
+			continue
+		}
+
 		status, _ := value.(string)
 
 		components["capability."+key] = status
@@ -351,7 +360,7 @@ func capabilitiesMap(capabilities ports.PlatformCapabilities) map[string]any {
 		return map[string]any{}
 	}
 
-	return map[string]any{
+	out := map[string]any{
 		"platform":            capabilities.Platform,
 		"process":             capabilityString(capabilities.Process),
 		"screen":              capabilityString(capabilities.Screen),
@@ -364,6 +373,18 @@ func capabilitiesMap(capabilities ports.PlatformCapabilities) map[string]any {
 		"app_watcher":         capabilityString(capabilities.AppWatcher),
 		"dark_mode_detection": capabilityString(capabilities.DarkModeDetection),
 	}
+
+	// Surface dark-mode Detail as a sibling field so `neru doctor` can render
+	// the current live state (e.g. "current state: dark (source=xdg-portal)")
+	// without having to expand FeatureCapability into its own structured map.
+	// Only Linux probes a live state into Detail; Darwin/Windows leave a static
+	// description there, so gate on platform to keep it out of their output.
+	if detail := capabilities.DarkModeDetection.Detail; detail != "" &&
+		strings.HasPrefix(capabilities.Platform, "linux") {
+		out["dark_mode_detection_detail"] = detail
+	}
+
+	return out
 }
 
 func profileMap(profile platform.Profile) map[string]any {

--- a/internal/cli/cliutil/util.go
+++ b/internal/cli/cliutil/util.go
@@ -178,6 +178,7 @@ func (f *OutputFormatter) PrintHealth(cmd *cobra.Command, success bool, data any
 	}
 
 	printProfile(cmd, healthData["profile"])
+	printDarkMode(cmd, healthData["capabilities"])
 
 	cmd.Println()
 	// Print component checks
@@ -271,6 +272,24 @@ func isHealthyHealthStatus(componentKey, status string) bool {
 	}
 
 	return false
+}
+
+// printDarkMode renders a "Dark Mode:" metadata line when the platform
+// adapter populated dark_mode_detection_detail (currently Linux only).
+// On Linux this surfaces the live state ("dark" / "light" / "no preference"
+// + source), or the fix-it hint when no source is reachable.
+func printDarkMode(cmd *cobra.Command, rawCapabilities any) {
+	capabilities, ok := rawCapabilities.(map[string]any)
+	if !ok {
+		return
+	}
+
+	detail := stringValue(capabilities["dark_mode_detection_detail"])
+	if detail == "" {
+		return
+	}
+
+	cmd.Println("  Dark Mode: " + detail)
 }
 
 func printProfile(cmd *cobra.Command, rawProfile any) {

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -4,10 +4,16 @@
 package linux
 
 import (
+	"bufio"
 	"context"
 	"image"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/ports"
@@ -34,12 +40,23 @@ func (s *SystemAdapter) Health(ctx context.Context) error {
 }
 
 // Capabilities returns the current Linux capability surface.
+//
+// The dark-mode capability is live-probed: if a working source can be reached
+// the Detail field carries the current state ("dark" / "light" / "no
+// preference") plus the source name; if none of the sources work the status
+// is downgraded to stub with a fix-it hint. This is more useful than a
+// static "supported" claim because the user's actual question when running
+// `neru doctor` is "is dark mode being detected right now?", not "does the
+// code path exist on Linux?".
 func (s *SystemAdapter) Capabilities() ports.PlatformCapabilities {
 	capabilities := ports.LinuxCapabilities()
 
 	if s.backend != "" {
 		capabilities.Platform = "linux/" + s.backend
 	}
+
+	value, source, ok := darkModePreference()
+	capabilities.DarkModeDetection = darkModeCapability(value, source, ok)
 
 	return capabilities
 }
@@ -218,10 +235,12 @@ func (s *SystemAdapter) CursorPosition(ctx context.Context) (image.Point, error)
 	)
 }
 
-// IsDarkMode returns true if Linux dark mode is currently active.
-// TODO(linux): implement using org.freedesktop.appearance color-scheme D-Bus property.
+// IsDarkMode returns true if Linux dark mode is currently active. See
+// darkModePreference for source ordering and semantics.
 func (s *SystemAdapter) IsDarkMode() bool {
-	return false
+	value, _, ok := darkModePreference()
+
+	return ok && value == colorSchemeDark
 }
 
 // CheckPermissions verifies accessibility permissions on Linux.
@@ -250,3 +269,194 @@ func (s *SystemAdapter) ShowNotification(title, message string) {}
 
 // Ensure SystemAdapter implements ports.SystemPort.
 var _ ports.SystemPort = (*SystemAdapter)(nil)
+
+// darkModeSource names which input produced a color-scheme value.
+type darkModeSource string
+
+const (
+	darkModeSourcePortal     darkModeSource = "xdg-portal"
+	darkModeSourceKDEGlobals darkModeSource = "kdeglobals"
+)
+
+// freedesktop "color-scheme" enum (org.freedesktop.appearance).
+const (
+	colorSchemeNoPreference = 0
+	colorSchemeDark         = 1
+	colorSchemeLight        = 2
+)
+
+// darkModePortalTimeout caps the busctl call. The portal call is normally
+// sub-millisecond on a healthy session bus; 250ms gives us ample margin
+// without blocking `neru doctor` if the portal is wedged.
+const darkModePortalTimeout = 250 * time.Millisecond
+
+// darkModePreference returns the active freedesktop color-scheme preference.
+//
+// Sources are tried in order:
+//  1. The xdg-desktop-portal Settings.Read interface (works on GNOME, KDE
+//     when xdg-desktop-portal-kde is installed, and any wlroots compositor
+//     where xdg-desktop-portal-gtk is the fallback responder).
+//  2. ~/.config/kdeglobals [General] ColorScheme — covers vanilla KDE Plasma
+//     installs that haven't installed xdg-desktop-portal-kde and where the
+//     gtk-portal fallback returns nothing useful.
+//
+// Returns ok=false when no source could be queried (e.g. busctl missing AND
+// no kdeglobals on disk). Callers should treat that as "we don't know" rather
+// than "light mode".
+func darkModePreference() (int, darkModeSource, bool) {
+	if value, ok := readPortalColorScheme(); ok {
+		return value, darkModeSourcePortal, true
+	}
+
+	if value, ok := readKDEColorScheme(); ok {
+		return value, darkModeSourceKDEGlobals, true
+	}
+
+	return -1, "", false
+}
+
+// readPortalColorScheme queries the xdg-desktop-portal Settings interface.
+//
+// The portal's Settings.Read returns a variant-of-variant containing a
+// uint32: 0 = no preference, 1 = prefer dark, 2 = prefer light. busctl
+// formats that as e.g. "v v u 1"; we take the trailing token.
+//
+// busctl's --quiet flag suppresses the method-call return value (not just
+// bus chatter), so we deliberately do NOT pass it.
+func readPortalColorScheme() (int, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), darkModePortalTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "busctl",
+		"--user", "call",
+		"org.freedesktop.portal.Desktop",
+		"/org/freedesktop/portal/desktop",
+		"org.freedesktop.portal.Settings",
+		"Read", "ss",
+		"org.freedesktop.appearance", "color-scheme",
+	).Output()
+	if err != nil {
+		return 0, false
+	}
+
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return 0, false
+	}
+
+	value, err := strconv.Atoi(fields[len(fields)-1])
+	if err != nil {
+		return 0, false
+	}
+
+	if value < colorSchemeNoPreference || value > colorSchemeLight {
+		return 0, false
+	}
+
+	return value, true
+}
+
+// readKDEColorScheme reads ~/.config/kdeglobals (and the kdedefaults variant)
+// and infers a color-scheme value from the [General] ColorScheme key. Plasma
+// scheme names containing "dark" (case-insensitive) — BreezeDark, OxygenDark,
+// custom *Dark schemes — map to colorSchemeDark; everything else to
+// colorSchemeLight. Returns ok=false when neither file exists or the key is
+// missing, so the caller can fall through to "unknown".
+func readKDEColorScheme() (int, bool) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return 0, false
+	}
+
+	candidates := []string{
+		filepath.Join(home, ".config", "kdeglobals"),
+		filepath.Join(home, ".config", "kdedefaults", "kdeglobals"),
+	}
+
+	for _, candidate := range candidates {
+		file, err := os.Open(candidate)
+		if err != nil {
+			continue
+		}
+
+		scheme := scanINIValue(file, "General", "ColorScheme")
+		_ = file.Close()
+
+		if scheme == "" {
+			continue
+		}
+
+		if strings.Contains(strings.ToLower(scheme), "dark") {
+			return colorSchemeDark, true
+		}
+
+		return colorSchemeLight, true
+	}
+
+	return 0, false
+}
+
+// scanINIValue is a minimal INI-section/key reader. Used only for the
+// kdeglobals lookups above so we don't pull in a full INI parser dependency.
+// Kept generic on (section, key) rather than hardcoding "General" /
+// "ColorScheme" to keep the parsing logic and the dark-mode policy decoupled
+// (the tests exercise both axes).
+//
+//nolint:unparam // section is parameterised on purpose; see comment above.
+func scanINIValue(r io.Reader, section, key string) string {
+	scanner := bufio.NewScanner(r)
+	sectionHeader := "[" + section + "]"
+	keyPrefix := key + "="
+
+	inSection := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inSection = (line == sectionHeader)
+
+			continue
+		}
+
+		if inSection && strings.HasPrefix(line, keyPrefix) {
+			return strings.TrimSpace(strings.TrimPrefix(line, keyPrefix))
+		}
+	}
+
+	return ""
+}
+
+// darkModeCapability builds a FeatureCapability describing the current
+// dark-mode state for surfacing through `neru doctor` / IPC. When ok=false
+// the capability is downgraded to stub with a fix-it hint, since "we have a
+// function that returns false" is misleading -- the user almost certainly
+// has a real preference set somewhere we just can't see.
+func darkModeCapability(value int, source darkModeSource, ok bool) ports.FeatureCapability {
+	if !ok {
+		return ports.FeatureCapability{
+			Status: ports.FeatureStatusStub,
+			Detail: "no dark-mode source reachable; install xdg-desktop-portal-{gnome,kde} or set ~/.config/kdeglobals [General] ColorScheme",
+		}
+	}
+
+	var label string
+
+	switch value {
+	case colorSchemeDark:
+		label = "dark"
+	case colorSchemeLight:
+		label = "light"
+	case colorSchemeNoPreference:
+		label = "no preference"
+	default:
+		label = "unknown"
+	}
+
+	return ports.FeatureCapability{
+		Status: ports.FeatureStatusSupported,
+		Detail: "current state: " + label + " (source=" + string(source) + ")",
+	}
+}

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -290,6 +290,10 @@ const (
 // without blocking `neru doctor` if the portal is wedged.
 const darkModePortalTimeout = 250 * time.Millisecond
 
+// portalBusctlMinFields is the minimum token count in a successful busctl
+// Settings.Read response ("v v u N").
+const portalBusctlMinFields = 4
+
 // darkModePreference returns the active freedesktop color-scheme preference.
 //
 // Sources are tried in order:
@@ -342,9 +346,9 @@ func readPortalColorScheme() (int, bool) {
 	fields := strings.Fields(string(out))
 	// Expected busctl format: "v v u N" — at least 4 tokens with the uint32
 	// value as the last field. Fewer tokens means something unexpected was
-	// returned (busctl exited 0 with prose we don't recognise), so we must
+	// returned (busctl exited 0 with prose we don't recognize), so we must
 	// not treat the trailing token as a color-scheme value.
-	if len(fields) < 4 {
+	if len(fields) < portalBusctlMinFields {
 		return 0, false
 	}
 
@@ -405,8 +409,6 @@ func readKDEColorScheme() (int, bool) {
 // Kept generic on (section, key) rather than hardcoding "General" /
 // "ColorScheme" to keep the parsing logic and the dark-mode policy decoupled
 // (the tests exercise both axes).
-//
-//nolint:unparam // section is parameterised on purpose; see comment above.
 func scanINIValue(r io.Reader, section, key string) string {
 	scanner := bufio.NewScanner(r)
 	sectionHeader := "[" + section + "]"

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -340,7 +340,11 @@ func readPortalColorScheme() (int, bool) {
 	}
 
 	fields := strings.Fields(string(out))
-	if len(fields) == 0 {
+	// Expected busctl format: "v v u N" — at least 4 tokens with the uint32
+	// value as the last field. Fewer tokens means something unexpected was
+	// returned (busctl exited 0 with prose we don't recognise), so we must
+	// not treat the trailing token as a color-scheme value.
+	if len(fields) < 4 {
 		return 0, false
 	}
 

--- a/internal/core/infra/platform/linux/system_linux_dark_mode_test.go
+++ b/internal/core/infra/platform/linux/system_linux_dark_mode_test.go
@@ -1,0 +1,170 @@
+//go:build linux
+
+//nolint:testpackage // Exercises unexported helpers (scanINIValue, darkModeCapability).
+package linux
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+func TestScanINIValueFindsKeyInCorrectSection(t *testing.T) {
+	t.Parallel()
+
+	// kdeglobals-shaped fixture: comments, multiple sections, the key we
+	// care about lives only in the [General] section.
+	body := strings.Join([]string{
+		"# kdeglobals fixture",
+		"[KDE]",
+		"ColorScheme=ShouldBeIgnored",
+		"",
+		"[General]",
+		"ColorScheme=BreezeDark",
+		"Other=value",
+		"",
+		"[General-Substitution]",
+		"ColorScheme=AlsoIgnored",
+	}, "\n")
+
+	got := scanINIValue(strings.NewReader(body), "General", "ColorScheme")
+	if got != "BreezeDark" {
+		t.Fatalf("scanINIValue() = %q, want %q", got, "BreezeDark")
+	}
+}
+
+func TestScanINIValueReturnsEmptyWhenSectionOrKeyMissing(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"missing section": "[Other]\nColorScheme=BreezeDark\n",
+		"missing key":     "[General]\nOther=value\n",
+		"empty body":      "",
+	}
+
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := scanINIValue(strings.NewReader(body), "General", "ColorScheme")
+			if got != "" {
+				t.Fatalf("scanINIValue() = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestDarkModeCapabilitySupportedStates(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		value      int
+		source     darkModeSource
+		wantStatus ports.FeatureStatus
+		wantInDtl  string
+	}{
+		{
+			name:       "dark via portal",
+			value:      colorSchemeDark,
+			source:     darkModeSourcePortal,
+			wantStatus: ports.FeatureStatusSupported,
+			wantInDtl:  "dark (source=xdg-portal)",
+		},
+		{
+			name:       "light via portal",
+			value:      colorSchemeLight,
+			source:     darkModeSourcePortal,
+			wantStatus: ports.FeatureStatusSupported,
+			wantInDtl:  "light (source=xdg-portal)",
+		},
+		{
+			name:       "no preference via portal",
+			value:      colorSchemeNoPreference,
+			source:     darkModeSourcePortal,
+			wantStatus: ports.FeatureStatusSupported,
+			wantInDtl:  "no preference (source=xdg-portal)",
+		},
+		{
+			name:       "dark via kdeglobals fallback",
+			value:      colorSchemeDark,
+			source:     darkModeSourceKDEGlobals,
+			wantStatus: ports.FeatureStatusSupported,
+			wantInDtl:  "dark (source=kdeglobals)",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := darkModeCapability(testCase.value, testCase.source, true)
+			if got.Status != testCase.wantStatus {
+				t.Fatalf("Status = %q, want %q", got.Status, testCase.wantStatus)
+			}
+
+			if !strings.Contains(got.Detail, testCase.wantInDtl) {
+				t.Fatalf("Detail = %q, want substring %q", got.Detail, testCase.wantInDtl)
+			}
+		})
+	}
+}
+
+func TestDarkModeCapabilityDowngradesToStubWhenUnreachable(t *testing.T) {
+	t.Parallel()
+
+	got := darkModeCapability(-1, "", false)
+
+	if got.Status != ports.FeatureStatusStub {
+		t.Fatalf("Status = %q, want %q", got.Status, ports.FeatureStatusStub)
+	}
+	// The detail must point the user at a real fix; an empty string would
+	// regress to the same "we know nothing" UX as the original bug.
+	if !strings.Contains(got.Detail, "xdg-desktop-portal") {
+		t.Fatalf(
+			"Detail = %q, want a fix-it hint mentioning xdg-desktop-portal",
+			got.Detail,
+		)
+	}
+}
+
+func TestReadKDEColorSchemeIsDarkWhenSchemeNameContainsDark(t *testing.T) {
+	t.Parallel()
+
+	// Pure scheme-name → dark/light inference, exercising the case-insensitive
+	// "dark" substring rule that protects vanilla KDE installs without
+	// xdg-desktop-portal-kde from silently reporting the wrong state.
+	cases := map[string]int{
+		"BreezeDark":   colorSchemeDark,
+		"OXYGEN-DARK":  colorSchemeDark,
+		"BreezeLight":  colorSchemeLight,
+		"Custom":       colorSchemeLight,
+		"DarkMatter":   colorSchemeDark,
+		"NotApplied!?": colorSchemeLight,
+	}
+
+	for scheme, want := range cases {
+		t.Run(scheme, func(t *testing.T) {
+			t.Parallel()
+
+			body := "[General]\nColorScheme=" + scheme + "\n"
+
+			got := scanINIValue(strings.NewReader(body), "General", "ColorScheme")
+			if got != scheme {
+				t.Fatalf("scanINIValue() = %q, want %q", got, scheme)
+			}
+
+			isDark := strings.Contains(strings.ToLower(got), "dark")
+
+			gotValue := colorSchemeLight
+			if isDark {
+				gotValue = colorSchemeDark
+			}
+
+			if gotValue != want {
+				t.Fatalf("derived color-scheme = %d, want %d", gotValue, want)
+			}
+		})
+	}
+}

--- a/internal/core/infra/platform/linux/system_linux_dark_mode_test.go
+++ b/internal/core/infra/platform/linux/system_linux_dark_mode_test.go
@@ -4,6 +4,8 @@
 package linux
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -129,41 +131,121 @@ func TestDarkModeCapabilityDowngradesToStubWhenUnreachable(t *testing.T) {
 	}
 }
 
-func TestReadKDEColorSchemeIsDarkWhenSchemeNameContainsDark(t *testing.T) {
-	t.Parallel()
+// writeKDEGlobals writes a minimal kdeglobals fixture with the given
+// ColorScheme into dir, creating parent directories as needed. An empty
+// scheme writes a file without the key, to exercise the "present but no key"
+// fall-through.
+func writeKDEGlobals(t *testing.T, path, scheme string) {
+	t.Helper()
 
-	// Pure scheme-name → dark/light inference, exercising the case-insensitive
-	// "dark" substring rule that protects vanilla KDE installs without
-	// xdg-desktop-portal-kde from silently reporting the wrong state.
-	cases := map[string]int{
-		"BreezeDark":   colorSchemeDark,
-		"OXYGEN-DARK":  colorSchemeDark,
-		"BreezeLight":  colorSchemeLight,
-		"Custom":       colorSchemeLight,
-		"DarkMatter":   colorSchemeDark,
-		"NotApplied!?": colorSchemeLight,
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
 	}
 
-	for scheme, want := range cases {
-		t.Run(scheme, func(t *testing.T) {
-			t.Parallel()
+	body := "[General]\n"
+	if scheme != "" {
+		body += "ColorScheme=" + scheme + "\n"
+	}
 
-			body := "[General]\nColorScheme=" + scheme + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
 
-			got := scanINIValue(strings.NewReader(body), "General", "ColorScheme")
-			if got != scheme {
-				t.Fatalf("scanINIValue() = %q, want %q", got, scheme)
+// TestReadKDEColorScheme exercises readKDEColorScheme directly through a
+// fake HOME, covering the case-insensitive "dark" inference, candidate
+// ordering (~/.config/kdeglobals wins over ~/.config/kdedefaults/kdeglobals),
+// the no-file and no-HOME fall-throughs, and first-hit-wins semantics.
+//
+// Not parallel: t.Setenv (HOME) is incompatible with t.Parallel.
+func TestReadKDEColorScheme(t *testing.T) {
+	primary := func(home string) string {
+		return filepath.Join(home, ".config", "kdeglobals")
+	}
+	defaults := func(home string) string {
+		return filepath.Join(home, ".config", "kdedefaults", "kdeglobals")
+	}
+
+	cases := []struct {
+		name   string
+		setup  func(t *testing.T, home string)
+		noHome bool
+		want   int
+		wantOK bool
+	}{
+		{
+			name: "primary BreezeDark is dark",
+			setup: func(t *testing.T, home string) {
+				writeKDEGlobals(t, primary(home), "BreezeDark")
+			},
+			want:   colorSchemeDark,
+			wantOK: true,
+		},
+		{
+			name: "primary case-insensitive dark match",
+			setup: func(t *testing.T, home string) {
+				writeKDEGlobals(t, primary(home), "OXYGEN-DARK")
+			},
+			want:   colorSchemeDark,
+			wantOK: true,
+		},
+		{
+			name: "primary BreezeLight is light",
+			setup: func(t *testing.T, home string) {
+				writeKDEGlobals(t, primary(home), "BreezeLight")
+			},
+			want:   colorSchemeLight,
+			wantOK: true,
+		},
+		{
+			name: "falls back to kdedefaults when primary absent",
+			setup: func(t *testing.T, home string) {
+				writeKDEGlobals(t, defaults(home), "BreezeDark")
+			},
+			want:   colorSchemeDark,
+			wantOK: true,
+		},
+		{
+			name: "primary wins over kdedefaults (first hit)",
+			setup: func(t *testing.T, home string) {
+				writeKDEGlobals(t, primary(home), "BreezeLight")
+				writeKDEGlobals(t, defaults(home), "BreezeDark")
+			},
+			want:   colorSchemeLight,
+			wantOK: true,
+		},
+		{
+			name:   "no files yields unknown",
+			setup:  nil, // empty HOME dir, no kdeglobals written
+			wantOK: false,
+		},
+		{
+			name:   "no HOME yields unknown",
+			noHome: true,
+			wantOK: false,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			home := t.TempDir()
+			if testCase.noHome {
+				t.Setenv("HOME", "")
+			} else {
+				t.Setenv("HOME", home)
 			}
 
-			isDark := strings.Contains(strings.ToLower(got), "dark")
-
-			gotValue := colorSchemeLight
-			if isDark {
-				gotValue = colorSchemeDark
+			if testCase.setup != nil {
+				testCase.setup(t, home)
 			}
 
-			if gotValue != want {
-				t.Fatalf("derived color-scheme = %d, want %d", gotValue, want)
+			got, ok := readKDEColorScheme()
+			if ok != testCase.wantOK {
+				t.Fatalf("readKDEColorScheme() ok = %v, want %v", ok, testCase.wantOK)
+			}
+
+			if ok && got != testCase.want {
+				t.Fatalf("readKDEColorScheme() = %d, want %d", got, testCase.want)
 			}
 		})
 	}

--- a/internal/core/infra/platform/linux/system_linux_dark_mode_test.go
+++ b/internal/core/infra/platform/linux/system_linux_dark_mode_test.go
@@ -138,7 +138,8 @@ func TestDarkModeCapabilityDowngradesToStubWhenUnreachable(t *testing.T) {
 func writeKDEGlobals(t *testing.T, path, scheme string) {
 	t.Helper()
 
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	err := os.MkdirAll(filepath.Dir(path), 0o755)
+	if err != nil {
 		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
 	}
 
@@ -147,7 +148,8 @@ func writeKDEGlobals(t *testing.T, path, scheme string) {
 		body += "ColorScheme=" + scheme + "\n"
 	}
 
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+	err = os.WriteFile(path, []byte(body), 0o600)
+	if err != nil {
 		t.Fatalf("WriteFile(%q): %v", path, err)
 	}
 }
@@ -176,6 +178,7 @@ func TestReadKDEColorScheme(t *testing.T) {
 		{
 			name: "primary BreezeDark is dark",
 			setup: func(t *testing.T, home string) {
+				t.Helper()
 				writeKDEGlobals(t, primary(home), "BreezeDark")
 			},
 			want:   colorSchemeDark,
@@ -184,6 +187,7 @@ func TestReadKDEColorScheme(t *testing.T) {
 		{
 			name: "primary case-insensitive dark match",
 			setup: func(t *testing.T, home string) {
+				t.Helper()
 				writeKDEGlobals(t, primary(home), "OXYGEN-DARK")
 			},
 			want:   colorSchemeDark,
@@ -192,6 +196,7 @@ func TestReadKDEColorScheme(t *testing.T) {
 		{
 			name: "primary BreezeLight is light",
 			setup: func(t *testing.T, home string) {
+				t.Helper()
 				writeKDEGlobals(t, primary(home), "BreezeLight")
 			},
 			want:   colorSchemeLight,
@@ -200,6 +205,7 @@ func TestReadKDEColorScheme(t *testing.T) {
 		{
 			name: "falls back to kdedefaults when primary absent",
 			setup: func(t *testing.T, home string) {
+				t.Helper()
 				writeKDEGlobals(t, defaults(home), "BreezeDark")
 			},
 			want:   colorSchemeDark,
@@ -208,6 +214,7 @@ func TestReadKDEColorScheme(t *testing.T) {
 		{
 			name: "primary wins over kdedefaults (first hit)",
 			setup: func(t *testing.T, home string) {
+				t.Helper()
 				writeKDEGlobals(t, primary(home), "BreezeLight")
 				writeKDEGlobals(t, defaults(home), "BreezeDark")
 			},

--- a/internal/core/ports/capability_presets.go
+++ b/internal/core/ports/capability_presets.go
@@ -74,8 +74,11 @@ func LinuxCapabilities() PlatformCapabilities {
 		AppWatcher: stubCapability(
 			"app watcher not needed for Neru's current navigation model",
 		),
-		DarkModeDetection: stubCapability(
-			"dark mode detection not implemented yet; target freedesktop appearance APIs",
+		// Default placeholder; the Linux SystemAdapter overrides this with
+		// the live-probed state (current color-scheme + source) on each
+		// Capabilities() call. See linux.SystemAdapter.Capabilities.
+		DarkModeDetection: supportedCapability(
+			"dark mode detection via freedesktop appearance portal (Settings.Read), with kdeglobals fallback",
 		),
 	}
 }


### PR DESCRIPTION
Scoped down per your review to Linux dark mode detection only.

What's new:
- Reads the color scheme from xdg-desktop-portal (org.freedesktop.appearance via Settings.Read), falling back to ~/.config/kdeglobals.
- Surfaces it in `neru doctor` as a "Dark Mode:" line (state + source).
- Flips the Linux DarkModeDetection capability from stub to supported; the SystemAdapter overrides it with the live value on each call.
- One line in docs/LINUX_SETUP.md.

The rest of the Linux capability work this branch originally carried (wlroots/KDE input + overlay) is reverted back to main. Those stay off until the libei / RemoteDesktop portal path is done and working, which I'll send as a separate PR (KWin won't implement zwlr_virtual_pointer_v1; WONTFIX, bug 518354).

Review comments: dropped logger export_test.go (the dark mode test uses package linux with //nolint:testpackage); no validation-linux docs; default-config.toml untouched; the dark mode code is universal so it stays in system_linux_common.go (portal covers GNOME/KDE/wlroots/X11, kdeglobals is a KDE-only fallback). Logging isn't in this PR anymore since it already landed on main in #908.

Testing: built on a clean Fedora 44 KDE VM (Plasma 6.6.4, arm64, CGO on); unit tests pass; a Breeze Dark session returns 1 and parses correctly. A full `neru doctor` on KDE needs the KDE backend that isn't on main yet, so that end-to-end check comes with the libei work.