### PR TITLE
perf(overlay,indicator): dynamically size indicator badge to save memory

### DIFF
--- a/internal/app/components/modeindicator/overlay_darwin.go
+++ b/internal/app/components/modeindicator/overlay_darwin.go
@@ -149,25 +149,12 @@ func (o *Overlay) Clear() {
 	C.NeruClearOverlay(o.window)
 }
 
-// ResizeToActiveScreen adjusts the overlay window size with callback notification.
-// Falls back to a non-callback resize if the callback ID pool is exhausted.
+// ResizeToActiveScreen is a no-op for mode indicator overlays.
+// The mode indicator uses a small window positioned dynamically by
+// DrawModeIndicator via NeruPositionAndSizeOverlayToFitHint, so full-screen resizing
+// is unnecessary and would defeat the small-window memory optimization.
 func (o *Overlay) ResizeToActiveScreen() {
-	started := o.callbackManager.StartResizeOperation(func(callbackID uint64, generation uint64) {
-		// Pass callback ID and generation as opaque pointer context for C callback.
-		// Uses CallbackIDToPointer to convert in a way that go vet accepts.
-		contextPtr := overlayutil.CallbackIDToPointer(callbackID, generation)
-
-		C.NeruResizeOverlayToActiveScreenWithCallback(
-			o.window,
-			(C.ResizeCompletionCallback)(C.resizeModeIndicatorCompletionCallback),
-			contextPtr,
-		)
-	})
-	if !started {
-		// Pool exhausted — fall back to non-callback resize so the overlay
-		// is still moved to the correct screen.
-		C.NeruResizeOverlayToActiveScreen(o.window)
-	}
+	// No-op: positioning is handled dynamically in DrawModeIndicator.
 }
 
 // DrawModeIndicator draws a mode label at the specified position.
@@ -177,6 +164,12 @@ func (o *Overlay) ResizeToActiveScreen() {
 // allowing users to customize (or hide) each mode's indicator text.
 // The caller is responsible for calling Show() once before the first draw
 // (e.g. in startModeIndicatorPolling) rather than showing every tick.
+//
+// xCoordinate and yCoordinate are absolute Quartz screen coordinates.
+// The overlay positions a small window around the indicator badge
+// instead of using a full-screen window, saves some memory of backing store
+// per Retina display. The native side clamps the window to a single
+// display to prevent the multi-monitor flicker regression.
 //
 // IMPORTANT: This method must only be called from a single goroutine at a
 // time. The shared styleCache is invalidated and repopulated based on the
@@ -216,21 +209,6 @@ func (o *Overlay) DrawModeIndicator(mode string, xCoordinate, yCoordinate int) {
 	}
 
 	label := o.getOrCacheLabel(labelText)
-
-	// Create a single hint for the indicator
-	hint := C.HintData{
-		label: label,
-		position: C.CGPoint{
-			x: C.double(xCoordinate + xOffset),
-			y: C.double(yCoordinate + yOffset),
-		},
-		size: C.CGSize{
-			// Size is not strictly needed for just drawing the label, but providing reasonable defaults
-			width:  defaultIndicatorWidth,
-			height: defaultIndicatorHeight,
-		},
-		matchedPrefixLength: 0,
-	}
 
 	// Resolve per-mode color overrides (falls back to UI defaults).
 	modeConfig := o.resolveModeConfig(mode)
@@ -296,6 +274,36 @@ func (o *Overlay) DrawModeIndicator(mode string, xCoordinate, yCoordinate int) {
 		paddingX:         C.int(o.indicatorConfig.UI.PaddingX),
 		paddingY:         C.int(o.indicatorConfig.UI.PaddingY),
 		showArrow:        0, // No arrow for mode indicator
+	}
+
+	// Position the small window centered on the indicator's absolute position.
+	// We calculate the hint size dynamically and size/position the window accordingly,
+	// returning the calculated width and height.
+	indicatorAbsX := xCoordinate + xOffset
+	indicatorAbsY := yCoordinate + yOffset
+	var windowWidth, windowHeight C.double
+	C.NeruPositionAndSizeOverlayToFitHint(
+		o.window,
+		C.double(indicatorAbsX),
+		C.double(indicatorAbsY),
+		label,
+		style,
+		&windowWidth,
+		&windowHeight,
+	)
+
+	// Create a single hint centered in the small window.
+	hint := C.HintData{
+		label: label,
+		position: C.CGPoint{
+			x: C.double(windowWidth / 2),  //nolint:mnd
+			y: C.double(windowHeight / 2), //nolint:mnd
+		},
+		size: C.CGSize{
+			width:  windowWidth,
+			height: windowHeight,
+		},
+		matchedPrefixLength: 0,
 	}
 
 	// Reuse NeruDrawHints which can draw arbitrary labels

--- a/internal/app/components/modeindicator/overlay_darwin.go
+++ b/internal/app/components/modeindicator/overlay_darwin.go
@@ -7,9 +7,6 @@ package modeindicator
 #cgo CFLAGS: -x objective-c
 #include "../../../core/infra/platform/darwin/overlay.h"
 #include <stdlib.h>
-
-// Callback function that Go can reference.
-extern void resizeModeIndicatorCompletionCallback(void* context);
 */
 import "C"
 
@@ -25,28 +22,11 @@ import (
 )
 
 const (
-	// defaultIndicatorWidth is the default width for the mode indicator.
-	defaultIndicatorWidth = 60
-	// defaultIndicatorHeight is the default height for the mode indicator.
-	defaultIndicatorHeight = 20
-
 	// NSWindowSharingNone represents NSWindowSharingNone (0) - hidden from screen sharing.
 	NSWindowSharingNone = 0
 	// NSWindowSharingReadOnly represents NSWindowSharingReadOnly (1) - visible in screen sharing.
 	NSWindowSharingReadOnly = 1
 )
-
-//export resizeModeIndicatorCompletionCallback
-func resizeModeIndicatorCompletionCallback(context unsafe.Pointer) {
-	// Read callback context from the C-heap-allocated CallbackContext
-	ctx := *(*overlayutil.CallbackContext)(context)
-
-	// Free the C-allocated context now that we've copied the values
-	overlayutil.FreeCallbackContext(context)
-
-	// Delegate to global callback manager
-	overlayutil.CompleteGlobalCallback(ctx.CallbackID, ctx.Generation)
-}
 
 // Overlay manages the rendering of mode indicator overlays using native platform APIs.
 type Overlay struct {
@@ -54,7 +34,6 @@ type Overlay struct {
 	indicatorConfig config.ModeIndicatorConfig
 	theme           config.ThemeProvider
 	logger          *zap.Logger
-	callbackManager *overlayutil.CallbackManager
 
 	// styleCache holds cached C style strings for the currently drawn mode.
 	// It is shared across all modes and invalidated on mode change via
@@ -90,14 +69,12 @@ func NewOverlay(
 	if err != nil {
 		return nil, err
 	}
-	base.CallbackManager.SetComponent("modeindicator")
 
 	return &Overlay{
 		window:          (C.OverlayWindow)(base.Window),
 		indicatorConfig: indicatorCfg,
 		theme:           theme,
 		logger:          logger,
-		callbackManager: base.CallbackManager,
 		styleCache:      base.StyleCache,
 		cachedLabels:    make(map[string]*C.char),
 	}, nil
@@ -111,14 +88,12 @@ func NewOverlayWithWindow(
 	windowPtr unsafe.Pointer,
 ) (*Overlay, error) {
 	base := overlayutil.NewBaseOverlayWithWindow(logger, windowPtr)
-	base.CallbackManager.SetComponent("modeindicator")
 
 	return &Overlay{
 		window:          (C.OverlayWindow)(base.Window),
 		indicatorConfig: indicatorCfg,
 		theme:           theme,
 		logger:          logger,
-		callbackManager: base.CallbackManager,
 		styleCache:      base.StyleCache,
 		cachedLabels:    make(map[string]*C.char),
 	}, nil
@@ -329,18 +304,9 @@ func (o *Overlay) SetSharingType(hide bool) {
 	C.NeruSetOverlaySharingType(o.window, sharingType)
 }
 
-// Cleanup frees Go-side resources (callbackManager, styleCache, labelCache)
-// without destroying the native window.
-func (o *Overlay) Cleanup() {
-	if o.callbackManager != nil {
-		o.callbackManager.Cleanup()
-	}
-	o.freeAllCaches()
-}
-
 // Destroy releases the overlay window resources.
 func (o *Overlay) Destroy() {
-	o.Cleanup()
+	o.freeAllCaches()
 
 	if o.window != nil {
 		C.NeruDestroyOverlayWindow(o.window)

--- a/internal/app/components/modeindicator/overlay_darwin.go
+++ b/internal/app/components/modeindicator/overlay_darwin.go
@@ -249,6 +249,7 @@ func (o *Overlay) DrawModeIndicator(mode string, xCoordinate, yCoordinate int) {
 		paddingX:         C.int(o.indicatorConfig.UI.PaddingX),
 		paddingY:         C.int(o.indicatorConfig.UI.PaddingY),
 		showArrow:        0, // No arrow for mode indicator
+		forceFlush:       1, // Indicator must flush synchronously to avoid first-show empty-badge flash
 	}
 
 	// Position the small window centered on the indicator's absolute position.

--- a/internal/app/components/stickyindicator/overlay_darwin.go
+++ b/internal/app/components/stickyindicator/overlay_darwin.go
@@ -190,6 +190,7 @@ func (o *Overlay) Draw(xCoordinate, yCoordinate int, symbols string) {
 		paddingX:         C.int(o.uiConfig.PaddingX),
 		paddingY:         C.int(o.uiConfig.PaddingY),
 		showArrow:        0,
+		forceFlush:       1, // Indicator must flush synchronously to avoid first-show empty-badge flash
 	}
 
 	// Position the small window centered on the indicator's absolute position.

--- a/internal/app/components/stickyindicator/overlay_darwin.go
+++ b/internal/app/components/stickyindicator/overlay_darwin.go
@@ -7,9 +7,6 @@ package stickyindicator
 #cgo CFLAGS: -x objective-c
 #include "../../../core/infra/platform/darwin/overlay.h"
 #include <stdlib.h>
-
-// Callback function that Go can reference.
-extern void resizeStickyIndicatorCompletionCallback(void* context);
 */
 import "C"
 
@@ -24,33 +21,19 @@ import (
 )
 
 const (
-	stickyIndicatorWidth  = 60
-	stickyIndicatorHeight = 20
-
 	// NSWindowSharingNone represents NSWindowSharingNone (0) - hidden from screen sharing.
 	NSWindowSharingNone = 0
 	// NSWindowSharingReadOnly represents NSWindowSharingReadOnly (1) - visible in screen sharing.
 	NSWindowSharingReadOnly = 1
 )
 
-//export resizeStickyIndicatorCompletionCallback
-func resizeStickyIndicatorCompletionCallback(context unsafe.Pointer) {
-	// Read callback context from the C-heap-allocated CallbackContext
-	ctx := *(*overlayutil.CallbackContext)(context)
-	// Free the C-allocated context now that we've copied the values
-	overlayutil.FreeCallbackContext(context)
-	// Delegate to global callback manager
-	overlayutil.CompleteGlobalCallback(ctx.CallbackID, ctx.Generation)
-}
-
 // Overlay manages the rendering of sticky modifiers indicator overlay.
 type Overlay struct {
-	window          C.OverlayWindow
-	uiConfig        config.StickyModifiersUI
-	theme           config.ThemeProvider
-	logger          *zap.Logger
-	callbackManager *overlayutil.CallbackManager
-	styleCache      *overlayutil.StyleCache
+	window     C.OverlayWindow
+	uiConfig   config.StickyModifiersUI
+	theme      config.ThemeProvider
+	logger     *zap.Logger
+	styleCache *overlayutil.StyleCache
 
 	configMu sync.RWMutex
 
@@ -72,16 +55,14 @@ func NewOverlay(
 	if err != nil {
 		return nil, err
 	}
-	base.CallbackManager.SetComponent("stickyindicator")
 
 	return &Overlay{
-		window:          (C.OverlayWindow)(base.Window),
-		uiConfig:        uiConfig,
-		theme:           theme,
-		logger:          logger,
-		callbackManager: base.CallbackManager,
-		styleCache:      base.StyleCache,
-		cachedLabels:    make(map[string]*C.char),
+		window:       (C.OverlayWindow)(base.Window),
+		uiConfig:     uiConfig,
+		theme:        theme,
+		logger:       logger,
+		styleCache:   base.StyleCache,
+		cachedLabels: make(map[string]*C.char),
 	}, nil
 }
 
@@ -93,16 +74,14 @@ func NewOverlayWithWindow(
 	windowPtr unsafe.Pointer,
 ) (*Overlay, error) {
 	base := overlayutil.NewBaseOverlayWithWindow(logger, windowPtr)
-	base.CallbackManager.SetComponent("stickyindicator")
 
 	return &Overlay{
-		window:          (C.OverlayWindow)(base.Window),
-		uiConfig:        uiConfig,
-		theme:           theme,
-		logger:          logger,
-		callbackManager: base.CallbackManager,
-		styleCache:      base.StyleCache,
-		cachedLabels:    make(map[string]*C.char),
+		window:       (C.OverlayWindow)(base.Window),
+		uiConfig:     uiConfig,
+		theme:        theme,
+		logger:       logger,
+		styleCache:   base.StyleCache,
+		cachedLabels: make(map[string]*C.char),
 	}, nil
 }
 
@@ -264,18 +243,9 @@ func (o *Overlay) SetSharingType(hide bool) {
 	C.NeruSetOverlaySharingType(o.window, sharingType)
 }
 
-// Cleanup frees Go-side resources (callbackManager, styleCache, labelCache)
-// without destroying the native window.
-func (o *Overlay) Cleanup() {
-	if o.callbackManager != nil {
-		o.callbackManager.Cleanup()
-	}
-	o.freeAllCaches()
-}
-
 // Destroy releases the overlay window resources.
 func (o *Overlay) Destroy() {
-	o.Cleanup()
+	o.freeAllCaches()
 	if o.window != nil {
 		C.NeruDestroyOverlayWindow(o.window)
 		o.window = nil

--- a/internal/app/components/stickyindicator/overlay_darwin.go
+++ b/internal/app/components/stickyindicator/overlay_darwin.go
@@ -121,23 +121,21 @@ func (o *Overlay) Clear() {
 	C.NeruClearOverlay(o.window)
 }
 
-// ResizeToActiveScreen adjusts the overlay window size with callback notification.
-// Falls back to a non-callback resize if the callback ID pool is exhausted.
+// ResizeToActiveScreen is a no-op for sticky indicator overlays.
+// The sticky indicator uses a small window positioned dynamically by Draw via
+// NeruPositionAndSizeOverlayToFitHint, so full-screen resizing is unnecessary and
+// would defeat the small-window memory optimization.
 func (o *Overlay) ResizeToActiveScreen() {
-	started := o.callbackManager.StartResizeOperation(func(callbackID uint64, generation uint64) {
-		contextPtr := overlayutil.CallbackIDToPointer(callbackID, generation)
-		C.NeruResizeOverlayToActiveScreenWithCallback(
-			o.window,
-			(C.ResizeCompletionCallback)(C.resizeStickyIndicatorCompletionCallback),
-			contextPtr,
-		)
-	})
-	if !started {
-		C.NeruResizeOverlayToActiveScreen(o.window)
-	}
+	// No-op: positioning is handled dynamically in Draw.
 }
 
 // Draw draws the sticky modifier symbols near the specified cursor position.
+// xCoordinate and yCoordinate are absolute Quartz screen coordinates. The
+// overlay positions a small window around the indicator badge instead of
+// using a full-screen window, saving some memory of backing store per Retina
+// display. The native side clamps the window to a single display to prevent
+// the multi-monitor flicker regression.
+//
 // X/Y offsets from uiConfig are applied internally (under configMu) to match
 // the mode indicator pattern. The caller must call Show() before Draw() for
 // the content to be visible.
@@ -201,19 +199,6 @@ func (o *Overlay) Draw(xCoordinate, yCoordinate int, symbols string) {
 		)
 	})
 
-	hint := C.HintData{
-		label: label,
-		position: C.CGPoint{
-			x: C.double(xCoordinate + xOffset),
-			y: C.double(yCoordinate + yOffset),
-		},
-		size: C.CGSize{
-			width:  stickyIndicatorWidth,
-			height: stickyIndicatorHeight,
-		},
-		matchedPrefixLength: 0,
-	}
-
 	style := C.HintStyle{
 		fontSize:         C.int(o.uiConfig.FontSize),
 		fontFamily:       (*C.char)(cachedStyle.FontFamily),
@@ -226,6 +211,35 @@ func (o *Overlay) Draw(xCoordinate, yCoordinate int, symbols string) {
 		paddingX:         C.int(o.uiConfig.PaddingX),
 		paddingY:         C.int(o.uiConfig.PaddingY),
 		showArrow:        0,
+	}
+
+	// Position the small window centered on the indicator's absolute position.
+	// We calculate the hint size dynamically and size/position the window accordingly,
+	// returning the calculated width and height.
+	indicatorAbsX := xCoordinate + xOffset
+	indicatorAbsY := yCoordinate + yOffset
+	var windowWidth, windowHeight C.double
+	C.NeruPositionAndSizeOverlayToFitHint(
+		o.window,
+		C.double(indicatorAbsX),
+		C.double(indicatorAbsY),
+		label,
+		style,
+		&windowWidth,
+		&windowHeight,
+	)
+
+	hint := C.HintData{
+		label: label,
+		position: C.CGPoint{
+			x: C.double(windowWidth / 2),  //nolint:mnd
+			y: C.double(windowHeight / 2), //nolint:mnd
+		},
+		size: C.CGSize{
+			width:  windowWidth,
+			height: windowHeight,
+		},
+		matchedPrefixLength: 0,
 	}
 
 	C.NeruDrawHints(o.window, &hint, 1, style)

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -124,21 +124,22 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 						if stickyInd := h.overlayManager.StickyModifiersOverlay(); stickyInd != nil {
 							stickyInd.ResizeToActiveScreen()
 						}
-						// Skip the draw this tick — the async resize hasn't
-						// completed yet, so drawing now would target the old
-						// window frame. The next tick will draw correctly.
+						// Skip the draw this tick so the next tick draws with
+						// a fully-updated h.screenBounds. The mode indicator
+						// and sticky modifier overlays use small windows that
+						// are positioned dynamically each tick, so this skip
+						// is mostly defensive against the display change
+						// coinciding with a draw dispatch.
 						continue
 					}
 				}
 
-				screenOrigin := h.screenBounds.Min
-
 				h.mu.Unlock()
 
-				localCursorX := cursorX - screenOrigin.X
-				localCursorY := cursorY - screenOrigin.Y
-				localStickyX := stickyPoint.X - screenOrigin.X
-				localStickyY := stickyPoint.Y - screenOrigin.Y
+				// The small indicator overlays (mode indicator, sticky modifiers)
+				// take absolute Quartz coordinates. The native side clamps the
+				// window frame to the active display to prevent the
+				// multi-monitor flicker.
 
 				// Mode indicator: show and draw when enabled, hide otherwise.
 				if showModeInd {
@@ -146,7 +147,7 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 						ind.Show()
 					}
 
-					h.modeIndicatorService.UpdateIndicatorPosition(localCursorX, localCursorY)
+					h.modeIndicatorService.UpdateIndicatorPosition(cursorX, cursorY)
 				} else if ind := h.overlayManager.ModeIndicatorOverlay(); ind != nil {
 					ind.Clear()
 					ind.Hide()
@@ -160,12 +161,12 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 							stickyInd.Show()
 						}
 
-						h.drawStickyModifiersIndicator(localStickyX, localStickyY)
+						h.drawStickyModifiersIndicator(stickyPoint.X, stickyPoint.Y)
 					} else if stickyInd := h.overlayManager.StickyModifiersOverlay(); stickyInd != nil {
 						if h.stickyIndicatorService != nil {
 							h.stickyIndicatorService.UpdateIndicatorPosition(
-								localStickyX,
-								localStickyY,
+								stickyPoint.X,
+								stickyPoint.Y,
 								"",
 							)
 						}

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -35,6 +35,7 @@ typedef struct {
 	int paddingY;                   ///< Vertical padding (-1 = auto)
 	int showArrow;                  ///< Show arrow (0 = no arrow, 1 = show arrow)
 	int placement;                  ///< Label placement relative to target
+	int forceFlush;                 ///< Force synchronous display flush after draw (0 = coalesce, 1 = flush)
 	int boundaryHighlightEnabled;   ///< Draw target boundary highlight (0 = off, 1 = on)
 	int boundaryBorderWidth;        ///< Target boundary border width
 	int boundaryBorderRadius;       ///< Target boundary corner radius

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -272,4 +272,23 @@ void NeruHideCursorIndicator(OverlayWindow window);
 /// @param style Indicator style
 void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle style);
 
+/// Position and resize overlay window to a specific rect centered on a point.
+/// Uses absolute Quartz coordinates for the desired hint center.
+///
+/// The window frame is clamped to the screen containing the center point so the
+/// entire window stays within a single display. This is required to prevent a
+/// regression on multi-monitor setups where a window straddling two displays
+/// causes the window's `screen` (and therefore the layer's contentsScale) to
+/// oscillate between displays as the cursor moves near the boundary.
+///
+
+/// Position and resize overlay window dynamically to fit a hint badge.
+/// Calculates the hint size using the provided label text and style configuration,
+/// sizes the window accordingly (with a small margin), and centers it on the target absolute position.
+/// Clamps the window frame to the containing display bounds.
+/// Returns the calculated window width and height via outWidth and outHeight pointers.
+void NeruPositionAndSizeOverlayToFitHint(
+    OverlayWindow window, double absoluteX, double absoluteY, const char *label, HintStyle style, double *outWidth,
+    double *outHeight);
+
 #endif  // OVERLAY_H

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -272,16 +272,6 @@ void NeruHideCursorIndicator(OverlayWindow window);
 /// @param style Indicator style
 void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle style);
 
-/// Position and resize overlay window to a specific rect centered on a point.
-/// Uses absolute Quartz coordinates for the desired hint center.
-///
-/// The window frame is clamped to the screen containing the center point so the
-/// entire window stays within a single display. This is required to prevent a
-/// regression on multi-monitor setups where a window straddling two displays
-/// causes the window's `screen` (and therefore the layer's contentsScale) to
-/// oscillate between displays as the cursor moves near the boundary.
-///
-
 /// Position and resize overlay window dynamically to fit a hint badge.
 /// Calculates the hint size using the provided label text and style configuration,
 /// sizes the window accordingly (with a small margin), and centers it on the target absolute position.

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -2169,7 +2169,9 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 			if (controller.shouldBeVisible) {
 				[controller.window setIsVisible:YES];
 				[controller.window orderFrontRegardless];
-				[controller.window display];
+				if (style.forceFlush) {
+					[controller.window display];
+				}
 			}
 		} else {
 			// Copy style strings before crossing the thread boundary
@@ -2181,6 +2183,7 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 			    .paddingY = style.paddingY,
 			    .showArrow = style.showArrow,
 			    .placement = style.placement,
+			    .forceFlush = style.forceFlush,
 			    .boundaryHighlightEnabled = style.boundaryHighlightEnabled,
 			    .boundaryBorderWidth = style.boundaryBorderWidth,
 			    .boundaryBorderRadius = style.boundaryBorderRadius,
@@ -2202,7 +2205,9 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 					if (controller.shouldBeVisible) {
 						[controller.window setIsVisible:YES];
 						[controller.window orderFrontRegardless];
-						[controller.window display];
+						if (styleCopy.forceFlush) {
+							[controller.window display];
+						}
 					}
 
 					free_hint_style_strings(&styleCopy);
@@ -3287,8 +3292,14 @@ static NSScreen *NeruScreenContainingQuartzPoint(CGPoint point) {
 void NeruPositionAndSizeOverlayToFitHint(
     OverlayWindow window, double absoluteX, double absoluteY, const char *label, HintStyle style, double *outWidth,
     double *outHeight) {
-	if (!window || !label)
+	if (!window || !label) {
+		if (outWidth)
+			*outWidth = 0;
+		if (outHeight)
+			*outHeight = 0;
+
 		return;
+	}
 
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -2166,6 +2166,11 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 			[controller.overlayView applyStyle:style];
 			[controller.overlayView.hints addObjectsFromArray:hintItems];
 			[controller.overlayView setNeedsDisplay:YES];
+			if (controller.shouldBeVisible) {
+				[controller.window setIsVisible:YES];
+				[controller.window orderFrontRegardless];
+				[controller.window display];
+			}
 		} else {
 			// Copy style strings before crossing the thread boundary
 			HintStyle styleCopy = {
@@ -2193,6 +2198,12 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 					[controller.overlayView applyStyle:styleCopy];
 					[controller.overlayView.hints addObjectsFromArray:hintItems];
 					[controller.overlayView setNeedsDisplay:YES];
+
+					if (controller.shouldBeVisible) {
+						[controller.window setIsVisible:YES];
+						[controller.window orderFrontRegardless];
+						[controller.window display];
+					}
 
 					free_hint_style_strings(&styleCopy);
 				}
@@ -3337,13 +3348,6 @@ void NeruPositionAndSizeOverlayToFitHint(
 			[controller.window setFrame:frame display:NO];
 			NSRect viewFrame = NSMakeRect(0, 0, windowWidth, windowHeight);
 			[controller.overlayView setFrame:viewFrame];
-
-			if (controller.shouldBeVisible) {
-				[controller.window setIsVisible:YES];
-				[controller.window orderFrontRegardless];
-				[controller.window display];
-				[controller.overlayView setNeedsDisplay:YES];
-			}
 
 			if (outWidth)
 				*outWidth = (double)windowWidth;

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -221,6 +221,8 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 /// Cached parsed colors keyed by normalized hex string
 @property(nonatomic, strong) NSCache *colorCache;
 
+- (void)clearContent;
+
 /// When YES, drawLayer:inContext: clears the full bounds and redraws everything.
 /// When NO, only the dirty region (clip box) is cleared and items intersecting it are redrawn.
 /// Defaults to YES; set to NO by match-prefix-only updates that use setNeedsDisplayInRect:.
@@ -370,6 +372,22 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	self.gridTransitionTimer = nil;
 }
 
+- (void)clearContent {
+	[self cancelGridTransition];
+	[self cancelCursorIndicatorTransition];
+	[self.hints removeAllObjects];
+	[self.gridCells removeAllObjects];
+	self.searchInput = nil;
+	self.cursorIndicatorVisible = NO;
+	[self.colorCache removeAllObjects];
+	[[self.cachedHintAttributedString mutableString] setString:@""];
+	[[self.cachedHintMeasureString mutableString] setString:@""];
+	[[self.cachedSearchInputAttributedString mutableString] setString:@""];
+	[[self.cachedGridCellAttributedString mutableString] setString:@""];
+	[[self.cachedGridSubKeyAttributedString mutableString] setString:@""];
+	[self setNeedsDisplay:YES];
+}
+
 /// Return the backing scale factor for the current screen, with fallbacks.
 /// Uses the window's actual screen (not mainScreen) to ensure correct rendering
 /// when the overlay moves between displays with different scale factors
@@ -398,6 +416,11 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	[super viewDidChangeBackingProperties];
 	if (self.layer) {
 		self.layer.contentsScale = [self currentBackingScaleFactor];
+		// Force a redraw so the layer's cached content is re-rendered at the
+		// new scale. Without this, the view can briefly show stale content at
+		// the previous scale factor when the window moves between displays
+		// with different backing properties (e.g. Retina to non-Retina).
+		[self setNeedsDisplay:YES];
 	}
 }
 
@@ -1713,13 +1736,17 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 
 /// Create window
 - (void)createWindow {
-	NSScreen *mainScreen = [NSScreen mainScreen];
-	NSRect screenFrame = [mainScreen frame];
+	// Start at 1x1 so the backing store is minimal until a resize is applied.
+	// Full-screen overlays call NeruResizeOverlayToActiveScreen before Show, and
+	// small indicator overlays (mode indicator, sticky modifiers) use
+	// NeruPositionOverlayRelative to set a small frame centered on the cursor.
+	// This saves some memory of backing store per hidden Retina overlay.
+	NSRect initialRect = NSMakeRect(0, 0, 1, 1);
 
 	// Use NSPanel for better floating overlay behavior.
 	// Non-activating panel won't steal focus from other apps.
 	NSPanel *panel =
-	    [[NSPanel alloc] initWithContentRect:screenFrame
+	    [[NSPanel alloc] initWithContentRect:initialRect
 	                               styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
 	                                 backing:NSBackingStoreBuffered
 	                                   defer:NO];
@@ -1753,7 +1780,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	[self.window setSharingType:self.sharingType];
 
 	// Create and attach overlay view
-	NSRect viewFrame = NSMakeRect(0, 0, screenFrame.size.width, screenFrame.size.height);
+	NSRect viewFrame = NSMakeRect(0, 0, 1, 1);
 	self.overlayView = [[OverlayView alloc] initWithFrame:viewFrame];
 	[self.window setContentView:self.overlayView];
 }
@@ -1815,11 +1842,19 @@ void NeruShowOverlayWindow(OverlayWindow window) {
 			                                         NSWindowCollectionBehaviorIgnoresCycle |
 			                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
 
-			[controller.window setIsVisible:YES];
-			[controller.window orderFrontRegardless];
-			[controller.window display];
+			NSRect frame = controller.window.frame;
+			// Only display/order front if the window frame is larger than 1x1.
+			// This prevents a brief 1x1 pixel flash at the top-left screen origin
+			// when reactivating shrunken overlays. Callers that show a freshly
+			// created overlay (full-screen or small indicator) must first call a
+			// resize/position function so the frame is non-trivial.
+			if (frame.size.width > 1.0 || frame.size.height > 1.0) {
+				[controller.window setIsVisible:YES];
+				[controller.window orderFrontRegardless];
+				[controller.window display];
 
-			[controller.overlayView setNeedsDisplay:YES];
+				[controller.overlayView setNeedsDisplay:YES];
+			}
 		}
 	});
 }
@@ -1835,11 +1870,18 @@ void NeruHideOverlayWindow(OverlayWindow window) {
 	if ([NSThread isMainThread]) {
 		controller.shouldBeVisible = NO;
 		[controller.window orderOut:nil];
+		// Shrink to 1x1 to release the large backing store (saves ~47MB per
+		// Retina-resolution full-screen window). The next resize/show call
+		// will restore the proper frame before the window becomes visible.
+		[controller.window setFrame:NSMakeRect(0, 0, 1, 1) display:NO];
+		[controller.overlayView setFrame:NSMakeRect(0, 0, 1, 1)];
 	} else {
 		dispatch_async(dispatch_get_main_queue(), ^{
 			@autoreleasepool {
 				controller.shouldBeVisible = NO;
 				[controller.window orderOut:nil];
+				[controller.window setFrame:NSMakeRect(0, 0, 1, 1) display:NO];
+				[controller.overlayView setFrame:NSMakeRect(0, 0, 1, 1)];
 			}
 		});
 	}
@@ -1854,35 +1896,11 @@ void NeruClearOverlay(OverlayWindow window) {
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
 	if ([NSThread isMainThread]) {
-		[controller.overlayView cancelGridTransition];
-		[controller.overlayView cancelCursorIndicatorTransition];
-		[controller.overlayView.hints removeAllObjects];
-		[controller.overlayView.gridCells removeAllObjects];
-		controller.overlayView.searchInput = nil;
-		controller.overlayView.cursorIndicatorVisible = NO;
-		[controller.overlayView.colorCache removeAllObjects];
-		[[controller.overlayView.cachedHintAttributedString mutableString] setString:@""];
-		[[controller.overlayView.cachedHintMeasureString mutableString] setString:@""];
-		[[controller.overlayView.cachedSearchInputAttributedString mutableString] setString:@""];
-		[[controller.overlayView.cachedGridCellAttributedString mutableString] setString:@""];
-		[[controller.overlayView.cachedGridSubKeyAttributedString mutableString] setString:@""];
-		[controller.overlayView setNeedsDisplay:YES];
+		[controller.overlayView clearContent];
 	} else {
 		dispatch_async(dispatch_get_main_queue(), ^{
 			@autoreleasepool {
-				[controller.overlayView cancelGridTransition];
-				[controller.overlayView cancelCursorIndicatorTransition];
-				[controller.overlayView.hints removeAllObjects];
-				[controller.overlayView.gridCells removeAllObjects];
-				controller.overlayView.searchInput = nil;
-				controller.overlayView.cursorIndicatorVisible = NO;
-				[controller.overlayView.colorCache removeAllObjects];
-				[[controller.overlayView.cachedHintAttributedString mutableString] setString:@""];
-				[[controller.overlayView.cachedHintMeasureString mutableString] setString:@""];
-				[[controller.overlayView.cachedSearchInputAttributedString mutableString] setString:@""];
-				[[controller.overlayView.cachedGridCellAttributedString mutableString] setString:@""];
-				[[controller.overlayView.cachedGridSubKeyAttributedString mutableString] setString:@""];
-				[controller.overlayView setNeedsDisplay:YES];
+				[controller.overlayView clearContent];
 			}
 		});
 	}
@@ -3222,6 +3240,123 @@ static NSPoint NeruAppKitPointFromQuartzPoint(CGPoint point) {
 
 	NSRect mainFrame = [NSScreen mainScreen].frame;
 	return NSMakePoint(point.x, NSMaxY(mainFrame) - point.y);
+}
+
+/// Resolve the NSScreen that contains the given Quartz point.
+/// Falls back to mainScreen, then the first available screen.
+/// Returns nil only if no screens are attached.
+static NSScreen *NeruScreenContainingQuartzPoint(CGPoint point) {
+	CGDirectDisplayID displayID = 0;
+	uint32_t displayCount = 0;
+	CGGetDisplaysWithPoint(point, 1, &displayID, &displayCount);
+
+	if (displayCount > 0) {
+		for (NSScreen *screen in [NSScreen screens]) {
+			NSNumber *screenNumber = screen.deviceDescription[@"NSScreenNumber"];
+			if (screenNumber.unsignedIntValue == displayID)
+				return screen;
+		}
+	}
+
+	return [NSScreen mainScreen] ?: [NSScreen.screens firstObject];
+}
+
+/// Position and resize overlay window to a specific rect centered on a point.
+/// Converts absolute Quartz coordinates to AppKit (bottom-left origin) and
+/// clamps the resulting frame to the screen containing the desired center so
+/// the entire window stays within a single display.
+///
+/// Clamping is critical: without it, a window straddling two displays causes
+/// AppKit to oscillate the window's `screen` (and therefore the layer's
+/// contentsScale) as the cursor moves near the boundary. That oscillation
+/// triggers `viewDidChangeBackingProperties` redraws at different scales and
+/// is perceived as a flicker on multi-monitor setups.
+///
+
+void NeruPositionAndSizeOverlayToFitHint(
+    OverlayWindow window, double absoluteX, double absoluteY, const char *label, HintStyle style, double *outWidth,
+    double *outHeight) {
+	if (!window || !label)
+		return;
+
+	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
+
+	void (^positionBlock)(void) = ^{
+		@autoreleasepool {
+			NSString *fontFamily = style.fontFamily ? @(style.fontFamily) : @"";
+			CGFloat fontSize = style.fontSize > 0 ? style.fontSize : kDefaultHintFontSize;
+			NSFont *font = nil;
+			if ([fontFamily length] > 0) {
+				font = [controller.overlayView resolveFont:fontFamily size:fontSize bold:YES];
+			}
+			if (!font) {
+				font = [NSFont boldSystemFontOfSize:fontSize];
+			}
+
+			NSMutableAttributedString *attrString = [[NSMutableAttributedString alloc] initWithString:@(label)];
+			NSRange fullRange = NSMakeRange(0, attrString.length);
+			[attrString setAttributes:@{NSFontAttributeName : font} range:fullRange];
+			NSSize textSize = [attrString size];
+
+			CGFloat paddingX = style.paddingX >= 0.0 ? style.paddingX : MAX(4.0, round(fontSize * 0.4));
+			CGFloat paddingY = style.paddingY >= 0.0 ? style.paddingY : MAX(2.0, round(fontSize * 0.25));
+			CGFloat borderWidth = style.borderWidth >= 0 ? style.borderWidth : 1.0;
+
+			CGFloat contentWidth = textSize.width + (paddingX * 2);
+			CGFloat contentHeight = textSize.height + (paddingY * 2);
+			CGFloat boxWidth = MAX(contentWidth, contentHeight);
+			CGFloat boxHeight = contentHeight;
+
+			// Add small margin for border anti-aliasing
+			CGFloat windowWidth = boxWidth + borderWidth * 2.0 + 4.0;
+			CGFloat windowHeight = boxHeight + borderWidth * 2.0 + 4.0;
+
+			CGPoint desiredCenter = CGPointMake(absoluteX, absoluteY);
+			NSPoint appKitCenter = NeruAppKitPointFromQuartzPoint(desiredCenter);
+
+			NSScreen *cursorScreen = NeruScreenContainingQuartzPoint(desiredCenter);
+			if (cursorScreen != nil) {
+				NSRect screenFrame = cursorScreen.frame;
+				CGFloat halfW = windowWidth / 2.0;
+				CGFloat halfH = windowHeight / 2.0;
+				CGFloat minX = screenFrame.origin.x + halfW;
+				CGFloat maxX = NSMaxX(screenFrame) - halfW;
+				CGFloat minY = screenFrame.origin.y + halfH;
+				CGFloat maxY = NSMaxY(screenFrame) - halfH;
+				if (minX <= maxX) {
+					appKitCenter.x = MAX(minX, MIN(appKitCenter.x, maxX));
+				}
+				if (minY <= maxY) {
+					appKitCenter.y = MAX(minY, MIN(appKitCenter.y, maxY));
+				}
+			}
+
+			NSRect frame = NSMakeRect(
+			    appKitCenter.x - windowWidth / 2.0, appKitCenter.y - windowHeight / 2.0, windowWidth, windowHeight);
+
+			[controller.window setFrame:frame display:NO];
+			NSRect viewFrame = NSMakeRect(0, 0, windowWidth, windowHeight);
+			[controller.overlayView setFrame:viewFrame];
+
+			if (controller.shouldBeVisible) {
+				[controller.window setIsVisible:YES];
+				[controller.window orderFrontRegardless];
+				[controller.window display];
+				[controller.overlayView setNeedsDisplay:YES];
+			}
+
+			if (outWidth)
+				*outWidth = (double)windowWidth;
+			if (outHeight)
+				*outHeight = (double)windowHeight;
+		}
+	};
+
+	if ([NSThread isMainThread]) {
+		positionBlock();
+	} else {
+		dispatch_sync(dispatch_get_main_queue(), positionBlock);
+	}
 }
 
 /// Show a transient mouse action indicator in its own overlay window.

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -3310,7 +3310,7 @@ void NeruPositionAndSizeOverlayToFitHint(
 			NSSize textSize = [attrString size];
 
 			CGFloat paddingX = style.paddingX >= 0.0 ? style.paddingX : MAX(4.0, round(fontSize * 0.4));
-			CGFloat paddingY = style.paddingY >= 0.0 ? style.paddingY : MAX(2.0, round(fontSize * 0.25));
+			CGFloat paddingY = style.paddingY >= 0.0 ? style.paddingY : MAX(2.0, round(fontSize * 0.2));
 			CGFloat borderWidth = style.borderWidth >= 0 ? style.borderWidth : 1.0;
 
 			CGFloat contentWidth = textSize.width + (paddingX * 2);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR implements dynamic sizing and positioning for macOS indicator badges (mode indicator and sticky modifiers overlays), ensuring minimal memory consumption.

This is an optimisation on top of the revert of #832 on PR #877

Instead of using a static sizing system, we now synchronously resolve the font and measure the text bounding box on the main thread. This dynamically resizes the native overlay window to match the badge dimensions exactly.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Follow up of #877

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
