### PR TITLE
feat(cli): add action to switch native workspace by index

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -72,7 +72,7 @@ neru idle                                  # Cancel active navigation mode
 | `--repeat, -r`            | bool   | Re-activate mode after action (requires `--action`)                                                                                       |
 | `--cursor-selection-mode` | string | `follow` (cursor follows selection) or `hold` (cursor stays)                                                                              |
 
-Not allowed as `--action`: `reset`, `backspace`, `search_hints`, `cycle_hint`, `focus_window`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos`, and scroll sub-actions (`scroll_up`, `page_down`, `go_top`, etc.).
+Not allowed as `--action`: `reset`, `backspace`, `search_hints`, `cycle_hint`, `focus_window`, `space`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos`, and scroll sub-actions (`scroll_up`, `page_down`, `go_top`, etc.).
 
 > The `--action` flag is most useful in hints mode (Vimium-style). In grid/recursive-grid, prefer composing behavior in per-mode hotkeys: `["action left_click", "idle"]`.
 
@@ -386,6 +386,19 @@ Bind to hotkeys for quick window switching:
 "Primary+Tab"       = "action focus_window"
 "Primary+Shift+Tab" = "action focus_window --backward"
 ```
+
+### Switching Spaces
+
+Focuses a Mission Control space by its 1-based index. macOS exposes no public API to activate a space, so Neru synthesizes a high-velocity horizontal dock swipe gesture to fast-forward to the destination space without the standard swipe animation. When the destination sits on a different display, the cursor is warped to its center first so the gesture is attributed to the correct screen.
+
+```bash
+neru action space 1     # Focus the first Mission Control space
+neru action space 3     # Focus the third
+```
+
+The index is 1-based and counted in Mission Control ordering across all connected displays. Index `1` is typically the leftmost space on the primary display. Returns a clear error if Mission Control is already active (swipe gestures are ignored there).
+
+> **Note:** This action is macOS only.
 
 ### Delay
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -232,10 +232,11 @@ All actions available in hotkeys. These also work as `neru action <name>` — se
 | Mode        | `reset`, `backspace`                                          |
 | Composition | `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos` |
 | Focus       | `focus_window`, `focus_window --backward`                     |
+| Space       | `space <number>` — 1-based Mission Control index (macOS only) |
 
 - Use `--bare` (e.g. `"action left_click --bare"`) to target the cursor position instead of the current mode selection (see [CLI.md](CLI.md#clicks))
 - `scroll_up` / `scroll_down` support `--steps` (e.g. `"action scroll_down --steps 200"`) to override `scroll_step` (see [CLI.md](CLI.md#scrolling))
-- `reset`, `backspace`, `search_hints`, `cycle_hint`, `focus_window`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, and `restore_cursor_pos` are not valid mode `--action` values — use `neru action ...` or in hotkeys as `"action ..."`
+- `reset`, `backspace`, `search_hints`, `cycle_hint`, `focus_window`, `space`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, and `restore_cursor_pos` are not valid mode `--action` values — use `neru action ...` or in hotkeys as `"action ..."`
 
 #### Feed Keys
 

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -266,7 +266,7 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 	}
 
 	if action.IsSpaceAction(actionName) {
-		return h.handleSpaceAction(ctx, cmd.Args[1:])
+		return h.dispatchSpaceAction(ctx, cmd.Args[1:])
 	}
 
 	parsed, parseErr := parseActionArgs(cmd.Args[1:])
@@ -723,6 +723,56 @@ func (h *IPCControllerActions) handleSleepAction(args []string) ipc.Response {
 		Message: "sleep performed",
 		Code:    ipc.CodeOK,
 	}
+}
+
+// dispatchSpaceAction validates the args and hands off to the
+// platform-specific handleSpaceAction. Extracted from handleAction to
+// keep the dispatcher's statement count under the funlen budget.
+func (h *IPCControllerActions) dispatchSpaceAction(
+	ctx context.Context,
+	args []string,
+) ipc.Response {
+	index, validationResp := parseSpaceActionArgs(args)
+	if validationResp != nil {
+		return *validationResp
+	}
+
+	return h.handleSpaceAction(ctx, index)
+}
+
+// parseSpaceActionArgs validates the positional arguments for the `space`
+// action and returns the 1-based index on success. On failure it returns
+// a non-nil *ipc.Response describing the error (caller should return it
+// directly). The helper is platform-agnostic so validation messages stay
+// consistent across macOS and stub platforms.
+func parseSpaceActionArgs(args []string) (int, *ipc.Response) {
+	if len(args) != 1 {
+		return 0, &ipc.Response{
+			Success: false,
+			Message: "space requires exactly one positional argument: the 1-based space number",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	raw := strings.TrimSpace(args[0])
+	if raw == "" {
+		return 0, &ipc.Response{
+			Success: false,
+			Message: "space number cannot be empty",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	index, parseErr := strconv.Atoi(raw)
+	if parseErr != nil || index < 1 {
+		return 0, &ipc.Response{
+			Success: false,
+			Message: "space number must be a positive integer, got " + args[0],
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	return index, nil
 }
 
 func parseSleepDuration(durationStr string) (time.Duration, error) {

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -767,7 +767,7 @@ func parseSpaceActionArgs(args []string) (int, *ipc.Response) {
 	if parseErr != nil || index < 1 {
 		return 0, &ipc.Response{
 			Success: false,
-			Message: "space number must be a positive integer, got " + args[0],
+			Message: "space number must be a positive integer, got " + raw,
 			Code:    ipc.CodeInvalidInput,
 		}
 	}

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -265,6 +265,10 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 		return h.handleSleepAction(cmd.Args[1:])
 	}
 
+	if action.IsSpaceAction(actionName) {
+		return h.handleSpaceAction(ctx, cmd.Args[1:])
+	}
+
 	parsed, parseErr := parseActionArgs(cmd.Args[1:])
 	if parseErr {
 		return ipc.Response{

--- a/internal/app/ipc_actions_darwin.go
+++ b/internal/app/ipc_actions_darwin.go
@@ -4,8 +4,6 @@ package app
 
 import (
 	"context"
-	"strconv"
-	"strings"
 
 	"go.uber.org/zap"
 
@@ -111,37 +109,13 @@ func (h *IPCControllerActions) handleFocusWindowAction(
 }
 
 // handleSpaceAction focuses the Mission Control space at the given 1-based
-// index using a synthetic high-velocity dock swipe gesture.
+// index using a synthetic high-velocity dock swipe gesture. The caller is
+// expected to have already validated the index via parseSpaceActionArgs,
+// so this handler is macOS-specific implementation only.
 func (h *IPCControllerActions) handleSpaceAction(
 	_ context.Context,
-	args []string,
+	index int,
 ) ipc.Response {
-	if len(args) != 1 {
-		return ipc.Response{
-			Success: false,
-			Message: "space requires exactly one positional argument: the 1-based space number",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	raw := strings.TrimSpace(args[0])
-	if raw == "" {
-		return ipc.Response{
-			Success: false,
-			Message: "space number cannot be empty",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	index, parseErr := strconv.Atoi(raw)
-	if parseErr != nil || index < 1 {
-		return ipc.Response{
-			Success: false,
-			Message: "space number must be a positive integer, got " + args[0],
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
 	if accessibility.IsMissionControlActive() {
 		return ipc.Response{
 			Success: false,

--- a/internal/app/ipc_actions_darwin.go
+++ b/internal/app/ipc_actions_darwin.go
@@ -4,11 +4,14 @@ package app
 
 import (
 	"context"
+	"strconv"
+	"strings"
 
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/core/infra/accessibility"
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+	"github.com/y3owk1n/neru/internal/core/infra/space"
 )
 
 func (h *IPCControllerActions) handleFocusWindowAction(
@@ -103,6 +106,70 @@ func (h *IPCControllerActions) handleFocusWindowAction(
 	return ipc.Response{
 		Success: true,
 		Message: "focus_window performed",
+		Code:    ipc.CodeOK,
+	}
+}
+
+// handleSpaceAction focuses the Mission Control space at the given 1-based
+// index using a synthetic high-velocity dock swipe gesture.
+func (h *IPCControllerActions) handleSpaceAction(
+	_ context.Context,
+	args []string,
+) ipc.Response {
+	if len(args) != 1 {
+		return ipc.Response{
+			Success: false,
+			Message: "space requires exactly one positional argument: the 1-based space number",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	raw := strings.TrimSpace(args[0])
+	if raw == "" {
+		return ipc.Response{
+			Success: false,
+			Message: "space number cannot be empty",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	index, parseErr := strconv.Atoi(raw)
+	if parseErr != nil || index < 1 {
+		return ipc.Response{
+			Success: false,
+			Message: "space number must be a positive integer, got " + args[0],
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	if accessibility.IsMissionControlActive() {
+		return ipc.Response{
+			Success: false,
+			Message: "cannot switch spaces while Mission Control is active",
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	h.logger.Debug("Focusing Mission Control space via IPC", zap.Int("index", index))
+
+	focusErr := space.FocusByIndex(index)
+	if focusErr != nil {
+		h.logger.Error(
+			"Failed to focus Mission Control space",
+			zap.Error(focusErr),
+			zap.Int("index", index),
+		)
+
+		return ipc.Response{
+			Success: false,
+			Message: "failed to focus space: " + focusErr.Error(),
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	return ipc.Response{
+		Success: true,
+		Message: "space performed",
 		Code:    ipc.CodeOK,
 	}
 }

--- a/internal/app/ipc_actions_other.go
+++ b/internal/app/ipc_actions_other.go
@@ -22,3 +22,17 @@ func (h *IPCControllerActions) handleFocusWindowAction(
 		Code: ipc.CodeActionFailed,
 	}
 }
+
+func (h *IPCControllerActions) handleSpaceAction(
+	_ context.Context,
+	_ []string,
+) ipc.Response {
+	return ipc.Response{
+		Success: false,
+		Message: derrors.New(
+			derrors.CodeNotSupported,
+			"space is only supported on macOS",
+		).Error(),
+		Code: ipc.CodeActionFailed,
+	}
+}

--- a/internal/app/ipc_actions_other.go
+++ b/internal/app/ipc_actions_other.go
@@ -25,7 +25,7 @@ func (h *IPCControllerActions) handleFocusWindowAction(
 
 func (h *IPCControllerActions) handleSpaceAction(
 	_ context.Context,
-	_ []string,
+	_ int,
 ) ipc.Response {
 	return ipc.Response{
 		Success: false,

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -435,6 +435,115 @@ func TestHandleAction_PreviousRejectedOnScrollAction(t *testing.T) {
 	}
 }
 
+func TestParseSpaceActionArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		args      []string
+		wantIndex int
+		wantErr   bool
+		wantMsg   string
+	}{
+		{
+			name:    "no args",
+			args:    []string{},
+			wantErr: true,
+			wantMsg: "space requires exactly one positional argument: the 1-based space number",
+		},
+		{
+			name:    "too many args",
+			args:    []string{"1", "2"},
+			wantErr: true,
+			wantMsg: "space requires exactly one positional argument: the 1-based space number",
+		},
+		{
+			name:    "empty string",
+			args:    []string{""},
+			wantErr: true,
+			wantMsg: "space number cannot be empty",
+		},
+		{
+			name:    "whitespace only",
+			args:    []string{"   "},
+			wantErr: true,
+			wantMsg: "space number cannot be empty",
+		},
+		{
+			name:    "non-numeric",
+			args:    []string{"abc"},
+			wantErr: true,
+			wantMsg: "space number must be a positive integer, got abc",
+		},
+		{
+			name:    "zero",
+			args:    []string{"0"},
+			wantErr: true,
+			wantMsg: "space number must be a positive integer, got 0",
+		},
+		{
+			name:    "negative",
+			args:    []string{"-3"},
+			wantErr: true,
+			wantMsg: "space number must be a positive integer, got -3",
+		},
+		{
+			name:      "one",
+			args:      []string{"1"},
+			wantIndex: 1,
+		},
+		{
+			name:      "large value",
+			args:      []string{"42"},
+			wantIndex: 42,
+		},
+		{
+			name:      "value with surrounding whitespace",
+			args:      []string{"  7  "},
+			wantIndex: 7,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			index, resp := parseSpaceActionArgs(testCase.args)
+			if testCase.wantErr {
+				if resp == nil {
+					t.Fatal("parseSpaceActionArgs() expected error response, got nil")
+				}
+
+				if index != 0 {
+					t.Fatalf("parseSpaceActionArgs() expected zero index on error, got %d", index)
+				}
+
+				if resp.Message != testCase.wantMsg {
+					t.Fatalf(
+						"parseSpaceActionArgs() message = %q, want %q",
+						resp.Message,
+						testCase.wantMsg,
+					)
+				}
+
+				return
+			}
+
+			if resp != nil {
+				t.Fatalf("parseSpaceActionArgs() unexpected error response: %v", *resp)
+			}
+
+			if index != testCase.wantIndex {
+				t.Fatalf(
+					"parseSpaceActionArgs() index = %d, want %d",
+					index,
+					testCase.wantIndex,
+				)
+			}
+		})
+	}
+}
+
 func TestHandleAction_SpaceRequiresOneArg(t *testing.T) {
 	controller := &IPCControllerActions{
 		appState: state.NewAppState(),

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -435,6 +435,126 @@ func TestHandleAction_PreviousRejectedOnScrollAction(t *testing.T) {
 	}
 }
 
+func TestHandleAction_SpaceRequiresOneArg(t *testing.T) {
+	controller := &IPCControllerActions{
+		appState: state.NewAppState(),
+		logger:   zap.NewNop(),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: "action",
+		Args:   []string{"space"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(space) expected failure with no args")
+	}
+
+	if resp.Message != "space requires exactly one positional argument: the 1-based space number" {
+		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
+func TestHandleAction_SpaceRejectsExtraArgs(t *testing.T) {
+	controller := &IPCControllerActions{
+		appState: state.NewAppState(),
+		logger:   zap.NewNop(),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: "action",
+		Args:   []string{"space", "1", "2"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(space 1 2) expected failure with too many args")
+	}
+
+	if resp.Message != "space requires exactly one positional argument: the 1-based space number" {
+		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
+func TestHandleAction_SpaceRejectsEmpty(t *testing.T) {
+	controller := &IPCControllerActions{
+		appState: state.NewAppState(),
+		logger:   zap.NewNop(),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: "action",
+		Args:   []string{"space", "   "},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(space <whitespace>) expected failure with empty arg")
+	}
+
+	if resp.Message != "space number cannot be empty" {
+		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
+func TestHandleAction_SpaceRejectsNonNumeric(t *testing.T) {
+	controller := &IPCControllerActions{
+		appState: state.NewAppState(),
+		logger:   zap.NewNop(),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: "action",
+		Args:   []string{"space", "abc"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(space abc) expected failure with non-numeric arg")
+	}
+
+	if resp.Message != "space number must be a positive integer, got abc" {
+		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
+func TestHandleAction_SpaceRejectsZero(t *testing.T) {
+	controller := &IPCControllerActions{
+		appState: state.NewAppState(),
+		logger:   zap.NewNop(),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: "action",
+		Args:   []string{"space", "0"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(space 0) expected failure with zero arg")
+	}
+
+	if resp.Message != "space number must be a positive integer, got 0" {
+		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
+func TestHandleAction_SpaceRejectsNegative(t *testing.T) {
+	controller := &IPCControllerActions{
+		appState: state.NewAppState(),
+		logger:   zap.NewNop(),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: "action",
+		Args:   []string{"space", "-3"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(space -3) expected failure with negative arg")
+	}
+
+	if resp.Message != "space number must be a positive integer, got -3" {
+		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
 func TestParseActionArgs_NameFlag(t *testing.T) {
 	parsed, parseErr := parseActionArgs([]string{"--name=DELL U2720Q"})
 	if parseErr {

--- a/internal/cli/action.go
+++ b/internal/cli/action.go
@@ -23,6 +23,7 @@ Available subcommands:
   Mouse movement:   move_mouse, move_mouse_relative, move_monitor
   Mode control:     reset, backspace, wait_for_mode_exit, cycle_hint
   Window control:   focus_window
+  Space control:    space
   Cursor saving:    save_cursor_pos, restore_cursor_pos
   Key injection:    feed
 
@@ -253,6 +254,9 @@ var ActionFocusWindowCmd = BuildFocusWindowCommand()
 // ActionCycleHintCmd cycles through visible hints in hints mode.
 var ActionCycleHintCmd = BuildCycleHintCommand()
 
+// ActionSpaceCmd focuses a Mission Control space by 1-based index.
+var ActionSpaceCmd = BuildSpaceCommand()
+
 func init() {
 	ActionCmd.AddCommand(ActionLeftClickCmd)
 	ActionCmd.AddCommand(ActionRightClickCmd)
@@ -278,6 +282,7 @@ func init() {
 	ActionCmd.AddCommand(ActionPageDownCmd)
 	ActionCmd.AddCommand(ActionCycleHintCmd)
 	ActionCmd.AddCommand(ActionFocusWindowCmd)
+	ActionCmd.AddCommand(ActionSpaceCmd)
 
 	RootCmd.AddCommand(ActionCmd)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -161,6 +161,7 @@ func TestCommandInitialization(t *testing.T) {
 		"move_monitor":        false,
 		"cycle_hint":          false,
 		"focus_window":        false,
+		"space <number>":      false,
 	}
 
 	for _, cmd := range cli.ActionCmd.Commands() {
@@ -219,6 +220,7 @@ func TestCommandExecutionWithoutDaemon(t *testing.T) {
 		{"action_page_down", getActionCmd("page_down"), true},
 		{"action_move_monitor", getActionCmd("move_monitor"), true},
 		{"action_focus_window", getActionCmd("focus_window"), true},
+		{"action_space", getActionCmd("space <number>"), true},
 		{"status", getCmd("status"), true},
 		{"doctor", getCmd("doctor"), true}, // doctor returns silentError when daemon is down
 		{"toggle-screen-share", getCmd("toggle-screen-share"), true},

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -574,4 +575,75 @@ Requires hints mode to be active.`,
 		BoolVar(&backward, "backward", false, "Cycle to the previous hint instead of the next one")
 
 	return cmd
+}
+
+// BuildSpaceCommand creates a space cobra command that focuses a Mission
+// Control space by its 1-based index using a synthetic dock swipe gesture
+// since macOS exposes no public API to directly activate a space).
+//
+// Warning, fragile!!
+func BuildSpaceCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "space <number>",
+		Short: "Focus a Mission Control space by 1-based index",
+		Long: `Focus a Mission Control space by its 1-based index.
+
+Spaces are enumerated in Mission Control ordering across all connected
+displays. Index 1 is the first space (typically the leftmost on the
+primary display), index 2 the second, and so on.
+
+macOS does not provide a public API to activate a space, so the daemon
+synthesizes a high-velocity horizontal dock swipe gesture to fast-forward
+to the destination space without the standard swipe animation. When the
+destination sits on a different display, the cursor is warped to its
+center first so the gesture is attributed to the correct screen.
+
+Examples:
+  neru action space 1     Focus the first Mission Control space
+  neru action space 3     Focus the third`,
+		Args: validateActionSpaceArgs,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return requiresRunningInstance()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return derrors.New(
+					derrors.CodeInvalidInput,
+					"space requires exactly one positional argument: the 1-based space number (e.g., neru action space 1)",
+				)
+			}
+
+			actionArgs := []string{"space", strings.TrimSpace(args[0])}
+
+			return sendCommand(cmd, "action", actionArgs)
+		},
+	}
+}
+
+func validateActionSpaceArgs(_ *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return derrors.New(
+			derrors.CodeInvalidInput,
+			"space requires exactly one positional argument: the 1-based space number (e.g., neru action space 1)",
+		)
+	}
+
+	raw := strings.TrimSpace(args[0])
+	if raw == "" {
+		return derrors.New(
+			derrors.CodeInvalidInput,
+			"space number cannot be empty",
+		)
+	}
+
+	index, parseErr := strconv.Atoi(raw)
+	if parseErr != nil || index < 1 {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"space number must be a positive integer, got %q",
+			args[0],
+		)
+	}
+
+	return nil
 }

--- a/internal/core/domain/action/action.go
+++ b/internal/core/domain/action/action.go
@@ -171,6 +171,8 @@ const (
 	NameSearchHints Name = "search_hints"
 	// NameFocusWindow cycles focus to the next/previous window on the active space.
 	NameFocusWindow Name = "focus_window"
+	// NameSpace focuses a Mission Control space by its 1-based index.
+	NameSpace Name = "space"
 
 	// PrefixExec is the prefix for shell command actions.
 	PrefixExec = "exec"
@@ -256,6 +258,11 @@ func IsFocusWindowAction(name string) bool {
 	return Name(name) == NameFocusWindow
 }
 
+// IsSpaceAction reports whether the given action is space.
+func IsSpaceAction(name string) bool {
+	return Name(name) == NameSpace
+}
+
 // IsKnownName determines whether the specified action name is recognized by the
 // application. This is a superset of the names in knownNames — it also includes
 // scroll sub-actions (scroll_up, page_down, etc.) which are IPC/CLI-only.
@@ -275,7 +282,7 @@ func IsKnownName(name Name) bool {
 		NameScrollUp, NameScrollDown, NameScrollLeft, NameScrollRight,
 		NameGoTop, NameGoBottom, NamePageUp, NamePageDown,
 		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints,
-		NameFocusWindow:
+		NameFocusWindow, NameSpace:
 		return true
 	default:
 		return false
@@ -299,7 +306,7 @@ func IsScrollSubAction(name string) bool {
 		NameMoveMouse, NameMoveMouseRelative, NameScroll,
 		NameReset, NameBackspace, NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
 		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints,
-		NameFocusWindow:
+		NameFocusWindow, NameSpace:
 		return false
 	default:
 		return false
@@ -378,7 +385,8 @@ func (n Name) ToType() (Type, error) {
 		NameSleep,
 		NameCycleHint,
 		NameSearchHints,
-		NameFocusWindow:
+		NameFocusWindow,
+		NameSpace:
 		return 0, derrors.Newf(derrors.CodeInvalidInput, "action name not executable: %s", n)
 	default:
 		return 0, derrors.Newf(derrors.CodeInvalidInput, "unknown action name: %s", n)

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -320,4 +320,38 @@ CGRect NeruGetScreenBoundsByName(const char *name, int *found);
 /// @return Current cursor position
 CGPoint NeruGetCurrentCursorPosition(void);
 
+#pragma mark - Space Functions
+
+/// Get the total number of Mission Control spaces across all displays
+/// in their current ordering. This is the 1-based maximum valid value for
+/// NeruMissionControlSpaceID.
+/// @return Number of Mission Control spaces, or 0 on failure
+int NeruCountMissionControlSpaces(void);
+
+/// Get the space ID at the given 1-based Mission Control index.
+/// @param index 1-based index in Mission Control ordering
+/// @return Space ID, or 0 if the index is out of range or unavailable
+uint64_t NeruMissionControlSpaceID(int index);
+
+/// Get the display ID that owns a given space.
+/// @param sid Space identifier
+/// @return Display ID, or 0 if the space is invalid
+uint32_t NeruSpaceDisplayID(uint64_t sid);
+
+/// Get the space ID currently active on the cursor's display.
+/// @return Active space ID, or 0 on failure
+uint64_t NeruActiveSpaceID(void);
+
+/// Focus a space using a synthetic high-velocity horizontal dock swipe gesture.
+///
+/// Pre-conditions: the caller must have already checked that Mission Control
+/// is not active and that the destination space is different from the current
+/// one. When focus crosses displays, the cursor is warped to the destination
+/// display first so the swipe is attributed to the correct screen.
+///
+/// @param new_did Display ID owning the destination space
+/// @param new_sid Destination space ID
+/// @return 1 on success, 0 on failure (e.g. CGEventCreate returned NULL)
+int NeruFocusSpaceUsingGesture(uint32_t new_did, uint64_t new_sid);
+
 #endif  // ACCESSIBILITY_H

--- a/internal/core/infra/platform/darwin/accessibility_space_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_space_darwin.m
@@ -296,8 +296,8 @@ int NeruFocusSpaceUsingGesture(uint32_t new_did, uint64_t new_sid) {
 	int newIndex = 0;
 	if (!neruResolveMCIndices(curSid, new_sid, &curIndex, &newIndex)) {
 		// Could not resolve Mission Control indices (e.g. transient state).
-		// Best-effort fallback: ensure the right display is active and click
-		// to nudge focus. The OS will pick the closest matching space.
+		// Best-effort fallback: ensure the right display is active so the OS
+		// picks the closest matching space on that display.
 		neruSetActiveMenuBarDisplay(new_did);
 
 		return 1;

--- a/internal/core/infra/platform/darwin/accessibility_space_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_space_darwin.m
@@ -1,0 +1,355 @@
+//
+//  accessibility_space_darwin.m
+//  Neru
+//
+//  Copyright © 2025 Neru. All rights reserved.
+//
+
+#import "accessibility.h"
+
+#import <ApplicationServices/ApplicationServices.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
+
+#pragma mark - SkyLight External Declarations
+
+// Private SkyLight / WindowServer symbols (not in the public SDK).
+extern int SLSMainConnectionID(void);
+extern CFArrayRef SLSCopyManagedDisplaySpaces(int cid);
+extern CFStringRef SLSCopyManagedDisplayForSpace(int cid, uint64_t sid);
+extern uint64_t SLSManagedDisplayGetCurrentSpace(int cid, CFStringRef uuid);
+extern CGError SLSSetActiveMenuBarDisplayIdentifier(int cid, CFStringRef uuid, CFStringRef repeat_uuid);
+extern CGError SLSGetCurrentCursorLocation(int cid, CGPoint *point);
+
+#pragma mark - Display / Space Helpers
+
+/// Translate a display ID to its UUID string.
+/// @param did Display identifier
+/// @return Retained CFStringRef (caller must CFRelease), or NULL on failure
+static CFStringRef neruDisplayUUID(uint32_t did) {
+	CFUUIDRef uuidRef = CGDisplayCreateUUIDFromDisplayID(did);
+	if (!uuidRef) {
+		return NULL;
+	}
+
+	CFStringRef uuidStr = CFUUIDCreateString(NULL, uuidRef);
+	CFRelease(uuidRef);
+
+	return uuidStr;
+}
+
+/// Translate a display UUID string back to a display ID.
+/// @param uuid UUID string
+/// @return Display ID, or 0 on failure
+static uint32_t neruDisplayIDFromUUID(CFStringRef uuid) {
+	if (!uuid) {
+		return 0;
+	}
+
+	CFUUIDRef uuidRef = CFUUIDCreateFromString(NULL, uuid);
+	if (!uuidRef) {
+		return 0;
+	}
+
+	uint32_t did = CGDisplayGetDisplayIDFromUUID(uuidRef);
+	CFRelease(uuidRef);
+
+	return did;
+}
+
+/// Get the current Mission Control space for a display.
+/// @param did Display identifier
+/// @return Space ID, or 0 on failure
+static uint64_t neruDisplaySpaceID(uint32_t did) {
+	CFStringRef uuid = neruDisplayUUID(did);
+	if (!uuid) {
+		return 0;
+	}
+
+	uint64_t sid = SLSManagedDisplayGetCurrentSpace(SLSMainConnectionID(), uuid);
+	CFRelease(uuid);
+
+	return sid;
+}
+
+/// Return the center point of a display's bounds (in CG coordinates).
+static CGPoint neruDisplayCenter(uint32_t did) {
+	CGRect bounds = CGDisplayBounds(did);
+
+	return (CGPoint){bounds.origin.x + bounds.size.width / 2.0, bounds.origin.y + bounds.size.height / 2.0};
+}
+
+/// Return the display ID that currently contains the cursor.
+static uint32_t neruCursorDisplayID(void) {
+	CGPoint cursor;
+	SLSGetCurrentCursorLocation(SLSMainConnectionID(), &cursor);
+
+	uint32_t matchingDisplays[16];
+	uint32_t matchingCount = 0;
+
+	CGError err = CGGetDisplaysWithPoint(cursor, 16, matchingDisplays, &matchingCount);
+	if (err == kCGErrorSuccess && matchingCount > 0) {
+		return matchingDisplays[0];
+	}
+
+	// Fall back to the main display if the cursor is somehow outside every display.
+	return CGMainDisplayID();
+}
+
+/// Set the active menu bar display, which updates which display is the
+/// "focused" one for Space purposes.
+static void neruSetActiveMenuBarDisplay(uint32_t did) {
+	CFStringRef uuid = neruDisplayUUID(did);
+	if (!uuid) {
+		return;
+	}
+
+	SLSSetActiveMenuBarDisplayIdentifier(SLSMainConnectionID(), uuid, uuid);
+	CFRelease(uuid);
+}
+
+#pragma mark - Mission Control Index Resolution
+
+/// Find the 1-based Mission Control indices of two space IDs in a single
+/// pass over SLSCopyManagedDisplaySpaces. Returns false if either sid is
+/// not found in the current Mission Control ordering.
+static bool neruResolveMCIndices(uint64_t curSid, uint64_t newSid, int *outCurIndex, int *outNewIndex) {
+	*outCurIndex = 0;
+	*outNewIndex = 0;
+
+	@autoreleasepool {
+		CFArrayRef displaySpaces = SLSCopyManagedDisplaySpaces(SLSMainConnectionID());
+		if (!displaySpaces) {
+			return false;
+		}
+
+		int counter = 1;
+
+		CFIndex displayCount = CFArrayGetCount(displaySpaces);
+		for (CFIndex i = 0; i < displayCount; i++) {
+			CFDictionaryRef displayRef = (CFDictionaryRef)CFArrayGetValueAtIndex(displaySpaces, i);
+			CFArrayRef spacesRef = (CFArrayRef)CFDictionaryGetValue(displayRef, CFSTR("Spaces"));
+			if (!spacesRef) {
+				continue;
+			}
+
+			CFIndex spacesCount = CFArrayGetCount(spacesRef);
+			for (CFIndex j = 0; j < spacesCount; j++) {
+				CFDictionaryRef spaceRef = (CFDictionaryRef)CFArrayGetValueAtIndex(spacesRef, j);
+				CFNumberRef sidRef = (CFNumberRef)CFDictionaryGetValue(spaceRef, CFSTR("id64"));
+				if (!sidRef) {
+					continue;
+				}
+
+				uint64_t sid = 0;
+				CFNumberGetValue(sidRef, CFNumberGetType(sidRef), &sid);
+
+				if (sid == curSid) {
+					*outCurIndex = counter;
+				}
+
+				if (sid == newSid) {
+					*outNewIndex = counter;
+				}
+
+				counter++;
+			}
+		}
+
+		CFRelease(displaySpaces);
+
+		return (*outCurIndex > 0) && (*outNewIndex > 0);
+	}
+}
+
+#pragma mark - Public Space API
+
+/// Get the total number of Mission Control spaces across all displays
+/// in their current ordering.
+int NeruCountMissionControlSpaces(void) {
+	@autoreleasepool {
+		CFArrayRef displaySpaces = SLSCopyManagedDisplaySpaces(SLSMainConnectionID());
+		if (!displaySpaces) {
+			return 0;
+		}
+
+		int total = 0;
+		CFIndex displayCount = CFArrayGetCount(displaySpaces);
+		for (CFIndex i = 0; i < displayCount; i++) {
+			CFDictionaryRef displayRef = (CFDictionaryRef)CFArrayGetValueAtIndex(displaySpaces, i);
+			CFArrayRef spacesRef = (CFArrayRef)CFDictionaryGetValue(displayRef, CFSTR("Spaces"));
+			if (!spacesRef) {
+				continue;
+			}
+
+			total += (int)CFArrayGetCount(spacesRef);
+		}
+
+		CFRelease(displaySpaces);
+
+		return total;
+	}
+}
+
+/// Get the space ID at the given 1-based Mission Control index.
+uint64_t NeruMissionControlSpaceID(int index) {
+	if (index < 1) {
+		return 0;
+	}
+
+	@autoreleasepool {
+		CFArrayRef displaySpaces = SLSCopyManagedDisplaySpaces(SLSMainConnectionID());
+		if (!displaySpaces) {
+			return 0;
+		}
+
+		uint64_t result = 0;
+		int counter = 1;
+
+		CFIndex displayCount = CFArrayGetCount(displaySpaces);
+		for (CFIndex i = 0; i < displayCount; i++) {
+			CFDictionaryRef displayRef = (CFDictionaryRef)CFArrayGetValueAtIndex(displaySpaces, i);
+			CFArrayRef spacesRef = (CFArrayRef)CFDictionaryGetValue(displayRef, CFSTR("Spaces"));
+			if (!spacesRef) {
+				continue;
+			}
+
+			CFIndex spacesCount = CFArrayGetCount(spacesRef);
+			for (CFIndex j = 0; j < spacesCount; j++) {
+				if (counter == index) {
+					CFDictionaryRef spaceRef = (CFDictionaryRef)CFArrayGetValueAtIndex(spacesRef, j);
+					CFNumberRef sidRef = (CFNumberRef)CFDictionaryGetValue(spaceRef, CFSTR("id64"));
+					if (sidRef) {
+						CFNumberGetValue(sidRef, CFNumberGetType(sidRef), &result);
+					}
+
+					CFRelease(displaySpaces);
+
+					return result;
+				}
+
+				counter++;
+			}
+		}
+
+		CFRelease(displaySpaces);
+
+		return 0;
+	}
+}
+
+/// Get the display ID that owns a given space.
+uint32_t NeruSpaceDisplayID(uint64_t sid) {
+	CFStringRef uuid = SLSCopyManagedDisplayForSpace(SLSMainConnectionID(), sid);
+	if (!uuid) {
+		return 0;
+	}
+
+	uint32_t did = neruDisplayIDFromUUID(uuid);
+	CFRelease(uuid);
+
+	return did;
+}
+
+/// Get the space ID currently active on the cursor's display.
+uint64_t NeruActiveSpaceID(void) { return neruDisplaySpaceID(neruCursorDisplayID()); }
+
+#pragma mark - Gesture-Based Space Focus
+
+// Private Core Graphics event field IDs used to synthesize a high-velocity
+// horizontal dock swipe that the Dock treats as a real multi-finger swipe
+// gesture. These constants are not part of the public SDK and require
+// suppressing -Wdeprecated-declarations around the implementation.
+static const int kNeruCGSEventTypeField = 55;              // kCGSEventTypeField
+static const int kNeruCGSEventDockControl = 30;            // kCGSEventDockControl
+static const int kNeruCGEventGestureHIDType = 110;         // kCGEventGestureHIDType
+static const int kNeruIOHIDEventTypeDockSwipe = 23;        // kIOHIDEventTypeDockSwipe
+static const int kNeruCGEventGestureSwipeMotion = 123;     // kCGEventGestureSwipeMotion
+static const int kNeruCGGestureMotionHorizontal = 1;       // kCGGestureMotionHorizontal
+static const int kNeruCGEventGestureSwipeProgress = 124;   // kCGEventGestureSwipeProgress
+static const int kNeruCGEventGestureSwipeVelocityX = 129;  // kCGEventGestureSwipeVelocityX
+static const int kNeruCGEventGesturePhase = 132;           // kCGEventGesturePhase
+static const int kNeruCGSGesturePhaseBegan = 1;            // kCGSGesturePhaseBegan
+static const int kNeruCGSGesturePhaseEnded = 4;            // kCGSGesturePhaseEnded
+
+/// Focus a space using a synthetic high-velocity horizontal dock swipe
+/// gesture to skip the standard Mission Control swipe animation — macOS
+/// exposes no public API to activate a space directly.
+///
+/// Technique attribution: reverse-engineered from BetterTouchTool. Prior
+/// art: https://github.com/jurplel/InstantSpaceSwitcher and the wacom-driver-fix
+/// project by thenickdude.
+int NeruFocusSpaceUsingGesture(uint32_t new_did, uint64_t new_sid) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+	uint32_t curDid = neruCursorDisplayID();
+	uint64_t curSid = neruDisplaySpaceID(curDid);
+	CGPoint point = neruDisplayCenter(new_did);
+	bool focusDisplay = curDid != new_did;
+
+	if (focusDisplay) {
+		CGWarpMouseCursorPosition(point);
+	}
+
+	int curIndex = 0;
+	int newIndex = 0;
+	if (!neruResolveMCIndices(curSid, new_sid, &curIndex, &newIndex)) {
+		// Could not resolve Mission Control indices (e.g. transient state).
+		// Best-effort fallback: ensure the right display is active and click
+		// to nudge focus. The OS will pick the closest matching space.
+		neruSetActiveMenuBarDisplay(new_did);
+
+		return 1;
+	}
+
+	int count = abs(newIndex - curIndex);
+	if (count == 0) {
+		// Already on the same Mission Control index. Make sure the right
+		// display is active in case the destination space sits on a
+		// different display at the same index.
+		if (focusDisplay) {
+			neruSetActiveMenuBarDisplay(new_did);
+			if (neruDisplaySpaceID(new_did) != new_sid) {
+				CGPostMouseEvent(point, false, 1, true);
+				CGPostMouseEvent(point, false, 1, false);
+			}
+		}
+
+		return 1;
+	}
+
+	CGEventRef event = CGEventCreate(NULL);
+	if (!event) {
+		return 0;
+	}
+
+	double sign = (newIndex - curIndex) > 0 ? 1.0 : -1.0;
+
+	CGEventSetIntegerValueField(event, kNeruCGSEventTypeField, kNeruCGSEventDockControl);
+	CGEventSetIntegerValueField(event, kNeruCGEventGestureHIDType, kNeruIOHIDEventTypeDockSwipe);
+	CGEventSetIntegerValueField(event, kNeruCGEventGestureSwipeMotion, kNeruCGGestureMotionHorizontal);
+	CGEventSetDoubleValueField(event, kNeruCGEventGestureSwipeProgress, sign);
+	CGEventSetDoubleValueField(event, kNeruCGEventGestureSwipeVelocityX, sign * 9999.0);
+
+	for (int i = 0; i < count; i++) {
+		CGEventSetIntegerValueField(event, kNeruCGEventGesturePhase, kNeruCGSGesturePhaseBegan);
+		CGEventPost(kCGSessionEventTap, event);
+		CGEventSetIntegerValueField(event, kNeruCGEventGesturePhase, kNeruCGSGesturePhaseEnded);
+		CGEventPost(kCGSessionEventTap, event);
+	}
+
+	CFRelease(event);
+
+	if (focusDisplay) {
+		neruSetActiveMenuBarDisplay(new_did);
+		if (neruDisplaySpaceID(new_did) != new_sid) {
+			CGPostMouseEvent(point, false, 1, true);
+			CGPostMouseEvent(point, false, 1, false);
+		}
+	}
+
+	return 1;
+
+#pragma clang diagnostic pop
+}

--- a/internal/core/infra/platform/darwin/cgo_flags.go
+++ b/internal/core/infra/platform/darwin/cgo_flags.go
@@ -4,6 +4,6 @@ package darwin
 
 /*
 #cgo CFLAGS: -x objective-c -fobjc-arc
-#cgo LDFLAGS: -framework Foundation -framework AppKit -framework Carbon -framework CoreGraphics -framework ApplicationServices -framework UserNotifications -framework QuartzCore -framework Vision -framework ScreenCaptureKit
+#cgo LDFLAGS: -framework Foundation -framework AppKit -framework Carbon -framework CoreGraphics -framework ApplicationServices -framework UserNotifications -framework QuartzCore -framework Vision -framework ScreenCaptureKit -F/System/Library/PrivateFrameworks -framework SkyLight
 */
 import "C"

--- a/internal/core/infra/space/space_darwin.go
+++ b/internal/core/infra/space/space_darwin.go
@@ -1,0 +1,80 @@
+//go:build darwin
+
+// Package space provides functions for focusing Mission Control spaces
+// on macOS using the synthetic high-velocity horizontal dock swipe gesture
+// technique.
+//
+// macOS does not expose a public API to directly activate a Mission Control
+// space, so the implementation synthesizes a series of fast horizontal
+// swipes (Began -> Ended, repeated) that the Dock treats as a real
+// multi-finger gesture and uses to fast-forward to the destination space
+// without the standard animation.
+package space
+
+/*
+#cgo CFLAGS: -x objective-c
+#include "../platform/darwin/accessibility.h"
+*/
+import "C"
+
+import (
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	_ "github.com/y3owk1n/neru/internal/core/infra/platform/darwin"
+)
+
+// FocusByIndex focuses the Mission Control space at the given 1-based
+// index. Index 1 is the first space (typically the leftmost on the primary
+// display), index 2 the second, and so on. Spaces are enumerated in
+// Mission Control display order across all connected displays.
+//
+// The function refuses to switch spaces while Mission Control is active
+// (so we don't fight the user's swipe). When the destination is on a
+// different display, the cursor is warped to its center first so the
+// synthetic gesture is attributed to the correct screen.
+func FocusByIndex(index int) error {
+	count := int(C.NeruCountMissionControlSpaces())
+	if count == 0 {
+		return derrors.New(derrors.CodeActionFailed, "failed to enumerate Mission Control spaces")
+	}
+
+	if index < 1 || index > count {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"space number %d is out of range; valid range is 1..%d",
+			index,
+			count,
+		)
+	}
+
+	sid := uint64(C.NeruMissionControlSpaceID(C.int(index)))
+	if sid == 0 {
+		return derrors.Newf(
+			derrors.CodeActionFailed,
+			"failed to resolve Mission Control space at index %d",
+			index,
+		)
+	}
+
+	did := uint32(C.NeruSpaceDisplayID(C.uint64_t(sid)))
+	if did == 0 {
+		return derrors.Newf(
+			derrors.CodeActionFailed,
+			"failed to resolve display for Mission Control space at index %d",
+			index,
+		)
+	}
+
+	if C.NeruFocusSpaceUsingGesture(C.uint32_t(did), C.uint64_t(sid)) == 0 {
+		return derrors.New(derrors.CodeActionFailed, "failed to focus Mission Control space")
+	}
+
+	return nil
+}
+
+// Count returns the total number of Mission Control spaces available
+// across all connected displays, in Mission Control ordering. This is
+// the inclusive upper bound of valid 1-based space numbers for
+// FocusByIndex. Returns 0 if the spaces cannot be enumerated.
+func Count() int {
+	return int(C.NeruCountMissionControlSpaces())
+}

--- a/internal/core/infra/space/space_other.go
+++ b/internal/core/infra/space/space_other.go
@@ -1,0 +1,25 @@
+//go:build !darwin
+
+// Package space provides functions for focusing Mission Control spaces.
+//
+// The macOS implementation uses the synthetic high-velocity horizontal
+// dock swipe gesture technique (see space_darwin.go). This file is a stub
+// used on non-macOS platforms where Mission Control does not exist.
+package space
+
+import derrors "github.com/y3owk1n/neru/internal/core/errors"
+
+// FocusByIndex focuses the Mission Control space at the given 1-based
+// index. Not supported outside macOS.
+func FocusByIndex(_ int) error {
+	return derrors.New(
+		derrors.CodeNotSupported,
+		"space switching is only supported on macOS",
+	)
+}
+
+// Count returns the total number of Mission Control spaces. Not
+// supported outside macOS.
+func Count() int {
+	return 0
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a new `neru action space <number>` IPC command that focuses a the macOS native space by its 1-based index. The index is counted in Mission Control ordering across all connected displays, and the command refuses to run while Mission Control is already active.

This uses private Skylight API just like every other programs.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/eaafbec9-e28f-4716-9239-be0799846722

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
