### PR TITLE
fix: prevent memory leak during window space transitions

### DIFF
--- a/internal/core/infra/platform/darwin/accessibility_space_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_space_darwin.m
@@ -474,8 +474,7 @@ int NeruMoveWindowToSpace(void *windowElement, uint64_t spaceID) {
 	if (SLSPerformAsynchronousBridgedWindowManagementOperation) {
 		Class cls = objc_getClass("SLSBridgedMoveWindowsToManagedSpaceOperation");
 		if (cls) {
-			id opAlloc = [cls alloc];
-			id operation = [(id<SLSBridgedMoveWindowsToManagedSpaceOperationProtocol>)opAlloc
+			id operation = [(id<SLSBridgedMoveWindowsToManagedSpaceOperationProtocol>)[cls alloc]
 			    initWithWindows:(__bridge id)windowList
 			            spaceID:spaceID];
 			if (operation) {

--- a/internal/core/infra/platform/darwin/accessibility_space_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_space_darwin.m
@@ -432,6 +432,10 @@ static void *neru_macho_find_symbol(const char *target_image, const char *target
 
 #pragma mark - Window-to-Space Movement
 
+@protocol SLSBridgedMoveWindowsToManagedSpaceOperationProtocol <NSObject>
+- (instancetype)initWithWindows:(id)windows spaceID:(uint64_t)spaceID;
+@end
+
 int NeruMoveWindowToSpace(void *windowElement, uint64_t spaceID) {
 	if (!windowElement) {
 		return 0;
@@ -470,9 +474,10 @@ int NeruMoveWindowToSpace(void *windowElement, uint64_t spaceID) {
 	if (SLSPerformAsynchronousBridgedWindowManagementOperation) {
 		Class cls = objc_getClass("SLSBridgedMoveWindowsToManagedSpaceOperation");
 		if (cls) {
-			SEL sel = sel_registerName("initWithWindows:spaceID:");
-			id operation =
-			    ((id (*)(id, SEL, id, uint64_t))objc_msgSend)([cls alloc], sel, (__bridge id)windowList, spaceID);
+			id opAlloc = [cls alloc];
+			id operation = [(id<SLSBridgedMoveWindowsToManagedSpaceOperationProtocol>)opAlloc
+			    initWithWindows:(__bridge id)windowList
+			            spaceID:spaceID];
 			if (operation) {
 				SLSPerformAsynchronousBridgedWindowManagementOperation((__bridge void *)operation);
 				success = 1;


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes a silent memory leak that occurred whenever a window was moved to another space using the `move_window_to_space` action.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
