### PR TITLE
docs: add disclaimer on `space` and `move_window_to_space` implementation

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -389,6 +389,8 @@ Bind to hotkeys for quick window switching:
 
 ### Switching Spaces
 
+> **Caveat emptor:** This action relies on a synthetic dock swipe gesture — a heuristic, not a public API. It is not guaranteed to work across macOS updates. Use at your own risk.
+
 Focuses a Mission Control space by its 1-based index. macOS exposes no public API to activate a space, so Neru synthesizes a high-velocity horizontal dock swipe gesture to fast-forward to the destination space without the standard swipe animation. When the destination sits on a different display, the cursor is warped to its center first so the gesture is attributed to the correct screen.
 
 ```bash
@@ -401,6 +403,8 @@ The index is 1-based and counted in Mission Control ordering across all connecte
 > **Note:** This action is macOS only.
 
 ### Moving Windows to Spaces
+
+> **Caveat emptor:** This action uses private SkyLight APIs (`SLSPerformAsynchronousBridgedWindowManagementOperation` / `SLSMoveWindowsToManagedSpace`). These are undocumented, unsupported, and may break on any macOS update. Use at your own risk. Implemented for my personal use case — reducing dependency on tiling window managers in favour of macOS-native space management.
 
 Moves the current focused window to a Mission Control space by its 1-based index. This action is implemented on macOS without requiring scripting additions (no need to disable SIP).
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -232,8 +232,8 @@ All actions available in hotkeys. These also work as `neru action <name>` — se
 | Mode        | `reset`, `backspace`                                          |
 | Composition | `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos` |
 | Focus       | `focus_window`, `focus_window --backward`                     |
-| Space       | `space <number>` — 1-based Mission Control index (macOS only) |
-| Space       | `move_window_to_space <number>` — Move active window to space (macOS only) |
+| Space       | `space <number>` — 1-based Mission Control index (macOS only) — **uses synthetic swipe gesture, not a public API** |
+| Space       | `move_window_to_space <number>` — Move active window to space (macOS only) — **uses private SkyLight APIs, may break on OS update** |
 
 - Use `--bare` (e.g. `"action left_click --bare"`) to target the cursor position instead of the current mode selection (see [CLI.md](CLI.md#clicks))
 - `scroll_up` / `scroll_down` support `--steps` (e.g. `"action scroll_down --steps 200"`) to override `scroll_step` (see [CLI.md](CLI.md#scrolling))

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -255,6 +255,8 @@ Useful for apps where you frequently need a right-click menu (e.g. Finder, VS Co
 
 ## Moving windows to other macOS native spaces
 
+> **Caveat emptor:** This feature uses private SkyLight APIs (`SLSPerformAsynchronousBridgedWindowManagementOperation` / `SLSMoveWindowsToManagedSpace`). These are undocumented, unsupported, and may break on any macOS update. The `space` action also uses a synthetic swipe heuristic rather than a public API. Use at your own risk. These were built for my personal use case — reducing dependency on tiling window managers in favour of macOS-native space management.
+
 Neru supports moving the active window to another Mission Control space natively on macOS. This does not require disabling SIP or installing scripting additions (unlike Yabai):
 
 ```toml

--- a/internal/core/infra/platform/darwin/accessibility_space_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_space_darwin.m
@@ -432,6 +432,9 @@ static void *neru_macho_find_symbol(const char *target_image, const char *target
 
 #pragma mark - Window-to-Space Movement
 
+// Private SkyLight API — undocumented, unsupported, may break on any
+// macOS update. Dynamically resolved so the tool degrades gracefully, but
+// no guarantees are made about future compatibility.
 @protocol SLSBridgedMoveWindowsToManagedSpaceOperationProtocol <NSObject>
 - (instancetype)initWithWindows:(id)windows spaceID:(uint64_t)spaceID;
 @end

--- a/internal/core/infra/space/space_darwin.go
+++ b/internal/core/infra/space/space_darwin.go
@@ -2,13 +2,24 @@
 
 // Package space provides functions for focusing Mission Control spaces
 // on macOS using the synthetic high-velocity horizontal dock swipe gesture
-// technique.
+// technique, and for moving windows between spaces using private SkyLight
+// APIs.
 //
 // macOS does not expose a public API to directly activate a Mission Control
 // space, so the implementation synthesizes a series of fast horizontal
 // swipes (Began -> Ended, repeated) that the Dock treats as a real
 // multi-finger gesture and uses to fast-forward to the destination space
 // without the standard animation.
+//
+// The move-window-to-space feature relies on undocumented private APIs in
+// the SkyLight framework (SLSPerformAsynchronousBridgedWindowManagementOperation
+// / SLSMoveWindowsToManagedSpace). These are unsupported by Apple, may
+// break on any macOS update, and are provided as-is.
+//
+// Both features were initially implemented for the author's personal use
+// case: reducing dependency on third-party tiling window managers (e.g.
+// yabai) in favor of macOS-native window and space management. They
+// worked at the time of writing but come with no guarantees.
 package space
 
 /*


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR update documentation related to private API used for `space` actions.

These are mainly implemented for my own use cases.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
