### PR TITLE
chore(nix): add extraEnvironment and launchd overrides to Nix modules

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -132,12 +132,15 @@ Use the nix-darwin module for system-wide installation:
 - `services.neru.package` - Package to use (default: `pkgs.neru` for latest version) or `pkgs.neru-source` for building from source
 - `services.neru.config` - Inline TOML configuration (default: uses `configs/default-config.toml`)
 - `services.neru.configFile` - Path to existing config file (default: `null`, takes precedence over `config`)
+- `services.neru.launchd.enable` - Enable the launchd agent (default: `true`)
+- `services.neru.launchd.keepAlive` - Keep the launchd service alive (default: `true`)
+- `services.neru.extraEnvironment` - Additional environment variables for the launchd service (default: `{}`; includes a sensible `PATH` with Nix binary directories)
 
 The module automatically:
 
 - Installs Neru system-wide
-- Creates a launchd user agent
-- Configures the agent to run at login with `KeepAlive = true` and `RunAtLoad = true`
+- Creates a launchd user agent with the configured environment
+- Configures the agent to run at login with `KeepAlive` and `RunAtLoad = true`
 - Installs shell completions for bash, fish, and zsh
 
 > [!NOTE]
@@ -207,12 +210,14 @@ Use the NixOS module for system-wide installation on Linux:
 - `services.neru.configFile` - Path to existing config file (default: `null`, takes precedence over `config`)
 - `services.neru.systemd.restart` - Systemd restart policy (default: `"on-failure"`)
 - `services.neru.systemd.restartSec` - Seconds to wait before restarting (default: `5`)
+- `services.neru.extraEnvironment` - Additional environment variables for the systemd service (default: `{}`; includes a sensible `PATH` with Nix binary directories)
 
 The module automatically:
 
 - Installs Neru system-wide
 - Creates a systemd user service tied to `graphical-session.target`
 - Configures automatic restart on failure
+- Sets the configured environment variables in the service
 
 > [!IMPORTANT]
 > On Linux, `pkgs.neru` uses the release artifact when available. Use `pkgs.neru-source` to build from source. If your nixpkgs doesn't ship a recent enough Go version, see [Patch Go Version](#patch-go-version) below.
@@ -319,13 +324,14 @@ Use the home-manager module for user-specific installation on macOS or Linux:
 - `services.neru.systemd.enable` - Enable the systemd user service on Linux (default: `true`)
 - `services.neru.systemd.restart` - Systemd restart policy (default: `"on-failure"`)
 - `services.neru.systemd.restartSec` - Seconds to wait before restarting (default: `5`)
+- `services.neru.extraEnvironment` - Additional environment variables for the launchd or systemd service (default: `{}`; includes a sensible `PATH` with Nix binary directories and the user's Nix profile)
 
 The module automatically:
 
 - Installs Neru in user environment
 - Creates `~/.config/neru/config.toml` (or uses your `configFile`)
-- **macOS:** Creates a launchd user agent (if `launchd.enable` is `true`) with `KeepAlive` and `RunAtLoad = true`
-- **Linux:** Creates a systemd user service tied to `graphical-session.target` (if `systemd.enable` is `true`)
+- **macOS:** Creates a launchd user agent (if `launchd.enable` is `true`) with `KeepAlive`, `RunAtLoad = true`, and the configured environment
+- **Linux:** Creates a systemd user service tied to `graphical-session.target` (if `systemd.enable` is `true`) with the configured environment
 - Installs shell completions for bash, fish, and zsh
 
 > [!NOTE]

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -8,6 +8,10 @@ let
   cfg = config.services.neru;
   configFile =
     if cfg.configFile != null then cfg.configFile else pkgs.writeText "config.toml" cfg.config;
+  effectiveEnv = {
+    PATH = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+  }
+  // cfg.extraEnvironment;
 in
 {
   options = {
@@ -24,18 +28,50 @@ in
         default = null;
         description = "Path to existing config.toml configuration file. Takes precedence over config option.";
       };
+      launchd = {
+        enable = lib.mkEnableOption "the launchd agent managing the Neru process" // {
+          default = true;
+        };
+        keepAlive = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Whether the launchd service should be kept alive.";
+        };
+      };
+
+      extraEnvironment = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        example = {
+          PATH = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+        };
+        description = ''
+          Additional environment variables to set in the launchd service.
+          These are merged with defaults such as a {env}`PATH`
+          that includes common Nix binary directories.
+          Setting {env}`PATH` here will override the default entirely.
+
+          To extend the default PATH with additional directories:
+          ```nix
+          services.neru.extraEnvironment = {
+            PATH = "/Users/me/.local/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+          };
+          ```
+        '';
+      };
     };
   };
   config = (
     lib.mkIf (cfg.enable) {
       environment.systemPackages = [ cfg.package ];
 
-      launchd.user.agents.neru = {
+      launchd.user.agents.neru = lib.mkIf cfg.launchd.enable {
         command =
           "${cfg.package}/Applications/Neru.app/Contents/MacOS/neru launch"
           + (lib.optionalString (cfg.configFile != null || cfg.config != "") " --config ${configFile}");
         serviceConfig = {
-          KeepAlive = true;
+          EnvironmentVariables = effectiveEnv;
+          KeepAlive = cfg.launchd.keepAlive;
           RunAtLoad = true;
           StandardOutPath = "/tmp/neru.log";
           StandardErrorPath = "/tmp/neru.err.log";

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -6,6 +6,22 @@
 }:
 let
   cfg = config.services.neru;
+  defaultPath = lib.concatStringsSep ":" (
+    [
+      "${config.home.homeDirectory}/.nix-profile/bin"
+      "/etc/profiles/per-user/${config.home.username}/bin"
+      "/run/current-system/sw/bin"
+      "/nix/var/nix/profiles/default/bin"
+      "/usr/local/bin"
+      "/usr/bin"
+      "/bin"
+    ]
+    ++ lib.optionals pkgs.stdenv.isDarwin [ "/opt/homebrew/bin" ]
+  );
+  effectiveEnv = {
+    PATH = defaultPath;
+  }
+  // cfg.extraEnvironment;
 in
 {
   options = {
@@ -73,6 +89,27 @@ in
         };
       };
 
+      extraEnvironment = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        example = {
+          PATH = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin";
+        };
+        description = ''
+          Additional environment variables to set in the launchd (macOS) or systemd (Linux) service.
+          These are merged with defaults such as a {env}`PATH`
+          that includes common Nix binary directories and the user's Nix profile.
+          Setting {env}`PATH` here will override the default entirely.
+
+          To extend the default PATH with additional directories:
+          ```nix
+          services.neru.extraEnvironment = {
+            PATH = "/Users/me/.cargo/bin:/Users/me/.nix-profile/bin:/etc/profiles/per-user/me/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin";
+          };
+          ```
+        '';
+      };
+
       systemd = {
         enable = lib.mkOption {
           type = lib.types.bool;
@@ -115,6 +152,7 @@ in
           "--config"
           "${config.xdg.configHome}/neru/config.toml"
         ];
+        EnvironmentVariables = effectiveEnv;
         RunAtLoad = true;
         KeepAlive = cfg.launchd.keepAlive;
         StandardOutPath = "/tmp/neru.log";
@@ -135,6 +173,7 @@ in
       };
       Service = {
         ExecStart = "${cfg.package}/bin/neru launch --config ${config.xdg.configHome}/neru/config.toml";
+        Environment = effectiveEnv;
         Restart = cfg.systemd.restart;
         RestartSec = cfg.systemd.restartSec;
         Nice = "-10";

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -173,7 +173,7 @@ in
       };
       Service = {
         ExecStart = "${cfg.package}/bin/neru launch --config ${config.xdg.configHome}/neru/config.toml";
-        Environment = effectiveEnv;
+        Environment = lib.mapAttrsToList (k: v: "${k}=${v}") effectiveEnv;
         Restart = cfg.systemd.restart;
         RestartSec = cfg.systemd.restartSec;
         Nice = "-10";

--- a/nix/nixos.nix
+++ b/nix/nixos.nix
@@ -90,7 +90,7 @@ in
           ExecStart =
             "${cfg.package}/bin/neru launch"
             + (lib.optionalString (cfg.configFile != null || cfg.config != "") " --config ${configFile}");
-          Environment = effectiveEnv;
+          Environment = lib.mapAttrsToList (k: v: "${k}=${v}") effectiveEnv;
           Restart = cfg.systemd.restart;
           RestartSec = cfg.systemd.restartSec;
           Nice = -10;

--- a/nix/nixos.nix
+++ b/nix/nixos.nix
@@ -8,6 +8,10 @@ let
   cfg = config.services.neru;
   configFile =
     if cfg.configFile != null then cfg.configFile else pkgs.writeText "config.toml" cfg.config;
+  effectiveEnv = {
+    PATH = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin";
+  }
+  // cfg.extraEnvironment;
 in
 {
   options = {
@@ -51,6 +55,26 @@ in
           description = "Seconds to wait before restarting the Neru service.";
         };
       };
+      extraEnvironment = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        example = {
+          PATH = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin";
+        };
+        description = ''
+          Additional environment variables to set in the systemd service.
+          These are merged with defaults such as a {env}`PATH`
+          that includes common Nix binary directories.
+          Setting {env}`PATH` here will override the default entirely.
+
+          To extend the default PATH with additional directories:
+          ```nix
+          services.neru.extraEnvironment = {
+            PATH = "/home/me/.local/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin";
+          };
+          ```
+        '';
+      };
     };
   };
   config = (
@@ -66,6 +90,7 @@ in
           ExecStart =
             "${cfg.package}/bin/neru launch"
             + (lib.optionalString (cfg.configFile != null || cfg.config != "") " --config ${configFile}");
+          Environment = effectiveEnv;
           Restart = cfg.systemd.restart;
           RestartSec = cfg.systemd.restartSec;
           Nice = -10;


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR add a consistent `extraEnvironment` option to all three Nix modules
(darwin, nixos, home-manager) that sets a sensible default `PATH`
including common Nix binary directories, and allows users to extend
or override environment variables.

Also add `launchd.enable` and `launchd.keepAlive` options to the
darwin module to match the overrides already exposed by home-manager.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #900

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
