### PR TITLE
fix: properly resolve keyboard layouts on layout switch

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,6 +215,7 @@ The [factory.go](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/fa
 2. **Infrastructure Level**: [adapter.go](file:///Users/kylewong/Dev/neru/internal/core/infra/eventtap/adapter.go) receives events and dispatches them to the app.
 3. **Application Level**: [handler.go](file:///Users/kylewong/Dev/neru/internal/app/modes/handler.go) receives the key and routes it to the active [Mode](file:///Users/kylewong/Dev/neru/internal/app/modes/base.go).
 4. **Service Level**: The mode calls into services like [hint_service.go](file:///Users/kylewong/Dev/neru/internal/app/services/hint_service.go) to perform business logic.
+5. **Keyboard Layout Changes**: On macOS, Carbon global hotkeys are registered with raw keycodes. When the user switches keyboard layout at runtime (e.g., US → Dvorak → Colemak), the [layout_change_darwin.go](file:///Users/kylewong/Dev/neru/internal/app/layout_change_darwin.go) handler unregisters all existing hotkeys and re-registers them with the new layout's keycodes. This is driven by a second callback slot in [keymap_darwin.m](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/darwin/keymap_darwin.m) (`NeruSetKeymapLayoutChangeCallback2`). On Linux and Windows, this is a no-op.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -264,7 +264,7 @@ See [CLI.md](CLI.md#feed-keys) for syntax, supported key names, and platform beh
 | Option                                 | Type   | Default       | Description                                         |
 | -------------------------------------- | ------ | ------------- | --------------------------------------------------- |
 | `excluded_apps`                        | array  | `[]`          | Bundle IDs where Neru won't activate                |
-| `kb_layout_to_use`                     | string | `""`          | Force keyboard layout InputSourceID (auto if empty) |
+| `kb_layout_to_use`                     | string | `""`          | Force keyboard layout InputSourceID bundle ID (auto if empty). E.g. `com.apple.keylayout.Colemak` |
 | `hide_overlay_in_screen_share`         | bool   | `false`       | Hide overlay in screen sharing apps                 |
 | `passthrough_unbounded_keys`           | bool   | `false`       | Let unbound Cmd/Ctrl/Alt shortcuts pass through     |
 | `should_exit_after_passthrough`        | bool   | `false`       | Exit mode after a passthrough shortcut              |

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -143,6 +143,14 @@ Use these suffixes:
 - `*_linux_wayland.go`: Linux Wayland implementation slot
 - `*_other.go`: non-target fallback for dispatch-style packages
 
+App-level platform dispatch also follows this pattern. For example,
+[layout_change_darwin.go](file:///Users/kylewong/Dev/neru/internal/app/layout_change_darwin.go)
+re-registers Carbon hotkeys when the keyboard layout changes at runtime, while
+[layout_change_linux.go](file:///Users/kylewong/Dev/neru/internal/app/layout_change_linux.go)
+and
+[layout_change_windows.go](file:///Users/kylewong/Dev/neru/internal/app/layout_change_windows.go)
+are no-ops.
+
 Do not create new ad hoc platform filenames if an existing slot already exists.
 
 Do not create fake empty `darwin` / `linux` / `windows` files just for symmetry.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -493,8 +493,24 @@ If you're still experiencing issues:
     - Ensure your desired layout is added and selected
 
 2. **Layout not detected correctly:**
-    - Some custom layouts may not be detected properly
-    - Try switching to a standard layout (US QWERTY, Colemak, Dvorak) in macOS input settings
+    - Some custom layouts (e.g., Colemak, Dvorak) may not be resolved automatically
+    - Force the layout by setting `kb_layout_to_use` in your config to the full bundle ID:
+
+      ```bash
+      # First, switch to your desired layout in the menu bar, then:
+      defaults read com.apple.HIToolbox AppleCurrentKeyboardLayoutInputSourceID
+      ```
+
+      Then use the returned value (e.g., `com.apple.keylayout.Colemak`):
+
+      ```toml
+      [general]
+      kb_layout_to_use = "com.apple.keylayout.Colemak"
+      ```
+
+3. **Layout changes at runtime not picked up:**
+    - Neru now automatically re-registers global hotkeys when the keyboard layout changes (e.g., switching from US to Dvorak while Neru is running)
+    - If hotkeys don't work after a layout switch, try toggling Neru off and on, or restart the daemon with `pkill neru && neru launch`
 
 ### Input methods not working (CJK IME)
 

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -39,6 +39,9 @@ func (a *App) prepareForConfigUpdate() {
 		a.ExitMode()
 	}
 
+	a.hotkeyRegistrationMu.Lock()
+	defer a.hotkeyRegistrationMu.Unlock()
+
 	if a.appState.HotkeysRegistered() {
 		a.logger.Debug("Unregistering current hotkeys before reload")
 		a.stopAllHotkeyRepeats()
@@ -73,6 +76,9 @@ func (a *App) restoreHotkeysAfterFailedReload() {
 	// Guard with HotkeysRegistered() because the blocking native alert
 	// shown by ReloadWithAppContext can trigger a focus-change notification,
 	// which may already have re-registered hotkeys on another path.
+	a.hotkeyRegistrationMu.Lock()
+	defer a.hotkeyRegistrationMu.Unlock()
+
 	if a.appState.IsEnabled() && !a.appState.HotkeysRegistered() {
 		a.registerHotkeys()
 		a.appState.SetHotkeysRegistered(true)

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -421,6 +421,10 @@ func initializeEventTapAndIPC(app *App) error {
 		app.configureEventTapHotkeys(cfg, logger)
 	}
 
+	// Register Go-level keyboard layout change handler so Carbon hotkeys
+	// (registered with raw keycodes) are re-registered when the layout changes.
+	app.registerLayoutChangeHandler()
+
 	// Initialize IPC server if not provided
 	if app.ipcServer == nil {
 		server, err := ipcadapter.NewServer(app.ipcController.HandleCommand, logger)
@@ -453,8 +457,11 @@ func initializeShutdownChannel(app *App) {
 func cleanupInfrastructure(app *App) {
 	// Clean up hotkey service
 	if app.hotkeyManager != nil {
+		app.hotkeyRegistrationMu.Lock()
 		app.stopAllHotkeyRepeats()
 		app.hotkeyManager.UnregisterAll()
+		app.appState.SetHotkeysRegistered(false)
+		app.hotkeyRegistrationMu.Unlock()
 		app.hotkeyManager = nil
 	}
 

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -455,6 +455,10 @@ func initializeShutdownChannel(app *App) {
 
 // cleanupInfrastructure cleans up resources allocated during infrastructure initialization.
 func cleanupInfrastructure(app *App) {
+	// Unregister layout change handler so a stale callback cannot fire
+	// after the App is torn down.
+	app.unregisterLayoutChangeHandler()
+
 	// Clean up hotkey service
 	if app.hotkeyManager != nil {
 		app.hotkeyRegistrationMu.Lock()

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -68,8 +68,9 @@ type App struct {
 	// concurrent writers (theme change observer, IPC config reload, systray reload).
 	configMu sync.RWMutex
 
-	hotkeyRepeatMu      sync.Mutex
-	hotkeyRepeatCancels map[string]context.CancelFunc
+	hotkeyRepeatMu       sync.Mutex
+	hotkeyRepeatCancels  map[string]context.CancelFunc
+	hotkeyRegistrationMu sync.Mutex
 
 	// New Architecture Services
 	hintService            *services.HintService

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -388,6 +388,9 @@ func (a *App) executeShellCommand(key, actionStr string) error {
 // refreshHotkeysForAppOrCurrent manages hotkey registration based on Neru's enabled state
 // and whether the currently focused application is excluded.
 func (a *App) refreshHotkeysForAppOrCurrent(bundleID string) {
+	a.hotkeyRegistrationMu.Lock()
+	defer a.hotkeyRegistrationMu.Unlock()
+
 	if !a.appState.IsEnabled() {
 		if a.appState.HotkeysRegistered() {
 			a.logger.Debug("Neru disabled; unregistering hotkeys")

--- a/internal/app/layout_change_darwin.go
+++ b/internal/app/layout_change_darwin.go
@@ -1,0 +1,45 @@
+//go:build darwin
+
+package app
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/infra/platform/darwin"
+)
+
+// registerLayoutChangeHandler registers a Go-level callback that fires after
+// keyboard layout maps are rebuilt at runtime (e.g. switching US → Dvorak).
+//
+// Carbon's RegisterEventHotKey stores raw keycodes at registration time, so
+// when the layout changes the keycodes for key names like "Space" or "H" may
+// change. This handler unregisters all global hotkeys and re-registers them
+// with the updated keycodes.
+func (a *App) registerLayoutChangeHandler() {
+	darwin.SetKeymapLayoutChangeHandler(func() {
+		a.logger.Info("Keyboard layout changed; re-registering global hotkeys")
+
+		a.hotkeyRegistrationMu.Lock()
+		defer a.hotkeyRegistrationMu.Unlock()
+
+		if !a.appState.HotkeysRegistered() {
+			a.logger.Debug("Hotkeys not currently registered; skipping re-registration")
+
+			return
+		}
+
+		// Unregister all existing Carbon hotkeys
+		a.stopAllHotkeyRepeats()
+		a.hotkeyManager.UnregisterAll()
+		a.appState.SetHotkeysRegistered(false)
+
+		// Re-register with updated keycodes from the new layout
+		a.registerHotkeys()
+		a.appState.SetHotkeysRegistered(true)
+
+		a.logger.Info("Global hotkeys re-registered for new keyboard layout")
+	})
+
+	a.logger.Debug("Registered keyboard layout change handler for hotkey re-registration",
+		zap.Bool("hotkeys_registered", a.appState.HotkeysRegistered()))
+}

--- a/internal/app/layout_change_darwin.go
+++ b/internal/app/layout_change_darwin.go
@@ -43,3 +43,9 @@ func (a *App) registerLayoutChangeHandler() {
 	a.logger.Debug("Registered keyboard layout change handler for hotkey re-registration",
 		zap.Bool("hotkeys_registered", a.appState.HotkeysRegistered()))
 }
+
+// unregisterLayoutChangeHandler clears the keyboard layout change handler
+// so a stale callback cannot fire after the App is torn down.
+func (a *App) unregisterLayoutChangeHandler() {
+	darwin.SetKeymapLayoutChangeHandler(nil)
+}

--- a/internal/app/layout_change_linux.go
+++ b/internal/app/layout_change_linux.go
@@ -1,0 +1,7 @@
+//go:build linux
+
+package app
+
+// registerLayoutChangeHandler is a no-op on Linux.
+// Linux does not use Carbon hotkeys, so no re-registration is needed.
+func (a *App) registerLayoutChangeHandler() {}

--- a/internal/app/layout_change_linux.go
+++ b/internal/app/layout_change_linux.go
@@ -5,3 +5,6 @@ package app
 // registerLayoutChangeHandler is a no-op on Linux.
 // Linux does not use Carbon hotkeys, so no re-registration is needed.
 func (a *App) registerLayoutChangeHandler() {}
+
+// unregisterLayoutChangeHandler is a no-op on Linux.
+func (a *App) unregisterLayoutChangeHandler() {}

--- a/internal/app/layout_change_windows.go
+++ b/internal/app/layout_change_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package app
+
+// registerLayoutChangeHandler is a no-op on Windows.
+// Windows does not use Carbon hotkeys, so no re-registration is needed.
+func (a *App) registerLayoutChangeHandler() {}

--- a/internal/app/layout_change_windows.go
+++ b/internal/app/layout_change_windows.go
@@ -5,3 +5,6 @@ package app
 // registerLayoutChangeHandler is a no-op on Windows.
 // Windows does not use Carbon hotkeys, so no re-registration is needed.
 func (a *App) registerLayoutChangeHandler() {}
+
+// unregisterLayoutChangeHandler is a no-op on Windows.
+func (a *App) unregisterLayoutChangeHandler() {}

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -598,6 +598,9 @@ func (a *App) Cleanup() {
 		// Stop theme observer: nil the handler first so any in-flight KVO callback
 		// (between the async dispatch and actual observer removal) is a no-op.
 		a.stopThemeObserver()
+		// Unregister layout change handler so a stale callback cannot fire
+		// after the App is torn down.
+		a.unregisterLayoutChangeHandler()
 		// Stop IPC server first to prevent new requests.
 		// Use a fresh context instead of a.ctx since the root context was
 		// canceled above; a canceled context would cause Stop() to fail
@@ -616,11 +619,10 @@ func (a *App) Cleanup() {
 
 		if a.hotkeyManager != nil {
 			a.hotkeyRegistrationMu.Lock()
-			defer a.hotkeyRegistrationMu.Unlock()
-
 			a.stopAllHotkeyRepeats()
 			a.hotkeyManager.UnregisterAll()
 			a.appState.SetHotkeysRegistered(false)
+			a.hotkeyRegistrationMu.Unlock()
 		}
 
 		if a.overlayManager != nil {

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -615,8 +615,12 @@ func (a *App) Cleanup() {
 		}
 
 		if a.hotkeyManager != nil {
+			a.hotkeyRegistrationMu.Lock()
+			defer a.hotkeyRegistrationMu.Unlock()
+
 			a.stopAllHotkeyRepeats()
 			a.hotkeyManager.UnregisterAll()
+			a.appState.SetHotkeysRegistered(false)
 		}
 
 		if a.overlayManager != nil {

--- a/internal/core/infra/platform/darwin/keymap.go
+++ b/internal/core/infra/platform/darwin/keymap.go
@@ -5,6 +5,8 @@ package darwin
 /*
 #include "keymap.h"
 #include <stdlib.h>
+
+extern void keymapLayoutChangeBridge(void);
 */
 import "C"
 
@@ -12,6 +14,32 @@ import (
 	"strings"
 	"unsafe"
 )
+
+// KeymapLayoutChangeHandler is called after keyboard layout maps are rebuilt.
+type KeymapLayoutChangeHandler func()
+
+var keymapLayoutChangeSlot cgoSlot[KeymapLayoutChangeHandler]
+
+// SetKeymapLayoutChangeHandler registers a Go-level callback invoked after
+// keyboard layout maps are rebuilt at runtime (e.g., when the user switches
+// between US and Dvorak). Pass nil to unregister.
+func SetKeymapLayoutChangeHandler(handler KeymapLayoutChangeHandler) {
+	keymapLayoutChangeSlot.Set(handler)
+	if handler != nil {
+		C.NeruSetKeymapLayoutChangeCallback2(
+			C.KeymapLayoutChangeCallback(C.keymapLayoutChangeBridge),
+		)
+	} else {
+		C.NeruSetKeymapLayoutChangeCallback2(nil)
+	}
+}
+
+//export keymapLayoutChangeBridge
+func keymapLayoutChangeBridge() {
+	keymapLayoutChangeSlot.withValidAsync(func(handler KeymapLayoutChangeHandler) {
+		handler()
+	})
+}
 
 // SetReferenceKeyboardLayout configures the key translation reference layout.
 // Pass an empty inputSourceID to use automatic fallback resolution.

--- a/internal/core/infra/platform/darwin/keymap.h
+++ b/internal/core/infra/platform/darwin/keymap.h
@@ -191,4 +191,10 @@ typedef void (*KeymapLayoutChangeCallback)(void);
 /// Pass NULL to unregister.
 void NeruSetKeymapLayoutChangeCallback(KeymapLayoutChangeCallback callback);
 
+/// Register a second callback to be invoked after keyboard layout maps are rebuilt.
+/// This is intended for Go-level notifications (e.g., re-registering Carbon hotkeys).
+/// Only one callback is supported; subsequent calls replace the previous one.
+/// Pass NULL to unregister.
+void NeruSetKeymapLayoutChangeCallback2(KeymapLayoutChangeCallback callback);
+
 #endif  // KEYMAP_H

--- a/internal/core/infra/platform/darwin/keymap_darwin.m
+++ b/internal/core/infra/platform/darwin/keymap_darwin.m
@@ -144,8 +144,9 @@ static TISInputSourceRef copyKeyboardLayoutInputSourceByID(NSString *inputSource
 			CFStringRef srcIDRef = (CFStringRef)TISGetInputSourceProperty(candidate, kTISPropertyInputSourceID);
 			if (srcIDRef) {
 				NSString *srcID = (__bridge NSString *)srcIDRef;
+				NSString *suffix = [NSString stringWithFormat:@".%@", inputSourceID];
 				if ([srcID caseInsensitiveCompare:inputSourceID] == NSOrderedSame ||
-				    [srcID hasSuffix:[NSString stringWithFormat:@".%@", inputSourceID]]) {
+				    [srcID.lowercaseString hasSuffix:suffix.lowercaseString]) {
 					CFRetain(candidate);
 					matched = candidate;
 					break;
@@ -812,13 +813,16 @@ static void handleKeyboardLayoutChanged(
     CFDictionaryRef userInfo) {
 	[gKeymapLock lock];
 	BOOL hasConfiguredLayout = (gConfiguredInputSourceID != nil && gConfiguredInputSourceID.length > 0);
+	BOOL configuredResolved = gConfiguredInputSourceResolved;
 	BOOL usesCurrentFallback = gUsesCurrentLayoutFallback;
 	[gKeymapLock unlock];
 
-	// When the user has explicitly configured a layout via kb_layout_to_use,
-	// layout switches should not affect key interpretation.
+	// When the user has explicitly configured a layout via kb_layout_to_use
+	// AND it resolved successfully, layout switches should not affect key
+	// interpretation. If the configured ID failed to resolve, Neru falls
+	// through to auto-detection and must follow system changes.
 	// Otherwise, always rebuild so Neru follows the active system layout.
-	BOOL shouldRebuild = !hasConfiguredLayout || usesCurrentFallback;
+	BOOL shouldRebuild = !hasConfiguredLayout || !configuredResolved || usesCurrentFallback;
 
 	if (!shouldRebuild) {
 		return;

--- a/internal/core/infra/platform/darwin/keymap_darwin.m
+++ b/internal/core/infra/platform/darwin/keymap_darwin.m
@@ -46,6 +46,8 @@ static dispatch_block_t gLayoutChangeDebounceBlock = nil;
 
 /// optional callback invoked after layout maps are rebuilt
 static _Atomic(KeymapLayoutChangeCallback) gLayoutChangeCallback = NULL;
+/// second callback slot for Go-level layout change notifications
+static _Atomic(KeymapLayoutChangeCallback) gLayoutChangeCallback2 = NULL;
 
 #pragma mark - UCKeyTranslate Helper
 
@@ -92,24 +94,67 @@ static TISInputSourceRef copyKeyboardLayoutInputSourceByID(NSString *inputSource
 		return nil;
 	}
 
+	// First try matching by input source ID directly
 	NSDictionary *filter = @{(__bridge NSString *)kTISPropertyInputSourceID : inputSourceID};
 	CFArrayRef inputSourceList = TISCreateInputSourceList((__bridge CFDictionaryRef)filter, false);
-	if (!inputSourceList) {
-		return nil;
-	}
-
 	TISInputSourceRef matched = nil;
-	CFIndex sourceCount = CFArrayGetCount(inputSourceList);
-	for (CFIndex i = 0; i < sourceCount; i++) {
-		TISInputSourceRef candidate = (TISInputSourceRef)CFArrayGetValueAtIndex(inputSourceList, i);
-		if (inputSourceHasUnicodeLayoutData(candidate)) {
-			CFRetain(candidate);
-			matched = candidate;
-			break;
+
+	if (inputSourceList) {
+		CFIndex sourceCount = CFArrayGetCount(inputSourceList);
+		for (CFIndex i = 0; i < sourceCount; i++) {
+			TISInputSourceRef candidate = (TISInputSourceRef)CFArrayGetValueAtIndex(inputSourceList, i);
+			if (inputSourceHasUnicodeLayoutData(candidate)) {
+				CFRetain(candidate);
+				matched = candidate;
+				break;
+			}
 		}
+		CFRelease(inputSourceList);
 	}
 
-	CFRelease(inputSourceList);
+	if (matched) {
+		return matched;
+	}
+
+	// If not matched directly, query all keyboard layouts to match by localized name or ID suffix.
+	// This handles cases like inputSourceID being "Colemak" or "Dvorak".
+	NSDictionary *allFilter =
+	    @{(__bridge NSString *)kTISPropertyInputSourceType : (__bridge NSString *)kTISTypeKeyboardLayout};
+	CFArrayRef allSources = TISCreateInputSourceList((__bridge CFDictionaryRef)allFilter, false);
+	if (allSources) {
+		CFIndex sourceCount = CFArrayGetCount(allSources);
+		for (CFIndex i = 0; i < sourceCount; i++) {
+			TISInputSourceRef candidate = (TISInputSourceRef)CFArrayGetValueAtIndex(allSources, i);
+			if (!inputSourceHasUnicodeLayoutData(candidate)) {
+				continue;
+			}
+
+			// Check localized name (e.g. "Colemak")
+			CFStringRef locNameRef = (CFStringRef)TISGetInputSourceProperty(candidate, kTISPropertyLocalizedName);
+			if (locNameRef) {
+				NSString *locName = (__bridge NSString *)locNameRef;
+				if ([locName caseInsensitiveCompare:inputSourceID] == NSOrderedSame) {
+					CFRetain(candidate);
+					matched = candidate;
+					break;
+				}
+			}
+
+			// Check input source ID suffix (e.g. matches "Colemak" in "com.apple.keylayout.Colemak")
+			CFStringRef srcIDRef = (CFStringRef)TISGetInputSourceProperty(candidate, kTISPropertyInputSourceID);
+			if (srcIDRef) {
+				NSString *srcID = (__bridge NSString *)srcIDRef;
+				if ([srcID caseInsensitiveCompare:inputSourceID] == NSOrderedSame ||
+				    [srcID hasSuffix:[NSString stringWithFormat:@".%@", inputSourceID]]) {
+					CFRetain(candidate);
+					matched = candidate;
+					break;
+				}
+			}
+		}
+		CFRelease(allSources);
+	}
+
 	return matched;
 }
 
@@ -212,9 +257,10 @@ static TISInputSourceRef copyResolvedReferenceInputSource(
 
 	// Resolution order:
 	// 1. User-configured input source ID
-	// 2. Preferred stable Latin layouts (ABC, US)
-	// 3. First English keyboard layout
-	// 4. Current layout (fallback — unstable across layout switches)
+	// 2. Current ASCII-capable keyboard layout (if it has Unicode layout data)
+	// 3. Preferred stable Latin layouts (ABC, US)
+	// 4. First English keyboard layout
+	// 5. Current layout (fallback — unstable across layout switches)
 	NSArray<NSString *> *preferredIDs = @[
 		@"com.apple.keylayout.ABC",
 		@"com.apple.keylayout.US",
@@ -228,6 +274,17 @@ static TISInputSourceRef copyResolvedReferenceInputSource(
 		resolvedInputSource = copyKeyboardLayoutInputSourceByID(configuredID);
 		if (!resolvedInputSource) {
 			configuredResolved = NO;
+		}
+	}
+
+	if (!resolvedInputSource) {
+		TISInputSourceRef currentASCII = TISCopyCurrentASCIICapableKeyboardLayoutInputSource();
+		if (currentASCII) {
+			if (inputSourceHasUnicodeLayoutData(currentASCII)) {
+				resolvedInputSource = currentASCII;
+			} else {
+				CFRelease(currentASCII);
+			}
 		}
 	}
 
@@ -754,11 +811,15 @@ static void handleKeyboardLayoutChanged(
     CFNotificationCenterRef center, void *observer, CFNotificationName name, const void *object,
     CFDictionaryRef userInfo) {
 	[gKeymapLock lock];
-	BOOL shouldRebuild = gUsesCurrentLayoutFallback;
+	BOOL hasConfiguredLayout = (gConfiguredInputSourceID != nil && gConfiguredInputSourceID.length > 0);
+	BOOL usesCurrentFallback = gUsesCurrentLayoutFallback;
 	[gKeymapLock unlock];
 
-	// With a resolved reference layout (configured or auto-detected), active
+	// When the user has explicitly configured a layout via kb_layout_to_use,
 	// layout switches should not affect key interpretation.
+	// Otherwise, always rebuild so Neru follows the active system layout.
+	BOOL shouldRebuild = !hasConfiguredLayout || usesCurrentFallback;
+
 	if (!shouldRebuild) {
 		return;
 	}
@@ -770,8 +831,6 @@ static void handleKeyboardLayoutChanged(
 
 	gLayoutChangeDebounceBlock = dispatch_block_create(0, ^{
 		[gKeymapLock lock];
-		// Re-resolve when current-layout fallback is active so layout switches
-		// pick up the new selected source.
 		clearResolvedReferenceInputSourceLocked();
 		[gKeymapLock unlock];
 
@@ -780,6 +839,10 @@ static void handleKeyboardLayoutChanged(
 		KeymapLayoutChangeCallback cb = atomic_load(&gLayoutChangeCallback);
 		if (cb)
 			cb();
+
+		KeymapLayoutChangeCallback cb2 = atomic_load(&gLayoutChangeCallback2);
+		if (cb2)
+			cb2();
 
 		gLayoutChangeDebounceBlock = nil;
 	});
@@ -1164,4 +1227,8 @@ int NeruSetReferenceKeyboardLayout(const char *inputSourceID) {
 
 void NeruSetKeymapLayoutChangeCallback(KeymapLayoutChangeCallback callback) {
 	atomic_store(&gLayoutChangeCallback, callback);
+}
+
+void NeruSetKeymapLayoutChangeCallback2(KeymapLayoutChangeCallback callback) {
+	atomic_store(&gLayoutChangeCallback2, callback);
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes keyboard layout resolution for non-QWERTY layouts like dvorak, colemak and more.

- Now configured `kb_layout_to_use` will based of localized name and ID suffix.
- Added runtime layout change detection for both carbon layer and internal event tap.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to #904
Closes #906

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
