### PR TITLE
fix: ensure cross platform log file path

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -261,16 +261,16 @@ See [CLI.md](CLI.md#feed-keys) for syntax, supported key names, and platform beh
 
 ## [general]
 
-| Option                                 | Type   | Default       | Description                                         |
-| -------------------------------------- | ------ | ------------- | --------------------------------------------------- |
-| `excluded_apps`                        | array  | `[]`          | Bundle IDs where Neru won't activate                |
+| Option                                 | Type   | Default       | Description                                                                                       |
+| -------------------------------------- | ------ | ------------- | ------------------------------------------------------------------------------------------------- |
+| `excluded_apps`                        | array  | `[]`          | Bundle IDs where Neru won't activate                                                              |
 | `kb_layout_to_use`                     | string | `""`          | Force keyboard layout InputSourceID bundle ID (auto if empty). E.g. `com.apple.keylayout.Colemak` |
-| `hide_overlay_in_screen_share`         | bool   | `false`       | Hide overlay in screen sharing apps                 |
-| `passthrough_unbounded_keys`           | bool   | `false`       | Let unbound Cmd/Ctrl/Alt shortcuts pass through     |
-| `should_exit_after_passthrough`        | bool   | `false`       | Exit mode after a passthrough shortcut              |
-| `passthrough_unbounded_keys_blacklist` | array  | `[]`          | Shortcuts to keep consumed when passthrough is on   |
-| `exec_shell`                           | string | `"/bin/bash"` | Shell binary used for `exec` hotkey commands        |
-| `exec_shell_args`                      | array  | `["-lc"]`     | Shell arguments; command string is appended last    |
+| `hide_overlay_in_screen_share`         | bool   | `false`       | Hide overlay in screen sharing apps                                                               |
+| `passthrough_unbounded_keys`           | bool   | `false`       | Let unbound Cmd/Ctrl/Alt shortcuts pass through                                                   |
+| `should_exit_after_passthrough`        | bool   | `false`       | Exit mode after a passthrough shortcut                                                            |
+| `passthrough_unbounded_keys_blacklist` | array  | `[]`          | Shortcuts to keep consumed when passthrough is on                                                 |
+| `exec_shell`                           | string | `"/bin/bash"` | Shell binary used for `exec` hotkey commands                                                      |
+| `exec_shell_args`                      | array  | `["-lc"]`     | Shell arguments; command string is appended last                                                  |
 
 Find available `kb_layout_to_use` IDs on macOS:
 
@@ -914,6 +914,14 @@ duration_per_pixel = 1.0
 | `max_file_size`        | int    | `10`     | MB before rotation                                |
 | `max_backups`          | int    | `5`      | Old log files to keep                             |
 | `max_age`              | int    | `30`     | Days to retain old logs                           |
+
+When `log_file` is empty, Neru writes to a platform default location:
+
+| Platform | Default log file                  |
+| -------- | --------------------------------- |
+| macOS    | `~/Library/Logs/neru/app.log`     |
+| Linux    | `~/.local/state/neru/log/app.log` |
+| Windows  | `%LOCALAPPDATA%\neru\log\app.log` |
 
 At the default `info` level, logs focus on lifecycle, configuration, mode activation, and actionable operational events. Use `debug` temporarily when investigating key routing, hint generation, accessibility collection, overlay redraws, or IPC action flow. Debug logs intentionally avoid typed UI text, feed-key payloads, exec output, and full configuration values.
 

--- a/internal/core/infra/logger/logger.go
+++ b/internal/core/infra/logger/logger.go
@@ -107,12 +107,12 @@ func Init(
 	if !disableFileLogging {
 		// Determine log file path
 		if logFilePath == "" {
-			homeDir, err := os.UserHomeDir()
+			defaultLogFilePath, err := defaultLogFilePath()
 			if err != nil {
 				return derrors.Wrap(err, derrors.CodeLoggingFailed, "failed to get home directory")
 			}
 
-			logFilePath = filepath.Join(homeDir, "Library", "Logs", "neru", "app.log")
+			logFilePath = defaultLogFilePath
 		}
 
 		// Create log directory

--- a/internal/core/infra/logger/logger.go
+++ b/internal/core/infra/logger/logger.go
@@ -109,7 +109,11 @@ func Init(
 		if logFilePath == "" {
 			defaultLogFilePath, err := defaultLogFilePath()
 			if err != nil {
-				return derrors.Wrap(err, derrors.CodeLoggingFailed, "failed to get home directory")
+				return derrors.Wrap(
+					err,
+					derrors.CodeLoggingFailed,
+					"failed to determine default log file path",
+				)
 			}
 
 			logFilePath = defaultLogFilePath

--- a/internal/core/infra/logger/logger_path.go
+++ b/internal/core/infra/logger/logger_path.go
@@ -1,0 +1,35 @@
+package logger
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// defaultLogFilePath returns the platform default neru log file path when
+// [logging].log_file is empty.
+func defaultLogFilePath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	var logDir string
+
+	switch runtime.GOOS {
+	case "darwin":
+		logDir = filepath.Join(homeDir, "Library", "Logs", "neru")
+	case "windows":
+		localAppData := os.Getenv("LOCALAPPDATA")
+		if localAppData == "" {
+			localAppData = filepath.Join(homeDir, "AppData", "Local")
+		}
+
+		logDir = filepath.Join(localAppData, "neru", "log")
+	default:
+		// the rest are Linux, BSD, etc.
+		logDir = filepath.Join(homeDir, ".local", "state", "neru", "log")
+	}
+
+	return filepath.Join(logDir, "app.log"), nil
+}

--- a/internal/core/infra/logger/logger_path_test.go
+++ b/internal/core/infra/logger/logger_path_test.go
@@ -1,0 +1,45 @@
+//nolint:testpackage
+package logger
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const (
+	goosWindows = "windows"
+	goosDarwin  = "darwin"
+)
+
+func TestDefaultLogFilePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if runtime.GOOS == goosWindows {
+		t.Setenv("USERPROFILE", home)
+		t.Setenv("HOMEDRIVE", "")
+		t.Setenv("HOMEPATH", "")
+		t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
+	}
+
+	got, err := defaultLogFilePath()
+	if err != nil {
+		t.Fatalf("DefaultLogFilePath() error = %v", err)
+	}
+
+	var want string
+
+	switch runtime.GOOS {
+	case goosDarwin:
+		want = filepath.Join(home, "Library", "Logs", "neru", "app.log")
+	case goosWindows:
+		want = filepath.Join(home, "AppData", "Local", "neru", "log", "app.log")
+	default:
+		want = filepath.Join(home, ".local", "state", "neru", "log", "app.log")
+	}
+
+	if got != want {
+		t.Fatalf("DefaultLogFilePath() = %q, want %q", got, want)
+	}
+}

--- a/internal/core/infra/logger/logger_path_test.go
+++ b/internal/core/infra/logger/logger_path_test.go
@@ -29,7 +29,6 @@ func TestDefaultLogFilePath(t *testing.T) {
 	}
 
 	var want string
-
 	switch runtime.GOOS {
 	case goosDarwin:
 		want = filepath.Join(home, "Library", "Logs", "neru", "app.log")
@@ -41,5 +40,28 @@ func TestDefaultLogFilePath(t *testing.T) {
 
 	if got != want {
 		t.Fatalf("DefaultLogFilePath() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultLogFilePathWindowsFallback(t *testing.T) {
+	if runtime.GOOS != goosWindows {
+		t.Skip("Windows-only test")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	t.Setenv("LOCALAPPDATA", "")
+
+	got, err := defaultLogFilePath()
+	if err != nil {
+		t.Fatalf("DefaultLogFilePath() fallback error = %v", err)
+	}
+
+	want := filepath.Join(home, "AppData", "Local", "neru", "log", "app.log")
+	if got != want {
+		t.Fatalf("DefaultLogFilePath() fallback = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR ensures the default log file path are platform aware.

- macOS at `~/Library/Logs/neru/app.log`
- Linux at `~/.local/state/neru/log/app.log`
- Windows at `%LOCALAPPDATA%\neru\log\app.log`

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
