### PR TITLE
feat(systray): add `Open in Editor` for config

### DIFF
--- a/internal/app/components/systray/systray.go
+++ b/internal/app/components/systray/systray.go
@@ -281,17 +281,7 @@ func (c *Component) handleEvents() {
 		case <-c.mReloadConfig.ClickedCh:
 			c.handleReloadConfig()
 		case <-c.mOpenConfig.ClickedCh:
-			go func() {
-				configPath := c.app.GetConfigPath()
-				if configPath == "" {
-					return
-				}
-
-				err := exec.CommandContext(c.ctx, "/usr/bin/open", configPath).Run()
-				if err != nil {
-					c.logger.Error("Failed to open config file", zap.Error(err))
-				}
-			}()
+			go c.handleOpenConfig()
 		case <-c.mSourceCode.ClickedCh:
 			go func() {
 				err := exec.CommandContext(c.ctx, "/usr/bin/open", "https://github.com/y3owk1n/neru").
@@ -375,6 +365,18 @@ func (c *Component) handleToggleEnable() {
 }
 
 // handleReloadConfig reloads the configuration from disk.
+func (c *Component) handleOpenConfig() {
+	configPath := c.app.GetConfigPath()
+	if configPath == "" {
+		return
+	}
+
+	err := exec.CommandContext(c.ctx, "/usr/bin/open", configPath).Run()
+	if err != nil {
+		c.logger.Error("Failed to open config file", zap.Error(err))
+	}
+}
+
 func (c *Component) handleReloadConfig() {
 	configPath := c.app.GetConfigPath()
 

--- a/internal/app/components/systray/systray.go
+++ b/internal/app/components/systray/systray.go
@@ -66,7 +66,9 @@ type Component struct {
 	mHints              *systray.MenuItem
 	mGrid               *systray.MenuItem
 	mRecursiveGrid      *systray.MenuItem
+	mConfig             *systray.MenuItem
 	mReloadConfig       *systray.MenuItem
+	mOpenConfig         *systray.MenuItem
 	mHelp               *systray.MenuItem
 	mSourceCode         *systray.MenuItem
 	mDocsConfig         *systray.MenuItem
@@ -191,7 +193,9 @@ func (c *Component) OnReady() {
 
 	systray.AddSeparator()
 
-	c.mReloadConfig = systray.AddMenuItem("Reload Config")
+	c.mConfig = systray.AddMenuItem("Config")
+	c.mReloadConfig = c.mConfig.AddSubMenuItem("Reload")
+	c.mOpenConfig = c.mConfig.AddSubMenuItem("Open in Editor")
 
 	c.mToggleDisable = systray.AddMenuItem("Pause Neru")
 	c.mToggleEnable = systray.AddMenuItem("Resume Neru")
@@ -276,6 +280,18 @@ func (c *Component) handleEvents() {
 			c.app.ActivateMode(domain.ModeRecursiveGrid)
 		case <-c.mReloadConfig.ClickedCh:
 			c.handleReloadConfig()
+		case <-c.mOpenConfig.ClickedCh:
+			go func() {
+				configPath := c.app.GetConfigPath()
+				if configPath == "" {
+					return
+				}
+
+				err := exec.CommandContext(c.ctx, "/usr/bin/open", configPath).Run()
+				if err != nil {
+					c.logger.Error("Failed to open config file", zap.Error(err))
+				}
+			}()
 		case <-c.mSourceCode.ClickedCh:
 			go func() {
 				err := exec.CommandContext(c.ctx, "/usr/bin/open", "https://github.com/y3owk1n/neru").

--- a/internal/app/components/systray/systray.go
+++ b/internal/app/components/systray/systray.go
@@ -364,7 +364,7 @@ func (c *Component) handleToggleEnable() {
 	c.app.ToggleEnabled()
 }
 
-// handleReloadConfig reloads the configuration from disk.
+// handleOpenConfig opens the configuration file in the default editor.
 func (c *Component) handleOpenConfig() {
 	configPath := c.app.GetConfigPath()
 	if configPath == "" {
@@ -377,6 +377,7 @@ func (c *Component) handleOpenConfig() {
 	}
 }
 
+// handleReloadConfig reloads the configuration from disk.
 func (c *Component) handleReloadConfig() {
 	configPath := c.app.GetConfigPath()
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a "Config" submenu to the systray with "Reload" and "Open in Editor" items. The new item opens the config file in the system default editor using `/usr/bin/open`.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to #909

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

<img width="535" height="312" alt="Screenshot 2026-06-09 at 11 23 28 AM" src="https://github.com/user-attachments/assets/1a0219a7-ea9c-4daf-bd58-e79e4d66f3c9" />

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
