### PR TITLE
feat(config): make held-key repeat configurable

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -346,6 +346,13 @@ steps = 20                                  # Number of animation steps
 max_duration = 180                          # Maximum animation duration in ms
 duration_per_pixel = 1.00                   # Ms per pixel for adaptive duration
 
+# Held-key repeat (fires scroll/page/mouse-move actions repeatedly while held)
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#held_repeat
+[held_repeat]
+enabled = false                         # Master toggle for held-key repeat
+initial_delay_ms = 50                   # Delay before first repeat fires (ms)
+interval_ms = 50                        # Interval between subsequent repeats (ms)
+
 # Systray
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#systray
 [systray]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -25,6 +25,7 @@ Neru uses TOML for configuration. No config file is required — Neru works out 
 - [Sticky Modifiers](#sticky_modifiers)
 - [Smooth Cursor](#smooth_cursor)
 - [Smooth Scroll](#smooth_scroll)
+- [Held Repeat](#held_repeat)
 - [Systray](#systray)
 - [Logging](#logging)
 
@@ -892,6 +893,25 @@ enabled = false
 steps = 20
 max_duration = 180
 duration_per_pixel = 1.0
+```
+
+---
+
+## [held_repeat]
+
+Repeatedly dispatches scroll, page, and relative-mouse-move actions while the key is held, with a configurable initial delay and repeat interval. Disable held-key repeat entirely by setting `enabled = false`.
+
+| Option             | Type | Default | Description                              |
+| ------------------ | ---- | ------- | ---------------------------------------- |
+| `enabled`          | bool | `false` | Master toggle for held-key repeat        |
+| `initial_delay_ms` | int  | `50`    | Delay before first repeat fires (ms)     |
+| `interval_ms`      | int  | `50`    | Interval between subsequent repeats (ms) |
+
+```toml
+[held_repeat]
+enabled = false
+initial_delay_ms = 50
+interval_ms = 50
 ```
 
 ---

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -15,11 +15,6 @@ import (
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
 )
 
-const (
-	globalHotkeyRepeatInitialDelay = 50 * time.Millisecond
-	globalHotkeyRepeatInterval     = 50 * time.Millisecond
-)
-
 // actionsReferenceDisabledMode reports whether any action in the list
 // activates a mode that is currently disabled in the configuration.
 // This ensures that multi-action bindings like ["exec echo test", "hints"]
@@ -77,7 +72,7 @@ func (a *App) registerHotkeys() {
 		var registerHotkeyErr error
 
 		if releaseManager, ok := a.hotkeyManager.(HotkeyReleaseService); ok &&
-			a.hotkeyActionsRepeatWhileHeld(bindActions) {
+			a.hotkeyActionsRepeatWhileHeld(bindActions, cfg) {
 			_, registerHotkeyErr = releaseManager.RegisterWithRelease(
 				bindKey,
 				func() {
@@ -140,6 +135,8 @@ func (a *App) dispatchHotkeyActions(key string, actions []string) {
 }
 
 func (a *App) startHotkeyRepeat(key string, actions []string) {
+	cfg := a.configSnapshot().HeldRepeat
+
 	ctx, cancel := context.WithCancel(a.ctx)
 
 	a.hotkeyRepeatMu.Lock()
@@ -173,7 +170,7 @@ func (a *App) startHotkeyRepeat(key string, actions []string) {
 
 		a.dispatchHotkeyActions(key, actions)
 
-		initialTimer := time.NewTimer(globalHotkeyRepeatInitialDelay)
+		initialTimer := time.NewTimer(time.Duration(cfg.InitialDelay) * time.Millisecond)
 		defer initialTimer.Stop()
 
 		select {
@@ -182,7 +179,7 @@ func (a *App) startHotkeyRepeat(key string, actions []string) {
 		case <-initialTimer.C:
 		}
 
-		ticker := time.NewTicker(globalHotkeyRepeatInterval)
+		ticker := time.NewTicker(time.Duration(cfg.Interval) * time.Millisecond)
 		defer ticker.Stop()
 
 		for {
@@ -221,7 +218,11 @@ func (a *App) stopAllHotkeyRepeats() {
 	}
 }
 
-func (a *App) hotkeyActionsRepeatWhileHeld(actions []string) bool {
+func (a *App) hotkeyActionsRepeatWhileHeld(actions []string, cfg *config.Config) bool {
+	if !cfg.HeldRepeat.Enabled {
+		return false
+	}
+
 	if len(actions) != 1 {
 		return false
 	}

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -136,6 +136,9 @@ func (a *App) dispatchHotkeyActions(key string, actions []string) {
 
 func (a *App) startHotkeyRepeat(key string, actions []string) {
 	cfg := a.configSnapshot().HeldRepeat
+	if !cfg.Enabled {
+		return
+	}
 
 	ctx, cancel := context.WithCancel(a.ctx)
 

--- a/internal/app/hotkeys_test.go
+++ b/internal/app/hotkeys_test.go
@@ -4,6 +4,7 @@ package app
 import (
 	"testing"
 
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 )
 
@@ -144,6 +145,9 @@ func TestSplitArgs(t *testing.T) {
 func TestHotkeyActionsRepeatWhileHeld(t *testing.T) {
 	app := &App{}
 
+	cfg := config.DefaultConfig()
+	cfg.HeldRepeat.Enabled = true
+
 	tests := []struct {
 		name    string
 		actions []string
@@ -193,13 +197,46 @@ func TestHotkeyActionsRepeatWhileHeld(t *testing.T) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			got := app.hotkeyActionsRepeatWhileHeld(testCase.actions)
+			got := app.hotkeyActionsRepeatWhileHeld(testCase.actions, cfg)
 			if got != testCase.want {
 				t.Fatalf(
 					"hotkeyActionsRepeatWhileHeld(%v) = %v, want %v",
 					testCase.actions,
 					got,
 					testCase.want,
+				)
+			}
+		})
+	}
+}
+
+func TestHotkeyActionsRepeatWhileHeldDisabled(t *testing.T) {
+	app := &App{}
+
+	cfg := config.DefaultConfig()
+
+	tests := []struct {
+		name    string
+		actions []string
+	}{
+		{
+			name:    "scroll down does not repeat when disabled",
+			actions: []string{"action scroll_down"},
+		},
+		{
+			name:    "relative mouse movement does not repeat when disabled",
+			actions: []string{"action move_mouse_relative --dx=0 --dy=10"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := app.hotkeyActionsRepeatWhileHeld(testCase.actions, cfg)
+			if got != false {
+				t.Fatalf(
+					"hotkeyActionsRepeatWhileHeld(%v) with Enabled=false = %v, want false",
+					testCase.actions,
+					got,
 				)
 			}
 		})

--- a/internal/app/hotkeys_test.go
+++ b/internal/app/hotkeys_test.go
@@ -232,7 +232,7 @@ func TestHotkeyActionsRepeatWhileHeldDisabled(t *testing.T) {
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			got := app.hotkeyActionsRepeatWhileHeld(testCase.actions, cfg)
-			if got != false {
+			if got {
 				t.Fatalf(
 					"hotkeyActionsRepeatWhileHeld(%v) with Enabled=false = %v, want false",
 					testCase.actions,

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -13,9 +13,7 @@ import (
 )
 
 const (
-	hotkeySequenceTimeout  = 500 * time.Millisecond
-	heldRepeatInitialDelay = 50 * time.Millisecond
-	heldRepeatInterval     = 50 * time.Millisecond
+	hotkeySequenceTimeout = 500 * time.Millisecond
 )
 
 const keyUpPrefix = "__keyup_"
@@ -373,7 +371,8 @@ func (h *Handler) dispatchHotkeyActions(
 }
 
 // maybeStartHeldRepeatLocked starts a custom repeat goroutine if the given
-// actions are held-repeatable (scroll, page, mouse move).
+// actions are held-repeatable (scroll, page, mouse move) and held-key
+// repeat is enabled in config.
 // actions is the already-resolved action list from handleHotkey.
 // bindKey is the normalised config-binding key (for consistent logging).
 // Caller must hold h.mu.
@@ -382,9 +381,11 @@ func (h *Handler) maybeStartHeldRepeatLocked(key, bindKey string, actions []stri
 		return
 	}
 
-	if isHeldRepeatAction(actions) {
-		h.startHeldRepeatLocked(key, bindKey, actions)
+	if !h.config.HeldRepeat.Enabled || !isHeldRepeatAction(actions) {
+		return
 	}
+
+	h.startHeldRepeatLocked(key, bindKey, actions)
 }
 
 // startHeldRepeatLocked launches a goroutine that dispatches the held-key
@@ -392,6 +393,8 @@ func (h *Handler) maybeStartHeldRepeatLocked(key, bindKey string, actions []stri
 // bindKey is the normalised config-binding key (for consistent logging).
 // Caller must hold h.mu.
 func (h *Handler) startHeldRepeatLocked(key, bindKey string, actions []string) {
+	cfg := h.config.HeldRepeat
+
 	ctx, cancel := context.WithCancel(h.ctx)
 	h.heldRepeatingKey = key
 	h.heldRepeatingCancel = cancel
@@ -407,7 +410,7 @@ func (h *Handler) startHeldRepeatLocked(key, bindKey string, actions []string) {
 			}
 		}()
 
-		initialTimer := time.NewTimer(heldRepeatInitialDelay)
+		initialTimer := time.NewTimer(time.Duration(cfg.InitialDelay) * time.Millisecond)
 		defer initialTimer.Stop()
 
 		select {
@@ -416,7 +419,7 @@ func (h *Handler) startHeldRepeatLocked(key, bindKey string, actions []string) {
 		case <-initialTimer.C:
 		}
 
-		ticker := time.NewTicker(heldRepeatInterval)
+		ticker := time.NewTicker(time.Duration(cfg.Interval) * time.Millisecond)
 		defer ticker.Stop()
 
 		for {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -400,6 +400,7 @@ type Config struct {
 	Logging         LoggingConfig         `json:"logging"         toml:"logging"`
 	SmoothCursor    SmoothCursorConfig    `json:"smoothCursor"    toml:"smooth_cursor"`
 	SmoothScroll    SmoothScrollConfig    `json:"smoothScroll"    toml:"smooth_scroll"`
+	HeldRepeat      HeldRepeatConfig      `json:"heldRepeat"      toml:"held_repeat"`
 	Systray         SystrayConfig         `json:"systray"         toml:"systray"`
 }
 
@@ -819,6 +820,13 @@ type SmoothScrollConfig struct {
 	DurationPerPixel float64 `json:"durationPerPixel" toml:"duration_per_pixel"`
 }
 
+// HeldRepeatConfig defines held-key repeat settings for scroll, page, and mouse-move actions.
+type HeldRepeatConfig struct {
+	Enabled      bool `json:"enabled"      toml:"enabled"`          // Master toggle for held-key repeat
+	InitialDelay int  `json:"initialDelay" toml:"initial_delay_ms"` // Delay before first repeat fires (ms)
+	Interval     int  `json:"interval"     toml:"interval_ms"`      // Interval between subsequent repeats (ms)
+}
+
 // AdditionalAXSupport defines accessibility support for specific application frameworks.
 type AdditionalAXSupport struct {
 	Enable                    bool     `json:"enable"                    toml:"enable"`
@@ -924,6 +932,12 @@ func (c *Config) Validate() error {
 
 	// Validate smooth scroll settings
 	err = c.ValidateSmoothScroll()
+	if err != nil {
+		return err
+	}
+
+	// Validate held-key repeat settings
+	err = c.ValidateHeldRepeat()
 	if err != nil {
 		return err
 	}

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -123,6 +123,10 @@ const (
 
 	// DefaultSmoothScrollDurationPerPixel is the default ms per pixel for adaptive duration.
 	DefaultSmoothScrollDurationPerPixel = 1.0
+	// DefaultHeldRepeatInitialDelay is the default held-key initial delay in ms.
+	DefaultHeldRepeatInitialDelay = 50
+	// DefaultHeldRepeatInterval is the default held-key repeat interval in ms.
+	DefaultHeldRepeatInterval = 50
 
 	// DefaultIPCTimeout is the default IPC timeout.
 	DefaultIPCTimeout = 5
@@ -642,6 +646,11 @@ func newDefaultConfig() *Config {
 			Steps:            DefaultSmoothScrollSteps,
 			MaxDuration:      DefaultSmoothScrollMaxDuration,
 			DurationPerPixel: DefaultSmoothScrollDurationPerPixel,
+		},
+		HeldRepeat: HeldRepeatConfig{
+			Enabled:      false,
+			InitialDelay: DefaultHeldRepeatInitialDelay,
+			Interval:     DefaultHeldRepeatInterval,
 		},
 		Systray: SystrayConfig{
 			Enabled: true, // Enabled by default

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -754,6 +754,19 @@ func (c *Config) ValidateSmoothScroll() error {
 	return nil
 }
 
+// ValidateHeldRepeat validates held-key repeat settings.
+func (c *Config) ValidateHeldRepeat() error {
+	if c.HeldRepeat.InitialDelay < 0 {
+		return derrors.New(derrors.CodeInvalidConfig, "held_repeat.initial_delay_ms must be >= 0")
+	}
+
+	if c.HeldRepeat.Interval < 1 {
+		return derrors.New(derrors.CodeInvalidConfig, "held_repeat.interval_ms must be >= 1")
+	}
+
+	return nil
+}
+
 // ValidateHotkeys validates per-mode hotkey syntax and actions.
 func (c *Config) ValidateHotkeys() error {
 	modeHotkeys := []struct {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a new `[held_repeat]` config section that exposes the held-key repeat behaviour (for scroll, page, and relative-mouse-move actions) as user-configurable options.

Previously the timings (50ms initial delay, 50ms interval) were hardcoded constants and the feature was always active for eligible actions.

Now users can:

- Disable held-key repeat entirely (`enabled = false`)
- Tune the initial delay and repeat interval to their preference

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
