### PR TITLE
fix(hints): validate and dedupe hint characters

### DIFF
--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -114,6 +114,21 @@ func (c *Config) ValidateHints() error {
 		}
 	}
 
+	seen := make(map[rune]struct{}, len(c.Hints.HintCharacters))
+	for _, char := range c.Hints.HintCharacters {
+		upper := unicode.ToUpper(char)
+
+		if _, ok := seen[upper]; ok {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"hint_characters contains duplicate character %q",
+				char,
+			)
+		}
+
+		seen[upper] = struct{}{}
+	}
+
 	err := validateColors([]colorField{
 		{c.Hints.UI.BackgroundColor, "hints.ui.background_color"},
 		{c.Hints.UI.TextColor, "hints.ui.text_color"},

--- a/internal/config/validators_config_test.go
+++ b/internal/config/validators_config_test.go
@@ -152,6 +152,38 @@ func TestConfigValidateScroll_AppConfigs(t *testing.T) {
 	}
 }
 
+func TestConfigValidateHints_DuplicateHintChars(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	cfg.Hints.HintCharacters = "ab"
+
+	err := cfg.ValidateHints()
+	if err != nil {
+		t.Fatalf("ValidateHints() unexpected error for unique chars: %v", err)
+	}
+
+	cfg.Hints.HintCharacters = "aab"
+
+	err = cfg.ValidateHints()
+	if err == nil {
+		t.Fatal("ValidateHints() expected error for duplicate hint_characters")
+	}
+
+	cfg.Hints.HintCharacters = "aba"
+
+	err = cfg.ValidateHints()
+	if err == nil {
+		t.Fatal("ValidateHints() expected error for duplicate hint_characters (non-adjacent)")
+	}
+
+	cfg.Hints.HintCharacters = "aA"
+
+	err = cfg.ValidateHints()
+	if err == nil {
+		t.Fatal("ValidateHints() expected error for case-insensitive duplicate hint_characters")
+	}
+}
+
 func TestConfigValidateHints_AsciiHintChars(t *testing.T) {
 	cfg := config.DefaultConfig()
 

--- a/internal/core/domain/hint/alphabet_generator.go
+++ b/internal/core/domain/hint/alphabet_generator.go
@@ -63,19 +63,28 @@ func NewAlphabetGenerator(characters string) (*AlphabetGenerator, error) {
 		)
 	}
 
-	// Build uppercase mapping
+	// Build uppercase mapping and deduplicate characters
 	uppercaseRuneMap := make(map[rune]rune)
 
-	var uppercaseBuilder strings.Builder
+	var (
+		uppercaseBuilder strings.Builder
+		seen             = make(map[rune]struct{}, len(characters))
+	)
 
 	for _, rune := range characters {
 		upper := unicode.ToUpper(rune)
 		uppercaseRuneMap[rune] = upper
+
+		if _, ok := seen[upper]; ok {
+			continue
+		}
+
+		seen[upper] = struct{}{}
 		uppercaseBuilder.WriteRune(upper)
 	}
 
 	uppercaseChars := uppercaseBuilder.String()
-	charCount := len(characters)
+	charCount := len(uppercaseChars)
 
 	// Calculate max hints: up to 3 chars
 	// Max capacity for fixed-length 3-char base-N encoding is N^3
@@ -182,19 +191,28 @@ func (g *AlphabetGenerator) UpdateCharacters(characters string) error {
 		)
 	}
 
-	// Build uppercase mapping
+	// Build uppercase mapping and deduplicate characters
 	uppercaseRuneMap := make(map[rune]rune)
 
-	var uppercaseBuilder strings.Builder
+	var (
+		uppercaseBuilder strings.Builder
+		seen             = make(map[rune]struct{}, len(characters))
+	)
 
 	for _, rune := range characters {
 		upper := unicode.ToUpper(rune)
 		uppercaseRuneMap[rune] = upper
+
+		if _, ok := seen[upper]; ok {
+			continue
+		}
+
+		seen[upper] = struct{}{}
 		uppercaseBuilder.WriteRune(upper)
 	}
 
 	uppercaseChars := uppercaseBuilder.String()
-	charCount := len(characters)
+	charCount := len(uppercaseChars)
 	// Max capacity for fixed-length 3-char base-N encoding is N^3
 	n := charCount
 	maxHints := n * n * n

--- a/internal/core/domain/hint/alphabet_generator.go
+++ b/internal/core/domain/hint/alphabet_generator.go
@@ -86,6 +86,15 @@ func NewAlphabetGenerator(characters string) (*AlphabetGenerator, error) {
 	uppercaseChars := uppercaseBuilder.String()
 	charCount := len(uppercaseChars)
 
+	if charCount < MinCharactersLength {
+		return nil, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"characters must have at least %d unique characters after deduplication, got %d",
+			MinCharactersLength,
+			charCount,
+		)
+	}
+
 	// Calculate max hints: up to 3 chars
 	// Max capacity for fixed-length 3-char base-N encoding is N^3
 	n := charCount
@@ -99,7 +108,7 @@ func NewAlphabetGenerator(characters string) (*AlphabetGenerator, error) {
 	}
 
 	return &AlphabetGenerator{
-		characters:       characters,
+		characters:       uppercaseChars,
 		uppercaseChars:   uppercaseChars,
 		maxHints:         maxHints,
 		uppercaseRuneMap: uppercaseRuneMap,
@@ -213,11 +222,21 @@ func (g *AlphabetGenerator) UpdateCharacters(characters string) error {
 
 	uppercaseChars := uppercaseBuilder.String()
 	charCount := len(uppercaseChars)
+
+	if charCount < MinCharactersLength {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"characters must have at least %d unique characters after deduplication, got %d",
+			MinCharactersLength,
+			charCount,
+		)
+	}
+
 	// Max capacity for fixed-length 3-char base-N encoding is N^3
 	n := charCount
 	maxHints := n * n * n
 
-	g.characters = characters
+	g.characters = uppercaseChars
 	g.uppercaseChars = uppercaseChars
 	g.maxHints = maxHints
 	g.uppercaseRuneMap = uppercaseRuneMap

--- a/internal/core/domain/hint/hint_test.go
+++ b/internal/core/domain/hint/hint_test.go
@@ -257,32 +257,34 @@ func TestAlphabetGenerator_Generate(t *testing.T) {
 }
 
 func TestAlphabetGenerator_DeduplicatesCharacters(t *testing.T) {
-	tests := []struct {
-		name       string
-		characters string
-		wantMax    int
-	}{
-		{"dedup duplicate chars", "aab", 8},
-		{"no dedup needed", "abc", 27},
-		{"dedup case insensitive", "aA", 1},
-	}
+	t.Run("dedup duplicate chars", func(t *testing.T) {
+		generator, err := hint.NewAlphabetGenerator("aab")
+		if err != nil {
+			t.Fatalf("NewAlphabetGenerator() error: %v", err)
+		}
 
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			generator, generatorErr := hint.NewAlphabetGenerator(testCase.characters)
-			if generatorErr != nil {
-				t.Fatalf("NewAlphabetGenerator() error: %v", generatorErr)
-			}
+		if got := generator.MaxHints(); got != 8 {
+			t.Errorf("MaxHints() = %d, want 8 (deduped from \"aab\")", got)
+		}
+	})
 
-			got := generator.MaxHints()
-			if got != testCase.wantMax {
-				t.Errorf(
-					"MaxHints() = %d, want %d (deduped from %q)",
-					got, testCase.wantMax, testCase.characters,
-				)
-			}
-		})
-	}
+	t.Run("no dedup needed", func(t *testing.T) {
+		generator, err := hint.NewAlphabetGenerator("abc")
+		if err != nil {
+			t.Fatalf("NewAlphabetGenerator() error: %v", err)
+		}
+
+		if got := generator.MaxHints(); got != 27 {
+			t.Errorf("MaxHints() = %d, want 27", got)
+		}
+	})
+
+	t.Run("rejects below minimum after dedup", func(t *testing.T) {
+		_, err := hint.NewAlphabetGenerator("aA")
+		if err == nil {
+			t.Fatal("NewAlphabetGenerator() expected error for \"aA\" (1 unique char after dedup)")
+		}
+	})
 }
 
 func TestAlphabetGenerator_DeduplicateProducesUniqueLabels(t *testing.T) {
@@ -291,6 +293,10 @@ func TestAlphabetGenerator_DeduplicateProducesUniqueLabels(t *testing.T) {
 	generator, err := hint.NewAlphabetGenerator("aabc")
 	if err != nil {
 		t.Fatalf("NewAlphabetGenerator() error: %v", err)
+	}
+
+	if got := generator.Characters(); got != "ABC" {
+		t.Fatalf("Characters() = %q, want %q (deduped)", got, "ABC")
 	}
 
 	elements := make([]*element.Element, 10)

--- a/internal/core/domain/hint/hint_test.go
+++ b/internal/core/domain/hint/hint_test.go
@@ -256,6 +256,72 @@ func TestAlphabetGenerator_Generate(t *testing.T) {
 	}
 }
 
+func TestAlphabetGenerator_DeduplicatesCharacters(t *testing.T) {
+	tests := []struct {
+		name       string
+		characters string
+		wantMax    int
+	}{
+		{"dedup duplicate chars", "aab", 8},
+		{"no dedup needed", "abc", 27},
+		{"dedup case insensitive", "aA", 1},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			generator, generatorErr := hint.NewAlphabetGenerator(testCase.characters)
+			if generatorErr != nil {
+				t.Fatalf("NewAlphabetGenerator() error: %v", generatorErr)
+			}
+
+			got := generator.MaxHints()
+			if got != testCase.wantMax {
+				t.Errorf(
+					"MaxHints() = %d, want %d (deduped from %q)",
+					got, testCase.wantMax, testCase.characters,
+				)
+			}
+		})
+	}
+}
+
+func TestAlphabetGenerator_DeduplicateProducesUniqueLabels(t *testing.T) {
+	// With "aabc", deduped unique chars are "abc" (3 chars).
+	// 3^3 = 27 max hints, so 10 elements should get unique 2-char labels.
+	generator, err := hint.NewAlphabetGenerator("aabc")
+	if err != nil {
+		t.Fatalf("NewAlphabetGenerator() error: %v", err)
+	}
+
+	elements := make([]*element.Element, 10)
+	for i := range elements {
+		elements[i], _ = element.NewElement(
+			element.ID(string(rune('0'+i))),
+			image.Rect(i*10, i*10, i*10+50, i*10+50),
+			element.RoleButton,
+		)
+	}
+
+	hints, err := generator.Generate(context.Background(), elements)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	seen := make(map[string]struct{}, len(hints))
+	for _, h := range hints {
+		label := h.Label()
+		if _, ok := seen[label]; ok {
+			t.Errorf("Duplicate label generated: %q (characters=%q)", label, "aabc")
+		}
+
+		seen[label] = struct{}{}
+	}
+
+	if len(seen) != len(hints) {
+		t.Errorf("Got %d unique labels for %d hints", len(seen), len(hints))
+	}
+}
+
 func TestAlphabetGenerator_MaxHints(t *testing.T) {
 	tests := []struct {
 		characters string


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes an issue where `hint_characters` does not get validated and deduped when same char is configured, e.g. `aabc`.

- validator now rejects duplicate characters (case-insensitive)
- generator now dedpulicate the same characters in case validation is bypassed
- added test to prevent the regression

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to #915

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
