### PR TITLE
fix(linux): improve sticky modifier detection

### DIFF
--- a/internal/app/modes/scroll.go
+++ b/internal/app/modes/scroll.go
@@ -1,7 +1,12 @@
 package modes
 
 import (
+	"time"
+
+	"go.uber.org/zap"
+
 	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/infra/accessibility"
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
@@ -10,11 +15,43 @@ import (
 func (h *Handler) StartInteractiveScroll() {
 	h.cursorState.SkipNextRestore()
 
-	// Defensively reset scroll context before exiting the current mode.
-	// exitModeLocked returns early when already idle without running cleanup.
 	h.scroll.Context.Reset()
 
-	h.exitModeLocked()
+	if h.appState.CurrentMode() != domain.ModeIdle {
+		// Mode-to-mode transition: clean up the current mode but keep the
+		// event tap enabled. Skipping disableEventTap avoids a brief dead
+		// window where CGEventTap silently drops key events between the
+		// disable and subsequent re-enable (the root cause of missed
+		// scrolling keys when activating from grid mode).
+		h.performModeSpecificCleanup()
+		h.stopHeldRepeatLocked()
+		h.overlayManager.Clear()
+
+		if h.refreshHintsTimer != nil {
+			h.refreshHintsTimer.Stop()
+			h.refreshHintsTimer = nil
+		}
+
+		h.hotkeyLastKey = ""
+		h.hotkeyLastKeyTime = 0
+		h.clearStickyModifiers()
+		accessibility.EnsureMouseUp()
+
+		h.suppressedModifiers = 0
+		h.suppressedUntil = time.Time{}
+		h.cursorState.Reset()
+
+		if h.appState.HotkeyRefreshPending() {
+			h.appState.SetHotkeyRefreshPending(false)
+
+			if h.refreshHotkeys != nil {
+				go h.refreshHotkeys()
+			}
+		}
+
+		h.logger.Debug("Transitioned to scroll mode",
+			zap.String("from", h.CurrModeString()))
+	}
 
 	h.scroll.Context.SetIsActive(true)
 

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -92,10 +92,9 @@ type EventTap struct {
 	// The event-tap goroutine enqueues keys here; the dispatch goroutine
 	// reads from this channel and invokes the callback. This matches the
 	// macOS eventtap design.
-	dispatchCh      chan string
-	dispatchWg      sync.WaitGroup
-	dispatchStarted bool
-	destroyed       bool
+	dispatchCh chan string
+	dispatchWg sync.WaitGroup
+	destroyed  bool
 
 	// dispatchEpoch is incremented on every Disable(). dispatchLoop
 	// snapshots the epoch before processing a key and verifies it
@@ -113,7 +112,6 @@ func NewEventTap(callback Callback, logger *zap.Logger) *EventTap {
 	tap.dispatchCh = make(chan string, dispatchChBufferSize)
 	tap.dispatchWg.Add(1)
 
-	tap.dispatchStarted = true
 	go tap.dispatchLoop()
 
 	return tap

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -95,6 +96,12 @@ type EventTap struct {
 	dispatchWg      sync.WaitGroup
 	dispatchStarted bool
 	destroyed       bool
+
+	// dispatchEpoch is incremented on every Disable(). dispatchLoop
+	// snapshots the epoch before processing a key and verifies it
+	// hasn't changed before invoking the callback. This prevents
+	// stale buffered events from leaking across enable/disable cycles.
+	dispatchEpoch atomic.Uint64
 }
 
 // NewEventTap creates a new EventTap instance.
@@ -160,8 +167,13 @@ func (et *EventTap) Disable() {
 	close(stopCh)
 	<-doneCh
 
-	// Drain any stale events from the dispatch channel. Afte the evdev
-	// go routine has exited, no new events are being enqueued, so whatever
+	// Bump the dispatch epoch so any in-flight event that dispatchLoop
+	// picked up before we drained will be discarded rather than delivered
+	// to the callback.
+	et.dispatchEpoch.Add(1)
+
+	// Drain any stale events from the dispatch channel. After the evdev
+	// goroutine has exited, no new events are being enqueued, so whatever
 	// remains in the buffer was enqueued before the stop signal landed.
 	// These stale events must be discarded to prevent them from being
 	// misinterpreted by the next mode's handler after the event tap is
@@ -340,11 +352,13 @@ func (et *EventTap) dispatchLoop() {
 	defer et.dispatchWg.Done()
 
 	for key := range et.dispatchCh {
+		epoch := et.dispatchEpoch.Load()
+
 		et.mu.RLock()
 		cb := et.callback
 		et.mu.RUnlock()
 
-		if cb != nil {
+		if cb != nil && et.dispatchEpoch.Load() == epoch {
 			cb(key)
 		}
 	}

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -28,6 +28,8 @@ type pendingSyntheticModifierEvent struct {
 
 const syntheticModifierSuppressionWindow = 250 * time.Millisecond
 
+const dispatchChBufferSize = 256
+
 // EventTap intercepts keyboard events on Linux.
 type EventTap struct {
 	logger *zap.Logger
@@ -39,18 +41,41 @@ type EventTap struct {
 	stickyModifierToggle bool
 	enabled              bool
 
+	// Detection arming: sticky modifier events are only dispatched once all
+	// initially-held modifiers have been released (matching macOS behavior).
+	// SetStickyModifierToggle(true) disarms; the platform handler re-arms when
+	// the modifier state reaches a clean slate.
+	stickyModifierDetectionArmed bool
+
 	syntheticModifierEvents []pendingSyntheticModifierEvent
 
 	stopCh chan struct{}
 	doneCh chan struct{}
+
+	// dispatchCh decouples the event-tap goroutine from the callback
+	// goroutine, preventing a deadlock when a key dispatch triggers a mode
+	// exit that waits for the event-tap goroutine to stop.
+	// The event-tap goroutine enqueues keys here; the dispatch goroutine
+	// reads from this channel and invokes the callback. This matches the
+	// macOS eventtap design.
+	dispatchCh      chan string
+	dispatchWg      sync.WaitGroup
+	dispatchStarted bool
 }
 
 // NewEventTap creates a new EventTap instance.
 func NewEventTap(callback Callback, logger *zap.Logger) *EventTap {
-	return &EventTap{
+	tap := &EventTap{
 		logger:   logger,
 		callback: callback,
 	}
+	tap.dispatchCh = make(chan string, dispatchChBufferSize)
+	tap.dispatchWg.Add(1)
+
+	tap.dispatchStarted = true
+	go tap.dispatchLoop()
+
+	return tap
 }
 
 // Enable starts intercepting keyboard events.
@@ -105,6 +130,15 @@ func (et *EventTap) Disable() {
 // Destroy stops and cleans up the EventTap.
 func (et *EventTap) Destroy() {
 	et.Disable()
+
+	// Stop the dispatch goroutine and wait for it to finish.
+	// The dispatchCh is created once in NewEventTap and lives for the
+	// entire lifetime of the EventTap, so we close the channel to signal
+	// the dispatch goroutine to exit.
+	if et.dispatchStarted {
+		close(et.dispatchCh)
+		et.dispatchWg.Wait()
+	}
 }
 
 // SetHandler sets the callback for key events.
@@ -143,6 +177,15 @@ func (et *EventTap) SetStickyModifierToggle(enabled bool) {
 	defer et.mu.Unlock()
 
 	et.stickyModifierToggle = enabled
+	if enabled {
+		// Disarm detection: the platform handler will re-arm once the
+		// modifier state reaches a clean slate (all pre-held modifiers
+		// released). This matches macOS behavior where modifier events
+		// from the activation chord are not interpreted as sticky toggles.
+		et.stickyModifierDetectionArmed = false
+	} else {
+		et.stickyModifierDetectionArmed = true
+	}
 }
 
 // PostModifierEvent posts a modifier key event.
@@ -152,10 +195,21 @@ func (et *EventTap) PostModifierEvent(modifier string, isDown bool) {
 		return
 	}
 
-	et.rememberSyntheticModifierEvent(modifier, isDown)
+	// On X11, synthetic modifier events (from XTest) re-enter the event tap
+	// loop and must be suppressed so they don't trigger __modifier_ events.
+	// On Wayland, zwp_virtual_keyboard_v1_modifiers does not generate evdev
+	// or wl_keyboard events, so the synthetic event never re-enters.
+	// Remembering it would falsely suppress a genuine physical modifier
+	// press within the suppression window.
+	onWayland := os.Getenv("WAYLAND_DISPLAY") != ""
+	if !onWayland {
+		et.rememberSyntheticModifierEvent(modifier, isDown)
+	}
 
 	if !postLinuxModifierEvent(modifier, isDown) {
-		et.consumeSyntheticModifierEvent(modifier, isDown)
+		if !onWayland {
+			et.consumeSyntheticModifierEvent(modifier, isDown)
+		}
 	}
 }
 
@@ -170,6 +224,23 @@ func (et *EventTap) IsEnabled() bool {
 	return et.enabled
 }
 
+// stickyArmDetection arms sticky modifier detection. The platform handler
+// calls this when it determines all pre-held modifiers have been released.
+func (et *EventTap) stickyArmDetection() {
+	et.mu.Lock()
+	defer et.mu.Unlock()
+
+	et.stickyModifierDetectionArmed = true
+}
+
+// stickyDetectionArmed returns whether sticky detection is armed.
+func (et *EventTap) stickyDetectionArmed() bool {
+	et.mu.RLock()
+	defer et.mu.RUnlock()
+
+	return et.stickyModifierDetectionArmed
+}
+
 // run starts the event interception loop.
 func (et *EventTap) run() {
 	if os.Getenv("WAYLAND_DISPLAY") != "" {
@@ -179,14 +250,38 @@ func (et *EventTap) run() {
 	}
 }
 
-// dispatchKey dispatches a key event to the callback.
+// dispatchKey enqueues a key event for dispatch. The callback is invoked
+// from a dedicated dispatch goroutine so that the event-tap goroutine never
+// blocks on the callback (preventing a deadlock when the callback triggers
+// a mode exit that waits for the event-tap goroutine to stop).
 func (et *EventTap) dispatchKey(key string) {
-	et.mu.RLock()
-	callback := et.callback
-	et.mu.RUnlock()
+	if key == "" {
+		return
+	}
 
-	if callback != nil && key != "" {
-		callback(key)
+	select {
+	case et.dispatchCh <- key:
+	default:
+		if et.logger != nil {
+			et.logger.Warn("Dispatch channel full, dropping key", zap.String("key", key))
+		}
+	}
+}
+
+// dispatchLoop reads key events from the dispatch channel and invokes the
+// registered callback. It runs in a dedicated goroutine that lives for the
+// entire lifetime of the EventTap.
+func (et *EventTap) dispatchLoop() {
+	defer et.dispatchWg.Done()
+
+	for key := range et.dispatchCh {
+		et.mu.RLock()
+		cb := et.callback
+		et.mu.RUnlock()
+
+		if cb != nil {
+			cb(key)
+		}
 	}
 }
 

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -30,6 +30,39 @@ const syntheticModifierSuppressionWindow = 250 * time.Millisecond
 
 const dispatchChBufferSize = 256
 
+// linuxModifierState tracks the reference count of each modifier key group.
+// Counts may go transiently negative when a grab captures the keyboard after
+// some modifiers were already held (the release arrives without a matching
+// press). The <= 0 sentinel in allZero() handles this gracefully.
+type linuxModifierState struct {
+	shift int
+	ctrl  int
+	alt   int
+	cmd   int
+}
+
+func (s *linuxModifierState) update(modifier string, isDown bool) {
+	delta := 1
+	if !isDown {
+		delta = -1
+	}
+
+	switch modifier {
+	case evdevModifierShift:
+		s.shift += delta
+	case evdevModifierCtrl:
+		s.ctrl += delta
+	case evdevModifierAlt:
+		s.alt += delta
+	case evdevModifierCmd:
+		s.cmd += delta
+	}
+}
+
+func (s *linuxModifierState) allZero() bool {
+	return s.shift <= 0 && s.ctrl <= 0 && s.alt <= 0 && s.cmd <= 0
+}
+
 // EventTap intercepts keyboard events on Linux.
 type EventTap struct {
 	logger *zap.Logger

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -61,6 +61,7 @@ type EventTap struct {
 	dispatchCh      chan string
 	dispatchWg      sync.WaitGroup
 	dispatchStarted bool
+	destroyed       bool
 }
 
 // NewEventTap creates a new EventTap instance.
@@ -81,7 +82,7 @@ func NewEventTap(callback Callback, logger *zap.Logger) *EventTap {
 // Enable starts intercepting keyboard events.
 func (et *EventTap) Enable() {
 	et.mu.Lock()
-	if et.enabled {
+	if et.enabled || et.destroyed {
 		et.mu.Unlock()
 
 		return
@@ -128,17 +129,25 @@ func (et *EventTap) Disable() {
 }
 
 // Destroy stops and cleans up the EventTap.
+// It is safe to call multiple times — subsequent calls are no-ops.
 func (et *EventTap) Destroy() {
+	et.mu.Lock()
+	if et.destroyed {
+		et.mu.Unlock()
+
+		return
+	}
+	et.destroyed = true
+	et.mu.Unlock()
+
 	et.Disable()
 
 	// Stop the dispatch goroutine and wait for it to finish.
 	// The dispatchCh is created once in NewEventTap and lives for the
 	// entire lifetime of the EventTap, so we close the channel to signal
 	// the dispatch goroutine to exit.
-	if et.dispatchStarted {
-		close(et.dispatchCh)
-		et.dispatchWg.Wait()
-	}
+	close(et.dispatchCh)
+	et.dispatchWg.Wait()
 }
 
 // SetHandler sets the callback for key events.
@@ -256,6 +265,13 @@ func (et *EventTap) run() {
 // a mode exit that waits for the event-tap goroutine to stop).
 func (et *EventTap) dispatchKey(key string) {
 	if key == "" {
+		return
+	}
+
+	et.mu.RLock()
+	destroyed := et.destroyed
+	et.mu.RUnlock()
+	if destroyed {
 		return
 	}
 

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -159,6 +159,20 @@ func (et *EventTap) Disable() {
 
 	close(stopCh)
 	<-doneCh
+
+	// Drain any stale events from the dispatch channel. Afte the evdev
+	// go routine has exited, no new events are being enqueued, so whatever
+	// remains in the buffer was enqueued before the stop signal landed.
+	// These stale events must be discarded to prevent them from being
+	// misinterpreted by the next mode's handler after the event tap is
+	// re-enabled.
+	for {
+		select {
+		case <-et.dispatchCh:
+		default:
+			return
+		}
+	}
 }
 
 // Destroy stops and cleans up the EventTap.

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -184,6 +184,7 @@ func (et *EventTap) Destroy() {
 
 		return
 	}
+
 	et.destroyed = true
 	et.mu.Unlock()
 
@@ -318,6 +319,7 @@ func (et *EventTap) dispatchKey(key string) {
 	et.mu.RLock()
 	destroyed := et.destroyed
 	et.mu.RUnlock()
+
 	if destroyed {
 		return
 	}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -322,8 +322,10 @@ func (capture *waylandEvdevCapture) modifierKeysHeld() bool {
 
 // queryEvdevModifierState queries the current evdev key state and returns
 // a linuxModifierState counting any held modifier keys across all captured
-// devices. This mirrors x11QueryModifierState for the X11 path.
-func queryEvdevModifierState(capture *waylandEvdevCapture) linuxModifierState {
+// devices. Keys that are physically held are also recorded in pressed so that
+// the event-loop press handler can avoid double-counting when the
+// corresponding evdev press event is processed from the buffer.
+func queryEvdevModifierState(capture *waylandEvdevCapture, pressed map[uint16]bool) linuxModifierState {
 	if capture == nil {
 		return linuxModifierState{}
 	}
@@ -351,6 +353,7 @@ func queryEvdevModifierState(capture *waylandEvdevCapture) linuxModifierState {
 		for _, mk := range modifierKeys {
 			if C.neru_evdev_key_down(fd, C.uint(mk.code)) != 0 {
 				state.update(mk.modifier, true)
+				pressed[mk.code] = true
 			}
 		}
 	}
@@ -421,9 +424,10 @@ func (et *EventTap) runWaylandEvdev() bool {
 		)
 	}
 
+	pressed := make(map[uint16]bool)
 	state := waylandEvdevKeyState{
-		pressed:   make(map[uint16]bool),
-		modifiers: evdevModifierState{linuxModifierState: queryEvdevModifierState(capture)},
+		pressed:   pressed,
+		modifiers: evdevModifierState{linuxModifierState: queryEvdevModifierState(capture, pressed)},
 	}
 
 	for {
@@ -457,8 +461,11 @@ func (et *EventTap) handleWaylandEvdevEvent(
 
 		switch {
 		case isDown:
+			alreadyTracked := state.pressed[event.code]
 			state.trackKey(event.code, true)
-			state.modifiers.update(modifier, true)
+			if !alreadyTracked {
+				state.modifiers.update(modifier, true)
+			}
 		case state.pressed[event.code]:
 			state.trackKey(event.code, false)
 			state.modifiers.update(modifier, false)

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -320,6 +320,44 @@ func (capture *waylandEvdevCapture) modifierKeysHeld() bool {
 	return false
 }
 
+// queryEvdevModifierState queries the current evdev key state and returns
+// a linuxModifierState counting any held modifier keys across all captured
+// devices. This mirrors x11QueryModifierState for the X11 path.
+func queryEvdevModifierState(capture *waylandEvdevCapture) linuxModifierState {
+	if capture == nil {
+		return linuxModifierState{}
+	}
+
+	var state linuxModifierState
+
+	type modifierKey struct {
+		code     uint16
+		modifier string
+	}
+	modifierKeys := []modifierKey{
+		{evdevKeyLeftShift, evdevModifierShift},
+		{evdevKeyRightShift, evdevModifierShift},
+		{evdevKeyLeftCtrl, evdevModifierCtrl},
+		{evdevKeyRightCtrl, evdevModifierCtrl},
+		{evdevKeyLeftAlt, evdevModifierAlt},
+		{evdevKeyRightAlt, evdevModifierAlt},
+		{evdevKeyLeftMeta, evdevModifierCmd},
+		{evdevKeyRightMeta, evdevModifierCmd},
+	}
+
+	for _, file := range capture.files {
+		fd := C.int(file.Fd())
+
+		for _, mk := range modifierKeys {
+			if C.neru_evdev_key_down(fd, C.uint(mk.code)) != 0 {
+				state.update(mk.modifier, true)
+			}
+		}
+	}
+
+	return state
+}
+
 func (et *EventTap) runWaylandEvdev() bool {
 	capture, err := newWaylandEvdevCapture(et.logger)
 	if err != nil {
@@ -384,7 +422,8 @@ func (et *EventTap) runWaylandEvdev() bool {
 	}
 
 	state := waylandEvdevKeyState{
-		pressed: make(map[uint16]bool),
+		pressed:   make(map[uint16]bool),
+		modifiers: evdevModifierState{linuxModifierState: queryEvdevModifierState(capture)},
 	}
 
 	for {
@@ -415,8 +454,20 @@ func (et *EventTap) handleWaylandEvdevEvent(
 		}
 
 		isDown := event.value == evdevValuePress
-		state.trackKey(event.code, isDown)
-		state.modifiers.update(modifier, isDown)
+
+		if isDown {
+			state.trackKey(event.code, true)
+			state.modifiers.update(modifier, true)
+		} else if state.pressed[event.code] {
+			state.trackKey(event.code, false)
+			state.modifiers.update(modifier, false)
+		} else {
+			// Release without a matching press (press happened before
+			// fd was opened). Don't decrement — the count was never
+			// incremented for this key, and doing so would drive it
+			// negative, causing allZero() to return true prematurely.
+			return
+		}
 
 		if et.consumeSyntheticModifierEvent(modifier, isDown) {
 			return

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -422,8 +422,15 @@ func (et *EventTap) handleWaylandEvdevEvent(
 			return
 		}
 
-		if et.stickyToggleEnabled() {
+		if et.stickyToggleEnabled() && et.stickyDetectionArmed() {
 			et.dispatchKey(linuxModifierToggleEvent(modifier, isDown))
+		}
+
+		// Re-arm detection when the modifier state reaches a clean slate,
+		// matching macOS behavior where initial held-modifier releases from
+		// an activation chord are not interpreted as sticky toggles.
+		if !isDown && !et.stickyDetectionArmed() && state.modifiers.allZero() {
+			et.stickyArmDetection()
 		}
 
 		return

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -325,7 +325,10 @@ func (capture *waylandEvdevCapture) modifierKeysHeld() bool {
 // devices. Keys that are physically held are also recorded in pressed so that
 // the event-loop press handler can avoid double-counting when the
 // corresponding evdev press event is processed from the buffer.
-func queryEvdevModifierState(capture *waylandEvdevCapture, pressed map[uint16]bool) linuxModifierState {
+func queryEvdevModifierState(
+	capture *waylandEvdevCapture,
+	pressed map[uint16]bool,
+) linuxModifierState {
 	if capture == nil {
 		return linuxModifierState{}
 	}
@@ -426,8 +429,10 @@ func (et *EventTap) runWaylandEvdev() bool {
 
 	pressed := make(map[uint16]bool)
 	state := waylandEvdevKeyState{
-		pressed:   pressed,
-		modifiers: evdevModifierState{linuxModifierState: queryEvdevModifierState(capture, pressed)},
+		pressed: pressed,
+		modifiers: evdevModifierState{
+			linuxModifierState: queryEvdevModifierState(capture, pressed),
+		},
 	}
 
 	for {

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -455,13 +455,14 @@ func (et *EventTap) handleWaylandEvdevEvent(
 
 		isDown := event.value == evdevValuePress
 
-		if isDown {
+		switch {
+		case isDown:
 			state.trackKey(event.code, true)
 			state.modifiers.update(modifier, true)
-		} else if state.pressed[event.code] {
+		case state.pressed[event.code]:
 			state.trackKey(event.code, false)
 			state.modifiers.update(modifier, false)
-		} else {
+		default:
 			// Release without a matching press (press happened before
 			// fd was opened). Don't decrement — the count was never
 			// incremented for this key, and doing so would drive it

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
@@ -247,6 +247,12 @@ func (s *evdevModifierState) update(modifier string, isDown bool) {
 	}
 }
 
+// allZero reports whether all modifier reference counts are zero, meaning no
+// physical modifier key is logically held.
+func (s *evdevModifierState) allZero() bool {
+	return s.shift <= 0 && s.ctrl <= 0 && s.alt <= 0 && s.cmd <= 0
+}
+
 func (s *evdevModifierState) prefix() string {
 	if s == nil {
 		return ""

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
@@ -223,34 +223,7 @@ var evdevKeyNames = map[uint16]string{
 }
 
 type evdevModifierState struct {
-	shift int
-	ctrl  int
-	alt   int
-	cmd   int
-}
-
-func (s *evdevModifierState) update(modifier string, isDown bool) {
-	delta := 1
-	if !isDown {
-		delta = -1
-	}
-
-	switch modifier {
-	case evdevModifierShift:
-		s.shift += delta
-	case evdevModifierCtrl:
-		s.ctrl += delta
-	case evdevModifierAlt:
-		s.alt += delta
-	case evdevModifierCmd:
-		s.cmd += delta
-	}
-}
-
-// allZero reports whether all modifier reference counts are zero, meaning no
-// physical modifier key is logically held.
-func (s *evdevModifierState) allZero() bool {
-	return s.shift <= 0 && s.ctrl <= 0 && s.alt <= 0 && s.cmd <= 0
+	linuxModifierState
 }
 
 func (s *evdevModifierState) prefix() string {

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-var asyncTimeout = time.Second
+const asyncTimeout = time.Second
 
 func TestEvdevModifierName(t *testing.T) {
 	t.Parallel()

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
@@ -3,7 +3,12 @@
 //nolint:testpackage // These tests validate unexported evdev translation helpers directly.
 package eventtap
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+var asyncTimeout = time.Second
 
 func TestEvdevModifierName(t *testing.T) {
 	t.Parallel()
@@ -70,10 +75,10 @@ func TestEvdevModifierStatePrefix(t *testing.T) {
 func TestHandleWaylandEvdevEvent_IgnoresRepeatWithoutPress(t *testing.T) {
 	t.Parallel()
 
-	var got []string
+	keyCh := make(chan string, 1)
 
 	eventTap := NewEventTap(func(key string) {
-		got = append(got, key)
+		keyCh <- key
 	}, nil)
 
 	state := waylandEvdevKeyState{
@@ -86,18 +91,20 @@ func TestHandleWaylandEvdevEvent_IgnoresRepeatWithoutPress(t *testing.T) {
 		value:     evdevValueRepeat,
 	})
 
-	if len(got) != 0 {
-		t.Fatalf("got keys %v, want none", got)
+	select {
+	case <-keyCh:
+		t.Fatal("expected no events, got one")
+	case <-time.After(asyncTimeout):
 	}
 }
 
 func TestHandleWaylandEvdevEvent_AllowsRepeatAfterPress(t *testing.T) {
 	t.Parallel()
 
-	var got []string
+	keyCh := make(chan string, 2)
 
 	eventTap := NewEventTap(func(key string) {
-		got = append(got, key)
+		keyCh <- key
 	}, nil)
 
 	state := waylandEvdevKeyState{
@@ -115,7 +122,10 @@ func TestHandleWaylandEvdevEvent_AllowsRepeatAfterPress(t *testing.T) {
 		value:     evdevValueRepeat,
 	})
 
-	if len(got) != 2 || got[0] != "u" || got[1] != "u" {
-		t.Fatalf("got keys %v, want [u u]", got)
+	got1 := <-keyCh
+	got2 := <-keyCh
+
+	if got1 != "u" || got2 != "u" {
+		t.Fatalf("got keys [%s %s], want [u u]", got1, got2)
 	}
 }

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
@@ -80,6 +80,7 @@ func TestHandleWaylandEvdevEvent_IgnoresRepeatWithoutPress(t *testing.T) {
 	eventTap := NewEventTap(func(key string) {
 		keyCh <- key
 	}, nil)
+	t.Cleanup(func() { eventTap.Destroy() })
 
 	state := waylandEvdevKeyState{
 		pressed: make(map[uint16]bool),
@@ -106,6 +107,7 @@ func TestHandleWaylandEvdevEvent_AllowsRepeatAfterPress(t *testing.T) {
 	eventTap := NewEventTap(func(key string) {
 		keyCh <- key
 	}, nil)
+	t.Cleanup(func() { eventTap.Destroy() })
 
 	state := waylandEvdevKeyState{
 		pressed: make(map[uint16]bool),

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
@@ -124,8 +124,19 @@ func TestHandleWaylandEvdevEvent_AllowsRepeatAfterPress(t *testing.T) {
 		value:     evdevValueRepeat,
 	})
 
-	got1 := <-keyCh
-	got2 := <-keyCh
+	var got1, got2 string
+
+	select {
+	case got1 = <-keyCh:
+	case <-time.After(asyncTimeout):
+		t.Fatal("timeout waiting for first key event")
+	}
+
+	select {
+	case got2 = <-keyCh:
+	case <-time.After(asyncTimeout):
+		t.Fatal("timeout waiting for second key event")
+	}
 
 	if got1 != "u" || got2 != "u" {
 		t.Fatalf("got keys [%s %s], want [u u]", got1, got2)

--- a/internal/core/infra/eventtap/eventtap_linux_x11.go
+++ b/internal/core/infra/eventtap/eventtap_linux_x11.go
@@ -22,6 +22,35 @@ const (
 	x11KeyBufferSize   = 64
 )
 
+type x11ModifierState struct {
+	shift int
+	ctrl  int
+	alt   int
+	cmd   int
+}
+
+func (s *x11ModifierState) update(modifier string, isDown bool) {
+	delta := 1
+	if !isDown {
+		delta = -1
+	}
+
+	switch modifier {
+	case evdevModifierShift:
+		s.shift += delta
+	case evdevModifierCtrl:
+		s.ctrl += delta
+	case evdevModifierAlt:
+		s.alt += delta
+	case evdevModifierCmd:
+		s.cmd += delta
+	}
+}
+
+func (s *x11ModifierState) allZero() bool {
+	return s.shift <= 0 && s.ctrl <= 0 && s.alt <= 0 && s.cmd <= 0
+}
+
 func (et *EventTap) runX11() {
 	defer close(et.doneCh)
 
@@ -47,6 +76,14 @@ func (et *EventTap) runX11() {
 		return
 	}
 	defer C.neru_eventtap_ungrab_keyboard(display) //nolint:nlreturn
+
+	// Track held modifier state for detection arming. Starts at zero because
+	// the grab captures the keyboard from scratch; any modifier that was
+	// pressed before the grab will produce a KeyRelease first (without a
+	// matching KeyPress), causing the count to go transiently negative.
+	// allZero() handles this with <= 0 checks, and the evdev path mitigates
+	// the same issue by polling modifierKeysHeld() before grabbing.
+	var modState x11ModifierState
 
 	for {
 		select {
@@ -80,12 +117,20 @@ func (et *EventTap) runX11() {
 
 		if modifier := x11ModifierName(keysym); modifier != "" {
 			isDown := eventType == C.KeyPress
+			modState.update(modifier, isDown)
+
 			if et.consumeSyntheticModifierEvent(modifier, isDown) {
 				continue
 			}
 
-			if et.stickyToggleEnabled() {
+			if et.stickyToggleEnabled() && et.stickyDetectionArmed() {
 				et.dispatchKey(linuxModifierToggleEvent(modifier, isDown))
+			}
+
+			// Re-arm when the modifier state reaches a clean slate, so
+			// activation-chord releases are not interpreted as sticky toggles.
+			if !isDown && !et.stickyDetectionArmed() && modState.allZero() {
+				et.stickyArmDetection()
 			}
 
 			continue

--- a/internal/core/infra/eventtap/eventtap_linux_x11.go
+++ b/internal/core/infra/eventtap/eventtap_linux_x11.go
@@ -22,35 +22,6 @@ const (
 	x11KeyBufferSize   = 64
 )
 
-type x11ModifierState struct {
-	shift int
-	ctrl  int
-	alt   int
-	cmd   int
-}
-
-func (s *x11ModifierState) update(modifier string, isDown bool) {
-	delta := 1
-	if !isDown {
-		delta = -1
-	}
-
-	switch modifier {
-	case evdevModifierShift:
-		s.shift += delta
-	case evdevModifierCtrl:
-		s.ctrl += delta
-	case evdevModifierAlt:
-		s.alt += delta
-	case evdevModifierCmd:
-		s.cmd += delta
-	}
-}
-
-func (s *x11ModifierState) allZero() bool {
-	return s.shift <= 0 && s.ctrl <= 0 && s.alt <= 0 && s.cmd <= 0
-}
-
 func (et *EventTap) runX11() {
 	defer close(et.doneCh)
 
@@ -83,7 +54,7 @@ func (et *EventTap) runX11() {
 	// matching KeyPress), causing the count to go transiently negative.
 	// allZero() handles this with <= 0 checks, and the evdev path mitigates
 	// the same issue by polling modifierKeysHeld() before grabbing.
-	var modState x11ModifierState
+	var modState linuxModifierState
 
 	for {
 		select {

--- a/internal/core/infra/eventtap/eventtap_linux_x11.go
+++ b/internal/core/infra/eventtap/eventtap_linux_x11.go
@@ -20,6 +20,7 @@ import (
 const (
 	x11PollingInterval = 10 * time.Millisecond
 	x11KeyBufferSize   = 64
+	x11BitsPerByte     = 8
 )
 
 // x11QueryModifierState queries the X11 server for the current keyboard
@@ -31,7 +32,7 @@ func x11QueryModifierState(display *C.Display) linuxModifierState {
 	var state linuxModifierState
 
 	var keymap [32]C.char
-	C.XQueryKeymap(display, &keymap[0])
+	C.XQueryKeymap(display, &keymap[0]) //nolint:nlreturn
 
 	// Map X11 modifier keysyms → our canonical modifier names.
 	type modifierKeysym struct {
@@ -51,15 +52,15 @@ func x11QueryModifierState(display *C.Display) linuxModifierState {
 		{C.XK_Meta_R, evdevModifierCmd},
 	}
 
-	for _, mk := range modifierKeysyms {
-		keycode := C.XKeysymToKeycode(display, mk.keysym)
+	for _, modKey := range modifierKeysyms {
+		keycode := C.XKeysymToKeycode(display, modKey.keysym) //nolint:nlreturn
 		if keycode == 0 {
 			continue
 		}
-		idx := int(keycode) / 8
-		bit := int(keycode) % 8
+		idx := int(keycode) / x11BitsPerByte
+		bit := int(keycode) % x11BitsPerByte
 		if idx < 32 && (keymap[idx]>>uint(bit))&1 != 0 {
-			state.update(mk.modifier, true)
+			state.update(modKey.modifier, true)
 		}
 	}
 

--- a/internal/core/infra/eventtap/eventtap_linux_x11.go
+++ b/internal/core/infra/eventtap/eventtap_linux_x11.go
@@ -22,6 +22,50 @@ const (
 	x11KeyBufferSize   = 64
 )
 
+// x11QueryModifierState queries the X11 server for the current keyboard
+// state and returns a linuxModifierState counting any held modifier keys.
+// This avoids premature detection arming when modifiers were held at grab
+// time — their initial KeyRelease events drive counts from positive toward
+// zero rather than from zero into negative territory.
+func x11QueryModifierState(display *C.Display) linuxModifierState {
+	var state linuxModifierState
+
+	var keymap [32]C.char
+	C.XQueryKeymap(display, &keymap[0])
+
+	// Map X11 modifier keysyms → our canonical modifier names.
+	type modifierKeysym struct {
+		keysym   C.KeySym
+		modifier string
+	}
+	modifierKeysyms := []modifierKeysym{
+		{C.XK_Shift_L, evdevModifierShift},
+		{C.XK_Shift_R, evdevModifierShift},
+		{C.XK_Control_L, evdevModifierCtrl},
+		{C.XK_Control_R, evdevModifierCtrl},
+		{C.XK_Alt_L, evdevModifierAlt},
+		{C.XK_Alt_R, evdevModifierAlt},
+		{C.XK_Super_L, evdevModifierCmd},
+		{C.XK_Super_R, evdevModifierCmd},
+		{C.XK_Meta_L, evdevModifierCmd},
+		{C.XK_Meta_R, evdevModifierCmd},
+	}
+
+	for _, mk := range modifierKeysyms {
+		keycode := C.XKeysymToKeycode(display, mk.keysym)
+		if keycode == 0 {
+			continue
+		}
+		idx := int(keycode) / 8
+		bit := int(keycode) % 8
+		if idx < 32 && (keymap[idx]>>uint(bit))&1 != 0 {
+			state.update(mk.modifier, true)
+		}
+	}
+
+	return state
+}
+
 func (et *EventTap) runX11() {
 	defer close(et.doneCh)
 
@@ -48,13 +92,12 @@ func (et *EventTap) runX11() {
 	}
 	defer C.neru_eventtap_ungrab_keyboard(display) //nolint:nlreturn
 
-	// Track held modifier state for detection arming. Starts at zero because
-	// the grab captures the keyboard from scratch; any modifier that was
-	// pressed before the grab will produce a KeyRelease first (without a
-	// matching KeyPress), causing the count to go transiently negative.
-	// allZero() handles this with <= 0 checks, and the evdev path mitigates
-	// the same issue by polling modifierKeysHeld() before grabbing.
-	var modState linuxModifierState
+	// Query the actual keyboard state after the grab so that modifiers
+	// held at grab time are counted in modState. Without this, initial
+	// KeyRelease events would drive counts negative, and allZero() would
+	// return true prematurely when only some of the held modifiers have
+	// been released — arming detection while others are still held.
+	modState := x11QueryModifierState(display)
 
 	for {
 		select {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR improve sticky modifier detection to be similar to our darwin port, and also fixes a deadlock on mode exit.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #925 

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A