### PR TITLE
fix(linux,wayland): send 1-notch scroll events to prevent clipping

### DIFF
--- a/internal/core/infra/accessibility/element_linux.go
+++ b/internal/core/infra/accessibility/element_linux.go
@@ -424,91 +424,66 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 	}
 
 	if currentLinuxBackend() == linuxBackendWayland {
-		// Scale factor: similar to X11 backend's scaling.
-		// Each uinput event scrolls ~1 line, so we scale delta to
-		// get number of scroll events.
-		const (
-			scrollScale     = 30
-			maxScrollEvents = 50
-		)
+		// Scale factor: each uinput scroll event approximates ~1 line.
+		const scrollScale = 30
 
-		yDone, xDone := false, false
+		// maxBatchEvents caps the number of uinput events sent per
+		// write/flush to avoid overflowing the kernel evdev buffer (~8192
+		// bytes) or the Wayland socket buffer.  Each batch is kept small so
+		// the compositor and client can process events incrementally.
+		const maxBatchEvents = 50
 
-		if deltaY != 0 {
-			numEvents := abs(deltaY) / scrollScale
-			if numEvents == 0 {
-				numEvents = 1
+		sendScaledScroll := func(axis int, delta int) int {
+			if delta == 0 {
+				return 0
 			}
 
-			if numEvents > maxScrollEvents {
-				numEvents = maxScrollEvents
+			totalNotches := abs(delta) / scrollScale
+			if totalNotches == 0 {
+				totalNotches = 1
 			}
 
-			axis := 0
+			remainingNotches := totalNotches
+			batch := make([]int, 0, maxBatchEvents)
 
 			value := 1
-			if deltaY < 0 {
+			if delta < 0 {
 				value = -1
 			}
 
-			err := func() error {
-				for range numEvents {
-					err := eventtap.ScrollDeviceScroll(axis, value)
-					if err != nil {
-						return err
-					}
-				}
+			for remainingNotches > 0 {
+				batch = append(batch, value)
+				remainingNotches--
 
-				return nil
-			}()
-			if err == nil {
-				yDone = true
+				if len(batch) >= maxBatchEvents || remainingNotches == 0 {
+					err := eventtap.ScrollDeviceScrollBatch(axis, batch)
+					if err != nil {
+						// uinput unavailable — reset so the full delta is
+						// retried via wlroots virtual pointer fallback.
+						remainingNotches = totalNotches
+
+						break
+					}
+
+					batch = batch[:0]
+				}
 			}
+
+			notchesSent := totalNotches - remainingNotches
+
+			pixelsSent := notchesSent * scrollScale
+			if delta > 0 {
+				return max(delta-pixelsSent, 0)
+			}
+
+			return min(delta+pixelsSent, 0)
 		}
 
-		if deltaX != 0 {
-			numEvents := abs(deltaX) / scrollScale
-			if numEvents == 0 {
-				numEvents = 1
-			}
+		remainY := sendScaledScroll(0, deltaY)
+		remainX := sendScaledScroll(1, deltaX)
 
-			if numEvents > maxScrollEvents {
-				numEvents = maxScrollEvents
-			}
-
-			axis := 1
-
-			value := 1
-			if deltaX < 0 {
-				value = -1
-			}
-
-			err := func() error {
-				for range numEvents {
-					err := eventtap.ScrollDeviceScroll(axis, value)
-					if err != nil {
-						return err
-					}
-				}
-
-				return nil
-			}()
-			if err == nil {
-				xDone = true
-			}
-		}
-
-		if (deltaY == 0 || yDone) && (deltaX == 0 || xDone) {
+		if remainY == 0 && remainX == 0 {
 			return nil
-		}
-
-		remainX, remainY := deltaX, deltaY
-		if yDone {
-			remainY = 0
-		}
-
-		if xDone {
-			remainX = 0
 		}
 
 		return wlrootsScrollAtCursor(remainX, remainY)
@@ -558,10 +533,10 @@ func currentLinuxBackend() linuxBackend {
 	switch platform.DetectLinuxBackend() {
 	case platform.BackendX11:
 		return linuxBackendX11
-	case platform.BackendWaylandWlroots:
-		return linuxBackendWayland
-	case platform.BackendUnknown, platform.BackendWaylandGNOME,
+	case platform.BackendWaylandWlroots, platform.BackendWaylandGNOME,
 		platform.BackendWaylandKDE, platform.BackendWaylandOther:
+		return linuxBackendWayland
+	case platform.BackendUnknown:
 		return linuxBackendUnknown
 	}
 

--- a/internal/core/infra/accessibility/element_linux.go
+++ b/internal/core/infra/accessibility/element_linux.go
@@ -458,9 +458,10 @@ func ScrollAtCursor(deltaX, deltaY int) error {
 				if len(batch) >= maxBatchEvents || remainingNotches == 0 {
 					err := eventtap.ScrollDeviceScrollBatch(axis, batch)
 					if err != nil {
-						// uinput unavailable — reset so the full delta is
-						// retried via wlroots virtual pointer fallback.
-						remainingNotches = totalNotches
+						// uinput unavailable — add back unsent notches so the
+						// remaining delta is retried via wlroots virtual pointer
+						// fallback without double-counting already-sent notches.
+						remainingNotches += len(batch)
 
 						break
 					}

--- a/internal/core/infra/accessibility/element_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/accessibility/element_linux_wayland_wlroots_cgo.go
@@ -248,15 +248,14 @@ func wlrootsMouseDownModifiers() (action.Modifiers, bool) {
 	return globalWlrootsPointerState.mouseDownModifiers, globalWlrootsPointerState.mouseDown
 }
 
-// wlrootsScrollScale and wlrootsScrollMaxEvents mirror the X11 scroll
-// scaling constants so that both backends produce comparable scroll
-// behavior from the same pixel-level delta values supplied by the
-// scroll service (e.g. ScrollStep=50, ScrollStepHalf=500,
-// ScrollStepFull=1000000).
+// wlrootsScrollScale mirrors the uinput scroll scaling constant so
+// that both backends produce comparable scroll behavior from the same
+// pixel-level delta values supplied by the scroll service
+// (e.g. ScrollStep=50, ScrollStepHalf=500, ScrollStepFull=1000000).
 const (
 	wlrootsScrollScale     = 30
 	wlrootsScrollMaxEvents = 50
-	wlrootsScrollStep      = 15 // pixels per Wayland axis event
+	wlrootsScrollStep      = 30 // pixels per notch (matches uinput scrollScale)
 )
 
 func wlrootsScrollAtCursor(deltaX, deltaY int) error {
@@ -267,74 +266,70 @@ func wlrootsScrollAtCursor(deltaX, deltaY int) error {
 		)
 	}
 
-	// Vertical scroll (axis 0).
-	// Incoming deltas are pixel-level values from the scroll service config.
-	// We scale them to a bounded number of small Wayland axis events, just
-	// like the X11 backend converts them to discrete button clicks, to
-	// avoid sending a single enormous axis event for ScrollStepFull.
 	if deltaY != 0 {
-		events := wlrootsScrollEvents(deltaY)
-
-		// Wayland axis convention: positive = scroll down.
-		// Application convention: positive deltaY = scroll up.
-		// Negate to convert between the two conventions.
-		step := -wlrootsScrollStep
-
-		discreteStep := 1
-		if deltaY < 0 {
-			step = wlrootsScrollStep
-			discreteStep = -1
-		}
-
-		for range events {
-			err := linux.WlrootsScroll(0, step, discreteStep)
-			if err != nil {
-				return err
-			}
+		err := wlrootsScrollAxis(0, deltaY)
+		if err != nil {
+			return err
 		}
 	}
 
-	// Horizontal scroll (axis 1).
-	// Wayland axis convention: positive = scroll right.
-	// Application convention: positive deltaX = scroll right.
-	// No negation needed.
 	if deltaX != 0 {
-		events := wlrootsScrollEvents(deltaX)
-
-		step := wlrootsScrollStep
-
-		discreteStep := 1
-		if deltaX < 0 {
-			step = -wlrootsScrollStep
-			discreteStep = -1
-		}
-
-		for range events {
-			err := linux.WlrootsScroll(1, step, discreteStep)
-			if err != nil {
-				return err
-			}
+		err := wlrootsScrollAxis(1, deltaX)
+		if err != nil {
+			return err
 		}
 	}
 
 	return nil
 }
 
-// wlrootsScrollEvents converts a raw pixel delta to a bounded number of
-// scroll events, matching the X11 backend's scaling logic.
-func wlrootsScrollEvents(delta int) int {
+// wlrootsScrollAxis sends Wayland axis events for one axis.
+// Each event carries 1 notch (axis_discrete=±1, axis_value120=±120) to
+// match what a physical mouse wheel produces — no toolkit clipping.
+// Events are sent in batches of wlrootsScrollMaxEvents to avoid flooding
+// the compositor socket.
+//
+// Wayland axis convention: positive = scroll down (axis 0) / right (axis 1).
+// Application  convention: positive delta = scroll up (axis 0) / right (axis 1).
+// Vertical axis sign is negated to convert between the two.
+func wlrootsScrollAxis(axis int, delta int) error {
+	totalNotches := abs(delta) / wlrootsScrollScale
+	if totalNotches == 0 {
+		totalNotches = 1
+	}
+
+	negate := axis == 0
+
+	step := wlrootsScrollStep
+	if negate {
+		step = -step
+	}
+
+	disc := 1
 	if delta < 0 {
-		delta = -delta
+		step = -step
+		disc = -disc
 	}
 
-	events := delta / wlrootsScrollScale
-	if events == 0 {
-		events = 1
+	deltas := make([]int, 0, wlrootsScrollMaxEvents)
+	discretes := make([]int, 0, wlrootsScrollMaxEvents)
+	remaining := totalNotches
+
+	for remaining > 0 {
+		deltas = append(deltas, step)
+		discretes = append(discretes, disc)
+		remaining--
+
+		if len(deltas) >= wlrootsScrollMaxEvents || remaining == 0 {
+			err := linux.WlrootsScrollBatch(axis, deltas, discretes)
+			if err != nil {
+				return err
+			}
+
+			deltas = deltas[:0]
+			discretes = discretes[:0]
+		}
 	}
 
-	if events > wlrootsScrollMaxEvents {
-		events = wlrootsScrollMaxEvents
-	}
-
-	return events
+	return nil
 }

--- a/internal/core/infra/accessibility/element_linux_x11_cgo.go
+++ b/internal/core/infra/accessibility/element_linux_x11_cgo.go
@@ -162,9 +162,8 @@ func x11ScrollAtCursor(deltaX, deltaY int) error {
 	// X11 scrolling is simulated via discrete button clicks (4, 5, 6, 7).
 	// Incoming deltas are pixel-level values from the scroll service config
 	// (e.g. ScrollStep=50, ScrollStepHalf=500, ScrollStepFull=1000000).
-	// We scale them to a reasonable number of discrete clicks and cap the
-	// maximum to avoid flooding X11 with tens of thousands of button events
-	// when ScrollStepFull (scroll-to-end) sends very large deltas.
+	// We scale them to a capped number of clicks to avoid flooding X11
+	// with tens of thousands of button events on large scrolls.
 	const (
 		scale     = 30
 		maxClicks = 50

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unsafe"
 
 	"go.uber.org/zap"
 
@@ -612,10 +611,15 @@ func ScrollDeviceScrollBatch(axis int, values []int) error {
 		return err
 	}
 
+	cValues := make([]C.int, len(values))
+	for i, v := range values {
+		cValues[i] = C.int(v)
+	}
+
 	if C.neru_uinput_scroll_batch(
 		C.int(ufd),
 		C.int(axis),
-		(*C.int)(unsafe.Pointer(&values[0])),
+		&cValues[0],
 		C.int(len(values)),
 	) == 0 { //nolint:lll
 		return fmt.Errorf("%w", errUinputScrollSend)

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"go.uber.org/zap"
 
@@ -594,6 +595,29 @@ func ScrollDeviceScroll(axis, value int) error {
 		return err
 	}
 	if C.neru_uinput_scroll(C.int(fd), C.int(axis), C.int(value)) == 0 {
+		return fmt.Errorf("%w", errUinputScrollSend)
+	}
+
+	return nil
+}
+
+// ScrollDeviceScrollBatch sends multiple scroll events in a single write.
+func ScrollDeviceScrollBatch(axis int, values []int) error {
+	if len(values) == 0 {
+		return nil
+	}
+
+	ufd, err := getUinputScrollFd()
+	if err != nil {
+		return err
+	}
+
+	if C.neru_uinput_scroll_batch(
+		C.int(ufd),
+		C.int(axis),
+		(*C.int)(unsafe.Pointer(&values[0])),
+		C.int(len(values)),
+	) == 0 { //nolint:lll
 		return fmt.Errorf("%w", errUinputScrollSend)
 	}
 

--- a/internal/core/infra/platform/linux/evdev.c
+++ b/internal/core/infra/platform/linux/evdev.c
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include <linux/input.h>
 #include <linux/uinput.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
@@ -124,4 +125,42 @@ int neru_uinput_scroll(int fd, int axis, int value) {
 	ssize_t w3 = write(fd, &ev, sizeof(ev));
 
 	return (w1 == sizeof(ev) && w2 == sizeof(ev) && w3 == sizeof(ev)) ? 1 : 0;
+}
+
+int neru_uinput_scroll_batch(int fd, int axis, int *values, int count) {
+	if (fd < 0 || !values || count <= 0)
+		return 0;
+
+	size_t event_size = sizeof(struct input_event);
+	size_t total = (size_t)count * 3 * event_size;
+	struct input_event *events = (struct input_event *)malloc(total);
+	if (!events)
+		return 0;
+
+	int rel_code = (axis == 0) ? REL_WHEEL : REL_HWHEEL;
+	int rel_hi_code = (axis == 0) ? REL_WHEEL_HI_RES : REL_HWHEEL_HI_RES;
+
+	for (int i = 0; i < count; i++) {
+		int base = i * 3;
+		int v = values[i];
+
+		memset(&events[base], 0, event_size);
+		events[base].type = EV_REL;
+		events[base].code = rel_hi_code;
+		events[base].value = v * 120;
+
+		memset(&events[base + 1], 0, event_size);
+		events[base + 1].type = EV_REL;
+		events[base + 1].code = rel_code;
+		events[base + 1].value = v;
+
+		memset(&events[base + 2], 0, event_size);
+		events[base + 2].type = EV_SYN;
+		events[base + 2].code = SYN_REPORT;
+		events[base + 2].value = 0;
+	}
+
+	ssize_t written = write(fd, events, total);
+	free(events);
+	return (written == (ssize_t)total) ? 1 : 0;
 }

--- a/internal/core/infra/platform/linux/evdev.h
+++ b/internal/core/infra/platform/linux/evdev.h
@@ -13,5 +13,6 @@ int neru_evdev_get_bustype(int fd);
 ssize_t neru_evdev_read_event(int fd, struct input_event *event);
 int neru_uinput_create_scroll(int *out_fd);
 int neru_uinput_scroll(int fd, int axis, int value);
+int neru_uinput_scroll_batch(int fd, int axis, int *values, int count);
 
 #endif /* EVDEV_H */

--- a/internal/core/infra/platform/linux/system_linux_wayland.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland.go
@@ -43,6 +43,12 @@ func WlrootsScroll(axis, delta, discrete int) error {
 	return wlrootsScroll(axis, delta, discrete)
 }
 
+// WlrootsScrollBatch sends multiple scroll events in a single flush.
+// deltas and discretes must have the same length.
+func WlrootsScrollBatch(axis int, deltas, discretes []int) error {
+	return wlrootsScrollBatch(axis, deltas, discretes)
+}
+
 // WlrootsModifierEvent presses or releases a virtual keyboard modifier.
 func WlrootsModifierEvent(modifier string, isDown bool) error {
 	return globalWlrootsModifierDispatcher.event(modifier, isDown)

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -377,7 +377,11 @@ func wlrootsScroll(axis, delta, discrete int) error {
 	return nil
 }
 
-func wlrootsModifierEvent(modifier string, isDown bool) error {
+func wlrootsScrollBatch(axis int, deltas, discretes []int) error {
+	if len(deltas) == 0 {
+		return nil
+	}
+
 	err := ensureWlrootsState()
 	if err != nil {
 		return err
@@ -387,13 +391,32 @@ func wlrootsModifierEvent(modifier string, isDown bool) error {
 	client := globalWlrootsState.client
 	defer globalWlrootsState.mu.Unlock()
 
-	if C.neru_wlr_has_virtual_keyboard(client) == 0 { //nolint:nlreturn
+	res := C.neru_wlr_scroll_batch(
+		client,
+		C.int(axis),
+		(*C.int)(unsafe.Pointer(&deltas[0])),
+		(*C.int)(unsafe.Pointer(&discretes[0])),
+		C.int(len(deltas)), //nolint:nlreturn
+	)
+	if res == 0 {
 		return derrors.New(
 			derrors.CodeActionFailed,
-			"Wayland compositor does not support zwp_virtual_keyboard_manager_v1 protocol; "+
-				"this protocol is required for sticky modifier key injection on Wayland",
+			"failed to perform wlroots batch scroll",
 		)
 	}
+
+	return nil
+}
+
+func wlrootsModifierEvent(modifier string, isDown bool) error {
+	err := ensureWlrootsState()
+	if err != nil {
+		return err
+	}
+
+	globalWlrootsState.mu.Lock()
+	client := globalWlrootsState.client
+	defer globalWlrootsState.mu.Unlock()
 
 	cModifier := C.CString(modifier)
 	defer C.free(unsafe.Pointer(cModifier)) //nolint:nlreturn

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -391,11 +391,18 @@ func wlrootsScrollBatch(axis int, deltas, discretes []int) error {
 	client := globalWlrootsState.client
 	defer globalWlrootsState.mu.Unlock()
 
+	cDeltas := make([]C.int, len(deltas))
+	cDiscretes := make([]C.int, len(discretes))
+	for i := range deltas {
+		cDeltas[i] = C.int(deltas[i])
+		cDiscretes[i] = C.int(discretes[i])
+	}
+
 	res := C.neru_wlr_scroll_batch(
 		client,
 		C.int(axis),
-		(*C.int)(unsafe.Pointer(&deltas[0])),
-		(*C.int)(unsafe.Pointer(&discretes[0])),
+		&cDeltas[0],
+		&cDiscretes[0],
 		C.int(len(deltas)), //nolint:nlreturn
 	)
 	if res == 0 {

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -606,6 +606,26 @@ int neru_wlr_scroll(NeruWlrootsClient *c, int axis, int delta, int discrete) {
 	return 1;
 }
 
+int neru_wlr_scroll_batch(NeruWlrootsClient *c, int axis, int *deltas, int *discretes, int count) {
+	if (!c || !c->vptr || !deltas || !discretes || count <= 0)
+		return 0;
+
+	pthread_mutex_lock(&c->display_mutex);
+	zwlr_virtual_pointer_v1_axis_source(c->vptr, 0);
+	for (int i = 0; i < count; i++) {
+		zwlr_virtual_pointer_v1_axis_discrete(c->vptr, 0, (uint32_t)axis, wl_fixed_from_int(deltas[i]), discretes[i]);
+		zwlr_virtual_pointer_v1_frame(c->vptr);
+	}
+	// Ignore flush return value — the events are queued in the client
+	// output buffer and will be flushed by the dispatch loop.  Returning 0
+	// on EAGAIN (transient buffer-full) is worse than ignoring it:
+	// it would cause the entire batch to be reported as failed even though
+	// delivery is guaranteed.
+	wl_display_flush(c->display);
+	pthread_mutex_unlock(&c->display_mutex);
+	return 1;
+}
+
 static uint32_t neru_wlr_modifier_mask(NeruWlrootsClient *c, const char *modifier) {
 	if (strcmp(modifier, "shift") == 0)
 		return c->mod_shift;

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -611,8 +611,8 @@ int neru_wlr_scroll_batch(NeruWlrootsClient *c, int axis, int *deltas, int *disc
 		return 0;
 
 	pthread_mutex_lock(&c->display_mutex);
-	zwlr_virtual_pointer_v1_axis_source(c->vptr, 0);
 	for (int i = 0; i < count; i++) {
+		zwlr_virtual_pointer_v1_axis_source(c->vptr, 0);
 		zwlr_virtual_pointer_v1_axis_discrete(c->vptr, 0, (uint32_t)axis, wl_fixed_from_int(deltas[i]), discretes[i]);
 		zwlr_virtual_pointer_v1_frame(c->vptr);
 	}

--- a/internal/core/infra/platform/linux/wlroots_client.h
+++ b/internal/core/infra/platform/linux/wlroots_client.h
@@ -73,6 +73,7 @@ int neru_wlr_move_absolute(NeruWlrootsClient *c, int x, int y);
 int neru_wlr_button(NeruWlrootsClient *c, int button, int pressed);
 int neru_wlr_click(NeruWlrootsClient *c, int button);
 int neru_wlr_scroll(NeruWlrootsClient *c, int axis, int delta, int discrete);
+int neru_wlr_scroll_batch(NeruWlrootsClient *c, int axis, int *deltas, int *discretes, int count);
 int neru_wlr_modifier_event(NeruWlrootsClient *c, const char *modifier, int is_down);
 int neru_wlr_get_cursor(NeruWlrootsClient *c, int *x, int *y);
 int neru_wlr_screen_count(NeruWlrootsClient *c);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR ensure to send scroll events with exactly 1 notch each in batches of 50, looping as many times as needed, to prevent toolkit to clip it.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #924 

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A