### PR TITLE
fix: resolve fonts via ports on all platforms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Neru is a keyboard-driven navigation tool for macOS built with Go and Objective-
 - **Mode**: Navigation context (hints, grid, scroll, action)
 - **Bridge**: Objective-C macOS integration layer
 - **Adapter**: Port implementation for external systems
-- **Port**: Interface definition for system capabilities (e.g., [accessibility.go](file:///Users/kylewong/Dev/neru/internal/core/ports/accessibility.go))
+- **Port**: Interface definition for system capabilities (e.g., [accessibility.go](internal/core/ports/accessibility.go))
 
 ## Architecture & Cross-Platform
 
@@ -19,20 +19,20 @@ Neru follows a **Hexagonal Architecture (Ports and Adapters)**. All OS-specific 
 
 ### File Organization for Platforms
 
-- **Ports**: [internal/core/ports/](file:///Users/kylewong/Dev/neru/internal/core/ports/)
-- **Infrastructure**: [internal/core/infra/](file:///Users/kylewong/Dev/neru/internal/core/infra/)
-- **Platform Factory**: [internal/core/infra/platform/factory.go](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/factory.go) and build-tagged siblings.
-- **Platform Implementations**: [internal/core/infra/platform/darwin/](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/darwin/), `linux/`, `windows/`.
+- **Ports**: [internal/core/ports/](internal/core/ports/)
+- **Infrastructure**: [internal/core/infra/](internal/core/infra/)
+- **Platform Factory**: [internal/core/infra/platform/factory.go](internal/core/infra/platform/factory.go) and build-tagged siblings.
+- **Platform Implementations**: [internal/core/infra/platform/darwin/](internal/core/infra/platform/darwin/), `linux/`, `windows/`.
 
 ## AI Assistant Exploration Tips
 
 ### Finding the "Source of Truth"
 
-- **App Startup**: [app_initialization.go](file:///Users/kylewong/Dev/neru/internal/app/app_initialization.go)
-- **Navigation Logic**: [internal/app/modes/](file:///Users/kylewong/Dev/neru/internal/app/modes/)
-- **Coordinate Conversion**: [conversion.go](file:///Users/kylewong/Dev/neru/internal/ui/coordinates/conversion.go)
-- **Error Definitions**: [errors.go](file:///Users/kylewong/Dev/neru/internal/core/errors/errors.go)
-- **Native macOS Logic**: [internal/core/infra/platform/darwin/](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/darwin/)
+- **App Startup**: [app_initialization.go](internal/app/app_initialization.go)
+- **Navigation Logic**: [internal/app/modes/](internal/app/modes/)
+- **Coordinate Conversion**: [conversion.go](internal/ui/coordinates/conversion.go)
+- **Error Definitions**: [errors.go](internal/core/errors/errors.go)
+- **Native macOS Logic**: [internal/core/infra/platform/darwin/](internal/core/infra/platform/darwin/)
 
 ### Contextual Shortcuts
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -94,7 +94,7 @@ It is intentionally high-level. For the contributor playbook, see
 
 The main architecture-level source of truth for platform expectations is:
 
-- [profile.go](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/profile.go)
+- [profile.go](../internal/core/infra/platform/profile.go)
 
 It describes:
 
@@ -197,25 +197,25 @@ To understand how Neru works, follow the path of an event from the OS to the use
 
 ### 1. Entry Points
 
-- [main_darwin.go](file:///Users/kylewong/Dev/neru/cmd/neru/main_darwin.go): Bootstraps the application, locking the main thread for Cocoa.
-- [root.go](file:///Users/kylewong/Dev/neru/internal/cli/root.go): The Cobra root command for the CLI.
+- [main_darwin.go](../cmd/neru/main_darwin.go): Bootstraps the application, locking the main thread for Cocoa.
+- [root.go](../internal/cli/root.go): The Cobra root command for the CLI.
 
 ### 2. Application Wiring
 
-- [app_initialization.go](file:///Users/kylewong/Dev/neru/internal/app/app_initialization.go): Orchestrates the startup phases.
-- [app_initialization_steps.go](file:///Users/kylewong/Dev/neru/internal/app/app_initialization_steps.go): Detailed steps for initializing infrastructure, services, and UI.
+- [app_initialization.go](../internal/app/app_initialization.go): Orchestrates the startup phases.
+- [app_initialization_steps.go](../internal/app/app_initialization_steps.go): Detailed steps for initializing infrastructure, services, and UI.
 
 ### 3. The Platform Factory
 
-The [factory.go](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/factory.go) and its build-tagged siblings (e.g., [factory_darwin.go](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/factory_darwin.go)) are the gatekeepers for OS-specific code. They return the correct `ports.SystemPort` implementation without polluting shared code with OS-specific imports.
+The [factory.go](../internal/core/infra/platform/factory.go) and its build-tagged siblings (e.g., [factory_darwin.go](../internal/core/infra/platform/factory_darwin.go)) are the gatekeepers for OS-specific code. They return the correct `ports.SystemPort` implementation without polluting shared code with OS-specific imports.
 
 ### 4. Input Processing Flow
 
-1. **OS Level**: [eventtap_darwin.m](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/darwin/eventtap_darwin.m) captures low-level keyboard events.
-2. **Infrastructure Level**: [adapter.go](file:///Users/kylewong/Dev/neru/internal/core/infra/eventtap/adapter.go) receives events and dispatches them to the app.
-3. **Application Level**: [handler.go](file:///Users/kylewong/Dev/neru/internal/app/modes/handler.go) receives the key and routes it to the active [Mode](file:///Users/kylewong/Dev/neru/internal/app/modes/base.go).
-4. **Service Level**: The mode calls into services like [hint_service.go](file:///Users/kylewong/Dev/neru/internal/app/services/hint_service.go) to perform business logic.
-5. **Keyboard Layout Changes**: On macOS, Carbon global hotkeys are registered with raw keycodes. When the user switches keyboard layout at runtime (e.g., US → Dvorak → Colemak), the [layout_change_darwin.go](file:///Users/kylewong/Dev/neru/internal/app/layout_change_darwin.go) handler unregisters all existing hotkeys and re-registers them with the new layout's keycodes. This is driven by a second callback slot in [keymap_darwin.m](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/darwin/keymap_darwin.m) (`NeruSetKeymapLayoutChangeCallback2`). On Linux and Windows, this is a no-op.
+1. **OS Level**: [eventtap_darwin.m](../internal/core/infra/platform/darwin/eventtap_darwin.m) captures low-level keyboard events.
+2. **Infrastructure Level**: [adapter.go](../internal/core/infra/eventtap/adapter.go) receives events and dispatches them to the app.
+3. **Application Level**: [handler.go](../internal/app/modes/handler.go) receives the key and routes it to the active [Mode](../internal/app/modes/base.go).
+4. **Service Level**: The mode calls into services like [hint_service.go](../internal/app/services/hint_service.go) to perform business logic.
+5. **Keyboard Layout Changes**: On macOS, Carbon global hotkeys are registered with raw keycodes. When the user switches keyboard layout at runtime (e.g., US → Dvorak → Colemak), the [layout_change_darwin.go](../internal/app/layout_change_darwin.go) handler unregisters all existing hotkeys and re-registers them with the new layout's keycodes. This is driven by a second callback slot in [keymap_darwin.m](../internal/core/infra/platform/darwin/keymap_darwin.m) (`NeruSetKeymapLayoutChangeCallback2`). On Linux and Windows, this is a no-op.
 
 ---
 
@@ -242,13 +242,13 @@ Neru uses a **global top-left (0,0) coordinate system** for all shared logic.
 
 ### macOS Coordinate Inversion
 
-macOS Cocoa APIs use a bottom-left (0,0) coordinate system where Y increases upwards. The [darwin platform adapter](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/darwin/accessibility_screen_darwin.m) is responsible for inverting the Y coordinate before passing it to shared Go code.
+macOS Cocoa APIs use a bottom-left (0,0) coordinate system where Y increases upwards. The [darwin platform adapter](../internal/core/infra/platform/darwin/accessibility_screen_darwin.m) is responsible for inverting the Y coordinate before passing it to shared Go code.
 
 ---
 
 ## Error Handling and Graceful Degradation
 
-Neru uses a custom error package [derrors](file:///Users/kylewong/Dev/neru/internal/core/errors/errors.go) for structured error handling.
+Neru uses a custom error package [derrors](../internal/core/errors/errors.go) for structured error handling.
 
 ### The `CodeNotSupported` Policy
 
@@ -317,10 +317,10 @@ graph TD
 
 ### Layer Responsibilities
 
-- **Domain (`internal/core/domain`)**: Pure business logic and entities (e.g., [hint.go](file:///Users/kylewong/Dev/neru/internal/core/domain/hint/hint.go), [grid.go](file:///Users/kylewong/Dev/neru/internal/core/domain/grid/grid.go)). No external dependencies.
-- **Ports (`internal/core/ports`)**: Interface contracts defining system capabilities (e.g., [accessibility.go](file:///Users/kylewong/Dev/neru/internal/core/ports/accessibility.go), [overlay.go](file:///Users/kylewong/Dev/neru/internal/core/ports/overlay.go)).
-- **Application (`internal/app`)**: Orchestrates domain entities and services. Manages application lifecycle and navigation modes (e.g., [hints.go](file:///Users/kylewong/Dev/neru/internal/app/modes/hints.go)).
-- **Infrastructure (`internal/core/infra`)**: Concrete implementations of ports using platform-specific APIs (e.g., [accessibility/adapter.go](file:///Users/kylewong/Dev/neru/internal/core/infra/accessibility/adapter.go)).
+- **Domain (`internal/core/domain`)**: Pure business logic and entities (e.g., [hint.go](../internal/core/domain/hint/hint.go), [grid.go](../internal/core/domain/grid/grid.go)). No external dependencies.
+- **Ports (`internal/core/ports`)**: Interface contracts defining system capabilities (e.g., [accessibility.go](../internal/core/ports/accessibility.go), [overlay.go](../internal/core/ports/overlay.go), [font.go](../internal/core/ports/font.go)).
+- **Application (`internal/app`)**: Orchestrates domain entities and services. Manages application lifecycle and navigation modes (e.g., [hints.go](../internal/app/modes/hints.go)).
+- **Infrastructure (`internal/core/infra`)**: Concrete implementations of ports using platform-specific APIs (e.g., [accessibility/adapter.go](../internal/core/infra/accessibility/adapter.go)).
 - **UI (`internal/ui`)**: Handles coordinate transformations and abstract rendering logic.
 - **CLI (`internal/cli`)**: Handles user commands, configuration loading, and IPC communication with the daemon.
 
@@ -393,7 +393,7 @@ Neru uses a sophisticated bridge between Go and Objective-C. Native macOS classe
 
 ### IPC Controller
 
-The CLI communicates with the background daemon using Unix Domain Sockets. The [ipc_controller.go](file:///Users/kylewong/Dev/neru/internal/app/ipc_controller.go) manages this communication, routing commands like `neru hints` or `neru stop` to the running application instance.
+The CLI communicates with the background daemon using Unix Domain Sockets. The [ipc_controller.go](../internal/app/ipc_controller.go) manages this communication, routing commands like `neru hints` or `neru stop` to the running application instance.
 
 ---
 
@@ -418,7 +418,7 @@ Neru uses `just` for build automation.
 ## Performance Considerations
 
 1. **Event Tap Latency**: The event tap callback is kept extremely lean to prevent system-wide keyboard lag. Heavy processing is deferred to Go routines.
-2. **Accessibility Caching**: Querying the macOS Accessibility API is expensive. Neru implements intelligent caching in the [accessibility/cache.go](file:///Users/kylewong/Dev/neru/internal/core/infra/accessibility/cache.go) to minimize IPC overhead.
+2. **Accessibility Caching**: Querying the macOS Accessibility API is expensive. Neru implements intelligent caching in the [accessibility/cache.go](../internal/core/infra/accessibility/cache.go) to minimize IPC overhead.
 3. **Native Rendering**: Overlays are rendered using native Cocoa APIs for GPU-accelerated, flicker-free UI.
 
 ---

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -198,9 +198,9 @@ Use this table as the default routing guide.
 
 Examples:
 
-- X11 hotkeys belong in [manager_linux_x11.go](Users/kylewong/Dev/neru/internal/core/infra/hotkeys/manager_linux_x11.go)
-- Wayland keyboard capture belongs in [eventtap_linux_wayland.go](Users/kylewong/Dev/neru/internal/core/infra/eventtap/eventtap_linux_wayland.go)
-- shared Linux system fallbacks belong in [system_linux_common.go](Users/kylewong/Dev/neru/internal/core/infra/platform/linux/system_linux_common.go)
+- X11 hotkeys belong in [manager_linux_x11.go](../internal/core/infra/hotkeys/manager_linux_x11.go)
+- Wayland keyboard capture belongs in [eventtap_linux_wayland.go](../internal/core/infra/eventtap/eventtap_linux_wayland.go)
+- shared Linux system fallbacks belong in [system_linux_common.go](../internal/core/infra/platform/linux/system_linux_common.go)
 
 ---
 
@@ -260,7 +260,7 @@ Do not introduce additional Windows backend naming until there is a real reason.
 
 Do not decide CGO usage by OS alone.
 
-Use [profile.go](Users/kylewong/Dev/neru/internal/core/infra/platform/profile.go)
+Use [profile.go](../internal/core/infra/platform/profile.go)
 as the source of truth for the current backend plan.
 
 Current intent:
@@ -278,8 +278,8 @@ Good default instincts:
 
 If you introduce a backend that changes the build story, update:
 
-- [profile.go](Users/kylewong/Dev/neru/internal/core/infra/platform/profile.go)
-- [justfile](Users/kylewong/Dev/neru/justfile)
+- [profile.go](../internal/core/infra/platform/profile.go)
+- [justfile](../justfile)
 - this document
 
 When in doubt, make the build assumption explicit in your PR description and in
@@ -402,7 +402,7 @@ When you land platform work, update docs in the same PR.
 
 Usually that means checking these files:
 
-- [README.md](Users/kylewong/Dev/neru/README.md)
+- [README.md](../README.md)
 - [ARCHITECTURE.md](./ARCHITECTURE.md)
 - [DEVELOPMENT.md](./DEVELOPMENT.md)
 - [CONVENTIONS.md](./go/CONVENTIONS.md)

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -56,10 +56,11 @@ The guiding principles are:
 
 Before changing code, read these files first:
 
-- [internal/core/infra/platform/profile.go](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/profile.go)
-- [internal/core/ports/system.go](file:///Users/kylewong/Dev/neru/internal/core/ports/system.go)
-- [internal/core/ports/capabilities.go](file:///Users/kylewong/Dev/neru/internal/core/ports/capabilities.go)
-- [internal/core/ports/capability_presets.go](file:///Users/kylewong/Dev/neru/internal/core/ports/capability_presets.go)
+- [internal/core/infra/platform/profile.go](../internal/core/infra/platform/profile.go)
+- [internal/core/ports/system.go](../internal/core/ports/system.go)
+- [internal/core/ports/capabilities.go](../internal/core/ports/capabilities.go)
+- [internal/core/ports/capability_presets.go](../internal/core/ports/capability_presets.go)
+- [internal/core/ports/font.go](../internal/core/ports/font.go) — FontResolver port (fontconfig on Linux, NSFont on macOS)
 - [ARCHITECTURE.md](./ARCHITECTURE.md)
 - [CONVENTIONS.md](./go/CONVENTIONS.md)
 
@@ -78,7 +79,7 @@ If you are new to the codebase, this is the recommended startup path.
 
 ### Any platform
 
-1. Read [profile.go](file:///Users/kylewong/Dev/neru/internal/core/infra/platform/profile.go)
+1. Read [profile.go](../internal/core/infra/platform/profile.go)
 2. Read the relevant port in `internal/core/ports/`
 3. Find the implementation slot you expect to touch
 4. Run:
@@ -144,11 +145,11 @@ Use these suffixes:
 - `*_other.go`: non-target fallback for dispatch-style packages
 
 App-level platform dispatch also follows this pattern. For example,
-[layout_change_darwin.go](file:///Users/kylewong/Dev/neru/internal/app/layout_change_darwin.go)
+[layout_change_darwin.go](../internal/app/layout_change_darwin.go)
 re-registers Carbon hotkeys when the keyboard layout changes at runtime, while
-[layout_change_linux.go](file:///Users/kylewong/Dev/neru/internal/app/layout_change_linux.go)
+[layout_change_linux.go](../internal/app/layout_change_linux.go)
 and
-[layout_change_windows.go](file:///Users/kylewong/Dev/neru/internal/app/layout_change_windows.go)
+[layout_change_windows.go](../internal/app/layout_change_windows.go)
 are no-ops.
 
 Do not create new ad hoc platform filenames if an existing slot already exists.
@@ -197,9 +198,9 @@ Use this table as the default routing guide.
 
 Examples:
 
-- X11 hotkeys belong in [manager_linux_x11.go](/Users/kylewong/Dev/neru/internal/core/infra/hotkeys/manager_linux_x11.go)
-- Wayland keyboard capture belongs in [eventtap_linux_wayland.go](/Users/kylewong/Dev/neru/internal/core/infra/eventtap/eventtap_linux_wayland.go)
-- shared Linux system fallbacks belong in [system_linux_common.go](/Users/kylewong/Dev/neru/internal/core/infra/platform/linux/system_linux_common.go)
+- X11 hotkeys belong in [manager_linux_x11.go](Users/kylewong/Dev/neru/internal/core/infra/hotkeys/manager_linux_x11.go)
+- Wayland keyboard capture belongs in [eventtap_linux_wayland.go](Users/kylewong/Dev/neru/internal/core/infra/eventtap/eventtap_linux_wayland.go)
+- shared Linux system fallbacks belong in [system_linux_common.go](Users/kylewong/Dev/neru/internal/core/infra/platform/linux/system_linux_common.go)
 
 ---
 
@@ -259,7 +260,7 @@ Do not introduce additional Windows backend naming until there is a real reason.
 
 Do not decide CGO usage by OS alone.
 
-Use [profile.go](/Users/kylewong/Dev/neru/internal/core/infra/platform/profile.go)
+Use [profile.go](Users/kylewong/Dev/neru/internal/core/infra/platform/profile.go)
 as the source of truth for the current backend plan.
 
 Current intent:
@@ -277,8 +278,8 @@ Good default instincts:
 
 If you introduce a backend that changes the build story, update:
 
-- [profile.go](/Users/kylewong/Dev/neru/internal/core/infra/platform/profile.go)
-- [justfile](/Users/kylewong/Dev/neru/justfile)
+- [profile.go](Users/kylewong/Dev/neru/internal/core/infra/platform/profile.go)
+- [justfile](Users/kylewong/Dev/neru/justfile)
 - this document
 
 When in doubt, make the build assumption explicit in your PR description and in
@@ -299,9 +300,9 @@ Use these rules:
 
 Relevant files:
 
-- [internal/config/config.go](file:///Users/kylewong/Dev/neru/internal/config/config.go)
-- [internal/core/domain/action/modifiers.go](file:///Users/kylewong/Dev/neru/internal/core/domain/action/modifiers.go)
-- [internal/app/hotkeys.go](file:///Users/kylewong/Dev/neru/internal/app/hotkeys.go)
+- [internal/config/config.go](../internal/config/config.go)
+- [internal/core/domain/action/modifiers.go](../internal/core/domain/action/modifiers.go)
+- [internal/app/hotkeys.go](../internal/app/hotkeys.go)
 
 ---
 
@@ -313,7 +314,7 @@ Use this flow.
 
 If multiple services or app layers will need the capability:
 
-1. Add it to [internal/core/ports/system.go](file:///Users/kylewong/Dev/neru/internal/core/ports/system.go)
+1. Add it to [internal/core/ports/system.go](../internal/core/ports/system.go)
 2. Implement it in the darwin adapter
 3. Add Linux common fallback behavior in `system_linux_common.go`
 4. Add Windows fallback behavior in `system.go` under the Windows platform package
@@ -358,9 +359,9 @@ Capability reporting is part of the contributor contract, not just a user nicety
 
 When you implement or partially implement a feature, review:
 
-- [internal/core/ports/capabilities.go](file:///Users/kylewong/Dev/neru/internal/core/ports/capabilities.go)
-- [internal/core/ports/capability_presets.go](file:///Users/kylewong/Dev/neru/internal/core/ports/capability_presets.go)
-- [internal/app/ipc_info.go](file:///Users/kylewong/Dev/neru/internal/app/ipc_info.go)
+- [internal/core/ports/capabilities.go](../internal/core/ports/capabilities.go)
+- [internal/core/ports/capability_presets.go](../internal/core/ports/capability_presets.go)
+- [internal/app/ipc_info.go](../internal/app/ipc_info.go)
 
 `neru doctor` should help contributors and users understand what is actually
 available on the current platform.
@@ -401,7 +402,7 @@ When you land platform work, update docs in the same PR.
 
 Usually that means checking these files:
 
-- [README.md](/Users/kylewong/Dev/neru/README.md)
+- [README.md](Users/kylewong/Dev/neru/README.md)
 - [ARCHITECTURE.md](./ARCHITECTURE.md)
 - [DEVELOPMENT.md](./DEVELOPMENT.md)
 - [CONVENTIONS.md](./go/CONVENTIONS.md)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -599,7 +599,7 @@ The key project directories and their roles at a glance:
 | Directory                  | Role                                         |
 | -------------------------- | -------------------------------------------- |
 | `internal/core/domain/`    | Pure business logic, entities, value objects |
-| `internal/core/ports/`     | Interface contracts (Accessibility, Overlay) |
+| `internal/core/ports/`     | Interface contracts (Accessibility, Overlay, Font) |
 | `internal/core/infra/`     | Platform-specific adapter implementations    |
 | `internal/app/`            | Application orchestration, services, modes   |
 | `internal/app/components/` | Mode-specific overlay rendering              |

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -138,7 +138,9 @@ sudo apt-get install -y \
   libxinerama-dev \
   libxfixes-dev \
   libxkbcommon-dev \
-  wayland-protocols
+  libfontconfig-dev \
+  wayland-protocols \
+  fonts-dejavu-core
 ```
 
 ### Fedora
@@ -153,7 +155,9 @@ sudo dnf install -y \
   libXinerama-devel \
   libXfixes-devel \
   libxkbcommon-devel \
-  wayland-protocols-devel
+  fontconfig-devel \
+  wayland-protocols-devel \
+  dejavu-sans-fonts dejavu-serif-fonts dejavu-sans-mono-fonts
 ```
 
 ### Arch Linux
@@ -168,8 +172,17 @@ sudo pacman -S \
   libxinerama \
   libxfixes \
   libxkbcommon \
-  wayland-protocols
+  fontconfig \
+  wayland-protocols \
+  ttf-dejavu
 ```
+
+`fontconfig` is required at build time (the Linux CGo overlay links against
+it for font resolution). `fonts-dejavu-core` / `dejavu-sans-fonts` /
+`ttf-dejavu` are only recommended — Neru falls back to them when no explicit
+`font_family` is set or when fontconfig cannot match a configured name, but
+any font that covers your required glyphs (especially `❖⇧⌥⌃` for the sticky
+modifier indicator) works equally well.
 
 ---
 
@@ -368,6 +381,29 @@ Set a font explicitly in your config:
 font_family = "Your installed symbol-capable font"
 ```
 
-An empty `font_family` uses the system default, which may not have the required
-symbol coverage. A quick way to verify a candidate font is to paste `❖⇧⌥⌃` into
+When `font_family` is empty, Neru resolves a Linux-quality default via
+fontconfig: `"Sans"` / `"Sans Serif"` → `DejaVu Sans`, `"Monospace"` →
+`DejaVu Sans Mono`, `"Serif"` → `DejaVu Serif`. A user-supplied family
+that fontconfig cannot match falls back to the same defaults, so the
+indicator never falls back to a low-quality system generic.
+
+Useful fontconfig snippets for verifying what Neru will use:
+
+```bash
+# List installed families whose name contains "Inter"
+fc-list | awk -F: '{print $2}' | sort -u | grep -i inter
+
+# See which font fontconfig will actually use for a given family
+fc-match "Inter"
+
+# See the top alternates fontconfig will try, in order
+fc-match -s "Inter" | head -5
+
+# See what the generic aliases resolve to on this system
+fc-match "sans-serif"
+fc-match "monospace"
+fc-match "serif"
+```
+
+A quick way to verify a candidate font is to paste `❖⇧⌥⌃` into
 a text editor and confirm the symbols render there first.

--- a/docs/go/CONVENTIONS.md
+++ b/docs/go/CONVENTIONS.md
@@ -182,8 +182,8 @@ package platform
 ### Platform Isolation
 
 - **The One Rule**: Non-darwin-tagged code must **never** import `internal/core/infra/platform/darwin`.
-- Use **Ports** ([internal/core/ports/](file:///Users/kylewong/Dev/neru/internal/core/ports/)) to define platform-agnostic interfaces.
-- Use **Adapters** ([internal/core/infra/](file:///Users/kylewong/Dev/neru/internal/core/infra/)) to implement those interfaces for specific platforms.
+- Use **Ports** ([internal/core/ports/](../../internal/core/ports/)) to define platform-agnostic interfaces.
+- Use **Adapters** ([internal/core/infra/](../../internal/core/infra/)) to implement those interfaces for specific platforms.
 
 ### OS-Specific File Naming
 

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -21,6 +21,7 @@ import (
 	ipcadapter "github.com/y3owk1n/neru/internal/core/infra/ipc"
 	"github.com/y3owk1n/neru/internal/core/infra/platform"
 	textinputadapter "github.com/y3owk1n/neru/internal/core/infra/textinput"
+	"github.com/y3owk1n/neru/internal/core/ports"
 	"github.com/y3owk1n/neru/internal/ui"
 )
 
@@ -63,6 +64,14 @@ func initializeInfrastructure(app *App) error {
 
 	if app.textInput == nil {
 		app.textInput = textinputadapter.NewAdapter(textinputadapter.NewTextInput(logger), logger)
+	}
+
+	// Install the platform font resolver. SetFontResolver makes the
+	// resolver available globally to every call site that builds an
+	// overlay style, so they do not have to thread the port through
+	// their own signatures.
+	if resolver := platform.NewFontResolver(); resolver != nil {
+		ports.SetFontResolver(resolver)
 	}
 
 	return nil

--- a/internal/app/components/grid/overlay_darwin.go
+++ b/internal/app/components/grid/overlay_darwin.go
@@ -25,6 +25,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app/components/overlayutil"
 	"github.com/y3owk1n/neru/internal/config"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 const (
@@ -1054,7 +1055,7 @@ func (s Style) BorderColor() string {
 func BuildStyle(cfg config.GridConfig, theme config.ThemeProvider) Style {
 	style := Style{
 		fontSize:    cfg.UI.FontSize,
-		fontFamily:  cfg.UI.FontFamily,
+		fontFamily:  ports.ResolveFont(cfg.UI.FontFamily, true),
 		borderWidth: cfg.UI.BorderWidth,
 		backgroundColor: cfg.UI.BackgroundColor.ForTheme(
 			theme,

--- a/internal/app/components/grid/overlay_linux_common.go
+++ b/internal/app/components/grid/overlay_linux_common.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/config"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 const (
@@ -123,7 +124,7 @@ func BuildStyle(cfg config.GridConfig, theme config.ThemeProvider) Style {
 			cfg.UI.TextColor.ForTheme(theme, config.GridTextColorLight, config.GridTextColorDark),
 		),
 		LabelFontSize: float64(max(cfg.UI.FontSize, minFontSize)),
-		LabelFontName: cfg.UI.FontFamily,
+		LabelFontName: ports.ResolveFont(cfg.UI.FontFamily, true),
 		MatchedTextColor: parseLinuxColor(
 			cfg.UI.MatchedTextColor.ForTheme(
 				theme,

--- a/internal/app/components/hints/overlay_darwin.go
+++ b/internal/app/components/hints/overlay_darwin.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/app/components/overlayutil"
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 //export resizeHintCompletionCallback
@@ -355,7 +356,7 @@ func (o *Overlay) HideSearchInput() {
 func BuildStyle(cfg config.HintsConfig, theme config.ThemeProvider) StyleMode {
 	style := StyleMode{
 		fontSize:     cfg.UI.FontSize,
-		fontFamily:   cfg.UI.FontFamily,
+		fontFamily:   ports.ResolveFont(cfg.UI.FontFamily, true),
 		borderRadius: cfg.UI.BorderRadius,
 		paddingX:     cfg.UI.PaddingX,
 		paddingY:     cfg.UI.PaddingY,

--- a/internal/app/components/hints/overlay_linux_common.go
+++ b/internal/app/components/hints/overlay_linux_common.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 // StyleMode represents the visual styling configuration for hint overlays.
@@ -137,7 +138,7 @@ func (o *Overlay) Config() config.HintsConfig {
 func BuildStyle(cfg config.HintsConfig, theme config.ThemeProvider) StyleMode {
 	return StyleMode{
 		fontSize:     cfg.UI.FontSize,
-		fontFamily:   cfg.UI.FontFamily,
+		fontFamily:   ports.ResolveFont(cfg.UI.FontFamily, true),
 		borderRadius: cfg.UI.BorderRadius,
 		paddingX:     cfg.UI.PaddingX,
 		paddingY:     cfg.UI.PaddingY,

--- a/internal/app/components/hints/types.go
+++ b/internal/app/components/hints/types.go
@@ -4,6 +4,7 @@ import (
 	"image"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 // Hint represents a hint to be displayed on the overlay.
@@ -136,7 +137,7 @@ func (s SearchInputStyle) BorderColor() string { return s.borderColor }
 func BuildSearchInputStyle(cfg config.HintsConfig, theme config.ThemeProvider) SearchInputStyle {
 	return SearchInputStyle{
 		fontSize:     cfg.SearchInputUI.FontSize,
-		fontFamily:   cfg.SearchInputUI.FontFamily,
+		fontFamily:   ports.ResolveFont(cfg.SearchInputUI.FontFamily, false),
 		borderRadius: cfg.SearchInputUI.BorderRadius,
 		paddingX:     cfg.SearchInputUI.PaddingX,
 		paddingY:     cfg.SearchInputUI.PaddingY,

--- a/internal/app/components/modeindicator/overlay_darwin.go
+++ b/internal/app/components/modeindicator/overlay_darwin.go
@@ -19,6 +19,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app/components/overlayutil"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 const (
@@ -194,7 +195,9 @@ func (o *Overlay) DrawModeIndicator(mode string, xCoordinate, yCoordinate int) {
 
 	// Use cached style strings to avoid repeated allocations and fix use-after-free
 	cachedStyle := o.styleCache.Get(func(cached *overlayutil.CachedStyle) {
-		cached.FontFamily = unsafe.Pointer(C.CString(o.indicatorConfig.UI.FontFamily))
+		cached.FontFamily = unsafe.Pointer(
+			C.CString(ports.ResolveFont(o.indicatorConfig.UI.FontFamily, true)),
+		)
 		cached.BgColor = unsafe.Pointer(
 			C.CString(
 				modeConfig.BackgroundColor.ForThemeWithOverride(

--- a/internal/app/components/recursivegrid/overlay_darwin.go
+++ b/internal/app/components/recursivegrid/overlay_darwin.go
@@ -23,6 +23,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app/components/overlayutil"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain/recursivegrid"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 //export recursiveGridResizeCompletionCallback
@@ -607,7 +608,7 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 			config.RecursiveGridTextColorDark,
 		),
 		fontSize:        cfg.UI.FontSize,
-		fontFamily:      cfg.UI.FontFamily,
+		fontFamily:      ports.ResolveFont(cfg.UI.FontFamily, true),
 		labelBackground: cfg.UI.LabelBackground,
 		labelBackgroundColor: cfg.UI.LabelBackgroundColor.ForTheme(
 			theme,

--- a/internal/app/components/recursivegrid/overlay_linux_common.go
+++ b/internal/app/components/recursivegrid/overlay_linux_common.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 const (
@@ -135,7 +136,7 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 			),
 		),
 		LabelFontSize:   float64(max(cfg.UI.FontSize, minFontSize)),
-		LabelFontName:   cfg.UI.FontFamily,
+		LabelFontName:   ports.ResolveFont(cfg.UI.FontFamily, true),
 		LabelBackground: cfg.UI.LabelBackground,
 		LabelBackgroundColor: parseLinuxColor(
 			cfg.UI.LabelBackgroundColor.ForTheme(

--- a/internal/app/components/stickyindicator/overlay_darwin.go
+++ b/internal/app/components/stickyindicator/overlay_darwin.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/app/components/overlayutil"
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 const (
@@ -138,7 +139,9 @@ func (o *Overlay) Draw(xCoordinate, yCoordinate int, symbols string) {
 	label := o.getOrCacheLabel(symbols)
 
 	cachedStyle := o.styleCache.Get(func(cached *overlayutil.CachedStyle) {
-		cached.FontFamily = unsafe.Pointer(C.CString(o.uiConfig.FontFamily))
+		cached.FontFamily = unsafe.Pointer(
+			C.CString(ports.ResolveFont(o.uiConfig.FontFamily, false)),
+		)
 		cached.BgColor = unsafe.Pointer(
 			C.CString(
 				o.uiConfig.BackgroundColor.ForTheme(

--- a/internal/core/infra/platform/darwin/font_darwin.go
+++ b/internal/core/infra/platform/darwin/font_darwin.go
@@ -46,11 +46,13 @@ func (r *nsFontResolver) Resolve(family string, bold bool) string {
 	key := strings.ToLower(strings.TrimSpace(family))
 
 	r.mu.RLock()
+
 	if cached, ok := r.cache[key]; ok {
 		r.mu.RUnlock()
 
 		return cached
 	}
+
 	r.mu.RUnlock()
 
 	resolved := mapDarwinGenericAlias(family)
@@ -63,12 +65,16 @@ func (r *nsFontResolver) Resolve(family string, bold bool) string {
 }
 
 // mapDarwinGenericAlias translates fontconfig-style generic names (and
-// empty input) to a concrete macOS family. Case- and whitespace-
-// insensitive. Non-generic names are returned unchanged so the C layer
-// can verify them via NSFontManager.
+// empty input) to a concrete macOS family. Case-, whitespace-, and
+// separator-insensitive (spaces, hyphens, and underscores all
+// normalize to the same key). Non-generic names are returned unchanged
+// so the C layer can verify them via NSFontManager.
 func mapDarwinGenericAlias(family string) string {
-	switch strings.ToLower(strings.TrimSpace(family)) {
-	case "", "sans", "sans-serif", "sansserif":
+	normalized := strings.NewReplacer(" ", "", "-", "", "_", "").Replace(
+		strings.ToLower(strings.TrimSpace(family)),
+	)
+	switch normalized {
+	case "", "sans", "sansserif":
 		return defaultDarwinSans
 	case "serif":
 		return defaultDarwinSerif

--- a/internal/core/infra/platform/darwin/font_darwin.go
+++ b/internal/core/infra/platform/darwin/font_darwin.go
@@ -1,0 +1,80 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+const (
+	// defaultDarwinSans is the macOS baseline sans-serif family used for
+	// empty input and for generic "Sans" / "Sans Serif" aliases.
+	defaultDarwinSans = "Helvetica Neue"
+	// defaultDarwinMono is the macOS baseline monospace family.
+	defaultDarwinMono = "Menlo"
+	// defaultDarwinSerif is the macOS baseline serif family.
+	defaultDarwinSerif = "Times New Roman"
+)
+
+// NewFontResolver returns a macOS-backed ports.FontResolver. The Go-side
+// resolver maps generic aliases to known macOS families. User-supplied
+// names are returned unchanged so the existing C/Objective-C layer
+// (which already does PostScript and family lookups via NSFontManager)
+// can verify and weight-resolve them.
+func NewFontResolver() ports.FontResolver {
+	return &nsFontResolver{
+		cache: make(map[string]string),
+	}
+}
+
+// nsFontResolver implements ports.FontResolver for macOS. Generic
+// aliases are translated to concrete macOS families; everything else
+// is passed through to the C layer, which already performs the full
+// NSFont + NSFontManager resolution chain.
+type nsFontResolver struct {
+	mu    sync.RWMutex
+	cache map[string]string
+}
+
+// Resolve implements ports.FontResolver.
+func (r *nsFontResolver) Resolve(family string, bold bool) string {
+	_ = bold // weight is enforced at the C layer
+
+	key := strings.ToLower(strings.TrimSpace(family))
+
+	r.mu.RLock()
+	if cached, ok := r.cache[key]; ok {
+		r.mu.RUnlock()
+
+		return cached
+	}
+	r.mu.RUnlock()
+
+	resolved := mapDarwinGenericAlias(family)
+
+	r.mu.Lock()
+	r.cache[key] = resolved
+	r.mu.Unlock()
+
+	return resolved
+}
+
+// mapDarwinGenericAlias translates fontconfig-style generic names (and
+// empty input) to a concrete macOS family. Case- and whitespace-
+// insensitive. Non-generic names are returned unchanged so the C layer
+// can verify them via NSFontManager.
+func mapDarwinGenericAlias(family string) string {
+	switch strings.ToLower(strings.TrimSpace(family)) {
+	case "", "sans", "sans-serif", "sansserif":
+		return defaultDarwinSans
+	case "serif":
+		return defaultDarwinSerif
+	case "mono", "monospace":
+		return defaultDarwinMono
+	default:
+		return family
+	}
+}

--- a/internal/core/infra/platform/darwin/font_darwin_test.go
+++ b/internal/core/infra/platform/darwin/font_darwin_test.go
@@ -1,0 +1,70 @@
+//go:build darwin
+
+package darwin
+
+import "testing"
+
+func TestMapDarwinGenericAlias_EmptyDefaultsToSans(t *testing.T) {
+	if got := mapDarwinGenericAlias(""); got != defaultDarwinSans {
+		t.Fatalf("expected %q for empty input, got %q", defaultDarwinSans, got)
+	}
+}
+
+func TestMapDarwinGenericAlias_GenericAliases(t *testing.T) {
+	cases := map[string]string{
+		"":           defaultDarwinSans,
+		"sans":       defaultDarwinSans,
+		"Sans":       defaultDarwinSans,
+		"sans-serif": defaultDarwinSans,
+		"Sans Serif": defaultDarwinSans,
+		"SANSSERIF":  defaultDarwinSans,
+		"serif":      defaultDarwinSerif,
+		"Serif":      defaultDarwinSerif,
+		"mono":       defaultDarwinMono,
+		"Monospace":  defaultDarwinMono,
+		"   mono   ": defaultDarwinMono,
+	}
+
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := mapDarwinGenericAlias(input); got != want {
+				t.Fatalf("mapDarwinGenericAlias(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestMapDarwinGenericAlias_NonGenericPassesThrough(t *testing.T) {
+	// Non-generic names are passed through to the C layer unchanged so
+	// NSFontManager can verify and weight-resolve them.
+	for _, input := range []string{"JetBrains Mono", "SF Mono", "Helvetica Neue"} {
+		if got := mapDarwinGenericAlias(input); got != input {
+			t.Fatalf("mapDarwinGenericAlias(%q) = %q, want %q", input, got, input)
+		}
+	}
+}
+
+func TestNSFontResolver_CachesByFamily(t *testing.T) {
+	r := &nsFontResolver{cache: make(map[string]string)}
+
+	for range 3 {
+		if got := r.Resolve("sans", true); got != defaultDarwinSans {
+			t.Fatalf("expected generic alias to resolve to %q, got %q", defaultDarwinSans, got)
+		}
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if len(r.cache) != 1 {
+		t.Fatalf("expected exactly one cache entry, got %d", len(r.cache))
+	}
+}
+
+func TestNSFontResolver_EmptyDefaultsToSans(t *testing.T) {
+	r := &nsFontResolver{cache: make(map[string]string)}
+
+	if got := r.Resolve("", false); got != defaultDarwinSans {
+		t.Fatalf("expected empty input to resolve to %q, got %q", defaultDarwinSans, got)
+	}
+}

--- a/internal/core/infra/platform/darwin/font_darwin_test.go
+++ b/internal/core/infra/platform/darwin/font_darwin_test.go
@@ -1,5 +1,6 @@
 //go:build darwin
 
+//nolint:testpackage
 package darwin
 
 import "testing"
@@ -45,26 +46,26 @@ func TestMapDarwinGenericAlias_NonGenericPassesThrough(t *testing.T) {
 }
 
 func TestNSFontResolver_CachesByFamily(t *testing.T) {
-	r := &nsFontResolver{cache: make(map[string]string)}
+	fontResolver := &nsFontResolver{cache: make(map[string]string)}
 
 	for range 3 {
-		if got := r.Resolve("sans", true); got != defaultDarwinSans {
+		if got := fontResolver.Resolve("sans", true); got != defaultDarwinSans {
 			t.Fatalf("expected generic alias to resolve to %q, got %q", defaultDarwinSans, got)
 		}
 	}
 
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	fontResolver.mu.RLock()
+	defer fontResolver.mu.RUnlock()
 
-	if len(r.cache) != 1 {
-		t.Fatalf("expected exactly one cache entry, got %d", len(r.cache))
+	if len(fontResolver.cache) != 1 {
+		t.Fatalf("expected exactly one cache entry, got %d", len(fontResolver.cache))
 	}
 }
 
 func TestNSFontResolver_EmptyDefaultsToSans(t *testing.T) {
-	r := &nsFontResolver{cache: make(map[string]string)}
+	fontResolver := &nsFontResolver{cache: make(map[string]string)}
 
-	if got := r.Resolve("", false); got != defaultDarwinSans {
+	if got := fontResolver.Resolve("", false); got != defaultDarwinSans {
 		t.Fatalf("expected empty input to resolve to %q, got %q", defaultDarwinSans, got)
 	}
 }

--- a/internal/core/infra/platform/factory_darwin.go
+++ b/internal/core/infra/platform/factory_darwin.go
@@ -12,6 +12,11 @@ func NewSystemPort() (ports.SystemPort, error) {
 	return darwin.NewSystemAdapter(), nil
 }
 
+// NewFontResolver returns a macOS-backed FontResolver.
+func NewFontResolver() ports.FontResolver {
+	return darwin.NewFontResolver()
+}
+
 // ShowConfigOnboardingAlert displays a native macOS alert for new users without a config file.
 func ShowConfigOnboardingAlert(configPath string) int {
 	return int(darwin.ShowConfigOnboardingAlert(configPath))

--- a/internal/core/infra/platform/factory_linux.go
+++ b/internal/core/infra/platform/factory_linux.go
@@ -19,6 +19,12 @@ func NewSystemPort() (ports.SystemPort, error) {
 	}
 }
 
+// NewFontResolver returns a Linux-backed FontResolver backed by fontconfig
+// (CGO builds) or a no-CGO passthrough that still maps generic aliases.
+func NewFontResolver() ports.FontResolver {
+	return linux.NewFontResolver()
+}
+
 // ShowConfigOnboardingAlert is a stub on Linux.
 func ShowConfigOnboardingAlert(_ string) int {
 	return ConfigOnboardingDefaults

--- a/internal/core/infra/platform/factory_other.go
+++ b/internal/core/infra/platform/factory_other.go
@@ -14,6 +14,11 @@ func NewSystemPort() (ports.SystemPort, error) {
 	return nil, fmt.Errorf("%w: %s", ErrUnsupportedPlatform, runtime.GOOS)
 }
 
+// NewFontResolver returns the no-op FontResolver on unsupported platforms.
+func NewFontResolver() ports.FontResolver {
+	return nil
+}
+
 // ShowConfigOnboardingAlert is a stub on non-darwin platforms.
 func ShowConfigOnboardingAlert(_ string) int {
 	return ConfigOnboardingDefaults

--- a/internal/core/infra/platform/factory_windows.go
+++ b/internal/core/infra/platform/factory_windows.go
@@ -12,6 +12,13 @@ func NewSystemPort() (ports.SystemPort, error) {
 	return windows.NewSystemAdapter(), nil
 }
 
+// NewFontResolver returns the process-wide no-op FontResolver on Windows.
+// Windows builds do not yet have a font resolver; the value is returned
+// unchanged so the existing C paths continue to work.
+func NewFontResolver() ports.FontResolver {
+	return nil
+}
+
 // ShowConfigOnboardingAlert is a stub on Windows.
 func ShowConfigOnboardingAlert(_ string) int {
 	return ConfigOnboardingDefaults

--- a/internal/core/infra/platform/linux/cgo_linux.go
+++ b/internal/core/infra/platform/linux/cgo_linux.go
@@ -6,6 +6,6 @@
 package linux
 
 /*
-#cgo linux pkg-config: x11 xtst xrandr wayland-client xkbcommon cairo xrender xfixes xext
+#cgo linux pkg-config: x11 xtst xrandr wayland-client xkbcommon cairo xrender xfixes xext fontconfig
 */
 import "C"

--- a/internal/core/infra/platform/linux/font_linux_cgo.go
+++ b/internal/core/infra/platform/linux/font_linux_cgo.go
@@ -1,0 +1,127 @@
+//go:build linux && cgo
+
+package linux
+
+/*
+#include <fontconfig/fontconfig.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+// Returns the family name that fontconfig matches for the given input,
+// or NULL if it cannot be resolved. The returned string is a heap
+// allocation; the caller must free it.
+static char *fc_match_family(const char *family) {
+	if (!family || !*family) {
+		return NULL;
+	}
+	if (!FcInit()) {
+		return NULL;
+	}
+
+	FcPattern *pat = FcNameParse((const FcChar8 *)family);
+	if (!pat) {
+		return NULL;
+	}
+
+	FcConfigSubstitute(NULL, pat, FcMatchPattern);
+	FcDefaultSubstitute(pat);
+
+	FcResult result = FcResultNoMatch;
+	FcPattern *match = FcFontMatch(NULL, pat, &result);
+	FcPatternDestroy(pat);
+
+	if (!match || result != FcResultMatch) {
+		if (match) {
+			FcPatternDestroy(match);
+		}
+
+		return NULL;
+	}
+
+	FcChar8 *matched_family = NULL;
+	char *out = NULL;
+	if (FcPatternGetString(match, FC_FAMILY, 0, &matched_family) == FcResultMatch
+		&& matched_family) {
+		out = strdup((const char *)matched_family);
+	}
+	FcPatternDestroy(match);
+
+	return out;
+}
+*/
+import "C"
+
+import (
+	"strings"
+	"sync"
+	"unsafe"
+
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+// NewFontResolver returns a fontconfig-backed ports.FontResolver.
+// Each (family) tuple is resolved on first use and cached for the
+// lifetime of the process.
+func NewFontResolver() ports.FontResolver {
+	return &fontconfigResolver{
+		cache: make(map[string]string),
+	}
+}
+
+// fontconfigResolver implements ports.FontResolver using libfontconfig.
+// It maps generic aliases to known-good installed families, asks
+// fontconfig to verify user-supplied names, and falls back to a hardcoded
+// default when fontconfig cannot resolve a family at all.
+type fontconfigResolver struct {
+	mu    sync.RWMutex
+	cache map[string]string
+}
+
+// Resolve implements ports.FontResolver.
+func (r *fontconfigResolver) Resolve(family string, bold bool) string {
+	_ = bold // reserved for future weight-specific resolution
+
+	key := strings.ToLower(strings.TrimSpace(family))
+
+	r.mu.RLock()
+	if cached, ok := r.cache[key]; ok {
+		r.mu.RUnlock()
+
+		return cached
+	}
+	r.mu.RUnlock()
+
+	resolved := r.resolve(family)
+
+	r.mu.Lock()
+	r.cache[key] = resolved
+	r.mu.Unlock()
+
+	return resolved
+}
+
+// resolve performs the actual lookup. It first maps the input to a
+// concrete family, then asks fontconfig to match it. If fontconfig
+// cannot match the family at all, it falls back to a hardcoded default.
+func (r *fontconfigResolver) resolve(family string) string {
+	mapped := mapGenericAlias(family)
+	if mapped == "" {
+		return defaultLinuxSans
+	}
+
+	cFamily := C.CString(mapped)
+	defer C.free(unsafe.Pointer(cFamily)) //nolint:nlreturn
+
+	matched := C.fc_match_family(cFamily)
+	if matched != nil {
+		defer C.free(unsafe.Pointer(matched)) //nolint:nlreturn
+
+		got := C.GoString(matched)
+		if got != "" {
+			return got
+		}
+	}
+
+	return defaultForMapped(mapped)
+}

--- a/internal/core/infra/platform/linux/font_linux_cgo.go
+++ b/internal/core/infra/platform/linux/font_linux_cgo.go
@@ -106,9 +106,6 @@ func (r *fontconfigResolver) Resolve(family string, bold bool) string {
 // cannot match the family at all, it falls back to a hardcoded default.
 func (r *fontconfigResolver) resolve(family string) string {
 	mapped := mapGenericAlias(family)
-	if mapped == "" {
-		return defaultLinuxSans
-	}
 
 	cFamily := C.CString(mapped)
 	defer C.free(unsafe.Pointer(cFamily)) //nolint:nlreturn

--- a/internal/core/infra/platform/linux/font_linux_common.go
+++ b/internal/core/infra/platform/linux/font_linux_common.go
@@ -21,7 +21,7 @@ const (
 // can ask fontconfig to verify them.
 func mapGenericAlias(family string) string {
 	switch strings.ToLower(strings.TrimSpace(family)) {
-	case "", "sans", "sans-serif", "sansserif":
+	case "", "sans", "sans-serif", "sans serif", "sansserif":
 		return defaultLinuxSans
 	case "serif":
 		return defaultLinuxSerif

--- a/internal/core/infra/platform/linux/font_linux_common.go
+++ b/internal/core/infra/platform/linux/font_linux_common.go
@@ -1,0 +1,46 @@
+//go:build linux
+
+package linux
+
+import "strings"
+
+const (
+	// defaultLinuxSans is the baseline Linux sans-serif family used when
+	// fontconfig cannot be consulted (fontconfig absent, family missing,
+	// generic alias requested).
+	defaultLinuxSans = "DejaVu Sans"
+	// defaultLinuxMono is the baseline Linux monospace family.
+	defaultLinuxMono = "DejaVu Sans Mono"
+	// defaultLinuxSerif is the baseline Linux serif family.
+	defaultLinuxSerif = "DejaVu Serif"
+)
+
+// mapGenericAlias translates fontconfig-style generic names (and empty
+// input) to a known-good Linux family. Case- and whitespace-insensitive.
+// Non-generic names are returned unchanged (trimmed) so the CGO path
+// can ask fontconfig to verify them.
+func mapGenericAlias(family string) string {
+	switch strings.ToLower(strings.TrimSpace(family)) {
+	case "", "sans", "sans-serif", "sansserif":
+		return defaultLinuxSans
+	case "serif":
+		return defaultLinuxSerif
+	case "mono", "monospace":
+		return defaultLinuxMono
+	default:
+		return strings.TrimSpace(family)
+	}
+}
+
+// defaultForMapped returns the last-resort hardcoded family for a mapped
+// generic, falling back to the sans-serif default.
+func defaultForMapped(mapped string) string {
+	switch mapped {
+	case defaultLinuxSerif:
+		return defaultLinuxSerif
+	case defaultLinuxMono:
+		return defaultLinuxMono
+	default:
+		return defaultLinuxSans
+	}
+}

--- a/internal/core/infra/platform/linux/font_linux_nocgo.go
+++ b/internal/core/infra/platform/linux/font_linux_nocgo.go
@@ -1,0 +1,23 @@
+//go:build linux && !cgo
+
+package linux
+
+import "github.com/y3owk1n/neru/internal/core/ports"
+
+// NewFontResolver returns a fontconfig-less ports.FontResolver. It still
+// maps generic aliases to the Linux baseline families so non-CGO builds
+// behave deterministically, but cannot verify whether a user-supplied
+// family is installed. CGO builds (the default) get a full fontconfig
+// adapter in font_linux_cgo.go.
+func NewFontResolver() ports.FontResolver {
+	return &passthroughResolver{}
+}
+
+// passthroughResolver maps generic aliases to known-good installed
+// families and otherwise returns the input unchanged.
+type passthroughResolver struct{}
+
+// Resolve implements ports.FontResolver.
+func (passthroughResolver) Resolve(family string, _ bool) string {
+	return mapGenericAlias(family)
+}

--- a/internal/core/infra/platform/linux/font_linux_nocgo_test.go
+++ b/internal/core/infra/platform/linux/font_linux_nocgo_test.go
@@ -1,0 +1,64 @@
+//go:build linux && !cgo
+
+package linux
+
+import "testing"
+
+func TestMapGenericAlias_EmptyDefaultsToSans(t *testing.T) {
+	if got := mapGenericAlias(""); got != defaultLinuxSans {
+		t.Fatalf("expected %q for empty input, got %q", defaultLinuxSans, got)
+	}
+}
+
+func TestMapGenericAlias_GenericAliases(t *testing.T) {
+	cases := map[string]string{
+		"sans":       defaultLinuxSans,
+		"Sans":       defaultLinuxSans,
+		"SANS":       defaultLinuxSans,
+		"sans-serif": defaultLinuxSans,
+		"Sans Serif": defaultLinuxSans,
+		"SANSSERIF":  defaultLinuxSans,
+		"serif":      defaultLinuxSerif,
+		"Serif":      defaultLinuxSerif,
+		"mono":       defaultLinuxMono,
+		"Monospace":  defaultLinuxMono,
+		"   mono   ": defaultLinuxMono,
+	}
+
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := mapGenericAlias(input); got != want {
+				t.Fatalf("mapGenericAlias(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestMapGenericAlias_NonGenericPassesThrough(t *testing.T) {
+	// Non-generic names are returned unchanged (trimmed) so the CGO path
+	// can ask fontconfig to verify them.
+	for _, input := range []string{"JetBrains Mono", "DejaVu Sans", "Comic Sans MS"} {
+		if got := mapGenericAlias(input); got != input {
+			t.Fatalf("mapGenericAlias(%q) = %q, want %q", input, got, input)
+		}
+	}
+}
+
+func TestPassthroughResolver_CachesByFamily(t *testing.T) {
+	r := passthroughResolver{}
+
+	// Repeated calls with the same input should not mutate behaviour.
+	for range 3 {
+		if got := r.Resolve("sans", true); got != defaultLinuxSans {
+			t.Fatalf("expected generic alias to resolve to %q, got %q", defaultLinuxSans, got)
+		}
+	}
+}
+
+func TestPassthroughResolver_EmptyDefaultsToSans(t *testing.T) {
+	r := passthroughResolver{}
+
+	if got := r.Resolve("", false); got != defaultLinuxSans {
+		t.Fatalf("expected empty input to resolve to %q, got %q", defaultLinuxSans, got)
+	}
+}

--- a/internal/core/infra/platform/linux/overlay_wayland.c
+++ b/internal/core/infra/platform/linux/overlay_wayland.c
@@ -653,9 +653,7 @@ void neru_wayland_overlay_text(
 		cairo_t *cr = scr->cr;
 		cairo_text_extents_t extents;
 		cairo_save(cr);
-		cairo_select_font_face(
-		    cr, (font_family && font_family[0]) ? font_family : "Sans", CAIRO_FONT_SLANT_NORMAL,
-		    CAIRO_FONT_WEIGHT_BOLD);
+		cairo_select_font_face(cr, font_family, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
 		cairo_set_font_size(cr, font_size);
 		cairo_text_extents(cr, text, &extents);
 		neru_wayland_overlay_color(cr, color);

--- a/internal/core/infra/platform/linux/x11_overlay.c
+++ b/internal/core/infra/platform/linux/x11_overlay.c
@@ -165,8 +165,7 @@ void neru_x11_overlay_text(
 	cairo_t *cr = overlay->cr;
 	cairo_text_extents_t extents;
 	cairo_save(cr);
-	cairo_select_font_face(
-	    cr, font_family && font_family[0] ? font_family : "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
+	cairo_select_font_face(cr, font_family, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
 	cairo_set_font_size(cr, font_size);
 	cairo_text_extents(cr, text, &extents);
 	neru_x11_overlay_color(cr, color);

--- a/internal/core/ports/font.go
+++ b/internal/core/ports/font.go
@@ -1,0 +1,59 @@
+package ports
+
+import "sync"
+
+// FontResolver resolves a user-supplied font family to a real, installed font
+// family on the host system. Implementations handle generic aliases
+// (e.g. "Sans", "Monospace"), verify family availability, and apply
+// platform-specific fallback chains. Results are cached internally.
+type FontResolver interface {
+	// Resolve returns a family name guaranteed to be usable on this platform.
+	//
+	//   - empty input maps to a sensible default sans-serif family
+	//   - generic aliases ("Sans", "Sans Serif", "Serif", "Monospace", ...) are
+	//     mapped to a known-good installed family
+	//   - other family names are returned unchanged when installed; missing
+	//     families fall back to the resolved generic family
+	//   - bold is reserved for future weight-specific resolution and is
+	//     currently ignored by all implementations
+	Resolve(family string, bold bool) string
+}
+
+var (
+	fontResolverMu sync.RWMutex
+	fontResolver   FontResolver = noopFontResolver{}
+)
+
+// SetFontResolver installs the process-wide FontResolver. Call once during
+// infrastructure initialization. Passing nil restores the no-op default.
+func SetFontResolver(resolver FontResolver) {
+	fontResolverMu.Lock()
+	defer fontResolverMu.Unlock()
+
+	if resolver == nil {
+		fontResolver = noopFontResolver{}
+
+		return
+	}
+
+	fontResolver = resolver
+}
+
+// ResolveFont is a convenience wrapper around the active FontResolver. Returns
+// the input unchanged when no resolver has been installed (e.g. in tests).
+func ResolveFont(family string, bold bool) string {
+	fontResolverMu.RLock()
+
+	r := fontResolver
+
+	fontResolverMu.RUnlock()
+
+	return r.Resolve(family, bold)
+}
+
+// noopFontResolver is the default resolver. It returns the input unchanged so
+// that tests and unsupported platforms behave like a transparent passthrough.
+type noopFontResolver struct{}
+
+// Resolve returns the input family unchanged.
+func (noopFontResolver) Resolve(family string, _ bool) string { return family }

--- a/internal/core/ports/font_test.go
+++ b/internal/core/ports/font_test.go
@@ -1,0 +1,63 @@
+package ports_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+// fakeResolver is a deterministic ports.FontResolver used to exercise the
+// global accessor and the noop default behavior in isolation.
+type fakeResolver struct {
+	calls int
+	last  string
+}
+
+func (f *fakeResolver) Resolve(family string, _ bool) string {
+	f.calls++
+	f.last = family
+
+	return "RESOLVED:" + family
+}
+
+func TestResolveFont_DefaultNoopReturnsInput(t *testing.T) {
+	ports.SetFontResolver(nil)
+	t.Cleanup(func() { ports.SetFontResolver(nil) })
+
+	if got := ports.ResolveFont("Anything", true); got != "Anything" {
+		t.Fatalf("expected input to be returned unchanged, got %q", got)
+	}
+
+	if got := ports.ResolveFont("", false); got != "" {
+		t.Fatalf("expected empty input to be returned unchanged, got %q", got)
+	}
+}
+
+func TestResolveFont_DispatchesToInstalledResolver(t *testing.T) {
+	fake := &fakeResolver{}
+
+	ports.SetFontResolver(fake)
+	t.Cleanup(func() { ports.SetFontResolver(nil) })
+
+	if got := ports.ResolveFont("JetBrains Mono", true); got != "RESOLVED:JetBrains Mono" {
+		t.Fatalf("expected resolver to be called, got %q", got)
+	}
+
+	if fake.calls != 1 {
+		t.Fatalf("expected resolver to be called exactly once, got %d", fake.calls)
+	}
+
+	if fake.last != "JetBrains Mono" {
+		t.Fatalf("expected resolver to receive input family, got %q", fake.last)
+	}
+}
+
+func TestResolveFont_NilResetRestoresNoop(t *testing.T) {
+	ports.SetFontResolver(&fakeResolver{})
+	ports.SetFontResolver(nil)
+	t.Cleanup(func() { ports.SetFontResolver(nil) })
+
+	if got := ports.ResolveFont("X", false); got != "X" {
+		t.Fatalf("expected noop default after reset, got %q", got)
+	}
+}

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -771,7 +771,7 @@ func resolveModeIndicatorAppearance(
 	}
 
 	style := overlayBadgeStyle{
-		fontFamily:  cfg.UI.FontFamily,
+		fontFamily:  ports.ResolveFont(cfg.UI.FontFamily, true),
 		fontSize:    float64(max(cfg.UI.FontSize, 1)),
 		paddingX:    cfg.UI.PaddingX,
 		paddingY:    cfg.UI.PaddingY,
@@ -818,7 +818,7 @@ func resolveStickyIndicatorAppearance(
 	}
 
 	style := overlayBadgeStyle{
-		fontFamily:  cfg.FontFamily,
+		fontFamily:  ports.ResolveFont(cfg.FontFamily, false),
 		fontSize:    float64(max(cfg.FontSize, 1)),
 		paddingX:    cfg.PaddingX,
 		paddingY:    cfg.PaddingY,


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR moves all the font resolution to ports, plus sane default for linux.

TLDR: now linux users can use better fonts that they like.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
