### PR TITLE
fix(darwin,overlay): keep mode indicator visible after reactivation

### DIFF
--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -1789,6 +1789,29 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 
 #pragma mark - C Interface Implementation
 
+/// Order an overlay window front once it has a drawable frame.
+/// Hidden overlays are shrunk to 1x1 to release backing memory; callers may
+/// request Show before the small indicator window has been resized. In that
+/// case Show records shouldBeVisible but intentionally does not order the tiny
+/// window. The resize path calls this helper again after it has a real frame.
+static void NeruOrderOverlayWindowIfDrawable(OverlayWindowController *controller, BOOL displayNow) {
+	if (!controller || !controller.shouldBeVisible)
+		return;
+
+	NSRect frame = controller.window.frame;
+	if (frame.size.width <= 1.0 && frame.size.height <= 1.0)
+		return;
+
+	[controller.window setIsVisible:YES];
+	[controller.window orderFrontRegardless];
+
+	if (displayNow) {
+		[controller.window display];
+	}
+
+	[controller.overlayView setNeedsDisplay:YES];
+}
+
 /// Create overlay window
 /// @return Overlay window handle
 OverlayWindow NeruCreateOverlayWindow(void) {
@@ -1842,19 +1865,7 @@ void NeruShowOverlayWindow(OverlayWindow window) {
 			                                         NSWindowCollectionBehaviorIgnoresCycle |
 			                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
 
-			NSRect frame = controller.window.frame;
-			// Only display/order front if the window frame is larger than 1x1.
-			// This prevents a brief 1x1 pixel flash at the top-left screen origin
-			// when reactivating shrunken overlays. Callers that show a freshly
-			// created overlay (full-screen or small indicator) must first call a
-			// resize/position function so the frame is non-trivial.
-			if (frame.size.width > 1.0 || frame.size.height > 1.0) {
-				[controller.window setIsVisible:YES];
-				[controller.window orderFrontRegardless];
-				[controller.window display];
-
-				[controller.overlayView setNeedsDisplay:YES];
-			}
+			NeruOrderOverlayWindowIfDrawable(controller, YES);
 		}
 	});
 }
@@ -3359,6 +3370,7 @@ void NeruPositionAndSizeOverlayToFitHint(
 			[controller.window setFrame:frame display:NO];
 			NSRect viewFrame = NSMakeRect(0, 0, windowWidth, windowHeight);
 			[controller.overlayView setFrame:viewFrame];
+			NeruOrderOverlayWindowIfDrawable(controller, NO);
 
 			if (outWidth)
 				*outWidth = (double)windowWidth;


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR ensures the mode indicator is brought back to the front after reactivation when its hidden overlay was previously reduced to a minimal frame.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
