### PR TITLE
fix(windows): auto launch daemon when running .exe

### DIFF
--- a/internal/cli/root_other.go
+++ b/internal/cli/root_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !windows
 
 package cli
 

--- a/internal/cli/root_windows.go
+++ b/internal/cli/root_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package cli
+
+import "syscall"
+
+// isRunningFromAppBundle returns true when the binary was launched via
+// double-click from Explorer (i.e., no console window).
+//
+// The Windows build uses -H windowsgui (GUI subsystem) so that double-clicking
+// does not open a console window. In that subsystem GetConsoleWindow returns
+// zero, which tells the root command to auto-launch the daemon — the same
+// convention used on macOS when running from a .app bundle.
+func isRunningFromAppBundle() bool {
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleWindow := kernel32.NewProc("GetConsoleWindow")
+	hwnd, _, _ := procGetConsoleWindow.Call()
+
+	return hwnd == 0
+}

--- a/justfile
+++ b/justfile
@@ -5,9 +5,10 @@ VERSION := `git describe --tags --always --dirty 2>/dev/null || echo "dev"`
 GIT_COMMIT := `git rev-parse --short HEAD 2>/dev/null || echo "unknown"`
 BUILD_DATE := `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
-# Ldflags for version injection
+# Ldflags for version injection; Windows uses GUI subsystem (no console window).
 
 LDFLAGS := "-s -w -X github.com/y3owk1n/neru/internal/cli.Version=" + VERSION + " -X github.com/y3owk1n/neru/internal/cli.GitCommit=" + GIT_COMMIT + " -X github.com/y3owk1n/neru/internal/cli.BuildDate=" + BUILD_DATE
+WIN_LDFLAGS := "-H windowsgui -s -w -X github.com/y3owk1n/neru/internal/cli.Version=" + VERSION + " -X github.com/y3owk1n/neru/internal/cli.GitCommit=" + GIT_COMMIT + " -X github.com/y3owk1n/neru/internal/cli.BuildDate=" + BUILD_DATE
 
 # Default build
 default: build
@@ -19,7 +20,7 @@ default: build
 build:
     @echo "Building Neru..."
     @echo "Version: {{ VERSION }}"
-    {{ if os() == "windows" { "CGO_ENABLED=0" } else { "CGO_ENABLED=1" } }} go build -ldflags="{{ LDFLAGS }}" -o bin/neru{{ if os() == "windows" { ".exe" } else { "" } }} ./cmd/neru
+    {{ if os() == "windows" { "CGO_ENABLED=0" } else { "CGO_ENABLED=1" } }} go build -ldflags="{{ if os() == "windows" { WIN_LDFLAGS } else { LDFLAGS } }}" -o bin/neru{{ if os() == "windows" { ".exe" } else { "" } }} ./cmd/neru
     @echo "✓ Build complete: bin/neru"
 
 # Build a Linux binary. Must run on a Linux host (CGO required for native backends).
@@ -35,7 +36,7 @@ build-linux ARCH="amd64":
 build-windows ARCH="amd64":
     @echo "Building Neru for windows/{{ ARCH }}..."
     mkdir -p bin
-    CGO_ENABLED=0 GOOS=windows GOARCH={{ ARCH }} go build -ldflags="{{ LDFLAGS }}" -o bin/neru-windows-{{ ARCH }}.exe ./cmd/neru
+    CGO_ENABLED=0 GOOS=windows GOARCH={{ ARCH }} go build -ldflags="{{ WIN_LDFLAGS }}" -o bin/neru-windows-{{ ARCH }}.exe ./cmd/neru
     @echo "✓ Build complete: bin/neru-windows-{{ ARCH }}.exe"
 
 # Build a macOS binary for the current host.
@@ -95,7 +96,7 @@ release-ci-windows ARCH VERSION_OVERRIDE:
     @echo "Commit: {{ GIT_COMMIT }}"
     @echo "Date: {{ BUILD_DATE }}"
     mkdir -p bin
-    CGO_ENABLED=0 GOOS=windows GOARCH={{ ARCH }} go build -ldflags="-s -w -X github.com/y3owk1n/neru/internal/cli.Version={{ VERSION_OVERRIDE }} -X github.com/y3owk1n/neru/internal/cli.GitCommit={{ GIT_COMMIT }} -X github.com/y3owk1n/neru/internal/cli.BuildDate={{ BUILD_DATE }}" -trimpath -o bin/neru-windows-{{ ARCH }}.exe ./cmd/neru
+    CGO_ENABLED=0 GOOS=windows GOARCH={{ ARCH }} go build -ldflags="-H windowsgui -s -w -X github.com/y3owk1n/neru/internal/cli.Version={{ VERSION_OVERRIDE }} -X github.com/y3owk1n/neru/internal/cli.GitCommit={{ GIT_COMMIT }} -X github.com/y3owk1n/neru/internal/cli.BuildDate={{ BUILD_DATE }}" -trimpath -o bin/neru-windows-{{ ARCH }}.exe ./cmd/neru
     @echo "✓ Release artifact for windows/{{ ARCH }} built successfully"
 
 # Bundle the application


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes the Windows double click .exe issue. Two changes:

- Sets the PE subsystem to `IMAGE_SUBSYSTEM_WINDOWS_GUI` so that Windows never create a console window.
- Ensure auto-launch pattern similar to macOS `.app` bundle detection

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Fixes #942

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
