### PR TITLE
fix(windows): ensure exe launches and quit properly

### DIFF
--- a/cmd/neru/mousetrap_windows.go
+++ b/cmd/neru/mousetrap_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package main
+
+import "github.com/spf13/cobra"
+
+func init() {
+	// Disable cobra's Windows mousetrap, which shows "This is a command line
+	// tool..." when double-clicking from Explorer. We handle this ourselves
+	// via isRunningFromAppBundle / GetConsoleWindow.
+	cobra.MousetrapHelpText = ""
+}

--- a/internal/app/initialization_platform_windows.go
+++ b/internal/app/initialization_platform_windows.go
@@ -2,10 +2,16 @@
 
 package app
 
-import "go.uber.org/zap"
+import (
+	"go.uber.org/zap"
+
+	infrasystray "github.com/y3owk1n/neru/internal/core/infra/systray"
+)
 
 // initializePlatformLogger is a no-op on Windows.
 func initializePlatformLogger(_ *zap.Logger) {}
 
-// platformQuit is a no-op on Windows.
-func platformQuit() {}
+// platformQuit posts WM_QUIT to unblock the Windows message pump.
+func platformQuit() {
+	infrasystray.Quit()
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/y3owk1n/neru/configs"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
@@ -33,12 +35,31 @@ func WriteDefaultConfig(cfgPath string, force bool) error {
 		)
 	}
 
-	writeErr := os.WriteFile(cfgPath, configs.DefaultConfig, DefaultFilePerms)
+	writeErr := os.WriteFile(cfgPath, platformDefaultConfig(), DefaultFilePerms)
 	if writeErr != nil {
 		return derrors.Wrap(writeErr, derrors.CodeConfigIOFailed, "failed to write config file")
 	}
 
 	return nil
+}
+
+// platformDefaultConfig returns the embedded default config with platform-specific
+// adjustments applied (e.g. exec_shell path on Windows).
+func platformDefaultConfig() []byte {
+	cfg := configs.DefaultConfig
+	if runtime.GOOS == "windows" {
+		s := string(cfg)
+		s = strings.ReplaceAll(s,
+			`exec_shell = "/bin/bash"`,
+			`exec_shell = "C:\\Windows\\System32\\cmd.exe"`,
+		)
+		s = strings.ReplaceAll(s,
+			`exec_shell_args = ["-lc"]`,
+			`exec_shell_args = ["/c"]`,
+		)
+		cfg = []byte(s)
+	}
+	return cfg
 }
 
 // DefaultConfigPath returns the default configuration file path.

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -48,17 +48,18 @@ func WriteDefaultConfig(cfgPath string, force bool) error {
 func platformDefaultConfig() []byte {
 	cfg := configs.DefaultConfig
 	if runtime.GOOS == "windows" {
-		s := string(cfg)
-		s = strings.ReplaceAll(s,
+		content := string(cfg)
+		content = strings.ReplaceAll(content,
 			`exec_shell = "/bin/bash"`,
 			`exec_shell = "C:\\Windows\\System32\\cmd.exe"`,
 		)
-		s = strings.ReplaceAll(s,
+		content = strings.ReplaceAll(content,
 			`exec_shell_args = ["-lc"]`,
 			`exec_shell_args = ["/c"]`,
 		)
-		cfg = []byte(s)
+		cfg = []byte(content)
 	}
+
 	return cfg
 }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes 3 windows specific issue:

1. Default config `exec_shell` is wrong and need to be substituted on init time
2. Ensure posts `WM_QUIT` when calling `systray.Quit()`
3. Fixes `This is a command line tool` issue by setting `cobra.MousetrapHelpText = ""`

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
