### PR TITLE
fix(windows): consume non-modifier key-down events to prevent passthrough to apps

### DIFF
--- a/internal/core/infra/eventtap/eventtap_windows.go
+++ b/internal/core/infra/eventtap/eventtap_windows.go
@@ -168,9 +168,9 @@ func IsUinputScrollAvailable() bool {
 	return false
 }
 
-func (et *EventTap) handleKey(key string, isUp bool) {
+func (et *EventTap) handleKey(key string, isUp bool) bool {
 	if key == "" {
-		return
+		return false
 	}
 
 	if mod := normalizeWindowsModifier(key); mod != "" {
@@ -178,7 +178,7 @@ func (et *EventTap) handleKey(key string, isUp bool) {
 			et.dispatchKey(windowsModifierToggleEvent(mod, !isUp))
 		}
 
-		return
+		return false
 	}
 
 	if isUp {
@@ -186,10 +186,26 @@ func (et *EventTap) handleKey(key string, isUp bool) {
 			et.dispatchKey(keyUp)
 		}
 
-		return
+		return false
 	}
 
-	et.dispatchKey(normalizeWindowsKey(key))
+	// Key-down with system-level modifiers (ctrl, alt, cmd) should pass through
+	// to the application so system shortcuts like Ctrl+C, Alt+Tab, Win+D still
+	// work while a mode is active. The mode handler still receives the key for
+	// hotkey matching.
+	normalized := normalizeWindowsKey(key)
+	lower := strings.ToLower(normalized)
+	if strings.Contains(lower, "ctrl+") || strings.Contains(lower, "alt+") || strings.Contains(lower, "cmd+") {
+		et.dispatchKey(normalized)
+		return false
+	}
+
+	// Non-modifier key-down (single character, Shift+letter, named key like
+	// Return/Space/arrows): consume the key so it does not reach the
+	// application behind the overlay. This matches macOS behavior where all
+	// non-modifier keys are consumed by the event tap.
+	et.dispatchKey(normalized)
+	return true
 }
 
 func (et *EventTap) dispatchKey(key string) {

--- a/internal/core/infra/eventtap/eventtap_windows.go
+++ b/internal/core/infra/eventtap/eventtap_windows.go
@@ -194,10 +194,12 @@ func (et *EventTap) handleKey(key string, isUp bool) bool {
 	// work while a mode is active. The mode handler still receives the key for
 	// hotkey matching.
 	normalized := normalizeWindowsKey(key)
+
 	lower := strings.ToLower(normalized)
 	if strings.Contains(lower, "ctrl+") || strings.Contains(lower, "alt+") ||
 		strings.Contains(lower, "cmd+") {
 		et.dispatchKey(normalized)
+
 		return false
 	}
 
@@ -206,6 +208,7 @@ func (et *EventTap) handleKey(key string, isUp bool) bool {
 	// application behind the overlay. This matches macOS behavior where all
 	// non-modifier keys are consumed by the event tap.
 	et.dispatchKey(normalized)
+
 	return true
 }
 

--- a/internal/core/infra/eventtap/eventtap_windows.go
+++ b/internal/core/infra/eventtap/eventtap_windows.go
@@ -195,7 +195,8 @@ func (et *EventTap) handleKey(key string, isUp bool) bool {
 	// hotkey matching.
 	normalized := normalizeWindowsKey(key)
 	lower := strings.ToLower(normalized)
-	if strings.Contains(lower, "ctrl+") || strings.Contains(lower, "alt+") || strings.Contains(lower, "cmd+") {
+	if strings.Contains(lower, "ctrl+") || strings.Contains(lower, "alt+") ||
+		strings.Contains(lower, "cmd+") {
 		et.dispatchKey(normalized)
 		return false
 	}

--- a/internal/core/infra/platform/windows/keyboard_hook.go
+++ b/internal/core/infra/platform/windows/keyboard_hook.go
@@ -56,7 +56,7 @@ type KeyboardHook struct {
 	mu       sync.Mutex
 	hook     uintptr
 	threadID uint32
-	callback func(key string, isUp bool)
+	callback func(key string, isUp bool) bool
 	stopCh   chan struct{}
 	doneCh   chan struct{}
 	startErr chan error
@@ -84,7 +84,7 @@ var (
 )
 
 // StartKeyboardHook installs a WH_KEYBOARD_LL hook and begins dispatching events.
-func StartKeyboardHook(callback func(key string, isUp bool)) (*KeyboardHook, error) {
+func StartKeyboardHook(callback func(key string, isUp bool) bool) (*KeyboardHook, error) {
 	if callback == nil {
 		return nil, errKeyboardHookCallbackNil
 	}
@@ -194,8 +194,8 @@ func (h *KeyboardHook) run() {
 		isUp := wParam == wmKeyUp || wParam == wmSysKeyUp || kbd.flags&llkhfUp != 0
 
 		key := hookKeyName(kbd.vkCode, isUp)
-		if key != "" {
-			current.callback(key, isUp)
+		if key != "" && current.callback(key, isUp) {
+			return 1
 		}
 
 		ret, _, _ := procCallNextHookEx.Call(0, uintptr(code), wParam, uintptr(lParam))


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes a bug where in a mode, key presses works but passthrough to the behind app at the same time.

The fix adds a bool return to the hook callback — when it returns true, the hook procedure returns 1 (non-zero) instead of calling CallNextHookEx, which tells Windows to consume the key. The Windows event tap now:

- Consumes non-modifier key-down events (single characters, Shift+letters, named keys like Return/Space/arrows)
- Passes through modifier-only keys (Ctrl, Alt, Shift, Win), key-up events, and system modifier combos (Ctrl+C, Alt+Tab, Win+D) — so system shortcuts still work while a mode is active

This matches macOS behavior where all non-modifier key-down events are consumed by the event tap (return NULL).

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Fixes #937

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
