### PR TITLE
feat(windows): add native alert dialogs for validation and startup

### DIFF
--- a/internal/core/infra/platform/factory_windows.go
+++ b/internal/core/infra/platform/factory_windows.go
@@ -19,14 +19,14 @@ func NewFontResolver() ports.FontResolver {
 	return nil
 }
 
-// ShowConfigOnboardingAlert is a stub on Windows.
-func ShowConfigOnboardingAlert(_ string) int {
-	return ConfigOnboardingDefaults
+// ShowConfigOnboardingAlert displays a native Windows dialog for new users without a config file.
+func ShowConfigOnboardingAlert(configPath string) int {
+	return windows.ShowConfigOnboardingAlert(configPath)
 }
 
-// ShowConfigValidationErrorAlert is a stub on Windows.
-func ShowConfigValidationErrorAlert(_, _ string) int {
-	return ConfigValidationOK
+// ShowConfigValidationErrorAlert displays a native Windows dialog for config validation errors.
+func ShowConfigValidationErrorAlert(errorMessage, configPath string) int {
+	return windows.ShowConfigValidationErrorAlert(errorMessage, configPath)
 }
 
 // CheckAccessibilityPermissions is always true on Windows for startup gating.

--- a/internal/core/infra/platform/windows/alert.go
+++ b/internal/core/infra/platform/windows/alert.go
@@ -6,6 +6,7 @@
 package windows
 
 import (
+	"context"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -49,6 +50,7 @@ var (
 func showMessageBox(title, message string, mbType uintptr) int {
 	titlePtr, _ := syscall.UTF16PtrFromString(title)
 	messagePtr, _ := syscall.UTF16PtrFromString(message)
+
 	if titlePtr == nil || messagePtr == nil {
 		return 0
 	}
@@ -68,7 +70,8 @@ func showMessageBox(title, message string, mbType uintptr) int {
 
 // copyToClipboard copies text to the Windows clipboard via the clip.exe utility.
 func copyToClipboard(text string) {
-	cmd := exec.Command("clip")
+	ctx := context.Background()
+	cmd := exec.CommandContext(ctx, "clip")
 	cmd.Stdin = strings.NewReader(text)
 	_ = cmd.Run()
 }

--- a/internal/core/infra/platform/windows/alert.go
+++ b/internal/core/infra/platform/windows/alert.go
@@ -1,0 +1,101 @@
+//go:build windows
+
+// internal/core/infra/platform/windows/alert.go
+// Native Windows alert dialogs using MessageBoxW.
+
+package windows
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	mbOK            = 0x00000000
+	mbOKCancel      = 0x00000001
+	mbYesNoCancel   = 0x00000003
+	mbIconWarning   = 0x00000030
+	mbIconInfo      = 0x00000040
+	mbDefButton2    = 0x00000100
+	mbDefButton3    = 0x00000200
+	mbTopmost       = 0x00040000
+	mbSetForeground = 0x00010000
+
+	idOK     = 1
+	idCancel = 2
+	idYes    = 6
+	idNo     = 7
+)
+
+var (
+	user32Alert    = windows.NewLazySystemDLL("user32.dll")
+	procMessageBox = user32Alert.NewProc("MessageBoxW")
+)
+
+// showMessageBox displays a Win32 MessageBoxW and returns the button ID.
+func showMessageBox(title, message string, mbType uintptr) int {
+	t, _ := syscall.UTF16PtrFromString(title)
+	m, _ := syscall.UTF16PtrFromString(message)
+	if t == nil || m == nil {
+		return 0
+	}
+
+	// MB_TOPMOST | MB_SETFOREGROUND ensures the dialog appears above other windows.
+	flags := mbType | mbTopmost | mbSetForeground
+
+	ret, _, _ := procMessageBox.Call(
+		0,
+		uintptr(unsafe.Pointer(m)),
+		uintptr(unsafe.Pointer(t)),
+		flags,
+	)
+	return int(ret)
+}
+
+// ShowConfigValidationErrorAlert displays a config validation error dialog.
+func ShowConfigValidationErrorAlert(errorMessage, configPath string) int {
+	title := "Neru - Configuration Validation Failed"
+	message := "Neru encountered an error while loading your configuration file:\n\n" +
+		errorMessage + "\n\nConfig file: " + configPath +
+		"\n\nClick OK to exit, or Cancel to copy the path."
+
+	result := showMessageBox(title, message, mbOKCancel|mbIconWarning)
+	switch result {
+	case idOK:
+		return 1
+	case idCancel:
+		return 2
+	default:
+		return 1
+	}
+}
+
+// ShowConfigOnboardingAlert displays a config onboarding dialog for new users.
+func ShowConfigOnboardingAlert(configPath string) int {
+	title := "Neru - Welcome!"
+	message := "No configuration file found.\n\n" +
+		"A default config will be created at:\n" + configPath + "\n\n" +
+		"You can run 'neru config init' later to recreate it.\n\n" +
+		"Yes    = Create Config\n" +
+		"No     = Use Defaults (No Config)\n" +
+		"Cancel = Quit"
+
+	result := showMessageBox(title, message, mbYesNoCancel|mbIconInfo)
+	switch result {
+	case idYes:
+		return 1
+	case idNo:
+		return 2
+	case idCancel:
+		return 3
+	default:
+		return 2
+	}
+}
+
+// ShowAlert displays a simple alert dialog with an OK button.
+func ShowAlert(title, message string) {
+	showMessageBox(title, message, mbOK|mbIconWarning)
+}

--- a/internal/core/infra/platform/windows/alert.go
+++ b/internal/core/infra/platform/windows/alert.go
@@ -6,6 +6,8 @@
 package windows
 
 import (
+	"os/exec"
+	"strings"
 	"syscall"
 	"unsafe"
 
@@ -64,6 +66,13 @@ func showMessageBox(title, message string, mbType uintptr) int {
 	return int(ret)
 }
 
+// copyToClipboard copies text to the Windows clipboard via the clip.exe utility.
+func copyToClipboard(text string) {
+	cmd := exec.Command("clip")
+	cmd.Stdin = strings.NewReader(text)
+	_ = cmd.Run()
+}
+
 // ShowConfigValidationErrorAlert displays a config validation error dialog.
 func ShowConfigValidationErrorAlert(errorMessage, configPath string) int {
 	title := "Neru - Configuration Validation Failed"
@@ -72,14 +81,13 @@ func ShowConfigValidationErrorAlert(errorMessage, configPath string) int {
 		"\n\nClick OK to exit, or Cancel to copy the path."
 
 	result := showMessageBox(title, message, mbOKCancel|mbIconWarning)
-	switch result {
-	case idOK:
-		return ConfigValidationOK
-	case idCancel:
+	if result == idCancel {
+		copyToClipboard(configPath)
+
 		return ConfigValidationCopyPath
-	default:
-		return ConfigValidationOK
 	}
+
+	return ConfigValidationOK
 }
 
 // ShowConfigOnboardingAlert displays a config onboarding dialog for new users.

--- a/internal/core/infra/platform/windows/alert.go
+++ b/internal/core/infra/platform/windows/alert.go
@@ -12,14 +12,23 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// Alert choice constants that mirror the platform/factory.go values.
+// These must match exactly so factory_windows.go can pass them through.
+const (
+	ConfigOnboardingCreate   = 1
+	ConfigOnboardingDefaults = 2
+	ConfigOnboardingQuit     = 3
+
+	ConfigValidationOK       = 1
+	ConfigValidationCopyPath = 2
+)
+
 const (
 	mbOK            = 0x00000000
 	mbOKCancel      = 0x00000001
 	mbYesNoCancel   = 0x00000003
 	mbIconWarning   = 0x00000030
 	mbIconInfo      = 0x00000040
-	mbDefButton2    = 0x00000100
-	mbDefButton3    = 0x00000200
 	mbTopmost       = 0x00040000
 	mbSetForeground = 0x00010000
 
@@ -36,9 +45,9 @@ var (
 
 // showMessageBox displays a Win32 MessageBoxW and returns the button ID.
 func showMessageBox(title, message string, mbType uintptr) int {
-	t, _ := syscall.UTF16PtrFromString(title)
-	m, _ := syscall.UTF16PtrFromString(message)
-	if t == nil || m == nil {
+	titlePtr, _ := syscall.UTF16PtrFromString(title)
+	messagePtr, _ := syscall.UTF16PtrFromString(message)
+	if titlePtr == nil || messagePtr == nil {
 		return 0
 	}
 
@@ -47,10 +56,11 @@ func showMessageBox(title, message string, mbType uintptr) int {
 
 	ret, _, _ := procMessageBox.Call(
 		0,
-		uintptr(unsafe.Pointer(m)),
-		uintptr(unsafe.Pointer(t)),
+		uintptr(unsafe.Pointer(messagePtr)),
+		uintptr(unsafe.Pointer(titlePtr)),
 		flags,
 	)
+
 	return int(ret)
 }
 
@@ -64,11 +74,11 @@ func ShowConfigValidationErrorAlert(errorMessage, configPath string) int {
 	result := showMessageBox(title, message, mbOKCancel|mbIconWarning)
 	switch result {
 	case idOK:
-		return 1
+		return ConfigValidationOK
 	case idCancel:
-		return 2
+		return ConfigValidationCopyPath
 	default:
-		return 1
+		return ConfigValidationOK
 	}
 }
 
@@ -85,13 +95,13 @@ func ShowConfigOnboardingAlert(configPath string) int {
 	result := showMessageBox(title, message, mbYesNoCancel|mbIconInfo)
 	switch result {
 	case idYes:
-		return 1
+		return ConfigOnboardingCreate
 	case idNo:
-		return 2
+		return ConfigOnboardingDefaults
 	case idCancel:
-		return 3
+		return ConfigOnboardingQuit
 	default:
-		return 2
+		return ConfigOnboardingDefaults
 	}
 }
 

--- a/internal/core/infra/platform/windows/system.go
+++ b/internal/core/infra/platform/windows/system.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"path/filepath"
 
-	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
@@ -221,10 +220,10 @@ func (s *SystemAdapter) IsSecureInputEnabled() bool {
 // ShowSecureInputNotification is a no-op on Windows — secure input is a macOS-only concept.
 func (s *SystemAdapter) ShowSecureInputNotification() {}
 
-// ShowAlert displays a native system alert on Windows.
-// TODO(windows): implement using MessageBox (user32.dll) or Windows Toast Notifications.
-func (s *SystemAdapter) ShowAlert(ctx context.Context, title, message string) error {
-	return derrors.New(derrors.CodeNotSupported, "ShowAlert not yet implemented on windows")
+// ShowAlert displays a native system alert on Windows using MessageBoxW.
+func (s *SystemAdapter) ShowAlert(_ context.Context, title, message string) error {
+	ShowAlert(title, message)
+	return nil
 }
 
 // ShowNotification displays a lightweight notification on Windows.

--- a/internal/core/infra/platform/windows/system.go
+++ b/internal/core/infra/platform/windows/system.go
@@ -223,6 +223,7 @@ func (s *SystemAdapter) ShowSecureInputNotification() {}
 // ShowAlert displays a native system alert on Windows using MessageBoxW.
 func (s *SystemAdapter) ShowAlert(_ context.Context, title, message string) error {
 	ShowAlert(title, message)
+
 	return nil
 }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds native `MessageBoxW` alert dialog support for Windows.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #945

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/1e387ef2-7f29-48c5-b7e9-c50c8dcc3ac1

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
