### PR TITLE
feat(windows,overlay): rewrite overlay renderenig with real per-pixel alpha and full theme support

### DIFF
--- a/internal/app/component_factory.go
+++ b/internal/app/component_factory.go
@@ -327,6 +327,10 @@ func (f *ComponentFactory) createOverlay(overlayType string, cfg any) (any, erro
 			return nil, derrors.New(derrors.CodeInvalidInput, "invalid mode indicator config type")
 		}
 
+		if f.headless() {
+			return nil, nil //nolint:nilnil
+		}
+
 		return modeindicator.NewOverlay(
 			indicatorConfig,
 			f.themeProvider,
@@ -354,6 +358,10 @@ func (f *ComponentFactory) createOverlay(overlayType string, cfg any) (any, erro
 				derrors.CodeInvalidInput,
 				"invalid sticky modifiers config type",
 			)
+		}
+
+		if f.headless() {
+			return nil, nil //nolint:nilnil
 		}
 
 		return stickyindicator.NewOverlay(

--- a/internal/app/component_factory.go
+++ b/internal/app/component_factory.go
@@ -305,7 +305,7 @@ func (f *ComponentFactory) createOverlay(overlayType string, cfg any) (any, erro
 		// When no real overlay window exists (e.g. in tests with a no-op overlay
 		// manager), return nil rather than creating an overlay with a nil C window
 		// handle, which would crash on any CGo call.
-		if f.overlayManager.WindowPtr() == nil {
+		if f.headless() {
 			return nil, nil //nolint:nilnil
 		}
 
@@ -316,7 +316,7 @@ func (f *ComponentFactory) createOverlay(overlayType string, cfg any) (any, erro
 			return nil, derrors.New(derrors.CodeInvalidInput, "invalid grid config type")
 		}
 
-		if f.overlayManager.WindowPtr() == nil {
+		if f.headless() {
 			return nil, nil //nolint:nilnil
 		}
 
@@ -325,14 +325,6 @@ func (f *ComponentFactory) createOverlay(overlayType string, cfg any) (any, erro
 		indicatorConfig, ok := cfg.(config.ModeIndicatorConfig)
 		if !ok {
 			return nil, derrors.New(derrors.CodeInvalidInput, "invalid mode indicator config type")
-		}
-
-		// Mode indicator creates its own dedicated window (not the shared manager
-		// window) so it doesn't conflict with hints/grid content. The nil-window
-		// check here serves as a proxy for detecting headless/test environments
-		// where no native windows should be created at all.
-		if f.overlayManager.WindowPtr() == nil {
-			return nil, nil //nolint:nilnil
 		}
 
 		return modeindicator.NewOverlay(
@@ -346,7 +338,7 @@ func (f *ComponentFactory) createOverlay(overlayType string, cfg any) (any, erro
 			return nil, derrors.New(derrors.CodeInvalidInput, "invalid recursive_grid config type")
 		}
 
-		if f.overlayManager.WindowPtr() == nil {
+		if f.headless() {
 			return nil, nil //nolint:nilnil
 		}
 
@@ -362,10 +354,6 @@ func (f *ComponentFactory) createOverlay(overlayType string, cfg any) (any, erro
 				derrors.CodeInvalidInput,
 				"invalid sticky modifiers config type",
 			)
-		}
-
-		if f.overlayManager.WindowPtr() == nil {
-			return nil, nil //nolint:nilnil
 		}
 
 		return stickyindicator.NewOverlay(

--- a/internal/app/component_factory_headless.go
+++ b/internal/app/component_factory_headless.go
@@ -1,0 +1,10 @@
+//go:build darwin || linux
+
+package app
+
+// headless returns true when the overlay manager has no real native window
+// handle. Creating an overlay with a nil window pointer would crash on any
+// platform call (CGo, X11), so callers must bail out early.
+func (f *ComponentFactory) headless() bool {
+	return f.overlayManager.WindowPtr() == nil
+}

--- a/internal/app/component_factory_headless_windows.go
+++ b/internal/app/component_factory_headless_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package app
+
+// headless always returns false on Windows. Mode and sticky indicator overlays
+// are config/theme data holders that do not create native windows, so the
+// headless guard is unnecessary.
+func (f *ComponentFactory) headless() bool {
+	return false
+}

--- a/internal/app/components/modeindicator/overlay_windows.go
+++ b/internal/app/components/modeindicator/overlay_windows.go
@@ -32,24 +32,24 @@ func NewOverlay(
 	}, nil
 }
 
-// DrawModeIndicator draws the mode indicator for the specified mode (Windows stub).
+// DrawModeIndicator is unused on Windows; drawing is handled by the manager.
 func (o *Overlay) DrawModeIndicator(mode string) error {
 	return nil
 }
 
-// Show shows the mode indicator overlay (Windows stub).
+// Show is unused on Windows; the indicator is drawn on the shared overlay.
 func (o *Overlay) Show() {}
 
-// Hide hides the mode indicator overlay (Windows stub).
+// Hide is unused on Windows; the indicator is drawn on the shared overlay.
 func (o *Overlay) Hide() {}
 
-// Clear clears the mode indicator overlay (Windows stub).
+// Clear is unused on Windows; the indicator is drawn on the shared overlay.
 func (o *Overlay) Clear() {}
 
 // ResizeToActiveScreen resizes the mode indicator overlay to the active screen (Windows stub).
 func (o *Overlay) ResizeToActiveScreen() {}
 
-// Destroy destroys the mode indicator overlay (Windows stub).
+// Destroy is unused on Windows; the indicator is drawn on the shared overlay.
 func (o *Overlay) Destroy() {}
 
 // SetConfig updates the indicator configuration (Windows stub).
@@ -65,10 +65,34 @@ func (o *Overlay) SetIndicatorConfig(cfg config.ModeIndicatorConfig) {
 	o.SetConfig(cfg)
 }
 
-// IndicatorConfig returns the indicator configuration (Windows stub).
+// IndicatorConfig returns the indicator configuration.
 func (o *Overlay) IndicatorConfig() config.ModeIndicatorConfig {
 	o.configMu.RLock()
 	defer o.configMu.RUnlock()
 
 	return o.indicatorConfig
+}
+
+// ModeConfig returns the mode config for the given mode string.
+func (o *Overlay) ModeConfig(mode string) config.ModeIndicatorModeConfig {
+	o.configMu.RLock()
+	defer o.configMu.RUnlock()
+
+	switch mode {
+	case "hints":
+		return o.indicatorConfig.Hints
+	case "grid":
+		return o.indicatorConfig.Grid
+	case "scroll":
+		return o.indicatorConfig.Scroll
+	case "recursive_grid":
+		return o.indicatorConfig.RecursiveGrid
+	default:
+		return config.ModeIndicatorModeConfig{}
+	}
+}
+
+// Theme returns the theme provider.
+func (o *Overlay) Theme() config.ThemeProvider {
+	return o.theme
 }

--- a/internal/app/components/stickyindicator/overlay_windows.go
+++ b/internal/app/components/stickyindicator/overlay_windows.go
@@ -11,7 +11,7 @@ import (
 	"github.com/y3owk1n/neru/internal/config"
 )
 
-// Overlay manages the rendering of sticky modifiers indicator overlay (Windows stub).
+// Overlay manages the rendering of sticky modifiers indicator overlay.
 type Overlay struct {
 	uiConfig config.StickyModifiersUI
 	theme    config.ThemeProvider
@@ -19,7 +19,7 @@ type Overlay struct {
 	configMu sync.RWMutex
 }
 
-// NewOverlay initializes a new sticky modifiers indicator overlay (Windows stub).
+// NewOverlay initializes a new sticky modifiers indicator overlay.
 func NewOverlay(
 	uiConfig config.StickyModifiersUI,
 	theme config.ThemeProvider,
@@ -32,34 +32,47 @@ func NewOverlay(
 	}, nil
 }
 
-// Draw draws the sticky modifiers indicator at the specified position (Windows stub).
+// Draw is unused on Windows; drawing is handled by the manager.
 func (o *Overlay) Draw(x, y int, symbols string) {}
 
-// Show shows the sticky modifiers indicator overlay (Windows stub).
+// Show is unused on Windows; the indicator is drawn on the shared overlay.
 func (o *Overlay) Show() {}
 
-// Hide hides the sticky modifiers indicator overlay (Windows stub).
+// Hide is unused on Windows; the indicator is drawn on the shared overlay.
 func (o *Overlay) Hide() {}
 
-// Clear clears the sticky modifiers indicator overlay (Windows stub).
+// Clear is unused on Windows; the indicator is drawn on the shared overlay.
 func (o *Overlay) Clear() {}
 
-// ResizeToActiveScreen resizes the sticky modifiers indicator overlay to the active screen (Windows stub).
+// ResizeToActiveScreen is unused on Windows; the indicator is drawn on the shared overlay.
 func (o *Overlay) ResizeToActiveScreen() {}
 
-// Destroy destroys the sticky modifiers indicator overlay (Windows stub).
+// Destroy is unused on Windows; the indicator is drawn on the shared overlay.
 func (o *Overlay) Destroy() {}
 
-// Cleanup frees Go-side resources (Windows stub).
+// Cleanup is unused on Windows.
 func (o *Overlay) Cleanup() {}
 
-// SetSharingType sets the window sharing type for screen sharing visibility (Windows stub).
+// SetSharingType is unused on Windows.
 func (o *Overlay) SetSharingType(_ bool) {}
 
-// SetConfig updates the overlay configuration (Windows stub).
+// SetConfig updates the overlay configuration.
 func (o *Overlay) SetConfig(cfg config.StickyModifiersUI) {
 	o.configMu.Lock()
 	defer o.configMu.Unlock()
 
 	o.uiConfig = cfg
+}
+
+// UI returns the indicator UI config.
+func (o *Overlay) UI() config.StickyModifiersUI {
+	o.configMu.RLock()
+	defer o.configMu.RUnlock()
+
+	return o.uiConfig
+}
+
+// Theme returns the theme provider.
+func (o *Overlay) Theme() config.ThemeProvider {
+	return o.theme
 }

--- a/internal/app/mocks_darwin_test.go
+++ b/internal/app/mocks_darwin_test.go
@@ -163,6 +163,9 @@ func (m *mockOverlayManager) Clear() {
 	m.mu.Unlock()
 }
 
+// ClearCache implements OverlayManager.
+func (m *mockOverlayManager) ClearCache() {}
+
 // ResizeToActiveScreen implements OverlayManager.
 func (m *mockOverlayManager) ResizeToActiveScreen() {}
 

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -57,6 +57,7 @@ func (h *Handler) clearAndHideOverlay() {
 	h.stopIndicatorPolling()
 
 	h.overlayManager.Clear()
+	h.overlayManager.ClearCache()
 	h.overlayManager.Hide()
 }
 
@@ -115,6 +116,7 @@ func (h *Handler) performCommonCleanup() {
 	h.stopIndicatorPolling()
 	h.stopHeldRepeatLocked()
 	h.overlayManager.Clear()
+	h.overlayManager.ClearCache()
 
 	// Stop any pending hints refresh timer to prevent re-activation after exit
 	if h.refreshHintsTimer != nil {

--- a/internal/app/modes/scroll.go
+++ b/internal/app/modes/scroll.go
@@ -26,6 +26,7 @@ func (h *Handler) StartInteractiveScroll() {
 		h.performModeSpecificCleanup()
 		h.stopHeldRepeatLocked()
 		h.overlayManager.Clear()
+		h.overlayManager.ClearCache()
 
 		if h.refreshHintsTimer != nil {
 			h.refreshHintsTimer.Stop()

--- a/internal/app/runtime_config_windows.go
+++ b/internal/app/runtime_config_windows.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !windows
+//go:build windows
 
 package app
 

--- a/internal/app/theme_observer_windows.go
+++ b/internal/app/theme_observer_windows.go
@@ -16,7 +16,7 @@ const themePollInterval = 2 * time.Second
 // Windows does not fire a notification when AppsUseLightTheme changes, so we
 // poll the registry every themePollInterval and fire handleThemeChange when
 // the dark/light state flips. The goroutine exits when the app context is
-// cancelled, so no separate stop mechanism is needed.
+// canceled, so no separate stop mechanism is needed.
 func (a *App) setupThemeObserver() {
 	wasDark := windows.AppsUseDarkTheme()
 

--- a/internal/app/theme_observer_windows.go
+++ b/internal/app/theme_observer_windows.go
@@ -2,13 +2,47 @@
 
 package app
 
-// setupThemeObserver is a no-op on Windows.
-func (a *App) setupThemeObserver() {}
+import (
+	"time"
 
-// stopThemeObserver is a no-op on Windows.
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/infra/platform/windows"
+)
+
+const themePollInterval = 2 * time.Second
+
+// setupThemeObserver starts polling the Windows registry for theme changes.
+// Windows does not fire a notification when AppsUseLightTheme changes, so we
+// poll the registry every themePollInterval and fire handleThemeChange when
+// the dark/light state flips. The goroutine exits when the app context is
+// cancelled, so no separate stop mechanism is needed.
+func (a *App) setupThemeObserver() {
+	wasDark := windows.AppsUseDarkTheme()
+
+	go func() {
+		ticker := time.NewTicker(themePollInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-a.ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			currentDark := windows.AppsUseDarkTheme()
+			if currentDark != wasDark {
+				wasDark = currentDark
+				a.logger.Debug("Windows theme change detected via registry poll",
+					zap.Bool("is_dark", currentDark))
+				a.handleThemeChange(currentDark)
+			}
+		}
+	}()
+}
+
+// stopThemeObserver is a no-op on Windows. The poll goroutine is stopped by
+// app context cancellation (a.cancel is called before stopThemeObserver in
+// Cleanup, so <-a.ctx.Done() fires before this runs).
 func (a *App) stopThemeObserver() {}
-
-// Unused import and method markers for cross-platform code.
-// handleThemeChange is defined in theme.go and called from darwin/linux
-// observer files. This reference silences the unused linter on Windows.
-var _ = (*App).handleThemeChange

--- a/internal/core/infra/platform/factory_windows.go
+++ b/internal/core/infra/platform/factory_windows.go
@@ -12,11 +12,10 @@ func NewSystemPort() (ports.SystemPort, error) {
 	return windows.NewSystemAdapter(), nil
 }
 
-// NewFontResolver returns the process-wide no-op FontResolver on Windows.
-// Windows builds do not yet have a font resolver; the value is returned
-// unchanged so the existing C paths continue to work.
+// NewFontResolver returns a Windows-backed FontResolver that maps generic
+// aliases to native Windows font families.
 func NewFontResolver() ports.FontResolver {
-	return nil
+	return windows.NewFontResolver()
 }
 
 // ShowConfigOnboardingAlert displays a native Windows dialog for new users without a config file.

--- a/internal/core/infra/platform/windows/font_windows.go
+++ b/internal/core/infra/platform/windows/font_windows.go
@@ -34,10 +34,13 @@ func (r *winFontResolver) Resolve(family string, bold bool) string {
 	key := strings.ToLower(strings.TrimSpace(family))
 
 	r.mu.RLock()
+
 	if cached, ok := r.cache[key]; ok {
 		r.mu.RUnlock()
+
 		return cached
 	}
+
 	r.mu.RUnlock()
 
 	resolved := mapWindowsGenericAlias(family)

--- a/internal/core/infra/platform/windows/font_windows.go
+++ b/internal/core/infra/platform/windows/font_windows.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	defaultWindowsSans = "Segoe UI"
-	defaultWindowsMono = "Consolas"
+	defaultWindowsSans  = "Segoe UI"
+	defaultWindowsMono  = "Consolas"
 	defaultWindowsSerif = "Cambria"
 )
 

--- a/internal/core/infra/platform/windows/font_windows.go
+++ b/internal/core/infra/platform/windows/font_windows.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package windows
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+const (
+	defaultWindowsSans = "Segoe UI"
+	defaultWindowsMono = "Consolas"
+	defaultWindowsSerif = "Cambria"
+)
+
+// NewFontResolver returns a Windows-backed ports.FontResolver.
+func NewFontResolver() ports.FontResolver {
+	return &winFontResolver{
+		cache: make(map[string]string),
+	}
+}
+
+type winFontResolver struct {
+	mu    sync.RWMutex
+	cache map[string]string
+}
+
+// Resolve implements ports.FontResolver.
+func (r *winFontResolver) Resolve(family string, bold bool) string {
+	_ = bold
+
+	key := strings.ToLower(strings.TrimSpace(family))
+
+	r.mu.RLock()
+	if cached, ok := r.cache[key]; ok {
+		r.mu.RUnlock()
+		return cached
+	}
+	r.mu.RUnlock()
+
+	resolved := mapWindowsGenericAlias(family)
+
+	r.mu.Lock()
+	r.cache[key] = resolved
+	r.mu.Unlock()
+
+	return resolved
+}
+
+// mapWindowsGenericAlias translates generic font names and empty input to
+// concrete Windows font families. Non-generic names pass through unchanged.
+func mapWindowsGenericAlias(family string) string {
+	normalized := strings.NewReplacer(" ", "", "-", "", "_", "").Replace(
+		strings.ToLower(strings.TrimSpace(family)),
+	)
+	switch normalized {
+	case "", "sans", "sansserif", "sans-serif":
+		return defaultWindowsSans
+	case "serif":
+		return defaultWindowsSerif
+	case "mono", "monospace":
+		return defaultWindowsMono
+	default:
+		return family
+	}
+}

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -42,6 +42,25 @@ const (
 	bytesPerPixel = 4
 	acSrcOver     = 0
 	acSrcAlpha    = 1
+
+	// DIB section bit depth for ARGB overlay rendering.
+	dibBitCount = 32
+
+	// Channel masks for BITMAPV4HEADER in BGRA pixel layout.
+	maskRed   = 0x00FF0000
+	maskGreen = 0x0000FF00
+	maskBlue  = 0x000000FF
+	maskAlpha = 0xFF000000
+
+	// Windows sRGB color space identifier ('Win ').
+	colorSpaceWinRGB = 0x206E6957
+
+	// ARGB compositing constants.
+	alphaMax = 255
+
+	// GDI text rendering defaults.
+	defaultFontSize = 14
+	gdiWhiteText    = 0x00FFFFFF
 )
 
 var (
@@ -176,6 +195,7 @@ type OverlayWindow struct {
 
 func overlayWndProc(hwnd uintptr, msg uint32, wParam, lParam uintptr) uintptr {
 	ret, _, _ := procDefWindowProcW.Call(hwnd, uintptr(msg), wParam, lParam)
+
 	return ret
 }
 
@@ -184,6 +204,7 @@ func registerOverlayWindowClass() error {
 		className, err := windows.UTF16PtrFromString(overlayClassName)
 		if err != nil {
 			errOverlayClass = err
+
 			return
 		}
 
@@ -236,74 +257,33 @@ func NewOverlayWindow() (*OverlayWindow, error) {
 	return overlay, nil
 }
 
-func (o *OverlayWindow) createHWNDLocked() error {
-	className, err := windows.UTF16PtrFromString(overlayClassName)
-	if err != nil {
-		return err
-	}
-
-	width := o.bounds.Dx()
-	height := o.bounds.Dy()
+// NewOverlayWindowAt creates a layered overlay at the given screen position and
+// size. Used for small transient windows like the mode indicator badge.
+func NewOverlayWindowAt(posX, posY, width, height int) (*OverlayWindow, error) {
 	if width <= 0 || height <= 0 {
-		return fmt.Errorf("%w: %v", errInvalidOverlayBounds, o.bounds)
+		return nil, fmt.Errorf("%w: %dx%d", errInvalidOverlayBounds, width, height)
 	}
 
-	hwnd, _, err := procCreateWindowExW.Call(
-		wsExLayered|wsExTransparent|wsExTopmost|wsExToolWindow|wsExNoActivate,
-		uintptr(unsafe.Pointer(className)),
-		0,
-		wsPopup,
-		uintptr(o.bounds.Min.X),
-		uintptr(o.bounds.Min.Y),
-		uintptr(width),
-		uintptr(height),
-		0,
-		0,
-		moduleHandle(),
-		0,
-	)
-	if hwnd == 0 {
-		return fmt.Errorf("CreateWindowExW: %w", err)
+	err := registerOverlayWindowClass()
+	if err != nil {
+		return nil, err
 	}
 
-	o.hwnd = windows.HWND(hwnd)
-	o.width = width
-	o.height = height
-	o.pixels = make([]byte, width*height*bytesPerPixel)
-	overlayRegistry.Store(o.hwnd, o)
-
-	const (
-		swpNomove = 0x0002
-		swpNosize = 0x0001
-	)
-
-	discardCall(procSetWindowPos.Call(
-		hwnd,
-		hwndTopMost,
-		0,
-		0,
-		0,
-		0,
-		swpNoActivate|swpNomove|swpNosize,
-	))
-	discardCall(procShowWindow.Call(hwnd, swHide))
-
-	o.visible = false
-
-	return nil
-}
-
-func (o *OverlayWindow) destroyHWNDLocked() {
-	if o.hwnd != 0 {
-		overlayRegistry.Delete(o.hwnd)
-		discardCall(procDestroyWindow.Call(uintptr(o.hwnd)))
-		o.hwnd = 0
-		o.pixels = nil
+	overlay := &OverlayWindow{
+		bounds: image.Rect(posX, posY, posX+width, posY+height),
 	}
-}
 
-func (o *OverlayWindow) localBounds() image.Rectangle {
-	return image.Rect(0, 0, o.width, o.height)
+	var createErr error
+
+	runOnOverlayUI(func() {
+		createErr = overlay.createHWNDLocked()
+	})
+
+	if createErr != nil {
+		return nil, createErr
+	}
+
+	return overlay, nil
 }
 
 // HWND returns the native window handle.
@@ -318,6 +298,7 @@ func (o *OverlayWindow) Healthy() bool {
 	}
 
 	ret, _, _ := procIsWindow.Call(uintptr(o.hwnd))
+
 	return ret != 0
 }
 
@@ -407,6 +388,7 @@ func (o *OverlayWindow) Clear() {
 	for i := range o.pixels {
 		o.pixels[i] = 0
 	}
+
 	o.dirty = true
 }
 
@@ -460,38 +442,9 @@ func (o *OverlayWindow) ResizeToActiveScreen() error {
 	return nil
 }
 
-// NewOverlayWindowAt creates a layered overlay at the given screen position and
-// size. Used for small transient windows like the mode indicator badge.
-func NewOverlayWindowAt(x, y, width, height int) (*OverlayWindow, error) {
-	if width <= 0 || height <= 0 {
-		return nil, fmt.Errorf("%w: %dx%d", errInvalidOverlayBounds, width, height)
-	}
-
-	err := registerOverlayWindowClass()
-	if err != nil {
-		return nil, err
-	}
-
-	overlay := &OverlayWindow{
-		bounds: image.Rect(x, y, x+width, y+height),
-	}
-
-	var createErr error
-
-	runOnOverlayUI(func() {
-		createErr = overlay.createHWNDLocked()
-	})
-
-	if createErr != nil {
-		return nil, createErr
-	}
-
-	return overlay, nil
-}
-
 // ResizeTo repositions and resizes the overlay window to the given screen
 // coordinates and dimensions, reallocating the pixel buffer as needed.
-func (o *OverlayWindow) ResizeTo(x, y, width, height int) error {
+func (o *OverlayWindow) ResizeTo(posX, posY, width, height int) error {
 	if o == nil {
 		return errOverlayNil
 	}
@@ -501,7 +454,7 @@ func (o *OverlayWindow) ResizeTo(x, y, width, height int) error {
 	}
 
 	o.mu.Lock()
-	o.bounds = image.Rect(x, y, x+width, y+height)
+	o.bounds = image.Rect(posX, posY, posX+width, posY+height)
 	o.width = width
 	o.height = height
 	o.dirty = true
@@ -524,8 +477,8 @@ func (o *OverlayWindow) ResizeTo(x, y, width, height int) error {
 		discardCall(procSetWindowPos.Call(
 			uintptr(o.hwnd),
 			hwndTopMost,
-			uintptr(x),
-			uintptr(y),
+			uintptr(posX),
+			uintptr(posY),
 			uintptr(width),
 			uintptr(height),
 			flags,
@@ -582,6 +535,7 @@ func (o *OverlayWindow) StrokeRect(bounds image.Rectangle, color uint32, lineWid
 func (o *OverlayWindow) FillRoundedRect(bounds image.Rectangle, radius float64, color uint32) {
 	if o == nil || bounds.Empty() || radius <= 0 {
 		o.FillRect(bounds, color)
+
 		return
 	}
 
@@ -606,6 +560,7 @@ func (o *OverlayWindow) StrokeRoundedRect(
 ) {
 	if o == nil || bounds.Empty() || lineWidth <= 0 || radius <= 0 {
 		o.StrokeRect(bounds, color, lineWidth)
+
 		return
 	}
 
@@ -657,11 +612,14 @@ func (o *OverlayWindow) Flush() error {
 	}
 
 	o.mu.Lock()
+
 	dirty := o.dirty
 	if !dirty {
 		o.mu.Unlock()
+
 		return nil
 	}
+
 	o.dirty = false
 
 	fills := append([]rectFill(nil), o.fills...)
@@ -710,12 +668,84 @@ func (o *OverlayWindow) Flush() error {
 	return nil
 }
 
+func (o *OverlayWindow) createHWNDLocked() error {
+	className, err := windows.UTF16PtrFromString(overlayClassName)
+	if err != nil {
+		return err
+	}
+
+	width := o.bounds.Dx()
+
+	height := o.bounds.Dy()
+	if width <= 0 || height <= 0 {
+		return fmt.Errorf("%w: %v", errInvalidOverlayBounds, o.bounds)
+	}
+
+	hwnd, _, err := procCreateWindowExW.Call(
+		wsExLayered|wsExTransparent|wsExTopmost|wsExToolWindow|wsExNoActivate,
+		uintptr(unsafe.Pointer(className)),
+		0,
+		wsPopup,
+		uintptr(o.bounds.Min.X),
+		uintptr(o.bounds.Min.Y),
+		uintptr(width),
+		uintptr(height),
+		0,
+		0,
+		moduleHandle(),
+		0,
+	)
+	if hwnd == 0 {
+		return fmt.Errorf("CreateWindowExW: %w", err)
+	}
+
+	o.hwnd = windows.HWND(hwnd)
+	o.width = width
+	o.height = height
+	o.pixels = make([]byte, width*height*bytesPerPixel)
+	overlayRegistry.Store(o.hwnd, o)
+
+	const (
+		swpNomove = 0x0002
+		swpNosize = 0x0001
+	)
+
+	discardCall(procSetWindowPos.Call(
+		hwnd,
+		hwndTopMost,
+		0,
+		0,
+		0,
+		0,
+		swpNoActivate|swpNomove|swpNosize,
+	))
+	discardCall(procShowWindow.Call(hwnd, swHide))
+
+	o.visible = false
+
+	return nil
+}
+
+func (o *OverlayWindow) destroyHWNDLocked() {
+	if o.hwnd != 0 {
+		overlayRegistry.Delete(o.hwnd)
+		discardCall(procDestroyWindow.Call(uintptr(o.hwnd)))
+		o.hwnd = 0
+		o.pixels = nil
+	}
+}
+
+func (o *OverlayWindow) localBounds() image.Rectangle {
+	return image.Rect(0, 0, o.width, o.height)
+}
+
 func (o *OverlayWindow) flushPixels() {
 	if o == nil || o.hwnd == 0 {
 		return
 	}
 
 	hdcMem, _, _ := procCreateCompatibleDC.Call(0)
+
 	if hdcMem == 0 {
 		return
 	}
@@ -726,17 +756,18 @@ func (o *OverlayWindow) flushPixels() {
 		Width:       int32(o.width),
 		Height:      -int32(o.height), // negative = top-down bitmap
 		Planes:      1,
-		BitCount:    32,
+		BitCount:    dibBitCount,
 		Compression: biBitfields,
 		SizeImage:   uint32(o.width * o.height * bytesPerPixel),
-		RedMask:     0x00FF0000,
-		GreenMask:   0x0000FF00,
-		BlueMask:    0x000000FF,
-		AlphaMask:   0xFF000000,
-		CSType:      0x206E6957, // 'Win '
+		RedMask:     maskRed,
+		GreenMask:   maskGreen,
+		BlueMask:    maskBlue,
+		AlphaMask:   maskAlpha,
+		CSType:      colorSpaceWinRGB,
 	}
 
 	var bits unsafe.Pointer
+
 	hDib, _, _ := procCreateDIBSection.Call(
 		hdcMem,
 		uintptr(unsafe.Pointer(&bih)),
@@ -745,6 +776,7 @@ func (o *OverlayWindow) flushPixels() {
 		0,
 		0,
 	)
+
 	if hDib == 0 {
 		return
 	}
@@ -758,6 +790,7 @@ func (o *OverlayWindow) flushPixels() {
 	))
 
 	prevObj, _, _ := procSelectObject.Call(hdcMem, hDib)
+
 	if prevObj == 0 {
 		return
 	}
@@ -766,7 +799,7 @@ func (o *OverlayWindow) flushPixels() {
 	blend := blendFunction{
 		BlendOp:             acSrcOver,
 		AlphaFormat:         acSrcAlpha,
-		SourceConstantAlpha: 255,
+		SourceConstantAlpha: alphaMax,
 	}
 
 	discardCall(procUpdateLayeredWindow.Call(
@@ -782,40 +815,45 @@ func (o *OverlayWindow) flushPixels() {
 	))
 }
 
-func renderTextAlphaInto(pixels []byte, w, h int, t textDraw) {
+func renderTextAlphaInto(pixels []byte, bufW, bufH int, textCmd textDraw) {
 	// Clamp text rect to overlay bounds.
-	textRect := t.rect.Intersect(image.Rect(0, 0, w, h))
+	textRect := textCmd.rect.Intersect(image.Rect(0, 0, bufW, bufH))
 	if textRect.Empty() {
 		return
 	}
 
 	// Add 1px padding around text rect for anti-aliasing at edges.
 	pad := 1
-	tw := textRect.Dx() + pad*2
-	th := textRect.Dy() + pad*2
+	texW := textRect.Dx() + pad*2 //nolint:mnd
+	texH := textRect.Dy() + pad*2 //nolint:mnd
 	textX := textRect.Min.X - pad
 	textY := textRect.Min.Y - pad
 
 	// Clamp to overlay.
 	if textX < 0 {
-		tw += textX
+		texW += textX
 		textX = 0
 	}
+
 	if textY < 0 {
-		th += textY
+		texH += textY
 		textY = 0
 	}
-	if textX+tw > w {
-		tw = w - textX
+
+	if textX+texW > bufW {
+		texW = bufW - textX
 	}
-	if textY+th > h {
-		th = h - textY
+
+	if textY+texH > bufH {
+		texH = bufH - textY
 	}
-	if tw <= 0 || th <= 0 {
+
+	if texW <= 0 || texH <= 0 {
 		return
 	}
 
 	hdcMem, _, _ := procCreateCompatibleDC.Call(0)
+
 	if hdcMem == 0 {
 		return
 	}
@@ -823,20 +861,21 @@ func renderTextAlphaInto(pixels []byte, w, h int, t textDraw) {
 
 	bih := bitmapV4Header{
 		Size:        bmpV4Size,
-		Width:       int32(tw),
-		Height:      -int32(th),
+		Width:       int32(texW),
+		Height:      -int32(texH),
 		Planes:      1,
-		BitCount:    32,
+		BitCount:    dibBitCount,
 		Compression: biBitfields,
-		SizeImage:   uint32(tw * th * bytesPerPixel),
-		RedMask:     0x00FF0000,
-		GreenMask:   0x0000FF00,
-		BlueMask:    0x000000FF,
-		AlphaMask:   0xFF000000,
-		CSType:      0x206E6957,
+		SizeImage:   uint32(texW * texH * bytesPerPixel),
+		RedMask:     maskRed,
+		GreenMask:   maskGreen,
+		BlueMask:    maskBlue,
+		AlphaMask:   maskAlpha,
+		CSType:      colorSpaceWinRGB,
 	}
 
 	var bits unsafe.Pointer
+
 	hDib, _, _ := procCreateDIBSection.Call(
 		hdcMem,
 		uintptr(unsafe.Pointer(&bih)),
@@ -845,28 +884,30 @@ func renderTextAlphaInto(pixels []byte, w, h int, t textDraw) {
 		0,
 		0,
 	)
+
 	if hDib == 0 {
 		return
 	}
 	defer func() { discardCall(procDeleteObject.Call(hDib)) }()
 
 	prevObj, _, _ := procSelectObject.Call(hdcMem, hDib)
+
 	if prevObj == 0 {
 		return
 	}
 	defer func() { discardCall(procSelectObject.Call(hdcMem, prevObj)) }()
 
-	tmpPixels := (*[1 << 30]byte)(bits)[: tw*th*bytesPerPixel : tw*th*bytesPerPixel]
+	tmpPixels := (*[1 << 30]byte)(bits)[: texW*texH*bytesPerPixel : texW*texH*bytesPerPixel]
 	for i := range tmpPixels {
 		tmpPixels[i] = 0
 	}
 
-	size := int(-t.fontSize)
+	size := int(-textCmd.fontSize)
 	if size == 0 {
-		size = -14
+		size = -defaultFontSize
 	}
 
-	fontName, err := windows.UTF16PtrFromString(t.fontFamily)
+	fontName, err := windows.UTF16PtrFromString(textCmd.fontFamily)
 	if err != nil {
 		return
 	}
@@ -875,21 +916,23 @@ func renderTextAlphaInto(pixels []byte, w, h int, t textDraw) {
 		uintptr(size), 0, 0, 0, fwBold, 0, 0, 0, 1, 0, 0, 0, 0,
 		uintptr(unsafe.Pointer(fontName)),
 	)
+
 	if hFont == 0 {
 		return
 	}
 	defer func() { discardCall(procDeleteObject.Call(hFont)) }()
 
 	prevFont, _, _ := procSelectObject.Call(hdcMem, hFont)
+
 	if prevFont == 0 {
 		return
 	}
 	defer func() { discardCall(procSelectObject.Call(hdcMem, prevFont)) }()
 
 	discardCall(procSetBkMode.Call(hdcMem, transparentBk))
-	discardCall(procSetTextColor.Call(hdcMem, 0x00FFFFFF))
+	discardCall(procSetTextColor.Call(hdcMem, gdiWhiteText))
 
-	utf16Text, err := windows.UTF16FromString(t.text)
+	utf16Text, err := windows.UTF16FromString(textCmd.text)
 	if err != nil {
 		return
 	}
@@ -912,67 +955,73 @@ func renderTextAlphaInto(pixels []byte, w, h int, t textDraw) {
 	))
 
 	// Composite the small text bitmap into the main pixel buffer at the correct offset.
-	alphaCompositeTextAt(pixels, w, h, tmpPixels, tw, th, textX, textY, t.color)
+	alphaCompositeTextAt(pixels, bufW, bufH, tmpPixels, texW, texH, textX, textY, textCmd.color)
 }
 
 // alphaFillRect composites a semi-transparent ARGB fill over the pixel buffer.
-func alphaFillRect(pixels []byte, w, h int, rect image.Rectangle, color uint32) {
-	a := uint32(color >> 24)
-	if a == 0 {
+func alphaFillRect(pixels []byte, bufW, bufH int, rect image.Rectangle, color uint32) {
+	colA := color >> alphaShift
+	if colA == 0 {
 		return
 	}
 
-	r := (color >> 16) & 0xFF
-	g := (color >> 8) & 0xFF
-	b := color & 0xFF
+	colR := (color >> redShift) & byteMask
+	colG := (color >> greenShift) & byteMask
+	colB := color & byteMask
 
 	// Pre-multiply the source color by its alpha.
-	sr := r * a
-	sg := g * a
-	sb := b * a
+	srcR := colR * colA
+	srcG := colG * colA
+	srcB := colB * colA
 
-	ia := 255 - a
-	y0 := clamp(rect.Min.Y, 0, h)
-	y1 := clamp(rect.Max.Y, 0, h)
-	x0 := clamp(rect.Min.X, 0, w)
-	x1 := clamp(rect.Max.X, 0, w)
+	invA := alphaMax - colA
+	startY := clamp(rect.Min.Y, bufH)
+	endY := clamp(rect.Max.Y, bufH)
+	startX := clamp(rect.Min.X, bufW)
+	endX := clamp(rect.Max.X, bufW)
 
-	for y := y0; y < y1; y++ {
-		row := y * w * bytesPerPixel
-		for x := x0; x < x1; x++ {
+	for y := startY; y < endY; y++ {
+		row := y * bufW * bytesPerPixel
+		for x := startX; x < endX; x++ {
 			idx := row + x*bytesPerPixel
 			dstB := uint32(pixels[idx])
 			dstG := uint32(pixels[idx+1])
 			dstR := uint32(pixels[idx+2])
 			dstA := uint32(pixels[idx+3])
 
-			pixels[idx] = byte((sb + dstB*ia) / 255)
-			pixels[idx+1] = byte((sg + dstG*ia) / 255)
-			pixels[idx+2] = byte((sr + dstR*ia) / 255)
-			pixels[idx+3] = byte(a + (dstA*ia)/255)
+			pixels[idx] = byte((srcB + dstB*invA) / alphaMax)
+			pixels[idx+1] = byte((srcG + dstG*invA) / alphaMax)
+			pixels[idx+2] = byte((srcR + dstR*invA) / alphaMax)
+			pixels[idx+3] = byte(colA + (dstA*invA)/alphaMax)
 		}
 	}
 }
 
 // alphaStrokeRect composites a stroked rectangle border over the pixel buffer.
-func alphaStrokeRect(pixels []byte, w, h int, rect image.Rectangle, color uint32, width int) {
-	if width < 1 {
+func alphaStrokeRect(
+	pixels []byte,
+	bufW, bufH int,
+	rect image.Rectangle,
+	color uint32,
+	lineWidth int,
+) {
+	if lineWidth < 1 {
 		return
 	}
 
-	for i := range width {
+	for i := range lineWidth {
 		inset := rect.Inset(i)
 		// Top edge
-		alphaFillRect(pixels, w, h,
+		alphaFillRect(pixels, bufW, bufH,
 			image.Rect(inset.Min.X, inset.Min.Y, inset.Max.X, inset.Min.Y+1), color)
 		// Bottom edge
-		alphaFillRect(pixels, w, h,
+		alphaFillRect(pixels, bufW, bufH,
 			image.Rect(inset.Min.X, inset.Max.Y-1, inset.Max.X, inset.Max.Y), color)
 		// Left edge
-		alphaFillRect(pixels, w, h,
+		alphaFillRect(pixels, bufW, bufH,
 			image.Rect(inset.Min.X, inset.Min.Y, inset.Min.X+1, inset.Max.Y), color)
 		// Right edge
-		alphaFillRect(pixels, w, h,
+		alphaFillRect(pixels, bufW, bufH,
 			image.Rect(inset.Max.X-1, inset.Min.Y, inset.Max.X, inset.Max.Y), color)
 	}
 }
@@ -980,15 +1029,15 @@ func alphaStrokeRect(pixels []byte, w, h int, rect image.Rectangle, color uint32
 // sdRoundedBox computes the signed distance from a point (px, py) to a rounded
 // rectangle centered at the origin with half-extents (halfW, halfH) and corner
 // radius r.  Negative inside, positive outside, zero at the boundary.
-func sdRoundedBox(px, py, halfW, halfH, r float64) float64 {
-	qx := math.Abs(px) - halfW + r
-	qy := math.Abs(py) - halfH + r
+func sdRoundedBox(ptX, ptY, halfW, halfH, radius float64) float64 {
+	distX := math.Abs(ptX) - halfW + radius
+	distY := math.Abs(ptY) - halfH + radius
 
-	insideX := math.Max(qx, 0)
-	insideY := math.Max(qy, 0)
-	outside := math.Sqrt(insideX*insideX+insideY*insideY) - r
+	insideX := math.Max(distX, 0)
+	insideY := math.Max(distY, 0)
+	outside := math.Sqrt(insideX*insideX+insideY*insideY) - radius
 
-	inside := math.Min(math.Max(qx, qy), 0)
+	inside := math.Min(math.Max(distX, distY), 0)
 
 	return outside + inside
 }
@@ -997,29 +1046,29 @@ func sdRoundedBox(px, py, halfW, halfH, r float64) float64 {
 // using signed-distance-function edge smoothing.
 func alphaFillRoundedRect(
 	pixels []byte,
-	w, h int,
+	bufW, bufH int,
 	rect image.Rectangle,
 	radius float64,
 	color uint32,
 ) {
-	a := uint32(color >> 24)
-	if a == 0 {
+	colA := color >> alphaShift
+	if colA == 0 {
 		return
 	}
 
-	r := (color >> 16) & 0xFF
-	g := (color >> 8) & 0xFF
-	b := color & 0xFF
+	colR := (color >> redShift) & byteMask
+	colG := (color >> greenShift) & byteMask
+	colB := color & byteMask
 
-	halfW := float64(rect.Dx()) / 2.0
-	halfH := float64(rect.Dy()) / 2.0
+	halfW := float64(rect.Dx()) / 2.0 //nolint:mnd // simple arithmetic
+	halfH := float64(rect.Dy()) / 2.0 //nolint:mnd // simple arithmetic
 	centerX := float64(rect.Min.X) + halfW
 	centerY := float64(rect.Min.Y) + halfH
 
-	y0 := clamp(rect.Min.Y, 0, h)
-	y1 := clamp(rect.Max.Y, 0, h)
-	x0 := clamp(rect.Min.X, 0, w)
-	x1 := clamp(rect.Max.X, 0, w)
+	startY := clamp(rect.Min.Y, bufH)
+	endY := clamp(rect.Max.Y, bufH)
+	startX := clamp(rect.Min.X, bufW)
+	endX := clamp(rect.Max.X, bufW)
 
 	// Inner region is fully inside the rounded rect (no SDF needed).
 	innerMinX := float64(rect.Min.X) + radius
@@ -1027,54 +1076,55 @@ func alphaFillRoundedRect(
 	innerMinY := float64(rect.Min.Y) + radius
 	innerMaxY := float64(rect.Max.Y) - radius
 
-	sr := r * a
-	sg := g * a
-	sb := b * a
+	srcR := colR * colA
+	srcG := colG * colA
+	srcB := colB * colA
 
-	for y := y0; y < y1; y++ {
-		row := y * w * bytesPerPixel
-		fy := float64(y)
+	for y := startY; y < endY; y++ {
+		row := y * bufW * bytesPerPixel
+		floatY := float64(y)
 
-		for x := x0; x < x1; x++ {
-			fx := float64(x)
+		for col := startX; col < endX; col++ {
+			floatX := float64(col)
 
 			// Fast path: pixel is well inside the rounded rect.
-			if fx >= innerMinX && fx <= innerMaxX && fy >= innerMinY && fy <= innerMaxY {
-				idx := row + x*bytesPerPixel
+			if floatX >= innerMinX && floatX <= innerMaxX && floatY >= innerMinY &&
+				floatY <= innerMaxY {
+				idx := row + col*bytesPerPixel
 				dstB := uint32(pixels[idx])
 				dstG := uint32(pixels[idx+1])
 				dstR := uint32(pixels[idx+2])
 				dstA := uint32(pixels[idx+3])
 
-				pixels[idx] = byte((sb + dstB*(255-a)) / 255)
-				pixels[idx+1] = byte((sg + dstG*(255-a)) / 255)
-				pixels[idx+2] = byte((sr + dstR*(255-a)) / 255)
-				pixels[idx+3] = byte(a + (dstA*(255-a))/255)
+				pixels[idx] = byte((srcB + dstB*(alphaMax-colA)) / alphaMax)
+				pixels[idx+1] = byte((srcG + dstG*(alphaMax-colA)) / alphaMax)
+				pixels[idx+2] = byte((srcR + dstR*(alphaMax-colA)) / alphaMax)
+				pixels[idx+3] = byte(colA + (dstA*(alphaMax-colA))/alphaMax)
 
 				continue
 			}
 
-			d := sdRoundedBox(fx-centerX, fy-centerY, halfW, halfH, radius)
-			if d > 1 {
+			dist := sdRoundedBox(floatX-centerX, floatY-centerY, halfW, halfH, radius)
+			if dist > 1 {
 				continue
 			}
 
-			pixelAlpha := uint32(math.Max(0, math.Min(1, 1.0-d)) * float64(a))
+			pixelAlpha := uint32(math.Max(0, math.Min(1, 1.0-dist)) * float64(colA))
 			if pixelAlpha == 0 {
 				continue
 			}
 
-			ia := 255 - pixelAlpha
-			idx := row + x*bytesPerPixel
+			invA := alphaMax - pixelAlpha
+			idx := row + col*bytesPerPixel
 			dstB := uint32(pixels[idx])
 			dstG := uint32(pixels[idx+1])
 			dstR := uint32(pixels[idx+2])
 			dstA := uint32(pixels[idx+3])
 
-			pixels[idx] = byte((r*pixelAlpha + dstB*ia) / 255)
-			pixels[idx+1] = byte((g*pixelAlpha + dstG*ia) / 255)
-			pixels[idx+2] = byte((b*pixelAlpha + dstR*ia) / 255)
-			pixels[idx+3] = byte(pixelAlpha + (dstA*ia)/255)
+			pixels[idx] = byte((colR*pixelAlpha + dstB*invA) / alphaMax)
+			pixels[idx+1] = byte((colG*pixelAlpha + dstG*invA) / alphaMax)
+			pixels[idx+2] = byte((colB*pixelAlpha + dstR*invA) / alphaMax)
+			pixels[idx+3] = byte(pixelAlpha + (dstA*invA)/alphaMax)
 		}
 	}
 }
@@ -1083,131 +1133,128 @@ func alphaFillRoundedRect(
 // using signed-distance-function edge smoothing at both outer and inner edges.
 func alphaStrokeRoundedRect(
 	pixels []byte,
-	w, h int,
+	bufW, bufH int,
 	rect image.Rectangle,
 	radius float64,
 	color uint32,
-	width int,
+	lineWidth int,
 ) {
-	if width < 1 {
+	if lineWidth < 1 {
 		return
 	}
 
-	a := uint32(color >> 24)
-	if a == 0 {
+	colA := color >> alphaShift
+	if colA == 0 {
 		return
 	}
 
-	r := (color >> 16) & 0xFF
-	g := (color >> 8) & 0xFF
-	b := color & 0xFF
+	colR := (color >> redShift) & byteMask
+	colG := (color >> greenShift) & byteMask
+	colB := color & byteMask
 
-	halfW := float64(rect.Dx()) / 2.0
-	halfH := float64(rect.Dy()) / 2.0
+	halfW := float64(rect.Dx()) / 2.0 //nolint:mnd // simple arithmetic
+	halfH := float64(rect.Dy()) / 2.0 //nolint:mnd // simple arithmetic
 	centerX := float64(rect.Min.X) + halfW
 	centerY := float64(rect.Min.Y) + halfH
 
-	strokeW := float64(width)
+	strokeW := float64(lineWidth)
 	innerRadius := math.Max(radius-strokeW, 0)
 	innerHalfW := math.Max(halfW-strokeW, 0)
 	innerHalfH := math.Max(halfH-strokeW, 0)
 
-	y0 := clamp(rect.Min.Y, 0, h)
-	y1 := clamp(rect.Max.Y, 0, h)
-	x0 := clamp(rect.Min.X, 0, w)
-	x1 := clamp(rect.Max.X, 0, w)
+	startY := clamp(rect.Min.Y, bufH)
+	endY := clamp(rect.Max.Y, bufH)
+	startX := clamp(rect.Min.X, bufW)
+	endX := clamp(rect.Max.X, bufW)
 
-	for y := y0; y < y1; y++ {
-		row := y * w * bytesPerPixel
-		for x := x0; x < x1; x++ {
-			px := float64(x) - centerX
-			py := float64(y) - centerY
+	for y := startY; y < endY; y++ {
+		row := y * bufW * bytesPerPixel
+		for col := startX; col < endX; col++ {
+			relX := float64(col) - centerX
+			relY := float64(y) - centerY
 
-			dOuter := sdRoundedBox(px, py, halfW, halfH, radius)
+			dOuter := sdRoundedBox(relX, relY, halfW, halfH, radius)
 			if dOuter > 1 {
 				continue
 			}
 
-			dInner := sdRoundedBox(px, py, innerHalfW, innerHalfH, innerRadius)
+			dInner := sdRoundedBox(relX, relY, innerHalfW, innerHalfH, innerRadius)
 			if dInner < -1 {
 				continue // inside inner hole, not part of stroke
 			}
 
 			outerAlpha := math.Max(0, math.Min(1, 1.0-dOuter))
 			innerAlpha := math.Max(0, math.Min(1, 1.0-dInner))
-			pixelAlpha := uint32(outerAlpha * (1.0 - innerAlpha) * float64(a))
+
+			pixelAlpha := uint32(outerAlpha * (1.0 - innerAlpha) * float64(colA))
 			if pixelAlpha == 0 {
 				continue
 			}
 
-			ia := 255 - pixelAlpha
-			sr := r * pixelAlpha
-			sg := g * pixelAlpha
-			sb := b * pixelAlpha
+			invA := alphaMax - pixelAlpha
+			srcR := colR * pixelAlpha
+			srcG := colG * pixelAlpha
+			srcB := colB * pixelAlpha
 
-			idx := row + x*bytesPerPixel
+			idx := row + col*bytesPerPixel
 			dstB := uint32(pixels[idx])
 			dstG := uint32(pixels[idx+1])
 			dstR := uint32(pixels[idx+2])
 			dstA := uint32(pixels[idx+3])
 
-			pixels[idx] = byte((sb + dstB*ia) / 255)
-			pixels[idx+1] = byte((sg + dstG*ia) / 255)
-			pixels[idx+2] = byte((sr + dstR*ia) / 255)
-			pixels[idx+3] = byte(pixelAlpha + (dstA*ia)/255)
+			pixels[idx] = byte((srcB + dstB*invA) / alphaMax)
+			pixels[idx+1] = byte((srcG + dstG*invA) / alphaMax)
+			pixels[idx+2] = byte((srcR + dstR*invA) / alphaMax)
+			pixels[idx+3] = byte(pixelAlpha + (dstA*invA)/alphaMax)
 		}
 	}
-}
-
-// alphaCompositeText composites a GDI-rendered white-on-transparent text bitmap
-// over the main pixel buffer using the given ARGB color.
-func alphaCompositeText(pixels []byte, w, h int, textPixels []byte, color uint32) {
-	alphaCompositeTextAt(pixels, w, h, textPixels, w, h, 0, 0, color)
 }
 
 // alphaCompositeTextAt composites a text bitmap of size (tw x th) at position
 // (offX, offY) in the main pixel buffer using the given ARGB color.
 func alphaCompositeTextAt(
 	pixels []byte,
-	w, h int,
+	bufW, bufH int,
 	textPixels []byte,
-	tw, th, offX, offY int,
+	texW, texH, offX, offY int,
 	color uint32,
 ) {
-	ta := (color >> 24) & 0xFF
-	if ta == 0 {
+	textA := (color >> alphaShift) & byteMask
+	if textA == 0 {
 		return
 	}
-	tr := (color >> 16) & 0xFF
-	tg := (color >> 8) & 0xFF
-	tb := color & 0xFF
 
-	for ty := 0; ty < th; ty++ {
-		dstY := offY + ty
-		if dstY < 0 || dstY >= h {
+	textR := (color >> redShift) & byteMask
+	textG := (color >> greenShift) & byteMask
+	textB := color & byteMask
+
+	for texY := range texH {
+		dstY := offY + texY
+		if dstY < 0 || dstY >= bufH {
 			continue
 		}
 
-		srcRow := ty * tw * bytesPerPixel
-		dstRow := dstY * w * bytesPerPixel
+		srcRow := texY * texW * bytesPerPixel
+		dstRow := dstY * bufW * bytesPerPixel
 
-		for tx := 0; tx < tw; tx++ {
-			dstX := offX + tx
-			if dstX < 0 || dstX >= w {
+		for texX := range texW {
+			dstX := offX + texX
+			if dstX < 0 || dstX >= bufW {
 				continue
 			}
 
-			srcIdx := srcRow + tx*bytesPerPixel
+			srcIdx := srcRow + texX*bytesPerPixel
+
 			coverage := uint32(textPixels[srcIdx+2])
 			if coverage == 0 {
 				continue
 			}
 
-			srcA := coverage * ta / 255
-			sr := tr * srcA
-			sg := tg * srcA
-			sb := tb * srcA
-			ia := 255 - srcA
+			srcA := coverage * textA / alphaMax
+			srcR := textR * srcA
+			srcG := textG * srcA
+			srcB := textB * srcA
+			invA := alphaMax - srcA
 
 			dstIdx := dstRow + dstX*bytesPerPixel
 			dstB := uint32(pixels[dstIdx])
@@ -1215,26 +1262,29 @@ func alphaCompositeTextAt(
 			dstR := uint32(pixels[dstIdx+2])
 			dstA := uint32(pixels[dstIdx+3])
 
-			pixels[dstIdx] = byte((sb + dstB*ia) / 255)
-			pixels[dstIdx+1] = byte((sg + dstG*ia) / 255)
-			pixels[dstIdx+2] = byte((sr + dstR*ia) / 255)
-			pixels[dstIdx+3] = byte(srcA + (dstA*ia)/255)
+			pixels[dstIdx] = byte((srcB + dstB*invA) / alphaMax)
+			pixels[dstIdx+1] = byte((srcG + dstG*invA) / alphaMax)
+			pixels[dstIdx+2] = byte((srcR + dstR*invA) / alphaMax)
+			pixels[dstIdx+3] = byte(srcA + (dstA*invA)/alphaMax)
 		}
 	}
 }
 
-func clamp(val, min, max int) int {
-	if val < min {
-		return min
+func clamp(val, maxVal int) int {
+	if val < 0 {
+		return 0
 	}
-	if val > max {
-		return max
+
+	if val > maxVal {
+		return maxVal
 	}
+
 	return val
 }
 
 func moduleHandle() uintptr {
 	handle, _, _ := procGetModuleHandleW.Call(0)
+
 	return handle
 }
 

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -62,13 +62,13 @@ var (
 	procSetTextColor       = gdi32.NewProc("SetTextColor")
 	procCreateFontW        = gdi32.NewProc("CreateFontW")
 
-	procRegisterClassExW = user32.NewProc("RegisterClassExW")
-	procCreateWindowExW  = user32.NewProc("CreateWindowExW")
-	procDestroyWindow    = user32.NewProc("DestroyWindow")
-	procShowWindow       = user32.NewProc("ShowWindow")
-	procSetWindowPos     = user32.NewProc("SetWindowPos")
-	procDefWindowProcW   = user32.NewProc("DefWindowProcW")
-	procIsWindow         = user32.NewProc("IsWindow")
+	procRegisterClassExW    = user32.NewProc("RegisterClassExW")
+	procCreateWindowExW     = user32.NewProc("CreateWindowExW")
+	procDestroyWindow       = user32.NewProc("DestroyWindow")
+	procShowWindow          = user32.NewProc("ShowWindow")
+	procSetWindowPos        = user32.NewProc("SetWindowPos")
+	procDefWindowProcW      = user32.NewProc("DefWindowProcW")
+	procIsWindow            = user32.NewProc("IsWindow")
 	procUpdateLayeredWindow = user32.NewProc("UpdateLayeredWindow")
 
 	kernel32 = windows.NewLazySystemDLL("kernel32.dll")
@@ -120,26 +120,26 @@ type textDraw struct {
 }
 
 type bitmapV4Header struct {
-	Size            uint32
-	Width           int32
-	Height          int32
-	Planes          uint16
-	BitCount        uint16
-	Compression     uint32
-	SizeImage       uint32
-	XPelsPerMeter   int32
-	YPelsPerMeter   int32
-	ClrUsed         uint32
-	ClrImportant    uint32
-	RedMask         uint32
-	GreenMask       uint32
-	BlueMask        uint32
-	AlphaMask       uint32
-	CSType          uint32
-	Endpoints       [9]uint32
-	GammaRed        uint32
-	GammaGreen      uint32
-	GammaBlue       uint32
+	Size          uint32
+	Width         int32
+	Height        int32
+	Planes        uint16
+	BitCount      uint16
+	Compression   uint32
+	SizeImage     uint32
+	XPelsPerMeter int32
+	YPelsPerMeter int32
+	ClrUsed       uint32
+	ClrImportant  uint32
+	RedMask       uint32
+	GreenMask     uint32
+	BlueMask      uint32
+	AlphaMask     uint32
+	CSType        uint32
+	Endpoints     [9]uint32
+	GammaRed      uint32
+	GammaGreen    uint32
+	GammaBlue     uint32
 }
 
 type blendFunction struct {
@@ -598,7 +598,12 @@ func (o *OverlayWindow) FillRoundedRect(bounds image.Rectangle, radius float64, 
 
 // StrokeRoundedRect draws a rounded rectangular border with the given ARGB
 // color, width, and corner radius, using signed-distance-function anti-aliasing.
-func (o *OverlayWindow) StrokeRoundedRect(bounds image.Rectangle, radius float64, color uint32, lineWidth float64) {
+func (o *OverlayWindow) StrokeRoundedRect(
+	bounds image.Rectangle,
+	radius float64,
+	color uint32,
+	lineWidth float64,
+) {
 	if o == nil || bounds.Empty() || lineWidth <= 0 || radius <= 0 {
 		o.StrokeRect(bounds, color, lineWidth)
 		return
@@ -607,7 +612,10 @@ func (o *OverlayWindow) StrokeRoundedRect(bounds image.Rectangle, radius float64
 	width := max(int(lineWidth), 1)
 
 	o.mu.Lock()
-	o.strokes = append(o.strokes, rectStroke{rect: bounds, color: color, width: width, radius: radius})
+	o.strokes = append(
+		o.strokes,
+		rectStroke{rect: bounds, color: color, width: width, radius: radius},
+	)
 	o.dirty = true
 	o.mu.Unlock()
 }
@@ -894,7 +902,7 @@ func renderTextAlphaInto(pixels []byte, w, h int, t textDraw) {
 		Bottom: int32(pad + textRect.Dy()),
 	}
 
-	var procDrawTextW = user32.NewProc("DrawTextW")
+	procDrawTextW := user32.NewProc("DrawTextW")
 	discardCall(procDrawTextW.Call(
 		hdcMem,
 		uintptr(unsafe.Pointer(&utf16Text[0])),
@@ -987,7 +995,13 @@ func sdRoundedBox(px, py, halfW, halfH, r float64) float64 {
 
 // alphaFillRoundedRect composites an anti-aliased rounded rectangle fill
 // using signed-distance-function edge smoothing.
-func alphaFillRoundedRect(pixels []byte, w, h int, rect image.Rectangle, radius float64, color uint32) {
+func alphaFillRoundedRect(
+	pixels []byte,
+	w, h int,
+	rect image.Rectangle,
+	radius float64,
+	color uint32,
+) {
 	a := uint32(color >> 24)
 	if a == 0 {
 		return
@@ -1067,7 +1081,14 @@ func alphaFillRoundedRect(pixels []byte, w, h int, rect image.Rectangle, radius 
 
 // alphaStrokeRoundedRect composites an anti-aliased rounded rectangle stroke
 // using signed-distance-function edge smoothing at both outer and inner edges.
-func alphaStrokeRoundedRect(pixels []byte, w, h int, rect image.Rectangle, radius float64, color uint32, width int) {
+func alphaStrokeRoundedRect(
+	pixels []byte,
+	w, h int,
+	rect image.Rectangle,
+	radius float64,
+	color uint32,
+	width int,
+) {
 	if width < 1 {
 		return
 	}
@@ -1146,7 +1167,13 @@ func alphaCompositeText(pixels []byte, w, h int, textPixels []byte, color uint32
 
 // alphaCompositeTextAt composites a text bitmap of size (tw x th) at position
 // (offX, offY) in the main pixel buffer using the given ARGB color.
-func alphaCompositeTextAt(pixels []byte, w, h int, textPixels []byte, tw, th, offX, offY int, color uint32) {
+func alphaCompositeTextAt(
+	pixels []byte,
+	w, h int,
+	textPixels []byte,
+	tw, th, offX, offY int,
+	color uint32,
+) {
 	ta := (color >> 24) & 0xFF
 	if ta == 0 {
 		return

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -700,6 +700,38 @@ func (o *OverlayWindow) flushPixels() {
 }
 
 func renderTextAlphaInto(pixels []byte, w, h int, t textDraw) {
+	// Clamp text rect to overlay bounds.
+	textRect := t.rect.Intersect(image.Rect(0, 0, w, h))
+	if textRect.Empty() {
+		return
+	}
+
+	// Add 1px padding around text rect for anti-aliasing at edges.
+	pad := 1
+	tw := textRect.Dx() + pad*2
+	th := textRect.Dy() + pad*2
+	textX := textRect.Min.X - pad
+	textY := textRect.Min.Y - pad
+
+	// Clamp to overlay.
+	if textX < 0 {
+		tw += textX
+		textX = 0
+	}
+	if textY < 0 {
+		th += textY
+		textY = 0
+	}
+	if textX+tw > w {
+		tw = w - textX
+	}
+	if textY+th > h {
+		th = h - textY
+	}
+	if tw <= 0 || th <= 0 {
+		return
+	}
+
 	hdcMem, _, _ := procCreateCompatibleDC.Call(0)
 	if hdcMem == 0 {
 		return
@@ -708,12 +740,12 @@ func renderTextAlphaInto(pixels []byte, w, h int, t textDraw) {
 
 	bih := bitmapV4Header{
 		Size:        bmpV4Size,
-		Width:       int32(w),
-		Height:      -int32(h),
+		Width:       int32(tw),
+		Height:      -int32(th),
 		Planes:      1,
 		BitCount:    32,
 		Compression: biBitfields,
-		SizeImage:   uint32(w * h * bytesPerPixel),
+		SizeImage:   uint32(tw * th * bytesPerPixel),
 		RedMask:     0x00FF0000,
 		GreenMask:   0x0000FF00,
 		BlueMask:    0x000000FF,
@@ -741,7 +773,7 @@ func renderTextAlphaInto(pixels []byte, w, h int, t textDraw) {
 	}
 	defer func() { discardCall(procSelectObject.Call(hdcMem, prevObj)) }()
 
-	tmpPixels := (*[1 << 30]byte)(bits)[: w*h*bytesPerPixel : w*h*bytesPerPixel]
+	tmpPixels := (*[1 << 30]byte)(bits)[: tw*th*bytesPerPixel : tw*th*bytesPerPixel]
 	for i := range tmpPixels {
 		tmpPixels[i] = 0
 	}
@@ -779,11 +811,12 @@ func renderTextAlphaInto(pixels []byte, w, h int, t textDraw) {
 		return
 	}
 
-	rect := windows.Rect{
-		Left:   int32(t.rect.Min.X),
-		Top:    int32(t.rect.Min.Y),
-		Right:  int32(t.rect.Max.X),
-		Bottom: int32(t.rect.Max.Y),
+	// Draw text centered inside the text bounding box, offset by padding.
+	drawRect := windows.Rect{
+		Left:   int32(pad),
+		Top:    int32(pad),
+		Right:  int32(pad + textRect.Dx()),
+		Bottom: int32(pad + textRect.Dy()),
 	}
 
 	var procDrawTextW = user32.NewProc("DrawTextW")
@@ -791,11 +824,12 @@ func renderTextAlphaInto(pixels []byte, w, h int, t textDraw) {
 		hdcMem,
 		uintptr(unsafe.Pointer(&utf16Text[0])),
 		uintptr(^uint32(0)),
-		uintptr(unsafe.Pointer(&rect)),
+		uintptr(unsafe.Pointer(&drawRect)),
 		dtCenter|dtVCenter|dtSingleLine,
 	))
 
-	alphaCompositeText(pixels, w, h, tmpPixels, t.color)
+	// Composite the small text bitmap into the main pixel buffer at the correct offset.
+	alphaCompositeTextAt(pixels, w, h, tmpPixels, tw, th, textX, textY, t.color)
 }
 
 // alphaFillRect composites a semi-transparent ARGB fill over the pixel buffer.
@@ -832,7 +866,7 @@ func alphaFillRect(pixels []byte, w, h int, rect image.Rectangle, color uint32) 
 			pixels[idx] = byte((sb + dstB*ia) / 255)
 			pixels[idx+1] = byte((sg + dstG*ia) / 255)
 			pixels[idx+2] = byte((sr + dstR*ia) / 255)
-			pixels[idx+3] = byte((a + dstA*ia) / 255)
+			pixels[idx+3] = byte(a + (dstA*ia)/255)
 		}
 	}
 }
@@ -898,10 +932,40 @@ func alphaFillRoundedRect(pixels []byte, w, h int, rect image.Rectangle, radius 
 	x0 := clamp(rect.Min.X, 0, w)
 	x1 := clamp(rect.Max.X, 0, w)
 
+	// Inner region is fully inside the rounded rect (no SDF needed).
+	innerMinX := float64(rect.Min.X) + radius
+	innerMaxX := float64(rect.Max.X) - radius
+	innerMinY := float64(rect.Min.Y) + radius
+	innerMaxY := float64(rect.Max.Y) - radius
+
+	sr := r * a
+	sg := g * a
+	sb := b * a
+
 	for y := y0; y < y1; y++ {
 		row := y * w * bytesPerPixel
+		fy := float64(y)
+
 		for x := x0; x < x1; x++ {
-			d := sdRoundedBox(float64(x)-centerX, float64(y)-centerY, halfW, halfH, radius)
+			fx := float64(x)
+
+			// Fast path: pixel is well inside the rounded rect.
+			if fx >= innerMinX && fx <= innerMaxX && fy >= innerMinY && fy <= innerMaxY {
+				idx := row + x*bytesPerPixel
+				dstB := uint32(pixels[idx])
+				dstG := uint32(pixels[idx+1])
+				dstR := uint32(pixels[idx+2])
+				dstA := uint32(pixels[idx+3])
+
+				pixels[idx] = byte((sb + dstB*(255-a)) / 255)
+				pixels[idx+1] = byte((sg + dstG*(255-a)) / 255)
+				pixels[idx+2] = byte((sr + dstR*(255-a)) / 255)
+				pixels[idx+3] = byte(a + (dstA*(255-a))/255)
+
+				continue
+			}
+
+			d := sdRoundedBox(fx-centerX, fy-centerY, halfW, halfH, radius)
 			if d > 1 {
 				continue
 			}
@@ -912,20 +976,16 @@ func alphaFillRoundedRect(pixels []byte, w, h int, rect image.Rectangle, radius 
 			}
 
 			ia := 255 - pixelAlpha
-			sr := r * pixelAlpha
-			sg := g * pixelAlpha
-			sb := b * pixelAlpha
-
 			idx := row + x*bytesPerPixel
 			dstB := uint32(pixels[idx])
 			dstG := uint32(pixels[idx+1])
 			dstR := uint32(pixels[idx+2])
 			dstA := uint32(pixels[idx+3])
 
-			pixels[idx] = byte((sb + dstB*ia) / 255)
-			pixels[idx+1] = byte((sg + dstG*ia) / 255)
-			pixels[idx+2] = byte((sr + dstR*ia) / 255)
-			pixels[idx+3] = byte((pixelAlpha + dstA*ia) / 255)
+			pixels[idx] = byte((r*pixelAlpha + dstB*ia) / 255)
+			pixels[idx+1] = byte((g*pixelAlpha + dstG*ia) / 255)
+			pixels[idx+2] = byte((b*pixelAlpha + dstR*ia) / 255)
+			pixels[idx+3] = byte(pixelAlpha + (dstA*ia)/255)
 		}
 	}
 }
@@ -973,6 +1033,9 @@ func alphaStrokeRoundedRect(pixels []byte, w, h int, rect image.Rectangle, radiu
 			}
 
 			dInner := sdRoundedBox(px, py, innerHalfW, innerHalfH, innerRadius)
+			if dInner < -1 {
+				continue // inside inner hole, not part of stroke
+			}
 
 			outerAlpha := math.Max(0, math.Min(1, 1.0-dOuter))
 			innerAlpha := math.Max(0, math.Min(1, 1.0-dInner))
@@ -995,7 +1058,7 @@ func alphaStrokeRoundedRect(pixels []byte, w, h int, rect image.Rectangle, radiu
 			pixels[idx] = byte((sb + dstB*ia) / 255)
 			pixels[idx+1] = byte((sg + dstG*ia) / 255)
 			pixels[idx+2] = byte((sr + dstR*ia) / 255)
-			pixels[idx+3] = byte((pixelAlpha + dstA*ia) / 255)
+			pixels[idx+3] = byte(pixelAlpha + (dstA*ia)/255)
 		}
 	}
 }
@@ -1003,6 +1066,12 @@ func alphaStrokeRoundedRect(pixels []byte, w, h int, rect image.Rectangle, radiu
 // alphaCompositeText composites a GDI-rendered white-on-transparent text bitmap
 // over the main pixel buffer using the given ARGB color.
 func alphaCompositeText(pixels []byte, w, h int, textPixels []byte, color uint32) {
+	alphaCompositeTextAt(pixels, w, h, textPixels, w, h, 0, 0, color)
+}
+
+// alphaCompositeTextAt composites a text bitmap of size (tw x th) at position
+// (offX, offY) in the main pixel buffer using the given ARGB color.
+func alphaCompositeTextAt(pixels []byte, w, h int, textPixels []byte, tw, th, offX, offY int, color uint32) {
 	ta := (color >> 24) & 0xFF
 	if ta == 0 {
 		return
@@ -1011,12 +1080,23 @@ func alphaCompositeText(pixels []byte, w, h int, textPixels []byte, color uint32
 	tg := (color >> 8) & 0xFF
 	tb := color & 0xFF
 
-	for y := 0; y < h; y++ {
-		row := y * w * bytesPerPixel
-		for x := 0; x < w; x++ {
-			idx := row + x*bytesPerPixel
-			// Extract coverage from the rendered white pixel (R channel).
-			coverage := uint32(textPixels[idx+2])
+	for ty := 0; ty < th; ty++ {
+		dstY := offY + ty
+		if dstY < 0 || dstY >= h {
+			continue
+		}
+
+		srcRow := ty * tw * bytesPerPixel
+		dstRow := dstY * w * bytesPerPixel
+
+		for tx := 0; tx < tw; tx++ {
+			dstX := offX + tx
+			if dstX < 0 || dstX >= w {
+				continue
+			}
+
+			srcIdx := srcRow + tx*bytesPerPixel
+			coverage := uint32(textPixels[srcIdx+2])
 			if coverage == 0 {
 				continue
 			}
@@ -1027,15 +1107,16 @@ func alphaCompositeText(pixels []byte, w, h int, textPixels []byte, color uint32
 			sb := tb * srcA
 			ia := 255 - srcA
 
-			dstB := uint32(pixels[idx])
-			dstG := uint32(pixels[idx+1])
-			dstR := uint32(pixels[idx+2])
-			dstA := uint32(pixels[idx+3])
+			dstIdx := dstRow + dstX*bytesPerPixel
+			dstB := uint32(pixels[dstIdx])
+			dstG := uint32(pixels[dstIdx+1])
+			dstR := uint32(pixels[dstIdx+2])
+			dstA := uint32(pixels[dstIdx+3])
 
-			pixels[idx] = byte((sb + dstB*ia) / 255)
-			pixels[idx+1] = byte((sg + dstG*ia) / 255)
-			pixels[idx+2] = byte((sr + dstR*ia) / 255)
-			pixels[idx+3] = byte((srcA + dstA*ia) / 255)
+			pixels[dstIdx] = byte((sb + dstB*ia) / 255)
+			pixels[dstIdx+1] = byte((sg + dstG*ia) / 255)
+			pixels[dstIdx+2] = byte((sr + dstR*ia) / 255)
+			pixels[dstIdx+3] = byte(srcA + (dstA*ia)/255)
 		}
 	}
 }

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -460,6 +460,81 @@ func (o *OverlayWindow) ResizeToActiveScreen() error {
 	return nil
 }
 
+// NewOverlayWindowAt creates a layered overlay at the given screen position and
+// size. Used for small transient windows like the mode indicator badge.
+func NewOverlayWindowAt(x, y, width, height int) (*OverlayWindow, error) {
+	if width <= 0 || height <= 0 {
+		return nil, fmt.Errorf("%w: %dx%d", errInvalidOverlayBounds, width, height)
+	}
+
+	err := registerOverlayWindowClass()
+	if err != nil {
+		return nil, err
+	}
+
+	overlay := &OverlayWindow{
+		bounds: image.Rect(x, y, x+width, y+height),
+	}
+
+	var createErr error
+
+	runOnOverlayUI(func() {
+		createErr = overlay.createHWNDLocked()
+	})
+
+	if createErr != nil {
+		return nil, createErr
+	}
+
+	return overlay, nil
+}
+
+// ResizeTo repositions and resizes the overlay window to the given screen
+// coordinates and dimensions, reallocating the pixel buffer as needed.
+func (o *OverlayWindow) ResizeTo(x, y, width, height int) error {
+	if o == nil {
+		return errOverlayNil
+	}
+
+	if width <= 0 || height <= 0 {
+		return fmt.Errorf("%w: %dx%d", errInvalidOverlayBounds, width, height)
+	}
+
+	o.mu.Lock()
+	o.bounds = image.Rect(x, y, x+width, y+height)
+	o.width = width
+	o.height = height
+	o.dirty = true
+	o.mu.Unlock()
+
+	if o.hwnd == 0 {
+		return nil
+	}
+
+	runOnOverlayUI(func() {
+		o.mu.Lock()
+		o.pixels = make([]byte, o.width*o.height*bytesPerPixel)
+		o.mu.Unlock()
+
+		flags := uintptr(swpNoActivate)
+		if o.visible {
+			flags |= swpShowWindow
+		}
+
+		discardCall(procSetWindowPos.Call(
+			uintptr(o.hwnd),
+			hwndTopMost,
+			uintptr(x),
+			uintptr(y),
+			uintptr(width),
+			uintptr(height),
+			flags,
+		))
+	})
+
+	return nil
+}
+
 // Destroy releases native overlay resources.
 func (o *OverlayWindow) Destroy() {
 	if o == nil {

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -756,10 +756,12 @@ func (o *OverlayWindow) drawTextGDI(hdc windows.Handle, text textDraw) {
 }
 
 func (o *OverlayWindow) argbToGDI(argb uint32) uint32 {
-	blend := themeSurfaceLight
+	blend := ThemeSurfaceRGB()
 	if o != nil {
 		o.mu.Lock()
-		blend = o.colorBlendRGB
+		if o.colorBlendRGB != 0 {
+			blend = o.colorBlendRGB
+		}
 		o.mu.Unlock()
 	}
 

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -1,15 +1,12 @@
 //go:build windows
 
-// internal/core/infra/platform/windows/overlay.go
-// Layered Win32 overlay using color-key transparency and WM_PAINT GDI drawing.
-// Does not implement grid logic or ports; ui/overlay consumes this surface.
-
 package windows
 
 import (
 	"errors"
 	"fmt"
 	"image"
+	"math"
 	"sync"
 	"syscall"
 	"unsafe"
@@ -20,9 +17,6 @@ import (
 const (
 	overlayClassName = "NeruOverlayWindow"
 
-	csHRedraw = 0x0002
-	csVRedraw = 0x0001
-
 	wsPopup          = 0x80000000
 	wsExLayered      = 0x00080000
 	wsExTransparent  = 0x00000020
@@ -31,55 +25,56 @@ const (
 	wsExNoActivate   = 0x08000000
 	swHide           = 0
 	swShowNoActivate = 4
-	transparentBk    = 1
-	dtCenter         = 0x00000001
-	dtVCenter        = 0x00000004
-	dtSingleLine     = 0x00000020
 	hwndTopMost      = ^uintptr(0)
 	swpNoActivate    = 0x0010
 	swpShowWindow    = 0x0040
-	lwaColorKey      = 0x00000001
-	wmPaint          = 0x000F
 
 	defaultOverlayFont = "Segoe UI"
 	fwBold             = 700
+	dtCenter           = 0x00000001
+	dtVCenter          = 0x00000004
+	dtSingleLine       = 0x00000020
+	transparentBk      = 1
 
-	rgbMask           = 0xFFFFFF
-	defaultFontHeight = -14
+	bmpV4Size     = 108
+	biBitfields   = 3
+	ulwAlpha      = 2
+	bytesPerPixel = 4
+	acSrcOver     = 0
+	acSrcAlpha    = 1
 )
 
 var (
-	errCreateSolidBrush      = errors.New("CreateSolidBrush failed")
-	errInvalidOverlayBounds  = errors.New("invalid overlay bounds")
-	errOverlayNil            = errors.New("overlay is nil")
-	errOverlayNotInitialized = errors.New("overlay window is not initialized")
+	errInvalidOverlayBounds = errors.New("invalid overlay bounds")
+	errOverlayNil           = errors.New("overlay is nil")
+	errOverlayNotInit       = errors.New("overlay window is not initialized")
 )
 
 var (
 	gdi32 = windows.NewLazySystemDLL("gdi32.dll")
 
-	procCreateSolidBrush           = gdi32.NewProc("CreateSolidBrush")
-	procDeleteObject               = gdi32.NewProc("DeleteObject")
-	procCreateFontW                = gdi32.NewProc("CreateFontW")
-	procSetBkMode                  = gdi32.NewProc("SetBkMode")
-	procSetTextColor               = gdi32.NewProc("SetTextColor")
-	procRegisterClassExW           = user32.NewProc("RegisterClassExW")
-	procCreateWindowExW            = user32.NewProc("CreateWindowExW")
-	procDestroyWindow              = user32.NewProc("DestroyWindow")
-	procShowWindow                 = user32.NewProc("ShowWindow")
-	procSetWindowPos               = user32.NewProc("SetWindowPos")
-	procDefWindowProcW             = user32.NewProc("DefWindowProcW")
-	procSetLayeredWindowAttributes = user32.NewProc("SetLayeredWindowAttributes")
-	procInvalidateRect             = user32.NewProc("InvalidateRect")
-	procUpdateWindow               = user32.NewProc("UpdateWindow")
-	procIsWindow                   = user32.NewProc("IsWindow")
-	procBeginPaint                 = user32.NewProc("BeginPaint")
-	procEndPaint                   = user32.NewProc("EndPaint")
-	procValidateRect               = user32.NewProc("ValidateRect")
-	procFillRect                   = user32.NewProc("FillRect")
-	procDrawTextW                  = user32.NewProc("DrawTextW")
-	kernel32                       = windows.NewLazySystemDLL("kernel32.dll")
-	procGetModuleHandleW           = kernel32.NewProc("GetModuleHandleW")
+	procCreateCompatibleDC = gdi32.NewProc("CreateCompatibleDC")
+	procDeleteDC           = gdi32.NewProc("DeleteDC")
+	procCreateDIBSection   = gdi32.NewProc("CreateDIBSection")
+	procSelectObject       = gdi32.NewProc("SelectObject")
+	procDeleteObject       = gdi32.NewProc("DeleteObject")
+	procSetBkMode          = gdi32.NewProc("SetBkMode")
+	procSetTextColor       = gdi32.NewProc("SetTextColor")
+	procCreateFontW        = gdi32.NewProc("CreateFontW")
+
+	procRegisterClassExW = user32.NewProc("RegisterClassExW")
+	procCreateWindowExW  = user32.NewProc("CreateWindowExW")
+	procDestroyWindow    = user32.NewProc("DestroyWindow")
+	procShowWindow       = user32.NewProc("ShowWindow")
+	procSetWindowPos     = user32.NewProc("SetWindowPos")
+	procDefWindowProcW   = user32.NewProc("DefWindowProcW")
+	procIsWindow         = user32.NewProc("IsWindow")
+	procUpdateLayeredWindow = user32.NewProc("UpdateLayeredWindow")
+
+	kernel32 = windows.NewLazySystemDLL("kernel32.dll")
+
+	procGetModuleHandleW = kernel32.NewProc("GetModuleHandleW")
+	procRtlMoveMemory    = kernel32.NewProc("RtlMoveMemory")
 
 	overlayClassOnce  sync.Once
 	errOverlayClass   error
@@ -103,24 +98,17 @@ type wndClassEx struct {
 	hIconSm       windows.Handle
 }
 
-type paintStruct struct {
-	hdc         windows.Handle
-	fErase      int32
-	rcPaint     windows.Rect
-	fRestore    int32
-	fIncUpdate  int32
-	rgbReserved [32]byte
-}
-
 type rectFill struct {
-	rect  image.Rectangle
-	color uint32
+	rect   image.Rectangle
+	color  uint32
+	radius float64
 }
 
 type rectStroke struct {
-	rect  image.Rectangle
-	color uint32
-	width int
+	rect   image.Rectangle
+	color  uint32
+	width  int
+	radius float64
 }
 
 type textDraw struct {
@@ -131,7 +119,45 @@ type textDraw struct {
 	color      uint32
 }
 
-// OverlayWindow is a fullscreen click-through layered HWND painted via WM_PAINT.
+type bitmapV4Header struct {
+	Size            uint32
+	Width           int32
+	Height          int32
+	Planes          uint16
+	BitCount        uint16
+	Compression     uint32
+	SizeImage       uint32
+	XPelsPerMeter   int32
+	YPelsPerMeter   int32
+	ClrUsed         uint32
+	ClrImportant    uint32
+	RedMask         uint32
+	GreenMask       uint32
+	BlueMask        uint32
+	AlphaMask       uint32
+	CSType          uint32
+	Endpoints       [9]uint32
+	GammaRed        uint32
+	GammaGreen      uint32
+	GammaBlue       uint32
+}
+
+type blendFunction struct {
+	BlendOp             byte
+	BlendFlags          byte
+	SourceConstantAlpha byte
+	AlphaFormat         byte
+}
+
+type point struct {
+	X, Y int32
+}
+
+type size struct {
+	CX, CY int32
+}
+
+// OverlayWindow is a fullscreen click-through layered HWND with per-pixel alpha.
 type OverlayWindow struct {
 	mu      sync.Mutex
 	hwnd    windows.HWND
@@ -145,37 +171,12 @@ type OverlayWindow struct {
 	strokes []rectStroke
 	texts   []textDraw
 
-	colorBlendRGB uint32
+	pixels []byte
 }
 
 func overlayWndProc(hwnd uintptr, msg uint32, wParam, lParam uintptr) uintptr {
-	switch msg {
-	case wmPaint:
-		var paintData paintStruct
-
-		hdc, _, _ := procBeginPaint.Call(hwnd, uintptr(unsafe.Pointer(&paintData)))
-		if hdc != 0 {
-			if raw, ok := overlayRegistry.Load(windows.HWND(hwnd)); ok {
-				if overlay, ok := raw.(*OverlayWindow); ok {
-					overlay.paintLocked(windows.Handle(hdc))
-				}
-			}
-
-			discardCall(procEndPaint.Call(hwnd, uintptr(unsafe.Pointer(&paintData))))
-		} else {
-			// BeginPaint failed, so EndPaint will not run to validate the
-			// update region. WM_PAINT is a generated message that PeekMessage
-			// keeps returning until the region is validated, so without this
-			// the pump would spin forever and wedge the overlay UI thread.
-			discardCall(procValidateRect.Call(hwnd, 0))
-		}
-
-		return 0
-	default:
-		ret, _, _ := procDefWindowProcW.Call(hwnd, uintptr(msg), wParam, lParam)
-
-		return ret
-	}
+	ret, _, _ := procDefWindowProcW.Call(hwnd, uintptr(msg), wParam, lParam)
+	return ret
 }
 
 func registerOverlayWindowClass() error {
@@ -183,26 +184,17 @@ func registerOverlayWindowClass() error {
 		className, err := windows.UTF16PtrFromString(overlayClassName)
 		if err != nil {
 			errOverlayClass = err
-
 			return
 		}
 
 		overlayWndProcPtr = syscall.NewCallback(overlayWndProc)
 		instance, _, _ := procGetModuleHandleW.Call(0)
 
-		bgBrush, _, _ := procCreateSolidBrush.Call(overlayColorKey)
-		if bgBrush == 0 {
-			errOverlayClass = errCreateSolidBrush
-
-			return
-		}
-
 		class := wndClassEx{
 			cbSize:        uint32(unsafe.Sizeof(wndClassEx{})),
-			style:         csHRedraw | csVRedraw,
+			style:         0,
 			lpfnWndProc:   overlayWndProcPtr,
 			hInstance:     windows.Handle(instance),
-			hbrBackground: windows.Handle(bgBrush),
 			lpszClassName: className,
 		}
 
@@ -228,8 +220,7 @@ func NewOverlayWindow() (*OverlayWindow, error) {
 	}
 
 	overlay := &OverlayWindow{
-		bounds:        bounds,
-		colorBlendRGB: ThemeSurfaceRGB(),
+		bounds: bounds,
 	}
 
 	var createErr error
@@ -245,6 +236,76 @@ func NewOverlayWindow() (*OverlayWindow, error) {
 	return overlay, nil
 }
 
+func (o *OverlayWindow) createHWNDLocked() error {
+	className, err := windows.UTF16PtrFromString(overlayClassName)
+	if err != nil {
+		return err
+	}
+
+	width := o.bounds.Dx()
+	height := o.bounds.Dy()
+	if width <= 0 || height <= 0 {
+		return fmt.Errorf("%w: %v", errInvalidOverlayBounds, o.bounds)
+	}
+
+	hwnd, _, err := procCreateWindowExW.Call(
+		wsExLayered|wsExTransparent|wsExTopmost|wsExToolWindow|wsExNoActivate,
+		uintptr(unsafe.Pointer(className)),
+		0,
+		wsPopup,
+		uintptr(o.bounds.Min.X),
+		uintptr(o.bounds.Min.Y),
+		uintptr(width),
+		uintptr(height),
+		0,
+		0,
+		moduleHandle(),
+		0,
+	)
+	if hwnd == 0 {
+		return fmt.Errorf("CreateWindowExW: %w", err)
+	}
+
+	o.hwnd = windows.HWND(hwnd)
+	o.width = width
+	o.height = height
+	o.pixels = make([]byte, width*height*bytesPerPixel)
+	overlayRegistry.Store(o.hwnd, o)
+
+	const (
+		swpNomove = 0x0002
+		swpNosize = 0x0001
+	)
+
+	discardCall(procSetWindowPos.Call(
+		hwnd,
+		hwndTopMost,
+		0,
+		0,
+		0,
+		0,
+		swpNoActivate|swpNomove|swpNosize,
+	))
+	discardCall(procShowWindow.Call(hwnd, swHide))
+
+	o.visible = false
+
+	return nil
+}
+
+func (o *OverlayWindow) destroyHWNDLocked() {
+	if o.hwnd != 0 {
+		overlayRegistry.Delete(o.hwnd)
+		discardCall(procDestroyWindow.Call(uintptr(o.hwnd)))
+		o.hwnd = 0
+		o.pixels = nil
+	}
+}
+
+func (o *OverlayWindow) localBounds() image.Rectangle {
+	return image.Rect(0, 0, o.width, o.height)
+}
+
 // HWND returns the native window handle.
 func (o *OverlayWindow) HWND() windows.HWND {
 	return o.hwnd
@@ -257,7 +318,6 @@ func (o *OverlayWindow) Healthy() bool {
 	}
 
 	ret, _, _ := procIsWindow.Call(uintptr(o.hwnd))
-
 	return ret != 0
 }
 
@@ -279,17 +339,8 @@ func (o *OverlayWindow) Bounds() image.Rectangle {
 	return o.bounds
 }
 
-// SetColorBlendRGB sets the opaque RGB backdrop used to approximate semi-transparent
-// theme colors on the GDI overlay (see argbToGDIColorRef).
-func (o *OverlayWindow) SetColorBlendRGB(rgb uint32) {
-	if o == nil {
-		return
-	}
-
-	o.mu.Lock()
-	o.colorBlendRGB = rgb & rgbMask
-	o.mu.Unlock()
-}
+// SetColorBlendRGB is a no-op since the overlay now uses per-pixel alpha.
+func (o *OverlayWindow) SetColorBlendRGB(uint32) {}
 
 // Show displays the overlay without taking focus.
 func (o *OverlayWindow) Show() {
@@ -305,7 +356,6 @@ func (o *OverlayWindow) Show() {
 			}
 		}
 
-		o.prepareForDisplayLocked()
 		discardCall(procShowWindow.Call(uintptr(o.hwnd), swShowNoActivate))
 
 		const (
@@ -323,7 +373,9 @@ func (o *OverlayWindow) Show() {
 			swpNoActivate|swpShowWindow|swpNomove|swpNosize,
 		))
 		o.visible = true
-		o.requestPaintLocked()
+
+		// Force a flush on show so content is visible immediately.
+		o.flushPixels()
 	})
 }
 
@@ -339,7 +391,7 @@ func (o *OverlayWindow) Hide() {
 	})
 }
 
-// Clear resets queued draw commands.
+// Clear resets queued draw commands and clears the pixel buffer.
 func (o *OverlayWindow) Clear() {
 	if o == nil {
 		return
@@ -351,6 +403,10 @@ func (o *OverlayWindow) Clear() {
 	o.fills = o.fills[:0]
 	o.strokes = o.strokes[:0]
 	o.texts = o.texts[:0]
+	// Clear pixel buffer to transparent black (all zeros).
+	for i := range o.pixels {
+		o.pixels[i] = 0
+	}
 	o.dirty = true
 }
 
@@ -381,6 +437,10 @@ func (o *OverlayWindow) ResizeToActiveScreen() error {
 	}
 
 	runOnOverlayUI(func() {
+		o.mu.Lock()
+		o.pixels = make([]byte, o.width*o.height*bytesPerPixel)
+		o.mu.Unlock()
+
 		flags := uintptr(swpNoActivate)
 		if o.visible {
 			flags |= swpShowWindow
@@ -395,10 +455,6 @@ func (o *OverlayWindow) ResizeToActiveScreen() error {
 			uintptr(o.height),
 			flags,
 		))
-
-		if o.visible {
-			o.requestPaintLocked()
-		}
 	})
 
 	return nil
@@ -415,8 +471,7 @@ func (o *OverlayWindow) Destroy() {
 	})
 }
 
-// FillRect fills a rectangle with an ARGB color.
-// Bounds are window-local coordinates (0,0 at the overlay top-left).
+// FillRect fills a rectangle with an ARGB color (uses per-pixel alpha).
 func (o *OverlayWindow) FillRect(bounds image.Rectangle, color uint32) {
 	if o == nil || bounds.Empty() {
 		return
@@ -428,7 +483,7 @@ func (o *OverlayWindow) FillRect(bounds image.Rectangle, color uint32) {
 	}
 
 	o.mu.Lock()
-	o.fills = append(o.fills, rectFill{rect: rect, color: color})
+	o.fills = append(o.fills, rectFill{rect: rect, color: color, radius: 0})
 	o.dirty = true
 	o.mu.Unlock()
 }
@@ -442,12 +497,48 @@ func (o *OverlayWindow) StrokeRect(bounds image.Rectangle, color uint32, lineWid
 	width := max(int(lineWidth), 1)
 
 	o.mu.Lock()
-	o.strokes = append(o.strokes, rectStroke{rect: bounds, color: color, width: width})
+	o.strokes = append(o.strokes, rectStroke{rect: bounds, color: color, width: width, radius: 0})
 	o.dirty = true
 	o.mu.Unlock()
 }
 
-// DrawTextCentered renders centered text inside bounds using GDI.
+// FillRoundedRect fills a rounded rectangle with an ARGB color using
+// signed-distance-function anti-aliasing.
+func (o *OverlayWindow) FillRoundedRect(bounds image.Rectangle, radius float64, color uint32) {
+	if o == nil || bounds.Empty() || radius <= 0 {
+		o.FillRect(bounds, color)
+		return
+	}
+
+	rect := bounds.Intersect(o.localBounds())
+	if rect.Empty() {
+		return
+	}
+
+	o.mu.Lock()
+	o.fills = append(o.fills, rectFill{rect: rect, color: color, radius: radius})
+	o.dirty = true
+	o.mu.Unlock()
+}
+
+// StrokeRoundedRect draws a rounded rectangular border with the given ARGB
+// color, width, and corner radius, using signed-distance-function anti-aliasing.
+func (o *OverlayWindow) StrokeRoundedRect(bounds image.Rectangle, radius float64, color uint32, lineWidth float64) {
+	if o == nil || bounds.Empty() || lineWidth <= 0 || radius <= 0 {
+		o.StrokeRect(bounds, color, lineWidth)
+		return
+	}
+
+	width := max(int(lineWidth), 1)
+
+	o.mu.Lock()
+	o.strokes = append(o.strokes, rectStroke{rect: bounds, color: color, width: width, radius: radius})
+	o.dirty = true
+	o.mu.Unlock()
+}
+
+// DrawTextCentered renders centered text inside bounds using GDI onto the
+// pixel buffer with alpha compositing.
 func (o *OverlayWindow) DrawTextCentered(
 	text string,
 	bounds image.Rectangle,
@@ -475,307 +566,493 @@ func (o *OverlayWindow) DrawTextCentered(
 	o.mu.Unlock()
 }
 
-// Flush presents queued draw commands via WM_PAINT.
-//
-// It is a no-op when nothing changed since the last paint. The shared
-// indicator-polling loop calls Flush every ~16ms; without this guard each tick
-// forces a full-screen grid repaint (thousands of GDI calls), which on a slow
-// GPU outlasts the tick interval and saturates the single overlay UI thread.
-// That backlog starves mode-exit ops and makes the daemon look unresponsive
-// (idle/escape time out). Show and resize repaint directly, so they are
-// unaffected by this guard.
+// Flush composites all queued draw commands into the pixel buffer and presents
+// them via UpdateLayeredWindow.
 func (o *OverlayWindow) Flush() error {
 	if o == nil || o.hwnd == 0 {
-		return errOverlayNotInitialized
+		return errOverlayNotInit
 	}
 
 	o.mu.Lock()
 	dirty := o.dirty
+	if !dirty {
+		o.mu.Unlock()
+		return nil
+	}
+	o.dirty = false
+
+	fills := append([]rectFill(nil), o.fills...)
+	strokes := append([]rectStroke(nil), o.strokes...)
+	texts := append([]textDraw(nil), o.texts...)
+
+	o.fills = o.fills[:0]
+	o.strokes = o.strokes[:0]
+	o.texts = o.texts[:0]
+	// Copy pixels under the lock so compositing outside the lock is safe.
+	pixels := make([]byte, len(o.pixels))
+	copy(pixels, o.pixels)
 	o.mu.Unlock()
 
-	if !dirty {
-		return nil
+	// Render fills with alpha compositing.
+	for _, f := range fills {
+		if f.radius > 0 {
+			alphaFillRoundedRect(pixels, o.width, o.height, f.rect, f.radius, f.color)
+		} else {
+			alphaFillRect(pixels, o.width, o.height, f.rect, f.color)
+		}
+	}
+
+	// Render strokes with alpha compositing.
+	for _, s := range strokes {
+		if s.radius > 0 {
+			alphaStrokeRoundedRect(pixels, o.width, o.height, s.rect, s.radius, s.color, s.width)
+		} else {
+			alphaStrokeRect(pixels, o.width, o.height, s.rect, s.color, s.width)
+		}
+	}
+
+	// Render text via GDI onto a temporary bitmap, then composite.
+	for _, t := range texts {
+		renderTextAlphaInto(pixels, o.width, o.height, t)
 	}
 
 	runOnOverlayUI(func() {
-		o.requestPaintLocked()
+		// Swap rendered pixels under the lock.
+		o.mu.Lock()
+		o.pixels = pixels
+		o.mu.Unlock()
+		o.flushPixels()
 	})
 
 	return nil
 }
 
-func (o *OverlayWindow) createHWNDLocked() error {
-	className, err := windows.UTF16PtrFromString(overlayClassName)
-	if err != nil {
-		return err
-	}
-
-	width := o.bounds.Dx()
-
-	height := o.bounds.Dy()
-	if width <= 0 || height <= 0 {
-		return fmt.Errorf("%w: %v", errInvalidOverlayBounds, o.bounds)
-	}
-
-	hwnd, _, err := procCreateWindowExW.Call(
-		wsExLayered|wsExTransparent|wsExTopmost|wsExToolWindow|wsExNoActivate,
-		uintptr(unsafe.Pointer(className)),
-		0,
-		wsPopup,
-		uintptr(o.bounds.Min.X),
-		uintptr(o.bounds.Min.Y),
-		uintptr(width),
-		uintptr(height),
-		0,
-		0,
-		moduleHandle(),
-		0,
-	)
-	if hwnd == 0 {
-		return fmt.Errorf("CreateWindowExW: %w", err)
-	}
-
-	o.hwnd = windows.HWND(hwnd)
-	o.width = width
-	o.height = height
-	overlayRegistry.Store(o.hwnd, o)
-
-	ret, _, err := procSetLayeredWindowAttributes.Call(
-		hwnd,
-		overlayColorKey,
-		0,
-		lwaColorKey,
-	)
-	if ret == 0 {
-		return fmt.Errorf("SetLayeredWindowAttributes: %w", err)
-	}
-
-	const (
-		swpNomove = 0x0002
-		swpNosize = 0x0001
-	)
-
-	discardCall(procSetWindowPos.Call(
-		hwnd,
-		hwndTopMost,
-		0,
-		0,
-		0,
-		0,
-		swpNoActivate|swpNomove|swpNosize,
-	))
-	discardCall(procShowWindow.Call(hwnd, swHide))
-
-	o.visible = false
-
-	return nil
-}
-
-func (o *OverlayWindow) destroyHWNDLocked() {
-	if o.hwnd != 0 {
-		overlayRegistry.Delete(o.hwnd)
-		discardCall(procDestroyWindow.Call(uintptr(o.hwnd)))
-		o.hwnd = 0
-	}
-}
-
-func (o *OverlayWindow) prepareForDisplayLocked() {
+func (o *OverlayWindow) flushPixels() {
 	if o == nil || o.hwnd == 0 {
 		return
 	}
 
-	// Reapply after SW_HIDE; layered color-key can be lost across hide/show cycles.
-	discardCall(procSetLayeredWindowAttributes.Call(
+	hdcMem, _, _ := procCreateCompatibleDC.Call(0)
+	if hdcMem == 0 {
+		return
+	}
+	defer func() { discardCall(procDeleteDC.Call(hdcMem)) }()
+
+	bih := bitmapV4Header{
+		Size:        bmpV4Size,
+		Width:       int32(o.width),
+		Height:      -int32(o.height), // negative = top-down bitmap
+		Planes:      1,
+		BitCount:    32,
+		Compression: biBitfields,
+		SizeImage:   uint32(o.width * o.height * bytesPerPixel),
+		RedMask:     0x00FF0000,
+		GreenMask:   0x0000FF00,
+		BlueMask:    0x000000FF,
+		AlphaMask:   0xFF000000,
+		CSType:      0x206E6957, // 'Win '
+	}
+
+	var bits unsafe.Pointer
+	hDib, _, _ := procCreateDIBSection.Call(
+		hdcMem,
+		uintptr(unsafe.Pointer(&bih)),
+		0, // DIB_RGB_COLORS
+		uintptr(unsafe.Pointer(&bits)),
+		0,
+		0,
+	)
+	if hDib == 0 {
+		return
+	}
+	defer func() { discardCall(procDeleteObject.Call(hDib)) }()
+
+	// Copy pre-multiplied pixel data into the DIBSection.
+	discardCall(procRtlMoveMemory.Call(
+		uintptr(bits),
+		uintptr(unsafe.Pointer(&o.pixels[0])),
+		uintptr(len(o.pixels)),
+	))
+
+	prevObj, _, _ := procSelectObject.Call(hdcMem, hDib)
+	if prevObj == 0 {
+		return
+	}
+	defer func() { discardCall(procSelectObject.Call(hdcMem, prevObj)) }()
+
+	blend := blendFunction{
+		BlendOp:             acSrcOver,
+		AlphaFormat:         acSrcAlpha,
+		SourceConstantAlpha: 255,
+	}
+
+	discardCall(procUpdateLayeredWindow.Call(
 		uintptr(o.hwnd),
-		overlayColorKey,
+		hdcMem,
+		uintptr(unsafe.Pointer(&point{X: int32(o.bounds.Min.X), Y: int32(o.bounds.Min.Y)})),
+		uintptr(unsafe.Pointer(&size{CX: int32(o.width), CY: int32(o.height)})),
+		hdcMem,
+		uintptr(unsafe.Pointer(&point{})),
 		0,
-		lwaColorKey,
+		uintptr(unsafe.Pointer(&blend)),
+		ulwAlpha,
 	))
 }
 
-func (o *OverlayWindow) localBounds() image.Rectangle {
-	return image.Rect(0, 0, o.width, o.height)
-}
-
-func (o *OverlayWindow) requestPaintLocked() {
-	if o == nil || o.hwnd == 0 {
+func renderTextAlphaInto(pixels []byte, w, h int, t textDraw) {
+	hdcMem, _, _ := procCreateCompatibleDC.Call(0)
+	if hdcMem == 0 {
 		return
 	}
+	defer func() { discardCall(procDeleteDC.Call(hdcMem)) }()
 
-	discardCall(procInvalidateRect.Call(uintptr(o.hwnd), 0, 1))
-	discardCall(procUpdateWindow.Call(uintptr(o.hwnd)))
-}
+	bih := bitmapV4Header{
+		Size:        bmpV4Size,
+		Width:       int32(w),
+		Height:      -int32(h),
+		Planes:      1,
+		BitCount:    32,
+		Compression: biBitfields,
+		SizeImage:   uint32(w * h * bytesPerPixel),
+		RedMask:     0x00FF0000,
+		GreenMask:   0x0000FF00,
+		BlueMask:    0x000000FF,
+		AlphaMask:   0xFF000000,
+		CSType:      0x206E6957,
+	}
 
-func (o *OverlayWindow) paintLocked(hdc windows.Handle) {
-	if o == nil {
+	var bits unsafe.Pointer
+	hDib, _, _ := procCreateDIBSection.Call(
+		hdcMem,
+		uintptr(unsafe.Pointer(&bih)),
+		0,
+		uintptr(unsafe.Pointer(&bits)),
+		0,
+		0,
+	)
+	if hDib == 0 {
 		return
 	}
+	defer func() { discardCall(procDeleteObject.Call(hDib)) }()
 
-	o.mu.Lock()
-	fills := append([]rectFill(nil), o.fills...)
-	strokes := append([]rectStroke(nil), o.strokes...)
-	texts := append([]textDraw(nil), o.texts...)
-	o.dirty = false
-	o.mu.Unlock()
-
-	// Paint straight onto the BeginPaint DC. DWM redirects the whole WM_PAINT
-	// batch to an offscreen surface and composites it atomically, so a manual
-	// memory-DC double buffer adds no flicker protection here. It also breaks on
-	// virtual GPUs where the compositing BitBlt silently no-ops (reports success
-	// but copies nothing), leaving the overlay blank.
-	o.renderCommands(hdc, fills, strokes, texts)
-}
-
-func (o *OverlayWindow) renderCommands(
-	hdc windows.Handle,
-	fills []rectFill,
-	strokes []rectStroke,
-	texts []textDraw,
-) {
-	client := windows.Rect{
-		Left:   0,
-		Top:    0,
-		Right:  int32(o.width),
-		Bottom: int32(o.height),
-	}
-
-	bgBrush, _, _ := procCreateSolidBrush.Call(overlayColorKey)
-	if bgBrush != 0 {
-		discardCall(procFillRect.Call(uintptr(hdc), uintptr(unsafe.Pointer(&client)), bgBrush))
-		discardCall(procDeleteObject.Call(bgBrush))
-	}
-
-	for _, fill := range fills {
-		o.fillRectGDI(hdc, fill.rect, fill.color)
-	}
-
-	for _, stroke := range strokes {
-		o.strokeRectGDI(hdc, stroke.rect, stroke.color, stroke.width)
-	}
-
-	for _, text := range texts {
-		o.drawTextGDI(hdc, text)
-	}
-}
-
-func (o *OverlayWindow) fillRectGDI(hdc windows.Handle, rect image.Rectangle, color uint32) {
-	if rect.Empty() {
+	prevObj, _, _ := procSelectObject.Call(hdcMem, hDib)
+	if prevObj == 0 {
 		return
 	}
+	defer func() { discardCall(procSelectObject.Call(hdcMem, prevObj)) }()
 
-	brush, _, _ := procCreateSolidBrush.Call(uintptr(o.argbToGDI(color)))
-	if brush == 0 {
-		return
+	tmpPixels := (*[1 << 30]byte)(bits)[: w*h*bytesPerPixel : w*h*bytesPerPixel]
+	for i := range tmpPixels {
+		tmpPixels[i] = 0
 	}
 
-	defer func() { discardCall(procDeleteObject.Call(brush)) }()
-
-	winRect := windows.Rect{
-		Left:   int32(rect.Min.X),
-		Top:    int32(rect.Min.Y),
-		Right:  int32(rect.Max.X),
-		Bottom: int32(rect.Max.Y),
-	}
-	discardCall(procFillRect.Call(uintptr(hdc), uintptr(unsafe.Pointer(&winRect)), brush))
-}
-
-func (o *OverlayWindow) strokeRectGDI(
-	hdc windows.Handle,
-	bounds image.Rectangle,
-	color uint32,
-	width int,
-) {
-	if bounds.Empty() || width < 1 {
-		return
-	}
-
-	for i := range width {
-		inset := bounds.Inset(i)
-		o.fillRectGDI(hdc, image.Rect(inset.Min.X, inset.Min.Y, inset.Max.X, inset.Min.Y+1), color)
-		o.fillRectGDI(hdc, image.Rect(inset.Min.X, inset.Max.Y-1, inset.Max.X, inset.Max.Y), color)
-		o.fillRectGDI(hdc, image.Rect(inset.Min.X, inset.Min.Y, inset.Min.X+1, inset.Max.Y), color)
-		o.fillRectGDI(hdc, image.Rect(inset.Max.X-1, inset.Min.Y, inset.Max.X, inset.Max.Y), color)
-	}
-}
-
-func (o *OverlayWindow) drawTextGDI(hdc windows.Handle, text textDraw) {
-	size := int(-text.fontSize)
+	size := int(-t.fontSize)
 	if size == 0 {
-		size = defaultFontHeight
+		size = -14
 	}
 
-	fontName, err := windows.UTF16PtrFromString(text.fontFamily)
+	fontName, err := windows.UTF16PtrFromString(t.fontFamily)
 	if err != nil {
 		return
 	}
 
 	hFont, _, _ := procCreateFontW.Call(
-		uintptr(size),
-		0,
-		0,
-		0,
-		fwBold,
-		0,
-		0,
-		0,
-		1,
-		0,
-		0,
-		0,
-		0,
+		uintptr(size), 0, 0, 0, fwBold, 0, 0, 0, 1, 0, 0, 0, 0,
 		uintptr(unsafe.Pointer(fontName)),
 	)
 	if hFont == 0 {
 		return
 	}
-
 	defer func() { discardCall(procDeleteObject.Call(hFont)) }()
 
-	discardCall(procSetBkMode.Call(uintptr(hdc), transparentBk))
-	discardCall(procSetTextColor.Call(uintptr(hdc), uintptr(o.argbToGDI(text.color))))
+	prevFont, _, _ := procSelectObject.Call(hdcMem, hFont)
+	if prevFont == 0 {
+		return
+	}
+	defer func() { discardCall(procSelectObject.Call(hdcMem, prevFont)) }()
 
-	utf16Text, err := windows.UTF16FromString(text.text)
+	discardCall(procSetBkMode.Call(hdcMem, transparentBk))
+	discardCall(procSetTextColor.Call(hdcMem, 0x00FFFFFF))
+
+	utf16Text, err := windows.UTF16FromString(t.text)
 	if err != nil {
 		return
 	}
 
 	rect := windows.Rect{
-		Left:   int32(text.rect.Min.X),
-		Top:    int32(text.rect.Min.Y),
-		Right:  int32(text.rect.Max.X),
-		Bottom: int32(text.rect.Max.Y),
+		Left:   int32(t.rect.Min.X),
+		Top:    int32(t.rect.Min.Y),
+		Right:  int32(t.rect.Max.X),
+		Bottom: int32(t.rect.Max.Y),
 	}
 
+	var procDrawTextW = user32.NewProc("DrawTextW")
 	discardCall(procDrawTextW.Call(
-		uintptr(hdc),
+		hdcMem,
 		uintptr(unsafe.Pointer(&utf16Text[0])),
 		uintptr(^uint32(0)),
 		uintptr(unsafe.Pointer(&rect)),
 		dtCenter|dtVCenter|dtSingleLine,
 	))
+
+	alphaCompositeText(pixels, w, h, tmpPixels, t.color)
 }
 
-func (o *OverlayWindow) argbToGDI(argb uint32) uint32 {
-	blend := ThemeSurfaceRGB()
-	if o != nil {
-		o.mu.Lock()
-		if o.colorBlendRGB != 0 {
-			blend = o.colorBlendRGB
-		}
-		o.mu.Unlock()
+// alphaFillRect composites a semi-transparent ARGB fill over the pixel buffer.
+func alphaFillRect(pixels []byte, w, h int, rect image.Rectangle, color uint32) {
+	a := uint32(color >> 24)
+	if a == 0 {
+		return
 	}
 
-	return argbToGDIColorRef(argb, blend)
+	r := (color >> 16) & 0xFF
+	g := (color >> 8) & 0xFF
+	b := color & 0xFF
+
+	// Pre-multiply the source color by its alpha.
+	sr := r * a
+	sg := g * a
+	sb := b * a
+
+	ia := 255 - a
+	y0 := clamp(rect.Min.Y, 0, h)
+	y1 := clamp(rect.Max.Y, 0, h)
+	x0 := clamp(rect.Min.X, 0, w)
+	x1 := clamp(rect.Max.X, 0, w)
+
+	for y := y0; y < y1; y++ {
+		row := y * w * bytesPerPixel
+		for x := x0; x < x1; x++ {
+			idx := row + x*bytesPerPixel
+			dstB := uint32(pixels[idx])
+			dstG := uint32(pixels[idx+1])
+			dstR := uint32(pixels[idx+2])
+			dstA := uint32(pixels[idx+3])
+
+			pixels[idx] = byte((sb + dstB*ia) / 255)
+			pixels[idx+1] = byte((sg + dstG*ia) / 255)
+			pixels[idx+2] = byte((sr + dstR*ia) / 255)
+			pixels[idx+3] = byte((a + dstA*ia) / 255)
+		}
+	}
+}
+
+// alphaStrokeRect composites a stroked rectangle border over the pixel buffer.
+func alphaStrokeRect(pixels []byte, w, h int, rect image.Rectangle, color uint32, width int) {
+	if width < 1 {
+		return
+	}
+
+	for i := range width {
+		inset := rect.Inset(i)
+		// Top edge
+		alphaFillRect(pixels, w, h,
+			image.Rect(inset.Min.X, inset.Min.Y, inset.Max.X, inset.Min.Y+1), color)
+		// Bottom edge
+		alphaFillRect(pixels, w, h,
+			image.Rect(inset.Min.X, inset.Max.Y-1, inset.Max.X, inset.Max.Y), color)
+		// Left edge
+		alphaFillRect(pixels, w, h,
+			image.Rect(inset.Min.X, inset.Min.Y, inset.Min.X+1, inset.Max.Y), color)
+		// Right edge
+		alphaFillRect(pixels, w, h,
+			image.Rect(inset.Max.X-1, inset.Min.Y, inset.Max.X, inset.Max.Y), color)
+	}
+}
+
+// sdRoundedBox computes the signed distance from a point (px, py) to a rounded
+// rectangle centered at the origin with half-extents (halfW, halfH) and corner
+// radius r.  Negative inside, positive outside, zero at the boundary.
+func sdRoundedBox(px, py, halfW, halfH, r float64) float64 {
+	qx := math.Abs(px) - halfW + r
+	qy := math.Abs(py) - halfH + r
+
+	insideX := math.Max(qx, 0)
+	insideY := math.Max(qy, 0)
+	outside := math.Sqrt(insideX*insideX+insideY*insideY) - r
+
+	inside := math.Min(math.Max(qx, qy), 0)
+
+	return outside + inside
+}
+
+// alphaFillRoundedRect composites an anti-aliased rounded rectangle fill
+// using signed-distance-function edge smoothing.
+func alphaFillRoundedRect(pixels []byte, w, h int, rect image.Rectangle, radius float64, color uint32) {
+	a := uint32(color >> 24)
+	if a == 0 {
+		return
+	}
+
+	r := (color >> 16) & 0xFF
+	g := (color >> 8) & 0xFF
+	b := color & 0xFF
+
+	halfW := float64(rect.Dx()) / 2.0
+	halfH := float64(rect.Dy()) / 2.0
+	centerX := float64(rect.Min.X) + halfW
+	centerY := float64(rect.Min.Y) + halfH
+
+	y0 := clamp(rect.Min.Y, 0, h)
+	y1 := clamp(rect.Max.Y, 0, h)
+	x0 := clamp(rect.Min.X, 0, w)
+	x1 := clamp(rect.Max.X, 0, w)
+
+	for y := y0; y < y1; y++ {
+		row := y * w * bytesPerPixel
+		for x := x0; x < x1; x++ {
+			d := sdRoundedBox(float64(x)-centerX, float64(y)-centerY, halfW, halfH, radius)
+			if d > 1 {
+				continue
+			}
+
+			pixelAlpha := uint32(math.Max(0, math.Min(1, 1.0-d)) * float64(a))
+			if pixelAlpha == 0 {
+				continue
+			}
+
+			ia := 255 - pixelAlpha
+			sr := r * pixelAlpha
+			sg := g * pixelAlpha
+			sb := b * pixelAlpha
+
+			idx := row + x*bytesPerPixel
+			dstB := uint32(pixels[idx])
+			dstG := uint32(pixels[idx+1])
+			dstR := uint32(pixels[idx+2])
+			dstA := uint32(pixels[idx+3])
+
+			pixels[idx] = byte((sb + dstB*ia) / 255)
+			pixels[idx+1] = byte((sg + dstG*ia) / 255)
+			pixels[idx+2] = byte((sr + dstR*ia) / 255)
+			pixels[idx+3] = byte((pixelAlpha + dstA*ia) / 255)
+		}
+	}
+}
+
+// alphaStrokeRoundedRect composites an anti-aliased rounded rectangle stroke
+// using signed-distance-function edge smoothing at both outer and inner edges.
+func alphaStrokeRoundedRect(pixels []byte, w, h int, rect image.Rectangle, radius float64, color uint32, width int) {
+	if width < 1 {
+		return
+	}
+
+	a := uint32(color >> 24)
+	if a == 0 {
+		return
+	}
+
+	r := (color >> 16) & 0xFF
+	g := (color >> 8) & 0xFF
+	b := color & 0xFF
+
+	halfW := float64(rect.Dx()) / 2.0
+	halfH := float64(rect.Dy()) / 2.0
+	centerX := float64(rect.Min.X) + halfW
+	centerY := float64(rect.Min.Y) + halfH
+
+	strokeW := float64(width)
+	innerRadius := math.Max(radius-strokeW, 0)
+	innerHalfW := math.Max(halfW-strokeW, 0)
+	innerHalfH := math.Max(halfH-strokeW, 0)
+
+	y0 := clamp(rect.Min.Y, 0, h)
+	y1 := clamp(rect.Max.Y, 0, h)
+	x0 := clamp(rect.Min.X, 0, w)
+	x1 := clamp(rect.Max.X, 0, w)
+
+	for y := y0; y < y1; y++ {
+		row := y * w * bytesPerPixel
+		for x := x0; x < x1; x++ {
+			px := float64(x) - centerX
+			py := float64(y) - centerY
+
+			dOuter := sdRoundedBox(px, py, halfW, halfH, radius)
+			if dOuter > 1 {
+				continue
+			}
+
+			dInner := sdRoundedBox(px, py, innerHalfW, innerHalfH, innerRadius)
+
+			outerAlpha := math.Max(0, math.Min(1, 1.0-dOuter))
+			innerAlpha := math.Max(0, math.Min(1, 1.0-dInner))
+			pixelAlpha := uint32(outerAlpha * (1.0 - innerAlpha) * float64(a))
+			if pixelAlpha == 0 {
+				continue
+			}
+
+			ia := 255 - pixelAlpha
+			sr := r * pixelAlpha
+			sg := g * pixelAlpha
+			sb := b * pixelAlpha
+
+			idx := row + x*bytesPerPixel
+			dstB := uint32(pixels[idx])
+			dstG := uint32(pixels[idx+1])
+			dstR := uint32(pixels[idx+2])
+			dstA := uint32(pixels[idx+3])
+
+			pixels[idx] = byte((sb + dstB*ia) / 255)
+			pixels[idx+1] = byte((sg + dstG*ia) / 255)
+			pixels[idx+2] = byte((sr + dstR*ia) / 255)
+			pixels[idx+3] = byte((pixelAlpha + dstA*ia) / 255)
+		}
+	}
+}
+
+// alphaCompositeText composites a GDI-rendered white-on-transparent text bitmap
+// over the main pixel buffer using the given ARGB color.
+func alphaCompositeText(pixels []byte, w, h int, textPixels []byte, color uint32) {
+	ta := (color >> 24) & 0xFF
+	if ta == 0 {
+		return
+	}
+	tr := (color >> 16) & 0xFF
+	tg := (color >> 8) & 0xFF
+	tb := color & 0xFF
+
+	for y := 0; y < h; y++ {
+		row := y * w * bytesPerPixel
+		for x := 0; x < w; x++ {
+			idx := row + x*bytesPerPixel
+			// Extract coverage from the rendered white pixel (R channel).
+			coverage := uint32(textPixels[idx+2])
+			if coverage == 0 {
+				continue
+			}
+
+			srcA := coverage * ta / 255
+			sr := tr * srcA
+			sg := tg * srcA
+			sb := tb * srcA
+			ia := 255 - srcA
+
+			dstB := uint32(pixels[idx])
+			dstG := uint32(pixels[idx+1])
+			dstR := uint32(pixels[idx+2])
+			dstA := uint32(pixels[idx+3])
+
+			pixels[idx] = byte((sb + dstB*ia) / 255)
+			pixels[idx+1] = byte((sg + dstG*ia) / 255)
+			pixels[idx+2] = byte((sr + dstR*ia) / 255)
+			pixels[idx+3] = byte((srcA + dstA*ia) / 255)
+		}
+	}
+}
+
+func clamp(val, min, max int) int {
+	if val < min {
+		return min
+	}
+	if val > max {
+		return max
+	}
+	return val
 }
 
 func moduleHandle() uintptr {
 	handle, _, _ := procGetModuleHandleW.Call(0)
-
 	return handle
 }
 
-// discardCall consumes the result of a fire-and-forget user32/gdi32 syscall.
-// These draw and window-management calls have no actionable failure path here,
-// and routing them through a sink keeps errcheck satisfied without a bare
-// `_, _, _ =` assignment (which trips the dogsled blank-identifier linter).
 func discardCall(uintptr, uintptr, error) {}

--- a/internal/core/infra/platform/windows/overlay_color.go
+++ b/internal/core/infra/platform/windows/overlay_color.go
@@ -19,8 +19,10 @@ const (
 	maxChannel = 255
 )
 
+// rgbToColorRef converts individual R/G/B channels into a Win32 COLORREF.
+// COLORREF format is 0x00BBGGRR: B in the highest byte, R in the lowest byte.
 func rgbToColorRef(red, green, blue uint8) uint32 {
-	return uint32(blue) | (uint32(green) << greenShift) | (uint32(red) << redShift)
+	return uint32(red) | (uint32(green) << greenShift) | (uint32(blue) << redShift)
 }
 
 // argbToGDIColorRef converts AARRGGBB to an opaque COLORREF for GDI.

--- a/internal/ui/overlay/manager_darwin.go
+++ b/internal/ui/overlay/manager_darwin.go
@@ -166,6 +166,10 @@ func (m *Manager) Clear() {
 	}
 }
 
+// ClearCache is a no-op on Darwin; each overlay owns its own NSWindow and
+// does not retain stale cross-mode cache state.
+func (m *Manager) ClearCache() {}
+
 // ResizeToActiveScreen resizes the overlay window to the active screen.
 func (m *Manager) ResizeToActiveScreen() {
 	C.NeruResizeOverlayToActiveScreen(m.window)

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -214,6 +214,10 @@ func (m *Manager) Clear() {
 	m.modeIndicatorBadgeRect = image.Rectangle{}
 }
 
+// ClearCache is a no-op on Linux; the overlay backend does not retain stale
+// cross-mode cache state.
+func (m *Manager) ClearCache() {}
+
 // ResizeToActiveScreen resizes the overlay to the active screen.
 func (m *Manager) ResizeToActiveScreen() {
 	m.renderMu.Lock()

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -474,7 +474,12 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 		config.ModeIndicatorBorderColorDark,
 	)
 
-	badgeBounds := image.Rect(borderWidth, borderWidth, badgeWidth+borderWidth, badgeHeight+borderWidth)
+	badgeBounds := image.Rect(
+		borderWidth,
+		borderWidth,
+		badgeWidth+borderWidth,
+		badgeHeight+borderWidth,
+	)
 
 	m.indicatorWin.FillRect(badgeBounds, parseHexColorARGB(bgColor))
 	if borderWidth > 0 {
@@ -561,7 +566,12 @@ func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 		config.StickyModifiersBorderColorDark,
 	)
 
-	badgeBounds := image.Rect(borderWidth, borderWidth, badgeWidth+borderWidth, badgeHeight+borderWidth)
+	badgeBounds := image.Rect(
+		borderWidth,
+		borderWidth,
+		badgeWidth+borderWidth,
+		badgeHeight+borderWidth,
+	)
 
 	m.stickyWin.FillRect(badgeBounds, parseHexColorARGB(bgColor))
 	if borderWidth > 0 {

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -622,6 +622,8 @@ func (m *Manager) DrawMouseActionIndicator(
 		return
 	}
 
+	m.win.Clear()
+
 	size := max(style.Size, 1)
 	half := size / 2 //nolint:mnd // simple arithmetic
 	bounds := image.Rect(point.X-half, point.Y-half, point.X+half, point.Y+half)

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -367,6 +367,12 @@ func (m *Manager) DrawHintSearchInput(
 
 	m.win.Resize()
 
+	if m.win.lastHints != nil {
+		m.win.DrawHints(m.win.lastHints, m.win.lastHintStyle)
+	} else {
+		m.win.Clear()
+	}
+
 	pos := frame.Position()
 	width := frame.Width()
 

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -396,7 +396,10 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 	// content, so clearForIndicator() is a no-op and the badge draws on top.
 	// In scroll mode the buffer is cleared so only the current badge is shown.
 	m.win.clearForIndicator()
-	m.win.Show()
+	// EnsureVisible makes the HWND visible without flushing, avoiding the
+	// blink that Show()'s intermediate flush would cause. The single
+	// flushOverlay() below composites the badge and sends the frame.
+	m.win.EnsureVisible()
 
 	offsetX := cfg.UI.IndicatorXOffset
 	offsetY := cfg.UI.IndicatorYOffset
@@ -482,7 +485,7 @@ func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 
 	// Clear stale indicator badges before drawing the new one.
 	m.win.clearForIndicator()
-	m.win.Show()
+	m.win.EnsureVisible()
 
 	bgColor := ui.BackgroundColor.ForTheme(
 		m.stickyModifiersOverlay.Theme(),

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -374,6 +374,8 @@ func (m *Manager) DrawHintSearchInput(
 		parseHexColorARGB(style.TextColor()),
 	)
 
+	m.win.flushOverlay("search-input")
+
 	return nil
 }
 
@@ -633,6 +635,9 @@ func (m *Manager) DrawMouseActionIndicator(
 		borderColor,
 		float64(max(style.BorderWidth, 0)),
 	)
+
+	m.win.flushOverlay("mouse-action")
+	m.win.Show()
 }
 
 // modeIndicatorLabel returns the configured label for the given mode string.

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -391,9 +391,11 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 
 	m.win.Resize()
 
-	// Ensure the overlay is visible before drawing the indicator.
-	// Show() redraws from cache if needed and flushes, so the indicator
-	// drawn below will appear on top of the current content.
+	// Clear stale indicator badges from the pixel buffer before drawing the
+	// new one. In grid/hints mode the buffer already contains the rendered
+	// content, so clearForIndicator() is a no-op and the badge draws on top.
+	// In scroll mode the buffer is cleared so only the current badge is shown.
+	m.win.clearForIndicator()
 	m.win.Show()
 
 	offsetX := cfg.UI.IndicatorXOffset
@@ -478,7 +480,8 @@ func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 		return
 	}
 
-	// Ensure the overlay is visible before drawing on it.
+	// Clear stale indicator badges before drawing the new one.
+	m.win.clearForIndicator()
 	m.win.Show()
 
 	bgColor := ui.BackgroundColor.ForTheme(

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -397,7 +397,7 @@ func (m *Manager) HideHintSearchInput() {
 // layered window that repositions every tick to follow the cursor. This
 // avoids the clear-then-flush blink that occurs when drawing transient
 // badges into the shared full-screen overlay pixel buffer.
-func (m *Manager) DrawModeIndicator(x, y int) {
+func (m *Manager) DrawModeIndicator(cursorX, cursorY int) {
 	if m.modeIndicatorOverlay == nil {
 		return
 	}
@@ -408,6 +408,7 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 	}
 
 	cfg := m.modeIndicatorOverlay.IndicatorConfig()
+
 	label := modeIndicatorLabel(cfg, string(mode))
 	if label == "" {
 		return
@@ -426,10 +427,10 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 	badgeHeight := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
 	borderWidth := max(cfg.UI.BorderWidth, 0)
 
-	posX := x + offsetX - borderWidth
-	posY := y + offsetY - borderWidth
-	sizeX := badgeWidth + borderWidth*2
-	sizeY := badgeHeight + borderWidth*2
+	posX := cursorX + offsetX - borderWidth
+	posY := cursorY + offsetY - borderWidth
+	sizeX := badgeWidth + borderWidth*2  //nolint:mnd // simple arithmetic
+	sizeY := badgeHeight + borderWidth*2 //nolint:mnd // simple arithmetic
 
 	// Lazily create the small indicator overlay window.
 	if m.indicatorWin == nil || !m.indicatorWin.Healthy() {
@@ -482,9 +483,11 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 	)
 
 	m.indicatorWin.FillRect(badgeBounds, parseHexColorARGB(bgColor))
+
 	if borderWidth > 0 {
 		m.indicatorWin.StrokeRect(badgeBounds, parseHexColorARGB(borderColor), float64(borderWidth))
 	}
+
 	m.indicatorWin.DrawTextCentered(
 		label,
 		badgeBounds,
@@ -496,34 +499,40 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 	// Flush composites fills/strokes/texts into the pixel buffer and sends
 	// the frame to the HWND via UpdateLayeredWindow. Must be called before
 	// Show() so the window appears with the badge already rendered.
-	m.indicatorWin.Flush()
+	err := m.indicatorWin.Flush()
+	if err != nil {
+		if m.logger != nil {
+			m.logger.Error("indicator flush failed", zap.Error(err))
+		}
+	}
+
 	m.indicatorWin.Show()
 }
 
 // DrawStickyModifiersIndicator renders a sticky modifiers indicator badge in
 // its own dedicated layered window, following the cursor without touching the
 // shared overlay.
-func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
+func (m *Manager) DrawStickyModifiersIndicator(cursorX, cursorY int, symbols string) {
 	if m.stickyModifiersOverlay == nil || symbols == "" {
 		return
 	}
 
-	ui := m.stickyModifiersOverlay.UI()
-	fontSize := float64(max(ui.FontSize, 1))
+	indicatorUI := m.stickyModifiersOverlay.UI()
+	fontSize := float64(max(indicatorUI.FontSize, 1))
 
-	paddingX := resolveWinAutoPadding(fontSize, ui.PaddingX, true)
-	paddingY := resolveWinAutoPadding(fontSize, ui.PaddingY, false)
+	paddingX := resolveWinAutoPadding(fontSize, indicatorUI.PaddingX, true)
+	paddingY := resolveWinAutoPadding(fontSize, indicatorUI.PaddingY, false)
 	badgeWidth := estimateWinTextWidth(symbols, fontSize) + paddingX*winPaddingMultiplier
 	badgeHeight := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
-	borderWidth := max(ui.BorderWidth, 0)
+	borderWidth := max(indicatorUI.BorderWidth, 0)
 
-	offsetX := ui.IndicatorXOffset
-	offsetY := ui.IndicatorYOffset
+	offsetX := indicatorUI.IndicatorXOffset
+	offsetY := indicatorUI.IndicatorYOffset
 
-	posX := x + offsetX - borderWidth
-	posY := y + offsetY - borderWidth
-	sizeX := badgeWidth + borderWidth*2
-	sizeY := badgeHeight + borderWidth*2
+	posX := cursorX + offsetX - borderWidth
+	posY := cursorY + offsetY - borderWidth
+	sizeX := badgeWidth + borderWidth*2  //nolint:mnd // simple arithmetic
+	sizeY := badgeHeight + borderWidth*2 //nolint:mnd // simple arithmetic
 
 	m.renderMu.Lock()
 	defer m.renderMu.Unlock()
@@ -550,17 +559,17 @@ func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 
 	m.stickyWin.Clear()
 
-	bgColor := ui.BackgroundColor.ForTheme(
+	bgColor := indicatorUI.BackgroundColor.ForTheme(
 		m.stickyModifiersOverlay.Theme(),
 		config.StickyModifiersBackgroundColorLight,
 		config.StickyModifiersBackgroundColorDark,
 	)
-	textColor := ui.TextColor.ForTheme(
+	textColor := indicatorUI.TextColor.ForTheme(
 		m.stickyModifiersOverlay.Theme(),
 		config.StickyModifiersTextColorLight,
 		config.StickyModifiersTextColorDark,
 	)
-	borderColor := ui.BorderColor.ForTheme(
+	borderColor := indicatorUI.BorderColor.ForTheme(
 		m.stickyModifiersOverlay.Theme(),
 		config.StickyModifiersBorderColorLight,
 		config.StickyModifiersBorderColorDark,
@@ -574,18 +583,26 @@ func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 	)
 
 	m.stickyWin.FillRect(badgeBounds, parseHexColorARGB(bgColor))
+
 	if borderWidth > 0 {
 		m.stickyWin.StrokeRect(badgeBounds, parseHexColorARGB(borderColor), float64(borderWidth))
 	}
+
 	m.stickyWin.DrawTextCentered(
 		symbols,
 		badgeBounds,
-		ports.ResolveFont(ui.FontFamily, false),
+		ports.ResolveFont(indicatorUI.FontFamily, false),
 		fontSize,
 		parseHexColorARGB(textColor),
 	)
 
-	m.stickyWin.Flush()
+	err := m.stickyWin.Flush()
+	if err != nil {
+		if m.logger != nil {
+			m.logger.Error("sticky flush failed", zap.Error(err))
+		}
+	}
+
 	m.stickyWin.Show()
 }
 
@@ -604,7 +621,7 @@ func (m *Manager) DrawMouseActionIndicator(
 	}
 
 	size := max(style.Size, 1)
-	half := size / 2
+	half := size / 2 //nolint:mnd // simple arithmetic
 	bounds := image.Rect(point.X-half, point.Y-half, point.X+half, point.Y+half)
 
 	bgColor := parseHexColorARGB(style.BackgroundColor)

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -488,6 +488,10 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 		parseHexColorARGB(textColor),
 	)
 
+	// Flush composites fills/strokes/texts into the pixel buffer and sends
+	// the frame to the HWND via UpdateLayeredWindow. Must be called before
+	// Show() so the window appears with the badge already rendered.
+	m.indicatorWin.Flush()
 	m.indicatorWin.Show()
 }
 
@@ -571,6 +575,7 @@ func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 		parseHexColorARGB(textColor),
 	)
 
+	m.stickyWin.Flush()
 	m.stickyWin.Show()
 }
 

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -24,6 +24,7 @@ import (
 	"github.com/y3owk1n/neru/internal/config"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	winplatform "github.com/y3owk1n/neru/internal/core/infra/platform/windows"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
@@ -40,6 +41,17 @@ type Manager struct {
 
 	renderMu sync.Mutex
 	win      *winOverlay
+
+	// indicatorWin is a small dedicated layered window for the mode
+	// indicator badge. It is created lazily on first use and repositioned
+	// every tick. Keeping it separate from the main overlay avoids the
+	// clear-then-flush blink caused by drawing transient badges into the
+	// shared full-screen pixel buffer.
+	indicatorWin *winplatform.OverlayWindow
+
+	// stickyWin is a small dedicated layered window for the sticky modifiers
+	// indicator badge, same pattern as indicatorWin.
+	stickyWin *winplatform.OverlayWindow
 
 	hintOverlay            *hints.Overlay
 	gridOverlay            *grid.Overlay
@@ -102,6 +114,14 @@ func (m *Manager) Hide() {
 
 	if m.win != nil {
 		m.win.Hide()
+	}
+
+	if m.indicatorWin != nil {
+		m.indicatorWin.Hide()
+	}
+
+	if m.stickyWin != nil {
+		m.stickyWin.Hide()
 	}
 }
 
@@ -190,6 +210,16 @@ func (m *Manager) Destroy() {
 	if m.win != nil {
 		m.win.Destroy()
 		m.win = nil
+	}
+
+	if m.indicatorWin != nil {
+		m.indicatorWin.Destroy()
+		m.indicatorWin = nil
+	}
+
+	if m.stickyWin != nil {
+		m.stickyWin.Destroy()
+		m.stickyWin = nil
 	}
 }
 
@@ -363,7 +393,10 @@ func (m *Manager) HideHintSearchInput() {
 	}
 }
 
-// DrawModeIndicator renders a mode indicator badge on the Windows overlay.
+// DrawModeIndicator renders a mode indicator badge in its own dedicated
+// layered window that repositions every tick to follow the cursor. This
+// avoids the clear-then-flush blink that occurs when drawing transient
+// badges into the shared full-screen overlay pixel buffer.
 func (m *Manager) DrawModeIndicator(x, y int) {
 	if m.modeIndicatorOverlay == nil {
 		return
@@ -383,24 +416,6 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 	m.renderMu.Lock()
 	defer m.renderMu.Unlock()
 
-	m.ensureWinOverlayLocked()
-
-	if m.win == nil {
-		return
-	}
-
-	m.win.Resize()
-
-	// Clear stale indicator badges from the pixel buffer before drawing the
-	// new one. In grid/hints mode the buffer already contains the rendered
-	// content, so clearForIndicator() is a no-op and the badge draws on top.
-	// In scroll mode the buffer is cleared so only the current badge is shown.
-	m.win.clearForIndicator()
-	// EnsureVisible makes the HWND visible without flushing, avoiding the
-	// blink that Show()'s intermediate flush would cause. The single
-	// flushOverlay() below composites the badge and sends the frame.
-	m.win.EnsureVisible()
-
 	offsetX := cfg.UI.IndicatorXOffset
 	offsetY := cfg.UI.IndicatorYOffset
 	fontSize := float64(max(cfg.UI.FontSize, 1))
@@ -409,11 +424,35 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 	paddingY := resolveWinAutoPadding(fontSize, cfg.UI.PaddingY, false)
 	badgeWidth := estimateWinTextWidth(label, fontSize) + paddingX*winPaddingMultiplier
 	badgeHeight := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
+	borderWidth := max(cfg.UI.BorderWidth, 0)
 
-	bounds := image.Rect(
-		x+offsetX, y+offsetY,
-		x+offsetX+badgeWidth, y+offsetY+badgeHeight,
-	)
+	posX := x + offsetX - borderWidth
+	posY := y + offsetY - borderWidth
+	sizeX := badgeWidth + borderWidth*2
+	sizeY := badgeHeight + borderWidth*2
+
+	// Lazily create the small indicator overlay window.
+	if m.indicatorWin == nil || !m.indicatorWin.Healthy() {
+		if m.indicatorWin != nil {
+			m.indicatorWin.Destroy()
+		}
+
+		win, err := winplatform.NewOverlayWindowAt(posX, posY, sizeX, sizeY)
+		if err != nil {
+			if m.logger != nil {
+				m.logger.Error("failed to create indicator overlay window", zap.Error(err))
+			}
+
+			return
+		}
+
+		m.indicatorWin = win
+	} else {
+		_ = m.indicatorWin.ResizeTo(posX, posY, sizeX, sizeY)
+	}
+
+	// Clear and draw the badge into the small window.
+	m.indicatorWin.Clear()
 
 	modeCfg := m.modeIndicatorOverlay.ModeConfig(string(mode))
 	bgColor := modeCfg.BackgroundColor.ForThemeWithOverride(
@@ -434,28 +473,27 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 		config.ModeIndicatorBorderColorLight,
 		config.ModeIndicatorBorderColorDark,
 	)
-	borderWidth := cfg.UI.BorderWidth
 
-	m.win.drawFilledRect(
-		bounds,
-		parseHexColorARGB(bgColor),
-		parseHexColorARGB(borderColor),
-		float64(max(borderWidth, 0)),
-	)
-	m.win.drawTextCentered(
+	badgeBounds := image.Rect(borderWidth, borderWidth, badgeWidth+borderWidth, badgeHeight+borderWidth)
+
+	m.indicatorWin.FillRect(badgeBounds, parseHexColorARGB(bgColor))
+	if borderWidth > 0 {
+		m.indicatorWin.StrokeRect(badgeBounds, parseHexColorARGB(borderColor), float64(borderWidth))
+	}
+	m.indicatorWin.DrawTextCentered(
 		label,
-		bounds,
+		badgeBounds,
 		ports.ResolveFont(cfg.UI.FontFamily, true),
 		fontSize,
 		parseHexColorARGB(textColor),
 	)
 
-	// Flush the indicator onto the pixel buffer. Show() was already called
-	// above if needed; now we just flush so the indicator is visible.
-	m.win.flushOverlay("mode-indicator")
+	m.indicatorWin.Show()
 }
 
-// DrawStickyModifiersIndicator renders a sticky modifiers indicator badge on the Windows overlay.
+// DrawStickyModifiersIndicator renders a sticky modifiers indicator badge in
+// its own dedicated layered window, following the cursor without touching the
+// shared overlay.
 func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 	if m.stickyModifiersOverlay == nil || symbols == "" {
 		return
@@ -468,24 +506,40 @@ func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 	paddingY := resolveWinAutoPadding(fontSize, ui.PaddingY, false)
 	badgeWidth := estimateWinTextWidth(symbols, fontSize) + paddingX*winPaddingMultiplier
 	badgeHeight := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
+	borderWidth := max(ui.BorderWidth, 0)
 
-	bounds := image.Rect(
-		x+ui.IndicatorXOffset, y+ui.IndicatorYOffset,
-		x+ui.IndicatorXOffset+badgeWidth, y+ui.IndicatorYOffset+badgeHeight,
-	)
+	offsetX := ui.IndicatorXOffset
+	offsetY := ui.IndicatorYOffset
+
+	posX := x + offsetX - borderWidth
+	posY := y + offsetY - borderWidth
+	sizeX := badgeWidth + borderWidth*2
+	sizeY := badgeHeight + borderWidth*2
 
 	m.renderMu.Lock()
 	defer m.renderMu.Unlock()
 
-	m.ensureWinOverlayLocked()
+	// Lazily create the small sticky overlay window.
+	if m.stickyWin == nil || !m.stickyWin.Healthy() {
+		if m.stickyWin != nil {
+			m.stickyWin.Destroy()
+		}
 
-	if m.win == nil {
-		return
+		win, err := winplatform.NewOverlayWindowAt(posX, posY, sizeX, sizeY)
+		if err != nil {
+			if m.logger != nil {
+				m.logger.Error("failed to create sticky overlay window", zap.Error(err))
+			}
+
+			return
+		}
+
+		m.stickyWin = win
+	} else {
+		_ = m.stickyWin.ResizeTo(posX, posY, sizeX, sizeY)
 	}
 
-	// Clear stale indicator badges before drawing the new one.
-	m.win.clearForIndicator()
-	m.win.EnsureVisible()
+	m.stickyWin.Clear()
 
 	bgColor := ui.BackgroundColor.ForTheme(
 		m.stickyModifiersOverlay.Theme(),
@@ -503,24 +557,21 @@ func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 		config.StickyModifiersBorderColorDark,
 	)
 
-	m.win.drawFilledRect(
-		bounds,
-		parseHexColorARGB(bgColor),
-		parseHexColorARGB(borderColor),
-		float64(max(ui.BorderWidth, 0)),
-	)
-	m.win.drawTextCentered(
+	badgeBounds := image.Rect(borderWidth, borderWidth, badgeWidth+borderWidth, badgeHeight+borderWidth)
+
+	m.stickyWin.FillRect(badgeBounds, parseHexColorARGB(bgColor))
+	if borderWidth > 0 {
+		m.stickyWin.StrokeRect(badgeBounds, parseHexColorARGB(borderColor), float64(borderWidth))
+	}
+	m.stickyWin.DrawTextCentered(
 		symbols,
-		bounds,
+		badgeBounds,
 		ports.ResolveFont(ui.FontFamily, false),
 		fontSize,
 		parseHexColorARGB(textColor),
 	)
 
-	// Flush the indicator onto the pixel buffer. Show() was already called
-	// above to make the window visible; now we just flush so the indicator
-	// is visible immediately.
-	m.win.flushOverlay("sticky-indicator")
+	m.stickyWin.Show()
 }
 
 // DrawMouseActionIndicator renders a transient mouse action indicator on the Windows overlay.

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -379,6 +379,11 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 
 	m.win.Resize()
 
+	// Ensure the overlay is visible before drawing the indicator.
+	// Show() redraws from cache if needed and flushes, so the indicator
+	// drawn below will appear on top of the current content.
+	m.win.Show()
+
 	offsetX := cfg.UI.IndicatorXOffset
 	offsetY := cfg.UI.IndicatorYOffset
 	fontSize := float64(max(cfg.UI.FontSize, 1))
@@ -428,10 +433,9 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 		parseHexColorARGB(textColor),
 	)
 
-	// Ensure the overlay is visible (especially for modes like scroll that
-	// do not call Show themselves). Show() flushes the buffer, so we call it
-	// after drawing so content is visible immediately.
-	m.win.Show()
+	// Flush the indicator onto the pixel buffer. Show() was already called
+	// above if needed; now we just flush so the indicator is visible.
+	m.win.flushOverlay("mode-indicator")
 }
 
 // DrawStickyModifiersIndicator renders a sticky modifiers indicator badge on the Windows overlay.
@@ -495,10 +499,10 @@ func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 		parseHexColorARGB(textColor),
 	)
 
-	// Ensure the overlay is visible (especially for modes like scroll that
-	// do not call Show themselves). Show() flushes the buffer, so we call it
-	// after drawing so content is visible immediately.
-	m.win.Show()
+	// Flush the indicator onto the pixel buffer. Show() was already called
+	// above to make the window visible; now we just flush so the indicator
+	// is visible immediately.
+	m.win.flushOverlay("sticky-indicator")
 }
 
 // DrawMouseActionIndicator renders a transient mouse action indicator on the Windows overlay.

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -8,10 +8,12 @@
 package overlay
 
 import (
+	"context"
 	"image"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 	"unsafe"
 
 	"go.uber.org/zap"
@@ -52,6 +54,11 @@ type Manager struct {
 	// stickyWin is a small dedicated layered window for the sticky modifiers
 	// indicator badge, same pattern as indicatorWin.
 	stickyWin *winplatform.OverlayWindow
+
+	// mouseWin is a small dedicated layered window for mouse action indicators.
+	mouseWin *winplatform.OverlayWindow
+	// mouseActionCancel cancels any running mouse action animation.
+	mouseActionCancel context.CancelFunc
 
 	hintOverlay            *hints.Overlay
 	gridOverlay            *grid.Overlay
@@ -112,6 +119,11 @@ func (m *Manager) Hide() {
 	m.renderMu.Lock()
 	defer m.renderMu.Unlock()
 
+	if m.mouseActionCancel != nil {
+		m.mouseActionCancel()
+		m.mouseActionCancel = nil
+	}
+
 	if m.win != nil {
 		m.win.Hide()
 	}
@@ -122,6 +134,10 @@ func (m *Manager) Hide() {
 
 	if m.stickyWin != nil {
 		m.stickyWin.Hide()
+	}
+
+	if m.mouseWin != nil {
+		m.mouseWin.Hide()
 	}
 }
 
@@ -207,6 +223,11 @@ func (m *Manager) Destroy() {
 	m.renderMu.Lock()
 	defer m.renderMu.Unlock()
 
+	if m.mouseActionCancel != nil {
+		m.mouseActionCancel()
+		m.mouseActionCancel = nil
+	}
+
 	if m.win != nil {
 		m.win.Destroy()
 		m.win = nil
@@ -220,6 +241,11 @@ func (m *Manager) Destroy() {
 	if m.stickyWin != nil {
 		m.stickyWin.Destroy()
 		m.stickyWin = nil
+	}
+
+	if m.mouseWin != nil {
+		m.mouseWin.Destroy()
+		m.mouseWin = nil
 	}
 }
 
@@ -632,41 +658,55 @@ func (m *Manager) DrawMouseActionIndicator(
 	m.renderMu.Lock()
 	defer m.renderMu.Unlock()
 
-	m.ensureWinOverlayLocked()
-
-	if m.win == nil {
-		return
+	// Cancel any running mouse action animation.
+	if m.mouseActionCancel != nil {
+		m.mouseActionCancel()
+		m.mouseActionCancel = nil
 	}
 
-	m.win.Clear()
+	maxScale := max(style.StartScale, style.EndScale)
+	if maxScale <= 0 {
+		maxScale = 1.0
+	}
 
-	size := max(style.Size, 1)
-	half := size / 2 //nolint:mnd // simple arithmetic
-	bounds := image.Rect(point.X-half, point.Y-half, point.X+half, point.Y+half)
+	baseSize := float64(max(style.Size, 1))
+	maxIndicatorSize := baseSize * maxScale
+	borderWidth := float64(max(style.BorderWidth, 0))
 
-	bgColor := parseHexColorARGB(style.BackgroundColor)
-	borderColor := parseHexColorARGB(style.BorderColor)
+	// Create window bounds to fit the maximum indicator size plus border.
+	const paddingFactor = 4
 
-	var mouseRadius float64
-	if style.Shape == "circle" {
-		mouseRadius = float64(size) / 2 //nolint:mnd // half-size for fully round circle
+	winSize := int(maxIndicatorSize) + int(borderWidth)*2 + paddingFactor
+	halfWinSize := winSize / 2 //nolint:mnd // divide by 2
+
+	posX := point.X - halfWinSize
+	posY := point.Y - halfWinSize
+
+	if m.mouseWin == nil || !m.mouseWin.Healthy() {
+		if m.mouseWin != nil {
+			m.mouseWin.Destroy()
+		}
+
+		win, err := winplatform.NewOverlayWindowAt(posX, posY, winSize, winSize)
+		if err != nil {
+			if m.logger != nil {
+				m.logger.Error("failed to create mouse action overlay window", zap.Error(err))
+			}
+
+			return
+		}
+
+		m.mouseWin = win
 	} else {
-		mouseRadius = max(
-			float64(size)*winMouseActionSquareRadiusScale,
-			winMouseActionMinSquareRadius,
-		)
+		_ = m.mouseWin.ResizeTo(posX, posY, winSize, winSize)
 	}
 
-	m.win.drawFilledRect(
-		bounds,
-		bgColor,
-		borderColor,
-		float64(max(style.BorderWidth, 0)),
-		mouseRadius,
-	)
+	m.mouseWin.Clear()
 
-	m.win.flushOverlay("mouse-action")
-	m.win.Show()
+	ctx, cancel := context.WithCancel(context.Background())
+	m.mouseActionCancel = cancel
+
+	go m.animateMouseAction(ctx, winSize, style)
 }
 
 // modeIndicatorLabel returns the configured label for the given mode string.
@@ -808,6 +848,147 @@ func (m *Manager) Flush() {
 // SetKeyboardCaptureEnabled is a no-op on Windows; the low-level keyboard hook
 // manages capture directly and has no scroll-passthrough toggle.
 func (m *Manager) SetKeyboardCaptureEnabled(_ bool) {}
+
+func (m *Manager) animateMouseAction(
+	ctx context.Context,
+	winSize int,
+	style ports.MouseActionIndicatorStyle,
+) {
+	duration := time.Duration(style.DurationMS) * time.Millisecond
+	if duration <= 0 {
+		duration = 260 * time.Millisecond //nolint:mnd // default duration
+	}
+
+	startTime := time.Now()
+
+	ticker := time.NewTicker(16 * time.Millisecond) //nolint:mnd // ~60 FPS
+	defer ticker.Stop()
+
+	halfWinSize := float64(winSize) / 2.0 //nolint:mnd // divide by 2
+	borderWidth := float64(max(style.BorderWidth, 0))
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-ticker.C:
+			elapsed := time.Since(startTime)
+
+			progressFraction := float64(elapsed) / float64(duration)
+			if progressFraction >= 1.0 {
+				progressFraction = 1.0
+			}
+
+			progress := ease(progressFraction, style.Easing)
+			scale := style.StartScale + progress*(style.EndScale-style.StartScale)
+			opacity := style.StartOpacity + progress*(style.EndOpacity-style.StartOpacity)
+
+			baseSize := float64(max(style.Size, 1))
+			currentSize := baseSize * scale
+			halfSize := currentSize / 2.0 //nolint:mnd // divide by 2
+
+			bounds := image.Rect(
+				int(halfWinSize-halfSize),
+				int(halfWinSize-halfSize),
+				int(halfWinSize+halfSize),
+				int(halfWinSize+halfSize),
+			)
+
+			bgColor := scaleColorAlpha(style.BackgroundColor, opacity)
+			borderColor := scaleColorAlpha(style.BorderColor, opacity)
+
+			var radius float64
+			if style.Shape == "circle" {
+				radius = halfSize
+			} else {
+				radius = max(
+					currentSize*winMouseActionSquareRadiusScale,
+					winMouseActionMinSquareRadius,
+				)
+			}
+
+			m.renderMu.Lock()
+			select {
+			case <-ctx.Done():
+				m.renderMu.Unlock()
+
+				return
+			default:
+			}
+
+			if m.mouseWin != nil && m.mouseWin.Healthy() {
+				m.mouseWin.Clear()
+				m.mouseWin.FillRoundedRect(bounds, radius, bgColor)
+
+				if borderWidth > 0 {
+					m.mouseWin.StrokeRoundedRect(bounds, radius, borderColor, borderWidth)
+				}
+
+				_ = m.mouseWin.Flush()
+				m.mouseWin.Show()
+			}
+			m.renderMu.Unlock()
+
+			if progressFraction >= 1.0 {
+				m.renderMu.Lock()
+				if m.mouseWin != nil {
+					m.mouseWin.Hide()
+				}
+				m.renderMu.Unlock()
+
+				return
+			}
+		}
+	}
+}
+
+func ease(progressFraction float64, easing string) float64 {
+	switch easing {
+	case "ease_in":
+		res := progressFraction * progressFraction * progressFraction
+
+		return res
+
+	case "ease_out":
+		invT := 1.0 - progressFraction
+		res := 1.0 - invT*invT*invT
+
+		return res
+
+	case "ease_in_out":
+		if progressFraction < 0.5 { //nolint:mnd
+			res := 4.0 * progressFraction * progressFraction * progressFraction
+
+			return res
+		}
+
+		invT := 1.0 - progressFraction
+		res := 1.0 - 4.0*invT*invT*invT
+
+		return res
+
+	case "linear":
+		fallthrough
+	default:
+		return progressFraction
+	}
+}
+
+func scaleColorAlpha(hexColor string, opacity float64) uint32 {
+	colorVal := parseHexColorARGB(hexColor)
+	alphaVal := float64((colorVal >> 24) & 0xFF) //nolint:mnd
+	redVal := (colorVal >> 16) & 0xFF            //nolint:mnd
+	greenVal := (colorVal >> 8) & 0xFF           //nolint:mnd
+	blueVal := colorVal & 0xFF                   //nolint:mnd
+
+	const maxAlpha = 255
+
+	newA := uint32(max(0, min(maxAlpha, alphaVal*opacity)))
+	res := (newA << 24) | (redVal << 16) | (greenVal << 8) | blueVal //nolint:mnd
+
+	return res
+}
 
 func (m *Manager) publish(change StateChange) {
 	for _, sub := range m.subs {

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -24,7 +24,6 @@ import (
 	"github.com/y3owk1n/neru/internal/config"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
-	winplatform "github.com/y3owk1n/neru/internal/core/infra/platform/windows"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
@@ -319,7 +318,6 @@ func (m *Manager) DrawHintSearchInput(
 	badgeHeight := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
 	bounds := image.Rect(pos.X, pos.Y, pos.X+max(badgeWidth, width), pos.Y+badgeHeight)
 
-	m.win.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
 	m.win.drawFilledRect(
 		bounds,
 		parseHexColorARGB(style.BackgroundColor()),
@@ -379,6 +377,8 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 		return
 	}
 
+	m.win.Resize()
+
 	offsetX := cfg.UI.IndicatorXOffset
 	offsetY := cfg.UI.IndicatorYOffset
 	fontSize := float64(max(cfg.UI.FontSize, 1))
@@ -414,7 +414,6 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 	)
 	borderWidth := cfg.UI.BorderWidth
 
-	m.win.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
 	m.win.drawFilledRect(
 		bounds,
 		parseHexColorARGB(bgColor),
@@ -482,7 +481,6 @@ func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 		config.StickyModifiersBorderColorDark,
 	)
 
-	m.win.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
 	m.win.drawFilledRect(
 		bounds,
 		parseHexColorARGB(bgColor),
@@ -524,7 +522,6 @@ func (m *Manager) DrawMouseActionIndicator(
 	bgColor := parseHexColorARGB(style.BackgroundColor)
 	borderColor := parseHexColorARGB(style.BorderColor)
 
-	m.win.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
 	m.win.drawFilledRect(
 		bounds,
 		bgColor,

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -365,6 +365,7 @@ func (m *Manager) DrawHintSearchInput(
 		parseHexColorARGB(style.BackgroundColor()),
 		parseHexColorARGB(style.BorderColor()),
 		float64(max(style.BorderWidth(), 0)),
+		resolveWinBorderRadius(style.BorderRadius(), bounds, winAutoRadiusBadgeCap),
 	)
 	m.win.drawTextCentered(
 		label,
@@ -484,10 +485,15 @@ func (m *Manager) DrawModeIndicator(cursorX, cursorY int) {
 		badgeHeight+borderWidth,
 	)
 
-	m.indicatorWin.FillRect(badgeBounds, parseHexColorARGB(bgColor))
+	indicatorRadius := resolveWinBorderRadius(
+		cfg.UI.BorderRadius, badgeBounds, winAutoRadiusBadgeCap,
+	)
+	m.indicatorWin.FillRoundedRect(badgeBounds, indicatorRadius, parseHexColorARGB(bgColor))
 
 	if borderWidth > 0 {
-		m.indicatorWin.StrokeRect(badgeBounds, parseHexColorARGB(borderColor), float64(borderWidth))
+		m.indicatorWin.StrokeRoundedRect(
+			badgeBounds, indicatorRadius, parseHexColorARGB(borderColor), float64(borderWidth),
+		)
 	}
 
 	m.indicatorWin.DrawTextCentered(
@@ -584,10 +590,20 @@ func (m *Manager) DrawStickyModifiersIndicator(cursorX, cursorY int, symbols str
 		badgeHeight+borderWidth,
 	)
 
-	m.stickyWin.FillRect(badgeBounds, parseHexColorARGB(bgColor))
+	stickyRadius := resolveWinBorderRadius(
+		indicatorUI.BorderRadius,
+		badgeBounds,
+		winAutoRadiusBadgeCap,
+	)
+	m.stickyWin.FillRoundedRect(badgeBounds, stickyRadius, parseHexColorARGB(bgColor))
 
 	if borderWidth > 0 {
-		m.stickyWin.StrokeRect(badgeBounds, parseHexColorARGB(borderColor), float64(borderWidth))
+		m.stickyWin.StrokeRoundedRect(
+			badgeBounds,
+			stickyRadius,
+			parseHexColorARGB(borderColor),
+			float64(borderWidth),
+		)
 	}
 
 	m.stickyWin.DrawTextCentered(
@@ -631,11 +647,22 @@ func (m *Manager) DrawMouseActionIndicator(
 	bgColor := parseHexColorARGB(style.BackgroundColor)
 	borderColor := parseHexColorARGB(style.BorderColor)
 
+	var mouseRadius float64
+	if style.Shape == "circle" {
+		mouseRadius = float64(size) / 2 //nolint:mnd // half-size for fully round circle
+	} else {
+		mouseRadius = max(
+			float64(size)*winMouseActionSquareRadiusScale,
+			winMouseActionMinSquareRadius,
+		)
+	}
+
 	m.win.drawFilledRect(
 		bounds,
 		bgColor,
 		borderColor,
 		float64(max(style.BorderWidth, 0)),
+		mouseRadius,
 	)
 
 	m.win.flushOverlay("mouse-action")

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -115,6 +115,18 @@ func (m *Manager) Clear() {
 	}
 }
 
+// ClearCache invalidates cached grid and hints state on the Windows overlay
+// so that a subsequent Show() does not redraw stale content from a previous
+// mode. Called during mode cleanup to prevent ghost artifacts.
+func (m *Manager) ClearCache() {
+	m.renderMu.Lock()
+	defer m.renderMu.Unlock()
+
+	if m.win != nil {
+		m.win.ClearCache()
+	}
+}
+
 // ResizeToActiveScreen resizes the overlay to the active monitor.
 func (m *Manager) ResizeToActiveScreen() {
 	m.renderMu.Lock()

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -428,6 +428,11 @@ func (m *Manager) DrawModeIndicator(x, y int) {
 		fontSize,
 		parseHexColorARGB(textColor),
 	)
+
+	// Ensure the overlay is visible (especially for modes like scroll that
+	// do not call Show themselves). Show() flushes the buffer, so we call it
+	// after drawing so content is visible immediately.
+	m.win.Show()
 }
 
 // DrawStickyModifiersIndicator renders a sticky modifiers indicator badge on the Windows overlay.
@@ -457,6 +462,9 @@ func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 	if m.win == nil {
 		return
 	}
+
+	// Ensure the overlay is visible before drawing on it.
+	m.win.Show()
 
 	bgColor := ui.BackgroundColor.ForTheme(
 		m.stickyModifiersOverlay.Theme(),
@@ -488,6 +496,11 @@ func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
 		fontSize,
 		parseHexColorARGB(textColor),
 	)
+
+	// Ensure the overlay is visible (especially for modes like scroll that
+	// do not call Show themselves). Show() flushes the buffer, so we call it
+	// after drawing so content is visible immediately.
+	m.win.Show()
 }
 
 // DrawMouseActionIndicator renders a transient mouse action indicator on the Windows overlay.

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -9,6 +9,7 @@ package overlay
 
 import (
 	"image"
+	"strconv"
 	"strings"
 	"sync"
 	"unsafe"
@@ -20,8 +21,10 @@ import (
 	"github.com/y3owk1n/neru/internal/app/components/modeindicator"
 	"github.com/y3owk1n/neru/internal/app/components/recursivegrid"
 	"github.com/y3owk1n/neru/internal/app/components/stickyindicator"
+	"github.com/y3owk1n/neru/internal/config"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	winplatform "github.com/y3owk1n/neru/internal/core/infra/platform/windows"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
@@ -279,27 +282,259 @@ func (m *Manager) DrawHintsWithStyle(hintsSlice []*hints.Hint, style hints.Style
 	return nil
 }
 
-// DrawHintSearchInput is a no-op on Windows; the hint search box is not rendered.
+// DrawHintSearchInput renders the hints search input on the Windows overlay.
 func (m *Manager) DrawHintSearchInput(
-	_ string,
-	_ int,
-	_ hints.SearchInputFrame,
-	_ hints.SearchInputStyle,
+	query string,
+	resultCount int,
+	frame hints.SearchInputFrame,
+	style hints.SearchInputStyle,
 ) error {
+	m.renderMu.Lock()
+	defer m.renderMu.Unlock()
+
+	m.ensureWinOverlayLocked()
+
+	if m.win == nil {
+		return nil
+	}
+
+	m.win.Resize()
+
+	pos := frame.Position()
+	width := frame.Width()
+
+	fontSize := float64(max(style.FontSize(), 1))
+	paddingX := resolveWinAutoPadding(fontSize, style.PaddingX(), true)
+	paddingY := resolveWinAutoPadding(fontSize, style.PaddingY(), false)
+
+	// / query  count /  format
+	label := "/ " + query
+	if resultCount >= 0 {
+		label += "  " + strconv.Itoa(resultCount) + " /"
+	} else {
+		label += " /"
+	}
+
+	badgeWidth := estimateWinTextWidth(label, fontSize) + paddingX*winPaddingMultiplier
+	badgeHeight := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
+	bounds := image.Rect(pos.X, pos.Y, pos.X+max(badgeWidth, width), pos.Y+badgeHeight)
+
+	m.win.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
+	m.win.drawFilledRect(
+		bounds,
+		parseHexColorARGB(style.BackgroundColor()),
+		parseHexColorARGB(style.BorderColor()),
+		float64(max(style.BorderWidth(), 0)),
+	)
+	m.win.drawTextCentered(
+		label,
+		bounds,
+		style.FontFamily(),
+		fontSize,
+		parseHexColorARGB(style.TextColor()),
+	)
+
 	return nil
 }
 
-// HideHintSearchInput is a no-op on Windows.
-func (m *Manager) HideHintSearchInput() {}
+// HideHintSearchInput redraws the hints overlay to clear the search input.
+func (m *Manager) HideHintSearchInput() {
+	m.renderMu.Lock()
+	defer m.renderMu.Unlock()
 
-// DrawModeIndicator is a no-op on Windows.
-func (m *Manager) DrawModeIndicator(_, _ int) {}
+	if m.win == nil {
+		return
+	}
 
-// DrawStickyModifiersIndicator is a no-op on Windows.
-func (m *Manager) DrawStickyModifiersIndicator(_, _ int, _ string) {}
+	if m.win.lastHints != nil {
+		m.win.Resize()
+		// DrawHints clears + redraws; using it erases the search overlay.
+		m.win.DrawHints(m.win.lastHints, m.win.lastHintStyle)
+	}
+}
 
-// DrawMouseActionIndicator is a no-op on Windows.
-func (m *Manager) DrawMouseActionIndicator(_ image.Point, _ ports.MouseActionIndicatorStyle) {}
+// DrawModeIndicator renders a mode indicator badge on the Windows overlay.
+func (m *Manager) DrawModeIndicator(x, y int) {
+	if m.modeIndicatorOverlay == nil {
+		return
+	}
+
+	mode := m.Mode()
+	if mode == ModeIdle {
+		return
+	}
+
+	cfg := m.modeIndicatorOverlay.IndicatorConfig()
+	label := modeIndicatorLabel(cfg, string(mode))
+	if label == "" {
+		return
+	}
+
+	m.renderMu.Lock()
+	defer m.renderMu.Unlock()
+
+	m.ensureWinOverlayLocked()
+
+	if m.win == nil {
+		return
+	}
+
+	offsetX := cfg.UI.IndicatorXOffset
+	offsetY := cfg.UI.IndicatorYOffset
+	fontSize := float64(max(cfg.UI.FontSize, 1))
+
+	paddingX := resolveWinAutoPadding(fontSize, cfg.UI.PaddingX, true)
+	paddingY := resolveWinAutoPadding(fontSize, cfg.UI.PaddingY, false)
+	badgeWidth := estimateWinTextWidth(label, fontSize) + paddingX*winPaddingMultiplier
+	badgeHeight := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
+
+	bounds := image.Rect(
+		x+offsetX, y+offsetY,
+		x+offsetX+badgeWidth, y+offsetY+badgeHeight,
+	)
+
+	modeCfg := m.modeIndicatorOverlay.ModeConfig(string(mode))
+	bgColor := modeCfg.BackgroundColor.ForThemeWithOverride(
+		cfg.UI.BackgroundColor,
+		m.modeIndicatorOverlay.Theme(),
+		config.ModeIndicatorBackgroundColorLight,
+		config.ModeIndicatorBackgroundColorDark,
+	)
+	textColor := modeCfg.TextColor.ForThemeWithOverride(
+		cfg.UI.TextColor,
+		m.modeIndicatorOverlay.Theme(),
+		config.ModeIndicatorTextColorLight,
+		config.ModeIndicatorTextColorDark,
+	)
+	borderColor := modeCfg.BorderColor.ForThemeWithOverride(
+		cfg.UI.BorderColor,
+		m.modeIndicatorOverlay.Theme(),
+		config.ModeIndicatorBorderColorLight,
+		config.ModeIndicatorBorderColorDark,
+	)
+	borderWidth := cfg.UI.BorderWidth
+
+	m.win.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
+	m.win.drawFilledRect(
+		bounds,
+		parseHexColorARGB(bgColor),
+		parseHexColorARGB(borderColor),
+		float64(max(borderWidth, 0)),
+	)
+	m.win.drawTextCentered(
+		label,
+		bounds,
+		ports.ResolveFont(cfg.UI.FontFamily, true),
+		fontSize,
+		parseHexColorARGB(textColor),
+	)
+}
+
+// DrawStickyModifiersIndicator renders a sticky modifiers indicator badge on the Windows overlay.
+func (m *Manager) DrawStickyModifiersIndicator(x, y int, symbols string) {
+	if m.stickyModifiersOverlay == nil || symbols == "" {
+		return
+	}
+
+	ui := m.stickyModifiersOverlay.UI()
+	fontSize := float64(max(ui.FontSize, 1))
+
+	paddingX := resolveWinAutoPadding(fontSize, ui.PaddingX, true)
+	paddingY := resolveWinAutoPadding(fontSize, ui.PaddingY, false)
+	badgeWidth := estimateWinTextWidth(symbols, fontSize) + paddingX*winPaddingMultiplier
+	badgeHeight := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
+
+	bounds := image.Rect(
+		x+ui.IndicatorXOffset, y+ui.IndicatorYOffset,
+		x+ui.IndicatorXOffset+badgeWidth, y+ui.IndicatorYOffset+badgeHeight,
+	)
+
+	m.renderMu.Lock()
+	defer m.renderMu.Unlock()
+
+	m.ensureWinOverlayLocked()
+
+	if m.win == nil {
+		return
+	}
+
+	bgColor := ui.BackgroundColor.ForTheme(
+		m.stickyModifiersOverlay.Theme(),
+		config.StickyModifiersBackgroundColorLight,
+		config.StickyModifiersBackgroundColorDark,
+	)
+	textColor := ui.TextColor.ForTheme(
+		m.stickyModifiersOverlay.Theme(),
+		config.StickyModifiersTextColorLight,
+		config.StickyModifiersTextColorDark,
+	)
+	borderColor := ui.BorderColor.ForTheme(
+		m.stickyModifiersOverlay.Theme(),
+		config.StickyModifiersBorderColorLight,
+		config.StickyModifiersBorderColorDark,
+	)
+
+	m.win.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
+	m.win.drawFilledRect(
+		bounds,
+		parseHexColorARGB(bgColor),
+		parseHexColorARGB(borderColor),
+		float64(max(ui.BorderWidth, 0)),
+	)
+	m.win.drawTextCentered(
+		symbols,
+		bounds,
+		ports.ResolveFont(ui.FontFamily, false),
+		fontSize,
+		parseHexColorARGB(textColor),
+	)
+}
+
+// DrawMouseActionIndicator renders a transient mouse action indicator on the Windows overlay.
+func (m *Manager) DrawMouseActionIndicator(
+	point image.Point,
+	style ports.MouseActionIndicatorStyle,
+) {
+	m.renderMu.Lock()
+	defer m.renderMu.Unlock()
+
+	m.ensureWinOverlayLocked()
+
+	if m.win == nil {
+		return
+	}
+
+	size := max(style.Size, 1)
+	half := size / 2
+	bounds := image.Rect(point.X-half, point.Y-half, point.X+half, point.Y+half)
+
+	bgColor := parseHexColorARGB(style.BackgroundColor)
+	borderColor := parseHexColorARGB(style.BorderColor)
+
+	m.win.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
+	m.win.drawFilledRect(
+		bounds,
+		bgColor,
+		borderColor,
+		float64(max(style.BorderWidth, 0)),
+	)
+}
+
+// modeIndicatorLabel returns the configured label for the given mode string.
+func modeIndicatorLabel(cfg config.ModeIndicatorConfig, mode string) string {
+	switch mode {
+	case "hints":
+		return cfg.Hints.Text
+	case "grid":
+		return cfg.Grid.Text
+	case "scroll":
+		return cfg.Scroll.Text
+	case "recursive_grid":
+		return cfg.RecursiveGrid.Text
+	default:
+		return ""
+	}
+}
 
 // DrawGrid draws the grid overlay.
 func (m *Manager) DrawGrid(gridValue *domainGrid.Grid, input string, style grid.Style) error {

--- a/internal/ui/overlay/manager_windows_features.go
+++ b/internal/ui/overlay/manager_windows_features.go
@@ -182,6 +182,10 @@ func (o *winOverlay) DrawRecursiveGrid(
 				cell.Max.Y = bounds.Max.Y
 			}
 
+			if style.HighlightColor != 0 {
+				o.window.FillRect(cell, style.HighlightColor)
+			}
+
 			if style.LineWidth > 0 {
 				o.window.StrokeRect(cell, style.LineColor, style.LineWidth)
 			}

--- a/internal/ui/overlay/manager_windows_features.go
+++ b/internal/ui/overlay/manager_windows_features.go
@@ -14,7 +14,6 @@ import (
 
 	hintscomponent "github.com/y3owk1n/neru/internal/app/components/hints"
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/app/components/recursivegrid"
-	winplatform "github.com/y3owk1n/neru/internal/core/infra/platform/windows"
 )
 
 const (
@@ -63,7 +62,6 @@ func (o *winOverlay) DrawHints(
 	o.suppressDraw = false
 
 	o.Clear()
-	o.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
 
 	o.lastHints = hintsSlice
 	o.lastHintStyle = style
@@ -162,7 +160,6 @@ func (o *winOverlay) DrawRecursiveGrid(
 	o.suppressDraw = false
 
 	o.Clear()
-	o.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
 
 	keyRunes := []rune(strings.ToUpper(keys))
 	cellWidth := bounds.Dx() / gridCols
@@ -184,8 +181,6 @@ func (o *winOverlay) DrawRecursiveGrid(
 			if row == gridRows-1 {
 				cell.Max.Y = bounds.Max.Y
 			}
-
-			o.window.FillRect(cell, style.HighlightColor)
 
 			if style.LineWidth > 0 {
 				o.window.StrokeRect(cell, style.LineColor, style.LineWidth)

--- a/internal/ui/overlay/manager_windows_features.go
+++ b/internal/ui/overlay/manager_windows_features.go
@@ -35,6 +35,11 @@ const (
 	winCenteredRectDivisor             = 2
 	winPaddingMultiplier               = 2
 	winSubKeyPreviewPaddingBottom      = 4
+
+	winAutoRadiusBadgeCap           = 6.0
+	winAutoRadiusBoundaryCap        = 4.0
+	winMouseActionSquareRadiusScale = 0.18
+	winMouseActionMinSquareRadius   = 2.0
 )
 
 // DrawHints renders the hint overlay using GDI, mirroring the cross-platform
@@ -84,6 +89,9 @@ func (o *winOverlay) DrawHints(
 				parseHexColorARGB(style.BoundaryBackgroundColor()),
 				parseHexColorARGB(style.BoundaryBorderColor()),
 				float64(max(style.BoundaryBorderWidth(), 0)),
+				resolveWinBorderRadius(
+					style.BoundaryBorderRadius(), boundary, winAutoRadiusBoundaryCap,
+				),
 			)
 		}
 
@@ -114,6 +122,7 @@ func (o *winOverlay) DrawHints(
 			parseHexColorARGB(style.BackgroundColor()),
 			parseHexColorARGB(style.BorderColor()),
 			float64(max(style.BorderWidth(), 0)),
+			resolveWinBorderRadius(style.BorderRadius(), bounds, winAutoRadiusBadgeCap),
 		)
 		o.drawTextCentered(
 			hint.Label(),
@@ -226,29 +235,31 @@ func (o *winOverlay) DrawRecursiveGrid(
 			parseHexColorARGB(virtualPointer.FillColor),
 			style.LineColor,
 			winSubgridLineWidth,
+			0,
 		)
 	}
 
 	o.flushOverlay("recursive-grid")
 }
 
-// drawFilledRect fills bounds then strokes its border. Used by hint badges,
-// label backgrounds, and the recursive virtual pointer; recursive-grid cells
-// themselves are stroked only (transparent interior) so content stays visible.
+// drawFilledRect fills bounds then strokes its border, optionally with rounded
+// corners. When radius > 0 the anti-aliased SDF rounded-rect primitives are
+// used; otherwise the faster axis-aligned FillRect/StrokeRect path is taken.
 func (o *winOverlay) drawFilledRect(
 	bounds image.Rectangle,
 	fill uint32,
 	border uint32,
 	lineWidth float64,
+	radius float64,
 ) {
 	if o == nil || o.window == nil {
 		return
 	}
 
-	o.window.FillRect(bounds, fill)
+	o.window.FillRoundedRect(bounds, radius, fill)
 
 	if lineWidth > 0 {
-		o.window.StrokeRect(bounds, border, lineWidth)
+		o.window.StrokeRoundedRect(bounds, radius, border, lineWidth)
 	}
 }
 
@@ -269,6 +280,7 @@ func (o *winOverlay) drawRecursiveLabelBackground(
 		style.LabelBackgroundColor,
 		style.LineColor,
 		max(style.LabelBackgroundBorderWidth, 0),
+		resolveWinBorderRadius(style.LabelBackgroundBorderRadius, rect, 0),
 	)
 }
 
@@ -317,6 +329,29 @@ func resolveWinAutoPadding(fontSize float64, padding int, horizontal bool) int {
 	}
 
 	return max(int(fontSize*winAutoPaddingVerticalMultiplier), winAutoPaddingMinVertical)
+}
+
+// resolveWinBorderRadius resolves a configured border-radius value for the
+// given rectangle. Negative values select an automatic radius: autoCap limits
+// the auto-radius for badge-style corners (e.g. 6 px for hint badges); pass 0
+// for a full pill shape (label backgrounds). Zero means sharp corners.
+// Positive values are clamped to half the smaller dimension.
+func resolveWinBorderRadius(configured int, bounds image.Rectangle, autoCap float64) float64 {
+	maxR := float64(min(bounds.Dx(), bounds.Dy())) / 2 //nolint:mnd // half the smaller dimension
+
+	if configured < 0 {
+		if autoCap > 0 {
+			return min(maxR, autoCap)
+		}
+
+		return maxR
+	}
+
+	if configured == 0 {
+		return 0
+	}
+
+	return min(float64(configured), maxR)
 }
 
 func estimateWinTextWidth(text string, fontSize float64) int {

--- a/internal/ui/overlay/manager_windows_features.go
+++ b/internal/ui/overlay/manager_windows_features.go
@@ -65,6 +65,9 @@ func (o *winOverlay) DrawHints(
 	o.Clear()
 	o.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
 
+	o.lastHints = hintsSlice
+	o.lastHintStyle = style
+
 	for _, hint := range hintsSlice {
 		if hint == nil {
 			continue

--- a/internal/ui/overlay/manager_windows_features.go
+++ b/internal/ui/overlay/manager_windows_features.go
@@ -14,6 +14,7 @@ import (
 
 	hintscomponent "github.com/y3owk1n/neru/internal/app/components/hints"
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/app/components/recursivegrid"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 const (
@@ -117,7 +118,7 @@ func (o *winOverlay) DrawHints(
 		o.drawTextCentered(
 			hint.Label(),
 			bounds,
-			style.FontFamily(),
+			ports.ResolveFont(style.FontFamily(), false),
 			fontSize,
 			parseHexColorARGB(textColor),
 		)
@@ -199,7 +200,7 @@ func (o *winOverlay) DrawRecursiveGrid(
 				o.drawTextCentered(
 					label,
 					cell,
-					style.LabelFontName,
+					ports.ResolveFont(style.LabelFontName, false),
 					style.LabelFontSize,
 					style.LabelFontColor,
 				)
@@ -286,7 +287,7 @@ func (o *winOverlay) drawRecursiveSubKeyPreview(
 	o.drawTextCentered(
 		label,
 		previewRect,
-		style.LabelFontName,
+		ports.ResolveFont(style.LabelFontName, false),
 		style.SubKeyPreviewFontSize,
 		style.SubKeyPreviewTextColor,
 	)

--- a/internal/ui/overlay/manager_windows_features.go
+++ b/internal/ui/overlay/manager_windows_features.go
@@ -185,11 +185,8 @@ func (o *winOverlay) DrawRecursiveGrid(
 				cell.Max.Y = bounds.Max.Y
 			}
 
-			// Stroke the cell border only; leave the interior transparent (the
-			// layered color-key) so the content being navigated to stays visible.
-			// The Windows overlay has no real alpha, so any interior fill blends
-			// to an opaque tint that hides what is underneath. Grid mode draws
-			// borders + labels for the same reason; recursive-grid matches it.
+			o.window.FillRect(cell, style.HighlightColor)
+
 			if style.LineWidth > 0 {
 				o.window.StrokeRect(cell, style.LineColor, style.LineWidth)
 			}

--- a/internal/ui/overlay/manager_windows_overlay.go
+++ b/internal/ui/overlay/manager_windows_overlay.go
@@ -342,7 +342,13 @@ func (o *winOverlay) redrawGridWithoutFlush() {
 		o.drawCellBorder(cell.Bounds(), border, style.LineWidth)
 
 		if style.ShowLabels {
-			o.drawTextCentered(label, cell.Bounds(), ports.ResolveFont(style.LabelFontName, false), style.LabelFontSize, text)
+			o.drawTextCentered(
+				label,
+				cell.Bounds(),
+				ports.ResolveFont(style.LabelFontName, false),
+				style.LabelFontSize,
+				text,
+			)
 		}
 	}
 

--- a/internal/ui/overlay/manager_windows_overlay.go
+++ b/internal/ui/overlay/manager_windows_overlay.go
@@ -177,7 +177,6 @@ func (o *winOverlay) ShowSubgrid(cell *domainGrid.Cell, _ gridcomponent.Style) {
 
 	o.currentSubgrid = cell
 	o.Clear()
-	o.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
 	o.drawSubgrid(cell.Bounds(), o.cachedStyle)
 	o.flushOverlay("subgrid")
 }
@@ -300,7 +299,6 @@ func (o *winOverlay) redrawGridWithoutFlush() {
 	}
 
 	o.Clear()
-	o.window.SetColorBlendRGB(winplatform.ThemeSurfaceRGB())
 
 	style := o.cachedStyle
 	prefix := o.currentPrefix
@@ -313,16 +311,16 @@ func (o *winOverlay) redrawGridWithoutFlush() {
 			continue
 		}
 
-		bg := style.BackgroundColor
+		fill := style.BackgroundColor
 		text := style.LabelFontColor
 		border := style.LineColor
 		if matched && prefix != "" {
-			bg = style.MatchedBackgroundColor
+			fill = style.MatchedBackgroundColor
 			text = style.MatchedTextColor
 			border = style.MatchedBorderColor
 		}
 
-		o.window.FillRect(cell.Bounds(), bg)
+		o.drawCellFill(cell.Bounds(), fill)
 		o.drawCellBorder(cell.Bounds(), border, style.LineWidth)
 
 		if style.ShowLabels {
@@ -403,7 +401,6 @@ func (o *winOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Sty
 				xBreaks[col+1],
 				yBreaks[row+1],
 			)
-			o.window.FillRect(cell, style.BackgroundColor)
 			o.drawCellBorder(cell, style.LineColor, style.LineWidth)
 			o.drawTextCentered(
 				string(keyRunes[index]),
@@ -415,6 +412,14 @@ func (o *winOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Sty
 			index++
 		}
 	}
+}
+
+func (o *winOverlay) drawCellFill(bounds image.Rectangle, fill uint32) {
+	if o == nil || o.window == nil {
+		return
+	}
+
+	o.window.FillRect(bounds, fill)
 }
 
 // drawCellBorder draws only the grid outline; cell interiors stay color-key transparent.

--- a/internal/ui/overlay/manager_windows_overlay.go
+++ b/internal/ui/overlay/manager_windows_overlay.go
@@ -138,6 +138,25 @@ func (o *winOverlay) Clear() {
 	}
 }
 
+// clearForIndicator clears the pixel buffer before drawing a transient
+// indicator badge so that old badges at previous cursor positions are
+// erased. When cached grid or hints content exists (grid/hints mode),
+// the buffer is left untouched so the indicator draws on top of the
+// existing content.
+func (o *winOverlay) clearForIndicator() {
+	if o == nil || o.window == nil {
+		return
+	}
+
+	// In grid or hints mode, the cached content is already rendered in the
+	// pixel buffer. Do not clear — the indicator badge is drawn on top.
+	if o.cachedGrid != nil || len(o.lastHints) > 0 {
+		return
+	}
+
+	o.window.Clear()
+}
+
 // ClearCache invalidates cached grid and hints state so that a subsequent
 // Show() does not redraw stale content from a previous mode. This must be
 // called when modes exit to prevent ghost artifacts (e.g. the old grid

--- a/internal/ui/overlay/manager_windows_overlay.go
+++ b/internal/ui/overlay/manager_windows_overlay.go
@@ -119,25 +119,6 @@ func (o *winOverlay) Show() {
 	}
 }
 
-// EnsureVisible makes the overlay HWND visible without flushing the pixel
-// buffer. Used by indicator draw paths that need the window to be on-screen
-// before composing a new frame, avoiding the blink that Show()'s intermediate
-// flush would cause.
-func (o *winOverlay) EnsureVisible() {
-	if o == nil {
-		return
-	}
-
-	o.ensureWindowForDraw()
-
-	if o.window == nil {
-		return
-	}
-
-	o.suppressDraw = false
-	o.window.Show()
-}
-
 func (o *winOverlay) Hide() {
 	if o == nil {
 		return
@@ -155,25 +136,6 @@ func (o *winOverlay) Clear() {
 	if o != nil && o.window != nil {
 		o.window.Clear()
 	}
-}
-
-// clearForIndicator clears the pixel buffer before drawing a transient
-// indicator badge so that old badges at previous cursor positions are
-// erased. When cached grid or hints content exists (grid/hints mode),
-// the buffer is left untouched so the indicator draws on top of the
-// existing content.
-func (o *winOverlay) clearForIndicator() {
-	if o == nil || o.window == nil {
-		return
-	}
-
-	// In grid or hints mode, the cached content is already rendered in the
-	// pixel buffer. Do not clear — the indicator badge is drawn on top.
-	if o.cachedGrid != nil || len(o.lastHints) > 0 {
-		return
-	}
-
-	o.window.Clear()
 }
 
 // ClearCache invalidates cached grid and hints state so that a subsequent

--- a/internal/ui/overlay/manager_windows_overlay.go
+++ b/internal/ui/overlay/manager_windows_overlay.go
@@ -331,6 +331,7 @@ func (o *winOverlay) redrawGridWithoutFlush() {
 
 		fill := style.BackgroundColor
 		text := style.LabelFontColor
+
 		border := style.LineColor
 		if matched && prefix != "" {
 			fill = style.MatchedBackgroundColor

--- a/internal/ui/overlay/manager_windows_overlay.go
+++ b/internal/ui/overlay/manager_windows_overlay.go
@@ -119,6 +119,25 @@ func (o *winOverlay) Show() {
 	}
 }
 
+// EnsureVisible makes the overlay HWND visible without flushing the pixel
+// buffer. Used by indicator draw paths that need the window to be on-screen
+// before composing a new frame, avoiding the blink that Show()'s intermediate
+// flush would cause.
+func (o *winOverlay) EnsureVisible() {
+	if o == nil {
+		return
+	}
+
+	o.ensureWindowForDraw()
+
+	if o.window == nil {
+		return
+	}
+
+	o.suppressDraw = false
+	o.window.Show()
+}
+
 func (o *winOverlay) Hide() {
 	if o == nil {
 		return

--- a/internal/ui/overlay/manager_windows_overlay.go
+++ b/internal/ui/overlay/manager_windows_overlay.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	gridcomponent "github.com/y3owk1n/neru/internal/app/components/grid"
+	hintscomponent "github.com/y3owk1n/neru/internal/app/components/hints"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 	winplatform "github.com/y3owk1n/neru/internal/core/infra/platform/windows"
 )
@@ -35,6 +36,9 @@ type winOverlay struct {
 	cachedGrid     *domainGrid.Grid
 	cachedStyle    gridcomponent.Style
 	suppressDraw   bool
+
+	lastHints     []*hintscomponent.Hint
+	lastHintStyle hintscomponent.StyleMode
 }
 
 func newWinOverlay(logger *zap.Logger) *winOverlay {
@@ -309,14 +313,17 @@ func (o *winOverlay) redrawGridWithoutFlush() {
 			continue
 		}
 
+		bg := style.BackgroundColor
 		text := style.LabelFontColor
-
 		border := style.LineColor
 		if matched && prefix != "" {
+			bg = style.MatchedBackgroundColor
 			text = style.MatchedTextColor
 			border = style.MatchedBorderColor
 		}
 
+		// Fill the cell background before drawing the border and label.
+		o.window.FillRect(cell.Bounds(), bg)
 		o.drawCellBorder(cell.Bounds(), border, style.LineWidth)
 
 		if style.ShowLabels {
@@ -397,6 +404,7 @@ func (o *winOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Sty
 				xBreaks[col+1],
 				yBreaks[row+1],
 			)
+			o.window.FillRect(cell, style.BackgroundColor)
 			o.drawCellBorder(cell, style.LineColor, style.LineWidth)
 			o.drawTextCentered(
 				string(keyRunes[index]),

--- a/internal/ui/overlay/manager_windows_overlay.go
+++ b/internal/ui/overlay/manager_windows_overlay.go
@@ -138,6 +138,23 @@ func (o *winOverlay) Clear() {
 	}
 }
 
+// ClearCache invalidates cached grid and hints state so that a subsequent
+// Show() does not redraw stale content from a previous mode. This must be
+// called when modes exit to prevent ghost artifacts (e.g. the old grid
+// reappearing when a mode indicator is drawn).
+func (o *winOverlay) ClearCache() {
+	if o == nil {
+		return
+	}
+
+	o.cachedGrid = nil
+	o.cachedStyle = gridcomponent.Style{}
+	o.currentPrefix = ""
+	o.currentSubgrid = nil
+	o.lastHints = nil
+	o.lastHintStyle = hintscomponent.StyleMode{}
+}
+
 func (o *winOverlay) Resize() {
 	if o == nil || o.window == nil {
 		return

--- a/internal/ui/overlay/manager_windows_overlay.go
+++ b/internal/ui/overlay/manager_windows_overlay.go
@@ -322,7 +322,6 @@ func (o *winOverlay) redrawGridWithoutFlush() {
 			border = style.MatchedBorderColor
 		}
 
-		// Fill the cell background before drawing the border and label.
 		o.window.FillRect(cell.Bounds(), bg)
 		o.drawCellBorder(cell.Bounds(), border, style.LineWidth)
 

--- a/internal/ui/overlay/manager_windows_overlay.go
+++ b/internal/ui/overlay/manager_windows_overlay.go
@@ -17,6 +17,7 @@ import (
 	hintscomponent "github.com/y3owk1n/neru/internal/app/components/hints"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 	winplatform "github.com/y3owk1n/neru/internal/core/infra/platform/windows"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 const (
@@ -324,7 +325,7 @@ func (o *winOverlay) redrawGridWithoutFlush() {
 		o.drawCellBorder(cell.Bounds(), border, style.LineWidth)
 
 		if style.ShowLabels {
-			o.drawTextCentered(label, cell.Bounds(), style.LabelFontName, style.LabelFontSize, text)
+			o.drawTextCentered(label, cell.Bounds(), ports.ResolveFont(style.LabelFontName, false), style.LabelFontSize, text)
 		}
 	}
 
@@ -405,7 +406,7 @@ func (o *winOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Sty
 			o.drawTextCentered(
 				string(keyRunes[index]),
 				cell,
-				style.LabelFontName,
+				ports.ResolveFont(style.LabelFontName, false),
 				style.LabelFontSize*winSubgridFontScale,
 				style.LabelFontColor,
 			)

--- a/internal/ui/overlay/types.go
+++ b/internal/ui/overlay/types.go
@@ -64,6 +64,9 @@ func (n *NoOpManager) Hide() {}
 // Clear is a no-op implementation.
 func (n *NoOpManager) Clear() {}
 
+// ClearCache is a no-op implementation.
+func (n *NoOpManager) ClearCache() {}
+
 // ResizeToActiveScreen is a no-op implementation.
 func (n *NoOpManager) ResizeToActiveScreen() {}
 
@@ -208,6 +211,7 @@ type ManagerInterface interface {
 	Show()
 	Hide()
 	Clear()
+	ClearCache()
 	ResizeToActiveScreen()
 	SwitchTo(next Mode)
 	Subscribe(fn func(StateChange)) uint64


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR rewrite the Windows overlay system from GDI color-key to UpdateLayeredWindow with 32-bit ARGB DIBSections, enabling real per-pixel transparency, anti-aliased rounded corners, and full configuration color support — matching the Darwin overlay's visual capabilities.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Fixes #938 

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/2e28969b-d293-4f25-bc03-29ad6cdb70e5

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
