### PR TITLE
fix(windows): align roles for hints and fix styling

### DIFF
--- a/internal/app/components/hints/overlay_windows_test.go
+++ b/internal/app/components/hints/overlay_windows_test.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+package hints //nolint:testpackage
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+type mockThemeProvider struct {
+	darkMode bool
+}
+
+func (m *mockThemeProvider) IsDarkMode() bool {
+	return m.darkMode
+}
+
+func TestBuildStyle_UsesThemeAwareConfigValues(t *testing.T) {
+	cfg := config.DefaultConfig().Hints
+
+	lightStyle := BuildStyle(cfg, &mockThemeProvider{darkMode: false})
+
+	if lightStyle.BackgroundColor() != config.HintsBackgroundColorLight {
+		t.Fatalf(
+			"expected light background %q, got %q",
+			config.HintsBackgroundColorLight,
+			lightStyle.BackgroundColor(),
+		)
+	}
+
+	if lightStyle.TextColor() != config.HintsTextColorLight {
+		t.Fatalf(
+			"expected light text %q, got %q",
+			config.HintsTextColorLight,
+			lightStyle.TextColor(),
+		)
+	}
+
+	if lightStyle.BorderColor() != config.HintsBorderColorLight {
+		t.Fatalf(
+			"expected light border %q, got %q",
+			config.HintsBorderColorLight,
+			lightStyle.BorderColor(),
+		)
+	}
+
+	darkStyle := BuildStyle(cfg, &mockThemeProvider{darkMode: true})
+
+	if darkStyle.BackgroundColor() != config.HintsBackgroundColorDark {
+		t.Fatalf(
+			"expected dark background %q, got %q",
+			config.HintsBackgroundColorDark,
+			darkStyle.BackgroundColor(),
+		)
+	}
+
+	if darkStyle.TextColor() != config.HintsTextColorDark {
+		t.Fatalf(
+			"expected dark text %q, got %q",
+			config.HintsTextColorDark,
+			darkStyle.TextColor(),
+		)
+	}
+}

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -473,7 +473,10 @@ func (h *Handler) RefreshHintsForThemeChange() bool {
 		)
 	}
 
-	drawHintsErr := h.renderer.DrawHints(overlayHints)
+	drawHintsErr := h.overlayManager.DrawHintsWithStyle(
+		overlayHints,
+		h.currentHintStyleLocked(),
+	)
 	if drawHintsErr != nil {
 		h.logger.Error("Failed to refresh hints after theme change", zap.Error(drawHintsErr))
 

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -22,6 +22,18 @@ func debugElapsed(logger *zap.Logger, start time.Time, msg string, fields ...zap
 	logger.Debug(msg, append(fields, zap.Duration("elapsed", time.Since(start)))...)
 }
 
+// currentHintStyleLocked resolves theme-aware hint overlay colors from the live
+// config, matching search-input and mode-indicator draw paths. Caller must
+// hold h.mu.
+func (h *Handler) currentHintStyleLocked() hints.StyleMode {
+	style := hints.BuildStyle(h.config.Hints, h.themeProvider)
+	if h.hints != nil {
+		h.hints.Style = style
+	}
+
+	return style
+}
+
 // ModeActivationOptions configures a mode activation request.
 type ModeActivationOptions struct {
 	Action                *string
@@ -423,7 +435,10 @@ func (h *Handler) activateHintModeInternal(
 				)
 			}
 
-			drawHintsErr := h.overlayManager.DrawHintsWithStyle(overlayHints, h.hints.Style)
+			drawHintsErr := h.overlayManager.DrawHintsWithStyle(
+				overlayHints,
+				h.currentHintStyleLocked(),
+			)
 			if drawHintsErr != nil {
 				h.logger.Error("Failed to update hints overlay", zap.Error(drawHintsErr))
 			}

--- a/internal/config/config_windows.go
+++ b/internal/config/config_windows.go
@@ -13,17 +13,21 @@ func applyPlatformDefaults(cfg *Config) {
 	cfg.General.ExecShell = filepath.Join(os.Getenv("SystemRoot"), "System32", "cmd.exe")
 	cfg.General.ExecShellArgs = []string{"/c"}
 
-	// UIA control type roles for clickable elements
+	// AX-style roles produced by the Windows UI Automation enumerator
+	// (see mapControlType in uia_windows.go). These must match the roles
+	// assigned during element discovery, not the raw UIA control type names.
 	cfg.Hints.ClickableRoles = append(cfg.Hints.ClickableRoles,
-		"Button",
-		"CheckBox",
-		"RadioButton",
-		"Hyperlink",
-		"ComboBox",
-		"Edit",
-		"Slider",
-		"TabItem",
-		"MenuItem",
-		"DataItem",
+		"AXButton",
+		"AXCheckBox",
+		"AXRadioButton",
+		"AXLink",
+		"AXComboBox",
+		"AXTextField",
+		"AXSlider",
+		"AXTabButton",
+		"AXMenuItem",
+		"AXCell",
+		"AXRow",
+		"AXIncrementor",
 	)
 }

--- a/internal/core/infra/accessibility/tree_windows.go
+++ b/internal/core/infra/accessibility/tree_windows.go
@@ -72,9 +72,7 @@ func (n *TreeNode) FindClickableElements(
 		}
 
 		if node.info != nil && node.info.clickable {
-			if len(keptRoles) == 0 {
-				out = append(out, node)
-			} else if _, ok := keptRoles[node.info.role]; ok {
+			if windowsRoleMatchesFilter(node.info.role, keptRoles) {
 				out = append(out, node)
 			}
 		}
@@ -173,3 +171,43 @@ func ProcessClickableNodes(root *TreeNode, _ config.HintsConfig) []*TreeNode {
 
 // ReleaseTree is a no-op: Windows nodes hold no live COM references.
 func ReleaseTree(_ *TreeNode) {}
+
+// windowsUIAToAXRole maps legacy UIA control-type names that may still appear
+// in user configs to the AX-style roles assigned during enumeration.
+var windowsUIAToAXRole = map[string]string{
+	"Button":      "AXButton",
+	"CheckBox":    "AXCheckBox",
+	"RadioButton": "AXRadioButton",
+	"Hyperlink":   "AXLink",
+	"ComboBox":    "AXComboBox",
+	"Edit":        "AXTextField",
+	"Slider":      "AXSlider",
+	"TabItem":     "AXTabButton",
+	"MenuItem":    "AXMenuItem",
+	"DataItem":    "AXCell",
+	"ListItem":    "AXCell",
+	"TreeItem":    "AXRow",
+	"Spinner":     "AXIncrementor",
+	"SplitButton": "AXButton",
+}
+
+// windowsRoleMatchesFilter reports whether elementRole satisfies keptRoles.
+// An empty keptRoles set accepts every clickable element. Configured roles
+// may use either AX-style names or legacy UIA control-type names.
+func windowsRoleMatchesFilter(elementRole string, keptRoles map[string]struct{}) bool {
+	if len(keptRoles) == 0 {
+		return true
+	}
+
+	if _, ok := keptRoles[elementRole]; ok {
+		return true
+	}
+
+	for configRole := range keptRoles {
+		if axRole, ok := windowsUIAToAXRole[configRole]; ok && axRole == elementRole {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/core/infra/accessibility/tree_windows_test.go
+++ b/internal/core/infra/accessibility/tree_windows_test.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package accessibility //nolint:testpackage // exercises unexported windowsRoleMatchesFilter
+
+import "testing"
+
+func TestWindowsRoleMatchesFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		elementRole string
+		keptRoles   map[string]struct{}
+		want        bool
+	}{
+		{
+			name:        "empty filter accepts all",
+			elementRole: "AXButton",
+			keptRoles:   nil,
+			want:        true,
+		},
+		{
+			name:        "direct AX match",
+			elementRole: "AXButton",
+			keptRoles:   map[string]struct{}{"AXButton": {}},
+			want:        true,
+		},
+		{
+			name:        "legacy UIA name matches AX role",
+			elementRole: "AXTextField",
+			keptRoles:   map[string]struct{}{"Edit": {}},
+			want:        true,
+		},
+		{
+			name:        "unrelated roles do not match",
+			elementRole: "AXButton",
+			keptRoles:   map[string]struct{}{"AXLink": {}},
+			want:        false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := windowsRoleMatchesFilter(testCase.elementRole, testCase.keptRoles)
+			if got != testCase.want {
+				t.Fatalf(
+					"windowsRoleMatchesFilter(%q, %v) = %v, want %v",
+					testCase.elementRole,
+					testCase.keptRoles,
+					got,
+					testCase.want,
+				)
+			}
+		})
+	}
+}

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -1121,9 +1121,9 @@ func alphaFillRoundedRect(
 			dstR := uint32(pixels[idx+2])
 			dstA := uint32(pixels[idx+3])
 
-			pixels[idx] = byte((colR*pixelAlpha + dstB*invA) / alphaMax)
+			pixels[idx] = byte((colB*pixelAlpha + dstB*invA) / alphaMax)
 			pixels[idx+1] = byte((colG*pixelAlpha + dstG*invA) / alphaMax)
-			pixels[idx+2] = byte((colB*pixelAlpha + dstR*invA) / alphaMax)
+			pixels[idx+2] = byte((colR*pixelAlpha + dstR*invA) / alphaMax)
 			pixels[idx+3] = byte(pixelAlpha + (dstA*invA)/alphaMax)
 		}
 	}

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -1066,9 +1066,9 @@ func alphaFillRoundedRect(
 	centerY := float64(rect.Min.Y) + halfH
 
 	startY := clamp(rect.Min.Y, bufH)
-	endY := clamp(rect.Max.Y+1, bufH)
+	endY := clamp(rect.Max.Y, bufH)
 	startX := clamp(rect.Min.X, bufW)
-	endX := clamp(rect.Max.X+1, bufW)
+	endX := clamp(rect.Max.X, bufW)
 
 	// Inner region is fully inside the rounded rect (no SDF needed).
 	innerMinX := float64(rect.Min.X) + radius
@@ -1082,10 +1082,10 @@ func alphaFillRoundedRect(
 
 	for y := startY; y < endY; y++ {
 		row := y * bufW * bytesPerPixel
-		floatY := float64(y)
+		floatY := float64(y) + 0.5
 
 		for col := startX; col < endX; col++ {
-			floatX := float64(col)
+			floatX := float64(col) + 0.5
 
 			// Fast path: pixel is well inside the rounded rect.
 			if floatX >= innerMinX && floatX <= innerMaxX && floatY >= innerMinY &&
@@ -1163,15 +1163,15 @@ func alphaStrokeRoundedRect(
 	innerHalfH := math.Max(halfH-strokeW, 0)
 
 	startY := clamp(rect.Min.Y, bufH)
-	endY := clamp(rect.Max.Y+1, bufH)
+	endY := clamp(rect.Max.Y, bufH)
 	startX := clamp(rect.Min.X, bufW)
-	endX := clamp(rect.Max.X+1, bufW)
+	endX := clamp(rect.Max.X, bufW)
 
 	for y := startY; y < endY; y++ {
 		row := y * bufW * bytesPerPixel
 		for col := startX; col < endX; col++ {
-			relX := float64(col) - centerX
-			relY := float64(y) - centerY
+			relX := float64(col) + 0.5 - centerX
+			relY := float64(y) + 0.5 - centerY
 
 			dOuter := sdRoundedBox(relX, relY, halfW, halfH, radius)
 			if dOuter > 1 {

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -55,6 +55,9 @@ const (
 	// Windows sRGB color space identifier ('Win ').
 	colorSpaceWinRGB = 0x206E6957
 
+	// Half-pixel offset for SDF sample points to match the pixel-as-area model.
+	pixelHalf = 0.5
+
 	// ARGB compositing constants.
 	alphaMax = 255
 
@@ -1082,10 +1085,10 @@ func alphaFillRoundedRect(
 
 	for y := startY; y < endY; y++ {
 		row := y * bufW * bytesPerPixel
-		floatY := float64(y) + 0.5
+		floatY := float64(y) + pixelHalf
 
 		for col := startX; col < endX; col++ {
-			floatX := float64(col) + 0.5
+			floatX := float64(col) + pixelHalf
 
 			// Fast path: pixel is well inside the rounded rect.
 			if floatX >= innerMinX && floatX <= innerMaxX && floatY >= innerMinY &&
@@ -1170,8 +1173,8 @@ func alphaStrokeRoundedRect(
 	for y := startY; y < endY; y++ {
 		row := y * bufW * bytesPerPixel
 		for col := startX; col < endX; col++ {
-			relX := float64(col) + 0.5 - centerX
-			relY := float64(y) + 0.5 - centerY
+			relX := float64(col) + pixelHalf - centerX
+			relY := float64(y) + pixelHalf - centerY
 
 			dOuter := sdRoundedBox(relX, relY, halfW, halfH, radius)
 			if dOuter > 1 {

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -1066,9 +1066,9 @@ func alphaFillRoundedRect(
 	centerY := float64(rect.Min.Y) + halfH
 
 	startY := clamp(rect.Min.Y, bufH)
-	endY := clamp(rect.Max.Y, bufH)
+	endY := clamp(rect.Max.Y+1, bufH)
 	startX := clamp(rect.Min.X, bufW)
-	endX := clamp(rect.Max.X, bufW)
+	endX := clamp(rect.Max.X+1, bufW)
 
 	// Inner region is fully inside the rounded rect (no SDF needed).
 	innerMinX := float64(rect.Min.X) + radius
@@ -1163,9 +1163,9 @@ func alphaStrokeRoundedRect(
 	innerHalfH := math.Max(halfH-strokeW, 0)
 
 	startY := clamp(rect.Min.Y, bufH)
-	endY := clamp(rect.Max.Y, bufH)
+	endY := clamp(rect.Max.Y+1, bufH)
 	startX := clamp(rect.Min.X, bufW)
-	endX := clamp(rect.Max.X, bufW)
+	endX := clamp(rect.Max.X+1, bufW)
 
 	for y := startY; y < endY; y++ {
 		row := y * bufW * bytesPerPixel

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -342,6 +342,12 @@ func (m *Manager) DrawHintsWithStyle(hintsSlice []*hints.Hint, style hints.Style
 		)
 	}
 
+	// Match the infra adapter and mode-indicator paths: rebuild from the hints
+	// overlay config when the caller passed an empty style (e.g. stale cache).
+	if style.BackgroundColor() == "" && m.hintOverlay != nil {
+		style = hints.BuildStyle(m.hintOverlay.Config(), nil)
+	}
+
 	// Shared activation may draw before the resize; enforce monitor bounds here.
 	m.win.Resize()
 	m.win.DrawHints(hintsSlice, style)

--- a/internal/ui/overlay/manager_windows_features_test.go
+++ b/internal/ui/overlay/manager_windows_features_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/app/components/recursivegrid"
+	"github.com/y3owk1n/neru/internal/config"
 )
 
 func TestEstimateWinTextWidth(t *testing.T) {
@@ -130,6 +131,8 @@ func TestParseHexColorARGB(t *testing.T) {
 		want  uint32
 	}{
 		{"full argb", "80FF0000", 0x80FF0000},
+		{"hints light background", config.HintsBackgroundColorLight, 0xF2EEF2FF},
+		{"hints dark background", config.HintsBackgroundColorDark, 0xF20A1338},
 		{"rgb no alpha gets opaque", "#FF0000", 0xFFFF0000},
 		{"short form expands", "#F00", 0xFFFF0000},
 		{"short form mixed", "#abc", 0xFFAABBCC},


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes 2 things related to hints on windows:

1. Ensure UI Automation enumeration assigns AX-style roles (`AXButton`, `AXTextField`, etc.) via `mapControlType`.
2. Hint label styling (colors and borders) are now more consistent and expected.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/4538d9ad-75aa-4cce-851e-a93a1e23d4fa

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
