### PR TITLE
fix(windows,hints): render badges atomically for correct z index

### DIFF
--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -607,6 +607,46 @@ func (o *OverlayWindow) DrawTextCentered(
 	o.mu.Unlock()
 }
 
+// CompositeCurrent composites all queued draw commands into the pixel buffer
+// in-place and clears the command queues. Use this when you need to render
+// each object as an atomic unit (e.g. per-hint) so that later objects render
+// fully on top of earlier ones, avoiding fill/stroke/text batching across
+// objects. Call Flush() at the end to present the final buffer.
+func (o *OverlayWindow) CompositeCurrent() {
+	if o == nil {
+		return
+	}
+
+	o.mu.Lock()
+	fills := append([]rectFill(nil), o.fills...)
+	strokes := append([]rectStroke(nil), o.strokes...)
+	texts := append([]textDraw(nil), o.texts...)
+	o.fills = o.fills[:0]
+	o.strokes = o.strokes[:0]
+	o.texts = o.texts[:0]
+	o.mu.Unlock()
+
+	for _, f := range fills {
+		if f.radius > 0 {
+			alphaFillRoundedRect(o.pixels, o.width, o.height, f.rect, f.radius, f.color)
+		} else {
+			alphaFillRect(o.pixels, o.width, o.height, f.rect, f.color)
+		}
+	}
+
+	for _, s := range strokes {
+		if s.radius > 0 {
+			alphaStrokeRoundedRect(o.pixels, o.width, o.height, s.rect, s.radius, s.color, s.width)
+		} else {
+			alphaStrokeRect(o.pixels, o.width, o.height, s.rect, s.color, s.width)
+		}
+	}
+
+	for _, t := range texts {
+		renderTextAlphaInto(o.pixels, o.width, o.height, t)
+	}
+}
+
 // Flush composites all queued draw commands into the pixel buffer and presents
 // them via UpdateLayeredWindow.
 func (o *OverlayWindow) Flush() error {

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -618,13 +618,14 @@ func (o *OverlayWindow) CompositeCurrent() {
 	}
 
 	o.mu.Lock()
+	defer o.mu.Unlock()
+
 	fills := append([]rectFill(nil), o.fills...)
 	strokes := append([]rectStroke(nil), o.strokes...)
 	texts := append([]textDraw(nil), o.texts...)
 	o.fills = o.fills[:0]
 	o.strokes = o.strokes[:0]
 	o.texts = o.texts[:0]
-	o.mu.Unlock()
 
 	for _, f := range fills {
 		if f.radius > 0 {

--- a/internal/ui/overlay/manager_windows_features.go
+++ b/internal/ui/overlay/manager_windows_features.go
@@ -44,6 +44,9 @@ const (
 
 // DrawHints renders the hint overlay using GDI, mirroring the cross-platform
 // software renderer: an element-sized box per hint with a centered label.
+// Each hint is rendered as an atomic unit (fill + stroke + text) so that
+// overlapping hints have correct Z-ordering — later hints are fully on top of
+// earlier ones, matching macOS behavior.
 func (o *winOverlay) DrawHints(
 	hintsSlice []*hintscomponent.Hint,
 	style hintscomponent.StyleMode,
@@ -84,15 +87,18 @@ func (o *winOverlay) DrawHints(
 				hint.Position().X+hint.Size().X/2,
 				hint.Position().Y+hint.Size().Y/2,
 			)
-			o.drawFilledRect(
-				boundary,
-				parseHexColorARGB(style.BoundaryBackgroundColor()),
-				parseHexColorARGB(style.BoundaryBorderColor()),
-				float64(max(style.BoundaryBorderWidth(), 0)),
-				resolveWinBorderRadius(
-					style.BoundaryBorderRadius(), boundary, winAutoRadiusBoundaryCap,
-				),
+			bdr := resolveWinBorderRadius(
+				style.BoundaryBorderRadius(), boundary, winAutoRadiusBoundaryCap,
 			)
+			o.window.FillRoundedRect(
+				boundary, bdr, parseHexColorARGB(style.BoundaryBackgroundColor()),
+			)
+
+			if bw := float64(max(style.BoundaryBorderWidth(), 0)); bw > 0 {
+				o.window.StrokeRoundedRect(
+					boundary, bdr, parseHexColorARGB(style.BoundaryBorderColor()), bw,
+				)
+			}
 		}
 
 		// Size the badge to the label text, not the element. hint.Size() is the
@@ -117,20 +123,28 @@ func (o *winOverlay) DrawHints(
 			textColor = style.MatchedTextColor()
 		}
 
-		o.drawFilledRect(
-			bounds,
-			parseHexColorARGB(style.BackgroundColor()),
-			parseHexColorARGB(style.BorderColor()),
-			float64(max(style.BorderWidth(), 0)),
-			resolveWinBorderRadius(style.BorderRadius(), bounds, winAutoRadiusBadgeCap),
+		bdr := resolveWinBorderRadius(style.BorderRadius(), bounds, winAutoRadiusBadgeCap)
+		o.window.FillRoundedRect(
+			bounds, bdr, parseHexColorARGB(style.BackgroundColor()),
 		)
-		o.drawTextCentered(
+
+		if bw := float64(max(style.BorderWidth(), 0)); bw > 0 {
+			o.window.StrokeRoundedRect(
+				bounds, bdr, parseHexColorARGB(style.BorderColor()), bw,
+			)
+		}
+
+		o.window.DrawTextCentered(
 			hint.Label(),
 			bounds,
 			ports.ResolveFont(style.FontFamily(), false),
 			fontSize,
 			parseHexColorARGB(textColor),
 		)
+
+		// Composite this hint atomically so its content lands as a unit,
+		// giving correct Z-ordering with overlapping hints.
+		o.window.CompositeCurrent()
 	}
 
 	o.flushOverlay("hints")


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes an issue on windows hints label where they are not rendered atomically, and causes overlapped hints label to be visually non overlapped.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
