### PR TITLE
fix(linux,wayland): prevent keyboard grab leak from evdev EINTR and blocked poll

### DIFF
--- a/internal/config/config_integration_test.go
+++ b/internal/config/config_integration_test.go
@@ -203,6 +203,8 @@ scroll_step_full = 1000
 		appCfg := cfg.Scroll.AppConfigForBundleID("com.apple.Safari")
 		if appCfg == nil {
 			t.Fatal("expected Safari app config to be present")
+
+			return
 		}
 
 		if appCfg.ScrollStep == nil || *appCfg.ScrollStep != 25 {

--- a/internal/core/infra/platform/linux/evdev.c
+++ b/internal/core/infra/platform/linux/evdev.c
@@ -52,7 +52,13 @@ int neru_evdev_get_bustype(int fd) {
 	return id.bustype;
 }
 
-ssize_t neru_evdev_read_event(int fd, struct input_event *event) { return read(fd, event, sizeof(struct input_event)); }
+ssize_t neru_evdev_read_event(int fd, struct input_event *event) {
+	ssize_t n;
+	do {
+		n = read(fd, event, sizeof(struct input_event));
+	} while (n < 0 && errno == EINTR);
+	return n;
+}
 
 int neru_uinput_create_scroll(int *out_fd) {
 	int fd = open("/dev/uinput", O_RDWR);

--- a/internal/core/infra/platform/linux/overlay_wayland.c
+++ b/internal/core/infra/platform/linux/overlay_wayland.c
@@ -671,8 +671,12 @@ int neru_wayland_overlay_poll(NeruWaylandOverlay *overlay) {
 
 	struct wl_display *display = overlay->display;
 
+	int prepare_retries = 0;
 	while (wl_display_prepare_read(display) != 0) {
-		wl_display_dispatch_pending(display);
+		if (wl_display_dispatch_pending(display) < 0)
+			return -1;
+		if (++prepare_retries > 100)
+			return -1;
 	}
 
 	wl_display_flush(display);

--- a/internal/core/infra/platform/linux/overlay_wayland.c
+++ b/internal/core/infra/platform/linux/overlay_wayland.c
@@ -669,14 +669,24 @@ int neru_wayland_overlay_poll(NeruWaylandOverlay *overlay) {
 	if (!overlay || !overlay->display)
 		return -1;
 
-	struct pollfd pfd = {.fd = wl_display_get_fd(overlay->display), .events = POLLIN, .revents = 0};
+	struct wl_display *display = overlay->display;
+
+	while (wl_display_prepare_read(display) != 0) {
+		wl_display_dispatch_pending(display);
+	}
+
+	wl_display_flush(display);
+
+	struct pollfd pfd = {.fd = wl_display_get_fd(display), .events = POLLIN, .revents = 0};
 
 	int ret = poll(&pfd, 1, 0);
 	if (ret > 0 && (pfd.revents & POLLIN)) {
-		wl_display_dispatch(overlay->display);
+		wl_display_read_events(display);
 	} else {
-		wl_display_dispatch_pending(overlay->display);
+		wl_display_cancel_read(display);
 	}
+
+	wl_display_dispatch_pending(display);
 	return ret;
 }
 

--- a/internal/core/infra/platform/linux/overlay_wayland.c
+++ b/internal/core/infra/platform/linux/overlay_wayland.c
@@ -684,6 +684,8 @@ int neru_wayland_overlay_poll(NeruWaylandOverlay *overlay) {
 		wl_display_read_events(display);
 	} else {
 		wl_display_cancel_read(display);
+		if (ret > 0)
+			ret = -1;
 	}
 
 	wl_display_dispatch_pending(display);

--- a/internal/core/infra/platform/linux/overlay_wayland.c
+++ b/internal/core/infra/platform/linux/overlay_wayland.c
@@ -681,7 +681,8 @@ int neru_wayland_overlay_poll(NeruWaylandOverlay *overlay) {
 
 	int ret = poll(&pfd, 1, 0);
 	if (ret > 0 && (pfd.revents & POLLIN)) {
-		wl_display_read_events(display);
+		if (wl_display_read_events(display) < 0)
+			ret = -1;
 	} else {
 		wl_display_cancel_read(display);
 		if (ret > 0)

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -360,7 +360,13 @@ func (o *wlrootsOverlay) keyboardPoller() {
 			o.displayMu.Lock()
 		}
 
-		C.neru_wayland_overlay_poll(o.raw) //nolint:nlreturn
+		if C.neru_wayland_overlay_poll(o.raw) < 0 { //nolint:nlreturn
+			if o.displayMu != nil {
+				o.displayMu.Unlock()
+			}
+
+			return
+		}
 
 		for {
 			key := C.neru_wayland_overlay_get_key(o.raw) //nolint:nlreturn


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

Two independent code paths could leave the keyboard `EVIOCGRAB`'d after the overlay was dismissed, requiring a USB replug to recover on multi-interface keyboards.

**evdev EINTR** (`evdev.c`): `neru_evdev_read_event` used a bare `read()`. Because the fd comes from `os.File.Fd()` it is in blocking mode, Go's async preemption can deliver `EINTR` to the cgo syscall. `readLoop` treats any non-positive result as fatal, killing the reader goroutine and leaving the grab active. Fixed by retrying on `EINTR`.

**Blocked poll** (`overlay_wayland.c`): The keyboard poller held `displayMu` while calling `wl_display_dispatch`, which can block indefinitely on a busy display fd and deadlock mode-exit cleanup before evdev ungrab. Fixed by using the canonical `prepare_read` / `poll` / `read_events` sequence so the poller never blocks while holding the mutex.

Both issues only manifest on multi-interface keyboards, where surviving readers prevent the "all readers exited → ungrab" cleanup path from firing.

## Related Issues

N/A

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

N/A

## Additional Context

N/A