### PR TITLE
fix(grid): avoid overlay redraw flash on mode exit

### DIFF
--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -99,6 +99,13 @@ func (h *Handler) cleanupGridMode() {
 		h.grid.Manager.ResetSilent()
 	}
 
+	// Reset renderer match state so the native hideUnmatched flag and
+	// stale cell-match data do not persist across activations. Normally
+	// the update callback (fired by Reset()) would do this, but
+	// ResetSilent() deliberately skips it.
+	h.renderer.SetHideUnmatched(false)
+	h.renderer.UpdateGridMatches("")
+
 	// Explicitly hide the virtual pointer before clearing the overlay.
 	// NeruClearOverlay also resets cursorIndicatorVisible, but we do this
 	// explicitly so the pointer cleanup does not silently depend on the

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -56,7 +56,6 @@ func (h *Handler) performModeSpecificCleanup() {
 func (h *Handler) clearAndHideOverlay() {
 	h.stopIndicatorPolling()
 
-	h.overlayManager.Clear()
 	h.overlayManager.ClearCache()
 	h.overlayManager.Hide()
 }
@@ -97,7 +96,7 @@ func (h *Handler) cleanupGridMode() {
 	h.grid.Context.SetRepeat(false)
 
 	if h.grid.Manager != nil {
-		h.grid.Manager.Reset()
+		h.grid.Manager.ResetSilent()
 	}
 
 	// Explicitly hide the virtual pointer before clearing the overlay.

--- a/internal/core/domain/grid/manager.go
+++ b/internal/core/domain/grid/manager.go
@@ -118,16 +118,21 @@ func (m *Manager) CurrentGrid() *Grid {
 	return m.grid
 }
 
-// Reset resets the input state.
+// Reset resets the input state and triggers a redraw via the onUpdate callback.
 func (m *Manager) Reset() {
-	m.SetCurrentInput("")
-	m.mainGridInput = ""
-	m.inSubgrid = false
-	m.selectedCell = nil
+	m.ResetSilent()
 
 	if m.onUpdate != nil {
 		m.onUpdate(false)
 	}
+}
+
+// ResetSilent resets the input state without triggering the onUpdate callback.
+func (m *Manager) ResetSilent() {
+	m.SetCurrentInput("")
+	m.mainGridInput = ""
+	m.inSubgrid = false
+	m.selectedCell = nil
 }
 
 // Grid returns the grid.

--- a/internal/core/domain/grid/manager_test.go
+++ b/internal/core/domain/grid/manager_test.go
@@ -271,6 +271,62 @@ func TestManager_CustomLabelsWithSymbols(t *testing.T) {
 	}
 }
 
+func TestGridManager_ResetSilentClearsInputWithoutCallback(t *testing.T) {
+	logger := logger.Get()
+
+	testGrid := grid.NewGrid("abcdefghijklmnopqrstuvwxyz", image.Rect(0, 0, 1000, 1000), logger)
+
+	var updates int
+
+	manager := grid.NewManager(
+		testGrid,
+		3, 3, "asdf",
+		func(_ bool) { updates++ },
+		func(_ *grid.Cell) {},
+		logger,
+	)
+
+	manager.SetCurrentInput("AB")
+
+	manager.ResetSilent()
+
+	if input := manager.CurrentInput(); input != "" {
+		t.Errorf("CurrentInput() = %q, want '' after ResetSilent()", input)
+	}
+
+	if updates != 0 {
+		t.Errorf("ResetSilent() fired onUpdate %d times, want 0", updates)
+	}
+}
+
+func TestGridManager_ResetClearsInputAndFiresCallback(t *testing.T) {
+	logger := logger.Get()
+
+	testGrid := grid.NewGrid("abcdefghijklmnopqrstuvwxyz", image.Rect(0, 0, 1000, 1000), logger)
+
+	var redraws []bool
+
+	manager := grid.NewManager(
+		testGrid,
+		3, 3, "asdf",
+		func(redraw bool) { redraws = append(redraws, redraw) },
+		func(_ *grid.Cell) {},
+		logger,
+	)
+
+	manager.SetCurrentInput("AB")
+
+	manager.Reset()
+
+	if input := manager.CurrentInput(); input != "" {
+		t.Errorf("CurrentInput() = %q, want '' after Reset()", input)
+	}
+
+	if len(redraws) != 1 || redraws[0] {
+		t.Errorf("Reset() onUpdate calls = %v, want exactly one call with redraw=false", redraws)
+	}
+}
+
 func TestManager_InputValidation(t *testing.T) {
 	logger := logger.Get()
 


### PR DESCRIPTION
## Description

Exiting grid mode called `Manager.Reset()`, whose `onUpdate` callback re-rendered and flushed the full unfiltered grid for a frame before the overlay was hidden, producing a visible flash.

Add `Manager.ResetSilent()` to clear input state without firing the callback. Use it during cleanup; `Reset()` delegates to it so the two stay in sync. Also remove the redundant `Clear()` in `clearAndHideOverlay` — the subsequent `Hide()` tears down the buffer, and `Clear()` never flushed.

## Related Issues

N/A

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

N/A

## Additional Context

N/A