### PR TITLE
feat(linux,wayland): render overlay at output buffer scale

### DIFF
--- a/internal/config/config_integration_test.go
+++ b/internal/config/config_integration_test.go
@@ -203,6 +203,8 @@ scroll_step_full = 1000
 		appCfg := cfg.Scroll.AppConfigForBundleID("com.apple.Safari")
 		if appCfg == nil {
 			t.Fatal("expected Safari app config to be present")
+
+			return
 		}
 
 		if appCfg.ScrollStep == nil || *appCfg.ScrollStep != 25 {

--- a/internal/core/infra/platform/linux/overlay_wayland.c
+++ b/internal/core/infra/platform/linux/overlay_wayland.c
@@ -519,8 +519,8 @@ void neru_wayland_overlay_setup_buffers(NeruWaylandOverlay *overlay) {
 		wl_shm_pool_destroy(pool);
 		close(fd);
 
-		scr->cairo_surface = cairo_image_surface_create_for_data(
-		    scr->shm_data, CAIRO_FORMAT_ARGB32, buf_width, buf_height, (int)stride);
+		scr->cairo_surface =
+		    cairo_image_surface_create_for_data(scr->shm_data, CAIRO_FORMAT_ARGB32, buf_width, buf_height, (int)stride);
 		scr->cr = cairo_create(scr->cairo_surface);
 		cairo_scale(scr->cr, scale, scale);
 

--- a/internal/core/infra/platform/linux/overlay_wayland.c
+++ b/internal/core/infra/platform/linux/overlay_wayland.c
@@ -118,6 +118,28 @@ static const struct zwlr_layer_surface_v1_listener layer_surface_listener = {
     .closed = neru_layer_surface_closed,
 };
 
+// Output listener to track per-output buffer scale.
+static void neru_wl_output_geometry(
+    void *data, struct wl_output *output, int32_t x, int32_t y, int32_t phys_w, int32_t phys_h, int32_t subpixel,
+    const char *make, const char *model, int32_t transform) {}
+
+static void neru_wl_output_mode(
+    void *data, struct wl_output *output, uint32_t flags, int32_t width, int32_t height, int32_t refresh) {}
+
+static void neru_wl_output_done(void *data, struct wl_output *output) {}
+
+static void neru_wl_output_scale(void *data, struct wl_output *output, int32_t factor) {
+	NeruWaylandOverlayScreen *scr = (NeruWaylandOverlayScreen *)data;
+	scr->scale = factor;
+}
+
+static const struct wl_output_listener wl_output_listener = {
+    .geometry = neru_wl_output_geometry,
+    .mode = neru_wl_output_mode,
+    .done = neru_wl_output_done,
+    .scale = neru_wl_output_scale,
+};
+
 static void neru_overlay_registry_global(
     void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version) {
 	NeruWaylandOverlay *overlay = (NeruWaylandOverlay *)data;
@@ -130,8 +152,10 @@ static void neru_overlay_registry_global(
 		overlay->layer_shell = wl_registry_bind(registry, name, &zwlr_layer_shell_v1_interface, 1);
 	} else if (strcmp(interface, "wl_output") == 0) {
 		if (overlay->nr_screens < NERU_MAX_OUTPUTS) {
-			overlay->screens[overlay->nr_screens].wl_output =
-			    wl_registry_bind(registry, name, &wl_output_interface, 3 < version ? 3 : version);
+			NeruWaylandOverlayScreen *scr = &overlay->screens[overlay->nr_screens];
+			scr->scale = 1;
+			scr->wl_output = wl_registry_bind(registry, name, &wl_output_interface, 3 < version ? 3 : version);
+			wl_output_add_listener(scr->wl_output, &wl_output_listener, scr);
 			overlay->nr_screens++;
 		}
 	} else if (strcmp(interface, "zxdg_output_manager_v1") == 0) {
@@ -475,8 +499,12 @@ void neru_wayland_overlay_setup_buffers(NeruWaylandOverlay *overlay) {
 		if (scr->buffer)
 			continue;
 
-		size_t stride = ((size_t)scr->width) * 4u;
-		scr->shm_size = stride * (size_t)scr->height;
+		int scale = scr->scale > 0 ? scr->scale : 1;
+		int buf_width = scr->width * scale;
+		int buf_height = scr->height * scale;
+
+		size_t stride = ((size_t)buf_width) * 4u;
+		scr->shm_size = stride * (size_t)buf_height;
 		int fd = create_shm_file(scr->shm_size);
 		if (fd < 0)
 			continue;
@@ -487,13 +515,17 @@ void neru_wayland_overlay_setup_buffers(NeruWaylandOverlay *overlay) {
 			continue;
 		}
 		struct wl_shm_pool *pool = wl_shm_create_pool(overlay->shm, fd, (int)scr->shm_size);
-		scr->buffer = wl_shm_pool_create_buffer(pool, 0, scr->width, scr->height, (int)stride, WL_SHM_FORMAT_ARGB8888);
+		scr->buffer = wl_shm_pool_create_buffer(pool, 0, buf_width, buf_height, (int)stride, WL_SHM_FORMAT_ARGB8888);
 		wl_shm_pool_destroy(pool);
 		close(fd);
 
 		scr->cairo_surface = cairo_image_surface_create_for_data(
-		    scr->shm_data, CAIRO_FORMAT_ARGB32, scr->width, scr->height, (int)stride);
+		    scr->shm_data, CAIRO_FORMAT_ARGB32, buf_width, buf_height, (int)stride);
 		scr->cr = cairo_create(scr->cairo_surface);
+		cairo_scale(scr->cr, scale, scale);
+
+		if (scr->wl_surface)
+			wl_surface_set_buffer_scale(scr->wl_surface, scale);
 	}
 }
 

--- a/internal/core/infra/platform/linux/overlay_wayland.h
+++ b/internal/core/infra/platform/linux/overlay_wayland.h
@@ -12,6 +12,7 @@
 
 typedef struct {
 	int x, y, width, height;
+	int scale;
 	struct wl_output *wl_output;
 	struct zxdg_output_v1 *xdg_output;
 


### PR DESCRIPTION
## Description

On HiDPI outputs the overlay was drawn into a buffer sized in logical pixels and upscaled by the compositor, making grid labels and hints look blurry.

Track each output's scale factor via a `wl_output` listener, allocate the shm buffer at physical resolution (`logical_size × scale`), apply a matching `cairo_scale` so existing logical-coordinate drawing is unchanged, and advertise the scale with `wl_surface_set_buffer_scale`.

Scale defaults to `1`, preserving the current behaviour on non-HiDPI outputs and before the scale event arrives.

## Related Issues

N/A

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<img width="3840" height="2160" alt="neru-hidpi" src="https://github.com/user-attachments/assets/4ced14ce-2fe7-4ea7-b045-7cbe52d06ef9" />

## Additional Context

N/A