### PR TITLE
fix(darwin): keep mode indicator visible across Spaces

### DIFF
--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -1717,11 +1717,17 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 @property(nonatomic, assign) NSInteger sharingType;     ///< Current window sharing type
 @property(nonatomic, assign) BOOL sharingTypeExplicit;  ///< Whether sharingType was explicitly configured
 @property(nonatomic, assign) BOOL shouldBeVisible;      ///< Whether the window should currently be visible on screen
+- (void)applyOverlayCollectionBehavior;
+- (void)reattachToAllSpacesIfVisible;
 @end
 
 #pragma mark - Overlay Window Controller Implementation
 
 @implementation OverlayWindowController
+
+- (void)dealloc {
+	[[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self];
+}
 
 /// Initialize
 /// @return Initialized instance
@@ -1732,6 +1738,41 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 		[self createWindow];
 	}
 	return self;
+}
+
+- (void)applyOverlayCollectionBehavior {
+	[self.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
+	                                   NSWindowCollectionBehaviorStationary | NSWindowCollectionBehaviorIgnoresCycle |
+	                                   NSWindowCollectionBehaviorFullScreenAuxiliary];
+}
+
+- (BOOL)hasDrawableFrame {
+	NSRect frame = self.window.frame;
+	return frame.size.width > 1.0 || frame.size.height > 1.0;
+}
+
+- (void)reattachToAllSpacesIfVisible {
+	if (!self.shouldBeVisible || ![self hasDrawableFrame])
+		return;
+
+	[self.window orderOut:nil];
+	[self.window setCollectionBehavior:NSWindowCollectionBehaviorDefault];
+	[self applyOverlayCollectionBehavior];
+	[self.window setIsVisible:YES];
+	[self.window orderFrontRegardless];
+	[self.overlayView setNeedsDisplay:YES];
+}
+
+- (void)handleActiveSpaceDidChange:(NSNotification *)notification {
+	(void)notification;
+	if ([NSThread isMainThread]) {
+		[self reattachToAllSpacesIfVisible];
+		return;
+	}
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[self reattachToAllSpacesIfVisible];
+	});
 }
 
 /// Create window
@@ -1769,9 +1810,12 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	[self.window setIgnoresMouseEvents:YES];
 	[self.window setAcceptsMouseMovedEvents:NO];
 	[self.window setHasShadow:NO];
-	[self.window
-	    setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorStationary |
-	                          NSWindowCollectionBehaviorFullScreenAuxiliary | NSWindowCollectionBehaviorIgnoresCycle];
+	[self applyOverlayCollectionBehavior];
+
+	[[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self
+	                                                       selector:@selector(handleActiveSpaceDidChange:)
+	                                                           name:NSWorkspaceActiveSpaceDidChangeNotification
+	                                                         object:nil];
 
 	// Set sharing type — default to visible (NSWindowSharingReadOnly = 1) unless explicitly configured
 	if (!self.sharingTypeExplicit) {
@@ -1860,10 +1904,7 @@ void NeruShowOverlayWindow(OverlayWindow window) {
 			controller.shouldBeVisible = YES;
 
 			[controller.window setLevel:kCGMaximumWindowLevel];
-			[controller.window setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
-			                                         NSWindowCollectionBehaviorStationary |
-			                                         NSWindowCollectionBehaviorIgnoresCycle |
-			                                         NSWindowCollectionBehaviorFullScreenAuxiliary];
+			[controller applyOverlayCollectionBehavior];
 
 			NeruOrderOverlayWindowIfDrawable(controller, YES);
 		}

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -1757,10 +1757,15 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 
 	[self.window orderOut:nil];
 	[self.window setCollectionBehavior:NSWindowCollectionBehaviorDefault];
-	[self applyOverlayCollectionBehavior];
-	[self.window setIsVisible:YES];
-	[self.window orderFrontRegardless];
-	[self.overlayView setNeedsDisplay:YES];
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (!self.shouldBeVisible || ![self hasDrawableFrame])
+			return;
+
+		[self applyOverlayCollectionBehavior];
+		[self.window setIsVisible:YES];
+		[self.window orderFrontRegardless];
+		[self.overlayView setNeedsDisplay:YES];
+	});
 }
 
 - (void)handleActiveSpaceDidChange:(NSNotification *)notification {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes a macOS issue where the mode indicator could become stuck on a single Space after switching Spaces or moving through fullscreen contexts. When this happened, the indicator was still being updated internally, but its overlay window was no longer attached to every Space, so it appeared missing everywhere except the Space that still owned it.

There's previous attempt at #936 to fix this issue but seems like it's not working as expected.

This change makes the macOS overlay window reapply its all-Spaces behavior when the active Space changes. If the indicator is currently visible, the overlay is briefly detached and brought forward again with the correct Space behavior, so it can recover without restarting the app.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
