### PR TITLE
fix(darwin): keep indicators visible after wake changes

### DIFF
--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -1717,6 +1717,8 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 @property(nonatomic, assign) NSInteger sharingType;     ///< Current window sharing type
 @property(nonatomic, assign) BOOL sharingTypeExplicit;  ///< Whether sharingType was explicitly configured
 @property(nonatomic, assign) BOOL shouldBeVisible;      ///< Whether the window should currently be visible on screen
+@property(nonatomic, assign) BOOL needsWindowServerReattach;
+@property(nonatomic, assign) BOOL windowServerReattachScheduled;
 - (void)applyOverlayCollectionBehavior;
 - (void)reattachToAllSpacesIfVisible;
 @end
@@ -1727,6 +1729,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 
 - (void)dealloc {
 	[[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self];
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 /// Initialize
@@ -1735,6 +1738,8 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	self = [super init];
 	if (self) {
 		_shouldBeVisible = NO;
+		_needsWindowServerReattach = NO;
+		_windowServerReattachScheduled = NO;
 		[self createWindow];
 	}
 	return self;
@@ -1752,31 +1757,49 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 }
 
 - (void)reattachToAllSpacesIfVisible {
-	if (!self.shouldBeVisible || ![self hasDrawableFrame])
+	if (!self.shouldBeVisible || ![self hasDrawableFrame] || self.windowServerReattachScheduled)
 		return;
 
+	self.windowServerReattachScheduled = YES;
 	[self.window orderOut:nil];
 	[self.window setCollectionBehavior:NSWindowCollectionBehaviorDefault];
 	dispatch_async(dispatch_get_main_queue(), ^{
+		self.windowServerReattachScheduled = NO;
 		if (!self.shouldBeVisible || ![self hasDrawableFrame])
 			return;
 
+		self.needsWindowServerReattach = NO;
 		[self applyOverlayCollectionBehavior];
 		[self.window setIsVisible:YES];
 		[self.window orderFrontRegardless];
+		[self.window display];
 		[self.overlayView setNeedsDisplay:YES];
 	});
 }
 
-- (void)handleActiveSpaceDidChange:(NSNotification *)notification {
+- (void)handleWindowServerAttachmentInvalidated:(NSNotification *)notification {
 	(void)notification;
 	if ([NSThread isMainThread]) {
+		self.needsWindowServerReattach = YES;
 		[self reattachToAllSpacesIfVisible];
 		return;
 	}
 
 	dispatch_async(dispatch_get_main_queue(), ^{
+		self.needsWindowServerReattach = YES;
 		[self reattachToAllSpacesIfVisible];
+	});
+}
+
+- (void)handleWindowServerAttachmentWillInvalidate:(NSNotification *)notification {
+	(void)notification;
+	if ([NSThread isMainThread]) {
+		self.needsWindowServerReattach = YES;
+		return;
+	}
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		self.needsWindowServerReattach = YES;
 	});
 }
 
@@ -1818,9 +1841,22 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	[self applyOverlayCollectionBehavior];
 
 	[[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self
-	                                                       selector:@selector(handleActiveSpaceDidChange:)
+	                                                       selector:@selector(handleWindowServerAttachmentInvalidated:)
 	                                                           name:NSWorkspaceActiveSpaceDidChangeNotification
 	                                                         object:nil];
+	[[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self
+	                                                       selector:@selector(handleWindowServerAttachmentInvalidated:)
+	                                                           name:NSWorkspaceDidWakeNotification
+	                                                         object:nil];
+	[[[NSWorkspace sharedWorkspace] notificationCenter]
+	    addObserver:self
+	       selector:@selector(handleWindowServerAttachmentWillInvalidate:)
+	           name:NSWorkspaceWillSleepNotification
+	         object:nil];
+	[[NSNotificationCenter defaultCenter] addObserver:self
+	                                         selector:@selector(handleWindowServerAttachmentInvalidated:)
+	                                             name:NSApplicationDidChangeScreenParametersNotification
+	                                           object:nil];
 
 	// Set sharing type — default to visible (NSWindowSharingReadOnly = 1) unless explicitly configured
 	if (!self.sharingTypeExplicit) {
@@ -1851,6 +1887,12 @@ static void NeruOrderOverlayWindowIfDrawable(OverlayWindowController *controller
 	if (frame.size.width <= 1.0 && frame.size.height <= 1.0)
 		return;
 
+	if (controller.needsWindowServerReattach || controller.windowServerReattachScheduled) {
+		[controller reattachToAllSpacesIfVisible];
+		return;
+	}
+
+	[controller applyOverlayCollectionBehavior];
 	[controller.window setIsVisible:YES];
 	[controller.window orderFrontRegardless];
 
@@ -1926,6 +1968,7 @@ void NeruHideOverlayWindow(OverlayWindow window) {
 
 	if ([NSThread isMainThread]) {
 		controller.shouldBeVisible = NO;
+		controller.needsWindowServerReattach = YES;
 		[controller.window orderOut:nil];
 		// Shrink to 1x1 to release the large backing store (saves ~47MB per
 		// Retina-resolution full-screen window). The next resize/show call
@@ -1936,6 +1979,7 @@ void NeruHideOverlayWindow(OverlayWindow window) {
 		dispatch_async(dispatch_get_main_queue(), ^{
 			@autoreleasepool {
 				controller.shouldBeVisible = NO;
+				controller.needsWindowServerReattach = YES;
 				[controller.window orderOut:nil];
 				[controller.window setFrame:NSMakeRect(0, 0, 1, 1) display:NO];
 				[controller.overlayView setFrame:NSMakeRect(0, 0, 1, 1)];
@@ -2223,13 +2267,7 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 			[controller.overlayView applyStyle:style];
 			[controller.overlayView.hints addObjectsFromArray:hintItems];
 			[controller.overlayView setNeedsDisplay:YES];
-			if (controller.shouldBeVisible) {
-				[controller.window setIsVisible:YES];
-				[controller.window orderFrontRegardless];
-				if (style.forceFlush) {
-					[controller.window display];
-				}
-			}
+			NeruOrderOverlayWindowIfDrawable(controller, style.forceFlush ? YES : NO);
 		} else {
 			// Copy style strings before crossing the thread boundary
 			HintStyle styleCopy = {
@@ -2258,14 +2296,7 @@ void NeruDrawHints(OverlayWindow window, HintData *hints, int count, HintStyle s
 					[controller.overlayView applyStyle:styleCopy];
 					[controller.overlayView.hints addObjectsFromArray:hintItems];
 					[controller.overlayView setNeedsDisplay:YES];
-
-					if (controller.shouldBeVisible) {
-						[controller.window setIsVisible:YES];
-						[controller.window orderFrontRegardless];
-						if (styleCopy.forceFlush) {
-							[controller.window display];
-						}
-					}
+					NeruOrderOverlayWindowIfDrawable(controller, styleCopy.forceFlush ? YES : NO);
 
 					free_hint_style_strings(&styleCopy);
 				}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes a macOS issue where the mode indicator and sticky modifiers indicator could disappear from most Spaces while still appearing on one Space. This was most likely caused by their long-lived reusable overlay panels keeping stale WindowServer or Space attachment state after sleep/wake, Space changes, display changes, or hide/show cycles.

This change marks reusable indicator panels for reattachment when those lifecycle events occur, then safely reattaches them once they are visible and have a drawable frame again. The reattach flow preserves the delayed re-show behavior so WindowServer has time to process the detach before the panel is brought forward again.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Tried fixing this with #956 but the behavior still persists.

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
