### PR TITLE
fix(darwin,monitor_select): allow current monitor to be selectable

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -261,8 +261,6 @@ easing = "ease_out"                         # linear, ease_in, ease_out, ease_in
 enabled = false                                # Enable interactive monitor picking mode
 characters = "123456789"                       # Characters used for monitor labels
 
-show_current_monitor = true                    # Show current monitor marker with label
-
 [monitor_select.ui]
 font_size = 96                                 # Badge label font size
 font_family = ""                               # Badge label font family

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -740,7 +740,6 @@ Interactive display picking mode. Shows per-monitor overlay badges labelled with
 | ---------------------- | ------ | ------------- | --------------------------------------------------- |
 | `enabled`              | bool   | `false`       | Enable interactive monitor picking                  |
 | `characters`           | string | `"123456789"` | Characters used for monitor labels                  |
-| `show_current_monitor` | bool   | `true`        | Show a "Current" marker on the active monitor badge |
 
 ### UI
 
@@ -774,7 +773,6 @@ Interactive display picking mode. Shows per-monitor overlay badges labelled with
 [monitor_select]
 enabled = false
 characters = "123456789"
-show_current_monitor = true
 
 [monitor_select.ui]
 font_size = 96

--- a/internal/app/modes/monitor_select_overlay_darwin.go
+++ b/internal/app/modes/monitor_select_overlay_darwin.go
@@ -228,22 +228,12 @@ func (h *Handler) currentMonitorSelectRenderStateLocked() monitorSelectRenderSta
 		selectedName = selected.Name
 	}
 
-	if current := h.monitorSelect.Current(); current != nil {
-		state.Targets = append(state.Targets, monitorSelectRenderTarget{
-			Bounds:     current.Bounds,
-			Label:      "Current",
-			Subtitle:   current.Name,
-			IsCurrent:  true,
-			IsSelected: false,
-		})
-	}
-
 	for _, target := range h.monitorSelect.Targets() {
 		state.Targets = append(state.Targets, monitorSelectRenderTarget{
 			Bounds:           target.Bounds,
 			Label:            target.Label,
 			Subtitle:         target.Name,
-			IsCurrent:        false,
+			IsCurrent:        target.IsCurrent,
 			IsSelected:       target.Name == selectedName,
 			MatchedPrefixLen: matchedPrefixLength(target.Label, state.Input),
 		})

--- a/internal/app/modes/monitor_select_session.go
+++ b/internal/app/modes/monitor_select_session.go
@@ -51,32 +51,24 @@ func newMonitorSelectSession(
 	// Assign positional labels to ALL monitors based on the fixed spatial order.
 	assignMonitorLabels(monitors, cfg.Characters)
 
-	targets := make([]monitorSelectTarget, 0, len(monitors)-1)
+	targets := make([]monitorSelectTarget, len(monitors))
 
-	var current *monitorSelectTarget
+	var currentPtr *monitorSelectTarget
 
 	for idx := range monitors {
 		if idx == currentIndex {
 			monitors[idx].IsCurrent = true
-			if cfg.ShowCurrentMonitor {
-				currentCopy := monitors[idx]
-				current = &currentCopy
-			}
-
-			continue
+			currentCopy := monitors[idx]
+			currentPtr = &currentCopy
 		}
 
-		targets = append(targets, monitors[idx])
-	}
-
-	if len(targets) == 0 {
-		return nil
+		targets[idx] = monitors[idx]
 	}
 
 	return &monitorSelectSession{
 		characters:    []rune(cfg.Characters),
 		targets:       targets,
-		current:       current,
+		current:       currentPtr,
 		selectedIndex: 0,
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -602,11 +602,10 @@ type MonitorSelectUI struct {
 
 // MonitorSelectConfig defines behavior and appearance settings for monitor_select mode.
 type MonitorSelectConfig struct {
-	Enabled            bool                           `json:"enabled"            toml:"enabled"`
-	Characters         string                         `json:"characters"         toml:"characters"`
-	ShowCurrentMonitor bool                           `json:"showCurrentMonitor" toml:"show_current_monitor"`
-	UI                 MonitorSelectUI                `json:"ui"                 toml:"ui"`
-	Hotkeys            map[string]StringOrStringArray `json:"hotkeys"            toml:"-"`
+	Enabled    bool                           `json:"enabled"    toml:"enabled"`
+	Characters string                         `json:"characters" toml:"characters"`
+	UI         MonitorSelectUI                `json:"ui"         toml:"ui"`
+	Hotkeys    map[string]StringOrStringArray `json:"hotkeys"    toml:"-"`
 }
 
 // HintsUI defines the visual/appearance settings for hints mode.

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -617,9 +617,8 @@ func newDefaultConfig() *Config {
 			},
 		},
 		MonitorSelect: MonitorSelectConfig{
-			Enabled:            false,
-			Characters:         DefaultMonitorSelectCharacters,
-			ShowCurrentMonitor: true,
+			Enabled:    false,
+			Characters: DefaultMonitorSelectCharacters,
 			Hotkeys: map[string]StringOrStringArray{
 				KeyDisplayEscape: {CmdIdle},
 			},


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR makes the current monitor to be selectable in `monitor_select` mode. Previously, we assumed that the current is not selectable, which is a little weird.

Also removed the `monitor_select.show_current_monitor` from config, not needed anymore...

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Discussed in https://github.com/y3owk1n/neru/discussions/961#discussioncomment-17498725

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
