### PR TITLE
fix(windows): correct active monitor detection

### DIFF
--- a/internal/core/infra/platform/windows/win32.go
+++ b/internal/core/infra/platform/windows/win32.go
@@ -236,10 +236,8 @@ func enumerateMonitors() ([]displayMonitor, error) {
 func activeScreenBounds() (image.Rectangle, error) {
 	cursor, err := cursorPosition()
 	if err == nil {
-		pt := winPoint{x: int32(cursor.X), y: int32(cursor.Y)}
-
 		ret, _, pointErr := procMonitorFromPoint.Call(
-			uintptr(unsafe.Pointer(&pt)),
+			packMonitorPoint(cursor),
 			uintptr(monitorDefaultToNearest),
 		)
 		if ret != 0 {
@@ -258,6 +256,10 @@ func activeScreenBounds() (image.Rectangle, error) {
 	}
 
 	return monitors[0].bounds, nil
+}
+
+func packMonitorPoint(point image.Point) uintptr {
+	return uintptr(uint64(uint32(point.X)) | uint64(uint32(point.Y))<<32)
 }
 
 func screenBoundsByName(name string) (image.Rectangle, bool, error) {

--- a/internal/core/infra/platform/windows/win32_test.go
+++ b/internal/core/infra/platform/windows/win32_test.go
@@ -1,0 +1,44 @@
+//go:build windows && (amd64 || arm64)
+
+package windows //nolint:testpackage // exercises unexported Win32 argument packing helper
+
+import (
+	"image"
+	"testing"
+)
+
+func TestPackMonitorPoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		point image.Point
+		want  uintptr
+	}{
+		{
+			name:  "primary monitor coordinate",
+			point: image.Pt(1280, 720),
+			want:  uintptr(0x000002D000000500),
+		},
+		{
+			name:  "left of primary monitor coordinate",
+			point: image.Pt(-1080, 261),
+			want:  uintptr(0x00000105FFFFFBC8),
+		},
+		{
+			name:  "right monitor coordinate",
+			point: image.Pt(2846, 261),
+			want:  uintptr(0x0000010500000B1E),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := packMonitorPoint(testCase.point); got != testCase.want {
+				t.Fatalf("packMonitorPoint(%v) = %#x, want %#x", testCase.point, got, testCase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- pass the Windows POINT argument to MonitorFromPoint by value instead of passing a pointer
- add Windows coverage for packed monitor coordinates, including left-of-primary negative X layouts

## Testing

- go test ./internal/core/infra/platform/windows
- gofmt -w internal/core/infra/platform/windows/win32.go internal/core/infra/platform/windows/win32_test.go
- git diff --check
- just --shell C:\opt\Git\bin\sh.exe --shell-arg -cu build

## Notes

- just fmt and just lint could not run in this Windows Git Bash environment because golangci-lint was not available on PATH.
- go test ./... currently fails in internal/cli when a local Neru daemon is already running; focused Windows platform tests pass.