### PR TITLE
feat(cli): add `--bail` flag to `wait_for_mode_exit` for chain abort-on-cancel

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -325,9 +325,14 @@ neru action go_bottom                         # Jump to bottom
 neru action reset                             # Reset state in current mode
 neru action backspace                         # Mode-aware backspace
 neru action wait_for_mode_exit                # Block until mode exits to idle
+neru action wait_for_mode_exit --bail         # Block; abort chain if mode was cancelled (no selection)
 neru action save_cursor_pos                   # Save current cursor position
 neru action restore_cursor_pos                # Restore saved cursor position
 ```
+
+| Flag      | Description                                                                   |
+| --------- | ----------------------------------------------------------------------------- |
+| `--bail`  | Abort the action chain if the mode exits without a completed selection        |
 
 ### Feed Keys
 
@@ -566,6 +571,7 @@ Commands are queued by the daemon, so concurrent calls from scripts work safely.
 | --------------------- | ------------------------------------ |
 | `ERR_MODE_DISABLED`   | Requested mode is disabled in config |
 | `ERR_UNKNOWN_COMMAND` | Invalid command name                 |
+| `ERR_CHAIN_BAIL`      | Chain aborted (e.g. `--bail` on `wait_for_mode_exit` when user cancelled) |
 | _(connection error)_  | Daemon is not running                |
 
 ### Log Monitoring

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -234,7 +234,7 @@ All actions available in hotkeys. These also work as `neru action <name>` — se
 | Hints       | `search_hints`, `cycle_hint`, `cycle_hint --backward`                                 |
 | Delay       | `sleep <duration>` — plain numbers are seconds (`0.5`), explicit units: `500ms`, `1s` |
 | Mode        | `reset`, `backspace`                                                                  |
-| Composition | `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos`                         |
+| Composition | `wait_for_mode_exit` (with optional `--bail`), `save_cursor_pos`, `restore_cursor_pos` |
 
 - Use `--bare` (e.g. `"action left_click --bare"`) to target the cursor position instead of the current mode selection (see [CLI.md](CLI.md#clicks))
 - `scroll_up` / `scroll_down` support `--steps` (e.g. `"action scroll_down --steps 200"`) to override `scroll_step` (see [CLI.md](CLI.md#scrolling))
@@ -259,7 +259,12 @@ See [CLI.md](CLI.md#feed-keys) for syntax, supported key names, and platform beh
 [hints.hotkeys]
 "Enter"  = ["action save_cursor_pos", "idle", "action wait_for_mode_exit", "action restore_cursor_pos"]
 "Return" = ["action left_click", "action sleep 0.5", "hints"]
+
+# Bail: abort the chain if the user cancels (Escape) instead of making a selection
+"Ctrl+Z" = ["monitor_select", "action wait_for_mode_exit --bail", "recursive_grid"]
 ```
+
+Use `--bail` to abort the chain when the mode exits without a selection (e.g., user presses Escape). Without `--bail`, `wait_for_mode_exit` always succeeds and the chain continues.
 
 ---
 

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -126,6 +126,10 @@ func (a *App) dispatchHotkeyActions(key string, actions []string) {
 
 		executeHotkeyActionErr := a.executeHotkeyAction(key, trimmedAction)
 		if executeHotkeyActionErr != nil {
+			if derrors.IsCode(executeHotkeyActionErr, derrors.CodeChainBail) {
+				return
+			}
+
 			a.logger.Error("hotkey action failed",
 				zap.String("key", key),
 				zap.String("action", trimmedAction),
@@ -327,6 +331,10 @@ func (a *App) executeHotkeyAction(key, actionStr string) error {
 		ipc.Command{Action: actionStr, Args: params},
 	)
 	if !ipcResponse.Success {
+		if ipcResponse.Code == ipc.CodeChainBail {
+			return derrors.New(derrors.CodeChainBail, ipcResponse.Message)
+		}
+
 		return derrors.New(derrors.CodeIPCFailed, ipcResponse.Message)
 	}
 

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -293,6 +293,14 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 		}
 	}
 
+	if parsed.useBail && !action.IsWaitForModeExitAction(actionName) {
+		return ipc.Response{
+			Success: false,
+			Message: "--bail is only supported with wait_for_mode_exit",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
 	// Handle scroll sub-actions (scroll_up, scroll_down, etc.)
 	// These only require scrollService, so dispatch before the actionService nil check.
 	if action.IsScrollSubAction(actionName) {

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -50,6 +50,7 @@ const (
 	flagPrevious  = "--previous"
 	flagName      = "--name"
 	flagBare      = "--bare"
+	flagBail      = "--bail"
 
 	msgActionServiceNotAvailable           = "action service not available"
 	msgModesHandlerNotAvailable            = "modes handler not available"
@@ -98,6 +99,7 @@ type parsedActionArgs struct {
 	modifierStr    string
 	stepsOverride  int
 	hasSteps       bool
+	useBail        bool
 }
 
 func shouldClearSelectionAfterMoveMouse(parsed parsedActionArgs, targetsSelection bool) bool {
@@ -227,6 +229,8 @@ func parseActionArgs(rawArgs []string) (parsedActionArgs, bool) {
 			parsed.usePrevious = true
 		case arg == "--backward":
 			parsed.useBackward = true
+		case arg == flagBail:
+			parsed.useBail = true
 		case strings.HasPrefix(arg, flagName) && (arg == flagName || arg[len(flagName)] == '='):
 			val, newIdx, ok := extractStringFlag(rawArgs, idx, flagName)
 			idx = newIdx
@@ -1021,7 +1025,7 @@ func (h *IPCControllerActions) handleWaitForModeExitAction(
 	if hasUnsupportedFlags(parsed) {
 		return ipc.Response{
 			Success: false,
-			Message: "wait_for_mode_exit does not support action flags",
+			Message: "wait_for_mode_exit does not support these flags",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}
@@ -1054,6 +1058,17 @@ func (h *IPCControllerActions) handleWaitForModeExitAction(
 				Code:    ipc.CodeActionFailed,
 			}
 		case <-ticker.C:
+		}
+	}
+
+	if parsed.useBail {
+		reason := h.appState.ConsumeModeExitReason()
+		if reason != state.ModeExitReasonCompleted {
+			return ipc.Response{
+				Success: false,
+				Message: "mode exited without selection",
+				Code:    ipc.CodeChainBail,
+			}
 		}
 	}
 

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -1069,14 +1069,15 @@ func (h *IPCControllerActions) handleWaitForModeExitAction(
 		}
 	}
 
-	if parsed.useBail {
-		reason := h.appState.ConsumeModeExitReason()
-		if reason != state.ModeExitReasonCompleted {
-			return ipc.Response{
-				Success: false,
-				Message: "mode exited without selection",
-				Code:    ipc.CodeChainBail,
-			}
+	// Always consume the exit reason to prevent stale values from
+	// leaking into a subsequent wait_for_mode_exit --bail call.
+	reason := h.appState.ConsumeModeExitReason()
+
+	if parsed.useBail && reason != state.ModeExitReasonCompleted {
+		return ipc.Response{
+			Success: false,
+			Message: "mode exited without selection",
+			Code:    ipc.CodeChainBail,
 		}
 	}
 

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -134,6 +134,27 @@ func TestParseActionArgs_BailFlag(t *testing.T) {
 	}
 }
 
+func TestHandleAction_RejectsBailOnNonWaitForModeExit(t *testing.T) {
+	controller := &IPCControllerActions{logger: zap.NewNop()}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: actionCmd,
+		Args:   []string{"left_click", flagBail},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(left_click --bail) expected rejection, got success")
+	}
+
+	if resp.Code != ipc.CodeInvalidInput {
+		t.Fatalf(
+			"handleAction(left_click --bail) code = %q, want %q",
+			resp.Code,
+			ipc.CodeInvalidInput,
+		)
+	}
+}
+
 func TestParseActionArgs_BareFlag(t *testing.T) {
 	parsed, parseErr := parseActionArgs([]string{"--bare"})
 	if parseErr {

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -10,15 +10,17 @@ import (
 
 	"github.com/y3owk1n/neru/internal/app/services"
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
 	portmocks "github.com/y3owk1n/neru/internal/core/ports/mocks"
 )
 
 const (
-	moveMonitor = "move_monitor"
-	moveMouse   = "move_mouse"
-	fooStr      = "foo"
+	moveMonitor     = "move_monitor"
+	moveMouse       = "move_mouse"
+	fooStr          = "foo"
+	waitForModeExit = "wait_for_mode_exit"
 )
 
 func TestParseActionArgs_MoveMouseFlags(t *testing.T) {
@@ -118,6 +120,17 @@ func TestHandleAction_MoveMonitorRejectsUnsupportedFlags(t *testing.T) {
 
 	if resp.Message != msgMoveMonitorDoesNotSupportTheseFlags {
 		t.Fatalf("unexpected error message: %q", resp.Message)
+	}
+}
+
+func TestParseActionArgs_BailFlag(t *testing.T) {
+	parsed, parseErr := parseActionArgs([]string{flagBail})
+	if parseErr {
+		t.Fatal("parseActionArgs() unexpected parse error for --bail")
+	}
+
+	if !parsed.useBail {
+		t.Fatal("parseActionArgs() expected useBail to be true")
 	}
 }
 
@@ -629,5 +642,86 @@ func TestParseSleepDuration(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestHandleAction_WaitForModeExitBail_NoSelection(t *testing.T) {
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeIdle)
+
+	controller := &IPCControllerActions{
+		appState: appState,
+		logger:   zap.NewNop(),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: actionCmd,
+		Args:   []string{waitForModeExit, flagBail},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(wait_for_mode_exit --bail) expected bail when no selection was made")
+	}
+
+	if resp.Code != ipc.CodeChainBail {
+		t.Fatalf("response code = %q, want %q", resp.Code, ipc.CodeChainBail)
+	}
+}
+
+func TestHandleAction_WaitForModeExitBail_WithSelection(t *testing.T) {
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeMonitorSelect)
+
+	controller := &IPCControllerActions{
+		appState: appState,
+		logger:   zap.NewNop(),
+	}
+
+	respCh := make(chan ipc.Response, 1)
+
+	go func() {
+		respCh <- controller.handleAction(context.Background(), ipc.Command{
+			Action: actionCmd,
+			Args:   []string{waitForModeExit, flagBail},
+		})
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	appState.SetModeExitReason(state.ModeExitReasonCompleted)
+	appState.SetMode(domain.ModeIdle)
+
+	select {
+	case resp := <-respCh:
+		if !resp.Success {
+			t.Fatalf("expected success after selection, got: %s", resp.Message)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for wait_for_mode_exit --bail")
+	}
+}
+
+func TestHandleAction_WaitForModeExitBail_StaleReasonCleared(t *testing.T) {
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeIdle)
+	appState.SetModeExitReason(state.ModeExitReasonCompleted)
+	appState.ConsumeModeExitReason()
+
+	controller := &IPCControllerActions{
+		appState: appState,
+		logger:   zap.NewNop(),
+	}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: actionCmd,
+		Args:   []string{waitForModeExit, flagBail},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(wait_for_mode_exit --bail) expected bail after stale reason consumed")
+	}
+
+	if resp.Code != ipc.CodeChainBail {
+		t.Fatalf("response code = %q, want %q", resp.Code, ipc.CodeChainBail)
 	}
 }

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
 
 const (
@@ -363,6 +364,10 @@ func (h *Handler) dispatchHotkeyActions(
 
 			err := h.executeHotkeyAction(capturedKey, trimmedAction)
 			if err != nil {
+				if derrors.IsCode(err, derrors.CodeChainBail) {
+					return
+				}
+
 				h.logger.Error("Hotkey action failed",
 					zap.String("key", capturedKey),
 					zap.String("action", trimmedAction),

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -3,6 +3,7 @@ package modes
 
 import (
 	"image"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -140,14 +141,15 @@ func TestHandleKeyPressRoutesAllKeysToHintSearch(t *testing.T) {
 func TestDispatchHotkeyActions_AbortsOnBail(t *testing.T) {
 	t.Parallel()
 
-	var callCount int
+	var callCount atomic.Int64
 
 	handler := &Handler{
 		logger:   zap.NewNop(),
 		appState: state.NewAppState(),
 		executeHotkeyAction: func(_, actionStr string) error {
-			callCount++
-			if callCount == 1 {
+			callCount.Add(1)
+
+			if callCount.Load() == 1 {
 				return derrors.New(derrors.CodeChainBail, "bail")
 			}
 
@@ -157,13 +159,12 @@ func TestDispatchHotkeyActions_AbortsOnBail(t *testing.T) {
 
 	handler.dispatchHotkeyActions("test-mode", "test-bind", "t", []string{"first", "second"})
 
-	// Give the goroutine time to execute
 	time.Sleep(50 * time.Millisecond)
 
-	if callCount != 1 {
+	if got := callCount.Load(); got != 1 {
 		t.Fatalf(
 			"executeHotkeyAction called %d times, want 1 (chain should abort on bail)",
-			callCount,
+			got,
 		)
 	}
 }
@@ -171,14 +172,15 @@ func TestDispatchHotkeyActions_AbortsOnBail(t *testing.T) {
 func TestDispatchHotkeyActions_ContinuesOnRegularError(t *testing.T) {
 	t.Parallel()
 
-	var callCount int
+	var callCount atomic.Int64
 
 	handler := &Handler{
 		logger:   zap.NewNop(),
 		appState: state.NewAppState(),
 		executeHotkeyAction: func(_, actionStr string) error {
-			callCount++
-			if callCount == 1 {
+			callCount.Add(1)
+
+			if callCount.Load() == 1 {
 				return derrors.New(derrors.CodeIPCFailed, "generic error")
 			}
 
@@ -190,10 +192,10 @@ func TestDispatchHotkeyActions_ContinuesOnRegularError(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	if callCount != 2 {
+	if got := callCount.Load(); got != 2 {
 		t.Fatalf(
 			"executeHotkeyAction called %d times, want 2 (chain should continue on regular error)",
-			callCount,
+			got,
 		)
 	}
 }

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/y3owk1n/neru/internal/core/domain/element"
 	domainhint "github.com/y3owk1n/neru/internal/core/domain/hint"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
@@ -133,6 +134,67 @@ func TestHandleKeyPressRoutesAllKeysToHintSearch(t *testing.T) {
 
 	if got := handler.hints.Context.SearchQuery(); got != "/" {
 		t.Fatalf("search query = %q, want %q", got, "/")
+	}
+}
+
+func TestDispatchHotkeyActions_AbortsOnBail(t *testing.T) {
+	t.Parallel()
+
+	var callCount int
+
+	handler := &Handler{
+		logger:   zap.NewNop(),
+		appState: state.NewAppState(),
+		executeHotkeyAction: func(_, actionStr string) error {
+			callCount++
+			if callCount == 1 {
+				return derrors.New(derrors.CodeChainBail, "bail")
+			}
+
+			return nil
+		},
+	}
+
+	handler.dispatchHotkeyActions("test-mode", "test-bind", "t", []string{"first", "second"})
+
+	// Give the goroutine time to execute
+	time.Sleep(50 * time.Millisecond)
+
+	if callCount != 1 {
+		t.Fatalf(
+			"executeHotkeyAction called %d times, want 1 (chain should abort on bail)",
+			callCount,
+		)
+	}
+}
+
+func TestDispatchHotkeyActions_ContinuesOnRegularError(t *testing.T) {
+	t.Parallel()
+
+	var callCount int
+
+	handler := &Handler{
+		logger:   zap.NewNop(),
+		appState: state.NewAppState(),
+		executeHotkeyAction: func(_, actionStr string) error {
+			callCount++
+			if callCount == 1 {
+				return derrors.New(derrors.CodeIPCFailed, "generic error")
+			}
+
+			return nil
+		},
+	}
+
+	handler.dispatchHotkeyActions("test-mode", "test-bind", "t", []string{"first", "second"})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if callCount != 2 {
+		t.Fatalf(
+			"executeHotkeyAction called %d times, want 2 (chain should continue on regular error)",
+			callCount,
+		)
 	}
 }
 

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -10,6 +10,7 @@ import (
 	hintscomponent "github.com/y3owk1n/neru/internal/app/components/hints"
 	configpkg "github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/domain/state"
 	"github.com/y3owk1n/neru/internal/ui/coordinates"
 )
 
@@ -69,6 +70,7 @@ func (h *Handler) executeActionAtPoint(
 		return
 	}
 
+	h.appState.SetModeExitReason(state.ModeExitReasonCompleted)
 	h.exitModeLocked()
 }
 

--- a/internal/app/modes/monitor_select.go
+++ b/internal/app/modes/monitor_select.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/domain/state"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
@@ -65,7 +66,15 @@ func (h *Handler) activateMonitorSelectMode(_ ModeActivationOptions) {
 
 	session := newMonitorSelectSession(monitors, h.config.MonitorSelect)
 	if session == nil {
-		h.logger.Debug("Skipping monitor_select activation; no selectable monitors")
+		if len(monitors) == 1 {
+			// Single monitor: auto-confirm immediately so that
+			// wait_for_mode_exit --bail chains see a completed selection.
+			h.appState.SetModeExitReason(state.ModeExitReasonCompleted)
+			h.exitModeLocked()
+			h.confirmMonitorSelectLocked(&monitors[0])
+		} else {
+			h.logger.Debug("Skipping monitor_select activation; no selectable monitors")
+		}
 
 		return
 	}
@@ -116,6 +125,7 @@ func (h *Handler) confirmMonitorSelectLocked(target *monitorSelectTarget) {
 		Y: bounds.Min.Y + bounds.Dy()/2,
 	}
 
+	h.appState.SetModeExitReason(state.ModeExitReasonCompleted)
 	h.exitModeLocked()
 
 	go func() {

--- a/internal/cli/action.go
+++ b/internal/cli/action.go
@@ -132,13 +132,35 @@ var ActionBackspaceCmd = BuildActionCommand(
 )
 
 // ActionWaitForModeExitCmd blocks until the current mode exits.
-var ActionWaitForModeExitCmd = BuildActionCommand(
-	"wait_for_mode_exit",
-	"Wait until mode exits",
-	`Block until the current mode exits and Neru returns to idle.`,
-	[]string{"wait_for_mode_exit"},
-	false,
-)
+// Has its own builder to support the --bail flag.
+var ActionWaitForModeExitCmd = func() *cobra.Command {
+	var bail bool
+
+	cmd := &cobra.Command{
+		Use:   "wait_for_mode_exit",
+		Short: "Wait until mode exits",
+		Long: `Block until the current mode exits and Neru returns to idle.
+
+Use --bail in an action chain to abort the chain when the mode exits
+without a completed selection (e.g. user presses Escape).`,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return requiresRunningInstance()
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			args := []string{"wait_for_mode_exit"}
+			if bail {
+				args = append(args, "--bail")
+			}
+
+			return sendCommand(cmd, "action", args)
+		},
+	}
+
+	cmd.Flags().BoolVar(&bail, "bail", false,
+		"Abort the action chain if the mode exits without a selection")
+
+	return cmd
+}()
 
 // ActionSaveCursorPosCmd saves cursor position for later restoration.
 var ActionSaveCursorPosCmd = BuildActionCommand(

--- a/internal/core/domain/state/app_state.go
+++ b/internal/core/domain/state/app_state.go
@@ -6,6 +6,18 @@ import (
 	"github.com/y3owk1n/neru/internal/core/domain"
 )
 
+// ModeExitReason indicates how the most recent mode was exited.
+type ModeExitReason int
+
+const (
+	// ModeExitReasonNone is the initial state — no exit has been observed.
+	ModeExitReasonNone ModeExitReason = iota
+	// ModeExitReasonCompleted means the user made a deliberate selection.
+	ModeExitReasonCompleted
+	// ModeExitReasonCancelled means the user dismissed the mode without selecting.
+	ModeExitReasonCancelled
+)
+
 // AppState manages the core application state including enabled status,
 // current mode, and various operational flags.
 type AppState struct {
@@ -16,6 +28,8 @@ type AppState struct {
 	currentMode          domain.Mode
 	hiddenForScreenShare bool
 	scrollInverted       bool
+	modeExitReason       ModeExitReason
+	modeExitReasonValid  bool
 
 	// Callbacks - stored as map for O(1) unsubscribe
 	// Note: All callback maps share a single nextCallbackID counter to ensure
@@ -331,11 +345,46 @@ func (s *AppState) CurrentMode() domain.Mode {
 }
 
 // SetMode sets the current application mode.
+// When entering a non-idle mode, any stale exit reason is invalidated.
 func (s *AppState) SetMode(mode domain.Mode) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if mode != domain.ModeIdle {
+		s.modeExitReason = ModeExitReasonNone
+		s.modeExitReasonValid = false
+	}
+
 	s.currentMode = mode
+}
+
+// SetModeExitReason records how the current mode session exited. Must be
+// called before the mode transitions to idle (before exitModeLocked).
+func (s *AppState) SetModeExitReason(reason ModeExitReason) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.modeExitReason = reason
+	s.modeExitReasonValid = true
+}
+
+// ConsumeModeExitReason atomically reads and resets the exit reason.
+// Returns ModeExitReasonNone if no valid reason was recorded.
+// This ensures each consumer (e.g. wait_for_mode_exit --bail) sees the
+// value exactly once and stale values don't leak between chains.
+func (s *AppState) ConsumeModeExitReason() ModeExitReason {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.modeExitReasonValid {
+		return ModeExitReasonNone
+	}
+
+	reason := s.modeExitReason
+	s.modeExitReason = ModeExitReasonNone
+	s.modeExitReasonValid = false
+
+	return reason
 }
 
 // HotkeysRegistered returns whether hotkeys are currently registered.

--- a/internal/core/domain/state/app_state_test.go
+++ b/internal/core/domain/state/app_state_test.go
@@ -75,6 +75,46 @@ func TestAppState_Mode(t *testing.T) {
 	}
 }
 
+func TestAppState_ModeExitReason(t *testing.T) {
+	_state := state.NewAppState()
+
+	// Initially should be None.
+	if got := _state.ConsumeModeExitReason(); got != state.ModeExitReasonNone {
+		t.Fatalf("initial ConsumeModeExitReason() = %v, want ModeExitReasonNone", got)
+	}
+
+	// Set and consume Completed.
+	_state.SetModeExitReason(state.ModeExitReasonCompleted)
+
+	if got := _state.ConsumeModeExitReason(); got != state.ModeExitReasonCompleted {
+		t.Fatalf("after Set(Completed) ConsumeModeExitReason() = %v, want Completed", got)
+	}
+
+	// Should be reset to None after consumption.
+
+	if got := _state.ConsumeModeExitReason(); got != state.ModeExitReasonNone {
+		t.Fatalf("after consume ConsumeModeExitReason() = %v, want ModeExitReasonNone", got)
+	}
+
+	// Set and consume Canceled.
+	_state.SetModeExitReason(state.ModeExitReasonCancelled)
+
+	if got := _state.ConsumeModeExitReason(); got != state.ModeExitReasonCancelled {
+		t.Fatalf(
+			"after Set(Canceled) ConsumeModeExitReason() = %v, want Canceled",
+			got,
+		)
+	}
+
+	// Double consume should return None (already reset).
+	_state.SetModeExitReason(state.ModeExitReasonCompleted)
+	_state.ConsumeModeExitReason() // consume once
+
+	if got := _state.ConsumeModeExitReason(); got != state.ModeExitReasonNone {
+		t.Fatalf("double consume = %v, want ModeExitReasonNone", got)
+	}
+}
+
 func TestAppState_HotkeysRegistered(t *testing.T) {
 	_state := state.NewAppState()
 

--- a/internal/core/errors/errors.go
+++ b/internal/core/errors/errors.go
@@ -85,6 +85,10 @@ const (
 	//           "screen bounds not yet implemented on linux")
 	//   }
 	CodeNotSupported Code = "NOT_SUPPORTED"
+
+	// CodeChainBail indicates a chain action should abort (e.g. user canceled
+	// a mode without making a selection).
+	CodeChainBail Code = "CHAIN_BAIL"
 )
 
 // Error represents a domain error with code, message, and optional cause.

--- a/internal/core/infra/ipc/ipc.go
+++ b/internal/core/infra/ipc/ipc.go
@@ -77,6 +77,10 @@ const (
 	CodeInvalidInput    = "ERR_INVALID_INPUT"
 	CodeActionFailed    = "ERR_ACTION_FAILED"
 	CodeVersionMismatch = "ERR_VERSION_MISMATCH"
+
+	// CodeChainBail indicates a chain action should abort (e.g. user canceled
+	// a mode without making a selection).
+	CodeChainBail = "ERR_CHAIN_BAIL"
 )
 
 // Command represents a command sent through the IPC interface.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds `--bail` flag to the `wait_for_mode_exit` composition action. When set, the action chain aborts if the mode exits without a completed selection (e.g. user presses Escape). Without `--bail`, the chain always continues.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to https://github.com/y3owk1n/neru/discussions/961#discussioncomment-17533632

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
