### PR TITLE
feat(hotkeys): let per-mode hotkeys override a global hotkey on the same key

### DIFF
--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -153,7 +153,12 @@ func (a *App) dispatchModeAwareHeldHotkey(key string, globalActions []string) {
 		override, hasOverride = a.modes.ModeHotkeyOverride(key)
 	}
 
-	actions, repeat := a.effectiveHeldHotkey(hasOverride, override, globalActions, a.configSnapshot())
+	actions, repeat := a.effectiveHeldHotkey(
+		hasOverride,
+		override,
+		globalActions,
+		a.configSnapshot(),
+	)
 	if repeat {
 		a.startHotkeyRepeat(key, actions)
 

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -71,18 +71,26 @@ func (a *App) registerHotkeys() {
 
 		var registerHotkeyErr error
 
-		if releaseManager, ok := a.hotkeyManager.(HotkeyReleaseService); ok &&
-			a.hotkeyActionsRepeatWhileHeld(bindActions, cfg) {
+		// When the backend can report key releases, register every hotkey through
+		// the release path and decide press-by-press whether to repeat. The
+		// repeat-vs-once choice depends on the effective binding (the per-mode
+		// override when the active mode binds this key, otherwise the global
+		// binding), which is only known at press time — so it cannot be made here,
+		// at registration, from the global action alone.
+		if releaseManager, ok := a.hotkeyManager.(HotkeyReleaseService); ok {
 			_, registerHotkeyErr = releaseManager.RegisterWithRelease(
 				bindKey,
 				func() {
-					a.startHotkeyRepeat(bindKey, bindActions)
+					a.dispatchModeAwareHeldHotkey(bindKey, bindActions)
 				},
 				func() {
 					a.stopHotkeyRepeat(bindKey)
 				},
 			)
 		} else {
+			// Backend without release events (currently Windows and Linux): held-key
+			// repeat is not possible, so a single mode-aware dispatch is the whole
+			// behavior.
 			_, registerHotkeyErr = a.hotkeyManager.Register(bindKey, func() {
 				a.dispatchModeAwareHotkeyAsync(bindKey, bindActions)
 			})
@@ -101,17 +109,21 @@ func (a *App) registerHotkeys() {
 	}
 }
 
-// dispatchModeAwareHotkeyAsync dispatches a global hotkey, applying any per-mode
-// binding for the same key while a navigation mode is active.
+// dispatchModeAwareHotkeyAsync dispatches a global hotkey once, applying any
+// per-mode binding for the same key while a navigation mode is active.
 //
 // Global hotkeys fire through an always-on, per-hotkey event tap that is
 // separate from the event tap serving per-mode hotkeys. When a mode is active
 // and the pressed key is bound both globally and by that mode, the global tap
 // runs the global action and consumes the event before the mode tap can apply
 // the mode-specific binding. Resolving the mode binding here makes the more
-// specific per-mode binding win deterministically, regardless of which tap
-// observes the key first. Falls back to the global actions when the active mode
-// does not bind the key (or when idle).
+// specific per-mode binding win. Falls back to the global actions when the
+// active mode does not bind the key (or when idle).
+//
+// This is the single-dispatch path used by hotkey backends that cannot report
+// key releases (and therefore cannot repeat while held). Backends that can
+// report releases use dispatchModeAwareHeldHotkey, which applies the same
+// override resolution and additionally repeats held-repeatable actions.
 func (a *App) dispatchModeAwareHotkeyAsync(key string, globalActions []string) {
 	actions := globalActions
 
@@ -122,6 +134,51 @@ func (a *App) dispatchModeAwareHotkeyAsync(key string, globalActions []string) {
 	}
 
 	a.dispatchHotkeyActionsAsync(key, actions)
+}
+
+// dispatchModeAwareHeldHotkey handles a global hotkey press on backends that
+// report key releases. It resolves the effective binding (the per-mode override
+// when the active mode binds the key, otherwise the global binding) and
+// dispatches it, repeating while held only when that effective binding is a
+// single held-repeatable action and held-key repeat is enabled. The matching
+// release callback (stopHotkeyRepeat) cancels any repeat this started; it is a
+// no-op when nothing was started.
+func (a *App) dispatchModeAwareHeldHotkey(key string, globalActions []string) {
+	var (
+		override    []string
+		hasOverride bool
+	)
+
+	if a.modes != nil {
+		override, hasOverride = a.modes.ModeHotkeyOverride(key)
+	}
+
+	actions, repeat := a.effectiveHeldHotkey(hasOverride, override, globalActions, a.configSnapshot())
+	if repeat {
+		a.startHotkeyRepeat(key, actions)
+
+		return
+	}
+
+	a.dispatchHotkeyActionsAsync(key, actions)
+}
+
+// effectiveHeldHotkey resolves which actions a global hotkey press should run
+// and whether they should repeat while held. The per-mode override wins over
+// the global binding when present, and the repeat decision is then made from
+// the resolved actions — not from the global binding — so a per-mode override
+// takes precedence on the held-repeat path too.
+func (a *App) effectiveHeldHotkey(
+	hasOverride bool,
+	override, globalActions []string,
+	cfg *config.Config,
+) ([]string, bool) {
+	actions := globalActions
+	if hasOverride {
+		actions = override
+	}
+
+	return actions, a.hotkeyActionsRepeatWhileHeld(actions, cfg)
 }
 
 func (a *App) dispatchHotkeyActionsAsync(key string, actions []string) {

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -84,7 +84,7 @@ func (a *App) registerHotkeys() {
 			)
 		} else {
 			_, registerHotkeyErr = a.hotkeyManager.Register(bindKey, func() {
-				a.dispatchHotkeyActionsAsync(bindKey, bindActions)
+				a.dispatchModeAwareHotkeyAsync(bindKey, bindActions)
 			})
 		}
 
@@ -99,6 +99,29 @@ func (a *App) registerHotkeys() {
 			continue
 		}
 	}
+}
+
+// dispatchModeAwareHotkeyAsync dispatches a global hotkey, applying any per-mode
+// binding for the same key while a navigation mode is active.
+//
+// Global hotkeys fire through an always-on, per-hotkey event tap that is
+// separate from the event tap serving per-mode hotkeys. When a mode is active
+// and the pressed key is bound both globally and by that mode, the global tap
+// runs the global action and consumes the event before the mode tap can apply
+// the mode-specific binding. Resolving the mode binding here makes the more
+// specific per-mode binding win deterministically, regardless of which tap
+// observes the key first. Falls back to the global actions when the active mode
+// does not bind the key (or when idle).
+func (a *App) dispatchModeAwareHotkeyAsync(key string, globalActions []string) {
+	actions := globalActions
+
+	if a.modes != nil {
+		if overrideActions, ok := a.modes.ModeHotkeyOverride(key); ok {
+			actions = overrideActions
+		}
+	}
+
+	a.dispatchHotkeyActionsAsync(key, actions)
 }
 
 func (a *App) dispatchHotkeyActionsAsync(key string, actions []string) {

--- a/internal/app/hotkeys_dispatch_test.go
+++ b/internal/app/hotkeys_dispatch_test.go
@@ -1,0 +1,298 @@
+//nolint:testpackage // Tests private hotkey dispatch/registration behavior.
+package app
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain/state"
+	"github.com/y3owk1n/neru/internal/core/infra/hotkeys"
+)
+
+// fakeReleaseHotkeyManager implements both HotkeyService and
+// HotkeyReleaseService so registerHotkeys drives the release path, and captures
+// the press/release callbacks per key so tests can invoke them.
+type fakeReleaseHotkeyManager struct {
+	mu         sync.Mutex
+	press      map[string]hotkeys.Callback
+	release    map[string]hotkeys.Callback
+	viaRelease map[string]bool
+	nextID     hotkeys.HotkeyID
+}
+
+func newFakeReleaseHotkeyManager() *fakeReleaseHotkeyManager {
+	return &fakeReleaseHotkeyManager{
+		press:      map[string]hotkeys.Callback{},
+		release:    map[string]hotkeys.Callback{},
+		viaRelease: map[string]bool{},
+	}
+}
+
+func (f *fakeReleaseHotkeyManager) Register(
+	key string, callback hotkeys.Callback,
+) (hotkeys.HotkeyID, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.nextID++
+	f.press[key] = callback
+	f.viaRelease[key] = false
+
+	return f.nextID, nil
+}
+
+func (f *fakeReleaseHotkeyManager) RegisterWithRelease(
+	key string, press, release hotkeys.Callback,
+) (hotkeys.HotkeyID, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.nextID++
+	f.press[key] = press
+	f.release[key] = release
+	f.viaRelease[key] = true
+
+	return f.nextID, nil
+}
+
+func (f *fakeReleaseHotkeyManager) UnregisterAll() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.press = map[string]hotkeys.Callback{}
+	f.release = map[string]hotkeys.Callback{}
+	f.viaRelease = map[string]bool{}
+}
+
+func (f *fakeReleaseHotkeyManager) pressCallback(key string) hotkeys.Callback {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.press[key]
+}
+
+func (f *fakeReleaseHotkeyManager) releaseCallback(key string) hotkeys.Callback {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.release[key]
+}
+
+func (f *fakeReleaseHotkeyManager) registeredViaRelease(key string) (bool, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	via, ok := f.viaRelease[key]
+
+	return via, ok
+}
+
+// newDispatchTestApp builds a whitebox App wired with just enough for the
+// hotkey registration/dispatch paths: a config, app state, a nop logger, a
+// cancelable context, the given hotkey manager, and a real IPC controller
+// backed by nil services (so executeHotkeyAction resolves built-in commands
+// without any system dependency). modes is left nil.
+func newDispatchTestApp(t *testing.T, cfg *config.Config, hkm HotkeyService) *App {
+	t.Helper()
+
+	logger := zap.NewNop()
+	appState := state.NewAppState()
+	configService := config.NewService(cfg, "", logger, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	return &App{
+		ctx:           ctx,
+		logger:        logger,
+		config:        cfg,
+		appState:      appState,
+		hotkeyManager: hkm,
+		ipcController: NewIPCController(
+			nil, // hintService
+			nil, // gridService
+			nil, // actionService
+			nil, // scrollService
+			configService,
+			appState,
+			cfg,
+			nil, // modesHandler
+			nil, // systemPort
+			nil, // eventTap
+			nil, // ipcServer
+			nil, // reloadConfig
+			logger,
+		),
+	}
+}
+
+func (a *App) repeatActive(key string) bool {
+	a.hotkeyRepeatMu.Lock()
+	defer a.hotkeyRepeatMu.Unlock()
+
+	return a.hotkeyRepeatCancels[key] != nil
+}
+
+func TestEffectiveHeldHotkey(t *testing.T) {
+	t.Parallel()
+
+	const (
+		heldRepeatAction = "action scroll_down"
+		modeSwitch       = "recursive_grid"
+		modeLaunch       = "hints"
+	)
+
+	tests := []struct {
+		name        string
+		enabled     bool
+		hasOverride bool
+		override    []string
+		global      []string
+		wantActions []string
+		wantRepeat  bool
+	}{
+		{
+			name:        "no override, held-repeat global, enabled -> repeat global",
+			enabled:     true,
+			global:      []string{heldRepeatAction},
+			wantActions: []string{heldRepeatAction},
+			wantRepeat:  true,
+		},
+		{
+			name:        "no override, non-repeat global, enabled -> global once",
+			enabled:     true,
+			global:      []string{modeLaunch},
+			wantActions: []string{modeLaunch},
+			wantRepeat:  false,
+		},
+		{
+			name:        "override mode switch beats held-repeat global -> override once",
+			enabled:     true,
+			hasOverride: true,
+			override:    []string{modeSwitch},
+			global:      []string{heldRepeatAction},
+			wantActions: []string{modeSwitch},
+			wantRepeat:  false,
+		},
+		{
+			name:        "held-repeat override beats non-repeat global -> override repeats",
+			enabled:     true,
+			hasOverride: true,
+			override:    []string{heldRepeatAction},
+			global:      []string{modeLaunch},
+			wantActions: []string{heldRepeatAction},
+			wantRepeat:  true,
+		},
+		{
+			name:        "held_repeat disabled -> never repeats",
+			enabled:     false,
+			global:      []string{heldRepeatAction},
+			wantActions: []string{heldRepeatAction},
+			wantRepeat:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.DefaultConfig()
+			cfg.HeldRepeat.Enabled = tc.enabled
+
+			actions, repeat := (&App{}).effectiveHeldHotkey(
+				tc.hasOverride, tc.override, tc.global, cfg,
+			)
+
+			if !reflect.DeepEqual(actions, tc.wantActions) {
+				t.Fatalf("actions = %v, want %v", actions, tc.wantActions)
+			}
+
+			if repeat != tc.wantRepeat {
+				t.Fatalf("repeat = %v, want %v", repeat, tc.wantRepeat)
+			}
+		})
+	}
+}
+
+func TestRegisterHotkeysUsesReleasePathWhenSupported(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultConfig()
+	cfg.Hotkeys.Bindings = map[string][]string{
+		"Ctrl+Alt+J": {"action scroll_down"}, // held-repeat action
+		"Ctrl+Alt+P": {"ping"},               // non-repeat command
+	}
+
+	fake := newFakeReleaseHotkeyManager()
+	app := newDispatchTestApp(t, cfg, fake)
+
+	app.registerHotkeys()
+
+	for rawKey := range cfg.Hotkeys.Bindings {
+		key := config.CanonicalHotkeyForPlatform(rawKey)
+
+		via, ok := fake.registeredViaRelease(key)
+		if !ok {
+			t.Fatalf("key %q was not registered at all", key)
+		}
+
+		if !via {
+			t.Fatalf("key %q registered via plain Register; want RegisterWithRelease", key)
+		}
+
+		if fake.pressCallback(key) == nil {
+			t.Fatalf("key %q has no press callback", key)
+		}
+
+		if fake.releaseCallback(key) == nil {
+			t.Fatalf("key %q has no release callback", key)
+		}
+	}
+}
+
+func TestDispatchModeAwareHeldHotkey_RepeatVsOnce(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultConfig()
+	cfg.HeldRepeat.Enabled = true
+	// Large delays so the repeat goroutine parks before ticking; the test
+	// cancels via the release callback (and the deferred ctx cancel) first.
+	cfg.HeldRepeat.InitialDelay = 60000
+	cfg.HeldRepeat.Interval = 60000
+	cfg.Hotkeys.Bindings = map[string][]string{
+		"Ctrl+Alt+J": {"action scroll_down"}, // held-repeat -> should repeat
+		"Ctrl+Alt+P": {"ping"},               // non-repeat -> single dispatch
+	}
+
+	fake := newFakeReleaseHotkeyManager()
+	app := newDispatchTestApp(t, cfg, fake)
+	app.registerHotkeys()
+
+	repeatKey := config.CanonicalHotkeyForPlatform("Ctrl+Alt+J")
+	onceKey := config.CanonicalHotkeyForPlatform("Ctrl+Alt+P")
+
+	// Held-repeat binding: press starts a repeat, release stops it.
+	fake.pressCallback(repeatKey)()
+
+	if !app.repeatActive(repeatKey) {
+		t.Fatalf("expected held-repeat to be active after press on %q", repeatKey)
+	}
+
+	fake.releaseCallback(repeatKey)()
+
+	if app.repeatActive(repeatKey) {
+		t.Fatalf("expected held-repeat to be cleared after release on %q", repeatKey)
+	}
+
+	// Non-repeat binding: press dispatches once, never starts a repeat.
+	fake.pressCallback(onceKey)()
+
+	if app.repeatActive(onceKey) {
+		t.Fatalf("non-repeat binding %q must not start a held-repeat", onceKey)
+	}
+}

--- a/internal/app/hotkeys_dispatch_test.go
+++ b/internal/app/hotkeys_dispatch_test.go
@@ -197,23 +197,23 @@ func TestEffectiveHeldHotkey(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			cfg := config.DefaultConfig()
-			cfg.HeldRepeat.Enabled = tc.enabled
+			cfg.HeldRepeat.Enabled = testCase.enabled
 
 			actions, repeat := (&App{}).effectiveHeldHotkey(
-				tc.hasOverride, tc.override, tc.global, cfg,
+				testCase.hasOverride, testCase.override, testCase.global, cfg,
 			)
 
-			if !reflect.DeepEqual(actions, tc.wantActions) {
-				t.Fatalf("actions = %v, want %v", actions, tc.wantActions)
+			if !reflect.DeepEqual(actions, testCase.wantActions) {
+				t.Fatalf("actions = %v, want %v", actions, testCase.wantActions)
 			}
 
-			if repeat != tc.wantRepeat {
-				t.Fatalf("repeat = %v, want %v", repeat, tc.wantRepeat)
+			if repeat != testCase.wantRepeat {
+				t.Fatalf("repeat = %v, want %v", repeat, testCase.wantRepeat)
 			}
 		})
 	}
@@ -224,8 +224,8 @@ func TestRegisterHotkeysUsesReleasePathWhenSupported(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.Hotkeys.Bindings = map[string][]string{
-		"Ctrl+Alt+J": {"action scroll_down"}, // held-repeat action
-		"Ctrl+Alt+P": {"ping"},               // non-repeat command
+		"Ctrl+Alt+J": {actionScrollDown}, // held-repeat action
+		"Ctrl+Alt+P": {"ping"},           // non-repeat command
 	}
 
 	fake := newFakeReleaseHotkeyManager()

--- a/internal/app/hotkeys_test.go
+++ b/internal/app/hotkeys_test.go
@@ -195,7 +195,7 @@ func TestHotkeyActionsRepeatWhileHeld(t *testing.T) {
 		},
 		{
 			name:    "chains do not repeat",
-			actions: []string{"action scroll_down", "action scroll_down"},
+			actions: []string{actionScrollDown, actionScrollDown},
 			want:    false,
 		},
 	}

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -99,31 +99,11 @@ func (h *Handler) HandleKeyPress(key string) {
 	}
 
 	// Resolve the focused app bundle ID once so that both handleHotkey calls
-	// (rawKey and stripped key) share the same snapshot.
+	// (rawKey and stripped key) share the same snapshot. Only needed when the
+	// active mode defines per-app hotkey overrides.
 	var bundleID string
-
-	currentMode := h.appState.CurrentMode()
-	switch currentMode {
-	case domain.ModeHints:
-		if h.config.Hints.HasAppHotkeyOverrides() {
-			bundleID = h.focusedBundleID()
-		}
-	case domain.ModeGrid:
-		if h.config.Grid.HasAppHotkeyOverrides() {
-			bundleID = h.focusedBundleID()
-		}
-	case domain.ModeRecursiveGrid:
-		if h.config.RecursiveGrid.HasAppHotkeyOverrides() {
-			bundleID = h.focusedBundleID()
-		}
-	case domain.ModeScroll:
-		if h.config.Scroll.HasAppHotkeyOverrides() {
-			bundleID = h.focusedBundleID()
-		}
-	case domain.ModeIdle:
-		// No app hotkey overrides for these modes
-	case domain.ModeMonitorSelect:
-		// No app hotkey overrides for monitor select mode
+	if h.modeHasAppHotkeyOverrides(h.appState.CurrentMode()) {
+		bundleID = h.focusedBundleID()
 	}
 
 	// Check for per-mode hotkeys before mode-specific handling.
@@ -157,6 +137,26 @@ func (h *Handler) handleModeSpecificKey(key string) {
 	}
 
 	mode.HandleKey(key)
+}
+
+// modeHasAppHotkeyOverrides reports whether the given mode defines any per-app
+// hotkey overrides. That is the only situation requiring the focused app's
+// bundle ID to be resolved in order to select the correct per-mode hotkey table.
+func (h *Handler) modeHasAppHotkeyOverrides(mode domain.Mode) bool {
+	switch mode {
+	case domain.ModeHints:
+		return h.config.Hints.HasAppHotkeyOverrides()
+	case domain.ModeGrid:
+		return h.config.Grid.HasAppHotkeyOverrides()
+	case domain.ModeRecursiveGrid:
+		return h.config.RecursiveGrid.HasAppHotkeyOverrides()
+	case domain.ModeScroll:
+		return h.config.Scroll.HasAppHotkeyOverrides()
+	case domain.ModeIdle, domain.ModeMonitorSelect:
+		return false
+	default:
+		return false
+	}
 }
 
 // stripStickyModifiersFromKey removes any currently active sticky modifiers from the

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -159,6 +159,46 @@ func (h *Handler) modeHasAppHotkeyOverrides(mode domain.Mode) bool {
 	}
 }
 
+// ModeHotkeyOverride returns the per-mode hotkey actions bound to key in the
+// currently active navigation mode, with ok=true, when such a binding exists.
+// It returns nil, false in idle mode or when the active mode does not bind key.
+//
+// Global (idle-scope) hotkeys are delivered through an always-on, per-hotkey
+// event tap that is independent of the event tap used for per-mode hotkeys.
+// When a key is bound both globally and by the active mode, the global tap
+// consumes the event and runs the global action before the per-mode tap can
+// act, so the per-mode binding for that key would otherwise never take effect.
+// The global-hotkey dispatch path calls this so the more specific per-mode
+// binding wins while a mode is active — e.g. a global "Primary+Ctrl+F" = "hints"
+// launcher and a per-mode [hints.hotkeys] "Primary+Ctrl+F" = "recursive_grid"
+// can coexist, with the latter applied whenever hints mode is active.
+func (h *Handler) ModeHotkeyOverride(key string) ([]string, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	mode := h.appState.CurrentMode()
+	if mode == domain.ModeIdle {
+		return nil, false
+	}
+
+	var bundleID string
+	if h.modeHasAppHotkeyOverrides(mode) {
+		bundleID = h.focusedBundleID()
+	}
+
+	hotkeys := h.config.HotkeysForModeAndApp(domain.ModeString(mode), bundleID)
+	if len(hotkeys) == 0 {
+		return nil, false
+	}
+
+	_, actions, ok := findHotkeyMatch(hotkeys, config.NormalizeKeyForComparison(key))
+	if !ok {
+		return nil, false
+	}
+
+	return actions, true
+}
+
 // stripStickyModifiersFromKey removes any currently active sticky modifiers from the
 // incoming key string so that physical injections don't break expected key bindings.
 func (h *Handler) stripStickyModifiersFromKey(key string, mods action.Modifiers) string {

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -259,12 +259,12 @@ func TestModeHotkeyOverride(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			appState := state.NewAppState()
-			appState.SetMode(tc.mode)
+			appState.SetMode(testCase.mode)
 
 			handler := &Handler{
 				config:   cfg,
@@ -272,22 +272,27 @@ func TestModeHotkeyOverride(t *testing.T) {
 				appState: appState,
 			}
 
-			actions, ok := handler.ModeHotkeyOverride(tc.key)
-			if ok != tc.wantOK {
-				t.Fatalf("ModeHotkeyOverride(%q) ok = %v, want %v", tc.key, ok, tc.wantOK)
+			actions, ok := handler.ModeHotkeyOverride(testCase.key)
+			if ok != testCase.wantOK {
+				t.Fatalf(
+					"ModeHotkeyOverride(%q) ok = %v, want %v",
+					testCase.key,
+					ok,
+					testCase.wantOK,
+				)
 			}
 
-			if !tc.wantOK {
+			if !testCase.wantOK {
 				return
 			}
 
-			if len(actions) != len(tc.wantActions) {
-				t.Fatalf("actions = %v, want %v", actions, tc.wantActions)
+			if len(actions) != len(testCase.wantActions) {
+				t.Fatalf("actions = %v, want %v", actions, testCase.wantActions)
 			}
 
 			for i := range actions {
-				if actions[i] != tc.wantActions[i] {
-					t.Fatalf("actions = %v, want %v", actions, tc.wantActions)
+				if actions[i] != testCase.wantActions[i] {
+					t.Fatalf("actions = %v, want %v", actions, testCase.wantActions)
 				}
 			}
 		})

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -200,6 +200,100 @@ func TestDispatchHotkeyActions_ContinuesOnRegularError(t *testing.T) {
 	}
 }
 
+func TestModeHotkeyOverride(t *testing.T) {
+	t.Parallel()
+
+	cfg := &configpkg.Config{
+		Hints: configpkg.HintsConfig{
+			Hotkeys: map[string]configpkg.StringOrStringArray{
+				"Primary+Ctrl+F": {"recursive_grid"},
+				"Escape":         {"idle"},
+			},
+		},
+		Grid: configpkg.GridConfig{
+			Hotkeys: map[string]configpkg.StringOrStringArray{
+				"Primary+Ctrl+F": {"scroll"},
+			},
+		},
+	}
+
+	// Global-hotkey dispatch passes the platform-canonical key (e.g. "Cmd+Ctrl+F"
+	// on macOS), while the config stores the shared "Primary+..." alias. Build the
+	// lookup keys exactly as registerHotkeys does so the test exercises the real
+	// normalization path on every platform.
+	overrideKey := configpkg.CanonicalHotkeyForPlatform("Primary+Ctrl+F")
+	unboundGlobalKey := configpkg.CanonicalHotkeyForPlatform("Primary+Shift+G")
+
+	tests := []struct {
+		name        string
+		mode        domain.Mode
+		key         string
+		wantActions []string
+		wantOK      bool
+	}{
+		{
+			name:        "active mode binds the key: per-mode action overrides the global binding",
+			mode:        domain.ModeHints,
+			key:         overrideKey,
+			wantActions: []string{"recursive_grid"},
+			wantOK:      true,
+		},
+		{
+			name:   "active mode does not bind the key: no override, global hotkey still fires (#21 preserved)",
+			mode:   domain.ModeHints,
+			key:    unboundGlobalKey,
+			wantOK: false,
+		},
+		{
+			name:   "idle: a global launcher is never overridden",
+			mode:   domain.ModeIdle,
+			key:    overrideKey,
+			wantOK: false,
+		},
+		{
+			name:        "override is scoped to the active mode's own hotkey table",
+			mode:        domain.ModeGrid,
+			key:         overrideKey,
+			wantActions: []string{"scroll"},
+			wantOK:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			appState := state.NewAppState()
+			appState.SetMode(tc.mode)
+
+			handler := &Handler{
+				config:   cfg,
+				logger:   zap.NewNop(),
+				appState: appState,
+			}
+
+			actions, ok := handler.ModeHotkeyOverride(tc.key)
+			if ok != tc.wantOK {
+				t.Fatalf("ModeHotkeyOverride(%q) ok = %v, want %v", tc.key, ok, tc.wantOK)
+			}
+
+			if !tc.wantOK {
+				return
+			}
+
+			if len(actions) != len(tc.wantActions) {
+				t.Fatalf("actions = %v, want %v", actions, tc.wantActions)
+			}
+
+			for i := range actions {
+				if actions[i] != tc.wantActions[i] {
+					t.Fatalf("actions = %v, want %v", actions, tc.wantActions)
+				}
+			}
+		})
+	}
+}
+
 func mustNewModeHint(label string, elem *element.Element) *domainhint.Interface {
 	hint, err := domainhint.NewHint(label, elem, image.Point{})
 	if err != nil {


### PR DESCRIPTION
Disclaimer: This code was written by Claude. I managed and steered the LLM towards a solution I thought sensible.

# Rationale

I wanted to cycle through all the modes from a single key. The idea was that I'd press `Primary+Ctrl+F` to open hints, and pressing it again would take me to the next mode, cycling through hints, recursive grid, grid, and scroll before looping back to hints. The obvious way to set that up is to have the global key open hints, and then have the same key inside each mode point to the next one in the loop.

```toml
[hotkeys]
"Primary+Ctrl+F" = "hints"

[hints.hotkeys]
"Primary+Ctrl+F" = "recursive_grid"
[recursive_grid.hotkeys]
"Primary+Ctrl+F" = "grid"
[grid.hotkeys]
"Primary+Ctrl+F" = "scroll"
[scroll.hotkeys]
"Primary+Ctrl+F" = "hints"
```

That didn't work. As soon as I was inside a mode, pressing the key just reopened hints instead of moving me forward, so the cycle never got past the first step.

# Issue

Global hotkeys and per-mode hotkeys go through two separate event taps, and the global one catches the key and fires its action before the mode's tap ever receives the event. That means a global binding always wins over a per-mode binding on the same key, and there was no way to make a global key do something different while you were inside a mode.

# Changes

This PR makes it so that when a global hotkey fires, it first checks whether the active mode binds that same key. If it does, the mode's binding runs instead. If it doesn't, the global action runs exactly like it used to. Global keys still work from idle, and they still let you jump straight to another mode from inside one, but a mode can now override a key for as long as it's active. That's enough to make the cycle work.

# Repeat keys

I ran into a second version of the same issue while I was making this change. Some global keys are meant to repeat while you hold them, such as scroll, page, and cursor nudge when held-key repeat is enabled, and those go through a different registration path that also skips the override. That path checks whether a key repeats, once during startup, based on the global action. I moved the decision to press time so it's based on whichever binding actually wins, which makes the override work on that path too.

# Notes

There's also a small refactor that pulls a repeated per-app check into a shared helper.

You can still jump to another mode using its global hotkey from inside a mode, because when the current mode doesn't bind that key the global action runs as before. 

Windows and Linux are unaffected, since their hotkey backend can't report key releases, so they never had hold-to-repeat and their path already resolved the override.

For tests I covered the override lookup across the cases that matter (mode binds the key, mode doesn't, idle, and a key that only lives in another mode's table), the press-time repeat decision for every override-and-global combination, and the registration wiring where a press starts the repeat and the release stops it.

# Potential improvements

Key matching doesn't sort modifiers, so `Cmd+Ctrl+F` and `Ctrl+Cmd+F` are treated as different keys for the override. That's a pre-existing quirk in the shared normalize function, and fixing it felt like a separate change.