### PR TITLE
fix(linux,recursive_grid): render subkey preview properly when enabled

### DIFF
--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -48,8 +48,8 @@ const (
 	centeredRectHalf                       = 0.5
 	hintPillRadiusDivisor                  = 2.0
 	paddingMultiplier                      = 2
-	subKeyPreviewPaddingBottom             = 4
-	stickyBadgeClearPadding                = 3
+
+	stickyBadgeClearPadding = 3
 )
 
 type linuxOverlayBackend string
@@ -552,11 +552,31 @@ func (m *Manager) DrawRecursiveGrid(
 	defer m.renderMu.Unlock()
 
 	if m.x11 != nil {
-		m.x11.DrawRecursiveGrid(bounds, depth, keys, gridCols, gridRows, style, virtualPointer)
+		m.x11.DrawRecursiveGridWithSubKeyPreview(
+			bounds,
+			keys,
+			gridCols,
+			gridRows,
+			nextKeys,
+			nextGridCols,
+			nextGridRows,
+			style,
+			virtualPointer,
+		)
 
 		return nil
 	} else if m.wlroots != nil {
-		m.wlroots.DrawRecursiveGrid(bounds, depth, keys, gridCols, gridRows, style, virtualPointer)
+		m.wlroots.DrawRecursiveGridWithSubKeyPreview(
+			bounds,
+			keys,
+			gridCols,
+			gridRows,
+			nextKeys,
+			nextGridCols,
+			nextGridRows,
+			style,
+			virtualPointer,
+		)
 
 		return nil
 	}

--- a/internal/ui/overlay/manager_linux_wayland.go
+++ b/internal/ui/overlay/manager_linux_wayland.go
@@ -57,4 +57,17 @@ func (o *wlrootsOverlay) DrawRecursiveGrid(
 	recursivegridcomponent.VirtualPointerState,
 ) {
 }
+
+func (o *wlrootsOverlay) DrawRecursiveGridWithSubKeyPreview(
+	image.Rectangle,
+	string,
+	int,
+	int,
+	string,
+	int,
+	int,
+	recursivegridcomponent.Style,
+	recursivegridcomponent.VirtualPointerState,
+) {
+}
 func (o *wlrootsOverlay) DrawBadge(int, int, string, overlayColors, overlayBadgeStyle) {}

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -184,6 +184,30 @@ func (o *wlrootsOverlay) DrawRecursiveGrid(
 	style recursivegridcomponent.Style,
 	virtualPointer recursivegridcomponent.VirtualPointerState,
 ) {
+	o.DrawRecursiveGridWithSubKeyPreview(
+		bounds,
+		keys,
+		gridCols,
+		gridRows,
+		"",
+		0,
+		0,
+		style,
+		virtualPointer,
+	)
+}
+
+func (o *wlrootsOverlay) DrawRecursiveGridWithSubKeyPreview(
+	bounds image.Rectangle,
+	keys string,
+	gridCols int,
+	gridRows int,
+	nextKeys string,
+	nextGridCols int,
+	nextGridRows int,
+	style recursivegridcomponent.Style,
+	virtualPointer recursivegridcomponent.VirtualPointerState,
+) {
 	if o == nil || o.raw == nil || bounds.Empty() || gridCols <= 0 || gridRows <= 0 {
 		return
 	}
@@ -191,6 +215,10 @@ func (o *wlrootsOverlay) DrawRecursiveGrid(
 	o.Clear()
 
 	keyRunes := []rune(strings.ToUpper(keys))
+	nextKeyRunes := []rune(strings.ToUpper(nextKeys))
+	drawSubPreview := style.SubKeyPreview && len(nextKeyRunes) > 0 && nextGridCols > 0 &&
+		nextGridRows > 0
+
 	cellWidth := bounds.Dx() / gridCols
 	cellHeight := bounds.Dy() / gridRows
 	index := 0
@@ -228,8 +256,14 @@ func (o *wlrootsOverlay) DrawRecursiveGrid(
 					style.LabelFontColor,
 				)
 
-				if shouldShowSubKeyPreview(cell, style) {
-					o.drawSubKeyPreview(label, cell, style)
+				if drawSubPreview && shouldShowSubKeyPreview(cell, style) {
+					o.drawSubKeyMiniGrid(
+						cell,
+						nextKeyRunes,
+						nextGridCols,
+						nextGridRows,
+						style,
+					)
 				}
 			}
 			index++
@@ -596,23 +630,52 @@ func (o *wlrootsOverlay) drawLabelBackground(
 	)
 }
 
-func (o *wlrootsOverlay) drawSubKeyPreview(
-	label string,
+func (o *wlrootsOverlay) drawSubKeyMiniGrid(
 	cell image.Rectangle,
+	nextKeyRunes []rune,
+	nextGridCols int,
+	nextGridRows int,
 	style recursivegridcomponent.Style,
 ) {
-	previewRect := image.Rect(
-		cell.Min.X,
-		cell.Max.Y-estimateTextHeight(style.SubKeyPreviewFontSize)-subKeyPreviewPaddingBottom,
-		cell.Max.X,
-		cell.Max.Y,
-	)
+	subCellWidth := cell.Dx() / nextGridCols
+	subCellHeight := cell.Dy() / nextGridRows
 
-	o.drawTextCentered(
-		label,
-		previewRect,
-		style.LabelFontName,
-		style.SubKeyPreviewFontSize,
-		style.SubKeyPreviewTextColor,
-	)
+	subIndex := 0
+	for subRow := range nextGridRows {
+		for subCol := range nextGridCols {
+			if subCol == nextGridCols/2 && subRow == nextGridRows/2 &&
+				nextGridCols%2 == 1 && nextGridRows%2 == 1 {
+				subIndex++
+
+				continue
+			}
+
+			if subIndex >= len(nextKeyRunes) {
+				return
+			}
+
+			subCell := image.Rect(
+				cell.Min.X+subCol*subCellWidth,
+				cell.Min.Y+subRow*subCellHeight,
+				cell.Min.X+(subCol+1)*subCellWidth,
+				cell.Min.Y+(subRow+1)*subCellHeight,
+			)
+			if subCol == nextGridCols-1 {
+				subCell.Max.X = cell.Max.X
+			}
+			if subRow == nextGridRows-1 {
+				subCell.Max.Y = cell.Max.Y
+			}
+
+			subLabel := string(nextKeyRunes[subIndex])
+			o.drawTextCentered(
+				subLabel,
+				subCell,
+				style.LabelFontName,
+				style.SubKeyPreviewFontSize,
+				style.SubKeyPreviewTextColor,
+			)
+			subIndex++
+		}
+	}
 }

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -139,12 +139,40 @@ func (o *x11Overlay) DrawRecursiveGrid(
 	style recursivegridcomponent.Style,
 	virtualPointer recursivegridcomponent.VirtualPointerState,
 ) {
+	o.DrawRecursiveGridWithSubKeyPreview(
+		bounds,
+		keys,
+		gridCols,
+		gridRows,
+		"",
+		0,
+		0,
+		style,
+		virtualPointer,
+	)
+}
+
+func (o *x11Overlay) DrawRecursiveGridWithSubKeyPreview(
+	bounds image.Rectangle,
+	keys string,
+	gridCols int,
+	gridRows int,
+	nextKeys string,
+	nextGridCols int,
+	nextGridRows int,
+	style recursivegridcomponent.Style,
+	virtualPointer recursivegridcomponent.VirtualPointerState,
+) {
 	if o == nil || o.raw == nil || bounds.Empty() || gridCols <= 0 || gridRows <= 0 {
 		return
 	}
 	o.Clear()
 
 	keyRunes := []rune(strings.ToUpper(keys))
+	nextKeyRunes := []rune(strings.ToUpper(nextKeys))
+	drawSubPreview := style.SubKeyPreview && len(nextKeyRunes) > 0 && nextGridCols > 0 &&
+		nextGridRows > 0
+
 	cellWidth := bounds.Dx() / gridCols
 	cellHeight := bounds.Dy() / gridRows
 	index := 0
@@ -182,8 +210,14 @@ func (o *x11Overlay) DrawRecursiveGrid(
 					style.LabelFontColor,
 				)
 
-				if shouldShowSubKeyPreview(cell, style) {
-					o.drawSubKeyPreview(label, cell, style)
+				if drawSubPreview && shouldShowSubKeyPreview(cell, style) {
+					o.drawSubKeyMiniGrid(
+						cell,
+						nextKeyRunes,
+						nextGridCols,
+						nextGridRows,
+						style,
+					)
 				}
 			}
 			index++
@@ -434,23 +468,52 @@ func (o *x11Overlay) drawLabelBackground(
 	)
 }
 
-func (o *x11Overlay) drawSubKeyPreview(
-	label string,
+func (o *x11Overlay) drawSubKeyMiniGrid(
 	cell image.Rectangle,
+	nextKeyRunes []rune,
+	nextGridCols int,
+	nextGridRows int,
 	style recursivegridcomponent.Style,
 ) {
-	previewRect := image.Rect(
-		cell.Min.X,
-		cell.Max.Y-estimateTextHeight(style.SubKeyPreviewFontSize)-subKeyPreviewPaddingBottom,
-		cell.Max.X,
-		cell.Max.Y,
-	)
+	subCellWidth := cell.Dx() / nextGridCols
+	subCellHeight := cell.Dy() / nextGridRows
 
-	o.drawTextCentered(
-		label,
-		previewRect,
-		style.LabelFontName,
-		style.SubKeyPreviewFontSize,
-		style.SubKeyPreviewTextColor,
-	)
+	subIndex := 0
+	for subRow := range nextGridRows {
+		for subCol := range nextGridCols {
+			if subCol == nextGridCols/2 && subRow == nextGridRows/2 &&
+				nextGridCols%2 == 1 && nextGridRows%2 == 1 {
+				subIndex++
+
+				continue
+			}
+
+			if subIndex >= len(nextKeyRunes) {
+				return
+			}
+
+			subCell := image.Rect(
+				cell.Min.X+subCol*subCellWidth,
+				cell.Min.Y+subRow*subCellHeight,
+				cell.Min.X+(subCol+1)*subCellWidth,
+				cell.Min.Y+(subRow+1)*subCellHeight,
+			)
+			if subCol == nextGridCols-1 {
+				subCell.Max.X = cell.Max.X
+			}
+			if subRow == nextGridRows-1 {
+				subCell.Max.Y = cell.Max.Y
+			}
+
+			subLabel := string(nextKeyRunes[subIndex])
+			o.drawTextCentered(
+				subLabel,
+				subCell,
+				style.LabelFontName,
+				style.SubKeyPreviewFontSize,
+				style.SubKeyPreviewTextColor,
+			)
+			subIndex++
+		}
+	}
 }

--- a/internal/ui/overlay/manager_linux_x11_nocgo.go
+++ b/internal/ui/overlay/manager_linux_x11_nocgo.go
@@ -48,4 +48,17 @@ func (o *x11Overlay) DrawRecursiveGrid(
 	recursivegridcomponent.VirtualPointerState,
 ) {
 }
+
+func (o *x11Overlay) DrawRecursiveGridWithSubKeyPreview(
+	image.Rectangle,
+	string,
+	int,
+	int,
+	string,
+	int,
+	int,
+	recursivegridcomponent.Style,
+	recursivegridcomponent.VirtualPointerState,
+) {
+}
 func (o *x11Overlay) DrawBadge(int, int, string, overlayColors, overlayBadgeStyle) {}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes an issue where when `sub_key_preview` is enabled on linux, it doesn't render as expected. 

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/8cdd497d-a306-46c9-842a-cdccc33ea25f

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A