### PR TITLE
feat(cli,action): add `--mode` flag to `action feed` to feed keys into neru

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -336,7 +336,7 @@ neru action restore_cursor_pos                # Restore saved cursor position
 
 ### Feed Keys
 
-Posts keystrokes to the system through IPC. Works from CLI and config [hotkey arrays](CONFIGURATION.md#hotkeys).
+Posts keystrokes to the system or to Neru's mode system through IPC. Works from CLI and config [hotkey arrays](CONFIGURATION.md#hotkeys).
 
 ```bash
 neru action feed o
@@ -348,6 +348,28 @@ neru action feed h e l l o return
 **Syntax:** `neru action feed <key-or-chord> [key-or-chord...]`
 
 Each space-separated item is one key press or chord. Chords use `+` (e.g. `ctrl+c`, `Cmd+Shift+P`). Use `space` for a literal space key.
+
+#### `--mode` Flag
+
+By default, keys are posted directly to the OS (e.g. typing into the focused application). With `--mode`, keys are routed through Neru's active mode/action pipeline instead — useful for scripting mode interactions in hotkey chains:
+
+```bash
+neru action feed --mode o              # Feed "o" to the active mode
+neru action feed --mode Escape         # Feed Escape
+neru action feed --mode Cmd+Shift+p    # Feed a chord to the mode system
+```
+
+This is especially useful in hotkey arrays:
+
+```toml
+[hints.hotkeys]
+"Cmd+3" = [
+    "hints --role AXRadioButton --text design --action left_click",
+    "action feed --mode a",
+]
+```
+
+The hints command completes fully (AX elements collected, overlay drawn) before the feed fires, so there is no race.
 
 **Supported key names:**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -249,9 +249,15 @@ All actions available in hotkeys. These also work as `neru action <name>` — se
 
 [hints.hotkeys]
 "o"               = ["idle", "action feed o"]
+
+# Feed into Neru's own mode system (--mode)
+"Cmd+3"           = [
+    "hints --role AXRadioButton --text design --action left_click",
+    "action feed --mode a",
+]
 ```
 
-See [CLI.md](CLI.md#feed-keys) for syntax, supported key names, and platform behavior.
+Use `--mode` to route keys through Neru's active mode/action pipeline instead of the OS. See [CLI.md](CLI.md#feed-keys) for syntax, supported key names, and platform behavior.
 
 #### Composition Example
 

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/app/modes"
 	"github.com/y3owk1n/neru/internal/app/services"
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
@@ -275,6 +276,10 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 	}
 
 	actionName := cmd.Args[0]
+
+	if action.IsFeedToModeAction(actionName) {
+		return h.handleFeedToModeAction(cmd.Args[1:])
+	}
 
 	if action.IsFeedAction(actionName) {
 		return h.handleFeedAction(cmd.Args[1:])
@@ -663,6 +668,12 @@ func (h *IPCControllerActions) handleFeedAction(args []string) ipc.Response {
 		}
 	}
 
+	// Check for --mode flag passed via IPC (from hotkey action strings).
+	// When coming from the CLI, cobra strips the flag before it reaches this handler.
+	if args[0] == "--mode" {
+		return h.handleFeedToModeAction(args[1:])
+	}
+
 	keys := make([]string, 0, len(args))
 	for _, arg := range args {
 		key := strings.TrimSpace(arg)
@@ -703,6 +714,51 @@ func (h *IPCControllerActions) handleFeedAction(args []string) ipc.Response {
 	return ipc.Response{
 		Success: true,
 		Message: "feed performed",
+		Code:    ipc.CodeOK,
+	}
+}
+
+func (h *IPCControllerActions) handleFeedToModeAction(args []string) ipc.Response {
+	if len(args) == 0 {
+		return ipc.Response{
+			Success: false,
+			Message: "feed-mode requires at least one key (e.g., action feed --mode o, action feed --mode ctrl+c)",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	keys := make([]string, 0, len(args))
+	for _, arg := range args {
+		key := strings.TrimSpace(arg)
+		if key == "" {
+			return ipc.Response{
+				Success: false,
+				Message: "feed-mode keys cannot be empty",
+				Code:    ipc.CodeInvalidInput,
+			}
+		}
+
+		keys = append(keys, key)
+	}
+
+	h.logger.Debug("Feeding keys to mode system", zap.Int("key_count", len(keys)))
+
+	for _, key := range keys {
+		normalized := config.CanonicalHotkeyForPlatform(key)
+		if normalized == "" {
+			return ipc.Response{
+				Success: false,
+				Message: fmt.Sprintf("invalid key: %q", key),
+				Code:    ipc.CodeInvalidInput,
+			}
+		}
+
+		h.modesHandler.HandleKeyPress(normalized)
+	}
+
+	return ipc.Response{
+		Success: true,
+		Message: "feed-mode performed",
 		Code:    ipc.CodeOK,
 	}
 }

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -277,10 +277,6 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 
 	actionName := cmd.Args[0]
 
-	if action.IsFeedToModeAction(actionName) {
-		return h.handleFeedToModeAction(cmd.Args[1:])
-	}
-
 	if action.IsFeedAction(actionName) {
 		return h.handleFeedAction(cmd.Args[1:])
 	}

--- a/internal/cli/action_feed.go
+++ b/internal/cli/action_feed.go
@@ -12,21 +12,46 @@ import (
 var ActionFeedCmd = &cobra.Command{
 	Use:   "feed <key> [key...]",
 	Short: "Feed keys directly to the operating system",
-	Long:  "Feed one or more keys or key chords directly to the operating system through\nNeru's action IPC path. On macOS, the daemon posts the key back to macOS\nwithout routing it through Neru's active mode/action pipeline.\n\nExamples:\n  neru action feed o\n  neru action feed ctrl+c\n  neru action feed Cmd+Shift+P\n  neru action feed h e l o return",
-	Args:  validateActionFeedArgs,
+	Long: `Feed one or more keys or key chords to the operating system or to Neru's
+own mode system.
+
+By default, keys are posted directly to the OS. Use --mode to route keys
+through Neru's active mode/action pipeline instead.
+
+Examples:
+  neru action feed o
+  neru action feed ctrl+c
+  neru action feed Cmd+Shift+P
+  neru action feed h e l o return
+  neru action feed --mode o
+  neru action feed --mode Escape
+  neru action feed --mode Cmd+Shift+p`,
+	Args: validateActionFeedArgs,
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return requiresRunningInstance()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		toMode, _ := cmd.Flags().GetBool("mode")
+
+		actionName := "feed"
+		if toMode {
+			actionName = "feed-mode"
+		}
+
 		actionArgs := make([]string, 0, len(args)+1)
 
-		actionArgs = append(actionArgs, "feed")
+		actionArgs = append(actionArgs, actionName)
 		for _, arg := range args {
 			actionArgs = append(actionArgs, strings.TrimSpace(arg))
 		}
 
 		return sendCommand(cmd, "action", actionArgs)
 	},
+}
+
+func init() {
+	ActionFeedCmd.Flags().Bool("mode", false,
+		"Feed keys into Neru's own mode system instead of the OS")
 }
 
 func validateActionFeedArgs(_ *cobra.Command, args []string) error {

--- a/internal/cli/action_feed.go
+++ b/internal/cli/action_feed.go
@@ -33,14 +33,15 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		toMode, _ := cmd.Flags().GetBool("mode")
 
-		actionName := "feed"
+		capacity := len(args) + 2 //nolint:mnd // "feed" + optional "--mode" + keys
+
+		actionArgs := make([]string, 0, capacity)
+
+		actionArgs = append(actionArgs, "feed")
 		if toMode {
-			actionName = "feed-mode"
+			actionArgs = append(actionArgs, "--mode")
 		}
 
-		actionArgs := make([]string, 0, len(args)+1)
-
-		actionArgs = append(actionArgs, actionName)
 		for _, arg := range args {
 			actionArgs = append(actionArgs, strings.TrimSpace(arg))
 		}

--- a/internal/core/domain/action/action.go
+++ b/internal/core/domain/action/action.go
@@ -155,8 +155,6 @@ const (
 	NameMoveMonitor Name = "move_monitor"
 	// NameFeed posts a key or key chord directly to the operating system.
 	NameFeed Name = "feed"
-	// NameFeedToMode posts a key or key chord to Neru's own mode system.
-	NameFeedToMode Name = "feed-mode"
 	// NameGoTop represents the go-to-top action.
 	NameGoTop Name = "go_top"
 	// NameGoBottom represents the go-to-bottom action.
@@ -269,7 +267,7 @@ func IsKnownName(name Name) bool {
 		NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
 		NameScrollUp, NameScrollDown, NameScrollLeft, NameScrollRight,
 		NameGoTop, NameGoBottom, NamePageUp, NamePageDown,
-		NameMoveMonitor, NameFeed, NameFeedToMode, NameSleep, NameCycleHint, NameSearchHints:
+		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints:
 		return true
 	default:
 		return false
@@ -279,11 +277,6 @@ func IsKnownName(name Name) bool {
 // IsFeedAction reports whether the given action feeds a key to the operating system.
 func IsFeedAction(name string) bool {
 	return Name(name) == NameFeed
-}
-
-// IsFeedToModeAction reports whether the given action feeds a key to Neru's own mode system.
-func IsFeedToModeAction(name string) bool {
-	return Name(name) == NameFeedToMode
 }
 
 // IsScrollSubAction reports whether the given name is a scroll sub-action
@@ -297,7 +290,7 @@ func IsScrollSubAction(name string) bool {
 		NameMouseDown, NameMouseUp,
 		NameMoveMouse, NameMoveMouseRelative, NameScroll,
 		NameReset, NameBackspace, NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
-		NameMoveMonitor, NameFeed, NameFeedToMode, NameSleep, NameCycleHint, NameSearchHints:
+		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints:
 		return false
 	default:
 		return false
@@ -373,7 +366,6 @@ func (n Name) ToType() (Type, error) {
 		NameRestoreCursorPos,
 		NameMoveMonitor,
 		NameFeed,
-		NameFeedToMode,
 		NameSleep,
 		NameCycleHint,
 		NameSearchHints:

--- a/internal/core/domain/action/action.go
+++ b/internal/core/domain/action/action.go
@@ -155,6 +155,8 @@ const (
 	NameMoveMonitor Name = "move_monitor"
 	// NameFeed posts a key or key chord directly to the operating system.
 	NameFeed Name = "feed"
+	// NameFeedToMode posts a key or key chord to Neru's own mode system.
+	NameFeedToMode Name = "feed-mode"
 	// NameGoTop represents the go-to-top action.
 	NameGoTop Name = "go_top"
 	// NameGoBottom represents the go-to-bottom action.
@@ -267,7 +269,7 @@ func IsKnownName(name Name) bool {
 		NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
 		NameScrollUp, NameScrollDown, NameScrollLeft, NameScrollRight,
 		NameGoTop, NameGoBottom, NamePageUp, NamePageDown,
-		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints:
+		NameMoveMonitor, NameFeed, NameFeedToMode, NameSleep, NameCycleHint, NameSearchHints:
 		return true
 	default:
 		return false
@@ -277,6 +279,11 @@ func IsKnownName(name Name) bool {
 // IsFeedAction reports whether the given action feeds a key to the operating system.
 func IsFeedAction(name string) bool {
 	return Name(name) == NameFeed
+}
+
+// IsFeedToModeAction reports whether the given action feeds a key to Neru's own mode system.
+func IsFeedToModeAction(name string) bool {
+	return Name(name) == NameFeedToMode
 }
 
 // IsScrollSubAction reports whether the given name is a scroll sub-action
@@ -290,7 +297,7 @@ func IsScrollSubAction(name string) bool {
 		NameMouseDown, NameMouseUp,
 		NameMoveMouse, NameMoveMouseRelative, NameScroll,
 		NameReset, NameBackspace, NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
-		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints:
+		NameMoveMonitor, NameFeed, NameFeedToMode, NameSleep, NameCycleHint, NameSearchHints:
 		return false
 	default:
 		return false
@@ -366,6 +373,7 @@ func (n Name) ToType() (Type, error) {
 		NameRestoreCursorPos,
 		NameMoveMonitor,
 		NameFeed,
+		NameFeedToMode,
 		NameSleep,
 		NameCycleHint,
 		NameSearchHints:


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds `--mode` flag to `neru action feed`. It will send the feed chords to neru active mode instead of sending to the OS.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to #998

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
