### PR TITLE
docs(tips): add mode-cycling and element-targeted shortcut recipes

### DIFF
--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -12,6 +12,9 @@
 - [Custom Mouse Movement Step Size](#custom-mouse-movement-step-size)
 - [Click, sleep, move](#click-sleep-move)
 - [Target Menus Without Moving the Real Cursor](#target-menus-without-moving-the-real-cursor)
+- [Mode Toggle (On/Off)](#mode-toggle-onoff)
+- [Cycle Through Modes with One Hotkey](#cycle-through-modes-with-one-hotkey)
+- [Bind a Shortcut to a Specific UI Element](#bind-a-shortcut-to-a-specific-ui-element)
 - [Disabling All Built-In Hotkeys](#disabling-all-built-in-hotkeys)
 - [Give Browser Content Time To Load Before Refreshing Hints](#give-browser-content-time-to-load-before-refreshing-hints)
 - [Checking the Accessibility Tree on macOS](#checking-the-accessibility-tree-on-macos)
@@ -163,6 +166,99 @@ Use `--toggle` to turn a single hotkey into a mode toggle — pressing it once a
 ```
 
 This is especially useful when you want a single key to both enter and exit a mode, avoiding the need for a separate `Escape` press or a dedicated exit keybinding.
+
+## Cycle Through Modes with One Hotkey
+
+Instead of a separate launcher key for every mode, one key can walk through all of them. Press it from idle to open the first mode, then press the same key again to advance through hints, recursive grid, grid, and scroll, wrapping back to hints at the end.
+
+This works because a per-mode hotkey overrides a global hotkey bound to the same key (requires Neru 1.47.0 and later). The global `[hotkeys]` binding fires only from idle. Once you are inside a mode, that mode's own `[<mode>.hotkeys]` binding for the same key wins, and it points at the next mode in the cycle.
+
+```toml
+# From idle, this opens hints.
+[hotkeys]
+"Primary+Ctrl+F" = "hints"
+
+# Inside each mode, the same key advances to the next mode.
+[hints.hotkeys]
+"Primary+Ctrl+F" = "recursive_grid"
+
+[recursive_grid.hotkeys]
+"Primary+Ctrl+F" = "grid"
+
+[grid.hotkeys]
+"Primary+Ctrl+F" = "scroll"
+
+[scroll.hotkeys]
+"Primary+Ctrl+F" = "hints"   # wrap back to the start
+```
+
+`Enter` and `Escape` still return you to idle from any point in the cycle. To change the order, drop a mode, or shorten the loop, edit which mode each block points to.
+
+If you keep the default per-mode launcher keys, disable the ones this cycle replaces so a leftover default doesn't compete with the shared key:
+
+```toml
+[hotkeys]
+"Primary+Shift+Space" = "__disabled__"   # default hints launcher
+"Primary+Shift+G" = "__disabled__"       # default grid launcher
+"Primary+Shift+C" = "__disabled__"       # default recursive_grid launcher
+"Primary+Shift+S" = "__disabled__"       # default scroll launcher
+```
+
+## Bind a Shortcut to a Specific UI Element
+
+Some apps never expose a keyboard shortcut for a UI element you use often, and some remove one you relied on. Claude for macOS, for example, dropped `Cmd+1` / `Cmd+2` / `Cmd+3` for switching between its Home, Code, and Cowork views, leaving no shortcut for those buttons at all. In some limited cases you can rebuild one by driving Neru to click a fixed spot or a specific element in the focused window.
+
+Bind the key inside a root-level `[[app_configs]]` block scoped to the target app by its `bundle_id` (requires Neru 1.47.0 and later). That block overrides `[hotkeys]` only while that app is focused, so the key drives Neru there and passes straight through to every other app. See [Per-App Global Hotkey Overrides](CONFIGURATION.md#per-app-global-hotkey-overrides) for the full syntax.
+
+Inside the block, each hotkey value is an action sequence that clicks the element. Pointing at a UI element reliably is the hard part, and the three approaches below break under different conditions:
+
+| Approach                     | Survives window move | Survives resize | Breaks when                          |
+| ---------------------------- | -------------------- | --------------- | ------------------------------------ |
+| Absolute coordinates         | No                   | No              | the window ever moves                |
+| Window-relative coordinates  | Yes                  | No              | the layout is responsive             |
+| Filtered hints + feed        | Yes                  | Yes             | the role and text are not unique     |
+
+**1. Absolute coordinates.** The most direct option, but it only holds if the window never moves or resizes:
+
+```toml
+[[app_configs]]
+bundle_id = "com.anthropic.claudefordesktop"
+hotkeys = { "Cmd+1" = ["action move_mouse --x 113 --y 123", "action left_click"] }
+```
+
+**2. Window-relative coordinates.** Recomputes the target from the focused window each time, so it survives moving the window and breaks only on resize. Move to the window center, offset to a corner, then nudge to the target:
+
+```toml
+[[app_configs]]
+bundle_id = "com.anthropic.claudefordesktop"
+hotkeys = { "Cmd+1" = ["action move_mouse --window --x -1000 --y -1000", "action sleep 0.1", "action move_mouse_relative --dx 100 --dy 70", "action sleep 0.1", "action left_click"] }
+```
+
+`--window` measures the offset from the window center. A large negative offset like `--x -1000 --y -1000` is clamped to the window's top-left corner, giving you a stable origin to measure from, and `move_mouse_relative` then walks to the element.
+
+**3. Filtered hints + feed.** Targets an element by its accessibility role and text, then feeds the first hint label to click it:
+
+```toml
+[[app_configs]]
+bundle_id = "com.anthropic.claudefordesktop"
+hotkeys = { "Cmd+1" = ["hints --role AXButton --text Home --action left_click", "action feed --mode a"] }
+```
+
+`action feed --mode a` presses the first hint label. Which element gets `a` depends on your hint configuration (menu-bar hints, label direction, and so on), so confirm it lands on the element you mean. This method is precise when the element is unique, and fragile when the text is common. A button labelled "Code" is easy to confuse with every "Copy code" button in the same window. When a view's hint filter is too ambiguous to trust, fall back to the window-relative form for that key.
+
+Putting it together, a Claude view switcher scopes three keys to the app. `Cmd+1`, `Cmd+2`, and `Cmd+3` click the Home, Code, and Cowork buttons, each nudged to a different offset from the window's top-left corner:
+
+```toml
+[[app_configs]]
+bundle_id = "com.anthropic.claudefordesktop"
+hotkeys = {
+    "Cmd+1" = ["action move_mouse --window --x -1000 --y -1000", "action sleep 0.1", "action move_mouse_relative --dx 100 --dy 70", "action sleep 0.1", "action left_click"],
+    "Cmd+2" = ["action move_mouse --window --x -1000 --y -1000", "action sleep 0.1", "action move_mouse_relative --dx 250 --dy 70", "action sleep 0.1", "action left_click"],
+    "Cmd+3" = ["action move_mouse --window --x -1000 --y -1000", "action sleep 0.1", "action move_mouse_relative --dx 400 --dy 70", "action sleep 0.1", "action left_click"]
+}
+```
+
+Capture your own offsets once, since they depend on the window's layout. Move the pointer over each button, read its screen coordinates, and subtract the window's top-left corner to get the `--dx` / `--dy` values.
 
 ## Disabling All Built-In Hotkeys
 


### PR DESCRIPTION
Disclaimer: This doc was written by Claude. I steered it toward the setup I actually use.

Follow-up to #998, where I offered to add a couple of recipes to the tips docs. Here they are.

## Rationale

Two things I set up for myself and figured were worth writing down: cycling every navigation mode from one key, and faking a shortcut for a UI element an app never exposes (the case that kicked off #998, when Claude for macOS dropped its Cmd+1/2/3 view switch).

## Changes

Two new sections in `docs/TIPS_TRICKS.md`:

- **Cycle Through Modes with One Hotkey** — bind a single key to walk hints → recursive grid → grid → scroll and wrap back to hints. It works because a per-mode hotkey overrides a global hotkey bound to the same key (#993): the global binding fires from idle, and each mode's own binding takes over once you are inside it.
- **Bind a Shortcut to a Specific UI Element** — rebuild a shortcut an app never gives you. The binding lives in a root-level `[[app_configs]]` block (#1008) scoped to the target app by `bundle_id`, so it drives Neru only in that app and passes through everywhere else. Inside the block it clicks the element one of three ways: absolute coordinates, window-relative coordinates, or filtered hints plus `action feed --mode`. Ends with a Claude view switcher binding Cmd+1/2/3.

Also adds the existing "Mode Toggle (On/Off)" section to the table of contents, which was missing its entry.

## Addressing the review

@y3owk1n pointed out that the element recipe's app-scoping steps read like a temporary workaround, since scoping a global hotkey to one app is something Neru should do itself. #1008 landed exactly that with root-level `[[app_configs]]`, so I dropped the three workaround sections (the external-tool scoping note, the bash view-switcher script, and the per-platform list of Karabiner / AutoHotkey / GNOME shortcut tools) and rewrote the recipe to use `[[app_configs]]` directly.

## Notes

- These recipes rely on features that are on `main` but not in a tagged release yet: #993 for the per-mode hotkey override, #999 for `action feed --mode`, and #1008 for scoping global hotkeys to one app. Each section notes it needs 1.47.0 and later. If that version number is wrong, tell me and I'll fix it.
