### PR TITLE
[PoC, do not merge] push-based auto-refresh on accessibility-tree changes 

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -111,7 +111,8 @@ visible_check_enabled = false
 # accessibility notifications, which Chromium/WebKit do inconsistently (often
 # nothing on scroll). Native apps, menus, and Notification Center are reliable.
 enabled = false
-debounce_ms = 80             # trailing coalesce/floor; a burst collapses into one refresh
+debounce_ms = 150            # settle delay: wait this long after the last change before rescanning
+                             # (many apps post a notification before their tree finishes updating)
 watch_value_changed = false  # also observe kAXValueChanged on the front window (noisy)
 
 [hints.additional_ax_support]

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -100,12 +100,33 @@ visible_check_enabled = false
 "Left" = "action move_mouse_relative --dx=-10 --dy=0"
 "Right" = "action move_mouse_relative --dx=10 --dy=0"
 
+[hints.auto_refresh]
+# Push-based auto-refresh of hints while hints mode is active (macOS). neru
+# watches the processes the hint scan targeted via accessibility change
+# notifications (AXObserver) and re-scans when they change, instead of relying on
+# a fixed post-action delay. Observers run only while hints mode is active, so an
+# idle neru has no background cost.
+#
+# Web/Electron coverage is best effort: it depends on the app posting
+# accessibility notifications, which Chromium/WebKit do inconsistently (often
+# nothing on scroll). Native apps, menus, and Notification Center are reliable.
+enabled = false
+debounce_ms = 80             # trailing coalesce/floor; a burst collapses into one refresh
+watch_value_changed = false  # also observe kAXValueChanged on the front window (noisy)
+
 [hints.additional_ax_support]
-enable = false                              # Enable enhanced AX for Electron/Chromium/Firefox/WebKit apps
+# Wakes Electron/Chromium/Firefox accessibility trees so their hints (and change
+# notifications) work. AXManualAccessibility is attempted for every activated app
+# (a safe no-op on apps that do not implement it).
+enable = false
 additional_electron_bundles = []
 additional_chromium_bundles = []
 additional_firefox_bundles = []
 additional_webkit_bundles = []
+# When AXEnhancedUserInterface (which can relayout/move some apps) is used:
+# "whitelist" (default) = known/added browsers only; "off" = never; "all" = any
+# app whose tree does not wake.
+escalate_enhanced = "whitelist"
 
 [hints.ui]
 font_size = 10

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -426,17 +426,37 @@ y_offset = 24
 width = 320
 ```
 
+### Auto Refresh
+
+Push-based auto-refresh of hints while hints mode is active (macOS). When enabled, neru watches the processes the hint scan targeted using accessibility change notifications (`AXObserver`) and re-scans when they actually change, instead of relying on a fixed post-action delay. Observers run only while hints mode is active, so an idle neru has no background cost.
+
+Coverage for web and Electron content is best effort: it depends on the app posting accessibility notifications, which Chromium and WebKit do inconsistently (for example, often nothing on scroll). Native apps, menus, and Notification Center are reliable.
+
+| Option                | Type | Default | Description                                                                      |
+| --------------------- | ---- | ------- | -------------------------------------------------------------------------------- |
+| `enabled`             | bool | `false` | Enable push-based auto-refresh while hints mode is active                         |
+| `debounce_ms`         | int  | `80`    | Trailing coalesce/floor interval; a burst of changes collapses into one refresh  |
+| `watch_value_changed` | bool | `false` | Also observe `kAXValueChanged` on the front window (noisy; off by default)        |
+
+```toml
+[hints.auto_refresh]
+enabled = false
+debounce_ms = 80
+watch_value_changed = false
+```
+
 ### Additional AX Support
 
-Framework-specific accessibility improvements for Electron, Chromium, Firefox, and WebKit apps:
+Wakes Electron, Chromium, and Firefox accessibility trees so their hints (and auto-refresh notifications) work. `AXManualAccessibility` is attempted for every activated app (a safe no-op on apps that do not implement it, so it also covers Electron apps that are not on any list). `AXEnhancedUserInterface`, which can relayout or move some apps, is only used according to `escalate_enhanced`.
 
-| Option                        | Type  | Default | Description                  |
-| ----------------------------- | ----- | ------- | ---------------------------- |
-| `enable`                      | bool  | `false` | Enable additional AX support |
-| `additional_electron_bundles` | array | `[]`    | Bundle IDs of Electron apps  |
-| `additional_chromium_bundles` | array | `[]`    | Bundle IDs of Chromium apps  |
-| `additional_firefox_bundles`  | array | `[]`    | Bundle IDs of Firefox apps   |
-| `additional_webkit_bundles`   | array | `[]`    | Bundle IDs of WebKit apps    |
+| Option                        | Type   | Default       | Description                                                                                     |
+| ----------------------------- | ------ | ------------- | ---------------------------------------------------------------------------------------------- |
+| `enable`                      | bool   | `false`       | Enable waking accessibility trees on app activation                                            |
+| `additional_electron_bundles` | array  | `[]`          | Bundle IDs of Electron apps                                                                     |
+| `additional_chromium_bundles` | array  | `[]`          | Bundle IDs of Chromium apps                                                                     |
+| `additional_firefox_bundles`  | array  | `[]`          | Bundle IDs of Firefox apps                                                                      |
+| `additional_webkit_bundles`   | array  | `[]`          | Bundle IDs of WebKit apps                                                                       |
+| `escalate_enhanced`           | string | `"whitelist"` | When `AXEnhancedUserInterface` is used: `"whitelist"` (browsers only), `"off"`, or `"all"`      |
 
 ```toml
 [hints.additional_ax_support]
@@ -445,6 +465,7 @@ additional_electron_bundles = []
 additional_chromium_bundles = []
 additional_firefox_bundles = []
 additional_webkit_bundles = []
+escalate_enhanced = "whitelist"
 ```
 
 Find bundle IDs: `osascript -e 'id of app "Safari"'`

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"os"
 
 	"go.uber.org/zap"
 
@@ -18,6 +19,7 @@ import (
 	domainHint "github.com/y3owk1n/neru/internal/core/domain/hint"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	"github.com/y3owk1n/neru/internal/core/infra/axobserver"
 	eventtapadapter "github.com/y3owk1n/neru/internal/core/infra/eventtap"
 	ipcadapter "github.com/y3owk1n/neru/internal/core/infra/ipc"
 	"github.com/y3owk1n/neru/internal/core/infra/platform"
@@ -413,6 +415,18 @@ func initializeModeHandler(app *App) {
 		app.textInput,
 		app.systemPort,
 	)
+
+	// Wire push-based hint auto-refresh. The manager is inert until Reconcile is
+	// called (only while hints mode is active), so it is always constructed;
+	// disabling auto-refresh simply means Reconcile is never called. On non-darwin
+	// platforms the underlying observer is a no-op.
+	app.observers = axobserver.NewManager(deps.logger, axobserver.Config{
+		SelfPID:           os.Getpid(),
+		SelfBundleID:      config.BundleNeru,
+		WatchValueChanged: deps.config.Hints.AutoRefresh.WatchValueChanged,
+		OnChange:          app.modes.RequestObserverRefresh,
+	})
+	app.modes.SetObserverController(app.observers)
 }
 
 // initializeIPCController sets up the IPC controller for external communication.

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -14,6 +14,7 @@ import (
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
+	"github.com/y3owk1n/neru/internal/core/infra/axobserver"
 	"github.com/y3owk1n/neru/internal/core/ports"
 	"github.com/y3owk1n/neru/internal/ui"
 )
@@ -58,6 +59,10 @@ type App struct {
 	appWatcher     Watcher
 
 	modes *modes.Handler
+
+	// observers watches the processes the hint scan targeted and drives push-based
+	// hint auto-refresh. Inert unless auto-refresh is configured on.
+	observers *axobserver.Manager
 
 	// Control channels
 	stopChan    chan struct{}

--- a/internal/app/components/hints/overlay_darwin.go
+++ b/internal/app/components/hints/overlay_darwin.go
@@ -667,16 +667,18 @@ func (o *Overlay) drawHintsIncremental(
 		return true
 	}
 
-	// Handle structural changes (hints added/removed) using incremental C API
-	return o.drawHintsIncrementalStructural(
-		hints,
-		previousHints,
-		currentInput,
-		style,
-		previousInput,
-		previousStyle,
-		showArrow,
-	)
+	// A structural change (hints added/removed) falls back to a full redraw.
+	//
+	// The incremental structural path diffed purely by on-screen position, and only
+	// treated the update as a full replacement when *every* hint changed. A partial
+	// change that keeps most hints but swaps a few — an in-page control group being
+	// dismissed while another appears, common in Electron/web apps — took the
+	// incremental path, where overlapping or colliding positions could leave the
+	// newly appeared controls without hints. A full redraw via NeruDrawHints is
+	// atomic (it replaces the whole hint set in a single repaint with no blank
+	// frame), so it is both correct and flicker-free; the only cost is redrawing
+	// every hint, which is negligible. Returning false here routes to that path.
+	return false
 }
 
 // hintsAreStructurallyEqual checks if two hint lists have the same structure (same hints at same positions).

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -193,6 +193,14 @@ func (a *App) setupAppWatcherCallbacks() {
 		a.handleAppActivation(bundleID)
 	})
 
+	// Proactively disarm observers for a quit application (dead pid), so a
+	// terminated app's observer is torn down without waiting for the next scan.
+	a.appWatcher.OnTerminate(func(_, bundleID string) {
+		if a.observers != nil {
+			a.observers.HandleAppTerminated(bundleID)
+		}
+	})
+
 	// Watch for display parameter changes (monitor unplug/plug, resolution changes)
 	a.appWatcher.OnScreenParametersChanged(func() {
 		a.handleScreenParametersChange()
@@ -427,23 +435,45 @@ func (a *App) handleAppActivation(bundleID string) {
 	}
 }
 
-// handleAdditionalAccessibility configures accessibility support for Electron/Chromium/Firefox applications.
+// handleAdditionalAccessibility wakes an application's accessibility tree so its
+// hints (and change notifications) work. AXManualAccessibility is attempted for
+// every activated app (a safe no-op on apps that do not implement it, so it
+// catches Electron apps that are not on any list), while AXEnhancedUserInterface
+// escalation — which can relayout/move native apps — is gated by the configured
+// EscalateEnhanced mode so it is never sprayed on native apps.
 func (a *App) handleAdditionalAccessibility(bundleID string, cfg *config.Config) {
-	config := cfg.Hints.AdditionalAXSupport
+	axCfg := cfg.Hints.AdditionalAXSupport
 
-	isElectron := electron.ShouldEnableElectronSupport(bundleID, config.AdditionalElectronBundles)
-	isChromium := electron.ShouldEnableChromiumSupport(bundleID, config.AdditionalChromiumBundles)
-	isFirefox := electron.ShouldEnableFirefoxSupport(bundleID, config.AdditionalFirefoxBundles)
+	// Classification decides only whether AXEnhancedUserInterface may be used.
+	isElectron := electron.ShouldEnableElectronSupport(bundleID, axCfg.AdditionalElectronBundles)
+	isChromium := electron.ShouldEnableChromiumSupport(bundleID, axCfg.AdditionalChromiumBundles)
+	isFirefox := electron.ShouldEnableFirefoxSupport(bundleID, axCfg.AdditionalFirefoxBundles)
+	classified := isElectron || isChromium || isFirefox
 
-	if !isElectron && !isChromium && !isFirefox {
-		return
+	allowEnhanced := false
+
+	switch axCfg.EscalateEnhanced {
+	case config.EscalateEnhancedAll:
+		allowEnhanced = true
+	case config.EscalateEnhancedOff:
+		allowEnhanced = false
+	default: // whitelist (and any unrecognized value): classified browsers/electron only
+		allowEnhanced = classified
 	}
 
 	go func() {
-		// Apps may need time to initialize their accessibility tree after launch.
-		// We retry a few times to ensure the accessibility attributes are successfully set.
-		// Use exponential backoff to minimize latency for fast-booting apps while
-		// still accommodating slow-booting ones.
+		// Unclassified apps get a single cheap attempt (short wait, negative-cached
+		// in EnsureAppAccessibility), so a native app is not re-probed with a full
+		// retry storm on every activation.
+		if !classified {
+			electron.EnsureAppAccessibility(bundleID, allowEnhanced, false, a.logger)
+
+			return
+		}
+
+		// Classified apps (browsers, listed Electron) may need time to initialize
+		// their accessibility tree after launch. Retry with exponential backoff to
+		// minimize latency for fast-booting apps while accommodating slow ones.
 		const (
 			maxRetries    = 5
 			initialDelay  = 100 * time.Millisecond
@@ -452,31 +482,10 @@ func (a *App) handleAdditionalAccessibility(bundleID string, cfg *config.Config)
 
 		delay := initialDelay
 		for range maxRetries {
-			allSuccess := true
-
-			if isElectron {
-				if !electron.EnsureElectronAccessibility(bundleID, a.logger) {
-					allSuccess = false
-				}
-			}
-
-			if isChromium {
-				if !electron.EnsureChromiumAccessibility(bundleID, a.logger) {
-					allSuccess = false
-				}
-			}
-
-			if isFirefox {
-				if !electron.EnsureFirefoxAccessibility(bundleID, a.logger) {
-					allSuccess = false
-				}
-			}
-
-			if allSuccess {
+			if electron.EnsureAppAccessibility(bundleID, allowEnhanced, true, a.logger) {
 				return
 			}
 
-			// Wait before retrying
 			time.Sleep(delay)
 			delay *= backoffFactor
 		}
@@ -595,6 +604,13 @@ func (a *App) Cleanup() {
 		}
 
 		a.ExitMode()
+		// Tear down push auto-refresh: stop the coordinator and close the observer
+		// (disarm all, stop+join the run-loop thread). Done after ExitMode so no
+		// refresh is scheduled mid-teardown, and before appWatcher.Stop so a
+		// terminate callback cannot race it.
+		if a.modes != nil {
+			a.modes.ShutdownAutoRefresh()
+		}
 		// Stop theme observer: nil the handler first so any in-flight KVO callback
 		// (between the async dispatch and actual observer removal) is a no-op.
 		a.stopThemeObserver()

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"image"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -101,6 +102,14 @@ type Handler struct {
 	// inert unless auto-refresh is configured on.
 	observers          ObserverController
 	refreshCoordinator *refreshCoordinator
+	// observerScanning is true while a hint scan is running, and observerSuppressUntil
+	// (unix nanos) opens a short margin after it. Together they mute observer-driven
+	// refreshes for the whole scan plus a tail: scanning an app's AX tree makes some
+	// apps create/destroy elements throughout the scan, and those self-induced
+	// notifications must not trigger another refresh (a flicker loop). A fixed window
+	// is not enough because a slow scan outlasts it.
+	observerScanning      atomic.Bool
+	observerSuppressUntil atomic.Int64
 
 	hotkeyLastKey     string
 	hotkeyLastKeyTime          int64

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -94,7 +94,15 @@ type Handler struct {
 	shutdown                   func()
 	refreshHintsTimer          *time.Timer
 	modeSession                uint64
-	hotkeyLastKey              string
+
+	// Push-based hint auto-refresh (macOS). observers watches the processes the
+	// hint scan targeted; refreshCoordinator coalesces change notifications into
+	// refreshes and defers them while the user is mid-selection. Both are nil/
+	// inert unless auto-refresh is configured on.
+	observers          ObserverController
+	refreshCoordinator *refreshCoordinator
+
+	hotkeyLastKey     string
 	hotkeyLastKeyTime          int64
 
 	textInput                  ports.TextInputPort
@@ -233,6 +241,20 @@ func NewHandler(
 		domain.ModeRecursiveGrid: NewRecursiveGridMode(handler),
 		domain.ModeMonitorSelect: NewMonitorSelectMode(handler),
 	}
+
+	// The refresh coordinator coalesces observer-driven refreshes. It is always
+	// constructed (cheap and inert until Request is called), so RequestObserverRefresh
+	// is safe even before an observer controller is wired.
+	debounce := time.Duration(0)
+	if config != nil && config.Hints.AutoRefresh.DebounceMs > 0 {
+		debounce = time.Duration(config.Hints.AutoRefresh.DebounceMs) * time.Millisecond
+	}
+
+	handler.refreshCoordinator = newRefreshCoordinator(refreshCoordinatorConfig{
+		debounce:    debounce,
+		onRefresh:   handler.observerDrivenRefresh,
+		shouldDefer: handler.isMidSelection,
+	})
 
 	return handler
 }

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -103,13 +103,21 @@ type Handler struct {
 	observers          ObserverController
 	refreshCoordinator *refreshCoordinator
 	// observerScanning is true while a hint scan is running, and observerSuppressUntil
-	// (unix nanos) opens a short margin after it. Together they mute observer-driven
-	// refreshes for the whole scan plus a tail: scanning an app's AX tree makes some
-	// apps create/destroy elements throughout the scan, and those self-induced
-	// notifications must not trigger another refresh (a flicker loop). A fixed window
-	// is not enough because a slow scan outlasts it.
-	observerScanning      atomic.Bool
-	observerSuppressUntil atomic.Int64
+	// (unix nanos) opens a short margin after a scan that changed nothing. Together
+	// they mute observer-driven refreshes: scanning an app's AX tree makes some apps
+	// create/destroy elements throughout the scan, and those self-induced
+	// notifications must not trigger another refresh (a flicker loop). The scanning
+	// flag covers the whole scan (a slow scan outlasts any fixed window); the post-
+	// scan margin only opens when the scan produced the same hint set as the previous
+	// one, so a scan that caught a real change stays hot to converge on the settled
+	// state instead of dropping the follow-up notifications (the source of missed
+	// refreshes). The fingerprint fields below drive that decision; all four are
+	// touched only under h.mu (the scan path and its deferred cleanup both hold it).
+	observerScanning           atomic.Bool
+	observerSuppressUntil      atomic.Int64
+	observerLastFingerprint    uint64
+	observerScanFingerprint    uint64
+	observerScanHasFingerprint bool
 
 	hotkeyLastKey     string
 	hotkeyLastKeyTime          int64

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -118,6 +118,8 @@ type Handler struct {
 	observerLastFingerprint    uint64
 	observerScanFingerprint    uint64
 	observerScanHasFingerprint bool
+	observerScanIsRefresh      bool
+	observerSettleChecks       int
 
 	hotkeyLastKey     string
 	hotkeyLastKeyTime          int64

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -169,6 +169,16 @@ func (h *Handler) activateHintModeInternal(
 	// Detect refresh before validation so we can clean up on failure
 	isRefresh := h.appState.CurrentMode() == domain.ModeHints
 
+	// Mute observer-driven refreshes for the whole duration of this scan plus a
+	// short margin: scanning the AX tree makes some apps create/destroy their own
+	// elements throughout the scan, and those self-induced notifications must not
+	// feed back into another refresh (a flicker loop). A fixed window is not
+	// enough because a slow scan outlasts it, so gate on an explicit flag.
+	if h.autoRefreshEnabled() {
+		h.observerScanning.Store(true)
+		defer h.endObserverScanWindow()
+	}
+
 	// Reset cycle index on refresh since the hint list is regenerated
 	if isRefresh {
 		h.cycleHintIndex = -1

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -169,13 +169,15 @@ func (h *Handler) activateHintModeInternal(
 	// Detect refresh before validation so we can clean up on failure
 	isRefresh := h.appState.CurrentMode() == domain.ModeHints
 
-	// Mute observer-driven refreshes for the whole duration of this scan plus a
-	// short margin: scanning the AX tree makes some apps create/destroy their own
-	// elements throughout the scan, and those self-induced notifications must not
-	// feed back into another refresh (a flicker loop). A fixed window is not
-	// enough because a slow scan outlasts it, so gate on an explicit flag.
+	// Mute observer-driven refreshes for the whole duration of this scan: scanning
+	// the AX tree makes some apps create/destroy their own elements throughout the
+	// scan, and those self-induced notifications must not feed back into another
+	// refresh (a flicker loop). endObserverScanWindow then decides, from the hint
+	// set this scan produced, whether to open a short post-scan margin (a no-op
+	// scan, so drop the churn tail) or stay hot (a real change, so keep catching
+	// the still-settling updates).
 	if h.autoRefreshEnabled() {
-		h.observerScanning.Store(true)
+		h.beginObserverScanWindow()
 		defer h.endObserverScanWindow()
 	}
 
@@ -408,6 +410,14 @@ func (h *Handler) activateHintModeInternal(
 		}
 
 		return
+	}
+
+	// Fingerprint the resolved hint set (before label reuse, which only permutes
+	// labels and leaves element identity and bounds unchanged). endObserverScanWindow
+	// compares this to the previous scan's fingerprint to decide whether this scan
+	// caught a real change (stay hot) or only self-induced churn (open the margin).
+	if h.autoRefreshEnabled() {
+		h.recordScanFingerprint(domainHints)
 	}
 
 	// On a refresh, carry each persisting element's label over from the previous

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -215,12 +215,16 @@ func (h *Handler) activateHintModeInternal(
 	actionString := domain.ActionString(actionEnum)
 
 	if isRefresh {
-		// During refresh, only clear overlay and stop polling but do NOT change mode
-		// or disable event tap. Mode and event tap are already in the correct state,
-		// so SetModeHints() can be skipped on the success path.
-		// This prevents leaving the app in idle mode with event tap disabled if hint
-		// generation fails.
-		h.overlayManager.Clear()
+		// During refresh, only stop polling; do NOT change mode or disable the event
+		// tap (both are already correct, so SetModeHints() can be skipped on success).
+		//
+		// Deliberately do NOT clear the overlay here. Clearing blanks the window and
+		// resets the incremental-draw state, so the final draw is a full redraw after
+		// the whole scan, leaving the overlay empty for the scan's duration (a visible
+		// flicker on every refresh). Leaving the previous hints up lets DrawHints do an
+		// incremental diff old->new instead: an unchanged set renders nothing, and a
+		// changed set morphs in place with no blank frame. A refresh that fails or
+		// resolves to no hints still falls through to exitModeLocked below, which clears.
 		h.stopIndicatorPolling()
 	} else {
 		h.exitModeLocked()
@@ -250,9 +254,14 @@ func (h *Handler) activateHintModeInternal(
 	}
 
 	h.screenBounds = activeScreenBounds
-	// Clear any previous overlay content (e.g., scroll highlights) before drawing hints.
-	// This prevents scroll highlights from persisting when switching from scroll mode to hints mode.
-	h.overlayManager.Clear()
+	// Clear any previous overlay content (e.g. scroll highlights) before drawing hints,
+	// but only on a fresh activation. On a refresh the previous content is the prior
+	// hint set, which the incremental draw replaces in place; clearing it here would
+	// reintroduce the per-refresh blank-frame flicker (see the isRefresh branch above).
+	if !isRefresh {
+		h.overlayManager.Clear()
+	}
+
 	h.appState.SetHintOverlayNeedsRefresh(false)
 
 	if h.hints != nil && h.hints.Context != nil {

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -177,7 +177,7 @@ func (h *Handler) activateHintModeInternal(
 	// scan, so drop the churn tail) or stay hot (a real change, so keep catching
 	// the still-settling updates).
 	if h.autoRefreshEnabled() {
-		h.beginObserverScanWindow()
+		h.beginObserverScanWindow(isRefresh)
 		defer h.endObserverScanWindow()
 	}
 

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -400,6 +400,16 @@ func (h *Handler) activateHintModeInternal(
 		return
 	}
 
+	// On a refresh, carry each persisting element's label over from the previous
+	// scan so hints do not reshuffle. Prefix-freeness is preserved because the set
+	// of labels is unchanged; only their assignment to elements is permuted.
+	if isRefresh && h.hints != nil && h.hints.Context != nil {
+		if prev := h.hints.Context.SourceHints(); prev != nil {
+			domainHints = domainHint.ReuseLabels(
+				domainHints, domainHint.LabelsByStableID(prev.All()))
+		}
+	}
+
 	// Create domain hint collection from generated hints
 	hintCollection := domainHint.NewCollection(domainHints)
 
@@ -492,6 +502,11 @@ func (h *Handler) activateHintModeInternal(
 	}
 
 	h.startIndicatorPolling(domain.ModeHints)
+
+	// Keep the push observer aimed at exactly the processes this scan targeted.
+	// Runs for the initial activation and every refresh, so a front-app switch
+	// re-targets. The observer arm/disarm itself happens off this lock.
+	h.reconcileObserversLocked(bundleID, strategy)
 }
 
 // ensureScreenCapturePermissionsLocked checks and requests screen capture permissions.

--- a/internal/app/modes/mode_setup.go
+++ b/internal/app/modes/mode_setup.go
@@ -35,6 +35,7 @@ func (h *Handler) setAppModeLocked(mode domain.Mode) {
 
 	h.syncModifierPassthrough(mode)
 	h.syncStickyModifierToggle(mode)
+	h.syncObservers(mode)
 }
 
 func (h *Handler) syncStickyModifierToggle(mode domain.Mode) {

--- a/internal/app/modes/observers.go
+++ b/internal/app/modes/observers.go
@@ -1,0 +1,134 @@
+package modes
+
+import (
+	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+// ObserverController is the subset of the push-based AX observer manager that the
+// Handler drives. It is satisfied by *axobserver.Manager; the Handler depends on
+// this interface so the modes package stays free of platform infrastructure.
+type ObserverController interface {
+	// Reconcile sets the processes to observe for the current hint scan.
+	Reconcile(targets []ports.ObservationTarget)
+	// DisarmAll tears down every observer (called when hints mode exits).
+	DisarmAll()
+	// Close shuts the observer down for good (called at app teardown).
+	Close()
+}
+
+// SetObserverController wires the push-based change observer. Called once at
+// startup, before hints mode is ever entered.
+func (h *Handler) SetObserverController(controller ObserverController) {
+	h.observers = controller
+}
+
+// autoRefreshEnabled reports whether push auto-refresh is configured on and an
+// observer is wired.
+func (h *Handler) autoRefreshEnabled() bool {
+	return h.observers != nil && h.config != nil && h.config.Hints.AutoRefresh.Enabled
+}
+
+// RequestObserverRefresh is the observer manager's change sink: a non-stale
+// accessibility notification arrived, so ask the coordinator for a coalesced
+// refresh. Runs on the observer run-loop thread and must not block.
+func (h *Handler) RequestObserverRefresh() {
+	if h.refreshCoordinator != nil {
+		h.refreshCoordinator.Request()
+	}
+}
+
+// observerDrivenRefresh performs a coalesced, observer-triggered refresh. It runs
+// on a timer goroutine, so it takes the handler lock and re-checks that hints
+// mode is still active before re-scanning.
+func (h *Handler) observerDrivenRefresh() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.appState.CurrentMode() != domain.ModeHints {
+		return
+	}
+
+	if h.hints == nil || h.hints.Context == nil {
+		return
+	}
+
+	h.logger.Debug("observer-driven hint refresh")
+
+	// Re-read the session's filter/strategy context so an observer-driven refresh
+	// preserves custom roles, text filters, search, and overrides, exactly as the
+	// modifier-passthrough refresh does. activateHintModeInternal detects it is a
+	// refresh from the current mode and re-scans without changing mode or the tap.
+	filterRoles := h.hints.Context.FilterRoles()
+	filterTextContains := h.hints.Context.FilterTextContains()
+	startWithSearch := h.hints.Context.StartWithSearch()
+	strategyOverride := h.hints.Context.StrategyOverride()
+	labelDirectionOverride := h.hints.Context.LabelDirectionOverride()
+
+	h.activateHintModeInternal(
+		nil,
+		nil,
+		filterRoles,
+		filterTextContains,
+		&startWithSearch,
+		&strategyOverride,
+		&labelDirectionOverride,
+	)
+}
+
+// isMidSelection reports whether the user is part-way through choosing a hint (a
+// partially typed label, or an active text search), so an auto-refresh should be
+// deferred rather than swap the hint set out from under them. Runs on a timer
+// goroutine; takes the handler lock.
+func (h *Handler) isMidSelection() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.hints == nil || h.hints.Context == nil {
+		return false
+	}
+
+	if h.hints.Context.SearchActive() {
+		return true
+	}
+
+	manager := h.hints.Context.Manager()
+
+	return manager != nil && manager.CurrentInput() != ""
+}
+
+// reconcileObserversLocked recomputes and applies the observation target set for
+// the current scan. The caller holds h.mu. No-op when auto-refresh is off.
+func (h *Handler) reconcileObserversLocked(bundleID, strategy string) {
+	if !h.autoRefreshEnabled() {
+		return
+	}
+
+	targets := h.hintService.ObservationTargets(h.ctx, bundleID, strategy)
+	h.observers.Reconcile(targets)
+}
+
+// ShutdownAutoRefresh stops the refresh coordinator and closes the observer
+// controller. Called once at app teardown.
+func (h *Handler) ShutdownAutoRefresh() {
+	if h.refreshCoordinator != nil {
+		h.refreshCoordinator.Stop()
+	}
+
+	if h.observers != nil {
+		h.observers.Close()
+	}
+}
+
+// syncObservers is called on every mode transition (from setAppModeLocked). It is
+// the single disarm site: leaving hints mode tears down all observers, which
+// catches every exit path plus SetModeIdle and any future mode-changing path.
+func (h *Handler) syncObservers(mode domain.Mode) {
+	if h.observers == nil {
+		return
+	}
+
+	if mode != domain.ModeHints {
+		h.observers.DisarmAll()
+	}
+}

--- a/internal/app/modes/observers.go
+++ b/internal/app/modes/observers.go
@@ -1,14 +1,16 @@
 package modes
 
 import (
+	"hash/fnv"
 	"time"
 
 	"github.com/y3owk1n/neru/internal/core/domain"
+	domainHint "github.com/y3owk1n/neru/internal/core/domain/hint"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 // observerSelfScanSuppress is how long observer-driven refreshes are muted after
-// a scan starts, to swallow the create/destroy notifications a scan induces in
+// a no-op scan, to swallow the create/destroy notifications that scan induces in
 // some apps (which would otherwise loop into another refresh).
 const observerSelfScanSuppress = 200 * time.Millisecond
 
@@ -56,12 +58,87 @@ func (h *Handler) RequestObserverRefresh() {
 	}
 }
 
-// endObserverScanWindow ends scan suppression: it opens a short post-scan margin
-// (to catch notifications an app posts just after neru finishes reading) and
-// then clears the scanning flag. Deferred from activateHintModeInternal.
+// beginObserverScanWindow starts scan suppression: it raises the scanning flag
+// (which drops observer refreshes for the whole scan) and resets the per-scan
+// fingerprint state. Called at the top of activateHintModeInternal, under h.mu.
+func (h *Handler) beginObserverScanWindow() {
+	h.observerScanning.Store(true)
+	h.observerScanHasFingerprint = false
+}
+
+// recordScanFingerprint stores the fingerprint of the hint set this scan
+// produced, so endObserverScanWindow can tell a real change from self-induced
+// churn. Called once the final hint set is known, under h.mu.
+func (h *Handler) recordScanFingerprint(hints []*domainHint.Interface) {
+	h.observerScanFingerprint = fingerprintHints(hints)
+	h.observerScanHasFingerprint = true
+}
+
+// endObserverScanWindow ends scan suppression. Deferred from
+// activateHintModeInternal, so it runs on every exit path, under h.mu.
+//
+// It opens the short post-scan margin only when the scan produced the same hint
+// set as the previous scan (self-induced churn, nothing really changed). A scan
+// that changed the hint set caught a real change, so it clears any lingering
+// margin and stays hot: the change is often still settling and will post more
+// notifications, and dropping those was what made roughly one refresh in five
+// miss the fresh hints. A scan that never reached a fingerprint (an early error
+// or empty result) leaves the stored fingerprint untouched and opens no margin.
 func (h *Handler) endObserverScanWindow() {
+	defer h.observerScanning.Store(false)
+
+	if !h.observerScanHasFingerprint {
+		return
+	}
+
+	changed := h.observerScanFingerprint != h.observerLastFingerprint
+	h.observerLastFingerprint = h.observerScanFingerprint
+
+	if changed {
+		h.observerSuppressUntil.Store(0)
+
+		return
+	}
+
 	h.observerSuppressUntil.Store(time.Now().Add(observerSelfScanSuppress).UnixNano())
-	h.observerScanning.Store(false)
+}
+
+// fingerprintHints computes an order-independent fingerprint of a hint set from
+// each element's stable identity and bounds. Two scans that resolve the same
+// elements at the same positions produce the same value; adding, removing, or
+// moving an element changes it. Order independence (XOR-combining per-element
+// hashes) means a reordered-but-identical set is correctly seen as unchanged.
+func fingerprintHints(hints []*domainHint.Interface) uint64 {
+	var combined uint64
+
+	for _, hint := range hints {
+		el := hint.Element()
+		if el == nil {
+			continue
+		}
+
+		hh := fnv.New64a()
+		_, _ = hh.Write([]byte(el.StableID()))
+
+		b := el.Bounds()
+		var box [8]byte
+		putInt16(box[0:], b.Min.X)
+		putInt16(box[2:], b.Min.Y)
+		putInt16(box[4:], b.Dx())
+		putInt16(box[6:], b.Dy())
+		_, _ = hh.Write(box[:])
+
+		combined ^= hh.Sum64()
+	}
+
+	// Fold the count in so a set that XORs to the same value with a different
+	// number of elements (e.g. a duplicated pair) is still seen as changed.
+	return combined ^ (uint64(len(hints)) * 0x9E3779B97F4A7C15)
+}
+
+func putInt16(dst []byte, v int) {
+	dst[0] = byte(v)
+	dst[1] = byte(v >> 8)
 }
 
 // observerDrivenRefresh performs a coalesced, observer-triggered refresh. It runs

--- a/internal/app/modes/observers.go
+++ b/internal/app/modes/observers.go
@@ -14,6 +14,14 @@ import (
 // some apps (which would otherwise loop into another refresh).
 const observerSelfScanSuppress = 200 * time.Millisecond
 
+// maxObserverSettleChecks bounds how many times in a row a changed scan may
+// proactively schedule a settle re-check before the fingerprint stabilizes. A
+// real multi-phase change (a menu being dismissed then rebuilt) settles within a
+// couple of checks; this cap stops content that changes on every frame (an
+// animation) from re-checking forever. Once the cap is hit, refreshes fall back
+// to being notification-driven. The counter resets whenever a scan settles.
+const maxObserverSettleChecks = 5
+
 // ObserverController is the subset of the push-based AX observer manager that the
 // Handler drives. It is satisfied by *axobserver.Manager; the Handler depends on
 // this interface so the modes package stays free of platform infrastructure.
@@ -60,10 +68,19 @@ func (h *Handler) RequestObserverRefresh() {
 
 // beginObserverScanWindow starts scan suppression: it raises the scanning flag
 // (which drops observer refreshes for the whole scan) and resets the per-scan
-// fingerprint state. Called at the top of activateHintModeInternal, under h.mu.
-func (h *Handler) beginObserverScanWindow() {
+// fingerprint state. isRefresh records whether this scan is a refresh of an
+// active hint session (versus a fresh activation), which gates the proactive
+// settle re-check in endObserverScanWindow. Called at the top of
+// activateHintModeInternal, under h.mu.
+func (h *Handler) beginObserverScanWindow(isRefresh bool) {
 	h.observerScanning.Store(true)
 	h.observerScanHasFingerprint = false
+	h.observerScanIsRefresh = isRefresh
+
+	// A fresh activation starts a new hint session, so reset the settle-check budget.
+	if !isRefresh {
+		h.observerSettleChecks = 0
+	}
 }
 
 // recordScanFingerprint stores the fingerprint of the hint set this scan
@@ -79,11 +96,18 @@ func (h *Handler) recordScanFingerprint(hints []*domainHint.Interface) {
 //
 // It opens the short post-scan margin only when the scan produced the same hint
 // set as the previous scan (self-induced churn, nothing really changed). A scan
-// that changed the hint set caught a real change, so it clears any lingering
-// margin and stays hot: the change is often still settling and will post more
-// notifications, and dropping those was what made roughly one refresh in five
-// miss the fresh hints. A scan that never reached a fingerprint (an early error
-// or empty result) leaves the stored fingerprint untouched and opens no margin.
+// that changed the hint set caught something mid-change, so it clears any
+// lingering margin and, on a refresh, proactively schedules one more refresh
+// after the debounce. That settle re-check is the important part: some changes
+// arrive in two phases (an old menu is dismissed, then a new one is built), and
+// the notification that the second phase finished often lands inside this scan's
+// own window and is dropped, so nothing else would re-trigger. Re-checking on any
+// change catches the settled state without depending on that dropped
+// notification. It self-terminates: the re-check keeps firing only while the
+// fingerprint keeps changing, and stops once it stabilizes (a real change
+// settles) or matches the prior scan (self-induced churn nets out). A scan that
+// never reached a fingerprint (an early error or empty result) leaves the stored
+// fingerprint untouched and opens no margin.
 func (h *Handler) endObserverScanWindow() {
 	defer h.observerScanning.Store(false)
 
@@ -97,9 +121,18 @@ func (h *Handler) endObserverScanWindow() {
 	if changed {
 		h.observerSuppressUntil.Store(0)
 
+		if h.observerScanIsRefresh && h.refreshCoordinator != nil &&
+			h.observerSettleChecks < maxObserverSettleChecks {
+			h.observerSettleChecks++
+			h.refreshCoordinator.Request()
+		}
+
 		return
 	}
 
+	// Settled: nothing changed since the previous scan. Reset the budget so the
+	// next change episode gets a full allowance of settle re-checks.
+	h.observerSettleChecks = 0
 	h.observerSuppressUntil.Store(time.Now().Add(observerSelfScanSuppress).UnixNano())
 }
 

--- a/internal/app/modes/observers.go
+++ b/internal/app/modes/observers.go
@@ -1,9 +1,16 @@
 package modes
 
 import (
+	"time"
+
 	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
+
+// observerSelfScanSuppress is how long observer-driven refreshes are muted after
+// a scan starts, to swallow the create/destroy notifications a scan induces in
+// some apps (which would otherwise loop into another refresh).
+const observerSelfScanSuppress = 200 * time.Millisecond
 
 // ObserverController is the subset of the push-based AX observer manager that the
 // Handler drives. It is satisfied by *axobserver.Manager; the Handler depends on
@@ -33,9 +40,28 @@ func (h *Handler) autoRefreshEnabled() bool {
 // accessibility notification arrived, so ask the coordinator for a coalesced
 // refresh. Runs on the observer run-loop thread and must not block.
 func (h *Handler) RequestObserverRefresh() {
+	// Drop notifications while a scan is running, and for a short margin after it:
+	// a scan makes some apps churn their own AX elements throughout, and those
+	// self-induced notifications must not feed back into another refresh.
+	if h.observerScanning.Load() {
+		return
+	}
+
+	if until := h.observerSuppressUntil.Load(); until != 0 && time.Now().UnixNano() < until {
+		return
+	}
+
 	if h.refreshCoordinator != nil {
 		h.refreshCoordinator.Request()
 	}
+}
+
+// endObserverScanWindow ends scan suppression: it opens a short post-scan margin
+// (to catch notifications an app posts just after neru finishes reading) and
+// then clears the scanning flag. Deferred from activateHintModeInternal.
+func (h *Handler) endObserverScanWindow() {
+	h.observerSuppressUntil.Store(time.Now().Add(observerSelfScanSuppress).UnixNano())
+	h.observerScanning.Store(false)
 }
 
 // observerDrivenRefresh performs a coalesced, observer-triggered refresh. It runs

--- a/internal/app/modes/observers_test.go
+++ b/internal/app/modes/observers_test.go
@@ -1,0 +1,91 @@
+package modes
+
+import (
+	"image"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+	domainHint "github.com/y3owk1n/neru/internal/core/domain/hint"
+)
+
+func fpHint(t *testing.T, stableID string, bounds image.Rectangle) *domainHint.Interface {
+	t.Helper()
+
+	el, err := element.NewElement(
+		element.ID(stableID+"#ptr"),
+		bounds,
+		element.Role("AXButton"),
+		element.WithStableID(stableID),
+	)
+	if err != nil {
+		t.Fatalf("NewElement: %v", err)
+	}
+
+	h, err := domainHint.NewHint("a", el, el.Center())
+	if err != nil {
+		t.Fatalf("NewHint: %v", err)
+	}
+
+	return h
+}
+
+// The fingerprint is what lets endObserverScanWindow tell a real change from the
+// create/destroy churn a scan induces: an unchanged set (even reordered) must
+// hash equal so the post-scan margin opens and the flicker loop is broken, while
+// any add, removal, or move must hash differently so a real change stays hot.
+func TestFingerprintHints(t *testing.T) {
+	a := image.Rect(0, 0, 10, 10)
+	b := image.Rect(20, 20, 40, 44)
+	c := image.Rect(5, 5, 15, 30)
+
+	base := []*domainHint.Interface{
+		fpHint(t, "x1", a),
+		fpHint(t, "x2", b),
+	}
+
+	reordered := []*domainHint.Interface{
+		fpHint(t, "x2", b),
+		fpHint(t, "x1", a),
+	}
+
+	added := []*domainHint.Interface{
+		fpHint(t, "x1", a),
+		fpHint(t, "x2", b),
+		fpHint(t, "x3", c),
+	}
+
+	removed := []*domainHint.Interface{
+		fpHint(t, "x1", a),
+	}
+
+	moved := []*domainHint.Interface{
+		fpHint(t, "x1", a),
+		fpHint(t, "x2", c), // same identity, different bounds
+	}
+
+	reidentified := []*domainHint.Interface{
+		fpHint(t, "x1", a),
+		fpHint(t, "x9", b), // same bounds, different identity
+	}
+
+	baseFP := fingerprintHints(base)
+
+	if got := fingerprintHints(reordered); got != baseFP {
+		t.Errorf("reordered set changed fingerprint: %#x != %#x", got, baseFP)
+	}
+
+	for name, set := range map[string][]*domainHint.Interface{
+		"added":        added,
+		"removed":      removed,
+		"moved":        moved,
+		"reidentified": reidentified,
+	} {
+		if got := fingerprintHints(set); got == baseFP {
+			t.Errorf("%s set did not change fingerprint (both %#x)", name, got)
+		}
+	}
+
+	if fingerprintHints(nil) != fingerprintHints([]*domainHint.Interface{}) {
+		t.Error("nil and empty sets must hash equal")
+	}
+}

--- a/internal/app/modes/refresh_coordinator.go
+++ b/internal/app/modes/refresh_coordinator.go
@@ -1,0 +1,156 @@
+package modes
+
+import (
+	"sync"
+	"time"
+)
+
+// refreshCoordinatorConfig configures a refreshCoordinator.
+type refreshCoordinatorConfig struct {
+	// debounce is the trailing coalesce interval: a burst of change requests
+	// collapses into one refresh once the burst pauses for this long.
+	debounce time.Duration
+	// idleRetry is how often to re-check the defer predicate while a refresh is
+	// held back because the user is mid-selection.
+	idleRetry time.Duration
+	// maxDefer bounds how long a pending refresh can be held back before it fires
+	// regardless: both while the user idles mid-type, and during a sustained
+	// sub-debounce storm that would otherwise keep resetting the trailing timer
+	// forever. It is the effective refresh floor during a continuous storm.
+	maxDefer time.Duration
+	// onRefresh performs the actual refresh. Called off the coordinator lock, on
+	// a timer goroutine.
+	onRefresh func()
+	// shouldDefer reports whether a refresh must be held back right now (e.g. the
+	// user is part-way through typing a hint label or a search query). May be nil.
+	shouldDefer func() bool
+	// now is injectable for tests; nil uses time.Now.
+	now func() time.Time
+}
+
+// refreshCoordinator coalesces refresh requests from the push observer (and any
+// other feed) into a single debounced call, and defers a refresh while the user
+// is mid-selection so the hint set is never swapped out from under a partially
+// typed label. It never blocks a caller: Request only arms a timer.
+type refreshCoordinator struct {
+	cfg refreshCoordinatorConfig
+
+	mu           sync.Mutex
+	timer        *time.Timer
+	pendingSince time.Time
+	stopped      bool
+}
+
+const (
+	defaultRefreshDebounce  = 80 * time.Millisecond
+	defaultRefreshIdleRetry = 120 * time.Millisecond
+	defaultRefreshMaxDefer  = 3 * time.Second
+)
+
+func newRefreshCoordinator(cfg refreshCoordinatorConfig) *refreshCoordinator {
+	if cfg.debounce <= 0 {
+		cfg.debounce = defaultRefreshDebounce
+	}
+
+	if cfg.idleRetry <= 0 {
+		cfg.idleRetry = defaultRefreshIdleRetry
+	}
+
+	if cfg.maxDefer <= 0 {
+		cfg.maxDefer = defaultRefreshMaxDefer
+	}
+
+	if cfg.now == nil {
+		cfg.now = time.Now
+	}
+
+	return &refreshCoordinator{cfg: cfg}
+}
+
+// Request schedules a coalesced refresh. Safe to call from any goroutine
+// (including the observer run-loop thread); it only (re)arms a timer.
+func (c *refreshCoordinator) Request() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.stopped {
+		return
+	}
+
+	if c.pendingSince.IsZero() {
+		c.pendingSince = c.cfg.now()
+	}
+
+	c.armLocked(c.cfg.debounce)
+}
+
+// Stop cancels any pending refresh. After Stop, Request is a no-op.
+func (c *refreshCoordinator) Stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.stopped = true
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+
+	c.pendingSince = time.Time{}
+}
+
+func (c *refreshCoordinator) armLocked(d time.Duration) {
+	// Cap the delay so the timer fires within maxDefer of the first pending
+	// request, even if a continuous sub-debounce storm keeps resetting it. When
+	// fire() runs at the cap it sees the request as overdue and refreshes.
+	if !c.pendingSince.IsZero() {
+		if remaining := c.cfg.maxDefer - c.cfg.now().Sub(c.pendingSince); remaining < d {
+			d = remaining
+		}
+
+		if d < 0 {
+			d = 0
+		}
+	}
+
+	if c.timer == nil {
+		c.timer = time.AfterFunc(d, c.fire)
+
+		return
+	}
+
+	c.timer.Reset(d)
+}
+
+func (c *refreshCoordinator) fire() {
+	c.mu.Lock()
+	if c.stopped {
+		c.mu.Unlock()
+
+		return
+	}
+
+	pendingSince := c.pendingSince
+	c.mu.Unlock()
+
+	// Evaluate the defer predicate and the refresh callback OUTSIDE the
+	// coordinator lock. onRefresh acquires the handler mutex; keeping c.mu out of
+	// that path avoids any lock-ordering coupling between the two mutexes.
+	overdue := !pendingSince.IsZero() && c.cfg.now().Sub(pendingSince) >= c.cfg.maxDefer
+	if !overdue && c.cfg.shouldDefer != nil && c.cfg.shouldDefer() {
+		c.mu.Lock()
+		if !c.stopped {
+			c.armLocked(c.cfg.idleRetry)
+		}
+		c.mu.Unlock()
+
+		return
+	}
+
+	c.mu.Lock()
+	c.pendingSince = time.Time{}
+	c.mu.Unlock()
+
+	if c.cfg.onRefresh != nil {
+		c.cfg.onRefresh()
+	}
+}

--- a/internal/app/modes/refresh_coordinator_test.go
+++ b/internal/app/modes/refresh_coordinator_test.go
@@ -1,0 +1,144 @@
+package modes
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func waitForCount(t *testing.T, get func() int64, want int64, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if get() == want {
+			return
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Fatalf("count did not reach %d within %s (last=%d)", want, timeout, get())
+}
+
+func TestRefreshCoordinatorCoalesces(t *testing.T) {
+	var calls atomic.Int64
+
+	c := newRefreshCoordinator(refreshCoordinatorConfig{
+		debounce:  30 * time.Millisecond,
+		onRefresh: func() { calls.Add(1) },
+	})
+	defer c.Stop()
+
+	for range 5 {
+		c.Request()
+	}
+
+	waitForCount(t, calls.Load, 1, time.Second)
+
+	// No further refreshes after the burst collapses into one.
+	time.Sleep(60 * time.Millisecond)
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("burst should coalesce into one refresh, got %d", got)
+	}
+}
+
+func TestRefreshCoordinatorDefersWhileMidSelection(t *testing.T) {
+	var (
+		calls     atomic.Int64
+		deferring atomic.Bool
+	)
+
+	deferring.Store(true)
+
+	c := newRefreshCoordinator(refreshCoordinatorConfig{
+		debounce:    15 * time.Millisecond,
+		idleRetry:   15 * time.Millisecond,
+		maxDefer:    10 * time.Second, // large: isolate the defer behavior from anti-starvation
+		onRefresh:   func() { calls.Add(1) },
+		shouldDefer: func() bool { return deferring.Load() },
+	})
+	defer c.Stop()
+
+	c.Request()
+
+	// While the user is mid-selection, the refresh is held back.
+	time.Sleep(80 * time.Millisecond)
+
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("refresh must be deferred while mid-selection, got %d", got)
+	}
+
+	// Once selection ends, the pending refresh applies.
+	deferring.Store(false)
+	waitForCount(t, calls.Load, 1, time.Second)
+}
+
+func TestRefreshCoordinatorAntiStarvation(t *testing.T) {
+	var calls atomic.Int64
+
+	c := newRefreshCoordinator(refreshCoordinatorConfig{
+		debounce:    15 * time.Millisecond,
+		idleRetry:   15 * time.Millisecond,
+		maxDefer:    50 * time.Millisecond,
+		onRefresh:   func() { calls.Add(1) },
+		shouldDefer: func() bool { return true }, // never a neutral point
+	})
+	defer c.Stop()
+
+	c.Request()
+
+	// Even though shouldDefer is always true, the refresh must eventually fire so
+	// stale hints do not linger forever.
+	waitForCount(t, calls.Load, 1, time.Second)
+}
+
+func TestRefreshCoordinatorStormStillFires(t *testing.T) {
+	var calls atomic.Int64
+
+	c := newRefreshCoordinator(refreshCoordinatorConfig{
+		debounce:  20 * time.Millisecond,
+		maxDefer:  100 * time.Millisecond,
+		onRefresh: func() { calls.Add(1) },
+	})
+	defer c.Stop()
+
+	// Continuous sub-debounce storm: request faster than the debounce for longer
+	// than maxDefer. A pure trailing debounce would never fire; the max-defer cap
+	// must force at least one refresh.
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for range 40 {
+			c.Request()
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	<-done
+
+	if got := calls.Load(); got < 1 {
+		t.Fatalf("sustained storm produced no refresh; got %d", got)
+	}
+}
+
+func TestRefreshCoordinatorStopIsNoOp(t *testing.T) {
+	var calls atomic.Int64
+
+	c := newRefreshCoordinator(refreshCoordinatorConfig{
+		debounce:  15 * time.Millisecond,
+		onRefresh: func() { calls.Add(1) },
+	})
+
+	c.Stop()
+	c.Request()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("Request after Stop must not fire, got %d", got)
+	}
+}

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -369,6 +369,76 @@ func (s *HintService) generateHintsAX(
 	return elements, nil
 }
 
+// ObservationTargets returns the set of processes the current hint scan targets,
+// for a push-based change observer to watch while hints mode is active.
+//
+// The frontmost application's pid is resolved live because it is the only
+// drift-sensitive target (it depends on which app is focused right now). The
+// fixed system sources are resolved by their constant bundle IDs, gated by the
+// same include settings the scan uses, so an absent process simply yields no
+// target. Under the vision strategy no front-window target is emitted: that
+// window is detected via the Vision framework rather than the accessibility
+// tree, so there is no accessibility notification that corresponds to it.
+func (s *HintService) ObservationTargets(
+	ctx context.Context,
+	bundleID string,
+	strategy string,
+) []ports.ObservationTarget {
+	s.mu.RLock()
+	cfg := s.config
+	s.mu.RUnlock()
+
+	targets := make([]ports.ObservationTarget, 0, 8)
+
+	frontPID, pidErr := s.system.FocusedApplicationPID(ctx)
+	if pidErr != nil {
+		s.logger.Debug("observation targets: no focused pid", zap.Error(pidErr))
+	} else if frontPID > 0 {
+		if strategy != config.StrategyVision {
+			targets = append(targets, ports.ObservationTarget{
+				PID:      frontPID,
+				BundleID: bundleID,
+				Source:   ports.ObservationFrontWindow,
+			})
+		}
+
+		if cfg.IncludeMenubarHints {
+			targets = append(targets, ports.ObservationTarget{
+				PID:      frontPID,
+				BundleID: bundleID,
+				Source:   ports.ObservationAppMenubar,
+			})
+		}
+	}
+
+	add := func(enabled bool, bundle string, src ports.ObservationSource) {
+		if !enabled || bundle == "" {
+			return
+		}
+
+		pid, err := s.accessibility.PIDForBundleID(ctx, bundle)
+		if err != nil || pid <= 0 {
+			return
+		}
+
+		targets = append(targets, ports.ObservationTarget{PID: pid, BundleID: bundle, Source: src})
+	}
+
+	add(cfg.IncludeNCHints, config.BundleNotificationCenter, ports.ObservationNotificationCenter)
+	add(cfg.IncludeDockHints, config.BundleDock, ports.ObservationDock)
+	add(cfg.IncludeStageManagerHints, config.BundleWindowManager, ports.ObservationStageManager)
+	add(cfg.IncludePIPHints, config.BundlePIPAgent, ports.ObservationPIP)
+	add(cfg.IncludeScreenCaptureHints, config.BundleScreenCaptureUI, ports.ObservationScreenCapture)
+
+	if cfg.IncludeMenubarHints {
+		for _, target := range cfg.AdditionalMenubarHintsTargets {
+			add(true, target, ports.ObservationAdditionalMenubar)
+		}
+	}
+
+	return targets
+}
+
 // generateHintsVision collects window elements via vision detection and
 // supplementary elements (menubar, dock, etc.) via AX. This hybrid approach
 // ensures system UI is always detected while the frontmost window content

--- a/internal/architecture/dependency_boundary_test.go
+++ b/internal/architecture/dependency_boundary_test.go
@@ -40,9 +40,13 @@ func TestNonDarwinFilesDoNotImportDarwinPlatformPackage(t *testing.T) {
 		}
 
 		slashed := filepath.ToSlash(relPath)
+		// Files that are darwin-only by Go's build system may import the darwin
+		// platform package: they are never part of a non-darwin build. That
+		// covers the platform/darwin package itself, any *_darwin.go file, and any
+		// *_darwin_test.go file (the GOOS suffix applies to test files too).
 		if strings.Contains(slashed, "/platform/darwin/") ||
 			strings.HasSuffix(slashed, "_darwin.go") ||
-			strings.HasSuffix(slashed, "integration_darwin_test.go") {
+			strings.HasSuffix(slashed, "_darwin_test.go") {
 			return nil
 		}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -706,6 +706,7 @@ type HintsConfig struct {
 	IncludeStageManagerHints      bool                `json:"includeStageManagerHints"      toml:"include_stage_manager_hints"`
 	IncludePIPHints               bool                `json:"includePipHints"               toml:"include_pip_hints"`
 	IncludeScreenCaptureHints     bool                `json:"includeScreenCaptureHints"     toml:"include_screen_capture_hints"`
+	AutoRefresh                   AutoRefreshConfig   `json:"autoRefresh"                   toml:"auto_refresh"`
 	DetectMissionControl          bool                `json:"detectMissionControl"          toml:"detect_mission_control"`
 	OnMissionControlActivated     StringOrStringArray `json:"onMissionControlActivated"     toml:"on_mission_control_activated"`
 	OnMissionControlDeactivated   StringOrStringArray `json:"onMissionControlDeactivated"   toml:"on_mission_control_deactivated"`
@@ -913,6 +914,36 @@ type HeldRepeatConfig struct {
 	Interval     int  `json:"interval"     toml:"interval_ms"`      // Interval between subsequent repeats (ms)
 }
 
+// AutoRefreshConfig configures push-based auto-refresh of hints while hints mode
+// is active. On macOS this observes accessibility change notifications (AXObserver)
+// on the processes the hint scan targeted and re-scans when they change, instead
+// of relying on a fixed post-action delay. Observers run only while hints mode is
+// active, so an idle process has zero background cost.
+type AutoRefreshConfig struct {
+	// Enabled turns on push-based auto-refresh. Off by default.
+	Enabled bool `json:"enabled" toml:"enabled"`
+	// DebounceMs is the trailing coalesce/floor interval in milliseconds: a burst
+	// of notifications collapses into one refresh, and sustained churn is capped
+	// to roughly one refresh per interval. 0 uses a built-in default.
+	DebounceMs int `json:"debounceMs" toml:"debounce_ms"`
+	// WatchValueChanged also observes kAXValueChanged on the front window. It is
+	// the noisiest notification and off by default.
+	WatchValueChanged bool `json:"watchValueChanged" toml:"watch_value_changed"`
+}
+
+// Enhanced-attribute escalation modes for AdditionalAXSupport.EscalateEnhanced.
+const (
+	// EscalateEnhancedWhitelist escalates to AXEnhancedUserInterface only for
+	// apps matched by the browser bundle lists. Default and recommended.
+	EscalateEnhancedWhitelist = "whitelist"
+	// EscalateEnhancedOff never sets AXEnhancedUserInterface (AXManualAccessibility
+	// only). Safest, but Chrome/Firefox will not expose their tree.
+	EscalateEnhancedOff = "off"
+	// EscalateEnhancedAll escalates to AXEnhancedUserInterface on any app whose
+	// tree does not wake. Broadest coverage, but can relayout/move native apps.
+	EscalateEnhancedAll = "all"
+)
+
 // AdditionalAXSupport defines accessibility support for specific application frameworks.
 type AdditionalAXSupport struct {
 	Enable                    bool     `json:"enable"                    toml:"enable"`
@@ -920,6 +951,10 @@ type AdditionalAXSupport struct {
 	AdditionalChromiumBundles []string `json:"additionalChromiumBundles" toml:"additional_chromium_bundles"`
 	AdditionalFirefoxBundles  []string `json:"additionalFirefoxBundles"  toml:"additional_firefox_bundles"`
 	AdditionalWebKitBundles   []string `json:"additionalWebKitBundles"   toml:"additional_webkit_bundles"`
+	// EscalateEnhanced controls when AXEnhancedUserInterface is set: "whitelist"
+	// (default; browsers only), "off", or "all". AXManualAccessibility is always
+	// attempted for every activated app regardless of this setting.
+	EscalateEnhanced string `json:"escalateEnhanced" toml:"escalate_enhanced"`
 }
 
 // SystrayConfig defines system tray settings.

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -147,6 +147,9 @@ const (
 	// DefaultMaxDepth is the default max depth for accessibility tree traversal.
 	DefaultMaxDepth = 50
 
+	// DefaultAutoRefreshDebounceMs is the default hint auto-refresh debounce.
+	DefaultAutoRefreshDebounceMs = 80
+
 	// DefaultChildrenCapacity is the default children capacity.
 	DefaultChildrenCapacity = 8
 
@@ -426,9 +429,14 @@ func newDefaultConfig() *Config {
 			IncludeStageManagerHints:      false,
 			IncludePIPHints:               false,
 			IncludeScreenCaptureHints:     false,
-			DetectMissionControl:          false,
-			OnMissionControlActivated:     nil,
-			OnMissionControlDeactivated:   nil,
+			AutoRefresh: AutoRefreshConfig{
+				Enabled:           false,
+				DebounceMs:        DefaultAutoRefreshDebounceMs,
+				WatchValueChanged: false,
+			},
+			DetectMissionControl:        false,
+			OnMissionControlActivated:   nil,
+			OnMissionControlDeactivated: nil,
 
 			ClickableRoles: []string{},
 
@@ -443,6 +451,7 @@ func newDefaultConfig() *Config {
 				AdditionalChromiumBundles: []string{},
 				AdditionalFirefoxBundles:  []string{},
 				AdditionalWebKitBundles:   []string{},
+				EscalateEnhanced:          EscalateEnhancedWhitelist,
 			},
 		},
 		Grid: GridConfig{

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -147,8 +147,12 @@ const (
 	// DefaultMaxDepth is the default max depth for accessibility tree traversal.
 	DefaultMaxDepth = 50
 
-	// DefaultAutoRefreshDebounceMs is the default hint auto-refresh debounce.
-	DefaultAutoRefreshDebounceMs = 80
+	// DefaultAutoRefreshDebounceMs is the default hint auto-refresh debounce. It
+	// doubles as a settle delay: many apps post a change notification before their
+	// accessibility tree has finished updating, so scanning immediately reads a
+	// half-updated tree. Waiting this long after the last notification lets it
+	// settle. Tune higher for apps that update slowly.
+	DefaultAutoRefreshDebounceMs = 150
 
 	// DefaultChildrenCapacity is the default children capacity.
 	DefaultChildrenCapacity = 8

--- a/internal/config/system_bundles.go
+++ b/internal/config/system_bundles.go
@@ -1,0 +1,20 @@
+package config
+
+// macOS system process bundle identifiers for the supplementary hint sources.
+// These are fixed Apple identifiers, shared by the accessibility scan and the
+// push-based change observer so both target the same processes without drifting.
+const (
+	// BundleDock is the Dock.
+	BundleDock = "com.apple.dock"
+	// BundleNotificationCenter is the Notification Center UI agent.
+	BundleNotificationCenter = "com.apple.notificationcenterui"
+	// BundleWindowManager is the window/stage manager.
+	BundleWindowManager = "com.apple.WindowManager"
+	// BundlePIPAgent is the Picture-in-Picture agent.
+	BundlePIPAgent = "com.apple.PIPAgent"
+	// BundleScreenCaptureUI is the screen capture / screenshot UI.
+	BundleScreenCaptureUI = "com.apple.screencaptureui"
+	// BundleNeru is neru's own bundle identifier, excluded from observation so its
+	// overlay redraws cannot trigger a refresh loop.
+	BundleNeru = "com.y3owk1n.neru"
+)

--- a/internal/core/domain/element/element.go
+++ b/internal/core/domain/element/element.go
@@ -78,6 +78,10 @@ type Element struct {
 	value       string
 	searchText  string
 	visionOnly  bool
+	// stableID is a cross-scan identity (e.g. "pid:cfhash" on macOS), used to
+	// carry a hint's label across auto-refreshes when the element persists. Empty
+	// when no stable identity is available (the element then gets a fresh label).
+	stableID string
 }
 
 // NewElement creates a new element with validation.
@@ -142,6 +146,13 @@ func WithSearchText(text string) Option {
 	}
 }
 
+// WithStableID sets a cross-scan identity used for stable hint labels.
+func WithStableID(id string) Option {
+	return func(e *Element) {
+		e.stableID = id
+	}
+}
+
 // WithVisionOnly marks the element as detected via vision rather than
 // the accessibility tree. Vision-only elements have no AX reference and
 // actions must always use coordinate-based clicks (PerformActionAtPoint).
@@ -196,6 +207,11 @@ func (e *Element) SearchText() string {
 // actions must use coordinate-based clicks (PerformActionAtPoint).
 func (e *Element) IsVisionOnly() bool {
 	return e.visionOnly
+}
+
+// StableID returns the cross-scan identity, or "" if none is available.
+func (e *Element) StableID() string {
+	return e.stableID
 }
 
 // Center returns the center point of the element.

--- a/internal/core/domain/hint/reuse.go
+++ b/internal/core/domain/hint/reuse.go
@@ -1,0 +1,114 @@
+package hint
+
+// LabelsByStableID maps each hint's element stable identity to its label.
+// Elements without a stable identity are skipped. On a rare identity collision
+// the first writer wins. Used to carry labels across an auto-refresh.
+func LabelsByStableID(hints []*Interface) map[string]string {
+	out := make(map[string]string, len(hints))
+
+	for _, h := range hints {
+		if h == nil || h.Element() == nil {
+			continue
+		}
+
+		sid := h.Element().StableID()
+		if sid == "" {
+			continue
+		}
+
+		if _, exists := out[sid]; !exists {
+			out[sid] = h.Label()
+		}
+	}
+
+	return out
+}
+
+// ReuseLabels reassigns the labels of newHints so an element that persists from a
+// previous scan (matched by stable identity) keeps its previous label, while
+// preserving the exact set of labels the generator produced.
+//
+// The output is a bijection over the same label set the generator produced, so
+// the prefix-free property of those labels is preserved by construction: labels
+// are only permuted between elements, never invented or dropped.
+//
+// prevLabelByStable maps stable identity -> previous label (see LabelsByStableID).
+// A hint with no stable identity, or whose previous label is not in the new label
+// set (e.g. the set crossed a label-length boundary and the old label no longer
+// exists), receives a fresh label from the remaining pool in the generator's
+// order.
+func ReuseLabels(newHints []*Interface, prevLabelByStable map[string]string) []*Interface {
+	if len(newHints) == 0 || len(prevLabelByStable) == 0 {
+		return newHints
+	}
+
+	available := make(map[string]bool, len(newHints))
+	order := make([]string, len(newHints))
+
+	for i, h := range newHints {
+		available[h.Label()] = true
+		order[i] = h.Label()
+	}
+
+	assigned := make([]string, len(newHints))
+	taken := make(map[string]bool, len(newHints))
+
+	// Pass 1: pin persistent elements to their previous label when it is still in
+	// the new label set and not already claimed by another element.
+	for i, h := range newHints {
+		if h.Element() == nil {
+			continue
+		}
+
+		sid := h.Element().StableID()
+		if sid == "" {
+			continue
+		}
+
+		old, ok := prevLabelByStable[sid]
+		if !ok || !available[old] || taken[old] {
+			continue
+		}
+
+		assigned[i] = old
+		taken[old] = true
+	}
+
+	// Pass 2: the remaining (unclaimed) labels, in generator order, go to the
+	// unpinned hints. The counts match exactly: one label is claimed per pin, so
+	// remaining count == unpinned count.
+	remaining := make([]string, 0, len(newHints))
+	for _, label := range order {
+		if !taken[label] {
+			remaining = append(remaining, label)
+		}
+	}
+
+	out := make([]*Interface, len(newHints))
+	remainingIdx := 0
+
+	for i, h := range newHints {
+		label := assigned[i]
+		if label == "" {
+			label = remaining[remainingIdx]
+			remainingIdx++
+		}
+
+		if label == h.Label() {
+			out[i] = h
+
+			continue
+		}
+
+		reassigned, err := NewHint(label, h.Element(), h.Position())
+		if err != nil {
+			out[i] = h
+
+			continue
+		}
+
+		out[i] = reassigned
+	}
+
+	return out
+}

--- a/internal/core/domain/hint/reuse_test.go
+++ b/internal/core/domain/hint/reuse_test.go
@@ -1,0 +1,155 @@
+package hint
+
+import (
+	"image"
+	"reflect"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+)
+
+func mkHint(t *testing.T, label, stableID string) *Interface {
+	t.Helper()
+
+	el, err := element.NewElement(
+		element.ID(stableID+"#ptr"),
+		image.Rect(0, 0, 10, 10),
+		element.Role("AXButton"),
+		element.WithStableID(stableID),
+	)
+	if err != nil {
+		t.Fatalf("NewElement: %v", err)
+	}
+
+	h, err := NewHint(label, el, el.Center())
+	if err != nil {
+		t.Fatalf("NewHint: %v", err)
+	}
+
+	return h
+}
+
+func labelMultiset(hints []*Interface) map[string]int {
+	out := map[string]int{}
+	for _, h := range hints {
+		out[h.Label()]++
+	}
+
+	return out
+}
+
+func labelForStableID(hints []*Interface, sid string) string {
+	for _, h := range hints {
+		if h.Element().StableID() == sid {
+			return h.Label()
+		}
+	}
+
+	return ""
+}
+
+// The core guarantee: the output uses exactly the same label set as the input,
+// so the generator's prefix-free property is preserved (labels are only permuted).
+func TestReuseLabelsPreservesLabelSetAndCarriesPersistent(t *testing.T) {
+	newHints := []*Interface{
+		mkHint(t, "a", "x1"),
+		mkHint(t, "s", "x2"),
+		mkHint(t, "d", "x3"),
+	}
+	prev := map[string]string{"x2": "a", "x3": "s"}
+
+	out := ReuseLabels(newHints, prev)
+
+	if !reflect.DeepEqual(labelMultiset(out), labelMultiset(newHints)) {
+		t.Fatalf("label set changed: got %v want %v", labelMultiset(out), labelMultiset(newHints))
+	}
+
+	if got := labelForStableID(out, "x2"); got != "a" {
+		t.Fatalf("x2 should keep its previous label a, got %q", got)
+	}
+
+	if got := labelForStableID(out, "x3"); got != "s" {
+		t.Fatalf("x3 should keep its previous label s, got %q", got)
+	}
+
+	if got := labelForStableID(out, "x1"); got != "d" {
+		t.Fatalf("x1 should get the remaining label d, got %q", got)
+	}
+}
+
+// When the set crosses a label-length boundary (old label no longer in the new
+// set), the element is relabeled but the set stays prefix-free.
+func TestReuseLabelsGrowthDropsUnusableOldLabel(t *testing.T) {
+	newHints := []*Interface{
+		mkHint(t, "aa", "x1"),
+		mkHint(t, "ab", "x2"),
+		mkHint(t, "ac", "x3"),
+	}
+	prev := map[string]string{"x1": "s"} // 1-char label not present in the new 2-char set
+
+	out := ReuseLabels(newHints, prev)
+
+	if !reflect.DeepEqual(labelMultiset(out), labelMultiset(newHints)) {
+		t.Fatalf("label set changed: got %v want %v", labelMultiset(out), labelMultiset(newHints))
+	}
+
+	if got := labelForStableID(out, "x1"); got == "s" || got == "" {
+		t.Fatalf("x1 should be relabeled from the new set, got %q", got)
+	}
+}
+
+func TestReuseLabelsNoPreviousIsNoOp(t *testing.T) {
+	newHints := []*Interface{mkHint(t, "a", "x1"), mkHint(t, "s", "x2")}
+
+	out := ReuseLabels(newHints, nil)
+
+	if len(out) != len(newHints) {
+		t.Fatalf("length changed: %d vs %d", len(out), len(newHints))
+	}
+
+	for i := range newHints {
+		if out[i] != newHints[i] {
+			t.Fatalf("hint %d changed with no previous labels", i)
+		}
+	}
+}
+
+// A stable-identity collision (two elements sharing an id) must not break the
+// bijection: exactly one claims the carried label, the other is relabeled.
+func TestReuseLabelsHandlesIdentityCollision(t *testing.T) {
+	newHints := []*Interface{
+		mkHint(t, "a", "dup"),
+		mkHint(t, "s", "dup"),
+		mkHint(t, "d", "x3"),
+	}
+	prev := map[string]string{"dup": "a"}
+
+	out := ReuseLabels(newHints, prev)
+
+	if !reflect.DeepEqual(labelMultiset(out), labelMultiset(newHints)) {
+		t.Fatalf("label set changed on collision: got %v want %v",
+			labelMultiset(out), labelMultiset(newHints))
+	}
+
+	if len(out) != 3 {
+		t.Fatalf("expected 3 hints, got %d", len(out))
+	}
+}
+
+func TestLabelsByStableIDSkipsEmptyAndDedupes(t *testing.T) {
+	hints := []*Interface{
+		mkHint(t, "a", "x1"),
+		mkHint(t, "s", ""),    // no stable identity: skipped
+		mkHint(t, "d", "x1"),  // collision: first writer wins
+	}
+
+	got := LabelsByStableID(hints)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 mapping, got %d: %v", len(got), got)
+	}
+
+	if got["x1"] != "a" {
+		t.Fatalf("first writer should win: got %q want a", got["x1"])
+	}
+}

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -488,6 +488,37 @@ func (a *Adapter) IsAppExcluded(_ context.Context, bundleID string) bool {
 	return a.excludedBundles[bundleID]
 }
 
+// PIDForBundleID returns the process id of a running application by bundle ID,
+// or an error if it is not running.
+func (a *Adapter) PIDForBundleID(ctx context.Context, bundleID string) (int, error) {
+	if err := a.checkContext(ctx); err != nil {
+		return 0, err
+	}
+
+	app, appErr := a.client.ApplicationByBundleID(ctx, bundleID)
+	if appErr != nil {
+		return 0, appErr
+	}
+
+	if app == nil {
+		return 0, derrors.Newf(
+			derrors.CodeAccessibilityFailed, "application %q is not running", bundleID)
+	}
+	defer app.Release()
+
+	info, infoErr := app.Info()
+	if infoErr != nil {
+		return 0, infoErr
+	}
+
+	if info.PID <= 0 {
+		return 0, derrors.Newf(
+			derrors.CodeAccessibilityFailed, "no pid for application %q", bundleID)
+	}
+
+	return info.PID, nil
+}
+
 // Health checks if the accessibility permissions are granted.
 func (a *Adapter) Health(ctx context.Context) error {
 	// Check context

--- a/internal/core/infra/accessibility/adapter_conversion.go
+++ b/internal/core/infra/accessibility/adapter_conversion.go
@@ -28,6 +28,14 @@ func (a *Adapter) convertToDomainElement(node AXNode) (*element.Element, error) 
 		searchText = provider.SearchText()
 	}
 
+	// Capture a cross-scan identity (macOS CFHash + pid) before the native ref is
+	// released, so hint labels can persist across auto-refreshes. Absent on
+	// platforms/elements without a stable identity.
+	stableID := ""
+	if provider, ok := node.(interface{ StableID() string }); ok {
+		stableID = provider.StableID()
+	}
+
 	// Create element with options
 	domElement, elementErr := element.NewElement(
 		elementID,
@@ -38,6 +46,7 @@ func (a *Adapter) convertToDomainElement(node AXNode) (*element.Element, error) 
 		element.WithDescription(node.Description()),
 		element.WithValue(node.Value()),
 		element.WithSearchText(searchText),
+		element.WithStableID(stableID),
 	)
 	if elementErr != nil {
 		return nil, derrors.Wrap(

--- a/internal/core/infra/accessibility/client.go
+++ b/internal/core/infra/accessibility/client.go
@@ -63,6 +63,7 @@ type AXClient interface {
 type AXAppInfo struct {
 	Role  string
 	Title string
+	PID   int
 }
 
 // AXApp represents an application element.

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -417,6 +417,7 @@ func (a *InfraApp) Info() (*AXAppInfo, error) {
 	return &AXAppInfo{
 		Role:  info.Role(),
 		Title: info.Title(),
+		PID:   info.PID(),
 	}, nil
 }
 
@@ -434,6 +435,33 @@ func (n *InfraNode) ID() string {
 	}
 
 	return fmt.Sprintf("elem_%p", n.node.Element())
+}
+
+// StableID returns a cross-scan identity for the node ("pid:cfhash" on macOS),
+// or "" when no stable identity is available (non-darwin, or the hash could not
+// be computed). Unlike ID, this is stable across separate scans for the same
+// underlying native element, so hint labels can persist across auto-refreshes.
+func (n *InfraNode) StableID() string {
+	if n.node == nil {
+		return ""
+	}
+
+	el := n.node.Element()
+	if el == nil {
+		return ""
+	}
+
+	hash, hashErr := el.Hash()
+	if hashErr != nil || hash == 0 {
+		return ""
+	}
+
+	pid := 0
+	if info := n.node.Info(); info != nil {
+		pid = info.PID()
+	}
+
+	return fmt.Sprintf("%d:%d", pid, hash)
 }
 
 // Bounds returns the node bounds.

--- a/internal/core/infra/axobserver/doc.go
+++ b/internal/core/infra/axobserver/doc.go
@@ -1,0 +1,17 @@
+// Package axobserver provides a push-based, resource-safe observer of macOS
+// accessibility-tree changes, used to auto-refresh hints while hints mode is
+// active.
+//
+// The Manager is an actor: every mutation (Reconcile, DisarmAll,
+// HandleAppTerminated, Close) is a command processed on a single goroutine, so
+// callers on different threads never touch the observer map directly and no
+// cross-process accessibility call runs under a caller's lock. Observers are
+// armed only for the processes a hint scan resolved (see ports.ObservationTarget)
+// and only while hints mode is active; when the last observer is disarmed the
+// dedicated run-loop thread is stopped and joined, so an idle process has zero
+// observer threads and zero background cost.
+//
+// The platform-specific work lives behind the platform* shims: darwin wires the
+// AXObserver bridge in internal/core/infra/platform/darwin; other platforms are
+// no-ops until a native change-observer is implemented.
+package axobserver

--- a/internal/core/infra/axobserver/manager.go
+++ b/internal/core/infra/axobserver/manager.go
@@ -1,0 +1,377 @@
+package axobserver
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+const (
+	defaultMessagingTimeout = 0.25
+	defaultCloseTimeout     = 2 * time.Second
+	commandBuffer           = 64
+)
+
+// Config configures a Manager.
+type Config struct {
+	// SelfPID is neru's own process id, excluded from observation so its overlay
+	// redraws cannot trigger a refresh loop.
+	SelfPID int
+	// SelfBundleID is neru's own bundle id, also excluded.
+	SelfBundleID string
+	// WatchValueChanged enables kAXValueChanged for the front window (noisy).
+	WatchValueChanged bool
+	// MessagingTimeout bounds synchronous AX calls, in seconds; 0 uses a default.
+	MessagingTimeout float64
+	// OnChange is invoked (must be fast and non-blocking) when a non-stale
+	// notification arrives from any observed process. Typically the refresh
+	// coordinator's request function.
+	OnChange func()
+	// CloseTimeout bounds Manager.Close waiting for the actor to drain; 0 uses a
+	// default.
+	CloseTimeout time.Duration
+}
+
+// handle is one armed observer, owned exclusively by the actor goroutine.
+type handle struct {
+	pid      int
+	bundleID string
+	ptr      unsafe.Pointer // opaque native handle from platformArmObserver
+	mask     uint32
+}
+
+type command interface{ isCommand() }
+
+type reconcileCmd struct {
+	targets []ports.ObservationTarget
+	gen     uint64
+}
+type terminateCmd struct{ bundleID string }
+type closeCmd struct{}
+type syncCmd struct{ done chan struct{} }
+type wakeCmd struct{}
+
+func (reconcileCmd) isCommand() {}
+func (terminateCmd) isCommand() {}
+func (closeCmd) isCommand()     {}
+func (syncCmd) isCommand()      {}
+func (wakeCmd) isCommand()      {}
+
+// Manager owns all AX observers, structured as an actor. Every mutation is a
+// command processed on one goroutine, so callers on different threads never
+// touch the observer map directly and no cross-process AX call runs under a
+// caller's lock. Observers exist only while hints mode is active; when the last
+// one is disarmed the dedicated run-loop thread is stopped and joined, so an
+// idle neru has zero observer threads and zero background cost.
+type Manager struct {
+	logger *zap.Logger
+	cfg    Config
+	plat   platform
+
+	cmds chan command
+	done chan struct{}
+
+	curEpoch   atomic.Uint64 // read by the callback sink, bumped by the actor
+	liveCount  atomic.Int64  // armed observer count, for tests
+	desiredGen atomic.Uint64 // bumped by DisarmAll under the caller's lock
+
+	closeOnce sync.Once
+
+	// owned exclusively by the actor goroutine:
+	handles         map[int]*handle
+	threadUp        bool
+	lastDisarmedGen uint64
+}
+
+// NewManager creates and starts a Manager. The actor goroutine runs until Close.
+func NewManager(logger *zap.Logger, cfg Config) *Manager {
+	return newManager(logger, cfg, realPlatform{})
+}
+
+// newManager is the testable constructor: it accepts an injectable platform.
+func newManager(logger *zap.Logger, cfg Config, plat platform) *Manager {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	if cfg.MessagingTimeout <= 0 {
+		cfg.MessagingTimeout = defaultMessagingTimeout
+	}
+
+	if cfg.CloseTimeout <= 0 {
+		cfg.CloseTimeout = defaultCloseTimeout
+	}
+
+	m := &Manager{
+		logger:  logger.Named("axobserver"),
+		cfg:     cfg,
+		plat:    plat,
+		cmds:    make(chan command, commandBuffer),
+		done:    make(chan struct{}),
+		handles: make(map[int]*handle),
+	}
+	m.curEpoch.Store(1)
+
+	m.plat.setSink(m.onNotification)
+
+	go m.run()
+
+	return m
+}
+
+// Reconcile sets the desired set of observed processes. The frontmost app pid
+// may appear under several sources (window, menubar); their masks merge. This is
+// the primary mutator, called after each hint scan. Non-blocking: if the actor's
+// mailbox is momentarily full the command is dropped, and the next scan's
+// Reconcile corrects it (reconcile is idempotent and self-healing).
+func (m *Manager) Reconcile(targets []ports.ObservationTarget) {
+	m.enqueue(reconcileCmd{targets: targets, gen: m.desiredGen.Load()})
+}
+
+// DisarmAll tears down every observer and stops the run-loop thread. Called when
+// hints mode exits, under the mode-transition lock, so it must never block.
+//
+// It bumps an atomic generation. The actor tears down once per new generation
+// before processing the next command, and any reconcile that was already queued
+// from the exiting session carries an older generation and is skipped, so a
+// backed-up mailbox can neither lose the teardown nor let a trailing reconcile
+// re-arm observers after it. The wake is a best-effort nudge for an idle actor.
+func (m *Manager) DisarmAll() {
+	m.desiredGen.Add(1)
+
+	select {
+	case m.cmds <- wakeCmd{}:
+	default:
+	}
+}
+
+// HandleAppTerminated proactively disarms observers for a quit application
+// (matched by bundle id), skipping the notification-unregister IPC to the dead
+// process.
+func (m *Manager) HandleAppTerminated(bundleID string) {
+	if bundleID == "" {
+		return
+	}
+
+	m.enqueue(terminateCmd{bundleID: bundleID})
+}
+
+// Close disarms everything, stops and joins the run-loop thread, and stops the
+// actor. Idempotent. Bounded so a wedged app cannot hang shutdown forever.
+func (m *Manager) Close() {
+	m.closeOnce.Do(func() {
+		select {
+		case m.cmds <- closeCmd{}:
+		case <-time.After(m.cfg.CloseTimeout):
+			m.logger.Warn("axobserver close enqueue timed out")
+			m.plat.setSink(nil)
+
+			return
+		}
+
+		select {
+		case <-m.done:
+		case <-time.After(m.cfg.CloseTimeout):
+			m.logger.Warn("axobserver close drain timed out")
+		}
+
+		m.plat.setSink(nil)
+	})
+}
+
+// LiveObservers returns the number of currently armed observers (test hook).
+func (m *Manager) LiveObservers() int {
+	return int(m.liveCount.Load())
+}
+
+// ThreadRunning reports whether the observer run-loop thread is running (test hook).
+func (m *Manager) ThreadRunning() bool {
+	return m.plat.threadRunning()
+}
+
+// onNotification runs on the observer run-loop thread. It must be O(1) and
+// non-blocking: it rejects stale-session callbacks by epoch, then signals the
+// coordinator.
+func (m *Manager) onNotification(pid int, epoch uint64, notif string) {
+	if epoch != m.curEpoch.Load() {
+		return
+	}
+
+	m.logger.Debug("ax notification", zap.Int("pid", pid), zap.String("notif", notif))
+
+	if m.cfg.OnChange != nil {
+		m.cfg.OnChange()
+	}
+}
+
+// flush blocks until all previously enqueued commands have been processed. Used
+// by tests to observe the actor deterministically. The send is blocking (not the
+// drop-on-full path) so the barrier is never lost.
+func (m *Manager) flush() {
+	done := make(chan struct{})
+	m.cmds <- syncCmd{done: done}
+	<-done
+}
+
+func (m *Manager) enqueue(cmd command) {
+	select {
+	case m.cmds <- cmd:
+	default:
+		m.logger.Warn("axobserver command mailbox full; dropped a command")
+	}
+}
+
+func (m *Manager) run() {
+	for cmd := range m.cmds {
+		// A DisarmAll bumps desiredGen. Tear down once per new generation, before
+		// processing this command, so a reconcile that predates the disarm cannot
+		// revive observers and a full mailbox cannot lose the teardown.
+		gen := m.desiredGen.Load()
+		if gen != m.lastDisarmedGen {
+			m.doDisarmAll()
+			m.lastDisarmedGen = gen
+		}
+
+		switch c := cmd.(type) {
+		case reconcileCmd:
+			// Skip a reconcile enqueued before a later DisarmAll; it is stale and
+			// would re-arm observers for a session that has already exited.
+			if c.gen == gen {
+				m.doReconcile(c.targets)
+			}
+		case terminateCmd:
+			m.doTerminate(c.bundleID)
+		case wakeCmd:
+			// no-op; exists only to wake the actor so the generation check runs
+		case syncCmd:
+			close(c.done)
+		case closeCmd:
+			m.doDisarmAll()
+			m.stopThreadIfUp()
+			close(m.done)
+
+			return
+		}
+	}
+}
+
+func (m *Manager) doReconcile(targets []ports.ObservationTarget) {
+	desiredMask := make(map[int]uint32)
+	desiredBundle := make(map[int]string)
+
+	for _, t := range targets {
+		if t.PID <= 0 || t.PID == m.cfg.SelfPID {
+			continue
+		}
+
+		if m.cfg.SelfBundleID != "" && t.BundleID == m.cfg.SelfBundleID {
+			continue
+		}
+
+		desiredMask[t.PID] |= maskForSource(t.Source, m.cfg.WatchValueChanged)
+		desiredBundle[t.PID] = t.BundleID
+	}
+
+	// Disarm observers that are gone, changed identity (recycled pid), or need a
+	// different notification set.
+	for pid, h := range m.handles {
+		newMask, want := desiredMask[pid]
+		if !want || h.bundleID != desiredBundle[pid] || h.mask != newMask {
+			m.disarm(pid, true)
+		}
+	}
+
+	// Arm newly desired processes.
+	for pid, mask := range desiredMask {
+		if _, ok := m.handles[pid]; ok {
+			continue
+		}
+
+		m.arm(pid, desiredBundle[pid], mask)
+	}
+
+	if len(m.handles) == 0 {
+		m.stopThreadIfUp()
+	}
+}
+
+func (m *Manager) doDisarmAll() {
+	// Bump the epoch first so any callback in flight during teardown is rejected.
+	m.curEpoch.Add(1)
+
+	for pid := range m.handles {
+		m.disarm(pid, true)
+	}
+
+	m.stopThreadIfUp()
+}
+
+func (m *Manager) doTerminate(bundleID string) {
+	for pid, h := range m.handles {
+		if h.bundleID == bundleID {
+			m.disarm(pid, false)
+		}
+	}
+
+	if len(m.handles) == 0 {
+		m.stopThreadIfUp()
+	}
+}
+
+func (m *Manager) arm(pid int, bundleID string, mask uint32) {
+	if mask == 0 {
+		return
+	}
+
+	m.ensureThreadUp()
+
+	ptr := m.plat.arm(pid, m.curEpoch.Load(), mask)
+	if ptr == nil {
+		m.logger.Debug("failed to arm observer",
+			zap.Int("pid", pid), zap.String("bundle_id", bundleID))
+
+		if len(m.handles) == 0 {
+			m.stopThreadIfUp()
+		}
+
+		return
+	}
+
+	m.handles[pid] = &handle{pid: pid, bundleID: bundleID, ptr: ptr, mask: mask}
+	m.liveCount.Store(int64(len(m.handles)))
+}
+
+func (m *Manager) disarm(pid int, live bool) {
+	h := m.handles[pid]
+	if h == nil {
+		return
+	}
+
+	delete(m.handles, pid)
+	m.plat.disarm(h.ptr, live)
+	m.liveCount.Store(int64(len(m.handles)))
+}
+
+func (m *Manager) ensureThreadUp() {
+	if m.threadUp {
+		return
+	}
+
+	m.plat.setMessagingTimeout(m.cfg.MessagingTimeout)
+	m.plat.startThread()
+	m.threadUp = true
+}
+
+func (m *Manager) stopThreadIfUp() {
+	if !m.threadUp {
+		return
+	}
+
+	m.plat.stopThread()
+	m.threadUp = false
+}

--- a/internal/core/infra/axobserver/manager_soak_integration_darwin_test.go
+++ b/internal/core/infra/axobserver/manager_soak_integration_darwin_test.go
@@ -1,0 +1,65 @@
+//go:build darwin
+
+package axobserver
+
+import (
+	"os"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/infra/platform/darwin"
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+// TestNativeObserverSoakBalance drives the real native AXObserver layer through
+// many arm/disarm cycles and asserts there is no CFObject or thread leak: the
+// created-minus-released counts return to zero and the run-loop thread is idle.
+//
+// It uses the test process's own pid as the observation target. Whether native
+// notification registration succeeds depends on whether the test process is
+// accessibility-trusted (it usually is not under `go test`), but every
+// AXObserver / application element that is created is released on both the
+// success and the failure path, so the CFRelease balance must hold either way —
+// that balance is the leak assertion. The trust state is logged so it is clear
+// which path this run exercised.
+func TestNativeObserverSoakBalance(t *testing.T) {
+	pid := os.Getpid()
+
+	if darwin.CheckAccessibilityPermissions() {
+		t.Log("process is accessibility-trusted: soak exercises live observer arm/disarm")
+	} else {
+		t.Log("process is NOT accessibility-trusted: soak exercises the create/release " +
+			"failure-path balance (arm returns nil after releasing); still a valid leak check")
+	}
+
+	// SelfPID -1 never matches, so our own pid is not excluded and is used purely
+	// as a lifecycle target.
+	m := NewManager(nil, Config{SelfPID: -1})
+	defer m.Close()
+
+	targets := []ports.ObservationTarget{
+		{PID: pid, BundleID: "test.self", Source: ports.ObservationFrontWindow},
+	}
+
+	const iterations = 500
+
+	for range iterations {
+		// Blocking sends so no cycle is dropped under load.
+		m.cmds <- reconcileCmd{targets: targets}
+		m.cmds <- reconcileCmd{targets: nil}
+	}
+
+	m.flush()
+
+	if m.ThreadRunning() {
+		t.Fatal("observer thread must be idle after the soak (no observers armed)")
+	}
+
+	if got := m.LiveObservers(); got != 0 {
+		t.Fatalf("live observers after soak = %d, want 0", got)
+	}
+
+	obs, appEls := darwin.ObserverLiveCounts()
+	if obs != 0 || appEls != 0 {
+		t.Fatalf("CFRelease imbalance after soak: observers=%d appElements=%d", obs, appEls)
+	}
+}

--- a/internal/core/infra/axobserver/manager_test.go
+++ b/internal/core/infra/axobserver/manager_test.go
@@ -1,0 +1,398 @@
+package axobserver
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+	"unsafe"
+
+	"go.uber.org/goleak"
+
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+// fakePlatform records observer operations and lets a test drive the sink.
+type fakePlatform struct {
+	mu          sync.Mutex
+	armed       map[int]uint32 // pid -> currently-armed mask
+	handlePID   map[unsafe.Pointer]int
+	armCalls    int
+	disarmCalls int
+	disarmLive  []bool
+	startCount  int
+	stopCount   int
+	running     bool
+	failArm     map[int]bool
+	armGate     chan struct{} // if non-nil, arm blocks until it is closed/sent
+	sink        func(pid int, epoch uint64, notif string)
+}
+
+func newFakePlatform() *fakePlatform {
+	return &fakePlatform{
+		armed:     map[int]uint32{},
+		handlePID: map[unsafe.Pointer]int{},
+		failArm:   map[int]bool{},
+	}
+}
+
+func (f *fakePlatform) startThread() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.running = true
+	f.startCount++
+}
+
+func (f *fakePlatform) stopThread() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.running = false
+	f.stopCount++
+}
+
+func (f *fakePlatform) threadRunning() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.running
+}
+
+func (f *fakePlatform) setMessagingTimeout(float64) {}
+
+func (f *fakePlatform) arm(pid int, _ uint64, mask uint32) unsafe.Pointer {
+	f.mu.Lock()
+	f.armCalls++
+	gate := f.armGate
+	fail := f.failArm[pid]
+	f.mu.Unlock()
+
+	// Block outside the lock so a test can stall the actor mid-arm.
+	if gate != nil {
+		<-gate
+	}
+
+	if fail {
+		return nil
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// A real Go allocation gives a unique, GC-safe handle without uintptr tricks.
+	handle := unsafe.Pointer(new(byte))
+	f.handlePID[handle] = pid
+	f.armed[pid] = mask
+
+	return handle
+}
+
+func (f *fakePlatform) disarm(handle unsafe.Pointer, live bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.disarmCalls++
+	f.disarmLive = append(f.disarmLive, live)
+
+	if pid, ok := f.handlePID[handle]; ok {
+		delete(f.armed, pid)
+		delete(f.handlePID, handle)
+	}
+}
+
+func (f *fakePlatform) setSink(sink func(pid int, epoch uint64, notif string)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.sink = sink
+}
+
+func (f *fakePlatform) maskFor(pid int) (uint32, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	m, ok := f.armed[pid]
+
+	return m, ok
+}
+
+func (f *fakePlatform) armedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return len(f.armed)
+}
+
+func (f *fakePlatform) counts() (arm, disarm, start, stop int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.armCalls, f.disarmCalls, f.startCount, f.stopCount
+}
+
+func (f *fakePlatform) callSink(pid int, epoch uint64) {
+	f.mu.Lock()
+	sink := f.sink
+	f.mu.Unlock()
+
+	if sink != nil {
+		sink(pid, epoch, "AXTest")
+	}
+}
+
+func waitFor(t *testing.T, msg string, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Fatalf("condition not met within timeout: %s", msg)
+}
+
+func target(pid int, bundle string, src ports.ObservationSource) ports.ObservationTarget {
+	return ports.ObservationTarget{PID: pid, BundleID: bundle, Source: src}
+}
+
+func TestReconcileArmsAndDisarms(t *testing.T) {
+	fake := newFakePlatform()
+	m := newManager(nil, Config{}, fake)
+	defer m.Close()
+
+	m.Reconcile([]ports.ObservationTarget{
+		target(101, "com.example.a", ports.ObservationFrontWindow),
+	})
+	waitFor(t, "pid 101 armed", func() bool { _, ok := fake.maskFor(101); return ok })
+
+	if !fake.threadRunning() {
+		t.Fatal("observer thread should be running while an observer is armed")
+	}
+
+	m.Reconcile(nil)
+	waitFor(t, "all disarmed", func() bool { return fake.armedCount() == 0 })
+
+	if fake.threadRunning() {
+		t.Fatal("observer thread should stop when no observers remain")
+	}
+}
+
+func TestReconcileMergesMasksForSamePID(t *testing.T) {
+	fake := newFakePlatform()
+	m := newManager(nil, Config{}, fake)
+	defer m.Close()
+
+	m.Reconcile([]ports.ObservationTarget{
+		target(7, "com.example.front", ports.ObservationFrontWindow),
+		target(7, "com.example.front", ports.ObservationAppMenubar),
+	})
+	waitFor(t, "pid 7 armed", func() bool { _, ok := fake.maskFor(7); return ok })
+
+	mask, _ := fake.maskFor(7)
+	want := maskForSource(ports.ObservationFrontWindow, false) |
+		maskForSource(ports.ObservationAppMenubar, false)
+
+	if mask != want {
+		t.Fatalf("merged mask = %#x, want %#x", mask, want)
+	}
+
+	if fake.armedCount() != 1 {
+		t.Fatalf("same pid under two sources must arm exactly one observer, got %d", fake.armedCount())
+	}
+}
+
+func TestSelfExclusion(t *testing.T) {
+	fake := newFakePlatform()
+	m := newManager(nil, Config{SelfPID: 42, SelfBundleID: "com.y3owk1n.neru"}, fake)
+	defer m.Close()
+
+	m.Reconcile([]ports.ObservationTarget{
+		target(42, "com.other", ports.ObservationFrontWindow),         // excluded by pid
+		target(99, "com.y3owk1n.neru", ports.ObservationFrontWindow),  // excluded by bundle
+		target(100, "com.example.ok", ports.ObservationFrontWindow),   // allowed
+	})
+	waitFor(t, "pid 100 armed", func() bool { _, ok := fake.maskFor(100); return ok })
+
+	if _, ok := fake.maskFor(42); ok {
+		t.Fatal("own pid must not be observed")
+	}
+
+	if _, ok := fake.maskFor(99); ok {
+		t.Fatal("own bundle id must not be observed")
+	}
+
+	if fake.armedCount() != 1 {
+		t.Fatalf("only the allowed pid should be armed, got %d", fake.armedCount())
+	}
+}
+
+func TestRecycledPIDReArms(t *testing.T) {
+	fake := newFakePlatform()
+	m := newManager(nil, Config{}, fake)
+	defer m.Close()
+
+	m.Reconcile([]ports.ObservationTarget{target(5, "com.app.old", ports.ObservationDock)})
+	waitFor(t, "pid 5 armed (old)", func() bool { _, ok := fake.maskFor(5); return ok })
+
+	// Same pid, different bundle id: a recycled pid must be disarmed and re-armed.
+	m.Reconcile([]ports.ObservationTarget{target(5, "com.app.new", ports.ObservationDock)})
+
+	waitFor(t, "pid 5 re-armed", func() bool {
+		arm, disarm, _, _ := fake.counts()
+
+		return arm == 2 && disarm == 1
+	})
+}
+
+func TestUnchangedReconcileIsNoOp(t *testing.T) {
+	fake := newFakePlatform()
+	m := newManager(nil, Config{}, fake)
+	defer m.Close()
+
+	tgt := []ports.ObservationTarget{target(11, "com.app", ports.ObservationFrontWindow)}
+	m.Reconcile(tgt)
+	waitFor(t, "pid 11 armed", func() bool { _, ok := fake.maskFor(11); return ok })
+
+	m.Reconcile(tgt)
+	m.Reconcile(tgt)
+
+	// Give the actor time to process the repeats, then assert no re-arm churn.
+	time.Sleep(20 * time.Millisecond)
+
+	arm, disarm, _, _ := fake.counts()
+	if arm != 1 || disarm != 0 {
+		t.Fatalf("unchanged reconcile churned: arm=%d disarm=%d, want arm=1 disarm=0", arm, disarm)
+	}
+}
+
+func TestTerminateDisarmsDeadPIDWithoutRemoveNotification(t *testing.T) {
+	fake := newFakePlatform()
+	m := newManager(nil, Config{}, fake)
+	defer m.Close()
+
+	m.Reconcile([]ports.ObservationTarget{
+		target(21, "com.app.alive", ports.ObservationFrontWindow),
+		target(22, "com.app.dying", ports.ObservationFrontWindow),
+	})
+	waitFor(t, "both armed", func() bool { return fake.armedCount() == 2 })
+
+	m.HandleAppTerminated("com.app.dying")
+	waitFor(t, "dying disarmed", func() bool { _, ok := fake.maskFor(22); return !ok })
+
+	if _, ok := fake.maskFor(21); !ok {
+		t.Fatal("live app must remain observed after another app terminates")
+	}
+
+	// The terminate path passes live=false (skip RemoveNotification IPC to a dead pid).
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+
+	if len(fake.disarmLive) != 1 || fake.disarmLive[0] {
+		t.Fatalf("terminate disarm should be non-live, got %v", fake.disarmLive)
+	}
+}
+
+func TestStaleEpochCallbackDropped(t *testing.T) {
+	fake := newFakePlatform()
+
+	var changes atomic.Int64
+
+	m := newManager(nil, Config{OnChange: func() { changes.Add(1) }}, fake)
+	defer m.Close()
+
+	m.Reconcile([]ports.ObservationTarget{target(3, "com.app", ports.ObservationFrontWindow)})
+	waitFor(t, "pid 3 armed", func() bool { _, ok := fake.maskFor(3); return ok })
+
+	epochOld := m.curEpoch.Load()
+
+	// A live-session callback triggers a change.
+	fake.callSink(3, epochOld)
+	waitFor(t, "change registered", func() bool { return changes.Load() == 1 })
+
+	// DisarmAll bumps the epoch; a callback tagged with the old epoch is stale.
+	m.DisarmAll()
+	waitFor(t, "epoch bumped", func() bool { return m.curEpoch.Load() != epochOld })
+
+	fake.callSink(3, epochOld)
+	time.Sleep(20 * time.Millisecond)
+
+	if got := changes.Load(); got != 1 {
+		t.Fatalf("stale-epoch callback must be dropped: changes=%d, want 1", got)
+	}
+}
+
+func TestArmFailureDoesNotLeakThread(t *testing.T) {
+	fake := newFakePlatform()
+	fake.failArm[404] = true
+
+	m := newManager(nil, Config{}, fake)
+	defer m.Close()
+
+	m.Reconcile([]ports.ObservationTarget{target(404, "com.app.fails", ports.ObservationFrontWindow)})
+
+	// The arm fails, so no observer is held and the thread must not stay running.
+	waitFor(t, "thread stopped after failed arm", func() bool {
+		return !fake.threadRunning() && fake.armedCount() == 0
+	})
+}
+
+func TestIdempotentClose(t *testing.T) {
+	fake := newFakePlatform()
+	m := newManager(nil, Config{}, fake)
+
+	m.Reconcile([]ports.ObservationTarget{target(1, "com.app", ports.ObservationFrontWindow)})
+	waitFor(t, "armed", func() bool { _, ok := fake.maskFor(1); return ok })
+
+	m.Close()
+	m.Close() // must not panic or hang
+
+	if fake.threadRunning() {
+		t.Fatal("thread must be stopped after Close")
+	}
+
+	if fake.armedCount() != 0 {
+		t.Fatal("all observers must be disarmed after Close")
+	}
+}
+
+// Regression: a reconcile queued (from the exiting session) while the actor is
+// stuck arming must not re-arm observers after DisarmAll tears them down.
+func TestDisarmAllVoidsReconcileQueuedBehindIt(t *testing.T) {
+	fake := newFakePlatform()
+	fake.armGate = make(chan struct{})
+
+	m := newManager(nil, Config{}, fake)
+	defer m.Close()
+
+	// The actor starts arming pid 1 and blocks on the gate.
+	m.Reconcile([]ports.ObservationTarget{target(1, "com.a", ports.ObservationFrontWindow)})
+	waitFor(t, "arm in progress", func() bool {
+		arm, _, _, _ := fake.counts()
+
+		return arm >= 1
+	})
+
+	// While the actor is stuck mid-arm, another refresh queues a reconcile (same
+	// generation), then the user exits hints (DisarmAll bumps the generation).
+	m.Reconcile([]ports.ObservationTarget{target(2, "com.b", ports.ObservationFrontWindow)})
+	m.DisarmAll()
+
+	// Let the stuck arm finish.
+	close(fake.armGate)
+
+	// The reconcile queued behind DisarmAll must not re-arm anything, and the
+	// thread must be idle: hints mode has exited.
+	m.flush()
+	waitFor(t, "disarmed and idle after DisarmAll", func() bool {
+		return fake.armedCount() == 0 && !fake.threadRunning() && m.LiveObservers() == 0
+	})
+}

--- a/internal/core/infra/axobserver/masks.go
+++ b/internal/core/infra/axobserver/masks.go
@@ -1,0 +1,49 @@
+package axobserver
+
+import "github.com/y3owk1n/neru/internal/core/ports"
+
+// Notification mask bits. These MUST match the enum in
+// internal/core/infra/platform/darwin/axobserver.h and the mirrored constants in
+// axobserver.go; the darwin build asserts equality in masks_darwin_test.go.
+const (
+	maskLayoutChanged           uint32 = 1 << 0
+	maskCreated                 uint32 = 1 << 1
+	maskUIElementDestroyed      uint32 = 1 << 2
+	maskWindowCreated           uint32 = 1 << 3
+	maskWindowMoved             uint32 = 1 << 4
+	maskWindowResized           uint32 = 1 << 5
+	maskFocusedUIElementChanged uint32 = 1 << 6
+	maskMenuOpened              uint32 = 1 << 7
+	maskMenuClosed              uint32 = 1 << 8
+	maskValueChanged            uint32 = 1 << 9
+)
+
+// maskForSource returns the notification bits worth watching for a source. The
+// front window watches structure and geometry; menu targets watch menu and
+// element lifecycle only (so unrelated window churn does not fire refreshes);
+// Notification Center watches window/element create and destroy. valueChanged is
+// added only for the front window and only when explicitly enabled, since it is
+// the noisiest notification.
+func maskForSource(src ports.ObservationSource, watchValueChanged bool) uint32 {
+	switch src {
+	case ports.ObservationFrontWindow:
+		m := maskLayoutChanged | maskCreated | maskUIElementDestroyed |
+			maskWindowCreated | maskWindowMoved | maskWindowResized |
+			maskFocusedUIElementChanged
+		if watchValueChanged {
+			m |= maskValueChanged
+		}
+
+		return m
+	case ports.ObservationAppMenubar, ports.ObservationAdditionalMenubar:
+		return maskMenuOpened | maskMenuClosed | maskCreated | maskUIElementDestroyed
+	case ports.ObservationNotificationCenter:
+		return maskWindowCreated | maskUIElementDestroyed
+	case ports.ObservationDock, ports.ObservationStageManager:
+		return maskCreated | maskUIElementDestroyed | maskLayoutChanged
+	case ports.ObservationPIP, ports.ObservationScreenCapture:
+		return maskCreated | maskUIElementDestroyed
+	default:
+		return maskCreated | maskUIElementDestroyed
+	}
+}

--- a/internal/core/infra/axobserver/masks.go
+++ b/internal/core/infra/axobserver/masks.go
@@ -16,6 +16,7 @@ const (
 	maskMenuOpened              uint32 = 1 << 7
 	maskMenuClosed              uint32 = 1 << 8
 	maskValueChanged            uint32 = 1 << 9
+	maskLoadComplete            uint32 = 1 << 10
 )
 
 // maskForSource returns the notification bits worth watching for a source. The
@@ -27,9 +28,13 @@ const (
 func maskForSource(src ports.ObservationSource, watchValueChanged bool) uint32 {
 	switch src {
 	case ports.ObservationFrontWindow:
+		// kAXFocusedUIElementChanged is deliberately excluded: it is noisy (it can
+		// fire on mere hover/focus shuffles) and is not needed to detect that the
+		// set of hintable elements changed. AXLoadComplete is included so browser
+		// page navigation triggers a refresh.
 		m := maskLayoutChanged | maskCreated | maskUIElementDestroyed |
 			maskWindowCreated | maskWindowMoved | maskWindowResized |
-			maskFocusedUIElementChanged
+			maskLoadComplete
 		if watchValueChanged {
 			m |= maskValueChanged
 		}

--- a/internal/core/infra/axobserver/masks_darwin_test.go
+++ b/internal/core/infra/axobserver/masks_darwin_test.go
@@ -28,6 +28,7 @@ func TestMaskBitsMatchNativeHeader(t *testing.T) {
 		{"MenuOpened", maskMenuOpened, darwin.AXNotifMenuOpened},
 		{"MenuClosed", maskMenuClosed, darwin.AXNotifMenuClosed},
 		{"ValueChanged", maskValueChanged, darwin.AXNotifValueChanged},
+		{"LoadComplete", maskLoadComplete, darwin.AXNotifLoadComplete},
 	}
 
 	for _, c := range cases {

--- a/internal/core/infra/axobserver/masks_darwin_test.go
+++ b/internal/core/infra/axobserver/masks_darwin_test.go
@@ -1,0 +1,38 @@
+//go:build darwin
+
+package axobserver
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/infra/platform/darwin"
+)
+
+// TestMaskBitsMatchNativeHeader guards against drift between the mask bits in
+// masks.go and the C enum in the darwin AXObserver header. The darwin package
+// mirrors that enum directly from cgo (darwin.AXNotif* = C.NeruAXNotif*), so
+// asserting equality here fails the build if the two ever disagree.
+func TestMaskBitsMatchNativeHeader(t *testing.T) {
+	cases := []struct {
+		name string
+		got  uint32
+		want uint32
+	}{
+		{"LayoutChanged", maskLayoutChanged, darwin.AXNotifLayoutChanged},
+		{"Created", maskCreated, darwin.AXNotifCreated},
+		{"UIElementDestroyed", maskUIElementDestroyed, darwin.AXNotifUIElementDestroyed},
+		{"WindowCreated", maskWindowCreated, darwin.AXNotifWindowCreated},
+		{"WindowMoved", maskWindowMoved, darwin.AXNotifWindowMoved},
+		{"WindowResized", maskWindowResized, darwin.AXNotifWindowResized},
+		{"FocusedUIElementChanged", maskFocusedUIElementChanged, darwin.AXNotifFocusedUIElementChanged},
+		{"MenuOpened", maskMenuOpened, darwin.AXNotifMenuOpened},
+		{"MenuClosed", maskMenuClosed, darwin.AXNotifMenuClosed},
+		{"ValueChanged", maskValueChanged, darwin.AXNotifValueChanged},
+	}
+
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("mask %s = %#x, native header = %#x", c.name, c.got, c.want)
+		}
+	}
+}

--- a/internal/core/infra/axobserver/platform_darwin.go
+++ b/internal/core/infra/axobserver/platform_darwin.go
@@ -1,0 +1,50 @@
+//go:build darwin
+
+package axobserver
+
+import (
+	"unsafe"
+
+	"github.com/y3owk1n/neru/internal/core/infra/platform/darwin"
+)
+
+func platformStartObserverThread() {
+	darwin.StartObserverThread()
+}
+
+func platformStopObserverThread() {
+	darwin.StopObserverThread()
+}
+
+func platformObserverThreadRunning() bool {
+	return darwin.ObserverThreadRunning()
+}
+
+func platformSetObserverMessagingTimeout(seconds float64) {
+	darwin.SetObserverMessagingTimeout(seconds)
+}
+
+func platformArmObserver(pid int, epoch uint64, mask uint32) unsafe.Pointer {
+	return darwin.ArmObserver(pid, epoch, mask)
+}
+
+func platformDisarmObserver(handle unsafe.Pointer, live bool) {
+	darwin.DisarmObserver(handle, live)
+}
+
+// sinkFunc adapts a plain function to the darwin.ObserverSink interface.
+type sinkFunc func(pid int, epoch uint64, notif string)
+
+func (f sinkFunc) HandleAXNotification(pid int, epoch uint64, notif string) {
+	f(pid, epoch, notif)
+}
+
+func platformSetObserverSink(f func(pid int, epoch uint64, notif string)) {
+	if f == nil {
+		darwin.SetObserverSink(nil)
+
+		return
+	}
+
+	darwin.SetObserverSink(sinkFunc(f))
+}

--- a/internal/core/infra/axobserver/platform_iface.go
+++ b/internal/core/infra/axobserver/platform_iface.go
@@ -1,0 +1,41 @@
+package axobserver
+
+import "unsafe"
+
+// platform abstracts the native observer operations so the Manager can be unit
+// tested with a fake on any OS. The real implementation forwards to the
+// build-tagged platform* shims (the darwin AXObserver bridge, or no-ops).
+type platform interface {
+	startThread()
+	stopThread()
+	threadRunning() bool
+	setMessagingTimeout(seconds float64)
+	arm(pid int, epoch uint64, mask uint32) unsafe.Pointer
+	disarm(handle unsafe.Pointer, live bool)
+	setSink(sink func(pid int, epoch uint64, notif string))
+}
+
+// realPlatform forwards to the platform* package functions.
+type realPlatform struct{}
+
+func (realPlatform) startThread() { platformStartObserverThread() }
+
+func (realPlatform) stopThread() { platformStopObserverThread() }
+
+func (realPlatform) threadRunning() bool { return platformObserverThreadRunning() }
+
+func (realPlatform) setMessagingTimeout(seconds float64) {
+	platformSetObserverMessagingTimeout(seconds)
+}
+
+func (realPlatform) arm(pid int, epoch uint64, mask uint32) unsafe.Pointer {
+	return platformArmObserver(pid, epoch, mask)
+}
+
+func (realPlatform) disarm(handle unsafe.Pointer, live bool) {
+	platformDisarmObserver(handle, live)
+}
+
+func (realPlatform) setSink(sink func(pid int, epoch uint64, notif string)) {
+	platformSetObserverSink(sink)
+}

--- a/internal/core/infra/axobserver/platform_other.go
+++ b/internal/core/infra/axobserver/platform_other.go
@@ -1,0 +1,23 @@
+//go:build !darwin
+
+package axobserver
+
+import "unsafe"
+
+// On non-darwin platforms the observer is a no-op. A push-based change-observer
+// for AT-SPI (Linux) or UI Automation (Windows) can implement these shims later;
+// the Manager and ObservationTarget types are already platform-agnostic.
+
+func platformStartObserverThread() {}
+
+func platformStopObserverThread() {}
+
+func platformObserverThreadRunning() bool { return false }
+
+func platformSetObserverMessagingTimeout(_ float64) {}
+
+func platformArmObserver(_ int, _ uint64, _ uint32) unsafe.Pointer { return nil }
+
+func platformDisarmObserver(_ unsafe.Pointer, _ bool) {}
+
+func platformSetObserverSink(_ func(pid int, epoch uint64, notif string)) {}

--- a/internal/core/infra/electron/electron.go
+++ b/internal/core/infra/electron/electron.go
@@ -12,65 +12,58 @@ import (
 )
 
 const (
-	electronAttributeName = "AXManualAccessibility"
+	manualAttributeName   = "AXManualAccessibility"
 	enhancedAttributeName = "AXEnhancedUserInterface"
 )
 
+// axCacheEntry records the outcome of an enable attempt for one pid.
+type axCacheEntry struct {
+	bundle string
+	ok     bool
+	at     time.Time
+}
+
 var (
-	electronPIDsMu      sync.Mutex
-	electronEnabledPIDs = make(map[int]struct{})
-	chromiumPIDsMu      sync.Mutex
-	chromiumEnabledPIDs = make(map[int]struct{})
-	firefoxPIDsMu       sync.Mutex
-	firefoxEnabledPIDs  = make(map[int]struct{})
+	enabledPIDsMu sync.Mutex
+	// enabledPIDs caches the enable outcome per pid. Keying on the bundle id too
+	// means a recycled pid (same number, different app after a quit/relaunch) is
+	// treated as new. A positive result is cached permanently; a negative result
+	// is honored only for non-patient apps and only for negativeCacheTTL, so a
+	// native app is not re-probed on every activation while a classified app can
+	// still be retried as its tree boots.
+	enabledPIDs = make(map[int]axCacheEntry)
 )
 
 const (
-	accessibilityRetryCount = 10
-	accessibilityRetryDelay = 100 * time.Millisecond
-	maxAccessibilityDepth   = 10
+	accessibilityRetryCount   = 10
+	quickAccessibilityRetries = 3
+	accessibilityRetryDelay   = 100 * time.Millisecond
+	// negativeCacheTTL bounds how often a non-patient (unclassified) app that did
+	// not become usable is re-probed.
+	negativeCacheTTL = 30 * time.Second
+	// maxAccessibilityDepth and maxAccessibilityNodes bound the tree probe so it
+	// stays cheap even though EnsureAppAccessibility now runs for every activated
+	// app (not just a whitelist).
+	maxAccessibilityDepth = 8
+	maxAccessibilityNodes = 400
 )
 
-// EnsureElectronAccessibility ensures Electron accessibility is enabled for the provided bundle ID.
-func EnsureElectronAccessibility(bundleID string, logger *zap.Logger) bool {
-	return ensureAccessibility(
-		bundleID,
-		&electronPIDsMu,
-		electronEnabledPIDs,
-		logger,
-		true,
-	)
-}
-
-// EnsureChromiumAccessibility ensures Chromium accessibility is enabled for the provided bundle ID.
-func EnsureChromiumAccessibility(bundleID string, logger *zap.Logger) bool {
-	return ensureAccessibility(
-		bundleID,
-		&chromiumPIDsMu,
-		chromiumEnabledPIDs,
-		logger,
-		false,
-	)
-}
-
-// EnsureFirefoxAccessibility ensures Firefox accessibility is enabled for the provided bundle ID.
-func EnsureFirefoxAccessibility(bundleID string, logger *zap.Logger) bool {
-	return ensureAccessibility(
-		bundleID,
-		&firefoxPIDsMu,
-		firefoxEnabledPIDs,
-		logger,
-		false,
-	)
-}
-
-func ensureAccessibility(
-	bundleID string,
-	pidsMu *sync.Mutex,
-	enabledPIDs map[int]struct{},
-	logger *zap.Logger,
-	isElectron bool,
-) bool {
+// EnsureAppAccessibility wakes an application's accessibility tree if it is not
+// already usable, caching the result per pid.
+//
+// AXManualAccessibility is always attempted first: it wakes Electron and
+// Chromium trees and is a harmless no-op on apps that do not implement it, with
+// no window side effects. AXEnhancedUserInterface — which some apps react to by
+// relaying out or moving their windows — is attempted only when allowEnhanced is
+// true, so it is never sprayed on native apps. Callers derive allowEnhanced from
+// AdditionalAXSupport.EscalateEnhanced (browsers only by default).
+//
+// patient controls how hard we wait and re-probe. Classified apps (browsers,
+// listed Electron) are patient: they get the full retry window and ignore the
+// negative cache, because their tree may still be booting. Unclassified apps are
+// impatient: a short wait and a negative cache, so a native app is not re-probed
+// (a bounded but non-trivial tree walk) on every activation.
+func EnsureAppAccessibility(bundleID string, allowEnhanced, patient bool, logger *zap.Logger) bool {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -90,74 +83,83 @@ func ensureAccessibility(
 	}
 
 	pid := info.PID()
-
 	if pid <= 0 {
 		return false
 	}
 
-	pidsMu.Lock()
+	enabledPIDsMu.Lock()
+	entry, cached := enabledPIDs[pid]
+	enabledPIDsMu.Unlock()
 
-	_, already := enabledPIDs[pid]
-
-	pidsMu.Unlock()
-
-	if already {
-		return true
-	}
-
-	if hasUsableAccessibilityTree(app, logger) {
-		markPIDEnabled(pidsMu, enabledPIDs, pid)
-
-		return true
-	}
-
-	if isElectron {
-		success := platformSetApplicationAttribute(pid, electronAttributeName, true)
-
-		if !success {
-			logger.Debug(
-				"Failed to set AXManualAccessibility",
-				zap.Int("pid", pid),
-				zap.String("bundle_id", bundleID),
-			)
+	if cached && entry.bundle == bundleID {
+		if entry.ok {
+			return true
+		}
+		// Recently probed and unusable. Impatient apps skip the re-probe; patient
+		// apps fall through and retry as their tree may still be coming up.
+		if !patient && time.Since(entry.at) < negativeCacheTTL {
+			return false
 		}
 	}
 
-	if waitForAccessibility(app, logger) {
-		markPIDEnabled(pidsMu, enabledPIDs, pid)
+	// Already usable (accessibility already on, or a native app with a scroll
+	// area): nothing to do, and no attribute is touched.
+	if hasUsableAccessibilityTree(app, logger) {
+		markPIDResult(pid, bundleID, true)
 
 		return true
 	}
 
-	success := platformSetApplicationAttribute(pid, enhancedAttributeName, true)
+	// Safe listless step for every app.
+	if !platformSetApplicationAttribute(pid, manualAttributeName, true) {
+		logger.Debug("Failed to set AXManualAccessibility",
+			zap.Int("pid", pid), zap.String("bundle_id", bundleID))
+	}
 
-	if !success {
-		logger.Debug(
-			"Failed to enable AXEnhancedUserInterface",
-			zap.Int("pid", pid),
-			zap.String("bundle_id", bundleID),
-		)
+	if waitForAccessibility(app, patient, logger) {
+		markPIDResult(pid, bundleID, true)
+
+		return true
+	}
+
+	// Gated escalation: only for apps the caller allows (browsers by default),
+	// never native apps.
+	if !allowEnhanced {
+		logger.Debug("Accessibility tree not usable; enhanced escalation not allowed",
+			zap.Int("pid", pid), zap.String("bundle_id", bundleID))
+		markPIDResult(pid, bundleID, false)
 
 		return false
 	}
 
-	if waitForAccessibility(app, logger) {
-		markPIDEnabled(pidsMu, enabledPIDs, pid)
+	if !platformSetApplicationAttribute(pid, enhancedAttributeName, true) {
+		logger.Debug("Failed to enable AXEnhancedUserInterface",
+			zap.Int("pid", pid), zap.String("bundle_id", bundleID))
+		markPIDResult(pid, bundleID, false)
+
+		return false
+	}
+
+	if waitForAccessibility(app, patient, logger) {
+		markPIDResult(pid, bundleID, true)
 
 		return true
 	}
 
-	logger.Warn(
-		"Accessibility could not be enabled",
-		zap.Int("pid", pid),
-		zap.String("bundle_id", bundleID),
-	)
+	logger.Warn("Accessibility could not be enabled",
+		zap.Int("pid", pid), zap.String("bundle_id", bundleID))
+	markPIDResult(pid, bundleID, false)
 
 	return false
 }
 
-func waitForAccessibility(app *accessibility.Element, logger *zap.Logger) bool {
-	for range accessibilityRetryCount {
+func waitForAccessibility(app *accessibility.Element, patient bool, logger *zap.Logger) bool {
+	retries := quickAccessibilityRetries
+	if patient {
+		retries = accessibilityRetryCount
+	}
+
+	for range retries {
 		if hasUsableAccessibilityTree(app, logger) {
 			return true
 		}
@@ -179,6 +181,7 @@ func hasUsableAccessibilityTree(root *accessibility.Element, logger *zap.Logger)
 	}
 
 	queue := []entry{{root, 0}}
+	visited := 0
 
 	for len(queue) > 0 {
 		cur := queue[0]
@@ -186,6 +189,11 @@ func hasUsableAccessibilityTree(root *accessibility.Element, logger *zap.Logger)
 
 		if cur.el == nil {
 			continue
+		}
+
+		visited++
+		if visited > maxAccessibilityNodes {
+			return false
 		}
 
 		info, err := cur.el.Info()
@@ -219,15 +227,11 @@ func hasUsableAccessibilityTree(root *accessibility.Element, logger *zap.Logger)
 	return false
 }
 
-func markPIDEnabled(
-	pidsMu *sync.Mutex,
-	enabledPIDs map[int]struct{},
-	pid int,
-) {
-	pidsMu.Lock()
-	defer pidsMu.Unlock()
+func markPIDResult(pid int, bundleID string, ok bool) {
+	enabledPIDsMu.Lock()
+	defer enabledPIDsMu.Unlock()
 
-	enabledPIDs[pid] = struct{}{}
+	enabledPIDs[pid] = axCacheEntry{bundle: bundleID, ok: ok, at: time.Now()}
 }
 
 // ShouldEnableElectronSupport determines if the provided bundle identifier

--- a/internal/core/infra/platform/darwin/axobserver.go
+++ b/internal/core/infra/platform/darwin/axobserver.go
@@ -23,6 +23,7 @@ const (
 	AXNotifMenuOpened              uint32 = C.NeruAXNotifMenuOpened
 	AXNotifMenuClosed              uint32 = C.NeruAXNotifMenuClosed
 	AXNotifValueChanged            uint32 = C.NeruAXNotifValueChanged
+	AXNotifLoadComplete            uint32 = C.NeruAXNotifLoadComplete
 )
 
 // ObserverSink receives AX notification signals from the observer run-loop

--- a/internal/core/infra/platform/darwin/axobserver.go
+++ b/internal/core/infra/platform/darwin/axobserver.go
@@ -1,0 +1,106 @@
+//go:build darwin
+
+package darwin
+
+/*
+#include "axobserver.h"
+*/
+import "C"
+
+import "unsafe"
+
+// AX notification mask bits, mirrored from axobserver.h. Callers OR these
+// together to select which notifications an observer registers on an
+// application element.
+const (
+	AXNotifLayoutChanged           uint32 = C.NeruAXNotifLayoutChanged
+	AXNotifCreated                 uint32 = C.NeruAXNotifCreated
+	AXNotifUIElementDestroyed      uint32 = C.NeruAXNotifUIElementDestroyed
+	AXNotifWindowCreated           uint32 = C.NeruAXNotifWindowCreated
+	AXNotifWindowMoved             uint32 = C.NeruAXNotifWindowMoved
+	AXNotifWindowResized           uint32 = C.NeruAXNotifWindowResized
+	AXNotifFocusedUIElementChanged uint32 = C.NeruAXNotifFocusedUIElementChanged
+	AXNotifMenuOpened              uint32 = C.NeruAXNotifMenuOpened
+	AXNotifMenuClosed              uint32 = C.NeruAXNotifMenuClosed
+	AXNotifValueChanged            uint32 = C.NeruAXNotifValueChanged
+)
+
+// ObserverSink receives AX notification signals from the observer run-loop
+// thread. Implementations must do O(1), non-blocking work (a channel send);
+// the callback fires on the run-loop thread. notif is the notification name,
+// for debug logging.
+type ObserverSink interface {
+	HandleAXNotification(pid int, epoch uint64, notif string)
+}
+
+// observerSlot holds the process-global sink for C-exported AX callbacks, using
+// the same generation-checked slot as the other darwin bridges so a cleared or
+// replaced sink ignores in-flight callbacks.
+var observerSlot cgoSlot[ObserverSink]
+
+// SetObserverSink registers the process-global AX notification sink. Passing nil
+// clears it.
+func SetObserverSink(sink ObserverSink) {
+	observerSlot.Set(sink)
+}
+
+//export handleAXNotification
+func handleAXNotification(pid C.int, epoch C.ulonglong, notif *C.char) {
+	p := int(pid)
+	e := uint64(epoch)
+	name := C.GoString(notif)
+
+	observerSlot.withValid(func(sink ObserverSink) {
+		sink.HandleAXNotification(p, e, name)
+	})
+}
+
+// StartObserverThread starts the dedicated observer run-loop thread if it is not
+// already running, blocking until it is live. Idempotent.
+func StartObserverThread() {
+	C.NeruStartObserverThread()
+}
+
+// StopObserverThread stops and joins the observer run-loop thread. Idempotent.
+func StopObserverThread() {
+	C.NeruStopObserverThread()
+}
+
+// ObserverThreadRunning reports whether the observer run-loop thread is running.
+func ObserverThreadRunning() bool {
+	return C.NeruObserverThreadRunning() != 0
+}
+
+// SetObserverMessagingTimeout sets the accessibility messaging timeout on the
+// system-wide element (best effort; bounds synchronous AX calls process-wide).
+func SetObserverMessagingTimeout(seconds float64) {
+	C.NeruSetObserverMessagingTimeout(C.float(seconds))
+}
+
+// ArmObserver creates an AXObserver for pid registering the notifications
+// selected by mask, and returns an opaque handle (nil on failure). epoch is
+// packed into the callback refcon so stale callbacks can be rejected.
+func ArmObserver(pid int, epoch uint64, mask uint32) unsafe.Pointer {
+	return unsafe.Pointer(
+		C.NeruArmObserver(C.int(pid), C.ulonglong(epoch), C.uint32_t(mask)),
+	)
+}
+
+// DisarmObserver tears down an observer handle from ArmObserver. When live is
+// true it unregisters notifications (skip for a dead process). Safe with a nil
+// handle.
+func DisarmObserver(handle unsafe.Pointer, live bool) {
+	liveFlag := C.int(0)
+	if live {
+		liveFlag = C.int(1)
+	}
+
+	C.NeruDisarmObserver(handle, liveFlag)
+}
+
+// ObserverLiveCounts returns the created-minus-released counts of AXObserver and
+// application-element refs, for leak-balance assertions in tests.
+func ObserverLiveCounts() (observers, appElements int64) {
+	return int64(C.NeruObserverLiveObserverCount()),
+		int64(C.NeruObserverLiveAppElementCount())
+}

--- a/internal/core/infra/platform/darwin/axobserver.h
+++ b/internal/core/infra/platform/darwin/axobserver.h
@@ -1,0 +1,87 @@
+//
+//  axobserver.h
+//  Neru
+//
+//  Copyright © 2025 Neru. All rights reserved.
+//
+//  Push-based accessibility change notifications. A dedicated, lazily started
+//  CFRunLoop thread services AXObserver callbacks for a set of application
+//  processes. The Go ObserverManager owns lifecycle and calls arm/disarm from
+//  its actor goroutine, but the actual AXObserver create/register/release and
+//  run-loop source operations are marshalled onto the run-loop thread. That
+//  serializes them against the observer's own callbacks (the run loop dispatches
+//  one thing at a time), so releasing an AXObserver can never race an in-flight
+//  callback for it, and a synchronous AX registration call that hangs stalls only
+//  the observer thread, never the caller's lock.
+//
+
+#ifndef AXOBSERVER_H
+#define AXOBSERVER_H
+
+#import <Foundation/Foundation.h>
+#include <stdint.h>
+
+#pragma mark - Notification mask bits
+
+// Bit flags selecting which AX notifications an observer registers on an
+// application element. Kept in sync with the mirrored Go constants in
+// axobserver.go. Descendant elements' notifications bubble up to an observer
+// registered on the application element.
+enum {
+	NeruAXNotifLayoutChanged = 1u << 0,
+	NeruAXNotifCreated = 1u << 1,
+	NeruAXNotifUIElementDestroyed = 1u << 2,
+	NeruAXNotifWindowCreated = 1u << 3,
+	NeruAXNotifWindowMoved = 1u << 4,
+	NeruAXNotifWindowResized = 1u << 5,
+	NeruAXNotifFocusedUIElementChanged = 1u << 6,
+	NeruAXNotifMenuOpened = 1u << 7,
+	NeruAXNotifMenuClosed = 1u << 8,
+	NeruAXNotifValueChanged = 1u << 9,
+};
+
+#pragma mark - Observer run-loop thread
+
+/// Start the dedicated observer run-loop thread if it is not already running.
+/// Blocks until the run loop is live so a subsequent NeruArmObserver can attach
+/// its source. Idempotent.
+void NeruStartObserverThread(void);
+
+/// Stop the observer run-loop thread and join it. Idempotent; safe when the
+/// thread is not running.
+void NeruStopObserverThread(void);
+
+/// Report whether the observer run-loop thread is currently running. Test hook.
+int NeruObserverThreadRunning(void);
+
+#pragma mark - Arm / disarm
+
+/// Create an AXObserver for pid, register the notifications selected by mask on
+/// the application element, and attach its run-loop source to the observer
+/// thread. refcon carries (epoch << 32 | pid) so the callback can reject stale
+/// events. Returns an opaque handle, or NULL if the application element could
+/// not be created or no notification could be registered. The observer thread
+/// must be running (call NeruStartObserverThread first).
+void *NeruArmObserver(int pid, unsigned long long epoch, uint32_t mask);
+
+/// Remove the observer's source, unregister notifications (only when live != 0,
+/// to avoid IPC to a dead process), release the observer and application
+/// element, and free the handle. Safe to call with a NULL handle.
+void NeruDisarmObserver(void *handle, int live);
+
+#pragma mark - Messaging timeout
+
+/// Set the accessibility messaging timeout on the system-wide element, bounding
+/// synchronous AX calls process-wide (best effort; see
+/// AXUIElementSetMessagingTimeout).
+void NeruSetObserverMessagingTimeout(float seconds);
+
+#pragma mark - Leak instrumentation (test hooks)
+
+/// Live count of created-minus-released AXObserver refs.
+long NeruObserverLiveObserverCount(void);
+
+/// Live count of created-minus-released application AXUIElement refs.
+long NeruObserverLiveAppElementCount(void);
+
+#endif /* AXOBSERVER_H */

--- a/internal/core/infra/platform/darwin/axobserver.h
+++ b/internal/core/infra/platform/darwin/axobserver.h
@@ -38,6 +38,7 @@ enum {
 	NeruAXNotifMenuOpened = 1u << 7,
 	NeruAXNotifMenuClosed = 1u << 8,
 	NeruAXNotifValueChanged = 1u << 9,
+	NeruAXNotifLoadComplete = 1u << 10,
 };
 
 #pragma mark - Observer run-loop thread

--- a/internal/core/infra/platform/darwin/axobserver_darwin.m
+++ b/internal/core/infra/platform/darwin/axobserver_darwin.m
@@ -1,0 +1,360 @@
+//
+//  axobserver_darwin.m
+//  Neru
+//
+//  Copyright © 2025 Neru. All rights reserved.
+//
+
+#import "axobserver.h"
+
+#import <ApplicationServices/ApplicationServices.h>
+#import <Cocoa/Cocoa.h>
+
+#include <dispatch/dispatch.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdlib.h>
+
+#pragma mark - Go bridge
+
+// Implemented in axobserver.go. Called on the observer run-loop thread; must do
+// O(1) work only (no AX calls, no blocking). notif is the notification name, for
+// debug logging.
+extern void handleAXNotification(int pid, unsigned long long epoch, const char *notif);
+
+#pragma mark - Handle
+
+// One armed observer. notifs holds the notification name constants that were
+// successfully registered, so a live disarm can unregister exactly those. The
+// kAX*Notification values are process-owned constants and are not retained.
+typedef struct {
+	AXObserverRef observer;
+	AXUIElementRef appElement;
+	CFStringRef notifs[10];
+	int notifCount;
+} NeruObserverHandle;
+
+#pragma mark - Leak counters
+
+static _Atomic long gLiveObservers = 0;
+static _Atomic long gLiveAppElements = 0;
+
+long NeruObserverLiveObserverCount(void) {
+	return atomic_load(&gLiveObservers);
+}
+
+long NeruObserverLiveAppElementCount(void) {
+	return atomic_load(&gLiveAppElements);
+}
+
+#pragma mark - Run-loop thread
+
+static pthread_t gObserverThread;
+static CFRunLoopRef gObserverRunLoop = NULL;      // retained while running
+static CFRunLoopSourceRef gKeepAlive = NULL;      // owned by the observer thread
+static CFRunLoopObserverRef gEntryObserver = NULL;  // signals gReady on loop entry
+static dispatch_semaphore_t gReady = NULL;
+static int gRunning = 0;
+
+// runOnObserverLoop runs block on the observer run-loop thread and waits for it
+// to finish. All AXObserver create/register/release and run-loop source
+// operations go through here, so they are serialized against the observer's own
+// callbacks (the run loop dispatches one thing at a time). This is what makes it
+// safe to CFRelease an AXObserver: a callback for it can never be running
+// concurrently. If the loop is not up yet, the block runs inline (the caller is
+// the actor goroutine, which starts the thread before arming).
+static void runOnObserverLoop(void (^block)(void)) {
+	if (gObserverRunLoop == NULL) {
+		block();
+
+		return;
+	}
+
+	if (CFRunLoopGetCurrent() == gObserverRunLoop) {
+		block();
+
+		return;
+	}
+
+	dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+	CFRunLoopPerformBlock(gObserverRunLoop, kCFRunLoopDefaultMode, ^{
+		block();
+		dispatch_semaphore_signal(sem);
+	});
+	CFRunLoopWakeUp(gObserverRunLoop);
+	dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+}
+
+// No-op perform for the keep-alive source. Its only job is to keep the run loop
+// from exiting when no observer sources are attached.
+static void keepAlivePerform(void *info) {
+	(void)info;
+}
+
+// Fires once, when the run loop is actually entered, so NeruStartObserverThread
+// only returns after the loop is genuinely running.
+static void observerLoopEntered(
+    CFRunLoopObserverRef observer, CFRunLoopActivity activity, void *info) {
+	(void)observer;
+	(void)activity;
+	(void)info;
+	dispatch_semaphore_signal(gReady);
+}
+
+static void *observerThreadMain(void *arg) {
+	(void)arg;
+	@autoreleasepool {
+		CFRunLoopRef rl = CFRunLoopGetCurrent();
+
+		CFRunLoopSourceContext ctx;
+		memset(&ctx, 0, sizeof(ctx));
+		ctx.perform = keepAlivePerform;
+		gKeepAlive = CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &ctx);
+		CFRunLoopAddSource(rl, gKeepAlive, kCFRunLoopDefaultMode);
+
+		// Publish the run loop (retained) so other threads can add/remove sources
+		// and stop it. CFRunLoopGetCurrent returns a non-owned reference.
+		gObserverRunLoop = (CFRunLoopRef)CFRetain(rl);
+
+		// Signal readiness from a one-shot entry observer, so the waiter is
+		// released only once the loop is actually running.
+		gEntryObserver = CFRunLoopObserverCreate(
+		    kCFAllocatorDefault, kCFRunLoopEntry, false, 0, observerLoopEntered, NULL);
+		CFRunLoopAddObserver(rl, gEntryObserver, kCFRunLoopDefaultMode);
+
+		CFRunLoopRun();
+
+		// Stopped via CFRunLoopStop. Tear down on this thread.
+		CFRunLoopRemoveObserver(rl, gEntryObserver, kCFRunLoopDefaultMode);
+		CFRelease(gEntryObserver);
+		gEntryObserver = NULL;
+		CFRunLoopRemoveSource(rl, gKeepAlive, kCFRunLoopDefaultMode);
+		CFRelease(gKeepAlive);
+		gKeepAlive = NULL;
+	}
+
+	return NULL;
+}
+
+void NeruStartObserverThread(void) {
+	if (gRunning) {
+		return;
+	}
+
+	gReady = dispatch_semaphore_create(0);
+	gRunning = 1;
+
+	int rc = pthread_create(&gObserverThread, NULL, observerThreadMain, NULL);
+	if (rc != 0) {
+		// The thread never starts, so gReady would never be signaled. Leave the
+		// subsystem stopped so NeruArmObserver fails cleanly instead of the caller
+		// blocking forever on the wait below.
+		gRunning = 0;
+		gReady = NULL;
+
+		return;
+	}
+
+	// Wait until the run loop is live and published before returning, so the
+	// first NeruArmObserver has a valid run loop to attach to.
+	dispatch_semaphore_wait(gReady, DISPATCH_TIME_FOREVER);
+}
+
+void NeruStopObserverThread(void) {
+	if (!gRunning) {
+		return;
+	}
+
+	// CFRunLoopStop / WakeUp are thread-safe.
+	CFRunLoopStop(gObserverRunLoop);
+	CFRunLoopWakeUp(gObserverRunLoop);
+
+	pthread_join(gObserverThread, NULL);
+
+	CFRelease(gObserverRunLoop);
+	gObserverRunLoop = NULL;
+	gReady = NULL;
+	gRunning = 0;
+}
+
+int NeruObserverThreadRunning(void) {
+	return gRunning;
+}
+
+#pragma mark - Callback
+
+static void observerCallback(
+    AXObserverRef observer,
+    AXUIElementRef element,
+    CFStringRef notification,
+    CFDictionaryRef info,
+    void *refcon) {
+	(void)observer;
+	(void)element;
+	(void)info;
+
+	uint64_t packed = (uint64_t)(uintptr_t)refcon;
+	int pid = (int)(uint32_t)(packed & 0xFFFFFFFFu);
+	unsigned long long epoch = (unsigned long long)(packed >> 32);
+
+	char nameBuf[128];
+	const char *name = "";
+	if (notification != NULL &&
+	    CFStringGetCString(notification, nameBuf, sizeof(nameBuf), kCFStringEncodingUTF8)) {
+		name = nameBuf;
+	}
+
+	handleAXNotification(pid, epoch, name);
+}
+
+#pragma mark - Arm / disarm
+
+// Maps a mask bit to its notification name constant.
+typedef struct {
+	uint32_t bit;
+	CFStringRef name;
+} NeruNotifEntry;
+
+static const NeruNotifEntry *notifTable(int *count) {
+	static NeruNotifEntry table[10];
+	table[0] = (NeruNotifEntry){NeruAXNotifLayoutChanged, kAXLayoutChangedNotification};
+	table[1] = (NeruNotifEntry){NeruAXNotifCreated, kAXCreatedNotification};
+	table[2] = (NeruNotifEntry){NeruAXNotifUIElementDestroyed, kAXUIElementDestroyedNotification};
+	table[3] = (NeruNotifEntry){NeruAXNotifWindowCreated, kAXWindowCreatedNotification};
+	table[4] = (NeruNotifEntry){NeruAXNotifWindowMoved, kAXWindowMovedNotification};
+	table[5] = (NeruNotifEntry){NeruAXNotifWindowResized, kAXWindowResizedNotification};
+	table[6] =
+	    (NeruNotifEntry){NeruAXNotifFocusedUIElementChanged, kAXFocusedUIElementChangedNotification};
+	table[7] = (NeruNotifEntry){NeruAXNotifMenuOpened, kAXMenuOpenedNotification};
+	table[8] = (NeruNotifEntry){NeruAXNotifMenuClosed, kAXMenuClosedNotification};
+	table[9] = (NeruNotifEntry){NeruAXNotifValueChanged, kAXValueChangedNotification};
+	*count = 10;
+
+	return table;
+}
+
+// armOnLoop runs on the observer run-loop thread (via runOnObserverLoop). It is
+// serialized against the observer callbacks, so the synchronous AX registration
+// calls here cannot race a callback.
+static NeruObserverHandle *armOnLoop(int pid, unsigned long long epoch, uint32_t mask) {
+	AXUIElementRef appEl = AXUIElementCreateApplication(pid);
+	if (appEl == NULL) {
+		return NULL;
+	}
+	atomic_fetch_add(&gLiveAppElements, 1);
+
+	AXObserverRef obs = NULL;
+	AXError createErr = AXObserverCreateWithInfoCallback(pid, observerCallback, &obs);
+	if (createErr != kAXErrorSuccess || obs == NULL) {
+		CFRelease(appEl);
+		atomic_fetch_sub(&gLiveAppElements, 1);
+
+		return NULL;
+	}
+	atomic_fetch_add(&gLiveObservers, 1);
+
+	NeruObserverHandle *handle = calloc(1, sizeof(NeruObserverHandle));
+	handle->observer = obs;
+	handle->appElement = appEl;
+
+	void *refcon = (void *)(uintptr_t)((epoch << 32) | (uint64_t)(uint32_t)pid);
+
+	int tableCount = 0;
+	const NeruNotifEntry *table = notifTable(&tableCount);
+
+	int armed = 0;
+	int fatal = 0;
+	for (int i = 0; i < tableCount; i++) {
+		if ((mask & table[i].bit) == 0) {
+			continue;
+		}
+
+		AXError addErr = AXObserverAddNotification(obs, appEl, table[i].name, refcon);
+		if (addErr == kAXErrorSuccess || addErr == kAXErrorNotificationAlreadyRegistered) {
+			handle->notifs[handle->notifCount++] = table[i].name;
+			armed++;
+		} else if (addErr == kAXErrorInvalidUIElement || addErr == kAXErrorCannotComplete) {
+			// The app is gone or wedged. Abort the whole handle rather than
+			// registering a partial, unreliable set.
+			fatal = 1;
+			break;
+		}
+		// kAXErrorNotificationUnsupported and any other soft failure: skip this
+		// notification and continue with the rest.
+	}
+
+	if (fatal || armed == 0) {
+		CFRelease(obs);
+		atomic_fetch_sub(&gLiveObservers, 1);
+		CFRelease(appEl);
+		atomic_fetch_sub(&gLiveAppElements, 1);
+		free(handle);
+
+		return NULL;
+	}
+
+	// Already on the run-loop thread, so the source is serviced on the next
+	// iteration without an explicit wake.
+	CFRunLoopSourceRef src = AXObserverGetRunLoopSource(obs);
+	CFRunLoopAddSource(gObserverRunLoop, src, kCFRunLoopDefaultMode);
+
+	return handle;
+}
+
+void *NeruArmObserver(int pid, unsigned long long epoch, uint32_t mask) {
+	if (!gRunning || gObserverRunLoop == NULL) {
+		return NULL;
+	}
+
+	__block NeruObserverHandle *result = NULL;
+	runOnObserverLoop(^{
+		result = armOnLoop(pid, epoch, mask);
+	});
+
+	return result;
+}
+
+// disarmOnLoop runs on the observer run-loop thread. Because it is serialized
+// against callbacks, releasing the observer here cannot race an in-flight
+// callback for it.
+static void disarmOnLoop(NeruObserverHandle *h, int live) {
+	CFRunLoopSourceRef src = AXObserverGetRunLoopSource(h->observer);
+	if (gObserverRunLoop != NULL && src != NULL) {
+		CFRunLoopRemoveSource(gObserverRunLoop, src, kCFRunLoopDefaultMode);
+	}
+
+	// For a live app, unregister exactly the notifications we registered. For a
+	// dead/wedged app (live == 0) skip this to avoid a blocking IPC to a gone
+	// process; CFRelease of the observer drops the registration.
+	if (live) {
+		for (int i = 0; i < h->notifCount; i++) {
+			AXObserverRemoveNotification(h->observer, h->appElement, h->notifs[i]);
+		}
+	}
+
+	CFRelease(h->observer);
+	atomic_fetch_sub(&gLiveObservers, 1);
+	CFRelease(h->appElement);
+	atomic_fetch_sub(&gLiveAppElements, 1);
+	free(h);
+}
+
+void NeruDisarmObserver(void *handle, int live) {
+	if (handle == NULL) {
+		return;
+	}
+
+	runOnObserverLoop(^{
+		disarmOnLoop((NeruObserverHandle *)handle, live);
+	});
+}
+
+#pragma mark - Messaging timeout
+
+void NeruSetObserverMessagingTimeout(float seconds) {
+	AXUIElementRef systemWide = AXUIElementCreateSystemWide();
+	if (systemWide != NULL) {
+		AXUIElementSetMessagingTimeout(systemWide, seconds);
+		CFRelease(systemWide);
+	}
+}

--- a/internal/core/infra/platform/darwin/axobserver_darwin.m
+++ b/internal/core/infra/platform/darwin/axobserver_darwin.m
@@ -30,7 +30,7 @@ extern void handleAXNotification(int pid, unsigned long long epoch, const char *
 typedef struct {
 	AXObserverRef observer;
 	AXUIElementRef appElement;
-	CFStringRef notifs[10];
+	CFStringRef notifs[16];
 	int notifCount;
 } NeruObserverHandle;
 
@@ -216,7 +216,7 @@ typedef struct {
 } NeruNotifEntry;
 
 static const NeruNotifEntry *notifTable(int *count) {
-	static NeruNotifEntry table[10];
+	static NeruNotifEntry table[16];
 	table[0] = (NeruNotifEntry){NeruAXNotifLayoutChanged, kAXLayoutChangedNotification};
 	table[1] = (NeruNotifEntry){NeruAXNotifCreated, kAXCreatedNotification};
 	table[2] = (NeruNotifEntry){NeruAXNotifUIElementDestroyed, kAXUIElementDestroyedNotification};
@@ -228,7 +228,11 @@ static const NeruNotifEntry *notifTable(int *count) {
 	table[7] = (NeruNotifEntry){NeruAXNotifMenuOpened, kAXMenuOpenedNotification};
 	table[8] = (NeruNotifEntry){NeruAXNotifMenuClosed, kAXMenuClosedNotification};
 	table[9] = (NeruNotifEntry){NeruAXNotifValueChanged, kAXValueChangedNotification};
-	*count = 10;
+	// AXLoadComplete has no public kAX* constant; the notification name is the
+	// string below (NSAccessibilityLoadCompleteNotification). Web areas post it
+	// when a page finishes loading, which is the key signal for browser navigation.
+	table[10] = (NeruNotifEntry){NeruAXNotifLoadComplete, CFSTR("AXLoadComplete")};
+	*count = 11;
 
 	return table;
 }

--- a/internal/core/ports/accessibility.go
+++ b/internal/core/ports/accessibility.go
@@ -43,6 +43,12 @@ type ApplicationInfo interface {
 	// configured exclusion list. The identifier format is platform-dependent
 	// (see FocusedAppBundleID).
 	IsAppExcluded(ctx context.Context, bundleID string) bool
+
+	// PIDForBundleID returns the process id of a running application identified
+	// by bundleID, or an error if it is not running. Used to resolve the fixed
+	// system processes (dock, Notification Center, etc.) that hint sources scan,
+	// so a push observer can attach to exactly those processes.
+	PIDForBundleID(ctx context.Context, bundleID string) (int, error)
 }
 
 // AccessibilityPort defines the interface for interacting with the platform

--- a/internal/core/ports/mocks/accessibility.go
+++ b/internal/core/ports/mocks/accessibility.go
@@ -21,6 +21,7 @@ type MockAccessibilityPort struct {
 	ScrollFunc               func(context.Context, int, int) error
 	FocusedAppBundleIDFunc   func(context.Context) (string, error)
 	IsAppExcludedFunc        func(context.Context, string) bool
+	PIDForBundleIDFunc       func(context.Context, string) (int, error)
 }
 
 // Health implements ports.AccessibilityPort.
@@ -96,6 +97,15 @@ func (m *MockAccessibilityPort) IsAppExcluded(ctx context.Context, bundleID stri
 	}
 
 	return false
+}
+
+// PIDForBundleID implements ports.AccessibilityPort.
+func (m *MockAccessibilityPort) PIDForBundleID(ctx context.Context, bundleID string) (int, error) {
+	if m.PIDForBundleIDFunc != nil {
+		return m.PIDForBundleIDFunc(ctx, bundleID)
+	}
+
+	return 0, nil
 }
 
 // Ensure MockAccessibilityPort implements ports.AccessibilityPort.

--- a/internal/core/ports/observe.go
+++ b/internal/core/ports/observe.go
@@ -1,0 +1,39 @@
+package ports
+
+// ObservationSource identifies which hint source a process was resolved from.
+// It selects the set of accessibility notifications worth observing on that
+// process (e.g. a menubar target only cares about menu open/close, while a
+// window cares about layout and window geometry).
+type ObservationSource int
+
+const (
+	// ObservationFrontWindow is the frontmost application's focused window.
+	ObservationFrontWindow ObservationSource = iota
+	// ObservationAppMenubar is the frontmost application's menu bar (same pid as
+	// the front window).
+	ObservationAppMenubar
+	// ObservationAdditionalMenubar is a user-configured menu-extra / status-item
+	// process.
+	ObservationAdditionalMenubar
+	// ObservationNotificationCenter is com.apple.notificationcenterui.
+	ObservationNotificationCenter
+	// ObservationDock is com.apple.dock.
+	ObservationDock
+	// ObservationStageManager is com.apple.WindowManager.
+	ObservationStageManager
+	// ObservationPIP is com.apple.PIPAgent.
+	ObservationPIP
+	// ObservationScreenCapture is com.apple.screencaptureui.
+	ObservationScreenCapture
+)
+
+// ObservationTarget is one process the hint scan resolved, to be watched for
+// accessibility changes while hints mode is active. Only the pid is needed to
+// register an observer (it attaches to the application element, whose descendant
+// notifications propagate up); BundleID guards against a recycled pid attaching
+// to the wrong process, and Source selects the notification set.
+type ObservationTarget struct {
+	PID      int
+	BundleID string
+	Source   ObservationSource
+}


### PR DESCRIPTION
Disclaimer: This code was written by Claude. I steered it toward a solution I thought sensible, and I am opening it as a proof of concept, not a merge candidate.

## Status

Do not merge. This is a still-flaky proof of concept for push-based hint auto-refresh, opened to share the approach and gather feedback against #1002. It's a LOT of code. It should probably be done with less code. It is opt-in and off by default, and there is a known miss rate (see Known issues).

## Rationale

neru scans the accessibility tree once when hints mode is entered and only re-scans on a few discrete events. If a window's contents change after that scan (a page finishes loading, a banner appears, a menu opens, an Electron view re-renders), the on-screen hints go stale until the user manually refreshes. macOS exposes a push API for exactly this, `AXObserver`, which delivers a callback when an app posts an accessibility notification, with no polling.

This PR watches the processes a hint scan resolved and re-runs the scan when they actually change, coalesced so bursts collapse into one refresh. The paramount design constraint is resource safety: zero background cost when hints mode is inactive, and no leaked, hanging, or doubled observers or threads.

## How it works

- A dedicated, lazily started `CFRunLoop` thread services `AXObserver` callbacks. It is created on the first arm and stopped and joined on the last disarm, so an idle neru has no observer thread and no background cost.
- `AXObserver` create, register, and release, plus run-loop source add/remove, all run on that one thread. That serializes them against the observer's own callbacks, so releasing an observer can never race an in-flight callback, and a synchronous AX registration that hangs stalls only the observer thread, never a keystroke or shutdown.
- The observer callback does integer-only work (it rejects stale-session events by a packed epoch, then signals a coordinator) and retains nothing, so it is O(1).
- A Go `Manager` owns every observer as an actor: all mutations are commands processed on one goroutine, so `Reconcile`, `DisarmAll`, app-terminate, and `Close` can arrive from different threads without touching the observer map directly.
- Observers are bound to hints mode. Leaving hints mode disarms everything at a single site, and a refresh stays in hints mode so it re-targets across a front-app switch without tearing the thread down.
- The notification set is per-source: the front window watches structure and geometry, menu targets watch only menu and element lifecycle, Notification Center watches window create/destroy, and so on. `kAXValueChanged` is off by default (the noisiest one).

## Changes

- New native bridge `internal/core/infra/platform/darwin/axobserver.{h,m,go}`.
- New actor package `internal/core/infra/axobserver` (manager, per-source masks, platform shim).
- Observation targets emitted by the actual scan (`internal/core/infra/accessibility`, `internal/core/ports`), so coverage tracks the existing `include_*_hints` settings with no per-source special-casing, and vision-strategy windows never emit a target.
- A refresh coordinator that debounces the observer and modifier-passthrough feeds into one call and defers a refresh while the user is mid-typing a hint label.
- Stable hint labels: a domain element now carries a native-hash identity, and a label-reuse pass keeps a persisting element's label across a refresh (prefix-free preserved) so labels do not reshuffle on every refresh.
- Web/Electron accessibility enablement reworked from a whitelist to a listless model (see below), gated by a config safeguard.
- Config surface under `[hints.auto_refresh]` and `[hints.additional_ax_support]`.

## Web/Electron accessibility enablement

An Electron or Chromium app exposes no accessibility tree, and posts no notifications, until an assistive tool sets an attribute on it. There are two attributes with very different risk:

- `AXManualAccessibility` wakes Electron. It is a safe no-op on non-Electron apps and has no window side effect.
- `AXEnhancedUserInterface` wakes Chromium browsers (Chrome, Arc) and Firefox. It is the attribute known to make some apps relayout or move their windows, and it adds real overhead in the target app.

The old code only tried `AXManualAccessibility` on a hardcoded Electron whitelist and otherwise went straight to the enhanced attribute. This PR attempts `AXManualAccessibility` on every activated app except neru itself, so Electron apps work without a whitelist, while escalation to `AXEnhancedUserInterface` stays gated behind a browser signal so it is never sprayed on native apps (which have no web area and would just get relayouted for nothing). The gate is `additional_ax_support.escalate_enhanced` (whitelist | off | all).

The whole additional-accessibility path is behind `additional_ax_support.enable`, off by default, because waking a browser tree is intrusive by nature (the enhanced attribute's window moves). Native apps need none of this and auto-refresh works on them out of the box.

## Known issues

- Roughly one refresh in five does not catch fresh hints. Diagnosis: reading the tree makes some apps churn their own elements, which fed back into an infinite refresh loop (visible as continuous flicker after the first selection). The current fix suppresses observer refreshes during neru's own scan plus a short margin. That stops the flicker, but it is a lossy time window: a real change whose notification lands inside it is dropped, so the settled state is sometimes never re-scanned. Adding delay does not help, because the missed notification is discarded regardless of timing. The proper fix is a post-scan content fingerprint (element count plus a bounding-box hash) so self-induced churn can be distinguished from a real change without a lossy window, at which point the suppression window can be removed. Not implemented here.
- Web and Electron auto-refresh is best-effort. It depends on the app posting AX notifications, which Chromium and WebKit do inconsistently, and often not at all on scroll.
- Every refresh re-scans all sources; the observer only fixes detection, not scan scope.
- Under vision strategy the frontmost window does not auto-refresh, because AX gives no push signal for vision-detected pixels. Only AX-backed sources (menubar, Notification Center) refresh under that strategy.

## Testing

Manager unit tests (self-exclusion, recycled-pid, idempotent double-disarm and double-close, stale-epoch drop, the generation scheme that voids a reconcile queued behind a disarm), all goleak-clean with a fake platform. A native darwin soak test runs many Reconcile/DisarmAll cycles and asserts balanced CFRelease counts and no run-loop thread at idle. Label-reuse tests assert the carried set stays prefix-free. Field-tested by hand on Electron (Claude), the Settings app, and Arc.
