### PR TITLE
feat: add `app_configs` for global hotkey overrides

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -24,6 +24,7 @@ Neru uses TOML for configuration. No config file is required — Neru works out 
 - [Mouse Action Indicator](#mouse_action_indicator)
 - [Mode Indicator](#mode_indicator)
 - [Sticky Modifiers](#sticky_modifiers)
+- [Per-App Global Hotkey Overrides](#per-app-global-hotkey-overrides)
 - [Smooth Cursor](#smooth_cursor)
 - [Smooth Scroll](#smooth_scroll)
 - [Held Repeat](#held_repeat)
@@ -184,6 +185,31 @@ When a mode is disabled (`enabled = false`), its default launcher hotkey is remo
 
 **Mode toggling:** Append `--toggle` to turn a hotkey into a toggle — activates the mode on first press, exits to idle on the second. Works with any mode: `"Ctrl+F" = "grid --toggle"`.
 
+#### Per-App Global Hotkey Overrides
+
+`[[app_configs]]` overrides `[hotkeys]` bindings for specific apps. Use this when you want different launcher hotkeys depending on which app is focused.
+
+```toml
+[hotkeys]
+"Cmd+Shift+Space" = "hints"
+
+[[app_configs]]
+bundle_id = "com.apple.Terminal"
+hotkeys = {
+    "Cmd+Space" = "hints",
+    "Cmd+Shift+Space" = "__disabled__"
+}
+
+[[app_configs]]
+bundle_id = "com.apple.Safari"
+hotkeys = {
+    "Cmd+Shift+F" = "hints",
+    "Cmd+Shift+Space" = "__disabled__"
+}
+```
+
+The same [merging rules](#merging-behavior) apply: app hotkeys merge on top of the base `[hotkeys]` bindings, and `__disabled__` removes an inherited binding. When no `[[app_configs]]` entry matches the focused app, the base `[hotkeys]` bindings are used as-is.
+
 ### Per-Mode Hotkeys
 
 Each mode can define hotkeys active only while that mode is running. Follows the same [merging rules](#merging-behavior) as global hotkeys.
@@ -203,9 +229,23 @@ Multi-key alphabetic sequences (e.g. `gg`) use a 500ms timeout.
 
 #### Per-App Hotkey Overrides
 
-`[[<mode>.app_configs]]` overrides `<mode>.hotkeys` for specific apps. Supported for `hints`, `grid`, `recursive_grid`, and `scroll`. App hotkeys merge on top of mode hotkeys; `__disabled__` removes an inherited binding.
+Both global and per-mode hotkeys support per-app overrides via `[[app_configs]]` and `[[<mode>.app_configs]]`.
+
+- Global: `[[app_configs]]` overrides `[hotkeys]` bindings for specific apps
+- Per-mode: `[[<mode>.app_configs]]` overrides `<mode>.hotkeys` for specific apps
+
+Supported modes for per-mode overrides are `hints`, `grid`, `recursive_grid`, and `scroll`. App hotkeys merge on top of base hotkeys; `__disabled__` removes an inherited binding.
 
 ```toml
+# Per-app global hotkey overrides (root-level)
+[[app_configs]]
+bundle_id = "com.apple.Terminal"
+hotkeys = {
+    "Cmd+Space" = "hints",
+    "Cmd+Shift+Space" = "__disabled__"
+}
+
+# Per-app mode hotkey overrides
 [[hints.app_configs]]
 bundle_id = "com.brave.Browser"
 hotkeys = {
@@ -214,10 +254,18 @@ hotkeys = {
 }
 ```
 
-**Priority order** when a key is pressed inside a mode:
+**Priority order** when a key is pressed while Neru is running:
+
+| Context | Resolution |
+|---|---|
+| **Idle (no mode active)** | `[hotkeys]` bindings merged with per-app `[[app_configs]]` overrides for the focused app |
+| **Inside a mode** | `[<mode>.hotkeys]` merged with per-app `[[<mode>.app_configs]]` overrides, checked before the mode's built-in keys |
+| **Global hotkey conflicts with mode hotkey** | Mode hotkey override wins (e.g., a global `Cmd+Shift+F = "hints"` launcher is replaced by `[hints.hotkeys]` `"Cmd+Shift+F" = "recursive_grid"` while hints mode is active) |
+
+Inside a mode, the dispatch order is:
 
 1. Modifier toggle
-2. `<mode>.hotkeys` + per-app overrides
+2. `<mode>.hotkeys` + per-app overrides  
 3. Mode built-in keys (hint/grid character input)
 
 ### Action Reference

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -82,6 +82,7 @@ func (a *App) restoreHotkeysAfterFailedReload() {
 
 		a.registerHotkeys(bundleID)
 		a.appState.SetHotkeysRegistered(true)
+		a.currentHotkeyBundleID = bundleID
 		a.logger.Debug("Hotkeys restored after failed config reload")
 	}
 }

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -80,12 +80,11 @@ func (a *App) restoreHotkeysAfterFailedReload() {
 	defer a.hotkeyRegistrationMu.Unlock()
 
 	if a.appState.IsEnabled() && !a.appState.HotkeysRegistered() {
-		// Use "" to register base bindings without app override. The next
-		// focus-change event will re-register with the correct app-specific
-		// bindings if any are configured.
-		a.registerHotkeys("")
+		// Restore with the previously tracked bundle ID so per-app
+		// [[app_configs]] overrides are preserved without re-querying
+		// the focused app (which can fail during alert dialog focus).
+		a.registerHotkeys(a.currentHotkeyBundleID)
 		a.appState.SetHotkeysRegistered(true)
-		a.currentHotkeyBundleID = ""
 		a.logger.Debug("Hotkeys restored after failed config reload")
 	}
 }

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -63,6 +63,19 @@ func (a *App) applyAppSpecificConfigUpdates(loadResult *config.LoadResult) {
 func (a *App) reconfigureAfterUpdate(loadResult *config.LoadResult) {
 	a.updateConfigSnapshot(loadResult)
 	a.reconfigureRuntimeFromConfig(loadResult.Config)
+
+	// An activation refresh between prepareForConfigUpdate and here may
+	// have re-registered with the old config for the current bundle,
+	// causing refreshHotkeysForAppOrCurrent to skip because the bundle
+	// hasn't changed.  Force clean registration with the new config.
+	a.hotkeyRegistrationMu.Lock()
+	if a.appState.HotkeysRegistered() {
+		a.stopAllHotkeyRepeats()
+		a.hotkeyManager.UnregisterAll()
+		a.appState.SetHotkeysRegistered(false)
+	}
+	a.hotkeyRegistrationMu.Unlock()
+
 	a.refreshHotkeysForAppOrCurrent("")
 }
 

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -80,8 +80,12 @@ func (a *App) restoreHotkeysAfterFailedReload() {
 	defer a.hotkeyRegistrationMu.Unlock()
 
 	if a.appState.IsEnabled() && !a.appState.HotkeysRegistered() {
-		a.registerHotkeys()
+		// Use "" to register base bindings without app override. The next
+		// focus-change event will re-register with the correct app-specific
+		// bindings if any are configured.
+		a.registerHotkeys("")
 		a.appState.SetHotkeysRegistered(true)
+		a.currentHotkeyBundleID = ""
 		a.logger.Debug("Hotkeys restored after failed config reload")
 	}
 }

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -67,23 +67,20 @@ func (a *App) reconfigureAfterUpdate(loadResult *config.LoadResult) {
 }
 
 func (a *App) restoreHotkeysAfterFailedReload() {
-	// Restore hotkeys with the current (unchanged) config so the app
-	// does not remain in a degraded state after a failed reload.
-	// Use registerHotkeys directly instead of refreshHotkeysForAppOrCurrent
-	// because the latter depends on FocusedAppBundleID which can fail,
-	// leaving the app without hotkeys.
-	//
-	// Guard with HotkeysRegistered() because the blocking native alert
-	// shown by ReloadWithAppContext can trigger a focus-change notification,
-	// which may already have re-registered hotkeys on another path.
 	a.hotkeyRegistrationMu.Lock()
 	defer a.hotkeyRegistrationMu.Unlock()
 
 	if a.appState.IsEnabled() && !a.appState.HotkeysRegistered() {
-		// Restore with the previously tracked bundle ID so per-app
-		// [[app_configs]] overrides are preserved without re-querying
-		// the focused app (which can fail during alert dialog focus).
-		a.registerHotkeys(a.currentHotkeyBundleID)
+		// Query the currently focused app so we register the right
+		// [[app_configs]] overrides.  Focus can change while the
+		// blocking reload-alert dialog is up, making the cached
+		// currentHotkeyBundleID stale.
+		bundleID, err := a.actionService.FocusedAppBundleID(a.ctx)
+		if err != nil {
+			bundleID = ""
+		}
+
+		a.registerHotkeys(bundleID)
 		a.appState.SetHotkeysRegistered(true)
 		a.logger.Debug("Hotkeys restored after failed config reload")
 	}

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -102,4 +102,9 @@ type App struct {
 
 	// IPC Controller
 	ipcController *IPCController
+
+	// currentHotkeyBundleID tracks which app's global hotkey bindings are
+	// currently registered. Used by refreshHotkeysForAppOrCurrent to avoid
+	// unnecessary re-registration on focus changes to the same app.
+	currentHotkeyBundleID string
 }

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -45,11 +45,18 @@ func actionsReferenceDisabledMode(actions []string, cfg *config.Config) bool {
 	return false
 }
 
-// registerHotkeys registers all global hotkeys defined in the configuration.
-func (a *App) registerHotkeys() {
+// registerHotkeys registers global hotkeys for the specified app bundle ID.
+// When bundleID is non-empty and per-app hotkey overrides are configured, the
+// app-specific bindings are used instead of the default [hotkeys] bindings.
+func (a *App) registerHotkeys(bundleID string) {
 	cfg := a.configSnapshot()
 
-	for key, actions := range cfg.Hotkeys.Bindings {
+	bindings := cfg.Hotkeys.Bindings
+	if bundleID != "" && cfg.HasGlobalAppHotkeyOverrides() {
+		bindings = cfg.GlobalHotkeysForApp(bundleID)
+	}
+
+	for key, actions := range bindings {
 		trimmedKey := strings.TrimSpace(key)
 
 		if trimmedKey == "" || len(actions) == 0 {
@@ -545,8 +552,20 @@ func (a *App) refreshHotkeysForAppOrCurrent(bundleID string) {
 	}
 
 	if !a.appState.HotkeysRegistered() {
-		a.registerHotkeys()
+		a.registerHotkeys(bundleID)
 		a.appState.SetHotkeysRegistered(true)
-		a.logger.Debug("Hotkeys registered")
+		a.logger.Debug("Hotkeys registered",
+			zap.String("bundle_id", bundleID))
+	} else if bundleID != a.currentHotkeyBundleID && cfg.HasGlobalAppHotkeyOverrides() {
+		// Focus changed to a different app with possibly different hotkey
+		// bindings. Re-register with the new app's bindings.
+		a.stopAllHotkeyRepeats()
+		a.hotkeyManager.UnregisterAll()
+		a.registerHotkeys(bundleID)
+		a.logger.Debug("Hotkeys re-registered for app",
+			zap.String("bundle_id", bundleID))
 	}
+
+	// Track which bundle ID's bindings are currently registered.
+	a.currentHotkeyBundleID = bundleID
 }

--- a/internal/app/hotkeys_dispatch_test.go
+++ b/internal/app/hotkeys_dispatch_test.go
@@ -231,7 +231,7 @@ func TestRegisterHotkeysUsesReleasePathWhenSupported(t *testing.T) {
 	fake := newFakeReleaseHotkeyManager()
 	app := newDispatchTestApp(t, cfg, fake)
 
-	app.registerHotkeys()
+	app.registerHotkeys("")
 
 	for rawKey := range cfg.Hotkeys.Bindings {
 		key := config.CanonicalHotkeyForPlatform(rawKey)
@@ -271,7 +271,7 @@ func TestDispatchModeAwareHeldHotkey_RepeatVsOnce(t *testing.T) {
 
 	fake := newFakeReleaseHotkeyManager()
 	app := newDispatchTestApp(t, cfg, fake)
-	app.registerHotkeys()
+	app.registerHotkeys("")
 
 	repeatKey := config.CanonicalHotkeyForPlatform("Ctrl+Alt+J")
 	onceKey := config.CanonicalHotkeyForPlatform("Ctrl+Alt+P")

--- a/internal/app/layout_change_darwin.go
+++ b/internal/app/layout_change_darwin.go
@@ -33,9 +33,12 @@ func (a *App) registerLayoutChangeHandler() {
 		a.hotkeyManager.UnregisterAll()
 		a.appState.SetHotkeysRegistered(false)
 
-		// Re-register with updated keycodes from the new layout
-		a.registerHotkeys()
+		// Re-register with updated keycodes from the new layout.
+		// Pass "" to use base bindings; the next focus change will
+		// register app-specific overrides if any are configured.
+		a.registerHotkeys("")
 		a.appState.SetHotkeysRegistered(true)
+		a.currentHotkeyBundleID = ""
 
 		a.logger.Info("Global hotkeys re-registered for new keyboard layout")
 	})

--- a/internal/app/layout_change_darwin.go
+++ b/internal/app/layout_change_darwin.go
@@ -33,12 +33,10 @@ func (a *App) registerLayoutChangeHandler() {
 		a.hotkeyManager.UnregisterAll()
 		a.appState.SetHotkeysRegistered(false)
 
-		// Re-register with updated keycodes from the new layout.
-		// Pass "" to use base bindings; the next focus change will
-		// register app-specific overrides if any are configured.
-		a.registerHotkeys("")
+		// Re-register with updated keycodes from the new layout, preserving
+		// per-app [[app_configs]] overrides for the currently focused app.
+		a.registerHotkeys(a.currentHotkeyBundleID)
 		a.appState.SetHotkeysRegistered(true)
-		a.currentHotkeyBundleID = ""
 
 		a.logger.Info("Global hotkeys re-registered for new keyboard layout")
 	})

--- a/internal/app/layout_change_darwin.go
+++ b/internal/app/layout_change_darwin.go
@@ -33,9 +33,15 @@ func (a *App) registerLayoutChangeHandler() {
 		a.hotkeyManager.UnregisterAll()
 		a.appState.SetHotkeysRegistered(false)
 
-		// Re-register with updated keycodes from the new layout, preserving
-		// per-app [[app_configs]] overrides for the currently focused app.
-		a.registerHotkeys(a.currentHotkeyBundleID)
+		// Re-register with updated keycodes from the new layout, querying
+		// the currently focused app so [[app_configs]] overrides match
+		// the app the user is actually in.
+		bundleID, err := a.actionService.FocusedAppBundleID(a.ctx)
+		if err != nil {
+			bundleID = ""
+		}
+		a.currentHotkeyBundleID = bundleID
+		a.registerHotkeys(bundleID)
 		a.appState.SetHotkeysRegistered(true)
 
 		a.logger.Info("Global hotkeys re-registered for new keyboard layout")

--- a/internal/app/layout_change_darwin.go
+++ b/internal/app/layout_change_darwin.go
@@ -40,6 +40,7 @@ func (a *App) registerLayoutChangeHandler() {
 		if err != nil {
 			bundleID = ""
 		}
+
 		a.currentHotkeyBundleID = bundleID
 		a.registerHotkeys(bundleID)
 		a.appState.SetHotkeysRegistered(true)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -448,6 +448,12 @@ type Config struct {
 	SmoothScroll    SmoothScrollConfig    `json:"smoothScroll"    toml:"smooth_scroll"`
 	HeldRepeat      HeldRepeatConfig      `json:"heldRepeat"      toml:"held_repeat"`
 	Systray         SystrayConfig         `json:"systray"         toml:"systray"`
+
+	// AppConfigs holds per-application overrides for global hotkeys, similar to
+	// per-mode [[<mode>.app_configs]].  Each entry can override or disable
+	// specific global bindings (via __disabled__) when the identified app
+	// is focused.  Populated by the TOML struct decoder from [[app_configs]].
+	AppConfigs []AppConfig `json:"appConfigs" toml:"app_configs"`
 }
 
 // ThemePalette defines a semantic base palette for one appearance mode.
@@ -987,6 +993,12 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	// Validate global hotkey app configs
+	err = validateHotkeysAppConfigs("app_configs", c.AppConfigs)
+	if err != nil {
+		return err
+	}
+
 	// Validate grid settings
 	err = c.ValidateGrid()
 	if err != nil {
@@ -1473,6 +1485,65 @@ func (c *Config) HotkeysForModeAndApp(
 	}
 
 	return merged
+}
+
+// GlobalHotkeysForApp returns the effective global hotkey bindings for the given
+// focused app bundle ID. When the bundle ID matches an entry in [[app_configs]],
+// the app-specific hotkeys are merged on top of the base [hotkeys] bindings.
+// The __disabled__ sentinel removes a base binding.
+// Returns the base bindings unchanged when bundleID is empty or no matching
+// app config has hotkey overrides.
+func (c *Config) GlobalHotkeysForApp(bundleID string) map[string][]string {
+	base := c.Hotkeys.Bindings
+	if bundleID == "" || !c.HasGlobalAppHotkeyOverrides() {
+		return base
+	}
+
+	for idx := range c.AppConfigs {
+		if c.AppConfigs[idx].BundleID == bundleID {
+			appConfig := &c.AppConfigs[idx]
+			if len(appConfig.Hotkeys) == 0 {
+				return base
+			}
+
+			merged := make(map[string][]string, len(base))
+			for key, actions := range base {
+				copied := make([]string, len(actions))
+				copy(copied, actions)
+				merged[key] = copied
+			}
+
+			for key, sosa := range appConfig.Hotkeys {
+				canonicalKey := findNormalizedMapKey(merged, key)
+				if len(sosa) == 1 && sosa[0] == DisabledSentinel {
+					delete(merged, canonicalKey)
+
+					continue
+				}
+
+				delete(merged, canonicalKey)
+				merged[key] = []string(sosa)
+			}
+
+			return merged
+		}
+	}
+
+	return base
+}
+
+// HasGlobalAppHotkeyOverrides reports whether any [[app_configs]] entry
+// has a non-empty Hotkeys map. Callers can use this to skip expensive
+// operations (e.g. accessibility API calls) when no per-app hotkey overrides
+// are configured.
+func (c *Config) HasGlobalAppHotkeyOverrides() bool {
+	for idx := range c.AppConfigs {
+		if len(c.AppConfigs[idx].Hotkeys) > 0 {
+			return true
+		}
+	}
+
+	return false
 }
 
 // HasAppHotkeyOverrides reports whether any [[hints.app_configs]] entry has a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1597,9 +1597,12 @@ func (c *ScrollConfig) HasAppHotkeyOverrides() bool {
 }
 
 // AppConfigForBundleID returns the matching hints app config for the given bundle ID.
+// Bundle ID matching is case-insensitive (after trimming whitespace).
 func (c *HintsConfig) AppConfigForBundleID(bundleID string) *AppConfig {
+	lowerBundleID := strings.ToLower(strings.TrimSpace(bundleID))
+
 	for idx := range c.AppConfigs {
-		if c.AppConfigs[idx].BundleID == bundleID {
+		if strings.ToLower(strings.TrimSpace(c.AppConfigs[idx].BundleID)) == lowerBundleID {
 			return &c.AppConfigs[idx]
 		}
 	}
@@ -1608,9 +1611,12 @@ func (c *HintsConfig) AppConfigForBundleID(bundleID string) *AppConfig {
 }
 
 // AppConfigForBundleID returns the matching grid app config for the given bundle ID.
+// Bundle ID matching is case-insensitive (after trimming whitespace).
 func (c *GridConfig) AppConfigForBundleID(bundleID string) *AppConfig {
+	lowerBundleID := strings.ToLower(strings.TrimSpace(bundleID))
+
 	for idx := range c.AppConfigs {
-		if c.AppConfigs[idx].BundleID == bundleID {
+		if strings.ToLower(strings.TrimSpace(c.AppConfigs[idx].BundleID)) == lowerBundleID {
 			return &c.AppConfigs[idx]
 		}
 	}
@@ -1619,9 +1625,12 @@ func (c *GridConfig) AppConfigForBundleID(bundleID string) *AppConfig {
 }
 
 // AppConfigForBundleID returns the matching recursive grid app config for the given bundle ID.
+// Bundle ID matching is case-insensitive (after trimming whitespace).
 func (c *RecursiveGridConfig) AppConfigForBundleID(bundleID string) *AppConfig {
+	lowerBundleID := strings.ToLower(strings.TrimSpace(bundleID))
+
 	for idx := range c.AppConfigs {
-		if c.AppConfigs[idx].BundleID == bundleID {
+		if strings.ToLower(strings.TrimSpace(c.AppConfigs[idx].BundleID)) == lowerBundleID {
 			return &c.AppConfigs[idx]
 		}
 	}
@@ -1630,9 +1639,12 @@ func (c *RecursiveGridConfig) AppConfigForBundleID(bundleID string) *AppConfig {
 }
 
 // AppConfigForBundleID returns the matching scroll app config for the given bundle ID.
+// Bundle ID matching is case-insensitive (after trimming whitespace).
 func (c *ScrollConfig) AppConfigForBundleID(bundleID string) *AppConfig {
+	lowerBundleID := strings.ToLower(strings.TrimSpace(bundleID))
+
 	for idx := range c.AppConfigs {
-		if c.AppConfigs[idx].BundleID == bundleID {
+		if strings.ToLower(strings.TrimSpace(c.AppConfigs[idx].BundleID)) == lowerBundleID {
 			return &c.AppConfigs[idx]
 		}
 	}
@@ -1831,8 +1843,9 @@ func (c *HintsConfig) buildRolesMap(bundleID string) map[string]struct{} {
 		}
 	}
 
+	lowerBundleID := strings.ToLower(strings.TrimSpace(bundleID))
 	for _, appConfig := range c.AppConfigs {
-		if appConfig.BundleID == bundleID {
+		if strings.ToLower(strings.TrimSpace(appConfig.BundleID)) == lowerBundleID {
 			for _, role := range appConfig.AdditionalClickable {
 				trimmed := strings.TrimSpace(role)
 				if trimmed != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1499,8 +1499,9 @@ func (c *Config) GlobalHotkeysForApp(bundleID string) map[string][]string {
 		return base
 	}
 
+	lowerBundleID := strings.ToLower(strings.TrimSpace(bundleID))
 	for idx := range c.AppConfigs {
-		if c.AppConfigs[idx].BundleID == bundleID {
+		if strings.ToLower(strings.TrimSpace(c.AppConfigs[idx].BundleID)) == lowerBundleID {
 			appConfig := &c.AppConfigs[idx]
 			if len(appConfig.Hotkeys) == 0 {
 				return base

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -368,6 +368,11 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 
 			parsedHotkeyActions := make(map[string][]string, len(hotMap))
 			for key, value := range hotMap {
+				// Skip hotmap infrastructure keys that are not hotkey bindings.
+				if key == "app_configs" {
+					continue
+				}
+
 				actions, actionsErr := parseRawHotkeyActions("hotkeys."+key, value)
 				if actionsErr != nil {
 					continue
@@ -390,6 +395,11 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 
 			// Merge user entries on top of defaults (already populated by DefaultConfig).
 			for key, value := range hotMap {
+				// Skip hotmap infrastructure keys that are not hotkey bindings.
+				if key == "app_configs" {
+					continue
+				}
+
 				// Find the existing default key that normalizes to the same value
 				// so that e.g. "cmd+shift+s" correctly overrides "Cmd+Shift+S".
 				canonicalKey := findNormalizedMapKey(

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -554,6 +554,10 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 		}
 	}
 
+	if result := validateAppConfigsHotkeys(s.logger, "app_configs", raw); result != nil {
+		return result
+	}
+
 	if hintsRaw, ok := raw["hints"].(map[string]any); ok {
 		if result := validateAppConfigsHotkeys(s.logger, "hints", hintsRaw); result != nil {
 			return result

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -1,6 +1,9 @@
 package config_test
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -184,4 +187,93 @@ func TestService_Concurrency(_ *testing.T) {
 	}
 
 	waitGroup.Wait()
+}
+
+func writeTempToml(t *testing.T, content string) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+
+	writeFileErr := os.WriteFile(configPath, []byte(content), 0o644)
+	if writeFileErr != nil {
+		t.Fatalf("Failed to write temp config: %v", writeFileErr)
+	}
+
+	return configPath
+}
+
+func TestService_LoadWithValidation_AppConfigsDuplicateNormalizedHotkeys(t *testing.T) {
+	service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+
+	tests := []struct {
+		name    string
+		toml    string
+		wantErr bool
+	}{
+		{
+			name: "root app_configs duplicate normalized hotkeys",
+			toml: `
+[[app_configs]]
+bundle_id = "com.example.app"
+[app_configs.hotkeys]
+"Ctrl+Alt+K" = "hints"
+"Ctrl+Alt+k" = "grid"
+`,
+			wantErr: true,
+		},
+		{
+			name: "hints app_configs duplicate normalized hotkeys",
+			toml: `
+[hints]
+enabled = true
+hint_characters = "asdf"
+clickable_roles = ["AXButton"]
+
+[[hints.app_configs]]
+bundle_id = "com.example.app"
+[hints.app_configs.hotkeys]
+"Ctrl+Alt+K" = "action left_click"
+"Ctrl+Alt+k" = "action right_click"
+`,
+			wantErr: true,
+		},
+		{
+			name: "valid root app_configs no duplicates",
+			toml: `
+[[app_configs]]
+bundle_id = "com.example.app"
+[app_configs.hotkeys]
+"Ctrl+Alt+K" = "hints"
+"Ctrl+Shift+L" = "grid"
+`,
+			wantErr: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			configPath := writeTempToml(t, testCase.toml)
+			result := service.LoadWithValidation(configPath)
+
+			if testCase.wantErr {
+				if result.ValidationError == nil {
+					t.Error("LoadWithValidation() expected ValidationError, got nil")
+				} else if errMsg := result.ValidationError.Error(); !strings.Contains(errMsg, "duplicate bindings") &&
+					!strings.Contains(errMsg, "duplicate normalized") {
+					t.Errorf(
+						"LoadWithValidation() error = %q, want error containing 'duplicate bindings'",
+						errMsg,
+					)
+				}
+			}
+
+			if !testCase.wantErr && result.ValidationError != nil {
+				t.Errorf(
+					"LoadWithValidation() unexpected ValidationError: %v",
+					result.ValidationError,
+				)
+			}
+		})
+	}
 }

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -631,6 +631,11 @@ func validateScrollAppConfigs(modeName string, appConfigs []AppConfig) error {
 	return validateAppConfigsWithCallback(modeName, appConfigs, scrollFieldValidator)
 }
 
+// validateHotkeysAppConfigs validates per-app global hotkey configuration.
+func validateHotkeysAppConfigs(modeName string, appConfigs []AppConfig) error {
+	return validateAppConfigsWithCallback(modeName, appConfigs, nil)
+}
+
 // ValidateAppConfigs validates per-app hint configuration.
 func (c *Config) ValidateAppConfigs() error {
 	return validateAppConfigsWithCallback(
@@ -940,6 +945,31 @@ func (c *Config) checkHotkeysConflicts() error {
 				appConfig.BundleID,
 			),
 			c.HotkeysForModeAndApp(ModeNameScroll, appConfig.BundleID),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Check merged global hotkeys for each [[app_configs]] entry
+	for idx, appConfig := range c.AppConfigs {
+		merged := c.GlobalHotkeysForApp(appConfig.BundleID)
+		if merged == nil {
+			continue
+		}
+		// Convert to StringOrStringArray for conflict checking
+		table := make(map[string]StringOrStringArray, len(merged))
+		for k, v := range merged {
+			table[k] = StringOrStringArray(v)
+		}
+
+		err := checkHotkeyConflicts(
+			fmt.Sprintf(
+				"hotkeys merged with app_configs[%d] (%s)",
+				idx,
+				appConfig.BundleID,
+			),
+			table,
 		)
 		if err != nil {
 			return err

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -475,7 +475,8 @@ func validateAppConfigsWithCallback(
 			)
 		}
 
-		if _, ok := seen[appConfig.BundleID]; ok {
+		lowerID := strings.ToLower(strings.TrimSpace(appConfig.BundleID))
+		if _, ok := seen[lowerID]; ok {
 			return derrors.Newf(
 				derrors.CodeInvalidConfig,
 				"duplicate %s.app_configs bundle_id: %s",
@@ -483,7 +484,7 @@ func validateAppConfigsWithCallback(
 			)
 		}
 
-		seen[appConfig.BundleID] = struct{}{}
+		seen[lowerID] = struct{}{}
 
 		err := validateHotkeyTable(
 			fmt.Sprintf("%s.app_configs[%d].hotkeys", modeName, idx),


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a new `app_configs` in the root config. The pattern is exactly the same as `<mode>.app_configs` except this covers the global hotkey case.

The resolving hierachy would be as follows based on the specificity (the lower wins):

1. Global hotkey
2. Global app configs hotkey
3. Mode hotkey
4. Mode app configs hotkey

### Example

`Cmd+1` and `Cmd+2` will only work globally when focuses claude app.

```toml
[hotkeys]
"Ctrl+F" = "recursive_grid"
"Ctrl+G" = "hints"
"Ctrl+S" = "scroll"

[[app_configs]]
bundle_id = "com.anthropic.claudefordesktop"
hotkeys = {
	"Cmd+1" = ["action move_mouse --window --x -1000 --y -1000", "action sleep 0.1", "action move_mouse_relative --dx 100 --dy 70", "action sleep 0.1", "action left_click"],
	"Cmd+2" = ["action move_mouse --window --x -1000 --y -1000", "action sleep 0.1", "action move_mouse_relative --dx 250 --dy 70", "action sleep 0.1", "action left_click"],
}
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Related to #1004 #998

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
