### PR TITLE
docs: add bernatGene config showcase

### DIFF
--- a/docs/CONFIG_SHOWCASES.md
+++ b/docs/CONFIG_SHOWCASES.md
@@ -6,3 +6,4 @@ This document contains community-submitted configurations and setups for Neru. F
 
 - [@y3owk1n](https://github.com/y3owk1n) - <https://github.com/y3owk1n/nix-system-config-v2/blob/main/home-manager/packages/neru.nix>
 - [@y9san9](https://github.com/y9san9) - <https://github.com/y9san9/y9san9.neru>
+- [@bernatGene](https://github.com/bernatGene) - <https://github.com/bernatGene/dotfiles/tree/main/neru>


### PR DESCRIPTION
## Description

Adds a link to @bernatGene's public Neru configuration showcase.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)