### PR TITLE
fix(darwin,stick_modifier): prevent random sticky modifier toggles

### DIFF
--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -31,7 +31,7 @@ func actionsReferenceDisabledMode(actions []string, cfg *config.Config) bool {
 			continue
 		}
 
-		mode := strings.Split(trimmed, " ")[0]
+		mode := strings.Fields(trimmed)[0]
 		switch {
 		case mode == hintsStr && !cfg.Hints.Enabled:
 			return true
@@ -378,7 +378,7 @@ func actionsContainModeSwitch(actions []string) bool {
 
 		// The action format is "<mode_name>" with optional args, so split
 		// to get just the mode name for comparison.
-		mode := strings.Split(trimmed, " ")[0]
+		mode := strings.Fields(trimmed)[0]
 		switch mode {
 		case domain.ModeString(domain.ModeHints),
 			domain.ModeString(domain.ModeGrid),

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -138,6 +138,12 @@ func (a *App) dispatchModeAwareHotkeyAsync(key string, globalActions []string) {
 		if overrideActions, ok := a.modes.ModeHotkeyOverride(key); ok {
 			actions = overrideActions
 		}
+
+		// Suppress hotkey modifiers synchronously so the per-mode event tap
+		// sees them as suppressed before the debounce timer can fire.
+		if actionsContainModeSwitch(actions) {
+			a.modes.SuppressModifiersForHotkey(hotkeyModifiersFromKey(key))
+		}
 	}
 
 	a.dispatchHotkeyActionsAsync(key, actions)
@@ -166,6 +172,14 @@ func (a *App) dispatchModeAwareHeldHotkey(key string, globalActions []string) {
 		globalActions,
 		a.configSnapshot(),
 	)
+
+	// Suppress hotkey modifiers synchronously so the per-mode event tap
+	// sees them as suppressed before the debounce timer can fire.
+	// This must happen before the async dispatch or startHotkeyRepeat.
+	if a.modes != nil && actionsContainModeSwitch(actions) {
+		a.modes.SuppressModifiersForHotkey(hotkeyModifiersFromKey(key))
+	}
+
 	if repeat {
 		a.startHotkeyRepeat(key, actions)
 
@@ -351,6 +365,31 @@ func hotkeyModifiersFromKey(key string) action.Modifiers {
 	}
 
 	return mods
+}
+
+// actionsContainModeSwitch reports whether any action in the list is a
+// mode-switch action (hints, grid, recursive_grid, scroll, monitor_select).
+func actionsContainModeSwitch(actions []string) bool {
+	for _, actionStr := range actions {
+		trimmed := strings.TrimSpace(actionStr)
+		if trimmed == "" {
+			continue
+		}
+
+		// The action format is "<mode_name>" with optional args, so split
+		// to get just the mode name for comparison.
+		mode := strings.Split(trimmed, " ")[0]
+		switch mode {
+		case domain.ModeString(domain.ModeHints),
+			domain.ModeString(domain.ModeGrid),
+			domain.ModeString(domain.ModeRecursiveGrid),
+			domain.ModeString(domain.ModeScroll),
+			domain.ModeString(domain.ModeMonitorSelect):
+			return true
+		}
+	}
+
+	return false
 }
 
 func splitArgs(input string) []string {

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -147,8 +147,20 @@ func (h *Handler) performCommonCleanup() {
 	accessibility.EnsureMouseUp()
 
 	h.setAppModeLocked(domain.ModeIdle)
-	h.suppressedModifiers = 0
-	h.suppressedUntil = time.Time{}
+
+	// Do NOT reset suppressedModifiers here — SuppressModifiersForHotkey was
+	// called synchronously by the hotkey dispatch path (dispatchModeAwareHeldHotkey
+	// or dispatchModeAwareHotkeyAsync) before the mode switch, and the modifier
+	// UP events arrive after the user releases the chord. Clearing
+	// suppressedModifiers here causes the modifier DOWN events (for the next
+	// chord press) to be handled as normal modifier taps instead of suppressed,
+	// which schedules a debounce timer that fires and toggles the sticky modifier
+	// when it shouldn't.
+	//
+	// expireSuppressedModifiersIfNeeded handles cleanup after the 2-second
+	// activationModifierSuppressionWindow expires.
+	// h.suppressedModifiers = 0
+	// h.suppressedUntil = time.Time{}
 	h.logger.Debug("Mode transition complete",
 		zap.String("to", "idle"))
 	h.overlayManager.SwitchTo(overlay.ModeIdle)

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -109,6 +109,7 @@ type Handler struct {
 	usedInChordModifiers  action.Modifiers
 	suppressedModifiers   action.Modifiers
 	suppressedUntil       time.Time
+	modifierFreshPress    map[action.Modifiers]bool
 	debounceNotify        chan struct{} // test-only: signaled when a debounce callback completes
 
 	// moveMonitorMu serializes MoveMonitor invocations. Lock ordering is

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -379,6 +379,17 @@ func (h *Handler) dispatchHotkeyActions(
 		zap.String("key", rawKey),
 		zap.Int("action_count", len(actions)))
 
+	// Note: we do NOT suppress modifiers here because this function is called
+	// from handleHotkey which is called from HandleKeyPress while h.mu is held.
+	// Suppression via SuppressModifiersForHotkey would deadlock. However, this
+	// per-mode path is only reached when the per-mode event tap sees the key
+	// event before the global hotkey tap consumes it. In the certain scenario
+	// (switching modes on the same chord), the global hotkey tap consumes the
+	// non-modifier key first, so this path is never hit for the mode-switch
+	// hotkey. Modifier suppression for mode-switch actions is handled
+	// synchronously in dispatchModeAwareHeldHotkey / dispatchModeAwareHotkeyAsync
+	// in hotkeys.go before any async dispatch occurs.
+
 	// Execute in a goroutine so the event tap callback returns quickly.
 	// This also avoids a deadlock: executeHotkeyAction may call
 	// ipcController.HandleCommand -> ActivateModeWithOptions which

--- a/internal/app/modes/modifier_toggle.go
+++ b/internal/app/modes/modifier_toggle.go
@@ -81,12 +81,45 @@ func (h *Handler) handleModifierToggle(key string) bool {
 
 	if isDown {
 		if h.suppressedModifiers.Has(mod) {
+			// Record this as a fresh press so the UP handler can
+			// distinguish between a chord release (no fresh press)
+			// and a non-chord modifier tap (fresh press while suppressed).
+			if h.modifierFreshPress == nil {
+				h.modifierFreshPress = make(map[action.Modifiers]bool)
+			}
+
+			h.modifierFreshPress[mod] = true
+			h.suppressedModifiers &^= mod
+			h.usedInChordModifiers &^= mod
 			h.heldModifiers |= mod
 			delete(h.pendingModifierKeys, mod)
 			h.stopPendingModifierTimer(mod)
-			h.usedInChordModifiers &^= mod
 
 			return true
+		}
+
+		// Non-chord modifier detection at Go level: if a non-suppressed modifier
+		// is pressed while suppressedModifiers is set (from a previous
+		// hotkey chord), this signals a non-chord modifier press. Create pending keys
+		// for all suppressed modifiers so their subsequent UP events
+		// are handled as sticky toggles.
+		if h.suppressedModifiers != 0 {
+			now := time.Now()
+
+			for _, suppressedMod := range allStickyModifiers {
+				if h.suppressedModifiers.Has(suppressedMod) {
+					if h.pendingModifierKeys == nil {
+						h.pendingModifierKeys = make(map[action.Modifiers]time.Time)
+					}
+
+					h.pendingModifierKeys[suppressedMod] = now
+				}
+			}
+
+			h.suppressedModifiers = 0
+			h.usedInChordModifiers = 0
+			h.suppressedUntil = time.Time{}
+			h.logger.Debug("Suppression cleared by non-chord modifier press, pending keys created")
 		}
 
 		if h.pendingModifierKeys == nil {
@@ -118,6 +151,28 @@ func (h *Handler) handleModifierToggle(key string) bool {
 
 	downTime, pending := h.pendingModifierKeys[mod]
 	if !pending {
+		// If this modifier was pressed fresh while suppressed (set by
+		// the suppressed DOWN handler), treat the release as a tap.
+		// This handles the non-chord modifier case where stale suppression bits
+		// would otherwise cause the UP to be silently dropped.
+		if h.modifierFreshPress[mod] {
+			delete(h.modifierFreshPress, mod)
+
+			now := time.Now()
+
+			if h.pendingModifierKeys == nil {
+				h.pendingModifierKeys = make(map[action.Modifiers]time.Time)
+			}
+
+			h.pendingModifierKeys[mod] = now
+			h.scheduleModifierToggle(mod, now)
+			h.logger.Debug("Modifier key up (fresh press while suppressed, treating as tap)",
+				zap.String("key", key),
+				zap.String("modifier", mod.String()))
+
+			return true
+		}
+
 		h.logger.Debug("Modifier key up ignored (no matching pending down)",
 			zap.String("key", key),
 			zap.Any("pending", h.pendingModifierKeys))
@@ -263,6 +318,11 @@ func (h *Handler) notifyDebounceComplete() {
 }
 
 // clearStickyModifiers releases any physically held sticky modifiers and resets internal state.
+// UsedInChordModifiers is NOT reset here because it may have been set by
+// SuppressModifiersForHotkey (called from the global hotkey dispatch path)
+// to prevent modifier UP events from starting debounce timers during a
+// mode switch. Resetting it here would undo the suppression before the
+// UP events arrive, causing unintended sticky modifier toggles.
 func (h *Handler) clearStickyModifiers() {
 	if h.modifierState == nil {
 		return
@@ -289,7 +349,6 @@ func (h *Handler) clearStickyModifiers() {
 
 	h.modifierState.Reset()
 	h.heldModifiers = 0
-	h.usedInChordModifiers = 0
 }
 
 func (h *Handler) cancelPendingModifierToggle() {
@@ -338,6 +397,40 @@ func (h *Handler) SuppressModifiersUntilReleased(mods action.Modifiers) {
 	}
 }
 
+// SuppressModifiersForHotkey suppresses the given modifiers from sticky toggle
+// and also marks them as used-in-chord so that any modifier UP events that were
+// already enqueued by the per-mode event tap (before the synchronous suppression
+// could take effect) will be ignored by handleModifierToggle instead of starting
+// a debounce timer. This provides defense-in-depth against the race between the
+// per-mode event tap thread and the global hotkey callback goroutine.
+func (h *Handler) SuppressModifiersForHotkey(mods action.Modifiers) {
+	if mods == 0 {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.suppressedModifiers |= mods
+	h.suppressedUntil = time.Now().Add(activationModifierSuppressionWindow)
+
+	for _, mod := range allStickyModifiers {
+		if mods.Has(mod) {
+			// Clean up any modifierFreshPress state from a previous suppressed
+			// DOWN handler invocation — this prevents stale fresh-press flags
+			// from triggering spurious sticky toggles on the next cycle.
+			delete(h.modifierFreshPress, mod)
+			delete(h.pendingModifierKeys, mod)
+			h.stopPendingModifierTimer(mod)
+
+			// Mark as used-in-chord so that modifier UP events from the per-mode
+			// event tap that arrive before our suppression takes effect are still
+			// caught by the usedInChordModifiers check in handleModifierToggle.
+			h.usedInChordModifiers |= mod
+		}
+	}
+}
+
 func (h *Handler) expireSuppressedModifiersIfNeeded() {
 	if h.suppressedModifiers == 0 || h.suppressedUntil.IsZero() {
 		return
@@ -349,6 +442,8 @@ func (h *Handler) expireSuppressedModifiersIfNeeded() {
 
 	h.suppressedModifiers = 0
 	h.suppressedUntil = time.Time{}
+	h.usedInChordModifiers = 0
+	h.modifierFreshPress = nil
 }
 
 func (h *Handler) stickyModifiersEnabled() bool {

--- a/internal/app/modes/modifier_toggle.go
+++ b/internal/app/modes/modifier_toggle.go
@@ -392,7 +392,15 @@ func (h *Handler) SuppressModifiersUntilReleased(mods action.Modifiers) {
 		if mods.Has(mod) {
 			delete(h.pendingModifierKeys, mod)
 			h.stopPendingModifierTimer(mod)
-			h.usedInChordModifiers &^= mod
+			// Don't clear usedInChordModifiers here — it may have been
+			// set by SuppressModifiersForHotkey (called from the global
+			// hotkey dispatch path) before the async mode-action path
+			// reaches us. Clearing it would let a modifier UP event
+			// from the per-mode event tap fall through to the debounce
+			// path and create an unintended sticky toggle.
+			// usedInChordModifiers is cleaned up by handleModifierToggle
+			// on modifier release, or by expireSuppressedModifiersIfNeeded
+			// on suppression timeout.
 		}
 	}
 }

--- a/internal/core/infra/platform/darwin/eventtap_darwin.m
+++ b/internal/core/infra/platform/darwin/eventtap_darwin.m
@@ -34,8 +34,8 @@ typedef struct {
 	os_unfair_lock modifierPassthroughLock;                  ///< Lock for modifier passthrough config
 	CGEventFlags previousFlags;                              ///< Previous modifier flags for toggle detection
 	CGEventFlags modifierChordFlags;  ///< Modifiers used in a key chord and not eligible for sticky on release
-	BOOL
-	    nonChordModifierPress;  ///< Set when a non-chord modifier (Shift/Alt) is pressed while chord modifiers are held
+	CGEventFlags
+	    nonChordModifierFlags;  ///< Bitmask of non-chord modifiers (Shift/Alt) pressed while chord modifiers were held
 	BOOL stickyModifierDetectionArmed;  ///< Whether sticky modifier callbacks are armed for this mode session
 	BOOL stickyModifierToggleEnabled;   ///< Whether to emit __modifier_ events
 	os_unfair_lock stickyModifierLock;  ///< Lock for sticky modifier toggle config
@@ -347,7 +347,7 @@ CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 			context->previousFlags = flags;
 			detectionArmed = context->stickyModifierDetectionArmed;
 			// All modifiers released — clear chord tracking state
-			// unconditionally so a stale nonChordModifierPress flag from a
+			// unconditionally so a stale nonChordModifierFlags value from a
 			// previous cycle doesn't leak into the next one.
 			if (stickyFlags == 0) {
 				// Don't clear modifierChordFlags here — the loop below still
@@ -406,9 +406,11 @@ CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 						// also suppressed. If nonChordModifierPress is set
 						// (Shift/Alt was pressed), let the UP through.
 						if (inChord) {
-							if (context->nonChordModifierPress) {
-								// Non-chord modifier — let the chord modifier UP
+							if (context->nonChordModifierFlags & modifiers[i].mask) {
+								// This modifier was pressed as a non-chord modifier
+								// while chord modifiers were held — let its UP
 								// reach Go so it can be a sticky toggle.
+								context->nonChordModifierFlags &= ~modifiers[i].mask;
 								context->modifierChordFlags &= ~modifiers[i].mask;
 							} else {
 								suppressChordRelease = YES;
@@ -422,7 +424,7 @@ CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 						// is pressed while chord modifiers are held - this
 						// signals a non-chord modifier press.
 						if (context->modifierChordFlags && !(context->modifierChordFlags & modifiers[i].mask)) {
-							context->nonChordModifierPress = YES;
+							context->nonChordModifierFlags |= modifiers[i].mask;
 						}
 					}
 
@@ -445,7 +447,7 @@ CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 			os_unfair_lock_lock(&context->stickyModifierLock);
 			if ((flags & kStickyModifierMask) == 0) {
 				context->modifierChordFlags = 0;
-				context->nonChordModifierPress = NO;
+				context->nonChordModifierFlags = 0;
 			}
 			os_unfair_lock_unlock(&context->stickyModifierLock);
 

--- a/internal/core/infra/platform/darwin/eventtap_darwin.m
+++ b/internal/core/infra/platform/darwin/eventtap_darwin.m
@@ -33,7 +33,9 @@ typedef struct {
 	BOOL passthroughUnboundedModifiers;                      ///< Whether unbound modifier shortcuts reach macOS
 	os_unfair_lock modifierPassthroughLock;                  ///< Lock for modifier passthrough config
 	CGEventFlags previousFlags;                              ///< Previous modifier flags for toggle detection
-	CGEventFlags modifierChordFlags;    ///< Modifiers used in a key chord and not eligible for sticky on release
+	CGEventFlags modifierChordFlags;  ///< Modifiers used in a key chord and not eligible for sticky on release
+	BOOL
+	    nonChordModifierPress;  ///< Set when a non-chord modifier (Shift/Alt) is pressed while chord modifiers are held
 	BOOL stickyModifierDetectionArmed;  ///< Whether sticky modifier callbacks are armed for this mode session
 	BOOL stickyModifierToggleEnabled;   ///< Whether to emit __modifier_ events
 	os_unfair_lock stickyModifierLock;  ///< Lock for sticky modifier toggle config
@@ -344,9 +346,19 @@ CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 			changed = flags ^ context->previousFlags;
 			context->previousFlags = flags;
 			detectionArmed = context->stickyModifierDetectionArmed;
-			if (!detectionArmed && stickyFlags == 0) {
-				context->stickyModifierDetectionArmed = YES;
-				context->modifierChordFlags = 0;
+			// All modifiers released — clear chord tracking state
+			// unconditionally so a stale nonChordModifierPress flag from a
+			// previous cycle doesn't leak into the next one.
+			if (stickyFlags == 0) {
+				// Don't clear modifierChordFlags here — the loop below still
+				// needs it to suppress modifier UP events from the same event.
+				// If multiple modifiers are released in the same or consecutive
+				// events, clearing here causes the second modifier's UP to miss
+				// the chord flag and leak through to Go. We defer clearing to
+				// after the loop.
+				if (!context->stickyModifierDetectionArmed) {
+					context->stickyModifierDetectionArmed = YES;
+				}
 			}
 			os_unfair_lock_unlock(&context->stickyModifierLock);
 
@@ -381,23 +393,61 @@ CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 			for (size_t i = 0; i < sizeof(modifiers) / sizeof(modifiers[0]); i++) {
 				if (changed & modifiers[i].mask) {
 					BOOL suppressChordRelease = NO;
+					BOOL isRelease = (flags & modifiers[i].mask) == 0;
 					os_unfair_lock_lock(&context->stickyModifierLock);
-					if ((context->modifierChordFlags & modifiers[i].mask) && (flags & modifiers[i].mask) == 0) {
-						suppressChordRelease = YES;
-						context->modifierChordFlags &= ~modifiers[i].mask;
+
+					if (isRelease) {
+						BOOL inChord = (context->modifierChordFlags & modifiers[i].mask) != 0;
+
+						// Suppress modifier UP events when they were part of
+						// a hotkey chord (set in modifierChordFlags by the
+						// per-hotkey tap or kCGEventKeyDown handler). Don't
+						// clear the bit so subsequent inter-cycle UPs are
+						// also suppressed. If nonChordModifierPress is set
+						// (Shift/Alt was pressed), let the UP through.
+						if (inChord) {
+							if (context->nonChordModifierPress) {
+								// Non-chord modifier — let the chord modifier UP
+								// reach Go so it can be a sticky toggle.
+								context->modifierChordFlags &= ~modifiers[i].mask;
+							} else {
+								suppressChordRelease = YES;
+								// Don't clear modifierChordFlags — the bit
+								// persists for inter-cycle re-press
+								// suppression.
+							}
+						}
+					} else {
+						// Modifier DOWN event: check if a non-chord modifier
+						// is pressed while chord modifiers are held - this
+						// signals a non-chord modifier press.
+						if (context->modifierChordFlags && !(context->modifierChordFlags & modifiers[i].mask)) {
+							context->nonChordModifierPress = YES;
+						}
 					}
+
 					os_unfair_lock_unlock(&context->stickyModifierLock);
 					if (suppressChordRelease) {
 						continue;
 					}
 
-					const char *modName = (flags & modifiers[i].mask) ? modifiers[i].downName : modifiers[i].upName;
+					const char *modName = isRelease ? modifiers[i].upName : modifiers[i].downName;
 					if (context->callback) {
 						context->callback(modName, context->userData);
 						handled = YES;
 					}
 				}
 			}
+
+			// Deferred clearing: all modifiers released — clear chord tracking
+			// state AFTER the loop so modifier UP events from the same event
+			// are processed with modifierChordFlags still intact.
+			os_unfair_lock_lock(&context->stickyModifierLock);
+			if ((flags & kStickyModifierMask) == 0) {
+				context->modifierChordFlags = 0;
+				context->nonChordModifierPress = NO;
+			}
+			os_unfair_lock_unlock(&context->stickyModifierLock);
 
 			return handled ? NULL : event;
 		}
@@ -603,6 +653,31 @@ static CGEventRef hotkeyTapCallback(CGEventTapProxy proxy, CGEventType type, CGE
 		if (!tap->down) {
 			tap->down = 1;
 			tap->callback(tap->hotkeyID, 1, tap->userData);  // pressed
+
+			// Inform the per-mode event tap that these modifiers are part of a
+			// hotkey chord so it suppresses the corresponding modifier UP events
+			// (kCGEventFlagsChanged). Without this, the per-mode tap would emit
+			// __modifier_*_up events for modifiers released after the hotkey,
+			// triggering unintended sticky modifier toggles when the user presses
+			// the same chord again to switch modes.
+			//
+			// This is safe because:
+			// 1. The per-mode tap runs AFTER this hotkey tap (kCGHeadInsertEventTap
+			//    ordering: most-recently-created runs first), so by the time the
+			//    per-mode tap processes subsequent events (modifier UP events are
+			//    separate kCGEventFlagsChanged events), modifierChordFlags is set.
+			// 2. modifierChordFlags is protected by os_unfair_lock.
+			// 3. Both taps run on the main run loop (serialized execution).
+			if (gEventTapContext && tap->cgFlags) {
+				os_unfair_lock_lock(&gEventTapContext->stickyModifierLock);
+				// REPLACE modifierChordFlags with the hotkey's modifiers
+				// (instead of OR) to clear any stale bits from a previous
+				// cycle that weren't cleaned up by the deferred clearing
+				// (e.g., when modifiers were released while the event tap
+				// was disabled during idle).
+				gEventTapContext->modifierChordFlags = tap->cgFlags;
+				os_unfair_lock_unlock(&gEventTapContext->stickyModifierLock);
+			}
 		}
 		return NULL;  // consume
 	}
@@ -975,12 +1050,33 @@ void NeruSetEventTapStickyModifierToggle(EventTap tap, int enabled) {
 	os_unfair_lock_lock(&context->stickyModifierLock);
 	context->stickyModifierToggleEnabled = enabled != 0;
 	if (enabled) {
-		context->previousFlags = CGEventSourceFlagsState(kCGEventSourceStateCombinedSessionState);
-		context->modifierChordFlags = 0;
-		context->stickyModifierDetectionArmed = (context->previousFlags & kStickyModifierMask) == 0;
+		context->previousFlags = CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState);
+
+		// Do NOT seed modifierChordFlags from CGEventSourceFlagsState —
+		// that function returns unreliable results when called from the
+		// Go callback goroutine (non-main thread). Instead, rely on the
+		// per-hotkey tap callback which REPLACES modifierChordFlags with
+		// the exact hotkey chord modifiers during F key DOWN processing.
+		// The hotkey tap runs before this function is called, so
+		// modifierChordFlags is already correct unless StickyModifierToggle
+		// was called with enabled=0 first (which clears it). In that case,
+		// modifierChordFlags will be 0 until the next F key DOWN event
+		// sets it correctly, which is fine because the event tap is NOT
+		// yet enabled (enableEventTap dispatches async to main thread).
+
+		// Always arm detection on mode entry so the C-level
+		// suppressChordRelease check runs for the initial hotkey
+		// chord's modifier UP events, even when modifiers are held.
+		context->stickyModifierDetectionArmed = YES;
 	} else {
+		// Do NOT clear modifierChordFlags here — the per-hotkey tap
+		// REPLACES it with the current hotkey's modifiers on every
+		// F key DOWN event. The mode exit path calls
+		// StickyModifierToggle(disable) which would undo the hotkey
+		// tap's work. The deferred clearing after the loop handles
+		// cleanup when all modifiers are physically released.
 		context->previousFlags = 0;
-		context->modifierChordFlags = 0;
+		// context->modifierChordFlags = 0;
 		context->stickyModifierDetectionArmed = NO;
 	}
 	os_unfair_lock_unlock(&context->stickyModifierLock);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes a bug where releasing the hotkey chord modifiers (e.g., Cmd+Ctrl) after switching modes would trigger unintended sticky modifier toggles. When the user held Cmd+Ctrl to activate a mode and released both modifiers, the second modifier's UP event was not recognized as part of the chord, causing the Go-level handler to start a debounce timer and toggle the modifier as sticky.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Fixes #1009

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
