### PR TITLE
feat(linux,wayland,kde): add `action feed` support

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -381,7 +381,7 @@ The hints command completes fully (AX elements collected, overlay drawn) before 
 - Function: `f1`–`f20`
 - Chord modifiers: `cmd`, `command`, `super`, `meta`, `shift`, `alt`, `option`, `ctrl`, `control`, and left/right forms (`LeftCmd`, `RightShift`)
 
-> Linux and Windows: returns not-supported error.
+> **Platform support:** macOS (all compositors). Linux — wlroots compositors (niri, Sway, Hyprland, River) via `zwp_virtual_keyboard_v1`; KDE/KWin via `libei`/RemoteDesktop portal when a keyboard device is granted. GNOME returns not-supported error. Windows returns not-supported error.
 
 ### Cycling Hints
 

--- a/docs/LINUX_DESKTOPS.md
+++ b/docs/LINUX_DESKTOPS.md
@@ -30,7 +30,8 @@ KWin does **not** implement `zwlr_virtual_pointer_v1` (confirmed on KWin 6.6.4 v
 | Concern                         | Mechanism                                                               | Why                                                                                |
 | ------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | Overlay + screen geometry       | Shared wlroots client (`zwlr_layer_shell_v1`, `zxdg_output_manager_v1`) | KWin exposes these; same path as Sway/Hyprland                                     |
-| Pointer / click / scroll / keys | `libei` via `org.freedesktop.portal.RemoteDesktop`                      | Only input path KWin exposes for third-party automation                            |
+| Pointer / click / scroll        | `libei` via `org.freedesktop.portal.RemoteDesktop`                      | Only input path KWin exposes for third-party automation                            |
+| Key feeding (`action feed`)     | `libei` via `org.freedesktop.portal.RemoteDesktop`                     | Keyboard device must be granted in portal; defaults to pointer-only               |
 | Hints (AT-SPI)                  | AT-SPI D-Bus + KWin geometry bridge                                     | AT-SPI coords are window-relative; bridge maps to global compositor space          |
 | Global hotkeys                  | Compositor keybindings only                                             | Wayland has no global-hotkey protocol; user binds `neru <mode>` in System Settings |
 | Systray                         | D-Bus StatusNotifierItem + `com.canonical.dbusmenu`                     | Matches KDE/GNOME tray hosts; no GTK dependency                                    |
@@ -82,6 +83,10 @@ See [Checking compositor protocols](#checking-compositor-protocols) for the
   `restore_token` + `persist_mode` instead of relying on `liboeffis` alone.
 - **Modifier keys need a keyboard device from the portal** — If the grant
   includes only a pointer device, modified clicks degrade.
+- **Key feeding needs a keyboard device from the portal** — `action feed`
+  requires keyboard capability from the RemoteDesktop portal. The portal defaults
+  to pointer-only; if keyboard is not granted, `neru action feed` returns
+  `CodeNotSupported` with a clear message.
 - **Screen geometry cached at startup** — Resolution changes after launch
   (monitor hotplug, VM resize) require a daemon relaunch. Same limitation as
   other Wayland backends; tracked for live refresh.
@@ -100,6 +105,13 @@ Confirm portal services are running.
 
 Expected. Neru routes input through libei on KDE; this message applies to
 compositors that lack both virtual pointer and a libei path.
+
+**"key feeding unavailable on KDE: the RemoteDesktop portal session did not grant a keyboard device"**
+
+The portal commonly grants pointer capability only. To enable key feeding on
+KDE, the portal session must include a keyboard device — this depends on the
+portal backend and KDE version. On most setups, keyboard is unavailable for
+security reasons. There is no user-facing toggle to request it.
 
 **Verifying injected input with the KWin Debug Console**
 
@@ -128,6 +140,7 @@ device (libei), while real hardware shows the physical device path.
 | Overlay                       | `zwlr_layer_shell_v1` with empty `input_region` for click-through                                                 |
 | Pointer / click / scroll      | `zwlr_virtual_pointer_v1`                                                                                         |
 | Sticky modifiers              | `zwp_virtual_keyboard_v1` when available                                                                          |
+| Key feeding (`action feed`)   | `zwp_virtual_keyboard_v1` — same virtual keyboard path as sticky modifiers                                        |
 | Keyboard capture during modes | `evdev` on `/dev/input/event*` (requires `input` group)                                                           |
 | Global hotkeys                | Compositor config (`bind` / `bindsym` / `spawn-sh`)                                                               |
 | Cursor position               | Client-side cache (Wayland hides global pointer); "agitation" via layer-shell + virtual pointer wiggle at startup |

--- a/internal/core/infra/keyfeed/keyfeed_linux.go
+++ b/internal/core/infra/keyfeed/keyfeed_linux.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+// Package keyfeed posts keyboard input directly to the host operating system.
+package keyfeed
+
+import (
+	"strings"
+
+	"github.com/y3owk1n/neru/internal/config"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	"github.com/y3owk1n/neru/internal/core/infra/platform/linux"
+)
+
+// Feed posts a key or key chord directly to the OS via the Wayland virtual
+// keyboard protocol (zwp_virtual_keyboard_v1). Only wlroots-based compositors
+// (niri, Sway, Hyprland, River) are supported.
+//
+// Key strings follow the canonical form used by CanonicalHotkeyForPlatform:
+//   - single character: "a", "B", "1"
+//   - named key: "Return", "F1", "Space"
+//   - modifier+key: "Ctrl+c", "Shift+F1", "Ctrl+Shift+Space"
+//
+// Uppercase letters (A-Z) without an explicit Shift modifier automatically
+// inject Shift, producing the correct uppercase character.
+func Feed(key string) error {
+	normalized, err := NormalizeKeyForFeed(key)
+	if err != nil {
+		return err
+	}
+
+	err = linux.FeedKey(normalized)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NormalizeKeyForFeed normalizes a key string for feeding to the OS.
+// It handles uppercase letter detection and Shift injection.
+func NormalizeKeyForFeed(key string) (string, error) {
+	trimmed := strings.TrimSpace(key)
+
+	isSingleUppercase := len(trimmed) == 1 && trimmed[0] >= 'A' && trimmed[0] <= 'Z'
+
+	normalized := config.CanonicalHotkeyForPlatform(trimmed)
+	if normalized == "" {
+		return "", derrors.New(derrors.CodeInvalidInput, "key is required")
+	}
+
+	if isSingleUppercase && !strings.Contains(normalized, "+") {
+		normalized = "Shift+" + normalized
+	}
+
+	return normalized, nil
+}

--- a/internal/core/infra/keyfeed/keyfeed_other.go
+++ b/internal/core/infra/keyfeed/keyfeed_other.go
@@ -1,23 +1,23 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 // Package keyfeed posts keyboard input directly to the host operating system.
 package keyfeed
 
 import derrors "github.com/y3owk1n/neru/internal/core/errors"
 
-// Feed is not implemented outside macOS yet.
+// Feed is not implemented outside macOS and Linux yet.
 func Feed(_ string) error {
 	return derrors.New(
 		derrors.CodeNotSupported,
-		"key feeding is only supported on macOS",
+		"key feeding is only supported on macOS and Linux",
 	)
 }
 
 // NormalizeKeyForFeed normalizes a key string for feeding to the OS.
-// Not supported outside macOS.
+// Not supported outside macOS and Linux.
 func NormalizeKeyForFeed(key string) (string, error) {
 	return "", derrors.New(
 		derrors.CodeNotSupported,
-		"key feeding is only supported on macOS",
+		"key feeding is only supported on macOS and Linux",
 	)
 }

--- a/internal/core/infra/platform/linux/system_linux_wayland_input.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_input.go
@@ -36,14 +36,22 @@ const (
 	keycodeLeftMeta  = 125 // KEY_LEFTMETA
 )
 
+// Modifier name constants used in key injection.
+const (
+	modNameShift = "shift"
+	modNameCtrl  = "ctrl"
+	modNameAlt   = "alt"
+	modNameCmd   = "cmd"
+)
+
 // libeiModifierKeycodes maps Neru's modifier names to evdev keycodes for the
 // libei keyboard path. KWin's RemoteDesktop portal commonly grants only a
 // pointer device, so libeiKey may still report these as unsupported.
 var libeiModifierKeycodes = map[string]int{
-	"shift": keycodeLeftShift,
-	"ctrl":  keycodeLeftCtrl,
-	"alt":   keycodeLeftAlt,
-	"cmd":   keycodeLeftMeta,
+	modNameShift: keycodeLeftShift,
+	modNameCtrl:  keycodeLeftCtrl,
+	modNameAlt:   keycodeLeftAlt,
+	modNameCmd:   keycodeLeftMeta,
 }
 
 // Release-retry backoff for the libei click path. When KWin pauses the

--- a/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
@@ -204,8 +204,15 @@ func libeiKey(keycode int, pressed bool) error {
 // device. The portal often grants only pointer + absolute-pointer capability,
 // so this check lets callers fail fast with a clear message rather than
 // discovering the absence mid-sequence.
+//
+// It uses TryLock so that `action feed` never blocks behind the portal warm-up
+// lock (held up to 120 s). If the lock is busy the result is conservatively
+// false, causing the caller to return CodeNotSupported immediately.
 func libeiHasKeyboard() bool {
-	globalLibeiState.mu.Lock()
+	if !globalLibeiState.mu.TryLock() {
+		return false
+	}
+
 	defer globalLibeiState.mu.Unlock()
 
 	if !globalLibeiState.ready {

--- a/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
@@ -199,3 +199,18 @@ func libeiKey(keycode int, pressed bool) error {
 
 	return nil
 }
+
+// libeiHasKeyboard reports whether the granted libei session includes a keyboard
+// device. The portal often grants only pointer + absolute-pointer capability,
+// so this check lets callers fail fast with a clear message rather than
+// discovering the absence mid-sequence.
+func libeiHasKeyboard() bool {
+	globalLibeiState.mu.Lock()
+	defer globalLibeiState.mu.Unlock()
+
+	if !globalLibeiState.ready {
+		return false
+	}
+
+	return C.neru_ei_has_keyboard(globalLibeiState.client) != 0 //nolint:nlreturn
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
@@ -206,18 +206,18 @@ func libeiKey(keycode int, pressed bool) error {
 // discovering the absence mid-sequence.
 //
 // It uses TryLock so that `action feed` never blocks behind the portal warm-up
-// lock (held up to 120 s). If the lock is busy the result is conservatively
-// false, causing the caller to return CodeNotSupported immediately.
-func libeiHasKeyboard() bool {
+// lock (held up to 120 s). If the lock is busy, busy is true and the caller
+// should return a retriable error instead of a permanent unsupported result.
+func libeiHasKeyboard() (bool, bool) {
 	if !globalLibeiState.mu.TryLock() {
-		return false
+		return false, true
 	}
 
 	defer globalLibeiState.mu.Unlock()
 
 	if !globalLibeiState.ready {
-		return false
+		return false, false
 	}
 
-	return C.neru_ei_has_keyboard(globalLibeiState.client) != 0 //nolint:nlreturn
+	return C.neru_ei_has_keyboard(globalLibeiState.client) != 0, false //nolint:nlreturn
 }

--- a/internal/core/infra/platform/linux/system_linux_wayland_kde_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_kde_nocgo.go
@@ -51,6 +51,6 @@ func libeiKey(keycode int, pressed bool) error {
 	)
 }
 
-func libeiHasKeyboard() bool {
-	return false
+func libeiHasKeyboard() (bool, bool) {
+	return false, false
 }

--- a/internal/core/infra/platform/linux/system_linux_wayland_kde_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_kde_nocgo.go
@@ -50,3 +50,7 @@ func libeiKey(keycode int, pressed bool) error {
 		"libei backend requires CGO-enabled Linux builds",
 	)
 }
+
+func libeiHasKeyboard() bool {
+	return false
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
@@ -104,29 +104,34 @@ var modifierNameMap = map[string]string{
 //     granted by the user (the portal defaults to pointer-only, so keyboard
 //     may be unavailable).
 func FeedKey(key string) error {
+	// Validate the key before any backend probing so that invalid keys
+	// always return CodeInvalidInput regardless of compositor or CGO
+	// availability.
+	modifiers, keycode, err := parseKeyString(key)
+	if err != nil {
+		return err
+	}
+
 	hasVKB, err := wlrootsHasVirtualKeyboard()
 	if err != nil {
 		return err
 	}
 
 	if hasVKB {
-		return feedKeyWlroots(key)
+		return feedKeyWlroots(modifiers, keycode)
 	}
 
-	return feedKeyLibei(key)
+	return feedKeyLibei(modifiers, keycode)
 }
 
-func feedKeyWlroots(key string) error {
-	modifiers, keycode, err := parseKeyString(key)
-	if err != nil {
-		return err
-	}
+func feedKeyWlroots(modifiers []string, keycode uint32) error {
+	var err error
 
 	// 1. Press modifiers through the ref-counting dispatcher so that
 	// modifiers already held (e.g. by sticky modifiers) are not
 	// released when this feed sequence ends.
 	for _, modifier := range modifiers {
-		err := WaylandModifierEvent(modifier, true)
+		err = WaylandModifierEvent(modifier, true)
 		if err != nil {
 			for j := range modifiers {
 				if j >= len(modifiers) {
@@ -156,7 +161,7 @@ func feedKeyWlroots(key string) error {
 	return err
 }
 
-func feedKeyLibei(key string) error {
+func feedKeyLibei(modifiers []string, keycode uint32) error {
 	if !libeiHasKeyboard() {
 		return derrors.New(
 			derrors.CodeNotSupported,
@@ -165,17 +170,14 @@ func feedKeyLibei(key string) error {
 		)
 	}
 
-	modifiers, keycode, err := parseKeyString(key)
-	if err != nil {
-		return err
-	}
+	var err error
 
 	// 1. Press modifier keys through the ref-counting dispatcher. On KDE
 	// the dispatcher routes to waylandModifierEvent -> libeiKey, but the
 	// ref-count prevents releasing a modifier that another consumer (sticky
 	// modifiers, accessibility clicks) still holds.
 	for _, modifier := range modifiers {
-		err := WaylandModifierEvent(modifier, true)
+		err = WaylandModifierEvent(modifier, true)
 		if err != nil {
 			for j := range modifiers {
 				if j >= len(modifiers) {

--- a/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
@@ -1,0 +1,251 @@
+//go:build linux
+
+package linux
+
+import (
+	"slices"
+	"strings"
+
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+)
+
+// evdevKeycode maps canonical key names (lowercase) to evdev keycodes.
+// Based on linux/input-event-codes.h KEY_* constants.
+//
+//nolint:mnd // evdev keycodes are hardware constants, not magic numbers.
+var evdevKeycode = map[string]uint32{
+	// Letters
+	"a": 30, "b": 48, "c": 46, "d": 32, "e": 18, "f": 33, "g": 34, "h": 35,
+	"i": 23, "j": 36, "k": 37, "l": 38, "m": 50, "n": 49, "o": 24, "p": 25,
+	"q": 16, "r": 19, "s": 31, "t": 20, "u": 22, "v": 47, "w": 17, "x": 45,
+	"y": 21, "z": 44,
+	// Digits
+	"0": 11, "1": 2, "2": 3, "3": 4, "4": 5, "5": 6, "6": 7, "7": 8, "8": 9, "9": 10,
+	// Function keys
+	"f1": 59, "f2": 60, "f3": 61, "f4": 62, "f5": 63, "f6": 64,
+	"f7": 65, "f8": 66, "f9": 67, "f10": 68, "f11": 87, "f12": 88,
+	"f13": 183, "f14": 184, "f15": 185, "f16": 186, "f17": 187, "f18": 188,
+	"f19": 189, "f20": 190, "f21": 191, "f22": 192, "f23": 193, "f24": 194,
+	// Named keys
+	"space":     57,
+	"return":    28,
+	"enter":     28,
+	"tab":       15,
+	"escape":    1,
+	"backspace": 14,
+	"delete":    111,
+	"home":      102,
+	"end":       107,
+	"pageup":    104,
+	"pagedown":  109,
+	"up":        103,
+	"down":      108,
+	"left":      105,
+	"right":     106,
+	// Punctuation and symbols
+	"comma":        51,
+	"period":       52,
+	"semicolon":    39,
+	"quote":        40,
+	"apostrophe":   40,
+	"slash":        53,
+	"backslash":    43,
+	"bracketleft":  26,
+	"bracketright": 27,
+	"minus":        12,
+	"equal":        13,
+	"grave":        41,
+	// Character aliases for punctuation
+	",":  51,
+	".":  52,
+	";":  39,
+	"'":  40,
+	"/":  53,
+	"\\": 43,
+	"[":  26,
+	"]":  27,
+	"-":  12,
+	"=":  13,
+	"`":  41,
+	// Numpad
+	"kp0": 82, "kp1": 79, "kp2": 80, "kp3": 81, "kp4": 75,
+	"kp5": 76, "kp6": 77, "kp7": 71, "kp8": 72, "kp9": 73,
+	"kpdot":      83,
+	"kpdivide":   98,
+	"kpmultiply": 55,
+	"kpminus":    74,
+	"kpplus":     78,
+	"kpenter":    96,
+}
+
+// modifierNameMap maps display-form modifier names (from
+// CanonicalHotkeyForPlatform) to the lowercase names expected by
+// neru_wlr_modifier_event / waylandModifierEvent.
+var modifierNameMap = map[string]string{
+	modNameCtrl:  modNameCtrl,
+	modNameShift: modNameShift,
+	modNameAlt:   modNameAlt,
+	"super":      modNameCmd,
+	modNameCmd:   modNameCmd,
+}
+
+// FeedKey injects a key or key chord into the Wayland compositor.
+// The key string must already be in canonical form (as returned by
+// config.CanonicalHotkeyForPlatform).
+//
+// Supported formats:
+//   - single key: "a", "Return", "F1"
+//   - modifier+key: "Ctrl+c", "Shift+F1", "Ctrl+Shift+Space"
+//
+// Backend selection:
+//   - wlroots compositors (niri, Sway, Hyprland, River) use
+//     zwp_virtual_keyboard_v1.
+//   - KDE/KWin uses libei / RemoteDesktop portal when a keyboard device was
+//     granted by the user (the portal defaults to pointer-only, so keyboard
+//     may be unavailable).
+func FeedKey(key string) error {
+	hasVKB, err := wlrootsHasVirtualKeyboard()
+	if err != nil {
+		return err
+	}
+
+	if hasVKB {
+		return feedKeyWlroots(key)
+	}
+
+	return feedKeyLibei(key)
+}
+
+func feedKeyWlroots(key string) error {
+	modifiers, keycode, err := parseKeyString(key)
+	if err != nil {
+		return err
+	}
+
+	// 1. Press modifiers via protocol-level modifier state.
+	for _, modifier := range modifiers {
+		err := wlrootsModifierEvent(modifier, true)
+		if err != nil {
+			for j := range modifiers {
+				if j >= len(modifiers) {
+					break
+				}
+
+				_ = wlrootsModifierEvent(modifiers[j], false)
+			}
+
+			return err
+		}
+	}
+
+	// 2. Press and release the main key.
+	err = wlrootsKey(keycode, true)
+	if err == nil {
+		err = wlrootsKey(keycode, false)
+	}
+
+	// 3. Release modifiers in reverse order.
+	for _, v := range slices.Backward(modifiers) {
+		_ = wlrootsModifierEvent(v, false)
+	}
+
+	return err
+}
+
+func feedKeyLibei(key string) error {
+	if !libeiHasKeyboard() {
+		return derrors.New(
+			derrors.CodeNotSupported,
+			"key feeding unavailable on KDE: the RemoteDesktop portal session "+
+				"did not grant a keyboard device; only a pointer was granted",
+		)
+	}
+
+	modifiers, keycode, err := parseKeyString(key)
+	if err != nil {
+		return err
+	}
+
+	// Modifier names to evdev keycodes for the libei path (actual key presses).
+	modCode := func(name string) (int, bool) {
+		code, ok := libeiModifierKeycodes[name]
+
+		return code, ok
+	}
+
+	// 1. Press modifier keys.
+	for _, mod := range modifiers {
+		code, ok := modCode(mod)
+		if !ok {
+			return derrors.Newf(
+				derrors.CodeInvalidInput,
+				"unsupported modifier %q for libei keyboard",
+				mod,
+			)
+		}
+
+		err := libeiKey(code, true)
+		if err != nil {
+			for j := range modifiers {
+				if j >= len(modifiers) {
+					break
+				}
+
+				if releaseCode, ok2 := modCode(modifiers[j]); ok2 {
+					_ = libeiKey(releaseCode, false)
+				}
+			}
+
+			return err
+		}
+	}
+
+	// 2. Press and release the main key.
+	err = libeiKey(int(keycode), true)
+	if err == nil {
+		err = libeiKey(int(keycode), false)
+	}
+
+	// 3. Release modifier keys in reverse order.
+	for _, v := range slices.Backward(modifiers) {
+		if releaseCode, ok := modCode(v); ok {
+			_ = libeiKey(releaseCode, false)
+		}
+	}
+
+	return err
+}
+
+// parseKeyString splits a canonical key string into modifier names and
+// an evdev keycode. Returns the modifiers (lowercase internal names,
+// e.g. "ctrl", "shift") and the main key's evdev keycode.
+func parseKeyString(key string) ([]string, uint32, error) {
+	parts := strings.Split(key, "+")
+
+	var modifiers []string
+
+	// Identify modifiers (all parts except the last).
+	for i := range len(parts) - 1 {
+		lower := strings.ToLower(strings.TrimSpace(parts[i]))
+
+		internal, ok := modifierNameMap[lower]
+		if !ok {
+			return nil, 0, derrors.Newf(derrors.CodeInvalidInput, "unknown modifier %q", parts[i])
+		}
+
+		modifiers = append(modifiers, internal)
+	}
+
+	// Identify the main key (last part).
+	mainKey := strings.TrimSpace(parts[len(parts)-1])
+	if mainKey == "" {
+		return nil, 0, derrors.New(derrors.CodeInvalidInput, "key is required")
+	}
+
+	code, ok := evdevKeycode[strings.ToLower(mainKey)]
+	if !ok {
+		return nil, 0, derrors.Newf(derrors.CodeInvalidInput, "unsupported key %q", mainKey)
+	}
+
+	return modifiers, code, nil
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
@@ -158,7 +158,16 @@ func feedKeyWlroots(modifiers []string, keycode uint32) error {
 }
 
 func feedKeyLibei(modifiers []string, keycode uint32) error {
-	if !libeiHasKeyboard() {
+	hasKeyboard, busy := libeiHasKeyboard()
+	if busy {
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"libei session busy: RemoteDesktop portal warm-up in progress; "+
+				"approve the one-time consent prompt, then retry",
+		)
+	}
+
+	if !hasKeyboard {
 		return derrors.New(
 			derrors.CodeNotSupported,
 			"key feeding unavailable on KDE: the RemoteDesktop portal session "+

--- a/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
@@ -122,16 +122,18 @@ func feedKeyWlroots(key string) error {
 		return err
 	}
 
-	// 1. Press modifiers via protocol-level modifier state.
+	// 1. Press modifiers through the ref-counting dispatcher so that
+	// modifiers already held (e.g. by sticky modifiers) are not
+	// released when this feed sequence ends.
 	for _, modifier := range modifiers {
-		err := wlrootsModifierEvent(modifier, true)
+		err := WaylandModifierEvent(modifier, true)
 		if err != nil {
 			for j := range modifiers {
 				if j >= len(modifiers) {
 					break
 				}
 
-				_ = wlrootsModifierEvent(modifiers[j], false)
+				_ = WaylandModifierEvent(modifiers[j], false)
 			}
 
 			return err
@@ -144,9 +146,11 @@ func feedKeyWlroots(key string) error {
 		err = wlrootsKey(keycode, false)
 	}
 
-	// 3. Release modifiers in reverse order.
+	// 3. Release modifiers in reverse order. The dispatcher ref-count
+	// suppresses the actual compositor release if another consumer
+	// (sticky modifiers, accessibility clicks) still holds the modifier.
 	for _, v := range slices.Backward(modifiers) {
-		_ = wlrootsModifierEvent(v, false)
+		_ = WaylandModifierEvent(v, false)
 	}
 
 	return err
@@ -166,34 +170,19 @@ func feedKeyLibei(key string) error {
 		return err
 	}
 
-	// Modifier names to evdev keycodes for the libei path (actual key presses).
-	modCode := func(name string) (int, bool) {
-		code, ok := libeiModifierKeycodes[name]
-
-		return code, ok
-	}
-
-	// 1. Press modifier keys.
-	for _, mod := range modifiers {
-		code, ok := modCode(mod)
-		if !ok {
-			return derrors.Newf(
-				derrors.CodeInvalidInput,
-				"unsupported modifier %q for libei keyboard",
-				mod,
-			)
-		}
-
-		err := libeiKey(code, true)
+	// 1. Press modifier keys through the ref-counting dispatcher. On KDE
+	// the dispatcher routes to waylandModifierEvent -> libeiKey, but the
+	// ref-count prevents releasing a modifier that another consumer (sticky
+	// modifiers, accessibility clicks) still holds.
+	for _, modifier := range modifiers {
+		err := WaylandModifierEvent(modifier, true)
 		if err != nil {
 			for j := range modifiers {
 				if j >= len(modifiers) {
 					break
 				}
 
-				if releaseCode, ok2 := modCode(modifiers[j]); ok2 {
-					_ = libeiKey(releaseCode, false)
-				}
+				_ = WaylandModifierEvent(modifiers[j], false)
 			}
 
 			return err
@@ -206,11 +195,11 @@ func feedKeyLibei(key string) error {
 		err = libeiKey(int(keycode), false)
 	}
 
-	// 3. Release modifier keys in reverse order.
+	// 3. Release modifier keys in reverse order. The dispatcher ref-count
+	// suppresses the actual compositor release if another consumer still
+	// holds the modifier.
 	for _, v := range slices.Backward(modifiers) {
-		if releaseCode, ok := modCode(v); ok {
-			_ = libeiKey(releaseCode, false)
-		}
+		_ = WaylandModifierEvent(v, false)
 	}
 
 	return err

--- a/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
@@ -130,14 +130,10 @@ func feedKeyWlroots(modifiers []string, keycode uint32) error {
 	// 1. Press modifiers through the ref-counting dispatcher so that
 	// modifiers already held (e.g. by sticky modifiers) are not
 	// released when this feed sequence ends.
-	for _, modifier := range modifiers {
+	for i, modifier := range modifiers {
 		err = WaylandModifierEvent(modifier, true)
 		if err != nil {
-			for j := range modifiers {
-				if j >= len(modifiers) {
-					break
-				}
-
+			for j := range i {
 				_ = WaylandModifierEvent(modifiers[j], false)
 			}
 
@@ -176,14 +172,10 @@ func feedKeyLibei(modifiers []string, keycode uint32) error {
 	// the dispatcher routes to waylandModifierEvent -> libeiKey, but the
 	// ref-count prevents releasing a modifier that another consumer (sticky
 	// modifiers, accessibility clicks) still holds.
-	for _, modifier := range modifiers {
+	for i, modifier := range modifiers {
 		err = WaylandModifierEvent(modifier, true)
 		if err != nil {
-			for j := range modifiers {
-				if j >= len(modifiers) {
-					break
-				}
-
+			for j := range i {
 				_ = WaylandModifierEvent(modifiers[j], false)
 			}
 

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -485,6 +485,47 @@ func wlrootsModifierEvent(modifier string, isDown bool) error {
 	return nil
 }
 
+// wlrootsHasVirtualKeyboard reports whether the connected compositor advertises
+// a usable virtual keyboard (zwp_virtual_keyboard_v1).
+func wlrootsHasVirtualKeyboard() (bool, error) {
+	err := ensureWlrootsState()
+	if err != nil {
+		return false, err
+	}
+
+	globalWlrootsState.mu.RLock()
+	defer globalWlrootsState.mu.RUnlock()
+
+	return C.neru_wlr_has_virtual_keyboard(globalWlrootsState.client) != 0, nil //nolint:nlreturn
+}
+
+// wlrootsKey presses (pressed=true) or releases (pressed=false) a single key
+// identified by its evdev keycode on the virtual keyboard.
+func wlrootsKey(keycode uint32, pressed bool) error {
+	err := ensureWlrootsState()
+	if err != nil {
+		return err
+	}
+
+	globalWlrootsState.mu.Lock()
+	client := globalWlrootsState.client
+	defer globalWlrootsState.mu.Unlock()
+
+	pressedInt := 0
+	if pressed {
+		pressedInt = 1
+	}
+
+	if C.neru_wlr_key(client, C.uint32_t(keycode), C.int(pressedInt)) == 0 { //nolint:nlreturn
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"failed to post virtual keyboard key event",
+		)
+	}
+
+	return nil
+}
+
 // Exported button constants for use by the accessibility adapter.
 const (
 	WlrBtnLeft   = 0x110

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
@@ -117,6 +117,22 @@ func wlrootsSetCursor(point image.Point) error {
 	)
 }
 
+func wlrootsHasVirtualKeyboard() (bool, error) {
+	return false, derrors.New(
+		derrors.CodeNotSupported,
+		"wlroots backend requires CGO-enabled Linux builds",
+	)
+}
+
+func wlrootsKey(keycode uint32, pressed bool) error {
+	_, _ = keycode, pressed
+
+	return derrors.New(
+		derrors.CodeNotSupported,
+		"wlroots backend requires CGO-enabled Linux builds",
+	)
+}
+
 // Button constants matching the CGo version.
 const (
 	WlrBtnLeft   = 0x110

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -701,3 +701,18 @@ int neru_wlr_screen_info(NeruWlrootsClient *c, int idx, int *x, int *y, int *w, 
 int neru_wlr_has_virtual_pointer(NeruWlrootsClient *c) { return c && c->vptr != NULL; }
 
 int neru_wlr_has_virtual_keyboard(NeruWlrootsClient *c) { return c && c->vkeyboard != NULL && c->vkeyboard_ready; }
+
+int neru_wlr_key(NeruWlrootsClient *c, uint32_t keycode, int pressed) {
+	if (!c || !c->vkeyboard || !c->vkeyboard_ready)
+		return 0;
+
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	uint32_t time = (uint32_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+
+	pthread_mutex_lock(&c->display_mutex);
+	zwp_virtual_keyboard_v1_key(c->vkeyboard, time, keycode, pressed ? 1 : 0);
+	wl_display_flush(c->display);
+	pthread_mutex_unlock(&c->display_mutex);
+	return 1;
+}

--- a/internal/core/infra/platform/linux/wlroots_client.h
+++ b/internal/core/infra/platform/linux/wlroots_client.h
@@ -81,5 +81,6 @@ int neru_wlr_screen_count(NeruWlrootsClient *c);
 int neru_wlr_screen_info(NeruWlrootsClient *c, int idx, int *x, int *y, int *w, int *h, char *name_out, int name_len);
 int neru_wlr_has_virtual_pointer(NeruWlrootsClient *c);
 int neru_wlr_has_virtual_keyboard(NeruWlrootsClient *c);
+int neru_wlr_key(NeruWlrootsClient *c, uint32_t keycode, int pressed);
 
 #endif /* WLROOTS_CLIENT_H */


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR implements `action feed` command on Linux family, specifically wayland and kde. This will allow supported families to utilise commands like:

```bash
neru action feed a o e u # feed 'aoeu' to the os
neru action ctrl+b ctrl+g # some custom tmux command
neru action home # feed home key
neru action end # feed end key
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/c0bca364-d856-4651-8876-55d7b2b66e19

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
