### PR TITLE
fix(linux,kde): work around KDE EIS keyboard drop bug

### DIFF
--- a/cmd/neru/daemon_host_linux.go
+++ b/cmd/neru/daemon_host_linux.go
@@ -41,6 +41,18 @@ func (linuxDaemonHost) Run(application *app.App) error {
 			return
 		}
 
+		if !linux.HasKeyboard() {
+			application.Logger().Warn(
+				"Wayland input warm-up complete but RemoteDesktop portal did not grant a " +
+					"keyboard device; \"action feed\" and sticky modifiers will be unavailable. " +
+					"Restart neru and check \"Enable keyboard\" in the consent prompt; if the " +
+					"prompt does not appear, run `flatpak permission-remove kde-authorized " +
+					"remote-desktop \"\"` first to clear the saved grant",
+			)
+
+			return
+		}
+
 		application.Logger().Info("Wayland input warm-up complete")
 	}()
 

--- a/docs/LINUX_DESKTOPS.md
+++ b/docs/LINUX_DESKTOPS.md
@@ -108,10 +108,29 @@ compositors that lack both virtual pointer and a libei path.
 
 **"key feeding unavailable on KDE: the RemoteDesktop portal session did not grant a keyboard device"**
 
-The portal commonly grants pointer capability only. To enable key feeding on
-KDE, the portal session must include a keyboard device — this depends on the
-portal backend and KDE version. On most setups, keyboard is unavailable for
-security reasons. There is no user-facing toggle to request it.
+The RemoteDesktop portal defaults to pointer-only capability. To enable key
+feeding on KDE, start with a fresh portal grant:
+
+**Option A — Plasma 6.5+:** Open **System Settings → Applications → Remote
+Desktop**, find any saved `neru` permission, and remove it.
+
+**Option B — Plasma 6.3+ (CLI):** Run:
+```sh
+flatpak permission-remove kde-authorized remote-desktop ""
+```
+
+This clears KDE's portal permission store for host applications. The command
+works on any Plasma ≥ 6.3 regardless of whether `flatpak` packages are used.
+
+After clearing the saved permission:
+
+1. Restart the `neru` daemon.
+2. When the **"Remote Control" consent prompt** appears by
+   `xdg-desktop-portal-kde`, **check the "Enable keyboard" box** before
+   clicking "Allow".
+
+The daemon's startup log confirms success with `"Wayland input warm-up
+complete"` (keyboard available) or a warning when keyboard was not granted.
 
 **Verifying injected input with the KWin Debug Console**
 

--- a/internal/core/infra/platform/linux/libei_client.c
+++ b/internal/core/infra/platform/linux/libei_client.c
@@ -11,6 +11,9 @@ struct NeruEiClient {
 	struct oeffis *oeffis;
 	struct ei *ei;
 
+	struct ei_seat *seat;  // Saved seat for two-stage capability bind
+	int seat_caps_bound;   // Keyboard bound, pointer caps still pending
+
 	struct ei_device *pointer;
 	int pointer_resumed;
 	int pointer_emulating;
@@ -54,14 +57,17 @@ static void drain(NeruEiClient *c) {
 	while ((e = ei_get_event(c->ei)) != NULL) {
 		switch (ei_event_get_type(e)) {
 		case EI_EVENT_SEAT_ADDED: {
-			struct ei_seat *seat = ei_event_get_seat(e);
-			// Bind relative pointer alongside absolute: after an absolute warp
-			// KWin updates the logical pointer (clicks land) but does not always
-			// repaint the visible cursor sprite. A zero-delta relative motion on
-			// the same device forces the sprite to snap to the warped position.
-			ei_seat_bind_capabilities(
-			    seat, EI_DEVICE_CAP_POINTER, EI_DEVICE_CAP_POINTER_ABSOLUTE, EI_DEVICE_CAP_BUTTON, EI_DEVICE_CAP_SCROLL,
-			    EI_DEVICE_CAP_KEYBOARD, NULL);
+			struct ei_seat *s = ei_event_get_seat(e);
+			if (!c->seat) {
+				c->seat = ei_seat_ref(s);
+				// Stage 1: bind keyboard alone. KWin's EIS implementation
+				// silently drops the keyboard device when it is bound
+				// alongside pointer capabilities in a single call (KDE bug
+				// (https://bugs.kde.org/show_bug.cgi?id=520464, confirmed on Plasma 6). After this bind is flushed
+				// and the keyboard device exists, a second bind adds the
+				// pointer capabilities without affecting the keyboard.
+				ei_seat_bind_capabilities(s, EI_DEVICE_CAP_KEYBOARD, NULL);
+			}
 			break;
 		}
 		case EI_EVENT_DEVICE_ADDED: {
@@ -199,6 +205,43 @@ NeruEiClient *neru_ei_connect(int timeout_ms) {
 		}
 		ei_dispatch(c->ei);
 		drain(c);
+
+		// Two-stage capability bind: KDE bug https://bugs.kde.org/show_bug.cgi?id=520464 causes KWin to silently
+		// drop the keyboard device when keyboard and pointer are bound together
+		// in a single ei_seat_bind_capabilities() call. The workaround:
+		//   Stage 1 (in drain's EI_EVENT_SEAT_ADDED handler) binds keyboard
+		//   alone so the keyboard device is created before any pointer caps
+		//   are requested.
+		//   Stage 2 (here) flushes the keyboard bind, then binds the remaining
+		//   pointer capabilities. KWin sees the keyboard already exists and
+		//   keeps it, while also creating the pointer devices.
+		if (c->seat && !c->seat_caps_bound) {
+			ei_dispatch(c->ei);
+			// Drain any keyboard device events that arrived in response to
+			// the stage 1 bind before queuing stage 2, so c->keyboard and
+			// c->keyboard_resumed reflect the actual state.
+			drain(c);
+			ei_seat_bind_capabilities(
+			    c->seat, EI_DEVICE_CAP_KEYBOARD, EI_DEVICE_CAP_POINTER, EI_DEVICE_CAP_POINTER_ABSOLUTE,
+			    EI_DEVICE_CAP_BUTTON, EI_DEVICE_CAP_SCROLL, NULL);
+			c->seat_caps_bound = 1;
+		}
+	}
+
+	// 3b) Give the keyboard device a brief extra window to appear after the
+	// pointer. The portal may advertise both devices but the keyboard add/resume
+	// events can arrive slightly later. If keyboard was not granted by the portal
+	// this loop simply times out in ~1 s and the connection still succeeds so
+	// pointer/click/scroll work. The caller can check neru_ei_has_keyboard.
+	{
+		int64_t kbd_deadline = now_ms() + 1000;
+		while (!c->keyboard_resumed && now_ms() < kbd_deadline) {
+			if (wait_readable(efd, kbd_deadline) != 1) {
+				break;
+			}
+			ei_dispatch(c->ei);
+			drain(c);
+		}
 	}
 
 	return c;
@@ -219,6 +262,9 @@ void neru_ei_disconnect(NeruEiClient *c) {
 			ei_device_stop_emulating(c->keyboard);
 		}
 		ei_device_unref(c->keyboard);
+	}
+	if (c->seat) {
+		ei_seat_unref(c->seat);
 	}
 	if (c->ei) {
 		ei_unref(c->ei);
@@ -298,4 +344,16 @@ int neru_ei_key(NeruEiClient *c, int keycode, int pressed) {
 	return 1;
 }
 
-int neru_ei_has_keyboard(NeruEiClient *c) { return c && c->keyboard != NULL; }
+int neru_ei_has_keyboard(NeruEiClient *c) {
+	if (!c) {
+		return 0;
+	}
+	// The keyboard device may have been added/resumed after we finished waiting
+	// in neru_ei_connect (which only waits for the pointer device). Pump any
+	// pending EIS events so the keyboard state is visible to the caller.
+	pump(c);
+	// Only check device existence, not resume state: a transient pause by the
+	// compositor would otherwise make the Go layer report a permanent "not
+	// granted" error even though the device exists and will be resumed shortly.
+	return c->keyboard != NULL;
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland_input.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_input.go
@@ -86,6 +86,10 @@ func libeiButtonRelease(button int) error {
 // action does not block on the dialog past the IPC timeout. Best-effort: errors
 // (no Wayland session, consent declined) are returned for logging and the lazy
 // path remains as a fallback.
+//
+// When the session is established without a keyboard device, the function still
+// succeeds (pointer/click/scroll work) so that error messages about keyboard
+// availability come from the caller, not from this warm-up path.
 func WarmWaylandInput() error {
 	if os.Getenv("WAYLAND_DISPLAY") == "" {
 		return nil
@@ -101,6 +105,29 @@ func WarmWaylandInput() error {
 	}
 
 	return libeiEnsure()
+}
+
+// HasKeyboard reports whether the Wayland backend can inject keyboard events.
+// On wlroots compositors it always returns true (zwp_virtual_keyboard_v1 is
+// available). On KDE/KWin it reflects whether the RemoteDesktop portal grant
+// included keyboard capability. Safe to call before any warm-up (returns false
+// if no session exists yet). On X11 / non-Wayland sessions it returns true
+// (keyboard injection goes through XTest, not through this backend).
+func HasKeyboard() bool {
+	if os.Getenv("WAYLAND_DISPLAY") == "" {
+		return true
+	}
+
+	// wlroots compositors provide a virtual keyboard regardless of any portal
+	// grant, so we must check that path first before querying the libei state.
+	hasVKB, err := wlrootsHasVirtualKeyboard()
+	if err == nil && hasVKB {
+		return true
+	}
+
+	has, _ := libeiHasKeyboard()
+
+	return has
 }
 
 func waylandMoveCursorToPoint(point image.Point) error {

--- a/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
@@ -193,7 +193,10 @@ func libeiKey(keycode int, pressed bool) error {
 		return derrors.New(
 			derrors.CodeNotSupported,
 			"libei keyboard injection unavailable; the RemoteDesktop portal "+
-				"session did not grant a keyboard device",
+				"session did not grant a keyboard device. Restart neru and "+
+				"check \"Enable keyboard\" in the consent prompt; if the prompt "+
+				"does not appear, run `flatpak permission-remove kde-authorized "+
+				"remote-desktop \"\"` first to clear the saved grant",
 		)
 	}
 

--- a/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
@@ -171,7 +171,10 @@ func feedKeyLibei(modifiers []string, keycode uint32) error {
 		return derrors.New(
 			derrors.CodeNotSupported,
 			"key feeding unavailable on KDE: the RemoteDesktop portal session "+
-				"did not grant a keyboard device; only a pointer was granted",
+				"did not grant a keyboard device. Restart neru and check "+
+				"\"Enable keyboard\" in the consent prompt; if the prompt "+
+				"does not appear, run `flatpak permission-remove kde-authorized "+
+				"remote-desktop \"\"` first to clear the saved grant",
 		)
 	}
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes `action feed` on KDE Plasma Wayland. 2 issues that causes it to not work as expected:

- KDE bug [520464](https://bugs.kde.org/show_bug.cgi?id=520464), where kWin silently drops the keyboard device when `ei_seat_bind_capabilities` is called with keyboard alongside pointer in a single call.
- `neru_ei_has_keyboard` doesn't pump the pending EIS events.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A