### PR TITLE
fix(linux): recover from stale evdev/libei connections after sleep and config reload

### DIFF
--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -30,6 +30,9 @@ func (a *App) ReloadConfig(ctx context.Context, configPath string) error {
 	a.applyAppSpecificConfigUpdates(loadResult)
 	a.reconfigureAfterUpdate(loadResult)
 
+	// On Linux, verify the hotkey listener started correctly after reload.
+	a.schedulePostReloadVerification()
+
 	return nil
 }
 

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -76,6 +76,8 @@ func (a *App) Run() error {
 	a.refreshHotkeysForAppOrCurrent("")
 	a.logger.Info("Hotkeys initialized")
 
+	a.setupSleepObserver()
+
 	a.setupAppWatcherCallbacks()
 
 	if cfg.Grid.EnableGC {
@@ -598,6 +600,7 @@ func (a *App) Cleanup() {
 		// Stop theme observer: nil the handler first so any in-flight KVO callback
 		// (between the async dispatch and actual observer removal) is a no-op.
 		a.stopThemeObserver()
+		a.stopSleepObserver()
 		// Stop IPC server first to prevent new requests.
 		// Use a fresh context instead of a.ctx since the root context was
 		// canceled above; a canceled context would cause Stop() to fail

--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -1,0 +1,224 @@
+//go:build linux
+
+package app
+
+import (
+	"sync"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/infra/platform/linux"
+)
+
+const (
+	sleepSignalBuffer = 8
+	login1Interface   = "org.freedesktop.login1.Manager"
+	login1Member      = "PrepareForSleep"
+	// hibernateReinitDelay is how long after PrepareForSleep(true) we wait
+	// before reinitialising. If PrepareForSleep(false) (normal resume) arrives
+	// within this window, the reinit is cancelled. This handles the systemd
+	// bug (https://github.com/systemd/systemd/issues/30666) where
+	// PrepareForSleep(false) is not emitted after hibernation.
+	hibernateReinitDelay = 10 * time.Second
+	// postReloadCheckDelay is how long after a config reload we wait before
+	// verifying the hotkey listener started correctly.
+	postReloadCheckDelay = 2 * time.Second
+)
+
+// Package-level resources for sleep observer cleanup. Stored here (rather than
+// on App) so that non-Linux builds never reference the D-Bus types or fields.
+var (
+	sleepStopChan  chan struct{}
+	sleepDBusClose func() error
+	sleepWG        sync.WaitGroup
+	// hibernateReinitTimer fires after hibernateReinitDelay unless cancelled by
+	// a matching PrepareForSleep(false) signal.
+	hibernateReinitTimer *time.Timer
+)
+
+// setupSleepObserver subscribes to logind's PrepareForSleep D-Bus signal. On
+// wake (signal with body=false) it reinitializes the evdev-based hotkey
+// listener and the libei input session, both of which go stale after system
+// suspend.
+//
+// On PrepareForSleep(true) it arms a deferred reinit timer that fires
+// hibernateReinitDelay later unless cancelled by a matching
+// PrepareForSleep(false). This covers the systemd bug
+// (https://github.com/systemd/systemd/issues/30666) where the resume signal
+// is not emitted after hibernation.
+func (a *App) setupSleepObserver() {
+	sleepStopChan = make(chan struct{})
+
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		a.logger.Warn(
+			"D-Bus system bus unavailable, cannot listen for sleep/wake signals; "+
+				"evdev hotkey listeners may fail after system suspend",
+			zap.Error(err),
+		)
+
+		return
+	}
+
+	err = conn.AddMatchSignal(
+		dbus.WithMatchInterface(login1Interface),
+		dbus.WithMatchMember(login1Member),
+	)
+	if err != nil {
+		a.logger.Warn("Failed to subscribe to logind sleep signals", zap.Error(err))
+
+		_ = conn.Close()
+
+		return
+	}
+
+	signalCh := make(chan *dbus.Signal, sleepSignalBuffer)
+	conn.Signal(signalCh)
+	sleepDBusClose = conn.Close
+
+	sleepWG.Add(1)
+
+	go func() {
+		defer sleepWG.Done()
+
+		for {
+			select {
+			case <-sleepStopChan:
+				// Stop the deferred hibernation timer if one is running.
+				if hibernateReinitTimer != nil {
+					hibernateReinitTimer.Stop()
+				}
+
+				return
+			case signal, ok := <-signalCh:
+				if !ok {
+					return
+				}
+
+				if len(signal.Body) < 1 {
+					continue
+				}
+
+				preparing, ok := signal.Body[0].(bool)
+				if !ok {
+					continue
+				}
+
+				if preparing {
+					// Going to sleep/hibernate. Arm a deferred reinit in case
+					// the resume signal never arrives
+					// (https://github.com/systemd/systemd/issues/30666).
+					if hibernateReinitTimer == nil {
+						hibernateReinitTimer = time.AfterFunc(
+							hibernateReinitDelay,
+							a.handleWakeFromSleep,
+						)
+					} else {
+						hibernateReinitTimer.Reset(hibernateReinitDelay)
+					}
+				} else {
+					// Normal wake: cancel the deferred timer. If the timer
+					// already fired (Stop returns false), skip the reinit
+					// to avoid a redundant cycle.
+					timerFired := false
+					if hibernateReinitTimer != nil {
+						timerFired = !hibernateReinitTimer.Stop()
+					}
+
+					if !timerFired {
+						a.handleWakeFromSleep()
+					}
+				}
+			}
+		}
+	}()
+}
+
+// stopSleepObserver shuts down the D-Bus connection and signal goroutine
+// by closing the D-Bus connection and signaling the stop channel.
+func (a *App) stopSleepObserver() {
+	close(sleepStopChan)
+
+	if sleepDBusClose != nil {
+		_ = sleepDBusClose()
+	}
+
+	sleepWG.Wait()
+}
+
+// handleWakeFromSleep reinitializes all input subsystems after the system
+// resumes from suspend, or after a health check detects stale connections.
+// Called from the logind PrepareForSleep(false) signal handler, the deferred
+// hibernation timer, and the post-reload verification.
+func (a *App) handleWakeFromSleep() {
+	a.logger.Info("Reinitializing input listeners after sleep/wake or stale evdev")
+
+	// Step 1: Exit any active navigation mode. This stops the in-mode evdev
+	// EventTap and cleans up the overlay. Safe to call when already idle.
+	a.ExitMode()
+
+	// Step 2: Re-register global hotkeys. The stop+restart cycle closes stale
+	// evdev file descriptors and opens fresh ones, reviving the GlobalHotkeyListener.
+	a.hotkeyRegistrationMu.Lock()
+	needReregister := a.appState.HotkeysRegistered()
+	if needReregister {
+		a.stopAllHotkeyRepeats()
+		a.hotkeyManager.UnregisterAll()
+		a.appState.SetHotkeysRegistered(false)
+	}
+
+	a.hotkeyRegistrationMu.Unlock()
+
+	if needReregister {
+		a.refreshHotkeysForAppOrCurrent("")
+	}
+
+	// Step 3: Reset the libei/RemoteDesktop session so the next input operation
+	// re-establishes the portal connection. The old socket is stale after the
+	// compositor reinitialized during resume.
+	linux.LibeiReset()
+
+	a.logger.Info("Input listeners reinitialized")
+}
+
+// schedulePostReloadVerification checks the hotkey listener is alive 2s after
+// a config reload and reinitialises if not. Catches the "first reload after
+// fresh start" lifecycle bug where Start() returns nil but the listener is
+// effectively dead.
+func (a *App) schedulePostReloadVerification() {
+	sleepWG.Add(1)
+
+	go func() {
+		defer sleepWG.Done()
+
+		timer := time.NewTimer(postReloadCheckDelay)
+		defer timer.Stop()
+
+		select {
+		case <-sleepStopChan:
+			return
+		case <-timer.C:
+			a.verifyHotkeyHealth()
+		}
+	}()
+}
+
+// verifyHotkeyHealth tests whether the global hotkey listener is alive when it
+// should be running, and triggers a full reinitialization if not.
+func (a *App) verifyHotkeyHealth() {
+	if !a.appState.HotkeysRegistered() {
+		return
+	}
+
+	hc, ok := a.hotkeyManager.(interface{ HealthCheck() bool })
+	if !ok {
+		return
+	}
+
+	if !hc.HealthCheck() {
+		a.logger.Warn("Hotkey listener not healthy after config reload; reinitialising")
+		a.handleWakeFromSleep()
+	}
+}

--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -36,6 +36,7 @@ var (
 	// hibernateReinitTimer fires after hibernateReinitDelay unless canceled by
 	// a matching PrepareForSleep(false) signal.
 	hibernateReinitTimer *time.Timer
+	hibernateTimerCh     <-chan time.Time
 )
 
 // setupSleepObserver subscribes to logind's PrepareForSleep D-Bus signal. On
@@ -82,12 +83,22 @@ func (a *App) setupSleepObserver() {
 		for {
 			select {
 			case <-sleepStopChan:
-				// Stop the deferred hibernation timer if one is running.
 				if hibernateReinitTimer != nil {
 					hibernateReinitTimer.Stop()
 				}
 
 				return
+			case <-hibernateTimerCh:
+				hibernateTimerCh = nil
+				hibernateReinitTimer = nil
+
+				select {
+				case <-sleepStopChan:
+					return
+				default:
+				}
+
+				a.handleWakeFromSleep()
 			case signal, chOpen := <-signalCh:
 				if !chOpen {
 					return
@@ -103,29 +114,21 @@ func (a *App) setupSleepObserver() {
 				}
 
 				if preparing {
-					// Going to sleep/hibernate. Arm a deferred reinit in case
-					// the resume signal never arrives
-					// (https://github.com/systemd/systemd/issues/30666).
-					if hibernateReinitTimer == nil {
-						hibernateReinitTimer = time.AfterFunc(
-							hibernateReinitDelay,
-							a.handleWakeFromSleep,
-						)
-					} else {
-						hibernateReinitTimer.Reset(hibernateReinitDelay)
-					}
-				} else {
-					// Normal wake: cancel the deferred timer. If the timer
-					// already fired (Stop returns false), skip the reinit
-					// to avoid a redundant cycle.
-					timerFired := false
 					if hibernateReinitTimer != nil {
-						timerFired = !hibernateReinitTimer.Stop()
+						hibernateReinitTimer.Stop()
 					}
 
-					if !timerFired {
-						a.handleWakeFromSleep()
+					hibernateReinitTimer = time.NewTimer(hibernateReinitDelay)
+					hibernateTimerCh = hibernateReinitTimer.C
+				} else {
+					if hibernateReinitTimer != nil {
+						hibernateReinitTimer.Stop()
+
+						hibernateTimerCh = nil
+						hibernateReinitTimer = nil
 					}
+
+					a.handleWakeFromSleep()
 				}
 			}
 		}

--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -147,19 +147,15 @@ func (a *App) stopSleepObserver() {
 	sleepWG.Wait()
 }
 
-// handleWakeFromSleep reinitializes all input subsystems after the system
-// resumes from suspend, or after a health check detects stale connections.
-// Called from the logind PrepareForSleep(false) signal handler, the deferred
-// hibernation timer, and the post-reload verification.
-func (a *App) handleWakeFromSleep() {
-	a.logger.Info("Reinitializing input listeners after sleep/wake or stale evdev")
+// reinitializeHotkeys tears down and re-registers the global hotkey listener
+// without touching the libei/RemoteDesktop session. Use this for health-check
+// recovery after stale evdev fds; it avoids triggering a fresh RemoteDesktop
+// portal consent prompt.
+func (a *App) reinitializeHotkeys() {
+	a.logger.Info("Reinitializing hotkey listener (evdev only)")
 
-	// Step 1: Exit any active navigation mode. This stops the in-mode evdev
-	// EventTap and cleans up the overlay. Safe to call when already idle.
 	a.ExitMode()
 
-	// Step 2: Re-register global hotkeys. The stop+restart cycle closes stale
-	// evdev file descriptors and opens fresh ones, reviving the GlobalHotkeyListener.
 	a.hotkeyRegistrationMu.Lock()
 
 	needReregister := a.appState.HotkeysRegistered()
@@ -175,12 +171,29 @@ func (a *App) handleWakeFromSleep() {
 		a.refreshHotkeysForAppOrCurrent("")
 	}
 
-	// Step 3: Reset the libei/RemoteDesktop session so the next input operation
+	a.logger.Info("Hotkey listener reinitialized")
+}
+
+// handleWakeFromSleep reinitializes all input subsystems after the system
+// resumes from suspend. It re-registers the evdev-based hotkey listener and
+// resets the libei/RemoteDesktop portal session, both of which go stale when
+// the compositor reinitializes during resume.
+//
+// Called from the logind PrepareForSleep(false) signal handler and the
+// deferred hibernation timer. Do NOT call this from post-reload health
+// checks — use reinitializeHotkeys instead to avoid triggering a fresh
+// RemoteDesktop consent prompt on every recovery.
+func (a *App) handleWakeFromSleep() {
+	a.logger.Info("Reinitializing input listeners after sleep/wake")
+
+	a.reinitializeHotkeys()
+
+	// Reset the libei/RemoteDesktop session so the next input operation
 	// re-establishes the portal connection. The old socket is stale after the
 	// compositor reinitialized during resume.
 	linux.LibeiReset()
 
-	a.logger.Info("Input listeners reinitialized")
+	a.logger.Info("Input listeners reinitialized after sleep/wake")
 }
 
 // schedulePostReloadVerification checks the hotkey listener is alive 2s after
@@ -202,7 +215,9 @@ func (a *App) schedulePostReloadVerification() {
 }
 
 // verifyHotkeyHealth tests whether the global hotkey listener is alive when it
-// should be running, and triggers a full reinitialization if not.
+// should be running, and re-registers hotkeys if not. Uses evdev-only recovery
+// (reinitializeHotkeys) rather than the full handleWakeFromSleep so the
+// libei/RemoteDesktop session is not torn down unnecessarily.
 func (a *App) verifyHotkeyHealth() {
 	if !a.appState.HotkeysRegistered() {
 		return
@@ -215,6 +230,6 @@ func (a *App) verifyHotkeyHealth() {
 
 	if !hc.HealthCheck() {
 		a.logger.Warn("Hotkey listener not healthy after config reload; reinitialising")
-		a.handleWakeFromSleep()
+		a.reinitializeHotkeys()
 	}
 }

--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -18,8 +18,8 @@ const (
 	login1Member      = "PrepareForSleep"
 	// hibernateReinitDelay is how long after PrepareForSleep(true) we wait
 	// before reinitialising. If PrepareForSleep(false) (normal resume) arrives
-	// within this window, the reinit is cancelled. This handles the systemd
-	// bug (https://github.com/systemd/systemd/issues/30666) where
+	// within this window, the reinit is canceled. This handles the systemd
+	// issue (https://github.com/systemd/systemd/issues/30666) where
 	// PrepareForSleep(false) is not emitted after hibernation.
 	hibernateReinitDelay = 10 * time.Second
 	// postReloadCheckDelay is how long after a config reload we wait before
@@ -33,7 +33,7 @@ var (
 	sleepStopChan  chan struct{}
 	sleepDBusClose func() error
 	sleepWG        sync.WaitGroup
-	// hibernateReinitTimer fires after hibernateReinitDelay unless cancelled by
+	// hibernateReinitTimer fires after hibernateReinitDelay unless canceled by
 	// a matching PrepareForSleep(false) signal.
 	hibernateReinitTimer *time.Timer
 )
@@ -44,8 +44,8 @@ var (
 // suspend.
 //
 // On PrepareForSleep(true) it arms a deferred reinit timer that fires
-// hibernateReinitDelay later unless cancelled by a matching
-// PrepareForSleep(false). This covers the systemd bug
+// hibernateReinitDelay later unless canceled by a matching
+// PrepareForSleep(false). This covers the systemd issue
 // (https://github.com/systemd/systemd/issues/30666) where the resume signal
 // is not emitted after hibernation.
 func (a *App) setupSleepObserver() {
@@ -78,11 +78,7 @@ func (a *App) setupSleepObserver() {
 	conn.Signal(signalCh)
 	sleepDBusClose = conn.Close
 
-	sleepWG.Add(1)
-
-	go func() {
-		defer sleepWG.Done()
-
+	sleepWG.Go(func() {
 		for {
 			select {
 			case <-sleepStopChan:
@@ -92,8 +88,8 @@ func (a *App) setupSleepObserver() {
 				}
 
 				return
-			case signal, ok := <-signalCh:
-				if !ok {
+			case signal, chOpen := <-signalCh:
+				if !chOpen {
 					return
 				}
 
@@ -133,7 +129,7 @@ func (a *App) setupSleepObserver() {
 				}
 			}
 		}
-	}()
+	})
 }
 
 // stopSleepObserver shuts down the D-Bus connection and signal goroutine
@@ -162,6 +158,7 @@ func (a *App) handleWakeFromSleep() {
 	// Step 2: Re-register global hotkeys. The stop+restart cycle closes stale
 	// evdev file descriptors and opens fresh ones, reviving the GlobalHotkeyListener.
 	a.hotkeyRegistrationMu.Lock()
+
 	needReregister := a.appState.HotkeysRegistered()
 	if needReregister {
 		a.stopAllHotkeyRepeats()
@@ -188,11 +185,7 @@ func (a *App) handleWakeFromSleep() {
 // fresh start" lifecycle bug where Start() returns nil but the listener is
 // effectively dead.
 func (a *App) schedulePostReloadVerification() {
-	sleepWG.Add(1)
-
-	go func() {
-		defer sleepWG.Done()
-
+	sleepWG.Go(func() {
 		timer := time.NewTimer(postReloadCheckDelay)
 		defer timer.Stop()
 
@@ -202,7 +195,7 @@ func (a *App) schedulePostReloadVerification() {
 		case <-timer.C:
 			a.verifyHotkeyHealth()
 		}
-	}()
+	})
 }
 
 // verifyHotkeyHealth tests whether the global hotkey listener is alive when it

--- a/internal/app/sleep_handler_other.go
+++ b/internal/app/sleep_handler_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package app
+
+// setupSleepObserver is a no-op on non-Linux platforms. The evdev-based hotkey
+// listener and libei input session used on Wayland are Linux-only, and system
+// sleep/wake does not require special handling on Darwin or Windows.
+func (a *App) setupSleepObserver() {}
+
+// stopSleepObserver is a no-op on non-Linux platforms.
+func (a *App) stopSleepObserver() {}
+
+// schedulePostReloadVerification is a no-op on non-Linux platforms. The evdev
+// hotkey listener health check is Linux-only.
+func (a *App) schedulePostReloadVerification() {}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -123,11 +123,24 @@ func newWaylandEvdevCapture(logger *zap.Logger) (*waylandEvdevCapture, error) {
 	}
 
 	if len(capture.files) == 0 {
+		logger.Warn(
+			"No keyboard /dev/input/event* devices could be opened; "+
+				"check read permissions on /dev/input/event*",
+			zap.Int("total_event_devices", len(paths)),
+			zap.Error(errWaylandEvdevUnavailable),
+		)
+
 		return nil, fmt.Errorf(
 			"%w: no keyboard /dev/input/event* devices could be opened",
 			errWaylandEvdevUnavailable,
 		)
 	}
+
+	logger.Debug(
+		"Evdev capture created",
+		zap.Int("keyboard_devices", len(capture.files)),
+		zap.Int("total_event_devices", len(paths)),
+	)
 
 	return capture, nil
 }
@@ -142,6 +155,13 @@ func (capture *waylandEvdevCapture) Close() {
 
 		for _, file := range capture.files {
 			_ = file.Close()
+		}
+
+		if capture.logger != nil {
+			capture.logger.Debug(
+				"Evdev capture closed",
+				zap.Int("devices", len(capture.files)),
+			)
 		}
 	})
 }
@@ -169,6 +189,14 @@ func (capture *waylandEvdevCapture) readLoop(file *os.File) {
 
 		readResult := C.neru_evdev_read_event(fd, &inputEvent)
 		if readResult <= 0 {
+			if capture.logger != nil {
+				capture.logger.Debug(
+					"Evdev reader exiting",
+					zap.String("device", file.Name()),
+					zap.Int("read_result", readResult),
+				)
+			}
+
 			return
 		}
 

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -193,7 +193,7 @@ func (capture *waylandEvdevCapture) readLoop(file *os.File) {
 				capture.logger.Debug(
 					"Evdev reader exiting",
 					zap.String("device", file.Name()),
-					zap.Int("read_result", readResult),
+					zap.Int("read_result", int(readResult)),
 				)
 			}
 

--- a/internal/core/infra/eventtap/global_hotkey_linux_cgo.go
+++ b/internal/core/infra/eventtap/global_hotkey_linux_cgo.go
@@ -124,12 +124,83 @@ func (l *GlobalHotkeyListener) run(capture *waylandEvdevCapture, stopCh chan str
 			return
 		case event, ok := <-capture.events:
 			if !ok {
-				return
+				// Events channel closed: all reader goroutines exited. This can
+				// happen when the evdev file descriptors become stale after
+				// sleep/wake or device disconnection. Auto-restart the capture
+				// unless Stop() was already called.
+				if !l.tryRestartLocked(&capture, &stopCh, &state) {
+					return
+				}
+
+				continue
 			}
 
 			l.handleEvent(&state, event)
 		}
 	}
+}
+
+// tryRestartLocked attempts to re-establish the evdev capture after a reader
+// failure. The caller must NOT hold l.mu. Returns true when the capture was
+// replaced successfully and the loop should continue; false when Stop was
+// called concurrently or evdev remains unavailable and the loop must exit.
+func (l *GlobalHotkeyListener) tryRestartLocked(
+	capture **waylandEvdevCapture,
+	stopCh *chan struct{},
+	state *waylandEvdevKeyState,
+) bool {
+	l.mu.Lock()
+
+	if !l.running {
+		l.mu.Unlock()
+
+		return false
+	}
+
+	newCapture, err := newWaylandEvdevCapture(l.logger)
+	if err != nil {
+		l.logger.Warn(
+			"Evdev hotkey listener readers died and reconnection failed; "+
+				"global hotkeys will stop working until neru is restarted",
+			zap.Error(err),
+		)
+		l.running = false
+		l.mu.Unlock()
+
+		return false
+	}
+
+	newCapture.startReaders()
+
+	// Close the old capture in the background so we don't hold l.mu across
+	// the blocking ungrab/close calls.
+	oldCapture := *capture
+
+	*capture = newCapture
+	*stopCh = make(chan struct{})
+	*state = waylandEvdevKeyState{pressed: make(map[uint16]bool)}
+	l.capture = newCapture
+	l.stopCh = *stopCh
+	l.mu.Unlock()
+
+	if oldCapture != nil {
+		go oldCapture.Close()
+	}
+
+	l.logger.Info(
+		"Evdev hotkey listener reconnected after reader failure",
+		zap.Int("devices", len(newCapture.files)),
+	)
+
+	return true
+}
+
+// IsRunning reports whether the listener is actively watching for chords.
+func (l *GlobalHotkeyListener) IsRunning() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.running
 }
 
 func (l *GlobalHotkeyListener) handleEvent(

--- a/internal/core/infra/eventtap/global_hotkey_linux_cgo.go
+++ b/internal/core/infra/eventtap/global_hotkey_linux_cgo.go
@@ -115,6 +115,14 @@ func (l *GlobalHotkeyListener) Stop() {
 	}
 }
 
+// IsRunning reports whether the listener is actively watching for chords.
+func (l *GlobalHotkeyListener) IsRunning() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.running
+}
+
 func (l *GlobalHotkeyListener) run(capture *waylandEvdevCapture, stopCh chan struct{}) {
 	state := waylandEvdevKeyState{pressed: make(map[uint16]bool)}
 
@@ -124,10 +132,6 @@ func (l *GlobalHotkeyListener) run(capture *waylandEvdevCapture, stopCh chan str
 			return
 		case event, ok := <-capture.events:
 			if !ok {
-				// Events channel closed: all reader goroutines exited. This can
-				// happen when the evdev file descriptors become stale after
-				// sleep/wake or device disconnection. Auto-restart the capture
-				// unless Stop() was already called.
 				if !l.tryRestartLocked(&capture, &stopCh, &state) {
 					return
 				}
@@ -172,8 +176,6 @@ func (l *GlobalHotkeyListener) tryRestartLocked(
 
 	newCapture.startReaders()
 
-	// Close the old capture in the background so we don't hold l.mu across
-	// the blocking ungrab/close calls.
 	oldCapture := *capture
 
 	*capture = newCapture
@@ -193,14 +195,6 @@ func (l *GlobalHotkeyListener) tryRestartLocked(
 	)
 
 	return true
-}
-
-// IsRunning reports whether the listener is actively watching for chords.
-func (l *GlobalHotkeyListener) IsRunning() bool {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	return l.running
 }
 
 func (l *GlobalHotkeyListener) handleEvent(

--- a/internal/core/infra/eventtap/global_hotkey_linux_nocgo.go
+++ b/internal/core/infra/eventtap/global_hotkey_linux_nocgo.go
@@ -27,3 +27,6 @@ func (l *GlobalHotkeyListener) Start() error { return nil }
 
 // Stop is a no-op without cgo.
 func (l *GlobalHotkeyListener) Stop() {}
+
+// IsRunning returns false without cgo (evdev is unavailable).
+func (l *GlobalHotkeyListener) IsRunning() bool { return false }

--- a/internal/core/infra/hotkeys/manager_linux_common.go
+++ b/internal/core/infra/hotkeys/manager_linux_common.go
@@ -189,6 +189,25 @@ func (m *Manager) stopWayland() {
 	m.waylandStarted = false
 }
 
+// HealthCheck returns true when the global hotkey listener is healthy.
+// On non-Wayland backends (X11) it always returns true because there is no
+// passive evdev listener to monitor. Callers (the app health-check loop)
+// reinitialize the listener if this returns false.
+func (m *Manager) HealthCheck() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.waylandHotkeys == nil {
+		return true
+	}
+
+	if !m.waylandStarted {
+		return true
+	}
+
+	return m.waylandHotkeys.IsRunning()
+}
+
 // SetGlobalManager assigns the global manager instance (Linux stub).
 func SetGlobalManager(_ *Manager) {}
 

--- a/internal/core/infra/hotkeys/manager_linux_common.go
+++ b/internal/core/infra/hotkeys/manager_linux_common.go
@@ -143,6 +143,25 @@ func (m *Manager) UnregisterAll() {
 	}
 }
 
+// HealthCheck returns true when the global hotkey listener is healthy.
+// On non-Wayland backends (X11) it always returns true because there is no
+// passive evdev listener to monitor. Callers (the app health-check loop)
+// reinitialize the listener if this returns false.
+func (m *Manager) HealthCheck() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.waylandHotkeys == nil {
+		return true
+	}
+
+	if !m.waylandStarted {
+		return true
+	}
+
+	return m.waylandHotkeys.IsRunning()
+}
+
 // rebuildWaylandBindings re-syncs the evdev listener with the current set of
 // registered hotkeys. Callers must hold m.mu.
 func (m *Manager) rebuildWaylandBindings() {
@@ -187,25 +206,6 @@ func (m *Manager) stopWayland() {
 
 	m.waylandHotkeys.Stop()
 	m.waylandStarted = false
-}
-
-// HealthCheck returns true when the global hotkey listener is healthy.
-// On non-Wayland backends (X11) it always returns true because there is no
-// passive evdev listener to monitor. Callers (the app health-check loop)
-// reinitialize the listener if this returns false.
-func (m *Manager) HealthCheck() bool {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	if m.waylandHotkeys == nil {
-		return true
-	}
-
-	if !m.waylandStarted {
-		return true
-	}
-
-	return m.waylandHotkeys.IsRunning()
 }
 
 // SetGlobalManager assigns the global manager instance (Linux stub).

--- a/internal/core/infra/hotkeys/manager_linux_common.go
+++ b/internal/core/infra/hotkeys/manager_linux_common.go
@@ -179,8 +179,16 @@ func (m *Manager) rebuildWaylandBindings() {
 // ensureWaylandStarted lazily starts the evdev listener on first registration.
 // Callers must hold m.mu.
 func (m *Manager) ensureWaylandStarted() {
-	if m.waylandHotkeys == nil || m.waylandStarted {
+	if m.waylandHotkeys == nil {
 		return
+	}
+
+	if m.waylandStarted {
+		if m.waylandHotkeys.IsRunning() {
+			return
+		}
+
+		m.waylandStarted = false
 	}
 
 	err := m.waylandHotkeys.Start()

--- a/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
@@ -224,3 +224,23 @@ func libeiHasKeyboard() (bool, bool) {
 
 	return C.neru_ei_has_keyboard(globalLibeiState.client) != 0, false //nolint:nlreturn
 }
+
+// LibeiReset tears down the libei/RemoteDesktop portal session. The next input
+// operation re-establishes the session via tryAcquire. Call after sleep/wake and
+// after a detected evdev failure so that stale portal connections don't silently
+// block input injection.
+func LibeiReset() {
+	globalLibeiState.mu.Lock()
+	defer globalLibeiState.mu.Unlock()
+
+	if !globalLibeiState.ready {
+		return
+	}
+
+	if globalLibeiState.client != nil {
+		C.neru_ei_disconnect(globalLibeiState.client)
+		globalLibeiState.client = nil
+	}
+
+	globalLibeiState.ready = false
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland_kde_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_kde_nocgo.go
@@ -54,3 +54,5 @@ func libeiKey(keycode int, pressed bool) error {
 func libeiHasKeyboard() (bool, bool) {
 	return false, false
 }
+
+func LibeiReset() {}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds 3 recovery layers to prevent neru stops responding to hotkeys after system suspend/resume, hibernation and config reload on linux ports.

1. reinitialise evdev capture and libei session on system wake
2. repoen devices and resume listening when evdev events channel closes unexpectedly or stale fds
3. apply a light weight 2s health check after config reload, and reinitialise if hotkeys are not alive

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
