### PR TITLE
fix: lower down minimum font size to `1` and add missing validations

### DIFF
--- a/internal/app/components/grid/overlay_linux_common.go
+++ b/internal/app/components/grid/overlay_linux_common.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	minFontSize  = 12
 	minLineWidth = 1
 	invalidColor = 0xFFFFFFFF
 	hexPairCount = 2
@@ -123,7 +122,7 @@ func BuildStyle(cfg config.GridConfig, theme config.ThemeProvider) Style {
 		LabelFontColor: parseLinuxColor(
 			cfg.UI.TextColor.ForTheme(theme, config.GridTextColorLight, config.GridTextColorDark),
 		),
-		LabelFontSize: float64(max(cfg.UI.FontSize, minFontSize)),
+		LabelFontSize: float64(cfg.UI.FontSize),
 		LabelFontName: ports.ResolveFont(cfg.UI.FontFamily, true),
 		MatchedTextColor: parseLinuxColor(
 			cfg.UI.MatchedTextColor.ForTheme(

--- a/internal/app/components/grid/overlay_windows.go
+++ b/internal/app/components/grid/overlay_windows.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	minFontSize  = 12
 	minLineWidth = 1
 	invalidColor = 0xFFFFFFFF
 	hexPairCount = 2
@@ -122,7 +121,7 @@ func BuildStyle(cfg config.GridConfig, theme config.ThemeProvider) Style {
 		LabelFontColor: parseWindowsColor(
 			cfg.UI.TextColor.ForTheme(theme, config.GridTextColorLight, config.GridTextColorDark),
 		),
-		LabelFontSize: float64(max(cfg.UI.FontSize, minFontSize)),
+		LabelFontSize: float64(cfg.UI.FontSize),
 		LabelFontName: cfg.UI.FontFamily,
 		MatchedTextColor: parseWindowsColor(
 			cfg.UI.MatchedTextColor.ForTheme(

--- a/internal/app/components/recursivegrid/overlay_linux_common.go
+++ b/internal/app/components/recursivegrid/overlay_linux_common.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	minFontSize   = 14
 	hexDigitCount = 2
 	invalidColor  = 0xFFFFFFFF
 	colorLen3     = 3
@@ -135,7 +134,7 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 				config.RecursiveGridTextColorDark,
 			),
 		),
-		LabelFontSize:   float64(max(cfg.UI.FontSize, minFontSize)),
+		LabelFontSize:   float64(cfg.UI.FontSize),
 		LabelFontName:   ports.ResolveFont(cfg.UI.FontFamily, true),
 		LabelBackground: cfg.UI.LabelBackground,
 		LabelBackgroundColor: parseLinuxColor(

--- a/internal/app/components/recursivegrid/overlay_windows.go
+++ b/internal/app/components/recursivegrid/overlay_windows.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	minFontSize   = 14
 	hexDigitCount = 2
 	invalidColor  = 0xFFFFFFFF
 	colorLen3     = 3
@@ -135,7 +134,7 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 				config.RecursiveGridTextColorDark,
 			),
 		),
-		LabelFontSize:   float64(max(cfg.UI.FontSize, minFontSize)),
+		LabelFontSize:   float64(cfg.UI.FontSize),
 		LabelFontName:   ports.ResolveFont(cfg.UI.FontFamily, true),
 		LabelBackground: cfg.UI.LabelBackground,
 		LabelBackgroundColor: parseWindowsColor(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1182,12 +1182,15 @@ func (c *Config) ValidateGeneral() error {
 
 // ValidateModeIndicator validates the mode indicator configuration.
 func (c *Config) ValidateModeIndicator() error {
-	err := validateMinValue(c.ModeIndicator.UI.FontSize, 1, "mode_indicator.ui.font_size")
-	if err != nil {
-		return err
+	if c.ModeIndicator.UI.FontSize < 1 || c.ModeIndicator.UI.FontSize > maxFontSize {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"mode_indicator.ui.font_size must be between 1 and %d",
+			maxFontSize,
+		)
 	}
 
-	err = validateMinValue(c.ModeIndicator.UI.BorderWidth, 0, "mode_indicator.ui.border_width")
+	err := validateMinValue(c.ModeIndicator.UI.BorderWidth, 0, "mode_indicator.ui.border_width")
 	if err != nil {
 		return err
 	}

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -144,8 +144,8 @@ func (c *Config) ValidateHints() error {
 		return err
 	}
 
-	if c.Hints.UI.FontSize < 6 || c.Hints.UI.FontSize > 72 {
-		return derrors.New(derrors.CodeInvalidConfig, "hints.ui.font_size must be between 6 and 72")
+	if c.Hints.UI.FontSize < 1 {
+		return derrors.New(derrors.CodeInvalidConfig, "hints.ui.font_size must be >= 1")
 	}
 
 	err = validateMinValue(c.Hints.UI.BorderRadius, -1, "hints.ui.border_radius")
@@ -178,10 +178,10 @@ func (c *Config) ValidateHints() error {
 		)
 	}
 
-	if c.Hints.SearchInputUI.FontSize < 6 || c.Hints.SearchInputUI.FontSize > 72 {
+	if c.Hints.SearchInputUI.FontSize < 1 {
 		return derrors.New(
 			derrors.CodeInvalidConfig,
-			"hints.search_input_ui.font_size must be between 6 and 72",
+			"hints.search_input_ui.font_size must be >= 1",
 		)
 	}
 
@@ -715,8 +715,8 @@ func (c *Config) ValidateGrid() error {
 		return err
 	}
 
-	if c.Grid.UI.FontSize < 6 || c.Grid.UI.FontSize > 72 {
-		return derrors.New(derrors.CodeInvalidConfig, "grid.ui.font_size must be between 6 and 72")
+	if c.Grid.UI.FontSize < 1 {
+		return derrors.New(derrors.CodeInvalidConfig, "grid.ui.font_size must be >= 1")
 	}
 
 	if c.Grid.UI.BorderWidth < 0 {
@@ -764,6 +764,20 @@ func (c *Config) ValidateMonitorSelect() error {
 		return err
 	}
 
+	err = validateMinValue(c.MonitorSelect.UI.FontSize, 1, "monitor_select.ui.font_size")
+	if err != nil {
+		return err
+	}
+
+	err = validateMinValue(
+		c.MonitorSelect.UI.SubtitleFontSize,
+		1,
+		"monitor_select.ui.subtitle_font_size",
+	)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -778,6 +792,11 @@ func (c *Config) ValidateStickyModifiers() error {
 			derrors.CodeInvalidConfig,
 			"sticky_modifiers.tap_max_duration must be >= 0",
 		)
+	}
+
+	err := validateMinValue(c.StickyModifiers.UI.FontSize, 1, "sticky_modifiers.ui.font_size")
+	if err != nil {
+		return err
 	}
 
 	return validateColors([]colorField{
@@ -1230,6 +1249,13 @@ func (c *Config) ValidateRecursiveGrid() error {
 
 	if c.RecursiveGrid.UI.FontSize < 1 {
 		return derrors.New(derrors.CodeInvalidConfig, "recursive_grid.ui.font_size must be >= 1")
+	}
+
+	if c.RecursiveGrid.UI.SubKeyPreviewFontSize < 1 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"recursive_grid.ui.sub_key_preview_font_size must be >= 1",
+		)
 	}
 
 	err = validateAppConfigsWithCallback(

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -9,6 +10,11 @@ import (
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
+
+// maxFontSize is the maximum font size accepted by the config validator.
+// Values above this can overflow C.int (int32) on Darwin or platform int on
+// Windows when passed to native overlay renderers.
+const maxFontSize = math.MaxInt32
 
 var validModifiers = map[string]bool{
 	"Primary":     true,
@@ -144,8 +150,12 @@ func (c *Config) ValidateHints() error {
 		return err
 	}
 
-	if c.Hints.UI.FontSize < 1 {
-		return derrors.New(derrors.CodeInvalidConfig, "hints.ui.font_size must be >= 1")
+	if c.Hints.UI.FontSize < 1 || c.Hints.UI.FontSize > maxFontSize {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"hints.ui.font_size must be between 1 and %d",
+			maxFontSize,
+		)
 	}
 
 	err = validateMinValue(c.Hints.UI.BorderRadius, -1, "hints.ui.border_radius")
@@ -178,10 +188,11 @@ func (c *Config) ValidateHints() error {
 		)
 	}
 
-	if c.Hints.SearchInputUI.FontSize < 1 {
-		return derrors.New(
+	if c.Hints.SearchInputUI.FontSize < 1 || c.Hints.SearchInputUI.FontSize > maxFontSize {
+		return derrors.Newf(
 			derrors.CodeInvalidConfig,
-			"hints.search_input_ui.font_size must be >= 1",
+			"hints.search_input_ui.font_size must be between 1 and %d",
+			maxFontSize,
 		)
 	}
 
@@ -715,8 +726,12 @@ func (c *Config) ValidateGrid() error {
 		return err
 	}
 
-	if c.Grid.UI.FontSize < 1 {
-		return derrors.New(derrors.CodeInvalidConfig, "grid.ui.font_size must be >= 1")
+	if c.Grid.UI.FontSize < 1 || c.Grid.UI.FontSize > maxFontSize {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"grid.ui.font_size must be between 1 and %d",
+			maxFontSize,
+		)
 	}
 
 	if c.Grid.UI.BorderWidth < 0 {
@@ -764,18 +779,21 @@ func (c *Config) ValidateMonitorSelect() error {
 		return err
 	}
 
-	err = validateMinValue(c.MonitorSelect.UI.FontSize, 1, "monitor_select.ui.font_size")
-	if err != nil {
-		return err
+	if c.MonitorSelect.UI.FontSize < 1 || c.MonitorSelect.UI.FontSize > maxFontSize {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"monitor_select.ui.font_size must be between 1 and %d",
+			maxFontSize,
+		)
 	}
 
-	err = validateMinValue(
-		c.MonitorSelect.UI.SubtitleFontSize,
-		1,
-		"monitor_select.ui.subtitle_font_size",
-	)
-	if err != nil {
-		return err
+	if c.MonitorSelect.UI.SubtitleFontSize < 1 ||
+		c.MonitorSelect.UI.SubtitleFontSize > maxFontSize {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"monitor_select.ui.subtitle_font_size must be between 1 and %d",
+			maxFontSize,
+		)
 	}
 
 	return nil
@@ -794,9 +812,12 @@ func (c *Config) ValidateStickyModifiers() error {
 		)
 	}
 
-	err := validateMinValue(c.StickyModifiers.UI.FontSize, 1, "sticky_modifiers.ui.font_size")
-	if err != nil {
-		return err
+	if c.StickyModifiers.UI.FontSize < 1 || c.StickyModifiers.UI.FontSize > maxFontSize {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"sticky_modifiers.ui.font_size must be between 1 and %d",
+			maxFontSize,
+		)
 	}
 
 	return validateColors([]colorField{
@@ -1247,14 +1268,20 @@ func (c *Config) ValidateRecursiveGrid() error {
 		)
 	}
 
-	if c.RecursiveGrid.UI.FontSize < 1 {
-		return derrors.New(derrors.CodeInvalidConfig, "recursive_grid.ui.font_size must be >= 1")
+	if c.RecursiveGrid.UI.FontSize < 1 || c.RecursiveGrid.UI.FontSize > maxFontSize {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"recursive_grid.ui.font_size must be between 1 and %d",
+			maxFontSize,
+		)
 	}
 
-	if c.RecursiveGrid.UI.SubKeyPreviewFontSize < 1 {
-		return derrors.New(
+	if c.RecursiveGrid.UI.SubKeyPreviewFontSize < 1 ||
+		c.RecursiveGrid.UI.SubKeyPreviewFontSize > maxFontSize {
+		return derrors.Newf(
 			derrors.CodeInvalidConfig,
-			"recursive_grid.ui.sub_key_preview_font_size must be >= 1",
+			"recursive_grid.ui.sub_key_preview_font_size must be between 1 and %d",
+			maxFontSize,
 		)
 	}
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR makes the minimum font size to `1` for all the port overlays for consistency. Also updates and adds missing font validation against the config.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
