### PR TITLE
docs(troubleshooting): Add notes about element size and element type, clean up Electron/Browser troubleshooting

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -152,13 +152,6 @@ Restart Neru:
 pkill neru && neru launch
 ```
 
-**Check logs for:**
-
-```
-App requires Electron support
-Enabled AXManualAccessibility for: com.your.app
-```
-
 ### Some elements that should have hints don't have hints
 
 This can happen when the element you're trying to select is small. If you encounter this, open an issue.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -163,22 +163,29 @@ Enabled AXManualAccessibility for: com.your.app
 
 This can happen when the element you're trying to select is small. If you encounter this, open an issue.
 
-Alternatively, make sure all relevant roles are enabled. Look at [default-config.toml](https://github.com/y3owk1n/neru/blob/3a8d3c848d63e6757b602cb4dc31fb532aa310d7/configs/default-config.toml#L65) for available roles.
+Alternatively, make sure all relevant roles are enabled. Copy the complete `clickable_roles` list from [default-config.toml](https://github.com/y3owk1n/neru/blob/3a8d3c848d63e6757b602cb4dc31fb532aa310d7/configs/default-config.toml#L65) to enable all roles.
+
+Run `neru config reload` and then test.
 
 ```toml
 [hints]
 clickable_roles = [
-    "AXButton",
-	"AXMenuButton",
     # ...
 ]
 ```
 
 ### Certain hints don't visually match any on-screen UI
 
-Neru may be generating hints for elements that are not directly visible to you, such as `AXRow` and `AXCell`. Try removing those from `hints.clickable_roles`.
+Neru may be generating hints for elements that are not directly visible to you, such as `AXRow` and `AXCell`. Copy the complete `clickable_roles` list from [default-config.toml](https://github.com/y3owk1n/neru/blob/3a8d3c848d63e6757b602cb4dc31fb532aa310d7/configs/default-config.toml#L65), then remove only those roles so the remaining defaults stay enabled.
 
 Run `neru config reload` and then test.
+
+```toml
+[hints]
+clickable_roles = [
+    # ...
+]
+```
 
 ### Menubar/Dock hints missing
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -169,7 +169,7 @@ clickable_roles = [
 
 ### Certain hints don't visually match any on-screen UI
 
-Neru may be generating hints for elements that are not directly visible to you, such as `AXRow` and `AXCell`. Copy the complete `clickable_roles` list from [default-config.toml](https://github.com/y3owk1n/neru/blob/3a8d3c848d63e6757b602cb4dc31fb532aa310d7/configs/default-config.toml#L65), then remove only those roles so the remaining defaults stay enabled.
+Neru may be generating hints for elements that are not directly visible to you, such as `AXRow` and `AXCell`. Copy the complete `clickable_roles` list from [default-config.toml](https://github.com/y3owk1n/neru/blob/main/configs/default-config.toml), then remove only those roles so the remaining defaults stay enabled.
 
 Run `neru config reload` and then test.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -122,14 +122,57 @@ neru hints               # CLI works?
 log_level = "debug"
 ```
 
-### Electron/Chromium/Firefox issues
+### Hints don't appear in Electron apps or Chrome/Firefox content
 
-**Enable additional AX support:**
+**Browsers and Electron apps needs additional AX support.**
+
+**Solution:**
+
+Edit `~/.config/neru/config.toml`:
 
 ```toml
 [hints.additional_ax_support]
 enable = true
+
+# If your app isn't auto-detected, add it:
+additional_electron_bundles = [
+    "com.your.electronapp",
+]
 ```
+
+Restart Neru:
+
+```bash
+pkill neru && neru launch
+```
+
+**Check logs for:**
+
+```
+App requires Electron support
+Enabled AXManualAccessibility for: com.your.app
+```
+
+### Some elements that should have hints don't have hints
+
+This can happen when the element you're trying to select is small. If you encounter this, open an issue.
+
+Alternatively, make sure all relevant roles are enabled. Look at [default-config.toml](https://github.com/y3owk1n/neru/blob/3a8d3c848d63e6757b602cb4dc31fb532aa310d7/configs/default-config.toml#L65) for available roles.
+
+```toml
+[hints]
+clickable_roles = [
+    "AXButton",
+	"AXMenuButton",
+    # ...
+]
+```
+
+### Certain hints don't visually match any on-screen UI
+
+Neru may be generating hints for elements that are not directly visible to you, such as `AXRow` and `AXCell`. Try removing those from `hints.clickable_roles`.
+
+Run `neru config reload` and then test.
 
 ### Menubar/Dock hints missing
 
@@ -160,41 +203,6 @@ tail -f ~/Library/Logs/neru/app.log
 # - App name and version
 # - Screenshot
 ```
-
-### Hints don't appear in Electron apps
-
-**Electron apps need additional AX support.**
-
-**Solution:**
-
-Edit `~/.config/neru/config.toml`:
-
-```toml
-[hints.additional_ax_support]
-enable = true
-
-# If your app isn't auto-detected, add it:
-additional_electron_bundles = [
-    "com.your.electronapp",
-]
-```
-
-Restart Neru:
-
-```bash
-pkill neru && neru launch
-```
-
-**Check logs for:**
-
-```
-App requires Electron support
-Enabled AXManualAccessibility for: com.your.app
-```
-
-### Hints don't appear in Chrome/Firefox content
-
-**Browser needs additional AX support.**
 
 ### No hints in menubar/Dock
 
@@ -496,17 +504,17 @@ If you're still experiencing issues:
     - Some custom layouts (e.g., Colemak, Dvorak) may not be resolved automatically
     - Force the layout by setting `kb_layout_to_use` in your config to the full bundle ID:
 
-      ```bash
-      # First, switch to your desired layout in the menu bar, then:
-      defaults read com.apple.HIToolbox AppleCurrentKeyboardLayoutInputSourceID
-      ```
+        ```bash
+        # First, switch to your desired layout in the menu bar, then:
+        defaults read com.apple.HIToolbox AppleCurrentKeyboardLayoutInputSourceID
+        ```
 
-      Then use the returned value (e.g., `com.apple.keylayout.Colemak`):
+        Then use the returned value (e.g., `com.apple.keylayout.Colemak`):
 
-      ```toml
-      [general]
-      kb_layout_to_use = "com.apple.keylayout.Colemak"
-      ```
+        ```toml
+        [general]
+        kb_layout_to_use = "com.apple.keylayout.Colemak"
+        ```
 
 3. **Layout changes at runtime not picked up:**
     - Neru now automatically re-registers global hotkeys when the keyboard layout changes (e.g., switching from US to Dvorak while Neru is running)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -134,9 +134,15 @@ Edit `~/.config/neru/config.toml`:
 [hints.additional_ax_support]
 enable = true
 
-# If your app isn't auto-detected, add it:
+# If your app isn't auto-detected, add it to the matching list:
 additional_electron_bundles = [
     "com.your.electronapp",
+]
+additional_chromium_bundles = [
+    "com.your.chromiumapp",
+]
+additional_firefox_bundles = [
+    "com.your.firefoxapp",
 ]
 ```
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -156,7 +156,7 @@ pkill neru && neru launch
 
 This can happen when the element you're trying to select is small. If you encounter this, open an issue.
 
-Alternatively, make sure all relevant roles are enabled. Copy the complete `clickable_roles` list from [default-config.toml](https://github.com/y3owk1n/neru/blob/3a8d3c848d63e6757b602cb4dc31fb532aa310d7/configs/default-config.toml#L65) to enable all roles.
+Alternatively, make sure all relevant roles are enabled. If you've customized `hints.clickable_roles`, you can remove that customization or restore it to the original value from [default-config.toml](https://github.com/y3owk1n/neru/blob/3a8d3c848d63e6757b602cb4dc31fb532aa310d7/configs/default-config.toml#L65).
 
 Run `neru config reload` and then test.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -646,10 +646,6 @@ grep "com.apple.Safari" ~/Library/Logs/neru/app.log
 
 ### Common log messages
 
-**"App requires Electron support"** - Electron app detected, needs AX support enabled
-
-**"Enabled AXManualAccessibility"** - Electron support activated successfully
-
 **"Hints mode activated"** - Hint overlay is active; includes hint count when available
 
 **"Clickable element collection was slow"** - Accessibility scanning completed but took longer than expected


### PR DESCRIPTION
Disclaimer: This PR description was written by Claude. I reviewed it and it matches the change.

## Context

Follow-up to #1019, where hints were missing for some links on certain web pages (for example the small comment links on Hacker News). The root cause was fixed in code by lowering the minimum element size threshold, and the phantom hint clusters that appeared afterward were traced to the `AXRow`/`AXCell` clickable roles being applied to table-based layouts. This adds the troubleshooting entry the maintainer asked for so users hitting the same symptoms can self-serve.

## What Changed

All edits are in `docs/TROUBLESHOOTING.md`:

- Add "Some elements that should have hints don't have hints", covering the two causes: the element is too small to pass the size filter (open an issue), or a relevant role is not in `hints.clickable_roles` (links to `default-config.toml` for the full list of roles).
- Add "Certain hints don't visually match any on-screen UI", explaining that Neru may generate hints for non-visible structural elements such as `AXRow` and `AXCell`, and that removing those roles and running `neru config reload` clears them.
- Consolidate the Electron and browser hint troubleshooting. The same topic was previously split across three headings ("Electron/Chromium/Firefox issues", "Hints don't appear in Electron apps", "Hints don't appear in Chrome/Firefox content"), two of which were nearly empty. These are merged into a single "Hints don't appear in Electron apps or Chrome/Firefox content" section with the full config, restart, and log-check steps.
- Fix the markdown indentation of the keyboard-layout code blocks so they nest correctly under their list item.

## Notes

Documentation only. No code changes.
