### PR TITLE
docs(troubleshooting): explain missing hints on multi-monitor setups

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -113,6 +113,23 @@ neru hints               # CLI works?
 - Remove app from `excluded_apps` in config
 - Test in different app
 
+### No hints visible when using multiple monitors
+
+**Focused window and cursor are on different displays.** Neru only draws hints on the display where the cursor is. If the focused window is on another display, no hints will show for that window.
+
+**Solution:**
+
+If you're using a window manager, you can probably set it up so that your cursor always follows the focused window.
+
+Alternatively, you can change the shortcut that you use to activate `hints` to chain `action move_mouse --window` before activation, so the cursor moves to the focused window first:
+
+```toml
+[hotkeys]
+"Primary+Shift+Space" = ["action move_mouse --window", "hints"]
+```
+
+A tiling window manager with focus-follows-mouse avoids this at the source.
+
 ### Misaligned hints/grids
 
 **Rare issue.** Enable debug logging and check logs:


### PR DESCRIPTION
Disclaimer: Claude wrote this PR and the docs change. I hit this problem myself, pointed it at the fix that worked for me, and reviewed the result.

## Description

Adds a troubleshooting entry for a multi-monitor case that tripped me up: no hints appear when the focused window and the cursor are on different displays.

Neru generates hints from the focused window but draws the hint overlay on the display where the cursor currently is. When focus moves to another display while the cursor stays behind (most often via `Cmd+Tab` to an app whose only window is on the other display), the hints are generated for the focused window but rendered on the empty display under the cursor, so nothing shows up.

The entry explains the cause and gives the fix: chain `action move_mouse --window` before `hints` so the cursor moves to the center of the focused window first, and the overlay renders on the display that holds the hints.

```toml
[hotkeys]
"Primary+Shift+Space" = ["action move_mouse --window", "hints"]
```

It also notes that a tiling window manager with focus-follows-mouse avoids the mismatch at the window-manager level.

## Related Issues

Closes #1014

## Target Platform

- [x] macOS

## Type of Change

- [x] `docs` — Documentation only

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
