### PR TITLE
fix(darwin): use a lightweight handler for space changes

### DIFF
--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -1777,6 +1777,25 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	});
 }
 
+- (void)handleActiveSpaceDidChange:(NSNotification *)notification {
+	(void)notification;
+	if (!self.shouldBeVisible || ![self hasDrawableFrame] || self.windowServerReattachScheduled)
+		return;
+
+	void (^lightweightBlock)(void) = ^{
+		[self.window setLevel:kCGMaximumWindowLevel];
+		[self applyOverlayCollectionBehavior];
+		[self.window orderFrontRegardless];
+		[self.overlayView setNeedsDisplay:YES];
+	};
+
+	if ([NSThread isMainThread]) {
+		lightweightBlock();
+	} else {
+		dispatch_async(dispatch_get_main_queue(), lightweightBlock);
+	}
+}
+
 - (void)handleWindowServerAttachmentInvalidated:(NSNotification *)notification {
 	(void)notification;
 	if ([NSThread isMainThread]) {
@@ -1841,7 +1860,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	[self applyOverlayCollectionBehavior];
 
 	[[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self
-	                                                       selector:@selector(handleWindowServerAttachmentInvalidated:)
+	                                                       selector:@selector(handleActiveSpaceDidChange:)
 	                                                           name:NSWorkspaceActiveSpaceDidChangeNotification
 	                                                         object:nil];
 	[[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -1782,18 +1782,22 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	if (!self.shouldBeVisible || ![self hasDrawableFrame] || self.windowServerReattachScheduled)
 		return;
 
-	void (^lightweightBlock)(void) = ^{
+	if ([NSThread isMainThread]) {
 		[self.window setLevel:kCGMaximumWindowLevel];
 		[self applyOverlayCollectionBehavior];
 		[self.window orderFrontRegardless];
 		[self.overlayView setNeedsDisplay:YES];
-	};
-
-	if ([NSThread isMainThread]) {
-		lightweightBlock();
-	} else {
-		dispatch_async(dispatch_get_main_queue(), lightweightBlock);
+		return;
 	}
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (!self.shouldBeVisible || ![self hasDrawableFrame] || self.windowServerReattachScheduled)
+			return;
+		[self.window setLevel:kCGMaximumWindowLevel];
+		[self applyOverlayCollectionBehavior];
+		[self.window orderFrontRegardless];
+		[self.overlayView setNeedsDisplay:YES];
+	});
 }
 
 - (void)handleWindowServerAttachmentInvalidated:(NSNotification *)notification {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR separates the notification handlers out for macOS:

- `ActiveSpaceDidChange` - lightweight path so that window server doesn't get boomed as this is a frequent action.
- `DidWakeNotification`, `DidChangeScreenParametersNotification` - use the proper full cycle whene window server invalidates the window attachments.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #1030

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
