### PR TITLE
feat: allow `--modifier` in mode `--action`

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -69,6 +69,7 @@ neru idle                                  # Cancel active navigation mode
 | Flag                      | Type   | Description                                                                                                                               |
 | ------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `--action, -a`            | string | Action on selection: `left_click`, `right_click`, `middle_click`, `mouse_down`, `mouse_up`, `move_mouse`, `move_mouse_relative`, `scroll`. Commas chain multiple actions (e.g. `left_click,left_click` for double-click) |
+| `--modifier`              | string | Comma-separated modifier keys to hold during action: `cmd`, `super`, `meta`, `shift`, `alt`, `option`, `ctrl` (requires `--action`)                                        |
 | `--repeat, -r`            | bool   | Re-activate mode after action (requires `--action`)                                                                                       |
 | `--toggle, -t`            | bool   | Toggle mode on/off — exit to idle if already active                                                                                       |
 | `--cursor-selection-mode` | string | `follow` (cursor follows selection) or `hold` (cursor stays)                                                                              |
@@ -80,6 +81,7 @@ Not allowed as `--action`: `reset`, `backspace`, `search_hints`, `cycle_hint`, `
 ```bash
 # Examples
 neru hints --action left_click                     # Click via hints
+neru hints --action left_click --modifier shift    # Shift+click via hints
 neru hints --action left_click --repeat            # Click and re-enter hints
 neru hints --search                                # Start with search input visible
 neru grid --toggle                                 # Toggle grid on/off
@@ -109,6 +111,7 @@ neru hints --text next --action left_click --repeat   # Filter persists across r
 | Flag                      | Type   | Description                                                                                                                                                      |
 | ------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--action, -a`            | string | Action on selection (same values as [Common Flags](#common-flags))                                                                                               |
+| `--modifier`              | string | Modifier keys to hold during action (requires `--action`)                                                                                                        |
 | `--repeat, -r`            | bool   | Re-activate hints after action (requires `--action`)                                                                                                             |
 | `--toggle, -t`            | bool   | Toggle hints on/off                                                                                                                                              |
 | `--cursor-selection-mode` | string | `follow` (default) or `hold` — whether cursor jumps to selection                                                                                                 |
@@ -133,6 +136,7 @@ neru grid --cursor-selection-mode hold          # Grid with stationary cursor
 | Flag                      | Type   | Description                                                        |
 | ------------------------- | ------ | ------------------------------------------------------------------ |
 | `--action, -a`            | string | Action on selection (same values as [Common Flags](#common-flags)) |
+| `--modifier`              | string | Modifier keys to hold during action (requires `--action`)          |
 | `--repeat, -r`            | bool   | Re-activate grid after action (requires `--action`)                |
 | `--toggle, -t`            | bool   | Toggle grid on/off                                                 |
 | `--cursor-selection-mode` | string | `follow` (default) or `hold`                                       |
@@ -157,6 +161,7 @@ neru recursive_grid --action middle_click       # Middle-click via recursive gri
 | Flag                      | Type   | Description                                                        |
 | ------------------------- | ------ | ------------------------------------------------------------------ |
 | `--action, -a`            | string | Action on selection (same values as [Common Flags](#common-flags)) |
+| `--modifier`              | string | Modifier keys to hold during action (requires `--action`)          |
 | `--repeat, -r`            | bool   | Re-activate recursive grid after action (requires `--action`)      |
 | `--toggle, -t`            | bool   | Toggle recursive grid on/off                                       |
 | `--cursor-selection-mode` | string | `follow` (default) or `hold`                                       |

--- a/internal/app/components/grid/context.go
+++ b/internal/app/components/grid/context.go
@@ -10,6 +10,7 @@ import (
 // It contains shared state fields used across different mode contexts.
 type baseContext struct {
 	pendingAction         *string
+	pendingModifier       *string
 	repeat                bool
 	cursorFollowSelection bool
 	selectedPoint         image.Point
@@ -24,6 +25,16 @@ func (c *baseContext) SetPendingAction(action *string) {
 // PendingAction returns the pending action to execute.
 func (c *baseContext) PendingAction() *string {
 	return c.pendingAction
+}
+
+// SetPendingModifier sets the modifier keys to apply when the pending action fires.
+func (c *baseContext) SetPendingModifier(modifier *string) {
+	c.pendingModifier = modifier
+}
+
+// PendingModifier returns the modifier keys to apply when the pending action fires.
+func (c *baseContext) PendingModifier() *string {
+	return c.pendingModifier
 }
 
 // SetRepeat sets whether the mode should re-activate after performing the action.
@@ -73,6 +84,7 @@ func (c *baseContext) SelectionPoint() (image.Point, bool) {
 // Reset resets the base context to its initial state.
 func (c *baseContext) Reset() {
 	c.pendingAction = nil
+	c.pendingModifier = nil
 	c.repeat = false
 	c.cursorFollowSelection = false
 	c.ClearSelectionPoint()

--- a/internal/app/components/hints/context.go
+++ b/internal/app/components/hints/context.go
@@ -8,6 +8,7 @@ import (
 // It contains shared state fields used across different mode contexts.
 type baseContext struct {
 	pendingAction          *string
+	pendingModifier        *string
 	repeat                 bool
 	cursorFollowSelection  bool
 	filterRoles            []string
@@ -25,6 +26,16 @@ func (c *baseContext) SetPendingAction(action *string) {
 // PendingAction returns the pending action to execute.
 func (c *baseContext) PendingAction() *string {
 	return c.pendingAction
+}
+
+// SetPendingModifier sets the modifier keys to apply when the pending action fires.
+func (c *baseContext) SetPendingModifier(modifier *string) {
+	c.pendingModifier = modifier
+}
+
+// PendingModifier returns the modifier keys to apply when the pending action fires.
+func (c *baseContext) PendingModifier() *string {
+	return c.pendingModifier
 }
 
 // SetRepeat sets whether the mode should re-activate after performing the action.
@@ -57,6 +68,7 @@ func (c *baseContext) ToggleCursorFollowSelection() bool {
 // Reset resets the base context to its initial state.
 func (c *baseContext) Reset() {
 	c.pendingAction = nil
+	c.pendingModifier = nil
 	c.repeat = false
 	c.cursorFollowSelection = false
 	c.filterRoles = nil

--- a/internal/app/components/recursivegrid/component.go
+++ b/internal/app/components/recursivegrid/component.go
@@ -10,6 +10,7 @@ import (
 // baseContext provides common functionality for mode component contexts.
 type baseContext struct {
 	pendingAction         *string
+	pendingModifier       *string
 	repeat                bool
 	cursorFollowSelection bool
 	selectedPoint         image.Point
@@ -24,6 +25,16 @@ func (c *baseContext) SetPendingAction(action *string) {
 // PendingAction returns the pending action to execute.
 func (c *baseContext) PendingAction() *string {
 	return c.pendingAction
+}
+
+// SetPendingModifier sets the modifier keys to apply when the pending action fires.
+func (c *baseContext) SetPendingModifier(modifier *string) {
+	c.pendingModifier = modifier
+}
+
+// PendingModifier returns the modifier keys to apply when the pending action fires.
+func (c *baseContext) PendingModifier() *string {
+	return c.pendingModifier
 }
 
 // SetRepeat sets whether the mode should re-activate after performing the action.
@@ -73,6 +84,7 @@ func (c *baseContext) SelectionPoint() (image.Point, bool) {
 // Reset resets the base context to its initial state.
 func (c *baseContext) Reset() {
 	c.pendingAction = nil
+	c.pendingModifier = nil
 	c.repeat = false
 	c.cursorFollowSelection = false
 	c.ClearSelectionPoint()

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -480,11 +480,21 @@ func (h *IPCControllerModes) extractModeOptions(
 			return opts, &resp
 		}
 
-		_, modErr := action.ParseModifiers(*opts.Modifier)
+		mods, modErr := action.ParseModifiers(*opts.Modifier)
 		if modErr != nil {
 			resp := ipc.Response{
 				Success: false,
 				Message: modErr.Error(),
+				Code:    ipc.CodeInvalidInput,
+			}
+
+			return opts, &resp
+		}
+
+		if mods == 0 {
+			resp := ipc.Response{
+				Success: false,
+				Message: "modifier values cannot be empty",
 				Code:    ipc.CodeInvalidInput,
 			}
 

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -469,14 +469,27 @@ func (h *IPCControllerModes) extractModeOptions(
 		return opts, &resp
 	}
 
-	if opts.Modifier != nil && opts.Action == nil {
-		resp := ipc.Response{
-			Success: false,
-			Message: "--modifier requires an action",
-			Code:    ipc.CodeInvalidInput,
+	if opts.Modifier != nil {
+		if opts.Action == nil {
+			resp := ipc.Response{
+				Success: false,
+				Message: "--modifier requires an action",
+				Code:    ipc.CodeInvalidInput,
+			}
+
+			return opts, &resp
 		}
 
-		return opts, &resp
+		_, modErr := action.ParseModifiers(*opts.Modifier)
+		if modErr != nil {
+			resp := ipc.Response{
+				Success: false,
+				Message: modErr.Error(),
+				Code:    ipc.CodeInvalidInput,
+			}
+
+			return opts, &resp
+		}
 	}
 
 	return opts, nil

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -151,6 +151,7 @@ func (h *IPCControllerModes) modesUnavailableResponse() ipc.Response {
 // ModeActivationOptions holds the parsed options for activating a navigation mode.
 type ModeActivationOptions struct {
 	Action                *string
+	Modifier              *string
 	Repeat                *bool
 	CursorFollowSelection *bool
 	FilterRoles           []string
@@ -187,6 +188,8 @@ func parseCursorSelectionModeValue(value string) (*bool, *ipc.Response) {
 // parameters from a mode IPC command. It returns the options and an optional
 // error response. If the response is non-nil the caller should return it
 // immediately.
+//
+//nolint:funlen
 func (h *IPCControllerModes) extractModeOptions(
 	cmd ipc.Command,
 ) (ModeActivationOptions, *ipc.Response) {
@@ -225,6 +228,23 @@ func (h *IPCControllerModes) extractModeOptions(
 		case arg == "--debug" || arg == "-d":
 			debugTrue := true
 			opts.Debug = &debugTrue
+		case strings.HasPrefix(arg, "--modifier="):
+			modifierArg := strings.TrimPrefix(arg, "--modifier=")
+			opts.Modifier = &modifierArg
+		case arg == "--modifier":
+			if startIdx+1 >= len(cmd.Args) {
+				resp := ipc.Response{
+					Success: false,
+					Message: "--modifier requires a value",
+					Code:    ipc.CodeInvalidInput,
+				}
+
+				return opts, &resp
+			}
+
+			startIdx++
+			modifierArg := cmd.Args[startIdx]
+			opts.Modifier = &modifierArg
 		case strings.HasPrefix(arg, "--action="):
 			actionArg := strings.TrimPrefix(arg, "--action=")
 			opts.Action = &actionArg
@@ -449,6 +469,16 @@ func (h *IPCControllerModes) extractModeOptions(
 		return opts, &resp
 	}
 
+	if opts.Modifier != nil && opts.Action == nil {
+		resp := ipc.Response{
+			Success: false,
+			Message: "--modifier requires an action",
+			Code:    ipc.CodeInvalidInput,
+		}
+
+		return opts, &resp
+	}
+
 	return opts, nil
 }
 
@@ -489,6 +519,7 @@ func (h *IPCControllerModes) handleHints(ctx context.Context, cmd ipc.Command) i
 
 	h.modes.ActivateModeWithOptions(domain.ModeHints, modes.ModeActivationOptions{
 		Action:                opts.Action,
+		Modifier:              opts.Modifier,
 		Repeat:                opts.Repeat,
 		CursorFollowSelection: opts.CursorFollowSelection,
 		FilterRoles:           opts.FilterRoles,
@@ -514,6 +545,7 @@ func (h *IPCControllerModes) handleGrid(_ context.Context, cmd ipc.Command) ipc.
 
 	h.modes.ActivateModeWithOptions(domain.ModeGrid, modes.ModeActivationOptions{
 		Action:                opts.Action,
+		Modifier:              opts.Modifier,
 		Repeat:                opts.Repeat,
 		CursorFollowSelection: opts.CursorFollowSelection,
 		Toggle:                opts.Toggle,
@@ -534,6 +566,7 @@ func (h *IPCControllerModes) handleRecursiveGrid(_ context.Context, cmd ipc.Comm
 
 	h.modes.ActivateModeWithOptions(domain.ModeRecursiveGrid, modes.ModeActivationOptions{
 		Action:                opts.Action,
+		Modifier:              opts.Modifier,
 		Repeat:                opts.Repeat,
 		CursorFollowSelection: opts.CursorFollowSelection,
 		Toggle:                opts.Toggle,

--- a/internal/app/ipc_handlers_test.go
+++ b/internal/app/ipc_handlers_test.go
@@ -253,3 +253,48 @@ func TestExtractModeOptions_ModifierRequiresAction(t *testing.T) {
 		t.Fatalf("expected error message containing %q, got: %q", expectedMsg, resp.Message)
 	}
 }
+
+func TestExtractModeOptions_ModifierEmptyList(t *testing.T) {
+	cfg := config.DefaultConfig()
+	appState := state.NewAppState()
+	logger := zap.NewNop()
+	configService := config.NewService(cfg, "", logger, nil)
+	actionService := services.NewActionService(
+		&portmocks.MockAccessibilityPort{},
+		&portmocks.MockOverlayPort{},
+		&portmocks.MockSystemPort{},
+		logger,
+	)
+
+	controller := app.NewIPCController(
+		nil,
+		nil,
+		actionService,
+		nil,
+		configService,
+		appState,
+		cfg,
+		newTestModesHandler(cfg, logger, appState, actionService),
+		nil,
+		nil,
+		nil,
+		nil,
+		logger,
+	)
+
+	resp := controller.HandleCommand(context.Background(), ipc.Command{
+		Action: actionHints,
+		Args:   []string{actionHints, "--action=left_click", "--modifier=,"},
+	})
+
+	if resp.Success {
+		t.Fatal(
+			"HandleCommand() expected error response since --modifier value had no actual modifier names",
+		)
+	}
+
+	expectedMsg := "modifier values cannot be empty"
+	if !strings.Contains(resp.Message, expectedMsg) {
+		t.Fatalf("expected error message containing %q, got: %q", expectedMsg, resp.Message)
+	}
+}

--- a/internal/app/ipc_handlers_test.go
+++ b/internal/app/ipc_handlers_test.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/y3owk1n/neru/internal/app"
 	"github.com/y3owk1n/neru/internal/app/modes"
+	"github.com/y3owk1n/neru/internal/app/services"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+	portmocks "github.com/y3owk1n/neru/internal/core/ports/mocks"
 )
 
 const (
@@ -20,21 +22,66 @@ const (
 	actionScroll = "scroll"
 )
 
+func newTestModesHandler(
+	cfg *config.Config,
+	logger *zap.Logger,
+	appState *state.AppState,
+	actionService *services.ActionService,
+) *modes.Handler {
+	return modes.NewHandler(
+		context.Background(),
+		cfg,
+		logger,
+		appState,
+		state.NewCursorState(),
+		nil,                     // overlayManager
+		nil,                     // renderer
+		nil,                     // hintService
+		nil,                     // gridService
+		actionService,           // actionService
+		nil,                     // scrollService
+		nil,                     // modeIndicatorService
+		nil,                     // stickyIndicatorService
+		nil,                     // hintsComponent
+		nil,                     // grid
+		nil,                     // scroll
+		nil,                     // recursiveGridComponent
+		func() {},               // enableEventTap
+		func() {},               // disableEventTap
+		func(bool, []string) {}, // setModifierPassthrough
+		func([]string) {},       // setInterceptedModifierKeys
+		func(func()) {},         // setPassthroughCallback
+		func(bool) {},           // setStickyModifierToggle
+		func(string, bool) {},   // postModifierEvent
+		func() {},               // refreshHotkeys
+		func(string, string) error { return nil }, // executeHotkeyAction
+		func() {}, // shutdown
+		nil,       // textInput
+		nil,       // systemPort
+	)
+}
+
 func TestExtractModeOptions_InvalidCursorSelectionModeEqualsValue(t *testing.T) {
 	cfg := config.DefaultConfig()
 	appState := state.NewAppState()
 	logger := zap.NewNop()
 	configService := config.NewService(cfg, "", logger, nil)
+	actionService := services.NewActionService(
+		&portmocks.MockAccessibilityPort{},
+		&portmocks.MockOverlayPort{},
+		&portmocks.MockSystemPort{},
+		logger,
+	)
 
 	controller := app.NewIPCController(
 		nil,
 		nil,
-		nil,
+		actionService,
 		nil,
 		configService,
 		appState,
 		cfg,
-		&modes.Handler{},
+		newTestModesHandler(cfg, logger, appState, actionService),
 		nil,
 		nil,
 		nil,
@@ -61,16 +108,22 @@ func TestExtractModeOptions_InvalidLabelDirection(t *testing.T) {
 	appState := state.NewAppState()
 	logger := zap.NewNop()
 	configService := config.NewService(cfg, "", logger, nil)
+	actionService := services.NewActionService(
+		&portmocks.MockAccessibilityPort{},
+		&portmocks.MockOverlayPort{},
+		&portmocks.MockSystemPort{},
+		logger,
+	)
 
 	controller := app.NewIPCController(
 		nil,
 		nil,
-		nil,
+		actionService,
 		nil,
 		configService,
 		appState,
 		cfg,
-		&modes.Handler{},
+		newTestModesHandler(cfg, logger, appState, actionService),
 		nil,
 		nil,
 		nil,
@@ -97,16 +150,22 @@ func TestExtractModeOptions_InvalidModeAction(t *testing.T) {
 	appState := state.NewAppState()
 	logger := zap.NewNop()
 	configService := config.NewService(cfg, "", logger, nil)
+	actionService := services.NewActionService(
+		&portmocks.MockAccessibilityPort{},
+		&portmocks.MockOverlayPort{},
+		&portmocks.MockSystemPort{},
+		logger,
+	)
 
 	controller := app.NewIPCController(
 		nil,
 		nil,
-		nil,
+		actionService,
 		nil,
 		configService,
 		appState,
 		cfg,
-		&modes.Handler{},
+		newTestModesHandler(cfg, logger, appState, actionService),
 		nil,
 		nil,
 		nil,
@@ -147,5 +206,50 @@ func TestExtractModeOptions_InvalidModeAction(t *testing.T) {
 				expectedMsg,
 			)
 		}
+	}
+}
+
+func TestExtractModeOptions_ModifierRequiresAction(t *testing.T) {
+	cfg := config.DefaultConfig()
+	appState := state.NewAppState()
+	logger := zap.NewNop()
+	configService := config.NewService(cfg, "", logger, nil)
+	actionService := services.NewActionService(
+		&portmocks.MockAccessibilityPort{},
+		&portmocks.MockOverlayPort{},
+		&portmocks.MockSystemPort{},
+		logger,
+	)
+
+	controller := app.NewIPCController(
+		nil,
+		nil,
+		actionService,
+		nil,
+		configService,
+		appState,
+		cfg,
+		newTestModesHandler(cfg, logger, appState, actionService),
+		nil,
+		nil,
+		nil,
+		nil,
+		logger,
+	)
+
+	resp := controller.HandleCommand(context.Background(), ipc.Command{
+		Action: actionHints,
+		Args:   []string{actionHints, "--modifier=shift"},
+	})
+
+	if resp.Success {
+		t.Fatal(
+			"HandleCommand() expected error response since --modifier was passed without --action",
+		)
+	}
+
+	expectedMsg := "--modifier requires an action"
+	if !strings.Contains(resp.Message, expectedMsg) {
+		t.Fatalf("expected error message containing %q, got: %q", expectedMsg, resp.Message)
 	}
 }

--- a/internal/app/modes/generic_mode.go
+++ b/internal/app/modes/generic_mode.go
@@ -47,6 +47,7 @@ func (m *GenericMode) Activate(opts ModeActivationOptions) {
 		case domain.ModeHints:
 			m.handler.activateHintModeWithAction(
 				opts.Action,
+				opts.Modifier,
 				opts.Repeat,
 				opts.CursorFollowSelection,
 				opts.FilterRoles,
@@ -58,12 +59,14 @@ func (m *GenericMode) Activate(opts ModeActivationOptions) {
 		case domain.ModeGrid:
 			m.handler.activateGridModeWithAction(
 				opts.Action,
+				opts.Modifier,
 				opts.Repeat,
 				opts.CursorFollowSelection,
 			)
 		case domain.ModeRecursiveGrid:
 			m.handler.activateRecursiveGridModeWithAction(
 				opts.Action,
+				opts.Modifier,
 				opts.Repeat,
 				opts.CursorFollowSelection,
 			)

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -17,6 +17,7 @@ import (
 // activateGridModeWithAction activates grid mode with optional action parameter.
 func (h *Handler) activateGridModeWithAction(
 	actionStr *string,
+	modifier *string,
 	repeat *bool,
 	cursorFollowSelection *bool,
 ) {
@@ -93,6 +94,10 @@ func (h *Handler) activateGridModeWithAction(
 			h.grid.Context.SetPendingAction(actionStr)
 		}
 
+		if modifier != nil {
+			h.grid.Context.SetPendingModifier(modifier)
+		}
+
 		if repeat != nil {
 			h.grid.Context.SetRepeat(*repeat)
 		}
@@ -102,6 +107,7 @@ func (h *Handler) activateGridModeWithAction(
 		}
 	} else {
 		h.grid.Context.SetPendingAction(actionStr)
+		h.grid.Context.SetPendingModifier(modifier)
 		h.grid.Context.SetRepeat(repeat != nil && *repeat)
 		h.grid.Context.SetCursorFollowSelection(resolveCursorFollowSelection(
 			domain.ModeGrid,

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -763,6 +763,8 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 	}
 
 	pendingAction := h.hints.Context.PendingAction()
+
+	pendingModifier := h.hints.Context.PendingModifier()
 	if pendingAction != nil {
 		cursorFollowSelection := h.hints.Context.CursorFollowSelection()
 		filterRoles := h.hints.Context.FilterRoles()
@@ -771,8 +773,9 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 		strategyOverride := h.hints.Context.StrategyOverride()
 		labelDirectionOverride := h.hints.Context.LabelDirectionOverride()
 
-		h.executeActionAtPoint(pendingAction, center, true, func() {
+		h.executeActionAtPoint(pendingAction, pendingModifier, center, true, func() {
 			h.activateHintModeInternal(
+				nil,
 				nil,
 				nil,
 				filterRoles,
@@ -786,6 +789,7 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 			if h.appState.CurrentMode() == domain.ModeHints &&
 				h.hints != nil && h.hints.Context != nil {
 				h.hints.Context.SetPendingAction(pendingAction)
+				h.hints.Context.SetPendingModifier(pendingModifier)
 				h.hints.Context.SetRepeat(true)
 				h.hints.Context.SetCursorFollowSelection(cursorFollowSelection)
 				h.hints.Context.SetFilterRoles(filterRoles)

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -37,6 +37,7 @@ func (h *Handler) currentHintStyleLocked() hints.StyleMode {
 // ModeActivationOptions configures a mode activation request.
 type ModeActivationOptions struct {
 	Action                *string
+	Modifier              *string
 	Repeat                *bool
 	CursorFollowSelection *bool
 	FilterRoles           []string
@@ -129,6 +130,7 @@ func filterHintsForScreen(
 // activateHintModeWithAction activates hint mode with optional action parameter.
 func (h *Handler) activateHintModeWithAction(
 	action *string,
+	modifier *string,
 	repeat *bool,
 	cursorFollowSelection *bool,
 	filterRoles []string,
@@ -139,6 +141,7 @@ func (h *Handler) activateHintModeWithAction(
 ) {
 	h.activateHintModeInternal(
 		action,
+		modifier,
 		cursorFollowSelection,
 		filterRoles,
 		filterTextContains,
@@ -159,6 +162,7 @@ func (h *Handler) activateHintModeWithAction(
 
 func (h *Handler) activateHintModeInternal(
 	actionStr *string,
+	modifier *string,
 	cursorFollowSelection *bool,
 	filterRoles []string,
 	filterTextContains []string,
@@ -256,6 +260,10 @@ func (h *Handler) activateHintModeInternal(
 				h.hints.Context.SetPendingAction(actionStr)
 			}
 
+			if modifier != nil {
+				h.hints.Context.SetPendingModifier(modifier)
+			}
+
 			if cursorFollowSelection != nil {
 				h.hints.Context.SetCursorFollowSelection(*cursorFollowSelection)
 			}
@@ -281,6 +289,7 @@ func (h *Handler) activateHintModeInternal(
 			}
 		} else {
 			h.hints.Context.SetPendingAction(actionStr)
+			h.hints.Context.SetPendingModifier(modifier)
 			h.hints.Context.SetRepeat(false)
 			h.hints.Context.SetCursorFollowSelection(resolveCursorFollowSelection(
 				domain.ModeHints,

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -39,6 +39,8 @@ func (h *Handler) executeActionAtPoint(
 		modifiers, err = action.ParseModifiers(*modifierStr)
 		if err != nil {
 			h.logger.Error("Failed to parse pending modifier", zap.Error(err))
+
+			return
 		}
 	}
 

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -42,6 +42,12 @@ func (h *Handler) executeActionAtPoint(
 
 			return
 		}
+
+		if *modifierStr != "" && modifiers == 0 {
+			h.logger.Error("Pending modifier was non-empty but parsed to no modifiers")
+
+			return
+		}
 	}
 
 	modifiers |= h.stickyModifiers()

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -11,6 +11,7 @@ import (
 	hintscomponent "github.com/y3owk1n/neru/internal/app/components/hints"
 	configpkg "github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/domain/action"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
 	"github.com/y3owk1n/neru/internal/ui/coordinates"
 )
@@ -19,20 +20,33 @@ import (
 // When repeat is true and reActivateFunc is provided, the mode is re-activated
 // instead of exiting after performing the action.
 func (h *Handler) executeActionAtPoint(
-	action *string,
+	actionStr *string,
+	modifierStr *string,
 	point image.Point,
 	repeat bool,
 	reActivateFunc func(),
 ) {
-	if action == nil {
+	if actionStr == nil {
 		h.logger.Warn("executeActionAtPoint called with nil action")
 
 		return
 	}
 
+	var modifiers action.Modifiers
+	if modifierStr != nil {
+		var err error
+
+		modifiers, err = action.ParseModifiers(*modifierStr)
+		if err != nil {
+			h.logger.Error("Failed to parse pending modifier", zap.Error(err))
+		}
+	}
+
+	modifiers |= h.stickyModifiers()
+
 	h.logger.Debug("Executing pending action",
-		zap.String("action", *action),
-		zap.String("modifiers", h.stickyModifiers().String()),
+		zap.String("action", *actionStr),
+		zap.String("modifiers", modifiers.String()),
 		zap.Bool("repeat", repeat))
 
 	ctx := h.ctx
@@ -40,7 +54,7 @@ func (h *Handler) executeActionAtPoint(
 	// Split comma-separated actions and execute each one sequentially.
 	// This enables multi-click sequences like --action left_click,left_click
 	// which produce a double-click via the native click-counting layer.
-	actions := strings.Split(*action, ",")
+	actions := strings.Split(*actionStr, ",")
 	actionPerformed := false
 	chainFailed := false
 
@@ -61,7 +75,7 @@ func (h *Handler) executeActionAtPoint(
 			ctx,
 			trimmed,
 			point,
-			h.stickyModifiers(),
+			modifiers,
 		)
 		if performErr != nil {
 			h.logger.Error("Failed to perform pending action", zap.Error(performErr))
@@ -113,6 +127,7 @@ func (h *Handler) executeActionAtPoint(
 func (h *Handler) moveCursorAndHandleAction(
 	point image.Point,
 	pendingAction *string,
+	pendingModifier *string,
 	shouldReActivate bool,
 	reActivateFunc func(),
 ) {
@@ -124,7 +139,9 @@ func (h *Handler) moveCursorAndHandleAction(
 	}
 
 	if pendingAction != nil {
-		h.executeActionAtPoint(pendingAction, point, shouldReActivate, reActivateFunc)
+		h.executeActionAtPoint(
+			pendingAction, pendingModifier, point, shouldReActivate, reActivateFunc,
+		)
 
 		return
 	}
@@ -160,6 +177,7 @@ func (h *Handler) handleHintsModeKey(key string) {
 		h.logger.Debug("Found element", zap.String("label", hint.Label()))
 
 		pendingAction := h.hints.Context.PendingAction()
+		pendingModifier := h.hints.Context.PendingModifier()
 		repeat := h.hints.Context.Repeat()
 		cursorFollowSelection := h.hints.Context.CursorFollowSelection()
 		filterRoles := h.hints.Context.FilterRoles()
@@ -171,10 +189,12 @@ func (h *Handler) handleHintsModeKey(key string) {
 		h.moveCursorAndHandleAction(
 			center,
 			pendingAction,
+			pendingModifier,
 			repeat ||
 				pendingAction == nil, // re-activate on repeat, or when no action (existing behavior)
 			func() {
 				h.activateHintModeInternal(
+					nil,
 					nil,
 					&cursorFollowSelection,
 					filterRoles,
@@ -183,12 +203,13 @@ func (h *Handler) handleHintsModeKey(key string) {
 					&strategyOverride,
 					&labelDirectionOverride,
 				)
-				// Restore repeat and action on the fresh context so subsequent
+				// Restore repeat, action and modifier on the fresh context so subsequent
 				// selections continue the repeat cycle.
 				// Guard: only restore if re-activation succeeded (mode is still hints).
 				if repeat && h.appState.CurrentMode() == domain.ModeHints &&
 					h.hints != nil && h.hints.Context != nil {
 					h.hints.Context.SetPendingAction(pendingAction)
+					h.hints.Context.SetPendingModifier(pendingModifier)
 					h.hints.Context.SetRepeat(true)
 					h.hints.Context.SetCursorFollowSelection(cursorFollowSelection)
 					h.hints.Context.SetFilterRoles(filterRoles)
@@ -429,6 +450,7 @@ func (h *Handler) handleGridModeKey(key string) {
 
 		repeat := h.grid.Context.Repeat()
 		pendingAction := h.grid.Context.PendingAction()
+		pendingModifier := h.grid.Context.PendingModifier()
 		cursorFollowSelection := h.grid.Context.CursorFollowSelection()
 
 		if pendingAction == nil && !repeat && !cursorFollowSelection {
@@ -440,9 +462,15 @@ func (h *Handler) handleGridModeKey(key string) {
 		h.moveCursorAndHandleAction(
 			absolutePoint,
 			pendingAction,
+			pendingModifier,
 			repeat, // Re-activate grid mode when --repeat is set
 			func() {
-				h.activateGridModeWithAction(pendingAction, &repeat, &cursorFollowSelection)
+				h.activateGridModeWithAction(
+					pendingAction,
+					pendingModifier,
+					&repeat,
+					&cursorFollowSelection,
+				)
 			},
 		)
 	} else if targetPoint := gridKeyResult.TargetPoint(); !targetPoint.Eq(image.Point{}) {

--- a/internal/app/modes/mode_handlers_test.go
+++ b/internal/app/modes/mode_handlers_test.go
@@ -16,7 +16,7 @@ func TestExecuteActionAtPoint_NilActionNoop(t *testing.T) {
 		cursorState: state.NewCursorState(),
 	}
 
-	handler.executeActionAtPoint(nil, point(10, 10), false, nil)
+	handler.executeActionAtPoint(nil, nil, point(10, 10), false, nil)
 
 	if handler.cursorState.WasActionPerformed() {
 		t.Fatal("expected no action state change for nil action")

--- a/internal/app/modes/passthrough.go
+++ b/internal/app/modes/passthrough.go
@@ -189,6 +189,7 @@ func (h *Handler) handlePassthroughLocked(mode domain.Mode, session uint64) {
 		h.activateHintModeInternal(
 			nil,
 			nil,
+			nil,
 			filterRoles,
 			filterTextContains,
 			&startWithSearch,

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -18,6 +18,7 @@ import (
 // activateRecursiveGridModeWithAction activates recursive-grid mode with optional action parameter.
 func (h *Handler) activateRecursiveGridModeWithAction(
 	actionStr *string,
+	modifier *string,
 	repeat *bool,
 	cursorFollowSelection *bool,
 ) {
@@ -108,6 +109,10 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 				h.recursiveGrid.Context.SetPendingAction(actionStr)
 			}
 
+			if modifier != nil {
+				h.recursiveGrid.Context.SetPendingModifier(modifier)
+			}
+
 			if repeat != nil {
 				h.recursiveGrid.Context.SetRepeat(*repeat)
 			}
@@ -117,6 +122,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 			}
 		} else {
 			h.recursiveGrid.Context.SetPendingAction(actionStr)
+			h.recursiveGrid.Context.SetPendingModifier(modifier)
 			h.recursiveGrid.Context.SetRepeat(repeat != nil && *repeat)
 			h.recursiveGrid.Context.SetCursorFollowSelection(cursorShouldFollow)
 		}
@@ -218,6 +224,7 @@ func (h *Handler) handleRecursiveGridKey(key string) {
 
 		repeat := h.recursiveGrid.Context.Repeat()
 		pendingAction := h.recursiveGrid.Context.PendingAction()
+		pendingModifier := h.recursiveGrid.Context.PendingModifier()
 		cursorFollowSelection := h.recursiveGrid.Context.CursorFollowSelection()
 
 		if pendingAction == nil && !repeat && !cursorFollowSelection {
@@ -229,10 +236,12 @@ func (h *Handler) handleRecursiveGridKey(key string) {
 		h.moveCursorAndHandleAction(
 			absoluteCenter,
 			pendingAction,
+			pendingModifier,
 			repeat, // Re-activate recursive-grid mode when --repeat is set
 			func() {
 				h.activateRecursiveGridModeWithAction(
 					pendingAction,
+					pendingModifier,
 					&repeat,
 					&cursorFollowSelection,
 				)

--- a/internal/app/modes/recursive_grid_mode.go
+++ b/internal/app/modes/recursive_grid_mode.go
@@ -15,6 +15,7 @@ func NewRecursiveGridMode(handler *Handler) *RecursiveGridMode {
 		ActivateFunc: func(handler *Handler, opts ModeActivationOptions) {
 			handler.activateRecursiveGridModeWithAction(
 				opts.Action,
+				opts.Modifier,
 				opts.Repeat,
 				opts.CursorFollowSelection,
 			)

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -121,9 +121,16 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 					)
 				}
 
-				_, modErr := action.ParseModifiers(modifierFlag)
+				mods, modErr := action.ParseModifiers(modifierFlag)
 				if modErr != nil {
 					return modErr
+				}
+
+				if mods == 0 {
+					return derrors.New(
+						derrors.CodeInvalidInput,
+						"modifier values cannot be empty",
+					)
 				}
 			}
 

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -113,11 +113,18 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				)
 			}
 
-			if modifierFlag != "" && actionFlag == "" {
-				return derrors.New(
-					derrors.CodeInvalidInput,
-					"--modifier requires --action",
-				)
+			if modifierFlag != "" {
+				if actionFlag == "" {
+					return derrors.New(
+						derrors.CodeInvalidInput,
+						"--modifier requires --action",
+					)
+				}
+
+				_, modErr := action.ParseModifiers(modifierFlag)
+				if modErr != nil {
+					return modErr
+				}
 			}
 
 			if actionFlag != "" {

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -41,6 +41,11 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				return err
 			}
 
+			modifierFlag, err := cmd.Flags().GetString("modifier")
+			if err != nil {
+				return err
+			}
+
 			repeatFlag, err := cmd.Flags().GetBool("repeat")
 			if err != nil {
 				return err
@@ -108,6 +113,13 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				)
 			}
 
+			if modifierFlag != "" && actionFlag == "" {
+				return derrors.New(
+					derrors.CodeInvalidInput,
+					"--modifier requires --action",
+				)
+			}
+
 			if actionFlag != "" {
 				// Split comma-separated actions and validate each one.
 				// This enables multi-click sequences like:
@@ -163,6 +175,10 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 			params = append(params, config.Name)
 			if actionFlag != "" {
 				params = append(params, actionFlag)
+			}
+
+			if modifierFlag != "" {
+				params = append(params, "--modifier="+modifierFlag)
 			}
 
 			if repeatFlag {
@@ -236,6 +252,12 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 		"r",
 		false,
 		"Re-activate mode after performing the action (requires --action)",
+	)
+
+	cmd.Flags().String(
+		"modifier",
+		"",
+		"Comma-separated modifier keys to hold during action (cmd, super, meta, shift, alt, option, ctrl) (requires --action)",
 	)
 	cmd.Flags().String(
 		"cursor-selection-mode",


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds `--modifier` support when using `--action` in a mode.

```bash
neru hints --action left_click --modifier ctrl
neru hints --action left_click --modifier alt,ctrl
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
