### PR TITLE
feat(hints,vision,darwin): add `--split-word` flag for vision only

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -100,6 +100,7 @@ neru hints
 neru hints --search                                # Start with search input active
 neru hints --action left_click --repeat            # Click multiple elements in succession
 neru hints --strategy vision                       # Use Vision Framework for element detection
+neru hints --strategy vision --split-word          # Split detected text into word-level regions (requires vision)
 neru hints --label-direction normal                # Use prefix-avoidance label algorithm for this activation
 
 # Filtering
@@ -119,6 +120,7 @@ neru hints --text next --action left_click --repeat   # Filter persists across r
 | `--role`                  | string | Filter by AX role. Comma-separated for multiple (e.g. `--role AXButton,AXLink`).                                                                                 |
 | `--text`                  | string | Filter elements by text content (title, description, value). Case-insensitive substring match. Comma-separated for OR match.                                     |
 | `--strategy`              | string | Element detection strategy: `axtree` (macOS AX API, default) or `vision` (Vision Framework). Overrides config for this invocation.                               |
+| `--split-word`            | bool   | Split detected text into word-level regions (requires `vision` strategy).                                                                                        |
 | `--label-direction`       | string | Hint label algorithm: `normal` (default, prefix-avoidance) or `reverse` (spread). Overrides `[hints].label_direction` and per-app overrides for this invocation. |
 
 The filter is preserved across repeat activations.

--- a/internal/app/components/hints/context.go
+++ b/internal/app/components/hints/context.go
@@ -16,6 +16,7 @@ type baseContext struct {
 	startWithSearch        bool
 	strategyOverride       string
 	labelDirectionOverride string
+	splitWord              bool
 }
 
 // SetPendingAction sets the action to execute when mode selection is complete.
@@ -76,6 +77,7 @@ func (c *baseContext) Reset() {
 	c.startWithSearch = false
 	c.strategyOverride = ""
 	c.labelDirectionOverride = ""
+	c.splitWord = false
 }
 
 // SetFilterRoles sets the filter roles for hint mode.
@@ -127,6 +129,16 @@ func (c *baseContext) SetLabelDirectionOverride(direction string) {
 // LabelDirectionOverride returns the session hint label direction override.
 func (c *baseContext) LabelDirectionOverride() string {
 	return c.labelDirectionOverride
+}
+
+// SetSplitWord stores the session word splitting preference.
+func (c *baseContext) SetSplitWord(split bool) {
+	c.splitWord = split
+}
+
+// SplitWord returns the session word splitting preference.
+func (c *baseContext) SplitWord() bool {
+	return c.splitWord
 }
 
 // Context holds the state and context for hint mode operations.

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -161,6 +161,7 @@ type ModeActivationOptions struct {
 	LabelDirection        *string
 	Toggle                *bool
 	Debug                 *bool
+	SplitWord             *bool
 }
 
 // parseCursorSelectionModeValue resolves a --cursor-selection-mode value into a
@@ -245,6 +246,9 @@ func (h *IPCControllerModes) extractModeOptions(
 			startIdx++
 			modifierArg := cmd.Args[startIdx]
 			opts.Modifier = &modifierArg
+		case arg == "--split-word":
+			splitWordTrue := true
+			opts.SplitWord = &splitWordTrue
 		case strings.HasPrefix(arg, "--action="):
 			actionArg := strings.TrimPrefix(arg, "--action=")
 			opts.Action = &actionArg
@@ -264,7 +268,8 @@ func (h *IPCControllerModes) extractModeOptions(
 			opts.Action = &actionArg
 		case strings.HasPrefix(arg, "--cursor-selection-mode="):
 			val, resp := parseCursorSelectionModeValue(
-				strings.TrimPrefix(arg, "--cursor-selection-mode="))
+				strings.TrimPrefix(arg, "--cursor-selection-mode="),
+			)
 			if resp != nil {
 				return opts, resp
 			}
@@ -290,7 +295,8 @@ func (h *IPCControllerModes) extractModeOptions(
 		case strings.HasPrefix(arg, "--role="):
 			opts.FilterRoles = append(
 				opts.FilterRoles,
-				parseCSV(strings.TrimPrefix(arg, "--role="))...)
+				parseCSV(strings.TrimPrefix(arg, "--role="))...,
+			)
 		case arg == "--role":
 			if startIdx+1 >= len(cmd.Args) || cmd.Args[startIdx+1] == "--role" {
 				resp := ipc.Response{
@@ -523,11 +529,17 @@ func (h *IPCControllerModes) handleHints(ctx context.Context, cmd ipc.Command) i
 			strategy = *opts.Strategy
 		}
 
+		splitWord := false
+		if opts.SplitWord != nil {
+			splitWord = *opts.SplitWord
+		}
+
 		summary, probeErr := h.modes.DebugProbeHints(
 			ctx,
 			opts.FilterRoles,
 			opts.FilterTextContains,
 			strategy,
+			splitWord,
 		)
 		if probeErr != nil {
 			return ipc.Response{
@@ -551,6 +563,7 @@ func (h *IPCControllerModes) handleHints(ctx context.Context, cmd ipc.Command) i
 		Strategy:              opts.Strategy,
 		LabelDirection:        opts.LabelDirection,
 		Toggle:                opts.Toggle,
+		SplitWord:             opts.SplitWord,
 	})
 
 	return ipc.Response{Success: true, Message: "hints mode activated", Code: ipc.CodeOK}

--- a/internal/app/modes/generic_mode.go
+++ b/internal/app/modes/generic_mode.go
@@ -55,6 +55,7 @@ func (m *GenericMode) Activate(opts ModeActivationOptions) {
 				opts.Search,
 				opts.Strategy,
 				opts.LabelDirection,
+				opts.SplitWord,
 			)
 		case domain.ModeGrid:
 			m.handler.activateGridModeWithAction(

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -287,6 +287,11 @@ func (h *Handler) RefreshHintsForScreenChange(
 
 	// Generate hints with filters preserved; SetHints below performs the
 	// single redraw after active-screen filtering.
+	splitWordOverride := false
+	if h.hints != nil && h.hints.Context != nil {
+		splitWordOverride = h.hints.Context.SplitWord()
+	}
+
 	domainHints, showHintsErr := hintService.GenerateHints(
 		ctx,
 		filterRoles,
@@ -294,6 +299,7 @@ func (h *Handler) RefreshHintsForScreenChange(
 		"",
 		strategyOverride,
 		labelDirectionOverride,
+		splitWordOverride,
 	)
 	if showHintsErr != nil {
 		h.logger.Error("Failed to refresh hints after screen change", zap.Error(showHintsErr))
@@ -772,6 +778,7 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 		startWithSearch := h.hints.Context.StartWithSearch()
 		strategyOverride := h.hints.Context.StrategyOverride()
 		labelDirectionOverride := h.hints.Context.LabelDirectionOverride()
+		splitWord := h.hints.Context.SplitWord()
 
 		h.executeActionAtPoint(pendingAction, pendingModifier, center, true, func() {
 			h.activateHintModeInternal(
@@ -783,6 +790,7 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 				&startWithSearch,
 				&strategyOverride,
 				&labelDirectionOverride,
+				&splitWord,
 			)
 
 			// Restore state so subsequent cycles continue to execute the action
@@ -797,6 +805,7 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 				h.hints.Context.SetStartWithSearch(startWithSearch)
 				h.hints.Context.SetStrategyOverride(strategyOverride)
 				h.hints.Context.SetLabelDirectionOverride(labelDirectionOverride)
+				h.hints.Context.SetSplitWord(splitWord)
 			}
 		})
 	}

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -46,6 +46,7 @@ type ModeActivationOptions struct {
 	Strategy              *string
 	LabelDirection        *string
 	Toggle                *bool
+	SplitWord             *bool
 }
 
 const (
@@ -138,6 +139,7 @@ func (h *Handler) activateHintModeWithAction(
 	search *bool,
 	strategy *string,
 	labelDirection *string,
+	splitWord *bool,
 ) {
 	h.activateHintModeInternal(
 		action,
@@ -148,6 +150,7 @@ func (h *Handler) activateHintModeWithAction(
 		search,
 		strategy,
 		labelDirection,
+		splitWord,
 	)
 
 	// Store repeat flag after activation so the context is already initialized.
@@ -169,6 +172,7 @@ func (h *Handler) activateHintModeInternal(
 	search *bool,
 	strategyOverride *string,
 	labelDirectionOverride *string,
+	splitWordOverride *bool,
 ) {
 	// Detect refresh before validation so we can clean up on failure
 	isRefresh := h.appState.CurrentMode() == domain.ModeHints
@@ -287,6 +291,10 @@ func (h *Handler) activateHintModeInternal(
 			if labelDirectionOverride != nil {
 				h.hints.Context.SetLabelDirectionOverride(*labelDirectionOverride)
 			}
+
+			if splitWordOverride != nil {
+				h.hints.Context.SetSplitWord(*splitWordOverride)
+			}
 		} else {
 			h.hints.Context.SetPendingAction(actionStr)
 			h.hints.Context.SetPendingModifier(modifier)
@@ -309,6 +317,12 @@ func (h *Handler) activateHintModeInternal(
 				h.hints.Context.SetLabelDirectionOverride(*labelDirectionOverride)
 			} else {
 				h.hints.Context.SetLabelDirectionOverride("")
+			}
+
+			if splitWordOverride != nil {
+				h.hints.Context.SetSplitWord(*splitWordOverride)
+			} else {
+				h.hints.Context.SetSplitWord(false)
 			}
 		}
 	}
@@ -352,6 +366,13 @@ func (h *Handler) activateHintModeInternal(
 		labelDirectionVal = *labelDirectionOverride
 	}
 
+	splitWordVal := false
+	if h.hints != nil && h.hints.Context != nil {
+		splitWordVal = h.hints.Context.SplitWord()
+	} else if splitWordOverride != nil {
+		splitWordVal = *splitWordOverride
+	}
+
 	var permissionOk bool
 
 	activeScreenBounds, bundleID, strategy, permissionOk = h.ensureScreenCapturePermissionsLocked(
@@ -377,6 +398,7 @@ func (h *Handler) activateHintModeInternal(
 		bundleID,
 		strategyVal,
 		labelDirectionVal,
+		splitWordVal,
 	)
 	if domainHintsErr != nil {
 		h.logger.Error(

--- a/internal/app/modes/hints_debug.go
+++ b/internal/app/modes/hints_debug.go
@@ -29,6 +29,7 @@ func (h *Handler) DebugProbeHints(
 	filterRoles []string,
 	filterTextContains []string,
 	strategy string,
+	splitWord bool,
 ) (string, error) {
 	bundleID, bundleErr := h.actionService.FocusedAppBundleID(ctx)
 	if bundleErr != nil {
@@ -47,6 +48,7 @@ func (h *Handler) DebugProbeHints(
 		bundleID,
 		strategy,
 		"", // labelDirectionOverride: probe uses the configured default
+		splitWord,
 	)
 	if genErr != nil {
 		return "", genErr

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -193,6 +193,7 @@ func (h *Handler) handleHintsModeKey(key string) {
 		startWithSearch := h.hints.Context.StartWithSearch()
 		strategyOverride := h.hints.Context.StrategyOverride()
 		labelDirectionOverride := h.hints.Context.LabelDirectionOverride()
+		splitWord := h.hints.Context.SplitWord()
 
 		h.moveCursorAndHandleAction(
 			center,
@@ -210,6 +211,7 @@ func (h *Handler) handleHintsModeKey(key string) {
 					&startWithSearch,
 					&strategyOverride,
 					&labelDirectionOverride,
+					&splitWord,
 				)
 				// Restore repeat, action and modifier on the fresh context so subsequent
 				// selections continue the repeat cycle.
@@ -225,6 +227,7 @@ func (h *Handler) handleHintsModeKey(key string) {
 					h.hints.Context.SetStartWithSearch(startWithSearch)
 					h.hints.Context.SetStrategyOverride(strategyOverride)
 					h.hints.Context.SetLabelDirectionOverride(labelDirectionOverride)
+					h.hints.Context.SetSplitWord(splitWord)
 				}
 			},
 		)

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -380,6 +380,11 @@ func (h *Handler) refreshHintsForMonitorMove(
 	strategyOverride := h.hints.Context.StrategyOverride()
 	labelDirectionOverride := h.hints.Context.LabelDirectionOverride()
 
+	splitWordOverride := false
+	if h.hints != nil && h.hints.Context != nil {
+		splitWordOverride = h.hints.Context.SplitWord()
+	}
+
 	domainHints, err := h.hintService.GenerateHints(
 		ctx,
 		filterRoles,
@@ -387,6 +392,7 @@ func (h *Handler) refreshHintsForMonitorMove(
 		"",
 		strategyOverride,
 		labelDirectionOverride,
+		splitWordOverride,
 	)
 	if err != nil {
 		h.logger.Error(

--- a/internal/app/modes/passthrough.go
+++ b/internal/app/modes/passthrough.go
@@ -186,6 +186,7 @@ func (h *Handler) handlePassthroughLocked(mode domain.Mode, session uint64) {
 		startWithSearch := h.hints.Context.StartWithSearch()
 		strategyOverride := h.hints.Context.StrategyOverride()
 		labelDirectionOverride := h.hints.Context.LabelDirectionOverride()
+		splitWord := h.hints.Context.SplitWord()
 		h.activateHintModeInternal(
 			nil,
 			nil,
@@ -195,6 +196,7 @@ func (h *Handler) handlePassthroughLocked(mode domain.Mode, session uint64) {
 			&startWithSearch,
 			&strategyOverride,
 			&labelDirectionOverride,
+			&splitWord,
 		)
 	})
 	h.refreshHintsTimer = timer

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -77,7 +77,7 @@ func (s *HintService) ShowHints(
 ) ([]*hint.Interface, error) {
 	s.logger.Debug("Showing hints")
 
-	hints, err := s.GenerateHints(ctx, filterRoles, filterTextContains, "", "", "")
+	hints, err := s.GenerateHints(ctx, filterRoles, filterTextContains, "", "", "", false)
 	if err != nil {
 		return nil, err
 	}
@@ -112,6 +112,7 @@ func (s *HintService) GenerateHints(
 	bundleID string,
 	strategyOverride string,
 	labelDirectionOverride string,
+	splitWord bool,
 ) ([]*hint.Interface, error) {
 	s.mu.RLock()
 	cfg := s.config
@@ -189,6 +190,13 @@ func (s *HintService) GenerateHints(
 		labelDirection = labelDirectionOverride
 	}
 
+	if splitWord && strategy != config.StrategyVision {
+		return nil, derrors.New(
+			derrors.CodeInvalidInput,
+			"--split-word is only supported when resolved strategy is 'vision'",
+		)
+	}
+
 	var (
 		elements []*element.Element
 		genErr   error
@@ -196,7 +204,7 @@ func (s *HintService) GenerateHints(
 
 	switch strategy {
 	case config.StrategyVision:
-		elements = s.generateHintsVision(ctx, bundleID, filter)
+		elements = s.generateHintsVision(ctx, bundleID, filter, splitWord)
 	default:
 		elements, genErr = s.generateHintsAX(ctx, filter)
 	}
@@ -377,6 +385,7 @@ func (s *HintService) generateHintsVision(
 	ctx context.Context,
 	_ string,
 	filter ports.ElementFilter,
+	splitWord bool,
 ) []*element.Element {
 	// Collect supplementary elements (menubar, dock, NC, etc.) via AX.
 	// These are system-level components that vision should not attempt to detect.
@@ -422,7 +431,12 @@ func (s *HintService) generateHintsVision(
 
 	// Detect window elements via vision
 	visionStart := time.Now()
-	windowElements, visionErr := s.vision.DetectElements(ctx, windowBounds, s.config.Vision)
+	windowElements, visionErr := s.vision.DetectElements(
+		ctx,
+		windowBounds,
+		s.config.Vision,
+		splitWord,
+	)
 	s.logger.Debug("TIMING: Window elements (vision)",
 		zap.Duration("elapsed", time.Since(visionStart)),
 		zap.Int("count", len(windowElements)),

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -533,6 +533,7 @@ func TestHintService_GenerateHintsVisionCombinesSupplementaryAndWindowElements(
 		"com.example.app",
 		config.StrategyVision,
 		"",
+		false,
 	)
 	if err != nil {
 		t.Fatalf("GenerateHints() unexpected error: %v", err)
@@ -593,6 +594,7 @@ func TestHintService_GenerateHintsVisionWithNilPortReturnsSupplementaryElements(
 		"com.example.app",
 		config.StrategyVision,
 		"",
+		false,
 	)
 	if err != nil {
 		t.Fatalf("GenerateHints() unexpected error: %v", err)
@@ -756,7 +758,7 @@ func TestHintService_GenerateHintsPicksDirectionGenerator(t *testing.T) {
 	// to the default normal generator. The normal algorithm keeps 3
 	// single-char slots ([A S D]) and expands the 4th alphabet slot (F)
 	// into 2-char labels starting at [FA].
-	hints, err := service.GenerateHints(ctx, nil, nil, "", "", "")
+	hints, err := service.GenerateHints(ctx, nil, nil, "", "", "", false)
 	if err != nil {
 		t.Fatalf("GenerateHints() unexpected error: %v", err)
 	}
@@ -777,7 +779,7 @@ func TestHintService_GenerateHintsPicksDirectionGenerator(t *testing.T) {
 	// The reverse algorithm fills all 4 single-char slots ([AA SA DA FA])
 	// before yielding a 2-char label ([AS]). The 1st and 5th labels (AA, AS)
 	// prove the override actually engaged.
-	hints, err = service.GenerateHints(ctx, nil, nil, "", "", config.LabelDirectionReverse)
+	hints, err = service.GenerateHints(ctx, nil, nil, "", "", config.LabelDirectionReverse, false)
 	if err != nil {
 		t.Fatalf("GenerateHints() with reverse override unexpected error: %v", err)
 	}
@@ -871,6 +873,7 @@ func (m *mockVisionPort) DetectElements(
 	context.Context,
 	image.Rectangle,
 	config.HintsVisionConfig,
+	bool,
 ) ([]*element.Element, error) {
 	if m.detectErr != nil {
 		return nil, m.detectErr
@@ -885,4 +888,38 @@ func (m *mockVisionPort) CaptureScreen(context.Context) (*image.RGBA, error) {
 
 func (m *mockVisionPort) Health(context.Context) error {
 	return nil
+}
+
+func TestHintService_GenerateHintsRejectsSplitWordForNonVisionStrategy(t *testing.T) {
+	generator, _ := hint.NewAlphabetGenerator("asdf", hint.LabelDirectionNormal)
+	service := services.NewHintService(
+		&mocks.MockAccessibilityPort{},
+		&mocks.MockOverlayPort{},
+		&mocks.MockSystemPort{},
+		generator,
+		config.HintsConfig{
+			Strategy: config.StrategyAXTree,
+		},
+		logger.Get(),
+		nil,
+	)
+
+	ctx := context.Background()
+
+	_, err := service.GenerateHints(
+		ctx,
+		nil,
+		nil,
+		"",
+		config.StrategyAXTree,
+		"",
+		true, // splitWord
+	)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Errorf("expected invalid input error, got: %v", err)
+	}
 }

--- a/internal/cli/hints.go
+++ b/internal/cli/hints.go
@@ -24,6 +24,9 @@ var HintsCmd = BuildModeCommand(ModeConfig{
   Use --strategy vision to use the Vision Framework (macOS) for element
   detection instead of the default AX API.
 
+  Use --split-word to split detected text into word-level regions (requires
+  vision strategy).
+
   Use --debug to probe the focused window and print the clickable elements
   that would be hinted (count plus a sample) without showing the overlay.
   This is handy for verifying the platform accessibility pipeline.
@@ -40,6 +43,7 @@ var HintsCmd = BuildModeCommand(ModeConfig{
     neru hints --search                      Start with search input shown
     neru hints --role AXButton               Hint only buttons
     neru hints --strategy vision             Use Vision Framework detection
+    neru hints --strategy vision --split-word Use vision strategy with word-level splitting
     neru hints --debug                       Print detected elements, no overlay (used on windows),
     neru hints --label-direction reverse     Use spread labels for this run`,
 
@@ -49,6 +53,7 @@ var HintsCmd = BuildModeCommand(ModeConfig{
 	SupportStrategy:       true,
 	SupportDebug:          true,
 	SupportLabelDirection: true,
+	SupportSplitWord:      true,
 })
 
 func init() {

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -23,6 +23,7 @@ type ModeConfig struct {
 	SupportStrategy       bool     // Whether this mode supports the --strategy flag
 	SupportLabelDirection bool     // Whether this mode supports the --label-direction flag
 	SupportDebug          bool     // Whether this mode supports the --debug probe flag
+	SupportSplitWord      bool     // Whether this mode supports the --split-word flag
 }
 
 // BuildModeCommand creates a CLI command for a navigation mode (hints, grid, etc.).
@@ -88,6 +89,14 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 			var debugFlag bool
 			if config.SupportDebug {
 				debugFlag, err = cmd.Flags().GetBool("debug")
+				if err != nil {
+					return err
+				}
+			}
+
+			var splitWordFlag bool
+			if config.SupportSplitWord {
+				splitWordFlag, err = cmd.Flags().GetBool("split-word")
 				if err != nil {
 					return err
 				}
@@ -239,6 +248,10 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				params = append(params, "--label-direction="+labelDirectionFlag)
 			}
 
+			if splitWordFlag {
+				params = append(params, "--split-word")
+			}
+
 			return sendCommand(cmd, config.Name, params)
 		},
 	}
@@ -323,6 +336,14 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 			"label-direction",
 			"",
 			"Hint label enumeration: normal (default, prefix-avoidance, prefers shorter labels) or reverse (spreads labels across the alphabet)",
+		)
+	}
+
+	if config.SupportSplitWord {
+		cmd.Flags().Bool(
+			"split-word",
+			false,
+			"Split detected text into word-level regions (requires vision strategy)",
 		)
 	}
 

--- a/internal/core/infra/platform/darwin/vision.h
+++ b/internal/core/infra/platform/darwin/vision.h
@@ -23,6 +23,7 @@ typedef struct {
 	double rectangleMinSize;
 	double rectangleMinAspect;
 	double rectangleMaxAspect;
+	int wordLevel;
 } NeruVisionConfig;
 
 // Captures the display containing the given rect and runs Vision Framework

--- a/internal/core/infra/platform/darwin/vision_darwin.m
+++ b/internal/core/infra/platform/darwin/vision_darwin.m
@@ -260,19 +260,49 @@ VisionResult *NeruDetectElements(CGRect screenBounds, NeruVisionConfig config) {
 
 		// Add detected text regions
 		for (VNRecognizedTextObservation *obs in texts) {
-			CGRect r = [obs boundingBox];
-			CGRect pixelRect = visionRectToCGRect(imgRect, r);
 			VNRecognizedText *top = [[obs topCandidates:1] firstObject];
 			NSString *text = top ? top.string : @"";
-			[regionList addObject:@{
-				@"x" : @(originX + pixelRect.origin.x / scaleX),
-				@"y" : @(originY + pixelRect.origin.y / scaleY),
-				@"w" : @(pixelRect.size.width / scaleX),
-				@"h" : @(pixelRect.size.height / scaleY),
-				@"score" : @(obs.confidence),
-				@"isText" : @(1),
-				@"label" : text ?: @""
-			}];
+
+			if (config.wordLevel && top && text.length > 0) {
+				// Split into word-level regions
+				[text enumerateSubstringsInRange:NSMakeRange(0, text.length)
+				                         options:NSStringEnumerationByWords
+				                      usingBlock:^(
+				                          NSString *word, NSRange wordRange, NSRange enclosingRange, BOOL *stop) {
+					                      NSError *err = nil;
+					                      VNRectangleObservation *wordObs = [top boundingBoxForRange:wordRange
+					                                                                           error:&err];
+					                      if (err != nil || wordObs == nil) {
+						                      return;
+					                      }
+					                      CGRect wordBox = [wordObs boundingBox];
+					                      if (CGRectIsEmpty(wordBox) || CGRectIsNull(wordBox)) {
+						                      return;
+					                      }
+					                      CGRect pixelRect = visionRectToCGRect(imgRect, wordBox);
+					                      [regionList addObject:@{
+						                      @"x" : @(originX + pixelRect.origin.x / scaleX),
+						                      @"y" : @(originY + pixelRect.origin.y / scaleY),
+						                      @"w" : @(pixelRect.size.width / scaleX),
+						                      @"h" : @(pixelRect.size.height / scaleY),
+						                      @"score" : @(obs.confidence),
+						                      @"isText" : @(1),
+						                      @"label" : word
+					                      }];
+				                      }];
+			} else {
+				CGRect r = [obs boundingBox];
+				CGRect pixelRect = visionRectToCGRect(imgRect, r);
+				[regionList addObject:@{
+					@"x" : @(originX + pixelRect.origin.x / scaleX),
+					@"y" : @(originY + pixelRect.origin.y / scaleY),
+					@"w" : @(pixelRect.size.width / scaleX),
+					@"h" : @(pixelRect.size.height / scaleY),
+					@"score" : @(obs.confidence),
+					@"isText" : @(1),
+					@"label" : text ?: @""
+				}];
+			}
 		}
 
 		// Build C result

--- a/internal/core/infra/vision/adapter_darwin.go
+++ b/internal/core/infra/vision/adapter_darwin.go
@@ -33,6 +33,7 @@ func (a *Adapter) DetectElements(
 	ctx context.Context,
 	screenBounds image.Rectangle,
 	cfg config.HintsVisionConfig,
+	splitWord bool,
 ) ([]*element.Element, error) {
 	select {
 	case <-ctx.Done():
@@ -56,6 +57,11 @@ func (a *Adapter) DetectElements(
 		detectRectangles = 1
 	}
 
+	var wordLevel C.int
+	if splitWord {
+		wordLevel = 1
+	}
+
 	cCfg := C.NeruVisionConfig{
 		detectText:             detectText,
 		detectRectangles:       detectRectangles,
@@ -64,6 +70,7 @@ func (a *Adapter) DetectElements(
 		rectangleMinSize:       C.double(cfg.RectangleMinSize),
 		rectangleMinAspect:     C.double(cfg.RectangleMinAspect),
 		rectangleMaxAspect:     C.double(cfg.RectangleMaxAspect),
+		wordLevel:              wordLevel,
 	}
 
 	result := C.NeruDetectElements(cgRect, cCfg)

--- a/internal/core/infra/vision/adapter_other.go
+++ b/internal/core/infra/vision/adapter_other.go
@@ -16,6 +16,7 @@ func (a *Adapter) DetectElements(
 	_ context.Context,
 	_ image.Rectangle,
 	_ config.HintsVisionConfig,
+	_ bool,
 ) ([]*element.Element, error) {
 	return nil, derrors.New(derrors.CodeNotSupported, "vision detection is only supported on macOS")
 }

--- a/internal/core/ports/vision.go
+++ b/internal/core/ports/vision.go
@@ -28,6 +28,7 @@ type VisionPort interface {
 		ctx context.Context,
 		screenBounds image.Rectangle,
 		cfg config.HintsVisionConfig,
+		splitWord bool,
 	) ([]*element.Element, error)
 
 	// CaptureScreen returns the current screen image for the primary display.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a new flag `--split-word` for hint mode (vision only strategy), where it will be the best effort to split out all of the words into clickable labels.

```bash
neru hints --strategy vision --split-word
```

You can compose it for different use cases, e.g. copy a block of text with start and end:

```toml
# 1. launch hints, select a label and double click on the word
# 2. launch another hints, select a lable and single click on the word with shift modifier
"Cmd+1" = ["hints --strategy vision --split-word --action left_click,left_click", "action wait_for_mode_exit", "hints --strategy vision --split-word --action left_click --modifier shift"]
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
