### PR TITLE
fix(hints): separate `cycle_hint` from action execution

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -402,7 +402,7 @@ The hints command completes fully (AX elements collected, overlay drawn) before 
 
 ### Cycling Hints
 
-In hints mode, cycles through visible hints without requiring label input.
+In hints mode, cycles through visible hints without requiring label input. Cycling moves the cursor to the next hint but does **not** execute the pending action — this lets you browse results before committing. Use `Enter` on a single search result or type an exact hint label to trigger the action.
 
 ```bash
 neru action cycle_hint                        # Next hint

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -71,7 +71,9 @@ If you want to have the search input shown automatically when activating hints m
 - `Space` is supported for multi-word searches (e.g., "search for issue")
 - `Backspace` removes characters
 - `Escape` cancels and restores all hints
-- `Enter` auto-selects the first hint when 1+ hints remain, handling pending actions and cursor movement
+- `Enter` with 1 result: executes the pending action (if any) and exits
+- `Enter` with multiple results: closes search only, letting you type the exact hint label to select
+- `Tab` / `cycle_hint`: navigates between filtered results without executing the action
 
 ## Auto-Exit After Click
 

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -1344,7 +1344,7 @@ func (h *IPCControllerActions) handleCycleHintAction(
 		zap.Bool("backward", parsed.useBackward),
 	)
 
-	err := h.modesHandler.CycleHint(ctx, parsed.useBackward)
+	err := h.modesHandler.CycleHint(ctx, parsed.useBackward, false)
 	if err != nil {
 		h.logger.Error("Failed to cycle hints", zap.Error(err))
 

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -705,7 +705,10 @@ func (h *Handler) StartHintSearch() error {
 }
 
 // CycleHint cycles through visible hints in hints mode, selecting the next or previous one.
-func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
+// When executeAction is true, any pending action is performed on the selected hint
+// (used by search confirmation). When false, only the cursor moves (used by the
+// cycle_hint IPC action so users can browse results without triggering clicks).
+func (h *Handler) CycleHint(ctx context.Context, backward bool, executeAction bool) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -771,7 +774,8 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 	pendingAction := h.hints.Context.PendingAction()
 
 	pendingModifier := h.hints.Context.PendingModifier()
-	if pendingAction != nil {
+	if pendingAction != nil && executeAction {
+		repeat := h.hints.Context.Repeat()
 		cursorFollowSelection := h.hints.Context.CursorFollowSelection()
 		filterRoles := h.hints.Context.FilterRoles()
 		filterTextContains := h.hints.Context.FilterTextContains()
@@ -780,7 +784,7 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 		labelDirectionOverride := h.hints.Context.LabelDirectionOverride()
 		splitWord := h.hints.Context.SplitWord()
 
-		h.executeActionAtPoint(pendingAction, pendingModifier, center, true, func() {
+		h.executeActionAtPoint(pendingAction, pendingModifier, center, repeat, func() {
 			h.activateHintModeInternal(
 				nil,
 				nil,
@@ -794,7 +798,8 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool) error {
 			)
 
 			// Restore state so subsequent cycles continue to execute the action
-			if h.appState.CurrentMode() == domain.ModeHints &&
+			// Guard: only restore if repeat was originally set (mode is still hints).
+			if repeat && h.appState.CurrentMode() == domain.ModeHints &&
 				h.hints != nil && h.hints.Context != nil {
 				h.hints.Context.SetPendingAction(pendingAction)
 				h.hints.Context.SetPendingModifier(pendingModifier)

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -306,9 +306,20 @@ func (h *Handler) confirmHintSearch() {
 	ctx.SetSearchActive(false)
 	h.overlayManager.HideHintSearchInput()
 
-	if visibleHints := ctx.Hints(); visibleHints != nil && visibleHints.Count() >= 1 {
+	visibleHints := ctx.Hints()
+	if visibleHints != nil && visibleHints.Count() >= 1 {
+		// When a pending action is configured and more than one hint matches
+		// the search query, just close the search overlay without executing
+		// the action. This lets the user type the exact hint label to select
+		// an element instead of blindly acting on the first match.
+		if ctx.PendingAction() != nil && visibleHints.Count() > 1 {
+			h.cycleHintIndex = -1
+
+			return
+		}
+
 		go func() {
-			_ = h.CycleHint(h.ctx, false)
+			_ = h.CycleHint(h.ctx, false, true)
 		}()
 	} else {
 		h.cancelHintSearch()


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR make hints mode UX better when `--search` is used with `--action`.

| Scenario | Enter (1 result) | Enter (N results) | Tab/cycle | Type label |
|---|---|---|---|---|
| `--search` | Move cursor, stay | Close search, show labels | Move cursor, stay | Move cursor, stay |
| `--search --action` | Execute action, exit | Close search, show labels | Move cursor only | Execute action, exit |
| `--search --action --repeat` | Execute action, re-activate | Close search, show labels | Move cursor only | Execute action, re-activate |

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
