### PR TITLE
feat(hints,cli): add `--hide-on-empty-search` flag when search is empty

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -98,6 +98,7 @@ neru hints
 # Type hint label (e.g. "as") to select an element
 
 neru hints --search                                # Start with search input active
+neru hints --search --hide-on-empty-search          # Start search with hints hidden until you type
 neru hints --action left_click --repeat            # Click multiple elements in succession
 neru hints --strategy vision                       # Use Vision Framework for element detection
 neru hints --strategy vision --split-word          # Split detected text into word-level regions (requires vision)
@@ -116,7 +117,8 @@ neru hints --text next --action left_click --repeat   # Filter persists across r
 | `--repeat, -r`            | bool   | Re-activate hints after action (requires `--action`)                                                                                                             |
 | `--toggle, -t`            | bool   | Toggle hints on/off                                                                                                                                              |
 | `--cursor-selection-mode` | string | `follow` (default) or `hold` — whether cursor jumps to selection                                                                                                 |
-| `--search, -s`            | bool   | Start with search input active.                                                                                                                                  |
+| `--search, -s`            | bool   | Start with search input active.                                                                                                                               |
+| `--hide-on-empty-search` | bool   | Hide all hints when search query is empty — hints appear only as you type (requires `--search`).                                                               |                                                                                                                                  |
 | `--role`                  | string | Filter by AX role. Comma-separated for multiple (e.g. `--role AXButton,AXLink`).                                                                                 |
 | `--text`                  | string | Filter elements by text content (title, description, value). Case-insensitive substring match. Comma-separated for OR match.                                     |
 | `--strategy`              | string | Element detection strategy: `axtree` (macOS AX API, default) or `vision` (Vision Framework). Overrides config for this invocation.                               |

--- a/internal/app/components/hints/context.go
+++ b/internal/app/components/hints/context.go
@@ -150,8 +150,9 @@ type Context struct {
 	hints       *domainHint.Collection
 	sourceHints *domainHint.Collection
 
-	searchQuery  string
-	searchActive bool
+	searchQuery       string
+	searchActive      bool
+	hideOnEmptySearch bool
 }
 
 // SetManager sets the domain hint manager.
@@ -204,6 +205,15 @@ func (c *Context) SetVisibleHints(hints *domainHint.Collection) error {
 	return nil
 }
 
+// ClearVisibleHints replaces the visible hints with an empty collection,
+// effectively hiding all hints while preserving the source collection for
+// search cancellation.
+func (c *Context) ClearVisibleHints() error {
+	hints := domainHint.NewCollection(nil)
+
+	return c.SetVisibleHints(hints)
+}
+
 // Hints returns the current hint collection.
 func (c *Context) Hints() *domainHint.Collection {
 	return c.hints
@@ -234,6 +244,18 @@ func (c *Context) SearchActive() bool {
 	return c.searchActive
 }
 
+// SetHideOnEmptySearch sets whether hints should be hidden when the search
+// query is empty.
+func (c *Context) SetHideOnEmptySearch(hide bool) {
+	c.hideOnEmptySearch = hide
+}
+
+// HideOnEmptySearch returns whether hints should be hidden when the search
+// query is empty.
+func (c *Context) HideOnEmptySearch() bool {
+	return c.hideOnEmptySearch
+}
+
 // Reset resets the hints context to its initial state.
 func (c *Context) Reset() error {
 	var err error
@@ -245,6 +267,7 @@ func (c *Context) Reset() error {
 	c.sourceHints = nil
 	c.searchQuery = ""
 	c.searchActive = false
+	c.hideOnEmptySearch = false
 	c.baseContext.Reset()
 
 	return err

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -479,6 +479,17 @@ func (h *IPCControllerModes) extractModeOptions(
 		return opts, &resp
 	}
 
+	if opts.HideOnEmptySearch != nil && *opts.HideOnEmptySearch &&
+		(opts.Search == nil || !*opts.Search) {
+		resp := ipc.Response{
+			Success: false,
+			Message: "--hide-on-empty-search requires --search",
+			Code:    ipc.CodeInvalidInput,
+		}
+
+		return opts, &resp
+	}
+
 	if opts.Modifier != nil {
 		if opts.Action == nil {
 			resp := ipc.Response{

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -157,6 +157,7 @@ type ModeActivationOptions struct {
 	FilterRoles           []string
 	FilterTextContains    []string
 	Search                *bool
+	HideOnEmptySearch     *bool
 	Strategy              *string
 	LabelDirection        *string
 	Toggle                *bool
@@ -226,6 +227,9 @@ func (h *IPCControllerModes) extractModeOptions(
 		case arg == "--search" || arg == "-s":
 			searchTrue := true
 			opts.Search = &searchTrue
+		case arg == "--hide-on-empty-search":
+			hideTrue := true
+			opts.HideOnEmptySearch = &hideTrue
 		case arg == "--debug" || arg == "-d":
 			debugTrue := true
 			opts.Debug = &debugTrue
@@ -560,6 +564,7 @@ func (h *IPCControllerModes) handleHints(ctx context.Context, cmd ipc.Command) i
 		FilterRoles:           opts.FilterRoles,
 		FilterTextContains:    opts.FilterTextContains,
 		Search:                opts.Search,
+		HideOnEmptySearch:     opts.HideOnEmptySearch,
 		Strategy:              opts.Strategy,
 		LabelDirection:        opts.LabelDirection,
 		Toggle:                opts.Toggle,

--- a/internal/app/modes/generic_mode.go
+++ b/internal/app/modes/generic_mode.go
@@ -53,6 +53,7 @@ func (m *GenericMode) Activate(opts ModeActivationOptions) {
 				opts.FilterRoles,
 				opts.FilterTextContains,
 				opts.Search,
+				opts.HideOnEmptySearch,
 				opts.Strategy,
 				opts.LabelDirection,
 				opts.SplitWord,

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -792,6 +792,7 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool, executeAction bo
 				filterRoles,
 				filterTextContains,
 				&startWithSearch,
+				nil,
 				&strategyOverride,
 				&labelDirectionOverride,
 				&splitWord,
@@ -835,11 +836,20 @@ func (h *Handler) startHintSearchLocked() error {
 	h.hints.Context.SetSearchQuery("")
 	h.hints.Context.SetSearchActive(true)
 
-	setHintsErr := h.hints.Context.SetVisibleHints(
-		h.hints.Context.SourceHints(),
-	)
-	if setHintsErr != nil {
-		return setHintsErr
+	if h.hints.Context.HideOnEmptySearch() {
+		// When hide-on-empty-search is active, hide all hints initially.
+		// Hints will appear as the user types a query.
+		setHintsErr := h.hints.Context.ClearVisibleHints()
+		if setHintsErr != nil {
+			return setHintsErr
+		}
+	} else {
+		setHintsErr := h.hints.Context.SetVisibleHints(
+			h.hints.Context.SourceHints(),
+		)
+		if setHintsErr != nil {
+			return setHintsErr
+		}
 	}
 
 	h.cycleHintIndex = -1

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -43,6 +43,7 @@ type ModeActivationOptions struct {
 	FilterRoles           []string
 	FilterTextContains    []string
 	Search                *bool
+	HideOnEmptySearch     *bool
 	Strategy              *string
 	LabelDirection        *string
 	Toggle                *bool
@@ -137,6 +138,7 @@ func (h *Handler) activateHintModeWithAction(
 	filterRoles []string,
 	filterTextContains []string,
 	search *bool,
+	hideOnEmptySearch *bool,
 	strategy *string,
 	labelDirection *string,
 	splitWord *bool,
@@ -148,6 +150,7 @@ func (h *Handler) activateHintModeWithAction(
 		filterRoles,
 		filterTextContains,
 		search,
+		hideOnEmptySearch,
 		strategy,
 		labelDirection,
 		splitWord,
@@ -170,6 +173,7 @@ func (h *Handler) activateHintModeInternal(
 	filterRoles []string,
 	filterTextContains []string,
 	search *bool,
+	hideOnEmptySearch *bool,
 	strategyOverride *string,
 	labelDirectionOverride *string,
 	splitWordOverride *bool,
@@ -284,6 +288,10 @@ func (h *Handler) activateHintModeInternal(
 				h.hints.Context.SetStartWithSearch(*search)
 			}
 
+			if hideOnEmptySearch != nil {
+				h.hints.Context.SetHideOnEmptySearch(*hideOnEmptySearch)
+			}
+
 			if strategyOverride != nil {
 				h.hints.Context.SetStrategyOverride(*strategyOverride)
 			}
@@ -306,6 +314,7 @@ func (h *Handler) activateHintModeInternal(
 			h.hints.Context.SetFilterRoles(filterRoles)
 			h.hints.Context.SetFilterTextContains(filterTextContains)
 			h.hints.Context.SetStartWithSearch(search != nil && *search)
+			h.hints.Context.SetHideOnEmptySearch(hideOnEmptySearch != nil && *hideOnEmptySearch)
 
 			if strategyOverride != nil {
 				h.hints.Context.SetStrategyOverride(*strategyOverride)

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -209,6 +209,7 @@ func (h *Handler) handleHintsModeKey(key string) {
 					filterRoles,
 					filterTextContains,
 					&startWithSearch,
+					nil,
 					&strategyOverride,
 					&labelDirectionOverride,
 					&splitWord,
@@ -281,6 +282,20 @@ func (h *Handler) applyHintSearchFilter() {
 
 	sourceHints := ctx.SourceHints()
 	if sourceHints == nil {
+		return
+	}
+
+	// When HideOnEmptySearch is active and the query is empty, hide all hints.
+	// This lets the user see nothing until they type a search query.
+	if ctx.HideOnEmptySearch() && ctx.SearchQuery() == "" {
+		setHintsErr := ctx.ClearVisibleHints()
+		if setHintsErr != nil {
+			h.logger.Error("Failed to clear hints for empty search", zap.Error(setHintsErr))
+		}
+
+		h.drawHintSearchInput()
+		h.cycleHintIndex = -1
+
 		return
 	}
 

--- a/internal/app/modes/passthrough.go
+++ b/internal/app/modes/passthrough.go
@@ -194,6 +194,7 @@ func (h *Handler) handlePassthroughLocked(mode domain.Mode, session uint64) {
 			filterRoles,
 			filterTextContains,
 			&startWithSearch,
+			nil,
 			&strategyOverride,
 			&labelDirectionOverride,
 			&splitWord,

--- a/internal/cli/hints.go
+++ b/internal/cli/hints.go
@@ -17,6 +17,10 @@ var HintsCmd = BuildModeCommand(ModeConfig{
   When --search is enabled, the mode shows a search/filter input
   instead of navigating by hint keys directly.
 
+  Use --hide-on-empty-search with --search to hide all hints when the
+  search query is empty. Hints appear only as you type a query, making
+  it easier to focus on matching results.
+
   Use --role and --text to filter which elements get hinted:
     --role AXButton,AXLink       Only hint buttons and links
     --text "Submit,Cancel"        Only hint elements containing "Submit" or "Cancel"
@@ -41,19 +45,21 @@ var HintsCmd = BuildModeCommand(ModeConfig{
     neru hints --action left_click           Select a hint to click once
     neru hints --action left_click --repeat  Click multiple elements in sequence
     neru hints --search                      Start with search input shown
+    neru hints --search --hide-on-empty-search Start search with hints hidden until you type
     neru hints --role AXButton               Hint only buttons
     neru hints --strategy vision             Use Vision Framework detection
     neru hints --strategy vision --split-word Use vision strategy with word-level splitting
     neru hints --debug                       Print detected elements, no overlay (used on windows),
     neru hints --label-direction reverse     Use spread labels for this run`,
 
-	ActionDesc:            "hint selection",
-	SupportSearch:         true,
-	SupportFiltering:      true,
-	SupportStrategy:       true,
-	SupportDebug:          true,
-	SupportLabelDirection: true,
-	SupportSplitWord:      true,
+	ActionDesc:               "hint selection",
+	SupportSearch:            true,
+	SupportHideOnEmptySearch: true,
+	SupportFiltering:         true,
+	SupportStrategy:          true,
+	SupportDebug:             true,
+	SupportLabelDirection:    true,
+	SupportSplitWord:         true,
 })
 
 func init() {

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -13,17 +13,18 @@ import (
 
 // ModeConfig holds configuration for creating a mode command.
 type ModeConfig struct {
-	Name                  string
-	Short                 string
-	Long                  string
-	ActionDesc            string   // Description for the action flag (e.g., "hint selection" or "grid selection")
-	Aliases               []string // Optional CLI aliases (e.g., "recursive-grid" for "recursive_grid")
-	SupportSearch         bool     // Whether this mode supports the --search flag
-	SupportFiltering      bool     // Whether this mode supports --role and --text filter flags
-	SupportStrategy       bool     // Whether this mode supports the --strategy flag
-	SupportLabelDirection bool     // Whether this mode supports the --label-direction flag
-	SupportDebug          bool     // Whether this mode supports the --debug probe flag
-	SupportSplitWord      bool     // Whether this mode supports the --split-word flag
+	Name                     string
+	Short                    string
+	Long                     string
+	ActionDesc               string   // Description for the action flag (e.g., "hint selection" or "grid selection")
+	Aliases                  []string // Optional CLI aliases (e.g., "recursive-grid" for "recursive_grid")
+	SupportSearch            bool     // Whether this mode supports the --search flag
+	SupportHideOnEmptySearch bool     // Whether this mode supports the --hide-on-empty-search flag
+	SupportFiltering         bool     // Whether this mode supports --role and --text filter flags
+	SupportStrategy          bool     // Whether this mode supports the --strategy flag
+	SupportLabelDirection    bool     // Whether this mode supports the --label-direction flag
+	SupportDebug             bool     // Whether this mode supports the --debug probe flag
+	SupportSplitWord         bool     // Whether this mode supports the --split-word flag
 }
 
 // BuildModeCommand creates a CLI command for a navigation mode (hints, grid, etc.).
@@ -102,6 +103,14 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				}
 			}
 
+			var hideOnEmptySearchFlag bool
+			if config.SupportHideOnEmptySearch {
+				hideOnEmptySearchFlag, err = cmd.Flags().GetBool("hide-on-empty-search")
+				if err != nil {
+					return err
+				}
+			}
+
 			var labelDirectionFlag string
 			if config.SupportLabelDirection {
 				labelDirectionFlag, err = cmd.Flags().GetString("label-direction")
@@ -119,6 +128,13 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				return derrors.New(
 					derrors.CodeInvalidInput,
 					"--repeat requires --action",
+				)
+			}
+
+			if hideOnEmptySearchFlag && !searchFlag {
+				return derrors.New(
+					derrors.CodeInvalidInput,
+					"--hide-on-empty-search requires --search",
 				)
 			}
 
@@ -216,6 +232,10 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				params = append(params, "--search")
 			}
 
+			if hideOnEmptySearchFlag {
+				params = append(params, "--hide-on-empty-search")
+			}
+
 			if roleFlag != "" {
 				params = append(params, "--role="+roleFlag)
 			}
@@ -298,6 +318,14 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 			"s",
 			false,
 			"Show search input when the mode is activated",
+		)
+	}
+
+	if config.SupportHideOnEmptySearch {
+		cmd.Flags().Bool(
+			"hide-on-empty-search",
+			false,
+			"Hide all hints when search query is empty (requires --search)",
 		)
 	}
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a new `--hide-on-empty-search` flag for hints mode to be used together with `--search`.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
