### PR TITLE
fix(recursive_grid,overlay): evenly distribute cells and round centers to nearest pixel

### DIFF
--- a/internal/app/components/recursivegrid/overlay_darwin.go
+++ b/internal/app/components/recursivegrid/overlay_darwin.go
@@ -42,6 +42,8 @@ const (
 	NSWindowSharingReadOnly = 1
 	// millisecondsPerSecond converts config milliseconds into native seconds.
 	millisecondsPerSecond = 1000.0
+	// cellCenterDivisor is the divisor used when centering a cell grid within its bounds.
+	cellCenterDivisor = 2
 )
 
 // Overlay manages the rendering of recursive_grid overlays using native platform APIs.
@@ -281,9 +283,14 @@ func (o *Overlay) DrawRecursiveGrid(
 		)
 	}
 
-	// Calculate cell dimensions
-	cellWidth := bounds.Dx() / gridCols
-	cellHeight := bounds.Dy() / gridRows
+	// All cells are exactly the same size: floor(W/cols) × floor(H/rows).
+	// Leftover pixels from uneven division become uniform padding around the grid.
+	cellW := bounds.Dx() / gridCols
+	cellH := bounds.Dy() / gridRows
+	gridW := cellW * gridCols
+	gridH := cellH * gridRows
+	offX := (bounds.Dx() - gridW) / cellCenterDivisor
+	offY := (bounds.Dy() - gridH) / cellCenterDivisor
 
 	// Hold drawMu.RLock for the entire span from label lookup through the C
 	// draw call so that freeLabelCache cannot free labels mid-draw.
@@ -296,26 +303,10 @@ func (o *Overlay) DrawRecursiveGrid(
 		for col := range gridCols {
 			idx := row*gridCols + col
 
-			maxX := bounds.Min.X + (col+1)*cellWidth
-			if col == gridCols-1 {
-				maxX = bounds.Max.X
-			}
+			x := bounds.Min.X + offX + col*cellW
+			y := bounds.Min.Y + offY + row*cellH
 
-			maxY := bounds.Min.Y + (row+1)*cellHeight
-			if row == gridRows-1 {
-				maxY = bounds.Max.Y
-			}
-
-			cell := image.Rectangle{
-				Min: image.Point{
-					X: bounds.Min.X + col*cellWidth,
-					Y: bounds.Min.Y + row*cellHeight,
-				},
-				Max: image.Point{
-					X: maxX,
-					Y: maxY,
-				},
-			}
+			cell := image.Rect(x, y, x+cellW, y+cellH)
 
 			labelStr := ""
 			if idx < len(keyRunes) {

--- a/internal/core/domain/grid/grid.go
+++ b/internal/core/domain/grid/grid.go
@@ -556,8 +556,8 @@ func generateCellsWithRegions(
 						xCoordinate+cellWidth, yCoordinate+cellHeight,
 					),
 					center: image.Point{
-						X: xCoordinate + cellWidth/2,
-						Y: yCoordinate + cellHeight/2,
+						X: xCoordinate + gridRound(cellWidth),
+						Y: yCoordinate + gridRound(cellHeight),
 					},
 				}
 				cells[cellIndex] = cell
@@ -834,4 +834,10 @@ func gridMin(a, b int) int {
 	}
 
 	return b
+}
+
+// gridRound performs integer division rounding to the nearest integer (half away from zero).
+// All coordinates in this package are non-negative so only the positive branch is needed.
+func gridRound(numerator int) int {
+	return (numerator + CenterDivisor/2) / CenterDivisor
 }

--- a/internal/core/domain/grid/manager.go
+++ b/internal/core/domain/grid/manager.go
@@ -277,13 +277,15 @@ func (m *Manager) handleSubgridSelection(key string) (image.Point, bool) {
 	xBreaks[m.subCols] = cellBounds.Max.X
 	yBreaks[m.subRows] = cellBounds.Max.Y
 
-	// Calculate center point of the selected subgrid cell
+	// Calculate center point of the selected subgrid cell, rounded to nearest pixel
 	left := xBreaks[colIndex]
 	right := xBreaks[colIndex+1]
 	top := yBreaks[rowIndex]
 	bottom := yBreaks[rowIndex+1]
-	xCoordinate := left + (right-left)/CenterDivisor
-	yCoordinate := top + (bottom-top)/CenterDivisor
+	dx := right - left
+	dy := bottom - top
+	xCoordinate := left + gridRound(dx)
+	yCoordinate := top + gridRound(dy)
 	m.Logger.Debug("Grid manager: Subgrid selection complete",
 		zap.Int("row", rowIndex), zap.Int("col", colIndex),
 		zap.Int("x", xCoordinate), zap.Int("y", yCoordinate))

--- a/internal/core/domain/recursivegrid/manager_test.go
+++ b/internal/core/domain/recursivegrid/manager_test.go
@@ -233,6 +233,8 @@ func TestManagerHandleInputCompletion(t *testing.T) {
 	assert.True(t, completed2, "Should be completed after selection at final depth")
 	assert.True(t, completeCalled, "Complete callback should be called")
 	assert.Equal(t, point2, completePoint, "Complete point should match return point")
+	// BottomRight of (0,0)-(50,50) with 2x2: cell (25,25)-(50,50), center rounded
+	assert.Equal(t, image.Point{X: 38, Y: 38}, point2, "Center should be at (38, 38)")
 }
 
 func TestManagerHandleInputMaxDepth(t *testing.T) {

--- a/internal/core/domain/recursivegrid/recursive_grid.go
+++ b/internal/core/domain/recursivegrid/recursive_grid.go
@@ -11,6 +11,9 @@ const (
 	DefaultGridCols = 3
 	// DefaultGridRows is the default recursive-grid row count.
 	DefaultGridRows = 3
+	// CenterDivisor is the divisor used when computing the center of a rectangle,
+	// i.e. Min.X + Dx()/CenterDivisor.
+	CenterDivisor = 2
 )
 
 // Cell represents the index of a cell in the grid.
@@ -116,41 +119,36 @@ func (qg *RecursiveGrid) GridRows() int {
 
 // Divide splits the current bounds into cells based on grid dimensions for the current depth.
 // Cells are ordered left-to-right, top-to-bottom.
+// Every cell is exactly the same size: floor(W/cols) × floor(H/rows). Any leftover pixels
+// from uneven division are distributed as uniform padding around the grid, so cells within
+// a single level are always identically sized.
 func (qg *RecursiveGrid) Divide() []image.Rectangle {
 	layout := qg.LayoutForDepth(qg.depth)
 	cols := layout.GridCols
 	rows := layout.GridRows
-	cellWidth := qg.currentBounds.Dx() / cols
-	cellHeight := qg.currentBounds.Dy() / rows
-	cells := make([]image.Rectangle, cols*rows)
+	boundsW := qg.currentBounds.Dx()
+	boundsH := qg.currentBounds.Dy()
+	cellW := boundsW / cols
+	cellH := boundsH / rows
+	usedW := cellW * cols
+	usedH := cellH * rows
+	offX := (boundsW - usedW) / CenterDivisor
+	offY := (boundsH - usedH) / CenterDivisor
 
+	cells := make([]image.Rectangle, cols*rows)
 	for row := range rows {
 		for col := range cols {
 			idx := row*cols + col
-
-			maxX := qg.currentBounds.Min.X + (col+1)*cellWidth
-			if col == cols-1 {
-				maxX = qg.currentBounds.Max.X
-			}
-
-			maxY := qg.currentBounds.Min.Y + (row+1)*cellHeight
-			if row == rows-1 {
-				maxY = qg.currentBounds.Max.Y
-			}
-
-			cells[idx] = image.Rect(
-				qg.currentBounds.Min.X+col*cellWidth,
-				qg.currentBounds.Min.Y+row*cellHeight,
-				maxX,
-				maxY,
-			)
+			x := qg.currentBounds.Min.X + offX + col*cellW
+			y := qg.currentBounds.Min.Y + offY + row*cellH
+			cells[idx] = image.Rect(x, y, x+cellW, y+cellH)
 		}
 	}
 
 	return cells
 }
 
-// CellCenter returns the center point of the specified cell.
+// CellCenter returns the center point of the specified cell, rounded to nearest pixel.
 func (qg *RecursiveGrid) CellCenter(cell Cell) image.Point {
 	cells := qg.Divide()
 	idx := int(cell)
@@ -162,15 +160,15 @@ func (qg *RecursiveGrid) CellCenter(cell Cell) image.Point {
 	selected := cells[idx]
 
 	return image.Point{
-		X: selected.Min.X + selected.Dx()/2,
-		Y: selected.Min.Y + selected.Dy()/2,
+		X: selected.Min.X + divRound(selected.Dx(), CenterDivisor),
+		Y: selected.Min.Y + divRound(selected.Dy(), CenterDivisor),
 	}
 }
 
 // SelectCell narrows the active area to the selected cell.
 // Returns the center point of the selected cell and whether the selection is complete.
 // If the grid cannot be divided further (min size or max depth), the selection completes
-// immediately without changing bounds. Otherwise, the bounds narrow to the selected cell.
+// but currentBounds is still narrowed to the selected cell for consistency.
 func (qg *RecursiveGrid) SelectCell(cell Cell) (image.Point, bool) {
 	cells := qg.Divide()
 	idx := int(cell)
@@ -180,24 +178,25 @@ func (qg *RecursiveGrid) SelectCell(cell Cell) (image.Point, bool) {
 		return qg.CurrentCenter(), true
 	}
 
-	// Check if we can divide further
-	if !qg.CanDivide() {
-		// If we can't divide further (max depth or min size),
-		// return the center of the selected cell without changing bounds.
-		return qg.CellCenter(cell), true
+	selected := cells[idx]
+
+	// Compute center from the cell bounds before any state mutation.
+	center := image.Point{
+		X: selected.Min.X + divRound(selected.Dx(), CenterDivisor),
+		Y: selected.Min.Y + divRound(selected.Dy(), CenterDivisor),
 	}
 
-	selected := cells[idx]
+	if !qg.CanDivide() {
+		qg.history = append(qg.history, qg.currentBounds)
+		qg.currentBounds = selected
+
+		return center, true
+	}
 
 	// Save current bounds for backtracking
 	qg.history = append(qg.history, qg.currentBounds)
 	qg.currentBounds = selected
 	qg.depth++
-
-	center := image.Point{
-		X: selected.Min.X + selected.Dx()/2,
-		Y: selected.Min.Y + selected.Dy()/2,
-	}
 
 	return center, false
 }
@@ -218,11 +217,11 @@ func (qg *RecursiveGrid) CanDivide() bool {
 	return cellWidth >= qg.minSizeWidth && cellHeight >= qg.minSizeHeight
 }
 
-// CurrentCenter returns the center point of the current bounds.
+// CurrentCenter returns the center point of the current bounds, rounded to nearest pixel.
 func (qg *RecursiveGrid) CurrentCenter() image.Point {
 	return image.Point{
-		X: qg.currentBounds.Min.X + qg.currentBounds.Dx()/2,
-		Y: qg.currentBounds.Min.Y + qg.currentBounds.Dy()/2,
+		X: qg.currentBounds.Min.X + divRound(qg.currentBounds.Dx(), CenterDivisor),
+		Y: qg.currentBounds.Min.Y + divRound(qg.currentBounds.Dy(), CenterDivisor),
 	}
 }
 

--- a/internal/core/domain/recursivegrid/recursive_grid.go
+++ b/internal/core/domain/recursivegrid/recursive_grid.go
@@ -167,8 +167,8 @@ func (qg *RecursiveGrid) CellCenter(cell Cell) image.Point {
 
 // SelectCell narrows the active area to the selected cell.
 // Returns the center point of the selected cell and whether the selection is complete.
-// If the grid cannot be divided further (min size or max depth), the selection completes
-// but currentBounds is still narrowed to the selected cell for consistency.
+// When the grid cannot be divided further (min size or max depth), the selection completes
+// and currentBounds is left unchanged so that backtrack restores the correct ancestor bounds.
 func (qg *RecursiveGrid) SelectCell(cell Cell) (image.Point, bool) {
 	cells := qg.Divide()
 	idx := int(cell)
@@ -187,8 +187,6 @@ func (qg *RecursiveGrid) SelectCell(cell Cell) (image.Point, bool) {
 	}
 
 	if !qg.CanDivide() {
-		qg.currentBounds = selected
-
 		return center, true
 	}
 

--- a/internal/core/domain/recursivegrid/recursive_grid.go
+++ b/internal/core/domain/recursivegrid/recursive_grid.go
@@ -187,7 +187,6 @@ func (qg *RecursiveGrid) SelectCell(cell Cell) (image.Point, bool) {
 	}
 
 	if !qg.CanDivide() {
-		qg.history = append(qg.history, qg.currentBounds)
 		qg.currentBounds = selected
 
 		return center, true

--- a/internal/core/domain/recursivegrid/recursive_grid_test.go
+++ b/internal/core/domain/recursivegrid/recursive_grid_test.go
@@ -99,9 +99,9 @@ func TestSelectCellCompletion(t *testing.T) {
 	// The user gets one more selection at this final depth.
 	center, completed := grid.SelectCell(recursivegrid.TopLeft)
 
-	// After selecting top-left, bounds are (0,0)-(25,25), center is at (12, 12)
-	expectedCenter := image.Point{X: 12, Y: 12}
-	assert.Equal(t, expectedCenter, center, "Center should be at (12, 12)")
+	// After selecting top-left, bounds are (0,0)-(25,25), center rounded to nearest pixel
+	expectedCenter := image.Point{X: 13, Y: 13}
+	assert.Equal(t, expectedCenter, center, "Center should be at (13, 13)")
 	assert.False(
 		t,
 		completed,
@@ -112,7 +112,8 @@ func TestSelectCellCompletion(t *testing.T) {
 	center2, completed2 := grid.SelectCell(recursivegrid.BottomRight)
 	assert.True(t, completed2, "Should be completed after selection at final depth")
 
-	// CellCenter of BottomRight within (0,0)-(25,25): cell is (12,12)-(25,25), center is (18, 18)
+	// All cells are exactly 12×12, centered in (0,0)-(25,25): offsets are (0,0),
+	// so the grid spans (0,0)-(24,24). BottomRight cell is (12,12)-(24,24), center rounded.
 	expectedCenter2 := image.Point{X: 18, Y: 18}
 	assert.Equal(t, expectedCenter2, center2, "Center should be at (18, 18)")
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR ensures that recursive grid ui are properly evenly distributed to avoid weird UI situation.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/f3b7bfe7-4d19-4894-9901-f3a45af9f6c9

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
