### PR TITLE
fix(recursive_grid,darwin): pass font family to sub-key preview renderer

### DIFF
--- a/internal/app/components/overlayutil/style_cache.go
+++ b/internal/app/components/overlayutil/style_cache.go
@@ -20,6 +20,7 @@ type CachedStyle struct {
 	MatchedBorderColor  unsafe.Pointer
 	HighlightColor      unsafe.Pointer
 	SubKeyTextColor     unsafe.Pointer
+	SubKeyFontFamily    unsafe.Pointer
 	BoundaryBgColor     unsafe.Pointer
 	BoundaryBorderColor unsafe.Pointer
 }
@@ -91,6 +92,8 @@ func (c *StyleCache) freeLocked() {
 	c.style.HighlightColor = nil
 	native.FreeCString(c.style.SubKeyTextColor)
 	c.style.SubKeyTextColor = nil
+	native.FreeCString(c.style.SubKeyFontFamily)
+	c.style.SubKeyFontFamily = nil
 	native.FreeCString(c.style.BoundaryBgColor)
 	c.style.BoundaryBgColor = nil
 	native.FreeCString(c.style.BoundaryBorderColor)

--- a/internal/app/components/recursivegrid/overlay_darwin.go
+++ b/internal/app/components/recursivegrid/overlay_darwin.go
@@ -347,6 +347,7 @@ func (o *Overlay) DrawRecursiveGrid(
 		cached.MatchedBorderColor = unsafe.Pointer(C.CString(style.LineColor()))
 		cached.BorderColor = unsafe.Pointer(C.CString(style.LineColor()))
 		cached.SubKeyTextColor = unsafe.Pointer(C.CString(style.SubKeyPreviewTextColor()))
+		cached.SubKeyFontFamily = unsafe.Pointer(C.CString(style.FontFamily()))
 	})
 
 	finalStyle := C.GridCellStyle{
@@ -369,6 +370,7 @@ func (o *Overlay) DrawRecursiveGrid(
 		subKeyGridRows:              C.int(nextGridRows),
 		drawSubKeyPreview:           C.int(boolToInt(style.SubKeyPreview() && nextKeys != "")),
 		subKeyFontSize:              C.int(style.SubKeyPreviewFontSize()),
+		subKeyFontFamily:            (*C.char)(cachedStyle.SubKeyFontFamily),
 		subKeyAutohideMultiplier:    C.float(style.SubKeyPreviewAutohideMultiplier()),
 		subKeyTextColor:             (*C.char)(cachedStyle.SubKeyTextColor),
 		subKeyKeys:                  o.getOrCacheLabel(subKeyLabel),

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -93,6 +93,7 @@ typedef struct {
 	int subKeyGridRows;               ///< Sub-key preview grid rows (next depth's rows)
 	int drawSubKeyPreview;            ///< Draw miniature key grid inside each cell (1 = yes, 0 = no)
 	int subKeyFontSize;               ///< Font size for sub-key preview labels
+	char *subKeyFontFamily;           ///< Font family for sub-key preview labels
 	float subKeyAutohideMultiplier;   ///< Minimum cell size multiplier for sub-key preview autohide (0 = disable)
 	char *subKeyTextColor;            ///< Text color for sub-key preview labels
 	char *subKeyKeys;                 ///< Key string for sub-key preview (next depth's keys, uppercased)

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -177,12 +177,13 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 @property(nonatomic, assign) BOOL hideUnmatched;                       ///< Hide unmatched cells
 
 // Sub-key preview: draws a miniature key grid inside each cell
-@property(nonatomic, assign) BOOL gridDrawSubKeyPreview;        ///< Draw sub-key preview mini-grid
-@property(nonatomic, assign) int gridSubKeyCols;                ///< Sub-key preview grid columns
-@property(nonatomic, assign) int gridSubKeyRows;                ///< Sub-key preview grid rows
-@property(nonatomic, strong) NSFont *gridSubKeyFont;            ///< Sub-key preview font
-@property(nonatomic, strong) NSColor *gridSubKeyTextColor;      ///< Sub-key preview text color
-@property(nonatomic, assign) CGFloat cachedGridSubKeyFontSize;  ///< Cached sub-key font size
+@property(nonatomic, assign) BOOL gridDrawSubKeyPreview;          ///< Draw sub-key preview mini-grid
+@property(nonatomic, assign) int gridSubKeyCols;                  ///< Sub-key preview grid columns
+@property(nonatomic, assign) int gridSubKeyRows;                  ///< Sub-key preview grid rows
+@property(nonatomic, strong) NSFont *gridSubKeyFont;              ///< Sub-key preview font
+@property(nonatomic, strong) NSColor *gridSubKeyTextColor;        ///< Sub-key preview text color
+@property(nonatomic, assign) CGFloat cachedGridSubKeyFontSize;    ///< Cached sub-key font size
+@property(nonatomic, copy) NSString *cachedGridSubKeyFontFamily;  ///< Cached sub-key font family
 @property(nonatomic, assign)
     CGFloat gridSubKeyAutohideMultiplier;  ///< Sub-key preview autohide multiplier (0 = disable)
 @property(nonatomic, strong)
@@ -2702,6 +2703,12 @@ void NeruDrawGridCells(OverlayWindow window, GridCell *cells, int count, GridCel
 	int subKeyGridCols = style.subKeyGridCols;
 	int subKeyGridRows = style.subKeyGridRows;
 	CGFloat subKeyFontSize = style.subKeyFontSize > 0 ? style.subKeyFontSize : 6.0;
+	NSString *subKeyFontFamily = nil;
+	if (style.subKeyFontFamily) {
+		subKeyFontFamily = @(style.subKeyFontFamily);
+		if (subKeyFontFamily.length == 0)
+			subKeyFontFamily = nil;
+	}
 	CGFloat subKeyAutohideMultiplier = style.subKeyAutohideMultiplier;
 	NSString *subKeyTextHex = style.subKeyTextColor ? @(style.subKeyTextColor) : nil;
 
@@ -2770,9 +2777,19 @@ void NeruDrawGridCells(OverlayWindow window, GridCell *cells, int count, GridCel
 			controller.overlayView.gridSubKeyRows = subKeyGridRows;
 			controller.overlayView.gridSubKeyLabels = subKeyLabels;
 			if (drawSubKeyPreview) {
-				if (subKeyFontSize != controller.overlayView.cachedGridSubKeyFontSize) {
-					controller.overlayView.gridSubKeyFont = [NSFont systemFontOfSize:subKeyFontSize];
+				if (subKeyFontSize != controller.overlayView.cachedGridSubKeyFontSize ||
+				    (subKeyFontFamily != controller.overlayView.cachedGridSubKeyFontFamily &&
+				     ![subKeyFontFamily isEqualToString:controller.overlayView.cachedGridSubKeyFontFamily])) {
+					NSFont *subFont = nil;
+					if (subKeyFontFamily && [subKeyFontFamily length] > 0) {
+						subFont = [controller.overlayView resolveFont:subKeyFontFamily size:subKeyFontSize bold:NO];
+					}
+					if (!subFont) {
+						subFont = [NSFont systemFontOfSize:subKeyFontSize];
+					}
+					controller.overlayView.gridSubKeyFont = subFont;
 					controller.overlayView.cachedGridSubKeyFontSize = subKeyFontSize;
+					controller.overlayView.cachedGridSubKeyFontFamily = subKeyFontFamily;
 				}
 				controller.overlayView.gridSubKeyAutohideMultiplier = subKeyAutohideMultiplier;
 				controller.overlayView.gridSubKeyTextColor = [controller.overlayView colorFromHex:subKeyTextHex

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -2850,6 +2850,12 @@ void NeruAnimateRecursiveGridTransition(
 	int subKeyGridCols = style.subKeyGridCols;
 	int subKeyGridRows = style.subKeyGridRows;
 	CGFloat subKeyFontSize = style.subKeyFontSize > 0 ? style.subKeyFontSize : 6.0;
+	NSString *subKeyFontFamily = nil;
+	if (style.subKeyFontFamily) {
+		subKeyFontFamily = @(style.subKeyFontFamily);
+		if (subKeyFontFamily.length == 0)
+			subKeyFontFamily = nil;
+	}
 	CGFloat subKeyAutohideMultiplier = style.subKeyAutohideMultiplier;
 	NSString *subKeyTextHex = style.subKeyTextColor ? @(style.subKeyTextColor) : nil;
 
@@ -2911,9 +2917,19 @@ void NeruAnimateRecursiveGridTransition(
 			controller.overlayView.gridSubKeyRows = subKeyGridRows;
 			controller.overlayView.gridSubKeyLabels = subKeyLabels;
 			if (drawSubKeyPreview) {
-				if (subKeyFontSize != controller.overlayView.cachedGridSubKeyFontSize) {
-					controller.overlayView.gridSubKeyFont = [NSFont systemFontOfSize:subKeyFontSize];
+				if (subKeyFontSize != controller.overlayView.cachedGridSubKeyFontSize ||
+				    (subKeyFontFamily != controller.overlayView.cachedGridSubKeyFontFamily &&
+				     ![subKeyFontFamily isEqualToString:controller.overlayView.cachedGridSubKeyFontFamily])) {
+					NSFont *subFont = nil;
+					if (subKeyFontFamily && [subKeyFontFamily length] > 0) {
+						subFont = [controller.overlayView resolveFont:subKeyFontFamily size:subKeyFontSize bold:NO];
+					}
+					if (!subFont) {
+						subFont = [NSFont systemFontOfSize:subKeyFontSize];
+					}
+					controller.overlayView.gridSubKeyFont = subFont;
 					controller.overlayView.cachedGridSubKeyFontSize = subKeyFontSize;
+					controller.overlayView.cachedGridSubKeyFontFamily = subKeyFontFamily;
 				}
 				controller.overlayView.gridSubKeyAutohideMultiplier = subKeyAutohideMultiplier;
 				controller.overlayView.gridSubKeyTextColor = [controller.overlayView colorFromHex:subKeyTextHex


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR passes the configured font family to subkey renderer as well, so that it renders consistently.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
