### PR TITLE
feat(recursive_grid,config): add `label_autohide_multiplier` to hide cramped labels

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -218,6 +218,7 @@ label_background_padding_y = -1
 label_background_border_radius = -1
 label_background_border_width = 1
 label_char = ""                             # Override cell labels with a single character (e.g. "·"); empty = use key
+label_autohide_multiplier = 1.5             # Hide labels when cell < fontSize × multiplier (0 = disable)
 sub_key_preview = false                     # Draw miniature key grid inside each cell
 sub_key_preview_font_size = 8
 sub_key_preview_autohide_multiplier = 1.5

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -682,6 +682,7 @@ layers = [
 | `label_background_border_radius`      | int    | `-1`    | Label corner radius (-1 = auto)      |
 | `label_background_border_width`       | int    | `1`     | Label border width                   |
 | `label_char`                          | string | `""`    | Override all cell labels with a single character (e.g. `·`); empty = use key |
+| `label_autohide_multiplier`           | float  | `1.5`   | Hide labels when cell < fontSize × multiplier (0 = disable) |
 | `sub_key_preview`                     | bool   | `false` | Show sub-key previews in cells       |
 | `sub_key_preview_font_size`           | int    | `8`     | Sub-key preview font size            |
 | `sub_key_preview_autohide_multiplier` | float  | `1.5`   | Autohide threshold multiplier        |

--- a/internal/app/components/recursivegrid/overlay_darwin.go
+++ b/internal/app/components/recursivegrid/overlay_darwin.go
@@ -369,6 +369,7 @@ func (o *Overlay) DrawRecursiveGrid(
 		subKeyGridCols:              C.int(nextGridCols),
 		subKeyGridRows:              C.int(nextGridRows),
 		drawSubKeyPreview:           C.int(boolToInt(style.SubKeyPreview() && nextKeys != "")),
+		labelAutohideMultiplier:     C.float(style.LabelAutohideMultiplier()),
 		subKeyFontSize:              C.int(style.SubKeyPreviewFontSize()),
 		subKeyFontFamily:            (*C.char)(cachedStyle.SubKeyFontFamily),
 		subKeyAutohideMultiplier:    C.float(style.SubKeyPreviewAutohideMultiplier()),
@@ -504,6 +505,7 @@ type Style struct {
 	labelBackgroundBorderRadius     int
 	labelBackgroundBorderWidth      int
 	labelChar                       string
+	labelAutohideMultiplier         float64
 	subKeyPreview                   bool
 	subKeyPreviewFontSize           int
 	subKeyPreviewAutohideMultiplier float64
@@ -596,6 +598,11 @@ func (s Style) SubKeyPreviewAutohideMultiplier() float64 {
 	return s.subKeyPreviewAutohideMultiplier
 }
 
+// LabelAutohideMultiplier returns the minimum cell size multiplier for main label autohide.
+func (s Style) LabelAutohideMultiplier() float64 {
+	return s.labelAutohideMultiplier
+}
+
 // SubKeyPreviewTextColor returns the text color for sub-key preview labels.
 func (s Style) SubKeyPreviewTextColor() string {
 	return s.subKeyPreviewTextColor
@@ -635,6 +642,7 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 		labelBackgroundBorderRadius:     cfg.UI.LabelBackgroundBorderRadius,
 		labelBackgroundBorderWidth:      cfg.UI.LabelBackgroundBorderWidth,
 		labelChar:                       cfg.UI.LabelChar,
+		labelAutohideMultiplier:         cfg.UI.LabelAutohideMultiplier,
 		subKeyPreview:                   cfg.UI.SubKeyPreview,
 		subKeyPreviewFontSize:           cfg.UI.SubKeyPreviewFontSize,
 		subKeyPreviewAutohideMultiplier: cfg.UI.SubKeyPreviewAutohideMultiplier,

--- a/internal/app/components/recursivegrid/overlay_linux_common.go
+++ b/internal/app/components/recursivegrid/overlay_linux_common.go
@@ -37,6 +37,7 @@ type Style struct {
 	LabelBackgroundBorderRadius     int
 	LabelBackgroundBorderWidth      float64
 	LabelChar                       string
+	LabelAutohideMultiplier         float64
 	SubKeyPreview                   bool
 	SubKeyPreviewFontSize           float64
 	SubKeyPreviewAutohideMultiplier float64

--- a/internal/app/components/recursivegrid/overlay_linux_common.go
+++ b/internal/app/components/recursivegrid/overlay_linux_common.go
@@ -152,6 +152,7 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 		LabelBackgroundBorderRadius:     cfg.UI.LabelBackgroundBorderRadius,
 		LabelBackgroundBorderWidth:      float64(max(cfg.UI.LabelBackgroundBorderWidth, 0)),
 		LabelChar:                       cfg.UI.LabelChar,
+		LabelAutohideMultiplier:         cfg.UI.LabelAutohideMultiplier,
 		SubKeyPreview:                   cfg.UI.SubKeyPreview,
 		SubKeyPreviewFontSize:           float64(max(cfg.UI.SubKeyPreviewFontSize, 1)),
 		SubKeyPreviewAutohideMultiplier: cfg.UI.SubKeyPreviewAutohideMultiplier,

--- a/internal/app/components/recursivegrid/overlay_windows.go
+++ b/internal/app/components/recursivegrid/overlay_windows.go
@@ -37,6 +37,7 @@ type Style struct {
 	LabelBackgroundBorderRadius     int
 	LabelBackgroundBorderWidth      float64
 	LabelChar                       string
+	LabelAutohideMultiplier         float64
 	SubKeyPreview                   bool
 	SubKeyPreviewFontSize           float64
 	SubKeyPreviewAutohideMultiplier float64

--- a/internal/app/components/recursivegrid/overlay_windows.go
+++ b/internal/app/components/recursivegrid/overlay_windows.go
@@ -152,6 +152,7 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 		LabelBackgroundBorderRadius:     cfg.UI.LabelBackgroundBorderRadius,
 		LabelBackgroundBorderWidth:      float64(max(cfg.UI.LabelBackgroundBorderWidth, 0)),
 		LabelChar:                       cfg.UI.LabelChar,
+		LabelAutohideMultiplier:         cfg.UI.LabelAutohideMultiplier,
 		SubKeyPreview:                   cfg.UI.SubKeyPreview,
 		SubKeyPreviewFontSize:           float64(max(cfg.UI.SubKeyPreviewFontSize, 1)),
 		SubKeyPreviewAutohideMultiplier: cfg.UI.SubKeyPreviewAutohideMultiplier,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -774,6 +774,7 @@ type RecursiveGridUI struct {
 	LabelBackgroundBorderRadius     int     `json:"labelBackgroundBorderRadius"     toml:"label_background_border_radius"`
 	LabelBackgroundBorderWidth      int     `json:"labelBackgroundBorderWidth"      toml:"label_background_border_width"`
 	LabelChar                       string  `json:"labelChar"                       toml:"label_char"`
+	LabelAutohideMultiplier         float64 `json:"labelAutohideMultiplier"         toml:"label_autohide_multiplier"`
 	SubKeyPreview                   bool    `json:"subKeyPreview"                   toml:"sub_key_preview"`
 	SubKeyPreviewFontSize           int     `json:"subKeyPreviewFontSize"           toml:"sub_key_preview_font_size"`
 	SubKeyPreviewAutohideMultiplier float64 `json:"subKeyPreviewAutohideMultiplier" toml:"sub_key_preview_autohide_multiplier"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -280,6 +280,9 @@ const (
 	DefaultRecursiveGridLabelChar = ""
 	// DefaultRecursiveGridSubKeyPreviewLabelChar is the default sub-key preview label character override (empty = use key character).
 	DefaultRecursiveGridSubKeyPreviewLabelChar = ""
+	// DefaultRecursiveGridLabelAutohideMultiplier is the default minimum cell size multiplier
+	// for main label autohide. Set to 0 to disable autohide.
+	DefaultRecursiveGridLabelAutohideMultiplier = 1.5
 	// DefaultRecursiveGridSubKeyPreview controls whether the sub-key mini-grid is shown inside each cell.
 	DefaultRecursiveGridSubKeyPreview = false
 	// DefaultRecursiveGridSubKeyPreviewFontSize is the default font size for sub-key preview labels.
@@ -519,6 +522,7 @@ func newDefaultConfig() *Config {
 				LabelBackgroundBorderWidth:      DefaultRecursiveGridLabelBackgroundBorderWidth,
 				LabelBackground:                 false,
 				LabelChar:                       DefaultRecursiveGridLabelChar,
+				LabelAutohideMultiplier:         DefaultRecursiveGridLabelAutohideMultiplier,
 				SubKeyPreview:                   DefaultRecursiveGridSubKeyPreview,
 				SubKeyPreviewFontSize:           DefaultRecursiveGridSubKeyPreviewFontSize,
 				SubKeyPreviewAutohideMultiplier: DefaultRecursiveGridSubKeyPreviewAutohideMultiplier,

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -89,6 +89,7 @@ typedef struct {
 	int labelBackgroundPaddingY;      ///< Label badge vertical padding (-1 = auto)
 	int labelBackgroundBorderRadius;  ///< Label badge border radius (-1 = auto)
 	int labelBackgroundBorderWidth;   ///< Label badge border width
+	float labelAutohideMultiplier;    ///< Minimum cell size multiplier for main label autohide (0 = disable)
 	int subKeyGridCols;               ///< Sub-key preview grid columns (next depth's cols)
 	int subKeyGridRows;               ///< Sub-key preview grid rows (next depth's rows)
 	int drawSubKeyPreview;            ///< Draw miniature key grid inside each cell (1 = yes, 0 = no)

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -175,6 +175,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 @property(nonatomic, assign) CGFloat gridLabelBackgroundBorderRadius;  ///< Grid label badge border radius
 @property(nonatomic, assign) CGFloat gridLabelBackgroundBorderWidth;   ///< Grid label badge border width
 @property(nonatomic, assign) BOOL hideUnmatched;                       ///< Hide unmatched cells
+@property(nonatomic, assign) CGFloat gridLabelAutohideMultiplier;      ///< Main label autohide multiplier (0 = disable)
 
 // Sub-key preview: draws a miniature key grid inside each cell
 @property(nonatomic, assign) BOOL gridDrawSubKeyPreview;          ///< Draw sub-key preview mini-grid
@@ -334,6 +335,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 		_gridLabelBackgroundBorderRadius = -1.0;
 		_gridLabelBackgroundBorderWidth = 1.0;
 		_gridSubKeyAutohideMultiplier = 1.5;
+		_gridLabelAutohideMultiplier = 0.0;
 		_hideUnmatched = NO;
 		_cursorIndicatorVisible = NO;
 		_cursorIndicatorRadius = 3.0;
@@ -1547,6 +1549,15 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 		return;
 	}
 
+	// Skip main label when cells are too small to render legibly.
+	// Each cell must be at least (multiplier × font size) in both dimensions.
+	// A multiplier of 0 disables autohide.
+	if (self.gridLabelAutohideMultiplier > 0) {
+		CGFloat minCell = self.gridFont.pointSize * self.gridLabelAutohideMultiplier;
+		if (cellRect.size.width < minCell || cellRect.size.height < minCell)
+			return;
+	}
+
 	// Set up attributed string
 	NSMutableAttributedString *attrString = self.cachedGridCellAttributedString;
 	[[attrString mutableString] setString:label];
@@ -2699,6 +2710,7 @@ void NeruDrawGridCells(OverlayWindow window, GridCell *cells, int count, GridCel
 	CGFloat labelBackgroundPaddingY = style.labelBackgroundPaddingY;
 	CGFloat labelBackgroundBorderRadius = style.labelBackgroundBorderRadius;
 	CGFloat labelBackgroundBorderWidth = style.labelBackgroundBorderWidth;
+	CGFloat labelAutohideMultiplier = style.labelAutohideMultiplier;
 	BOOL drawSubKeyPreview = style.drawSubKeyPreview ? YES : NO;
 	int subKeyGridCols = style.subKeyGridCols;
 	int subKeyGridRows = style.subKeyGridRows;
@@ -2770,6 +2782,7 @@ void NeruDrawGridCells(OverlayWindow window, GridCell *cells, int count, GridCel
 			controller.overlayView.gridLabelBackgroundPaddingY = labelBackgroundPaddingY;
 			controller.overlayView.gridLabelBackgroundBorderRadius = labelBackgroundBorderRadius;
 			controller.overlayView.gridLabelBackgroundBorderWidth = labelBackgroundBorderWidth;
+			controller.overlayView.gridLabelAutohideMultiplier = labelAutohideMultiplier;
 
 			// Apply sub-key preview settings
 			controller.overlayView.gridDrawSubKeyPreview = drawSubKeyPreview;
@@ -2846,6 +2859,7 @@ void NeruAnimateRecursiveGridTransition(
 	CGFloat labelBackgroundPaddingY = style.labelBackgroundPaddingY;
 	CGFloat labelBackgroundBorderRadius = style.labelBackgroundBorderRadius;
 	CGFloat labelBackgroundBorderWidth = style.labelBackgroundBorderWidth;
+	CGFloat labelAutohideMultiplier = style.labelAutohideMultiplier;
 	BOOL drawSubKeyPreview = style.drawSubKeyPreview ? YES : NO;
 	int subKeyGridCols = style.subKeyGridCols;
 	int subKeyGridRows = style.subKeyGridRows;
@@ -2912,6 +2926,7 @@ void NeruAnimateRecursiveGridTransition(
 			controller.overlayView.gridLabelBackgroundPaddingY = labelBackgroundPaddingY;
 			controller.overlayView.gridLabelBackgroundBorderRadius = labelBackgroundBorderRadius;
 			controller.overlayView.gridLabelBackgroundBorderWidth = labelBackgroundBorderWidth;
+			controller.overlayView.gridLabelAutohideMultiplier = labelAutohideMultiplier;
 			controller.overlayView.gridDrawSubKeyPreview = drawSubKeyPreview;
 			controller.overlayView.gridSubKeyCols = subKeyGridCols;
 			controller.overlayView.gridSubKeyRows = subKeyGridRows;

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -973,6 +973,19 @@ func centeredRect(cell image.Rectangle, width, height int) image.Rectangle {
 	)
 }
 
+func shouldShowLabel(
+	cell image.Rectangle,
+	style recursivegrid.Style,
+) bool {
+	if style.LabelAutohideMultiplier <= 0 {
+		return true
+	}
+
+	threshold := style.LabelFontSize * style.LabelAutohideMultiplier
+
+	return float64(cell.Dx()) >= threshold && float64(cell.Dy()) >= threshold
+}
+
 func shouldShowSubKeyPreview(
 	cell image.Rectangle,
 	style recursivegrid.Style,

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -249,17 +249,19 @@ func (o *wlrootsOverlay) DrawRecursiveGridWithSubKeyPreview(
 					label = string(keyRunes[index])
 				}
 
-				if style.LabelBackground {
-					o.drawLabelBackground(label, cell, style)
-				}
+				if shouldShowLabel(cell, style) {
+					if style.LabelBackground {
+						o.drawLabelBackground(label, cell, style)
+					}
 
-				o.drawTextCentered(
-					label,
-					cell,
-					style.LabelFontName,
-					style.LabelFontSize,
-					style.LabelFontColor,
-				)
+					o.drawTextCentered(
+						label,
+						cell,
+						style.LabelFontName,
+						style.LabelFontSize,
+						style.LabelFontColor,
+					)
+				}
 
 				if drawSubPreview && shouldShowSubKeyPreview(cell, style) {
 					o.drawSubKeyMiniGrid(

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -203,17 +203,19 @@ func (o *x11Overlay) DrawRecursiveGridWithSubKeyPreview(
 					label = string(keyRunes[index])
 				}
 
-				if style.LabelBackground {
-					o.drawLabelBackground(label, cell, style)
-				}
+				if shouldShowLabel(cell, style) {
+					if style.LabelBackground {
+						o.drawLabelBackground(label, cell, style)
+					}
 
-				o.drawTextCentered(
-					label,
-					cell,
-					style.LabelFontName,
-					style.LabelFontSize,
-					style.LabelFontColor,
-				)
+					o.drawTextCentered(
+						label,
+						cell,
+						style.LabelFontName,
+						style.LabelFontSize,
+						style.LabelFontColor,
+					)
+				}
 
 				if drawSubPreview && shouldShowSubKeyPreview(cell, style) {
 					o.drawSubKeyMiniGrid(

--- a/internal/ui/overlay/manager_windows_features.go
+++ b/internal/ui/overlay/manager_windows_features.go
@@ -220,17 +220,19 @@ func (o *winOverlay) DrawRecursiveGrid(
 					label = string(keyRunes[index])
 				}
 
-				if style.LabelBackground {
-					o.drawRecursiveLabelBackground(label, cell, style)
-				}
+				if shouldShowWinLabel(cell, style) {
+					if style.LabelBackground {
+						o.drawRecursiveLabelBackground(label, cell, style)
+					}
 
-				o.drawTextCentered(
-					label,
-					cell,
-					ports.ResolveFont(style.LabelFontName, false),
-					style.LabelFontSize,
-					style.LabelFontColor,
-				)
+					o.drawTextCentered(
+						label,
+						cell,
+						ports.ResolveFont(style.LabelFontName, false),
+						style.LabelFontSize,
+						style.LabelFontColor,
+					)
+				}
 
 				if shouldShowWinSubKeyPreview(cell, style) {
 					o.drawRecursiveSubKeyPreview(label, cell, style)
@@ -326,6 +328,16 @@ func (o *winOverlay) drawRecursiveSubKeyPreview(
 		style.SubKeyPreviewFontSize,
 		style.SubKeyPreviewTextColor,
 	)
+}
+
+func shouldShowWinLabel(cell image.Rectangle, style recursivegridcomponent.Style) bool {
+	if style.LabelAutohideMultiplier <= 0 {
+		return true
+	}
+
+	threshold := style.LabelFontSize * style.LabelAutohideMultiplier
+
+	return float64(cell.Dx()) >= threshold && float64(cell.Dy()) >= threshold
 }
 
 func shouldShowWinSubKeyPreview(cell image.Rectangle, style recursivegridcomponent.Style) bool {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a `label_autohide_multiplier` similar to how subkey preview autohide works, with the same default `1.5`. This is to prevent deeply zoomed grid views show unreadably cramped labels.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/e3263d0c-d5c9-47fd-817f-d613d5623f5e

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
