### PR TITLE
fix(linux): use native relative pointer motion

### DIFF
--- a/internal/app/services/action_service.go
+++ b/internal/app/services/action_service.go
@@ -25,6 +25,10 @@ type ActionService struct {
 	logger   *zap.Logger
 }
 
+type relativeCursorMover interface {
+	MoveCursorBy(ctx context.Context, delta image.Point) (bool, error)
+}
+
 // NewActionService creates a new action service.
 func NewActionService(
 	accessibility ports.AccessibilityPort,
@@ -217,14 +221,25 @@ func (s *ActionService) MoveMouseRelative(
 	deltaX, deltaY int,
 	bypassSmooth ...bool,
 ) error {
+	shouldBypass := len(bypassSmooth) > 0 && bypassSmooth[0]
+
+	if mover, ok := s.system.(relativeCursorMover); ok {
+		handled, err := mover.MoveCursorBy(ctx, image.Point{X: deltaX, Y: deltaY})
+		if handled {
+			if err != nil {
+				s.logger.Error("Failed to move cursor relatively", zap.Error(err))
+			}
+
+			return err
+		}
+	}
+
 	cursorPos, err := s.system.CursorPosition(ctx)
 	if err != nil {
 		s.logger.Error("Failed to get cursor position", zap.Error(err))
 
 		return derrors.WrapAccessibilityFailed(err, "get cursor position")
 	}
-
-	shouldBypass := len(bypassSmooth) > 0 && bypassSmooth[0]
 
 	return s.MoveMouseTo(ctx, cursorPos.X+deltaX, cursorPos.Y+deltaY, shouldBypass)
 }

--- a/internal/app/services/action_service_test.go
+++ b/internal/app/services/action_service_test.go
@@ -18,7 +18,7 @@ const leftClickAction = "left_click"
 
 func newTestActionService(
 	acc *portmocks.MockAccessibilityPort,
-	sys *portmocks.MockSystemPort,
+	sys ports.SystemPort,
 ) *services.ActionService {
 	return services.NewActionService(acc, &portmocks.MockOverlayPort{}, sys, zap.NewNop())
 }
@@ -275,6 +275,46 @@ func TestMoveMouseRelative_UsesCurrentCursorPosition(t *testing.T) {
 
 	if moved != (image.Point{X: 50, Y: 35}) {
 		t.Fatalf("MoveMouseRelative() moved to %v, want (50,35)", moved)
+	}
+}
+
+type relativeCursorSystem struct {
+	*portmocks.MockSystemPort
+
+	handled bool
+	moved   image.Point
+}
+
+func (s *relativeCursorSystem) MoveCursorBy(
+	_ context.Context,
+	delta image.Point,
+) (bool, error) {
+	s.moved = delta
+
+	return s.handled, nil
+}
+
+func TestMoveMouseRelative_UsesNativeRelativeMovement(t *testing.T) {
+	ctx := context.Background()
+	sys := &relativeCursorSystem{
+		MockSystemPort: &portmocks.MockSystemPort{
+			CursorPositionFunc: func(context.Context) (image.Point, error) {
+				t.Fatal("CursorPosition() should not be called for native relative movement")
+
+				return image.Point{}, nil
+			},
+		},
+		handled: true,
+	}
+	service := newTestActionService(&portmocks.MockAccessibilityPort{}, sys)
+
+	err := service.MoveMouseRelative(ctx, 10, -5)
+	if err != nil {
+		t.Fatalf("MoveMouseRelative() error = %v", err)
+	}
+
+	if sys.moved != (image.Point{X: 10, Y: -5}) {
+		t.Fatalf("MoveMouseRelative() delta = %v, want (10,-5)", sys.moved)
 	}
 }
 

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -216,6 +216,20 @@ func (s *SystemAdapter) MoveCursorToPoint(
 	return derrors.New(derrors.CodeNotSupported, "MoveCursorToPoint not yet implemented on linux")
 }
 
+// MoveCursorBy uses native relative motion when the Wayland backend supports it.
+// The bool result reports whether the request was handled, allowing callers to
+// retain their absolute-position fallback on X11 and unsupported backends.
+func (s *SystemAdapter) MoveCursorBy(
+	ctx context.Context,
+	delta image.Point,
+) (bool, error) {
+	if s.backend == backendWaylandWlroots {
+		return true, wlrootsMoveCursorBy(delta)
+	}
+
+	return false, nil
+}
+
 // WaitForCursorIdle returns immediately on Linux until smooth cursor support exists.
 func (s *SystemAdapter) WaitForCursorIdle(ctx context.Context) error {
 	return nil

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -299,6 +299,29 @@ func wlrootsMoveCursorToPoint(point image.Point) error {
 	return nil
 }
 
+func wlrootsMoveCursorBy(delta image.Point) error {
+	err := ensureWlrootsState()
+	if err != nil {
+		return err
+	}
+
+	globalWlrootsState.mu.Lock()
+	defer globalWlrootsState.mu.Unlock()
+
+	client := globalWlrootsState.client
+
+	if C.neru_wlr_move_relative(client, C.int(delta.X), C.int(delta.Y)) == 0 { //nolint:nlreturn
+		return derrors.Newf(
+			derrors.CodeActionFailed,
+			"failed to move wlroots virtual pointer by (%d, %d)",
+			delta.X,
+			delta.Y,
+		)
+	}
+
+	return nil
+}
+
 // wlrootsClick performs a mouse click at the given position using the virtual pointer.
 func wlrootsClick(point image.Point, button int) error {
 	err := ensureWlrootsState()

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
@@ -47,6 +47,15 @@ func wlrootsMoveCursorToPoint(point image.Point) error {
 	)
 }
 
+func wlrootsMoveCursorBy(delta image.Point) error {
+	_ = delta
+
+	return derrors.New(
+		derrors.CodeNotSupported,
+		"wlroots backend requires CGO-enabled Linux builds",
+	)
+}
+
 func wlrootsClick(point image.Point, button int) error {
 	_, _ = point, button
 

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -559,6 +559,19 @@ int neru_wlr_move_absolute(NeruWlrootsClient *c, int x, int y) {
 	return 1;
 }
 
+int neru_wlr_move_relative(NeruWlrootsClient *c, int dx, int dy) {
+	if (!c || !c->vptr)
+		return 0;
+
+	pthread_mutex_lock(&c->display_mutex);
+	zwlr_virtual_pointer_v1_motion(c->vptr, 0, wl_fixed_from_int(dx), wl_fixed_from_int(dy));
+	zwlr_virtual_pointer_v1_frame(c->vptr);
+	wl_display_flush(c->display);
+	pthread_mutex_unlock(&c->display_mutex);
+
+	return 1;
+}
+
 // Button codes for linux/input-event-codes.h
 #define NERU_BTN_LEFT 0x110
 #define NERU_BTN_RIGHT 0x111

--- a/internal/core/infra/platform/linux/wlroots_client.h
+++ b/internal/core/infra/platform/linux/wlroots_client.h
@@ -70,6 +70,7 @@ void neru_wlr_disconnect(NeruWlrootsClient *c);
 int neru_wlr_start_dispatch(NeruWlrootsClient *c);
 void neru_wlr_init_cursor(NeruWlrootsClient *c);
 int neru_wlr_move_absolute(NeruWlrootsClient *c, int x, int y);
+int neru_wlr_move_relative(NeruWlrootsClient *c, int dx, int dy);
 int neru_wlr_button(NeruWlrootsClient *c, int button, int pressed);
 int neru_wlr_click(NeruWlrootsClient *c, int button);
 int neru_wlr_scroll(NeruWlrootsClient *c, int axis, int delta, int discrete);


### PR DESCRIPTION
## Description

- route `move_mouse_relative` through an optional native relative-movement path
- emit `zwlr_virtual_pointer_v1.motion` directly on wlroots compositors
- preserve the existing absolute-position fallback for X11 and other platforms
- add a regression test proving native relative movement bypasses the stale cursor-position lookup

Wayland does not expose a reliable global pointer position. When Neru falls back to its screen-center cursor cache, converting a relative action into an absolute move makes the real pointer jump relative to the center. Sending a compositor-native relative event keeps movement anchored to the actual pointer position.

## Related Issues

Fixes #921

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` - New feature
- [x] `fix` - Bug fix
- [ ] `refactor` - Code restructuring (no behavior change)
- [ ] `perf` - Performance improvement
- [ ] `docs` - Documentation only
- [x] `test` - Adding or updating tests
- [ ] `chore` - Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags
- [x] No darwin imports from untagged shared code
- [x] Stub implementation added for non-CGO Linux builds
- [ ] N/A - This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted
- [x] Linters pass
- [x] Tests pass
- [x] Build succeeds
- [x] Tests added for changed behavior
- [x] Documentation updated (not applicable)
- [x] Commit message follows Conventional Commits

## Validation

Run in a Linux CGO container with the same native packages used by CI:

- `go test ./...`
- `go test -tags=integration ./...`
- `go test -race ./...`
- `go test -tags=integration -race ./...`
- `go vet ./...`
- `golangci-lint v2.12.2 run`
- `CGO_ENABLED=1 go build ./cmd/neru`
- `clang-format --dry-run -Werror` on changed C/header files

All passed.

## Disclosure

Implementation and regression test were generated with OpenAI Codex. The change was validated against the full Linux test, race, vet, lint, formatting, and build gates listed above.