### PR TITLE
fix(linux,wayland): sync cursor cache after move relative

### DIFF
--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -569,6 +569,14 @@ int neru_wlr_move_relative(NeruWlrootsClient *c, int dx, int dy) {
 	wl_display_flush(c->display);
 	pthread_mutex_unlock(&c->display_mutex);
 
+	// Update cache synchronously — relative-motion events from the compositor
+	// never reach us because this client never owns pointer focus (all our
+	// surfaces have empty input regions after init). Without this, every
+	// MoveCursorBy call drifts the cache further from the real cursor.
+	atomic_fetch_add(&c->cursor_x, dx);
+	atomic_fetch_add(&c->cursor_y, dy);
+	atomic_store(&c->cursor_initialized, 1);
+
 	return 1;
 }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR is to ensure the cursor cache is synced after the new move relative executed. So that our indicator polling will follows the right cursor position.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Follow up of #1055

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

What's still not fixed, the mode indicator still doesn't respect the actual cursor position, e.g. manual cursor movement (for cursor moved by neru works perfectly)