### PR TITLE
feat(darwin,action): add hide and show system cursor action with virtual pointer

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -74,7 +74,7 @@ neru idle                                  # Cancel active navigation mode
 | `--toggle, -t`            | bool   | Toggle mode on/off — exit to idle if already active                                                                                       |
 | `--cursor-selection-mode` | string | `follow` (cursor follows selection) or `hold` (cursor stays)                                                                              |
 
-Not allowed as `--action`: `reset`, `backspace`, `search_hints`, `cycle_hint`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos`, and scroll sub-actions (`scroll_up`, `page_down`, `go_top`, etc.).
+Not allowed as `--action`: `reset`, `backspace`, `search_hints`, `cycle_hint`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos`, `hide_cursor`, `show_cursor`, and scroll sub-actions (`scroll_up`, `page_down`, `go_top`, etc.).
 
 > The `--action` flag is most useful in hints mode (Vimium-style). In grid/recursive-grid, prefer composing behavior in per-mode hotkeys: `["action left_click", "idle"]`.
 
@@ -347,6 +347,8 @@ neru action wait_for_mode_exit                # Block until mode exits to idle
 neru action wait_for_mode_exit --bail         # Block; abort chain if mode was cancelled (no selection)
 neru action save_cursor_pos                   # Save current cursor position
 neru action restore_cursor_pos                # Restore saved cursor position
+neru action hide_cursor                       # Hide the system cursor
+neru action show_cursor                       # Show the system cursor
 ```
 
 | Flag      | Description                                                                   |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -283,10 +283,11 @@ All actions available in hotkeys. These also work as `neru action <name>` — se
 | Delay       | `sleep <duration>` — plain numbers are seconds (`0.5`), explicit units: `500ms`, `1s` |
 | Mode        | `reset`, `backspace`                                                                  |
 | Composition | `wait_for_mode_exit` (with optional `--bail`), `save_cursor_pos`, `restore_cursor_pos` |
+| Cursor      | `hide_cursor`, `show_cursor`                                                           |
 
 - Use `--bare` (e.g. `"action left_click --bare"`) to target the cursor position instead of the current mode selection (see [CLI.md](CLI.md#clicks))
 - `scroll_up` / `scroll_down` support `--steps` (e.g. `"action scroll_down --steps 200"`) to override `scroll_step` (see [CLI.md](CLI.md#scrolling))
-- `reset`, `backspace`, `search_hints`, `cycle_hint`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, and `restore_cursor_pos` are not valid mode `--action` values — use `neru action ...` or in hotkeys as `"action ..."`
+- `reset`, `backspace`, `search_hints`, `cycle_hint`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos`, `hide_cursor`, and `show_cursor` are not valid mode `--action` values — use `neru action ...` or in hotkeys as `"action ..."`
 
 #### Feed Keys
 

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -143,6 +143,10 @@ func (a *App) updateComponentConfigs(cfg *config.Config) {
 	if a.recursiveGridComponent != nil {
 		a.recursiveGridComponent.UpdateConfig(cfg, a.logger)
 	}
+
+	if a.virtualPointerOverlay != nil {
+		a.virtualPointerOverlay.SetConfig(cfg.VirtualPointer)
+	}
 }
 
 func (a *App) updateServiceConfigs(cfg *config.Config) {

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -241,6 +241,13 @@ func initializeUIComponents(app *App) error {
 
 	app.stickyIndicatorComponent = stickyIndicatorComponent
 
+	virtualPointerOverlay, err := factory.CreateVirtualPointerOverlay()
+	if err != nil {
+		return err
+	}
+
+	app.virtualPointerOverlay = virtualPointerOverlay
+
 	recursiveGridComponent, err := factory.CreateRecursiveGridComponent(ComponentCreationOptions{
 		SkipIfDisabled: false,
 		Required:       false,
@@ -562,6 +569,7 @@ func cleanupUIComponents(app *App) {
 	app.scrollComponent = nil
 	app.modeIndicatorComponent = nil
 	app.stickyIndicatorComponent = nil
+	app.virtualPointerOverlay = nil
 
 	// Clean up renderer
 	app.renderer = nil

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/app/components"
+	"github.com/y3owk1n/neru/internal/app/components/virtualpointer"
 	"github.com/y3owk1n/neru/internal/app/modes"
 	"github.com/y3owk1n/neru/internal/app/services"
 	"github.com/y3owk1n/neru/internal/app/services/modeindicator"
@@ -88,6 +89,7 @@ type App struct {
 	modeIndicatorComponent   *components.ModeIndicatorComponent
 	stickyIndicatorComponent *components.StickyIndicatorComponent
 	recursiveGridComponent   *components.RecursiveGridComponent
+	virtualPointerOverlay    *virtualpointer.Overlay
 	systrayComponent         SystrayComponent
 
 	// Lifecycle management

--- a/internal/app/component_factory.go
+++ b/internal/app/component_factory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app/components/recursivegrid"
 	"github.com/y3owk1n/neru/internal/app/components/scroll"
 	"github.com/y3owk1n/neru/internal/app/components/stickyindicator"
+	"github.com/y3owk1n/neru/internal/app/components/virtualpointer"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
@@ -253,6 +254,36 @@ func (f *ComponentFactory) CreateStickyIndicatorComponent(
 	}, nil
 }
 
+// CreateVirtualPointerOverlay creates the cursor-following virtual pointer overlay.
+func (f *ComponentFactory) CreateVirtualPointerOverlay() (*virtualpointer.Overlay, error) {
+	if f.headless() {
+		return nil, nil //nolint:nilnil
+	}
+
+	overlay, err := f.createOverlay("virtual_pointer", f.config.VirtualPointer)
+	if err != nil {
+		return nil, derrors.Wrap(
+			err,
+			derrors.CodeOverlayFailed,
+			"failed to create virtual pointer overlay",
+		)
+	}
+
+	if overlay == nil {
+		return nil, nil //nolint:nilnil
+	}
+
+	typed, ok := overlay.(*virtualpointer.Overlay)
+	if !ok {
+		return nil, derrors.New(
+			derrors.CodeOverlayFailed,
+			"unexpected virtual pointer overlay type",
+		)
+	}
+
+	return typed, nil
+}
+
 // CreateRecursiveGridComponent creates a recursive-grid component with standardized error handling.
 func (f *ComponentFactory) CreateRecursiveGridComponent(
 	opts ComponentCreationOptions,
@@ -366,6 +397,21 @@ func (f *ComponentFactory) createOverlay(overlayType string, cfg any) (any, erro
 
 		return stickyindicator.NewOverlay(
 			uiConfig,
+			f.themeProvider,
+			f.logger,
+		)
+	case "virtual_pointer":
+		virtualPointerConfig, ok := cfg.(config.VirtualPointerConfig)
+		if !ok {
+			return nil, derrors.New(derrors.CodeInvalidInput, "invalid virtual pointer config type")
+		}
+
+		if f.headless() {
+			return nil, nil //nolint:nilnil
+		}
+
+		return virtualpointer.NewOverlay(
+			virtualPointerConfig,
 			f.themeProvider,
 			f.logger,
 		)

--- a/internal/app/components/virtualpointer/doc.go
+++ b/internal/app/components/virtualpointer/doc.go
@@ -1,0 +1,2 @@
+// Package virtualpointer renders a cursor-following virtual pointer overlay.
+package virtualpointer

--- a/internal/app/components/virtualpointer/overlay_darwin.go
+++ b/internal/app/components/virtualpointer/overlay_darwin.go
@@ -1,0 +1,103 @@
+//go:build darwin
+
+package virtualpointer
+
+/*
+#cgo CFLAGS: -x objective-c
+#include "../../../core/infra/platform/darwin/overlay.h"
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"sync"
+	"unsafe"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/app/components/overlayutil"
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// Overlay renders a cursor-following virtual pointer in its own small window.
+type Overlay struct {
+	window C.OverlayWindow
+	config config.VirtualPointerConfig
+	theme  config.ThemeProvider
+	logger *zap.Logger
+
+	configMu sync.RWMutex
+}
+
+// NewOverlay creates a dedicated virtual pointer overlay window.
+func NewOverlay(
+	cfg config.VirtualPointerConfig,
+	theme config.ThemeProvider,
+	logger *zap.Logger,
+) (*Overlay, error) {
+	base, err := overlayutil.NewBaseOverlay(logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Overlay{
+		window: C.OverlayWindow(base.Window),
+		config: cfg,
+		theme:  theme,
+		logger: logger,
+	}, nil
+}
+
+// SetConfig updates the virtual pointer configuration.
+func (o *Overlay) SetConfig(cfg config.VirtualPointerConfig) {
+	o.configMu.Lock()
+	defer o.configMu.Unlock()
+
+	o.config = cfg
+}
+
+// Show displays the virtual pointer overlay window.
+func (o *Overlay) Show() {
+	C.NeruShowOverlayWindow(o.window)
+}
+
+// Hide conceals the virtual pointer overlay window.
+func (o *Overlay) Hide() {
+	C.NeruHideOverlayWindow(o.window)
+}
+
+// Clear removes the virtual pointer from the overlay.
+func (o *Overlay) Clear() {
+	C.NeruHideCursorIndicator(o.window)
+}
+
+// ResizeToActiveScreen is a no-op; positioning is handled per draw.
+func (o *Overlay) ResizeToActiveScreen() {}
+
+// Draw positions the overlay on the cursor and renders the virtual pointer dot.
+func (o *Overlay) Draw(xCoordinate, yCoordinate, size int, fillColor string) {
+	if size < 1 || fillColor == "" {
+		return
+	}
+
+	cFillColor := C.CString(fillColor)
+	defer C.free(unsafe.Pointer(cFillColor)) //nolint:nlreturn
+
+	C.NeruPositionAndDrawVirtualPointer(
+		o.window,
+		C.double(xCoordinate),
+		C.double(yCoordinate),
+		C.CursorIndicatorStyle{
+			radius:    C.double(size),
+			fillColor: cFillColor,
+		},
+	)
+}
+
+// Destroy releases the overlay window.
+func (o *Overlay) Destroy() {
+	if o.window != nil {
+		C.NeruDestroyOverlayWindow(o.window)
+		o.window = nil
+	}
+}

--- a/internal/app/components/virtualpointer/overlay_darwin.go
+++ b/internal/app/components/virtualpointer/overlay_darwin.go
@@ -20,6 +20,14 @@ import (
 )
 
 // Overlay renders a cursor-following virtual pointer in its own small window.
+const (
+	// NSWindowSharingNone represents NSWindowSharingNone (0) - hidden from screen sharing.
+	NSWindowSharingNone = 0
+	// NSWindowSharingReadOnly represents NSWindowSharingReadOnly (1) - visible in screen sharing.
+	NSWindowSharingReadOnly = 1
+)
+
+// Overlay is a virtual pointer overlay window.
 type Overlay struct {
 	window C.OverlayWindow
 	config config.VirtualPointerConfig
@@ -69,6 +77,16 @@ func (o *Overlay) Hide() {
 // Clear removes the virtual pointer from the overlay.
 func (o *Overlay) Clear() {
 	C.NeruHideCursorIndicator(o.window)
+}
+
+// SetSharingType sets the window sharing type for screen sharing visibility.
+func (o *Overlay) SetSharingType(hide bool) {
+	sharingType := C.int(NSWindowSharingReadOnly)
+	if hide {
+		sharingType = C.int(NSWindowSharingNone)
+	}
+
+	C.NeruSetOverlaySharingType(o.window, sharingType)
 }
 
 // ResizeToActiveScreen is a no-op; positioning is handled per draw.

--- a/internal/app/components/virtualpointer/overlay_stub.go
+++ b/internal/app/components/virtualpointer/overlay_stub.go
@@ -1,0 +1,42 @@
+//go:build !darwin
+
+package virtualpointer
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// Overlay is a no-op virtual pointer overlay on non-macOS platforms.
+type Overlay struct{}
+
+// NewOverlay creates a no-op virtual pointer overlay.
+func NewOverlay(
+	_ config.VirtualPointerConfig,
+	_ config.ThemeProvider,
+	_ *zap.Logger,
+) (*Overlay, error) {
+	return &Overlay{}, nil
+}
+
+// SetConfig is a no-op.
+func (o *Overlay) SetConfig(_ config.VirtualPointerConfig) {}
+
+// Show is a no-op.
+func (o *Overlay) Show() {}
+
+// Hide is a no-op.
+func (o *Overlay) Hide() {}
+
+// Clear is a no-op.
+func (o *Overlay) Clear() {}
+
+// ResizeToActiveScreen is a no-op.
+func (o *Overlay) ResizeToActiveScreen() {}
+
+// Draw is a no-op.
+func (o *Overlay) Draw(_, _, _ int, _ string) {}
+
+// Destroy is a no-op.
+func (o *Overlay) Destroy() {}

--- a/internal/app/components/virtualpointer/overlay_stub.go
+++ b/internal/app/components/virtualpointer/overlay_stub.go
@@ -38,5 +38,8 @@ func (o *Overlay) ResizeToActiveScreen() {}
 // Draw is a no-op.
 func (o *Overlay) Draw(_, _, _ int, _ string) {}
 
+// SetSharingType is a no-op.
+func (o *Overlay) SetSharingType(_ bool) {}
+
 // Destroy is a no-op.
 func (o *Overlay) Destroy() {}

--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -256,4 +256,8 @@ func (a *App) registerOverlays() {
 	if a.recursiveGridComponent != nil && a.recursiveGridComponent.Overlay != nil {
 		a.overlayManager.UseRecursiveGridOverlay(a.recursiveGridComponent.Overlay)
 	}
+
+	if a.virtualPointerOverlay != nil {
+		a.overlayManager.UseVirtualPointerOverlay(a.virtualPointerOverlay)
+	}
 }

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -1260,6 +1260,19 @@ func (h *IPCControllerActions) handleCursorVisibilityAction(
 		}
 	}
 
+	if !h.modesHandler.CursorVisibilitySupported() {
+		actionName := "show_cursor"
+		if hide {
+			actionName = "hide_cursor"
+		}
+
+		return ipc.Response{
+			Success: false,
+			Message: actionName + " is not supported on this platform",
+			Code:    ipc.CodeNotSupported,
+		}
+	}
+
 	if hide {
 		h.modesHandler.HideSystemCursor()
 

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -346,6 +346,10 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 		return h.handleSearchHintsAction(parsed)
 	}
 
+	if action.IsHideCursorAction(actionName) || action.IsShowCursorAction(actionName) {
+		return h.handleCursorVisibilityAction(parsed, action.IsHideCursorAction(actionName))
+	}
+
 	// Handle comma-separated action chains (e.g., "left_click,left_click")
 	// which produce multi-click sequences via the native click-counting layer.
 	// Only mouse button actions are allowed in chains.
@@ -1229,6 +1233,42 @@ func (h *IPCControllerActions) handleRestoreCursorPosAction(
 	h.savedCursorMu.Unlock()
 
 	return ipc.Response{Success: true, Message: "cursor restored", Code: ipc.CodeOK}
+}
+
+func (h *IPCControllerActions) handleCursorVisibilityAction(
+	parsed parsedActionArgs,
+	hide bool,
+) ipc.Response {
+	if hasUnsupportedFlags(parsed) {
+		actionName := "show_cursor"
+		if hide {
+			actionName = "hide_cursor"
+		}
+
+		return ipc.Response{
+			Success: false,
+			Message: actionName + " does not support action flags",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	if h.modesHandler == nil {
+		return ipc.Response{
+			Success: false,
+			Message: msgModesHandlerNotAvailable,
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	if hide {
+		h.modesHandler.HideSystemCursor()
+
+		return ipc.Response{Success: true, Message: "system cursor hidden", Code: ipc.CodeOK}
+	}
+
+	h.modesHandler.ShowSystemCursor()
+
+	return ipc.Response{Success: true, Message: "system cursor shown", Code: ipc.CodeOK}
 }
 
 // handleMoveMonitorAction moves the cursor (and any active mode overlay)

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -552,6 +552,10 @@ func (a *App) Cleanup() {
 		}
 
 		a.ExitMode()
+
+		if a.modes != nil {
+			a.modes.ShowSystemCursor()
+		}
 		// Stop theme observer: nil the handler first so any in-flight KVO callback
 		// (between the async dispatch and actual observer removal) is a no-op.
 		a.stopThemeObserver()

--- a/internal/app/mocks_darwin_test.go
+++ b/internal/app/mocks_darwin_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app/components/modeindicator"
 	"github.com/y3owk1n/neru/internal/app/components/recursivegrid"
 	"github.com/y3owk1n/neru/internal/app/components/stickyindicator"
+	"github.com/y3owk1n/neru/internal/app/components/virtualpointer"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 	"github.com/y3owk1n/neru/internal/core/infra/appwatcher"
 	"github.com/y3owk1n/neru/internal/core/infra/hotkeys"
@@ -209,6 +210,7 @@ func (m *mockOverlayManager) UseGridOverlay(_ *grid.Overlay)                    
 func (m *mockOverlayManager) UseModeIndicatorOverlay(_ *modeindicator.Overlay)     {}
 func (m *mockOverlayManager) UseStickyModifiersOverlay(_ *stickyindicator.Overlay) {}
 func (m *mockOverlayManager) UseRecursiveGridOverlay(_ *recursivegrid.Overlay)     {}
+func (m *mockOverlayManager) UseVirtualPointerOverlay(_ *virtualpointer.Overlay)   {}
 
 func (m *mockOverlayManager) HintOverlay() *hints.Overlay { return nil }
 func (m *mockOverlayManager) GridOverlay() *grid.Overlay  { return nil }
@@ -224,6 +226,10 @@ func (m *mockOverlayManager) RecursiveGridOverlay() *recursivegrid.Overlay {
 	return nil
 }
 
+func (m *mockOverlayManager) VirtualPointerOverlay() *virtualpointer.Overlay {
+	return nil
+}
+
 func (m *mockOverlayManager) DrawHintsWithStyle(
 	_ []*hints.Hint,
 	_ hints.StyleMode,
@@ -232,6 +238,7 @@ func (m *mockOverlayManager) DrawHintsWithStyle(
 }
 func (m *mockOverlayManager) DrawModeIndicator(_, _ int)                      {}
 func (m *mockOverlayManager) DrawStickyModifiersIndicator(_, _ int, _ string) {}
+func (m *mockOverlayManager) DrawVirtualPointer(_, _, _ int, _ string)        {}
 
 func (m *mockOverlayManager) DrawMouseActionIndicator(
 	_ image.Point,

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -62,6 +62,10 @@ func (h *Handler) clearAndHideOverlay() {
 
 // cleanupHintsMode handles cleanup for hints mode.
 func (h *Handler) cleanupHintsMode() {
+	if h.config.VirtualPointer.Enabled {
+		h.showSystemCursorLocked()
+	}
+
 	h.stopHintSearchTextInputLocked(false)
 
 	resetErr := h.hints.Context.Reset()

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -62,10 +62,6 @@ func (h *Handler) clearAndHideOverlay() {
 
 // cleanupHintsMode handles cleanup for hints mode.
 func (h *Handler) cleanupHintsMode() {
-	if h.config.VirtualPointer.Enabled {
-		h.showSystemCursorLocked()
-	}
-
 	h.stopHintSearchTextInputLocked(false)
 
 	resetErr := h.hints.Context.Reset()

--- a/internal/app/modes/cursor_darwin.go
+++ b/internal/app/modes/cursor_darwin.go
@@ -1,0 +1,24 @@
+//go:build darwin
+
+package modes
+
+/*
+#cgo CFLAGS: -x objective-c -fobjc-arc
+#include "../../core/infra/platform/darwin/overlay.h"
+*/
+import "C"
+
+func (h *Handler) hideSystemCursorNative() {
+	C.NeruHideSystemCursor()
+}
+
+func (h *Handler) showSystemCursorNative() {
+	C.NeruShowSystemCursor()
+}
+
+// RehideSystemCursor performs a show+hide pair so the CGDisplayHideCursor ref
+// count stays at 1. Use this to recover from Mission Control, Exposé, or
+// workspace switches that reveal the cursor.
+func (h *Handler) RehideSystemCursor() {
+	C.NeruRehideSystemCursor()
+}

--- a/internal/app/modes/cursor_darwin.go
+++ b/internal/app/modes/cursor_darwin.go
@@ -8,6 +8,8 @@ package modes
 */
 import "C"
 
+func (h *Handler) CursorVisibilitySupported() bool { return true }
+
 func (h *Handler) hideSystemCursorNative() {
 	C.NeruHideSystemCursor()
 }

--- a/internal/app/modes/cursor_darwin.go
+++ b/internal/app/modes/cursor_darwin.go
@@ -8,6 +8,7 @@ package modes
 */
 import "C"
 
+// CursorVisibilitySupported returns true on macOS where system cursor visibility control is available.
 func (h *Handler) CursorVisibilitySupported() bool { return true }
 
 func (h *Handler) hideSystemCursorNative() {

--- a/internal/app/modes/cursor_stubs.go
+++ b/internal/app/modes/cursor_stubs.go
@@ -2,6 +2,7 @@
 
 package modes
 
+// CursorVisibilitySupported returns false on non-macOS platforms.
 func (h *Handler) CursorVisibilitySupported() bool { return false }
 
 func (h *Handler) hideSystemCursorNative() {}

--- a/internal/app/modes/cursor_stubs.go
+++ b/internal/app/modes/cursor_stubs.go
@@ -2,6 +2,8 @@
 
 package modes
 
+func (h *Handler) CursorVisibilitySupported() bool { return false }
+
 func (h *Handler) hideSystemCursorNative() {}
 
 func (h *Handler) showSystemCursorNative() {}

--- a/internal/app/modes/cursor_stubs.go
+++ b/internal/app/modes/cursor_stubs.go
@@ -1,0 +1,10 @@
+//go:build !darwin
+
+package modes
+
+func (h *Handler) hideSystemCursorNative() {}
+
+func (h *Handler) showSystemCursorNative() {}
+
+// RehideSystemCursor is a no-op on non-macOS platforms.
+func (h *Handler) RehideSystemCursor() {}

--- a/internal/app/modes/cursor_visibility.go
+++ b/internal/app/modes/cursor_visibility.go
@@ -1,0 +1,95 @@
+package modes
+
+import (
+	"github.com/y3owk1n/neru/internal/core/domain"
+)
+
+// HideSystemCursor hides the system cursor and shows the virtual pointer when enabled.
+func (h *Handler) HideSystemCursor() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.hideSystemCursorLocked()
+}
+
+// hideSystemCursorLocked hides the system cursor. Caller must hold h.mu.
+func (h *Handler) hideSystemCursorLocked() {
+	if h.systemCursorHidden {
+		return
+	}
+
+	h.hideSystemCursorNative()
+	h.systemCursorHidden = true
+	h.ensureCursorOverlayPollingLocked()
+}
+
+// ShowSystemCursor shows the system cursor and hides the cursor-following virtual pointer.
+func (h *Handler) ShowSystemCursor() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.showSystemCursorLocked()
+}
+
+// showSystemCursorLocked shows the system cursor. Caller must hold h.mu.
+func (h *Handler) showSystemCursorLocked() {
+	if !h.systemCursorHidden {
+		return
+	}
+
+	h.showSystemCursorNative()
+	h.systemCursorHidden = false
+	h.hideCursorFollowingVirtualPointerLocked()
+	h.stopCursorOverlayPollingIfIdleLocked()
+}
+
+func (h *Handler) shouldShowCursorFollowingVirtualPointerLocked() bool {
+	if !h.systemCursorHidden || h.config == nil || !h.config.VirtualPointer.Enabled {
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) ensureCursorOverlayPollingLocked() {
+	if !h.shouldShowCursorFollowingVirtualPointerLocked() {
+		return
+	}
+
+	h.startIndicatorPolling(h.appState.CurrentMode())
+}
+
+func (h *Handler) stopCursorOverlayPollingIfIdleLocked() {
+	if h.shouldPollCursorOverlaysLocked(h.appState.CurrentMode()) {
+		return
+	}
+
+	h.stopIndicatorPolling()
+}
+
+func (h *Handler) shouldPollCursorOverlaysLocked(mode domain.Mode) bool {
+	if h.config == nil {
+		return false
+	}
+
+	if h.stickyModifiersEnabled() {
+		return true
+	}
+
+	if h.modeIndicatorEnabled(mode) {
+		return true
+	}
+
+	return h.shouldShowCursorFollowingVirtualPointerLocked()
+}
+
+func (h *Handler) hideCursorFollowingVirtualPointerLocked() {
+	if h.overlayManager == nil {
+		return
+	}
+
+	if vp := h.overlayManager.VirtualPointerOverlay(); vp != nil {
+		vp.Clear()
+		vp.Hide()
+	}
+}

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -123,6 +123,9 @@ type Handler struct {
 	indicatorStopCh chan struct{}
 	indicatorDoneCh chan struct{}
 
+	// systemCursorHidden tracks whether hide_cursor (or hints virtual pointer) is active.
+	systemCursorHidden bool
+
 	// Cycle hint state
 	cycleHintIndex int
 

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -23,9 +23,9 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 	if h.indicatorTicker != nil || h.indicatorStopCh != nil {
 		return
 	}
-	// Only start polling if at least one of mode indicator or sticky modifiers
-	// indicator is enabled for this mode.
-	if h.config == nil || (!h.modeIndicatorEnabled(mode) && !h.stickyModifiersEnabled()) {
+
+	// All callers hold h.mu, so we can call the *Locked helpers directly.
+	if h.config == nil || !h.shouldPollCursorOverlaysLocked(mode) {
 		return
 	}
 	// Disable exclusive keyboard so scroll events pass through to applications
@@ -100,6 +100,16 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 				}
 				showModeInd := h.shouldShowModeIndicator(h.appState.CurrentMode())
 				stickyEnabled := h.stickyModifiersEnabled()
+				showVirtualPointer := h.shouldShowCursorFollowingVirtualPointerLocked()
+
+				var (
+					virtualPointerSize      int
+					virtualPointerFillColor string
+				)
+				if showVirtualPointer {
+					virtualPointerSize, virtualPointerFillColor, showVirtualPointer = h.virtualPointerStyle()
+				}
+
 				stickyPoint := h.stickyIndicatorAnchorLocked(image.Pt(cursorX, cursorY))
 
 				cursorPt := image.Pt(cursorX, cursorY)
@@ -176,10 +186,20 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 					}
 				}
 
-				// Flush both indicator draws atomically to avoid intermediate
-				// buffer states appearing between the mode indicator and sticky
-				// modifiers draws. The overlay backend batches the buffer
-				// modifications and only sends them on Flush().
+				if showVirtualPointer {
+					if vp := h.overlayManager.VirtualPointerOverlay(); vp != nil {
+						vp.Show()
+						h.overlayManager.DrawVirtualPointer(
+							cursorX,
+							cursorY,
+							virtualPointerSize,
+							virtualPointerFillColor,
+						)
+					}
+				}
+
+				// Flush indicator draws atomically to avoid intermediate buffer
+				// states appearing between overlay updates.
 				h.overlayManager.Flush()
 			}
 		}
@@ -216,6 +236,10 @@ func (h *Handler) stopIndicatorPolling() {
 	if stickyInd := h.overlayManager.StickyModifiersOverlay(); stickyInd != nil {
 		stickyInd.Clear()
 		stickyInd.Hide()
+	}
+	// All callers hold h.mu, so we can call the *Locked helpers directly.
+	if !h.shouldShowCursorFollowingVirtualPointerLocked() {
+		h.hideCursorFollowingVirtualPointerLocked()
 	}
 	// Clean up resources after loop has exited.
 	if h.indicatorTicker != nil {

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -196,6 +196,9 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 							virtualPointerFillColor,
 						)
 					}
+				} else if vp := h.overlayManager.VirtualPointerOverlay(); vp != nil {
+					vp.Hide()
+					vp.Clear()
 				}
 
 				// Flush indicator draws atomically to avoid intermediate buffer

--- a/internal/cli/action.go
+++ b/internal/cli/action.go
@@ -25,6 +25,7 @@ Available subcommands:
   Mouse movement:   move_mouse, move_mouse_relative, move_monitor
   Mode control:     reset, backspace, wait_for_mode_exit, cycle_hint
   Cursor saving:    save_cursor_pos, restore_cursor_pos
+  Cursor visibility: hide_cursor, show_cursor
   Key injection:    feed
 
 Click actions can be chained with commas to produce multi-click sequences:
@@ -195,6 +196,26 @@ var ActionRestoreCursorPosCmd = BuildActionCommand(
 	false,
 )
 
+// ActionHideCursorCmd hides the system cursor.
+var ActionHideCursorCmd = BuildActionCommand(
+	"hide_cursor",
+	"Hide system cursor",
+	`Hide the system cursor. Used together with show_cursor to create a virtual
+pointer experience. The cursor stays hidden until show_cursor is called or
+the application exits.`,
+	[]string{"hide_cursor"},
+	false,
+)
+
+// ActionShowCursorCmd shows the system cursor.
+var ActionShowCursorCmd = BuildActionCommand(
+	"show_cursor",
+	"Show system cursor",
+	`Show the system cursor after it was hidden by hide_cursor.`,
+	[]string{"show_cursor"},
+	false,
+)
+
 // ActionScrollUpCmd scrolls up at the current cursor position.
 var ActionScrollUpCmd = BuildScrollActionCommand(
 	"scroll_up",
@@ -310,6 +331,8 @@ func init() {
 	ActionCmd.AddCommand(ActionPageUpCmd)
 	ActionCmd.AddCommand(ActionPageDownCmd)
 	ActionCmd.AddCommand(ActionCycleHintCmd)
+	ActionCmd.AddCommand(ActionHideCursorCmd)
+	ActionCmd.AddCommand(ActionShowCursorCmd)
 
 	RootCmd.AddCommand(ActionCmd)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -173,6 +173,8 @@ func TestCommandInitialization(t *testing.T) {
 		"page_down":           false,
 		"move_monitor":        false,
 		"cycle_hint":          false,
+		"hide_cursor":         false,
+		"show_cursor":         false,
 	}
 
 	for _, cmd := range cli.ActionCmd.Commands() {
@@ -230,6 +232,8 @@ func TestCommandExecutionWithoutDaemon(t *testing.T) {
 		{"action_page_up", getActionCmd("page_up"), true},
 		{"action_page_down", getActionCmd("page_down"), true},
 		{"action_move_monitor", getActionCmd("move_monitor"), true},
+		{"action_hide_cursor", getActionCmd("hide_cursor"), true},
+		{"action_show_cursor", getActionCmd("show_cursor"), true},
 		{cliTestStatus, getCmd(cliTestStatus), true},
 		{
 			"doctor",

--- a/internal/core/domain/action/action.go
+++ b/internal/core/domain/action/action.go
@@ -163,6 +163,10 @@ const (
 	NamePageUp Name = "page_up"
 	// NamePageDown represents the page-down action.
 	NamePageDown Name = "page_down"
+	// NameHideCursor hides the system cursor.
+	NameHideCursor Name = "hide_cursor"
+	// NameShowCursor shows the system cursor.
+	NameShowCursor Name = "show_cursor"
 	// NameSleep pauses action execution for a specified duration.
 	NameSleep Name = "sleep"
 	// NameCycleHint cycles through visible hints in hints mode.
@@ -234,6 +238,16 @@ func IsRestoreCursorPosAction(name string) bool {
 	return Name(name) == NameRestoreCursorPos
 }
 
+// IsHideCursorAction reports whether the given action is hide_cursor.
+func IsHideCursorAction(name string) bool {
+	return Name(name) == NameHideCursor
+}
+
+// IsShowCursorAction reports whether the given action is show_cursor.
+func IsShowCursorAction(name string) bool {
+	return Name(name) == NameShowCursor
+}
+
 // IsMoveMonitorAction reports whether the given action is move_monitor.
 func IsMoveMonitorAction(name string) bool {
 	return Name(name) == NameMoveMonitor
@@ -267,7 +281,8 @@ func IsKnownName(name Name) bool {
 		NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
 		NameScrollUp, NameScrollDown, NameScrollLeft, NameScrollRight,
 		NameGoTop, NameGoBottom, NamePageUp, NamePageDown,
-		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints:
+		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints,
+		NameHideCursor, NameShowCursor:
 		return true
 	default:
 		return false
@@ -290,7 +305,8 @@ func IsScrollSubAction(name string) bool {
 		NameMouseDown, NameMouseUp,
 		NameMoveMouse, NameMoveMouseRelative, NameScroll,
 		NameReset, NameBackspace, NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
-		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints:
+		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints,
+		NameHideCursor, NameShowCursor:
 		return false
 	default:
 		return false
@@ -368,7 +384,9 @@ func (n Name) ToType() (Type, error) {
 		NameFeed,
 		NameSleep,
 		NameCycleHint,
-		NameSearchHints:
+		NameSearchHints,
+		NameHideCursor,
+		NameShowCursor:
 		return 0, derrors.Newf(derrors.CodeInvalidInput, "action name not executable: %s", n)
 	default:
 		return 0, derrors.Newf(derrors.CodeInvalidInput, "unknown action name: %s", n)

--- a/internal/core/domain/action/action_test.go
+++ b/internal/core/domain/action/action_test.go
@@ -259,6 +259,8 @@ func TestIsKnownName(t *testing.T) {
 		{action.NameRestoreCursorPos, true},
 		{action.NameMoveMonitor, true},
 		{action.NameFeed, true},
+		{action.NameHideCursor, true},
+		{action.NameShowCursor, true},
 		// Scroll sub-actions are recognized by IsKnownName (superset of knownNames).
 		{action.NameScrollUp, true},
 		{action.NameScrollDown, true},
@@ -311,6 +313,8 @@ func TestIsScrollSubAction(t *testing.T) {
 		{"save_cursor_pos", false},
 		{"restore_cursor_pos", false},
 		{"move_monitor", false},
+		{"hide_cursor", false},
+		{"show_cursor", false},
 		// Unknown / empty return false.
 		{"unknown", false},
 		{"", false},

--- a/internal/core/infra/ipc/ipc.go
+++ b/internal/core/infra/ipc/ipc.go
@@ -81,6 +81,9 @@ const (
 	// CodeChainBail indicates a chain action should abort (e.g. user canceled
 	// a mode without making a selection).
 	CodeChainBail = "ERR_CHAIN_BAIL"
+
+	// CodeNotSupported indicates the operation is not supported on this platform.
+	CodeNotSupported = "ERR_NOT_SUPPORTED"
 )
 
 // Command represents a command sent through the IPC interface.

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -270,6 +270,26 @@ void NeruShowCursorIndicator(OverlayWindow window, CGPoint position, CursorIndic
 /// @param window Overlay window handle
 void NeruHideCursorIndicator(OverlayWindow window);
 
+/// Position a small overlay window on the cursor and draw the virtual pointer dot.
+/// @param window Overlay window handle
+/// @param absoluteX Cursor X in Quartz screen coordinates
+/// @param absoluteY Cursor Y in Quartz screen coordinates
+/// @param style Virtual pointer style
+void NeruPositionAndDrawVirtualPointer(
+    OverlayWindow window, double absoluteX, double absoluteY, CursorIndicatorStyle style);
+
+/// Hide the system cursor (CGDisplayHideCursor).
+/// Uses the private CGS API to allow cursor changes from background processes.
+void NeruHideSystemCursor(void);
+
+/// Show the system cursor (CGDisplayShowCursor).
+void NeruShowSystemCursor(void);
+
+/// Safely re-hide the system cursor (show+hide pair) so the ref count never
+/// exceeds 1. The show decrements the ref count (or is a no-op if already 0)
+/// and the hide increments it, so the net delta is always zero.
+void NeruRehideSystemCursor(void);
+
 /// Show a transient mouse action indicator in its own overlay window.
 /// @param position Global cursor position in Quartz coordinates
 /// @param style Indicator style

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -3318,6 +3318,61 @@ void NeruShowCursorIndicator(OverlayWindow window, CGPoint position, CursorIndic
 	});
 }
 
+static NSPoint NeruAppKitPointFromQuartzPoint(CGPoint point);
+static NSScreen *NeruScreenContainingQuartzPoint(CGPoint point);
+
+/// Position a small overlay window on the cursor and draw the virtual pointer dot.
+void NeruPositionAndDrawVirtualPointer(
+    OverlayWindow window, double absoluteX, double absoluteY, CursorIndicatorStyle style) {
+	if (!window)
+		return;
+
+	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
+
+	CGFloat radius = style.radius > 0 ? style.radius : 3.0;
+	NSString *fillHex = style.fillColor ? @(style.fillColor) : nil;
+	CGFloat margin = 2.0;
+	CGFloat windowSize = (radius * 2.0) + margin * 2.0;
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		@autoreleasepool {
+			CGPoint desiredCenter = CGPointMake(absoluteX, absoluteY);
+			NSPoint appKitCenter = NeruAppKitPointFromQuartzPoint(desiredCenter);
+
+			NSScreen *cursorScreen = NeruScreenContainingQuartzPoint(desiredCenter);
+			if (cursorScreen != nil) {
+				NSRect screenFrame = cursorScreen.frame;
+				CGFloat half = windowSize / 2.0;
+				CGFloat minX = screenFrame.origin.x + half;
+				CGFloat maxX = NSMaxX(screenFrame) - half;
+				CGFloat minY = screenFrame.origin.y + half;
+				CGFloat maxY = NSMaxY(screenFrame) - half;
+				if (minX <= maxX) {
+					appKitCenter.x = MAX(minX, MIN(appKitCenter.x, maxX));
+				}
+				if (minY <= maxY) {
+					appKitCenter.y = MAX(minY, MIN(appKitCenter.y, maxY));
+				}
+			}
+
+			NSRect frame = NSMakeRect(
+			    appKitCenter.x - windowSize / 2.0, appKitCenter.y - windowSize / 2.0, windowSize, windowSize);
+
+			[controller.window setFrame:frame display:NO];
+			[controller.overlayView setFrame:NSMakeRect(0, 0, windowSize, windowSize)];
+			NeruOrderOverlayWindowIfDrawable(controller, NO);
+
+			[controller.overlayView cancelCursorIndicatorTransition];
+			controller.overlayView.cursorIndicatorVisible = YES;
+			controller.overlayView.cursorIndicatorPosition = NSMakePoint(windowSize / 2.0, windowSize / 2.0);
+			controller.overlayView.cursorIndicatorRadius = radius;
+			controller.overlayView.cursorIndicatorFillColor =
+			    [controller.overlayView colorFromHex:fillHex defaultColor:[NSColor whiteColor]];
+			[controller.overlayView setNeedsDisplay:YES];
+		}
+	});
+}
+
 /// Hide the virtual cursor indicator.
 /// @param window Overlay window handle
 void NeruHideCursorIndicator(OverlayWindow window) {
@@ -3642,5 +3697,42 @@ void NeruShowMouseActionIndicator(CGPoint position, MouseActionIndicatorStyle st
 				    }
 			    });
 		}
+	});
+}
+
+#pragma mark - System Cursor
+
+/// Private CGS API to allow cursor changes from background processes.
+typedef int CGSConnectionID;
+CGError CGSSetConnectionProperty(CGSConnectionID cid, CGSConnectionID targetCID, CFStringRef key, CFTypeRef value);
+CGSConnectionID _CGSDefaultConnection(void);
+
+static void _NeruEnableCursorInBackground(void) {
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		CGSConnectionID cid = _CGSDefaultConnection();
+		CFStringRef key = CFSTR("SetsCursorInBackground");
+		CGSSetConnectionProperty(cid, cid, key, kCFBooleanTrue);
+	});
+}
+
+void NeruHideSystemCursor(void) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		_NeruEnableCursorInBackground();
+		CGDisplayHideCursor(kCGNullDirectDisplay);
+	});
+}
+
+void NeruShowSystemCursor(void) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		CGDisplayShowCursor(kCGNullDirectDisplay);
+	});
+}
+
+void NeruRehideSystemCursor(void) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		_NeruEnableCursorInBackground();
+		CGDisplayShowCursor(kCGNullDirectDisplay);
+		CGDisplayHideCursor(kCGNullDirectDisplay);
 	});
 }

--- a/internal/ui/overlay/manager_darwin.go
+++ b/internal/ui/overlay/manager_darwin.go
@@ -292,6 +292,10 @@ func (m *Manager) UseRecursiveGridOverlay(o *recursivegrid.Overlay) {
 // UseVirtualPointerOverlay sets the cursor-following virtual pointer overlay renderer.
 func (m *Manager) UseVirtualPointerOverlay(o *virtualpointer.Overlay) {
 	m.virtualPointerOverlay = o
+
+	if o != nil && m.hideInScreenShare {
+		o.SetSharingType(true)
+	}
 }
 
 // HintOverlay returns the hint overlay renderer.
@@ -558,6 +562,10 @@ func (m *Manager) SetSharingType(hide bool) {
 
 	if m.stickyModifiersOverlay != nil {
 		m.stickyModifiersOverlay.SetSharingType(hide)
+	}
+
+	if m.virtualPointerOverlay != nil {
+		m.virtualPointerOverlay.SetSharingType(hide)
 	}
 
 	if m.logger != nil {

--- a/internal/ui/overlay/manager_darwin.go
+++ b/internal/ui/overlay/manager_darwin.go
@@ -21,6 +21,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app/components/modeindicator"
 	"github.com/y3owk1n/neru/internal/app/components/recursivegrid"
 	"github.com/y3owk1n/neru/internal/app/components/stickyindicator"
+	"github.com/y3owk1n/neru/internal/app/components/virtualpointer"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/ports"
@@ -60,6 +61,7 @@ type Manager struct {
 	modeIndicatorOverlay   *modeindicator.Overlay
 	recursiveGridOverlay   *recursivegrid.Overlay
 	stickyModifiersOverlay *stickyindicator.Overlay
+	virtualPointerOverlay  *virtualpointer.Overlay
 }
 
 var (
@@ -287,6 +289,11 @@ func (m *Manager) UseRecursiveGridOverlay(o *recursivegrid.Overlay) {
 	m.recursiveGridOverlay = o
 }
 
+// UseVirtualPointerOverlay sets the cursor-following virtual pointer overlay renderer.
+func (m *Manager) UseVirtualPointerOverlay(o *virtualpointer.Overlay) {
+	m.virtualPointerOverlay = o
+}
+
 // HintOverlay returns the hint overlay renderer.
 func (m *Manager) HintOverlay() *hints.Overlay {
 	return m.hintOverlay
@@ -310,6 +317,11 @@ func (m *Manager) StickyModifiersOverlay() *stickyindicator.Overlay {
 // RecursiveGridOverlay returns the recursive-grid overlay renderer.
 func (m *Manager) RecursiveGridOverlay() *recursivegrid.Overlay {
 	return m.recursiveGridOverlay
+}
+
+// VirtualPointerOverlay returns the cursor-following virtual pointer overlay renderer.
+func (m *Manager) VirtualPointerOverlay() *virtualpointer.Overlay {
+	return m.virtualPointerOverlay
 }
 
 // DrawHintsWithStyle draws hints with the specified style using the hint overlay renderer.
@@ -383,6 +395,15 @@ func (m *Manager) DrawStickyModifiersIndicator(xCoordinate, yCoordinate int, sym
 	}
 
 	m.stickyModifiersOverlay.Draw(xCoordinate, yCoordinate, symbols)
+}
+
+// DrawVirtualPointer renders the cursor-following virtual pointer overlay.
+func (m *Manager) DrawVirtualPointer(xCoordinate, yCoordinate, size int, fillColor string) {
+	if m.virtualPointerOverlay == nil {
+		return
+	}
+
+	m.virtualPointerOverlay.Draw(xCoordinate, yCoordinate, size, fillColor)
 }
 
 // DrawMouseActionIndicator renders a transient mouse action indicator in its own native window.

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -709,6 +709,15 @@ type overlayBadgeStyle struct {
 	offsetY     int
 }
 
+// DrawVirtualPointer renders the cursor-following virtual pointer overlay.
+func (m *Manager) DrawVirtualPointer(xCoordinate, yCoordinate, size int, fillColor string) {
+	if m.virtualPointerOverlay == nil {
+		return
+	}
+
+	m.virtualPointerOverlay.Draw(xCoordinate, yCoordinate, size, fillColor)
+}
+
 // DrawMouseActionIndicator is a macOS-only renderer; Linux currently stubs it.
 func (m *Manager) DrawMouseActionIndicator(_ image.Point, _ ports.MouseActionIndicatorStyle) {}
 

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -17,6 +17,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app/components/modeindicator"
 	"github.com/y3owk1n/neru/internal/app/components/recursivegrid"
 	"github.com/y3owk1n/neru/internal/app/components/stickyindicator"
+	"github.com/y3owk1n/neru/internal/app/components/virtualpointer"
 	"github.com/y3owk1n/neru/internal/config"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
@@ -87,6 +88,7 @@ type Manager struct {
 	modeIndicatorOverlay   *modeindicator.Overlay
 	recursiveGridOverlay   *recursivegrid.Overlay
 	stickyModifiersOverlay *stickyindicator.Overlay
+	virtualPointerOverlay  *virtualpointer.Overlay
 
 	stickyBadgeRect    image.Rectangle
 	stickyBadgeVisible bool
@@ -336,6 +338,11 @@ func (m *Manager) UseRecursiveGridOverlay(o *recursivegrid.Overlay) {
 	m.recursiveGridOverlay = o
 }
 
+// UseVirtualPointerOverlay sets the cursor-following virtual pointer overlay.
+func (m *Manager) UseVirtualPointerOverlay(o *virtualpointer.Overlay) {
+	m.virtualPointerOverlay = o
+}
+
 // HintOverlay returns the hints overlay.
 func (m *Manager) HintOverlay() *hints.Overlay { return m.hintOverlay }
 
@@ -350,6 +357,9 @@ func (m *Manager) StickyModifiersOverlay() *stickyindicator.Overlay { return m.s
 
 // RecursiveGridOverlay returns the recursive grid overlay.
 func (m *Manager) RecursiveGridOverlay() *recursivegrid.Overlay { return m.recursiveGridOverlay }
+
+// VirtualPointerOverlay returns the cursor-following virtual pointer overlay.
+func (m *Manager) VirtualPointerOverlay() *virtualpointer.Overlay { return m.virtualPointerOverlay }
 
 // OverlayCapabilities returns the feature capabilities.
 func (m *Manager) OverlayCapabilities() ports.FeatureCapability {

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -64,7 +64,8 @@ type Manager struct {
 	gridOverlay            *grid.Overlay
 	modeIndicatorOverlay   *modeindicator.Overlay
 	recursiveGridOverlay   *recursivegrid.Overlay
-	stickyModifiersOverlay *stickyindicator.Overlay
+	stickyModifiersOverlay   *stickyindicator.Overlay
+	virtualPointerOverlay    *virtualpointer.Overlay
 }
 
 var (
@@ -311,6 +312,16 @@ func (m *Manager) StickyModifiersOverlay() *stickyindicator.Overlay {
 // RecursiveGridOverlay returns the recursive-grid overlay component.
 func (m *Manager) RecursiveGridOverlay() *recursivegrid.Overlay {
 	return m.recursiveGridOverlay
+}
+
+// UseVirtualPointerOverlay sets the cursor-following virtual pointer overlay renderer.
+func (m *Manager) UseVirtualPointerOverlay(o *virtualpointer.Overlay) {
+	m.virtualPointerOverlay = o
+}
+
+// VirtualPointerOverlay returns the cursor-following virtual pointer overlay renderer.
+func (m *Manager) VirtualPointerOverlay() *virtualpointer.Overlay {
+	return m.virtualPointerOverlay
 }
 
 // OverlayCapabilities reports Windows overlay support.

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -23,6 +23,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app/components/modeindicator"
 	"github.com/y3owk1n/neru/internal/app/components/recursivegrid"
 	"github.com/y3owk1n/neru/internal/app/components/stickyindicator"
+	"github.com/y3owk1n/neru/internal/app/components/virtualpointer"
 	"github.com/y3owk1n/neru/internal/config"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
@@ -64,8 +65,8 @@ type Manager struct {
 	gridOverlay            *grid.Overlay
 	modeIndicatorOverlay   *modeindicator.Overlay
 	recursiveGridOverlay   *recursivegrid.Overlay
-	stickyModifiersOverlay   *stickyindicator.Overlay
-	virtualPointerOverlay    *virtualpointer.Overlay
+	stickyModifiersOverlay *stickyindicator.Overlay
+	virtualPointerOverlay  *virtualpointer.Overlay
 }
 
 var (

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -662,6 +662,15 @@ func (m *Manager) DrawStickyModifiersIndicator(cursorX, cursorY int, symbols str
 	m.stickyWin.Show()
 }
 
+// DrawVirtualPointer renders the cursor-following virtual pointer overlay.
+func (m *Manager) DrawVirtualPointer(xCoordinate, yCoordinate, size int, fillColor string) {
+	if m.virtualPointerOverlay == nil {
+		return
+	}
+
+	m.virtualPointerOverlay.Draw(xCoordinate, yCoordinate, size, fillColor)
+}
+
 // DrawMouseActionIndicator renders a transient mouse action indicator on the Windows overlay.
 func (m *Manager) DrawMouseActionIndicator(
 	point image.Point,

--- a/internal/ui/overlay/types.go
+++ b/internal/ui/overlay/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app/components/modeindicator"
 	"github.com/y3owk1n/neru/internal/app/components/recursivegrid"
 	"github.com/y3owk1n/neru/internal/app/components/stickyindicator"
+	"github.com/y3owk1n/neru/internal/app/components/virtualpointer"
 	"github.com/y3owk1n/neru/internal/core/domain"
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 	"github.com/y3owk1n/neru/internal/core/ports"
@@ -105,6 +106,9 @@ func (n *NoOpManager) UseRecursiveGridOverlay(o *recursivegrid.Overlay) {}
 // UseStickyModifiersOverlay is a no-op implementation.
 func (n *NoOpManager) UseStickyModifiersOverlay(o *stickyindicator.Overlay) {}
 
+// UseVirtualPointerOverlay is a no-op implementation.
+func (n *NoOpManager) UseVirtualPointerOverlay(o *virtualpointer.Overlay) {}
+
 // HintOverlay returns nil.
 func (n *NoOpManager) HintOverlay() *hints.Overlay { return nil }
 
@@ -119,6 +123,9 @@ func (n *NoOpManager) RecursiveGridOverlay() *recursivegrid.Overlay { return nil
 
 // StickyModifiersOverlay returns nil.
 func (n *NoOpManager) StickyModifiersOverlay() *stickyindicator.Overlay { return nil }
+
+// VirtualPointerOverlay returns nil.
+func (n *NoOpManager) VirtualPointerOverlay() *virtualpointer.Overlay { return nil }
 
 // DrawHintsWithStyle is a no-op implementation.
 func (n *NoOpManager) DrawHintsWithStyle(
@@ -146,6 +153,9 @@ func (n *NoOpManager) DrawModeIndicator(x, y int) {}
 
 // DrawStickyModifiersIndicator is a no-op implementation.
 func (n *NoOpManager) DrawStickyModifiersIndicator(x, y int, symbols string) {}
+
+// DrawVirtualPointer is a no-op implementation.
+func (n *NoOpManager) DrawVirtualPointer(_, _ int, _ int, _ string) {}
 
 // DrawMouseActionIndicator is a no-op implementation.
 func (n *NoOpManager) DrawMouseActionIndicator(
@@ -227,12 +237,14 @@ type ManagerInterface interface {
 	UseModeIndicatorOverlay(o *modeindicator.Overlay)
 	UseRecursiveGridOverlay(o *recursivegrid.Overlay)
 	UseStickyModifiersOverlay(o *stickyindicator.Overlay)
+	UseVirtualPointerOverlay(o *virtualpointer.Overlay)
 
 	HintOverlay() *hints.Overlay
 	GridOverlay() *grid.Overlay
 	ModeIndicatorOverlay() *modeindicator.Overlay
 	RecursiveGridOverlay() *recursivegrid.Overlay
 	StickyModifiersOverlay() *stickyindicator.Overlay
+	VirtualPointerOverlay() *virtualpointer.Overlay
 
 	DrawHintsWithStyle(hs []*hints.Hint, style hints.StyleMode) error
 	DrawHintSearchInput(
@@ -244,6 +256,7 @@ type ManagerInterface interface {
 	HideHintSearchInput()
 	DrawModeIndicator(x, y int)
 	DrawStickyModifiersIndicator(x, y int, symbols string)
+	DrawVirtualPointer(x, y int, size int, fillColor string)
 	DrawMouseActionIndicator(point image.Point, style ports.MouseActionIndicatorStyle)
 	DrawGrid(g *domainGrid.Grid, input string, style grid.Style) error
 	DrawRecursiveGrid(


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds new actions for darwin only (at this moment) to hide cursor and show cursor.

When the cursor is hidden, it will show a virtual pointer that is less intrusive and customizabel.

Note that this requires some private API access.

```bash
neru action show_cursor
neru action hide_cursor
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/cdf74edb-44c4-4372-a2e3-2511eef6461c

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
