### PR TITLE
fix(linux,windows): ensure proper render for configured virtual pointer

### DIFF
--- a/internal/app/components/recursivegrid/component.go
+++ b/internal/app/components/recursivegrid/component.go
@@ -101,6 +101,8 @@ type VirtualPointerState struct {
 	Position  image.Point
 	Size      int
 	FillColor string
+	Char      string
+	FontName  string
 }
 
 // Reset resets the recursive_grid context to its initial state.

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -107,7 +107,13 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 					virtualPointerFillColor string
 				)
 				if showVirtualPointer {
-					virtualPointerSize, virtualPointerFillColor, showVirtualPointer = h.virtualPointerStyle()
+					vps, enabled := h.virtualPointerStyle()
+
+					showVirtualPointer = enabled
+					if enabled {
+						virtualPointerSize = vps.fontSize
+						virtualPointerFillColor = vps.fillColor
+					}
 				}
 
 				stickyPoint := h.stickyIndicatorAnchorLocked(image.Pt(cursorX, cursorY))

--- a/internal/app/modes/selection.go
+++ b/internal/app/modes/selection.go
@@ -148,7 +148,7 @@ func (h *Handler) refreshGridVirtualPointerLocked() {
 
 	point, ok := h.grid.Context.SelectionPoint()
 
-	size, fillColor, enabled := h.virtualPointerStyle()
+	style, enabled := h.virtualPointerStyle()
 	if !ok || h.grid.Context.CursorFollowSelection() || !enabled {
 		h.grid.Overlay.HideVirtualPointer()
 
@@ -156,7 +156,7 @@ func (h *Handler) refreshGridVirtualPointerLocked() {
 	}
 
 	localPoint := coordinates.ConvertToLocalCoordinates(point, h.screenBounds)
-	h.grid.Overlay.ShowVirtualPointer(localPoint, size, fillColor)
+	h.grid.Overlay.ShowVirtualPointer(localPoint, style.fontSize, style.fillColor)
 }
 
 func (h *Handler) refreshRecursiveGridVirtualPointerLocked() {
@@ -181,7 +181,7 @@ func (h *Handler) currentRecursiveGridVirtualPointerState() componentrecursivegr
 
 	point, ok := h.recursiveGrid.Context.SelectionPoint()
 
-	size, fillColor, enabled := h.virtualPointerStyle()
+	style, enabled := h.virtualPointerStyle()
 	if !ok || h.recursiveGrid.Context.CursorFollowSelection() || !enabled {
 		return componentrecursivegrid.VirtualPointerState{}
 	}
@@ -189,12 +189,21 @@ func (h *Handler) currentRecursiveGridVirtualPointerState() componentrecursivegr
 	return componentrecursivegrid.VirtualPointerState{
 		Visible:   true,
 		Position:  coordinates.ConvertToLocalCoordinates(point, h.screenBounds),
-		Size:      size,
-		FillColor: fillColor,
+		Size:      style.fontSize,
+		FillColor: style.fillColor,
+		Char:      style.char,
+		FontName:  style.fontName,
 	}
 }
 
-func (h *Handler) virtualPointerStyle() (int, string, bool) {
+type virtualPointerStyle struct {
+	fontSize  int
+	fillColor string
+	char      string
+	fontName  string
+}
+
+func (h *Handler) virtualPointerStyle() (virtualPointerStyle, bool) {
 	cfg := h.config.VirtualPointer
 
 	fillColor := cfg.UI.TextColor.ForTheme(
@@ -208,5 +217,15 @@ func (h *Handler) virtualPointerStyle() (int, string, bool) {
 		size = config.DefaultVirtualPointerFontSize
 	}
 
-	return size, fillColor, true
+	char := cfg.UI.Char
+	if char == "" {
+		char = config.DefaultVirtualPointerChar
+	}
+
+	return virtualPointerStyle{
+		fontSize:  size,
+		fillColor: fillColor,
+		char:      char,
+		fontName:  cfg.UI.FontFamily,
+	}, true
 }

--- a/internal/core/infra/platform/linux/x11_overlay.c
+++ b/internal/core/infra/platform/linux/x11_overlay.c
@@ -159,6 +159,38 @@ void neru_x11_overlay_rect(
 	cairo_restore(cr);
 }
 
+static void neru_x11_overlay_rounded_path(cairo_t *cr, double x, double y, double width, double height, double radius) {
+	double max_radius = (width < height ? width : height) / 2.0;
+	if (radius > max_radius)
+		radius = max_radius;
+	if (radius <= 0) {
+		cairo_rectangle(cr, x, y, width, height);
+		return;
+	}
+
+	const double deg = 0.0174532925199432957692;
+	cairo_new_sub_path(cr);
+	cairo_arc(cr, x + width - radius, y + radius, radius, -90.0 * deg, 0.0 * deg);
+	cairo_arc(cr, x + width - radius, y + height - radius, radius, 0.0 * deg, 90.0 * deg);
+	cairo_arc(cr, x + radius, y + height - radius, radius, 90.0 * deg, 180.0 * deg);
+	cairo_arc(cr, x + radius, y + radius, radius, 180.0 * deg, 270.0 * deg);
+	cairo_close_path(cr);
+}
+
+void neru_x11_overlay_rounded_rect(
+    NeruX11Overlay *overlay, double x, double y, double width, double height, double radius, unsigned int fill,
+    unsigned int stroke, double stroke_width) {
+	cairo_t *cr = overlay->cr;
+	cairo_save(cr);
+	neru_x11_overlay_rounded_path(cr, x, y, width, height, radius);
+	neru_x11_overlay_color(cr, fill);
+	cairo_fill_preserve(cr);
+	neru_x11_overlay_color(cr, stroke);
+	cairo_set_line_width(cr, stroke_width);
+	cairo_stroke(cr);
+	cairo_restore(cr);
+}
+
 void neru_x11_overlay_text(
     NeruX11Overlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
     unsigned int color) {

--- a/internal/core/infra/platform/linux/x11_overlay.h
+++ b/internal/core/infra/platform/linux/x11_overlay.h
@@ -27,6 +27,9 @@ void neru_x11_overlay_resize(NeruX11Overlay *overlay);
 void neru_x11_overlay_rect(
     NeruX11Overlay *overlay, double x, double y, double width, double height, unsigned int fill, unsigned int stroke,
     double stroke_width);
+void neru_x11_overlay_rounded_rect(
+    NeruX11Overlay *overlay, double x, double y, double width, double height, double radius, unsigned int fill,
+    unsigned int stroke, double stroke_width);
 void neru_x11_overlay_text(
     NeruX11Overlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
     unsigned int color);

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -25,6 +25,7 @@ import (
 	"github.com/y3owk1n/neru/internal/core/domain/recursivegrid"
 	_ "github.com/y3owk1n/neru/internal/core/infra/platform/linux"
 	_ "github.com/y3owk1n/neru/internal/core/infra/platform/linux/wlr_protocol"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 type wlrootsOverlay struct {
@@ -261,13 +262,29 @@ func (o *wlrootsOverlay) DrawRecursiveGridWithSubKeyPreview(
 	}
 
 	if virtualPointer.Visible {
+		vpChar := virtualPointer.Char
+		if vpChar == "" {
+			vpChar = "\u25CF"
+		}
+
+		fontName := ports.ResolveFont(virtualPointer.FontName, false)
+
+		fontSize := float64(virtualPointer.Size)
+		halfSize := max(virtualPointer.Size/2, 1) //nolint:mnd
+
 		vpBounds := image.Rect(
-			virtualPointer.Position.X-virtualPointer.Size/2,
-			virtualPointer.Position.Y-virtualPointer.Size/2,
-			virtualPointer.Position.X+virtualPointer.Size/2,
-			virtualPointer.Position.Y+virtualPointer.Size/2,
+			virtualPointer.Position.X-halfSize,
+			virtualPointer.Position.Y-halfSize,
+			virtualPointer.Position.X+halfSize,
+			virtualPointer.Position.Y+halfSize,
 		)
-		o.drawRect(vpBounds, parseHexColor(virtualPointer.FillColor), style.LineColor, 1)
+		o.drawTextCentered(
+			vpChar,
+			vpBounds,
+			fontName,
+			fontSize,
+			parseHexColor(virtualPointer.FillColor),
+		)
 	}
 
 	C.neru_wayland_overlay_flush(o.raw)

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -22,6 +22,7 @@ import (
 	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
 	"github.com/y3owk1n/neru/internal/core/domain/recursivegrid"
 	_ "github.com/y3owk1n/neru/internal/core/infra/platform/linux"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 type x11Overlay struct {
@@ -215,17 +216,28 @@ func (o *x11Overlay) DrawRecursiveGridWithSubKeyPreview(
 	}
 
 	if virtualPointer.Visible {
+		vpChar := virtualPointer.Char
+		if vpChar == "" {
+			vpChar = "\u25CF"
+		}
+
+		fontName := ports.ResolveFont(virtualPointer.FontName, false)
+
+		fontSize := float64(virtualPointer.Size)
+		halfSize := max(virtualPointer.Size/2, 1) //nolint:mnd
+
 		vpBounds := image.Rect(
-			virtualPointer.Position.X-virtualPointer.Size/2,
-			virtualPointer.Position.Y-virtualPointer.Size/2,
-			virtualPointer.Position.X+virtualPointer.Size/2,
-			virtualPointer.Position.Y+virtualPointer.Size/2,
+			virtualPointer.Position.X-halfSize,
+			virtualPointer.Position.Y-halfSize,
+			virtualPointer.Position.X+halfSize,
+			virtualPointer.Position.Y+halfSize,
 		)
-		o.drawRect(
+		o.drawTextCentered(
+			vpChar,
 			vpBounds,
+			fontName,
+			fontSize,
 			parseHexColor(virtualPointer.FillColor),
-			style.LineColor,
-			subgridLineWidth,
 		)
 	}
 
@@ -408,6 +420,26 @@ func (o *x11Overlay) drawRect(
 		C.double(bounds.Min.Y),
 		C.double(bounds.Dx()),
 		C.double(bounds.Dy()),
+		C.uint(fill),
+		C.uint(border),
+		C.double(lineWidth),
+	)
+}
+
+func (o *x11Overlay) drawRoundedRect(
+	bounds image.Rectangle,
+	radius float64,
+	fill uint32,
+	border uint32,
+	lineWidth float64,
+) {
+	C.neru_x11_overlay_rounded_rect(
+		o.raw,
+		C.double(bounds.Min.X),
+		C.double(bounds.Min.Y),
+		C.double(bounds.Dx()),
+		C.double(bounds.Dy()),
+		C.double(radius),
 		C.uint(fill),
 		C.uint(border),
 		C.double(lineWidth),

--- a/internal/ui/overlay/manager_windows_features.go
+++ b/internal/ui/overlay/manager_windows_features.go
@@ -225,18 +225,28 @@ func (o *winOverlay) DrawRecursiveGrid(
 	}
 
 	if virtualPointer.Visible {
+		vpChar := virtualPointer.Char
+		if vpChar == "" {
+			vpChar = "\u25CF"
+		}
+
+		fontName := ports.ResolveFont(virtualPointer.FontName, false)
+
+		fontSize := float64(virtualPointer.Size)
+		halfSize := max(virtualPointer.Size/2, 1) //nolint:mnd
+
 		vpBounds := image.Rect(
-			virtualPointer.Position.X-virtualPointer.Size/2,
-			virtualPointer.Position.Y-virtualPointer.Size/2,
-			virtualPointer.Position.X+virtualPointer.Size/2,
-			virtualPointer.Position.Y+virtualPointer.Size/2,
+			virtualPointer.Position.X-halfSize,
+			virtualPointer.Position.Y-halfSize,
+			virtualPointer.Position.X+halfSize,
+			virtualPointer.Position.Y+halfSize,
 		)
-		o.drawFilledRect(
+		o.drawTextCentered(
+			vpChar,
 			vpBounds,
+			fontName,
+			fontSize,
 			parseHexColorARGB(virtualPointer.FillColor),
-			style.LineColor,
-			winSubgridLineWidth,
-			0,
 		)
 	}
 

--- a/internal/ui/overlay/manager_windows_features.go
+++ b/internal/ui/overlay/manager_windows_features.go
@@ -19,14 +19,11 @@ import (
 )
 
 const (
-	winSubgridLineWidth = 1
-
-	winHexColorOpaque     = 0xFFFFFFFF
-	winHexRepeatCount     = 2
-	winHexColorLenShort   = 3
-	winHexColorLenNoAlpha = 6
-	winHexColorLenFull    = 8
-
+	winHexColorOpaque                  = 0xFFFFFFFF
+	winHexRepeatCount                  = 2
+	winHexColorLenShort                = 3
+	winHexColorLenNoAlpha              = 6
+	winHexColorLenFull                 = 8
 	winAutoPaddingHorizontalMultiplier = 0.6
 	winAutoPaddingVerticalMultiplier   = 0.35
 	winAutoPaddingMinHorizontal        = 6
@@ -36,11 +33,10 @@ const (
 	winCenteredRectDivisor             = 2
 	winPaddingMultiplier               = 2
 	winSubKeyPreviewPaddingBottom      = 4
-
-	winAutoRadiusBadgeCap           = 6.0
-	winAutoRadiusBoundaryCap        = 4.0
-	winMouseActionSquareRadiusScale = 0.18
-	winMouseActionMinSquareRadius   = 2.0
+	winAutoRadiusBadgeCap              = 6.0
+	winAutoRadiusBoundaryCap           = 4.0
+	winMouseActionSquareRadiusScale    = 0.18
+	winMouseActionMinSquareRadius      = 2.0
 )
 
 // DrawHints renders the hint overlay using GDI, mirroring the cross-platform


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR ensures that on windows and linux ports, we properly render the configured virtual pointers by also passing the configured styles, font names and so on.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A