### PR TITLE
refactor(darwin): extract common grid cell border drawing into helper

### DIFF
--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -273,6 +273,10 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 
 /// Resolve vertical hint padding (-1 = auto based on font size).
 - (CGFloat)resolvedHintPaddingY;
+
+/// Draw a grid cell border with edge-clipping at the view boundary.
+/// cellRect must be in view (flipped) coordinates.
+- (void)drawGridCellBorder:(NSRect)cellRect isMatched:(BOOL)isMatched screenWidth:(CGFloat)screenWidth;
 @end
 
 #pragma mark - Overlay View Implementation
@@ -1428,23 +1432,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 		NSRectFill(cellRect);
 
 		// Draw border
-		NSColor *borderColor =
-		    isMatched && self.gridMatchedBorderColor ? self.gridMatchedBorderColor : self.gridBorderColor;
-		[borderColor setStroke];
-		NSRect borderRect = cellRect;
-		if ((int)self.gridBorderWidth % 2 == 1) {
-			borderRect = NSOffsetRect(cellRect, 0.5, -0.5);
-		}
-		if (NSMaxX(cellRect) >= screenWidth) {
-			borderRect.size.width -= 1.0;
-		}
-		if (NSMinY(cellRect) <= 0) {
-			borderRect.origin.y += ceil(self.gridBorderWidth / 2.0);
-			borderRect.size.height -= ceil(self.gridBorderWidth / 2.0);
-		}
-		NSBezierPath *borderPath = [NSBezierPath bezierPathWithRect:borderRect];
-		[borderPath setLineWidth:self.gridBorderWidth];
-		[borderPath stroke];
+		[self drawGridCellBorder:cellRect isMatched:isMatched screenWidth:screenWidth];
 
 		// Draw label
 		if (label && [label length] > 0) {
@@ -1469,6 +1457,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 
 	BOOL filterByRect = !NSIsEmptyRect(dirtyRect);
 	CGFloat screenHeight = self.bounds.size.height;
+	CGFloat screenWidth = self.bounds.size.width;
 	CGRect fromBounds = CGRectNull;
 	CGRect toBounds = CGRectNull;
 
@@ -1506,14 +1495,7 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 		[bgBase setFill];
 		NSRectFill(cellRect);
 
-		[self.gridBorderColor setStroke];
-		NSRect borderRect = cellRect;
-		if ((int)self.gridBorderWidth % 2 == 1) {
-			borderRect = NSOffsetRect(cellRect, 0.5, -0.5);
-		}
-		NSBezierPath *borderPath = [NSBezierPath bezierPathWithRect:borderRect];
-		[borderPath setLineWidth:self.gridBorderWidth];
-		[borderPath stroke];
+		[self drawGridCellBorder:cellRect isMatched:NO screenWidth:screenWidth];
 
 		NSString *fromLabel = fromCell.label ?: @"";
 		NSString *toLabel = toCell.label ?: fromLabel;
@@ -1537,6 +1519,29 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 			[self drawGridLabel:toLabel inCellRect:cellRect isMatched:NO matchedPrefixLength:0 alpha:progress];
 		}
 	}
+}
+
+/// Draw a grid cell border with edge-clipping at the view boundary.
+/// cellRect must be in view (flipped) coordinates.
+- (void)drawGridCellBorder:(NSRect)cellRect isMatched:(BOOL)isMatched screenWidth:(CGFloat)screenWidth {
+	NSColor *borderColor =
+	    isMatched && self.gridMatchedBorderColor ? self.gridMatchedBorderColor : self.gridBorderColor;
+	[borderColor setStroke];
+
+	NSRect borderRect = cellRect;
+	if ((int)self.gridBorderWidth % 2 == 1) {
+		borderRect = NSOffsetRect(cellRect, 0.5, -0.5);
+	}
+	if (NSMaxX(cellRect) >= screenWidth) {
+		borderRect.size.width -= 1.0;
+	}
+	if (NSMinY(cellRect) <= 0) {
+		borderRect.origin.y += ceil(self.gridBorderWidth / 2.0);
+		borderRect.size.height -= ceil(self.gridBorderWidth / 2.0);
+	}
+	NSBezierPath *borderPath = [NSBezierPath bezierPathWithRect:borderRect];
+	[borderPath setLineWidth:self.gridBorderWidth];
+	[borderPath stroke];
 }
 
 /// Draw a grid label centered in the cell, optionally with a rounded badge.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR extracts the duplicated grid cell border drawing logic into a shared helper method, so that we don't have to always update for both animated and non animated path when things changes.

Nothing sohuld change, or else it's a bug.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
