### PR TITLE
fix(darwin): auto-rehide cursor when macOS reveal it

### DIFF
--- a/internal/app/modes/cursor_visibility.go
+++ b/internal/app/modes/cursor_visibility.go
@@ -1,6 +1,8 @@
 package modes
 
 import (
+	"time"
+
 	"github.com/y3owk1n/neru/internal/core/domain"
 )
 
@@ -77,6 +79,34 @@ func (h *Handler) shouldPollCursorOverlaysLocked(mode domain.Mode) bool {
 	}
 
 	return h.shouldShowCursorFollowingVirtualPointerLocked()
+}
+
+// cursorRehideInterval is the minimum interval between automatic cursor re-hide
+// calls in the indicator polling loop. This prevents excessive main-queue
+// dispatches while ensuring the cursor is re-hidden within ~500ms after
+// macOS reveals it (e.g. right-click context menus, Mission Control).
+const cursorRehideInterval = 500 * time.Millisecond
+
+// rehideSystemCursor re-hides the system cursor if it may have been
+// revealed by a system event (right-click, Mission Control, Exposé, etc.).
+// Uses TryLock internally to avoid deadlocks with the polling goroutine.
+// Respects the rate limit defined by cursorRehideInterval.
+func (h *Handler) rehideSystemCursor() {
+	if !h.mu.TryLock() {
+		return
+	}
+	defer h.mu.Unlock()
+
+	if !h.systemCursorHidden {
+		return
+	}
+
+	if time.Since(h.lastCursorRehideTime) < cursorRehideInterval {
+		return
+	}
+
+	h.lastCursorRehideTime = time.Now()
+	h.RehideSystemCursor()
 }
 
 func (h *Handler) hideCursorFollowingVirtualPointerLocked() {

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -126,6 +126,10 @@ type Handler struct {
 	// systemCursorHidden tracks whether hide_cursor (or hints virtual pointer) is active.
 	systemCursorHidden bool
 
+	// lastCursorRehideTime records the last time RehideSystemCursor was called
+	// to avoid excessive re-hide calls in the polling loop.
+	lastCursorRehideTime time.Time
+
 	// Cycle hint state
 	cycleHintIndex int
 

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -207,6 +207,10 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 					vp.Clear()
 				}
 
+				// Re-hide the system cursor if macOS revealed it (e.g. right-click
+				// context menu, Mission Control, Exposé). Rate-limited to ~2 Hz.
+				h.rehideSystemCursor()
+
 				// Flush indicator draws atomically to avoid intermediate buffer
 				// states appearing between overlay updates.
 				h.overlayManager.Flush()


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR ensures that we have a lightweight polling to always rehide the system cursor (if it's suppose to be hidden). There are certain cases where macOS will auto unhide the cursor, e.g. right click, enter mission control or more.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
