### PR TITLE
fix(linux): ensure subkey preview autohide checks the subcell dimensions

### DIFF
--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -1008,6 +1008,8 @@ func shouldShowLabel(
 func shouldShowSubKeyPreview(
 	cell image.Rectangle,
 	style recursivegrid.Style,
+	subGridCols int,
+	subGridRows int,
 ) bool {
 	if !style.SubKeyPreview {
 		return false
@@ -1018,8 +1020,10 @@ func shouldShowSubKeyPreview(
 	}
 
 	threshold := style.SubKeyPreviewFontSize * style.SubKeyPreviewAutohideMultiplier
+	subCellW := float64(cell.Dx()) / float64(subGridCols)
+	subCellH := float64(cell.Dy()) / float64(subGridRows)
 
-	return float64(cell.Dx()) >= threshold && float64(cell.Dy()) >= threshold
+	return subCellW >= threshold && subCellH >= threshold
 }
 
 func parseHexColor(value string) uint32 {

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -249,7 +249,7 @@ func (o *wlrootsOverlay) DrawRecursiveGridWithSubKeyPreview(
 				)
 			}
 
-			if drawSubPreview && shouldShowSubKeyPreview(cell, style) {
+			if drawSubPreview && shouldShowSubKeyPreview(cell, style, nextGridCols, nextGridRows) {
 				o.drawSubKeyMiniGrid(
 					cell,
 					nextKeyRunes,

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -203,7 +203,7 @@ func (o *x11Overlay) DrawRecursiveGridWithSubKeyPreview(
 				)
 			}
 
-			if drawSubPreview && shouldShowSubKeyPreview(cell, style) {
+			if drawSubPreview && shouldShowSubKeyPreview(cell, style, nextGridCols, nextGridRows) {
 				o.drawSubKeyMiniGrid(
 					cell,
 					nextKeyRunes,


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes the issue where on linux, the sub key preview autohide are wrongly calculated, hence, it will never be hidden as expected.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A