### PR TITLE
feat(overlay): add configurable text outline and strokes

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -108,6 +108,8 @@ padding_x = -1                              # -1 = auto based on font size
 padding_y = -1                              # -1 = auto based on font size
 border_width = 1
 placement = "bottom"                        # top, center, bottom
+text_outline_color = ""                     # Empty = no outline
+text_outline_width = 0                      # 0 = no outline (positive = stroke width)
 
 [hints.search_input_ui]
 font_size = 10
@@ -177,6 +179,8 @@ enable_gc = false                           # Periodic memory cleanup (adds CPU 
 font_size = 10
 font_family = ""
 border_width = 1
+text_outline_color = ""
+text_outline_width = 0
 
 # Recursive grid mode (recommended)
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#recursive_grid
@@ -223,6 +227,10 @@ sub_key_preview = false                     # Draw miniature key grid inside eac
 sub_key_preview_font_size = 8
 sub_key_preview_autohide_multiplier = 1.5
 sub_key_preview_label_char = ""             # Override sub-key preview labels with a single character (e.g. "·"); empty = use key
+text_outline_color = ""                     # Empty = no outline
+text_outline_width = 0                      # 0 = no outline (positive = stroke width)
+sub_key_preview_text_outline_color = ""     # Sub-key preview text outline color
+sub_key_preview_text_outline_width = 0      # Sub-key preview text outline width
 
 # Virtual pointer
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#virtual_pointer
@@ -230,6 +238,8 @@ sub_key_preview_label_char = ""             # Override sub-key preview labels wi
 char = "●"             # Character to display (e.g. "•", "●", "◉", "⬤") or anything you like
 font_size = 8
 font_family = ""
+text_outline_color = ""
+text_outline_width = 0
 
 # Mouse action indicator (macOS)
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#mouse_action_indicator
@@ -266,6 +276,8 @@ padding_x = -1                                 # Badge horizontal padding (-1 = 
 padding_y = -1                                 # Badge vertical padding (-1 = auto)
 border_width = 0                               # Badge border width
 backdrop_color = ""                            # Per-monitor tint backdrop
+text_outline_color = ""                        # Empty = no outline
+text_outline_width = 0                         # 0 = no outline (positive = stroke width)
 
 [monitor_select.hotkeys]
 "Escape" = "idle"
@@ -307,22 +319,27 @@ invert_scroll = false                       # Invert scroll direction (for tools
 [mode_indicator.scroll]
 enabled = true
 text = "Scroll"
+text_outline_color = ""
 
 [mode_indicator.hints]
 enabled = false
 text = "Hints"
+text_outline_color = ""
 
 [mode_indicator.grid]
 enabled = false
 text = "Grid"
+text_outline_color = ""
 
 [mode_indicator.recursive_grid]
 enabled = false
 text = "Recursive Grid"
+text_outline_color = ""
 
 [mode_indicator.monitor_select]
 enabled = false
 text = "Monitor Select"
+text_outline_color = ""
 
 [mode_indicator.ui]
 font_size = 10
@@ -333,6 +350,8 @@ padding_y = -1
 border_radius = -1
 indicator_x_offset = 20
 indicator_y_offset = 20
+text_outline_color = ""
+text_outline_width = 0
 
 # Sticky modifiers
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#sticky_modifiers
@@ -349,6 +368,8 @@ padding_y = -1
 border_radius = -1
 indicator_x_offset = -40
 indicator_y_offset = 20
+text_outline_color = ""
+text_outline_width = 0
 
 # Smooth cursor (animates cursor movement between positions)
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#smooth_cursor

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -426,6 +426,8 @@ Start with search visible: `neru hints --search` (see [CLI.md](CLI.md#hints-mode
 | `text_color`         | color  | derived    | Text color                                 |
 | `matched_text_color` | color  | derived    | Text color for matched characters          |
 | `border_color`       | color  | derived    | Border color                               |
+| `text_outline_color` | color  | `""`       | Text outline color (empty = no outline)    |
+| `text_outline_width` | int    | `0`        | Text outline width in pixels (0 = none)    |
 
 ```toml
 [hints.ui]
@@ -591,17 +593,19 @@ Cursor behavior is chosen per invocation: `neru grid --cursor-selection-mode fol
 
 ### UI
 
-| Option                     | Type   | Default | Description                          |
-| -------------------------- | ------ | ------- | ------------------------------------ |
-| `font_size`                | int    | `10`    | Font size in points                  |
-| `font_family`              | string | `""`    | Font family (empty = system default) |
-| `border_width`             | int    | `1`     | Border width in pixels               |
-| `background_color`         | color  | derived | Cell background                      |
-| `text_color`               | color  | derived | Label text                           |
-| `matched_text_color`       | color  | derived | Matched cell text                    |
-| `matched_background_color` | color  | derived | Matched cell background              |
-| `matched_border_color`     | color  | derived | Matched cell border                  |
-| `border_color`             | color  | derived | Default cell border                  |
+| Option                     | Type   | Default | Description                             |
+| -------------------------- | ------ | ------- | --------------------------------------- |
+| `font_size`                | int    | `10`    | Font size in points                     |
+| `font_family`              | string | `""`    | Font family (empty = system default)    |
+| `border_width`             | int    | `1`     | Border width in pixels                  |
+| `background_color`         | color  | derived | Cell background                         |
+| `text_color`               | color  | derived | Label text                              |
+| `matched_text_color`       | color  | derived | Matched cell text                       |
+| `matched_background_color` | color  | derived | Matched cell background                 |
+| `matched_border_color`     | color  | derived | Matched cell border                     |
+| `border_color`             | color  | derived | Default cell border                     |
+| `text_outline_color`       | color  | `""`    | Text outline color (empty = no outline) |
+| `text_outline_width`       | int    | `0`     | Text outline width in pixels (0 = none) |
 
 ```toml
 [grid.ui]
@@ -689,6 +693,10 @@ layers = [
 | `sub_key_preview_autohide_multiplier` | float  | `1.5`   | Autohide threshold multiplier                                                |
 | `sub_key_preview_text_color`          | color  | derived | Sub-key preview text color                                                   |
 | `sub_key_preview_label_char`          | string | `""`    | Override sub-key labels with a single character (e.g. `·`); empty = use key  |
+| `text_outline_color`                  | color  | `""`    | Text outline color (empty = no outline)                                      |
+| `text_outline_width`                  | int    | `0`     | Text outline width in pixels (0 = none)                                      |
+| `sub_key_preview_text_outline_color`  | color  | `""`    | Sub-key preview text outline color                                           |
+| `sub_key_preview_text_outline_width`  | int    | `0`     | Sub-key preview text outline width in px                                     |
 
 ```toml
 [recursive_grid.ui]
@@ -772,22 +780,24 @@ Interactive display picking mode. Shows per-monitor overlay badges labelled with
 
 ### UI
 
-| Key                    | Default       | Description                       |
-| ---------------------- | ------------- | --------------------------------- |
-| `font_size`            | `96`          | Badge label font size             |
-| `font_family`          | `""` (system) | Badge label font family           |
-| `subtitle_font_size`   | `18`          | Monitor name subtitle font size   |
-| `subtitle_font_family` | `""` (system) | Subtitle font family              |
-| `border_radius`        | `-1` (auto)   | Badge corner radius               |
-| `padding_x`            | `-1` (auto)   | Horizontal padding                |
-| `padding_y`            | `-1` (auto)   | Vertical padding                  |
-| `border_width`         | `0`           | Badge border width                |
-| `background_color`     | derived       | Badge fill color                  |
-| `text_color`           | derived       | Label text color                  |
-| `matched_text_color`   | derived       | Partially-typed label text color  |
-| `border_color`         | derived       | Badge border color                |
-| `backdrop_color`       | `""` (none)   | Per-monitor overlay backdrop tint |
-| `subtitle_text_color`  | derived       | Subtitle text color               |
+| Key                    | Default       | Description                             |
+| ---------------------- | ------------- | --------------------------------------- |
+| `font_size`            | `96`          | Badge label font size                   |
+| `font_family`          | `""` (system) | Badge label font family                 |
+| `subtitle_font_size`   | `18`          | Monitor name subtitle font size         |
+| `subtitle_font_family` | `""` (system) | Subtitle font family                    |
+| `border_radius`        | `-1` (auto)   | Badge corner radius                     |
+| `padding_x`            | `-1` (auto)   | Horizontal padding                      |
+| `padding_y`            | `-1` (auto)   | Vertical padding                        |
+| `border_width`         | `0`           | Badge border width                      |
+| `background_color`     | derived       | Badge fill color                        |
+| `text_color`           | derived       | Label text color                        |
+| `matched_text_color`   | derived       | Partially-typed label text color        |
+| `border_color`         | derived       | Badge border color                      |
+| `backdrop_color`       | `""` (none)   | Per-monitor overlay backdrop tint       |
+| `text_outline_color`   | `""`          | Text outline color (empty = no outline) |
+| `text_outline_width`   | `0`           | Text outline width in pixels (0 = none) |
+| `subtitle_text_color`  | derived       | Subtitle text color                     |
 
 ### Hotkeys
 
@@ -823,12 +833,14 @@ A small character rendered at the cursor when the system cursor is hidden. macOS
 
 ### UI
 
-| Option        | Type   | Default | Description                  |
-| ------------- | ------ | ------- | ---------------------------- |
-| `char`        | string | `"●"`   | Character to display         |
-| `font_size`   | int    | `8`     | Font size in points          |
-| `font_family` | string | `""`    | Font family (empty = system) |
-| `text_color`  | color  | derived | Character color              |
+| Option               | Type   | Default | Description                             |
+| -------------------- | ------ | ------- | --------------------------------------- |
+| `char`               | string | `"●"`   | Character to display                    |
+| `font_size`          | int    | `8`     | Font size in points                     |
+| `font_family`        | string | `""`    | Font family (empty = system)            |
+| `text_color`         | color  | derived | Character color                         |
+| `text_outline_color` | color  | `""`    | Text outline color (empty = no outline) |
+| `text_outline_width` | int    | `0`     | Text outline width in pixels (0 = none) |
 
 ```toml
 [virtual_pointer.ui]
@@ -891,13 +903,14 @@ A floating label that follows the cursor and displays the current mode name.
 
 ### Per-Mode
 
-| Option             | Type   | Default        | Description                       |
-| ------------------ | ------ | -------------- | --------------------------------- |
-| `enabled`          | bool   | varies by mode | Show/hide indicator for this mode |
-| `text`             | string | varies by mode | Label text                        |
-| `background_color` | color  | derived        | Override background color         |
-| `text_color`       | color  | derived        | Override text color               |
-| `border_color`     | color  | derived        | Override border color             |
+| Option               | Type   | Default        | Description                                          |
+| -------------------- | ------ | -------------- | ---------------------------------------------------- |
+| `enabled`            | bool   | varies by mode | Show/hide indicator for this mode                    |
+| `text`               | string | varies by mode | Label text                                           |
+| `background_color`   | color  | derived        | Override background color                            |
+| `text_color`         | color  | derived        | Override text color                                  |
+| `border_color`       | color  | derived        | Override border color                                |
+| `text_outline_color` | color  | `""`           | Text outline color override (empty = use ui default) |
 
 ```toml
 [mode_indicator.scroll]
@@ -936,6 +949,8 @@ text = "Monitor Select"
 | `border_radius`      | int    | `-1`    | Corner radius (-1 = auto)               |
 | `indicator_x_offset` | int    | `20`    | X offset from cursor (positive = right) |
 | `indicator_y_offset` | int    | `20`    | Y offset from cursor (positive = down)  |
+| `text_outline_color` | color  | `""`    | Text outline color (empty = no outline) |
+| `text_outline_width` | int    | `0`     | Text outline width in pixels (0 = none) |
 
 ```toml
 [mode_indicator.ui]
@@ -961,19 +976,21 @@ Tap modifiers inside a mode to make them sticky for subsequent actions.
 
 ### UI
 
-| Option               | Type   | Default | Description                            |
-| -------------------- | ------ | ------- | -------------------------------------- |
-| `font_size`          | int    | `10`    | Font size                              |
-| `font_family`        | string | `""`    | Font family (empty = system default)   |
-| `background_color`   | color  | derived | Background with alpha                  |
-| `text_color`         | color  | derived | Text color                             |
-| `border_color`       | color  | derived | Border color                           |
-| `border_width`       | int    | `1`     | Border width                           |
-| `padding_x`          | int    | `-1`    | Horizontal padding (-1 = auto)         |
-| `padding_y`          | int    | `-1`    | Vertical padding (-1 = auto)           |
-| `border_radius`      | int    | `-1`    | Corner radius (-1 = auto)              |
-| `indicator_x_offset` | int    | `-40`   | X offset from cursor (negative = left) |
-| `indicator_y_offset` | int    | `20`    | Y offset from cursor (down)            |
+| Option               | Type   | Default | Description                             |
+| -------------------- | ------ | ------- | --------------------------------------- |
+| `font_size`          | int    | `10`    | Font size                               |
+| `font_family`        | string | `""`    | Font family (empty = system default)    |
+| `background_color`   | color  | derived | Background with alpha                   |
+| `text_color`         | color  | derived | Text color                              |
+| `border_color`       | color  | derived | Border color                            |
+| `border_width`       | int    | `1`     | Border width                            |
+| `padding_x`          | int    | `-1`    | Horizontal padding (-1 = auto)          |
+| `padding_y`          | int    | `-1`    | Vertical padding (-1 = auto)            |
+| `border_radius`      | int    | `-1`    | Corner radius (-1 = auto)               |
+| `indicator_x_offset` | int    | `-40`   | X offset from cursor (negative = left)  |
+| `indicator_y_offset` | int    | `20`    | Y offset from cursor (down)             |
+| `text_outline_color` | color  | `""`    | Text outline color (empty = no outline) |
+| `text_outline_width` | int    | `0`     | Text outline width in pixels (0 = none) |
 
 ```toml
 [sticky_modifiers]

--- a/internal/app/components/grid/overlay_darwin.go
+++ b/internal/app/components/grid/overlay_darwin.go
@@ -519,6 +519,7 @@ func (o *Overlay) ShowSubgrid(cell *domainGrid.Cell, style Style) {
 		cached.BgColor = unsafe.Pointer(C.CString(style.BackgroundColor()))
 		cached.TextColor = unsafe.Pointer(C.CString(style.TextColor()))
 		cached.MatchedTextColor = unsafe.Pointer(C.CString(style.MatchedTextColor()))
+		cached.TextOutlineColor = unsafe.Pointer(C.CString(style.TextOutlineColor()))
 		cached.MatchedBgColor = unsafe.Pointer(C.CString(style.MatchedBackgroundColor()))
 		cached.MatchedBorderColor = unsafe.Pointer(C.CString(style.MatchedBorderColor()))
 		cached.BorderColor = unsafe.Pointer(C.CString(style.BorderColor()))
@@ -530,6 +531,8 @@ func (o *Overlay) ShowSubgrid(cell *domainGrid.Cell, style Style) {
 		backgroundColor:        (*C.char)(cachedStyle.BgColor),
 		textColor:              (*C.char)(cachedStyle.TextColor),
 		matchedTextColor:       (*C.char)(cachedStyle.MatchedTextColor),
+		textOutlineColor:       (*C.char)(cachedStyle.TextOutlineColor),
+		textOutlineWidth:       C.int(style.TextOutlineWidth()),
 		matchedBackgroundColor: (*C.char)(cachedStyle.MatchedBgColor),
 		matchedBorderColor:     (*C.char)(cachedStyle.MatchedBorderColor),
 		borderColor:            (*C.char)(cachedStyle.BorderColor),
@@ -755,6 +758,7 @@ func (o *Overlay) drawGridIncrementalStructural(
 		cached.BgColor = unsafe.Pointer(C.CString(currentStyle.BackgroundColor()))
 		cached.TextColor = unsafe.Pointer(C.CString(currentStyle.TextColor()))
 		cached.MatchedTextColor = unsafe.Pointer(C.CString(currentStyle.MatchedTextColor()))
+		cached.TextOutlineColor = unsafe.Pointer(C.CString(currentStyle.TextOutlineColor()))
 		cached.MatchedBgColor = unsafe.Pointer(C.CString(currentStyle.MatchedBackgroundColor()))
 		cached.MatchedBorderColor = unsafe.Pointer(C.CString(currentStyle.MatchedBorderColor()))
 		cached.BorderColor = unsafe.Pointer(C.CString(currentStyle.BorderColor()))
@@ -766,6 +770,8 @@ func (o *Overlay) drawGridIncrementalStructural(
 		backgroundColor:        (*C.char)(cachedStyle.BgColor),
 		textColor:              (*C.char)(cachedStyle.TextColor),
 		matchedTextColor:       (*C.char)(cachedStyle.MatchedTextColor),
+		textOutlineColor:       (*C.char)(cachedStyle.TextOutlineColor),
+		textOutlineWidth:       C.int(currentStyle.TextOutlineWidth()),
 		matchedBackgroundColor: (*C.char)(cachedStyle.MatchedBgColor),
 		matchedBorderColor:     (*C.char)(cachedStyle.MatchedBorderColor),
 		borderColor:            (*C.char)(cachedStyle.BorderColor),
@@ -983,6 +989,7 @@ func (o *Overlay) drawGridCells(cellsGo []*domainGrid.Cell, currentInput string,
 		cached.BgColor = unsafe.Pointer(C.CString(style.BackgroundColor()))
 		cached.TextColor = unsafe.Pointer(C.CString(style.TextColor()))
 		cached.MatchedTextColor = unsafe.Pointer(C.CString(style.MatchedTextColor()))
+		cached.TextOutlineColor = unsafe.Pointer(C.CString(style.TextOutlineColor()))
 		cached.MatchedBgColor = unsafe.Pointer(C.CString(style.MatchedBackgroundColor()))
 		cached.MatchedBorderColor = unsafe.Pointer(C.CString(style.MatchedBorderColor()))
 		cached.BorderColor = unsafe.Pointer(C.CString(style.BorderColor()))
@@ -994,6 +1001,8 @@ func (o *Overlay) drawGridCells(cellsGo []*domainGrid.Cell, currentInput string,
 		backgroundColor:        (*C.char)(cachedStyle.BgColor),
 		textColor:              (*C.char)(cachedStyle.TextColor),
 		matchedTextColor:       (*C.char)(cachedStyle.MatchedTextColor),
+		textOutlineColor:       (*C.char)(cachedStyle.TextOutlineColor),
+		textOutlineWidth:       C.int(style.TextOutlineWidth()),
 		matchedBackgroundColor: (*C.char)(cachedStyle.MatchedBgColor),
 		matchedBorderColor:     (*C.char)(cachedStyle.MatchedBorderColor),
 		borderColor:            (*C.char)(cachedStyle.BorderColor),
@@ -1030,6 +1039,8 @@ type Style struct {
 	backgroundColor        string
 	textColor              string
 	matchedTextColor       string
+	textOutlineColor       string
+	textOutlineWidth       int
 	matchedBackgroundColor string
 	matchedBorderColor     string
 	borderColor            string
@@ -1063,6 +1074,16 @@ func (s Style) TextColor() string {
 // MatchedTextColor returns the matched text color.
 func (s Style) MatchedTextColor() string {
 	return s.matchedTextColor
+}
+
+// TextOutlineColor returns the text outline color.
+func (s Style) TextOutlineColor() string {
+	return s.textOutlineColor
+}
+
+// TextOutlineWidth returns the text outline width.
+func (s Style) TextOutlineWidth() int {
+	return s.textOutlineWidth
 }
 
 // MatchedBackgroundColor returns the matched background color.
@@ -1101,6 +1122,12 @@ func BuildStyle(cfg config.GridConfig, theme config.ThemeProvider) Style {
 			config.GridMatchedTextColorLight,
 			config.GridMatchedTextColorDark,
 		),
+		textOutlineColor: cfg.UI.TextOutlineColor.ForTheme(
+			theme,
+			"",
+			"",
+		),
+		textOutlineWidth: cfg.UI.TextOutlineWidth,
 		matchedBackgroundColor: cfg.UI.MatchedBackgroundColor.ForTheme(
 			theme,
 			config.GridMatchedBackgroundColorLight,

--- a/internal/app/components/grid/overlay_linux_common.go
+++ b/internal/app/components/grid/overlay_linux_common.go
@@ -163,6 +163,7 @@ func parseOptionalColor(value string) uint32 {
 	if value == "" {
 		return 0
 	}
+
 	return parseLinuxColor(value)
 }
 

--- a/internal/app/components/grid/overlay_linux_common.go
+++ b/internal/app/components/grid/overlay_linux_common.go
@@ -36,6 +36,8 @@ type Style struct {
 	MatchedBackgroundColor uint32
 	MatchedBorderColor     uint32
 	ShowLabels             bool
+	TextOutlineColor       uint32
+	TextOutlineWidth       float64
 }
 
 // Overlay manages the rendering of grid overlays using native platform APIs (Linux stub).
@@ -149,7 +151,19 @@ func BuildStyle(cfg config.GridConfig, theme config.ThemeProvider) Style {
 			),
 		),
 		ShowLabels: true,
+		TextOutlineColor: parseOptionalColor(
+			cfg.UI.TextOutlineColor.ForTheme(theme, "", ""),
+		),
+		TextOutlineWidth: float64(cfg.UI.TextOutlineWidth),
 	}
+}
+
+func parseOptionalColor(value string) uint32 {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	return parseLinuxColor(value)
 }
 
 func parseLinuxColor(value string) uint32 {

--- a/internal/app/components/grid/overlay_windows.go
+++ b/internal/app/components/grid/overlay_windows.go
@@ -34,6 +34,8 @@ type Style struct {
 	MatchedTextColor       uint32
 	MatchedBackgroundColor uint32
 	MatchedBorderColor     uint32
+	TextOutlineColor       uint32
+	TextOutlineWidth       int
 	ShowLabels             bool
 }
 
@@ -147,7 +149,13 @@ func BuildStyle(cfg config.GridConfig, theme config.ThemeProvider) Style {
 				config.GridMatchedBorderColorDark,
 			),
 		),
-		ShowLabels: true,
+		TextOutlineColor: parseWindowsColor(cfg.UI.TextOutlineColor.ForTheme(
+			theme,
+			config.GridTextColorLight,
+			config.GridTextColorDark,
+		)),
+		TextOutlineWidth: cfg.UI.TextOutlineWidth,
+		ShowLabels:       true,
 	}
 }
 

--- a/internal/app/components/grid/overlay_windows.go
+++ b/internal/app/components/grid/overlay_windows.go
@@ -151,8 +151,8 @@ func BuildStyle(cfg config.GridConfig, theme config.ThemeProvider) Style {
 		),
 		TextOutlineColor: parseWindowsColor(cfg.UI.TextOutlineColor.ForTheme(
 			theme,
-			config.GridTextColorLight,
-			config.GridTextColorDark,
+			"",
+			"",
 		)),
 		TextOutlineWidth: cfg.UI.TextOutlineWidth,
 		ShowLabels:       true,
@@ -160,7 +160,11 @@ func BuildStyle(cfg config.GridConfig, theme config.ThemeProvider) Style {
 }
 
 func parseWindowsColor(value string) uint32 {
-	value = strings.TrimPrefix(strings.TrimSpace(value), "#")
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	value = strings.TrimPrefix(value, "#")
 	switch len(value) {
 	case colorLen3:
 		value = "FF" + strings.Repeat(string(value[0]), hexPairCount) +

--- a/internal/app/components/grid/overlay_windows.go
+++ b/internal/app/components/grid/overlay_windows.go
@@ -164,6 +164,7 @@ func parseWindowsColor(value string) uint32 {
 	if value == "" {
 		return 0
 	}
+
 	value = strings.TrimPrefix(value, "#")
 	switch len(value) {
 	case colorLen3:

--- a/internal/app/components/hints/overlay_darwin.go
+++ b/internal/app/components/hints/overlay_darwin.go
@@ -106,6 +106,8 @@ type StyleMode struct {
 	backgroundColor          string
 	textColor                string
 	matchedTextColor         string
+	textOutlineColor         string
+	textOutlineWidth         int
 	borderColor              string
 	boundaryHighlightEnabled bool
 	boundaryBorderWidth      int
@@ -162,6 +164,16 @@ func (s StyleMode) TextColor() string {
 // MatchedTextColor returns the matched text color.
 func (s StyleMode) MatchedTextColor() string {
 	return s.matchedTextColor
+}
+
+// TextOutlineColor returns the text outline color.
+func (s StyleMode) TextOutlineColor() string {
+	return s.textOutlineColor
+}
+
+// TextOutlineWidth returns the text outline width.
+func (s StyleMode) TextOutlineWidth() int {
+	return s.textOutlineWidth
 }
 
 // BorderColor returns the border color.
@@ -377,6 +389,12 @@ func BuildStyle(cfg config.HintsConfig, theme config.ThemeProvider) StyleMode {
 			config.HintsMatchedTextColorLight,
 			config.HintsMatchedTextColorDark,
 		),
+		textOutlineColor: cfg.UI.TextOutlineColor.ForTheme(
+			theme,
+			"",
+			"",
+		),
+		textOutlineWidth: cfg.UI.TextOutlineWidth,
 		borderColor: cfg.UI.BorderColor.ForTheme(
 			theme,
 			config.HintsBorderColorLight,
@@ -571,6 +589,7 @@ func (o *Overlay) drawHintsInternal(hints []*Hint, style StyleMode, showArrow bo
 		_cachedStyle.BgColor = unsafe.Pointer(C.CString(style.BackgroundColor()))
 		_cachedStyle.TextColor = unsafe.Pointer(C.CString(style.TextColor()))
 		_cachedStyle.MatchedTextColor = unsafe.Pointer(C.CString(style.MatchedTextColor()))
+		_cachedStyle.TextOutlineColor = unsafe.Pointer(C.CString(style.TextOutlineColor()))
 		_cachedStyle.BorderColor = unsafe.Pointer(C.CString(style.BorderColor()))
 		_cachedStyle.BoundaryBgColor = unsafe.Pointer(C.CString(style.BoundaryBackgroundColor()))
 		_cachedStyle.BoundaryBorderColor = unsafe.Pointer(C.CString(style.BoundaryBorderColor()))
@@ -587,6 +606,8 @@ func (o *Overlay) drawHintsInternal(hints []*Hint, style StyleMode, showArrow bo
 		backgroundColor:          (*C.char)(cachedStyle.BgColor),
 		textColor:                (*C.char)(cachedStyle.TextColor),
 		matchedTextColor:         (*C.char)(cachedStyle.MatchedTextColor),
+		textOutlineColor:         (*C.char)(cachedStyle.TextOutlineColor),
+		textOutlineWidth:         C.double(style.TextOutlineWidth()),
 		borderColor:              (*C.char)(cachedStyle.BorderColor),
 		borderRadius:             C.int(style.BorderRadius()),
 		borderWidth:              C.int(style.BorderWidth()),
@@ -820,6 +841,7 @@ func (o *Overlay) drawHintsIncrementalStructural(
 		_cachedStyle.BgColor = unsafe.Pointer(C.CString(currentStyle.BackgroundColor()))
 		_cachedStyle.TextColor = unsafe.Pointer(C.CString(currentStyle.TextColor()))
 		_cachedStyle.MatchedTextColor = unsafe.Pointer(C.CString(currentStyle.MatchedTextColor()))
+		_cachedStyle.TextOutlineColor = unsafe.Pointer(C.CString(currentStyle.TextOutlineColor()))
 		_cachedStyle.BorderColor = unsafe.Pointer(C.CString(currentStyle.BorderColor()))
 		_cachedStyle.BoundaryBgColor = unsafe.Pointer(
 			C.CString(currentStyle.BoundaryBackgroundColor()),
@@ -840,6 +862,8 @@ func (o *Overlay) drawHintsIncrementalStructural(
 		backgroundColor:          (*C.char)(cachedStyle.BgColor),
 		textColor:                (*C.char)(cachedStyle.TextColor),
 		matchedTextColor:         (*C.char)(cachedStyle.MatchedTextColor),
+		textOutlineColor:         (*C.char)(cachedStyle.TextOutlineColor),
+		textOutlineWidth:         C.double(currentStyle.TextOutlineWidth()),
 		borderColor:              (*C.char)(cachedStyle.BorderColor),
 		borderRadius:             C.int(currentStyle.BorderRadius()),
 		borderWidth:              C.int(currentStyle.BorderWidth()),

--- a/internal/app/components/hints/overlay_linux_common.go
+++ b/internal/app/components/hints/overlay_linux_common.go
@@ -29,6 +29,8 @@ type StyleMode struct {
 	boundaryBorderRadius     int
 	boundaryBackgroundColor  string
 	boundaryBorderColor      string
+	textOutlineColor         string
+	textOutlineWidth         int
 }
 
 // FontSize returns the font size.
@@ -78,6 +80,12 @@ func (s StyleMode) BoundaryBackgroundColor() string { return s.boundaryBackgroun
 
 // BoundaryBorderColor returns the target boundary stroke color.
 func (s StyleMode) BoundaryBorderColor() string { return s.boundaryBorderColor }
+
+// TextOutlineColor returns the text outline color.
+func (s StyleMode) TextOutlineColor() string { return s.textOutlineColor }
+
+// TextOutlineWidth returns the text outline width.
+func (s StyleMode) TextOutlineWidth() int { return s.textOutlineWidth }
 
 // Overlay manages the rendering of hint overlays using native platform APIs (Linux stub).
 type Overlay struct {
@@ -177,5 +185,7 @@ func BuildStyle(cfg config.HintsConfig, theme config.ThemeProvider) StyleMode {
 			config.HintsBoundaryBorderColorLight,
 			config.HintsBoundaryBorderColorDark,
 		),
+		textOutlineColor: cfg.UI.TextOutlineColor.ForTheme(theme, "", ""),
+		textOutlineWidth: cfg.UI.TextOutlineWidth,
 	}
 }

--- a/internal/app/components/hints/overlay_windows.go
+++ b/internal/app/components/hints/overlay_windows.go
@@ -173,8 +173,8 @@ func BuildStyle(cfg config.HintsConfig, theme config.ThemeProvider) StyleMode {
 		),
 		textOutlineColor: cfg.UI.TextOutlineColor.ForTheme(
 			theme,
-			config.HintsTextColorLight,
-			config.HintsTextColorDark,
+			"",
+			"",
 		),
 		textOutlineWidth:         cfg.UI.TextOutlineWidth,
 		boundaryHighlightEnabled: cfg.BoundaryHighlight.Enabled,

--- a/internal/app/components/hints/overlay_windows.go
+++ b/internal/app/components/hints/overlay_windows.go
@@ -23,6 +23,8 @@ type StyleMode struct {
 	textColor                string
 	matchedTextColor         string
 	borderColor              string
+	textOutlineColor         string
+	textOutlineWidth         int
 	boundaryHighlightEnabled bool
 	boundaryBorderWidth      int
 	boundaryBorderRadius     int
@@ -77,6 +79,12 @@ func (s StyleMode) BoundaryBackgroundColor() string { return s.boundaryBackgroun
 
 // BoundaryBorderColor returns the target boundary stroke color.
 func (s StyleMode) BoundaryBorderColor() string { return s.boundaryBorderColor }
+
+// TextOutlineColor returns the text outline color.
+func (s StyleMode) TextOutlineColor() string { return s.textOutlineColor }
+
+// TextOutlineWidth returns the text outline width.
+func (s StyleMode) TextOutlineWidth() int { return s.textOutlineWidth }
 
 // Overlay manages the rendering of hint overlays using native platform APIs (Windows stub).
 type Overlay struct {
@@ -163,6 +171,12 @@ func BuildStyle(cfg config.HintsConfig, theme config.ThemeProvider) StyleMode {
 			config.HintsBorderColorLight,
 			config.HintsBorderColorDark,
 		),
+		textOutlineColor: cfg.UI.TextOutlineColor.ForTheme(
+			theme,
+			config.HintsTextColorLight,
+			config.HintsTextColorDark,
+		),
+		textOutlineWidth:         cfg.UI.TextOutlineWidth,
 		boundaryHighlightEnabled: cfg.BoundaryHighlight.Enabled,
 		boundaryBorderWidth:      cfg.BoundaryHighlight.BorderWidth,
 		boundaryBorderRadius:     cfg.BoundaryHighlight.BorderRadius,

--- a/internal/app/components/modeindicator/overlay_darwin.go
+++ b/internal/app/components/modeindicator/overlay_darwin.go
@@ -218,6 +218,16 @@ func (o *Overlay) DrawModeIndicator(mode string, xCoordinate, yCoordinate int) {
 				),
 			),
 		)
+		cached.TextOutlineColor = unsafe.Pointer(
+			C.CString(
+				modeConfig.TextOutlineColor.ForThemeWithOverride(
+					o.indicatorConfig.UI.TextOutlineColor,
+					o.theme,
+					"",
+					"",
+				),
+			),
+		)
 		cached.MatchedTextColor = unsafe.Pointer(
 			C.CString(
 				modeConfig.TextColor.ForThemeWithOverride(
@@ -246,6 +256,8 @@ func (o *Overlay) DrawModeIndicator(mode string, xCoordinate, yCoordinate int) {
 		backgroundColor:  (*C.char)(cachedStyle.BgColor),
 		textColor:        (*C.char)(cachedStyle.TextColor),
 		matchedTextColor: (*C.char)(cachedStyle.MatchedTextColor),
+		textOutlineColor: (*C.char)(cachedStyle.TextOutlineColor),
+		textOutlineWidth: C.double(o.indicatorConfig.UI.TextOutlineWidth),
 		borderColor:      (*C.char)(cachedStyle.BorderColor),
 		borderRadius:     C.int(o.indicatorConfig.UI.BorderRadius),
 		borderWidth:      C.int(o.indicatorConfig.UI.BorderWidth),

--- a/internal/app/components/overlayutil/style_cache.go
+++ b/internal/app/components/overlayutil/style_cache.go
@@ -10,19 +10,21 @@ import (
 // CachedStyle holds pointers to C strings for style properties.
 // Fields are unsafe.Pointer to avoid C type dependency across packages.
 type CachedStyle struct {
-	FontFamily          unsafe.Pointer
-	BgColor             unsafe.Pointer
-	LabelBgColor        unsafe.Pointer
-	TextColor           unsafe.Pointer
-	MatchedTextColor    unsafe.Pointer
-	BorderColor         unsafe.Pointer
-	MatchedBgColor      unsafe.Pointer
-	MatchedBorderColor  unsafe.Pointer
-	HighlightColor      unsafe.Pointer
-	SubKeyTextColor     unsafe.Pointer
-	SubKeyFontFamily    unsafe.Pointer
-	BoundaryBgColor     unsafe.Pointer
-	BoundaryBorderColor unsafe.Pointer
+	FontFamily             unsafe.Pointer
+	BgColor                unsafe.Pointer
+	LabelBgColor           unsafe.Pointer
+	TextColor              unsafe.Pointer
+	MatchedTextColor       unsafe.Pointer
+	TextOutlineColor       unsafe.Pointer
+	BorderColor            unsafe.Pointer
+	MatchedBgColor         unsafe.Pointer
+	MatchedBorderColor     unsafe.Pointer
+	HighlightColor         unsafe.Pointer
+	SubKeyTextColor        unsafe.Pointer
+	SubKeyTextOutlineColor unsafe.Pointer
+	SubKeyFontFamily       unsafe.Pointer
+	BoundaryBgColor        unsafe.Pointer
+	BoundaryBorderColor    unsafe.Pointer
 }
 
 // StyleCache manages caching of C strings for styles to reduce allocations.
@@ -82,6 +84,8 @@ func (c *StyleCache) freeLocked() {
 	c.style.TextColor = nil
 	native.FreeCString(c.style.MatchedTextColor)
 	c.style.MatchedTextColor = nil
+	native.FreeCString(c.style.TextOutlineColor)
+	c.style.TextOutlineColor = nil
 	native.FreeCString(c.style.BorderColor)
 	c.style.BorderColor = nil
 	native.FreeCString(c.style.MatchedBgColor)
@@ -92,6 +96,8 @@ func (c *StyleCache) freeLocked() {
 	c.style.HighlightColor = nil
 	native.FreeCString(c.style.SubKeyTextColor)
 	c.style.SubKeyTextColor = nil
+	native.FreeCString(c.style.SubKeyTextOutlineColor)
+	c.style.SubKeyTextOutlineColor = nil
 	native.FreeCString(c.style.SubKeyFontFamily)
 	c.style.SubKeyFontFamily = nil
 	native.FreeCString(c.style.BoundaryBgColor)

--- a/internal/app/components/recursivegrid/overlay_darwin.go
+++ b/internal/app/components/recursivegrid/overlay_darwin.go
@@ -351,11 +351,15 @@ func (o *Overlay) DrawRecursiveGrid(
 		cached.BgColor = unsafe.Pointer(C.CString(style.HighlightColor()))
 		cached.LabelBgColor = unsafe.Pointer(C.CString(style.LabelBackgroundColor()))
 		cached.TextColor = unsafe.Pointer(C.CString(style.TextColor()))
+		cached.TextOutlineColor = unsafe.Pointer(C.CString(style.TextOutlineColor()))
 		cached.MatchedTextColor = unsafe.Pointer(C.CString(style.TextColor()))
 		cached.MatchedBgColor = unsafe.Pointer(C.CString(style.HighlightColor()))
 		cached.MatchedBorderColor = unsafe.Pointer(C.CString(style.LineColor()))
 		cached.BorderColor = unsafe.Pointer(C.CString(style.LineColor()))
 		cached.SubKeyTextColor = unsafe.Pointer(C.CString(style.SubKeyPreviewTextColor()))
+		cached.SubKeyTextOutlineColor = unsafe.Pointer(
+			C.CString(style.SubKeyPreviewTextOutlineColor()),
+		)
 		cached.SubKeyFontFamily = unsafe.Pointer(C.CString(style.FontFamily()))
 	})
 
@@ -366,6 +370,8 @@ func (o *Overlay) DrawRecursiveGrid(
 		labelBackgroundColor:        (*C.char)(cachedStyle.LabelBgColor),
 		textColor:                   (*C.char)(cachedStyle.TextColor),
 		matchedTextColor:            (*C.char)(cachedStyle.MatchedTextColor),
+		textOutlineColor:            (*C.char)(cachedStyle.TextOutlineColor),
+		textOutlineWidth:            C.int(style.TextOutlineWidth()),
 		matchedBackgroundColor:      (*C.char)(cachedStyle.MatchedBgColor),
 		matchedBorderColor:          (*C.char)(cachedStyle.MatchedBorderColor),
 		borderColor:                 (*C.char)(cachedStyle.BorderColor),
@@ -383,6 +389,8 @@ func (o *Overlay) DrawRecursiveGrid(
 		subKeyFontFamily:            (*C.char)(cachedStyle.SubKeyFontFamily),
 		subKeyAutohideMultiplier:    C.float(style.SubKeyPreviewAutohideMultiplier()),
 		subKeyTextColor:             (*C.char)(cachedStyle.SubKeyTextColor),
+		subKeyTextOutlineColor:      (*C.char)(cachedStyle.SubKeyTextOutlineColor),
+		subKeyTextOutlineWidth:      C.int(style.SubKeyPreviewTextOutlineWidth()),
 		subKeyKeys:                  o.getOrCacheLabel(subKeyLabel),
 	}
 
@@ -505,6 +513,8 @@ type Style struct {
 	lineWidth                       int
 	highlightColor                  string
 	textColor                       string
+	textOutlineColor                string
+	textOutlineWidth                int
 	fontSize                        int
 	fontFamily                      string
 	labelBackground                 bool
@@ -519,6 +529,8 @@ type Style struct {
 	subKeyPreviewFontSize           int
 	subKeyPreviewAutohideMultiplier float64
 	subKeyPreviewTextColor          string
+	subKeyPreviewTextOutlineColor   string
+	subKeyPreviewTextOutlineWidth   int
 	subKeyPreviewLabelChar          string
 }
 
@@ -540,6 +552,26 @@ func (s Style) HighlightColor() string {
 // TextColor returns the text color.
 func (s Style) TextColor() string {
 	return s.textColor
+}
+
+// TextOutlineColor returns the text outline color.
+func (s Style) TextOutlineColor() string {
+	return s.textOutlineColor
+}
+
+// TextOutlineWidth returns the text outline width.
+func (s Style) TextOutlineWidth() int {
+	return s.textOutlineWidth
+}
+
+// SubKeyPreviewTextOutlineColor returns the sub-key preview text outline color.
+func (s Style) SubKeyPreviewTextOutlineColor() string {
+	return s.subKeyPreviewTextOutlineColor
+}
+
+// SubKeyPreviewTextOutlineWidth returns the sub-key preview text outline width.
+func (s Style) SubKeyPreviewTextOutlineWidth() int {
+	return s.subKeyPreviewTextOutlineWidth
 }
 
 // FontSize returns the font size.
@@ -638,9 +670,15 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 			config.RecursiveGridTextColorLight,
 			config.RecursiveGridTextColorDark,
 		),
-		fontSize:        cfg.UI.FontSize,
-		fontFamily:      ports.ResolveFont(cfg.UI.FontFamily, true),
-		labelBackground: cfg.UI.LabelBackground,
+		textOutlineColor: cfg.UI.TextOutlineColor.ForTheme(
+			theme,
+			"",
+			"",
+		),
+		textOutlineWidth: cfg.UI.TextOutlineWidth,
+		fontSize:         cfg.UI.FontSize,
+		fontFamily:       ports.ResolveFont(cfg.UI.FontFamily, true),
+		labelBackground:  cfg.UI.LabelBackground,
 		labelBackgroundColor: cfg.UI.LabelBackgroundColor.ForTheme(
 			theme,
 			config.RecursiveGridLabelBackgroundColorLight,
@@ -660,6 +698,12 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 			config.RecursiveGridSubKeyPreviewTextColorLight,
 			config.RecursiveGridSubKeyPreviewTextColorDark,
 		),
-		subKeyPreviewLabelChar: cfg.UI.SubKeyPreviewLabelChar,
+		subKeyPreviewTextOutlineColor: cfg.UI.SubKeyPreviewTextOutlineColor.ForTheme(
+			theme,
+			"",
+			"",
+		),
+		subKeyPreviewTextOutlineWidth: cfg.UI.SubKeyPreviewTextOutlineWidth,
+		subKeyPreviewLabelChar:        cfg.UI.SubKeyPreviewLabelChar,
 	}
 }

--- a/internal/app/components/recursivegrid/overlay_linux_common.go
+++ b/internal/app/components/recursivegrid/overlay_linux_common.go
@@ -188,6 +188,7 @@ func parseOptionalColor(value string) uint32 {
 	if value == "" {
 		return 0
 	}
+
 	return parseLinuxColor(value)
 }
 

--- a/internal/app/components/recursivegrid/overlay_linux_common.go
+++ b/internal/app/components/recursivegrid/overlay_linux_common.go
@@ -44,6 +44,10 @@ type Style struct {
 	SubKeyPreviewTextColor          uint32
 	SubKeyPreviewLabelChar          string
 	ShowLabels                      bool
+	TextOutlineColor                uint32
+	TextOutlineWidth                float64
+	SubKeyPreviewTextOutlineColor   uint32
+	SubKeyPreviewTextOutlineWidth   float64
 }
 
 // Overlay manages the rendering of recursive_grid overlays using native platform APIs (Linux stub).
@@ -168,7 +172,23 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 		),
 		SubKeyPreviewLabelChar: cfg.UI.SubKeyPreviewLabelChar,
 		ShowLabels:             true,
+		TextOutlineColor: parseOptionalColor(
+			cfg.UI.TextOutlineColor.ForTheme(theme, "", ""),
+		),
+		TextOutlineWidth: float64(cfg.UI.TextOutlineWidth),
+		SubKeyPreviewTextOutlineColor: parseOptionalColor(
+			cfg.UI.SubKeyPreviewTextOutlineColor.ForTheme(theme, "", ""),
+		),
+		SubKeyPreviewTextOutlineWidth: float64(cfg.UI.SubKeyPreviewTextOutlineWidth),
 	}
+}
+
+func parseOptionalColor(value string) uint32 {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	return parseLinuxColor(value)
 }
 
 func parseLinuxColor(value string) uint32 {

--- a/internal/app/components/recursivegrid/overlay_windows.go
+++ b/internal/app/components/recursivegrid/overlay_windows.go
@@ -186,7 +186,12 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 }
 
 func parseWindowsColor(value string) uint32 {
-	value = strings.TrimPrefix(strings.TrimSpace(value), "#")
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+
+	value = strings.TrimPrefix(value, "#")
 	switch len(value) {
 	case colorLen3:
 		value = "FF" + strings.Repeat(string(value[0]), hexDigitCount) +

--- a/internal/app/components/recursivegrid/overlay_windows.go
+++ b/internal/app/components/recursivegrid/overlay_windows.go
@@ -176,10 +176,12 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 			"",
 			"",
 		)),
-		TextOutlineWidth:                cfg.UI.TextOutlineWidth,
-		SubKeyPreviewTextOutlineColor:   parseWindowsColor(cfg.UI.SubKeyPreviewTextOutlineColor.ForTheme(theme, "", "")),
-		SubKeyPreviewTextOutlineWidth:   cfg.UI.SubKeyPreviewTextOutlineWidth,
-		ShowLabels:                      true,
+		TextOutlineWidth: cfg.UI.TextOutlineWidth,
+		SubKeyPreviewTextOutlineColor: parseWindowsColor(
+			cfg.UI.SubKeyPreviewTextOutlineColor.ForTheme(theme, "", ""),
+		),
+		SubKeyPreviewTextOutlineWidth: cfg.UI.SubKeyPreviewTextOutlineWidth,
+		ShowLabels:                    true,
 	}
 }
 

--- a/internal/app/components/recursivegrid/overlay_windows.go
+++ b/internal/app/components/recursivegrid/overlay_windows.go
@@ -40,6 +40,8 @@ type Style struct {
 	LabelAutohideMultiplier         float64
 	TextOutlineColor                uint32
 	TextOutlineWidth                int
+	SubKeyPreviewTextOutlineColor   uint32
+	SubKeyPreviewTextOutlineWidth   int
 	SubKeyPreview                   bool
 	SubKeyPreviewFontSize           float64
 	SubKeyPreviewAutohideMultiplier float64
@@ -171,11 +173,13 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 		SubKeyPreviewLabelChar: cfg.UI.SubKeyPreviewLabelChar,
 		TextOutlineColor: parseWindowsColor(cfg.UI.TextOutlineColor.ForTheme(
 			theme,
-			config.RecursiveGridTextColorLight,
-			config.RecursiveGridTextColorDark,
+			"",
+			"",
 		)),
-		TextOutlineWidth: cfg.UI.TextOutlineWidth,
-		ShowLabels:       true,
+		TextOutlineWidth:                cfg.UI.TextOutlineWidth,
+		SubKeyPreviewTextOutlineColor:   parseWindowsColor(cfg.UI.SubKeyPreviewTextOutlineColor.ForTheme(theme, "", "")),
+		SubKeyPreviewTextOutlineWidth:   cfg.UI.SubKeyPreviewTextOutlineWidth,
+		ShowLabels:                      true,
 	}
 }
 

--- a/internal/app/components/recursivegrid/overlay_windows.go
+++ b/internal/app/components/recursivegrid/overlay_windows.go
@@ -38,6 +38,8 @@ type Style struct {
 	LabelBackgroundBorderWidth      float64
 	LabelChar                       string
 	LabelAutohideMultiplier         float64
+	TextOutlineColor                uint32
+	TextOutlineWidth                int
 	SubKeyPreview                   bool
 	SubKeyPreviewFontSize           float64
 	SubKeyPreviewAutohideMultiplier float64
@@ -167,7 +169,13 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 			),
 		),
 		SubKeyPreviewLabelChar: cfg.UI.SubKeyPreviewLabelChar,
-		ShowLabels:             true,
+		TextOutlineColor: parseWindowsColor(cfg.UI.TextOutlineColor.ForTheme(
+			theme,
+			config.RecursiveGridTextColorLight,
+			config.RecursiveGridTextColorDark,
+		)),
+		TextOutlineWidth: cfg.UI.TextOutlineWidth,
+		ShowLabels:       true,
 	}
 }
 

--- a/internal/app/modes/monitor_select_overlay_darwin.go
+++ b/internal/app/modes/monitor_select_overlay_darwin.go
@@ -37,6 +37,8 @@ type monitorSelectRenderStyle struct {
 	BackgroundColor    string
 	TextColor          string
 	MatchedTextColor   string
+	TextOutlineColor   string
+	TextOutlineWidth   int
 	BorderColor        string
 	BackdropColor      string
 	SubtitleTextColor  string
@@ -90,6 +92,8 @@ func (h *Handler) showMonitorSelectLocked() error {
 		backgroundColor:    cStringOrNil(style.BackgroundColor),
 		textColor:          cStringOrNil(style.TextColor),
 		matchedTextColor:   cStringOrNil(style.MatchedTextColor),
+		textOutlineColor:   cStringOrNil(style.TextOutlineColor),
+		textOutlineWidth:   C.int(style.TextOutlineWidth),
 		borderColor:        cStringOrNil(style.BorderColor),
 		backdropColor:      cStringOrNil(style.BackdropColor),
 		subtitleTextColor:  cStringOrNil(style.SubtitleTextColor),
@@ -154,6 +158,9 @@ func freeMonitorSelectStyle(styl C.MonitorSelectStyle) {
 	if styl.subtitleTextColor != nil {
 		C.free(unsafe.Pointer(styl.subtitleTextColor))
 	}
+	if styl.textOutlineColor != nil {
+		C.free(unsafe.Pointer(styl.textOutlineColor))
+	}
 }
 
 func (h *Handler) currentMonitorSelectRenderStateLocked() monitorSelectRenderState {
@@ -182,6 +189,8 @@ func (h *Handler) currentMonitorSelectRenderStateLocked() monitorSelectRenderSta
 			MatchedTextColor: uiCfg.MatchedTextColor.ForTheme(theme,
 				configpkg.MonitorSelectMatchedTextColorLight,
 				configpkg.MonitorSelectMatchedTextColorDark),
+			TextOutlineColor: uiCfg.TextOutlineColor.ForTheme(theme, "", ""),
+			TextOutlineWidth: uiCfg.TextOutlineWidth,
 			BorderColor: uiCfg.BorderColor.ForTheme(theme,
 				configpkg.MonitorSelectBorderColorLight,
 				configpkg.MonitorSelectBorderColorDark),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -490,6 +490,8 @@ type ModeIndicatorUI struct {
 	FontFamily       string `json:"fontFamily"       toml:"font_family"`
 	BackgroundColor  Color  `json:"backgroundColor"  toml:"background_color"`
 	TextColor        Color  `json:"textColor"        toml:"text_color"`
+	TextOutlineColor Color  `json:"textOutlineColor" toml:"text_outline_color"`
+	TextOutlineWidth int    `json:"textOutlineWidth" toml:"text_outline_width"`
 	BorderColor      Color  `json:"borderColor"      toml:"border_color"`
 	BorderWidth      int    `json:"borderWidth"      toml:"border_width"`
 	PaddingX         int    `json:"paddingX"         toml:"padding_x"`
@@ -503,11 +505,12 @@ type ModeIndicatorUI struct {
 // Text is the label shown in the indicator; empty string hides the label.
 // Color overrides are optional; empty string inherits from [mode_indicator.ui].
 type ModeIndicatorModeConfig struct {
-	Enabled         bool   `json:"enabled"         toml:"enabled"`
-	Text            string `json:"text"            toml:"text"`
-	BackgroundColor Color  `json:"backgroundColor" toml:"background_color"`
-	TextColor       Color  `json:"textColor"       toml:"text_color"`
-	BorderColor     Color  `json:"borderColor"     toml:"border_color"`
+	Enabled          bool   `json:"enabled"          toml:"enabled"`
+	Text             string `json:"text"             toml:"text"`
+	BackgroundColor  Color  `json:"backgroundColor"  toml:"background_color"`
+	TextColor        Color  `json:"textColor"        toml:"text_color"`
+	TextOutlineColor Color  `json:"textOutlineColor" toml:"text_outline_color"`
+	BorderColor      Color  `json:"borderColor"      toml:"border_color"`
 }
 
 // ModeIndicatorConfig defines per-mode indicator visibility and appearance.
@@ -526,6 +529,8 @@ type StickyModifiersUI struct {
 	FontFamily       string `json:"fontFamily"       toml:"font_family"`
 	BackgroundColor  Color  `json:"backgroundColor"  toml:"background_color"`
 	TextColor        Color  `json:"textColor"        toml:"text_color"`
+	TextOutlineColor Color  `json:"textOutlineColor" toml:"text_outline_color"`
+	TextOutlineWidth int    `json:"textOutlineWidth" toml:"text_outline_width"`
 	BorderColor      Color  `json:"borderColor"      toml:"border_color"`
 	BorderWidth      int    `json:"borderWidth"      toml:"border_width"`
 	PaddingX         int    `json:"paddingX"         toml:"padding_x"`
@@ -596,6 +601,8 @@ type MonitorSelectUI struct {
 	BackgroundColor    Color  `json:"backgroundColor"    toml:"background_color"`
 	TextColor          Color  `json:"textColor"          toml:"text_color"`
 	MatchedTextColor   Color  `json:"matchedTextColor"   toml:"matched_text_color"`
+	TextOutlineColor   Color  `json:"textOutlineColor"   toml:"text_outline_color"`
+	TextOutlineWidth   int    `json:"textOutlineWidth"   toml:"text_outline_width"`
 	BorderColor        Color  `json:"borderColor"        toml:"border_color"`
 	BackdropColor      Color  `json:"backdropColor"      toml:"backdrop_color"`
 	SubtitleFontSize   int    `json:"subtitleFontSize"   toml:"subtitle_font_size"`
@@ -623,6 +630,8 @@ type HintsUI struct {
 	BackgroundColor  Color  `json:"backgroundColor"  toml:"background_color"`
 	TextColor        Color  `json:"textColor"        toml:"text_color"`
 	MatchedTextColor Color  `json:"matchedTextColor" toml:"matched_text_color"`
+	TextOutlineColor Color  `json:"textOutlineColor" toml:"text_outline_color"`
+	TextOutlineWidth int    `json:"textOutlineWidth" toml:"text_outline_width"`
 	BorderColor      Color  `json:"borderColor"      toml:"border_color"`
 }
 
@@ -734,6 +743,8 @@ type GridUI struct {
 	BackgroundColor        Color `json:"backgroundColor"        toml:"background_color"`
 	TextColor              Color `json:"textColor"              toml:"text_color"`
 	MatchedTextColor       Color `json:"matchedTextColor"       toml:"matched_text_color"`
+	TextOutlineColor       Color `json:"textOutlineColor"       toml:"text_outline_color"`
+	TextOutlineWidth       int   `json:"textOutlineWidth"       toml:"text_outline_width"`
 	MatchedBackgroundColor Color `json:"matchedBackgroundColor" toml:"matched_background_color"`
 	MatchedBorderColor     Color `json:"matchedBorderColor"     toml:"matched_border_color"`
 	BorderColor            Color `json:"borderColor"            toml:"border_color"`
@@ -765,6 +776,8 @@ type RecursiveGridUI struct {
 	LineWidth                       int     `json:"lineWidth"                       toml:"line_width"`
 	HighlightColor                  Color   `json:"highlightColor"                  toml:"highlight_color"`
 	TextColor                       Color   `json:"textColor"                       toml:"text_color"`
+	TextOutlineColor                Color   `json:"textOutlineColor"                toml:"text_outline_color"`
+	TextOutlineWidth                int     `json:"textOutlineWidth"                toml:"text_outline_width"`
 	FontSize                        int     `json:"fontSize"                        toml:"font_size"`
 	FontFamily                      string  `json:"fontFamily"                      toml:"font_family"`
 	LabelBackground                 bool    `json:"labelBackground"                 toml:"label_background"`
@@ -779,6 +792,8 @@ type RecursiveGridUI struct {
 	SubKeyPreviewFontSize           int     `json:"subKeyPreviewFontSize"           toml:"sub_key_preview_font_size"`
 	SubKeyPreviewAutohideMultiplier float64 `json:"subKeyPreviewAutohideMultiplier" toml:"sub_key_preview_autohide_multiplier"`
 	SubKeyPreviewTextColor          Color   `json:"subKeyPreviewTextColor"          toml:"sub_key_preview_text_color"`
+	SubKeyPreviewTextOutlineColor   Color   `json:"subKeyPreviewTextOutlineColor"   toml:"sub_key_preview_text_outline_color"`
+	SubKeyPreviewTextOutlineWidth   int     `json:"subKeyPreviewTextOutlineWidth"   toml:"sub_key_preview_text_outline_width"`
 	SubKeyPreviewLabelChar          string  `json:"subKeyPreviewLabelChar"          toml:"sub_key_preview_label_char"`
 }
 
@@ -823,10 +838,12 @@ type RecursiveGridConfig struct {
 
 // VirtualPointerUI defines the visual settings for the character-based virtual pointer.
 type VirtualPointerUI struct {
-	Char       string `json:"char"       toml:"char"`
-	FontSize   int    `json:"fontSize"   toml:"font_size"`
-	FontFamily string `json:"fontFamily" toml:"font_family"`
-	TextColor  Color  `json:"textColor"  toml:"text_color"`
+	Char             string `json:"char"             toml:"char"`
+	FontSize         int    `json:"fontSize"         toml:"font_size"`
+	FontFamily       string `json:"fontFamily"       toml:"font_family"`
+	TextColor        Color  `json:"textColor"        toml:"text_color"`
+	TextOutlineColor Color  `json:"textOutlineColor" toml:"text_outline_color"`
+	TextOutlineWidth int    `json:"textOutlineWidth" toml:"text_outline_width"`
 }
 
 // VirtualPointerConfig defines settings for the hold-mode virtual pointer.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1205,6 +1205,13 @@ func (c *Config) ValidateModeIndicator() error {
 		return err
 	}
 
+	if c.ModeIndicator.UI.TextOutlineWidth < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"mode_indicator.ui.text_outline_width must be non-negative",
+		)
+	}
+
 	err = validateMinValue(c.ModeIndicator.UI.PaddingX, -1, "mode_indicator.ui.padding_x")
 	if err != nil {
 		return err
@@ -1223,6 +1230,7 @@ func (c *Config) ValidateModeIndicator() error {
 	err = validateColors([]colorField{
 		{c.ModeIndicator.UI.BackgroundColor, "mode_indicator.ui.background_color"},
 		{c.ModeIndicator.UI.TextColor, "mode_indicator.ui.text_color"},
+		{c.ModeIndicator.UI.TextOutlineColor, "mode_indicator.ui.text_outline_color"},
 		{c.ModeIndicator.UI.BorderColor, "mode_indicator.ui.border_color"},
 	})
 	if err != nil {
@@ -1244,6 +1252,7 @@ func (c *Config) ValidateModeIndicator() error {
 		err = validateColors([]colorField{
 			{mode.cfg.BackgroundColor, "mode_indicator." + mode.name + ".background_color"},
 			{mode.cfg.TextColor, "mode_indicator." + mode.name + ".text_color"},
+			{mode.cfg.TextOutlineColor, "mode_indicator." + mode.name + ".text_outline_color"},
 			{mode.cfg.BorderColor, "mode_indicator." + mode.name + ".border_color"},
 		})
 		if err != nil {

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -139,6 +139,7 @@ func (c *Config) ValidateHints() error {
 		{c.Hints.UI.BackgroundColor, "hints.ui.background_color"},
 		{c.Hints.UI.TextColor, "hints.ui.text_color"},
 		{c.Hints.UI.MatchedTextColor, "hints.ui.matched_text_color"},
+		{c.Hints.UI.TextOutlineColor, "hints.ui.text_outline_color"},
 		{c.Hints.UI.BorderColor, "hints.ui.border_color"},
 		{c.Hints.SearchInputUI.BackgroundColor, "hints.search_input_ui.background_color"},
 		{c.Hints.SearchInputUI.TextColor, "hints.search_input_ui.text_color"},
@@ -148,6 +149,13 @@ func (c *Config) ValidateHints() error {
 	})
 	if err != nil {
 		return err
+	}
+
+	if c.Hints.UI.TextOutlineWidth < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.ui.text_outline_width must be non-negative",
+		)
 	}
 
 	if c.Hints.UI.FontSize < 1 || c.Hints.UI.FontSize > maxFontSize {
@@ -720,10 +728,18 @@ func (c *Config) ValidateGrid() error {
 		{c.Grid.UI.MatchedTextColor, "grid.ui.matched_text_color"},
 		{c.Grid.UI.MatchedBackgroundColor, "grid.ui.matched_background_color"},
 		{c.Grid.UI.MatchedBorderColor, "grid.ui.matched_border_color"},
+		{c.Grid.UI.TextOutlineColor, "grid.ui.text_outline_color"},
 		{c.Grid.UI.BorderColor, "grid.ui.border_color"},
 	})
 	if err != nil {
 		return err
+	}
+
+	if c.Grid.UI.TextOutlineWidth < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"grid.ui.text_outline_width must be non-negative",
+		)
 	}
 
 	if c.Grid.UI.FontSize < 1 || c.Grid.UI.FontSize > maxFontSize {
@@ -771,12 +787,20 @@ func (c *Config) ValidateMonitorSelect() error {
 		{c.MonitorSelect.UI.BackgroundColor, "monitor_select.ui.background_color"},
 		{c.MonitorSelect.UI.TextColor, "monitor_select.ui.text_color"},
 		{c.MonitorSelect.UI.MatchedTextColor, "monitor_select.ui.matched_text_color"},
+		{c.MonitorSelect.UI.TextOutlineColor, "monitor_select.ui.text_outline_color"},
 		{c.MonitorSelect.UI.BorderColor, "monitor_select.ui.border_color"},
 		{c.MonitorSelect.UI.BackdropColor, "monitor_select.ui.backdrop_color"},
 		{c.MonitorSelect.UI.SubtitleTextColor, "monitor_select.ui.subtitle_text_color"},
 	})
 	if err != nil {
 		return err
+	}
+
+	if c.MonitorSelect.UI.TextOutlineWidth < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"monitor_select.ui.text_outline_width must be non-negative",
+		)
 	}
 
 	if c.MonitorSelect.UI.FontSize < 1 || c.MonitorSelect.UI.FontSize > maxFontSize {
@@ -820,9 +844,17 @@ func (c *Config) ValidateStickyModifiers() error {
 		)
 	}
 
+	if c.StickyModifiers.UI.TextOutlineWidth < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"sticky_modifiers.ui.text_outline_width must be non-negative",
+		)
+	}
+
 	return validateColors([]colorField{
 		{c.StickyModifiers.UI.BackgroundColor, "sticky_modifiers.ui.background_color"},
 		{c.StickyModifiers.UI.TextColor, "sticky_modifiers.ui.text_color"},
+		{c.StickyModifiers.UI.TextOutlineColor, "sticky_modifiers.ui.text_outline_color"},
 		{c.StickyModifiers.UI.BorderColor, "sticky_modifiers.ui.border_color"},
 	})
 }
@@ -1254,11 +1286,30 @@ func (c *Config) ValidateRecursiveGrid() error {
 		{c.RecursiveGrid.UI.LineColor, "recursive_grid.ui.line_color"},
 		{c.RecursiveGrid.UI.HighlightColor, "recursive_grid.ui.highlight_color"},
 		{c.RecursiveGrid.UI.TextColor, "recursive_grid.ui.text_color"},
+		{c.RecursiveGrid.UI.TextOutlineColor, "recursive_grid.ui.text_outline_color"},
+		{
+			c.RecursiveGrid.UI.SubKeyPreviewTextOutlineColor,
+			"recursive_grid.ui.sub_key_preview_text_outline_color",
+		},
 		{c.RecursiveGrid.UI.LabelBackgroundColor, "recursive_grid.ui.label_background_color"},
 		{c.RecursiveGrid.UI.SubKeyPreviewTextColor, "recursive_grid.ui.sub_key_preview_text_color"},
 	})
 	if err != nil {
 		return err
+	}
+
+	if c.RecursiveGrid.UI.TextOutlineWidth < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"recursive_grid.ui.text_outline_width must be non-negative",
+		)
+	}
+
+	if c.RecursiveGrid.UI.SubKeyPreviewTextOutlineWidth < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"recursive_grid.ui.sub_key_preview_text_outline_width must be non-negative",
+		)
 	}
 
 	if c.RecursiveGrid.UI.LineWidth < 0 {
@@ -1315,9 +1366,17 @@ func (c *Config) ValidateRecursiveGrid() error {
 func (c *Config) ValidateVirtualPointer() error {
 	err := validateColors([]colorField{
 		{c.VirtualPointer.UI.TextColor, "virtual_pointer.ui.text_color"},
+		{c.VirtualPointer.UI.TextOutlineColor, "virtual_pointer.ui.text_outline_color"},
 	})
 	if err != nil {
 		return err
+	}
+
+	if c.VirtualPointer.UI.TextOutlineWidth < 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"virtual_pointer.ui.text_outline_width must be non-negative",
+		)
 	}
 
 	charLen := utf8.RuneCountInString(c.VirtualPointer.UI.Char)

--- a/internal/core/infra/platform/darwin/monitor_select_overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/monitor_select_overlay_darwin.m
@@ -148,10 +148,13 @@ void NeruShowMonitorSelectPanels(MonitorSelectTargetData *targets, int count, Mo
 				// Colors
 				NSString *bgHex = style.backgroundColor ? @(style.backgroundColor) : nil;
 				NSString *textHex = style.textColor ? @(style.textColor) : nil;
+				NSString *textOutlineHex = style.textOutlineColor ? @(style.textOutlineColor) : nil;
+				int textOutlineWidth = style.textOutlineWidth;
 				NSString *borderHex = style.borderColor ? @(style.borderColor) : nil;
 
 				NSColor *bgColor = monitorSelectColorFromHex(bgHex, [NSColor colorWithWhite:0.95 alpha:0.95]);
 				NSColor *textColor = monitorSelectColorFromHex(textHex, [NSColor blackColor]);
+				NSColor *textOutlineColor = monitorSelectColorFromHex(textOutlineHex, nil);
 				NSColor *borderColor = monitorSelectColorFromHex(borderHex, [NSColor colorWithWhite:0.5 alpha:0.5]);
 
 				// Fonts
@@ -221,7 +224,22 @@ void NeruShowMonitorSelectPanels(MonitorSelectTargetData *targets, int count, Mo
 
 				// Label text layer
 				CATextLayer *textLayer = [CATextLayer layer];
-				textLayer.string = label;
+				if (textOutlineWidth > 0 && textOutlineColor) {
+					NSMutableAttributedString *attrStr = [[NSMutableAttributedString alloc] initWithString:label];
+					[attrStr addAttribute:NSForegroundColorAttributeName
+					                value:textColor
+					                range:NSMakeRange(0, label.length)];
+					[attrStr addAttribute:NSStrokeColorAttributeName
+					                value:textOutlineColor
+					                range:NSMakeRange(0, label.length)];
+					[attrStr addAttribute:NSStrokeWidthAttributeName
+					                value:@(textOutlineWidth)
+					                range:NSMakeRange(0, label.length)];
+					[attrStr addAttribute:NSFontAttributeName value:labelFont range:NSMakeRange(0, label.length)];
+					textLayer.string = attrStr;
+				} else {
+					textLayer.string = label;
+				}
 				textLayer.font = (__bridge CTFontRef)labelFont;
 				textLayer.fontSize = fontSize;
 				textLayer.foregroundColor = textColor.CGColor;
@@ -237,7 +255,25 @@ void NeruShowMonitorSelectPanels(MonitorSelectTargetData *targets, int count, Mo
 					CGFloat subY = textY + labelSize.height + 4;
 
 					CATextLayer *subLayer = [CATextLayer layer];
-					subLayer.string = subtitle;
+					if (textOutlineWidth > 0 && textOutlineColor) {
+						NSMutableAttributedString *attrStr =
+						    [[NSMutableAttributedString alloc] initWithString:subtitle];
+						[attrStr addAttribute:NSForegroundColorAttributeName
+						                value:subColor
+						                range:NSMakeRange(0, subtitle.length)];
+						[attrStr addAttribute:NSStrokeColorAttributeName
+						                value:textOutlineColor
+						                range:NSMakeRange(0, subtitle.length)];
+						[attrStr addAttribute:NSStrokeWidthAttributeName
+						                value:@(textOutlineWidth)
+						                range:NSMakeRange(0, subtitle.length)];
+						[attrStr addAttribute:NSFontAttributeName
+						                value:subtitleFont
+						                range:NSMakeRange(0, subtitle.length)];
+						subLayer.string = attrStr;
+					} else {
+						subLayer.string = subtitle;
+					}
 					subLayer.font = (__bridge CTFontRef)subtitleFont;
 					subLayer.fontSize = subFontSize;
 					subLayer.foregroundColor = subColor.CGColor;

--- a/internal/core/infra/platform/darwin/overlay.h
+++ b/internal/core/infra/platform/darwin/overlay.h
@@ -28,6 +28,8 @@ typedef struct {
 	char *backgroundColor;          ///< Background color
 	char *textColor;                ///< Text color
 	char *matchedTextColor;         ///< Matched text color
+	char *textOutlineColor;         ///< Text outline color (NULL = no outline)
+	double textOutlineWidth;        ///< Text outline width (0 = no outline)
 	char *borderColor;              ///< Border color
 	int borderRadius;               ///< Border radius (-1 = auto)
 	int borderWidth;                ///< Border width
@@ -80,6 +82,8 @@ typedef struct {
 	char *labelBackgroundColor;       ///< Label background color
 	char *textColor;                  ///< Text color
 	char *matchedTextColor;           ///< Matched text color
+	char *textOutlineColor;           ///< Text outline color (NULL = no outline)
+	int textOutlineWidth;             ///< Text outline width (0 = no outline)
 	char *matchedBackgroundColor;     ///< Matched background color
 	char *matchedBorderColor;         ///< Matched border color
 	char *borderColor;                ///< Border color
@@ -97,6 +101,8 @@ typedef struct {
 	char *subKeyFontFamily;           ///< Font family for sub-key preview labels
 	float subKeyAutohideMultiplier;   ///< Minimum cell size multiplier for sub-key preview autohide (0 = disable)
 	char *subKeyTextColor;            ///< Text color for sub-key preview labels
+	char *subKeyTextOutlineColor;     ///< Text outline color for sub-key preview labels (NULL = no outline)
+	int subKeyTextOutlineWidth;       ///< Text outline width for sub-key preview labels (0 = no outline)
 	char *subKeyKeys;                 ///< Key string for sub-key preview (next depth's keys, uppercased)
 } GridCellStyle;
 
@@ -335,6 +341,8 @@ typedef struct {
 	char *backgroundColor;     ///< Badge background color
 	char *textColor;           ///< Label text color
 	char *matchedTextColor;    ///< Matched prefix text color
+	char *textOutlineColor;    ///< Text outline color (NULL = no outline)
+	int textOutlineWidth;      ///< Text outline width (0 = no outline)
 	char *borderColor;         ///< Badge border color
 	char *backdropColor;       ///< Monitor backdrop tint color
 	char *subtitleTextColor;   ///< Subtitle text color

--- a/internal/core/infra/platform/darwin/overlay_darwin.m
+++ b/internal/core/infra/platform/darwin/overlay_darwin.m
@@ -130,6 +130,8 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 @property(nonatomic, strong) NSFont *hintFont;                      ///< Hint font
 @property(nonatomic, strong) NSColor *hintTextColor;                ///< Hint text color
 @property(nonatomic, strong) NSColor *hintMatchedTextColor;         ///< Hint matched text color
+@property(nonatomic, strong) NSColor *hintTextOutlineColor;         ///< Hint text outline color
+@property(nonatomic, assign) CGFloat hintTextOutlineWidth;          ///< Hint text outline width
 @property(nonatomic, strong) NSColor *hintBackgroundColor;          ///< Hint background color
 @property(nonatomic, strong) NSColor *hintBorderColor;              ///< Hint border color
 @property(nonatomic, strong) NSColor *hintBoundaryBackgroundColor;  ///< Target boundary fill color
@@ -163,6 +165,10 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 @property(nonatomic, strong) NSFont *gridFont;        ///< Grid font
 @property(nonatomic, strong) NSColor *gridTextColor;  ///< Grid text color
 @property(nonatomic, strong) NSColor *gridMatchedTextColor;            ///< Grid matched text color
+@property(nonatomic, strong) NSColor *gridTextOutlineColor;            ///< Grid text outline color
+@property(nonatomic, assign) CGFloat gridTextOutlineWidth;             ///< Grid text outline width
+@property(nonatomic, strong) NSColor *gridSubKeyTextOutlineColor;      ///< Sub-key preview text outline color
+@property(nonatomic, assign) CGFloat gridSubKeyTextOutlineWidth;       ///< Sub-key preview text outline width
 @property(nonatomic, strong) NSColor *gridMatchedBackgroundColor;      ///< Grid matched background color
 @property(nonatomic, strong) NSColor *gridMatchedBorderColor;          ///< Grid matched border color
 @property(nonatomic, strong) NSColor *gridBackgroundColor;             ///< Grid background color
@@ -314,6 +320,8 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 		_hintBoundaryHighlightEnabled = NO;
 		_hintBoundaryBorderWidth = 1.0;
 		_hintBoundaryBorderRadius = 4.0;
+		_hintTextOutlineColor = nil;
+		_hintTextOutlineWidth = 0;
 		_hintPaddingX = -1.0;
 		_hintPaddingY = -1.0;
 		_searchInput = nil;
@@ -344,6 +352,10 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 		_gridSubKeyAutohideMultiplier = 1.5;
 		_gridLabelAutohideMultiplier = 0.0;
 		_hideUnmatched = NO;
+		_gridTextOutlineColor = nil;
+		_gridTextOutlineWidth = 0;
+		_gridSubKeyTextOutlineColor = nil;
+		_gridSubKeyTextOutlineWidth = 0;
 		_cursorIndicatorVisible = NO;
 		_cursorIndicatorRadius = 3.0;
 		_cursorIndicatorFillColor = [NSColor colorWithWhite:1.0 alpha:1.0];
@@ -1303,6 +1315,10 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 		[attrString
 		    setAttributes:@{NSFontAttributeName : self.hintFont, NSForegroundColorAttributeName : self.hintTextColor}
 		            range:fullRange];
+		if (self.hintTextOutlineWidth > 0 && self.hintTextOutlineColor) {
+			[attrString addAttribute:NSStrokeColorAttributeName value:self.hintTextOutlineColor range:fullRange];
+			[attrString addAttribute:NSStrokeWidthAttributeName value:@(-self.hintTextOutlineWidth) range:fullRange];
+		}
 		if (matchedPrefixLength > 0 && matchedPrefixLength <= [label length]) {
 			[attrString addAttribute:NSForegroundColorAttributeName
 			                   value:self.hintMatchedTextColor
@@ -1586,6 +1602,12 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	[attrString addAttribute:NSForegroundColorAttributeName
 	                   value:[self color:self.cachedGridTextColor withMultipliedAlpha:alpha]
 	                   range:fullRange];
+	if (self.gridTextOutlineWidth > 0 && self.gridTextOutlineColor) {
+		[attrString addAttribute:NSStrokeColorAttributeName
+		                   value:[self color:self.gridTextOutlineColor withMultipliedAlpha:alpha]
+		                   range:fullRange];
+		[attrString addAttribute:NSStrokeWidthAttributeName value:@(-self.gridTextOutlineWidth) range:fullRange];
+	}
 	if (isMatched && matchedPrefixLength > 0 && matchedPrefixLength <= [label length]) {
 		[attrString addAttribute:NSForegroundColorAttributeName
 		                   value:[self color:self.cachedGridMatchedTextColor withMultipliedAlpha:alpha]
@@ -1730,6 +1752,10 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 			[[str mutableString] setString:subLabel];
 			NSRange range = NSMakeRange(0, subLabel.length);
 			[str setAttributes:@{NSFontAttributeName : subFont, NSForegroundColorAttributeName : subColor} range:range];
+			if (self.gridSubKeyTextOutlineWidth > 0 && self.gridSubKeyTextOutlineColor) {
+				[str addAttribute:NSStrokeColorAttributeName value:self.gridSubKeyTextOutlineColor range:range];
+				[str addAttribute:NSStrokeWidthAttributeName value:@(-self.gridSubKeyTextOutlineWidth) range:range];
+			}
 
 			NSSize textSize = [str size];
 			CGFloat x = subRect.origin.x + (subCellWidth - textSize.width) / 2.0;
@@ -2535,6 +2561,8 @@ void NeruDrawIncrementHints(
 	NSString *bgHex = style.backgroundColor ? @(style.backgroundColor) : nil;
 	NSString *textHex = style.textColor ? @(style.textColor) : nil;
 	NSString *matchedTextHex = style.matchedTextColor ? @(style.matchedTextColor) : nil;
+	NSString *textOutlineHex = style.textOutlineColor ? @(style.textOutlineColor) : nil;
+	double textOutlineWidth = style.textOutlineWidth;
 	NSString *borderHex = style.borderColor ? @(style.borderColor) : nil;
 	NSString *boundaryBgHex = style.boundaryBackgroundColor ? @(style.boundaryBackgroundColor) : nil;
 	NSString *boundaryBorderHex = style.boundaryBorderColor ? @(style.boundaryBorderColor) : nil;
@@ -2602,6 +2630,15 @@ void NeruDrawIncrementHints(
 			controller.overlayView.hintBoundaryHighlightEnabled = boundaryHighlightEnabled ? YES : NO;
 			controller.overlayView.hintBoundaryBorderWidth = boundaryBorderWidth >= 0 ? boundaryBorderWidth : 1.0;
 			controller.overlayView.hintBoundaryBorderRadius = boundaryBorderRadius >= 0 ? boundaryBorderRadius : 4.0;
+
+			// Apply text outline
+			if (textOutlineHex) {
+				controller.overlayView.hintTextOutlineColor = [controller.overlayView colorFromHex:textOutlineHex
+				                                                                      defaultColor:nil];
+			} else {
+				controller.overlayView.hintTextOutlineColor = nil;
+			}
+			controller.overlayView.hintTextOutlineWidth = textOutlineWidth;
 
 			// Remove hints matching the given positions
 			if (positionsToRemoveArray && [positionsToRemoveArray count] > 0) {
@@ -2743,6 +2780,10 @@ void NeruDrawGridCells(OverlayWindow window, GridCell *cells, int count, GridCel
 	}
 	CGFloat subKeyAutohideMultiplier = style.subKeyAutohideMultiplier;
 	NSString *subKeyTextHex = style.subKeyTextColor ? @(style.subKeyTextColor) : nil;
+	NSString *textOutlineHex = style.textOutlineColor ? @(style.textOutlineColor) : nil;
+	int textOutlineWidth = style.textOutlineWidth;
+	NSString *subKeyTextOutlineHex = style.subKeyTextOutlineColor ? @(style.subKeyTextOutlineColor) : nil;
+	int subKeyTextOutlineWidth = style.subKeyTextOutlineWidth;
 
 	// Build sub-key labels array from the next-depth key string.
 	// Use composed-character enumeration so this stays correct even if
@@ -2833,6 +2874,24 @@ void NeruDrawGridCells(OverlayWindow window, GridCell *cells, int count, GridCel
 			controller.overlayView.cachedGridTextColor = controller.overlayView.gridTextColor;
 			controller.overlayView.cachedGridMatchedTextColor = controller.overlayView.gridMatchedTextColor;
 
+			// Apply text outline
+			if (textOutlineHex) {
+				controller.overlayView.gridTextOutlineColor = [controller.overlayView colorFromHex:textOutlineHex
+				                                                                      defaultColor:nil];
+			} else {
+				controller.overlayView.gridTextOutlineColor = nil;
+			}
+			controller.overlayView.gridTextOutlineWidth = textOutlineWidth;
+
+			// Apply sub-key preview text outline
+			if (subKeyTextOutlineHex) {
+				controller.overlayView.gridSubKeyTextOutlineColor =
+				    [controller.overlayView colorFromHex:subKeyTextOutlineHex defaultColor:nil];
+			} else {
+				controller.overlayView.gridSubKeyTextOutlineColor = nil;
+			}
+			controller.overlayView.gridSubKeyTextOutlineWidth = subKeyTextOutlineWidth;
+
 			// Replace cell data and redisplay
 			[controller.overlayView cancelGridTransition];
 			[controller.overlayView cancelCursorIndicatorTransition];
@@ -2892,6 +2951,8 @@ void NeruAnimateRecursiveGridTransition(
 	}
 	CGFloat subKeyAutohideMultiplier = style.subKeyAutohideMultiplier;
 	NSString *subKeyTextHex = style.subKeyTextColor ? @(style.subKeyTextColor) : nil;
+	NSString *textOutlineHex = style.textOutlineColor ? @(style.textOutlineColor) : nil;
+	int textOutlineWidth = style.textOutlineWidth;
 
 	NSString *subKeyKeysStr = style.subKeyKeys ? @(style.subKeyKeys) : nil;
 	NSMutableArray<NSString *> *subKeyLabels = nil;
@@ -2973,6 +3034,16 @@ void NeruAnimateRecursiveGridTransition(
 
 			controller.overlayView.cachedGridTextColor = controller.overlayView.gridTextColor;
 			controller.overlayView.cachedGridMatchedTextColor = controller.overlayView.gridMatchedTextColor;
+
+			// Apply text outline
+			if (textOutlineHex) {
+				controller.overlayView.gridTextOutlineColor = [controller.overlayView colorFromHex:textOutlineHex
+				                                                                      defaultColor:nil];
+			} else {
+				controller.overlayView.gridTextOutlineColor = nil;
+			}
+			controller.overlayView.gridTextOutlineWidth = textOutlineWidth;
+
 			[controller.overlayView startGridTransitionToCells:cellItems duration:duration];
 		}
 	});
@@ -3165,6 +3236,8 @@ void NeruDrawIncrementGrid(
 	NSString *labelBgHex = style.labelBackgroundColor ? @(style.labelBackgroundColor) : nil;
 	NSString *textHex = style.textColor ? @(style.textColor) : nil;
 	NSString *matchedTextHex = style.matchedTextColor ? @(style.matchedTextColor) : nil;
+	NSString *textOutlineHex = style.textOutlineColor ? @(style.textOutlineColor) : nil;
+	int textOutlineWidth = style.textOutlineWidth;
 	NSString *matchedBgHex = style.matchedBackgroundColor ? @(style.matchedBackgroundColor) : nil;
 	NSString *matchedBorderHex = style.matchedBorderColor ? @(style.matchedBorderColor) : nil;
 	NSString *borderHex = style.borderColor ? @(style.borderColor) : nil;
@@ -3240,6 +3313,16 @@ void NeruDrawIncrementGrid(
 			// Sync cached color references
 			controller.overlayView.cachedGridTextColor = controller.overlayView.gridTextColor;
 			controller.overlayView.cachedGridMatchedTextColor = controller.overlayView.gridMatchedTextColor;
+
+			// Apply text outline
+			if (textOutlineHex) {
+				controller.overlayView.gridTextOutlineColor = [controller.overlayView colorFromHex:textOutlineHex
+				                                                                      defaultColor:nil];
+			} else {
+				controller.overlayView.gridTextOutlineColor = nil;
+			}
+			controller.overlayView.gridTextOutlineWidth = textOutlineWidth;
+
 			[controller.overlayView cancelGridTransition];
 			[controller.overlayView cancelCursorIndicatorTransition];
 

--- a/internal/core/infra/platform/linux/overlay_wayland.c
+++ b/internal/core/infra/platform/linux/overlay_wayland.c
@@ -715,7 +715,7 @@ void neru_wayland_overlay_rounded_rect(
 
 void neru_wayland_overlay_text(
     NeruWaylandOverlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
-    unsigned int color) {
+    unsigned int color, unsigned int outline_color, double outline_width) {
 	for (int i = 0; i < overlay->nr_screens; i++) {
 		NeruWaylandOverlayScreen *scr = &overlay->screens[i];
 		if (!scr->cr)
@@ -731,10 +731,22 @@ void neru_wayland_overlay_text(
 		cairo_select_font_face(cr, font_family, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
 		cairo_set_font_size(cr, font_size);
 		cairo_text_extents(cr, text, &extents);
-		neru_wayland_overlay_color(cr, color);
-		cairo_move_to(
-		    cr, scr_x - (extents.width / 2.0) - extents.x_bearing, scr_y - (extents.height / 2.0) - extents.y_bearing);
-		cairo_show_text(cr, text);
+		double text_x = scr_x - (extents.width / 2.0) - extents.x_bearing;
+		double text_y = scr_y - (extents.height / 2.0) - extents.y_bearing;
+		if (outline_width > 0.0) {
+			cairo_move_to(cr, text_x, text_y);
+			cairo_text_path(cr, text);
+			neru_wayland_overlay_color(cr, outline_color);
+			cairo_set_line_width(cr, outline_width);
+			cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
+			cairo_stroke_preserve(cr);
+			neru_wayland_overlay_color(cr, color);
+			cairo_fill(cr);
+		} else {
+			neru_wayland_overlay_color(cr, color);
+			cairo_move_to(cr, text_x, text_y);
+			cairo_show_text(cr, text);
+		}
 		cairo_restore(cr);
 	}
 }

--- a/internal/core/infra/platform/linux/overlay_wayland.h
+++ b/internal/core/infra/platform/linux/overlay_wayland.h
@@ -75,7 +75,7 @@ void neru_wayland_overlay_rounded_rect(
     unsigned int stroke, double stroke_width);
 void neru_wayland_overlay_text(
     NeruWaylandOverlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
-    unsigned int color);
+    unsigned int color, unsigned int outline_color, double outline_width);
 int neru_wayland_overlay_poll(NeruWaylandOverlay *overlay);
 const char *neru_wayland_overlay_get_key(NeruWaylandOverlay *overlay);
 

--- a/internal/core/infra/platform/linux/x11_overlay.c
+++ b/internal/core/infra/platform/linux/x11_overlay.c
@@ -193,16 +193,29 @@ void neru_x11_overlay_rounded_rect(
 
 void neru_x11_overlay_text(
     NeruX11Overlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
-    unsigned int color) {
+    unsigned int color, unsigned int outline_color, double outline_width) {
 	cairo_t *cr = overlay->cr;
 	cairo_text_extents_t extents;
 	cairo_save(cr);
 	cairo_select_font_face(cr, font_family, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
 	cairo_set_font_size(cr, font_size);
 	cairo_text_extents(cr, text, &extents);
-	neru_x11_overlay_color(cr, color);
-	cairo_move_to(cr, x - (extents.width / 2.0) - extents.x_bearing, y - (extents.height / 2.0) - extents.y_bearing);
-	cairo_show_text(cr, text);
+	double text_x = x - (extents.width / 2.0) - extents.x_bearing;
+	double text_y = y - (extents.height / 2.0) - extents.y_bearing;
+	if (outline_width > 0.0) {
+		cairo_move_to(cr, text_x, text_y);
+		cairo_text_path(cr, text);
+		neru_x11_overlay_color(cr, outline_color);
+		cairo_set_line_width(cr, outline_width);
+		cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
+		cairo_stroke_preserve(cr);
+		neru_x11_overlay_color(cr, color);
+		cairo_fill(cr);
+	} else {
+		neru_x11_overlay_color(cr, color);
+		cairo_move_to(cr, text_x, text_y);
+		cairo_show_text(cr, text);
+	}
 	cairo_restore(cr);
 }
 

--- a/internal/core/infra/platform/linux/x11_overlay.h
+++ b/internal/core/infra/platform/linux/x11_overlay.h
@@ -32,7 +32,7 @@ void neru_x11_overlay_rounded_rect(
     unsigned int stroke, double stroke_width);
 void neru_x11_overlay_text(
     NeruX11Overlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
-    unsigned int color);
+    unsigned int color, unsigned int outline_color, double outline_width);
 void neru_x11_overlay_flush(NeruX11Overlay *overlay);
 
 #endif /* X11_OVERLAY_H */

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -134,11 +134,13 @@ type rectStroke struct {
 }
 
 type textDraw struct {
-	text       string
-	rect       image.Rectangle
-	fontFamily string
-	fontSize   float64
-	color      uint32
+	text         string
+	rect         image.Rectangle
+	fontFamily   string
+	fontSize     float64
+	color        uint32
+	outlineColor uint32
+	outlineWidth int
 }
 
 type bitmapV4Header struct {
@@ -579,13 +581,27 @@ func (o *OverlayWindow) StrokeRoundedRect(
 }
 
 // DrawTextCentered renders centered text inside bounds using GDI onto the
-// pixel buffer with alpha compositing.
+// pixel buffer with alpha compositing, without text outline.
 func (o *OverlayWindow) DrawTextCentered(
 	text string,
 	bounds image.Rectangle,
 	fontFamily string,
 	fontSize float64,
 	color uint32,
+) {
+	o.DrawTextCenteredWithOutline(text, bounds, fontFamily, fontSize, color, 0, 0)
+}
+
+// DrawTextCenteredWithOutline renders centered text with an optional outline
+// stroke. When outlineWidth <= 0, behavior is identical to DrawTextCentered.
+func (o *OverlayWindow) DrawTextCenteredWithOutline(
+	text string,
+	bounds image.Rectangle,
+	fontFamily string,
+	fontSize float64,
+	color uint32,
+	outlineColor uint32,
+	outlineWidth int,
 ) {
 	if o == nil || text == "" || bounds.Empty() {
 		return
@@ -597,11 +613,13 @@ func (o *OverlayWindow) DrawTextCentered(
 
 	o.mu.Lock()
 	o.texts = append(o.texts, textDraw{
-		text:       text,
-		rect:       bounds,
-		fontFamily: fontFamily,
-		fontSize:   fontSize,
-		color:      color,
+		text:         text,
+		rect:         bounds,
+		fontFamily:   fontFamily,
+		fontSize:     fontSize,
+		color:        color,
+		outlineColor: outlineColor,
+		outlineWidth: outlineWidth,
 	})
 	o.dirty = true
 	o.mu.Unlock()
@@ -644,7 +662,7 @@ func (o *OverlayWindow) CompositeCurrent() {
 	}
 
 	for _, t := range texts {
-		renderTextAlphaInto(o.pixels, o.width, o.height, t)
+		renderTextAlphaInto(o.pixels, o.width, o.height, t, t.outlineColor, t.outlineWidth)
 	}
 }
 
@@ -698,7 +716,7 @@ func (o *OverlayWindow) Flush() error {
 
 	// Render text via GDI onto a temporary bitmap, then composite.
 	for _, t := range texts {
-		renderTextAlphaInto(pixels, o.width, o.height, t)
+		renderTextAlphaInto(pixels, o.width, o.height, t, t.outlineColor, t.outlineWidth)
 	}
 
 	runOnOverlayUI(func() {
@@ -859,7 +877,13 @@ func (o *OverlayWindow) flushPixels() {
 	))
 }
 
-func renderTextAlphaInto(pixels []byte, bufW, bufH int, textCmd textDraw) {
+func renderTextAlphaInto(
+	pixels []byte,
+	bufW, bufH int,
+	textCmd textDraw,
+	outlineColor uint32,
+	outlineWidth int,
+) {
 	// Clamp text rect to overlay bounds.
 	textRect := textCmd.rect.Intersect(image.Rect(0, 0, bufW, bufH))
 	if textRect.Empty() {
@@ -998,7 +1022,33 @@ func renderTextAlphaInto(pixels []byte, bufW, bufH int, textCmd textDraw) {
 		dtCenter|dtVCenter|dtSingleLine,
 	))
 
-	// Composite the small text bitmap into the main pixel buffer at the correct offset.
+	// When outlineWidth > 0, dilate the text coverage mask and composite the
+	// outline behind the fill text.
+	if outlineWidth > 0 {
+		dilated := dilateCoverage(tmpPixels, texW, texH, outlineWidth)
+		outlinePixels := make([]byte, texW*texH*bytesPerPixel)
+		for y := 0; y < texH; y++ {
+			for x := 0; x < texW; x++ {
+				cov := dilated[y*texW+x]
+				if cov > 0 {
+					outlinePixels[(y*texW+x)*bytesPerPixel+2] = cov
+				}
+			}
+		}
+		alphaCompositeTextAt(
+			pixels,
+			bufW,
+			bufH,
+			outlinePixels,
+			texW,
+			texH,
+			textX,
+			textY,
+			outlineColor,
+		)
+	}
+
+	// Composite the fill text on top of any outline.
 	alphaCompositeTextAt(pixels, bufW, bufH, tmpPixels, texW, texH, textX, textY, textCmd.color)
 }
 
@@ -1312,6 +1362,45 @@ func alphaCompositeTextAt(
 			pixels[dstIdx+3] = byte(srcA + (dstA*invA)/alphaMax)
 		}
 	}
+}
+
+// dilateCoverage creates a dilated coverage mask from the text bitmap. For
+// each pixel, it finds the maximum coverage within a (outlineWidth*2+1) square
+// neighborhood in the source text bitmap. Coverage is read from the red channel
+// (index +2 in BGRA layout).
+func dilateCoverage(src []byte, w, h, outlineWidth int) []byte {
+	if outlineWidth <= 0 {
+		dst := make([]byte, w*h)
+		for y := 0; y < h; y++ {
+			for x := 0; x < w; x++ {
+				dst[y*w+x] = src[(y*w+x)*bytesPerPixel+2]
+			}
+		}
+		return dst
+	}
+
+	dst := make([]byte, w*h)
+	for y := 0; y < h; y++ {
+		y0 := max(0, y-outlineWidth)
+		y1 := min(h, y+outlineWidth+1)
+		for x := 0; x < w; x++ {
+			x0 := max(0, x-outlineWidth)
+			x1 := min(w, x+outlineWidth+1)
+
+			var maxCov byte
+			for dy := y0; dy < y1; dy++ {
+				row := dy * w * bytesPerPixel
+				for dx := x0; dx < x1; dx++ {
+					cov := src[row+dx*bytesPerPixel+2]
+					if cov > maxCov {
+						maxCov = cov
+					}
+				}
+			}
+			dst[y*w+x] = maxCov
+		}
+	}
+	return dst
 }
 
 func clamp(val, maxVal int) int {

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -1383,25 +1383,26 @@ func dilateCoverage(src []byte, width, height, outlineWidth int) []byte {
 	}
 
 	dst := make([]byte, width*height)
-	for y := range height {
-		yStart := max(0, y-outlineWidth)
-		yEnd := min(height, y+outlineWidth+1)
-		for x := range width {
-			xStart := max(0, x-outlineWidth)
-			xEnd := min(width, x+outlineWidth+1)
+	for row := range height {
+		yStart := max(0, row-outlineWidth)
+		yEnd := min(height, row+outlineWidth+1)
+
+		for col := range width {
+			xStart := max(0, col-outlineWidth)
+			xEnd := min(width, col+outlineWidth+1)
 
 			var maxCov byte
 			for dy := yStart; dy < yEnd; dy++ {
-				row := dy * width * bytesPerPixel
+				rowOffset := dy * width * bytesPerPixel
 				for dx := xStart; dx < xEnd; dx++ {
-					cov := src[row+dx*bytesPerPixel+2]
+					cov := src[rowOffset+dx*bytesPerPixel+2]
 					if cov > maxCov {
 						maxCov = cov
 					}
 				}
 			}
 
-			dst[y*width+x] = maxCov
+			dst[row*width+col] = maxCov
 		}
 	}
 

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -1027,14 +1027,16 @@ func renderTextAlphaInto(
 	if outlineWidth > 0 {
 		dilated := dilateCoverage(tmpPixels, texW, texH, outlineWidth)
 		outlinePixels := make([]byte, texW*texH*bytesPerPixel)
-		for y := 0; y < texH; y++ {
-			for x := 0; x < texW; x++ {
+
+		for y := range texH {
+			for x := range texW {
 				cov := dilated[y*texW+x]
 				if cov > 0 {
 					outlinePixels[(y*texW+x)*bytesPerPixel+2] = cov
 				}
 			}
 		}
+
 		alphaCompositeTextAt(
 			pixels,
 			bufW,
@@ -1368,38 +1370,41 @@ func alphaCompositeTextAt(
 // each pixel, it finds the maximum coverage within a (outlineWidth*2+1) square
 // neighborhood in the source text bitmap. Coverage is read from the red channel
 // (index +2 in BGRA layout).
-func dilateCoverage(src []byte, w, h, outlineWidth int) []byte {
+func dilateCoverage(src []byte, width, height, outlineWidth int) []byte {
 	if outlineWidth <= 0 {
-		dst := make([]byte, w*h)
-		for y := 0; y < h; y++ {
-			for x := 0; x < w; x++ {
-				dst[y*w+x] = src[(y*w+x)*bytesPerPixel+2]
+		dst := make([]byte, width*height)
+		for y := range height {
+			for x := range width {
+				dst[y*width+x] = src[(y*width+x)*bytesPerPixel+2]
 			}
 		}
+
 		return dst
 	}
 
-	dst := make([]byte, w*h)
-	for y := 0; y < h; y++ {
-		y0 := max(0, y-outlineWidth)
-		y1 := min(h, y+outlineWidth+1)
-		for x := 0; x < w; x++ {
-			x0 := max(0, x-outlineWidth)
-			x1 := min(w, x+outlineWidth+1)
+	dst := make([]byte, width*height)
+	for y := range height {
+		yStart := max(0, y-outlineWidth)
+		yEnd := min(height, y+outlineWidth+1)
+		for x := range width {
+			xStart := max(0, x-outlineWidth)
+			xEnd := min(width, x+outlineWidth+1)
 
 			var maxCov byte
-			for dy := y0; dy < y1; dy++ {
-				row := dy * w * bytesPerPixel
-				for dx := x0; dx < x1; dx++ {
+			for dy := yStart; dy < yEnd; dy++ {
+				row := dy * width * bytesPerPixel
+				for dx := xStart; dx < xEnd; dx++ {
 					cov := src[row+dx*bytesPerPixel+2]
 					if cov > maxCov {
 						maxCov = cov
 					}
 				}
 			}
-			dst[y*w+x] = maxCov
+
+			dst[y*width+x] = maxCov
 		}
 	}
+
 	return dst
 }
 

--- a/internal/core/infra/platform/windows/overlay.go
+++ b/internal/core/infra/platform/windows/overlay.go
@@ -1024,7 +1024,7 @@ func renderTextAlphaInto(
 
 	// When outlineWidth > 0, dilate the text coverage mask and composite the
 	// outline behind the fill text.
-	if outlineWidth > 0 {
+	if outlineWidth > 0 && outlineColor != 0 {
 		dilated := dilateCoverage(tmpPixels, texW, texH, outlineWidth)
 		outlinePixels := make([]byte, texW*texH*bytesPerPixel)
 

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -246,6 +246,8 @@ func (o *wlrootsOverlay) DrawRecursiveGridWithSubKeyPreview(
 					style.LabelFontName,
 					style.LabelFontSize,
 					style.LabelFontColor,
+					style.TextOutlineColor,
+					style.TextOutlineWidth,
 				)
 			}
 
@@ -284,6 +286,8 @@ func (o *wlrootsOverlay) DrawRecursiveGridWithSubKeyPreview(
 			fontName,
 			fontSize,
 			parseHexColor(virtualPointer.FillColor),
+			0,
+			0,
 		)
 	}
 
@@ -310,7 +314,7 @@ func (o *wlrootsOverlay) DrawBadge(
 	rect := badgeBounds(posX, posY, text, style)
 
 	o.drawRect(rect, colors.background, colors.border, max(style.borderWidth, 1))
-	o.drawTextCentered(text, rect, style.fontFamily, fontSize, colors.text)
+	o.drawTextCentered(text, rect, style.fontFamily, fontSize, colors.text, 0, 0)
 }
 
 func (o *wlrootsOverlay) Flush() {
@@ -365,12 +369,22 @@ func (o *wlrootsOverlay) DrawHints(
 			parseHexColor(style.BorderColor()),
 			float64(max(style.BorderWidth(), 0)),
 		)
+		outlineColor := uint32(0)
+		outlineWidth := float64(0)
+		if style.TextOutlineWidth() > 0 {
+			if oc := style.TextOutlineColor(); oc != "" {
+				outlineColor = parseHexColor(oc)
+			}
+			outlineWidth = float64(style.TextOutlineWidth())
+		}
 		o.drawTextCentered(
 			hint.Label(),
 			bounds,
 			style.FontFamily(),
 			float64(max(style.FontSize(), 1)),
 			parseHexColor(textColor),
+			outlineColor,
+			outlineWidth,
 		)
 	}
 
@@ -488,7 +502,15 @@ func (o *wlrootsOverlay) redrawGrid() {
 			border = style.MatchedBorderColor
 		}
 		o.drawRect(cell.Bounds(), fill, border, style.LineWidth)
-		o.drawTextCentered(label, cell.Bounds(), style.LabelFontName, style.LabelFontSize, text)
+		o.drawTextCentered(
+			label,
+			cell.Bounds(),
+			style.LabelFontName,
+			style.LabelFontSize,
+			text,
+			style.TextOutlineColor,
+			style.TextOutlineWidth,
+		)
 	}
 
 	if o.currentSubgrid != nil {
@@ -550,6 +572,8 @@ func (o *wlrootsOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent
 				style.LabelFontName,
 				style.LabelFontSize*subgridFontScale,
 				style.LabelFontColor,
+				style.TextOutlineColor,
+				style.TextOutlineWidth,
 			)
 			index++
 		}
@@ -600,6 +624,8 @@ func (o *wlrootsOverlay) drawTextCentered(
 	fontFamily string,
 	fontSize float64,
 	color uint32,
+	outlineColor uint32,
+	outlineWidth float64,
 ) {
 	cText := C.CString(text)
 	cFontFamily := C.CString(fontFamily)
@@ -614,6 +640,8 @@ func (o *wlrootsOverlay) drawTextCentered(
 		C.double(bounds.Min.Y+bounds.Dy()/2),
 		C.double(fontSize),
 		C.uint(color),
+		C.uint(outlineColor),
+		C.double(outlineWidth),
 	)
 }
 
@@ -675,6 +703,8 @@ func (o *wlrootsOverlay) drawSubKeyMiniGrid(
 			style.LabelFontName,
 			style.SubKeyPreviewFontSize,
 			style.SubKeyPreviewTextColor,
+			style.SubKeyPreviewTextOutlineColor,
+			style.SubKeyPreviewTextOutlineWidth,
 		)
 		subIndex++
 	}

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -200,6 +200,8 @@ func (o *x11Overlay) DrawRecursiveGridWithSubKeyPreview(
 					style.LabelFontName,
 					style.LabelFontSize,
 					style.LabelFontColor,
+					style.TextOutlineColor,
+					style.TextOutlineWidth,
 				)
 			}
 
@@ -238,6 +240,8 @@ func (o *x11Overlay) DrawRecursiveGridWithSubKeyPreview(
 			fontName,
 			fontSize,
 			parseHexColor(virtualPointer.FillColor),
+			0,
+			0,
 		)
 	}
 
@@ -263,7 +267,7 @@ func (o *x11Overlay) DrawBadge(
 	rect := badgeBounds(posX, posY, text, style)
 
 	o.drawRect(rect, colors.background, colors.border, max(style.borderWidth, 1))
-	o.drawTextCentered(text, rect, style.fontFamily, fontSize, colors.text)
+	o.drawTextCentered(text, rect, style.fontFamily, fontSize, colors.text, 0, 0)
 }
 
 func (o *x11Overlay) Flush() {
@@ -313,12 +317,22 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 			parseHexColor(style.BorderColor()),
 			float64(max(style.BorderWidth(), 0)),
 		)
+		outlineColor := uint32(0)
+		outlineWidth := float64(0)
+		if style.TextOutlineWidth() > 0 {
+			if oc := style.TextOutlineColor(); oc != "" {
+				outlineColor = parseHexColor(oc)
+			}
+			outlineWidth = float64(style.TextOutlineWidth())
+		}
 		o.drawTextCentered(
 			hint.Label(),
 			bounds,
 			style.FontFamily(),
 			float64(max(style.FontSize(), 1)),
 			parseHexColor(textColor),
+			outlineColor,
+			outlineWidth,
 		)
 	}
 
@@ -350,7 +364,15 @@ func (o *x11Overlay) redrawGrid() {
 			border = style.MatchedBorderColor
 		}
 		o.drawRect(cell.Bounds(), fill, border, style.LineWidth)
-		o.drawTextCentered(label, cell.Bounds(), style.LabelFontName, style.LabelFontSize, text)
+		o.drawTextCentered(
+			label,
+			cell.Bounds(),
+			style.LabelFontName,
+			style.LabelFontSize,
+			text,
+			style.TextOutlineColor,
+			style.TextOutlineWidth,
+		)
 	}
 
 	if o.currentSubgrid != nil {
@@ -402,6 +424,8 @@ func (o *x11Overlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Sty
 				style.LabelFontName,
 				style.LabelFontSize*subgridFontScale,
 				style.LabelFontColor,
+				style.TextOutlineColor,
+				style.TextOutlineWidth,
 			)
 			index++
 		}
@@ -452,6 +476,8 @@ func (o *x11Overlay) drawTextCentered(
 	fontFamily string,
 	fontSize float64,
 	color uint32,
+	outlineColor uint32,
+	outlineWidth float64,
 ) {
 	cText := C.CString(text)
 	cFontFamily := C.CString(fontFamily)
@@ -467,6 +493,8 @@ func (o *x11Overlay) drawTextCentered(
 		C.double(bounds.Min.Y+bounds.Dy()/2),
 		C.double(fontSize),
 		C.uint(color),
+		C.uint(outlineColor),
+		C.double(outlineWidth),
 	)
 }
 
@@ -528,6 +556,8 @@ func (o *x11Overlay) drawSubKeyMiniGrid(
 			style.LabelFontName,
 			style.SubKeyPreviewFontSize,
 			style.SubKeyPreviewTextColor,
+			style.SubKeyPreviewTextOutlineColor,
+			style.SubKeyPreviewTextOutlineWidth,
 		)
 		subIndex++
 	}

--- a/internal/ui/overlay/manager_windows_features.go
+++ b/internal/ui/overlay/manager_windows_features.go
@@ -322,8 +322,8 @@ func (o *winOverlay) drawRecursiveSubKeyPreview(
 		ports.ResolveFont(style.LabelFontName, false),
 		style.SubKeyPreviewFontSize,
 		style.SubKeyPreviewTextColor,
-		style.TextOutlineColor,
-		style.TextOutlineWidth,
+		style.SubKeyPreviewTextOutlineColor,
+		style.SubKeyPreviewTextOutlineWidth,
 	)
 }
 

--- a/internal/ui/overlay/manager_windows_features.go
+++ b/internal/ui/overlay/manager_windows_features.go
@@ -131,12 +131,16 @@ func (o *winOverlay) DrawHints(
 			)
 		}
 
-		o.window.DrawTextCentered(
+		outlineColor := parseHexColorARGB(style.TextOutlineColor())
+		outlineWidth := style.TextOutlineWidth()
+		o.window.DrawTextCenteredWithOutline(
 			hint.Label(),
 			bounds,
 			ports.ResolveFont(style.FontFamily(), false),
 			fontSize,
 			parseHexColorARGB(textColor),
+			outlineColor,
+			outlineWidth,
 		)
 
 		// Composite this hint atomically so its content lands as a unit,
@@ -205,12 +209,14 @@ func (o *winOverlay) DrawRecursiveGrid(
 					o.drawRecursiveLabelBackground(label, cell, style)
 				}
 
-				o.drawTextCentered(
+				o.drawTextCenteredWithOutline(
 					label,
 					cell,
 					ports.ResolveFont(style.LabelFontName, false),
 					style.LabelFontSize,
 					style.LabelFontColor,
+					style.TextOutlineColor,
+					style.TextOutlineWidth,
 				)
 			}
 
@@ -237,12 +243,14 @@ func (o *winOverlay) DrawRecursiveGrid(
 			virtualPointer.Position.X+halfSize,
 			virtualPointer.Position.Y+halfSize,
 		)
-		o.drawTextCentered(
+		o.drawTextCenteredWithOutline(
 			vpChar,
 			vpBounds,
 			fontName,
 			fontSize,
 			parseHexColorARGB(virtualPointer.FillColor),
+			0,
+			0,
 		)
 	}
 
@@ -308,12 +316,14 @@ func (o *winOverlay) drawRecursiveSubKeyPreview(
 		cell.Max.Y,
 	)
 
-	o.drawTextCentered(
+	o.drawTextCenteredWithOutline(
 		previewLabel,
 		previewRect,
 		ports.ResolveFont(style.LabelFontName, false),
 		style.SubKeyPreviewFontSize,
 		style.SubKeyPreviewTextColor,
+		style.TextOutlineColor,
+		style.TextOutlineWidth,
 	)
 }
 

--- a/internal/ui/overlay/manager_windows_overlay.go
+++ b/internal/ui/overlay/manager_windows_overlay.go
@@ -343,12 +343,14 @@ func (o *winOverlay) redrawGridWithoutFlush() {
 		o.drawCellBorder(cell.Bounds(), border, style.LineWidth)
 
 		if style.ShowLabels {
-			o.drawTextCentered(
+			o.drawTextCenteredWithOutline(
 				label,
 				cell.Bounds(),
 				ports.ResolveFont(style.LabelFontName, false),
 				style.LabelFontSize,
 				text,
+				style.TextOutlineColor,
+				style.TextOutlineWidth,
 			)
 		}
 	}
@@ -427,12 +429,14 @@ func (o *winOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Sty
 				yBreaks[row+1],
 			)
 			o.drawCellBorder(cell, style.LineColor, style.LineWidth)
-			o.drawTextCentered(
+			o.drawTextCenteredWithOutline(
 				string(keyRunes[index]),
 				cell,
 				ports.ResolveFont(style.LabelFontName, false),
 				style.LabelFontSize*winSubgridFontScale,
 				style.LabelFontColor,
+				style.TextOutlineColor,
+				style.TextOutlineWidth,
 			)
 			index++
 		}
@@ -467,9 +471,33 @@ func (o *winOverlay) drawTextCentered(
 	fontSize float64,
 	color uint32,
 ) {
+	o.drawTextCenteredWithOutline(text, bounds, fontFamily, fontSize, color, 0, 0)
+}
+
+func (o *winOverlay) drawTextCenteredWithOutline(
+	text string,
+	bounds image.Rectangle,
+	fontFamily string,
+	fontSize float64,
+	color uint32,
+	outlineColor uint32,
+	outlineWidth int,
+) {
 	if o == nil || o.window == nil {
 		return
 	}
 
-	o.window.DrawTextCentered(text, bounds, fontFamily, fontSize, color)
+	if outlineWidth > 0 {
+		o.window.DrawTextCenteredWithOutline(
+			text,
+			bounds,
+			fontFamily,
+			fontSize,
+			color,
+			outlineColor,
+			outlineWidth,
+		)
+	} else {
+		o.window.DrawTextCentered(text, bounds, fontFamily, fontSize, color)
+	}
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds `text_outline_color` and `text_outline_width` options for overlay text labels.

Defaults are `text_outline_color = ""` and `text_outline_width = 0`.

> [!NOTE]
> linux and windows code are written by AI................... I hope it works..

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #1067

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

### Rendering approach per platform

- **macOS**: `NSStrokeColorAttributeName` / `NSStrokeWidthAttributeName` on `NSMutableAttributedString` for `NSView`-based text. For `CATextLayer` (monitor select), an `NSAttributedString` with the same attributes is set as the layer's `string`.
- **Linux (X11/Wayland)**: `cairo_text_path()` + `cairo_stroke_preserve()` + `cairo_fill()` — stroke then fill within the same path.
- **Windows**: GDI `DrawTextW` into a DIB, followed by pixel-level coverage dilation for the outline pass.
