### PR TITLE
feat(cli): add `neru config set` for runtime config changes

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -522,13 +522,44 @@ neru config init -c /path/to/config.toml
 
 Check config for syntax errors and invalid values. Does not require a running daemon. Exits successfully if no config is found (Neru uses built-in defaults).
 
-### 13c. dump
+### 13c. set
+
+`neru config set <key> <value>`
+
+Set a configuration value on the running daemon without restarting. Changes take effect immediately. Requires a running daemon.
+
+The key uses dotted TOML path notation matching your config file (e.g. `hints.hint_characters`, `general.passthrough_unbounded_keys`).
+
+**SUPPORTED TYPES**
+
+| Type    | Example value                          |
+| ------- | -------------------------------------- |
+| string  | `"asdfghjkl"`                          |
+| integer | `14`                                   |
+| boolean | `true`                                 |
+| float   | `0.5`                                  |
+| color   | `"#FF0000AA"` or `{"light":"#000","dark":"#FFF"}` |
+| array   | `"AXButton,AXLink"` or `'["AXButton","AXLink"]'` |
+
+**EXAMPLES**
+
+```bash
+neru config set hints.hint_characters "asdfghjkl"
+neru config set hints.ui.font_size 14
+neru config set general.passthrough_unbounded_keys true
+neru config set hints.clickable_roles "AXButton,AXLink"
+neru config set scroll.scroll_step 50
+```
+
+Use `neru config dump | jq` to explore all available keys and their current values.
+
+### 13d. dump
 
 `neru config dump [-h|--help]`
 
 Print active config as JSON. Requires a running daemon.
 
-### 13d. reload
+### 13e. reload
 
 `neru config reload [-h|--help]`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -11,6 +11,7 @@ Neru uses TOML for configuration. No config file is required — Neru works out 
 - [Quick Start](#quick-start)
 - [Config File Location](#config-file-location)
 - [Managing Your Config](#managing-your-config)
+- [Runtime Config Changes](#runtime-config-changes)
 - [Color Format](#color-format)
 - [Hotkeys](#hotkeys)
 - [General](#general)
@@ -76,9 +77,48 @@ neru config validate    # Check syntax (no daemon needed)
 neru config reload      # Apply changes to running daemon
 neru config dump        # Print loaded config as JSON (daemon required)
 neru config init        # Create default config file
+neru config set <key> <value>  # Change a single value at runtime (see below)
 ```
 
 See [CLI.md](CLI.md#configuration-management) for full flag documentation.
+
+---
+
+## Runtime Config Changes
+
+Neru supports changing individual configuration values at runtime without restarting the daemon or re-reading the config file from disk.
+
+```bash
+neru config set hints.hint_characters "qwerty"
+neru config set scroll.scroll_step 25
+neru config set general.passthrough_unbounded_keys true
+```
+
+### How it works
+
+1. The CLI validates the path and value locally before sending to the daemon.
+2. The daemon deep-copies the current in-memory config, applies the change, and validates the result.
+3. Services, overlays, and hotkeys are reconfigured automatically — the same internal path used by `neru config reload`.
+4. The change is in-memory only. To make it persistent across restarts, update your config file too.
+
+### Supported field types
+
+| Type    | Example                                   |
+| ------- | ----------------------------------------- |
+| string  | `neru config set hints.hint_characters qwerty` |
+| integer | `neru config set hints.ui.font_size 14`        |
+| boolean | `neru config set scroll.invert_scroll true`    |
+| float   | `neru config set hints.vision.minimum_confidence 0.3` |
+| color   | `neru config set hints.ui.background_color "#FF0000AA"` |
+| array   | `neru config set hints.clickable_roles "AXButton,AXLink"` |
+
+> **Tip:** Use `neru config dump | jq` to explore the full config structure and find the dotted path for any setting.
+
+### Limitations
+
+- Array elements are replaced wholesale, not appended.
+- Struct fields (like `[theme]`) must be set via their leaf sub-paths, not as a whole object.
+- Config reload (`neru config reload`) via file on disk will override any runtime changes.
 
 ---
 

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -7,8 +7,65 @@ import (
 
 	"github.com/y3owk1n/neru/internal/config"
 	domainHint "github.com/y3owk1n/neru/internal/core/domain/hint"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	infra "github.com/y3owk1n/neru/internal/core/infra/accessibility"
 )
+
+// SetConfigField applies a single runtime config field change with full
+// app-level reconfiguration (component updates, hotkey re-registration, etc.).
+// This mirrors the reload path but operates on the in-memory config rather
+// than re-reading from disk.
+func (a *App) SetConfigField(ctx context.Context, key, value string) error {
+	a.prepareForConfigUpdate()
+
+	// Deep copy the current config so we only mutate the new copy.
+	newCfg, err := config.DeepCopyConfig(a.config)
+	if err != nil {
+		a.restoreHotkeysAfterFailedReload()
+
+		return derrors.Wrap(err, derrors.CodeSerializationFailed, "deep copy config")
+	}
+
+	// Apply the field change to the copy.
+	setErr := config.SetField(newCfg, key, value)
+	if setErr != nil {
+		a.restoreHotkeysAfterFailedReload()
+
+		return setErr
+	}
+
+	// Validate the new config.
+	valErr := newCfg.Validate()
+	if valErr != nil {
+		a.restoreHotkeysAfterFailedReload()
+
+		return derrors.Wrap(valErr, derrors.CodeInvalidConfig, "config-set validation")
+	}
+
+	// Update the config service (notifies watchers with the new config).
+	updateErr := a.configService.Update(newCfg)
+	if updateErr != nil {
+		a.restoreHotkeysAfterFailedReload()
+
+		return updateErr
+	}
+
+	// Build a LoadResult for the reconfiguration helpers.
+	loadResult := &config.LoadResult{
+		Config:     newCfg,
+		ConfigPath: a.ConfigPath,
+	}
+
+	a.applyAppSpecificConfigUpdates(loadResult)
+	a.reconfigureAfterUpdate(loadResult)
+
+	a.logger.Info("Config field updated at runtime",
+		zap.String("key", key),
+		zap.String("value", value),
+	)
+
+	return nil
+}
 
 // ReloadConfig reloads the configuration from the specified path.
 // If validation fails, shows an alert and keeps the current config.

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -424,7 +424,9 @@ func initializeModeHandler(app *App) {
 
 // initializeIPCController sets up the IPC controller for external communication.
 // Note: eventTap and ipcServer are nil at this point; they are set later
-// via SetInfrastructure in initializeEventTapAndIPC (Phase 8).
+// via SetInfrastructure in initializeEventTapAndIPC (Phase 8). The
+// SetConfigField callback is set after creation so the constructor's
+// signature stays stable for test callers.
 func initializeIPCController(app *App) {
 	app.ipcController = NewIPCController(
 		app.hintService,
@@ -441,6 +443,12 @@ func initializeIPCController(app *App) {
 		app.ReloadConfig,
 		app.logger,
 	)
+
+	// Set the config-set callback so runtime field changes propagate to
+	// app components (services, overlays, hotkeys, etc.). Uses the setter
+	// method so it also propagates to the info handler (which was created
+	// during construction before the callback was available).
+	app.ipcController.SetConfigFieldCallback(app.SetConfigField)
 }
 
 // setupScreenShareStateSubscription sets up a callback to update overlay when screen share state changes.

--- a/internal/app/ipc_controller.go
+++ b/internal/app/ipc_controller.go
@@ -37,6 +37,11 @@ type IPCController struct {
 	// Reload callback for full app-level config reload
 	ReloadConfig func(ctx context.Context, configPath string) error
 
+	// SetConfigField callback for runtime config field changes with full
+	// app-level reconfiguration (component updates, hotkey re-registration, etc.).
+	// If nil, the config is only updated in-memory.
+	SetConfigField func(ctx context.Context, key, value string) error
+
 	// Info handler for config updates
 	infoHandler *IPCControllerInfo
 
@@ -111,6 +116,19 @@ func (c *IPCController) UpdateConfig(cfg *config.Config) {
 	}
 }
 
+// SetConfigFieldCallback sets the callback for runtime config field changes
+// and propagates it to the info handler. Must be called after construction
+// (e.g. from initializeIPCController) since the constructor's registerHandlers
+// runs before the callback can be set.
+func (c *IPCController) SetConfigFieldCallback(
+	cb func(ctx context.Context, key, value string) error,
+) {
+	c.SetConfigField = cb
+	if c.infoHandler != nil {
+		c.infoHandler.setConfigField = cb
+	}
+}
+
 // SetInfrastructure updates the infrastructure references on the controller
 // and its info handler. This is called after event tap and IPC server are
 // initialized (Phase 8), since the IPC controller is created earlier (Phase 7).
@@ -150,12 +168,14 @@ func (c *IPCController) registerHandlers(cfg *config.Config) {
 		c.IPCServer,
 		c.ReloadConfig,
 		c.Logger,
+		nil, // setConfigField — set below before RegisterHandlers
 	)
 
 	// Register handlers from each component
 	lifecycleHandler.RegisterHandlers(c.Handlers)
 	modesHandler.RegisterHandlers(c.Handlers)
 	actionsHandler.RegisterHandlers(c.Handlers)
+
 	c.infoHandler.RegisterHandlers(c.Handlers)
 
 	// Register overlay handler

--- a/internal/app/ipc_controller_test.go
+++ b/internal/app/ipc_controller_test.go
@@ -165,6 +165,136 @@ func TestIPCController_UnknownCommand(t *testing.T) {
 	}
 }
 
+func TestIPCController_HandleConfigSet_String(t *testing.T) {
+	controller := newTestController()
+
+	ctx := context.Background()
+
+	// Set a string config field
+	commandResponse := controller.HandleCommand(ctx, ipc.Command{
+		Action: domain.CommandConfigSet,
+		Args:   []string{"hints.hint_characters", "qwerty"},
+	})
+
+	if !commandResponse.Success {
+		t.Fatalf(
+			"Expected success=true, got %v: %s",
+			commandResponse.Success,
+			commandResponse.Message,
+		)
+	}
+
+	if commandResponse.Code != ipc.CodeOK {
+		t.Fatalf("Expected code=%s, got %s", ipc.CodeOK, commandResponse.Code)
+	}
+
+	// Verify the change took effect by dumping the config
+	cfgResp := controller.HandleCommand(ctx, ipc.Command{Action: domain.CommandConfig})
+	if cfg, ok := cfgResp.Data.(*config.Config); ok && cfg != nil {
+		if cfg.Hints.HintCharacters != "qwerty" {
+			t.Errorf("Expected hint_characters='qwerty', got %q", cfg.Hints.HintCharacters)
+		}
+	} else {
+		t.Error("Failed to read config after set")
+	}
+}
+
+func TestIPCController_HandleConfigSet_Integer(t *testing.T) {
+	controller := newTestController()
+
+	ctx := context.Background()
+
+	commandResponse := controller.HandleCommand(ctx, ipc.Command{
+		Action: domain.CommandConfigSet,
+		Args:   []string{"hints.ui.font_size", "14"},
+	})
+
+	if !commandResponse.Success {
+		t.Fatalf(
+			"Expected success=true, got %v: %s",
+			commandResponse.Success,
+			commandResponse.Message,
+		)
+	}
+
+	// Verify the change
+	cfgResp := controller.HandleCommand(ctx, ipc.Command{Action: domain.CommandConfig})
+	if cfg, ok := cfgResp.Data.(*config.Config); ok && cfg != nil {
+		if cfg.Hints.UI.FontSize != 14 {
+			t.Errorf("Expected font_size=14, got %d", cfg.Hints.UI.FontSize)
+		}
+	} else {
+		t.Error("Failed to read config after set")
+	}
+}
+
+func TestIPCController_HandleConfigSet_Bool(t *testing.T) {
+	controller := newTestController()
+
+	ctx := context.Background()
+
+	commandResponse := controller.HandleCommand(ctx, ipc.Command{
+		Action: domain.CommandConfigSet,
+		Args:   []string{"general.passthrough_unbounded_keys", "true"},
+	})
+
+	if !commandResponse.Success {
+		t.Fatalf(
+			"Expected success=true, got %v: %s",
+			commandResponse.Success,
+			commandResponse.Message,
+		)
+	}
+
+	// Verify the change
+	cfgResp := controller.HandleCommand(ctx, ipc.Command{Action: domain.CommandConfig})
+	if cfg, ok := cfgResp.Data.(*config.Config); ok && cfg != nil {
+		if !cfg.General.PassthroughUnboundedKeys {
+			t.Error("Expected passthrough_unbounded_keys=true")
+		}
+	} else {
+		t.Error("Failed to read config after set")
+	}
+}
+
+func TestIPCController_HandleConfigSet_InvalidKey(t *testing.T) {
+	controller := newTestController()
+
+	ctx := context.Background()
+
+	commandResponse := controller.HandleCommand(ctx, ipc.Command{
+		Action: domain.CommandConfigSet,
+		Args:   []string{"hints.nonexistent", "value"},
+	})
+
+	if commandResponse.Success {
+		t.Fatal("Expected success=false for invalid key")
+	}
+
+	if commandResponse.Code != ipc.CodeInvalidInput {
+		t.Fatalf("Expected code=%s, got %s", ipc.CodeInvalidInput, commandResponse.Code)
+	}
+}
+
+func TestIPCController_HandleConfigSet_MissingArgs(t *testing.T) {
+	controller := newTestController()
+
+	ctx := context.Background()
+
+	commandResponse := controller.HandleCommand(ctx, ipc.Command{
+		Action: domain.CommandConfigSet,
+		Args:   []string{"hints.hint_characters"},
+	})
+
+	if commandResponse.Success {
+		t.Fatal("Expected success=false for missing args")
+	}
+
+	if commandResponse.Code != ipc.CodeInvalidInput {
+		t.Fatalf("Expected code=%s, got %s", ipc.CodeInvalidInput, commandResponse.Code)
+	}
+}
+
 func TestIPCController_UpdateConfig(t *testing.T) {
 	controller := newTestController()
 	ctx := context.Background()

--- a/internal/app/ipc_info.go
+++ b/internal/app/ipc_info.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,6 +30,10 @@ const healthNotInitialized = "not initialized"
 // supported/stub/headless/ok vocabulary.
 const detailSuffix = "_detail"
 
+// minConfigSetArgs is the minimum number of arguments required by the
+// config-set IPC handler (key and value).
+const minConfigSetArgs = 2
+
 // IPCControllerInfo handles info and config-related IPC commands.
 type IPCControllerInfo struct {
 	configService *config.Service
@@ -47,6 +52,11 @@ type IPCControllerInfo struct {
 
 	// configMu protects config from concurrent read/write.
 	configMu sync.RWMutex
+
+	// setConfigField is a callback invoked by handleConfigSet to apply a
+	// config field change at the app level (reconfigure components, re-register
+	// hotkeys, etc.). If nil only the in-memory config is updated.
+	setConfigField func(ctx context.Context, key, value string) error
 }
 
 // NewIPCControllerInfo creates a new info/config command handler.
@@ -64,21 +74,23 @@ func NewIPCControllerInfo(
 	ipcServer ports.IPCPort,
 	reloadConfig func(ctx context.Context, configPath string) error,
 	logger *zap.Logger,
+	setConfigField func(ctx context.Context, key, value string) error,
 ) *IPCControllerInfo {
 	return &IPCControllerInfo{
-		configService: configService,
-		appState:      appState,
-		config:        config,
-		modes:         modes,
-		hintService:   hintService,
-		gridService:   gridService,
-		actionService: actionService,
-		scrollService: scrollService,
-		systemPort:    systemPort,
-		eventTap:      eventTap,
-		ipcServer:     ipcServer,
-		reloadConfig:  reloadConfig,
-		logger:        logger,
+		configService:  configService,
+		appState:       appState,
+		config:         config,
+		modes:          modes,
+		hintService:    hintService,
+		gridService:    gridService,
+		actionService:  actionService,
+		scrollService:  scrollService,
+		systemPort:     systemPort,
+		eventTap:       eventTap,
+		ipcServer:      ipcServer,
+		reloadConfig:   reloadConfig,
+		setConfigField: setConfigField,
+		logger:         logger,
 	}
 }
 
@@ -90,6 +102,7 @@ func (h *IPCControllerInfo) RegisterHandlers(
 	handlers[domain.CommandConfig] = h.handleConfig
 	handlers[domain.CommandReloadConfig] = h.handleReloadConfig
 	handlers[domain.CommandHealth] = h.handleHealth
+	handlers[domain.CommandConfigSet] = h.handleConfigSet
 }
 
 // ResolveConfigPath determines the configuration file path for status reporting.
@@ -139,11 +152,7 @@ func (h *IPCControllerInfo) handleStatus(_ context.Context, _ ipc.Command) ipc.R
 	if cfg == nil {
 		h.logger.Error("Config is nil in handleStatus")
 
-		return ipc.Response{
-			Success: false,
-			Message: "config not available",
-			Code:    ipc.CodeActionFailed,
-		}
+		return h.configNotAvailableResponse()
 	}
 
 	status := map[string]any{
@@ -171,11 +180,7 @@ func (h *IPCControllerInfo) handleConfig(_ context.Context, _ ipc.Command) ipc.R
 	if cfg == nil {
 		h.logger.Error("Config is nil in handleConfig")
 
-		return ipc.Response{
-			Success: false,
-			Message: "config not available",
-			Code:    ipc.CodeActionFailed,
-		}
+		return h.configNotAvailableResponse()
 	}
 
 	return ipc.Response{
@@ -350,6 +355,96 @@ func (h *IPCControllerInfo) handleHealth(ctx context.Context, _ ipc.Command) ipc
 	}
 
 	return response
+}
+
+func (h *IPCControllerInfo) handleConfigSet(ctx context.Context, cmd ipc.Command) ipc.Response {
+	if len(cmd.Args) < minConfigSetArgs {
+		return ipc.Response{
+			Success: false,
+			Message: "config-set requires key and value arguments",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	key := cmd.Args[0]
+	value := cmd.Args[1]
+
+	// If an app-level callback is provided, delegate to it for full
+	// reconfiguration (component updates, hotkey re-registration, etc.).
+	if h.setConfigField != nil {
+		err := h.setConfigField(ctx, key, value)
+		if err != nil {
+			return ipc.Response{
+				Success: false,
+				Message: err.Error(),
+				Code:    ipc.CodeActionFailed,
+			}
+		}
+
+		return ipc.Response{
+			Success: true,
+			Message: fmt.Sprintf("config %s set to %q", key, value),
+			Code:    ipc.CodeOK,
+		}
+	}
+
+	// Fallback: update in-memory config only via the config service.
+	cfg := h.configSnapshot()
+	if cfg == nil {
+		return h.configNotAvailableResponse()
+	}
+
+	newCfg, err := config.DeepCopyConfig(cfg)
+	if err != nil {
+		h.logger.Error("Failed to deep copy config", zap.Error(err))
+
+		return ipc.Response{
+			Success: false,
+			Message: "failed to copy config: " + err.Error(),
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	setErr := config.SetField(newCfg, key, value)
+	if setErr != nil {
+		return ipc.Response{
+			Success: false,
+			Message: setErr.Error(),
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	updateErr := h.configService.Update(newCfg)
+	if updateErr != nil {
+		h.logger.Error("Failed to update config service", zap.Error(updateErr))
+
+		return ipc.Response{
+			Success: false,
+			Message: "failed to apply config: " + updateErr.Error(),
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	// Update the local config pointer.
+	h.configMu.Lock()
+	h.config = newCfg
+	h.configMu.Unlock()
+
+	return ipc.Response{
+		Success: true,
+		Message: fmt.Sprintf("config %s set to %q", key, value),
+		Code:    ipc.CodeOK,
+	}
+}
+
+// configNotAvailableResponse returns a standardized response for when the
+// config is nil. Extracted as a helper to avoid repeating the string literal.
+func (h *IPCControllerInfo) configNotAvailableResponse() ipc.Response {
+	return ipc.Response{
+		Success: false,
+		Message: "config not available",
+		Code:    ipc.CodeActionFailed,
+	}
 }
 
 func (h *IPCControllerInfo) systemCapabilities() ports.PlatformCapabilities {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -18,6 +18,7 @@ var configCmd = &cobra.Command{
 Subcommands:
   dump       Print the currently active configuration as JSON
   reload     Reload configuration from disk without restarting
+  set        Set a config value at runtime (no restart needed)
   init       Create a default configuration file to get started
   validate   Check a configuration file for errors
 
@@ -87,5 +88,6 @@ var configReloadCmd = &cobra.Command{
 func init() {
 	configCmd.AddCommand(configDumpCmd)
 	configCmd.AddCommand(configReloadCmd)
+	configCmd.AddCommand(configSetCmd)
 	RootCmd.AddCommand(configCmd)
 }

--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+// commandArgCount is the exact number of arguments expected by the config
+// set command (key and value).
+const commandArgCount = 2
+
+var configSetCmd = &cobra.Command{
+	Use:   "set <key> <value>",
+	Short: "Set a config value at runtime",
+	Long: `Set a configuration value on the running daemon without restarting.
+The key uses dotted TOML path notation matching your config file.
+
+Supported types: string, integer, boolean, float, color (#RGB/#RRGGBB/#AARRGGBB),
+array (comma-separated or JSON: "AXButton,AXLink" or '["AXButton","AXLink"]').
+
+Examples:
+  neru config set hints.hint_characters "asdfghjkl"
+  neru config set hints.ui.font_size 14
+  neru config set general.passthrough_unbounded_keys true
+  neru config set hints.clickable_roles "AXButton,AXLink"
+  neru config set scroll.scroll_step 50
+
+Use "neru config dump | jq" to explore all available keys.`,
+	Args: cobra.ExactArgs(commandArgCount),
+	PreRunE: func(_ *cobra.Command, _ []string) error {
+		return requiresRunningInstance()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		value := args[1]
+
+		valErr := config.ValidateConfigSetField(key, value)
+		if valErr != nil {
+			typeHint := config.ConfigFieldType(key)
+
+			return fmt.Errorf(
+				"invalid config path or value: %w\n  Field %q type: %s",
+				valErr,
+				key,
+				typeHint,
+			)
+		}
+
+		client := ipc.NewClient()
+
+		resp, err := client.Send(ipc.Command{
+			Action: domain.CommandConfigSet,
+			Args:   []string{key, value},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to send config-set command: %w", err)
+		}
+
+		if !resp.Success {
+			if resp.Code != "" {
+				return derrors.Newf(
+					derrors.CodeActionFailed,
+					"%s (code: %s)",
+					resp.Message,
+					resp.Code,
+				)
+			}
+
+			return derrors.New(derrors.CodeActionFailed, resp.Message)
+		}
+
+		if resp.Message != "" {
+			cmd.Println(resp.Message)
+		}
+
+		return nil
+	},
+}

--- a/internal/config/set_field.go
+++ b/internal/config/set_field.go
@@ -243,6 +243,9 @@ func ValidateConfigSetField(path, value string) error {
 	return nil
 }
 
+// unknownField is returned by ConfigFieldType when the path cannot be resolved.
+const unknownField = "unknown"
+
 // ConfigFieldType returns a human-readable type hint for a config path.
 //
 //nolint:revive,exhaustive
@@ -250,21 +253,30 @@ func ConfigFieldType(path string) string {
 	cfg := DefaultConfig()
 	target := reflect.ValueOf(cfg).Elem()
 
-	for part := range strings.SplitSeq(path, ".") {
+	parts := strings.Split(path, ".")
+	for partIdx, part := range parts {
 		field := findFieldByTomlTag(target, part)
 		if !field.IsValid() {
-			return "unknown"
+			return unknownField
 		}
 
-		if field.Kind() == reflect.Pointer {
-			field = field.Elem()
+		// Intermediate path elements must resolve to structs so the next
+		// iteration can call findFieldByTomlTag without panicking on
+		// NumField of a non-struct type.
+		if partIdx < len(parts)-1 {
+			target = derefStruct(field)
+			if target.Kind() != reflect.Struct {
+				return unknownField
+			}
+
+			continue
 		}
 
 		target = field
 	}
 
 	if !target.IsValid() {
-		return "unknown"
+		return unknownField
 	}
 
 	target = derefStruct(target)

--- a/internal/config/set_field.go
+++ b/internal/config/set_field.go
@@ -1,0 +1,291 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+)
+
+// SetField sets a field on a Config by dotted path (e.g. "hints.hint_characters").
+// Path elements use TOML tag names. Returns an error if the path is unknown or
+// the value cannot be converted.
+func SetField(cfg *Config, path, value string) error {
+	parts := strings.Split(path, ".")
+	if len(parts) == 0 || parts[0] == "" {
+		return derrors.New(derrors.CodeInvalidConfig, "config path cannot be empty")
+	}
+
+	target := reflect.ValueOf(cfg).Elem()
+	for partIdx, part := range parts {
+		field := findFieldByTomlTag(target, part)
+		if !field.IsValid() {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"unknown config field: %s (path element %q not found)",
+				path, part,
+			)
+		}
+
+		if partIdx == len(parts)-1 {
+			return setLeafValue(field, value)
+		}
+
+		target = derefStruct(field)
+		if target.Kind() != reflect.Struct {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%q in path %q is not a struct",
+				part, path,
+			)
+		}
+	}
+
+	return nil
+}
+
+// DeepCopyConfig returns a deep copy of cfg via JSON round-trip.
+func DeepCopyConfig(cfg *Config) (*Config, error) {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, derrors.Wrap(err, derrors.CodeSerializationFailed, "deep copy config")
+	}
+
+	var dst Config
+
+	unmarshalErr := json.Unmarshal(data, &dst)
+	if unmarshalErr != nil {
+		return nil, derrors.Wrap(unmarshalErr, derrors.CodeSerializationFailed, "deep copy config")
+	}
+
+	return &dst, nil
+}
+
+func findFieldByTomlTag(target reflect.Value, tagName string) reflect.Value {
+	typ := target.Type()
+	for fieldIdx := range typ.NumField() {
+		field := typ.Field(fieldIdx)
+
+		tag := field.Tag.Get("toml")
+		if tag == "" {
+			tag = field.Name
+		}
+
+		if idx := strings.Index(tag, ","); idx >= 0 {
+			tag = tag[:idx]
+		}
+
+		if tag == tagName {
+			return target.Field(fieldIdx)
+		}
+	}
+
+	return reflect.Value{}
+}
+
+func derefStruct(field reflect.Value) reflect.Value {
+	for field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+
+		field = field.Elem()
+	}
+
+	return field
+}
+
+// many variants (Chan, Map, Func, etc.) that are never valid config field types.
+//
+//nolint:exhaustive // Only config-relevant types are handled; reflect.Kind has
+func setLeafValue(field reflect.Value, value string) error {
+	field = derefStruct(field)
+
+	switch field.Kind() {
+	case reflect.String:
+		field.SetString(value)
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return derrors.Newf(derrors.CodeInvalidConfig, "cannot parse %q as integer", value)
+		}
+
+		field.SetInt(n)
+
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return derrors.Newf(derrors.CodeInvalidConfig, "cannot parse %q as float", value)
+		}
+
+		field.SetFloat(f)
+
+	case reflect.Bool:
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return derrors.Newf(derrors.CodeInvalidConfig, "cannot parse %q as boolean", value)
+		}
+
+		field.SetBool(b)
+
+	case reflect.Slice:
+		if field.Type().Elem().Kind() == reflect.String {
+			items := parseStringSlice(value)
+
+			sl := reflect.MakeSlice(field.Type(), len(items), len(items))
+			for i, s := range items {
+				sl.Index(i).SetString(s)
+			}
+
+			field.Set(sl)
+		} else {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"unsupported slice element type for %s",
+				field.Type(),
+			)
+		}
+
+	case reflect.Struct:
+		if field.Type().Name() == "Color" {
+			c := parseColorValue(value)
+
+			field.Set(reflect.ValueOf(c))
+		} else {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"cannot set struct field %q directly; use a dotted path to a leaf field or provide a JSON object",
+				field.Type().Name(),
+			)
+		}
+
+	default:
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"unsupported config field type: %s",
+			field.Type(),
+		)
+	}
+
+	return nil
+}
+
+func parseStringSlice(value string) []string {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+		inner := strings.TrimSpace(value[1 : len(value)-1])
+		if inner == "" {
+			return nil
+		}
+
+		var out []string
+		for item := range strings.SplitSeq(inner, ",") {
+			item = strings.TrimSpace(item)
+
+			item = strings.Trim(item, `"'`)
+			if item != "" {
+				out = append(out, item)
+			}
+		}
+
+		return out
+	}
+
+	if value == "" {
+		return nil
+	}
+
+	var out []string
+	for item := range strings.SplitSeq(value, ",") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+
+	return out
+}
+
+func parseColorValue(value string) Color {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}") {
+		var m map[string]string
+
+		err := json.Unmarshal([]byte(value), &m)
+		if err == nil {
+			return Color{Light: m["light"], Dark: m["dark"]}
+		}
+	}
+
+	return Color{Light: value, Dark: value}
+}
+
+// ValidateConfigSetField validates a config path is settable and value is valid
+// by performing the mutation on a throwaway copy. Used by the CLI to validate
+// before sending to the daemon.
+func ValidateConfigSetField(path, value string) error {
+	cfg := DefaultConfig()
+
+	err := SetField(cfg, path, value)
+	if err != nil {
+		return err
+	}
+
+	err = cfg.Validate()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ConfigFieldType returns a human-readable type hint for a config path.
+//
+//nolint:revive,exhaustive
+func ConfigFieldType(path string) string {
+	cfg := DefaultConfig()
+	target := reflect.ValueOf(cfg).Elem()
+
+	for part := range strings.SplitSeq(path, ".") {
+		field := findFieldByTomlTag(target, part)
+		if !field.IsValid() {
+			return "unknown"
+		}
+
+		if field.Kind() == reflect.Pointer {
+			field = field.Elem()
+		}
+
+		target = field
+	}
+
+	if !target.IsValid() {
+		return "unknown"
+	}
+
+	target = derefStruct(target)
+	switch target.Kind() {
+	case reflect.String:
+		return "string"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return "integer"
+	case reflect.Float32, reflect.Float64:
+		return "float"
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Slice:
+		return "array"
+	case reflect.Struct:
+		if target.Type().Name() == "Color" {
+			return "color (#RGB/#RRGGBB/#AARRGGBB or JSON object)"
+		}
+
+		return "object"
+	default:
+		return fmt.Sprintf("unknown (%s)", target.Kind())
+	}
+}

--- a/internal/config/set_field_test.go
+++ b/internal/config/set_field_test.go
@@ -1,0 +1,263 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+const (
+	testHintChars = "qwerty"
+	testColorHex  = "#FF0000AA"
+)
+
+func TestSetField_String(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := config.SetField(cfg, "hints.hint_characters", testHintChars)
+	if err != nil {
+		t.Fatalf("SetField() unexpected error: %v", err)
+	}
+
+	if cfg.Hints.HintCharacters != testHintChars {
+		t.Fatalf("Expected hint_characters=%q, got %q", testHintChars, cfg.Hints.HintCharacters)
+	}
+}
+
+func TestSetField_Integer(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := config.SetField(cfg, "hints.ui.font_size", "14")
+	if err != nil {
+		t.Fatalf("SetField() unexpected error: %v", err)
+	}
+
+	if cfg.Hints.UI.FontSize != 14 {
+		t.Fatalf("Expected font_size=14, got %d", cfg.Hints.UI.FontSize)
+	}
+}
+
+func TestSetField_Bool(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := config.SetField(cfg, "general.passthrough_unbounded_keys", "true")
+	if err != nil {
+		t.Fatalf("SetField() unexpected error: %v", err)
+	}
+
+	if !cfg.General.PassthroughUnboundedKeys {
+		t.Fatal("Expected passthrough_unbounded_keys=true")
+	}
+}
+
+func TestSetField_Float(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := config.SetField(cfg, "hints.vision.minimum_confidence", "0.5")
+	if err != nil {
+		t.Fatalf("SetField() unexpected error: %v", err)
+	}
+
+	if cfg.Hints.Vision.MinimumConfidence != 0.5 {
+		t.Fatalf("Expected minimum_confidence=0.5, got %f", cfg.Hints.Vision.MinimumConfidence)
+	}
+}
+
+func TestSetField_StringSlice(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := config.SetField(cfg, "hints.clickable_roles", "AXButton,AXLink")
+	if err != nil {
+		t.Fatalf("SetField() unexpected error: %v", err)
+	}
+
+	expected := []string{"AXButton", "AXLink"}
+	if len(cfg.Hints.ClickableRoles) != len(expected) {
+		t.Fatalf("Expected %d roles, got %d", len(expected), len(cfg.Hints.ClickableRoles))
+	}
+
+	for i, role := range expected {
+		if cfg.Hints.ClickableRoles[i] != role {
+			t.Fatalf("Expected role[%d]=%q, got %q", i, role, cfg.Hints.ClickableRoles[i])
+		}
+	}
+}
+
+func TestSetField_Color(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := config.SetField(cfg, "hints.ui.background_color", testColorHex)
+	if err != nil {
+		t.Fatalf("SetField() unexpected error: %v", err)
+	}
+
+	if cfg.Hints.UI.BackgroundColor.Light != testColorHex {
+		t.Fatalf(
+			"Expected background_color light=%q, got %q",
+			testColorHex,
+			cfg.Hints.UI.BackgroundColor.Light,
+		)
+	}
+
+	if cfg.Hints.UI.BackgroundColor.Dark != testColorHex {
+		t.Fatalf(
+			"Expected background_color dark=%q, got %q",
+			testColorHex,
+			cfg.Hints.UI.BackgroundColor.Dark,
+		)
+	}
+}
+
+func TestSetField_ColorJSON(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := config.SetField(
+		cfg,
+		"hints.ui.background_color",
+		`{"light":"#000","dark":"#FFF"}`,
+	)
+	if err != nil {
+		t.Fatalf("SetField() unexpected error: %v", err)
+	}
+
+	if cfg.Hints.UI.BackgroundColor.Light != "#000" {
+		t.Fatalf(
+			"Expected background_color light=%q, got %q",
+			"#000",
+			cfg.Hints.UI.BackgroundColor.Light,
+		)
+	}
+
+	if cfg.Hints.UI.BackgroundColor.Dark != "#FFF" {
+		t.Fatalf(
+			"Expected background_color dark=%q, got %q",
+			"#FFF",
+			cfg.Hints.UI.BackgroundColor.Dark,
+		)
+	}
+}
+
+func TestSetField_InvalidPath(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := config.SetField(cfg, "hints.nonexistent_field", "value")
+	if err == nil {
+		t.Fatal("Expected error for invalid path, got nil")
+	}
+}
+
+func TestSetField_EmptyPath(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := config.SetField(cfg, "", "value")
+	if err == nil {
+		t.Fatal("Expected error for empty path, got nil")
+	}
+}
+
+func TestSetField_InvalidIntegerValue(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := config.SetField(cfg, "hints.ui.font_size", "not-a-number")
+	if err == nil {
+		t.Fatal("Expected error for invalid integer value, got nil")
+	}
+}
+
+func TestSetField_InvalidBoolValue(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := config.SetField(cfg, "general.passthrough_unbounded_keys", "not-a-bool")
+	if err == nil {
+		t.Fatal("Expected error for invalid boolean value, got nil")
+	}
+}
+
+func TestDeepCopyConfig(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Hints.HintCharacters = testHintChars
+
+	deepCopy, err := config.DeepCopyConfig(cfg)
+	if err != nil {
+		t.Fatalf("DeepCopyConfig() unexpected error: %v", err)
+	}
+
+	if deepCopy.Hints.HintCharacters != testHintChars {
+		t.Fatalf(
+			"Expected copy hint_characters=%q, got %q",
+			testHintChars,
+			deepCopy.Hints.HintCharacters,
+		)
+	}
+
+	// Ensure it's a deep copy — modifying the copy should not affect the original
+	deepCopy.Hints.HintCharacters = "asdf"
+	if cfg.Hints.HintCharacters != testHintChars {
+		t.Fatal("DeepCopyConfig() did not produce an independent copy")
+	}
+}
+
+func TestValidateConfigSetField_Valid(t *testing.T) {
+	err := config.ValidateConfigSetField("hints.hint_characters", testHintChars)
+	if err != nil {
+		t.Fatalf("ValidateConfigSetField() unexpected error: %v", err)
+	}
+}
+
+func TestValidateConfigSetField_InvalidPath(t *testing.T) {
+	err := config.ValidateConfigSetField("hints.nonexistent", "value")
+	if err == nil {
+		t.Fatal("Expected error for invalid path")
+	}
+}
+
+func TestConfigFieldType_String(t *testing.T) {
+	typeHint := config.ConfigFieldType("hints.hint_characters")
+	if typeHint != "string" {
+		t.Fatalf("Expected type 'string', got %q", typeHint)
+	}
+}
+
+func TestConfigFieldType_Integer(t *testing.T) {
+	typeHint := config.ConfigFieldType("hints.ui.font_size")
+	if typeHint != "integer" {
+		t.Fatalf("Expected type 'integer', got %q", typeHint)
+	}
+}
+
+func TestConfigFieldType_Bool(t *testing.T) {
+	typeHint := config.ConfigFieldType("general.passthrough_unbounded_keys")
+	if typeHint != "boolean" {
+		t.Fatalf("Expected type 'boolean', got %q", typeHint)
+	}
+}
+
+func TestConfigFieldType_Float(t *testing.T) {
+	typeHint := config.ConfigFieldType("hints.vision.minimum_confidence")
+	if typeHint != "float" {
+		t.Fatalf("Expected type 'float', got %q", typeHint)
+	}
+}
+
+func TestConfigFieldType_Array(t *testing.T) {
+	typeHint := config.ConfigFieldType("hints.clickable_roles")
+	if typeHint != "array" {
+		t.Fatalf("Expected type 'array', got %q", typeHint)
+	}
+}
+
+func TestConfigFieldType_Color(t *testing.T) {
+	const want = "color (#RGB/#RRGGBB/#AARRGGBB or JSON object)"
+
+	typeHint := config.ConfigFieldType("hints.ui.background_color")
+	if typeHint != want {
+		t.Fatalf("Expected type %q, got %q", want, typeHint)
+	}
+}
+
+func TestConfigFieldType_Unknown(t *testing.T) {
+	typeHint := config.ConfigFieldType("nonexistent.path")
+	if typeHint != "unknown" {
+		t.Fatalf("Expected 'unknown', got %q", typeHint)
+	}
+}

--- a/internal/core/domain/domain_constants.go
+++ b/internal/core/domain/domain_constants.go
@@ -37,6 +37,7 @@ const (
 	CommandToggleScreenShare           = "toggle-screen-share"
 	CommandToggleCursorFollowSelection = "toggle-cursor-follow-selection"
 	CommandToggleScrollInvert          = "toggle-scroll-invert"
+	CommandConfigSet                   = "config-set"
 )
 
 // Mode-related constants.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a new cli `neru config set <key> <value>` for changing the config in runtime. The key uses dotted TOML path notation with supported vaue types of `string`, `integer`, `boolean`, `float`, `color`, and `string arrays`.

Example:

```bash
neru config set hints.hint_characters "bmwvz;qjkxdhtns"
neru config set recursive_grid.ui.highlight_color "#B00A1338"
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #1069

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/84f326e3-639d-48e8-9546-65e3c25af816

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
