### PR TITLE
feat(recursive_grid): add `--zoom-to-depth` flag

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -187,7 +187,7 @@ neru grid --cursor-selection-mode hold
 
 ## 9. neru recursive_grid
 
-`neru recursive_grid [-h|--help] [-a|--action <action>] [-t|--toggle] [-r|--repeat] [--modifier <mod>] [--cursor-selection-mode <mode>]`
+`neru recursive_grid [-h|--help] [-a|--action <action>] [-t|--toggle] [-r|--repeat] [--modifier <mod>] [--cursor-selection-mode <mode>] [--zoom-to-depth <depth>]`
 
 Divide the screen into cells. Each keypress narrows the active area recursively.
 
@@ -205,11 +205,15 @@ Divide the screen into cells. Each keypress narrows the active area recursively.
 
 `--cursor-selection-mode <mode>` -- `follow` (default) or `hold`.
 
+`--zoom-to-depth <depth>` -- Auto-drill to the specified depth at the current cursor position. If the grid cannot divide further (min size or max depth), zooming stops early. Negative values are rejected.
+
 **EXAMPLES**
 
 ```bash
 neru recursive_grid
 neru recursive_grid --action middle_click
+neru recursive_grid --zoom-to-depth 2
+neru recursive_grid --zoom-to-depth 3 --action left_click
 ```
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -665,7 +665,7 @@ See [per-app hotkey overrides](#per-app-hotkey-overrides).
 
 Narrows the active area with each keypress for precise cursor placement.
 
-Cursor behavior: `neru recursive_grid --cursor-selection-mode follow|hold` (see [CLI.md](CLI.md#recursive-grid-mode)). Default hotkeys include `` ` `` for `toggle-cursor-follow-selection`.
+Cursor behavior: `neru recursive_grid --cursor-selection-mode follow|hold` (see [CLI.md](CLI.md#recursive-grid-mode)). Auto-zoom to a specific depth on activation with `--zoom-to-depth <n>` (e.g. `neru recursive_grid --zoom-to-depth 3`). Default hotkeys include `` ` `` for `toggle-cursor-follow-selection`.
 
 ### Options
 

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -169,6 +169,18 @@ Use `--toggle` to turn a single hotkey into a mode toggle — pressing it once a
 
 This is especially useful when you want a single key to both enter and exit a mode, avoiding the need for a separate `Escape` press or a dedicated exit keybinding.
 
+## Auto-Zoom to Depth on Activation
+
+Use `--zoom-to-depth` to automatically drill down to a target depth at the current cursor position when recursive grid opens. This skips intermediate cell selections and places you directly at the desired depth:
+
+```toml
+[hotkeys]
+"Primary+Shift+2" = "recursive_grid --zoom-to-depth 2"
+"Primary+Shift+3" = "recursive_grid --zoom-to-depth 3 --action left_click"
+```
+
+If the depth exceeds the available grid depth, zooming clamps silently at the deepest level possible.
+
 ## Cycle Through Modes with One Hotkey
 
 Instead of a separate launcher key for every mode, one key can walk through all of them. Press it from idle to open the first mode, then press the same key again to advance through hints, recursive grid, grid, and scroll, wrapping back to hints at the end.

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
@@ -154,6 +155,7 @@ type ModeActivationOptions struct {
 	Modifier              *string
 	Repeat                *bool
 	CursorFollowSelection *bool
+	ZoomToDepth           *int
 	FilterRoles           []string
 	FilterTextContains    []string
 	Search                *bool
@@ -224,6 +226,44 @@ func (h *IPCControllerModes) extractModeOptions(
 		case arg == "--toggle" || arg == "-t":
 			toggleTrue := true
 			opts.Toggle = &toggleTrue
+		case strings.HasPrefix(arg, "--zoom-to-depth="):
+			depthVal, err := strconv.Atoi(strings.TrimPrefix(arg, "--zoom-to-depth="))
+			if err != nil || depthVal < 0 {
+				resp := ipc.Response{
+					Success: false,
+					Message: "--zoom-to-depth requires a non-negative integer",
+					Code:    ipc.CodeInvalidInput,
+				}
+
+				return opts, &resp
+			}
+
+			opts.ZoomToDepth = &depthVal
+		case arg == "--zoom-to-depth":
+			if startIdx+1 >= len(cmd.Args) {
+				resp := ipc.Response{
+					Success: false,
+					Message: "--zoom-to-depth requires a value",
+					Code:    ipc.CodeInvalidInput,
+				}
+
+				return opts, &resp
+			}
+
+			startIdx++
+
+			depthVal, err := strconv.Atoi(cmd.Args[startIdx])
+			if err != nil || depthVal < 0 {
+				resp := ipc.Response{
+					Success: false,
+					Message: "--zoom-to-depth requires a non-negative integer",
+					Code:    ipc.CodeInvalidInput,
+				}
+
+				return opts, &resp
+			}
+
+			opts.ZoomToDepth = &depthVal
 		case arg == "--search" || arg == "-s":
 			searchTrue := true
 			opts.Search = &searchTrue
@@ -621,6 +661,7 @@ func (h *IPCControllerModes) handleRecursiveGrid(_ context.Context, cmd ipc.Comm
 		Modifier:              opts.Modifier,
 		Repeat:                opts.Repeat,
 		CursorFollowSelection: opts.CursorFollowSelection,
+		ZoomToDepth:           opts.ZoomToDepth,
 		Toggle:                opts.Toggle,
 	})
 

--- a/internal/app/modes/generic_mode.go
+++ b/internal/app/modes/generic_mode.go
@@ -71,6 +71,7 @@ func (m *GenericMode) Activate(opts ModeActivationOptions) {
 				opts.Modifier,
 				opts.Repeat,
 				opts.CursorFollowSelection,
+				nil, // zoom is not re-applied on screen change
 			)
 		case domain.ModeScroll:
 			m.handler.StartInteractiveScroll()

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -40,6 +40,7 @@ type ModeActivationOptions struct {
 	Modifier              *string
 	Repeat                *bool
 	CursorFollowSelection *bool
+	ZoomToDepth           *int
 	FilterRoles           []string
 	FilterTextContains    []string
 	Search                *bool

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -87,24 +87,9 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 		)
 	}
 
-	// Move cursor to center of initial grid
-	if h.recursiveGrid.Manager != nil {
-		center := h.recursiveGrid.Manager.CurrentGrid().CurrentCenter()
-
-		absoluteCenter := coordinates.ConvertToAbsoluteCoordinates(center, h.screenBounds)
-		if h.recursiveGrid.Context != nil {
-			h.recursiveGrid.Context.SetSelectionPoint(absoluteCenter)
-		}
-
-		if cursorShouldFollow {
-			err := h.actionService.MoveCursorToPoint(h.ctx, absoluteCenter)
-			if err != nil {
-				h.logger.Warn("Failed to move cursor to initial center", zap.Error(err))
-			}
-		}
-	}
-
-	// Auto-zoom to depth if requested
+	// Auto-zoom to depth if requested.
+	// This reads the cursor position *before* we potentially move it to
+	// the grid center below, so zoom uses the user's actual cursor location.
 	var (
 		zoomCompleted bool
 		zoomCenter    image.Point
@@ -119,6 +104,27 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 			zoomCompleted = completed
 		} else {
 			h.logger.Warn("Failed to get cursor position for zoom", zap.Error(posErr))
+		}
+	}
+
+	// Move cursor to center of initial grid.
+	// When zoom-to-depth is active, skip this — the zoom completion handler
+	// (or partial-zoom handler below) positions the cursor from the user's
+	// actual cursor position rather than the grid center.
+	isZoomRequested := zoomToDepth != nil && *zoomToDepth > 0 && !isRefresh
+	if !isZoomRequested && h.recursiveGrid.Manager != nil {
+		center := h.recursiveGrid.Manager.CurrentGrid().CurrentCenter()
+
+		absoluteCenter := coordinates.ConvertToAbsoluteCoordinates(center, h.screenBounds)
+		if h.recursiveGrid.Context != nil {
+			h.recursiveGrid.Context.SetSelectionPoint(absoluteCenter)
+		}
+
+		if cursorShouldFollow {
+			err := h.actionService.MoveCursorToPoint(h.ctx, absoluteCenter)
+			if err != nil {
+				h.logger.Warn("Failed to move cursor to initial center", zap.Error(err))
+			}
 		}
 	}
 

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -15,12 +15,15 @@ import (
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
-// activateRecursiveGridModeWithAction activates recursive-grid mode with optional action parameter.
+// activateRecursiveGridModeWithAction activates recursive-grid mode with optional action parameter
+// and optional zoom-to-depth. When zoomToDepth is set, the mode will automatically drill down to
+// the specified depth at the current cursor position before awaiting user input.
 func (h *Handler) activateRecursiveGridModeWithAction(
 	actionStr *string,
 	modifier *string,
 	repeat *bool,
 	cursorFollowSelection *bool,
+	zoomToDepth *int,
 ) {
 	// Detect refresh before validation so we can do partial cleanup on re-activation.
 	isRefresh := h.appState.CurrentMode() == domain.ModeRecursiveGrid
@@ -101,6 +104,24 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 		}
 	}
 
+	// Auto-zoom to depth if requested
+	var (
+		zoomCompleted bool
+		zoomCenter    image.Point
+	)
+
+	if zoomToDepth != nil && *zoomToDepth > 0 && h.recursiveGrid.Manager != nil && !isRefresh {
+		cursorPos, posErr := h.actionService.CursorPosition(h.ctx)
+		if posErr == nil {
+			localCursorPos := coordinates.ConvertToLocalCoordinates(cursorPos, h.screenBounds)
+			center, completed := h.recursiveGrid.Manager.ZoomToPoint(localCursorPos, *zoomToDepth)
+			zoomCenter = center
+			zoomCompleted = completed
+		} else {
+			h.logger.Warn("Failed to get cursor position for zoom", zap.Error(posErr))
+		}
+	}
+
 	// Draw initial recursive-grid
 	// Store pending action and repeat flag if provided
 	if h.recursiveGrid.Context != nil {
@@ -125,6 +146,57 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 			h.recursiveGrid.Context.SetPendingModifier(modifier)
 			h.recursiveGrid.Context.SetRepeat(repeat != nil && *repeat)
 			h.recursiveGrid.Context.SetCursorFollowSelection(cursorShouldFollow)
+		}
+	}
+
+	// If zoom-to-depth completed the grid, handle completion immediately
+	// instead of entering interactive mode.
+	if zoomCompleted {
+		absoluteCenter := coordinates.ConvertToAbsoluteCoordinates(zoomCenter, h.screenBounds)
+		if h.recursiveGrid.Context != nil {
+			h.recursiveGrid.Context.SetSelectionPoint(absoluteCenter)
+		}
+
+		shouldReActivate := repeat != nil && *repeat
+		pendingAction := h.recursiveGrid.Context.PendingAction()
+
+		// Move cursor and either execute action or re-activate
+		h.moveCursorAndHandleAction(
+			absoluteCenter,
+			pendingAction,
+			h.recursiveGrid.Context.PendingModifier(),
+			shouldReActivate,
+			func() {
+				h.activateRecursiveGridModeWithAction(
+					pendingAction,
+					h.recursiveGrid.Context.PendingModifier(),
+					repeat,
+					&cursorShouldFollow,
+					nil,
+				)
+			},
+		)
+
+		// Exit here since moveCursorAndHandleAction handles mode transition.
+		return
+	}
+
+	// When zoom was active (but didn't complete), update the selection point
+	// to reflect the zoomed position.
+	if zoomToDepth != nil && *zoomToDepth > 0 && !isRefresh &&
+		h.recursiveGrid.Manager != nil {
+		center := h.recursiveGrid.Manager.CurrentGrid().CurrentCenter()
+
+		absoluteCenter := coordinates.ConvertToAbsoluteCoordinates(center, h.screenBounds)
+		if h.recursiveGrid.Context != nil {
+			h.recursiveGrid.Context.SetSelectionPoint(absoluteCenter)
+		}
+
+		if cursorShouldFollow {
+			err := h.actionService.MoveCursorToPoint(h.ctx, absoluteCenter)
+			if err != nil {
+				h.logger.Warn("Failed to move cursor after zoom", zap.Error(err))
+			}
 		}
 	}
 
@@ -244,6 +316,7 @@ func (h *Handler) handleRecursiveGridKey(key string) {
 					pendingModifier,
 					&repeat,
 					&cursorFollowSelection,
+					nil, // zoom is not re-applied on repeat
 				)
 			},
 		)

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -90,18 +90,11 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 	// Auto-zoom to depth if requested.
 	// This reads the cursor position *before* we potentially move it to
 	// the grid center below, so zoom uses the user's actual cursor location.
-	var (
-		zoomCompleted bool
-		zoomCenter    image.Point
-	)
-
 	if zoomToDepth != nil && *zoomToDepth > 0 && h.recursiveGrid.Manager != nil && !isRefresh {
 		cursorPos, posErr := h.actionService.CursorPosition(h.ctx)
 		if posErr == nil {
 			localCursorPos := coordinates.ConvertToLocalCoordinates(cursorPos, h.screenBounds)
-			center, completed := h.recursiveGrid.Manager.ZoomToPoint(localCursorPos, *zoomToDepth)
-			zoomCenter = center
-			zoomCompleted = completed
+			h.recursiveGrid.Manager.ZoomToPoint(localCursorPos, *zoomToDepth)
 		} else {
 			h.logger.Warn("Failed to get cursor position for zoom", zap.Error(posErr))
 		}
@@ -155,40 +148,10 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 		}
 	}
 
-	// If zoom-to-depth completed the grid, handle completion immediately
-	// instead of entering interactive mode.
-	if zoomCompleted {
-		absoluteCenter := coordinates.ConvertToAbsoluteCoordinates(zoomCenter, h.screenBounds)
-		if h.recursiveGrid.Context != nil {
-			h.recursiveGrid.Context.SetSelectionPoint(absoluteCenter)
-		}
-
-		shouldReActivate := repeat != nil && *repeat
-		pendingAction := h.recursiveGrid.Context.PendingAction()
-
-		// Move cursor and either execute action or re-activate
-		h.moveCursorAndHandleAction(
-			absoluteCenter,
-			pendingAction,
-			h.recursiveGrid.Context.PendingModifier(),
-			shouldReActivate,
-			func() {
-				h.activateRecursiveGridModeWithAction(
-					pendingAction,
-					h.recursiveGrid.Context.PendingModifier(),
-					repeat,
-					&cursorShouldFollow,
-					nil,
-				)
-			},
-		)
-
-		// Exit here since moveCursorAndHandleAction handles mode transition.
-		return
-	}
-
-	// When zoom was active (but didn't complete), update the selection point
-	// to reflect the zoomed position.
+	// When zoom-to-depth completed (or clamped), update the selection point
+	// to the zoomed position and let the user refine in interactive mode.
+	// The pending action fires on the next manual cell selection rather than
+	// executing immediately, which is consistent with normal grid behavior.
 	if zoomToDepth != nil && *zoomToDepth > 0 && !isRefresh &&
 		h.recursiveGrid.Manager != nil {
 		center := h.recursiveGrid.Manager.CurrentGrid().CurrentCenter()

--- a/internal/app/modes/recursive_grid_mode.go
+++ b/internal/app/modes/recursive_grid_mode.go
@@ -18,6 +18,7 @@ func NewRecursiveGridMode(handler *Handler) *RecursiveGridMode {
 				opts.Modifier,
 				opts.Repeat,
 				opts.CursorFollowSelection,
+				opts.ZoomToDepth,
 			)
 		},
 		HandleKeyFunc: func(handler *Handler, key string) {

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -35,7 +35,19 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 		Aliases: config.Aliases,
 		Short:   config.Short,
 		Long:    config.Long,
-		PreRunE: func(_ *cobra.Command, _ []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Validate before requiring a running daemon so users get
+			// immediate feedback on invalid arguments regardless of daemon state.
+			if config.SupportZoomToDepth {
+				zoomToDepth, err := cmd.Flags().GetInt("zoom-to-depth")
+				if err == nil && zoomToDepth < 0 {
+					return derrors.New(
+						derrors.CodeInvalidInput,
+						"--zoom-to-depth requires a non-negative integer",
+					)
+				}
+			}
+
 			return requiresRunningInstance()
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -25,6 +25,7 @@ type ModeConfig struct {
 	SupportLabelDirection    bool     // Whether this mode supports the --label-direction flag
 	SupportDebug             bool     // Whether this mode supports the --debug probe flag
 	SupportSplitWord         bool     // Whether this mode supports the --split-word flag
+	SupportZoomToDepth       bool     // Whether this mode supports the --zoom-to-depth flag
 }
 
 // BuildModeCommand creates a CLI command for a navigation mode (hints, grid, etc.).
@@ -116,6 +117,21 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				labelDirectionFlag, err = cmd.Flags().GetString("label-direction")
 				if err != nil {
 					return err
+				}
+			}
+
+			var zoomToDepthFlag int
+			if config.SupportZoomToDepth {
+				zoomToDepthFlag, err = cmd.Flags().GetInt("zoom-to-depth")
+				if err != nil {
+					return err
+				}
+
+				if zoomToDepthFlag < 0 {
+					return derrors.New(
+						derrors.CodeInvalidInput,
+						"--zoom-to-depth requires a non-negative integer",
+					)
 				}
 			}
 
@@ -256,6 +272,10 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				params = append(params, "--cursor-selection-mode="+cursorSelectionMode)
 			}
 
+			if config.SupportZoomToDepth && zoomToDepthFlag > 0 {
+				params = append(params, fmt.Sprintf("--zoom-to-depth=%d", zoomToDepthFlag))
+			}
+
 			if strategyFlag != "" {
 				params = append(params, "--strategy="+strategyFlag)
 			}
@@ -311,6 +331,14 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 		"",
 		"How the real cursor should behave during selection: follow or hold",
 	)
+
+	if config.SupportZoomToDepth {
+		cmd.Flags().Int(
+			"zoom-to-depth",
+			0,
+			"Auto-zoom to the specified depth in recursive-grid at the current cursor position",
+		)
+	}
 
 	if config.SupportSearch {
 		cmd.Flags().BoolP(

--- a/internal/cli/recursive_grid.go
+++ b/internal/cli/recursive_grid.go
@@ -2,9 +2,10 @@ package cli
 
 // RecursiveGridCmd is the CLI recursive_grid command.
 var RecursiveGridCmd = BuildModeCommand(ModeConfig{
-	Name:    "recursive_grid",
-	Aliases: []string{"recursive-grid"},
-	Short:   "Activate recursive-grid navigation mode",
+	Name:               "recursive_grid",
+	Aliases:            []string{"recursive-grid"},
+	Short:              "Activate recursive-grid navigation mode",
+	SupportZoomToDepth: true,
 	Long: `Recursive-grid mode provides recursive cell-based navigation.
 
 The screen is divided into NxN cells (default 2x2, keys: u,i,j,k).
@@ -23,7 +24,9 @@ Navigation:
 Examples:
   neru recursive_grid                                  # Start recursive-grid mode
   neru recursive_grid --action click                   # Start with pending click action
-  neru recursive_grid --action left_click --repeat     # Click and restart mode`,
+  neru recursive_grid --action left_click --repeat     # Click and restart mode
+  neru recursive_grid --zoom-to-depth 2                # Zoom to depth 2 at cursor
+  neru recursive_grid --zoom-to-depth 3 --action click # Zoom to depth 3 and click`,
 	ActionDesc: "recursive-grid selection",
 })
 

--- a/internal/core/domain/recursivegrid/manager.go
+++ b/internal/core/domain/recursivegrid/manager.go
@@ -299,6 +299,28 @@ func (m *Manager) HasHistory() bool {
 	return m.grid.HasHistory()
 }
 
+// ZoomToPoint auto-navigates to the given target depth based on cursor position.
+// Returns the final center point and whether the selection is complete.
+func (m *Manager) ZoomToPoint(point image.Point, targetDepth int) (image.Point, bool) {
+	center, isComplete := m.grid.ZoomToPoint(point, targetDepth)
+
+	m.SetCurrentInput("")
+
+	if isComplete {
+		if m.onComplete != nil {
+			m.onComplete(center)
+		}
+
+		return center, true
+	}
+
+	if m.onUpdate != nil {
+		m.onUpdate(center)
+	}
+
+	return center, false
+}
+
 // keyToCell maps an input key to a cell index using the current depth's key mapping.
 // Returns -1 if the key is not mapped.
 func (m *Manager) keyToCell(key string) Cell {

--- a/internal/core/domain/recursivegrid/recursive_grid.go
+++ b/internal/core/domain/recursivegrid/recursive_grid.go
@@ -368,3 +368,44 @@ func (qg *RecursiveGrid) CellBounds(q Cell) image.Rectangle {
 
 	return cells[idx]
 }
+
+// CellForPoint returns the cell index containing the given point.
+// Returns -1 if the point is outside the current bounds.
+func (qg *RecursiveGrid) CellForPoint(point image.Point) Cell {
+	if !point.In(qg.currentBounds) {
+		return -1
+	}
+
+	cells := qg.Divide()
+	for i, cell := range cells {
+		if point.In(cell) {
+			return Cell(i)
+		}
+	}
+
+	return -1
+}
+
+// ZoomToPoint automatically selects cells at each depth level that contain
+// the given point, up to the target depth. If the grid cannot be divided
+// further (min size or max depth), zooming stops early. Returns the final
+// center point and whether the selection is complete.
+func (qg *RecursiveGrid) ZoomToPoint(point image.Point, targetDepth int) (image.Point, bool) {
+	for qg.depth < targetDepth {
+		if !qg.CanDivide() {
+			return qg.CurrentCenter(), true
+		}
+
+		cell := qg.CellForPoint(point)
+		if cell < 0 {
+			return qg.CurrentCenter(), true
+		}
+
+		center, isComplete := qg.SelectCell(cell)
+		if isComplete {
+			return center, true
+		}
+	}
+
+	return qg.CurrentCenter(), false
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a `--zoom-to-depth` flag to the recursive grid mode. When invoked with this flag, it will drills down to the specified depth at the current cursor position.

- Negative values is rejected.
- Zero based index, so `--zoom-to-depth=0` is the root node.
- If the depth is greater than maximum depth, it will be clamped to the maximum depth, no error for this.

Usage:

```bash
neru recursive_grid --zoom-to-depth 0 # this will be exactly the same as `neru recursive_grid`... lol
neru recursive_grid --zoom-to-depth 2
```

You can bind this to anywhere you want, but if you want to bind it within recursive grid, you'll have to `idle` it first:

```toml
[recursive_grid.hotkeys]
"Cmd+1" = [ "idle", "recursive_grid --zoom-to-depth 2" ]
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/827024e8-720b-45d3-a972-9fedcbc8a246

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
