### PR TITLE
fix(linux): disable default global hotkeys to avoid collisions

### DIFF
--- a/internal/config/config_integration_test.go
+++ b/internal/config/config_integration_test.go
@@ -15,6 +15,20 @@ import (
 
 const hintsCommand = "hints"
 
+// defaultConfigWithHotkeys returns a config with standard default hotkeys,
+// regardless of platform. This keeps the integration tests platform-independent.
+func defaultConfigWithHotkeys() *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.Hotkeys.Bindings = map[string][]string{
+		"Primary+Shift+Space": {hintsCommand},
+		"Primary+Shift+G":     {config.ModeNameGrid},
+		"Primary+Shift+C":     {config.ModeNameRecursiveGrid},
+		"Primary+Shift+S":     {config.ModeNameScroll},
+	}
+
+	return cfg
+}
+
 // TestConfigFileOperationsIntegration tests real file system operations
 // for configuration loading and reloading to prevent file system regressions.
 func TestConfigFileOperationsIntegration(t *testing.T) {
@@ -75,7 +89,7 @@ max_age = 30
 		writeConfigFile(t, configPath, configContent, 0o644)
 
 		// Load config from real file
-		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
 		loadResult := service.LoadWithValidation(configPath)
 
 		if loadResult.ValidationError != nil {
@@ -111,7 +125,7 @@ font_size = 12
 		writeConfigFile(t, configPath, initialContent, 0o644)
 
 		// Create a config service and load initial config
-		configSvc := config.NewService(config.DefaultConfig(), configPath, zap.NewNop(), nil)
+		configSvc := config.NewService(defaultConfigWithHotkeys(), configPath, zap.NewNop(), nil)
 
 		initialLoad := configSvc.LoadWithValidation(configPath)
 		if initialLoad.ValidationError != nil {
@@ -156,7 +170,7 @@ bundle_id = "com.apple.Safari"
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -191,7 +205,7 @@ scroll_step_full = 1000
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -237,7 +251,7 @@ scroll_step_full = 1000
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -266,7 +280,7 @@ scroll_step_full = 1000
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -297,7 +311,7 @@ scroll_step_full = 1000
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -331,7 +345,7 @@ enabled = false
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -358,7 +372,7 @@ enabled = false
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -389,7 +403,7 @@ enabled = false
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -415,7 +429,7 @@ enabled = true
 		writeConfigFile(t, configPath, configContent, 0o600)
 
 		// Should still be able to load it
-		service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {

--- a/internal/config/config_integration_test.go
+++ b/internal/config/config_integration_test.go
@@ -15,18 +15,26 @@ import (
 
 const hintsCommand = "hints"
 
-// defaultConfigWithHotkeys returns a config with standard default hotkeys,
-// regardless of platform. This keeps the integration tests platform-independent.
-func defaultConfigWithHotkeys() *config.Config {
-	cfg := config.DefaultConfig()
-	cfg.Hotkeys.Bindings = map[string][]string{
+// defaultHotkeys returns a Config with the standard default hotkeys set,
+// so that merge-logic tests (rebind, disable, etc.) work identically on
+// all platforms regardless of platform-level differences in DefaultConfig().
+func defaultHotkeys() map[string][]string {
+	return map[string][]string{
 		"Primary+Shift+Space": {hintsCommand},
 		"Primary+Shift+G":     {config.ModeNameGrid},
 		"Primary+Shift+C":     {config.ModeNameRecursiveGrid},
 		"Primary+Shift+S":     {config.ModeNameScroll},
 	}
+}
 
-	return cfg
+// serviceWithDefaultHotkeys creates a config.Service whose base defaults
+// include the standard hotkeys. The returned service uses a config file
+// path of "" so callers must pass an explicit path to LoadWithValidation.
+func serviceWithDefaultHotkeys(logger *zap.Logger) *config.Service {
+	base := config.DefaultConfig()
+	base.Hotkeys.Bindings = defaultHotkeys()
+
+	return config.NewService(config.DefaultConfig(), "", logger, nil).WithDefaults(base)
 }
 
 // TestConfigFileOperationsIntegration tests real file system operations
@@ -89,7 +97,7 @@ max_age = 30
 		writeConfigFile(t, configPath, configContent, 0o644)
 
 		// Load config from real file
-		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
+		service := serviceWithDefaultHotkeys(zap.NewNop())
 		loadResult := service.LoadWithValidation(configPath)
 
 		if loadResult.ValidationError != nil {
@@ -125,7 +133,7 @@ font_size = 12
 		writeConfigFile(t, configPath, initialContent, 0o644)
 
 		// Create a config service and load initial config
-		configSvc := config.NewService(defaultConfigWithHotkeys(), configPath, zap.NewNop(), nil)
+		configSvc := config.NewService(config.DefaultConfig(), configPath, zap.NewNop(), nil)
 
 		initialLoad := configSvc.LoadWithValidation(configPath)
 		if initialLoad.ValidationError != nil {
@@ -170,7 +178,7 @@ bundle_id = "com.apple.Safari"
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
+		service := serviceWithDefaultHotkeys(zap.NewNop())
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -205,7 +213,7 @@ scroll_step_full = 1000
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
+		service := serviceWithDefaultHotkeys(zap.NewNop())
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -251,7 +259,7 @@ scroll_step_full = 1000
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
+		service := serviceWithDefaultHotkeys(zap.NewNop())
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -280,7 +288,7 @@ scroll_step_full = 1000
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
+		service := serviceWithDefaultHotkeys(zap.NewNop())
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -311,7 +319,7 @@ scroll_step_full = 1000
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
+		service := serviceWithDefaultHotkeys(zap.NewNop())
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -345,7 +353,7 @@ enabled = false
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
+		service := serviceWithDefaultHotkeys(zap.NewNop())
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -372,7 +380,7 @@ enabled = false
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
+		service := serviceWithDefaultHotkeys(zap.NewNop())
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -403,7 +411,7 @@ enabled = false
 
 		writeConfigFile(t, configPath, configContent, 0o644)
 
-		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
+		service := serviceWithDefaultHotkeys(zap.NewNop())
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {
@@ -429,7 +437,7 @@ enabled = true
 		writeConfigFile(t, configPath, configContent, 0o600)
 
 		// Should still be able to load it
-		service := config.NewService(defaultConfigWithHotkeys(), "", zap.NewNop(), nil)
+		service := serviceWithDefaultHotkeys(zap.NewNop())
 
 		loadResult := service.LoadWithValidation(configPath)
 		if loadResult.ValidationError != nil {

--- a/internal/config/config_linux.go
+++ b/internal/config/config_linux.go
@@ -3,6 +3,12 @@
 package config
 
 func applyPlatformDefaults(cfg *Config) {
+	// Clear default global hotkeys to avoid collisions with terminal and
+	// application shortcuts (e.g. Ctrl+Shift+C / copy, Ctrl+Shift+V / paste).
+	// Users can enable global hotkeys in their config, or bind `neru <mode>`
+	// in their desktop environment / window manager.
+	cfg.Hotkeys.Bindings = make(map[string][]string)
+
 	// Linux-specific defaults
 	cfg.Hints.ClickableRoles = append(cfg.Hints.ClickableRoles,
 		"push button",

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -10,6 +10,23 @@ import (
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
 
+// linuxHotkeysBlock matches the default [hotkeys] section in default-config.toml.
+// It is replaced with a commented-out version on Linux to avoid terminal collisions.
+const linuxHotkeysBlock = `[hotkeys]
+"Primary+Shift+Space" = "hints"
+"Primary+Shift+G" = "grid"
+"Primary+Shift+C" = "recursive_grid"
+"Primary+Shift+S" = "scroll"`
+
+const linuxHotkeysBlockComment = `# Global hotkeys are disabled by default on Linux to avoid conflicts with
+# terminal and application shortcuts (e.g. Ctrl+Shift+C / copy).
+# Uncomment to enable, or bind \` + "`neru <mode>`" + ` in your DE/WM.
+# [hotkeys]
+# "Primary+Shift+Space" = "hints"
+# "Primary+Shift+G" = "grid"
+# "Primary+Shift+C" = "recursive_grid"
+# "Primary+Shift+S" = "scroll"`
+
 // WriteDefaultConfig writes the default configuration to the specified path.
 // If force is false and the file already exists, it returns an error.
 func WriteDefaultConfig(cfgPath string, force bool) error {
@@ -47,8 +64,10 @@ func WriteDefaultConfig(cfgPath string, force bool) error {
 // adjustments applied (e.g. exec_shell path on Windows).
 func platformDefaultConfig() []byte {
 	cfg := configs.DefaultConfig
+
+	content := string(cfg)
+
 	if runtime.GOOS == "windows" {
-		content := string(cfg)
 		content = strings.ReplaceAll(content,
 			`exec_shell = "/bin/bash"`,
 			`exec_shell = "C:\\Windows\\System32\\cmd.exe"`,
@@ -57,8 +76,16 @@ func platformDefaultConfig() []byte {
 			`exec_shell_args = ["-lc"]`,
 			`exec_shell_args = ["/c"]`,
 		)
-		cfg = []byte(content)
 	}
+
+	if runtime.GOOS == "linux" {
+		content = strings.ReplaceAll(content,
+			linuxHotkeysBlock,
+			linuxHotkeysBlockComment,
+		)
+	}
+
+	cfg = []byte(content)
 
 	return cfg
 }

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -231,6 +231,11 @@ type Service struct {
 	watchers      []chan<- *Config
 	logger        *zap.Logger
 	alertProvider AlertProvider
+
+	// defaults is the base configuration used as the starting point by
+	// LoadWithValidation. It is initialized from defaultConfigForDecoding()
+	// in NewService, but can be overridden by tests via withDefaults.
+	defaults *Config
 }
 
 // NewService creates a new configuration service.
@@ -250,18 +255,47 @@ func NewService(
 
 	return &Service{
 		config:        cfg,
+		defaults:      defaultConfigForDecoding(),
 		path:          path,
 		logger:        logger.Named("config"),
 		alertProvider: alertProvider,
 	}
 }
 
+// WithDefaults sets the base defaults used by LoadWithValidation. This is
+// intended for tests that need to override platform-specific default hotkeys.
+func (s *Service) WithDefaults(cfg *Config) *Service {
+	if cfg != nil {
+		s.defaults = cfg
+	}
+
+	return s
+}
+
 // LoadWithValidation loads configuration from the specified path and returns both
 // the config and any validation error separately. This allows callers to decide
 // how to handle validation failures (e.g., show alert and use default config).
 func (s *Service) LoadWithValidation(path string) *LoadResult {
+	// Start from a fresh platform-default config, then overlay hotkey
+	// overrides from s.defaults (which may be injected by tests). This
+	// avoids both shared-state mutation and accumulation across loads
+	// (since Hotkeys.Bindings has a toml:"-" tag and is not reset by
+	// the TOML decode that follows).
+	base := newDefaultConfig()
+	applyPlatformDefaults(base)
+
+	if s.defaults != nil {
+		for k, v := range s.defaults.Hotkeys.Bindings {
+			if base.Hotkeys.Bindings == nil {
+				base.Hotkeys.Bindings = make(map[string][]string, len(s.defaults.Hotkeys.Bindings))
+			}
+
+			base.Hotkeys.Bindings[k] = v
+		}
+	}
+
 	configResult := &LoadResult{
-		Config:     defaultConfigForDecoding(),
+		Config:     base,
 		ConfigPath: path,
 	}
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR disables global hotkeys by default on linux, including `config init` too.

User needs to explicitly bind them in their DE/WM compositor, which is a more recommended approach.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

https://github.com/y3owk1n/neru/discussions/559#discussioncomment-17721766

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
