### PR TITLE
feat(config): add `--no-reload` for `set` and add `reset`

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -528,11 +528,15 @@ Check config for syntax errors and invalid values. Does not require a running da
 
 ### 13c. set
 
-`neru config set <key> <value>`
+`neru config set [--no-reload] <key> <value>`
 
 Set a configuration value on the running daemon without restarting. Changes take effect immediately and are persisted to `config.override.toml` so they survive restarts. Requires a running daemon.
 
 The key uses dotted TOML path notation matching your config file (e.g. `hints.hint_characters`, `general.passthrough_unbounded_keys`).
+
+**OPTIONS**
+
+`--no-reload` — Skip hotkey re-registration and mode exit. Use when setting multiple interdependent fields in sequence (e.g. changing both `recursive_grid.grid_cols` and `recursive_grid.keys`). Run `neru config reload` afterwards to apply all changes at once.
 
 **SUPPORTED TYPES**
 
@@ -553,15 +557,18 @@ neru config set hints.ui.font_size 14
 neru config set general.passthrough_unbounded_keys true
 neru config set hints.clickable_roles "AXButton,AXLink"
 neru config set scroll.scroll_step 50
+neru config set --no-reload recursive_grid.grid_cols 3
+neru config set --no-reload recursive_grid.keys "abcdefghijkl"
+neru config reload
 ```
 
 **REVERTING CHANGES**
 
-Changes are stored in an override file derived from your config filename (e.g. `config.toml` → `config.override.toml`, `my-neru.toml` → `my-neru.override.toml`). To revert:
+Changes are stored in an override file derived from your config filename (e.g. `config.toml` → `config.override.toml`, `my-neru.toml` → `my-neru.override.toml`). To revert a single field use `config reset` or manually:
 
 ```bash
 # Revert a single field:
-# Edit the override file and remove the line, then:
+neru config reset recursive_grid.grid_cols
 neru config reload
 
 # Revert all overrides:
@@ -577,7 +584,26 @@ Use `neru config dump | jq` to explore all available keys and their current valu
 
 Print active config as JSON. Requires a running daemon.
 
-### 13e. reload
+### 13e. reset
+
+`neru config reset [--no-reload] <key>`
+
+Remove a single field from the override file, reverting it to the value from your base config file (or the code default) on the next reload. Requires a running daemon.
+
+**OPTIONS**
+
+`--no-reload` — Defer reloading. Use when resetting multiple fields in sequence. Run `neru config reload` afterward.
+
+**EXAMPLES**
+
+```bash
+neru config reset recursive_grid.grid_cols
+neru config reset --no-reload recursive_grid.grid_rows
+neru config reset --no-reload recursive_grid.keys
+neru config reload
+```
+
+### 13f. reload
 
 `neru config reload [-h|--help]`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -92,7 +92,8 @@ neru config validate    # Check syntax (no daemon needed)
 neru config reload      # Apply changes to running daemon
 neru config dump        # Print loaded config as JSON (daemon required)
 neru config init        # Create default config file
-neru config set <key> <value>  # Change a single value at runtime (see below)
+neru config set <key> <value>   # Change a single value at runtime (see below)
+neru config reset <key>         # Remove a single override (reverts to base config)
 ```
 
 See [CLI.md](CLI.md#configuration-management) for full flag documentation.
@@ -116,9 +117,30 @@ neru config set general.passthrough_unbounded_keys true
 3. Services, overlays, and hotkeys are reconfigured automatically — the same internal path used by `neru config reload`.
 4. The change is automatically persisted to `config.override.toml` alongside your config file. This file is loaded on every start, so changes survive restarts.
 
+### Batch changes with `--no-reload`
+
+Use `--no-reload` when setting or resetting multiple interdependent fields (e.g. `recursive_grid.grid_cols` + `recursive_grid.keys`). Each change persists to the override file without disrupting active hotkeys or exiting the current mode. Run `neru config reload` once after all changes to apply them.
+
+```bash
+neru config set --no-reload recursive_grid.grid_cols 3
+neru config set --no-reload recursive_grid.grid_rows 3
+neru config set --no-reload recursive_grid.keys "gcrhtnmwv"
+neru config reload
+```
+
+### Resetting overrides with `config reset`
+
+To revert a single field to its base config value, use `neru config reset <key>`. Like `config set`, it supports `--no-reload` for batch operations.
+
+```bash
+neru config reset recursive_grid.grid_cols
+neru config reset --no-reload recursive_grid.grid_rows
+neru config reload
+```
+
 ### Config override file
 
-Runtime changes via `neru config set` are written to an override file alongside your main config file. The override filename is derived from your config file's name: `config.toml` produces `config.override.toml`, `my-neru.toml` produces `my-neru.override.toml`, etc.
+Runtime changes via `neru config set` and `neru config reset` are written to an override file alongside your main config file. The override filename is derived from your config file's name: `config.toml` produces `config.override.toml`, `my-neru.toml` produces `my-neru.override.toml`, etc.
 
 The file uses the same TOML format and follows the same layering:
 
@@ -126,9 +148,7 @@ The file uses the same TOML format and follows the same layering:
 Defaults → config.toml → config.override.toml → Runtime (in-memory)
 ```
 
-To revert a change:
-- **Single field**: Edit the override file and remove the line, or set it to a different value, then run `neru config reload`.
-- **All overrides**: Delete the override file and run `neru config reload` to reset to config.toml values.
+To revert all overrides at once, delete the override file and run `neru config reload`.
 
 ### Supported field types
 
@@ -145,7 +165,7 @@ To revert a change:
 
 ### Limitations
 
-- **Hotkeys**: Cannot be set via `neru config set` (edit `config.toml` directly instead).
+- **Hotkeys**: Cannot be set via `neru config set` (edit `config.toml` directly instead). However, `config set` and `config reset` can be used *as hotkey actions* to change other config fields at runtime.
 - **Struct fields**: Sections like `[theme]` must be set via their leaf sub-paths, not as an object.
 - **`app_configs`**: Per-app overrides can't be set via `config set` (edit `config.toml` directly).
 - **Override file hotkeys**: If you manually edit the override file to add a `[hotkeys]` section, those bindings won't be loaded. The override file is intended for typed field overrides from `config set` — hotkey changes belong in `config.toml`.
@@ -233,6 +253,16 @@ Multi-key sequences (e.g. `gg`, `ab`) are supported for per-mode hotkeys with a 
 [hotkeys]
 "Primary+Shift+D" = ["hints", "exec echo 'hints activated'"]
 "PageUp"          = ["action go_top", "action page_down"]
+"Cmd+8"           = [
+    "config set recursive_grid.grid_cols 3 --no-reload",
+    "config set recursive_grid.grid_rows 3 --no-reload",
+    "config set recursive_grid.keys gcrhtnmwv",
+]
+"Cmd+9"           = [
+    "config reset recursive_grid.grid_cols --no-reload",
+    "config reset recursive_grid.grid_rows --no-reload",
+    "config reset recursive_grid.keys",
+]
 ```
 
 **Shell commands** use the `exec` prefix: `"Primary+T" = "exec open -a Terminal"`

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -19,7 +19,9 @@ func (a *App) SetConfigField(ctx context.Context, key, value string) error {
 	a.prepareForConfigUpdate()
 
 	// Deep copy the current config so we only mutate the new copy.
-	newCfg, err := config.DeepCopyConfig(a.config)
+	// Read from the service (source of truth) so prior --no-reload
+	// changes are included.
+	newCfg, err := config.DeepCopyConfig(a.configService.Get())
 	if err != nil {
 		a.restoreHotkeysAfterFailedReload()
 

--- a/internal/app/ipc_controller_test.go
+++ b/internal/app/ipc_controller_test.go
@@ -2,6 +2,7 @@ package app_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -292,6 +293,77 @@ func TestIPCController_HandleConfigSet_MissingArgs(t *testing.T) {
 
 	if commandResponse.Code != ipc.CodeInvalidInput {
 		t.Fatalf("Expected code=%s, got %s", ipc.CodeInvalidInput, commandResponse.Code)
+	}
+}
+
+func TestIPCController_HandleConfigSet_NoReload(t *testing.T) {
+	controller := newTestController()
+	ctx := context.Background()
+
+	// Default config: grid_cols=3, grid_rows=3, keys="rtyfghvbn" (9 chars).
+
+	// Step 1: change grid_cols to 4 with --no-reload.
+	// This creates an unbalanced state (4*3=12 ≠ 9 chars keys).
+	// Without --no-reload this would fail validation.
+	resp := controller.HandleCommand(ctx, ipc.Command{
+		Action: domain.CommandConfigSet,
+		Args:   []string{"recursive_grid.grid_cols", "4", "--no-reload"},
+	})
+	if !resp.Success {
+		t.Fatalf("--no-reload grid_cols: expected success, got %v: %s",
+			resp.Success, resp.Message)
+	}
+
+	if resp.Code != ipc.CodeOK {
+		t.Fatalf("--no-reload grid_cols: expected code %s, got %s",
+			ipc.CodeOK, resp.Code)
+	}
+
+	if !strings.Contains(resp.Message, "reload required") {
+		t.Fatalf("--no-reload grid_cols: message should contain 'reload required', got %q",
+			resp.Message)
+	}
+
+	// Step 2: fix keys to match (4*3=12 chars).
+	resp = controller.HandleCommand(ctx, ipc.Command{
+		Action: domain.CommandConfigSet,
+		Args:   []string{"recursive_grid.keys", "abcdefghijkl", "--no-reload"},
+	})
+	if !resp.Success {
+		t.Fatalf("--no-reload keys: expected success, got %v: %s",
+			resp.Success, resp.Message)
+	}
+
+	// Step 3: set an unrelated field without --no-reload.
+	// This exercises that prior --no-reload changes are visible to the
+	// full validation path (deep copies from service, sees 4*3=12=keys).
+	resp = controller.HandleCommand(ctx, ipc.Command{
+		Action: domain.CommandConfigSet,
+		Args:   []string{"recursive_grid.min_size_width", "2"},
+	})
+	if !resp.Success {
+		t.Fatalf("regular set after --no-reload: expected success, got %v: %s",
+			resp.Success, resp.Message)
+	}
+
+	// Step 4: verify final state.
+	cfgResp := controller.HandleCommand(ctx, ipc.Command{Action: domain.CommandConfig})
+
+	cfg, ok := cfgResp.Data.(*config.Config)
+	if !ok || cfg == nil {
+		t.Fatal("failed to read config after no-reload sequence")
+	}
+
+	if cfg.RecursiveGrid.GridCols != 4 {
+		t.Errorf("expected grid_cols=4, got %d", cfg.RecursiveGrid.GridCols)
+	}
+
+	if cfg.RecursiveGrid.Keys != "abcdefghijkl" {
+		t.Errorf("expected keys=%q, got %q", "abcdefghijkl", cfg.RecursiveGrid.Keys)
+	}
+
+	if cfg.RecursiveGrid.MinSizeWidth != 2 {
+		t.Errorf("expected min_size_width=2, got %d", cfg.RecursiveGrid.MinSizeWidth)
 	}
 }
 

--- a/internal/app/ipc_info.go
+++ b/internal/app/ipc_info.go
@@ -174,9 +174,27 @@ func (h *IPCControllerInfo) handleStatus(_ context.Context, _ ipc.Command) ipc.R
 	}
 }
 
-func (h *IPCControllerInfo) handleConfig(_ context.Context, _ ipc.Command) ipc.Response {
-	cfg := h.configSnapshot()
+func (h *IPCControllerInfo) handleConfig(ctx context.Context, cmd ipc.Command) ipc.Response {
+	// Support sub-commands like "config set ..." from hotkey bindings.
+	if len(cmd.Args) > 0 {
+		switch cmd.Args[0] {
+		case "set":
+			return h.handleConfigSet(ctx, ipc.Command{
+				Action: domain.CommandConfigSet,
+				Args:   cmd.Args[1:],
+			})
+		case "reset":
+			return h.handleConfigReset(ctx, ipc.Command{
+				Action: "config-reset",
+				Args:   cmd.Args[1:],
+			})
+		case "reload":
+			return h.handleReloadConfig(ctx, ipc.Command{})
+		}
+	}
 
+	// Default: dump the full config.
+	cfg := h.configSnapshot()
 	if cfg == nil {
 		h.logger.Error("Config is nil in handleConfig")
 
@@ -368,9 +386,18 @@ func (h *IPCControllerInfo) handleConfigSet(ctx context.Context, cmd ipc.Command
 
 	key := cmd.Args[0]
 	value := cmd.Args[1]
+	noReload := len(cmd.Args) > minConfigSetArgs && cmd.Args[minConfigSetArgs] == "--no-reload"
 
-	// If an app-level callback is provided, delegate to it for full
-	// reconfiguration (component updates, hotkey re-registration, etc.).
+	if noReload {
+		// Lightweight path: update in-memory config and persist without
+		// disrupting active hotkeys or exiting the current mode. Useful
+		// when setting multiple fields in sequence. Caller should run
+		// "neru config reload" afterward to apply all changes.
+		return h.handleConfigSetNoReload(ctx, key, value)
+	}
+
+	// Full path: delegate to the app-level callback for reconfiguration
+	// (component updates, hotkey re-registration, etc.).
 	if h.setConfigField != nil {
 		err := h.setConfigField(ctx, key, value)
 		if err != nil {
@@ -388,7 +415,107 @@ func (h *IPCControllerInfo) handleConfigSet(ctx context.Context, cmd ipc.Command
 		}
 	}
 
-	// Fallback: update in-memory config only via the config service.
+	// Fallback (e.g. tests with no callback): update in-memory config only.
+	return h.handleConfigSetInMemory(ctx, key, value)
+}
+
+// handleConfigSetNoReload updates the in-memory config and persists to the
+// override file without triggering mode exit or hotkey re-registration.
+func (h *IPCControllerInfo) handleConfigSetNoReload(
+	_ context.Context,
+	key, value string,
+) ipc.Response {
+	cfg := h.configSnapshot()
+	if cfg == nil {
+		return h.configNotAvailableResponse()
+	}
+
+	newCfg, err := config.DeepCopyConfig(cfg)
+	if err != nil {
+		return ipc.Response{
+			Success: false,
+			Message: "failed to copy config: " + err.Error(),
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	setErr := config.SetField(newCfg, key, value)
+	if setErr != nil {
+		return ipc.Response{
+			Success: false,
+			Message: setErr.Error(),
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	// Skip Validate() here so interdependent fields (e.g. grid_cols + keys)
+	// can be updated incrementally before a final "neru config reload".
+	h.configService.Replace(newCfg)
+	h.configMu.Lock()
+	h.config = newCfg
+	h.configMu.Unlock()
+
+	// Persist to override file so changes survive restart.
+	persistErr := h.configService.SaveOverrideField(key, value)
+	if persistErr != nil {
+		return ipc.Response{
+			Success: false,
+			Message: "config set but failed to persist: " + persistErr.Error(),
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	return ipc.Response{
+		Success: true,
+		Message: fmt.Sprintf("config %s set to %q (reload required to apply)", key, value),
+		Code:    ipc.CodeOK,
+	}
+}
+
+// handleConfigReset removes a field from the override file, reverting it to
+// the base config or default value on the next reload.  When --no-reload is
+// present the in-memory config is left alone so callers can batch multiple
+// resets before a final "neru config reload".
+func (h *IPCControllerInfo) handleConfigReset(ctx context.Context, cmd ipc.Command) ipc.Response {
+	if len(cmd.Args) < 1 {
+		return ipc.Response{
+			Success: false,
+			Message: "config-reset requires a key argument",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	key := cmd.Args[0]
+	noReload := len(cmd.Args) > 1 && cmd.Args[1] == "--no-reload"
+
+	removeErr := h.configService.RemoveOverrideField(key)
+	if removeErr != nil {
+		return ipc.Response{
+			Success: false,
+			Message: "failed to remove override: " + removeErr.Error(),
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	if noReload {
+		return ipc.Response{
+			Success: true,
+			Message: fmt.Sprintf("config %s reset (reload required to apply)", key),
+			Code:    ipc.CodeOK,
+		}
+	}
+
+	// Full reload to apply the reset immediately.
+	return h.handleReloadConfig(ctx, ipc.Command{})
+}
+
+// handleConfigSetInMemory updates the in-memory config without persisting.
+// This is the fallback path used when no app-level callback is registered
+// (e.g. in tests).
+func (h *IPCControllerInfo) handleConfigSetInMemory(
+	_ context.Context,
+	key, value string,
+) ipc.Response {
 	cfg := h.configSnapshot()
 	if cfg == nil {
 		return h.configNotAvailableResponse()
@@ -425,7 +552,6 @@ func (h *IPCControllerInfo) handleConfigSet(ctx context.Context, cmd ipc.Command
 		}
 	}
 
-	// Update the local config pointer.
 	h.configMu.Lock()
 	h.config = newCfg
 	h.configMu.Unlock()

--- a/internal/app/ipc_info.go
+++ b/internal/app/ipc_info.go
@@ -190,6 +190,12 @@ func (h *IPCControllerInfo) handleConfig(ctx context.Context, cmd ipc.Command) i
 			})
 		case "reload":
 			return h.handleReloadConfig(ctx, ipc.Command{})
+		default:
+			return ipc.Response{
+				Success: false,
+				Message: "unknown config subcommand: " + cmd.Args[0],
+				Code:    ipc.CodeInvalidInput,
+			}
 		}
 	}
 

--- a/internal/app/ipc_info.go
+++ b/internal/app/ipc_info.go
@@ -488,6 +488,14 @@ func (h *IPCControllerInfo) handleConfigReset(ctx context.Context, cmd ipc.Comma
 	key := cmd.Args[0]
 	noReload := len(cmd.Args) > 1 && cmd.Args[1] == "--no-reload"
 
+	if config.ConfigFieldType(key) == "unknown" {
+		return ipc.Response{
+			Success: false,
+			Message: "unknown config field: " + key,
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
 	removeErr := h.configService.RemoveOverrideField(key)
 	if removeErr != nil {
 		return ipc.Response{

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -19,6 +19,7 @@ Subcommands:
   dump       Print the currently active configuration as JSON
   reload     Reload configuration from disk without restarting
   set        Set a config value at runtime (no restart needed)
+  reset      Reset a config field to its default value
   init       Create a default configuration file to get started
   validate   Check a configuration file for errors
 
@@ -89,5 +90,6 @@ func init() {
 	configCmd.AddCommand(configDumpCmd)
 	configCmd.AddCommand(configReloadCmd)
 	configCmd.AddCommand(configSetCmd)
+	configCmd.AddCommand(configResetCmd)
 	RootCmd.AddCommand(configCmd)
 }

--- a/internal/cli/config_reset.go
+++ b/internal/cli/config_reset.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/y3owk1n/neru/internal/core/domain"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+const minConfigResetArgs = 1
+
+var configResetCmd = &cobra.Command{
+	Use:   "reset <key>",
+	Short: "Reset a config field to its default value",
+	Long: `Remove a single config field from the override file, reverting it to the
+value from your base config file (or the code default).
+
+Use --no-reload to defer reloading when resetting multiple fields.
+Run "neru config reload" afterward to apply all changes at once.
+
+Examples:
+  neru config reset recursive_grid.grid_cols
+  neru config reset --no-reload recursive_grid.grid_rows
+  neru config reset --no-reload recursive_grid.keys
+  neru config reload`,
+	Args: cobra.ExactArgs(minConfigResetArgs),
+	PreRunE: func(_ *cobra.Command, _ []string) error {
+		return requiresRunningInstance()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		noReload, _ := cmd.Flags().GetBool(noReloadFlagName)
+
+		ipcArgs := []string{"reset", key}
+		if noReload {
+			ipcArgs = append(ipcArgs, "--no-reload")
+		}
+
+		client := ipc.NewClient()
+
+		resp, err := client.Send(ipc.Command{
+			Action: domain.CommandConfig,
+			Args:   ipcArgs,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to send config-reset command: %w", err)
+		}
+
+		if !resp.Success {
+			if resp.Code != "" {
+				return derrors.Newf(
+					derrors.CodeActionFailed,
+					"%s (code: %s)",
+					resp.Message,
+					resp.Code,
+				)
+			}
+
+			return derrors.New(derrors.CodeActionFailed, resp.Message)
+		}
+
+		if resp.Message != "" {
+			cmd.Println(resp.Message)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	configResetCmd.Flags().Bool(noReloadFlagName, false,
+		"Skip reload. Use when resetting multiple fields; "+
+			"run `neru config reload` afterwards to apply.")
+}

--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -36,10 +36,10 @@ Examples:
   neru config set general.passthrough_unbounded_keys true
   neru config set hints.clickable_roles "AXButton,AXLink"
   neru config set scroll.scroll_step 50
-  neru config set --no-reload recursive_grid.cols 4
-  neru config set --no-reload recursive_grid.rows 3
-  neru config reload
+  neru config set --no-reload recursive_grid.grid_cols 4
+  neru config set --no-reload recursive_grid.grid_rows 3
 
+Use "neru config reload" after setting multiple fields with --no-reload.
 Use "neru config dump | jq" to explore all available keys.`,
 	Args: cobra.ExactArgs(commandArgCount),
 	PreRunE: func(_ *cobra.Command, _ []string) error {

--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -15,6 +15,9 @@ import (
 // set command (key and value).
 const commandArgCount = 2
 
+// noReloadFlagName is the flag name for deferring hotkey re-registration.
+const noReloadFlagName = "no-reload"
+
 var configSetCmd = &cobra.Command{
 	Use:   "set <key> <value>",
 	Short: "Set a config value at runtime",
@@ -24,12 +27,18 @@ The key uses dotted TOML path notation matching your config file.
 Supported types: string, integer, boolean, float, color (#RGB/#RRGGBB/#AARRGGBB),
 array (comma-separated or JSON: "AXButton,AXLink" or '["AXButton","AXLink"]').
 
+Use --no-reload to skip hotkey re-registration when setting multiple fields
+in sequence. Run "neru config reload" afterward to apply all changes at once.
+
 Examples:
   neru config set hints.hint_characters "asdfghjkl"
   neru config set hints.ui.font_size 14
   neru config set general.passthrough_unbounded_keys true
   neru config set hints.clickable_roles "AXButton,AXLink"
   neru config set scroll.scroll_step 50
+  neru config set --no-reload recursive_grid.cols 4
+  neru config set --no-reload recursive_grid.rows 3
+  neru config reload
 
 Use "neru config dump | jq" to explore all available keys.`,
 	Args: cobra.ExactArgs(commandArgCount),
@@ -52,11 +61,18 @@ Use "neru config dump | jq" to explore all available keys.`,
 			)
 		}
 
+		noReload, _ := cmd.Flags().GetBool(noReloadFlagName)
+
 		client := ipc.NewClient()
+
+		ipcArgs := []string{key, value}
+		if noReload {
+			ipcArgs = append(ipcArgs, "--no-reload")
+		}
 
 		resp, err := client.Send(ipc.Command{
 			Action: domain.CommandConfigSet,
-			Args:   []string{key, value},
+			Args:   ipcArgs,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to send config-set command: %w", err)
@@ -81,4 +97,10 @@ Use "neru config dump | jq" to explore all available keys.`,
 
 		return nil
 	},
+}
+
+func init() {
+	configSetCmd.Flags().Bool(noReloadFlagName, false,
+		"Skip hotkey re-registration. Use when setting multiple fields; "+
+			"run `neru config reload` afterwards to apply.")
 }

--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -49,7 +49,15 @@ Use "neru config dump | jq" to explore all available keys.`,
 		key := args[0]
 		value := args[1]
 
-		valErr := config.ValidateConfigSetField(key, value)
+		noReload, _ := cmd.Flags().GetBool(noReloadFlagName)
+
+		var valErr error
+		if noReload {
+			valErr = config.SetField(config.DefaultConfig(), key, value)
+		} else {
+			valErr = config.ValidateConfigSetField(key, value)
+		}
+
 		if valErr != nil {
 			typeHint := config.ConfigFieldType(key)
 
@@ -60,8 +68,6 @@ Use "neru config dump | jq" to explore all available keys.`,
 				typeHint,
 			)
 		}
-
-		noReload, _ := cmd.Flags().GetBool(noReloadFlagName)
 
 		client := ipc.NewClient()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1543,6 +1543,42 @@ func setNestedMapValue(data map[string]any, path string, value any) {
 	}
 }
 
+// deleteNestedMapValue removes a dotted-path key from a nested map. Empty
+// ancestor maps are pruned so the serialized override file stays clean.
+func deleteNestedMapValue(data map[string]any, path string) {
+	parts := strings.Split(path, ".")
+	if len(parts) == 0 || parts[0] == "" {
+		return
+	}
+
+	// Walk down, collecting each level so we can prune on the way back up.
+	stack := make([]map[string]any, 0, len(parts))
+	stack = append(stack, data)
+
+	current := data
+	for i := range len(parts) - 1 {
+		next, ok := current[parts[i]].(map[string]any)
+		if !ok {
+			return
+		}
+
+		stack = append(stack, next)
+		current = next
+	}
+
+	// Delete the leaf key.
+	delete(current, parts[len(parts)-1])
+
+	// Prune empty ancestors from leaf upward.
+	for i := len(stack) - 1; i > 0; i-- {
+		if len(stack[i]) > 0 {
+			break
+		}
+
+		delete(stack[i-1], parts[i-1])
+	}
+}
+
 // getFieldValue reads a typed value from a Config by dotted path.
 func getFieldValue(cfg *Config, path string) (any, error) {
 	parts := strings.Split(path, ".")

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -911,6 +911,15 @@ func (s *Service) Update(config *Config) error {
 	return nil
 }
 
+// Replace swaps the in-memory config without validation or watcher
+// notification. Use only when callers manage consistency themselves
+// (e.g. --no-reload batches multiple changes before a final reload).
+func (s *Service) Replace(config *Config) {
+	s.mu.Lock()
+	s.config = config
+	s.mu.Unlock()
+}
+
 // SaveOverrideField persists a single config field change to the override file.
 // It reads any existing overrides, applies the new field, and writes the result.
 // Returns nil if there is no config path (daemon was started without a file).
@@ -961,6 +970,45 @@ func (s *Service) SaveOverrideField(key, value string) error {
 	s.logger.Info("Config override persisted",
 		zap.String("key", key),
 		zap.String("value", value),
+		zap.String("override_path", overridePath))
+
+	return nil
+}
+
+// RemoveOverrideField removes a single config field from the override file.
+// After the next reload, the field will revert to its value from the base
+// config file (or the code default).
+func (s *Service) RemoveOverrideField(key string) error {
+	s.mu.RLock()
+	configPath := s.path
+	s.mu.RUnlock()
+
+	if configPath == "" {
+		return nil
+	}
+
+	overridePath := OverridePath(configPath)
+
+	overrides := make(map[string]any)
+
+	_, decodeErr := toml.DecodeFile(overridePath, &overrides)
+	if decodeErr != nil && !os.IsNotExist(decodeErr) {
+		return derrors.Wrap(
+			decodeErr,
+			derrors.CodeConfigIOFailed,
+			"failed to read existing overrides",
+		)
+	}
+
+	deleteNestedMapValue(overrides, key)
+
+	saveErr := SaveOverride(overridePath, overrides)
+	if saveErr != nil {
+		return saveErr
+	}
+
+	s.logger.Info("Config override removed",
+		zap.String("key", key),
 		zap.String("override_path", overridePath))
 
 	return nil

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -156,6 +156,33 @@ func TestService_Watch(t *testing.T) {
 	}
 }
 
+func TestService_Replace(t *testing.T) {
+	t.Parallel()
+
+	service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+	ctx := t.Context()
+
+	watchCh := service.Watch(ctx)
+	// Drain initial notification.
+	<-watchCh
+
+	modified := config.DefaultConfig()
+	modified.Hints.HintCharacters = "replaced"
+	service.Replace(modified)
+
+	// Config should be updated.
+	if got := service.Get().Hints.HintCharacters; got != "replaced" {
+		t.Errorf("Replace() did not update config: got %q, want %q", got, "replaced")
+	}
+
+	// Replace should NOT send a watcher notification.
+	select {
+	case <-watchCh:
+		t.Error("Replace() sent unexpected watcher notification")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestService_Concurrency(_ *testing.T) {
 	service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
 

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -1458,7 +1458,8 @@ func validateHotkeyActionString(actionStr string) error {
 	case "idle", ModeNameHints, ModeNameGrid, ModeNameScroll, ModeNameRecursiveGrid,
 		ModeNameMonitorSelect,
 		"toggle-screen-share", CmdToggleCursorFollowSelection,
-		"toggle-scroll-invert":
+		"toggle-scroll-invert",
+		"config":
 		return nil
 	default:
 		return derrors.Newf(derrors.CodeInvalidConfig, "unknown command: %s", trimmed)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR extends more support for persistent config settings.

- `neru config set [--no-reload] <key> <value>` is added so that you can have intermediate update for configurations that are validated against each other, say grid cols and grid characters.
- `neru config remove [--no-reload] <key> <value>` is for you to remove a key from the override config.

Example:

```bash
# set the grid to 3x3
neru config set --no-reload recursive_grid.grid_cols 3 # without `--no-reload`, this will fail on validation
neru config set --no-reload recursive_grid.grid_rows 3 # same as above
neru config set recursive_grid.keys gcrhtnmwv # commit and reload after the change

# reset the grid to your own configured default
neru config remove --no-reload recursive_grid.grid_cols
neru config remove --no-reload recursive_grid.grid_rows
neru config remove recursive_grid.keys
```

Or you can bind it like so, and you can toggle between your own configured default and the new overrides:

```toml
[hotkeys]
"Cmd+8" = [
    "config set recursive_grid.grid_cols 3 --no-reload",
    "config set recursive_grid.grid_rows 3 --no-reload",
    "config set recursive_grid.keys gcrhtnmwv",
]

"Cmd+9" = [
    "config reset recursive_grid.grid_cols --no-reload",
    "config reset recursive_grid.grid_rows --no-reload",
    "config reset recursive_grid.keys",
]
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

The below example is using the hotkeys in the above section `cmd+8` and `cmd+9`

https://github.com/user-attachments/assets/72d5528d-c535-4524-bbbd-fd1251c61a21

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
