### PR TITLE
fix: replace startup warning on launch with dynamic capability notice

### DIFF
--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -41,12 +41,14 @@ func LaunchDaemon(configPath string) {
 	systemPort, sysPortErr := platform.NewSystemPort()
 
 	// On non-macOS, print a brief startup notice directing to 'neru doctor'
-	// for the full platform capability report.
+	// for the full platform capability report. Uses the system port's
+	// lightweight PlatformLabel() (no I/O or live probes) as the primary
+	// source, falling back to CurrentOS() when the port is unavailable.
 	if !platform.IsDarwin() {
 		if sysPortErr != nil {
 			fmt.Fprintf(os.Stderr, "⚠️  %s\n\n", sysPortErr.Error())
 		} else {
-			printPlatformStartupNotice()
+			printPlatformStartupNotice(systemPort.PlatformLabel())
 		}
 	}
 
@@ -86,11 +88,17 @@ func LaunchDaemon(configPath string) {
 }
 
 // printPlatformStartupNotice prints a compact startup notice on non-macOS.
-func printPlatformStartupNotice() {
+// Uses the system port's lightweight PlatformLabel() (no I/O, no live probes)
+// as the primary source, falling back to CurrentOS() when unavailable.
+func printPlatformStartupNotice(platformLabel string) {
+	if platformLabel == "" {
+		platformLabel = string(platform.CurrentOS())
+	}
+
 	fmt.Fprintf(
 		os.Stderr,
 		"⚠️  Neru is running on %s. Run 'neru doctor' for platform capabilities.\n\n",
-		platform.CurrentOS(),
+		platformLabel,
 	)
 }
 

--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/infra/platform"
+	"github.com/y3owk1n/neru/internal/core/ports"
 )
 
 // main is defined in main_os.go files (main_darwin.go / main_other.go)
@@ -22,12 +23,7 @@ type alertProvider struct {
 	system config.AlertProvider
 }
 
-func newAlertProvider() *alertProvider {
-	sp, err := platform.NewSystemPort()
-	if err != nil {
-		return &alertProvider{}
-	}
-
+func newAlertProvider(sp ports.SystemPort) *alertProvider {
 	return &alertProvider{system: sp}
 }
 
@@ -41,28 +37,24 @@ func (p *alertProvider) ShowAlert(ctx context.Context, title, message string) er
 
 // LaunchDaemon is called by the CLI to launch the daemon.
 func LaunchDaemon(configPath string) {
+	// Create system port early for startup notice and alerts.
+	systemPort, sysPortErr := platform.NewSystemPort()
+
+	// On non-macOS, print a brief startup notice with platform capabilities
+	// rather than a stale warning. Users can run 'neru doctor' for full details.
 	if !platform.IsDarwin() {
-		fmt.Fprintf(
-			os.Stderr,
-			"⚠️  WARNING: Neru is running on %s, which is not yet fully supported.\n",
-			platform.CurrentOS(),
-		)
-		fmt.Fprintf(
-			os.Stderr,
-			"   Most features (hotkeys, overlays, accessibility, notifications) are stubs\n",
-		)
-		fmt.Fprintf(os.Stderr, "   and will not function. Only macOS is currently supported.\n")
-		fmt.Fprintf(
-			os.Stderr,
-			"   See docs/ARCHITECTURE.md for the contribution guide.\n\n",
-		)
+		if sysPortErr != nil {
+			fmt.Fprintf(os.Stderr, "⚠️  %s\n\n", sysPortErr.Error())
+		} else {
+			printPlatformStartupNotice(systemPort.Capabilities())
+		}
 	}
 
 	service := config.NewService(
 		config.DefaultConfig(),
 		configPath,
 		zap.NewNop(),
-		newAlertProvider(),
+		newAlertProvider(systemPort),
 	)
 	configResult := service.LoadWithValidation(configPath)
 
@@ -91,6 +83,22 @@ func LaunchDaemon(configPath string) {
 		fmt.Fprintf(os.Stderr, "Error running app: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// printPlatformStartupNotice prints a compact, dynamic startup message on non-macOS
+// platforms. It uses the system port's live capability report so it never goes stale
+// as features get implemented. Users are directed to 'neru doctor' for full details.
+func printPlatformStartupNotice(caps ports.PlatformCapabilities) {
+	platformLabel := caps.Platform
+	if platformLabel == "" {
+		platformLabel = string(platform.CurrentOS())
+	}
+
+	fmt.Fprintf(
+		os.Stderr,
+		"⚠️  Neru is running on %s. Run 'neru doctor' for platform capabilities.\n\n",
+		platformLabel,
+	)
 }
 
 // handleConfigValidationError shows a validation error and exits.

--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -40,13 +40,13 @@ func LaunchDaemon(configPath string) {
 	// Create system port early for startup notice and alerts.
 	systemPort, sysPortErr := platform.NewSystemPort()
 
-	// On non-macOS, print a brief startup notice with platform capabilities
-	// rather than a stale warning. Users can run 'neru doctor' for full details.
+	// On non-macOS, print a brief startup notice directing to 'neru doctor'
+	// for the full platform capability report.
 	if !platform.IsDarwin() {
 		if sysPortErr != nil {
 			fmt.Fprintf(os.Stderr, "⚠️  %s\n\n", sysPortErr.Error())
 		} else {
-			printPlatformStartupNotice(systemPort.Capabilities())
+			printPlatformStartupNotice()
 		}
 	}
 
@@ -85,19 +85,12 @@ func LaunchDaemon(configPath string) {
 	}
 }
 
-// printPlatformStartupNotice prints a compact, dynamic startup message on non-macOS
-// platforms. It uses the system port's live capability report so it never goes stale
-// as features get implemented. Users are directed to 'neru doctor' for full details.
-func printPlatformStartupNotice(caps ports.PlatformCapabilities) {
-	platformLabel := caps.Platform
-	if platformLabel == "" {
-		platformLabel = string(platform.CurrentOS())
-	}
-
+// printPlatformStartupNotice prints a compact startup notice on non-macOS.
+func printPlatformStartupNotice() {
 	fmt.Fprintf(
 		os.Stderr,
 		"⚠️  Neru is running on %s. Run 'neru doctor' for platform capabilities.\n\n",
-		platformLabel,
+		platform.CurrentOS(),
 	)
 }
 

--- a/internal/core/infra/platform/darwin/system.go
+++ b/internal/core/infra/platform/darwin/system.go
@@ -20,6 +20,9 @@ func NewSystemAdapter() *SystemAdapter {
 	return &SystemAdapter{}
 }
 
+// PlatformLabel returns "darwin".
+func (s *SystemAdapter) PlatformLabel() string { return "darwin" }
+
 // Health checks the health of the macOS system adapter.
 func (s *SystemAdapter) Health(ctx context.Context) error {
 	return nil

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -35,6 +35,16 @@ func NewSystemAdapter(backend string) *SystemAdapter {
 	return &SystemAdapter{backend: backend}
 }
 
+// PlatformLabel returns "linux/<backend>" (e.g. "linux/x11", "linux/wayland-kde").
+// Uses the cached backend field set at construction time — no I/O or live probes.
+func (s *SystemAdapter) PlatformLabel() string {
+	if s.backend != "" {
+		return "linux/" + s.backend
+	}
+
+	return "linux"
+}
+
 // Health checks the health of the Linux system adapter.
 func (s *SystemAdapter) Health(ctx context.Context) error {
 	return nil

--- a/internal/core/infra/platform/windows/system.go
+++ b/internal/core/infra/platform/windows/system.go
@@ -27,6 +27,9 @@ func NewSystemAdapter() *SystemAdapter {
 	return &SystemAdapter{}
 }
 
+// PlatformLabel returns "windows".
+func (s *SystemAdapter) PlatformLabel() string { return "windows" }
+
 // Health checks the health of the Windows system adapter.
 func (s *SystemAdapter) Health(ctx context.Context) error {
 	return nil

--- a/internal/core/ports/mocks/system.go
+++ b/internal/core/ports/mocks/system.go
@@ -29,6 +29,7 @@ type MockSystemPort struct {
 	ShowAlertFunc                   func(ctx context.Context, title, message string) error
 	ShowNotificationFunc            func(title, message string)
 	CapabilitiesFunc                func() ports.PlatformCapabilities
+	PlatformLabelFunc               func() string
 	HealthFunc                      func(ctx context.Context) error
 }
 
@@ -215,6 +216,15 @@ func (m *MockSystemPort) Capabilities() ports.PlatformCapabilities {
 	}
 
 	return ports.PlatformCapabilities{}
+}
+
+// PlatformLabel is a mock implementation.
+func (m *MockSystemPort) PlatformLabel() string {
+	if m.PlatformLabelFunc != nil {
+		return m.PlatformLabelFunc()
+	}
+
+	return ""
 }
 
 // Health is a mock implementation.

--- a/internal/core/ports/system.go
+++ b/internal/core/ports/system.go
@@ -95,6 +95,13 @@ type SystemPort interface {
 	ThemeProviderPort
 	SecureInputPort
 
+	// PlatformLabel returns a human-readable platform identifier that can be
+	// used in startup notices and diagnostics. Unlike Capabilities().Platform,
+	// this method performs no I/O or live probes — it returns a cached label
+	// set at construction time.
+	// Examples: "darwin", "windows", "linux/x11", "linux/wayland-kde".
+	PlatformLabel() string
+
 	// ShowAlert displays a native system alert/notification.
 	// title   — brief summary shown as the alert heading (e.g. the error message)
 	// message — detail text shown in the alert body (e.g. the config file path)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR simplifies the startup warning on windows and linux ports to be less scary... lol

Example output:

`⚠️  Neru is running on linux/wayland-wlroots. Run 'neru doctor' for platform capabilities.`

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
