### PR TITLE
fix(linux): gate AT-SPI accessibility init and ensure reset on quit

### DIFF
--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -90,6 +90,7 @@ func initializeServicesAndAdapters(app *App) error {
 
 	// Initialize adapters
 	accAdapter, overlayAdapter := initializeAdapters(
+		app,
 		cfg,
 		cfgService,
 		logger,

--- a/internal/app/app_types.go
+++ b/internal/app/app_types.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"io"
 	"sync"
 
 	"go.uber.org/zap"
@@ -59,6 +60,11 @@ type App struct {
 	appWatcher     Watcher
 
 	modes *modes.Handler
+
+	// axClient is stored so it can be closed during Cleanup.
+	// On Linux this resets AT-SPI accessibility status and releases the
+	// D-Bus connection; on other platforms it is a no-op.
+	axClient io.Closer
 
 	// Control channels
 	stopChan    chan struct{}

--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -85,7 +85,7 @@ func initializeAdapters(
 	clickableRoles := cfg.Hints.ClickableRoles
 
 	// Create infrastructure client.
-	axClient := accessibilityAdapter.NewPlatformAXClient(logger, cfgService, cfg.Hints.Enabled)
+	axClient := accessibilityAdapter.NewPlatformAXClient(logger, cfgService)
 
 	// Store axClient so Cleanup can release its resources (D-Bus conn, a11y status).
 	app.axClient = axClient

--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -74,6 +74,7 @@ func initializeAppWatcher(logger *zap.Logger) Watcher {
 
 // initializeAdapters creates and initializes the accessibility and overlay adapters.
 func initializeAdapters(
+	app *App,
 	cfg *config.Config,
 	cfgService *config.Service,
 	logger *zap.Logger,
@@ -84,7 +85,10 @@ func initializeAdapters(
 	clickableRoles := cfg.Hints.ClickableRoles
 
 	// Create infrastructure client.
-	axClient := accessibilityAdapter.NewPlatformAXClient(logger, cfgService)
+	axClient := accessibilityAdapter.NewPlatformAXClient(logger, cfgService, cfg.Hints.Enabled)
+
+	// Store axClient so Cleanup can release its resources (D-Bus conn, a11y status).
+	app.axClient = axClient
 
 	// Create base accessibility adapter with core functionality
 	accAdapter := accessibilityAdapter.NewAdapter(

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -600,6 +600,14 @@ func (a *App) Cleanup() {
 		if a.eventTap != nil {
 			a.eventTap.Destroy()
 		}
+		// Close the accessibility client to release platform resources
+		// (e.g. AT-SPI D-Bus connection and a11y status on Linux).
+		if a.axClient != nil {
+			closeErr := a.axClient.Close()
+			if closeErr != nil {
+				a.logger.Error("Failed to close accessibility client", zap.Error(closeErr))
+			}
+		}
 		// Sync and close logger
 		loggerSyncErr := logger.Sync()
 		if loggerSyncErr != nil {

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -144,52 +144,37 @@ type ATSPIClient struct {
 
 	// a11y state management.
 	a11yMu    sync.Mutex
-	activated bool   // true once we enabled AT-SPI this session
-	savedIsOn bool   // original IsEnabled before our first enable
-	savedSrOn bool   // original ScreenReaderEnabled before our first enable
+	activated bool // true once we enabled AT-SPI this session
+	savedIsOn bool // original IsEnabled before our first enable
+	savedSrOn bool // original ScreenReaderEnabled before our first enable
 }
 
-// NewATSPIClient builds the Linux accessibility client and best-effort enables
-// assistive-tech mode so apps start exposing their trees before the first
-// hints request. When hints are disabled, accessibility is not activated
-// to avoid triggering unnecessary screen-reader prompts in applications.
+// NewATSPIClient builds the Linux accessibility client. AT-SPI is not
+// activated until ensureA11yEnabled is called (lazily on first hints request),
+// so hints-disabled sessions never touch the session-wide a11y status.
 func NewATSPIClient(
 	logger *zap.Logger,
 	configProvider config.Provider,
-	hintsEnabled bool,
+	_ bool,
 ) *ATSPIClient {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 
-	client := &ATSPIClient{
+	return &ATSPIClient{
 		InfraAXClient: NewInfraAXClient(logger, configProvider),
 		logger:        logger.Named("accessibility.atspi"),
 		kwin:          newKWinBridge(logger),
 	}
-
-	// Always reset a11y status on startup to clear any state left by a previous
-	// run. If hints are enabled, re-enable after the reset.
-	go func() {
-		_ = client.disableAccessibility()
-
-		if hintsEnabled {
-			err := client.enableAccessibility()
-			if err != nil {
-				client.logger.Warn("Failed to enable AT-SPI accessibility status", zap.Error(err))
-			}
-
-			// Install the KWin geometry bridge so AT-SPI window-relative
-			// coordinates can be offset into screen coordinates.
-			go client.kwin.start()
-		}
-	}()
-
-	return client
 }
 
 // FrontmostWindow returns the active top-level window via AT-SPI.
 func (c *ATSPIClient) FrontmostWindow(_ context.Context) (AXWindow, error) {
+	err := c.ensureA11yEnabled()
+	if err != nil {
+		c.logger.Warn("Failed to enable AT-SPI accessibility", zap.Error(err))
+	}
+
 	conn, err := c.ensureA11yConn()
 	if err != nil {
 		return nil, err
@@ -304,6 +289,7 @@ func (c *ATSPIClient) Close() error {
 		if closeErr != nil {
 			c.logger.Warn("Failed to close AT-SPI D-Bus connection", zap.Error(closeErr))
 		}
+
 		c.a11y = nil
 		c.a11yReady = false
 	}
@@ -319,22 +305,27 @@ func (c *ATSPIClient) readA11yStatus() (bool, bool, error) {
 	if connErr != nil {
 		return false, false, connErr
 	}
+
 	obj := conn.Object(a11yBusDest, a11yBusPath)
 
 	var isVariant dbus.Variant
+
 	getErr := obj.Call("org.freedesktop.DBus.Properties.Get", 0,
 		a11yStatusIfc, a11yPropIsEnabled).Store(&isVariant)
 	if getErr != nil {
 		return false, false, getErr
 	}
+
 	isOn, _ := isVariant.Value().(bool)
 
 	var srVariant dbus.Variant
+
 	getErr = obj.Call("org.freedesktop.DBus.Properties.Get", 0,
 		a11yStatusIfc, a11yPropScreenReader).Store(&srVariant)
 	if getErr != nil {
 		return false, false, getErr
 	}
+
 	srOn, _ := srVariant.Value().(bool)
 
 	return isOn, srOn, nil
@@ -348,6 +339,7 @@ func (c *ATSPIClient) setA11yStatus(srEnabled, isEnabled bool) error {
 	if connErr != nil {
 		return connErr
 	}
+
 	obj := conn.Object(a11yBusDest, a11yBusPath)
 
 	var props []string
@@ -365,6 +357,7 @@ func (c *ATSPIClient) setA11yStatus(srEnabled, isEnabled bool) error {
 		case a11yPropScreenReader:
 			propVal = srEnabled
 		}
+
 		err := obj.Call("org.freedesktop.DBus.Properties.Set", 0,
 			a11yStatusIfc, prop, dbus.MakeVariant(propVal)).Err
 		if err != nil {
@@ -379,61 +372,42 @@ func (c *ATSPIClient) setA11yStatus(srEnabled, isEnabled bool) error {
 	return nil
 }
 
-// enableAccessibility flips org.a11y.Status so toolkits expose their trees.
-func (c *ATSPIClient) enableAccessibility() error {
-	obj, connErr := c.getA11yStatusObj()
-	if connErr != nil {
-		return connErr
+// ensureA11yEnabled activates AT-SPI on first call (lazy, safe to call
+// multiple times). It saves the original a11y status so Close can restore it.
+func (c *ATSPIClient) ensureA11yEnabled() error {
+	c.a11yMu.Lock()
+	if c.activated {
+		c.a11yMu.Unlock()
+
+		return nil
 	}
 
-	t := true
-	for _, prop := range []string{"IsEnabled", "ScreenReaderEnabled"} {
-		callErr := obj.Call(
-			"org.freedesktop.DBus.Properties.Set", 0,
-			a11yStatusIfc, prop, dbus.MakeVariant(t),
-		).Err
-		if callErr != nil {
-			return callErr
-		}
-	}
-
-	c.logger.Debug("AT-SPI accessibility status enabled")
-
-	return nil
-}
-
-// disableAccessibility clears org.a11y.Status so toolkits stop exposing their
-// accessibility trees and apps no longer detect a screen reader.
-func (c *ATSPIClient) disableAccessibility() error {
-	obj, connErr := c.getA11yStatusObj()
-	if connErr != nil {
-		return connErr
-	}
-
-	f := false
-	for _, prop := range []string{"ScreenReaderEnabled", "IsEnabled"} {
-		callErr := obj.Call(
-			"org.freedesktop.DBus.Properties.Set", 0,
-			a11yStatusIfc, prop, dbus.MakeVariant(f),
-		).Err
-		if callErr != nil {
-			return callErr
-		}
-	}
-
-	c.logger.Debug("AT-SPI accessibility status disabled")
-
-	return nil
-}
-
-// getA11yStatusObj returns a D-Bus object for the org.a11y.Status interface.
-func (c *ATSPIClient) getA11yStatusObj() (dbus.BusObject, error) {
-	conn, err := dbus.SessionBus()
+	savedIsOn, savedSrOn, err := c.readA11yStatus()
 	if err != nil {
-		return nil, err
+		c.a11yMu.Unlock()
+
+		return err
 	}
 
-	return conn.Object(a11yBusDest, a11yBusPath), nil
+	c.savedIsOn = savedIsOn
+	c.savedSrOn = savedSrOn
+	c.activated = false
+	c.a11yMu.Unlock()
+
+	err = c.setA11yStatus(true, true)
+	if err != nil {
+		return err
+	}
+
+	go c.kwin.start()
+
+	c.a11yMu.Lock()
+	c.activated = true
+	c.a11yMu.Unlock()
+
+	c.logger.Debug("AT-SPI accessibility enabled (lazy)")
+
+	return nil
 }
 
 // ensureA11yConn lazily connects to the dedicated AT-SPI bus.

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -51,6 +51,10 @@ const (
 	// Capacity hint for the clickable-node slice: most windows fit well under
 	// this and the slice grows if a dense tree exceeds it.
 	atspiClickableNodesCap = 128
+
+	// org.a11y.Status D-Bus property names.
+	a11yPropIsEnabled    = "IsEnabled"
+	a11yPropScreenReader = "ScreenReaderEnabled"
 )
 
 // accRef is the AT-SPI (bus-name, object-path) reference returned by
@@ -137,6 +141,12 @@ type ATSPIClient struct {
 	mu        sync.Mutex
 	a11y      *dbus.Conn
 	a11yReady bool
+
+	// a11y state management.
+	a11yMu    sync.Mutex
+	activated bool   // true once we enabled AT-SPI this session
+	savedIsOn bool   // original IsEnabled before our first enable
+	savedSrOn bool   // original ScreenReaderEnabled before our first enable
 }
 
 // NewATSPIClient builds the Linux accessibility client and best-effort enables
@@ -272,21 +282,99 @@ func (c *ATSPIClient) ClickableNodes(
 	return out, nil
 }
 
-// Close resets the AT-SPI accessibility status to disabled and releases the
-// dedicated D-Bus connection to the a11y bus.
+// Close restores the org.a11y.Status to the values that were active before
+// our first enable, and releases the dedicated D-Bus connection.
 func (c *ATSPIClient) Close() error {
-	_ = c.disableAccessibility()
+	c.a11yMu.Lock()
+	wasActivated := c.activated
+	restoreIsOn := c.savedIsOn
+	restoreSrOn := c.savedSrOn
+	c.a11yMu.Unlock()
+
+	if wasActivated {
+		err := c.setA11yStatus(restoreSrOn, restoreIsOn)
+		if err != nil {
+			c.logger.Warn("Failed to restore AT-SPI a11y status", zap.Error(err))
+		}
+	}
+
 	c.mu.Lock()
 	if c.a11y != nil {
 		closeErr := c.a11y.Close()
 		if closeErr != nil {
 			c.logger.Warn("Failed to close AT-SPI D-Bus connection", zap.Error(closeErr))
 		}
-
 		c.a11y = nil
 		c.a11yReady = false
 	}
 	c.mu.Unlock()
+
+	return nil
+}
+
+// readA11yStatus reads the current IsEnabled and ScreenReaderEnabled D-Bus
+// properties from org.a11y.Status.
+func (c *ATSPIClient) readA11yStatus() (bool, bool, error) {
+	conn, connErr := dbus.SessionBus()
+	if connErr != nil {
+		return false, false, connErr
+	}
+	obj := conn.Object(a11yBusDest, a11yBusPath)
+
+	var isVariant dbus.Variant
+	getErr := obj.Call("org.freedesktop.DBus.Properties.Get", 0,
+		a11yStatusIfc, a11yPropIsEnabled).Store(&isVariant)
+	if getErr != nil {
+		return false, false, getErr
+	}
+	isOn, _ := isVariant.Value().(bool)
+
+	var srVariant dbus.Variant
+	getErr = obj.Call("org.freedesktop.DBus.Properties.Get", 0,
+		a11yStatusIfc, a11yPropScreenReader).Store(&srVariant)
+	if getErr != nil {
+		return false, false, getErr
+	}
+	srOn, _ := srVariant.Value().(bool)
+
+	return isOn, srOn, nil
+}
+
+// setA11yStatus writes the given values for IsEnabled and ScreenReaderEnabled
+// on org.a11y.Status. When disabling, ScreenReaderEnabled is cleared before
+// IsEnabled; when enabling, IsEnabled is set first.
+func (c *ATSPIClient) setA11yStatus(srEnabled, isEnabled bool) error {
+	conn, connErr := dbus.SessionBus()
+	if connErr != nil {
+		return connErr
+	}
+	obj := conn.Object(a11yBusDest, a11yBusPath)
+
+	var props []string
+	if !srEnabled {
+		props = []string{a11yPropScreenReader, a11yPropIsEnabled}
+	} else {
+		props = []string{a11yPropIsEnabled, a11yPropScreenReader}
+	}
+
+	for _, prop := range props {
+		var propVal bool
+		switch prop {
+		case a11yPropIsEnabled:
+			propVal = isEnabled
+		case a11yPropScreenReader:
+			propVal = srEnabled
+		}
+		err := obj.Call("org.freedesktop.DBus.Properties.Set", 0,
+			a11yStatusIfc, prop, dbus.MakeVariant(propVal)).Err
+		if err != nil {
+			return err
+		}
+	}
+
+	c.logger.Debug("AT-SPI status set",
+		zap.Bool(a11yPropIsEnabled, isEnabled),
+		zap.Bool(a11yPropScreenReader, srEnabled))
 
 	return nil
 }

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -141,8 +141,13 @@ type ATSPIClient struct {
 
 // NewATSPIClient builds the Linux accessibility client and best-effort enables
 // assistive-tech mode so apps start exposing their trees before the first
-// hints request.
-func NewATSPIClient(logger *zap.Logger, configProvider config.Provider) *ATSPIClient {
+// hints request. When hints are disabled, accessibility is not activated
+// to avoid triggering unnecessary screen-reader prompts in applications.
+func NewATSPIClient(
+	logger *zap.Logger,
+	configProvider config.Provider,
+	hintsEnabled bool,
+) *ATSPIClient {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -153,18 +158,22 @@ func NewATSPIClient(logger *zap.Logger, configProvider config.Provider) *ATSPICl
 		kwin:          newKWinBridge(logger),
 	}
 
-	// Enable a11y now (in the background) so Qt/GTK apps build their trees
-	// well before the user triggers hints.
+	// Always reset a11y status on startup to clear any state left by a previous
+	// run. If hints are enabled, re-enable after the reset.
 	go func() {
-		err := client.enableAccessibility()
-		if err != nil {
-			client.logger.Warn("Failed to enable AT-SPI accessibility status", zap.Error(err))
+		_ = client.disableAccessibility()
+
+		if hintsEnabled {
+			err := client.enableAccessibility()
+			if err != nil {
+				client.logger.Warn("Failed to enable AT-SPI accessibility status", zap.Error(err))
+			}
+
+			// Install the KWin geometry bridge so AT-SPI window-relative
+			// coordinates can be offset into screen coordinates.
+			go client.kwin.start()
 		}
 	}()
-
-	// Install the KWin geometry bridge so AT-SPI window-relative coordinates
-	// can be offset into screen coordinates.
-	go client.kwin.start()
 
 	return client
 }
@@ -263,14 +272,31 @@ func (c *ATSPIClient) ClickableNodes(
 	return out, nil
 }
 
+// Close resets the AT-SPI accessibility status to disabled and releases the
+// dedicated D-Bus connection to the a11y bus.
+func (c *ATSPIClient) Close() error {
+	_ = c.disableAccessibility()
+	c.mu.Lock()
+	if c.a11y != nil {
+		closeErr := c.a11y.Close()
+		if closeErr != nil {
+			c.logger.Warn("Failed to close AT-SPI D-Bus connection", zap.Error(closeErr))
+		}
+
+		c.a11y = nil
+		c.a11yReady = false
+	}
+	c.mu.Unlock()
+
+	return nil
+}
+
 // enableAccessibility flips org.a11y.Status so toolkits expose their trees.
 func (c *ATSPIClient) enableAccessibility() error {
-	conn, err := dbus.SessionBus()
-	if err != nil {
-		return err
+	obj, connErr := c.getA11yStatusObj()
+	if connErr != nil {
+		return connErr
 	}
-
-	obj := conn.Object(a11yBusDest, a11yBusPath)
 
 	t := true
 	for _, prop := range []string{"IsEnabled", "ScreenReaderEnabled"} {
@@ -286,6 +312,40 @@ func (c *ATSPIClient) enableAccessibility() error {
 	c.logger.Debug("AT-SPI accessibility status enabled")
 
 	return nil
+}
+
+// disableAccessibility clears org.a11y.Status so toolkits stop exposing their
+// accessibility trees and apps no longer detect a screen reader.
+func (c *ATSPIClient) disableAccessibility() error {
+	obj, connErr := c.getA11yStatusObj()
+	if connErr != nil {
+		return connErr
+	}
+
+	f := false
+	for _, prop := range []string{"ScreenReaderEnabled", "IsEnabled"} {
+		callErr := obj.Call(
+			"org.freedesktop.DBus.Properties.Set", 0,
+			a11yStatusIfc, prop, dbus.MakeVariant(f),
+		).Err
+		if callErr != nil {
+			return callErr
+		}
+	}
+
+	c.logger.Debug("AT-SPI accessibility status disabled")
+
+	return nil
+}
+
+// getA11yStatusObj returns a D-Bus object for the org.a11y.Status interface.
+func (c *ATSPIClient) getA11yStatusObj() (dbus.BusObject, error) {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return nil, err
+	}
+
+	return conn.Object(a11yBusDest, a11yBusPath), nil
 }
 
 // ensureA11yConn lazily connects to the dedicated AT-SPI bus.

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -11,6 +11,7 @@ package accessibility
 
 import (
 	"context"
+	"errors"
 	"image"
 	"strings"
 	"sync"
@@ -21,6 +22,8 @@ import (
 
 	"github.com/y3owk1n/neru/internal/config"
 )
+
+var errClientClosed = errors.New("AT-SPI client is closed")
 
 const (
 	a11yBusDest   = "org.a11y.Bus"
@@ -145,6 +148,7 @@ type ATSPIClient struct {
 	// a11y state management.
 	a11yMu    sync.Mutex
 	activated bool // true once we enabled AT-SPI this session
+	closed    bool // true after Close() runs; prevents re-activation
 	savedIsOn bool // original IsEnabled before our first enable
 	savedSrOn bool // original ScreenReaderEnabled before our first enable
 }
@@ -270,6 +274,7 @@ func (c *ATSPIClient) Close() error {
 	wasActivated := c.activated
 	restoreIsOn := c.savedIsOn
 	restoreSrOn := c.savedSrOn
+	c.closed = true
 	c.a11yMu.Unlock()
 
 	if wasActivated {
@@ -378,6 +383,10 @@ func (c *ATSPIClient) ensureA11yEnabled() error {
 
 	if c.activated {
 		return nil
+	}
+
+	if c.closed {
+		return errClientClosed
 	}
 
 	savedIsOn, savedSrOn, err := c.readA11yStatus()

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -370,25 +370,23 @@ func (c *ATSPIClient) setA11yStatus(srEnabled, isEnabled bool) error {
 
 // ensureA11yEnabled activates AT-SPI on first call (lazy, safe to call
 // multiple times). It saves the original a11y status so Close can restore it.
+// a11yMu is held across the D-Bus calls so Close() sees a consistent view:
+// either activation has finished (activated == true) or it hasn't started.
 func (c *ATSPIClient) ensureA11yEnabled() error {
 	c.a11yMu.Lock()
-	if c.activated {
-		c.a11yMu.Unlock()
+	defer c.a11yMu.Unlock()
 
+	if c.activated {
 		return nil
 	}
 
 	savedIsOn, savedSrOn, err := c.readA11yStatus()
 	if err != nil {
-		c.a11yMu.Unlock()
-
 		return err
 	}
 
 	c.savedIsOn = savedIsOn
 	c.savedSrOn = savedSrOn
-	c.activated = false
-	c.a11yMu.Unlock()
 
 	err = c.setA11yStatus(true, true)
 	if err != nil {
@@ -397,9 +395,7 @@ func (c *ATSPIClient) ensureA11yEnabled() error {
 
 	go c.kwin.start()
 
-	c.a11yMu.Lock()
 	c.activated = true
-	c.a11yMu.Unlock()
 
 	c.logger.Debug("AT-SPI accessibility enabled (lazy)")
 

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -152,11 +152,7 @@ type ATSPIClient struct {
 // NewATSPIClient builds the Linux accessibility client. AT-SPI is not
 // activated until ensureA11yEnabled is called (lazily on first hints request),
 // so hints-disabled sessions never touch the session-wide a11y status.
-func NewATSPIClient(
-	logger *zap.Logger,
-	configProvider config.Provider,
-	_ bool,
-) *ATSPIClient {
+func NewATSPIClient(logger *zap.Logger, configProvider config.Provider) *ATSPIClient {
 	if logger == nil {
 		logger = zap.NewNop()
 	}

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -373,6 +373,18 @@ func (c *ATSPIClient) setA11yStatus(srEnabled, isEnabled bool) error {
 	return nil
 }
 
+// setA11yProp writes a single org.a11y.Status property.
+func (c *ATSPIClient) setA11yProp(prop string, val bool) error {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return err
+	}
+
+	return conn.Object(a11yBusDest, a11yBusPath).
+		Call("org.freedesktop.DBus.Properties.Set", 0,
+			a11yStatusIfc, prop, dbus.MakeVariant(val)).Err
+}
+
 // ensureA11yEnabled activates AT-SPI on first call (lazy, safe to call
 // multiple times). It saves the original a11y status so Close can restore it.
 // a11yMu is held across the D-Bus calls so Close() sees a consistent view:
@@ -397,8 +409,15 @@ func (c *ATSPIClient) ensureA11yEnabled() error {
 	c.savedIsOn = savedIsOn
 	c.savedSrOn = savedSrOn
 
-	err = c.setA11yStatus(true, true)
+	err = c.setA11yProp(a11yPropIsEnabled, true)
 	if err != nil {
+		return err
+	}
+
+	err = c.setA11yProp(a11yPropScreenReader, true)
+	if err != nil {
+		_ = c.setA11yProp(a11yPropIsEnabled, c.savedIsOn) // best-effort rollback
+
 		return err
 	}
 

--- a/internal/core/infra/accessibility/client.go
+++ b/internal/core/infra/accessibility/client.go
@@ -57,6 +57,10 @@ type AXClient interface {
 	SetClickableRoles(roles []string)
 	ClickableRoles() []string
 	IsMissionControlActive() bool
+
+	// Close releases any resources held by the client (e.g. D-Bus connections
+	// or AT-SPI accessibility status).
+	Close() error
 }
 
 // AXAppInfo contains information about an application.

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -301,6 +301,10 @@ func (c *InfraAXClient) IsMissionControlActive() bool {
 	return IsMissionControlActive()
 }
 
+// Close is a no-op for the default infrastructure client; the macOS AX API
+// does not hold process-external resources that need explicit teardown.
+func (c *InfraAXClient) Close() error { return nil }
+
 // extractElement returns the raw *Element from an AXElement wrapper.
 func (c *InfraAXClient) extractElement(root AXElement) (*Element, error) {
 	switch elementType := root.(type) {

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -179,6 +179,9 @@ func (m *MockAXClient) IsMissionControlActive() bool {
 	return m.MockMissionControlActive
 }
 
+// Close is a no-op for the mock.
+func (m *MockAXClient) Close() error { return nil }
+
 // Mock implementations for Window, App, Node
 
 // MockWindow is a mock implementation of AXWindow.

--- a/internal/core/infra/accessibility/platform_client_linux.go
+++ b/internal/core/infra/accessibility/platform_client_linux.go
@@ -13,12 +13,8 @@ import (
 )
 
 // NewPlatformAXClient returns the AT-SPI-backed client on Linux.
-// When hintsEnabled is false the underlying AT-SPI client skips activating
-// the accessibility bus, avoiding unnecessary screen-reader prompts.
-func NewPlatformAXClient(
-	logger *zap.Logger,
-	configProvider config.Provider,
-	hintsEnabled bool,
-) AXClient {
-	return NewATSPIClient(logger, configProvider, hintsEnabled)
+// AT-SPI activation is now lazy (on first hints request), so the
+// caller does not need to pass a hints-enabled flag at construction.
+func NewPlatformAXClient(logger *zap.Logger, configProvider config.Provider) AXClient {
+	return NewATSPIClient(logger, configProvider)
 }

--- a/internal/core/infra/accessibility/platform_client_linux.go
+++ b/internal/core/infra/accessibility/platform_client_linux.go
@@ -13,6 +13,12 @@ import (
 )
 
 // NewPlatformAXClient returns the AT-SPI-backed client on Linux.
-func NewPlatformAXClient(logger *zap.Logger, configProvider config.Provider) AXClient {
-	return NewATSPIClient(logger, configProvider)
+// When hintsEnabled is false the underlying AT-SPI client skips activating
+// the accessibility bus, avoiding unnecessary screen-reader prompts.
+func NewPlatformAXClient(
+	logger *zap.Logger,
+	configProvider config.Provider,
+	hintsEnabled bool,
+) AXClient {
+	return NewATSPIClient(logger, configProvider, hintsEnabled)
 }

--- a/internal/core/infra/accessibility/platform_client_other.go
+++ b/internal/core/infra/accessibility/platform_client_other.go
@@ -13,6 +13,7 @@ import (
 )
 
 // NewPlatformAXClient returns the default infrastructure client.
-func NewPlatformAXClient(logger *zap.Logger, configProvider config.Provider) AXClient {
+// hintsEnabled is only meaningful on Linux; on other platforms it is ignored.
+func NewPlatformAXClient(logger *zap.Logger, configProvider config.Provider, _ bool) AXClient {
 	return NewInfraAXClient(logger, configProvider)
 }

--- a/internal/core/infra/accessibility/platform_client_other.go
+++ b/internal/core/infra/accessibility/platform_client_other.go
@@ -13,7 +13,6 @@ import (
 )
 
 // NewPlatformAXClient returns the default infrastructure client.
-// hintsEnabled is only meaningful on Linux; on other platforms it is ignored.
-func NewPlatformAXClient(logger *zap.Logger, configProvider config.Provider, _ bool) AXClient {
+func NewPlatformAXClient(logger *zap.Logger, configProvider config.Provider) AXClient {
 	return NewInfraAXClient(logger, configProvider)
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR makes AT-SPI activation conditional on hints configuration, and also always reset the state on startup and shutdown.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/0b5dde1d-2e5f-47a4-bfb2-88370b9a0a1e

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A