### PR TITLE
fix(linux,wayland): make evdev capture persistent with kb hotplug support

### DIFF
--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -105,8 +105,8 @@ type EventTap struct {
 	// evdevWaylandCapture holds a *waylandEvdevCapture created once and
 	// reused across Enable/Disable cycles. This avoids re-scanning
 	// /dev/input/event* devices on every mode activation, which was the
-	// source of a ~0.5s delay before the grid/hints mode accepted input.
-	evdevWaylandCapture    any
+	// source of a mild delay before the grid/hints mode accepted input.
+	evdevWaylandCapture     any
 	evdevWaylandCaptureInit sync.Once
 }
 
@@ -221,10 +221,6 @@ func (et *EventTap) Destroy() {
 	close(et.dispatchCh)
 	et.dispatchWg.Wait()
 }
-
-// closeEvdevCapture is a no-op on non-cgo Linux builds.
-// On cgo+Wayland, it closes the persistent evdev capture.
-func (et *EventTap) closeEvdevCapture() {}
 
 // SetHandler sets the callback for key events.
 func (et *EventTap) SetHandler(handler func(key string)) {

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -101,6 +101,13 @@ type EventTap struct {
 	// hasn't changed before invoking the callback. This prevents
 	// stale buffered events from leaking across enable/disable cycles.
 	dispatchEpoch atomic.Uint64
+
+	// evdevWaylandCapture holds a *waylandEvdevCapture created once and
+	// reused across Enable/Disable cycles. This avoids re-scanning
+	// /dev/input/event* devices on every mode activation, which was the
+	// source of a ~0.5s delay before the grid/hints mode accepted input.
+	evdevWaylandCapture    any
+	evdevWaylandCaptureInit sync.Once
 }
 
 // NewEventTap creates a new EventTap instance.
@@ -201,6 +208,12 @@ func (et *EventTap) Destroy() {
 
 	et.Disable()
 
+	// Clean up the persistent evdev capture (closes file descriptors
+	// and drains reader goroutines). The closeEvdevCapture method is
+	// defined in the cgo build-tagged file for Wayland+cgo builds;
+	// it is a no-op when the capture was never initialized.
+	et.closeEvdevCapture()
+
 	// Stop the dispatch goroutine and wait for it to finish.
 	// The dispatchCh is created once in NewEventTap and lives for the
 	// entire lifetime of the EventTap, so we close the channel to signal
@@ -208,6 +221,10 @@ func (et *EventTap) Destroy() {
 	close(et.dispatchCh)
 	et.dispatchWg.Wait()
 }
+
+// closeEvdevCapture is a no-op on non-cgo Linux builds.
+// On cgo+Wayland, it closes the persistent evdev capture.
+func (et *EventTap) closeEvdevCapture() {}
 
 // SetHandler sets the callback for key events.
 func (et *EventTap) SetHandler(handler func(key string)) {

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -107,7 +107,7 @@ type EventTap struct {
 	// /dev/input/event* devices on every mode activation, which was the
 	// source of a mild delay before the grid/hints mode accepted input.
 	evdevWaylandCapture     any
-	evdevWaylandCaptureInit sync.Once
+	evdevWaylandCaptureInit sync.Mutex
 }
 
 // NewEventTap creates a new EventTap instance.

--- a/internal/core/infra/eventtap/eventtap_linux_nocgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_nocgo.go
@@ -2,6 +2,34 @@
 
 package eventtap
 
-// closeEvdevCapture is a no-op on non-cgo Linux builds.
-// On cgo+Wayland, it closes the persistent evdev capture.
+import "errors"
+
+func (et *EventTap) runWayland() {
+	close(et.doneCh)
+}
+
+func (et *EventTap) runX11() {
+	close(et.doneCh)
+}
+
+func postLinuxModifierEvent(_ string, _ bool) bool {
+	return false
+}
+
+func getUinputScrollFd() (int, error) {
+	return 0, errors.New("uinput scroll unavailable (no CGO)")
+}
+
+func ScrollDeviceScroll(_, _ int) error {
+	return errors.New("uinput scroll unavailable (no CGO)")
+}
+
+func ScrollDeviceScrollBatch(_ int, _ []int) error {
+	return errors.New("uinput scroll batch unavailable (no CGO)")
+}
+
+func IsUinputScrollAvailable() bool {
+	return false
+}
+
 func (et *EventTap) closeEvdevCapture() {}

--- a/internal/core/infra/eventtap/eventtap_linux_nocgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_nocgo.go
@@ -2,33 +2,6 @@
 
 package eventtap
 
-import "errors"
-
-func (et *EventTap) runWayland() {
-	close(et.doneCh)
-}
-
-func (et *EventTap) runX11() {
-	close(et.doneCh)
-}
-
-func postLinuxModifierEvent(_ string, _ bool) bool {
-	return false
-}
-
-func getUinputScrollFd() (int, error) {
-	return 0, errors.New("uinput scroll unavailable (no CGO)")
-}
-
-func ScrollDeviceScroll(_, _ int) error {
-	return errors.New("uinput scroll unavailable (no CGO)")
-}
-
-func ScrollDeviceScrollBatch(_ int, _ []int) error {
-	return errors.New("uinput scroll batch unavailable (no CGO)")
-}
-
-// IsUinputScrollAvailable returns false when CGO is disabled.
-func IsUinputScrollAvailable() bool {
-	return false
-}
+// closeEvdevCapture is a no-op on non-cgo Linux builds.
+// On cgo+Wayland, it closes the persistent evdev capture.
+func (et *EventTap) closeEvdevCapture() {}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -533,12 +533,16 @@ func (capture *waylandEvdevCapture) hotplugLoop() {
 
 	buf := make([]byte, waylandEvdevHotplugBufSize)
 	for {
-		n, err := syscall.Read(capture.inotifyFd, buf)
+		nread, err := syscall.Read(capture.inotifyFd, buf)
 		if err != nil {
+			if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EWOULDBLOCK) {
+				continue
+			}
+
 			return
 		}
 
-		capture.handleInotifyEvents(buf[:n])
+		capture.handleInotifyEvents(buf[:nread])
 	}
 }
 

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -175,6 +175,12 @@ func (capture *waylandEvdevCapture) Close() {
 		capture.files = nil
 		capture.deviceMu.Unlock()
 
+		// Wait for all reader goroutines to finish. Closing the files above
+		// makes neru_evdev_read_event return immediately, causing each reader
+		// to exit. We must wait here so that no reader can send on the events
+		// channel after we close it below.
+		capture.done.Wait()
+
 		close(capture.events)
 
 		if capture.logger != nil {

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -602,13 +602,17 @@ func (capture *waylandEvdevCapture) handleNewDevice(name string) {
 		}
 	}
 
-	capture.files = append(capture.files, file)
-	isGrabbed := capture.grabbed
-	capture.deviceMu.Unlock()
+	// If the capture is currently grabbed, grab the new device under the
+	// same lock so Disable cannot race ahead and ungrab before we finish.
+	if capture.grabbed && C.neru_evdev_grab(C.int(file.Fd()), 1) != 0 {
+		capture.deviceMu.Unlock()
+		_ = file.Close()
 
-	if isGrabbed {
-		C.neru_evdev_grab(C.int(file.Fd()), 1)
+		return
 	}
+
+	capture.files = append(capture.files, file)
+	capture.deviceMu.Unlock()
 
 	capture.startReader(file)
 
@@ -616,7 +620,6 @@ func (capture *waylandEvdevCapture) handleNewDevice(name string) {
 		capture.logger.Info(
 			"New keyboard device detected and captured",
 			zap.String("device", path),
-			zap.Bool("grabbed", isGrabbed),
 		)
 	}
 }

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -621,48 +621,42 @@ func (capture *waylandEvdevCapture) handleNewDevice(name string) {
 	}
 }
 
-// initEvdevCapture initializes the persistent waylandEvdevCapture once and
-// stores it on the EventTap. Subsequent calls return the existing capture.
+// initEvdevCapture initializes the persistent waylandEvdevCapture.
+// A failed attempt can be retried later, allowing detection of newly
+// connected keyboards after startup.
 func (et *EventTap) initEvdevCapture() (*waylandEvdevCapture, error) {
-	var err error
+	et.evdevWaylandCaptureInit.Lock()
+	defer et.evdevWaylandCaptureInit.Unlock()
 
-	et.evdevWaylandCaptureInit.Do(func() {
-		wlCapture, capErr := newWaylandEvdevCapture(et.logger)
-		if capErr != nil {
-			if et.logger != nil {
-				level := et.logger.Info
-				if !errors.Is(capErr, errWaylandEvdevUnavailable) {
-					level = et.logger.Warn
-				}
-
-				level(
-					"Wayland evdev capture unavailable; falling back to overlay keyboard focus",
-					zap.Error(capErr),
-				)
-			}
-
-			err = capErr
-
-			return
+	if et.evdevWaylandCapture != nil {
+		c, ok := et.evdevWaylandCapture.(*waylandEvdevCapture)
+		if !ok {
+			return nil, errWaylandEvdevUnavailable
 		}
 
-		et.evdevWaylandCapture = wlCapture
-	})
-
-	if err != nil {
-		return nil, err
+		return c, nil
 	}
 
-	if et.evdevWaylandCapture == nil {
-		return nil, errWaylandEvdevUnavailable
+	wlCapture, capErr := newWaylandEvdevCapture(et.logger)
+	if capErr != nil {
+		if et.logger != nil {
+			level := et.logger.Info
+			if !errors.Is(capErr, errWaylandEvdevUnavailable) {
+				level = et.logger.Warn
+			}
+
+			level(
+				"Wayland evdev capture unavailable; falling back to overlay keyboard focus",
+				zap.Error(capErr),
+			)
+		}
+
+		return nil, capErr
 	}
 
-	c, ok := et.evdevWaylandCapture.(*waylandEvdevCapture)
-	if !ok {
-		return nil, errWaylandEvdevUnavailable
-	}
+	et.evdevWaylandCapture = wlCapture
 
-	return c, nil
+	return wlCapture, nil
 }
 
 // closeEvdevCapture closes the persistent evdev capture, releasing all file

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -77,9 +77,10 @@ type waylandEvdevCapture struct {
 	events chan waylandEvdevEvent
 	logger *zap.Logger
 
-	closeOnce sync.Once
-	done      sync.WaitGroup
-	grabbed   bool
+	closeOnce        sync.Once
+	done             sync.WaitGroup
+	grabbed          bool
+	startReadersOnce sync.Once
 }
 
 func newWaylandEvdevCapture(logger *zap.Logger) (*waylandEvdevCapture, error) {
@@ -157,6 +158,8 @@ func (capture *waylandEvdevCapture) Close() {
 			_ = file.Close()
 		}
 
+		close(capture.events)
+
 		if capture.logger != nil {
 			capture.logger.Debug(
 				"Evdev capture closed",
@@ -166,17 +169,17 @@ func (capture *waylandEvdevCapture) Close() {
 	})
 }
 
+// startReaders launches reader goroutines for each captured keyboard device.
+// These goroutines run for the entire lifetime of the capture, outliving
+// individual Enable/Disable cycles. Events are sent to capture.events with
+// a non-blocking send so that a full buffer (e.g. while Neru is disabled)
+// simply drops stale events instead of blocking the reader.
 func (capture *waylandEvdevCapture) startReaders() {
 	for _, file := range capture.files {
 		capture.done.Add(1)
 
 		go capture.readLoop(file)
 	}
-
-	go func() {
-		capture.done.Wait()
-		close(capture.events)
-	}()
 }
 
 func (capture *waylandEvdevCapture) readLoop(file *os.File) {
@@ -200,10 +203,16 @@ func (capture *waylandEvdevCapture) readLoop(file *os.File) {
 			return
 		}
 
-		capture.events <- waylandEvdevEvent{
+		// Non-blocking send: if the events channel is full (Neru is disabled
+		// between modes and stale events have accumulated), silently drop the
+		// event rather than blocking the reader.
+		select {
+		case capture.events <- waylandEvdevEvent{
 			eventType: uint16(inputEvent._type),
 			code:      uint16(inputEvent.code),
 			value:     int32(inputEvent.value),
+		}:
+		default:
 		}
 	}
 }
@@ -392,24 +401,67 @@ func queryEvdevModifierState(
 	return state
 }
 
-func (et *EventTap) runWaylandEvdev() bool {
-	capture, err := newWaylandEvdevCapture(et.logger)
-	if err != nil {
-		if et.logger != nil {
-			level := et.logger.Info
-			if !errors.Is(err, errWaylandEvdevUnavailable) {
-				level = et.logger.Warn
+// initEvdevCapture initializes the persistent waylandEvdevCapture once and
+// stores it on the EventTap. Subsequent calls return the existing capture.
+func (et *EventTap) initEvdevCapture() (*waylandEvdevCapture, error) {
+	var err error
+
+	et.evdevWaylandCaptureInit.Do(func() {
+		cap, capErr := newWaylandEvdevCapture(et.logger)
+		if capErr != nil {
+			if et.logger != nil {
+				level := et.logger.Info
+				if !errors.Is(capErr, errWaylandEvdevUnavailable) {
+					level = et.logger.Warn
+				}
+
+				level(
+					"Wayland evdev capture unavailable; falling back to overlay keyboard focus",
+					zap.Error(capErr),
+				)
 			}
 
-			level(
-				"Wayland evdev capture unavailable; falling back to overlay keyboard focus",
-				zap.Error(err),
-			)
+			err = capErr
+
+			return
 		}
 
+		et.evdevWaylandCapture = cap
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if et.evdevWaylandCapture == nil {
+		return nil, errWaylandEvdevUnavailable
+	}
+
+	return et.evdevWaylandCapture.(*waylandEvdevCapture), nil
+}
+
+// closeEvdevCapture closes the persistent evdev capture, releasing all file
+// descriptors and stopping reader goroutines. It is safe to call multiple
+// times — the underlying Close() uses sync.Once.
+func (et *EventTap) closeEvdevCapture() {
+	if et.evdevWaylandCapture == nil {
+		return
+	}
+
+	capture := et.evdevWaylandCapture.(*waylandEvdevCapture)
+	capture.Close()
+	et.evdevWaylandCapture = nil
+}
+
+func (et *EventTap) runWaylandEvdev() bool {
+	// Get or create the persistent capture (initialized once, reused
+	// across Enable/Disable cycles). This avoids re-scanning
+	// /dev/input/event* devices on every mode activation, which was
+	// the source of a ~0.5s delay before modes accepted input.
+	capture, err := et.initEvdevCapture()
+	if err != nil {
 		return false
 	}
-	defer capture.Close()
 
 	manager := overlay.Get()
 	keyboardCaptureDisabled := false
@@ -441,7 +493,11 @@ func (et *EventTap) runWaylandEvdev() bool {
 		return false
 	}
 
-	capture.startReaders()
+	// Start reader goroutines on first invocation only; they run for
+	// the entire lifetime of the capture (until EventTap.Destroy()).
+	capture.startReadersOnce.Do(func() {
+		capture.startReaders()
+	})
 
 	if manager != nil {
 		manager.SetKeyboardCaptureEnabled(false)
@@ -455,6 +511,20 @@ func (et *EventTap) runWaylandEvdev() bool {
 		)
 	}
 
+	// Drain any stale events that accumulated in the channel while
+	// Neru was disabled between modes. These are events from other
+	// applications that were pushed into the buffer when we were
+	// ungrabbed. A labeled break is required here — plain break
+	// inside select only exits the select, not the for loop.
+drainStale:
+	for {
+		select {
+		case <-capture.events:
+		default:
+			break drainStale
+		}
+	}
+
 	pressed := make(map[uint16]bool)
 	state := waylandEvdevKeyState{
 		pressed: pressed,
@@ -466,6 +536,12 @@ func (et *EventTap) runWaylandEvdev() bool {
 	for {
 		select {
 		case <-et.stopCh:
+			// Ungrab devices but keep the capture alive for reuse
+			// on the next Enable(). The reader goroutines stay
+			// running and will drop stale events via the non-blocking
+			// send until we drain and re-grab.
+			capture.ungrabAll()
+
 			return true
 		case event, ok := <-capture.events:
 			if !ok {

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -407,7 +407,7 @@ func (et *EventTap) initEvdevCapture() (*waylandEvdevCapture, error) {
 	var err error
 
 	et.evdevWaylandCaptureInit.Do(func() {
-		cap, capErr := newWaylandEvdevCapture(et.logger)
+		wlCapture, capErr := newWaylandEvdevCapture(et.logger)
 		if capErr != nil {
 			if et.logger != nil {
 				level := et.logger.Info
@@ -426,7 +426,7 @@ func (et *EventTap) initEvdevCapture() (*waylandEvdevCapture, error) {
 			return
 		}
 
-		et.evdevWaylandCapture = cap
+		et.evdevWaylandCapture = wlCapture
 	})
 
 	if err != nil {
@@ -437,7 +437,12 @@ func (et *EventTap) initEvdevCapture() (*waylandEvdevCapture, error) {
 		return nil, errWaylandEvdevUnavailable
 	}
 
-	return et.evdevWaylandCapture.(*waylandEvdevCapture), nil
+	c, ok := et.evdevWaylandCapture.(*waylandEvdevCapture)
+	if !ok {
+		return nil, errWaylandEvdevUnavailable
+	}
+
+	return c, nil
 }
 
 // closeEvdevCapture closes the persistent evdev capture, releasing all file
@@ -448,7 +453,11 @@ func (et *EventTap) closeEvdevCapture() {
 		return
 	}
 
-	capture := et.evdevWaylandCapture.(*waylandEvdevCapture)
+	capture, ok := et.evdevWaylandCapture.(*waylandEvdevCapture)
+	if !ok {
+		return
+	}
+
 	capture.Close()
 	et.evdevWaylandCapture = nil
 }
@@ -457,7 +466,7 @@ func (et *EventTap) runWaylandEvdev() bool {
 	// Get or create the persistent capture (initialized once, reused
 	// across Enable/Disable cycles). This avoids re-scanning
 	// /dev/input/event* devices on every mode activation, which was
-	// the source of a ~0.5s delay before modes accepted input.
+	// the source of a mild delay before modes accepted input.
 	capture, err := et.initEvdevCapture()
 	if err != nil {
 		return false

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -15,7 +15,9 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
+	"unsafe"
 
 	"go.uber.org/zap"
 
@@ -26,6 +28,8 @@ import (
 const (
 	waylandEvdevEventBufferSize           = 128
 	waylandEvdevModifierReleasePollPeriod = 5 * time.Millisecond
+	waylandEvdevHotplugBufSize            = 4096
+	waylandEvdevHotplugSettleDelay        = 100 * time.Millisecond
 )
 
 var (
@@ -81,6 +85,10 @@ type waylandEvdevCapture struct {
 	done             sync.WaitGroup
 	grabbed          bool
 	startReadersOnce sync.Once
+
+	deviceMu  sync.Mutex
+	inotifyFd int
+	hotplugWg sync.WaitGroup
 }
 
 func newWaylandEvdevCapture(logger *zap.Logger) (*waylandEvdevCapture, error) {
@@ -90,9 +98,10 @@ func newWaylandEvdevCapture(logger *zap.Logger) (*waylandEvdevCapture, error) {
 	}
 
 	capture := &waylandEvdevCapture{
-		files:  make([]*os.File, 0, len(paths)),
-		events: make(chan waylandEvdevEvent, waylandEvdevEventBufferSize),
-		logger: logger,
+		files:     make([]*os.File, 0, len(paths)),
+		events:    make(chan waylandEvdevEvent, waylandEvdevEventBufferSize),
+		logger:    logger,
+		inotifyFd: -1,
 	}
 
 	for _, path := range paths {
@@ -152,34 +161,48 @@ func (capture *waylandEvdevCapture) Close() {
 	}
 
 	capture.closeOnce.Do(func() {
-		capture.ungrabAll()
+		// Stop the hotplug watcher first: closing the inotify fd unblocks
+		// the hotplugLoop goroutine, causing it to exit.
+		capture.stopHotplugWatcher()
+
+		capture.deviceMu.Lock()
+		capture.ungrabAllLocked()
 
 		for _, file := range capture.files {
 			_ = file.Close()
 		}
 
+		capture.files = nil
+		capture.deviceMu.Unlock()
+
 		close(capture.events)
 
 		if capture.logger != nil {
-			capture.logger.Debug(
-				"Evdev capture closed",
-				zap.Int("devices", len(capture.files)),
-			)
+			capture.logger.Debug("Evdev capture closed")
 		}
 	})
 }
 
-// startReaders launches reader goroutines for each captured keyboard device.
+// startReaders launches reader goroutines for each captured keyboard device
+// and starts the inotify hotplug watcher for detecting device hotplug.
 // These goroutines run for the entire lifetime of the capture, outliving
 // individual Enable/Disable cycles. Events are sent to capture.events with
 // a non-blocking send so that a full buffer (e.g. while Neru is disabled)
 // simply drops stale events instead of blocking the reader.
 func (capture *waylandEvdevCapture) startReaders() {
+	capture.deviceMu.Lock()
 	for _, file := range capture.files {
 		capture.done.Add(1)
-
 		go capture.readLoop(file)
 	}
+	capture.deviceMu.Unlock()
+
+	capture.startHotplugWatcher()
+}
+
+func (capture *waylandEvdevCapture) startReader(file *os.File) {
+	capture.done.Add(1)
+	go capture.readLoop(file)
 }
 
 func (capture *waylandEvdevCapture) readLoop(file *os.File) {
@@ -200,6 +223,13 @@ func (capture *waylandEvdevCapture) readLoop(file *os.File) {
 				)
 			}
 
+			// Device disconnected — remove it from the tracked files slice
+			// so we don't attempt to grab/query a stale fd on the next cycle.
+			capture.deviceMu.Lock()
+			capture.removeFileLocked(file)
+			capture.deviceMu.Unlock()
+			_ = file.Close()
+
 			return
 		}
 
@@ -217,7 +247,26 @@ func (capture *waylandEvdevCapture) readLoop(file *os.File) {
 	}
 }
 
+// removeFileLocked removes file from the tracked files slice.
+// Must be called with capture.deviceMu held.
+func (capture *waylandEvdevCapture) removeFileLocked(file *os.File) {
+	for i, f := range capture.files {
+		if f == file {
+			capture.files = append(capture.files[:i], capture.files[i+1:]...)
+
+			return
+		}
+	}
+}
+
 func (capture *waylandEvdevCapture) grabAll() error {
+	capture.deviceMu.Lock()
+	defer capture.deviceMu.Unlock()
+
+	return capture.grabAllLocked()
+}
+
+func (capture *waylandEvdevCapture) grabAllLocked() error {
 	if capture == nil || capture.grabbed {
 		return nil
 	}
@@ -316,6 +365,13 @@ func (capture *waylandEvdevCapture) findVirtualDevice() *os.File {
 }
 
 func (capture *waylandEvdevCapture) ungrabAll() {
+	capture.deviceMu.Lock()
+	defer capture.deviceMu.Unlock()
+
+	capture.ungrabAllLocked()
+}
+
+func (capture *waylandEvdevCapture) ungrabAllLocked() {
 	if capture == nil || !capture.grabbed {
 		return
 	}
@@ -332,6 +388,9 @@ func (capture *waylandEvdevCapture) modifierKeysHeld() bool {
 	if capture == nil {
 		return false
 	}
+
+	capture.deviceMu.Lock()
+	defer capture.deviceMu.Unlock()
 
 	modifierCodes := []uint16{
 		evdevKeyLeftShift,
@@ -370,6 +429,9 @@ func queryEvdevModifierState(
 		return linuxModifierState{}
 	}
 
+	capture.deviceMu.Lock()
+	defer capture.deviceMu.Unlock()
+
 	var state linuxModifierState
 
 	type modifierKey struct {
@@ -399,6 +461,160 @@ func queryEvdevModifierState(
 	}
 
 	return state
+}
+
+// startHotplugWatcher starts an inotify watch on /dev/input/ to detect new
+// keyboard devices being plugged in after initial capture creation.
+func (capture *waylandEvdevCapture) startHotplugWatcher() {
+	if capture == nil {
+		return
+	}
+
+	inotifyFd, err := syscall.InotifyInit1(syscall.IN_NONBLOCK)
+	if err != nil {
+		if capture.logger != nil {
+			capture.logger.Debug(
+				"Inotify init failed, keyboard hotplug detection disabled",
+				zap.Error(err),
+			)
+		}
+
+		return
+	}
+
+	_, err = syscall.InotifyAddWatch(inotifyFd, "/dev/input", syscall.IN_CREATE)
+	if err != nil {
+		_ = syscall.Close(inotifyFd)
+
+		if capture.logger != nil {
+			capture.logger.Debug(
+				"Inotify add watch failed, keyboard hotplug detection disabled",
+				zap.Error(err),
+			)
+		}
+
+		return
+	}
+
+	capture.deviceMu.Lock()
+	if capture.inotifyFd != -1 {
+		// A watcher is already running; clean up the duplicate.
+		capture.deviceMu.Unlock()
+		_ = syscall.Close(inotifyFd)
+
+		return
+	}
+
+	capture.inotifyFd = inotifyFd
+	capture.deviceMu.Unlock()
+
+	capture.hotplugWg.Add(1)
+	go capture.hotplugLoop()
+}
+
+// stopHotplugWatcher closes the inotify fd, which unblocks the hotplugLoop
+// goroutine, then waits for the goroutine to finish.
+func (capture *waylandEvdevCapture) stopHotplugWatcher() {
+	capture.deviceMu.Lock()
+	fd := capture.inotifyFd
+	capture.inotifyFd = -1
+	capture.deviceMu.Unlock()
+
+	if fd != -1 {
+		_ = syscall.Close(fd)
+	}
+
+	capture.hotplugWg.Wait()
+}
+
+// hotplugLoop reads inotify events and handles new keyboard device creation.
+func (capture *waylandEvdevCapture) hotplugLoop() {
+	defer capture.hotplugWg.Done()
+
+	buf := make([]byte, waylandEvdevHotplugBufSize)
+	for {
+		n, err := syscall.Read(capture.inotifyFd, buf)
+		if err != nil {
+			return
+		}
+
+		capture.handleInotifyEvents(buf[:n])
+	}
+}
+
+// handleInotifyEvents parses raw inotify event bytes and reacts to new device
+// creation events.
+func (capture *waylandEvdevCapture) handleInotifyEvents(buf []byte) {
+	offset := 0
+	for offset+syscall.SizeofInotifyEvent <= len(buf) {
+		event := (*syscall.InotifyEvent)(unsafe.Pointer(&buf[offset]))
+		nameLen := int(event.Len)
+		if nameLen > 0 && event.Mask&syscall.IN_CREATE != 0 {
+			nameStart := offset + syscall.SizeofInotifyEvent
+			nameEnd := nameStart + nameLen
+			nameEnd = min(nameEnd, len(buf))
+			name := strings.TrimRight(string(buf[nameStart:nameEnd]), "\x00")
+			if strings.HasPrefix(name, "event") {
+				capture.handleNewDevice(name)
+			}
+		}
+		offset += syscall.SizeofInotifyEvent + nameLen
+	}
+}
+
+// handleNewDevice opens a newly created /dev/input/event* device and, if it
+// is a keyboard, adds it to the capture and starts a reader goroutine. If
+// the capture is currently in a grabbed state, the new device is also grabbed
+// immediately so Neru stays in full control.
+func (capture *waylandEvdevCapture) handleNewDevice(name string) {
+	// Give udev a moment to fully initialize the device node and populate
+	// the input capabilities before we interrogate it.
+	time.Sleep(waylandEvdevHotplugSettleDelay)
+
+	path := filepath.Join("/dev/input", name)
+	file, err := os.Open(path)
+	if err != nil {
+		return
+	}
+
+	fd := C.int(file.Fd())
+	if C.neru_evdev_is_keyboard(fd) == 0 {
+		_ = file.Close()
+
+		return
+	}
+
+	capture.deviceMu.Lock()
+
+	// Avoid duplicates: the device might already be tracked if the inotify
+	// event fired for a device that was open at initial scan time (unlikely
+	// but possible on some kernels).
+	for _, f := range capture.files {
+		if f.Name() == path {
+			capture.deviceMu.Unlock()
+			_ = file.Close()
+
+			return
+		}
+	}
+
+	capture.files = append(capture.files, file)
+	isGrabbed := capture.grabbed
+	capture.deviceMu.Unlock()
+
+	if isGrabbed {
+		C.neru_evdev_grab(C.int(file.Fd()), 1)
+	}
+
+	capture.startReader(file)
+
+	if capture.logger != nil {
+		capture.logger.Info(
+			"New keyboard device detected and captured",
+			zap.String("device", path),
+			zap.Bool("grabbed", isGrabbed),
+		)
+	}
 }
 
 // initEvdevCapture initializes the persistent waylandEvdevCapture once and


### PR DESCRIPTION
<!-- What does this PR do? Why is it needed? -->

This PR fixes an issue where previously we are re-scanning `/dev/input/event*` devices on every mode activation, which makes an approximate 0.5s delay for input. This changes includes 2 fixes to make it more robust:

1. evdev device capture is now created once and reused across our enable and disable cycle
2. adds an inotify watcher on `/dev/input/` to detect if keyboard plugged or unplugged, so that captured device list are in sync properly

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A