### PR TITLE
fix(linux,wayland): prevent stale evdev state from causing stuck keys after grab

### DIFF
--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -28,6 +28,8 @@ import (
 const (
 	waylandEvdevEventBufferSize           = 128
 	waylandEvdevModifierReleasePollPeriod = 5 * time.Millisecond
+	waylandEvdevPreGrabHoldPollPeriod     = 50 * time.Millisecond
+	waylandEvdevPreGrabTimeout            = 5 * time.Second
 	waylandEvdevHotplugBufSize            = 4096
 	waylandEvdevHotplugSettleDelay        = 100 * time.Millisecond
 )
@@ -750,6 +752,57 @@ func (et *EventTap) runWaylandEvdev() bool {
 		}
 	}
 
+	// Wait for ALL physically held keys to be released before
+	// grabbing.  Grabbing while a key is held causes the kernel to
+	// route that key's release to our fd only — libinput never sees
+	// it and permanently considers the key pressed.  The next press
+	// of the same key after the mode exits is then treated as a
+	// duplicate by libinput and silently consumed.
+	{
+		held := make(map[uint16]bool)
+		queryAllPressedKeys(capture, held)
+		if len(held) > 0 {
+			if manager != nil {
+				manager.SetKeyboardCaptureEnabled(true)
+			}
+
+			deadline := time.After(waylandEvdevPreGrabTimeout)
+			ticker := time.NewTicker(waylandEvdevPreGrabHoldPollPeriod)
+		waitLoop:
+			for {
+				pressed := make(map[uint16]bool)
+				queryAllPressedKeys(capture, pressed)
+				if len(pressed) == 0 {
+					break waitLoop
+				}
+
+				select {
+				case <-et.stopCh:
+					ticker.Stop()
+					if manager != nil {
+						manager.SetKeyboardCaptureEnabled(false)
+					}
+
+					return true
+				case <-deadline:
+					break waitLoop
+				case <-ticker.C:
+				case _, ok := <-capture.events:
+					if !ok {
+						ticker.Stop()
+
+						return true
+					}
+				}
+			}
+			ticker.Stop()
+
+			if manager != nil {
+				manager.SetKeyboardCaptureEnabled(false)
+			}
+		}
+	}
+
 	grabErr := capture.grabAll()
 	if grabErr != nil {
 		if et.logger != nil {
@@ -820,23 +873,17 @@ drainStale:
 	for {
 		select {
 		case <-et.stopCh:
-			// Inject synthetic release events for keys that were
-			// physically held when the mode was activated but have
-			// since been released.  The evdev grab consumed those
-			// release events; the compositor/terminal never saw them
-			// and so continues repeating the key.  Releasing them
-			// here unsticks the compositor's key state before we
-			// ungrab.
+			// Inject synthetic releases for any keys that were
+			// released during the grab and whose release events
+			// never reached libinput.  (After the pre-grab wait
+			// above, initialKeys is typically empty — this is a
+			// safety net for keys pressed during the mode itself.)
 			for code := range state.initialKeys {
 				if !state.pressed[code] {
 					_ = linux.WaylandKeyEvent(uint32(code), false)
 				}
 			}
 
-			// Ungrab devices but keep the capture alive for reuse
-			// on the next Enable(). The reader goroutines stay
-			// running and will drop stale events via the non-blocking
-			// send until we drain and re-grab.
 			capture.ungrabAll()
 
 			return true

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -79,11 +79,16 @@ type waylandEvdevEvent struct {
 type waylandEvdevKeyState struct {
 	modifiers evdevModifierState
 	pressed   map[uint16]bool
-	// initialKeys tracks keys that were already physically held when the event
-	// tap was (re-)enabled. The kernel replays press events for these via the
-	// SYN_DROPPED mechanism after EVIOCGRAB. We suppress dispatches for these
-	// keys until they are released (removing from initialKeys) and re-pressed.
+	// initialKeys tracks keys that were already physically held when
+	// the event tap was (re-)enabled.  The kernel replays press events
+	// via SYN_DROPPED after EVIOCGRAB; we suppress dispatch for these
+	// until the physical release (removing from initialKeys).
 	initialKeys map[uint16]bool
+	// releasedDuringGrab is a subset of initialKeys: keys that were
+	// released while the evdev grab was active and whose release events
+	// never reached libinput.  We inject synthetic releases for these
+	// at shutdown so libinput's per-keycode hw_is_key_down is cleared.
+	releasedDuringGrab map[uint16]bool
 }
 
 type waylandEvdevCapture struct {
@@ -849,8 +854,9 @@ drainStale:
 
 	pressed := make(map[uint16]bool)
 	state := waylandEvdevKeyState{
-		pressed:     pressed,
-		initialKeys: make(map[uint16]bool),
+		pressed:            pressed,
+		initialKeys:        make(map[uint16]bool),
+		releasedDuringGrab: make(map[uint16]bool),
 		modifiers: evdevModifierState{
 			linuxModifierState: queryEvdevModifierState(capture, pressed),
 		},
@@ -873,11 +879,14 @@ drainStale:
 	for {
 		select {
 		case <-et.stopCh:
-			// Inject synthetic releases for any keys that were
-			// released during the grab and whose release events
-			// never reached libinput.  (After the pre-grab wait
-			// above, initialKeys is typically empty — this is a
-			// safety net for keys pressed during the mode itself.)
+			// Inject synthetic releases for keys that were in
+			// initialKeys and physically released during the grab
+			// (their release never reached libinput), or are still
+			// in initialKeys but no longer pressed (released during
+			// the grab before the event handler processed them).
+			for code := range state.releasedDuringGrab {
+				_ = linux.WaylandKeyEvent(uint32(code), false)
+			}
 			for code := range state.initialKeys {
 				if !state.pressed[code] {
 					_ = linux.WaylandKeyEvent(uint32(code), false)
@@ -962,7 +971,10 @@ func (et *EventTap) handleWaylandEvdevEvent(
 			return
 		}
 	case evdevValueRelease:
-		delete(state.initialKeys, event.code)
+		if state.initialKeys[event.code] {
+			state.releasedDuringGrab[event.code] = true
+			delete(state.initialKeys, event.code)
+		}
 		state.trackKey(event.code, false)
 
 		key := evdevKeyName(event.code)

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -885,11 +885,23 @@ drainStale:
 			// in initialKeys but no longer pressed (released during
 			// the grab before the event handler processed them).
 			for code := range state.releasedDuringGrab {
-				_ = linux.WaylandKeyEvent(uint32(code), false)
+				err := linux.WaylandKeyEvent(uint32(code), false)
+				if err != nil && et.logger != nil {
+					et.logger.Warn("Failed to inject synthetic key release at shutdown",
+						zap.Uint16("keycode", code),
+						zap.Error(err),
+					)
+				}
 			}
 			for code := range state.initialKeys {
 				if !state.pressed[code] {
-					_ = linux.WaylandKeyEvent(uint32(code), false)
+					err := linux.WaylandKeyEvent(uint32(code), false)
+					if err != nil && et.logger != nil {
+						et.logger.Warn("Failed to inject synthetic key release at shutdown",
+							zap.Uint16("keycode", code),
+							zap.Error(err),
+						)
+					}
 				}
 			}
 

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -39,7 +39,10 @@ var (
 	errUinputScrollSend        = errors.New("failed to send uinput scroll event")
 )
 
-const waylandEvdevDeviceNameSize = 256
+const (
+	waylandEvdevDeviceNameSize = 256
+	evdevMaxPressedKeys        = 256
+)
 
 const waylandEvdevBusVirtual = 0x06
 
@@ -440,7 +443,7 @@ func queryAllPressedKeys(capture *waylandEvdevCapture, pressed map[uint16]bool) 
 	capture.deviceMu.Lock()
 	defer capture.deviceMu.Unlock()
 
-	keycodes := make([]C.uint, 256)
+	keycodes := make([]C.uint, evdevMaxPressedKeys)
 
 	for _, file := range capture.files {
 		fd := C.int(file.Fd())

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -74,6 +74,11 @@ type waylandEvdevEvent struct {
 type waylandEvdevKeyState struct {
 	modifiers evdevModifierState
 	pressed   map[uint16]bool
+	// initialKeys tracks keys that were already physically held when the event
+	// tap was (re-)enabled. The kernel replays press events for these via the
+	// SYN_DROPPED mechanism after EVIOCGRAB. We suppress dispatches for these
+	// keys until they are released (removing from initialKeys) and re-pressed.
+	initialKeys map[uint16]bool
 }
 
 type waylandEvdevCapture struct {
@@ -422,6 +427,35 @@ func (capture *waylandEvdevCapture) modifierKeysHeld() bool {
 	return false
 }
 
+// queryAllPressedKeys retrieves all currently pressed keys via EVIOCGKEY from
+// each captured device and records them in the pressed map. This is called
+// after EVIOCGRAB because the kernel replays the current key state through the
+// SYN_DROPPED mechanism. By querying the state here we can distinguish keys
+// that were held before mode activation from keys pressed during the mode.
+func queryAllPressedKeys(capture *waylandEvdevCapture, pressed map[uint16]bool) {
+	if capture == nil {
+		return
+	}
+
+	capture.deviceMu.Lock()
+	defer capture.deviceMu.Unlock()
+
+	keycodes := make([]C.uint, 256)
+
+	for _, file := range capture.files {
+		fd := C.int(file.Fd())
+		n := int(C.neru_evdev_get_pressed_keys(fd, &keycodes[0], C.int(len(keycodes))))
+		if n <= 0 {
+			continue
+		}
+
+		for i := range min(n, len(keycodes)) {
+			code := uint16(keycodes[i])
+			pressed[code] = true
+		}
+	}
+}
+
 // queryEvdevModifierState queries the current evdev key state and returns
 // a linuxModifierState counting any held modifier keys across all captured
 // devices. Keys that are physically held are also recorded in pressed so that
@@ -759,10 +793,25 @@ drainStale:
 
 	pressed := make(map[uint16]bool)
 	state := waylandEvdevKeyState{
-		pressed: pressed,
+		pressed:     pressed,
+		initialKeys: make(map[uint16]bool),
 		modifiers: evdevModifierState{
 			linuxModifierState: queryEvdevModifierState(capture, pressed),
 		},
+	}
+
+	// Query all currently pressed (not just modifier) keys so we can suppress
+	// dispatch for keys that were held before this mode session started.
+	// Without this, the kernel's SYN_DROPPED replay after EVIOCGRAB delivers
+	// stale press events that would be interpreted as fresh key presses.
+	queryAllPressedKeys(capture, pressed)
+
+	// Copy the queried keys into initialKeys so the event handler can
+	// distinguish pre-existing presses from new ones. Keys that were already
+	// held when the event tap was enabled will have their repeat events
+	// suppressed until the user releases and re-presses them.
+	for code := range pressed {
+		state.initialKeys[code] = true
 	}
 
 	for {
@@ -838,8 +887,19 @@ func (et *EventTap) handleWaylandEvdevEvent(
 
 	switch event.value {
 	case evdevValuePress:
+		// If this key was already held when the event tap was enabled, the
+		// press is from the kernel's SYN_DROPPED state replay after
+		// EVIOCGRAB. Track it in pressed (so subsequent repeats are not
+		// silently consumed) but skip dispatch — the user did not press
+		// it during this mode session. The initialKeys entry persists
+		// until the physical release so repeats continue to be suppressed.
 		state.trackKey(event.code, true)
+
+		if state.initialKeys[event.code] {
+			return
+		}
 	case evdevValueRelease:
+		delete(state.initialKeys, event.code)
 		state.trackKey(event.code, false)
 
 		key := evdevKeyName(event.code)
@@ -852,6 +912,13 @@ func (et *EventTap) handleWaylandEvdevEvent(
 		return
 	case evdevValueRepeat:
 		if !state.pressed[event.code] {
+			return
+		}
+
+		// Suppress repeat dispatch for keys that were held before mode
+		// activation. The user must release and re-press to have the key
+		// register as a fresh input in the active mode.
+		if state.initialKeys[event.code] {
 			return
 		}
 	default:

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -21,7 +21,7 @@ import (
 
 	"go.uber.org/zap"
 
-	_ "github.com/y3owk1n/neru/internal/core/infra/platform/linux"
+	linux "github.com/y3owk1n/neru/internal/core/infra/platform/linux"
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
@@ -817,6 +817,19 @@ drainStale:
 	for {
 		select {
 		case <-et.stopCh:
+			// Inject synthetic release events for keys that were
+			// physically held when the mode was activated but have
+			// since been released.  The evdev grab consumed those
+			// release events; the compositor/terminal never saw them
+			// and so continues repeating the key.  Releasing them
+			// here unsticks the compositor's key state before we
+			// ungrab.
+			for code := range state.initialKeys {
+				if !state.pressed[code] {
+					_ = linux.WaylandKeyEvent(uint32(code), false)
+				}
+			}
+
 			// Ungrab devices but keep the capture alive for reuse
 			// on the next Enable(). The reader goroutines stay
 			// running and will drop stale events via the non-blocking

--- a/internal/core/infra/platform/linux/evdev.c
+++ b/internal/core/infra/platform/linux/evdev.c
@@ -60,6 +60,28 @@ ssize_t neru_evdev_read_event(int fd, struct input_event *event) {
 	return n;
 }
 
+int neru_evdev_get_pressed_keys(int fd, unsigned int *out_keys, int max_keys) {
+	unsigned long key_bits[(KEY_MAX + 8 * sizeof(unsigned long)) / (8 * sizeof(unsigned long))];
+	memset(key_bits, 0, sizeof(key_bits));
+
+	if (ioctl(fd, EVIOCGKEY(sizeof(key_bits)), key_bits) < 0) {
+		return -1;
+	}
+
+	int count = 0;
+	for (unsigned int i = 0; i < KEY_MAX; i++) {
+		int idx = i / (8 * (int)sizeof(unsigned long));
+		int bit = i % (8 * (int)sizeof(unsigned long));
+		if ((key_bits[idx] >> bit) & 1UL) {
+			if (count < max_keys) {
+				out_keys[count] = i;
+			}
+			count++;
+		}
+	}
+	return count;
+}
+
 int neru_uinput_create_scroll(int *out_fd) {
 	int fd = open("/dev/uinput", O_RDWR);
 	if (fd < 0) {

--- a/internal/core/infra/platform/linux/evdev.h
+++ b/internal/core/infra/platform/linux/evdev.h
@@ -11,6 +11,7 @@ int neru_evdev_is_keyboard(int fd);
 int neru_evdev_get_name(int fd, char *name, size_t name_size);
 int neru_evdev_get_bustype(int fd);
 ssize_t neru_evdev_read_event(int fd, struct input_event *event);
+int neru_evdev_get_pressed_keys(int fd, unsigned int *out_keys, int max_keys);
 int neru_uinput_create_scroll(int *out_fd);
 int neru_uinput_scroll(int fd, int axis, int value);
 int neru_uinput_scroll_batch(int fd, int axis, int *values, int count);

--- a/internal/core/infra/platform/linux/system_linux_wayland.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland.go
@@ -58,3 +58,12 @@ func WlrootsScrollBatch(axis int, deltas, discretes []int) error {
 func WaylandModifierEvent(modifier string, isDown bool) error {
 	return globalWlrootsModifierDispatcher.event(modifier, isDown)
 }
+
+// WaylandKeyEvent presses (pressed=true) or releases (pressed=false) a single
+// key identified by its evdev keycode using the virtual keyboard protocol.
+// This is used to inject synthetic release events for keys that were held
+// before an evdev grab and released during it, so the compositor's key state
+// stays consistent.
+func WaylandKeyEvent(keycode uint32, pressed bool) error {
+	return waylandKeyEvent(keycode, pressed)
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland_input.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_input.go
@@ -282,3 +282,18 @@ func waylandModifierEvent(modifier string, isDown bool) error {
 
 	return libeiKey(keycode, isDown)
 }
+
+// waylandKeyEvent presses or releases a key on the virtual keyboard, routing
+// through the wlroots virtual keyboard or libei depending on the compositor.
+func waylandKeyEvent(keycode uint32, pressed bool) error {
+	hasVirtualKeyboard, err := wlrootsHasVirtualKeyboard()
+	if err != nil {
+		return err
+	}
+
+	if hasVirtualKeyboard {
+		return wlrootsKey(keycode, pressed)
+	}
+
+	return libeiKey(int(keycode), pressed)
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes a combination of issue where the evdev key state is not properly in sync in general. Keys held before mode activation produce stale press dispatches, and if released during the mode, the release reaches only Neru's fd — libinput never sees it and permanently considers the key pressed.

This PR fixes the issue with three changes:

1. **Pre-grab hold wait** — Before grabbing, poll all evdev devices via `EVIOCGKEY` and wait (up to 5 s) for held keys to be released. This avoids splitting key state between fds in the first place.
2. **`initialKeys` suppression** — Keys still held when the grab proceeds are tracked; their `SYN_DROPPED` replay press events update internal state but are not dispatched. Repeats are also suppressed until release+re-press.
3. **Synthetic release injection** — On disable, inject virtual-keyboard releases for keys in `initialKeys` that are no longer physically pressed.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

https://github.com/user-attachments/assets/064c16af-72f5-42bd-bb9c-502d9bc846f1

Previously:

1. when we hold the `l` key, when the grid runs, it will keep repeat the `l` key by it's own
2. once the grid runs, escape the mode, and press the first `l` key will be eaten up, the second `l` will only shown

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A