### PR TITLE
fix(linux,wayland): prevent hotpulgLoop busy wait

### DIFF
--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -520,7 +520,7 @@ func (capture *waylandEvdevCapture) startHotplugWatcher() {
 		return
 	}
 
-	inotifyFd, err := syscall.InotifyInit1(syscall.IN_NONBLOCK)
+	inotifyFd, err := syscall.InotifyInit()
 	if err != nil {
 		if capture.logger != nil {
 			capture.logger.Debug(

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -32,6 +32,7 @@ const (
 	waylandEvdevPreGrabTimeout            = 5 * time.Second
 	waylandEvdevHotplugBufSize            = 4096
 	waylandEvdevHotplugSettleDelay        = 100 * time.Millisecond
+	waylandEvdevHotplugPollInterval       = 500 * time.Millisecond
 )
 
 var (
@@ -101,9 +102,11 @@ type waylandEvdevCapture struct {
 	grabbed          bool
 	startReadersOnce sync.Once
 
-	deviceMu  sync.Mutex
-	inotifyFd int
-	hotplugWg sync.WaitGroup
+	deviceMu      sync.Mutex
+	inotifyFd     int
+	hotplugStopCh chan struct{}
+	hotplugOnce   sync.Once
+	hotplugWg     sync.WaitGroup
 }
 
 func newWaylandEvdevCapture(logger *zap.Logger) (*waylandEvdevCapture, error) {
@@ -520,7 +523,7 @@ func (capture *waylandEvdevCapture) startHotplugWatcher() {
 		return
 	}
 
-	inotifyFd, err := syscall.InotifyInit()
+	inotifyFd, err := syscall.InotifyInit1(syscall.IN_NONBLOCK)
 	if err != nil {
 		if capture.logger != nil {
 			capture.logger.Debug(
@@ -556,36 +559,55 @@ func (capture *waylandEvdevCapture) startHotplugWatcher() {
 	}
 
 	capture.inotifyFd = inotifyFd
+	capture.hotplugStopCh = make(chan struct{})
 	capture.deviceMu.Unlock()
 
 	capture.hotplugWg.Add(1)
 	go capture.hotplugLoop()
 }
 
-// stopHotplugWatcher closes the inotify fd, which unblocks the hotplugLoop
-// goroutine, then waits for the goroutine to finish.
+// stopHotplugWatcher signals the hotplugLoop goroutine to stop via the stop
+// channel, closes the inotify fd, then waits for the goroutine to finish.
 func (capture *waylandEvdevCapture) stopHotplugWatcher() {
 	capture.deviceMu.Lock()
-	fd := capture.inotifyFd
+	inotifyFd := capture.inotifyFd
 	capture.inotifyFd = -1
 	capture.deviceMu.Unlock()
 
-	if fd != -1 {
-		_ = syscall.Close(fd)
+	capture.hotplugOnce.Do(func() {
+		if capture.hotplugStopCh != nil {
+			close(capture.hotplugStopCh)
+		}
+	})
+
+	if inotifyFd != -1 {
+		_ = syscall.Close(inotifyFd)
 	}
 
 	capture.hotplugWg.Wait()
 }
 
-// hotplugLoop reads inotify events and handles new keyboard device creation.
+// hotplugLoop polls for inotify events with a non-blocking read and
+// rate-limits the poll via a ticker so the goroutine does not busy-wait
+// on EAGAIN.  A dedicated stop channel provides an interruptible shutdown
+// that does not rely on closing the inotify fd to unblock the read.
 func (capture *waylandEvdevCapture) hotplugLoop() {
 	defer capture.hotplugWg.Done()
 
 	buf := make([]byte, waylandEvdevHotplugBufSize)
+	ticker := time.NewTicker(waylandEvdevHotplugPollInterval)
+	defer ticker.Stop()
+
 	for {
 		nread, err := syscall.Read(capture.inotifyFd, buf)
 		if err != nil {
 			if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EWOULDBLOCK) {
+				select {
+				case <-capture.hotplugStopCh:
+					return
+				case <-ticker.C:
+				}
+
 				continue
 			}
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes an infinite loop mistake where evdev hotplug watcher via inotify was created in `IN_NONBLOCK`, causing `sys call.Read` to return `EAGAIN` immediately when no hot plug is detected... and it keep repeats looping, which create an infinite loop that burns the cpu to potentially 100%.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

First attempt is before this fix, and second is after this fix.

https://github.com/user-attachments/assets/ca76d11f-3855-447c-97c3-058bcba9fcfa

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
