### PR TITLE
fix(linux,wayland): sync cursor before mode activation

### DIFF
--- a/internal/app/modes/scroll.go
+++ b/internal/app/modes/scroll.go
@@ -13,6 +13,7 @@ import (
 // StartInteractiveScroll activates the interactive scroll mode,
 // showing the scroll overlay and enabling key handling for scrolling.
 func (h *Handler) StartInteractiveScroll() {
+	h.prepareForModeActivation()
 	h.cursorState.SkipNextRestore()
 
 	h.scroll.Context.Reset()

--- a/internal/app/modes/validation.go
+++ b/internal/app/modes/validation.go
@@ -14,6 +14,10 @@ const (
 	ValidationTimeout = 2 * time.Second
 )
 
+type cursorSyncer interface {
+	SyncCursorPosition(ctx context.Context) error
+}
+
 // validateModeActivation performs common validation checks before mode activation.
 // Returns an error if the mode cannot be activated.
 // If bundleID is non-empty, it is used directly for exclusion check (skips AX call).
@@ -69,9 +73,10 @@ func (h *Handler) validateModeActivation(bundleID string, modeName string, modeE
 }
 
 // prepareForModeActivation performs common preparation steps before activating a mode.
-// This includes resetting scroll context.
+// This includes resetting scroll state and syncing any platform cursor cache.
 func (h *Handler) prepareForModeActivation() {
 	h.resetScrollContext()
+	h.syncCursorPositionForModeActivation()
 }
 
 // resetScrollContext resets scroll-related state to ensure clean mode transitions.
@@ -81,5 +86,19 @@ func (h *Handler) resetScrollContext() {
 		h.scroll.Context.Reset()
 		// Also reset the skip restore flag since we're transitioning from scroll mode
 		h.cursorState.Reset()
+	}
+}
+
+func (h *Handler) syncCursorPositionForModeActivation() {
+	syncer, ok := h.system.(cursorSyncer)
+	if !ok {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(h.ctx, 150*time.Millisecond)
+	defer cancel()
+
+	if err := syncer.SyncCursorPosition(ctx); err != nil {
+		h.logger.Debug("Failed to sync cursor position for mode activation", zap.Error(err))
 	}
 }

--- a/internal/app/modes/validation.go
+++ b/internal/app/modes/validation.go
@@ -12,6 +12,8 @@ import (
 const (
 	// ValidationTimeout is the timeout for validation checks.
 	ValidationTimeout = 2 * time.Second
+	// cursorSyncTimeout is the timeout for cursor sync before mode activation.
+	cursorSyncTimeout = 150 * time.Millisecond
 )
 
 type cursorSyncer interface {
@@ -95,10 +97,11 @@ func (h *Handler) syncCursorPositionForModeActivation() {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(h.ctx, 150*time.Millisecond)
+	ctx, cancel := context.WithTimeout(h.ctx, cursorSyncTimeout)
 	defer cancel()
 
-	if err := syncer.SyncCursorPosition(ctx); err != nil {
+	err := syncer.SyncCursorPosition(ctx)
+	if err != nil {
 		h.logger.Debug("Failed to sync cursor position for mode activation", zap.Error(err))
 	}
 }

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -262,6 +262,25 @@ func (s *SystemAdapter) CursorPosition(ctx context.Context) (image.Point, error)
 	)
 }
 
+// SyncCursorPosition refreshes Wayland's client-side cursor cache from the
+// compositor when possible. X11 and macOS query the OS directly on every
+// CursorPosition call; Wayland does not expose a global pointer query, so the
+// Wayland backend briefly maps transparent layer-shell surfaces and captures
+// wl_pointer.enter coordinates before a mode uses the cached position.
+func (s *SystemAdapter) SyncCursorPosition(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	if s.waylandUsesWlrClientStack() {
+		return waylandRefreshCursorPosition()
+	}
+
+	return nil
+}
+
 // IsDarkMode returns true if Linux dark mode is currently active. See
 // darkModePreference for source ordering and semantics.
 func (s *SystemAdapter) IsDarkMode() bool {

--- a/internal/core/infra/platform/linux/system_linux_wayland_input.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_input.go
@@ -154,6 +154,10 @@ func waylandCursorPosition() (image.Point, error) {
 	return wlrootsCursorPosition()
 }
 
+func waylandRefreshCursorPosition() error {
+	return wlrootsRefreshCursorPosition()
+}
+
 func waylandClick(point image.Point, button int) error {
 	hasVirtualPointer, err := wlrootsHasVirtualPointer()
 	if err != nil {

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -174,6 +174,25 @@ func wlrootsSetCursor(point image.Point) error {
 	return nil
 }
 
+func wlrootsRefreshCursorPosition() error {
+	err := ensureWlrootsState()
+	if err != nil {
+		return err
+	}
+
+	globalWlrootsState.mu.Lock()
+	defer globalWlrootsState.mu.Unlock()
+
+	if C.neru_wlr_refresh_cursor(globalWlrootsState.client) == 0 { //nolint:nlreturn
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"failed to refresh wlroots cursor position",
+		)
+	}
+
+	return nil
+}
+
 func wlrootsScreenBounds() (image.Rectangle, error) {
 	err := ensureWlrootsState()
 	if err != nil {

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
@@ -126,6 +126,13 @@ func wlrootsSetCursor(point image.Point) error {
 	)
 }
 
+func wlrootsRefreshCursorPosition() error {
+	return derrors.New(
+		derrors.CodeNotSupported,
+		"wlroots backend requires CGO-enabled Linux builds",
+	)
+}
+
 func wlrootsHasVirtualKeyboard() (bool, error) {
 	return false, derrors.New(
 		derrors.CodeNotSupported,

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -56,7 +56,7 @@ static void neru_wlr_pointer_leave(
 static void neru_wlr_pointer_motion(
     void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->vptr && c->entered_discovery_surface && atomic_load(&c->cursor_initialized) == 0) {
+	if (c && c->vptr && c->entered_discovery_surface) {
 		for (int i = 0; i < c->nr_screens; i++) {
 			NeruWaylandScreen *scr = &c->screens[i];
 			if (scr->discovery_surface == c->entered_discovery_surface) {
@@ -89,7 +89,7 @@ static void neru_wlr_pointer_motion(
 static void neru_wlr_pointer_button(
     void *data, struct wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->vptr && c->entered_discovery_surface && atomic_load(&c->cursor_initialized) == 0) {
+	if (c && c->vptr && c->entered_discovery_surface) {
 		zwlr_virtual_pointer_v1_button(c->vptr, time, button, state);
 		zwlr_virtual_pointer_v1_frame(c->vptr);
 	}
@@ -99,7 +99,7 @@ static void neru_wlr_pointer_button(
 static void neru_wlr_pointer_axis(
     void *data, struct wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->vptr && c->entered_discovery_surface && atomic_load(&c->cursor_initialized) == 0) {
+	if (c && c->vptr && c->entered_discovery_surface) {
 		zwlr_virtual_pointer_v1_axis(c->vptr, time, axis, value);
 		zwlr_virtual_pointer_v1_frame(c->vptr);
 	}

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -155,7 +155,7 @@ static int neru_wlr_create_shm_file(off_t size) {
 #endif
 
 	char name[] = "/tmp/neru-cursor-discovery-XXXXXX";
-	int fd = mkstemp(name);
+	fd = mkstemp(name);
 	if (fd < 0)
 		return -1;
 	unlink(name);

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -5,6 +5,8 @@
 #include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
 #include <wayland-client.h>
@@ -23,7 +25,7 @@
 static void neru_wlr_pointer_enter(
     void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface, wl_fixed_t sx, wl_fixed_t sy) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && atomic_load(&c->cursor_initialized) == 0) {
+	if (c) {
 		for (int i = 0; i < c->nr_screens; i++) {
 			NeruWaylandScreen *scr = &c->screens[i];
 			if (surface != NULL && surface == scr->discovery_surface) {
@@ -121,6 +123,143 @@ static const struct wl_pointer_listener neru_wlr_pointer_listener = {
     .axis_stop = neru_wlr_pointer_axis_stop,
     .axis_discrete = neru_wlr_pointer_axis_discrete,
 };
+
+typedef struct {
+	NeruWlrootsClient *client;
+	NeruWaylandScreen *screen;
+	struct wl_surface *surface;
+	struct zwlr_layer_surface_v1 *layer_surface;
+	struct wl_buffer *buffer;
+	void *shm_data;
+	size_t shm_size;
+	int width;
+	int height;
+	int configured;
+} NeruCursorDiscoverySurface;
+
+static int neru_wlr_discovery_attach_buffer(NeruWlrootsClient *c, NeruCursorDiscoverySurface *surface);
+
+static int neru_wlr_create_shm_file(off_t size) {
+	int ret;
+
+#ifdef __NR_memfd_create
+	int fd = syscall(__NR_memfd_create, "neru-cursor-discovery-shm", 0);
+	if (fd >= 0) {
+		do {
+			ret = ftruncate(fd, size);
+		} while (ret < 0 && errno == EINTR);
+		if (ret >= 0)
+			return fd;
+		close(fd);
+	}
+#endif
+
+	char name[] = "/tmp/neru-cursor-discovery-XXXXXX";
+	int fd = mkstemp(name);
+	if (fd < 0)
+		return -1;
+	unlink(name);
+	do {
+		ret = ftruncate(fd, size);
+	} while (ret < 0 && errno == EINTR);
+	if (ret < 0) {
+		close(fd);
+		return -1;
+	}
+	return fd;
+}
+
+static void neru_wlr_discovery_configure(
+    void *data, struct zwlr_layer_surface_v1 *layer_surface, uint32_t serial, uint32_t width, uint32_t height) {
+	NeruCursorDiscoverySurface *surface = (NeruCursorDiscoverySurface *)data;
+	zwlr_layer_surface_v1_ack_configure(layer_surface, serial);
+	if (width > 0)
+		surface->width = (int)width;
+	if (height > 0)
+		surface->height = (int)height;
+	surface->configured = 1;
+	neru_wlr_discovery_attach_buffer(surface->client, surface);
+}
+
+static void neru_wlr_discovery_closed(void *data, struct zwlr_layer_surface_v1 *layer_surface) {
+	NeruCursorDiscoverySurface *surface = (NeruCursorDiscoverySurface *)data;
+	surface->configured = -1;
+}
+
+static const struct zwlr_layer_surface_v1_listener neru_wlr_discovery_layer_listener = {
+    .configure = neru_wlr_discovery_configure,
+    .closed = neru_wlr_discovery_closed,
+};
+
+static int neru_wlr_discovery_attach_buffer(NeruWlrootsClient *c, NeruCursorDiscoverySurface *surface) {
+	if (!c || !c->shm || !surface || !surface->surface || surface->width <= 0 || surface->height <= 0)
+		return 0;
+	if (surface->buffer)
+		return 1;
+
+	size_t stride = (size_t)surface->width * 4u;
+	surface->shm_size = stride * (size_t)surface->height;
+	int fd = neru_wlr_create_shm_file((off_t)surface->shm_size);
+	if (fd < 0)
+		return 0;
+
+	surface->shm_data = mmap(NULL, surface->shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (surface->shm_data == MAP_FAILED) {
+		surface->shm_data = NULL;
+		close(fd);
+		return 0;
+	}
+	memset(surface->shm_data, 0, surface->shm_size);
+
+	struct wl_shm_pool *pool = wl_shm_create_pool(c->shm, fd, (int)surface->shm_size);
+	if (!pool) {
+		munmap(surface->shm_data, surface->shm_size);
+		surface->shm_data = NULL;
+		close(fd);
+		return 0;
+	}
+
+	surface->buffer =
+	    wl_shm_pool_create_buffer(pool, 0, surface->width, surface->height, (int)stride, WL_SHM_FORMAT_ARGB8888);
+	wl_shm_pool_destroy(pool);
+	close(fd);
+	if (!surface->buffer) {
+		munmap(surface->shm_data, surface->shm_size);
+		surface->shm_data = NULL;
+		return 0;
+	}
+
+	wl_surface_attach(surface->surface, surface->buffer, 0, 0);
+	wl_surface_damage_buffer(surface->surface, 0, 0, INT32_MAX, INT32_MAX);
+	wl_surface_commit(surface->surface);
+
+	return 1;
+}
+
+static void neru_wlr_discovery_destroy(NeruCursorDiscoverySurface *surface) {
+	if (!surface)
+		return;
+	if (surface->surface) {
+		wl_surface_attach(surface->surface, NULL, 0, 0);
+		wl_surface_commit(surface->surface);
+	}
+	if (surface->layer_surface) {
+		zwlr_layer_surface_v1_destroy(surface->layer_surface);
+		surface->layer_surface = NULL;
+	}
+	if (surface->surface) {
+		wl_surface_destroy(surface->surface);
+		surface->surface = NULL;
+	}
+	if (surface->buffer) {
+		wl_buffer_destroy(surface->buffer);
+		surface->buffer = NULL;
+	}
+	if (surface->shm_data) {
+		munmap(surface->shm_data, surface->shm_size);
+		surface->shm_data = NULL;
+	}
+}
 
 static int neru_wlr_create_keymap_fd(const char *keymap, size_t size) {
 	char template[] = "/tmp/neru-vkbd-keymap-XXXXXX";
@@ -452,68 +591,110 @@ void neru_wlr_disconnect(NeruWlrootsClient *c) {
 	free(c);
 }
 
-// Initialize cursor position to the center of the screen containing the
-// cursor (or first screen). Wayland has no protocol to query global
-// pointer position, so we initialize to the center and then track
-// position purely client-side via neru_wlr_move_absolute (matching
-// warpd's pattern where ptr.x/ptr.y are only set by way_mouse_move).
+int neru_wlr_refresh_cursor(NeruWlrootsClient *c) {
+	if (!c || !c->layer_shell || !c->compositor || !c->shm || !c->pointer || c->nr_screens == 0)
+		return 0;
+
+	NeruCursorDiscoverySurface surfaces[NERU_MAX_OUTPUTS] = {0};
+	int created = 0;
+	int was_initialized = atomic_load(&c->cursor_initialized);
+	int old_x = atomic_load(&c->cursor_x);
+	int old_y = atomic_load(&c->cursor_y);
+
+	atomic_store(&c->cursor_initialized, 0);
+
+	pthread_mutex_lock(&c->display_mutex);
+	for (int i = 0; i < c->nr_screens; i++) {
+		NeruWaylandScreen *scr = &c->screens[i];
+		if (!scr->wl_output || scr->w <= 0 || scr->h <= 0)
+			continue;
+
+		NeruCursorDiscoverySurface *surface = &surfaces[created];
+		surface->client = c;
+		surface->screen = scr;
+		surface->width = scr->w;
+		surface->height = scr->h;
+		surface->surface = wl_compositor_create_surface(c->compositor);
+		if (!surface->surface)
+			continue;
+
+		scr->discovery_surface = surface->surface;
+		surface->layer_surface = zwlr_layer_shell_v1_get_layer_surface(
+		    c->layer_shell, surface->surface, scr->wl_output, ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY, "neru_cursor_sync");
+		if (!surface->layer_surface) {
+			scr->discovery_surface = NULL;
+			wl_surface_destroy(surface->surface);
+			surface->surface = NULL;
+			continue;
+		}
+
+		zwlr_layer_surface_v1_set_size(surface->layer_surface, scr->w, scr->h);
+		zwlr_layer_surface_v1_set_anchor(
+		    surface->layer_surface, ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
+		                                ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT | ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM);
+		zwlr_layer_surface_v1_set_exclusive_zone(surface->layer_surface, -1);
+		zwlr_layer_surface_v1_set_keyboard_interactivity(
+		    surface->layer_surface, ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE);
+		zwlr_layer_surface_v1_add_listener(surface->layer_surface, &neru_wlr_discovery_layer_listener, surface);
+		wl_surface_commit(surface->surface);
+		created++;
+	}
+	wl_display_flush(c->display);
+	pthread_mutex_unlock(&c->display_mutex);
+
+	if (created == 0) {
+		if (was_initialized) {
+			atomic_store(&c->cursor_x, old_x);
+			atomic_store(&c->cursor_y, old_y);
+			atomic_store(&c->cursor_initialized, 1);
+		}
+		return 0;
+	}
+
+	if (atomic_load(&c->dispatch_running)) {
+		for (int attempt = 0; attempt < 50 && atomic_load(&c->cursor_initialized) == 0; attempt++) {
+			usleep(2000);
+		}
+	} else {
+		pthread_mutex_lock(&c->display_mutex);
+		for (int attempt = 0; attempt < 4 && atomic_load(&c->cursor_initialized) == 0; attempt++) {
+			wl_display_roundtrip(c->display);
+		}
+		pthread_mutex_unlock(&c->display_mutex);
+	}
+
+	int discovered = atomic_load(&c->cursor_initialized);
+
+	pthread_mutex_lock(&c->display_mutex);
+	for (int i = 0; i < created; i++) {
+		if (surfaces[i].screen)
+			surfaces[i].screen->discovery_surface = NULL;
+		neru_wlr_discovery_destroy(&surfaces[i]);
+	}
+	wl_display_flush(c->display);
+	pthread_mutex_unlock(&c->display_mutex);
+
+	if (!discovered && was_initialized) {
+		atomic_store(&c->cursor_x, old_x);
+		atomic_store(&c->cursor_y, old_y);
+		atomic_store(&c->cursor_initialized, 1);
+	}
+
+	return discovered;
+}
+
+// Initialize cursor position. Wayland has no global pointer-position query, so
+// Neru briefly maps transparent layer-shell surfaces and reads wl_pointer.enter
+// coordinates. If a compositor refuses discovery, startup falls back to the
+// first screen center and later mode activations can try to refresh again.
 void neru_wlr_init_cursor(NeruWlrootsClient *c) {
 	if (!c || atomic_load(&c->cursor_initialized))
 		return;
 
-	// Use Warpd's cursor discovery trick: create invisible full-screen layer-shell surfaces
-	// across all outputs, wiggle the virtual pointer, and capture the pointer_enter event.
-	if (!c->layer_shell || !c->compositor || !c->pointer || !c->vptr || c->nr_screens == 0) {
-		atomic_store(&c->cursor_x, c->screens[0].x + c->screens[0].w / 2);
-		atomic_store(&c->cursor_y, c->screens[0].y + c->screens[0].h / 2);
-		atomic_store(&c->cursor_initialized, 1);
+	if (neru_wlr_refresh_cursor(c))
 		return;
-	}
 
-	struct zwlr_layer_surface_v1 *layer_surfaces[NERU_MAX_OUTPUTS] = {0};
-
-	for (int i = 0; i < c->nr_screens; i++) {
-		c->screens[i].discovery_surface = wl_compositor_create_surface(c->compositor);
-		layer_surfaces[i] = zwlr_layer_shell_v1_get_layer_surface(
-		    c->layer_shell, c->screens[i].discovery_surface, c->screens[i].wl_output, ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY,
-		    "neru_discovery");
-		zwlr_layer_surface_v1_set_size(layer_surfaces[i], c->screens[i].w, c->screens[i].h);
-		zwlr_layer_surface_v1_set_anchor(
-		    layer_surfaces[i], ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
-		                           ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT | ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM);
-		zwlr_layer_surface_v1_set_exclusive_zone(layer_surfaces[i], -1);
-		wl_surface_commit(c->screens[i].discovery_surface);
-	}
-
-	pthread_mutex_lock(&c->display_mutex);
-	wl_display_roundtrip(c->display);
-
-	// Wiggle the virtual pointer to force a pointer enter event
-	zwlr_virtual_pointer_v1_motion(c->vptr, 0, wl_fixed_from_int(1), wl_fixed_from_int(1));
-	zwlr_virtual_pointer_v1_frame(c->vptr);
-	wl_display_flush(c->display);
-	pthread_mutex_unlock(&c->display_mutex);
-
-	// Process the enter event synchronously (dispatch thread not started yet).
-	pthread_mutex_lock(&c->display_mutex);
-	wl_display_roundtrip(c->display);
-	pthread_mutex_unlock(&c->display_mutex);
-
-	// Destroy discovery surfaces
-	pthread_mutex_lock(&c->display_mutex);
-	for (int i = 0; i < c->nr_screens; i++) {
-		if (layer_surfaces[i])
-			zwlr_layer_surface_v1_destroy(layer_surfaces[i]);
-		if (c->screens[i].discovery_surface) {
-			wl_surface_destroy(c->screens[i].discovery_surface);
-			c->screens[i].discovery_surface = NULL;
-		}
-	}
-	wl_display_flush(c->display);
-	pthread_mutex_unlock(&c->display_mutex);
-
-	// Fallback if discovery failed
-	if (atomic_load(&c->cursor_initialized) == 0) {
+	if (c->nr_screens > 0) {
 		atomic_store(&c->cursor_x, c->screens[0].x + c->screens[0].w / 2);
 		atomic_store(&c->cursor_y, c->screens[0].y + c->screens[0].h / 2);
 		atomic_store(&c->cursor_initialized, 1);

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -56,7 +56,8 @@ static void neru_wlr_pointer_leave(
 static void neru_wlr_pointer_motion(
     void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->vptr && c->entered_discovery_surface) {
+	if (c && c->vptr && c->entered_discovery_surface && !c->forwarding) {
+		c->forwarding = 1;
 		for (int i = 0; i < c->nr_screens; i++) {
 			NeruWaylandScreen *scr = &c->screens[i];
 			if (scr->discovery_surface == c->entered_discovery_surface) {
@@ -82,6 +83,7 @@ static void neru_wlr_pointer_motion(
 				break;
 			}
 		}
+		c->forwarding = 0;
 	}
 	(void)pointer;
 }
@@ -89,9 +91,11 @@ static void neru_wlr_pointer_motion(
 static void neru_wlr_pointer_button(
     void *data, struct wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->vptr && c->entered_discovery_surface) {
+	if (c && c->vptr && c->entered_discovery_surface && !c->forwarding) {
+		c->forwarding = 1;
 		zwlr_virtual_pointer_v1_button(c->vptr, time, button, state);
 		zwlr_virtual_pointer_v1_frame(c->vptr);
+		c->forwarding = 0;
 	}
 	(void)pointer;
 }
@@ -99,9 +103,11 @@ static void neru_wlr_pointer_button(
 static void neru_wlr_pointer_axis(
     void *data, struct wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->vptr && c->entered_discovery_surface) {
+	if (c && c->vptr && c->entered_discovery_surface && !c->forwarding) {
+		c->forwarding = 1;
 		zwlr_virtual_pointer_v1_axis(c->vptr, time, axis, value);
 		zwlr_virtual_pointer_v1_frame(c->vptr);
+		c->forwarding = 0;
 	}
 	(void)pointer;
 }

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -34,8 +34,8 @@ static void neru_wlr_pointer_enter(
 			if (surface != NULL && surface == scr->discovery_surface) {
 				atomic_store(&c->cursor_x, scr->x + wl_fixed_to_int(sx));
 				atomic_store(&c->cursor_y, scr->y + wl_fixed_to_int(sy));
-				atomic_store(&c->cursor_initialized, 1);
 				c->entered_discovery_surface = surface;
+				atomic_store(&c->cursor_initialized, 1);
 				break;
 			}
 		}

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -22,16 +22,20 @@
 #include "wlroots_client.h"
 
 // Pointer listener callbacks — update cursor cache.
+// Forward discovery-surface pointer events through the virtual pointer so the
+// underlying application still receives them instead of having them swallowed.
 static void neru_wlr_pointer_enter(
     void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface, wl_fixed_t sx, wl_fixed_t sy) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
 	if (c) {
+		c->entered_discovery_surface = NULL;
 		for (int i = 0; i < c->nr_screens; i++) {
 			NeruWaylandScreen *scr = &c->screens[i];
 			if (surface != NULL && surface == scr->discovery_surface) {
 				atomic_store(&c->cursor_x, scr->x + wl_fixed_to_int(sx));
 				atomic_store(&c->cursor_y, scr->y + wl_fixed_to_int(sy));
 				atomic_store(&c->cursor_initialized, 1);
+				c->entered_discovery_surface = surface;
 				break;
 			}
 		}
@@ -42,26 +46,64 @@ static void neru_wlr_pointer_enter(
 
 static void neru_wlr_pointer_leave(
     void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface) {
-	// No-op.
+	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
+	if (c && surface && surface == c->entered_discovery_surface)
+		c->entered_discovery_surface = NULL;
+	(void)pointer;
+	(void)serial;
 }
 
 static void neru_wlr_pointer_motion(
     void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
-	(void)data;
+	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
+	if (c && c->vptr && c->entered_discovery_surface && atomic_load(&c->cursor_initialized) == 0) {
+		for (int i = 0; i < c->nr_screens; i++) {
+			NeruWaylandScreen *scr = &c->screens[i];
+			if (scr->discovery_surface == c->entered_discovery_surface) {
+				int minx = 0, miny = 0, maxx = 0, maxy = 0;
+				for (int j = 0; j < c->nr_screens; j++) {
+					NeruWaylandScreen *s = &c->screens[j];
+					if (j == 0 || s->x < minx)
+						minx = s->x;
+					if (j == 0 || s->y < miny)
+						miny = s->y;
+					int r = s->x + s->w, b = s->y + s->h;
+					if (j == 0 || r > maxx)
+						maxx = r;
+					if (j == 0 || b > maxy)
+						maxy = b;
+				}
+				wl_fixed_t gx = wl_fixed_from_int(scr->x) + sx;
+				wl_fixed_t gy = wl_fixed_from_int(scr->y) + sy;
+				zwlr_virtual_pointer_v1_motion_absolute(
+				    c->vptr, time, gx - wl_fixed_from_int(minx), gy - wl_fixed_from_int(miny),
+				    wl_fixed_from_int(maxx - minx), wl_fixed_from_int(maxy - miny));
+				zwlr_virtual_pointer_v1_frame(c->vptr);
+				break;
+			}
+		}
+	}
 	(void)pointer;
-	(void)time;
-	(void)sx;
-	(void)sy;
 }
 
 static void neru_wlr_pointer_button(
     void *data, struct wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
-	// No-op.
+	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
+	if (c && c->vptr && c->entered_discovery_surface && atomic_load(&c->cursor_initialized) == 0) {
+		zwlr_virtual_pointer_v1_button(c->vptr, time, button, state);
+		zwlr_virtual_pointer_v1_frame(c->vptr);
+	}
+	(void)pointer;
 }
 
 static void neru_wlr_pointer_axis(
     void *data, struct wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value) {
-	// No-op.
+	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
+	if (c && c->vptr && c->entered_discovery_surface && atomic_load(&c->cursor_initialized) == 0) {
+		zwlr_virtual_pointer_v1_axis(c->vptr, time, axis, value);
+		zwlr_virtual_pointer_v1_frame(c->vptr);
+	}
+	(void)pointer;
 }
 
 static void neru_wlr_pointer_frame(void *data, struct wl_pointer *pointer) {

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -53,6 +53,37 @@ static void neru_wlr_pointer_leave(
 	(void)serial;
 }
 
+// Align the virtual pointer to the current discovery-surface coordinates so
+// that subsequent button/axis events target the correct position.  Returns 1
+// if a motion_absolute was emitted, 0 otherwise.
+static int neru_wlr_sync_vptr_position(NeruWlrootsClient *c, uint32_t time) {
+	for (int i = 0; i < c->nr_screens; i++) {
+		NeruWaylandScreen *scr = &c->screens[i];
+		if (scr->discovery_surface == c->entered_discovery_surface) {
+			int minx = 0, miny = 0, maxx = 0, maxy = 0;
+			for (int j = 0; j < c->nr_screens; j++) {
+				NeruWaylandScreen *s = &c->screens[j];
+				if (j == 0 || s->x < minx)
+					minx = s->x;
+				if (j == 0 || s->y < miny)
+					miny = s->y;
+				int r = s->x + s->w, b = s->y + s->h;
+				if (j == 0 || r > maxx)
+					maxx = r;
+				if (j == 0 || b > maxy)
+					maxy = b;
+			}
+			int cx = atomic_load(&c->cursor_x);
+			int cy = atomic_load(&c->cursor_y);
+			zwlr_virtual_pointer_v1_motion_absolute(
+			    c->vptr, time, wl_fixed_from_int(cx - minx), wl_fixed_from_int(cy - miny),
+			    wl_fixed_from_int(maxx - minx), wl_fixed_from_int(maxy - miny));
+			return 1;
+		}
+	}
+	return 0;
+}
+
 static void neru_wlr_pointer_motion(
     void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
@@ -93,6 +124,7 @@ static void neru_wlr_pointer_button(
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
 	if (c && c->vptr && c->entered_discovery_surface && !c->forwarding) {
 		c->forwarding = 1;
+		neru_wlr_sync_vptr_position(c, time);
 		zwlr_virtual_pointer_v1_button(c->vptr, time, button, state);
 		zwlr_virtual_pointer_v1_frame(c->vptr);
 		c->forwarding = 0;
@@ -105,6 +137,7 @@ static void neru_wlr_pointer_axis(
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
 	if (c && c->vptr && c->entered_discovery_surface && !c->forwarding) {
 		c->forwarding = 1;
+		neru_wlr_sync_vptr_position(c, time);
 		zwlr_virtual_pointer_v1_axis(c->vptr, time, axis, value);
 		zwlr_virtual_pointer_v1_frame(c->vptr);
 		c->forwarding = 0;

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -29,16 +29,25 @@ static void neru_wlr_pointer_enter(
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
 	if (c) {
 		c->entered_discovery_surface = NULL;
+		int is_discovery = 0;
 		for (int i = 0; i < c->nr_screens; i++) {
 			NeruWaylandScreen *scr = &c->screens[i];
 			if (surface != NULL && surface == scr->discovery_surface) {
 				atomic_store(&c->cursor_x, scr->x + wl_fixed_to_int(sx));
 				atomic_store(&c->cursor_y, scr->y + wl_fixed_to_int(sy));
-				c->entered_discovery_surface = surface;
 				atomic_store(&c->cursor_initialized, 1);
+				is_discovery = 1;
+				// Only allow forwarding if this is a genuine physical
+				// enter, not an echo of our own virtual-pointer event.
+				if (!c->forwarding)
+					c->entered_discovery_surface = surface;
 				break;
 			}
 		}
+		// Focus moved to a non-discovery surface — safe to allow
+		// forwarding again on the next genuine discovery enter.
+		if (!is_discovery)
+			c->forwarding = 0;
 	}
 	(void)pointer;
 	(void)serial;
@@ -47,8 +56,10 @@ static void neru_wlr_pointer_enter(
 static void neru_wlr_pointer_leave(
     void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && surface && surface == c->entered_discovery_surface)
+	if (c && surface && surface == c->entered_discovery_surface) {
 		c->entered_discovery_surface = NULL;
+		c->forwarding = 0;
+	}
 	(void)pointer;
 	(void)serial;
 }
@@ -143,9 +154,7 @@ static void neru_wlr_pointer_axis(
 }
 
 static void neru_wlr_pointer_frame(void *data, struct wl_pointer *pointer) {
-	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c)
-		c->forwarding = 0;
+	(void)data;
 	(void)pointer;
 }
 

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -114,7 +114,6 @@ static void neru_wlr_pointer_motion(
 				break;
 			}
 		}
-		c->forwarding = 0;
 	}
 	(void)pointer;
 }
@@ -127,7 +126,6 @@ static void neru_wlr_pointer_button(
 		neru_wlr_sync_vptr_position(c, time);
 		zwlr_virtual_pointer_v1_button(c->vptr, time, button, state);
 		zwlr_virtual_pointer_v1_frame(c->vptr);
-		c->forwarding = 0;
 	}
 	(void)pointer;
 }
@@ -140,13 +138,14 @@ static void neru_wlr_pointer_axis(
 		neru_wlr_sync_vptr_position(c, time);
 		zwlr_virtual_pointer_v1_axis(c->vptr, time, axis, value);
 		zwlr_virtual_pointer_v1_frame(c->vptr);
-		c->forwarding = 0;
 	}
 	(void)pointer;
 }
 
 static void neru_wlr_pointer_frame(void *data, struct wl_pointer *pointer) {
-	(void)data;
+	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
+	if (c)
+		c->forwarding = 0;
 	(void)pointer;
 }
 

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -141,7 +141,15 @@ static void neru_wlr_relative_motion(
 		c->cursor_y_frac -= wl_fixed_from_int(idy);
 		atomic_fetch_add(&c->cursor_x, idx);
 		atomic_fetch_add(&c->cursor_y, idy);
-		atomic_store(&c->cursor_initialized, 1);
+		int in_discovery = 0;
+		for (int i = 0; i < c->nr_screens; i++) {
+			if (c->screens[i].discovery_surface) {
+				in_discovery = 1;
+				break;
+			}
+		}
+		if (!in_discovery)
+			atomic_store(&c->cursor_initialized, 1);
 	}
 	(void)zwp_relative_pointer_v1;
 	(void)utime_hi;

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -28,9 +28,11 @@ static void neru_wlr_pointer_enter(
     void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface, wl_fixed_t sx, wl_fixed_t sy) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
 	if (c) {
+		c->entered_discovery_surface = NULL;
 		for (int i = 0; i < c->nr_screens; i++) {
 			NeruWaylandScreen *scr = &c->screens[i];
 			if (surface != NULL && surface == scr->discovery_surface) {
+				c->entered_discovery_surface = surface;
 				atomic_store(&c->cursor_x, scr->x + wl_fixed_to_int(sx));
 				atomic_store(&c->cursor_y, scr->y + wl_fixed_to_int(sy));
 				atomic_store(&c->cursor_initialized, 1);
@@ -55,19 +57,20 @@ static void neru_wlr_pointer_enter(
 
 static void neru_wlr_pointer_leave(
     void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface) {
-	(void)data;
+	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
+	if (c && surface && surface == c->entered_discovery_surface)
+		c->entered_discovery_surface = NULL;
 	(void)pointer;
 	(void)serial;
-	(void)surface;
 }
 
 static void neru_wlr_pointer_motion(
     void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c) {
+	if (c && c->entered_discovery_surface) {
 		for (int i = 0; i < c->nr_screens; i++) {
 			NeruWaylandScreen *scr = &c->screens[i];
-			if (scr->discovery_surface) {
+			if (scr->discovery_surface && scr->discovery_surface == c->entered_discovery_surface) {
 				atomic_store(&c->cursor_x, scr->x + wl_fixed_to_int(sx));
 				atomic_store(&c->cursor_y, scr->y + wl_fixed_to_int(sy));
 				break;
@@ -78,23 +81,50 @@ static void neru_wlr_pointer_motion(
 	(void)time;
 }
 
+static void neru_wlr_sync_vptr_to_cursor(NeruWlrootsClient *c, uint32_t time) {
+	if (!c || !c->vptr || c->nr_screens == 0)
+		return;
+	int minx = 0, miny = 0, maxx = 0, maxy = 0;
+	for (int j = 0; j < c->nr_screens; j++) {
+		NeruWaylandScreen *s = &c->screens[j];
+		if (j == 0 || s->x < minx)
+			minx = s->x;
+		if (j == 0 || s->y < miny)
+			miny = s->y;
+		int r = s->x + s->w, b = s->y + s->h;
+		if (j == 0 || r > maxx)
+			maxx = r;
+		if (j == 0 || b > maxy)
+			maxy = b;
+	}
+	int cx = atomic_load(&c->cursor_x);
+	int cy = atomic_load(&c->cursor_y);
+	zwlr_virtual_pointer_v1_motion_absolute(
+	    c->vptr, time, wl_fixed_from_int(cx - minx), wl_fixed_from_int(cy - miny),
+	    wl_fixed_from_int(maxx - minx), wl_fixed_from_int(maxy - miny));
+}
+
 static void neru_wlr_pointer_button(
     void *data, struct wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
-	(void)data;
+	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
+	if (c && c->vptr && c->entered_discovery_surface) {
+		neru_wlr_sync_vptr_to_cursor(c, time);
+		zwlr_virtual_pointer_v1_button(c->vptr, time, button, state);
+		zwlr_virtual_pointer_v1_frame(c->vptr);
+	}
 	(void)pointer;
 	(void)serial;
-	(void)time;
-	(void)button;
-	(void)state;
 }
 
 static void neru_wlr_pointer_axis(
     void *data, struct wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value) {
-	(void)data;
+	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
+	if (c && c->vptr && c->entered_discovery_surface) {
+		neru_wlr_sync_vptr_to_cursor(c, time);
+		zwlr_virtual_pointer_v1_axis(c->vptr, time, axis, value);
+		zwlr_virtual_pointer_v1_frame(c->vptr);
+	}
 	(void)pointer;
-	(void)time;
-	(void)axis;
-	(void)value;
 }
 
 static void neru_wlr_pointer_frame(void *data, struct wl_pointer *pointer) {

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -100,8 +100,8 @@ static void neru_wlr_sync_vptr_to_cursor(NeruWlrootsClient *c, uint32_t time) {
 	int cx = atomic_load(&c->cursor_x);
 	int cy = atomic_load(&c->cursor_y);
 	zwlr_virtual_pointer_v1_motion_absolute(
-	    c->vptr, time, wl_fixed_from_int(cx - minx), wl_fixed_from_int(cy - miny),
-	    wl_fixed_from_int(maxx - minx), wl_fixed_from_int(maxy - miny));
+	    c->vptr, time, wl_fixed_from_int(cx - minx), wl_fixed_from_int(cy - miny), wl_fixed_from_int(maxx - minx),
+	    wl_fixed_from_int(maxy - miny));
 }
 
 static void neru_wlr_pointer_button(

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -28,23 +28,26 @@ static void neru_wlr_pointer_enter(
     void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface, wl_fixed_t sx, wl_fixed_t sy) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
 	if (c) {
-		c->entered_discovery_surface = NULL;
-		int is_discovery = 0;
 		for (int i = 0; i < c->nr_screens; i++) {
 			NeruWaylandScreen *scr = &c->screens[i];
 			if (surface != NULL && surface == scr->discovery_surface) {
 				atomic_store(&c->cursor_x, scr->x + wl_fixed_to_int(sx));
 				atomic_store(&c->cursor_y, scr->y + wl_fixed_to_int(sy));
 				atomic_store(&c->cursor_initialized, 1);
-				is_discovery = 1;
-				c->entered_discovery_surface = surface;
-				if (c->forwarding)
-					c->forwarding = 0;
+
+				// Immediately set empty input region so the discovery surface
+				// becomes pass-through and does not swallow user input.
+				if (c->compositor) {
+					struct wl_region *region = wl_compositor_create_region(c->compositor);
+					if (region) {
+						wl_surface_set_input_region(surface, region);
+						wl_region_destroy(region);
+						wl_surface_commit(surface);
+					}
+				}
 				break;
 			}
 		}
-		if (!is_discovery)
-			c->forwarding = 0;
 	}
 	(void)pointer;
 	(void)serial;
@@ -52,114 +55,46 @@ static void neru_wlr_pointer_enter(
 
 static void neru_wlr_pointer_leave(
     void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface) {
-	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && surface && surface == c->entered_discovery_surface) {
-		c->entered_discovery_surface = NULL;
-		c->forwarding = 0;
-	}
+	(void)data;
 	(void)pointer;
 	(void)serial;
-}
-
-// Align the virtual pointer to the current discovery-surface coordinates so
-// that subsequent button/axis events target the correct position.  Returns 1
-// if a motion_absolute was emitted, 0 otherwise.
-static int neru_wlr_sync_vptr_position(NeruWlrootsClient *c, uint32_t time) {
-	for (int i = 0; i < c->nr_screens; i++) {
-		NeruWaylandScreen *scr = &c->screens[i];
-		if (scr->discovery_surface == c->entered_discovery_surface) {
-			int minx = 0, miny = 0, maxx = 0, maxy = 0;
-			for (int j = 0; j < c->nr_screens; j++) {
-				NeruWaylandScreen *s = &c->screens[j];
-				if (j == 0 || s->x < minx)
-					minx = s->x;
-				if (j == 0 || s->y < miny)
-					miny = s->y;
-				int r = s->x + s->w, b = s->y + s->h;
-				if (j == 0 || r > maxx)
-					maxx = r;
-				if (j == 0 || b > maxy)
-					maxy = b;
-			}
-			int cx = atomic_load(&c->cursor_x);
-			int cy = atomic_load(&c->cursor_y);
-			zwlr_virtual_pointer_v1_motion_absolute(
-			    c->vptr, time, wl_fixed_from_int(cx - minx), wl_fixed_from_int(cy - miny),
-			    wl_fixed_from_int(maxx - minx), wl_fixed_from_int(maxy - miny));
-			return 1;
-		}
-	}
-	return 0;
+	(void)surface;
 }
 
 static void neru_wlr_pointer_motion(
     void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->vptr && c->entered_discovery_surface) {
-		if (!c->forwarding) {
-			c->forwarding = 1;
-			for (int i = 0; i < c->nr_screens; i++) {
-				NeruWaylandScreen *scr = &c->screens[i];
-				if (scr->discovery_surface == c->entered_discovery_surface) {
-					int minx = 0, miny = 0, maxx = 0, maxy = 0;
-					for (int j = 0; j < c->nr_screens; j++) {
-						NeruWaylandScreen *s = &c->screens[j];
-						if (j == 0 || s->x < minx)
-							minx = s->x;
-						if (j == 0 || s->y < miny)
-							miny = s->y;
-						int r = s->x + s->w, b = s->y + s->h;
-						if (j == 0 || r > maxx)
-							maxx = r;
-						if (j == 0 || b > maxy)
-							maxy = b;
-					}
-					wl_fixed_t gx = wl_fixed_from_int(scr->x) + sx;
-					wl_fixed_t gy = wl_fixed_from_int(scr->y) + sy;
-					zwlr_virtual_pointer_v1_motion_absolute(
-					    c->vptr, time, gx - wl_fixed_from_int(minx), gy - wl_fixed_from_int(miny),
-					    wl_fixed_from_int(maxx - minx), wl_fixed_from_int(maxy - miny));
-					zwlr_virtual_pointer_v1_frame(c->vptr);
-					break;
-				}
+	if (c) {
+		for (int i = 0; i < c->nr_screens; i++) {
+			NeruWaylandScreen *scr = &c->screens[i];
+			if (scr->discovery_surface) {
+				atomic_store(&c->cursor_x, scr->x + wl_fixed_to_int(sx));
+				atomic_store(&c->cursor_y, scr->y + wl_fixed_to_int(sy));
+				break;
 			}
-		} else {
-			c->forwarding = 0;
 		}
 	}
 	(void)pointer;
+	(void)time;
 }
 
 static void neru_wlr_pointer_button(
     void *data, struct wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
-	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->vptr && c->entered_discovery_surface) {
-		if (!c->forwarding) {
-			c->forwarding = 1;
-			neru_wlr_sync_vptr_position(c, time);
-			zwlr_virtual_pointer_v1_button(c->vptr, time, button, state);
-			zwlr_virtual_pointer_v1_frame(c->vptr);
-		} else {
-			c->forwarding = 0;
-		}
-	}
+	(void)data;
 	(void)pointer;
+	(void)serial;
+	(void)time;
+	(void)button;
+	(void)state;
 }
 
 static void neru_wlr_pointer_axis(
     void *data, struct wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value) {
-	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->vptr && c->entered_discovery_surface) {
-		if (!c->forwarding) {
-			c->forwarding = 1;
-			neru_wlr_sync_vptr_position(c, time);
-			zwlr_virtual_pointer_v1_axis(c->vptr, time, axis, value);
-			zwlr_virtual_pointer_v1_frame(c->vptr);
-		} else {
-			c->forwarding = 0;
-		}
-	}
+	(void)data;
 	(void)pointer;
+	(void)time;
+	(void)axis;
+	(void)value;
 }
 
 static void neru_wlr_pointer_frame(void *data, struct wl_pointer *pointer) {

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -37,15 +37,12 @@ static void neru_wlr_pointer_enter(
 				atomic_store(&c->cursor_y, scr->y + wl_fixed_to_int(sy));
 				atomic_store(&c->cursor_initialized, 1);
 				is_discovery = 1;
-				// Only allow forwarding if this is a genuine physical
-				// enter, not an echo of our own virtual-pointer event.
-				if (!c->forwarding)
-					c->entered_discovery_surface = surface;
+				c->entered_discovery_surface = surface;
+				if (c->forwarding)
+					c->forwarding = 0;
 				break;
 			}
 		}
-		// Focus moved to a non-discovery surface — safe to allow
-		// forwarding again on the next genuine discovery enter.
 		if (!is_discovery)
 			c->forwarding = 0;
 	}
@@ -98,32 +95,36 @@ static int neru_wlr_sync_vptr_position(NeruWlrootsClient *c, uint32_t time) {
 static void neru_wlr_pointer_motion(
     void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->vptr && c->entered_discovery_surface && !c->forwarding) {
-		c->forwarding = 1;
-		for (int i = 0; i < c->nr_screens; i++) {
-			NeruWaylandScreen *scr = &c->screens[i];
-			if (scr->discovery_surface == c->entered_discovery_surface) {
-				int minx = 0, miny = 0, maxx = 0, maxy = 0;
-				for (int j = 0; j < c->nr_screens; j++) {
-					NeruWaylandScreen *s = &c->screens[j];
-					if (j == 0 || s->x < minx)
-						minx = s->x;
-					if (j == 0 || s->y < miny)
-						miny = s->y;
-					int r = s->x + s->w, b = s->y + s->h;
-					if (j == 0 || r > maxx)
-						maxx = r;
-					if (j == 0 || b > maxy)
-						maxy = b;
+	if (c && c->vptr && c->entered_discovery_surface) {
+		if (!c->forwarding) {
+			c->forwarding = 1;
+			for (int i = 0; i < c->nr_screens; i++) {
+				NeruWaylandScreen *scr = &c->screens[i];
+				if (scr->discovery_surface == c->entered_discovery_surface) {
+					int minx = 0, miny = 0, maxx = 0, maxy = 0;
+					for (int j = 0; j < c->nr_screens; j++) {
+						NeruWaylandScreen *s = &c->screens[j];
+						if (j == 0 || s->x < minx)
+							minx = s->x;
+						if (j == 0 || s->y < miny)
+							miny = s->y;
+						int r = s->x + s->w, b = s->y + s->h;
+						if (j == 0 || r > maxx)
+							maxx = r;
+						if (j == 0 || b > maxy)
+							maxy = b;
+					}
+					wl_fixed_t gx = wl_fixed_from_int(scr->x) + sx;
+					wl_fixed_t gy = wl_fixed_from_int(scr->y) + sy;
+					zwlr_virtual_pointer_v1_motion_absolute(
+					    c->vptr, time, gx - wl_fixed_from_int(minx), gy - wl_fixed_from_int(miny),
+					    wl_fixed_from_int(maxx - minx), wl_fixed_from_int(maxy - miny));
+					zwlr_virtual_pointer_v1_frame(c->vptr);
+					break;
 				}
-				wl_fixed_t gx = wl_fixed_from_int(scr->x) + sx;
-				wl_fixed_t gy = wl_fixed_from_int(scr->y) + sy;
-				zwlr_virtual_pointer_v1_motion_absolute(
-				    c->vptr, time, gx - wl_fixed_from_int(minx), gy - wl_fixed_from_int(miny),
-				    wl_fixed_from_int(maxx - minx), wl_fixed_from_int(maxy - miny));
-				zwlr_virtual_pointer_v1_frame(c->vptr);
-				break;
 			}
+		} else {
+			c->forwarding = 0;
 		}
 	}
 	(void)pointer;
@@ -132,11 +133,15 @@ static void neru_wlr_pointer_motion(
 static void neru_wlr_pointer_button(
     void *data, struct wl_pointer *pointer, uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->vptr && c->entered_discovery_surface && !c->forwarding) {
-		c->forwarding = 1;
-		neru_wlr_sync_vptr_position(c, time);
-		zwlr_virtual_pointer_v1_button(c->vptr, time, button, state);
-		zwlr_virtual_pointer_v1_frame(c->vptr);
+	if (c && c->vptr && c->entered_discovery_surface) {
+		if (!c->forwarding) {
+			c->forwarding = 1;
+			neru_wlr_sync_vptr_position(c, time);
+			zwlr_virtual_pointer_v1_button(c->vptr, time, button, state);
+			zwlr_virtual_pointer_v1_frame(c->vptr);
+		} else {
+			c->forwarding = 0;
+		}
 	}
 	(void)pointer;
 }
@@ -144,11 +149,15 @@ static void neru_wlr_pointer_button(
 static void neru_wlr_pointer_axis(
     void *data, struct wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
-	if (c && c->vptr && c->entered_discovery_surface && !c->forwarding) {
-		c->forwarding = 1;
-		neru_wlr_sync_vptr_position(c, time);
-		zwlr_virtual_pointer_v1_axis(c->vptr, time, axis, value);
-		zwlr_virtual_pointer_v1_frame(c->vptr);
+	if (c && c->vptr && c->entered_discovery_surface) {
+		if (!c->forwarding) {
+			c->forwarding = 1;
+			neru_wlr_sync_vptr_position(c, time);
+			zwlr_virtual_pointer_v1_axis(c->vptr, time, axis, value);
+			zwlr_virtual_pointer_v1_frame(c->vptr);
+		} else {
+			c->forwarding = 0;
+		}
 	}
 	(void)pointer;
 }

--- a/internal/core/infra/platform/linux/wlroots_client.h
+++ b/internal/core/infra/platform/linux/wlroots_client.h
@@ -58,6 +58,8 @@ typedef struct NeruWlrootsClient {
 	wl_fixed_t cursor_x_frac;  // guarded by display_mutex — fractional
 	wl_fixed_t cursor_y_frac;  // remainder for sub-pixel accumulation
 
+	struct wl_surface *entered_discovery_surface;
+
 	pthread_t dispatch_thread;
 	pthread_mutex_t display_mutex;
 	_Atomic int dispatch_running;

--- a/internal/core/infra/platform/linux/wlroots_client.h
+++ b/internal/core/infra/platform/linux/wlroots_client.h
@@ -59,6 +59,7 @@ typedef struct NeruWlrootsClient {
 	wl_fixed_t cursor_y_frac;  // remainder for sub-pixel accumulation
 
 	struct wl_surface *entered_discovery_surface;
+	int forwarding;
 
 	pthread_t dispatch_thread;
 	pthread_mutex_t display_mutex;

--- a/internal/core/infra/platform/linux/wlroots_client.h
+++ b/internal/core/infra/platform/linux/wlroots_client.h
@@ -69,6 +69,7 @@ NeruWlrootsClient *neru_wlr_connect(void);
 void neru_wlr_disconnect(NeruWlrootsClient *c);
 int neru_wlr_start_dispatch(NeruWlrootsClient *c);
 void neru_wlr_init_cursor(NeruWlrootsClient *c);
+int neru_wlr_refresh_cursor(NeruWlrootsClient *c);
 int neru_wlr_move_absolute(NeruWlrootsClient *c, int x, int y);
 int neru_wlr_move_relative(NeruWlrootsClient *c, int dx, int dy);
 int neru_wlr_button(NeruWlrootsClient *c, int button, int pressed);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR syncs the Wayland cursor-position cache before activating modes so overlays and mode indicators anchor to the actual pointer position instead of stale cached coordinates.

This fixes cases where the user manually moves the pointer, then activates scroll or another mode, and Neru still draws the indicator at the old cached position, often screen center.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #1057

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A