### PR TITLE
fix(linux): recover evdev global hotkeys post-sleep and fix health check

### DIFF
--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -168,11 +168,14 @@ func (a *App) reinitializeHotkeys() {
 	a.hotkeyRegistrationMu.Unlock()
 
 	if needReregister {
-		const maxRetries = 5
-		const retryDelay = 500 * time.Millisecond
+		const (
+			maxRetries = 5
+			retryDelay = 500 * time.Millisecond
+		)
 
 		for attempt := 1; attempt <= maxRetries; attempt++ {
 			a.refreshHotkeysForAppOrCurrent("")
+
 			hc, ok := a.hotkeyManager.(interface{ HealthCheck() bool })
 			if !ok || hc.HealthCheck() {
 				break

--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -168,7 +168,28 @@ func (a *App) reinitializeHotkeys() {
 	a.hotkeyRegistrationMu.Unlock()
 
 	if needReregister {
-		a.refreshHotkeysForAppOrCurrent("")
+		const maxRetries = 5
+		const retryDelay = 500 * time.Millisecond
+
+		for attempt := 1; attempt <= maxRetries; attempt++ {
+			a.refreshHotkeysForAppOrCurrent("")
+			if a.hotkeyManager.HealthCheck() {
+				break
+			}
+
+			if attempt < maxRetries {
+				a.logger.Debug(
+					"Hotkey listener not healthy after reinitialization attempt; retrying",
+					zap.Int("attempt", attempt),
+				)
+				a.hotkeyRegistrationMu.Lock()
+				a.stopAllHotkeyRepeats()
+				a.hotkeyManager.UnregisterAll()
+				a.appState.SetHotkeysRegistered(false)
+				a.hotkeyRegistrationMu.Unlock()
+				time.Sleep(retryDelay)
+			}
+		}
 	}
 
 	a.logger.Info("Hotkey listener reinitialized")

--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -173,7 +173,8 @@ func (a *App) reinitializeHotkeys() {
 
 		for attempt := 1; attempt <= maxRetries; attempt++ {
 			a.refreshHotkeysForAppOrCurrent("")
-			if a.hotkeyManager.HealthCheck() {
+			hc, ok := a.hotkeyManager.(interface{ HealthCheck() bool })
+			if !ok || hc.HealthCheck() {
 				break
 			}
 

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -152,23 +152,17 @@ func newWaylandEvdevCapture(logger *zap.Logger) (*waylandEvdevCapture, error) {
 
 	if len(capture.files) == 0 {
 		logger.Warn(
-			"No keyboard /dev/input/event* devices could be opened; "+
-				"check read permissions on /dev/input/event*",
+			"No keyboard /dev/input/event* devices could be opened initially; "+
+				"hotplug watcher will monitor for newly connected keyboard devices",
 			zap.Int("total_event_devices", len(paths)),
-			zap.Error(errWaylandEvdevUnavailable),
 		)
-
-		return nil, fmt.Errorf(
-			"%w: no keyboard /dev/input/event* devices could be opened",
-			errWaylandEvdevUnavailable,
+	} else {
+		logger.Debug(
+			"Evdev capture created",
+			zap.Int("keyboard_devices", len(capture.files)),
+			zap.Int("total_event_devices", len(paths)),
 		)
 	}
-
-	logger.Debug(
-		"Evdev capture created",
-		zap.Int("keyboard_devices", len(capture.files)),
-		zap.Int("total_event_devices", len(paths)),
-	)
 
 	return capture, nil
 }

--- a/internal/core/infra/eventtap/global_hotkey_linux_cgo.go
+++ b/internal/core/infra/eventtap/global_hotkey_linux_cgo.go
@@ -123,6 +123,21 @@ func (l *GlobalHotkeyListener) IsRunning() bool {
 	return l.running
 }
 
+// DeviceCount returns the number of captured keyboard devices.
+func (l *GlobalHotkeyListener) DeviceCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.capture == nil {
+		return 0
+	}
+
+	l.capture.deviceMu.Lock()
+	defer l.capture.deviceMu.Unlock()
+
+	return len(l.capture.files)
+}
+
 func (l *GlobalHotkeyListener) run(capture *waylandEvdevCapture, stopCh chan struct{}) {
 	state := waylandEvdevKeyState{pressed: make(map[uint16]bool)}
 

--- a/internal/core/infra/eventtap/global_hotkey_linux_nocgo.go
+++ b/internal/core/infra/eventtap/global_hotkey_linux_nocgo.go
@@ -30,3 +30,6 @@ func (l *GlobalHotkeyListener) Stop() {}
 
 // IsRunning returns false without cgo (evdev is unavailable).
 func (l *GlobalHotkeyListener) IsRunning() bool { return false }
+
+// DeviceCount returns 0 without cgo.
+func (l *GlobalHotkeyListener) DeviceCount() int { return 0 }

--- a/internal/core/infra/hotkeys/manager_linux_common.go
+++ b/internal/core/infra/hotkeys/manager_linux_common.go
@@ -151,15 +151,27 @@ func (m *Manager) HealthCheck() bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	if !isWaylandBackend(m.backend) {
+		return true
+	}
+
 	if m.waylandHotkeys == nil {
 		return true
 	}
 
-	if !m.waylandStarted {
+	if len(m.callbacks) == 0 {
 		return true
 	}
 
-	return m.waylandHotkeys.IsRunning()
+	if !m.waylandStarted {
+		return false
+	}
+
+	if !m.waylandHotkeys.IsRunning() {
+		return false
+	}
+
+	return m.waylandHotkeys.DeviceCount() > 0
 }
 
 // rebuildWaylandBindings re-syncs the evdev listener with the current set of

--- a/internal/core/infra/hotkeys/manager_linux_common_test.go
+++ b/internal/core/infra/hotkeys/manager_linux_common_test.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package hotkeys
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestLinuxManagerHealthCheck(t *testing.T) {
+	mgr := NewManager(zap.NewNop())
+	if mgr == nil {
+		t.Fatal("expected non-nil manager")
+	}
+
+	// Unregistered / zero callbacks should report healthy
+	if !mgr.HealthCheck() {
+		t.Errorf("expected HealthCheck() to be true when no callbacks registered")
+	}
+}

--- a/internal/core/infra/hotkeys/manager_linux_common_test.go
+++ b/internal/core/infra/hotkeys/manager_linux_common_test.go
@@ -1,15 +1,17 @@
 //go:build linux
 
-package hotkeys
+package hotkeys_test
 
 import (
 	"testing"
 
 	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/infra/hotkeys"
 )
 
 func TestLinuxManagerHealthCheck(t *testing.T) {
-	mgr := NewManager(zap.NewNop())
+	mgr := hotkeys.NewManager(zap.NewNop())
 	if mgr == nil {
 		t.Fatal("expected non-nil manager")
 	}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes an issue on Linux Wayland where global hotkeys become permanently un-responsive after system sleep/suspend.

### Root Cause
1. **Sleep Wake Race Condition**: When resuming from suspend, `PrepareForSleep(false)` fires immediately. At that millisecond, kernel/udev has not re-enumerated `/dev/input/event*` devices yet. `GlobalHotkeyListener.Start()` returned an error when 0 keyboard devices were opened, preventing the inotify hotplug watcher from instantiating.
2. **Missing Hotplug Watcher**: Because initial capture creation failed on wake, no inotify hotplug watcher was active for global hotkeys when `/dev/input/event16` came back online seconds later.
3. **Flawed Health Check**: `Manager.HealthCheck()` returned `true` (healthy) when `!m.waylandStarted`, causing `verifyHotkeyHealth()` to ignore the failed hotkey listener.

### Solution
- Updated `newWaylandEvdevCapture` to return a valid capture object even if 0 keyboard devices are initially open, enabling the inotify hotplug watcher to monitor `/dev/input/` and auto-capture devices as soon as udev initializes them post-wake.
- Updated `Manager.HealthCheck()` to return `false` when global hotkeys are registered but `waylandStarted` is false, `IsRunning()` is false, or `DeviceCount() == 0`.
- Added a bounded retry loop (up to 5 attempts with 500ms backoff) in `reinitializeHotkeys()` on wake from sleep to give udev time to re-populate device nodes.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
