### PR TITLE
fix(linux): resolve evdev hotkey deadlock post-suspend and preserve RemoteDesktop session

### DIFF
--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -184,11 +184,15 @@ func (a *App) reinitializeHotkeysWithParams(maxRetries int, retryDelay time.Dura
 	a.hotkeyRegistrationMu.Unlock()
 
 	if needReregister {
+		healthy := false
+
 		for attempt := 1; attempt <= maxRetries; attempt++ {
 			a.refreshHotkeysForAppOrCurrent("")
 
 			hc, ok := a.hotkeyManager.(interface{ HealthCheck() bool })
 			if !ok || hc.HealthCheck() {
+				healthy = true
+
 				break
 			}
 
@@ -205,6 +209,15 @@ func (a *App) reinitializeHotkeysWithParams(maxRetries int, retryDelay time.Dura
 				a.hotkeyRegistrationMu.Unlock()
 				time.Sleep(retryDelay)
 			}
+		}
+
+		if !healthy {
+			a.logger.Warn(
+				"Hotkey listener failed to recover after max reinitialization attempts",
+				zap.Int("max_retries", maxRetries),
+			)
+
+			return
 		}
 	}
 

--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -23,6 +23,13 @@ const (
 	// postReloadCheckDelay is how long after a config reload we wait before
 	// verifying the hotkey listener started correctly.
 	postReloadCheckDelay = 2 * time.Second
+	// hotkeyReinitRetries is the default number of hotkey reinitialization retries.
+	hotkeyReinitRetries = 5
+	// hotkeyReinitDelay is the delay between retry attempts during normal reinit.
+	hotkeyReinitDelay = 500 * time.Millisecond
+	// hotkeySleepRetries is the number of hotkey reinitialization retries after
+	// sleep/wake, allowing extra time for evdev devices to settle.
+	hotkeySleepRetries = 10
 )
 
 // Package-level resources for sleep observer cleanup. Stored here (rather than
@@ -150,14 +157,14 @@ func (a *App) stopSleepObserver() {
 // recovery after stale evdev fds; it avoids triggering a fresh RemoteDesktop
 // portal consent prompt.
 func (a *App) reinitializeHotkeys() {
-	a.reinitializeHotkeysWithParams(5, 500*time.Millisecond)
+	a.reinitializeHotkeysWithParams(hotkeyReinitRetries, hotkeyReinitDelay)
 }
 
 // reinitializeHotkeysAfterSleep is used on sleep/wake resume. Systems like
 // Steam Deck can take several seconds for evdev input devices to settle after
 // resume, so this uses a longer retry window (10 retries x 1s = 10s).
 func (a *App) reinitializeHotkeysAfterSleep() {
-	a.reinitializeHotkeysWithParams(10, 1*time.Second)
+	a.reinitializeHotkeysWithParams(hotkeySleepRetries, 1*time.Second)
 }
 
 func (a *App) reinitializeHotkeysWithParams(maxRetries int, retryDelay time.Duration) {

--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/godbus/dbus/v5"
 	"go.uber.org/zap"
-
-	"github.com/y3owk1n/neru/internal/core/infra/platform/linux"
 )
 
 const (
@@ -219,11 +217,6 @@ func (a *App) handleWakeFromSleep() {
 	a.logger.Info("Reinitializing input listeners after sleep/wake")
 
 	a.reinitializeHotkeysAfterSleep()
-
-	// Reset the libei/RemoteDesktop session so the next input operation
-	// re-establishes the portal connection. The old socket is stale after the
-	// compositor reinitialized during resume.
-	linux.LibeiReset()
 
 	a.logger.Info("Input listeners reinitialized after sleep/wake")
 }

--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -160,8 +160,8 @@ func (a *App) reinitializeHotkeys() {
 	a.reinitializeHotkeysWithParams(hotkeyReinitRetries, hotkeyReinitDelay)
 }
 
-// reinitializeHotkeysAfterSleep is used on sleep/wake resume. Systems like
-// Steam Deck can take several seconds for evdev input devices to settle after
+// reinitializeHotkeysAfterSleep is used on sleep/wake resume. Some systems
+// can take several seconds for evdev input devices to settle after
 // resume, so this uses a longer retry window (10 retries x 1s = 10s).
 func (a *App) reinitializeHotkeysAfterSleep() {
 	a.reinitializeHotkeysWithParams(hotkeySleepRetries, 1*time.Second)

--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -152,6 +152,17 @@ func (a *App) stopSleepObserver() {
 // recovery after stale evdev fds; it avoids triggering a fresh RemoteDesktop
 // portal consent prompt.
 func (a *App) reinitializeHotkeys() {
+	a.reinitializeHotkeysWithParams(5, 500*time.Millisecond)
+}
+
+// reinitializeHotkeysAfterSleep is used on sleep/wake resume. Systems like
+// Steam Deck can take several seconds for evdev input devices to settle after
+// resume, so this uses a longer retry window (10 retries x 1s = 10s).
+func (a *App) reinitializeHotkeysAfterSleep() {
+	a.reinitializeHotkeysWithParams(10, 1*time.Second)
+}
+
+func (a *App) reinitializeHotkeysWithParams(maxRetries int, retryDelay time.Duration) {
 	a.logger.Info("Reinitializing hotkey listener (evdev only)")
 
 	a.ExitMode()
@@ -168,11 +179,6 @@ func (a *App) reinitializeHotkeys() {
 	a.hotkeyRegistrationMu.Unlock()
 
 	if needReregister {
-		const (
-			maxRetries = 5
-			retryDelay = 500 * time.Millisecond
-		)
-
 		for attempt := 1; attempt <= maxRetries; attempt++ {
 			a.refreshHotkeysForAppOrCurrent("")
 
@@ -185,6 +191,7 @@ func (a *App) reinitializeHotkeys() {
 				a.logger.Debug(
 					"Hotkey listener not healthy after reinitialization attempt; retrying",
 					zap.Int("attempt", attempt),
+					zap.Int("max_retries", maxRetries),
 				)
 				a.hotkeyRegistrationMu.Lock()
 				a.stopAllHotkeyRepeats()
@@ -211,7 +218,7 @@ func (a *App) reinitializeHotkeys() {
 func (a *App) handleWakeFromSleep() {
 	a.logger.Info("Reinitializing input listeners after sleep/wake")
 
-	a.reinitializeHotkeys()
+	a.reinitializeHotkeysAfterSleep()
 
 	// Reset the libei/RemoteDesktop session so the next input operation
 	// re-establishes the portal connection. The old socket is stale after the

--- a/internal/core/infra/eventtap/global_hotkey_linux_cgo.go
+++ b/internal/core/infra/eventtap/global_hotkey_linux_cgo.go
@@ -119,7 +119,7 @@ func (l *GlobalHotkeyListener) Stop() {
 // StopWithTimeout halts watching with a deadline. Returns true if the stop
 // completed cleanly, false if the timeout expired and the old capture was
 // abandoned. On timeout the stale reader goroutines are leaked but will
-// eventually exit when the kernel finalises the file descriptors.
+// eventually exit when the kernel finalizes the file descriptors.
 func (l *GlobalHotkeyListener) StopWithTimeout(timeout time.Duration) bool {
 	l.mu.Lock()
 	if !l.running {

--- a/internal/core/infra/eventtap/global_hotkey_linux_cgo.go
+++ b/internal/core/infra/eventtap/global_hotkey_linux_cgo.go
@@ -11,6 +11,7 @@ package eventtap
 
 import (
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -112,6 +113,48 @@ func (l *GlobalHotkeyListener) Stop() {
 
 	if capture != nil {
 		capture.Close()
+	}
+}
+
+// StopWithTimeout halts watching with a deadline. Returns true if the stop
+// completed cleanly, false if the timeout expired and the old capture was
+// abandoned. On timeout the stale reader goroutines are leaked but will
+// eventually exit when the kernel finalises the file descriptors.
+func (l *GlobalHotkeyListener) StopWithTimeout(timeout time.Duration) bool {
+	l.mu.Lock()
+	if !l.running {
+		l.mu.Unlock()
+
+		return true
+	}
+
+	close(l.stopCh)
+	capture := l.capture
+	l.capture = nil
+	l.running = false
+	l.mu.Unlock()
+
+	if capture == nil {
+		return true
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		capture.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		l.logger.Warn(
+			"Evdev capture close timed out; abandoning stale readers",
+			zap.Duration("timeout", timeout),
+		)
+
+		return false
 	}
 }
 

--- a/internal/core/infra/eventtap/global_hotkey_linux_nocgo.go
+++ b/internal/core/infra/eventtap/global_hotkey_linux_nocgo.go
@@ -6,7 +6,11 @@
 
 package eventtap
 
-import "go.uber.org/zap"
+import (
+	"time"
+
+	"go.uber.org/zap"
+)
 
 // GlobalHotkeyListener is a no-op stub when cgo is disabled.
 type GlobalHotkeyListener struct{}
@@ -27,6 +31,9 @@ func (l *GlobalHotkeyListener) Start() error { return nil }
 
 // Stop is a no-op without cgo.
 func (l *GlobalHotkeyListener) Stop() {}
+
+// StopWithTimeout is a no-op stub without cgo.
+func (l *GlobalHotkeyListener) StopWithTimeout(_ time.Duration) bool { return true }
 
 // IsRunning returns false without cgo (evdev is unavailable).
 func (l *GlobalHotkeyListener) IsRunning() bool { return false }

--- a/internal/core/infra/hotkeys/manager_linux_common.go
+++ b/internal/core/infra/hotkeys/manager_linux_common.go
@@ -4,12 +4,15 @@ package hotkeys
 
 import (
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/core/infra/eventtap"
 	"github.com/y3owk1n/neru/internal/core/infra/platform"
 )
+
+const waylandStopTimeout = 3 * time.Second
 
 // HotkeyID represents a unique identifier for a registered hotkey.
 type HotkeyID int
@@ -22,6 +25,7 @@ type Manager struct {
 	callbacks map[HotkeyID]Callback
 	keys      map[HotkeyID]string
 	logger    *zap.Logger
+	rawLogger *zap.Logger
 	nextID    HotkeyID
 	backend   platform.LinuxBackend
 	mu        sync.RWMutex
@@ -42,6 +46,7 @@ func NewManager(logger *zap.Logger) *Manager {
 		callbacks: make(map[HotkeyID]Callback),
 		keys:      make(map[HotkeyID]string),
 		logger:    logger.Named("hotkeys"),
+		rawLogger: logger,
 		nextID:    1,
 		backend:   platformBackend(),
 	}
@@ -224,7 +229,11 @@ func (m *Manager) stopWayland() {
 		return
 	}
 
-	m.waylandHotkeys.Stop()
+	if !m.waylandHotkeys.StopWithTimeout(waylandStopTimeout) {
+		m.logger.Warn("Replacing stuck evdev hotkey listener with fresh instance")
+		m.waylandHotkeys = eventtap.NewGlobalHotkeyListener(m.rawLogger)
+	}
+
 	m.waylandStarted = false
 }
 

--- a/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
@@ -122,7 +122,7 @@ func (s *libeiState) tryAcquire() error {
 // fails (e.g. because the portal session went stale across system sleep), it
 // resets the session, re-acquires a fresh session, and retries once.
 func (s *libeiState) execute(
-	fn func(client *C.NeruEiClient) bool,
+	clientFn func(client *C.NeruEiClient) bool,
 	errorProvider func() error,
 ) error {
 	err := s.tryAcquire()
@@ -131,7 +131,7 @@ func (s *libeiState) execute(
 	}
 
 	client := s.client
-	ok := fn(client)
+	ok := clientFn(client)
 	s.mu.Unlock()
 
 	if ok {
@@ -148,7 +148,7 @@ func (s *libeiState) execute(
 	}
 	defer s.mu.Unlock()
 
-	if !fn(s.client) {
+	if !clientFn(s.client) {
 		return errorProvider()
 	}
 
@@ -157,9 +157,7 @@ func (s *libeiState) execute(
 
 func libeiMoveAbs(posX, posY int) error {
 	return globalLibeiState.execute(
-		func(c *C.NeruEiClient) bool {
-			return C.neru_ei_move_abs(c, C.int(posX), C.int(posY)) != 0
-		},
+		func(c *C.NeruEiClient) bool { return C.neru_ei_move_abs(c, C.int(posX), C.int(posY)) != 0 }, //nolint:nlreturn
 		func() error {
 			return derrors.Newf(
 				derrors.CodeActionFailed,
@@ -177,9 +175,7 @@ func libeiButton(button int, pressed bool) error {
 	}
 
 	return globalLibeiState.execute(
-		func(c *C.NeruEiClient) bool {
-			return C.neru_ei_button(c, C.int(button), pressedInt) != 0
-		},
+		func(c *C.NeruEiClient) bool { return C.neru_ei_button(c, C.int(button), pressedInt) != 0 }, //nolint:nlreturn
 		func() error {
 			return derrors.New(derrors.CodeActionFailed, "libei failed to emit button event")
 		},
@@ -188,9 +184,7 @@ func libeiButton(button int, pressed bool) error {
 
 func libeiScroll(axis, delta int) error {
 	return globalLibeiState.execute(
-		func(c *C.NeruEiClient) bool {
-			return C.neru_ei_scroll(c, C.int(axis), C.int(delta)) != 0
-		},
+		func(c *C.NeruEiClient) bool { return C.neru_ei_scroll(c, C.int(axis), C.int(delta)) != 0 }, //nolint:nlreturn
 		func() error {
 			return derrors.New(derrors.CodeActionFailed, "libei failed to emit scroll event")
 		},
@@ -204,9 +198,7 @@ func libeiKey(keycode int, pressed bool) error {
 	}
 
 	return globalLibeiState.execute(
-		func(c *C.NeruEiClient) bool {
-			return C.neru_ei_key(c, C.int(keycode), pressedInt) != 0
-		},
+		func(c *C.NeruEiClient) bool { return C.neru_ei_key(c, C.int(keycode), pressedInt) != 0 }, //nolint:nlreturn
 		func() error {
 			return derrors.New(
 				derrors.CodeNotSupported,

--- a/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
@@ -121,7 +121,10 @@ func (s *libeiState) tryAcquire() error {
 // execute runs an input action against the active libei client. If the action
 // fails (e.g. because the portal session went stale across system sleep), it
 // resets the session, re-acquires a fresh session, and retries once.
-func (s *libeiState) execute(fn func(client *C.NeruEiClient) bool, errorProvider func() error) error {
+func (s *libeiState) execute(
+	fn func(client *C.NeruEiClient) bool,
+	errorProvider func() error,
+) error {
 	err := s.tryAcquire()
 	if err != nil {
 		return err

--- a/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_kde_cgo.go
@@ -118,89 +118,103 @@ func (s *libeiState) tryAcquire() error {
 	return nil
 }
 
-func libeiMoveAbs(posX, posY int) error {
-	err := globalLibeiState.tryAcquire()
+// execute runs an input action against the active libei client. If the action
+// fails (e.g. because the portal session went stale across system sleep), it
+// resets the session, re-acquires a fresh session, and retries once.
+func (s *libeiState) execute(fn func(client *C.NeruEiClient) bool, errorProvider func() error) error {
+	err := s.tryAcquire()
 	if err != nil {
 		return err
 	}
-	defer globalLibeiState.mu.Unlock()
 
-	client := globalLibeiState.client
+	client := s.client
+	ok := fn(client)
+	s.mu.Unlock()
 
-	if C.neru_ei_move_abs(client, C.int(posX), C.int(posY)) == 0 { //nolint:nlreturn
-		return derrors.Newf(
-			derrors.CodeActionFailed,
-			"libei failed to move pointer to (%d, %d)",
-			posX, posY,
-		)
+	if ok {
+		return nil
+	}
+
+	// Action failed on existing session; it might be stale after system suspend.
+	// Reset and attempt a single reconnect + retry.
+	LibeiReset()
+
+	err = s.tryAcquire()
+	if err != nil {
+		return err
+	}
+	defer s.mu.Unlock()
+
+	if !fn(s.client) {
+		return errorProvider()
 	}
 
 	return nil
+}
+
+func libeiMoveAbs(posX, posY int) error {
+	return globalLibeiState.execute(
+		func(c *C.NeruEiClient) bool {
+			return C.neru_ei_move_abs(c, C.int(posX), C.int(posY)) != 0
+		},
+		func() error {
+			return derrors.Newf(
+				derrors.CodeActionFailed,
+				"libei failed to move pointer to (%d, %d)",
+				posX, posY,
+			)
+		},
+	)
 }
 
 func libeiButton(button int, pressed bool) error {
-	err := globalLibeiState.tryAcquire()
-	if err != nil {
-		return err
-	}
-	defer globalLibeiState.mu.Unlock()
-
-	client := globalLibeiState.client
-
 	pressedInt := C.int(0)
 	if pressed {
 		pressedInt = C.int(1)
 	}
 
-	if C.neru_ei_button(client, C.int(button), pressedInt) == 0 { //nolint:nlreturn
-		return derrors.New(derrors.CodeActionFailed, "libei failed to emit button event")
-	}
-
-	return nil
+	return globalLibeiState.execute(
+		func(c *C.NeruEiClient) bool {
+			return C.neru_ei_button(c, C.int(button), pressedInt) != 0
+		},
+		func() error {
+			return derrors.New(derrors.CodeActionFailed, "libei failed to emit button event")
+		},
+	)
 }
 
 func libeiScroll(axis, delta int) error {
-	err := globalLibeiState.tryAcquire()
-	if err != nil {
-		return err
-	}
-	defer globalLibeiState.mu.Unlock()
-
-	client := globalLibeiState.client
-
-	if C.neru_ei_scroll(client, C.int(axis), C.int(delta)) == 0 { //nolint:nlreturn
-		return derrors.New(derrors.CodeActionFailed, "libei failed to emit scroll event")
-	}
-
-	return nil
+	return globalLibeiState.execute(
+		func(c *C.NeruEiClient) bool {
+			return C.neru_ei_scroll(c, C.int(axis), C.int(delta)) != 0
+		},
+		func() error {
+			return derrors.New(derrors.CodeActionFailed, "libei failed to emit scroll event")
+		},
+	)
 }
 
 func libeiKey(keycode int, pressed bool) error {
-	err := globalLibeiState.tryAcquire()
-	if err != nil {
-		return err
-	}
-	defer globalLibeiState.mu.Unlock()
-
-	client := globalLibeiState.client
-
 	pressedInt := C.int(0)
 	if pressed {
 		pressedInt = C.int(1)
 	}
 
-	if C.neru_ei_key(client, C.int(keycode), pressedInt) == 0 { //nolint:nlreturn
-		return derrors.New(
-			derrors.CodeNotSupported,
-			"libei keyboard injection unavailable; the RemoteDesktop portal "+
-				"session did not grant a keyboard device. Restart neru and "+
-				"check \"Enable keyboard\" in the consent prompt; if the prompt "+
-				"does not appear, run `flatpak permission-remove kde-authorized "+
-				"remote-desktop \"\"` first to clear the saved grant",
-		)
-	}
-
-	return nil
+	return globalLibeiState.execute(
+		func(c *C.NeruEiClient) bool {
+			return C.neru_ei_key(c, C.int(keycode), pressedInt) != 0
+		},
+		func() error {
+			return derrors.New(
+				derrors.CodeNotSupported,
+				"libei keyboard injection unavailable; the RemoteDesktop portal "+
+					"session did not grant a keyboard device. Restart neru and "+
+					"check \"Enable keyboard\" in the consent prompt; if the prompt "+
+					"does not appear, run `flatpak permission-remove kde-authorized "+
+					"remote-desktop \"\"` first to clear the saved grant",
+			)
+		},
+	)
 }
 
 // libeiHasKeyboard reports whether the granted libei session includes a keyboard


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes two sleep/resume bugs on Linux/Wayland: the daemon could hang after waking from deep sleep due to stuck hotkey cleanup, and users were being re-prompted for Remote Control permission on every sleep cycle even though their session was still valid.

Hotkey teardown now times out and recovers automatically instead of hanging, input devices get more time to reconnect after wake, and we stopped needlessly resetting the Remote Control session — so permissions persist and input actions just retry once if they hit a stale connection.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
