### PR TITLE
fix(linux,wayland): use compositor keymap to respect XKB options

### DIFF
--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -1016,8 +1016,6 @@ func (et *EventTap) xkbStateModifierName(capture *waylandEvdevCapture, code uint
 		return evdevModifierAlt
 	case "Meta_L", "Meta_R", "Super_L", "Super_R", "Hyper_L", "Hyper_R":
 		return evdevModifierCmd
-	case "Caps_Lock":
-		return ""
 	}
 
 	return ""

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -1036,15 +1036,12 @@ func (et *EventTap) handleWaylandEvdevEvent(
 	// like caps:swapescape set by the compositor).
 	capture, _ := et.evdevWaylandCapture.(*waylandEvdevCapture)
 	if capture != nil && capture.xkbState != nil {
-		press := C.int(0)
-		if event.value == evdevValuePress {
-			press = 1
+		switch event.value {
+		case evdevValuePress:
+			C.neru_xkb_state_key((*C.neru_xkb_state)(capture.xkbState), C.uint16_t(event.code), 1)
+		case evdevValueRelease:
+			C.neru_xkb_state_key((*C.neru_xkb_state)(capture.xkbState), C.uint16_t(event.code), 0)
 		}
-		C.neru_xkb_state_key(
-			(*C.neru_xkb_state)(capture.xkbState),
-			C.uint16_t(event.code),
-			press,
-		)
 	}
 
 	// Resolve the modifier name through the XKB keymap so that compositor

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -773,7 +773,7 @@ func (et *EventTap) runWaylandEvdev() bool {
 	xkb := C.neru_xkb_state_create()
 	capture.xkbState = unsafe.Pointer(xkb)
 	if xkb == nil && et.logger != nil {
-		et.logger.Warn(
+		et.logger.Error(
 			"Failed to initialize Wayland xkb_state; XKB options will be ignored, " +
 				"falling back to hardcoded evdev key names",
 		)

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -994,30 +994,33 @@ func (et *EventTap) xkbEvdevKeyName(capture *waylandEvdevCapture, code uint16) s
 	return evdevKeyName(code)
 }
 
-// xkbStateResolvesAsModifier reports whether the xkb_state resolves the
-// given scan code as a modifier key. This prevents the hardcoded evdev
-// modifier map from treating a physical modifier as such when the
-// compositor's XKB options remap it (e.g. caps:swapescape, ctrl:swapcaps).
-func (et *EventTap) xkbStateResolvesAsModifier(capture *waylandEvdevCapture, code uint16) bool {
+// xkbStateModifierName returns the canonical evdev modifier name for the
+// given scan code as resolved by the XKB keymap, or empty string when the
+// key is not a modifier.  When XKB remaps a physical modifier to a different
+// function (e.g. ctrl:swapcaps makes Caps Lock act as Control), this returns
+// the remapped modifier name so the handler tracks the correct modifier.
+func (et *EventTap) xkbStateModifierName(capture *waylandEvdevCapture, code uint16) string {
 	if capture == nil || capture.xkbState == nil {
-		return true
+		return evdevModifierName(code)
 	}
 	key := et.xkbEvdevKeyName(capture, code)
 	if key == "" {
-		return true
+		return evdevModifierName(code)
 	}
 	switch key {
-	case "Shift_L", "Shift_R",
-		"Control_L", "Control_R",
-		"Alt_L", "Alt_R",
-		"Meta_L", "Meta_R",
-		"Super_L", "Super_R",
-		"Hyper_L", "Hyper_R",
-		"Caps_Lock", "Num_Lock":
-		return true
+	case "Shift_L", "Shift_R":
+		return evdevModifierShift
+	case "Control_L", "Control_R":
+		return evdevModifierCtrl
+	case "Alt_L", "Alt_R":
+		return evdevModifierAlt
+	case "Meta_L", "Meta_R", "Super_L", "Super_R", "Hyper_L", "Hyper_R":
+		return evdevModifierCmd
+	case "Caps_Lock":
+		return evdevModifierLock
 	}
 
-	return false
+	return ""
 }
 
 func (et *EventTap) handleWaylandEvdevEvent(
@@ -1044,12 +1047,13 @@ func (et *EventTap) handleWaylandEvdevEvent(
 		)
 	}
 
-	// Skip modifier handling when XKB remaps this physical key to a
-	// non-modifier function (e.g. caps:swapescape remaps Caps Lock to
-	// Escape, but the hardcoded scan-code check would still classify it
-	// as a modifier and return before the compositor keymap fires).
-	modifier := evdevModifierName(event.code)
-	if modifier != "" && et.xkbStateResolvesAsModifier(capture, event.code) {
+	// Resolve the modifier name through the XKB keymap so that compositor
+	// options like ctrl:swapcaps and caps:swapescape are respected: when
+	// XKB remaps a physical modifier to a different function, the handler
+	// uses the remapped modifier name (or bypasses modifier handling when
+	// the key is remapped to a non-modifier).
+	modifier := et.xkbStateModifierName(capture, event.code)
+	if modifier != "" {
 		if event.value == evdevValueRepeat {
 			return
 		}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -1017,7 +1017,7 @@ func (et *EventTap) xkbStateModifierName(capture *waylandEvdevCapture, code uint
 	case "Meta_L", "Meta_R", "Super_L", "Super_R", "Hyper_L", "Hyper_R":
 		return evdevModifierCmd
 	case "Caps_Lock":
-		return evdevModifierLock
+		return ""
 	}
 
 	return ""

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -927,7 +927,8 @@ drainStale:
 			for code := range state.releasedDuringGrab {
 				err := linux.WaylandKeyEvent(uint32(code), false)
 				if err != nil && et.logger != nil {
-					et.logger.Warn("Failed to inject synthetic key release at shutdown",
+					et.logger.Warn(
+						"Failed to inject synthetic key release at shutdown",
 						zap.Uint16("keycode", code),
 						zap.Error(err),
 					)
@@ -937,7 +938,8 @@ drainStale:
 				if !state.pressed[code] {
 					err := linux.WaylandKeyEvent(uint32(code), false)
 					if err != nil && et.logger != nil {
-						et.logger.Warn("Failed to inject synthetic key release at shutdown",
+						et.logger.Warn(
+							"Failed to inject synthetic key release at shutdown",
 							zap.Uint16("keycode", code),
 							zap.Error(err),
 						)
@@ -968,7 +970,7 @@ func (et *EventTap) xkbEvdevKeyName(capture *waylandEvdevCapture, code uint16) s
 		(*C.neru_xkb_state)(capture.xkbState),
 		C.uint16_t(code),
 		&buf[0],
-		64,
+		64, //nolint:nlreturn
 	) == 0 {
 		return C.GoString(&buf[0])
 	}
@@ -1045,8 +1047,7 @@ func (et *EventTap) handleWaylandEvdevEvent(
 
 	switch event.value {
 	case evdevValuePress:
-		// If this key was already held when the event tap was enabled, the
-		// press is from the kernel's SYN_DROPPED state replay after
+		// If this key was already held when the event tap was e kernel's SYN_DROPPED state replay after
 		// EVIOCGRAB. Track it in pressed (so subsequent repeats are not
 		// silently consumed) but skip dispatch — the user did not press
 		// it during this mode session. The initialKeys entry persists

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -778,6 +778,22 @@ func (et *EventTap) runWaylandEvdev() bool {
 				"falling back to hardcoded evdev key names",
 		)
 	}
+	if xkb != nil {
+		numLock := C.int(0)
+		capsLock := C.int(0)
+		capture.deviceMu.Lock()
+		for _, file := range capture.files {
+			fd := C.int(file.Fd())
+			if C.neru_evdev_led_is_on(fd, C.uint(0)) != 0 {
+				numLock = 1
+			}
+			if C.neru_evdev_led_is_on(fd, C.uint(1)) != 0 {
+				capsLock = 1
+			}
+		}
+		capture.deviceMu.Unlock()
+		C.neru_xkb_state_sync_leds(xkb, numLock, capsLock)
+	}
 
 	manager := overlay.Get()
 	keyboardCaptureDisabled := false

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -4,6 +4,7 @@ package eventtap
 
 /*
 #include "../platform/linux/evdev.h"
+#include "../platform/linux/wayland_keymap.h"
 */
 import "C"
 
@@ -107,6 +108,10 @@ type waylandEvdevCapture struct {
 	hotplugStopCh chan struct{}
 	hotplugOnce   sync.Once
 	hotplugWg     sync.WaitGroup
+
+	// xkbState holds a C xkb_state initialized from the compositor's keymap.
+	// Used to resolve evdev scan codes to key names that respect XKB options.
+	xkbState unsafe.Pointer // *C.neru_xkb_state
 }
 
 func newWaylandEvdevCapture(logger *zap.Logger) (*waylandEvdevCapture, error) {
@@ -194,6 +199,11 @@ func (capture *waylandEvdevCapture) Close() {
 		capture.done.Wait()
 
 		close(capture.events)
+
+		if capture.xkbState != nil {
+			C.neru_xkb_state_destroy((*C.neru_xkb_state)(capture.xkbState))
+			capture.xkbState = nil
+		}
 
 		if capture.logger != nil {
 			capture.logger.Debug("Evdev capture closed")
@@ -755,6 +765,20 @@ func (et *EventTap) runWaylandEvdev() bool {
 		return false
 	}
 
+	// Initialize xkb_state from the compositor's keymap (once, cached
+	// across cycles). This ensures evdev scan codes are resolved through
+	// the XKB keymap, respecting options like caps:swapescape.
+	if capture.xkbState == nil {
+		state := C.neru_xkb_state_create()
+		capture.xkbState = unsafe.Pointer(state)
+		if state == nil && et.logger != nil {
+			et.logger.Warn(
+				"Failed to initialize Wayland xkb_state; XKB options will be ignored, " +
+					"falling back to hardcoded evdev key names",
+			)
+		}
+	}
+
 	manager := overlay.Get()
 	keyboardCaptureDisabled := false
 	if manager != nil {
@@ -934,12 +958,46 @@ drainStale:
 	}
 }
 
+func (et *EventTap) xkbEvdevKeyName(capture *waylandEvdevCapture, code uint16) string {
+	if capture == nil || capture.xkbState == nil {
+		return evdevKeyName(code)
+	}
+
+	var buf [64]C.char
+	if C.neru_xkb_state_key_get_name(
+		(*C.neru_xkb_state)(capture.xkbState),
+		C.uint16_t(code),
+		&buf[0],
+		64,
+	) == 0 {
+		return C.GoString(&buf[0])
+	}
+
+	return evdevKeyName(code)
+}
+
 func (et *EventTap) handleWaylandEvdevEvent(
 	state *waylandEvdevKeyState,
 	event waylandEvdevEvent,
 ) {
 	if event.eventType != evdevEventKey {
 		return
+	}
+
+	// Feed all key events to xkb_state so its internal state stays
+	// consistent for key symbol resolution via XKB (respects options
+	// like caps:swapescape set by the compositor).
+	capture, _ := et.evdevWaylandCapture.(*waylandEvdevCapture)
+	if capture != nil && capture.xkbState != nil {
+		press := C.int(0)
+		if event.value == evdevValuePress {
+			press = 1
+		}
+		C.neru_xkb_state_key(
+			(*C.neru_xkb_state)(capture.xkbState),
+			C.uint16_t(event.code),
+			press,
+		)
 	}
 
 	if modifier := evdevModifierName(event.code); modifier != "" {
@@ -1005,7 +1063,7 @@ func (et *EventTap) handleWaylandEvdevEvent(
 		}
 		state.trackKey(event.code, false)
 
-		key := evdevKeyName(event.code)
+		key := et.xkbEvdevKeyName(capture, event.code)
 		if key != "" {
 			if keyUp := linuxKeyUpEvent(key); keyUp != "" {
 				et.dispatchKey(keyUp)
@@ -1028,7 +1086,7 @@ func (et *EventTap) handleWaylandEvdevEvent(
 		return
 	}
 
-	key := evdevKeyName(event.code)
+	key := et.xkbEvdevKeyName(capture, event.code)
 	if key == "" {
 		return
 	}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -765,18 +765,18 @@ func (et *EventTap) runWaylandEvdev() bool {
 		return false
 	}
 
-	// Initialize xkb_state from the compositor's keymap (once, cached
-	// across cycles). This ensures evdev scan codes are resolved through
-	// the XKB keymap, respecting options like caps:swapescape.
-	if capture.xkbState == nil {
-		state := C.neru_xkb_state_create()
-		capture.xkbState = unsafe.Pointer(state)
-		if state == nil && et.logger != nil {
-			et.logger.Warn(
-				"Failed to initialize Wayland xkb_state; XKB options will be ignored, " +
-					"falling back to hardcoded evdev key names",
-			)
-		}
+	// Refresh xkb_state on every activation so lock modifiers (Num Lock,
+	// Caps Lock) and layout group reflect the current compositor state.
+	if capture.xkbState != nil {
+		C.neru_xkb_state_destroy((*C.neru_xkb_state)(capture.xkbState))
+	}
+	xkb := C.neru_xkb_state_create()
+	capture.xkbState = unsafe.Pointer(xkb)
+	if xkb == nil && et.logger != nil {
+		et.logger.Warn(
+			"Failed to initialize Wayland xkb_state; XKB options will be ignored, " +
+				"falling back to hardcoded evdev key names",
+		)
 	}
 
 	manager := overlay.Get()

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -994,6 +994,32 @@ func (et *EventTap) xkbEvdevKeyName(capture *waylandEvdevCapture, code uint16) s
 	return evdevKeyName(code)
 }
 
+// xkbStateResolvesAsModifier reports whether the xkb_state resolves the
+// given scan code as a modifier key. This prevents the hardcoded evdev
+// modifier map from treating a physical modifier as such when the
+// compositor's XKB options remap it (e.g. caps:swapescape, ctrl:swapcaps).
+func (et *EventTap) xkbStateResolvesAsModifier(capture *waylandEvdevCapture, code uint16) bool {
+	if capture == nil || capture.xkbState == nil {
+		return true
+	}
+	key := et.xkbEvdevKeyName(capture, code)
+	if key == "" {
+		return true
+	}
+	switch key {
+	case "Shift_L", "Shift_R",
+		"Control_L", "Control_R",
+		"Alt_L", "Alt_R",
+		"Meta_L", "Meta_R",
+		"Super_L", "Super_R",
+		"Hyper_L", "Hyper_R",
+		"Caps_Lock", "Num_Lock":
+		return true
+	}
+
+	return false
+}
+
 func (et *EventTap) handleWaylandEvdevEvent(
 	state *waylandEvdevKeyState,
 	event waylandEvdevEvent,
@@ -1018,7 +1044,12 @@ func (et *EventTap) handleWaylandEvdevEvent(
 		)
 	}
 
-	if modifier := evdevModifierName(event.code); modifier != "" {
+	// Skip modifier handling when XKB remaps this physical key to a
+	// non-modifier function (e.g. caps:swapescape remaps Caps Lock to
+	// Escape, but the hardcoded scan-code check would still classify it
+	// as a modifier and return before the compositor keymap fires).
+	modifier := evdevModifierName(event.code)
+	if modifier != "" && et.xkbStateResolvesAsModifier(capture, event.code) {
 		if event.value == evdevValueRepeat {
 			return
 		}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
@@ -67,7 +67,6 @@ const (
 	evdevKeyRightShift uint16 = 54
 	evdevKeyLeftAlt    uint16 = 56
 	evdevKeySpace      uint16 = 57
-	evdevKeyCapsLock   uint16 = 58
 	evdevKeyF1         uint16 = 59
 	evdevKeyF2         uint16 = 60
 	evdevKeyF3         uint16 = 61
@@ -99,7 +98,7 @@ const (
 	evdevModifierCtrl  = "ctrl"
 	evdevModifierAlt   = "alt"
 	evdevModifierCmd   = "cmd"
-	evdevModifierLock  = "lock"
+
 
 	// Alias spellings accepted in configs for the canonical modifier tokens.
 	evdevModifierAliasControl = "control"
@@ -149,7 +148,6 @@ var evdevModifierNames = map[uint16]string{
 	evdevKeyRightAlt:   evdevModifierAlt,
 	evdevKeyLeftMeta:   evdevModifierCmd,
 	evdevKeyRightMeta:  evdevModifierCmd,
-	evdevKeyCapsLock:   evdevModifierLock,
 }
 
 var evdevKeyNames = map[uint16]string{

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
@@ -68,6 +68,7 @@ const (
 	evdevKeyLeftAlt    uint16 = 56
 	evdevKeySpace      uint16 = 57
 	evdevKeyCapsLock   uint16 = 58
+	evdevKeyNumLock    uint16 = 69
 	evdevKeyF1         uint16 = 59
 	evdevKeyF2         uint16 = 60
 	evdevKeyF3         uint16 = 61

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
@@ -68,7 +68,6 @@ const (
 	evdevKeyLeftAlt    uint16 = 56
 	evdevKeySpace      uint16 = 57
 	evdevKeyCapsLock   uint16 = 58
-	evdevKeyNumLock    uint16 = 69
 	evdevKeyF1         uint16 = 59
 	evdevKeyF2         uint16 = 60
 	evdevKeyF3         uint16 = 61

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
@@ -99,7 +99,6 @@ const (
 	evdevModifierAlt   = "alt"
 	evdevModifierCmd   = "cmd"
 
-
 	// Alias spellings accepted in configs for the canonical modifier tokens.
 	evdevModifierAliasControl = "control"
 	evdevModifierAliasOption  = "option"

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
@@ -100,6 +100,7 @@ const (
 	evdevModifierCtrl  = "ctrl"
 	evdevModifierAlt   = "alt"
 	evdevModifierCmd   = "cmd"
+	evdevModifierLock  = "lock"
 
 	// Alias spellings accepted in configs for the canonical modifier tokens.
 	evdevModifierAliasControl = "control"
@@ -149,6 +150,7 @@ var evdevModifierNames = map[uint16]string{
 	evdevKeyRightAlt:   evdevModifierAlt,
 	evdevKeyLeftMeta:   evdevModifierCmd,
 	evdevKeyRightMeta:  evdevModifierCmd,
+	evdevKeyCapsLock:   evdevModifierLock,
 }
 
 var evdevKeyNames = map[uint16]string{

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && cgo
 
 //nolint:testpackage // These tests validate unexported evdev translation helpers directly.
 package eventtap

--- a/internal/core/infra/platform/linux/evdev.c
+++ b/internal/core/infra/platform/linux/evdev.c
@@ -44,6 +44,19 @@ int neru_evdev_get_name(int fd, char *name, size_t name_size) {
 	return r;
 }
 
+int neru_evdev_led_is_on(int fd, unsigned int led) {
+	unsigned long led_bits[(LED_MAX + 8 * sizeof(unsigned long)) / (8 * sizeof(unsigned long))];
+	memset(led_bits, 0, sizeof(led_bits));
+
+	if (ioctl(fd, EVIOCGLED(sizeof(led_bits)), led_bits) < 0) {
+		return 0;
+	}
+
+	int idx = led / (8 * (int)sizeof(unsigned long));
+	int bit = led % (8 * (int)sizeof(unsigned long));
+	return (led_bits[idx] >> bit) & 1UL;
+}
+
 int neru_evdev_get_bustype(int fd) {
 	struct input_id id;
 	if (ioctl(fd, EVIOCGID, &id) < 0) {

--- a/internal/core/infra/platform/linux/evdev.h
+++ b/internal/core/infra/platform/linux/evdev.h
@@ -7,6 +7,7 @@
 
 int neru_evdev_grab(int fd, int grab);
 int neru_evdev_key_down(int fd, unsigned int keycode);
+int neru_evdev_led_is_on(int fd, unsigned int led);
 int neru_evdev_is_keyboard(int fd);
 int neru_evdev_get_name(int fd, char *name, size_t name_size);
 int neru_evdev_get_bustype(int fd);

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -283,16 +283,28 @@ void neru_xkb_state_sync_leds(neru_xkb_state *state, int num_lock_on, int caps_l
 	if (!keymap)
 		return;
 
-	xkb_mod_mask_t locked = 0;
+	xkb_mod_mask_t depressed = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_DEPRESSED);
+	xkb_mod_mask_t latched = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_LATCHED);
+	xkb_mod_mask_t locked = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_LOCKED);
 
 	xkb_mod_index_t num_idx = xkb_keymap_mod_get_index(keymap, "Mod2");
-	if (num_idx != XKB_MOD_INVALID && num_lock_on)
-		locked |= (xkb_mod_mask_t)1 << num_idx;
+	if (num_idx != XKB_MOD_INVALID) {
+		xkb_mod_mask_t bit = (xkb_mod_mask_t)1 << num_idx;
+		if (num_lock_on)
+			locked |= bit;
+		else
+			locked &= ~bit;
+	}
 
 	xkb_mod_index_t caps_idx = xkb_keymap_mod_get_index(keymap, "Lock");
-	if (caps_idx != XKB_MOD_INVALID && caps_lock_on)
-		locked |= (xkb_mod_mask_t)1 << caps_idx;
+	if (caps_idx != XKB_MOD_INVALID) {
+		xkb_mod_mask_t bit = (xkb_mod_mask_t)1 << caps_idx;
+		if (caps_lock_on)
+			locked |= bit;
+		else
+			locked &= ~bit;
+	}
 
 	xkb_layout_index_t current_group = xkb_state_serialize_layout(state->state, XKB_STATE_LAYOUT_LOCKED);
-	xkb_state_update_mask(state->state, 0, 0, locked, 0, 0, current_group);
+	xkb_state_update_mask(state->state, depressed, latched, locked, 0, 0, current_group);
 }

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -245,7 +245,7 @@ static void neru_normalize_xkb_name(char *buf, size_t buf_size) {
 	}
 	/* KP_0 through KP_9 */
 	size_t blen = strlen(buf);
-	if (blen == 5 && buf[0] == 'K' && buf[1] == 'P' && buf[2] == '_' && buf[3] >= '0' && buf[3] <= '9') {
+	if (blen == 4 && buf[0] == 'K' && buf[1] == 'P' && buf[2] == '_' && buf[3] >= '0' && buf[3] <= '9') {
 		buf[0] = buf[3];
 		buf[1] = '\0';
 	}

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -236,7 +236,8 @@ static void neru_normalize_xkb_name(char *buf, size_t buf_size) {
 	    {"KP_Left", "Left"},
 	    {"KP_Right", "Right"},
 	    {"KP_Begin", "5"},
-	    {"KP_Decimal", "."},
+	{"KP_Decimal", "."},
+	{"Caps_Lock", "CapsLock"},
 	};
 
 	for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); i++) {

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -284,8 +284,8 @@ void neru_xkb_state_sync_leds(neru_xkb_state *state, int num_lock_on, int caps_l
 		return;
 
 	xkb_mod_mask_t depressed = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_DEPRESSED);
-	xkb_mod_mask_t latched   = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_LATCHED);
-	xkb_mod_mask_t locked    = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_LOCKED);
+	xkb_mod_mask_t latched = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_LATCHED);
+	xkb_mod_mask_t locked = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_LOCKED);
 	xkb_layout_index_t group = xkb_state_serialize_layout(state->state, XKB_STATE_LAYOUT_LOCKED);
 
 	xkb_mod_mask_t new_locked = locked;

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -293,7 +293,6 @@ void neru_xkb_state_sync_leds(neru_xkb_state *state, int num_lock_on, int caps_l
 	if (caps_idx != XKB_MOD_INVALID && caps_lock_on)
 		locked |= (xkb_mod_mask_t)1 << caps_idx;
 
-	xkb_layout_index_t current_group =
-	    xkb_state_serialize_layout(state->state, XKB_STATE_LAYOUT_LOCKED);
+	xkb_layout_index_t current_group = xkb_state_serialize_layout(state->state, XKB_STATE_LAYOUT_LOCKED);
 	xkb_state_update_mask(state->state, 0, 0, locked, 0, 0, current_group);
 }

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -54,7 +54,12 @@ static void neru_keyboard_key(
 
 static void neru_keyboard_modifiers(
     void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched,
-    uint32_t mods_locked, uint32_t group) {}
+    uint32_t mods_locked, uint32_t group) {
+	struct keymap_ready *kr = data;
+	if (kr->state) {
+		xkb_state_update_mask(kr->state, mods_depressed, mods_latched, mods_locked, 0, 0, group);
+	}
+}
 
 static void neru_keyboard_repeat_info(void *data, struct wl_keyboard *wl_keyboard, int32_t rate, int32_t delay) {}
 

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -88,7 +88,7 @@ static void neru_registry_global(
     void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version) {
 	struct registry_data *rd = data;
 	if (strcmp(interface, "wl_seat") == 0) {
-		rd->seat = wl_registry_bind(registry, name, &wl_seat_interface, 7);
+		rd->seat = wl_registry_bind(registry, name, &wl_seat_interface, version < 7 ? version : 7);
 	}
 }
 

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -183,27 +183,57 @@ static void neru_normalize_xkb_name(char *buf, size_t buf_size) {
 		const char *xkb;
 		const char *canon;
 	} table[] = {
-		{"semicolon", ";"},   {"colon", ":"},       {"comma", ","},
-		{"period", "."},      {"slash", "/"},        {"backslash", "\\"},
-		{"apostrophe", "'"},  {"grave", "`"},        {"minus", "-"},
-		{"equal", "="},       {"bracketleft", "["},  {"bracketright", "]"},
-		{"less", "<"},        {"greater", ">"},      {"underscore", "_"},
-		{"plus", "+"},        {"asciitilde", "~"},   {"exclam", "!"},
-		{"at", "@"},          {"numbersign", "#"},   {"dollar", "$"},
-		{"percent", "%"},     {"asciicircum", "^"},  {"ampersand", "&"},
-		{"asterisk", "*"},    {"parenleft", "("},    {"parenright", ")"},
-		{"question", "?"},    {"quotedbl", "\""},    {"bar", "|"},
-		{"Page_Up", "PageUp"},     {"Page_Down", "PageDown"},
-		{"KP_Add", "+"},           {"KP_Subtract", "-"},
-		{"KP_Multiply", "*"},      {"KP_Divide", "/"},
-		{"KP_Enter", "Return"},    {"KP_Delete", "Delete"},
-		{"KP_Insert", "Insert"},   {"KP_Home", "Home"},
-		{"KP_End", "End"},         {"KP_Page_Up", "PageUp"},
-		{"KP_Page_Down", "PageDown"}, {"KP_Up", "Up"},
-		{"KP_Down", "Down"},       {"KP_Left", "Left"},
-		{"KP_Right", "Right"},     {"KP_Begin", "5"},
-		{"KP_Decimal", "."},
+	    {"semicolon", ";"},
+	    {"colon", ":"},
+	    {"comma", ","},
+	    {"period", "."},
+	    {"slash", "/"},
+	    {"backslash", "\\"},
+	    {"apostrophe", "'"},
+	    {"grave", "`"},
+	    {"minus", "-"},
+	    {"equal", "="},
+	    {"bracketleft", "["},
+	    {"bracketright", "]"},
+	    {"less", "<"},
+	    {"greater", ">"},
+	    {"underscore", "_"},
+	    {"plus", "+"},
+	    {"asciitilde", "~"},
+	    {"exclam", "!"},
+	    {"at", "@"},
+	    {"numbersign", "#"},
+	    {"dollar", "$"},
+	    {"percent", "%"},
+	    {"asciicircum", "^"},
+	    {"ampersand", "&"},
+	    {"asterisk", "*"},
+	    {"parenleft", "("},
+	    {"parenright", ")"},
+	    {"question", "?"},
+	    {"quotedbl", "\""},
+	    {"bar", "|"},
+	    {"Page_Up", "PageUp"},
+	    {"Page_Down", "PageDown"},
+	    {"KP_Add", "+"},
+	    {"KP_Subtract", "-"},
+	    {"KP_Multiply", "*"},
+	    {"KP_Divide", "/"},
+	    {"KP_Enter", "Return"},
+	    {"KP_Delete", "Delete"},
+	    {"KP_Insert", "Insert"},
+	    {"KP_Home", "Home"},
+	    {"KP_End", "End"},
+	    {"KP_Page_Up", "PageUp"},
+	    {"KP_Page_Down", "PageDown"},
+	    {"KP_Up", "Up"},
+	    {"KP_Down", "Down"},
+	    {"KP_Left", "Left"},
+	    {"KP_Right", "Right"},
+	    {"KP_Begin", "5"},
+	    {"KP_Decimal", "."},
 	};
+
 	for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); i++) {
 		if (strcmp(buf, table[i].xkb) == 0) {
 			size_t len = strlen(table[i].canon);
@@ -215,8 +245,7 @@ static void neru_normalize_xkb_name(char *buf, size_t buf_size) {
 	}
 	/* KP_0 through KP_9 */
 	size_t blen = strlen(buf);
-	if (blen == 5 && buf[0] == 'K' && buf[1] == 'P' && buf[2] == '_' &&
-	    buf[3] >= '0' && buf[3] <= '9') {
+	if (blen == 5 && buf[0] == 'K' && buf[1] == 'P' && buf[2] == '_' && buf[3] >= '0' && buf[3] <= '9') {
 		buf[0] = buf[3];
 		buf[1] = '\0';
 	}

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -178,6 +178,50 @@ void neru_xkb_state_key(neru_xkb_state *state, uint16_t evdev_code, int is_press
 	xkb_state_update_key(state->state, (xkb_keycode_t)evdev_code + 8, is_press ? XKB_KEY_DOWN : XKB_KEY_UP);
 }
 
+static void neru_normalize_xkb_name(char *buf, size_t buf_size) {
+	static const struct {
+		const char *xkb;
+		const char *canon;
+	} table[] = {
+		{"semicolon", ";"},   {"colon", ":"},       {"comma", ","},
+		{"period", "."},      {"slash", "/"},        {"backslash", "\\"},
+		{"apostrophe", "'"},  {"grave", "`"},        {"minus", "-"},
+		{"equal", "="},       {"bracketleft", "["},  {"bracketright", "]"},
+		{"less", "<"},        {"greater", ">"},      {"underscore", "_"},
+		{"plus", "+"},        {"asciitilde", "~"},   {"exclam", "!"},
+		{"at", "@"},          {"numbersign", "#"},   {"dollar", "$"},
+		{"percent", "%"},     {"asciicircum", "^"},  {"ampersand", "&"},
+		{"asterisk", "*"},    {"parenleft", "("},    {"parenright", ")"},
+		{"question", "?"},    {"quotedbl", "\""},    {"bar", "|"},
+		{"Page_Up", "PageUp"},     {"Page_Down", "PageDown"},
+		{"KP_Add", "+"},           {"KP_Subtract", "-"},
+		{"KP_Multiply", "*"},      {"KP_Divide", "/"},
+		{"KP_Enter", "Return"},    {"KP_Delete", "Delete"},
+		{"KP_Insert", "Insert"},   {"KP_Home", "Home"},
+		{"KP_End", "End"},         {"KP_Page_Up", "PageUp"},
+		{"KP_Page_Down", "PageDown"}, {"KP_Up", "Up"},
+		{"KP_Down", "Down"},       {"KP_Left", "Left"},
+		{"KP_Right", "Right"},     {"KP_Begin", "5"},
+		{"KP_Decimal", "."},
+	};
+	for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); i++) {
+		if (strcmp(buf, table[i].xkb) == 0) {
+			size_t len = strlen(table[i].canon);
+			if (len < buf_size) {
+				memmove(buf, table[i].canon, len + 1);
+			}
+			return;
+		}
+	}
+	/* KP_0 through KP_9 */
+	size_t blen = strlen(buf);
+	if (blen == 5 && buf[0] == 'K' && buf[1] == 'P' && buf[2] == '_' &&
+	    buf[3] >= '0' && buf[3] <= '9') {
+		buf[0] = buf[3];
+		buf[1] = '\0';
+	}
+}
+
 int neru_xkb_state_key_get_name(neru_xkb_state *state, uint16_t evdev_code, char *buf, size_t buf_size) {
 	if (!state || !state->state || !buf || buf_size == 0)
 		return -1;
@@ -187,6 +231,10 @@ int neru_xkb_state_key_get_name(neru_xkb_state *state, uint16_t evdev_code, char
 		return -1;
 
 	xkb_keysym_get_name(keysym, buf, buf_size);
+	if (buf[0] == '\0')
+		return -1;
+
+	neru_normalize_xkb_name(buf, buf_size);
 	if (buf[0] == '\0')
 		return -1;
 

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -1,0 +1,194 @@
+#include "wayland_keymap.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <wayland-client.h>
+#include <xkbcommon/xkbcommon.h>
+
+struct neru_xkb_state {
+	struct xkb_state *state;
+	struct wl_display *display;
+	struct wl_keyboard *wl_keyboard;
+};
+
+// ── wl_keyboard listener (only .keymap is used) ─────────────────────────
+
+struct keymap_ready {
+	struct xkb_state *state;
+	int ready;
+};
+
+static void neru_keyboard_keymap(
+    void *data, struct wl_keyboard *wl_keyboard, uint32_t format, int32_t fd, uint32_t size) {
+	struct keymap_ready *kr = data;
+	if (format == WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
+		char *map_str = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+		if (map_str != MAP_FAILED) {
+			struct xkb_context *ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+			if (ctx) {
+				struct xkb_keymap *keymap =
+				    xkb_keymap_new_from_string(ctx, map_str, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+				if (keymap) {
+					kr->state = xkb_state_new(keymap);
+					xkb_keymap_unref(keymap);
+				}
+				xkb_context_unref(ctx);
+			}
+			munmap(map_str, size);
+		}
+	}
+	close(fd);
+	kr->ready = 1;
+}
+
+static void neru_keyboard_enter(
+    void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, struct wl_surface *surface, struct wl_array *keys) {}
+
+static void neru_keyboard_leave(
+    void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, struct wl_surface *surface) {}
+
+static void neru_keyboard_key(
+    void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state) {}
+
+static void neru_keyboard_modifiers(
+    void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched,
+    uint32_t mods_locked, uint32_t group) {}
+
+static void neru_keyboard_repeat_info(void *data, struct wl_keyboard *wl_keyboard, int32_t rate, int32_t delay) {}
+
+static const struct wl_keyboard_listener keyboard_listener = {
+    .keymap = neru_keyboard_keymap,
+    .enter = neru_keyboard_enter,
+    .leave = neru_keyboard_leave,
+    .key = neru_keyboard_key,
+    .modifiers = neru_keyboard_modifiers,
+    .repeat_info = neru_keyboard_repeat_info,
+};
+
+// ── wl_seat listener ────────────────────────────────────────────────────
+
+static void neru_seat_capabilities(void *data, struct wl_seat *seat, uint32_t capabilities) {}
+
+static void neru_seat_name(void *data, struct wl_seat *seat, const char *name) {}
+
+static const struct wl_seat_listener seat_listener = {
+    .capabilities = neru_seat_capabilities,
+    .name = neru_seat_name,
+};
+
+// ── wl_registry listener ────────────────────────────────────────────────
+
+struct registry_data {
+	struct wl_seat *seat;
+};
+
+static void neru_registry_global(
+    void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version) {
+	struct registry_data *rd = data;
+	if (strcmp(interface, "wl_seat") == 0) {
+		rd->seat = wl_registry_bind(registry, name, &wl_seat_interface, 7);
+	}
+}
+
+static void neru_registry_global_remove(void *data, struct wl_registry *registry, uint32_t name) {}
+
+static const struct wl_registry_listener registry_listener = {
+    .global = neru_registry_global,
+    .global_remove = neru_registry_global_remove,
+};
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+neru_xkb_state *neru_xkb_state_create(void) {
+	struct wl_display *display = wl_display_connect(NULL);
+	if (!display)
+		return NULL;
+
+	struct wl_registry *registry = wl_display_get_registry(display);
+	if (!registry) {
+		wl_display_disconnect(display);
+		return NULL;
+	}
+
+	struct registry_data rd = {0};
+	wl_registry_add_listener(registry, &registry_listener, &rd);
+	wl_display_roundtrip(display);
+	wl_display_roundtrip(display);
+
+	if (!rd.seat) {
+		wl_registry_destroy(registry);
+		wl_display_disconnect(display);
+		return NULL;
+	}
+
+	struct wl_keyboard *kb = wl_seat_get_keyboard(rd.seat);
+	wl_registry_destroy(registry);
+
+	if (!kb) {
+		wl_display_disconnect(display);
+		return NULL;
+	}
+
+	struct keymap_ready kr = {0};
+	wl_keyboard_add_listener(kb, &keyboard_listener, &kr);
+	wl_display_roundtrip(display);
+	wl_display_roundtrip(display);
+
+	if (!kr.state) {
+		wl_keyboard_destroy(kb);
+		wl_display_disconnect(display);
+		return NULL;
+	}
+
+	neru_xkb_state *state = calloc(1, sizeof(neru_xkb_state));
+	if (!state) {
+		xkb_state_unref(kr.state);
+		wl_keyboard_destroy(kb);
+		wl_display_disconnect(display);
+		return NULL;
+	}
+
+	state->state = kr.state;
+	state->display = display;
+	state->wl_keyboard = kb;
+
+	return state;
+}
+
+void neru_xkb_state_destroy(neru_xkb_state *state) {
+	if (!state)
+		return;
+
+	if (state->state)
+		xkb_state_unref(state->state);
+	if (state->wl_keyboard)
+		wl_keyboard_destroy(state->wl_keyboard);
+	if (state->display)
+		wl_display_disconnect(state->display);
+
+	free(state);
+}
+
+void neru_xkb_state_key(neru_xkb_state *state, uint16_t evdev_code, int is_press) {
+	if (!state || !state->state)
+		return;
+
+	xkb_state_update_key(state->state, (xkb_keycode_t)evdev_code + 8, is_press ? XKB_KEY_DOWN : XKB_KEY_UP);
+}
+
+int neru_xkb_state_key_get_name(neru_xkb_state *state, uint16_t evdev_code, char *buf, size_t buf_size) {
+	if (!state || !state->state || !buf || buf_size == 0)
+		return -1;
+
+	xkb_keysym_t keysym = xkb_state_key_get_one_sym(state->state, (xkb_keycode_t)evdev_code + 8);
+	if (keysym == XKB_KEY_NoSymbol)
+		return -1;
+
+	xkb_keysym_get_name(keysym, buf, buf_size);
+	if (buf[0] == '\0')
+		return -1;
+
+	return 0;
+}

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -283,15 +283,20 @@ void neru_xkb_state_sync_leds(neru_xkb_state *state, int num_lock_on, int caps_l
 	if (!keymap)
 		return;
 
-	xkb_mod_mask_t locked = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_LOCKED);
+	xkb_mod_mask_t depressed = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_DEPRESSED);
+	xkb_mod_mask_t latched   = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_LATCHED);
+	xkb_mod_mask_t locked    = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_LOCKED);
+	xkb_layout_index_t group = xkb_state_serialize_layout(state->state, XKB_STATE_LAYOUT_LOCKED);
+
+	xkb_mod_mask_t new_locked = locked;
+	int changed = 0;
 
 	xkb_mod_index_t num_idx = xkb_keymap_mod_get_index(keymap, "Mod2");
 	if (num_idx != XKB_MOD_INVALID) {
 		int cur = (locked >> num_idx) & 1;
 		if (cur != num_lock_on) {
-			xkb_keycode_t kc = 69 + 8;
-			xkb_state_update_key(state->state, kc, XKB_KEY_DOWN);
-			xkb_state_update_key(state->state, kc, XKB_KEY_UP);
+			new_locked ^= (xkb_mod_mask_t)1 << num_idx;
+			changed = 1;
 		}
 	}
 
@@ -299,9 +304,12 @@ void neru_xkb_state_sync_leds(neru_xkb_state *state, int num_lock_on, int caps_l
 	if (caps_idx != XKB_MOD_INVALID) {
 		int cur = (locked >> caps_idx) & 1;
 		if (cur != caps_lock_on) {
-			xkb_keycode_t kc = 58 + 8;
-			xkb_state_update_key(state->state, kc, XKB_KEY_DOWN);
-			xkb_state_update_key(state->state, kc, XKB_KEY_UP);
+			new_locked ^= (xkb_mod_mask_t)1 << caps_idx;
+			changed = 1;
 		}
+	}
+
+	if (changed) {
+		xkb_state_update_mask(state->state, depressed, latched, new_locked, 0, 0, group);
 	}
 }

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -236,8 +236,8 @@ static void neru_normalize_xkb_name(char *buf, size_t buf_size) {
 	    {"KP_Left", "Left"},
 	    {"KP_Right", "Right"},
 	    {"KP_Begin", "5"},
-	{"KP_Decimal", "."},
-	{"Caps_Lock", "CapsLock"},
+	    {"KP_Decimal", "."},
+	    {"Caps_Lock", "CapsLock"},
 	};
 
 	for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); i++) {

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -293,5 +293,7 @@ void neru_xkb_state_sync_leds(neru_xkb_state *state, int num_lock_on, int caps_l
 	if (caps_idx != XKB_MOD_INVALID && caps_lock_on)
 		locked |= (xkb_mod_mask_t)1 << caps_idx;
 
-	xkb_state_update_mask(state->state, 0, 0, locked, 0, 0, 0);
+	xkb_layout_index_t current_group =
+	    xkb_state_serialize_layout(state->state, XKB_STATE_LAYOUT_LOCKED);
+	xkb_state_update_mask(state->state, 0, 0, locked, 0, 0, current_group);
 }

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -283,28 +283,25 @@ void neru_xkb_state_sync_leds(neru_xkb_state *state, int num_lock_on, int caps_l
 	if (!keymap)
 		return;
 
-	xkb_mod_mask_t depressed = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_DEPRESSED);
-	xkb_mod_mask_t latched = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_LATCHED);
 	xkb_mod_mask_t locked = xkb_state_serialize_mods(state->state, XKB_STATE_MODS_LOCKED);
 
 	xkb_mod_index_t num_idx = xkb_keymap_mod_get_index(keymap, "Mod2");
 	if (num_idx != XKB_MOD_INVALID) {
-		xkb_mod_mask_t bit = (xkb_mod_mask_t)1 << num_idx;
-		if (num_lock_on)
-			locked |= bit;
-		else
-			locked &= ~bit;
+		int cur = (locked >> num_idx) & 1;
+		if (cur != num_lock_on) {
+			xkb_keycode_t kc = 69 + 8;
+			xkb_state_update_key(state->state, kc, XKB_KEY_DOWN);
+			xkb_state_update_key(state->state, kc, XKB_KEY_UP);
+		}
 	}
 
 	xkb_mod_index_t caps_idx = xkb_keymap_mod_get_index(keymap, "Lock");
 	if (caps_idx != XKB_MOD_INVALID) {
-		xkb_mod_mask_t bit = (xkb_mod_mask_t)1 << caps_idx;
-		if (caps_lock_on)
-			locked |= bit;
-		else
-			locked &= ~bit;
+		int cur = (locked >> caps_idx) & 1;
+		if (cur != caps_lock_on) {
+			xkb_keycode_t kc = 58 + 8;
+			xkb_state_update_key(state->state, kc, XKB_KEY_DOWN);
+			xkb_state_update_key(state->state, kc, XKB_KEY_UP);
+		}
 	}
-
-	xkb_layout_index_t current_group = xkb_state_serialize_layout(state->state, XKB_STATE_LAYOUT_LOCKED);
-	xkb_state_update_mask(state->state, depressed, latched, locked, 0, 0, current_group);
 }

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -7,18 +7,19 @@
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
 
-struct neru_xkb_state {
-	struct xkb_state *state;
-	struct wl_display *display;
-	struct wl_keyboard *wl_keyboard;
-};
-
-// ── wl_keyboard listener (only .keymap is used) ─────────────────────────
-
 struct keymap_ready {
 	struct xkb_state *state;
 	int ready;
 };
+
+struct neru_xkb_state {
+	struct xkb_state *state;
+	struct wl_display *display;
+	struct wl_keyboard *wl_keyboard;
+	struct keymap_ready kr; // listener data, alive for lifetime of this struct
+};
+
+// ── wl_keyboard listener (only .keymap is used) ─────────────────────────
 
 static void neru_keyboard_keymap(
     void *data, struct wl_keyboard *wl_keyboard, uint32_t format, int32_t fd, uint32_t size) {
@@ -136,28 +137,27 @@ neru_xkb_state *neru_xkb_state_create(void) {
 		return NULL;
 	}
 
-	struct keymap_ready kr = {0};
-	wl_keyboard_add_listener(kb, &keyboard_listener, &kr);
-	wl_display_roundtrip(display);
-	wl_display_roundtrip(display);
-
-	if (!kr.state) {
-		wl_keyboard_destroy(kb);
-		wl_display_disconnect(display);
-		return NULL;
-	}
-
 	neru_xkb_state *state = calloc(1, sizeof(neru_xkb_state));
 	if (!state) {
-		xkb_state_unref(kr.state);
 		wl_keyboard_destroy(kb);
 		wl_display_disconnect(display);
 		return NULL;
 	}
 
-	state->state = kr.state;
 	state->display = display;
 	state->wl_keyboard = kb;
+	state->kr = (struct keymap_ready){0};
+
+	wl_keyboard_add_listener(kb, &keyboard_listener, &state->kr);
+	wl_display_roundtrip(display);
+	wl_display_roundtrip(display);
+
+	if (!state->kr.state) {
+		neru_xkb_state_destroy(state);
+		return NULL;
+	}
+
+	state->state = state->kr.state;
 
 	return state;
 }

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -274,3 +274,24 @@ int neru_xkb_state_key_get_name(neru_xkb_state *state, uint16_t evdev_code, char
 
 	return 0;
 }
+
+void neru_xkb_state_sync_leds(neru_xkb_state *state, int num_lock_on, int caps_lock_on) {
+	if (!state || !state->state)
+		return;
+
+	struct xkb_keymap *keymap = xkb_state_get_keymap(state->state);
+	if (!keymap)
+		return;
+
+	xkb_mod_mask_t locked = 0;
+
+	xkb_mod_index_t num_idx = xkb_keymap_mod_get_index(keymap, "Mod2");
+	if (num_idx != XKB_MOD_INVALID && num_lock_on)
+		locked |= (xkb_mod_mask_t)1 << num_idx;
+
+	xkb_mod_index_t caps_idx = xkb_keymap_mod_get_index(keymap, "Lock");
+	if (caps_idx != XKB_MOD_INVALID && caps_lock_on)
+		locked |= (xkb_mod_mask_t)1 << caps_idx;
+
+	xkb_state_update_mask(state->state, 0, 0, locked, 0, 0, 0);
+}

--- a/internal/core/infra/platform/linux/wayland_keymap.c
+++ b/internal/core/infra/platform/linux/wayland_keymap.c
@@ -16,7 +16,7 @@ struct neru_xkb_state {
 	struct xkb_state *state;
 	struct wl_display *display;
 	struct wl_keyboard *wl_keyboard;
-	struct keymap_ready kr; // listener data, alive for lifetime of this struct
+	struct keymap_ready kr;  // listener data, alive for lifetime of this struct
 };
 
 // ── wl_keyboard listener (only .keymap is used) ─────────────────────────

--- a/internal/core/infra/platform/linux/wayland_keymap.h
+++ b/internal/core/infra/platform/linux/wayland_keymap.h
@@ -22,4 +22,6 @@ void neru_xkb_state_key(neru_xkb_state *state, uint16_t evdev_code, int is_press
 // Returns 0 on success, -1 on failure.
 int neru_xkb_state_key_get_name(neru_xkb_state *state, uint16_t evdev_code, char *buf, size_t buf_size);
 
+void neru_xkb_state_sync_leds(neru_xkb_state *state, int num_lock_on, int caps_lock_on);
+
 #endif

--- a/internal/core/infra/platform/linux/wayland_keymap.h
+++ b/internal/core/infra/platform/linux/wayland_keymap.h
@@ -1,0 +1,25 @@
+#ifndef NERU_WAYLAND_KEYMAP_H
+#define NERU_WAYLAND_KEYMAP_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct neru_xkb_state;
+typedef struct neru_xkb_state neru_xkb_state;
+
+// Connect to the Wayland display and retrieve the compositor's keymap
+// via wl_keyboard to create an xkb_state. Returns NULL on failure.
+neru_xkb_state *neru_xkb_state_create(void);
+
+// Destroy the xkb_state and associated Wayland resources.
+void neru_xkb_state_destroy(neru_xkb_state *state);
+
+// Feed a key press (is_press=1) or release (is_press=0) to the xkb_state.
+void neru_xkb_state_key(neru_xkb_state *state, uint16_t evdev_code, int is_press);
+
+// Resolve the xkb key name for the given evdev scan code.
+// Writes the key name into buf (up to buf_size bytes).
+// Returns 0 on success, -1 on failure.
+int neru_xkb_state_key_get_name(neru_xkb_state *state, uint16_t evdev_code, char *buf, size_t buf_size);
+
+#endif


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR resolves evdev scan codes through the compositor's `libxkbcommon` keymap instead of a hardcoded lookup table, so XKB options like `caps:swapescape` configured in the compositor are honored.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #1096 

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A