### PR TITLE
test(darwin): service the main run loop during macOS integration tests

### DIFF
--- a/docs/testing/TESTING_PATTERNS.md
+++ b/docs/testing/TESTING_PATTERNS.md
@@ -102,6 +102,32 @@ func TestDarwinAccessibility(t *testing.T) {
 }
 ```
 
+#### macOS tests that need the main run loop
+
+Native work such as building the keyboard layout maps or creating a `CGEventTap`
+is dispatched to the main queue, which is only drained while the main run loop
+runs. The daemon starts that loop in `cmd/neru`; a `go test` binary never does.
+A test that reaches such code therefore only passes when the Go scheduler
+happens to run it on the main OS thread — otherwise `dispatch_async` work
+silently times out (an empty keymap makes every key name fail to parse) and
+`dispatch_sync` deadlocks.
+
+Pump the run loop from `TestMain` so the behaviour is deterministic:
+
+```go
+// Pin the main thread during package init so TestMain still runs on it.
+func init() {
+    runtime.LockOSThread()
+}
+
+func TestMain(m *testing.M) {
+    os.Exit(darwin.RunMainLoopForTesting(m.Run))
+}
+```
+
+`*_integration_darwin_test.go` files are exempt from the "One Rule", so they may
+import `internal/core/infra/platform/darwin` directly.
+
 ### Test Command Usage
 
 - `just test`: Runs all unit tests (platform-agnostic).

--- a/internal/core/infra/eventtap/adapter_integration_darwin_test.go
+++ b/internal/core/infra/eventtap/adapter_integration_darwin_test.go
@@ -4,13 +4,27 @@ package eventtap_test
 
 import (
 	"context"
+	"os"
+	"runtime"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/core/infra/eventtap"
 	"github.com/y3owk1n/neru/internal/core/infra/logger"
-	_ "github.com/y3owk1n/neru/internal/core/infra/platform/darwin" // Link CGO implementations
+	"github.com/y3owk1n/neru/internal/core/infra/platform/darwin" // Link CGO implementations
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
+
+// Pin the main thread during package init so TestMain still runs on it.
+func init() {
+	runtime.LockOSThread()
+}
+
+// TestMain services the macOS main run loop while the tests run. Resolving
+// hotkey strings to key codes happens on the main queue, which nothing drains
+// in a plain `go test` binary.
+func TestMain(m *testing.M) {
+	os.Exit(darwin.RunMainLoopForTesting(m.Run))
+}
 
 // TestEventTapAdapterImplementsPort verifies the adapter implements the port interface.
 func TestEventTapAdapterImplementsPort(_ *testing.T) {

--- a/internal/core/infra/hotkeys/adapter_integration_darwin_test.go
+++ b/internal/core/infra/hotkeys/adapter_integration_darwin_test.go
@@ -4,13 +4,28 @@ package hotkeys_test
 
 import (
 	"context"
+	"os"
+	"runtime"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/core/infra/hotkeys"
 	"github.com/y3owk1n/neru/internal/core/infra/logger"
-	_ "github.com/y3owk1n/neru/internal/core/infra/platform/darwin" // Link CGO implementations
+	"github.com/y3owk1n/neru/internal/core/infra/platform/darwin" // Link CGO implementations
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
+
+// Pin the main thread during package init so TestMain still runs on it.
+func init() {
+	runtime.LockOSThread()
+}
+
+// TestMain services the macOS main run loop while the tests run. Registering a
+// hotkey needs the keyboard layout maps and a CGEventTap, both of which are
+// built on the main queue; nothing drains that queue in a plain `go test`
+// binary.
+func TestMain(m *testing.M) {
+	os.Exit(darwin.RunMainLoopForTesting(m.Run))
+}
 
 // TestHotkeyAdapterImplementsPort verifies the adapter implements the port interface.
 func TestHotkeyAdapterImplementsPort(_ *testing.T) {

--- a/internal/core/infra/platform/darwin/keymap_darwin.m
+++ b/internal/core/infra/platform/darwin/keymap_darwin.m
@@ -895,6 +895,15 @@ static void waitForLayoutMapsInitialized(NSTimeInterval timeoutSeconds) {
 		}
 	}
 	[gLayoutInitCondition unlock];
+
+	// The build is dispatched to the main queue, so a timeout means the main
+	// run loop never ran it. Callers then see an empty keymap and every key
+	// name fails to resolve, which is worth saying out loud.
+	if (!atomic_load_explicit(&gLayoutMapsInitialized, memory_order_acquire)) {
+		NSLog(
+		    @"Neru: timed out after %.1fs waiting for keyboard layout maps (main run loop not running?)",
+		    timeoutSeconds);
+	}
 }
 
 /// Register notification observer (called once from initializeKeyMaps)

--- a/internal/core/infra/platform/darwin/runloop_darwin.go
+++ b/internal/core/infra/platform/darwin/runloop_darwin.go
@@ -1,0 +1,72 @@
+//go:build darwin
+
+package darwin
+
+/*
+#include <CoreFoundation/CoreFoundation.h>
+
+// Runs the main run loop for at most `seconds` and returns the CFRunLoopRunResult.
+static int neruRunMainLoopSlice(double seconds) {
+	return (int)CFRunLoopRunInMode(kCFRunLoopDefaultMode, seconds, false);
+}
+
+static void neruStopMainLoop(void) {
+	CFRunLoopStop(CFRunLoopGetMain());
+}
+*/
+import "C"
+
+import "time"
+
+// mainLoopSlice bounds how long a single run loop pump blocks before the
+// caller re-checks whether the tests finished.
+const mainLoopSlice = 100 * time.Millisecond
+
+// cfRunLoopRunFinished mirrors kCFRunLoopRunFinished: the mode had nothing left
+// to service, so CFRunLoopRunInMode returned without waiting out its timeout.
+const cfRunLoopRunFinished = 1
+
+// RunMainLoopForTesting runs testMain on a background goroutine while the
+// calling goroutine services the CoreFoundation main run loop, and returns the
+// exit code testMain produced.
+//
+// Native work Neru depends on — building the keyboard layout maps, creating a
+// CGEventTap — is dispatched to the main queue, which is only drained while the
+// main run loop runs. The daemon starts that loop (see cmd/neru), but a `go
+// test` binary never does, so without this helper those dispatches are never
+// serviced: dispatch_async work silently times out (leaving, for example, an
+// empty keymap so every key name fails to parse) and dispatch_sync deadlocks.
+// Whether a test hit that depended on which OS thread the Go scheduler happened
+// to run it on, which is what made the macOS integration tests flaky.
+//
+// Call it from TestMain, and lock the main thread from an init function in the
+// same package so TestMain is guaranteed to run on it:
+//
+//	func init() { runtime.LockOSThread() }
+//
+//	func TestMain(m *testing.M) { os.Exit(darwin.RunMainLoopForTesting(m.Run)) }
+func RunMainLoopForTesting(testMain func() int) int {
+	result := make(chan int, 1)
+
+	go func() {
+		result <- testMain()
+
+		// Cut the current pump short so the exit code is picked up
+		// immediately instead of after the remainder of the slice.
+		C.neruStopMainLoop()
+	}()
+
+	for {
+		select {
+		case code := <-result:
+			return code
+		default:
+		}
+
+		// A run loop with no sources left returns immediately; sleep out
+		// the slice instead of spinning on it.
+		if C.neruRunMainLoopSlice(C.double(mainLoopSlice.Seconds())) == cfRunLoopRunFinished {
+			time.Sleep(mainLoopSlice)
+		}
+	}
+}


### PR DESCRIPTION
## Description

The hotkey adapter integration test failed intermittently in CI, always after exactly 5.05s, complaining that a perfectly valid hotkey string could not be parsed.

The macOS keyboard layout maps are built on the main queue, and callers block up to 5 seconds waiting for that to happen. Nothing drains the main queue in a `go test` binary, so the build only ran when the Go scheduler happened to put the test on the main OS thread. When it did not, the wait timed out, the keymap stayed empty and every key name failed to resolve — hence the flakiness. The event tap integration test hit the same wait, spending 10s per run on lookups that could never succeed.

The tests now service the main run loop while they run, so the native work they depend on is actually performed. The event tap integration test drops from ~10s to under 1s as a result. Also added a log line when the layout map wait times out, since it previously handed back an empty keymap in silence, which is what made this hard to diagnose.

Daemon behaviour is unchanged: it runs the Cocoa loop, so the wait works as designed there.

## Related Issues

Fixes #1098

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The failure was reproduced deterministically by parking the main goroutine on a locked main thread, which produced the same error and the same 5s timing as CI. With the fix in place the tests always run off the main thread, so the previously flaky path is now the only path taken — verified with `-race` and repeated runs.

The macOS integration testing pattern is documented in `docs/testing/TESTING_PATTERNS.md`.
