### PR TITLE
feat(install): unify the Windows binary, add cross-platform uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ just install
 
 ---
 
-Once you're done with the installation, you can just run the `Neru.app` (macOS) or `neru launch` binary (macOS / Linux) or `neru.exe` (Windows). Neru will prompt for config initialization and accessibility permission whenever is needed.
+Once you're done with the installation, you can just run the `Neru.app` (macOS) or the `neru launch` binary (macOS / Linux / Windows). On Windows you can also start Neru from the Start Menu, which runs the same `neru.exe` without a console window. Neru will prompt for config initialization and accessibility permission whenever is needed.
 
 ---
 

--- a/cmd/neru/mousetrap_windows.go
+++ b/cmd/neru/mousetrap_windows.go
@@ -7,6 +7,7 @@ import "github.com/spf13/cobra"
 func init() {
 	// Disable cobra's Windows mousetrap, which shows "This is a command line
 	// tool..." when double-clicking from Explorer. We handle this ourselves
-	// via isRunningFromAppBundle / GetConsoleWindow.
+	// via isRunningFromAppBundle / GetConsoleProcessList, which launches the
+	// daemon instead of printing a notice.
 	cobra.MousetrapHelpText = ""
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -61,12 +61,18 @@ neru config init -c /path/to/config.toml  # Custom path
 Loaded in priority order (highest first):
 
 1. `$XDG_CONFIG_HOME/neru/config.toml`
-2. `~/.config/neru/config.toml`
-3. `~/.neru.toml` (legacy)
-4. `neru.toml` (current directory)
-5. `config.toml` (current directory)
+2. `%APPDATA%\neru\config.toml` (Windows only)
+3. `~/.config/neru/config.toml`
+4. `~/.neru.toml` (legacy)
+5. `neru.toml` (current directory)
+6. `config.toml` (current directory)
 
 Override at launch: `neru launch -c /path/to/config.toml`
+
+On Windows, `neru config init` writes to `%APPDATA%\neru\config.toml` — the
+platform convention — but `~/.config/neru/config.toml` is still read, so a config
+kept in a cross-platform dotfiles repo works as-is. Set `XDG_CONFIG_HOME` if you
+want `neru config init` and `neru config set` to write there too.
 
 ### Config Layering
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -522,7 +522,8 @@ just install   # copies neru to ~/.local/bin, offers a systemd user service,
 
 # Windows (from Git Bash): build the exe, then install it
 just build-windows
-just install   # copies neru.exe under %LOCALAPPDATA% and offers a login autostart entry
+just install   # copies neru.exe under %LOCALAPPDATA%, and offers a user PATH entry,
+               # a Start Menu shortcut, and a login autostart entry
 ```
 
 `just install` refuses to run over a Homebrew or Nix-managed install and tells you
@@ -532,6 +533,8 @@ accept them all and install everything without asking:
 ```bash
 just install -y
 ```
+
+To undo it later, see [`just uninstall`](#just-uninstall).
 
 ### Build and install manually
 
@@ -665,26 +668,109 @@ url = "https://github.com/y3owk1n/neru/releases/download/v${version}/neru-darwin
 brew uninstall --cask neru
 ```
 
+### Nix
+
+Remove the module from your configuration and rebuild.
+
+### `just uninstall`
+
+If you installed from source with `just install`, `just uninstall` undoes each of
+its steps in reverse, asking before each one. On Windows it runs under a bash such
+as Git Bash, same as the installer.
+
+```bash
+just uninstall            # interactive
+just uninstall -y         # accept every prompt
+just uninstall -y --purge # ...and delete your config and logs too
+```
+
+**Your config and logs are kept unless you pass `--purge`.** `-y` on its own can
+never delete a hand-tuned `config.toml`. With `--purge` it lists the fully
+resolved directories and asks before deleting any of them — worth reading, since
+`XDG_CONFIG_HOME` can put your config somewhere other than `~/.config`.
+
+It refuses to run over a Homebrew- or Nix-managed install and points you at the
+right removal command instead. Two things it deliberately leaves alone:
+
+- **A `/usr/local/bin/neru` that is not a symlink into the app bundle** — that is
+  a hand-installed binary, which the installer also refuses to touch.
+- **The Linux `input` group** — other evdev tools may rely on it, so it prints the
+  `gpasswd -d` line rather than dropping your membership.
+
+On macOS, the Accessibility and Input Monitoring entries stay in System Settings →
+Privacy & Security; remove them by hand if you are not reinstalling.
+
 ### Manual
+
+<details>
+<summary>macOS</summary>
 
 ```bash
 # Stop and remove launchd service (if installed)
 neru services uninstall
 
-# Remove app bundle
+# Remove app bundle and CLI
 rm -rf /Applications/Neru.app
-
-# Remove CLI
 rm /usr/local/bin/neru
 
-# Remove configuration
-rm -rf ~/.config/neru
-rm -rf ~/Library/Application\ Support/neru
+# Remove completions and man pages
+rm -f ~/.config/fish/completions/neru.fish ~/.zsh/completions/_neru \
+      ~/.local/share/bash-completion/completions/neru
+rm -f /usr/local/share/man/man1/neru*.1
 
-# Remove logs
-rm -rf ~/Library/Logs/neru
+# Remove configuration, data and logs
+rm -rf ~/.config/neru ~/Library/Application\ Support/neru ~/Library/Logs/neru
 ```
 
-### Nix
+</details>
 
-Remove the module from your configuration and rebuild.
+<details>
+<summary>Linux</summary>
+
+```bash
+# Stop and remove the systemd user service
+systemctl --user disable --now neru.service
+rm -f ~/.config/systemd/user/neru.service
+systemctl --user daemon-reload
+
+# Remove the binary
+rm -f ~/.local/bin/neru
+
+# Remove completions and man pages
+rm -f ~/.local/share/bash-completion/completions/neru ~/.zsh/completions/_neru \
+      ~/.config/fish/completions/neru.fish
+rm -f ~/.local/share/man/man1/neru*.1
+
+# Remove configuration, data and logs
+rm -rf ~/.config/neru ~/.local/share/neru ~/.local/state/neru
+
+# Only if nothing else needs it
+sudo gpasswd -d "$USER" input
+```
+
+</details>
+
+<details>
+<summary>Windows (PowerShell)</summary>
+
+```powershell
+Stop-Process -Name neru -Force -ErrorAction SilentlyContinue
+
+# Autostart and Start Menu shortcut
+Remove-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name Neru
+Remove-Item "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Neru.lnk"
+
+# Binary
+Remove-Item "$env:LOCALAPPDATA\Programs\neru" -Recurse
+
+# Configuration, data and logs
+Remove-Item "$env:APPDATA\neru" -Recurse
+Remove-Item "$env:LOCALAPPDATA\neru" -Recurse
+```
+
+Removing the PATH entry by hand is fiddly — `setx` truncates the value at 1024
+characters and flattens other tools' `%VAR%` entries. Either use
+`just uninstall`, or edit it through System Settings → *Edit environment
+variables for your account*.
+
+</details>

--- a/internal/cli/config_validate.go
+++ b/internal/cli/config_validate.go
@@ -20,7 +20,8 @@ var configValidateCmd = &cobra.Command{
 Checks for syntax errors, invalid values, and configuration conflicts.
 Useful for verifying config changes before reloading.
 By default, searches for config in standard locations for your platform
-(e.g. %APPDATA%/neru/config.toml on Windows, or $XDG_CONFIG_HOME/neru/config.toml on Unix).
+(e.g. %APPDATA%/neru/config.toml then ~/.config/neru/config.toml on Windows,
+or $XDG_CONFIG_HOME/neru/config.toml on Unix).
 Use the global --config flag to validate a specific file.`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return runConfigValidate(cmd)

--- a/internal/cli/console_other.go
+++ b/internal/cli/console_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package cli
+
+// detachConsoleIfOwned is a no-op outside Windows. Consoles are a Windows
+// concept; on macOS and Linux the daemon either inherits the terminal it was
+// started from or is started by launchd/systemd with no terminal at all.
+func detachConsoleIfOwned() {}

--- a/internal/cli/console_windows.go
+++ b/internal/cli/console_windows.go
@@ -1,0 +1,76 @@
+//go:build windows
+
+package cli
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32                  = syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleProcessList = kernel32.NewProc("GetConsoleProcessList")
+	procFreeConsole           = kernel32.NewProc("FreeConsole")
+)
+
+// consoleProcessCount returns how many processes are attached to this process's
+// console, or zero when it has none.
+//
+// neru.exe is built for the console subsystem so that every subcommand can
+// write to the terminal it was invoked from. The trade-off is that the Windows
+// shell also allocates a console when it starts the binary — from Explorer, a
+// Start Menu shortcut, or the autostart Run key. The attached-process count
+// tells the two apart: a terminal has at least the shell attached alongside
+// Neru, whereas a shell-allocated console has only Neru.
+func consoleProcessCount() uintptr {
+	// Two slots is enough to distinguish "only us" from "more than us"; the
+	// call reports the true total even when the buffer cannot hold it.
+	var pids [2]uint32
+
+	count, _, _ := procGetConsoleProcessList.Call(
+		uintptr(unsafe.Pointer(&pids[0])),
+		uintptr(len(pids)),
+	)
+
+	return count
+}
+
+// startedByShell reports whether Neru was started by the Windows shell rather
+// than typed into a terminal: either it owns its console outright, or it has no
+// console at all because a parent created it detached.
+func startedByShell() bool {
+	return consoleProcessCount() <= 1
+}
+
+// ownsConsole reports whether Neru has a console that was allocated for this
+// process alone, and so is Neru's to close.
+func ownsConsole() bool {
+	return consoleProcessCount() == 1
+}
+
+// detachConsoleIfOwned releases a console that Windows allocated for this
+// process, so the daemon does not leave a stray window on screen for the rest
+// of the session. It deliberately does nothing when Neru was started from a
+// terminal: that console belongs to the user, and `neru launch` in a terminal
+// should keep printing there.
+func detachConsoleIfOwned() {
+	if !ownsConsole() {
+		return
+	}
+
+	if ret, _, _ := procFreeConsole.Call(); ret == 0 {
+		return
+	}
+
+	// The inherited standard handles refer to the console that just went away.
+	// Point them at NUL so later writes are no-ops rather than errors.
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return
+	}
+
+	os.Stdin = devNull
+	os.Stdout = devNull
+	os.Stderr = devNull
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -152,6 +152,12 @@ func launchProgram(cmd *cobra.Command, cfgPath string) {
 		os.Exit(0)
 	}
 
+	// From here on this process is the daemon rather than a CLI client. On
+	// Windows that means giving up a console the shell allocated for us, so a
+	// Start Menu or autostart launch does not leave a window behind. No-op
+	// elsewhere, and no-op when a terminal owns the console.
+	detachConsoleIfOwned()
+
 	if LaunchFunc != nil {
 		LaunchFunc(cfgPath)
 	} else {

--- a/internal/cli/root_windows.go
+++ b/internal/cli/root_windows.go
@@ -2,19 +2,13 @@
 
 package cli
 
-import "syscall"
-
-// isRunningFromAppBundle returns true when the binary was launched via
-// double-click from Explorer (i.e., no console window).
-//
-// The Windows build uses -H windowsgui (GUI subsystem) so that double-clicking
-// does not open a console window. In that subsystem GetConsoleWindow returns
-// zero, which tells the root command to auto-launch the daemon — the same
+// isRunningFromAppBundle returns true when the binary was launched by the
+// Windows shell — double-clicked from Explorer, opened from its Start Menu
+// shortcut, or started by the autostart Run key — rather than typed into a
+// terminal. In that case the root command auto-launches the daemon, the same
 // convention used on macOS when running from a .app bundle.
+//
+// The signal is that no terminal shares Neru's console; see startedByShell.
 func isRunningFromAppBundle() bool {
-	kernel32 := syscall.NewLazyDLL("kernel32.dll")
-	procGetConsoleWindow := kernel32.NewProc("GetConsoleWindow")
-	hwnd, _, _ := procGetConsoleWindow.Call()
-
-	return hwnd == 0
+	return startedByShell()
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -547,6 +548,78 @@ func TestFindConfigFile(t *testing.T) {
 		if !filepath.IsAbs(result) {
 			t.Errorf("FindConfigFile() returned relative path: %s", result)
 		}
+	}
+}
+
+// writeConfigFile creates a minimal, valid config file at path, creating any
+// missing parent directories.
+func writeConfigFile(t *testing.T, path string) {
+	t.Helper()
+
+	mkdirErr := os.MkdirAll(filepath.Dir(path), 0o755)
+	if mkdirErr != nil {
+		t.Fatalf("MkdirAll(%q) failed: %v", filepath.Dir(path), mkdirErr)
+	}
+
+	writeErr := os.WriteFile(path, []byte("[hints]\n"), 0o600)
+	if writeErr != nil {
+		t.Fatalf("WriteFile(%q) failed: %v", path, writeErr)
+	}
+}
+
+// TestFindConfigFile_DotConfigFallback pins that ~/.config/neru/config.toml is
+// discovered even when it is not the preferred directory. On Windows the
+// preferred directory is %APPDATA%\neru, so this is what lets a config carried
+// over from a Unix dotfiles repo work without setting XDG_CONFIG_HOME.
+func TestFindConfigFile_DotConfigFallback(t *testing.T) {
+	homeDir := t.TempDir()
+	preferredDir := t.TempDir()
+
+	// Point the preferred directory at an empty location, and os.UserHomeDir
+	// at ours: it reads USERPROFILE on Windows and HOME on Unix.
+	if runtime.GOOS == goosWindows {
+		t.Setenv("XDG_CONFIG_HOME", "")
+		t.Setenv("APPDATA", preferredDir)
+		t.Setenv("USERPROFILE", homeDir)
+	} else {
+		t.Setenv("XDG_CONFIG_HOME", preferredDir)
+		t.Setenv("HOME", homeDir)
+	}
+
+	dotConfig := filepath.Join(homeDir, ".config", "neru", "config.toml")
+	writeConfigFile(t, dotConfig)
+
+	service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+	if got := service.FindConfigFile(); got != dotConfig {
+		t.Errorf("FindConfigFile() = %q, want %q", got, dotConfig)
+	}
+}
+
+// TestFindConfigFile_PrefersPreferredDir pins that the ~/.config fallback does
+// not shadow the platform's preferred directory when both exist.
+func TestFindConfigFile_PrefersPreferredDir(t *testing.T) {
+	homeDir := t.TempDir()
+	preferredDir := t.TempDir()
+
+	if runtime.GOOS == goosWindows {
+		t.Setenv("XDG_CONFIG_HOME", "")
+		t.Setenv("APPDATA", preferredDir)
+		t.Setenv("USERPROFILE", homeDir)
+	} else {
+		t.Setenv("XDG_CONFIG_HOME", preferredDir)
+		t.Setenv("HOME", homeDir)
+	}
+
+	preferred := filepath.Join(preferredDir, "neru", "config.toml")
+	dotConfig := filepath.Join(homeDir, ".config", "neru", "config.toml")
+
+	for _, path := range []string{preferred, dotConfig} {
+		writeConfigFile(t, path)
+	}
+
+	service := config.NewService(config.DefaultConfig(), "", zap.NewNop(), nil)
+	if got := service.FindConfigFile(); got != preferred {
+		t.Errorf("FindConfigFile() = %q, want %q", got, preferred)
 	}
 }
 

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -690,7 +690,9 @@ func (s *Service) LoadWithValidation(path string) *LoadResult {
 // The $XDG_CONFIG_HOME environment variable is also respected on Windows when set,
 // for users of cross-platform shell environments.
 // This is the single source of truth for the primary config location,
-// used by both FindConfigFile and config init.
+// used by both FindConfigFile and config init. It is where a config file is
+// written; FindConfigFile additionally reads ~/.config/neru on Windows, so a
+// config carried over from a Unix dotfiles repo is still picked up.
 func DefaultConfigDir() (string, error) {
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
 		return filepath.Join(xdg, "neru"), nil
@@ -721,9 +723,14 @@ func DefaultConfigDir() (string, error) {
 // FindConfigFile searches for a configuration file in standard locations.
 // Returns the path to the config file, or an empty string if not found.
 func (s *Service) FindConfigFile() string {
-	// Try preferred config directory first (XDG_CONFIG_HOME or ~/.config)
+	// Try preferred config directory first (XDG_CONFIG_HOME, %APPDATA% on
+	// Windows, or ~/.config)
+	preferredDir := ""
+
 	configDir, dirErr := DefaultConfigDir()
 	if dirErr == nil {
+		preferredDir = configDir
+
 		path := filepath.Join(configDir, "config.toml")
 		if found := s.tryConfigPath(path); found != "" {
 			return found
@@ -732,11 +739,19 @@ func (s *Service) FindConfigFile() string {
 		s.logger.Warn("Failed to determine config directory", zap.Error(dirErr))
 	}
 
-	// When XDG_CONFIG_HOME is set, also check ~/.config as a fallback
-	if os.Getenv("XDG_CONFIG_HOME") != "" {
-		homeDir, homeErr := os.UserHomeDir()
-		if homeErr == nil {
-			path := filepath.Join(homeDir, ".config", "neru", "config.toml")
+	homeDir, homeErr := os.UserHomeDir()
+	if homeErr != nil {
+		s.logger.Warn("Failed to get user home directory", zap.Error(homeErr))
+	}
+
+	// Also check ~/.config/neru whenever it is not already the preferred
+	// directory. That covers XDG_CONFIG_HOME pointing elsewhere, and Windows,
+	// where the preferred directory is %APPDATA%\neru — cross-platform
+	// dotfiles keep working there without setting XDG_CONFIG_HOME.
+	if homeErr == nil {
+		dotConfigDir := filepath.Join(homeDir, ".config", "neru")
+		if dotConfigDir != preferredDir {
+			path := filepath.Join(dotConfigDir, "config.toml")
 			if found := s.tryConfigPath(path); found != "" {
 				return found
 			}
@@ -744,15 +759,12 @@ func (s *Service) FindConfigFile() string {
 	}
 
 	// Try legacy and current-directory locations
-	homeDir, homeErr := os.UserHomeDir()
 	if homeErr == nil {
 		// Try .neru.toml
 		path := filepath.Join(homeDir, ".neru.toml")
 		if found := s.tryConfigPath(path); found != "" {
 			return found
 		}
-	} else {
-		s.logger.Warn("Failed to get user home directory", zap.Error(homeErr))
 	}
 
 	// Try current directory

--- a/justfile
+++ b/justfile
@@ -8,10 +8,13 @@ BUILD_DATE := `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 # macOS deployment target (used in CGO CFLAGS and as an env var for clang/ld).
 MACOSX_DEPLOYMENT_TARGET := "14.0"
 
-# Ldflags for version injection; Windows uses GUI subsystem (no console window).
+# Ldflags for version injection. Windows deliberately builds for the console
+# subsystem (no -H windowsgui) so a single neru.exe serves as both the CLI and
+# the daemon: subcommands can write to the terminal they were typed into, and
+# the daemon frees the console the shell allocated for it (see
+# internal/cli/console_windows.go).
 
 LDFLAGS := "-s -w -X github.com/y3owk1n/neru/internal/cli.Version=" + VERSION + " -X github.com/y3owk1n/neru/internal/cli.GitCommit=" + GIT_COMMIT + " -X github.com/y3owk1n/neru/internal/cli.BuildDate=" + BUILD_DATE
-WIN_LDFLAGS := "-H windowsgui -s -w -X github.com/y3owk1n/neru/internal/cli.Version=" + VERSION + " -X github.com/y3owk1n/neru/internal/cli.GitCommit=" + GIT_COMMIT + " -X github.com/y3owk1n/neru/internal/cli.BuildDate=" + BUILD_DATE
 
 # Default build
 default: build
@@ -23,7 +26,7 @@ default: build
 build:
     @echo "Building Neru..."
     @echo "Version: {{ VERSION }}"
-    {{ if os() == "windows" { "CGO_ENABLED=0" } else { "CGO_ENABLED=1" } }} go build -ldflags="{{ if os() == "windows" { WIN_LDFLAGS } else { LDFLAGS } }}" -o bin/neru{{ if os() == "windows" { ".exe" } else { "" } }} ./cmd/neru
+    {{ if os() == "windows" { "CGO_ENABLED=0" } else { "CGO_ENABLED=1" } }} go build -ldflags="{{ LDFLAGS }}" -o bin/neru{{ if os() == "windows" { ".exe" } else { "" } }} ./cmd/neru
     @echo "✓ Build complete: bin/neru"
 
 # Build a Linux binary. Must run on a Linux host (CGO required for native backends).
@@ -58,7 +61,7 @@ build-windows ARCH="amd64":
     @echo "Building Neru for windows/{{ ARCH }}..."
     mkdir -p bin
     just generate-winres {{ ARCH }}
-    CGO_ENABLED=0 GOOS=windows GOARCH={{ ARCH }} go build -ldflags="{{ WIN_LDFLAGS }}" -o bin/neru-windows-{{ ARCH }}.exe ./cmd/neru
+    CGO_ENABLED=0 GOOS=windows GOARCH={{ ARCH }} go build -ldflags="{{ LDFLAGS }}" -o bin/neru-windows-{{ ARCH }}.exe ./cmd/neru
     @echo "✓ Build complete: bin/neru-windows-{{ ARCH }}.exe"
 
 # Build a macOS binary for the current host.
@@ -119,7 +122,7 @@ release-ci-windows ARCH VERSION_OVERRIDE:
     @echo "Date: {{ BUILD_DATE }}"
     mkdir -p bin
     just generate-winres {{ ARCH }}
-    CGO_ENABLED=0 GOOS=windows GOARCH={{ ARCH }} go build -ldflags="-H windowsgui -s -w -X github.com/y3owk1n/neru/internal/cli.Version={{ VERSION_OVERRIDE }} -X github.com/y3owk1n/neru/internal/cli.GitCommit={{ GIT_COMMIT }} -X github.com/y3owk1n/neru/internal/cli.BuildDate={{ BUILD_DATE }}" -trimpath -o bin/neru-windows-{{ ARCH }}.exe ./cmd/neru
+    CGO_ENABLED=0 GOOS=windows GOARCH={{ ARCH }} go build -ldflags="-s -w -X github.com/y3owk1n/neru/internal/cli.Version={{ VERSION_OVERRIDE }} -X github.com/y3owk1n/neru/internal/cli.GitCommit={{ GIT_COMMIT }} -X github.com/y3owk1n/neru/internal/cli.BuildDate={{ BUILD_DATE }}" -trimpath -o bin/neru-windows-{{ ARCH }}.exe ./cmd/neru
     @echo "✓ Release artifact for windows/{{ ARCH }} built successfully"
 
 # Bundle the application
@@ -148,6 +151,21 @@ install *ARGS:
     script="{{ justfile_directory() }}/scripts/install-{{ os() }}.sh"
     if [ ! -f "$script" ]; then
         echo "just install: unsupported platform '{{ os() }}'" >&2
+        exit 1
+    fi
+    exec bash "$script" {{ ARGS }}
+
+# Remove a Neru installed by `just install`, undoing each of its steps in
+# reverse. Dispatches to the per-platform script in scripts/. Pass -y to accept
+# every prompt non-interactively, and --purge to also remove your config and
+# logs (they are kept otherwise, so -y alone can never delete your config.toml).
+# On Windows this runs under a bash such as Git Bash.
+uninstall *ARGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    script="{{ justfile_directory() }}/scripts/uninstall-{{ os() }}.sh"
+    if [ ! -f "$script" ]; then
+        echo "just uninstall: unsupported platform '{{ os() }}'" >&2
         exit 1
     fi
     exec bash "$script" {{ ARGS }}

--- a/scripts/install-windows.sh
+++ b/scripts/install-windows.sh
@@ -29,15 +29,36 @@ ask() {
     printf '%s' "$reply"
 }
 
+# win_path prints the Windows form (C:\Users\...) of a POSIX path. Everything
+# Windows-facing needs it: PATH entries, shortcut targets, registry values, and
+# anything we print for the user to copy. Git Bash's /c/Users/... form is not a
+# path Windows itself understands.
+win_path() {
+    cygpath -w "$1" 2>/dev/null || printf '%s' "$1"
+}
 
-# Minimal Windows install: a per-user binary plus optional autostart via
-# the registry Run key. Windows has no launchd or systemd and `neru
-# services` is macOS-only, so autostart is authored here, not by Neru.
-# Runs under a bash (e.g. Git Bash); `just` needs cygpath on PATH to
-# translate the shebang, and reg is called with MSYS2_ARG_CONV_EXCL so
-# its /flags are not path-mangled. Windows support is partial (grid,
-# recursive grid, scroll, hotkeys, mouse injection, UIA); see
-# docs/CROSS_PLATFORM.md.
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# run_ps runs a PowerShell script supplied on stdin, passing any extra
+# arguments through to it. The script is staged in a temp file and run with
+# -File rather than passed inline with -Command so that bash, MSYS path
+# mangling and PowerShell quoting never have to agree with each other.
+run_ps() {
+    local script="$tmp_dir/step.ps1"
+    cat >"$script"
+    MSYS2_ARG_CONV_EXCL='*' powershell -NoProfile -NonInteractive \
+        -ExecutionPolicy Bypass -File "$(win_path "$script")" "$@"
+}
+
+# Minimal Windows install: a per-user binary, a Start Menu shortcut so Neru is
+# searchable from the taskbar like any other app, and optional autostart via
+# the registry Run key. Windows has no launchd or systemd and `neru services`
+# is macOS-only, so autostart is authored here, not by Neru. Runs under a bash
+# (e.g. Git Bash); `just` needs cygpath on PATH to translate the shebang, and
+# reg is called with MSYS2_ARG_CONV_EXCL so its /flags are not path-mangled.
+# Windows support is partial (grid, recursive grid, scroll, hotkeys, mouse
+# injection, UIA); see docs/CROSS_PLATFORM.md.
 arch="$(uname -m)"
 case "$arch" in
     aarch64 | arm64) arch=arm64 ;;
@@ -53,26 +74,142 @@ if [ ! -f "$exe_src" ]; then
     esac
 fi
 
-# Step 1: the binary, to a per-user location. Editing PATH from a script
-# is error-prone, so print the directory to add rather than modifying it.
-echo "Step 1/2: Binary"
-dst_dir="${LOCALAPPDATA:-$HOME/AppData/Local}/Programs/neru"
+# Step 1: the binary, to a per-user location. One neru.exe serves as both the
+# CLI and the daemon: it is built for the console subsystem so subcommands can
+# print to the terminal, and it frees the console when the shell started it.
+echo "Step 1/4: Binary"
+dst_dir="$(cygpath -u "${LOCALAPPDATA:-$HOME/AppData/Local}")/Programs/neru"
 mkdir -p "$dst_dir"
 cp "$exe_src" "$dst_dir/neru.exe"
-echo "✓ Installed $dst_dir/neru.exe"
-echo "  Add this directory to your PATH if it is not already:"
-echo "      $dst_dir"
+dst_exe="$dst_dir/neru.exe"
+win_dst_dir="$(win_path "$dst_dir")"
+win_dst_exe="$(win_path "$dst_exe")"
+echo "✓ Installed $win_dst_exe"
 
-# Step 2: autostart via the per-user Run key (no admin). Uses the full
+# Step 2: PATH. Offered rather than applied silently, matching the macOS and
+# Linux installers. Windows has no shell rc file to edit by hand, so the offer
+# writes the per-user Environment key directly instead of using setx, which
+# truncates the value at 1024 characters.
+echo "Step 2/4: PATH"
+on_path=""
+if resolved="$(command -v neru.exe 2>/dev/null)"; then
+    on_path="$(cygpath -u "$resolved" 2>/dev/null || printf '%s' "$resolved")"
+fi
+if [ "$on_path" = "$dst_exe" ]; then
+    echo "✓ neru is already on PATH"
+else
+    path_reply="$(ask "Add $win_dst_dir to your user PATH? [y/N] ")"
+    case "$path_reply" in
+        [Yy] | [Yy][Ee][Ss])
+            if path_result="$(run_ps "$win_dst_dir" <<'PS'
+param([Parameter(Mandatory = $true)][string]$Dir)
+$ErrorActionPreference = 'Stop'
+
+$key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+try {
+    # Read the raw value: an existing REG_EXPAND_SZ entry such as
+    # %USERPROFILE%\bin must be written back unexpanded, and its kind
+    # preserved, or every other tool's PATH entry silently freezes.
+    $kind = [Microsoft.Win32.RegistryValueKind]::ExpandString
+    $current = ''
+    if ($key.GetValueNames() -contains 'Path') {
+        $current = [string]$key.GetValue('Path', '', 'DoNotExpandEnvironmentNames')
+        $kind = $key.GetValueKind('Path')
+    }
+
+    $entries = @($current -split ';' | Where-Object { $_ -ne '' })
+    if ($entries -contains $Dir) {
+        Write-Output 'already'
+        exit 0
+    }
+
+    $key.SetValue('Path', (($entries + $Dir) -join ';'), $kind)
+} finally {
+    $key.Close()
+}
+
+# Tell already-running processes (Explorer above all) to reread the
+# environment, so a shell opened afterwards sees the new entry without a
+# sign-out. Without this the change only lands on the next login.
+Add-Type -Namespace Neru -Name Env -MemberDefinition @'
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg,
+    UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout,
+    out UIntPtr lpdwResult);
+'@
+$result = [UIntPtr]::Zero
+[void][Neru.Env]::SendMessageTimeout([IntPtr]0xffff, 0x1A, [UIntPtr]::Zero,
+    'Environment', 0x2, 5000, [ref]$result)
+
+Write-Output 'added'
+PS
+            )"; then
+                if [ "${path_result%$'\r'}" = "already" ]; then
+                    echo "✓ Already on your user PATH (open a new terminal to pick it up)"
+                else
+                    echo "✓ Added to your user PATH (open a new terminal to pick it up)"
+                fi
+            else
+                echo "Could not update PATH; add this directory yourself:" >&2
+                echo "      $win_dst_dir" >&2
+            fi
+            ;;
+        *)
+            echo "Skipped. Add this directory to your PATH to run 'neru' from anywhere:"
+            echo "      $win_dst_dir"
+            ;;
+    esac
+fi
+
+# Step 3: Start Menu shortcut. This, not PATH, is what makes an app searchable
+# from the taskbar — Windows Search indexes the per-user Start Menu folder.
+echo "Step 3/4: Start Menu"
+menu_reply="$(ask "Add a Start Menu shortcut (searchable from the taskbar)? [y/N] ")"
+case "$menu_reply" in
+    [Yy] | [Yy][Ee][Ss])
+        if link="$(run_ps "$win_dst_exe" <<'PS'
+param([Parameter(Mandatory = $true)][string]$Exe)
+$ErrorActionPreference = 'Stop'
+
+$dir = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
+New-Item -ItemType Directory -Force -Path $dir | Out-Null
+$link = Join-Path $dir 'Neru.lnk'
+
+$shortcut = (New-Object -ComObject WScript.Shell).CreateShortcut($link)
+$shortcut.TargetPath = $Exe
+$shortcut.Arguments = 'launch'
+$shortcut.WorkingDirectory = Split-Path -Parent $Exe
+$shortcut.IconLocation = $Exe
+$shortcut.Description = 'Neru - keyboard-driven navigation'
+# Minimized: neru.exe is a console-subsystem binary, so Windows allocates a
+# console before main runs. Neru frees it immediately, and starting minimized
+# keeps even that moment off the screen.
+$shortcut.WindowStyle = 7
+$shortcut.Save()
+
+Write-Output $link
+PS
+        )"; then
+            echo "✓ Neru is now searchable from the taskbar"
+            echo "  Shortcut: ${link%$'\r'}"
+        else
+            echo "Could not create the Start Menu shortcut." >&2
+        fi
+        ;;
+    *)
+        echo "Skipped Start Menu shortcut."
+        ;;
+esac
+
+# Step 4: autostart via the per-user Run key (no admin). Uses the full
 # exe path, so it does not depend on PATH.
-echo "Step 2/2: Autostart"
+echo "Step 4/4: Autostart"
 run_reply="$(ask "Start Neru at login (a registry Run entry)? [y/N] ")"
 case "$run_reply" in
     [Yy] | [Yy][Ee][Ss])
-        win_exe="$(cygpath -w "$dst_dir/neru.exe" 2>/dev/null || echo "$dst_dir/neru.exe")"
         # MSYS2_ARG_CONV_EXCL='*' stops Git Bash from rewriting reg's
         # /v /t /d /f flags (and the HKCU\... key) as POSIX paths.
-        if MSYS2_ARG_CONV_EXCL='*' reg add "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run" /v Neru /t REG_SZ /d "\"$win_exe\" launch" /f >/dev/null 2>&1; then
+        if MSYS2_ARG_CONV_EXCL='*' reg add "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run" /v Neru /t REG_SZ /d "\"$win_dst_exe\" launch" /f >/dev/null 2>&1; then
             echo "✓ Neru will start at login"
             echo "  Remove later with: MSYS2_ARG_CONV_EXCL='*' reg delete \"HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\" /v Neru /f"
         else
@@ -80,7 +217,7 @@ case "$run_reply" in
         fi
         ;;
     *)
-        echo "Skipped autostart. Start Neru with: neru.exe launch"
+        echo "Skipped autostart. Start Neru with: neru launch"
         ;;
 esac
 echo "Windows support is partial; see docs/CROSS_PLATFORM.md."

--- a/scripts/uninstall-linux.sh
+++ b/scripts/uninstall-linux.sh
@@ -106,7 +106,9 @@ for comp in \
         comp_found=1
     fi
 done
-[ "$comp_found" -eq 0 ] && echo "  No completions found"
+if [ "$comp_found" -eq 0 ]; then
+    echo "  No completions found"
+fi
 
 # Step 5: man pages. Only Neru's own pages, never the directory itself.
 echo "Step 5/5: Man pages"

--- a/scripts/uninstall-linux.sh
+++ b/scripts/uninstall-linux.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# neru Linux uninstaller. Invoked by `just uninstall`; can also be run
+# directly from the repo root. Undoes scripts/install-linux.sh in reverse.
+set -euo pipefail
+
+# Run from the repo root so build/, bin/, and `just` resolve.
+cd "$(dirname "$0")/.."
+
+# -y / --yes auto-accepts every prompt. --purge additionally offers to delete
+# your config and logs; without it they are never touched, so -y on its own can
+# never destroy a hand-tuned config.toml.
+assume_yes=0
+purge=0
+for arg in "$@"; do
+    case "$arg" in
+        -y | --yes) assume_yes=1 ;;
+        --purge) purge=1 ;;
+        *) echo "unknown argument: $arg (use -y to auto-accept prompts, --purge to also remove config and logs)" >&2; exit 2 ;;
+    esac
+done
+
+# ask "prompt" -> prints the reply on stdout. Under -y it echoes the prompt with
+# a "y" and answers yes without reading, so the whole run is non-interactive.
+ask() {
+    if [ "$assume_yes" -eq 1 ]; then
+        printf '%sy\n' "$1" >&2
+        printf 'y'
+        return 0
+    fi
+    local reply
+    read -r -p "$1" reply || reply=""
+    printf '%s' "$reply"
+}
+
+# purge_list accumulates "label|dir" lines for the directories that actually
+# exist. Collecting them before deleting anything is what lets the prompt show
+# the fully resolved paths: XDG_CONFIG_HOME can point the config directory
+# somewhere other than $HOME, and you should see where before saying yes.
+purge_list=""
+note_purge_target() {
+    [ -d "$2" ] && purge_list="$purge_list$1|$2"$'\n'
+    return 0
+}
+
+bin_dir="$HOME/.local/bin"
+neru_bin="$bin_dir/neru"
+unit_dir="$HOME/.config/systemd/user"
+unit_file="$unit_dir/neru.service"
+
+echo "This removes $neru_bin and the systemd user service, completions and man"
+echo "pages that 'just install' created."
+if [ "$purge" -eq 0 ]; then
+    echo "Your config and logs are kept; pass --purge to remove those too."
+fi
+
+# Step 1: the systemd user service and any running instance. Done first:
+# Restart=on-failure would otherwise respawn Neru from a binary we then delete.
+echo "Step 1/5: systemd user service"
+if [ -e "$unit_file" ]; then
+    systemctl --user disable --now neru.service >/dev/null 2>&1 || true
+    rm -f "$unit_file"
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+    echo "✓ Stopped and removed $unit_file"
+else
+    echo "  No unit at $unit_file"
+fi
+# A manually started daemon is not known to systemd, so stop it separately.
+if pkill -f "$neru_bin launch" >/dev/null 2>&1; then
+    echo "✓ Stopped a running Neru"
+fi
+
+# Step 2: the binary.
+echo "Step 2/5: Binary"
+if [ -e "$neru_bin" ]; then
+    rm -f "$neru_bin"
+    echo "✓ Removed $neru_bin"
+else
+    echo "  No binary at $neru_bin"
+fi
+
+# Step 3: the input group. Deliberately NOT reverted. Membership is a
+# system-level change that other tools (other evdev readers, input remappers)
+# may equally depend on, and dropping it could break them silently. Print the
+# command instead and let the user decide.
+echo "Step 3/5: input group (Wayland)"
+if id -nG 2>/dev/null | tr ' ' '\n' | grep -qx input; then
+    echo "  You are still in the 'input' group; left as-is, since other tools may"
+    echo "  rely on it. Remove it yourself if nothing else needs it:"
+    echo "      sudo gpasswd -d \$USER input"
+else
+    echo "  Not in the 'input' group"
+fi
+
+# Step 4: shell completions, from the same per-user locations the installer
+# writes to.
+echo "Step 4/5: Shell completions"
+comp_found=0
+for comp in \
+    "$HOME/.local/share/bash-completion/completions/neru" \
+    "$HOME/.zsh/completions/_neru" \
+    "$HOME/.config/fish/completions/neru.fish"; do
+    if [ -e "$comp" ]; then
+        rm -f "$comp"
+        echo "✓ Removed $comp"
+        comp_found=1
+    fi
+done
+[ "$comp_found" -eq 0 ] && echo "  No completions found"
+
+# Step 5: man pages. Only Neru's own pages, never the directory itself.
+echo "Step 5/5: Man pages"
+man_dir="$HOME/.local/share/man/man1"
+# shellcheck disable=SC2086 # deliberate glob expansion
+set -- "$man_dir"/neru*.1
+if [ -e "$1" ]; then
+    rm -f "$@"
+    echo "✓ Removed man pages from $man_dir"
+else
+    echo "  No man pages found"
+fi
+
+# Config and logs. Opt-in via --purge, and still confirmed, because a
+# hand-tuned config.toml is the one thing here that cannot be rebuilt.
+echo "Config and logs"
+if [ "$purge" -eq 0 ]; then
+    echo "  Kept. Pass --purge to remove your config and logs too."
+else
+    note_purge_target "config" "${XDG_CONFIG_HOME:-$HOME/.config}/neru"
+    note_purge_target "application data" "$HOME/.local/share/neru"
+    note_purge_target "state and logs" "$HOME/.local/state/neru"
+
+    if [ -z "$purge_list" ]; then
+        echo "  Nothing to remove."
+    else
+        echo "  These directories will be permanently deleted:"
+        while IFS='|' read -r label dir; do
+            [ -n "$dir" ] || continue
+            echo "      $dir  ($label)"
+        done <<< "$purge_list"
+
+        purge_reply="$(ask "Delete them? [y/N] ")"
+        case "$purge_reply" in
+            [Yy] | [Yy][Ee][Ss])
+                while IFS='|' read -r label dir; do
+                    [ -n "$dir" ] || continue
+                    rm -rf "$dir"
+                    echo "✓ Removed $label: $dir"
+                done <<< "$purge_list"
+                ;;
+            *)
+                echo "  Kept your config and logs."
+                ;;
+        esac
+    fi
+fi
+
+echo "Neru has been uninstalled."

--- a/scripts/uninstall-macos.sh
+++ b/scripts/uninstall-macos.sh
@@ -137,7 +137,9 @@ for comp in \
         comp_found=1
     fi
 done
-[ "$comp_found" -eq 0 ] && echo "  No completions found"
+if [ "$comp_found" -eq 0 ]; then
+    echo "  No completions found"
+fi
 
 # Step 5: man pages. The installer picks whichever manpath directory was
 # writable, so scan the same set and remove only Neru's own pages — never the
@@ -156,7 +158,9 @@ for man_base in $(manpath 2>/dev/null | tr ':' ' ') "/usr/local/share/man"; do
     echo "✓ Removed man pages from $man_dir"
     man_found=1
 done
-[ "$man_found" -eq 0 ] && echo "  No man pages found"
+if [ "$man_found" -eq 0 ]; then
+    echo "  No man pages found"
+fi
 
 # Config and logs. Opt-in via --purge, and still confirmed, because a
 # hand-tuned config.toml is the one thing here that cannot be rebuilt.

--- a/scripts/uninstall-macos.sh
+++ b/scripts/uninstall-macos.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# neru macOS uninstaller. Invoked by `just uninstall`; can also be run
+# directly from the repo root. Undoes scripts/install-macos.sh in reverse.
+set -euo pipefail
+
+# Run from the repo root so build/, bin/, and `just` resolve.
+cd "$(dirname "$0")/.."
+
+# -y / --yes auto-accepts every prompt. --purge additionally offers to delete
+# your config and logs; without it they are never touched, so -y on its own can
+# never destroy a hand-tuned config.toml.
+assume_yes=0
+purge=0
+for arg in "$@"; do
+    case "$arg" in
+        -y | --yes) assume_yes=1 ;;
+        --purge) purge=1 ;;
+        *) echo "unknown argument: $arg (use -y to auto-accept prompts, --purge to also remove config and logs)" >&2; exit 2 ;;
+    esac
+done
+
+# ask "prompt" -> prints the reply on stdout. Under -y it echoes the prompt with
+# a "y" and answers yes without reading, so the whole run is non-interactive.
+ask() {
+    if [ "$assume_yes" -eq 1 ]; then
+        printf '%sy\n' "$1" >&2
+        printf 'y'
+        return 0
+    fi
+    local reply
+    read -r -p "$1" reply || reply=""
+    printf '%s' "$reply"
+}
+
+# purge_list accumulates "label|dir" lines for the directories that actually
+# exist. Collecting them before deleting anything is what lets the prompt show
+# the fully resolved paths: XDG_CONFIG_HOME can point the config directory
+# somewhere other than $HOME, and you should see where before saying yes.
+purge_list=""
+note_purge_target() {
+    [ -d "$2" ] && purge_list="$purge_list$1|$2"$'\n'
+    return 0
+}
+
+app_dst="/Applications/Neru.app"
+neru_bin="$app_dst/Contents/MacOS/neru"
+link_dst="/usr/local/bin/neru"
+
+# Refuse to fight another installer, the same stance the install recipe takes.
+# Homebrew's cask owns /Applications/Neru.app and the PATH symlink, and on disk
+# its app is indistinguishable from a source install, so asking brew is the only
+# reliable signal about who the files belong to.
+if command -v brew >/dev/null 2>&1 && brew list --cask 2>/dev/null | grep -qxE 'neru|neru-nightly'; then
+    echo "Neru is installed with Homebrew; this script would delete files brew tracks." >&2
+    echo "Remove it with:  brew uninstall --cask y3owk1n/tap/neru" >&2
+    exit 1
+fi
+# A Nix-managed install keeps its app inside the store rather than
+# /Applications, so the check above never sees it. Its login agent does show up
+# under a nix label, which is the signal to send the user to their config.
+for plist in \
+    "$HOME/Library/LaunchAgents/"org.nixos.*neru*.plist \
+    "$HOME/Library/LaunchAgents/"org.nix-community.*neru*.plist \
+    "/Library/LaunchAgents/"org.nixos.*neru*.plist; do
+    [ -e "$plist" ] || continue
+    echo "Neru is managed by nix-darwin or home-manager:" >&2
+    echo "    plist: $plist" >&2
+    echo "Remove Neru from that configuration and rebuild instead." >&2
+    exit 1
+done
+
+echo "This removes $app_dst and the login agent, PATH symlink, completions"
+echo "and man pages that 'just install' created."
+if [ "$purge" -eq 0 ]; then
+    echo "Your config and logs are kept; pass --purge to remove those too."
+fi
+
+# Step 1: the login agent and any running instance. Done first: a KeepAlive
+# agent would respawn Neru from an app bundle we are about to delete.
+echo "Step 1/5: Login agent"
+if [ -x "$neru_bin" ]; then
+    "$neru_bin" services uninstall >/dev/null 2>&1 || true
+fi
+# A detached "run now" instance from an earlier install is not known to
+# launchd, so kill it separately.
+pkill -f "$app_dst/Contents/MacOS/neru launch" >/dev/null 2>&1 || true
+echo "✓ Login agent unloaded and any running Neru stopped"
+
+# Step 2: the app bundle. Uses sudo when /Applications is not writable, the
+# same escalation the installer uses to put it there.
+echo "Step 2/5: App bundle"
+if [ -e "$app_dst" ]; then
+    app_reply="$(ask "Delete $app_dst? [y/N] ")"
+    case "$app_reply" in
+        [Yy] | [Yy][Ee][Ss])
+            app_sudo=""
+            [ -w "/Applications" ] || app_sudo="sudo"
+            $app_sudo rm -rf "$app_dst"
+            echo "✓ Removed $app_dst"
+            ;;
+        *)
+            echo "  Kept $app_dst"
+            ;;
+    esac
+else
+    echo "  No app bundle at $app_dst"
+fi
+
+# Step 3: the PATH symlink. Only removed when it actually points into the app
+# bundle we installed; a real file there is a hand-installed binary the
+# installer also refuses to touch, so leave it alone.
+echo "Step 3/5: CLI on PATH"
+if [ -L "$link_dst" ] && [ "$(readlink "$link_dst")" = "$neru_bin" ]; then
+    link_sudo=""
+    [ -w "$(dirname "$link_dst")" ] || link_sudo="sudo"
+    $link_sudo rm -f "$link_dst"
+    echo "✓ Removed $link_dst"
+elif [ -e "$link_dst" ] || [ -L "$link_dst" ]; then
+    echo "  Kept $link_dst: it is not a symlink to $neru_bin"
+    echo "  (a hand-installed binary, or another installer's). Remove it yourself if you want it gone."
+else
+    echo "  No symlink at $link_dst"
+fi
+
+# Step 4: shell completions, from the same per-user locations the installer
+# writes to.
+echo "Step 4/5: Shell completions"
+comp_found=0
+for comp in \
+    "$HOME/.config/fish/completions/neru.fish" \
+    "$HOME/.zsh/completions/_neru" \
+    "$HOME/.local/share/bash-completion/completions/neru"; do
+    if [ -e "$comp" ]; then
+        rm -f "$comp"
+        echo "✓ Removed $comp"
+        comp_found=1
+    fi
+done
+[ "$comp_found" -eq 0 ] && echo "  No completions found"
+
+# Step 5: man pages. The installer picks whichever manpath directory was
+# writable, so scan the same set and remove only Neru's own pages — never the
+# directory, which belongs to the system.
+echo "Step 5/5: Man pages"
+man_found=0
+for man_base in $(manpath 2>/dev/null | tr ':' ' ') "/usr/local/share/man"; do
+    man_dir="$man_base/man1"
+    [ -d "$man_dir" ] || continue
+    # shellcheck disable=SC2086 # deliberate glob expansion
+    set -- "$man_dir"/neru*.1
+    [ -e "$1" ] || continue
+    man_sudo=""
+    [ -w "$man_dir" ] || man_sudo="sudo"
+    $man_sudo rm -f "$@"
+    echo "✓ Removed man pages from $man_dir"
+    man_found=1
+done
+[ "$man_found" -eq 0 ] && echo "  No man pages found"
+
+# Config and logs. Opt-in via --purge, and still confirmed, because a
+# hand-tuned config.toml is the one thing here that cannot be rebuilt.
+echo "Config and logs"
+if [ "$purge" -eq 0 ]; then
+    echo "  Kept. Pass --purge to remove your config and logs too."
+else
+    note_purge_target "config" "${XDG_CONFIG_HOME:-$HOME/.config}/neru"
+    note_purge_target "application data" "$HOME/Library/Application Support/neru"
+    note_purge_target "logs" "$HOME/Library/Logs/neru"
+
+    if [ -z "$purge_list" ]; then
+        echo "  Nothing to remove."
+    else
+        echo "  These directories will be permanently deleted:"
+        while IFS='|' read -r label dir; do
+            [ -n "$dir" ] || continue
+            echo "      $dir  ($label)"
+        done <<< "$purge_list"
+
+        purge_reply="$(ask "Delete them? [y/N] ")"
+        case "$purge_reply" in
+            [Yy] | [Yy][Ee][Ss])
+                while IFS='|' read -r label dir; do
+                    [ -n "$dir" ] || continue
+                    rm -rf "$dir"
+                    echo "✓ Removed $label: $dir"
+                done <<< "$purge_list"
+                ;;
+            *)
+                echo "  Kept your config and logs."
+                ;;
+        esac
+    fi
+fi
+
+echo "Neru has been uninstalled."
+echo "macOS keeps its Accessibility and Input Monitoring entries; remove them in"
+echo "System Settings → Privacy & Security if you are not reinstalling."

--- a/scripts/uninstall-windows.sh
+++ b/scripts/uninstall-windows.sh
@@ -75,12 +75,32 @@ if [ "$purge" -eq 0 ]; then
 fi
 
 # Step 0: stop a running Neru. Windows locks the image of a running process, so
-# the binary in step 4 cannot be deleted while the daemon is up.
+# the binary in step 4 cannot be deleted while the daemon is up. Matched by full
+# path, not image name: a dev build or a second install is also called neru.exe,
+# and this must only stop the one it is about to delete.
 echo "Step 0/5: Running instance"
-if MSYS2_ARG_CONV_EXCL='*' taskkill /IM neru.exe /F >/dev/null 2>&1; then
-    echo "✓ Stopped a running Neru"
+if stop_result="$(run_ps "$win_dst_exe" <<'PS'
+param([Parameter(Mandatory = $true)][string]$Exe)
+$ErrorActionPreference = 'Stop'
+
+$running = @(Get-Process -Name neru -ErrorAction SilentlyContinue |
+    Where-Object { $_.Path -eq $Exe })
+if ($running.Count -eq 0) {
+    Write-Output 'absent'
+    exit 0
+}
+
+$running | Stop-Process -Force
+Write-Output 'stopped'
+PS
+)"; then
+    if [ "${stop_result%$'\r'}" = "stopped" ]; then
+        echo "✓ Stopped the Neru running from $win_dst_exe"
+    else
+        echo "  No Neru running from $win_dst_exe"
+    fi
 else
-    echo "  Neru is not running"
+    echo "Could not stop a running Neru; close it before retrying." >&2
 fi
 
 # Step 1: autostart. Removed first so a half-finished uninstall never leaves a
@@ -200,8 +220,9 @@ if [ "$purge" -eq 0 ]; then
     echo "  Kept. Pass --purge to remove your config and logs too."
 else
     note_purge_target "config" "$(cygpath -u "${APPDATA:-$HOME/AppData/Roaming}")/neru"
-    [ -n "${XDG_CONFIG_HOME:-}" ] &&
+    if [ -n "${XDG_CONFIG_HOME:-}" ]; then
         note_purge_target "XDG config" "$(cygpath -u "$XDG_CONFIG_HOME")/neru"
+    fi
     # Neru also reads ~/.config/neru on Windows, for configs carried over from a
     # Unix dotfiles repo.
     note_purge_target "dotfiles config" "$HOME/.config/neru"

--- a/scripts/uninstall-windows.sh
+++ b/scripts/uninstall-windows.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+#
+# neru Windows uninstaller. Invoked by `just uninstall` under a bash such as
+# Git Bash. Undoes scripts/install-windows.sh step for step, in reverse.
+set -euo pipefail
+
+# Run from the repo root so `just` resolves.
+cd "$(dirname "$0")/.."
+
+# -y / --yes auto-accepts every prompt. --purge additionally offers to delete
+# your config and logs; without it they are never touched, so -y on its own can
+# never destroy a hand-tuned config.toml.
+assume_yes=0
+purge=0
+for arg in "$@"; do
+    case "$arg" in
+        -y | --yes) assume_yes=1 ;;
+        --purge) purge=1 ;;
+        *) echo "unknown argument: $arg (use -y to auto-accept prompts, --purge to also remove config and logs)" >&2; exit 2 ;;
+    esac
+done
+
+# ask "prompt" -> prints the reply on stdout. Under -y it echoes the prompt with
+# a "y" and answers yes without reading, so the whole run is non-interactive.
+ask() {
+    if [ "$assume_yes" -eq 1 ]; then
+        printf '%sy\n' "$1" >&2
+        printf 'y'
+        return 0
+    fi
+    local reply
+    read -r -p "$1" reply || reply=""
+    printf '%s' "$reply"
+}
+
+# win_path prints the Windows form (C:\Users\...) of a POSIX path, which is what
+# every Windows-facing consumer needs: PATH entries, shortcuts, the registry.
+win_path() {
+    cygpath -w "$1" 2>/dev/null || printf '%s' "$1"
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# run_ps runs a PowerShell script supplied on stdin, passing any extra
+# arguments through to it. The script is staged in a temp file and run with
+# -File rather than passed inline with -Command so that bash, MSYS path
+# mangling and PowerShell quoting never have to agree with each other.
+run_ps() {
+    local script="$tmp_dir/step.ps1"
+    cat >"$script"
+    MSYS2_ARG_CONV_EXCL='*' powershell -NoProfile -NonInteractive \
+        -ExecutionPolicy Bypass -File "$(win_path "$script")" "$@"
+}
+
+# purge_list accumulates "label|dir" lines for the directories that actually
+# exist. Collecting them before deleting anything is what lets the prompt show
+# the fully resolved paths: XDG_CONFIG_HOME can point the config directory
+# somewhere other than %APPDATA%, and you should see where before saying yes.
+purge_list=""
+note_purge_target() {
+    [ -d "$2" ] && purge_list="$purge_list$1|$2"$'\n'
+    return 0
+}
+
+dst_dir="$(cygpath -u "${LOCALAPPDATA:-$HOME/AppData/Local}")/Programs/neru"
+dst_exe="$dst_dir/neru.exe"
+win_dst_dir="$(win_path "$dst_dir")"
+run_key="HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+
+echo "This removes Neru from $win_dst_dir and undoes the PATH, Start Menu"
+echo "and autostart entries that 'just install' created."
+if [ "$purge" -eq 0 ]; then
+    echo "Your config and logs are kept; pass --purge to remove those too."
+fi
+
+# Step 0: stop a running Neru. Windows locks the image of a running process, so
+# the binary in step 4 cannot be deleted while the daemon is up.
+echo "Step 0/5: Running instance"
+if MSYS2_ARG_CONV_EXCL='*' taskkill /IM neru.exe /F >/dev/null 2>&1; then
+    echo "✓ Stopped a running Neru"
+else
+    echo "  Neru is not running"
+fi
+
+# Step 1: autostart. Removed first so a half-finished uninstall never leaves a
+# Run key pointing at a binary that is already gone.
+echo "Step 1/5: Autostart"
+if MSYS2_ARG_CONV_EXCL='*' reg query "$run_key" /v Neru >/dev/null 2>&1; then
+    if MSYS2_ARG_CONV_EXCL='*' reg delete "$run_key" /v Neru /f >/dev/null 2>&1; then
+        echo "✓ Removed the login autostart entry"
+    else
+        echo "Could not remove the Run key; delete 'Neru' from $run_key yourself." >&2
+    fi
+else
+    echo "  No autostart entry found"
+fi
+
+# Step 2: Start Menu shortcut.
+echo "Step 2/5: Start Menu"
+if menu_result="$(run_ps <<'PS'
+$ErrorActionPreference = 'Stop'
+
+$link = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\Neru.lnk'
+if (Test-Path -LiteralPath $link) {
+    Remove-Item -LiteralPath $link -Force
+    Write-Output 'removed'
+} else {
+    Write-Output 'absent'
+}
+PS
+)"; then
+    if [ "${menu_result%$'\r'}" = "removed" ]; then
+        echo "✓ Removed the Start Menu shortcut"
+    else
+        echo "  No Start Menu shortcut found"
+    fi
+else
+    echo "Could not remove the Start Menu shortcut." >&2
+fi
+
+# Step 3: PATH. Drops only our exact entry, reading and writing the value the
+# same way the installer does so other tools' %VAR% entries survive intact.
+echo "Step 3/5: PATH"
+if path_result="$(run_ps "$win_dst_dir" <<'PS'
+param([Parameter(Mandatory = $true)][string]$Dir)
+$ErrorActionPreference = 'Stop'
+
+$key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+try {
+    if (-not ($key.GetValueNames() -contains 'Path')) {
+        Write-Output 'absent'
+        exit 0
+    }
+
+    # Read the raw value: an existing REG_EXPAND_SZ entry such as
+    # %USERPROFILE%\bin must be written back unexpanded, and its kind
+    # preserved, or every other tool's PATH entry silently freezes.
+    $current = [string]$key.GetValue('Path', '', 'DoNotExpandEnvironmentNames')
+    $kind = $key.GetValueKind('Path')
+
+    # -ne on strings is case-insensitive, which matches how Windows compares
+    # paths, so a differently-cased entry is still recognised as ours.
+    $entries = @($current -split ';' | Where-Object { $_ -ne '' })
+    $kept = @($entries | Where-Object { $_ -ne $Dir })
+    if ($kept.Count -eq $entries.Count) {
+        Write-Output 'absent'
+        exit 0
+    }
+
+    $key.SetValue('Path', ($kept -join ';'), $kind)
+} finally {
+    $key.Close()
+}
+
+# Tell already-running processes (Explorer above all) to reread the
+# environment, so a shell opened afterwards no longer has the entry.
+Add-Type -Namespace Neru -Name Env -MemberDefinition @'
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg,
+    UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout,
+    out UIntPtr lpdwResult);
+'@
+$result = [UIntPtr]::Zero
+[void][Neru.Env]::SendMessageTimeout([IntPtr]0xffff, 0x1A, [UIntPtr]::Zero,
+    'Environment', 0x2, 5000, [ref]$result)
+
+Write-Output 'removed'
+PS
+)"; then
+    if [ "${path_result%$'\r'}" = "removed" ]; then
+        echo "✓ Removed $win_dst_dir from your user PATH"
+    else
+        echo "  $win_dst_dir was not on your user PATH"
+    fi
+else
+    echo "Could not update PATH; remove this directory yourself:" >&2
+    echo "      $win_dst_dir" >&2
+fi
+
+# Step 4: the binary. Only neru.exe is deleted, and the directory only when
+# nothing else is left in it, so anything you put there yourself survives.
+echo "Step 4/5: Binary"
+if [ -e "$dst_exe" ]; then
+    rm -f "$dst_exe"
+    echo "✓ Removed $(win_path "$dst_exe")"
+    if rmdir "$dst_dir" 2>/dev/null; then
+        echo "✓ Removed $win_dst_dir"
+    else
+        echo "  Kept $win_dst_dir (not empty)"
+    fi
+else
+    echo "  No binary found at $(win_path "$dst_exe")"
+fi
+
+# Step 5: config and logs. Opt-in via --purge, and still confirmed, because a
+# hand-tuned config.toml is the one thing here that cannot be rebuilt.
+echo "Step 5/5: Config and logs"
+if [ "$purge" -eq 0 ]; then
+    echo "  Kept. Pass --purge to remove your config and logs too."
+else
+    note_purge_target "config" "$(cygpath -u "${APPDATA:-$HOME/AppData/Roaming}")/neru"
+    [ -n "${XDG_CONFIG_HOME:-}" ] &&
+        note_purge_target "XDG config" "$(cygpath -u "$XDG_CONFIG_HOME")/neru"
+    # Neru also reads ~/.config/neru on Windows, for configs carried over from a
+    # Unix dotfiles repo.
+    note_purge_target "dotfiles config" "$HOME/.config/neru"
+    # %LOCALAPPDATA%\neru holds data and logs; the binary lives in the separate
+    # %LOCALAPPDATA%\Programs\neru handled above.
+    note_purge_target "data and logs" \
+        "$(cygpath -u "${LOCALAPPDATA:-$HOME/AppData/Local}")/neru"
+
+    if [ -z "$purge_list" ]; then
+        echo "  Nothing to remove."
+    else
+        echo "  These directories will be permanently deleted:"
+        while IFS='|' read -r label dir; do
+            [ -n "$dir" ] || continue
+            echo "      $(win_path "$dir")  ($label)"
+        done <<< "$purge_list"
+
+        purge_reply="$(ask "Delete them? [y/N] ")"
+        case "$purge_reply" in
+            [Yy] | [Yy][Ee][Ss])
+                while IFS='|' read -r label dir; do
+                    [ -n "$dir" ] || continue
+                    rm -rf "$dir"
+                    echo "✓ Removed $label: $(win_path "$dir")"
+                done <<< "$purge_list"
+                ;;
+            *)
+                echo "  Kept your config and logs."
+                ;;
+        esac
+    fi
+fi
+
+echo "Neru has been uninstalled."


### PR DESCRIPTION
## Description

Windows shipped a single GUI-subsystem binary, so no subcommand could write to the terminal it was typed into. Building for the console subsystem instead, and releasing the console when the shell rather than a terminal started the daemon, lets one binary serve as both the CLI and the daemon while keeping its embedded icon. Typing `neru` works; the Start Menu and autostart entries still open no window.

The Windows installer also gained the pieces that make it behave like a normal app install:

- Every Windows-facing path is converted properly, so PATH entries, shortcuts and registry values are real Windows paths instead of mixed or POSIX-style ones.
- The user PATH entry is written through the registry rather than `setx`, which truncates the value at 1024 characters and flattens other tools' expandable entries.
- An optional Start Menu shortcut, which is what actually makes an app searchable from the taskbar — PATH does not.

Windows previously only found a config under `%APPDATA%` or `XDG_CONFIG_HOME`. Discovery now also covers `~/.config/neru`, so a config carried over from a Unix dotfiles repo works unchanged. `%APPDATA%` stays the write location.

Finally, `just uninstall` undoes each install step in reverse on all three platforms. Config and logs are kept unless `--purge` is passed, so `-y` alone can never delete a hand-tuned config; `--purge` lists the fully resolved directories before deleting anything. It deliberately leaves alone what it did not install — a binary on PATH that is not our symlink, and the Linux `input` group, which other tools may depend on.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`) — not applicable, the console handling is not a port; the non-Windows counterpart is a deliberate no-op

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

N/A
