### PR TITLE
feat(linux): Wayland hints support, app watcher, and overlay fixes

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -653,11 +653,13 @@ window's screen origin, supplied by a compositor-specific `windowOriginSource`
 - **KDE / KWin** — a small KWin script pushes the focused window's geometry over
   D-Bus (`kwin_geometry_linux.go`).
 - **niri** (`NIRI_SOCKET`) — `niri msg -j focused-window`/`focused-output`.
-  Works for **floating** windows (niri populates `tile_pos_in_workspace_view`);
-  for **tiled** windows niri does not expose the on-screen position
-  ([niri#2381](https://github.com/niri-wm/niri/issues/2381)), so neru falls back
-  to unoffset coordinates — hints then align only when the window fills the
-  output (maximize/float as a workaround).
+  Works for **floating** windows (niri populates `tile_pos_in_workspace_view`)
+  and **fullscreen** windows (whose frame sits at the output origin with no
+  offset needed). For **tiled** windows — including a maximized column
+  (`maximize-column`, the default `Mod+F`) — niri does not expose the on-screen
+  position ([niri#2381](https://github.com/niri-wm/niri/issues/2381)), so neru
+  falls back to unoffset coordinates and hints are misaligned there. Use a
+  floating window, or true fullscreen (`fullscreen-window`), for aligned hints.
 - **Sway** (`SWAYSOCK`) — `swaymsg -t get_tree`, focused node `rect + window_rect`.
 - **Hyprland** (`HYPRLAND_INSTANCE_SIGNATURE`) — `hyprctl -j activewindow` `at`/`size`.
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -571,12 +571,12 @@ From `internal/core/ports/capability_presets.go` and actual adapter code.
 | **Cursor Move**                     | ✅                          | ✅ (XTest)         | ✅ (zwlr_virtual_pointer) | ✅ (libei)               | ❌                | ✅ (SetCursorPos)        |
 | **Cursor Smooth Animation**         | ✅                          | ❌                 | ❌                        | ❌                       | ❌                | ❌                       |
 | **Scroll Smooth Animation**         | ✅                          | ❌                 | ❌                        | ❌                       | ❌                | ❌                       |
-| **Accessibility Element Discovery** | ✅ (AXUIElement)            | 🟡 (AT-SPI stub)   | 🟡 (AT-SPI stub)          | 🟡 (AT-SPI stub)         | 🟡 (AT-SPI stub)  | ✅ (UIA initial)         |
-| **Accessibility Click/Scroll**      | ✅                          | 🟡                 | 🟡                        | 🟡                       | 🟡                | ✅ (UIA initial)         |
+| **Accessibility Element Discovery** | ✅ (AXUIElement)            | ⚠️ (AT-SPI walk)   | ⚠️ (AT-SPI walk)          | ⚠️ (AT-SPI walk)         | 🟡 (no injection) | ✅ (UIA initial)         |
+| **Accessibility Click/Scroll**      | ✅                          | ✅ (XTest)         | ✅ (virtual-pointer)      | ✅ (libei)               | 🟡                | ✅ (UIA initial)         |
 | **Overlay**                         | ✅ (Cocoa NSPanel)          | ✅ (X11 Cairo)     | ✅ (wl-layer Cairo)       | ✅ (wl-layer Cairo)      | ❌                | ✅ (Layered HWND)        |
 | **Global Hotkeys**                  | ✅ (CGEventTap)             | ✅ (XGrabKey)      | ✅ (evdev grab)           | ✅ (evdev grab)          | ❌                | ✅ (RegisterHotKey)      |
 | **Keyboard Event Capture**          | ✅ (CGEventTap)             | ✅ (XGrabKeyboard) | ✅ (evdev + wl-keyboard)  | ✅ (evdev + wl-keyboard) | ❌                | ✅ (WH_KEYBOARD_LL)      |
-| **App Watcher**                     | ✅ (NSWorkspace)            | 🟡                 | 🟡                        | 🟡                       | 🟡                | 🟡                       |
+| **App Watcher**                     | ✅ (NSWorkspace)            | ✅ (WM_CLASS poll) | ✅ (toplevel app_id poll)  | ✅ (toplevel app_id poll) | 🟡 (no source)    | 🟡                       |
 | **Dark Mode Detection**             | ✅ (Cocoa)                  | ✅ (xdg-portal)    | ✅ (xdg-portal)           | ✅ (kdeglobals)          | ✅ (xdg-portal)   | ✅ (registry)            |
 | **Secure Input Detection**          | ✅                          | 🟡 (always false)  | 🟡 (always false)         | 🟡 (always false)        | 🟡 (always false) | 🟡 (always false)        |
 | **Native Notifications**            | ✅ (NSAlert/UNNotification) | 🟡                 | 🟡                        | 🟡                       | 🟡                | 🟡                       |
@@ -593,6 +593,77 @@ its PID — Wayland clients cannot read another client's process credentials.
 against `/proc`; when no process matches it returns `CodeNotSupported` with the
 app_id rather than a fabricated number. GNOME/Mutter does not implement the
 protocol, so it stays a stub there (use an X11 session under GNOME).
+
+**App Watcher on Linux:** macOS receives focus changes from an NSWorkspace
+observer; Linux has no equivalent push API, so the watcher
+(`internal/core/infra/appwatcher/platform_linux.go`) **polls** the focused
+application's identity every 400ms and dispatches activate/deactivate events
+when it changes. The identity comes from
+`platform/linux.FocusedAppID(backend)`: the active window's **WM_CLASS** on X11
+(`neru_x11_get_window_class`) and the focused toplevel's **app_id** on Wayland
+wlroots/KDE (`wlr-foreign-toplevel-management`, reusing the same source as
+Focused App PID). This drives per-app global-hotkey switching
+(`App.handleAppActivation`), which previously never fired on Linux. GNOME/Mutter
+exposes no focused-app source, so the poll yields nothing and no events fire
+there — per-app hotkey switching needs an X11 session under GNOME. Only
+activate/deactivate are emitted; launch, terminate, screen-parameter, and
+Mission Control events remain macOS-only.
+
+**Accessibility on Linux (⚠️, not a stub):** hints-mode element discovery is
+implemented via AT-SPI over D-Bus. `ATSPIClient` (`atspi_linux.go`) enables
+assistive-tech mode, finds the active frame, and walks its tree
+(`ClickableNodes`) for clickable elements, mapping AT-SPI roles to Neru's AX
+role vocabulary. This is the client the Linux adapter actually uses
+(`platform_client_linux.go` → `Adapter.ClickableElements` → `client.ClickableNodes`);
+the `TreeNode`/`BuildTree` stub in `tree_linux.go` is the macOS-style tree API
+and is **not** on the Linux hints path. Click/scroll then inject at the hint
+point through the embedded `InfraAXClient` — XTest on X11, `zwlr_virtual_pointer`
+on wlroots, libei on KDE, plus evdev/uinput for Wayland scroll. It is marked ⚠️
+rather than ✅ because coverage depends on each app exposing AT-SPI (Qt/GTK do
+with accessibility enabled; some toolkits expose little), and there is no
+Vision/OCR fallback like macOS. AT-SPI discovery itself is display-server
+independent, but GNOME/Mutter has no usable injection path, so hints are not
+usable there (use an X11 session under GNOME).
+
+**Chromium/Electron apps on Linux:** Chromium-based apps (Chrome, Electron,
+and forks such as Helium) do **not** expose their web-content accessibility
+tree over AT-SPI by default — they gate it behind their own runtime detection
+and, unlike macOS, there is no per-app attribute Neru can toggle to force it on
+(the macOS `AXManualAccessibility` nudge in `electron.EnsureAccessibility` is a
+no-op on Linux). The result is an AT-SPI frame with a single empty child, so
+hints find nothing inside such windows. The reliable workaround is to launch the
+app with `--force-renderer-accessibility` (e.g. `chromium --force-renderer-accessibility`),
+which forces the full web tree. Native GTK/Qt apps and Firefox expose their tree
+without this flag. This is a Chromium behavior, not a Neru limitation.
+
+**Active-window selection on Wayland:** the AT-SPI `ACTIVE` state is unreliable
+on wlroots compositors (niri, Sway, Hyprland) — the focused window can report
+`ACTIVE=false` while background frames report `ACTIVE=true`. Neru therefore
+selects the AT-SPI frame by matching the compositor's focused **app_id** (from
+`wlr-foreign-toplevel-management`, the same source as Focused App PID / the app
+watcher), falling back to the `ACTIVE`/`SHOWING` heuristic only on X11, GNOME,
+or when no app_id is available. See `findActiveFrame` in `atspi_linux.go`.
+
+**Window-origin offset on Wayland:** a Wayland client cannot know its own
+on-screen position, so AT-SPI reports element coordinates relative to the
+window. To place the hint overlay correctly, neru offsets those by the focused
+window's screen origin, supplied by a compositor-specific `windowOriginSource`
+(`window_origin_linux.go`), selected by environment:
+
+- **KDE / KWin** — a small KWin script pushes the focused window's geometry over
+  D-Bus (`kwin_geometry_linux.go`).
+- **niri** (`NIRI_SOCKET`) — `niri msg -j focused-window`/`focused-output`.
+  Works for **floating** windows (niri populates `tile_pos_in_workspace_view`);
+  for **tiled** windows niri does not expose the on-screen position
+  ([niri#2381](https://github.com/niri-wm/niri/issues/2381)), so neru falls back
+  to unoffset coordinates — hints then align only when the window fills the
+  output (maximize/float as a workaround).
+- **Sway** (`SWAYSOCK`) — `swaymsg -t get_tree`, focused node `rect + window_rect`.
+- **Hyprland** (`HYPRLAND_INSTANCE_SIGNATURE`) — `hyprctl -j activewindow` `at`/`size`.
+
+Each source verifies the reported window size matches the AT-SPI frame (a focus
+change can race the query) and is best-effort — an unavailable origin degrades
+to unoffset (window-relative) coordinates rather than misplacing hints.
 
 ### Overlay Rendering
 
@@ -674,10 +745,10 @@ Key files:
 | **Backend**                | AXUIElement (via CGO ObjC bridge)                                                                                                                                                        | AT-SPI via D-Bus (pure Go)                                              | UI Automation via COM (pure Go)                                                      |
 | **Adapter location**       | `internal/core/infra/accessibility/element_darwin.go`                                                                                                                                    | `internal/core/infra/accessibility/element_linux.go` + `atspi_linux.go` | `internal/core/infra/accessibility/element_windows.go` + `uia_windows.go`            |
 | **Client**                 | `InfraAXClient` wraps Element/TreeNode → ObjC bridge                                                                                                                                     | `ATSPIClient` → D-Bus `org.a11y.atspi`                                  | `UIAClient` → raw COM vtable calls                                                   |
-| **Tree building**          | Full recursive tree walk of AXUIElement hierarchy (`tree.go`). Collects from: frontmost window, popover windows, menubar, dock, notification center, Stage Manager, PIP, screen capture. | Stub — `ClickableNodes` returns `(nil, nil)` (`tree_linux.go`).         | Shallow UIA tree walk returning root-level clickable nodes (`tree_windows.go`).      |
-| **Clickable filtering**    | Extensive: role matching, size/position heuristics, excluded apps list. Multiple strategy backends (AX + Vision).                                                                        | Stub.                                                                   | Basic: collects `IUIAutomationElement` with `IsControlElement` + `IsContentElement`. |
-| **Strategy support**       | `config.StrategyAX` (default), `config.StrategyVision` (macOS Vision Framework).                                                                                                         | AX only.                                                                | AX only.                                                                             |
-| **Popover / menu support** | ✅ (AXOrientation-based popover detection, menubar walking).                                                                                                                             | 🟡                                                                      | 🟡                                                                                   |
+| **Tree building**          | Full recursive tree walk of AXUIElement hierarchy (`tree.go`). Collects from: frontmost window, popover windows, menubar, dock, notification center, Stage Manager, PIP, screen capture. | Recursive AT-SPI D-Bus walk of the active frame (`ATSPIClient.ClickableNodes`, `atspi_linux.go`), depth/node capped. The `tree_linux.go` `BuildTree` stub is the macOS-style API and is not on this path. | Shallow UIA tree walk returning root-level clickable nodes (`tree_windows.go`).      |
+| **Clickable filtering**    | Extensive: role matching, size/position heuristics, excluded apps list. Multiple strategy backends (AX + Vision).                                                                        | AT-SPI role → AX role mapping, SHOWING-state + on-screen extents check; coverage depends on the app's AT-SPI support. | Basic: collects `IUIAutomationElement` with `IsControlElement` + `IsContentElement`. |
+| **Strategy support**       | `config.StrategyAX` (default), `config.StrategyVision` (macOS Vision Framework).                                                                                                         | AX only (no Vision/OCR fallback).                                       | AX only.                                                                             |
+| **Popover / menu support** | ✅ (AXOrientation-based popover detection, menubar walking).                                                                                                                             | ⚠️ (popovers/menus in the active frame's AT-SPI subtree are walked; no separate menubar/dock collection). | 🟡                                                                                   |
 | **Focused application**    | ✅ (NSWorkspace + AXUIElement).                                                                                                                                                          | ✅ (X11: `_NET_ACTIVE_WINDOW`; Wayland: `wlr-foreign-toplevel` app_id on wlroots/KDE, XWayland fallback). | ✅ (Win32 `GetForegroundWindow`).                                                    |
 
 #### Action Execution
@@ -706,12 +777,19 @@ All 8 action types from `internal/core/domain/action/action.go` are dispatched v
 5. Deduplicates overlapping elements
 6. Filters by size, position, visibility, and excluded apps
 
-**Linux** (`tree_linux.go`) is a stub:
+**Linux** (`atspi_linux.go`) walks the AT-SPI tree over D-Bus:
 
-- Returns immediately with no elements
-- AT-SPI client (`atspi_linux.go`) connects via D-Bus but tree queries are stubbed
-- The `collectClickableNodes` function returns nil
-- Element structs in `element_linux.go` implement cursor/scroll/click but tree queries are stubs
+- `ATSPIClient.FrontmostWindow` finds the active frame (ACTIVE + SHOWING state)
+  across registered applications, skipping virtual keyboards and system surfaces
+- `ClickableNodes` recursively walks that frame's subtree (depth/node capped),
+  keeping SHOWING elements whose mapped AX role is in the requested set
+- AT-SPI role names are mapped to Neru's AX role vocabulary
+  (`atspiToAXRole`) so the shared filter pipeline matches them
+- On Wayland it offsets element extents by the focused window's screen origin
+  (via the KWin geometry bridge) since AT-SPI reports window-relative coords
+- Element structs in `element_linux.go` implement cursor/scroll/click injection
+- The `tree_linux.go` `BuildTree`/`TreeNode` API is a stub, but it is the
+  macOS-style tree path and is **not** used by the Linux adapter
 
 **Windows** (`tree_windows.go`):
 
@@ -764,12 +842,12 @@ All 8 action types from `internal/core/domain/action/action.go` are dispatched v
 
 | Feature                        | macOS                                                             | Linux                                       | Windows                         |
 | ------------------------------ | ----------------------------------------------------------------- | ------------------------------------------- | ------------------------------- |
-| **Element discovery**          | ✅ Full AXUIElement tree walk + Vision framework                  | 🟡 (stub — returns no elements)             | ⚠️ (UIA initial — shallow tree) |
-| **Multi-letter labels**        | ✅                                                                | N/A (no elements)                           | ✅                              |
-| **Label filtering / search**   | ✅ (interactive search with `/` prefix, role filter, text filter) | N/A                                         | ✅                              |
-| **Split word**                 | ✅                                                                | N/A                                         | ✅                              |
-| **Label direction**            | ✅ (configurable: horizontal, vertical, row-major, col-major)     | N/A                                         | ✅                              |
-| **Hide unmatched**             | ✅                                                                | N/A                                         | ✅                              |
+| **Element discovery**          | ✅ Full AXUIElement tree walk + Vision framework                  | ⚠️ (AT-SPI walk; toolkit-dependent)         | ⚠️ (UIA initial — shallow tree) |
+| **Multi-letter labels**        | ✅                                                                | ✅ (shared alphabet logic)                  | ✅                              |
+| **Label filtering / search**   | ✅ (interactive search with `/` prefix, role filter, text filter) | ✅ (logic shared; no search input badge)    | ✅                              |
+| **Split word**                 | ✅                                                                | ✅                                          | ✅                              |
+| **Label direction**            | ✅ (configurable: horizontal, vertical, row-major, col-major)     | ✅                                          | ✅                              |
+| **Hide unmatched**             | ✅                                                                | ✅                                          | ✅                              |
 | **Strategy selection**         | `ax` (default), `vision` (macOS Vision Framework)                 | `ax` only                                   | `ax` only                       |
 | **Vision fallback**            | ✅ (AX → Vision → combined)                                       | N/A (Vision is macOS-only)                  | N/A                             |
 | **Per-app strategy overrides** | ✅                                                                | N/A                                         | N/A                             |
@@ -780,7 +858,7 @@ All 8 action types from `internal/core/domain/action/action.go` are dispatched v
 | **Scroll at element**          | ✅ (CGScrollWheelEvent)                                           | 🟡                                          | 🟡                              |
 | **Menubar elements**           | ✅                                                                | 🟡                                          | 🟡                              |
 | **Dock elements**              | ✅                                                                | N/A                                         | N/A                             |
-| **Popup/popover elements**     | ✅ (AXOrientation-based)                                          | 🟡                                          | 🟡                              |
+| **Popup/popover elements**     | ✅ (AXOrientation-based)                                          | ⚠️ (walked when in active frame's subtree)  | 🟡                              |
 | **Hint overlay arrows**        | ✅ (top/bottom arrow indicators on labels)                        | ❌                                          | ❌                              |
 | **Boundary highlight**         | ✅                                                                | ✅ (Cairo)                                  | ✅ (SDF)                        |
 | **Search input badge**         | ✅                                                                | ❌                                          | ✅                              |
@@ -788,8 +866,13 @@ All 8 action types from `internal/core/domain/action/action.go` are dispatched v
 **Implementation note:** On macOS, hints work fully because AXUIElement tree
 walking gives a complete picture of clickable elements on screen. On Windows,
 the UIA integration provides initial element coverage but the tree is shallow.
-On Linux, AT-SPI integration is stubbed — no clickable elements can be
-discovered.
+On Linux, hints work via an AT-SPI (D-Bus) walk of the active frame, so coverage
+depends on the app exposing AT-SPI (Qt/GTK apps with accessibility enabled do;
+some toolkits expose little) and there is no Vision/OCR fallback. Chromium/Electron
+apps expose nothing unless launched with `--force-renderer-accessibility`, and
+GNOME/Mutter has no usable injection path, so hints are not usable there. See the
+Linux accessibility notes under [Port Capability Matrix](#port-capability-matrix)
+for details.
 
 #### Grid Mode
 

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -265,70 +265,76 @@ func (a *Adapter) ClickableElements(
 		}()
 	}
 
-	// Menubar elements
-	if !missionControlActive && filter.IncludeMenubar {
-		waitGroup.Add(1)
+	// The Dock, menu bar, Notification Center, Stage Manager, Picture-in-Picture
+	// and screen-capture UI are macOS-specific surfaces resolved by system
+	// bundle ID. They do not exist on other platforms, so skip them entirely
+	// there rather than probing for nonexistent apps (which only logs failures).
+	if a.client.SupportsSupplementaryElements() {
+		// Menubar elements
+		if !missionControlActive && filter.IncludeMenubar {
+			waitGroup.Add(1)
 
-		go func() {
-			collectElements("menubar", func() ([]*element.Element, error) {
-				return a.addMenubarElements(ctx, nil, filter), nil
-			})
-		}()
-	}
+			go func() {
+				collectElements("menubar", func() ([]*element.Element, error) {
+					return a.addMenubarElements(ctx, nil, filter), nil
+				})
+			}()
+		}
 
-	// Dock elements
-	if filter.IncludeDock {
-		waitGroup.Add(1)
+		// Dock elements
+		if filter.IncludeDock {
+			waitGroup.Add(1)
 
-		go func() {
-			collectElements("dock", func() ([]*element.Element, error) {
-				return a.addDockElements(ctx, nil), nil
-			})
-		}()
-	}
+			go func() {
+				collectElements("dock", func() ([]*element.Element, error) {
+					return a.addDockElements(ctx, nil), nil
+				})
+			}()
+		}
 
-	// Notification Center
-	if !missionControlActive && filter.IncludeNotificationCenter {
-		waitGroup.Add(1)
+		// Notification Center
+		if !missionControlActive && filter.IncludeNotificationCenter {
+			waitGroup.Add(1)
 
-		go func() {
-			collectElements("notification_center", func() ([]*element.Element, error) {
-				return a.addNotificationCenterElements(ctx, nil), nil
-			})
-		}()
-	}
+			go func() {
+				collectElements("notification_center", func() ([]*element.Element, error) {
+					return a.addNotificationCenterElements(ctx, nil), nil
+				})
+			}()
+		}
 
-	// Stage Manager
-	if !missionControlActive && filter.IncludeStageManager {
-		waitGroup.Add(1)
+		// Stage Manager
+		if !missionControlActive && filter.IncludeStageManager {
+			waitGroup.Add(1)
 
-		go func() {
-			collectElements("stage_manager", func() ([]*element.Element, error) {
-				return a.addStageManagerElements(ctx, nil), nil
-			})
-		}()
-	}
+			go func() {
+				collectElements("stage_manager", func() ([]*element.Element, error) {
+					return a.addStageManagerElements(ctx, nil), nil
+				})
+			}()
+		}
 
-	// PIP
-	if !missionControlActive && filter.IncludePIP {
-		waitGroup.Add(1)
+		// PIP
+		if !missionControlActive && filter.IncludePIP {
+			waitGroup.Add(1)
 
-		go func() {
-			collectElements("pip", func() ([]*element.Element, error) {
-				return a.addPIPElements(ctx, nil), nil
-			})
-		}()
-	}
+			go func() {
+				collectElements("pip", func() ([]*element.Element, error) {
+					return a.addPIPElements(ctx, nil), nil
+				})
+			}()
+		}
 
-	// Screen Capture
-	if !missionControlActive && filter.IncludeScreenCapture {
-		waitGroup.Add(1)
+		// Screen Capture
+		if !missionControlActive && filter.IncludeScreenCapture {
+			waitGroup.Add(1)
 
-		go func() {
-			collectElements("screen_capture", func() ([]*element.Element, error) {
-				return a.addScreenCaptureElements(ctx, nil), nil
-			})
-		}()
+			go func() {
+				collectElements("screen_capture", func() ([]*element.Element, error) {
+					return a.addScreenCaptureElements(ctx, nil), nil
+				})
+			}()
+		}
 	}
 
 	// Wait for all queries to complete or context to be canceled

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -196,11 +196,11 @@ func (c *ATSPIClient) FrontmostWindow(_ context.Context) (AXWindow, error) {
 		zap.String("app", c.name(conn, accRef{Name: frame.Name, Path: atspiRootPath})),
 		zap.String("frameTitle", c.name(conn, frame)))
 
-	// Record the compositor's focused app_id and title at selection time so
-	// ClickableNodes can detect a focus change (including a same-application
-	// window switch) before walking or offsetting the frame.
-	focusedAppID, _ := linux.WaylandFocusedAppID()
-	focusedTitle, _ := linux.WaylandFocusedAppTitle()
+	// Record the compositor's focused app_id and title (read together so they
+	// describe one window) at selection time, so ClickableNodes can detect a
+	// focus change — including a same-application window switch — before walking
+	// or offsetting the frame.
+	focusedAppID, focusedTitle, _ := linux.WaylandFocusedAppIdentity()
 
 	return &atspiWindow{
 		ref:          frame,
@@ -512,18 +512,12 @@ func (c *ATSPIClient) ensureA11yConn() (*dbus.Conn, error) {
 // cannot distinguish sibling windows, so a switch between them is not detected —
 // there is no distinguishing information to use.
 func (c *ATSPIClient) focusStableSince(selectedAppID, selectedTitle string) bool {
-	currentAppID, ok := linux.WaylandFocusedAppID()
+	currentAppID, currentTitle, ok := linux.WaylandFocusedAppIdentity()
 	if !ok {
 		return true
 	}
 
-	if currentAppID != selectedAppID {
-		return false
-	}
-
-	currentTitle, _ := linux.WaylandFocusedAppTitle()
-
-	return currentTitle == selectedTitle
+	return currentAppID == selectedAppID && currentTitle == selectedTitle
 }
 
 // children returns the AT-SPI children of an accessible. It prefers the bulk
@@ -686,24 +680,25 @@ func isNonTargetSurfaceApp(name string) bool {
 func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 	root := accRef{Name: atspiRegistryDest, Path: atspiRootPath}
 
-	// Compositor-reported focused app_id (Wayland wlroots/KWin); empty on X11,
-	// GNOME, or when nothing is focused yet. The focused title disambiguates
-	// multiple windows of the focused application, which share an app_id.
-	focusedAppID, haveFocused := linux.WaylandFocusedAppID()
-	focusedTitle, haveFocusedTitle := linux.WaylandFocusedAppTitle()
+	// Compositor-reported focused app_id and title (read together so they
+	// describe one window); empty on X11, GNOME, or when nothing is focused yet.
+	// The title disambiguates multiple windows of the focused application, which
+	// share an app_id.
+	focusedAppID, focusedTitle, haveFocused := linux.WaylandFocusedAppIdentity()
+	haveFocusedTitle := focusedTitle != ""
 
 	var (
-		// Frames whose application matches the compositor's focused app_id — the
-		// most reliable signal on Wayland, so they win over the ACTIVE heuristic.
-		// When that app has several visible windows, prefer the one whose title
-		// matches the focused toplevel's title, then the one the toolkit marks
-		// ACTIVE, so a background window of the focused app cannot win.
-		focusedTitleFrame     accRef
-		haveFocusedTitleMatch bool
-		focusedActiveShowing  accRef
-		haveFocusedActive     bool
-		focusedShowing        accRef
-		haveFocusedShowing    bool
+		// Frames of the application the compositor reports as focused. A window
+		// of that app is only chosen when uniquely identified: exactly one of its
+		// windows matches the focused toplevel's title, or it has a single showing
+		// window. When several windows share (or lack) the title, no unique match
+		// exists and selection defers to the compositor ACTIVE state (reliable
+		// only on KDE) rather than guessing a sibling.
+		focusedTitleFrame   accRef
+		focusedTitleCount   int // windows of the focused app matching the title
+		focusedShowingFrame accRef
+		haveFocusedShowing  bool
+		focusedShowingCount int // showing windows of the focused app
 
 		activeShowing accRef
 		haveAS        bool
@@ -754,26 +749,23 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 				continue
 			}
 
-			// The application the compositor reports as focused wins outright,
-			// regardless of the (unreliable) cross-app AT-SPI ACTIVE state. Among
-			// that app's visible windows, prefer the one whose title matches the
-			// focused toplevel, then the one it marks ACTIVE, then the first
-			// showing one.
+			// Count the focused application's showing windows and how many match
+			// the focused toplevel's title, so selectFrame can tell a unique
+			// identification from an ambiguous one.
 			if matchesFocused && showing {
-				if haveFocusedTitle && !haveFocusedTitleMatch &&
-					titleMatchesFocused(c.name(conn, frame), focusedTitle) {
-					focusedTitleFrame = frame
-					haveFocusedTitleMatch = true
-				}
-
-				if active && !haveFocusedActive {
-					focusedActiveShowing = frame
-					haveFocusedActive = true
-				}
+				focusedShowingCount++
 
 				if !haveFocusedShowing {
-					focusedShowing = frame
+					focusedShowingFrame = frame
 					haveFocusedShowing = true
+				}
+
+				if haveFocusedTitle && titleMatchesFocused(c.name(conn, frame), focusedTitle) {
+					focusedTitleCount++
+
+					if focusedTitleCount == 1 {
+						focusedTitleFrame = frame
+					}
 				}
 			}
 
@@ -795,21 +787,19 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 	}
 
 	return selectFrame(frameCandidates{
-		focusedTitleFrame:    focusedTitleFrame,
-		haveFocusedTitle:     haveFocusedTitleMatch,
-		focusedActiveShowing: focusedActiveShowing,
-		haveFocusedActive:    haveFocusedActive,
-		focusedShowing:       focusedShowing,
-		haveFocusedShowing:   haveFocusedShowing,
-		activeShowing:        activeShowing,
-		haveActiveShowing:    haveAS,
-		activeAny:            activeAny,
-		haveActiveAny:        haveAA,
-		showingAny:           showingAny,
-		haveShowingAny:       haveSA,
-		shellShowing:         shellShowing,
-		haveShell:            haveShell,
-		haveFocused:          haveFocused,
+		focusedTitleFrame:   focusedTitleFrame,
+		focusedTitleCount:   focusedTitleCount,
+		focusedShowingFrame: focusedShowingFrame,
+		focusedShowingCount: focusedShowingCount,
+		activeShowing:       activeShowing,
+		haveActiveShowing:   haveAS,
+		activeAny:           activeAny,
+		haveActiveAny:       haveAA,
+		showingAny:          showingAny,
+		haveShowingAny:      haveSA,
+		shellShowing:        shellShowing,
+		haveShell:           haveShell,
+		haveFocused:         haveFocused,
 		// The AT-SPI ACTIVE state reliably marks the compositor-focused window
 		// only on KWin/KDE; on wlroots it is set inconsistently across frames.
 		activeStateIdentifiesFocus: platform.DetectLinuxBackend() == platform.BackendWaylandKDE,
@@ -820,13 +810,12 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 // by how reliably each identifies the focused window, plus the compositor
 // signals needed to choose between them.
 type frameCandidates struct {
-	// Matched the compositor's focused app_id, in preference order.
-	focusedTitleFrame    accRef // title also matched the focused toplevel
-	haveFocusedTitle     bool
-	focusedActiveShowing accRef // marked ACTIVE by its own toolkit
-	haveFocusedActive    bool
-	focusedShowing       accRef // first showing frame of the focused app
-	haveFocusedShowing   bool
+	// Frames of the compositor-focused application, with the counts needed to
+	// tell a unique identification from an ambiguous one.
+	focusedTitleFrame   accRef // first window whose title matched the focused toplevel
+	focusedTitleCount   int    // windows of the focused app matching that title
+	focusedShowingFrame accRef // first showing window of the focused app
+	focusedShowingCount int    // showing windows of the focused app
 
 	// Cross-application ACTIVE/SHOWING fallbacks (reliable only on KDE).
 	activeShowing     accRef
@@ -852,20 +841,23 @@ type frameCandidates struct {
 // unit-tested without a live AT-SPI bus.
 func selectFrame(cand frameCandidates) (accRef, bool) {
 	switch {
-	case cand.haveFocusedTitle:
+	case cand.focusedTitleCount == 1:
+		// Exactly one window of the focused app carries the focused toplevel's
+		// title — an unambiguous match (works on any compositor).
 		return cand.focusedTitleFrame, true
-	case cand.haveFocusedActive:
-		return cand.focusedActiveShowing, true
-	case cand.haveFocusedShowing:
-		return cand.focusedShowing, true
+	case cand.focusedShowingCount == 1:
+		// The focused app has a single showing window, so it is unambiguous even
+		// without a title match.
+		return cand.focusedShowingFrame, true
 	case cand.haveFocused:
-		// A focused app_id was reported but no AT-SPI frame of that application
-		// matched (name differs from the app_id, or it exposes no AT-SPI). On
-		// KWin/KDE the ACTIVE state still marks the focused window, so an ACTIVE
-		// frame is it (catches name-mismatched apps such as GTK "Files" vs
-		// org.gnome.Nautilus). When no frame is ACTIVE the focused app exposes no
-		// AT-SPI, so return nothing rather than an unrelated SHOWING or shell
-		// window. On wlroots the ACTIVE state is unreliable, so return nothing.
+		// A focused app_id was reported but its window could not be uniquely
+		// identified — no AT-SPI frame matched (name differs from the app_id, or
+		// it exposes no AT-SPI), or several sibling windows share/lack the title.
+		// On KWin/KDE the ACTIVE state still marks the focused window, so an
+		// ACTIVE frame is it (covers name-mismatched apps such as GTK "Files" vs
+		// org.gnome.Nautilus and duplicate-title siblings). On wlroots ACTIVE is
+		// unreliable, so return nothing rather than guess a sibling or a
+		// background window.
 		if cand.activeStateIdentifiesFocus && cand.haveActiveShowing {
 			return cand.activeShowing, true
 		}

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -254,7 +254,17 @@ func (c *ATSPIClient) ClickableNodes(
 
 	frameRect, frameOK := c.extents(conn, win.ref)
 	if frameOK && c.focusStableSince(win.focusedAppID) {
-		offX, offY, haveOrigin = c.windowOrigin.originFor(frameRect.Dx(), frameRect.Dy())
+		originX, originY, ok := c.windowOrigin.originFor(frameRect.Dx(), frameRect.Dy())
+		if ok {
+			// AT-SPI reports element coordinates in the app's own space, where the
+			// frame content sits at frameRect.Min — non-zero when the toolkit adds a
+			// margin (e.g. a GTK client-side-decoration shadow). The compositor
+			// origin is the content's screen position, so shift element coordinates
+			// by (compositor origin − frame margin) to avoid a constant offset.
+			offX = originX - frameRect.Min.X
+			offY = originY - frameRect.Min.Y
+			haveOrigin = true
+		}
 	}
 
 	out := make([]AXNode, 0, atspiClickableNodesCap)

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -196,11 +196,18 @@ func (c *ATSPIClient) FrontmostWindow(_ context.Context) (AXWindow, error) {
 		zap.String("app", c.name(conn, accRef{Name: frame.Name, Path: atspiRootPath})),
 		zap.String("frameTitle", c.name(conn, frame)))
 
-	// Record the compositor's focused app_id at selection time so ClickableNodes
-	// can detect a focus change before applying window-origin geometry.
+	// Record the compositor's focused app_id and title at selection time so
+	// ClickableNodes can detect a focus change (including a same-application
+	// window switch) before walking or offsetting the frame.
 	focusedAppID, _ := linux.WaylandFocusedAppID()
+	focusedTitle, _ := linux.WaylandFocusedAppTitle()
 
-	return &atspiWindow{ref: frame, valid: true, focusedAppID: focusedAppID}, nil
+	return &atspiWindow{
+		ref:          frame,
+		valid:        true,
+		focusedAppID: focusedAppID,
+		focusedTitle: focusedTitle,
+	}, nil
 }
 
 // FrontmostAndPopoverWindows returns the active window (popovers are part of
@@ -248,7 +255,7 @@ func (c *ATSPIClient) ClickableNodes(
 	// geometry would belong to a different window). Return nothing so hints do
 	// not target the wrong surface. When no focused app_id is available
 	// (X11/GNOME) there is nothing to compare, so the walk proceeds.
-	if !c.focusStableSince(win.focusedAppID) {
+	if !c.focusStableSince(win.focusedAppID, win.focusedTitle) {
 		return nil, nil
 	}
 
@@ -488,19 +495,27 @@ func (c *ATSPIClient) ensureA11yConn() (*dbus.Conn, error) {
 	return conn, nil
 }
 
-// focusStableSince reports whether the compositor's focused app_id still equals
-// the value captured when the window was selected. A mismatch means focus
-// changed before the geometry query, so the compositor's origin belongs to a
-// different window and must not be applied to this frame. When no live app_id
-// is available (X11/GNOME) there is nothing to compare, so it returns true and
-// the window-origin source's own size guard governs the offset.
-func (c *ATSPIClient) focusStableSince(selectedAppID string) bool {
-	current, ok := linux.WaylandFocusedAppID()
+// focusStableSince reports whether the compositor's focused window still matches
+// the one captured when the frame was selected. It compares the app_id and, for
+// same-application window switches (which share an app_id), the window title. A
+// mismatch means focus changed before the walk, so the selected frame is stale
+// and must not be walked or offset. When no live app_id is available (X11/GNOME)
+// there is nothing to compare, so it returns true. Identical or empty titles
+// cannot distinguish sibling windows, so a switch between them is not detected —
+// there is no distinguishing information to use.
+func (c *ATSPIClient) focusStableSince(selectedAppID, selectedTitle string) bool {
+	currentAppID, ok := linux.WaylandFocusedAppID()
 	if !ok {
 		return true
 	}
 
-	return current == selectedAppID
+	if currentAppID != selectedAppID {
+		return false
+	}
+
+	currentTitle, _ := linux.WaylandFocusedAppTitle()
+
+	return currentTitle == selectedTitle
 }
 
 // children returns the AT-SPI children of an accessible. It prefers the bulk
@@ -783,12 +798,22 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 		return focusedActiveShowing, true
 	case haveFocusedShowing:
 		return focusedShowing, true
-	case haveFocused && !activeStateIdentifiesFocus:
-		// The compositor reports a focused application but no AT-SPI application
-		// matched it, and this compositor does not set ACTIVE reliably. Every
-		// remaining candidate — a background ACTIVE/SHOWING window or the desktop
-		// shell — would target the wrong surface, so return no frame and let
-		// hints simply not appear rather than click a background/shell control.
+	case haveFocused:
+		// A focused app_id was reported but no AT-SPI frame of that application
+		// matched (name differs from the app_id, or it exposes no AT-SPI). On
+		// KWin/KDE the ACTIVE state still marks the focused window, so an ACTIVE
+		// frame is it (catches name-mismatched apps such as GTK "Files" vs
+		// org.gnome.Nautilus). When no frame is ACTIVE the focused app exposes no
+		// AT-SPI, so return nothing rather than an unrelated SHOWING or shell
+		// window. On wlroots the ACTIVE state is unreliable, so return nothing.
+		if activeStateIdentifiesFocus && haveAS {
+			return activeShowing, true
+		}
+
+		if activeStateIdentifiesFocus && haveAA {
+			return activeAny, true
+		}
+
 		return accRef{}, false
 	case haveAS:
 		return activeShowing, true
@@ -929,11 +954,14 @@ func rolesSet(roles []string) map[string]struct{} {
 type atspiWindow struct {
 	ref   accRef
 	valid bool
-	// focusedAppID is the compositor's focused app_id captured when this window
-	// was selected (empty on X11/GNOME). ClickableNodes compares it against the
-	// live focused app_id so a focus change between selection and the geometry
-	// query does not offset hints by an unrelated window's origin.
+	// focusedAppID and focusedTitle are the compositor's focused app_id and
+	// window title captured when this window was selected (empty on X11/GNOME).
+	// ClickableNodes compares both against the live values so a focus change
+	// between selection and the walk — including a switch to another window of
+	// the same application (same app_id, different title) — is detected and the
+	// stale frame is not walked or offset.
 	focusedAppID string
+	focusedTitle string
 }
 
 func (w *atspiWindow) Release()     {}

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -195,7 +195,11 @@ func (c *ATSPIClient) FrontmostWindow(_ context.Context) (AXWindow, error) {
 		zap.String("app", c.name(conn, accRef{Name: frame.Name, Path: atspiRootPath})),
 		zap.String("frameTitle", c.name(conn, frame)))
 
-	return &atspiWindow{ref: frame, valid: true}, nil
+	// Record the compositor's focused app_id at selection time so ClickableNodes
+	// can detect a focus change before applying window-origin geometry.
+	focusedAppID, _ := linux.WaylandFocusedAppID()
+
+	return &atspiWindow{ref: frame, valid: true, focusedAppID: focusedAppID}, nil
 }
 
 // FrontmostAndPopoverWindows returns the active window (popovers are part of
@@ -249,7 +253,7 @@ func (c *ATSPIClient) ClickableNodes(
 	)
 
 	frameRect, frameOK := c.extents(conn, win.ref)
-	if frameOK {
+	if frameOK && c.focusStableSince(win.focusedAppID) {
 		offX, offY, haveOrigin = c.windowOrigin.originFor(frameRect.Dx(), frameRect.Dy())
 	}
 
@@ -464,6 +468,21 @@ func (c *ATSPIClient) ensureA11yConn() (*dbus.Conn, error) {
 	return conn, nil
 }
 
+// focusStableSince reports whether the compositor's focused app_id still equals
+// the value captured when the window was selected. A mismatch means focus
+// changed before the geometry query, so the compositor's origin belongs to a
+// different window and must not be applied to this frame. When no live app_id
+// is available (X11/GNOME) there is nothing to compare, so it returns true and
+// the window-origin source's own size guard governs the offset.
+func (c *ATSPIClient) focusStableSince(selectedAppID string) bool {
+	current, ok := linux.WaylandFocusedAppID()
+	if !ok {
+		return true
+	}
+
+	return current == selectedAppID
+}
+
 // children returns the AT-SPI children of an accessible. It prefers the bulk
 // GetChildren method and falls back to ChildCount + GetChildAtIndex for older
 // toolkits that do not expose GetChildren.
@@ -623,10 +642,15 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 	focusedAppID, haveFocused := linux.WaylandFocusedAppID()
 
 	var (
-		// Frame whose application matches the compositor's focused app_id — the
-		// most reliable signal on Wayland, so it wins over the ACTIVE heuristic.
-		focusedShowing   accRef
-		haveFocusedMatch bool
+		// Frames whose application matches the compositor's focused app_id — the
+		// most reliable signal on Wayland, so they win over the ACTIVE heuristic.
+		// When that app has several visible windows, prefer the one the app's own
+		// toolkit marks ACTIVE (reliable within a single app, unlike the cross-app
+		// ACTIVE state) so a background window of the focused app cannot win.
+		focusedActiveShowing accRef
+		haveFocusedActive    bool
+		focusedShowing       accRef
+		haveFocusedShowing   bool
 
 		activeShowing accRef
 		haveAS        bool
@@ -678,10 +702,18 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 			}
 
 			// The application the compositor reports as focused wins outright,
-			// regardless of the (unreliable) AT-SPI ACTIVE state.
-			if matchesFocused && showing && !haveFocusedMatch {
-				focusedShowing = frame
-				haveFocusedMatch = true
+			// regardless of the (unreliable) cross-app AT-SPI ACTIVE state. Among
+			// that app's visible windows, prefer the one it marks ACTIVE.
+			if matchesFocused && showing {
+				if active && !haveFocusedActive {
+					focusedActiveShowing = frame
+					haveFocusedActive = true
+				}
+
+				if !haveFocusedShowing {
+					focusedShowing = frame
+					haveFocusedShowing = true
+				}
 			}
 
 			if active && showing && !haveAS {
@@ -702,7 +734,9 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 	}
 
 	switch {
-	case haveFocusedMatch:
+	case haveFocusedActive:
+		return focusedActiveShowing, true
+	case haveFocusedShowing:
 		return focusedShowing, true
 	case haveAS:
 		return activeShowing, true
@@ -833,6 +867,11 @@ func rolesSet(roles []string) map[string]struct{} {
 type atspiWindow struct {
 	ref   accRef
 	valid bool
+	// focusedAppID is the compositor's focused app_id captured when this window
+	// was selected (empty on X11/GNOME). ClickableNodes compares it against the
+	// live focused app_id so a focus change between selection and the geometry
+	// query does not offset hints by an unrelated window's origin.
+	focusedAppID string
 }
 
 func (w *atspiWindow) Release()     {}

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/infra/platform/linux"
 )
 
 var errClientClosed = errors.New("AT-SPI client is closed")
@@ -138,8 +139,8 @@ var defaultClickableAXRoles = map[string]struct{}{
 type ATSPIClient struct {
 	*InfraAXClient
 
-	logger *zap.Logger
-	kwin   *kwinBridge
+	logger       *zap.Logger
+	windowOrigin windowOriginSource
 
 	mu        sync.Mutex
 	a11y      *dbus.Conn
@@ -164,7 +165,7 @@ func NewATSPIClient(logger *zap.Logger, configProvider config.Provider) *ATSPICl
 	return &ATSPIClient{
 		InfraAXClient: NewInfraAXClient(logger, configProvider),
 		logger:        logger.Named("accessibility.atspi"),
-		kwin:          newKWinBridge(logger),
+		windowOrigin:  newWindowOriginSource(logger),
 	}
 }
 
@@ -249,7 +250,7 @@ func (c *ATSPIClient) ClickableNodes(
 
 	frameRect, frameOK := c.extents(conn, win.ref)
 	if frameOK {
-		offX, offY, haveOrigin = c.kwin.originFor(frameRect.Dx(), frameRect.Dy())
+		offX, offY, haveOrigin = c.windowOrigin.originFor(frameRect.Dx(), frameRect.Dy())
 	}
 
 	out := make([]AXNode, 0, atspiClickableNodesCap)
@@ -421,7 +422,7 @@ func (c *ATSPIClient) ensureA11yEnabled() error {
 		return err
 	}
 
-	go c.kwin.start()
+	go c.windowOrigin.start()
 
 	c.activated = true
 
@@ -604,15 +605,29 @@ func isNonTargetSurfaceApp(name string) bool {
 }
 
 // findActiveFrame locates the focused top-level window across all registered
-// applications by looking for a frame with the ACTIVE state.
-// On KDE several frames can report the ACTIVE state at once (e.g. the maliit
-// virtual keyboard "plasma-keyboard" is persistently active but off-screen).
-// The genuinely focused window is the one that is ACTIVE *and* SHOWING, so we
-// prefer that and fall back to any active, then any showing, frame.
+// applications.
+//
+// The primary signal on Wayland is the compositor's focused app_id from
+// wlr-foreign-toplevel-management (wlroots/KWin): the AT-SPI ACTIVE state is
+// unreliable there — wlroots compositors such as niri/Sway/Hyprland leave the
+// genuinely focused window ACTIVE=false while background frames report
+// ACTIVE=true — so a frame whose application matches the focused app_id wins
+// over the ACTIVE heuristic. When no app_id is available (X11, GNOME, or the
+// focused app exposes no AT-SPI frame) we fall back to the ACTIVE-state
+// heuristic: prefer ACTIVE+SHOWING, then any ACTIVE, then any SHOWING frame.
 func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 	root := accRef{Name: atspiRegistryDest, Path: atspiRootPath}
 
+	// Compositor-reported focused app_id (Wayland wlroots/KWin); empty on X11,
+	// GNOME, or when nothing is focused yet.
+	focusedAppID, haveFocused := linux.WaylandFocusedAppID()
+
 	var (
+		// Frame whose application matches the compositor's focused app_id — the
+		// most reliable signal on Wayland, so it wins over the ACTIVE heuristic.
+		focusedShowing   accRef
+		haveFocusedMatch bool
+
 		activeShowing accRef
 		haveAS        bool
 		activeAny     accRef
@@ -640,6 +655,7 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 		}
 
 		isShell := isDesktopShellApp(appName)
+		matchesFocused := haveFocused && appMatchesFocusedID(appName, focusedAppID)
 
 		for _, frame := range c.children(conn, app) {
 			role := c.roleName(conn, frame)
@@ -661,6 +677,13 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 				continue
 			}
 
+			// The application the compositor reports as focused wins outright,
+			// regardless of the (unreliable) AT-SPI ACTIVE state.
+			if matchesFocused && showing && !haveFocusedMatch {
+				focusedShowing = frame
+				haveFocusedMatch = true
+			}
+
 			if active && showing && !haveAS {
 				activeShowing = frame
 				haveAS = true
@@ -679,6 +702,8 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 	}
 
 	switch {
+	case haveFocusedMatch:
+		return focusedShowing, true
 	case haveAS:
 		return activeShowing, true
 	case haveAA:
@@ -690,6 +715,47 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 	default:
 		return accRef{}, false
 	}
+}
+
+// appMatchesFocusedID reports whether an AT-SPI application name corresponds to
+// the compositor's focused app_id. The two vocabularies differ: AT-SPI reports
+// a display name ("Firefox") while wlr-foreign-toplevel reports an app_id that
+// is often reverse-DNS ("org.mozilla.firefox") or a bare id ("helium"). The
+// match is case-insensitive and also compares the last dot-segment of either
+// side, so "Firefox" matches "org.mozilla.firefox" and "Helium" matches
+// "helium".
+func appMatchesFocusedID(atspiName, appID string) bool {
+	name := strings.ToLower(strings.TrimSpace(atspiName))
+	focusedID := strings.ToLower(strings.TrimSpace(appID))
+
+	if name == "" || focusedID == "" {
+		return false
+	}
+
+	if name == focusedID {
+		return true
+	}
+
+	if seg := lastDotSegment(focusedID); seg != "" && seg == name {
+		return true
+	}
+
+	if seg := lastDotSegment(name); seg != "" && seg == focusedID {
+		return true
+	}
+
+	return false
+}
+
+// lastDotSegment returns the substring after the final '.', or "" when there is
+// no interior dot (nothing after the dot, or no dot at all).
+func lastDotSegment(value string) string {
+	i := strings.LastIndex(value, ".")
+	if i < 0 || i == len(value)-1 {
+		return ""
+	}
+
+	return value[i+1:]
 }
 
 // walk recursively collects clickable, showing nodes under ref.

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -644,6 +644,12 @@ func isNonTargetSurfaceApp(name string) bool {
 // over the ACTIVE heuristic. When no app_id is available (X11, GNOME, or the
 // focused app exposes no AT-SPI frame) we fall back to the ACTIVE-state
 // heuristic: prefer ACTIVE+SHOWING, then any ACTIVE, then any SHOWING frame.
+//
+// If a focused app_id is reported but no AT-SPI application matched it, the
+// ACTIVE fallback is only trusted when exactly one application reports an
+// ACTIVE frame (so ACTIVE unambiguously identifies the focused window, as on
+// KWin/KDE). Where several — or no — applications report ACTIVE (wlroots) the
+// fallback would target a background window, so no frame is returned instead.
 func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 	root := accRef{Name: atspiRegistryDest, Path: atspiRootPath}
 
@@ -673,6 +679,13 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 		// cursor move cannot hijack a still-showing real application window.
 		shellShowing accRef
 		haveShell    bool
+
+		// appsWithActive counts distinct non-shell applications reporting an
+		// ACTIVE frame. On KWin/KDE exactly one does (the focused window), so
+		// ACTIVE reliably identifies the focused app; on wlroots several
+		// background frames report ACTIVE, making it unreliable. Used to decide
+		// whether the ACTIVE fallback is trustworthy when no app_id matched.
+		appsWithActive int
 	)
 
 	for _, app := range c.children(conn, root) {
@@ -690,6 +703,7 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 
 		isShell := isDesktopShellApp(appName)
 		matchesFocused := haveFocused && appMatchesFocusedID(appName, focusedAppID)
+		appHasActive := false
 
 		for _, frame := range c.children(conn, app) {
 			role := c.roleName(conn, frame)
@@ -709,6 +723,10 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 				}
 
 				continue
+			}
+
+			if active {
+				appHasActive = true
 			}
 
 			// The application the compositor reports as focused wins outright,
@@ -741,6 +759,10 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 				haveSA = true
 			}
 		}
+
+		if appHasActive {
+			appsWithActive++
+		}
 	}
 
 	switch {
@@ -748,6 +770,20 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 		return focusedActiveShowing, true
 	case haveFocusedShowing:
 		return focusedShowing, true
+	case haveFocused && appsWithActive != 1:
+		// The compositor reports a focused application but no AT-SPI application
+		// matched it. The ACTIVE/SHOWING heuristic would return a *different*
+		// application's frame, so trust it only when ACTIVE unambiguously
+		// identifies one application (exactly one active app — as on KWin/KDE,
+		// where the focused window is the sole ACTIVE one). Otherwise (wlroots
+		// reports several active frames, or none) selecting any of them would
+		// target a background window, so return no frame (shell as a last
+		// resort) and let hints simply not appear.
+		if haveShell {
+			return shellShowing, true
+		}
+
+		return accRef{}, false
 	case haveAS:
 		return activeShowing, true
 	case haveAA:

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -182,7 +182,14 @@ func (c *ATSPIClient) FrontmostWindow(_ context.Context) (AXWindow, error) {
 		return nil, err
 	}
 
-	frame, ok := c.findActiveFrame(conn)
+	// Read the compositor's focused app_id and title once (together so they
+	// describe one window) and use this single snapshot both to select the frame
+	// and to record it on the window. Reading it again after selection could
+	// capture a newer window's identity against the old frame, letting the
+	// ClickableNodes stability check accept a stale frame.
+	focusedAppID, focusedTitle, _ := linux.WaylandFocusedAppIdentity()
+
+	frame, ok := c.findActiveFrame(conn, focusedAppID, focusedTitle)
 	if !ok {
 		c.logger.Debug("AT-SPI: no active frame found")
 
@@ -195,12 +202,6 @@ func (c *ATSPIClient) FrontmostWindow(_ context.Context) (AXWindow, error) {
 		zap.String("bus", frame.Name),
 		zap.String("app", c.name(conn, accRef{Name: frame.Name, Path: atspiRootPath})),
 		zap.String("frameTitle", c.name(conn, frame)))
-
-	// Record the compositor's focused app_id and title (read together so they
-	// describe one window) at selection time, so ClickableNodes can detect a
-	// focus change — including a same-application window switch — before walking
-	// or offsetting the frame.
-	focusedAppID, focusedTitle, _ := linux.WaylandFocusedAppIdentity()
 
 	return &atspiWindow{
 		ref:          frame,
@@ -677,14 +678,18 @@ func isNonTargetSurfaceApp(name string) bool {
 // the focused window. On other Wayland compositors (wlroots) the fallback —
 // including the desktop-shell last resort — could return a background surface,
 // so no frame is returned and hints simply do not appear.
-func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
+// The focusedAppID and focusedTitle are the caller's single focus snapshot
+// (empty on X11, GNOME, or when nothing is focused), used so the selected frame
+// and the identity recorded for the stability check come from the same read.
+func (c *ATSPIClient) findActiveFrame(
+	conn *dbus.Conn,
+	focusedAppID, focusedTitle string,
+) (accRef, bool) {
 	root := accRef{Name: atspiRegistryDest, Path: atspiRootPath}
 
-	// Compositor-reported focused app_id and title (read together so they
-	// describe one window); empty on X11, GNOME, or when nothing is focused yet.
 	// The title disambiguates multiple windows of the focused application, which
 	// share an app_id.
-	focusedAppID, focusedTitle, haveFocused := linux.WaylandFocusedAppIdentity()
+	haveFocused := focusedAppID != ""
 	haveFocusedTitle := focusedTitle != ""
 
 	var (

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -250,11 +250,11 @@ func (c *ATSPIClient) ClickableNodes(
 
 	start := time.Now()
 
-	// If focus changed since this window was selected, the frame is stale:
-	// walking it would surface hints for a now-background window (and any
-	// geometry would belong to a different window). Return nothing so hints do
-	// not target the wrong surface. When no focused app_id is available
-	// (X11/GNOME) there is nothing to compare, so the walk proceeds.
+	// Early-out: if focus already changed since this window was selected, the
+	// frame is stale, so skip the (subprocess-spawning) geometry query below and
+	// return nothing. When no focused app_id is available (X11/GNOME) there is
+	// nothing to compare, so the walk proceeds. The stability is re-checked after
+	// the geometry query to close the race window described there.
 	if !c.focusStableSince(win.focusedAppID, win.focusedTitle) {
 		return nil, nil
 	}
@@ -282,6 +282,14 @@ func (c *ATSPIClient) ClickableNodes(
 			offY = originY - frameRect.Min.Y
 			haveOrigin = true
 		}
+	}
+
+	// originFor reads the *current* focused window's geometry, so a focus change
+	// between the early-out above and that read would pair this frame with a
+	// different (equally sized) window's origin. Re-verify stability and abort if
+	// focus moved, rather than walk a stale frame or apply a mismatched origin.
+	if !c.focusStableSince(win.focusedAppID, win.focusedTitle) {
+		return nil, nil
 	}
 
 	out := make([]AXNode, 0, atspiClickableNodesCap)

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -786,19 +786,71 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 		}
 	}
 
-	// The AT-SPI ACTIVE state reliably marks the compositor-focused window only
-	// on KWin/KDE; on wlroots compositors it is set inconsistently across
-	// background frames.
-	activeStateIdentifiesFocus := platform.DetectLinuxBackend() == platform.BackendWaylandKDE
+	return selectFrame(frameCandidates{
+		focusedTitleFrame:    focusedTitleFrame,
+		haveFocusedTitle:     haveFocusedTitleMatch,
+		focusedActiveShowing: focusedActiveShowing,
+		haveFocusedActive:    haveFocusedActive,
+		focusedShowing:       focusedShowing,
+		haveFocusedShowing:   haveFocusedShowing,
+		activeShowing:        activeShowing,
+		haveActiveShowing:    haveAS,
+		activeAny:            activeAny,
+		haveActiveAny:        haveAA,
+		showingAny:           showingAny,
+		haveShowingAny:       haveSA,
+		shellShowing:         shellShowing,
+		haveShell:            haveShell,
+		haveFocused:          haveFocused,
+		// The AT-SPI ACTIVE state reliably marks the compositor-focused window
+		// only on KWin/KDE; on wlroots it is set inconsistently across frames.
+		activeStateIdentifiesFocus: platform.DetectLinuxBackend() == platform.BackendWaylandKDE,
+	})
+}
 
+// frameCandidates holds the frames found during a findActiveFrame walk, ranked
+// by how reliably each identifies the focused window, plus the compositor
+// signals needed to choose between them.
+type frameCandidates struct {
+	// Matched the compositor's focused app_id, in preference order.
+	focusedTitleFrame    accRef // title also matched the focused toplevel
+	haveFocusedTitle     bool
+	focusedActiveShowing accRef // marked ACTIVE by its own toolkit
+	haveFocusedActive    bool
+	focusedShowing       accRef // first showing frame of the focused app
+	haveFocusedShowing   bool
+
+	// Cross-application ACTIVE/SHOWING fallbacks (reliable only on KDE).
+	activeShowing     accRef
+	haveActiveShowing bool
+	activeAny         accRef
+	haveActiveAny     bool
+	showingAny        accRef
+	haveShowingAny    bool
+
+	// Desktop shell, used only as a last resort when nothing is focused.
+	shellShowing accRef
+	haveShell    bool
+
+	// haveFocused is true when the compositor reported a focused app_id.
+	haveFocused bool
+	// activeStateIdentifiesFocus is true only where the AT-SPI ACTIVE state
+	// reliably marks the focused window (KWin/KDE).
+	activeStateIdentifiesFocus bool
+}
+
+// selectFrame chooses the focused frame from the ranked candidates. It is the
+// pure decision half of findActiveFrame, split out so the ordering can be
+// unit-tested without a live AT-SPI bus.
+func selectFrame(cand frameCandidates) (accRef, bool) {
 	switch {
-	case haveFocusedTitleMatch:
-		return focusedTitleFrame, true
-	case haveFocusedActive:
-		return focusedActiveShowing, true
-	case haveFocusedShowing:
-		return focusedShowing, true
-	case haveFocused:
+	case cand.haveFocusedTitle:
+		return cand.focusedTitleFrame, true
+	case cand.haveFocusedActive:
+		return cand.focusedActiveShowing, true
+	case cand.haveFocusedShowing:
+		return cand.focusedShowing, true
+	case cand.haveFocused:
 		// A focused app_id was reported but no AT-SPI frame of that application
 		// matched (name differs from the app_id, or it exposes no AT-SPI). On
 		// KWin/KDE the ACTIVE state still marks the focused window, so an ACTIVE
@@ -806,23 +858,23 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 		// org.gnome.Nautilus). When no frame is ACTIVE the focused app exposes no
 		// AT-SPI, so return nothing rather than an unrelated SHOWING or shell
 		// window. On wlroots the ACTIVE state is unreliable, so return nothing.
-		if activeStateIdentifiesFocus && haveAS {
-			return activeShowing, true
+		if cand.activeStateIdentifiesFocus && cand.haveActiveShowing {
+			return cand.activeShowing, true
 		}
 
-		if activeStateIdentifiesFocus && haveAA {
-			return activeAny, true
+		if cand.activeStateIdentifiesFocus && cand.haveActiveAny {
+			return cand.activeAny, true
 		}
 
 		return accRef{}, false
-	case haveAS:
-		return activeShowing, true
-	case haveAA:
-		return activeAny, true
-	case haveSA:
-		return showingAny, true
-	case haveShell:
-		return shellShowing, true
+	case cand.haveActiveShowing:
+		return cand.activeShowing, true
+	case cand.haveActiveAny:
+		return cand.activeAny, true
+	case cand.haveShowingAny:
+		return cand.showingAny, true
+	case cand.haveShell:
+		return cand.shellShowing, true
 	default:
 		return accRef{}, false
 	}

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/infra/platform"
 	"github.com/y3owk1n/neru/internal/core/infra/platform/linux"
 )
 
@@ -646,10 +647,10 @@ func isNonTargetSurfaceApp(name string) bool {
 // heuristic: prefer ACTIVE+SHOWING, then any ACTIVE, then any SHOWING frame.
 //
 // If a focused app_id is reported but no AT-SPI application matched it, the
-// ACTIVE fallback is only trusted when exactly one application reports an
-// ACTIVE frame (so ACTIVE unambiguously identifies the focused window, as on
-// KWin/KDE). Where several — or no — applications report ACTIVE (wlroots) the
-// fallback would target a background window, so no frame is returned instead.
+// ACTIVE/SHOWING fallback is used only on KWin/KDE, where ACTIVE reliably marks
+// the focused window. On other Wayland compositors (wlroots) the fallback —
+// including the desktop-shell last resort — could return a background surface,
+// so no frame is returned and hints simply do not appear.
 func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 	root := accRef{Name: atspiRegistryDest, Path: atspiRootPath}
 
@@ -679,13 +680,6 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 		// cursor move cannot hijack a still-showing real application window.
 		shellShowing accRef
 		haveShell    bool
-
-		// appsWithActive counts distinct non-shell applications reporting an
-		// ACTIVE frame. On KWin/KDE exactly one does (the focused window), so
-		// ACTIVE reliably identifies the focused app; on wlroots several
-		// background frames report ACTIVE, making it unreliable. Used to decide
-		// whether the ACTIVE fallback is trustworthy when no app_id matched.
-		appsWithActive int
 	)
 
 	for _, app := range c.children(conn, root) {
@@ -703,7 +697,6 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 
 		isShell := isDesktopShellApp(appName)
 		matchesFocused := haveFocused && appMatchesFocusedID(appName, focusedAppID)
-		appHasActive := false
 
 		for _, frame := range c.children(conn, app) {
 			role := c.roleName(conn, frame)
@@ -723,10 +716,6 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 				}
 
 				continue
-			}
-
-			if active {
-				appHasActive = true
 			}
 
 			// The application the compositor reports as focused wins outright,
@@ -759,30 +748,24 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 				haveSA = true
 			}
 		}
-
-		if appHasActive {
-			appsWithActive++
-		}
 	}
+
+	// The AT-SPI ACTIVE state reliably marks the compositor-focused window only
+	// on KWin/KDE; on wlroots compositors it is set inconsistently across
+	// background frames.
+	activeStateIdentifiesFocus := platform.DetectLinuxBackend() == platform.BackendWaylandKDE
 
 	switch {
 	case haveFocusedActive:
 		return focusedActiveShowing, true
 	case haveFocusedShowing:
 		return focusedShowing, true
-	case haveFocused && appsWithActive != 1:
+	case haveFocused && !activeStateIdentifiesFocus:
 		// The compositor reports a focused application but no AT-SPI application
-		// matched it. The ACTIVE/SHOWING heuristic would return a *different*
-		// application's frame, so trust it only when ACTIVE unambiguously
-		// identifies one application (exactly one active app — as on KWin/KDE,
-		// where the focused window is the sole ACTIVE one). Otherwise (wlroots
-		// reports several active frames, or none) selecting any of them would
-		// target a background window, so return no frame (shell as a last
-		// resort) and let hints simply not appear.
-		if haveShell {
-			return shellShowing, true
-		}
-
+		// matched it, and this compositor does not set ACTIVE reliably. Every
+		// remaining candidate — a background ACTIVE/SHOWING window or the desktop
+		// shell — would target the wrong surface, so return no frame and let
+		// hints simply not appear rather than click a background/shell control.
 		return accRef{}, false
 	case haveAS:
 		return activeShowing, true

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -243,6 +243,15 @@ func (c *ATSPIClient) ClickableNodes(
 
 	start := time.Now()
 
+	// If focus changed since this window was selected, the frame is stale:
+	// walking it would surface hints for a now-background window (and any
+	// geometry would belong to a different window). Return nothing so hints do
+	// not target the wrong surface. When no focused app_id is available
+	// (X11/GNOME) there is nothing to compare, so the walk proceeds.
+	if !c.focusStableSince(win.focusedAppID) {
+		return nil, nil
+	}
+
 	// Validate the cached KWin origin against the frame actually being walked
 	// (by size): a stale origin from a previous window would offset every hint
 	// to the wrong screen position. When the frame extents are unavailable the
@@ -254,7 +263,7 @@ func (c *ATSPIClient) ClickableNodes(
 	)
 
 	frameRect, frameOK := c.extents(conn, win.ref)
-	if frameOK && c.focusStableSince(win.focusedAppID) {
+	if frameOK {
 		originX, originY, ok := c.windowOrigin.originFor(frameRect.Dx(), frameRect.Dy())
 		if ok {
 			// AT-SPI reports element coordinates in the app's own space, where the
@@ -655,19 +664,23 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 	root := accRef{Name: atspiRegistryDest, Path: atspiRootPath}
 
 	// Compositor-reported focused app_id (Wayland wlroots/KWin); empty on X11,
-	// GNOME, or when nothing is focused yet.
+	// GNOME, or when nothing is focused yet. The focused title disambiguates
+	// multiple windows of the focused application, which share an app_id.
 	focusedAppID, haveFocused := linux.WaylandFocusedAppID()
+	focusedTitle, haveFocusedTitle := linux.WaylandFocusedAppTitle()
 
 	var (
 		// Frames whose application matches the compositor's focused app_id — the
 		// most reliable signal on Wayland, so they win over the ACTIVE heuristic.
-		// When that app has several visible windows, prefer the one the app's own
-		// toolkit marks ACTIVE (reliable within a single app, unlike the cross-app
-		// ACTIVE state) so a background window of the focused app cannot win.
-		focusedActiveShowing accRef
-		haveFocusedActive    bool
-		focusedShowing       accRef
-		haveFocusedShowing   bool
+		// When that app has several visible windows, prefer the one whose title
+		// matches the focused toplevel's title, then the one the toolkit marks
+		// ACTIVE, so a background window of the focused app cannot win.
+		focusedTitleFrame     accRef
+		haveFocusedTitleMatch bool
+		focusedActiveShowing  accRef
+		haveFocusedActive     bool
+		focusedShowing        accRef
+		haveFocusedShowing    bool
 
 		activeShowing accRef
 		haveAS        bool
@@ -720,8 +733,16 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 
 			// The application the compositor reports as focused wins outright,
 			// regardless of the (unreliable) cross-app AT-SPI ACTIVE state. Among
-			// that app's visible windows, prefer the one it marks ACTIVE.
+			// that app's visible windows, prefer the one whose title matches the
+			// focused toplevel, then the one it marks ACTIVE, then the first
+			// showing one.
 			if matchesFocused && showing {
+				if haveFocusedTitle && !haveFocusedTitleMatch &&
+					titleMatchesFocused(c.name(conn, frame), focusedTitle) {
+					focusedTitleFrame = frame
+					haveFocusedTitleMatch = true
+				}
+
 				if active && !haveFocusedActive {
 					focusedActiveShowing = frame
 					haveFocusedActive = true
@@ -756,6 +777,8 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 	activeStateIdentifiesFocus := platform.DetectLinuxBackend() == platform.BackendWaylandKDE
 
 	switch {
+	case haveFocusedTitleMatch:
+		return focusedTitleFrame, true
 	case haveFocusedActive:
 		return focusedActiveShowing, true
 	case haveFocusedShowing:
@@ -778,6 +801,16 @@ func (c *ATSPIClient) findActiveFrame(conn *dbus.Conn) (accRef, bool) {
 	default:
 		return accRef{}, false
 	}
+}
+
+// titleMatchesFocused reports whether an AT-SPI frame title equals the
+// compositor's focused toplevel title. Both derive from the window's
+// xdg_toplevel.title, so a whitespace-trimmed exact comparison disambiguates
+// windows of the same application. Empty titles never match.
+func titleMatchesFocused(frameTitle, focusedTitle string) bool {
+	frameTitle = strings.TrimSpace(frameTitle)
+
+	return frameTitle != "" && frameTitle == strings.TrimSpace(focusedTitle)
 }
 
 // appMatchesFocusedID reports whether an AT-SPI application name corresponds to

--- a/internal/core/infra/accessibility/atspi_linux_test.go
+++ b/internal/core/infra/accessibility/atspi_linux_test.go
@@ -8,6 +8,7 @@ import "testing"
 const (
 	appIDFirefox = "org.mozilla.firefox"
 	appKonsole   = "konsole"
+	titleEditor  = "Editor"
 )
 
 func TestAppMatchesFocusedID(t *testing.T) {
@@ -56,5 +57,145 @@ func TestLastDotSegment(t *testing.T) {
 		if got := lastDotSegment(tc.in); got != tc.want {
 			t.Errorf("lastDotSegment(%q) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestTitleMatchesFocused(t *testing.T) {
+	cases := []struct {
+		name         string
+		frameTitle   string
+		focusedTitle string
+		want         bool
+	}{
+		{"exact match", "Google — Mozilla Firefox", "Google — Mozilla Firefox", true},
+		{"whitespace trimmed", "  " + titleEditor + "  ", titleEditor, true},
+		{"different windows", "Tab A — Firefox", "Tab B — Firefox", false},
+		{"empty frame title never matches", "", "", false},
+		{"empty focused title", titleEditor, "", false},
+		{"empty frame with non-empty focused", "", titleEditor, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := titleMatchesFocused(tc.frameTitle, tc.focusedTitle); got != tc.want {
+				t.Errorf("titleMatchesFocused(%q, %q) = %v, want %v",
+					tc.frameTitle, tc.focusedTitle, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectFrame(t *testing.T) {
+	// Distinct refs so the test can tell which candidate was chosen.
+	var (
+		title    = accRef{Name: "title"}
+		fActive  = accRef{Name: "focused-active"}
+		fShowing = accRef{Name: "focused-showing"}
+		active   = accRef{Name: "active"}
+		activeA  = accRef{Name: "active-any"}
+		showing  = accRef{Name: "showing"}
+		shell    = accRef{Name: "shell"}
+	)
+
+	cases := []struct {
+		name   string
+		cand   frameCandidates
+		want   accRef
+		wantOK bool
+	}{
+		{
+			name: "focused title match wins over everything",
+			cand: frameCandidates{
+				focusedTitleFrame: title, haveFocusedTitle: true,
+				focusedActiveShowing: fActive, haveFocusedActive: true,
+				activeShowing: active, haveActiveShowing: true,
+				haveFocused: true,
+			},
+			want: title, wantOK: true,
+		},
+		{
+			name: "focused active beats focused showing",
+			cand: frameCandidates{
+				focusedActiveShowing: fActive, haveFocusedActive: true,
+				focusedShowing: fShowing, haveFocusedShowing: true,
+				haveFocused: true,
+			},
+			want: fActive, wantOK: true,
+		},
+		{
+			name: "focused showing beats cross-app active",
+			cand: frameCandidates{
+				focusedShowing: fShowing, haveFocusedShowing: true,
+				activeShowing: active, haveActiveShowing: true,
+				haveFocused: true,
+			},
+			want: fShowing, wantOK: true,
+		},
+		{
+			name: "KDE unmatched focus uses active frame",
+			cand: frameCandidates{
+				activeShowing: active, haveActiveShowing: true,
+				showingAny: showing, haveShowingAny: true,
+				shellShowing: shell, haveShell: true,
+				haveFocused: true, activeStateIdentifiesFocus: true,
+			},
+			want: active, wantOK: true,
+		},
+		{
+			name: "KDE unmatched focus with no active returns nothing (not showing/shell)",
+			cand: frameCandidates{
+				showingAny: showing, haveShowingAny: true,
+				shellShowing: shell, haveShell: true,
+				haveFocused: true, activeStateIdentifiesFocus: true,
+			},
+			want: accRef{}, wantOK: false,
+		},
+		{
+			name: "wlroots unmatched focus returns nothing even with active frame",
+			cand: frameCandidates{
+				activeShowing: active, haveActiveShowing: true,
+				showingAny: showing, haveShowingAny: true,
+				shellShowing: shell, haveShell: true,
+				haveFocused: true, activeStateIdentifiesFocus: false,
+			},
+			want: accRef{}, wantOK: false,
+		},
+		{
+			name: "no focused app_id (X11/GNOME) falls back to active+showing",
+			cand: frameCandidates{
+				activeShowing: active, haveActiveShowing: true,
+				activeAny: activeA, haveActiveAny: true,
+				showingAny: showing, haveShowingAny: true,
+			},
+			want: active, wantOK: true,
+		},
+		{
+			name: "no focus, only showing available",
+			cand: frameCandidates{
+				showingAny: showing, haveShowingAny: true,
+				shellShowing: shell, haveShell: true,
+			},
+			want: showing, wantOK: true,
+		},
+		{
+			name: "no focus, only shell available (last resort)",
+			cand: frameCandidates{shellShowing: shell, haveShell: true},
+			want: shell, wantOK: true,
+		},
+		{
+			name:   "nothing found",
+			cand:   frameCandidates{},
+			want:   accRef{},
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := selectFrame(tc.cand)
+			if ok != tc.wantOK || got != tc.want {
+				t.Errorf("selectFrame() = (%+v, %v), want (%+v, %v)", got, ok, tc.want, tc.wantOK)
+			}
+		})
 	}
 }

--- a/internal/core/infra/accessibility/atspi_linux_test.go
+++ b/internal/core/infra/accessibility/atspi_linux_test.go
@@ -88,13 +88,12 @@ func TestTitleMatchesFocused(t *testing.T) {
 func TestSelectFrame(t *testing.T) {
 	// Distinct refs so the test can tell which candidate was chosen.
 	var (
-		title    = accRef{Name: "title"}
-		fActive  = accRef{Name: "focused-active"}
-		fShowing = accRef{Name: "focused-showing"}
-		active   = accRef{Name: "active"}
-		activeA  = accRef{Name: "active-any"}
-		showing  = accRef{Name: "showing"}
-		shell    = accRef{Name: "shell"}
+		fTitle  = accRef{Name: "focused-title"}
+		fShow   = accRef{Name: "focused-showing"}
+		active  = accRef{Name: "active"}
+		activeA = accRef{Name: "active-any"}
+		showing = accRef{Name: "showing"}
+		shell   = accRef{Name: "shell"}
 	)
 
 	cases := []struct {
@@ -104,35 +103,57 @@ func TestSelectFrame(t *testing.T) {
 		wantOK bool
 	}{
 		{
-			name: "focused title match wins over everything",
+			name: "unique title match wins even with sibling windows",
 			cand: frameCandidates{
-				focusedTitleFrame: title, haveFocusedTitle: true,
-				focusedActiveShowing: fActive, haveFocusedActive: true,
+				focusedTitleFrame: fTitle, focusedTitleCount: 1,
+				focusedShowingFrame: fShow, focusedShowingCount: 3,
 				activeShowing: active, haveActiveShowing: true,
 				haveFocused: true,
 			},
-			want: title, wantOK: true,
+			want: fTitle, wantOK: true,
 		},
 		{
-			name: "focused active beats focused showing",
+			name: "single showing window is unambiguous without a title match",
 			cand: frameCandidates{
-				focusedActiveShowing: fActive, haveFocusedActive: true,
-				focusedShowing: fShowing, haveFocusedShowing: true,
-				haveFocused: true,
-			},
-			want: fActive, wantOK: true,
-		},
-		{
-			name: "focused showing beats cross-app active",
-			cand: frameCandidates{
-				focusedShowing: fShowing, haveFocusedShowing: true,
+				focusedShowingFrame: fShow, focusedShowingCount: 1,
 				activeShowing: active, haveActiveShowing: true,
 				haveFocused: true,
 			},
-			want: fShowing, wantOK: true,
+			want: fShow, wantOK: true,
 		},
 		{
-			name: "KDE unmatched focus uses active frame",
+			name: "ambiguous title (duplicate siblings) on KDE uses ACTIVE",
+			cand: frameCandidates{
+				focusedTitleFrame: fTitle, focusedTitleCount: 2,
+				focusedShowingFrame: fShow, focusedShowingCount: 2,
+				activeShowing: active, haveActiveShowing: true,
+				haveFocused: true, activeStateIdentifiesFocus: true,
+			},
+			want: active, wantOK: true,
+		},
+		{
+			name: "ambiguous title on wlroots returns nothing (no sibling guess)",
+			cand: frameCandidates{
+				focusedTitleFrame: fTitle, focusedTitleCount: 2,
+				focusedShowingFrame: fShow, focusedShowingCount: 2,
+				activeShowing: active, haveActiveShowing: true,
+				haveFocused: true, activeStateIdentifiesFocus: false,
+			},
+			want: accRef{}, wantOK: false,
+		},
+		{
+			name: "multi-window no title match on wlroots returns nothing",
+			cand: frameCandidates{
+				focusedShowingFrame: fShow, focusedShowingCount: 2,
+				activeShowing: active, haveActiveShowing: true,
+				showingAny: showing, haveShowingAny: true,
+				shellShowing: shell, haveShell: true,
+				haveFocused: true, activeStateIdentifiesFocus: false,
+			},
+			want: accRef{}, wantOK: false,
+		},
+		{
+			name: "name-mismatched app (no focused frame) on KDE uses ACTIVE",
 			cand: frameCandidates{
 				activeShowing: active, haveActiveShowing: true,
 				showingAny: showing, haveShowingAny: true,
@@ -142,21 +163,11 @@ func TestSelectFrame(t *testing.T) {
 			want: active, wantOK: true,
 		},
 		{
-			name: "KDE unmatched focus with no active returns nothing (not showing/shell)",
+			name: "KDE unmatched focus with no ACTIVE returns nothing (not showing/shell)",
 			cand: frameCandidates{
 				showingAny: showing, haveShowingAny: true,
 				shellShowing: shell, haveShell: true,
 				haveFocused: true, activeStateIdentifiesFocus: true,
-			},
-			want: accRef{}, wantOK: false,
-		},
-		{
-			name: "wlroots unmatched focus returns nothing even with active frame",
-			cand: frameCandidates{
-				activeShowing: active, haveActiveShowing: true,
-				showingAny: showing, haveShowingAny: true,
-				shellShowing: shell, haveShell: true,
-				haveFocused: true, activeStateIdentifiesFocus: false,
 			},
 			want: accRef{}, wantOK: false,
 		},

--- a/internal/core/infra/accessibility/atspi_linux_test.go
+++ b/internal/core/infra/accessibility/atspi_linux_test.go
@@ -1,0 +1,60 @@
+//go:build linux
+
+//nolint:testpackage // Exercises the unexported app_id matching helpers directly.
+package accessibility
+
+import "testing"
+
+const (
+	appIDFirefox = "org.mozilla.firefox"
+	appKonsole   = "konsole"
+)
+
+func TestAppMatchesFocusedID(t *testing.T) {
+	cases := []struct {
+		name      string
+		atspiName string
+		appID     string
+		want      bool
+	}{
+		{"reverse-dns app_id vs display name", "Firefox", appIDFirefox, true},
+		{"bare app_id case-insensitive", "Helium", "helium", true},
+		{"exact match", appKonsole, appKonsole, true},
+		{"reverse-dns both sides", "org.kde.konsole", appKonsole, true},
+		{"kde reverse-dns app_id", "Konsole", "org.kde.konsole", true},
+		{"no match", "Unnamed", appIDFirefox, false},
+		{"empty atspi name", "", appIDFirefox, false},
+		{"empty app_id", "Firefox", "", false},
+		{"segment does not collide", "fox", appIDFirefox, false},
+		{"different apps", "Nautilus", "org.gnome.Calculator", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := appMatchesFocusedID(tc.atspiName, tc.appID); got != tc.want {
+				t.Errorf("appMatchesFocusedID(%q, %q) = %v, want %v",
+					tc.atspiName, tc.appID, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLastDotSegment(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"org.mozilla.firefox", "firefox"},
+		{"helium", ""},
+		{"trailing.", ""},
+		{"", ""},
+		{"a.b", "b"},
+		{".leading", "leading"},
+	}
+
+	for _, tc := range cases {
+		if got := lastDotSegment(tc.in); got != tc.want {
+			t.Errorf("lastDotSegment(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/core/infra/accessibility/client.go
+++ b/internal/core/infra/accessibility/client.go
@@ -57,6 +57,11 @@ type AXClient interface {
 	SetClickableRoles(roles []string)
 	ClickableRoles() []string
 	IsMissionControlActive() bool
+	// SupportsSupplementaryElements reports whether the platform exposes the
+	// macOS-specific auxiliary surfaces hints can also scan (Dock, menu bar,
+	// Notification Center, Stage Manager, Picture-in-Picture, screen-capture
+	// UI). False on Linux/Windows so those collectors are skipped.
+	SupportsSupplementaryElements() bool
 
 	// Close releases any resources held by the client (e.g. D-Bus connections
 	// or AT-SPI accessibility status).

--- a/internal/core/infra/accessibility/hyprland_geometry_linux.go
+++ b/internal/core/infra/accessibility/hyprland_geometry_linux.go
@@ -1,0 +1,65 @@
+//go:build linux
+
+// internal/core/infra/accessibility/hyprland_geometry_linux.go
+// Hyprland window-origin source. `hyprctl -j activewindow` reports the focused
+// window's absolute position ("at") and size ("size"), which give the screen
+// origin directly.
+
+package accessibility
+
+import (
+	"go.uber.org/zap"
+)
+
+type hyprlandOriginSource struct {
+	logger *zap.Logger
+}
+
+func newHyprlandOriginSource(logger *zap.Logger) *hyprlandOriginSource {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &hyprlandOriginSource{logger: logger.Named("accessibility.hyprland")}
+}
+
+func (h *hyprlandOriginSource) start() {}
+
+// hyprlandWindow mirrors the fields of `hyprctl -j activewindow` we use.
+// "at" is [x, y] and "size" is [w, h], both in absolute screen pixels.
+type hyprlandWindow struct {
+	At   []int `json:"at"`
+	Size []int `json:"size"`
+}
+
+func (h *hyprlandOriginSource) originFor(frameW, frameH int) (int, int, bool) {
+	var win hyprlandWindow
+	if !compositorJSON(&win, "hyprctl", "-j", "activewindow") {
+		return 0, 0, false
+	}
+
+	return hyprlandComputeOrigin(win, frameW, frameH, h.logger)
+}
+
+// hyprlandComputeOrigin derives the focused window's screen origin from
+// `hyprctl activewindow` data, rejecting a size mismatch with the AT-SPI frame.
+func hyprlandComputeOrigin(
+	win hyprlandWindow,
+	frameW, frameH int,
+	logger *zap.Logger,
+) (int, int, bool) {
+	if len(win.At) < coordPairLen || len(win.Size) < coordPairLen {
+		return 0, 0, false
+	}
+
+	if absInt(win.Size[0]-frameW) > windowOriginSizeTolerance ||
+		absInt(win.Size[1]-frameH) > windowOriginSizeTolerance {
+		logger.Debug("hyprland origin rejected: window size does not match AT-SPI frame",
+			zap.Ints("windowSize", win.Size),
+			zap.Int("frameW", frameW), zap.Int("frameH", frameH))
+
+		return 0, 0, false
+	}
+
+	return win.At[0], win.At[1], true
+}

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -301,6 +301,13 @@ func (c *InfraAXClient) IsMissionControlActive() bool {
 	return IsMissionControlActive()
 }
 
+// SupportsSupplementaryElements reports whether the platform exposes the
+// macOS-specific auxiliary surfaces (Dock, menu bar, etc.). True on macOS,
+// false on Linux/Windows.
+func (c *InfraAXClient) SupportsSupplementaryElements() bool {
+	return supportsSupplementaryElements()
+}
+
 // Close is a no-op for the default infrastructure client; the macOS AX API
 // does not hold process-external resources that need explicit teardown.
 func (c *InfraAXClient) Close() error { return nil }

--- a/internal/core/infra/accessibility/mock_client.go
+++ b/internal/core/infra/accessibility/mock_client.go
@@ -179,6 +179,10 @@ func (m *MockAXClient) IsMissionControlActive() bool {
 	return m.MockMissionControlActive
 }
 
+// SupportsSupplementaryElements returns true so tests exercise the Dock/menu
+// bar/Stage Manager/PIP/screen-capture collectors regardless of host platform.
+func (m *MockAXClient) SupportsSupplementaryElements() bool { return true }
+
 // Close is a no-op for the mock.
 func (m *MockAXClient) Close() error { return nil }
 

--- a/internal/core/infra/accessibility/niri_geometry_linux.go
+++ b/internal/core/infra/accessibility/niri_geometry_linux.go
@@ -1,0 +1,89 @@
+//go:build linux
+
+// internal/core/infra/accessibility/niri_geometry_linux.go
+// niri window-origin source. niri exposes the focused window's position within
+// the workspace view (layout.tile_pos_in_workspace_view) plus the focused
+// output's logical origin, which together give the window's screen origin.
+// That field is populated for FLOATING windows; for tiled windows niri does not
+// expose the on-screen position (upstream niri#2381), so originFor reports no
+// origin and hints fall back to unoffset coordinates.
+
+package accessibility
+
+import (
+	"go.uber.org/zap"
+)
+
+type niriOriginSource struct {
+	logger *zap.Logger
+}
+
+func newNiriOriginSource(logger *zap.Logger) *niriOriginSource {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &niriOriginSource{logger: logger.Named("accessibility.niri")}
+}
+
+func (n *niriOriginSource) start() {}
+
+// niriWindow mirrors the fields of `niri msg -j focused-window` we use.
+type niriWindow struct {
+	Layout struct {
+		WindowSize             []int     `json:"window_size"`                //nolint:tagliatelle // niri wire format is snake_case.
+		TilePosInWorkspaceView []float64 `json:"tile_pos_in_workspace_view"` //nolint:tagliatelle // niri wire format is snake_case.
+	} `json:"layout"`
+}
+
+// niriOutput mirrors the fields of `niri msg -j focused-output` we use.
+type niriOutput struct {
+	Logical struct {
+		X int `json:"x"`
+		Y int `json:"y"`
+	} `json:"logical"`
+}
+
+func (n *niriOriginSource) originFor(frameW, frameH int) (int, int, bool) {
+	var win niriWindow
+	if !compositorJSON(&win, "niri", "msg", "-j", "focused-window") {
+		return 0, 0, false
+	}
+
+	var out niriOutput
+	if !compositorJSON(&out, "niri", "msg", "-j", "focused-output") {
+		return 0, 0, false
+	}
+
+	return niriComputeOrigin(win, out, frameW, frameH, n.logger)
+}
+
+// niriComputeOrigin derives the focused window's screen origin from niri's
+// focused-window + focused-output data. It reports no origin for tiled windows
+// (tile_pos_in_workspace_view absent — niri#2381) and when the window size does
+// not match the AT-SPI frame (a focus change raced the query).
+func niriComputeOrigin(
+	win niriWindow,
+	out niriOutput,
+	frameW, frameH int,
+	logger *zap.Logger,
+) (int, int, bool) {
+	tile := win.Layout.TilePosInWorkspaceView
+	if len(tile) < coordPairLen {
+		logger.Debug("niri origin unavailable: tiled window (niri#2381)")
+
+		return 0, 0, false
+	}
+
+	if len(win.Layout.WindowSize) < coordPairLen ||
+		absInt(win.Layout.WindowSize[0]-frameW) > windowOriginSizeTolerance ||
+		absInt(win.Layout.WindowSize[1]-frameH) > windowOriginSizeTolerance {
+		logger.Debug("niri origin rejected: window size does not match AT-SPI frame",
+			zap.Ints("windowSize", win.Layout.WindowSize),
+			zap.Int("frameW", frameW), zap.Int("frameH", frameH))
+
+		return 0, 0, false
+	}
+
+	return out.Logical.X + int(tile[0]), out.Logical.Y + int(tile[1]), true
+}

--- a/internal/core/infra/accessibility/supplementary_darwin.go
+++ b/internal/core/infra/accessibility/supplementary_darwin.go
@@ -1,0 +1,10 @@
+//go:build darwin
+
+package accessibility
+
+// supportsSupplementaryElements reports whether the platform exposes the
+// macOS-specific auxiliary surfaces that hints can additionally scan — the menu
+// bar, Dock, Notification Center, Stage Manager, Picture-in-Picture, and the
+// screen-capture UI. These are resolved by bundle ID through the accessibility
+// API and exist only on macOS.
+func supportsSupplementaryElements() bool { return true }

--- a/internal/core/infra/accessibility/supplementary_other.go
+++ b/internal/core/infra/accessibility/supplementary_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin
+
+package accessibility
+
+// supportsSupplementaryElements reports whether the platform exposes the
+// macOS-specific auxiliary surfaces (Dock, menu bar, Notification Center, Stage
+// Manager, Picture-in-Picture, screen-capture UI). They exist only on macOS, so
+// hints skip them elsewhere instead of probing for nonexistent system apps by
+// bundle ID — which otherwise just logs "application not found" warnings.
+func supportsSupplementaryElements() bool { return false }

--- a/internal/core/infra/accessibility/sway_geometry_linux.go
+++ b/internal/core/infra/accessibility/sway_geometry_linux.go
@@ -1,0 +1,106 @@
+//go:build linux
+
+// internal/core/infra/accessibility/sway_geometry_linux.go
+// Sway window-origin source. `swaymsg -t get_tree` returns the full node tree;
+// the focused node's on-screen content origin is rect + window_rect (window_rect
+// is the content area relative to rect, i.e. it excludes server-side
+// decorations so it aligns with the AT-SPI content origin).
+
+package accessibility
+
+import (
+	"go.uber.org/zap"
+)
+
+type swayOriginSource struct {
+	logger *zap.Logger
+}
+
+func newSwayOriginSource(logger *zap.Logger) *swayOriginSource {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &swayOriginSource{logger: logger.Named("accessibility.sway")}
+}
+
+func (s *swayOriginSource) start() {}
+
+type swayRect struct {
+	X      int `json:"x"`
+	Y      int `json:"y"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+// swayNode mirrors the fields of `swaymsg -t get_tree` we use. rect is the
+// node's absolute geometry; window_rect is the content area relative to rect.
+type swayNode struct {
+	Focused       bool       `json:"focused"`
+	Rect          swayRect   `json:"rect"`
+	WindowRect    swayRect   `json:"window_rect"` //nolint:tagliatelle // sway wire format is snake_case.
+	Nodes         []swayNode `json:"nodes"`
+	FloatingNodes []swayNode `json:"floating_nodes"` //nolint:tagliatelle // sway wire format is snake_case.
+}
+
+// findFocused returns the focused node in the tree, if any.
+func findFocused(node *swayNode) *swayNode {
+	if node.Focused {
+		return node
+	}
+
+	for i := range node.Nodes {
+		if hit := findFocused(&node.Nodes[i]); hit != nil {
+			return hit
+		}
+	}
+
+	for i := range node.FloatingNodes {
+		if hit := findFocused(&node.FloatingNodes[i]); hit != nil {
+			return hit
+		}
+	}
+
+	return nil
+}
+
+func (s *swayOriginSource) originFor(frameW, frameH int) (int, int, bool) {
+	var tree swayNode
+	if !compositorJSON(&tree, "swaymsg", "-t", "get_tree") {
+		return 0, 0, false
+	}
+
+	return swayComputeOrigin(&tree, frameW, frameH, s.logger)
+}
+
+// swayComputeOrigin finds the focused node in a sway tree and derives its
+// on-screen content origin (rect + window_rect, which excludes decorations),
+// rejecting a size mismatch with the AT-SPI frame.
+func swayComputeOrigin(tree *swayNode, frameW, frameH int, logger *zap.Logger) (int, int, bool) {
+	focused := findFocused(tree)
+	if focused == nil {
+		return 0, 0, false
+	}
+
+	// Content origin/size: prefer window_rect (excludes decorations); fall back
+	// to rect when window_rect carries no size.
+	contentW, contentH := focused.WindowRect.Width, focused.WindowRect.Height
+	originX := focused.Rect.X + focused.WindowRect.X
+	originY := focused.Rect.Y + focused.WindowRect.Y
+
+	if contentW <= 0 || contentH <= 0 {
+		contentW, contentH = focused.Rect.Width, focused.Rect.Height
+		originX, originY = focused.Rect.X, focused.Rect.Y
+	}
+
+	if absInt(contentW-frameW) > windowOriginSizeTolerance ||
+		absInt(contentH-frameH) > windowOriginSizeTolerance {
+		logger.Debug("sway origin rejected: window size does not match AT-SPI frame",
+			zap.Int("contentW", contentW), zap.Int("contentH", contentH),
+			zap.Int("frameW", frameW), zap.Int("frameH", frameH))
+
+		return 0, 0, false
+	}
+
+	return originX, originY, true
+}

--- a/internal/core/infra/accessibility/window_origin_linux.go
+++ b/internal/core/infra/accessibility/window_origin_linux.go
@@ -1,0 +1,81 @@
+//go:build linux
+
+// internal/core/infra/accessibility/window_origin_linux.go
+// Window-origin sources for Wayland. A Wayland client cannot know its own
+// on-screen position, so AT-SPI reports element coordinates relative to the
+// window. To turn those into true screen coordinates for the hint overlay, the
+// focused window's screen origin is supplied by a compositor-specific source:
+// KWin (KDE) pushes it over D-Bus; the wlroots family (niri, Sway, Hyprland)
+// exposes it via their IPC. Every source is best-effort — when the origin
+// cannot be determined, callers fall back to unoffset (window-relative)
+// coordinates.
+
+package accessibility
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// compositorQueryTimeout bounds each compositor IPC call so a wedged
+// compositor cannot stall hint activation.
+const compositorQueryTimeout = 500 * time.Millisecond
+
+// coordPairLen is the length of a [x,y] / [w,h] pair in compositor JSON.
+const coordPairLen = 2
+
+// compositorJSON runs a compositor CLI (name + args) and decodes its JSON
+// stdout into dst. Returns false on spawn error, non-zero exit, timeout, or
+// malformed JSON — callers then fall back to unoffset coordinates.
+func compositorJSON(dst any, name string, args ...string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), compositorQueryTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, name, args...).Output()
+	if err != nil {
+		return false
+	}
+
+	return json.Unmarshal(out, dst) == nil
+}
+
+// windowOriginSizeTolerance is the max per-dimension difference (px) allowed
+// between the compositor-reported window size and the AT-SPI frame extents
+// before the reported origin is treated as belonging to a different window
+// (focus can change between the AT-SPI walk and the geometry query). Qt apps
+// match exactly; GTK/CSD apps can differ by a title bar's worth of pixels.
+const windowOriginSizeTolerance = 32
+
+// windowOriginSource supplies the focused window's on-screen origin so AT-SPI
+// window-relative element coordinates can be offset into screen coordinates.
+type windowOriginSource interface {
+	// start performs any one-time setup. Best-effort; failures are logged.
+	start()
+	// originFor returns the focused window's screen origin, but only when its
+	// size matches the given AT-SPI frame extents within
+	// windowOriginSizeTolerance. ok is false when the origin is unknown or
+	// stale, in which case callers use unoffset coordinates.
+	originFor(frameW, frameH int) (x, y int, ok bool)
+}
+
+// newWindowOriginSource selects the geometry source for the running compositor.
+// The wlroots-family IPC environment variables are checked first because they
+// are only set under their respective compositor; otherwise the KWin bridge is
+// used (KDE, or a harmless no-op that never reports an origin elsewhere).
+func newWindowOriginSource(logger *zap.Logger) windowOriginSource {
+	switch {
+	case os.Getenv("NIRI_SOCKET") != "":
+		return newNiriOriginSource(logger)
+	case os.Getenv("SWAYSOCK") != "":
+		return newSwayOriginSource(logger)
+	case os.Getenv("HYPRLAND_INSTANCE_SIGNATURE") != "":
+		return newHyprlandOriginSource(logger)
+	default:
+		return newKWinBridge(logger)
+	}
+}

--- a/internal/core/infra/accessibility/window_origin_linux_test.go
+++ b/internal/core/infra/accessibility/window_origin_linux_test.go
@@ -1,0 +1,163 @@
+//go:build linux
+
+//nolint:testpackage // Exercises the unexported per-compositor origin helpers directly.
+package accessibility
+
+import (
+	"encoding/json"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestNiriComputeOrigin(t *testing.T) {
+	out := niriOutput{}
+	out.Logical.X = 100
+	out.Logical.Y = 10
+
+	makeWindow := func(size []int, tile []float64) niriWindow {
+		var w niriWindow
+
+		w.Layout.WindowSize = size
+		w.Layout.TilePosInWorkspaceView = tile
+
+		return w
+	}
+
+	cases := []struct {
+		name           string
+		win            niriWindow
+		frameW, frameH int
+		wantX, wantY   int
+		wantOK         bool
+	}{
+		{
+			"floating window offset by output+tile",
+			makeWindow([]int{946, 942}, []float64{958, 52}),
+			946,
+			942,
+			1058,
+			62,
+			true,
+		},
+		{"tiled window has no tile_pos", makeWindow([]int{946, 942}, nil), 946, 942, 0, 0, false},
+		{
+			"size mismatch rejected",
+			makeWindow([]int{946, 942}, []float64{958, 52}),
+			500,
+			942,
+			0,
+			0,
+			false,
+		},
+		{
+			"size within tolerance accepted",
+			makeWindow([]int{946, 942}, []float64{958, 52}),
+			950,
+			940,
+			1058,
+			62,
+			true,
+		},
+		{
+			"missing window_size rejected",
+			makeWindow(nil, []float64{958, 52}),
+			946,
+			942,
+			0,
+			0,
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			x, y, ok := niriComputeOrigin(tc.win, out, tc.frameW, tc.frameH, zap.NewNop())
+			if ok != tc.wantOK || (ok && (x != tc.wantX || y != tc.wantY)) {
+				t.Errorf("got (%d,%d,%v), want (%d,%d,%v)", x, y, ok, tc.wantX, tc.wantY, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestHyprlandComputeOrigin(t *testing.T) {
+	cases := []struct {
+		name           string
+		win            hyprlandWindow
+		frameW, frameH int
+		wantX, wantY   int
+		wantOK         bool
+	}{
+		{
+			"active window at/size",
+			hyprlandWindow{At: []int{958, 52}, Size: []int{946, 942}},
+			946,
+			942,
+			958,
+			52,
+			true,
+		},
+		{
+			"size mismatch rejected",
+			hyprlandWindow{At: []int{958, 52}, Size: []int{946, 942}},
+			500,
+			500,
+			0,
+			0,
+			false,
+		},
+		{"missing at rejected", hyprlandWindow{Size: []int{946, 942}}, 946, 942, 0, 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			x, y, ok := hyprlandComputeOrigin(tc.win, tc.frameW, tc.frameH, zap.NewNop())
+			if ok != tc.wantOK || (ok && (x != tc.wantX || y != tc.wantY)) {
+				t.Errorf("got (%d,%d,%v), want (%d,%d,%v)", x, y, ok, tc.wantX, tc.wantY, tc.wantOK)
+			}
+		})
+	}
+}
+
+// swayTreeJSON is a trimmed `swaymsg -t get_tree` with a focused window nested
+// under output → workspace → container, plus a decoration offset in window_rect.
+const swayTreeJSON = `{
+  "focused": false, "rect": {"x":0,"y":0,"width":1920,"height":1080},
+  "window_rect": {"x":0,"y":0,"width":0,"height":0},
+  "nodes": [
+    {"focused": false, "rect": {"x":960,"y":0,"width":960,"height":1080},
+     "window_rect": {"x":0,"y":0,"width":0,"height":0},
+     "nodes": [
+       {"focused": true, "rect": {"x":960,"y":0,"width":960,"height":1080},
+        "window_rect": {"x":2,"y":24,"width":956,"height":1052}, "nodes": [], "floating_nodes": []}
+     ], "floating_nodes": []}
+  ], "floating_nodes": []
+}`
+
+func TestSwayComputeOrigin(t *testing.T) {
+	var tree swayNode
+
+	err := json.Unmarshal([]byte(swayTreeJSON), &tree)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Content origin = rect(960,0) + window_rect(2,24) = (962,24); content size
+	// = window_rect 956x1052.
+	x, y, ok := swayComputeOrigin(&tree, 956, 1052, zap.NewNop())
+	if !ok || x != 962 || y != 24 {
+		t.Fatalf("focused content origin: got (%d,%d,%v), want (962,24,true)", x, y, ok)
+	}
+
+	// Size mismatch against the content size is rejected.
+	if _, _, ok := swayComputeOrigin(&tree, 500, 500, zap.NewNop()); ok {
+		t.Fatal("expected size mismatch to be rejected")
+	}
+}
+
+func TestSwayFindFocusedNoneFocused(t *testing.T) {
+	tree := swayNode{Focused: false, Nodes: []swayNode{{Focused: false}}}
+	if findFocused(&tree) != nil {
+		t.Fatal("expected no focused node")
+	}
+}

--- a/internal/core/infra/appwatcher/platform_linux.go
+++ b/internal/core/infra/appwatcher/platform_linux.go
@@ -1,0 +1,160 @@
+//go:build linux
+
+// internal/core/infra/appwatcher/platform_linux.go
+// Linux app-watcher backend. macOS receives focus changes from an NSWorkspace
+// observer; Linux has no equivalent push API, so this polls the focused
+// application's identity (app_id on Wayland wlroots/KDE, WM_CLASS on X11) and
+// dispatches activate/deactivate events when it changes. GNOME/Mutter exposes
+// no focused-app source, so the poll yields nothing and no events fire there.
+
+package appwatcher
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/infra/platform"
+	"github.com/y3owk1n/neru/internal/core/infra/platform/linux"
+)
+
+// focusPollInterval is how often the focused application is sampled. It trades
+// switch latency (per-app hotkeys re-register on the next poll after an
+// alt-tab) against idle cost (one lightweight focus query per interval).
+const focusPollInterval = 400 * time.Millisecond
+
+// globalLinuxWatcher is the process-wide app watcher, mirroring the single
+// darwin.SetAppWatcher registration. NewWatcher registers itself here via
+// platformRegisterWatcher.
+var globalLinuxWatcher = &linuxAppWatcher{
+	identity: linux.FocusedAppID,
+	interval: focusPollInterval,
+}
+
+// linuxAppWatcher polls the focused-application identity and dispatches
+// activation changes to the registered Watcher.
+type linuxAppWatcher struct {
+	// identity resolves the focused app_id for a backend; injectable for tests.
+	identity func(backend string) (string, bool)
+	interval time.Duration
+
+	mu      sync.Mutex
+	watcher *Watcher
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+
+	// last is the most recently dispatched app_id ("" means "none focused").
+	// It is owned exclusively by the poll goroutine, so it needs no lock.
+	last string
+}
+
+// register records the Watcher that poll events are dispatched to.
+func (l *linuxAppWatcher) register(w *Watcher) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.watcher = w
+}
+
+// start launches the poll loop. It is idempotent: a second call while already
+// running is a no-op.
+func (l *linuxAppWatcher) start() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.watcher == nil || l.cancel != nil {
+		return
+	}
+
+	backend := platform.DetectLinuxBackend().String()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	l.cancel = cancel
+	l.last = ""
+
+	l.wg.Add(1)
+
+	go l.loop(ctx, backend)
+}
+
+// stop halts the poll loop and waits for it to exit.
+func (l *linuxAppWatcher) stop() {
+	l.mu.Lock()
+
+	if l.cancel == nil {
+		l.mu.Unlock()
+
+		return
+	}
+
+	cancel := l.cancel
+	l.cancel = nil
+
+	l.mu.Unlock()
+
+	cancel()
+	l.wg.Wait()
+}
+
+// loop samples the focused application every interval until the context is
+// canceled, dispatching a deactivate/activate pair on each change.
+func (l *linuxAppWatcher) loop(ctx context.Context, backend string) {
+	defer l.wg.Done()
+
+	ticker := time.NewTicker(l.interval)
+	defer ticker.Stop()
+
+	// Sample once immediately so per-app state converges without waiting a
+	// full interval for the first tick.
+	l.tick(backend)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			l.tick(backend)
+		}
+	}
+}
+
+// tick samples the focused application once and dispatches activation changes.
+// A transition to "no focused app" (ok == false) emits a deactivate for the
+// previous app with no matching activate.
+func (l *linuxAppWatcher) tick(backend string) {
+	appID, ok := l.identity(backend)
+	if !ok {
+		appID = ""
+	}
+
+	if appID == l.last {
+		return
+	}
+
+	prev := l.last
+	l.last = appID
+
+	// On Linux the app_id is the only identity available, so it serves as both
+	// the human-facing app name and the per-app bundle identifier.
+	if prev != "" {
+		l.watcher.HandleDeactivate(prev, prev)
+	}
+
+	if appID != "" {
+		l.watcher.logger.Debug("App watcher: focused app changed",
+			zap.String("app_id", appID),
+			zap.String("previous", prev),
+			zap.String("backend", backend))
+		l.watcher.HandleActivate(appID, appID)
+	}
+}
+
+func platformRegisterWatcher(w *Watcher) { globalLinuxWatcher.register(w) }
+func platformStartWatcher()              { globalLinuxWatcher.start() }
+func platformStopWatcher()               { globalLinuxWatcher.stop() }
+
+// platformSetMCDetection is a no-op on Linux: Mission Control is a macOS
+// concept with no Linux equivalent.
+func platformSetMCDetection(_ bool) {}

--- a/internal/core/infra/appwatcher/platform_linux_test.go
+++ b/internal/core/infra/appwatcher/platform_linux_test.go
@@ -1,0 +1,206 @@
+//go:build linux
+
+//nolint:testpackage // Exercises the unexported linuxAppWatcher poll/dispatch logic directly.
+package appwatcher
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	kindActivate   = "activate"
+	kindDeactivate = "deactivate"
+
+	appFirefox = "firefox"
+	appKonsole = "org.kde.konsole"
+)
+
+type watchEvent struct {
+	kind   string
+	name   string
+	bundle string
+}
+
+// newRecordingWatcher returns a Watcher whose activate/deactivate events are
+// appended to the returned slice pointer.
+func newRecordingWatcher() (*Watcher, *[]watchEvent) {
+	watcher := NewWatcher(nil)
+
+	var events []watchEvent
+
+	watcher.OnActivate(func(name, bundle string) {
+		events = append(events, watchEvent{kindActivate, name, bundle})
+	})
+	watcher.OnDeactivate(func(name, bundle string) {
+		events = append(events, watchEvent{kindDeactivate, name, bundle})
+	})
+
+	return watcher, &events
+}
+
+func TestLinuxAppWatcherTickDispatch(t *testing.T) {
+	watcher, events := newRecordingWatcher()
+
+	var (
+		curID string
+		curOK bool
+	)
+
+	poller := &linuxAppWatcher{
+		identity: func(string) (string, bool) { return curID, curOK },
+		interval: time.Millisecond,
+		watcher:  watcher,
+	}
+
+	steps := []struct {
+		name     string
+		id       string
+		ok       bool
+		expected []watchEvent
+	}{
+		{
+			name: "initial focus emits activate only",
+			id:   appFirefox, ok: true,
+			expected: []watchEvent{{kindActivate, appFirefox, appFirefox}},
+		},
+		{
+			name: "same app repeated emits nothing",
+			id:   appFirefox, ok: true,
+			expected: nil,
+		},
+		{
+			name: "switch app emits deactivate then activate",
+			id:   appKonsole, ok: true,
+			expected: []watchEvent{
+				{kindDeactivate, appFirefox, appFirefox},
+				{kindActivate, appKonsole, appKonsole},
+			},
+		},
+		{
+			name: "focus lost emits deactivate only",
+			id:   "", ok: false,
+			expected: []watchEvent{{kindDeactivate, appKonsole, appKonsole}},
+		},
+		{
+			name: "still no focus emits nothing",
+			id:   "", ok: false,
+			expected: nil,
+		},
+		{
+			name: "regain focus emits activate only",
+			id:   appFirefox, ok: true,
+			expected: []watchEvent{{kindActivate, appFirefox, appFirefox}},
+		},
+	}
+
+	for _, step := range steps {
+		curID, curOK = step.id, step.ok
+		*events = nil
+
+		poller.tick("x11")
+
+		if !eventsEqual(*events, step.expected) {
+			t.Errorf("%s: got %+v, want %+v", step.name, *events, step.expected)
+		}
+	}
+}
+
+// TestLinuxAppWatcherOKFalseWithIDTreatedAsNoFocus ensures a non-ok result is
+// treated as "no focus" even when the identity returns a stray non-empty id.
+func TestLinuxAppWatcherOKFalseWithIDTreatedAsNoFocus(t *testing.T) {
+	watcher, events := newRecordingWatcher()
+
+	poller := &linuxAppWatcher{
+		identity: func(string) (string, bool) { return "stale", false },
+		interval: time.Millisecond,
+		watcher:  watcher,
+	}
+
+	poller.tick("wayland-kde")
+
+	if len(*events) != 0 {
+		t.Fatalf("expected no events when ok=false, got %+v", *events)
+	}
+
+	if poller.last != "" {
+		t.Fatalf("expected last to stay empty, got %q", poller.last)
+	}
+}
+
+func TestLinuxAppWatcherStartStopLifecycle(t *testing.T) {
+	watcher, _ := newRecordingWatcher()
+
+	var callMu sync.Mutex
+
+	calls := 0
+
+	poller := &linuxAppWatcher{
+		identity: func(string) (string, bool) {
+			callMu.Lock()
+			calls++
+			callMu.Unlock()
+
+			return "app", true
+		},
+		interval: time.Millisecond,
+		watcher:  watcher,
+	}
+
+	// stop before start must be safe.
+	poller.stop()
+
+	poller.start()
+
+	// start is idempotent while running.
+	poller.start()
+
+	// Give the poll loop time to run a few ticks.
+	time.Sleep(20 * time.Millisecond)
+
+	poller.stop()
+
+	callMu.Lock()
+	got := calls
+	callMu.Unlock()
+
+	if got == 0 {
+		t.Fatal("expected the poll loop to sample identity at least once")
+	}
+
+	// stop is idempotent.
+	poller.stop()
+}
+
+func TestLinuxAppWatcherStartWithoutWatcherIsNoop(t *testing.T) {
+	poller := &linuxAppWatcher{
+		identity: func(string) (string, bool) { return "app", true },
+		interval: time.Millisecond,
+	}
+
+	poller.start()
+	defer poller.stop()
+
+	poller.mu.Lock()
+	running := poller.cancel != nil
+	poller.mu.Unlock()
+
+	if running {
+		t.Fatal("start with no registered watcher should not launch the poll loop")
+	}
+}
+
+func eventsEqual(left, right []watchEvent) bool {
+	if len(left) != len(right) {
+		return false
+	}
+
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/core/infra/appwatcher/platform_other.go
+++ b/internal/core/infra/appwatcher/platform_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 package appwatcher
 

--- a/internal/core/infra/platform/linux/overlay_wayland.c
+++ b/internal/core/infra/platform/linux/overlay_wayland.c
@@ -811,9 +811,55 @@ void neru_wayland_overlay_rounded_rect(
 	}
 }
 
+// neru_resolve_font_family returns a font family cairo's toy API can actually
+// render, substituting a generic fallback when the requested family fails.
+//
+// This guards against a subtle, catastrophic failure mode: on some
+// cairo/fontconfig setups (e.g. certain Nix closures on non-NixOS hosts)
+// cairo_show_text with a specific family name — even a common one like
+// "DejaVu Sans" — fails with CAIRO_STATUS_NO_MEMORY, which permanently poisons
+// the cairo context so every subsequent draw silently no-ops. Generic families
+// ("sans-serif", "monospace", ...) resolve fine there. We probe the requested
+// family on a throwaway context (never touching a real buffer context, so a
+// failure cannot poison it) and fall back to "sans-serif" when it fails. The
+// result is cached for the last family, since a single draw pass uses one
+// family for all its glyphs.
+static const char *neru_resolve_font_family(const char *family) {
+	static char cache_key[128];
+	static char cache_val[128];
+	static int cache_valid = 0;
+
+	if (family == NULL || family[0] == '\0')
+		return "sans-serif";
+
+	if (cache_valid && strncmp(cache_key, family, sizeof(cache_key)) == 0)
+		return cache_val;
+
+	const char *resolved = family;
+
+	cairo_surface_t *probe = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 8, 8);
+	cairo_t *cr = cairo_create(probe);
+	cairo_select_font_face(cr, family, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+	cairo_set_font_size(cr, 10.0);
+	cairo_move_to(cr, 0.0, 6.0);
+	cairo_show_text(cr, "A");
+	if (cairo_status(cr) != CAIRO_STATUS_SUCCESS)
+		resolved = "sans-serif";
+	cairo_destroy(cr);
+	cairo_surface_destroy(probe);
+
+	snprintf(cache_key, sizeof(cache_key), "%s", family);
+	snprintf(cache_val, sizeof(cache_val), "%s", resolved);
+	cache_valid = 1;
+
+	return cache_val;
+}
+
 void neru_wayland_overlay_text(
     NeruWaylandOverlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
     unsigned int color) {
+	const char *resolved_family = neru_resolve_font_family(font_family);
+
 	for (int i = 0; i < overlay->nr_screens; i++) {
 		NeruWaylandOverlayScreen *scr = &overlay->screens[i];
 		if (!scr->cr)
@@ -826,7 +872,7 @@ void neru_wayland_overlay_text(
 		cairo_t *cr = scr->cr;
 		cairo_text_extents_t extents;
 		cairo_save(cr);
-		cairo_select_font_face(cr, font_family, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
+		cairo_select_font_face(cr, resolved_family, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
 		cairo_set_font_size(cr, font_size);
 		cairo_text_extents(cr, text, &extents);
 		neru_wayland_overlay_color(cr, color);

--- a/internal/core/infra/platform/linux/system_linux_focused_app.go
+++ b/internal/core/infra/platform/linux/system_linux_focused_app.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+// internal/core/infra/platform/linux/system_linux_focused_app.go
+// Focused-application identity for Linux, used by the app watcher to detect
+// foreground-app changes and by per-app configuration lookups. Returns the
+// app_id (Wayland wlr-foreign-toplevel) or WM_CLASS (X11) that Neru keys
+// per-app config on. GNOME/Mutter and unknown backends report no identity.
+
+package linux
+
+// FocusedAppID returns the focused application's identifier for the given
+// backend (as produced by platform.LinuxBackend.String()) and whether one is
+// available. The identifier is the WM_CLASS on X11 and the app_id on Wayland
+// wlroots/KDE — the same value per-app configuration is keyed on. It is empty
+// (ok == false) on GNOME/Mutter (no wlr-foreign-toplevel manager), on unknown
+// backends, when nothing is focused yet, or on CGO-disabled builds.
+func FocusedAppID(backend string) (string, bool) {
+	switch backend {
+	case backendX11:
+		return x11FocusedAppID()
+	case backendWaylandWlroots, backendWaylandKDE:
+		return WaylandFocusedAppID()
+	default:
+		return "", false
+	}
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland.go
@@ -79,10 +79,11 @@ func WaylandFocusedAppID() (string, bool) {
 	return wlrootsFocusedAppID()
 }
 
-// WaylandFocusedAppTitle returns the title of the focused toplevel (via
-// wlr-foreign-toplevel-management), used to disambiguate multiple windows of
-// the focused application, which share an app_id. The bool is false when no
-// title is available (GNOME/Mutter, nothing focused, or CGO disabled).
-func WaylandFocusedAppTitle() (string, bool) {
-	return wlrootsFocusedAppTitle()
+// WaylandFocusedAppIdentity returns the focused toplevel's app_id and title
+// together (via wlr-foreign-toplevel-management), read under a single lock so
+// they always describe the same window. The title disambiguates multiple
+// windows of the focused application, which share an app_id. The bool is false
+// when nothing is focused (GNOME/Mutter, or CGO disabled).
+func WaylandFocusedAppIdentity() (string, string, bool) {
+	return wlrootsFocusedAppIdentity()
 }

--- a/internal/core/infra/platform/linux/system_linux_wayland.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland.go
@@ -78,3 +78,11 @@ func WaylandKeyEvent(keycode uint32, pressed bool) error {
 func WaylandFocusedAppID() (string, bool) {
 	return wlrootsFocusedAppID()
 }
+
+// WaylandFocusedAppTitle returns the title of the focused toplevel (via
+// wlr-foreign-toplevel-management), used to disambiguate multiple windows of
+// the focused application, which share an app_id. The bool is false when no
+// title is available (GNOME/Mutter, nothing focused, or CGO disabled).
+func WaylandFocusedAppTitle() (string, bool) {
+	return wlrootsFocusedAppTitle()
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -192,14 +192,15 @@ func wlrootsFocusedAppID() (string, bool) {
 // wlrootsFocusedTitleBufferSize matches NERU_TITLE_LEN in wlroots_client.h.
 const wlrootsFocusedTitleBufferSize = 512
 
-// wlrootsFocusedAppTitle returns the title of the currently activated (focused)
-// toplevel. The bool is false when no manager is present or nothing is focused.
-// The title disambiguates multiple windows of the focused application, which
-// share an app_id.
-func wlrootsFocusedAppTitle() (string, bool) {
+// wlrootsFocusedAppIdentity returns the app_id and title of the currently
+// activated (focused) toplevel, read together under a single lock so they
+// always describe the same window. The bool is false when no manager is present
+// or nothing is focused. The title disambiguates multiple windows of the
+// focused application, which share an app_id.
+func wlrootsFocusedAppIdentity() (string, string, bool) {
 	err := ensureWlrootsState()
 	if err != nil {
-		return "", false
+		return "", "", false
 	}
 
 	globalWlrootsState.mu.RLock()
@@ -207,17 +208,26 @@ func wlrootsFocusedAppTitle() (string, bool) {
 
 	client := globalWlrootsState.client
 	if client == nil {
-		return "", false
+		return "", "", false
 	}
 
-	buf := make([]C.char, wlrootsFocusedTitleBufferSize)
-	bufLen := C.int(wlrootsFocusedTitleBufferSize)
+	appBuf := make([]C.char, wlrootsFocusedAppIDBufferSize)
+	titleBuf := make([]C.char, wlrootsFocusedTitleBufferSize)
+	appLen := C.int(wlrootsFocusedAppIDBufferSize)
+	titleLen := C.int(wlrootsFocusedTitleBufferSize)
 
-	if C.neru_wlr_focused_app_title(client, &buf[0], bufLen) == 0 { //nolint:nlreturn
-		return "", false
+	found := C.neru_wlr_focused_app_identity( //nolint:nlreturn
+		client,
+		&appBuf[0],
+		appLen,
+		&titleBuf[0],
+		titleLen, //nolint:nlreturn
+	)
+	if found == 0 {
+		return "", "", false
 	}
 
-	return C.GoString(&buf[0]), true
+	return C.GoString(&appBuf[0]), C.GoString(&titleBuf[0]), true
 }
 
 // wlrootsSetCursor mirrors an externally-injected pointer position (e.g. a

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -189,6 +189,37 @@ func wlrootsFocusedAppID() (string, bool) {
 	return C.GoString(&buf[0]), true
 }
 
+// wlrootsFocusedTitleBufferSize matches NERU_TITLE_LEN in wlroots_client.h.
+const wlrootsFocusedTitleBufferSize = 512
+
+// wlrootsFocusedAppTitle returns the title of the currently activated (focused)
+// toplevel. The bool is false when no manager is present or nothing is focused.
+// The title disambiguates multiple windows of the focused application, which
+// share an app_id.
+func wlrootsFocusedAppTitle() (string, bool) {
+	err := ensureWlrootsState()
+	if err != nil {
+		return "", false
+	}
+
+	globalWlrootsState.mu.RLock()
+	defer globalWlrootsState.mu.RUnlock()
+
+	client := globalWlrootsState.client
+	if client == nil {
+		return "", false
+	}
+
+	buf := make([]C.char, wlrootsFocusedTitleBufferSize)
+	bufLen := C.int(wlrootsFocusedTitleBufferSize)
+
+	if C.neru_wlr_focused_app_title(client, &buf[0], bufLen) == 0 { //nolint:nlreturn
+		return "", false
+	}
+
+	return C.GoString(&buf[0]), true
+}
+
 // wlrootsSetCursor mirrors an externally-injected pointer position (e.g. a
 // libei move on KDE) into the wlroots client's client-side cursor cache so
 // CursorPosition and screen resolution stay accurate.

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
@@ -124,6 +124,10 @@ func wlrootsFocusedAppID() (string, bool) {
 	return "", false
 }
 
+func wlrootsFocusedAppTitle() (string, bool) {
+	return "", false
+}
+
 func wlrootsSetCursor(point image.Point) error {
 	_ = point
 

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
@@ -124,8 +124,8 @@ func wlrootsFocusedAppID() (string, bool) {
 	return "", false
 }
 
-func wlrootsFocusedAppTitle() (string, bool) {
-	return "", false
+func wlrootsFocusedAppIdentity() (string, string, bool) {
+	return "", "", false
 }
 
 func wlrootsSetCursor(point image.Point) error {

--- a/internal/core/infra/platform/linux/system_linux_x11.go
+++ b/internal/core/infra/platform/linux/system_linux_x11.go
@@ -4,6 +4,7 @@ package linux
 
 /*
 #cgo linux pkg-config: x11 xtst xrandr
+#include <stdlib.h>
 #include "x11_system.h"
 */
 import "C"
@@ -105,6 +106,36 @@ func x11FocusedApplicationPID() (int, error) {
 	}
 
 	return int(pid), nil
+}
+
+// x11FocusedAppID returns the WM_CLASS "class" of the active X11 window, used
+// as the per-app bundle identifier (matching accessibility's focused-app
+// identity on X11). The bool is false when DISPLAY is unset, no window is
+// active, or the window exposes no WM_CLASS.
+func x11FocusedAppID() (string, bool) {
+	display, err := x11OpenDisplay()
+	if err != nil {
+		return "", false
+	}
+	defer C.neru_x11_close_display(display) //nolint:nlreturn
+
+	var window C.Window
+	if C.neru_x11_get_active_window(display, &window) == 0 { //nolint:nlreturn
+		return "", false
+	}
+
+	className := C.neru_x11_get_window_class(display, window) //nolint:nlreturn
+	if className == nil {
+		return "", false
+	}
+	defer C.free(unsafe.Pointer(className)) //nolint:nlreturn
+
+	appID := C.GoString(className)
+	if appID == "" {
+		return "", false
+	}
+
+	return appID, true
 }
 
 func x11Monitors() ([]x11Monitor, error) {

--- a/internal/core/infra/platform/linux/system_linux_x11_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_x11_nocgo.go
@@ -30,6 +30,10 @@ func x11FocusedApplicationPID() (int, error) {
 	)
 }
 
+func x11FocusedAppID() (string, bool) {
+	return "", false
+}
+
 func x11ActiveScreenBounds() (image.Rectangle, error) {
 	return image.Rectangle{}, derrors.New(
 		derrors.CodeNotSupported,

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -492,28 +492,43 @@ static NeruToplevel *neru_wlr_find_toplevel(NeruWlrootsClient *c, struct zwlr_fo
 	return NULL;
 }
 
-// Recompute the cached focused app_id from the committed per-toplevel state.
-// The last activated toplevel carrying a non-empty app_id wins; if none is
-// activated the cache is cleared. Callers must hold toplevel_mutex.
+// Recompute the cached focused app_id and title from the committed per-toplevel
+// state. The last activated toplevel carrying a non-empty app_id wins; if none
+// is activated the cache is cleared. Callers must hold toplevel_mutex.
 static void neru_wlr_recompute_focused(NeruWlrootsClient *c) {
 	const char *found = NULL;
+	const char *found_title = NULL;
 	NeruToplevel *t;
 	wl_list_for_each(t, &c->toplevels, link) {
-		if (t->activated && t->app_id[0] != '\0')
+		if (t->activated && t->app_id[0] != '\0') {
 			found = t->app_id;
+			found_title = t->title;
+		}
 	}
 	if (found) {
 		strncpy(c->focused_app_id, found, NERU_APP_ID_LEN - 1);
 		c->focused_app_id[NERU_APP_ID_LEN - 1] = '\0';
+		strncpy(c->focused_title, found_title ? found_title : "", NERU_TITLE_LEN - 1);
+		c->focused_title[NERU_TITLE_LEN - 1] = '\0';
 	} else {
 		c->focused_app_id[0] = '\0';
+		c->focused_title[0] = '\0';
 	}
 }
 
 static void neru_wlr_toplevel_title(void *data, struct zwlr_foreign_toplevel_handle_v1 *handle, const char *title) {
-	(void)data;
-	(void)handle;
-	(void)title;
+	NeruWlrootsClient *c = (NeruWlrootsClient *)data;
+	if (!c || !title)
+		return;
+	neru_wlr_toplevel_lock(c);
+	NeruToplevel *t = neru_wlr_find_toplevel(c, handle);
+	if (t) {
+		// Buffer until `done` so title commits atomically with app_id/state.
+		strncpy(t->pending_title, title, NERU_TITLE_LEN - 1);
+		t->pending_title[NERU_TITLE_LEN - 1] = '\0';
+		t->has_pending_title = 1;
+	}
+	neru_wlr_toplevel_unlock(c);
 }
 
 static void neru_wlr_toplevel_app_id(void *data, struct zwlr_foreign_toplevel_handle_v1 *handle, const char *app_id) {
@@ -576,6 +591,11 @@ static void neru_wlr_toplevel_done(void *data, struct zwlr_foreign_toplevel_hand
 			strncpy(t->app_id, t->pending_app_id, NERU_APP_ID_LEN - 1);
 			t->app_id[NERU_APP_ID_LEN - 1] = '\0';
 			t->has_pending_app_id = 0;
+		}
+		if (t->has_pending_title) {
+			strncpy(t->title, t->pending_title, NERU_TITLE_LEN - 1);
+			t->title[NERU_TITLE_LEN - 1] = '\0';
+			t->has_pending_title = 0;
 		}
 		t->activated = t->pending_activated;
 		neru_wlr_recompute_focused(c);
@@ -662,6 +682,7 @@ static void neru_wlr_manager_finished(void *data, struct zwlr_foreign_toplevel_m
 		free(t);
 	}
 	c->focused_app_id[0] = '\0';
+	c->focused_title[0] = '\0';
 	neru_wlr_toplevel_unlock(c);
 
 	// Do not destroy the manager proxy here: the server destroys it right after
@@ -1256,6 +1277,23 @@ int neru_wlr_focused_app_id(NeruWlrootsClient *c, char *out, int out_len) {
 	neru_wlr_toplevel_lock(c);
 	if (c->focused_app_id[0] != '\0') {
 		strncpy(out, c->focused_app_id, (size_t)(out_len - 1));
+		out[out_len - 1] = '\0';
+		ok = 1;
+	} else {
+		out[0] = '\0';
+	}
+	neru_wlr_toplevel_unlock(c);
+	return ok;
+}
+
+int neru_wlr_focused_app_title(NeruWlrootsClient *c, char *out, int out_len) {
+	if (!c || !out || out_len <= 0)
+		return 0;
+
+	int ok = 0;
+	neru_wlr_toplevel_lock(c);
+	if (c->focused_title[0] != '\0') {
+		strncpy(out, c->focused_title, (size_t)(out_len - 1));
 		out[out_len - 1] = '\0';
 		ok = 1;
 	} else {

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -1286,18 +1286,24 @@ int neru_wlr_focused_app_id(NeruWlrootsClient *c, char *out, int out_len) {
 	return ok;
 }
 
-int neru_wlr_focused_app_title(NeruWlrootsClient *c, char *out, int out_len) {
-	if (!c || !out || out_len <= 0)
+int neru_wlr_focused_app_identity(
+    NeruWlrootsClient *c, char *app_out, int app_len, char *title_out, int title_len) {
+	if (!c || !app_out || app_len <= 0 || !title_out || title_len <= 0)
 		return 0;
 
 	int ok = 0;
+	// Read app_id and title under a single lock so they always describe the same
+	// toplevel; a focus commit cannot interleave between them.
 	neru_wlr_toplevel_lock(c);
-	if (c->focused_title[0] != '\0') {
-		strncpy(out, c->focused_title, (size_t)(out_len - 1));
-		out[out_len - 1] = '\0';
+	if (c->focused_app_id[0] != '\0') {
+		strncpy(app_out, c->focused_app_id, (size_t)(app_len - 1));
+		app_out[app_len - 1] = '\0';
+		strncpy(title_out, c->focused_title, (size_t)(title_len - 1));
+		title_out[title_len - 1] = '\0';
 		ok = 1;
 	} else {
-		out[0] = '\0';
+		app_out[0] = '\0';
+		title_out[0] = '\0';
 	}
 	neru_wlr_toplevel_unlock(c);
 	return ok;

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -1286,8 +1286,7 @@ int neru_wlr_focused_app_id(NeruWlrootsClient *c, char *out, int out_len) {
 	return ok;
 }
 
-int neru_wlr_focused_app_identity(
-    NeruWlrootsClient *c, char *app_out, int app_len, char *title_out, int title_len) {
+int neru_wlr_focused_app_identity(NeruWlrootsClient *c, char *app_out, int app_len, char *title_out, int title_len) {
 	if (!c || !app_out || app_len <= 0 || !title_out || title_len <= 0)
 		return 0;
 

--- a/internal/core/infra/platform/linux/wlroots_client.h
+++ b/internal/core/infra/platform/linux/wlroots_client.h
@@ -135,10 +135,12 @@ int neru_wlr_has_toplevel_manager(NeruWlrootsClient *c);
 // focused, or the focused toplevel has no app_id yet).
 int neru_wlr_focused_app_id(NeruWlrootsClient *c, char *out, int out_len);
 
-// neru_wlr_focused_app_title copies the title of the currently-activated
-// toplevel into out (NUL-terminated, capped at out_len). Returns 1 when a
-// non-empty focused title is available, 0 otherwise. Used to disambiguate
-// multiple windows of the focused application, which share an app_id.
-int neru_wlr_focused_app_title(NeruWlrootsClient *c, char *out, int out_len);
+// neru_wlr_focused_app_identity copies the app_id and title of the currently-
+// activated toplevel under a single lock, so the two always describe the same
+// window (no focus commit can interleave). Returns 1 when a focused app_id is
+// available, 0 otherwise. The title disambiguates multiple windows of the
+// focused application, which share an app_id.
+int neru_wlr_focused_app_identity(
+    NeruWlrootsClient *c, char *app_out, int app_len, char *title_out, int title_len);
 
 #endif /* WLROOTS_CLIENT_H */

--- a/internal/core/infra/platform/linux/wlroots_client.h
+++ b/internal/core/infra/platform/linux/wlroots_client.h
@@ -26,6 +26,10 @@ typedef struct {
 // "org.kde.konsole") and freedesktop app-ids fit comfortably in 256 bytes.
 #define NERU_APP_ID_LEN 256
 
+// Window-title buffer length. Titles can be longer than app-ids; 512 bytes
+// avoids truncating most window titles so they match the AT-SPI frame name.
+#define NERU_TITLE_LEN 512
+
 // NeruToplevel mirrors one zwlr_foreign_toplevel_handle_v1. Nodes are heap
 // allocated and threaded onto NeruWlrootsClient.toplevels via `link`, so there
 // is no fixed cap on the number of windows tracked. app_id and the activated
@@ -38,6 +42,9 @@ typedef struct {
 	char app_id[NERU_APP_ID_LEN];
 	char pending_app_id[NERU_APP_ID_LEN];
 	int has_pending_app_id;
+	char title[NERU_TITLE_LEN];
+	char pending_title[NERU_TITLE_LEN];
+	int has_pending_title;
 	int activated;
 	int pending_activated;
 } NeruToplevel;
@@ -67,6 +74,7 @@ typedef struct NeruWlrootsClient {
 	struct zwlr_foreign_toplevel_manager_v1 *toplevel_mgr;
 	struct wl_list toplevels;              // list of NeruToplevel, guarded by toplevel_mutex
 	char focused_app_id[NERU_APP_ID_LEN];  // guarded by toplevel_mutex
+	char focused_title[NERU_TITLE_LEN];    // guarded by toplevel_mutex
 	pthread_mutex_t toplevel_mutex;
 	int toplevel_mutex_ready;
 
@@ -126,5 +134,11 @@ int neru_wlr_has_toplevel_manager(NeruWlrootsClient *c);
 // non-empty focused app_id is available, 0 otherwise (no manager, nothing
 // focused, or the focused toplevel has no app_id yet).
 int neru_wlr_focused_app_id(NeruWlrootsClient *c, char *out, int out_len);
+
+// neru_wlr_focused_app_title copies the title of the currently-activated
+// toplevel into out (NUL-terminated, capped at out_len). Returns 1 when a
+// non-empty focused title is available, 0 otherwise. Used to disambiguate
+// multiple windows of the focused application, which share an app_id.
+int neru_wlr_focused_app_title(NeruWlrootsClient *c, char *out, int out_len);
 
 #endif /* WLROOTS_CLIENT_H */

--- a/internal/core/infra/platform/linux/wlroots_client.h
+++ b/internal/core/infra/platform/linux/wlroots_client.h
@@ -140,7 +140,6 @@ int neru_wlr_focused_app_id(NeruWlrootsClient *c, char *out, int out_len);
 // window (no focus commit can interleave). Returns 1 when a focused app_id is
 // available, 0 otherwise. The title disambiguates multiple windows of the
 // focused application, which share an app_id.
-int neru_wlr_focused_app_identity(
-    NeruWlrootsClient *c, char *app_out, int app_len, char *title_out, int title_len);
+int neru_wlr_focused_app_identity(NeruWlrootsClient *c, char *app_out, int app_len, char *title_out, int title_len);
 
 #endif /* WLROOTS_CLIENT_H */

--- a/internal/core/infra/platform/linux/x11_system.c
+++ b/internal/core/infra/platform/linux/x11_system.c
@@ -94,6 +94,31 @@ unsigned long neru_x11_get_window_pid(Display *display, Window window, int *ok) 
 	return pid;
 }
 
+char *neru_x11_get_window_class(Display *display, Window window) {
+	if (window == 0) {
+		return NULL;
+	}
+
+	XClassHint hint;
+	if (XGetClassHint(display, window, &hint) == 0) {
+		return NULL;
+	}
+
+	char *class_name = NULL;
+	if (hint.res_class != NULL) {
+		class_name = strdup(hint.res_class);
+	}
+
+	if (hint.res_name != NULL) {
+		XFree(hint.res_name);
+	}
+	if (hint.res_class != NULL) {
+		XFree(hint.res_class);
+	}
+
+	return class_name;
+}
+
 NeruX11Monitor *neru_x11_get_monitors(Display *display, int *count) {
 	Window root = neru_x11_root_window(display);
 	int monitor_count = 0;

--- a/internal/core/infra/platform/linux/x11_system.h
+++ b/internal/core/infra/platform/linux/x11_system.h
@@ -19,6 +19,10 @@ int neru_x11_query_pointer(Display *display, int *x, int *y);
 int neru_x11_move_pointer(Display *display, int x, int y);
 int neru_x11_get_active_window(Display *display, Window *out);
 unsigned long neru_x11_get_window_pid(Display *display, Window window, int *ok);
+// neru_x11_get_window_class returns a heap-allocated copy of the window's
+// WM_CLASS "class" field (res_class), or NULL when unavailable. The caller
+// owns the returned pointer and must free() it.
+char *neru_x11_get_window_class(Display *display, Window window);
 NeruX11Monitor *neru_x11_get_monitors(Display *display, int *count);
 void neru_x11_free_monitors(NeruX11Monitor *monitors, int count);
 

--- a/internal/core/ports/capability_presets.go
+++ b/internal/core/ports/capability_presets.go
@@ -59,7 +59,12 @@ func LinuxCapabilities() PlatformCapabilities {
 		Cursor: supportedCapability(
 			"cursor movement/tracking available via XTest and Wayland virtual-pointer",
 		),
-		Accessibility: stubCapability("AT-SPI integration not implemented yet"),
+		Accessibility: supportedCapability(
+			"clickable-element discovery via AT-SPI (D-Bus) tree walk; " +
+				"click/scroll injection via XTest (X11) or virtual-pointer/libei " +
+				"(Wayland wlroots/KDE). Coverage depends on the app's AT-SPI " +
+				"support; there is no Vision/OCR fallback",
+		),
 		Overlay: supportedCapability(
 			"native overlays available via X11 windows or Wayland layer-shell + Cairo",
 		),
@@ -72,8 +77,10 @@ func LinuxCapabilities() PlatformCapabilities {
 		KeyboardEventTap: supportedCapability(
 			"keyboard event tap available via X11 grab and Wayland layer-shell keyboard interactivity",
 		),
-		AppWatcher: stubCapability(
-			"app watcher not needed for Neru's current navigation model",
+		AppWatcher: supportedCapability(
+			"focused-app change detection via polling the WM_CLASS (X11) or " +
+				"wlr-foreign-toplevel app_id (Wayland wlroots/KDE); GNOME/Mutter " +
+				"exposes no focused-app source",
 		),
 		// Default placeholder; the Linux SystemAdapter overrides this with
 		// the live-probed state (current color-scheme + source) on each

--- a/internal/core/ports/capability_presets_test.go
+++ b/internal/core/ports/capability_presets_test.go
@@ -32,12 +32,13 @@ func TestNonDarwinCapabilities_ReportStubbedFeatures(t *testing.T) {
 		capabilities        ports.PlatformCapabilities
 		accessibilityStatus ports.FeatureStatus
 	}{
-		// Linux accessibility (AT-SPI) is still a stub; Windows now discovers
-		// clickable elements via UI Automation.
+		// Linux discovers clickable elements via an AT-SPI (D-Bus) tree walk;
+		// Windows discovers them via UI Automation. Notifications remain stubbed
+		// on both (asserted below).
 		{
 			name:                "linux",
 			capabilities:        ports.LinuxCapabilities(),
-			accessibilityStatus: ports.FeatureStatusStub,
+			accessibilityStatus: ports.FeatureStatusSupported,
 		},
 		{
 			name:                "windows",

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -51,6 +51,10 @@ const (
 	// hintPlacementGap is the pixel gap between a hint badge and its target
 	// point for top/bottom placement, mirroring the macOS overlay.
 	hintPlacementGap = 1
+	// hintAutoRadiusMax caps the auto (border_radius = -1) hint badge corner
+	// radius so labels get a subtle rounded corner rather than a full pill,
+	// matching the macOS overlay's MIN(height/2, 6).
+	hintAutoRadiusMax = 6
 
 	stickyBadgeClearPadding = 3
 )

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -48,6 +48,9 @@ const (
 	centeredRectDivisor                    = 2
 	centeredRectHalf                       = 0.5
 	paddingMultiplier                      = 2
+	// hintPlacementGap is the pixel gap between a hint badge and its target
+	// point for top/bottom placement, mirroring the macOS overlay.
+	hintPlacementGap = 1
 
 	stickyBadgeClearPadding = 3
 )

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -330,13 +330,16 @@ func (o *wlrootsOverlay) DrawHints(
 		badgeWidth := estimateTextWidth(label, fontSize) + paddingX*paddingMultiplier
 		badgeHeight := estimateTextHeight(fontSize) + paddingY*paddingMultiplier
 
-		centerX := hint.Position().X + hint.Size().X/centeredRectDivisor
-		centerY := hint.Position().Y + hint.Size().Y/centeredRectDivisor
+		// hint.Position() is the element center (set in modes/hints.go), so the
+		// badge is centered horizontally on it and placed above / on / below the
+		// center to match the macOS placement behavior.
+		centerX := hint.Position().X
+		centerY := hint.Position().Y
 		switch style.Placement() {
 		case "top":
-			centerY = hint.Position().Y
+			centerY = hint.Position().Y - hintPlacementGap - badgeHeight/centeredRectDivisor
 		case "bottom":
-			centerY = hint.Position().Y + hint.Size().Y
+			centerY = hint.Position().Y + hintPlacementGap + badgeHeight/centeredRectDivisor
 		}
 
 		badge := image.Rect(

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -350,7 +350,7 @@ func (o *wlrootsOverlay) DrawHints(
 		)
 		radius := style.BorderRadius()
 		if radius < 0 {
-			radius = badgeHeight / centeredRectDivisor
+			radius = min(badgeHeight/centeredRectDivisor, hintAutoRadiusMax)
 		}
 		if radius > 0 {
 			o.drawRoundedRect(

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -298,13 +298,16 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 		badgeWidth := estimateTextWidth(label, fontSize) + paddingX*paddingMultiplier
 		badgeHeight := estimateTextHeight(fontSize) + paddingY*paddingMultiplier
 
-		centerX := hint.Position().X + hint.Size().X/centeredRectDivisor
-		centerY := hint.Position().Y + hint.Size().Y/centeredRectDivisor
+		// hint.Position() is the element center (set in modes/hints.go), so the
+		// badge is centered horizontally on it and placed above / on / below the
+		// center to match the macOS placement behavior.
+		centerX := hint.Position().X
+		centerY := hint.Position().Y
 		switch style.Placement() {
 		case "top":
-			centerY = hint.Position().Y
+			centerY = hint.Position().Y - hintPlacementGap - badgeHeight/centeredRectDivisor
 		case "bottom":
-			centerY = hint.Position().Y + hint.Size().Y
+			centerY = hint.Position().Y + hintPlacementGap + badgeHeight/centeredRectDivisor
 		}
 
 		badge := image.Rect(

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -318,7 +318,7 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 		)
 		radius := style.BorderRadius()
 		if radius < 0 {
-			radius = badgeHeight / centeredRectDivisor
+			radius = min(badgeHeight/centeredRectDivisor, hintAutoRadiusMax)
 		}
 		if radius > 0 {
 			o.drawRoundedRect(


### PR DESCRIPTION
## Description

This PR makes hints mode work on Linux Wayland (wlroots/KDE): it discovers and positions clickable-element hints via AT-SPI, adds a Linux app watcher so per-app config switches on focus change, and fixes overlay text rendering.

## Related Issues

N/A

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Verified live on niri: AT-SPI hints discover and click, and floating-window hints are offset correctly. niri tiled windows — including a maximized column (`maximize-column`) — do not expose their on-screen position ([niri#2381](https://github.com/niri-wm/niri/issues/2381)), so hints fall back to unoffset coordinates there; use a floating or true-fullscreen window for aligned hints. Sway and Hyprland use their IPC and are covered by unit tests.

