### PR TITLE
feat(linux): smooth cursor animation for X11 and Wayland

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1100,7 +1100,9 @@ On Linux, the indicator renders the symbols `❖⇧⌥⌃`. If they appear as `[
 
 ## [smooth_cursor]
 
-Animates cursor movement between positions.
+Animates cursor movement between positions. Supported on macOS and Linux
+(X11, Wayland wlroots/KDE); GNOME/Wayland and Windows fall back to instant
+movement.
 
 | Option               | Type  | Default | Description                        |
 | -------------------- | ----- | ------- | ---------------------------------- |

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -569,7 +569,7 @@ From `internal/core/ports/capability_presets.go` and actual adapter code.
 | **Screen Enumeration**              | ✅                          | ✅ (XRandR)        | ✅ (xdg-output)           | ✅ (xdg-output)          | ✅ (xdg-output)   | ✅ (EnumDisplayMonitors) |
 | **Cursor Position**                 | ✅                          | ✅                 | ✅ (sync surface)         | ✅ (sync surface)        | ❌                | ✅                       |
 | **Cursor Move**                     | ✅                          | ✅ (XTest)         | ✅ (zwlr_virtual_pointer) | ✅ (libei)               | ❌                | ✅ (SetCursorPos)        |
-| **Cursor Smooth Animation**         | ✅                          | ❌                 | ❌                        | ❌                       | ❌                | ❌                       |
+| **Cursor Smooth Animation**         | ✅                          | ✅                 | ✅                        | ✅                       | ❌                | ❌                       |
 | **Scroll Smooth Animation**         | ✅                          | ❌                 | ❌                        | ❌                       | ❌                | ❌                       |
 | **Accessibility Element Discovery** | ✅ (AXUIElement)            | ⚠️ (AT-SPI walk)   | ⚠️ (AT-SPI walk)          | ⚠️ (AT-SPI walk)         | 🟡 (no injection) | ✅ (UIA initial)         |
 | **Accessibility Click/Scroll**      | ✅                          | ✅ (XTest)         | ✅ (virtual-pointer)      | ✅ (libei)               | 🟡                | ✅ (UIA initial)         |
@@ -584,6 +584,22 @@ From `internal/core/ports/capability_presets.go` and actual adapter code.
 | **Font Resolution**                 | ✅ (NSFont)                 | ✅ (fontconfig)    | ✅ (fontconfig)           | ✅ (fontconfig)          | ✅ (fontconfig)   | ✅ (DirectWrite)         |
 | **System Cursor Hide**              | ✅ (CGDisplayHideCursor)    | ❌                 | ❌                        | ❌                       | ❌                | ❌                       |
 | **Monitor Select Panels**           | ✅ (native Cocoa panels)    | ❌                 | ❌                        | ❌                       | ❌                | ❌                       |
+
+**Smooth cursor animation on Linux:** off by default and opt-in via
+`smooth_cursor.move_mouse_enabled` (the same cross-platform
+`SmoothCursorConfig` macOS uses). When enabled, `SystemAdapter.MoveCursorToPoint`
+routes through `smoothCursorAnimator` (`mouse_animator_linux.go`) — a single
+worker goroutine that samples the current position once, then steps the direct
+per-backend warp (XTest on X11, `zwlr_virtual_pointer` on wlroots, libei on KDE)
+toward the target with linear interpolation, and `WaitForCursorIdle` now blocks
+until it settles instead of returning immediately. This mirrors the darwin
+animator (coalescing, latest-target-wins), but drives discrete warps rather than
+a Quartz event stream, so there is no drag-event distinction. It applies to the
+same flows macOS animates — grid/recursive-grid cursor-follow, `move_mouse`, and
+selection moves; clicks stay instant. On Wayland the interpolation start point
+comes from the client-side cursor cache; a stale read only skews the glide path,
+never the final landing point (the last step lands exactly on the target).
+GNOME/Mutter has no injection path, so it stays unsupported there.
 
 **Focused App PID on Wayland:** wlroots and KDE sessions resolve the focused
 window through the `wlr-foreign-toplevel-management` protocol, which exposes the
@@ -693,7 +709,7 @@ to unoffset (window-relative) coordinates rather than misplacing hints.
 | ----------------------------- | -------------------------------------------------- | -------------------------------------- | ------------------------------------------- | ----------------------------------------- |
 | **Grid transition animation** | CoreAnimation 120Hz, ease-in-out + linear fallback | Goroutine 120fps, easeInOut smoothstep | Goroutine 120fps, easeInOut smoothstep      | ❌                                        |
 | **Mouse action indicator**    | CoreAnimation CABasicAnimation (scale+opacity)     | ❌                                     | ❌                                          | Goroutine 60fps, custom cubic easing, SDF |
-| **Smooth cursor animation**   | ✅ (goroutine, configurable easing, tween)         | ❌                                     | ❌                                          | ❌                                        |
+| **Smooth cursor animation**   | ✅ (goroutine, configurable easing, tween)         | ✅ (goroutine, stepped warp)           | ✅ (goroutine, stepped warp)                | ❌                                        |
 | **Smooth scroll animation**   | ✅ (goroutine, ease-out cubic)                     | ❌                                     | ❌                                          | ❌                                        |
 | **Animation frame rate**      | 120fps (NSTimer display link)                      | 120fps (ticker)                        | ~120fps                                     | 60fps (16ms ticker)                       |
 | **Thread model**              | Main thread dispatch (dispatch_async/sync)         | `renderMu sync.Mutex`                  | `displayMu sync.Mutex` (shared w/ renderMu) | Dedicated UI thread (`LockOSThread`)      |
@@ -835,7 +851,7 @@ All 8 action types from `internal/core/domain/action/action.go` are dispatched v
 | **Right click**         | ✅                                   | ✅ (XTest button 3)       | ✅                                                                               | ✅                         |
 | **Middle click**        | ✅                                   | ✅ (XTest button 2)       | ✅                                                                               | ✅                         |
 | **Scroll**              | ✅ (CGScrollWheelEvent)              | ✅ (XTest button 4/5)     | ✅ (zwlr_virtual_pointer axis)                                                   | ✅ (SendInput mouse wheel) |
-| **Smooth animation**    | ✅ (mouse_animator.go, configurable) | ❌                        | ❌                                                                               | ❌                         |
+| **Smooth animation**    | ✅ (mouse_animator.go, configurable) | ✅ (mouse_animator_linux.go) | ✅ (mouse_animator_linux.go)                                                  | ❌                         |
 | **Wayland cursor sync** | N/A                                  | N/A                       | ✅ (brief map of transparent layer surface to capture `wl_pointer.enter` coords) | N/A                        |
 
 ### Mode Feature Coverage
@@ -941,7 +957,7 @@ Windows has pure Go implementations for all subsystems (see the Port Capability 
 2. **Notifications** — no Windows toast notifications
 3. **Tree walking depth** — UIA tree is shallow; needs deeper traversal for complex apps
 4. **Grid transition animation** — not implemented (macOS and Linux have it)
-5. **Smooth cursor/scroll animation** — not implemented (macOS only)
+5. **Smooth cursor/scroll animation** — not implemented (smooth cursor exists on macOS + Linux; smooth scroll is macOS-only)
 6. **Modifier passthrough, PostModifierEvent** — no-ops
 7. **Scroll horizontal** — `ScrollAtCursor` ignores `deltaX` (vertical only)
 8. **Virtual pointer overlay** — stub only
@@ -956,8 +972,7 @@ The following features exist on exactly one platform:
 | Feature                   | Location                                                                                | Reason Not Cross-Platform                                                                        |
 | ------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | System cursor hide/show   | `internal/app/modes/cursor_darwin.go`                                                   | Uses `CGDisplayHideCursor` / `CGDisplayShowCursor` (Quartz). Other platforms have no equivalent. |
-| Smooth cursor animation   | `internal/core/infra/platform/darwin/mouse_animator.go`                                 | Quartz event-level animation tracking. Requires platform-specific cursor event stream.           |
-| Smooth scroll animation   | `internal/core/infra/platform/darwin/scroll_animator.go`                                | Same — platform scroll event stream                                                              |
+| Smooth scroll animation   | `internal/core/infra/platform/darwin/scroll_animator.go`                                | Platform scroll event stream. (Smooth **cursor** animation is now cross-platform on Linux too — see `mouse_animator_linux.go`.) |
 | Vision framework strategy | `internal/core/ports/vision.go` + `internal/core/infra/platform/darwin/vision_darwin.m` | macOS-only `VNRequest` / `VGImageRequestHandler` APIs                                            |
 | Monitor select panels     | `internal/app/modes/monitor_select_overlay_darwin.go`                                   | Uses Cocoa NSPanel per display. Not implemented on other platforms.                              |
 | Screen sharing hide       | `internal/core/infra/platform/darwin/overlay_darwin.m`                                  | NSWindow sharing level property (Quartz only)                                                    |

--- a/internal/app/runtime_config_linux.go
+++ b/internal/app/runtime_config_linux.go
@@ -1,0 +1,12 @@
+//go:build linux
+
+package app
+
+import (
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/infra/platform/linux"
+)
+
+func configurePlatformRuntimeConfigProviders(cfgService *config.Service) {
+	linux.SetConfigProvider(cfgService)
+}

--- a/internal/app/runtime_config_other.go
+++ b/internal/app/runtime_config_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !windows
+//go:build !darwin && !windows && !linux
 
 package app
 

--- a/internal/core/infra/platform/linux/config_provider_linux.go
+++ b/internal/core/infra/platform/linux/config_provider_linux.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package linux
+
+import (
+	"sync"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// configProvider is a process-global runtime config source for the Linux system
+// adapter, mirroring the darwin config-provider slot. It is set once at daemon
+// startup (see internal/app/runtime_config_linux.go) and read by the smooth
+// cursor path. A nil provider (tests, or before wiring) means "no config", so
+// callers fall back to the direct, non-animated move.
+var (
+	configProviderMu sync.RWMutex
+	configProvider   config.Provider
+)
+
+// SetConfigProvider updates the runtime config provider used by the Linux
+// system adapter's smooth-cursor path.
+func SetConfigProvider(provider config.Provider) {
+	configProviderMu.Lock()
+	configProvider = provider
+	configProviderMu.Unlock()
+}
+
+// currentLinuxConfig returns the latest config snapshot, or nil when no provider
+// has been wired yet.
+func currentLinuxConfig() *config.Config {
+	configProviderMu.RLock()
+
+	provider := configProvider
+
+	configProviderMu.RUnlock()
+
+	if provider == nil {
+		return nil
+	}
+
+	return provider.Get()
+}

--- a/internal/core/infra/platform/linux/mouse_animator_linux.go
+++ b/internal/core/infra/platform/linux/mouse_animator_linux.go
@@ -22,22 +22,37 @@ const (
 
 // cursorAnimationDone is a once-closable completion signal shared with
 // WaitForCursorIdle. It mirrors the darwin animator's done channel so callers
-// can block until the cursor settles.
+// can block until the cursor settles, and additionally carries the first
+// backend move error so WaitForCursorIdle can surface a failed warp instead of
+// reporting a phantom success. err is written inside once.Do before the channel
+// closes, so a reader that observes the close also observes err (the channel
+// close is the happens-before edge — no extra lock needed).
 type cursorAnimationDone struct {
 	ch   chan struct{}
 	once sync.Once
+	err  error
 }
 
 func newCursorAnimationDone() *cursorAnimationDone {
 	return &cursorAnimationDone{ch: make(chan struct{})}
 }
 
+// close settles the animation as successful (no backend error).
 func (d *cursorAnimationDone) close() {
+	d.closeWithErr(nil)
+}
+
+// closeWithErr settles the animation, recording err for the first caller to
+// close. Cancellation paths pass nil (a stopped animation is not a move
+// failure); only a failed backend warp passes a non-nil err.
+func (d *cursorAnimationDone) closeWithErr(err error) {
 	if d == nil {
 		return
 	}
 
 	d.once.Do(func() {
+		d.err = err
+
 		close(d.ch)
 	})
 }
@@ -113,7 +128,7 @@ func (a *smoothCursorAnimator) wait(ctx context.Context) error {
 
 	select {
 	case <-done.ch:
-		return nil
+		return done.err
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -121,6 +136,13 @@ func (a *smoothCursorAnimator) wait(ctx context.Context) error {
 
 // animateTo enqueues an animation toward end, coalescing so only the latest
 // target survives when requests arrive faster than the worker drains them.
+//
+// Worker start and enqueue happen under a.mu in one critical section. This is
+// what makes it safe against a concurrent stop(): a bypassed move can never
+// swap out the channel or kill the worker between "pick a channel" and "send",
+// so a request can never be stranded on an orphaned channel with an unclosed
+// done. Because every producer holds the lock and the worker is the sole
+// consumer of the size-1 buffer, the enqueue is always non-blocking.
 func (a *smoothCursorAnimator) animateTo(
 	end image.Point,
 	steps, maxDuration int,
@@ -135,38 +157,46 @@ func (a *smoothCursorAnimator) animateTo(
 		done:             done,
 	}
 
-	reqCh := a.ensureWorker(done)
-	select {
-	case reqCh <- req:
-	default:
-		select {
-		case dropped := <-reqCh:
-			dropped.done.close()
-		default:
-		}
-
-		reqCh <- req
-	}
-}
-
-func (a *smoothCursorAnimator) ensureWorker(done *cursorAnimationDone) chan cursorRequest {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	a.done = done
+	if a.reqCh == nil {
+		a.reqCh = make(chan cursorRequest, 1)
+		a.stopCh = make(chan struct{})
 
-	if a.reqCh != nil {
-		return a.reqCh
+		go a.run(a.reqCh, a.stopCh)
 	}
 
-	reqCh := make(chan cursorRequest, 1)
-	stopCh := make(chan struct{})
-	a.reqCh = reqCh
-	a.stopCh = stopCh
+	a.done = done
+	a.enqueueLocked(req)
+}
 
-	go a.run(reqCh, stopCh)
+// enqueueLocked places req on the worker channel, coalescing so only the latest
+// target survives. The caller must hold a.mu.
+//
+// The buffer is size 1 and, under the lock, we are the only producer while the
+// worker is the only consumer (it removes, never adds). So after draining a
+// stale request the buffer is empty and the follow-up send cannot block. The
+// final default branch is therefore unreachable in practice; it closes done
+// defensively so a waiter can never hang even if that invariant is ever broken.
+func (a *smoothCursorAnimator) enqueueLocked(req cursorRequest) {
+	select {
+	case a.reqCh <- req:
+		return
+	default:
+	}
 
-	return reqCh
+	select {
+	case dropped := <-a.reqCh:
+		dropped.done.close()
+	default:
+	}
+
+	select {
+	case a.reqCh <- req:
+	default:
+		req.done.close()
+	}
 }
 
 func (a *smoothCursorAnimator) run(reqCh <-chan cursorRequest, stopCh <-chan struct{}) {
@@ -234,7 +264,18 @@ restart:
 			Y: int(float64(start.Y) + float64(req.end.Y-start.Y)*progress),
 		}
 
-		_ = a.move(intermediate)
+		// A failed backend warp means the cursor is not where the caller
+		// expects, so surface it through WaitForCursorIdle rather than
+		// reporting a phantom success. Backend move failures reflect device
+		// state (disconnected virtual pointer, lost display), so abort the
+		// remaining steps instead of spinning on calls that will also fail.
+		moveErr := a.move(intermediate)
+		if moveErr != nil {
+			req.done.closeWithErr(moveErr)
+			a.clearDoneIfCurrent(req.done)
+
+			return
+		}
 
 		if step < actualSteps {
 			timer.Reset(stepDelay)

--- a/internal/core/infra/platform/linux/mouse_animator_linux.go
+++ b/internal/core/infra/platform/linux/mouse_animator_linux.go
@@ -1,0 +1,281 @@
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"image"
+	"math"
+	"sync"
+	"time"
+)
+
+const (
+	// minCursorAnimationDuration is the floor for a single move so even a
+	// zero-distance request settles promptly instead of instantly.
+	minCursorAnimationDuration = 10 // ms
+	// minCursorStepDelay is the shortest gap between injected steps.
+	minCursorStepDelay = 1 // ms
+	// defaultCursorSteps is used when the config value is unset (<= 0).
+	defaultCursorSteps = 10
+)
+
+// cursorAnimationDone is a once-closable completion signal shared with
+// WaitForCursorIdle. It mirrors the darwin animator's done channel so callers
+// can block until the cursor settles.
+type cursorAnimationDone struct {
+	ch   chan struct{}
+	once sync.Once
+}
+
+func newCursorAnimationDone() *cursorAnimationDone {
+	return &cursorAnimationDone{ch: make(chan struct{})}
+}
+
+func (d *cursorAnimationDone) close() {
+	if d == nil {
+		return
+	}
+
+	d.once.Do(func() {
+		close(d.ch)
+	})
+}
+
+// cursorRequest is a single "animate to end" job. Config values are captured
+// per-request so a live config reload mid-animation does not change an
+// in-flight tween.
+type cursorRequest struct {
+	end              image.Point
+	steps            int
+	maxDuration      int
+	durationPerPixel float64
+	done             *cursorAnimationDone
+}
+
+// smoothCursorAnimator animates cursor movement toward a target by stepping a
+// backend move function over time. It mirrors the darwin animator design: a
+// single worker goroutine, latest-request-wins coalescing, and a done channel
+// that WaitForCursorIdle blocks on.
+//
+// The X11/Wayland injection detail is kept out of the animator by injecting
+// pos/move at construction: pos samples the current cursor once per request
+// (the interpolation is then purely mathematical, so a stale Wayland cache only
+// affects the glide path, never the final landing point) and move performs one
+// instantaneous warp. Per-step move errors are best-effort and ignored, exactly
+// like the cgo darwin path where the C call cannot fail back to Go.
+type smoothCursorAnimator struct {
+	pos  func() image.Point
+	move func(image.Point) error
+
+	mu     sync.Mutex
+	reqCh  chan cursorRequest
+	stopCh chan struct{}
+	done   *cursorAnimationDone
+}
+
+func newSmoothCursorAnimator(
+	pos func() image.Point,
+	move func(image.Point) error,
+) *smoothCursorAnimator {
+	return &smoothCursorAnimator{pos: pos, move: move}
+}
+
+// stop cancels any in-flight animation and releases waiters. It is called on
+// the non-smooth move path so a direct warp always wins over a running tween.
+func (a *smoothCursorAnimator) stop() {
+	a.mu.Lock()
+	stopCh := a.stopCh
+	done := a.done
+	a.reqCh = nil
+	a.stopCh = nil
+	a.done = nil
+
+	if stopCh != nil {
+		close(stopCh)
+	}
+	a.mu.Unlock()
+
+	done.close()
+}
+
+// wait blocks until the current animation settles or ctx is canceled. It
+// returns immediately when no animation is active, preserving the historical
+// "WaitForCursorIdle is a no-op on Linux" behavior for the non-smooth path.
+func (a *smoothCursorAnimator) wait(ctx context.Context) error {
+	a.mu.Lock()
+	done := a.done
+	a.mu.Unlock()
+
+	if done == nil {
+		return nil
+	}
+
+	select {
+	case <-done.ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// animateTo enqueues an animation toward end, coalescing so only the latest
+// target survives when requests arrive faster than the worker drains them.
+func (a *smoothCursorAnimator) animateTo(
+	end image.Point,
+	steps, maxDuration int,
+	durationPerPixel float64,
+) {
+	done := newCursorAnimationDone()
+	req := cursorRequest{
+		end:              end,
+		steps:            steps,
+		maxDuration:      maxDuration,
+		durationPerPixel: durationPerPixel,
+		done:             done,
+	}
+
+	reqCh := a.ensureWorker(done)
+	select {
+	case reqCh <- req:
+	default:
+		select {
+		case dropped := <-reqCh:
+			dropped.done.close()
+		default:
+		}
+
+		reqCh <- req
+	}
+}
+
+func (a *smoothCursorAnimator) ensureWorker(done *cursorAnimationDone) chan cursorRequest {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.done = done
+
+	if a.reqCh != nil {
+		return a.reqCh
+	}
+
+	reqCh := make(chan cursorRequest, 1)
+	stopCh := make(chan struct{})
+	a.reqCh = reqCh
+	a.stopCh = stopCh
+
+	go a.run(reqCh, stopCh)
+
+	return reqCh
+}
+
+func (a *smoothCursorAnimator) run(reqCh <-chan cursorRequest, stopCh <-chan struct{}) {
+	timer := time.NewTimer(time.Hour)
+
+	stopAndDrainTimer(timer)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		case req := <-reqCh:
+			a.runRequest(req, reqCh, stopCh, timer)
+		}
+	}
+}
+
+func (a *smoothCursorAnimator) runRequest(
+	req cursorRequest,
+	reqCh <-chan cursorRequest,
+	stopCh <-chan struct{},
+	timer *time.Timer,
+) {
+restart:
+	start := a.pos()
+
+	distance := math.Hypot(float64(req.end.X-start.X), float64(req.end.Y-start.Y))
+
+	duration := math.Min(float64(req.maxDuration), distance*req.durationPerPixel)
+	if duration < minCursorAnimationDuration {
+		duration = minCursorAnimationDuration
+	}
+
+	actualSteps := req.steps
+	if actualSteps <= 0 {
+		actualSteps = defaultCursorSteps
+	}
+
+	maxSteps := max(int(duration/float64(minCursorStepDelay)), 1)
+	if actualSteps > maxSteps {
+		actualSteps = maxSteps
+	}
+
+	stepDelayMs := max(int(math.Round(duration/float64(actualSteps))), minCursorStepDelay)
+	stepDelay := time.Duration(stepDelayMs) * time.Millisecond
+
+	for step := 1; step <= actualSteps; step++ {
+		select {
+		case <-stopCh:
+			req.done.close()
+
+			return
+		case nextReq := <-reqCh:
+			req.done.close()
+			req = nextReq
+
+			goto restart
+		default:
+		}
+
+		progress := float64(step) / float64(actualSteps)
+		intermediate := image.Point{
+			X: int(float64(start.X) + float64(req.end.X-start.X)*progress),
+			Y: int(float64(start.Y) + float64(req.end.Y-start.Y)*progress),
+		}
+
+		_ = a.move(intermediate)
+
+		if step < actualSteps {
+			timer.Reset(stepDelay)
+
+			select {
+			case <-stopCh:
+				stopAndDrainTimer(timer)
+				req.done.close()
+
+				return
+			case nextReq := <-reqCh:
+				stopAndDrainTimer(timer)
+				req.done.close()
+				req = nextReq
+
+				goto restart
+			case <-timer.C:
+			}
+		}
+	}
+
+	req.done.close()
+	a.clearDoneIfCurrent(req.done)
+}
+
+func (a *smoothCursorAnimator) clearDoneIfCurrent(done *cursorAnimationDone) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.done == done {
+		a.done = nil
+	}
+}
+
+// stopAndDrainTimer stops timer and clears any pending tick so the next Reset
+// starts clean.
+func stopAndDrainTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}

--- a/internal/core/infra/platform/linux/mouse_animator_linux.go
+++ b/internal/core/infra/platform/linux/mouse_animator_linux.go
@@ -22,37 +22,22 @@ const (
 
 // cursorAnimationDone is a once-closable completion signal shared with
 // WaitForCursorIdle. It mirrors the darwin animator's done channel so callers
-// can block until the cursor settles, and additionally carries the first
-// backend move error so WaitForCursorIdle can surface a failed warp instead of
-// reporting a phantom success. err is written inside once.Do before the channel
-// closes, so a reader that observes the close also observes err (the channel
-// close is the happens-before edge — no extra lock needed).
+// can block until the cursor settles.
 type cursorAnimationDone struct {
 	ch   chan struct{}
 	once sync.Once
-	err  error
 }
 
 func newCursorAnimationDone() *cursorAnimationDone {
 	return &cursorAnimationDone{ch: make(chan struct{})}
 }
 
-// close settles the animation as successful (no backend error).
 func (d *cursorAnimationDone) close() {
-	d.closeWithErr(nil)
-}
-
-// closeWithErr settles the animation, recording err for the first caller to
-// close. Cancellation paths pass nil (a stopped animation is not a move
-// failure); only a failed backend warp passes a non-nil err.
-func (d *cursorAnimationDone) closeWithErr(err error) {
 	if d == nil {
 		return
 	}
 
 	d.once.Do(func() {
-		d.err = err
-
 		close(d.ch)
 	})
 }
@@ -69,18 +54,25 @@ type cursorRequest struct {
 }
 
 // smoothCursorAnimator animates cursor movement toward a target by stepping a
-// backend move function over time. It mirrors the darwin animator design: a
-// single worker goroutine, latest-target-wins coalescing, and a completion
+// backend move function over time. It mirrors the darwin animator's semantics:
+// a single worker goroutine, latest-target-wins coalescing, and a completion
 // channel that WaitForCursorIdle blocks on.
 //
+// Like the darwin animator it is preemptive and fire-and-forget: callers do not
+// serialize cursor access (IPC, hotkey, and event-tap paths all drive moves
+// concurrently), so a bypassed/direct move cancels an in-flight animation and
+// the last writer wins. Backend move errors during an animation are best-effort
+// and not reported through WaitForCursorIdle — matching darwin, whose native
+// move call cannot fail back to Go. The direct (non-smooth) MoveCursorToPoint
+// path still returns backend errors synchronously; only the opt-in animated
+// path degrades to best-effort.
+//
 // Completion is tracked per *session*, not per request. A session begins when
-// an idle animator receives a target and ends when the queue drains (or a
-// failed warp aborts it). All targets that arrive while the session is busy —
-// including coalesced replacements — share the one session completion, so a
-// waiter stays attached until the cursor reaches the latest target, and the
-// session's first move error stays observable by a WaitForCursorIdle that
-// arrives after the session ends (the completion is superseded by the next
-// session or a stop(), never silently cleared).
+// an idle animator receives a target and ends when the queue drains. All
+// targets that arrive while the session is busy — including coalesced
+// replacements — share the one session completion, so a waiter stays attached
+// until the cursor reaches the latest target rather than being released when an
+// intermediate target is superseded.
 //
 // The X11/Wayland injection detail is kept out of the animator by injecting
 // pos/move at construction: pos samples the current cursor once per request
@@ -95,7 +87,6 @@ type smoothCursorAnimator struct {
 	reqCh  chan cursorRequest
 	stopCh chan struct{}
 	done   *cursorAnimationDone // current session completion; nil only between stop() and the next session
-	err    error                // first backend move error of the current session
 	busy   bool                 // a session is in progress (worker actively draining toward a target)
 }
 
@@ -108,8 +99,8 @@ func newSmoothCursorAnimator(
 
 // stop cancels any in-flight animation and releases waiters. It is called on
 // the non-smooth move path so a direct warp always wins over a running tween.
-// It resets the whole session (including any recorded error) and detaches the
-// current worker via stopCh so a stale worker cannot mutate a later session.
+// It detaches the current worker via stopCh so a stale worker cannot mutate a
+// later session.
 func (a *smoothCursorAnimator) stop() {
 	a.mu.Lock()
 	stopCh := a.stopCh
@@ -117,7 +108,6 @@ func (a *smoothCursorAnimator) stop() {
 	a.reqCh = nil
 	a.stopCh = nil
 	a.done = nil
-	a.err = nil
 	a.busy = false
 
 	if stopCh != nil {
@@ -128,9 +118,8 @@ func (a *smoothCursorAnimator) stop() {
 	done.close()
 }
 
-// wait blocks until the current session settles or ctx is canceled, returning
-// the session's first backend move error (nil on success or cancellation). It
-// returns immediately when no session is active, preserving the historical
+// wait blocks until the current session settles or ctx is canceled. It returns
+// immediately when no session is active, preserving the historical
 // "WaitForCursorIdle is a no-op on Linux" behavior for the non-smooth path.
 func (a *smoothCursorAnimator) wait(ctx context.Context) error {
 	a.mu.Lock()
@@ -143,7 +132,7 @@ func (a *smoothCursorAnimator) wait(ctx context.Context) error {
 
 	select {
 	case <-done.ch:
-		return done.err
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -183,7 +172,6 @@ func (a *smoothCursorAnimator) animateTo(
 
 	if !a.busy {
 		a.done = newCursorAnimationDone()
-		a.err = nil
 		a.busy = true
 	}
 
@@ -278,17 +266,11 @@ restart:
 			Y: int(float64(start.Y) + float64(req.end.Y-start.Y)*progress),
 		}
 
-		// A failed backend warp means the cursor is not where the caller
-		// expects, so surface it through WaitForCursorIdle rather than
-		// reporting a phantom success. Backend move failures reflect device
-		// state (disconnected virtual pointer, lost display), so abort the
-		// session instead of spinning on steps that will also fail.
-		moveErr := a.move(intermediate)
-		if moveErr != nil {
-			a.endSessionWithError(reqCh, stopCh, moveErr)
-
-			return
-		}
+		// Best-effort, matching darwin (whose native move cannot fail back to
+		// Go): a failed backend warp during the opt-in animation is not
+		// surfaced through WaitForCursorIdle. The direct MoveCursorToPoint path
+		// still returns backend errors synchronously.
+		_ = a.move(intermediate)
 
 		if step < actualSteps {
 			timer.Reset(stepDelay)
@@ -322,8 +304,8 @@ restart:
 // finishOrNext, called after a target is reached, either hands back the next
 // queued target to continue the current session, or ends the session by closing
 // its completion (keeping a.done referencing the closed completion so a late
-// WaitForCursorIdle still observes the result). It no-ops when this worker has
-// been superseded by a stop()/restart, detected via stopCh identity, so a stale
+// WaitForCursorIdle still sees "idle"). It no-ops when this worker has been
+// superseded by a stop()/restart, detected via stopCh identity, so a stale
 // worker never closes a newer session's completion.
 func (a *smoothCursorAnimator) finishOrNext(
 	reqCh <-chan cursorRequest,
@@ -346,48 +328,12 @@ func (a *smoothCursorAnimator) finishOrNext(
 	}
 
 	done := a.done
-	err := a.err
 	a.busy = false
 	a.mu.Unlock()
 
-	done.closeWithErr(err)
+	done.close()
 
 	return cursorRequest{}, false
-}
-
-// endSessionWithError aborts the current session reporting moveErr. It discards
-// any target queued during the session (the device failed, so the session
-// aborts as a whole and a fresh animateTo will re-drive), then closes the
-// session completion. Like finishOrNext, it no-ops when this worker has been
-// superseded, detected via stopCh identity.
-func (a *smoothCursorAnimator) endSessionWithError(
-	reqCh <-chan cursorRequest,
-	stopCh <-chan struct{},
-	moveErr error,
-) {
-	a.mu.Lock()
-
-	if a.stopCh != stopCh {
-		a.mu.Unlock()
-
-		return
-	}
-
-	select {
-	case <-reqCh:
-	default:
-	}
-
-	if a.err == nil {
-		a.err = moveErr
-	}
-
-	done := a.done
-	err := a.err
-	a.busy = false
-	a.mu.Unlock()
-
-	done.closeWithErr(err)
 }
 
 // stopAndDrainTimer stops timer and clears any pending tick so the next Reset

--- a/internal/core/infra/platform/linux/mouse_animator_linux.go
+++ b/internal/core/infra/platform/linux/mouse_animator_linux.go
@@ -61,11 +61,13 @@ type cursorRequest struct {
 // Like the darwin animator it is preemptive and fire-and-forget: callers do not
 // serialize cursor access (IPC, hotkey, and event-tap paths all drive moves
 // concurrently), so a bypassed/direct move cancels an in-flight animation and
-// the last writer wins. Backend move errors during an animation are best-effort
-// and not reported through WaitForCursorIdle — matching darwin, whose native
-// move call cannot fail back to Go. The direct (non-smooth) MoveCursorToPoint
-// path still returns backend errors synchronously; only the opt-in animated
-// path degrades to best-effort.
+// the last writer wins. stop() fences on injectSem so a bypassed direct warp is
+// reliably ordered after any in-flight animation step — a canceled tween can
+// never land back at an intermediate point after the warp. Backend move errors
+// during an animation are best-effort and not reported through
+// WaitForCursorIdle — matching darwin, whose native move call cannot fail back
+// to Go. The direct (non-smooth) MoveCursorToPoint path still returns backend
+// errors synchronously; only the opt-in animated path degrades to best-effort.
 //
 // Completion is tracked per *session*, not per request. A session begins when
 // an idle animator receives a target and ends when the queue drains. All
@@ -88,13 +90,24 @@ type smoothCursorAnimator struct {
 	stopCh chan struct{}
 	done   *cursorAnimationDone // current session completion; nil only between stop() and the next session
 	busy   bool                 // a session is in progress (worker actively draining toward a target)
+
+	// injectSem is a size-1 semaphore serializing actual backend injection (one
+	// step at a time) and is the ordering handoff to stop(): the worker holds it
+	// across each step and re-checks stopCh under it, so once stop() acquires it
+	// no canceled step is mid-flight and none will start. It is never held
+	// together with mu.
+	injectSem chan struct{}
 }
 
 func newSmoothCursorAnimator(
 	pos func() image.Point,
 	move func(image.Point) error,
 ) *smoothCursorAnimator {
-	return &smoothCursorAnimator{pos: pos, move: move}
+	return &smoothCursorAnimator{
+		pos:       pos,
+		move:      move,
+		injectSem: make(chan struct{}, 1),
+	}
 }
 
 // stop cancels any in-flight animation and releases waiters. It is called on
@@ -116,6 +129,39 @@ func (a *smoothCursorAnimator) stop() {
 	a.mu.Unlock()
 
 	done.close()
+
+	// Order a bypassed direct warp after any in-flight animation step. stopCh is
+	// already closed above, so once we hold injectSem: any step that was
+	// mid-injection has finished (it releases the token on the way out), and any
+	// step that has not yet injected will see the closed stopCh (in stepMove) and
+	// skip. The caller's subsequent moveCursorDirect therefore lands last.
+	a.injectSem <- struct{}{}
+
+	<-a.injectSem
+}
+
+// stepMove injects one animation step while holding injectSem, re-checking
+// stopCh so a step cannot inject once the session is stopped. This, paired with
+// stop()'s injectSem barrier, guarantees a canceled tween never warps the cursor
+// after a bypassed direct move. It returns false when the step was skipped due
+// to stop.
+func (a *smoothCursorAnimator) stepMove(point image.Point, stopCh <-chan struct{}) bool {
+	a.injectSem <- struct{}{}
+	defer func() { <-a.injectSem }()
+
+	select {
+	case <-stopCh:
+		return false
+	default:
+	}
+
+	// Best-effort, matching darwin (whose native move cannot fail back to Go):
+	// a failed backend warp during the opt-in animation is not surfaced through
+	// WaitForCursorIdle. The direct MoveCursorToPoint path still returns backend
+	// errors synchronously.
+	_ = a.move(point)
+
+	return true
 }
 
 // wait blocks until the current session settles or ctx is canceled. It returns
@@ -266,11 +312,9 @@ restart:
 			Y: int(float64(start.Y) + float64(req.end.Y-start.Y)*progress),
 		}
 
-		// Best-effort, matching darwin (whose native move cannot fail back to
-		// Go): a failed backend warp during the opt-in animation is not
-		// surfaced through WaitForCursorIdle. The direct MoveCursorToPoint path
-		// still returns backend errors synchronously.
-		_ = a.move(intermediate)
+		if !a.stepMove(intermediate, stopCh) {
+			return
+		}
 
 		if step < actualSteps {
 			timer.Reset(stepDelay)

--- a/internal/core/infra/platform/linux/mouse_animator_linux.go
+++ b/internal/core/infra/platform/linux/mouse_animator_linux.go
@@ -57,28 +57,36 @@ func (d *cursorAnimationDone) closeWithErr(err error) {
 	})
 }
 
-// cursorRequest is a single "animate to end" job. Config values are captured
-// per-request so a live config reload mid-animation does not change an
-// in-flight tween.
+// cursorRequest is a single "animate to end" target. It carries no completion
+// object of its own: completion is tracked per animation *session* (see
+// smoothCursorAnimator), so coalescing a superseded target never releases a
+// waiter early.
 type cursorRequest struct {
 	end              image.Point
 	steps            int
 	maxDuration      int
 	durationPerPixel float64
-	done             *cursorAnimationDone
 }
 
 // smoothCursorAnimator animates cursor movement toward a target by stepping a
 // backend move function over time. It mirrors the darwin animator design: a
-// single worker goroutine, latest-request-wins coalescing, and a done channel
-// that WaitForCursorIdle blocks on.
+// single worker goroutine, latest-target-wins coalescing, and a completion
+// channel that WaitForCursorIdle blocks on.
+//
+// Completion is tracked per *session*, not per request. A session begins when
+// an idle animator receives a target and ends when the queue drains (or a
+// failed warp aborts it). All targets that arrive while the session is busy —
+// including coalesced replacements — share the one session completion, so a
+// waiter stays attached until the cursor reaches the latest target, and the
+// session's first move error stays observable by a WaitForCursorIdle that
+// arrives after the session ends (the completion is superseded by the next
+// session or a stop(), never silently cleared).
 //
 // The X11/Wayland injection detail is kept out of the animator by injecting
 // pos/move at construction: pos samples the current cursor once per request
-// (the interpolation is then purely mathematical, so a stale Wayland cache only
+// (interpolation is then purely mathematical, so a stale Wayland cache only
 // affects the glide path, never the final landing point) and move performs one
-// instantaneous warp. Per-step move errors are best-effort and ignored, exactly
-// like the cgo darwin path where the C call cannot fail back to Go.
+// instantaneous warp.
 type smoothCursorAnimator struct {
 	pos  func() image.Point
 	move func(image.Point) error
@@ -86,7 +94,9 @@ type smoothCursorAnimator struct {
 	mu     sync.Mutex
 	reqCh  chan cursorRequest
 	stopCh chan struct{}
-	done   *cursorAnimationDone
+	done   *cursorAnimationDone // current session completion; nil only between stop() and the next session
+	err    error                // first backend move error of the current session
+	busy   bool                 // a session is in progress (worker actively draining toward a target)
 }
 
 func newSmoothCursorAnimator(
@@ -98,6 +108,8 @@ func newSmoothCursorAnimator(
 
 // stop cancels any in-flight animation and releases waiters. It is called on
 // the non-smooth move path so a direct warp always wins over a running tween.
+// It resets the whole session (including any recorded error) and detaches the
+// current worker via stopCh so a stale worker cannot mutate a later session.
 func (a *smoothCursorAnimator) stop() {
 	a.mu.Lock()
 	stopCh := a.stopCh
@@ -105,6 +117,8 @@ func (a *smoothCursorAnimator) stop() {
 	a.reqCh = nil
 	a.stopCh = nil
 	a.done = nil
+	a.err = nil
+	a.busy = false
 
 	if stopCh != nil {
 		close(stopCh)
@@ -114,8 +128,9 @@ func (a *smoothCursorAnimator) stop() {
 	done.close()
 }
 
-// wait blocks until the current animation settles or ctx is canceled. It
-// returns immediately when no animation is active, preserving the historical
+// wait blocks until the current session settles or ctx is canceled, returning
+// the session's first backend move error (nil on success or cancellation). It
+// returns immediately when no session is active, preserving the historical
 // "WaitForCursorIdle is a no-op on Linux" behavior for the non-smooth path.
 func (a *smoothCursorAnimator) wait(ctx context.Context) error {
 	a.mu.Lock()
@@ -134,27 +149,26 @@ func (a *smoothCursorAnimator) wait(ctx context.Context) error {
 	}
 }
 
-// animateTo enqueues an animation toward end, coalescing so only the latest
-// target survives when requests arrive faster than the worker drains them.
+// animateTo enqueues an animation toward end. A fresh session completion is
+// created only when the animator is idle; a target arriving mid-session joins
+// the running session so its waiter tracks the latest target.
 //
 // Worker start and enqueue happen under a.mu in one critical section. This is
 // what makes it safe against a concurrent stop(): a bypassed move can never
 // swap out the channel or kill the worker between "pick a channel" and "send",
-// so a request can never be stranded on an orphaned channel with an unclosed
-// done. Because every producer holds the lock and the worker is the sole
-// consumer of the size-1 buffer, the enqueue is always non-blocking.
+// so a request can never be stranded on an orphaned channel. Because every
+// producer holds the lock and the worker is the sole consumer of the size-1
+// buffer, the enqueue is always non-blocking.
 func (a *smoothCursorAnimator) animateTo(
 	end image.Point,
 	steps, maxDuration int,
 	durationPerPixel float64,
 ) {
-	done := newCursorAnimationDone()
 	req := cursorRequest{
 		end:              end,
 		steps:            steps,
 		maxDuration:      maxDuration,
 		durationPerPixel: durationPerPixel,
-		done:             done,
 	}
 
 	a.mu.Lock()
@@ -167,7 +181,12 @@ func (a *smoothCursorAnimator) animateTo(
 		go a.run(a.reqCh, a.stopCh)
 	}
 
-	a.done = done
+	if !a.busy {
+		a.done = newCursorAnimationDone()
+		a.err = nil
+		a.busy = true
+	}
+
 	a.enqueueLocked(req)
 }
 
@@ -176,9 +195,9 @@ func (a *smoothCursorAnimator) animateTo(
 //
 // The buffer is size 1 and, under the lock, we are the only producer while the
 // worker is the only consumer (it removes, never adds). So after draining a
-// stale request the buffer is empty and the follow-up send cannot block. The
-// final default branch is therefore unreachable in practice; it closes done
-// defensively so a waiter can never hang even if that invariant is ever broken.
+// stale target the buffer is empty and the follow-up send cannot block. Targets
+// carry no completion object, so dropping a superseded one is a plain discard —
+// the shared session completion is untouched.
 func (a *smoothCursorAnimator) enqueueLocked(req cursorRequest) {
 	select {
 	case a.reqCh <- req:
@@ -187,15 +206,13 @@ func (a *smoothCursorAnimator) enqueueLocked(req cursorRequest) {
 	}
 
 	select {
-	case dropped := <-a.reqCh:
-		dropped.done.close()
+	case <-a.reqCh:
 	default:
 	}
 
 	select {
 	case a.reqCh <- req:
 	default:
-		req.done.close()
 	}
 }
 
@@ -247,11 +264,8 @@ restart:
 	for step := 1; step <= actualSteps; step++ {
 		select {
 		case <-stopCh:
-			req.done.close()
-
 			return
 		case nextReq := <-reqCh:
-			req.done.close()
 			req = nextReq
 
 			goto restart
@@ -268,11 +282,10 @@ restart:
 		// expects, so surface it through WaitForCursorIdle rather than
 		// reporting a phantom success. Backend move failures reflect device
 		// state (disconnected virtual pointer, lost display), so abort the
-		// remaining steps instead of spinning on calls that will also fail.
+		// session instead of spinning on steps that will also fail.
 		moveErr := a.move(intermediate)
 		if moveErr != nil {
-			req.done.closeWithErr(moveErr)
-			a.clearDoneIfCurrent(req.done)
+			a.endSessionWithError(reqCh, stopCh, moveErr)
 
 			return
 		}
@@ -283,12 +296,11 @@ restart:
 			select {
 			case <-stopCh:
 				stopAndDrainTimer(timer)
-				req.done.close()
 
 				return
 			case nextReq := <-reqCh:
 				stopAndDrainTimer(timer)
-				req.done.close()
+
 				req = nextReq
 
 				goto restart
@@ -297,17 +309,85 @@ restart:
 		}
 	}
 
-	req.done.close()
-	a.clearDoneIfCurrent(req.done)
+	// Target reached. Continue the same session if a newer target is already
+	// queued; otherwise the session ends.
+	next, ok := a.finishOrNext(reqCh, stopCh)
+	if ok {
+		req = next
+
+		goto restart
+	}
 }
 
-func (a *smoothCursorAnimator) clearDoneIfCurrent(done *cursorAnimationDone) {
+// finishOrNext, called after a target is reached, either hands back the next
+// queued target to continue the current session, or ends the session by closing
+// its completion (keeping a.done referencing the closed completion so a late
+// WaitForCursorIdle still observes the result). It no-ops when this worker has
+// been superseded by a stop()/restart, detected via stopCh identity, so a stale
+// worker never closes a newer session's completion.
+func (a *smoothCursorAnimator) finishOrNext(
+	reqCh <-chan cursorRequest,
+	stopCh <-chan struct{},
+) (cursorRequest, bool) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
 
-	if a.done == done {
-		a.done = nil
+	if a.stopCh != stopCh {
+		a.mu.Unlock()
+
+		return cursorRequest{}, false
 	}
+
+	select {
+	case next := <-reqCh:
+		a.mu.Unlock()
+
+		return next, true
+	default:
+	}
+
+	done := a.done
+	err := a.err
+	a.busy = false
+	a.mu.Unlock()
+
+	done.closeWithErr(err)
+
+	return cursorRequest{}, false
+}
+
+// endSessionWithError aborts the current session reporting moveErr. It discards
+// any target queued during the session (the device failed, so the session
+// aborts as a whole and a fresh animateTo will re-drive), then closes the
+// session completion. Like finishOrNext, it no-ops when this worker has been
+// superseded, detected via stopCh identity.
+func (a *smoothCursorAnimator) endSessionWithError(
+	reqCh <-chan cursorRequest,
+	stopCh <-chan struct{},
+	moveErr error,
+) {
+	a.mu.Lock()
+
+	if a.stopCh != stopCh {
+		a.mu.Unlock()
+
+		return
+	}
+
+	select {
+	case <-reqCh:
+	default:
+	}
+
+	if a.err == nil {
+		a.err = moveErr
+	}
+
+	done := a.done
+	err := a.err
+	a.busy = false
+	a.mu.Unlock()
+
+	done.closeWithErr(err)
 }
 
 // stopAndDrainTimer stops timer and clears any pending tick so the next Reset

--- a/internal/core/infra/platform/linux/mouse_animator_linux_test.go
+++ b/internal/core/infra/platform/linux/mouse_animator_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"image"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -218,6 +219,68 @@ func TestSmoothCursorAnimatorBestEffortOnMoveFailure(t *testing.T) {
 	err := animator.wait(ctx)
 	if err != nil {
 		t.Fatalf("smooth-move failure must not surface through wait: got %v", err)
+	}
+}
+
+// TestSmoothCursorAnimatorStopFencesInflightStep verifies stop() does not
+// return while a backend injection step is in flight, and blocks any further
+// step from injecting. This is the ordering guarantee that lets a bypassed
+// direct warp (issued right after stop) land last instead of racing a stale
+// animation step.
+func TestSmoothCursorAnimatorStopFencesInflightStep(t *testing.T) {
+	t.Parallel()
+
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	var moveActive atomic.Bool
+
+	blockingMove := func(_ image.Point) error {
+		moveActive.Store(true)
+
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+
+		<-release
+		moveActive.Store(false)
+
+		return nil
+	}
+	pos := func() image.Point {
+		return image.Point{}
+	}
+
+	animator := newSmoothCursorAnimator(pos, blockingMove)
+	animator.animateTo(image.Point{X: 100, Y: 100}, 10, 200, 1.0)
+
+	<-entered // a backend step is now in flight, blocked in blockingMove
+
+	stopReturned := make(chan struct{})
+
+	go func() {
+		animator.stop()
+		close(stopReturned)
+	}()
+
+	// stop() must not return while the step is mid-injection.
+	select {
+	case <-stopReturned:
+		t.Fatal("stop returned while a backend move was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if !moveActive.Load() {
+		t.Fatal("expected the in-flight step to still be active")
+	}
+
+	close(release) // let the in-flight step finish
+
+	select {
+	case <-stopReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop did not return after the in-flight step completed")
 	}
 }
 

--- a/internal/core/infra/platform/linux/mouse_animator_linux_test.go
+++ b/internal/core/infra/platform/linux/mouse_animator_linux_test.go
@@ -5,16 +5,11 @@ package linux
 
 import (
 	"context"
-	"errors"
 	"image"
 	"sync"
 	"testing"
 	"time"
 )
-
-// errMoveFailed is a static sentinel for the backend-move-failure test, so the
-// propagated error can be matched with errors.Is.
-var errMoveFailed = errors.New("virtual pointer disconnected")
 
 // recorder captures the moves an animator injects so tests can assert on the
 // glide path and final landing point without touching a real display server.
@@ -144,28 +139,6 @@ func TestSmoothCursorAnimatorWaitReturnsWhenIdle(t *testing.T) {
 	}
 }
 
-func TestSmoothCursorAnimatorPropagatesMoveError(t *testing.T) {
-	t.Parallel()
-
-	failingMove := func(_ image.Point) error {
-		return errMoveFailed
-	}
-	pos := func() image.Point {
-		return image.Point{}
-	}
-
-	animator := newSmoothCursorAnimator(pos, failingMove)
-	animator.animateTo(image.Point{X: 400, Y: 400}, 8, 60, 0.1)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	err := animator.wait(ctx)
-	if !errors.Is(err, errMoveFailed) {
-		t.Fatalf("wait did not surface the backend move error: got %v want %v", err, errMoveFailed)
-	}
-}
-
 // TestSmoothCursorAnimatorWaiterTracksSupersedingTarget guards the coalescing
 // race: a waiter that attaches while an earlier target animates must not be
 // released until the cursor reaches the *latest* target, even when the queued
@@ -223,21 +196,14 @@ func TestSmoothCursorAnimatorWaiterTracksSupersedingTarget(t *testing.T) {
 	}
 }
 
-// TestSmoothCursorAnimatorErrorVisibleToLateWaiter guards the completion-erase
-// race: an error that occurs before the caller reaches WaitForCursorIdle must
-// still be observable. The animation is allowed to fail and fully settle before
-// wait is called.
-func TestSmoothCursorAnimatorErrorVisibleToLateWaiter(t *testing.T) {
+// TestSmoothCursorAnimatorBestEffortOnMoveFailure documents that a failing
+// backend warp during the animation is best-effort (matching darwin): the
+// session still settles and WaitForCursorIdle returns without error.
+func TestSmoothCursorAnimatorBestEffortOnMoveFailure(t *testing.T) {
 	t.Parallel()
 
-	moved := make(chan struct{}, 1)
 	failingMove := func(_ image.Point) error {
-		select {
-		case moved <- struct{}{}:
-		default:
-		}
-
-		return errMoveFailed
+		return context.DeadlineExceeded // any non-nil error
 	}
 	pos := func() image.Point {
 		return image.Point{}
@@ -246,17 +212,12 @@ func TestSmoothCursorAnimatorErrorVisibleToLateWaiter(t *testing.T) {
 	animator := newSmoothCursorAnimator(pos, failingMove)
 	animator.animateTo(image.Point{X: 400, Y: 400}, 8, 60, 0.1)
 
-	// Wait until the (failing) move has run and the session has had time to
-	// settle, so wait() is a genuinely "late" caller.
-	<-moved
-	time.Sleep(20 * time.Millisecond)
-
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	err := animator.wait(ctx)
-	if !errors.Is(err, errMoveFailed) {
-		t.Fatalf("late waiter did not observe the move error: got %v want %v", err, errMoveFailed)
+	if err != nil {
+		t.Fatalf("smooth-move failure must not surface through wait: got %v", err)
 	}
 }
 

--- a/internal/core/infra/platform/linux/mouse_animator_linux_test.go
+++ b/internal/core/infra/platform/linux/mouse_animator_linux_test.go
@@ -5,11 +5,16 @@ package linux
 
 import (
 	"context"
+	"errors"
 	"image"
 	"sync"
 	"testing"
 	"time"
 )
+
+// errMoveFailed is a static sentinel for the backend-move-failure test, so the
+// propagated error can be matched with errors.Is.
+var errMoveFailed = errors.New("virtual pointer disconnected")
 
 // recorder captures the moves an animator injects so tests can assert on the
 // glide path and final landing point without touching a real display server.
@@ -137,6 +142,67 @@ func TestSmoothCursorAnimatorWaitReturnsWhenIdle(t *testing.T) {
 	if rec.count() != 0 {
 		t.Fatalf("idle animator injected %d moves, want 0", rec.count())
 	}
+}
+
+func TestSmoothCursorAnimatorPropagatesMoveError(t *testing.T) {
+	t.Parallel()
+
+	failingMove := func(_ image.Point) error {
+		return errMoveFailed
+	}
+	pos := func() image.Point {
+		return image.Point{}
+	}
+
+	animator := newSmoothCursorAnimator(pos, failingMove)
+	animator.animateTo(image.Point{X: 400, Y: 400}, 8, 60, 0.1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if !errors.Is(err, errMoveFailed) {
+		t.Fatalf("wait did not surface the backend move error: got %v want %v", err, errMoveFailed)
+	}
+}
+
+// TestSmoothCursorAnimatorConcurrentStopAndAnimate guards the animateTo/stop
+// race: a bypassed move (stop) must never strand a smooth request on an
+// orphaned channel with an unclosed done. Run with -race. The test passes if it
+// completes without deadlocking on a wait that never returns.
+func TestSmoothCursorAnimatorConcurrentStopAndAnimate(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	var waitGroup sync.WaitGroup
+
+	for index := range 200 {
+		waitGroup.Add(2)
+
+		go func() {
+			defer waitGroup.Done()
+
+			animator.animateTo(image.Point{X: index, Y: index}, 6, 40, 0.2)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			err := animator.wait(ctx)
+			if err != nil {
+				t.Errorf("wait blocked or errored during concurrent stop: %v", err)
+			}
+		}()
+
+		go func() {
+			defer waitGroup.Done()
+
+			animator.stop()
+		}()
+	}
+
+	waitGroup.Wait()
 }
 
 func TestSmoothCursorAnimatorStopReleasesWaiter(t *testing.T) {

--- a/internal/core/infra/platform/linux/mouse_animator_linux_test.go
+++ b/internal/core/infra/platform/linux/mouse_animator_linux_test.go
@@ -1,0 +1,163 @@
+//go:build linux
+
+//nolint:testpackage // Exercises the unexported smooth cursor animator directly.
+package linux
+
+import (
+	"context"
+	"image"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recorder captures the moves an animator injects so tests can assert on the
+// glide path and final landing point without touching a real display server.
+type recorder struct {
+	mu    sync.Mutex
+	moves []image.Point
+	start image.Point
+}
+
+func (r *recorder) pos() image.Point {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.moves) > 0 {
+		return r.moves[len(r.moves)-1]
+	}
+
+	return r.start
+}
+
+func (r *recorder) move(p image.Point) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.moves = append(r.moves, p)
+
+	return nil
+}
+
+func (r *recorder) last() (image.Point, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.moves) == 0 {
+		return image.Point{}, false
+	}
+
+	return r.moves[len(r.moves)-1], true
+}
+
+func (r *recorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.moves)
+}
+
+func TestSmoothCursorAnimatorLandsOnTarget(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{start: image.Point{X: 0, Y: 0}}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	target := image.Point{X: 300, Y: 200}
+	animator.animateTo(target, 8, 60, 0.1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	last, ok := rec.last()
+	if !ok {
+		t.Fatal("expected at least one move to be injected")
+	}
+
+	if last != target {
+		t.Fatalf("cursor did not land on target: got %v want %v", last, target)
+	}
+
+	if rec.count() < 2 {
+		t.Fatalf("expected a stepped glide (>=2 moves), got %d", rec.count())
+	}
+}
+
+func TestSmoothCursorAnimatorCoalescesToLatestTarget(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{start: image.Point{X: 0, Y: 0}}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	// Fire several requests back-to-back; only the last target must win.
+	animator.animateTo(image.Point{X: 100, Y: 100}, 10, 80, 0.5)
+	animator.animateTo(image.Point{X: 500, Y: 50}, 10, 80, 0.5)
+	final := image.Point{X: 640, Y: 480}
+	animator.animateTo(final, 10, 80, 0.5)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	last, ok := rec.last()
+	if !ok {
+		t.Fatal("expected at least one move to be injected")
+	}
+
+	if last != final {
+		t.Fatalf("coalesced animation landed on %v, want latest target %v", last, final)
+	}
+}
+
+func TestSmoothCursorAnimatorWaitReturnsWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	// No animation started: wait must return immediately, preserving the
+	// historical no-op WaitForCursorIdle behavior on the direct move path.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait on idle animator returned error: %v", err)
+	}
+
+	if rec.count() != 0 {
+		t.Fatalf("idle animator injected %d moves, want 0", rec.count())
+	}
+}
+
+func TestSmoothCursorAnimatorStopReleasesWaiter(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{start: image.Point{X: 0, Y: 0}}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	// Long animation so stop() interrupts it mid-flight.
+	animator.animateTo(image.Point{X: 5000, Y: 5000}, 200, 5000, 5.0)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		animator.stop()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait after stop returned error: %v", err)
+	}
+}

--- a/internal/core/infra/platform/linux/mouse_animator_linux_test.go
+++ b/internal/core/infra/platform/linux/mouse_animator_linux_test.go
@@ -166,6 +166,100 @@ func TestSmoothCursorAnimatorPropagatesMoveError(t *testing.T) {
 	}
 }
 
+// TestSmoothCursorAnimatorWaiterTracksSupersedingTarget guards the coalescing
+// race: a waiter that attaches while an earlier target animates must not be
+// released until the cursor reaches the *latest* target, even when the queued
+// target is superseded mid-flight. With per-request completion this waiter
+// returned early at the intermediate/previous position.
+func TestSmoothCursorAnimatorWaiterTracksSupersedingTarget(t *testing.T) {
+	t.Parallel()
+
+	// Slow the moves so the animation spans the follow-up enqueues.
+	rec := &recorder{start: image.Point{X: 0, Y: 0}}
+	slowMove := func(p image.Point) error {
+		time.Sleep(2 * time.Millisecond)
+
+		return rec.move(p)
+	}
+
+	animator := newSmoothCursorAnimator(rec.pos, slowMove)
+
+	final := image.Point{X: 900, Y: 900}
+
+	// Start a long first animation, then attach a waiter mid-flight.
+	animator.animateTo(image.Point{X: 120, Y: 120}, 20, 400, 1.0)
+
+	waitResult := make(chan error, 1)
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		waitResult <- animator.wait(ctx)
+	}()
+
+	// Supersede the target twice while the session is still animating.
+	time.Sleep(6 * time.Millisecond)
+	animator.animateTo(image.Point{X: 500, Y: 500}, 20, 400, 1.0)
+	time.Sleep(6 * time.Millisecond)
+	animator.animateTo(final, 20, 400, 1.0)
+
+	err := <-waitResult
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	last, ok := rec.last()
+	if !ok {
+		t.Fatal("expected at least one move to be injected")
+	}
+
+	if last != final {
+		t.Fatalf(
+			"waiter released before reaching the superseding target: got %v want %v",
+			last,
+			final,
+		)
+	}
+}
+
+// TestSmoothCursorAnimatorErrorVisibleToLateWaiter guards the completion-erase
+// race: an error that occurs before the caller reaches WaitForCursorIdle must
+// still be observable. The animation is allowed to fail and fully settle before
+// wait is called.
+func TestSmoothCursorAnimatorErrorVisibleToLateWaiter(t *testing.T) {
+	t.Parallel()
+
+	moved := make(chan struct{}, 1)
+	failingMove := func(_ image.Point) error {
+		select {
+		case moved <- struct{}{}:
+		default:
+		}
+
+		return errMoveFailed
+	}
+	pos := func() image.Point {
+		return image.Point{}
+	}
+
+	animator := newSmoothCursorAnimator(pos, failingMove)
+	animator.animateTo(image.Point{X: 400, Y: 400}, 8, 60, 0.1)
+
+	// Wait until the (failing) move has run and the session has had time to
+	// settle, so wait() is a genuinely "late" caller.
+	<-moved
+	time.Sleep(20 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if !errors.Is(err, errMoveFailed) {
+		t.Fatalf("late waiter did not observe the move error: got %v want %v", err, errMoveFailed)
+	}
+}
+
 // TestSmoothCursorAnimatorConcurrentStopAndAnimate guards the animateTo/stop
 // race: a bypassed move (stop) must never strand a smooth request on an
 // orphaned channel with an unclosed done. Run with -race. The test passes if it

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -27,12 +27,19 @@ const (
 
 // SystemAdapter is a Linux system adapter.
 type SystemAdapter struct {
-	backend string
+	backend        string
+	cursorAnimator *smoothCursorAnimator
 }
 
 // NewSystemAdapter creates a new SystemAdapter.
 func NewSystemAdapter(backend string) *SystemAdapter {
-	return &SystemAdapter{backend: backend}
+	adapter := &SystemAdapter{backend: backend}
+	adapter.cursorAnimator = newSmoothCursorAnimator(
+		adapter.currentCursorPosition,
+		adapter.moveCursorDirect,
+	)
+
+	return adapter
 }
 
 // PlatformLabel returns "linux/<backend>" (e.g. "linux/x11", "linux/wayland-kde").
@@ -203,23 +210,36 @@ func (s *SystemAdapter) FocusedWindowBounds(
 }
 
 // MoveCursorToPoint moves the mouse cursor to the specified point on Linux.
-// TODO(linux): implement using XTest (X11) or libinput (Wayland).
+//
+// When smooth cursor is enabled (config smooth_cursor.move_mouse_enabled) and
+// the caller has not requested a bypass, the move is animated by the shared
+// cursor animator, which steps moveCursorDirect over time; callers that need
+// the cursor settled before acting pair this with WaitForCursorIdle. Otherwise
+// (bypass, disabled, or no config wired) it warps directly. The animator is a
+// no-op wrapper on the direct path, so behavior is unchanged unless the user
+// opts into smooth cursor. Backend routing lives in moveCursorDirect.
 func (s *SystemAdapter) MoveCursorToPoint(
 	ctx context.Context,
 	point image.Point,
 	bypassSmooth bool,
 ) error {
-	if s.backend == backendX11 {
-		return x11MoveCursorToPoint(point)
+	cfg := currentLinuxConfig()
+	if cfg != nil && cfg.SmoothCursor.MoveMouseEnabled && !bypassSmooth {
+		s.cursorAnimator.animateTo(
+			point,
+			cfg.SmoothCursor.Steps,
+			cfg.SmoothCursor.MaxDuration,
+			cfg.SmoothCursor.DurationPerPixel,
+		)
+
+		return nil
 	}
 
-	if s.waylandUsesWlrClientStack() {
-		// Route through the Wayland input dispatcher so KDE (no virtual
-		// pointer) uses libei while wlroots compositors use the native path.
-		return waylandMoveCursorToPoint(point)
-	}
+	// A direct warp must win over any in-flight animation, matching the darwin
+	// behavior where every non-smooth move stops the animator first.
+	s.cursorAnimator.stop()
 
-	return derrors.New(derrors.CodeNotSupported, "MoveCursorToPoint not yet implemented on linux")
+	return s.moveCursorDirect(point)
 }
 
 // MoveCursorBy uses native relative motion when the Wayland backend supports it.
@@ -236,9 +256,11 @@ func (s *SystemAdapter) MoveCursorBy(
 	return false, nil
 }
 
-// WaitForCursorIdle returns immediately on Linux until smooth cursor support exists.
+// WaitForCursorIdle blocks until any in-flight smooth cursor animation settles,
+// or ctx is canceled. It returns immediately when no animation is active — the
+// common case on the direct (non-smooth) move path.
 func (s *SystemAdapter) WaitForCursorIdle(ctx context.Context) error {
-	return nil
+	return s.cursorAnimator.wait(ctx)
 }
 
 // CursorPosition returns the current cursor position on Linux.
@@ -308,6 +330,36 @@ func (s *SystemAdapter) ShowAlert(ctx context.Context, title, message string) er
 // ShowNotification displays a lightweight notification on Linux.
 // TODO(linux): implement using org.freedesktop.Notifications D-Bus interface.
 func (s *SystemAdapter) ShowNotification(title, message string) {}
+
+// moveCursorDirect performs a single instantaneous cursor warp, routing to the
+// backend-specific injector. It is the shared sink for both the direct move
+// path and each step of the smooth animator.
+func (s *SystemAdapter) moveCursorDirect(point image.Point) error {
+	if s.backend == backendX11 {
+		return x11MoveCursorToPoint(point)
+	}
+
+	if s.waylandUsesWlrClientStack() {
+		// Route through the Wayland input dispatcher so KDE (no virtual
+		// pointer) uses libei while wlroots compositors use the native path.
+		return waylandMoveCursorToPoint(point)
+	}
+
+	return derrors.New(derrors.CodeNotSupported, "MoveCursorToPoint not yet implemented on linux")
+}
+
+// currentCursorPosition returns the current cursor position for the animator,
+// collapsing the error to a zero point. The animator samples this once per
+// request to seed interpolation; a bad read only skews the glide path, never
+// the final landing point (the last step lands exactly on the target).
+func (s *SystemAdapter) currentCursorPosition() image.Point {
+	point, err := s.CursorPosition(context.Background())
+	if err != nil {
+		return image.Point{}
+	}
+
+	return point
+}
 
 // waylandUsesWlrClientStack is true when the session uses the same Wayland
 // client protocols as wlroots (layer shell, xdg-output, virtual pointer, etc.).

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -235,8 +235,12 @@ func (s *SystemAdapter) MoveCursorToPoint(
 		return nil
 	}
 
-	// A direct warp must win over any in-flight animation, matching the darwin
-	// behavior where every non-smooth move stops the animator first.
+	// Stop before warping: the animation worker must be canceled first so a
+	// pending tween step cannot override the direct warp. This matches the
+	// darwin non-smooth path (stop, then move). Cursor access is not serialized
+	// across the IPC/hotkey/event-tap goroutines, so this is deliberately
+	// preemptive last-writer-wins — a bypassed move cancels an in-flight
+	// animation and releases its waiter, exactly as on macOS.
 	s.cursorAnimator.stop()
 
 	return s.moveCursorDirect(point)

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -236,11 +236,11 @@ func (s *SystemAdapter) MoveCursorToPoint(
 	}
 
 	// Stop before warping: the animation worker must be canceled first so a
-	// pending tween step cannot override the direct warp. This matches the
-	// darwin non-smooth path (stop, then move). Cursor access is not serialized
-	// across the IPC/hotkey/event-tap goroutines, so this is deliberately
-	// preemptive last-writer-wins — a bypassed move cancels an in-flight
-	// animation and releases its waiter, exactly as on macOS.
+	// pending tween step cannot override the direct warp. stop() drains the
+	// animator's injection mutex, so on return no animation step is in flight
+	// and none will start — this warp lands last, not racing a stale step back
+	// to an intermediate point. (Which of two distinct concurrent callers wins
+	// is still last-writer-wins, as on macOS.)
 	s.cursorAnimator.stop()
 
 	return s.moveCursorDirect(point)


### PR DESCRIPTION
## Description

This PR adds smooth cursor animation on Linux (X11 and Wayland wlroots/KDE) so animated mouse movement — previously macOS-only — now works there too; GNOME/Wayland and Windows keep instant movement. It is opt-in via `smooth_cursor.move_mouse_enabled` and off by default, so existing behavior is unchanged.

## Related Issues

<!-- none -->

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Reuses the existing cross-platform `SmoothCursorConfig` and the `MoveCursorToPoint` / `WaitForCursorIdle` ports, so no interface changes were needed. On Wayland the animation's start point comes from the client-side cursor cache; a stale read only skews the glide path — the final step lands exactly on the target.