### PR TITLE
feat(linux): modifier passthrough on Wayland evdev

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -825,11 +825,28 @@ All 8 action types from `internal/core/domain/action/action.go` are dispatched v
 | ------------------------ | ------------------------------------------------ | ----------------------- | ---------------------------------- | ---------------------------- |
 | **Mechanism**            | `CGEventTapCreate` (Quartz)                      | `XGrabKeyboard`         | evdev grab + wl-keyboard           | `WH_KEYBOARD_LL` hook        |
 | **CGO required**         | Yes                                              | Yes                     | Yes (cgo path)                     | No                           |
-| **Modifier passthrough** | ✅ (CGEventTap callback can pass events through) | ❌ (no-op)              | ❌ (no-op)                         | ❌ (no-op)                   |
+| **Modifier passthrough** | ✅ (CGEventTap callback can pass events through) | ❌ (grab is all-or-nothing) | ✅ (evdev only; re-inject via virtual kbd) | ❌ (no-op)                   |
 | **PostModifierEvent**    | ✅                                               | ✅                      | ✅                                 | ❌ (no-op)                   |
 | **Sticky modifiers**     | ✅                                               | ✅                      | ✅                                 | ✅                           |
-| **File**                 | `eventtap_darwin.go`                             | `eventtap_linux_x11.go` | `eventtap_linux_wayland.go`        | `eventtap_windows.go`        |
+| **File**                 | `eventtap_darwin.go`                             | `eventtap_linux_x11.go` | `eventtap_linux_wayland.go` / `..._evdev_cgo.go` | `eventtap_windows.go`        |
 | **Event source**         | System-wide CGEvent stream                       | X11 grabbed keyboard    | `/dev/uinput` + wl_keyboard events | System-wide `WH_KEYBOARD_LL` |
+
+**Modifier passthrough on Linux (Wayland evdev only):** while a mode is active
+Neru captures the keyboard exclusively, so shortcuts it doesn't bind (e.g.
+`Ctrl+C`, `Ctrl+Tab`) are normally swallowed. With
+`general.passthrough_unbounded_keys`, unbound Ctrl/Alt/Cmd chords are instead
+re-injected to the focused app. This works on the **Wayland evdev** backend
+because Neru holds an `EVIOCGRAB` on the physical device but injects through a
+*separate* `zwp_virtual_keyboard_v1`, which bypasses that grab and reaches the
+app with no feedback loop (see `handleWaylandEvdevEvent` →
+`passthroughEvdevChord`). It is **not** available on **X11** — an `XGrabKeyboard`
+routes Neru's own synthetic XTest events back to itself, and `XSendEvent` is
+ignored by most apps — nor on the rare **wl-keyboard fallback**, which has no
+injection path. Classification (blacklist, mode-intercepted keys, the mode's own
+hotkeys) and the post-passthrough hint refresh are shared cross-platform in
+`internal/app/modes/passthrough.go`; only the final re-injection is
+backend-specific. The blacklist keeps chosen chords consumed, and
+`general.should_exit_after_passthrough` exits the mode after a passthrough.
 
 #### Global Hotkeys
 

--- a/internal/core/infra/eventtap/eventtap_linux_common.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common.go
@@ -11,6 +11,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/ui/overlay"
 )
 
@@ -74,6 +75,16 @@ type EventTap struct {
 	hotkeys              []string
 	stickyModifierToggle bool
 	enabled              bool
+
+	// Modifier passthrough state. Populated by SetModifierPassthrough /
+	// SetInterceptedModifierKeys and consulted only by the Wayland evdev
+	// backend (handleWaylandEvdevEvent): with a virtual-keyboard injection path
+	// it can re-emit an unbound chord to the focused app. The X11 grab and the
+	// wl-keyboard fallback cannot re-inject selectively, so this stays inert
+	// there. Chords are stored canonicalized via canonicalChordForMatch.
+	passthroughEnabled   bool
+	passthroughBlacklist map[string]struct{}
+	interceptedChords    map[string]struct{}
 
 	// Detection arming: sticky modifier events are only dispatched once all
 	// initially-held modifiers have been released (matching macOS behavior).
@@ -238,11 +249,28 @@ func (et *EventTap) SetHotkeys(hotkeys []string) {
 	et.hotkeys = append([]string(nil), hotkeys...)
 }
 
-// SetModifierPassthrough enables/disables modifier passthrough.
-func (et *EventTap) SetModifierPassthrough(_ bool, _ []string) {}
+// SetModifierPassthrough enables/disables modifier passthrough and records the
+// blacklist of chords Neru must keep consuming even when they are otherwise
+// unbound (the mode layer folds the active mode's own hotkeys into this list).
+// Only the Wayland evdev backend acts on it; see the struct field comment.
+func (et *EventTap) SetModifierPassthrough(enabled bool, blacklist []string) {
+	set := canonicalChordSet(blacklist)
 
-// SetInterceptedModifierKeys sets which modifier keys to intercept.
-func (et *EventTap) SetInterceptedModifierKeys(_ []string) {}
+	et.mu.Lock()
+	et.passthroughEnabled = enabled
+	et.passthroughBlacklist = set
+	et.mu.Unlock()
+}
+
+// SetInterceptedModifierKeys records the modifier chords the active mode still
+// wants Neru to consume while passthrough is enabled.
+func (et *EventTap) SetInterceptedModifierKeys(keys []string) {
+	set := canonicalChordSet(keys)
+
+	et.mu.Lock()
+	et.interceptedChords = set
+	et.mu.Unlock()
+}
 
 // SetPassthroughCallback sets the callback for passthrough mode.
 func (et *EventTap) SetPassthroughCallback(cb PassthroughCallback) {
@@ -250,6 +278,74 @@ func (et *EventTap) SetPassthroughCallback(cb PassthroughCallback) {
 	defer et.mu.Unlock()
 
 	et.passthroughCallback = cb
+}
+
+// canonicalChordSet builds a lookup set of chords normalized via
+// canonicalChordForMatch so runtime lookups are independent of the order the
+// user wrote their hotkeys in.
+func canonicalChordSet(chords []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(chords))
+
+	for _, chord := range chords {
+		if canonical := canonicalChordForMatch(chord); canonical != "" {
+			set[canonical] = struct{}{}
+		}
+	}
+
+	return set
+}
+
+// canonicalChordForMatch normalizes a modifier chord to a stable,
+// order-independent form for passthrough matching: aliases are resolved and
+// tokens lowercased via config.NormalizeKeyForComparison, then the modifiers
+// are re-emitted in the fixed shift+ctrl+alt+cmd order that
+// evdevModifierState.prefix() produces, with the base key last. Applying it to
+// both the configured blacklist/intercepted entries and the runtime evdev chord
+// makes lookups agree regardless of modifier ordering.
+func canonicalChordForMatch(chord string) string {
+	normalized := config.NormalizeKeyForComparison(strings.TrimSpace(chord))
+	if normalized == "" {
+		return ""
+	}
+
+	parts := strings.Split(normalized, "+")
+	base := strings.TrimSpace(parts[len(parts)-1])
+
+	var hasShift, hasCtrl, hasAlt, hasCmd bool
+
+	for _, part := range parts[:len(parts)-1] {
+		switch canonicalLinuxModifier(part) {
+		case evdevModifierShift:
+			hasShift = true
+		case evdevModifierCtrl:
+			hasCtrl = true
+		case evdevModifierAlt:
+			hasAlt = true
+		case evdevModifierCmd:
+			hasCmd = true
+		}
+	}
+
+	var builder strings.Builder
+
+	for _, mod := range []struct {
+		held bool
+		name string
+	}{
+		{hasShift, evdevModifierShift},
+		{hasCtrl, evdevModifierCtrl},
+		{hasAlt, evdevModifierAlt},
+		{hasCmd, evdevModifierCmd},
+	} {
+		if mod.held {
+			builder.WriteString(mod.name)
+			builder.WriteByte('+')
+		}
+	}
+
+	builder.WriteString(base)
+
+	return builder.String()
 }
 
 // SetStickyModifierToggle enables/disables sticky modifier toggle.
@@ -320,6 +416,52 @@ func (et *EventTap) stickyDetectionArmed() bool {
 	defer et.mu.RUnlock()
 
 	return et.stickyModifierDetectionArmed
+}
+
+// shouldPassthroughChord reports whether an unbound modifier chord should be
+// passed through to the focused application instead of consumed by Neru. It
+// mirrors the macOS event-tap decision: passthrough must be enabled, the chord
+// must carry a Ctrl/Alt/Cmd modifier (shift-only chords stay usable inside
+// modes), and it must be neither blacklisted nor in the mode's intercepted set.
+func (et *EventTap) shouldPassthroughChord(chord string) bool {
+	// Check the cheap enabled flag before the allocating normalization so the
+	// common disabled case (the default) costs nothing on the key hot path.
+	et.mu.RLock()
+	enabled := et.passthroughEnabled
+	et.mu.RUnlock()
+
+	if !enabled || !config.HasPassthroughModifier(chord) {
+		return false
+	}
+
+	canonical := canonicalChordForMatch(chord)
+
+	et.mu.RLock()
+	defer et.mu.RUnlock()
+
+	if _, ok := et.passthroughBlacklist[canonical]; ok {
+		return false
+	}
+
+	if _, ok := et.interceptedChords[canonical]; ok {
+		return false
+	}
+
+	return true
+}
+
+// firePassthroughCallback invokes the registered passthrough callback (if any)
+// on its own goroutine and without holding et.mu, so it can neither block the
+// key-reader goroutine nor deadlock against the mode handler's own lock. This
+// mirrors the async dispatch the macOS tap uses for the same callback.
+func (et *EventTap) firePassthroughCallback() {
+	et.mu.RLock()
+	cb := et.passthroughCallback
+	et.mu.RUnlock()
+
+	if cb != nil {
+		go cb()
+	}
 }
 
 // run starts the event interception loop.

--- a/internal/core/infra/eventtap/eventtap_linux_common_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_common_test.go
@@ -5,6 +5,11 @@ package eventtap
 
 import "testing"
 
+const (
+	chordCtrlC     = "Ctrl+c"
+	chordShiftCtrl = "shift+ctrl+t"
+)
+
 func TestLinuxModifierToggleEventCanonicalizes(t *testing.T) {
 	t.Parallel()
 
@@ -69,6 +74,119 @@ func TestSyntheticModifierSuppressionConsumesOnce(t *testing.T) {
 
 	if eventTap.consumeSyntheticModifierEvent("shift", true) {
 		t.Fatal("expected synthetic event to be consumed only once")
+	}
+}
+
+func TestCanonicalChordForMatchOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "single ctrl lowercased", in: chordCtrlC, want: "ctrl+c"},
+		{name: "cmd cased", in: "Cmd+C", want: "cmd+c"},
+		{name: "ctrl+shift order a", in: "ctrl+shift+t", want: chordShiftCtrl},
+		{name: "ctrl+shift order b", in: chordShiftCtrl, want: chordShiftCtrl},
+		{name: "all mods reordered", in: "cmd+alt+ctrl+shift+k", want: "shift+ctrl+alt+cmd+k"},
+		{name: "control alias", in: "control+a", want: "ctrl+a"},
+		{name: "plain key", in: "c", want: "c"},
+		{name: "empty", in: "", want: ""},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := canonicalChordForMatch(testCase.in); got != testCase.want {
+				t.Fatalf(
+					"canonicalChordForMatch(%q) = %q, want %q",
+					testCase.in,
+					got,
+					testCase.want,
+				)
+			}
+		})
+	}
+}
+
+func TestShouldPassthroughChord(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		enabled     bool
+		blacklist   []string
+		intercepted []string
+		chord       string
+		want        bool
+	}{
+		{name: "disabled", enabled: false, chord: chordCtrlC, want: false},
+		{name: "unbound ctrl passes", enabled: true, chord: chordCtrlC, want: true},
+		{name: "unbound alt passes", enabled: true, chord: "Alt+Left", want: true},
+		{name: "shift only excluded", enabled: true, chord: "Shift+a", want: false},
+		{name: "plain key excluded", enabled: true, chord: "c", want: false},
+		{
+			name:      "blacklisted consumed",
+			enabled:   true,
+			blacklist: []string{chordCtrlC},
+			chord:     chordCtrlC,
+			want:      false,
+		},
+		{
+			name:      "blacklist order independent",
+			enabled:   true,
+			blacklist: []string{"Cmd+Shift+K"},
+			chord:     "Shift+Cmd+k",
+			want:      false,
+		},
+		{
+			name:        "intercepted consumed",
+			enabled:     true,
+			intercepted: []string{"Ctrl+j"},
+			chord:       "Ctrl+j",
+			want:        false,
+		},
+		{
+			name:      "non-blacklisted sibling passes",
+			enabled:   true,
+			blacklist: []string{chordCtrlC},
+			chord:     "Ctrl+v",
+			want:      true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			eventTap := NewEventTap(nil, nil)
+			eventTap.SetModifierPassthrough(testCase.enabled, testCase.blacklist)
+			eventTap.SetInterceptedModifierKeys(testCase.intercepted)
+
+			if got := eventTap.shouldPassthroughChord(testCase.chord); got != testCase.want {
+				t.Fatalf(
+					"shouldPassthroughChord(%q) = %t, want %t",
+					testCase.chord,
+					got,
+					testCase.want,
+				)
+			}
+		})
+	}
+}
+
+func TestSetModifierPassthroughDisabledStillMatchesBlacklist(t *testing.T) {
+	t.Parallel()
+
+	// Even with the blacklist populated, a disabled passthrough never passes
+	// anything through — the enabled flag gates first.
+	eventTap := NewEventTap(nil, nil)
+	eventTap.SetModifierPassthrough(false, []string{"Ctrl+x"})
+
+	if eventTap.shouldPassthroughChord("Ctrl+y") {
+		t.Fatal("expected no passthrough while disabled")
 	}
 }
 

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -91,6 +91,14 @@ type waylandEvdevKeyState struct {
 	// never reached libinput.  We inject synthetic releases for these
 	// at shutdown so libinput's per-keycode hw_is_key_down is cleared.
 	releasedDuringGrab map[uint16]bool
+	// passthroughHeld maps a base keycode that is currently being passed
+	// through to the focused app to the modifier names we pressed on the
+	// virtual keyboard for it. The modifiers stay held (refcounted by the
+	// wlroots modifier dispatcher) across the whole press→repeat→release
+	// span so auto-repeat works without flapping the modifier, and are
+	// released on the physical key-up. Presence also marks the release as
+	// "already passed through" so no stray key-up leaks into Neru.
+	passthroughHeld map[uint16][]string
 }
 
 type waylandEvdevCapture struct {
@@ -963,6 +971,17 @@ drainStale:
 				}
 			}
 
+			// Release any modifiers still held for a passthrough key that was
+			// down when the mode exited, so a virtual modifier can never stay
+			// latched after the grab ends.
+			for code, mods := range state.passthroughHeld {
+				delete(state.passthroughHeld, code)
+
+				for _, mod := range slices.Backward(mods) {
+					_ = linux.WaylandModifierEvent(mod, false)
+				}
+			}
+
 			capture.ungrabAll()
 
 			return true
@@ -1110,6 +1129,20 @@ func (et *EventTap) handleWaylandEvdevEvent(
 		}
 		state.trackKey(event.code, false)
 
+		// A key that was passed through never reached Neru as a press, so its
+		// release must not leak a key-up into Neru either. Release the virtual
+		// modifiers we were holding for it (refcounted, so a modifier shared
+		// with another passthrough key or a sticky hold stays down).
+		if mods, ok := state.passthroughHeld[event.code]; ok {
+			delete(state.passthroughHeld, event.code)
+
+			for _, mod := range slices.Backward(mods) {
+				_ = linux.WaylandModifierEvent(mod, false)
+			}
+
+			return
+		}
+
 		key := et.xkbEvdevKeyName(capture, event.code)
 		if key != "" {
 			if keyUp := linuxKeyUpEvent(key); keyUp != "" {
@@ -1143,7 +1176,84 @@ func (et *EventTap) handleWaylandEvdevEvent(
 		return
 	}
 
+	// Modifier passthrough: when an unbound Ctrl/Alt/Cmd chord should reach the
+	// focused application, re-inject it through the virtual keyboard (a distinct
+	// device from the EVIOCGRAB'd physical keyboard, so it does not re-enter this
+	// reader) and skip Neru's own dispatch.
+	if et.shouldPassthroughChord(key) {
+		et.passthroughEvdevChord(state, event.code, event.value == evdevValuePress)
+
+		return
+	}
+
 	et.dispatchKey(key)
+}
+
+// passthroughEvdevChord re-injects a modifier chord to the focused application
+// through the zwp_virtual_keyboard_v1 path. On the initial press it holds the
+// currently-held modifiers down (refcounted by the wlroots modifier dispatcher)
+// and taps the base keycode, records the hold so the physical release can drop
+// those modifiers, and notifies the mode layer once. On auto-repeat it re-taps
+// only the base key, leaving the modifiers held so the app sees a steadily-held
+// modifier instead of it flapping around every repeat. Injection is best-effort
+// (a failed event is dropped) since there is no meaningful recovery mid-chord.
+func (et *EventTap) passthroughEvdevChord(state *waylandEvdevKeyState, code uint16, isPress bool) {
+	if _, held := state.passthroughHeld[code]; held && !isPress {
+		// Auto-repeat: modifiers are already held; just re-tap the base key.
+		_ = linux.WaylandKeyEvent(uint32(code), true)
+		_ = linux.WaylandKeyEvent(uint32(code), false)
+
+		return
+	}
+
+	mods := heldPassthroughModifiers(state)
+
+	for _, mod := range mods {
+		_ = linux.WaylandModifierEvent(mod, true)
+	}
+
+	_ = linux.WaylandKeyEvent(uint32(code), true)
+	_ = linux.WaylandKeyEvent(uint32(code), false)
+
+	if state.passthroughHeld == nil {
+		state.passthroughHeld = make(map[uint16][]string)
+	}
+
+	state.passthroughHeld[code] = mods
+
+	et.firePassthroughCallback()
+}
+
+// passthroughModifierCount is the number of distinct modifier groups
+// (shift/ctrl/alt/cmd) a re-injected chord can carry.
+const passthroughModifierCount = 4
+
+// heldPassthroughModifiers returns the canonical names of the modifiers
+// currently held, in a stable shift→ctrl→alt→cmd order, for chord re-injection.
+func heldPassthroughModifiers(state *waylandEvdevKeyState) []string {
+	if state == nil {
+		return nil
+	}
+
+	mods := make([]string, 0, passthroughModifierCount)
+
+	if state.modifiers.shift > 0 {
+		mods = append(mods, evdevModifierShift)
+	}
+
+	if state.modifiers.ctrl > 0 {
+		mods = append(mods, evdevModifierCtrl)
+	}
+
+	if state.modifiers.alt > 0 {
+		mods = append(mods, evdevModifierAlt)
+	}
+
+	if state.modifiers.cmd > 0 {
+		mods = append(mods, evdevModifierCmd)
+	}
+
+	return mods
 }
 
 func (state *waylandEvdevKeyState) trackKey(code uint16, isDown bool) {

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -1247,7 +1247,17 @@ func (et *EventTap) passthroughEvdevChord(
 		return false
 	}
 
-	_ = linux.WaylandKeyEvent(uint32(code), false)
+	keyUpErr := linux.WaylandKeyEvent(uint32(code), false)
+	if keyUpErr != nil && et.logger != nil {
+		// The chord was already delivered by the key-down; a rejected key-up is
+		// not retried (the injection channel would have to recover), but log it
+		// so a stuck virtual key is diagnosable.
+		et.logger.Warn(
+			"Failed to release passthrough key",
+			zap.Uint16("keycode", code),
+			zap.Error(keyUpErr),
+		)
+	}
 
 	if state.passthroughHeld == nil {
 		state.passthroughHeld = make(map[uint16][]string)
@@ -1263,10 +1273,19 @@ func (et *EventTap) passthroughEvdevChord(
 // releasePassthroughModifiers releases the given modifiers in reverse press
 // order (refcounted, so a modifier shared with another passthrough key or a
 // sticky hold stays down). Used both to unwind a failed press and to drop a
-// held chord's modifiers on release/shutdown.
+// held chord's modifiers on release/shutdown. A rejected release is not retried
+// (a dead injection channel would keep failing), but is logged so a latched
+// virtual modifier is diagnosable — matching the shutdown synthetic-release path.
 func (et *EventTap) releasePassthroughModifiers(mods []string) {
 	for _, mod := range slices.Backward(mods) {
-		_ = linux.WaylandModifierEvent(mod, false)
+		err := linux.WaylandModifierEvent(mod, false)
+		if err != nil && et.logger != nil {
+			et.logger.Warn(
+				"Failed to release passthrough modifier",
+				zap.String("modifier", mod),
+				zap.Error(err),
+			)
+		}
 	}
 }
 

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -976,10 +976,7 @@ drainStale:
 			// latched after the grab ends.
 			for code, mods := range state.passthroughHeld {
 				delete(state.passthroughHeld, code)
-
-				for _, mod := range slices.Backward(mods) {
-					_ = linux.WaylandModifierEvent(mod, false)
-				}
+				et.releasePassthroughModifiers(mods)
 			}
 
 			capture.ungrabAll()
@@ -1135,10 +1132,7 @@ func (et *EventTap) handleWaylandEvdevEvent(
 		// with another passthrough key or a sticky hold stays down).
 		if mods, ok := state.passthroughHeld[event.code]; ok {
 			delete(state.passthroughHeld, event.code)
-
-			for _, mod := range slices.Backward(mods) {
-				_ = linux.WaylandModifierEvent(mod, false)
-			}
+			et.releasePassthroughModifiers(mods)
 
 			return
 		}
@@ -1166,6 +1160,17 @@ func (et *EventTap) handleWaylandEvdevEvent(
 		return
 	}
 
+	// A key already owned by passthrough keeps routing its repeats to the app for
+	// as long as it is physically held, regardless of the current modifier state.
+	// Releasing a modifier mid-hold must not reclassify the key back into Neru
+	// (the virtual modifier stays held until the physical key-up). Keyed by code,
+	// so this runs before key-name resolution.
+	if _, held := state.passthroughHeld[event.code]; held {
+		et.passthroughEvdevChord(state, event.code, false)
+
+		return
+	}
+
 	key := et.xkbEvdevKeyName(capture, event.code)
 	if key == "" {
 		return
@@ -1179,10 +1184,9 @@ func (et *EventTap) handleWaylandEvdevEvent(
 	// Modifier passthrough: when an unbound Ctrl/Alt/Cmd chord should reach the
 	// focused application, re-inject it through the virtual keyboard (a distinct
 	// device from the EVIOCGRAB'd physical keyboard, so it does not re-enter this
-	// reader) and skip Neru's own dispatch.
-	if et.shouldPassthroughChord(key) {
-		et.passthroughEvdevChord(state, event.code, event.value == evdevValuePress)
-
+	// reader) and skip Neru's own dispatch. If injection fails, fall through to
+	// normal dispatch rather than silently dropping the shortcut.
+	if et.shouldPassthroughChord(key) && et.passthroughEvdevChord(state, event.code, true) {
 		return
 	}
 
@@ -1190,29 +1194,59 @@ func (et *EventTap) handleWaylandEvdevEvent(
 }
 
 // passthroughEvdevChord re-injects a modifier chord to the focused application
-// through the zwp_virtual_keyboard_v1 path. On the initial press it holds the
-// currently-held modifiers down (refcounted by the wlroots modifier dispatcher)
-// and taps the base keycode, records the hold so the physical release can drop
-// those modifiers, and notifies the mode layer once. On auto-repeat it re-taps
-// only the base key, leaving the modifiers held so the app sees a steadily-held
-// modifier instead of it flapping around every repeat. Injection is best-effort
-// (a failed event is dropped) since there is no meaningful recovery mid-chord.
-func (et *EventTap) passthroughEvdevChord(state *waylandEvdevKeyState, code uint16, isPress bool) {
+// through the zwp_virtual_keyboard_v1 path and reports whether it was delivered.
+// On the initial press it holds the currently-held modifiers down (refcounted by
+// the wlroots modifier dispatcher) and taps the base keycode, records the hold so
+// the physical release can drop those modifiers, and notifies the mode layer
+// once. On auto-repeat it re-taps only the base key, leaving the modifiers held
+// so the app sees a steadily-held modifier instead of it flapping around every
+// repeat.
+//
+// It returns false when the essential injection (a held modifier or the base-key
+// press) failed on the initial press, having rolled back any modifiers it pressed
+// so none stays latched; the caller then falls back to normal dispatch rather
+// than reporting a delivered shortcut. Returns true once the key is owned by
+// passthrough — a dropped auto-repeat is tolerated, since the key stays owned and
+// its modifiers held until the physical release either way.
+func (et *EventTap) passthroughEvdevChord(
+	state *waylandEvdevKeyState,
+	code uint16,
+	isPress bool,
+) bool {
 	if _, held := state.passthroughHeld[code]; held && !isPress {
 		// Auto-repeat: modifiers are already held; just re-tap the base key.
 		_ = linux.WaylandKeyEvent(uint32(code), true)
 		_ = linux.WaylandKeyEvent(uint32(code), false)
 
-		return
+		return true
 	}
 
 	mods := heldPassthroughModifiers(state)
 
+	// Press the held modifiers, remembering which actually took so a
+	// mid-sequence failure can be unwound without leaving one latched.
+	pressed := make([]string, 0, len(mods))
+
 	for _, mod := range mods {
-		_ = linux.WaylandModifierEvent(mod, true)
+		err := linux.WaylandModifierEvent(mod, true)
+		if err != nil {
+			et.releasePassthroughModifiers(pressed)
+
+			return false
+		}
+
+		pressed = append(pressed, mod)
 	}
 
-	_ = linux.WaylandKeyEvent(uint32(code), true)
+	// The app acts on the key-down (the chord is delivered there); a failed
+	// key-up only leaves cleanup pending, so only the down gates success.
+	keyDownErr := linux.WaylandKeyEvent(uint32(code), true)
+	if keyDownErr != nil {
+		et.releasePassthroughModifiers(pressed)
+
+		return false
+	}
+
 	_ = linux.WaylandKeyEvent(uint32(code), false)
 
 	if state.passthroughHeld == nil {
@@ -1222,6 +1256,18 @@ func (et *EventTap) passthroughEvdevChord(state *waylandEvdevKeyState, code uint
 	state.passthroughHeld[code] = mods
 
 	et.firePassthroughCallback()
+
+	return true
+}
+
+// releasePassthroughModifiers releases the given modifiers in reverse press
+// order (refcounted, so a modifier shared with another passthrough key or a
+// sticky hold stays down). Used both to unwind a failed press and to drop a
+// held chord's modifiers on release/shutdown.
+func (et *EventTap) releasePassthroughModifiers(mods []string) {
+	for _, mod := range slices.Backward(mods) {
+		_ = linux.WaylandModifierEvent(mod, false)
+	}
 }
 
 // passthroughModifierCount is the number of distinct modifier groups

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_passthrough_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_passthrough_test.go
@@ -1,0 +1,79 @@
+//go:build linux && cgo
+
+//nolint:testpackage // These tests validate unexported evdev passthrough helpers directly.
+package eventtap
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestHeldPassthroughModifiers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(s *waylandEvdevKeyState)
+		want  []string
+	}{
+		{
+			name:  "none held",
+			setup: func(_ *waylandEvdevKeyState) {},
+			want:  []string{},
+		},
+		{
+			name:  "ctrl only",
+			setup: func(s *waylandEvdevKeyState) { s.modifiers.ctrl = 1 },
+			want:  []string{evdevModifierCtrl},
+		},
+		{
+			name: "shift and cmd emitted in fixed order",
+			setup: func(s *waylandEvdevKeyState) {
+				s.modifiers.cmd = 1
+				s.modifiers.shift = 1
+			},
+			want: []string{evdevModifierShift, evdevModifierCmd},
+		},
+		{
+			name: "all four in shift ctrl alt cmd order",
+			setup: func(s *waylandEvdevKeyState) {
+				s.modifiers.alt = 1
+				s.modifiers.cmd = 1
+				s.modifiers.ctrl = 1
+				s.modifiers.shift = 1
+			},
+			want: []string{
+				evdevModifierShift,
+				evdevModifierCtrl,
+				evdevModifierAlt,
+				evdevModifierCmd,
+			},
+		},
+		{
+			name:  "refcount above one still counts once",
+			setup: func(s *waylandEvdevKeyState) { s.modifiers.ctrl = 3 },
+			want:  []string{evdevModifierCtrl},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := &waylandEvdevKeyState{}
+			testCase.setup(state)
+
+			if got := heldPassthroughModifiers(state); !slices.Equal(got, testCase.want) {
+				t.Fatalf("heldPassthroughModifiers() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestHeldPassthroughModifiersNilState(t *testing.T) {
+	t.Parallel()
+
+	if got := heldPassthroughModifiers(nil); got != nil {
+		t.Fatalf("heldPassthroughModifiers(nil) = %v, want nil", got)
+	}
+}

--- a/internal/core/ports/capability_presets.go
+++ b/internal/core/ports/capability_presets.go
@@ -75,7 +75,10 @@ func LinuxCapabilities() PlatformCapabilities {
 			"global hotkeys available via X11 (Wayland relies on compositor bindings)",
 		),
 		KeyboardEventTap: supportedCapability(
-			"keyboard event tap available via X11 grab and Wayland layer-shell keyboard interactivity",
+			"keyboard event tap available via X11 grab and Wayland evdev/layer-shell " +
+				"keyboard interactivity; modifier passthrough of unbound shortcuts is " +
+				"supported on the Wayland evdev backend only (X11's exclusive grab and " +
+				"the wl-keyboard fallback cannot re-inject selectively)",
 		),
 		AppWatcher: supportedCapability(
 			"focused-app change detection via polling the WM_CLASS (X11) or " +


### PR DESCRIPTION
## Description

This PR adds modifier passthrough on the Linux Wayland evdev backend, so unbound Ctrl/Alt/Cmd shortcuts (e.g. Ctrl+C, Ctrl+Tab) reach the focused application while a Neru mode is active instead of being swallowed. Passthrough stays inert (and honestly documented) on X11 and the wl-keyboard fallback, which cannot re-inject selectively.

## Related Issues

<!-- none -->

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The whole passthrough system (config, blacklist, mode state machine, post-passthrough hint refresh) already existed and drove the correct data down to a no-op platform hop; only the final re-injection was missing. Wayland evdev is the one backend where it is reliable, because the virtual keyboard is a distinct device from the grabbed physical one — X11's exclusive grab routes synthetic events back to Neru, and `XSendEvent` is ignored by most apps. Modifiers are held across the press→repeat→release span and released on key-up (with a mode-exit safety net) so a virtual modifier can never stay latched.