### PR TITLE
feat(linux): hint arrows for top/bottom placement

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -719,7 +719,7 @@ to unoffset (window-relative) coordinates rather than misplacing hints.
 | Element                        | macOS                                        | Linux X11                        | Linux Wayland                    | Windows                             |
 | ------------------------------ | -------------------------------------------- | -------------------------------- | -------------------------------- | ----------------------------------- |
 | **Hint badges — rectangular**  | ✅ (with rounded rect + text)                | ✅ (Cairo rounded rect)          | ✅ (Cairo rounded rect)          | ✅ (SDF rounded rect)               |
-| **Hint arrows (top/bottom)**   | ✅ (1pt arrow height, NSBezierPath)          | ❌                               | ❌                               | ❌                                  |
+| **Hint arrows (top/bottom)**   | ✅ (1pt arrow height, NSBezierPath)          | ✅ (Cairo triangle tail)         | ✅ (Cairo triangle tail)         | ❌                                  |
 | **Hint boundary highlight**    | ✅ (rounded rect behind element border)      | ✅ (Cairo)                       | ✅ (Cairo)                       | ✅ (SDF, capped 4px radius)         |
 | **Hint search input overlay**  | ✅ (`/ query count/` rounded badge)          | ❌                               | ❌                               | ✅ (`/ query count/` rounded badge) |
 | **Grid cell labels**           | ✅                                           | ✅                               | ✅                               | ✅                                  |
@@ -894,7 +894,7 @@ backend-specific. The blacklist keeps chosen chords consumed, and
 | **Menubar elements**           | ✅                                                                | 🟡                                          | 🟡                              |
 | **Dock elements**              | ✅                                                                | N/A                                         | N/A                             |
 | **Popup/popover elements**     | ✅ (AXOrientation-based)                                          | ⚠️ (walked when in active frame's subtree)  | 🟡                              |
-| **Hint overlay arrows**        | ✅ (top/bottom arrow indicators on labels)                        | ❌                                          | ❌                              |
+| **Hint overlay arrows**        | ✅ (top/bottom arrow indicators on labels)                        | ✅ (Cairo triangle tail)                    | ❌                              |
 | **Boundary highlight**         | ✅                                                                | ✅ (Cairo)                                  | ✅ (SDF)                        |
 | **Search input badge**         | ✅                                                                | ❌                                          | ✅                              |
 
@@ -993,7 +993,6 @@ The following features exist on exactly one platform:
 | Vision framework strategy | `internal/core/ports/vision.go` + `internal/core/infra/platform/darwin/vision_darwin.m` | macOS-only `VNRequest` / `VGImageRequestHandler` APIs                                            |
 | Monitor select panels     | `internal/app/modes/monitor_select_overlay_darwin.go`                                   | Uses Cocoa NSPanel per display. Not implemented on other platforms.                              |
 | Screen sharing hide       | `internal/core/infra/platform/darwin/overlay_darwin.m`                                  | NSWindow sharing level property (Quartz only)                                                    |
-| Per-hint arrow indicators | `internal/app/components/hints/overlay_darwin.go`                                       | NSBezierPath arrow drawing — not in Cairo/SDF renderers                                          |
 | Secure input detection    | `internal/core/infra/platform/darwin/secureinput.go`                                    | Uses `CGSessionCopyCurrentDictionary` — private API                                              |
 
 #### Linux-Only

--- a/internal/core/infra/platform/linux/overlay_wayland.c
+++ b/internal/core/infra/platform/linux/overlay_wayland.c
@@ -811,6 +811,42 @@ void neru_wayland_overlay_rounded_rect(
 	}
 }
 
+// neru_wayland_overlay_triangle draws the hint connector arrow on every output.
+// Like the X11 variant it fills the closed triangle then strokes only the two
+// edges meeting at the apex (x1,y1), leaving the base seamless under the badge
+// so the arrow reads as a tail attached to the badge.
+void neru_wayland_overlay_triangle(
+    NeruWaylandOverlay *overlay, double x0, double y0, double x1, double y1, double x2, double y2, unsigned int fill,
+    unsigned int stroke, double stroke_width) {
+	for (int i = 0; i < overlay->nr_screens; i++) {
+		NeruWaylandOverlayScreen *scr = &overlay->screens[i];
+		if (!scr->cr)
+			continue;
+
+		double sx0 = x0 - scr->x, sy0 = y0 - scr->y;
+		double sx1 = x1 - scr->x, sy1 = y1 - scr->y;
+		double sx2 = x2 - scr->x, sy2 = y2 - scr->y;
+
+		cairo_t *cr = scr->cr;
+		cairo_save(cr);
+		cairo_move_to(cr, sx0, sy0);
+		cairo_line_to(cr, sx1, sy1);
+		cairo_line_to(cr, sx2, sy2);
+		cairo_close_path(cr);
+		neru_wayland_overlay_color(cr, fill);
+		cairo_fill(cr);
+		if (stroke_width > 0.0) {
+			cairo_move_to(cr, sx0, sy0);
+			cairo_line_to(cr, sx1, sy1);
+			cairo_line_to(cr, sx2, sy2);
+			neru_wayland_overlay_color(cr, stroke);
+			cairo_set_line_width(cr, stroke_width);
+			cairo_stroke(cr);
+		}
+		cairo_restore(cr);
+	}
+}
+
 // neru_resolve_font_family returns a font family cairo's toy API can actually
 // render, substituting a generic fallback when the requested family fails.
 //

--- a/internal/core/infra/platform/linux/overlay_wayland.c
+++ b/internal/core/infra/platform/linux/overlay_wayland.c
@@ -811,38 +811,81 @@ void neru_wayland_overlay_rounded_rect(
 	}
 }
 
-// neru_wayland_overlay_triangle draws the hint connector arrow on every output.
-// Like the X11 variant it fills the closed triangle then strokes only the two
-// edges meeting at the apex (x1,y1), leaving the base seamless under the badge
-// so the arrow reads as a tail attached to the badge.
-void neru_wayland_overlay_triangle(
-    NeruWaylandOverlay *overlay, double x0, double y0, double x1, double y1, double x2, double y2, unsigned int fill,
-    unsigned int stroke, double stroke_width) {
+// neru_wayland_hint_badge_path mirrors neru_x11_hint_badge_path: a rounded rect
+// with an optional triangular tail merged into one edge as a single closed
+// outline. edge: 0 = none, 1 = top-edge tail (apex above), 2 = bottom-edge tail
+// (apex below). The tail base is clamped to the edge's flat span. Coordinates
+// are surface-local (the caller applies the per-output offset).
+static void neru_wayland_hint_badge_path(
+    cairo_t *cr, double x, double y, double w, double h, double radius, int edge, double a_left, double a_right,
+    double tip_x, double tip_y) {
+	double r = radius;
+	double max_r = (w < h ? w : h) / 2.0;
+	if (r > max_r)
+		r = max_r;
+	if (r < 0)
+		r = 0;
+
+	double flat_left = x + r;
+	double flat_right = x + w - r;
+	if (edge != 0) {
+		if (a_left < flat_left)
+			a_left = flat_left;
+		if (a_right > flat_right)
+			a_right = flat_right;
+		if (a_left >= a_right)
+			edge = 0;
+	}
+
+	const double deg = 0.0174532925199432957692;
+	cairo_new_sub_path(cr);
+	cairo_move_to(cr, flat_left, y);
+	if (edge == 1) {
+		cairo_line_to(cr, a_left, y);
+		cairo_line_to(cr, tip_x, tip_y);
+		cairo_line_to(cr, a_right, y);
+	}
+	cairo_line_to(cr, flat_right, y);
+	if (r > 0)
+		cairo_arc(cr, x + w - r, y + r, r, -90.0 * deg, 0.0 * deg);
+	cairo_line_to(cr, x + w, y + h - r);
+	if (r > 0)
+		cairo_arc(cr, x + w - r, y + h - r, r, 0.0 * deg, 90.0 * deg);
+	if (edge == 2) {
+		cairo_line_to(cr, a_right, y + h);
+		cairo_line_to(cr, tip_x, tip_y);
+		cairo_line_to(cr, a_left, y + h);
+	}
+	cairo_line_to(cr, flat_left, y + h);
+	if (r > 0)
+		cairo_arc(cr, x + r, y + h - r, r, 90.0 * deg, 180.0 * deg);
+	cairo_line_to(cr, x, y + r);
+	if (r > 0)
+		cairo_arc(cr, x + r, y + r, r, 180.0 * deg, 270.0 * deg);
+	cairo_close_path(cr);
+}
+
+// neru_wayland_overlay_hint_badge fills and strokes a hint badge with an
+// optional connector tail as one continuous outline on every output.
+void neru_wayland_overlay_hint_badge(
+    NeruWaylandOverlay *overlay, double x, double y, double width, double height, double radius, int edge,
+    double a_left, double a_right, double tip_x, double tip_y, unsigned int fill, unsigned int stroke,
+    double stroke_width) {
 	for (int i = 0; i < overlay->nr_screens; i++) {
 		NeruWaylandOverlayScreen *scr = &overlay->screens[i];
 		if (!scr->cr)
 			continue;
 
-		double sx0 = x0 - scr->x, sy0 = y0 - scr->y;
-		double sx1 = x1 - scr->x, sy1 = y1 - scr->y;
-		double sx2 = x2 - scr->x, sy2 = y2 - scr->y;
-
 		cairo_t *cr = scr->cr;
 		cairo_save(cr);
-		cairo_move_to(cr, sx0, sy0);
-		cairo_line_to(cr, sx1, sy1);
-		cairo_line_to(cr, sx2, sy2);
-		cairo_close_path(cr);
+		neru_wayland_hint_badge_path(
+		    cr, x - scr->x, y - scr->y, width, height, radius, edge, a_left - scr->x, a_right - scr->x, tip_x - scr->x,
+		    tip_y - scr->y);
 		neru_wayland_overlay_color(cr, fill);
-		cairo_fill(cr);
-		if (stroke_width > 0.0) {
-			cairo_move_to(cr, sx0, sy0);
-			cairo_line_to(cr, sx1, sy1);
-			cairo_line_to(cr, sx2, sy2);
-			neru_wayland_overlay_color(cr, stroke);
-			cairo_set_line_width(cr, stroke_width);
-			cairo_stroke(cr);
-		}
+		cairo_fill_preserve(cr);
+		neru_wayland_overlay_color(cr, stroke);
+		cairo_set_line_width(cr, stroke_width);
+		cairo_stroke(cr);
 		cairo_restore(cr);
 	}
 }

--- a/internal/core/infra/platform/linux/overlay_wayland.h
+++ b/internal/core/infra/platform/linux/overlay_wayland.h
@@ -89,6 +89,9 @@ void neru_wayland_overlay_rect(
 void neru_wayland_overlay_rounded_rect(
     NeruWaylandOverlay *overlay, double x, double y, double width, double height, double radius, unsigned int fill,
     unsigned int stroke, double stroke_width);
+void neru_wayland_overlay_triangle(
+    NeruWaylandOverlay *overlay, double x0, double y0, double x1, double y1, double x2, double y2, unsigned int fill,
+    unsigned int stroke, double stroke_width);
 void neru_wayland_overlay_text(
     NeruWaylandOverlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
     unsigned int color);

--- a/internal/core/infra/platform/linux/overlay_wayland.h
+++ b/internal/core/infra/platform/linux/overlay_wayland.h
@@ -89,9 +89,10 @@ void neru_wayland_overlay_rect(
 void neru_wayland_overlay_rounded_rect(
     NeruWaylandOverlay *overlay, double x, double y, double width, double height, double radius, unsigned int fill,
     unsigned int stroke, double stroke_width);
-void neru_wayland_overlay_triangle(
-    NeruWaylandOverlay *overlay, double x0, double y0, double x1, double y1, double x2, double y2, unsigned int fill,
-    unsigned int stroke, double stroke_width);
+void neru_wayland_overlay_hint_badge(
+    NeruWaylandOverlay *overlay, double x, double y, double width, double height, double radius, int edge,
+    double a_left, double a_right, double tip_x, double tip_y, unsigned int fill, unsigned int stroke,
+    double stroke_width);
 void neru_wayland_overlay_text(
     NeruWaylandOverlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
     unsigned int color);

--- a/internal/core/infra/platform/linux/x11_overlay.c
+++ b/internal/core/infra/platform/linux/x11_overlay.c
@@ -198,29 +198,76 @@ void neru_x11_overlay_rounded_rect(
 	cairo_restore(cr);
 }
 
-// neru_x11_overlay_triangle draws the hint connector arrow. It fills the closed
-// triangle (x0,y0)->(x1,y1)->(x2,y2) then strokes only the two edges meeting at
-// the apex (x1,y1) as an open path, leaving the base seamless where the badge is
-// drawn over it so the arrow reads as a tail attached to the badge.
-void neru_x11_overlay_triangle(
-    NeruX11Overlay *overlay, double x0, double y0, double x1, double y1, double x2, double y2, unsigned int fill,
-    unsigned int stroke, double stroke_width) {
+// neru_x11_hint_badge_path builds a rounded-rectangle path with an optional
+// triangular tail merged into one edge, as a single closed outline. edge: 0 =
+// no tail, 1 = tail on the top edge (apex above), 2 = tail on the bottom edge
+// (apex below). The tail base (a_left..a_right) is clamped to the edge's flat
+// span so it never runs onto a rounded corner; if no room remains the tail is
+// dropped. Building badge and tail as one path lets the caller fill and stroke
+// once, avoiding the double-composited seam a separate overlaid triangle causes
+// with translucent colors.
+static void neru_x11_hint_badge_path(
+    cairo_t *cr, double x, double y, double w, double h, double radius, int edge, double a_left, double a_right,
+    double tip_x, double tip_y) {
+	double r = radius;
+	double max_r = (w < h ? w : h) / 2.0;
+	if (r > max_r)
+		r = max_r;
+	if (r < 0)
+		r = 0;
+
+	double flat_left = x + r;
+	double flat_right = x + w - r;
+	if (edge != 0) {
+		if (a_left < flat_left)
+			a_left = flat_left;
+		if (a_right > flat_right)
+			a_right = flat_right;
+		if (a_left >= a_right)
+			edge = 0;
+	}
+
+	const double deg = 0.0174532925199432957692;
+	cairo_new_sub_path(cr);
+	cairo_move_to(cr, flat_left, y);
+	if (edge == 1) {
+		cairo_line_to(cr, a_left, y);
+		cairo_line_to(cr, tip_x, tip_y);
+		cairo_line_to(cr, a_right, y);
+	}
+	cairo_line_to(cr, flat_right, y);
+	if (r > 0)
+		cairo_arc(cr, x + w - r, y + r, r, -90.0 * deg, 0.0 * deg);
+	cairo_line_to(cr, x + w, y + h - r);
+	if (r > 0)
+		cairo_arc(cr, x + w - r, y + h - r, r, 0.0 * deg, 90.0 * deg);
+	if (edge == 2) {
+		cairo_line_to(cr, a_right, y + h);
+		cairo_line_to(cr, tip_x, tip_y);
+		cairo_line_to(cr, a_left, y + h);
+	}
+	cairo_line_to(cr, flat_left, y + h);
+	if (r > 0)
+		cairo_arc(cr, x + r, y + h - r, r, 90.0 * deg, 180.0 * deg);
+	cairo_line_to(cr, x, y + r);
+	if (r > 0)
+		cairo_arc(cr, x + r, y + r, r, 180.0 * deg, 270.0 * deg);
+	cairo_close_path(cr);
+}
+
+// neru_x11_overlay_hint_badge fills and strokes a hint badge with an optional
+// connector tail as one continuous outline (see neru_x11_hint_badge_path).
+void neru_x11_overlay_hint_badge(
+    NeruX11Overlay *overlay, double x, double y, double width, double height, double radius, int edge, double a_left,
+    double a_right, double tip_x, double tip_y, unsigned int fill, unsigned int stroke, double stroke_width) {
 	cairo_t *cr = overlay->cr;
 	cairo_save(cr);
-	cairo_move_to(cr, x0, y0);
-	cairo_line_to(cr, x1, y1);
-	cairo_line_to(cr, x2, y2);
-	cairo_close_path(cr);
+	neru_x11_hint_badge_path(cr, x, y, width, height, radius, edge, a_left, a_right, tip_x, tip_y);
 	neru_x11_overlay_color(cr, fill);
-	cairo_fill(cr);
-	if (stroke_width > 0.0) {
-		cairo_move_to(cr, x0, y0);
-		cairo_line_to(cr, x1, y1);
-		cairo_line_to(cr, x2, y2);
-		neru_x11_overlay_color(cr, stroke);
-		cairo_set_line_width(cr, stroke_width);
-		cairo_stroke(cr);
-	}
+	cairo_fill_preserve(cr);
+	neru_x11_overlay_color(cr, stroke);
+	cairo_set_line_width(cr, stroke_width);
+	cairo_stroke(cr);
 	cairo_restore(cr);
 }
 

--- a/internal/core/infra/platform/linux/x11_overlay.c
+++ b/internal/core/infra/platform/linux/x11_overlay.c
@@ -198,6 +198,32 @@ void neru_x11_overlay_rounded_rect(
 	cairo_restore(cr);
 }
 
+// neru_x11_overlay_triangle draws the hint connector arrow. It fills the closed
+// triangle (x0,y0)->(x1,y1)->(x2,y2) then strokes only the two edges meeting at
+// the apex (x1,y1) as an open path, leaving the base seamless where the badge is
+// drawn over it so the arrow reads as a tail attached to the badge.
+void neru_x11_overlay_triangle(
+    NeruX11Overlay *overlay, double x0, double y0, double x1, double y1, double x2, double y2, unsigned int fill,
+    unsigned int stroke, double stroke_width) {
+	cairo_t *cr = overlay->cr;
+	cairo_save(cr);
+	cairo_move_to(cr, x0, y0);
+	cairo_line_to(cr, x1, y1);
+	cairo_line_to(cr, x2, y2);
+	cairo_close_path(cr);
+	neru_x11_overlay_color(cr, fill);
+	cairo_fill(cr);
+	if (stroke_width > 0.0) {
+		cairo_move_to(cr, x0, y0);
+		cairo_line_to(cr, x1, y1);
+		cairo_line_to(cr, x2, y2);
+		neru_x11_overlay_color(cr, stroke);
+		cairo_set_line_width(cr, stroke_width);
+		cairo_stroke(cr);
+	}
+	cairo_restore(cr);
+}
+
 void neru_x11_overlay_text(
     NeruX11Overlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
     unsigned int color) {

--- a/internal/core/infra/platform/linux/x11_overlay.h
+++ b/internal/core/infra/platform/linux/x11_overlay.h
@@ -31,6 +31,9 @@ void neru_x11_overlay_rect(
 void neru_x11_overlay_rounded_rect(
     NeruX11Overlay *overlay, double x, double y, double width, double height, double radius, unsigned int fill,
     unsigned int stroke, double stroke_width);
+void neru_x11_overlay_triangle(
+    NeruX11Overlay *overlay, double x0, double y0, double x1, double y1, double x2, double y2, unsigned int fill,
+    unsigned int stroke, double stroke_width);
 void neru_x11_overlay_text(
     NeruX11Overlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
     unsigned int color);

--- a/internal/core/infra/platform/linux/x11_overlay.h
+++ b/internal/core/infra/platform/linux/x11_overlay.h
@@ -31,9 +31,9 @@ void neru_x11_overlay_rect(
 void neru_x11_overlay_rounded_rect(
     NeruX11Overlay *overlay, double x, double y, double width, double height, double radius, unsigned int fill,
     unsigned int stroke, double stroke_width);
-void neru_x11_overlay_triangle(
-    NeruX11Overlay *overlay, double x0, double y0, double x1, double y1, double x2, double y2, unsigned int fill,
-    unsigned int stroke, double stroke_width);
+void neru_x11_overlay_hint_badge(
+    NeruX11Overlay *overlay, double x, double y, double width, double height, double radius, int edge, double a_left,
+    double a_right, double tip_x, double tip_y, unsigned int fill, unsigned int stroke, double stroke_width);
 void neru_x11_overlay_text(
     NeruX11Overlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
     unsigned int color);

--- a/internal/ui/overlay/hint_arrow_linux_test.go
+++ b/internal/ui/overlay/hint_arrow_linux_test.go
@@ -142,6 +142,31 @@ func TestHintBadgePlacement_ArrowBaseClampedToFlatEdge(t *testing.T) {
 	}
 }
 
+func TestHintTailEdge(t *testing.T) {
+	target := image.Pt(200, 150)
+
+	badge, arrow, hasArrow := hintBadgePlacement(target, 40, 20, 4, "bottom")
+	if edge := hintTailEdge(badge, arrow, hasArrow); edge != hintTailTop {
+		t.Errorf(
+			"bottom placement (arrow points up) should merge the tail into the top edge, got %d",
+			edge,
+		)
+	}
+
+	badge, arrow, hasArrow = hintBadgePlacement(target, 40, 20, 4, "top")
+	if edge := hintTailEdge(badge, arrow, hasArrow); edge != hintTailBottom {
+		t.Errorf(
+			"top placement (arrow points down) should merge the tail into the bottom edge, got %d",
+			edge,
+		)
+	}
+
+	badge, arrow, hasArrow = hintBadgePlacement(target, 40, 20, 4, "center")
+	if edge := hintTailEdge(badge, arrow, hasArrow); edge != hintTailNone {
+		t.Errorf("center placement should have no tail, got %d", edge)
+	}
+}
+
 func assertArrowSymmetry(t *testing.T, arrow hintArrowTriangle, centerX int) {
 	t.Helper()
 

--- a/internal/ui/overlay/hint_arrow_linux_test.go
+++ b/internal/ui/overlay/hint_arrow_linux_test.go
@@ -1,0 +1,158 @@
+//go:build linux
+
+// Unit tests for the pure hint badge/arrow placement math shared by the X11 and
+// Wayland overlays. Native Cairo rendering is covered by overlay integration
+// tests; here we only assert the geometry the C draw calls receive.
+
+package overlay //nolint:testpackage // tests exercise unexported render helpers directly
+
+import (
+	"image"
+	"testing"
+)
+
+func TestHintBadgePlacement_CenterHasNoArrow(t *testing.T) {
+	target := image.Pt(100, 100)
+	badge, arrow, hasArrow := hintBadgePlacement(target, 40, 20, 4, "center")
+
+	if hasArrow {
+		t.Fatalf("center placement should not draw an arrow, got %+v", arrow)
+	}
+	// Center placement keeps the badge centered on the target.
+	if got := badge.Min.X + badge.Dx()/2; got != target.X {
+		t.Errorf("badge center X = %d, want %d", got, target.X)
+	}
+
+	if got := badge.Min.Y + badge.Dy()/2; got != target.Y {
+		t.Errorf("badge center Y = %d, want %d", got, target.Y)
+	}
+}
+
+func TestHintBadgePlacement_UnknownPlacementHasNoArrow(t *testing.T) {
+	if _, _, hasArrow := hintBadgePlacement(image.Pt(10, 10), 40, 20, 4, "floating"); hasArrow {
+		t.Fatal("unrecognized placement should not draw an arrow")
+	}
+}
+
+func TestHintBadgePlacement_Bottom(t *testing.T) {
+	target := image.Pt(200, 150)
+	badgeWidth, badgeHeight, radius := 40, 20, 4
+	badge, arrow, hasArrow := hintBadgePlacement(target, badgeWidth, badgeHeight, radius, "bottom")
+
+	if !hasArrow {
+		t.Fatal("bottom placement should draw an arrow")
+	}
+
+	// Badge sits below the target, offset by gap + arrow height + half height.
+	wantTop := target.Y + hintPlacementGap + hintArrowHeight
+	if badge.Min.Y != wantTop {
+		t.Errorf("badge top = %d, want %d", badge.Min.Y, wantTop)
+	}
+
+	if got := badge.Min.X + badge.Dx()/2; got != target.X {
+		t.Errorf(
+			"badge is not horizontally centered on target: center X = %d, want %d",
+			got,
+			target.X,
+		)
+	}
+
+	// The arrow base is flush with the badge top edge and the tip points up at
+	// the target, landing one gap short of it.
+	if arrow.baseLeft.Y != badge.Min.Y || arrow.baseRight.Y != badge.Min.Y {
+		t.Errorf("arrow base not on badge top edge: baseLeft=%v baseRight=%v top=%d",
+			arrow.baseLeft, arrow.baseRight, badge.Min.Y)
+	}
+
+	if arrow.tip.Y >= arrow.baseLeft.Y {
+		t.Errorf(
+			"bottom-placement arrow tip should point up (above base): tip=%v base=%v",
+			arrow.tip,
+			arrow.baseLeft,
+		)
+	}
+
+	if arrow.tip.X != target.X {
+		t.Errorf("arrow tip X = %d, want %d (aligned with target)", arrow.tip.X, target.X)
+	}
+
+	if wantTipY := badge.Min.Y - hintArrowHeight; arrow.tip.Y != wantTipY {
+		t.Errorf("arrow tip Y = %d, want %d", arrow.tip.Y, wantTipY)
+	}
+
+	assertArrowSymmetry(t, arrow, target.X)
+}
+
+func TestHintBadgePlacement_Top(t *testing.T) {
+	target := image.Pt(200, 150)
+	badgeWidth, badgeHeight, radius := 40, 20, 4
+	badge, arrow, hasArrow := hintBadgePlacement(target, badgeWidth, badgeHeight, radius, "top")
+
+	if !hasArrow {
+		t.Fatal("top placement should draw an arrow")
+	}
+
+	// Badge sits above the target.
+	wantBottom := target.Y - hintPlacementGap - hintArrowHeight
+	if badge.Max.Y != wantBottom {
+		t.Errorf("badge bottom = %d, want %d", badge.Max.Y, wantBottom)
+	}
+
+	// The arrow base is flush with the badge bottom edge and the tip points down
+	// at the target.
+	if arrow.baseLeft.Y != badge.Max.Y || arrow.baseRight.Y != badge.Max.Y {
+		t.Errorf("arrow base not on badge bottom edge: baseLeft=%v baseRight=%v bottom=%d",
+			arrow.baseLeft, arrow.baseRight, badge.Max.Y)
+	}
+
+	if arrow.tip.Y <= arrow.baseLeft.Y {
+		t.Errorf(
+			"top-placement arrow tip should point down (below base): tip=%v base=%v",
+			arrow.tip,
+			arrow.baseLeft,
+		)
+	}
+
+	if wantTipY := badge.Max.Y + hintArrowHeight; arrow.tip.Y != wantTipY {
+		t.Errorf("arrow tip Y = %d, want %d", arrow.tip.Y, wantTipY)
+	}
+
+	assertArrowSymmetry(t, arrow, target.X)
+}
+
+func TestHintBadgePlacement_ArrowBaseClampedToFlatEdge(t *testing.T) {
+	// A narrow badge with a large radius leaves little flat edge; the arrow base
+	// must clamp inside the corner radius rather than run onto the rounded
+	// corners or overflow the badge.
+	target := image.Pt(50, 50)
+	badgeWidth, badgeHeight, radius := 14, 20, 6
+
+	badge, arrow, hasArrow := hintBadgePlacement(target, badgeWidth, badgeHeight, radius, "bottom")
+	if !hasArrow {
+		t.Fatal("expected an arrow")
+	}
+
+	halfBase := arrow.baseRight.X - target.X
+	if maxHalf := badge.Dx()/2 - radius; halfBase > maxHalf {
+		t.Errorf("arrow half-base %d exceeds flat-edge limit %d", halfBase, maxHalf)
+	}
+
+	if arrow.baseLeft.X < badge.Min.X || arrow.baseRight.X > badge.Max.X {
+		t.Errorf("arrow base %v..%v overflows badge %v", arrow.baseLeft, arrow.baseRight, badge)
+	}
+}
+
+func assertArrowSymmetry(t *testing.T, arrow hintArrowTriangle, centerX int) {
+	t.Helper()
+
+	leftGap := centerX - arrow.baseLeft.X
+
+	rightGap := arrow.baseRight.X - centerX
+	if leftGap != rightGap {
+		t.Errorf("arrow base not symmetric about center: left=%d right=%d", leftGap, rightGap)
+	}
+
+	if leftGap <= 0 {
+		t.Errorf("arrow base has non-positive width: half-base=%d", leftGap)
+	}
+}

--- a/internal/ui/overlay/hint_arrow_linux_test.go
+++ b/internal/ui/overlay/hint_arrow_linux_test.go
@@ -167,6 +167,58 @@ func TestHintTailEdge(t *testing.T) {
 	}
 }
 
+func TestHintBadgeRadius_ReservesTailFlatEdge(t *testing.T) {
+	// Center placement is never capped — the tail doesn't exist there.
+	if got := hintBadgeRadius(100, 40, "center"); got != 100 {
+		t.Errorf("center radius should be unchanged, got %d", got)
+	}
+
+	// A radius large enough to consume the whole flat edge is capped so the
+	// connector tail still has somewhere to attach.
+	// halfW = 20, so max = 20 - hintArrowMinHalfBase.
+	if got, want := hintBadgeRadius(1000, 40, "bottom"), 20-hintArrowMinHalfBase; got != want {
+		t.Errorf("oversized radius = %d, want capped to %d", got, want)
+	}
+
+	// A normal radius that already leaves room is left untouched.
+	if got := hintBadgeRadius(6, 40, "top"); got != 6 {
+		t.Errorf("normal radius should be unchanged, got %d", got)
+	}
+}
+
+func TestHintBadgePlacement_FullPillKeepsTail(t *testing.T) {
+	// Regression: a full-pill border radius on a top/bottom hint must still
+	// produce a visible tail once the radius is capped to reserve a flat edge.
+	// Previously the tail base expanded to the full badge width and both native
+	// renderers collapsed it to a point, dropping the arrow.
+	target := image.Pt(200, 150)
+	badgeWidth, badgeHeight := 40, 24
+
+	radius := hintBadgeRadius(1000, badgeWidth, "bottom")
+	badge, arrow, hasArrow := hintBadgePlacement(target, badgeWidth, badgeHeight, radius, "bottom")
+
+	if !hasArrow {
+		t.Fatal("full-pill bottom placement should still draw a tail")
+	}
+
+	if arrow.baseLeft.X >= arrow.baseRight.X {
+		t.Errorf(
+			"tail base collapsed to a point: baseLeft=%v baseRight=%v",
+			arrow.baseLeft,
+			arrow.baseRight,
+		)
+	}
+	// The base must stay within the flat span the (capped) radius leaves, so the
+	// native renderer does not clamp it away.
+	flatLeft := badge.Min.X + radius
+
+	flatRight := badge.Max.X - radius
+	if arrow.baseLeft.X < flatLeft || arrow.baseRight.X > flatRight {
+		t.Errorf("tail base %v..%v escapes flat span [%d,%d]",
+			arrow.baseLeft, arrow.baseRight, flatLeft, flatRight)
+	}
+}
+
 func assertArrowSymmetry(t *testing.T, arrow hintArrowTriangle, centerX int) {
 	t.Helper()
 

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -51,6 +51,10 @@ const (
 	// hintPlacementGap is the pixel gap between a hint badge and its target
 	// point for top/bottom placement, mirroring the macOS overlay.
 	hintPlacementGap = 1
+	// Hint badge placement values (hints.ui.placement); "center" needs no
+	// constant as it is the implicit default branch.
+	placementTop    = "top"
+	placementBottom = "bottom"
 	// hintAutoRadiusMax caps the auto (border_radius = -1) hint badge corner
 	// radius so labels get a subtle rounded corner rather than a full pill,
 	// matching the macOS overlay's MIN(height/2, 6).
@@ -58,9 +62,12 @@ const (
 	// hintArrowHeight is the height in pixels of the triangular connector arrow
 	// drawn between a hint badge and its target for top/bottom placement,
 	// mirroring the macOS overlay's tooltip arrow. hintArrowHalfBase is half the
-	// arrow's base width where it meets the badge edge.
-	hintArrowHeight   = 5
-	hintArrowHalfBase = 5
+	// arrow's base width where it meets the badge edge; hintArrowMinHalfBase is
+	// the smallest half-base still worth drawing, and the flat edge the badge
+	// radius must leave for the tail to attach.
+	hintArrowHeight      = 5
+	hintArrowHalfBase    = 5
+	hintArrowMinHalfBase = 2
 
 	stickyBadgeClearPadding = 3
 )
@@ -1056,6 +1063,25 @@ type hintArrowTriangle struct {
 	baseRight image.Point
 }
 
+// hintBadgeRadius caps the badge corner radius for top/bottom placement so the
+// badge always keeps a flat top/bottom edge wide enough for the connector tail
+// to attach to. Without this, a large configured radius (e.g. a full pill)
+// consumes the flat edge and the renderer drops the tail entirely. Center
+// placement (no tail) and radii that already leave room are returned unchanged.
+func hintBadgeRadius(radius, badgeWidth int, placement string) int {
+	if placement != placementTop && placement != placementBottom {
+		return radius
+	}
+
+	maxRadius := max(badgeWidth/centeredRectDivisor-hintArrowMinHalfBase, 0)
+
+	if radius > maxRadius {
+		return maxRadius
+	}
+
+	return radius
+}
+
 // hintTailEdge reports which badge edge the connector tail merges into, so the
 // renderer can build the badge and tail as one outline. It returns hintTailNone
 // when there is no arrow.
@@ -1091,11 +1117,11 @@ func hintBadgePlacement(
 	centerY := target.Y
 
 	switch placement {
-	case "top":
+	case placementTop:
 		// Badge sits above the target, offset by the gap plus arrow height so
 		// the arrow has room to point down at the target.
 		centerY = target.Y - hintPlacementGap - hintArrowHeight - halfH
-	case "bottom":
+	case placementBottom:
 		// Badge sits below the target; arrow points up at the target.
 		centerY = target.Y + hintPlacementGap + hintArrowHeight + halfH
 	default:
@@ -1107,14 +1133,12 @@ func hintBadgePlacement(
 	badge := image.Rect(centerX-halfW, centerY-halfH, centerX+halfW, centerY+halfH)
 
 	// Keep the arrow base within the badge's flat edge (inside the corner
-	// radius); fall back to the badge half-width for badges too narrow to clamp.
+	// radius). The caller caps the radius (see hintBadgeRadius) so a flat edge
+	// remains; only a degenerately narrow badge leaves no room, in which case
+	// the tail is dropped rather than collapsed onto the corners.
 	halfBase := hintArrowHalfBase
 	if limit := halfW - max(radius, 0); halfBase > limit {
 		halfBase = limit
-	}
-
-	if halfBase < 1 {
-		halfBase = halfW
 	}
 
 	if halfBase < 1 {
@@ -1124,14 +1148,14 @@ func hintBadgePlacement(
 	var arrow hintArrowTriangle
 
 	switch placement {
-	case "bottom":
+	case placementBottom:
 		baseY := badge.Min.Y
 		arrow = hintArrowTriangle{
 			baseLeft:  image.Pt(centerX-halfBase, baseY),
 			tip:       image.Pt(centerX, baseY-hintArrowHeight),
 			baseRight: image.Pt(centerX+halfBase, baseY),
 		}
-	case "top":
+	case placementTop:
 		baseY := badge.Max.Y
 		arrow = hintArrowTriangle{
 			baseLeft:  image.Pt(centerX-halfBase, baseY),

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -55,6 +55,12 @@ const (
 	// radius so labels get a subtle rounded corner rather than a full pill,
 	// matching the macOS overlay's MIN(height/2, 6).
 	hintAutoRadiusMax = 6
+	// hintArrowHeight is the height in pixels of the triangular connector arrow
+	// drawn between a hint badge and its target for top/bottom placement,
+	// mirroring the macOS overlay's tooltip arrow. hintArrowHalfBase is half the
+	// arrow's base width where it meets the badge edge.
+	hintArrowHeight   = 5
+	hintArrowHalfBase = 5
 
 	stickyBadgeClearPadding = 3
 )
@@ -1031,6 +1037,87 @@ func badgeBounds(posX, posY int, text string, style overlayBadgeStyle) image.Rec
 		posX+style.offsetX+width,
 		posY+style.offsetY+height,
 	)
+}
+
+// hintArrowTriangle holds the three vertices of a hint connector arrow in
+// screen coordinates: the two base corners flush with the badge edge and the
+// tip pointing at the target element.
+type hintArrowTriangle struct {
+	baseLeft  image.Point
+	tip       image.Point
+	baseRight image.Point
+}
+
+// hintBadgePlacement computes the badge rect for a hint given its target point
+// (the element center) and, for top/bottom placement, the connector arrow that
+// visually ties the badge to the target. It centralizes the placement math
+// shared by the X11 and Wayland overlays so both stay in lockstep with the
+// macOS overlay's arrow behavior.
+//
+// radius is the badge's already-resolved corner radius; it keeps the arrow base
+// on the badge's flat edge rather than over a rounded corner. hasArrow is false
+// for center or unrecognized placements, which draw no arrow.
+func hintBadgePlacement(
+	target image.Point,
+	badgeWidth, badgeHeight, radius int,
+	placement string,
+) (image.Rectangle, hintArrowTriangle, bool) {
+	halfW := badgeWidth / centeredRectDivisor
+	halfH := badgeHeight / centeredRectDivisor
+	centerX := target.X
+	centerY := target.Y
+
+	switch placement {
+	case "top":
+		// Badge sits above the target, offset by the gap plus arrow height so
+		// the arrow has room to point down at the target.
+		centerY = target.Y - hintPlacementGap - hintArrowHeight - halfH
+	case "bottom":
+		// Badge sits below the target; arrow points up at the target.
+		centerY = target.Y + hintPlacementGap + hintArrowHeight + halfH
+	default:
+		badge := image.Rect(centerX-halfW, centerY-halfH, centerX+halfW, centerY+halfH)
+
+		return badge, hintArrowTriangle{}, false
+	}
+
+	badge := image.Rect(centerX-halfW, centerY-halfH, centerX+halfW, centerY+halfH)
+
+	// Keep the arrow base within the badge's flat edge (inside the corner
+	// radius); fall back to the badge half-width for badges too narrow to clamp.
+	halfBase := hintArrowHalfBase
+	if limit := halfW - max(radius, 0); halfBase > limit {
+		halfBase = limit
+	}
+
+	if halfBase < 1 {
+		halfBase = halfW
+	}
+
+	if halfBase < 1 {
+		return badge, hintArrowTriangle{}, false
+	}
+
+	var arrow hintArrowTriangle
+
+	switch placement {
+	case "bottom":
+		baseY := badge.Min.Y
+		arrow = hintArrowTriangle{
+			baseLeft:  image.Pt(centerX-halfBase, baseY),
+			tip:       image.Pt(centerX, baseY-hintArrowHeight),
+			baseRight: image.Pt(centerX+halfBase, baseY),
+		}
+	case "top":
+		baseY := badge.Max.Y
+		arrow = hintArrowTriangle{
+			baseLeft:  image.Pt(centerX-halfBase, baseY),
+			tip:       image.Pt(centerX, baseY+hintArrowHeight),
+			baseRight: image.Pt(centerX+halfBase, baseY),
+		}
+	}
+
+	return badge, arrow, true
 }
 
 func expandRect(rect image.Rectangle, amount int) image.Rectangle {

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -1039,6 +1039,14 @@ func badgeBounds(posX, posY int, text string, style overlayBadgeStyle) image.Rec
 	)
 }
 
+// Hint connector tail edge, matching the C hint-badge renderer: which badge
+// edge the triangular tail is merged into (0 = none).
+const (
+	hintTailNone   = 0
+	hintTailTop    = 1 // tail on the badge's top edge, apex above (placement "bottom")
+	hintTailBottom = 2 // tail on the badge's bottom edge, apex below (placement "top")
+)
+
 // hintArrowTriangle holds the three vertices of a hint connector arrow in
 // screen coordinates: the two base corners flush with the badge edge and the
 // tip pointing at the target element.
@@ -1046,6 +1054,21 @@ type hintArrowTriangle struct {
 	baseLeft  image.Point
 	tip       image.Point
 	baseRight image.Point
+}
+
+// hintTailEdge reports which badge edge the connector tail merges into, so the
+// renderer can build the badge and tail as one outline. It returns hintTailNone
+// when there is no arrow.
+func hintTailEdge(badge image.Rectangle, arrow hintArrowTriangle, hasArrow bool) int {
+	if !hasArrow {
+		return hintTailNone
+	}
+
+	if arrow.tip.Y < badge.Min.Y {
+		return hintTailTop
+	}
+
+	return hintTailBottom
 }
 
 // hintBadgePlacement computes the badge rect for a hint given its target point

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -334,6 +334,8 @@ func (o *wlrootsOverlay) DrawHints(
 		if radius < 0 {
 			radius = min(badgeHeight/centeredRectDivisor, hintAutoRadiusMax)
 		}
+		// Cap the radius so a top/bottom badge keeps a flat edge for the tail.
+		radius = hintBadgeRadius(radius, badgeWidth, style.Placement())
 
 		// hint.Position() is the element center (set in modes/hints.go). The
 		// badge is centered horizontally on it and placed above / on / below the

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -330,43 +330,32 @@ func (o *wlrootsOverlay) DrawHints(
 		badgeWidth := estimateTextWidth(label, fontSize) + paddingX*paddingMultiplier
 		badgeHeight := estimateTextHeight(fontSize) + paddingY*paddingMultiplier
 
-		// hint.Position() is the element center (set in modes/hints.go), so the
-		// badge is centered horizontally on it and placed above / on / below the
-		// center to match the macOS placement behavior.
-		centerX := hint.Position().X
-		centerY := hint.Position().Y
-		switch style.Placement() {
-		case "top":
-			centerY = hint.Position().Y - hintPlacementGap - badgeHeight/centeredRectDivisor
-		case "bottom":
-			centerY = hint.Position().Y + hintPlacementGap + badgeHeight/centeredRectDivisor
-		}
-
-		badge := image.Rect(
-			centerX-badgeWidth/centeredRectDivisor,
-			centerY-badgeHeight/centeredRectDivisor,
-			centerX+badgeWidth/centeredRectDivisor,
-			centerY+badgeHeight/centeredRectDivisor,
-		)
 		radius := style.BorderRadius()
 		if radius < 0 {
 			radius = min(badgeHeight/centeredRectDivisor, hintAutoRadiusMax)
 		}
+
+		// hint.Position() is the element center (set in modes/hints.go). The
+		// badge is centered horizontally on it and placed above / on / below the
+		// center to match macOS; top/bottom placement also draws a connector
+		// arrow pointing back at the target.
+		badge, arrow, hasArrow := hintBadgePlacement(
+			hint.Position(), badgeWidth, badgeHeight, radius, style.Placement(),
+		)
+
+		fill := parseHexColor(style.BackgroundColor())
+		border := parseHexColor(style.BorderColor())
+		borderWidth := float64(max(style.BorderWidth(), 0))
+
 		if radius > 0 {
-			o.drawRoundedRect(
-				badge,
-				float64(radius),
-				parseHexColor(style.BackgroundColor()),
-				parseHexColor(style.BorderColor()),
-				float64(max(style.BorderWidth(), 0)),
-			)
+			o.drawRoundedRect(badge, float64(radius), fill, border, borderWidth)
 		} else {
-			o.drawRect(
-				badge,
-				parseHexColor(style.BackgroundColor()),
-				parseHexColor(style.BorderColor()),
-				float64(max(style.BorderWidth(), 0)),
-			)
+			o.drawRect(badge, fill, border, borderWidth)
+		}
+		// Draw the arrow after the badge so its fill hides the badge edge where
+		// the two meet, leaving a seamless tail.
+		if hasArrow {
+			o.drawArrow(arrow, fill, border, borderWidth)
 		}
 		o.drawTextCentered(
 			label, badge,
@@ -1026,6 +1015,19 @@ func (o *wlrootsOverlay) drawRoundedRect(
 		C.double(bounds.Min.X), C.double(bounds.Min.Y),
 		C.double(bounds.Dx()), C.double(bounds.Dy()),
 		C.double(radius),
+		C.uint(fill), C.uint(border), C.double(lineWidth),
+	)
+}
+
+func (o *wlrootsOverlay) drawArrow(
+	arrow hintArrowTriangle,
+	fill uint32, border uint32, lineWidth float64,
+) {
+	C.neru_wayland_overlay_triangle(
+		o.raw,
+		C.double(arrow.baseLeft.X), C.double(arrow.baseLeft.Y),
+		C.double(arrow.tip.X), C.double(arrow.tip.Y),
+		C.double(arrow.baseRight.X), C.double(arrow.baseRight.Y),
 		C.uint(fill), C.uint(border), C.double(lineWidth),
 	)
 }

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -347,16 +347,12 @@ func (o *wlrootsOverlay) DrawHints(
 		border := parseHexColor(style.BorderColor())
 		borderWidth := float64(max(style.BorderWidth(), 0))
 
-		if radius > 0 {
-			o.drawRoundedRect(badge, float64(radius), fill, border, borderWidth)
-		} else {
-			o.drawRect(badge, fill, border, borderWidth)
-		}
-		// Draw the arrow after the badge so its fill hides the badge edge where
-		// the two meet, leaving a seamless tail.
-		if hasArrow {
-			o.drawArrow(arrow, fill, border, borderWidth)
-		}
+		// Badge and connector tail are drawn as one filled+stroked outline so
+		// translucent colors don't double-composite at the junction.
+		o.drawHintBadge(
+			badge, float64(radius), hintTailEdge(badge, arrow, hasArrow), arrow,
+			fill, border, borderWidth,
+		)
 		o.drawTextCentered(
 			label, badge,
 			style.FontFamily(),
@@ -1019,15 +1015,18 @@ func (o *wlrootsOverlay) drawRoundedRect(
 	)
 }
 
-func (o *wlrootsOverlay) drawArrow(
-	arrow hintArrowTriangle,
+func (o *wlrootsOverlay) drawHintBadge(
+	badge image.Rectangle, radius float64, edge int, arrow hintArrowTriangle,
 	fill uint32, border uint32, lineWidth float64,
 ) {
-	C.neru_wayland_overlay_triangle(
+	C.neru_wayland_overlay_hint_badge(
 		o.raw,
-		C.double(arrow.baseLeft.X), C.double(arrow.baseLeft.Y),
+		C.double(badge.Min.X), C.double(badge.Min.Y),
+		C.double(badge.Dx()), C.double(badge.Dy()),
+		C.double(radius),
+		C.int(edge),
+		C.double(arrow.baseLeft.X), C.double(arrow.baseRight.X),
 		C.double(arrow.tip.X), C.double(arrow.tip.Y),
-		C.double(arrow.baseRight.X), C.double(arrow.baseRight.Y),
 		C.uint(fill), C.uint(border), C.double(lineWidth),
 	)
 }

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -315,16 +315,12 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 		border := parseHexColor(style.BorderColor())
 		borderWidth := float64(max(style.BorderWidth(), 0))
 
-		if radius > 0 {
-			o.drawRoundedRect(badge, float64(radius), fill, border, borderWidth)
-		} else {
-			o.drawRect(badge, fill, border, borderWidth)
-		}
-		// Draw the arrow after the badge so its fill hides the badge edge where
-		// the two meet, leaving a seamless tail.
-		if hasArrow {
-			o.drawArrow(arrow, fill, border, borderWidth)
-		}
+		// Badge and connector tail are drawn as one filled+stroked outline so
+		// translucent colors don't double-composite at the junction.
+		o.drawHintBadge(
+			badge, float64(radius), hintTailEdge(badge, arrow, hasArrow), arrow,
+			fill, border, borderWidth,
+		)
 		o.drawTextCentered(
 			label, badge,
 			style.FontFamily(),
@@ -860,15 +856,18 @@ func (o *x11Overlay) drawRoundedRect(
 	)
 }
 
-func (o *x11Overlay) drawArrow(
-	arrow hintArrowTriangle,
+func (o *x11Overlay) drawHintBadge(
+	badge image.Rectangle, radius float64, edge int, arrow hintArrowTriangle,
 	fill uint32, border uint32, lineWidth float64,
 ) {
-	C.neru_x11_overlay_triangle(
+	C.neru_x11_overlay_hint_badge(
 		o.raw,
-		C.double(arrow.baseLeft.X), C.double(arrow.baseLeft.Y),
+		C.double(badge.Min.X), C.double(badge.Min.Y),
+		C.double(badge.Dx()), C.double(badge.Dy()),
+		C.double(radius),
+		C.int(edge),
+		C.double(arrow.baseLeft.X), C.double(arrow.baseRight.X),
 		C.double(arrow.tip.X), C.double(arrow.tip.Y),
-		C.double(arrow.baseRight.X), C.double(arrow.baseRight.Y),
 		C.uint(fill), C.uint(border), C.double(lineWidth),
 	)
 }

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -302,6 +302,8 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 		if radius < 0 {
 			radius = min(badgeHeight/centeredRectDivisor, hintAutoRadiusMax)
 		}
+		// Cap the radius so a top/bottom badge keeps a flat edge for the tail.
+		radius = hintBadgeRadius(radius, badgeWidth, style.Placement())
 
 		// hint.Position() is the element center (set in modes/hints.go). The
 		// badge is centered horizontally on it and placed above / on / below the

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -298,43 +298,32 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 		badgeWidth := estimateTextWidth(label, fontSize) + paddingX*paddingMultiplier
 		badgeHeight := estimateTextHeight(fontSize) + paddingY*paddingMultiplier
 
-		// hint.Position() is the element center (set in modes/hints.go), so the
-		// badge is centered horizontally on it and placed above / on / below the
-		// center to match the macOS placement behavior.
-		centerX := hint.Position().X
-		centerY := hint.Position().Y
-		switch style.Placement() {
-		case "top":
-			centerY = hint.Position().Y - hintPlacementGap - badgeHeight/centeredRectDivisor
-		case "bottom":
-			centerY = hint.Position().Y + hintPlacementGap + badgeHeight/centeredRectDivisor
-		}
-
-		badge := image.Rect(
-			centerX-badgeWidth/centeredRectDivisor,
-			centerY-badgeHeight/centeredRectDivisor,
-			centerX+badgeWidth/centeredRectDivisor,
-			centerY+badgeHeight/centeredRectDivisor,
-		)
 		radius := style.BorderRadius()
 		if radius < 0 {
 			radius = min(badgeHeight/centeredRectDivisor, hintAutoRadiusMax)
 		}
+
+		// hint.Position() is the element center (set in modes/hints.go). The
+		// badge is centered horizontally on it and placed above / on / below the
+		// center to match macOS; top/bottom placement also draws a connector
+		// arrow pointing back at the target.
+		badge, arrow, hasArrow := hintBadgePlacement(
+			hint.Position(), badgeWidth, badgeHeight, radius, style.Placement(),
+		)
+
+		fill := parseHexColor(style.BackgroundColor())
+		border := parseHexColor(style.BorderColor())
+		borderWidth := float64(max(style.BorderWidth(), 0))
+
 		if radius > 0 {
-			o.drawRoundedRect(
-				badge,
-				float64(radius),
-				parseHexColor(style.BackgroundColor()),
-				parseHexColor(style.BorderColor()),
-				float64(max(style.BorderWidth(), 0)),
-			)
+			o.drawRoundedRect(badge, float64(radius), fill, border, borderWidth)
 		} else {
-			o.drawRect(
-				badge,
-				parseHexColor(style.BackgroundColor()),
-				parseHexColor(style.BorderColor()),
-				float64(max(style.BorderWidth(), 0)),
-			)
+			o.drawRect(badge, fill, border, borderWidth)
+		}
+		// Draw the arrow after the badge so its fill hides the badge edge where
+		// the two meet, leaving a seamless tail.
+		if hasArrow {
+			o.drawArrow(arrow, fill, border, borderWidth)
 		}
 		o.drawTextCentered(
 			label, badge,
@@ -867,6 +856,19 @@ func (o *x11Overlay) drawRoundedRect(
 		C.double(bounds.Min.X), C.double(bounds.Min.Y),
 		C.double(bounds.Dx()), C.double(bounds.Dy()),
 		C.double(radius),
+		C.uint(fill), C.uint(border), C.double(lineWidth),
+	)
+}
+
+func (o *x11Overlay) drawArrow(
+	arrow hintArrowTriangle,
+	fill uint32, border uint32, lineWidth float64,
+) {
+	C.neru_x11_overlay_triangle(
+		o.raw,
+		C.double(arrow.baseLeft.X), C.double(arrow.baseLeft.Y),
+		C.double(arrow.tip.X), C.double(arrow.tip.Y),
+		C.double(arrow.baseRight.X), C.double(arrow.baseRight.Y),
 		C.uint(fill), C.uint(border), C.double(lineWidth),
 	)
 }


### PR DESCRIPTION
## Description

This PR adds hint arrows for top/bottom placement on Linux (X11 and Wayland), drawing a small connector tail from each hint badge back to its target element so labels visually point at what they select — matching the macOS overlay. Because the default placement is "bottom", arrows now show by default on Linux.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The placement/arrow geometry is computed by a single shared helper so the X11 and Wayland backends stay in lockstep. The arrow is filled over the badge and only its two slanted edges are stroked, so it reads as a seamless tail; with a translucent hint background the base region blends slightly (macOS avoids this via a single unified path). Windows overlay arrows remain unimplemented and stay documented as such.
