### PR TITLE
fix(linux): stop hints clearing on Wayland refresh

### DIFF
--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -29,8 +29,13 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 		return
 	}
 	// Disable exclusive keyboard so scroll events pass through to applications
-	// when indicator overlays are shown, but only if uinput scroll is active
-	if m := overlay.Get(); m != nil && eventtap.IsUinputScrollAvailable() {
+	// when indicator overlays are shown, but only if uinput scroll is active.
+	// Skip entirely when an evdev keyboard grab owns the keyboard: there the
+	// overlay must stay keyboard-passive (its grab would deactivate the focused
+	// app's toplevel on wlroots, breaking the next hints refresh), and the evdev
+	// path already keeps it that way.
+	if m := overlay.Get(); m != nil && eventtap.IsUinputScrollAvailable() &&
+		!eventtap.IsWaylandEvdevKeyboardActive() {
 		m.SetKeyboardCaptureEnabled(false)
 	}
 	// Ensure the mode indicator overlay covers the correct screen before
@@ -222,8 +227,13 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 // stopIndicatorPolling stops the indicator polling goroutine and cleans up
 // both mode indicator and sticky modifiers indicator overlays.
 func (h *Handler) stopIndicatorPolling() {
-	// Restore keyboard capture if uinput scroll was active.
-	if m := overlay.Get(); m != nil && eventtap.IsUinputScrollAvailable() {
+	// Restore keyboard capture if uinput scroll was active. Never re-enable it
+	// while an evdev keyboard grab owns the keyboard: on wlroots compositors the
+	// overlay's exclusive keyboard grab deactivates the focused app's toplevel,
+	// so a hints refresh (which stops indicator polling before rescanning) would
+	// re-read the wrong focused window and clear the hints.
+	if m := overlay.Get(); m != nil && eventtap.IsUinputScrollAvailable() &&
+		!eventtap.IsWaylandEvdevKeyboardActive() {
 		m.SetKeyboardCaptureEnabled(true)
 	}
 

--- a/internal/core/infra/eventtap/eventtap_darwin.go
+++ b/internal/core/infra/eventtap/eventtap_darwin.go
@@ -510,3 +510,8 @@ func eventTapPassthroughBridge(_ unsafe.Pointer) {
 func IsUinputScrollAvailable() bool {
 	return false
 }
+
+// IsWaylandEvdevKeyboardActive returns false on Darwin (no evdev / Wayland).
+func IsWaylandEvdevKeyboardActive() bool {
+	return false
+}

--- a/internal/core/infra/eventtap/eventtap_linux_nocgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_nocgo.go
@@ -32,4 +32,9 @@ func IsUinputScrollAvailable() bool {
 	return false
 }
 
+// IsWaylandEvdevKeyboardActive is always false without CGO (no evdev grab).
+func IsWaylandEvdevKeyboardActive() bool {
+	return false
+}
+
 func (et *EventTap) closeEvdevCapture() {}

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -35,6 +36,22 @@ const (
 	waylandEvdevHotplugSettleDelay        = 100 * time.Millisecond
 	waylandEvdevHotplugPollInterval       = 500 * time.Millisecond
 )
+
+// waylandEvdevKeyboardActive reports whether an evdev keyboard grab is currently
+// held, i.e. keys are captured directly from the input devices rather than via
+// the overlay layer-surface's keyboard grab. When true, the overlay must NOT
+// request exclusive keyboard focus: on wlroots compositors (niri, Sway, …) a
+// layer-surface keyboard grab deactivates the focused app's toplevel, which
+// makes a hints refresh re-read the wrong "focused window" and tear the overlay
+// down. See IsWaylandEvdevKeyboardActive and its use in the indicator polling.
+var waylandEvdevKeyboardActive atomic.Bool
+
+// IsWaylandEvdevKeyboardActive reports whether keys are currently being captured
+// via an evdev grab (so the overlay's keyboard grab is redundant and must stay
+// off). False on non-Wayland sessions, when the grab failed, and between modes.
+func IsWaylandEvdevKeyboardActive() bool {
+	return waylandEvdevKeyboardActive.Load()
+}
 
 var (
 	errWaylandEvdevUnavailable = errors.New("wayland evdev capture unavailable")
@@ -764,6 +781,10 @@ func (et *EventTap) closeEvdevCapture() {
 }
 
 func (et *EventTap) runWaylandEvdev() bool {
+	// Clear the evdev-active flag on every exit path (mode end / ungrab), so the
+	// overlay may reclaim the keyboard grab if it ever becomes the fallback.
+	defer waylandEvdevKeyboardActive.Store(false)
+
 	// Get or create the persistent capture (initialized once, reused
 	// across Enable/Disable cycles). This avoids re-scanning
 	// /dev/input/event* devices on every mode activation, which was
@@ -804,14 +825,6 @@ func (et *EventTap) runWaylandEvdev() bool {
 	}
 
 	manager := overlay.Get()
-	keyboardCaptureDisabled := false
-	if manager != nil {
-		defer func() {
-			if keyboardCaptureDisabled {
-				manager.SetKeyboardCaptureEnabled(true)
-			}
-		}()
-	}
 
 	for capture.modifierKeysHeld() {
 		select {
@@ -884,6 +897,11 @@ func (et *EventTap) runWaylandEvdev() bool {
 		return false
 	}
 
+	// The evdev grab now owns the keyboard for this mode session, so the overlay
+	// must stay keyboard-passive (see waylandEvdevKeyboardActive). Cleared by the
+	// deferred Store(false) when this function returns on mode exit / ungrab.
+	waylandEvdevKeyboardActive.Store(true)
+
 	// Start reader goroutines on first invocation only; they run for
 	// the entire lifetime of the capture (until EventTap.Destroy()).
 	capture.startReadersOnce.Do(func() {
@@ -891,8 +909,12 @@ func (et *EventTap) runWaylandEvdev() bool {
 	})
 
 	if manager != nil {
+		// Keep the overlay keyboard-passive for the whole session and do NOT
+		// restore it to EXCLUSIVE on exit: the evdev grab owns the keyboard, so a
+		// layer-surface grab would only deactivate the focused app's toplevel on
+		// wlroots. Every subsequent mode therefore also starts from NONE. The
+		// non-evdev fallback (runWayland) raises EXCLUSIVE itself when it needs it.
 		manager.SetKeyboardCaptureEnabled(false)
-		keyboardCaptureDisabled = true
 	}
 
 	if et.logger != nil {

--- a/internal/core/infra/eventtap/eventtap_windows.go
+++ b/internal/core/infra/eventtap/eventtap_windows.go
@@ -168,6 +168,11 @@ func IsUinputScrollAvailable() bool {
 	return false
 }
 
+// IsWaylandEvdevKeyboardActive returns false on Windows (no evdev / Wayland).
+func IsWaylandEvdevKeyboardActive() bool {
+	return false
+}
+
 func (et *EventTap) handleKey(key string, isUp bool) bool {
 	if key == "" {
 		return false

--- a/internal/core/infra/platform/linux/overlay_wayland.c
+++ b/internal/core/infra/platform/linux/overlay_wayland.c
@@ -379,9 +379,14 @@ NeruWaylandOverlay *neru_wayland_overlay_new(void) {
 	if (!overlay)
 		return NULL;
 
-	// EXCLUSIVE by default for keyboard capture fallback
-	// SetKeyboardCaptureEnabled can change it to NONE when not needed
-	overlay->keyboard_interactivity_set = ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
+	// NONE by default so the overlay never steals keyboard focus on creation. A
+	// layer-surface keyboard grab makes wlroots compositors (niri, Sway, …)
+	// deactivate the focused app's toplevel, which breaks the "focused window"
+	// query a hints refresh depends on. Keys are captured via the evdev grab; only
+	// the non-evdev fallback (see runWayland in eventtap_linux_wayland.go) turns
+	// this back to EXCLUSIVE via neru_wayland_overlay_set_keyboard_capture. This
+	// mirrors macOS, whose overlay is a non-activating panel.
+	overlay->keyboard_interactivity_set = ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
 
 	overlay->display = wl_display_connect(NULL);
 	if (!overlay->display) {
@@ -529,8 +534,9 @@ void neru_wayland_overlay_setup_buffers(NeruWaylandOverlay *overlay) {
 		                            ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT | ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM);
 		zwlr_layer_surface_v1_set_exclusive_zone(scr->layer_surface, -1);
 
-		// Request exclusive keyboard interactivity when overlay is shown
-		// This tells the compositor to send keyboard events to this surface
+		// Apply the current keyboard-interactivity mode (NONE by default so the
+		// overlay does not steal focus; the non-evdev fallback raises it to
+		// EXCLUSIVE via neru_wayland_overlay_set_keyboard_capture).
 		zwlr_layer_surface_v1_set_keyboard_interactivity(scr->layer_surface, overlay->keyboard_interactivity_set);
 
 		zwlr_layer_surface_v1_add_listener(scr->layer_surface, &layer_surface_listener, overlay);


### PR DESCRIPTION
## Description

This PR fixes hints being cleared when refreshing on Wayland/wlroots compositors, where the overlay's exclusive keyboard grab deactivated the focused app's window and made the refresh re-read the wrong one.

## Target Platform

- [x] Linux

## Type of Change

- [x] `fix` — Bug fix

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

On this setup keys are captured via the evdev grab, so the overlay's layer-surface keyboard grab is redundant; the fix keeps the overlay keyboard-passive while evdev owns the keyboard, and the non-evdev fallback still raises exclusive capture when it needs it. Verified live on niri across many refreshes.