### PR TITLE
perf(linux): use AT-SPI Collection.GetMatches for hint element collection

### DIFF
--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"image"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -46,8 +47,9 @@ const (
 	atspiStateActive  = 1
 	atspiStateShowing = 25
 
-	// AT-SPI packs state into an array of uint32 words (one bit per state).
-	atspiStateBitsPerWord = 32
+	// Bit width of the int32 words AT-SPI packs its state and role sets into
+	// (one bit per state/role index).
+	atspiBitsPerWord = 32
 
 	// Walk bounds to keep D-Bus traffic sane on deep trees.
 	atspiMaxDepth = 40
@@ -60,7 +62,80 @@ const (
 	// org.a11y.Status D-Bus property names.
 	a11yPropIsEnabled    = "IsEnabled"
 	a11yPropScreenReader = "ScreenReaderEnabled"
+
+	// org.a11y.atspi.Collection.GetMatches fetches all descendants matching a
+	// role+state predicate in a single D-Bus call, instead of the per-node walk.
+	atspiCollectionIfc = "org.a11y.atspi.Collection"
+
+	// AtspiCollectionMatchType values (atspi-constants.h): how a criterion set is
+	// interpreted. MATCH_ALL requires all listed items; MATCH_ANY requires any.
+	// An empty set with MATCH_ALL imposes no constraint.
+	atspiMatchAll = int32(1)
+	atspiMatchAny = int32(2)
+
+	// AtspiCollectionSortOrder CANONICAL (atspi-constants.h). Ordering is
+	// irrelevant here since hints are re-positioned, but a valid value is required.
+	atspiSortCanonical = uint32(1)
+
+	// Fixed word counts libatspi marshals the role/state sets into (see
+	// _atspi_match_rule_marshal in at-spi2-core/atspi/atspi-matchrule.c): the role
+	// bitfield is always 5 int32 words, the state bitset always 2.
+	atspiRoleWords  = 5
+	atspiStateWords = 2
+
+	// collectionMaxWorkers bounds the goroutines that materialize GetMatches
+	// results (role/extents/name lookups). These are latency-bound D-Bus calls
+	// that godbus multiplexes over one connection, so overlapping them cuts the
+	// per-match cost; the cap keeps a large page from flooding the a11y bus.
+	collectionMaxWorkers = 16
 )
+
+// AtspiRole enum ids (declaration-order indices in atspi-constants.h), used to
+// build the Collection.GetMatches role bitfield. The enum is ABI-stable
+// (append-only), so these are fixed.
+const (
+	atspiRolePushButton     = 43
+	atspiRoleToggleButton   = 62
+	atspiRolePushButtonMenu = 129
+	atspiRoleComboBox       = 11
+	atspiRoleCheckBox       = 7
+	atspiRoleCheckMenuItem  = 8
+	atspiRoleRadioButton    = 44
+	atspiRoleRadioMenuItem  = 45
+	atspiRoleLinkID         = 88
+	atspiRoleEntry          = 79
+	atspiRolePasswordText   = 40
+	atspiRoleSlider         = 51
+	atspiRolePageTab        = 37
+	atspiRoleMenuItemID     = 35
+	atspiRoleListItem       = 32
+	atspiRoleTableCell      = 56
+	atspiRoleTableRow       = 90
+)
+
+// atspiRoleNameToID maps the AT-SPI role names Neru cares about (the keys of
+// atspiToAXRole) to their AtspiRole id, for building the Collection.GetMatches
+// role bitfield.
+var atspiRoleNameToID = map[string]int32{
+	"push button":     atspiRolePushButton,
+	"button":          atspiRolePushButton,
+	"toggle button":   atspiRoleToggleButton,
+	"menu button":     atspiRolePushButtonMenu,
+	"combo box":       atspiRoleComboBox,
+	"check box":       atspiRoleCheckBox,
+	"check menu item": atspiRoleCheckMenuItem,
+	"radio button":    atspiRoleRadioButton,
+	"radio menu item": atspiRoleRadioMenuItem,
+	"link":            atspiRoleLinkID,
+	"entry":           atspiRoleEntry,
+	"password text":   atspiRolePasswordText,
+	"slider":          atspiRoleSlider,
+	"page tab":        atspiRolePageTab,
+	"menu item":       atspiRoleMenuItemID,
+	"list item":       atspiRoleListItem,
+	"table cell":      atspiRoleTableCell,
+	"table row":       atspiRoleTableRow,
+}
 
 // accRef is the AT-SPI (bus-name, object-path) reference returned by
 // GetChildren and the registry root.
@@ -293,11 +368,28 @@ func (c *ATSPIClient) ClickableNodes(
 		return nil, nil
 	}
 
+	roleSet := rolesSet(roles)
+
+	// Fast path: a single Collection.GetMatches call instead of the per-node
+	// walk. Falls back to the walk when the toolkit doesn't implement Collection.
+	if nodes, ok := c.collectViaCollection(ctx, conn, win.ref, roleSet, offX, offY); ok {
+		c.logger.Debug("AT-SPI clickable scan complete",
+			zap.String("path", "collection"),
+			zap.Int("count", len(nodes)),
+			zap.Int("offsetX", offX),
+			zap.Int("offsetY", offY),
+			zap.Bool("haveOrigin", haveOrigin),
+			zap.Duration("elapsed", time.Since(start)))
+
+		return nodes, nil
+	}
+
 	out := make([]AXNode, 0, atspiClickableNodesCap)
 	visited := 0
-	c.walk(ctx, conn, win.ref, rolesSet(roles), 0, &out, &visited, offX, offY)
+	c.walk(ctx, conn, win.ref, roleSet, 0, &out, &visited, offX, offY)
 
-	c.logger.Debug("AT-SPI clickable walk complete",
+	c.logger.Debug("AT-SPI clickable scan complete",
+		zap.String("path", "walk"),
 		zap.Int("count", len(out)),
 		zap.Int("visited", visited),
 		zap.Int("offsetX", offX),
@@ -306,6 +398,84 @@ func (c *ATSPIClient) ClickableNodes(
 		zap.Duration("elapsed", time.Since(start)))
 
 	return out, nil
+}
+
+// atspiMatchRule mirrors the AT-SPI Collection MatchRule D-Bus struct
+// (aiia{ss}iaiiasib); godbus marshals the exported fields in declaration order.
+type atspiMatchRule struct {
+	States     []int32
+	StateMatch int32
+	Attributes map[string]string
+	AttrMatch  int32
+	Roles      []int32
+	RoleMatch  int32
+	Interfaces []string
+	IfaceMatch int32
+	Invert     bool
+}
+
+// deriveTargetRoleIDs returns the AtspiRole ids whose AX mapping is in roleSet —
+// exactly the roles the per-node walk would emit — so the Collection query has
+// identical semantics.
+func deriveTargetRoleIDs(roleSet map[string]struct{}) []int32 {
+	var ids []int32
+
+	seen := make(map[int32]struct{})
+
+	for atspiName, axRole := range atspiToAXRole {
+		if _, ok := roleSet[axRole]; !ok {
+			continue
+		}
+
+		roleID, ok := atspiRoleNameToID[atspiName]
+		if !ok {
+			continue
+		}
+
+		if _, dup := seen[roleID]; dup {
+			continue
+		}
+
+		seen[roleID] = struct{}{}
+
+		ids = append(ids, roleID)
+	}
+
+	return ids
+}
+
+// roleBitfield packs AtspiRole ids into the fixed 5-word int32 bitfield libatspi
+// expects: bit (id%32) of word (id/32).
+func roleBitfield(ids []int32) []int32 {
+	words := make([]int32, atspiRoleWords)
+
+	for _, roleID := range ids {
+		if roleID < 0 {
+			continue
+		}
+
+		word := roleID / atspiBitsPerWord
+		if int(word) < len(words) {
+			words[word] |= 1 << uint(roleID%atspiBitsPerWord)
+		}
+	}
+
+	return words
+}
+
+// stateBitset packs AT-SPI state indices into the fixed 2-word int32 array
+// libatspi expects: bit (s%32) of word (s/32).
+func stateBitset(states ...uint) []int32 {
+	words := make([]int32, atspiStateWords)
+
+	for _, s := range states {
+		w := s / atspiBitsPerWord
+		if int(w) < len(words) {
+			words[w] |= 1 << (s % atspiBitsPerWord)
+		}
+	}
+
+	return words
 }
 
 // Close restores the org.a11y.Status to the values that were active before
@@ -338,6 +508,144 @@ func (c *ATSPIClient) Close() error {
 	c.mu.Unlock()
 
 	return nil
+}
+
+// collectViaCollection fetches clickable elements with a single
+// org.a11y.atspi.Collection.GetMatches call rooted at the frame, instead of the
+// recursive per-node walk. It returns (nodes, true) on success, or (nil, false)
+// to signal the caller to fall back to the walk — when Collection is disabled,
+// no requested role maps to an AtspiRole, or the toolkit does not implement the
+// interface (the GetMatches call errors). Results have identical semantics to
+// the walk: SHOWING elements whose role maps (via atspiToAXRole) into roleSet.
+func (c *ATSPIClient) collectViaCollection(
+	ctx context.Context,
+	conn *dbus.Conn,
+	root accRef,
+	roleSet map[string]struct{},
+	offX, offY int,
+) ([]AXNode, bool) {
+	if os.Getenv("NERU_ATSPI_NO_COLLECTION") != "" {
+		return nil, false
+	}
+
+	ids := deriveTargetRoleIDs(roleSet)
+	if len(ids) == 0 {
+		// No requested role has an AtspiRole equivalent; the walk would also emit
+		// nothing. Fall back rather than issue a match-nothing query.
+		return nil, false
+	}
+
+	rule := atspiMatchRule{
+		States:     stateBitset(atspiStateShowing),
+		StateMatch: atspiMatchAll,
+		Attributes: map[string]string{},
+		AttrMatch:  atspiMatchAll,
+		Roles:      roleBitfield(ids),
+		RoleMatch:  atspiMatchAny,
+		Interfaces: []string{},
+		IfaceMatch: atspiMatchAll,
+		Invert:     false,
+	}
+
+	var matches []accRef
+
+	err := conn.Object(root.Name, root.Path).
+		CallWithContext(ctx, atspiCollectionIfc+".GetMatches", 0,
+			rule, atspiSortCanonical, int32(0), true).
+		Store(&matches)
+	if err != nil {
+		c.logger.Debug("AT-SPI Collection.GetMatches unavailable; falling back to walk",
+			zap.Error(err))
+
+		return nil, false
+	}
+
+	// Collection is implemented but returned nothing. Don't trust that as
+	// authoritative — a toolkit's Collection may be incomplete or scope the
+	// subtree differently than the per-node walk (e.g. return zero on a page the
+	// walk would find elements on). Fall back to the walk, which is the safe
+	// baseline; genuinely empty windows are cheap to walk.
+	if len(matches) == 0 {
+		return nil, false
+	}
+
+	// Bound the work before materializing so a pathological page cannot spawn an
+	// unbounded number of goroutines (the walk applies the same cap to its output).
+	if len(matches) > atspiMaxNodes {
+		matches = matches[:atspiMaxNodes]
+	}
+
+	// Materialize each match (role re-check + extents + name) concurrently: the
+	// lookups are independent, latency-bound D-Bus round-trips that godbus
+	// multiplexes safely over the one connection. Each goroutine writes its own
+	// slot, so no lock is needed; nil slots are dropped afterward.
+	results := make([]*atspiNode, len(matches))
+
+	sem := make(chan struct{}, collectionMaxWorkers)
+
+	var waitGroup sync.WaitGroup
+
+	for index, ref := range matches {
+		if ctx.Err() != nil {
+			break
+		}
+
+		waitGroup.Add(1)
+
+		sem <- struct{}{}
+
+		go func(slot int, ref accRef) {
+			defer waitGroup.Done()
+			defer func() { <-sem }()
+
+			results[slot] = c.materializeMatch(conn, ref, roleSet, offX, offY)
+		}(index, ref)
+	}
+
+	waitGroup.Wait()
+
+	out := make([]AXNode, 0, len(results))
+	for _, node := range results {
+		if node != nil {
+			out = append(out, node)
+		}
+	}
+
+	return out, true
+}
+
+// materializeMatch turns a GetMatches result into an atspiNode, or nil if it
+// should be dropped (role not in the requested set, or no valid on-screen
+// extents). It mirrors the walk's emit filter and is safe for concurrent use —
+// it only issues reads over the shared connection, which godbus multiplexes.
+func (c *ATSPIClient) materializeMatch(
+	conn *dbus.Conn,
+	ref accRef,
+	roleSet map[string]struct{},
+	offX, offY int,
+) *atspiNode {
+	// Re-verify the role maps into the requested set: a toolkit may return a role
+	// we did not ask for, and this keeps parity with the walk's filter.
+	axRole, mappable := atspiToAXRole[strings.ToLower(c.roleName(conn, ref))]
+	if !mappable {
+		return nil
+	}
+
+	if _, ok := roleSet[axRole]; !ok {
+		return nil
+	}
+
+	rect, valid := c.extents(conn, ref)
+	if !valid {
+		return nil
+	}
+
+	return &atspiNode{
+		id:    string(ref.Path) + "@" + ref.Name,
+		role:  axRole,
+		title: c.name(conn, ref),
+		rect:  rect.Add(image.Pt(offX, offY)),
+	}
 }
 
 // readA11yStatus reads the current IsEnabled and ScreenReaderEnabled D-Bus
@@ -590,12 +898,12 @@ func (c *ATSPIClient) stateHas(conn *dbus.Conn, ref accRef, bit uint) bool {
 		return false
 	}
 
-	word := bit / atspiStateBitsPerWord
+	word := bit / atspiBitsPerWord
 	if int(word) >= len(states) {
 		return false
 	}
 
-	return states[word]&(1<<(bit%atspiStateBitsPerWord)) != 0
+	return states[word]&(1<<(bit%atspiBitsPerWord)) != 0
 }
 
 // extents returns the on-screen rectangle of an accessible.

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/godbus/dbus/v5"
@@ -569,24 +570,28 @@ func (c *ATSPIClient) collectViaCollection(
 		return nil, false
 	}
 
-	// Bound the work before materializing so a pathological page cannot spawn an
-	// unbounded number of goroutines (the walk applies the same cap to its output).
-	if len(matches) > atspiMaxNodes {
-		matches = matches[:atspiMaxNodes]
-	}
-
 	// Materialize each match (role re-check + extents + name) concurrently: the
 	// lookups are independent, latency-bound D-Bus round-trips that godbus
-	// multiplexes safely over the one connection. Each goroutine writes its own
-	// slot, so no lock is needed; nil slots are dropped afterward.
+	// multiplexes safely over the one connection. The bounded semaphore paces the
+	// loop, so at most collectionMaxWorkers goroutines run at once no matter how
+	// many matches there are. Each goroutine writes its own slot, so no lock is
+	// needed; nil slots are dropped afterward.
 	results := make([]*atspiNode, len(matches))
 
 	sem := make(chan struct{}, collectionMaxWorkers)
 
-	var waitGroup sync.WaitGroup
+	var (
+		waitGroup  sync.WaitGroup
+		validCount atomic.Int64
+	)
 
 	for index, ref := range matches {
-		if ctx.Err() != nil {
+		// Stop scheduling once canceled, or once we have enough *valid* nodes.
+		// Capping on emitted nodes (like the walk) rather than raw candidates
+		// keeps invalid/zero-sized matches from crowding out valid ones past the
+		// limit. validCount lags slightly under concurrency, so a few in-flight
+		// workers may push past the cap — the output loop below trims the excess.
+		if ctx.Err() != nil || validCount.Load() >= atspiMaxNodes {
 			break
 		}
 
@@ -598,17 +603,39 @@ func (c *ATSPIClient) collectViaCollection(
 			defer waitGroup.Done()
 			defer func() { <-sem }()
 
-			results[slot] = c.materializeMatch(conn, ref, roleSet, offX, offY)
+			if ctx.Err() != nil {
+				return
+			}
+
+			node := c.materializeMatch(conn, ref, roleSet, offX, offY)
+			if node != nil {
+				results[slot] = node
+
+				validCount.Add(1)
+			}
 		}(index, ref)
 	}
 
 	waitGroup.Wait()
 
 	out := make([]AXNode, 0, len(results))
+
 	for _, node := range results {
-		if node != nil {
-			out = append(out, node)
+		if node == nil {
+			continue
 		}
+
+		out = append(out, node)
+		if len(out) >= atspiMaxNodes {
+			break
+		}
+	}
+
+	// Every match failed to materialize (e.g. a dynamic UI invalidated every
+	// reference between GetMatches and the per-match lookups). Treat that like an
+	// empty result and fall back to the walk rather than report an empty success.
+	if len(out) == 0 {
+		return nil, false
 	}
 
 	return out, true

--- a/internal/core/infra/accessibility/atspi_linux_test.go
+++ b/internal/core/infra/accessibility/atspi_linux_test.go
@@ -3,7 +3,10 @@
 //nolint:testpackage // Exercises the unexported app_id matching helpers directly.
 package accessibility
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 const (
 	appIDFirefox = "org.mozilla.firefox"
@@ -208,5 +211,136 @@ func TestSelectFrame(t *testing.T) {
 				t.Errorf("selectFrame() = (%+v, %v), want (%+v, %v)", got, ok, tc.want, tc.wantOK)
 			}
 		})
+	}
+}
+
+func TestStateBitset(t *testing.T) {
+	got := stateBitset(atspiStateShowing) // SHOWING = 25
+	if len(got) != atspiStateWords {
+		t.Fatalf("len = %d, want %d", len(got), atspiStateWords)
+	}
+
+	if got[0] != 1<<25 || got[1] != 0 {
+		t.Fatalf("stateBitset(SHOWING) = %v, want [%d 0]", got, int32(1)<<25)
+	}
+}
+
+func TestRoleBitfield(t *testing.T) {
+	// push button 43 -> word1 bit11; link 88 -> word2 bit24; menu 129 -> word4 bit1.
+	got := roleBitfield([]int32{43, 88, 129})
+	if len(got) != atspiRoleWords {
+		t.Fatalf("len = %d, want %d", len(got), atspiRoleWords)
+	}
+
+	want := make([]int32, atspiRoleWords)
+	for _, id := range []int32{43, 88, 129} {
+		want[id/32] |= 1 << uint(id%32)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("word %d = %d, want %d (got=%v want=%v)", i, got[i], want[i], got, want)
+		}
+	}
+
+	// Explicit spot-checks guard against off-by-one word/bit packing.
+	if got[1] != 1<<11 {
+		t.Errorf("word1 = %d, want %d (push button)", got[1], int32(1)<<11)
+	}
+
+	if got[4] != 1<<1 {
+		t.Errorf("word4 = %d, want %d (push-button-menu)", got[4], int32(1)<<1)
+	}
+}
+
+func TestDeriveTargetRoleIDs(t *testing.T) {
+	noDuplicates := func(t *testing.T, ids []int32) {
+		t.Helper()
+
+		seen := make(map[int32]bool)
+		for _, roleID := range ids {
+			if seen[roleID] {
+				t.Errorf("duplicate id %d in %v", roleID, ids)
+			}
+
+			seen[roleID] = true
+		}
+	}
+
+	t.Run("AXButton maps to its several atspi roles (deduped)", func(t *testing.T) {
+		// push button(43), button(43 -> deduped), toggle button(62).
+		ids := deriveTargetRoleIDs(map[string]struct{}{axRoleButton: {}})
+		for _, want := range []int32{43, 62} {
+			if !slices.Contains(ids, want) {
+				t.Errorf("missing role id %d in %v", want, ids)
+			}
+		}
+
+		noDuplicates(t, ids)
+
+		if len(ids) != 2 {
+			t.Errorf("AXButton -> %v, want exactly ids {43, 62}", ids)
+		}
+	})
+
+	t.Run("AXMenuItem gathers all three menu-item roles", func(t *testing.T) {
+		// check menu item(8), radio menu item(45), menu item(35).
+		ids := deriveTargetRoleIDs(map[string]struct{}{axRoleMenuItem: {}})
+		for _, want := range []int32{8, 45, 35} {
+			if !slices.Contains(ids, want) {
+				t.Errorf("missing role id %d in %v", want, ids)
+			}
+		}
+
+		noDuplicates(t, ids)
+	})
+
+	t.Run("AXTextField gathers entry and password text", func(t *testing.T) {
+		ids := deriveTargetRoleIDs(map[string]struct{}{axRoleTextField: {}})
+		for _, want := range []int32{79, 40} {
+			if !slices.Contains(ids, want) {
+				t.Errorf("missing role id %d in %v", want, ids)
+			}
+		}
+	})
+
+	t.Run("multiple AX roles union their ids", func(t *testing.T) {
+		ids := deriveTargetRoleIDs(map[string]struct{}{axRoleRow: {}, axRoleButton: {}})
+		for _, want := range []int32{32, 90, 43, 62} { // list item, table row, push/toggle button
+			if !slices.Contains(ids, want) {
+				t.Errorf("missing role id %d in %v", want, ids)
+			}
+		}
+
+		noDuplicates(t, ids)
+	})
+
+	t.Run("raw AT-SPI names never match (parity with the walk)", func(t *testing.T) {
+		// deriveTargetRoleIDs keys on the AX values of atspiToAXRole, exactly like
+		// the walk, so a set of raw AT-SPI role names resolves to nothing.
+		ids := deriveTargetRoleIDs(map[string]struct{}{"spin button": {}, "toolbar": {}})
+		if len(ids) != 0 {
+			t.Errorf("atspi-name set -> %v, want none", ids)
+		}
+	})
+
+	t.Run("role with no atspi equivalent yields none", func(t *testing.T) {
+		ids := deriveTargetRoleIDs(map[string]struct{}{"AXUnknownWidget": {}})
+		if len(ids) != 0 {
+			t.Errorf("unknown role -> %v, want none", ids)
+		}
+	})
+}
+
+func TestAtspiRoleNameToIDCoversAtspiToAXRole(t *testing.T) {
+	// Every AT-SPI role name that maps to an AX role (and is therefore hintable
+	// via the walk) must also have an AtspiRole id. If the two maps drift, the
+	// Collection fast path would silently miss that role type while the walk
+	// still finds it — a subtle correctness gap.
+	for atspiName := range atspiToAXRole {
+		if _, ok := atspiRoleNameToID[atspiName]; !ok {
+			t.Errorf("atspiToAXRole has %q but atspiRoleNameToID lacks it; "+
+				"Collection.GetMatches would not match that role", atspiName)
+		}
 	}
 }


### PR DESCRIPTION
## Description

This PR speeds up clickable-element collection on Linux by ~5–15× by fetching all matching elements in a single AT-SPI Collection query with concurrent per-match lookups, instead of a recursive per-node D-Bus walk; it falls back to the walk when a toolkit doesn't support it, so results are unchanged.

## Target Platform

- [x] Linux

## Type of Change

- [x] `perf` — Performance improvement

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Verified parity live on Firefox (identical element counts vs the walk) and via `NERU_ATSPI_NO_COLLECTION=1` to force the walk. New unit tests cover the role/state bitfield marshalling and guard against the role maps drifting out of sync.