### PR TITLE
feat(linux): event-driven focused-app changes for per-app config

### DIFF
--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -40,8 +40,17 @@ clickable_roles = [
 ]
 ignore_clickable_check = false
 
-## Application-specific configurations for customizing hint behavior per app
-## Each entry allows overriding clickable roles and clickable check behavior for specific bundle IDs
+## Application-specific configurations for customizing hint behavior per app.
+## Each entry overrides behavior for one app, matched on `bundle_id`.
+##
+## `bundle_id` is platform-specific (the field name is kept for compatibility):
+##   macOS         -> bundle ID          e.g. "com.brave.Browser"  (osascript -e 'id of app "Brave Browser"')
+##   Linux/X11     -> WM_CLASS class     e.g. "brave-browser"      (xprop WM_CLASS)
+##   Linux/Wayland -> toplevel app_id    e.g. "brave-browser"      (swaymsg -t get_tree / hyprctl activewindow)
+## GNOME/Mutter on Wayland exposes no focused-app source, so per-app config
+## never applies there; GNOME on X11 and all wlroots/KDE Wayland sessions work.
+
+## macOS example:
 # [[hints.app_configs]]
 # bundle_id = "com.brave.Browser"
 # additional_clickable_roles = ["AXTabGroup"]
@@ -50,6 +59,11 @@ ignore_clickable_check = false
 # 	"Return" = "action left_click",
 # 	"Shift+L" = "__disabled__"
 # }
+
+## Linux example (key on WM_CLASS / app_id, confirmed via xprop / swaymsg):
+# [[hints.app_configs]]
+# bundle_id = "org.kde.konsole"
+# ignore_clickable_check = true
 
 [grid]
 enabled = false

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -318,6 +318,24 @@ hotkeys = {
 
 The same [merging rules](#merging-behavior) apply: app hotkeys merge on top of the base `[hotkeys]` bindings, and `__disabled__` removes an inherited binding. When no `[[app_configs]]` entry matches the focused app, the base `[hotkeys]` bindings are used as-is.
 
+#### App identity across platforms (`bundle_id`)
+
+The `bundle_id` key selects which app an override applies to — for both `[[app_configs]]` and every `[[<mode>.app_configs]]`. What it matches is platform-specific, even though the field is named `bundle_id` everywhere for config compatibility:
+
+| Platform | Identity Neru matches | How to find it |
+| --- | --- | --- |
+| macOS | Bundle ID, reverse-DNS (e.g. `com.apple.Safari`) | `osascript -e 'id of app "Safari"'` |
+| Linux · X11 | Window `WM_CLASS` — the *class* field | `xprop WM_CLASS`, then click the window |
+| Linux · Wayland (wlroots: Sway/Hyprland/niri/COSMIC, and KWin/KDE) | Toplevel `app_id` | `swaymsg -t get_tree` (Sway), `hyprctl activewindow` (Hyprland), `niri msg windows` (niri), or your compositor's window inspector |
+
+On Linux, put the `WM_CLASS` or `app_id` in the `bundle_id` field. Matching is case-insensitive but exact — no globbing or partial matches.
+
+> **Heads up:** Linux identity strings vary by toolkit and distribution. GTK, Qt, Electron, and XWayland apps often report a `WM_CLASS`/`app_id` you would not guess (e.g. `Google-chrome`, `code`, `org.kde.konsole`). Always confirm with the commands above rather than assuming a reverse-DNS name.
+
+**GNOME/Mutter on Wayland is not supported.** Mutter implements no focused-app protocol (no `wlr-foreign-toplevel-management`), so Neru cannot tell which application is focused and per-app overrides never apply there. GNOME on **X11** works normally, as do all wlroots compositors and KWin/KDE on Wayland. See [CROSS_PLATFORM.md](./CROSS_PLATFORM.md) for the backend matrix.
+
+Where the compositor or X11 exposes a focus-change signal, Neru applies per-app overrides the instant you switch windows; otherwise it re-checks the focused app a few times per second.
+
 ### Per-Mode Hotkeys
 
 Each mode can define hotkeys active only while that mode is running. Follows the same [merging rules](#merging-behavior) as global hotkeys.

--- a/internal/core/infra/appwatcher/platform_linux.go
+++ b/internal/core/infra/appwatcher/platform_linux.go
@@ -2,43 +2,67 @@
 
 // internal/core/infra/appwatcher/platform_linux.go
 // Linux app-watcher backend. macOS receives focus changes from an NSWorkspace
-// observer; Linux has no equivalent push API, so this polls the focused
-// application's identity (app_id on Wayland wlroots/KDE, WM_CLASS on X11) and
-// dispatches activate/deactivate events when it changes. GNOME/Mutter exposes
-// no focused-app source, so the poll yields nothing and no events fire there.
+// observer; on Linux the focused application's identity is the app_id (Wayland
+// wlroots/KDE) or WM_CLASS (X11). Where the compositor/X11 exposes a
+// focus-change notification (via linux.SubscribeFocusedApp), the watcher blocks
+// on that fd and re-samples on each wake — near-instant per-app hotkey
+// re-registration. Otherwise it falls back to polling on a fixed interval.
+// GNOME/Mutter exposes no focused-app source, so no events fire there.
 
 package appwatcher
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	"github.com/y3owk1n/neru/internal/core/infra/platform"
 	"github.com/y3owk1n/neru/internal/core/infra/platform/linux"
 )
 
-// focusPollInterval is how often the focused application is sampled. It trades
-// switch latency (per-app hotkeys re-register on the next poll after an
-// alt-tab) against idle cost (one lightweight focus query per interval).
+// focusPollInterval is how often the focused application is sampled on the
+// polling fallback (backends with no focus-change fd). It trades switch latency
+// (per-app hotkeys re-register on the next poll after an alt-tab) against idle
+// cost (one lightweight focus query per interval).
 const focusPollInterval = 400 * time.Millisecond
+
+// focusEventPollTimeout bounds a single poll() wait on the event-driven path so
+// the loop notices context cancellation within this window even when no focus
+// event arrives. It is short enough for prompt shutdown yet long enough that an
+// idle daemon makes only a couple of no-op poll() syscalls per second.
+const focusEventPollTimeout = 500 * time.Millisecond
+
+// focusEventSafetyInterval bounds how long the event-driven loop goes without a
+// forced re-sample. Focus changes normally wake it immediately via the fd; this
+// periodic re-sample is a safety net against a missed or coalesced event and
+// costs one focus query per interval (matching the polling fallback's idle
+// cost, but far less often).
+const focusEventSafetyInterval = 3 * time.Second
 
 // globalLinuxWatcher is the process-wide app watcher, mirroring the single
 // darwin.SetAppWatcher registration. NewWatcher registers itself here via
 // platformRegisterWatcher.
 var globalLinuxWatcher = &linuxAppWatcher{
-	identity: linux.FocusedAppID,
-	interval: focusPollInterval,
+	identity:  linux.FocusedAppID,
+	subscribe: linux.SubscribeFocusedApp,
+	interval:  focusPollInterval,
 }
 
-// linuxAppWatcher polls the focused-application identity and dispatches
-// activation changes to the registered Watcher.
+// linuxAppWatcher samples the focused-application identity and dispatches
+// activation changes to the registered Watcher, waking on a focus-change fd
+// where one is available and polling otherwise.
 type linuxAppWatcher struct {
 	// identity resolves the focused app_id for a backend; injectable for tests.
 	identity func(backend string) (string, bool)
-	interval time.Duration
+	// subscribe returns an fd that becomes readable on focus changes, or
+	// ok=false to select the polling fallback; injectable for tests. A nil
+	// subscribe also selects polling.
+	subscribe func(backend string) (int, bool)
+	interval  time.Duration
 
 	mu      sync.Mutex
 	watcher *Watcher
@@ -46,7 +70,7 @@ type linuxAppWatcher struct {
 	wg      sync.WaitGroup
 
 	// last is the most recently dispatched app_id ("" means "none focused").
-	// It is owned exclusively by the poll goroutine, so it needs no lock.
+	// It is owned exclusively by the sample goroutine, so it needs no lock.
 	last string
 }
 
@@ -98,17 +122,37 @@ func (l *linuxAppWatcher) stop() {
 	l.wg.Wait()
 }
 
-// loop samples the focused application every interval until the context is
-// canceled, dispatching a deactivate/activate pair on each change.
+// loop samples the focused application until the context is canceled. It
+// samples once immediately, then either blocks on a focus-change fd (when the
+// backend exposes one) or polls on a fixed interval.
 func (l *linuxAppWatcher) loop(ctx context.Context, backend string) {
 	defer l.wg.Done()
 
+	// Sample once immediately so per-app state converges without waiting for the
+	// first event or poll tick.
+	l.tick(backend)
+
+	if l.subscribe != nil {
+		if fd, ok := l.subscribe(backend); ok && fd >= 0 {
+			l.watcher.logger.Debug("App watcher: using event-driven focus updates",
+				zap.String("backend", backend))
+			l.loopEvent(ctx, backend, fd)
+
+			return
+		}
+	}
+
+	l.watcher.logger.Debug("App watcher: polling focus updates",
+		zap.String("backend", backend),
+		zap.Duration("interval", l.interval))
+	l.loopPoll(ctx, backend)
+}
+
+// loopPoll samples the focused application every interval until the context is
+// canceled. Used when the backend exposes no focus-change fd.
+func (l *linuxAppWatcher) loopPoll(ctx context.Context, backend string) {
 	ticker := time.NewTicker(l.interval)
 	defer ticker.Stop()
-
-	// Sample once immediately so per-app state converges without waiting a
-	// full interval for the first tick.
-	l.tick(backend)
 
 	for {
 		select {
@@ -116,6 +160,102 @@ func (l *linuxAppWatcher) loop(ctx context.Context, backend string) {
 			return
 		case <-ticker.C:
 			l.tick(backend)
+		}
+	}
+}
+
+// loopEvent blocks on the focus-change fd and re-samples on each wake. A short
+// poll timeout keeps shutdown responsive to context cancellation, and a
+// periodic safety-net re-sample guards against a missed or coalesced event. If
+// the fd hangs up or errors, it degrades to polling so focus tracking survives.
+//
+// focusFD is owned by the platform layer (a process-lifetime pipe/monitor).
+// We poll a dup of it so this goroutine holds its own descriptor: if that layer
+// ever closes the underlying fd, our in-flight Poll can't become a
+// use-after-close or fd-reuse race — we simply see POLLHUP and fall back to
+// polling. dup(2) clears close-on-exec, so we re-arm it; neru spawns exec-action
+// children that must not inherit this fd.
+func (l *linuxAppWatcher) loopEvent(ctx context.Context, backend string, focusFD int) {
+	dupFD, err := unix.Dup(focusFD)
+	if err != nil {
+		l.watcher.logger.Warn("App watcher: dup focus fd failed, falling back to polling",
+			zap.String("backend", backend),
+			zap.Error(err))
+		l.loopPoll(ctx, backend)
+
+		return
+	}
+
+	unix.CloseOnExec(dupFD)
+
+	defer func() { _ = unix.Close(dupFD) }()
+
+	pollFDs := []unix.PollFd{{Fd: int32(dupFD), Events: unix.POLLIN}}
+	nextSafety := time.Now().Add(focusEventSafetyInterval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		_, err = unix.Poll(pollFDs, int(focusEventPollTimeout/time.Millisecond))
+		if err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			// Unexpected poll failure — degrade to polling rather than spin.
+			l.watcher.logger.Warn("App watcher: focus fd poll failed, falling back to polling",
+				zap.String("backend", backend),
+				zap.Error(err))
+			l.loopPoll(ctx, backend)
+
+			return
+		}
+
+		revents := pollFDs[0].Revents
+
+		if revents&(unix.POLLHUP|unix.POLLERR|unix.POLLNVAL) != 0 {
+			l.watcher.logger.Warn("App watcher: focus fd hung up, falling back to polling",
+				zap.String("backend", backend))
+			l.loopPoll(ctx, backend)
+
+			return
+		}
+
+		if revents&unix.POLLIN != 0 {
+			drainFD(dupFD)
+			l.tick(backend)
+
+			nextSafety = time.Now().Add(focusEventSafetyInterval)
+
+			continue
+		}
+
+		// Poll timed out with no event: re-sample only when the safety interval
+		// has elapsed, so an idle X11 daemon isn't opening a display every tick.
+		if !time.Now().Before(nextSafety) {
+			l.tick(backend)
+
+			nextSafety = time.Now().Add(focusEventSafetyInterval)
+		}
+	}
+}
+
+// drainFD reads and discards all pending bytes from a non-blocking fd so a
+// burst of focus-change signals coalesces into a single re-sample.
+func drainFD(fd int) {
+	var buf [64]byte
+
+	for {
+		n, err := unix.Read(fd, buf[:])
+		if n <= 0 || err != nil {
+			return
+		}
+
+		if n < len(buf) {
+			return
 		}
 	}
 }

--- a/internal/core/infra/appwatcher/platform_linux_test.go
+++ b/internal/core/infra/appwatcher/platform_linux_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -171,6 +173,79 @@ func TestLinuxAppWatcherStartStopLifecycle(t *testing.T) {
 
 	// stop is idempotent.
 	poller.stop()
+}
+
+// TestLinuxAppWatcherEventLoopWakesOnFD proves the event-driven path dispatches
+// an activation when the focus-change fd becomes readable, rather than waiting
+// for a poll interval. A real non-blocking pipe stands in for the platform
+// focus fd; writing a byte simulates a compositor/X11 focus-change signal.
+func TestLinuxAppWatcherEventLoopWakesOnFD(t *testing.T) {
+	watcher := NewWatcher(nil)
+
+	activated := make(chan string, 4)
+	watcher.OnActivate(func(_, bundle string) { activated <- bundle })
+
+	var pipeFDs [2]int
+
+	err := unix.Pipe(pipeFDs[:])
+	if err != nil {
+		t.Fatalf("unix.Pipe: %v", err)
+	}
+
+	err = unix.SetNonblock(pipeFDs[0], true)
+	if err != nil {
+		t.Fatalf("SetNonblock: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = unix.Close(pipeFDs[0])
+		_ = unix.Close(pipeFDs[1])
+	})
+
+	var (
+		curMu sync.Mutex
+		cur   string
+	)
+
+	poller := &linuxAppWatcher{
+		identity: func(string) (string, bool) {
+			curMu.Lock()
+			defer curMu.Unlock()
+
+			if cur == "" {
+				return "", false
+			}
+
+			return cur, true
+		},
+		// A large interval ensures a passing test exercises the fd wake, not the
+		// safety-net re-sample.
+		subscribe: func(string) (int, bool) { return pipeFDs[0], true },
+		interval:  time.Hour,
+		watcher:   watcher,
+	}
+
+	poller.start()
+	t.Cleanup(poller.stop)
+
+	// Change focus, then signal via the fd.
+	curMu.Lock()
+	cur = appFirefox
+	curMu.Unlock()
+
+	_, err = unix.Write(pipeFDs[1], []byte{1})
+	if err != nil {
+		t.Fatalf("unix.Write: %v", err)
+	}
+
+	select {
+	case got := <-activated:
+		if got != appFirefox {
+			t.Fatalf("activate bundle = %q, want %q", got, appFirefox)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("event loop did not dispatch activate after fd signal")
+	}
 }
 
 func TestLinuxAppWatcherStartWithoutWatcherIsNoop(t *testing.T) {

--- a/internal/core/infra/platform/linux/system_linux_focus_events.go
+++ b/internal/core/infra/platform/linux/system_linux_focus_events.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+// internal/core/infra/platform/linux/system_linux_focus_events.go
+// Event-driven focused-application change notifications for Linux. Complements
+// FocusedAppID (which reports the current identity) by exposing a file
+// descriptor that becomes readable whenever the focused app changes, so the app
+// watcher can wake on focus changes instead of polling on a fixed interval.
+
+package linux
+
+// SubscribeFocusedApp returns a file descriptor that becomes readable whenever
+// the focused application changes on the given backend (as produced by
+// platform.LinuxBackend.String()). The app watcher blocks on this fd and
+// re-queries FocusedAppID on each wake instead of polling.
+//
+// ok is false when the backend exposes no such fd — GNOME/Mutter (no
+// focused-app source at all), unknown backends, or CGO-disabled builds — in
+// which case callers must fall back to polling FocusedAppID. The fd is owned by
+// the platform layer for the process lifetime; callers must poll it read-only
+// and must not close it.
+func SubscribeFocusedApp(backend string) (int, bool) {
+	switch backend {
+	case backendX11:
+		return x11FocusEventFD()
+	case backendWaylandWlroots, backendWaylandKDE:
+		return wlrootsFocusEventFD()
+	default:
+		return -1, false
+	}
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_cgo.go
@@ -230,6 +230,34 @@ func wlrootsFocusedAppIdentity() (string, string, bool) {
 	return C.GoString(&appBuf[0]), C.GoString(&titleBuf[0]), true
 }
 
+// wlrootsFocusEventFD returns a readable file descriptor that becomes ready
+// whenever the focused app_id changes, so the app watcher can wake on focus
+// changes instead of polling. ok is false when the wlroots client is
+// unavailable (GNOME/Mutter, no compositor) or exposes no pipe. The fd is owned
+// by the client and closed on disconnect; callers must not close it and must
+// poll it read-only.
+func wlrootsFocusEventFD() (int, bool) {
+	err := ensureWlrootsState()
+	if err != nil {
+		return -1, false
+	}
+
+	globalWlrootsState.mu.RLock()
+	defer globalWlrootsState.mu.RUnlock()
+
+	client := globalWlrootsState.client
+	if client == nil {
+		return -1, false
+	}
+
+	fd := C.neru_wlr_focus_event_fd(client) //nolint:nlreturn
+	if fd < 0 {
+		return -1, false
+	}
+
+	return int(fd), true
+}
+
 // wlrootsSetCursor mirrors an externally-injected pointer position (e.g. a
 // libei move on KDE) into the wlroots client's client-side cursor cache so
 // CursorPosition and screen resolution stay accurate.

--- a/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_wlroots_nocgo.go
@@ -128,6 +128,12 @@ func wlrootsFocusedAppIdentity() (string, string, bool) {
 	return "", "", false
 }
 
+// wlrootsFocusEventFD is unavailable without CGO — the foreign-toplevel client
+// lives in the CGO build. Callers fall back to polling.
+func wlrootsFocusEventFD() (int, bool) {
+	return -1, false
+}
+
 func wlrootsSetCursor(point image.Point) error {
 	_ = point
 

--- a/internal/core/infra/platform/linux/system_linux_x11.go
+++ b/internal/core/infra/platform/linux/system_linux_x11.go
@@ -4,6 +4,7 @@ package linux
 
 /*
 #cgo linux pkg-config: x11 xtst xrandr
+#cgo linux LDFLAGS: -lpthread
 #include <stdlib.h>
 #include "x11_system.h"
 */
@@ -14,6 +15,7 @@ import (
 	"image"
 	"os"
 	"strings"
+	"sync"
 	"unsafe"
 
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
@@ -136,6 +138,35 @@ func x11FocusedAppID() (string, bool) {
 	}
 
 	return appID, true
+}
+
+var (
+	x11FocusMonitorMu   sync.Mutex
+	x11FocusMonitorInst *C.NeruX11FocusMonitor
+)
+
+// x11FocusEventFD lazily starts the X11 focused-window monitor and returns a
+// readable fd that becomes ready when the active window changes. ok is false
+// when X11 is unavailable (DISPLAY unset, XOpenDisplay failed). The monitor is
+// process-global and persists for the daemon lifetime, matching the singleton
+// wlroots client; the fd is owned by the monitor and callers must not close it.
+func x11FocusEventFD() (int, bool) {
+	x11FocusMonitorMu.Lock()
+	defer x11FocusMonitorMu.Unlock()
+
+	if x11FocusMonitorInst == nil {
+		x11FocusMonitorInst = C.neru_x11_focus_monitor_start()
+		if x11FocusMonitorInst == nil {
+			return -1, false
+		}
+	}
+
+	fd := C.neru_x11_focus_monitor_fd(x11FocusMonitorInst) //nolint:nlreturn
+	if fd < 0 {
+		return -1, false
+	}
+
+	return int(fd), true
 }
 
 func x11Monitors() ([]x11Monitor, error) {

--- a/internal/core/infra/platform/linux/system_linux_x11_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_x11_nocgo.go
@@ -34,6 +34,12 @@ func x11FocusedAppID() (string, bool) {
 	return "", false
 }
 
+// x11FocusEventFD is unavailable without CGO — the focus monitor uses Xlib.
+// Callers fall back to polling.
+func x11FocusEventFD() (int, bool) {
+	return -1, false
+}
+
 func x11ActiveScreenBounds() (image.Rectangle, error) {
 	return image.Rectangle{}, derrors.New(
 		derrors.CodeNotSupported,

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -764,6 +764,7 @@ static const struct wl_registry_listener neru_wlr_registry_listener = {
 
 static void *neru_wlr_dispatch_loop(void *arg) {
 	NeruWlrootsClient *c = (NeruWlrootsClient *)arg;
+	int connection_lost = 0;
 	while (c->dispatch_running) {
 		// Non-blocking prepare-read under lock
 		pthread_mutex_lock(&c->display_mutex);
@@ -791,11 +792,13 @@ static void *neru_wlr_dispatch_loop(void *arg) {
 			// still needs to pthread_join this thread.
 			wl_display_cancel_read(c->display);
 			pthread_mutex_unlock(&c->display_mutex);
+			connection_lost = 1;
 			break;
 		}
 		if (pfd.revents & POLLIN) {
 			if (wl_display_read_events(c->display) < 0) {
 				pthread_mutex_unlock(&c->display_mutex);
+				connection_lost = 1;
 				break;
 			}
 			wl_display_dispatch_pending(c->display);
@@ -804,6 +807,18 @@ static void *neru_wlr_dispatch_loop(void *arg) {
 		}
 		pthread_mutex_unlock(&c->display_mutex);
 	}
+
+	// If the compositor connection broke (not a clean disconnect, which exits
+	// via dispatch_running == 0), close the focus pipe's write end so the Go
+	// reader observes POLLHUP and restores its polling fallback rather than
+	// silently degrading to the safety-sample interval. Set to -1 so
+	// neru_wlr_disconnect's later close is a no-op. Safe without extra locking:
+	// this thread is the only pipe writer and has stopped dispatching by here.
+	if (connection_lost && c->focus_pipe[1] >= 0) {
+		close(c->focus_pipe[1]);
+		c->focus_pipe[1] = -1;
+	}
+
 	return NULL;
 }
 

--- a/internal/core/infra/platform/linux/wlroots_client.c
+++ b/internal/core/infra/platform/linux/wlroots_client.c
@@ -496,6 +496,12 @@ static NeruToplevel *neru_wlr_find_toplevel(NeruWlrootsClient *c, struct zwlr_fo
 // state. The last activated toplevel carrying a non-empty app_id wins; if none
 // is activated the cache is cleared. Callers must hold toplevel_mutex.
 static void neru_wlr_recompute_focused(NeruWlrootsClient *c) {
+	// Snapshot the previous focused app_id so we only wake the Go watcher when
+	// the focused application actually changes (not on every `done` commit).
+	char prev[NERU_APP_ID_LEN];
+	strncpy(prev, c->focused_app_id, NERU_APP_ID_LEN - 1);
+	prev[NERU_APP_ID_LEN - 1] = '\0';
+
 	const char *found = NULL;
 	const char *found_title = NULL;
 	NeruToplevel *t;
@@ -513,6 +519,17 @@ static void neru_wlr_recompute_focused(NeruWlrootsClient *c) {
 	} else {
 		c->focused_app_id[0] = '\0';
 		c->focused_title[0] = '\0';
+	}
+
+	// Push a focus-change notification to Go. The write is non-blocking, so a
+	// full pipe (a byte still unread) simply drops this one via EAGAIN — the
+	// reader re-queries the live focused_app_id on the next wake regardless, so
+	// no state is lost. Runs under toplevel_mutex; a non-blocking write never
+	// stalls the dispatch thread.
+	if (c->focus_pipe_ready && strcmp(prev, c->focused_app_id) != 0) {
+		char b = 1;
+		ssize_t n = write(c->focus_pipe[1], &b, 1);
+		(void)n;
 	}
 }
 
@@ -821,6 +838,26 @@ NeruWlrootsClient *neru_wlr_connect(void) {
 	pthread_mutex_init(&c->toplevel_mutex, NULL);
 	c->toplevel_mutex_ready = 1;
 
+	// Self-pipe for pushing focus changes to Go. Created before the
+	// foreign-toplevel listener is bound below so the initial focus burst during
+	// the discovery roundtrip is signaled too. calloc zeroed focus_pipe, but 0
+	// is a valid fd, so reset to -1 before pipe() so cleanup can tell "unset"
+	// from "fd 0". A failure here is non-fatal: focus_pipe_ready stays 0 and Go
+	// falls back to polling.
+	c->focus_pipe[0] = -1;
+	c->focus_pipe[1] = -1;
+	if (pipe(c->focus_pipe) == 0) {
+		for (int i = 0; i < 2; i++) {
+			int flags = fcntl(c->focus_pipe[i], F_GETFL, 0);
+			if (flags != -1)
+				fcntl(c->focus_pipe[i], F_SETFL, flags | O_NONBLOCK);
+			int fdflags = fcntl(c->focus_pipe[i], F_GETFD, 0);
+			if (fdflags != -1)
+				fcntl(c->focus_pipe[i], F_SETFD, fdflags | FD_CLOEXEC);
+		}
+		c->focus_pipe_ready = 1;
+	}
+
 	c->registry = wl_display_get_registry(c->display);
 	wl_registry_add_listener(c->registry, &neru_wlr_registry_listener, c);
 
@@ -891,6 +928,19 @@ void neru_wlr_disconnect(NeruWlrootsClient *c) {
 	if (had_dispatch)
 		pthread_join(c->dispatch_thread, NULL);
 	pthread_mutex_destroy(&c->display_mutex);
+
+	// Close the focus self-pipe now that the dispatch thread (the only writer)
+	// has joined, so no write can race the close. Closing the read end makes any
+	// blocked Go reader observe EOF/POLLHUP.
+	if (c->focus_pipe_ready) {
+		if (c->focus_pipe[0] >= 0)
+			close(c->focus_pipe[0]);
+		if (c->focus_pipe[1] >= 0)
+			close(c->focus_pipe[1]);
+		c->focus_pipe[0] = -1;
+		c->focus_pipe[1] = -1;
+		c->focus_pipe_ready = 0;
+	}
 
 	if (c->vptr) {
 		zwlr_virtual_pointer_v1_destroy(c->vptr);
@@ -1306,4 +1356,10 @@ int neru_wlr_focused_app_identity(NeruWlrootsClient *c, char *app_out, int app_l
 	}
 	neru_wlr_toplevel_unlock(c);
 	return ok;
+}
+
+int neru_wlr_focus_event_fd(NeruWlrootsClient *c) {
+	if (!c || !c->focus_pipe_ready)
+		return -1;
+	return c->focus_pipe[0];
 }

--- a/internal/core/infra/platform/linux/wlroots_client.h
+++ b/internal/core/infra/platform/linux/wlroots_client.h
@@ -78,6 +78,15 @@ typedef struct NeruWlrootsClient {
 	pthread_mutex_t toplevel_mutex;
 	int toplevel_mutex_ready;
 
+	// focus_pipe is a self-pipe that pushes focus-change notifications to Go
+	// without a cross-thread callback: neru_wlr_recompute_focused writes one
+	// byte to focus_pipe[1] (the write end) whenever focused_app_id changes, and
+	// the Go app watcher blocks reading focus_pipe[0] (the read end, exposed via
+	// neru_wlr_focus_event_fd). Both ends are non-blocking so the dispatch
+	// thread never stalls under toplevel_mutex. Both are -1 until initialized.
+	int focus_pipe[2];
+	int focus_pipe_ready;
+
 	struct xkb_context *xkb_ctx;
 	struct xkb_keymap *xkb_keymap;
 	uint32_t mod_shift;
@@ -141,5 +150,12 @@ int neru_wlr_focused_app_id(NeruWlrootsClient *c, char *out, int out_len);
 // available, 0 otherwise. The title disambiguates multiple windows of the
 // focused application, which share an app_id.
 int neru_wlr_focused_app_identity(NeruWlrootsClient *c, char *app_out, int app_len, char *title_out, int title_len);
+
+// neru_wlr_focus_event_fd returns a readable file descriptor that becomes
+// readable whenever the focused app_id changes. Callers poll it, drain the
+// pending byte(s), then re-query neru_wlr_focused_app_id. Returns -1 when no
+// pipe is available. The fd is owned by the client and closed by
+// neru_wlr_disconnect; callers must not close it.
+int neru_wlr_focus_event_fd(NeruWlrootsClient *c);
 
 #endif /* WLROOTS_CLIENT_H */

--- a/internal/core/infra/platform/linux/x11_system.c
+++ b/internal/core/infra/platform/linux/x11_system.c
@@ -227,6 +227,8 @@ static void *neru_x11_focus_loop(void *arg) {
 	fds[1].fd = m->quit_pipe[0];
 	fds[1].events = POLLIN;
 
+	int connection_lost = 0;
+
 	for (;;) {
 		fds[0].revents = 0;
 		fds[1].revents = 0;
@@ -236,14 +238,16 @@ static void *neru_x11_focus_loop(void *arg) {
 			if (errno == EINTR) {
 				continue;
 			}
+			connection_lost = 1;
 			break;
 		}
 
 		if (fds[1].revents & POLLIN) {
-			break;  // stop() signaled.
+			break;  // stop() signaled — clean exit; stop() closes the pipes.
 		}
 
 		if (fds[0].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+			connection_lost = 1;
 			break;  // X connection died.
 		}
 
@@ -265,6 +269,17 @@ static void *neru_x11_focus_loop(void *arg) {
 			ssize_t n = write(m->event_pipe[1], &b, 1);
 			(void)n;  // Best-effort: EAGAIN means a prior byte is still unread.
 		}
+	}
+
+	// If the X connection died (as opposed to a clean stop), close the event
+	// pipe's write end so the Go reader observes POLLHUP and restores its
+	// polling fallback instead of silently degrading to the safety-sample
+	// interval. Cleared to -1 so a later stop()'s close is a no-op (no
+	// double-close of a possibly-reused fd). Safe without locking: only this
+	// thread writes the pipe, and it has stopped writing by here.
+	if (connection_lost && m->event_pipe[1] >= 0) {
+		close(m->event_pipe[1]);
+		m->event_pipe[1] = -1;
 	}
 
 	return NULL;

--- a/internal/core/infra/platform/linux/x11_system.c
+++ b/internal/core/infra/platform/linux/x11_system.c
@@ -5,8 +5,13 @@
 #include <X11/Xutil.h>
 #include <X11/extensions/XTest.h>
 #include <X11/extensions/Xrandr.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 Display *neru_x11_open_display(void) { return XOpenDisplay(NULL); }
 
@@ -166,4 +171,184 @@ void neru_x11_free_monitors(NeruX11Monitor *monitors, int count) {
 	}
 
 	free(monitors);
+}
+
+// ---------- Focused-window monitor ----------
+
+struct NeruX11FocusMonitor {
+	Display *display;
+	Window root;
+	Atom active_atom;
+	int event_pipe[2];  // [0] read (exposed to Go), [1] write (thread)
+	int quit_pipe[2];   // [0] read (thread), [1] write (stop)
+	pthread_t thread;
+	int thread_started;
+};
+
+static void neru_x11_set_nonblock_cloexec(int fd) {
+	if (fd < 0) {
+		return;
+	}
+
+	int flags = fcntl(fd, F_GETFL, 0);
+	if (flags != -1) {
+		fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+	}
+
+	int fdflags = fcntl(fd, F_GETFD, 0);
+	if (fdflags != -1) {
+		fcntl(fd, F_SETFD, fdflags | FD_CLOEXEC);
+	}
+}
+
+static void neru_x11_close_pipe(int pipe_fds[2]) {
+	if (pipe_fds[0] >= 0) {
+		close(pipe_fds[0]);
+		pipe_fds[0] = -1;
+	}
+	if (pipe_fds[1] >= 0) {
+		close(pipe_fds[1]);
+		pipe_fds[1] = -1;
+	}
+}
+
+// The monitor thread blocks in poll() on the X11 connection and the quit pipe.
+// The dedicated display is used only by this thread, so no XInitThreads is
+// needed. On each _NET_ACTIVE_WINDOW PropertyNotify it writes a byte to the
+// event pipe (coalescing a burst into one signal); the Go reader re-queries the
+// live active window on wake.
+static void *neru_x11_focus_loop(void *arg) {
+	NeruX11FocusMonitor *m = (NeruX11FocusMonitor *)arg;
+	int xfd = ConnectionNumber(m->display);
+
+	struct pollfd fds[2];
+	fds[0].fd = xfd;
+	fds[0].events = POLLIN;
+	fds[1].fd = m->quit_pipe[0];
+	fds[1].events = POLLIN;
+
+	for (;;) {
+		fds[0].revents = 0;
+		fds[1].revents = 0;
+
+		int pr = poll(fds, 2, -1);
+		if (pr < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			break;
+		}
+
+		if (fds[1].revents & POLLIN) {
+			break;  // stop() signaled.
+		}
+
+		if (fds[0].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+			break;  // X connection died.
+		}
+
+		if (!(fds[0].revents & POLLIN)) {
+			continue;
+		}
+
+		int changed = 0;
+		while (XPending(m->display) > 0) {
+			XEvent ev;
+			XNextEvent(m->display, &ev);
+			if (ev.type == PropertyNotify && ev.xproperty.window == m->root && ev.xproperty.atom == m->active_atom) {
+				changed = 1;
+			}
+		}
+
+		if (changed) {
+			char b = 1;
+			ssize_t n = write(m->event_pipe[1], &b, 1);
+			(void)n;  // Best-effort: EAGAIN means a prior byte is still unread.
+		}
+	}
+
+	return NULL;
+}
+
+NeruX11FocusMonitor *neru_x11_focus_monitor_start(void) {
+	if (getenv("DISPLAY") == NULL) {
+		return NULL;
+	}
+
+	Display *display = XOpenDisplay(NULL);
+	if (display == NULL) {
+		return NULL;
+	}
+
+	NeruX11FocusMonitor *m = calloc(1, sizeof(NeruX11FocusMonitor));
+	if (m == NULL) {
+		XCloseDisplay(display);
+		return NULL;
+	}
+
+	m->display = display;
+	m->root = neru_x11_root_window(display);
+	m->active_atom = XInternAtom(display, "_NET_ACTIVE_WINDOW", False);
+	m->event_pipe[0] = -1;
+	m->event_pipe[1] = -1;
+	m->quit_pipe[0] = -1;
+	m->quit_pipe[1] = -1;
+
+	if (pipe(m->event_pipe) != 0 || pipe(m->quit_pipe) != 0) {
+		neru_x11_close_pipe(m->event_pipe);
+		neru_x11_close_pipe(m->quit_pipe);
+		XCloseDisplay(display);
+		free(m);
+		return NULL;
+	}
+
+	neru_x11_set_nonblock_cloexec(m->event_pipe[0]);
+	neru_x11_set_nonblock_cloexec(m->event_pipe[1]);
+	neru_x11_set_nonblock_cloexec(m->quit_pipe[0]);
+	neru_x11_set_nonblock_cloexec(m->quit_pipe[1]);
+
+	XSelectInput(display, m->root, PropertyChangeMask);
+	XFlush(display);
+
+	if (pthread_create(&m->thread, NULL, neru_x11_focus_loop, m) != 0) {
+		neru_x11_close_pipe(m->event_pipe);
+		neru_x11_close_pipe(m->quit_pipe);
+		XCloseDisplay(display);
+		free(m);
+		return NULL;
+	}
+	m->thread_started = 1;
+
+	return m;
+}
+
+int neru_x11_focus_monitor_fd(NeruX11FocusMonitor *monitor) {
+	if (monitor == NULL) {
+		return -1;
+	}
+	return monitor->event_pipe[0];
+}
+
+void neru_x11_focus_monitor_stop(NeruX11FocusMonitor *monitor) {
+	if (monitor == NULL) {
+		return;
+	}
+
+	if (monitor->thread_started) {
+		char b = 1;
+		ssize_t n = write(monitor->quit_pipe[1], &b, 1);
+		(void)n;
+		pthread_join(monitor->thread, NULL);
+		monitor->thread_started = 0;
+	}
+
+	neru_x11_close_pipe(monitor->event_pipe);
+	neru_x11_close_pipe(monitor->quit_pipe);
+
+	if (monitor->display != NULL) {
+		XCloseDisplay(monitor->display);
+		monitor->display = NULL;
+	}
+
+	free(monitor);
 }

--- a/internal/core/infra/platform/linux/x11_system.h
+++ b/internal/core/infra/platform/linux/x11_system.h
@@ -26,4 +26,25 @@ char *neru_x11_get_window_class(Display *display, Window window);
 NeruX11Monitor *neru_x11_get_monitors(Display *display, int *count);
 void neru_x11_free_monitors(NeruX11Monitor *monitors, int count);
 
+// NeruX11FocusMonitor watches _NET_ACTIVE_WINDOW on the root window from a
+// dedicated X11 connection and thread, pushing a byte down a self-pipe whenever
+// the active window changes so callers can wake on focus changes rather than
+// polling. Opaque to Go; the fields live in x11_system.c.
+typedef struct NeruX11FocusMonitor NeruX11FocusMonitor;
+
+// neru_x11_focus_monitor_start opens a dedicated display, subscribes to
+// _NET_ACTIVE_WINDOW property changes on the root window, and spawns a thread
+// that signals its self-pipe on each change. Returns NULL when DISPLAY is unset
+// or X11 is otherwise unavailable. The returned monitor is owned by the caller
+// and released with neru_x11_focus_monitor_stop.
+NeruX11FocusMonitor *neru_x11_focus_monitor_start(void);
+
+// neru_x11_focus_monitor_fd returns a readable fd that becomes readable on
+// active-window changes, or -1. Owned by the monitor; callers must not close it.
+int neru_x11_focus_monitor_fd(NeruX11FocusMonitor *monitor);
+
+// neru_x11_focus_monitor_stop signals the thread to exit, joins it, and frees
+// the monitor. Safe to call with NULL.
+void neru_x11_focus_monitor_stop(NeruX11FocusMonitor *monitor);
+
 #endif /* X11_SYSTEM_H */

--- a/internal/core/ports/capability_presets.go
+++ b/internal/core/ports/capability_presets.go
@@ -81,9 +81,10 @@ func LinuxCapabilities() PlatformCapabilities {
 				"the wl-keyboard fallback cannot re-inject selectively)",
 		),
 		AppWatcher: supportedCapability(
-			"focused-app change detection via polling the WM_CLASS (X11) or " +
-				"wlr-foreign-toplevel app_id (Wayland wlroots/KDE); GNOME/Mutter " +
-				"exposes no focused-app source",
+			"focused-app change detection keyed on the WM_CLASS (X11) or " +
+				"wlr-foreign-toplevel app_id (Wayland wlroots/KDE), event-driven " +
+				"where the compositor/X11 exposes a focus-change signal and polling " +
+				"otherwise; GNOME/Mutter exposes no focused-app source",
 		),
 		// Default placeholder; the Linux SystemAdapter overrides this with
 		// the live-probed state (current color-scheme + source) on each


### PR DESCRIPTION
## Description

This PR makes per-app configuration on Linux apply the instant you switch windows by pushing focused-application changes through an event notification (Wayland wlroots/KDE and X11) instead of sampling on a fixed poll, falling back to polling where no such signal exists (GNOME/Mutter, CGO-disabled builds). It also documents the per-app identity string on Linux and how to find it.

## Related Issues

<!-- none -->

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The focus fd is a self-pipe (no cross-thread Go callbacks); the app watcher polls a `dup` of it so a future teardown of the process-lifetime pipe/monitor can't race an in-flight poll. Verified live on niri (wlroots): every window switch pushed the correct new `app_id` immediately. The X11 monitor path compiles and is unit/logic-covered but was not exercised on a native X11 session.