### PR TITLE
fix(darwin): keep cursor accurate and visible under Accessibility Zoom

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -487,6 +487,18 @@ detect_mission_control = true
 > [!NOTE]
 > Mission Control detection uses `CGWindowListCopyWindowInfo` to check for Dock overlay windows. It works on macOS 14+ (Sonoma) and 15+ (Sequoia/Tahoe). On macOS 13 and earlier, it looks for a "Mission Control" app window instead.
 
+### Accessibility Zoom: cursor lands in the wrong place
+
+**Symptom:** with macOS Accessibility Zoom (System Settings → Accessibility → Zoom) zoomed in, hints, grid movement, `move_mouse`, dragging and scrolling all send the cursor somewhere other than the target, while overlays still draw correctly. Or the cursor lands correctly but the magnified view does not follow it, so it disappears off screen.
+
+**Solution:** update to a build that posts synthetic mouse events at the session event tap and pans the zoom viewport itself. If you still see it, file an issue with your macOS version and zoom factor.
+
+> [!NOTE]
+> While zoomed in, the window server rewrites the location of pointer-motion events that enter at the HID event tap, reading the posted point as a coordinate in zoomed-viewport space (`landed = zoomOrigin + (posted - displayCenter) / zoomFactor`). Neru posts mouse events at the session tap instead, which sits above that transform, so positioning is exact whether or not zoom is engaged. Reading the cursor position was never affected.
+
+> [!NOTE]
+> Only real pointer-device movement pans the zoom viewport — no synthetic event does, at any event tap. `UAZoomChangeFocus` does not help either: it drives the keyboard-focus and text-insertion-point paths, so it is a no-op when zoom is set to follow the mouse pointer. Neru therefore pans the viewport itself before each cursor move, by the smallest amount that brings the target on screen, which reproduces the edge-panning behaviour of a real mouse. It uses SkyLight's zoom SPI resolved at runtime; if a future macOS removes it, cursor positioning stays correct and only the follow behaviour is lost.
+
 ---
 
 ## Keyboard Layout Issues

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -497,7 +497,7 @@ detect_mission_control = true
 > While zoomed in, the window server rewrites the location of pointer-motion events that enter at the HID event tap, reading the posted point as a coordinate in zoomed-viewport space (`landed = zoomOrigin + (posted - displayCenter) / zoomFactor`). Neru posts mouse events at the session tap instead, which sits above that transform, so positioning is exact whether or not zoom is engaged. Reading the cursor position was never affected.
 
 > [!NOTE]
-> Only real pointer-device movement pans the zoom viewport — no synthetic event does, at any event tap. `UAZoomChangeFocus` does not help either: it drives the keyboard-focus and text-insertion-point paths, so it is a no-op when zoom is set to follow the mouse pointer. Neru therefore pans the viewport itself before each cursor move, by the smallest amount that brings the target on screen, which reproduces the edge-panning behaviour of a real mouse. It uses SkyLight's zoom SPI resolved at runtime; if a future macOS removes it, cursor positioning stays correct and only the follow behaviour is lost.
+> Only real pointer-device movement pans the zoom viewport — no synthetic event does, at any event tap. `UAZoomChangeFocus` does not help either: it drives the keyboard-focus and text-insertion-point paths, so it is a no-op when zoom is set to follow the mouse pointer. Neru therefore pans the viewport itself before each cursor move, by the smallest amount that brings the target on screen, which reproduces the edge-panning behavior of a real mouse. It uses SkyLight's zoom SPI resolved at runtime; if a future macOS removes it, cursor positioning stays correct and only the follow behavior is lost.
 
 ---
 

--- a/internal/core/infra/accessibility/adapter_integration_darwin_test.go
+++ b/internal/core/infra/accessibility/adapter_integration_darwin_test.go
@@ -191,7 +191,10 @@ func TestAccessibilityAdapterIntegration(t *testing.T) {
 
 			// Landing on the point is not enough while zoomed in: the viewport
 			// has to have followed, or the cursor is correct but off screen.
-			if viewport, zoomed := darwinplatform.ZoomViewport(); zoomed && !landed.In(viewport) {
+			if viewport, zoomed := darwinplatform.ZoomViewportAt(
+				landed,
+			); zoomed &&
+				!landed.In(viewport) {
 				t.Errorf(
 					"MoveCursorToPoint(%v) landed at %v, outside the zoom viewport %v",
 					target, landed, viewport,

--- a/internal/core/infra/accessibility/adapter_integration_darwin_test.go
+++ b/internal/core/infra/accessibility/adapter_integration_darwin_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"image"
 	"testing"
+	"time"
 
 	"github.com/y3owk1n/neru/internal/core/infra/accessibility"
 	"github.com/y3owk1n/neru/internal/core/infra/logger"
@@ -92,6 +93,110 @@ func TestAccessibilityAdapterIntegration(t *testing.T) {
 		startPosErr = system.MoveCursorToPoint(ctx, target, true)
 		if startPosErr != nil {
 			t.Errorf("MoveCursorToPoint(bypassSmooth=true) error = %v, want nil", startPosErr)
+		}
+	})
+
+	t.Run("MoveCursorToPoint lands on the requested point", func(t *testing.T) {
+		// Regression guard for the macOS Accessibility Zoom interaction: when
+		// pointer-motion events are posted at the HID tap and the screen is
+		// zoomed in, the window server rewrites their location to
+		// zoomOrigin+(posted-displayCenter)/zoomFactor and the cursor lands
+		// hundreds of points away. Posting at the session tap is exact in both
+		// states, so this must hold whether or not zoom is engaged.
+		if darwinplatform.IsScreenZoomed() {
+			t.Log("Accessibility Zoom is engaged — exercising the zoomed path")
+		}
+
+		// Earlier subtests kick off a smooth-cursor animation. Let it settle,
+		// then give the worker a moment to drain any step already in flight, so
+		// a trailing animation frame cannot overwrite the positions asserted here.
+		idleErr := system.WaitForCursorIdle(ctx)
+		if idleErr != nil {
+			t.Fatalf("WaitForCursorIdle() error = %v, want nil", idleErr)
+		}
+
+		time.Sleep(50 * time.Millisecond)
+
+		screenBounds, screenBoundsErr := system.ScreenBounds(ctx)
+		if screenBoundsErr != nil {
+			t.Fatalf("ScreenBounds() error = %v, want nil", screenBoundsErr)
+		}
+
+		startPos, startPosErr := system.CursorPosition(ctx)
+		if startPosErr != nil {
+			t.Fatalf("CursorPosition() error = %v, want nil", startPosErr)
+		}
+
+		defer func() {
+			_ = system.MoveCursorToPoint(ctx, startPos, true)
+		}()
+
+		// Spread the targets across the display so that at least one of them
+		// falls outside any plausible zoom viewport.
+		width := screenBounds.Dx()
+		height := screenBounds.Dy()
+		targets := []image.Point{
+			{X: screenBounds.Min.X + width/10, Y: screenBounds.Min.Y + height/10},
+			{X: screenBounds.Min.X + width/2, Y: screenBounds.Min.Y + height/2},
+			{X: screenBounds.Min.X + width*4/5, Y: screenBounds.Min.Y + height*4/5},
+		}
+
+		// One point of slack absorbs the float64->int rounding in the bridge.
+		const tolerance = 1
+
+		// The window server reflects a posted move in the cursor state
+		// asynchronously, so poll rather than reading once. A cursor that is
+		// merely late converges within a frame or two; one that is mispositioned
+		// (the zoom bug lands it hundreds of points away) never converges.
+		const settleTimeout = 500 * time.Millisecond
+
+		for _, target := range targets {
+			moveErr := system.MoveCursorToPoint(ctx, target, true)
+			if moveErr != nil {
+				t.Fatalf("MoveCursorToPoint(%v) error = %v, want nil", target, moveErr)
+			}
+
+			var (
+				landed image.Point
+				offset image.Point
+			)
+
+			deadline := time.Now().Add(settleTimeout)
+
+			for {
+				var landedErr error
+
+				landed, landedErr = system.CursorPosition(ctx)
+				if landedErr != nil {
+					t.Fatalf("CursorPosition() error = %v, want nil", landedErr)
+				}
+
+				offset = landed.Sub(target)
+				if offset.X >= -tolerance && offset.X <= tolerance &&
+					offset.Y >= -tolerance && offset.Y <= tolerance {
+					break
+				}
+
+				if time.Now().After(deadline) {
+					t.Errorf(
+						"MoveCursorToPoint(%v) settled at %v, off by %v; zoomed=%t",
+						target, landed, offset, darwinplatform.IsScreenZoomed(),
+					)
+
+					break
+				}
+
+				time.Sleep(5 * time.Millisecond)
+			}
+
+			// Landing on the point is not enough while zoomed in: the viewport
+			// has to have followed, or the cursor is correct but off screen.
+			if viewport, zoomed := darwinplatform.ZoomViewport(); zoomed && !landed.In(viewport) {
+				t.Errorf(
+					"MoveCursorToPoint(%v) landed at %v, outside the zoom viewport %v",
+					target, landed, viewport,
+				)
+			}
 		}
 	})
 

--- a/internal/core/infra/accessibility/cursor_integration_darwin_test.go
+++ b/internal/core/infra/accessibility/cursor_integration_darwin_test.go
@@ -10,6 +10,7 @@ package accessibility_test
 
 import (
 	"image"
+	"sync"
 	"testing"
 	"time"
 
@@ -90,7 +91,7 @@ func TestSmoothCursorSettlesOnTarget(t *testing.T) {
 
 		// While zoomed in, landing on the point is only half the job — the
 		// viewport has to have followed, or the cursor is correct but off screen.
-		if viewport, ok := darwinplatform.ZoomViewport(); ok && !landed.In(viewport) {
+		if viewport, ok := darwinplatform.ZoomViewportAt(landed); ok && !landed.In(viewport) {
 			t.Errorf(
 				"MoveMouseSmooth(%v) landed at %v, outside the zoom viewport %v",
 				target, landed, viewport,
@@ -154,6 +155,83 @@ func TestDirectMoveOverridesInFlightAnimation(t *testing.T) {
 					landed.Sub(directTarget),
 				)
 			}
+		}
+	}
+}
+
+// TestConcurrentMovesKeepCursorInViewport runs cursor moves from several
+// goroutines at once and requires the cursor to end up somewhere visible.
+//
+// Cursor moves are not serialized across callers: every hotkey press dispatches
+// its own goroutine, repeat-while-held runs another, and IPC actions run on the
+// IPC goroutine. While zoomed, each move both pans the magnified region and
+// posts the cursor, and if two moves interleave those halves the cursor is left
+// at a correct coordinate outside the magnified region — a state nothing
+// corrects until the next move. The final position is naturally undefined when
+// callers race, but it must always be somewhere the user can see.
+func TestConcurrentMovesKeepCursorInViewport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	bounds := darwinplatform.ActiveScreenBounds()
+	if bounds.Empty() {
+		t.Skip("no active screen bounds")
+	}
+
+	if _, zoomed := darwinplatform.ZoomViewportAt(darwinplatform.CursorPosition()); !zoomed {
+		t.Log("Accessibility Zoom is not engaged — this only checks for races, not visibility")
+	}
+
+	startPos := darwinplatform.CursorPosition()
+	defer darwinplatform.MoveMouse(startPos, true)
+
+	// Far apart, so an interleaved pan and post cannot accidentally agree.
+	targets := []image.Point{
+		{X: bounds.Min.X + bounds.Dx()/10, Y: bounds.Min.Y + bounds.Dy()/10},
+		{X: bounds.Min.X + bounds.Dx()*9/10, Y: bounds.Min.Y + bounds.Dy()*9/10},
+		{X: bounds.Min.X + bounds.Dx()*9/10, Y: bounds.Min.Y + bounds.Dy()/10},
+		{X: bounds.Min.X + bounds.Dx()/10, Y: bounds.Min.Y + bounds.Dy()*9/10},
+	}
+
+	const (
+		rounds        = 40
+		movesPerRound = 6
+	)
+
+	for round := range rounds {
+		var movers sync.WaitGroup
+
+		for _, target := range targets {
+			movers.Add(1)
+
+			go func(destination image.Point) {
+				defer movers.Done()
+
+				for range movesPerRound {
+					darwinplatform.MoveMouse(destination, true)
+				}
+			}(target)
+		}
+
+		movers.Wait()
+		time.Sleep(80 * time.Millisecond)
+
+		landed := darwinplatform.CursorPosition()
+
+		viewport, zoomed := darwinplatform.ZoomViewportAt(landed)
+		if !zoomed {
+			continue
+		}
+
+		if !landed.In(viewport) {
+			t.Fatalf(
+				"round %d: concurrent moves left the cursor at %v, outside the magnified region %v — "+
+					"a pan and a post from different moves interleaved",
+				round,
+				landed,
+				viewport,
+			)
 		}
 	}
 }

--- a/internal/core/infra/accessibility/cursor_integration_darwin_test.go
+++ b/internal/core/infra/accessibility/cursor_integration_darwin_test.go
@@ -98,3 +98,62 @@ func TestSmoothCursorSettlesOnTarget(t *testing.T) {
 		}
 	}
 }
+
+// TestDirectMoveOverridesInFlightAnimation requires a direct move to win against
+// a smooth animation it interrupts.
+//
+// Canceling the animator closes its stop channel, but a worker that has already
+// passed its cancellation check can still post one more step. That step lands
+// after the direct move and drags the cursor back toward the abandoned target —
+// and, while zoomed, drags the zoom viewport with it, which nothing afterwards
+// corrects. The interruption is timing-dependent, so sweep the delay across a
+// whole animation rather than trying a single one.
+func TestDirectMoveOverridesInFlightAnimation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	bounds := darwinplatform.ActiveScreenBounds()
+	if bounds.Empty() {
+		t.Skip("no active screen bounds")
+	}
+
+	startPos := darwinplatform.CursorPosition()
+	defer darwinplatform.MoveMouse(startPos, true)
+
+	animationTarget := image.Point{
+		X: bounds.Min.X + bounds.Dx()*9/10,
+		Y: bounds.Min.Y + bounds.Dy()*9/10,
+	}
+	directTarget := image.Point{
+		X: bounds.Min.X + bounds.Dx()/6,
+		Y: bounds.Min.Y + bounds.Dy()/4,
+	}
+
+	const (
+		maxInterruptDelayMs = 40
+		repeats             = 2
+	)
+
+	for delayMs := range maxInterruptDelayMs + 1 {
+		for range repeats {
+			darwinplatform.MoveMouseSmooth(animationTarget, 20, eventMouseMoved)
+			time.Sleep(time.Duration(delayMs) * time.Millisecond)
+			darwinplatform.MoveMouse(directTarget, true)
+
+			time.Sleep(60 * time.Millisecond)
+
+			landed := darwinplatform.CursorPosition()
+			if landed != directTarget {
+				t.Fatalf(
+					"interrupting a smooth move after %dms left the cursor at %v, want %v (off by %v) — "+
+						"a canceled animation step landed after the direct move",
+					delayMs,
+					landed,
+					directTarget,
+					landed.Sub(directTarget),
+				)
+			}
+		}
+	}
+}

--- a/internal/core/infra/accessibility/cursor_zoom_integration_darwin_test.go
+++ b/internal/core/infra/accessibility/cursor_zoom_integration_darwin_test.go
@@ -1,0 +1,100 @@
+//go:build integration && darwin
+
+// This exercises the darwin platform package rather than the accessibility
+// adapter, but it lives here on purpose: it drives the one global cursor, and so
+// does TestAccessibilityAdapterIntegration. Tests in a single package run
+// sequentially, whereas `go test ./...` runs packages concurrently, so splitting
+// the two across packages makes them fight over the cursor and fail randomly.
+
+package accessibility_test
+
+import (
+	"image"
+	"testing"
+	"time"
+
+	darwinplatform "github.com/y3owk1n/neru/internal/core/infra/platform/darwin"
+)
+
+// kCGEventMouseMoved, as passed through to the CGEvent bridge.
+const eventMouseMoved = 5
+
+// TestSmoothCursorSettlesOnTarget drives the smooth-cursor animator to a spread
+// of absolute points and requires it to settle exactly on each one.
+//
+// This is the counterpart to the direct-move guard in
+// TestAccessibilityAdapterIntegration, and it matters most while macOS
+// Accessibility Zoom is engaged: the animator posts a move per step and each
+// step first pans the zoom viewport, which itself drags the cursor. The two have
+// to converge rather than fight, and the cursor has to end up somewhere the user
+// can actually see.
+func TestSmoothCursorSettlesOnTarget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	zoomed := darwinplatform.IsScreenZoomed()
+	if zoomed {
+		t.Log("Accessibility Zoom is engaged — exercising the zoomed path")
+	}
+
+	bounds := darwinplatform.ActiveScreenBounds()
+	if bounds.Empty() {
+		t.Skip("no active screen bounds")
+	}
+
+	startPos := darwinplatform.CursorPosition()
+	defer darwinplatform.MoveMouse(startPos, true)
+
+	width := bounds.Dx()
+	height := bounds.Dy()
+	targets := []image.Point{
+		{X: bounds.Min.X + width/10, Y: bounds.Min.Y + height/10},
+		{X: bounds.Min.X + width*9/10, Y: bounds.Min.Y + height*9/10},
+		{X: bounds.Min.X + width/2, Y: bounds.Min.Y + height/2},
+		{X: bounds.Min.X + width/10, Y: bounds.Min.Y + height*9/10},
+	}
+
+	const (
+		tolerance     = 1
+		settleTimeout = 3 * time.Second
+	)
+
+	for _, target := range targets {
+		darwinplatform.MoveMouseSmooth(target, 20, eventMouseMoved)
+
+		var landed image.Point
+
+		deadline := time.Now().Add(settleTimeout)
+
+		for {
+			landed = darwinplatform.CursorPosition()
+
+			offset := landed.Sub(target)
+			if offset.X >= -tolerance && offset.X <= tolerance &&
+				offset.Y >= -tolerance && offset.Y <= tolerance {
+				break
+			}
+
+			if time.Now().After(deadline) {
+				t.Errorf(
+					"MoveMouseSmooth(%v) settled at %v, off by %v; zoomed=%t",
+					target, landed, offset, zoomed,
+				)
+
+				break
+			}
+
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		// While zoomed in, landing on the point is only half the job — the
+		// viewport has to have followed, or the cursor is correct but off screen.
+		if viewport, ok := darwinplatform.ZoomViewport(); ok && !landed.In(viewport) {
+			t.Errorf(
+				"MoveMouseSmooth(%v) landed at %v, outside the zoom viewport %v",
+				target, landed, viewport,
+			)
+		}
+	}
+}

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -314,4 +314,21 @@ CGRect NeruGetScreenBoundsByName(const char *name, int *found);
 /// @return Current cursor position
 CGPoint NeruGetCurrentCursorPosition(void);
 
+/// Report whether the macOS Accessibility Zoom feature is currently zoomed in
+/// @return true when the screen is magnified by Accessibility Zoom
+bool NeruIsScreenZoomed(void);
+
+/// Get the on-screen region of the Accessibility Zoom viewport
+/// @param outViewport Receives the visible rectangle in global CG coordinates
+/// @return 1 when zoomed in and outViewport was written, 0 otherwise
+int NeruGetZoomViewport(CGRect *outViewport);
+
+/// Pan the Accessibility Zoom viewport by the smallest amount that brings the
+/// given point on screen, mirroring what dragging a real mouse into the edge of
+/// the viewport does. No-op when not zoomed in.
+/// @param target Point that must end up visible, in global CG coordinates
+/// @note Panning moves the cursor with the viewport, so call this *before*
+///       positioning the cursor, never after.
+void NeruEnsureZoomViewportContainsPoint(CGPoint target);
+
 #endif  // ACCESSIBILITY_H

--- a/internal/core/infra/platform/darwin/accessibility.h
+++ b/internal/core/infra/platform/darwin/accessibility.h
@@ -318,10 +318,11 @@ CGPoint NeruGetCurrentCursorPosition(void);
 /// @return true when the screen is magnified by Accessibility Zoom
 bool NeruIsScreenZoomed(void);
 
-/// Get the on-screen region of the Accessibility Zoom viewport
+/// Get the on-screen region of the Accessibility Zoom viewport covering a point
+/// @param point Point in global CG coordinates, used to pick the display
 /// @param outViewport Receives the visible rectangle in global CG coordinates
-/// @return 1 when zoomed in and outViewport was written, 0 otherwise
-int NeruGetZoomViewport(CGRect *outViewport);
+/// @return 1 when that display is magnified and outViewport was written, 0 otherwise
+int NeruGetZoomViewportForPoint(CGPoint point, CGRect *outViewport);
 
 /// Pan the Accessibility Zoom viewport by the smallest amount that brings the
 /// given point on screen, mirroring what dragging a real mouse into the edge of

--- a/internal/core/infra/platform/darwin/accessibility_constants.h
+++ b/internal/core/infra/platform/darwin/accessibility_constants.h
@@ -12,6 +12,31 @@
 extern "C" {
 #endif
 
+#pragma mark - Event Posting Constants
+
+/// Tap location for every synthetic mouse event we post.
+///
+/// This is deliberately the session tap rather than the HID tap. When the macOS
+/// Accessibility Zoom feature is zoomed in, the window server rewrites the
+/// location of pointer-motion events entering at the HID tap, treating the
+/// posted point as a coordinate in zoomed-viewport space:
+///
+///     landed = zoomOrigin + (posted - displayCenter) / zoomFactor
+///
+/// so an absolute move lands hundreds of points away from its target and every
+/// cursor-driven feature (hints, grid, move_mouse, drag, scroll) misses. Events
+/// posted at the session tap enter above that transform and land exactly on the
+/// requested point whether or not zoom is active.
+static const CGEventTapLocation kNeruMouseEventTapLocation = kCGSessionEventTap;
+
+#pragma mark - Accessibility Zoom Constants
+
+/// Margin kept between a point and the edge of the Accessibility Zoom viewport
+/// when panning to reveal it (points, in unmagnified global coordinates).
+/// Without it the point lands exactly on the boundary and the cursor drawn
+/// there is half clipped.
+static const CGFloat kNeruZoomViewportMarginPoints = 8.0;
+
 #pragma mark - Mouse Timing Constants
 
 /// Delay between mouse down and mouse up events during a click (seconds)

--- a/internal/core/infra/platform/darwin/accessibility_mouse_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_mouse_darwin.m
@@ -15,32 +15,46 @@
 
 #pragma mark - Mouse Functions
 
-/// Lock making "pan the zoom viewport, then post the move" indivisible.
+/// Lock making "pan the zoom viewport, then post the event" indivisible.
 ///
-/// Cursor moves are issued concurrently — each hotkey press dispatches its own
-/// goroutine, repeat-while-held runs another, and IPC actions run on the IPC
-/// goroutine — and those paths do not share a lock. Two interleaved moves could
-/// otherwise pan for one target and then post the other, leaving the cursor at a
-/// correct coordinate but outside the magnified region, where nothing corrects
-/// it until the next move.
+/// Cursor operations are issued concurrently — each hotkey press dispatches its
+/// own goroutine, repeat-while-held runs another, and IPC actions run on the IPC
+/// goroutine — and those paths do not share a lock. Two interleaved operations
+/// could otherwise pan for one target and then post the other, leaving the
+/// cursor at a correct coordinate but outside the magnified region, where
+/// nothing corrects it until the next move.
+///
+/// Every posted event that carries a position takes this, button events
+/// included: they reposition the cursor just as a move does, so a click whose
+/// button events escaped the lock could still land outside the magnified region
+/// even though the move preceding it was itself atomic. Each pan/post pair being
+/// individually consistent is what guarantees that whichever one happens to go
+/// last leaves the cursor and the viewport agreeing.
 static os_unfair_lock mouseMoveLock = OS_UNFAIR_LOCK_INIT;
+
+/// Pan the zoom viewport to reveal a point and post an event positioned there
+/// @param event Event to post; its location must already be set to position
+/// @param position Position the event acts at
+static void postPositionedEventLocked(CGEventRef event, CGPoint position) {
+	os_unfair_lock_lock(&mouseMoveLock);
+
+	NeruEnsureZoomViewportContainsPoint(position);
+	CGEventPost(kNeruMouseEventTapLocation, event);
+
+	os_unfair_lock_unlock(&mouseMoveLock);
+}
 
 /// Pan the zoom viewport to reveal a point and post a mouse move there
 /// @param position Target position
 /// @param eventType CGEvent type (kCGEventMouseMoved or kCGEventLeftMouseDragged)
 static void postMouseMoveLocked(CGPoint position, CGEventType eventType) {
-	os_unfair_lock_lock(&mouseMoveLock);
-
-	NeruEnsureZoomViewportContainsPoint(position);
-
 	CGEventRef move = CGEventCreateMouseEvent(NULL, eventType, position, kCGMouseButtonLeft);
-	if (move) {
-		CGEventSetFlags(move, 0);
-		CGEventPost(kNeruMouseEventTapLocation, move);
-		CFRelease(move);
-	}
+	if (!move)
+		return;
 
-	os_unfair_lock_unlock(&mouseMoveLock);
+	CGEventSetFlags(move, 0);
+	postPositionedEventLocked(move, position);
+	CFRelease(move);
 }
 
 /// Move mouse cursor to position with specified event type
@@ -77,7 +91,7 @@ int NeruPerformLeftMouseUpAtCursor(void) {
 
 	// Clear all modifier flags to ensure clean mouse up
 	CGEventSetFlags(up, 0);
-	CGEventPost(kNeruMouseEventTapLocation, up);
+	postPositionedEventLocked(up, currentPos);
 	CFRelease(up);
 
 	CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseClickProcessingDelay, false);
@@ -126,10 +140,10 @@ static int performClickAtPosition(
 
 	// Post mouse down, allow the system to process it, then post mouse up.
 	// Give the event loop a short moment to register the down event before sending up.
-	CGEventPost(kNeruMouseEventTapLocation, down);
+	postPositionedEventLocked(down, pos);
 	CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseClickDownUpDelay, false);
 
-	CGEventPost(kNeruMouseEventTapLocation, up);
+	postPositionedEventLocked(up, pos);
 	CFRelease(down);
 	CFRelease(up);
 
@@ -224,10 +238,10 @@ int NeruPerformLeftClickAtPosition(CGPoint position, bool restoreCursor, CGEvent
 
 	// Post mouse down and allow a short moment before posting mouse up to ensure
 	// the system attributes the down/up pair to the target location.
-	CGEventPost(kNeruMouseEventTapLocation, down);
+	postPositionedEventLocked(down, position);
 	CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseClickDownUpDelay, false);
 
-	CGEventPost(kNeruMouseEventTapLocation, up);
+	postPositionedEventLocked(up, position);
 	CFRelease(down);
 	CFRelease(up);
 
@@ -270,7 +284,7 @@ int NeruPerformLeftMouseDownAtPosition(CGPoint position, CGEventFlags flags) {
 
 	// Set modifier flags (0 = no modifiers for clean mouse down)
 	CGEventSetFlags(down, flags);
-	CGEventPost(kNeruMouseEventTapLocation, down);
+	postPositionedEventLocked(down, position);
 	CFRelease(down);
 
 	CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseClickProcessingDelay, false);
@@ -290,7 +304,7 @@ int NeruPerformLeftMouseUpAtPosition(CGPoint position, CGEventFlags flags) {
 
 	// Set modifier flags (0 = no modifiers for clean mouse up)
 	CGEventSetFlags(up, flags);
-	CGEventPost(kNeruMouseEventTapLocation, up);
+	postPositionedEventLocked(up, position);
 	CFRelease(up);
 
 	CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseClickProcessingDelay, false);

--- a/internal/core/infra/platform/darwin/accessibility_mouse_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_mouse_darwin.m
@@ -15,10 +15,22 @@
 
 #pragma mark - Mouse Functions
 
-/// Move mouse cursor to position with specified event type
+/// Lock making "pan the zoom viewport, then post the move" indivisible.
+///
+/// Cursor moves are issued concurrently — each hotkey press dispatches its own
+/// goroutine, repeat-while-held runs another, and IPC actions run on the IPC
+/// goroutine — and those paths do not share a lock. Two interleaved moves could
+/// otherwise pan for one target and then post the other, leaving the cursor at a
+/// correct coordinate but outside the magnified region, where nothing corrects
+/// it until the next move.
+static os_unfair_lock mouseMoveLock = OS_UNFAIR_LOCK_INIT;
+
+/// Pan the zoom viewport to reveal a point and post a mouse move there
 /// @param position Target position
 /// @param eventType CGEvent type (kCGEventMouseMoved or kCGEventLeftMouseDragged)
-void NeruMoveMouseWithType(CGPoint position, CGEventType eventType) {
+static void postMouseMoveLocked(CGPoint position, CGEventType eventType) {
+	os_unfair_lock_lock(&mouseMoveLock);
+
 	NeruEnsureZoomViewportContainsPoint(position);
 
 	CGEventRef move = CGEventCreateMouseEvent(NULL, eventType, position, kCGMouseButtonLeft);
@@ -26,24 +38,26 @@ void NeruMoveMouseWithType(CGPoint position, CGEventType eventType) {
 		CGEventSetFlags(move, 0);
 		CGEventPost(kNeruMouseEventTapLocation, move);
 		CFRelease(move);
-
-		CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseMoveDelay, false);
 	}
+
+	os_unfair_lock_unlock(&mouseMoveLock);
+}
+
+/// Move mouse cursor to position with specified event type
+/// @param position Target position
+/// @param eventType CGEvent type (kCGEventMouseMoved or kCGEventLeftMouseDragged)
+void NeruMoveMouseWithType(CGPoint position, CGEventType eventType) {
+	postMouseMoveLocked(position, eventType);
+
+	// Deliberately outside the lock: this spins the run loop for milliseconds,
+	// and serialising that would stall every other cursor path.
+	CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseMoveDelay, false);
 }
 
 /// Post a single mouse move event (non-blocking, for async animation)
 /// @param position Target position
 /// @param eventType CGEvent type (kCGEventMouseMoved or kCGEventLeftMouseDragged)
-void NeruPostMouseMoveEvent(CGPoint position, CGEventType eventType) {
-	NeruEnsureZoomViewportContainsPoint(position);
-
-	CGEventRef move = CGEventCreateMouseEvent(NULL, eventType, position, kCGMouseButtonLeft);
-	if (move) {
-		CGEventSetFlags(move, 0);
-		CGEventPost(kNeruMouseEventTapLocation, move);
-		CFRelease(move);
-	}
-}
+void NeruPostMouseMoveEvent(CGPoint position, CGEventType eventType) { postMouseMoveLocked(position, eventType); }
 
 #pragma mark - Mouse Action Functions
 

--- a/internal/core/infra/platform/darwin/accessibility_mouse_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_mouse_darwin.m
@@ -19,10 +19,12 @@
 /// @param position Target position
 /// @param eventType CGEvent type (kCGEventMouseMoved or kCGEventLeftMouseDragged)
 void NeruMoveMouseWithType(CGPoint position, CGEventType eventType) {
+	NeruEnsureZoomViewportContainsPoint(position);
+
 	CGEventRef move = CGEventCreateMouseEvent(NULL, eventType, position, kCGMouseButtonLeft);
 	if (move) {
 		CGEventSetFlags(move, 0);
-		CGEventPost(kCGHIDEventTap, move);
+		CGEventPost(kNeruMouseEventTapLocation, move);
 		CFRelease(move);
 
 		CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseMoveDelay, false);
@@ -33,10 +35,12 @@ void NeruMoveMouseWithType(CGPoint position, CGEventType eventType) {
 /// @param position Target position
 /// @param eventType CGEvent type (kCGEventMouseMoved or kCGEventLeftMouseDragged)
 void NeruPostMouseMoveEvent(CGPoint position, CGEventType eventType) {
+	NeruEnsureZoomViewportContainsPoint(position);
+
 	CGEventRef move = CGEventCreateMouseEvent(NULL, eventType, position, kCGMouseButtonLeft);
 	if (move) {
 		CGEventSetFlags(move, 0);
-		CGEventPost(kCGHIDEventTap, move);
+		CGEventPost(kNeruMouseEventTapLocation, move);
 		CFRelease(move);
 	}
 }
@@ -59,7 +63,7 @@ int NeruPerformLeftMouseUpAtCursor(void) {
 
 	// Clear all modifier flags to ensure clean mouse up
 	CGEventSetFlags(up, 0);
-	CGEventPost(kCGHIDEventTap, up);
+	CGEventPost(kNeruMouseEventTapLocation, up);
 	CFRelease(up);
 
 	CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseClickProcessingDelay, false);
@@ -108,10 +112,10 @@ static int performClickAtPosition(
 
 	// Post mouse down, allow the system to process it, then post mouse up.
 	// Give the event loop a short moment to register the down event before sending up.
-	CGEventPost(kCGHIDEventTap, down);
+	CGEventPost(kNeruMouseEventTapLocation, down);
 	CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseClickDownUpDelay, false);
 
-	CGEventPost(kCGHIDEventTap, up);
+	CGEventPost(kNeruMouseEventTapLocation, up);
 	CFRelease(down);
 	CFRelease(up);
 
@@ -206,10 +210,10 @@ int NeruPerformLeftClickAtPosition(CGPoint position, bool restoreCursor, CGEvent
 
 	// Post mouse down and allow a short moment before posting mouse up to ensure
 	// the system attributes the down/up pair to the target location.
-	CGEventPost(kCGHIDEventTap, down);
+	CGEventPost(kNeruMouseEventTapLocation, down);
 	CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseClickDownUpDelay, false);
 
-	CGEventPost(kCGHIDEventTap, up);
+	CGEventPost(kNeruMouseEventTapLocation, up);
 	CFRelease(down);
 	CFRelease(up);
 
@@ -252,7 +256,7 @@ int NeruPerformLeftMouseDownAtPosition(CGPoint position, CGEventFlags flags) {
 
 	// Set modifier flags (0 = no modifiers for clean mouse down)
 	CGEventSetFlags(down, flags);
-	CGEventPost(kCGHIDEventTap, down);
+	CGEventPost(kNeruMouseEventTapLocation, down);
 	CFRelease(down);
 
 	CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseClickProcessingDelay, false);
@@ -272,7 +276,7 @@ int NeruPerformLeftMouseUpAtPosition(CGPoint position, CGEventFlags flags) {
 
 	// Set modifier flags (0 = no modifiers for clean mouse up)
 	CGEventSetFlags(up, flags);
-	CGEventPost(kCGHIDEventTap, up);
+	CGEventPost(kNeruMouseEventTapLocation, up);
 	CFRelease(up);
 
 	CFRunLoopRunInMode(kCFRunLoopDefaultMode, kNeruMouseClickProcessingDelay, false);

--- a/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_screen_darwin.m
@@ -6,7 +6,9 @@
 //
 
 #import "accessibility.h"
+#import "accessibility_constants.h"
 
+#import <ApplicationServices/ApplicationServices.h>
 #import <Cocoa/Cocoa.h>
 
 #pragma mark - Mission Control Detection State
@@ -157,7 +159,7 @@ int NeruScrollAtPoint(CGPoint pos, int deltaX, int deltaY) {
 			return 0;
 
 		CGEventSetLocation(scrollEvent, pos);
-		CGEventPost(kCGHIDEventTap, scrollEvent);
+		CGEventPost(kNeruMouseEventTapLocation, scrollEvent);
 		CFRelease(scrollEvent);
 		return 1;
 	}
@@ -501,6 +503,12 @@ CGRect NeruGetScreenBoundsByName(const char *name, int *found) {
 		return cgFrame;
 	}
 }
+
+/// Report whether the macOS Accessibility Zoom feature is currently zoomed in
+/// @return true when the screen is magnified by Accessibility Zoom
+/// @note Used for diagnostics — cursor positioning is zoom-independent because
+///       synthetic mouse events are posted at kNeruMouseEventTapLocation.
+bool NeruIsScreenZoomed(void) { return UAZoomEnabled(); }
 
 /// Get current cursor position
 /// @return Current cursor position

--- a/internal/core/infra/platform/darwin/accessibility_zoom_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_zoom_darwin.m
@@ -26,23 +26,36 @@
 // SPI. Those symbols are resolved with dlsym and every entry point degrades to
 // "leave the viewport alone" when they are missing, so a future macOS that drops
 // them costs the follow behavior and nothing else.
+//
+// The per-display entry points are the ones to use. Zoom magnifies one display
+// at a time, and the display-agnostic variants report whichever display the
+// pointer is over while clamping a requested origin against the bounding box of
+// all displays. With a second display stacked below the main one that lower
+// bound sits well inside the main display, leaving a band at its top edge that
+// can never be brought into view. The per-display variants clamp against the
+// display itself, which is both correct and what the geometry below assumes.
 
 typedef int NeruCGSConnectionID;
 
 typedef NeruCGSConnectionID (*NeruSLSMainConnectionIDFn)(void);
 
-/// Reads the zoom viewport center, magnification and smoothing flag.
-typedef CGError (*NeruSLSGetZoomParametersFn)(
-    NeruCGSConnectionID cid, CGPoint *outOrigin, double *outFactor, bool *outSmoothing);
+/// Reads one display's zoom viewport center, magnification and smoothing flag.
+typedef CGError (*NeruSLSGetZoomParametersForDisplayFn)(
+    NeruCGSConnectionID cid, CGDirectDisplayID display, CGPoint *outOrigin, double *outFactor, bool *outSmoothing);
 
-/// Moves the zoom viewport. The trailing two arguments are undocumented; zero
-/// reproduces the behavior of the system's own panning.
-typedef CGError (*NeruSLSSetZoomParametersFn)(
-    NeruCGSConnectionID cid, CGPoint *origin, double factor, int smoothing, int reserved, double reserved2);
+/// Moves one display's zoom viewport. The two reserved arguments are
+/// undocumented; zero reproduces the behavior of the system's own panning.
+///
+/// @note smoothing is persistent user state rather than a per-call option —
+///       passing anything other than the value just read from the getter
+///       silently rewrites the user's preference.
+typedef CGError (*NeruSLSSetZoomParametersForDisplayFn)(
+    NeruCGSConnectionID cid, CGDirectDisplayID display, CGPoint *origin, int smoothing, int reserved, double factor,
+    double reserved2);
 
 static NeruCGSConnectionID gNeruZoomConnection = 0;
-static NeruSLSGetZoomParametersFn gNeruGetZoomParameters = NULL;
-static NeruSLSSetZoomParametersFn gNeruSetZoomParameters = NULL;
+static NeruSLSGetZoomParametersForDisplayFn gNeruGetZoomParametersForDisplay = NULL;
+static NeruSLSSetZoomParametersForDisplayFn gNeruSetZoomParametersForDisplay = NULL;
 static bool gNeruZoomSPIAvailable = false;
 
 /// Resolve the SkyLight zoom SPI once
@@ -54,10 +67,12 @@ static void neruLoadZoomSPI(void) {
 			return;
 
 		NeruSLSMainConnectionIDFn mainConnectionID = (NeruSLSMainConnectionIDFn)dlsym(skyLight, "SLSMainConnectionID");
-		gNeruGetZoomParameters = (NeruSLSGetZoomParametersFn)dlsym(skyLight, "SLSGetZoomParameters");
-		gNeruSetZoomParameters = (NeruSLSSetZoomParametersFn)dlsym(skyLight, "SLSSetZoomParameters");
+		gNeruGetZoomParametersForDisplay =
+		    (NeruSLSGetZoomParametersForDisplayFn)dlsym(skyLight, "SLSGetZoomParametersForDisplay");
+		gNeruSetZoomParametersForDisplay =
+		    (NeruSLSSetZoomParametersForDisplayFn)dlsym(skyLight, "SLSSetZoomParametersForDisplay");
 
-		if (!mainConnectionID || !gNeruGetZoomParameters || !gNeruSetZoomParameters)
+		if (!mainConnectionID || !gNeruGetZoomParametersForDisplay || !gNeruSetZoomParametersForDisplay)
 			return;
 
 		gNeruZoomConnection = mainConnectionID();
@@ -65,59 +80,78 @@ static void neruLoadZoomSPI(void) {
 	});
 }
 
-/// Read the current zoom viewport center and magnification
-/// @param outOrigin Receives the viewport center in global CG coordinates
-/// @param outFactor Receives the magnification factor
-/// @param outSmoothing Receives the user's smoothing preference
-/// @return true when the screen is zoomed in and the values are usable
-static bool neruCurrentZoomParameters(CGPoint *outOrigin, double *outFactor, bool *outSmoothing) {
-	if (!UAZoomEnabled())
-		return false;
-
-	neruLoadZoomSPI();
-	if (!gNeruZoomSPIAvailable)
-		return false;
-
-	CGPoint origin = CGPointZero;
-	double factor = 0.0;
-	bool smoothing = false;
-
-	if (gNeruGetZoomParameters(gNeruZoomConnection, &origin, &factor, &smoothing) != kCGErrorSuccess)
-		return false;
-
-	// A factor of 1 means zoomed all the way out — there is no viewport to pan.
-	if (factor <= 1.0)
-		return false;
-
-	*outOrigin = origin;
-	*outFactor = factor;
-	*outSmoothing = smoothing;
-
-	return true;
-}
-
-/// Bounds of the display the zoom viewport currently sits on
-/// @param origin Viewport center in global CG coordinates
-/// @return Display bounds, falling back to the main display
-static CGRect neruZoomDisplayBounds(CGPoint origin) {
+/// Find the display a point falls on
+/// @param point Point in global CG coordinates
+/// @param outBounds Receives that display's bounds
+/// @return The display, or kCGNullDirectDisplay when the point is off-screen
+static CGDirectDisplayID neruDisplayForPoint(CGPoint point, CGRect *outBounds) {
 	CGDirectDisplayID display = kCGNullDirectDisplay;
 	uint32_t matched = 0;
 
-	if (CGGetDisplaysWithPoint(origin, 1, &display, &matched) == kCGErrorSuccess && matched > 0)
-		return CGDisplayBounds(display);
+	if (CGGetDisplaysWithPoint(point, 1, &display, &matched) != kCGErrorSuccess || matched == 0)
+		return kCGNullDirectDisplay;
 
-	return CGDisplayBounds(CGMainDisplayID());
+	if (outBounds)
+		*outBounds = CGDisplayBounds(display);
+
+	return display;
 }
 
-int NeruGetZoomViewport(CGRect *outViewport) {
+/// Read the zoom viewport of the display a point falls on
+/// @param point Point in global CG coordinates
+/// @param outBounds Receives the display's bounds
+/// @param outOrigin Receives the viewport center in global CG coordinates
+/// @param outFactor Receives the magnification factor
+/// @param outSmoothing Receives the user's smoothing preference, to be passed back unchanged
+/// @return The display when it is magnified, kCGNullDirectDisplay otherwise
+static CGDirectDisplayID neruZoomedDisplayForPoint(
+    CGPoint point, CGRect *outBounds, CGPoint *outOrigin, double *outFactor, bool *outSmoothing) {
+	if (!UAZoomEnabled())
+		return kCGNullDirectDisplay;
+
+	neruLoadZoomSPI();
+	if (!gNeruZoomSPIAvailable)
+		return kCGNullDirectDisplay;
+
+	CGRect bounds = CGRectZero;
+	CGDirectDisplayID display = neruDisplayForPoint(point, &bounds);
+	if (display == kCGNullDirectDisplay)
+		return kCGNullDirectDisplay;
+
 	CGPoint origin = CGPointZero;
 	double factor = 0.0;
 	bool smoothing = false;
 
-	if (!neruCurrentZoomParameters(&origin, &factor, &smoothing))
+	if (gNeruGetZoomParametersForDisplay(gNeruZoomConnection, display, &origin, &factor, &smoothing) != kCGErrorSuccess)
+		return kCGNullDirectDisplay;
+
+	// A factor of 1 means this display is not magnified — either zoom is on a
+	// different display, or it is zoomed all the way out. Either way there is no
+	// viewport to pan, and the point is already displayed normally.
+	if (factor <= 1.0)
+		return kCGNullDirectDisplay;
+
+	if (outBounds)
+		*outBounds = bounds;
+	if (outOrigin)
+		*outOrigin = origin;
+	if (outFactor)
+		*outFactor = factor;
+	if (outSmoothing)
+		*outSmoothing = smoothing;
+
+	return display;
+}
+
+int NeruGetZoomViewportForPoint(CGPoint point, CGRect *outViewport) {
+	CGRect bounds = CGRectZero;
+	CGPoint origin = CGPointZero;
+	double factor = 0.0;
+	bool smoothing = false;
+
+	if (neruZoomedDisplayForPoint(point, &bounds, &origin, &factor, &smoothing) == kCGNullDirectDisplay)
 		return 0;
 
-	CGRect bounds = neruZoomDisplayBounds(origin);
 	CGFloat halfWidth = bounds.size.width / (2 * factor);
 	CGFloat halfHeight = bounds.size.height / (2 * factor);
 
@@ -128,20 +162,13 @@ int NeruGetZoomViewport(CGRect *outViewport) {
 }
 
 void NeruEnsureZoomViewportContainsPoint(CGPoint target) {
+	CGRect bounds = CGRectZero;
 	CGPoint origin = CGPointZero;
 	double factor = 0.0;
 	bool smoothing = false;
 
-	if (!neruCurrentZoomParameters(&origin, &factor, &smoothing))
-		return;
-
-	CGRect bounds = neruZoomDisplayBounds(origin);
-
-	// Zoom magnifies one display at a time; the others render normally. A target
-	// on one of those is already plainly visible, and panning the zoomed
-	// display's viewport toward it only drags that viewport to an edge for no
-	// benefit, leaving it somewhere the user did not put it.
-	if (!CGRectContainsPoint(bounds, target))
+	CGDirectDisplayID display = neruZoomedDisplayForPoint(target, &bounds, &origin, &factor, &smoothing);
+	if (display == kCGNullDirectDisplay)
 		return;
 
 	CGFloat halfWidth = bounds.size.width / (2 * factor);
@@ -167,17 +194,12 @@ void NeruEnsureZoomViewportContainsPoint(CGPoint target) {
 	else if (target.y > origin.y + insetHeight)
 		wanted.y = target.y - insetHeight;
 
-	// The viewport cannot leave its display, and the window server clamps to
-	// exactly this range. Clamping here too means a target that is unreachable —
-	// most often one on a different display than the zoomed one — compares equal
-	// to the current origin and costs nothing instead of re-pinning the viewport
-	// to the same edge on every move.
-	CGFloat minX = CGRectGetMinX(bounds) + halfWidth;
-	CGFloat maxX = CGRectGetMaxX(bounds) - halfWidth;
-	CGFloat minY = CGRectGetMinY(bounds) + halfHeight;
-	CGFloat maxY = CGRectGetMaxY(bounds) - halfHeight;
-	wanted.x = fmax(minX, fmin(maxX, wanted.x));
-	wanted.y = fmax(minY, fmin(maxY, wanted.y));
+	// The viewport cannot leave its display, and the window server clamps a
+	// requested origin to exactly this range. Clamping here too means an
+	// unreachable target compares equal to the current origin and costs nothing
+	// instead of re-pinning the viewport to the same edge on every move.
+	wanted.x = fmax(CGRectGetMinX(bounds) + halfWidth, fmin(CGRectGetMaxX(bounds) - halfWidth, wanted.x));
+	wanted.y = fmax(CGRectGetMinY(bounds) + halfHeight, fmin(CGRectGetMaxY(bounds) - halfHeight, wanted.y));
 
 	if (CGPointEqualToPoint(wanted, origin))
 		return;
@@ -185,5 +207,5 @@ void NeruEnsureZoomViewportContainsPoint(CGPoint target) {
 	// The window server keeps the cursor at a fixed position within the
 	// viewport, so panning drags the cursor with it. Callers must pan first and
 	// position the cursor afterwards, never the other way round.
-	gNeruSetZoomParameters(gNeruZoomConnection, &wanted, factor, smoothing ? 1 : 0, 0, 0.0);
+	gNeruSetZoomParametersForDisplay(gNeruZoomConnection, display, &wanted, smoothing ? 1 : 0, 0, factor, 0.0);
 }

--- a/internal/core/infra/platform/darwin/accessibility_zoom_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_zoom_darwin.m
@@ -1,0 +1,181 @@
+//
+//  accessibility_zoom.m
+//  Neru
+//
+//  Copyright © 2025 Neru. All rights reserved.
+//
+
+#import "accessibility.h"
+#import "accessibility_constants.h"
+
+#import <ApplicationServices/ApplicationServices.h>
+#import <Cocoa/Cocoa.h>
+#include <dlfcn.h>
+
+#pragma mark - Accessibility Zoom Viewport
+
+// When macOS Accessibility Zoom is zoomed in, only a sub-rectangle of the
+// display is on screen. Moving a real mouse to the edge of that rectangle pans
+// it; synthetic events never do, at either event tap. So a cursor we position
+// outside the viewport is correct but invisible, and the user is left with no
+// idea where it went.
+//
+// UAZoomChangeFocus() is the public API for this and is a no-op when the user's
+// zoom is set to follow the pointer (it drives the keyboard-focus and insertion
+// -point paths only), so the viewport can only be moved through SkyLight's zoom
+// SPI. Those symbols are resolved with dlsym and every entry point degrades to
+// "leave the viewport alone" when they are missing, so a future macOS that drops
+// them costs the follow behaviour and nothing else.
+
+typedef int NeruCGSConnectionID;
+
+typedef NeruCGSConnectionID (*NeruSLSMainConnectionIDFn)(void);
+
+/// Reads the zoom viewport centre, magnification and smoothing flag.
+typedef CGError (*NeruSLSGetZoomParametersFn)(
+    NeruCGSConnectionID cid, CGPoint *outOrigin, double *outFactor, bool *outSmoothing);
+
+/// Moves the zoom viewport. The trailing two arguments are undocumented; zero
+/// reproduces the behaviour of the system's own panning.
+typedef CGError (*NeruSLSSetZoomParametersFn)(
+    NeruCGSConnectionID cid, CGPoint *origin, double factor, int smoothing, int reserved, double reserved2);
+
+static NeruCGSConnectionID gNeruZoomConnection = 0;
+static NeruSLSGetZoomParametersFn gNeruGetZoomParameters = NULL;
+static NeruSLSSetZoomParametersFn gNeruSetZoomParameters = NULL;
+static bool gNeruZoomSPIAvailable = false;
+
+/// Resolve the SkyLight zoom SPI once
+static void neruLoadZoomSPI(void) {
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		void *skyLight = dlopen("/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight", RTLD_LAZY);
+		if (!skyLight)
+			return;
+
+		NeruSLSMainConnectionIDFn mainConnectionID = (NeruSLSMainConnectionIDFn)dlsym(skyLight, "SLSMainConnectionID");
+		gNeruGetZoomParameters = (NeruSLSGetZoomParametersFn)dlsym(skyLight, "SLSGetZoomParameters");
+		gNeruSetZoomParameters = (NeruSLSSetZoomParametersFn)dlsym(skyLight, "SLSSetZoomParameters");
+
+		if (!mainConnectionID || !gNeruGetZoomParameters || !gNeruSetZoomParameters)
+			return;
+
+		gNeruZoomConnection = mainConnectionID();
+		gNeruZoomSPIAvailable = true;
+	});
+}
+
+/// Read the current zoom viewport centre and magnification
+/// @param outOrigin Receives the viewport centre in global CG coordinates
+/// @param outFactor Receives the magnification factor
+/// @param outSmoothing Receives the user's smoothing preference
+/// @return true when the screen is zoomed in and the values are usable
+static bool neruCurrentZoomParameters(CGPoint *outOrigin, double *outFactor, bool *outSmoothing) {
+	if (!UAZoomEnabled())
+		return false;
+
+	neruLoadZoomSPI();
+	if (!gNeruZoomSPIAvailable)
+		return false;
+
+	CGPoint origin = CGPointZero;
+	double factor = 0.0;
+	bool smoothing = false;
+
+	if (gNeruGetZoomParameters(gNeruZoomConnection, &origin, &factor, &smoothing) != kCGErrorSuccess)
+		return false;
+
+	// A factor of 1 means zoomed all the way out — there is no viewport to pan.
+	if (factor <= 1.0)
+		return false;
+
+	*outOrigin = origin;
+	*outFactor = factor;
+	*outSmoothing = smoothing;
+
+	return true;
+}
+
+/// Bounds of the display the zoom viewport currently sits on
+/// @param origin Viewport centre in global CG coordinates
+/// @return Display bounds, falling back to the main display
+static CGRect neruZoomDisplayBounds(CGPoint origin) {
+	CGDirectDisplayID display = kCGNullDirectDisplay;
+	uint32_t matched = 0;
+
+	if (CGGetDisplaysWithPoint(origin, 1, &display, &matched) == kCGErrorSuccess && matched > 0)
+		return CGDisplayBounds(display);
+
+	return CGDisplayBounds(CGMainDisplayID());
+}
+
+int NeruGetZoomViewport(CGRect *outViewport) {
+	CGPoint origin = CGPointZero;
+	double factor = 0.0;
+	bool smoothing = false;
+
+	if (!neruCurrentZoomParameters(&origin, &factor, &smoothing))
+		return 0;
+
+	CGRect bounds = neruZoomDisplayBounds(origin);
+	CGFloat halfWidth = bounds.size.width / (2 * factor);
+	CGFloat halfHeight = bounds.size.height / (2 * factor);
+
+	if (outViewport)
+		*outViewport = CGRectMake(origin.x - halfWidth, origin.y - halfHeight, halfWidth * 2, halfHeight * 2);
+
+	return 1;
+}
+
+void NeruEnsureZoomViewportContainsPoint(CGPoint target) {
+	CGPoint origin = CGPointZero;
+	double factor = 0.0;
+	bool smoothing = false;
+
+	if (!neruCurrentZoomParameters(&origin, &factor, &smoothing))
+		return;
+
+	CGRect bounds = neruZoomDisplayBounds(origin);
+	CGFloat halfWidth = bounds.size.width / (2 * factor);
+	CGFloat halfHeight = bounds.size.height / (2 * factor);
+
+	// Nudge by the smallest amount that brings the target inside, so that a
+	// cursor already on screen never shifts the viewport. This is what dragging
+	// a real mouse into the edge of the viewport does. The margin is clamped so
+	// that it can never exceed the viewport itself at extreme zoom factors.
+	CGFloat marginX = fmin(kNeruZoomViewportMarginPoints, halfWidth / 2);
+	CGFloat marginY = fmin(kNeruZoomViewportMarginPoints, halfHeight / 2);
+	CGFloat insetWidth = halfWidth - marginX;
+	CGFloat insetHeight = halfHeight - marginY;
+
+	CGPoint wanted = origin;
+	if (target.x < origin.x - insetWidth)
+		wanted.x = target.x + insetWidth;
+	else if (target.x > origin.x + insetWidth)
+		wanted.x = target.x - insetWidth;
+
+	if (target.y < origin.y - insetHeight)
+		wanted.y = target.y + insetHeight;
+	else if (target.y > origin.y + insetHeight)
+		wanted.y = target.y - insetHeight;
+
+	// The viewport cannot leave its display, and the window server clamps to
+	// exactly this range. Clamping here too means a target that is unreachable —
+	// most often one on a different display than the zoomed one — compares equal
+	// to the current origin and costs nothing instead of re-pinning the viewport
+	// to the same edge on every move.
+	CGFloat minX = CGRectGetMinX(bounds) + halfWidth;
+	CGFloat maxX = CGRectGetMaxX(bounds) - halfWidth;
+	CGFloat minY = CGRectGetMinY(bounds) + halfHeight;
+	CGFloat maxY = CGRectGetMaxY(bounds) - halfHeight;
+	wanted.x = fmax(minX, fmin(maxX, wanted.x));
+	wanted.y = fmax(minY, fmin(maxY, wanted.y));
+
+	if (CGPointEqualToPoint(wanted, origin))
+		return;
+
+	// The window server keeps the cursor at a fixed position within the
+	// viewport, so panning drags the cursor with it. Callers must pan first and
+	// position the cursor afterwards, never the other way round.
+	gNeruSetZoomParameters(gNeruZoomConnection, &wanted, factor, smoothing ? 1 : 0, 0, 0.0);
+}

--- a/internal/core/infra/platform/darwin/accessibility_zoom_darwin.m
+++ b/internal/core/infra/platform/darwin/accessibility_zoom_darwin.m
@@ -25,18 +25,18 @@
 // -point paths only), so the viewport can only be moved through SkyLight's zoom
 // SPI. Those symbols are resolved with dlsym and every entry point degrades to
 // "leave the viewport alone" when they are missing, so a future macOS that drops
-// them costs the follow behaviour and nothing else.
+// them costs the follow behavior and nothing else.
 
 typedef int NeruCGSConnectionID;
 
 typedef NeruCGSConnectionID (*NeruSLSMainConnectionIDFn)(void);
 
-/// Reads the zoom viewport centre, magnification and smoothing flag.
+/// Reads the zoom viewport center, magnification and smoothing flag.
 typedef CGError (*NeruSLSGetZoomParametersFn)(
     NeruCGSConnectionID cid, CGPoint *outOrigin, double *outFactor, bool *outSmoothing);
 
 /// Moves the zoom viewport. The trailing two arguments are undocumented; zero
-/// reproduces the behaviour of the system's own panning.
+/// reproduces the behavior of the system's own panning.
 typedef CGError (*NeruSLSSetZoomParametersFn)(
     NeruCGSConnectionID cid, CGPoint *origin, double factor, int smoothing, int reserved, double reserved2);
 
@@ -65,8 +65,8 @@ static void neruLoadZoomSPI(void) {
 	});
 }
 
-/// Read the current zoom viewport centre and magnification
-/// @param outOrigin Receives the viewport centre in global CG coordinates
+/// Read the current zoom viewport center and magnification
+/// @param outOrigin Receives the viewport center in global CG coordinates
 /// @param outFactor Receives the magnification factor
 /// @param outSmoothing Receives the user's smoothing preference
 /// @return true when the screen is zoomed in and the values are usable
@@ -97,7 +97,7 @@ static bool neruCurrentZoomParameters(CGPoint *outOrigin, double *outFactor, boo
 }
 
 /// Bounds of the display the zoom viewport currently sits on
-/// @param origin Viewport centre in global CG coordinates
+/// @param origin Viewport center in global CG coordinates
 /// @return Display bounds, falling back to the main display
 static CGRect neruZoomDisplayBounds(CGPoint origin) {
 	CGDirectDisplayID display = kCGNullDirectDisplay;
@@ -136,6 +136,14 @@ void NeruEnsureZoomViewportContainsPoint(CGPoint target) {
 		return;
 
 	CGRect bounds = neruZoomDisplayBounds(origin);
+
+	// Zoom magnifies one display at a time; the others render normally. A target
+	// on one of those is already plainly visible, and panning the zoomed
+	// display's viewport toward it only drags that viewport to an edge for no
+	// benefit, leaving it somewhere the user did not put it.
+	if (!CGRectContainsPoint(bounds, target))
+		return;
+
 	CGFloat halfWidth = bounds.size.width / (2 * factor);
 	CGFloat halfHeight = bounds.size.height / (2 * factor);
 

--- a/internal/core/infra/platform/darwin/mouse_animator.go
+++ b/internal/core/infra/platform/darwin/mouse_animator.go
@@ -53,6 +53,9 @@ type smoothCursorAnimator struct {
 	reqCh  chan cursorRequest
 	stopCh chan struct{}
 	done   *cursorAnimationDone
+	// generation is bumped by stop() to invalidate steps from the animation
+	// being canceled. See postIfCurrent.
+	generation uint64
 }
 
 var cursorAnimator smoothCursorAnimator
@@ -65,12 +68,48 @@ func (a *smoothCursorAnimator) stop() {
 	a.stopCh = nil
 	a.done = nil
 
+	// Closing stopCh on its own is not enough to stop the worker: it can already
+	// have passed its cancellation check and be about to post a step, which then
+	// lands after whatever replaced this animation and drags the cursor — and
+	// the zoom viewport — back toward the abandoned target. Bumping the
+	// generation under the same lock the worker posts under closes that window.
+	a.generation++
+
 	if stopCh != nil {
 		close(stopCh)
 	}
 	a.mu.Unlock()
 
 	done.close()
+}
+
+// currentGeneration returns the animation generation in effect right now.
+func (a *smoothCursorAnimator) currentGeneration() uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.generation
+}
+
+// postIfCurrent posts one cursor move, but only if the animation that produced
+// it has not been canceled in the meantime. The check and the post share the
+// lock with stop(), so once stop() has returned no further step can escape.
+func (a *smoothCursorAnimator) postIfCurrent(
+	generation uint64,
+	point image.Point,
+	eventType uint32,
+) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.generation != generation {
+		return false
+	}
+
+	pos := C.CGPoint{x: C.double(point.X), y: C.double(point.Y)}
+	C.NeruPostMouseMoveEvent(pos, C.CGEventType(eventType))
+
+	return true
 }
 
 func (a *smoothCursorAnimator) wait(ctx context.Context) error {
@@ -164,6 +203,7 @@ func (a *smoothCursorAnimator) runRequest(
 	timer *time.Timer,
 ) {
 restart:
+	generation := a.currentGeneration()
 	start := CursorPosition()
 	distance := math.Hypot(float64(req.end.X-start.X), float64(req.end.Y-start.Y))
 
@@ -205,8 +245,11 @@ restart:
 			Y: int(float64(start.Y) + float64(req.end.Y-start.Y)*progress),
 		}
 
-		pos := C.CGPoint{x: C.double(intermediate.X), y: C.double(intermediate.Y)}
-		C.NeruPostMouseMoveEvent(pos, C.CGEventType(req.eventType))
+		if !a.postIfCurrent(generation, intermediate, req.eventType) {
+			req.done.close()
+
+			return
+		}
 
 		if step < actualSteps {
 			timer.Reset(stepDelay)

--- a/internal/core/infra/platform/darwin/screen.go
+++ b/internal/core/infra/platform/darwin/screen.go
@@ -99,15 +99,17 @@ func IsScreenZoomed() bool {
 	return bool(C.NeruIsScreenZoomed())
 }
 
-// ZoomViewport returns the region of the screen that the Accessibility Zoom
-// viewport currently shows, in global CG coordinates. The viewport edges are
+// ZoomViewportAt returns the region that Accessibility Zoom currently shows on
+// the display containing point, in global CG coordinates. The viewport edges are
 // fractional, so this is the smallest integer rectangle that fully contains it.
-// The second return value is false when the screen is not zoomed in, or when the
+// The second return value is false when that display is not magnified — zoom is
+// off, zoomed all the way out, or magnifying a different display — or when the
 // SkyLight zoom SPI that backs it is unavailable.
-func ZoomViewport() (image.Rectangle, bool) {
+func ZoomViewportAt(point image.Point) (image.Rectangle, bool) {
 	var viewport C.CGRect
 
-	if C.NeruGetZoomViewport(&viewport) == 0 {
+	target := C.CGPoint{x: C.double(point.X), y: C.double(point.Y)}
+	if C.NeruGetZoomViewportForPoint(target, &viewport) == 0 {
 		return image.Rectangle{}, false
 	}
 

--- a/internal/core/infra/platform/darwin/screen.go
+++ b/internal/core/infra/platform/darwin/screen.go
@@ -10,6 +10,7 @@ import "C"
 
 import (
 	"image"
+	"math"
 	"unsafe"
 )
 
@@ -88,6 +89,34 @@ func ScreenBoundsByName(name string) (image.Rectangle, bool) {
 // IsMissionControlActive returns true if Mission Control is active.
 func IsMissionControlActive() bool {
 	return bool(C.NeruIsMissionControlActive())
+}
+
+// IsScreenZoomed reports whether the macOS Accessibility Zoom feature is
+// currently zoomed in. Cursor positioning does not depend on this — synthetic
+// mouse events are posted at the session tap so they bypass the window server's
+// zoom coordinate transform — but it is useful when diagnosing pointer bugs.
+func IsScreenZoomed() bool {
+	return bool(C.NeruIsScreenZoomed())
+}
+
+// ZoomViewport returns the region of the screen that the Accessibility Zoom
+// viewport currently shows, in global CG coordinates. The viewport edges are
+// fractional, so this is the smallest integer rectangle that fully contains it.
+// The second return value is false when the screen is not zoomed in, or when the
+// SkyLight zoom SPI that backs it is unavailable.
+func ZoomViewport() (image.Rectangle, bool) {
+	var viewport C.CGRect
+
+	if C.NeruGetZoomViewport(&viewport) == 0 {
+		return image.Rectangle{}, false
+	}
+
+	return image.Rect(
+		int(math.Floor(float64(viewport.origin.x))),
+		int(math.Floor(float64(viewport.origin.y))),
+		int(math.Ceil(float64(viewport.origin.x+viewport.size.width))),
+		int(math.Ceil(float64(viewport.origin.y+viewport.size.height))),
+	), true
 }
 
 // FocusedWindowBounds returns the bounds of the focused (frontmost) window.


### PR DESCRIPTION
## Description

This PR fixes cursor positioning while the macOS Accessibility Zoom feature is zoomed in.

Every cursor-driven feature — hints, grids, mouse movement, dragging and scrolling — sent the cursor hundreds of points away from its target, because the window server rewrites the location of synthetic pointer-motion events while zoomed, reading the requested point as a coordinate in magnified-viewport space. Those events now enter the event system above that transform, so they land exactly on target whether or not zoom is engaged.

Landing on the target is only half the job: only real pointer-device movement pans the magnified region, so a correctly placed cursor could still end up off screen. The magnified region is now panned before each move, by the smallest amount that brings the target into view, mirroring what pushing a real mouse into the edge of the region does.

Reading the cursor position was never affected, and behaviour with zoom off is unchanged.

https://github.com/user-attachments/assets/573bdfe8-cce1-4958-a00e-00c51715ff1f

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability surface was added; this is entirely internal to the existing macOS adapter
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Trade-off worth reviewing.** Panning the magnified region has no public API — the documented one is a no-op when zoom is set to follow the mouse pointer, which is the default. The only mechanism that works is private SkyLight SPI. It is resolved at runtime rather than linked, and every path degrades to leaving the region alone when the symbols are missing, so a future macOS that drops them costs the follow behaviour and nothing else. Cursor positioning does not depend on it.

**Why the event tap change is unconditional.** Gating it on the zoom state was measured and would be correct, but it makes the tap location dynamic per event, so a click or drag could straddle a zoom toggle and enter the event system at two different points. Posting at the session tap when not zoomed is also not worse — identical accuracy, and lower propagation latency than the previous path. If a tool that observes events below the session tap ever needs the old behaviour, a static config option is the right answer rather than an automatic switch.

**Verification.** The regression tests assert that the cursor settles exactly on its target and, while zoomed, ends up inside the visible region; they were confirmed to fail against the previous behaviour and pass with the fix. The full integration suite was run with zoom both engaged and disengaged. The per-move cost is 0.08 µs with zoom off and under 21 µs with zoom on, against an existing per-move cost of roughly 12 ms, and 200,000 iterations showed no memory growth.
