### PR TITLE
feat(linux,windows): support function keys F13 through F24

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -412,7 +412,7 @@ Chords use `+` (e.g. `ctrl+c`, `Cmd+Shift+P`). `space` for a literal space key.
 
 **ARGUMENTS**
 
-`<key>` -- One or more keys or chords. Supported names: letters `a`–`z`, numbers `0`–`9`, symbols (`=`, `-`, `[`, `]`, etc.), named keys (`space`, `return`, `escape`, `tab`, `delete`), navigation (`left`, `right`, `up`, `down`, `pageup`, `home`, `end`), function (`f1`–`f20`), chord modifiers (`cmd`, `shift`, `alt`, `ctrl`, `LeftCmd`, `RightShift`).
+`<key>` -- One or more keys or chords. Supported names: letters `a`–`z`, numbers `0`–`9`, symbols (`=`, `-`, `[`, `]`, etc.), named keys (`space`, `return`, `escape`, `tab`, `delete`), navigation (`left`, `right`, `up`, `down`, `pageup`, `home`, `end`), function (`f1`–`f24`; `f21`–`f24` on Linux and Windows only), chord modifiers (`cmd`, `shift`, `alt`, `ctrl`, `LeftCmd`, `RightShift`).
 
 **EXAMPLES**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -247,7 +247,7 @@ Omitted colors inherit Neru's theme-derived defaults and update in real time whe
 | Symbols    | `` ` ``, `-`, `=`, `[`, `]`, `\`, `;`, `'`, `,`, `.`, `/`          |
 | Named      | `Space`, `Return`, `Enter`, `Escape`, `Tab`, `Delete`, `Backspace` |
 | Navigation | `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown` |
-| Function   | `F1`–`F20`                                                         |
+| Function   | `F1`–`F24` (`F21`–`F24` on Linux and Windows only)                 |
 
 See [CLI.md](CLI.md#feed-keys) for a full key reference with key codes and platform behavior.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -194,6 +194,13 @@ var validNamedKeys = map[string]bool{
 	"F18": true,
 	"F19": true,
 	"F20": true,
+	// F21-F24 have no macOS virtual keycode (Carbon stops at F20), so they are
+	// Linux/Windows only. They stay in the shared set so a config file can be
+	// shared across platforms without failing validation.
+	"F21": true,
+	"F22": true,
+	"F23": true,
+	"F24": true,
 }
 
 // validNamedKeysLower is a precomputed lowercase lookup for IsValidNamedKey.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -880,6 +882,40 @@ func TestCanonicalHotkeyForPlatform(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+// TestIsValidNamedKey_FunctionKeys pins the full F1-F24 range as valid named
+// keys, case-insensitively, and confirms F25 is not silently accepted.
+func TestIsValidNamedKey_FunctionKeys(t *testing.T) {
+	for index := 1; index <= 24; index++ {
+		display := "F" + strconv.Itoa(index)
+		lower := strings.ToLower(display)
+
+		t.Run(display, func(t *testing.T) {
+			if !config.IsValidNamedKey(display) {
+				t.Errorf("IsValidNamedKey(%q) = false, want true", display)
+			}
+
+			if !config.IsValidNamedKey(lower) {
+				t.Errorf("IsValidNamedKey(%q) = false, want true", lower)
+			}
+
+			canonical, recognized := config.CanonicalNamedKeyForm(lower)
+			if !recognized || canonical != display {
+				t.Errorf(
+					"CanonicalNamedKeyForm(%q) = (%q, %t), want (%q, true)",
+					lower,
+					canonical,
+					recognized,
+					display,
+				)
+			}
+		})
+	}
+
+	if config.IsValidNamedKey("F25") {
+		t.Error(`IsValidNamedKey("F25") = true, want false`)
 	}
 }
 

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys.go
@@ -93,6 +93,18 @@ const (
 	evdevKeyDelete     uint16 = 111
 	evdevKeyLeftMeta   uint16 = 125
 	evdevKeyRightMeta  uint16 = 126
+	evdevKeyF13        uint16 = 183
+	evdevKeyF14        uint16 = 184
+	evdevKeyF15        uint16 = 185
+	evdevKeyF16        uint16 = 186
+	evdevKeyF17        uint16 = 187
+	evdevKeyF18        uint16 = 188
+	evdevKeyF19        uint16 = 189
+	evdevKeyF20        uint16 = 190
+	evdevKeyF21        uint16 = 191
+	evdevKeyF22        uint16 = 192
+	evdevKeyF23        uint16 = 193
+	evdevKeyF24        uint16 = 194
 
 	evdevModifierShift = "shift"
 	evdevModifierCtrl  = "ctrl"
@@ -136,6 +148,18 @@ const (
 	evdevKeyNameF10       = "F10"
 	evdevKeyNameF11       = "F11"
 	evdevKeyNameF12       = "F12"
+	evdevKeyNameF13       = "F13"
+	evdevKeyNameF14       = "F14"
+	evdevKeyNameF15       = "F15"
+	evdevKeyNameF16       = "F16"
+	evdevKeyNameF17       = "F17"
+	evdevKeyNameF18       = "F18"
+	evdevKeyNameF19       = "F19"
+	evdevKeyNameF20       = "F20"
+	evdevKeyNameF21       = "F21"
+	evdevKeyNameF22       = "F22"
+	evdevKeyNameF23       = "F23"
+	evdevKeyNameF24       = "F24"
 )
 
 var evdevModifierNames = map[uint16]string{
@@ -182,6 +206,18 @@ var evdevKeyNames = map[uint16]string{
 	evdevKeyF10:        evdevKeyNameF10,
 	evdevKeyF11:        evdevKeyNameF11,
 	evdevKeyF12:        evdevKeyNameF12,
+	evdevKeyF13:        evdevKeyNameF13,
+	evdevKeyF14:        evdevKeyNameF14,
+	evdevKeyF15:        evdevKeyNameF15,
+	evdevKeyF16:        evdevKeyNameF16,
+	evdevKeyF17:        evdevKeyNameF17,
+	evdevKeyF18:        evdevKeyNameF18,
+	evdevKeyF19:        evdevKeyNameF19,
+	evdevKeyF20:        evdevKeyNameF20,
+	evdevKeyF21:        evdevKeyNameF21,
+	evdevKeyF22:        evdevKeyNameF22,
+	evdevKeyF23:        evdevKeyNameF23,
+	evdevKeyF24:        evdevKeyNameF24,
 	evdevKeyU:          "u",
 	evdevKeyV:          "v",
 	evdevKeyW:          "w",

--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_keys_test.go
@@ -4,6 +4,7 @@
 package eventtap
 
 import (
+	"strconv"
 	"testing"
 	"time"
 )
@@ -44,11 +45,33 @@ func TestEvdevKeyName(t *testing.T) {
 		{code: evdevKeyBackspace, want: "Backspace"},
 		{code: evdevKeyLeft, want: evdevKeyNameLeft},
 		{code: evdevKeyF1, want: "F1"},
+		{code: evdevKeyF12, want: "F12"},
+		{code: evdevKeyF13, want: "F13"},
+		{code: evdevKeyF20, want: "F20"},
+		{code: evdevKeyF21, want: "F21"},
+		{code: evdevKeyF24, want: "F24"},
 	}
 
 	for _, testCase := range testCases {
 		if got := evdevKeyName(testCase.code); got != testCase.want {
 			t.Fatalf("evdevKeyName(%d) = %q, want %q", testCase.code, got, testCase.want)
+		}
+	}
+}
+
+// TestEvdevKeyNameFunctionKeysContiguous pins the F13-F24 evdev codes, which
+// are not adjacent to the F1-F12 block (KEY_F13 is 183, not 89).
+func TestEvdevKeyNameFunctionKeysContiguous(t *testing.T) {
+	t.Parallel()
+
+	const firstHighFunctionKeyCode = 183
+
+	for index := 13; index <= 24; index++ {
+		code := uint16(firstHighFunctionKeyCode + index - 13)
+		want := "F" + strconv.Itoa(index)
+
+		if got := evdevKeyName(code); got != want {
+			t.Errorf("evdevKeyName(%d) = %q, want %q", code, got, want)
 		}
 	}
 }

--- a/internal/core/infra/eventtap/eventtap_linux_x11.go
+++ b/internal/core/infra/eventtap/eventtap_linux_x11.go
@@ -200,6 +200,64 @@ func x11KeysymName(keysym C.KeySym) string {
 	case C.XK_Down:
 		return "Down"
 	default:
+		return x11FunctionKeysymName(keysym)
+	}
+}
+
+// x11FunctionKeysymName maps the F1-F24 keysyms to their Neru display names.
+// XLookupString yields no character for function keys, so they only reach the
+// handler through this lookup.
+func x11FunctionKeysymName(keysym C.KeySym) string {
+	switch keysym {
+	case C.XK_F1:
+		return evdevKeyNameF1
+	case C.XK_F2:
+		return evdevKeyNameF2
+	case C.XK_F3:
+		return evdevKeyNameF3
+	case C.XK_F4:
+		return evdevKeyNameF4
+	case C.XK_F5:
+		return evdevKeyNameF5
+	case C.XK_F6:
+		return evdevKeyNameF6
+	case C.XK_F7:
+		return evdevKeyNameF7
+	case C.XK_F8:
+		return evdevKeyNameF8
+	case C.XK_F9:
+		return evdevKeyNameF9
+	case C.XK_F10:
+		return evdevKeyNameF10
+	case C.XK_F11:
+		return evdevKeyNameF11
+	case C.XK_F12:
+		return evdevKeyNameF12
+	case C.XK_F13:
+		return evdevKeyNameF13
+	case C.XK_F14:
+		return evdevKeyNameF14
+	case C.XK_F15:
+		return evdevKeyNameF15
+	case C.XK_F16:
+		return evdevKeyNameF16
+	case C.XK_F17:
+		return evdevKeyNameF17
+	case C.XK_F18:
+		return evdevKeyNameF18
+	case C.XK_F19:
+		return evdevKeyNameF19
+	case C.XK_F20:
+		return evdevKeyNameF20
+	case C.XK_F21:
+		return evdevKeyNameF21
+	case C.XK_F22:
+		return evdevKeyNameF22
+	case C.XK_F23:
+		return evdevKeyNameF23
+	case C.XK_F24:
+		return evdevKeyNameF24
+	default:
 		return ""
 	}
 }

--- a/internal/core/infra/platform/windows/keys.go
+++ b/internal/core/infra/platform/windows/keys.go
@@ -9,6 +9,7 @@ package windows
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -40,6 +41,14 @@ const (
 	vkControl  = 0x11
 	vkMenu     = 0x12
 	vkShift    = 0x10
+
+	// Function keys occupy a contiguous VK range: VK_F1 (0x70) through
+	// VK_F24 (0x87). They are handled arithmetically rather than as 24
+	// separate constants.
+	vkF1              = 0x70
+	vkF24             = 0x87
+	functionKeyCount  = vkF24 - vkF1 + 1
+	functionKeyPrefix = "f"
 
 	// mapvkVkToChar is MapVirtualKey's MAPVK_VK_TO_CHAR mode: translate a
 	// virtual-key code to its unshifted character for the active keyboard
@@ -145,6 +154,10 @@ func KeyNameFromVirtualKey(virtualKey uint32) string {
 		if virtualKey >= 0x41 && virtualKey <= 0x5A {
 			return strings.ToLower(string(rune(virtualKey)))
 		}
+
+		if name := functionKeyName(virtualKey); name != "" {
+			return name
+		}
 		// OEM/punctuation keys (e.g. "`", "/", "-") are layout-dependent: the
 		// same character lives on different VK codes across keyboard layouts.
 		// Translate via the active layout so hotkeys like "`" match regardless
@@ -155,6 +168,32 @@ func KeyNameFromVirtualKey(virtualKey uint32) string {
 	}
 
 	return ""
+}
+
+// functionKeyName returns the Neru display name ("F1" - "F24") for a function
+// key virtual-key code, or "" when the code is not in the function key range.
+func functionKeyName(vk uint32) string {
+	if vk < vkF1 || vk > vkF24 {
+		return ""
+	}
+
+	return "F" + strconv.Itoa(int(vk-vkF1)+1)
+}
+
+// functionKeyVirtualKey resolves a lowercase function key name ("f1" - "f24")
+// to its virtual-key code. The second result is false for any other name.
+func functionKeyVirtualKey(name string) (uint32, bool) {
+	digits, ok := strings.CutPrefix(name, functionKeyPrefix)
+	if !ok || digits == "" {
+		return 0, false
+	}
+
+	index, err := strconv.Atoi(digits)
+	if err != nil || index < 1 || index > functionKeyCount {
+		return 0, false
+	}
+
+	return uint32(vkF1 + index - 1), true
 }
 
 // charNameFromVirtualKey maps a virtual-key code to its unshifted printable
@@ -267,7 +306,9 @@ func ModifierNameFromVirtualKey(virtualKey uint32) string {
 }
 
 func nameToVirtualKey(name string) (uint32, bool) {
-	switch strings.ToLower(strings.TrimSpace(name)) {
+	lowered := strings.ToLower(strings.TrimSpace(name))
+
+	switch lowered {
 	case "return", "enter":
 		return vkReturn, true
 	case "space":
@@ -287,6 +328,10 @@ func nameToVirtualKey(name string) (uint32, bool) {
 	case "down":
 		return vkDown, true
 	default:
+		if vk, ok := functionKeyVirtualKey(lowered); ok {
+			return vk, true
+		}
+
 		if len(name) == 1 {
 			keyRune := rune(name[0])
 			if unicode.IsLetter(keyRune) {

--- a/internal/core/infra/platform/windows/keys_test.go
+++ b/internal/core/infra/platform/windows/keys_test.go
@@ -2,7 +2,11 @@
 
 package windows //nolint:testpackage // exercises unexported key translation helpers directly
 
-import "testing"
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
 
 func TestKeyComboFromBaseAndModifiers(t *testing.T) {
 	t.Parallel()
@@ -60,6 +64,50 @@ func TestKeyNameFromVirtualKeyLetters(t *testing.T) {
 
 	if got := ModifierNameFromVirtualKey(vkLShift); got != modNameShift {
 		t.Fatalf("ModifierNameFromVirtualKey(vkLShift) = %q, want shift", got)
+	}
+}
+
+func TestFunctionKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// F1-F24 are contiguous from VK_F1, so the whole range must round-trip
+	// between the hook's name lookup and hotkey parsing. F21-F24 in particular
+	// exist only on Windows and Linux (macOS has no virtual keycode for them).
+	for index := 1; index <= functionKeyCount; index++ {
+		want := "F" + strconv.Itoa(index)
+		wantVK := uint32(vkF1 + index - 1)
+
+		if got := KeyNameFromVirtualKey(wantVK); got != want {
+			t.Fatalf("KeyNameFromVirtualKey(%#x) = %q, want %q", wantVK, got, want)
+		}
+
+		// Config files and the CLI both accept lowercase spellings.
+		for _, spelling := range []string{want, strings.ToLower(want)} {
+			virtualKey, resolved := nameToVirtualKey(spelling)
+			if !resolved || virtualKey != wantVK {
+				t.Fatalf("nameToVirtualKey(%q) = %#x ok=%v, want %#x",
+					spelling, virtualKey, resolved, wantVK)
+			}
+		}
+	}
+
+	// Function keys are not modifiers and must not be reported as such.
+	if got := ModifierNameFromVirtualKey(vkF1); got != "" {
+		t.Fatalf("ModifierNameFromVirtualKey(vkF1) = %q, want empty", got)
+	}
+}
+
+func TestFunctionKeyOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"f0", "f25", "f", "f1x", "fa"} {
+		if virtualKey, resolved := functionKeyVirtualKey(name); resolved {
+			t.Errorf("functionKeyVirtualKey(%q) = %#x ok=true, want false", name, virtualKey)
+		}
+	}
+
+	if got := functionKeyName(vkF24 + 1); got != "" {
+		t.Errorf("functionKeyName(%#x) = %q, want empty", vkF24+1, got)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR extends function key support up to F24 on Linux and Windows. Keys above F20 were previously rejected, and the keys below it were only partially recognised.

Two existing gaps are fixed along the way. On X11, no function key worked at all — function keys produce no character, and the fallback lookup that handles such keys dropped them. On Windows, no function key was recognised in either direction, so both hotkey registration and the keyboard hook ignored them. On Wayland, the fallback used when the compositor keymap is unavailable only covered F1 to F12.

F21 to F24 are Linux and Windows only. macOS has no virtual keycode for them, so binding one there reports an invalid-key error rather than silently binding a different key. Configs remain portable: the keys validate everywhere, so the same file can be shared across machines.

## Configuration Changes

No option is added, renamed, or given a new default. What changes is the set of accepted key names: hotkey bindings and `neru action feed` now take `F1` through `F24` where they previously stopped at `F20`. Names remain case-insensitive, so `f21` and `F21` both work.

```toml
[hotkeys]
"F21" = "hints"
"Ctrl+F24" = "scroll"
```

```console
neru action feed f21
```

Existing configs are unaffected — this only widens what validates, so nothing that worked before stops working.

`F21` through `F24` validate on macOS as well, so a config file stays portable across machines. Binding one there fails at hotkey registration with an invalid-key error, rather than silently binding a different key.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code) — N/A, this PR also changes OS-specific input code
- [ ] macOS — N/A, macOS has no virtual keycode for F21–F24 and is unchanged
- [x] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, the unsupported macOS path already reports an invalid-key error through the existing hotkey parse failure
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Support was uneven before this change:

| Path | Before | After |
| --- | --- | --- |
| Wayland evdev fallback | F1–F12 | F1–F24 |
| X11 event tap | none | F1–F24 |
| Windows | none | F1–F24 |
| Wayland XKB keymap | F1–F24 | unchanged |
| Wayland key synthesis | F1–F24 | unchanged |
| X11 hotkey registration | F1–F24 | unchanged |

Restricting the change to F21–F24 alone would have produced the odd result of F21 working on X11 and Windows while F13 did not, so the whole range was filled in.

Two details worth noting for review. The evdev codes for F13–F24 are 183–194, not adjacent to the F1–F12 block, which is why they are listed rather than derived. The Windows virtual keys are contiguous from `VK_F1` through `VK_F24`, so they are handled arithmetically instead of as 24 constants.

On verification: the Linux CGO paths cannot be cross-compiled from macOS, so they were built and tested in a Linux container with the X11, Wayland and libei development packages — full unit test run, plus the pinned linter version. The macOS and Windows gates were run natively.
