### PR TITLE
feat(held_repeat): accelerate step distance while a key is held

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -406,6 +406,10 @@ duration_per_pixel = 1.00                   # Ms per pixel for adaptive duration
 enabled = false                         # Master toggle for held-key repeat
 initial_delay_ms = 50                   # Delay before first repeat fires (ms)
 interval_ms = 50                        # Interval between subsequent repeats (ms)
+accel_enabled = false                   # Ramp step distance up the longer the key is held
+accel_ramp_ms = 500                     # Hold time to reach accel_max_multiplier (ms)
+accel_max_multiplier = 4.0              # Step distance multiplier at full ramp
+accel_targets = ["move_mouse_relative"] # Action names eligible for acceleration
 
 # Systray
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#systray

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1450,18 +1450,45 @@ duration_per_pixel = 1.0
 
 Repeatedly dispatches scroll, page, relative-mouse-move, and `move_cell` actions while the key is held, with a configurable initial delay and repeat interval. Disable held-key repeat entirely by setting `enabled = false`.
 
-| Option             | Type | Default | Description                              |
-| ------------------ | ---- | ------- | ---------------------------------------- |
-| `enabled`          | bool | `false` | Master toggle for held-key repeat        |
-| `initial_delay_ms` | int  | `50`    | Delay before first repeat fires (ms)     |
-| `interval_ms`      | int  | `50`    | Interval between subsequent repeats (ms) |
+| Option                 | Type     | Default                   | Description                                      |
+| ---------------------- | -------- | ------------------------- | ------------------------------------------------ |
+| `enabled`              | bool     | `false`                   | Master toggle for held-key repeat                |
+| `initial_delay_ms`     | int      | `50`                      | Delay before first repeat fires (ms)             |
+| `interval_ms`          | int      | `50`                      | Interval between subsequent repeats (ms)         |
+| `accel_enabled`        | bool     | `false`                   | Ramp step distance up the longer the key is held |
+| `accel_ramp_ms`        | int      | `500`                     | Hold time to reach `accel_max_multiplier` (ms)   |
+| `accel_max_multiplier` | float    | `4.0`                     | Step distance multiplier at full ramp            |
+| `accel_targets`        | string[] | `["move_mouse_relative"]` | Action names eligible for acceleration           |
 
 ```toml
 [held_repeat]
 enabled = false
 initial_delay_ms = 50
 interval_ms = 50
+accel_enabled = false
+accel_ramp_ms = 500
+accel_max_multiplier = 4.0
+accel_targets = ["move_mouse_relative"]
 ```
+
+### Acceleration
+
+With `accel_enabled = true`, a held key ramps linearly from 1x to `accel_max_multiplier`
+over `accel_ramp_ms`, then holds there until release. With the values above the
+multiplier is 2.5x at 250ms and 4x from 500ms onward, so a binding of
+`action move_mouse_relative --dx=20 --dy=0` moves 50px per tick at 250ms and 80px per
+tick from 500ms. The repeat interval never changes, only the per-tick distance, which is
+how pointer acceleration works at the OS level and avoids rescheduling the repeat timer
+on every tick.
+
+The ramp is measured from the first repeat, not from the key press, so `initial_delay_ms`
+does not eat into it.
+
+Acceleration only applies to actions listed in `accel_targets`. Scaling acts on the
+action's `--dx`/`--dy` flags, which only `move_mouse_relative` accepts, so that is
+currently the sole valid entry: anything else is a config error rather than a binding
+that silently never accelerates. An empty `accel_targets` while `accel_enabled = true` is
+rejected for the same reason. Scroll and page keep their fixed step.
 
 ---
 

--- a/internal/app/heldrepeat/heldrepeat.go
+++ b/internal/app/heldrepeat/heldrepeat.go
@@ -1,0 +1,55 @@
+// Package heldrepeat drives the repeat-while-held loop shared by both hotkey paths.
+package heldrepeat
+
+import (
+	"context"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/domain/action"
+)
+
+// Run blocks, repeating actions until ctx is canceled. The dispatch on key-down
+// belongs to the caller: the two call sites disagree about whether the press has
+// already fired.
+func Run(
+	ctx context.Context,
+	cfg config.HeldRepeatConfig,
+	actions []string,
+	dispatch func([]string),
+) {
+	accelerate := cfg.AccelAppliesTo(config.HeldRepeatActionName(actions))
+
+	initialTimer := time.NewTimer(time.Duration(cfg.InitialDelay) * time.Millisecond)
+	defer initialTimer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-initialTimer.C:
+	}
+
+	// Timed from the first repeat, not the press: nothing moves during
+	// initial_delay, so an earlier start would land tick one mid-ramp.
+	repeatingSince := time.Now()
+
+	ticker := time.NewTicker(time.Duration(cfg.Interval) * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickActions := actions
+			if accelerate {
+				tickActions = action.ScaleAllDeltaFlags(
+					actions,
+					cfg.AccelMultiplierAt(time.Since(repeatingSince)),
+				)
+			}
+
+			dispatch(tickActions)
+		}
+	}
+}

--- a/internal/app/heldrepeat/heldrepeat_test.go
+++ b/internal/app/heldrepeat/heldrepeat_test.go
@@ -1,0 +1,154 @@
+package heldrepeat_test
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/app/heldrepeat"
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+const testBinding = "action move_mouse_relative --dx=10 --dy=0"
+
+type collector struct {
+	mu    sync.Mutex
+	ticks [][]string
+}
+
+func (c *collector) dispatch(actions []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.ticks = append(c.ticks, append([]string(nil), actions...))
+}
+
+func (c *collector) snapshot() [][]string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return append([][]string(nil), c.ticks...)
+}
+
+func dxOf(t *testing.T, actionStr string) int {
+	t.Helper()
+
+	for token := range strings.FieldsSeq(actionStr) {
+		flag, value, found := strings.Cut(token, "=")
+		if !found || flag != "--dx" {
+			continue
+		}
+
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			t.Fatalf("unparsable --dx in %q: %v", actionStr, err)
+		}
+
+		return parsed
+	}
+
+	t.Fatalf("no --dx flag in %q", actionStr)
+
+	return 0
+}
+
+func runUntilIdle(t *testing.T, cfg config.HeldRepeatConfig, hold time.Duration) [][]string {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var col collector
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		heldrepeat.Run(ctx, cfg, []string{testBinding}, col.dispatch)
+	}()
+
+	time.Sleep(hold)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancellation")
+	}
+
+	return col.snapshot()
+}
+
+func TestRunAcceleratesWhileHeld(t *testing.T) {
+	cfg := config.HeldRepeatConfig{
+		Enabled:            true,
+		InitialDelay:       1,
+		Interval:           5,
+		AccelEnabled:       true,
+		AccelRampMs:        50,
+		AccelMaxMultiplier: 4,
+		AccelTargets:       []string{"move_mouse_relative"},
+	}
+
+	ticks := runUntilIdle(t, cfg, 250*time.Millisecond)
+
+	if len(ticks) < 3 {
+		t.Fatalf("expected several ticks, got %d", len(ticks))
+	}
+
+	previous := 0
+
+	for idx, tick := range ticks {
+		got := dxOf(t, tick[0])
+
+		if got < previous {
+			t.Errorf("tick %d moved %d px, less than the previous %d: ramp went backwards",
+				idx, got, previous)
+		}
+
+		if got < 10 || got > 40 {
+			t.Errorf("tick %d moved %d px, outside the 1x..4x range of a 10px step", idx, got)
+		}
+
+		previous = got
+	}
+
+	// The ramp is 50ms and the hold is far longer, so the tail must be clamped.
+	if last := dxOf(t, ticks[len(ticks)-1][0]); last != 40 {
+		t.Errorf("final tick moved %d px, want the clamped 40 px", last)
+	}
+}
+
+func TestRunDoesNotAccelerateUntargetedAction(t *testing.T) {
+	cfg := config.HeldRepeatConfig{
+		Enabled:            true,
+		InitialDelay:       1,
+		Interval:           5,
+		AccelEnabled:       true,
+		AccelRampMs:        50,
+		AccelMaxMultiplier: 4,
+		AccelTargets:       []string{"scroll_down"},
+	}
+
+	for idx, tick := range runUntilIdle(t, cfg, 120*time.Millisecond) {
+		if tick[0] != testBinding {
+			t.Fatalf("tick %d was rewritten to %q, want the binding untouched", idx, tick[0])
+		}
+	}
+}
+
+func TestRunDispatchesNothingBeforeInitialDelay(t *testing.T) {
+	cfg := config.HeldRepeatConfig{
+		Enabled:      true,
+		InitialDelay: 500,
+		Interval:     5,
+	}
+
+	if ticks := runUntilIdle(t, cfg, 20*time.Millisecond); len(ticks) != 0 {
+		t.Errorf("expected no repeats during initial_delay, got %d", len(ticks))
+	}
+}

--- a/internal/app/ipcctrl/actions.go
+++ b/internal/app/ipcctrl/actions.go
@@ -33,7 +33,7 @@ const (
 	// ActionCommand is the IPC command that carries a mouse or key action.
 	// It is exported because the hotkey layer recognizes the same word when it
 	// decides whether a binding is an action step.
-	ActionCommand = "action"
+	ActionCommand = action.PrefixAction
 
 	flagCenter    = "--center"
 	flagWindow    = "--window"

--- a/internal/app/keybinding/binder.go
+++ b/internal/app/keybinding/binder.go
@@ -3,11 +3,10 @@ package keybinding
 import (
 	"context"
 	"strings"
-	"time"
 
 	"go.uber.org/zap"
 
-	"github.com/y3owk1n/neru/internal/app/ipcctrl"
+	"github.com/y3owk1n/neru/internal/app/heldrepeat"
 	"github.com/y3owk1n/neru/internal/app/sequence"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/domain"
@@ -246,26 +245,9 @@ func (b *Binder) startHotkeyRepeat(key string, actions []string) {
 
 		b.runActionSequence(key, actions)
 
-		initialTimer := time.NewTimer(time.Duration(cfg.InitialDelay) * time.Millisecond)
-		defer initialTimer.Stop()
-
-		select {
-		case <-ctx.Done():
-			return
-		case <-initialTimer.C:
-		}
-
-		ticker := time.NewTicker(time.Duration(cfg.Interval) * time.Millisecond)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				b.runActionSequence(key, actions)
-			}
-		}
+		heldrepeat.Run(ctx, cfg, actions, func(tickActions []string) {
+			b.runActionSequence(key, tickActions)
+		})
 	}()
 }
 
@@ -299,16 +281,7 @@ func (b *Binder) hotkeyActionsRepeatWhileHeld(actions []string, cfg *config.Conf
 		return false
 	}
 
-	if len(actions) != 1 {
-		return false
-	}
-
-	parts := splitArgs(strings.TrimSpace(actions[0]))
-	if len(parts) < 2 || parts[0] != ipcctrl.ActionCommand {
-		return false
-	}
-
-	return action.IsHeldRepeatAction(action.Name(parts[1]))
+	return action.IsHeldRepeatAction(action.Name(config.HeldRepeatActionName(actions)))
 }
 
 // ModifiersFromKey reads the modifier part of a hotkey specification, so a

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -7,6 +7,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/app/heldrepeat"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/action"
@@ -487,40 +488,14 @@ func (h *handlerState) startHeldRepeat(key, bindKey string, actions []string) {
 			}
 		}()
 
-		initialTimer := time.NewTimer(time.Duration(cfg.InitialDelay) * time.Millisecond)
-		defer initialTimer.Stop()
-
-		select {
-		case <-ctx.Done():
-			return
-		case <-initialTimer.C:
-		}
-
-		ticker := time.NewTicker(time.Duration(cfg.Interval) * time.Millisecond)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				h.executeActionSequence(bindKey, capturedActions)
-			}
-		}
+		heldrepeat.Run(ctx, cfg, capturedActions, func(tickActions []string) {
+			h.executeActionSequence(bindKey, tickActions)
+		})
 	}()
 }
 
 // isHeldRepeatAction reports whether the action list contains a single
 // held-repeatable action (scroll, page, relative mouse move, or cell move).
 func isHeldRepeatAction(actions []string) bool {
-	if len(actions) != 1 {
-		return false
-	}
-
-	parts := strings.SplitN(strings.TrimSpace(actions[0]), " ", 3) //nolint:mnd
-	if len(parts) < 2 || parts[0] != "action" {
-		return false
-	}
-
-	return action.IsHeldRepeatAction(action.Name(parts[1]))
+	return action.IsHeldRepeatAction(action.Name(config.HeldRepeatActionName(actions)))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -669,9 +669,13 @@ type SmoothScrollConfig struct {
 
 // HeldRepeatConfig defines held-key repeat settings for scroll, page, and mouse-move actions.
 type HeldRepeatConfig struct {
-	Enabled      bool `json:"enabled"      toml:"enabled"`          // Master toggle for held-key repeat
-	InitialDelay int  `json:"initialDelay" toml:"initial_delay_ms"` // Delay before first repeat fires (ms)
-	Interval     int  `json:"interval"     toml:"interval_ms"`      // Interval between subsequent repeats (ms)
+	Enabled            bool     `json:"enabled"            toml:"enabled"`              // Master toggle for held-key repeat
+	InitialDelay       int      `json:"initialDelay"       toml:"initial_delay_ms"`     // Delay before first repeat fires (ms)
+	Interval           int      `json:"interval"           toml:"interval_ms"`          // Interval between subsequent repeats (ms)
+	AccelEnabled       bool     `json:"accelEnabled"       toml:"accel_enabled"`        // Ramp step distance up while the key stays held
+	AccelRampMs        int      `json:"accelRampMs"        toml:"accel_ramp_ms"`        // Hold time to reach accel_max_multiplier (ms)
+	AccelMaxMultiplier float64  `json:"accelMaxMultiplier" toml:"accel_max_multiplier"` // Step distance multiplier at full ramp
+	AccelTargets       []string `json:"accelTargets"       toml:"accel_targets"`        // Action names eligible for acceleration
 }
 
 // SystrayConfig defines system tray settings.

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/y3owk1n/neru/internal/domain/action"
 	"github.com/y3owk1n/neru/internal/domain/element"
 )
 
@@ -132,6 +133,12 @@ const (
 	DefaultHeldRepeatInitialDelay = 50
 	// DefaultHeldRepeatInterval is the default held-key repeat interval in ms.
 	DefaultHeldRepeatInterval = 50
+	// DefaultHeldRepeatAccelRampMs is the default ramp duration, in ms.
+	DefaultHeldRepeatAccelRampMs = 500
+	// DefaultHeldRepeatAccelMaxMultiplier is the default multiplier at full ramp.
+	DefaultHeldRepeatAccelMaxMultiplier = 4.0
+	// MaxHeldRepeatAccelMultiplier bounds accel_max_multiplier.
+	MaxHeldRepeatAccelMultiplier = 100
 
 	// DefaultIPCTimeout is the default IPC timeout.
 	DefaultIPCTimeout = 5
@@ -773,9 +780,13 @@ func defaultSmoothScroll() SmoothScrollConfig {
 
 func defaultHeldRepeat() HeldRepeatConfig {
 	return HeldRepeatConfig{
-		Enabled:      false,
-		InitialDelay: DefaultHeldRepeatInitialDelay,
-		Interval:     DefaultHeldRepeatInterval,
+		Enabled:            false,
+		InitialDelay:       DefaultHeldRepeatInitialDelay,
+		Interval:           DefaultHeldRepeatInterval,
+		AccelEnabled:       false,
+		AccelRampMs:        DefaultHeldRepeatAccelRampMs,
+		AccelMaxMultiplier: DefaultHeldRepeatAccelMaxMultiplier,
+		AccelTargets:       []string{string(action.NameMoveMouseRelative)},
 	}
 }
 

--- a/internal/config/held_repeat.go
+++ b/internal/config/held_repeat.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"slices"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/domain/action"
+)
+
+// HeldRepeatActionName returns the name of a lone "action <name> …" binding, or "".
+func HeldRepeatActionName(actions []string) string {
+	if len(actions) != 1 {
+		return ""
+	}
+
+	parts := SplitStepArgs(actions[0])
+	if len(parts) < 2 || parts[0] != action.PrefixAction {
+		return ""
+	}
+
+	return parts[1]
+}
+
+// AccelMultiplierAt ramps linearly from 1x to AccelMaxMultiplier over AccelRampMs.
+// Only the distance grows, never the interval, so the timer is never rescheduled.
+func (c HeldRepeatConfig) AccelMultiplierAt(held time.Duration) float64 {
+	if !c.AccelEnabled || c.AccelMaxMultiplier <= 1 {
+		return 1
+	}
+
+	if c.AccelRampMs <= 0 {
+		return c.AccelMaxMultiplier
+	}
+
+	progress := float64(held.Milliseconds()) / float64(c.AccelRampMs)
+	if progress <= 0 {
+		return 1
+	}
+
+	if progress >= 1 {
+		return c.AccelMaxMultiplier
+	}
+
+	return 1 + progress*(c.AccelMaxMultiplier-1)
+}
+
+// AccelAppliesTo reports whether the named action is in the acceleration allowlist.
+func (c HeldRepeatConfig) AccelAppliesTo(name string) bool {
+	return c.AccelEnabled && slices.Contains(c.AccelTargets, name)
+}

--- a/internal/config/held_repeat_test.go
+++ b/internal/config/held_repeat_test.go
@@ -1,0 +1,71 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+const (
+	testAccelMoveBinding = "action move_mouse_relative --dx=20 --dy=0"
+	testAccelScrollDown  = "action scroll_down"
+	testAccelScrollUp    = "action scroll_up"
+)
+
+func TestHeldRepeatActionName(t *testing.T) {
+	tests := []struct {
+		name    string
+		actions []string
+		want    string
+	}{
+		{
+			name:    "single action binding",
+			actions: []string{testAccelMoveBinding},
+			want:    "move_mouse_relative",
+		},
+		{
+			name:    "action without arguments",
+			actions: []string{testAccelScrollDown},
+			want:    "scroll_down",
+		},
+		{
+			name:    "leading whitespace is tolerated",
+			actions: []string{"  " + testAccelScrollUp + "  "},
+			want:    "scroll_up",
+		},
+		{
+			name:    "quoted name is unquoted",
+			actions: []string{`action "scroll_up"`},
+			want:    "scroll_up",
+		},
+		{
+			name:    "multi-action binding has no single name",
+			actions: []string{testAccelScrollDown, testAccelScrollUp},
+			want:    "",
+		},
+		{
+			name:    "mode switch is not an action binding",
+			actions: []string{"hints --action left_click"},
+			want:    "",
+		},
+		{
+			name:    "exec binding is not an action binding",
+			actions: []string{"exec echo test"},
+			want:    "",
+		},
+		{
+			name:    "empty list",
+			actions: nil,
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.HeldRepeatActionName(tt.actions)
+			if got != tt.want {
+				t.Errorf("HeldRepeatActionName(%v) = %q, want %q", tt.actions, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/loader/load.go
+++ b/internal/config/loader/load.go
@@ -64,6 +64,15 @@ func (s *Service) LoadWithValidation(path string) *config.LoadResult {
 		return refuse(result, overrideErr)
 	}
 
+	// Settings that are valid alone but inert in context warn rather than fail:
+	// rejecting them would stop someone switching a feature off without also
+	// unwinding the settings beneath it.
+	if result.Config.HeldRepeat.AccelEnabled && !result.Config.HeldRepeat.Enabled {
+		s.logger.Warn(
+			"held_repeat.accel_enabled has no effect while held_repeat.enabled is false",
+		)
+	}
+
 	s.logger.Info("Configuration loaded successfully")
 
 	removeLauncherBindingsForDisabledModes(result.Config)

--- a/internal/config/validators_held_repeat_test.go
+++ b/internal/config/validators_held_repeat_test.go
@@ -1,0 +1,179 @@
+package config_test
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+func TestConfigValidateHeldRepeat_AccelDefaults(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := cfg.ValidateHeldRepeat()
+	if err != nil {
+		t.Fatalf("ValidateHeldRepeat() unexpected error: %v", err)
+	}
+}
+
+func TestConfigValidateHeldRepeat_AccelInvalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*config.Config)
+	}{
+		{
+			name: "negative ramp",
+			mutate: func(c *config.Config) {
+				c.HeldRepeat.AccelRampMs = -1
+			},
+		},
+		{
+			name: "multiplier below one",
+			mutate: func(c *config.Config) {
+				c.HeldRepeat.AccelMaxMultiplier = 0.5
+			},
+		},
+		{
+			name: "multiplier above the upper bound",
+			mutate: func(c *config.Config) {
+				c.HeldRepeat.AccelMaxMultiplier = config.MaxHeldRepeatAccelMultiplier + 1
+			},
+		},
+		{
+			name: "multiplier is NaN",
+			mutate: func(c *config.Config) {
+				c.HeldRepeat.AccelMaxMultiplier = math.NaN()
+			},
+		},
+		{
+			name: "multiplier is Inf",
+			mutate: func(c *config.Config) {
+				c.HeldRepeat.AccelMaxMultiplier = math.Inf(1)
+			},
+		},
+		{
+			name: "no targets while acceleration is enabled",
+			mutate: func(c *config.Config) {
+				c.HeldRepeat.AccelEnabled = true
+				c.HeldRepeat.AccelTargets = nil
+			},
+		},
+		{
+			name: "target action does not repeat while held",
+			mutate: func(c *config.Config) {
+				c.HeldRepeat.AccelTargets = []string{"left_click"}
+			},
+		},
+		{
+			name: "target repeats but takes no delta flags",
+			mutate: func(c *config.Config) {
+				c.HeldRepeat.AccelTargets = []string{"scroll_down"}
+			},
+		},
+		{
+			name: "target action is unknown",
+			mutate: func(c *config.Config) {
+				c.HeldRepeat.AccelTargets = []string{"move_mouse_relatve"}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			tt.mutate(cfg)
+
+			err := cfg.ValidateHeldRepeat()
+			if err == nil {
+				t.Error("ValidateHeldRepeat() expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestHeldRepeatAccelMultiplierAt(t *testing.T) {
+	accelerating := config.HeldRepeatConfig{
+		AccelEnabled:       true,
+		AccelRampMs:        500,
+		AccelMaxMultiplier: 4,
+	}
+
+	tests := []struct {
+		name string
+		cfg  config.HeldRepeatConfig
+		held time.Duration
+		want float64
+	}{
+		{"press starts at 1x", accelerating, 0, 1},
+		{"quarter ramp", accelerating, 125 * time.Millisecond, 1.75},
+		{"half ramp", accelerating, 250 * time.Millisecond, 2.5},
+		{"full ramp", accelerating, 500 * time.Millisecond, 4},
+		{"past ramp stays clamped", accelerating, 5 * time.Second, 4},
+		{
+			name: "disabled never scales",
+			cfg: config.HeldRepeatConfig{
+				AccelEnabled:       false,
+				AccelRampMs:        500,
+				AccelMaxMultiplier: 4,
+			},
+			held: time.Second,
+			want: 1,
+		},
+		{
+			name: "max multiplier of one never scales",
+			cfg: config.HeldRepeatConfig{
+				AccelEnabled:       true,
+				AccelRampMs:        500,
+				AccelMaxMultiplier: 1,
+			},
+			held: time.Second,
+			want: 1,
+		},
+		{
+			name: "zero ramp jumps straight to max",
+			cfg: config.HeldRepeatConfig{
+				AccelEnabled:       true,
+				AccelRampMs:        0,
+				AccelMaxMultiplier: 4,
+			},
+			held: time.Millisecond,
+			want: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.AccelMultiplierAt(tt.held)
+			if got != tt.want {
+				t.Errorf("AccelMultiplierAt(%v) = %v, want %v", tt.held, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeldRepeatAccelAppliesTo(t *testing.T) {
+	enabled := config.HeldRepeatConfig{
+		AccelEnabled: true,
+		AccelTargets: []string{"move_mouse_relative"},
+	}
+
+	if !enabled.AccelAppliesTo("move_mouse_relative") {
+		t.Error("expected move_mouse_relative to be accelerated")
+	}
+
+	if enabled.AccelAppliesTo("scroll_up") {
+		t.Error("expected action outside the allowlist to be left alone")
+	}
+
+	if enabled.AccelAppliesTo("") {
+		t.Error("expected empty action name to be left alone")
+	}
+
+	disabled := enabled
+	disabled.AccelEnabled = false
+
+	if disabled.AccelAppliesTo("move_mouse_relative") {
+		t.Error("expected no acceleration while accel_enabled is false")
+	}
+}

--- a/internal/config/validators_pointer.go
+++ b/internal/config/validators_pointer.go
@@ -85,6 +85,39 @@ func (c *Config) ValidateHeldRepeat() error {
 		return derrors.New(derrors.CodeInvalidConfig, "held_repeat.interval_ms must be >= 1")
 	}
 
+	if c.HeldRepeat.AccelRampMs < 0 {
+		return derrors.New(derrors.CodeInvalidConfig, "held_repeat.accel_ramp_ms must be >= 0")
+	}
+
+	// Negated so NaN, which compares false to everything, is rejected too.
+	if !(c.HeldRepeat.AccelMaxMultiplier >= 1 &&
+		c.HeldRepeat.AccelMaxMultiplier <= MaxHeldRepeatAccelMultiplier) {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"held_repeat.accel_max_multiplier must be between 1 and %d",
+			MaxHeldRepeatAccelMultiplier,
+		)
+	}
+
+	if c.HeldRepeat.AccelEnabled && len(c.HeldRepeat.AccelTargets) == 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"held_repeat.accel_targets must list at least one action while accel_enabled is true",
+		)
+	}
+
+	// Only move_mouse_relative accepts --dx/--dy; anything else would validate
+	// and then accelerate nothing.
+	for _, target := range c.HeldRepeat.AccelTargets {
+		if action.Name(target) != action.NameMoveMouseRelative {
+			return derrors.New(
+				derrors.CodeInvalidConfig,
+				"held_repeat.accel_targets only supports "+
+					string(action.NameMoveMouseRelative)+", got: "+target,
+			)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/domain/action/accel.go
+++ b/internal/domain/action/accel.go
@@ -1,0 +1,79 @@
+package action
+
+import (
+	"math"
+	"strconv"
+	"strings"
+)
+
+// ScaleDeltaFlags multiplies the --dx/--dy values in actionStr.
+//
+// Tokenizing with Fields rather than SplitArgs because this rejoins: SplitArgs
+// consumes the quotes it parses. Only move_mouse_relative is ever scaled and its
+// flags are integers, so there is nothing to quote.
+func ScaleDeltaFlags(actionStr string, multiplier float64) string {
+	if multiplier == 1 {
+		return actionStr
+	}
+
+	tokens := strings.Fields(actionStr)
+
+	for idx, token := range tokens {
+		flag, value, joined := strings.Cut(token, "=")
+		if flag != "--dx" && flag != "--dy" {
+			continue
+		}
+
+		target := idx
+
+		if !joined {
+			if idx+1 >= len(tokens) {
+				continue
+			}
+
+			target, value = idx+1, tokens[idx+1]
+		}
+
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			continue
+		}
+
+		scaled := strconv.Itoa(clampToInt(math.Round(float64(parsed) * multiplier)))
+		if joined {
+			scaled = flag + "=" + scaled
+		}
+
+		tokens[target] = scaled
+	}
+
+	return strings.Join(tokens, " ")
+}
+
+// Out-of-range float to int is implementation-defined in Go, so saturate.
+func clampToInt(value float64) int {
+	if value >= math.MaxInt {
+		return math.MaxInt
+	}
+
+	if value <= math.MinInt {
+		return math.MinInt
+	}
+
+	return int(value)
+}
+
+// ScaleAllDeltaFlags scales into a new slice, so ticks never compound onto the
+// original binding.
+func ScaleAllDeltaFlags(actions []string, multiplier float64) []string {
+	if multiplier == 1 {
+		return actions
+	}
+
+	scaled := make([]string, len(actions))
+	for idx, actionStr := range actions {
+		scaled[idx] = ScaleDeltaFlags(actionStr, multiplier)
+	}
+
+	return scaled
+}

--- a/internal/domain/action/accel_test.go
+++ b/internal/domain/action/accel_test.go
@@ -1,0 +1,161 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain/action"
+)
+
+const (
+	testMoveBinding = "action move_mouse_relative --dx=20 --dy=0"
+	testScrollDown  = "action scroll_down"
+)
+
+func TestScaleDeltaFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		multiplier float64
+		want       string
+	}{
+		{
+			name:       "joined form scales both axes",
+			input:      "action move_mouse_relative --dx=20 --dy=-20",
+			multiplier: 2,
+			want:       "action move_mouse_relative --dx=40 --dy=-40",
+		},
+		{
+			name:       "separated form scales both axes",
+			input:      "action move_mouse_relative --dx 20 --dy -20",
+			multiplier: 3,
+			want:       "action move_mouse_relative --dx 60 --dy -60",
+		},
+		{
+			name:       "fractional multiplier rounds to nearest",
+			input:      testMoveBinding,
+			multiplier: 1.55,
+			want:       "action move_mouse_relative --dx=31 --dy=0",
+		},
+		{
+			name:       "multiplier of one is a no-op",
+			input:      testMoveBinding,
+			multiplier: 1,
+			want:       testMoveBinding,
+		},
+		{
+			name:       "action without delta flags is untouched",
+			input:      testScrollDown,
+			multiplier: 4,
+			want:       testScrollDown,
+		},
+		{
+			name:       "unrelated flags are preserved",
+			input:      "action move_mouse_relative --dx=10 --bail --dy=10",
+			multiplier: 2,
+			want:       "action move_mouse_relative --dx=20 --bail --dy=20",
+		},
+		{
+			name:       "non-numeric value is left alone",
+			input:      "action move_mouse_relative --dx=abc",
+			multiplier: 2,
+			want:       "action move_mouse_relative --dx=abc",
+		},
+		{
+			name:       "overflowing delta saturates instead of wrapping",
+			input:      "action move_mouse_relative --dx=9223372036854775807",
+			multiplier: 100,
+			want:       "action move_mouse_relative --dx=9223372036854775807",
+		},
+		{
+			name:       "overflowing negative delta saturates instead of wrapping",
+			input:      "action move_mouse_relative --dx=-9223372036854775808",
+			multiplier: 100,
+			want:       "action move_mouse_relative --dx=-9223372036854775808",
+		},
+		{
+			name:       "trailing bare flag without value is left alone",
+			input:      "action move_mouse_relative --dx",
+			multiplier: 2,
+			want:       "action move_mouse_relative --dx",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := action.ScaleDeltaFlags(tt.input, tt.multiplier)
+			if got != tt.want {
+				t.Errorf("ScaleDeltaFlags(%q, %v) = %q, want %q",
+					tt.input, tt.multiplier, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScaleAllDeltaFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		actions    []string
+		multiplier float64
+		want       []string
+	}{
+		{
+			name:       "scales every entry that carries delta flags",
+			actions:    []string{testMoveBinding, "action move_mouse_relative --dx=0 --dy=-5"},
+			multiplier: 2,
+			want: []string{
+				"action move_mouse_relative --dx=40 --dy=0",
+				"action move_mouse_relative --dx=0 --dy=-10",
+			},
+		},
+		{
+			name:       "leaves entries without delta flags alone",
+			actions:    []string{testMoveBinding, testScrollDown},
+			multiplier: 2,
+			want:       []string{"action move_mouse_relative --dx=40 --dy=0", testScrollDown},
+		},
+		{
+			name:       "multiplier of one returns the input untouched",
+			actions:    []string{testMoveBinding},
+			multiplier: 1,
+			want:       []string{testMoveBinding},
+		},
+		{
+			name:       "empty list stays empty",
+			actions:    []string{},
+			multiplier: 2,
+			want:       []string{},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := action.ScaleAllDeltaFlags(testCase.actions, testCase.multiplier)
+			if len(got) != len(testCase.want) {
+				t.Fatalf("ScaleAllDeltaFlags(%v, %v) = %v, want %v",
+					testCase.actions, testCase.multiplier, got, testCase.want)
+			}
+
+			for idx := range got {
+				if got[idx] != testCase.want[idx] {
+					t.Errorf("ScaleAllDeltaFlags(%v, %v)[%d] = %q, want %q",
+						testCase.actions, testCase.multiplier, idx, got[idx], testCase.want[idx])
+				}
+			}
+		})
+	}
+}
+
+func TestScaleAllDeltaFlagsDoesNotMutateInput(t *testing.T) {
+	actions := []string{testMoveBinding}
+
+	first := action.ScaleAllDeltaFlags(actions, 2)
+	second := action.ScaleAllDeltaFlags(actions, 2)
+
+	if actions[0] != testMoveBinding {
+		t.Fatalf("input was mutated: %q", actions[0])
+	}
+
+	if first[0] != second[0] {
+		t.Errorf("repeated scaling diverged: %q vs %q", first[0], second[0])
+	}
+}

--- a/internal/domain/action/action.go
+++ b/internal/domain/action/action.go
@@ -422,6 +422,8 @@ const (
 
 	// PrefixExec is the prefix for shell command actions.
 	PrefixExec = "exec"
+	// PrefixAction is the prefix for IPC action bindings.
+	PrefixAction = "action"
 )
 
 // knownNames lists the action names that can be used as pending mode actions


### PR DESCRIPTION
Adds optional acceleration to `[held_repeat]`: a held key's `--dx`/`--dy` ramp linearly from 1x to `accel_max_multiplier` over `accel_ramp_ms`. `interval_ms` stays fixed, so only the per-tick distance grows — no timer rescheduling. `accel_targets` is an allowlist; `move_mouse_relative` is the only valid entry today, since scaling acts on `--dx`/`--dy` and no other repeating action accepts them.

```toml
[held_repeat]
accel_enabled = true
accel_ramp_ms = 500
accel_max_multiplier = 4.0
accel_targets = ["move_mouse_relative"]
```

Wired into both repeat paths — global hotkeys (`hotkeys.go`) and per-mode hotkeys (`modes/key_dispatch.go`) — since `move_mouse_relative` is commonly bound under `[scroll.hotkeys]`.

The ramp is timed from the first repeat rather than the key press: nothing moves during `initial_delay_ms`, so an earlier start would land tick one mid-ramp and lurch.

Also collapses `isHeldRepeatAction` and `hotkeyActionsRepeatWhileHeld` onto one shared parser instead of adding a third copy.


## Testing

`go test ./...`, `golangci-lint run` clean. Unit tests cover flag scaling (both `--dx=N` and `--dx N` forms), the multiplier curve, allowlist matching, and validation rejections. Manually tested on macOS with home-row `move_mouse_relative` bindings.

Closes #1104

