### PR TITLE
fix(linux): bound AT-SPI calls and surface real hints failures

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -15,7 +15,15 @@ import (
 
 const (
 	// DefaultIPCTimeoutSeconds is the default IPC timeout in seconds.
-	DefaultIPCTimeoutSeconds = 5
+	//
+	// This is the client-side ceiling for a full request/response round-trip
+	// and MUST stay comfortably larger than the daemon's own per-request work
+	// budget — notably the hints element scan (modes.HintTimeout, 5s) plus
+	// activation overhead. If the client gives up first, it disconnects and the
+	// daemon logs a spurious "broken pipe" when it finally writes the response
+	// (which the client is no longer there to read). The headroom keeps a slow
+	// (but not wedged) accessibility backend from tripping that race.
+	DefaultIPCTimeoutSeconds = 10
 )
 
 var (
@@ -27,8 +35,10 @@ var (
 	// GitCommit is set via ldflags at build time.
 	GitCommit = "unknown"
 	// BuildDate is set via ldflags at build time.
-	BuildDate  = "unknown"
-	timeoutSec = 5
+	BuildDate = "unknown"
+	// timeoutSec is overridden by the --timeout flag (default
+	// DefaultIPCTimeoutSeconds); kept in sync so any pre-parse use matches.
+	timeoutSec = DefaultIPCTimeoutSeconds
 
 	// CLI utilities.
 	formatter *cliutil.OutputFormatter

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -287,12 +287,13 @@ func (a *Adapter) ClickableElements(
 
 				windowsWg.Wait()
 
-				// If the window scan failed and produced nothing, hand the error
-				// up to the caller (not as this source's return value, which would
-				// abort the whole collection and throw away other sources' work).
-				// It is only surfaced if the *grand total* is empty — see the
-				// windowsSourceErr check after all sources join.
-				if len(allElements) == 0 && firstWindowErr != nil {
+				// Hand any window-scan error up to the caller rather than
+				// returning it as this source's value (which would abort the whole
+				// collection and throw away other sources' work). It is surfaced
+				// only if the *grand total* across every source is empty — see the
+				// windowsSourceErr check after all sources join — so a failure that
+				// still left some elements to show degrades to a Warn log instead.
+				if firstWindowErr != nil {
 					mutex.Lock()
 					if windowsSourceErr == nil {
 						windowsSourceErr = firstWindowErr

--- a/internal/core/infra/accessibility/adapter.go
+++ b/internal/core/infra/accessibility/adapter.go
@@ -141,6 +141,11 @@ func (a *Adapter) ClickableElements(
 		// Pre-allocate with estimated capacity for typical web page
 		allElements = make([]*element.Element, 0, TypicalElementCount)
 		firstError  error
+		// windowsSourceErr records a window-scan failure without aborting the
+		// whole collection. It is surfaced only if *no* source produced any
+		// elements (see below), so a transient per-window error can't discard
+		// elements other sources gathered in parallel (dock, menubar, …).
+		windowsSourceErr error
 	)
 
 	// Check Mission Control state once to ensure consistency across all code paths
@@ -212,8 +217,24 @@ func (a *Adapter) ClickableElements(
 
 				var windowsMutex sync.Mutex
 
+				// First error from any window. It is only surfaced if *no* window
+				// yields elements (see below): a transient failure on one popover
+				// must not discard hints the frontmost window did produce, but a
+				// hard failure (e.g. the AT-SPI bus is unreachable) that leaves us
+				// with nothing must be reported rather than silently look like an
+				// empty window.
+				var firstWindowErr error
+
 				// Semaphore to cap concurrent window processing goroutines
 				windowSem := make(chan struct{}, maxConcurrentWindows)
+
+				recordWindowErr := func(err error) {
+					windowsMutex.Lock()
+					if firstWindowErr == nil {
+						firstWindowErr = err
+					}
+					windowsMutex.Unlock()
+				}
 
 				processWindow := func(window AXWindow) {
 					defer windowsWg.Done()
@@ -226,6 +247,9 @@ func (a *Adapter) ClickableElements(
 						0,
 					)
 					if clickableNodesErr != nil {
+						a.logger.Warn("Failed to collect clickable nodes from window",
+							zap.Error(clickableNodesErr))
+						recordWindowErr(clickableNodesErr)
 						window.Release()
 
 						return
@@ -237,6 +261,9 @@ func (a *Adapter) ClickableElements(
 						filter,
 					)
 					if processErr != nil {
+						a.logger.Warn("Failed to process clickable nodes from window",
+							zap.Error(processErr))
+						recordWindowErr(processErr)
 						window.Release()
 
 						return
@@ -259,6 +286,19 @@ func (a *Adapter) ClickableElements(
 				}
 
 				windowsWg.Wait()
+
+				// If the window scan failed and produced nothing, hand the error
+				// up to the caller (not as this source's return value, which would
+				// abort the whole collection and throw away other sources' work).
+				// It is only surfaced if the *grand total* is empty — see the
+				// windowsSourceErr check after all sources join.
+				if len(allElements) == 0 && firstWindowErr != nil {
+					mutex.Lock()
+					if windowsSourceErr == nil {
+						windowsSourceErr = firstWindowErr
+					}
+					mutex.Unlock()
+				}
 
 				return allElements, nil
 			})
@@ -347,11 +387,24 @@ func (a *Adapter) ClickableElements(
 	select {
 	case <-done:
 	case <-ctx.Done():
-		return nil, derrors.Wrap(ctx.Err(), derrors.CodeContextCanceled, "operation canceled")
+		// Distinguish a real timeout ("...timed out") from a cancellation
+		// ("...canceled") instead of collapsing both into a bare message — a
+		// timeout here usually means the accessibility backend was slow or
+		// unresponsive, which is the actionable signal.
+		return nil, derrors.WrapContextCanceled(ctx, "element collection")
 	}
 
 	if firstError != nil {
 		return nil, firstError
+	}
+
+	// Surface a window-scan failure only when nothing at all was collected —
+	// across every source. When some source did yield elements we return those
+	// and keep the failure to the Warn log, degrading rather than failing hard.
+	// On Linux (no supplementary sources) this is the path that turns a dead or
+	// unreachable AT-SPI bus into a clear error instead of a silent empty result.
+	if len(allElements) == 0 && windowsSourceErr != nil {
+		return nil, derrors.WrapAccessibilityFailed(windowsSourceErr, "collect window elements")
 	}
 
 	// Log reason for empty results when Mission Control is active

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -591,6 +591,13 @@ func (c *ATSPIClient) collectViaCollection(
 		c.logger.Debug("AT-SPI Collection.GetMatches unavailable; falling back to walk",
 			zap.Error(err))
 
+		// GetMatches runs on the full scan budget rather than a per-call
+		// deadline, so it is the one scan call the leaf helpers don't cover.
+		// Record a scan-fatal error (a deadline, or the app leaving the bus)
+		// here so an empty fallback walk still surfaces it; a benign
+		// "Collection not implemented" error is ignored and the walk proceeds.
+		c.noteCallErr(ctx, err)
+
 		return nil, false
 	}
 

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -56,6 +56,21 @@ const (
 	atspiMaxDepth = 40
 	atspiMaxNodes = 2000
 
+	// atspiCallTimeout bounds a single AT-SPI D-Bus round-trip. A healthy
+	// toolkit answers each read (role, extents, name, children, state) in
+	// single-digit milliseconds; this only trips when an app is wedged or not
+	// answering accessibility queries. Without it a single hung call would
+	// consume the whole element-scan budget and the CLI would give up with a
+	// bare timeout (or the daemon would log a broken-pipe write after the
+	// client disconnected). Bounding each call lets a stuck node be dropped and
+	// the scan continue.
+	atspiCallTimeout = 500 * time.Millisecond
+
+	// atspiPropertiesGet is the standard D-Bus Properties.Get method, called
+	// with a context so a wedged property read cannot block indefinitely (the
+	// godbus GetProperty convenience method has no context-aware variant).
+	atspiPropertiesGet = "org.freedesktop.DBus.Properties.Get"
+
 	// Capacity hint for the clickable-node slice: most windows fit well under
 	// this and the slice grows if a dense tree exceeds it.
 	atspiClickableNodesCap = 128
@@ -247,7 +262,7 @@ func NewATSPIClient(logger *zap.Logger, configProvider config.Provider) *ATSPICl
 }
 
 // FrontmostWindow returns the active top-level window via AT-SPI.
-func (c *ATSPIClient) FrontmostWindow(_ context.Context) (AXWindow, error) {
+func (c *ATSPIClient) FrontmostWindow(ctx context.Context) (AXWindow, error) {
 	err := c.ensureA11yEnabled()
 	if err != nil {
 		c.logger.Warn("Failed to enable AT-SPI accessibility", zap.Error(err))
@@ -265,7 +280,7 @@ func (c *ATSPIClient) FrontmostWindow(_ context.Context) (AXWindow, error) {
 	// ClickableNodes stability check accept a stale frame.
 	focusedAppID, focusedTitle, _ := linux.WaylandFocusedAppIdentity()
 
-	frame, ok := c.findActiveFrame(conn, focusedAppID, focusedTitle)
+	frame, ok := c.findActiveFrame(ctx, conn, focusedAppID, focusedTitle)
 	if !ok {
 		c.logger.Debug("AT-SPI: no active frame found")
 
@@ -276,8 +291,8 @@ func (c *ATSPIClient) FrontmostWindow(_ context.Context) (AXWindow, error) {
 
 	c.logger.Debug("AT-SPI: selected active frame",
 		zap.String("bus", frame.Name),
-		zap.String("app", c.name(conn, accRef{Name: frame.Name, Path: atspiRootPath})),
-		zap.String("frameTitle", c.name(conn, frame)))
+		zap.String("app", c.name(ctx, conn, accRef{Name: frame.Name, Path: atspiRootPath})),
+		zap.String("frameTitle", c.name(ctx, conn, frame)))
 
 	return &atspiWindow{
 		ref:          frame,
@@ -346,7 +361,7 @@ func (c *ATSPIClient) ClickableNodes(
 		haveOrigin bool
 	)
 
-	frameRect, frameOK := c.extents(conn, win.ref)
+	frameRect, frameOK := c.extents(ctx, conn, win.ref)
 	if frameOK {
 		originX, originY, ok := c.windowOrigin.originFor(frameRect.Dx(), frameRect.Dy())
 		if ok {
@@ -607,7 +622,7 @@ func (c *ATSPIClient) collectViaCollection(
 				return
 			}
 
-			node := c.materializeMatch(conn, ref, roleSet, offX, offY)
+			node := c.materializeMatch(ctx, conn, ref, roleSet, offX, offY)
 			if node != nil {
 				results[slot] = node
 
@@ -646,6 +661,7 @@ func (c *ATSPIClient) collectViaCollection(
 // extents). It mirrors the walk's emit filter and is safe for concurrent use —
 // it only issues reads over the shared connection, which godbus multiplexes.
 func (c *ATSPIClient) materializeMatch(
+	ctx context.Context,
 	conn *dbus.Conn,
 	ref accRef,
 	roleSet map[string]struct{},
@@ -653,7 +669,7 @@ func (c *ATSPIClient) materializeMatch(
 ) *atspiNode {
 	// Re-verify the role maps into the requested set: a toolkit may return a role
 	// we did not ask for, and this keeps parity with the walk's filter.
-	axRole, mappable := atspiToAXRole[strings.ToLower(c.roleName(conn, ref))]
+	axRole, mappable := atspiToAXRole[strings.ToLower(c.roleName(ctx, conn, ref))]
 	if !mappable {
 		return nil
 	}
@@ -662,7 +678,7 @@ func (c *ATSPIClient) materializeMatch(
 		return nil
 	}
 
-	rect, valid := c.extents(conn, ref)
+	rect, valid := c.extents(ctx, conn, ref)
 	if !valid {
 		return nil
 	}
@@ -670,7 +686,7 @@ func (c *ATSPIClient) materializeMatch(
 	return &atspiNode{
 		id:    string(ref.Path) + "@" + ref.Name,
 		role:  axRole,
-		title: c.name(conn, ref),
+		title: c.name(ctx, conn, ref),
 		rect:  rect.Add(image.Pt(offX, offY)),
 	}
 }
@@ -859,17 +875,26 @@ func (c *ATSPIClient) focusStableSince(selectedAppID, selectedTitle string) bool
 // children returns the AT-SPI children of an accessible. It prefers the bulk
 // GetChildren method and falls back to ChildCount + GetChildAtIndex for older
 // toolkits that do not expose GetChildren.
-func (c *ATSPIClient) children(conn *dbus.Conn, ref accRef) []accRef {
+func (c *ATSPIClient) children(ctx context.Context, conn *dbus.Conn, ref accRef) []accRef {
 	obj := conn.Object(ref.Name, ref.Path)
 
 	var kids []accRef
 
-	err := obj.Call(atspiAccessibleIfc+".GetChildren", 0).Store(&kids)
+	childrenCtx, cancel := context.WithTimeout(ctx, atspiCallTimeout)
+	defer cancel()
+
+	err := obj.CallWithContext(childrenCtx, atspiAccessibleIfc+".GetChildren", 0).Store(&kids)
 	if err == nil {
 		return kids
 	}
 
-	countVar, propErr := obj.GetProperty(atspiAccessibleIfc + ".ChildCount")
+	var countVar dbus.Variant
+
+	countCtx, cancelCount := context.WithTimeout(ctx, atspiCallTimeout)
+	defer cancelCount()
+
+	propErr := obj.CallWithContext(countCtx, atspiPropertiesGet, 0,
+		atspiAccessibleIfc, "ChildCount").Store(&countVar)
 	if propErr != nil {
 		return nil
 	}
@@ -878,7 +903,13 @@ func (c *ATSPIClient) children(conn *dbus.Conn, ref accRef) []accRef {
 	for i := range count {
 		var child accRef
 
-		err := obj.Call(atspiAccessibleIfc+".GetChildAtIndex", 0, i).Store(&child)
+		childCtx, cancelChild := context.WithTimeout(ctx, atspiCallTimeout)
+
+		err := obj.CallWithContext(childCtx, atspiAccessibleIfc+".GetChildAtIndex", 0, i).
+			Store(&child)
+
+		cancelChild()
+
 		if err != nil {
 			continue
 		}
@@ -890,11 +921,14 @@ func (c *ATSPIClient) children(conn *dbus.Conn, ref accRef) []accRef {
 }
 
 // roleName returns the AT-SPI localized-independent role name (e.g. "push button").
-func (c *ATSPIClient) roleName(conn *dbus.Conn, ref accRef) string {
+func (c *ATSPIClient) roleName(ctx context.Context, conn *dbus.Conn, ref accRef) string {
+	callCtx, cancel := context.WithTimeout(ctx, atspiCallTimeout)
+	defer cancel()
+
 	var name string
 
 	err := conn.Object(ref.Name, ref.Path).
-		Call(atspiAccessibleIfc+".GetRoleName", 0).Store(&name)
+		CallWithContext(callCtx, atspiAccessibleIfc+".GetRoleName", 0).Store(&name)
 	if err != nil {
 		return ""
 	}
@@ -903,9 +937,14 @@ func (c *ATSPIClient) roleName(conn *dbus.Conn, ref accRef) string {
 }
 
 // name returns the accessible Name property (used as the element title).
-func (c *ATSPIClient) name(conn *dbus.Conn, ref accRef) string {
-	val, err := conn.Object(ref.Name, ref.Path).
-		GetProperty(atspiAccessibleIfc + ".Name")
+func (c *ATSPIClient) name(ctx context.Context, conn *dbus.Conn, ref accRef) string {
+	callCtx, cancel := context.WithTimeout(ctx, atspiCallTimeout)
+	defer cancel()
+
+	var val dbus.Variant
+
+	err := conn.Object(ref.Name, ref.Path).
+		CallWithContext(callCtx, atspiPropertiesGet, 0, atspiAccessibleIfc, "Name").Store(&val)
 	if err != nil {
 		return ""
 	}
@@ -916,11 +955,14 @@ func (c *ATSPIClient) name(conn *dbus.Conn, ref accRef) string {
 }
 
 // stateHas reports whether the accessible has the given AT-SPI state bit set.
-func (c *ATSPIClient) stateHas(conn *dbus.Conn, ref accRef, bit uint) bool {
+func (c *ATSPIClient) stateHas(ctx context.Context, conn *dbus.Conn, ref accRef, bit uint) bool {
+	callCtx, cancel := context.WithTimeout(ctx, atspiCallTimeout)
+	defer cancel()
+
 	var states []uint32
 
 	err := conn.Object(ref.Name, ref.Path).
-		Call(atspiAccessibleIfc+".GetState", 0).Store(&states)
+		CallWithContext(callCtx, atspiAccessibleIfc+".GetState", 0).Store(&states)
 	if err != nil || len(states) == 0 {
 		return false
 	}
@@ -934,11 +976,18 @@ func (c *ATSPIClient) stateHas(conn *dbus.Conn, ref accRef, bit uint) bool {
 }
 
 // extents returns the on-screen rectangle of an accessible.
-func (c *ATSPIClient) extents(conn *dbus.Conn, ref accRef) (image.Rectangle, bool) {
+func (c *ATSPIClient) extents(
+	ctx context.Context,
+	conn *dbus.Conn,
+	ref accRef,
+) (image.Rectangle, bool) {
+	callCtx, cancel := context.WithTimeout(ctx, atspiCallTimeout)
+	defer cancel()
+
 	var ext atspiExtents
 
 	err := conn.Object(ref.Name, ref.Path).
-		Call(atspiComponentIfc+".GetExtents", 0, atspiCoordScreen).Store(&ext)
+		CallWithContext(callCtx, atspiComponentIfc+".GetExtents", 0, atspiCoordScreen).Store(&ext)
 	if err != nil {
 		return image.Rectangle{}, false
 	}
@@ -1017,6 +1066,7 @@ func isNonTargetSurfaceApp(name string) bool {
 // (empty on X11, GNOME, or when nothing is focused), used so the selected frame
 // and the identity recorded for the stability check come from the same read.
 func (c *ATSPIClient) findActiveFrame(
+	ctx context.Context,
 	conn *dbus.Conn,
 	focusedAppID, focusedTitle string,
 ) (accRef, bool) {
@@ -1053,8 +1103,8 @@ func (c *ATSPIClient) findActiveFrame(
 		haveShell    bool
 	)
 
-	for _, app := range c.children(conn, root) {
-		appName := c.name(conn, app)
+	for _, app := range c.children(ctx, conn, root) {
+		appName := c.name(ctx, conn, app)
 
 		// Skip surfaces that are never valid hint targets and that steal the
 		// ACTIVE state right after a libei cursor move: on-screen virtual
@@ -1069,14 +1119,14 @@ func (c *ATSPIClient) findActiveFrame(
 		isShell := isDesktopShellApp(appName)
 		matchesFocused := haveFocused && appMatchesFocusedID(appName, focusedAppID)
 
-		for _, frame := range c.children(conn, app) {
-			role := c.roleName(conn, frame)
+		for _, frame := range c.children(ctx, conn, app) {
+			role := c.roleName(ctx, conn, frame)
 			if role != "frame" && role != "window" && role != "dialog" {
 				continue
 			}
 
-			active := c.stateHas(conn, frame, atspiStateActive)
-			showing := c.stateHas(conn, frame, atspiStateShowing)
+			active := c.stateHas(ctx, conn, frame, atspiStateActive)
+			showing := c.stateHas(ctx, conn, frame, atspiStateShowing)
 
 			// The desktop shell never wins the active-frame race; it is kept
 			// aside and only used if no real application frame is found.
@@ -1100,7 +1150,7 @@ func (c *ATSPIClient) findActiveFrame(
 					haveFocusedShowing = true
 				}
 
-				if haveFocusedTitle && titleMatchesFocused(c.name(conn, frame), focusedTitle) {
+				if haveFocusedTitle && titleMatchesFocused(c.name(ctx, conn, frame), focusedTitle) {
 					focusedTitleCount++
 
 					if focusedTitleCount == 1 {
@@ -1296,25 +1346,25 @@ func (c *ATSPIClient) walk(
 	// Translate the AT-SPI role into Neru's AX vocabulary, then match against
 	// the requested role set (also AX names). This keeps the whole pipeline,
 	// including the downstream Adapter.MatchesFilter, speaking one vocabulary.
-	axRole, mappable := atspiToAXRole[strings.ToLower(c.roleName(conn, ref))]
+	axRole, mappable := atspiToAXRole[strings.ToLower(c.roleName(ctx, conn, ref))]
 
 	if mappable {
-		if _, ok := roles[axRole]; ok && c.stateHas(conn, ref, atspiStateShowing) {
-			if rect, valid := c.extents(conn, ref); valid {
+		if _, ok := roles[axRole]; ok && c.stateHas(ctx, conn, ref, atspiStateShowing) {
+			if rect, valid := c.extents(ctx, conn, ref); valid {
 				// AT-SPI reports window-relative coords on Wayland; offset by the
 				// focused window's screen origin from the KWin bridge.
 				rect = rect.Add(image.Pt(offX, offY))
 				*out = append(*out, &atspiNode{
 					id:    string(ref.Path) + "@" + ref.Name,
 					role:  axRole,
-					title: c.name(conn, ref),
+					title: c.name(ctx, conn, ref),
 					rect:  rect,
 				})
 			}
 		}
 	}
 
-	for _, child := range c.children(conn, ref) {
+	for _, child := range c.children(ctx, conn, ref) {
 		c.walk(ctx, conn, child, roles, depth+1, out, visited, offX, offY)
 	}
 }

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -421,13 +421,14 @@ func (c *ATSPIClient) ClickableNodes(
 		zap.Duration("elapsed", time.Since(start)))
 
 	// An empty scan is normal for a window with nothing clickable, but if we got
-	// here because reads kept hitting the per-call deadline, the app is slow or
-	// unresponsive to accessibility queries — report that rather than silently
+	// here because reads kept failing fatally — the app timed out, exited, or
+	// dropped its accessibility connection — report that rather than silently
 	// showing no hints. A partial result (some nodes collected) is returned as-is.
-	if len(out) == 0 && diag.timedOut.Load() {
-		return nil, derrors.New(derrors.CodeTimeout,
-			"AT-SPI element scan timed out; the app may be slow or "+
-				"unresponsive to accessibility queries")
+	if len(out) == 0 {
+		ferr := diag.fatalErr()
+		if ferr != nil {
+			return nil, scanFailureError(ferr)
+		}
 	}
 
 	return out, nil
@@ -890,29 +891,96 @@ func (c *ATSPIClient) focusStableSince(selectedAppID, selectedTitle string) bool
 }
 
 // atspiScanDiag records diagnostics for a single ClickableNodes scan. It rides
-// on the scan context so the leaf D-Bus helpers can flag a per-call timeout
-// without threading an extra parameter through the whole walk. A scan that ends
-// up empty because the app stopped answering accessibility queries can then
-// report an actionable timeout instead of a silent empty result.
+// on the scan context so the leaf D-Bus helpers can report a scan-fatal failure
+// (a per-call timeout, a closed connection, or the target app disappearing from
+// the bus) without threading an extra parameter through the whole walk. A scan
+// that ends up empty for one of those reasons can then surface an actionable
+// error instead of a silent empty result; benign per-node errors are ignored.
 type atspiScanDiag struct {
-	timedOut atomic.Bool
+	mu  sync.Mutex
+	err error
+}
+
+// note records the first scan-fatal error. Safe for concurrent use by the
+// materialize/walk goroutines.
+func (d *atspiScanDiag) note(err error) {
+	d.mu.Lock()
+	if d.err == nil {
+		d.err = err
+	}
+	d.mu.Unlock()
+}
+
+// fatalErr returns the first scan-fatal error, or nil. Call after the scan's
+// goroutines have joined.
+func (d *atspiScanDiag) fatalErr() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.err
 }
 
 // atspiScanDiagKey is the context key for the active scan's *atspiScanDiag.
 type atspiScanDiagKey struct{}
 
-// noteCallErr flags the scan as timed out when err is a per-call context
-// deadline (godbus surfaces the raw context.DeadlineExceeded). Non-timeout
-// errors, and contexts with no diag attached (e.g. the frame-selection reads in
-// findActiveFrame), are ignored.
+// D-Bus error names that mean the scan cannot make progress: the target
+// application has left the bus, or its connection is gone. Deliberately NOT
+// including UnknownMethod (GetChildren has a fallback) or per-node errors on a
+// stale node, so an otherwise-healthy — or genuinely empty — window is never
+// misreported as a failure.
+const (
+	atspiErrServiceUnknown = "org.freedesktop.DBus.Error.ServiceUnknown"
+	atspiErrNoReply        = "org.freedesktop.DBus.Error.NoReply"
+	atspiErrDisconnected   = "org.freedesktop.DBus.Error.Disconnected"
+)
+
+// isScanFatalErr reports whether err means the whole scan is failing rather than
+// a single benign node: a per-call context deadline, a closed connection, or the
+// application having disappeared from the bus.
+func isScanFatalErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, dbus.ErrClosed) {
+		return true
+	}
+
+	if dbusErr, ok := errors.AsType[dbus.Error](err); ok {
+		switch dbusErr.Name {
+		case atspiErrServiceUnknown, atspiErrNoReply, atspiErrDisconnected:
+			return true
+		}
+	}
+
+	return false
+}
+
+// noteCallErr records a scan-fatal error on the scan's diagnostic (if one is
+// attached to ctx). Benign errors, and contexts with no diag attached (e.g. the
+// frame-selection reads in findActiveFrame), are ignored.
 func (c *ATSPIClient) noteCallErr(ctx context.Context, err error) {
-	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+	if !isScanFatalErr(err) {
 		return
 	}
 
 	if d, ok := ctx.Value(atspiScanDiagKey{}).(*atspiScanDiag); ok {
-		d.timedOut.Store(true)
+		d.note(err)
 	}
+}
+
+// scanFailureError turns a scan-fatal error into a user-facing hints error,
+// distinguishing an unresponsive app (per-call deadline) from one that has gone.
+func scanFailureError(err error) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return derrors.New(derrors.CodeTimeout,
+			"AT-SPI element scan timed out; the app may be slow or "+
+				"unresponsive to accessibility queries")
+	}
+
+	return derrors.Wrap(err, derrors.CodeAccessibilityFailed,
+		"AT-SPI element scan failed; the app may have exited or lost its "+
+			"accessibility connection")
 }
 
 // children returns the AT-SPI children of an accessible. It prefers the bulk

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -274,6 +274,13 @@ func (c *ATSPIClient) FrontmostWindow(ctx context.Context) (AXWindow, error) {
 		return nil, err
 	}
 
+	// Attach a scan diagnostic so the bounded frame-selection reads can flag a
+	// fatal AT-SPI failure (a timeout, a closed connection, or the registry/app
+	// leaving the bus). Without it a registry that stops responding looks like
+	// "no active frame" and hints show nothing with no error.
+	diag := &atspiScanDiag{}
+	ctx = context.WithValue(ctx, atspiScanDiagKey{}, diag)
+
 	// Read the compositor's focused app_id and title once (together so they
 	// describe one window) and use this single snapshot both to select the frame
 	// and to record it on the window. Reading it again after selection could
@@ -283,6 +290,14 @@ func (c *ATSPIClient) FrontmostWindow(ctx context.Context) (AXWindow, error) {
 
 	frame, ok := c.findActiveFrame(ctx, conn, focusedAppID, focusedTitle)
 	if !ok {
+		// Distinguish a genuine "nothing focused" from an AT-SPI failure during
+		// selection: only the latter recorded a scan-fatal error. A frame that
+		// *was* found is returned even if some other app errored mid-scan.
+		ferr := diag.fatalErr()
+		if ferr != nil {
+			return nil, scanFailureError(ferr)
+		}
+
 		c.logger.Debug("AT-SPI: no active frame found")
 
 		// No active frame: hand back an empty window so the adapter simply

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/infra/platform"
 	"github.com/y3owk1n/neru/internal/core/infra/platform/linux"
 )
@@ -340,6 +341,12 @@ func (c *ATSPIClient) ClickableNodes(
 		return nil, err
 	}
 
+	// Attach a per-scan diagnostic so the leaf D-Bus helpers can flag a per-call
+	// timeout. It lets an empty result caused by an unresponsive app surface as a
+	// clear timeout below instead of looking like a window with no elements.
+	diag := &atspiScanDiag{}
+	ctx = context.WithValue(ctx, atspiScanDiagKey{}, diag)
+
 	start := time.Now()
 
 	// Early-out: if focus already changed since this window was selected, the
@@ -412,6 +419,16 @@ func (c *ATSPIClient) ClickableNodes(
 		zap.Int("offsetY", offY),
 		zap.Bool("haveOrigin", haveOrigin),
 		zap.Duration("elapsed", time.Since(start)))
+
+	// An empty scan is normal for a window with nothing clickable, but if we got
+	// here because reads kept hitting the per-call deadline, the app is slow or
+	// unresponsive to accessibility queries — report that rather than silently
+	// showing no hints. A partial result (some nodes collected) is returned as-is.
+	if len(out) == 0 && diag.timedOut.Load() {
+		return nil, derrors.New(derrors.CodeTimeout,
+			"AT-SPI element scan timed out; the app may be slow or "+
+				"unresponsive to accessibility queries")
+	}
 
 	return out, nil
 }
@@ -872,6 +889,32 @@ func (c *ATSPIClient) focusStableSince(selectedAppID, selectedTitle string) bool
 	return currentAppID == selectedAppID && currentTitle == selectedTitle
 }
 
+// atspiScanDiag records diagnostics for a single ClickableNodes scan. It rides
+// on the scan context so the leaf D-Bus helpers can flag a per-call timeout
+// without threading an extra parameter through the whole walk. A scan that ends
+// up empty because the app stopped answering accessibility queries can then
+// report an actionable timeout instead of a silent empty result.
+type atspiScanDiag struct {
+	timedOut atomic.Bool
+}
+
+// atspiScanDiagKey is the context key for the active scan's *atspiScanDiag.
+type atspiScanDiagKey struct{}
+
+// noteCallErr flags the scan as timed out when err is a per-call context
+// deadline (godbus surfaces the raw context.DeadlineExceeded). Non-timeout
+// errors, and contexts with no diag attached (e.g. the frame-selection reads in
+// findActiveFrame), are ignored.
+func (c *ATSPIClient) noteCallErr(ctx context.Context, err error) {
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+
+	if d, ok := ctx.Value(atspiScanDiagKey{}).(*atspiScanDiag); ok {
+		d.timedOut.Store(true)
+	}
+}
+
 // children returns the AT-SPI children of an accessible. It prefers the bulk
 // GetChildren method and falls back to ChildCount + GetChildAtIndex for older
 // toolkits that do not expose GetChildren.
@@ -888,6 +931,8 @@ func (c *ATSPIClient) children(ctx context.Context, conn *dbus.Conn, ref accRef)
 		return kids
 	}
 
+	c.noteCallErr(ctx, err)
+
 	var countVar dbus.Variant
 
 	countCtx, cancelCount := context.WithTimeout(ctx, atspiCallTimeout)
@@ -896,6 +941,8 @@ func (c *ATSPIClient) children(ctx context.Context, conn *dbus.Conn, ref accRef)
 	propErr := obj.CallWithContext(countCtx, atspiPropertiesGet, 0,
 		atspiAccessibleIfc, "ChildCount").Store(&countVar)
 	if propErr != nil {
+		c.noteCallErr(ctx, propErr)
+
 		return nil
 	}
 
@@ -911,6 +958,8 @@ func (c *ATSPIClient) children(ctx context.Context, conn *dbus.Conn, ref accRef)
 		cancelChild()
 
 		if err != nil {
+			c.noteCallErr(ctx, err)
+
 			continue
 		}
 
@@ -930,6 +979,8 @@ func (c *ATSPIClient) roleName(ctx context.Context, conn *dbus.Conn, ref accRef)
 	err := conn.Object(ref.Name, ref.Path).
 		CallWithContext(callCtx, atspiAccessibleIfc+".GetRoleName", 0).Store(&name)
 	if err != nil {
+		c.noteCallErr(ctx, err)
+
 		return ""
 	}
 
@@ -946,6 +997,8 @@ func (c *ATSPIClient) name(ctx context.Context, conn *dbus.Conn, ref accRef) str
 	err := conn.Object(ref.Name, ref.Path).
 		CallWithContext(callCtx, atspiPropertiesGet, 0, atspiAccessibleIfc, "Name").Store(&val)
 	if err != nil {
+		c.noteCallErr(ctx, err)
+
 		return ""
 	}
 
@@ -964,6 +1017,8 @@ func (c *ATSPIClient) stateHas(ctx context.Context, conn *dbus.Conn, ref accRef,
 	err := conn.Object(ref.Name, ref.Path).
 		CallWithContext(callCtx, atspiAccessibleIfc+".GetState", 0).Store(&states)
 	if err != nil || len(states) == 0 {
+		c.noteCallErr(ctx, err)
+
 		return false
 	}
 
@@ -989,6 +1044,8 @@ func (c *ATSPIClient) extents(
 	err := conn.Object(ref.Name, ref.Path).
 		CallWithContext(callCtx, atspiComponentIfc+".GetExtents", 0, atspiCoordScreen).Store(&ext)
 	if err != nil {
+		c.noteCallErr(ctx, err)
+
 		return image.Rectangle{}, false
 	}
 

--- a/internal/core/infra/ipc/ipc.go
+++ b/internal/core/infra/ipc/ipc.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"go.uber.org/zap"
@@ -299,8 +301,27 @@ func (s *Server) handleConnection(connection net.Conn) {
 
 	connectionDeadline = encoder.Encode(response)
 	if connectionDeadline != nil {
-		logger.Error("Failed to encode response", zap.Error(connectionDeadline))
+		if isPeerGoneErr(connectionDeadline) {
+			// The client already disconnected before we could reply — almost
+			// always because it hit its own request timeout while the handler
+			// was still working. That is the client's decision, not a daemon
+			// fault, so log it quietly instead of as an error.
+			logger.Debug("Client disconnected before response was sent",
+				zap.Error(connectionDeadline))
+		} else {
+			logger.Error("Failed to encode response", zap.Error(connectionDeadline))
+		}
 	}
+}
+
+// isPeerGoneErr reports whether err is the expected result of writing to a
+// connection whose peer has already gone away (broken pipe, connection reset,
+// or an already-closed pipe/connection). These are benign races, not faults.
+func isPeerGoneErr(err error) bool {
+	return errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, io.ErrClosedPipe)
 }
 
 // Client provides an interface for sending commands to the IPC server.


### PR DESCRIPTION
## Description

This PR fixes hints mode on Linux failing with no elements shown and the daemon logging a bare "broken pipe": a slow or unresponsive accessibility backend now has each AT-SPI call individually bounded, real scan failures are surfaced as clear errors instead of silently looking like an empty window, and the client waits long enough for the daemon to reply.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The per-AT-SPI-call bound is 500ms (single-digit ms is normal); the bulk `Collection.GetMatches` keeps the full scan budget. A window-scan failure is only surfaced when no source produced any elements, so it degrades rather than discarding elements other sources collected in parallel. The broken-pipe log downgrade matches POSIX socket errors, so it applies on Linux/macOS; the Windows named-pipe transport keeps logging at error level.