### PR TITLE
feat(config): cross-platform role vocabulary for clickable_roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Neru is a keyboard-driven navigation tool for macOS built with Go and Objective-
 - **Bridge**: Objective-C macOS integration layer
 - **Adapter**: Port implementation for external systems
 - **Port**: Interface definition for system capabilities (e.g., [accessibility.go](internal/core/ports/accessibility.go))
+- **Semantic role**: Platform-neutral role name written in `hints.clickable_roles` (`button`, `text_field`). Resolved to each platform's native accessibility vocabulary — AX on macOS, AT-SPI on Linux, UI Automation on Windows — at config load. Native roles are addressed by prefix (`ax:`, `atspi:`, `uia:`). See [vocabulary.go](internal/core/domain/element/vocabulary.go)
 
 ## Architecture & Cross-Platform
 
@@ -32,6 +33,7 @@ Neru follows a **Hexagonal Architecture (Ports and Adapters)**. All OS-specific 
 - **Navigation Logic**: [internal/app/modes/](internal/app/modes/)
 - **Coordinate Conversion**: [conversion.go](internal/ui/coordinates/conversion.go)
 - **Error Definitions**: [errors.go](internal/core/errors/errors.go)
+- **Role Vocabulary**: [vocabulary.go](internal/core/domain/element/vocabulary.go) — adapters emit native role names; only config resolution translates
 - **Native macOS Logic**: [internal/core/infra/platform/darwin/](internal/core/infra/platform/darwin/)
 
 ### Contextual Shortcuts

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -63,23 +63,29 @@ include_pip_hints = false
 include_screen_capture_hints = false
 detect_mission_control = false
 clickable_roles = [
-    "AXButton",
-	"AXMenuButton",
-    "AXComboBox",
-    "AXCheckBox",
-    "AXRadioButton",
-    "AXLink",
-    "AXPopUpButton",
-    "AXTextField",
-    "AXSlider",
-    "AXTabButton",
-    "AXSwitch",
-    "AXDisclosureTriangle",
-    "AXTextArea",
-    "AXMenuItem",
-    "AXCell",
-    "AXRow",
-	"AXGenericElement",
+    ## Semantic role names. They resolve to each platform's native
+    ## accessibility vocabulary, so this list works on macOS, Linux and Windows.
+    ## Run `neru roles` for the full vocabulary and how it resolves here.
+    "button",
+    "menu_button",
+    "popup_button",
+    "combo_box",
+    "checkbox",
+    "radio",
+    "switch",
+    "disclosure",
+    "link",
+    "text_field",
+    "text_area",
+    "slider",
+    "tab",
+    "menu_item",
+    "cell",
+    "row",
+    ## Native roles are addressed through their vocabulary prefix
+    ## (`ax:` macOS, `atspi:` Linux, `uia:` Windows). Entries for other
+    ## platforms are ignored rather than rejected.
+    "ax:AXGenericElement",
 ]
 ignore_clickable_check = false
 visible_check_enabled = false

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -13,8 +13,12 @@ passthrough_unbounded_keys = false           # Let unbound Cmd/Ctrl/Alt shortcut
 should_exit_after_passthrough = false        # Exit the current mode after a shortcut is passed through
 passthrough_unbounded_keys_blacklist = []    # Shortcuts to still consume when passthrough is on
 hide_overlay_in_screen_share = false         # Hide overlay from screen sharing apps
-exec_shell = "/bin/bash"                     # Shell used for exec commands (e.g. "/bin/dash", "/bin/zsh")
-exec_shell_args = ["-lc"]                    # Shell arguments, where the last argument will be the command string
+# Shell used for exec commands. Left unset so the platform default applies:
+# /bin/bash -lc on macOS and Linux, %SystemRoot%\System32\cmd.exe /c on Windows.
+# Setting an absolute path here overrides that on every platform, so a value
+# valid on one will fail validation on another.
+# exec_shell = "/bin/bash"                   # e.g. "/bin/dash", "/bin/zsh"
+# exec_shell_args = ["-lc"]                  # last argument receives the command string
 
 # Theme palette
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#theme

--- a/configs/hints-only-config.toml
+++ b/configs/hints-only-config.toml
@@ -21,22 +21,29 @@ additional_menubar_hints_targets = [
     "com.y3owk1n.neru",
 ]
 clickable_roles = [
-    "AXButton",
-	"AXMenuButton",
-    "AXComboBox",
-    "AXCheckBox",
-    "AXRadioButton",
-    "AXLink",
-    "AXPopUpButton",
-    "AXTextField",
-    "AXSlider",
-    "AXTabButton",
-    "AXSwitch",
-    "AXDisclosureTriangle",
-    "AXTextArea",
-    "AXMenuItem",
-    "AXCell",
-    "AXRow",
+    ## Semantic role names. They resolve to each platform's native
+    ## accessibility vocabulary, so this list works on macOS, Linux and Windows.
+    ## Run `neru roles` for the full vocabulary and how it resolves here.
+    "button",
+    "menu_button",
+    "popup_button",
+    "combo_box",
+    "checkbox",
+    "radio",
+    "switch",
+    "disclosure",
+    "link",
+    "text_field",
+    "text_area",
+    "slider",
+    "tab",
+    "menu_item",
+    "cell",
+    "row",
+    ## Native roles are addressed through their vocabulary prefix
+    ## (`ax:` macOS, `atspi:` Linux, `uia:` Windows). Entries for other
+    ## platforms are ignored rather than rejected.
+    "ax:AXGenericElement",
 ]
 ignore_clickable_check = false
 
@@ -53,7 +60,7 @@ ignore_clickable_check = false
 ## macOS example:
 # [[hints.app_configs]]
 # bundle_id = "com.brave.Browser"
-# additional_clickable_roles = ["AXTabGroup"]
+# additional_clickable_roles = ["ax:AXTabGroup"]
 # ignore_clickable_check = false
 # hotkeys = {
 # 	"Return" = "action left_click",

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -129,7 +129,8 @@ Uses the macOS Accessibility API (`axtree`) or Vision Framework (`vision`) to di
 
 `--hide-on-empty-search` -- Hide all hints when search is empty (requires `--search`).
 
-`--role <role>` -- Filter by AX role. Comma-separated (e.g. `AXButton,AXLink`).
+`--role <role>` -- Filter by role. Comma-separated (e.g. `button,link`). Accepts the same
+vocabulary as `hints.clickable_roles`; run `neru roles` to list it.
 
 `--text <text>` -- Filter by text content. Case-insensitive substring match. Comma-separated for OR.
 
@@ -149,7 +150,7 @@ neru hints --action left_click
 neru hints --action left_click --modifier shift
 neru hints --action left_click --repeat
 neru hints --search
-neru hints --role AXButton --text submit
+neru hints --role button --text submit
 neru hints --strategy vision --split-word
 ```
 
@@ -601,7 +602,7 @@ The key uses dotted TOML path notation matching your config file (e.g. `hints.hi
 | boolean | `true`                                 |
 | float   | `0.5`                                  |
 | color   | `"#FF0000AA"` or `{"light":"#000","dark":"#FFF"}` |
-| array   | `"AXButton,AXLink"` or `'["AXButton","AXLink"]'` |
+| array   | `"button,link"` or `'["button","link"]'` |
 
 **EXAMPLES**
 
@@ -609,7 +610,7 @@ The key uses dotted TOML path notation matching your config file (e.g. `hints.hi
 neru config set hints.hint_characters "asdfghjkl"
 neru config set hints.ui.font_size 14
 neru config set general.passthrough_unbounded_keys true
-neru config set hints.clickable_roles "AXButton,AXLink"
+neru config set hints.clickable_roles "button,link"
 neru config set scroll.scroll_step 50
 neru config set --no-reload recursive_grid.grid_cols 3
 neru config set --no-reload recursive_grid.keys "abcdefghijkl"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -165,7 +165,7 @@ To revert all overrides at once, delete the override file and run `neru config r
 | boolean | `neru config set scroll.invert_scroll true`    |
 | float   | `neru config set hints.vision.minimum_confidence 0.3` |
 | color   | `neru config set hints.ui.background_color "#FF0000AA"` |
-| array   | `neru config set hints.clickable_roles "AXButton,AXLink"` |
+| array   | `neru config set hints.clickable_roles "button,link"` |
 
 > **Tip:** Use `neru config dump | jq` to explore the full config structure and find the dotted path for any setting.
 
@@ -538,9 +538,84 @@ Start with search visible: `neru hints --search` (see [CLI.md](CLI.md#7-neru-hin
 | `on_mission_control_activated`     | string/array | `nil`                   | Action(s) to execute when Mission Control opens                                                                                                                                                                                                                                                                                      |
 | `on_mission_control_deactivated`   | string/array | `nil`                   | Action(s) to execute when Mission Control closes                                                                                                                                                                                                                                                                                     |
 | `additional_menubar_hints_targets` | array        | macOS-specific defaults | Extra menubar bundle IDs                                                                                                                                                                                                                                                                                                             |
-| `clickable_roles`                  | array        | macOS-specific defaults | AX roles that generate hints                                                                                                                                                                                                                                                                                                         |
+| `clickable_roles`                  | array        | shared semantic defaults | Roles that generate hints. See [Clickable roles](#clickable-roles)                                                                                                                                                                                                                                                                  |
 | `ignore_clickable_check`           | bool         | `false`                 | Skip clickability heuristic                                                                                                                                                                                                                                                                                                          |
 | `visible_check_enabled`            | bool         | `false`                 | Enable visibility hit-test (slower but fewer noisy hints)                                                                                                                                                                                                                                                                            |
+
+### Clickable roles
+
+`hints.clickable_roles` decides which accessibility elements get a hint. Each platform
+exposes a different role vocabulary — macOS uses AX roles, Linux uses AT-SPI role names,
+Windows uses UI Automation control types — so entries are written in neru's own semantic
+vocabulary and resolved to the native names of whichever platform neru is running on.
+
+```toml
+[hints]
+clickable_roles = ["button", "link", "text_field"]
+```
+
+The same list works on every platform. Run `neru roles` to see the vocabulary and how each
+name resolves here, and `neru roles --explain` to see how your own config resolves.
+
+#### Semantic roles
+
+| Semantic       | macOS (`ax:`)          | Linux (`atspi:`)                        | Windows (`uia:`)      |
+| -------------- | ---------------------- | --------------------------------------- | --------------------- |
+| `button`       | `AXButton`             | `push button`, `button`, `toggle button` | `Button`, `SplitButton` |
+| `menu_button`  | `AXMenuButton`         | `push button menu`                      | —                     |
+| `popup_button` | `AXPopUpButton`        | `combo box`                             | `ComboBox`            |
+| `combo_box`    | `AXComboBox`           | `combo box`                             | `ComboBox`            |
+| `link`         | `AXLink`               | `link`                                  | `Hyperlink`           |
+| `checkbox`     | `AXCheckBox`           | `check box`, `check menu item`          | `CheckBox`            |
+| `radio`        | `AXRadioButton`        | `radio button`, `radio menu item`       | `RadioButton`         |
+| `switch`       | `AXSwitch`             | `switch`, `toggle button`               | —                     |
+| `disclosure`   | `AXDisclosureTriangle` | —                                       | —                     |
+| `text_field`   | `AXTextField`          | `entry`, `password text`                | `Edit`                |
+| `text_area`    | `AXTextArea`           | `entry`                                 | `Edit`                |
+| `search_field` | `AXSearchField`        | `entry`                                 | `Edit`                |
+| `slider`       | `AXSlider`             | `slider`                                | `Slider`              |
+| `stepper`      | `AXIncrementor`        | `spin button`                           | `Spinner`             |
+| `tab`          | `AXTabButton`          | `page tab`                              | `TabItem`             |
+| `menu_item`    | `AXMenuItem`           | `menu item`                             | `MenuItem`            |
+| `menubar_item` | `AXMenuBarItem`        | —                                       | —                     |
+| `dock_item`    | `AXDockItem`           | —                                       | —                     |
+| `cell`         | `AXCell`               | `table cell`                            | `DataItem`            |
+| `row`          | `AXRow`                | `table row`                             | `TreeItem`            |
+| `list_item`    | `AXRow`                | `list item`                             | `ListItem`            |
+| `image`        | `AXImage`              | `image`, `icon`                         | `Image`               |
+| `static_text`  | `AXStaticText`         | `static`, `label`, `text`               | `Text`                |
+| `heading`      | `AXHeading`            | `heading`                               | —                     |
+| `color_well`   | `AXColorWell`          | `color chooser`                         | —                     |
+| `toolbar_button` | `AXToolbarButton`    | —                                       | —                     |
+
+A `—` means the platform has no equivalent; that entry is ignored there and reported by
+`neru roles --explain` and `neru doctor`.
+
+#### Native roles
+
+The semantic vocabulary is deliberately not exhaustive. Any native role can be addressed
+directly through its vocabulary prefix:
+
+```toml
+clickable_roles = [
+    "button",
+    "ax:AXDisclosureTriangle",   # macOS only
+    "atspi:page tab list",       # Linux only
+    "uia:Custom",                # Windows only
+]
+```
+
+Prefixed entries that belong to another platform are ignored rather than rejected, so one
+config file can serve several machines. This is the escape hatch for toolkits that expose
+little role information — many legacy Win32 and WinForms controls surface only as
+`uia:Pane`, `uia:Custom` or `uia:Document`, and hinting them requires naming them directly.
+
+Unprefixed entries must be semantic roles. An unrecognised one is a configuration error,
+which is what makes typos visible:
+
+```
+hints.clickable_roles: unknown role "AXButton": use "button"
+```
 
 ### UI
 
@@ -683,7 +758,7 @@ You can also mix directions per-app via `[hints.app_configs]` or per-activation 
 | `bundle_id`                  | string | App bundle ID                                                                                                                                                                             |
 | `strategy`                   | string | Override element detection strategy for this app (`"axtree"` or `"vision"`). Empty string = use global `hints.strategy`.                                                                  |
 | `label_direction`            | string | Override hint label algorithm for this app (`"normal"` or `"reverse"`). Empty string = use global `hints.label_direction`. See [Choosing a label direction](#choosing-a-label-direction). |
-| `additional_clickable_roles` | array  | Extra AX roles to treat as clickable                                                                                                                                                      |
+| `additional_clickable_roles` | array  | Extra roles to treat as clickable, same vocabulary as [`clickable_roles`](#clickable-roles)                                                                                              |
 | `ignore_clickable_check`     | bool   | Skip clickability heuristic for this app                                                                                                                                                  |
 | `visible_check_enabled`      | bool   | Enable visibility hit-test for this app                                                                                                                                                   |
 | `hotkeys`                    | map    | [per-app hotkey overrides](#per-app-hotkey-overrides)                                                                                                                                     |
@@ -693,7 +768,7 @@ You can also mix directions per-app via `[hints.app_configs]` or per-activation 
 bundle_id = "com.apple.Safari"
 strategy = "vision"
 label_direction = "reverse"
-additional_clickable_roles = ["AXLink"]
+additional_clickable_roles = ["link"]
 ignore_clickable_check = true
 visible_check_enabled = true
 ```

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -628,8 +628,9 @@ Mission Control events remain macOS-only.
 **Accessibility on Linux (⚠️, not a stub):** hints-mode element discovery is
 implemented via AT-SPI over D-Bus. `ATSPIClient` (`atspi_linux.go`) enables
 assistive-tech mode, finds the active frame, and walks its tree
-(`ClickableNodes`) for clickable elements, mapping AT-SPI roles to Neru's AX
-role vocabulary. This is the client the Linux adapter actually uses
+(`ClickableNodes`) for clickable elements, emitting native AT-SPI role names.
+Configured roles are resolved into that vocabulary at config load, so both
+sides of the filter speak AT-SPI. This is the client the Linux adapter actually uses
 (`platform_client_linux.go` → `Adapter.ClickableElements` → `client.ClickableNodes`);
 the `TreeNode`/`BuildTree` stub in `tree_linux.go` is the macOS-style tree API
 and is **not** on the Linux hints path. Click/scroll then inject at the hint
@@ -764,7 +765,7 @@ Key files:
 | **Adapter location**       | `internal/core/infra/accessibility/element_darwin.go`                                                                                                                                    | `internal/core/infra/accessibility/element_linux.go` + `atspi_linux.go` | `internal/core/infra/accessibility/element_windows.go` + `uia_windows.go`            |
 | **Client**                 | `InfraAXClient` wraps Element/TreeNode → ObjC bridge                                                                                                                                     | `ATSPIClient` → D-Bus `org.a11y.atspi`                                  | `UIAClient` → raw COM vtable calls                                                   |
 | **Tree building**          | Full recursive tree walk of AXUIElement hierarchy (`tree.go`). Collects from: frontmost window, popover windows, menubar, dock, notification center, Stage Manager, PIP, screen capture. | Recursive AT-SPI D-Bus walk of the active frame (`ATSPIClient.ClickableNodes`, `atspi_linux.go`), depth/node capped. The `tree_linux.go` `BuildTree` stub is the macOS-style API and is not on this path. | Shallow UIA tree walk returning root-level clickable nodes (`tree_windows.go`).      |
-| **Clickable filtering**    | Extensive: role matching, size/position heuristics, excluded apps list. Multiple strategy backends (AX + Vision).                                                                        | AT-SPI role → AX role mapping, SHOWING-state + on-screen extents check; coverage depends on the app's AT-SPI support. | Basic: collects `IUIAutomationElement` with `IsControlElement` + `IsContentElement`. |
+| **Clickable filtering**    | Extensive: role matching, size/position heuristics, excluded apps list. Multiple strategy backends (AX + Vision).                                                                        | Native AT-SPI role matching, SHOWING-state + on-screen extents check; coverage depends on the app's AT-SPI support. | Basic: collects `IUIAutomationElement` with `IsControlElement` + `IsContentElement`. |
 | **Strategy support**       | `config.StrategyAX` (default), `config.StrategyVision` (macOS Vision Framework).                                                                                                         | AX only (no Vision/OCR fallback).                                       | AX only.                                                                             |
 | **Popover / menu support** | ✅ (AXOrientation-based popover detection, menubar walking).                                                                                                                             | ⚠️ (popovers/menus in the active frame's AT-SPI subtree are walked; no separate menubar/dock collection). | 🟡                                                                                   |
 | **Focused application**    | ✅ (NSWorkspace + AXUIElement).                                                                                                                                                          | ✅ (X11: `_NET_ACTIVE_WINDOW`; Wayland: `wlr-foreign-toplevel` app_id on wlroots/KDE, XWayland fallback). | ✅ (Win32 `GetForegroundWindow`).                                                    |
@@ -817,9 +818,10 @@ left-most held button — a single event cannot describe more than one.
 - `ATSPIClient.FrontmostWindow` finds the active frame (ACTIVE + SHOWING state)
   across registered applications, skipping virtual keyboards and system surfaces
 - `ClickableNodes` recursively walks that frame's subtree (depth/node capped),
-  keeping SHOWING elements whose mapped AX role is in the requested set
-- AT-SPI role names are mapped to Neru's AX role vocabulary
-  (`atspiToAXRole`) so the shared filter pipeline matches them
+  keeping SHOWING elements whose AT-SPI role is in the requested set
+- Configured roles are resolved from the semantic vocabulary into native
+  AT-SPI names before they reach the client
+  (`element.ResolveRoles`), so the shared filter pipeline matches them
 - On Wayland it offsets element extents by the focused window's screen origin
   (via the KWin geometry bridge) since AT-SPI reports window-relative coords
 - Element structs in `element_linux.go` implement cursor/scroll/click injection

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -302,7 +302,7 @@ hotkeys = { "Cmd+1" = ["action move_mouse --window --x -1000 --y -1000", "action
 ```toml
 [[app_configs]]
 bundle_id = "com.anthropic.claudefordesktop"
-hotkeys = { "Cmd+1" = ["hints --role AXButton --text Home --action left_click", "action feed --mode a"] }
+hotkeys = { "Cmd+1" = ["hints --role button --text Home --action left_click", "action feed --mode a"] }
 ```
 
 `action feed --mode a` presses the first hint label. Which element gets `a` depends on your hint configuration (menu-bar hints, label direction, and so on), so confirm it lands on the element you mean. This method is precise when the element is unique, and fragile when the text is common. A button labelled "Code" is easy to confuse with every "Copy code" button in the same window. When a view's hint filter is too ambiguous to trust, fall back to the window-relative form for that key.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -163,7 +163,11 @@ osascript -e 'id of app "Your Browser"'
 
 This can happen when the element you're trying to select is small. If you encounter this, open an issue.
 
-Alternatively, make sure all relevant roles are enabled. If you've customized `hints.clickable_roles`, you can remove that customization or restore it to the original value from [default-config.toml](https://github.com/y3owk1n/neru/blob/3a8d3c848d63e6757b602cb4dc31fb532aa310d7/configs/default-config.toml#L65).
+Alternatively, make sure all relevant roles are enabled. Run `neru roles --explain` to see
+exactly which roles your config selects on this platform, and `neru roles` for the full
+vocabulary. If you've customized `hints.clickable_roles`, you can remove that customization
+or restore it to the original value from
+[default-config.toml](https://github.com/y3owk1n/neru/blob/main/configs/default-config.toml).
 
 Run `neru config reload` and then test.
 
@@ -176,7 +180,10 @@ clickable_roles = [
 
 ### Certain hints don't visually match any on-screen UI
 
-Neru may be generating hints for elements that are not directly visible to you, such as `AXRow` and `AXCell`. Copy the complete `clickable_roles` list from [default-config.toml](https://github.com/y3owk1n/neru/blob/main/configs/default-config.toml), then remove only those roles so the remaining defaults stay enabled.
+Neru may be generating hints for elements that are not directly visible to you, such as `row`
+and `cell`. Copy the complete `clickable_roles` list from
+[default-config.toml](https://github.com/y3owk1n/neru/blob/main/configs/default-config.toml),
+then remove only those roles so the remaining defaults stay enabled.
 
 Run `neru config reload` and then test.
 
@@ -462,7 +469,7 @@ pkill -9 neru
 ```toml
 [[hints.app_configs]]
 bundle_id = "com.adobe.illustrator"
-additional_clickable_roles = ["AXStaticText", "AXImage"]
+additional_clickable_roles = ["static_text", "image"]
 ignore_clickable_check = true
 ```
 

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -122,9 +122,12 @@ func (a *App) prepareForConfigUpdate() {
 // applyAppSpecificConfigUpdates applies app-specific configuration updates.
 func (a *App) applyAppSpecificConfigUpdates(loadResult *config.LoadResult) {
 	if loadResult.Config.Hints.Enabled {
+		roles := loadResult.Config.Hints.ResolvedClickableRoles()
+
 		a.logger.Debug("Updating clickable roles",
-			zap.Int("count", len(loadResult.Config.Hints.ClickableRoles)))
-		infra.SetClickableRoles(loadResult.Config.Hints.ClickableRoles, a.logger)
+			zap.Int("configured", len(loadResult.Config.Hints.ClickableRoles)),
+			zap.Int("resolved", len(roles)))
+		infra.SetClickableRoles(roles, a.logger)
 	}
 }
 

--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -51,9 +51,12 @@ func initializeOverlayManager(logger *zap.Logger) OverlayManager {
 func initializeAccessibility(cfg *config.Config, logger *zap.Logger) error {
 	// Apply clickable roles if hints are enabled
 	if cfg.Hints.Enabled {
+		roles := cfg.Hints.ResolvedClickableRoles()
+
 		logger.Debug("Applying clickable roles",
-			zap.Int("count", len(cfg.Hints.ClickableRoles)))
-		accessibilityAdapter.SetClickableRoles(cfg.Hints.ClickableRoles, logger)
+			zap.Int("configured", len(cfg.Hints.ClickableRoles)),
+			zap.Int("resolved", len(roles)))
+		accessibilityAdapter.SetClickableRoles(roles, logger)
 	}
 
 	return nil

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -133,18 +133,34 @@ func (s *HintService) GenerateHints(
 		}
 	}
 
-	// Use filterRoles if provided, otherwise use configured roles
-	var roles []string
+	// Use filterRoles if provided, otherwise use configured roles. requested
+	// holds the entries as written, before resolution, so that "no filter at
+	// all" stays distinguishable from "a filter that resolved to nothing".
+	var roles, requested []string
+
 	if len(filterRoles) > 0 {
-		roles = filterRoles
+		// `neru hints --role ...` accepts the same vocabulary as the config and
+		// is resolved the same way.
+		requested = filterRoles
+
+		resolution := element.ResolveRolesForCurrentPlatform(filterRoles)
+		roles = resolution.Native
+
 		s.logger.Debug("Using override roles from activation options",
-			zap.Strings("roles", roles))
+			zap.Int("requested", len(requested)),
+			zap.Int("role_count", len(roles)))
+
+		for _, message := range resolution.FatalMessages() {
+			s.logger.Warn("Ignoring role filter entry", zap.String("reason", message))
+		}
 	} else {
+		requested = cfg.MergedForApp(bundleID).ClickableRoles
 		roles = cfg.ClickableRolesForApp(bundleID)
+
 		s.logger.Debug("Resolved clickable roles for hints",
 			zap.String("bundle_id", bundleID),
-			zap.Int("role_count", len(roles)),
-			zap.Strings("roles", roles))
+			zap.Int("requested", len(requested)),
+			zap.Int("role_count", len(roles)))
 	}
 
 	filter.Roles = make([]element.Role, 0, len(roles))
@@ -154,6 +170,21 @@ func (s *HintService) GenerateHints(
 		}
 
 		filter.Roles = append(filter.Roles, element.Role(role))
+	}
+
+	// An empty filter.Roles means "match every role" to both the accessibility
+	// filter and the vision path. That is the right reading when no roles were
+	// configured, but the opposite of what was asked for when every configured
+	// entry belongs to another platform — hinting everything is worse than
+	// hinting nothing, and hides the misconfiguration. `neru roles --explain`
+	// and `neru doctor` report the cause.
+	if len(filter.Roles) == 0 && len(requested) > 0 {
+		s.logger.Warn(
+			"No configured role applies on this platform; showing no hints",
+			zap.Int("requested", len(requested)),
+		)
+
+		return nil, nil
 	}
 
 	filter.IncludeMenubar = cfg.IncludeMenubarHints

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"image"
+	"runtime"
 	"slices"
 	"testing"
 
@@ -121,7 +122,7 @@ func TestHintService_ShowHints(t *testing.T) {
 						elem, _ := element.NewElement(
 							element.ID(fmt.Sprintf("elem%d", index)),
 							image.Rect(index*10, index*10, index*10+40, index*10+40),
-							element.RoleButton,
+							nativeButtonRole,
 						)
 						elements[index] = elem
 					}
@@ -868,8 +869,23 @@ func TestHintService_Health(t *testing.T) {
 }
 
 // Helper functions.
+// nativeButtonRole is the accessibility role a button reports on the platform
+// running the tests. Configured roles resolve to native names, so an element
+// built with a role from another platform would silently stop matching a
+// config that asks for "button".
+var nativeButtonRole = func() element.Role {
+	native := element.ResolveRolesForCurrentPlatform(
+		[]string{string(element.SemanticButton)},
+	).Native
+	if len(native) == 0 {
+		return element.RoleButton
+	}
+
+	return element.Role(native[0])
+}()
+
 func mustNewElement(id string, bounds image.Rectangle) *element.Element {
-	element, elementErr := element.NewElement(element.ID(id), bounds, element.RoleButton)
+	element, elementErr := element.NewElement(element.ID(id), bounds, nativeButtonRole)
 	if elementErr != nil {
 		panic(elementErr)
 	}
@@ -956,7 +972,7 @@ func TestHintService_GenerateHintsRoleFilterResolvingToNothing(t *testing.T) {
 	}{
 		{
 			name:  "configured roles all belong to another platform",
-			roles: []string{"atspi:push button", "uia:Button"},
+			roles: foreignRolesForCurrentPlatform(),
 		},
 		{
 			name:        "role flag entries are unresolvable",
@@ -967,6 +983,10 @@ func TestHintService_GenerateHintsRoleFilterResolvingToNothing(t *testing.T) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
+			if len(testCase.roles) == 0 {
+				t.Skipf("no foreign role set defined for %s", runtime.GOOS)
+			}
+
 			mockAcc := &mocks.MockAccessibilityPort{}
 			mockAcc.ClickableElementsFunc = func(
 				_ context.Context,
@@ -1078,4 +1098,15 @@ func TestHintService_GenerateHintsRoleFlagOverridesConfig(t *testing.T) {
 				captured, role)
 		}
 	}
+}
+
+// foreignRolesForCurrentPlatform returns native role entries that belong to
+// platforms other than the one running the tests, so they resolve to nothing
+// here. Returns nil on a platform with no accessibility backend.
+func foreignRolesForCurrentPlatform() []string {
+	return map[string][]string{
+		"darwin":  {"atspi:push button", "uia:Button"},
+		"linux":   {"ax:AXButton", "uia:Button"},
+		"windows": {"ax:AXButton", "atspi:push button"},
+	}[runtime.GOOS]
 }

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"image"
+	"slices"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/app/services"
@@ -229,16 +230,28 @@ func TestHintService_ShowHints(t *testing.T) {
 						roles[role] = true
 					}
 
-					if !roles[element.Role("AXButton")] {
-						t.Error("expected global role AXButton to be present")
+					// The filter carries native role names for the running
+					// platform, so expectations are resolved the same way.
+					wantGlobal := element.ResolveRolesForCurrentPlatform([]string{"button"}).Native
+					wantApp := element.ResolveRolesForCurrentPlatform([]string{"heading"}).Native
+
+					for _, role := range wantGlobal {
+						if !roles[element.Role(role)] {
+							t.Errorf("expected global role %q to be present", role)
+						}
 					}
 
-					if !roles[element.Role("AXHeading")] {
-						t.Error("expected app-specific role AXHeading to be present")
+					for _, role := range wantApp {
+						if !roles[element.Role(role)] {
+							t.Errorf("expected app-specific role %q to be present", role)
+						}
 					}
 
-					if len(roles) != 2 {
-						t.Errorf("expected exactly 2 roles, got %v", filter.Roles)
+					if len(roles) != len(wantGlobal)+len(wantApp) {
+						t.Errorf(
+							"expected exactly %d roles, got %v",
+							len(wantGlobal)+len(wantApp), filter.Roles,
+						)
 					}
 
 					return testElements, nil
@@ -250,11 +263,11 @@ func TestHintService_ShowHints(t *testing.T) {
 				return gen
 			},
 			config: config.HintsConfig{
-				ClickableRoles: []string{"AXButton"},
+				ClickableRoles: []string{"button"},
 				AppConfigs: []config.AppConfig{
 					{
 						BundleID:            "net.imput.helium",
-						AdditionalClickable: []string{"AXHeading"},
+						AdditionalClickable: []string{"heading"},
 					},
 				},
 			},
@@ -511,7 +524,7 @@ func TestHintService_GenerateHintsVisionCombinesSupplementaryAndWindowElements(
 		mockSystem,
 		generator,
 		config.HintsConfig{
-			ClickableRoles:                []string{string(element.RoleButton)},
+			ClickableRoles:                []string{string(element.SemanticButton)},
 			IncludeMenubarHints:           true,
 			AdditionalMenubarHintsTargets: []string{"Clock"},
 			IncludeDockHints:              true,
@@ -921,5 +934,148 @@ func TestHintService_GenerateHintsRejectsSplitWordForNonVisionStrategy(t *testin
 
 	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
 		t.Errorf("expected invalid input error, got: %v", err)
+	}
+}
+
+// TestHintService_GenerateHintsRoleFilterResolvingToNothing pins the behavior
+// of a role filter that is configured but resolves to no native role on this
+// platform — for example a config carrying only Linux entries, run on macOS.
+//
+// An empty ports.ElementFilter.Roles means "match every role", so the naive
+// outcome is that an unusable filter hints *everything*. It must hint nothing.
+func TestHintService_GenerateHintsRoleFilterResolvingToNothing(t *testing.T) {
+	testElements := []*element.Element{
+		mustNewElement("elem1", image.Rect(10, 10, 50, 50)),
+		mustNewElement("elem2", image.Rect(60, 10, 100, 50)),
+	}
+
+	tests := []struct {
+		name        string
+		roles       []string
+		filterRoles []string
+	}{
+		{
+			name:  "configured roles all belong to another platform",
+			roles: []string{"atspi:push button", "uia:Button"},
+		},
+		{
+			name:        "role flag entries are unresolvable",
+			roles:       []string{string(element.SemanticButton)},
+			filterRoles: []string{"AXButton"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			mockAcc := &mocks.MockAccessibilityPort{}
+			mockAcc.ClickableElementsFunc = func(
+				_ context.Context,
+				_ ports.ElementFilter,
+			) ([]*element.Element, error) {
+				return testElements, nil
+			}
+
+			generator, _ := hint.NewAlphabetGenerator("asdf", hint.LabelDirectionReverse)
+			service := services.NewHintService(
+				mockAcc,
+				&mocks.MockOverlayPort{},
+				&mocks.MockSystemPort{},
+				generator,
+				config.HintsConfig{ClickableRoles: testCase.roles},
+				logger.Get(),
+				nil,
+			)
+
+			hints, err := service.GenerateHints(
+				context.Background(),
+				testCase.filterRoles,
+				nil,
+				"com.example.app",
+				"",
+				"",
+				false,
+			)
+			if err != nil {
+				t.Fatalf("GenerateHints() unexpected error: %v", err)
+			}
+
+			if len(hints) != 0 {
+				t.Errorf(
+					"GenerateHints() returned %d hints for an unusable role filter, want 0",
+					len(hints),
+				)
+			}
+		})
+	}
+}
+
+// TestHintService_GenerateHintsRoleFlagOverridesConfig covers the happy path of
+// `neru hints --role ...`: the flag replaces the configured roles entirely and
+// is resolved through the same vocabulary, so it accepts semantic names and
+// vocabulary-prefixed native names alike.
+func TestHintService_GenerateHintsRoleFlagOverridesConfig(t *testing.T) {
+	testElements := []*element.Element{
+		mustNewElement("elem1", image.Rect(10, 10, 50, 50)),
+	}
+
+	var captured []element.Role
+
+	mockAcc := &mocks.MockAccessibilityPort{}
+	mockAcc.ClickableElementsFunc = func(
+		_ context.Context,
+		filter ports.ElementFilter,
+	) ([]*element.Element, error) {
+		captured = filter.Roles
+
+		return testElements, nil
+	}
+
+	generator, _ := hint.NewAlphabetGenerator("asdf", hint.LabelDirectionReverse)
+	service := services.NewHintService(
+		mockAcc,
+		&mocks.MockOverlayPort{},
+		&mocks.MockSystemPort{},
+		generator,
+		config.HintsConfig{
+			ClickableRoles: []string{string(element.SemanticButton)},
+		},
+		logger.Get(),
+		nil,
+	)
+
+	_, err := service.GenerateHints(
+		context.Background(),
+		[]string{string(element.SemanticLink)},
+		nil,
+		"com.example.app",
+		"",
+		"",
+		false,
+	)
+	if err != nil {
+		t.Fatalf("GenerateHints() unexpected error: %v", err)
+	}
+
+	want := element.ResolveRolesForCurrentPlatform(
+		[]string{string(element.SemanticLink)},
+	).Native
+	if len(want) == 0 {
+		t.Skip("link has no native role on this platform")
+	}
+
+	for _, role := range want {
+		if !slices.Contains(captured, element.Role(role)) {
+			t.Errorf("filter.Roles = %v, missing overridden role %q", captured, role)
+		}
+	}
+
+	// The configured role must not survive the override.
+	for _, role := range element.ResolveRolesForCurrentPlatform(
+		[]string{string(element.SemanticButton)},
+	).Native {
+		if slices.Contains(captured, element.Role(role)) {
+			t.Errorf("filter.Roles = %v, configured role %q leaked past the override",
+				captured, role)
+		}
 	}
 }

--- a/internal/architecture/role_vocabulary_docs_test.go
+++ b/internal/architecture/role_vocabulary_docs_test.go
@@ -1,0 +1,73 @@
+package architecture_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+)
+
+// TestConfigurationDocsCoverTheRoleVocabulary keeps the documented role table
+// in step with the code. The table is the only place a user can see the whole
+// vocabulary offline, and a role missing from it is effectively undiscoverable.
+func TestConfigurationDocsCoverTheRoleVocabulary(t *testing.T) {
+	docPath := filepath.Join(findRepoRoot(t), "docs", "CONFIGURATION.md")
+
+	contents, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", docPath, err)
+	}
+
+	doc := string(contents)
+
+	for _, mapping := range element.RoleVocabulary {
+		// The table renders each semantic role as an inline code span, which is
+		// specific enough not to match prose mentioning the same word.
+		if !strings.Contains(doc, "`"+string(mapping.Semantic)+"`") {
+			t.Errorf(
+				"semantic role %q is missing from docs/CONFIGURATION.md; "+
+					"add it to the Clickable roles table",
+				mapping.Semantic,
+			)
+		}
+	}
+}
+
+// TestConfigurationDocsUseTheCurrentRoleVocabulary catches documentation that
+// still tells users to write native role names without a vocabulary prefix,
+// which is now a configuration error.
+func TestConfigurationDocsUseTheCurrentRoleVocabulary(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+
+	docs := []string{
+		filepath.Join(repoRoot, "docs", "CONFIGURATION.md"),
+		filepath.Join(repoRoot, "docs", "CLI.md"),
+		filepath.Join(repoRoot, "docs", "TROUBLESHOOTING.md"),
+		filepath.Join(repoRoot, "docs", "TIPS_TRICKS.md"),
+	}
+
+	for _, path := range docs {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", path, err)
+		}
+
+		for line := range strings.SplitSeq(string(contents), "\n") {
+			// A bare AX name is legitimate when the line is quoting the error
+			// that a bare AX name now produces.
+			if strings.Contains(line, "unknown role") {
+				continue
+			}
+
+			// Otherwise native AX names must carry their vocabulary prefix.
+			if strings.Contains(line, `"AX`) && !strings.Contains(line, "ax:") {
+				t.Errorf(
+					"%s: bare AX role name in %q; write a semantic role or prefix it with ax:",
+					filepath.Base(path), strings.TrimSpace(line),
+				)
+			}
+		}
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -120,6 +120,7 @@ func TestCommandInitialization(t *testing.T) {
 		cliTestAction:                    false,
 		cliTestStatus:                    false,
 		"doctor":                         false,
+		cliTestRoles:                     false,
 		"launch":                         false,
 		"docs":                           false,
 		"config":                         false,

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -28,6 +28,8 @@ can use it to verify accessibility permissions before launching.`,
 		cmd.Println("Neru Doctor — pre-flight checks")
 		cmd.Println()
 		// --- client-side checks (no daemon needed) --------------------------
+		PrintClickableRolesCheck(cmd)
+
 		endpointPath := ipc.SocketPath()
 
 		if !ipc.IsServerRunning() {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -10,7 +10,12 @@ import (
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
 )
 
-var errDaemonUnreachable = errors.New("daemon unreachable")
+var (
+	errDaemonUnreachable = errors.New("daemon unreachable")
+	// errClickableRolesUnusable marks a configuration that loads but selects no
+	// accessibility role on this platform, so hints would find nothing.
+	errClickableRolesUnusable = errors.New("no clickable roles apply on this platform")
+)
 
 // DoctorCmd is the CLI doctor command.
 var DoctorCmd = &cobra.Command{
@@ -28,14 +33,25 @@ can use it to verify accessibility permissions before launching.`,
 		cmd.Println("Neru Doctor — pre-flight checks")
 		cmd.Println()
 		// --- client-side checks (no daemon needed) --------------------------
-		PrintClickableRolesCheck(cmd)
+		rolesUsable := printClickableRolesCheck(cmd)
 
 		endpointPath := ipc.SocketPath()
 
 		if !ipc.IsServerRunning() {
 			cmd.Printf("  ❌ %-24s %s\n", "ipc_endpoint", "not reachable: "+endpointPath)
 
-			return printClientDoctorWithoutDaemon(cmd)
+			err := printClientDoctorWithoutDaemon(cmd)
+			if err != nil {
+				return err
+			}
+
+			// Not every platform treats a stopped daemon as a failure, so the
+			// role check still has to be able to fail this branch.
+			if !rolesUsable {
+				return &silentError{err: errClickableRolesUnusable}
+			}
+
+			return nil
 		}
 
 		cmd.Printf("  ✅ %-24s %s\n", "ipc_endpoint", endpointPath)
@@ -62,7 +78,18 @@ can use it to verify accessibility permissions before launching.`,
 			return &silentError{err: err}
 		}
 
-		return err
+		if err != nil {
+			return err
+		}
+
+		// A healthy daemon running a config that selects no roles still cannot
+		// produce a hint, so the client-side failure has to reach the exit
+		// status or a scripted health check would treat it as fine.
+		if !rolesUsable {
+			return &silentError{err: errClickableRolesUnusable}
+		}
+
+		return nil
 	},
 }
 

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -135,11 +135,15 @@ func runRolesExplain(cmd *cobra.Command) error {
 	return nil
 }
 
-// PrintClickableRolesCheck reports how the configured clickable roles resolve
-// on this platform. It is a client-side doctor check: a config whose roles all
-// belong to another platform loads cleanly but produces no hints at all, which
-// is otherwise invisible until a user reports a blank overlay.
-func PrintClickableRolesCheck(cmd *cobra.Command) {
+// printClickableRolesCheck reports how the configured clickable roles resolve
+// on this platform, and returns whether they are usable. It is a client-side
+// doctor check: a config whose roles all belong to another platform loads
+// cleanly but produces no hints at all, which is otherwise invisible until a
+// user reports a blank overlay.
+//
+// The result feeds the doctor exit status, so a health check run from a script
+// fails on a configuration that cannot hint anything.
+func printClickableRolesCheck(cmd *cobra.Command) bool {
 	svc := config.NewService(config.DefaultConfig(), "", nil, nil)
 
 	path := configPath
@@ -151,7 +155,7 @@ func PrintClickableRolesCheck(cmd *cobra.Command) {
 	if loadResult.ValidationError != nil {
 		cmd.Printf("  ❌ %-24s %s\n", "clickable_roles", "config invalid: see neru config validate")
 
-		return
+		return false
 	}
 
 	resolution := element.ResolveRolesForCurrentPlatform(
@@ -163,7 +167,7 @@ func PrintClickableRolesCheck(cmd *cobra.Command) {
 			"no roles apply on "+runtime.GOOS+"; hints would be empty")
 		cmd.Printf("  %-27s %s\n", "", "run: neru roles --explain")
 
-		return
+		return false
 	}
 
 	cmd.Printf("  ✅ %-24s %d entries → %d native roles on %s\n",
@@ -172,6 +176,8 @@ func PrintClickableRolesCheck(cmd *cobra.Command) {
 	if ignored := len(resolution.IgnoredMessages()); ignored > 0 {
 		cmd.Printf("  %-27s %d entries do not apply here (neru roles --explain)\n", "", ignored)
 	}
+
+	return true
 }
 
 // explainEntry renders the resolution of a single configured entry.

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -1,0 +1,219 @@
+package cli
+
+import (
+	"runtime"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+)
+
+// rolesColumnPadding is the gap between the role name and its expansion.
+const rolesColumnPadding = 2
+
+// explainRoles is set by the --explain flag.
+var explainRoles bool
+
+// rolesCmd is the CLI roles command.
+var rolesCmd = &cobra.Command{
+	Use:   "roles",
+	Short: "List the accessibility roles accepted in hints.clickable_roles",
+	Long: `List the semantic role vocabulary accepted by hints.clickable_roles and
+show how each one resolves on this platform.
+
+Roles are written either as a semantic name ("button", "text_field"), which
+resolves to the native accessibility roles of whichever platform neru is running
+on, or as a native role addressed through its vocabulary prefix:
+
+  ax:AXDisclosureTriangle    macOS Accessibility
+  atspi:page tab list        Linux AT-SPI
+  uia:Custom                 Windows UI Automation
+
+Prefixed entries for other platforms are ignored rather than rejected, so one
+configuration file can serve several machines.
+
+With --explain, the loaded configuration is resolved entry by entry, showing
+which native roles each entry contributes here and which entries do not apply.`,
+	Example: `  neru roles             Show the semantic vocabulary for this platform
+  neru roles --explain   Show how the loaded config resolves here`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if explainRoles {
+			return runRolesExplain(cmd)
+		}
+
+		runRolesList(cmd)
+
+		return nil
+	},
+}
+
+func init() {
+	rolesCmd.Flags().BoolVar(&explainRoles, "explain", false,
+		"resolve the loaded config entry by entry")
+	RootCmd.AddCommand(rolesCmd)
+}
+
+// runRolesList prints the semantic vocabulary and its expansion here.
+func runRolesList(cmd *cobra.Command) {
+	vocabulary, supported := element.CurrentVocabulary()
+	if !supported {
+		cmd.Printf("No accessibility backend on %s: every role resolves to nothing.\n\n",
+			runtime.GOOS)
+	} else {
+		cmd.Printf("Semantic roles on %s (native vocabulary: %s)\n\n",
+			runtime.GOOS, vocabulary)
+	}
+
+	writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, rolesColumnPadding, ' ', 0)
+
+	for _, mapping := range element.RoleVocabulary {
+		native := mapping.Native(vocabulary)
+
+		expansion := strings.Join(native, ", ")
+		if len(native) == 0 {
+			expansion = "— no equivalent on this platform"
+		}
+
+		writeTabbed(writer, string(mapping.Semantic), expansion)
+	}
+
+	flushTabbed(writer)
+
+	cmd.Println("")
+	cmd.Println("Native roles not covered above are addressed by prefix, e.g. " +
+		prefixExample(vocabulary))
+}
+
+// runRolesExplain resolves the loaded configuration and reports each entry.
+func runRolesExplain(cmd *cobra.Command) error {
+	svc := config.NewService(config.DefaultConfig(), "", nil, nil)
+
+	path := configPath
+	if path == "" {
+		path = svc.FindConfigFile()
+	}
+
+	loadResult := svc.LoadWithValidation(path)
+	if loadResult.ValidationError != nil {
+		cmd.PrintErrln("Configuration validation failed:")
+		cmd.PrintErrln("")
+		cmd.PrintErrln("  " + loadResult.ValidationError.Error())
+
+		return &silentError{err: errConfigValidationFailed}
+	}
+
+	source := loadResult.ConfigPath
+	if source == "" {
+		source = "built-in defaults (no config file found)"
+	}
+
+	cmd.Printf("hints.clickable_roles on %s, from %s\n\n", runtime.GOOS, source)
+
+	resolution := element.ResolveRolesForCurrentPlatform(
+		loadResult.Config.Hints.ClickableRoles,
+	)
+
+	writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, rolesColumnPadding, ' ', 0)
+
+	for _, entry := range resolution.Entries {
+		writeTabbed(writer, entry.Entry, explainEntry(entry))
+	}
+
+	flushTabbed(writer)
+
+	cmd.Printf("\n%d configured entries resolve to %d native roles.\n",
+		len(resolution.Entries), len(resolution.Native))
+
+	ignored := resolution.IgnoredMessages()
+	if len(ignored) > 0 {
+		cmd.Printf("%d entries do not apply on %s.\n", len(ignored), runtime.GOOS)
+	}
+
+	return nil
+}
+
+// PrintClickableRolesCheck reports how the configured clickable roles resolve
+// on this platform. It is a client-side doctor check: a config whose roles all
+// belong to another platform loads cleanly but produces no hints at all, which
+// is otherwise invisible until a user reports a blank overlay.
+func PrintClickableRolesCheck(cmd *cobra.Command) {
+	svc := config.NewService(config.DefaultConfig(), "", nil, nil)
+
+	path := configPath
+	if path == "" {
+		path = svc.FindConfigFile()
+	}
+
+	loadResult := svc.LoadWithValidation(path)
+	if loadResult.ValidationError != nil {
+		cmd.Printf("  ❌ %-24s %s\n", "clickable_roles", "config invalid: see neru config validate")
+
+		return
+	}
+
+	resolution := element.ResolveRolesForCurrentPlatform(
+		loadResult.Config.Hints.ClickableRoles,
+	)
+
+	if len(resolution.Native) == 0 {
+		cmd.Printf("  ❌ %-24s %s\n", "clickable_roles",
+			"no roles apply on "+runtime.GOOS+"; hints would be empty")
+		cmd.Printf("  %-27s %s\n", "", "run: neru roles --explain")
+
+		return
+	}
+
+	cmd.Printf("  ✅ %-24s %d entries → %d native roles on %s\n",
+		"clickable_roles", len(resolution.Entries), len(resolution.Native), runtime.GOOS)
+
+	if ignored := len(resolution.IgnoredMessages()); ignored > 0 {
+		cmd.Printf("  %-27s %d entries do not apply here (neru roles --explain)\n", "", ignored)
+	}
+}
+
+// explainEntry renders the resolution of a single configured entry.
+func explainEntry(entry element.ResolvedRoleEntry) string {
+	if len(entry.Native) > 0 {
+		kind := "semantic"
+		if entry.Vocabulary != "" {
+			kind = "native/" + string(entry.Vocabulary)
+		}
+
+		return strings.Join(entry.Native, ", ") + "  [" + kind + "]"
+	}
+
+	if entry.Diagnostic != nil {
+		return entry.Diagnostic.Message()
+	}
+
+	return "no native roles"
+}
+
+// prefixExample returns a prefixed-entry example for the running platform.
+func prefixExample(vocabulary element.NativeVocabulary) string {
+	switch vocabulary {
+	case element.VocabularyATSPI:
+		return `"atspi:page tab list"`
+	case element.VocabularyUIA:
+		return `"uia:Custom"`
+	case element.VocabularyAX:
+		return `"ax:AXDisclosureTriangle"`
+	default:
+		return `"ax:...", "atspi:..." or "uia:..."`
+	}
+}
+
+// writeTabbed writes one aligned two-column row, ignoring write errors: the
+// destination is the command's output stream and a failure there is already
+// surfaced by the caller's own write failures.
+func writeTabbed(writer *tabwriter.Writer, left, right string) {
+	_, _ = writer.Write([]byte("  " + left + "\t" + right + "\n"))
+}
+
+// flushTabbed flushes the aligned output.
+func flushTabbed(writer *tabwriter.Writer) {
+	_ = writer.Flush()
+}

--- a/internal/cli/roles_check_internal_test.go
+++ b/internal/cli/roles_check_internal_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestPrintClickableRolesCheck covers the value that feeds the `neru doctor`
+// exit status. A config that loads but selects no role on this platform cannot
+// produce a hint, so it has to report as unhealthy rather than merely print a
+// warning that a scripted health check would ignore.
+func TestPrintClickableRolesCheck(t *testing.T) {
+	// Roles that belong to a platform other than the one running the test.
+	foreign := map[string]string{
+		"darwin":  `["atspi:push button", "uia:Button"]`,
+		"linux":   `["ax:AXButton", "uia:Button"]`,
+		"windows": `["ax:AXButton", "atspi:push button"]`,
+	}
+
+	tests := []struct {
+		name        string
+		roles       string
+		wantUsable  bool
+		wantMessage string
+	}{
+		{
+			name:        "roles that apply here are healthy",
+			roles:       `["button", "link"]`,
+			wantUsable:  true,
+			wantMessage: "native roles on",
+		},
+		{
+			name:        "roles for other platforms only",
+			roles:       foreign[runtime.GOOS],
+			wantUsable:  false,
+			wantMessage: "hints would be empty",
+		},
+		{
+			name:        "config that fails validation",
+			roles:       `["AXButton"]`,
+			wantUsable:  false,
+			wantMessage: "config invalid",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.roles == "" {
+				t.Skipf("no foreign role set defined for %s", runtime.GOOS)
+			}
+
+			path := filepath.Join(t.TempDir(), "config.toml")
+
+			contents := `
+[hints]
+enabled = true
+hint_characters = "asdf"
+clickable_roles = ` + testCase.roles + `
+`
+
+			err := os.WriteFile(path, []byte(contents), 0o600)
+			if err != nil {
+				t.Fatalf("failed to write config: %v", err)
+			}
+
+			previous := configPath
+			configPath = path
+
+			t.Cleanup(func() { configPath = previous })
+
+			var out bytes.Buffer
+
+			cmd := &cobra.Command{}
+			cmd.SetOut(&out)
+
+			got := printClickableRolesCheck(cmd)
+			if got != testCase.wantUsable {
+				t.Errorf(
+					"printClickableRolesCheck() = %v, want %v\noutput:\n%s",
+					got, testCase.wantUsable, out.String(),
+				)
+			}
+
+			if !strings.Contains(out.String(), testCase.wantMessage) {
+				t.Errorf(
+					"output does not mention %q:\n%s",
+					testCase.wantMessage, out.String(),
+				)
+			}
+		})
+	}
+}

--- a/internal/cli/roles_test.go
+++ b/internal/cli/roles_test.go
@@ -1,0 +1,158 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/cli"
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+)
+
+// cliTestRoles is the roles command name as registered on RootCmd.
+const cliTestRoles = "roles"
+
+// runRolesCmd executes `neru roles` through RootCmd so that flags are parsed
+// the way they are in real use, and returns everything it wrote. A config path
+// is always supplied so the test never reads the developer's own config.
+func runRolesCmd(t *testing.T, configPath string, args ...string) string {
+	t.Helper()
+
+	var out bytes.Buffer
+
+	full := append([]string{cliTestRoles, "--config", configPath}, args...)
+
+	cli.RootCmd.SetOut(&out)
+	cli.RootCmd.SetErr(&out)
+	cli.RootCmd.SetArgs(full)
+
+	t.Cleanup(func() {
+		cli.RootCmd.SetOut(nil)
+		cli.RootCmd.SetErr(nil)
+		cli.RootCmd.SetArgs(nil)
+	})
+
+	err := cli.RootCmd.Execute()
+	if err != nil {
+		t.Fatalf("neru %v failed: %v", full, err)
+	}
+
+	return out.String()
+}
+
+// writeRolesConfig writes a config with the given clickable_roles array.
+func writeRolesConfig(t *testing.T, roles string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+
+	contents := `
+[hints]
+enabled = true
+hint_characters = "asdf"
+clickable_roles = ` + roles + `
+`
+
+	err := os.WriteFile(path, []byte(contents), 0o600)
+	if err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	return path
+}
+
+// TestRolesCmd_ListsEverySemanticRole keeps the command in step with the
+// vocabulary. It is how a user discovers what they may write, so a role
+// missing from the listing is effectively missing from the product.
+func TestRolesCmd_ListsEverySemanticRole(t *testing.T) {
+	output := runRolesCmd(t, writeRolesConfig(t, `["button"]`))
+
+	for _, mapping := range element.RoleVocabulary {
+		if !strings.Contains(output, string(mapping.Semantic)) {
+			t.Errorf("neru roles output omits semantic role %q", mapping.Semantic)
+		}
+	}
+
+	if !strings.Contains(output, runtime.GOOS) {
+		t.Errorf("neru roles output does not name the platform %q", runtime.GOOS)
+	}
+
+	vocabulary, supported := element.CurrentVocabulary()
+	if !supported {
+		return
+	}
+
+	// Roles that apply here must show their native expansion; roles that do
+	// not must say so rather than render an empty column.
+	for _, mapping := range element.RoleVocabulary {
+		native := mapping.Native(vocabulary)
+		if len(native) == 0 {
+			continue
+		}
+
+		if !strings.Contains(output, native[0]) {
+			t.Errorf(
+				"neru roles output omits the expansion %q of role %q",
+				native[0], mapping.Semantic,
+			)
+		}
+	}
+}
+
+// TestRolesCmd_ExplainReportsEveryEntry covers the --explain path, including
+// the entries that do not apply on this platform — the case the command exists
+// to make visible.
+func TestRolesCmd_ExplainReportsEveryEntry(t *testing.T) {
+	entries := []string{"button", "ax:AXGenericElement", "atspi:page tab list", "uia:Custom"}
+	path := writeRolesConfig(
+		t,
+		`["button", "ax:AXGenericElement", "atspi:page tab list", "uia:Custom"]`,
+	)
+
+	output := runRolesCmd(t, path, "--explain")
+
+	for _, entry := range entries {
+		if !strings.Contains(output, entry) {
+			t.Errorf("neru roles --explain omits configured entry %q:\n%s", entry, output)
+		}
+	}
+
+	if !strings.Contains(output, "resolve to") {
+		t.Errorf("neru roles --explain has no summary line:\n%s", output)
+	}
+
+	// Exactly two of the three prefixed entries belong to other platforms.
+	if !strings.Contains(output, "do not apply on "+runtime.GOOS) {
+		t.Errorf("neru roles --explain does not report inapplicable entries:\n%s", output)
+	}
+}
+
+// TestRolesCmd_ExplainRejectsRetiredVocabulary checks that --explain surfaces a
+// stale config as an error rather than rendering a misleading empty result.
+func TestRolesCmd_ExplainRejectsRetiredVocabulary(t *testing.T) {
+	path := writeRolesConfig(t, `["AXButton"]`)
+
+	var out bytes.Buffer
+
+	cli.RootCmd.SetOut(&out)
+	cli.RootCmd.SetErr(&out)
+	cli.RootCmd.SetArgs([]string{cliTestRoles, "--config", path, "--explain"})
+
+	t.Cleanup(func() {
+		cli.RootCmd.SetOut(nil)
+		cli.RootCmd.SetErr(nil)
+		cli.RootCmd.SetArgs(nil)
+	})
+
+	err := cli.RootCmd.Execute()
+	if err == nil {
+		t.Fatal("neru roles --explain accepted a config using the retired vocabulary")
+	}
+
+	if !strings.Contains(out.String(), `use "button"`) {
+		t.Errorf("neru roles --explain did not print the migration hint:\n%s", out.String())
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/y3owk1n/neru/internal/core/domain/element"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
 
@@ -52,10 +53,13 @@ func (s *StringOrStringArray) UnmarshalTOML(value any) error {
 	return nil
 }
 
-// Accessibility role constants.
+// Semantic role names injected into the clickable role list when the
+// corresponding hints flags are enabled. They are resolved to native role
+// names alongside the user's own entries; on platforms with no menu bar or
+// dock they resolve to nothing.
 const (
-	RoleMenuBarItem = "AXMenuBarItem"
-	RoleDockItem    = "AXDockItem"
+	RoleMenuBarItem = string(element.SemanticMenubarItem)
+	RoleDockItem    = string(element.SemanticDockItem)
 )
 
 // Mode name constants used in config lookups (HotkeysForMode, validation).
@@ -2087,9 +2091,11 @@ func (c *Config) baseHotkeysForMode(modeName string) map[string]StringOrStringAr
 	}
 }
 
-// ClickableRolesForApp returns the clickable roles for a specific app bundle ID.
-// Starts from the merged config (root + app overrides), then appends
-// AXMenuBarItem / AXDockItem when the corresponding hints flags are enabled.
+// ClickableRolesForApp returns the native accessibility role names to hint for
+// a specific app bundle ID. Starts from the merged config (root + app
+// overrides), appends the menubar / dock roles when the corresponding hints
+// flags are enabled, then resolves the whole list against the running
+// platform's accessibility vocabulary.
 func (c *HintsConfig) ClickableRolesForApp(bundleID string) []string {
 	merged := c.MergedForApp(bundleID)
 
@@ -2102,7 +2108,13 @@ func (c *HintsConfig) ClickableRolesForApp(bundleID string) []string {
 		merged.ClickableRoles = append(merged.ClickableRoles, RoleDockItem)
 	}
 
-	return merged.ClickableRoles
+	return element.ResolveRolesForCurrentPlatform(merged.ClickableRoles).Native
+}
+
+// ResolvedClickableRoles returns the native accessibility role names for the
+// root hints config, without app-specific overrides.
+func (c *HintsConfig) ResolvedClickableRoles() []string {
+	return element.ResolveRolesForCurrentPlatform(c.ClickableRoles).Native
 }
 
 // StrategyForApp returns the element detection strategy for the given bundle ID.

--- a/internal/config/config_darwin.go
+++ b/internal/config/config_darwin.go
@@ -10,24 +10,4 @@ func applyPlatformDefaults(cfg *Config) {
 		"com.apple.systemuiserver",
 		"com.y3owk1n.neru",
 	)
-
-	cfg.Hints.ClickableRoles = append(cfg.Hints.ClickableRoles,
-		"AXButton",
-		"AXMenuButton",
-		"AXComboBox",
-		"AXCheckBox",
-		"AXRadioButton",
-		"AXLink",
-		"AXPopUpButton",
-		"AXTextField",
-		"AXSlider",
-		"AXTabButton",
-		"AXSwitch",
-		"AXDisclosureTriangle",
-		"AXTextArea",
-		"AXMenuItem",
-		"AXCell",
-		"AXRow",
-		"AXGenericElement",
-	)
 }

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -1,6 +1,11 @@
 package config
 
-import "time"
+import (
+	"slices"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+)
 
 const (
 	// DefaultHintFontSize is the default font size for hints.
@@ -441,7 +446,10 @@ func newDefaultConfig() *Config {
 			OnMissionControlActivated:     nil,
 			OnMissionControlDeactivated:   nil,
 
-			ClickableRoles: []string{},
+			// Semantic role names resolve to each platform's native
+			// accessibility vocabulary at load time, so one default serves
+			// every platform. See internal/core/domain/element/vocabulary.go.
+			ClickableRoles: slices.Clone(element.DefaultClickableRoles),
 
 			IgnoreClickableCheck: false,
 			VisibleCheckEnabled:  false,

--- a/internal/config/config_linux.go
+++ b/internal/config/config_linux.go
@@ -8,19 +8,4 @@ func applyPlatformDefaults(cfg *Config) {
 	// Users can enable global hotkeys in their config, or bind `neru <mode>`
 	// in their desktop environment / window manager.
 	cfg.Hotkeys.Bindings = make(map[string][]string)
-
-	// Linux-specific defaults
-	cfg.Hints.ClickableRoles = append(cfg.Hints.ClickableRoles,
-		"push button",
-		"check box",
-		"radio button",
-		"link",
-		"combo box",
-		"text",
-		"slider",
-		"tab",
-		"menu item",
-		"image",
-		"static",
-	)
 }

--- a/internal/config/config_other.go
+++ b/internal/config/config_other.go
@@ -2,6 +2,7 @@
 
 package config
 
-// applyPlatformDefaults is a no-op on unsupported platforms.
-// ClickableRoles and ExcludedApps will be empty; users must configure them manually.
+// applyPlatformDefaults is a no-op on unsupported platforms. The shared
+// semantic clickable roles still load, but resolve to no native role because
+// the platform has no accessibility vocabulary (see element.VocabularyForGOOS).
 func applyPlatformDefaults(_ *Config) {}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,10 +11,12 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain/element"
 )
 
 const (
-	isDarwinRuntime = runtime.GOOS == "darwin"
+	goosDarwin      = "darwin"
+	isDarwinRuntime = runtime.GOOS == goosDarwin
 
 	testBundleIDA       = "com.example.app"
 	testBundleIDB       = "com.other.app"
@@ -152,7 +154,7 @@ func TestConfig_ClickableRolesForApp(t *testing.T) {
 				},
 			},
 			bundleID: testBundleIDA,
-			want:     []string{TestRoleButton, "AXMenuBarItem"},
+			want:     []string{TestRoleButton, "menubar_item"},
 		},
 		{
 			name: "with dock hints",
@@ -163,7 +165,7 @@ func TestConfig_ClickableRolesForApp(t *testing.T) {
 				},
 			},
 			bundleID: testBundleIDA,
-			want:     []string{TestRoleButton, "AXDockItem"},
+			want:     []string{TestRoleButton, "dock_item"},
 		},
 		{
 			name: "with both menubar and dock hints",
@@ -175,7 +177,7 @@ func TestConfig_ClickableRolesForApp(t *testing.T) {
 				},
 			},
 			bundleID: testBundleIDA,
-			want:     []string{TestRoleButton, "AXMenuBarItem", "AXDockItem"},
+			want:     []string{TestRoleButton, "menubar_item", "dock_item"},
 		},
 		{
 			name: "empty roles filtered out",
@@ -211,23 +213,29 @@ func TestConfig_ClickableRolesForApp(t *testing.T) {
 					AppConfigs: []config.AppConfig{
 						{
 							BundleID:            "com.chrome.app",
-							AdditionalClickable: []string{"AXTabGroup"},
+							AdditionalClickable: []string{TestRoleTabGroup},
 						},
 						{
 							BundleID:            "com.firefox.app",
-							AdditionalClickable: []string{"AXWebArea"},
+							AdditionalClickable: []string{TestRoleWebArea},
 						},
 					},
 				},
 			},
 			bundleID: "com.chrome.app",
-			want:     []string{TestRoleButton, TestRoleLink, "AXTabGroup"},
+			want:     []string{TestRoleButton, TestRoleLink, TestRoleTabGroup},
 		},
 	}
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			got := testCase.config.ClickableRolesForApp(testCase.bundleID)
+
+			// ClickableRolesForApp returns native role names for the running
+			// platform, so the expectation is resolved the same way. This keeps
+			// the assertion about merge behavior rather than about which
+			// platform the test happens to run on.
+			want := element.ResolveRolesForCurrentPlatform(testCase.want).Native
 
 			// Convert to maps for comparison since order doesn't matter
 			gotMap := make(map[string]bool)
@@ -236,7 +244,7 @@ func TestConfig_ClickableRolesForApp(t *testing.T) {
 			}
 
 			wantMap := make(map[string]bool)
-			for _, role := range testCase.want {
+			for _, role := range want {
 				wantMap[role] = true
 			}
 
@@ -244,10 +252,10 @@ func TestConfig_ClickableRolesForApp(t *testing.T) {
 				t.Errorf(
 					"ClickableRolesForApp() length = %d, want %d",
 					len(got),
-					len(testCase.want),
+					len(want),
 				)
 				t.Errorf("Got: %v", got)
-				t.Errorf("Want: %v", testCase.want)
+				t.Errorf("Want: %v", want)
 
 				return
 			}
@@ -995,5 +1003,72 @@ func TestNormalizeKeyForComparison_CJKInputMethodScenarios(t *testing.T) {
 					testCase.desc, testCase.input, got, testCase.expected)
 			}
 		})
+	}
+}
+
+// TestConfig_ClickableRolesForApp_MixedVocabulary covers app-config merging in
+// the presence of the role vocabulary. Merging happens on the entries as
+// written, resolution afterwards, so two different entries can legitimately
+// expand onto the same native role and must not produce duplicates.
+func TestConfig_ClickableRolesForApp_MixedVocabulary(t *testing.T) {
+	cfg := config.Config{
+		Hints: config.HintsConfig{
+			ClickableRoles: []string{TestRoleTextField, TestRoleButton},
+			AppConfigs: []config.AppConfig{
+				{
+					BundleID: testBundleIDA,
+					AdditionalClickable: []string{
+						// Resolves onto the same native role as text_field on
+						// Linux and Windows; distinct only on macOS.
+						"text_area",
+						// Already in the base list: must not duplicate.
+						TestRoleButton,
+						// Applies on exactly one platform.
+						"ax:AXGenericElement",
+						"atspi:page tab list",
+						"uia:Custom",
+					},
+				},
+			},
+		},
+	}
+
+	got := cfg.ClickableRolesForApp(testBundleIDA)
+
+	seen := make(map[string]int, len(got))
+	for _, role := range got {
+		seen[role]++
+	}
+
+	for role, count := range seen {
+		if count > 1 {
+			t.Errorf("ClickableRolesForApp() returned %q %d times, want once", role, count)
+		}
+	}
+
+	// Whatever the platform, the base roles must survive the merge.
+	for _, want := range element.ResolveRolesForCurrentPlatform(
+		[]string{TestRoleTextField, TestRoleButton},
+	).Native {
+		if seen[want] == 0 {
+			t.Errorf("ClickableRolesForApp() = %v, missing base role %q", got, want)
+		}
+	}
+
+	// Exactly one of the three prefixed entries applies here; the other two
+	// must resolve to nothing rather than leaking across platforms.
+	exclusive := map[string]string{
+		goosDarwin: "AXGenericElement",
+		"linux":    "page tab list",
+		"windows":  "Custom",
+	}
+
+	for goos, name := range exclusive {
+		switch {
+		case goos == runtime.GOOS && seen[name] == 0:
+			t.Errorf("ClickableRolesForApp() = %v, missing platform-native role %q", got, name)
+		case goos != runtime.GOOS && seen[name] > 0:
+			t.Errorf("ClickableRolesForApp() = %v, leaked %s-only role %q", got, goos, name)
+		}
 	}
 }

--- a/internal/config/config_windows.go
+++ b/internal/config/config_windows.go
@@ -12,22 +12,4 @@ func applyPlatformDefaults(cfg *Config) {
 	// %SystemRoot% is always set on Windows (e.g. C:\Windows).
 	cfg.General.ExecShell = filepath.Join(os.Getenv("SystemRoot"), "System32", "cmd.exe")
 	cfg.General.ExecShellArgs = []string{"/c"}
-
-	// AX-style roles produced by the Windows UI Automation enumerator
-	// (see mapControlType in uia_windows.go). These must match the roles
-	// assigned during element discovery, not the raw UIA control type names.
-	cfg.Hints.ClickableRoles = append(cfg.Hints.ClickableRoles,
-		"AXButton",
-		"AXCheckBox",
-		"AXRadioButton",
-		"AXLink",
-		"AXComboBox",
-		"AXTextField",
-		"AXSlider",
-		"AXTabButton",
-		"AXMenuItem",
-		"AXCell",
-		"AXRow",
-		"AXIncrementor",
-	)
 }

--- a/internal/config/embedded_config_test.go
+++ b/internal/config/embedded_config_test.go
@@ -1,0 +1,127 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/configs"
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// TestEmbeddedDefaultConfig_Validates guards the shipped configuration against
+// the role vocabulary. A default config written in a stale role vocabulary
+// loads to zero hints, which is invisible until a user reports blank overlays.
+func TestEmbeddedDefaultConfig_Validates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	err := os.WriteFile(path, configs.DefaultConfig, 0o600)
+	if err != nil {
+		t.Fatalf("failed to write embedded config: %v", err)
+	}
+
+	service := config.NewService(config.DefaultConfig(), path, zap.NewNop(), nil)
+
+	result := service.LoadWithValidation(path)
+	if result.ValidationError != nil {
+		t.Fatalf("embedded default config failed validation: %v", result.ValidationError)
+	}
+
+	roles := result.Config.Hints.ResolvedClickableRoles()
+	if len(roles) == 0 {
+		t.Errorf(
+			"embedded default config resolves to no clickable roles on %s; "+
+				"hints would be blank",
+			result.Config.Hints.ClickableRoles,
+		)
+	}
+}
+
+// TestExampleConfigs_Validate loads every config under configs/ the way the
+// daemon would. These files are copied by users verbatim, so a stale role
+// vocabulary in one of them is shipped breakage that no other test sees —
+// only default-config.toml is embedded and reachable through configs.DefaultConfig.
+func TestExampleConfigs_Validate(t *testing.T) {
+	paths, err := filepath.Glob(filepath.Join("..", "..", "configs", "*.toml"))
+	if err != nil {
+		t.Fatalf("failed to glob example configs: %v", err)
+	}
+
+	if len(paths) == 0 {
+		t.Fatal("no example configs found; the glob path is probably wrong")
+	}
+
+	for _, path := range paths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			svc := config.NewService(config.DefaultConfig(), path, zap.NewNop(), nil)
+
+			result := svc.LoadWithValidation(path)
+			if result.ValidationError != nil {
+				t.Fatalf("%s failed validation: %v", path, result.ValidationError)
+			}
+
+			// A config that enables hints must select something here, or the
+			// user copies it and gets a blank overlay.
+			if !result.Config.Hints.Enabled {
+				return
+			}
+
+			if len(result.Config.Hints.ResolvedClickableRoles()) == 0 {
+				t.Errorf(
+					"%s enables hints but resolves to no clickable role on %s",
+					path, runtime.GOOS,
+				)
+			}
+		})
+	}
+}
+
+// TestCrossPlatformConfig_LoadsButSelectsNothing pins the two halves of the
+// cross-platform promise together. A config carrying only another platform's
+// native roles must still load — that is what lets one dotfile serve several
+// machines — but it must not then behave as though no filter was set.
+func TestCrossPlatformConfig_LoadsButSelectsNothing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	// Every entry belongs to a platform that is not this one.
+	foreign := map[string]string{
+		goosDarwin: `["atspi:push button", "uia:Button"]`,
+		"linux":    `["ax:AXButton", "uia:Button"]`,
+		"windows":  `["ax:AXButton", "atspi:push button"]`,
+	}[runtime.GOOS]
+
+	if foreign == "" {
+		t.Skipf("no foreign role set defined for %s", runtime.GOOS)
+	}
+
+	contents := `
+[hints]
+enabled = true
+hint_characters = "asdf"
+clickable_roles = ` + foreign + `
+`
+
+	err := os.WriteFile(path, []byte(contents), 0o600)
+	if err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	svc := config.NewService(config.DefaultConfig(), path, zap.NewNop(), nil)
+
+	result := svc.LoadWithValidation(path)
+	if result.ValidationError != nil {
+		t.Fatalf(
+			"a config of other platforms' roles must still load, got: %v",
+			result.ValidationError,
+		)
+	}
+
+	if roles := result.Config.Hints.ResolvedClickableRoles(); len(roles) != 0 {
+		t.Errorf("ResolvedClickableRoles() = %v, want none to apply on %s", roles, runtime.GOOS)
+	}
+}

--- a/internal/config/override_test.go
+++ b/internal/config/override_test.go
@@ -135,7 +135,7 @@ func TestService_SaveOverrideFieldAndLoad(t *testing.T) {
 [hints]
 enabled = true
 hint_characters = "asdfghjkl"
-clickable_roles = ["AXButton"]
+clickable_roles = ["button"]
 `
 
 	writeFileErr := os.WriteFile(configPath, []byte(configContent), 0o644)
@@ -208,7 +208,7 @@ func TestService_OverridePreservesOtherFields(t *testing.T) {
 [hints]
 enabled = true
 hint_characters = "asdfghjkl"
-clickable_roles = ["AXButton"]
+clickable_roles = ["button"]
 
 [general]
 passthrough_unbounded_keys = false
@@ -245,9 +245,9 @@ passthrough_unbounded_keys = false
 	}
 
 	if len(reloaded.Config.Hints.ClickableRoles) != 1 ||
-		reloaded.Config.Hints.ClickableRoles[0] != "AXButton" {
+		reloaded.Config.Hints.ClickableRoles[0] != TestRoleButton {
 		t.Errorf(
-			"Expected clickable_roles=[AXButton], got %v",
+			"Expected clickable_roles=[button], got %v",
 			reloaded.Config.Hints.ClickableRoles,
 		)
 	}
@@ -261,7 +261,7 @@ func TestService_OverrideInvalidatesConfig(t *testing.T) {
 [hints]
 enabled = true
 hint_characters = "asdfghjkl"
-clickable_roles = ["AXButton"]
+clickable_roles = ["button"]
 `
 
 	writeFileErr := os.WriteFile(configPath, []byte(configContent), 0o644)

--- a/internal/config/service_integration_test.go
+++ b/internal/config/service_integration_test.go
@@ -6,11 +6,14 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain/element"
 )
 
 func TestService_Reload(t *testing.T) {
@@ -22,7 +25,7 @@ func TestService_Reload(t *testing.T) {
 [hints]
 enabled = true
 hint_characters = "asdf"
-clickable_roles = ["AXButton"]
+clickable_roles = ["button"]
 `
 
 	writeFileErr := os.WriteFile(configPath, []byte(configContent), 0o644)
@@ -58,5 +61,124 @@ clickable_roles = ["AXButton"]
 	anotherReloadErr := service.Reload(ctx, configPath)
 	if anotherReloadErr == nil {
 		t.Error("Reload() should fail with invalid config file")
+	}
+}
+
+// TestService_ReloadWithRoleVocabulary covers config reload across the role
+// vocabulary: a valid change takes effect, and an invalid one is rejected
+// without disturbing the config the daemon is already running with.
+func TestService_ReloadWithRoleVocabulary(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	write := func(t *testing.T, roles string) {
+		t.Helper()
+
+		contents := `
+[hints]
+enabled = true
+hint_characters = "asdf"
+clickable_roles = ` + roles + `
+
+[[hints.app_configs]]
+bundle_id = "com.example.app"
+additional_clickable_roles = ["heading"]
+`
+
+		err := os.WriteFile(configPath, []byte(contents), 0o600)
+		if err != nil {
+			t.Fatalf("failed to write config: %v", err)
+		}
+	}
+
+	write(t, `["button", "link"]`)
+
+	svc := config.NewService(config.DefaultConfig(), configPath, zap.NewNop(), nil)
+	ctx := context.Background()
+
+	err := svc.Reload(ctx, configPath)
+	if err != nil {
+		t.Fatalf("initial Reload() failed: %v", err)
+	}
+
+	before := svc.Get().ClickableRolesForApp("com.example.app")
+	if len(before) == 0 {
+		t.Fatal("ClickableRolesForApp() resolved to nothing after reload")
+	}
+
+	// A valid reload must take effect, including the app-specific addition.
+	write(t, `["button", "link", "checkbox"]`)
+
+	err = svc.Reload(ctx, configPath)
+	if err != nil {
+		t.Fatalf("second Reload() failed: %v", err)
+	}
+
+	after := svc.Get().ClickableRolesForApp("com.example.app")
+	if len(after) <= len(before) {
+		t.Errorf(
+			"ClickableRolesForApp() = %v after adding checkbox, want more than %v",
+			after, before,
+		)
+	}
+
+	for _, want := range element.ResolveRolesForCurrentPlatform([]string{"checkbox"}).Native {
+		if !slices.Contains(after, want) {
+			t.Errorf("ClickableRolesForApp() = %v, missing newly added role %q", after, want)
+		}
+	}
+
+	// An invalid reload must be rejected and leave the running config alone.
+	write(t, `["AXButton"]`)
+
+	err = svc.Reload(ctx, configPath)
+	if err == nil {
+		t.Fatal("Reload() accepted a config using the retired role vocabulary")
+	}
+
+	if !strings.Contains(err.Error(), `use "button"`) {
+		t.Errorf("Reload() error = %v, want a migration hint naming \"button\"", err)
+	}
+
+	survived := svc.Get().ClickableRolesForApp("com.example.app")
+	if !slices.Equal(survived, after) {
+		t.Errorf(
+			"rejected reload changed the running config: got %v, want %v",
+			survived, after,
+		)
+	}
+}
+
+// TestService_ReloadRejectsInvalidAppConfigRoles pins validation of the
+// per-app role list, which is merged in before resolution.
+func TestService_ReloadRejectsInvalidAppConfigRoles(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	contents := `
+[hints]
+enabled = true
+hint_characters = "asdf"
+clickable_roles = ["button"]
+
+[[hints.app_configs]]
+bundle_id = "com.example.app"
+additional_clickable_roles = ["AXHeading"]
+`
+
+	err := os.WriteFile(configPath, []byte(contents), 0o600)
+	if err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	svc := config.NewService(config.DefaultConfig(), configPath, zap.NewNop(), nil)
+
+	err = svc.Reload(context.Background(), configPath)
+	if err == nil {
+		t.Fatal("Reload() accepted an app config using the retired role vocabulary")
+	}
+
+	if !strings.Contains(err.Error(), "additional_clickable_roles") {
+		t.Errorf("Reload() error = %v, want it to name the offending field", err)
 	}
 }

--- a/internal/config/testhelpers_test.go
+++ b/internal/config/testhelpers_test.go
@@ -1,9 +1,14 @@
 package config_test
 
+// Role entries below are written in the semantic vocabulary, the same way user
+// configuration is. Tests that assert on resolved output run both the input and
+// the expectation through the resolver so they hold on every platform.
 const (
-	TestRoleButton     = "AXButton"
-	TestRoleTextField  = "AXTextField"
-	TestRoleLink       = "AXLink"
+	TestRoleButton     = "button"
+	TestRoleTextField  = "text_field"
+	TestRoleLink       = "link"
+	TestRoleTabGroup   = "ax:AXTabGroup"
+	TestRoleWebArea    = "ax:AXWebArea"
 	TestBundleIDSafari = "com.apple.Safari"
 	KeyCmdSpace        = "Cmd+Space"
 	KeySuperSpace      = "Super+Space"

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -8,8 +8,29 @@ import (
 	"unicode/utf8"
 
 	"github.com/y3owk1n/neru/internal/core/domain/action"
+	"github.com/y3owk1n/neru/internal/core/domain/element"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
+
+// validateClickableRoles rejects role entries that name neither a semantic role
+// nor a native role in a known vocabulary. Entries that are well-formed but
+// belong to another platform are accepted silently here and reported by
+// `neru roles` / `neru doctor`, so one config can serve several machines.
+func validateClickableRoles(field string, roles []string) error {
+	resolution := element.ResolveRolesForCurrentPlatform(roles)
+
+	messages := resolution.FatalMessages()
+	if len(messages) == 0 {
+		return nil
+	}
+
+	return derrors.Newf(
+		derrors.CodeInvalidConfig,
+		"%s: %s (run `neru roles` for the accepted role names)",
+		field,
+		strings.Join(messages, "; "),
+	)
+}
 
 // maxFontSize is the maximum font size accepted by the config validator.
 // Values above this can overflow C.int (int32) on Darwin or platform int on
@@ -100,6 +121,21 @@ func (c *Config) ValidateHints() error {
 			"hints.clickable_roles cannot be empty when hints are enabled")
 	}
 
+	err := validateClickableRoles("hints.clickable_roles", c.Hints.ClickableRoles)
+	if err != nil {
+		return err
+	}
+
+	for _, appConfig := range c.Hints.AppConfigs {
+		err = validateClickableRoles(
+			"hints.app_configs.additional_clickable_roles",
+			appConfig.AdditionalClickable,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
 	if strings.TrimSpace(c.Hints.HintCharacters) == "" {
 		return derrors.New(derrors.CodeInvalidConfig, "hint_characters cannot be empty")
 	}
@@ -135,7 +171,7 @@ func (c *Config) ValidateHints() error {
 		seen[upper] = struct{}{}
 	}
 
-	err := validateColors([]colorField{
+	err = validateColors([]colorField{
 		{c.Hints.UI.BackgroundColor, "hints.ui.background_color"},
 		{c.Hints.UI.TextColor, "hints.ui.text_color"},
 		{c.Hints.UI.MatchedTextColor, "hints.ui.matched_text_color"},

--- a/internal/core/domain/element/vocabulary.go
+++ b/internal/core/domain/element/vocabulary.go
@@ -1,0 +1,367 @@
+package element
+
+import "runtime"
+
+// SemanticRole is a platform-neutral role name accepted in user configuration.
+// Semantic roles are the closed vocabulary neru documents: each one expands to
+// zero or more native role names for the platform neru is running on. Roles
+// that have no semantic equivalent remain reachable through a vocabulary
+// prefix (see NativeVocabulary).
+type SemanticRole string
+
+// The semantic role vocabulary. This set is closed: an unrecognized bare entry
+// in clickable_roles is a configuration error, which is what makes typos
+// detectable. Anything missing here is still addressable as "ax:...",
+// "atspi:..." or "uia:...".
+const (
+	SemanticButton        SemanticRole = "button"
+	SemanticMenuButton    SemanticRole = "menu_button"
+	SemanticPopupButton   SemanticRole = "popup_button"
+	SemanticComboBox      SemanticRole = "combo_box"
+	SemanticLink          SemanticRole = "link"
+	SemanticCheckbox      SemanticRole = "checkbox"
+	SemanticRadio         SemanticRole = "radio"
+	SemanticSwitch        SemanticRole = "switch"
+	SemanticDisclosure    SemanticRole = "disclosure"
+	SemanticTextField     SemanticRole = "text_field"
+	SemanticTextArea      SemanticRole = "text_area"
+	SemanticSearchField   SemanticRole = "search_field"
+	SemanticSlider        SemanticRole = "slider"
+	SemanticStepper       SemanticRole = "stepper"
+	SemanticTab           SemanticRole = "tab"
+	SemanticMenuItem      SemanticRole = "menu_item"
+	SemanticMenubarItem   SemanticRole = "menubar_item"
+	SemanticDockItem      SemanticRole = "dock_item"
+	SemanticCell          SemanticRole = "cell"
+	SemanticRow           SemanticRole = "row"
+	SemanticListItem      SemanticRole = "list_item"
+	SemanticImage         SemanticRole = "image"
+	SemanticStaticText    SemanticRole = "static_text"
+	SemanticHeading       SemanticRole = "heading"
+	SemanticColorWell     SemanticRole = "color_well"
+	SemanticToolbarButton SemanticRole = "toolbar_button"
+)
+
+// NativeVocabulary identifies one platform's accessibility role vocabulary. It
+// doubles as the prefix users write in configuration to address a native role
+// name directly, e.g. "atspi:page tab list".
+type NativeVocabulary string
+
+// The native vocabularies neru understands. Each maps to exactly one platform.
+const (
+	// VocabularyAX is the macOS Accessibility (AX*) role vocabulary.
+	VocabularyAX NativeVocabulary = "ax"
+	// VocabularyATSPI is the Linux AT-SPI role-name vocabulary, as returned by
+	// Accessible.GetRoleName (lowercase, space separated).
+	VocabularyATSPI NativeVocabulary = "atspi"
+	// VocabularyUIA is the Windows UI Automation control-type vocabulary, using
+	// the programmatic names behind the UIA_*ControlTypeId constants.
+	VocabularyUIA NativeVocabulary = "uia"
+)
+
+// Go platform identifiers for the platforms with an accessibility backend.
+const (
+	goosDarwin  = "darwin"
+	goosLinux   = "linux"
+	goosWindows = "windows"
+)
+
+// Native role names shared by several semantic roles. Linux and Windows do not
+// distinguish a text area or a search field from a plain text field.
+const (
+	atspiRoleEntry = "entry"
+	uiaControlEdit = "Edit"
+)
+
+// vocabularyByGOOS maps a Go platform identifier to the native role vocabulary
+// that platform's accessibility backend speaks.
+var vocabularyByGOOS = map[string]NativeVocabulary{
+	goosDarwin:  VocabularyAX,
+	goosLinux:   VocabularyATSPI,
+	goosWindows: VocabularyUIA,
+}
+
+// VocabularyForGOOS returns the native role vocabulary used by the given Go
+// platform identifier. The second result is false for platforms with no
+// accessibility backend, where every configured role resolves to nothing.
+func VocabularyForGOOS(goos string) (NativeVocabulary, bool) {
+	vocab, ok := vocabularyByGOOS[goos]
+
+	return vocab, ok
+}
+
+// CurrentVocabulary returns the native role vocabulary for the running platform.
+func CurrentVocabulary() (NativeVocabulary, bool) {
+	return VocabularyForGOOS(runtime.GOOS)
+}
+
+// RoleMapping records how one semantic role expands into native role names on
+// each supported platform. An empty slice means the platform has no equivalent;
+// such roles are reported by `neru roles` rather than silently ignored.
+type RoleMapping struct {
+	// Semantic is the platform-neutral name written in configuration.
+	Semantic SemanticRole
+	// AX lists the macOS role names this semantic role expands to.
+	AX []string
+	// ATSPI lists the Linux AT-SPI role names this semantic role expands to.
+	ATSPI []string
+	// UIA lists the Windows UI Automation control-type programmatic names this
+	// semantic role expands to.
+	UIA []string
+}
+
+// Native returns the native role names for the given vocabulary.
+func (m RoleMapping) Native(vocab NativeVocabulary) []string {
+	switch vocab {
+	case VocabularyAX:
+		return m.AX
+	case VocabularyATSPI:
+		return m.ATSPI
+	case VocabularyUIA:
+		return m.UIA
+	default:
+		return nil
+	}
+}
+
+// RoleVocabulary is the full semantic role table, in documentation order. It is
+// the single source of truth for `neru roles`, config resolution, and the role
+// table in docs/CONFIGURATION.md.
+//
+// Overlapping expansions are intentional: Linux and Windows do not distinguish
+// a text area or a search field from a plain text field, so those semantic
+// roles expand onto the same native name there. Resolution unions the results.
+var RoleVocabulary = []RoleMapping{
+	{
+		Semantic: SemanticButton,
+		AX:       []string{string(RoleButton)},
+		ATSPI:    []string{"push button", "button", "toggle button"},
+		UIA:      []string{"Button", "SplitButton"},
+	},
+	{
+		Semantic: SemanticMenuButton,
+		AX:       []string{string(RoleMenuButton)},
+		// AT-SPI reports the GEnum nick of ATSPI_ROLE_PUSH_BUTTON_MENU, which
+		// is "push button menu" — not "menu button".
+		ATSPI: []string{"push button menu"},
+	},
+	{
+		Semantic: SemanticPopupButton,
+		AX:       []string{string(RolePopUpButton)},
+		ATSPI:    []string{"combo box"},
+		UIA:      []string{"ComboBox"},
+	},
+	{
+		Semantic: SemanticComboBox,
+		AX:       []string{string(RoleComboBox)},
+		ATSPI:    []string{"combo box"},
+		UIA:      []string{"ComboBox"},
+	},
+	{
+		Semantic: SemanticLink,
+		AX:       []string{string(RoleLink)},
+		ATSPI:    []string{"link"},
+		UIA:      []string{"Hyperlink"},
+	},
+	{
+		Semantic: SemanticCheckbox,
+		AX:       []string{string(RoleCheckBox)},
+		ATSPI:    []string{"check box", "check menu item"},
+		UIA:      []string{"CheckBox"},
+	},
+	{
+		Semantic: SemanticRadio,
+		AX:       []string{string(RoleRadioButton)},
+		ATSPI:    []string{"radio button", "radio menu item"},
+		UIA:      []string{"RadioButton"},
+	},
+	{
+		Semantic: SemanticSwitch,
+		AX:       []string{string(RoleSwitch)},
+		// ATSPI_ROLE_SWITCH is the dedicated role (GTK4 GtkSwitch and friends);
+		// older toolkits still report a toggle button.
+		ATSPI: []string{"switch", "toggle button"},
+	},
+	{
+		Semantic: SemanticDisclosure,
+		AX:       []string{string(RoleDisclosureTriangle)},
+	},
+	{
+		Semantic: SemanticTextField,
+		AX:       []string{string(RoleTextField)},
+		ATSPI:    []string{atspiRoleEntry, "password text"},
+		UIA:      []string{uiaControlEdit},
+	},
+	{
+		Semantic: SemanticTextArea,
+		AX:       []string{string(RoleTextArea)},
+		ATSPI:    []string{atspiRoleEntry},
+		UIA:      []string{uiaControlEdit},
+	},
+	{
+		Semantic: SemanticSearchField,
+		AX:       []string{string(RoleSearchField)},
+		ATSPI:    []string{atspiRoleEntry},
+		UIA:      []string{uiaControlEdit},
+	},
+	{
+		Semantic: SemanticSlider,
+		AX:       []string{string(RoleSlider)},
+		ATSPI:    []string{"slider"},
+		UIA:      []string{"Slider"},
+	},
+	{
+		Semantic: SemanticStepper,
+		AX:       []string{string(RoleIncrementor)},
+		ATSPI:    []string{"spin button"},
+		UIA:      []string{"Spinner"},
+	},
+	{
+		Semantic: SemanticTab,
+		AX:       []string{string(RoleTabButton)},
+		ATSPI:    []string{"page tab"},
+		UIA:      []string{"TabItem"},
+	},
+	{
+		Semantic: SemanticMenuItem,
+		AX:       []string{string(RoleMenuItem)},
+		ATSPI:    []string{"menu item"},
+		UIA:      []string{"MenuItem"},
+	},
+	{
+		Semantic: SemanticMenubarItem,
+		AX:       []string{string(RoleMenuBarItem)},
+	},
+	{
+		Semantic: SemanticDockItem,
+		AX:       []string{string(RoleDockItem)},
+	},
+	{
+		Semantic: SemanticCell,
+		AX:       []string{string(RoleCell)},
+		ATSPI:    []string{"table cell"},
+		UIA:      []string{"DataItem"},
+	},
+	{
+		Semantic: SemanticRow,
+		AX:       []string{string(RoleRow)},
+		ATSPI:    []string{"table row"},
+		UIA:      []string{"TreeItem"},
+	},
+	{
+		Semantic: SemanticListItem,
+		AX:       []string{string(RoleRow)},
+		ATSPI:    []string{"list item"},
+		UIA:      []string{"ListItem"},
+	},
+	{
+		Semantic: SemanticImage,
+		AX:       []string{string(RoleImage)},
+		ATSPI:    []string{"image", "icon"},
+		UIA:      []string{"Image"},
+	},
+	{
+		Semantic: SemanticStaticText,
+		AX:       []string{string(RoleStaticText)},
+		ATSPI:    []string{"static", "label", "text"},
+		UIA:      []string{"Text"},
+	},
+	{
+		Semantic: SemanticHeading,
+		AX:       []string{string(RoleHeading)},
+		ATSPI:    []string{"heading"},
+	},
+	{
+		Semantic: SemanticColorWell,
+		AX:       []string{string(RoleColorWell)},
+		ATSPI:    []string{"color chooser"},
+	},
+	{
+		Semantic: SemanticToolbarButton,
+		AX:       []string{string(RoleToolbarButton)},
+	},
+}
+
+// DefaultClickableRoles is the role list neru ships as the default value of
+// hints.clickable_roles. It is also the fallback an accessibility backend uses
+// when a caller supplies no explicit role filter, so that the default hint
+// targets are the same whether or not a config is present.
+var DefaultClickableRoles = []string{
+	string(SemanticButton),
+	string(SemanticMenuButton),
+	string(SemanticPopupButton),
+	string(SemanticComboBox),
+	string(SemanticCheckbox),
+	string(SemanticRadio),
+	string(SemanticSwitch),
+	string(SemanticDisclosure),
+	string(SemanticLink),
+	string(SemanticTextField),
+	string(SemanticTextArea),
+	string(SemanticSlider),
+	string(SemanticTab),
+	string(SemanticMenuItem),
+	string(SemanticCell),
+	string(SemanticRow),
+	// macOS web content and other AX-only containers surface as
+	// AXGenericElement, which has no cross-platform meaning.
+	string(VocabularyAX) + vocabularySeparator + string(RoleGenericElement),
+}
+
+// semanticIndex indexes RoleVocabulary by semantic name.
+var semanticIndex = func() map[SemanticRole]RoleMapping {
+	index := make(map[SemanticRole]RoleMapping, len(RoleVocabulary))
+	for _, mapping := range RoleVocabulary {
+		index[mapping.Semantic] = mapping
+	}
+
+	return index
+}()
+
+// nativeIndex indexes RoleVocabulary the other way round: from a native role
+// name in a given vocabulary back to the semantic role that covers it. It is
+// used to turn a bare native name in a config into an actionable error message.
+var nativeIndex = func() map[NativeVocabulary]map[string]SemanticRole {
+	index := map[NativeVocabulary]map[string]SemanticRole{
+		VocabularyAX:    {},
+		VocabularyATSPI: {},
+		VocabularyUIA:   {},
+	}
+
+	for _, mapping := range RoleVocabulary {
+		for vocab, names := range map[NativeVocabulary][]string{
+			VocabularyAX:    mapping.AX,
+			VocabularyATSPI: mapping.ATSPI,
+			VocabularyUIA:   mapping.UIA,
+		} {
+			for _, name := range names {
+				if _, exists := index[vocab][name]; !exists {
+					index[vocab][name] = mapping.Semantic
+				}
+			}
+		}
+	}
+
+	return index
+}()
+
+// LookupSemantic returns the mapping for a semantic role name.
+func LookupSemantic(role SemanticRole) (RoleMapping, bool) {
+	mapping, ok := semanticIndex[role]
+
+	return mapping, ok
+}
+
+// SemanticForNative returns the semantic role covering a native role name in
+// the given vocabulary. Where several semantic roles expand onto the same
+// native name, the first in RoleVocabulary order wins.
+func SemanticForNative(vocab NativeVocabulary, native string) (SemanticRole, bool) {
+	names, ok := nativeIndex[vocab]
+	if !ok {
+		return "", false
+	}
+
+	semantic, found := names[native]
+
+	return semantic, found
+}

--- a/internal/core/domain/element/vocabulary_resolve.go
+++ b/internal/core/domain/element/vocabulary_resolve.go
@@ -1,0 +1,319 @@
+package element
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// vocabularySeparator separates a vocabulary prefix from a native role name in
+// a configuration entry, e.g. "atspi:page tab list". No accessibility role name
+// on any supported platform contains a colon, so splitting on the first one is
+// unambiguous.
+const vocabularySeparator = ":"
+
+// RoleDiagnosticKind classifies a problem found while resolving configured
+// roles into native role names.
+type RoleDiagnosticKind int
+
+const (
+	// RoleDiagnosticUnknownName marks a bare entry that is not a semantic role.
+	// It is fatal: the semantic vocabulary is closed, so this is a typo or a
+	// native role name written without its vocabulary prefix.
+	RoleDiagnosticUnknownName RoleDiagnosticKind = iota
+	// RoleDiagnosticUnknownVocabulary marks an entry whose prefix is not one of
+	// the known native vocabularies. It is fatal.
+	RoleDiagnosticUnknownVocabulary
+	// RoleDiagnosticForeignVocabulary marks a well-formed native entry that
+	// belongs to a different platform. It is informational: cross-platform
+	// configurations are expected to carry entries for every machine.
+	RoleDiagnosticForeignVocabulary
+	// RoleDiagnosticNoNativeEquivalent marks a valid semantic role that has no
+	// counterpart on the running platform. It is informational.
+	RoleDiagnosticNoNativeEquivalent
+)
+
+// RoleDiagnostic describes one configuration entry that could not be resolved
+// into a usable native role, together with a human-readable explanation.
+type RoleDiagnostic struct {
+	// Entry is the configuration entry verbatim.
+	Entry string
+	// Kind classifies the problem.
+	Kind RoleDiagnosticKind
+	// Suggestion is a replacement entry, when one can be derived.
+	Suggestion string
+	// GOOS is the platform the entry was resolved against.
+	GOOS string
+}
+
+// IsFatal reports whether the diagnostic should reject the configuration
+// rather than merely be reported. Only malformed or unrecognized entries are
+// fatal; entries that simply do not apply to this platform are not.
+func (d RoleDiagnostic) IsFatal() bool {
+	return d.Kind == RoleDiagnosticUnknownName || d.Kind == RoleDiagnosticUnknownVocabulary
+}
+
+// Message returns a human-readable explanation of the diagnostic.
+func (d RoleDiagnostic) Message() string {
+	switch d.Kind {
+	case RoleDiagnosticUnknownName:
+		if d.Suggestion != "" {
+			return fmt.Sprintf("unknown role %q: use %q", d.Entry, d.Suggestion)
+		}
+
+		return fmt.Sprintf("unknown role %q", d.Entry)
+	case RoleDiagnosticUnknownVocabulary:
+		return fmt.Sprintf(
+			"unknown role vocabulary in %q: expected a semantic role or one of %q, %q, %q",
+			d.Entry, VocabularyAX, VocabularyATSPI, VocabularyUIA,
+		)
+	case RoleDiagnosticForeignVocabulary:
+		return fmt.Sprintf("%q does not apply on %s and is ignored", d.Entry, d.GOOS)
+	case RoleDiagnosticNoNativeEquivalent:
+		return fmt.Sprintf("%q has no equivalent on %s and is ignored", d.Entry, d.GOOS)
+	default:
+		return fmt.Sprintf("invalid role %q", d.Entry)
+	}
+}
+
+// ResolvedRoleEntry records how a single configuration entry resolved. It backs
+// both role resolution and the `neru roles` explanation output.
+type ResolvedRoleEntry struct {
+	// Entry is the configuration entry verbatim.
+	Entry string
+	// Semantic is set when the entry named a semantic role.
+	Semantic SemanticRole
+	// Vocabulary is set when the entry carried a native vocabulary prefix.
+	Vocabulary NativeVocabulary
+	// Native lists the native role names the entry contributes on this
+	// platform. It is empty for entries that do not apply here.
+	Native []string
+	// Diagnostic is set when the entry could not be fully resolved.
+	Diagnostic *RoleDiagnostic
+}
+
+// RoleResolution is the outcome of resolving a configured role list.
+type RoleResolution struct {
+	// GOOS is the platform the entries were resolved against.
+	GOOS string
+	// Native is the deduplicated union of native role names, in entry order.
+	Native []string
+	// Entries records the per-entry outcome, in configuration order.
+	Entries []ResolvedRoleEntry
+	// Diagnostics lists every problem found, in configuration order.
+	Diagnostics []RoleDiagnostic
+}
+
+// HasFatal reports whether any diagnostic should reject the configuration.
+func (r RoleResolution) HasFatal() bool {
+	for _, diagnostic := range r.Diagnostics {
+		if diagnostic.IsFatal() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// FatalMessages returns the messages of every fatal diagnostic.
+func (r RoleResolution) FatalMessages() []string {
+	var messages []string
+
+	for _, diagnostic := range r.Diagnostics {
+		if diagnostic.IsFatal() {
+			messages = append(messages, diagnostic.Message())
+		}
+	}
+
+	return messages
+}
+
+// IgnoredMessages returns the messages of every non-fatal diagnostic, i.e. the
+// entries that are valid but do not apply on this platform.
+func (r RoleResolution) IgnoredMessages() []string {
+	var messages []string
+
+	for _, diagnostic := range r.Diagnostics {
+		if !diagnostic.IsFatal() {
+			messages = append(messages, diagnostic.Message())
+		}
+	}
+
+	return messages
+}
+
+// ResolveRoles expands configured role entries into the native role names used
+// by the accessibility backend of the given platform.
+//
+// An entry is either a semantic role from the closed vocabulary ("button"), or
+// a native role name addressed through its vocabulary prefix ("atspi:page tab
+// list"). Prefixed entries for other platforms resolve to nothing and are
+// reported, not rejected, so one configuration can serve several machines.
+// Empty and whitespace-only entries are skipped silently.
+func ResolveRoles(entries []string, goos string) RoleResolution {
+	current, hasVocabulary := VocabularyForGOOS(goos)
+
+	resolution := RoleResolution{GOOS: goos}
+	seen := make(map[string]struct{}, len(entries))
+
+	for _, raw := range entries {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+
+		resolved := resolveRoleEntry(entry, current, hasVocabulary, goos)
+
+		for _, native := range resolved.Native {
+			if _, duplicate := seen[native]; duplicate {
+				continue
+			}
+
+			seen[native] = struct{}{}
+
+			resolution.Native = append(resolution.Native, native)
+		}
+
+		if resolved.Diagnostic != nil {
+			resolution.Diagnostics = append(resolution.Diagnostics, *resolved.Diagnostic)
+		}
+
+		resolution.Entries = append(resolution.Entries, resolved)
+	}
+
+	return resolution
+}
+
+// ResolveRolesForCurrentPlatform resolves entries against the running platform.
+func ResolveRolesForCurrentPlatform(entries []string) RoleResolution {
+	return ResolveRoles(entries, runtime.GOOS)
+}
+
+// resolveRoleEntry resolves a single non-empty configuration entry.
+func resolveRoleEntry(
+	entry string,
+	current NativeVocabulary,
+	hasVocabulary bool,
+	goos string,
+) ResolvedRoleEntry {
+	if vocab, native, prefixed := splitVocabularyEntry(entry); prefixed {
+		return resolveNativeEntry(entry, vocab, native, current, hasVocabulary, goos)
+	}
+
+	return resolveSemanticEntry(entry, current, hasVocabulary, goos)
+}
+
+// splitVocabularyEntry splits a prefixed entry into its vocabulary and native
+// role name. The third result reports whether the entry carried a separator at
+// all; an unrecognized prefix still returns true so the caller can report it
+// rather than treating the whole string as a semantic name.
+func splitVocabularyEntry(entry string) (NativeVocabulary, string, bool) {
+	prefix, native, found := strings.Cut(entry, vocabularySeparator)
+	if !found {
+		return "", "", false
+	}
+
+	return NativeVocabulary(strings.TrimSpace(prefix)), strings.TrimSpace(native), true
+}
+
+// resolveNativeEntry resolves an entry that carried a vocabulary prefix.
+func resolveNativeEntry(
+	entry string,
+	vocab NativeVocabulary,
+	native string,
+	current NativeVocabulary,
+	hasVocabulary bool,
+	goos string,
+) ResolvedRoleEntry {
+	resolved := ResolvedRoleEntry{Entry: entry, Vocabulary: vocab}
+
+	if !knownVocabulary(vocab) || native == "" {
+		resolved.Diagnostic = &RoleDiagnostic{
+			Entry: entry,
+			Kind:  RoleDiagnosticUnknownVocabulary,
+			GOOS:  goos,
+		}
+
+		return resolved
+	}
+
+	if !hasVocabulary || vocab != current {
+		resolved.Diagnostic = &RoleDiagnostic{
+			Entry: entry,
+			Kind:  RoleDiagnosticForeignVocabulary,
+			GOOS:  goos,
+		}
+
+		return resolved
+	}
+
+	resolved.Native = []string{native}
+
+	return resolved
+}
+
+// resolveSemanticEntry resolves a bare entry, which must name a semantic role.
+func resolveSemanticEntry(
+	entry string,
+	current NativeVocabulary,
+	hasVocabulary bool,
+	goos string,
+) ResolvedRoleEntry {
+	semantic := SemanticRole(entry)
+
+	mapping, ok := LookupSemantic(semantic)
+	if !ok {
+		return ResolvedRoleEntry{
+			Entry: entry,
+			Diagnostic: &RoleDiagnostic{
+				Entry:      entry,
+				Kind:       RoleDiagnosticUnknownName,
+				Suggestion: suggestionForBareEntry(entry),
+				GOOS:       goos,
+			},
+		}
+	}
+
+	resolved := ResolvedRoleEntry{Entry: entry, Semantic: semantic}
+
+	if hasVocabulary {
+		resolved.Native = mapping.Native(current)
+	}
+
+	if len(resolved.Native) == 0 {
+		resolved.Diagnostic = &RoleDiagnostic{
+			Entry: entry,
+			Kind:  RoleDiagnosticNoNativeEquivalent,
+			GOOS:  goos,
+		}
+	}
+
+	return resolved
+}
+
+// knownVocabulary reports whether vocab is one of the native vocabularies.
+func knownVocabulary(vocab NativeVocabulary) bool {
+	switch vocab {
+	case VocabularyAX, VocabularyATSPI, VocabularyUIA:
+		return true
+	default:
+		return false
+	}
+}
+
+// suggestionForBareEntry derives a replacement for a bare entry that is not a
+// semantic role. A native role name written without its prefix — the shape
+// every pre-vocabulary configuration has — resolves to the semantic role that
+// covers it, which is the migration users need.
+func suggestionForBareEntry(entry string) string {
+	for _, vocab := range []NativeVocabulary{VocabularyAX, VocabularyATSPI, VocabularyUIA} {
+		semantic, ok := SemanticForNative(vocab, entry)
+		if !ok {
+			continue
+		}
+
+		return string(semantic)
+	}
+
+	return ""
+}

--- a/internal/core/domain/element/vocabulary_test.go
+++ b/internal/core/domain/element/vocabulary_test.go
@@ -1,0 +1,671 @@
+package element_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+)
+
+// Go platform identifiers used by the table-driven cases below.
+const (
+	testGOOSDarwin  = "darwin"
+	testGOOSLinux   = "linux"
+	testGOOSWindows = "windows"
+
+	// testRoleButton is the semantic role most cases resolve.
+	testRoleButton = "button"
+
+	// testATSPIPushButton is the AT-SPI role name for role id 43 on
+	// at-spi2-core releases predating the ATSPI_ROLE_BUTTON rename.
+	testATSPIPushButton = "push button"
+
+	// testATSPIToggleButton is the AT-SPI role older toolkits report for a
+	// switch, and one of the roles the button semantic role covers.
+	testATSPIToggleButton = "toggle button"
+
+	// Entries reused across the resolution cases.
+	testAXButton      = "AXButton"
+	testATSPIPageTabs = "atspi:page tab list"
+	testTypoRole      = "buton"
+)
+
+// TestRoleVocabulary_SemanticNamesAreUnique guards the closed vocabulary: a
+// duplicate semantic name would make one of the two mappings unreachable.
+func TestRoleVocabulary_SemanticNamesAreUnique(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[element.SemanticRole]struct{}, len(element.RoleVocabulary))
+
+	for _, mapping := range element.RoleVocabulary {
+		if _, duplicate := seen[mapping.Semantic]; duplicate {
+			t.Errorf("duplicate semantic role %q in element.RoleVocabulary", mapping.Semantic)
+		}
+
+		seen[mapping.Semantic] = struct{}{}
+	}
+}
+
+// TestRoleVocabulary_SemanticNamesDoNotCollideWithDifferentNativeMeanings is
+// the guard that keeps the vocabulary readable. A semantic name that is also a
+// native role name is fine when both mean the same thing ("button" is both a
+// semantic role and an AT-SPI role). It is a trap when they diverge: AT-SPI
+// "text" is a text-bearing element, so a semantic role named "text" meaning a
+// text field would read as one thing and resolve as another.
+func TestRoleVocabulary_SemanticNamesDoNotCollideWithDifferentNativeMeanings(t *testing.T) {
+	t.Parallel()
+
+	vocabularies := []element.NativeVocabulary{
+		element.VocabularyAX,
+		element.VocabularyATSPI,
+		element.VocabularyUIA,
+	}
+
+	for _, mapping := range element.RoleVocabulary {
+		for _, vocab := range vocabularies {
+			covering, ok := element.SemanticForNative(vocab, string(mapping.Semantic))
+			if !ok || covering == mapping.Semantic {
+				continue
+			}
+
+			t.Errorf(
+				"semantic role %q is also a %s native role name meaning %q; "+
+					"rename the semantic role so it cannot be misread",
+				mapping.Semantic, vocab, covering,
+			)
+		}
+	}
+}
+
+// TestRoleVocabulary_EverySemanticRoleHasAtLeastOneNativeName catches a mapping
+// that is empty on every platform, which would be dead vocabulary.
+func TestRoleVocabulary_EverySemanticRoleHasAtLeastOneNativeName(t *testing.T) {
+	t.Parallel()
+
+	for _, mapping := range element.RoleVocabulary {
+		if len(mapping.AX) == 0 && len(mapping.ATSPI) == 0 && len(mapping.UIA) == 0 {
+			t.Errorf("semantic role %q maps to no native role on any platform", mapping.Semantic)
+		}
+	}
+}
+
+func TestVocabularyForGOOS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		goos  string
+		want  element.NativeVocabulary
+		found bool
+	}{
+		{name: "darwin", goos: testGOOSDarwin, want: element.VocabularyAX, found: true},
+		{name: "linux", goos: testGOOSLinux, want: element.VocabularyATSPI, found: true},
+		{name: "windows", goos: testGOOSWindows, want: element.VocabularyUIA, found: true},
+		{name: "unsupported", goos: "freebsd", want: "", found: false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := element.VocabularyForGOOS(testCase.goos)
+			if ok != testCase.found {
+				t.Fatalf(
+					"element.VocabularyForGOOS(%q) found = %v, want %v",
+					testCase.goos,
+					ok,
+					testCase.found,
+				)
+			}
+
+			if got != testCase.want {
+				t.Errorf(
+					"element.VocabularyForGOOS(%q) = %q, want %q",
+					testCase.goos,
+					got,
+					testCase.want,
+				)
+			}
+		})
+	}
+}
+
+func TestResolveRoles_SemanticExpansionPerPlatform(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		goos string
+		want []string
+	}{
+		{name: "darwin", goos: testGOOSDarwin, want: []string{testAXButton}},
+		{
+			name: "linux",
+			goos: testGOOSLinux,
+			// The AT-SPI role literally named "button" is a distinct native role,
+			// not the semantic role of the same spelling.
+			want: []string{testATSPIPushButton, testRoleButton, testATSPIToggleButton},
+		},
+		{name: "windows", goos: testGOOSWindows, want: []string{"Button", "SplitButton"}},
+		{name: "unsupported platform resolves to nothing", goos: "freebsd", want: nil},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := element.ResolveRoles([]string{testRoleButton}, testCase.goos)
+			if !slices.Equal(got.Native, testCase.want) {
+				t.Errorf(
+					"element.ResolveRoles(button, %q) = %v, want %v",
+					testCase.goos,
+					got.Native,
+					testCase.want,
+				)
+			}
+		})
+	}
+}
+
+func TestResolveRoles_PrefixedEntries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		entry    string
+		goos     string
+		want     []string
+		wantKind element.RoleDiagnosticKind
+		wantDiag bool
+	}{
+		{
+			name:  "native entry for this platform is passed through verbatim",
+			entry: testATSPIPageTabs,
+			goos:  testGOOSLinux,
+			want:  []string{"page tab list"},
+		},
+		{
+			name:  "unmapped native name is accepted without complaint",
+			entry: "uia:Custom",
+			goos:  testGOOSWindows,
+			want:  []string{"Custom"},
+		},
+		{
+			name:     "native entry for another platform is ignored, not rejected",
+			entry:    "ax:AXDisclosureTriangle",
+			goos:     testGOOSLinux,
+			wantKind: element.RoleDiagnosticForeignVocabulary,
+			wantDiag: true,
+		},
+		{
+			name:     "unknown vocabulary is fatal",
+			entry:    "msaa:ROLE_SYSTEM_PUSHBUTTON",
+			goos:     testGOOSWindows,
+			wantKind: element.RoleDiagnosticUnknownVocabulary,
+			wantDiag: true,
+		},
+		{
+			name:     "empty native name is fatal",
+			entry:    "atspi:",
+			goos:     testGOOSLinux,
+			wantKind: element.RoleDiagnosticUnknownVocabulary,
+			wantDiag: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := element.ResolveRoles([]string{testCase.entry}, testCase.goos)
+
+			if !slices.Equal(got.Native, testCase.want) {
+				t.Errorf(
+					"element.ResolveRoles(%q) native = %v, want %v",
+					testCase.entry,
+					got.Native,
+					testCase.want,
+				)
+			}
+
+			if !testCase.wantDiag {
+				if len(got.Diagnostics) != 0 {
+					t.Fatalf(
+						"element.ResolveRoles(%q) unexpected diagnostics %v",
+						testCase.entry,
+						got.Diagnostics,
+					)
+				}
+
+				return
+			}
+
+			if len(got.Diagnostics) != 1 {
+				t.Fatalf(
+					"element.ResolveRoles(%q) diagnostics = %d, want 1",
+					testCase.entry, len(got.Diagnostics),
+				)
+			}
+
+			if got.Diagnostics[0].Kind != testCase.wantKind {
+				t.Errorf(
+					"element.ResolveRoles(%q) diagnostic kind = %v, want %v",
+					testCase.entry, got.Diagnostics[0].Kind, testCase.wantKind,
+				)
+			}
+		})
+	}
+}
+
+// TestResolveRoles_BareNativeNameSuggestsSemanticRole pins the migration
+// message every pre-vocabulary configuration will hit on first load.
+func TestResolveRoles_BareNativeNameSuggestsSemanticRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		entry          string
+		goos           string
+		wantSuggestion string
+	}{
+		{
+			name:           "legacy AX name",
+			entry:          testAXButton,
+			goos:           testGOOSDarwin,
+			wantSuggestion: testRoleButton,
+		},
+		{
+			name:           "legacy AT-SPI name",
+			entry:          "push button",
+			goos:           testGOOSLinux,
+			wantSuggestion: testRoleButton,
+		},
+		{
+			name:           "legacy UIA name",
+			entry:          "Edit",
+			goos:           testGOOSWindows,
+			wantSuggestion: "text_field",
+		},
+		{
+			name:           "role from another platform still suggests the semantic name",
+			entry:          "AXSlider",
+			goos:           testGOOSLinux,
+			wantSuggestion: "slider",
+		},
+		{
+			name:  "genuine typo has no suggestion",
+			entry: testTypoRole,
+			goos:  testGOOSDarwin,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := element.ResolveRoles([]string{testCase.entry}, testCase.goos)
+			if len(got.Diagnostics) != 1 {
+				t.Fatalf(
+					"element.ResolveRoles(%q) diagnostics = %v, want exactly 1",
+					testCase.entry,
+					got.Diagnostics,
+				)
+			}
+
+			diagnostic := got.Diagnostics[0]
+			if !diagnostic.IsFatal() {
+				t.Errorf("element.ResolveRoles(%q) diagnostic should be fatal", testCase.entry)
+			}
+
+			if diagnostic.Kind != element.RoleDiagnosticUnknownName {
+				t.Errorf(
+					"element.ResolveRoles(%q) kind = %v, want element.RoleDiagnosticUnknownName",
+					testCase.entry, diagnostic.Kind,
+				)
+			}
+
+			if diagnostic.Suggestion != testCase.wantSuggestion {
+				t.Errorf(
+					"element.ResolveRoles(%q) suggestion = %q, want %q",
+					testCase.entry, diagnostic.Suggestion, testCase.wantSuggestion,
+				)
+			}
+		})
+	}
+}
+
+func TestResolveRoles_DeduplicatesOverlappingExpansions(t *testing.T) {
+	t.Parallel()
+
+	// text_field, text_area and search_field all expand onto "Edit" on Windows.
+	got := element.ResolveRoles(
+		[]string{"text_field", "text_area", "search_field"},
+		testGOOSWindows,
+	)
+
+	want := []string{"Edit"}
+	if !slices.Equal(got.Native, want) {
+		t.Errorf("element.ResolveRoles(text roles, windows) = %v, want %v", got.Native, want)
+	}
+
+	if got.HasFatal() {
+		t.Errorf(
+			"element.ResolveRoles(text roles, windows) unexpectedly fatal: %v",
+			got.FatalMessages(),
+		)
+	}
+}
+
+func TestResolveRoles_SkipsEmptyEntries(t *testing.T) {
+	t.Parallel()
+
+	got := element.ResolveRoles([]string{"", "   ", testRoleButton}, testGOOSDarwin)
+
+	if len(got.Entries) != 1 {
+		t.Errorf("element.ResolveRoles() entries = %d, want 1", len(got.Entries))
+	}
+
+	if len(got.Diagnostics) != 0 {
+		t.Errorf("element.ResolveRoles() diagnostics = %v, want none", got.Diagnostics)
+	}
+}
+
+func TestResolveRoles_SemanticRoleWithNoPlatformEquivalentIsNotFatal(t *testing.T) {
+	t.Parallel()
+
+	got := element.ResolveRoles([]string{"disclosure"}, testGOOSLinux)
+
+	if got.HasFatal() {
+		t.Fatalf(
+			"element.ResolveRoles(disclosure, linux) should not be fatal: %v",
+			got.FatalMessages(),
+		)
+	}
+
+	if len(got.IgnoredMessages()) != 1 {
+		t.Errorf(
+			"element.ResolveRoles(disclosure, linux) ignored = %v, want 1",
+			got.IgnoredMessages(),
+		)
+	}
+}
+
+// TestResolveRoles_LinuxNamesMatchGetRoleNameOutput pins the AT-SPI expansions
+// against what Accessible.GetRoleName actually returns. That name is the GEnum
+// nick of the role with hyphens replaced by spaces, so it is not always the
+// name a reader would guess: ATSPI_ROLE_PUSH_BUTTON_MENU reports "push button
+// menu", never "menu button". A wrong name here matches nothing at runtime
+// while still looking plausible in the config.
+func TestResolveRoles_LinuxNamesMatchGetRoleNameOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		semantic element.SemanticRole
+		want     []string
+	}{
+		{
+			name:     "menu_button uses the push button menu nick",
+			semantic: element.SemanticMenuButton,
+			want:     []string{"push button menu"},
+		},
+		{
+			name:     "switch covers the dedicated role and the legacy fallback",
+			semantic: element.SemanticSwitch,
+			want:     []string{"switch", testATSPIToggleButton},
+		},
+		{
+			name:     "button covers both spellings of role id 43",
+			semantic: element.SemanticButton,
+			want:     []string{testATSPIPushButton, testRoleButton, testATSPIToggleButton},
+		},
+		{
+			name:     "stepper uses the spin button nick",
+			semantic: element.SemanticStepper,
+			want:     []string{"spin button"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := element.ResolveRoles([]string{string(testCase.semantic)}, testGOOSLinux)
+			if !slices.Equal(got.Native, testCase.want) {
+				t.Errorf(
+					"ResolveRoles(%q, linux) = %v, want %v",
+					testCase.semantic, got.Native, testCase.want,
+				)
+			}
+		})
+	}
+}
+
+// TestDefaultClickableRoles_ResolveOnEverySupportedPlatform is the guard for
+// the failure this vocabulary exists to prevent: a default role list that is
+// valid but resolves to nothing on some platform, so hints are silently blank
+// there. Checking only the platform the tests happen to run on would miss it.
+func TestDefaultClickableRoles_ResolveOnEverySupportedPlatform(t *testing.T) {
+	t.Parallel()
+
+	for _, goos := range []string{testGOOSDarwin, testGOOSLinux, testGOOSWindows} {
+		t.Run(goos, func(t *testing.T) {
+			t.Parallel()
+
+			resolution := element.ResolveRoles(element.DefaultClickableRoles, goos)
+
+			if resolution.HasFatal() {
+				t.Errorf(
+					"DefaultClickableRoles has invalid entries on %s: %v",
+					goos, resolution.FatalMessages(),
+				)
+			}
+
+			if len(resolution.Native) == 0 {
+				t.Fatalf(
+					"DefaultClickableRoles resolves to no native role on %s; "+
+						"hints would be blank out of the box",
+					goos,
+				)
+			}
+
+			// A default that only just resolves is a smell: the shipped list
+			// covers buttons, links and text fields on every platform.
+			for _, semantic := range []element.SemanticRole{
+				element.SemanticButton,
+				element.SemanticLink,
+				element.SemanticTextField,
+			} {
+				want := element.ResolveRoles([]string{string(semantic)}, goos).Native
+				for _, native := range want {
+					if !slices.Contains(resolution.Native, native) {
+						t.Errorf(
+							"DefaultClickableRoles on %s is missing %q (from %q)",
+							goos, native, semantic,
+						)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestResolveRoles_EntriesDescribeEachConfigEntry pins the per-entry record
+// that backs `neru roles --explain`. The rendering is only as good as these
+// fields, and a wrong Semantic/Vocabulary would mislabel entries in the output
+// without failing anything else.
+func TestResolveRoles_EntriesDescribeEachConfigEntry(t *testing.T) {
+	t.Parallel()
+
+	resolution := element.ResolveRoles(
+		[]string{"button", "", "ax:AXGenericElement", testATSPIPageTabs, testTypoRole},
+		testGOOSDarwin,
+	)
+
+	// The empty entry is skipped silently; the other four are recorded in order.
+	if len(resolution.Entries) != 4 {
+		t.Fatalf("Entries = %d, want 4 (empty entries skipped): %+v",
+			len(resolution.Entries), resolution.Entries)
+	}
+
+	semantic := resolution.Entries[0]
+	if semantic.Semantic != element.SemanticButton || semantic.Vocabulary != "" {
+		t.Errorf("semantic entry = %+v, want Semantic=button with no vocabulary", semantic)
+	}
+
+	if len(semantic.Native) == 0 || semantic.Diagnostic != nil {
+		t.Errorf("semantic entry = %+v, want native roles and no diagnostic", semantic)
+	}
+
+	native := resolution.Entries[1]
+	if native.Vocabulary != element.VocabularyAX || native.Semantic != "" {
+		t.Errorf("native entry = %+v, want Vocabulary=ax with no semantic", native)
+	}
+
+	if !slices.Equal(native.Native, []string{"AXGenericElement"}) {
+		t.Errorf("native entry Native = %v, want [AXGenericElement]", native.Native)
+	}
+
+	foreign := resolution.Entries[2]
+	if foreign.Vocabulary != element.VocabularyATSPI || len(foreign.Native) != 0 {
+		t.Errorf("foreign entry = %+v, want Vocabulary=atspi contributing nothing", foreign)
+	}
+
+	if foreign.Diagnostic == nil || foreign.Diagnostic.IsFatal() {
+		t.Errorf("foreign entry = %+v, want a non-fatal diagnostic", foreign)
+	}
+
+	unknown := resolution.Entries[3]
+	if unknown.Diagnostic == nil || !unknown.Diagnostic.IsFatal() {
+		t.Errorf("unknown entry = %+v, want a fatal diagnostic", unknown)
+	}
+}
+
+func TestRoleDiagnostic_Message(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		entry    string
+		goos     string
+		contains []string
+	}{
+		{
+			name:     "unknown name suggests the semantic role",
+			entry:    testAXButton,
+			goos:     testGOOSDarwin,
+			contains: []string{"unknown role", `"` + testAXButton + `"`, `use "button"`},
+		},
+		{
+			name:     "typo has no suggestion to offer",
+			entry:    testTypoRole,
+			goos:     testGOOSDarwin,
+			contains: []string{"unknown role", `"` + testTypoRole + `"`},
+		},
+		{
+			name:     "unknown vocabulary names the accepted prefixes",
+			entry:    "msaa:ROLE_SYSTEM_PUSHBUTTON",
+			goos:     testGOOSDarwin,
+			contains: []string{"unknown role vocabulary", `"ax"`, `"atspi"`, `"uia"`},
+		},
+		{
+			name:     "foreign vocabulary names the platform",
+			entry:    testATSPIPageTabs,
+			goos:     testGOOSDarwin,
+			contains: []string{"does not apply on darwin", "ignored"},
+		},
+		{
+			name:     "semantic role with no equivalent names the platform",
+			entry:    "disclosure",
+			goos:     testGOOSLinux,
+			contains: []string{"no equivalent on linux", "ignored"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			resolution := element.ResolveRoles([]string{testCase.entry}, testCase.goos)
+			if len(resolution.Diagnostics) != 1 {
+				t.Fatalf("Diagnostics = %v, want exactly 1", resolution.Diagnostics)
+			}
+
+			message := resolution.Diagnostics[0].Message()
+			for _, want := range testCase.contains {
+				if !strings.Contains(message, want) {
+					t.Errorf("Message() = %q, want it to contain %q", message, want)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveRoles_EntryParsing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		entry string
+		goos  string
+		want  []string
+	}{
+		{
+			name:  "surrounding whitespace is trimmed",
+			entry: "  button  ",
+			goos:  testGOOSDarwin,
+			want:  []string{testAXButton},
+		},
+		{
+			name:  "whitespace around a prefixed entry is trimmed",
+			entry: " atspi :  page tab list ",
+			goos:  testGOOSLinux,
+			want:  []string{"page tab list"},
+		},
+		{
+			name:  "only the first colon separates the vocabulary",
+			entry: "uia:Foo:Bar",
+			goos:  testGOOSWindows,
+			want:  []string{"Foo:Bar"},
+		},
+		{
+			name:  "native names keep their case",
+			entry: "uia:SplitButton",
+			goos:  testGOOSWindows,
+			want:  []string{"SplitButton"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := element.ResolveRoles([]string{testCase.entry}, testCase.goos)
+			if got.HasFatal() {
+				t.Fatalf("ResolveRoles(%q) fatal: %v", testCase.entry, got.FatalMessages())
+			}
+
+			if !slices.Equal(got.Native, testCase.want) {
+				t.Errorf(
+					"ResolveRoles(%q) = %v, want %v",
+					testCase.entry,
+					got.Native,
+					testCase.want,
+				)
+			}
+		})
+	}
+}
+
+// TestResolveRoles_SemanticNamesAreCaseSensitive documents that the semantic
+// vocabulary is matched exactly. Accepting "Button" would make the closed set
+// fuzzy and weaken typo detection.
+func TestResolveRoles_SemanticNamesAreCaseSensitive(t *testing.T) {
+	t.Parallel()
+
+	got := element.ResolveRoles([]string{"Button"}, testGOOSDarwin)
+	if !got.HasFatal() {
+		t.Errorf("ResolveRoles(Button) = %v, want it rejected as unknown", got.Native)
+	}
+}

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain/element"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/infra/platform"
 	"github.com/y3owk1n/neru/internal/core/infra/platform/linux"
@@ -107,51 +108,155 @@ const (
 	collectionMaxWorkers = 16
 )
 
-// AtspiRole enum ids (declaration-order indices in atspi-constants.h), used to
-// build the Collection.GetMatches role bitfield. The enum is ABI-stable
-// (append-only), so these are fixed.
-const (
-	atspiRolePushButton     = 43
-	atspiRoleToggleButton   = 62
-	atspiRolePushButtonMenu = 129
-	atspiRoleComboBox       = 11
-	atspiRoleCheckBox       = 7
-	atspiRoleCheckMenuItem  = 8
-	atspiRoleRadioButton    = 44
-	atspiRoleRadioMenuItem  = 45
-	atspiRoleLinkID         = 88
-	atspiRoleEntry          = 79
-	atspiRolePasswordText   = 40
-	atspiRoleSlider         = 51
-	atspiRolePageTab        = 37
-	atspiRoleMenuItemID     = 35
-	atspiRoleListItem       = 32
-	atspiRoleTableCell      = 56
-	atspiRoleTableRow       = 90
-)
-
-// atspiRoleNameToID maps the AT-SPI role names Neru cares about (the keys of
-// atspiToAXRole) to their AtspiRole id, for building the Collection.GetMatches
-// role bitfield.
+// atspiRoleNameToID maps AT-SPI role names, as returned by
+// Accessible.GetRoleName, to their AtspiRole id — the declaration-order index
+// in atspi-constants.h. Ids are needed to build the Collection.GetMatches role
+// bitfield, so any role missing here forces the slow per-node walk instead.
+//
+// The enum is ABI-stable (append-only), so these are fixed. The table is
+// complete as of AT-SPI 2.50 (ATSPI_ROLE_PUSH_BUTTON_MENU, the highest id
+// below, is the last member); newer roles simply fall back to the walk.
 var atspiRoleNameToID = map[string]int32{
-	"push button":     atspiRolePushButton,
-	"button":          atspiRolePushButton,
-	"toggle button":   atspiRoleToggleButton,
-	"menu button":     atspiRolePushButtonMenu,
-	"combo box":       atspiRoleComboBox,
-	"check box":       atspiRoleCheckBox,
-	"check menu item": atspiRoleCheckMenuItem,
-	"radio button":    atspiRoleRadioButton,
-	"radio menu item": atspiRoleRadioMenuItem,
-	"link":            atspiRoleLinkID,
-	"entry":           atspiRoleEntry,
-	"password text":   atspiRolePasswordText,
-	"slider":          atspiRoleSlider,
-	"page tab":        atspiRolePageTab,
-	"menu item":       atspiRoleMenuItemID,
-	"list item":       atspiRoleListItem,
-	"table cell":      atspiRoleTableCell,
-	"table row":       atspiRoleTableRow,
+	"invalid":               0,
+	"accelerator label":     1,
+	"alert":                 2,
+	"animation":             3,
+	"arrow":                 4,
+	"calendar":              5,
+	"canvas":                6,
+	"check box":             7,
+	"check menu item":       8,
+	"color chooser":         9,
+	"column header":         10,
+	"combo box":             11,
+	"date editor":           12,
+	"desktop icon":          13,
+	"desktop frame":         14,
+	"dial":                  15,
+	"dialog":                16,
+	"directory pane":        17,
+	"drawing area":          18,
+	"file chooser":          19,
+	"filler":                20,
+	"focus traversable":     21,
+	"font chooser":          22,
+	"frame":                 23,
+	"glass pane":            24,
+	"html container":        25,
+	"icon":                  26,
+	"image":                 27,
+	"internal frame":        28,
+	"label":                 29,
+	"layered pane":          30,
+	"list":                  31,
+	"list item":             32,
+	"menu":                  33,
+	"menu bar":              34,
+	"menu item":             35,
+	"option pane":           36,
+	"page tab":              37,
+	"page tab list":         38,
+	"panel":                 39,
+	"password text":         40,
+	"popup menu":            41,
+	"progress bar":          42,
+	"push button":           43,
+	"radio button":          44,
+	"radio menu item":       45,
+	"root pane":             46,
+	"row header":            47,
+	"scroll bar":            48,
+	"scroll pane":           49,
+	"separator":             50,
+	"slider":                51,
+	"spin button":           52,
+	"split pane":            53,
+	"status bar":            54,
+	"table":                 55,
+	"table cell":            56,
+	"table column header":   57,
+	"table row header":      58,
+	"tearoff menu item":     59,
+	"terminal":              60,
+	"text":                  61,
+	"toggle button":         62,
+	"tool bar":              63,
+	"tool tip":              64,
+	"tree":                  65,
+	"tree table":            66,
+	"unknown":               67,
+	"viewport":              68,
+	"window":                69,
+	"extended":              70,
+	"header":                71,
+	"footer":                72,
+	"paragraph":             73,
+	"ruler":                 74,
+	"application":           75,
+	"autocomplete":          76,
+	"editbar":               77,
+	"embedded":              78,
+	"entry":                 79,
+	"chart":                 80,
+	"caption":               81,
+	"document frame":        82,
+	"heading":               83,
+	"page":                  84,
+	"section":               85,
+	"redundant object":      86,
+	"form":                  87,
+	"link":                  88,
+	"input method window":   89,
+	"table row":             90,
+	"tree item":             91,
+	"document spreadsheet":  92,
+	"document presentation": 93,
+	"document text":         94,
+	"document web":          95,
+	"document email":        96,
+	"comment":               97,
+	"list box":              98,
+	"grouping":              99,
+	"image map":             100,
+	"notification":          101,
+	"info bar":              102,
+	"level bar":             103,
+	"title bar":             104,
+	"block quote":           105,
+	"audio":                 106,
+	"video":                 107,
+	"definition":            108,
+	"article":               109,
+	"landmark":              110,
+	"log":                   111,
+	"marquee":               112,
+	"math":                  113,
+	"rating":                114,
+	"timer":                 115,
+	"static":                116,
+	"math fraction":         117,
+	"math root":             118,
+	"subscript":             119,
+	"superscript":           120,
+	"description list":      121,
+	"description term":      122,
+	"description value":     123,
+	"footnote":              124,
+	"content deletion":      125,
+	"content insertion":     126,
+	"mark":                  127,
+	"suggestion":            128,
+	"push button menu":      129,
+	"switch":                130,
+
+	// Compatibility aliases. Accessible.GetRoleName returns the GEnum nick of
+	// the role with hyphens replaced by spaces, so id 43 reports "button" on
+	// current at-spi2-core (ATSPI_ROLE_BUTTON) and "push button" on releases
+	// predating that rename. Both are accepted so one config works either way.
+	// "menu button" is accepted because users reach for it before the less
+	// obvious "push button menu".
+	"button":      43,
+	"menu button": 129,
 }
 
 // accRef is the AT-SPI (bus-name, object-path) reference returned by
@@ -169,62 +274,19 @@ type atspiExtents struct {
 	H int32
 }
 
-// AX role names that appear in more than one place in the role maps below.
-const (
-	axRoleButton    = "AXButton"
-	axRoleMenuItem  = "AXMenuItem"
-	axRoleTextField = "AXTextField"
-	axRoleRow       = "AXRow"
-)
+// defaultClickableRoles is used when the caller passes no explicit role filter.
+// It is the shipped default role list resolved into AT-SPI role names, so the
+// fallback and a default configuration select exactly the same elements.
+var defaultClickableRoles = func() map[string]struct{} {
+	resolution := element.ResolveRoles(element.DefaultClickableRoles, "linux")
 
-// atspiToAXRole maps AT-SPI role names (lowercase, as returned by
-// Accessible.GetRoleName) to the macOS-style "AX*" role names that Neru's config
-// and the cross-platform filter pipeline speak. Neru's clickable_roles config is
-// authored in AX vocabulary (AXButton, AXLink, ...) and Adapter.MatchesFilter
-// re-checks elem.Role() against those same AX names, so the AT-SPI client must
-// emit AX role names for any of this to match. Roles with no clickable AX
-// equivalent are intentionally absent so containers (section, heading, label)
-// are skipped.
-var atspiToAXRole = map[string]string{
-	"push button":     axRoleButton,
-	"button":          axRoleButton,
-	"toggle button":   axRoleButton,
-	"menu button":     "AXMenuButton",
-	"combo box":       "AXComboBox",
-	"check box":       "AXCheckBox",
-	"check menu item": axRoleMenuItem,
-	"radio button":    "AXRadioButton",
-	"radio menu item": axRoleMenuItem,
-	"link":            "AXLink",
-	"entry":           axRoleTextField,
-	"password text":   axRoleTextField,
-	"slider":          "AXSlider",
-	"page tab":        "AXTabButton",
-	"menu item":       axRoleMenuItem,
-	"list item":       axRoleRow,
-	"table cell":      "AXCell",
-	"table row":       axRoleRow,
-}
+	set := make(map[string]struct{}, len(resolution.Native))
+	for _, native := range resolution.Native {
+		set[strings.ToLower(native)] = struct{}{}
+	}
 
-// defaultClickableAXRoles is used when the caller passes no explicit role
-// filter. It mirrors the AX names in the shipped default config.
-var defaultClickableAXRoles = map[string]struct{}{
-	axRoleButton:    {},
-	"AXMenuButton":  {},
-	"AXComboBox":    {},
-	"AXCheckBox":    {},
-	"AXRadioButton": {},
-	"AXLink":        {},
-	"AXPopUpButton": {},
-	axRoleTextField: {},
-	"AXSlider":      {},
-	"AXTabButton":   {},
-	"AXSwitch":      {},
-	"AXTextArea":    {},
-	axRoleMenuItem:  {},
-	"AXCell":        {},
-	axRoleRow:       {},
-}
+	return set
+}()
 
 // ATSPIClient is the Linux AXClient. It walks the AT-SPI tree for hints and
 // delegates everything else (input injection, focused-app identity) to the
@@ -477,20 +539,17 @@ type atspiMatchRule struct {
 	Invert     bool
 }
 
-// deriveTargetRoleIDs returns the AtspiRole ids whose AX mapping is in roleSet —
-// exactly the roles the per-node walk would emit — so the Collection query has
-// identical semantics.
+// deriveTargetRoleIDs returns the AtspiRole ids for the requested role names —
+// exactly the roles the per-node walk would keep — so the Collection query has
+// identical semantics. Requested names with no known id are skipped; the caller
+// falls back to the walk when nothing resolves.
 func deriveTargetRoleIDs(roleSet map[string]struct{}) []int32 {
 	var ids []int32
 
 	seen := make(map[int32]struct{})
 
-	for atspiName, axRole := range atspiToAXRole {
-		if _, ok := roleSet[axRole]; !ok {
-			continue
-		}
-
-		roleID, ok := atspiRoleNameToID[atspiName]
+	for roleName := range roleSet {
+		roleID, ok := atspiRoleNameToID[roleName]
 		if !ok {
 			continue
 		}
@@ -733,14 +792,11 @@ func (c *ATSPIClient) materializeMatch(
 	roleSet map[string]struct{},
 	offX, offY int,
 ) *atspiNode {
-	// Re-verify the role maps into the requested set: a toolkit may return a role
-	// we did not ask for, and this keeps parity with the walk's filter.
-	axRole, mappable := atspiToAXRole[strings.ToLower(c.roleName(ctx, conn, ref))]
-	if !mappable {
-		return nil
-	}
+	// Re-verify the role is in the requested set: a toolkit may return a role we
+	// did not ask for, and this keeps parity with the walk's filter.
+	roleName := strings.ToLower(c.roleName(ctx, conn, ref))
 
-	if _, ok := roleSet[axRole]; !ok {
+	if _, ok := roleSet[roleName]; !ok {
 		return nil
 	}
 
@@ -751,7 +807,7 @@ func (c *ATSPIClient) materializeMatch(
 
 	return &atspiNode{
 		id:    string(ref.Path) + "@" + ref.Name,
-		role:  axRole,
+		role:  roleName,
 		title: c.name(ctx, conn, ref),
 		rect:  rect.Add(image.Pt(offX, offY)),
 	}
@@ -1905,24 +1961,23 @@ func (c *ATSPIClient) walk(
 
 	*visited++
 
-	// Translate the AT-SPI role into Neru's AX vocabulary, then match against
-	// the requested role set (also AX names). This keeps the whole pipeline,
-	// including the downstream Adapter.MatchesFilter, speaking one vocabulary.
-	axRole, mappable := atspiToAXRole[strings.ToLower(c.roleName(ctx, conn, ref))]
+	// Match the AT-SPI role name against the requested set. Both sides are
+	// native AT-SPI names: configured roles are resolved into this vocabulary
+	// before they reach the client, and the node carries the native name
+	// downstream so Adapter.MatchesFilter compares like with like.
+	roleName := strings.ToLower(c.roleName(ctx, conn, ref))
 
-	if mappable {
-		if _, ok := roles[axRole]; ok && c.stateHas(ctx, conn, ref, atspiStateShowing) {
-			if rect, valid := c.extents(ctx, conn, ref); valid {
-				// AT-SPI reports window-relative coords on Wayland; offset by the
-				// focused window's screen origin from the KWin bridge.
-				rect = rect.Add(image.Pt(offX, offY))
-				*out = append(*out, &atspiNode{
-					id:    string(ref.Path) + "@" + ref.Name,
-					role:  axRole,
-					title: c.name(ctx, conn, ref),
-					rect:  rect,
-				})
-			}
+	if _, ok := roles[roleName]; ok && c.stateHas(ctx, conn, ref, atspiStateShowing) {
+		if rect, valid := c.extents(ctx, conn, ref); valid {
+			// AT-SPI reports window-relative coords on Wayland; offset by the
+			// focused window's screen origin from the KWin bridge.
+			rect = rect.Add(image.Pt(offX, offY))
+			*out = append(*out, &atspiNode{
+				id:    string(ref.Path) + "@" + ref.Name,
+				role:  roleName,
+				title: c.name(ctx, conn, ref),
+				rect:  rect,
+			})
 		}
 	}
 
@@ -1931,24 +1986,25 @@ func (c *ATSPIClient) walk(
 	}
 }
 
-// rolesSet converts the caller's AX role list into a lookup set, falling back
-// to the default clickable AX role set when empty. AX names are case-sensitive
-// (e.g. "AXButton") and must match the config and Adapter.MatchesFilter exactly,
-// so they are NOT lowercased.
+// rolesSet converts the caller's native AT-SPI role list into a lookup set,
+// falling back to the default clickable role set when empty. AT-SPI role names
+// are canonically lowercase, and both this set and the names read from
+// Accessible.GetRoleName are lowercased so a config written with different
+// casing still matches.
 func rolesSet(roles []string) map[string]struct{} {
 	if len(roles) == 0 {
-		return defaultClickableAXRoles
+		return defaultClickableRoles
 	}
 
 	set := make(map[string]struct{}, len(roles))
 	for _, r := range roles {
 		if trimmed := strings.TrimSpace(r); trimmed != "" {
-			set[trimmed] = struct{}{}
+			set[strings.ToLower(trimmed)] = struct{}{}
 		}
 	}
 
 	if len(set) == 0 {
-		return defaultClickableAXRoles
+		return defaultClickableRoles
 	}
 
 	return set

--- a/internal/core/infra/accessibility/atspi_linux.go
+++ b/internal/core/infra/accessibility/atspi_linux.go
@@ -108,156 +108,194 @@ const (
 	collectionMaxWorkers = 16
 )
 
-// atspiRoleNameToID maps AT-SPI role names, as returned by
-// Accessible.GetRoleName, to their AtspiRole id — the declaration-order index
-// in atspi-constants.h. Ids are needed to build the Collection.GetMatches role
-// bitfield, so any role missing here forces the slow per-node walk instead.
-//
-// The enum is ABI-stable (append-only), so these are fixed. The table is
-// complete as of AT-SPI 2.50 (ATSPI_ROLE_PUSH_BUTTON_MENU, the highest id
-// below, is the last member); newer roles simply fall back to the walk.
-var atspiRoleNameToID = map[string]int32{
-	"invalid":               0,
-	"accelerator label":     1,
-	"alert":                 2,
-	"animation":             3,
-	"arrow":                 4,
-	"calendar":              5,
-	"canvas":                6,
-	"check box":             7,
-	"check menu item":       8,
-	"color chooser":         9,
-	"column header":         10,
-	"combo box":             11,
-	"date editor":           12,
-	"desktop icon":          13,
-	"desktop frame":         14,
-	"dial":                  15,
-	"dialog":                16,
-	"directory pane":        17,
-	"drawing area":          18,
-	"file chooser":          19,
-	"filler":                20,
-	"focus traversable":     21,
-	"font chooser":          22,
-	"frame":                 23,
-	"glass pane":            24,
-	"html container":        25,
-	"icon":                  26,
-	"image":                 27,
-	"internal frame":        28,
-	"label":                 29,
-	"layered pane":          30,
-	"list":                  31,
-	"list item":             32,
-	"menu":                  33,
-	"menu bar":              34,
-	"menu item":             35,
-	"option pane":           36,
-	"page tab":              37,
-	"page tab list":         38,
-	"panel":                 39,
-	"password text":         40,
-	"popup menu":            41,
-	"progress bar":          42,
-	"push button":           43,
-	"radio button":          44,
-	"radio menu item":       45,
-	"root pane":             46,
-	"row header":            47,
-	"scroll bar":            48,
-	"scroll pane":           49,
-	"separator":             50,
-	"slider":                51,
-	"spin button":           52,
-	"split pane":            53,
-	"status bar":            54,
-	"table":                 55,
-	"table cell":            56,
-	"table column header":   57,
-	"table row header":      58,
-	"tearoff menu item":     59,
-	"terminal":              60,
-	"text":                  61,
-	"toggle button":         62,
-	"tool bar":              63,
-	"tool tip":              64,
-	"tree":                  65,
-	"tree table":            66,
-	"unknown":               67,
-	"viewport":              68,
-	"window":                69,
-	"extended":              70,
-	"header":                71,
-	"footer":                72,
-	"paragraph":             73,
-	"ruler":                 74,
-	"application":           75,
-	"autocomplete":          76,
-	"editbar":               77,
-	"embedded":              78,
-	"entry":                 79,
-	"chart":                 80,
-	"caption":               81,
-	"document frame":        82,
-	"heading":               83,
-	"page":                  84,
-	"section":               85,
-	"redundant object":      86,
-	"form":                  87,
-	"link":                  88,
-	"input method window":   89,
-	"table row":             90,
-	"tree item":             91,
-	"document spreadsheet":  92,
-	"document presentation": 93,
-	"document text":         94,
-	"document web":          95,
-	"document email":        96,
-	"comment":               97,
-	"list box":              98,
-	"grouping":              99,
-	"image map":             100,
-	"notification":          101,
-	"info bar":              102,
-	"level bar":             103,
-	"title bar":             104,
-	"block quote":           105,
-	"audio":                 106,
-	"video":                 107,
-	"definition":            108,
-	"article":               109,
-	"landmark":              110,
-	"log":                   111,
-	"marquee":               112,
-	"math":                  113,
-	"rating":                114,
-	"timer":                 115,
-	"static":                116,
-	"math fraction":         117,
-	"math root":             118,
-	"subscript":             119,
-	"superscript":           120,
-	"description list":      121,
-	"description term":      122,
-	"description value":     123,
-	"footnote":              124,
-	"content deletion":      125,
-	"content insertion":     126,
-	"mark":                  127,
-	"suggestion":            128,
-	"push button menu":      129,
-	"switch":                130,
+// atspiRoleFrame is the AT-SPI role of a top-level application window, used
+// both as a vocabulary entry and to recognize window elements during frame
+// selection.
+const atspiRoleFrame = "frame"
 
-	// Compatibility aliases. Accessible.GetRoleName returns the GEnum nick of
-	// the role with hyphens replaced by spaces, so id 43 reports "button" on
-	// current at-spi2-core (ATSPI_ROLE_BUTTON) and "push button" on releases
-	// predating that rename. Both are accepted so one config works either way.
-	// "menu button" is accepted because users reach for it before the less
-	// obvious "push button menu".
-	"button":      43,
-	"menu button": 129,
+// Role names that appear both in the ordered list below and in the alias map.
+const (
+	atspiRolePushButton     = "push button"
+	atspiRolePushButtonMenu = "push button menu"
+)
+
+// atspiRoleNames lists AT-SPI role names in AtspiRole declaration order, so a
+// name's index in this slice is its AtspiRole id. Ids are needed to build the
+// Collection.GetMatches role bitfield, and deriving them from position rather
+// than writing them out makes a gap or a duplicate impossible.
+//
+// A name is the GEnum nick of the role with hyphens replaced by spaces, which
+// is exactly what Accessible.GetRoleName returns. The enum is ABI-stable
+// (append-only), so existing entries never move; the list is complete through
+// ATSPI_ROLE_SWITCH, and roles added later fall back to the per-node walk
+// instead of the Collection query.
+//
+// Inserting or removing a line shifts every id after it, so
+// TestAtspiRoleNameToIDAnchors pins ids spread across the enum.
+var atspiRoleNames = []string{
+	"invalid",
+	"accelerator label",
+	"alert",
+	"animation",
+	"arrow",
+	"calendar",
+	"canvas",
+	"check box",
+	"check menu item",
+	"color chooser",
+	"column header",
+	"combo box",
+	"date editor",
+	"desktop icon",
+	"desktop frame",
+	"dial",
+	"dialog",
+	"directory pane",
+	"drawing area",
+	"file chooser",
+	"filler",
+	"focus traversable",
+	"font chooser",
+	atspiRoleFrame,
+	"glass pane",
+	"html container",
+	"icon",
+	"image",
+	"internal frame",
+	"label",
+	"layered pane",
+	"list",
+	"list item",
+	"menu",
+	"menu bar",
+	"menu item",
+	"option pane",
+	"page tab",
+	"page tab list",
+	"panel",
+	"password text",
+	"popup menu",
+	"progress bar",
+	atspiRolePushButton,
+	"radio button",
+	"radio menu item",
+	"root pane",
+	"row header",
+	"scroll bar",
+	"scroll pane",
+	"separator",
+	"slider",
+	"spin button",
+	"split pane",
+	"status bar",
+	"table",
+	"table cell",
+	"table column header",
+	"table row header",
+	"tearoff menu item",
+	"terminal",
+	"text",
+	"toggle button",
+	"tool bar",
+	"tool tip",
+	"tree",
+	"tree table",
+	"unknown",
+	"viewport",
+	"window",
+	"extended",
+	"header",
+	"footer",
+	"paragraph",
+	"ruler",
+	"application",
+	"autocomplete",
+	"editbar",
+	"embedded",
+	"entry",
+	"chart",
+	"caption",
+	"document frame",
+	"heading",
+	"page",
+	"section",
+	"redundant object",
+	"form",
+	"link",
+	"input method window",
+	"table row",
+	"tree item",
+	"document spreadsheet",
+	"document presentation",
+	"document text",
+	"document web",
+	"document email",
+	"comment",
+	"list box",
+	"grouping",
+	"image map",
+	"notification",
+	"info bar",
+	"level bar",
+	"title bar",
+	"block quote",
+	"audio",
+	"video",
+	"definition",
+	"article",
+	"landmark",
+	"log",
+	"marquee",
+	"math",
+	"rating",
+	"timer",
+	"static",
+	"math fraction",
+	"math root",
+	"subscript",
+	"superscript",
+	"description list",
+	"description term",
+	"description value",
+	"footnote",
+	"content deletion",
+	"content insertion",
+	"mark",
+	"suggestion",
+	atspiRolePushButtonMenu,
+	"switch",
 }
+
+// atspiRoleNameAliases map an accepted spelling onto the canonical role name it
+// shares an id with.
+//
+// Id 43 is ATSPI_ROLE_BUTTON on current at-spi2-core and was
+// ATSPI_ROLE_PUSH_BUTTON before it was renamed, and the name reported for it
+// has historically been "push button". Rather than depend on which spelling a
+// given release reports, both are accepted so one config works on either.
+// "menu button" is accepted because users reach for it before the less obvious
+// "push button menu".
+var atspiRoleNameAliases = map[string]string{
+	"button":      atspiRolePushButton,
+	"menu button": atspiRolePushButtonMenu,
+}
+
+// atspiRoleNameToID indexes atspiRoleNames by name, with the aliases folded in.
+var atspiRoleNameToID = func() map[string]int32 {
+	ids := make(map[string]int32, len(atspiRoleNames)+len(atspiRoleNameAliases))
+
+	for index, name := range atspiRoleNames {
+		ids[name] = int32(index)
+	}
+
+	for alias, canonical := range atspiRoleNameAliases {
+		if id, ok := ids[canonical]; ok {
+			ids[alias] = id
+		}
+	}
+
+	return ids
+}()
 
 // accRef is the AT-SPI (bus-name, object-path) reference returned by
 // GetChildren and the registry root.
@@ -1175,7 +1213,7 @@ func (c *ATSPIClient) children(ctx context.Context, conn *dbus.Conn, ref accRef)
 // isWindowRole reports whether an AT-SPI role name denotes a top-level window
 // (the only frames hint selection considers).
 func isWindowRole(role string) bool {
-	return role == "frame" || role == "window" || role == "dialog"
+	return role == atspiRoleFrame || role == "window" || role == "dialog"
 }
 
 // roleName returns the AT-SPI localized-independent role name (e.g. "push button").
@@ -2025,7 +2063,7 @@ type atspiWindow struct {
 }
 
 func (w *atspiWindow) Release()     {}
-func (w *atspiWindow) Role() string { return "frame" }
+func (w *atspiWindow) Role() string { return atspiRoleFrame }
 
 // atspiNode implements AXNode for a clickable AT-SPI element.
 type atspiNode struct {

--- a/internal/core/infra/accessibility/atspi_linux_test.go
+++ b/internal/core/infra/accessibility/atspi_linux_test.go
@@ -6,6 +6,8 @@ package accessibility
 import (
 	"slices"
 	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
 )
 
 const (
@@ -267,9 +269,9 @@ func TestDeriveTargetRoleIDs(t *testing.T) {
 		}
 	}
 
-	t.Run("AXButton maps to its several atspi roles (deduped)", func(t *testing.T) {
+	t.Run("the button semantic role expands to its atspi ids (deduped)", func(t *testing.T) {
 		// push button(43), button(43 -> deduped), toggle button(62).
-		ids := deriveTargetRoleIDs(map[string]struct{}{axRoleButton: {}})
+		ids := deriveTargetRoleIDs(rolesSet(resolveLinuxRoles(t, "button")))
 		for _, want := range []int32{43, 62} {
 			if !slices.Contains(ids, want) {
 				t.Errorf("missing role id %d in %v", want, ids)
@@ -279,14 +281,13 @@ func TestDeriveTargetRoleIDs(t *testing.T) {
 		noDuplicates(t, ids)
 
 		if len(ids) != 2 {
-			t.Errorf("AXButton -> %v, want exactly ids {43, 62}", ids)
+			t.Errorf("button -> %v, want exactly ids {43, 62}", ids)
 		}
 	})
 
-	t.Run("AXMenuItem gathers all three menu-item roles", func(t *testing.T) {
-		// check menu item(8), radio menu item(45), menu item(35).
-		ids := deriveTargetRoleIDs(map[string]struct{}{axRoleMenuItem: {}})
-		for _, want := range []int32{8, 45, 35} {
+	t.Run("checkbox gathers check box and check menu item", func(t *testing.T) {
+		ids := deriveTargetRoleIDs(rolesSet(resolveLinuxRoles(t, "checkbox")))
+		for _, want := range []int32{7, 8} {
 			if !slices.Contains(ids, want) {
 				t.Errorf("missing role id %d in %v", want, ids)
 			}
@@ -295,8 +296,8 @@ func TestDeriveTargetRoleIDs(t *testing.T) {
 		noDuplicates(t, ids)
 	})
 
-	t.Run("AXTextField gathers entry and password text", func(t *testing.T) {
-		ids := deriveTargetRoleIDs(map[string]struct{}{axRoleTextField: {}})
+	t.Run("text_field gathers entry and password text", func(t *testing.T) {
+		ids := deriveTargetRoleIDs(rolesSet(resolveLinuxRoles(t, "text_field")))
 		for _, want := range []int32{79, 40} {
 			if !slices.Contains(ids, want) {
 				t.Errorf("missing role id %d in %v", want, ids)
@@ -304,8 +305,8 @@ func TestDeriveTargetRoleIDs(t *testing.T) {
 		}
 	})
 
-	t.Run("multiple AX roles union their ids", func(t *testing.T) {
-		ids := deriveTargetRoleIDs(map[string]struct{}{axRoleRow: {}, axRoleButton: {}})
+	t.Run("multiple semantic roles union their ids", func(t *testing.T) {
+		ids := deriveTargetRoleIDs(rolesSet(resolveLinuxRoles(t, "list_item", "row", "button")))
 		for _, want := range []int32{32, 90, 43, 62} { // list item, table row, push/toggle button
 			if !slices.Contains(ids, want) {
 				t.Errorf("missing role id %d in %v", want, ids)
@@ -315,32 +316,130 @@ func TestDeriveTargetRoleIDs(t *testing.T) {
 		noDuplicates(t, ids)
 	})
 
-	t.Run("raw AT-SPI names never match (parity with the walk)", func(t *testing.T) {
-		// deriveTargetRoleIDs keys on the AX values of atspiToAXRole, exactly like
-		// the walk, so a set of raw AT-SPI role names resolves to nothing.
-		ids := deriveTargetRoleIDs(map[string]struct{}{"spin button": {}, "toolbar": {}})
-		if len(ids) != 0 {
-			t.Errorf("atspi-name set -> %v, want none", ids)
+	t.Run("raw AT-SPI names resolve on the fast path", func(t *testing.T) {
+		// A native role addressed through the atspi: prefix must reach the
+		// Collection query rather than silently downgrading to the walk.
+		ids := deriveTargetRoleIDs(rolesSet(resolveLinuxRoles(t, "atspi:spin button")))
+		if !slices.Contains(ids, 52) {
+			t.Errorf("spin button -> %v, want id 52", ids)
 		}
 	})
 
 	t.Run("role with no atspi equivalent yields none", func(t *testing.T) {
-		ids := deriveTargetRoleIDs(map[string]struct{}{"AXUnknownWidget": {}})
+		ids := deriveTargetRoleIDs(map[string]struct{}{"not a real role": {}})
 		if len(ids) != 0 {
 			t.Errorf("unknown role -> %v, want none", ids)
 		}
 	})
 }
 
-func TestAtspiRoleNameToIDCoversAtspiToAXRole(t *testing.T) {
-	// Every AT-SPI role name that maps to an AX role (and is therefore hintable
-	// via the walk) must also have an AtspiRole id. If the two maps drift, the
-	// Collection fast path would silently miss that role type while the walk
-	// still finds it — a subtle correctness gap.
-	for atspiName := range atspiToAXRole {
-		if _, ok := atspiRoleNameToID[atspiName]; !ok {
-			t.Errorf("atspiToAXRole has %q but atspiRoleNameToID lacks it; "+
-				"Collection.GetMatches would not match that role", atspiName)
+// resolveLinuxRoles turns semantic or prefixed config entries into the native
+// AT-SPI role names the client works with, the same way config load does.
+func resolveLinuxRoles(t *testing.T, entries ...string) []string {
+	t.Helper()
+
+	resolution := element.ResolveRoles(entries, "linux")
+	if resolution.HasFatal() {
+		t.Fatalf("resolving %v: %v", entries, resolution.FatalMessages())
+	}
+
+	return resolution.Native
+}
+
+// TestAtspiRoleNameToIDCoversTheVocabulary pins the Collection fast path
+// against the semantic vocabulary. Every AT-SPI role name the vocabulary can
+// expand to must have an AtspiRole id, otherwise that role would be found by
+// the walk but silently missed by Collection.GetMatches.
+func TestAtspiRoleNameToIDCoversTheVocabulary(t *testing.T) {
+	for _, mapping := range element.RoleVocabulary {
+		for _, native := range mapping.ATSPI {
+			if _, ok := atspiRoleNameToID[native]; !ok {
+				t.Errorf(
+					"semantic role %q expands to AT-SPI role %q but atspiRoleNameToID "+
+						"lacks it; Collection.GetMatches would not match that role",
+					mapping.Semantic, native,
+				)
+			}
+		}
+	}
+}
+
+// atspiRoleNameAliases are names accepted for a role that
+// Accessible.GetRoleName reports under a different string. They deliberately
+// duplicate an id, so the contiguity check excludes them.
+var atspiRoleNameAliases = map[string]struct{}{
+	"button":      {}, // id 43 also reports as "push button" on older at-spi2
+	"menu button": {}, // id 129 reports as "push button menu"
+}
+
+// TestAtspiRoleNameToIDIsContiguous checks the table against the shape of the
+// AtspiRole enum: ids 0 through ATSPI_ROLE_SWITCH (130) each appear exactly
+// once. A mistyped id would leave a gap and shift a role onto the wrong name,
+// which would silently select the wrong elements on the Collection fast path.
+// ATSPI_ROLE_LAST_DEFINED (131) is a sentinel and must not be present.
+func TestAtspiRoleNameToIDIsContiguous(t *testing.T) {
+	const lastRole = 130
+
+	byID := make(map[int32]string, len(atspiRoleNameToID))
+
+	for name, roleID := range atspiRoleNameToID {
+		if _, alias := atspiRoleNameAliases[name]; alias {
+			continue
+		}
+
+		if existing, duplicate := byID[roleID]; duplicate {
+			t.Errorf("id %d is used by both %q and %q", roleID, existing, name)
+		}
+
+		byID[roleID] = name
+
+		if roleID > lastRole {
+			t.Errorf("role %q has id %d, beyond ATSPI_ROLE_SWITCH (%d)", name, roleID, lastRole)
+		}
+	}
+
+	for roleID := int32(0); roleID <= lastRole; roleID++ {
+		if _, ok := byID[roleID]; !ok {
+			t.Errorf("no role name mapped to AtspiRole id %d", roleID)
+		}
+	}
+}
+
+// TestAtspiRoleNameToIDAnchors verifies the reconstructed AtspiRole enum
+// against ids that were independently known before the table was completed. A
+// mistake in the enum ordering would shift every id after the error, so these
+// anchors, spread across the enum, catch a bad transcription.
+func TestAtspiRoleNameToIDAnchors(t *testing.T) {
+	anchors := map[string]int32{
+		"check box":        7,
+		"check menu item":  8,
+		"combo box":        11,
+		"list item":        32,
+		"menu item":        35,
+		"page tab":         37,
+		"password text":    40,
+		"push button":      43,
+		"radio button":     44,
+		"radio menu item":  45,
+		"slider":           51,
+		"table cell":       56,
+		"toggle button":    62,
+		"entry":            79,
+		"link":             88,
+		"table row":        90,
+		"push button menu": 129,
+	}
+
+	for name, want := range anchors {
+		got, ok := atspiRoleNameToID[name]
+		if !ok {
+			t.Errorf("atspiRoleNameToID lacks anchor role %q", name)
+
+			continue
+		}
+
+		if got != want {
+			t.Errorf("atspiRoleNameToID[%q] = %d, want %d", name, got, want)
 		}
 	}
 }

--- a/internal/core/infra/accessibility/atspi_linux_test.go
+++ b/internal/core/infra/accessibility/atspi_linux_test.go
@@ -364,43 +364,45 @@ func TestAtspiRoleNameToIDCoversTheVocabulary(t *testing.T) {
 	}
 }
 
-// atspiRoleNameAliases are names accepted for a role that
-// Accessible.GetRoleName reports under a different string. They deliberately
-// duplicate an id, so the contiguity check excludes them.
-var atspiRoleNameAliases = map[string]struct{}{
-	"button":      {}, // id 43 also reports as "push button" on older at-spi2
-	"menu button": {}, // id 129 reports as "push button menu"
-}
+// TestAtspiRoleNames_CoverTheEnum checks the role list against the shape of the
+// AtspiRole enum. Ids are the slice indices, so gaps and duplicates cannot
+// occur by construction; what can still go wrong is a name being added or
+// dropped, which shifts every id after it. Pinning the length and the last
+// entry catches that, and TestAtspiRoleNameToIDAnchors catches a reordering.
+// ATSPI_ROLE_LAST_DEFINED (131) is a sentinel and must not be listed.
+func TestAtspiRoleNames_CoverTheEnum(t *testing.T) {
+	const lastRoleID = 130 // ATSPI_ROLE_SWITCH
 
-// TestAtspiRoleNameToIDIsContiguous checks the table against the shape of the
-// AtspiRole enum: ids 0 through ATSPI_ROLE_SWITCH (130) each appear exactly
-// once. A mistyped id would leave a gap and shift a role onto the wrong name,
-// which would silently select the wrong elements on the Collection fast path.
-// ATSPI_ROLE_LAST_DEFINED (131) is a sentinel and must not be present.
-func TestAtspiRoleNameToIDIsContiguous(t *testing.T) {
-	const lastRole = 130
-
-	byID := make(map[int32]string, len(atspiRoleNameToID))
-
-	for name, roleID := range atspiRoleNameToID {
-		if _, alias := atspiRoleNameAliases[name]; alias {
-			continue
-		}
-
-		if existing, duplicate := byID[roleID]; duplicate {
-			t.Errorf("id %d is used by both %q and %q", roleID, existing, name)
-		}
-
-		byID[roleID] = name
-
-		if roleID > lastRole {
-			t.Errorf("role %q has id %d, beyond ATSPI_ROLE_SWITCH (%d)", name, roleID, lastRole)
-		}
+	if len(atspiRoleNames) != lastRoleID+1 {
+		t.Errorf(
+			"atspiRoleNames has %d entries, want %d (ids 0..%d)",
+			len(atspiRoleNames), lastRoleID+1, lastRoleID,
+		)
 	}
 
-	for roleID := int32(0); roleID <= lastRole; roleID++ {
-		if _, ok := byID[roleID]; !ok {
-			t.Errorf("no role name mapped to AtspiRole id %d", roleID)
+	if last := atspiRoleNames[len(atspiRoleNames)-1]; last != "switch" {
+		t.Errorf("last role name = %q, want \"switch\" (ATSPI_ROLE_SWITCH)", last)
+	}
+
+	seen := make(map[string]int, len(atspiRoleNames))
+
+	for index, name := range atspiRoleNames {
+		if previous, duplicate := seen[name]; duplicate {
+			t.Errorf("role name %q appears at both %d and %d", name, previous, index)
+		}
+
+		seen[name] = index
+	}
+
+	// Every alias must point at a name that exists, or it silently resolves to
+	// nothing and the spelling it exists to accept stops working.
+	for alias, canonical := range atspiRoleNameAliases {
+		if _, ok := seen[canonical]; !ok {
+			t.Errorf("alias %q points at unknown role name %q", alias, canonical)
+		}
+
+		if _, ok := atspiRoleNameToID[alias]; !ok {
+			t.Errorf("alias %q is missing from atspiRoleNameToID", alias)
 		}
 	}
 }
@@ -411,23 +413,23 @@ func TestAtspiRoleNameToIDIsContiguous(t *testing.T) {
 // anchors, spread across the enum, catch a bad transcription.
 func TestAtspiRoleNameToIDAnchors(t *testing.T) {
 	anchors := map[string]int32{
-		"check box":        7,
-		"check menu item":  8,
-		"combo box":        11,
-		"list item":        32,
-		"menu item":        35,
-		"page tab":         37,
-		"password text":    40,
-		"push button":      43,
-		"radio button":     44,
-		"radio menu item":  45,
-		"slider":           51,
-		"table cell":       56,
-		"toggle button":    62,
-		"entry":            79,
-		"link":             88,
-		"table row":        90,
-		"push button menu": 129,
+		"check box":             7,
+		"check menu item":       8,
+		"combo box":             11,
+		"list item":             32,
+		"menu item":             35,
+		"page tab":              37,
+		"password text":         40,
+		atspiRolePushButton:     43,
+		"radio button":          44,
+		"radio menu item":       45,
+		"slider":                51,
+		"table cell":            56,
+		"toggle button":         62,
+		"entry":                 79,
+		"link":                  88,
+		"table row":             90,
+		atspiRolePushButtonMenu: 129,
 	}
 
 	for name, want := range anchors {

--- a/internal/core/infra/accessibility/infra_client.go
+++ b/internal/core/infra/accessibility/infra_client.go
@@ -392,6 +392,11 @@ func (c *InfraAXClient) buildClickableOpts(
 		}
 	}
 
+	// Backends that enumerate rather than walk a cached tree use the role set
+	// to prune before reading per-element properties; on the others this is a
+	// no-op and filtering happens in FindClickableElements.
+	opts.SetRoles(allowedRoles)
+
 	ignoreClickableCheck := false
 	if cfg := currentConfig(c.configProvider); cfg != nil {
 		ignoreClickableCheck = cfg.ShouldIgnoreClickableCheckForApp(element.BundleIdentifier())

--- a/internal/core/infra/accessibility/tree.go
+++ b/internal/core/infra/accessibility/tree.go
@@ -201,6 +201,10 @@ func (o *TreeOptions) SetFilterFunc(fn func(*ElementInfo) bool) {
 	o.filterFunc = fn
 }
 
+// SetRoles is a no-op on macOS: the AX tree is walked with its own filters and
+// role selection happens in FindClickableElements.
+func (o *TreeOptions) SetRoles(_ map[string]struct{}) {}
+
 // SetMaxDepth sets the max depth for tree traversal.
 func (o *TreeOptions) SetMaxDepth(depth int) {
 	o.maxDepth = depth

--- a/internal/core/infra/accessibility/tree_linux.go
+++ b/internal/core/infra/accessibility/tree_linux.go
@@ -62,6 +62,9 @@ func (o *TreeOptions) SetConfigProvider(cp config.Provider) {}
 // SetFilterFunc is a Linux stub.
 func (o *TreeOptions) SetFilterFunc(fn func(*ElementInfo) bool) {}
 
+// SetRoles is a Linux stub: the AT-SPI client receives the role set directly.
+func (o *TreeOptions) SetRoles(roles map[string]struct{}) {}
+
 // BuildTree builds the accessibility tree for the specified root element (Linux stub).
 func BuildTree(_ context.Context, _ *Element, _ TreeOptions) (*TreeNode, error) {
 	return &TreeNode{}, nil

--- a/internal/core/infra/accessibility/tree_windows.go
+++ b/internal/core/infra/accessibility/tree_windows.go
@@ -9,7 +9,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
-	"github.com/y3owk1n/neru/internal/core/domain/element"
 )
 
 // TreeNode represents a node in the accessibility element hierarchy. On Windows
@@ -73,7 +72,7 @@ func (n *TreeNode) FindClickableElements(
 		}
 
 		if node.info != nil && node.info.clickable {
-			if windowsRoleMatchesFilter(node.info.role, keptRoles) {
+			if _, ok := keptRoles[node.info.role]; ok || len(keptRoles) == 0 {
 				out = append(out, node)
 			}
 		}
@@ -97,6 +96,10 @@ func (n *TreeNode) Release(_ map[*Element]struct{}) {}
 type TreeOptions struct {
 	MaxDepth int
 	Bounds   image.Rectangle
+	// Roles is the set of UIA control-type names to enumerate. An empty set
+	// falls back to the shipped defaults. It is applied during enumeration so
+	// unwanted controls are rejected before their properties are read.
+	Roles map[string]struct{}
 }
 
 // DefaultTreeOptions returns the default tree options.
@@ -117,10 +120,13 @@ func (o *TreeOptions) SetConfigProvider(_ config.Provider) {}
 // SetFilterFunc is a no-op on Windows.
 func (o *TreeOptions) SetFilterFunc(_ func(*ElementInfo) bool) {}
 
+// SetRoles records the UIA control-type names to enumerate.
+func (o *TreeOptions) SetRoles(roles map[string]struct{}) { o.Roles = roles }
+
 // BuildTree enumerates the clickable controls under the given window element
 // via UI Automation and returns a root node with one child per control. For
 // non-window elements (no HWND) it returns an empty root.
-func BuildTree(_ context.Context, root *Element, _ TreeOptions) (*TreeNode, error) {
+func BuildTree(_ context.Context, root *Element, opts TreeOptions) (*TreeNode, error) {
 	if root == nil {
 		return &TreeNode{}, nil
 	}
@@ -136,7 +142,7 @@ func BuildTree(_ context.Context, root *Element, _ TreeOptions) (*TreeNode, erro
 		return rootNode, nil
 	}
 
-	controls := enumerateClickableElements(root.hwnd)
+	controls := enumerateClickableElements(root.hwnd, opts.Roles)
 
 	children := make([]*TreeNode, 0, len(controls))
 
@@ -172,43 +178,3 @@ func ProcessClickableNodes(root *TreeNode, _ config.HintsConfig) []*TreeNode {
 
 // ReleaseTree is a no-op: Windows nodes hold no live COM references.
 func ReleaseTree(_ *TreeNode) {}
-
-// windowsUIAToAXRole maps legacy UIA control-type names that may still appear
-// in user configs to the AX-style roles assigned during enumeration.
-var windowsUIAToAXRole = map[string]string{
-	"Button":      string(element.RoleButton),
-	"CheckBox":    string(element.RoleCheckBox),
-	"RadioButton": string(element.RoleRadioButton),
-	"Hyperlink":   string(element.RoleLink),
-	"ComboBox":    string(element.RoleComboBox),
-	"Edit":        string(element.RoleTextField),
-	"Slider":      string(element.RoleSlider),
-	"TabItem":     string(element.RoleTabButton),
-	"MenuItem":    string(element.RoleMenuItem),
-	"DataItem":    string(element.RoleCell),
-	"ListItem":    string(element.RoleCell),
-	"TreeItem":    string(element.RoleRow),
-	"Spinner":     string(element.RoleIncrementor),
-	"SplitButton": string(element.RoleButton),
-}
-
-// windowsRoleMatchesFilter reports whether elementRole satisfies keptRoles.
-// An empty keptRoles set accepts every clickable element. Configured roles
-// may use either AX-style names or legacy UIA control-type names.
-func windowsRoleMatchesFilter(elementRole string, keptRoles map[string]struct{}) bool {
-	if len(keptRoles) == 0 {
-		return true
-	}
-
-	if _, ok := keptRoles[elementRole]; ok {
-		return true
-	}
-
-	for configRole := range keptRoles {
-		if axRole, ok := windowsUIAToAXRole[configRole]; ok && axRole == elementRole {
-			return true
-		}
-	}
-
-	return false
-}

--- a/internal/core/infra/accessibility/tree_windows_test.go
+++ b/internal/core/infra/accessibility/tree_windows_test.go
@@ -1,62 +1,54 @@
 //go:build windows
 
-package accessibility //nolint:testpackage // exercises unexported windowsRoleMatchesFilter
+package accessibility //nolint:testpackage // exercises unexported defaultClickableRoles
 
 import (
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/core/domain/element"
 )
 
-func TestWindowsRoleMatchesFilter(t *testing.T) {
+// TestDefaultClickableRoles_ResolvesToUIANames checks the enumeration fallback
+// used when a caller supplies no role filter. It must resolve to real UIA
+// control-type names, otherwise hints are blank whenever the role set is empty.
+func TestDefaultClickableRoles_ResolvesToUIANames(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name        string
-		elementRole string
-		keptRoles   map[string]struct{}
-		want        bool
-	}{
-		{
-			name:        "empty filter accepts all",
-			elementRole: string(element.RoleButton),
-			keptRoles:   nil,
-			want:        true,
-		},
-		{
-			name:        "direct AX match",
-			elementRole: string(element.RoleButton),
-			keptRoles:   map[string]struct{}{string(element.RoleButton): {}},
-			want:        true,
-		},
-		{
-			name:        "legacy UIA name matches AX role",
-			elementRole: string(element.RoleTextField),
-			keptRoles:   map[string]struct{}{"Edit": {}},
-			want:        true,
-		},
-		{
-			name:        "unrelated roles do not match",
-			elementRole: string(element.RoleButton),
-			keptRoles:   map[string]struct{}{string(element.RoleLink): {}},
-			want:        false,
-		},
+	if len(defaultClickableRoles) == 0 {
+		t.Fatal("defaultClickableRoles is empty; enumeration would find nothing")
 	}
 
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
+	names := slices.Collect(maps.Values(controlTypeNames))
 
-			got := windowsRoleMatchesFilter(testCase.elementRole, testCase.keptRoles)
-			if got != testCase.want {
-				t.Fatalf(
-					"windowsRoleMatchesFilter(%q, %v) = %v, want %v",
-					testCase.elementRole,
-					testCase.keptRoles,
-					got,
-					testCase.want,
-				)
-			}
-		})
+	for role := range defaultClickableRoles {
+		if !slices.Contains(names, role) {
+			t.Errorf("defaultClickableRoles contains %q, which is not a UIA control type", role)
+		}
+	}
+
+	for _, want := range []string{"Button", "Edit", "Hyperlink"} {
+		if _, ok := defaultClickableRoles[want]; !ok {
+			t.Errorf("defaultClickableRoles missing %q", want)
+		}
+	}
+}
+
+// TestResolveRoles_WindowsNativeEntriesPassThrough covers the escape hatch that
+// makes neru usable in legacy Win32 and WinForms applications, whose controls
+// surface as Pane, Custom or Document and have no semantic role.
+func TestResolveRoles_WindowsNativeEntriesPassThrough(t *testing.T) {
+	t.Parallel()
+
+	resolution := element.ResolveRoles([]string{"button", "uia:Custom", "uia:Pane"}, "windows")
+	if resolution.HasFatal() {
+		t.Fatalf("unexpected fatal diagnostics: %v", resolution.FatalMessages())
+	}
+
+	for _, want := range []string{"Button", "SplitButton", "Custom", "Pane"} {
+		if !slices.Contains(resolution.Native, want) {
+			t.Errorf("resolution %v missing %q", resolution.Native, want)
+		}
 	}
 }

--- a/internal/core/infra/accessibility/tree_windows_test.go
+++ b/internal/core/infra/accessibility/tree_windows_test.go
@@ -28,7 +28,7 @@ func TestDefaultClickableRoles_ResolvesToUIANames(t *testing.T) {
 		}
 	}
 
-	for _, want := range []string{"Button", "Edit", "Hyperlink"} {
+	for _, want := range []string{uiaControlButton, uiaControlEdit, uiaControlHyperlink} {
 		if _, ok := defaultClickableRoles[want]; !ok {
 			t.Errorf("defaultClickableRoles missing %q", want)
 		}
@@ -46,7 +46,7 @@ func TestResolveRoles_WindowsNativeEntriesPassThrough(t *testing.T) {
 		t.Fatalf("unexpected fatal diagnostics: %v", resolution.FatalMessages())
 	}
 
-	for _, want := range []string{"Button", "SplitButton", "Custom", "Pane"} {
+	for _, want := range []string{uiaControlButton, uiaControlSplitButton, uiaControlCustom, uiaControlPane} {
 		if !slices.Contains(resolution.Native, want) {
 			t.Errorf("resolution %v missing %q", resolution.Native, want)
 		}

--- a/internal/core/infra/accessibility/uia_windows.go
+++ b/internal/core/infra/accessibility/uia_windows.go
@@ -10,6 +10,7 @@ package accessibility
 import (
 	"image"
 	"runtime"
+	"strconv"
 	"syscall"
 	"unsafe"
 
@@ -97,24 +98,56 @@ const (
 	vtArrayGetElement = 4
 )
 
-// UI Automation CONTROLTYPEID values for the controls neru treats as
-// clickable hint targets.
-const (
-	ctButton      = 50000
-	ctCheckBox    = 50002
-	ctComboBox    = 50003
-	ctEdit        = 50004
-	ctHyperlink   = 50005
-	ctListItem    = 50007
-	ctMenuItem    = 50011
-	ctRadioButton = 50013
-	ctSlider      = 50015
-	ctSpinner     = 50016
-	ctTabItem     = 50019
-	ctTreeItem    = 50024
-	ctDataItem    = 50029
-	ctSplitButton = 50031
-)
+// controlTypeNames maps UI Automation CONTROLTYPEID values to the programmatic
+// names behind the UIA_*ControlTypeId constants. These names — not the
+// localized LocalizedControlType, which changes with the system language — are
+// the vocabulary users address with the "uia:" prefix.
+//
+// The range is contiguous and stable: 50000 is Button and 50040 is AppBar, the
+// last control type added (Windows 8).
+var controlTypeNames = map[int32]string{
+	50000: "Button",
+	50001: "Calendar",
+	50002: "CheckBox",
+	50003: "ComboBox",
+	50004: "Edit",
+	50005: "Hyperlink",
+	50006: "Image",
+	50007: "ListItem",
+	50008: "List",
+	50009: "Menu",
+	50010: "MenuBar",
+	50011: "MenuItem",
+	50012: "ProgressBar",
+	50013: "RadioButton",
+	50014: "ScrollBar",
+	50015: "Slider",
+	50016: "Spinner",
+	50017: "StatusBar",
+	50018: "Tab",
+	50019: "TabItem",
+	50020: "Text",
+	50021: "ToolBar",
+	50022: "ToolTip",
+	50023: "Tree",
+	50024: "TreeItem",
+	50025: "Custom",
+	50026: "Group",
+	50027: "Thumb",
+	50028: "DataGrid",
+	50029: "DataItem",
+	50030: "Document",
+	50031: "SplitButton",
+	50032: "Window",
+	50033: "Pane",
+	50034: "Header",
+	50035: "HeaderItem",
+	50036: "Table",
+	50037: "TitleBar",
+	50038: "Separator",
+	50039: "SemanticZoom",
+	50040: "AppBar",
+}
 
 // winRect mirrors the Win32 RECT returned by get_CurrentBoundingRectangle.
 type winRect struct {
@@ -155,7 +188,11 @@ func failed(hresult uintptr) bool {
 // enumerateClickableElements returns the on-screen, clickable controls of the
 // given top-level window handle. It returns nil on any failure; callers treat
 // an empty result as "no hints", never as a crash.
-func enumerateClickableElements(hwnd uintptr) []winElement {
+func enumerateClickableElements(hwnd uintptr, keptRoles map[string]struct{}) []winElement {
+	if len(keptRoles) == 0 {
+		keptRoles = defaultClickableRoles
+	}
+
 	if hwnd == 0 {
 		return nil
 	}
@@ -214,7 +251,7 @@ func enumerateClickableElements(hwnd uintptr) []winElement {
 	}
 	defer comCall(array, vtRelease)
 
-	return collectArray(array)
+	return collectArray(array, keptRoles)
 }
 
 // createAutomation creates the default IUIAutomation instance.
@@ -237,7 +274,7 @@ func createAutomation() unsafe.Pointer {
 
 // collectArray walks an IUIAutomationElementArray and extracts the clickable
 // controls. Each element is released as soon as its data is copied out.
-func collectArray(array unsafe.Pointer) []winElement {
+func collectArray(array unsafe.Pointer, keptRoles map[string]struct{}) []winElement {
 	var length int32
 
 	hresult := comCall(array, vtArrayGetLength, uintptr(unsafe.Pointer(&length)))
@@ -255,7 +292,7 @@ func collectArray(array unsafe.Pointer) []winElement {
 			continue
 		}
 
-		extracted, ok := extractWinElement(element)
+		extracted, ok := extractWinElement(element, keptRoles)
 
 		comCall(element, vtRelease)
 
@@ -268,15 +305,27 @@ func collectArray(array unsafe.Pointer) []winElement {
 }
 
 // extractWinElement copies the relevant properties from a single UIA element.
-// It returns ok=false for non-clickable, offscreen, or zero-size controls.
-func extractWinElement(element unsafe.Pointer) (winElement, bool) {
+// It returns ok=false for offscreen or zero-size controls, and for controls
+// whose role is not in keptRoles.
+//
+// Role selection happens here rather than downstream because UIA is queried
+// with a true condition: the whole subtree comes back, and rejecting an
+// element before its bounds and name are read saves three cross-process COM
+// calls per unwanted element.
+func extractWinElement(element unsafe.Pointer, keptRoles map[string]struct{}) (winElement, bool) {
 	var controlType int32
 	if failed(comCall(element, vtGetCurrentControlType, uintptr(unsafe.Pointer(&controlType)))) {
 		return winElement{}, false
 	}
 
-	role, clickable := mapControlType(controlType)
-	if !clickable {
+	role, known := controlTypeName(controlType)
+	if !known {
+		// Unknown provider-specific control type: keep it addressable by id
+		// rather than dropping it outright.
+		role = strconv.FormatInt(int64(controlType), 10)
+	}
+
+	if _, ok := keptRoles[role]; !ok {
 		return winElement{}, false
 	}
 
@@ -318,39 +367,29 @@ func currentName(element unsafe.Pointer) string {
 	return name
 }
 
-// mapControlType maps UI Automation CONTROLTYPEID values onto the shared
-// AX-style role names for the controls neru treats as clickable hint targets.
-func mapControlType(controlType int32) (string, bool) {
-	switch controlType {
-	case ctButton:
-		return string(element.RoleButton), true
-	case ctCheckBox:
-		return string(element.RoleCheckBox), true
-	case ctComboBox:
-		return string(element.RoleComboBox), true
-	case ctEdit:
-		return string(element.RoleTextField), true
-	case ctHyperlink:
-		return string(element.RoleLink), true
-	case ctListItem:
-		return string(element.RoleCell), true
-	case ctMenuItem:
-		return string(element.RoleMenuItem), true
-	case ctRadioButton:
-		return string(element.RoleRadioButton), true
-	case ctSlider:
-		return string(element.RoleSlider), true
-	case ctSpinner:
-		return string(element.RoleIncrementor), true
-	case ctTabItem:
-		return string(element.RoleTabButton), true
-	case ctTreeItem:
-		return string(element.RoleRow), true
-	case ctDataItem:
-		return string(element.RoleCell), true
-	case ctSplitButton:
-		return string(element.RoleButton), true
-	default:
+// controlTypeName returns the programmatic name for a UIA CONTROLTYPEID. The
+// second result is false for ids outside the known range, which a third-party
+// provider may still report; those elements carry the numeric id so they remain
+// addressable rather than silently disappearing.
+func controlTypeName(controlType int32) (string, bool) {
+	name, ok := controlTypeNames[controlType]
+	if !ok {
 		return roleUnknown, false
 	}
+
+	return name, true
 }
+
+// defaultClickableRoles is used when the caller supplies no role filter. It is
+// the shipped default role list resolved into UIA control-type names, so the
+// fallback and a default configuration select exactly the same elements.
+var defaultClickableRoles = func() map[string]struct{} {
+	resolution := element.ResolveRoles(element.DefaultClickableRoles, "windows")
+
+	set := make(map[string]struct{}, len(resolution.Native))
+	for _, native := range resolution.Native {
+		set[native] = struct{}{}
+	}
+
+	return set
+}()

--- a/internal/core/infra/accessibility/uia_windows.go
+++ b/internal/core/infra/accessibility/uia_windows.go
@@ -98,6 +98,16 @@ const (
 	vtArrayGetElement = 4
 )
 
+// UI Automation control-type names referenced from more than one place.
+const (
+	uiaControlButton      = "Button"
+	uiaControlEdit        = "Edit"
+	uiaControlHyperlink   = "Hyperlink"
+	uiaControlCustom      = "Custom"
+	uiaControlSplitButton = "SplitButton"
+	uiaControlPane        = "Pane"
+)
+
 // controlTypeNames maps UI Automation CONTROLTYPEID values to the programmatic
 // names behind the UIA_*ControlTypeId constants. These names — not the
 // localized LocalizedControlType, which changes with the system language — are
@@ -106,12 +116,12 @@ const (
 // The range is contiguous and stable: 50000 is Button and 50040 is AppBar, the
 // last control type added (Windows 8).
 var controlTypeNames = map[int32]string{
-	50000: "Button",
+	50000: uiaControlButton,
 	50001: "Calendar",
 	50002: "CheckBox",
 	50003: "ComboBox",
-	50004: "Edit",
-	50005: "Hyperlink",
+	50004: uiaControlEdit,
+	50005: uiaControlHyperlink,
 	50006: "Image",
 	50007: "ListItem",
 	50008: "List",
@@ -131,15 +141,15 @@ var controlTypeNames = map[int32]string{
 	50022: "ToolTip",
 	50023: "Tree",
 	50024: "TreeItem",
-	50025: "Custom",
+	50025: uiaControlCustom,
 	50026: "Group",
 	50027: "Thumb",
 	50028: "DataGrid",
 	50029: "DataItem",
 	50030: "Document",
-	50031: "SplitButton",
+	50031: uiaControlSplitButton,
 	50032: "Window",
-	50033: "Pane",
+	50033: uiaControlPane,
 	50034: "Header",
 	50035: "HeaderItem",
 	50036: "Table",

--- a/internal/core/infra/accessibility/uia_windows_integration_test.go
+++ b/internal/core/infra/accessibility/uia_windows_integration_test.go
@@ -36,7 +36,7 @@ func TestEnumerateClickableElementsIntegration(t *testing.T) {
 		}
 
 		// Roles must be the native UIA control-type names the config vocabulary
-		// resolves to, never the AX-style names neru used to synthesise here.
+		// resolves to, never the AX-style names neru used to synthesize here.
 		if _, ok := defaultClickableRoles[elem.role]; !ok {
 			t.Errorf(
 				"element %d has role %q, which is not in the default role set",

--- a/internal/core/infra/accessibility/uia_windows_integration_test.go
+++ b/internal/core/infra/accessibility/uia_windows_integration_test.go
@@ -22,7 +22,9 @@ func TestEnumerateClickableElementsIntegration(t *testing.T) {
 		t.Skip("skipping: no foreground window (headless session)")
 	}
 
-	elements := enumerateClickableElements(hwnd)
+	// A nil role set falls back to the shipped defaults, which is what the
+	// hints path uses when no roles are configured.
+	elements := enumerateClickableElements(hwnd, nil)
 	if len(elements) == 0 {
 		t.Skip("skipping: foreground window exposed no clickable elements")
 	}
@@ -31,6 +33,15 @@ func TestEnumerateClickableElementsIntegration(t *testing.T) {
 	for idx, elem := range elements {
 		if elem.role == "" {
 			t.Errorf("element %d has empty role", idx)
+		}
+
+		// Roles must be the native UIA control-type names the config vocabulary
+		// resolves to, never the AX-style names neru used to synthesise here.
+		if _, ok := defaultClickableRoles[elem.role]; !ok {
+			t.Errorf(
+				"element %d has role %q, which is not in the default role set",
+				idx, elem.role,
+			)
 		}
 
 		if elem.bounds.Dx() <= 0 || elem.bounds.Dy() <= 0 {

--- a/internal/core/infra/accessibility/uia_windows_test.go
+++ b/internal/core/infra/accessibility/uia_windows_test.go
@@ -23,20 +23,20 @@ func TestControlTypeName(t *testing.T) {
 		wantName    string
 		wantKnown   bool
 	}{
-		{"button", 50000, "Button", true},
+		{"button", 50000, uiaControlButton, true},
 		{"checkbox", 50002, "CheckBox", true},
 		{"combobox", 50003, "ComboBox", true},
-		{"edit", 50004, "Edit", true},
-		{"hyperlink", 50005, "Hyperlink", true},
+		{"edit", 50004, uiaControlEdit, true},
+		{"hyperlink", 50005, uiaControlHyperlink, true},
 		{"menu item", 50011, "MenuItem", true},
 		{"radio button", 50013, "RadioButton", true},
 		{"tab item", 50019, "TabItem", true},
-		{"split button", 50031, "SplitButton", true},
+		{"split button", 50031, uiaControlSplitButton, true},
 		// Control types that were previously discarded are now named, so a
 		// config can address them through the uia: prefix.
 		{"text", 50020, "Text", true},
-		{"custom", 50025, "Custom", true},
-		{"pane", 50033, "Pane", true},
+		{"custom", 50025, uiaControlCustom, true},
+		{"pane", 50033, uiaControlPane, true},
 		{"document", 50030, "Document", true},
 		{"last known control type", 50040, "AppBar", true},
 		{"unknown control type", 99999, roleUnknown, false},
@@ -72,19 +72,19 @@ func TestControlTypeNamesAreContiguous(t *testing.T) {
 
 	seen := make(map[string]int32, len(controlTypeNames))
 
-	for id := int32(first); id <= last; id++ {
-		name, ok := controlTypeNames[id]
+	for controlType := int32(first); controlType <= last; controlType++ {
+		name, ok := controlTypeNames[controlType]
 		if !ok {
-			t.Errorf("controlTypeNames lacks id %d", id)
+			t.Errorf("controlTypeNames lacks id %d", controlType)
 
 			continue
 		}
 
 		if previous, duplicate := seen[name]; duplicate {
-			t.Errorf("controlTypeNames has %q for both %d and %d", name, previous, id)
+			t.Errorf("controlTypeNames has %q for both %d and %d", name, previous, controlType)
 		}
 
-		seen[name] = id
+		seen[name] = controlType
 	}
 
 	if len(controlTypeNames) != last-first+1 {

--- a/internal/core/infra/accessibility/uia_windows_test.go
+++ b/internal/core/infra/accessibility/uia_windows_test.go
@@ -1,36 +1,44 @@
 //go:build windows
 
 // internal/core/infra/accessibility/uia_windows_test.go
-// Unit tests for the pure UIA control-type mapping used by hint enumeration.
+// Unit tests for the pure UIA control-type naming used by hint enumeration.
 // Does not exercise live UIA (see accessibility integration tests on WIN-VM).
 
-package accessibility //nolint:testpackage // exercises unexported mapControlType directly
+package accessibility //nolint:testpackage // exercises unexported controlTypeName directly
 
 import (
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/core/domain/element"
 )
 
-func TestMapControlType(t *testing.T) {
+func TestControlTypeName(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		controlType   int32
-		wantRole      string
-		wantClickable bool
+		name        string
+		controlType int32
+		wantName    string
+		wantKnown   bool
 	}{
-		{"button", 50000, string(element.RoleButton), true},
-		{"checkbox", 50002, string(element.RoleCheckBox), true},
-		{"combobox", 50003, string(element.RoleComboBox), true},
-		{"edit", 50004, string(element.RoleTextField), true},
-		{"hyperlink", 50005, string(element.RoleLink), true},
-		{"menu item", 50011, string(element.RoleMenuItem), true},
-		{"radio button", 50013, string(element.RoleRadioButton), true},
-		{"tab item", 50019, string(element.RoleTabButton), true},
-		{"split button", 50031, string(element.RoleButton), true},
-		{"text is not clickable", 50020, roleUnknown, false},
+		{"button", 50000, "Button", true},
+		{"checkbox", 50002, "CheckBox", true},
+		{"combobox", 50003, "ComboBox", true},
+		{"edit", 50004, "Edit", true},
+		{"hyperlink", 50005, "Hyperlink", true},
+		{"menu item", 50011, "MenuItem", true},
+		{"radio button", 50013, "RadioButton", true},
+		{"tab item", 50019, "TabItem", true},
+		{"split button", 50031, "SplitButton", true},
+		// Control types that were previously discarded are now named, so a
+		// config can address them through the uia: prefix.
+		{"text", 50020, "Text", true},
+		{"custom", 50025, "Custom", true},
+		{"pane", 50033, "Pane", true},
+		{"document", 50030, "Document", true},
+		{"last known control type", 50040, "AppBar", true},
 		{"unknown control type", 99999, roleUnknown, false},
 		{"zero control type", 0, roleUnknown, false},
 	}
@@ -39,17 +47,71 @@ func TestMapControlType(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			role, clickable := mapControlType(testCase.controlType)
-			if role != testCase.wantRole || clickable != testCase.wantClickable {
+			name, known := controlTypeName(testCase.controlType)
+			if name != testCase.wantName || known != testCase.wantKnown {
 				t.Fatalf(
-					"mapControlType(%d) = (%q, %v), want (%q, %v)",
+					"controlTypeName(%d) = (%q, %v), want (%q, %v)",
 					testCase.controlType,
-					role,
-					clickable,
-					testCase.wantRole,
-					testCase.wantClickable,
+					name,
+					known,
+					testCase.wantName,
+					testCase.wantKnown,
 				)
 			}
 		})
+	}
+}
+
+// TestControlTypeNamesAreContiguous guards the transcription of the
+// UIA_*ControlTypeId range. A gap or duplicate would mean an id was mistyped,
+// which silently misnames a control type.
+func TestControlTypeNamesAreContiguous(t *testing.T) {
+	t.Parallel()
+
+	const first, last = 50000, 50040
+
+	seen := make(map[string]int32, len(controlTypeNames))
+
+	for id := int32(first); id <= last; id++ {
+		name, ok := controlTypeNames[id]
+		if !ok {
+			t.Errorf("controlTypeNames lacks id %d", id)
+
+			continue
+		}
+
+		if previous, duplicate := seen[name]; duplicate {
+			t.Errorf("controlTypeNames has %q for both %d and %d", name, previous, id)
+		}
+
+		seen[name] = id
+	}
+
+	if len(controlTypeNames) != last-first+1 {
+		t.Errorf(
+			"controlTypeNames has %d entries, want %d",
+			len(controlTypeNames), last-first+1,
+		)
+	}
+}
+
+// TestControlTypeNamesCoverTheVocabulary pins enumeration against the semantic
+// vocabulary: every UIA name a semantic role expands to must be a name the
+// enumerator can actually produce, or that role would never match anything.
+func TestControlTypeNamesCoverTheVocabulary(t *testing.T) {
+	t.Parallel()
+
+	names := slices.Collect(maps.Values(controlTypeNames))
+
+	for _, mapping := range element.RoleVocabulary {
+		for _, native := range mapping.UIA {
+			if !slices.Contains(names, native) {
+				t.Errorf(
+					"semantic role %q expands to UIA control type %q, which the "+
+						"enumerator never produces",
+					mapping.Semantic, native,
+				)
+			}
+		}
 	}
 }

--- a/internal/core/infra/electron/electron.go
+++ b/internal/core/infra/electron/electron.go
@@ -1,96 +1,20 @@
 package electron
 
 import (
-	"time"
-
 	"go.uber.org/zap"
-
-	"github.com/y3owk1n/neru/internal/core/infra/accessibility"
 )
 
-const (
-	accessibilityRetryCount = 10
-	accessibilityRetryDelay = 100 * time.Millisecond
-	maxAccessibilityDepth   = 10
-)
-
-// EnsureAccessibility ensures accessibility is enabled for the provided bundle ID.
+// EnsureAccessibility reports whether the application identified by bundleID
+// has an accessibility tree neru can hint against, waiting briefly for it to
+// appear. Electron, Chromium and Firefox build their tree asynchronously after
+// being asked to expose one, so the first hints activation after focusing such
+// an app would otherwise find nothing.
+//
+// It returns true once a usable tree is found, and false if the wait times out.
 func EnsureAccessibility(bundleID string, logger *zap.Logger) bool {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 
-	logger = logger.Named("electron")
-
-	app := accessibility.ApplicationByBundleID(bundleID)
-	if app == nil {
-		logger.Debug("Application not found for bundle ID", zap.String("bundle_id", bundleID))
-
-		return false
-	}
-
-	return waitForAccessibility(app, logger)
-}
-
-func waitForAccessibility(app *accessibility.Element, logger *zap.Logger) bool {
-	for range accessibilityRetryCount {
-		if hasUsableAccessibilityTree(app, logger) {
-			return true
-		}
-
-		time.Sleep(accessibilityRetryDelay)
-	}
-
-	return false
-}
-
-func hasUsableAccessibilityTree(root *accessibility.Element, logger *zap.Logger) bool {
-	if root == nil {
-		return false
-	}
-
-	type entry struct {
-		el    *accessibility.Element
-		depth int
-	}
-
-	queue := []entry{{root, 0}}
-
-	for len(queue) > 0 {
-		cur := queue[0]
-		queue = queue[1:]
-
-		if cur.el == nil {
-			continue
-		}
-
-		info, err := cur.el.Info()
-		if err != nil || info == nil {
-			continue
-		}
-
-		role := info.Role()
-
-		switch role {
-		case "AXWebArea", "AXScrollArea":
-			logger.Info("Found usable accessibility tree", zap.String("role", role))
-
-			return true
-		}
-
-		if cur.depth >= maxAccessibilityDepth {
-			continue
-		}
-
-		children, err := cur.el.Children(role)
-		if err != nil {
-			continue
-		}
-
-		for _, child := range children {
-			queue = append(queue, entry{child, cur.depth + 1})
-		}
-	}
-
-	return false
+	return ensureAccessibility(bundleID, logger.Named("electron"))
 }

--- a/internal/core/infra/electron/electron_darwin.go
+++ b/internal/core/infra/electron/electron_darwin.go
@@ -1,0 +1,98 @@
+//go:build darwin
+
+package electron
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/infra/accessibility"
+)
+
+const (
+	accessibilityRetryCount = 10
+	accessibilityRetryDelay = 100 * time.Millisecond
+	maxAccessibilityDepth   = 10
+)
+
+// readyRoles are the AX roles whose presence means the Chromium/Gecko
+// accessibility tree has been built. They are native macOS role names: this
+// file is the only place that inspects the tree, and it only runs on darwin.
+var readyRoles = map[string]struct{}{
+	"AXWebArea":    {},
+	"AXScrollArea": {},
+}
+
+func ensureAccessibility(bundleID string, logger *zap.Logger) bool {
+	app := accessibility.ApplicationByBundleID(bundleID)
+	if app == nil {
+		logger.Debug("Application not found for bundle ID", zap.String("bundle_id", bundleID))
+
+		return false
+	}
+
+	return waitForAccessibility(app, logger)
+}
+
+func waitForAccessibility(app *accessibility.Element, logger *zap.Logger) bool {
+	for range accessibilityRetryCount {
+		if hasUsableAccessibilityTree(app, logger) {
+			return true
+		}
+
+		time.Sleep(accessibilityRetryDelay)
+	}
+
+	return false
+}
+
+func hasUsableAccessibilityTree(root *accessibility.Element, logger *zap.Logger) bool {
+	if root == nil {
+		return false
+	}
+
+	type entry struct {
+		el    *accessibility.Element
+		depth int
+	}
+
+	queue := []entry{{root, 0}}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		if cur.el == nil {
+			continue
+		}
+
+		info, err := cur.el.Info()
+		if err != nil || info == nil {
+			continue
+		}
+
+		role := info.Role()
+
+		if _, ready := readyRoles[role]; ready {
+			logger.Info("Found usable accessibility tree", zap.String("role", role))
+
+			return true
+		}
+
+		if cur.depth >= maxAccessibilityDepth {
+			continue
+		}
+
+		children, err := cur.el.Children(role)
+		if err != nil {
+			continue
+		}
+
+		for _, child := range children {
+			queue = append(queue, entry{child, cur.depth + 1})
+		}
+	}
+
+	return false
+}

--- a/internal/core/infra/electron/electron_other.go
+++ b/internal/core/infra/electron/electron_other.go
@@ -1,0 +1,18 @@
+//go:build !darwin
+
+package electron
+
+import "go.uber.org/zap"
+
+// ensureAccessibility is a no-op outside macOS. The asynchronous tree it waits
+// for is a Chromium/Gecko behaviour behind macOS's AXManualAccessibility; the
+// AT-SPI and UI Automation backends expose their trees eagerly, so there is
+// nothing to wait for. It reports success so callers do not retry.
+func ensureAccessibility(bundleID string, logger *zap.Logger) bool {
+	logger.Debug(
+		"Accessibility tree priming not required on this platform",
+		zap.String("bundle_id", bundleID),
+	)
+
+	return true
+}

--- a/internal/core/infra/electron/electron_other.go
+++ b/internal/core/infra/electron/electron_other.go
@@ -5,7 +5,7 @@ package electron
 import "go.uber.org/zap"
 
 // ensureAccessibility is a no-op outside macOS. The asynchronous tree it waits
-// for is a Chromium/Gecko behaviour behind macOS's AXManualAccessibility; the
+// for is a Chromium/Gecko behavior behind macOS's AXManualAccessibility; the
 // AT-SPI and UI Automation backends expose their trees eagerly, so there is
 // nothing to wait for. It reports success so callers do not retry.
 func ensureAccessibility(bundleID string, logger *zap.Logger) bool {

--- a/internal/core/infra/vision/heuristics.go
+++ b/internal/core/infra/vision/heuristics.go
@@ -24,6 +24,14 @@ type regionClassifier struct {
 	cfg config.HintsVisionConfig
 }
 
+// roleButton is the role assigned to a detected region. It is a native macOS
+// AX role name because vision detection only has a darwin backend
+// (adapter_other.go reports CodeNotSupported), so this is the vocabulary the
+// configured clickable roles resolve to on the only platform that runs it.
+//
+// A Linux or Windows vision backend must emit that platform's native role name
+// instead — "push button" or "Button" — since role filtering compares against
+// native names. See internal/core/domain/element/vocabulary.go.
 const roleButton = "AXButton"
 
 // Classify assigns a role to a detected region based on its geometry and


### PR DESCRIPTION
## Description

This PR reworks how hint roles are configured so that one config file works on every
platform. `hints.clickable_roles` previously took each operating system's own accessibility
role names, which meant a config written on macOS selected nothing on Linux or Windows. The
shipped Linux defaults were affected by this too: they were written in one vocabulary while
the Linux backend reported another, so the default configuration matched no element and
produced no hints at all on Linux.

Roles are now written as platform-neutral names — `button`, `text_field`, `link` — and
resolved to the running platform's native role names when the config loads. Roles that have
no neutral equivalent stay reachable by naming the platform's own vocabulary explicitly, and
entries belonging to a different platform are reported and ignored rather than rejected, so
the same file can be synced across machines.

Windows benefits most: the full UI Automation control-type range is now recognised, so
controls that report as panes, custom or document elements — most of the interface in older
Win32 and WinForms applications — can be hinted for the first time.

### Configuration and command changes

#### `hints.clickable_roles` and `additional_clickable_roles`

Both accept the same two entry forms. This is the same field as before; only the accepted
values change.

| Form | Example | Meaning |
| --- | --- | --- |
| Semantic role | `"button"` | Resolves to the running platform's native roles |
| Native role | `"ax:AXDisclosureTriangle"` | A macOS role, ignored elsewhere |
| Native role | `"atspi:page tab list"` | A Linux AT-SPI role, ignored elsewhere |
| Native role | `"uia:Custom"` | A Windows UI Automation control type, ignored elsewhere |

```toml
[hints]
clickable_roles = [
    "button", "link", "text_field",
    "ax:AXGenericElement",
]
```

The semantic vocabulary is: `button`, `menu_button`, `popup_button`, `combo_box`, `link`,
`checkbox`, `radio`, `switch`, `disclosure`, `text_field`, `text_area`, `search_field`,
`slider`, `stepper`, `tab`, `menu_item`, `menubar_item`, `dock_item`, `cell`, `row`,
`list_item`, `image`, `static_text`, `heading`, `color_well`, `toolbar_button`. It is a
closed set — an unrecognised bare name is a configuration error, which is what makes typos
visible. Native names are open-ended and never validated.

The default value changes from a per-platform list of native names to one shared semantic
list, and it is now correct on all three platforms.

#### `general.exec_shell` (default config file only)

`configs/default-config.toml` — the file `neru config init` writes — pinned
`exec_shell = "/bin/bash"`, overriding the Windows platform default of
`%SystemRoot%\System32\cmd.exe`. On Windows that path is not absolute, so the
generated config failed validation and the daemon refused to load it. Both
`exec_shell` and `exec_shell_args` are now commented out so the platform default
applies. macOS and Linux behaviour is unchanged, since the shared default is
already `/bin/bash -lc`.

This is a pre-existing bug, surfaced by the new test that loads every example
config on every platform.

#### `neru hints --role`

Accepts the same vocabulary, so `--role button` replaces `--role AXButton`.

#### `neru roles` (new)

| Command | Purpose |
| --- | --- |
| `neru roles` | List the semantic vocabulary and how each entry resolves here |
| `neru roles --explain` | Show how the loaded config resolves, entry by entry |

#### `neru doctor`

Gains a `clickable_roles` line reporting how many configured entries apply on this platform,
and failing when none do.

### Potential breaking changes

**Existing `clickable_roles` values stop validating.** Any config that lists native role
names without a prefix — which is every config written before this PR, e.g.
`clickable_roles = ["AXButton", "AXLink"]` — is now rejected at load with an error naming the
replacement:

```
hints.clickable_roles: unknown role "AXButton": use "button"
```

Affected users edit the list once. Either switch to semantic names (`"button"`, `"link"`) or
keep the exact native roles by prefixing them (`"ax:AXButton"`). The same applies to
`additional_clickable_roles` in `[[hints.app_configs]]` and to `neru hints --role`.

This was a deliberate choice over accepting the old names silently: keeping a compatibility
path would have made a bare name ambiguous between "semantic role" and "native role", and
that ambiguity is what removes the ability to detect a typo at all. Worth a reviewer's
explicit sign-off, since it affects every existing user who customised this field.

Configs that did **not** customise `clickable_roles` are unaffected and pick up the new
defaults.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new port capability is introduced; the platform accessibility backends already exist and this PR only changes the role vocabulary they speak.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Where the translation happens.** Resolution moved out of the accessibility adapters into
config load. The AT-SPI and UI Automation backends now report their own native role names
rather than synthesising macOS-style ones, which deletes two mapping tables and leaves a
single translation point. Elements carry only their native role, so the element filter is
unchanged and there is no hot-path cost.

**The AT-SPI and UI Automation tables were verified against upstream sources**, not written
from memory. The AT-SPI role ids are checked against the enum in `atspi-constants.h`, and the
role name strings against the fact that `Accessible.GetRoleName` returns the GEnum nick with
hyphens replaced by spaces — that is why the menu button role resolves to `push button menu`
rather than the more obvious `menu button`, which would have matched nothing. Tests pin both
tables: the AT-SPI ids must be contiguous and cover the enum, and the UI Automation control
types must cover the documented range.

**A role filter that resolves to nothing now produces no hints.** An empty role set means
"match everything" to the element filter, so a config whose entries all belong to another
platform would otherwise have hinted every element on screen while `neru doctor` reported the
opposite. There is a regression test for both the config and `--role` paths.

**Windows role filtering moved into enumeration.** UI Automation is queried with a true
condition and the whole subtree comes back, so rejecting a control before reading its bounds
and name saves three cross-process COM calls per unwanted element.

**Not verified at runtime on Linux or Windows.** Both platforms build, vet and pass their
unit tests including with `-tags=integration`, and the tables are pinned by tests, but the
work was done on macOS — the Linux default-config fix and the Windows legacy-application
support have not been confirmed on real hardware.
