### PR TITLE
fix(action): make `feed --mode` a discrete press-and-release

### DIFF
--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -873,6 +873,14 @@ func (h *IPCControllerActions) handleFeedToModeAction(args []string) ipc.Respons
 		}
 	}
 
+	if h.modesHandler == nil {
+		return ipc.Response{
+			Success: false,
+			Message: msgModesHandlerNotAvailable,
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
 	keys := make([]string, 0, len(args))
 	for _, arg := range args {
 		key := strings.TrimSpace(arg)
@@ -899,7 +907,7 @@ func (h *IPCControllerActions) handleFeedToModeAction(args []string) ipc.Respons
 			}
 		}
 
-		h.modesHandler.HandleKeyPress(normalized)
+		h.modesHandler.HandleFedKeyPress(normalized)
 	}
 
 	return ipc.Response{

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -160,6 +160,35 @@ func TestHandleAction_RejectsBailOnNonWaitForModeExit(t *testing.T) {
 	}
 }
 
+func TestHandleAction_FeedModeWithoutModesHandler(t *testing.T) {
+	controller := &IPCControllerActions{logger: zap.NewNop()}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: actionCmd,
+		Args:   []string{"feed", "--mode", "o"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(feed --mode o) expected failure with nil modes handler, got success")
+	}
+
+	if resp.Code != ipc.CodeActionFailed {
+		t.Fatalf(
+			"handleAction(feed --mode o) code = %q, want %q",
+			resp.Code,
+			ipc.CodeActionFailed,
+		)
+	}
+
+	if resp.Message != msgModesHandlerNotAvailable {
+		t.Fatalf(
+			"handleAction(feed --mode o) message = %q, want %q",
+			resp.Message,
+			msgModesHandlerNotAvailable,
+		)
+	}
+}
+
 func TestParseActionArgs_BareFlag(t *testing.T) {
 	parsed, parseErr := parseActionArgs([]string{"--bare"})
 	if parseErr {

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -27,6 +27,30 @@ const (
 	keyPartOption = "option"
 )
 
+// HandleFedKeyPress dispatches a key that was injected over IPC (e.g. via
+// `action feed --mode`) as a discrete press-and-release.
+//
+// Unlike a physical keystroke, a fed key has no eventtap-generated
+// `__keyup_...` companion. Without a matching release, a fed key bound to a
+// held-repeat action (scroll/page/relative-move) would start a repeat
+// goroutine that can never be stopped by key release and would run until the
+// mode exits. Emitting the synthetic key-up immediately after the press tears
+// that repeat down while still letting the initial action fire once. For any
+// non-repeating key the release is a no-op (the key-up branch of
+// HandleKeyPress returns early when nothing is repeating).
+func (h *Handler) HandleFedKeyPress(key string) {
+	h.HandleKeyPress(key)
+
+	// The key-up handler compares against the modifier-free base key, so strip
+	// any modifier prefix before synthesizing the release.
+	base := key
+	if i := strings.LastIndex(base, "+"); i >= 0 {
+		base = base[i+1:]
+	}
+
+	h.HandleKeyPress(keyUpPrefix + base)
+}
+
 // HandleKeyPress dispatches key events by current mode.
 func (h *Handler) HandleKeyPress(key string) {
 	h.mu.Lock()

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -35,10 +35,14 @@ const (
 // held-repeat action (scroll/page/relative-move) would start a repeat
 // goroutine that can never be stopped by key release and would run until the
 // mode exits. Emitting the synthetic key-up immediately after the press tears
-// that repeat down while still letting the initial action fire once. For any
-// non-repeating key the release is a no-op (the key-up branch returns early
-// when nothing is repeating). The press and release run under a single lock
-// hold so no concurrent key event can observe the transient repeat.
+// that repeat down while still letting the initial action fire once.
+//
+// The release is synthesized only when the fed press itself started a repeat
+// (a transition from no repeat to an active one). A repeat that was already
+// running belongs to a physically held key, so the fed key must not cancel it;
+// and when the fed key starts no repeat the release would be a no-op anyway.
+// The press and the conditional release run under a single lock hold so no
+// concurrent key event can interleave or observe a transient repeat.
 func (h *Handler) HandleFedKeyPress(key string) {
 	// The key-up handler compares against the modifier-free base key, so strip
 	// any modifier prefix before synthesizing the release.
@@ -47,15 +51,17 @@ func (h *Handler) HandleFedKeyPress(key string) {
 		base = base[i+1:]
 	}
 
-	// Hold the lock across both the press and the synthetic release so the pair
-	// is atomic. Otherwise a concurrent physical event-tap key could interleave
-	// between them and act on held-repeat state the press just changed (or the
-	// release could cancel a repeat a physical key still holds).
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	repeatBefore := h.heldRepeatingKey
 	h.handleKeyPressLocked(key)
-	h.handleKeyPressLocked(keyUpPrefix + base)
+
+	// Only release a repeat this fed press just started; leave any pre-existing
+	// (physically held) repeat untouched.
+	if repeatBefore == "" && h.heldRepeatingKey != "" {
+		h.handleKeyPressLocked(keyUpPrefix + base)
+	}
 }
 
 // HandleKeyPress dispatches key events by current mode.

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -36,11 +36,10 @@ const (
 // goroutine that can never be stopped by key release and would run until the
 // mode exits. Emitting the synthetic key-up immediately after the press tears
 // that repeat down while still letting the initial action fire once. For any
-// non-repeating key the release is a no-op (the key-up branch of
-// HandleKeyPress returns early when nothing is repeating).
+// non-repeating key the release is a no-op (the key-up branch returns early
+// when nothing is repeating). The press and release run under a single lock
+// hold so no concurrent key event can observe the transient repeat.
 func (h *Handler) HandleFedKeyPress(key string) {
-	h.HandleKeyPress(key)
-
 	// The key-up handler compares against the modifier-free base key, so strip
 	// any modifier prefix before synthesizing the release.
 	base := key
@@ -48,7 +47,15 @@ func (h *Handler) HandleFedKeyPress(key string) {
 		base = base[i+1:]
 	}
 
-	h.HandleKeyPress(keyUpPrefix + base)
+	// Hold the lock across both the press and the synthetic release so the pair
+	// is atomic. Otherwise a concurrent physical event-tap key could interleave
+	// between them and act on held-repeat state the press just changed (or the
+	// release could cancel a repeat a physical key still holds).
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.handleKeyPressLocked(key)
+	h.handleKeyPressLocked(keyUpPrefix + base)
 }
 
 // HandleKeyPress dispatches key events by current mode.
@@ -56,6 +63,13 @@ func (h *Handler) HandleKeyPress(key string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	h.handleKeyPressLocked(key)
+}
+
+// handleKeyPressLocked contains the key-dispatch logic. The caller must hold
+// h.mu; the whole body runs under the lock so held-repeat and modifier-toggle
+// state stays consistent across the dispatch.
+func (h *Handler) handleKeyPressLocked(key string) {
 	// Handle key-up events for held-key repeat suppression.
 	// The eventtap emits modifier-free key names on key-up, so we compare
 	// only the base key name (last segment after "+") case-insensitively.

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -139,17 +139,14 @@ func TestHandleKeyPressRoutesAllKeysToHintSearch(t *testing.T) {
 	}
 }
 
-// TestHandleFedKeyPressStopsHeldRepeat verifies that a key injected via
-// `action feed --mode` does not leave a held-repeat goroutine running. A fed
-// key has no physical key-up, so the synthetic release emitted by
-// HandleFedKeyPress must tear down any repeat the press started.
-func TestHandleFedKeyPressStopsHeldRepeat(t *testing.T) {
-	t.Parallel()
-
+// newHeldRepeatTestHandler builds a handler in recursive-grid mode where "j" is
+// bound to a held-repeat action, with long delays so the repeat goroutine
+// blocks on its initial timer and never dispatches during the test.
+func newHeldRepeatTestHandler() *Handler {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeRecursiveGrid)
 
-	handler := &Handler{
+	return &Handler{
 		ctx: context.Background(),
 		config: &configpkg.Config{
 			RecursiveGrid: configpkg.RecursiveGridConfig{
@@ -158,9 +155,7 @@ func TestHandleFedKeyPressStopsHeldRepeat(t *testing.T) {
 				},
 			},
 			HeldRepeat: configpkg.HeldRepeatConfig{
-				Enabled: true,
-				// Long delay so the repeat goroutine blocks on the initial
-				// timer and never dispatches during the test.
+				Enabled:      true,
 				InitialDelay: 10_000,
 				Interval:     10_000,
 			},
@@ -176,9 +171,43 @@ func TestHandleFedKeyPressStopsHeldRepeat(t *testing.T) {
 			return nil
 		},
 	}
+}
 
-	// Sanity check: a plain press starts a held-repeat that a fed key would
-	// never be able to stop (no key-up ever arrives).
+// TestHandleFedKeyPressStopsOwnHeldRepeat verifies that a key injected via
+// `action feed --mode` does not leave its own held-repeat goroutine running. A
+// fed key has no physical key-up, so HandleFedKeyPress must synthesize the
+// release that tears down the repeat the fed press started.
+func TestHandleFedKeyPressStopsOwnHeldRepeat(t *testing.T) {
+	t.Parallel()
+
+	handler := newHeldRepeatTestHandler()
+
+	handler.HandleFedKeyPress("j")
+
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+
+	if handler.heldRepeatingKey != "" {
+		t.Fatalf(
+			"fed key left a held repeat active; heldRepeatingKey = %q, want empty",
+			handler.heldRepeatingKey,
+		)
+	}
+
+	if handler.heldRepeatingCancel != nil {
+		t.Fatal("fed key left the held-repeat cancel func set")
+	}
+}
+
+// TestHandleFedKeyPressPreservesPhysicalHeldRepeat verifies that feeding a key
+// that matches a repeat a physically held key already started does not cancel
+// that repeat. The fed key owns only repeats it starts itself.
+func TestHandleFedKeyPressPreservesPhysicalHeldRepeat(t *testing.T) {
+	t.Parallel()
+
+	handler := newHeldRepeatTestHandler()
+
+	// Simulate a physical hold that started a repeat.
 	handler.HandleKeyPress("j")
 
 	handler.mu.Lock()
@@ -187,29 +216,28 @@ func TestHandleFedKeyPressStopsHeldRepeat(t *testing.T) {
 
 	if startedKey != "j" {
 		t.Fatalf(
-			"held repeat not started by press; heldRepeatingKey = %q, want %q",
+			"physical press did not start held repeat; heldRepeatingKey = %q, want %q",
 			startedKey,
 			"j",
 		)
 	}
 
-	// Feeding the same key must leave no repeat active: the press re-arms it
-	// (suppressed as a duplicate) and the synthetic release tears it down.
+	// Feeding the same key must not cancel the physically held repeat.
 	handler.HandleFedKeyPress("j")
 
 	handler.mu.Lock()
 	defer handler.mu.Unlock()
 
-	if handler.heldRepeatingKey != "" {
+	if handler.heldRepeatingKey != "j" {
 		t.Fatalf(
-			"held repeat still active after fed key; heldRepeatingKey = %q, want empty",
+			"fed key canceled a physically held repeat; heldRepeatingKey = %q, want %q",
 			handler.heldRepeatingKey,
+			"j",
 		)
 	}
 
-	if handler.heldRepeatingCancel != nil {
-		t.Fatal("held repeat cancel func not cleared after fed key")
-	}
+	// Stop the still-running repeat goroutine so it does not outlive the test.
+	handler.stopHeldRepeatLocked()
 }
 
 func TestDispatchHotkeyActions_AbortsOnBail(t *testing.T) {

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -2,6 +2,7 @@
 package modes
 
 import (
+	"context"
 	"image"
 	"sync/atomic"
 	"testing"
@@ -135,6 +136,79 @@ func TestHandleKeyPressRoutesAllKeysToHintSearch(t *testing.T) {
 
 	if got := handler.hints.Context.SearchQuery(); got != "/" {
 		t.Fatalf("search query = %q, want %q", got, "/")
+	}
+}
+
+// TestHandleFedKeyPressStopsHeldRepeat verifies that a key injected via
+// `action feed --mode` does not leave a held-repeat goroutine running. A fed
+// key has no physical key-up, so the synthetic release emitted by
+// HandleFedKeyPress must tear down any repeat the press started.
+func TestHandleFedKeyPressStopsHeldRepeat(t *testing.T) {
+	t.Parallel()
+
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeRecursiveGrid)
+
+	handler := &Handler{
+		ctx: context.Background(),
+		config: &configpkg.Config{
+			RecursiveGrid: configpkg.RecursiveGridConfig{
+				Hotkeys: map[string]configpkg.StringOrStringArray{
+					"j": {"action scroll_down"},
+				},
+			},
+			HeldRepeat: configpkg.HeldRepeatConfig{
+				Enabled: true,
+				// Long delay so the repeat goroutine blocks on the initial
+				// timer and never dispatches during the test.
+				InitialDelay: 10_000,
+				Interval:     10_000,
+			},
+		},
+		logger:        zap.NewNop(),
+		appState:      appState,
+		modifierState: state.NewModifierState(),
+		modes: map[domain.Mode]Mode{
+			domain.ModeRecursiveGrid: &recordingMode{keys: make(chan string, 1)},
+		},
+		screenBounds: image.Rect(0, 0, 100, 100),
+		executeHotkeyAction: func(_, _ string) error {
+			return nil
+		},
+	}
+
+	// Sanity check: a plain press starts a held-repeat that a fed key would
+	// never be able to stop (no key-up ever arrives).
+	handler.HandleKeyPress("j")
+
+	handler.mu.Lock()
+	startedKey := handler.heldRepeatingKey
+	handler.mu.Unlock()
+
+	if startedKey != "j" {
+		t.Fatalf(
+			"held repeat not started by press; heldRepeatingKey = %q, want %q",
+			startedKey,
+			"j",
+		)
+	}
+
+	// Feeding the same key must leave no repeat active: the press re-arms it
+	// (suppressed as a duplicate) and the synthetic release tears it down.
+	handler.HandleFedKeyPress("j")
+
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+
+	if handler.heldRepeatingKey != "" {
+		t.Fatalf(
+			"held repeat still active after fed key; heldRepeatingKey = %q, want empty",
+			handler.heldRepeatingKey,
+		)
+	}
+
+	if handler.heldRepeatingCancel != nil {
+		t.Fatal("held repeat cancel func not cleared after fed key")
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes `action feed --mode` so that a fed key bound to a held-repeat action (scroll/page/relative-move) no longer starts an unstoppable repeat; each fed key now behaves as a discrete press-and-release. It also hardens the feed-to-mode path to return a clean error instead of panicking when the mode system is unavailable.

## Related Issues

<!-- none -->

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

A fed key has no eventtap-generated key-up, so the release is synthesized after the press. It is a no-op for non-repeating keys (the key-up branch returns early when nothing is repeating), so existing uses like feeding a hint label are unaffected.