### PR TITLE
fix(linux): render overlays properly on the selected monitor

### DIFF
--- a/internal/app/mocks_darwin_test.go
+++ b/internal/app/mocks_darwin_test.go
@@ -170,6 +170,9 @@ func (m *mockOverlayManager) ClearCache() {}
 // ResizeToActiveScreen implements OverlayManager.
 func (m *mockOverlayManager) ResizeToActiveScreen() {}
 
+// SetActiveScreenOrigin implements OverlayManager.
+func (m *mockOverlayManager) SetActiveScreenOrigin(_ image.Point) {}
+
 // SwitchTo implements OverlayManager.
 func (m *mockOverlayManager) SwitchTo(mode overlay.Mode) {
 	m.mu.Lock()

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -149,7 +149,7 @@ func (h *Handler) createGridInstance() *domainGrid.Grid {
 	}
 
 	// Store screen bounds for coordinate conversion
-	h.screenBounds = screenBounds
+	h.setScreenBounds(screenBounds)
 
 	// Normalize normalizedBounds to window-local coordinates using helper function
 	normalizedBounds := coordinates.NormalizeToLocalCoordinates(screenBounds)

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -272,7 +272,7 @@ func (h *Handler) RefreshHintsForScreenChange(
 	if h.system != nil {
 		b, err := h.system.ScreenBounds(ctx)
 		if err == nil {
-			h.screenBounds = b
+			h.setScreenBounds(b)
 		} else if !derrors.IsNotSupported(err) {
 			h.logger.Warn("Failed to refresh screen bounds after screen change", zap.Error(err))
 		}
@@ -423,7 +423,7 @@ func (h *Handler) RefreshRecursiveGridForScreenChange() bool {
 	if h.system != nil {
 		b, err := h.system.ScreenBounds(h.ctx)
 		if err == nil {
-			h.screenBounds = b
+			h.setScreenBounds(b)
 		} else if !derrors.IsNotSupported(err) {
 			h.logger.Warn("Failed to refresh screen bounds for recursive grid", zap.Error(err))
 		}
@@ -824,6 +824,20 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool, executeAction bo
 	}
 
 	return nil
+}
+
+// setScreenBounds records the active screen bounds used for overlay coordinate
+// conversion and informs the overlay backend of that screen's global origin.
+// The grid, recursive-grid and hint overlays render in screen-local coordinates
+// (origin 0,0); on backends whose overlay spans the whole desktop (Linux X11
+// and Wayland) the origin lets them translate that content onto the correct
+// monitor. It is a no-op where each screen owns an overlay window (macOS).
+func (h *Handler) setScreenBounds(bounds image.Rectangle) {
+	h.screenBounds = bounds
+
+	if h.overlayManager != nil {
+		h.overlayManager.SetActiveScreenOrigin(bounds.Min)
+	}
 }
 
 func (h *Handler) startHintSearchLocked() error {

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -249,7 +249,7 @@ func (h *Handler) activateHintModeInternal(
 		}
 	}
 
-	h.screenBounds = activeScreenBounds
+	h.setScreenBounds(activeScreenBounds)
 	// On a fresh activation, clear leftover overlay content (e.g. scroll highlights)
 	// before drawing hints. A refresh keeps its overlay so the existing labels persist
 	// until the redraw draws the new set over them.
@@ -594,7 +594,7 @@ func (h *Handler) ensureScreenCapturePermissionsLocked(
 		b, err := h.system.ScreenBounds(h.ctx)
 		if err == nil {
 			activeScreenBounds = b
-			h.screenBounds = activeScreenBounds
+			h.setScreenBounds(activeScreenBounds)
 		}
 	}
 

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -132,7 +132,7 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 					boundsCancel()
 
 					if boundsErr == nil && newBounds != h.screenBounds {
-						h.screenBounds = newBounds
+						h.setScreenBounds(newBounds)
 						// Must unlock before resizing overlays — the resize
 						// dispatches to the main queue and we must not hold
 						// h.mu across that call.

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -296,7 +296,7 @@ func (h *Handler) refreshGridForMonitorMove(targetBounds image.Rectangle) {
 		return
 	}
 	// Use the known target bounds instead of re-querying ScreenBounds.
-	h.screenBounds = targetBounds
+	h.setScreenBounds(targetBounds)
 	normalizedBounds := coordinates.NormalizeToLocalCoordinates(targetBounds)
 
 	characters := h.config.Grid.Characters
@@ -343,7 +343,7 @@ func (h *Handler) refreshRecursiveGridForMonitorMove(targetBounds image.Rectangl
 		return
 	}
 
-	h.screenBounds = targetBounds
+	h.setScreenBounds(targetBounds)
 
 	normalizedBounds := coordinates.NormalizeToLocalCoordinates(targetBounds)
 	if h.recursiveGrid != nil && h.recursiveGrid.Manager != nil {
@@ -418,7 +418,7 @@ func (h *Handler) refreshHintsForMonitorMove(
 		return
 	}
 	// Use the known target bounds instead of re-querying ScreenBounds.
-	h.screenBounds = targetBounds
+	h.setScreenBounds(targetBounds)
 
 	filtered := filterHintsForScreen(domainHints, targetBounds)
 	if len(filtered) == 0 {

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -71,7 +71,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 		}
 	}
 
-	h.screenBounds = screenBounds
+	h.setScreenBounds(screenBounds)
 	normalizedBounds := coordinates.NormalizeToLocalCoordinates(screenBounds)
 
 	// Initialize recursive-grid manager

--- a/internal/ui/overlay/manager_darwin.go
+++ b/internal/ui/overlay/manager_darwin.go
@@ -188,6 +188,11 @@ func (m *Manager) ResizeToActiveScreen() {
 // SetKeyboardCaptureEnabled is a no-op on Darwin.
 func (m *Manager) SetKeyboardCaptureEnabled(_ bool) {}
 
+// SetActiveScreenOrigin is a no-op on Darwin. Each screen has its own overlay
+// window positioned at the screen origin, so overlay content already uses
+// window-local coordinates and needs no global translation.
+func (m *Manager) SetActiveScreenOrigin(_ image.Point) {}
+
 // SwitchTo transitions the overlay to the specified mode and notifies subscribers.
 func (m *Manager) SwitchTo(next Mode) {
 	m.mu.Lock()

--- a/internal/ui/overlay/manager_linux_common.go
+++ b/internal/ui/overlay/manager_linux_common.go
@@ -290,6 +290,26 @@ func (m *Manager) ResizeToActiveScreen() {
 	}
 }
 
+// SetActiveScreenOrigin records the active screen's top-left origin (in global
+// coordinates) so the backend can translate screen-local overlay content — the
+// grid, recursive-grid and hint coordinates, which are normalized to a
+// screen-origin of (0,0) — onto the correct monitor. The Linux overlays span
+// the whole desktop (one X11 window / one layer-shell surface per output), so
+// without this offset that content is always composited at the global origin,
+// i.e. the leftmost monitor.
+func (m *Manager) SetActiveScreenOrigin(origin image.Point) {
+	m.renderMu.Lock()
+	defer m.renderMu.Unlock()
+
+	if m.x11 != nil {
+		m.x11.setOriginOffset(origin)
+	}
+
+	if m.wlroots != nil {
+		m.wlroots.setOriginOffset(origin)
+	}
+}
+
 // SwitchTo switches to a new mode.
 func (m *Manager) SwitchTo(next Mode) {
 	m.mu.Lock()

--- a/internal/ui/overlay/manager_linux_wayland.go
+++ b/internal/ui/overlay/manager_linux_wayland.go
@@ -43,6 +43,7 @@ func (o *wlrootsOverlay) Destroy()                                              
 func (o *wlrootsOverlay) UpdateGridMatches(string)                               {}
 func (o *wlrootsOverlay) ShowSubgrid(*domainGrid.Cell, gridcomponent.Style)      {}
 func (o *wlrootsOverlay) SetHideUnmatched(bool)                                  {}
+func (o *wlrootsOverlay) setOriginOffset(image.Point)                            {}
 func (o *wlrootsOverlay) DrawGrid(*domainGrid.Grid, string, gridcomponent.Style) {}
 func (o *wlrootsOverlay) DrawHints([]*hintscomponent.Hint, hintscomponent.StyleMode) {
 }

--- a/internal/ui/overlay/manager_linux_wayland_cgo.go
+++ b/internal/ui/overlay/manager_linux_wayland_cgo.go
@@ -38,6 +38,13 @@ type wlrootsOverlay struct {
 	cachedGrid     *domainGrid.Grid
 	cachedStyle    gridcomponent.Style
 
+	// originOffset is the active screen's top-left origin in global
+	// coordinates. Grid, recursive-grid and hint content arrives in
+	// screen-local coordinates (origin 0,0); adding this offset places it on
+	// the correct output of the desktop-spanning surface. Absolute-coordinate
+	// draws (badges, monitor_select, the click indicator) do not apply it.
+	originOffset image.Point
+
 	displayMu *sync.Mutex
 
 	stopCh chan struct{}
@@ -215,6 +222,13 @@ func (o *wlrootsOverlay) DrawRecursiveGridWithSubKeyPreview(
 		return
 	}
 
+	// Translate the screen-local bounds and virtual-pointer position onto the
+	// active output. Everything downstream (cell rects, animation from/to
+	// rects, the pointer) derives from these, so the whole frame lands on the
+	// right monitor.
+	bounds = o.offset(bounds)
+	virtualPointer.Position = virtualPointer.Position.Add(o.originOffset)
+
 	C.neru_wayland_overlay_setup_buffers(o.raw)
 	shouldAnimate := animEnabled && o.hasLast && depth != o.lastDepth &&
 		!o.lastBounds.Empty()
@@ -352,12 +366,15 @@ func (o *wlrootsOverlay) DrawHints(
 	C.neru_wayland_overlay_clear(o.raw)
 	fontSize := float64(max(style.FontSize(), 1))
 	for _, hint := range hintsSlice {
+		// hint.Position() is the element center in screen-local coordinates;
+		// translate it onto the active output.
+		pos := hint.Position().Add(o.originOffset)
 		if style.BoundaryHighlightEnabled() {
 			boundary := image.Rect(
-				hint.Position().X-hint.Size().X/2,
-				hint.Position().Y-hint.Size().Y/2,
-				hint.Position().X+hint.Size().X/2,
-				hint.Position().Y+hint.Size().Y/2,
+				pos.X-hint.Size().X/2,
+				pos.Y-hint.Size().Y/2,
+				pos.X+hint.Size().X/2,
+				pos.Y+hint.Size().Y/2,
 			)
 			o.drawRect(
 				boundary,
@@ -385,12 +402,12 @@ func (o *wlrootsOverlay) DrawHints(
 		// Cap the radius so a top/bottom badge keeps a flat edge for the tail.
 		radius = hintBadgeRadius(radius, badgeWidth, style.Placement())
 
-		// hint.Position() is the element center (set in modes/hints.go). The
-		// badge is centered horizontally on it and placed above / on / below the
-		// center to match macOS; top/bottom placement also draws a connector
-		// arrow pointing back at the target.
+		// pos is the element center (set in modes/hints.go). The badge is
+		// centered horizontally on it and placed above / on / below the center
+		// to match macOS; top/bottom placement also draws a connector arrow
+		// pointing back at the target.
 		badge, arrow, hasArrow := hintBadgePlacement(
-			hint.Position(), badgeWidth, badgeHeight, radius, style.Placement(),
+			pos, badgeWidth, badgeHeight, radius, style.Placement(),
 		)
 
 		fill := parseHexColor(style.BackgroundColor())
@@ -978,8 +995,9 @@ func (o *wlrootsOverlay) redrawGrid() {
 			text = style.MatchedTextColor
 			border = style.MatchedBorderColor
 		}
-		o.drawRect(cell.Bounds(), fill, border, style.LineWidth)
-		o.drawTextCentered(label, cell.Bounds(),
+		cellBounds := o.offset(cell.Bounds())
+		o.drawRect(cellBounds, fill, border, style.LineWidth)
+		o.drawTextCentered(label, cellBounds,
 			style.LabelFontName, style.LabelFontSize, text)
 	}
 
@@ -990,6 +1008,8 @@ func (o *wlrootsOverlay) redrawGrid() {
 }
 
 func (o *wlrootsOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Style) {
+	// bounds is screen-local; place the subgrid on the active output.
+	bounds = o.offset(bounds)
 	keyRunes := []rune("ASDFGHJKL")
 	if o.sublayerKeys != "" {
 		keyRunes = []rune(strings.ToUpper(o.sublayerKeys))
@@ -1037,6 +1057,21 @@ func (o *wlrootsOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent
 			index++
 		}
 	}
+}
+
+// setOriginOffset stores the active screen origin used to translate
+// screen-local grid/recursive-grid/hint coordinates onto the correct output.
+func (o *wlrootsOverlay) setOriginOffset(origin image.Point) {
+	if o == nil {
+		return
+	}
+
+	o.originOffset = origin
+}
+
+// offset translates a screen-local rectangle into global desktop coordinates.
+func (o *wlrootsOverlay) offset(r image.Rectangle) image.Rectangle {
+	return r.Add(o.originOffset)
 }
 
 func (o *wlrootsOverlay) drawRect(

--- a/internal/ui/overlay/manager_linux_x11.go
+++ b/internal/ui/overlay/manager_linux_x11.go
@@ -42,6 +42,13 @@ type x11Overlay struct {
 	cachedGrid     *domainGrid.Grid
 	cachedStyle    gridcomponent.Style
 
+	// originOffset is the active screen's top-left origin in global device
+	// pixels. Grid, recursive-grid and hint content arrives in screen-local
+	// coordinates (origin 0,0); adding this offset places it on the correct
+	// monitor of the desktop-spanning overlay window. Absolute-coordinate draws
+	// (badges, monitor_select, the click indicator) do not apply it.
+	originOffset image.Point
+
 	renderMu *sync.Mutex
 
 	cancelMu         sync.Mutex
@@ -207,6 +214,13 @@ func (o *x11Overlay) DrawRecursiveGridWithSubKeyPreview(
 		return
 	}
 
+	// Translate the screen-local bounds and virtual-pointer position onto the
+	// active monitor. Everything downstream (cell rects, animation from/to
+	// rects, the pointer) derives from these, so the whole frame lands on the
+	// right monitor.
+	bounds = o.offset(bounds)
+	virtualPointer.Position = virtualPointer.Position.Add(o.originOffset)
+
 	shouldAnimate := animEnabled && o.hasLast && depth != o.lastDepth &&
 		!o.lastBounds.Empty()
 
@@ -334,12 +348,15 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 	C.neru_x11_overlay_clear(o.raw)
 	fontSize := float64(max(style.FontSize(), 1))
 	for _, hint := range hintsSlice {
+		// hint.Position() is the element center in screen-local coordinates;
+		// translate it onto the active monitor.
+		pos := hint.Position().Add(o.originOffset)
 		if style.BoundaryHighlightEnabled() {
 			boundary := image.Rect(
-				hint.Position().X-hint.Size().X/2,
-				hint.Position().Y-hint.Size().Y/2,
-				hint.Position().X+hint.Size().X/2,
-				hint.Position().Y+hint.Size().Y/2,
+				pos.X-hint.Size().X/2,
+				pos.Y-hint.Size().Y/2,
+				pos.X+hint.Size().X/2,
+				pos.Y+hint.Size().Y/2,
 			)
 			o.drawRect(
 				boundary,
@@ -371,12 +388,12 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 		// Cap the radius so a top/bottom badge keeps a flat edge for the tail.
 		radius = hintBadgeRadius(radius, badgeWidth, style.Placement())
 
-		// hint.Position() is the element center (set in modes/hints.go). The
-		// badge is centered horizontally on it and placed above / on / below the
-		// center to match macOS; top/bottom placement also draws a connector
-		// arrow pointing back at the target.
+		// pos is the element center (set in modes/hints.go). The badge is
+		// centered horizontally on it and placed above / on / below the center
+		// to match macOS; top/bottom placement also draws a connector arrow
+		// pointing back at the target.
 		badge, arrow, hasArrow := hintBadgePlacement(
-			hint.Position(), badgeWidth, badgeHeight, radius, style.Placement(),
+			pos, badgeWidth, badgeHeight, radius, style.Placement(),
 		)
 
 		fill := parseHexColor(style.BackgroundColor())
@@ -846,8 +863,9 @@ func (o *x11Overlay) redrawGrid() {
 			text = style.MatchedTextColor
 			border = style.MatchedBorderColor
 		}
-		o.drawRect(cell.Bounds(), fill, border, style.LineWidth)
-		o.drawTextCentered(label, cell.Bounds(),
+		cellBounds := o.offset(cell.Bounds())
+		o.drawRect(cellBounds, fill, border, style.LineWidth)
+		o.drawTextCentered(label, cellBounds,
 			style.LabelFontName, style.LabelFontSize, text)
 	}
 
@@ -858,6 +876,8 @@ func (o *x11Overlay) redrawGrid() {
 }
 
 func (o *x11Overlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Style) {
+	// bounds is screen-local; place the subgrid on the active monitor.
+	bounds = o.offset(bounds)
 	keyRunes := []rune("ASDFGHJKL")
 	if o.sublayerKeys != "" {
 		keyRunes = []rune(strings.ToUpper(o.sublayerKeys))
@@ -910,6 +930,21 @@ func (o *x11Overlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Sty
 // Stroke widths scale with the HiDPI factor here so every draw path (grid,
 // hints, badges, indicator) gets consistent line weight without per-call-site
 // scaling. Element geometry that must fit scaled text is sized by the callers.
+// setOriginOffset stores the active screen origin used to translate
+// screen-local grid/recursive-grid/hint coordinates onto the correct monitor.
+func (o *x11Overlay) setOriginOffset(origin image.Point) {
+	if o == nil {
+		return
+	}
+
+	o.originOffset = origin
+}
+
+// offset translates a screen-local rectangle into global desktop coordinates.
+func (o *x11Overlay) offset(r image.Rectangle) image.Rectangle {
+	return r.Add(o.originOffset)
+}
+
 func (o *x11Overlay) drawRect(
 	bounds image.Rectangle,
 	fill uint32, border uint32, lineWidth float64,

--- a/internal/ui/overlay/manager_linux_x11_nocgo.go
+++ b/internal/ui/overlay/manager_linux_x11_nocgo.go
@@ -37,6 +37,7 @@ func (o *x11Overlay) Destroy()                                               {}
 func (o *x11Overlay) UpdateGridMatches(string)                               {}
 func (o *x11Overlay) ShowSubgrid(*domainGrid.Cell, gridcomponent.Style)      {}
 func (o *x11Overlay) SetHideUnmatched(bool)                                  {}
+func (o *x11Overlay) setOriginOffset(image.Point)                            {}
 func (o *x11Overlay) DrawGrid(*domainGrid.Grid, string, gridcomponent.Style) {}
 func (o *x11Overlay) DrawHints([]*hintscomponent.Hint, hintscomponent.StyleMode) {
 }

--- a/internal/ui/overlay/manager_windows.go
+++ b/internal/ui/overlay/manager_windows.go
@@ -177,6 +177,11 @@ func (m *Manager) ResizeToActiveScreen() {
 	}
 }
 
+// SetActiveScreenOrigin is a no-op on Windows. The overlay window is resized
+// and repositioned to the active screen, so its content uses window-local
+// coordinates and needs no global translation.
+func (m *Manager) SetActiveScreenOrigin(_ image.Point) {}
+
 // ActiveScreenBounds returns the overlay window bounds in screen coordinates.
 func (m *Manager) ActiveScreenBounds() (image.Rectangle, bool) {
 	m.renderMu.Lock()

--- a/internal/ui/overlay/types.go
+++ b/internal/ui/overlay/types.go
@@ -73,6 +73,9 @@ func (n *NoOpManager) ClearCache() {}
 // ResizeToActiveScreen is a no-op implementation.
 func (n *NoOpManager) ResizeToActiveScreen() {}
 
+// SetActiveScreenOrigin is a no-op implementation.
+func (n *NoOpManager) SetActiveScreenOrigin(origin image.Point) {}
+
 // SwitchTo is a no-op implementation.
 func (n *NoOpManager) SwitchTo(next Mode) {}
 
@@ -225,6 +228,13 @@ type ManagerInterface interface {
 	Clear()
 	ClearCache()
 	ResizeToActiveScreen()
+	// SetActiveScreenOrigin informs the overlay of the active screen's
+	// top-left origin in global coordinates. Backends whose overlay surfaces
+	// span the whole desktop (Linux X11 / Wayland) use it to translate the
+	// screen-local coordinates of grid, recursive-grid and hint content onto
+	// the correct monitor. It is a no-op where each screen has its own overlay
+	// window positioned at the screen origin (macOS).
+	SetActiveScreenOrigin(origin image.Point)
 	SwitchTo(next Mode)
 	Subscribe(fn func(StateChange)) uint64
 	Unsubscribe(id uint64)


### PR DESCRIPTION
## Description

The grid, recursive-grid and hint overlays are built in **screen-local** coordinates (normalized to a screen origin of `0,0`). That contract is macOS-shaped: each screen owns its own overlay window positioned at the screen origin, so local coordinates land correctly.

The Linux backends composite in **global desktop** coordinates instead — a single X11 window spanning the whole virtual desktop, or one wlroots `layer-shell` surface per output that converts global coordinates to surface-local. With no origin applied, screen-local content is always drawn at global `(0,0)`, i.e. the **leftmost monitor**, regardless of which monitor was selected (via `monitor_select` or the cursor). This matches the report exactly: the grid was *sized* to the selected monitor (portrait vs landscape respected) but *composited* on the wrong output. `monitor_select` panels and the mode/sticky badges already work because they are drawn in absolute coordinates.

The fix threads the active screen's global origin down to the Linux overlays via a new `ManagerInterface.SetActiveScreenOrigin`, and translates the screen-local coordinates of grid, recursive-grid, subgrid and hint draws by it in both the X11 and wlroots backends.

- `SetActiveScreenOrigin` is a **no-op on macOS/Windows**, whose overlay windows are already positioned per-screen.
- `Handler.setScreenBounds` becomes the single choke point: every place that updates `h.screenBounds` now also informs the overlay of the new origin.
- Absolute-coordinate draws (mode/sticky badges, `monitor_select` panels, the click indicator) are deliberately left untouched.

This also fixes the same latent bug for **hints** and the **X11** backend (both share the identical screen-local contract), not just wlroots grid/recursive-grid.

## Related Issues

Fixes #1126

## Target Platform

- [x] Linux
- [ ] macOS *(no-op path added, unchanged behavior)*

## Type of Change

- [x] `fix` — Bug fix

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags
- [x] No darwin imports from untagged (shared) code
- [x] N/A — no new unsupported capability (existing behavior corrected; no `CodeNotSupported` surface change)

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`golangci-lint` on touched packages — 0 issues)
- [x] Tests pass (`go test ./internal/app/... ./internal/ui/...`)
- [x] Build succeeds (linux/arm64 cgo, linux nocgo, windows cross-build)
- [x] Commit messages follow conventional commits

## Additional Context

Implementation notes:
- For recursive-grid the offset is applied once at the top of `DrawRecursiveGridWithSubKeyPreview` (to `bounds` and `virtualPointer.Position`); everything downstream — cell rects, animation from/to rects, `lastBounds`/`lastRects` — derives from those, so the whole animated frame stays consistent.
- For the grid the offset is applied to each cell rect and once to the subgrid bounds; for hints, once to the element-center position each badge derives from.
