### PR TITLE
feat(linux): feed keys through uinput when /dev/uinput is writable

### DIFF
--- a/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
+++ b/internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go
@@ -69,6 +69,16 @@ const waylandEvdevBusVirtual = 0x06
 
 var knownVirtualDevices = []string{"kanata"}
 
+// neruInjectionDevicePrefix identifies Neru's own synthetic uinput devices
+// (e.g. "neru-keyboard" from key feeding, "neru-scroll"). Capture must never
+// grab these: grabbing our injection keyboard would swallow fed keys before
+// they reach the focused app.
+const neruInjectionDevicePrefix = "neru-"
+
+func isNeruInjectionDevice(name string) bool {
+	return strings.HasPrefix(strings.ToLower(name), neruInjectionDevicePrefix)
+}
+
 func isUinputVirtualDevice(fd C.int, name string) bool {
 	bustype := int(C.neru_evdev_get_bustype(fd))
 	if bustype == waylandEvdevBusVirtual {
@@ -401,7 +411,7 @@ func (capture *waylandEvdevCapture) findVirtualDevice() *os.File {
 		}
 
 		name := C.GoString(&deviceName[0])
-		if !isUinputVirtualDevice(fileDescriptor, name) {
+		if !isUinputVirtualDevice(fileDescriptor, name) || isNeruInjectionDevice(name) {
 			_ = file.Close()
 
 			continue
@@ -1367,6 +1377,13 @@ var (
 	errUinputScroll  error
 )
 
+// uinputScrollMu serializes writes to the shared scroll device fd. A single
+// ScrollDeviceScroll emits three separate write() calls (hi-res, lo-res, SYN);
+// without this lock, two concurrent scroll requests (each on its own IPC
+// goroutine) could interleave those writes and deliver a malformed event
+// stream.
+var uinputScrollMu sync.Mutex
+
 func initUinputScroll() error {
 	var fd C.int
 	if C.neru_uinput_create_scroll(&fd) == 0 {
@@ -1397,11 +1414,15 @@ func IsUinputScrollAvailable() bool {
 
 // ScrollDeviceScroll sends a scroll event via the uinput virtual device.
 func ScrollDeviceScroll(axis, value int) error {
-	fd, err := getUinputScrollFd()
+	scrollFd, err := getUinputScrollFd()
 	if err != nil {
 		return err
 	}
-	if C.neru_uinput_scroll(C.int(fd), C.int(axis), C.int(value)) == 0 {
+
+	uinputScrollMu.Lock()
+	defer uinputScrollMu.Unlock()
+
+	if C.neru_uinput_scroll(C.int(scrollFd), C.int(axis), C.int(value)) == 0 {
 		return fmt.Errorf("%w", errUinputScrollSend)
 	}
 
@@ -1423,6 +1444,9 @@ func ScrollDeviceScrollBatch(axis int, values []int) error {
 	for i, v := range values {
 		cValues[i] = C.int(v)
 	}
+
+	uinputScrollMu.Lock()
+	defer uinputScrollMu.Unlock()
 
 	if C.neru_uinput_scroll_batch(
 		C.int(ufd),

--- a/internal/core/infra/platform/linux/evdev.c
+++ b/internal/core/infra/platform/linux/evdev.c
@@ -205,3 +205,69 @@ int neru_uinput_scroll_batch(int fd, int axis, int *values, int count) {
 	free(events);
 	return (written == (ssize_t)total) ? 1 : 0;
 }
+
+int neru_uinput_create_keyboard(int *out_fd) {
+	int fd = open("/dev/uinput", O_RDWR);
+	if (fd < 0) {
+		fd = open("/dev/input/uinput", O_RDWR);
+	}
+	if (fd < 0) {
+		return 0;
+	}
+
+	if (ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0 || ioctl(fd, UI_SET_EVBIT, EV_SYN) < 0) {
+		close(fd);
+		return 0;
+	}
+
+	// Advertise the full keyboard keycode range so any code a feed sequence
+	// emits (letters, digits, function keys, modifiers, punctuation) is a
+	// valid event on this device. KEY_MAX bounds the evdev keycode space.
+	for (int code = 1; code < KEY_MAX; code++) {
+		if (ioctl(fd, UI_SET_KEYBIT, code) < 0) {
+			close(fd);
+			return 0;
+		}
+	}
+
+	struct uinput_setup usetup;
+	memset(&usetup, 0, sizeof(usetup));
+	// BUS_VIRTUAL marks this device as synthetic so Neru's own evdev capture
+	// (isUinputVirtualDevice) skips it — otherwise EVIOCGRAB would grab our
+	// injected keys and loop them straight back into the event tap.
+	usetup.id.bustype = BUS_VIRTUAL;
+	usetup.id.vendor = 0x1234;
+	usetup.id.product = 0x5679;
+	strcpy(usetup.name, "neru-keyboard");
+	if (ioctl(fd, UI_DEV_SETUP, &usetup) < 0) {
+		close(fd);
+		return 0;
+	}
+	if (ioctl(fd, UI_DEV_CREATE) < 0) {
+		close(fd);
+		return 0;
+	}
+
+	*out_fd = fd;
+	return 1;
+}
+
+int neru_uinput_key(int fd, int keycode, int pressed) {
+	if (fd < 0)
+		return 0;
+
+	struct input_event ev;
+	memset(&ev, 0, sizeof(ev));
+	ev.type = EV_KEY;
+	ev.code = (unsigned short)keycode;
+	ev.value = pressed ? 1 : 0;
+	ssize_t w1 = write(fd, &ev, sizeof(ev));
+
+	memset(&ev, 0, sizeof(ev));
+	ev.type = EV_SYN;
+	ev.code = SYN_REPORT;
+	ev.value = 0;
+	ssize_t w2 = write(fd, &ev, sizeof(ev));
+
+	return (w1 == sizeof(ev) && w2 == sizeof(ev)) ? 1 : 0;
+}

--- a/internal/core/infra/platform/linux/evdev.c
+++ b/internal/core/infra/platform/linux/evdev.c
@@ -256,18 +256,21 @@ int neru_uinput_key(int fd, int keycode, int pressed) {
 	if (fd < 0)
 		return 0;
 
-	struct input_event ev;
-	memset(&ev, 0, sizeof(ev));
-	ev.type = EV_KEY;
-	ev.code = (unsigned short)keycode;
-	ev.value = pressed ? 1 : 0;
-	ssize_t w1 = write(fd, &ev, sizeof(ev));
+	// Emit the key event and its SYN_REPORT in a single write so the pair is
+	// submitted atomically. If they were separate writes, a key-down could land
+	// while its SYN failed, leaving the event buffered until a later SYN
+	// committed it — latching the key even though this call reported failure.
+	struct input_event ev[2];
+	memset(ev, 0, sizeof(ev));
 
-	memset(&ev, 0, sizeof(ev));
-	ev.type = EV_SYN;
-	ev.code = SYN_REPORT;
-	ev.value = 0;
-	ssize_t w2 = write(fd, &ev, sizeof(ev));
+	ev[0].type = EV_KEY;
+	ev[0].code = (unsigned short)keycode;
+	ev[0].value = pressed ? 1 : 0;
 
-	return (w1 == sizeof(ev) && w2 == sizeof(ev)) ? 1 : 0;
+	ev[1].type = EV_SYN;
+	ev[1].code = SYN_REPORT;
+	ev[1].value = 0;
+
+	ssize_t written = write(fd, ev, sizeof(ev));
+	return (written == (ssize_t)sizeof(ev)) ? 1 : 0;
 }

--- a/internal/core/infra/platform/linux/evdev.h
+++ b/internal/core/infra/platform/linux/evdev.h
@@ -16,5 +16,7 @@ int neru_evdev_get_pressed_keys(int fd, unsigned int *out_keys, int max_keys);
 int neru_uinput_create_scroll(int *out_fd);
 int neru_uinput_scroll(int fd, int axis, int value);
 int neru_uinput_scroll_batch(int fd, int axis, int *values, int count);
+int neru_uinput_create_keyboard(int *out_fd);
+int neru_uinput_key(int fd, int keycode, int pressed);
 
 #endif /* EVDEV_H */

--- a/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_keyfeed.go
@@ -112,6 +112,14 @@ func FeedKey(key string) error {
 		return err
 	}
 
+	// Prefer the uinput virtual keyboard when /dev/uinput is writable: it works
+	// uniformly across X11, wlroots, and KWin and avoids the compositor-specific
+	// protocols (KDE's RemoteDesktop portal in particular). Only when we lack
+	// evdev injection access do we fall back to the compositor backends.
+	if uinputKeyboardAvailable() {
+		return feedKeyUinput(modifiers, keycode)
+	}
+
 	hasVKB, err := wlrootsHasVirtualKeyboard()
 	if err != nil {
 		return err
@@ -122,6 +130,29 @@ func FeedKey(key string) error {
 	}
 
 	return feedKeyLibei(modifiers, keycode)
+}
+
+// uinputModifierCodes resolves canonical modifier names (as produced by
+// parseKeyString) to their evdev keycodes for uinput injection, preserving
+// order. It reuses libeiModifierKeycodes, which is a provider-agnostic
+// modifier-name→keycode table despite its name.
+func uinputModifierCodes(modifiers []string) ([]int, error) {
+	codes := make([]int, 0, len(modifiers))
+
+	for _, modifier := range modifiers {
+		code, ok := libeiModifierKeycodes[modifier]
+		if !ok {
+			return nil, derrors.Newf(
+				derrors.CodeNotSupported,
+				"unsupported modifier %q for uinput injection",
+				modifier,
+			)
+		}
+
+		codes = append(codes, code)
+	}
+
+	return codes, nil
 }
 
 func feedKeyWlroots(modifiers []string, keycode uint32) error {

--- a/internal/core/infra/platform/linux/system_linux_wayland_keyfeed_uinput_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_keyfeed_uinput_cgo.go
@@ -1,0 +1,128 @@
+//go:build linux && cgo
+
+package linux
+
+/*
+#include "evdev.h"
+*/
+import "C"
+
+import (
+	"errors"
+	"slices"
+	"sync"
+
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+)
+
+// uinput keyboard injection. When /dev/uinput is writable, `action feed` posts
+// keystrokes through a synthetic keyboard device instead of the compositor's
+// virtual-keyboard / libei protocols. The device enters the input stack below
+// libinput, so the compositor routes the keys to the focused surface exactly
+// like a physical keypress — uniformly across X11, wlroots, and KWin — and
+// sidesteps the fragile RemoteDesktop portal consent path on KDE.
+//
+// The device is created lazily on first use and reused for the process
+// lifetime. It is tagged BUS_VIRTUAL so Neru's own evdev capture skips it (see
+// isUinputVirtualDevice); otherwise an active EVIOCGRAB would grab our injected
+// keys and loop them back into the event tap.
+
+var errUinputKeyboardSend = errors.New("failed to send uinput key event")
+
+var (
+	uinputKeyboardOnce sync.Once
+	uinputKeyboardFd   C.int
+	errUinputKeyboard  error
+)
+
+// uinputKeyboardMu serializes chord emission. The events forming one chord
+// (modifier-down… key down/up… modifier-up) are separate write() calls to the
+// shared device fd; without this lock, two concurrent feeds could interleave
+// their writes and deliver a garbled chord.
+var uinputKeyboardMu sync.Mutex
+
+// ensureUinputKeyboard creates the synthetic keyboard device on first call and
+// caches the result. A creation failure (typically /dev/uinput not writable) is
+// remembered so callers fall through to the compositor backends.
+func ensureUinputKeyboard() error {
+	uinputKeyboardOnce.Do(func() {
+		var deviceFd C.int
+		if C.neru_uinput_create_keyboard(&deviceFd) == 0 {
+			errUinputKeyboard = derrors.New(
+				derrors.CodeNotSupported,
+				"uinput keyboard unavailable: /dev/uinput is not writable "+
+					"(add a udev rule or the input group to grant access)",
+			)
+
+			return
+		}
+
+		uinputKeyboardFd = deviceFd
+	})
+
+	return errUinputKeyboard
+}
+
+// uinputKeyboardAvailable reports whether keystrokes can be fed through the
+// uinput virtual keyboard, creating the device on first call.
+func uinputKeyboardAvailable() bool {
+	return ensureUinputKeyboard() == nil
+}
+
+// feedKeyUinput injects a key chord through the uinput virtual keyboard: press
+// modifiers in order, press and release the main key, then release modifiers in
+// reverse order. Each modifier is emitted on our own device; because libinput
+// tracks key state per device, releasing our modifier never clears one the user
+// is still physically holding.
+func feedKeyUinput(modifiers []string, keycode uint32) error {
+	err := ensureUinputKeyboard()
+	if err != nil {
+		return err
+	}
+
+	codes, err := uinputModifierCodes(modifiers)
+	if err != nil {
+		return err
+	}
+
+	// Hold the lock across the whole emit sequence so the chord's events reach
+	// the device fd contiguously, never interleaved with a concurrent feed.
+	uinputKeyboardMu.Lock()
+	defer uinputKeyboardMu.Unlock()
+
+	pressed := make([]int, 0, len(codes))
+
+	for _, code := range codes {
+		if C.neru_uinput_key(uinputKeyboardFd, C.int(code), 1) == 0 {
+			releaseUinputKeys(pressed)
+
+			return errUinputKeyboardSend
+		}
+
+		pressed = append(pressed, code)
+	}
+
+	// The app acts on the key-down, so only the down gates success; a failed
+	// key-up leaves only cleanup pending.
+	downOK := C.neru_uinput_key(uinputKeyboardFd, C.int(keycode), 1) != 0
+	if downOK {
+		_ = C.neru_uinput_key(uinputKeyboardFd, C.int(keycode), 0)
+	}
+
+	releaseUinputKeys(pressed)
+
+	if !downOK {
+		return errUinputKeyboardSend
+	}
+
+	return nil
+}
+
+// releaseUinputKeys releases the given keycodes in reverse press order. Errors
+// are ignored: a release failure only risks a latched virtual key, and there is
+// no recovery beyond retrying the same failing write.
+func releaseUinputKeys(codes []int) {
+	for _, code := range slices.Backward(codes) {
+		_ = C.neru_uinput_key(uinputKeyboardFd, C.int(code), 0)
+	}
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland_keyfeed_uinput_cgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_keyfeed_uinput_cgo.go
@@ -27,7 +27,10 @@ import (
 // isUinputVirtualDevice); otherwise an active EVIOCGRAB would grab our injected
 // keys and loop them back into the event tap.
 
-var errUinputKeyboardSend = errors.New("failed to send uinput key event")
+var (
+	errUinputKeyboardSend    = errors.New("failed to send uinput key event")
+	errUinputKeyboardRelease = errors.New("failed to release uinput key (key may be latched)")
+)
 
 var (
 	uinputKeyboardOnce sync.Once
@@ -94,7 +97,7 @@ func feedKeyUinput(modifiers []string, keycode uint32) error {
 
 	for _, code := range codes {
 		if C.neru_uinput_key(uinputKeyboardFd, C.int(code), 1) == 0 {
-			releaseUinputKeys(pressed)
+			_ = releaseUinputKeys(pressed)
 
 			return errUinputKeyboardSend
 		}
@@ -102,27 +105,42 @@ func feedKeyUinput(modifiers []string, keycode uint32) error {
 		pressed = append(pressed, code)
 	}
 
-	// The app acts on the key-down, so only the down gates success; a failed
-	// key-up leaves only cleanup pending.
-	downOK := C.neru_uinput_key(uinputKeyboardFd, C.int(keycode), 1) != 0
-	if downOK {
-		_ = C.neru_uinput_key(uinputKeyboardFd, C.int(keycode), 0)
+	// A failed key-down means nothing was delivered: unwind the modifiers and
+	// report failure.
+	if C.neru_uinput_key(uinputKeyboardFd, C.int(keycode), 1) == 0 {
+		_ = releaseUinputKeys(pressed)
+
+		return errUinputKeyboardSend
 	}
 
-	releaseUinputKeys(pressed)
+	// The chord is delivered on the key-down; now release the main key and the
+	// modifiers. Always attempt every release so one failure can't strand the
+	// rest down, and surface any failure — a discarded release would leave a
+	// key latched on the reused device and silently corrupt later input.
+	releasedOK := C.neru_uinput_key(uinputKeyboardFd, C.int(keycode), 0) != 0
+	if !releaseUinputKeys(pressed) {
+		releasedOK = false
+	}
 
-	if !downOK {
-		return errUinputKeyboardSend
+	if !releasedOK {
+		return errUinputKeyboardRelease
 	}
 
 	return nil
 }
 
-// releaseUinputKeys releases the given keycodes in reverse press order. Errors
-// are ignored: a release failure only risks a latched virtual key, and there is
-// no recovery beyond retrying the same failing write.
-func releaseUinputKeys(codes []int) {
+// releaseUinputKeys releases the given keycodes in reverse press order,
+// attempting every release even when one fails, and reports whether all
+// succeeded. A failed release leaves a key latched on the reused device, so
+// callers surface it rather than assuming a clean chord.
+func releaseUinputKeys(codes []int) bool {
+	allReleased := true
+
 	for _, code := range slices.Backward(codes) {
-		_ = C.neru_uinput_key(uinputKeyboardFd, C.int(code), 0)
+		if C.neru_uinput_key(uinputKeyboardFd, C.int(code), 0) == 0 {
+			allReleased = false
+		}
 	}
+
+	return allReleased
 }

--- a/internal/core/infra/platform/linux/system_linux_wayland_keyfeed_uinput_nocgo.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_keyfeed_uinput_nocgo.go
@@ -1,0 +1,21 @@
+//go:build linux && !cgo
+
+package linux
+
+import derrors "github.com/y3owk1n/neru/internal/core/errors"
+
+// uinputKeyboardAvailable is always false without CGO — the uinput device is
+// driven by the native bridge, so FeedKey falls through to the compositor
+// backends (which are themselves CGO-only and report CodeNotSupported here).
+func uinputKeyboardAvailable() bool {
+	return false
+}
+
+func feedKeyUinput(modifiers []string, keycode uint32) error {
+	_, _ = modifiers, keycode
+
+	return derrors.New(
+		derrors.CodeNotSupported,
+		"uinput keyboard requires CGO-enabled Linux builds",
+	)
+}

--- a/internal/core/infra/platform/linux/system_linux_wayland_keyfeed_uinput_test.go
+++ b/internal/core/infra/platform/linux/system_linux_wayland_keyfeed_uinput_test.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+//nolint:testpackage // Exercises the unexported uinput modifier-mapping helper directly.
+package linux
+
+import (
+	"testing"
+
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+)
+
+func TestUinputModifierCodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		modifiers []string
+		want      []int
+	}{
+		{name: "none", modifiers: nil, want: []int{}},
+		{name: "ctrl", modifiers: []string{modNameCtrl}, want: []int{keycodeLeftCtrl}},
+		{
+			name:      "ctrl+shift preserves order",
+			modifiers: []string{modNameCtrl, modNameShift},
+			want:      []int{keycodeLeftCtrl, keycodeLeftShift},
+		},
+		{
+			name:      "all four",
+			modifiers: []string{modNameShift, modNameCtrl, modNameAlt, modNameCmd},
+			want:      []int{keycodeLeftShift, keycodeLeftCtrl, keycodeLeftAlt, keycodeLeftMeta},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := uinputModifierCodes(testCase.modifiers)
+			if err != nil {
+				t.Fatalf("uinputModifierCodes(%v) returned error: %v", testCase.modifiers, err)
+			}
+
+			if len(got) != len(testCase.want) {
+				t.Fatalf("length = %d, want %d (%v)", len(got), len(testCase.want), got)
+			}
+
+			for i := range got {
+				if got[i] != testCase.want[i] {
+					t.Fatalf("codes = %v, want %v", got, testCase.want)
+				}
+			}
+		})
+	}
+}
+
+func TestUinputModifierCodesUnknown(t *testing.T) {
+	t.Parallel()
+
+	_, err := uinputModifierCodes([]string{"hyper"})
+	if err == nil {
+		t.Fatal("expected error for unknown modifier, got nil")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeNotSupported) {
+		t.Fatalf("error code = %v, want CodeNotSupported", err)
+	}
+}

--- a/internal/core/infra/platform/profile_linux.go
+++ b/internal/core/infra/platform/profile_linux.go
@@ -27,7 +27,8 @@ func linuxKDEProfile() Profile {
 			Name: "evdev from /dev/input (requires input group; bind triggers in KDE System Settings)",
 		},
 		KeyboardCapture: BackendPlan{
-			Name: "evdev capture + libei input via RemoteDesktop portal (consent per daemon launch)",
+			Name: "evdev capture + key injection via uinput when /dev/uinput is writable, " +
+				"else libei via RemoteDesktop portal (consent per daemon launch)",
 		},
 		Overlay: BackendPlan{
 			Name: "wlr-layer-shell via KWin",


### PR DESCRIPTION
## Description

This PR makes Linux `action feed` inject keystrokes through a synthetic uinput keyboard device when it has evdev access, falling back to the compositor virtual-keyboard / libei backends only when that access is missing. This works uniformly across X11, wlroots, and KWin — closing the prior gap where feed errored out on pure X11 sessions and avoiding KDE's fragile RemoteDesktop portal path.

## Related Issues

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The injection device is tagged `BUS_VIRTUAL` and excluded by name from evdev capture, so grabbed keys never loop back into the event tap. Chord emission is serialized against concurrent feeds, and the pre-existing uinput scroll device — previously the last unserialized shared-fd injection path — is serialized to match.