### PR TITLE
feat(modes): add `--on-exit` flag to modes

### DIFF
--- a/internal/app/components/grid/context.go
+++ b/internal/app/components/grid/context.go
@@ -11,6 +11,7 @@ import (
 type baseContext struct {
 	pendingAction         *string
 	pendingModifier       *string
+	onExit                *string
 	repeat                bool
 	cursorFollowSelection bool
 	selectedPoint         image.Point
@@ -25,6 +26,17 @@ func (c *baseContext) SetPendingAction(action *string) {
 // PendingAction returns the pending action to execute.
 func (c *baseContext) PendingAction() *string {
 	return c.pendingAction
+}
+
+// SetOnExit sets the action string to run when the pending action is fulfilled
+// and the mode exits back to idle through the action path.
+func (c *baseContext) SetOnExit(onExit *string) {
+	c.onExit = onExit
+}
+
+// OnExit returns the action string to run once the pending action is fulfilled.
+func (c *baseContext) OnExit() *string {
+	return c.onExit
 }
 
 // SetPendingModifier sets the modifier keys to apply when the pending action fires.
@@ -85,6 +97,7 @@ func (c *baseContext) SelectionPoint() (image.Point, bool) {
 func (c *baseContext) Reset() {
 	c.pendingAction = nil
 	c.pendingModifier = nil
+	c.onExit = nil
 	c.repeat = false
 	c.cursorFollowSelection = false
 	c.ClearSelectionPoint()

--- a/internal/app/components/hints/context.go
+++ b/internal/app/components/hints/context.go
@@ -9,6 +9,7 @@ import (
 type baseContext struct {
 	pendingAction          *string
 	pendingModifier        *string
+	onExit                 *string
 	repeat                 bool
 	cursorFollowSelection  bool
 	filterRoles            []string
@@ -27,6 +28,17 @@ func (c *baseContext) SetPendingAction(action *string) {
 // PendingAction returns the pending action to execute.
 func (c *baseContext) PendingAction() *string {
 	return c.pendingAction
+}
+
+// SetOnExit sets the action string to run when the pending action is fulfilled
+// and the mode exits back to idle through the action path.
+func (c *baseContext) SetOnExit(onExit *string) {
+	c.onExit = onExit
+}
+
+// OnExit returns the action string to run once the pending action is fulfilled.
+func (c *baseContext) OnExit() *string {
+	return c.onExit
 }
 
 // SetPendingModifier sets the modifier keys to apply when the pending action fires.
@@ -70,6 +82,7 @@ func (c *baseContext) ToggleCursorFollowSelection() bool {
 func (c *baseContext) Reset() {
 	c.pendingAction = nil
 	c.pendingModifier = nil
+	c.onExit = nil
 	c.repeat = false
 	c.cursorFollowSelection = false
 	c.filterRoles = nil

--- a/internal/app/components/recursivegrid/component.go
+++ b/internal/app/components/recursivegrid/component.go
@@ -11,6 +11,7 @@ import (
 type baseContext struct {
 	pendingAction         *string
 	pendingModifier       *string
+	onExit                *string
 	repeat                bool
 	cursorFollowSelection bool
 	selectedPoint         image.Point
@@ -25,6 +26,17 @@ func (c *baseContext) SetPendingAction(action *string) {
 // PendingAction returns the pending action to execute.
 func (c *baseContext) PendingAction() *string {
 	return c.pendingAction
+}
+
+// SetOnExit sets the action string to run when the pending action is fulfilled
+// and the mode exits back to idle through the action path.
+func (c *baseContext) SetOnExit(onExit *string) {
+	c.onExit = onExit
+}
+
+// OnExit returns the action string to run once the pending action is fulfilled.
+func (c *baseContext) OnExit() *string {
+	return c.onExit
 }
 
 // SetPendingModifier sets the modifier keys to apply when the pending action fires.
@@ -85,6 +97,7 @@ func (c *baseContext) SelectionPoint() (image.Point, bool) {
 func (c *baseContext) Reset() {
 	c.pendingAction = nil
 	c.pendingModifier = nil
+	c.onExit = nil
 	c.repeat = false
 	c.cursorFollowSelection = false
 	c.ClearSelectionPoint()

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -153,6 +153,7 @@ func (h *IPCControllerModes) modesUnavailableResponse() ipc.Response {
 type ModeActivationOptions struct {
 	Action                *string
 	Modifier              *string
+	OnExit                *string
 	Repeat                *bool
 	CursorFollowSelection *bool
 	ZoomToDepth           *int
@@ -310,6 +311,23 @@ func (h *IPCControllerModes) extractModeOptions(
 			startIdx++
 			actionArg := cmd.Args[startIdx]
 			opts.Action = &actionArg
+		case strings.HasPrefix(arg, "--on-exit="):
+			onExitArg := strings.TrimPrefix(arg, "--on-exit=")
+			opts.OnExit = &onExitArg
+		case arg == "--on-exit":
+			if startIdx+1 >= len(cmd.Args) {
+				resp := ipc.Response{
+					Success: false,
+					Message: "--on-exit requires a value",
+					Code:    ipc.CodeInvalidInput,
+				}
+
+				return opts, &resp
+			}
+
+			startIdx++
+			onExitArg := cmd.Args[startIdx]
+			opts.OnExit = &onExitArg
 		case strings.HasPrefix(arg, "--cursor-selection-mode="):
 			val, resp := parseCursorSelectionModeValue(
 				strings.TrimPrefix(arg, "--cursor-selection-mode="),
@@ -610,6 +628,7 @@ func (h *IPCControllerModes) handleHints(ctx context.Context, cmd ipc.Command) i
 	h.modes.ActivateModeWithOptions(domain.ModeHints, modes.ModeActivationOptions{
 		Action:                opts.Action,
 		Modifier:              opts.Modifier,
+		OnExit:                opts.OnExit,
 		Repeat:                opts.Repeat,
 		CursorFollowSelection: opts.CursorFollowSelection,
 		FilterRoles:           opts.FilterRoles,
@@ -638,6 +657,7 @@ func (h *IPCControllerModes) handleGrid(_ context.Context, cmd ipc.Command) ipc.
 	h.modes.ActivateModeWithOptions(domain.ModeGrid, modes.ModeActivationOptions{
 		Action:                opts.Action,
 		Modifier:              opts.Modifier,
+		OnExit:                opts.OnExit,
 		Repeat:                opts.Repeat,
 		CursorFollowSelection: opts.CursorFollowSelection,
 		Toggle:                opts.Toggle,
@@ -659,6 +679,7 @@ func (h *IPCControllerModes) handleRecursiveGrid(_ context.Context, cmd ipc.Comm
 	h.modes.ActivateModeWithOptions(domain.ModeRecursiveGrid, modes.ModeActivationOptions{
 		Action:                opts.Action,
 		Modifier:              opts.Modifier,
+		OnExit:                opts.OnExit,
 		Repeat:                opts.Repeat,
 		CursorFollowSelection: opts.CursorFollowSelection,
 		ZoomToDepth:           opts.ZoomToDepth,

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -93,6 +93,7 @@ func (h *Handler) cleanupGridMode() {
 	// Nilling it causes a nil-pointer dereference on re-activation
 	// when SetGridInstanceValue dereferences the pointer.
 	h.grid.Context.SetPendingAction(nil)
+	h.grid.Context.SetOnExit(nil)
 	h.grid.Context.SetRepeat(false)
 
 	if h.grid.Manager != nil {

--- a/internal/app/modes/generic_mode.go
+++ b/internal/app/modes/generic_mode.go
@@ -57,6 +57,7 @@ func (m *GenericMode) Activate(opts ModeActivationOptions) {
 				opts.Strategy,
 				opts.LabelDirection,
 				opts.SplitWord,
+				opts.OnExit,
 			)
 		case domain.ModeGrid:
 			m.handler.activateGridModeWithAction(
@@ -64,6 +65,7 @@ func (m *GenericMode) Activate(opts ModeActivationOptions) {
 				opts.Modifier,
 				opts.Repeat,
 				opts.CursorFollowSelection,
+				opts.OnExit,
 			)
 		case domain.ModeRecursiveGrid:
 			m.handler.activateRecursiveGridModeWithAction(
@@ -72,6 +74,7 @@ func (m *GenericMode) Activate(opts ModeActivationOptions) {
 				opts.Repeat,
 				opts.CursorFollowSelection,
 				nil, // zoom is not re-applied on screen change
+				opts.OnExit,
 			)
 		case domain.ModeScroll:
 			m.handler.StartInteractiveScroll()

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -20,6 +20,7 @@ func (h *Handler) activateGridModeWithAction(
 	modifier *string,
 	repeat *bool,
 	cursorFollowSelection *bool,
+	onExit *string,
 ) {
 	// Detect refresh before validation so we can do partial cleanup on re-activation.
 	isRefresh := h.appState.CurrentMode() == domain.ModeGrid
@@ -94,6 +95,10 @@ func (h *Handler) activateGridModeWithAction(
 			h.grid.Context.SetPendingAction(actionStr)
 		}
 
+		if onExit != nil {
+			h.grid.Context.SetOnExit(onExit)
+		}
+
 		if modifier != nil {
 			h.grid.Context.SetPendingModifier(modifier)
 		}
@@ -107,6 +112,7 @@ func (h *Handler) activateGridModeWithAction(
 		}
 	} else {
 		h.grid.Context.SetPendingAction(actionStr)
+		h.grid.Context.SetOnExit(onExit)
 		h.grid.Context.SetPendingModifier(modifier)
 		h.grid.Context.SetRepeat(repeat != nil && *repeat)
 		h.grid.Context.SetCursorFollowSelection(resolveCursorFollowSelection(

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -803,6 +803,7 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool, executeAction bo
 				&strategyOverride,
 				&labelDirectionOverride,
 				&splitWord,
+				nil, // preserve the stored --on-exit action across re-activation
 			)
 
 			// Restore state so subsequent cycles continue to execute the action

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -38,6 +38,7 @@ func (h *Handler) currentHintStyleLocked() hints.StyleMode {
 type ModeActivationOptions struct {
 	Action                *string
 	Modifier              *string
+	OnExit                *string
 	Repeat                *bool
 	CursorFollowSelection *bool
 	ZoomToDepth           *int
@@ -143,6 +144,7 @@ func (h *Handler) activateHintModeWithAction(
 	strategy *string,
 	labelDirection *string,
 	splitWord *bool,
+	onExit *string,
 ) {
 	h.activateHintModeInternal(
 		action,
@@ -155,6 +157,7 @@ func (h *Handler) activateHintModeWithAction(
 		strategy,
 		labelDirection,
 		splitWord,
+		onExit,
 	)
 
 	// Store repeat flag after activation so the context is already initialized.
@@ -178,6 +181,7 @@ func (h *Handler) activateHintModeInternal(
 	strategyOverride *string,
 	labelDirectionOverride *string,
 	splitWordOverride *bool,
+	onExit *string,
 ) {
 	// Detect refresh before validation so we can clean up on failure
 	isRefresh := h.appState.CurrentMode() == domain.ModeHints
@@ -269,6 +273,10 @@ func (h *Handler) activateHintModeInternal(
 				h.hints.Context.SetPendingAction(actionStr)
 			}
 
+			if onExit != nil {
+				h.hints.Context.SetOnExit(onExit)
+			}
+
 			if modifier != nil {
 				h.hints.Context.SetPendingModifier(modifier)
 			}
@@ -306,6 +314,7 @@ func (h *Handler) activateHintModeInternal(
 			}
 		} else {
 			h.hints.Context.SetPendingAction(actionStr)
+			h.hints.Context.SetOnExit(onExit)
 			h.hints.Context.SetPendingModifier(modifier)
 			h.hints.Context.SetRepeat(false)
 			h.hints.Context.SetCursorFollowSelection(resolveCursorFollowSelection(

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -94,6 +94,20 @@ func (h *Handler) ActivateModeWithOptions(mode domain.Mode, opts ModeActivationO
 		return
 	}
 
+	// Normalize --on-exit for external (re-)activations. This method is the sole
+	// entry point for user-driven activations (IPC, hotkeys, systray); internal
+	// refreshes (repeat re-activation, space/screen change, cycle) bypass it and
+	// call the activate* helpers directly with a nil onExit to preserve the
+	// stored callback. An omitted --on-exit on a fresh external command must
+	// clear any callback left over from a prior activation of the same mode
+	// rather than inheriting it, so a later completed action does not run a stale
+	// command. A nil pointer here means "clear"; the empty value is a no-op at
+	// dispatch time.
+	if opts.OnExit == nil {
+		empty := ""
+		opts.OnExit = &empty
+	}
+
 	modeImpl.Activate(opts)
 }
 

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/ui/coordinates"
 )
 
@@ -128,7 +129,77 @@ func (h *Handler) executeActionAtPoint(
 		h.appState.SetModeExitReason(state.ModeExitReasonCompleted)
 	}
 
+	// Capture the mode's --on-exit action before exitModeLocked clears the
+	// context. It only runs when the action chain was fulfilled and the mode
+	// idled through this action path — never on manual escape or a switch.
+	onExit := h.currentModeOnExit()
+
 	h.exitModeLocked()
+
+	if !chainFailed {
+		h.runOnExit(onExit)
+	}
+}
+
+// currentModeOnExit returns the --on-exit action configured for the currently
+// active action mode, or nil when none is set or the mode has no context.
+func (h *Handler) currentModeOnExit() *string {
+	switch h.appState.CurrentMode() {
+	case domain.ModeHints:
+		if h.hints != nil && h.hints.Context != nil {
+			return h.hints.Context.OnExit()
+		}
+	case domain.ModeGrid:
+		if h.grid != nil && h.grid.Context != nil {
+			return h.grid.Context.OnExit()
+		}
+	case domain.ModeRecursiveGrid:
+		if h.recursiveGrid != nil && h.recursiveGrid.Context != nil {
+			return h.recursiveGrid.Context.OnExit()
+		}
+	case domain.ModeIdle, domain.ModeScroll, domain.ModeMonitorSelect:
+		// These modes do not support a pending --action, so there is no
+		// --on-exit action to run.
+	}
+
+	return nil
+}
+
+// runOnExit dispatches the mode's --on-exit action after the pending action was
+// fulfilled. It reuses the hotkey action grammar ("action ...", "exec ...",
+// mode names) and runs asynchronously: executeHotkeyAction may route back
+// through IPC into ActivateModeWithOptions, which acquires h.mu — held by the
+// executeActionAtPoint caller.
+func (h *Handler) runOnExit(onExit *string) {
+	if onExit == nil || h.executeHotkeyAction == nil {
+		return
+	}
+
+	actionStr := strings.TrimSpace(*onExit)
+	if actionStr == "" {
+		return
+	}
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				h.logger.Error("panic in on-exit handler",
+					zap.Any("recover", r),
+					zap.String("action", actionStr))
+			}
+		}()
+
+		err := h.executeHotkeyAction("on-exit", actionStr)
+		if err != nil {
+			if derrors.IsCode(err, derrors.CodeChainBail) {
+				return
+			}
+
+			h.logger.Error("on-exit action failed",
+				zap.String("action", actionStr),
+				zap.Error(err))
+		}
+	}()
 }
 
 // moveCursorAndHandleAction moves the cursor to a point and executes any pending action.
@@ -213,6 +284,7 @@ func (h *Handler) handleHintsModeKey(key string) {
 					&strategyOverride,
 					&labelDirectionOverride,
 					&splitWord,
+					nil, // preserve the stored --on-exit action across re-activation
 				)
 				// Restore repeat, action and modifier on the fresh context so subsequent
 				// selections continue the repeat cycle.
@@ -507,6 +579,7 @@ func (h *Handler) handleGridModeKey(key string) {
 					pendingModifier,
 					&repeat,
 					&cursorFollowSelection,
+					nil, // preserve the stored --on-exit action across re-activation
 				)
 			},
 		)

--- a/internal/app/modes/mode_handlers_test.go
+++ b/internal/app/modes/mode_handlers_test.go
@@ -4,9 +4,15 @@ package modes
 import (
 	"image"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/app/components"
+	"github.com/y3owk1n/neru/internal/app/components/grid"
+	"github.com/y3owk1n/neru/internal/app/components/hints"
+	"github.com/y3owk1n/neru/internal/app/components/recursivegrid"
+	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
 )
 
@@ -20,6 +26,100 @@ func TestExecuteActionAtPoint_NilActionNoop(t *testing.T) {
 
 	if handler.cursorState.WasActionPerformed() {
 		t.Fatal("expected no action state change for nil action")
+	}
+}
+
+func TestRunOnExit_DispatchesActionString(t *testing.T) {
+	got := make(chan string, 1)
+	handler := &Handler{
+		logger: zap.NewNop(),
+		executeHotkeyAction: func(_, actionStr string) error {
+			got <- actionStr
+
+			return nil
+		},
+	}
+
+	onExit := "exec notify-send done"
+	handler.runOnExit(&onExit)
+
+	select {
+	case a := <-got:
+		if a != onExit {
+			t.Fatalf("on-exit dispatched %q, want %q", a, onExit)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("on-exit action was not dispatched")
+	}
+}
+
+func TestRunOnExit_NilAndEmptyNoop(t *testing.T) {
+	called := make(chan struct{}, 1)
+	handler := &Handler{
+		logger: zap.NewNop(),
+		executeHotkeyAction: func(_, _ string) error {
+			called <- struct{}{}
+
+			return nil
+		},
+	}
+
+	handler.runOnExit(nil)
+
+	blank := "   "
+	handler.runOnExit(&blank)
+
+	select {
+	case <-called:
+		t.Fatal("on-exit should not dispatch for nil or blank action")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestCurrentModeOnExit(t *testing.T) {
+	hintsExit := "action left_click"
+	gridExit := "exec grid-done"
+	rgExit := domain.ModeString(domain.ModeRecursiveGrid)
+
+	hintsCtx := &hints.Context{}
+	hintsCtx.SetOnExit(&hintsExit)
+
+	gridCtx := &grid.Context{}
+	gridCtx.SetOnExit(&gridExit)
+
+	rgCtx := &recursivegrid.Context{}
+	rgCtx.SetOnExit(&rgExit)
+
+	appState := state.NewAppState()
+	handler := &Handler{
+		appState:      appState,
+		hints:         &components.HintsComponent{Context: hintsCtx},
+		grid:          &components.GridComponent{Context: gridCtx},
+		recursiveGrid: &components.RecursiveGridComponent{Context: rgCtx},
+	}
+
+	cases := []struct {
+		mode domain.Mode
+		want string
+	}{
+		{domain.ModeHints, hintsExit},
+		{domain.ModeGrid, gridExit},
+		{domain.ModeRecursiveGrid, rgExit},
+	}
+	for _, testCase := range cases {
+		appState.SetMode(testCase.mode)
+
+		got := handler.currentModeOnExit()
+		if got == nil || *got != testCase.want {
+			t.Fatalf("currentModeOnExit() for %v = %v, want %q",
+				testCase.mode, got, testCase.want)
+		}
+	}
+
+	appState.SetMode(domain.ModeScroll)
+
+	if got := handler.currentModeOnExit(); got != nil {
+		t.Fatalf("currentModeOnExit() for non-action mode = %v, want nil", got)
 	}
 }
 

--- a/internal/app/modes/mode_handlers_test.go
+++ b/internal/app/modes/mode_handlers_test.go
@@ -76,6 +76,48 @@ func TestRunOnExit_NilAndEmptyNoop(t *testing.T) {
 	}
 }
 
+// optsRecordingMode is a minimal Mode used to capture the options an external
+// activation passes through ActivateModeWithOptions.
+type optsRecordingMode struct {
+	modeType domain.Mode
+	lastOpts ModeActivationOptions
+}
+
+func (m *optsRecordingMode) Activate(opts ModeActivationOptions) { m.lastOpts = opts }
+func (m *optsRecordingMode) HandleKey(string)                    {}
+func (m *optsRecordingMode) Exit()                               {}
+func (m *optsRecordingMode) ModeType() domain.Mode               { return m.modeType }
+
+func TestActivateModeWithOptions_OmittedOnExitClearsStaleCallback(t *testing.T) {
+	fake := &optsRecordingMode{modeType: domain.ModeGrid}
+	handler := &Handler{
+		logger:   zap.NewNop(),
+		appState: state.NewAppState(),
+		modes:    map[domain.Mode]Mode{domain.ModeGrid: fake},
+	}
+
+	// An external activation that omits --on-exit must reach the mode with a
+	// non-nil, empty OnExit so the refresh branch clears any stored callback
+	// rather than preserving it.
+	handler.ActivateModeWithOptions(domain.ModeGrid, ModeActivationOptions{})
+
+	if fake.lastOpts.OnExit == nil {
+		t.Fatal("expected omitted --on-exit to be normalized to a non-nil clear value")
+	}
+
+	if *fake.lastOpts.OnExit != "" {
+		t.Fatalf("expected normalized on-exit to be empty, got %q", *fake.lastOpts.OnExit)
+	}
+
+	// An explicit --on-exit must pass through untouched.
+	want := "exec foo"
+	handler.ActivateModeWithOptions(domain.ModeGrid, ModeActivationOptions{OnExit: &want})
+
+	if fake.lastOpts.OnExit == nil || *fake.lastOpts.OnExit != want {
+		t.Fatalf("expected on-exit %q to pass through, got %v", want, fake.lastOpts.OnExit)
+	}
+}
+
 func TestCurrentModeOnExit(t *testing.T) {
 	hintsExit := "action left_click"
 	gridExit := "exec grid-done"

--- a/internal/app/modes/passthrough.go
+++ b/internal/app/modes/passthrough.go
@@ -198,6 +198,7 @@ func (h *Handler) handlePassthroughLocked(mode domain.Mode, session uint64) {
 			&strategyOverride,
 			&labelDirectionOverride,
 			&splitWord,
+			nil, // preserve the stored --on-exit action across refresh
 		)
 	})
 	h.refreshHintsTimer = timer

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -24,6 +24,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 	repeat *bool,
 	cursorFollowSelection *bool,
 	zoomToDepth *int,
+	onExit *string,
 ) {
 	// Detect refresh before validation so we can do partial cleanup on re-activation.
 	isRefresh := h.appState.CurrentMode() == domain.ModeRecursiveGrid
@@ -129,6 +130,10 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 				h.recursiveGrid.Context.SetPendingAction(actionStr)
 			}
 
+			if onExit != nil {
+				h.recursiveGrid.Context.SetOnExit(onExit)
+			}
+
 			if modifier != nil {
 				h.recursiveGrid.Context.SetPendingModifier(modifier)
 			}
@@ -142,6 +147,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 			}
 		} else {
 			h.recursiveGrid.Context.SetPendingAction(actionStr)
+			h.recursiveGrid.Context.SetOnExit(onExit)
 			h.recursiveGrid.Context.SetPendingModifier(modifier)
 			h.recursiveGrid.Context.SetRepeat(repeat != nil && *repeat)
 			h.recursiveGrid.Context.SetCursorFollowSelection(cursorShouldFollow)
@@ -286,6 +292,7 @@ func (h *Handler) handleRecursiveGridKey(key string) {
 					&repeat,
 					&cursorFollowSelection,
 					nil, // zoom is not re-applied on repeat
+					nil, // preserve the stored --on-exit action across re-activation
 				)
 			},
 		)

--- a/internal/app/modes/recursive_grid_mode.go
+++ b/internal/app/modes/recursive_grid_mode.go
@@ -19,6 +19,7 @@ func NewRecursiveGridMode(handler *Handler) *RecursiveGridMode {
 				opts.Repeat,
 				opts.CursorFollowSelection,
 				opts.ZoomToDepth,
+				opts.OnExit,
 			)
 		},
 		HandleKeyFunc: func(handler *Handler, key string) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -18,6 +19,7 @@ const (
 	cliTestAction    = "action"
 	cliTestStatus    = "status"
 	cliTestLeftClick = "left_click"
+	cliTestRecursive = "recursive_grid"
 )
 
 // Helper to get command by name from RootCmd.
@@ -283,6 +285,34 @@ func TestCommandExecutionWithoutDaemon(t *testing.T) {
 	// launchd service). On other platforms they return
 	// CodeNotSupported. Their registration is already verified by
 	// TestCommandInitialization.
+}
+
+func TestModeCommand_OnExitRequiresAction(t *testing.T) {
+	for _, name := range []string{cliTestHints, cliTestGrid, cliTestRecursive} {
+		t.Run(name, func(t *testing.T) {
+			cmd := getCmd(name)
+			if cmd == nil {
+				t.Fatalf("command %q not found", name)
+			}
+
+			setErr := cmd.Flags().Set("on-exit", "exec notify-send done")
+			if setErr != nil {
+				t.Fatalf("failed to set --on-exit: %v", setErr)
+			}
+			// Reset the shared flag so later tests are unaffected.
+			defer func() {
+				resetErr := cmd.Flags().Set("on-exit", "")
+				if resetErr != nil {
+					t.Fatalf("failed to reset --on-exit: %v", resetErr)
+				}
+			}()
+
+			err := cmd.RunE(cmd, []string{})
+			if err == nil || !strings.Contains(err.Error(), "--on-exit requires --action") {
+				t.Fatalf("expected --on-exit requires --action error, got %v", err)
+			}
+		})
+	}
 }
 
 func TestLaunchCommandExecution(t *testing.T) {

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -61,6 +61,11 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				return err
 			}
 
+			onExitFlag, err := cmd.Flags().GetString("on-exit")
+			if err != nil {
+				return err
+			}
+
 			repeatFlag, err := cmd.Flags().GetBool("repeat")
 			if err != nil {
 				return err
@@ -159,6 +164,13 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				)
 			}
 
+			if strings.TrimSpace(onExitFlag) != "" && actionFlag == "" {
+				return derrors.New(
+					derrors.CodeInvalidInput,
+					"--on-exit requires --action (it runs only when the action is fulfilled)",
+				)
+			}
+
 			if hideOnEmptySearchFlag && !searchFlag {
 				return derrors.New(
 					derrors.CodeInvalidInput,
@@ -246,6 +258,10 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 
 			if modifierFlag != "" {
 				params = append(params, "--modifier="+modifierFlag)
+			}
+
+			if strings.TrimSpace(onExitFlag) != "" {
+				params = append(params, "--on-exit="+onExitFlag)
 			}
 
 			if repeatFlag {
@@ -337,6 +353,11 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 		"modifier",
 		"",
 		"Comma-separated modifier keys to hold during action (cmd, super, meta, shift, alt, option, ctrl) (requires --action)",
+	)
+	cmd.Flags().String(
+		"on-exit",
+		"",
+		"Command to run after the action is fulfilled and the mode exits (same syntax as hotkeys, e.g. 'action left_click' or 'exec notify-send done'). Requires --action; not run on manual escape/idle",
 	)
 	cmd.Flags().String(
 		"cursor-selection-mode",


### PR DESCRIPTION
## Description

This PR adds an `--on-exit` flag to the `hints`, `grid`, and `recursive_grid` modes that runs an arbitrary command — using the same grammar as hotkeys (`action ...` or `exec ...`) — after the mode's `--action` is fulfilled and the mode returns to idle through that action path. It fires only on action fulfillment (never on manual escape/idle, mode-switch, refresh, or during `--repeat`) and requires `--action`.

## Related Issues

<!-- none -->

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

`--on-exit` dispatch reuses the existing hotkey action bridge and runs asynchronously so it can safely re-enter mode activation without re-entrant lock contention.