### PR TITLE
fix(config): accept comma-separated action chains in hotkey bindings

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -414,6 +414,7 @@ All actions available in hotkeys. These also work as `neru action <name>` — se
 | Cursor      | `hide_cursor`, `show_cursor`                                                           |
 
 - Click actions accept `--state down` / `--state up` to press and release the button as separate hotkeys, and `--toggle` to do whichever comes next from a single hotkey. `"action right_click --state down"` and `"action right_mouse_down"` are the same action written two ways; the flag form is the documented spelling, and the name form is what a mode `--action` takes (`hints --action right_mouse_down`)
+- Click actions can be chained with commas to produce multi-click sequences at one target point: `"action left_click,left_click"` double-clicks, `"action left_click,left_click,left_click"` triple-clicks. Only mouse button actions are allowed in a chain, and the names must not be separated by spaces (see [CLI.md](CLI.md#12a-left_click-right_click-middle_click))
 - Any button Neru is holding is released automatically when it returns to idle
 - `mouse_down` and `mouse_up` are the original spellings of `left_mouse_down` and `left_mouse_up`. They still work in configs, but new configs should use the explicit names
 - Use `--bare` (e.g. `"action left_click --bare"`) to target the cursor position instead of the current mode selection (see [CLI.md](CLI.md#12a-left_click-right_click-middle_click))

--- a/internal/config/validators.go
+++ b/internal/config/validators.go
@@ -1462,6 +1462,40 @@ func validOpacity(value float64) bool {
 	return value >= 0 && value <= 1
 }
 
+// validateActionChain validates a comma-separated action chain such as
+// "left_click,left_click". The runtime executes chains at a single target
+// point, so only mouse button actions are accepted (see handleActionChain).
+func validateActionChain(chain string) error {
+	for name := range strings.SplitSeq(chain, ",") {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"empty action in comma-separated list: %s",
+				chain,
+			)
+		}
+
+		if !action.IsKnownName(action.Name(trimmed)) {
+			return derrors.Newf(derrors.CodeInvalidConfig, "unknown action subcommand: %s", trimmed)
+		}
+
+		// Known names without an executable type (sleep, feed, reset, ...) are
+		// not chainable either, so a ToType failure here is a chain violation
+		// rather than an unknown name.
+		actionType, err := action.Name(trimmed).ToType()
+		if err != nil || !actionType.IsMouseButton() {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%s cannot be used in an action chain; only mouse button actions are allowed",
+				trimmed,
+			)
+		}
+	}
+
+	return nil
+}
+
 func validateHotkeyActionString(actionStr string) error {
 	trimmed := strings.TrimSpace(actionStr)
 	if trimmed == "" {
@@ -1479,6 +1513,10 @@ func validateHotkeyActionString(actionStr string) error {
 		}
 
 		name := args[0]
+		if strings.Contains(name, ",") {
+			return validateActionChain(name)
+		}
+
 		if action.IsKnownName(action.Name(name)) {
 			return nil
 		}

--- a/internal/config/validators_hotkey_test.go
+++ b/internal/config/validators_hotkey_test.go
@@ -275,3 +275,96 @@ func TestValidateHotkeyBindings_DuplicateNormalizedKeys(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateHotkeyBindings_ActionChains tests that comma-separated action
+// chains (e.g. "action left_click,left_click") are accepted for mouse button
+// actions and rejected otherwise, matching the runtime chain rules.
+func TestValidateHotkeyBindings_ActionChains(t *testing.T) {
+	tests := []struct {
+		name    string
+		action  string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "double click chain",
+			action:  "action left_click,left_click",
+			wantErr: false,
+		},
+		{
+			name:    "triple click chain",
+			action:  "action left_click,left_click,left_click",
+			wantErr: false,
+		},
+		{
+			name:    "mixed button chain",
+			action:  "action left_click,right_click",
+			wantErr: false,
+		},
+		{
+			name:    "chain with flags",
+			action:  "action left_click,left_click --modifier shift",
+			wantErr: false,
+		},
+		{
+			name:    "chain with unknown action",
+			action:  "action left_click,not_an_action",
+			wantErr: true,
+			errMsg:  "unknown action subcommand: not_an_action",
+		},
+		{
+			name:    "chain with non mouse button action",
+			action:  "action left_click,scroll_down",
+			wantErr: true,
+			errMsg:  "only mouse button actions are allowed",
+		},
+		{
+			// sleep is a known action but has no executable type, so it must be
+			// reported as a chain violation rather than an unknown name.
+			name:    "chain with known but non chainable action",
+			action:  "action left_click,sleep",
+			wantErr: true,
+			errMsg:  "sleep cannot be used in an action chain",
+		},
+		{
+			name:    "chain of button hold actions",
+			action:  "action left_mouse_down,left_mouse_up",
+			wantErr: false,
+		},
+		{
+			name:    "chain of legacy button spellings",
+			action:  "action mouse_down,mouse_up",
+			wantErr: false,
+		},
+		{
+			name:    "chain with empty element",
+			action:  "action left_click,",
+			wantErr: true,
+			errMsg:  "empty action in comma-separated list",
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.Hotkeys.Bindings = map[string][]string{
+				"Ctrl+1": {testCase.action, config.CmdIdle},
+			}
+
+			err := cfg.ValidateHotkeyBindings()
+
+			if (err != nil) != testCase.wantErr {
+				t.Errorf("ValidateHotkeyBindings() error = %v, wantErr %v", err, testCase.wantErr)
+			}
+
+			if testCase.wantErr && testCase.errMsg != "" && err != nil {
+				if !strings.Contains(err.Error(), testCase.errMsg) {
+					t.Errorf(
+						"ValidateHotkeyBindings() error = %v, want error containing %q",
+						err,
+						testCase.errMsg,
+					)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes config files being rejected when a hotkey binding chains click
actions with commas. Writing a double-click as `"action left_click,left_click"`
worked from the command line and over IPC, but the identical string in a config
file failed validation with `unknown action subcommand: left_click,left_click`,
which meant the whole config would not load.

Comma-joined chains are now validated the same way the daemon executes them:
each element must be a known mouse button action. Chains that could never run —
an empty element, an unknown name, or a non-button action such as `scroll_down`
or `sleep` — are still rejected, now with an error that says which element is at
fault and why. This applies to the global `[hotkeys]` table, per-mode
`[<mode>.hotkeys]` tables, and the Mission Control hooks.

Only validation changed; how a chain runs once accepted is untouched.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Configuration Changes

No new options, and existing configs keep working untouched. What changes is
which values an existing option accepts: any hotkey action string may now chain
mouse button actions with commas, matching what `neru action` already accepts.

```toml
[hotkeys]
"Ctrl+1" = ["action left_click,left_click", "action sleep 0.2", "idle"]

[hints.hotkeys]
"d" = "action left_click,left_click,left_click"
```

Constraints on a chain, unchanged from how the daemon executes them:

| Form                                        | Accepted | Why                                            |
| ------------------------------------------- | -------- | ---------------------------------------------- |
| `action left_click,left_click`               | yes      | double-click at one target point               |
| `action left_mouse_down,left_mouse_up`       | yes      | button hold actions are mouse buttons          |
| `action left_click,scroll_down`              | no       | only mouse button actions may be chained       |
| `action left_click,sleep`                    | no       | `sleep` is not executable on its own           |
| `action left_click, left_click`              | no       | names must be comma-joined with no spaces      |

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no platform-specific code
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new platform capability
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The validator deliberately does not inspect flags on a chain, so
`"action left_click,left_click --bail"` passes validation and then fails at
press time — the daemon rejects `--bail` and the coordinate flags in chains.
That matches the surrounding validator, which does not check flags or arguments
for any action, so tightening it is a separate change.

Chained clicks pause briefly between elements so the OS click-counting window
produces a real double- or triple-click. Both hotkey dispatch paths already run
actions on their own goroutine, so that pause does not block the event tap or
hold the mode handler lock.

One case worth noting for a follow-up: a chain passed as a mode action, e.g.
`hints --action left_click,left_click`, is still neither validated nor
supported. That is pre-existing and out of scope here.
