### PR TITLE
docs: rewrite the CLI and configuration references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ For full details see:
 
 - [Development Guide](docs/DEVELOPMENT.md)
 - [System Architecture](docs/ARCHITECTURE.md)
-- [Cross-Platform Contributor Guide](docs/CROSS_PLATFORM.md)
+- [Cross-Platform Guide](docs/CROSS_PLATFORM.md)
 
 ---
 
@@ -162,7 +162,7 @@ Neru is designed as a cross-platform tool with a strong emphasis on architectura
 If you are working on Linux or Windows support:
 
 - Check the current [Platform Status](docs/ARCHITECTURE.md#platform-status) in the architecture guide.
-- Start with the [Cross-Platform Contributor Guide](docs/CROSS_PLATFORM.md).
+- Start with the [Cross-Platform Contributor Guide](docs/CROSS_PLATFORM.md#contributor-guide).
 - Implement in the existing platform slot instead of inventing new file layout.
 - For Linux, prefer the reserved backend files: `*_linux_common.go`, `*_linux_x11.go`, and `*_linux_wayland.go`.
 - Follow the patterns established in the macOS implementation where applicable, but keep macOS-specific assumptions out of shared code.

--- a/README.md
+++ b/README.md
@@ -132,8 +132,13 @@ Five modes, one tool — mix and match as the situation calls for it.
 | **Scroll**            | `Primary+Shift+S`     | Vim-style `j`/`k` scrolling, `u`/`d` for half pages                | Reading docs and code without lifting your hands |
 | **Monitor Select**    | _unbound_             | Labels each display; type a label to jump the cursor there         | Multi-monitor setups                             |
 
-`Primary` is `Cmd` on macOS and `Ctrl` on Linux and Windows. Monitor Select
-ships without a default binding — bind `monitor_select` to any key you like.
+`Primary` is `Cmd` on macOS and `Ctrl` on Windows. Monitor Select ships without
+a default binding — bind `monitor_select` to any key you like.
+
+**On Linux there are no default global hotkeys.** They are cleared at startup to
+avoid colliding with terminal and desktop shortcuts such as `Ctrl+Shift+C`. Bind
+the modes yourself in `[hotkeys]`, or in your compositor — see
+[Global hotkeys on Linux](docs/CONFIGURATION.md#hotkeys).
 
 All bindings are fully remappable — Colemak, Dvorak, whatever you're on. → [Configuration Reference](docs/CONFIGURATION.md#hotkeys)
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Once you're done with the installation, you can just run the `Neru.app` (macOS) 
 
 ## Pick your mode
 
-Four modes, one tool — mix and match as the situation calls for it.
+Five modes, one tool — mix and match as the situation calls for it.
 
 <table>
 <tr>
@@ -124,14 +124,18 @@ Four modes, one tool — mix and match as the situation calls for it.
 </tr>
 </table>
 
-| Mode                  | Hotkey            | How it works                                                       | Best for                                         |
-| :-------------------- | :---------------- | :----------------------------------------------------------------- | :----------------------------------------------- |
-| **Recursive Grid** ⭐ | `Cmd+Shift+C`     | Divides screen into cells; narrow down with home-row keys          | Everything — any app, canvas, or game            |
-| **Hints**             | `Cmd+Shift+Space` | Labels every clickable element via Accessibility API or Vision OCR | Native apps, Electron (VS Code, Slack), Figma    |
-| **Grid**              | `Cmd+Shift+G`     | Jump directly to a cell by row + column label                      | Fast coarse movement across large monitors       |
-| **Scroll**            | `Cmd+Shift+S`     | Vim-style `j`/`k` scrolling, `u`/`d` for half pages                | Reading docs and code without lifting your hands |
+| Mode                  | Default hotkey        | How it works                                                       | Best for                                         |
+| :-------------------- | :-------------------- | :----------------------------------------------------------------- | :----------------------------------------------- |
+| **Recursive Grid** ⭐ | `Primary+Shift+C`     | Divides screen into cells; narrow down with home-row keys          | Everything — any app, canvas, or game            |
+| **Hints**             | `Primary+Shift+Space` | Labels every clickable element via Accessibility API or Vision OCR | Native apps, Electron (VS Code, Slack), Figma    |
+| **Grid**              | `Primary+Shift+G`     | Jump directly to a cell by row + column label                      | Fast coarse movement across large monitors       |
+| **Scroll**            | `Primary+Shift+S`     | Vim-style `j`/`k` scrolling, `u`/`d` for half pages                | Reading docs and code without lifting your hands |
+| **Monitor Select**    | _unbound_             | Labels each display; type a label to jump the cursor there         | Multi-monitor setups                             |
 
-All bindings are fully remappable — Colemak, Dvorak, whatever you're on. → [Configuration Guide](docs/CONFIGURATION.md#hotkeys)
+`Primary` is `Cmd` on macOS and `Ctrl` on Linux and Windows. Monitor Select
+ships without a default binding — bind `monitor_select` to any key you like.
+
+All bindings are fully remappable — Colemak, Dvorak, whatever you're on. → [Configuration Reference](docs/CONFIGURATION.md#hotkeys)
 
 ---
 
@@ -156,7 +160,7 @@ neru config validate  # check for errors before applying
 neru config reload    # apply changes without restarting
 ```
 
-→ [CLI Guide](docs/CLI.md) · [Configuration Guide](docs/CONFIGURATION.md) · [Config Showcases](docs/CONFIG_SHOWCASES.md)
+→ [CLI Reference](docs/CLI.md) · [Configuration Reference](docs/CONFIGURATION.md) · [Config Showcases](docs/CONFIG_SHOWCASES.md)
 
 ---
 
@@ -208,11 +212,20 @@ More modes, more engines, more platforms — and it's free. If you've been payin
 | Recursive Grid            |  ✅   |  ✅   |   ✅    |
 | Grid                      |  ✅   |  ✅   |   ✅    |
 | Vim-Style Scroll          |  ✅   |  ✅   |   ✅    |
-| Hints (Accessibility API) |  ✅   |  🔲   |   ✅    |
+| Hints (Accessibility API) |  ✅   |  🔵   |   🔵    |
 | Hints (Vision OCR)        |  ✅   |  🔲   |   🔲    |
 | Direct Mouse Injection    |  ✅   |  ✅   |   ✅    |
 | Global Hotkeys            |  ✅   |  ✅   |   ✅    |
 | Native Overlays           |  ✅   |  ✅   |   ✅    |
+| Monitor Select            |  ✅   |  ✅   |   🔲    |
+
+✅ full · 🔵 works with limits · 🔲 not available
+
+**Hints caveats.** On **Linux**, hints work through AT-SPI, so coverage depends
+on the app exposing an accessibility tree (GTK/Qt do; Chromium and Electron apps
+need `--force-renderer-accessibility`). On **Windows**, UI Automation coverage is
+initial and the tree walk is shallow. **Linux requires X11 or Wayland on
+wlroots/KWin — GNOME Wayland is not supported**; use a GNOME X11 session.
 
 → [Roadmap](docs/ROADMAP.md) · [Cross-platform details](docs/CROSS_PLATFORM.md)
 
@@ -222,15 +235,18 @@ More modes, more engines, more platforms — and it's free. If you've been payin
 
 Everything you need to go deep:
 
-| Guide                                      | What's in it                                          |
-| :----------------------------------------- | :---------------------------------------------------- |
-| [Installation](docs/INSTALLATION.md)       | Homebrew, Nix, prebuilt binaries, source, permissions |
-| [CLI](docs/CLI.md)                         | Every command and flag                                |
-| [Configuration](docs/CONFIGURATION.md)     | Keybindings, themes, overlays, all settings           |
-| [Tips & Tricks](docs/TIPS_TRICKS.md)       | Power-user patterns and setups                        |
-| [Troubleshooting](docs/TROUBLESHOOTING.md) | Common issues and fixes                               |
-| [Roadmap](docs/ROADMAP.md)                 | What's coming                                         |
-| [Contributing](CONTRIBUTING.md)            | PRs and bug reports                                   |
+| Guide                                          | What's in it                                              |
+| :--------------------------------------------- | :-------------------------------------------------------- |
+| [Installation](docs/INSTALLATION.md)           | Homebrew, Nix, prebuilt binaries, source, permissions     |
+| [CLI Reference](docs/CLI.md)                   | Every command, flag, and argument                         |
+| [Configuration Reference](docs/CONFIGURATION.md) | Every option, with types, defaults, and platform support |
+| [Tips & Tricks](docs/TIPS_TRICKS.md)           | Worked configuration recipes                              |
+| [Config Showcases](docs/CONFIG_SHOWCASES.md)   | Real setups shared by the community                       |
+| [Troubleshooting](docs/TROUBLESHOOTING.md)     | Common issues and fixes                                   |
+| [Cross-Platform Guide](docs/CROSS_PLATFORM.md) | What works on each platform, and how it is implemented    |
+| [Linux Setup](docs/LINUX_SETUP.md)             | Dependencies, permissions, and per-desktop notes          |
+| [Roadmap](docs/ROADMAP.md)                     | What's coming                                             |
+| [Contributing](CONTRIBUTING.md)                | PRs and bug reports                                       |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,13 @@
-# Neru System Architecture
+# Architecture
 
-Neru is a keyboard-driven navigation tool for macOS (with Linux and Windows support in progress) built with Go and Objective-C. It enhances productivity by allowing users to quickly navigate and interact with UI elements using keyboard shortcuts.
+How Neru is structured internally: layers, boundaries, data flow, and the rules
+that keep platform code isolated.
+
+Neru is a keyboard-driven navigation tool written in Go with an Objective-C
+bridge on macOS. It runs as a daemon with a thin CLI client.
+
+**Related:** [Cross-Platform Guide](CROSS_PLATFORM.md) ·
+[Development Guide](DEVELOPMENT.md) · [Coding Standards](CODING_STANDARDS.md)
 
 ---
 
@@ -68,22 +75,22 @@ Violation of this rule is caught by `golangci-lint` using `depguard`.
 
 ## Platform Status
 
-> **Note:** This table is a quick-reference overview. For the full detailed
-> feature-level comparison, see [CROSS_PLATFORM.md](./CROSS_PLATFORM.md#feature-parity-reference).
+> **Note:** This is a one-paragraph-per-platform orientation. The authoritative
+> per-capability comparison — including per-Linux-backend detail — lives in
+> [CROSS_PLATFORM.md](./CROSS_PLATFORM.md#feature-parity-reference). Do not
+> duplicate that matrix here.
 
-| Capability               | macOS | Linux (X11) | Linux (wlroots) | Linux (KDE) | Linux (GNOME) | Windows  |
-| ------------------------ | ----- | ----------- | --------------- | ----------- | ------------- | -------- |
-| Screen bounds / cursor   | ✅    | ✅          | ✅              | ✅          | ✅            | ✅       |
-| Global hotkeys           | ✅    | ✅          | ✅              | ✅          | ❌            | ✅       |
-| Keyboard event tap       | ✅    | ✅          | ✅              | ✅          | ❌            | ✅       |
-| Accessibility (elements) | ✅    | 🟡 (AT-SPI) | 🟡 (AT-SPI)     | 🟡 (AT-SPI) | 🟡 (AT-SPI)   | ✅ (UIA) |
-| UI overlays              | ✅    | ✅          | ✅              | ✅          | ❌            | ✅       |
-| App watcher              | ✅    | 🟡          | 🟡              | 🟡          | 🟡            | 🟡       |
-| Dark mode detection      | ✅    | ✅          | ✅              | ✅          | ✅            | ✅       |
-| Notifications / alerts   | ✅    | 🟡          | 🟡              | 🟡          | 🟡            | 🟡       |
-| Config / log directories | ✅    | ✅          | ✅              | ✅          | ✅            | ✅       |
+| Platform    | Status           | Runtime backends                              | Notes                                                       |
+| ----------- | ---------------- | --------------------------------------------- | ----------------------------------------------------------- |
+| **macOS**   | Production-ready | Cocoa / Quartz (CGO)                          | Reference implementation; no known functional gaps           |
+| **Linux**   | Beta             | `x11`, `wayland-wlroots`, `wayland-kde`       | All modes work; notifications/alerts are stubs              |
+| **Windows** | Alpha            | Win32 / COM (pure Go)                         | Modes work; app watcher, notifications, `monitor_select` are stubs |
 
-✅ = Supported 🟡 = Stub (code exists, returns `CodeNotSupported`) ❌ = Not available
+**GNOME Wayland (`wayland-gnome`), unrecognized compositors (`wayland-other`),
+and sessions with neither `WAYLAND_DISPLAY` nor `DISPLAY` are not supported.**
+`platform.NewSystemPort` returns `CodeNotSupported` for them during the first
+initialization phase, so the daemon exits rather than running degraded. Under
+GNOME, use an X11 session.
 
 ---
 
@@ -114,8 +121,10 @@ Platform work should stay in these layers:
 - `internal/core/infra/hotkeys/`: global hotkey registration
 - `internal/core/infra/eventtap/`: keyboard event capture
 - `internal/core/infra/accessibility/`: platform accessibility integration
-- `internal/ui/overlay/`: overlay manager orchestration
-- `internal/app/components/*/overlay_*.go`: mode-specific overlay rendering
+- `internal/ui/overlay/`: overlay manager orchestration — **and all Linux and
+  Windows drawing**, which happens in the manager rather than per component
+- `internal/app/components/*/overlay_*.go`: mode-specific overlay rendering on
+  **macOS only**; the Linux and Windows files in these packages are style-only stubs
 
 Shared logic should stay in:
 
@@ -424,15 +433,16 @@ Neru uses `just` for build automation.
 
 - **GitHub Actions**: Runs linting, unit tests, and integration tests on every PR.
 - **Release Please**: Automatically manages versioning and generates GitHub releases upon merging to `main`.
-- **Cross-Compilation**: Go's native cross-compilation is used for Linux and Windows binaries (with `CGO_ENABLED=0`).
+- **Cross-Compilation**: Windows binaries cross-compile with `CGO_ENABLED=0`. Linux builds require `CGO_ENABLED=1` (X11/Wayland native backends) and must therefore run on a Linux host; macOS likewise requires CGO.
 
 ---
 
 ## Performance Considerations
 
 1. **Event Tap Latency**: The event tap callback is kept extremely lean to prevent system-wide keyboard lag. Heavy processing is deferred to Go routines.
-2. **Accessibility Caching**: Querying the macOS Accessibility API is expensive. Neru implements intelligent caching in the [accessibility/cache.go](../internal/core/infra/accessibility/cache.go) to minimize IPC overhead.
-3. **Native Rendering**: Overlays are rendered using native Cocoa APIs for GPU-accelerated, flicker-free UI.
+2. **Bounded accessibility walks**: Querying accessibility APIs is expensive, so tree traversal is bounded rather than exhaustive — `maxDepth` limits on the macOS walk ([client.go](../internal/core/infra/accessibility/client.go)) and depth/node caps on the Linux AT-SPI walk (`atspiMaxDepth` / `atspiMaxNodes` in [atspi_linux.go](../internal/core/infra/accessibility/atspi_linux.go)).
+3. **Caching**: A TTL/LRU cache for computed grid layouts ([grid/cache.go](../internal/core/domain/grid/cache.go)) and a cache of C string pointers for overlay styles ([style_cache.go](../internal/app/components/overlayutil/style_cache.go)) keep repeated activations off the hot path.
+4. **Native Rendering**: Overlays are rendered using native platform APIs — GPU-accelerated CoreAnimation on macOS, Cairo on Linux, GDI on Windows.
 
 ---
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -207,7 +207,7 @@ listed under each command.
 
 | Flag                       | Shorthand | Type   | Default  | Description                                                                                                       |
 | -------------------------- | --------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------- |
-| `--action`                 | `-a`      | string |          | Action to perform on selection. Commas chain multiple actions (`left_click,left_click` is a double-click). See [action names](#action-names). |
+| `--action`                 | `-a`      | string |          | Mouse-button action to perform on selection — see [action names](#action-names) for the accepted set. Commas chain multiple actions (`left_click,left_click` is a double-click). |
 | `--toggle`                 | `-t`      | bool   | `false`  | Exit to idle if this mode is already active, otherwise enter it.                                                    |
 | `--repeat`                 | `-r`      | bool   | `false`  | Re-enter the mode after the action instead of exiting. Requires `--action`.                                         |
 | `--modifier`               |           | string |          | Comma-separated modifiers held during the action: `cmd`, `super`, `meta`, `shift`, `alt`, `option`, `ctrl`. Requires `--action`. |
@@ -434,8 +434,11 @@ a hotkey binding string, or `neru action` directly.
 | Keys     | `feed`                                                                                              |
 | Timing   | `sleep` — [hotkey bindings only](#action-sleep-hotkey-bindings-only)                                |
 
-Mode `--action` accepts only the click, press, release, toggle, `move_mouse`,
-`move_mouse_relative`, and `scroll` names.
+**Mode `--action` accepts mouse-button names only** — the click, press, release,
+and toggle rows above, plus the deprecated `mouse_down` / `mouse_up`. Every
+other name, including `move_mouse`, `move_mouse_relative`, and `scroll`, is
+rejected with `ERR_INVALID_INPUT` and must be run as `neru action <name>` or
+bound as a hotkey action instead.
 
 ## Action platform support
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,148 +1,254 @@
-# CLI Usage
+# CLI Reference
 
-Neru provides a comprehensive command-line interface for controlling the daemon, triggering navigation modes, and building keyboard-driven workflows. Commands communicate with a running daemon over a Unix socket.
+Complete reference for every `neru` command, flag, and argument.
 
-> "The daemon" refers to the background process started with `neru launch`. Commands are also documented as manpages (`man neru` after install).
+Neru runs as a background daemon. Most commands are thin clients that send a
+request to that daemon over a Unix socket (a named pipe on Windows) and print
+the reply. "The daemon" below means the process started by `neru launch`.
+
+The same content is available as manpages (`man neru`) after installation.
+
+**Related:** [Configuration Reference](CONFIGURATION.md) ·
+[Installation](INSTALLATION.md) · [Troubleshooting](TROUBLESHOOTING.md)
 
 ---
 
 ## Table of Contents
 
-- [1. neru launch](#1-neru-launch)
-- [2. neru start](#2-neru-start)
-- [3. neru stop](#3-neru-stop)
-- [4. neru idle](#4-neru-idle)
-- [5. neru status](#5-neru-status)
-- [6. neru doctor](#6-neru-doctor)
-- [7. neru hints](#7-neru-hints)
-- [8. neru grid](#8-neru-grid)
-- [9. neru recursive_grid](#9-neru-recursive_grid)
-- [10. neru scroll](#10-neru-scroll)
-- [11. neru monitor_select](#11-neru-monitor_select)
-- [12. neru action](#12-neru-action)
-- [13. neru config](#13-neru-config)
-- [14. neru toggle-scroll-invert](#14-neru-toggle-scroll-invert)
-- [15. neru toggle-cursor-follow-selection](#15-neru-toggle-cursor-follow-selection)
-- [16. neru toggle-screen-share](#16-neru-toggle-screen-share)
-- [17. neru services](#17-neru-services)
-- [18. neru docs](#18-neru-docs)
+- [How to read this reference](#how-to-read-this-reference)
+- [Global flags](#global-flags)
+- [Command index](#command-index)
+- [Daemon lifecycle](#daemon-lifecycle) — `launch` · `start` · `stop` · `idle` · `status` · `doctor`
+- [Navigation modes](#navigation-modes) — `hints` · `grid` · `recursive_grid` · `scroll` · `monitor_select`
+- [Actions](#actions) — `action` and its subcommands
+- [Configuration commands](#configuration-commands) — `config`
+- [Runtime toggles](#runtime-toggles)
+- [Utilities](#utilities) — `roles` · `services` · `docs`
 - [Scripting](#scripting)
-- [IPC Communication](#ipc-communication)
+- [IPC protocol](#ipc-protocol)
 
 ---
 
-### Global Flags
+## How to read this reference
 
-| Flag        | Shorthand | Type   | Default | Description            |
-| ----------- | --------- | ------ | ------- | ---------------------- |
-| `--config`  | `-c`      | string | `""`    | Path to config file    |
-| `--timeout` |           | int    | `5`     | IPC timeout in seconds |
+Every command is documented in the same shape: a one-line purpose, a synopsis,
+a description, a flag table, and examples.
+
+**Synopsis notation**
+
+| Notation      | Meaning                                  |
+| ------------- | ---------------------------------------- |
+| `<value>`     | Required placeholder you replace         |
+| `[--flag]`    | Optional flag                            |
+| `a\|b`        | Choose one                               |
+| `[<key>...]`  | Repeatable argument                      |
+
+**Daemon requirement** is stated per command. Commands that do not need the
+daemon are `launch`, `doctor`, `roles`, `config init`, and `config validate`;
+every other command requires a running daemon.
+
+**Platform support** is listed for every command and flag whose behaviour is not
+identical on all three platforms, as a `Platforms:` line or a `Platforms`
+column. Anything without such a note works the same on macOS, Linux, and
+Windows. Commands that are unavailable return `ERR_NOT_SUPPORTED`.
+
+On Linux, "supported" means an X11 session or a Wayland session on wlroots or
+KWin. GNOME Wayland is not supported at all — the daemon exits at startup. See
+[CROSS_PLATFORM.md](CROSS_PLATFORM.md#platform-status).
+
+`-h`, `--help` is accepted by every command and is omitted from the flag tables
+below.
 
 ---
 
-## 1. neru launch
+## Global flags
 
-`neru launch [-h|--help] [-c|--config <path>] [--timeout <seconds>]`
+Accepted by every command.
+
+| Flag        | Shorthand | Type   | Default | Description                                                                        |
+| ----------- | --------- | ------ | ------- | ---------------------------------------------------------------------------------- |
+| `--config`  | `-c`      | string | `""`    | Path to the config file. Overrides the default search paths. See [Config file location](CONFIGURATION.md#config-file-location). |
+| `--timeout` |           | int    | `10`    | IPC timeout in seconds.                                                             |
+
+---
+
+## Command index
+
+| Command                             | Purpose                                        | Needs daemon | Platforms |
+| ----------------------------------- | ---------------------------------------------- | :----------: | --------- |
+| [`launch`](#neru-launch)                                     | Start the daemon                | No  | All |
+| [`start`](#neru-start)                                       | Resume after `stop`             | Yes | All |
+| [`stop`](#neru-stop)                                         | Pause without exiting           | Yes | All |
+| [`idle`](#neru-idle)                                         | Exit the active mode            | Yes | All |
+| [`status`](#neru-status)                                     | Print daemon state              | Yes | All |
+| [`doctor`](#neru-doctor)                                     | Run diagnostics                 | No  | All |
+| [`hints`](#neru-hints)                                       | Label and click UI elements     | Yes | All ¹ |
+| [`grid`](#neru-grid)                                         | Coordinate grid navigation      | Yes | All |
+| [`recursive_grid`](#neru-recursive_grid)                     | Recursive cell navigation       | Yes | All |
+| [`scroll`](#neru-scroll)                                     | Vim-style scrolling             | Yes | All |
+| [`monitor_select`](#neru-monitor_select)                     | Jump the cursor to a display    | Yes | macOS · Linux |
+| [`action`](#actions)                                         | One-shot mouse/scroll/key input | Yes | All ² |
+| [`config`](#configuration-commands)                          | Inspect and change config       | Mixed | All |
+| [`toggle-scroll-invert`](#neru-toggle-scroll-invert)         | Invert scroll direction         | Yes | All |
+| [`toggle-cursor-follow-selection`](#neru-toggle-cursor-follow-selection) | Toggle cursor follow | Yes | All |
+| [`toggle-screen-share`](#neru-toggle-screen-share)           | Hide overlays while sharing     | Yes | macOS |
+| [`roles`](#neru-roles)                                       | List the role vocabulary        | No  | All |
+| [`services`](#neru-services)                                 | Manage the system service       | No  | macOS |
+| [`docs`](#neru-docs)                                         | Open documentation in a browser | No  | macOS |
+
+¹ Element discovery quality differs by platform: a full accessibility tree on
+macOS, an AT-SPI walk on Linux whose coverage depends on the application, and an
+initial shallow UI Automation walk on Windows. The `vision` strategy is macOS
+only. See [Accessibility and hints](CROSS_PLATFORM.md#accessibility-and-hints).
+
+² Two action subcommands are limited: `hide_cursor` and `show_cursor` are macOS
+only, and `scroll_left` / `scroll_right` have no effect on Windows. See
+[Action platform support](#action-platform-support).
+
+---
+
+# Daemon lifecycle
+
+## neru launch
 
 Start the Neru daemon.
 
-Does not require a running daemon (this starts it). The daemon runs as a background process and listens for IPC commands on a Unix socket.
+```
+neru launch [-c <path>] [--timeout <seconds>]
+```
 
-**OPTIONS**
-
-`-h`, `--help` -- Print help
-
-`-c`, `--config <path>` -- Path to config file. Overrides default config search paths. See [CONFIGURATION.md](CONFIGURATION.md#config-file-location).
-
-`--timeout <seconds>` -- IPC timeout in seconds (default: `5`).
+Runs the background process that owns the event tap, overlays, and IPC server.
+Does not require a running daemon; this is what starts one. Takes only the
+[global flags](#global-flags).
 
 ---
 
-## 2. neru start
+## neru start
 
-`neru start [-h|--help]`
+Resume Neru after `neru stop`.
 
-Resume Neru after it has been stopped. Requires a running daemon.
+```
+neru start
+```
 
----
-
-## 3. neru stop
-
-`neru stop [-h|--help]`
-
-Pause Neru. The daemon stays running but mode switching and overlay rendering are disabled. Use `neru start` to resume.
+Requires a running daemon. Re-enables mode switching and overlay rendering.
 
 ---
 
-## 4. neru idle
+## neru stop
 
-`neru idle [-h|--help]`
+Pause Neru without exiting the daemon.
 
-Cancel the currently active navigation mode and return to idle. If no mode is active, this is a no-op.
+```
+neru stop
+```
 
----
-
-## 5. neru status
-
-`neru status [-h|--help]`
-
-Show the Neru daemon status and current mode.
-
-**OUTPUT**
-
-`Status`: `running`, `disabled`
-`Mode`: `idle`, `hints`, `grid`, `recursive_grid`, `scroll`
+Requires a running daemon. The process keeps running and keeps its socket open,
+but mode switching and overlay rendering are disabled. Resume with
+[`neru start`](#neru-start).
 
 ---
 
-## 6. neru doctor
+## neru idle
 
-`neru doctor [-h|--help]`
+Exit the active navigation mode.
 
-Run comprehensive system diagnostics. Works even when the daemon is not running. Checks config validity, socket health, platform compatibility, and internal components.
+```
+neru idle
+```
+
+Requires a running daemon. Returns to idle. No-op when no mode is active.
 
 ---
 
-## 7. neru hints
+## neru status
 
-`neru hints [-h|--help] [-a|--action <action>] [-t|--toggle] [-r|--repeat] [--modifier <mod>] [--cursor-selection-mode <mode>] [-s|--search] [--hide-on-empty-search] [--role <role>] [--text <text>] [--strategy <strategy>] [-d|--debug] [--label-direction <dir>] [--split-word]`
+Print the daemon state and current mode.
 
-Labels clickable UI elements with short overlay labels. Type a hint label to interact with the element.
+```
+neru status
+```
 
-Uses the macOS Accessibility API (`axtree`) or Vision Framework (`vision`) to discover elements. Default strategy is `axtree`.
+Requires a running daemon.
 
-**OPTIONS**
+**Output fields**
 
-`-h`, `--help` -- Print help
+| Field    | Values                                                  |
+| -------- | ------------------------------------------------------- |
+| `Status` | `running`, `disabled`                                   |
+| `Mode`   | `idle`, `hints`, `grid`, `recursive_grid`, `scroll`, `monitor_select` |
 
-`-a`, `--action <action>` -- Action on selection. Commas chain multiple actions (e.g. `left_click,left_click` for double-click). Valid: `left_click`, `right_click`, `middle_click`, `left_mouse_down`, `left_mouse_up`, `right_mouse_down`, `right_mouse_up`, `middle_mouse_down`, `middle_mouse_up`, `left_mouse_toggle`, `right_mouse_toggle`, `middle_mouse_toggle`.
+---
 
-`-t`, `--toggle` -- Toggle mode on/off.
+## neru doctor
 
-`-r`, `--repeat` -- Re-activate mode after performing the action (requires `--action`).
+Run system diagnostics.
 
-`--modifier <mod>` -- Comma-separated modifier keys to hold: `cmd`, `super`, `meta`, `shift`, `alt`, `option`, `ctrl` (requires `--action`).
+```
+neru doctor
+```
 
-`--cursor-selection-mode <mode>` -- `follow` (default, cursor jumps to selection) or `hold` (cursor stays).
+Does not require a running daemon. Reports config validity, socket health,
+platform capabilities, and internal component state. Platform capabilities come
+from the capability matrix described in
+[CROSS_PLATFORM.md](CROSS_PLATFORM.md#capability-matrix).
 
-`-s`, `--search` -- Start with search input active.
+---
 
-`--hide-on-empty-search` -- Hide all hints when search is empty (requires `--search`).
+# Navigation modes
 
-`--role <role>` -- Filter by role. Comma-separated (e.g. `button,link`). Accepts the same
-vocabulary as `hints.clickable_roles`; run `neru roles` to list it.
+Modes take over the keyboard until you select a target or exit. All five
+require a running daemon.
 
-`--text <text>` -- Filter by text content. Case-insensitive substring match. Comma-separated for OR.
+## Flags shared by hints, grid, and recursive_grid
 
-`--strategy <strategy>` -- Detection strategy: `axtree` (default) or `vision`. Overrides config.
+These three modes accept the same selection flags. Mode-specific flags are
+listed under each command.
 
-`-d`, `--debug` -- Probe the focused window and print detected elements without overlay.
+| Flag                       | Shorthand | Type   | Default  | Description                                                                                                       |
+| -------------------------- | --------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| `--action`                 | `-a`      | string |          | Action to perform on selection. Commas chain multiple actions (`left_click,left_click` is a double-click). See [action names](#action-names). |
+| `--toggle`                 | `-t`      | bool   | `false`  | Exit to idle if this mode is already active, otherwise enter it.                                                    |
+| `--repeat`                 | `-r`      | bool   | `false`  | Re-enter the mode after the action instead of exiting. Requires `--action`.                                         |
+| `--modifier`               |           | string |          | Comma-separated modifiers held during the action: `cmd`, `super`, `meta`, `shift`, `alt`, `option`, `ctrl`. Requires `--action`. |
+| `--on-exit`                |           | string |          | Command run after the action completes and the mode exits. Uses hotkey-binding syntax (`'action left_click'`, `'exec notify-send done'`). Requires `--action`. Not run when the mode is left manually via escape or `neru idle`. |
+| `--cursor-selection-mode`  |           | string | `follow` | `follow` moves the real cursor to the selection; `hold` leaves it in place.                                          |
 
-`--label-direction <dir>` -- Label algorithm: `normal` (default) or `reverse`. Overrides config.
+---
 
-`--split-word` -- Split detected text into word-level regions (requires `vision`).
+## neru hints
 
-**EXAMPLES**
+Label clickable elements and act on the one you type.
+
+```
+neru hints [-a <action>] [-t] [-r] [--modifier <mods>] [--on-exit <command>]
+           [--cursor-selection-mode follow|hold] [-s] [--hide-on-empty-search]
+           [--role <roles>] [--text <text>] [--strategy axtree|vision]
+           [--label-direction normal|reverse] [--split-word] [-d]
+```
+
+Scans the focused window for interactive elements and overlays a short letter
+label on each. Typing a label selects that element.
+
+Element discovery uses the `axtree` strategy by default. The `vision` strategy
+is macOS-only and detects on-screen text and rectangles via the Vision
+framework. Coverage per platform is documented in
+[CROSS_PLATFORM.md](CROSS_PLATFORM.md#accessibility-and-hints).
+
+**Flags** — in addition to the [shared mode flags](#flags-shared-by-hints-grid-and-recursive_grid).
+
+| Flag                     | Shorthand | Type   | Default  | Description                                                                                     |
+| ------------------------ | --------- | ------ | -------- | ------------------------------------------------------------------------------------------------- |
+| `--search`               | `-s`      | bool   | `false`  | Show the search input when the mode activates.                                                    |
+| `--hide-on-empty-search` |           | bool   | `false`  | Hide all hints while the search query is empty. Requires `--search`.                              |
+| `--role`                 |           | string |          | Only hint elements whose role matches. Comma-separated. Accepts the vocabulary listed by [`neru roles`](#neru-roles). |
+| `--text`                 |           | string |          | Only hint elements whose text matches. Comma-separated (OR), case-insensitive substring match.    |
+| `--strategy`             |           | string | `axtree` | Element detection strategy: `axtree` or `vision`. `vision` is macOS only. Overrides `hints.strategy`. |
+| `--label-direction`      |           | string | `normal` | Label enumeration: `normal` or `reverse`. Overrides `hints.label_direction`. See [Choosing a label direction](CONFIGURATION.md#choosing-a-label-direction). |
+| `--split-word`           |           | bool   | `false`  | Split detected text into word-level regions. Requires `--strategy vision`, so macOS only.          |
+| `--debug`                | `-d`      | bool   | `false`  | Print the elements that would be hinted, with a count and a sample, without showing the overlay.  |
+
+**Examples**
 
 ```bash
 neru hints
@@ -152,63 +258,58 @@ neru hints --action left_click --repeat
 neru hints --search
 neru hints --role button --text submit
 neru hints --strategy vision --split-word
+neru hints --debug
 ```
 
 ---
 
-## 8. neru grid
+## neru grid
 
-`neru grid [-h|--help] [-a|--action <action>] [-t|--toggle] [-r|--repeat] [--modifier <mod>] [--cursor-selection-mode <mode>]`
+Divide the screen into a labelled coordinate grid.
 
-Divide the screen into a labelled coordinate grid. Type row+column labels to jump to a position.
+```
+neru grid [-a <action>] [-t] [-r] [--modifier <mods>] [--on-exit <command>]
+          [--cursor-selection-mode follow|hold]
+```
 
-**OPTIONS**
+Overlays a grid of labelled cells. Typing a cell label moves the cursor there.
+Takes only the [shared mode flags](#flags-shared-by-hints-grid-and-recursive_grid).
 
-`-h`, `--help` -- Print help
+Grid size, labels, and appearance are configured under
+[`[grid]`](CONFIGURATION.md#grid).
 
-`-a`, `--action <action>` -- Action on selection. Valid: `left_click`, `right_click`, `middle_click`, `left_mouse_down`, `left_mouse_up`, `right_mouse_down`, `right_mouse_up`, `middle_mouse_down`, `middle_mouse_up`, `left_mouse_toggle`, `right_mouse_toggle`, `middle_mouse_toggle`.
-
-`-t`, `--toggle` -- Toggle mode on/off.
-
-`-r`, `--repeat` -- Re-activate after action (requires `--action`).
-
-`--modifier <mod>` -- Modifier keys to hold during action: `cmd`, `super`, `meta`, `shift`, `alt`, `option`, `ctrl` (requires `--action`).
-
-`--cursor-selection-mode <mode>` -- `follow` (default) or `hold`.
-
-**EXAMPLES**
+**Examples**
 
 ```bash
 neru grid
 neru grid --action left_click --repeat
 neru grid --cursor-selection-mode hold
+neru grid --action left_click --on-exit 'exec notify-send clicked'
 ```
 
 ---
 
-## 9. neru recursive_grid
+## neru recursive_grid
 
-`neru recursive_grid [-h|--help] [-a|--action <action>] [-t|--toggle] [-r|--repeat] [--modifier <mod>] [--cursor-selection-mode <mode>] [--zoom-to-depth <depth>]`
+Narrow the screen recursively, one keypress per level.
 
-Divide the screen into cells. Each keypress narrows the active area recursively.
+```
+neru recursive_grid [-a <action>] [-t] [-r] [--modifier <mods>]
+                    [--on-exit <command>] [--cursor-selection-mode follow|hold]
+                    [--zoom-to-depth <depth>]
+```
 
-**OPTIONS**
+Each keypress subdivides the selected cell, so successive presses converge on a
+point. Depth limits and per-depth layout are configured under
+[`[recursive_grid]`](CONFIGURATION.md#recursive_grid).
 
-`-h`, `--help` -- Print help
+**Flags** — in addition to the [shared mode flags](#flags-shared-by-hints-grid-and-recursive_grid).
 
-`-a`, `--action <action>` -- Action on selection. Valid: `left_click`, `right_click`, `middle_click`, `left_mouse_down`, `left_mouse_up`, `right_mouse_down`, `right_mouse_up`, `middle_mouse_down`, `middle_mouse_up`, `left_mouse_toggle`, `right_mouse_toggle`, `middle_mouse_toggle`.
+| Flag              | Type | Default | Description                                                                                                       |
+| ----------------- | ---- | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| `--zoom-to-depth` | int  |         | Drill to this depth at the current cursor position on activation. Stops early if the grid cannot subdivide further (minimum cell size or maximum depth). Negative values are rejected. |
 
-`-t`, `--toggle` -- Toggle mode on/off.
-
-`-r`, `--repeat` -- Re-activate after action (requires `--action`).
-
-`--modifier <mod>` -- Modifier keys to hold during action (requires `--action`).
-
-`--cursor-selection-mode <mode>` -- `follow` (default) or `hold`.
-
-`--zoom-to-depth <depth>` -- Auto-drill to the specified depth at the current cursor position. If the grid cannot divide further (min size or max depth), zooming stops early. Negative values are rejected.
-
-**EXAMPLES**
+**Examples**
 
 ```bash
 neru recursive_grid
@@ -219,30 +320,39 @@ neru recursive_grid --zoom-to-depth 3 --action left_click
 
 ---
 
-## 10. neru scroll
+## neru scroll
 
-`neru scroll [-h|--help] [-t|--toggle]`
+Scroll at the cursor with vim-style keys.
 
-Vim-style scrolling at the current cursor position. Scroll speed and step sizes are configured in [CONFIGURATION.md](CONFIGURATION.md#scroll).
+```
+neru scroll [-t]
+```
 
-**OPTIONS**
+| Flag       | Shorthand | Type | Default | Description                                        |
+| ---------- | --------- | ---- | ------- | -------------------------------------------------- |
+| `--toggle` | `-t`      | bool | `false` | Exit to idle if scroll mode is active, else enter.  |
 
-`-h`, `--help` -- Print help
+**Default key bindings**
 
-`-t`, `--toggle` -- Toggle scroll mode on/off.
+Every binding below is configurable under [`[scroll.hotkeys]`](CONFIGURATION.md#scroll).
 
-**KEY BINDINGS**
+| Key                    | Action                     |
+| ---------------------- | -------------------------- |
+| `j` / `k`              | Scroll down / up           |
+| `h` / `l`              | Scroll left / right        |
+| `d` / `PageDown`       | Page down                  |
+| `u` / `PageUp`         | Page up                    |
+| `gg`                   | Jump to top                |
+| `Shift+G`              | Jump to bottom             |
+| `Up` / `Down` / `Left` / `Right` | Move the cursor by 10 px |
+| `Shift+L` / `Shift+R` / `Shift+M` | Left / right / middle click |
+| `Shift+I` / `Shift+U`  | Press / release the left button |
+| `Escape`               | Exit to idle               |
 
-| Key       | Action              |
-| --------- | ------------------- |
-| `j` / `k` | Scroll down / up    |
-| `h` / `l` | Scroll left / right |
-| `d` / `u` | Half-page down / up |
-| `gg`      | Jump to top         |
-| `Shift+G` | Jump to bottom      |
-| `Esc`     | Exit                |
+Step sizes come from `scroll.scroll_step`, `scroll_step_half`, and
+`scroll_step_full`.
 
-**EXAMPLES**
+**Examples**
 
 ```bash
 neru scroll
@@ -251,26 +361,34 @@ neru scroll --toggle
 
 ---
 
-## 11. neru monitor_select
+## neru monitor_select
 
-`neru monitor_select [-h|--help] [-t|--toggle]`
+Move the cursor to another display.
 
-Open per-display overlay panels showing labelled selection badges. Type a label to move the cursor to that monitor. The current monitor is excluded from selection.
+```
+neru monitor_select [-t]
+```
 
-**OPTIONS**
+**Platforms:** macOS · Linux. Not implemented on Windows, where it returns
+`ERR_NOT_SUPPORTED`.
 
-`-h`, `--help` -- Print help
+Opens a labelled panel on each display. Typing a label moves the cursor to that
+display. The current display is excluded.
 
-`-t`, `--toggle` -- Toggle monitor_select mode on/off.
+| Flag       | Shorthand | Type | Default | Description                                            |
+| ---------- | --------- | ---- | ------- | ------------------------------------------------------ |
+| `--toggle` | `-t`      | bool | `false` | Exit to idle if the mode is active, else enter it.      |
 
-**KEY BINDINGS**
+**Default key bindings**
 
-| Key     | Action                       |
-| ------- | ---------------------------- |
-| `1`–`9` | Type label to select monitor |
-| `Esc`   | Cancel and return to idle    |
+| Key     | Action                          |
+| ------- | ------------------------------- |
+| `1`–`9` | Select the display with that label |
+| `Escape`| Cancel and return to idle       |
 
-**EXAMPLES**
+Labels come from `monitor_select.characters` (default `123456789`).
+
+**Examples**
 
 ```bash
 neru monitor_select
@@ -279,116 +397,157 @@ neru monitor_select --toggle
 
 ---
 
-## 12. neru action
+# Actions
 
-One-shot commands that operate independently of active modes. All require a running daemon.
+One-shot input that runs without entering a mode. All action subcommands
+require a running daemon.
 
-### 12a. left_click, right_click, middle_click
+```
+neru action <subcommand> [flags]
+```
 
-`neru action <click-type> [-h|--help] [--modifier <mod>] [--selection] [--bare] [--state <down|up>] [--toggle]`
+## Targeting
 
-Perform a mouse click, or press and release the button as separate actions.
+Point-targeted actions resolve their target in this order: the active mode
+selection when one exists, otherwise the current cursor position.
 
-**OPTIONS**
+| Flag          | Type | Description                                                        |
+| ------------- | ---- | ------------------------------------------------------------------ |
+| `--selection` | bool | Target the active mode selection.                                   |
+| `--bare`      | bool | Target the cursor position even when a mode selection exists.        |
 
-`--modifier <mod>` -- Hold modifier: `cmd`, `shift`, `alt`, `ctrl` (comma-separated).
+## Action names
 
-`--selection` -- Target the active mode selection.
+Every action has a name usable anywhere a name is expected: a mode `--action`,
+a hotkey binding string, or `neru action` directly.
 
-`--bare` -- Use the cursor position even when a mode selection exists.
+| Category | Names                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------- |
+| Click    | `left_click`, `right_click`, `middle_click`                                                        |
+| Press    | `left_mouse_down`, `right_mouse_down`, `middle_mouse_down`                                          |
+| Release  | `left_mouse_up`, `right_mouse_up`, `middle_mouse_up`                                                |
+| Toggle   | `left_mouse_toggle`, `right_mouse_toggle`, `middle_mouse_toggle`                                    |
+| Movement | `move_mouse`, `move_mouse_relative`, `move_monitor`                                                 |
+| Scroll   | `scroll`, `scroll_up`, `scroll_down`, `scroll_left`, `scroll_right`, `page_up`, `page_down`, `go_top`, `go_bottom` |
+| Mode     | `reset`, `backspace`, `cycle_hint`, `wait_for_mode_exit`                                            |
+| Cursor   | `save_cursor_pos`, `restore_cursor_pos`, `hide_cursor`, `show_cursor`                               |
+| Keys     | `feed`                                                                                              |
+| Timing   | `sleep` — [hotkey bindings only](#action-sleep-hotkey-bindings-only)                                |
 
-`--state <down|up>` -- Perform only one half of the click: `down` presses and holds the button, `up` releases it. Without this flag the button is pressed and released in one action.
+Mode `--action` accepts only the click, press, release, toggle, `move_mouse`,
+`move_mouse_relative`, and `scroll` names.
 
-`--toggle` -- Release the button when it is held, press and hold it otherwise. Useful for binding a whole drag to a single key.
+## Action platform support
 
-`--state` and `--toggle` cannot be combined, and are only accepted by the three click actions.
+Every action not listed here behaves identically on macOS, Linux, and Windows.
 
-Held buttons are released automatically when Neru returns to idle.
+| Action                            | macOS | Linux | Windows | Note                                                     |
+| --------------------------------- | :---: | :---: | :-----: | -------------------------------------------------------- |
+| `hide_cursor`, `show_cursor`      | Yes   | No    | No      | Uses a Quartz API with no cross-platform equivalent; a no-op elsewhere. |
+| `scroll_left`, `scroll_right`     | Yes   | Yes   | No      | Windows scroll injection ignores the horizontal delta.    |
+| `move_monitor`                    | Yes   | Yes   | Yes     | Requires more than one display.                           |
 
-**EXAMPLES**
+The injection mechanism differs per platform even where behaviour matches:
+`CGEventPost` on macOS, XTest on X11, `zwlr_virtual_pointer` on wlroots, libei
+on KDE, and `SendInput` on Windows. This affects nothing user-visible except the
+scroll limitation above.
+
+---
+
+## neru action left_click, right_click, middle_click
+
+Press and release a mouse button, or perform one half of that.
+
+```
+neru action left_click|right_click|middle_click
+            [--modifier <mods>] [--selection] [--bare] [--state down|up] [--toggle]
+```
+
+| Flag         | Type   | Description                                                                                          |
+| ------------ | ------ | ---------------------------------------------------------------------------------------------------- |
+| `--modifier` | string | Modifiers held during the click: `cmd`, `shift`, `alt`, `ctrl`. Comma-separated.                      |
+| `--state`    | string | Perform one half only: `down` presses and holds, `up` releases. Without it the button is pressed and released in one action. |
+| `--toggle`   | bool   | Release the button if held, press and hold it otherwise.                                              |
+| `--selection`| bool   | See [Targeting](#targeting).                                                                          |
+| `--bare`     | bool   | See [Targeting](#targeting).                                                                          |
+
+`--state` and `--toggle` cannot be combined, and are accepted only by these
+three click subcommands. Held buttons are released automatically when Neru
+returns to idle.
+
+**Flag forms and their action names**
+
+`--state` and `--toggle` are flags, so they cannot appear inside a comma chain
+or a mode `--action`. Each combination also has an action name, which can:
+
+| Flag form                   | Action name           |
+| --------------------------- | --------------------- |
+| `left_click --state down`   | `left_mouse_down`     |
+| `left_click --state up`     | `left_mouse_up`       |
+| `left_click --toggle`       | `left_mouse_toggle`   |
+| `right_click --state down`  | `right_mouse_down`    |
+| `right_click --state up`    | `right_mouse_up`      |
+| `right_click --toggle`      | `right_mouse_toggle`  |
+| `middle_click --state down` | `middle_mouse_down`   |
+| `middle_click --state up`   | `middle_mouse_up`     |
+| `middle_click --toggle`     | `middle_mouse_toggle` |
+
+**Examples**
 
 ```bash
 neru action left_click
 neru action left_click --modifier cmd
 neru action left_click --modifier cmd,shift
 neru action right_click --modifier alt
-```
 
-Drag workflows press at the start point and release at the destination:
+# Drags: press at the start, release at the destination
+neru action left_click --state down
+neru action middle_click --state down
+neru action middle_click --state up
 
-```bash
-neru action left_click --state down     # Start a left drag
-neru action right_click --state down    # Start a right drag
-neru action middle_click --state down   # Start a middle drag (canvas panning)
-neru action middle_click --state up     # Release it
-```
+# One binding for both halves
+neru action left_click --toggle
 
-`--toggle` performs whichever half comes next, so one binding covers both:
-
-```bash
-neru action left_click --toggle         # Press if free, release if held
-```
-
-Commas chain multiple click actions directly:
-
-```bash
+# Comma chains
 neru action left_click,left_click             # Double-click
 neru action left_click,left_click,left_click  # Triple-click
-neru hints --action left_click,left_click     # Same, via mode --action
+neru hints --action left_click,left_click     # Same, via a mode
+
+# Action-name equivalents
+neru action right_mouse_down
+neru hints --action right_mouse_down
 ```
 
-`--state` and `--toggle` are flags, so they cannot appear in a comma chain or in a
-mode `--action`. Each combination also has an action name, which works anywhere a
-name is expected — a mode `--action`, a hotkey action string, or `neru action`
-directly:
-
-| Flag form                      | Action name           |
-| ------------------------------ | --------------------- |
-| `left_click --state down`      | `left_mouse_down`     |
-| `left_click --state up`        | `left_mouse_up`       |
-| `left_click --toggle`          | `left_mouse_toggle`   |
-| `right_click --state down`     | `right_mouse_down`    |
-| `right_click --state up`       | `right_mouse_up`      |
-| `right_click --toggle`         | `right_mouse_toggle`  |
-| `middle_click --state down`    | `middle_mouse_down`   |
-| `middle_click --state up`      | `middle_mouse_up`     |
-| `middle_click --toggle`        | `middle_mouse_toggle` |
-
-```bash
-neru hints --action right_mouse_down     # press the right button on the hinted element
-neru action right_mouse_down             # same as right_click --state down
-```
-
-### 12a-1. mouse_down, mouse_up (deprecated)
+### mouse_down, mouse_up (deprecated)
 
 `mouse_down` and `mouse_up` are the original left-button spellings, from before
-the right and middle buttons could be pressed and released. They still work
-everywhere `left_mouse_down` and `left_mouse_up` do — including in existing
-configs — and the CLI prints a deprecation warning on stderr pointing at the
-replacement. Use `neru action left_click --state down` and
-`neru action left_click --state up` instead.
+the right and middle buttons could be pressed and released separately. They
+still work everywhere `left_mouse_down` and `left_mouse_up` do, including in
+existing configs, and the CLI prints a deprecation warning on stderr naming the
+replacement.
 
-### 12b. move_mouse
+Use `neru action left_click --state down` and `neru action left_click --state up`.
 
-`neru action move_mouse [-h|--help] [--x <px>] [--y <px>] [--center] [--window] [--selection] [--bare]`
+---
+
+## neru action move_mouse
 
 Move the cursor to an absolute position.
 
-**OPTIONS**
+```
+neru action move_mouse [--x <px>] [--y <px>] [--center] [--window] [--selection] [--bare]
+```
 
-`--x <px>` -- X coordinate (pixels). With `--center` or `--window`, acts as horizontal offset.
+| Flag          | Type | Default | Description                                                                 |
+| ------------- | ---- | ------- | ---------------------------------------------------------------------------- |
+| `--x`         | int  | `0`     | X coordinate in pixels. With `--center` or `--window`, a horizontal offset.   |
+| `--y`         | int  | `0`     | Y coordinate in pixels. With `--center` or `--window`, a vertical offset.     |
+| `--center`    | bool | `false` | Target the center of the active screen.                                       |
+| `--window`    | bool | `false` | Target the center of the focused window.                                      |
+| `--selection` | bool | `false` | See [Targeting](#targeting).                                                  |
+| `--bare`      | bool | `false` | See [Targeting](#targeting).                                                  |
 
-`--y <px>` -- Y coordinate (pixels). With `--center` or `--window`, acts as vertical offset.
-
-`--center` -- Move to the center of the active screen.
-
-`--window` -- Move to the center of the focused window.
-
-`--selection` -- Use the active mode selection.
-
-`--bare` -- Use the current cursor position when no other target is specified.
-
-**EXAMPLES**
+**Examples**
 
 ```bash
 neru action move_mouse --x 500 --y 300
@@ -398,39 +557,74 @@ neru action move_mouse --window
 neru action move_mouse --window --x -50
 ```
 
-### 12c. move_mouse_relative
+---
 
-`neru action move_mouse_relative [-h|--help] --dx <px> --dy <px>`
+## neru action move_mouse_relative
 
-Move the cursor by a relative delta.
+Move the cursor by a delta.
 
-**OPTIONS**
+```
+neru action move_mouse_relative --dx <px> --dy <px>
+```
 
-`--dx <px>` (required) -- Delta X. Positive = right, negative = left.
+| Flag   | Type | Required | Description                                  |
+| ------ | ---- | :------: | -------------------------------------------- |
+| `--dx` | int  | Yes      | Horizontal delta. Positive right, negative left. |
+| `--dy` | int  | Yes      | Vertical delta. Positive down, negative up.  |
 
-`--dy <px>` (required) -- Delta Y. Positive = down, negative = up.
-
-**EXAMPLES**
+**Examples**
 
 ```bash
 neru action move_mouse_relative --dx 10 --dy -5
 ```
 
-### 12d. scroll_up, scroll_down, scroll_left, scroll_right
+---
 
-`neru action scroll_<dir> [-h|--help] [--steps <px>] [--selection] [--bare]`
+## neru action move_monitor
 
-Scroll in the specified direction.
+Move the cursor to another display.
 
-**OPTIONS**
+```
+neru action move_monitor [--name <name>] [--previous]
+```
 
-`--steps <px>` -- Override scroll step (pixels). Uses configured default when omitted.
+Cycles to the next display by default. An active mode overlay follows the
+cursor to the new display.
 
-`--selection` -- Target the active mode selection.
+| Flag         | Type   | Default | Description                                                            |
+| ------------ | ------ | ------- | ------------------------------------------------------------------------ |
+| `--name`     | string |         | Target a display by name, e.g. `"Built-in Retina Display"`.              |
+| `--previous` | bool   | `false` | Cycle to the previous display instead of the next.                       |
 
-`--bare` -- Target the cursor position.
+**Examples**
 
-**EXAMPLES**
+```bash
+neru action move_monitor
+neru action move_monitor --previous
+neru action move_monitor --name "DELL U2720Q"
+```
+
+---
+
+## neru action scroll_up, scroll_down, scroll_left, scroll_right
+
+Scroll one step in a direction.
+
+```
+neru action scroll_up|scroll_down|scroll_left|scroll_right [--steps <px>] [--selection] [--bare]
+```
+
+| Flag          | Type | Description                                                                |
+| ------------- | ---- | -------------------------------------------------------------------------- |
+| `--steps`     | int  | Scroll amount in pixels. Uses `scroll.scroll_step` when omitted.            |
+| `--selection` | bool | See [Targeting](#targeting).                                               |
+| `--bare`      | bool | See [Targeting](#targeting).                                               |
+
+**Platforms:** vertical scrolling works everywhere. Horizontal scrolling
+(`scroll_left`, `scroll_right`) is not implemented on Windows and has no effect
+there.
+
+**Examples**
 
 ```bash
 neru action scroll_down
@@ -438,13 +632,20 @@ neru action scroll_down --steps 200
 neru action scroll_left --steps 100
 ```
 
-### 12e. page_up, page_down, go_top, go_bottom
+---
 
-`neru action page_up [-h|--help] [--selection] [--bare]`
+## neru action page_up, page_down, go_top, go_bottom
 
-Same as scroll actions without `--steps`.
+Scroll by a page, or to the top or bottom.
 
-**EXAMPLES**
+```
+neru action page_up|page_down|go_top|go_bottom [--selection] [--bare]
+```
+
+Page actions use `scroll.scroll_step_half` and `scroll.scroll_step_full`. These
+subcommands take no `--steps` flag.
+
+**Examples**
 
 ```bash
 neru action page_up
@@ -453,23 +654,38 @@ neru action go_top
 neru action go_bottom
 ```
 
-### 12f. feed
+---
 
-`neru action feed [-h|--help] [--mode] <key> [<key>...]`
+## neru action feed
 
-Post keystrokes to the system or to Neru's mode system.
+Send keystrokes to the focused application or to Neru's mode system.
 
-Chords use `+` (e.g. `ctrl+c`, `Cmd+Shift+P`). `space` for a literal space key.
+```
+neru action feed [--mode] <key> [<key>...]
+```
 
-**OPTIONS**
+Chords use `+`, for example `ctrl+c` or `Cmd+Shift+P`. Use `space` for a
+literal space key.
 
-`--mode` -- Route keys through Neru's active mode instead of posting to the OS.
+| Flag     | Type | Default | Description                                                              |
+| -------- | ---- | ------- | -------------------------------------------------------------------------- |
+| `--mode` | bool | `false` | Route the keys through Neru's active mode instead of posting them to the OS. |
 
-**ARGUMENTS**
+**Arguments**
 
-`<key>` -- One or more keys or chords. Supported names: letters `a`–`z`, numbers `0`–`9`, symbols (`=`, `-`, `[`, `]`, etc.), named keys (`space`, `return`, `escape`, `tab`, `delete`), navigation (`left`, `right`, `up`, `down`, `pageup`, `home`, `end`), function (`f1`–`f24`; `f21`–`f24` on Linux and Windows only), chord modifiers (`cmd`, `shift`, `alt`, `ctrl`, `LeftCmd`, `RightShift`).
+`<key>` — one or more keys or chords. Accepted names:
 
-**EXAMPLES**
+| Group        | Names                                                             |
+| ------------ | ------------------------------------------------------------------- |
+| Letters      | `a`–`z`                                                             |
+| Numbers      | `0`–`9`                                                             |
+| Symbols      | `=`, `-`, `[`, `]`, and similar                                     |
+| Named keys   | `space`, `return`, `escape`, `tab`, `delete`                        |
+| Navigation   | `left`, `right`, `up`, `down`, `pageup`, `home`, `end`              |
+| Function     | `f1`–`f24` (`f21`–`f24` on Linux and Windows only)                  |
+| Modifiers    | `cmd`, `shift`, `alt`, `ctrl`, `LeftCmd`, `RightShift`              |
+
+**Examples**
 
 ```bash
 neru action feed o
@@ -480,94 +696,126 @@ neru action feed --mode o
 neru action feed --mode Escape
 ```
 
-### 12g. cycle_hint
+---
 
-`neru action cycle_hint [-h|--help] [--backward]`
+## neru action cycle_hint
 
-In hints mode, cycle through visible hints without executing an action.
+Move the hint selection without acting on it.
 
-**OPTIONS**
-
-`--backward` -- Cycle to previous hint instead of next.
-
-### 12h. reset, backspace
-
-`neru action reset [-h|--help]` -- Reset state in the current mode.
-
-`neru action backspace [-h|--help]` -- Mode-aware backspace.
-
-### 12i. wait_for_mode_exit
-
-`neru action wait_for_mode_exit [-h|--help] [--bail]`
-
-Block the action chain until the current mode exits to idle.
-
-**OPTIONS**
-
-`--bail` -- Abort the chain if the mode exits without a selection.
-
-### 12j. save_cursor_pos, restore_cursor_pos, hide_cursor, show_cursor
-
-`neru action <cmd> [-h|--help]`
-
-Save/restore the cursor position, or hide/show the system cursor.
-
-### 12k. sleep
-
-`neru action sleep [-h|--help] <duration>`
-
-Pause execution. Useful in hotkey arrays to sequence actions.
-
-**ARGUMENTS**
-
-`<duration>` -- Plain numbers are seconds (`0.2`, `1`). Explicit units: `ms`, `s`.
-
-**EXAMPLES**
-
-```bash
-neru action sleep 0.5
-neru action sleep 500ms
-neru action sleep 1s
-neru action sleep 1
+```
+neru action cycle_hint [--backward]
 ```
 
-### 12l. move_monitor
+Valid in hints mode only.
 
-`neru action move_monitor [-h|--help] [--name <name>] [--previous]`
-
-Move the cursor to another monitor. When a mode overlay is active, it follows.
-
-**OPTIONS**
-
-`--name <name>` -- Target monitor by display name (e.g. `"Built-in Retina Display"`).
-
-`--previous` -- Cycle to the previous monitor.
-
-**EXAMPLES**
-
-```bash
-neru action move_monitor
-neru action move_monitor --previous
-neru action move_monitor --name "DELL U2720Q"
-```
+| Flag         | Type | Default | Description                                    |
+| ------------ | ---- | ------- | ---------------------------------------------- |
+| `--backward` | bool | `false` | Cycle to the previous hint instead of the next. |
 
 ---
 
-## 13. neru config
+## neru action wait_for_mode_exit
 
-### 13a. init
+Block an action chain until the current mode exits.
 
-`neru config init [-h|--help] [-f|--force] [-c|--config <path>]`
+```
+neru action wait_for_mode_exit [--bail]
+```
 
-Create a default configuration file. Does not require a running daemon.
+| Flag     | Type | Default | Description                                                            |
+| -------- | ---- | ------- | ------------------------------------------------------------------------ |
+| `--bail` | bool | `false` | Abort the chain with `ERR_CHAIN_BAIL` if the mode exits with no selection. |
 
-**OPTIONS**
+---
 
-`-f`, `--force` -- Overwrite existing file.
+## neru action reset, backspace
 
-`-c`, `--config <path>` -- Write to custom path.
+Mode state control.
 
-**EXAMPLES**
+```
+neru action reset
+neru action backspace
+```
+
+`reset` clears the current mode's input state. `backspace` applies
+mode-specific backspace behaviour: hints and grid input, grid subgrid, or
+recursive-grid backtracking.
+
+---
+
+## neru action save_cursor_pos, restore_cursor_pos, hide_cursor, show_cursor
+
+Cursor position and visibility.
+
+```
+neru action save_cursor_pos
+neru action restore_cursor_pos
+neru action hide_cursor
+neru action show_cursor
+```
+
+**Platforms:** `save_cursor_pos` and `restore_cursor_pos` work everywhere.
+`hide_cursor` and `show_cursor` are macOS only and are no-ops on Linux and
+Windows.
+
+`save_cursor_pos` records the cursor position; `restore_cursor_pos` returns it
+there. `hide_cursor` and `show_cursor` control the visibility of the system
+cursor.
+
+---
+
+## action sleep (hotkey bindings only)
+
+Pause between steps of a hotkey action array.
+
+```
+"action sleep <duration>"
+```
+
+There is no `neru action sleep` subcommand. Running it from a shell fails with
+`ERR_INVALID_INPUT`. The name exists only inside a hotkey binding, where the
+daemon executes it directly.
+
+**Arguments**
+
+`<duration>` — plain numbers are seconds (`0.2`, `1`). Explicit units are `ms`
+and `s`.
+
+`sleep` cannot appear in a comma-separated chain; `action left_click,sleep` is
+rejected at config validation. It must be its own entry in an action array.
+
+**Examples**
+
+```toml
+[hotkeys]
+"Return" = ["action left_click", "action sleep 0.5", "hints"]
+"F1" = ["action left_click", "action sleep 500ms", "action right_click"]
+```
+
+To pause inside a shell script, use the shell's own `sleep`.
+
+---
+
+# Configuration commands
+
+Full option reference: [CONFIGURATION.md](CONFIGURATION.md).
+
+## neru config init
+
+Create a default configuration file.
+
+```
+neru config init [-f] [-c <path>]
+```
+
+Does not require a running daemon.
+
+| Flag      | Shorthand | Type   | Default | Description                       |
+| --------- | --------- | ------ | ------- | --------------------------------- |
+| `--force` | `-f`      | bool   | `false` | Overwrite an existing file.        |
+| `--config`| `-c`      | string | `""`    | Write to a specific path.          |
+
+**Examples**
 
 ```bash
 neru config init
@@ -575,36 +823,58 @@ neru config init --force
 neru config init -c /path/to/config.toml
 ```
 
-### 13b. validate
+---
 
-`neru config validate [-h|--help] [-c|--config <path>]`
+## neru config validate
 
-Check config for syntax errors and invalid values. Does not require a running daemon. Exits successfully if no config is found (Neru uses built-in defaults).
+Check a config file for syntax errors and invalid values.
 
-### 13c. set
+```
+neru config validate [-c <path>]
+```
 
-`neru config set [--no-reload] <key> <value>`
+Does not require a running daemon. Exits successfully when no config file is
+found, because Neru runs on built-in defaults in that case.
 
-Set a configuration value on the running daemon without restarting. Changes take effect immediately and are persisted to `config.override.toml` so they survive restarts. Requires a running daemon.
+---
 
-The key uses dotted TOML path notation matching your config file (e.g. `hints.hint_characters`, `general.passthrough_unbounded_keys`).
+## neru config set
 
-**OPTIONS**
+Change a configuration value on the running daemon.
 
-`--no-reload` — Skip hotkey re-registration and mode exit. Use when setting multiple interdependent fields in sequence (e.g. changing both `recursive_grid.grid_cols` and `recursive_grid.keys`). Run `neru config reload` afterwards to apply all changes at once.
+```
+neru config set [--no-reload] <key> <value>
+```
 
-**SUPPORTED TYPES**
+Requires a running daemon. Changes take effect immediately and are written to
+an override file so they survive restarts.
 
-| Type    | Example value                          |
-| ------- | -------------------------------------- |
-| string  | `"asdfghjkl"`                          |
-| integer | `14`                                   |
-| boolean | `true`                                 |
-| float   | `0.5`                                  |
-| color   | `"#FF0000AA"` or `{"light":"#000","dark":"#FFF"}` |
-| array   | `"button,link"` or `'["button","link"]'` |
+`<key>` is a dotted TOML path matching the config file, for example
+`hints.hint_characters` or `general.passthrough_unbounded_keys`. Run
+`neru config dump` to list every key and its current value.
 
-**EXAMPLES**
+| Flag          | Type | Default | Description                                                                                                                            |
+| ------------- | ---- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--no-reload` | bool | `false` | Skip hotkey re-registration and mode exit. Use when setting interdependent fields in sequence, then run `neru config reload` once at the end. |
+
+**Value types**
+
+| Type    | Example                                             |
+| ------- | ----------------------------------------------------- |
+| string  | `"asdfghjkl"`                                        |
+| integer | `14`                                                  |
+| boolean | `true`                                                |
+| float   | `0.5`                                                 |
+| color   | `"#FF0000AA"` or `{"light":"#000","dark":"#FFF"}`     |
+| array   | `"button,link"` or `'["button","link"]'`              |
+
+**Override file**
+
+The override file name is derived from the config file name: `config.toml`
+becomes `config.override.toml`, `my-neru.toml` becomes
+`my-neru.override.toml`.
+
+**Examples**
 
 ```bash
 neru config set hints.hint_characters "asdfghjkl"
@@ -612,198 +882,285 @@ neru config set hints.ui.font_size 14
 neru config set general.passthrough_unbounded_keys true
 neru config set hints.clickable_roles "button,link"
 neru config set scroll.scroll_step 50
+
+# Interdependent fields, applied together
 neru config set --no-reload recursive_grid.grid_cols 3
 neru config set --no-reload recursive_grid.keys "abcdefghijkl"
 neru config reload
 ```
 
-**REVERTING CHANGES**
+---
 
-Changes are stored in an override file derived from your config filename (e.g. `config.toml` → `config.override.toml`, `my-neru.toml` → `my-neru.override.toml`). To revert a single field use `config reset` or manually:
+## neru config reset
+
+Remove a field from the override file.
+
+```
+neru config reset [--no-reload] <key>
+```
+
+Requires a running daemon. The field reverts to the value in the base config
+file, or the built-in default, on the next reload.
+
+| Flag          | Type | Default | Description                                                          |
+| ------------- | ---- | ------- | ---------------------------------------------------------------------- |
+| `--no-reload` | bool | `false` | Defer reloading. Run `neru config reload` after the last reset.        |
+
+**Examples**
 
 ```bash
-# Revert a single field:
 neru config reset recursive_grid.grid_cols
+
+neru config reset --no-reload recursive_grid.grid_rows
+neru config reset --no-reload recursive_grid.keys
 neru config reload
 
-# Revert all overrides:
+# Remove every override at once
 rm ~/.config/neru/config.override.toml
 neru config reload
 ```
 
-Use `neru config dump | jq` to explore all available keys and their current values.
+---
 
-### 13d. dump
+## neru config dump
 
-`neru config dump [-h|--help]`
+Print the active configuration as JSON.
 
-Print active config as JSON. Requires a running daemon.
+```
+neru config dump
+```
 
-### 13e. reset
+Requires a running daemon. Reflects the merged result of the base config,
+overrides, and defaults.
 
-`neru config reset [--no-reload] <key>`
-
-Remove a single field from the override file, reverting it to the value from your base config file (or the code default) on the next reload. Requires a running daemon.
-
-**OPTIONS**
-
-`--no-reload` — Defer reloading. Use when resetting multiple fields in sequence. Run `neru config reload` afterward.
-
-**EXAMPLES**
+**Examples**
 
 ```bash
-neru config reset recursive_grid.grid_cols
-neru config reset --no-reload recursive_grid.grid_rows
-neru config reset --no-reload recursive_grid.keys
+neru config dump | jq
+neru config dump | jq '.hints'
+```
+
+---
+
+## neru config reload
+
+Reload the configuration from disk.
+
+```
 neru config reload
 ```
 
-### 13f. reload
-
-`neru config reload [-h|--help]`
-
-Reload config from disk without restarting. Requires a running daemon. Some settings (e.g. `systray.enabled`) require a full restart.
+Requires a running daemon. Some settings, such as `systray.enabled`, take
+effect only after a full daemon restart.
 
 ---
 
-## 14. neru toggle-scroll-invert
+# Runtime toggles
 
-`neru toggle-scroll-invert [-h|--help]`
+Each toggle changes daemon state for the current session only; the configured
+value is restored on restart.
 
-Toggle scroll direction inversion at runtime. State resets to configured `invert_scroll` on daemon restart. Also accessible via systray menu.
+## neru toggle-scroll-invert
+
+Invert the scroll direction.
+
+```
+neru toggle-scroll-invert
+```
+
+Requires a running daemon. Overrides `scroll.invert_scroll` until restart. Also
+available from the systray menu.
 
 ---
 
-## 15. neru toggle-cursor-follow-selection
+## neru toggle-cursor-follow-selection
 
-`neru toggle-cursor-follow-selection [-h|--help]`
+Toggle whether the real cursor follows the selection.
 
-Toggle cursor-follow-selection in the active hints, grid, or recursive_grid session.
+```
+neru toggle-cursor-follow-selection
+```
+
+Requires a running daemon. Applies to the active hints, grid, or
+recursive_grid session.
 
 ---
 
-## 16. neru toggle-screen-share
+## neru toggle-screen-share
 
-`neru toggle-screen-share [-h|--help]`
+Hide or show overlays on shared screens.
 
-Toggle overlay visibility during screen sharing. Hidden overlays are invisible on shared screens but remain visible locally. State resets to visible on restart.
+```
+neru toggle-screen-share
+```
 
-| macOS Version | Effectiveness                         |
+**Platforms:** macOS only.
+
+Requires a running daemon. Hidden overlays remain visible locally.
+
+Implemented with the deprecated `NSWindow.sharingType` API, so effectiveness
+depends on the macOS version and the screen-sharing application:
+
+| macOS version | Behaviour                             |
 | ------------- | ------------------------------------- |
-| ≤ 14          | Works reliably                        |
+| 14 and older  | Reliable                              |
 | 15.0 – 15.3   | Partially effective                   |
-| 15.4+         | Limited (ScreenCaptureKit-based apps) |
-
-> Uses a deprecated `NSWindow.sharingType` API. Test with your setup.
+| 15.4 and newer| Limited to ScreenCaptureKit-based apps |
 
 ---
 
-## 17. neru services
+# Utilities
 
-Manage Neru as a system service for automatic startup on login. macOS only; other platforms return not-supported.
+## neru roles
 
-| Subcommand                | Description                                |
-| ------------------------- | ------------------------------------------ |
-| `neru services install`   | Install and load the launchd service       |
-| `neru services uninstall` | Unload and remove the service              |
-| `neru services start`     | Start the service                          |
-| `neru services stop`      | Stop the service                           |
-| `neru services restart`   | Restart the service                        |
-| `neru services status`    | Check if the service is loaded and running |
+List the accessibility role vocabulary.
 
-> If installed via Nix, Homebrew, or another package manager, use that tool's service manager instead.
+```
+neru roles [--explain] [-c <path>]
+```
 
----
+Does not require a running daemon. Lists the semantic roles accepted by
+`hints.clickable_roles` and `neru hints --role`, and shows how each resolves on
+the current platform.
 
-## 18. neru docs
+A role is written either as a semantic name, such as `button` or `text_field`,
+which resolves to the native roles of the current platform, or as a native role
+carrying a vocabulary prefix:
 
-`neru docs config [-h|--help]` -- Open configuration reference in browser.
+| Prefix   | Platform              | Example                    |
+| -------- | --------------------- | -------------------------- |
+| `ax:`    | macOS Accessibility   | `ax:AXDisclosureTriangle`  |
+| `atspi:` | Linux AT-SPI          | `atspi:page tab list`      |
+| `uia:`   | Windows UI Automation | `uia:Custom`               |
 
-`neru docs cli [-h|--help]` -- Open CLI reference in browser.
+Prefixed entries belonging to other platforms are ignored rather than rejected,
+so one config file can serve several machines.
 
-URLs point to the exact Git tag matching the installed version. Dev builds fall back to `main`. macOS only.
+| Flag        | Type | Default | Description                                                                                       |
+| ----------- | ---- | ------- | --------------------------------------------------------------------------------------------------- |
+| `--explain` | bool | `false` | Resolve the loaded config entry by entry, showing which native roles each contributes and which entries do not apply here. |
 
----
-
-## Scripting
+**Examples**
 
 ```bash
-# Toggle daemon on/off
+neru roles
+neru roles --explain
+```
+
+---
+
+## neru services
+
+Manage Neru as a system service that starts on login.
+
+```
+neru services install|uninstall|start|stop|restart|status
+```
+
+**Platforms:** macOS only, using launchd. Other platforms return
+`ERR_NOT_SUPPORTED`. When
+Neru was installed through Nix, Homebrew, or another package manager, use that
+tool's service manager instead.
+
+| Subcommand  | Description                                |
+| ----------- | ------------------------------------------ |
+| `install`   | Install and load the launchd service        |
+| `uninstall` | Unload and remove the service               |
+| `start`     | Start the service                           |
+| `stop`      | Stop the service                            |
+| `restart`   | Restart the service                         |
+| `status`    | Report whether the service is loaded and running |
+
+---
+
+## neru docs
+
+Open documentation in a browser.
+
+```
+neru docs config|cli
+```
+
+**Platforms:** macOS only; other platforms return `ERR_NOT_SUPPORTED`.
+
+URLs point at the Git tag matching the installed version. Development builds
+fall back to `main`.
+
+| Subcommand | Opens                       |
+| ---------- | --------------------------- |
+| `config`   | The configuration reference |
+| `cli`      | This CLI reference          |
+
+---
+
+# Scripting
+
+Neru commands are ordinary processes with conventional exit statuses, so they
+compose with shell scripts and external hotkey daemons.
+
+**Toggle the daemon**
+
+```bash
 STATUS=$(neru status | grep "Status:" | awk '{print $2}')
 if [ "$STATUS" = "running" ]; then
     neru stop
 else
     neru start
 fi
+```
 
-# External hotkey manager (skhd)
+**Check whether the daemon is reachable**
+
+```bash
+neru status &>/dev/null && echo "Running" || echo "Not running"
+```
+
+**Drive Neru from an external hotkey manager**
+
+```
 # ~/.config/skhd/skhdrc
 ctrl - f : neru hints
 ctrl - g : neru grid
 ctrl - r : neru hints --action right_click
 ctrl - t : neru hints --action left_click --repeat
-
-# Status check
-neru status &>/dev/null && echo "Running" || echo "Not running"
 ```
 
 ---
 
-## IPC Communication
+# IPC protocol
 
-CLI and daemon communicate via a Unix domain socket using JSON messages.
+The CLI and the daemon exchange JSON over a Unix domain socket, or a named pipe
+on Windows. The daemon queues incoming commands, so concurrent calls from
+scripts are safe.
 
-**Request:**
+**Request**
 
 ```json
 { "action": "hints", "params": {}, "args": [] }
 ```
 
-**Response:**
+**Response**
 
 ```json
 { "success": true, "message": "OK", "code": "OK" }
 ```
 
-Commands are queued by the daemon, so concurrent calls from scripts work safely.
+**Response codes**
 
-**Error Codes:**
+| Code                    | Meaning                                                  |
+| ----------------------- | -------------------------------------------------------- |
+| `OK`                    | Command succeeded                                        |
+| `ERR_UNKNOWN_COMMAND`   | No such command                                          |
+| `ERR_INVALID_INPUT`     | Malformed arguments or flag values                       |
+| `ERR_NOT_RUNNING`       | Neru is paused via `neru stop`                            |
+| `ERR_ALREADY_RUNNING`   | Target is already in the requested state                 |
+| `ERR_MODE_DISABLED`     | The requested mode is disabled in the configuration      |
+| `ERR_ACTION_FAILED`     | The action was dispatched but did not complete           |
+| `ERR_CHAIN_BAIL`        | An action chain aborted, for example `--bail`             |
+| `ERR_NOT_SUPPORTED`     | Not implemented on this platform                         |
+| `ERR_VERSION_MISMATCH`  | Client and daemon builds differ; restart the daemon       |
 
-| Code                  | Meaning                       |
-| --------------------- | ----------------------------- |
-| `ERR_MODE_DISABLED`   | Mode is disabled in config    |
-| `ERR_UNKNOWN_COMMAND` | Invalid command name          |
-| `ERR_CHAIN_BAIL`      | Chain aborted (e.g. `--bail`) |
-| _(connection error)_  | Daemon is not running         |
+A connection error rather than a response code means no daemon is running.
 
-### Log Monitoring
-
-```bash
-tail -f ~/Library/Logs/neru/app.log
-grep ERROR ~/Library/Logs/neru/app.log
-```
-
-### Troubleshooting
-
-**Command hangs:**
-
-```bash
-pkill -9 neru
-neru launch
-```
-
-**Socket permission errors:**
-
-```bash
-SOCK=$(grep "socket path" ~/Library/Logs/neru/app.log | tail -1 | awk '{print $NF}')
-rm -f "$SOCK"
-neru launch
-```
-
-**Daemon not running:**
-
-```bash
-neru status
-neru launch
-neru doctor
-```
+**Log file locations** are listed in
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md#log-file-locations).

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -1,6 +1,13 @@
-# Neru Coding Standards
+# Coding Standards
 
-This document defines the coding standards and conventions for the Neru project. Following these standards ensures the codebase appears written by a single developer and maintains consistency across all files.
+Cross-cutting conventions for the Neru codebase: formatting, logging,
+documentation, and commits. Following them keeps the codebase reading as though
+one person wrote it.
+
+Language-specific rules live alongside this page: [Go conventions](go/CONVENTIONS.md),
+[Objective-C guidelines](go/OBJECTIVE_C.md), and [testing patterns](testing/TESTING_PATTERNS.md).
+
+**Related:** [Development Guide](DEVELOPMENT.md) · [Architecture](ARCHITECTURE.md)
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,38 +1,118 @@
-# Configuration Guide
+# Configuration Reference
 
-Neru uses TOML for configuration. No config file is required — Neru works out of the box with sensible defaults. Only define the options you want to change; all other defaults are preserved automatically.
+Complete reference for every Neru configuration option.
 
-> "The daemon" refers to the background process started with `neru launch`.
+Neru is configured in TOML. No config file is required: Neru runs on built-in
+defaults. Define only the options you want to change — every option left out
+keeps its default. "The daemon" below means the process started by
+`neru launch`.
+
+**Related:** [CLI Reference](CLI.md) · [Tips & Tricks](TIPS_TRICKS.md) ·
+[Troubleshooting](TROUBLESHOOTING.md)
 
 ---
 
 ## Table of Contents
 
+**Getting started**
+
 - [Quick Start](#quick-start)
 - [Config File Location](#config-file-location)
 - [Managing Your Config](#managing-your-config)
 - [Runtime Config Changes](#runtime-config-changes)
+
+**Shared concepts**
+
 - [Color Format](#color-format)
 - [Hotkeys](#hotkeys)
-- [General](#general)
-- [Theme](#theme)
-- [Hints](#hints)
-- [Grid](#grid)
-- [Recursive Grid](#recursive_grid)
-- [Scroll](#scroll)
-- [Monitor Select](#monitor_select)
-- [Virtual Pointer](#virtual_pointer)
-- [Mouse Action Indicator](#mouse_action_indicator)
-- [Mode Indicator](#mode_indicator)
-- [Sticky Modifiers](#sticky_modifiers)
-- [Per-App Global Hotkey Overrides](#per-app-global-hotkey-overrides)
-- [Smooth Cursor](#smooth_cursor)
-- [Smooth Scroll](#smooth_scroll)
-- [Held Repeat](#held_repeat)
-- [Systray](#systray)
-- [Logging](#logging)
+
+**Sections**
+
+| Section                                       | Controls                                     |
+| --------------------------------------------- | -------------------------------------------- |
+| [`[general]`](#general)                       | Global behaviour, passthrough, `exec` shell   |
+| [`[theme]`](#theme)                           | Base palette all components derive from       |
+| [`[hints]`](#hints)                           | Hints mode and element discovery              |
+| [`[grid]`](#grid)                             | Grid mode                                     |
+| [`[recursive_grid]`](#recursive_grid)         | Recursive grid mode                           |
+| [`[scroll]`](#scroll)                         | Scroll mode and step sizes                    |
+| [`[monitor_select]`](#monitor_select)         | Display picker                                |
+| [`[virtual_pointer]`](#virtual_pointer)       | On-screen pointer indicator                   |
+| [`[mouse_action_indicator]`](#mouse_action_indicator) | Click feedback animation              |
+| [`[mode_indicator]`](#mode_indicator)         | Active-mode badge                             |
+| [`[sticky_modifiers]`](#sticky_modifiers)     | Sticky modifier badge                         |
+| [`[smooth_cursor]`](#smooth_cursor)           | Animated cursor movement                      |
+| [`[smooth_scroll]`](#smooth_scroll)           | Animated scrolling                            |
+| [`[held_repeat]`](#held_repeat)               | Key-repeat while held                         |
+| [`[systray]`](#systray)                       | System tray icon                              |
+| [`[logging]`](#logging)                       | Log level, file, rotation                     |
 
 ---
+
+## How to read this reference
+
+Each section below documents one TOML table. Options are listed in a table with
+this shape:
+
+| Column        | Meaning                                                   |
+| ------------- | --------------------------------------------------------- |
+| `Option`      | The key, written as it appears in the TOML table           |
+| `Type`        | `bool`, `int`, `float`, `string`, `array`, `color`, `map`  |
+| `Default`     | The built-in value used when the key is absent             |
+| `Description` | What the option does                                       |
+
+Nested tables are written with their full path, so `[hints.ui]` means a `[ui]`
+table inside `[hints]`. Options marked as overridable per app can also appear
+inside an `app_configs` entry for that section.
+
+**Platform support.** Sections and options whose behaviour is not identical on
+all three platforms carry a `Platforms:` line. Anything without one behaves the
+same on macOS, Linux, and Windows. Unsupported options are still accepted and
+validated rather than rejected, so one config file can be shared across
+machines — but see the table below for what each one does instead, because a
+few (notably `hints.strategy`) fail silently rather than degrading. The full
+list is in [Platform-specific options](#platform-specific-options).
+
+On Linux, "supported" means an X11 session or a Wayland session on wlroots or
+KWin. GNOME Wayland is not supported at all; the daemon exits at startup.
+
+---
+
+## Platform-specific options
+
+Every option not listed here behaves the same on all three platforms.
+
+| Option or section                        | macOS | Linux | Windows | Behaviour when unsupported                          |
+| ---------------------------------------- | :---: | :---: | :-----: | ---------------------------------------------------- |
+| `general.kb_layout_to_use`                | Yes   | No    | No      | Ignored; layout is detected automatically.           |
+| `general.hide_overlay_in_screen_share`    | Yes   | No    | No      | Ignored.                                             |
+| `general.passthrough_unbounded_keys`      | Yes   | Partial | No    | Linux: Wayland evdev backend only, not X11. Windows: ignored. |
+| `general.should_exit_after_passthrough`   | Yes   | Partial | No    | Follows `passthrough_unbounded_keys`.                |
+| `hints.strategy = "vision"`               | Yes   | No    | No      | Accepted by validation everywhere, but detection returns nothing and no hints appear. Set `axtree` on Linux and Windows. |
+| `[hints.vision]`                          | Yes   | No    | No      | Ignored.                                             |
+| `hints.include_menubar_hints`             | Yes   | No    | No      | Ignored; no equivalent surface exists.               |
+| `hints.additional_menubar_hints_targets`  | Yes   | No    | No      | Ignored.                                             |
+| `hints.include_dock_hints`                | Yes   | No    | No      | Ignored.                                             |
+| `hints.include_nc_hints`                  | Yes   | No    | No      | Ignored.                                             |
+| `hints.include_stage_manager_hints`       | Yes   | No    | No      | Ignored.                                             |
+| `hints.include_pip_hints`                 | Yes   | No    | No      | Ignored.                                             |
+| `hints.include_screen_capture_hints`      | Yes   | No    | No      | Ignored.                                             |
+| `hints.detect_mission_control`            | Yes   | No    | No      | Ignored.                                             |
+| `hints.on_mission_control_activated`      | Yes   | No    | No      | Never fires.                                         |
+| `hints.on_mission_control_deactivated`    | Yes   | No    | No      | Never fires.                                         |
+| `[hints.search_input_ui]`                 | Yes   | No    | Yes     | Linux: search filtering works, but the input badge is not drawn. |
+| `[monitor_select]`                        | Yes   | Yes   | No      | Windows: the mode returns `ERR_NOT_SUPPORTED`.       |
+| `[virtual_pointer]`                       | Yes   | No    | No      | Ignored; pairs with macOS-only cursor hiding.        |
+| `[smooth_cursor]`                         | Yes   | Yes   | No      | Windows: cursor moves instantly.                     |
+| `[smooth_scroll]`                         | Yes   | No    | No      | Linux and Windows: scrolling is instant.             |
+| `[recursive_grid.animation]`              | Yes   | Yes   | No      | Windows: depth transitions are not animated.         |
+
+Accessibility coverage for hints also differs in kind rather than by option; see
+[Accessibility and hints](CROSS_PLATFORM.md#accessibility-and-hints).
+
+---
+
+# Getting started
 
 ## Quick Start
 
@@ -102,7 +182,7 @@ neru config set <key> <value>   # Change a single value at runtime (see below)
 neru config reset <key>         # Remove a single override (reverts to base config)
 ```
 
-See [CLI.md](CLI.md#13-neru-config) for full flag documentation.
+See [CLI.md](CLI.md#configuration-commands) for full flag documentation.
 
 ---
 
@@ -180,6 +260,8 @@ To revert all overrides at once, delete the override file and run `neru config r
 
 ---
 
+# Shared concepts
+
 ## Color Format
 
 Colors use hex notation with optional alpha transparency.
@@ -249,7 +331,7 @@ Omitted colors inherit Neru's theme-derived defaults and update in real time whe
 | Navigation | `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown` |
 | Function   | `F1`–`F24` (`F21`–`F24` on Linux and Windows only)                 |
 
-See [CLI.md](CLI.md#12f-feed) for a full key reference with key codes and platform behavior.
+See [CLI.md](CLI.md#neru-action-feed) for a full key reference with key codes and platform behavior.
 
 Multi-key sequences (e.g. `gg`, `ab`) are supported for per-mode hotkeys with a 500ms timeout.
 
@@ -332,7 +414,7 @@ On Linux, put the `WM_CLASS` or `app_id` in the `bundle_id` field. Matching is c
 
 > **Heads up:** Linux identity strings vary by toolkit and distribution. GTK, Qt, Electron, and XWayland apps often report a `WM_CLASS`/`app_id` you would not guess (e.g. `Google-chrome`, `code`, `org.kde.konsole`). Always confirm with the commands above rather than assuming a reverse-DNS name.
 
-**GNOME/Mutter on Wayland is not supported.** Mutter implements no focused-app protocol (no `wlr-foreign-toplevel-management`), so Neru cannot tell which application is focused and per-app overrides never apply there. GNOME on **X11** works normally, as do all wlroots compositors and KWin/KDE on Wayland. See [CROSS_PLATFORM.md](./CROSS_PLATFORM.md) for the backend matrix.
+**GNOME/Mutter on Wayland is not supported at all** — the daemon exits at startup rather than running without per-app support, partly because Mutter implements no focused-app protocol (no `wlr-foreign-toplevel-management`) for Neru to identify the focused window with. GNOME on **X11** works normally, as do all wlroots compositors and KWin/KDE on Wayland. See [CROSS_PLATFORM.md](./CROSS_PLATFORM.md) for the backend matrix.
 
 Where the compositor or X11 exposes a focus-change signal, Neru applies per-app overrides the instant you switch windows; otherwise it re-checks the focused app a few times per second.
 
@@ -396,7 +478,7 @@ Inside a mode, the dispatch order is:
 
 ### Action Reference
 
-All actions available in hotkeys. These also work as `neru action <name>` — see [CLI.md](CLI.md#12-neru-action) for full flag documentation.
+All actions available in hotkeys. These also work as `neru action <name>` — see [CLI.md](CLI.md#actions) for full flag documentation.
 
 | Category    | Actions                                                                                |
 | ----------- | -------------------------------------------------------------------------------------- |
@@ -414,12 +496,13 @@ All actions available in hotkeys. These also work as `neru action <name>` — se
 | Cursor      | `hide_cursor`, `show_cursor`                                                           |
 
 - Click actions accept `--state down` / `--state up` to press and release the button as separate hotkeys, and `--toggle` to do whichever comes next from a single hotkey. `"action right_click --state down"` and `"action right_mouse_down"` are the same action written two ways; the flag form is the documented spelling, and the name form is what a mode `--action` takes (`hints --action right_mouse_down`)
-- Click actions can be chained with commas to produce multi-click sequences at one target point: `"action left_click,left_click"` double-clicks, `"action left_click,left_click,left_click"` triple-clicks. Only mouse button actions are allowed in a chain, and the names must not be separated by spaces (see [CLI.md](CLI.md#12a-left_click-right_click-middle_click))
+- Click actions can be chained with commas to produce multi-click sequences at one target point: `"action left_click,left_click"` double-clicks, `"action left_click,left_click,left_click"` triple-clicks. Only mouse button actions are allowed in a chain, and the names must not be separated by spaces (see [CLI.md](CLI.md#neru-action-left_click-right_click-middle_click))
 - Any button Neru is holding is released automatically when it returns to idle
 - `mouse_down` and `mouse_up` are the original spellings of `left_mouse_down` and `left_mouse_up`. They still work in configs, but new configs should use the explicit names
-- Use `--bare` (e.g. `"action left_click --bare"`) to target the cursor position instead of the current mode selection (see [CLI.md](CLI.md#12a-left_click-right_click-middle_click))
-- `scroll_up` / `scroll_down` support `--steps` (e.g. `"action scroll_down --steps 200"`) to override `scroll_step` (see [CLI.md](CLI.md#12d-scroll_up-scroll_down-scroll_left-scroll_right))
+- Use `--bare` (e.g. `"action left_click --bare"`) to target the cursor position instead of the current mode selection (see [CLI.md](CLI.md#neru-action-left_click-right_click-middle_click))
+- `scroll_up` / `scroll_down` support `--steps` (e.g. `"action scroll_down --steps 200"`) to override `scroll_step` (see [CLI.md](CLI.md#neru-action-scroll_up-scroll_down-scroll_left-scroll_right))
 - `reset`, `backspace`, `search_hints`, `cycle_hint`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos`, `hide_cursor`, and `show_cursor` are not valid mode `--action` values — use `neru action ...` or in hotkeys as `"action ..."`
+- `sleep` is the exception among those: it works only in hotkey bindings (`"action sleep 0.5"`), **not** as a terminal command, and it cannot appear in a comma-separated chain. See [CLI.md](CLI.md#action-sleep-hotkey-bindings-only)
 
 #### Feed Keys
 
@@ -438,7 +521,7 @@ All actions available in hotkeys. These also work as `neru action <name>` — se
 ]
 ```
 
-Use `--mode` to route keys through Neru's active mode/action pipeline instead of the OS. See [CLI.md](CLI.md#12f-feed) for syntax, supported key names, and platform behavior.
+Use `--mode` to route keys through Neru's active mode/action pipeline instead of the OS. See [CLI.md](CLI.md#neru-action-feed) for syntax, supported key names, and platform behavior.
 
 #### Composition Example
 
@@ -455,7 +538,12 @@ Use `--bail` to abort the chain when the mode exits without a selection (e.g., u
 
 ---
 
+# Sections
+
 ## [general]
+
+Global behaviour that is not tied to a single mode: app exclusions, keyboard
+layout, shortcut passthrough, and the shell used by `exec` hotkeys.
 
 | Option                                 | Type   | Default       | Description                                                                                       |
 | -------------------------------------- | ------ | ------------- | ------------------------------------------------------------------------------------------------- |
@@ -518,7 +606,7 @@ Labels clickable UI elements with short overlay labels. By default uses the macO
 
 Press `/` to text-search elements. `Space` for multi-word queries. `Return` confirms filtered hints (first is auto-selected). `Escape` cancels search.
 
-Start with search visible: `neru hints --search` (see [CLI.md](CLI.md#7-neru-hints))
+Start with search visible: `neru hints --search` (see [CLI.md](CLI.md#neru-hints))
 
 ### Options
 
@@ -536,8 +624,8 @@ Start with search visible: `neru hints --search` (see [CLI.md](CLI.md#7-neru-hin
 | `include_pip_hints`                | bool         | `false`                 | Show hints on Picture in Picture controls                                                                                                                                                                                                                                                                                            |
 | `include_screen_capture_hints`     | bool         | `false`                 | Show hints on Screen Capture controls                                                                                                                                                                                                                                                                                                |
 | `detect_mission_control`           | bool         | `false`                 | Enable Mission Control state detection                                                                                                                                                                                                                                                                                               |
-| `on_mission_control_activated`     | string/array | `nil`                   | Action(s) to execute when Mission Control opens                                                                                                                                                                                                                                                                                      |
-| `on_mission_control_deactivated`   | string/array | `nil`                   | Action(s) to execute when Mission Control closes                                                                                                                                                                                                                                                                                     |
+| `on_mission_control_activated`     | string/array | none                    | Action(s) to execute when Mission Control opens                                                                                                                                                                                                                                                                                      |
+| `on_mission_control_deactivated`   | string/array | none                    | Action(s) to execute when Mission Control closes                                                                                                                                                                                                                                                                                     |
 | `additional_menubar_hints_targets` | array        | macOS-specific defaults | Extra menubar bundle IDs                                                                                                                                                                                                                                                                                                             |
 | `clickable_roles`                  | array        | shared semantic defaults | Roles that generate hints. See [Clickable roles](#clickable-roles)                                                                                                                                                                                                                                                                  |
 | `ignore_clickable_check`           | bool         | `false`                 | Skip clickability heuristic                                                                                                                                                                                                                                                                                                          |
@@ -750,7 +838,7 @@ The `label_direction` setting controls how multi-character hint labels are enume
 - Many hints clustered in one region of the screen. `reverse` spreads the _first_ character of each label evenly across the alphabet, so labels rarely share a prefix and the hint key (the visible character) is less likely to be occluded by another element.
 - Workflows that consistently need more than `len(hint_characters)` hints.
 
-You can also mix directions per-app via `[hints.app_configs]` or per-activation via `neru hints --label-direction`. See the [per-app config table](#per-app-config) and [CLI reference](CLI.md#7-neru-hints).
+You can also mix directions per-app via `[hints.app_configs]` or per-activation via `neru hints --label-direction`. See the [per-app config table](#per-app-config) and [CLI reference](CLI.md#neru-hints).
 
 ### Per-App Config
 
@@ -780,7 +868,7 @@ visible_check_enabled = true
 
 Divides the screen into a labelled coordinate grid.
 
-Cursor behavior is chosen per invocation: `neru grid --cursor-selection-mode follow|hold` (see [CLI.md](CLI.md#8-neru-grid)). Default hotkeys include `` ` `` for `toggle-cursor-follow-selection`.
+Cursor behavior is chosen per invocation: `neru grid --cursor-selection-mode follow|hold` (see [CLI.md](CLI.md#neru-grid)). Default hotkeys include `` ` `` for `toggle-cursor-follow-selection`.
 
 ### Options
 
@@ -832,7 +920,7 @@ See [per-app hotkey overrides](#per-app-hotkey-overrides).
 
 Narrows the active area with each keypress for precise cursor placement.
 
-Cursor behavior: `neru recursive_grid --cursor-selection-mode follow|hold` (see [CLI.md](CLI.md#9-neru-recursive_grid)). Auto-zoom to a specific depth on activation with `--zoom-to-depth <n>` (e.g. `neru recursive_grid --zoom-to-depth 3`). Default hotkeys include `` ` `` for `toggle-cursor-follow-selection`.
+Cursor behavior: `neru recursive_grid --cursor-selection-mode follow|hold` (see [CLI.md](CLI.md#neru-recursive_grid)). Auto-zoom to a specific depth on activation with `--zoom-to-depth <n>` (e.g. `neru recursive_grid --zoom-to-depth 3`). Default hotkeys include `` ` `` for `toggle-cursor-follow-selection`.
 
 ### Options
 
@@ -972,6 +1060,8 @@ hotkeys = { "k" = "action scroll_up", "j" = "action scroll_down" }
 
 Interactive display picking mode. Shows per-monitor overlay badges labelled with selectable characters. Monitors are sorted in a fixed spatial order (top-to-bottom, left-to-right).
 
+**Platforms:** macOS · Linux. Not implemented on Windows.
+
 | Option       | Type   | Default       | Description                        |
 | ------------ | ------ | ------------- | ---------------------------------- |
 | `enabled`    | bool   | `false`       | Enable interactive monitor picking |
@@ -1026,7 +1116,13 @@ backdrop_color = ""
 
 ## [virtual_pointer]
 
-A small character rendered at the cursor when the system cursor is hidden. macOS only.
+A small character rendered at the cursor position when the system cursor is
+hidden.
+
+**Platforms:** macOS only. This section pairs with `hide_cursor`, which has no
+cross-platform equivalent, so it is a no-op on Linux and Windows. The separate
+virtual-pointer indicator drawn inside the recursive-grid overlay works on all
+platforms and is configured under [`[recursive_grid]`](#recursive_grid).
 
 ### UI
 
@@ -1048,7 +1144,11 @@ font_family = ""
 
 ## [mouse_action_indicator]
 
-Transient visual marker at mouse action locations. macOS only; other platforms accept the config and no-op.
+Transient visual marker drawn at the point of a mouse action.
+
+**Platforms:** all. The animation is implemented natively per platform —
+CoreAnimation on macOS, a 120fps goroutine on Linux, and a 60fps goroutine on
+Windows — so timing may differ slightly.
 
 | Option    | Type     | Default                                       | Description        |
 | --------- | -------- | --------------------------------------------- | ------------------ |
@@ -1205,8 +1305,7 @@ On Linux, the indicator renders the symbols `❖⇧⌥⌃`. If they appear as `[
 ## [smooth_cursor]
 
 Animates cursor movement between positions. Supported on macOS and Linux
-(X11, Wayland wlroots/KDE); GNOME/Wayland and Windows fall back to instant
-movement.
+(X11, Wayland wlroots/KDE); Windows falls back to instant movement.
 
 | Option               | Type  | Default | Description                        |
 | -------------------- | ----- | ------- | ---------------------------------- |
@@ -1227,7 +1326,9 @@ duration_per_pixel = 0.1
 
 ## [smooth_scroll]
 
-Splits scroll deltas into chunked ease-out events for visual feedback. macOS only; other platforms fall back to instant scrolling.
+Splits scroll deltas into chunked ease-out events for visual feedback.
+
+**Platforms:** macOS only. Linux and Windows fall back to instant scrolling.
 
 | Option               | Type  | Default | Description                        |
 | -------------------- | ----- | ------- | ---------------------------------- |
@@ -1267,6 +1368,9 @@ interval_ms = 50
 
 ## [systray]
 
+The system tray icon and its menu. Changing `enabled` requires a full daemon
+restart; `neru config reload` does not create or remove the icon.
+
 | Option    | Type | Default | Description                |
 | --------- | ---- | ------- | -------------------------- |
 | `enabled` | bool | `true`  | Show/hide the systray icon |
@@ -1276,6 +1380,9 @@ interval_ms = 50
 ---
 
 ## [logging]
+
+Log level, destination, and rotation. File paths per platform are listed in
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md#log-file-locations).
 
 | Option                 | Type   | Default  | Description                                       |
 | ---------------------- | ------ | -------- | ------------------------------------------------- |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -312,6 +312,18 @@ Omitted colors inherit Neru's theme-derived defaults and update in real time whe
 
 **Syntax:** `"Mod1+Mod2+Key" = "action"`
 
+**Defaults by platform.** macOS and Windows ship four launcher bindings:
+`Primary+Shift+Space` (hints), `Primary+Shift+G` (grid), `Primary+Shift+C`
+(recursive grid), and `Primary+Shift+S` (scroll). `monitor_select` has no
+default binding on any platform.
+
+**Linux ships no default global hotkeys at all.** They are cleared during
+startup because the defaults collide with common terminal and desktop shortcuts
+such as `Ctrl+Shift+C` (copy) and `Ctrl+Shift+V` (paste). Define the bindings
+you want in `[hotkeys]`, or bind `neru <mode>` in your compositor — see
+[Global hotkeys on Wayland](LINUX_DESKTOPS.md#global-hotkeys-on-wayland) for
+which of the two applies to your session.
+
 | Modifier  | Aliases                                 |
 | --------- | --------------------------------------- |
 | `Cmd`     | `Command`, `Super`, `Meta`              |

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -1,205 +1,500 @@
-# Cross-Platform Contributor Guide
+# Cross-Platform Guide
 
-This guide is the practical entry point for contributors working on Linux,
-Windows, or platform-neutral infrastructure in Neru.
+Neru runs on macOS, Linux, and Windows from one shared Go core. This document
+covers both sides of that:
 
-It explains:
+- **[Part 1 — Feature Parity Reference](#feature-parity-reference)**: what
+  actually works on each platform, and how it is implemented.
+- **[Part 2 — Contributor Guide](#contributor-guide)**: where platform code
+  lives, and how to add to it.
 
-- where platform code lives
-- how to choose the right file before writing code
-- how Linux backend splits work
-- when to use CGO
-- how to add a new platform capability safely
-- what tests and docs to update when you are done
-- **what actually works where** — see [Feature Parity Reference](#feature-parity-reference)
+Every claim in Part 1 is derived from code under `internal/core/infra/`,
+`internal/ui/overlay/`, and `internal/app/`. **If this document and the code
+disagree, the code wins** — and the disagreement is a bug worth fixing here.
 
-For the higher-level design, see [ARCHITECTURE.md](./ARCHITECTURE.md).
+**Related:** [Architecture](./ARCHITECTURE.md) · [Linux setup](./LINUX_SETUP.md) ·
+[Linux desktops](./LINUX_DESKTOPS.md) · [Development Guide](./DEVELOPMENT.md)
 
 ---
 
 ## Table of Contents
 
-- [Goals](#goals)
+**Part 1 — [Feature Parity Reference](#feature-parity-reference)**
+
+- [Platform Status](#platform-status)
+- [Capability Matrix](#capability-matrix)
+- [Input Injection](#input-injection)
+- [Keyboard Capture And Hotkeys](#keyboard-capture-and-hotkeys)
+- [Accessibility And Hints](#accessibility-and-hints)
+- [Overlay Rendering](#overlay-rendering)
+- [Mode Coverage](#mode-coverage)
+- [Platform Exclusives](#platform-exclusives)
+- [Known Gaps](#known-gaps)
+
+**Part 2 — [Contributor Guide](#contributor-guide)**
+
 - [First Stops](#first-stops)
-- [First 15 Minutes](#first-15-minutes)
 - [File Layout Rules](#file-layout-rules)
-- [Build And Test Commands](#build-and-test-commands)
 - [Where To Implement What](#where-to-implement-what)
+- [Build And Test Commands](#build-and-test-commands)
 - [Linux Backend Model](#linux-backend-model)
 - [Windows Model](#windows-model)
 - [CGO Guidance](#cgo-guidance)
 - [Hotkeys And Modifiers](#hotkeys-and-modifiers)
 - [Adding A New Capability](#adding-a-new-capability)
-- [Error Handling Rules](#error-handling-rules)
-- [Capability Reporting](#capability-reporting)
+- [Errors And Capability Reporting](#errors-and-capability-reporting)
 - [Testing Checklist](#testing-checklist)
 - [Documentation Checklist](#documentation-checklist)
-- [Suggested First Contributions](#suggested-first-contributions)
-- [What "Done" Looks Like](#what-done-looks-like)
-- [Feature Parity Reference](#feature-parity-reference)
-    - [Port Capability Matrix](#port-capability-matrix)
-    - [Overlay Rendering](#overlay-rendering)
-    - [Accessibility Systems](#accessibility-systems)
-    - [Input Handling](#input-handling)
-    - [Mode Feature Coverage](#mode-feature-coverage)
-    - [Linux Backend Breakdown](#linux-backend-breakdown)
-    - [Windows Feature Detail](#windows-feature-detail)
-    - [Platform-Specific Features](#platform-specific-features)
+- [Contributing Safely](#contributing-safely)
 
 ---
 
-## Goals
+# Feature Parity Reference
 
-Neru aims to make cross-platform work predictable and low-friction.
+## Platform Status
 
-The guiding principles are:
+| Aspect               | macOS (Darwin)              | Linux                                    | Windows                        |
+| -------------------- | --------------------------- | ---------------------------------------- | ------------------------------ |
+| **Status**           | Production-ready            | Beta                                     | Alpha (initial coverage)       |
+| **Build tag**        | `darwin`                    | `linux`                                  | `windows`                      |
+| **CGO**              | Required (Objective-C)      | Per-backend; most Linux backends need it | Not used (pure Go Win32 / COM) |
+| **Primary modifier** | `Cmd`                       | `Ctrl`                                   | `Ctrl`                         |
+| **Display stack**    | Cocoa / Quartz              | X11, or Wayland (wlroots / KWin)         | Win32 / DWM                    |
+| **Accessibility**    | AXUIElement                 | AT-SPI over D-Bus                        | UI Automation over COM         |
+| **Native product**   | Yes (`Neru.app`, codesigned)| Binary + install script                  | Binary                         |
+
+### Linux backends
+
+Linux is not one target. The live backend is detected once at startup from
+`XDG_CURRENT_DESKTOP`, `WAYLAND_DISPLAY`, and `DISPLAY`
+([linux_backend.go](../internal/core/infra/platform/linux_backend.go)):
+
+| Backend                | Detected when                                       | Status                       |
+| ---------------------- | --------------------------------------------------- | ---------------------------- |
+| `x11`                  | `DISPLAY` set, no `WAYLAND_DISPLAY`                 | Supported                    |
+| `wayland-wlroots`      | Sway, Hyprland, niri, River, Wayfire, or unset `XDG_CURRENT_DESKTOP` | Supported   |
+| `wayland-kde`          | `XDG_CURRENT_DESKTOP` contains `KDE`                | Supported                    |
+| `wayland-gnome`        | `XDG_CURRENT_DESKTOP` contains `GNOME`              | **Not supported**            |
+| `wayland-other`        | Any other Wayland compositor                        | **Not supported**            |
+| `unknown`              | Neither `WAYLAND_DISPLAY` nor `DISPLAY`             | **Not supported**            |
+
+> **GNOME Wayland does not run at all.** `platform.NewSystemPort` returns
+> `CodeNotSupported` for `wayland-gnome`, `wayland-other`, and `unknown`, and
+> that is the first step of daemon startup — the daemon exits instead of
+> starting in a degraded state. Mutter implements neither `wlr-layer-shell`
+> (overlays) nor `wlr-foreign-toplevel-management` (focused app), and exposes no
+> input-injection path Neru can use. **Use an X11 session under GNOME.** The
+> tables below therefore have no GNOME column: nothing runs there.
+
+---
+
+## Capability Matrix
+
+Status of each `ports.SystemPort`-level capability, with the mechanism that
+implements it. The KDE and wlroots columns differ only where noted; both are
+Wayland with `wlr-layer-shell` overlays.
+
+**Legend:** ✅ supported · ⚠️ works with known limits · 🟡 stub (`CodeNotSupported`
+or no-op) · ❌ no code path
+
+| Capability                    | macOS                    | Linux X11              | Linux Wayland (wlroots)      | Linux Wayland (KDE)     | Windows                      |
+| ----------------------------- | ------------------------ | ---------------------- | ---------------------------- | ----------------------- | ---------------------------- |
+| **Screen bounds / enumeration** | ✅ Cocoa               | ✅ XRandR              | ✅ xdg-output                | ✅ xdg-output           | ✅ `EnumDisplayMonitors`     |
+| **Display hotplug events**    | ✅ screen-params notif.  | ✅ RandR event fd      | ✅ `wl_output` events        | ✅ `wl_output` events   | 🟡                           |
+| **Focused app identity**      | ✅ NSWorkspace + AX      | ✅ `_NET_ACTIVE_WINDOW` / `WM_CLASS` | ⚠️ app_id only (see below) | ⚠️ app_id only     | ✅ `GetForegroundWindow`     |
+| **App watcher (focus change)**| ✅ NSWorkspace observer  | ✅ event-driven        | ✅ event-driven              | ✅ event-driven         | 🟡                           |
+| **Cursor position**           | ✅ `CGEventGetLocation`  | ✅ `XQueryPointer`     | ✅ sync-surface trick        | ✅ sync-surface trick   | ✅ `GetCursorPos`            |
+| **Cursor move**               | ✅ `CGWarpMouseCursorPosition` | ✅ XTest         | ✅ `zwlr_virtual_pointer`    | ✅ libei                | ✅ `SetCursorPos`            |
+| **Mouse buttons / drag**      | ✅ `CGEventPost`         | ✅ XTest               | ✅ `zwlr_virtual_pointer`    | ✅ libei                | ✅ `SendInput`               |
+| **Scroll injection**          | ✅ both axes             | ✅ both axes           | ✅ both axes (uinput + virtual pointer) | ✅ libei     | ⚠️ vertical only             |
+| **Smooth cursor animation**   | ✅                       | ✅ opt-in              | ✅ opt-in                    | ✅ opt-in               | ❌                           |
+| **Smooth scroll animation**   | ✅                       | ❌                     | ❌                           | ❌                      | ❌                           |
+| **Element discovery (hints)** | ✅ AXUIElement           | ⚠️ AT-SPI walk         | ⚠️ AT-SPI walk               | ⚠️ AT-SPI walk          | ⚠️ UIA, shallow tree         |
+| **Overlay**                   | ✅ NSPanel + CoreAnimation | ✅ X11 + Cairo       | ✅ layer-shell + Cairo       | ✅ layer-shell + Cairo  | ✅ layered HWND + GDI        |
+| **Global hotkeys**            | ✅ per-key CGEventTap    | ✅ `XGrabKey`          | ⚠️ passive evdev read        | ⚠️ passive evdev read   | ✅ `RegisterHotKey`          |
+| **Keyboard capture**          | ✅ CGEventTap            | ✅ `XGrabKeyboard`     | ✅ evdev grab (wl-keyboard fallback) | ✅ evdev grab   | ✅ `WH_KEYBOARD_LL`          |
+| **Modifier passthrough**      | ✅                       | ❌                     | ✅ evdev backend only        | ✅ evdev backend only   | ❌                           |
+| **Dark mode detection**       | ✅ Cocoa appearance      | ✅ xdg appearance portal | ✅ xdg appearance portal   | ✅ kdeglobals + portal  | ✅ registry                  |
+| **Font resolution**           | ✅ NSFont                | ✅ fontconfig          | ✅ fontconfig                | ✅ fontconfig           | ⚠️ generic-alias map only ¹  |
+| **System tray**               | ✅ NSStatusItem          | ✅ D-Bus StatusNotifierItem | ✅ StatusNotifierItem   | ✅ Win32 notification area | ✅                        |
+| **Native alerts**             | ✅ NSAlert               | 🟡                     | 🟡                           | 🟡                      | ✅ `MessageBoxW`             |
+| **Native notifications**      | ✅ UNNotification        | 🟡                     | 🟡                           | 🟡                      | 🟡                           |
+| **Secure input detection**    | ✅                       | 🟡 always false        | 🟡 always false              | 🟡 always false         | 🟡 always false              |
+| **System cursor hide**        | ✅ `CGDisplayHideCursor` | ❌                     | ❌                           | ❌                      | ❌                           |
+| **`monitor_select` mode**     | ✅ native panels         | ✅ Cairo panels        | ✅ Cairo panels              | ✅ Cairo panels         | 🟡 `CodeNotSupported`        |
+
+¹ macOS and Linux resolve font *families* through the OS (NSFont, fontconfig).
+Windows only maps the generic aliases `sans` / `serif` / `mono` to Segoe UI /
+Cambria / Consolas and passes every other name through verbatim; an unavailable
+family falls back to whatever GDI substitutes.
+
+### Notes on the ⚠️ entries
+
+**Focused app on Wayland.** wlroots and KWin resolve the focused window through
+`wlr-foreign-toplevel-management`, which exposes the window's **app_id** — used
+as the bundle identifier for per-app config — but not its PID, because a Wayland
+client cannot read another client's process credentials.
+`SystemPort.FocusedApplicationPID` best-effort matches the app_id against
+`/proc`; with no match it returns `CodeNotSupported` carrying the app_id rather
+than a fabricated number.
+
+**App watcher.** macOS gets focus changes pushed from an NSWorkspace observer.
+Linux has no equivalent single API, so `appwatcher/platform_linux.go` subscribes
+to a backend focus-change fd (`linux.SubscribeFocusedApp`: X11 event fd, or the
+wlroots toplevel manager) and re-samples on each wake — near-instant per-app
+hotkey re-registration — with a 3s safety re-sample against coalesced events.
+When no fd is available it degrades to polling `FocusedAppID` every 400ms. The
+identity is the **WM_CLASS** (X11) or **app_id** (Wayland). A sibling goroutine
+watches a display-configuration fd and dispatches screen-parameter changes, so
+monitor hotplug regenerates overlays like it does on macOS. Only
+activate/deactivate/screen-params are emitted; launch, terminate, and Mission
+Control events remain macOS-only.
+
+**Global hotkeys on Wayland.** No Wayland protocol lets an ordinary client
+register a global hotkey, so Neru reads `/dev/input/event*` directly with a
+**passive** evdev listener — it does not grab devices or inject anything, so the
+focused app still receives every key
+([global_hotkey_linux_cgo.go](../internal/core/infra/eventtap/global_hotkey_linux_cgo.go)).
+Two conditions apply: the process needs read access to `/dev/input` (add your
+user to the `input` group), and it requires CGO — a `CGO_ENABLED=0` build gets a
+no-op stub. When the listener cannot start, Neru logs a warning pointing at both
+the `input` group and the fallback: bind `neru <mode>` as a compositor
+keybinding. While a mode is active the in-mode event tap grabs the same devices,
+so the listener naturally goes quiet until the mode exits.
+
+**Smooth cursor animation on Linux.** Off by default; opt in with
+`smooth_cursor.move_mouse_enabled` (the same cross-platform `SmoothCursorConfig`
+macOS uses). When enabled, `SystemAdapter.MoveCursorToPoint` routes through
+`smoothCursorAnimator` ([mouse_animator_linux.go](../internal/core/infra/platform/linux/mouse_animator_linux.go)):
+one worker goroutine samples the current position, then steps the per-backend
+warp (XTest / `zwlr_virtual_pointer` / libei) toward the target by linear
+interpolation, and `WaitForCursorIdle` blocks until it settles. This mirrors the
+darwin animator (coalescing, latest-target-wins) but drives discrete warps
+rather than a Quartz event stream, so there is no drag-event distinction. It
+covers the same flows macOS animates — grid/recursive-grid cursor-follow,
+`move_mouse`, selection moves; clicks stay instant. On Wayland the interpolation
+start point comes from the client-side cursor cache, so a stale read only skews
+the glide path, never the landing point.
+
+---
+
+## Input Injection
+
+Every action type in
+[action.go](../internal/core/domain/action/action.go) — left/right/middle click,
+per-button down/up/toggle, absolute and relative moves, drag-while-held, and
+scroll — is dispatched through the shared `InfraAXClient.PerformAction`. The
+dispatch, the action set, and the mode logic that drives it are platform-neutral
+Go; only the final injection primitive differs:
+
+| Platform              | Primitive                                                      |
+| --------------------- | -------------------------------------------------------------- |
+| macOS                 | `CGEventPost` (+ `CGWarpMouseCursorPosition` for moves)         |
+| Linux X11             | XTest (`XWarpPointer`, buttons 1/2/3, scroll buttons 4/5)       |
+| Linux Wayland wlroots | `zwlr_virtual_pointer` (+ `/dev/uinput` for scroll)             |
+| Linux Wayland KDE     | libei via `org.freedesktop.portal.RemoteDesktop`                |
+| Windows               | `SendInput` / `SetCursorPos`                                    |
+
+**The one behavioral difference:** Windows `ScrollAtCursor` ignores `deltaX`, so
+horizontal scrolling is a no-op there. Everything else behaves the same on all
+three platforms.
+
+**Held mouse buttons.** Press and release are separate actions, so every backend
+must remember what it pressed — and that bookkeeping is shared, not
+per-platform. Each adapter keeps a
+[`mousestate.Tracker`](../internal/core/infra/platform/mousestate/tracker.go)
+recording which buttons are down, where, and with which modifiers. It drives
+three behaviors identically everywhere: toggle actions resolve against it (held
+→ release, free → press), `EnsureMouseUp` releases every held button when Neru
+returns to idle, and on macOS it selects the drag event type for cursor moves.
+macOS is the only backend needing that last distinction — Quartz requires
+`kCGEventLeftMouseDragged` / `RightMouseDragged` / `OtherMouseDragged` with a
+matching button number instead of `kCGEventMouseMoved`, while X11, Wayland, and
+Windows simply warp the pointer and let the compositor or OS infer the drag.
+When several buttons are held at once a macOS move is attributed to the
+left-most held button, since one event cannot describe more.
+
+---
+
+## Keyboard Capture And Hotkeys
+
+| Aspect                | macOS                  | Linux X11               | Linux Wayland                            | Windows                 |
+| --------------------- | ---------------------- | ----------------------- | ---------------------------------------- | ----------------------- |
+| **In-mode capture**   | `CGEventTapCreate`     | `XGrabKeyboard`         | evdev `EVIOCGRAB`, wl-keyboard fallback  | `WH_KEYBOARD_LL`        |
+| **Global hotkeys**    | Per-key CGEventTap     | `XGrabKey`              | Passive evdev read                       | `RegisterHotKey`        |
+| **CGO needed**        | Yes                    | Yes                     | Yes                                      | No                      |
+| **Press/release**     | ✅ separate callbacks  | ✅ KeyPress/KeyRelease  | ⚠️ press-only in some configs            | ✅ `WM_HOTKEY` flags    |
+| **Modifier passthrough** | ✅                  | ❌ grab is all-or-nothing | ✅ evdev only                          | ❌ no-op                |
+| **`PostModifierEvent`** | ✅                   | ✅                      | ✅ (`zwp_virtual_keyboard_v1`)           | ❌ no-op                |
+| **Sticky modifiers**  | ✅                     | ✅                      | ✅                                       | ✅                      |
+| **Capture files**     | `eventtap_darwin.go`   | `eventtap_linux_x11.go` | `eventtap_linux_wayland.go`, `..._evdev_cgo.go` | `eventtap_windows.go` |
+| **Hotkey files**      | `manager_darwin.go`    | `manager_linux_x11.go`  | `manager_linux_common.go` + `eventtap/global_hotkey_linux_cgo.go` ³ | `manager_windows.go` |
+
+³ `hotkeys/manager_linux_wayland.go` is an empty placeholder — the Wayland
+hotkey path lives in the common manager, which delegates to the evdev listener
+in the eventtap package.
+
+**Modifier passthrough (Wayland evdev only).** While a mode is active Neru
+captures the keyboard exclusively, so shortcuts it does not bind (`Ctrl+C`,
+`Ctrl+Tab`) are normally swallowed. With `general.passthrough_unbounded_keys`,
+unbound Ctrl/Alt/Cmd chords are re-injected to the focused app instead. This
+works on the Wayland evdev backend because Neru holds `EVIOCGRAB` on the
+physical device but injects through a *separate* `zwp_virtual_keyboard_v1`,
+which bypasses that grab and reaches the app with no feedback loop (see
+`handleWaylandEvdevEvent` → `passthroughEvdevChord`). It is **not** available on
+X11 — an `XGrabKeyboard` routes Neru's own synthetic XTest events back to
+itself, and `XSendEvent` is ignored by most apps — nor on the rare wl-keyboard
+fallback, which has no injection path. Classification (blacklist,
+mode-intercepted keys, the mode's own hotkeys) and the post-passthrough hint
+refresh are shared in
+[passthrough.go](../internal/app/modes/passthrough.go); only the final
+re-injection is backend-specific. The blacklist keeps chosen chords consumed,
+and `general.should_exit_after_passthrough` exits the mode after a passthrough.
+
+---
+
+## Accessibility And Hints
+
+| Aspect                  | macOS                                       | Linux                                              | Windows                              |
+| ----------------------- | ------------------------------------------- | -------------------------------------------------- | ------------------------------------ |
+| **Backend**             | AXUIElement (CGO ObjC bridge)               | AT-SPI over D-Bus (pure Go)                        | UI Automation over COM (pure Go)     |
+| **Client**              | `InfraAXClient` → ObjC bridge               | `ATSPIClient` → `org.a11y.atspi`                   | `UIAClient` → raw COM vtables        |
+| **Files**               | `element_darwin.go`, `tree.go`              | `element_linux.go`, `atspi_linux.go`               | `element_windows.go`, `uia_windows.go`, `tree_windows.go` |
+| **Traversal**           | Full recursive walk of the AXUIElement hierarchy | Recursive walk of the active frame's subtree, depth/node capped | Shallow walk of root-level nodes |
+| **Sources collected**   | Frontmost + all windows, popovers, menubar, dock, notification center, Stage Manager, PIP | Active frame's subtree only          | Root element's children only         |
+| **Filtering**           | Role matching, size/position heuristics, excluded apps, dedup | Native AT-SPI roles, `SHOWING` state, on-screen extents | `IsControlElement` + `IsContentElement`, non-zero bounds |
+| **Strategies**          | `axtree` (default) and `vision`, incl. per-app overrides | `axtree` only                          | `axtree` only                        |
+| **Popovers / menus**    | ✅ dedicated detection                      | ⚠️ only if inside the active frame's subtree       | 🟡                                   |
+
+macOS builds the richest tree by a wide margin: it walks multiple window and
+system sources, applies per-app strategy overrides, can fall back to the Vision
+framework for OCR-discovered targets, and deduplicates overlapping elements.
+Linux and Windows each walk a single tree with no OCR fallback.
+
+**Linux is ⚠️, not a stub.** Hints genuinely work: `ATSPIClient` enables
+assistive-tech mode, finds the active frame, and walks it (`ClickableNodes`)
+emitting native AT-SPI role names. Configured roles are resolved into that same
+vocabulary at config load (`element.ResolveRoles`), so both sides of the filter
+speak AT-SPI. This is the path the Linux adapter actually uses
+(`platform_client_linux.go` → `Adapter.ClickableElements` → `client.ClickableNodes`);
+the `TreeNode` / `BuildTree` stub in `tree_linux.go` is the macOS-style tree API
+and is **not** on the Linux hints path. The ⚠️ is about coverage: it depends on
+each app exposing AT-SPI. Qt and GTK apps do with accessibility enabled; some
+toolkits expose almost nothing, and there is no Vision/OCR fallback.
+
+**Chromium and Electron apps on Linux.** Chromium-based apps (Chrome, Electron,
+forks such as Helium) do not expose their web-content tree over AT-SPI by
+default — they gate it behind their own runtime detection, and unlike macOS
+there is no per-app attribute Neru can toggle to force it (the macOS
+`AXManualAccessibility` nudge in `electron.EnsureAccessibility` is a no-op on
+Linux). The result is an AT-SPI frame with a single empty child, so hints find
+nothing inside such windows. Launch the app with
+`--force-renderer-accessibility` to force the full tree. Native GTK/Qt apps and
+Firefox need no flag. This is Chromium behavior, not a Neru limitation.
+
+**Picking the active frame on Wayland.** The AT-SPI `ACTIVE` state is unreliable
+on wlroots compositors (niri, Sway, Hyprland) — the focused window can report
+`ACTIVE=false` while background frames report `ACTIVE=true`. Neru therefore
+matches the AT-SPI frame against the compositor's focused **app_id** (from
+`wlr-foreign-toplevel-management`, the same source as the app watcher), falling
+back to the `ACTIVE`/`SHOWING` heuristic only on X11 or when no app_id is
+available. See `findActiveFrame` in `atspi_linux.go`.
+
+**Window-origin offset on Wayland.** A Wayland client cannot know its own
+on-screen position, so AT-SPI reports element coordinates relative to the
+window. Neru offsets them by the focused window's screen origin, supplied by a
+compositor-specific `windowOriginSource`
+([window_origin_linux.go](../internal/core/infra/accessibility/window_origin_linux.go)):
+
+| Compositor | Source                                                       | Limits                                                                                                                    |
+| ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| KDE / KWin | KWin script pushing focused-window geometry over D-Bus       | —                                                                                                                          |
+| niri       | `niri msg -j focused-window` / `focused-output`              | Floating and fullscreen windows only. **Tiled** windows — including a maximized column (`Mod+F`) — expose no on-screen position ([niri#2381](https://github.com/niri-wm/niri/issues/2381)), so hints are misaligned there. |
+| Sway       | `swaymsg -t get_tree`, focused node `rect` + `window_rect`   | —                                                                                                                          |
+| Hyprland   | `hyprctl -j activewindow` `at` / `size`                      | —                                                                                                                          |
+
+Each source verifies the reported window size matches the AT-SPI frame (a focus
+change can race the query) and is best-effort: an unavailable origin degrades to
+unoffset window-relative coordinates rather than misplacing hints.
+
+---
+
+## Overlay Rendering
+
+### Architecture
+
+The three platforms split responsibility differently, which is the single most
+important thing to know before touching overlay code:
+
+- **macOS** — each component owns its own NSPanel. Component files such as
+  `components/hints/overlay_darwin.go` call the Objective-C bridge directly, and
+  rendering is GPU-backed via CoreAnimation.
+- **Linux and Windows** — component files are stubs holding only `Style` /
+  `BuildStyle`. All real rendering happens in the overlay **manager**
+  (`manager_linux_x11.go`, `manager_linux_wayland_cgo.go`, `manager_windows*.go`),
+  drawing every element into one shared surface.
+
+### Implementation
+
+| Aspect                | macOS                                    | Linux X11                              | Linux Wayland                                   | Windows                            |
+| --------------------- | ---------------------------------------- | -------------------------------------- | ------------------------------------------------ | ---------------------------------- |
+| **Window type**       | NSPanel, borderless non-activating       | override-redirect X11 window           | `wlr_layer_shell_v1` overlay surface             | layered `WS_POPUP` HWND            |
+| **Rendering**         | CoreAnimation (CALayer, GPU)             | Cairo on an Xlib surface (CPU)         | Cairo into SHM buffers (CPU)                     | GDI + software SDF, BGRA (CPU)     |
+| **Per-pixel alpha**   | clear color + non-opaque layer           | `CAIRO_OPERATOR_CLEAR`                 | `CAIRO_OPERATOR_CLEAR`                           | `AC_SRC_ALPHA` via `UpdateLayeredWindow` |
+| **Click-through**     | `setIgnoresMouseEvents:YES`              | XFixes empty input region              | empty `wl_surface` input region                  | `WS_EX_TRANSPARENT`                |
+| **Always on top**     | `NSScreenSaverWindowLevel`               | `_NET_WM_STATE_ABOVE` + `MapRaised`    | overlay layer                                    | `HWND_TOPMOST`                     |
+| **Focus prevention**  | non-activating panel                     | `override_redirect=YES`                | controlled keyboard interactivity                | `WS_EX_NOACTIVATE`                 |
+| **HiDPI**             | dynamic `contentsScale` + backing-change callback | `Xft.dpi`, one global factor  | `wl_output` scale + `wp_fractional_scale_v1` / `wp_viewporter` | not explicit           |
+| **Multi-monitor**     | per-display clamping, screen-change tracking | all monitors enumerated, per-monitor render, live RandR hotplug | one `wl_surface` per output (max 16), live hotplug | cursor-screen tracking, separate indicator/sticky windows |
+| **Buffers**           | layer-backed, OS-managed                 | single Cairo surface                   | triple-buffered SHM pool                         | single pixel buffer                |
+| **Rounded rects / borders** | NSBezierPath                       | Cairo arc path + stroke                | Cairo arc path + stroke                          | software SDF fill + multi-pass stroke |
+| **Text**              | NSFontManager                            | Cairo `select_font_face` / `show_text` | Cairo `select_font_face` / `show_text`           | GDI `CreateFontW` + `DrawTextW` + alpha composite |
+| **Coordinate origin** | bottom-left (Y-flipped in the adapter)   | top-left                               | top-left                                         | top-left (negative DIB height)     |
+| **Thread model**      | main-thread dispatch                     | `renderMu` mutex                       | `displayMu` mutex (shared with `renderMu`)       | dedicated UI thread (`LockOSThread`) |
+
+### Animation
+
+| Animation                    | macOS                                | Linux X11 / Wayland                | Windows                            |
+| ---------------------------- | ------------------------------------ | ---------------------------------- | ---------------------------------- |
+| **Grid transition**          | CoreAnimation, ease-in-out @120Hz    | goroutine, smoothstep @120fps      | ❌                                 |
+| **Mouse action indicator**   | `CABasicAnimation` (scale + opacity) | goroutine, scale + opacity @120fps | goroutine, cubic easing @60fps     |
+| **Smooth cursor**            | ✅ configurable easing               | ✅ stepped warp (opt-in)           | ❌                                 |
+| **Smooth scroll**            | ✅ ease-out cubic                    | ❌                                 | ❌                                 |
+
+---
+
+## Mode Coverage
+
+Mode logic — labelling, alphabets, matching, search filtering, grid subdivision,
+recursion depth, scroll amounts, cell navigation — is pure domain Go under
+`internal/core/domain/` and behaves **identically on all three platforms**. Only
+the rows below differ, and every difference traces to rendering or element
+discovery rather than the mode itself.
+
+| Mode              | Feature                        | macOS                      | Linux                      | Windows                     |
+| ----------------- | ------------------------------ | -------------------------- | -------------------------- | --------------------------- |
+| **Hints**         | Element discovery              | ✅ full AX tree            | ⚠️ AT-SPI, toolkit-dependent | ⚠️ UIA, shallow tree      |
+| **Hints**         | `vision` strategy + per-app overrides | ✅                  | ❌ macOS-only              | ❌ macOS-only               |
+| **Hints**         | Menubar / dock elements        | ✅                         | 🟡                         | 🟡                          |
+| **Hints**         | Search input badge             | ✅                         | ❌ no-op                   | ✅                          |
+| **Hints**         | Label arrow / tail             | ✅ NSBezierPath            | ✅ Cairo triangle          | ❌                          |
+| **Grid**          | Transition animation           | ✅                         | ✅                         | ❌                          |
+| **Grid**          | Sub-key preview                | ✅ centered mini-grid      | ✅ centered mini-grid      | ⚠️ single-line bottom text  |
+| **Recursive grid**| Transition animation           | ✅                         | ✅                         | ❌                          |
+| **Recursive grid**| Virtual pointer indicator      | ✅                         | ✅                         | ✅                          |
+| **Scroll**        | Smooth scroll animation        | ✅                         | ❌                         | ❌                          |
+| **Monitor select**| Whole mode                     | ✅ native panels           | ✅ Cairo panels            | 🟡 `CodeNotSupported`       |
+
+Everything else is shared: multi-letter labels, label direction, hide-unmatched,
+split-word, interactive search *behavior* (only the on-screen badge differs),
+boundary highlight, mode indicator, sticky-modifier indicator, all pending
+actions on grid cells, subgrid zoom, backtracking, and every scroll granularity.
+
+> The **cursor-replacement virtual pointer** — the pointer drawn when the real
+> cursor is hidden — is separate from the recursive-grid indicator above and is
+> macOS-only: `virtualpointer.Overlay` is a no-op on every non-darwin build, and
+> it is paired with `CGDisplayHideCursor`, which has no equivalent elsewhere.
+
+---
+
+## Platform Exclusives
+
+Features available on exactly one platform, with why they do not port:
+
+| Feature                                   | Platform | Location                                                | Why it is exclusive                                          |
+| ----------------------------------------- | -------- | ------------------------------------------------------- | ------------------------------------------------------------ |
+| System cursor hide + virtual-pointer replacement | macOS | `modes/cursor_darwin.go`, `components/virtualpointer/overlay_darwin.go` | `CGDisplayHideCursor` has no X11/Wayland/Win32 equivalent |
+| Smooth scroll animation                   | macOS    | `platform/darwin/scroll_animator.go`                    | Needs a synthesizable continuous scroll event stream          |
+| Vision (OCR) hint strategy                | macOS    | `ports/vision.go`, `platform/darwin/vision_darwin.m`    | macOS-only `VNRequest` APIs                                   |
+| Screen-sharing hide                       | macOS    | `platform/darwin/overlay_darwin.m`                      | NSWindow sharing level is a Quartz concept                    |
+| Secure input detection                    | macOS    | `platform/darwin/secureinput.go`                        | `CGSessionCopyCurrentDictionary`, a private API               |
+
+Linux and Windows have no exclusive *user-facing* features — their unique
+elements (evdev, `zwlr_virtual_pointer`, libei, the Wayland sync-cursor surface,
+`WH_KEYBOARD_LL`, `RegisterHotKey`, SDF rendering) are platform *mechanisms*
+serving cross-platform features, and are listed in the
+[Capability Matrix](#capability-matrix).
+
+---
+
+## Known Gaps
+
+Work that is genuinely missing, as opposed to deliberately platform-specific.
+
+**Linux**
+
+1. Native notifications and alerts — stubs; target freedesktop D-Bus notifications
+2. Smooth scroll animation — not implemented
+3. GNOME/Mutter Wayland — unsupported; the daemon refuses to start
+4. Hints search input badge — no-op in the overlay manager
+5. Secure input detection — always false
+6. Wayland global hotkeys — need `input`-group access and a CGO build
+
+**Windows**
+
+1. App watcher — no foreground-window change notifications, so per-app config never re-applies
+2. Display hotplug — no screen-parameter change events
+3. Native notifications — no toast support
+4. UIA tree depth — shallow walk; complex apps under-report clickable elements
+5. Grid and recursive-grid transition animation — not implemented
+6. Smooth cursor and smooth scroll animation — not implemented
+7. Modifier passthrough and `PostModifierEvent` — no-ops
+8. Horizontal scroll — `ScrollAtCursor` ignores `deltaX`
+9. `monitor_select` mode — returns `CodeNotSupported`
+10. Font resolution — alias mapping only, no system font enumeration
+
+**macOS**
+
+No known functional gaps; it is the reference implementation.
+
+---
+
+# Contributor Guide
+
+Guiding principles:
 
 - shared business logic stays in pure Go
 - platform-specific code is easy to locate
 - Linux backend differences are explicit
 - contributors implement in existing slots instead of inventing new file layout
-- unsupported features fail clearly with `CodeNotSupported`
-
----
+- unsupported features fail loudly with `CodeNotSupported`
 
 ## First Stops
 
-Before changing code, read these files first:
+Read these before changing platform code:
 
-- [internal/core/infra/platform/profile.go](../internal/core/infra/platform/profile.go)
-- [internal/core/ports/system.go](../internal/core/ports/system.go)
-- [internal/core/ports/capabilities.go](../internal/core/ports/capabilities.go)
-- [internal/core/ports/capability_presets.go](../internal/core/ports/capability_presets.go)
-- [internal/core/ports/font.go](../internal/core/ports/font.go) — FontResolver port (fontconfig on Linux, NSFont on macOS)
-- [ARCHITECTURE.md](./ARCHITECTURE.md)
-- [CONVENTIONS.md](./go/CONVENTIONS.md)
+- [platform/profile.go](../internal/core/infra/platform/profile.go) — per-subsystem backend family and CGO expectations
+- [ports/system.go](../internal/core/ports/system.go) — the main OS contract
+- [ports/capabilities.go](../internal/core/ports/capabilities.go) and [capability_presets.go](../internal/core/ports/capability_presets.go) — what `neru doctor` reports
+- [ports/font.go](../internal/core/ports/font.go) — FontResolver port
+- [ARCHITECTURE.md](./ARCHITECTURE.md) and [CONVENTIONS.md](./go/CONVENTIONS.md)
 
-If you are contributing Linux support, also inspect the reserved backend files in
-the package you plan to touch, such as:
-
-- `*_linux_common.go`
-- `*_linux_x11.go`
-- `*_linux_wayland.go`
-
----
-
-## First 15 Minutes
-
-If you are new to the codebase, this is the recommended startup path.
-
-### Any platform
-
-1. Read [profile.go](../internal/core/infra/platform/profile.go)
-2. Read the relevant port in `internal/core/ports/`
-3. Find the implementation slot you expect to touch
-4. Run:
-
-```bash
-just build
-just test-foundation
-```
-
-### Linux contributors
-
-1. Identify whether your work belongs in `common`, `x11`, or `wayland`
-2. Open the target file in that slot before writing code
-3. Build a Linux foundations binary from any host if needed:
-
-```bash
-just build-linux
-```
-
-4. If you are on Linux, also run:
-
-```bash
-just test
-```
-
-### Windows contributors
-
-1. Start in the `*_windows.go` slot for the package you are changing
-2. Build a Windows foundations binary from any host if needed:
-
-```bash
-just build-windows
-```
-
-3. If you are on Windows, run:
-
-```bash
-just test
-```
-
-### macOS contributors
-
-If your work touches the real native product path, run:
-
-```bash
-just build-darwin
-just test
-```
-
----
+Contributing Linux support? Also open the reserved backend files in the package
+you plan to touch (`*_linux_common.go`, `*_linux_x11.go`, `*_linux_wayland.go`)
+before writing anything.
 
 ## File Layout Rules
 
-Platform-specific files should make the intended implementation slot obvious.
+Platform files make the implementation slot obvious. Use these suffixes:
 
-Use these suffixes:
+| Suffix                            | Meaning                                                   |
+| --------------------------------- | --------------------------------------------------------- |
+| `*_darwin.go`                     | macOS                                                     |
+| `*_windows.go`                    | Windows                                                   |
+| `*_other.go`                      | non-target fallback for dispatch-style packages           |
+| `*_linux_common.go`               | Linux-shared wrapper, fallback, or backend routing        |
+| `*_linux_x11.go`                  | X11                                                       |
+| `*_linux_wayland.go`              | Wayland                                                   |
+| `*_linux_wayland_<compositor>.go` | one compositor family needing a distinct path             |
+| `*_cgo.go` / `*_nocgo.go`         | CGO and pure-Go variants of the same slot                 |
 
-- `*_darwin.go`: macOS implementation
-- `*_windows.go`: Windows implementation
-- `*_linux_common.go`: shared Linux wrapper or current fallback behavior
-- `*_linux_x11.go`: Linux X11 implementation slot
-- `*_linux_wayland.go`: Linux Wayland implementation slot
-- `*_linux_wayland_<compositor>.go`: Wayland compositor sub-slot when one
-  compositor family needs a distinct implementation (e.g.
-  `*_linux_wayland_wlroots.go`, `*_linux_wayland_kde.go`). Still the same
-  package + build tags; selection is at runtime (see Linux Backend Model).
-- `*_other.go`: non-target fallback for dispatch-style packages
+Two rules that save review cycles:
 
-App-level platform dispatch also follows this pattern. For example,
-per-hotkey CGEventTaps are re-registered on layout change (via
-`NeruSetKeymapLayoutChangeCallback2`) because `NeruKeyNameToCode` maps
-key names to layout-aware keycodes.
-
-Do not create new ad hoc platform filenames if an existing slot already exists.
-
-Do not create fake empty `darwin` / `linux` / `windows` files just for symmetry.
-Only add a new file when there is a real new implementation slot.
-
----
-
-## Build And Test Commands
-
-These are the main contributor commands:
-
-| Goal                                            | Command                |
-| ----------------------------------------------- | ---------------------- |
-| build for current host                          | `just build`           |
-| build macOS binary on macOS                     | `just build-darwin`    |
-| build Linux foundations binary                  | `just build-linux`     |
-| build Windows foundations binary                | `just build-windows`   |
-| run focused cross-platform-safe tests           | `just test-foundation` |
-| run full unit + integration suite on current OS | `just test`            |
-| run lint checks                                 | `just lint`            |
-
-Notes:
-
-- `just build-linux` produces a Beta backend with overlay rendering, hints,
-  grid, scroll, input injection, multi-monitor (per-monitor rendering, HiDPI /
-  fractional scaling, live hotplug), and `monitor_select` on X11 and
-  wlroots/KWin Wayland; GNOME/Mutter Wayland stays unsupported.
-- `just build-windows` produces a binary with grid, recursive grid,
-  scroll, global hotkeys, mouse injection, IPC, and initial UIA accessibility.
-- `just release-ci-linux <version>` and `just release-ci-windows <version>` to release a version tagged binary in ci.
-- macOS remains the only fully native product path today.
-
----
+- **Do not invent new ad hoc platform filenames** when a slot already exists.
+- **Do not create empty `darwin` / `linux` / `windows` files for symmetry.** Add
+  a file only when there is a real implementation slot behind it.
 
 ## Where To Implement What
-
-Use this table as the default routing guide.
 
 | Capability                                                   | Primary location                                             |
 | ------------------------------------------------------------ | ------------------------------------------------------------ |
@@ -207,832 +502,228 @@ Use this table as the default routing guide.
 | global hotkeys                                               | `internal/core/infra/hotkeys/`                               |
 | keyboard event capture                                       | `internal/core/infra/eventtap/`                              |
 | accessibility integration                                    | `internal/core/infra/accessibility/`                         |
-| overlay window orchestration                                 | `internal/ui/overlay/`                                       |
-| overlay rendering by mode                                    | `internal/app/components/*/overlay_*.go`                     |
-| app watcher / isolated platform hooks                        | dispatch-style `platform_*.go` files in the relevant package |
+| overlay window orchestration **and all Linux/Windows drawing** | `internal/ui/overlay/`                                     |
+| overlay rendering by mode (**macOS only**; stubs elsewhere)  | `internal/app/components/*/overlay_*.go`                     |
+| app watcher and other isolated platform hooks                | dispatch-style `platform_*.go` in the relevant package       |
 
-Examples:
+Worked examples:
 
-- X11 hotkeys belong in [manager_linux_x11.go](../internal/core/infra/hotkeys/manager_linux_x11.go)
-- Wayland keyboard capture belongs in [eventtap_linux_wayland.go](../internal/core/infra/eventtap/eventtap_linux_wayland.go)
-- shared Linux system fallbacks belong in [system_linux_common.go](../internal/core/infra/platform/linux/system_linux_common.go)
+- X11 hotkeys → [manager_linux_x11.go](../internal/core/infra/hotkeys/manager_linux_x11.go)
+- Wayland keyboard capture → [eventtap_linux_wayland.go](../internal/core/infra/eventtap/eventtap_linux_wayland.go)
+- shared Linux system fallbacks → [system_linux_common.go](../internal/core/infra/platform/linux/system_linux_common.go)
 
----
+## Build And Test Commands
+
+| Goal                                            | Command                |
+| ----------------------------------------------- | ---------------------- |
+| build for current host                          | `just build`           |
+| build macOS binary (on macOS)                   | `just build-darwin`    |
+| build Linux binary                              | `just build-linux`     |
+| build Windows binary                            | `just build-windows`   |
+| focused cross-platform-safe tests               | `just test-foundation` |
+| full unit + integration suite on current OS     | `just test`            |
+| lint                                            | `just lint`            |
+| tagged release binaries in CI                   | `just release-ci-linux <arch> <version>`, `just release-ci-windows <arch> <version>` |
+
+New to the codebase? `just build && just test-foundation` first, then find the
+slot you expect to touch before writing code. Cross-compiled binaries build from
+any host, but only the target OS can run `just test` meaningfully — integration
+tests are tagged per-OS.
 
 ## Linux Backend Model
 
-Linux is treated as a backend family, not a single target.
+Linux is a backend *family*, not a single target. Keep two axes separate:
 
-The expected split is:
+- **Compile-time axis (OS + CGO)** — expressed by build tags and file suffixes.
+  Build tags cannot distinguish compositors: KDE and GNOME are both `linux` +
+  Wayland at compile time. A suffix therefore never encodes a single desktop
+  environment on its own.
+- **Runtime axis (which compositor is live)** — expressed by the `LinuxBackend`
+  family in [linux_backend.go](../internal/core/infra/platform/linux_backend.go),
+  detected from environment variables and routed by `factory.go` plus dispatch
+  seams such as `system_linux_wayland_input.go`.
 
-- `common`: Linux-shared wrapper behavior, current fallback behavior, or backend selection
-- `x11`: X11-specific implementation
-- `wayland`: Wayland or compositor-specific implementation
+Within the compile-time axis, choose the slot by purpose:
 
-This does not mean every Linux package must fully implement both backends
-immediately. It means contributors should write code in the right slot from the
-start.
+| Slot      | Use for                                                                    |
+| --------- | -------------------------------------------------------------------------- |
+| `common`  | shared Linux types, shared fallbacks, backend detection/routing, helpers    |
+| `x11`     | X11 display enumeration, event capture, overlays, pointer queries and warps |
+| `wayland` | compositor capture/overlay behavior, layer-shell, output enumeration        |
 
-Use `common` for:
+Not every package must implement both backends immediately — but new code should
+land in the right slot from the start. Accessibility is the main exception: most
+Linux accessibility stays shared around AT-SPI even where other subsystems split.
 
-- shared Linux types
-- shared fallback behavior
-- backend detection or routing
-- helpers reused by both X11 and Wayland
+### Organize by mechanism, not by desktop
 
-Use `x11` for:
+Desktop environments share mechanisms, so the axis that actually varies is
+usually the mechanism:
 
-- X11 display enumeration
-- X11 event capture
-- X11 overlays
-- X11 cursor movement or pointer queries
-
-Use `wayland` for:
-
-- compositor-specific capture or overlay behavior
-- layer-shell integrations
-- Wayland-specific output enumeration or pointer behavior
-
-Accessibility is the main exception: much of Linux accessibility can stay
-shared around AT-SPI, even when other capabilities split by backend.
-
-### Wayland compositor backends (two axes)
-
-Wayland is not one target. KDE/KWin, the wlroots family (Sway, Hyprland, niri,
-COSMIC), and GNOME/Mutter differ in input, overlay, and hotkey mechanisms. Keep
-two axes separate:
-
-- **Compile-time axis** — OS + CGO. Expressed by build tags and the file
-  suffixes above. Build tags cannot distinguish compositors (KDE and GNOME are
-  both `linux` + Wayland at compile time), so the suffix never encodes a single
-  DE on its own.
-- **Runtime axis** — which compositor is live. Expressed by the `LinuxBackend`
-  family in [linux_backend.go](../internal/core/infra/platform/linux_backend.go)
-  (`BackendWaylandWlroots`, `BackendWaylandKDE`, `BackendWaylandGNOME`,
-  `BackendWaylandOther`), detected from `XDG_CURRENT_DESKTOP` and routed by the
-  factory + dispatch seams (e.g. `system_linux_wayland_input.go`).
-
-Per-DE behavior, protocol measurements, and known issues live in
-[LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md). Host setup (deps, build, deploy) lives
-in [LINUX_SETUP.md](./LINUX_SETUP.md).
-
-Organize implementation by the axis that actually varies, which is usually the
-**mechanism**, not the DE, because DEs share mechanisms:
-
-- Input: KDE uses libei (RemoteDesktop portal); GNOME also uses libei; wlroots
-  and COSMIC use `zwlr_virtual_pointer`. So a libei backend can serve multiple
-  DEs — do not duplicate it per DE.
-- Overlay: layer-shell works on KDE, wlroots, and COSMIC; only GNOME/Mutter
+- **Input** — KDE and GNOME both use libei (RemoteDesktop portal); wlroots and
+  COSMIC use `zwlr_virtual_pointer`. One libei backend serves several DEs; do
+  not duplicate it per DE.
+- **Overlay** — layer-shell works on KDE, wlroots, and COSMIC; only GNOME/Mutter
   lacks it.
-- Genuinely DE-specific: active-window geometry (KWin D-Bus vs Mutter D-Bus)
-  and hotkey registration. Put these in DE-named files (e.g.
-  `kwin_geometry_linux.go`).
+- **Genuinely DE-specific** — active-window geometry (KWin D-Bus vs Mutter
+  D-Bus) and hotkey registration. These belong in DE-named files such as
+  `kwin_geometry_linux.go`.
 
-Use a `*_linux_wayland_<compositor>.go` sub-slot when a compositor family needs
-a distinct path that another family does not share. Current slots:
+Use a `*_linux_wayland_<compositor>.go` sub-slot only when a compositor family
+needs a path no other family shares. Current sub-slots:
 `system_linux_wayland_wlroots_*.go` (virtual-pointer input) and
 `system_linux_wayland_kde_*.go` (libei input), with
 `system_linux_wayland_input.go` as the shared routing seam.
 
-To add a compositor (e.g. COSMIC): add a `LinuxBackend` value + detection in
-`linux_backend.go`, route it in the factory and the relevant dispatch seams,
-and only add a new `*_linux_wayland_<compositor>.go` slot if it cannot reuse an
+**To add a compositor** (COSMIC, say): add a `LinuxBackend` value and detection
+in `linux_backend.go`, route it in the factory and the relevant dispatch seams,
+and add a new `*_linux_wayland_<compositor>.go` slot *only* if it cannot reuse an
 existing mechanism file.
 
----
+Per-DE decisions, measured protocol support, and known issues live in
+[LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md); host setup lives in
+[LINUX_SETUP.md](./LINUX_SETUP.md).
 
 ## Windows Model
 
-Windows is currently treated as one backend family with basic support.
+Windows is one backend family with alpha-level support. Prefer:
 
-For now, prefer:
-
-- `*_windows.go` for the implementation slot
-- pure Go Win32 / COM bindings where practical
-
-Supported capabilities:
-
-- **grid, recursive grid, scroll** modes — layered GDI overlay, keyboard navigation
-- **direct mouse injection** — via `SendInput` / `SetCursorPos`
-- **global hotkeys** — via `RegisterHotKey`
-- **keyboard event capture** — via `WH_KEYBOARD_LL` hook
-- **accessibility** — UI Automation (UIA) COM-based integration (initial coverage)
-- **named-pipe IPC** — daemon CLI commands over `\\.\pipe\neru`
-
-Stubbed (not yet implemented):
-
-- notifications (Windows toast notifications)
-- app watcher (Win32 foreground-window notifications)
-- dark mode detection (personalization APIs)
+- `*_windows.go` as the implementation slot
+- pure Go Win32 / COM bindings (via `x/sys/windows` or syscall) over CGO
 
 Do not introduce additional Windows backend naming until there is a real reason.
-
----
+See [Known Gaps](#known-gaps) for the current Windows to-do list — several
+entries there are well-scoped starter tasks.
 
 ## CGO Guidance
 
-Do not decide CGO usage by OS alone.
-
-Use [profile.go](../internal/core/infra/platform/profile.go)
-as the source of truth for the current backend plan.
+**Do not decide CGO usage by OS alone.** CGO is a per-backend decision, and
+[profile.go](../internal/core/infra/platform/profile.go) is the source of truth.
 
 Current intent:
 
-- macOS: CGO required
-- Linux: backend-dependent
-- Windows: prefer pure Go first
+- **macOS** — CGO required throughout (Objective-C bridge)
+- **Linux** — backend-dependent; several backends already require it, and
+  `*_nocgo.go` variants must still compile and degrade honestly
+- **Windows** — pure Go first
 
 Good default instincts:
 
 - AT-SPI and freedesktop notifications should prefer pure Go / D-Bus paths
-- X11 may be possible in pure Go depending on library choice
-- some Wayland/compositor integrations may require CGO or native helpers
-- Win32 hotkeys, hooks, monitor APIs, and UIA should prefer pure Go bindings first
+- X11 may be feasible in pure Go depending on library choice
+- Wayland and compositor integrations often need CGO or native helpers
+- Win32 hotkeys, hooks, monitor APIs, and UIA should prefer pure Go bindings
 
-If you introduce a backend that changes the build story, update:
-
-- [profile.go](../internal/core/infra/platform/profile.go)
-- [justfile](../justfile)
-- this document
-
-When in doubt, make the build assumption explicit in your PR description and in
-the relevant backend comments.
-
----
+If you introduce a backend that changes the build story, update
+[profile.go](../internal/core/infra/platform/profile.go), the
+[justfile](../justfile), and this document — and state the build assumption
+explicitly in your PR description and the backend's package comments.
 
 ## Hotkeys And Modifiers
 
-Shared code should avoid hard-coding macOS conventions.
+Shared code must not hard-code macOS conventions:
 
-Use these rules:
-
-- Use `Primary` when you mean "main accelerator modifier"
+- use `Primary` when you mean "the main accelerator modifier"
 - `Primary` maps to `Cmd` on macOS and `Ctrl` on Linux/Windows
-- keep backend-specific key translation inside infra/platform code
-- do not spread X11, Wayland, Carbon, or Win32 naming into shared app logic
+- keep backend-specific key translation inside `infra/platform` code
+- never leak X11, Wayland, Carbon, or Win32 naming into shared app logic
 
-Relevant files:
+Relevant files: [config.go](../internal/config/config.go),
+[modifiers.go](../internal/core/domain/action/modifiers.go),
+[hotkeys.go](../internal/app/hotkeys.go).
 
-- [internal/config/config.go](../internal/config/config.go)
-- [internal/core/domain/action/modifiers.go](../internal/core/domain/action/modifiers.go)
-- [internal/app/hotkeys.go](../internal/app/hotkeys.go)
-
----
+On macOS, per-hotkey CGEventTaps are re-registered on keyboard-layout change
+(via `NeruSetKeymapLayoutChangeCallback2`) because `NeruKeyNameToCode` maps key
+names to layout-aware keycodes.
 
 ## Adding A New Capability
 
-Use this flow.
+**If multiple services or app layers need it** (broad system capability):
 
-### Option A: Broad system capability
-
-If multiple services or app layers will need the capability:
-
-1. Add it to [internal/core/ports/system.go](../internal/core/ports/system.go)
+1. Add it to [ports/system.go](../internal/core/ports/system.go)
 2. Implement it in the darwin adapter
-3. Add Linux common fallback behavior in `system_linux_common.go`
-4. Add Windows fallback behavior in `system.go` under the Windows platform package
-5. If Linux needs backend-specific behavior, push that implementation into `system_linux_x11.go` or `system_linux_wayland.go`
+3. Add a Linux shared fallback in `system_linux_common.go`
+4. Add a Windows implementation or explicit stub in the Windows platform package
+5. Push backend-specific Linux behavior down into `system_linux_x11.go` or `system_linux_wayland.go`
 6. Update capability reporting if the support surface changed
 
-### Option B: Isolated package-only platform behavior
-
-If only one infra package needs the capability:
+**If only one infra package needs it** (isolated platform behavior):
 
 1. Keep the shared package code platform-agnostic
-2. Use `platform_darwin.go` and `platform_other.go` dispatch files when that pattern fits
-3. If Linux needs backend-specific behavior, add Linux backend files in that package instead of pushing the logic up into shared app code
+2. Use `platform_darwin.go` / `platform_other.go` dispatch files where that fits
+3. Add Linux backend files inside that package rather than pushing detection up
+   into shared app or service code
 
----
+## Errors And Capability Reporting
 
-## Error Handling Rules
-
-For unimplemented platform behavior, return `CodeNotSupported`.
-
-Example:
+Unimplemented platform behavior returns `CodeNotSupported` — never a silent
+no-op, unless the behavior is explicitly documented as best-effort:
 
 ```go
 return derrors.New(derrors.CodeNotSupported, "ScreenBounds not yet implemented on linux")
 ```
 
-Use clear messages that name the missing operation and platform.
+Name the missing operation and the platform in the message. Callers degrade
+gracefully via `derrors.IsNotSupported(err)`.
 
-Do not silently no-op unless the behavior is explicitly documented as best-effort.
-
-When a feature becomes real:
-
-- replace the `CodeNotSupported` return
-- update capability details
-- remove stale TODO wording if it no longer applies
-
----
-
-## Capability Reporting
-
-Capability reporting is part of the contributor contract, not just a user nicety.
-
-When you implement or partially implement a feature, review:
-
-- [internal/core/ports/capabilities.go](../internal/core/ports/capabilities.go)
-- [internal/core/ports/capability_presets.go](../internal/core/ports/capability_presets.go)
-- [internal/app/ipc_info.go](../internal/app/ipc_info.go)
-
-`neru doctor` should help contributors and users understand what is actually
-available on the current platform.
-
-If a feature remains incomplete, keep the capability honest.
-
----
+Capability reporting is part of the contract, not a user nicety — it is what
+`neru doctor` prints. When you implement or partially implement a feature,
+review [capabilities.go](../internal/core/ports/capabilities.go),
+[capability_presets.go](../internal/core/ports/capability_presets.go), and
+[ipc_info.go](../internal/app/ipc_info.go). A stub must report `stub`, not
+`supported` — and a shipped feature must stop reporting `stub`. When a feature
+becomes real: replace the `CodeNotSupported` return, update the capability
+detail, and delete TODO wording that no longer applies.
 
 ## Testing Checklist
 
-Every platform contribution should update tests at the right level.
+- **unit tests** for shared parsing, normalization, routing, or config logic
+  (`*_test.go`, using mocks from `internal/core/ports/mocks`)
+- **contract tests** pinning `CodeNotSupported` behavior and capability semantics
+- **integration tests** for real platform behavior, tagged per-OS
+  (`*_integration_linux_test.go`, `*_integration_darwin_test.go`,
+  `*_integration_windows_test.go`)
 
-Use this checklist:
+Questions your tests should answer:
 
-- unit tests for shared parsing, normalization, routing, or config logic
-- contract tests for unsupported behavior and capability semantics
-- integration tests for real platform behavior on the target OS
-
-Typical test placement:
-
-- `*_test.go`: shared or mocked logic
-- `*_integration_linux_test.go`: real Linux behavior
-- `*_integration_darwin_test.go`: real macOS behavior
-- `*_integration_windows_test.go`: real Windows behavior when added
-
-Good questions to answer in tests:
-
-- does the adapter return the right error when unsupported?
+- does the adapter return the right error when the feature is unsupported?
 - does the capability matrix reflect the new state?
-- does backend selection route to the right Linux slot?
+- does backend selection route to the intended Linux slot?
 - does shared logic stay platform-neutral?
-
----
 
 ## Documentation Checklist
 
-When you land platform work, update docs in the same PR.
+Land docs in the same PR as the platform work. Check:
 
-Usually that means checking these files:
-
-- [README.md](../README.md)
-- [ARCHITECTURE.md](./ARCHITECTURE.md)
+- [README.md](../README.md) and [ARCHITECTURE.md](./ARCHITECTURE.md)
 - [DEVELOPMENT.md](./DEVELOPMENT.md)
+- **this file** — the parity tables in Part 1
 - [LINUX_SETUP.md](./LINUX_SETUP.md) — build, deps, deploy (keep DE-agnostic)
 - [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md) — per-DE decisions and known issues
 - [CONVENTIONS.md](./go/CONVENTIONS.md)
 
-Update them when:
+Update them whenever the capability matrix, the backend plan, the build/CGO
+story, or a contributor-facing file naming pattern changes.
 
-- the capability matrix changed
-- the backend plan changed
-- the build or CGO story changed
-- a contributor-facing file naming pattern changed
+## Contributing Safely
 
----
-
-## Suggested First Contributions
-
-Good cross-platform starter tasks:
+**Good starter tasks:**
 
 - improve capability detail text for an existing platform slice
 - replace a Linux `CodeNotSupported` return with real X11 or AT-SPI behavior
 - add a contract test for a currently stubbed feature
-- add Linux or Windows integration test scaffolding
+- pick a numbered item from [Known Gaps](#known-gaps)
 - document missing backend assumptions in the package you are touching
 
-Higher-risk tasks:
+**Higher-risk — open or link an issue first:**
 
 - changing shared input semantics
 - introducing CGO to a backend that was previously pure Go
 - moving shared logic into platform packages
-- mixing backend detection into app/service code
-
-If your change falls into the higher-risk group, open or link an issue first.
-
----
-
-## What "Done" Looks Like
-
-A good platform PR usually leaves the repo better in five ways:
-
-- the implementation lives in the intended file slot
-- unsupported paths remain explicit and honest
-- capability reporting is updated
-- tests cover the new behavior or contract
-- docs tell the next contributor what changed
-
-That is the bar to aim for, even for small slices.
-
----
-
-## Feature Parity Reference
-
-This section provides a **ground-truth comparison** of what Neru does on
-macOS, Linux, and Windows.
-
-Every claim below is derived from code in `internal/core/infra/platform/`,
-`internal/core/infra/accessibility/`, `internal/core/infra/eventtap/`,
-`internal/core/infra/hotkeys/`, `internal/ui/overlay/`,
-`internal/app/components/`, and the capability presets at
-`internal/core/ports/capability_presets.go`. If a doc claim contradicts code,
-trust the code.
-
-### OS Support Overview
-
-| Aspect                  | macOS (Darwin)                       | Linux                                             | Windows                                  |
-| ----------------------- | ------------------------------------ | ------------------------------------------------- | ---------------------------------------- |
-| **Status**              | Production-ready                     | Beta (X11 & Wayland wlroots/KDE)                  | Alpha (initial coverage)                 |
-| **CGO Required**        | Yes (Objective-C bridge)             | Backend-dependent                                 | No (pure Go Win32/COM)                   |
-| **Build Tag**           | `darwin`                             | `linux`                                           | `windows`                                |
-| **Primary Modifier**    | `Cmd`                                | `Ctrl`                                            | `Ctrl`                                   |
-| **Display Server**      | Cocoa/Quartz                         | X11, Wayland (wlroots/KDE/GNOME)                  | Win32 Desktop Window Manager             |
-| **Accessibility API**   | AXUIElement (Cocoa)                  | AT-SPI (D-Bus)                                    | UI Automation (COM)                      |
-| **Overlay Window Type** | NSPanel (borderless, non-activating) | X11 override-redirect / wlr-layer-shell           | Layered HWND (WS_POPUP \| WS_EX_LAYERED) |
-| **Overlay Rendering**   | CoreAnimation (CALayer, GPU)         | Cairo (X11: Xlib surface; Wayland: SHM buffers)   | GDI + software SDF (BGRA bitmaps)        |
-| **Keyboard Capture**    | CGEventTap (Quartz event taps)       | XGrabKeyboard / evdev grab / layer-shell keyboard | WH_KEYBOARD_LL (SetWindowsHookEx)        |
-| **Global Hotkeys**      | Per-key CGEventTap                   | XGrabKey / evdev passive grab                     | RegisterHotKey                           |
-
-### Port Capability Matrix
-
-From `internal/core/ports/capability_presets.go` and actual adapter code.
-
-#### Legend
-
-- ✅ **Supported** — implemented and expected to work in production
-- 🟡 **Stub** — code path exists but returns `CodeNotSupported` or no-ops
-- ⚠️ **Partial** — works for some backends or has known gaps
-- ❌ **Not present** — no code path at all
-
-| Capability                          | macOS                       | Linux (X11)        | Linux (wlroots)           | Linux (KDE)              | Linux (GNOME)     | Windows                  |
-| ----------------------------------- | --------------------------- | ------------------ | ------------------------- | ------------------------ | ----------------- | ------------------------ |
-| **Focused App PID**                 | ✅                          | ✅                 | ⚠️ (app_id; PID best-effort) | ⚠️ (app_id; PID best-effort) | 🟡                | ✅                       |
-| **Screen Bounds**                   | ✅                          | ✅                 | ✅                        | ✅                       | ✅                | ✅                       |
-| **Screen Enumeration**              | ✅                          | ✅ (XRandR)        | ✅ (xdg-output)           | ✅ (xdg-output)          | ✅ (xdg-output)   | ✅ (EnumDisplayMonitors) |
-| **Cursor Position**                 | ✅                          | ✅                 | ✅ (sync surface)         | ✅ (sync surface)        | ❌                | ✅                       |
-| **Cursor Move**                     | ✅                          | ✅ (XTest)         | ✅ (zwlr_virtual_pointer) | ✅ (libei)               | ❌                | ✅ (SetCursorPos)        |
-| **Cursor Smooth Animation**         | ✅                          | ✅                 | ✅                        | ✅                       | ❌                | ❌                       |
-| **Scroll Smooth Animation**         | ✅                          | ❌                 | ❌                        | ❌                       | ❌                | ❌                       |
-| **Accessibility Element Discovery** | ✅ (AXUIElement)            | ⚠️ (AT-SPI walk)   | ⚠️ (AT-SPI walk)          | ⚠️ (AT-SPI walk)         | 🟡 (no injection) | ✅ (UIA initial)         |
-| **Accessibility Click/Scroll**      | ✅                          | ✅ (XTest)         | ✅ (virtual-pointer)      | ✅ (libei)               | 🟡                | ✅ (UIA initial)         |
-| **Overlay**                         | ✅ (Cocoa NSPanel)          | ✅ (X11 Cairo)     | ✅ (wl-layer Cairo)       | ✅ (wl-layer Cairo)      | ❌                | ✅ (Layered HWND)        |
-| **Global Hotkeys**                  | ✅ (CGEventTap)             | ✅ (XGrabKey)      | ✅ (evdev grab)           | ✅ (evdev grab)          | ❌                | ✅ (RegisterHotKey)      |
-| **Keyboard Event Capture**          | ✅ (CGEventTap)             | ✅ (XGrabKeyboard) | ✅ (evdev + wl-keyboard)  | ✅ (evdev + wl-keyboard) | ❌                | ✅ (WH_KEYBOARD_LL)      |
-| **App Watcher**                     | ✅ (NSWorkspace)            | ✅ (WM_CLASS poll) | ✅ (toplevel app_id poll)  | ✅ (toplevel app_id poll) | 🟡 (no source)    | 🟡                       |
-| **Dark Mode Detection**             | ✅ (Cocoa)                  | ✅ (xdg-portal)    | ✅ (xdg-portal)           | ✅ (kdeglobals)          | ✅ (xdg-portal)   | ✅ (registry)            |
-| **Secure Input Detection**          | ✅                          | 🟡 (always false)  | 🟡 (always false)         | 🟡 (always false)        | 🟡 (always false) | 🟡 (always false)        |
-| **Native Notifications**            | ✅ (NSAlert/UNNotification) | 🟡                 | 🟡                        | 🟡                       | 🟡                | 🟡                       |
-| **Native Alerts**                   | ✅ (NSAlert)                | 🟡                 | 🟡                        | 🟡                       | 🟡                | ✅ (Win32 MessageBox)    |
-| **Font Resolution**                 | ✅ (NSFont)                 | ✅ (fontconfig)    | ✅ (fontconfig)           | ✅ (fontconfig)          | ✅ (fontconfig)   | ✅ (DirectWrite)         |
-| **System Cursor Hide**              | ✅ (CGDisplayHideCursor)    | ❌                 | ❌                        | ❌                       | ❌                | ❌                       |
-| **Monitor Select Panels**           | ✅ (native Cocoa panels)    | ✅ (Cairo)         | ✅ (Cairo)                | ✅ (Cairo)               | ❌                | ❌                       |
-
-**Smooth cursor animation on Linux:** off by default and opt-in via
-`smooth_cursor.move_mouse_enabled` (the same cross-platform
-`SmoothCursorConfig` macOS uses). When enabled, `SystemAdapter.MoveCursorToPoint`
-routes through `smoothCursorAnimator` (`mouse_animator_linux.go`) — a single
-worker goroutine that samples the current position once, then steps the direct
-per-backend warp (XTest on X11, `zwlr_virtual_pointer` on wlroots, libei on KDE)
-toward the target with linear interpolation, and `WaitForCursorIdle` now blocks
-until it settles instead of returning immediately. This mirrors the darwin
-animator (coalescing, latest-target-wins), but drives discrete warps rather than
-a Quartz event stream, so there is no drag-event distinction. It applies to the
-same flows macOS animates — grid/recursive-grid cursor-follow, `move_mouse`, and
-selection moves; clicks stay instant. On Wayland the interpolation start point
-comes from the client-side cursor cache; a stale read only skews the glide path,
-never the final landing point (the last step lands exactly on the target).
-GNOME/Mutter has no injection path, so it stays unsupported there.
-
-**Focused App PID on Wayland:** wlroots and KDE sessions resolve the focused
-window through the `wlr-foreign-toplevel-management` protocol, which exposes the
-window's **app_id** (used as the bundle identifier for per-app config) but not
-its PID — Wayland clients cannot read another client's process credentials.
-`SystemPort.FocusedApplicationPID` therefore best-effort matches the app_id
-against `/proc`; when no process matches it returns `CodeNotSupported` with the
-app_id rather than a fabricated number. GNOME/Mutter does not implement the
-protocol, so it stays a stub there (use an X11 session under GNOME).
-
-**App Watcher on Linux:** macOS receives focus changes from an NSWorkspace
-observer; Linux has no equivalent push API, so the watcher
-(`internal/core/infra/appwatcher/platform_linux.go`) **polls** the focused
-application's identity every 400ms and dispatches activate/deactivate events
-when it changes. The identity comes from
-`platform/linux.FocusedAppID(backend)`: the active window's **WM_CLASS** on X11
-(`neru_x11_get_window_class`) and the focused toplevel's **app_id** on Wayland
-wlroots/KDE (`wlr-foreign-toplevel-management`, reusing the same source as
-Focused App PID). This drives per-app global-hotkey switching
-(`App.handleAppActivation`), which previously never fired on Linux. GNOME/Mutter
-exposes no focused-app source, so the poll yields nothing and no events fire
-there — per-app hotkey switching needs an X11 session under GNOME. Only
-activate/deactivate are emitted; launch, terminate, screen-parameter, and
-Mission Control events remain macOS-only.
-
-**Accessibility on Linux (⚠️, not a stub):** hints-mode element discovery is
-implemented via AT-SPI over D-Bus. `ATSPIClient` (`atspi_linux.go`) enables
-assistive-tech mode, finds the active frame, and walks its tree
-(`ClickableNodes`) for clickable elements, emitting native AT-SPI role names.
-Configured roles are resolved into that vocabulary at config load, so both
-sides of the filter speak AT-SPI. This is the client the Linux adapter actually uses
-(`platform_client_linux.go` → `Adapter.ClickableElements` → `client.ClickableNodes`);
-the `TreeNode`/`BuildTree` stub in `tree_linux.go` is the macOS-style tree API
-and is **not** on the Linux hints path. Click/scroll then inject at the hint
-point through the embedded `InfraAXClient` — XTest on X11, `zwlr_virtual_pointer`
-on wlroots, libei on KDE, plus evdev/uinput for Wayland scroll. It is marked ⚠️
-rather than ✅ because coverage depends on each app exposing AT-SPI (Qt/GTK do
-with accessibility enabled; some toolkits expose little), and there is no
-Vision/OCR fallback like macOS. AT-SPI discovery itself is display-server
-independent, but GNOME/Mutter has no usable injection path, so hints are not
-usable there (use an X11 session under GNOME).
-
-**Chromium/Electron apps on Linux:** Chromium-based apps (Chrome, Electron,
-and forks such as Helium) do **not** expose their web-content accessibility
-tree over AT-SPI by default — they gate it behind their own runtime detection
-and, unlike macOS, there is no per-app attribute Neru can toggle to force it on
-(the macOS `AXManualAccessibility` nudge in `electron.EnsureAccessibility` is a
-no-op on Linux). The result is an AT-SPI frame with a single empty child, so
-hints find nothing inside such windows. The reliable workaround is to launch the
-app with `--force-renderer-accessibility` (e.g. `chromium --force-renderer-accessibility`),
-which forces the full web tree. Native GTK/Qt apps and Firefox expose their tree
-without this flag. This is a Chromium behavior, not a Neru limitation.
-
-**Active-window selection on Wayland:** the AT-SPI `ACTIVE` state is unreliable
-on wlroots compositors (niri, Sway, Hyprland) — the focused window can report
-`ACTIVE=false` while background frames report `ACTIVE=true`. Neru therefore
-selects the AT-SPI frame by matching the compositor's focused **app_id** (from
-`wlr-foreign-toplevel-management`, the same source as Focused App PID / the app
-watcher), falling back to the `ACTIVE`/`SHOWING` heuristic only on X11, GNOME,
-or when no app_id is available. See `findActiveFrame` in `atspi_linux.go`.
-
-**Window-origin offset on Wayland:** a Wayland client cannot know its own
-on-screen position, so AT-SPI reports element coordinates relative to the
-window. To place the hint overlay correctly, neru offsets those by the focused
-window's screen origin, supplied by a compositor-specific `windowOriginSource`
-(`window_origin_linux.go`), selected by environment:
-
-- **KDE / KWin** — a small KWin script pushes the focused window's geometry over
-  D-Bus (`kwin_geometry_linux.go`).
-- **niri** (`NIRI_SOCKET`) — `niri msg -j focused-window`/`focused-output`.
-  Works for **floating** windows (niri populates `tile_pos_in_workspace_view`)
-  and **fullscreen** windows (whose frame sits at the output origin with no
-  offset needed). For **tiled** windows — including a maximized column
-  (`maximize-column`, the default `Mod+F`) — niri does not expose the on-screen
-  position ([niri#2381](https://github.com/niri-wm/niri/issues/2381)), so neru
-  falls back to unoffset coordinates and hints are misaligned there. Use a
-  floating window, or true fullscreen (`fullscreen-window`), for aligned hints.
-- **Sway** (`SWAYSOCK`) — `swaymsg -t get_tree`, focused node `rect + window_rect`.
-- **Hyprland** (`HYPRLAND_INSTANCE_SIGNATURE`) — `hyprctl -j activewindow` `at`/`size`.
-
-Each source verifies the reported window size matches the AT-SPI frame (a focus
-change can race the query) and is best-effort — an unavailable origin degrades
-to unoffset (window-relative) coordinates rather than misplacing hints.
-
-### Overlay Rendering
-
-#### Visual Features
-
-| Feature               | macOS                                            | Linux X11                                 | Linux Wayland                                | Windows                                                   |
-| --------------------- | ------------------------------------------------ | ----------------------------------------- | -------------------------------------------- | --------------------------------------------------------- |
-| **Window type**       | NSPanel (borderless, non-activating)             | X11 override-redirect Window              | wlr_layer_shell_v1 overlay surface           | Win32 layered HWND                                        |
-| **Rendering API**     | CoreAnimation (CALayer, GPU)                     | Cairo (CPU, Xlib)                         | Cairo (CPU, SHM buffers)                     | GDI + software SDF (CPU, BGRA)                            |
-| **Per-pixel alpha**   | `[NSColor clearColor]` + layer opaque=NO         | `CAIRO_OPERATOR_CLEAR`                    | `CAIRO_OPERATOR_CLEAR`                       | `AC_SRC_ALPHA` via `UpdateLayeredWindow`                  |
-| **Click-through**     | `setIgnoresMouseEvents:YES`                      | XFixes empty input region                 | `wl_surface_set_input_region` (empty)        | `WS_EX_TRANSPARENT`                                       |
-| **Always on top**     | `NSScreenSaverWindowLevel`                       | `_NET_WM_STATE_ABOVE` + `MapRaised`       | `ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY`          | `HWND_TOPMOST`                                            |
-| **Focus prevention**  | Non-activating panel (returns NO)                | override_redirect=YES, no WM decorations  | Keyboard interactivity: controlled           | `WS_EX_NOACTIVATE`                                        |
-| **High-DPI / Retina** | Dynamic `contentsScale`, backing change callback | `Xft.dpi` UI scaling (single global factor) | `wl_output` scale + `wp_fractional_scale_v1`/`wp_viewporter` (crisp fractional) | Not explicit                                              |
-| **Multi-monitor**     | Clamps per display, screen change tracking       | Enumerates all monitors, per-monitor render, live RandR hotplug | Per-output `wl_surface` array (max 16), live `wl_output` hotplug | Cursor-screen tracking, separate indicator/sticky windows |
-| **Font rendering**    | NSFontManager (postscript/family names)          | Cairo `select_font_face` + `show_text`    | Cairo `select_font_face` + `show_text`       | GDI `CreateFontW` + `DrawTextW` + alpha composite         |
-| **Rounded rects**     | NSBezierPath (`bezierPathWithRoundedRect`)       | Cairo arc-based `rounded_path`            | Cairo arc-based `rounded_path`               | SDF `alphaFillRoundedRect` (software)                     |
-| **Borders**           | NSBezierPath stroke                              | Cairo stroke (`fill_preserve` + `stroke`) | Cairo stroke                                 | SDF multi-pass alpha `strokeRoundedRect`                  |
-| **Coordinate origin** | Bottom-left (Quartz → Y-flip)                    | Top-left                                  | Top-left                                     | Top-left (negative DIB height)                            |
-| **Buffer model**      | Layer-backed, OS-managed                         | Single cairo surface                      | Triple-buffered SHM pool (3 buffers)         | Single pixel buffer                                       |
-
-#### Animation & Interaction
-
-| Feature                       | macOS                                              | Linux X11                              | Linux Wayland                               | Windows                                   |
-| ----------------------------- | -------------------------------------------------- | -------------------------------------- | ------------------------------------------- | ----------------------------------------- |
-| **Grid transition animation** | CoreAnimation 120Hz, ease-in-out + linear fallback | Goroutine 120fps, easeInOut smoothstep | Goroutine 120fps, easeInOut smoothstep      | ❌                                        |
-| **Mouse action indicator**    | CoreAnimation CABasicAnimation (scale+opacity)     | Goroutine 120fps, scale+opacity fade   | Goroutine 120fps, scale+opacity fade        | Goroutine 60fps, custom cubic easing, SDF |
-| **Smooth cursor animation**   | ✅ (goroutine, configurable easing, tween)         | ✅ (goroutine, stepped warp)           | ✅ (goroutine, stepped warp)                | ❌                                        |
-| **Smooth scroll animation**   | ✅ (goroutine, ease-out cubic)                     | ❌                                     | ❌                                          | ❌                                        |
-| **Animation frame rate**      | 120fps (NSTimer display link)                      | 120fps (ticker)                        | ~120fps                                     | 60fps (16ms ticker)                       |
-| **Thread model**              | Main thread dispatch (dispatch_async/sync)         | `renderMu sync.Mutex`                  | `displayMu sync.Mutex` (shared w/ renderMu) | Dedicated UI thread (`LockOSThread`)      |
-
-#### Visual Elements Per Mode
-
-| Element                        | macOS                                        | Linux X11                        | Linux Wayland                    | Windows                             |
-| ------------------------------ | -------------------------------------------- | -------------------------------- | -------------------------------- | ----------------------------------- |
-| **Hint badges — rectangular**  | ✅ (with rounded rect + text)                | ✅ (Cairo rounded rect)          | ✅ (Cairo rounded rect)          | ✅ (SDF rounded rect)               |
-| **Hint arrows (top/bottom)**   | ✅ (1pt arrow height, NSBezierPath)          | ✅ (Cairo triangle tail)         | ✅ (Cairo triangle tail)         | ❌                                  |
-| **Hint boundary highlight**    | ✅ (rounded rect behind element border)      | ✅ (Cairo)                       | ✅ (Cairo)                       | ✅ (SDF, capped 4px radius)         |
-| **Hint search input overlay**  | ✅ (`/ query count/` rounded badge)          | ❌                               | ❌                               | ✅ (`/ query count/` rounded badge) |
-| **Grid cell labels**           | ✅                                           | ✅                               | ✅                               | ✅                                  |
-| **Grid sub-key preview**       | ✅ (centered mini-grid, auto-hide threshold) | ✅ (centered mini-grid)          | ✅ (centered mini-grid)          | ✅ (single-line bottom text)        |
-| **Grid auto-hide labels**      | ✅ (fontSize × multiplier threshold)         | ✅                               | ✅                               | ✅                                  |
-| **Recursive grid badge**       | ✅                                           | ✅ (Cairo)                       | ✅ (Cairo)                       | ✅ (SDF)                            |
-| **Mode indicator**             | ✅ (own NSPanel, positioned on cursor)       | ✅ (DrawBadge on shared overlay) | ✅ (DrawBadge on shared overlay) | ✅ (dedicated indicatorWin window)  |
-| **Sticky modifiers indicator** | ✅ (own NSPanel, sized to fit)               | ✅ (DrawBadge on shared overlay) | ✅ (DrawBadge on shared overlay) | ✅ (dedicated stickyWin window)     |
-| **Virtual pointer**            | ✅ (own NSPanel, animated w/ grid)           | ✅ (drawn in overlay)            | ✅ (drawn in overlay)            | 🟡                                  |
-| **Screen sharing hide**        | ✅ (NSWindowSharingNone/ReadOnly per window) | ❌                               | ❌                               | ❌                                  |
-
-#### Rendering Architecture
-
-The architecture differs fundamentally:
-
-**macOS (Darwin):** Each component owns its own NSPanel. The component
-overlay\_\*.go files (e.g., `hints/overlay_darwin.go`) directly call into
-Objective-C bridge functions. Full GPU-backed rendering via CoreAnimation.
-
-**Linux:** Component files are stubs (Style + BuildStyle only). Actual
-rendering happens in the manager (`manager_linux_x11.go`,
-`manager_linux_wayland_cgo.go`) which directly calls C Cairo rendering
-functions. All elements draw into a shared Cairo surface.
-
-**Windows:** Same pattern as Linux — component stubs, actual rendering in
-manager (`manager_windows.go`, `manager_windows_overlay.go`,
-`manager_windows_features.go`) via `winplatform.OverlayWindow` (GDI + SDF).
-
-Key files:
-
-- macOS component overlays: `internal/app/components/{hints,grid,modeindicator,virtualpointer}/overlay_darwin.go`
-- Linux component overlays: `internal/app/components/{hints,grid,recursivegrid,modeindicator,stickyindicator}/overlay_linux_*.go` (stubs; actual rendering in manager)
-- Windows component overlays: `internal/app/components/{hints,grid,recursivegrid,modeindicator,stickyindicator}/overlay_windows.go` (stubs; actual rendering in manager)
-
-### Accessibility Systems
-
-#### Element Discovery
-
-| Aspect                     | macOS                                                                                                                                                                                    | Linux                                                                   | Windows                                                                              |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| **Backend**                | AXUIElement (via CGO ObjC bridge)                                                                                                                                                        | AT-SPI via D-Bus (pure Go)                                              | UI Automation via COM (pure Go)                                                      |
-| **Adapter location**       | `internal/core/infra/accessibility/element_darwin.go`                                                                                                                                    | `internal/core/infra/accessibility/element_linux.go` + `atspi_linux.go` | `internal/core/infra/accessibility/element_windows.go` + `uia_windows.go`            |
-| **Client**                 | `InfraAXClient` wraps Element/TreeNode → ObjC bridge                                                                                                                                     | `ATSPIClient` → D-Bus `org.a11y.atspi`                                  | `UIAClient` → raw COM vtable calls                                                   |
-| **Tree building**          | Full recursive tree walk of AXUIElement hierarchy (`tree.go`). Collects from: frontmost window, popover windows, menubar, dock, notification center, Stage Manager, PIP, screen capture. | Recursive AT-SPI D-Bus walk of the active frame (`ATSPIClient.ClickableNodes`, `atspi_linux.go`), depth/node capped. The `tree_linux.go` `BuildTree` stub is the macOS-style API and is not on this path. | Shallow UIA tree walk returning root-level clickable nodes (`tree_windows.go`).      |
-| **Clickable filtering**    | Extensive: role matching, size/position heuristics, excluded apps list. Multiple strategy backends (AX + Vision).                                                                        | Native AT-SPI role matching, SHOWING-state + on-screen extents check; coverage depends on the app's AT-SPI support. | Basic: collects `IUIAutomationElement` with `IsControlElement` + `IsContentElement`. |
-| **Strategy support**       | `config.StrategyAX` (default), `config.StrategyVision` (macOS Vision Framework).                                                                                                         | AX only (no Vision/OCR fallback).                                       | AX only.                                                                             |
-| **Popover / menu support** | ✅ (AXOrientation-based popover detection, menubar walking).                                                                                                                             | ⚠️ (popovers/menus in the active frame's AT-SPI subtree are walked; no separate menubar/dock collection). | 🟡                                                                                   |
-| **Focused application**    | ✅ (NSWorkspace + AXUIElement).                                                                                                                                                          | ✅ (X11: `_NET_ACTIVE_WINDOW`; Wayland: `wlr-foreign-toplevel` app_id on wlroots/KDE, XWayland fallback). | ✅ (Win32 `GetForegroundWindow`).                                                    |
-
-#### Action Execution
-
-Every action type in `internal/core/domain/action/action.go` is dispatched via `InfraAXClient.PerformAction`:
-
-| Action                  | macOS                                                | Linux                                                                | Windows                                                            |
-| ----------------------- | ---------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| **Click at point**      | ✅ (`CGEventPost` via ObjC bridge)                   | ✅ (XTest btn 1 / zwlr_virtual_pointer)                              | ✅ (UIA pattern + `SendInput`)                                     |
-| **Right click**         | ✅ (`CGEventPost` right mouse down/up)               | ✅ (XTest btn 3 / zwlr_virtual_pointer)                              | ✅ (`SendInput` right button)                                      |
-| **Middle click**        | ✅ (`CGEventPost` middle mouse down/up)              | ✅ (XTest btn 2 / zwlr_virtual_pointer)                              | ✅ (`SendInput` middle button)                                     |
-| **Mouse down (any button)** | ✅ (`CGEventPost` left/right/other mouse down)   | ✅ (XTest btn 1/2/3 press / zwlr_virtual_pointer press)              | ✅ (`SendInput` left/right/middle down)                            |
-| **Mouse up (any button)**   | ✅ (`CGEventPost` left/right/other mouse up)     | ✅ (XTest btn 1/2/3 release / zwlr_virtual_pointer release)          | ✅ (`SendInput` left/right/middle up)                              |
-| **Drag while held**     | ✅ (move posts the matching `*MouseDragged` type)    | ✅ (pointer warp with the button held)                               | ✅ (`SetCursorPos` with the button held)                           |
-| **Move mouse to point** | ✅ (`CGEventPost` mouse move)                        | ✅ (XTest `XWarpPointer` / zwlr_virtual_pointer)                     | ✅ (`SetCursorPos`)                                                |
-| **Move mouse relative** | ✅ (same as absolute, delta applied)                 | ✅ (same as absolute, delta applied)                                 | ✅ (same as absolute, delta applied)                               |
-| **Scroll at cursor**    | ✅ (`CGEventCreateScrollWheelEvent` + `CGEventPost`) | ✅ (X11: XTest btn 4/5; Wayland: evdev uinput + wlr virtual-pointer) | ✅ vertical only (`SendInput` `MOUSEEVENTF_WHEEL`; deltaX ignored) |
-
-**Held mouse buttons:** press and release are separate actions, so every backend
-has to remember what it pressed. That bookkeeping is shared rather than
-per-platform: each adapter keeps a
-[`mousestate.Tracker`](../internal/core/infra/platform/mousestate/tracker.go)
-recording which buttons are down, where they were pressed, and with which
-modifiers. It drives three behaviors identically everywhere — toggle actions
-resolve against it (held → release, free → press), `EnsureMouseUp` releases
-every held button when Neru returns to idle, and on macOS it selects the drag
-event type for cursor moves. macOS is the only backend where a move needs that
-distinction: Quartz requires `kCGEventLeftMouseDragged` /
-`kCGEventRightMouseDragged` / `kCGEventOtherMouseDragged` (with a matching
-button number) instead of `kCGEventMouseMoved`, while X11, Wayland, and Windows
-warp the pointer and the compositor or OS infers the drag from the held button.
-When several buttons are held at once, a macOS move is attributed to the
-left-most held button — a single event cannot describe more than one.
-
-#### Tree Building Comparison
-
-**macOS** (`tree.go`) builds the most comprehensive accessibility tree:
-
-1. Walks the full AXUIElement hierarchy from the frontmost application root
-2. Collects from: frontmost window, all windows, popovers, menu bar, dock, notification center
-3. Applies per-app strategy overrides and role-based filtering
-4. Supports multiple concurrent strategies (AX + Vision)
-5. Deduplicates overlapping elements
-6. Filters by size, position, visibility, and excluded apps
-
-**Linux** (`atspi_linux.go`) walks the AT-SPI tree over D-Bus:
-
-- `ATSPIClient.FrontmostWindow` finds the active frame (ACTIVE + SHOWING state)
-  across registered applications, skipping virtual keyboards and system surfaces
-- `ClickableNodes` recursively walks that frame's subtree (depth/node capped),
-  keeping SHOWING elements whose AT-SPI role is in the requested set
-- Configured roles are resolved from the semantic vocabulary into native
-  AT-SPI names before they reach the client
-  (`element.ResolveRoles`), so the shared filter pipeline matches them
-- On Wayland it offsets element extents by the focused window's screen origin
-  (via the KWin geometry bridge) since AT-SPI reports window-relative coords
-- Element structs in `element_linux.go` implement cursor/scroll/click injection
-- The `tree_linux.go` `BuildTree`/`TreeNode` API is a stub, but it is the
-  macOS-style tree path and is **not** used by the Linux adapter
-
-**Windows** (`tree_windows.go`):
-
-- Builds a shallow tree from the root `IUIAutomation` element
-- Uses `TreeWalker.GetFirstChildElement` / `GetNextSiblingElement` for traversal
-- Filters by bounding rectangle (skip zero-size elements)
-- Returns `IUAElement` wrappers with basic metadata
-- The `uia_windows.go` provides the raw COM client
-
-### Input Handling
-
-#### Keyboard Event Capture
-
-| Aspect                   | macOS                                            | Linux X11               | Linux Wayland                      | Windows                      |
-| ------------------------ | ------------------------------------------------ | ----------------------- | ---------------------------------- | ---------------------------- |
-| **Mechanism**            | `CGEventTapCreate` (Quartz)                      | `XGrabKeyboard`         | evdev grab + wl-keyboard           | `WH_KEYBOARD_LL` hook        |
-| **CGO required**         | Yes                                              | Yes                     | Yes (cgo path)                     | No                           |
-| **Modifier passthrough** | ✅ (CGEventTap callback can pass events through) | ❌ (grab is all-or-nothing) | ✅ (evdev only; re-inject via virtual kbd) | ❌ (no-op)                   |
-| **PostModifierEvent**    | ✅                                               | ✅                      | ✅                                 | ❌ (no-op)                   |
-| **Sticky modifiers**     | ✅                                               | ✅                      | ✅                                 | ✅                           |
-| **File**                 | `eventtap_darwin.go`                             | `eventtap_linux_x11.go` | `eventtap_linux_wayland.go` / `..._evdev_cgo.go` | `eventtap_windows.go`        |
-| **Event source**         | System-wide CGEvent stream                       | X11 grabbed keyboard    | `/dev/uinput` + wl_keyboard events | System-wide `WH_KEYBOARD_LL` |
-
-**Modifier passthrough on Linux (Wayland evdev only):** while a mode is active
-Neru captures the keyboard exclusively, so shortcuts it doesn't bind (e.g.
-`Ctrl+C`, `Ctrl+Tab`) are normally swallowed. With
-`general.passthrough_unbounded_keys`, unbound Ctrl/Alt/Cmd chords are instead
-re-injected to the focused app. This works on the **Wayland evdev** backend
-because Neru holds an `EVIOCGRAB` on the physical device but injects through a
-*separate* `zwp_virtual_keyboard_v1`, which bypasses that grab and reaches the
-app with no feedback loop (see `handleWaylandEvdevEvent` →
-`passthroughEvdevChord`). It is **not** available on **X11** — an `XGrabKeyboard`
-routes Neru's own synthetic XTest events back to itself, and `XSendEvent` is
-ignored by most apps — nor on the rare **wl-keyboard fallback**, which has no
-injection path. Classification (blacklist, mode-intercepted keys, the mode's own
-hotkeys) and the post-passthrough hint refresh are shared cross-platform in
-`internal/app/modes/passthrough.go`; only the final re-injection is
-backend-specific. The blacklist keeps chosen chords consumed, and
-`general.should_exit_after_passthrough` exits the mode after a passthrough.
-
-#### Global Hotkeys
-
-| Aspect                               | macOS                              | Linux X11                           | Linux Wayland                          | Windows                   |
-| ------------------------------------ | ---------------------------------- | ----------------------------------- | -------------------------------------- | ------------------------- |
-| **Mechanism**                        | Per-key CGEventTap                 | `XGrabKey`                          | evdev passive key grab (GrabKey ioctl) | `RegisterHotKey`          |
-| **CGO required**                     | Yes                                | Yes                                 | No (pure Go via evdev)                 | No                        |
-| **Press/release detection**          | ✅ (separate CGEventTap callbacks) | ✅ (X11 KeyPress/KeyRelease events) | ⚠️ (press only in some configs)        | ✅ (WM_HOTKEY with flags) |
-| **Individual hotkey enable/disable** | ✅                                 | ✅                                  | ✅                                     | ✅                        |
-| **File**                             | `manager_darwin.go`                | `manager_linux_x11.go`              | `manager_linux_wayland.go`             | `manager_windows.go`      |
-
-#### Cursor & Mouse
-
-| Aspect                  | macOS                                | Linux X11                 | Linux Wayland                                                                    | Windows                    |
-| ----------------------- | ------------------------------------ | ------------------------- | -------------------------------------------------------------------------------- | -------------------------- |
-| **Get position**        | ✅ (`CGEventGetLocation`)            | ✅ (XQueryPointer)        | ✅ (sync surface trick)                                                          | ✅ (GetCursorPos)          |
-| **Move to point**       | ✅ (`CGWarpMouseCursorPosition`)     | ✅ (XTest `XWarpPointer`) | ✅ (zwlr_virtual_pointer)                                                        | ✅ (SetCursorPos)          |
-| **Left click**          | ✅ (CGEventPost)                     | ✅ (XTest button 1)       | ✅ (zwlr_virtual_pointer button)                                                 | ✅ (SendInput)             |
-| **Right click**         | ✅                                   | ✅ (XTest button 3)       | ✅                                                                               | ✅                         |
-| **Middle click**        | ✅                                   | ✅ (XTest button 2)       | ✅                                                                               | ✅                         |
-| **Hold / release button** | ✅ (left, right, middle)           | ✅ (XTest button 1/2/3)   | ✅ (zwlr_virtual_pointer BTN_LEFT/RIGHT/MIDDLE)                                  | ✅ (SendInput down/up)     |
-| **Drag while held**     | ✅ (`*MouseDragged` event type)      | ✅ (warp with button held) | ✅ (warp with button held)                                                      | ✅ (warp with button held) |
-| **Scroll**              | ✅ (CGScrollWheelEvent)              | ✅ (XTest button 4/5)     | ✅ (zwlr_virtual_pointer axis)                                                   | ✅ (SendInput mouse wheel) |
-| **Smooth animation**    | ✅ (mouse_animator.go, configurable) | ✅ (mouse_animator_linux.go) | ✅ (mouse_animator_linux.go)                                                  | ❌                         |
-| **Wayland cursor sync** | N/A                                  | N/A                       | ✅ (brief map of transparent layer surface to capture `wl_pointer.enter` coords) | N/A                        |
-
-### Mode Feature Coverage
-
-#### Hints Mode
-
-| Feature                        | macOS                                                             | Linux                                       | Windows                         |
-| ------------------------------ | ----------------------------------------------------------------- | ------------------------------------------- | ------------------------------- |
-| **Element discovery**          | ✅ Full AXUIElement tree walk + Vision framework                  | ⚠️ (AT-SPI walk; toolkit-dependent)         | ⚠️ (UIA initial — shallow tree) |
-| **Multi-letter labels**        | ✅                                                                | ✅ (shared alphabet logic)                  | ✅                              |
-| **Label filtering / search**   | ✅ (interactive search with `/` prefix, role filter, text filter) | ✅ (logic shared; no search input badge)    | ✅                              |
-| **Split word**                 | ✅                                                                | ✅                                          | ✅                              |
-| **Label direction**            | ✅ (configurable: horizontal, vertical, row-major, col-major)     | ✅                                          | ✅                              |
-| **Hide unmatched**             | ✅                                                                | ✅                                          | ✅                              |
-| **Strategy selection**         | `ax` (default), `vision` (macOS Vision Framework)                 | `ax` only                                   | `ax` only                       |
-| **Vision fallback**            | ✅ (AX → Vision → combined)                                       | N/A (Vision is macOS-only)                  | N/A                             |
-| **Per-app strategy overrides** | ✅                                                                | N/A                                         | N/A                             |
-| **Click at point**             | ✅                                                                | ✅ (system mouse click via XTest/SendInput) | ✅ (SendInput)                  |
-| **Hover**                      | ✅                                                                | 🟡                                          | 🟡                              |
-| **Right click**                | ✅                                                                | ✅ (XTest button 3)                         | ✅ (SendInput right)            |
-| **Middle click**               | ✅                                                                | ✅ (XTest button 2)                         | ✅ (SendInput middle)           |
-| **Hold button at element**     | ✅ (`--action left_mouse_down` etc.)                              | ✅ (XTest button press)                     | ✅ (SendInput down)             |
-| **Scroll at element**          | ✅ (CGScrollWheelEvent)                                           | 🟡                                          | 🟡                              |
-| **Menubar elements**           | ✅                                                                | 🟡                                          | 🟡                              |
-| **Dock elements**              | ✅                                                                | N/A                                         | N/A                             |
-| **Popup/popover elements**     | ✅ (AXOrientation-based)                                          | ⚠️ (walked when in active frame's subtree)  | 🟡                              |
-| **Hint overlay arrows**        | ✅ (top/bottom arrow indicators on labels)                        | ✅ (Cairo triangle tail)                    | ❌                              |
-| **Boundary highlight**         | ✅                                                                | ✅ (Cairo)                                  | ✅ (SDF)                        |
-| **Search input badge**         | ✅                                                                | ❌                                          | ✅                              |
-
-**Implementation note:** On macOS, hints work fully because AXUIElement tree
-walking gives a complete picture of clickable elements on screen. On Windows,
-the UIA integration provides initial element coverage but the tree is shallow.
-On Linux, hints work via an AT-SPI (D-Bus) walk of the active frame, so coverage
-depends on the app exposing AT-SPI (Qt/GTK apps with accessibility enabled do;
-some toolkits expose little) and there is no Vision/OCR fallback. Chromium/Electron
-apps expose nothing unless launched with `--force-renderer-accessibility`, and
-GNOME/Mutter has no usable injection path, so hints are not usable there. See the
-Linux accessibility notes under [Port Capability Matrix](#port-capability-matrix)
-for details.
-
-#### Grid Mode
-
-| Feature                           | macOS                                  | Linux                   | Windows                 |
-| --------------------------------- | -------------------------------------- | ----------------------- | ----------------------- |
-| **Full-screen grid**              | ✅                                     | ✅                      | ✅                      |
-| **Character-labeled cells**       | ✅                                     | ✅                      | ✅                      |
-| **Cell navigation (type coords)** | ✅                                     | ✅                      | ✅                      |
-| **Subgrid (3×3 zoom)**            | ✅                                     | ✅                      | ✅                      |
-| **Hide unmatched cells**          | ✅                                     | ✅                      | ✅                      |
-| **Grid transition animation**     | ✅ (CoreAnimation 120Hz)               | ✅ (goroutine 120fps)   | ❌                      |
-| **Sub-key preview**               | ✅ (centered mini-grid)                | ✅ (centered mini-grid) | ✅ (single-line text)   |
-| **Auto-hide labels**              | ✅                                     | ✅                      | ✅                      |
-| **Cursor-follow on activation**   | ✅                                     | ✅                      | ✅                      |
-| **Pending action on cell**        | ✅ (click, right-click, hover, scroll) | ✅ (click, right-click) | ✅ (click, right-click) |
-
-#### Recursive Grid Mode
-
-| Feature                     | macOS              | Linux          | Windows |
-| --------------------------- | ------------------ | -------------- | ------- |
-| **Multi-depth zoom**        | ✅                 | ✅             | ✅      |
-| **Per-depth layout config** | ✅                 | ✅             | ✅      |
-| **Center preview**          | ✅                 | ✅             | ✅      |
-| **Backtrack navigation**    | ✅                 | ✅             | ✅      |
-| **Grid transition**         | ✅ (CoreAnimation) | ✅ (goroutine) | ❌      |
-
-#### Scroll Mode
-
-| Feature                     | macOS                                   | Linux | Windows |
-| --------------------------- | --------------------------------------- | ----- | ------- |
-| **Vim-style scrolling**     | ✅                                      | ✅    | ✅      |
-| **Scroll overlay**          | ✅                                      | ✅    | ✅      |
-| **Smooth scroll animation** | ✅ (scroll_animator.go, ease-out cubic) | ❌    | ❌      |
-| **Line-by-line**            | ✅                                      | ✅    | ✅      |
-| **Page-by-page**            | ✅                                      | ✅    | ✅      |
-| **Half-page**               | ✅                                      | ✅    | ✅      |
-| **Top/bottom**              | ✅                                      | ✅    | ✅      |
-| **Custom scroll amounts**   | ✅ (configurable)                       | ✅    | ✅      |
-
-#### Monitor Select Mode
-
-| Feature               | macOS                    | Linux                   | Windows                 |
-| --------------------- | ------------------------ | ----------------------- | ----------------------- |
-| **Panel per display** | ✅ (native Cocoa panels) | ✅ (Cairo; X11 + wlroots/KDE, not GNOME) | ❌ (`CodeNotSupported`) |
-| **Label navigation**  | ✅                       | ✅                      | ❌                      |
-| **Cursor jump**       | ✅                       | ✅                      | ❌                      |
-
-### Linux Backend Breakdown
-
-Linux runtime backend detection is via `XDG_CURRENT_DESKTOP`, `WAYLAND_DISPLAY`, and
-`DISPLAY` (see `internal/core/infra/platform/linux_backend.go`). See the Port
-Capability Matrix above for per-backend capability status and mechanisms.
-
-**GNOME Wayland:** Not supported. GNOME/Mutter lacks `wlr-layer-shell` and has
-no usable input injection path. Users should use the X11 session with GNOME.
-
-### Windows Feature Detail
-
-Windows has pure Go implementations for all subsystems (see the Port Capability Matrix above for mechanisms).
-
-**Known gaps on Windows:**
-
-1. **App watcher** — no foreground-window change watching
-2. **Notifications** — no Windows toast notifications
-3. **Tree walking depth** — UIA tree is shallow; needs deeper traversal for complex apps
-4. **Grid transition animation** — not implemented (macOS and Linux have it)
-5. **Smooth cursor/scroll animation** — not implemented (smooth cursor exists on macOS + Linux; smooth scroll is macOS-only)
-6. **Modifier passthrough, PostModifierEvent** — no-ops
-7. **Scroll horizontal** — `ScrollAtCursor` ignores `deltaX` (vertical only)
-8. **Virtual pointer overlay** — stub only
-9. **Monitor select** — not implemented
-
-### Platform-Specific Features
-
-The following features exist on exactly one platform:
-
-#### macOS-Only
-
-| Feature                   | Location                                                                                | Reason Not Cross-Platform                                                                        |
-| ------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| System cursor hide/show   | `internal/app/modes/cursor_darwin.go`                                                   | Uses `CGDisplayHideCursor` / `CGDisplayShowCursor` (Quartz). Other platforms have no equivalent. |
-| Smooth scroll animation   | `internal/core/infra/platform/darwin/scroll_animator.go`                                | Platform scroll event stream. (Smooth **cursor** animation is now cross-platform on Linux too — see `mouse_animator_linux.go`.) |
-| Vision framework strategy | `internal/core/ports/vision.go` + `internal/core/infra/platform/darwin/vision_darwin.m` | macOS-only `VNRequest` / `VGImageRequestHandler` APIs                                            |
-| Screen sharing hide       | `internal/core/infra/platform/darwin/overlay_darwin.m`                                  | NSWindow sharing level property (Quartz only)                                                    |
-| Secure input detection    | `internal/core/infra/platform/darwin/secureinput.go`                                    | Uses `CGSessionCopyCurrentDictionary` — private API                                              |
-
-#### Linux-Only
-
-| Feature                         | Location                                                                                       | Notes                                                                        |
-| ------------------------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Wayland sync cursor surface     | `internal/core/infra/platform/linux/system_linux_wayland.go` `SyncCursorPosition()`            | Maps a transparent layer-shell surface to get `wl_pointer.enter` coordinates |
-| evdev scroll direct injection   | `internal/core/infra/eventtap/eventtap_linux_wayland_evdev_cgo.go` `IsUinputScrollAvailable()` | Direct `/dev/uinput` scroll; not available on macOS/Windows                  |
-| Linux backend detection         | `internal/core/infra/platform/linux_backend.go`                                                | `XDG_CURRENT_DESKTOP` / `WAYLAND_DISPLAY` / `DISPLAY` based routing          |
-| X11 event tap via XGrabKeyboard | `internal/core/infra/eventtap/eventtap_linux_x11.go`                                           | X11-specific mechanism                                                       |
-| Wayland focused-app app_id      | `internal/core/infra/platform/linux/wlroots_client.c` `neru_wlr_focused_app_id()`              | `wlr-foreign-toplevel-management` tracks the activated toplevel's app_id (wlroots/KDE) |
-
-#### Windows-Only
-
-| Feature                  | Location                                                | Notes                                                                    |
-| ------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `WH_KEYBOARD_LL` hook    | `internal/core/infra/eventtap/eventtap_windows.go`      | Low-level keyboard hook (different from macOS CGEventTap or Linux evdev) |
-| `RegisterHotKey` hotkeys | `internal/core/infra/hotkeys/manager_windows.go`        | Win32 `RegisterHotKey` API                                               |
-| SDF rendering            | `internal/core/infra/platform/windows/overlay_color.go` | Signed-distance-field rounded rectangle rendering (software)             |
-| GDI font compositing     | `internal/core/infra/platform/windows/overlay_ui.go`    | GDI `CreateFontW` + `DrawTextW` + alpha composite                        |
+- mixing backend detection into app or service code
+
+**A good platform PR** leaves the repo better in five ways: the implementation
+sits in the intended file slot, unsupported paths stay explicit and honest,
+capability reporting is updated, tests cover the new behavior or contract, and
+the docs tell the next contributor what changed. That is the bar even for small
+slices.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,6 +1,12 @@
 # Development Guide
 
-Contributing to Neru: build instructions, architecture overview, and contribution guidelines.
+How to set up a development environment, build, test, and contribute to Neru.
+
+For the architectural reference see [ARCHITECTURE.md](ARCHITECTURE.md); for
+platform-specific work see [CROSS_PLATFORM.md](CROSS_PLATFORM.md#contributor-guide).
+
+**Related:** [Architecture](ARCHITECTURE.md) ·
+[Coding Standards](CODING_STANDARDS.md) · [Cross-Platform Guide](CROSS_PLATFORM.md)
 
 ---
 
@@ -166,10 +172,24 @@ For the best development experience, we recommend:
 | Test   | `just test-integration` | Run integration tests              |
 | Test   | `just test-race`        | Run all tests with race detection  |
 | Test   | `just test-all`         | Run all tests (unit + integration) |
+| Test   | `just test-race-unit`   | Run unit tests with race detection |
+| Test   | `just test-race-integration` | Run integration tests with race detection |
 | Lint   | `just lint`             | Run linters                        |
-| Format | `just fmt`              | Format code                        |
-| Run    | `just run`              | Build and run the application      |
+| Lint   | `just vet`              | Run `go vet`                       |
+| Format | `just fmt`              | Format Go and Objective-C code     |
+| Format | `just fmt-check`        | Check Objective-C formatting       |
+| Docs   | `just genman`           | Generate man pages                 |
 | Clean  | `just clean`            | Remove build artifacts             |
+
+There is no `just run` recipe — build first, then launch the daemon directly:
+
+```bash
+just build
+./bin/neru launch
+```
+
+Run `just --list` for the full set, including the Wayland protocol generation
+and icon recipes.
 
 ### Debugging
 
@@ -403,18 +423,12 @@ go test -tags=integration ./internal/core/infra/accessibility/
 
 ## Architecture Overview
 
-### What Neru Does
-
-Neru is a keyboard-driven navigation tool that enhances productivity by allowing users to quickly navigate and interact with UI elements using keyboard shortcuts. macOS is the primary supported platform; Linux and Windows support is in progress (see [ARCHITECTURE.md](ARCHITECTURE.md)).
-
-**Four Navigation Modes:**
-
-- **Hints Mode**: Uses macOS Accessibility APIs to identify clickable elements and overlay hint labels
-- **Grid Mode**: Divides the screen into a grid system for coordinate-based navigation
-- **Scroll Mode**: Provides Vim-style scrolling at the cursor position
-- **Recursive Grid Mode**: Recursive cell navigation with center preview and reset/backtrack support
-
-All modes support various actions and can be configured extensively through TOML configuration files.
+This section covers only what you need in order to *add code*. The
+architectural reference — layers, component diagrams, data flow, coordinate
+systems, the "One Rule", and platform status — lives in
+[ARCHITECTURE.md](ARCHITECTURE.md), and per-platform feature support lives in
+[CROSS_PLATFORM.md](CROSS_PLATFORM.md#feature-parity-reference). Neither is
+repeated here.
 
 ### Mode Interface Contract
 
@@ -422,65 +436,58 @@ Neru uses a standardized `Mode` interface to ensure consistent behavior across a
 
 #### Interface Definition
 
+The live interface is defined in
+[internal/app/modes/handler.go](../internal/app/modes/handler.go):
+
 ```go
 type Mode interface {
-    // Activate initializes and starts the mode with optional action parameters
-    Activate(action *string)
+    // Activate activates the mode with an optional pending action.
+    Activate(opts ModeActivationOptions)
 
-    // HandleKey processes keyboard input during normal mode operation
+    // HandleKey processes a key press within the mode's context.
     HandleKey(key string)
 
-    // HandleActionKey processes keyboard input when in action sub-mode
-    HandleActionKey(key string)
-
-    // Exit performs cleanup and deactivates the mode
+    // Exit performs mode-specific cleanup and deactivation.
     Exit()
 
-    // ToggleActionMode switches between normal mode and action sub-mode
-    ToggleActionMode()
-
-    // ModeType returns the domain mode type identifier
+    // ModeType returns the domain mode type this implementation represents.
     ModeType() domain.Mode
 }
 ```
 
-#### Implementation Pattern
+`ModeActivationOptions` ([hints.go](../internal/app/modes/hints.go)) carries
+every per-activation override — `Action`, `Modifier`, `OnExit`, `Repeat`,
+`CursorFollowSelection`, `ZoomToDepth`, `FilterRoles`, `FilterTextContains`,
+`Search`, `HideOnEmptySearch`, `Strategy`, `LabelDirection`, `Toggle`,
+`SplitWord`. Adding a new CLI flag that varies a mode's activation usually means
+adding a field here rather than a new interface method.
 
-All mode implementations follow this pattern:
-
-1. **Struct Definition**: Create a struct that holds a reference to the Handler
-2. **Constructor**: Provide a `NewXXXMode(handler *Handler)` constructor
-3. **Interface Methods**: Implement all required interface methods
-4. **Registration**: Register the mode in `Handler.NewHandler()`
+> **Locking contract.** `Activate`, `HandleKey`, and `Exit` are all called with
+> the handler's `h.mu` **already held** by the public entry point
+> (`ActivateMode`, `HandleKeyPress`, `ExitMode`). Inside a mode, use only the
+> `*Locked` helpers (`setModeLocked`, `exitModeLocked`, …) — calling a public
+> `SetMode*` / `ExitMode` method self-deadlocks. See
+> [ARCHITECTURE.md](ARCHITECTURE.md) for the full lock ordering.
 
 #### Method Contracts
 
-##### `Activate(action *string)`
+##### `Activate(opts ModeActivationOptions)`
 
 - **Purpose**: Initialize the mode and set it as the active mode
-- **Parameters**: Optional action string for pending actions
 - **Responsibilities**:
     - Call `handler.setModeLocked()` to change app state (caller holds `h.mu`)
     - Show mode-specific overlays/UI
-    - Initialize mode-specific state
+    - Initialize mode-specific state from `opts`
     - Log mode activation at `info`; keep routing and redraw details at `debug`
 
 ##### `HandleKey(key string)`
 
-- **Purpose**: Process keyboard input during normal mode operation
+- **Purpose**: Process keyboard input while the mode is active
 - **Parameters**: Single key string (e.g., "a", "j", "escape")
 - **Responsibilities**:
     - Route keys to appropriate handlers
     - Update mode state based on input
     - Handle mode-specific navigation logic
-
-##### `HandleActionKey(key string)`
-
-- **Purpose**: Process keyboard input when in action sub-mode
-- **Parameters**: Single key string representing action selection
-- **Responsibilities**:
-    - Delegate to `handler.handleActionKey()` for action execution
-    - Handle action-specific key mappings
 
 ##### `Exit()`
 
@@ -490,93 +497,81 @@ All mode implementations follow this pattern:
     - Reset mode-specific state
     - Perform mode-specific cleanup only (common cleanup is handled by `exitModeLocked`)
 
-##### `ToggleActionMode()`
-
-- **Purpose**: Switch between normal mode and action sub-mode
-- **Responsibilities**:
-    - Delegate to handler's toggle method (e.g., `toggleActionModeForHints()`)
-    - Handle mode-specific action mode transitions
-
 ##### `ModeType()`
 
 - **Purpose**: Return the domain mode identifier
 - **Returns**: `domain.Mode` enum value (e.g., `domain.ModeHints`)
 
-#### Implementation Examples
+#### Implementation Pattern
 
-##### Basic Mode Structure
+Modes are **not** written as bare structs implementing four methods by hand.
+Two shared building blocks cover almost every case:
+
+- **`baseMode`** ([base.go](../internal/app/modes/base.go)) — holds the handler
+  and mode type, and supplies default no-op implementations of `Activate`,
+  `HandleKey`, and `Exit` plus a real `ModeType`. Embed it and override only
+  what differs.
+- **`GenericMode`** ([generic_mode.go](../internal/app/modes/generic_mode.go)) —
+  embeds `baseMode` and takes a `ModeBehavior` struct of optional
+  `ActivateFunc` / `HandleKeyFunc` / `ExitFunc` callbacks. When a callback is
+  nil it falls back to the handler's standard flow for that mode type.
+
+The result is that a mode is usually just a constructor supplying behavior.
+`ScrollMode` in full:
 
 ```go
-type ExampleMode struct {
-    handler *Handler
+type ScrollMode struct {
+    *GenericMode
 }
 
-func NewExampleMode(handler *Handler) *ExampleMode {
-    return &ExampleMode{handler: handler}
-}
-
-func (m *ExampleMode) ModeType() domain.Mode {
-    return domain.ModeExample
-}
-
-func (m *ExampleMode) Activate(action *string) {
-    // NOTE: Activate is called with h.mu already held (via ActivateModeWithAction).
-    // Use the *Locked helpers — never the public SetMode* methods (deadlock).
-    m.handler.setModeLocked(domain.ModeExample, overlay.ModeExample)
-    // Show example overlay
-    // Initialize state
-    m.handler.logger.Info("Example mode activated", zap.String("mode", "example"))
-}
-
-func (m *ExampleMode) HandleKey(key string) {
-    // NOTE: HandleKey is called with h.mu already held (via HandleKeyPress).
-    // Use exitModeLocked — never the public SetModeIdle (deadlock).
-    switch key {
-    case "escape":
-        m.handler.exitModeLocked()
-    // Handle other keys...
+func NewScrollMode(handler *Handler) *ScrollMode {
+    behavior := ModeBehavior{
+        ActivateFunc: func(handler *Handler, _ ModeActivationOptions) {
+            // Called with h.mu held — use *Locked helpers only.
+            handler.StartInteractiveScroll()
+            handler.startIndicatorPolling(domain.ModeScroll)
+        },
+        ExitFunc: func(handler *Handler) {
+            handler.stopIndicatorPolling()
+            handler.stopHeldRepeatLocked()
+            handler.clearAndHideOverlay()
+            // ... reset mode-specific state
+        },
     }
-}
 
-func (m *ExampleMode) HandleActionKey(key string) {
-    m.handler.handleActionKey(key, "Example")
-}
-
-func (m *ExampleMode) Exit() {
-    // Hide overlays
-    // Reset state
-}
-
-func (m *ExampleMode) ToggleActionMode() {
-    m.handler.toggleActionModeForExample()
+    return &ScrollMode{
+        GenericMode: NewGenericMode(handler, domain.ModeScroll, "ScrollMode", behavior),
+    }
 }
 ```
 
+Reach for a hand-written struct embedding `baseMode` only when the mode needs
+its own fields or a `HandleKey` too involved for a callback.
+
 ##### Registration Pattern
 
+Modes are registered in the map built by `NewHandler`
+([handler.go](../internal/app/modes/handler.go)):
+
 ```go
-func NewHandler(...) *Handler {
-    handler := &Handler{...}
-    handler.modes = map[domain.Mode]Mode{
-        domain.ModeHints:  NewHintsMode(handler),
-        domain.ModeGrid:   NewGridMode(handler),
-        domain.ModeAction: NewActionMode(handler),
-        domain.ModeScroll: NewScrollMode(handler),
-        // Add new modes here
-    }
-    return handler
+handler.modes = map[domain.Mode]Mode{
+    domain.ModeHints:         NewHintsMode(handler),
+    domain.ModeGrid:          NewGridMode(handler),
+    domain.ModeScroll:        NewScrollMode(handler),
+    domain.ModeRecursiveGrid: NewRecursiveGridMode(handler),
+    domain.ModeMonitorSelect: NewMonitorSelectMode(handler),
+    // Add new modes here
 }
 ```
 
 #### Best Practices
 
 1. **Consistent Naming**: Use `XXXMode` for struct names, `NewXXXMode` for constructors
-2. **Handler Reference**: Always store a reference to the Handler for accessing services
-3. **State Management**: Use the Handler's state management methods
+2. **Reuse the building blocks**: Prefer `GenericMode` + `ModeBehavior`; embed `baseMode` when you need custom fields
+3. **Respect the lock**: Only `*Locked` helpers inside `Activate` / `HandleKey` / `Exit`
 4. **Logging**: Log mode activation and real failures; keep key handling, redraws, and routine routing at `debug`
 5. **Error Handling**: Handle errors gracefully, don't panic
 6. **Resource Cleanup**: Always clean up overlays and state in `Exit()`
-7. **Action Mode Support**: Implement `ToggleActionMode()` even if not used
 
 #### Adding New Modes
 
@@ -619,7 +614,7 @@ Cross-platform file-slot conventions follow the naming rules in
 **Configuration Options:**
 
 1. Add fields to `internal/config/config.go` structs
-2. Update `commonDefaultConfig()` with shared defaults; add platform-specific defaults to `internal/config/config_<os>.go`
+2. Update `newDefaultConfig()` in `internal/config/config_defaults.go` with shared defaults; add platform overrides to `applyPlatformDefaults()` in `internal/config/config_<os>.go`
 3. Add validation in `Validate*()` methods
 4. Update `configs/` examples and [CONFIGURATION.md](CONFIGURATION.md)
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,8 +2,11 @@
 
 This guide covers installation methods for Neru, with the most complete support on macOS.
 
+**Related:** [CLI Reference](CLI.md) · [Configuration Reference](CONFIGURATION.md) ·
+[Linux setup](LINUX_SETUP.md) · [Troubleshooting](TROUBLESHOOTING.md)
+
 > [!NOTE]
-> macOS is the primary supported platform. Linux builds are available through the Nix flake (uses release artifacts when available, falls back to source build), and direct source builds. See the [Platform Support section in README.md](../README.md#💻-platform-support) for details.
+> macOS is the primary supported platform. Linux builds are available through the Nix flake (uses release artifacts when available, falls back to source build), and direct source builds. See the [Platform Support section in README.md](../README.md#platform-support) for details.
 
 ---
 

--- a/docs/LINUX_DESKTOPS.md
+++ b/docs/LINUX_DESKTOPS.md
@@ -1,9 +1,10 @@
 # Linux Desktop Environments
 
 Per-desktop-environment (DE) implementation notes for Neru on Linux: how each
-compositor is wired, important design decisions, and known issues. For building,
-installing dependencies, and preparing a host to run Neru, see
-[LINUX_SETUP.md](./LINUX_SETUP.md).
+compositor is wired, important design decisions, and known issues.
+
+**Related:** [Linux setup](./LINUX_SETUP.md) ·
+[Cross-Platform Guide](./CROSS_PLATFORM.md) · [Troubleshooting](./TROUBLESHOOTING.md)
 
 ---
 
@@ -13,6 +14,7 @@ installing dependencies, and preparing a host to run Neru, see
 - [wlroots compositors](#wlroots-compositors)
 - [X11 sessions](#x11-sessions)
 - [GNOME (not supported)](#gnome-not-supported)
+- [Global hotkeys on Wayland](#global-hotkeys-on-wayland)
 - [Checking compositor protocols](#checking-compositor-protocols)
 
 ---
@@ -33,7 +35,7 @@ KWin does **not** implement `zwlr_virtual_pointer_v1` (confirmed on KWin 6.6.4 v
 | Pointer / click / scroll        | `libei` via `org.freedesktop.portal.RemoteDesktop`                      | Only input path KWin exposes for third-party automation                            |
 | Key feeding (`action feed`)     | `libei` via `org.freedesktop.portal.RemoteDesktop`                     | Keyboard device must be granted in portal; defaults to pointer-only               |
 | Hints (AT-SPI)                  | AT-SPI D-Bus + KWin geometry bridge                                     | AT-SPI coords are window-relative; bridge maps to global compositor space          |
-| Global hotkeys                  | Compositor keybindings only                                             | Wayland has no global-hotkey protocol; user binds `neru <mode>` in System Settings |
+| Global hotkeys                  | Passive `evdev` read of `/dev/input/event*`, else compositor keybindings | Wayland has no global-hotkey protocol; Neru reads keyboards directly when permitted |
 | Systray                         | D-Bus StatusNotifierItem + `com.canonical.dbusmenu`                     | Matches KDE/GNOME tray hosts; no GTK dependency                                    |
 
 Routing lives in `system_linux_wayland_input.go`: if the compositor advertises
@@ -64,8 +66,11 @@ See [Checking compositor protocols](#checking-compositor-protocols) for the
    every fresh daemon start** (reboot, logout, relaunch): `liboeffis` does not
    expose restore-token / `persist_mode`, so KDE cannot persist the grant across
    launches.
-2. **Hotkeys** — Bind in **System Settings -> Shortcuts -> Custom Shortcuts**.
-   Use the absolute path to the binary so KWin resolves it reliably:
+2. **Hotkeys** — Neru's own `[hotkeys]` config works on KDE Wayland when the
+   daemon can read `/dev/input` (see [Global hotkeys on Wayland](#global-hotkeys-on-wayland)).
+   If you would rather not grant that access, bind the modes in **System
+   Settings → Shortcuts → Custom Shortcuts** instead. Use the absolute path to
+   the binary so KWin resolves it reliably:
 
     | Action         | Command                                      |
     | -------------- | -------------------------------------------- |
@@ -163,7 +168,7 @@ device (libei), while real hardware shows the physical device path.
 | Sticky modifiers              | `zwp_virtual_keyboard_v1` when available                                                                          |
 | Key feeding (`action feed`)   | `zwp_virtual_keyboard_v1` — same virtual keyboard path as sticky modifiers                                        |
 | Keyboard capture during modes | `evdev` on `/dev/input/event*` (requires `input` group)                                                           |
-| Global hotkeys                | Compositor config (`bind` / `bindsym` / `spawn-sh`)                                                               |
+| Global hotkeys                | Passive `evdev` read of Neru's own `[hotkeys]`; compositor config (`bind` / `bindsym` / `spawn-sh`) as fallback   |
 | Cursor position               | Client-side cache (Wayland hides global pointer); "agitation" via layer-shell + virtual pointer wiggle at startup |
 | Focused app                   | `zwlr_foreign_toplevel_manager_v1` app_id (no PID; `FocusedApplicationPID` best-effort matches app_id against `/proc`) |
 
@@ -209,6 +214,43 @@ and systemd deployment.
 GNOME Shell uses private protocols instead of wlr layer-shell / virtual pointer.
 Future work targets libei (same family as KDE) plus a GNOME Shell extension.
 See `internal/core/infra/platform/linux/wayland_gnome/PLACEHOLDER.md`.
+
+The daemon does not start in a GNOME Wayland session: `platform.NewSystemPort`
+returns `CodeNotSupported` during the first initialization phase rather than
+running in a degraded state. Use a **GNOME X11 session** instead — everything
+works there through the `x11` backend.
+
+---
+
+## Global hotkeys on Wayland
+
+Applies to both KDE and wlroots; X11 is unaffected (it uses `XGrabKey`).
+
+No Wayland protocol lets an ordinary client register a global hotkey. Neru
+therefore has two paths, and prefers the first:
+
+1. **Neru's own `[hotkeys]` config**, via a **passive** `evdev` listener that
+   reads `/dev/input/event*`. It never grabs devices or injects anything, so the
+   focused application still receives every key. While a mode is active the
+   in-mode event tap grabs the same devices, so the listener goes quiet until
+   the mode exits.
+2. **Compositor keybindings** — bind `neru hints`, `neru grid`, etc. in your
+   compositor config or System Settings. Always available, no permissions
+   needed, and the right choice if you prefer not to grant `/dev/input` access.
+
+Path 1 requires two things:
+
+- **Read access to `/dev/input`** — add your user to the `input` group and
+  re-login (see [LINUX_SETUP.md](./LINUX_SETUP.md)), or grant narrower access
+  via udev/ACL.
+- **A CGO build** — evdev support is compiled out when `CGO_ENABLED=0`, leaving
+  a no-op stub. Official Linux builds enable CGO.
+
+On startup the daemon logs which path it took: `"Wayland global hotkeys enabled
+via evdev; config keybindings are active"` on success, or a warning naming both
+the `input` group and the compositor-binding fallback on failure. The hotkey
+manager health-check re-initializes the listener if it dies or ends up with zero
+devices.
 
 ---
 

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -3,8 +3,11 @@
 Prepare a Linux host to **build, test, and deploy** Neru. This guide covers
 dependencies, permissions, building, validation, and generic troubleshooting.
 
-For per-desktop-environment implementation details, design decisions, and
-DE-specific known issues, see [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md).
+Per-desktop-environment implementation details and DE-specific known issues live
+in [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md).
+
+**Related:** [Linux desktops](./LINUX_DESKTOPS.md) ·
+[Cross-Platform Guide](./CROSS_PLATFORM.md) · [Installation](./INSTALLATION.md)
 
 ---
 
@@ -40,13 +43,17 @@ Host changes required before Neru runs correctly (not code changes):
 | #   | Adjustment                                                  | Why                                   | Backends  | Persists?               |
 | --- | ----------------------------------------------------------- | ------------------------------------- | --------- | ----------------------- |
 | 1   | Install [build dependencies](#build-dependencies)           | CGO backends and runtime libs         | All Linux | Yes                     |
-| 2   | Add user to `input` group: `sudo usermod -aG input "$USER"` | `evdev` keyboard capture on Wayland   | Wayland   | Yes (re-login required) |
-| 3   | Bind `neru <mode>` in compositor keybindings                | Wayland has no global-hotkey protocol | Wayland   | Yes (user config)       |
+| 2   | Add user to `input` group: `sudo usermod -aG input "$USER"` | `evdev` keyboard capture **and Neru's own global hotkeys** on Wayland | Wayland | Yes (re-login required) |
+| 3   | Bind `neru <mode>` in compositor keybindings                | Only needed if you skip item 2        | Wayland   | Yes (user config)       |
 
 Notes:
 
 - X11 only needs item 1; global hotkeys work via `XGrabKey` from Neru config.
 - Item 2 takes effect after a full logout/login or reboot.
+- Item 3 is a **fallback, not a requirement**: with item 2 in place Neru's own
+  `[hotkeys]` config works on Wayland through a passive evdev listener. Bind in
+  the compositor only if you would rather not grant `/dev/input` access. See
+  [Global hotkeys on Wayland](./LINUX_DESKTOPS.md#global-hotkeys-on-wayland).
 - Item 3 cannot be automated by a package; ship example snippets where helpful.
 
 ---
@@ -232,7 +239,11 @@ validating locally on Linux.
 
 **X11:** Hotkeys in `config.toml` work via `XGrabKey`.
 
-**Wayland:** Bind `neru <mode>` in the compositor. Examples:
+**Wayland:** Hotkeys in `config.toml` also work, through a passive `evdev`
+listener, provided the daemon can read `/dev/input` (see item 2 above). If you
+would rather not grant that access, bind `neru <mode>` in the compositor
+instead — see [Global hotkeys on Wayland](./LINUX_DESKTOPS.md#global-hotkeys-on-wayland).
+Compositor examples:
 
 Sway (`~/.config/sway/config`):
 
@@ -301,7 +312,10 @@ systemctl --user enable --now neru
 
 ## Known limitations
 
-1. **Wayland global hotkeys** — Configured in the compositor, not in Neru config.
+1. **Wayland global hotkeys** — Neru's own `[hotkeys]` config works via a passive
+   evdev listener, which needs `input`-group access and a CGO build; otherwise
+   bind the modes in your compositor instead. See
+   [Global hotkeys on Wayland](./LINUX_DESKTOPS.md#global-hotkeys-on-wayland).
 2. **Hints need AT-SPI** — Grid and scroll work without it; hints coverage varies
    by app. DE-specific coordinate details: [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md).
 3. **Dark mode** — Via `org.freedesktop.appearance` portal, with session-specific

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,6 +3,9 @@
 This roadmap keeps the next improvements visible for contributors and helps
 separate "stable on macOS today" from "portable by design, still incomplete".
 
+**Related:** [Cross-Platform Guide](CROSS_PLATFORM.md#feature-parity-reference) ·
+[Development Guide](DEVELOPMENT.md) · [Architecture](ARCHITECTURE.md)
+
 ---
 
 ## Table of Contents
@@ -26,30 +29,38 @@ separate "stable on macOS today" from "portable by design, still incomplete".
 - Linux (X11):
     - [x] native overlay rendering
     - [x] screen and cursor management
-    - [x] keyboard event capture & global hotkeys
-    - [ ] AT-SPI accessibility integration (shared)
-    - [ ] notifications and active app detection
+    - [x] keyboard event capture & global hotkeys (`XGrabKeyboard` / `XGrabKey`)
+    - [x] AT-SPI accessibility integration (shared)
+    - [x] active app detection & app watcher (event-driven)
+    - [ ] freedesktop notifications and alerts
 - Linux (Wayland wlroots):
     - [x] native layer-shell overlay rendering
     - [x] virtual pointer injection and cursor discovery
     - [x] keyboard event capture
-    - [ ] AT-SPI accessibility integration (shared)
-    - [ ] notifications and active app detection
-- Linux (Wayland GNOME):
-    - [ ] input injection (libei or GNOME shell extension)
-    - [ ] native overlay rendering
-    - [ ] global hotkeys & event capture
+    - [x] global hotkeys (passive evdev read of Neru's own config)
+    - [x] AT-SPI accessibility integration (shared)
+    - [x] active app detection & app watcher (`wlr-foreign-toplevel` app_id)
+    - [ ] freedesktop notifications and alerts
 - Linux (Wayland KDE Plasma):
     - [x] input injection (libei via RemoteDesktop portal)
     - [x] native overlay rendering (wlr-layer-shell + Cairo)
-    - [x] global hotkeys & event capture (evdev passive grab)
-    - [ ] app watcher / focus tracking
+    - [x] global hotkeys & event capture (passive evdev read)
+    - [x] app watcher / focus tracking
+    - [ ] persist the RemoteDesktop portal grant across daemon restarts
+    - [ ] freedesktop notifications and alerts
+- Linux (Wayland GNOME) — not supported; the daemon refuses to start:
+    - [ ] input injection (libei or GNOME shell extension)
+    - [ ] native overlay rendering
+    - [ ] global hotkeys & event capture
+    - [ ] focused-app source (Mutter exposes no `wlr-foreign-toplevel` equivalent)
 - Windows:
-    - [x] UI Automation integration — initial coverage
+    - [x] UI Automation integration — initial coverage (shallow tree)
     - [x] screen and cursor management
     - [x] global hotkeys and keyboard event capture
     - [x] native overlay rendering — layered Win32 window + GDI
-    - [ ] notifications and app watching
+    - [ ] app watcher (foreground-window notifications) and display hotplug events
+    - [ ] toast notifications
+    - [ ] `monitor_select` mode, grid transition animation, horizontal scroll
 
 ## Contributor Priorities
 

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -1,5 +1,13 @@
 # Tips & Tricks
 
+Worked configuration recipes for common workflows. Each entry states the goal,
+then the configuration that achieves it.
+
+For the full option reference see [CONFIGURATION.md](CONFIGURATION.md); for
+command flags see [CLI.md](CLI.md).
+
+**Related:** [Configuration Reference](CONFIGURATION.md) · [CLI Reference](CLI.md)
+
 ---
 
 ## Table of Contents

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,11 +1,35 @@
-# Troubleshooting Guide
+# Troubleshooting
 
-Common issues and solutions for Neru.
+Symptoms, causes, and fixes for common Neru problems.
+
+**Related:** [CLI Reference](CLI.md) · [Configuration Reference](CONFIGURATION.md) ·
+[Linux setup](LINUX_SETUP.md#troubleshooting)
+
+> **Platform note:** the examples below use macOS paths and, in a few places,
+> macOS-only features (Mission Control, Accessibility Zoom, Activity Monitor).
+> The diagnosis steps themselves apply everywhere — substitute your platform's
+> [log path](#log-file-locations). For Linux-specific setup problems (evdev
+> permissions, portal consent, compositor support) see
+> [LINUX_SETUP.md](./LINUX_SETUP.md#troubleshooting) and
+> [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md).
+
+---
+
+## Log File Locations
+
+`[logging].log_file` overrides this; when unset the default is:
+
+| Platform | Path                                     |
+| -------- | ---------------------------------------- |
+| macOS    | `~/Library/Logs/neru/app.log`            |
+| Linux    | `~/.local/state/neru/log/app.log`        |
+| Windows  | `%LOCALAPPDATA%\neru\log\app.log`        |
 
 ---
 
 ## Table of Contents
 
+- [Log File Locations](#log-file-locations)
 - [Quick Diagnosis](#quick-diagnosis)
 - [Installation & Setup](#installation--setup)
 - [Permissions](#permissions)
@@ -36,7 +60,7 @@ neru doctor
 # 3. Test basic functionality
 neru hints  # Should show hints
 
-# 4. Check logs
+# 4. Check logs (macOS path; see Log File Locations for Linux/Windows)
 tail -20 ~/Library/Logs/neru/app.log
 ```
 

--- a/internal/cli/hints.go
+++ b/internal/cli/hints.go
@@ -45,10 +45,10 @@ var HintsCmd = BuildModeCommand(ModeConfig{
     neru hints --action left_click           Select a hint to click once
     neru hints --action left_click --repeat  Click multiple elements in sequence
     neru hints --search                      Start with search input shown
-    neru hints --search --hide-on-empty-search Start search with hints hidden until you type
+    neru hints --search --hide-on-empty-search  Start search with hints hidden until you type
     neru hints --role AXButton               Hint only buttons
     neru hints --strategy vision             Use Vision Framework detection
-    neru hints --strategy vision --split-word Use vision strategy with word-level splitting
+    neru hints --strategy vision --split-word  Use vision strategy with word-level splitting
     neru hints --debug                       Print detected elements, no overlay (used on windows),
     neru hints --label-direction reverse     Use spread labels for this run`,
 

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -329,9 +329,11 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 		"a",
 		"",
 		fmt.Sprintf(
-			"Action to perform on %s (%s). Commas chain multiple actions (e.g. left_click,left_click for double-click)",
+			"Mouse button action to perform on %s (%s). Commas chain multiple actions "+
+				"(e.g. left_click,left_click for double-click). Other actions, such as "+
+				"scroll or move_mouse, run via 'neru action <name>'",
 			config.ActionDesc,
-			action.SupportedNamesString(),
+			action.ModeActionNamesString(),
 		),
 	)
 

--- a/internal/core/domain/action/action.go
+++ b/internal/core/domain/action/action.go
@@ -463,6 +463,28 @@ func SupportedNamesString() string {
 	return strings.Join(strs, ", ")
 }
 
+// ModeActionNamesString returns the comma-separated action names accepted by a
+// mode's --action flag, for use in help text.
+//
+// A mode performs its pending action at the selected point once the selection
+// is made, which only mouse button actions can do. The set is derived from the
+// same IsMouseButton predicate the CLI validates against, so help text cannot
+// drift from what is actually accepted.
+func ModeActionNamesString() string {
+	var names []string
+
+	for _, name := range KnownNames() {
+		actionType, err := name.ToType()
+		if err != nil || !actionType.IsMouseButton() {
+			continue
+		}
+
+		names = append(names, string(name))
+	}
+
+	return strings.Join(names, ", ")
+}
+
 // IsResetAction reports whether the given action is reset.
 func IsResetAction(name string) bool {
 	return Name(name) == NameReset

--- a/internal/core/ports/capability_presets.go
+++ b/internal/core/ports/capability_presets.go
@@ -72,7 +72,10 @@ func LinuxCapabilities() PlatformCapabilities {
 			"native notifications not implemented yet; target freedesktop notifications",
 		),
 		GlobalHotkeys: supportedCapability(
-			"global hotkeys available via X11 (Wayland relies on compositor bindings)",
+			"global hotkeys available via X11 XGrabKey; on Wayland via a passive " +
+				"evdev listener on /dev/input that honors neru's own keybindings " +
+				"(needs input-group access and a cgo build), falling back to " +
+				"compositor keybindings otherwise",
 		),
 		KeyboardEventTap: supportedCapability(
 			"keyboard event tap available via X11 grab and Wayland evdev/layer-shell " +
@@ -126,8 +129,9 @@ func WindowsCapabilities() PlatformCapabilities {
 		AppWatcher: stubCapability(
 			"app watcher not implemented yet; target Win32 foreground-window notifications",
 		),
-		DarkModeDetection: stubCapability(
-			"dark mode detection not implemented yet; target Windows personalization APIs",
+		DarkModeDetection: supportedCapability(
+			"dark mode detection available via the Windows personalization registry " +
+				"(Themes\\Personalize AppsUseLightTheme)",
 		),
 	}
 }


### PR DESCRIPTION
## Description

This PR rewrites the CLI and configuration references into a single consistent
reference layout, and corrects a set of claims in them that no longer matched
the code. Commands are now grouped by purpose with a uniform block each —
purpose, synopsis, description, a flag table, examples — and flags carry type,
default and platform support instead of being loose paragraphs.

Both references now state per-platform support explicitly, so a Linux or Windows
user can tell what applies to them without reading the source. Every remaining
document picks up the same front matter, table of contents and cross-link
conventions, and the duplicated architecture overview in the development guide
now links to the architecture document rather than restating it.

Two code fixes come with it, both cases of user-facing text disagreeing with
what the code does: `neru doctor` under-reported two capabilities, and the
`--action` help on the mode commands advertised values the CLI rejects. No
other runtime behaviour changes.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `docs` — Documentation only
- [x] `fix` — Bug fix (`neru doctor` capability reporting; mode `--action` help text)

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no OS-specific files added or changed.
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new platform capability introduced.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality — N/A, the two code changes alter help and diagnostic strings only; the accepted `--action` set is unchanged and already covered, and no test asserted the previous capability preset values.
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command and configuration surface

No commands, flags or configuration options are added, renamed or removed. The
changes below are documentation catching up with the shipped interface, plus one
correction to diagnostic output.

| Surface | Change |
| :------ | :----- |
| `neru roles` | Existing command, previously undocumented. Now has a reference entry, including `--explain`. |
| `neru action sleep` | Documented as a terminal command; it is not one. It exists only inside a hotkey binding, as `"action sleep 0.5"`, and cannot appear in a comma-separated chain. Running it from a shell returns `ERR_INVALID_INPUT`. |
| `--on-exit` | Existing flag on `hints`, `grid` and `recursive_grid`, previously undocumented. |
| `--timeout` | Documented default was `5`; the actual default is `10`. Documentation only — the flag is unchanged. |
| `neru doctor` | Now reports Windows dark mode detection as supported rather than a stub, and describes the Linux Wayland hotkey path accurately. |
| `--action` on `hints` / `grid` / `recursive_grid` | Help text listed every action name, but only mouse button actions are accepted; `scroll`, `move_mouse` and `move_mouse_relative` were rejected with `ERR_INVALID_INPUT`. Help now lists the accepted names only. Accepted values are unchanged. |
| Default global hotkeys | Unchanged, but now documented: Linux ships none (they are cleared at startup to avoid colliding with shortcuts such as `Ctrl+Shift+C`), while macOS and Windows ship the four launcher bindings. |

Per-platform support is now recorded for both surfaces: the CLI reference carries
a platform column per command plus a table for the actions that differ, and the
configuration reference lists every option whose behaviour is not identical
across platforms alongside what it does when unsupported. Unsupported options
remain accepted and validated, so a single config file still works across
machines.

## Potential breaking changes

None. No option, command or flag changes name, accepted values or default, and
no existing config file or script needs to change.

One behavioural note for reviewers: `neru doctor` output changes. Windows dark
mode detection moves from `stub` to `supported`, and the Linux global-hotkey
detail string is rewritten. Anything parsing `neru doctor` output for those two
fields would see different text — the fields themselves are unchanged, and this
brings the report in line with what the adapters have been doing.

## Additional Context

The corrections were found by checking both documents against the code rather
than by reading them. Verification carried out:

- Every command, subcommand and flag in the CLI reference was checked against
  the built binary's help output; coverage is complete.
- All 136 documented configuration defaults were compared against
  `DefaultConfig()`; zero mismatches remain.
- Internal links and anchors resolve across all 16 documents.

Corrections beyond the interface table above:

- `[mouse_action_indicator]` was documented as macOS-only. It is implemented on
  all three platforms, with a different animation driver on each.
- Wayland global hotkeys were described as compositor-only in three documents.
  Neru's own keybindings work through the passive evdev listener when the daemon
  can read `/dev/input`; compositor bindings are the fallback.
- The development guide documented a `Mode` interface with two methods that no
  longer exist, and an implementation pattern that predates the current shared
  mode helpers.
- References to a `just run` recipe and an `accessibility/cache.go` file, neither
  of which exists.
- The README stated Linux hints were unavailable; they work through AT-SPI, with
  coverage depending on the application. It also wrote the launcher hotkeys as
  `Cmd+`, when they default to `Primary+` — `Ctrl` on Windows, and unbound on
  Linux.
- `hints.strategy = "vision"` is accepted by validation on every platform but
  returns no elements off macOS, so hints appear empty rather than degrading.
  This is now called out explicitly.

Two issues raised in review were confirmed against the code and fixed:

- Mode `--action` was documented as accepting `scroll`, `move_mouse` and
  `move_mouse_relative`. It does not — a mode performs its pending action at the
  selected point, which only mouse button actions can do, so all three are
  rejected. The documentation came from the flag's own help text, which listed
  every known action name; that help string is the root cause and is fixed here
  rather than only the documentation. It is now generated from the same
  predicate the validator uses, so the two cannot drift again.
- The README presented the launcher hotkeys as defaults on every platform. Linux
  clears all global hotkey bindings at startup, so it has none. The README and
  the configuration reference now state the per-platform defaults.

The cross-platform guide shrank from 1039 to 730 lines by removing content
duplicated three ways, while the two references grew as platform detail and flag
tables were added.
