### PR TITLE
docs: give each contributor guide a single subject

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,15 @@
 # Contributing to Neru
 
-Thanks for your interest in contributing! Neru is a small project with an approachable codebase, and we welcome contributions of all kinds — code, docs, bug reports, config examples, or ideas.
+Thanks for your interest in contributing! Neru is a small project with an
+approachable codebase, and we welcome contributions of all kinds — code, docs,
+bug reports, config examples, or ideas.
+
+This document owns the **contribution process**: how to propose a change, how to
+commit it, and how to get it merged. The technical guides own the rest —
+[DEVELOPMENT.md](docs/DEVELOPMENT.md) for environment setup, building, and
+testing; [ARCHITECTURE.md](docs/ARCHITECTURE.md) for how the codebase is
+structured; [CROSS_PLATFORM.md](docs/CROSS_PLATFORM.md) for platform work; and
+[CODING_STANDARDS.md](docs/CODING_STANDARDS.md) for style.
 
 ---
 
@@ -8,13 +17,10 @@ Thanks for your interest in contributing! Neru is a small project with an approa
 
 - [Code of Conduct](#code-of-conduct)
 - [Getting Started](#getting-started)
-- [Development Setup](#development-setup)
 - [Making Changes](#making-changes)
 - [Commit Messages](#commit-messages)
-- [Architecture & Cross-Platform](#architecture--cross-platform)
 - [Pull Requests](#pull-requests)
-- [Testing](#testing)
-- [Code Style](#code-style)
+- [Platform Work](#platform-work)
 - [Good First Contributions](#good-first-contributions)
 - [Reporting Bugs](#reporting-bugs)
 - [Feature Requests](#feature-requests)
@@ -23,60 +29,24 @@ Thanks for your interest in contributing! Neru is a small project with an approa
 
 ## Code of Conduct
 
-This project follows our [Code of Conduct](CODE_OF_CONDUCT.md). By participating you agree to uphold it. Please report unacceptable behavior via [GitHub Issues](https://github.com/y3owk1n/neru/issues) or by contacting [@y3owk1n](https://github.com/y3owk1n) directly.
+This project follows our [Code of Conduct](CODE_OF_CONDUCT.md). By participating
+you agree to uphold it. Please report unacceptable behavior via
+[GitHub Issues](https://github.com/y3owk1n/neru/issues) or by contacting
+[@y3owk1n](https://github.com/y3owk1n) directly.
 
 ---
 
 ## Getting Started
 
-1. **Search existing issues** — check if someone is already working on the same thing or if there's a related discussion.
-2. **Open an issue first** for non-trivial changes — this avoids wasted effort and lets us align on approach before you write code.
-3. **Small, focused PRs** are preferred over large, sweeping changes.
+1. **Search existing issues** — check whether someone is already working on the
+   same thing, or whether there's a related discussion.
+2. **Open an issue first** for non-trivial changes. This avoids wasted effort and
+   lets us align on approach before you write code.
+3. **Small, focused PRs** are preferred over large, sweeping ones.
 
----
-
-## Development Setup
-
-### Prerequisites
-
-- **Go 1.26+** — [Install Go](https://golang.org/dl/)
-- **Xcode Command Line Tools** — `xcode-select --install`
-- **Just** — command runner — `brew install just`
-- **golangci-lint** — linter — `brew install golangci-lint`
-
-### Recommended: Devbox
-
-[Devbox](https://www.jetify.com/devbox) provides an isolated environment with all tools pre-configured:
-
-```bash
-curl -fsSL https://get.jetify.com/devbox | bash
-devbox shell
-```
-
-### Clone & Verify
-
-```bash
-git clone https://github.com/y3owk1n/neru.git
-cd neru
-go version          # Should be 1.26+
-just --version
-golangci-lint --version
-just --list         # See all available commands
-```
-
-### Cross-Platform Setup
-
-Neru can be developed on any OS, but some features require platform-specific APIs.
-
-- **macOS**: Full environment support (CGo, Accessibility, Overlays).
-- **Linux**: backend-dependent. Some work can stay pure Go; X11/Wayland and compositor work may need additional native tooling depending on the backend you choose.
-- **Windows**: prefer pure-Go Win32/COM bindings first. A C compiler is not the default requirement unless a specific backend introduces that need.
-
-For full details see:
-
-- [Development Guide](docs/DEVELOPMENT.md)
-- [System Architecture](docs/ARCHITECTURE.md)
-- [Cross-Platform Guide](docs/CROSS_PLATFORM.md)
+Set up your environment by following
+[DEVELOPMENT.md](docs/DEVELOPMENT.md#development-setup) — Devbox is the
+recommended path and provides every tool pre-configured.
 
 ---
 
@@ -89,38 +59,47 @@ For full details see:
     git checkout -b feat/my-feature
     ```
 
-3. **Make your changes** following the [Coding Standards](docs/CODING_STANDARDS.md).
-4. **Add or update tests** for any new or changed functionality.
-5. **Run the pre-commit checklist**:
+3. **Make your changes**, following
+   [CODING_STANDARDS.md](docs/CODING_STANDARDS.md). Where new code belongs is
+   mapped out in [DEVELOPMENT.md](docs/DEVELOPMENT.md#adding-code).
+4. **Add or update tests.** All new code needs coverage — see
+   [DEVELOPMENT.md](docs/DEVELOPMENT.md#testing) for the test tiers and
+   [TESTING_PATTERNS.md](docs/testing/TESTING_PATTERNS.md) for the patterns.
+5. **Run the pre-commit checks:**
 
     ```bash
-    just fmt            # Format code
-    just lint           # Run linters
-    just test           # Run unit tests
-    just build          # Verify build
+    just fmt      # format Go and Objective-C
+    just lint     # golangci-lint
+    just test     # unit + integration
+    just build    # verify the build
     ```
 
-   For Linux or Windows platform work, it is also reasonable to start with:
+    Doing Linux or Windows work? Start with `just test-foundation` and
+    `just build-linux` / `just build-windows`.
 
-    ```bash
-    just test-foundation
-    just build-linux     # or just build-windows
-    ```
-
-6. **Commit** using [conventional commits](#commit-messages).
-7. **Push** and open a pull request.
+6. **Update the docs** in the same PR. Each fact has one home — the
+   [documentation checklist](docs/CROSS_PLATFORM.md#documentation-checklist)
+   says which file owns what, so please update the owner rather than restating
+   it in a second place.
+7. **Commit** using [conventional commits](#commit-messages), then push and open
+   a pull request.
 
 ---
 
 ## Commit Messages
 
-We use [Conventional Commits](https://www.conventionalcommits.org/) to power automated releases via [Release Please](https://github.com/googleapis/release-please).
+We use [Conventional Commits](https://www.conventionalcommits.org/) to power
+automated releases via
+[Release Please](https://github.com/googleapis/release-please). **The commit
+subject is what ships in the changelog**, so write it for users.
 
 **Format:**
 
 ```
 <type>(<optional scope>): <subject>
+
 <optional body>
+
 <optional footer>
 ```
 
@@ -145,94 +124,69 @@ fix(hints): correct overlay positioning on multi-monitor setups
 docs: update configuration reference for scroll mode
 ```
 
----
+A fuller message earns its body by explaining *why*:
 
-## Architecture & Cross-Platform
+```
+feat: add grid-based navigation mode
 
-Neru is designed as a cross-platform tool with a strong emphasis on architectural separation. Before contributing code, especially for Linux or Windows support, please review the [System Architecture](docs/ARCHITECTURE.md).
+Implement grid-based navigation as an alternative to hints. Grid mode divides
+the screen into cells and allows precise cursor positioning without relying on
+the accessibility tree.
 
-### Key Architectural Rules
-
-1. **Platform Isolation**: OS-specific code must be strictly isolated. Non-darwin code must never import darwin-specific packages.
-2. **Hexagonal Architecture**: We use the Ports and Adapters pattern. Define interfaces (Ports) in `internal/core/ports` and implement them in `internal/core/infra`.
-3. **Build Tags**: Use Go build tags (e.g., `//go:build linux`) for OS-specific files.
-
-### Contributing to New Platforms
-
-If you are working on Linux or Windows support:
-
-- Check the current [Platform Status](docs/ARCHITECTURE.md#platform-status) in the architecture guide.
-- Start with the [Cross-Platform Contributor Guide](docs/CROSS_PLATFORM.md#contributor-guide).
-- Implement in the existing platform slot instead of inventing new file layout.
-- For Linux, prefer the reserved backend files: `*_linux_common.go`, `*_linux_x11.go`, and `*_linux_wayland.go`.
-- Follow the patterns established in the macOS implementation where applicable, but keep macOS-specific assumptions out of shared code.
-
-### Cross-Platform PR Checklist
-
-For Linux, Windows, and shared platform work, a good PR usually does all of the following:
-
-1. Puts the implementation in the intended file slot.
-2. Keeps unsupported paths explicit with `CodeNotSupported` where needed.
-3. Updates capability reporting if support changed.
-4. Adds tests at the right level.
-5. Updates contributor-facing docs if file layout, backend assumptions, or build requirements changed.
+Closes #123
+```
 
 ---
 
 ## Pull Requests
 
-- **Title** should follow the same conventional commit format (e.g. `feat(hints): add multi-monitor support`).
-- **Description** should explain _what_ changed and _why_. Include screenshots or recordings for UI changes.
+- **Title** follows the same conventional commit format (e.g.
+  `feat(hints): add multi-monitor support`).
+- **Description** explains _what_ changed and _why_. Include screenshots or
+  recordings for UI changes.
 - **Keep PRs focused** — one logical change per PR.
 - **Link related issues** (e.g. `Closes #123`).
 - All CI checks (lint, test, build) must pass before merge.
-- A maintainer will review your PR. Be open to feedback and iterate.
+- A maintainer will review. Be open to feedback and iterate.
 
 ---
 
-## Testing
+## Platform Work
 
-Neru separates tests into unit and integration tests:
+Neru puts a strong emphasis on architectural separation, and platform changes
+are where that matters most. Before writing Linux or Windows code:
 
-| Type              | File pattern            | Command                 | Build tag     |
-| ----------------- | ----------------------- | ----------------------- | ------------- |
-| Unit tests        | `*_test.go`             | `just test`             | —             |
-| Integration tests | `*_integration_test.go` | `just test-integration` | `integration` |
+- Read [The "One Rule"](docs/ARCHITECTURE.md#the-one-rule) — non-darwin code must
+  never import the darwin platform package. It is enforced by both `depguard` and
+  an architecture test.
+- Check the current
+  [platform status](docs/CROSS_PLATFORM.md#platform-status) and
+  [capability matrix](docs/CROSS_PLATFORM.md#capability-matrix).
+- Work through the
+  [Cross-Platform Contributor Guide](docs/CROSS_PLATFORM.md#contributor-guide) —
+  it covers file slots, the Linux backend model, CGO guidance, and the bar a
+  platform PR has to clear.
 
-**Guidelines:**
-
-- All new code requires tests.
-- Use **table-driven tests** where possible.
-- Unit tests should be fast with no system dependencies — use mocks.
-- Integration tests use real macOS APIs and are tagged `//go:build integration`.
-- Run `just test-coverage` to check coverage locally.
-
-For detailed patterns see [Testing Patterns](docs/testing/TESTING_PATTERNS.md).
-
----
-
-## Code Style
-
-All code must follow the [Coding Standards](docs/CODING_STANDARDS.md):
-
-- **Go**: [Go Conventions](docs/go/CONVENTIONS.md) — imports, naming, error handling, receiver conventions.
-- **Objective-C**: [Objective-C Guidelines](docs/go/OBJECTIVE_C.md) — `.h`/`.m` files, memory management, naming.
-- Format with `just fmt` (uses `goimports` + `gofumpt`).
-- Lint with `just lint` (uses `golangci-lint`).
-- Add godoc comments for all exported symbols.
+Implement in the existing platform slot rather than inventing new file layout,
+and keep macOS-specific assumptions out of shared code.
 
 ---
 
 ## Good First Contributions
 
-Not sure where to start? These are great entry points:
+Not sure where to start?
 
-- 🐛 Bug fixes — check [open issues](https://github.com/y3owk1n/neru/issues)
+- 🐛 Bug fixes — check the [open issues](https://github.com/y3owk1n/neru/issues)
 - 📝 Documentation improvements or typo fixes
 - 📦 Config examples for common setups
 - 🎥 Demo videos or GIFs
 - ⚡ Performance improvements
 - 🧪 Additional test coverage
+
+For platform work specifically,
+[Contributing safely](docs/CROSS_PLATFORM.md#contributing-safely) lists
+well-scoped starter tasks — and the changes worth opening an issue about first.
+Longer-term direction is in [ROADMAP.md](docs/ROADMAP.md).
 
 ---
 
@@ -240,11 +194,17 @@ Not sure where to start? These are great entry points:
 
 Open a [GitHub Issue](https://github.com/y3owk1n/neru/issues/new) with:
 
-1. **macOS version** and **Neru version** (`neru version`).
+1. **Your platform** (macOS/Linux/Windows and version; on Linux, your desktop
+   and session type) and **Neru version** (`neru version`).
 2. **Steps to reproduce** — minimal and specific.
 3. **Expected vs actual behavior**.
-4. **Logs** — run with `log_level = "debug"` and attach relevant lines from `~/Library/Logs/neru/app.log`.
+4. **Logs** — set `log_level = "debug"` and attach the relevant lines. Log paths
+   are listed in
+   [TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md#log-file-locations).
 5. **Screenshots or recordings** if the issue is visual.
+
+`neru doctor` output is useful too — it reports which capabilities your platform
+actually supports.
 
 See also: [Troubleshooting Guide](docs/TROUBLESHOOTING.md).
 
@@ -252,7 +212,8 @@ See also: [Troubleshooting Guide](docs/TROUBLESHOOTING.md).
 
 ## Feature Requests
 
-Open a [GitHub Issue](https://github.com/y3owk1n/neru/issues/new) or start a [Discussion](https://github.com/y3owk1n/neru/discussions) describing:
+Open a [GitHub Issue](https://github.com/y3owk1n/neru/issues/new) or start a
+[Discussion](https://github.com/y3owk1n/neru/discussions) describing:
 
 - **What** you'd like to see.
 - **Why** it would be useful (your use case).

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ _Built for the person who already remapped Caps Lock._
 
 **Free and open-source.** No subscription. No trial. No catch.
 
-|      macOS       |      Linux       |     Windows      |
-| :--------------: | :--------------: | :--------------: |
-| Full featured ✅ |     Beta 🔵      | Basic support 🔵 |
+|    macOS    |      Linux       |      Windows      |
+| :---------: | :--------------: | :---------------: |
+|  Stable ✅  | Beta — daily 🔵  | Alpha — try it 🟡 |
+
+<sub>[What these mean](docs/CROSS_PLATFORM.md#what-the-labels-mean) — stable is fully featured, beta is good for daily driving, alpha is worth trying but not yet worth switching to.</sub>
 
 </div>
 
@@ -229,8 +231,9 @@ More modes, more engines, more platforms — and it's free. If you've been payin
 **Hints caveats.** On **Linux**, hints work through AT-SPI, so coverage depends
 on the app exposing an accessibility tree (GTK/Qt do; Chromium and Electron apps
 need `--force-renderer-accessibility`). On **Windows**, UI Automation coverage is
-initial and the tree walk is shallow. **Linux requires X11 or Wayland on
-wlroots/KWin — GNOME Wayland is not supported**; use a GNOME X11 session.
+initial and the tree walk is shallow, and per-app config does not re-apply when
+you change windows. **Linux requires X11 or Wayland on wlroots/KWin — GNOME
+Wayland is not supported**; use a GNOME X11 session.
 
 → [Roadmap](docs/ROADMAP.md) · [Cross-platform details](docs/CROSS_PLATFORM.md)
 

--- a/README.md
+++ b/README.md
@@ -240,18 +240,34 @@ wlroots/KWin — GNOME Wayland is not supported**; use a GNOME X11 session.
 
 Everything you need to go deep:
 
+**Using Neru**
+
+| Guide                                            | What's in it                                             |
+| :----------------------------------------------- | :-------------------------------------------------------- |
+| [Installation](docs/INSTALLATION.md)             | Homebrew, Nix, prebuilt binaries, source, permissions     |
+| [CLI Reference](docs/CLI.md)                     | Every command, flag, and argument                         |
+| [Configuration Reference](docs/CONFIGURATION.md) | Every option, with types, defaults, and platform support  |
+| [Tips & Tricks](docs/TIPS_TRICKS.md)             | Worked configuration recipes                              |
+| [Config Showcases](docs/CONFIG_SHOWCASES.md)     | Real setups shared by the community                       |
+| [Troubleshooting](docs/TROUBLESHOOTING.md)       | Common issues and fixes                                   |
+
+**Platform support**
+
 | Guide                                          | What's in it                                              |
 | :--------------------------------------------- | :-------------------------------------------------------- |
-| [Installation](docs/INSTALLATION.md)           | Homebrew, Nix, prebuilt binaries, source, permissions     |
-| [CLI Reference](docs/CLI.md)                   | Every command, flag, and argument                         |
-| [Configuration Reference](docs/CONFIGURATION.md) | Every option, with types, defaults, and platform support |
-| [Tips & Tricks](docs/TIPS_TRICKS.md)           | Worked configuration recipes                              |
-| [Config Showcases](docs/CONFIG_SHOWCASES.md)   | Real setups shared by the community                       |
-| [Troubleshooting](docs/TROUBLESHOOTING.md)     | Common issues and fixes                                   |
 | [Cross-Platform Guide](docs/CROSS_PLATFORM.md) | What works on each platform, and how it is implemented    |
-| [Linux Setup](docs/LINUX_SETUP.md)             | Dependencies, permissions, and per-desktop notes          |
-| [Roadmap](docs/ROADMAP.md)                     | What's coming                                             |
-| [Contributing](CONTRIBUTING.md)                | PRs and bug reports                                       |
+| [Linux Setup](docs/LINUX_SETUP.md)             | Dependencies, permissions, building, deployment           |
+| [Linux Desktops](docs/LINUX_DESKTOPS.md)       | Per-desktop setup, protocol support, and known issues     |
+
+**Working on Neru**
+
+| Guide                                            | What's in it                                            |
+| :----------------------------------------------- | :-------------------------------------------------------- |
+| [Contributing](CONTRIBUTING.md)                  | How to propose, commit, and land a change                 |
+| [Development Guide](docs/DEVELOPMENT.md)         | Setup, building, testing, debugging, where code goes      |
+| [Architecture](docs/ARCHITECTURE.md)             | Layers, boundaries, data flow, platform isolation         |
+| [Coding Standards](docs/CODING_STANDARDS.md)     | Formatting, logging, documentation conventions            |
+| [Roadmap](docs/ROADMAP.md)                       | What's coming next                                        |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,6 +6,10 @@ that keep platform code isolated.
 Neru is a keyboard-driven navigation tool written in Go with an Objective-C
 bridge on macOS. It runs as a daemon with a thin CLI client.
 
+This document owns **system shape and rationale**. What actually works on each
+platform lives in [CROSS_PLATFORM.md](CROSS_PLATFORM.md); how to build and test
+lives in [DEVELOPMENT.md](DEVELOPMENT.md).
+
 **Related:** [Cross-Platform Guide](CROSS_PLATFORM.md) ·
 [Development Guide](DEVELOPMENT.md) · [Coding Standards](CODING_STANDARDS.md)
 
@@ -14,21 +18,19 @@ bridge on macOS. It runs as a daemon with a thin CLI client.
 ## Table of Contents
 
 - [System Overview](#system-overview)
-- [Cross-Platform Design Principles](#cross-platform-design-principles)
-- [Platform Status](#platform-status)
-- [Platform Contribution Model](#platform-contribution-model)
-- [CLI Layer Cross-Platform Notes](#cli-layer-cross-platform-notes)
-- [Application Identifier Terminology](#application-identifier-terminology)
+- [Runtime Shape](#runtime-shape)
+- [Design Principles](#design-principles)
+- [The "One Rule"](#the-one-rule)
+- [Component Architecture](#component-architecture)
 - [Codebase Navigation Guide](#codebase-navigation-guide)
-- [Runtime Capability Reporting](#runtime-capability-reporting)
+- [Data Flow](#data-flow)
+- [Mode Handler Locking](#mode-handler-locking)
 - [Coordinate Systems and Units](#coordinate-systems-and-units)
 - [Error Handling and Graceful Degradation](#error-handling-and-graceful-degradation)
+- [Runtime Capability Reporting](#runtime-capability-reporting)
+- [Platform Boundaries in the CLI Layer](#platform-boundaries-in-the-cli-layer)
+- [Application Identifier Terminology](#application-identifier-terminology)
 - [Technology Stack](#technology-stack)
-- [Component Architecture](#component-architecture)
-- [Platform-Specific Implementations](#platform-specific-implementations)
-- [Data Flow Diagrams](#data-flow-diagrams)
-- [API Integration Patterns](#api-integration-patterns)
-- [Build and Deployment Processes](#build-and-deployment-processes)
 - [Performance Considerations](#performance-considerations)
 - [Security Architecture](#security-architecture)
 - [References](#references)
@@ -37,268 +39,92 @@ bridge on macOS. It runs as a daemon with a thin CLI client.
 
 ## System Overview
 
-Neru operates as a background daemon that listens for global hotkeys and keyboard events. When activated, it provides several navigation modes:
+Neru runs as a background daemon that listens for global hotkeys and keyboard
+events. When activated it offers several navigation modes:
 
-- **Hints Mode**: Overlays unique character labels on clickable UI elements.
-- **Grid Mode**: Divides the screen into a coordinate-based grid system.
-- **Scroll Mode**: Provides Vim-style scrolling at the current cursor position.
-- **Recursive Grid Mode**: Recursive cell navigation with center preview and backtracking.
+- **Hints** — overlays unique character labels on clickable UI elements
+- **Grid** — divides the screen into a coordinate-based grid
+- **Recursive grid** — recursive cell navigation with center preview and backtracking
+- **Scroll** — Vim-style scrolling at the cursor position
 
-The architecture is designed for high performance, low latency, and cross-platform extensibility while maintaining a deep integration with macOS native APIs.
-
-This document focuses on system shape and architectural rationale.
-For contributor workflow, file-slot selection, Linux backend guidance, and
-practical porting steps, use [CROSS_PLATFORM.md](CROSS_PLATFORM.md).
-
----
-
-## Cross-Platform Design Principles
-
-Neru follows a layered architecture inspired by the **Hexagonal Architecture (Ports and Adapters)** pattern.
-
-### Core Principles
-
-1. **Shared Business Logic**: All core logic (hint generation, grid calculations, mode transitions) is written in pure Go and resides in `internal/core/domain` and `internal/app/services`.
-2. **Platform Isolation**: OS-specific code is strictly isolated. Non-darwin code must never import macOS-specific packages.
-3. **Ports and Adapters**: System capabilities (Accessibility, Hotkeys, Overlays) are defined as interfaces (Ports) in `internal/core/ports`. Concrete implementations (Adapters) reside in `internal/core/infra`.
-4. **Build Tag Separation**: OS-specific files use Go build tags (e.g., `//go:build darwin`) to ensure they are only compiled for the target platform.
-5. **Platform Roles Over Brand Names**: Shared code should talk about roles like "primary modifier", "display server", and "accessibility backend" instead of assuming macOS terms such as `Cmd` or a single display stack.
-6. **Build Strategy Follows Backend Choice**: CGO requirements should be modeled per backend family, not assumed per OS. macOS currently requires CGO; Linux and Windows may mix pure-Go and CGO-backed implementations depending on subsystem/backend.
-
-### The "One Rule"
-
-> **Non-darwin-tagged code must never import `internal/core/infra/platform/darwin`.**
-
-Violation of this rule is caught by `golangci-lint` using `depguard`.
+The architecture targets low latency and cross-platform extensibility while
+integrating deeply with native APIs. macOS is the reference implementation;
+current per-platform support is tracked in
+[CROSS_PLATFORM.md](CROSS_PLATFORM.md#platform-status).
 
 ---
 
-## Platform Status
-
-> **Note:** This is a one-paragraph-per-platform orientation. The authoritative
-> per-capability comparison — including per-Linux-backend detail — lives in
-> [CROSS_PLATFORM.md](./CROSS_PLATFORM.md#feature-parity-reference). Do not
-> duplicate that matrix here.
-
-| Platform    | Status           | Runtime backends                              | Notes                                                       |
-| ----------- | ---------------- | --------------------------------------------- | ----------------------------------------------------------- |
-| **macOS**   | Production-ready | Cocoa / Quartz (CGO)                          | Reference implementation; no known functional gaps           |
-| **Linux**   | Beta             | `x11`, `wayland-wlroots`, `wayland-kde`       | All modes work; notifications/alerts are stubs              |
-| **Windows** | Alpha            | Win32 / COM (pure Go)                         | Modes work; app watcher, notifications, `monitor_select` are stubs |
-
-**GNOME Wayland (`wayland-gnome`), unrecognized compositors (`wayland-other`),
-and sessions with neither `WAYLAND_DISPLAY` nor `DISPLAY` are not supported.**
-`platform.NewSystemPort` returns `CodeNotSupported` for them during the first
-initialization phase, so the daemon exits rather than running degraded. Under
-GNOME, use an X11 session.
-
----
-
-## Platform Contribution Model
-
-This section explains how platform work fits into the architecture.
-It is intentionally high-level. For the contributor playbook, see
-[CROSS_PLATFORM.md](CROSS_PLATFORM.md).
-
-### Source Of Truth
-
-The main architecture-level source of truth for platform expectations is:
-
-- [profile.go](../internal/core/infra/platform/profile.go)
-
-It describes:
-
-- primary modifier expectations
-- display server family
-- backend family per subsystem
-- expected build mode per backend family
-
-### Layer Placement
-
-Platform work should stay in these layers:
-
-- `internal/core/infra/platform/`: broad system capabilities
-- `internal/core/infra/hotkeys/`: global hotkey registration
-- `internal/core/infra/eventtap/`: keyboard event capture
-- `internal/core/infra/accessibility/`: platform accessibility integration
-- `internal/ui/overlay/`: overlay manager orchestration — **and all Linux and
-  Windows drawing**, which happens in the manager rather than per component
-- `internal/app/components/*/overlay_*.go`: mode-specific overlay rendering on
-  **macOS only**; the Linux and Windows files in these packages are style-only stubs
-
-Shared logic should stay in:
-
-- `internal/core/domain/`
-- `internal/app/services/`
-- `internal/app/modes/`
-
-### Linux Backend Shape
-
-Linux is modeled as a backend family rather than a single implementation.
-
-At the architecture level, the expected split is:
-
-- `*_linux_common.go`: shared wrapper/fallback layer
-- `*_linux_x11.go`: X11 implementation slot
-- `*_linux_wayland.go`: Wayland/compositor implementation slot
-- `*_linux_wayland_<compositor>.go`: per-compositor sub-slot (e.g. `_wlroots`,
-  `_kde`) when one Wayland family needs a distinct path
-
-Wayland is multi-compositor, so it carries a second, runtime axis on top of the
-compile-time build tags: the `LinuxBackend` family (`linux_backend.go`) detects
-the live compositor (wlroots/KDE/GNOME/other) and the factory + dispatch seams
-route to it. Prefer organizing files by mechanism (shared across DEs) and use a
-compositor sub-slot only for genuinely DE-specific paths. See
-[CROSS_PLATFORM.md](CROSS_PLATFORM.md) for contributor file layout and
-[LINUX_DESKTOPS.md](LINUX_DESKTOPS.md) for per-DE behavior and known issues.
-
-This keeps backend choice out of shared app code and makes implementation slots
-obvious before real Linux work lands.
-
-### Fallback And Unsupported Paths
-
-Dispatch-style packages may use:
-
-- `platform_darwin.go`
-- `platform_other.go`
-
-Unimplemented behavior should remain explicit through `CodeNotSupported` and
-capability reporting rather than silent failure.
-
-### Build Strategy
-
-Build strategy follows backend choice, not just OS choice.
-
-Current high-level model:
-
-- macOS: CGO-backed native bridge
-- Linux: backend-dependent
-- Windows: prefer pure Go first
-
-The practical decisions and file-by-file guidance live in
-[CROSS_PLATFORM.md](CROSS_PLATFORM.md).
-
----
-
-## CLI Layer Cross-Platform Notes
-
-### `neru services` — service management
-
-`internal/cli/services.go` carries `//go:build darwin` because it uses `launchctl` and macOS `.plist` files. On non-darwin platforms, the `services` command is simply not registered.
-**To add Linux service management:**
-
-1. Create `internal/cli/services_linux.go` with `//go:build linux`.
-2. Implement install/uninstall/start/stop using `systemctl` (systemd) or a cross-distro approach.
-3. Register the subcommands in `init()` just like the darwin version does.
-
-### `IsRunningFromAppBundle`
-
-`internal/cli/root.go` defines `IsRunningFromAppBundle()` which delegates to a build-tagged `isRunningFromAppBundle()` helper. On macOS it detects `.app/Contents/MacOS` paths so the daemon auto-starts when double-clicked in Finder. On other platforms it always returns false.
-
-### `cmd/neru/main.go` — main thread locking
-
-On macOS, the entry point calls `runtime.LockOSThread()` before anything else — required for Cocoa's main-thread requirement. Non-macOS builds omit this. Never add `LockOSThread` to shared code.
-
-## Application Identifier Terminology
-
-The codebase uses "bundle ID" as a generic term for the platform application identifier. The mapping per platform is:
-
-| Platform | Term                        | Example                          |
-| -------- | --------------------------- | -------------------------------- |
-| macOS    | Bundle ID                   | `com.apple.Safari`               |
-| Linux    | Desktop ID / executable     | `firefox.desktop` or `firefox`   |
-| Windows  | AppUserModelID / executable | `Microsoft.Edge` or `msedge.exe` |
-
-The `FocusedAppBundleID` method in `ports.AccessibilityPort` returns whatever the platform uses. The exclusion list in config (`general.excluded_apps`) should use the same format for the target platform.
-
----
-
-## Codebase Navigation Guide
-
-To understand how Neru works, follow the path of an event from the OS to the user action.
-
-### 1. Entry Points
-
-- [main_darwin.go](../cmd/neru/main_darwin.go): Bootstraps the application, locking the main thread for Cocoa.
-- [root.go](../internal/cli/root.go): The Cobra root command for the CLI.
-
-### 2. Application Wiring
-
-- [app_initialization.go](../internal/app/app_initialization.go): Orchestrates the startup phases.
-- [app_initialization_steps.go](../internal/app/app_initialization_steps.go): Detailed steps for initializing infrastructure, services, and UI.
-
-### 3. The Platform Factory
-
-The [factory.go](../internal/core/infra/platform/factory.go) and its build-tagged siblings (e.g., [factory_darwin.go](../internal/core/infra/platform/factory_darwin.go)) are the gatekeepers for OS-specific code. They return the correct `ports.SystemPort` implementation without polluting shared code with OS-specific imports.
-
-### 4. Input Processing Flow
-
-1. **OS Level**: [eventtap_darwin.m](../internal/core/infra/platform/darwin/eventtap_darwin.m) captures low-level keyboard events.
-2. **Infrastructure Level**: [adapter.go](../internal/core/infra/eventtap/adapter.go) receives events and dispatches them to the app.
-3. **Application Level**: [handler.go](../internal/app/modes/handler.go) receives the key and routes it to the active [Mode](../internal/app/modes/base.go).
-4. **Service Level**: The mode calls into services like [hint_service.go](../internal/app/services/hint_service.go) to perform business logic.
-5. **Keyboard Layout Changes**: On macOS, the mode-level CGEventTap rebuilds its key-name lookup tables at runtime (via `NeruSetKeymapLayoutChangeCallback` in [keymap_darwin.m](../internal/core/infra/platform/darwin/keymap_darwin.m)) so mode navigation keys continue to work across layout changes. Per-hotkey CGEventTaps for global hotkeys also re-register on layout change (via `NeruSetKeymapLayoutChangeCallback2`) because `NeruKeyNameToCode` maps key names to layout-aware keycodes.
-
----
-
-## Runtime Capability Reporting
-
-Neru reports a runtime capability matrix through the platform adapters.
-This is intentionally stricter than "it compiles":
-
-- Supported features report `supported`
-- Stubbed or incomplete features report `stub`
-
-The main user-facing entry point is `neru doctor`, which surfaces platform
-gaps instead of letting unsupported behavior fail silently.
-
----
-
-## Coordinate Systems and Units
-
-Neru uses a **global top-left (0,0) coordinate system** for all shared logic.
-
-- **Origin**: (0,0) is the top-left corner of the primary display.
-- **Y-Axis**: Increases downwards.
-- **Units**: Screen pixels (unscaled).
-
-### macOS Coordinate Inversion
-
-macOS Cocoa APIs use a bottom-left (0,0) coordinate system where Y increases upwards. The [darwin platform adapter](../internal/core/infra/platform/darwin/accessibility_screen_darwin.m) is responsible for inverting the Y coordinate before passing it to shared Go code.
-
----
-
-## Error Handling and Graceful Degradation
-
-Neru uses a custom error package [derrors](../internal/core/errors/errors.go) for structured error handling.
-
-### The `CodeNotSupported` Policy
-
-When a platform-specific feature is not yet implemented, the adapter must return an error with the `CodeNotSupported` code.
-
-```go
-return derrors.New(derrors.CodeNotSupported, "feature X not yet implemented on linux")
+## Runtime Shape
+
+Neru is a **daemon plus a thin CLI**. `neru launch` starts the daemon;
+`neru hints`, `neru action left_click`, `neru config reload` and friends dial a
+Unix domain socket (`$TMPDIR/neru.sock`, mode 0600) or a Windows named pipe —
+see `internal/core/infra/ipc` and `internal/app/ipc_controller.go` /
+`ipc_handlers.go`.
+
+New user-facing behavior therefore usually needs three pieces: a CLI command
+(`internal/cli/`, registered in an `init()`), an IPC handler, and the
+service/mode work behind it.
+
+Startup is a numbered, individually-unwound phase sequence in
+[app_initialization.go](../internal/app/app_initialization.go), with the
+individual steps in
+[app_initialization_steps.go](../internal/app/app_initialization_steps.go):
+
+```
+1. infrastructure   4. UI components        7. IPC controller
+2. services         4.5 systray             8. event tap + IPC server
+3. application state 5. renderer/overlays   9. shutdown channel
+                    6. mode handler
 ```
 
-### Graceful Degradation
-
-Callers in the service layer should use the `IsNotSupported(err)` helper to handle missing features gracefully (e.g., by logging a warning instead of returning an error to the user).
-
-For features that are intentionally unavailable on a platform, prefer returning
-`CodeNotSupported` over silent no-ops unless the operation is explicitly
-documented as best-effort.
+Dependency injection is manual and explicit. Each phase that allocates
+something appends a cleanup closure; on failure the app records `failurePhase`
+and runs those closures in reverse (`slices.Backward`), so a half-built daemon
+never lingers.
 
 ---
 
-## Technology Stack
+## Design Principles
 
-- **Core Language**: [Go](https://golang.org/) (1.26+)
-- **Native Integration**: [CGo](https://pkg.go.dev/cmd/cgo) + Objective-C (macOS Bridge)
-- **CLI Framework**: [Cobra](https://github.com/spf13/cobra)
-- **Configuration**: [TOML](https://toml.io/)
-- **IPC**: Unix Domain Sockets
-- **Build System**: [Just](https://github.com/casey/just)
-- **CI/CD**: GitHub Actions + [Release Please](https://github.com/googleapis/release-please)
+Neru follows a layered **Hexagonal Architecture (Ports and Adapters)**:
+
+1. **Shared business logic** — hint generation, grid calculations, mode
+   transitions are pure Go in `internal/core/domain` and `internal/app/services`.
+2. **Platform isolation** — OS-specific code is strictly quarantined.
+3. **Ports and adapters** — every system capability (Accessibility, Hotkeys,
+   Overlays) is an interface in `internal/core/ports`, implemented by an adapter
+   in `internal/core/infra`.
+4. **Build tag separation** — OS-specific files carry build tags (`//go:build
+   darwin`) so they compile only for their target.
+5. **Platform roles over brand names** — shared code says "primary modifier",
+   "display server", "accessibility backend", never `Cmd` or a single display
+   stack.
+6. **Build strategy follows backend choice** — CGO is a per-backend-family
+   decision, not a per-OS one. macOS requires it; Linux and Windows mix pure-Go
+   and CGO-backed implementations by subsystem.
+
+Where platform code physically goes, which file slot to use, and how the Linux
+backend family is organized are contributor concerns owned by
+[CROSS_PLATFORM.md](CROSS_PLATFORM.md#contributor-guide). The architectural
+source of truth for per-subsystem backend family, primary-modifier
+expectations, and build mode is
+[profile.go](../internal/core/infra/platform/profile.go).
+
+---
+
+## The "One Rule"
+
+> **Non-darwin-tagged code must never import
+> `internal/core/infra/platform/darwin`.**
+
+Enforced twice: `depguard` in `.golangci.yml`, and
+[dependency_boundary_test.go](../internal/architecture/dependency_boundary_test.go).
+The only exemptions are `platform/darwin/**`, `*_darwin.go`, and
+`*integration_darwin_test.go`.
+
+Cross the boundary through `ports.SystemPort` or a build-tagged dispatch pair
+(`platform_darwin.go` / `platform_other.go`).
 
 ---
 
@@ -337,37 +163,74 @@ graph TD
     UI --> Platform
 ```
 
-### Layer Responsibilities
+### Layer responsibilities
 
-- **Domain (`internal/core/domain`)**: Pure business logic and entities (e.g., [hint.go](../internal/core/domain/hint/hint.go), [grid.go](../internal/core/domain/grid/grid.go)). No external dependencies.
-- **Ports (`internal/core/ports`)**: Interface contracts defining system capabilities (e.g., [accessibility.go](../internal/core/ports/accessibility.go), [overlay.go](../internal/core/ports/overlay.go), [font.go](../internal/core/ports/font.go)).
-- **Application (`internal/app`)**: Orchestrates domain entities and services. Manages application lifecycle and navigation modes (e.g., [hints.go](../internal/app/modes/hints.go)).
-- **Infrastructure (`internal/core/infra`)**: Concrete implementations of ports using platform-specific APIs (e.g., [accessibility/adapter.go](../internal/core/infra/accessibility/adapter.go)).
-- **UI (`internal/ui`)**: Handles coordinate transformations and abstract rendering logic.
-- **CLI (`internal/cli`)**: Handles user commands, configuration loading, and IPC communication with the daemon.
+- **Domain** (`internal/core/domain`) — pure business logic and entities
+  ([hint.go](../internal/core/domain/hint/hint.go),
+  [grid.go](../internal/core/domain/grid/grid.go)). No external dependencies.
+- **Ports** (`internal/core/ports`) — interface contracts defining system
+  capabilities ([accessibility.go](../internal/core/ports/accessibility.go),
+  [overlay.go](../internal/core/ports/overlay.go),
+  [font.go](../internal/core/ports/font.go)).
+- **Application** (`internal/app`) — orchestrates domain entities and services;
+  owns lifecycle and navigation modes.
+- **Infrastructure** (`internal/core/infra`) — concrete port implementations on
+  platform APIs.
+- **UI** (`internal/ui`) — coordinate transformation and abstract rendering.
+- **CLI** (`internal/cli`) — user commands, config loading, IPC to the daemon.
 
----
-
-## Platform-Specific Implementations
-
-### macOS (Primary)
-
-- **Accessibility**: Uses `AXUIElement` to query UI hierarchies and perform actions (click, focus).
-- **Event Tap**: Uses `CGEventTap` for global keyboard interception.
-- **Hotkeys**: Uses native system APIs for global hotkey registration.
-- **Overlays**: Native Cocoa windows managed via Objective-C bridge.
-
-### Linux/Windows (In Progress)
-
-- **Linux**: Planned integration with AT-SPI for accessibility and X11/Wayland for events.
-- **Windows**: Planned integration with UI Automation (UIA) and Windows Hooks.
-- Currently, most non-macOS implementations are stubs returning `derrors.CodeNotSupported`.
+A directory-by-directory map for placing new code is in
+[DEVELOPMENT.md](DEVELOPMENT.md#where-things-go).
 
 ---
 
-## Data Flow Diagrams
+## Codebase Navigation Guide
 
-### Input Event Propagation
+The fastest way to understand Neru is to follow one event from the OS to the
+user-visible action.
+
+**1. Entry points**
+
+- [main_darwin.go](../cmd/neru/main_darwin.go) — bootstraps the app, locking the
+  main thread for Cocoa
+- [root.go](../internal/cli/root.go) — the Cobra root command
+
+**2. Application wiring**
+
+- [app_initialization.go](../internal/app/app_initialization.go) — startup phases
+- [app_initialization_steps.go](../internal/app/app_initialization_steps.go) —
+  the individual infrastructure, service, and UI steps
+
+**3. The platform factory**
+
+[factory.go](../internal/core/infra/platform/factory.go) and its build-tagged
+siblings are the only place that picks a `ports.SystemPort` implementation. On
+Linux there is a second, *runtime* axis on top of build tags:
+[linux_backend.go](../internal/core/infra/platform/linux_backend.go) detects the
+live compositor (wlroots / KDE / GNOME / other) and the factory routes to it.
+
+**4. Input processing**
+
+1. **OS** — [eventtap_darwin.m](../internal/core/infra/platform/darwin/eventtap_darwin.m)
+   captures low-level keyboard events (Linux/Windows have equivalents)
+2. **Infrastructure** — [adapter.go](../internal/core/infra/eventtap/adapter.go)
+   receives and dispatches them
+3. **Application** — [handler.go](../internal/app/modes/handler.go) routes the
+   key to the active [Mode](../internal/app/modes/base.go)
+4. **Service** — the mode calls into
+   [hint_service.go](../internal/app/services/hint_service.go) and friends
+5. **Keyboard layout changes** — on macOS the mode-level CGEventTap rebuilds its
+   key-name lookup tables at runtime (`NeruSetKeymapLayoutChangeCallback` in
+   [keymap_darwin.m](../internal/core/infra/platform/darwin/keymap_darwin.m)) so
+   navigation keys survive layout switches. Per-hotkey CGEventTaps re-register
+   too (`NeruSetKeymapLayoutChangeCallback2`), because `NeruKeyNameToCode` maps
+   key names to layout-aware keycodes.
+
+---
+
+## Data Flow
+
+### Input event propagation
 
 ```mermaid
 sequenceDiagram
@@ -386,7 +249,7 @@ sequenceDiagram
     A->>OS: Native API Call
 ```
 
-### Overlay Rendering Flow
+### Overlay rendering
 
 ```mermaid
 sequenceDiagram
@@ -402,62 +265,179 @@ sequenceDiagram
     B->>C: Render Native Windows
 ```
 
----
+On macOS each component owns its own NSPanel and calls the Objective-C bridge
+directly. On Linux and Windows the overlay **manager** does all drawing into one
+shared surface, and the per-component files are style-only stubs — see
+[CROSS_PLATFORM.md](CROSS_PLATFORM.md#overlay-rendering).
 
-## API Integration Patterns
+### The CGo bridge (macOS)
 
-### CGo Bridge (macOS)
-
-Neru uses a sophisticated bridge between Go and Objective-C. Native macOS classes are wrapped in CGo, allowing Go to call into Cocoa APIs while maintaining type safety.
-
-- **Location**: `internal/core/infra/platform/darwin/`
-- **Key Files**: `bridge.go`, `overlay_darwin.m`, `accessibility_element_darwin.m`.
-
-### IPC Controller
-
-The CLI communicates with the background daemon using Unix Domain Sockets. The [ipc_controller.go](../internal/app/ipc_controller.go) manages this communication, routing commands like `neru hints` or `neru stop` to the running application instance.
+Native macOS classes are wrapped in CGo so Go can call Cocoa while keeping type
+safety. Location: `internal/core/infra/platform/darwin/`; key files `bridge.go`,
+`overlay_darwin.m`, `accessibility_element_darwin.m`.
 
 ---
 
-## Build and Deployment Processes
+## Mode Handler Locking
 
-### Build System
+`modes.Handler` has a single `mu sync.Mutex` serializing the event-tap thread
+against timer goroutines. The public entry points (`HandleKeyPress`,
+`ActivateMode`, `ExitMode`, …) take the lock and then call into modes.
 
-Neru uses `just` for build automation.
+**Consequently `Mode.Activate` / `HandleKey` / `Exit` all run with `h.mu`
+already held.** Inside them, use only the `*Locked` helpers —
+`setModeLocked`, `exitModeLocked`, `refreshGridVirtualPointerLocked`, … — never
+the public `SetMode*` / `ExitMode` methods, which would self-deadlock.
 
-- `just build`: Compiles the binary for the current platform.
-- `just release`: Optimized build with stripped symbols.
-- `just bundle`: Creates a macOS `.app` bundle.
+There is one documented lock order: **`moveMonitorMu` → `h.mu`**, never the
+reverse.
 
-### CI/CD
+The interface itself and the `baseMode` / `GenericMode` building blocks are
+documented in
+[DEVELOPMENT.md](DEVELOPMENT.md#mode-interface-contract).
 
-- **GitHub Actions**: Runs linting, unit tests, and integration tests on every PR.
-- **Release Please**: Automatically manages versioning and generates GitHub releases upon merging to `main`.
-- **Cross-Compilation**: Windows binaries cross-compile with `CGO_ENABLED=0`. Linux builds require `CGO_ENABLED=1` (X11/Wayland native backends) and must therefore run on a Linux host; macOS likewise requires CGO.
+---
+
+## Coordinate Systems and Units
+
+All shared code uses a **global top-left (0,0)** coordinate system.
+
+- **Origin** — (0,0) is the top-left corner of the primary display
+- **Y-axis** — increases downwards
+- **Units** — screen pixels, unscaled
+
+macOS Cocoa uses a bottom-left origin with Y increasing upwards. The inversion
+happens inside the darwin adapter
+([accessibility_screen_darwin.m](../internal/core/infra/platform/darwin/accessibility_screen_darwin.m))
+— flipped coordinates must never leak into shared Go. Conversions live in
+`internal/ui/coordinates`.
+
+---
+
+## Error Handling and Graceful Degradation
+
+Neru uses the custom [derrors](../internal/core/errors/errors.go) package:
+`derrors.New(code, msg)` and `derrors.Wrap(err, code, msg)`.
+
+### The `CodeNotSupported` policy
+
+Unimplemented platform behavior must return `CodeNotSupported` explicitly rather
+than silently no-oping:
+
+```go
+return derrors.New(derrors.CodeNotSupported, "feature X not yet implemented on linux")
+```
+
+Callers in the service layer degrade gracefully via `derrors.IsNotSupported(err)`
+— typically logging a warning instead of surfacing an error. Prefer
+`CodeNotSupported` over a silent no-op unless the operation is explicitly
+documented as best-effort.
+
+---
+
+## Runtime Capability Reporting
+
+Neru reports a runtime capability matrix through the platform adapters,
+deliberately stricter than "it compiles":
+
+- supported features report `supported`
+- stubbed or incomplete features report `stub`
+
+`neru doctor` is the user-facing entry point, so the matrix
+([capabilities.go](../internal/core/ports/capabilities.go),
+[capability_presets.go](../internal/core/ports/capability_presets.go)) must stay
+in sync with reality — a stub reporting `supported` is a bug.
+
+---
+
+## Platform Boundaries in the CLI Layer
+
+**`neru services`** — `internal/cli/services.go` carries `//go:build darwin`
+because it drives `launchctl` and macOS `.plist` files. On other platforms the
+command is simply never registered. Adding Linux service management means a new
+`services_linux.go` with `//go:build linux` implementing install/uninstall/
+start/stop over `systemctl`, registered in its own `init()`.
+
+**`IsRunningFromAppBundle`** — [root.go](../internal/cli/root.go) delegates to a
+build-tagged `isRunningFromAppBundle()`. On macOS it detects
+`.app/Contents/MacOS` paths so the daemon auto-starts when double-clicked in
+Finder; elsewhere it returns false.
+
+**Main-thread locking** — on macOS `cmd/neru/main.go` calls
+`runtime.LockOSThread()` before anything else, required by Cocoa. Non-macOS
+builds omit it. Never add `LockOSThread` to shared code.
+
+---
+
+## Application Identifier Terminology
+
+The codebase says "bundle ID" generically for the platform application
+identifier:
+
+| Platform | Term                        | Example                          |
+| -------- | --------------------------- | -------------------------------- |
+| macOS    | Bundle ID                   | `com.apple.Safari`               |
+| Linux    | Desktop ID / executable     | `firefox.desktop` or `firefox`   |
+| Windows  | AppUserModelID / executable | `Microsoft.Edge` or `msedge.exe` |
+
+`ports.AccessibilityPort.FocusedAppBundleID` returns whatever the platform uses,
+and `general.excluded_apps` in the config should use the same format for the
+target platform.
+
+---
+
+## Technology Stack
+
+- **Core language** — [Go](https://golang.org/) 1.26+
+- **Native integration** — [CGo](https://pkg.go.dev/cmd/cgo) + Objective-C (macOS)
+- **CLI framework** — [Cobra](https://github.com/spf13/cobra)
+- **Configuration** — [TOML](https://toml.io/)
+- **IPC** — Unix domain sockets (Windows named pipes)
+- **Build system** — [Just](https://github.com/casey/just)
+- **CI/CD** — GitHub Actions + [Release Please](https://github.com/googleapis/release-please)
+
+GitHub Actions runs lint, unit, and integration tests on every PR. Windows
+binaries cross-compile with `CGO_ENABLED=0`; Linux builds need `CGO_ENABLED=1`
+(X11/Wayland native backends) and must run on a Linux host, as macOS does for
+its own.
 
 ---
 
 ## Performance Considerations
 
-1. **Event Tap Latency**: The event tap callback is kept extremely lean to prevent system-wide keyboard lag. Heavy processing is deferred to Go routines.
-2. **Bounded accessibility walks**: Querying accessibility APIs is expensive, so tree traversal is bounded rather than exhaustive — `maxDepth` limits on the macOS walk ([client.go](../internal/core/infra/accessibility/client.go)) and depth/node caps on the Linux AT-SPI walk (`atspiMaxDepth` / `atspiMaxNodes` in [atspi_linux.go](../internal/core/infra/accessibility/atspi_linux.go)).
-3. **Caching**: A TTL/LRU cache for computed grid layouts ([grid/cache.go](../internal/core/domain/grid/cache.go)) and a cache of C string pointers for overlay styles ([style_cache.go](../internal/app/components/overlayutil/style_cache.go)) keep repeated activations off the hot path.
-4. **Native Rendering**: Overlays are rendered using native platform APIs — GPU-accelerated CoreAnimation on macOS, Cairo on Linux, GDI on Windows.
+1. **Event tap latency** — the event tap callback stays extremely lean to avoid
+   system-wide keyboard lag; heavy processing is deferred to goroutines.
+2. **Bounded accessibility walks** — querying accessibility APIs is expensive, so
+   traversal is bounded rather than exhaustive: `maxDepth` on the macOS walk
+   ([client.go](../internal/core/infra/accessibility/client.go)), and
+   `atspiMaxDepth` / `atspiMaxNodes` on the Linux AT-SPI walk
+   ([atspi_linux.go](../internal/core/infra/accessibility/atspi_linux.go)).
+3. **Caching** — a TTL/LRU cache for computed grid layouts
+   ([grid/cache.go](../internal/core/domain/grid/cache.go)) and a cache of C
+   string pointers for overlay styles
+   ([style_cache.go](../internal/app/components/overlayutil/style_cache.go))
+   keep repeated activations off the hot path.
+4. **Native rendering** — GPU-accelerated CoreAnimation on macOS, Cairo on
+   Linux, GDI on Windows.
 
 ---
 
 ## Security Architecture
 
-1. **Secure Input Detection**: Neru detects when "Secure Input" is enabled (e.g., focusing a password field) and automatically suspends the event tap to prevent unintended key logging.
-2. **Permissions**: Neru requires Accessibility permissions on macOS. It only requests the minimum set of permissions needed for UI interaction.
-3. **IPC Security**: Unix domain sockets are created with restricted file permissions, ensuring only the current user can communicate with the daemon.
+1. **Secure input detection** — Neru detects when Secure Input is enabled (e.g.
+   a focused password field) and suspends the event tap, preventing unintended
+   key logging.
+2. **Permissions** — Accessibility permission is required on macOS; Neru requests
+   only the minimum needed for UI interaction.
+3. **IPC security** — the Unix domain socket is created with restricted file
+   permissions (0600), so only the current user can talk to the daemon.
 
 ---
 
 ## References
 
-- [CROSS_PLATFORM.md](CROSS_PLATFORM.md)
-- [DEVELOPMENT.md](DEVELOPMENT.md)
-- [CODING_STANDARDS.md](CODING_STANDARDS.md)
-- [CONFIGURATION.md](CONFIGURATION.md)
+- [CROSS_PLATFORM.md](CROSS_PLATFORM.md) — per-platform support and contributor guide
+- [DEVELOPMENT.md](DEVELOPMENT.md) — build, test, debug, add code
+- [CODING_STANDARDS.md](CODING_STANDARDS.md) — formatting, logging, documentation
+- [CONFIGURATION.md](CONFIGURATION.md) — configuration reference
 - [macOS Accessibility API](https://developer.apple.com/documentation/applicationservices/ax_ui_element_ref)

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -17,9 +17,10 @@ Language-specific rules live alongside this page: [Go conventions](go/CONVENTION
 - [General Standards](#general-standards)
 - [Logging Standards](#logging-standards)
 - [Documentation Standards](#documentation-standards)
-- [Git Commit Standards](#git-commit-standards)
-- [Pre-commit Checklist](#pre-commit-checklist)
 - [References](#references)
+
+Commit conventions and the pre-commit checklist live in
+[CONTRIBUTING.md](../CONTRIBUTING.md#commit-messages).
 
 ## Quick Reference
 
@@ -39,26 +40,12 @@ All files must follow these basic formatting rules (enforced by `.editorconfig`)
 - **Trailing whitespace**: None
 - **Final newline**: Required
 
-### File Organization
-
-```
-neru/
-├── cmd/                    # Application entry points
-├── internal/               # Private application code
-│   ├── app/               # Application orchestration
-│   ├── cli/               # CLI commands
-│   ├── config/            # Configuration management
-│   ├── core/              # Core business logic and infrastructure
-│   └── ui/                # UI rendering
-├── configs/               # Configuration examples
-├── docs/                  # Documentation
-```
-
 ### Naming Conventions
 
 - **Directories**: lowercase, underscore-separated
 - **Files**: lowercase, underscore-separated
-- **Test files**: `*_test.go`, `*_integration_darwin_test.go`, `*_integration_linux_test.go`
+- **Test files**: see [TESTING_PATTERNS.md](./testing/TESTING_PATTERNS.md#test-file-naming)
+- **Platform files**: see [file layout rules](./CROSS_PLATFORM.md#file-layout-rules)
 
 ## Logging Standards
 
@@ -166,38 +153,6 @@ logger.Info("Hotkey matched", zap.Strings("actions", actions))
 // Typical hint count is 50-200 elements, so we start with 100.
 hints := make([]Hint, 0, 100)
 ```
-
-## Git Commit Standards
-
-### Commit Message Format
-
-```
-<type>: <subject>
-
-<body>
-
-<footer>
-```
-
-### Types
-
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes (formatting, etc.)
-- `refactor`: Code refactoring
-- `perf`: Performance improvements
-- `test`: Adding or updating tests
-- `chore`: Build process, dependencies, etc.
-
-## Pre-commit Checklist
-
-- [ ] Code is formatted (`just fmt`)
-- [ ] Linters pass (`just lint`)
-- [ ] Tests pass (`just test`)
-- [ ] Build succeeds (`just build`)
-- [ ] Documentation updated if needed
-- [ ] Commit message follows standards
 
 ## References
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -514,21 +514,18 @@ Worked examples:
 
 ## Build And Test Commands
 
-| Goal                                            | Command                |
-| ----------------------------------------------- | ---------------------- |
-| build for current host                          | `just build`           |
-| build macOS binary (on macOS)                   | `just build-darwin`    |
-| build Linux binary                              | `just build-linux`     |
-| build Windows binary                            | `just build-windows`   |
-| focused cross-platform-safe tests               | `just test-foundation` |
-| full unit + integration suite on current OS     | `just test`            |
-| lint                                            | `just lint`            |
-| tagged release binaries in CI                   | `just release-ci-linux <arch> <version>`, `just release-ci-windows <arch> <version>` |
+Every build and test recipe is catalogued in
+[DEVELOPMENT.md](./DEVELOPMENT.md#common-tasks). Two apply specifically to
+platform work:
 
-New to the codebase? `just build && just test-foundation` first, then find the
-slot you expect to touch before writing code. Cross-compiled binaries build from
-any host, but only the target OS can run `just test` meaningfully — integration
-tests are tagged per-OS.
+- `just build && just test-foundation` — the cross-platform-safe baseline to run
+  before touching anything. Do that first, then find the slot you expect to
+  change before writing code.
+- `just release-ci-linux <arch> <version>` / `just release-ci-windows <arch>
+  <version>` — the tagged release binaries CI produces.
+
+Cross-compiled binaries build from any host, but only the target OS can run
+`just test` meaningfully — integration tests are tagged per-OS.
 
 ## Linux Backend Model
 
@@ -693,17 +690,22 @@ Questions your tests should answer:
 
 ## Documentation Checklist
 
-Land docs in the same PR as the platform work. Check:
+Land docs in the same PR as the platform work. Each fact has exactly one home —
+update the one that owns it rather than restating it elsewhere:
 
-- [README.md](../README.md) and [ARCHITECTURE.md](./ARCHITECTURE.md)
-- [DEVELOPMENT.md](./DEVELOPMENT.md)
-- **this file** — the parity tables in Part 1
-- [LINUX_SETUP.md](./LINUX_SETUP.md) — build, deps, deploy (keep DE-agnostic)
-- [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md) — per-DE decisions and known issues
-- [CONVENTIONS.md](./go/CONVENTIONS.md)
+| What changed                                    | Update                                                        |
+| ----------------------------------------------- | ------------------------------------------------------------- |
+| A capability's status or mechanism              | **this file** — the parity tables in Part 1                   |
+| A gap closed or discovered                      | **this file** — [Known Gaps](#known-gaps)                     |
+| Desktop-specific setup, protocol support, or a DE workaround | [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md)         |
+| Host dependencies, permissions, or deployment   | [LINUX_SETUP.md](./LINUX_SETUP.md) — keep DE-agnostic         |
+| A layer boundary, port contract, or data flow   | [ARCHITECTURE.md](./ARCHITECTURE.md)                          |
+| A build recipe or test tier                     | [DEVELOPMENT.md](./DEVELOPMENT.md)                            |
+| Go style, logging, or naming                    | [CONVENTIONS.md](./go/CONVENTIONS.md)                         |
+| What the project claims to support, at a glance | [README.md](../README.md)                                     |
 
-Update them whenever the capability matrix, the backend plan, the build/CGO
-story, or a contributor-facing file naming pattern changes.
+ARCHITECTURE.md deliberately does **not** track per-platform support — it
+describes shape, not status. Do not add a capability table there.
 
 ## Contributing Safely
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -53,9 +53,30 @@ disagree, the code wins** — and the disagreement is a bug worth fixing here.
 
 ## Platform Status
 
+### What the labels mean
+
+Three words carry the whole promise, so they are worth pinning down:
+
+**Stable** — fully featured. Everything Neru does works here. This is the
+reference implementation, and a gap on this platform is a bug.
+
+**Beta** — good for daily driving. Every navigation mode works and behaves the
+same as it does on a stable platform; what is missing sits around the edges
+(notifications, alerts, a few animations) rather than in your way.
+
+**Alpha** — worth trying, not yet worth switching to. Core navigation works, but
+hint coverage is incomplete and per-app config does not re-apply on focus
+change. You will notice the difference in ordinary use.
+
+Every claim behind these labels is enumerated in the
+[Capability Matrix](#capability-matrix) and [Known Gaps](#known-gaps). If a
+label and the matrix disagree, the matrix is right.
+
+### Per-platform
+
 | Aspect               | macOS (Darwin)              | Linux                                    | Windows                        |
 | -------------------- | --------------------------- | ---------------------------------------- | ------------------------------ |
-| **Status**           | Production-ready            | Beta                                     | Alpha (initial coverage)       |
+| **Status**           | **Stable**                  | **Beta**                                 | **Alpha**                      |
 | **Build tag**        | `darwin`                    | `linux`                                  | `windows`                      |
 | **CGO**              | Required (Objective-C)      | Per-backend; most Linux backends need it | Not used (pure Go Win32 / COM) |
 | **Primary modifier** | `Cmd`                       | `Ctrl`                                   | `Ctrl`                         |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,12 +1,14 @@
 # Development Guide
 
-How to set up a development environment, build, test, and contribute to Neru.
+How to set up a development environment, build, test, and debug Neru, and where
+to put new code.
 
-For the architectural reference see [ARCHITECTURE.md](ARCHITECTURE.md); for
-platform-specific work see [CROSS_PLATFORM.md](CROSS_PLATFORM.md#contributor-guide).
-
-**Related:** [Architecture](ARCHITECTURE.md) ·
-[Coding Standards](CODING_STANDARDS.md) · [Cross-Platform Guide](CROSS_PLATFORM.md)
+This guide owns the **local workflow**. Neighbouring documents own the rest:
+contribution process and commit conventions in
+[CONTRIBUTING.md](../CONTRIBUTING.md), the architectural reference in
+[ARCHITECTURE.md](ARCHITECTURE.md), per-platform support and platform file
+layout in [CROSS_PLATFORM.md](CROSS_PLATFORM.md), and style rules in
+[CODING_STANDARDS.md](CODING_STANDARDS.md). None of those are repeated here.
 
 ---
 
@@ -14,48 +16,40 @@ platform-specific work see [CROSS_PLATFORM.md](CROSS_PLATFORM.md#contributor-gui
 
 - [Quick Start](#quick-start)
 - [Development Setup](#development-setup)
+- [Common Tasks](#common-tasks)
 - [Building](#building)
-- [Testing Tiers](#testing-tiers)
 - [Testing](#testing)
-- [Architecture Overview](#architecture-overview)
-- [Contributing](#contributing)
+- [Debugging](#debugging)
+- [Adding Code](#adding-code)
 - [Release Process](#release-process)
-- [Development Tips](#development-tips)
-- [Troubleshooting](#troubleshooting)
 - [Resources](#resources)
 
 ---
 
 ## Quick Start
 
-Get Neru running locally in 5 minutes:
-
 ```bash
-# 1. Clone and setup
 git clone https://github.com/y3owk1n/neru.git
 cd neru
 
-# 2. Set up development environment
-
-## Option A: Using Devbox (Recommended)
-devbox shell
-
-See [Development Environment Options](#development-environment-options) for install details
-
-## Option B: Manual installation
-brew install just golangci-lint
-
-See [Development Environment Options](#development-environment-options) for install details
-
-# 3. Build and run
+devbox shell            # or: brew install go just golangci-lint llvm
 just build
-./bin/neru launch
-
-# 4. Test it works
-neru hints  # Should show hint overlays
+./bin/neru launch       # runs in the foreground
 ```
 
-**Need help?** See [INSTALLATION.md](INSTALLATION.md) for detailed setup instructions.
+Then from a second terminal:
+
+```bash
+./bin/neru hints        # should show hint overlays
+```
+
+There is no `just run` recipe — build first, then launch the daemon directly.
+The CLI talks to the running daemon over a socket, so both halves come from the
+same `./bin/neru` binary.
+
+For end-user installation (Homebrew, Nix, prebuilt binaries) see
+[INSTALLATION.md](INSTALLATION.md); for preparing a Linux host see
+[LINUX_SETUP.md](LINUX_SETUP.md).
 
 ---
 
@@ -63,258 +57,112 @@ neru hints  # Should show hint overlays
 
 ### Prerequisites
 
-- **Go 1.26+** - [Install Go](https://golang.org/dl/)
-- **Xcode Command Line Tools** - `xcode-select --install`
-- **Just** - Command runner ([Install](https://github.com/casey/just))
+- **Go 1.26+** — [Install Go](https://golang.org/dl/)
+- **Xcode Command Line Tools** (macOS) — `xcode-select --install`
+- **Just** — command runner — [install](https://github.com/casey/just)
+- **golangci-lint** — linter — [install](https://golangci-lint.run/usage/install/)
 
-    ```bash
-    brew install just
-    ```
+### Option A: Devbox (recommended)
 
-- **golangci-lint** - Linter ([Install](https://golangci-lint.run/usage/install/))
-
-    ```bash
-    brew install golangci-lint
-    ```
-
-### Development Environment Options
-
-For the best development experience, choose one of the following setup methods:
-
-#### Option A: Devbox (Recommended)
-
-[Devbox](https://www.jetify.com/devbox) provides an isolated development environment with all required tools pre-configured.
+[Devbox](https://www.jetify.com/devbox) provides an isolated environment with
+every tool pre-configured:
 
 ```bash
-# Install Devbox
 curl -fsSL https://get.jetify.com/devbox | bash
 
-# Option 1: Enter the development shell manually
-devbox shell
-
-# Option 2: Use direnv for automatic shell activation (recommended)
-# Install direnv: brew install direnv
-# Add to your shell: eval "$(direnv hook bash)" (or zsh/fish)
-# The .envrc file will automatically activate devbox when you cd into the project
+devbox shell            # enter the shell manually
 ```
 
-Devbox automatically installs and manages:
+Or let [direnv](https://direnv.net/) activate it automatically — install direnv,
+add `eval "$(direnv hook bash)"` (or zsh/fish) to your shell, and the `.envrc`
+in the repo root takes over whenever you `cd` in.
 
-- Go 1.26+
-- gopls (Go language server)
-- gotools, gofumpt, golines (Go formatting tools)
-- golangci-lint (linter)
-- just (command runner)
-- clang-tools (C/C++ tools for CGo)
+Devbox manages Go 1.26+, gopls, gotools, gofumpt, golines, golangci-lint, just,
+and clang-tools (for CGo).
 
-#### Option B: Manual Installation
-
-Install essential tools manually using Homebrew. Note that Devbox provides additional development tools (gopls, gofumpt, golines, etc.) that can be installed separately if desired.
+### Option B: Manual installation
 
 ```bash
 brew install go just golangci-lint llvm
 ```
 
-**Tool descriptions:**
-
-- `go` - Go compiler and toolchain (1.26+ required)
-- `just` - Command runner for build scripts
-- `golangci-lint` - Go linter and formatter
-- `llvm` - LLVM tools including clang-format for C/C++/Objective-C formatting (required for CGo code)
-
-**Optional additional tools** (install via `go install` if desired):
-
-- `gopls`: `go install golang.org/x/tools/gopls@latest`
-- `gofumpt`: `go install mvdan.cc/gofumpt@latest`
-- `golines`: `go install github.com/segmentio/golines@latest`
-
-### Clone Repository
+`llvm` supplies `clang-format` for Objective-C formatting. Devbox's extra tools
+are optional and installable on their own:
 
 ```bash
-git clone https://github.com/y3owk1n/neru.git
-cd neru
+go install golang.org/x/tools/gopls@latest
+go install mvdan.cc/gofumpt@latest
+go install github.com/segmentio/golines@latest
 ```
 
-### Verify Setup
+### Verify
 
 ```bash
-# Check Go version
-go version  # Should be 1.26+
-
-# Check tools
+go version              # 1.26+
 just --version
 golangci-lint --version
-
-# List available commands
-just --list
+just --list             # all available recipes
 ```
 
-### Development Environment
+An EditorConfig plugin is worth installing — `.editorconfig` carries the tab and
+line-ending rules that CI enforces.
 
-For the best development experience, we recommend:
+---
 
-1. **IDE Setup**: Use VS Code with Go extension or GoLand
-2. **EditorConfig**: Install EditorConfig plugin for consistent formatting
+## Common Tasks
 
-### Common Development Tasks
+Every build, test, and lint entry point goes through `just`. This table is the
+single reference for them; `just --list` shows the full set including the
+Wayland protocol generation and icon recipes.
 
-| Task   | Command                 | Description                        |
-| ------ | ----------------------- | ---------------------------------- |
-| Build  | `just build`            | Compile the application            |
-| Build  | `just build-darwin`     | Build a macOS binary on macOS      |
-| Build  | `just build-linux`      | Build a Linux foundations binary   |
-| Build  | `just build-windows`    | Build a Windows binary  |
-| Bundle | `just bundle`           | Package the macOS app bundle       |
-| Install| `just install`          | Install an already-built Neru; add `-y` to auto-accept (macOS/Linux/Windows) |
-| Test   | `just test`             | Run unit and integration tests     |
-| Test   | `just test-foundation`  | Run cross-platform-safe core tests |
-| Test   | `just test-unit`        | Run unit tests                     |
-| Test   | `just test-integration` | Run integration tests              |
-| Test   | `just test-race`        | Run all tests with race detection  |
-| Test   | `just test-all`         | Run all tests (unit + integration) |
-| Test   | `just test-race-unit`   | Run unit tests with race detection |
-| Test   | `just test-race-integration` | Run integration tests with race detection |
-| Lint   | `just lint`             | Run linters                        |
-| Lint   | `just vet`              | Run `go vet`                       |
-| Format | `just fmt`              | Format Go and Objective-C code     |
-| Format | `just fmt-check`        | Check Objective-C formatting       |
-| Docs   | `just genman`           | Generate man pages                 |
-| Clean  | `just clean`            | Remove build artifacts             |
+| Task    | Command                      | Description                                     |
+| ------- | ---------------------------- | ----------------------------------------------- |
+| Build   | `just build`                 | Compile for the current platform                |
+| Build   | `just build-darwin`          | Build a macOS binary (on macOS)                 |
+| Build   | `just build-linux [ARCH]`    | Build a Linux binary (defaults to amd64)        |
+| Build   | `just build-windows [ARCH]`  | Build a Windows binary                          |
+| Build   | `just build-version v1.0.0`  | Build with an explicit version string           |
+| Build   | `just release`               | Optimized, stripped release build               |
+| Bundle  | `just bundle`                | Release build + macOS `Neru.app` (ad-hoc signed) |
+| Install | `just install [-y]`          | Install an already-built Neru; `-y` auto-accepts |
+| Test    | `just test`                  | Unit + integration                              |
+| Test    | `just test-unit`             | Unit tests only                                 |
+| Test    | `just test-integration`      | Integration tests only                          |
+| Test    | `just test-foundation`       | Fast cross-platform-safe slice                  |
+| Test    | `just test-race`             | Unit + integration with `-race`                 |
+| Test    | `just test-race-unit`        | Unit tests with `-race`                         |
+| Test    | `just test-race-integration` | Integration tests with `-race`                  |
+| Test    | `just test-all`              | `test` **and** `test-race` — the full sweep     |
+| Lint    | `just lint`                  | `golangci-lint run`                             |
+| Lint    | `just vet`                   | `go vet`                                        |
+| Format  | `just fmt`                   | Format Go and Objective-C                       |
+| Format  | `just fmt-check`             | Check Objective-C formatting                    |
+| Docs    | `just genman`                | Generate man pages                              |
+| Clean   | `just clean`                 | Remove build artifacts                          |
 
-There is no `just run` recipe — build first, then launch the daemon directly:
+Targeting a single package or test:
 
 ```bash
-just build
-./bin/neru launch
+go test ./internal/core/domain/hint/
+go test -run TestHandler_HandleKey ./internal/app/modes/
+go test -tags=integration ./internal/core/infra/accessibility/
 ```
 
-Run `just --list` for the full set, including the Wayland protocol generation
-and icon recipes.
+Watch mode, if you have [entr](https://eradman.com/entrproject/):
 
-### Debugging
-
-To debug Neru during development:
-
-1. **Enable Debug Logging**:
-
-    ```toml
-    [logging]
-    log_level = "debug"
-    ```
-
-2. **View Logs**:
-
-    ```bash
-    # macOS
-    tail -f ~/Library/Logs/neru/app.log
-
-    # Linux
-    tail -f ~/.local/state/neru/log/app.log
-    ```
-
-3. **Use Delve Debugger**:
-
-    ```bash
-    dlv debug ./cmd/neru
-    ```
+```bash
+find . -name "*.go" | entr -r just test
+```
 
 ---
 
 ## Building
 
-Neru uses [Just](https://github.com/casey/just) as a command runner (alternative to Make).
-
-### Quick Start
+### Without Just
 
 ```bash
-# Development build
-just build
-
-# Run
-./bin/neru launch
-```
-
-### Build Commands
-
-```bash
-# Development build (auto-detects version from git tags)
-just build
-
-# Build target-specific contributor binaries
-just build-darwin
-just build-linux
-just build-windows
-
-# Release build (optimized, stripped)
-just release
-
-# Build app bundle (macOS .app)
-just bundle
-
-# Build with custom version
-just build-version v1.0.0
-
-# Clean build artifacts
-just clean
-```
-
-### Cross-Platform Contributor Baseline
-
-If you are starting Linux or Windows work, this is the recommended minimum
-smoke-test sequence:
-
-```bash
-just build
-just test-foundation
-```
-
-Then, depending on what you are targeting:
-
-- Linux: `just build-linux`
-- Windows: `just build-windows`
-- macOS: `just build-darwin`
-
-## Testing Tiers
-
-Neru uses a few different testing layers:
-
-1. Pure unit tests:
-   Shared Go logic with no native OS dependency.
-2. Contract tests:
-   Ports and adapters should agree on error semantics such as `CodeNotSupported`.
-3. Integration tests:
-   Real OS/native behavior behind `integration` build tags.
-4. Architecture tests:
-   Guardrails that protect package boundaries and platform isolation.
-
-When you add a stubbed platform feature, add or update a contract test so the
-unsupported behavior is explicit and stable until the real implementation lands.
-
-For cross-platform work, prefer shared terms over macOS-specific names:
-
-- `Primary` means the default accelerator modifier: `Cmd` on macOS, `Ctrl` on Linux/Windows.
-- Linux is not a single backend. Treat X11 and Wayland as separate infra concerns behind the same port.
-- Start backend decisions from `internal/core/infra/platform/profile.go` so contributors extend one source of truth.
-- Do not assume CGO based on OS alone. Check the backend plan first: some Linux and most early Windows integrations can stay pure Go, while macOS and some future Linux backends require CGO.
-
-For practical file-by-file contributor guidance, see [CROSS_PLATFORM.md](CROSS_PLATFORM.md).
-
-### Manual Build
-
-Without Just:
-
-```bash
-# Basic build
-go build -o bin/neru ./cmd/neru
-
-# With version info
 VERSION=$(git describe --tags --always --dirty)
-go build \
-  -ldflags="-s -w -X github.com/y3owk1n/neru/internal/cli.Version=$VERSION" \
-  -o bin/neru \
-  ./cmd/neru
 
-# For release (optimized)
 go build \
   -ldflags="-s -w -X github.com/y3owk1n/neru/internal/cli.Version=$VERSION" \
   -trimpath \
@@ -322,122 +170,173 @@ go build \
   ./cmd/neru
 ```
 
-### Build Flags Explained
+- `-ldflags="-s -w"` — strip debug info and symbol table (smaller binary)
+- `-trimpath` — remove filesystem paths from the binary
+- `-X pkg.Var=value` — inject the version at build time
 
-- `-ldflags="-s -w"` - Strip debug info and symbol table (smaller binary)
-- `-trimpath` - Remove file system paths from binary
-- `-X pkg.Var=value` - Set string variable at build time (version injection)
+### Cross-platform baseline
+
+Starting Linux or Windows work? The minimum smoke test is:
+
+```bash
+just build
+just test-foundation
+```
+
+then `just build-linux` / `just build-windows` / `just build-darwin` for your
+target. Cross-compiled binaries build from any host, but only the target OS can
+run `just test` meaningfully — integration tests are tagged per-OS, and
+cross-compiling to Linux from macOS is not supported (CGO plus Linux headers).
+
+Backend, CGO, and modifier expectations are **not** per-OS constants; start from
+[profile.go](../internal/core/infra/platform/profile.go) and
+[CROSS_PLATFORM.md](CROSS_PLATFORM.md#cgo-guidance).
 
 ---
 
 ## Testing
 
-Neru has a comprehensive test suite with clear separation between unit tests and integration tests. For detailed testing guidelines and standards, see [TESTING_PATTERNS.md](testing/TESTING_PATTERNS.md).
+Neru has four testing layers:
 
-### Test Organization
+1. **Unit tests** — shared Go logic with no native OS dependency, using mocks
+   from `internal/core/ports/mocks`.
+2. **Contract tests** — ports and adapters agreeing on error semantics such as
+   `CodeNotSupported`.
+3. **Integration tests** — real OS/native behavior behind the `integration`
+   build tag.
+4. **Architecture tests** — guardrails protecting package boundaries and
+   platform isolation (`internal/architecture/`).
 
-| Test Type             | File Pattern              | Purpose                                                            | Command                 | Coverage                                           |
-| --------------------- | ------------------------- | ------------------------------------------------------------------ | ----------------------- | -------------------------------------------------- |
-| **Unit Tests**        | `*_test.go`               | Business logic with mocks (no build tag required)                  | `just test`             | 50+ tests covering algorithms, isolated components |
-| **Integration Tests** | `*_integration_*_test.go` | Real system interactions (tagged `//go:build integration && <os>`) | `just test-integration` | Tests covering platform APIs, IPC, file operations |
+When you add a stubbed platform feature, add or update a contract test so the
+unsupported behavior is explicit and stable until the real implementation lands.
 
-### Test File Naming Convention
+### Organization
 
-```text
-package_test.go                          # Unit tests (logic, mocks)
-package_integration_darwin_test.go       # macOS integration tests //go:build integration && darwin
-package_integration_linux_test.go        # Linux integration tests  //go:build integration && linux
-package_integration_windows_test.go      # Windows integration tests //go:build integration && windows
-```
+| Type            | File pattern                 | Build tag             | Command                 |
+| --------------- | ---------------------------- | --------------------- | ----------------------- |
+| **Unit**        | `*_test.go`                  | —                     | `just test-unit`        |
+| **Integration** | `*_integration_<os>_test.go` | `integration && <os>` | `just test-integration` |
 
-### Run Tests
+Tests are table-driven and named `TestType_Method_EdgeCase`. Detailed patterns
+live in [TESTING_PATTERNS.md](testing/TESTING_PATTERNS.md).
 
-```bash
-# Unit tests only (fast, CI)
-just test
+### What each layer covers
 
-# Integration tests only (comprehensive, local)
-just test-integration
+**Unit** — hint generation, grid calculations, element filtering, action
+processing, mode transitions, config parsing/validation/defaults, CLI argument
+handling, and pure-logic benchmarks. These run everywhere.
 
-# All tests (unit + integration)
-just test-all
-
-# With race detection
-just test-race
-```
-
-### Test Coverage Areas
-
-#### Unit Test Coverage
-
-- **Domain Logic**: Hint generation, grid calculations, element filtering
-- **Service Logic**: Action processing, mode transitions, configuration validation
-- **Adapter Interfaces**: Port implementations with mocked dependencies
-- **Configuration**: TOML parsing, validation, defaults
-- **CLI Logic**: Command parsing, argument validation
-- **Pure Logic Benchmarks**: Performance testing of algorithms without system calls
-
-#### Integration Test Coverage
-
-- **macOS Accessibility API**: Real UI element access, cursor control, mouse actions
-- **macOS Event Tap API**: Real global keyboard event interception
-- **macOS Hotkey API**: Real global hotkey registration/unregistration
-- **Unix Socket IPC**: Real inter-process communication
-- **macOS Overlay API**: Real window/overlay management
-- **File System Operations**: Real config file loading/reloading
-- **Component Coordination**: Real service-to-adapter interactions
-
-### Run Linter
-
-```bash
-# Run all linters
-just lint
-
-# Auto-fix issues
-golangci-lint run --fix
-```
-
-### Test During Development
-
-```bash
-# Watch mode (requires entr or similar)
-find . -name "*.go" | entr -r just test
-
-# Quick iteration with unit tests
-just build && just test
-
-# Full validation before commit
-just test && just lint && just build
-
-# Test specific package
-go test ./internal/core/domain/hint/
-
-# Test with verbose output
-go test -v ./internal/app/services/
-
-# Integration test specific component
-go test -tags=integration ./internal/core/infra/accessibility/
-```
+**Integration** — today these are **macOS only**: real Accessibility and event
+tap APIs, global hotkey registration, overlay and window management, Unix socket
+IPC, config file loading and reloading, and service-to-adapter coordination.
+`*_integration_linux_test.go` and `*_integration_windows_test.go` are the
+reserved slots — no such tests exist yet, so Linux and Windows behavior is
+currently pinned by unit and contract tests alone. Adding real ones is one of
+the more valuable contributions available.
 
 ---
 
-## Architecture Overview
+## Debugging
 
-This section covers only what you need in order to *add code*. The
-architectural reference — layers, component diagrams, data flow, coordinate
-systems, the "One Rule", and platform status — lives in
-[ARCHITECTURE.md](ARCHITECTURE.md), and per-platform feature support lives in
-[CROSS_PLATFORM.md](CROSS_PLATFORM.md#feature-parity-reference). Neither is
-repeated here.
+Enable debug logging in `~/.config/neru/config.toml`:
 
-### Mode Interface Contract
+```toml
+[logging]
+log_level = "debug"
+```
 
-Neru uses a standardized `Mode` interface to ensure consistent behavior across all navigation modes. This interface defines the contract that all mode implementations must follow.
+Then follow the log:
 
-#### Interface Definition
+```bash
+tail -f ~/Library/Logs/neru/app.log       # macOS
+tail -f ~/.local/state/neru/log/app.log   # Linux
+```
 
-The live interface is defined in
-[internal/app/modes/handler.go](../internal/app/modes/handler.go):
+For a step debugger:
+
+```bash
+dlv debug ./cmd/neru
+```
+
+What belongs at which log level — and what must never be logged — is in
+[CODING_STANDARDS.md](CODING_STANDARDS.md#logging-standards).
+
+---
+
+## Adding Code
+
+### Where things go
+
+| Directory                  | Role                                               |
+| -------------------------- | -------------------------------------------------- |
+| `internal/core/domain/`    | Pure business logic, entities, value objects       |
+| `internal/core/ports/`     | Interface contracts (Accessibility, Overlay, Font) |
+| `internal/core/infra/`     | Platform-specific adapter implementations          |
+| `internal/app/`            | Application orchestration, services, modes         |
+| `internal/app/components/` | Mode-specific overlay rendering                    |
+| `internal/app/modes/`      | Navigation mode implementations                    |
+| `internal/ui/`             | Coordinate conversion, abstract rendering          |
+| `internal/cli/`            | Cobra CLI commands, IPC dispatch                   |
+| `internal/config/`         | TOML parsing, validation, defaults                 |
+
+Layer responsibilities and the boundaries between them are in
+[ARCHITECTURE.md](ARCHITECTURE.md#component-architecture); platform file-slot
+naming is in [CROSS_PLATFORM.md](CROSS_PLATFORM.md#file-layout-rules).
+
+**Configuration options**
+
+1. Add fields to the structs in `internal/config/config.go`
+2. Shared defaults in `newDefaultConfig()` (`config_defaults.go`); platform
+   overrides in `applyPlatformDefaults()` (`config_<os>.go`)
+3. Validation in the `Validate*()` methods
+4. Update `configs/` examples and [CONFIGURATION.md](CONFIGURATION.md)
+
+**Actions**
+
+1. Define the action in `internal/core/domain/action/action.go`
+2. Implement logic in `internal/app/services/action_service.go`
+3. Wire pending-action dispatch in `internal/app/modes/mode_handlers.go` (the
+   per-mode files set it via `Context.SetPendingAction`)
+4. Update config and documentation
+
+**UI components**
+
+1. Create the component in `internal/app/components/`
+2. Implement rendering in `internal/ui/`
+3. macOS Objective-C goes in `internal/core/infra/platform/darwin/` behind
+   `//go:build darwin`, with a no-op stub elsewhere
+4. Register in `internal/app/component_factory.go` or
+   `internal/app/app_initialization.go`
+
+**CLI commands**
+
+1. Create the command file in `internal/cli/`
+2. Register it in an `init()` (see `internal/cli/root.go`)
+3. Add the matching IPC handler in `internal/app/ipc_handlers.go`
+4. Document in [CLI.md](CLI.md)
+
+### Dependency injection
+
+Wiring is manual and explicit — constructors take their dependencies, and
+`internal/app/app_initialization.go` assembles everything in numbered phases
+that unwind in reverse on failure.
+
+`app.New` takes functional options ([app_options.go](../internal/app/app_options.go)),
+which is how tests substitute doubles for the ports they need — `WithSystemPort`,
+`WithEventTap`, `WithIPCServer`, `WithOverlayManager`, `WithHotkeyService`,
+`WithWatcher`, plus `WithConfig` / `WithConfigPath` / `WithLogger`. An option
+that is not supplied falls back to the real adapter built during initialization.
+
+```go
+hintService := services.NewHintService(accAdapter, overlayAdapter, systemPort, hintGen, cfg.Hints, logger, visionPort)
+gridService := services.NewGridService(overlayAdapter, systemPort, logger)
+actionService := services.NewActionService(accAdapter, overlayAdapter, systemPort, logger)
+```
+
+### Mode interface contract
+
+Every navigation mode implements `Mode`, defined in
+[handler.go](../internal/app/modes/handler.go):
 
 ```go
 type Mode interface {
@@ -459,65 +358,42 @@ type Mode interface {
 every per-activation override — `Action`, `Modifier`, `OnExit`, `Repeat`,
 `CursorFollowSelection`, `ZoomToDepth`, `FilterRoles`, `FilterTextContains`,
 `Search`, `HideOnEmptySearch`, `Strategy`, `LabelDirection`, `Toggle`,
-`SplitWord`. Adding a new CLI flag that varies a mode's activation usually means
-adding a field here rather than a new interface method.
+`SplitWord`. A new CLI flag that varies a mode's activation usually means a new
+field here rather than a new interface method.
 
 > **Locking contract.** `Activate`, `HandleKey`, and `Exit` are all called with
 > the handler's `h.mu` **already held** by the public entry point
-> (`ActivateMode`, `HandleKeyPress`, `ExitMode`). Inside a mode, use only the
+> (`ActivateMode`, `HandleKeyPress`, `ExitMode`). Inside a mode use only the
 > `*Locked` helpers (`setModeLocked`, `exitModeLocked`, …) — calling a public
-> `SetMode*` / `ExitMode` method self-deadlocks. See
-> [ARCHITECTURE.md](ARCHITECTURE.md) for the full lock ordering.
+> `SetMode*` / `ExitMode` method self-deadlocks. Full lock ordering is in
+> [ARCHITECTURE.md](ARCHITECTURE.md#mode-handler-locking).
 
-#### Method Contracts
+**Method contracts**
 
-##### `Activate(opts ModeActivationOptions)`
+- `Activate(opts)` — call `handler.setModeLocked()` to change app state, show
+  mode-specific overlays, initialize state from `opts`. Log activation at
+  `info`; keep routing and redraw detail at `debug`.
+- `HandleKey(key)` — route a single key string (`"a"`, `"j"`, `"escape"`) to the
+  right handler and update mode state.
+- `Exit()` — hide overlays, reset mode-specific state. Common cleanup is already
+  handled by `exitModeLocked`.
+- `ModeType()` — return the `domain.Mode` enum value (e.g. `domain.ModeHints`).
 
-- **Purpose**: Initialize the mode and set it as the active mode
-- **Responsibilities**:
-    - Call `handler.setModeLocked()` to change app state (caller holds `h.mu`)
-    - Show mode-specific overlays/UI
-    - Initialize mode-specific state from `opts`
-    - Log mode activation at `info`; keep routing and redraw details at `debug`
+**Implementation pattern**
 
-##### `HandleKey(key string)`
-
-- **Purpose**: Process keyboard input while the mode is active
-- **Parameters**: Single key string (e.g., "a", "j", "escape")
-- **Responsibilities**:
-    - Route keys to appropriate handlers
-    - Update mode state based on input
-    - Handle mode-specific navigation logic
-
-##### `Exit()`
-
-- **Purpose**: Clean up mode state and return to idle
-- **Responsibilities**:
-    - Hide overlays and UI elements
-    - Reset mode-specific state
-    - Perform mode-specific cleanup only (common cleanup is handled by `exitModeLocked`)
-
-##### `ModeType()`
-
-- **Purpose**: Return the domain mode identifier
-- **Returns**: `domain.Mode` enum value (e.g., `domain.ModeHints`)
-
-#### Implementation Pattern
-
-Modes are **not** written as bare structs implementing four methods by hand.
-Two shared building blocks cover almost every case:
+Modes are not written as bare structs implementing four methods by hand. Two
+shared building blocks cover almost every case:
 
 - **`baseMode`** ([base.go](../internal/app/modes/base.go)) — holds the handler
-  and mode type, and supplies default no-op implementations of `Activate`,
-  `HandleKey`, and `Exit` plus a real `ModeType`. Embed it and override only
-  what differs.
+  and mode type, supplies no-op `Activate` / `HandleKey` / `Exit` plus a real
+  `ModeType`. Embed it and override only what differs.
 - **`GenericMode`** ([generic_mode.go](../internal/app/modes/generic_mode.go)) —
-  embeds `baseMode` and takes a `ModeBehavior` struct of optional
-  `ActivateFunc` / `HandleKeyFunc` / `ExitFunc` callbacks. When a callback is
-  nil it falls back to the handler's standard flow for that mode type.
+  embeds `baseMode` and takes a `ModeBehavior` of optional `ActivateFunc` /
+  `HandleKeyFunc` / `ExitFunc` callbacks. A nil callback falls back to the
+  handler's standard flow for that mode type.
 
-The result is that a mode is usually just a constructor supplying behavior.
-`ScrollMode` in full:
+So a mode is usually just a constructor supplying behavior. `ScrollMode` in
+full:
 
 ```go
 type ScrollMode struct {
@@ -548,305 +424,51 @@ func NewScrollMode(handler *Handler) *ScrollMode {
 Reach for a hand-written struct embedding `baseMode` only when the mode needs
 its own fields or a `HandleKey` too involved for a callback.
 
-##### Registration Pattern
+**Adding a new mode**
 
-Modes are registered in the map built by `NewHandler`
-([handler.go](../internal/app/modes/handler.go)):
+1. Add the `Mode` constant to `internal/core/domain/domain_constants.go`
+2. Implement the `Mode` interface in `internal/app/modes/` — name it `XXXMode`
+   with a `NewXXXMode` constructor
+3. Register it in the map built by `NewHandler`:
 
-```go
-handler.modes = map[domain.Mode]Mode{
-    domain.ModeHints:         NewHintsMode(handler),
-    domain.ModeGrid:          NewGridMode(handler),
-    domain.ModeScroll:        NewScrollMode(handler),
-    domain.ModeRecursiveGrid: NewRecursiveGridMode(handler),
-    domain.ModeMonitorSelect: NewMonitorSelectMode(handler),
-    // Add new modes here
-}
-```
+    ```go
+    handler.modes = map[domain.Mode]Mode{
+        domain.ModeHints:         NewHintsMode(handler),
+        domain.ModeGrid:          NewGridMode(handler),
+        domain.ModeScroll:        NewScrollMode(handler),
+        domain.ModeRecursiveGrid: NewRecursiveGridMode(handler),
+        domain.ModeMonitorSelect: NewMonitorSelectMode(handler),
+        // Add new modes here
+    }
+    ```
 
-#### Best Practices
-
-1. **Consistent Naming**: Use `XXXMode` for struct names, `NewXXXMode` for constructors
-2. **Reuse the building blocks**: Prefer `GenericMode` + `ModeBehavior`; embed `baseMode` when you need custom fields
-3. **Respect the lock**: Only `*Locked` helpers inside `Activate` / `HandleKey` / `Exit`
-4. **Logging**: Log mode activation and real failures; keep key handling, redraws, and routine routing at `debug`
-5. **Error Handling**: Handle errors gracefully, don't panic
-6. **Resource Cleanup**: Always clean up overlays and state in `Exit()`
-
-#### Adding New Modes
-
-To add a new navigation mode:
-
-1. **Define Domain Mode**: Add to `internal/core/domain/modes.go`
-2. **Create Implementation**: Implement the Mode interface
-3. **Add CLI Command**: Create CLI command in `internal/cli/`
-4. **Update IPC**: Add handler in `internal/app/ipc_controller.go`
-5. **Register Mode**: Add to Handler's mode map
-6. **Add Tests**: Create unit and integration tests
-7. **Update Config**: Add hotkey defaults
-8. **Update Docs**: Document in [CLI.md](CLI.md) and [DEVELOPMENT.md](DEVELOPMENT.md)
-
-### Architecture Summary
-
-Neru follows a **Hexagonal Architecture (Ports and Adapters)** pattern. For the
-full architectural reference — layers, component diagrams, data flows, coordinate
-systems, and technology stack — see [ARCHITECTURE.md](ARCHITECTURE.md).
-
-The key project directories and their roles at a glance:
-
-| Directory                  | Role                                         |
-| -------------------------- | -------------------------------------------- |
-| `internal/core/domain/`    | Pure business logic, entities, value objects |
-| `internal/core/ports/`     | Interface contracts (Accessibility, Overlay, Font) |
-| `internal/core/infra/`     | Platform-specific adapter implementations    |
-| `internal/app/`            | Application orchestration, services, modes   |
-| `internal/app/components/` | Mode-specific overlay rendering              |
-| `internal/app/modes/`      | Navigation mode implementations              |
-| `internal/ui/`             | Coordinate conversion, abstract rendering    |
-| `internal/cli/`            | Cobra CLI commands, IPC dispatch             |
-| `internal/config/`         | TOML parsing, validation, defaults           |
-
-Cross-platform file-slot conventions follow the naming rules in
-[CROSS_PLATFORM.md](CROSS_PLATFORM.md).
-
-### Where to Add New Code
-
-**Configuration Options:**
-
-1. Add fields to `internal/config/config.go` structs
-2. Update `newDefaultConfig()` in `internal/config/config_defaults.go` with shared defaults; add platform overrides to `applyPlatformDefaults()` in `internal/config/config_<os>.go`
-3. Add validation in `Validate*()` methods
-4. Update `configs/` examples and [CONFIGURATION.md](CONFIGURATION.md)
-
-**Navigation Modes:**
-
-1. Define domain entities in `internal/core/domain/`
-2. Create service in `internal/app/services/`
-3. Implement infrastructure in `internal/core/infra/`
-4. Add components in `internal/app/components/`
-5. Implement the `Mode` interface in `internal/app/modes/` (see `HintsMode`, `GridMode`, `ScrollMode` for examples)
-    - See also `RecursiveGridMode` for recursive grid navigation
-6. Register mode in the Handler's mode map in `internal/app/modes/handler.go`
-
-**Actions:**
-
-1. Define action in `internal/core/domain/action/`
-2. Implement logic in `internal/app/services/action_service.go`
-3. Add handling in `internal/app/modes/actions.go`
-4. Update config and documentation
-
-**UI Components:**
-
-1. Create components in `internal/app/components/`
-2. Implement rendering in `internal/ui/`
-3. Add macOS-specific Objective-C in `internal/core/infra/platform/darwin/` with a `//go:build darwin` tag; provide a no-op stub for other platforms
-4. Register in `internal/app/component_factory.go` or `internal/app/app_initialization.go`
-
-**CLI Commands:**
-
-1. Create command file in `internal/cli/`
-2. Register in `internal/cli/root.go`
-3. Document in [CLI.md](CLI.md)
-
-### Dependency Injection and Wiring
-
-Neru uses manual dependency injection for better testability and explicit dependency management:
-
-1. **Construction**: Dependencies are explicitly passed to constructors
-2. **Wiring**: `internal/app/app_initialization.go` wires all components together
-3. **Testing**: Dependencies can be mocked by passing test doubles in `NewWithDeps`
-4. **Ports**: Interfaces define contracts between layers
-
-Example of dependency injection in action:
-
-```go
-// In internal/app/initialization.go
-hintService := services.NewHintService(accAdapter, overlayAdapter, systemPort, hintGen, cfg.Hints, logger)
-gridService := services.NewGridService(overlayAdapter, systemPort, logger)
-actionService := services.NewActionService(accAdapter, overlayAdapter, systemPort, logger)
-```
-
----
-
-## Contributing
-
-### Development Workflow
-
-1. **Fork and clone** the repository
-2. **Create a feature branch**: `git checkout -b feature/amazing-feature`
-3. **Make changes** following [CODING_STANDARDS.md](CODING_STANDARDS.md)
-4. **Add tests** for new functionality
-5. **Test thoroughly**: `just test && just lint && just build`
-6. **Commit conventionally**: `git commit -m "feat: description"`
-7. **Push and open PR** with description and screenshots
-
-### Before You Start
-
-- **Read the Architecture**: Understand layered design and code placement
-- **Check Existing Issues**: Search for similar work or start discussions
-- **Follow Standards**: See [CODING_STANDARDS.md](CODING_STANDARDS.md)
-- **Write Tests**: All new code needs appropriate test coverage
-- **Update Docs**: Keep documentation current with changes
-
-### Code Standards
-
-**All code must follow the [CODING_STANDARDS.md](CODING_STANDARDS.md) document.** See [TESTING_PATTERNS.md](testing/TESTING_PATTERNS.md) for test requirements.
-
-**Pre-commit Checklist:**
-
-- [ ] Code formatted (`just fmt`)
-- [ ] Linters pass (`just lint`)
-- [ ] Tests pass (`just test`)
-- [ ] Build succeeds (`just build`)
-- [ ] Documentation updated
-- [ ] Follows [CODING_STANDARDS.md](CODING_STANDARDS.md)
-
-**Key Requirements:**
-
-- Use `goimports` for import organization
-- Add godoc comments for exported symbols
-- Use custom error package with proper wrapping
-- Follow established naming patterns and receiver conventions
-
-### Testing Guidelines
-
-**All new code requires appropriate tests.** See [TESTING_PATTERNS.md](testing/TESTING_PATTERNS.md) for detailed guidelines.
-
-**Test Types:**
-
-- **Unit Tests**: Business logic, algorithms, validation (fast, no system deps)
-- **Integration Tests**: Real platform APIs, file system, IPC (tagged `//go:build integration && <os>`)
-
-**When to Use:**
-
-- **Unit Tests**: Business logic, config validation, component interfaces, pure algorithms
-- **Integration Tests**: Platform APIs, file operations, IPC, component coordination
-
-**Test Organization:**
-
-```
-package_test.go                        # Unit tests (logic, mocks)
-package_integration_darwin_test.go     # macOS integration tests //go:build integration && darwin
-package_integration_linux_test.go      # Linux integration tests  //go:build integration && linux
-package_integration_windows_test.go    # Windows integration tests //go:build integration && windows
-```
-
-### Documentation
-
-- **Update docs/** for significant changes
-- **Add godoc comments** for exported symbols
-- **Keep docs consistent** with code changes
-- **Include examples** where helpful
-
-### Commit Messages
-
-Use clear, descriptive commit messages following conventional commits:
-
-**Format:** `<type>(<scope>): <subject>`
-
-**Types:**
-
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes (formatting, etc.)
-- `refactor`: Code refactoring
-- `perf`: Performance improvements
-- `test`: Adding or updating tests
-- `chore`: Build process, dependencies, etc.
-
-**Good:**
-
-```
-feat: add grid-based navigation mode
-
-Implement grid-based navigation as an alternative to hint-based navigation.
-Grid mode divides the screen into cells and allows precise cursor positioning.
-
-Closes #123
-```
-
-**Bad:**
-
-```
-fix bug
-```
+4. Add the CLI command and IPC handler (see [CLI commands](#where-things-go))
+5. Add hotkey defaults to the config
+6. Add unit and integration tests
+7. Document in [CLI.md](CLI.md) and [CONFIGURATION.md](CONFIGURATION.md)
 
 ---
 
 ## Release Process
 
-Releases are being handled via [Release Please](https://github.com/googleapis/release-please) automatically.
+Releases are automated by
+[Release Please](https://github.com/googleapis/release-please). Merging the
+release PR builds and publishes the binaries on GitHub.
 
-### Version Numbering
-
-Neru uses semantic versioning: `vMAJOR.MINOR.PATCH`
-
-- **MAJOR** - Breaking changes
-- **MINOR** - New features (backward compatible)
-- **PATCH** - Bug fixes
-
-### Creating a Release
-
-Creating a release is just as easy as merging the release please PR, and it will build and publish the binaries on github.
+Versioning is semantic — `vMAJOR.MINOR.PATCH`: breaking changes, backward-
+compatible features, bug fixes. Because Release Please derives the changelog
+from commit subjects, the [conventional commit
+format](../CONTRIBUTING.md#commit-messages) is what ships to users.
 
 > [!NOTE]
-> Homebrew version bump is in a separate repo, it will be updated separately.
+> The Homebrew version bump lives in a separate repo and is updated separately.
 
 ---
-
-## Development Tips
-
-### Quick Iteration
-
-```bash
-# Build and run
-just build && ./bin/neru launch
-
-# Watch for changes (requires entr)
-ls **/*.go | entr -r sh -c 'just build && ./bin/neru launch'
-```
-
-### Debugging
-
-```bash
-# Enable debug logging in config
-[logging]
-log_level = "debug"
-
-# Watch logs (macOS)
-tail -f ~/Library/Logs/neru/app.log
-
-# Watch logs (Linux)
-tail -f ~/.local/state/neru/log/app.log
-```
-
-### Useful Commands
-
-```bash
-# Code quality
-just fmt          # Format code
-just lint         # Run linters
-just test         # Run tests
-
-# Dependencies
-go mod tidy       # Clean up modules
-go get -u ./...   # Update dependencies
-```
-
----
-
-## Troubleshooting
-
-- **Read existing code** - Well-structured codebase
-- **Check issues** - Search for similar problems
-- **Ask in discussions** - Open GitHub discussion for questions
-- **Open draft PR** - Get early feedback on approach
 
 ## Resources
 
-- **Go Documentation:** <https://golang.org/doc/>
-- **macOS Accessibility:** <https://developer.apple.com/documentation/applicationservices/ax_ui_element_ref>
-- **TOML Spec:** <https://toml.io/>
-- **Cobra CLI:** <https://github.com/spf13/cobra>
-- **Just Command Runner:** <https://github.com/casey/just>
+- [Go Documentation](https://golang.org/doc/)
+- [macOS Accessibility API](https://developer.apple.com/documentation/applicationservices/ax_ui_element_ref)
+- [TOML Spec](https://toml.io/)
+- [Cobra](https://github.com/spf13/cobra)
+- [Just](https://github.com/casey/just)

--- a/docs/LINUX_DESKTOPS.md
+++ b/docs/LINUX_DESKTOPS.md
@@ -1,7 +1,13 @@
 # Linux Desktop Environments
 
-Per-desktop-environment (DE) implementation notes for Neru on Linux: how each
-compositor is wired, important design decisions, and known issues.
+Per-desktop-environment notes for Neru on Linux: measured protocol support,
+desktop-specific setup, known issues, and how to diagnose them.
+
+This document is the **empirical, per-desktop** layer. The mechanism behind each
+capability — which protocol or API implements it, and why — is in the
+[Capability Matrix](CROSS_PLATFORM.md#capability-matrix); host preparation
+(dependencies, permissions, build, deploy) is in
+[LINUX_SETUP.md](./LINUX_SETUP.md).
 
 **Related:** [Linux setup](./LINUX_SETUP.md) ·
 [Cross-Platform Guide](./CROSS_PLATFORM.md) · [Troubleshooting](./TROUBLESHOOTING.md)
@@ -24,26 +30,23 @@ compositor is wired, important design decisions, and known issues.
 **Backend:** `wayland-kde`
 **Status:** Supported (Plasma 6 / KWin on Wayland)
 
-### Architecture decisions
+### Why KDE differs from wlroots
 
-KWin does **not** implement `zwlr_virtual_pointer_v1` (confirmed on KWin 6.6.4 via
-`wayland-info`). Neru therefore splits responsibilities:
+KWin does **not** implement `zwlr_virtual_pointer_v1`, so Neru cannot use the
+wlroots input path here. It splits the difference: overlays and screen geometry
+go through the shared wlroots client (KWin does implement layer-shell), while
+all pointer and keyboard injection goes through **libei** via
+`org.freedesktop.portal.RemoteDesktop`.
 
-| Concern                         | Mechanism                                                               | Why                                                                                |
-| ------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Overlay + screen geometry       | Shared wlroots client (`zwlr_layer_shell_v1`, `zxdg_output_manager_v1`) | KWin exposes these; same path as Sway/Hyprland                                     |
-| Pointer / click / scroll        | `libei` via `org.freedesktop.portal.RemoteDesktop`                      | Only input path KWin exposes for third-party automation                            |
-| Key feeding (`action feed`)     | `libei` via `org.freedesktop.portal.RemoteDesktop`                     | Keyboard device must be granted in portal; defaults to pointer-only               |
-| Hints (AT-SPI)                  | AT-SPI D-Bus + KWin geometry bridge                                     | AT-SPI coords are window-relative; bridge maps to global compositor space          |
-| Global hotkeys                  | Passive `evdev` read of `/dev/input/event*`, else compositor keybindings | Wayland has no global-hotkey protocol; Neru reads keyboards directly when permitted |
-| Systray                         | D-Bus StatusNotifierItem + `com.canonical.dbusmenu`                     | Matches KDE/GNOME tray hosts; no GTK dependency                                    |
+Routing lives in `system_linux_wayland_input.go` — if the compositor advertises
+`zwlr_virtual_pointer_v1` it uses the virtual pointer, otherwise libei. The two
+paths never overlap. Code slots: `system_linux_wayland_kde_*.go`,
+`accessibility/kwin_geometry_linux.go`, `accessibility/atspi_linux.go`.
 
-Routing lives in `system_linux_wayland_input.go`: if the compositor advertises
-`zwlr_virtual_pointer_v1`, use the wlroots virtual pointer; otherwise use libei.
-The two paths never overlap.
-
-Code slots: `system_linux_wayland_kde_*.go` (libei), shared wlroots client for
-overlay, `accessibility/kwin_geometry_linux.go`, `accessibility/atspi_linux.go`.
+AT-SPI reports window-relative coordinates, so a KWin script pushes
+focused-window geometry over D-Bus to translate them into global compositor
+space (see
+[window-origin offsets](CROSS_PLATFORM.md#accessibility-and-hints)).
 
 ### Protocol support (KWin 6.6.4, measured)
 
@@ -56,21 +59,22 @@ overlay, `accessibility/kwin_geometry_linux.go`, `accessibility/atspi_linux.go`.
 | `zwp_virtual_keyboard_manager_v1`     | Sticky-modifier injection | **no**     |
 | `org_kde_kwin_fake_input`             | KWin-native emulation     | **no**     |
 
-See [Checking compositor protocols](#checking-compositor-protocols) for the
-`wayland-info` one-liner.
+Re-measure with the one-liner under
+[Checking compositor protocols](#checking-compositor-protocols).
 
 ### Setup notes (beyond LINUX_SETUP.md)
 
-1. **RemoteDesktop consent** — First input in a session shows a "Remote Control"
-   portal prompt. Approve once per daemon lifetime. The prompt **reappears on
-   every fresh daemon start** (reboot, logout, relaunch): `liboeffis` does not
-   expose restore-token / `persist_mode`, so KDE cannot persist the grant across
-   launches.
+1. **RemoteDesktop consent** — the first input in a session shows a "Remote
+   Control" portal prompt. Approve it once per daemon lifetime. The prompt
+   **reappears on every fresh daemon start** (reboot, logout, relaunch):
+   `liboeffis` does not expose restore-token / `persist_mode`, so KDE cannot
+   persist the grant across launches.
 2. **Hotkeys** — Neru's own `[hotkeys]` config works on KDE Wayland when the
-   daemon can read `/dev/input` (see [Global hotkeys on Wayland](#global-hotkeys-on-wayland)).
-   If you would rather not grant that access, bind the modes in **System
-   Settings → Shortcuts → Custom Shortcuts** instead. Use the absolute path to
-   the binary so KWin resolves it reliably:
+   daemon can read `/dev/input` (see
+   [Global hotkeys on Wayland](#global-hotkeys-on-wayland)). If you would rather
+   not grant that access, bind the modes in **System Settings → Shortcuts →
+   Custom Shortcuts** instead, using the absolute path so KWin resolves it
+   reliably:
 
     | Action         | Command                                      |
     | -------------- | -------------------------------------------- |
@@ -79,25 +83,21 @@ See [Checking compositor protocols](#checking-compositor-protocols) for the
     | Recursive grid | `/home/<you>/.local/bin/neru recursive_grid` |
     | Scroll         | `/home/<you>/.local/bin/neru scroll`         |
 
-3. **Portal services** — Input needs `xdg-desktop-portal` and
+3. **Portal services** — input needs `xdg-desktop-portal` and
    `xdg-desktop-portal-kde` running in the session.
 
 ### Known issues
 
-- **Consent re-prompt every daemon launch** — See above. Planned follow-up:
+- **Consent re-prompt every daemon launch** — see above. Planned follow-up:
   drive `org.freedesktop.portal.RemoteDesktop` directly with a stored
   `restore_token` + `persist_mode` instead of relying on `liboeffis` alone.
-- **Modifier keys need a keyboard device from the portal** — If the grant
+- **Modifier keys need a keyboard device from the portal** — if the grant
   includes only a pointer device, modified clicks degrade.
 - **Key feeding needs a keyboard device from the portal** — `action feed`
-  requires keyboard capability from the RemoteDesktop portal. The portal defaults
-  to pointer-only; if keyboard is not granted, `neru action feed` returns
-  `CodeNotSupported` with a clear message.
-- **Monitor hotplug tracked live** — Plugging or unplugging a monitor is
-  detected (via `wl_output` add/remove) and the overlay follows without a
-  relaunch. A resolution or scale change to an *existing* monitor is picked up
-  on the next mode activation.
-- **Hints coverage** — Depends on each app exposing an AT-SPI tree. Grid and
+  requires keyboard capability from the RemoteDesktop portal, which defaults to
+  pointer-only. Without it, `neru action feed` returns `CodeNotSupported` with a
+  clear message.
+- **Hints coverage** — depends on each app exposing an AT-SPI tree. Grid and
   scroll work without AT-SPI.
 
 ### Troubleshooting
@@ -106,51 +106,47 @@ See [Checking compositor protocols](#checking-compositor-protocols) for the
 
 Approve the consent dialog before the connect times out. If denied, revoke and
 re-grant in System Settings (Apps & Window Management / portal permissions).
-Confirm portal services are running.
+Confirm the portal services are running.
 
 **"compositor does not support zwlr_virtual_pointer_v1" on KDE**
 
-Expected. Neru routes input through libei on KDE; this message applies to
-compositors that lack both virtual pointer and a libei path.
+Expected — Neru routes input through libei on KDE. The message only indicates a
+real problem on compositors that have neither a virtual pointer nor a libei
+path.
 
 **"key feeding unavailable on KDE: the RemoteDesktop portal session did not grant a keyboard device"**
 
-The RemoteDesktop portal defaults to pointer-only capability. To enable key
-feeding on KDE, start with a fresh portal grant:
+The portal defaults to pointer-only capability. To enable key feeding, start
+from a fresh portal grant:
 
-**Option A — Plasma 6.5+:** Open **System Settings → Applications → Remote
-Desktop**, find any saved `neru` permission, and remove it.
+- **Plasma 6.5+** — open **System Settings → Applications → Remote Desktop**,
+  find any saved `neru` permission, and remove it.
+- **Plasma 6.3+ (CLI)** — run:
 
-**Option B — Plasma 6.3+ (CLI):** Run:
-```sh
-flatpak permission-remove kde-authorized remote-desktop ""
-```
+    ```sh
+    flatpak permission-remove kde-authorized remote-desktop ""
+    ```
 
-This clears KDE's portal permission store for host applications. The command
-works on any Plasma ≥ 6.3 regardless of whether `flatpak` packages are used.
+    This clears KDE's portal permission store for host applications, and works
+    on any Plasma ≥ 6.3 whether or not you use flatpak packages.
 
-After clearing the saved permission:
-
-1. Restart the `neru` daemon.
-2. When the **"Remote Control" consent prompt** appears by
-   `xdg-desktop-portal-kde`, **check the "Enable keyboard" box** before
-   clicking "Allow".
-
-The daemon's startup log confirms success with `"Wayland input warm-up
-complete"` (keyboard available) or a warning when keyboard was not granted.
+Then restart the daemon, and when the **"Remote Control"** prompt appears from
+`xdg-desktop-portal-kde`, **check "Enable keyboard"** before clicking Allow. The
+startup log confirms with `"Wayland input warm-up complete"`, or warns when the
+keyboard was not granted.
 
 **Verifying injected input with the KWin Debug Console**
 
-KWin ships a built-in input inspector, useful for confirming that Neru's
-libei events actually reach the compositor:
+KWin ships an input inspector, useful for confirming Neru's libei events
+actually reach the compositor:
 
 ```bash
 qdbus org.kde.KWin /KWin org.kde.KWin.showDebugConsole
 ```
 
-The Input Events tab logs every pointer motion, button, and key event with
-its source device. Neru's injected events appear with an "Unknown" input
-device (libei), while real hardware shows the physical device path.
+The Input Events tab logs every pointer motion, button, and key event with its
+source device. Neru's injected events appear with an "Unknown" input device
+(libei); real hardware shows a physical device path.
 
 ---
 
@@ -159,50 +155,55 @@ device (libei), while real hardware shows the physical device path.
 **Backend:** `wayland-wlroots`
 **Status:** Supported — Sway, Hyprland, niri, River
 
-### Architecture decisions
+This is the reference Wayland path: `zwlr_layer_shell_v1` overlays with an empty
+`input_region` for click-through, `zwlr_virtual_pointer_v1` for pointer input,
+and `zwp_virtual_keyboard_v1` for sticky modifiers and `action feed`. The full
+per-capability breakdown is in the
+[Capability Matrix](CROSS_PLATFORM.md#capability-matrix).
 
-| Concern                       | Mechanism                                                                                                         |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| Overlay                       | `zwlr_layer_shell_v1` with empty `input_region` for click-through                                                 |
-| Pointer / click / scroll      | `zwlr_virtual_pointer_v1`                                                                                         |
-| Sticky modifiers              | `zwp_virtual_keyboard_v1` when available                                                                          |
-| Key feeding (`action feed`)   | `zwp_virtual_keyboard_v1` — same virtual keyboard path as sticky modifiers                                        |
-| Keyboard capture during modes | `evdev` on `/dev/input/event*` (requires `input` group)                                                           |
-| Global hotkeys                | Passive `evdev` read of Neru's own `[hotkeys]`; compositor config (`bind` / `bindsym` / `spawn-sh`) as fallback   |
-| Cursor position               | Client-side cache (Wayland hides global pointer); "agitation" via layer-shell + virtual pointer wiggle at startup |
-| Focused app                   | `zwlr_foreign_toplevel_manager_v1` app_id (no PID; `FocusedApplicationPID` best-effort matches app_id against `/proc`) |
+Two behaviors are specific enough to note here:
 
-Code slots: `system_linux_wayland_wlroots_*.go`, shared wlroots C client.
+- **Cursor position** — Wayland hides the global pointer, so Neru keeps a
+  client-side cache and "agitates" it at startup with a layer-shell surface plus
+  a virtual-pointer wiggle to establish a known position.
+- **Per-compositor window origins** — niri, Sway, and Hyprland each expose
+  focused-window geometry differently (`niri msg`, `swaymsg -t get_tree`,
+  `hyprctl -j activewindow`). On niri, **tiled** windows — including a maximized
+  column — expose no on-screen position
+  ([niri#2381](https://github.com/niri-wm/niri/issues/2381)), so hints are
+  misaligned there. Details in
+  [CROSS_PLATFORM.md](CROSS_PLATFORM.md#accessibility-and-hints).
+
+Code slots: `system_linux_wayland_wlroots_*.go` and the shared wlroots C client.
 
 ### Testing tips
 
-- **Multi-monitor cursor discovery** — Verify initial cursor position on asymmetric
-  layouts after daemon start.
-- **Modified keys** — Exercise `Shift`, `Ctrl`, and symbols like `+` / `,` under
+- **Multi-monitor cursor discovery** — verify the initial cursor position on
+  asymmetric layouts after daemon start.
+- **Modified keys** — exercise `Shift`, `Ctrl`, and symbols like `+` / `,` under
   rapid modifier taps.
-- **Click-through** — In recursive grid, synthetic click should reach the app
-  under the overlay.
-- **Scroll** — Scroll mode should feel smooth; no compositor event-queue lag.
+- **Click-through** — in recursive grid, a synthetic click should reach the app
+  beneath the overlay.
+- **Scroll** — scroll mode should feel smooth, with no compositor event-queue
+  lag.
 
 ### Known issues
 
-- **`evdev` access** — Without membership in the `input` group (or tighter
-  udev/ACL), Neru falls back to overlay-focused keyboard capture; modified
-  clicks may degrade.
-- **Monitor hotplug tracked live** — Adding or removing a monitor is detected
-  and the overlay follows; a relaunch is only needed for a resolution/scale
-  change to an existing monitor on Wayland.
+- **`evdev` access** — without membership in the `input` group (or a tighter
+  udev/ACL setup), Neru falls back to overlay-focused keyboard capture and
+  modified clicks may degrade.
 
 ---
 
 ## X11 sessions
 
 **Backend:** `x11`
-**Status:** Supported — XOrg, i3, etc.
+**Status:** Supported — XOrg, i3, and other X11 window managers
 
-Global hotkeys use `XGrabKey` from Neru's config. Input uses XTest. No compositor
-keybinding setup required. See [LINUX_SETUP.md](./LINUX_SETUP.md) for build deps
-and systemd deployment.
+The simplest configuration: global hotkeys come from Neru's own config via
+`XGrabKey`, input uses XTest, and no compositor keybinding setup is required.
+Build dependencies and systemd deployment are in
+[LINUX_SETUP.md](./LINUX_SETUP.md).
 
 ---
 
@@ -211,46 +212,56 @@ and systemd deployment.
 **Backend:** `wayland-gnome`
 **Status:** Not supported
 
-GNOME Shell uses private protocols instead of wlr layer-shell / virtual pointer.
-Future work targets libei (same family as KDE) plus a GNOME Shell extension.
-See `internal/core/infra/platform/linux/wayland_gnome/PLACEHOLDER.md`.
+**The daemon does not start in a GNOME Wayland session.**
+`platform.NewSystemPort` returns `CodeNotSupported` during the first
+initialization phase rather than running in a degraded state.
 
-The daemon does not start in a GNOME Wayland session: `platform.NewSystemPort`
-returns `CodeNotSupported` during the first initialization phase rather than
-running in a degraded state. Use a **GNOME X11 session** instead — everything
-works there through the `x11` backend.
+GNOME Shell uses private protocols instead of the wlr family: Mutter implements
+neither `wlr-layer-shell` (overlays) nor `wlr-foreign-toplevel-management`
+(focused app), and exposes no input-injection path Neru can use.
+
+**Use a GNOME X11 session instead** — everything works there through the `x11`
+backend.
+
+Future work targets libei (the same family as KDE) plus a GNOME Shell extension.
+See
+[wayland_gnome/PLACEHOLDER.md](../internal/core/infra/platform/linux/wayland_gnome/PLACEHOLDER.md).
 
 ---
 
 ## Global hotkeys on Wayland
 
-Applies to both KDE and wlroots; X11 is unaffected (it uses `XGrabKey`).
+Applies to both KDE and wlroots. X11 is unaffected — it uses `XGrabKey`.
 
-No Wayland protocol lets an ordinary client register a global hotkey. Neru
-therefore has two paths, and prefers the first:
+No Wayland protocol lets an ordinary client register a global hotkey, so Neru
+offers two paths and prefers the first:
 
-1. **Neru's own `[hotkeys]` config**, via a **passive** `evdev` listener that
-   reads `/dev/input/event*`. It never grabs devices or injects anything, so the
-   focused application still receives every key. While a mode is active the
-   in-mode event tap grabs the same devices, so the listener goes quiet until
-   the mode exits.
-2. **Compositor keybindings** — bind `neru hints`, `neru grid`, etc. in your
-   compositor config or System Settings. Always available, no permissions
-   needed, and the right choice if you prefer not to grant `/dev/input` access.
+1. **Neru's own `[hotkeys]` config**, through a passive `evdev` listener. It
+   never grabs devices or injects anything, so the focused application still
+   receives every key.
+2. **Compositor keybindings** — bind `neru hints`, `neru grid`, and friends in
+   your compositor config or System Settings. Always available, needs no
+   permissions, and the right choice if you would rather not grant `/dev/input`
+   access.
 
-Path 1 requires two things:
+Path 1 has two requirements:
 
 - **Read access to `/dev/input`** — add your user to the `input` group and
-  re-login (see [LINUX_SETUP.md](./LINUX_SETUP.md)), or grant narrower access
-  via udev/ACL.
-- **A CGO build** — evdev support is compiled out when `CGO_ENABLED=0`, leaving
-  a no-op stub. Official Linux builds enable CGO.
+  re-login (see
+  [LINUX_SETUP.md](./LINUX_SETUP.md#wayland-keyboard-capture-permissions)), or
+  grant narrower access via udev/ACL.
+- **A CGO build** — evdev support compiles out when `CGO_ENABLED=0`, leaving a
+  no-op stub. Official Linux builds enable CGO.
 
 On startup the daemon logs which path it took: `"Wayland global hotkeys enabled
 via evdev; config keybindings are active"` on success, or a warning naming both
 the `input` group and the compositor-binding fallback on failure. The hotkey
 manager health-check re-initializes the listener if it dies or ends up with zero
 devices.
+
+Why a passive listener is the only option, and how it interacts with the in-mode
+event tap, is explained in
+[CROSS_PLATFORM.md](CROSS_PLATFORM.md#keyboard-capture-and-hotkeys).
 
 ---
 
@@ -264,8 +275,9 @@ wayland-info | grep -E 'zwlr_layer_shell|zwlr_virtual_pointer|zwp_virtual_keyboa
 
 Neru's wlroots input path needs **both** `zwlr_layer_shell_v1` and
 `zwlr_virtual_pointer_v1`. If the pointer protocol is missing, the compositor
-needs a desktop-specific input path (KDE uses libei; GNOME is not yet supported).
+needs a desktop-specific input path — KDE uses libei; GNOME has none yet.
 
-When evaluating a new desktop (e.g. COSMIC): if both protocols are present, the
-shared wlroots path applies; otherwise plan a mechanism-specific backend file
-rather than duplicating per DE.
+When evaluating a new desktop (COSMIC, for instance): if both protocols are
+present the shared wlroots path applies as-is. Otherwise plan a
+mechanism-specific backend file rather than duplicating a whole per-DE stack —
+see [organize by mechanism, not by desktop](CROSS_PLATFORM.md#organize-by-mechanism-not-by-desktop).

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -218,18 +218,9 @@ go env GOARCH
 file bin/neru
 ```
 
-Run the standard checks before opening a PR:
-
-```bash
-just fmt
-just lint
-just vet
-just test
-just build
-```
-
-On Linux CI, lint uses `golangci-lint v2.12.2` — match that version when
-validating locally on Linux.
+Run the [pre-commit checks](../CONTRIBUTING.md#making-changes) before opening a
+PR. One Linux-specific note: CI lints with `golangci-lint v2.12.2`, so match
+that version when validating locally.
 
 ---
 
@@ -337,8 +328,9 @@ Running under X11 or a TTY. Neru uses the X11 backend when `DISPLAY` is set.
 
 ### "compositor does not support zwlr_virtual_pointer_v1"
 
-Common on GNOME; on KDE this is expected and input uses another path. See
-[LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md).
+Expected on KDE, where input routes through libei instead. On any other
+compositor it means there is no usable input path — see
+[Checking compositor protocols](./LINUX_DESKTOPS.md#checking-compositor-protocols).
 
 ### Overlay or hints wrong size after display change
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,10 +26,12 @@ Work that is not tied to any one platform:
 
 ## Cross-platform foundations
 
-Linux is in beta and Windows in alpha. Every remaining item is tracked as a
-numbered entry in [Known Gaps](CROSS_PLATFORM.md#known-gaps) — pick one from
-there rather than from a duplicate list here, so the status you read is the
-status the code reports.
+Linux is [beta and Windows alpha](CROSS_PLATFORM.md#what-the-labels-mean) —
+meaning Linux is good for daily driving, while Windows is worth trying but not
+yet worth switching to. Every remaining item is tracked as a numbered entry in
+[Known Gaps](CROSS_PLATFORM.md#known-gaps) — pick one from there rather than
+from a duplicate list here, so the status you read is the status the code
+reports.
 
 The two largest open areas:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,79 +1,57 @@
 # Roadmap
 
-This roadmap keeps the next improvements visible for contributors and helps
-separate "stable on macOS today" from "portable by design, still incomplete".
+What we intend to work on next, and where help is most valuable.
+
+This document holds **intent and priority only**. It deliberately does not
+restate what currently works — that lives in one place, the
+[Capability Matrix](CROSS_PLATFORM.md#capability-matrix), with the outstanding
+per-platform items enumerated under
+[Known Gaps](CROSS_PLATFORM.md#known-gaps).
 
 **Related:** [Cross-Platform Guide](CROSS_PLATFORM.md#feature-parity-reference) ·
-[Development Guide](DEVELOPMENT.md) · [Architecture](ARCHITECTURE.md)
+[Contributing](../CONTRIBUTING.md) · [Architecture](ARCHITECTURE.md)
 
 ---
 
-## Table of Contents
+## Near term
 
-- [Near Term](#near-term)
-- [Cross-Platform Foundations](#cross-platform-foundations)
-- [Contributor Priorities](#contributor-priorities)
-- [Definition Of Done For New Platform Work](#definition-of-done-for-new-platform-work)
+Work that is not tied to any one platform:
 
----
-
-## Near Term
-
-- Strengthen macOS reliability around startup, config reloads, and mode transitions.
+- Strengthen macOS reliability around startup, config reloads, and mode
+  transitions.
 - Keep reducing global state to the minimum required by native bridge callbacks.
 - Expand contract tests around ports, adapters, and reload behavior.
-- Make unsupported platform capabilities fail loudly instead of silently no-oping.
+- Make unsupported platform capabilities fail loudly instead of silently
+  no-oping.
 
-## Cross-Platform Foundations
+## Cross-platform foundations
 
-- Linux (X11):
-    - [x] native overlay rendering
-    - [x] screen and cursor management
-    - [x] keyboard event capture & global hotkeys (`XGrabKeyboard` / `XGrabKey`)
-    - [x] AT-SPI accessibility integration (shared)
-    - [x] active app detection & app watcher (event-driven)
-    - [ ] freedesktop notifications and alerts
-- Linux (Wayland wlroots):
-    - [x] native layer-shell overlay rendering
-    - [x] virtual pointer injection and cursor discovery
-    - [x] keyboard event capture
-    - [x] global hotkeys (passive evdev read of Neru's own config)
-    - [x] AT-SPI accessibility integration (shared)
-    - [x] active app detection & app watcher (`wlr-foreign-toplevel` app_id)
-    - [ ] freedesktop notifications and alerts
-- Linux (Wayland KDE Plasma):
-    - [x] input injection (libei via RemoteDesktop portal)
-    - [x] native overlay rendering (wlr-layer-shell + Cairo)
-    - [x] global hotkeys & event capture (passive evdev read)
-    - [x] app watcher / focus tracking
-    - [ ] persist the RemoteDesktop portal grant across daemon restarts
-    - [ ] freedesktop notifications and alerts
-- Linux (Wayland GNOME) — not supported; the daemon refuses to start:
-    - [ ] input injection (libei or GNOME shell extension)
-    - [ ] native overlay rendering
-    - [ ] global hotkeys & event capture
-    - [ ] focused-app source (Mutter exposes no `wlr-foreign-toplevel` equivalent)
-- Windows:
-    - [x] UI Automation integration — initial coverage (shallow tree)
-    - [x] screen and cursor management
-    - [x] global hotkeys and keyboard event capture
-    - [x] native overlay rendering — layered Win32 window + GDI
-    - [ ] app watcher (foreground-window notifications) and display hotplug events
-    - [ ] toast notifications
-    - [ ] `monitor_select` mode, grid transition animation, horizontal scroll
+Linux is in beta and Windows in alpha. Every remaining item is tracked as a
+numbered entry in [Known Gaps](CROSS_PLATFORM.md#known-gaps) — pick one from
+there rather than from a duplicate list here, so the status you read is the
+status the code reports.
 
-## Contributor Priorities
+The two largest open areas:
 
-If you want to help, the highest-leverage areas are:
+- **Linux** — freedesktop notifications and alerts across all backends, and
+  persisting the KDE RemoteDesktop portal grant across daemon restarts.
+- **Windows** — foreground-window and display-hotplug events, which currently
+  block per-app config re-application and monitor tracking.
+
+GNOME Wayland remains unsupported; the daemon refuses to start there. Reviving
+it needs libei plus a GNOME Shell extension — see
+[LINUX_DESKTOPS.md](LINUX_DESKTOPS.md#gnome-not-supported).
+
+## Contributor priorities
+
+The highest-leverage areas, roughly in order:
 
 1. Platform adapter implementations in `internal/core/infra/platform`.
 2. Overlay implementations and capability reporting.
 3. Config reload regression coverage.
 4. Reducing compatibility globals behind explicit interfaces.
 
-## Definition Of Done For New Platform Work
-
-- Return real values instead of `CodeNotSupported`.
-- Add unit tests next to the implementation.
-- Add integration tests when the feature needs a real OS session.
-- Update `ARCHITECTURE.md` and user-facing docs when support changes.
+New to the codebase?
+[Contributing safely](CROSS_PLATFORM.md#contributing-safely) lists good starter
+tasks, the changes worth opening an issue for first, and the five-point bar a
+platform change has to clear before it lands.

--- a/docs/testing/TESTING_PATTERNS.md
+++ b/docs/testing/TESTING_PATTERNS.md
@@ -1,11 +1,19 @@
 # Testing Patterns
 
+Conventions for writing tests. Which recipe runs what is in
+[DEVELOPMENT.md](../DEVELOPMENT.md#common-tasks); the test tiers and what they
+cover are in [DEVELOPMENT.md](../DEVELOPMENT.md#testing).
+
 ## Test File Naming
 
 - Unit tests: `*_test.go` (no build tag required)
 - macOS integration tests: `*_integration_darwin_test.go` (tagged `//go:build integration && darwin`)
 - Linux integration tests: `*_integration_linux_test.go` (tagged `//go:build integration && linux`)
+- Windows integration tests: `*_integration_windows_test.go` (tagged `//go:build integration && windows`)
 - Examples: `*_example_test.go`
+
+Only the macOS slot is populated today — the Linux and Windows patterns are
+reserved for the first tests that land there.
 
 ## Test Function Naming
 
@@ -14,13 +22,6 @@ func TestService_Method(t *testing.T)
 func TestService_Method_EdgeCase(t *testing.T)
 func ExampleService_Method()
 ```
-
-## Test Types
-
-| Type        | Command                 | Purpose                                                                        |
-| ----------- | ----------------------- | ------------------------------------------------------------------------------ |
-| Unit        | `just test`             | Business logic, algorithms, validation with mocks                              |
-| Integration | `just test-integration` | Real platform APIs, file system, IPC (tagged `//go:build integration && <os>`) |
 
 ## When to Use Each Type
 
@@ -128,8 +129,6 @@ func TestMain(m *testing.M) {
 `*_integration_darwin_test.go` files are exempt from the "One Rule", so they may
 import `internal/core/infra/platform/darwin` directly.
 
-### Test Command Usage
-
-- `just test`: Runs all unit tests (platform-agnostic).
-- `just test-integration`: Runs integration tests for the **current OS**.
-- `just test-all`: Runs both unit and integration tests.
+Integration tests only run meaningfully on their target OS — the build tag
+excludes them everywhere else. See
+[DEVELOPMENT.md](../DEVELOPMENT.md#common-tasks) for the recipes.

--- a/internal/core/infra/platform/windows/system.go
+++ b/internal/core/infra/platform/windows/system.go
@@ -5,7 +5,7 @@
 // Most methods currently return CodeNotSupported because Windows support is a
 // work-in-progress. Contributors should replace each stub with a real
 // implementation and remove the CodeNotSupported return when done.
-// See docs/ARCHITECTURE.md for the contribution guide.
+// See docs/CROSS_PLATFORM.md for the contributor guide.
 //
 //nolint:godox // TODO comments are intentional contributor guidance for unimplemented stubs.
 package windows

--- a/scripts/install-windows.sh
+++ b/scripts/install-windows.sh
@@ -57,7 +57,7 @@ run_ps() {
 # is macOS-only, so autostart is authored here, not by Neru. Runs under a bash
 # (e.g. Git Bash); `just` needs cygpath on PATH to translate the shebang, and
 # reg is called with MSYS2_ARG_CONV_EXCL so its /flags are not path-mangled.
-# Windows support is partial (grid, recursive grid, scroll, hotkeys, mouse
+# Windows support is alpha (grid, recursive grid, scroll, hotkeys, mouse
 # injection, UIA); see docs/CROSS_PLATFORM.md.
 arch="$(uname -m)"
 case "$arch" in
@@ -220,4 +220,6 @@ case "$run_reply" in
         echo "Skipped autostart. Start Neru with: neru launch"
         ;;
 esac
-echo "Windows support is partial; see docs/CROSS_PLATFORM.md."
+echo "Windows support is alpha: worth trying, not yet worth switching to."
+echo "Hint coverage is incomplete and per-app config does not re-apply."
+echo "See docs/CROSS_PLATFORM.md for what works today."


### PR DESCRIPTION
## Description

This PR reworks the contributor documentation so each guide covers one subject
instead of several guides half-covering the same ones. Build and test recipes
were listed in five places, commit conventions in three, and the pre-commit
checklist in three; the roadmap re-encoded the cross-platform capability matrix
as its own checkbox list.

Those copies had drifted apart. The roadmap was missing six documented gaps. The
architecture guide called Linux and Windows "planned" and "mostly stubs" twenty
lines below its own table describing Linux as beta with all modes working.
Several recipe descriptions were simply wrong. Consolidating removes about 480
lines net while resolving the contradictions rather than picking a winner
arbitrarily.

The split is now: contribution process in CONTRIBUTING, local workflow in
DEVELOPMENT, system shape in ARCHITECTURE, per-platform status in
CROSS_PLATFORM, per-desktop findings in LINUX_DESKTOPS, host setup in
LINUX_SETUP, forward intent in ROADMAP. To keep it from re-drifting, the
cross-platform guide's documentation checklist becomes an ownership table
mapping each kind of change to the file that documents it.

A second commit then settles the platform maturity labels, which had the
same problem in miniature: asserted in two places, defined in neither, and
worded differently in each.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no build tags changed
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule) — N/A, no imports changed
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no implementations changed
- [x] N/A — This PR does not touch platform-specific code

The only non-documentation change is a package comment in
`internal/core/infra/platform/windows/system.go`, which pointed contributors at
the architecture guide for the contributor guide. It now points at
`docs/CROSS_PLATFORM.md`, which is where that guidance lives.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — 71 packages, 0 failures
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality — N/A, documentation only
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Platform maturity labels

The README described platforms as "Full featured / Beta / Basic support"; the
cross-platform guide called the same three "Production-ready / Beta / Alpha".
Neither said what any of them promised, so the words carried no information.

Both now use **stable / beta / alpha**, defined once in the cross-platform guide
and linked from the README:

| Label | Promise |
| --- | --- |
| **Stable** | Fully featured. Everything Neru does works here; a gap is a bug. |
| **Beta** | Good for daily driving. Every navigation mode works; what is missing sits around the edges. |
| **Alpha** | Worth trying, not yet worth switching to. Hint coverage is incomplete and per-app config does not re-apply on focus change. |

Which platform sits in which tier does not change, and no capability claim
changes — this describes what the matrix already recorded. The alpha definition
deliberately names the two Windows gaps a user actually meets in ordinary use
(shallow UIA walk, no app watcher) rather than the ones that look worst in a
table. The Windows install script now prints the same thing, since that is the
moment someone decides whether to rely on it.

Reviewer's call: alpha reads as a demotion from "Basic support" even though
nothing about Windows changed. I think the honesty is worth it, but it is a
positioning decision rather than a factual one.

## Documentation corrections

Verifying the surviving content against the source turned up claims that were
wrong before this PR:

| Claim | Reality |
| --- | --- |
| Mock dependencies via `NewWithDeps` | No such symbol exists; the guide was its only occurrence. `app.New` takes functional options |
| Domain modes live in `internal/core/domain/modes.go` | The `Mode` constants are in `domain_constants.go` |
| Action handling goes in `internal/app/modes/actions.go` | No such file; dispatch is in `mode_handlers.go` |
| `NewHintService` sample call | Was missing its seventh argument |
| `just test-all` runs unit + integration | It runs the standard suite **and** the race suite |
| `just test` runs unit tests only | It runs unit + integration |
| Startup is an 8-phase sequence | There are 9 phases |
| Linux and Windows integration test patterns | No such tests exist; all 15 target macOS |

That last one was the most misleading, so it is now stated plainly: integration
coverage is macOS-only today, Linux and Windows behaviour rests on unit and
contract tests, and the per-OS filename patterns are reserved slots. It points
at a real gap rather than hiding it.

Two things the architecture guide previously promised but never documented are
now written down: the mode handler lock ordering (`moveMonitorMu` → `h.mu`,
never the reverse) and the daemon runtime shape with its numbered startup
phases.

## Configuration and command changes

None. No config option, command, flag, environment variable, or default is
added, renamed, removed, or changed. The only user-facing surfaces touched are
documentation files, one Go package comment, and two informational `echo` lines
in the Windows install script.

## Breaking changes

None to the software. Worth a reviewer's eye, though: several documentation
sections were removed rather than moved, so any external link or bookmark into
one of these anchors will break.

Removed anchors: `docs/ARCHITECTURE.md#platform-status`,
`#platform-contribution-model`, `#platform-specific-implementations`,
`#build-and-deployment-processes`; `docs/DEVELOPMENT.md#contributing`,
`#release-process` (kept, but its checklist content moved),
`#testing-tiers` (folded into `#testing`);
`docs/CODING_STANDARDS.md#git-commit-standards`, `#pre-commit-checklist`;
`docs/ROADMAP.md#cross-platform-foundations` (kept as a pointer),
`#definition-of-done-for-new-platform-work`.

All in-repo links were checked and updated — every internal link and anchor
across the 27 markdown files resolves. `CONTRIBUTING.md` previously linked
`docs/ARCHITECTURE.md#platform-status`, which no longer exists, and now points
at the cross-platform guide instead. The anchors most likely to be linked
externally (`#the-one-rule`, `#capability-matrix`, `#known-gaps`,
`#global-hotkeys-on-wayland`, `#gnome-not-supported`,
`#checking-compositor-protocols`) are all preserved deliberately, including the
four that runtime error messages in
`internal/core/infra/platform/linux_factory_messages.go` send users to.

## Additional Context

Two structural options I considered and did not take:

**Merging LINUX_SETUP and LINUX_DESKTOPS.** Once the duplication between them
was gone they read as two coherent documents with distinct audiences — one for
preparing a host, one for per-desktop behaviour — and merging would have meant
editing runtime strings and install scripts for no reader benefit. Easy to
revisit if you would rather have one Linux document.

**Deleting ROADMAP.** It drops from 79 lines to 58 once the duplicated matrix
goes, but its remaining content is genuinely forward-looking and not
cross-platform, so folding it into CROSS_PLATFORM would have been a worse fit
than leaving it small.

Verification beyond the standard gate: every backticked file path and Go symbol
in the rewritten documents was checked against the source, including the mode
interface, all fourteen `ModeActivationOptions` fields, the `ScrollMode`
example, the modes registration map, socket path and permissions, log paths on
all three platforms, the AT-SPI traversal caps, and the named zap loggers. A
normalised cross-file scan for repeated prose now finds one duplicated line in
the whole documentation set, in two files this PR does not touch.
