### PR TITLE
fix: report Linux capabilities from live probes and cover the whole grid

### DIFF
--- a/internal/app/components/types.go
+++ b/internal/app/components/types.go
@@ -62,9 +62,28 @@ func (g *GridComponent) UpdateConfig(cfg *config.Config, logger *zap.Logger) {
 			// Recreate grid if characters or labels changed
 			oldGrid := g.Manager.Grid()
 			if oldGrid != nil && cfg.Grid.Characters != "" {
-				charactersChanged := strings.ToUpper(cfg.Grid.Characters) != oldGrid.Characters()
-				rowLabelsChanged := strings.ToUpper(cfg.Grid.RowLabels) != oldGrid.RowLabels()
-				colLabelsChanged := strings.ToUpper(cfg.Grid.ColLabels) != oldGrid.ColLabels()
+				// Empty row/column labels in config mean "infer from
+				// characters", which is what NewGridWithLabels does when it
+				// builds the grid. Resolve them the same way before comparing:
+				// the grid stores the inferred labels, so comparing those
+				// against a bare "" would never match and every config reload
+				// would rebuild the grid — discarding in-flight grid input —
+				// even when nothing about the labels changed.
+				newCharacters := strings.ToUpper(cfg.Grid.Characters)
+
+				newRowLabels := newCharacters
+				if cfg.Grid.RowLabels != "" {
+					newRowLabels = strings.ToUpper(cfg.Grid.RowLabels)
+				}
+
+				newColLabels := newCharacters
+				if cfg.Grid.ColLabels != "" {
+					newColLabels = strings.ToUpper(cfg.Grid.ColLabels)
+				}
+
+				charactersChanged := newCharacters != oldGrid.Characters()
+				rowLabelsChanged := newRowLabels != oldGrid.RowLabels()
+				colLabelsChanged := newColLabels != oldGrid.ColLabels()
 
 				if charactersChanged || rowLabelsChanged || colLabelsChanged {
 					logger.Debug("Recreating grid due to config changes",

--- a/internal/app/components/types_test.go
+++ b/internal/app/components/types_test.go
@@ -1,0 +1,372 @@
+package components_test
+
+import (
+	"image"
+	"reflect"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/app/components"
+	"github.com/y3owk1n/neru/internal/config"
+	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
+	"github.com/y3owk1n/neru/internal/core/infra/overlay/render/grid"
+	"github.com/y3owk1n/neru/internal/core/infra/overlay/render/hints"
+)
+
+// testCharacters is the label alphabet the grid fixtures are built from.
+const testCharacters = "abcd"
+
+// lightTheme is a fixed config.ThemeProvider so built styles depend only on the
+// config values a test varies.
+type lightTheme struct{}
+
+func (lightTheme) IsDarkMode() bool { return false }
+
+// newGridComponent builds a GridComponent whose Manager holds a grid created
+// from the given labels. Overlay is deliberately nil: the overlay is a native
+// type, and the logic worth pinning here — when the grid gets recreated — lives
+// entirely on the Manager side and is guarded by its own nil check.
+func newGridComponent(
+	t *testing.T,
+	characters, rowLabels, colLabels string,
+) *components.GridComponent {
+	t.Helper()
+
+	log := zap.NewNop()
+
+	initial := domainGrid.NewGridWithLabels(
+		characters,
+		rowLabels,
+		colLabels,
+		image.Rect(0, 0, 800, 600),
+		log,
+	)
+
+	manager := domainGrid.NewManager(initial, 2, 2, characters, nil, nil, log)
+
+	return &components.GridComponent{
+		Manager: manager,
+		Theme:   lightTheme{},
+	}
+}
+
+// gridConfig returns a default config with the grid enabled and the given
+// labels applied.
+func gridConfig(characters, rowLabels, colLabels string) *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.Grid.Enabled = true
+	cfg.Grid.Characters = characters
+	cfg.Grid.RowLabels = rowLabels
+	cfg.Grid.ColLabels = colLabels
+
+	return cfg
+}
+
+// TestGridComponent_UpdateConfig_RecreatesGridOnLabelChanges pins exactly when a
+// config reload rebuilds the grid. Rebuilding drops the user's in-flight
+// coordinate input, so doing it too eagerly is as much a bug as not doing it at
+// all — in particular, the comparison is case-insensitive, because the grid
+// stores its labels upper-cased while config keeps whatever the user typed.
+func TestGridComponent_UpdateConfig_RecreatesGridOnLabelChanges(t *testing.T) {
+	tests := []struct {
+		name string
+		// initial labels the component starts with.
+		characters, rowLabels, colLabels string
+		// newCharacters etc. are what the reloaded config carries.
+		newCharacters, newRowLabels, newColLabels string
+		wantRecreate                              bool
+	}{
+		{
+			name:       "identical config keeps the existing grid",
+			characters: testCharacters, rowLabels: "", colLabels: "",
+			newCharacters: testCharacters, newRowLabels: "", newColLabels: "",
+			wantRecreate: false,
+		},
+		{
+			name:       "characters changing case only keeps the existing grid",
+			characters: testCharacters, rowLabels: "", colLabels: "",
+			newCharacters: "ABCD", newRowLabels: "", newColLabels: "",
+			wantRecreate: false,
+		},
+		{
+			name:       "different characters recreate the grid",
+			characters: testCharacters, rowLabels: "", colLabels: "",
+			newCharacters: "wxyz", newRowLabels: "", newColLabels: "",
+			wantRecreate: true,
+		},
+		{
+			name:       "different row labels recreate the grid",
+			characters: testCharacters, rowLabels: "ab", colLabels: "cd",
+			newCharacters: testCharacters, newRowLabels: "cd", newColLabels: "cd",
+			wantRecreate: true,
+		},
+		{
+			name:       "different column labels recreate the grid",
+			characters: testCharacters, rowLabels: "ab", colLabels: "cd",
+			newCharacters: testCharacters, newRowLabels: "ab", newColLabels: "ab",
+			wantRecreate: true,
+		},
+		{
+			name:       "row labels changing case only keeps the existing grid",
+			characters: testCharacters, rowLabels: "ab", colLabels: "cd",
+			newCharacters: testCharacters, newRowLabels: "AB", newColLabels: "cd",
+			wantRecreate: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			component := newGridComponent(
+				t,
+				testCase.characters,
+				testCase.rowLabels,
+				testCase.colLabels,
+			)
+
+			before := component.Manager.Grid()
+
+			component.UpdateConfig(
+				gridConfig(testCase.newCharacters, testCase.newRowLabels, testCase.newColLabels),
+				zap.NewNop(),
+			)
+
+			after := component.Manager.Grid()
+
+			if after == nil {
+				t.Fatal("Manager.Grid() is nil after UpdateConfig")
+			}
+
+			if recreated := after != before; recreated != testCase.wantRecreate {
+				t.Errorf("grid recreated = %t, want %t", recreated, testCase.wantRecreate)
+			}
+
+			// Whether or not it was rebuilt, the grid must end up describing
+			// the labels the reloaded config asked for.
+			if got, want := after.Characters(), upper(testCase.newCharacters); got != want {
+				t.Errorf("Characters() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// TestGridComponent_UpdateConfig_DefaultConfigReloadKeepsGrid is a regression
+// test for a spurious rebuild on every `neru config reload`.
+//
+// The default config leaves RowLabels and ColLabels empty, meaning "infer from
+// characters". The grid stores the *inferred* labels, so comparing them against
+// the bare "" from config never matched and the grid was rebuilt on every
+// reload — throwing away the user's in-flight coordinate input while grid mode
+// was open. The comparison now resolves empty labels the same way the grid
+// constructor does.
+func TestGridComponent_UpdateConfig_DefaultConfigReloadKeepsGrid(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.Enabled = true
+
+	component := newGridComponent(t, cfg.Grid.Characters, cfg.Grid.RowLabels, cfg.Grid.ColLabels)
+	before := component.Manager.Grid()
+
+	// Two reloads of the very same config, as a user editing an unrelated
+	// setting would produce.
+	component.UpdateConfig(cfg, zap.NewNop())
+	component.UpdateConfig(cfg, zap.NewNop())
+
+	if component.Manager.Grid() != before {
+		t.Error("reloading an unchanged default config rebuilt the grid, discarding grid input")
+	}
+}
+
+// TestGridComponent_UpdateConfig_RecreatedGridKeepsBounds checks that a rebuild
+// reuses the old grid's bounds. Falling back to a zero rectangle here would
+// place every cell off-screen after a config reload.
+func TestGridComponent_UpdateConfig_RecreatedGridKeepsBounds(t *testing.T) {
+	component := newGridComponent(t, testCharacters, "", "")
+	wantBounds := component.Manager.Grid().Bounds()
+
+	component.UpdateConfig(gridConfig("wxyz", "", ""), zap.NewNop())
+
+	if got := component.Manager.Grid().Bounds(); got != wantBounds {
+		t.Errorf("recreated grid bounds = %v, want %v", got, wantBounds)
+	}
+}
+
+// TestGridComponent_UpdateConfig_DisabledGridIsLeftAlone makes sure a disabled
+// grid is not silently rebuilt or restyled behind the user's back.
+func TestGridComponent_UpdateConfig_DisabledGridIsLeftAlone(t *testing.T) {
+	component := newGridComponent(t, testCharacters, "", "")
+	before := component.Manager.Grid()
+	beforeStyle := component.Style
+
+	cfg := gridConfig("wxyz", "", "")
+	cfg.Grid.Enabled = false
+
+	component.UpdateConfig(cfg, zap.NewNop())
+
+	if component.Manager.Grid() != before {
+		t.Error("grid was recreated even though cfg.Grid.Enabled is false")
+	}
+
+	if component.Style != beforeStyle {
+		t.Error("style was rebuilt even though cfg.Grid.Enabled is false")
+	}
+}
+
+// TestGridComponent_UpdateConfig_BuildsStyle checks the style is refreshed from
+// the new config, since that is the only path by which a theme or font change
+// reaches the grid overlay.
+func TestGridComponent_UpdateConfig_BuildsStyle(t *testing.T) {
+	component := newGridComponent(t, testCharacters, "", "")
+
+	cfg := gridConfig(testCharacters, "", "")
+	cfg.Grid.UI.FontSize = 33
+	cfg.Grid.UI.BorderWidth = 7
+
+	want := grid.BuildStyle(cfg.Grid, lightTheme{})
+
+	component.UpdateConfig(cfg, zap.NewNop())
+
+	if component.Style != want {
+		t.Error("Style was not rebuilt from the reloaded config")
+	}
+
+	// Guard against the assertion being vacuous: the style built from the
+	// reloaded config must differ from the zero value it started at.
+	if want == (grid.Style{}) {
+		t.Fatal("BuildStyle produced the zero Style; the assertion above proves nothing")
+	}
+}
+
+// TestGridComponent_UpdateConfig_NilManagerAndGrid covers the guarded paths.
+// Config reload runs on a live daemon, so a component that is not fully wired
+// yet must be skipped rather than panicking and taking the daemon down.
+func TestGridComponent_UpdateConfig_NilManagerAndGrid(t *testing.T) {
+	t.Run("nil manager", func(t *testing.T) {
+		component := &components.GridComponent{Theme: lightTheme{}}
+
+		component.UpdateConfig(gridConfig(testCharacters, "", ""), zap.NewNop())
+
+		if component.Style == (grid.Style{}) {
+			t.Error("Style was not built when Manager is nil")
+		}
+	})
+
+	t.Run("manager with nil grid", func(t *testing.T) {
+		manager := domainGrid.NewManager(nil, 2, 2, testCharacters, nil, nil, zap.NewNop())
+		component := &components.GridComponent{Manager: manager, Theme: lightTheme{}}
+
+		component.UpdateConfig(gridConfig("wxyz", "", ""), zap.NewNop())
+
+		if component.Manager.Grid() != nil {
+			t.Error("a nil grid was replaced; UpdateConfig should only recreate an existing grid")
+		}
+	})
+
+	t.Run("empty characters in config", func(t *testing.T) {
+		component := newGridComponent(t, testCharacters, "", "")
+		before := component.Manager.Grid()
+
+		cfg := gridConfig("", "", "")
+
+		component.UpdateConfig(cfg, zap.NewNop())
+
+		if component.Manager.Grid() != before {
+			t.Error("grid was recreated from an empty character set")
+		}
+	})
+}
+
+// TestHintsComponent_UpdateConfig_OnlyAppliesWhenEnabled pins the enabled gate.
+// HintsComponent.UpdateConfig also requires a non-nil overlay, so a component
+// without one must leave its style untouched even when hints are enabled.
+func TestHintsComponent_UpdateConfig_OnlyAppliesWhenEnabled(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Hints.Enabled = true
+	cfg.Hints.UI.FontSize = 29
+
+	component := &components.HintsComponent{Theme: lightTheme{}}
+	before := component.Style
+
+	component.UpdateConfig(cfg, zap.NewNop())
+
+	// Overlay is nil, so nothing should have been applied.
+	if component.Style != before {
+		t.Error("Style changed even though Overlay is nil")
+	}
+
+	if before != (hints.StyleMode{}) {
+		t.Fatal("expected the initial style to be the zero value")
+	}
+}
+
+// TestScrollComponent_UpdateConfig_IsANoOp documents that ScrollComponent
+// intentionally carries no config-derived state. If it ever gains some, this
+// test should be replaced rather than deleted.
+func TestScrollComponent_UpdateConfig_IsANoOp(t *testing.T) {
+	component := &components.ScrollComponent{}
+
+	component.UpdateConfig(config.DefaultConfig(), zap.NewNop())
+
+	if component.Context != nil {
+		t.Errorf("UpdateConfig populated Context = %v, want it left nil", component.Context)
+	}
+}
+
+// TestComponents_UpdateConfig_NilOverlayLeavesComponentUntouched covers the
+// overlay-backed components. Their overlays are native types that cannot be
+// constructed in a unit test, so what is checkable — and what actually matters
+// during a live config reload — is that a component with no overlay wired up is
+// skipped entirely: not dereferenced (which would panic and take the daemon
+// down), and not partially mutated into a state inconsistent with its overlay.
+func TestComponents_UpdateConfig_NilOverlayLeavesComponentUntouched(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.RecursiveGrid.Enabled = true
+	cfg.Hints.Enabled = true
+	cfg.Hints.UI.FontSize = 31
+	cfg.ModeIndicator.UI.FontSize = 31
+
+	log := zap.NewNop()
+
+	tests := []struct {
+		name      string
+		component interface {
+			UpdateConfig(cfg *config.Config, logger *zap.Logger)
+		}
+	}{
+		{"hints", &components.HintsComponent{Theme: lightTheme{}}},
+		{"modeIndicator", &components.ModeIndicatorComponent{}},
+		{"stickyIndicator", &components.StickyIndicatorComponent{}},
+		{"recursiveGrid", &components.RecursiveGridComponent{Theme: lightTheme{}}},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Snapshot the component before the reload. Every field is a
+			// pointer, interface or comparable style value, so a deep copy of
+			// the pointed-to struct is a faithful "before" image.
+			before := reflect.ValueOf(testCase.component).Elem().Interface()
+
+			testCase.component.UpdateConfig(cfg, log)
+
+			after := reflect.ValueOf(testCase.component).Elem().Interface()
+
+			if !reflect.DeepEqual(before, after) {
+				t.Errorf(
+					"UpdateConfig mutated a component with no overlay:\nbefore: %+v\nafter:  %+v",
+					before, after,
+				)
+			}
+		})
+	}
+}
+
+// upper mirrors the upper-casing the grid applies to its labels.
+func upper(s string) string {
+	out := []rune(s)
+	for i, r := range out {
+		if r >= 'a' && r <= 'z' {
+			out[i] = r - 32
+		}
+	}
+
+	return string(out)
+}

--- a/internal/app/config_integration_darwin_test.go
+++ b/internal/app/config_integration_darwin_test.go
@@ -59,14 +59,7 @@ func TestConfigurationLoadingIntegration(t *testing.T) {
 		application.Stop()
 
 		// Wait for Run() to return
-		select {
-		case err := <-runDone:
-			if err != nil {
-				t.Logf("App Run() returned error: %v", err)
-			}
-		case <-time.After(3 * time.Second):
-			t.Fatal("App did not stop within timeout")
-		}
+		requireCleanShutdown(t, runDone, 3*time.Second)
 	})
 
 	// Test with custom config
@@ -109,15 +102,7 @@ func TestConfigurationLoadingIntegration(t *testing.T) {
 		application.Stop()
 
 		// Wait for Run() to return
-		select {
-		case err := <-runDone:
-			if err != nil {
-				// Run() may return a context-canceled error after Stop(), which is expected
-				t.Logf("App Run() returned (expected after Stop): %v", err)
-			}
-		case <-time.After(3 * time.Second):
-			t.Fatal("App did not stop within timeout")
-		}
+		requireCleanShutdown(t, runDone, 3*time.Second)
 	})
 
 	t.Log("✅ Configuration loading integration test completed successfully")

--- a/internal/app/grid_mode_integration_darwin_test.go
+++ b/internal/app/grid_mode_integration_darwin_test.go
@@ -69,15 +69,7 @@ func TestGridModeEndToEnd(t *testing.T) {
 	application.Stop()
 
 	// Wait for Run() to return
-	select {
-	case err := <-runDone:
-		if err != nil {
-			// Run() may return a context-canceled error after Stop(), which is expected
-			t.Logf("App Run() returned (expected after Stop): %v", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("App did not stop within timeout")
-	}
+	requireCleanShutdown(t, runDone, 5*time.Second)
 
 	t.Log("✅ Grid mode E2E test completed successfully")
 }

--- a/internal/app/lifecycle_integration_darwin_test.go
+++ b/internal/app/lifecycle_integration_darwin_test.go
@@ -97,15 +97,7 @@ func TestAppLifecycleIntegration(t *testing.T) {
 	application.Stop()
 
 	// Wait for Run() to return
-	select {
-	case err := <-runDone:
-		if err != nil {
-			// Run() may return a context-canceled error after Stop(), which is expected
-			t.Logf("App Run() returned (expected after Stop): %v", err)
-		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("App did not stop within timeout")
-	}
+	requireCleanShutdown(t, runDone, 3*time.Second)
 
 	t.Log("✅ App lifecycle integration test completed successfully")
 }

--- a/internal/app/scroll_mode_integration_darwin_test.go
+++ b/internal/app/scroll_mode_integration_darwin_test.go
@@ -68,15 +68,7 @@ func TestScrollModeEndToEnd(t *testing.T) {
 	application.Stop()
 
 	// Wait for Run() to return
-	select {
-	case err := <-runDone:
-		if err != nil {
-			// Run() may return a context-canceled error after Stop(), which is expected
-			t.Logf("App Run() returned (expected after Stop): %v", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("App did not stop within timeout")
-	}
+	requireCleanShutdown(t, runDone, 5*time.Second)
 
 	t.Log("✅ Scroll mode E2E test completed successfully")
 }

--- a/internal/app/services/services_integration_darwin_test.go
+++ b/internal/app/services/services_integration_darwin_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"image"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	"github.com/y3owk1n/neru/internal/core/domain/element"
 	"github.com/y3owk1n/neru/internal/core/domain/hint"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/infra/accessibility"
 	"github.com/y3owk1n/neru/internal/core/infra/logger"
 	overlayAdapter "github.com/y3owk1n/neru/internal/core/infra/overlay"
@@ -68,56 +70,90 @@ func TestHintServiceIntegration(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("ShowHints integration", func(t *testing.T) {
-		// This tests the full pipeline: accessibility -> hint generation -> overlay
+		// This tests the full pipeline: accessibility -> hint generation -> overlay.
+		// Zero hints is a legitimate outcome (the machine may have no clickable
+		// elements on screen), but an error is not.
 		hints, err := hintService.ShowHints(ctx, nil, nil)
-
-		// Check that the service doesn't panic and returns some result
-		// In different environments, this may succeed or fail based on permissions/elements
 		if err != nil {
-			t.Logf("ShowHints failed (may be expected in some environments): %v", err)
-		} else {
-			t.Logf("ShowHints succeeded, found %d hints", len(hints))
-			// In test environment, it's normal to find 0 hints (no real UI elements)
-			// The overlay may or may not be visible depending on whether hints were found
-			if len(hints) == 0 {
-				t.Log("No hints found in test environment (expected)")
-			} else {
-				// If hints were found, overlay should be visible
-				if overlay.IsVisible() {
-					t.Logf("Overlay is visible after finding %d hints (expected)", len(hints))
-				} else {
-					t.Logf(
-						"Overlay is not visible after finding %d hints (unexpected but non-failing)",
-						len(hints),
-					)
-				}
+			t.Fatalf("ShowHints failed: %v", err)
+		}
+
+		// Whatever the pipeline produced must be individually addressable:
+		// every hint needs a non-empty, unique label and a real element, or the
+		// user cannot reach it by keyboard.
+		seen := make(map[string]int, len(hints))
+		for idx, generated := range hints {
+			if generated == nil {
+				t.Fatalf("hint %d is nil", idx)
 			}
+
+			if generated.Label() == "" {
+				t.Errorf("hint %d has an empty label", idx)
+			}
+
+			if prev, dup := seen[generated.Label()]; dup {
+				t.Errorf("hints %d and %d share label %q", prev, idx, generated.Label())
+			}
+
+			seen[generated.Label()] = idx
+
+			if generated.Element() == nil {
+				t.Errorf("hint %d (%q) has no element", idx, generated.Label())
+			}
+		}
+	})
+
+	t.Run("ShowHints leaves NoOpManager-backed overlay idle", func(t *testing.T) {
+		// initializeRealAdapters wires a NoOpManager whose Mode() is pinned to
+		// ModeIdle, and Adapter.IsVisible is defined as Mode() != idle. So the
+		// adapter must report not-visible no matter what was shown. If this
+		// starts failing, IsVisible has stopped delegating to the manager.
+		_, err := hintService.ShowHints(ctx, nil, nil)
+		if err != nil {
+			t.Fatalf("ShowHints failed: %v", err)
+		}
+
+		if overlay.IsVisible() {
+			t.Error("overlay reported visible while backed by NoOpManager")
 		}
 	})
 
 	t.Run("HideHints integration", func(t *testing.T) {
 		err := hintService.HideHints(ctx)
 		if err != nil {
-			t.Errorf("HideHints failed: %v", err)
-		} else {
-			// Verify overlay is hidden after HideHints
-			// Note: HideHints may not immediately hide if there are other overlays
-			t.Log("HideHints completed successfully")
+			t.Fatalf("HideHints failed: %v", err)
+		}
+
+		if overlay.IsVisible() {
+			t.Error("overlay still reports visible after HideHints")
+		}
+
+		// Hiding an already-hidden overlay must stay a no-op rather than
+		// erroring, since mode exit paths can call it more than once.
+		err = hintService.HideHints(ctx)
+		if err != nil {
+			t.Errorf("second HideHints failed, hide is not idempotent: %v", err)
 		}
 	})
 
 	t.Run("Service health check", func(t *testing.T) {
 		health := hintService.Health(ctx)
-		// Health returns a map of component health status
 		if health == nil {
-			t.Error("Expected health map, got nil")
+			t.Fatal("Health returned nil map")
 		}
-		// Log health status for debugging
-		for component, err := range health {
+
+		// Permissions were verified during setup, so every component the
+		// service reports on is expected to be healthy here.
+		for _, component := range []string{"accessibility", "overlay"} {
+			err, present := health[component]
+			if !present {
+				t.Errorf("Health is missing the %q component: got keys %v", component, health)
+
+				continue
+			}
+
 			if err != nil {
-				t.Logf("Component %s health: FAILED - %v", component, err)
-			} else {
-				t.Logf("Component %s health: OK", component)
+				t.Errorf("component %q reported unhealthy: %v", component, err)
 			}
 		}
 	})
@@ -145,14 +181,9 @@ func TestActionServiceIntegration(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("PerformActionAtPoint left click", func(t *testing.T) {
-		// Test performing an action at a point
 		err := actionService.PerformActionAtPoint(ctx, "left_click", image.Point{X: 100, Y: 100}, 0)
 		if err != nil {
-			t.Logf("PerformActionAtPoint failed (may be expected in some environments): %v", err)
-			// Even on failure, verify the service handled it gracefully
-			t.Log("Service handled action attempt gracefully")
-		} else {
-			t.Log("Left click action performed successfully")
+			t.Fatalf("PerformActionAtPoint(left_click) failed: %v", err)
 		}
 	})
 
@@ -164,9 +195,84 @@ func TestActionServiceIntegration(t *testing.T) {
 			0,
 		)
 		if err != nil {
-			t.Logf("Right click failed (may be expected): %v", err)
-		} else {
-			t.Log("Right click action performed successfully")
+			t.Fatalf("PerformActionAtPoint(right_click) failed: %v", err)
+		}
+	})
+
+	t.Run("PerformActionAtPoint rejects an unknown action", func(t *testing.T) {
+		// The action string is parsed before any native call, so an unknown
+		// name must be reported rather than silently no-op'ing.
+		err := actionService.PerformActionAtPoint(
+			ctx,
+			"definitely_not_an_action",
+			image.Point{X: 10, Y: 10},
+			0,
+		)
+		if err == nil {
+			t.Fatal("expected an error for an unknown action name, got nil")
+		}
+
+		if code := derrors.GetCode(err); code != derrors.CodeInvalidConfig {
+			t.Errorf("unknown action: got code %q, want %q", code, derrors.CodeInvalidConfig)
+		}
+	})
+
+	t.Run("cursor position round-trips through the real coordinate stack", func(t *testing.T) {
+		// This is the end-to-end check for the global top-left-origin, Y-down
+		// contract: a point written through MoveCursorToPoint must read back
+		// unchanged from CursorPosition. A regression in the darwin Y-flip
+		// (Cocoa is bottom-left origin) shows up here as a mirrored Y.
+		bounds, err := actionService.ScreenBounds(ctx)
+		if err != nil {
+			t.Fatalf("ScreenBounds failed: %v", err)
+		}
+
+		if bounds.Empty() {
+			t.Fatalf("ScreenBounds returned an empty rectangle: %v", bounds)
+		}
+
+		origin, err := actionService.CursorPosition(ctx)
+		if err != nil {
+			t.Fatalf("CursorPosition failed: %v", err)
+		}
+
+		t.Cleanup(func() {
+			// Leave the user's cursor where we found it.
+			_ = actionService.MoveCursorToPointAndWait(ctx, origin, true)
+		})
+
+		// Deliberately asymmetric in X and Y so a swapped or mirrored axis
+		// cannot coincidentally produce the right answer.
+		want := image.Point{
+			X: bounds.Min.X + bounds.Dx()/4,
+			Y: bounds.Min.Y + bounds.Dy()/3,
+		}
+
+		err = actionService.MoveCursorToPointAndWait(ctx, want, true)
+		if err != nil {
+			t.Fatalf("MoveCursorToPointAndWait(%v) failed: %v", want, err)
+		}
+
+		// CursorPosition reads HID state via CGEventGetLocation, which can lag
+		// a just-posted synthetic move by a few milliseconds. Poll to a
+		// deadline rather than reading once: the assertion stays strict (the
+		// cursor must actually arrive at `want`), it just tolerates the
+		// propagation delay instead of flaking on it.
+		got, err := actionService.CursorPosition(ctx)
+		deadline := time.Now().Add(2 * time.Second)
+
+		for err == nil && got != want && time.Now().Before(deadline) {
+			time.Sleep(5 * time.Millisecond)
+
+			got, err = actionService.CursorPosition(ctx)
+		}
+
+		if err != nil {
+			t.Fatalf("CursorPosition after move failed: %v", err)
+		}
+
+		if got != want {
+			t.Errorf("cursor position round-trip: moved to %v, read back %v", want, got)
 		}
 	})
 
@@ -184,9 +290,7 @@ func TestActionServiceIntegration(t *testing.T) {
 
 		err = actionService.ExecuteAction(ctx, testElement, action.TypeLeftClick)
 		if err != nil {
-			t.Logf("ExecuteAction failed (may be expected): %v", err)
-		} else {
-			t.Log("Element action executed successfully")
+			t.Fatalf("ExecuteAction failed: %v", err)
 		}
 	})
 }
@@ -213,14 +317,43 @@ func TestGridServiceIntegration(t *testing.T) {
 	t.Run("ShowGrid integration", func(t *testing.T) {
 		err := gridService.ShowGrid(ctx)
 		if err != nil {
-			t.Logf("ShowGrid failed: %v", err)
+			t.Fatalf("ShowGrid failed: %v", err)
+		}
+
+		// Re-showing must stay safe: the grid mode re-renders on screen change
+		// and monitor moves without hiding first.
+		err = gridService.ShowGrid(ctx)
+		if err != nil {
+			t.Errorf("second ShowGrid failed, show is not idempotent: %v", err)
 		}
 	})
 
 	t.Run("HideGrid integration", func(t *testing.T) {
 		err := gridService.HideGrid(ctx)
 		if err != nil {
-			t.Logf("HideGrid failed: %v", err)
+			t.Fatalf("HideGrid failed: %v", err)
+		}
+
+		if overlay.IsVisible() {
+			t.Error("overlay still reports visible after HideGrid")
+		}
+
+		err = gridService.HideGrid(ctx)
+		if err != nil {
+			t.Errorf("second HideGrid failed, hide is not idempotent: %v", err)
+		}
+	})
+
+	t.Run("Grid health check", func(t *testing.T) {
+		health := gridService.Health(ctx)
+		if health == nil {
+			t.Fatal("Health returned nil map")
+		}
+
+		for component, err := range health {
+			if err != nil {
+				t.Errorf("component %q reported unhealthy: %v", component, err)
+			}
 		}
 	})
 }
@@ -244,6 +377,55 @@ func TestScrollServiceIntegration(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Scroll integration", func(t *testing.T) {
+		// Every direction/amount pair must reach the native scroll API without
+		// error, not just the one combination that happened to be wired up.
+		for _, dir := range []services.ScrollDirection{
+			services.ScrollDirectionUp,
+			services.ScrollDirectionDown,
+			services.ScrollDirectionLeft,
+			services.ScrollDirectionRight,
+		} {
+			for _, amount := range []services.ScrollAmount{
+				services.ScrollAmountChar,
+				services.ScrollAmountHalfPage,
+				services.ScrollAmountEnd,
+			} {
+				err := scrollService.Scroll(ctx, dir, amount, 0)
+				if err != nil {
+					t.Errorf("Scroll(dir=%d, amount=%d) failed: %v", dir, amount, err)
+				}
+			}
+		}
+	})
+
+	t.Run("Scroll honors a step override", func(t *testing.T) {
+		err := scrollService.Scroll(
+			ctx,
+			services.ScrollDirectionDown,
+			services.ScrollAmountChar,
+			7,
+		)
+		if err != nil {
+			t.Fatalf("Scroll with step override failed: %v", err)
+		}
+	})
+
+	t.Run("SetInvertScroll round-trips", func(t *testing.T) {
+		original := scrollService.IsScrollInverted()
+		t.Cleanup(func() { scrollService.SetInvertScroll(original) })
+
+		scrollService.SetInvertScroll(!original)
+
+		if got := scrollService.IsScrollInverted(); got != !original {
+			t.Fatalf(
+				"IsScrollInverted after SetInvertScroll(%t) = %t, want %t",
+				!original,
+				got,
+				!original,
+			)
+		}
+
+		// Inversion must not break the native path.
 		err := scrollService.Scroll(
 			ctx,
 			services.ScrollDirectionDown,
@@ -251,7 +433,18 @@ func TestScrollServiceIntegration(t *testing.T) {
 			0,
 		)
 		if err != nil {
-			t.Logf("Scroll failed (expected in some environments): %v", err)
+			t.Errorf("Scroll with inverted direction failed: %v", err)
+		}
+	})
+
+	t.Run("Hide integration", func(t *testing.T) {
+		err := scrollService.Hide(ctx)
+		if err != nil {
+			t.Fatalf("Hide failed: %v", err)
+		}
+
+		if overlay.IsVisible() {
+			t.Error("overlay still reports visible after scroll Hide")
 		}
 	})
 }
@@ -283,6 +476,14 @@ func initializeRealAdapters(
 	systemPort, err := platform.NewSystemPort()
 	if err != nil {
 		t.Fatalf("Failed to create system port: %v", err)
+	}
+
+	// Accessibility permission is the one legitimate reason these tests cannot
+	// run. Gate on it once, explicitly, so that every assertion below is
+	// allowed to be strict: from here on any error is a real failure.
+	permErr := systemPort.CheckPermissions(context.Background())
+	if permErr != nil {
+		t.Skipf("accessibility permission not granted, cannot run integration test: %v", permErr)
 	}
 
 	// Create overlay adapter

--- a/internal/app/services/services_integration_darwin_test.go
+++ b/internal/app/services/services_integration_darwin_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"image"
 	"testing"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -217,64 +216,12 @@ func TestActionServiceIntegration(t *testing.T) {
 		}
 	})
 
-	t.Run("cursor position round-trips through the real coordinate stack", func(t *testing.T) {
-		// This is the end-to-end check for the global top-left-origin, Y-down
-		// contract: a point written through MoveCursorToPoint must read back
-		// unchanged from CursorPosition. A regression in the darwin Y-flip
-		// (Cocoa is bottom-left origin) shows up here as a mirrored Y.
-		bounds, err := actionService.ScreenBounds(ctx)
-		if err != nil {
-			t.Fatalf("ScreenBounds failed: %v", err)
-		}
-
-		if bounds.Empty() {
-			t.Fatalf("ScreenBounds returned an empty rectangle: %v", bounds)
-		}
-
-		origin, err := actionService.CursorPosition(ctx)
-		if err != nil {
-			t.Fatalf("CursorPosition failed: %v", err)
-		}
-
-		t.Cleanup(func() {
-			// Leave the user's cursor where we found it.
-			_ = actionService.MoveCursorToPointAndWait(ctx, origin, true)
-		})
-
-		// Deliberately asymmetric in X and Y so a swapped or mirrored axis
-		// cannot coincidentally produce the right answer.
-		want := image.Point{
-			X: bounds.Min.X + bounds.Dx()/4,
-			Y: bounds.Min.Y + bounds.Dy()/3,
-		}
-
-		err = actionService.MoveCursorToPointAndWait(ctx, want, true)
-		if err != nil {
-			t.Fatalf("MoveCursorToPointAndWait(%v) failed: %v", want, err)
-		}
-
-		// CursorPosition reads HID state via CGEventGetLocation, which can lag
-		// a just-posted synthetic move by a few milliseconds. Poll to a
-		// deadline rather than reading once: the assertion stays strict (the
-		// cursor must actually arrive at `want`), it just tolerates the
-		// propagation delay instead of flaking on it.
-		got, err := actionService.CursorPosition(ctx)
-		deadline := time.Now().Add(2 * time.Second)
-
-		for err == nil && got != want && time.Now().Before(deadline) {
-			time.Sleep(5 * time.Millisecond)
-
-			got, err = actionService.CursorPosition(ctx)
-		}
-
-		if err != nil {
-			t.Fatalf("CursorPosition after move failed: %v", err)
-		}
-
-		if got != want {
-			t.Errorf("cursor position round-trip: moved to %v, read back %v", want, got)
-		}
-	})
+	// The exact-placement contract for cursor movement — the global
+	// top-left-origin, Y-down guarantee that a Y-flip regression would break —
+	// is asserted in internal/core/infra/accessibility, which owns cursor
+	// movement. It is deliberately not repeated here: both packages would be
+	// driving the one physical cursor, and `go test ./...` runs them
+	// concurrently, so each would intermittently fail the other.
 
 	t.Run("ExecuteAction on element", func(t *testing.T) {
 		// This tests the element-based action execution

--- a/internal/app/testutil_darwin_test.go
+++ b/internal/app/testutil_darwin_test.go
@@ -3,12 +3,42 @@
 package app_test
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/y3owk1n/neru/internal/app"
 	"github.com/y3owk1n/neru/internal/core/domain"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
+
+// requireCleanShutdown asserts that App.Run returned the way Stop is supposed to
+// end it: either with no error, or with a cancellation of the run context.
+//
+// Any other error means teardown itself failed — a phase that could not unwind,
+// an adapter that could not release a native resource — and must fail the test
+// rather than being logged and ignored. Not returning at all is also a failure:
+// it means Stop did not actually unblock Run.
+func requireCleanShutdown(tb testing.TB, runDone <-chan error, timeout time.Duration) {
+	tb.Helper()
+
+	select {
+	case err := <-runDone:
+		if err == nil {
+			return
+		}
+
+		if errors.Is(err, context.Canceled) ||
+			derrors.IsCode(err, derrors.CodeContextCanceled) {
+			return
+		}
+
+		tb.Errorf("Run() returned an unexpected error after Stop(): %v", err)
+	case <-time.After(timeout):
+		tb.Fatalf("App did not stop within %v", timeout)
+	}
+}
 
 // waitForMode waits for the application to reach the expected mode with a timeout.
 func waitForMode(

--- a/internal/app/workflow_integration_darwin_test.go
+++ b/internal/app/workflow_integration_darwin_test.go
@@ -204,17 +204,7 @@ func TestFullUserWorkflowIntegration(t *testing.T) {
 	application.Stop()
 
 	// Wait for Run() to return
-	select {
-	case err := <-runDone:
-		if err != nil {
-			// Run() may return a context-canceled error after Stop(), which is expected
-			t.Logf("App Run() returned (expected after Stop): %v", err)
-		} else {
-			t.Log("✅ Application shut down gracefully")
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("Application did not stop within timeout")
-	}
+	requireCleanShutdown(t, runDone, 5*time.Second)
 
 	t.Log("✅ Full user workflow integration test completed successfully")
 }

--- a/internal/architecture/dependency_boundary_test.go
+++ b/internal/architecture/dependency_boundary_test.go
@@ -12,6 +12,17 @@ import (
 
 const forbiddenImport = "github.com/y3owk1n/neru/internal/core/infra/platform/darwin"
 
+// skippedWalkDirs are the directories every repository walk in this package
+// skips: version control, build outputs and vendored third-party code, none of
+// which contain first-party source subject to these guardrails.
+var skippedWalkDirs = map[string]bool{
+	".git": true, "bin": true, "build": true,
+	"node_modules": true, "vendor": true,
+}
+
+// isSkippedWalkDir reports whether a directory should be pruned from a walk.
+func isSkippedWalkDir(name string) bool { return skippedWalkDirs[name] }
+
 func TestNonDarwinFilesDoNotImportDarwinPlatformPackage(t *testing.T) {
 	repoRoot := findRepoRoot(t)
 	fileSet := token.NewFileSet()
@@ -22,8 +33,7 @@ func TestNonDarwinFilesDoNotImportDarwinPlatformPackage(t *testing.T) {
 		}
 
 		if entry.IsDir() {
-			switch entry.Name() {
-			case ".git", "bin", "build":
+			if isSkippedWalkDir(entry.Name()) {
 				return filepath.SkipDir
 			}
 

--- a/internal/architecture/platform_slots_test.go
+++ b/internal/architecture/platform_slots_test.go
@@ -254,8 +254,7 @@ func goFiles(t *testing.T) []goFile {
 			}
 
 			if entry.IsDir() {
-				switch entry.Name() {
-				case ".git", "bin", "build", "node_modules":
+				if isSkippedWalkDir(entry.Name()) {
 					return filepath.SkipDir
 				}
 

--- a/internal/architecture/test_quality_test.go
+++ b/internal/architecture/test_quality_test.go
@@ -1,0 +1,276 @@
+package architecture_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// These guardrails keep the test suite honest. Both patterns they forbid used
+// to be widespread here, and both share the same failure mode: the test runs,
+// reports PASS, and would keep reporting PASS after the code under it broke.
+// A test that cannot fail is worse than no test, because it reads as coverage.
+//
+// If a genuinely untestable case turns up, express it as an explicit t.Skip
+// with a reason rather than as a silently-passing assertion — a skip is visible
+// in the test output, a swallowed error is not.
+
+// failCalls are the testing.TB methods that can actually fail (or visibly skip)
+// a test. Anything else leaves the test reporting success.
+var failCalls = map[string]bool{
+	"Error": true, "Errorf": true,
+	"Fatal": true, "Fatalf": true,
+	"Fail": true, "FailNow": true,
+	"Skip": true, "Skipf": true, "SkipNow": true,
+}
+
+// TestNoTestSwallowsAnErrorWithoutFailing forbids the
+//
+//	if err != nil { t.Logf("...", err) }
+//
+// shape: an error path that logs and moves on. Under it, the operation under
+// test can start failing on every run and the suite stays green. Either the
+// error is a real failure (use t.Error/t.Fatal), or the case is legitimately
+// unsupported in this environment (use t.Skip, which is reported).
+func TestNoTestSwallowsAnErrorWithoutFailing(t *testing.T) {
+	var offenders []string
+
+	forEachTestFile(t, func(path string, fset *token.FileSet, file *ast.File) {
+		ast.Inspect(file, func(node ast.Node) bool {
+			ifStmt, ok := node.(*ast.IfStmt)
+			if !ok {
+				return true
+			}
+
+			if !isErrNotNilCond(ifStmt.Cond) {
+				return true
+			}
+
+			logged, failed := scanForCalls(ifStmt.Body)
+			if logged && !failed {
+				offenders = append(offenders, fset.Position(ifStmt.Pos()).String())
+			}
+
+			return true
+		})
+	})
+
+	reportOffenders(t, offenders,
+		"error branch logs the error but never fails or skips the test")
+}
+
+// TestEveryTestBodyCanFail forbids test functions and subtests that contain no
+// failure-producing call at all — they exercise code without checking anything,
+// so they only ever catch an outright panic.
+//
+// A function whose body only delegates to t.Run is fine: the assertions live in
+// the subtests, which are checked individually.
+func TestEveryTestBodyCanFail(t *testing.T) {
+	var offenders []string
+
+	forEachTestFile(t, func(path string, fset *token.FileSet, file *ast.File) {
+		for _, decl := range file.Decls {
+			funcDecl, ok := decl.(*ast.FuncDecl)
+			if !ok || funcDecl.Body == nil {
+				continue
+			}
+
+			if !strings.HasPrefix(funcDecl.Name.Name, "Test") {
+				continue
+			}
+
+			// TestMain is a harness entry point, not an assertion site.
+			if funcDecl.Name.Name == "TestMain" {
+				continue
+			}
+
+			checkBodyCanFail(fset, funcDecl.Name.Name, funcDecl.Body, &offenders)
+		}
+	})
+
+	reportOffenders(t, offenders,
+		"test body contains no assertion and no subtests, so it can never fail")
+}
+
+// checkBodyCanFail reports a body that neither asserts nor delegates to
+// subtests, recursing into each t.Run closure so subtests are judged on their
+// own contents.
+func checkBodyCanFail(
+	fset *token.FileSet,
+	name string,
+	body *ast.BlockStmt,
+	offenders *[]string,
+) {
+	subtests := 0
+
+	ast.Inspect(body, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+
+		selector, isSelector := call.Fun.(*ast.SelectorExpr)
+		if !isSelector || selector.Sel.Name != "Run" || len(call.Args) != 2 {
+			return true
+		}
+
+		closure, isClosure := call.Args[1].(*ast.FuncLit)
+		if !isClosure {
+			return true
+		}
+
+		subtests++
+
+		subName := name
+		if lit, isLiteral := call.Args[0].(*ast.BasicLit); isLiteral {
+			subName += "/" + strings.Trim(lit.Value, `"`)
+		}
+
+		checkBodyCanFail(fset, subName, closure.Body, offenders)
+
+		// Do not descend further here; the recursive call covers this closure.
+		return false
+	})
+
+	if subtests > 0 {
+		return
+	}
+
+	if _, failed := scanForCalls(body); failed {
+		return
+	}
+
+	*offenders = append(*offenders,
+		fset.Position(body.Pos()).String()+"\t"+name)
+}
+
+// scanForCalls reports whether the node contains a t.Log-style call and whether
+// it contains anything that can fail or skip the test. Nested t.Run closures
+// are not descended into: they are separate scopes with their own assertions.
+func scanForCalls(node ast.Node) (bool, bool) {
+	var logged, failed bool
+
+	ast.Inspect(node, func(inner ast.Node) bool {
+		call, ok := inner.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		if selector, ok := call.Fun.(*ast.SelectorExpr); ok {
+			if selector.Sel.Name == "Run" {
+				return false
+			}
+
+			switch selector.Sel.Name {
+			case "Log", "Logf":
+				logged = true
+			default:
+				if failCalls[selector.Sel.Name] {
+					failed = true
+				}
+			}
+		}
+
+		// Any call taking the testing handle as its first argument is treated
+		// as an assertion helper: testify's assert.Equal(t, ...), a local
+		// requireX(t, ...), and so on.
+		if len(call.Args) > 0 {
+			if ident, ok := call.Args[0].(*ast.Ident); ok &&
+				(ident.Name == "t" || ident.Name == "tb") {
+				failed = true
+			}
+		}
+
+		return true
+	})
+
+	return logged, failed
+}
+
+// isErrNotNilCond reports whether cond is an `err != nil`-shaped check, for any
+// identifier whose name mentions "err".
+func isErrNotNilCond(cond ast.Expr) bool {
+	binary, ok := cond.(*ast.BinaryExpr)
+	if !ok || binary.Op != token.NEQ {
+		return false
+	}
+
+	left, isIdent := binary.X.(*ast.Ident)
+	if !isIdent || !strings.Contains(strings.ToLower(left.Name), "err") {
+		return false
+	}
+
+	right, isIdent := binary.Y.(*ast.Ident)
+
+	return isIdent && right.Name == "nil"
+}
+
+// forEachTestFile parses every _test.go file in the repository, including
+// build-tagged ones, and hands it to fn. Tagged files are parsed rather than
+// built, so integration tests are covered on every platform.
+func forEachTestFile(
+	t *testing.T,
+	visit func(path string, fset *token.FileSet, file *ast.File),
+) {
+	t.Helper()
+
+	repoRoot := findRepoRoot(t)
+	fset := token.NewFileSet()
+
+	walkErr := filepath.WalkDir(repoRoot, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if entry.IsDir() {
+			if isSkippedWalkDir(entry.Name()) {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		parsed, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+
+		visit(path, fset, parsed)
+
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking the repository: %v", walkErr)
+	}
+}
+
+// reportOffenders fails the test with one line per offending site, relative to
+// the repo root so the output is clickable.
+func reportOffenders(t *testing.T, offenders []string, problem string) {
+	t.Helper()
+
+	if len(offenders) == 0 {
+		return
+	}
+
+	repoRoot := findRepoRoot(t) + string(filepath.Separator)
+
+	cleaned := make([]string, 0, len(offenders))
+	for _, offender := range offenders {
+		cleaned = append(cleaned, strings.ReplaceAll(offender, repoRoot, ""))
+	}
+
+	sort.Strings(cleaned)
+
+	t.Errorf("%d site(s) where the %s:\n\t%s",
+		len(cleaned), problem, strings.Join(cleaned, "\n\t"))
+}

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -163,8 +163,16 @@ func TestService_Replace(t *testing.T) {
 	ctx := t.Context()
 
 	watchCh := service.Watch(ctx)
-	// Drain initial notification.
-	<-watchCh
+
+	// Drain the initial notification. Bounded rather than a bare receive: if
+	// Watch ever stops emitting it, that is the regression this test exists
+	// around, and it should be reported as a failure instead of hanging until
+	// the package's test timeout kills every other test in the binary.
+	select {
+	case <-watchCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Watch() never delivered its initial notification")
+	}
 
 	modified := config.DefaultConfig()
 	modified.Hints.HintCharacters = "replaced"

--- a/internal/config/validators_boundary_test.go
+++ b/internal/config/validators_boundary_test.go
@@ -1,0 +1,510 @@
+package config_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+)
+
+// Every numeric config field is guarded by a range check, and every one of
+// those checks is a boundary the tests never exercised: the suite validated
+// wholesale-valid and wholesale-garbage configs, but never the value one step
+// either side of the limit.
+//
+// That is where these bugs live. A `< 1` that drifts to `<= 1` locks users out
+// of a legal setting; a `<= 0` that drifts to `< 0` admits a zero timeout or a
+// zero-size threshold that then divides by zero or spins at runtime. Neither
+// changes anything a coarse valid/invalid test would notice.
+//
+// The tables below assert both directions for each field: the smallest legal
+// value is accepted, and the largest illegal one is rejected.
+
+// intBound describes an integer config field with an inclusive lower limit.
+type intBound struct {
+	// name is the TOML path, used only for failure messages.
+	name string
+	// set writes the field on a config.
+	set func(*config.Config, int)
+	// validate runs the validator that owns the field.
+	validate func(*config.Config) error
+	// minValid is the smallest accepted value.
+	minValid int
+	// maxValid is the largest accepted value, or 0 when unbounded above.
+	maxValid int
+	// enable turns on the feature that owns the field. Several validators
+	// return early for a disabled feature — deliberately, so a user can leave
+	// garbage in a section they do not use — so the boundary is only reachable
+	// with the feature switched on.
+	enable func(*config.Config)
+}
+
+// fontSizeBounds covers the font-size fields, all of which share the same
+// `< 1 || > maxFontSize` guard.
+func fontSizeBounds() []intBound {
+	return []intBound{
+		{
+			name:     "hints.ui.font_size",
+			set:      func(c *config.Config, v int) { c.Hints.UI.FontSize = v },
+			validate: (*config.Config).ValidateHints,
+			minValid: 1, maxValid: math.MaxInt32,
+		},
+		{
+			name:     "hints.search_input_ui.font_size",
+			set:      func(c *config.Config, v int) { c.Hints.SearchInputUI.FontSize = v },
+			validate: (*config.Config).ValidateHints,
+			minValid: 1, maxValid: math.MaxInt32,
+		},
+		{
+			name:     "grid.ui.font_size",
+			set:      func(c *config.Config, v int) { c.Grid.UI.FontSize = v },
+			validate: (*config.Config).ValidateGrid,
+			minValid: 1, maxValid: math.MaxInt32,
+			enable: func(c *config.Config) { c.Grid.Enabled = true },
+		},
+		{
+			name:     "monitor_select.ui.font_size",
+			set:      func(c *config.Config, v int) { c.MonitorSelect.UI.FontSize = v },
+			validate: (*config.Config).ValidateMonitorSelect,
+			minValid: 1, maxValid: math.MaxInt32,
+			enable: func(c *config.Config) { c.MonitorSelect.Enabled = true },
+		},
+		{
+			name:     "monitor_select.ui.subtitle_font_size",
+			set:      func(c *config.Config, v int) { c.MonitorSelect.UI.SubtitleFontSize = v },
+			validate: (*config.Config).ValidateMonitorSelect,
+			minValid: 1, maxValid: math.MaxInt32,
+			enable: func(c *config.Config) { c.MonitorSelect.Enabled = true },
+		},
+		{
+			name:     "sticky_modifiers.ui.font_size",
+			set:      func(c *config.Config, v int) { c.StickyModifiers.UI.FontSize = v },
+			validate: (*config.Config).ValidateStickyModifiers,
+			minValid: 1, maxValid: math.MaxInt32,
+			enable: func(c *config.Config) { c.StickyModifiers.Enabled = true },
+		},
+		{
+			name:     "recursive_grid.ui.font_size",
+			set:      func(c *config.Config, v int) { c.RecursiveGrid.UI.FontSize = v },
+			validate: (*config.Config).ValidateRecursiveGrid,
+			minValid: 1, maxValid: math.MaxInt32,
+			enable: func(c *config.Config) { c.RecursiveGrid.Enabled = true },
+		},
+		{
+			name:     "recursive_grid.ui.sub_key_preview_font_size",
+			set:      func(c *config.Config, v int) { c.RecursiveGrid.UI.SubKeyPreviewFontSize = v },
+			validate: (*config.Config).ValidateRecursiveGrid,
+			minValid: 1,
+			maxValid: math.MaxInt32,
+			enable:   func(c *config.Config) { c.RecursiveGrid.Enabled = true },
+		},
+	}
+}
+
+// visionIntBounds covers the vision thresholds guarded by `<= 0`.
+func visionIntBounds() []intBound {
+	return []intBound{
+		{
+			name:     "hints.vision.request_timeout_ms",
+			set:      func(c *config.Config, v int) { c.Hints.Vision.RequestTimeoutMS = v },
+			validate: (*config.Config).ValidateHints,
+			minValid: 1,
+		},
+		{
+			name:     "hints.vision.rectangle_max_candidates",
+			set:      func(c *config.Config, v int) { c.Hints.Vision.RectangleMaxCandidates = v },
+			validate: (*config.Config).ValidateHints,
+			minValid: 1,
+		},
+	}
+}
+
+// validBase returns a config that every validator accepts, so a failure in a
+// table case can only come from the single field that case changed.
+func validBase(t *testing.T) *config.Config {
+	t.Helper()
+
+	cfg := config.DefaultConfig()
+
+	assertConfigValid(t, cfg, "the default config")
+
+	return cfg
+}
+
+// assertConfigValid fails if any validator rejects cfg.
+func assertConfigValid(t *testing.T, cfg *config.Config, what string) {
+	t.Helper()
+
+	validators := map[string]func(*config.Config) error{
+		"ValidateHints":           (*config.Config).ValidateHints,
+		"ValidateGrid":            (*config.Config).ValidateGrid,
+		"ValidateMonitorSelect":   (*config.Config).ValidateMonitorSelect,
+		"ValidateStickyModifiers": (*config.Config).ValidateStickyModifiers,
+		"ValidateRecursiveGrid":   (*config.Config).ValidateRecursiveGrid,
+		"ValidateVirtualPointer":  (*config.Config).ValidateVirtualPointer,
+		"ValidateMouseAction":     (*config.Config).ValidateMouseAction,
+		"ValidateSmoothCursor":    (*config.Config).ValidateSmoothCursor,
+		"ValidateSmoothScroll":    (*config.Config).ValidateSmoothScroll,
+		"ValidateHeldRepeat":      (*config.Config).ValidateHeldRepeat,
+	}
+
+	for name, validate := range validators {
+		err := validate(cfg)
+		if err != nil {
+			t.Fatalf("%s rejected %s: %v", name, what, err)
+		}
+	}
+}
+
+// assertRejected requires an error carrying the invalid-config code, so a field
+// that fails for an unrelated reason does not read as correct validation.
+func assertRejected(t *testing.T, err error, field string, value any) {
+	t.Helper()
+
+	if err == nil {
+		t.Errorf("%s = %v was accepted, want rejected", field, value)
+
+		return
+	}
+
+	if code := derrors.GetCode(err); code != derrors.CodeInvalidConfig {
+		t.Errorf("%s = %v rejected with code %q, want %q",
+			field, value, code, derrors.CodeInvalidConfig)
+	}
+}
+
+// runIntBounds asserts the accept/reject edge for each field in the table.
+func runIntBounds(t *testing.T, bounds []intBound) {
+	t.Helper()
+
+	for _, bound := range bounds {
+		t.Run(bound.name, func(t *testing.T) {
+			newCfg := func() *config.Config {
+				cfg := validBase(t)
+				if bound.enable != nil {
+					bound.enable(cfg)
+				}
+
+				return cfg
+			}
+
+			// One below the minimum must be rejected...
+			cfg := newCfg()
+			bound.set(cfg, bound.minValid-1)
+			assertRejected(t, bound.validate(cfg), bound.name, bound.minValid-1)
+
+			// ...as must clearly-out-of-range values.
+			for _, value := range []int{-1, math.MinInt32} {
+				if value >= bound.minValid {
+					continue
+				}
+
+				cfg = newCfg()
+				bound.set(cfg, value)
+				assertRejected(t, bound.validate(cfg), bound.name, value)
+			}
+
+			// The minimum itself must be accepted — the common off-by-one here
+			// silently forbids a legal setting.
+			cfg = newCfg()
+			bound.set(cfg, bound.minValid)
+
+			err := bound.validate(cfg)
+			if err != nil {
+				t.Errorf("%s = %d (the minimum) was rejected: %v",
+					bound.name, bound.minValid, err)
+			}
+
+			if bound.maxValid > 0 {
+				cfg = newCfg()
+				bound.set(cfg, bound.maxValid)
+
+				err := bound.validate(cfg)
+				if err != nil {
+					t.Errorf("%s = %d (the maximum) was rejected: %v",
+						bound.name, bound.maxValid, err)
+				}
+			}
+		})
+	}
+}
+
+func TestConfig_FontSizeBoundaries(t *testing.T) {
+	runIntBounds(t, fontSizeBounds())
+}
+
+func TestConfig_VisionIntBoundaries(t *testing.T) {
+	runIntBounds(t, visionIntBounds())
+}
+
+// unitFloatBound describes a float field constrained to a 0..1 confidence or
+// ratio range. inclusiveZero distinguishes validateUnitFloat (accepts 0) from
+// validatePositiveUnitFloat (rejects 0) — mixing the two up would let a
+// confidence threshold of zero through, matching everything on screen.
+type unitFloatBound struct {
+	name          string
+	set           func(*config.Config, float64)
+	inclusiveZero bool
+}
+
+func unitFloatBounds() []unitFloatBound {
+	return []unitFloatBound{
+		{
+			name:          "hints.vision.minimum_confidence",
+			set:           func(c *config.Config, v float64) { c.Hints.Vision.MinimumConfidence = v },
+			inclusiveZero: true,
+		},
+		{
+			name:          "hints.vision.rectangle_min_size",
+			set:           func(c *config.Config, v float64) { c.Hints.Vision.RectangleMinSize = v },
+			inclusiveZero: true,
+		},
+		{
+			name:          "hints.vision.merge_iou_threshold",
+			set:           func(c *config.Config, v float64) { c.Hints.Vision.MergeIOUThreshold = v },
+			inclusiveZero: false,
+		},
+		{
+			name:          "hints.vision.button_min_confidence",
+			set:           func(c *config.Config, v float64) { c.Hints.Vision.ButtonMinConfidence = v },
+			inclusiveZero: false,
+		},
+		{
+			name: "hints.vision.generic_clickable_min_confidence",
+			set: func(c *config.Config, v float64) {
+				c.Hints.Vision.GenericClickableMinConfidence = v
+			},
+			inclusiveZero: false,
+		},
+	}
+}
+
+// TestConfig_UnitFloatBoundaries pins the 0..1 range on every confidence and
+// ratio field, including whether zero is legal for that particular field.
+func TestConfig_UnitFloatBoundaries(t *testing.T) {
+	for _, bound := range unitFloatBounds() {
+		t.Run(bound.name, func(t *testing.T) {
+			// Above the range and below it are always rejected.
+			for _, value := range []float64{-0.001, -1, 1.001, 2} {
+				cfg := validBase(t)
+				bound.set(cfg, value)
+				assertRejected(t, cfg.ValidateHints(), bound.name, value)
+			}
+
+			// 1.0 is the inclusive upper bound for both variants.
+			cfg := validBase(t)
+			bound.set(cfg, 1)
+
+			err := cfg.ValidateHints()
+			if err != nil {
+				t.Errorf("%s = 1 (the inclusive maximum) was rejected: %v", bound.name, err)
+			}
+
+			// Zero is where the two variants differ.
+			cfg = validBase(t)
+			bound.set(cfg, 0)
+
+			err = cfg.ValidateHints()
+			if bound.inclusiveZero {
+				if err != nil {
+					t.Errorf("%s = 0 was rejected, but this field allows zero: %v", bound.name, err)
+				}
+			} else {
+				assertRejected(t, err, bound.name, 0.0)
+			}
+
+			// A mid-range value is always fine.
+			cfg = validBase(t)
+			bound.set(cfg, 0.5)
+
+			err = cfg.ValidateHints()
+			if err != nil {
+				t.Errorf("%s = 0.5 was rejected: %v", bound.name, err)
+			}
+		})
+	}
+}
+
+// aspectPair describes a min/max aspect-ratio pair validated together.
+type aspectPair struct {
+	name    string
+	setMin  func(*config.Config, float64)
+	setMax  func(*config.Config, float64)
+	readMin func(*config.Config) float64
+	readMax func(*config.Config) float64
+}
+
+func aspectPairs() []aspectPair {
+	return []aspectPair{
+		{
+			name:    "hints.vision rectangle aspect",
+			setMin:  func(c *config.Config, v float64) { c.Hints.Vision.RectangleMinAspect = v },
+			setMax:  func(c *config.Config, v float64) { c.Hints.Vision.RectangleMaxAspect = v },
+			readMin: func(c *config.Config) float64 { return c.Hints.Vision.RectangleMinAspect },
+			readMax: func(c *config.Config) float64 { return c.Hints.Vision.RectangleMaxAspect },
+		},
+		{
+			name:    "hints.vision button aspect",
+			setMin:  func(c *config.Config, v float64) { c.Hints.Vision.ButtonMinAspect = v },
+			setMax:  func(c *config.Config, v float64) { c.Hints.Vision.ButtonMaxAspect = v },
+			readMin: func(c *config.Config) float64 { return c.Hints.Vision.ButtonMinAspect },
+			readMax: func(c *config.Config) float64 { return c.Hints.Vision.ButtonMaxAspect },
+		},
+	}
+}
+
+// TestConfig_AspectPairBoundaries pins all three clauses of the aspect guard:
+// both ends must be positive, and min must not exceed max. An inverted pair
+// would silently match no rectangles at all.
+func TestConfig_AspectPairBoundaries(t *testing.T) {
+	for _, pair := range aspectPairs() {
+		t.Run(pair.name, func(t *testing.T) {
+			// A non-positive minimum is rejected.
+			for _, value := range []float64{0, -0.5} {
+				cfg := validBase(t)
+				pair.setMin(cfg, value)
+				assertRejected(t, cfg.ValidateHints(), pair.name+" min", value)
+			}
+
+			// A non-positive maximum is rejected.
+			for _, value := range []float64{0, -0.5} {
+				cfg := validBase(t)
+				pair.setMax(cfg, value)
+				assertRejected(t, cfg.ValidateHints(), pair.name+" max", value)
+			}
+
+			// min > max is rejected even when both are positive.
+			cfg := validBase(t)
+			pair.setMin(cfg, 5)
+			pair.setMax(cfg, 2)
+			assertRejected(t, cfg.ValidateHints(), pair.name+" min>max", "5 > 2")
+
+			// min == max is the inclusive edge and must be accepted.
+			cfg = validBase(t)
+			pair.setMin(cfg, 2)
+			pair.setMax(cfg, 2)
+
+			err := cfg.ValidateHints()
+			if err != nil {
+				t.Errorf("%s with min == max == 2 was rejected: %v", pair.name, err)
+			}
+
+			// And the default pair must itself satisfy min <= max.
+			cfg = validBase(t)
+			if pair.readMin(cfg) > pair.readMax(cfg) {
+				t.Errorf("%s default has min %v > max %v",
+					pair.name, pair.readMin(cfg), pair.readMax(cfg))
+			}
+		})
+	}
+}
+
+// visionSizeThresholds are the size fields validated together by a single
+// `<= 0` chain; each must be individually rejected when non-positive, or one
+// clause of the chain could be dropped unnoticed.
+func visionSizeThresholds() []intBound {
+	return []intBound{
+		{
+			name:     "hints.vision.button_icon_max_size",
+			set:      func(c *config.Config, v int) { c.Hints.Vision.ButtonIconMaxSize = v },
+			validate: (*config.Config).ValidateHints,
+			minValid: 1,
+		},
+		{
+			name:     "hints.vision.link_max_height",
+			set:      func(c *config.Config, v int) { c.Hints.Vision.LinkMaxHeight = v },
+			validate: (*config.Config).ValidateHints,
+			minValid: 1,
+		},
+		{
+			name:     "hints.vision.link_min_width",
+			set:      func(c *config.Config, v int) { c.Hints.Vision.LinkMinWidth = v },
+			validate: (*config.Config).ValidateHints,
+			minValid: 1,
+		},
+		{
+			name:     "hints.vision.image_min_size",
+			set:      func(c *config.Config, v int) { c.Hints.Vision.ImageMinSize = v },
+			validate: (*config.Config).ValidateHints,
+			minValid: 1,
+		},
+		{
+			name:     "hints.vision.checkbox_max_size",
+			set:      func(c *config.Config, v int) { c.Hints.Vision.CheckboxMaxSize = v },
+			validate: (*config.Config).ValidateHints,
+			minValid: 1,
+		},
+	}
+}
+
+func TestConfig_VisionSizeThresholdBoundaries(t *testing.T) {
+	runIntBounds(t, visionSizeThresholds())
+}
+
+// TestConfig_VisionLinkMinAspectBoundary covers the standalone positive check.
+func TestConfig_VisionLinkMinAspectBoundary(t *testing.T) {
+	for _, value := range []float64{0, -0.1, -1} {
+		cfg := validBase(t)
+		cfg.Hints.Vision.LinkMinAspect = value
+		assertRejected(t, cfg.ValidateHints(), "hints.vision.link_min_aspect", value)
+	}
+
+	for _, value := range []float64{0.001, 1, 10} {
+		cfg := validBase(t)
+		cfg.Hints.Vision.LinkMinAspect = value
+
+		err := cfg.ValidateHints()
+		if err != nil {
+			t.Errorf("hints.vision.link_min_aspect = %v was rejected: %v", value, err)
+		}
+	}
+}
+
+// TestConfig_VisionRequiresADetector pins the "at least one detector" rule.
+// With both off the vision strategy would run and find nothing, which looks
+// identical to "no elements on screen".
+func TestConfig_VisionRequiresADetector(t *testing.T) {
+	cfg := validBase(t)
+	cfg.Hints.Vision.DetectText = false
+	cfg.Hints.Vision.DetectRectangles = false
+
+	assertRejected(t, cfg.ValidateHints(), "hints.vision detectors", "both disabled")
+
+	// Either one alone is enough.
+	for _, useText := range []bool{true, false} {
+		cfg = validBase(t)
+		cfg.Hints.Vision.DetectText = useText
+		cfg.Hints.Vision.DetectRectangles = !useText
+
+		err := cfg.ValidateHints()
+		if err != nil {
+			t.Errorf("vision with detect_text=%t, detect_rectangles=%t was rejected: %v",
+				useText, !useText, err)
+		}
+	}
+}
+
+// TestConfig_MouseActionAnimationScalesRejectNegatives covers the animation
+// scale guard, where a negative scale would invert the indicator.
+func TestConfig_MouseActionAnimationScalesRejectNegatives(t *testing.T) {
+	for _, value := range []float64{-0.001, -1} {
+		cfg := validBase(t)
+		cfg.MouseAction.Animation.StartScale = value
+		assertRejected(t, cfg.ValidateMouseAction(), "mouse_action.animation.start_scale", value)
+
+		cfg = validBase(t)
+		cfg.MouseAction.Animation.EndScale = value
+		assertRejected(t, cfg.ValidateMouseAction(), "mouse_action.animation.end_scale", value)
+	}
+
+	// Zero is the inclusive lower edge for both.
+	cfg := validBase(t)
+	cfg.MouseAction.Animation.StartScale = 0
+	cfg.MouseAction.Animation.EndScale = 0
+
+	err := cfg.ValidateMouseAction()
+	if err != nil {
+		t.Errorf("animation scales of 0 were rejected: %v", err)
+	}
+}

--- a/internal/core/domain/action/predicates_test.go
+++ b/internal/core/domain/action/predicates_test.go
@@ -1,0 +1,208 @@
+package action_test
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/domain/action"
+)
+
+// The Is<X>Action helpers are the routing table for CLI and IPC action
+// dispatch: each one claims a single action name, and the caller runs whichever
+// branch says yes. They are one-liners, which is exactly why they were
+// untested — and exactly why a slip in one is invisible. An inverted comparison
+// makes a predicate answer "yes" for every action except its own, silently
+// routing every unrelated action into that branch.
+//
+// Testing them as a cross-product (each predicate against every name) pins both
+// halves of the contract: it matches its own name, and it matches nothing else.
+
+// namedPredicate pairs a predicate with the single action name it must accept.
+type namedPredicate struct {
+	name      action.Name
+	predicate func(string) bool
+}
+
+func namedPredicates() []namedPredicate {
+	return []namedPredicate{
+		{action.NameReset, action.IsResetAction},
+		{action.NameBackspace, action.IsBackspaceAction},
+		{action.NameWaitForModeExit, action.IsWaitForModeExitAction},
+		{action.NameSaveCursorPos, action.IsSaveCursorPosAction},
+		{action.NameRestoreCursorPos, action.IsRestoreCursorPosAction},
+		{action.NameHideCursor, action.IsHideCursorAction},
+		{action.NameShowCursor, action.IsShowCursorAction},
+		{action.NameMoveMonitor, action.IsMoveMonitorAction},
+		{action.NameCycleHint, action.IsCycleHintAction},
+		{action.NameSearchHints, action.IsSearchHintsAction},
+		{action.NameFeed, action.IsFeedAction},
+	}
+}
+
+// TestActionPredicates_MatchExactlyTheirOwnName runs every predicate against
+// every known action name plus a few near-misses, and requires each to accept
+// its own name and reject all others.
+func TestActionPredicates_MatchExactlyTheirOwnName(t *testing.T) {
+	predicates := namedPredicates()
+
+	// The candidate set is every known name, plus the names the predicates
+	// claim (in case one is not in knownNames), plus values that should never
+	// match anything.
+	candidates := make(map[action.Name]bool)
+
+	for _, name := range action.KnownNames() {
+		candidates[name] = true
+	}
+
+	for _, entry := range predicates {
+		candidates[entry.name] = true
+	}
+
+	for _, extra := range []action.Name{"", "not_an_action", "RESET", "reset ", " reset"} {
+		candidates[extra] = true
+	}
+
+	for _, entry := range predicates {
+		t.Run(string(entry.name), func(t *testing.T) {
+			if !entry.predicate(string(entry.name)) {
+				t.Errorf("predicate for %q rejected its own name", entry.name)
+			}
+
+			for candidate := range candidates {
+				if candidate == entry.name {
+					continue
+				}
+
+				if entry.predicate(string(candidate)) {
+					t.Errorf(
+						"predicate for %q also matched %q; it must accept only its own name",
+						entry.name, candidate,
+					)
+				}
+			}
+		})
+	}
+}
+
+// TestActionPredicates_AreMutuallyExclusive states the property the dispatch
+// code relies on directly: for any given action name at most one predicate
+// fires, so the dispatcher cannot take two branches for one action.
+func TestActionPredicates_AreMutuallyExclusive(t *testing.T) {
+	predicates := namedPredicates()
+
+	for _, name := range action.KnownNames() {
+		var matched []action.Name
+
+		for _, entry := range predicates {
+			if entry.predicate(string(name)) {
+				matched = append(matched, entry.name)
+			}
+		}
+
+		if len(matched) > 1 {
+			t.Errorf("action %q matched %d predicates (%v), want at most 1",
+				name, len(matched), matched)
+		}
+	}
+}
+
+// TestIsScrollSubAction_CoversEveryScrollNameAndNothingElse pins the boundary
+// between scroll sub-actions (CLI/IPC only) and the mode-compatible action set.
+// The two are dispatched down different paths, so a name landing on the wrong
+// side of this predicate is silently unroutable.
+func TestIsScrollSubAction_CoversEveryScrollNameAndNothingElse(t *testing.T) {
+	for _, name := range action.KnownNames() {
+		// Every mode-compatible known name is by definition not a scroll
+		// sub-action; the doc comment on KnownNames draws exactly that line.
+		if action.IsScrollSubAction(string(name)) {
+			t.Errorf("IsScrollSubAction(%q) = true, but %q is a mode-compatible known name",
+				name, name)
+		}
+	}
+
+	scrollNames := []string{
+		"scroll_up", "scroll_down", "scroll_left", "scroll_right",
+	}
+
+	for _, name := range scrollNames {
+		if !action.IsScrollSubAction(name) {
+			t.Errorf("IsScrollSubAction(%q) = false, want true", name)
+		}
+
+		// A scroll sub-action must still be a known name overall, or the CLI
+		// would reject it before dispatch ever sees it.
+		if !action.IsKnownName(action.Name(name)) {
+			t.Errorf("IsKnownName(%q) = false, but it is a dispatchable scroll sub-action", name)
+		}
+	}
+
+	for _, name := range []string{"", "scroll", "scroll_diagonal", "left_click"} {
+		if action.IsScrollSubAction(name) {
+			t.Errorf("IsScrollSubAction(%q) = true, want false", name)
+		}
+	}
+}
+
+// TestModeActionNamesString_ListsExactlyTheMouseButtonActions checks the help
+// text stays derived from the same predicate the CLI validates against. If the
+// two drift, `neru mode --help` advertises actions that are then rejected, or
+// omits ones that work.
+func TestModeActionNamesString_ListsExactlyTheMouseButtonActions(t *testing.T) {
+	listed := strings.Split(action.ModeActionNamesString(), ", ")
+
+	inList := make(map[string]bool, len(listed))
+	for _, name := range listed {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			continue
+		}
+
+		if inList[trimmed] {
+			t.Errorf("action %q is listed more than once", trimmed)
+		}
+
+		inList[trimmed] = true
+	}
+
+	if len(inList) == 0 {
+		t.Fatal("ModeActionNamesString() listed no actions")
+	}
+
+	for _, name := range action.KnownNames() {
+		actionType, err := name.ToType()
+		wantListed := err == nil && actionType.IsMouseButton()
+
+		if gotListed := inList[string(name)]; gotListed != wantListed {
+			t.Errorf("action %q listed = %t, want %t (IsMouseButton = %t)",
+				name, gotListed, wantListed, wantListed)
+		}
+	}
+
+	// Everything listed must be a real known name, not an invented string.
+	for name := range inList {
+		if !action.IsKnownName(action.Name(name)) {
+			t.Errorf("ModeActionNamesString() listed %q, which is not a known action name", name)
+		}
+	}
+}
+
+// TestPrimaryModifier_MatchesThePlatformAccelerator pins the platform's default
+// accelerator. Getting it backwards would make every default binding fire on
+// the wrong modifier — Control on macOS, Command on Linux and Windows.
+func TestPrimaryModifier_MatchesThePlatformAccelerator(t *testing.T) {
+	want := action.ModCtrl
+	if runtime.GOOS == "darwin" {
+		want = action.ModCmd
+	}
+
+	if got := action.PrimaryModifier(); got != want {
+		t.Errorf("PrimaryModifier() on %s = %v, want %v", runtime.GOOS, got, want)
+	}
+
+	// The two candidates must be distinct, or the assertion above proves
+	// nothing on either platform.
+	if action.ModCmd == action.ModCtrl {
+		t.Fatal("ModCmd and ModCtrl are equal; the platform assertion is vacuous")
+	}
+}

--- a/internal/core/domain/grid/grid.go
+++ b/internal/core/domain/grid/grid.go
@@ -147,6 +147,13 @@ func NewGridWithLabels(
 	bounds image.Rectangle,
 	logger *zap.Logger,
 ) *Grid {
+	// Constructors in this tree accept a nil logger and fall back to a no-op
+	// rather than panicking on first use. Without this the daemon dies with a
+	// nil dereference on any path that builds a grid before logging is wired.
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
 	logger.Debug("Creating new grid",
 		zap.String("characters", characters),
 		zap.String("rowLabels", rowLabels),
@@ -311,6 +318,20 @@ func NewGridWithLabels(
 		// Update totalCells to match the actual grid dimensions
 		totalCells = gridRows * gridCols //nolint:ineffassign,staticcheck,wastedassign // totalCells is used later in calculateLabelLength
 	}
+
+	// Cells are emitted region by region, and a region that runs off the right
+	// or bottom edge is clipped — its unused capacity is forfeited. With a large
+	// character set there are far more region prefixes than the grid needs, so
+	// that waste is invisible. With a small one the regions run out mid-grid and
+	// generateCellsWithRegions stops early, leaving screen area with no cell at
+	// all: a 4-character set on 1000x3000 lost the bottom ~430px entirely.
+	//
+	// Shrink the grid until the regions can actually reach every cell. This only
+	// binds for small character sets; the default 25-character alphabet has
+	// hundreds of spare prefixes and comes through untouched.
+	gridCols, gridRows = fitToAvailableRegions(
+		gridCols, gridRows, numChars, numRowChars, numColChars, labelLength,
+	)
 
 	// Calculate base cell sizes and remainders
 	baseCellWidth := width / gridCols
@@ -679,6 +700,82 @@ func calculateOptimalCellSizes(width, height int) (int, int) {
 }
 
 // calculateLabelLength determines the optimal label length based on total cells and available characters.
+// regionShape returns how many columns and rows one region spans, and how many
+// distinct region prefixes the label scheme provides.
+//
+// These must agree with generateCellsWithRegions: it derives the same shape
+// from labelLength and bounds its loop by the same prefix count.
+func regionShape(numChars, numRowChars, numColChars, labelLength int) (int, int, int) {
+	switch labelLength {
+	case LabelLength2:
+		// One region character, and a region is a single row of columns.
+		return numColChars, 1, numChars
+	case LabelLength3:
+		// One region character spanning a full column-by-row block.
+		return numColChars, numRowChars, numChars
+	default:
+		// Two region characters, so the prefix space is squared.
+		return numColChars, numRowChars, numChars * numChars
+	}
+}
+
+// regionsNeeded returns how many regions it takes to cover a gridCols x
+// gridRows grid, counting a clipped edge region as a whole one because that is
+// how the fill loop consumes them.
+func regionsNeeded(gridCols, gridRows, regionCols, regionRows int) int {
+	if regionCols < 1 || regionRows < 1 {
+		return 0
+	}
+
+	perBand := (gridCols + regionCols - 1) / regionCols
+	bands := (gridRows + regionRows - 1) / regionRows
+
+	return perBand * bands
+}
+
+// fitToAvailableRegions shrinks the grid until every cell can be reached by an
+// available region prefix.
+//
+// It trims whichever axis currently costs the most regions, so the grid stays
+// as close to the screen's aspect ratio as the prefix budget allows, and never
+// shrinks below the minimum usable grid.
+func fitToAvailableRegions(
+	gridCols, gridRows, numChars, numRowChars, numColChars, labelLength int,
+) (int, int) {
+	regionCols, regionRows, availablePrefixes := regionShape(
+		numChars, numRowChars, numColChars, labelLength,
+	)
+
+	if regionCols < 1 || regionRows < 1 || availablePrefixes < 1 {
+		return gridCols, gridRows
+	}
+
+	for regionsNeeded(gridCols, gridRows, regionCols, regionRows) > availablePrefixes {
+		canTrimCols := gridCols > MinGridCols
+		canTrimRows := gridRows > MinGridRows
+
+		if !canTrimCols && !canTrimRows {
+			// Already at the floor; the caller's dimensions are the best
+			// available even if some cells go unlabeled.
+			break
+		}
+
+		// Trim the axis spanning more regions, so the grid degrades evenly
+		// rather than collapsing into a stripe.
+		colBands := (gridCols + regionCols - 1) / regionCols
+		rowBands := (gridRows + regionRows - 1) / regionRows
+
+		switch {
+		case canTrimCols && (!canTrimRows || colBands >= rowBands):
+			gridCols--
+		default:
+			gridRows--
+		}
+	}
+
+	return gridCols, gridRows
+}
+
 func calculateLabelLength(totalCells, numChars, numRowChars, numColChars int) int {
 	// If custom row/col labels are provided (numRowChars/numColChars != numChars), use more labels
 	if numRowChars != numChars || numColChars != numChars {

--- a/internal/core/domain/grid/grid_invariants_test.go
+++ b/internal/core/domain/grid/grid_invariants_test.go
@@ -1,0 +1,414 @@
+package grid_test
+
+import (
+	"fmt"
+	"image"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/domain/grid"
+)
+
+// The grid is built by a geometry pass (splitting the screen into rows and
+// columns, distributing the leftover pixels) and a labeling pass (assigning a
+// coordinate to each cell). Both are arithmetic-heavy, and a single off-by-one
+// in either still produces a plausible-looking grid — cells exist, coordinates
+// look right — while leaving dead pixels the user cannot click, overlapping
+// cells that shadow each other, or duplicate coordinates.
+//
+// These tests assert the structural invariants that must hold for every grid,
+// rather than pinning specific numbers for one screen size.
+
+// gridSizes covers ordinary displays plus the extreme aspect ratios the cell
+// sizing has a special branch for, and sizes that do not divide evenly by the
+// cell count so the remainder-distribution path is exercised.
+func gridSizes() []image.Rectangle {
+	return []image.Rectangle{
+		image.Rect(0, 0, 1920, 1080),
+		image.Rect(0, 0, 1366, 768),
+		image.Rect(0, 0, 3840, 2160),
+		image.Rect(0, 0, 1080, 1920),    // portrait
+		image.Rect(0, 0, 5120, 1440),    // ultrawide
+		image.Rect(0, 0, 1000, 3000),    // extremely tall
+		image.Rect(0, 0, 1001, 733),     // prime-ish, forces remainders
+		image.Rect(100, 200, 1300, 950), // non-zero origin (secondary display)
+	}
+}
+
+func gridAlphabets() []string {
+	return []string{"ab", "abcd", "asdfghjkl", "abcdefghijklmnopqrstuvwxyz"}
+}
+
+func newTestGrid(bounds image.Rectangle, characters string) *grid.Grid {
+	return grid.NewGrid(characters, bounds, zap.NewNop())
+}
+
+func gridCaseName(bounds image.Rectangle, characters string) string {
+	return fmt.Sprintf("%dx%d@%d,%d/chars=%d",
+		bounds.Dx(), bounds.Dy(), bounds.Min.X, bounds.Min.Y, len(characters))
+}
+
+// TestGrid_CellsStayWithinBounds is the most basic geometric requirement: a
+// cell outside the screen cannot be clicked, and a cell that pokes past the
+// edge would place its center off-screen.
+func TestGrid_CellsStayWithinBounds(t *testing.T) {
+	for _, bounds := range gridSizes() {
+		for _, characters := range gridAlphabets() {
+			t.Run(gridCaseName(bounds, characters), func(t *testing.T) {
+				testGrid := newTestGrid(bounds, characters)
+
+				cells := testGrid.Cells()
+				if len(cells) == 0 {
+					t.Fatal("grid produced no cells")
+				}
+
+				for _, cell := range cells {
+					cellBounds := cell.Bounds()
+
+					if !cellBounds.In(bounds) {
+						t.Errorf("cell %q has bounds %v, outside the grid bounds %v",
+							cell.Coordinate(), cellBounds, bounds)
+					}
+
+					if cellBounds.Empty() {
+						t.Errorf("cell %q has empty bounds %v", cell.Coordinate(), cellBounds)
+					}
+
+					// The center is the point a click is dispatched to, so it
+					// has to be inside the cell it belongs to.
+					if center := cell.Center(); !center.In(cellBounds) {
+						t.Errorf("cell %q center %v lies outside its own bounds %v",
+							cell.Coordinate(), center, cellBounds)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestGrid_CellsTileTheBoundsExactly is the invariant that catches the leftover
+// pixel distribution. Rows and columns rarely divide the screen evenly, so the
+// remainder is spread one pixel at a time across the leading cells. If that
+// arithmetic drifts, adjacent cells either overlap (two labels claim the same
+// pixel) or leave a seam the user cannot target — neither of which changes the
+// cell count, so only a coverage check like this notices.
+func TestGrid_CellsTileTheBoundsExactly(t *testing.T) {
+	for _, bounds := range gridSizes() {
+		for _, characters := range gridAlphabets() {
+			t.Run(gridCaseName(bounds, characters), func(t *testing.T) {
+				cells := newTestGrid(bounds, characters).Cells()
+
+				coveredArea := assertCellsAbut(t, cells)
+
+				// Non-overlapping cells that abut in both directions and cover
+				// the full area can only be an exact tiling.
+				if wantArea := bounds.Dx() * bounds.Dy(); coveredArea != wantArea {
+					t.Errorf(
+						"cells cover %d square pixels, want %d (the grid must tile its bounds exactly)",
+						coveredArea,
+						wantArea,
+					)
+				}
+			})
+		}
+	}
+}
+
+// TestGrid_CellsNeverOverlapOrLeaveSeams is the weaker structural companion to
+// the tiling check: whatever cells exist must line up exactly, and the grid must
+// start at the bounds origin. Kept separate because it holds even for grids that
+// legitimately cannot cover the screen (a character set too small to address it).
+func TestGrid_CellsNeverOverlapOrLeaveSeams(t *testing.T) {
+	for _, bounds := range gridSizes() {
+		for _, characters := range gridAlphabets() {
+			t.Run(gridCaseName(bounds, characters), func(t *testing.T) {
+				cells := newTestGrid(bounds, characters).Cells()
+
+				coveredArea := assertCellsAbut(t, cells)
+
+				if coveredArea <= 0 {
+					t.Fatal("grid covers no area at all")
+				}
+
+				// Cells must start at the origin of the bounds; an offset grid
+				// would push the whole layout off the top-left of the screen.
+				minX, minY := cells[0].Bounds().Min.X, cells[0].Bounds().Min.Y
+				for _, cell := range cells {
+					minX = min(minX, cell.Bounds().Min.X)
+					minY = min(minY, cell.Bounds().Min.Y)
+				}
+
+				if minX != bounds.Min.X || minY != bounds.Min.Y {
+					t.Errorf("grid starts at (%d,%d), want the bounds origin (%d,%d)",
+						minX, minY, bounds.Min.X, bounds.Min.Y)
+				}
+			})
+		}
+	}
+}
+
+// assertCellsAbut checks that cells sharing a row abut horizontally and cells
+// sharing a column abut vertically, and returns the total area they cover.
+func assertCellsAbut(t *testing.T, cells []*grid.Cell) int {
+	t.Helper()
+
+	if len(cells) == 0 {
+		t.Fatal("grid produced no cells")
+	}
+
+	rows := make(map[int][]image.Rectangle)
+	columns := make(map[int][]image.Rectangle)
+
+	coveredArea := 0
+
+	for _, cell := range cells {
+		cellBounds := cell.Bounds()
+		rows[cellBounds.Min.Y] = append(rows[cellBounds.Min.Y], cellBounds)
+		columns[cellBounds.Min.X] = append(columns[cellBounds.Min.X], cellBounds)
+		coveredArea += cellBounds.Dx() * cellBounds.Dy()
+	}
+
+	assertStripsAbut(t, rows, true)
+	assertStripsAbut(t, columns, false)
+
+	return coveredArea
+}
+
+// assertStripsAbut checks that the rectangles in each strip, sorted along the
+// varying axis, touch edge-to-edge with no gap and no overlap.
+func assertStripsAbut(t *testing.T, strips map[int][]image.Rectangle, horizontal bool) {
+	t.Helper()
+
+	for key, strip := range strips {
+		sorted := make([]image.Rectangle, len(strip))
+		copy(sorted, strip)
+
+		// Insertion sort along the varying axis; strips are short.
+		for i := 1; i < len(sorted); i++ {
+			for j := i; j > 0 && startOf(sorted[j], horizontal) < startOf(sorted[j-1], horizontal); j-- {
+				sorted[j], sorted[j-1] = sorted[j-1], sorted[j]
+			}
+		}
+
+		for idx := 1; idx < len(sorted); idx++ {
+			prevEnd := endOf(sorted[idx-1], horizontal)
+			currStart := startOf(sorted[idx], horizontal)
+
+			if prevEnd != currStart {
+				axis := "row"
+				if !horizontal {
+					axis = "column"
+				}
+
+				t.Errorf(
+					"%s at %d: cell %v ends at %d but the next starts at %d (gap or overlap of %d px)",
+					axis,
+					key,
+					sorted[idx-1],
+					prevEnd,
+					currStart,
+					currStart-prevEnd,
+				)
+
+				break
+			}
+		}
+	}
+}
+
+func startOf(rect image.Rectangle, horizontal bool) int {
+	if horizontal {
+		return rect.Min.X
+	}
+
+	return rect.Min.Y
+}
+
+func endOf(rect image.Rectangle, horizontal bool) int {
+	if horizontal {
+		return rect.Max.X
+	}
+
+	return rect.Max.Y
+}
+
+// TestGrid_CoordinatesAreUniqueAndAddressable checks the labeling pass. Two
+// cells sharing a coordinate makes one of them permanently unreachable, and a
+// coordinate that does not resolve back to its own cell would send the click
+// somewhere else entirely.
+func TestGrid_CoordinatesAreUniqueAndAddressable(t *testing.T) {
+	for _, bounds := range gridSizes() {
+		for _, characters := range gridAlphabets() {
+			t.Run(gridCaseName(bounds, characters), func(t *testing.T) {
+				testGrid := newTestGrid(bounds, characters)
+
+				cells := testGrid.Cells()
+				seen := make(map[string]image.Rectangle, len(cells))
+
+				valid := testGrid.ValidCharacters()
+
+				for _, cell := range cells {
+					coordinate := cell.Coordinate()
+
+					if coordinate == "" {
+						t.Errorf("cell at %v has an empty coordinate", cell.Bounds())
+
+						continue
+					}
+
+					if previous, duplicate := seen[coordinate]; duplicate {
+						t.Errorf("coordinate %q is used by both %v and %v",
+							coordinate, previous, cell.Bounds())
+					}
+
+					seen[coordinate] = cell.Bounds()
+
+					// Every character in a coordinate must be typeable, i.e.
+					// reported by ValidCharacters — that set is what the input
+					// validator accepts, so a coordinate outside it could
+					// never be entered.
+					for _, char := range coordinate {
+						if !strings.ContainsRune(valid, char) {
+							t.Errorf(
+								"coordinate %q contains %q, which is not in ValidCharacters(%q)",
+								coordinate, string(char), valid,
+							)
+						}
+					}
+
+					// The coordinate must resolve back to this exact cell.
+					resolved := testGrid.CellByCoordinate(coordinate)
+					if resolved == nil {
+						t.Errorf("CellByCoordinate(%q) returned nil", coordinate)
+
+						continue
+					}
+
+					if resolved != cell {
+						t.Errorf("CellByCoordinate(%q) resolved to the cell at %v, want %v",
+							coordinate, resolved.Bounds(), cell.Bounds())
+					}
+				}
+
+				if len(testGrid.Index()) != len(cells) {
+					t.Errorf("index holds %d entries for %d cells",
+						len(testGrid.Index()), len(cells))
+				}
+			})
+		}
+	}
+}
+
+// TestGrid_CoordinateLengthIsUniform pins that every coordinate in a grid has
+// the same length. The input handler completes a selection once the user has
+// typed labelLength characters, so a grid mixing 2- and 3-character coordinates
+// would fire on the wrong cell partway through a longer label.
+func TestGrid_CoordinateLengthIsUniform(t *testing.T) {
+	for _, bounds := range gridSizes() {
+		for _, characters := range gridAlphabets() {
+			t.Run(gridCaseName(bounds, characters), func(t *testing.T) {
+				testGrid := newTestGrid(bounds, characters)
+
+				cells := testGrid.Cells()
+				if len(cells) == 0 {
+					t.Fatal("grid produced no cells")
+				}
+
+				want := len(cells[0].Coordinate())
+
+				if want < grid.LabelLength2 || want > grid.LabelLength4 {
+					t.Errorf("coordinate length %d is outside the supported range %d..%d",
+						want, grid.LabelLength2, grid.LabelLength4)
+				}
+
+				for _, cell := range cells {
+					if got := len(cell.Coordinate()); got != want {
+						t.Errorf("cell %q has a %d-character coordinate, want %d for every cell",
+							cell.Coordinate(), got, want)
+					}
+				}
+
+				// The label must be long enough to address every cell: with
+				// numChars characters, a label of length L can name at most
+				// numChars^L cells.
+				capacity := 1
+				for range want {
+					capacity *= len(characters)
+				}
+
+				if len(cells) > capacity {
+					t.Errorf(
+						"grid has %d cells but a %d-character label over %d characters addresses only %d",
+						len(cells),
+						want,
+						len(characters),
+						capacity,
+					)
+				}
+			})
+		}
+	}
+}
+
+// TestGrid_NilLoggerIsAccepted pins the constructor convention every other
+// constructor in this tree follows: a nil logger falls back to a no-op instead
+// of panicking. This is reachable in production from any path that builds a
+// grid before logging is wired, and the panic takes the daemon down.
+func TestGrid_NilLoggerIsAccepted(t *testing.T) {
+	testGrid := grid.NewGrid("abc", image.Rect(0, 0, 400, 300), nil)
+	if testGrid == nil {
+		t.Fatal("NewGrid with a nil logger returned nil")
+	}
+
+	if len(testGrid.Cells()) == 0 {
+		t.Error("NewGrid with a nil logger produced no cells")
+	}
+
+	withLabels := grid.NewGridWithLabels("abc", "ab", "bc", image.Rect(0, 0, 400, 300), nil)
+	if withLabels == nil {
+		t.Fatal("NewGridWithLabels with a nil logger returned nil")
+	}
+
+	if len(withLabels.Cells()) == 0 {
+		t.Error("NewGridWithLabels with a nil logger produced no cells")
+	}
+}
+
+// TestGrid_HasCoordinatePrefixMatchesRealPrefixes checks the prefix index the
+// input handler consults on every keystroke to decide whether the partial input
+// can still lead anywhere. A false negative rejects a valid keystroke; a false
+// positive leaves the user in a dead end.
+func TestGrid_HasCoordinatePrefixMatchesRealPrefixes(t *testing.T) {
+	testGrid := newTestGrid(image.Rect(0, 0, 1920, 1080), "asdfghjkl")
+
+	cells := testGrid.Cells()
+	if len(cells) == 0 {
+		t.Fatal("grid produced no cells")
+	}
+
+	// Every genuine prefix of every coordinate must be reported.
+	realPrefixes := make(map[string]bool)
+
+	for _, cell := range cells {
+		coordinate := cell.Coordinate()
+		for idx := 1; idx <= len(coordinate); idx++ {
+			realPrefixes[coordinate[:idx]] = true
+		}
+	}
+
+	for prefix := range realPrefixes {
+		if !testGrid.HasCoordinatePrefix(prefix) {
+			t.Errorf("HasCoordinatePrefix(%q) = false, but a coordinate starts with it", prefix)
+		}
+	}
+
+	// And a prefix no coordinate starts with must be rejected. "ZZ" cannot
+	// occur: Z is not in the alphabet above.
+	for _, absent := range []string{"Z", "ZZ", "ZZZ"} {
+		if testGrid.HasCoordinatePrefix(absent) {
+			t.Errorf("HasCoordinatePrefix(%q) = true, but no coordinate starts with it", absent)
+		}
+	}
+}

--- a/internal/core/domain/grid/manager_test.go
+++ b/internal/core/domain/grid/manager_test.go
@@ -92,10 +92,25 @@ func TestGridManager_RouterIntegration(t *testing.T) {
 			t.Error("Expected not complete on escape")
 		}
 
-		// Test tab key - should handle subgrid navigation
+		// Tab is not one of the grid's coordinate characters and no subgrid is
+		// active here, so it must be rejected outright: no completion, and —
+		// just as important — no effect on the coordinate input the user has
+		// typed so far. An unmapped key that silently landed in the input
+		// buffer would desynchronise the overlay from the manager.
+		beforeInput := gridManager.CurrentInput()
+
 		resultTab := gridRouter.RouteKey("\t")
-		// Tab behavior depends on subgrid state, just ensure it doesn't crash
-		_ = resultTab
+
+		if resultTab.Complete() {
+			t.Errorf(
+				"Expected tab not to complete a selection, got target %v",
+				resultTab.TargetPoint(),
+			)
+		}
+
+		if got := gridManager.CurrentInput(); got != beforeInput {
+			t.Errorf("tab changed the coordinate input from %q to %q", beforeInput, got)
+		}
 	})
 }
 

--- a/internal/core/domain/hint/generator_boundary_test.go
+++ b/internal/core/domain/hint/generator_boundary_test.go
@@ -1,0 +1,300 @@
+package hint_test
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+	"github.com/y3owk1n/neru/internal/core/domain/hint"
+)
+
+// TestNewAlphabetGenerator_CharacterCountBoundary pins the accept/reject edge of
+// the character-set length check. Exactly MinCharactersLength characters is the
+// smallest usable alphabet — a two-character set still produces a prefix-free
+// labeling — so it must be accepted, and one fewer must be rejected. An
+// off-by-one here either locks users out of a valid config or admits a
+// single-character set that cannot generate distinct labels at all.
+func TestNewAlphabetGenerator_CharacterCountBoundary(t *testing.T) {
+	tests := []struct {
+		name       string
+		characters string
+		wantErr    bool
+	}{
+		{"one below the minimum is rejected", "a", true},
+		{"empty is rejected", "", true},
+		{"exactly the minimum is accepted", "ab", false},
+		{"one above the minimum is accepted", "abc", false},
+	}
+
+	if hint.MinCharactersLength != 2 {
+		t.Fatalf(
+			"this test's fixtures assume MinCharactersLength == 2, got %d",
+			hint.MinCharactersLength,
+		)
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			generator, err := hint.NewAlphabetGenerator(
+				testCase.characters,
+				hint.LabelDirectionReverse,
+			)
+
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatalf("NewAlphabetGenerator(%q) error = nil, want an error",
+						testCase.characters)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("NewAlphabetGenerator(%q) error = %v, want nil",
+					testCase.characters, err)
+			}
+
+			// An accepted generator must actually be able to label elements.
+			if labels := generator.LabelsForTesting(4); len(labels) != 4 {
+				t.Errorf("LabelsForTesting(4) returned %d labels, want 4", len(labels))
+			}
+		})
+	}
+}
+
+// TestAlphabetGenerator_UpdateCharacterCountBoundary applies the same boundary
+// to the reload path. Update runs on config reload with user-supplied input, so
+// it has to reject a too-small set rather than leaving the generator in a state
+// that cannot produce distinct labels.
+func TestAlphabetGenerator_UpdateCharacterCountBoundary(t *testing.T) {
+	generator, err := hint.NewAlphabetGenerator("abcdef", hint.LabelDirectionReverse)
+	if err != nil {
+		t.Fatalf("NewAlphabetGenerator: %v", err)
+	}
+
+	err = generator.UpdateCharacters("a")
+	if err == nil {
+		t.Error(`UpdateCharacters("a") error = nil, want an error for a one-character set`)
+	}
+
+	// A rejected update must not have taken effect.
+	if got := generator.Characters(); !strings.EqualFold(got, "abcdef") {
+		t.Errorf("Characters() = %q after a rejected update, want the original set", got)
+	}
+
+	err = generator.UpdateCharacters("xy")
+	if err != nil {
+		t.Errorf(`UpdateCharacters("xy") error = %v, want nil for a minimum-size set`, err)
+	}
+
+	if got := generator.Characters(); !strings.EqualFold(got, "xy") {
+		t.Errorf("Characters() = %q after an accepted update, want %q", got, "xy")
+	}
+}
+
+// TestAlphabetGenerator_Generate_AssignsLabelsInReadingOrder pins the element
+// ordering. Labels are handed out in sorted order, so the sort comparator
+// decides which element gets the shortest / earliest label. Users navigate by
+// position, so top-to-bottom then left-to-right is the contract; a comparator
+// that comparedeither axis alone, or compared X before Y, would scramble it.
+func TestAlphabetGenerator_Generate_AssignsLabelsInReadingOrder(t *testing.T) {
+	generator, err := hint.NewAlphabetGenerator("abcdefghij", hint.LabelDirectionReverse)
+	if err != nil {
+		t.Fatalf("NewAlphabetGenerator: %v", err)
+	}
+
+	// Deliberately supplied out of order, and laid out so that sorting by X
+	// alone, or by Y alone, produces a different sequence than reading order.
+	type placed struct {
+		id   string
+		x, y int
+	}
+
+	input := []placed{
+		{"row2-right", 300, 200},
+		{"row1-right", 300, 100},
+		{"row2-left", 100, 200},
+		{"row1-left", 100, 100},
+		{"row1-middle", 200, 100},
+	}
+
+	elements := make([]*element.Element, 0, len(input))
+
+	for _, spec := range input {
+		created, elemErr := element.NewElement(
+			element.ID(spec.id),
+			image.Rect(spec.x, spec.y, spec.x+50, spec.y+20),
+			element.RoleButton,
+		)
+		if elemErr != nil {
+			t.Fatalf("NewElement(%s): %v", spec.id, elemErr)
+		}
+
+		elements = append(elements, created)
+	}
+
+	hints, err := generator.Generate(context.Background(), elements)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if len(hints) != len(elements) {
+		t.Fatalf("Generate returned %d hints, want %d", len(hints), len(elements))
+	}
+
+	wantOrder := []string{"row1-left", "row1-middle", "row1-right", "row2-left", "row2-right"}
+
+	gotOrder := make([]string, 0, len(hints))
+	for _, generated := range hints {
+		gotOrder = append(gotOrder, string(generated.Element().ID()))
+	}
+
+	if !slices.Equal(gotOrder, wantOrder) {
+		t.Errorf("elements labeled in order %v, want reading order %v", gotOrder, wantOrder)
+	}
+}
+
+// TestAlphabetGenerator_Generate_LabelsArePrefixFreeAndUnique is the invariant
+// the whole level-allocation algorithm exists to preserve: no label may be a
+// prefix of another, or typing the shorter one could never be resolved without
+// an extra keystroke, and no two elements may share a label.
+//
+// The counts are swept across the points where the algorithm rolls over to a
+// new label length, which is exactly where an off-by-one in the slot arithmetic
+// shows up.
+func TestAlphabetGenerator_Generate_LabelsArePrefixFreeAndUnique(t *testing.T) {
+	for _, characters := range []string{"ab", "abc", "asdfghjkl"} {
+		numChars := len(characters)
+
+		// Sweep around each level rollover: numChars, numChars^2, numChars^3.
+		counts := map[int]bool{1: true}
+		for capacity := numChars; capacity <= numChars*numChars*numChars; capacity *= numChars {
+			for _, delta := range []int{-1, 0, 1, 2} {
+				if capacity+delta > 0 {
+					counts[capacity+delta] = true
+				}
+			}
+		}
+
+		ordered := make([]int, 0, len(counts))
+		for count := range counts {
+			ordered = append(ordered, count)
+		}
+
+		slices.Sort(ordered)
+
+		for _, direction := range []hint.LabelDirection{
+			hint.LabelDirectionReverse,
+			hint.LabelDirectionNormal,
+		} {
+			generator, err := hint.NewAlphabetGenerator(characters, direction)
+			if err != nil {
+				t.Fatalf("NewAlphabetGenerator(%q): %v", characters, err)
+			}
+
+			maxHints := generator.MaxHints()
+
+			for _, count := range ordered {
+				if count > maxHints {
+					continue
+				}
+
+				t.Run(labelCaseName(characters, direction, count), func(t *testing.T) {
+					labels := generator.LabelsForTesting(count)
+
+					if len(labels) != count {
+						t.Fatalf("got %d labels, want %d", len(labels), count)
+					}
+
+					assertLabelsUniqueAndPrefixFree(t, labels)
+					assertLabelsNoLongerThanNecessary(t, labels, numChars, count)
+				})
+			}
+		}
+	}
+}
+
+// assertLabelsUniqueAndPrefixFree checks the two properties the hint router
+// depends on: labels are distinct, and none is a prefix of another.
+func assertLabelsUniqueAndPrefixFree(t *testing.T, labels []string) {
+	t.Helper()
+
+	seen := make(map[string]int, len(labels))
+
+	for idx, label := range labels {
+		if label == "" {
+			t.Errorf("label %d is empty", idx)
+
+			continue
+		}
+
+		if prev, dup := seen[label]; dup {
+			t.Errorf("labels %d and %d are both %q", prev, idx, label)
+		}
+
+		seen[label] = idx
+	}
+
+	sorted := slices.Clone(labels)
+	slices.Sort(sorted)
+
+	// After sorting, a label can only be a prefix of its immediate successors,
+	// so a single adjacent scan is enough.
+	for idx := 1; idx < len(sorted); idx++ {
+		if strings.HasPrefix(sorted[idx], sorted[idx-1]) {
+			t.Errorf("label %q is a prefix of %q; typing the former could never resolve",
+				sorted[idx-1], sorted[idx])
+		}
+	}
+}
+
+// assertLabelsNoLongerThanNecessary pins the efficiency the level-allocation
+// algorithm exists to deliver: label length is keystrokes, so no label may be
+// longer than the shortest fixed length that could address `count` elements
+// with `numChars` characters. A greedy step that keeps one slot too few (or too
+// many) at some level still yields unique, prefix-free labels — the property
+// checked above — but spills into an extra level and costs the user a keystroke
+// on every hint. That regression is only visible here.
+func assertLabelsNoLongerThanNecessary(t *testing.T, labels []string, numChars, count int) {
+	t.Helper()
+
+	// Smallest L with numChars^L >= count.
+	minimalLength := 1
+	for capacity := numChars; capacity < count; capacity *= numChars {
+		minimalLength++
+	}
+
+	longest := 0
+	longestLabel := ""
+
+	for _, label := range labels {
+		if length := len([]rune(label)); length > longest {
+			longest = length
+			longestLabel = label
+		}
+	}
+
+	if longest > minimalLength {
+		t.Errorf(
+			"longest label %q is %d characters; %d elements over a %d-character alphabet need at most %d",
+			longestLabel,
+			longest,
+			count,
+			numChars,
+			minimalLength,
+		)
+	}
+}
+
+func labelCaseName(characters string, direction hint.LabelDirection, count int) string {
+	name := "normal"
+	if direction == hint.LabelDirectionReverse {
+		name = "reverse"
+	}
+
+	return fmt.Sprintf("chars=%s/dir=%s/count=%d", characters, name, count)
+}

--- a/internal/core/domain/hint/manager_dispatch_test.go
+++ b/internal/core/domain/hint/manager_dispatch_test.go
@@ -1,0 +1,432 @@
+package hint_test
+
+import (
+	"image"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+	"github.com/y3owk1n/neru/internal/core/domain/hint"
+	"github.com/y3owk1n/neru/internal/core/infra/logger"
+)
+
+// updateRecorder captures how the manager delivered each hint update. The
+// distinction that matters is *when* onUpdate ran: immediateUpdate calls it
+// synchronously inside HandleInput, debouncedUpdate schedules it on a timer.
+type updateRecorder struct {
+	mu sync.Mutex
+
+	// synchronous counts callbacks that arrived while inCall was set.
+	synchronous int
+	// asynchronous counts callbacks that arrived after the call returned,
+	// i.e. ones delivered by the debounce timer.
+	asynchronous int
+	inCall       bool
+	// lastCount is the number of hints carried by the most recent callback.
+	lastCount int
+	async     chan struct{}
+}
+
+func newUpdateRecorder() *updateRecorder {
+	return &updateRecorder{async: make(chan struct{}, 16)}
+}
+
+func (r *updateRecorder) callback(hints []*hint.Interface) {
+	r.mu.Lock()
+	r.lastCount = len(hints)
+
+	if r.inCall {
+		r.synchronous++
+		r.mu.Unlock()
+
+		return
+	}
+
+	r.asynchronous++
+	r.mu.Unlock()
+
+	// Only debounced deliveries are signaled, so a waiter can never be woken
+	// by a stale token left behind by a synchronous callback.
+	select {
+	case r.async <- struct{}{}:
+	default:
+	}
+}
+
+// counts returns the recorded synchronous and asynchronous callback totals.
+func (r *updateRecorder) counts() (int, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.synchronous, r.asynchronous
+}
+
+// lastHintCount returns how many hints the most recent callback carried.
+func (r *updateRecorder) lastHintCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.lastCount
+}
+
+// during runs fn with the synchronous window marked, so a callback delivered
+// inside fn is distinguishable from one delivered by the debounce timer.
+func (r *updateRecorder) during(fn func()) {
+	r.mu.Lock()
+	r.inCall = true
+	r.mu.Unlock()
+
+	fn()
+
+	r.mu.Lock()
+	r.inCall = false
+	r.mu.Unlock()
+}
+
+// handleInput runs one keystroke with the recorder marking the synchronous
+// window, so a callback delivered inside the call is distinguishable from one
+// delivered by the debounce timer afterwards.
+func (r *updateRecorder) handleInput(
+	tb testing.TB,
+	manager *hint.Manager,
+	key string,
+) (*hint.Interface, bool) {
+	tb.Helper()
+
+	var (
+		match *hint.Interface
+		found bool
+		err   error
+	)
+
+	r.during(func() {
+		match, found, err = manager.HandleInput(key)
+	})
+
+	if err != nil {
+		tb.Fatalf("HandleInput(%q): %v", key, err)
+	}
+
+	return match, found
+}
+
+// backspace runs HandleBackspace inside the synchronous window.
+func (r *updateRecorder) backspace(tb testing.TB, manager *hint.Manager) {
+	tb.Helper()
+
+	var err error
+
+	r.during(func() {
+		err = manager.HandleBackspace()
+	})
+
+	if err != nil {
+		tb.Fatalf("HandleBackspace: %v", err)
+	}
+}
+
+// newDispatchManager wires a manager over the given labels, with an external
+// mutex (required by immediateUpdate) already held by the caller. The returned
+// unlock function releases it.
+func newDispatchManager(
+	tb testing.TB,
+	labels ...string,
+) (*hint.Manager, *updateRecorder, *sync.Mutex) {
+	tb.Helper()
+
+	elem, err := element.NewElement(element.ID("1"), image.Rect(0, 0, 10, 10), element.RoleButton)
+	if err != nil {
+		tb.Fatalf("NewElement: %v", err)
+	}
+
+	interfaces := make([]*hint.Interface, 0, len(labels))
+
+	for _, label := range labels {
+		created, hintErr := hint.NewHint(label, elem, image.Point{})
+		if hintErr != nil {
+			tb.Fatalf("NewHint(%q): %v", label, hintErr)
+		}
+
+		interfaces = append(interfaces, created)
+	}
+
+	mut := &sync.Mutex{}
+	manager := hint.NewManager(logger.Get(), mut)
+	recorder := newUpdateRecorder()
+
+	manager.SetUpdateCallback(recorder.callback)
+
+	mut.Lock()
+
+	recorder.during(func() {
+		err = manager.SetHints(hint.NewCollection(interfaces))
+	})
+
+	if err != nil {
+		mut.Unlock()
+		tb.Fatalf("SetHints: %v", err)
+	}
+
+	return manager, recorder, mut
+}
+
+// TestManager_HandleInput_UpdateDispatchFollowsHintCount pins the heuristic
+// that decides between a synchronous repaint and a debounced one: when the
+// filtered hint count is unchanged only text colors move, so the update is
+// immediate; when the count changes the overlay has to restructure, so the
+// update is debounced to batch redraws.
+//
+// Getting this backwards is invisible to a count-only assertion — the callback
+// still runs, just at the wrong time — which is why this test distinguishes
+// callbacks delivered inside HandleInput from ones delivered by the timer.
+func TestManager_HandleInput_UpdateDispatchFollowsHintCount(t *testing.T) {
+	// AAA and AAB share the "AA" prefix, ABC diverges at the second character,
+	// so typing A -> A narrows 3 -> 3 -> 2.
+	manager, recorder, mut := newDispatchManager(t, "AAA", "AAB", "ABC")
+	defer mut.Unlock()
+
+	// SetHints itself delivers one update.
+	syncBefore, asyncBefore := recorder.counts()
+
+	// First "A" matches all three: the count is unchanged, so this must be an
+	// immediate, synchronous repaint.
+	if _, found := recorder.handleInput(t, manager, "A"); found {
+		t.Fatal(`HandleInput("A") reported an exact match, want none`)
+	}
+
+	gotSync, gotAsync := recorder.counts()
+
+	if gotSync != syncBefore+1 {
+		t.Errorf(
+			"unchanged hint count: got %d synchronous updates, want %d (the repaint must not be debounced)",
+			gotSync-syncBefore,
+			1,
+		)
+	}
+
+	if gotAsync != asyncBefore {
+		t.Errorf(
+			"unchanged hint count delivered %d asynchronous updates, want 0",
+			gotAsync-asyncBefore,
+		)
+	}
+
+	// Second "A" narrows 3 -> 2: a structural change, so it must be debounced
+	// rather than delivered inside the call.
+	syncBefore, asyncBefore = recorder.counts()
+
+	if _, found := recorder.handleInput(t, manager, "A"); found {
+		t.Fatal(`HandleInput("AA") reported an exact match, want none`)
+	}
+
+	gotSync, _ = recorder.counts()
+
+	if gotSync != syncBefore {
+		t.Errorf(
+			"changed hint count delivered %d synchronous updates, want 0 (the restructure must be debounced)",
+			gotSync-syncBefore,
+		)
+	}
+
+	// Release the external mutex so the debounce timer's callback can take it,
+	// then wait for the deferred update to actually arrive.
+	mut.Unlock()
+
+	select {
+	case <-recorder.async:
+	case <-time.After(2 * time.Second):
+		mut.Lock()
+		t.Fatal("debounced update never fired")
+	}
+
+	mut.Lock()
+
+	if _, gotAsync = recorder.counts(); gotAsync != asyncBefore+1 {
+		t.Errorf("got %d asynchronous updates, want 1", gotAsync-asyncBefore)
+	}
+
+	// The deferred update must carry the narrowed set, not the pre-keystroke one.
+	if got := recorder.lastHintCount(); got != 2 {
+		t.Errorf("debounced update carried %d hints, want the narrowed set of 2", got)
+	}
+}
+
+// TestManager_HandleInput_ExactMatchRequiresUniqueAndEqualLabel pins both
+// halves of the exact-match condition. A hint is selected only when the input
+// has narrowed to exactly one hint *and* that hint's label equals the input in
+// full. Relaxing either half would fire a click on the wrong element, or on a
+// still-ambiguous one.
+func TestManager_HandleInput_ExactMatchRequiresUniqueAndEqualLabel(t *testing.T) {
+	t.Run("unique hint whose label equals the input matches", func(t *testing.T) {
+		manager, recorder, mut := newDispatchManager(t, "AA", "BB")
+		defer mut.Unlock()
+
+		recorder.handleInput(t, manager, "A")
+
+		match, found := recorder.handleInput(t, manager, "A")
+		if !found {
+			t.Fatal("typing the full label of the only remaining hint did not match")
+		}
+
+		if match == nil || match.Label() != "AA" {
+			t.Errorf("matched %v, want the hint labeled AA", match)
+		}
+	})
+
+	t.Run("input equal to a label but still ambiguous does not match", func(t *testing.T) {
+		// "AA" is a prefix of "AAB", so after typing "AA" two hints remain.
+		// The first of them has the label "AA", which is exactly the input —
+		// but the set has not been narrowed to one, so this must not select.
+		manager, recorder, mut := newDispatchManager(t, "AA", "AAB")
+		defer mut.Unlock()
+
+		recorder.handleInput(t, manager, "A")
+
+		match, found := recorder.handleInput(t, manager, "A")
+		if found {
+			t.Errorf(
+				"input %q selected %v while another hint still shares that prefix; selection must be unambiguous",
+				"AA",
+				match,
+			)
+		}
+	})
+
+	t.Run("unique hint whose label is longer than the input does not match", func(t *testing.T) {
+		// After "AA" only "AAB" remains — a unique hint, but the user has not
+		// finished typing its label, so nothing may be selected yet.
+		manager, recorder, mut := newDispatchManager(t, "AAB", "BBB")
+		defer mut.Unlock()
+
+		recorder.handleInput(t, manager, "A")
+
+		match, found := recorder.handleInput(t, manager, "A")
+		if found {
+			t.Errorf(
+				"input %q selected %v before its full label was typed",
+				"AA", match,
+			)
+		}
+
+		// Completing the label does select it.
+		match, found = recorder.handleInput(t, manager, "B")
+		if !found {
+			t.Fatal("completing the label of the only remaining hint did not match")
+		}
+
+		if match == nil || match.Label() != "AAB" {
+			t.Errorf("matched %v, want the hint labeled AAB", match)
+		}
+	})
+}
+
+// TestManager_HandleBackspace_OnEmptyInputResetsToFullSet covers the guard on
+// the backspace path. Backspace is reachable before any character has been
+// typed (the user opens hints and immediately presses it), where slicing the
+// input would panic; the documented behavior is instead to reset and re-show
+// the full hint set. Repeating it must stay stable rather than drifting.
+func TestManager_HandleBackspace_OnEmptyInputResetsToFullSet(t *testing.T) {
+	manager, recorder, mut := newDispatchManager(t, "AA", "AB", "AC")
+	defer mut.Unlock()
+
+	syncBefore, asyncBefore := recorder.counts()
+
+	// Several times, to also cover backspacing past the start of the input.
+	for range 3 {
+		recorder.backspace(t, manager)
+
+		if got := manager.CurrentInput(); got != "" {
+			t.Fatalf("CurrentInput() = %q after backspacing empty input, want %q", got, "")
+		}
+
+		if got := recorder.lastHintCount(); got != 3 {
+			t.Errorf("backspace on empty input re-showed %d hints, want the full set of 3", got)
+		}
+	}
+
+	gotSync, gotAsync := recorder.counts()
+
+	// Each reset delivers its update synchronously; none may be deferred to a
+	// timer, or the overlay would briefly keep showing a stale filtered set.
+	if gotSync != syncBefore+3 {
+		t.Errorf("got %d synchronous updates from 3 backspaces, want 3", gotSync-syncBefore)
+	}
+
+	if gotAsync != asyncBefore {
+		t.Errorf("backspace on empty input deferred %d updates, want 0", gotAsync-asyncBefore)
+	}
+}
+
+// TestManager_HandleBackspace_RestoresWiderHintSet checks the inverse of the
+// narrowing path: removing a character must widen the filtered set back out and
+// clear the matched prefix, or the overlay keeps highlighting a prefix the user
+// has already deleted.
+func TestManager_HandleBackspace_RestoresWiderHintSet(t *testing.T) {
+	manager, recorder, mut := newDispatchManager(t, "AAA", "AAB", "ABC")
+	defer mut.Unlock()
+
+	recorder.handleInput(t, manager, "A")
+	recorder.handleInput(t, manager, "A")
+
+	if got := manager.CurrentInput(); got != "AA" {
+		t.Fatalf("CurrentInput() = %q, want %q", got, "AA")
+	}
+
+	// Backspacing "AA" -> "A" widens the filtered set from 2 back to 3. That is
+	// a structural change, so — exactly as on the typing path — it must be
+	// debounced rather than delivered inside the call.
+	syncBefore, asyncBefore := recorder.counts()
+
+	recorder.backspace(t, manager)
+
+	if got := manager.CurrentInput(); got != "A" {
+		t.Errorf("CurrentInput() = %q after one backspace, want %q", got, "A")
+	}
+
+	gotSync, _ := recorder.counts()
+
+	if gotSync != syncBefore {
+		t.Errorf(
+			"widening backspace delivered %d synchronous updates, want 0 (the restructure must be debounced)",
+			gotSync-syncBefore,
+		)
+	}
+
+	mut.Unlock()
+
+	select {
+	case <-recorder.async:
+	case <-time.After(2 * time.Second):
+		mut.Lock()
+		t.Fatal("debounced update never fired after a widening backspace")
+	}
+
+	mut.Lock()
+
+	if _, gotAsync := recorder.counts(); gotAsync != asyncBefore+1 {
+		t.Errorf("got %d asynchronous updates after backspace, want 1", gotAsync-asyncBefore)
+	}
+
+	if got := recorder.lastHintCount(); got != 3 {
+		t.Errorf("backspace re-showed %d hints, want the widened set of 3", got)
+	}
+
+	// Backspacing "A" -> "" keeps the set at 3 (everything already matched the
+	// single-character prefix), so this one is only a color repaint and must
+	// be delivered immediately.
+	syncBefore, _ = recorder.counts()
+
+	recorder.backspace(t, manager)
+
+	if got := manager.CurrentInput(); got != "" {
+		t.Errorf("CurrentInput() = %q after two backspaces, want %q", got, "")
+	}
+
+	if gotSync, _ = recorder.counts(); gotSync != syncBefore+1 {
+		t.Errorf(
+			"unchanged-count backspace delivered %d synchronous updates, want 1",
+			gotSync-syncBefore,
+		)
+	}
+}

--- a/internal/core/domain/recursivegrid/bounds_guard_test.go
+++ b/internal/core/domain/recursivegrid/bounds_guard_test.go
@@ -1,0 +1,216 @@
+package recursivegrid_test
+
+import (
+	"image"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/domain/recursivegrid"
+)
+
+// Cell indices reach these methods straight from a keypress: the key-to-cell
+// map is built from user-configurable key strings, and a stale or mismatched
+// layout override can yield an index outside the current depth's cell list.
+// Every accessor therefore guards the index and falls back to the current
+// bounds rather than indexing out of range.
+//
+// The guards were untested, which is the dangerous combination: an inverted
+// comparison in one of them turns a mistyped key into a panic that takes the
+// daemon down, and the tests would not have noticed.
+
+// outOfRangeCells returns indices that must always be rejected for a grid whose
+// current depth has cellCount cells.
+func outOfRangeCells(cellCount int) []recursivegrid.Cell {
+	return []recursivegrid.Cell{
+		recursivegrid.Cell(-1),
+		recursivegrid.Cell(-100),
+		recursivegrid.Cell(cellCount),
+		recursivegrid.Cell(cellCount + 1),
+		recursivegrid.Cell(cellCount * 10),
+	}
+}
+
+func newGuardGrid() *recursivegrid.RecursiveGrid {
+	return recursivegrid.NewRecursiveGrid(image.Rect(0, 0, 800, 600), 10, 10, 5)
+}
+
+// TestRecursiveGrid_CellCenter_RejectsOutOfRangeCells pins the documented
+// fallback: an index outside the cell list yields the center of the current
+// bounds, and never panics.
+func TestRecursiveGrid_CellCenter_RejectsOutOfRangeCells(t *testing.T) {
+	grid := newGuardGrid()
+	cellCount := len(grid.Divide())
+
+	if cellCount == 0 {
+		t.Fatal("grid divided into no cells")
+	}
+
+	want := grid.CurrentCenter()
+
+	for _, cell := range outOfRangeCells(cellCount) {
+		if got := grid.CellCenter(cell); got != want {
+			t.Errorf("CellCenter(%d) = %v, want the current center %v", cell, got, want)
+		}
+	}
+
+	// Every in-range index must instead return a point inside that cell — the
+	// guard must not be so eager that it swallows valid selections.
+	cells := grid.Divide()
+	for idx, bounds := range cells {
+		center := grid.CellCenter(recursivegrid.Cell(idx))
+		if !center.In(bounds) {
+			t.Errorf("CellCenter(%d) = %v, outside that cell's bounds %v", idx, center, bounds)
+		}
+	}
+}
+
+// TestRecursiveGrid_CellBounds_RejectsOutOfRangeCells covers the rendering
+// path's guard. A bad index here would draw the highlight over uninitialized
+// memory-derived coordinates rather than the current region.
+func TestRecursiveGrid_CellBounds_RejectsOutOfRangeCells(t *testing.T) {
+	grid := newGuardGrid()
+	cellCount := len(grid.Divide())
+
+	want := grid.CurrentBounds()
+
+	for _, cell := range outOfRangeCells(cellCount) {
+		if got := grid.CellBounds(cell); got != want {
+			t.Errorf("CellBounds(%d) = %v, want the current bounds %v", cell, got, want)
+		}
+	}
+
+	for idx, bounds := range grid.Divide() {
+		if got := grid.CellBounds(recursivegrid.Cell(idx)); got != bounds {
+			t.Errorf("CellBounds(%d) = %v, want %v", idx, got, bounds)
+		}
+	}
+}
+
+// TestRecursiveGrid_SelectCell_RejectsOutOfRangeCells covers the selection
+// guard, which additionally reports completion so the caller exits the mode
+// rather than waiting for more input it will never be able to use.
+func TestRecursiveGrid_SelectCell_RejectsOutOfRangeCells(t *testing.T) {
+	for _, cell := range outOfRangeCells(len(newGuardGrid().Divide())) {
+		grid := newGuardGrid()
+		wantPoint := grid.CurrentCenter()
+		wantBounds := grid.CurrentBounds()
+		wantDepth := grid.CurrentDepth()
+
+		got, complete := grid.SelectCell(cell)
+
+		if got != wantPoint {
+			t.Errorf("SelectCell(%d) point = %v, want the current center %v", cell, got, wantPoint)
+		}
+
+		if !complete {
+			t.Errorf("SelectCell(%d) complete = false, want true", cell)
+		}
+
+		// An invalid selection must not descend: the bounds and depth have to
+		// be exactly where they were, or a later backtrack unwinds to the
+		// wrong ancestor.
+		if grid.CurrentBounds() != wantBounds {
+			t.Errorf("SelectCell(%d) changed bounds to %v, want %v unchanged",
+				cell, grid.CurrentBounds(), wantBounds)
+		}
+
+		if grid.CurrentDepth() != wantDepth {
+			t.Errorf("SelectCell(%d) changed depth to %d, want %d unchanged",
+				cell, grid.CurrentDepth(), wantDepth)
+		}
+	}
+}
+
+// TestRecursiveGrid_SelectCell_ValidCellDescends is the counterpart: the guard
+// must not reject the boundary indices 0 and cellCount-1, which an off-by-one
+// in either comparison would.
+func TestRecursiveGrid_SelectCell_ValidCellDescends(t *testing.T) {
+	cellCount := len(newGuardGrid().Divide())
+
+	for _, idx := range []int{0, cellCount / 2, cellCount - 1} {
+		grid := newGuardGrid()
+		cells := grid.Divide()
+		wantBounds := cells[idx]
+
+		got, _ := grid.SelectCell(recursivegrid.Cell(idx))
+
+		if grid.CurrentBounds() != wantBounds {
+			t.Errorf("SelectCell(%d) narrowed to %v, want the cell's bounds %v",
+				idx, grid.CurrentBounds(), wantBounds)
+		}
+
+		if grid.CurrentDepth() != 1 {
+			t.Errorf("SelectCell(%d) left depth at %d, want 1", idx, grid.CurrentDepth())
+		}
+
+		if !got.In(wantBounds) {
+			t.Errorf("SelectCell(%d) point %v is outside the selected cell %v",
+				idx, got, wantBounds)
+		}
+	}
+}
+
+// TestRecursiveGrid_RemapToNewBounds_HandlesNegativeOrigins exercises the
+// rounding helper on the path that actually produces negative coordinates: on
+// macOS a display positioned left of or above the primary has a negative
+// origin, so a monitor change remaps the active region into negative space.
+// Rounding that truncates toward zero instead of to nearest drifts the region
+// by a pixel per remap, in opposite directions either side of the origin.
+func TestRecursiveGrid_RemapToNewBounds_HandlesNegativeOrigins(t *testing.T) {
+	tests := []struct {
+		name     string
+		from, to image.Rectangle
+	}{
+		{
+			"primary to a display left of it",
+			image.Rect(0, 0, 1920, 1080),
+			image.Rect(-1920, 0, 0, 1080),
+		},
+		{
+			"primary to a display above it",
+			image.Rect(0, 0, 1920, 1080),
+			image.Rect(0, -1080, 1920, 0),
+		},
+		{
+			"negative origin back to primary",
+			image.Rect(-1920, -1080, 0, 0),
+			image.Rect(0, 0, 1920, 1080),
+		},
+		{"odd sizes across the origin", image.Rect(-1001, -733, 0, 0), image.Rect(0, 0, 1367, 769)},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			grid := recursivegrid.NewRecursiveGrid(testCase.from, 10, 10, 5)
+
+			// Descend twice so the remap has a non-trivial region to carry.
+			grid.SelectCell(recursivegrid.TopRight)
+			grid.SelectCell(recursivegrid.BottomLeft)
+
+			depthBefore := grid.CurrentDepth()
+
+			grid.RemapToNewBounds(testCase.to)
+
+			// The remapped region must land inside the new display, or the
+			// recursive grid is drawn off-screen after a monitor change.
+			if got := grid.CurrentBounds(); !got.In(testCase.to) {
+				t.Errorf("after remap CurrentBounds() = %v, outside the new bounds %v",
+					got, testCase.to)
+			}
+
+			if got := grid.CurrentBounds(); got.Empty() {
+				t.Errorf("after remap CurrentBounds() = %v, which is empty", got)
+			}
+
+			// Remapping repositions; it must not change how deep the user is.
+			if got := grid.CurrentDepth(); got != depthBefore {
+				t.Errorf("after remap CurrentDepth() = %d, want %d unchanged", got, depthBefore)
+			}
+
+			// The center must stay inside the region it belongs to.
+			if center := grid.CurrentCenter(); !center.In(grid.CurrentBounds()) {
+				t.Errorf("after remap CurrentCenter() = %v, outside CurrentBounds() %v",
+					center, grid.CurrentBounds())
+			}
+		})
+	}
+}

--- a/internal/core/domain/state/main_test.go
+++ b/internal/core/domain/state/main_test.go
@@ -1,0 +1,29 @@
+package state_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain fails the package if any goroutine outlives the tests.
+//
+// Every state type in this package notifies subscribers from goroutines
+// (AppState uses `go callback(...)` for all three of its flags, ModifierState
+// does the same for its initial OnChange delivery). A callback goroutine that
+// blocks — on a mutex a test still holds, on a channel nobody drains — is
+// invisible to an ordinary assertion: the test that spawned it has already
+// moved on, and the leak only surfaces later as an unrelated test appearing to
+// hang.
+//
+// That is not hypothetical here. TestModifierState_OnChange once ran out a
+// 10-minute package timeout and took the whole binary down with an unreadable
+// goroutine dump. It has not reproduced since — roughly 250 stress iterations
+// including -race did not trigger it — so the mechanism is still unknown, and a
+// stuck notification goroutine is the most plausible candidate. The waits in
+// these tests are now bounded so a stall fails fast and names the callback that
+// did not fire; this catches the complementary case where the test passes but
+// leaves a goroutine wedged behind it.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/core/domain/state/modifier_state_test.go
+++ b/internal/core/domain/state/modifier_state_test.go
@@ -3,10 +3,41 @@ package state_test
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
 )
+
+// callbackTimeout bounds how long a test waits for a subscriber callback.
+// Generous enough to survive a loaded CI machine, short enough that a callback
+// which never arrives is reported promptly.
+const callbackTimeout = 30 * time.Second
+
+// waitForCallbacks blocks until waitGroup reaches zero, failing the test if
+// that takes longer than callbackTimeout.
+//
+// A bare waitGroup.Wait() here would turn the very regression these tests exist
+// to catch — a callback that stops firing — into a silent hang that runs out
+// the whole package's test timeout and takes every other test in the binary
+// down with an unreadable goroutine dump. A bounded wait reports it as what it
+// is: this callback did not fire.
+func waitForCallbacks(t *testing.T, waitGroup *sync.WaitGroup, what string) {
+	t.Helper()
+
+	done := make(chan struct{})
+
+	go func() {
+		waitGroup.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(callbackTimeout):
+		t.Fatalf("timed out after %v waiting for %s", callbackTimeout, what)
+	}
+}
 
 func TestModifierState_Toggle(t *testing.T) {
 	modifierState := state.NewModifierState()
@@ -81,7 +112,7 @@ func TestModifierState_OnChange(t *testing.T) {
 		t.Error("Expected non-zero callback ID")
 	}
 
-	waitGroup.Wait()
+	waitForCallbacks(t, &waitGroup, "the initial OnChange callback")
 
 	if receivedMods != 0 {
 		t.Errorf("Expected initial callback with 0, got %v", receivedMods)
@@ -89,7 +120,7 @@ func TestModifierState_OnChange(t *testing.T) {
 
 	waitGroup.Add(1)
 	modifierState.Toggle(action.ModShift)
-	waitGroup.Wait()
+	waitForCallbacks(t, &waitGroup, "the callback for Toggle(ModShift)")
 
 	if receivedMods != action.ModShift {
 		t.Errorf("Expected ModShift, got %v", receivedMods)
@@ -114,7 +145,7 @@ func TestModifierState_OffChange(t *testing.T) {
 
 	// Wait for the initial async callback (fired by OnChange via goroutine)
 	// to complete before unsubscribing, so we don't race on receivedMods.
-	waitGroup.Wait()
+	waitForCallbacks(t, &waitGroup, "the initial OnChange callback")
 
 	modifierState.OffChange(subscriptionID)
 
@@ -135,7 +166,7 @@ func TestModifierState_Concurrent(t *testing.T) {
 		})
 	}
 
-	waitGroup.Wait()
+	waitForCallbacks(t, &waitGroup, "the concurrent Toggle goroutines")
 
 	// The race detector is the primary check. Also assert the state is still
 	// coherent and mutable, so the test is not vacuous without -race.

--- a/internal/core/domain/state/subscriptions_test.go
+++ b/internal/core/domain/state/subscriptions_test.go
@@ -1,0 +1,376 @@
+package state_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/domain/action"
+	"github.com/y3owk1n/neru/internal/core/domain/state"
+)
+
+// AppState exposes three independent publish/subscribe flags. The enabled flag
+// is covered in app_state_test.go; the screen-share and scroll-invert flags had
+// no subscription tests at all, so their "only notify when the value actually
+// changed" guards and their nil-callback guards were unverified.
+//
+// Both guards fail quietly. A broken change-guard floods every subscriber on
+// each no-op write (the systray redraws, the overlay reconfigures) without
+// changing any observable state; a broken nil-guard stores a nil callback that
+// panics later, on a different goroutine, far from the subscribe call.
+
+// settleWindow is how long a test waits before concluding that no further
+// notification is coming. Callbacks are dispatched with `go callback(...)`, so
+// asserting "no callback" immediately after a write would pass even when a
+// spurious one is already scheduled.
+const settleWindow = 250 * time.Millisecond
+
+// notifyRecorder collects the values a subscription delivered.
+type notifyRecorder struct {
+	mu       sync.Mutex
+	received []bool
+	signal   chan struct{}
+}
+
+func newNotifyRecorder() *notifyRecorder {
+	return &notifyRecorder{signal: make(chan struct{}, 64)}
+}
+
+func (r *notifyRecorder) callback(value bool) {
+	r.mu.Lock()
+	r.received = append(r.received, value)
+	r.mu.Unlock()
+
+	select {
+	case r.signal <- struct{}{}:
+	default:
+	}
+}
+
+func (r *notifyRecorder) values() []bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]bool(nil), r.received...)
+}
+
+// awaitCount blocks until at least want notifications have arrived, failing if
+// that does not happen within callbackTimeout.
+func (r *notifyRecorder) awaitCount(t *testing.T, want int, what string) {
+	t.Helper()
+
+	deadline := time.After(callbackTimeout)
+
+	for len(r.values()) < want {
+		select {
+		case <-r.signal:
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s: got %d notifications, want %d",
+				what, len(r.values()), want)
+		}
+	}
+}
+
+// expectNoFurtherNotification asserts that the recorder stays at want after a
+// settle window, so a spurious notification already in flight is still caught.
+func (r *notifyRecorder) expectNoFurtherNotification(t *testing.T, want int, what string) {
+	t.Helper()
+
+	time.Sleep(settleWindow)
+
+	if got := r.values(); len(got) != want {
+		t.Errorf("%s: got %d notifications (%v), want %d", what, len(got), got, want)
+	}
+}
+
+// boolSubscription describes one of AppState's publish/subscribe flags so the
+// same contract can be asserted against each.
+type boolSubscription struct {
+	name        string
+	get         func(*state.AppState) bool
+	set         func(*state.AppState, bool)
+	toggle      func(*state.AppState) bool
+	subscribe   func(*state.AppState, func(bool)) uint64
+	unsubscribe func(*state.AppState, uint64)
+}
+
+func boolSubscriptions() []boolSubscription {
+	return []boolSubscription{
+		{
+			name:        "screen share hidden",
+			get:         (*state.AppState).IsHiddenForScreenShare,
+			set:         (*state.AppState).SetHiddenForScreenShare,
+			toggle:      (*state.AppState).ToggleHiddenForScreenShare,
+			subscribe:   (*state.AppState).OnScreenShareStateChanged,
+			unsubscribe: (*state.AppState).OffScreenShareStateChanged,
+		},
+		{
+			name:        "scroll inverted",
+			get:         (*state.AppState).IsScrollInverted,
+			set:         (*state.AppState).SetScrollInverted,
+			toggle:      (*state.AppState).ToggleScrollInverted,
+			subscribe:   (*state.AppState).OnScrollInvertStateChanged,
+			unsubscribe: (*state.AppState).OffScrollInvertStateChanged,
+		},
+	}
+}
+
+// TestAppState_Subscriptions_RejectNilCallbacks pins the subscribe guard. A nil
+// callback must be refused with a zero ID rather than stored, because a stored
+// nil is only discovered when the notify loop reaches it.
+func TestAppState_Subscriptions_RejectNilCallbacks(t *testing.T) {
+	for _, sub := range boolSubscriptions() {
+		t.Run(sub.name, func(t *testing.T) {
+			appState := state.NewAppState()
+
+			if id := sub.subscribe(appState, nil); id != 0 {
+				t.Errorf("subscribing nil returned ID %d, want 0", id)
+			}
+
+			// A real callback must still get a usable, non-zero ID — the guard
+			// must reject only nil.
+			recorder := newNotifyRecorder()
+
+			first := sub.subscribe(appState, recorder.callback)
+			if first == 0 {
+				t.Fatal("subscribing a real callback returned ID 0")
+			}
+
+			second := sub.subscribe(appState, newNotifyRecorder().callback)
+			if second == first {
+				t.Errorf("second subscription reused ID %d; IDs must be distinct", first)
+			}
+
+			// Toggling must not panic on the refused nil subscription.
+			sub.toggle(appState)
+			recorder.awaitCount(t, 2, "the initial and toggle notifications")
+		})
+	}
+}
+
+// TestAppState_Subscriptions_FireInitialStateOnSubscribe checks a new subscriber
+// is told the current value immediately, so it can render without waiting for
+// the next change.
+func TestAppState_Subscriptions_FireInitialStateOnSubscribe(t *testing.T) {
+	for _, sub := range boolSubscriptions() {
+		t.Run(sub.name, func(t *testing.T) {
+			appState := state.NewAppState()
+
+			// Put the flag in the non-default position first, so the initial
+			// notification carries a value that is not merely the zero value.
+			sub.set(appState, true)
+
+			if !sub.get(appState) {
+				t.Fatal("set(true) did not take effect")
+			}
+
+			recorder := newNotifyRecorder()
+			sub.subscribe(appState, recorder.callback)
+
+			recorder.awaitCount(t, 1, "the initial notification")
+
+			if got := recorder.values(); got[0] != true {
+				t.Errorf("initial notification carried %t, want the current state true", got[0])
+			}
+		})
+	}
+}
+
+// TestAppState_Subscriptions_NotifyOnlyOnActualChange is the core guard: writing
+// the value the flag already holds must not wake subscribers.
+func TestAppState_Subscriptions_NotifyOnlyOnActualChange(t *testing.T) {
+	for _, sub := range boolSubscriptions() {
+		t.Run(sub.name, func(t *testing.T) {
+			appState := state.NewAppState()
+
+			recorder := newNotifyRecorder()
+			sub.subscribe(appState, recorder.callback)
+			recorder.awaitCount(t, 1, "the initial notification")
+
+			initial := sub.get(appState)
+
+			// Writing the current value repeatedly must stay silent.
+			sub.set(appState, initial)
+			sub.set(appState, initial)
+			recorder.expectNoFurtherNotification(t, 1, "writing the unchanged value")
+
+			// A genuine change must notify exactly once, with the new value.
+			sub.set(appState, !initial)
+			recorder.awaitCount(t, 2, "the notification for a real change")
+
+			values := recorder.values()
+			if values[1] != !initial {
+				t.Errorf("change notification carried %t, want %t", values[1], !initial)
+			}
+
+			// And writing that new value again must be silent too.
+			sub.set(appState, !initial)
+			recorder.expectNoFurtherNotification(t, 2, "rewriting the new value")
+
+			if got := sub.get(appState); got != !initial {
+				t.Errorf("state is %t after the change, want %t", got, !initial)
+			}
+		})
+	}
+}
+
+// TestAppState_Subscriptions_ToggleAlwaysNotifies covers the toggle path, which
+// deliberately skips the change guard because a toggle always changes the value.
+func TestAppState_Subscriptions_ToggleAlwaysNotifies(t *testing.T) {
+	for _, sub := range boolSubscriptions() {
+		t.Run(sub.name, func(t *testing.T) {
+			appState := state.NewAppState()
+
+			recorder := newNotifyRecorder()
+			sub.subscribe(appState, recorder.callback)
+			recorder.awaitCount(t, 1, "the initial notification")
+
+			want := !sub.get(appState)
+
+			// The returned value must be the post-toggle state; callers use it
+			// instead of a second racy read.
+			if got := sub.toggle(appState); got != want {
+				t.Errorf("toggle returned %t, want the new state %t", got, want)
+			}
+
+			if got := sub.get(appState); got != want {
+				t.Errorf("state is %t after toggle, want %t", got, want)
+			}
+
+			recorder.awaitCount(t, 2, "the toggle notification")
+
+			if values := recorder.values(); values[1] != want {
+				t.Errorf("toggle notification carried %t, want %t", values[1], want)
+			}
+
+			// Toggling back notifies again with the original value.
+			if got := sub.toggle(appState); got != !want {
+				t.Errorf("second toggle returned %t, want %t", got, !want)
+			}
+
+			recorder.awaitCount(t, 3, "the second toggle notification")
+
+			if values := recorder.values(); values[2] != !want {
+				t.Errorf("second toggle notification carried %t, want %t", values[2], !want)
+			}
+		})
+	}
+}
+
+// TestAppState_Subscriptions_UnsubscribeStopsNotifications checks that a
+// canceled subscription really is detached — a leaked one keeps a stale
+// component alive and repainting after it has been torn down.
+func TestAppState_Subscriptions_UnsubscribeStopsNotifications(t *testing.T) {
+	for _, sub := range boolSubscriptions() {
+		t.Run(sub.name, func(t *testing.T) {
+			appState := state.NewAppState()
+
+			staying := newNotifyRecorder()
+			leaving := newNotifyRecorder()
+
+			sub.subscribe(appState, staying.callback)
+
+			leavingID := sub.subscribe(appState, leaving.callback)
+
+			staying.awaitCount(t, 1, "the initial notification for the retained subscriber")
+			leaving.awaitCount(t, 1, "the initial notification for the departing subscriber")
+
+			sub.unsubscribe(appState, leavingID)
+
+			sub.toggle(appState)
+
+			// The remaining subscriber must still be notified: unsubscribing
+			// one must not detach the others.
+			staying.awaitCount(t, 2, "the toggle notification for the retained subscriber")
+
+			leaving.expectNoFurtherNotification(t, 1, "notifications after unsubscribing")
+
+			// Unsubscribing an unknown ID must be a harmless no-op.
+			sub.unsubscribe(appState, leavingID)
+			sub.unsubscribe(appState, 999999)
+
+			sub.toggle(appState)
+			staying.awaitCount(t, 3, "the notification after redundant unsubscribes")
+		})
+	}
+}
+
+// TestAppState_SetMode_InvalidatesStaleExitReasonOnlyForRealModes pins the
+// asymmetry in SetMode: entering a real mode clears any leftover exit reason,
+// while entering idle preserves the reason that was just recorded — that is how
+// the mode handler learns why the previous mode ended.
+func TestAppState_SetMode_InvalidatesStaleExitReasonOnlyForRealModes(t *testing.T) {
+	nonIdleModes := []domain.Mode{domain.ModeHints, domain.ModeGrid, domain.ModeScroll}
+
+	t.Run("entering idle preserves a freshly recorded reason", func(t *testing.T) {
+		appState := state.NewAppState()
+
+		appState.SetMode(domain.ModeHints)
+		appState.SetModeExitReason(state.ModeExitReasonCompleted)
+		appState.SetMode(domain.ModeIdle)
+
+		if got := appState.ConsumeModeExitReason(); got != state.ModeExitReasonCompleted {
+			t.Errorf("ConsumeModeExitReason() = %v, want %v",
+				got, state.ModeExitReasonCompleted)
+		}
+	})
+
+	for _, mode := range nonIdleModes {
+		t.Run(fmt.Sprintf("entering mode %v clears a stale reason", mode), func(t *testing.T) {
+			appState := state.NewAppState()
+
+			appState.SetModeExitReason(state.ModeExitReasonCompleted)
+
+			// Entering a real mode must drop the reason from the *previous*
+			// session, or the next exit would report why the last one ended.
+			appState.SetMode(mode)
+
+			if got := appState.ConsumeModeExitReason(); got != state.ModeExitReasonNone {
+				t.Errorf("ConsumeModeExitReason() after entering %v = %v, want %v",
+					mode, got, state.ModeExitReasonNone)
+			}
+
+			if got := appState.CurrentMode(); got != mode {
+				t.Errorf("CurrentMode() = %v, want %v", got, mode)
+			}
+		})
+	}
+}
+
+// TestModifierState_Reset_NotifiesOnlyWhenModifiersWereHeld covers the matching
+// guard on the sticky-modifier indicator. Reset runs on every mode exit, so
+// notifying unconditionally would repaint the indicator constantly even though
+// nothing was ever held.
+func TestModifierState_Reset_NotifiesOnlyWhenModifiersWereHeld(t *testing.T) {
+	modifierState := state.NewModifierState()
+
+	recorder := newNotifyRecorder()
+
+	modifierState.OnChange(func(mods action.Modifiers) {
+		recorder.callback(mods != 0)
+	})
+
+	recorder.awaitCount(t, 1, "the initial OnChange notification")
+
+	// Nothing is held, so Reset has nothing to clear and must stay silent.
+	modifierState.Reset()
+	modifierState.Reset()
+	recorder.expectNoFurtherNotification(t, 1, "resetting with no modifiers held")
+
+	// With a modifier held, Reset must notify that it was cleared.
+	modifierState.Toggle(action.ModShift)
+	recorder.awaitCount(t, 2, "the toggle notification")
+
+	modifierState.Reset()
+	recorder.awaitCount(t, 3, "the reset notification")
+
+	if values := recorder.values(); values[2] {
+		t.Error("reset notification reported modifiers still held, want cleared")
+	}
+
+	// And a second reset is silent again.
+	modifierState.Reset()
+	recorder.expectNoFurtherNotification(t, 3, "resetting an already-cleared state")
+}

--- a/internal/core/infra/accessibility/adapter_concurrent_test.go
+++ b/internal/core/infra/accessibility/adapter_concurrent_test.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"sync"
 	"testing"
+	"time"
 
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
@@ -111,14 +112,26 @@ func TestProcessClickableNodesConcurrent_CancelledMidProcessing(t *testing.T) {
 	}()
 
 	// Wait for a worker to begin processing a node, then cancel mid-flight
-	// while the worker is still blocked on Bounds().
-	<-started
+	// while the worker is still blocked on Bounds(). Both waits are bounded:
+	// "no worker ever started" and "the call never returned after cancellation"
+	// are precisely the regressions under test, and a bare receive would turn
+	// either into a hang that takes down the whole test binary.
+	select {
+	case <-started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("no worker began processing a node")
+	}
+
 	cancel()
 
 	// Release the blocked worker so it can observe the canceled context.
 	close(release)
 
-	<-done
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("processClickableNodesConcurrent did not return after its context was canceled")
+	}
 
 	if err == nil {
 		t.Fatal("expected error from canceled context, got nil")

--- a/internal/core/infra/accessibility/adapter_filter_test.go
+++ b/internal/core/infra/accessibility/adapter_filter_test.go
@@ -1,0 +1,241 @@
+package accessibility_test
+
+import (
+	"context"
+	"image"
+	"slices"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/domain/element"
+	"github.com/y3owk1n/neru/internal/core/infra/accessibility"
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+// IDs of the fixed node set the filter cases run against.
+const (
+	idBigButton    = "big-button"
+	idTinyButton   = "tiny-button"
+	idBigLink      = "big-link"
+	idWideFlatLink = "wide-flat-link"
+)
+
+// filterTestNodes is the fixed cast of AX nodes every filter case runs against.
+// Each node is chosen so that at least one filter field can single it out, and
+// so that role, size and text constraints are independent of one another.
+func filterTestNodes() []accessibility.AXNode {
+	return []accessibility.AXNode{
+		&accessibility.MockNode{
+			MockID:        idBigButton,
+			MockBounds:    image.Rect(0, 0, 100, 40),
+			MockRole:      axButtonRole,
+			MockTitle:     "Save",
+			MockClickable: true,
+		},
+		&accessibility.MockNode{
+			MockID:        idTinyButton,
+			MockBounds:    image.Rect(0, 0, 4, 4),
+			MockRole:      axButtonRole,
+			MockTitle:     "x",
+			MockClickable: true,
+		},
+		&accessibility.MockNode{
+			MockID:        idBigLink,
+			MockBounds:    image.Rect(0, 0, 200, 30),
+			MockRole:      axLinkRole,
+			MockTitle:     "Documentation",
+			MockClickable: true,
+		},
+		&accessibility.MockNode{
+			MockID:        idWideFlatLink,
+			MockBounds:    image.Rect(0, 0, 300, 4),
+			MockRole:      axLinkRole,
+			MockTitle:     "Divider",
+			MockClickable: true,
+		},
+	}
+}
+
+// newFilterAdapter builds an adapter whose frontmost window yields
+// filterTestNodes, so ClickableElements exercises the real collection and
+// filtering path against a known, non-empty element set.
+func newFilterAdapter(t *testing.T) *accessibility.Adapter {
+	t.Helper()
+
+	window := &accessibility.MockWindow{}
+	client := &accessibility.MockAXClient{
+		MockPermissions:     true,
+		MockFrontmostWindow: window,
+		MockAllWindows:      []accessibility.AXWindow{window},
+		MockClickableNodes:  filterTestNodes(),
+	}
+
+	return accessibility.NewAdapter(zap.NewNop(), nil, nil, client, false)
+}
+
+// idsOf returns element IDs in the order the adapter produced them.
+func idsOf(elements []*element.Element) []string {
+	ids := make([]string, 0, len(elements))
+	for _, el := range elements {
+		ids = append(ids, string(el.ID()))
+	}
+
+	slices.Sort(ids)
+
+	return ids
+}
+
+// TestAdapter_ClickableElements_FilterContract pins what ClickableElements
+// actually returns for a given filter, not merely which roles it forwarded to
+// the client. The existing role-plumbing tests discard the result slice, so
+// without this a regression that collected the right nodes and then dropped or
+// mis-filtered them would go unnoticed.
+func TestAdapter_ClickableElements_FilterContract(t *testing.T) {
+	tests := []struct {
+		name    string
+		filter  ports.ElementFilter
+		wantIDs []string
+	}{
+		{
+			name:    "no constraints returns every clickable node",
+			filter:  ports.ElementFilter{},
+			wantIDs: []string{idBigButton, idBigLink, idTinyButton, idWideFlatLink},
+		},
+		{
+			name: "MinSize drops nodes shorter or narrower than the minimum",
+			filter: ports.ElementFilter{
+				MinSize: image.Point{X: 10, Y: 10},
+			},
+			wantIDs: []string{idBigButton, idBigLink},
+		},
+		{
+			name: "MinSize compares both axes, not area",
+			filter: ports.ElementFilter{
+				// wide-flat-link is 300x4: far larger in area than the
+				// 10x10 minimum, but too short. An implementation that
+				// compared areas would wrongly keep it.
+				MinSize: image.Point{X: 10, Y: 10},
+			},
+			wantIDs: []string{idBigButton, idBigLink},
+		},
+		{
+			name: "Roles acts as an allowlist",
+			filter: ports.ElementFilter{
+				Roles: []element.Role{element.RoleButton},
+			},
+			wantIDs: []string{idBigButton, idTinyButton},
+		},
+		{
+			name: "ExcludeRoles removes the named roles",
+			filter: ports.ElementFilter{
+				ExcludeRoles: []element.Role{element.RoleLink},
+			},
+			wantIDs: []string{idBigButton, idTinyButton},
+		},
+		{
+			name: "ExcludeRoles wins over Roles for the same role",
+			filter: ports.ElementFilter{
+				Roles:        []element.Role{element.RoleButton, element.RoleLink},
+				ExcludeRoles: []element.Role{element.RoleLink},
+			},
+			wantIDs: []string{idBigButton, idTinyButton},
+		},
+		{
+			name: "Roles and MinSize both apply",
+			filter: ports.ElementFilter{
+				Roles:   []element.Role{element.RoleButton},
+				MinSize: image.Point{X: 10, Y: 10},
+			},
+			wantIDs: []string{idBigButton},
+		},
+		{
+			name: "a role that matches nothing yields no elements",
+			filter: ports.ElementFilter{
+				Roles: []element.Role{element.Role("AXCheckBox")},
+			},
+			wantIDs: []string{},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			adapter := newFilterAdapter(t)
+
+			got, err := adapter.ClickableElements(context.Background(), testCase.filter)
+			if err != nil {
+				t.Fatalf("ClickableElements() error = %v, want nil", err)
+			}
+
+			if gotIDs := idsOf(got); !slices.Equal(gotIDs, testCase.wantIDs) {
+				t.Errorf("ClickableElements() returned %v, want %v", gotIDs, testCase.wantIDs)
+			}
+		})
+	}
+}
+
+// TestAdapter_ClickableElements_PreservesNodeAttributes checks that the
+// AXNode -> element.Element conversion carries every attribute across. A
+// dropped bounds or role here would silently misplace every hint.
+func TestAdapter_ClickableElements_PreservesNodeAttributes(t *testing.T) {
+	adapter := newFilterAdapter(t)
+
+	got, err := adapter.ClickableElements(context.Background(), ports.ElementFilter{
+		Roles: []element.Role{element.RoleButton},
+		// Single out exactly one node so the assertions below are unambiguous.
+		MinSize: image.Point{X: 10, Y: 10},
+	})
+	if err != nil {
+		t.Fatalf("ClickableElements() error = %v, want nil", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one element, got %d (%v)", len(got), idsOf(got))
+	}
+
+	found := got[0]
+
+	if found.ID() != element.ID(idBigButton) {
+		t.Errorf("ID() = %q, want %q", found.ID(), idBigButton)
+	}
+
+	if want := image.Rect(0, 0, 100, 40); found.Bounds() != want {
+		t.Errorf("Bounds() = %v, want %v", found.Bounds(), want)
+	}
+
+	if found.Role() != element.RoleButton {
+		t.Errorf("Role() = %q, want %q", found.Role(), element.RoleButton)
+	}
+
+	if found.Title() != "Save" {
+		t.Errorf("Title() = %q, want %q", found.Title(), "Save")
+	}
+
+	// Center is what every click action ultimately targets.
+	if want := (image.Point{X: 50, Y: 20}); found.Center() != want {
+		t.Errorf("Center() = %v, want %v", found.Center(), want)
+	}
+}
+
+// TestAdapter_ClickableElements_PropagatesClientError makes sure a failure from
+// the underlying AX client surfaces instead of being reported as an empty but
+// successful result — which would look to a caller like "nothing on screen".
+func TestAdapter_ClickableElements_PropagatesClientError(t *testing.T) {
+	window := &accessibility.MockWindow{}
+	client := &accessibility.MockAXClient{
+		MockPermissions:       true,
+		MockFrontmostWindow:   window,
+		MockAllWindows:        []accessibility.AXWindow{window},
+		MockClickableNodesErr: errTestAccessibility,
+	}
+
+	adapter := accessibility.NewAdapter(zap.NewNop(), nil, nil, client, false)
+
+	got, err := adapter.ClickableElements(context.Background(), ports.ElementFilter{})
+	if err == nil {
+		t.Fatalf(
+			"ClickableElements() error = nil, want the client error; got %d elements",
+			len(got),
+		)
+	}
+}

--- a/internal/core/infra/accessibility/adapter_integration_darwin_test.go
+++ b/internal/core/infra/accessibility/adapter_integration_darwin_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/y3owk1n/neru/internal/core/domain/element"
 	"github.com/y3owk1n/neru/internal/core/infra/accessibility"
 	"github.com/y3owk1n/neru/internal/core/infra/logger"
 	darwinplatform "github.com/y3owk1n/neru/internal/core/infra/platform/darwin"
@@ -45,9 +46,30 @@ func TestAccessibilityAdapterIntegration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CursorPosition() error = %v, want nil", err)
 		}
-		// Position should be within screen bounds (roughly)
-		// We can't strictly enforce this as cursor might be on another screen
-		_ = pos
+
+		// The cursor may legitimately sit on a secondary display, so the
+		// active screen's bounds are not a valid box to test against. What is
+		// always true under the shared coordinate contract (global top-left
+		// origin, Y down, unscaled pixels) is that the position is finite and
+		// plausible for a desktop. A backend that failed to read the position
+		// and returned CGPointZero-as-error, or that leaked Cocoa's
+		// bottom-left origin as a negative Y, fails here.
+		const sane = 100000
+
+		if pos.X < -sane || pos.X > sane || pos.Y < -sane || pos.Y > sane {
+			t.Errorf("CursorPosition() = %v, outside any plausible desktop coordinate range", pos)
+		}
+
+		// Reading twice without moving must be stable; a jittering read means
+		// the position is being derived from something other than HID state.
+		again, err := system.CursorPosition(ctx)
+		if err != nil {
+			t.Fatalf("second CursorPosition() error = %v, want nil", err)
+		}
+
+		if again != pos {
+			t.Errorf("CursorPosition() is unstable without a move: got %v then %v", pos, again)
+		}
 	})
 
 	t.Run("MoveCursorToPoint", func(t *testing.T) {
@@ -65,14 +87,37 @@ func TestAccessibilityAdapterIntegration(t *testing.T) {
 			t.Errorf("MoveCursorToPoint() error = %v, want nil", startPosErr)
 		}
 
-		// Verify position (might be slightly off due to OS acceleration/constraints)
+		// This subtest uses the smooth-cursor path (bypassSmooth=false), so the
+		// cursor animates toward the target over several frames and its exact
+		// position at any instant is not assertable. What must hold is that it
+		// ends up at the target: "MoveCursorToPoint lands on the requested
+		// point" below pins exact placement for the direct path, and here we
+		// only require that the animated move converges rather than silently
+		// doing nothing.
+		deadline := time.Now().Add(time.Second)
+
 		newPos, newPosErr := system.CursorPosition(ctx)
 		if newPosErr != nil {
 			t.Fatalf("CursorPosition() error = %v, want nil", newPosErr)
 		}
 
-		// Just verify it moved or didn't error. Exact position check is flaky.
-		_ = newPos
+		for newPos != target && time.Now().Before(deadline) {
+			time.Sleep(5 * time.Millisecond)
+
+			newPos, newPosErr = system.CursorPosition(ctx)
+			if newPosErr != nil {
+				t.Fatalf("CursorPosition() error = %v, want nil", newPosErr)
+			}
+		}
+
+		if newPos != target {
+			t.Errorf(
+				"MoveCursorToPoint(%v) from %v settled at %v; the smooth move never reached its target",
+				target,
+				startPos,
+				newPos,
+			)
+		}
 	})
 
 	t.Run("MoveCursorToPoint bypassSmooth", func(t *testing.T) {
@@ -198,22 +243,58 @@ func TestAccessibilityAdapterIntegration(t *testing.T) {
 		}
 	})
 
-	t.Run("ClickableElements", func(t *testing.T) {
-		// This is hard to test without a known window.
-		// We'll just call it and ensure it doesn't panic or return error (unless permissions missing).
+	t.Run("ClickableElements queries the live AX tree without error", func(t *testing.T) {
+		// A `go test` binary is not a foreground app with its own window, so
+		// the live AX tree usually yields zero elements here. That makes the
+		// element *count* unassertable, and any per-element loop vacuous — the
+		// filter semantics are pinned deterministically instead by
+		// TestAdapter_ClickableElements_FilterContract, which drives the same
+		// code through MockAXClient with known nodes.
+		//
+		// What only a live run can check is that the real Objective-C query
+		// path completes against the real AX API and returns a well-formed
+		// slice rather than erroring or handing back nil entries.
+		const minSide = 10
+
 		filter := ports.ElementFilter{
-			MinSize: image.Point{X: 10, Y: 10},
+			MinSize:      image.Point{X: minSide, Y: minSide},
+			ExcludeRoles: []element.Role{element.RoleWindow},
 		}
 
-		clickableElements, clickableElementsErr := adapter.ClickableElements(ctx, filter)
-		if clickableElementsErr != nil {
-			// It might error if no permissions or no focused window
-			t.Logf(
-				"ClickableElements() error = %v (expected if no permissions)",
-				clickableElementsErr,
-			)
-		} else {
-			t.Logf("Found %d elements", len(clickableElements))
+		clickableElements, err := adapter.ClickableElements(ctx, filter)
+		if err != nil {
+			t.Fatalf("ClickableElements() error = %v, want nil", err)
 		}
+
+		seen := make(map[element.ID]int, len(clickableElements))
+
+		for idx, found := range clickableElements {
+			if found == nil {
+				t.Fatalf("element %d is nil", idx)
+			}
+
+			if found.ID() == "" {
+				t.Errorf("element %d has an empty ID", idx)
+			}
+
+			if prev, dup := seen[found.ID()]; dup {
+				t.Errorf("elements %d and %d share ID %q", prev, idx, found.ID())
+			}
+
+			seen[found.ID()] = idx
+
+			if bounds := found.Bounds(); bounds.Dx() < minSide || bounds.Dy() < minSide {
+				t.Errorf(
+					"element %d (%q) has bounds %v, smaller than the requested MinSize %v",
+					idx, found.ID(), bounds, filter.MinSize,
+				)
+			}
+
+			if found.Role() == element.RoleWindow {
+				t.Errorf("element %d (%q) has an excluded role %q", idx, found.ID(), found.Role())
+			}
+		}
+
+		t.Logf("live AX tree yielded %d clickable elements", len(clickableElements))
 	})
 }

--- a/internal/core/infra/eventtap/adapter_integration_darwin_test.go
+++ b/internal/core/infra/eventtap/adapter_integration_darwin_test.go
@@ -68,18 +68,67 @@ func TestEventTapAdapterIntegration(t *testing.T) {
 		}
 	})
 
-	t.Run("SetHandler", func(_ *testing.T) {
-		// SetHandler should not panic
-		adapter.SetHandler(func(_ string) {
-			// Handler
-		})
+	t.Run("SetHandler is inert and leaves the tap usable", func(t *testing.T) {
+		// On darwin the key handler is fixed when NewEventTap is called;
+		// Adapter.SetHandler is a deliberate no-op that only warns. Pin both
+		// halves of that contract: the replacement handler never runs, and
+		// calling it does not disturb the tap's enable state.
+		err := adapter.Enable(ctx)
+		if err != nil {
+			t.Fatalf("Enable() error = %v, want nil", err)
+		}
+
+		t.Cleanup(func() { _ = adapter.Disable(ctx) })
+
+		replaced := false
+
+		adapter.SetHandler(func(_ string) { replaced = true })
+
+		if replaced {
+			t.Error("handler passed to SetHandler was invoked; darwin SetHandler must stay inert")
+		}
+
+		if !adapter.IsEnabled() {
+			t.Error("IsEnabled() = false after SetHandler, want the tap to stay enabled")
+		}
 	})
 
-	t.Run("SetHotkeys", func(t *testing.T) {
-		// Test setting hotkeys
-		hotkeys := []string{"cmd+shift+k", "cmd+shift+l"}
-		adapter.SetHotkeys(hotkeys)
-		// Note: No direct way to verify hotkeys were set without internal access
+	t.Run("SetHotkeys accepts populated and empty sets", func(t *testing.T) {
+		err := adapter.Enable(ctx)
+		if err != nil {
+			t.Fatalf("Enable() error = %v, want nil", err)
+		}
+
+		t.Cleanup(func() { _ = adapter.Disable(ctx) })
+
+		// An empty slice is documented as valid (it clears monitoring), so
+		// cycling through populated -> empty -> populated must leave the tap
+		// enabled and usable rather than tearing it down.
+		for _, hotkeys := range [][]string{
+			{"cmd+shift+k", "cmd+shift+l"},
+			{},
+			nil,
+			{"cmd+shift+k"},
+		} {
+			adapter.SetHotkeys(hotkeys)
+
+			if !adapter.IsEnabled() {
+				t.Fatalf("IsEnabled() = false after SetHotkeys(%v), want true", hotkeys)
+			}
+		}
+	})
+
+	t.Run("SetKeyboardLayout reports whether the layout resolved", func(t *testing.T) {
+		// SetKeyboardLayout returns a bool precisely so callers can fall back
+		// when a configured layout does not exist. A backend that always
+		// returned true would silently accept typos in user config.
+		if adapter.SetKeyboardLayout("com.apple.keylayout.NotARealLayout") {
+			t.Error("SetKeyboardLayout(bogus layout) = true, want false")
+		}
+
+		if !adapter.SetKeyboardLayout("com.apple.keylayout.US") {
+			t.Error("SetKeyboardLayout(com.apple.keylayout.US) = false, want true")
+		}
 	})
 
 	t.Run("Destroy", func(t *testing.T) {

--- a/internal/core/infra/ipc/adapter_integration_test.go
+++ b/internal/core/infra/ipc/adapter_integration_test.go
@@ -78,10 +78,33 @@ func TestIPCAdapterIntegration(t *testing.T) {
 			t.Fatalf("First Start() error = %v, want nil", serverErr)
 		}
 
-		// Second start should handle gracefully (implementation dependent)
+		// Start is documented as idempotent: it returns nil when the server is
+		// already running rather than erroring or starting a second listener.
+		// The daemon relies on that during config reload, which re-runs the
+		// startup phase without tearing the socket down.
 		serverErr = adapter.Start(ctx)
-		// We don't assert error here as behavior may vary
-		_ = serverErr
+		if serverErr != nil {
+			t.Errorf("second Start() error = %v, want nil (Start must be idempotent)", serverErr)
+		}
+
+		// A single Stop must still fully stop it — the second Start must not
+		// have incremented a reference count that leaves the socket open.
+		serverErr = adapter.Stop(ctx)
+		if serverErr != nil {
+			t.Fatalf("Stop() error = %v, want nil", serverErr)
+		}
+
+		// Stop is idempotent too.
+		serverErr = adapter.Stop(ctx)
+		if serverErr != nil {
+			t.Errorf("second Stop() error = %v, want nil (Stop must be idempotent)", serverErr)
+		}
+
+		// And the adapter must be restartable after a clean stop.
+		serverErr = adapter.Start(ctx)
+		if serverErr != nil {
+			t.Errorf("Start() after Stop() error = %v, want nil", serverErr)
+		}
 	})
 }
 

--- a/internal/core/infra/logger/logger_integration_test.go
+++ b/internal/core/infra/logger/logger_integration_test.go
@@ -3,9 +3,11 @@
 package logger_test
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -137,38 +139,82 @@ func TestLoggingFunctions(t *testing.T) {
 	tests := []struct {
 		name string
 		fn   func()
+		// wantLevel is the level the entry must be recorded at, and wantFields
+		// the structured fields that must survive into the file. Asserting the
+		// level matters because a mis-wired level would silently downgrade
+		// error reporting while still "not panicking"; asserting the fields
+		// catches an encoder that drops structured context.
+		wantLevel  string
+		wantFields map[string]any
 	}{
 		{
 			name: "Debug",
 			fn: func() {
 				logger.Debug("test debug message", zap.String("key", "value"))
 			},
+			wantLevel:  "DEBUG",
+			wantFields: map[string]any{"key": "value"},
 		},
 		{
 			name: "Info",
 			fn: func() {
 				logger.Info("test info message", zap.Int("count", 42))
 			},
+			wantLevel:  "INFO",
+			wantFields: map[string]any{"count": float64(42)},
 		},
 		{
 			name: "Warn",
 			fn: func() {
 				logger.Warn("test warn message", zap.Bool("flag", true))
 			},
+			wantLevel:  "WARN",
+			wantFields: map[string]any{"flag": true},
 		},
 		{
 			name: "Error",
 			fn: func() {
 				logger.Error("test error message", zap.Error(os.ErrNotExist))
 			},
+			wantLevel:  "ERROR",
+			wantFields: map[string]any{"error": os.ErrNotExist.Error()},
 		},
 		// Note: Fatal test is skipped as it would exit the test process
 	}
 
 	for _, testCase := range tests {
-		t.Run(testCase.name, func(_ *testing.T) {
-			// Should not panic
+		t.Run(testCase.name, func(t *testing.T) {
+			wantMessage := "test " + strings.ToLower(testCase.name) + " message"
+
 			testCase.fn()
+
+			// Flush so the entry is on disk before we read it back.
+			_ = logger.Sync()
+
+			entry := findLogEntry(t, logPath, wantMessage)
+
+			if got := entry["level"]; got != testCase.wantLevel {
+				t.Errorf(
+					"entry %q logged at level %v, want %q",
+					wantMessage,
+					got,
+					testCase.wantLevel,
+				)
+			}
+
+			for key, want := range testCase.wantFields {
+				got, present := entry[key]
+				if !present {
+					t.Errorf("entry %q is missing field %q; got %v", wantMessage, key, entry)
+
+					continue
+				}
+
+				if got != want {
+					t.Errorf("entry %q field %q = %v (%T), want %v (%T)",
+						wantMessage, key, got, got, want, want)
+				}
+			}
 		})
 	}
 
@@ -177,6 +223,44 @@ func TestLoggingFunctions(t *testing.T) {
 	if os.IsNotExist(initErr) {
 		t.Error("Log file was not created")
 	}
+}
+
+// findLogEntry reads the JSON-lines log at path and returns the single entry
+// whose "msg" equals message, failing the test if there is not exactly one.
+// Decoding rather than substring-matching means a field has to be genuinely
+// encoded as structured data, not merely appear somewhere in the text.
+func findLogEntry(t *testing.T, path, message string) map[string]any {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+
+	var matches []map[string]any
+
+	for lineNo, line := range strings.Split(strings.TrimSpace(string(contents)), "\n") {
+		if line == "" {
+			continue
+		}
+
+		var entry map[string]any
+
+		err := json.Unmarshal([]byte(line), &entry)
+		if err != nil {
+			t.Fatalf("log line %d is not valid JSON (%v): %s", lineNo+1, err, line)
+		}
+
+		if entry["msg"] == message {
+			matches = append(matches, entry)
+		}
+	}
+
+	if len(matches) != 1 {
+		t.Fatalf("found %d log entries with msg %q, want exactly 1", len(matches), message)
+	}
+
+	return matches[0]
 }
 
 func TestWithIntegration(t *testing.T) {

--- a/internal/core/infra/overlay/adapter_integration_darwin_test.go
+++ b/internal/core/infra/overlay/adapter_integration_darwin_test.go
@@ -78,10 +78,37 @@ func TestOverlayAdapterIntegration(t *testing.T) {
 		}
 	})
 
-	t.Run("IsVisible", func(_ *testing.T) {
-		// IsVisible should return a boolean without error
-		visible := adapter.IsVisible()
-		_ = visible // Just verify it doesn't panic
+	t.Run("IsVisible tracks show and hide", func(t *testing.T) {
+		// Unlike the service-level tests, this runs against a real manager, so
+		// visibility is genuinely observable. The mode handler relies on this
+		// flag to decide whether an overlay still needs tearing down, so it
+		// must follow show/hide rather than being constant.
+		err := adapter.Hide(ctx)
+		if err != nil {
+			t.Fatalf("Hide() error = %v, want nil", err)
+		}
+
+		if adapter.IsVisible() {
+			t.Fatal("IsVisible() = true after Hide(), want false")
+		}
+
+		err = adapter.ShowGrid(ctx)
+		if err != nil {
+			t.Fatalf("ShowGrid() error = %v, want nil", err)
+		}
+
+		if !adapter.IsVisible() {
+			t.Error("IsVisible() = false after ShowGrid(), want true")
+		}
+
+		err = adapter.Hide(ctx)
+		if err != nil {
+			t.Fatalf("Hide() error = %v, want nil", err)
+		}
+
+		if adapter.IsVisible() {
+			t.Error("IsVisible() = true after Hide(), want false")
+		}
 	})
 }
 

--- a/internal/core/infra/overlay/manager_stub_contract_linux_test.go
+++ b/internal/core/infra/overlay/manager_stub_contract_linux_test.go
@@ -1,0 +1,146 @@
+//go:build linux
+
+// Reaching the stub path needs a Manager with no backend attached, and the
+// backend fields are unexported by design, so this is an internal test.
+//
+//nolint:testpackage
+package overlay
+
+import (
+	"image"
+	"testing"
+
+	"go.uber.org/zap"
+
+	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	"github.com/y3owk1n/neru/internal/core/infra/overlay/render/grid"
+	"github.com/y3owk1n/neru/internal/core/infra/overlay/render/hints"
+	"github.com/y3owk1n/neru/internal/core/infra/overlay/render/recursivegrid"
+)
+
+// The Linux overlay Manager dispatches every draw call to whichever backend
+// initialized — X11 or wlroots layer-shell — and falls through to a
+// CodeNotSupported stub when neither did. That happens on KWin and GNOME today,
+// and on any headless or unrecognised session.
+//
+// The mode handler treats an overlay draw failure as a reason to abandon mode
+// activation, and it distinguishes "this platform can't draw" from "drawing
+// broke" via derrors.IsNotSupported. A stub that returned nil would leave the
+// handler believing a mode was displayed: keyboard capture stays armed and the
+// user is trapped in an invisible mode with no way to see what they are typing.
+//
+// A zero-value Manager is exactly the no-backend state — both backend fields
+// nil, a valid zero renderMu — so these cases reach the stub without opening a
+// display connection, which also keeps them safe on a headless CI runner.
+// Deliberately not using Init(): it is a process-global sync.Once singleton
+// that probes for a display.
+
+// noBackendManager returns a Manager in the state a session with no usable
+// display server produces.
+func noBackendManager() *Manager {
+	return &Manager{}
+}
+
+func TestLinuxOverlayManager_DrawCallsReportNotSupportedWithNoBackend(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(*Manager) error
+	}{
+		{
+			name: "DrawHintsWithStyle",
+			call: func(m *Manager) error {
+				return m.DrawHintsWithStyle(nil, hints.StyleMode{})
+			},
+		},
+		{
+			name: "DrawGrid",
+			call: func(m *Manager) error {
+				return m.DrawGrid(nil, "", grid.Style{})
+			},
+		},
+		{
+			name: "DrawRecursiveGrid",
+			call: func(m *Manager) error {
+				return m.DrawRecursiveGrid(
+					image.Rect(0, 0, 100, 100),
+					0, "", 2, 2, "", 2, 2,
+					recursivegrid.Style{},
+					recursivegrid.VirtualPointerState{},
+				)
+			},
+		},
+		{
+			name: "DrawMonitorSelect",
+			call: func(m *Manager) error {
+				return m.DrawMonitorSelect(nil, MonitorSelectStyle{})
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.call(noBackendManager())
+			if err == nil {
+				t.Fatalf(
+					"%s returned nil with no backend attached; the mode handler would believe "+
+						"the overlay was drawn and arm keyboard capture over an invisible mode",
+					testCase.name,
+				)
+			}
+
+			if !derrors.IsNotSupported(err) {
+				t.Errorf("%s returned %v (code %q), want CodeNotSupported",
+					testCase.name, err, derrors.GetCode(err))
+			}
+		})
+	}
+}
+
+// TestLinuxOverlayManager_DrawCallsAreSafeWithRealArguments repeats the check
+// with populated arguments, so a stub that only short-circuits on nil input
+// cannot pass by accident.
+func TestLinuxOverlayManager_DrawCallsAreSafeWithRealArguments(t *testing.T) {
+	manager := noBackendManager()
+
+	testGrid := domainGrid.NewGrid("abc", image.Rect(0, 0, 800, 600), zap.NewNop())
+
+	if err := manager.DrawGrid(testGrid, "ab", grid.Style{}); !derrors.IsNotSupported(err) {
+		t.Errorf("DrawGrid with a real grid returned %v, want CodeNotSupported", err)
+	}
+
+	drawn := []*hints.Hint{
+		hints.NewHint("aa", image.Point{X: 10, Y: 10}, image.Point{X: 20, Y: 10}, ""),
+	}
+
+	if err := manager.DrawHintsWithStyle(drawn, hints.StyleMode{}); !derrors.IsNotSupported(err) {
+		t.Errorf("DrawHintsWithStyle with real hints returned %v, want CodeNotSupported", err)
+	}
+
+	targets := []MonitorSelectTarget{{Label: "A", Bounds: image.Rect(0, 0, 800, 600)}}
+
+	if err := manager.DrawMonitorSelect(
+		targets,
+		MonitorSelectStyle{},
+	); !derrors.IsNotSupported(
+		err,
+	) {
+		t.Errorf("DrawMonitorSelect with real targets returned %v, want CodeNotSupported", err)
+	}
+}
+
+// TestLinuxOverlayManager_StubsAreRepeatable guards against a stub that reports
+// NotSupported once and then changes its answer — the mode handler retries a
+// draw on screen-change events, and an inconsistent answer would let a later
+// attempt look like success.
+func TestLinuxOverlayManager_StubsAreRepeatable(t *testing.T) {
+	manager := noBackendManager()
+
+	for i := range 3 {
+		err := manager.DrawHintsWithStyle(nil, hints.StyleMode{})
+		if !derrors.IsNotSupported(err) {
+			t.Fatalf("DrawHintsWithStyle call %d returned %v, want CodeNotSupported every time",
+				i+1, err)
+		}
+	}
+}

--- a/internal/core/infra/overlay/manager_stub_contract_linux_test.go
+++ b/internal/core/infra/overlay/manager_stub_contract_linux_test.go
@@ -1,10 +1,10 @@
 //go:build linux
 
-// Reaching the stub path needs a Manager with no backend attached, and the
-// backend fields are unexported by design, so this is an internal test.
-//
 //nolint:testpackage
 package overlay
+
+// This is an internal test: reaching the stub path needs a Manager with no
+// backend attached, and the backend fields are unexported by design.
 
 import (
 	"image"
@@ -22,7 +22,7 @@ import (
 // The Linux overlay Manager dispatches every draw call to whichever backend
 // initialized — X11 or wlroots layer-shell — and falls through to a
 // CodeNotSupported stub when neither did. That happens on KWin and GNOME today,
-// and on any headless or unrecognised session.
+// and on any headless or unrecognized session.
 //
 // The mode handler treats an overlay draw failure as a reason to abandon mode
 // activation, and it distinguishes "this platform can't draw" from "drawing
@@ -105,7 +105,8 @@ func TestLinuxOverlayManager_DrawCallsAreSafeWithRealArguments(t *testing.T) {
 
 	testGrid := domainGrid.NewGrid("abc", image.Rect(0, 0, 800, 600), zap.NewNop())
 
-	if err := manager.DrawGrid(testGrid, "ab", grid.Style{}); !derrors.IsNotSupported(err) {
+	err := manager.DrawGrid(testGrid, "ab", grid.Style{})
+	if !derrors.IsNotSupported(err) {
 		t.Errorf("DrawGrid with a real grid returned %v, want CodeNotSupported", err)
 	}
 
@@ -113,18 +114,15 @@ func TestLinuxOverlayManager_DrawCallsAreSafeWithRealArguments(t *testing.T) {
 		hints.NewHint("aa", image.Point{X: 10, Y: 10}, image.Point{X: 20, Y: 10}, ""),
 	}
 
-	if err := manager.DrawHintsWithStyle(drawn, hints.StyleMode{}); !derrors.IsNotSupported(err) {
+	err = manager.DrawHintsWithStyle(drawn, hints.StyleMode{})
+	if !derrors.IsNotSupported(err) {
 		t.Errorf("DrawHintsWithStyle with real hints returned %v, want CodeNotSupported", err)
 	}
 
 	targets := []MonitorSelectTarget{{Label: "A", Bounds: image.Rect(0, 0, 800, 600)}}
 
-	if err := manager.DrawMonitorSelect(
-		targets,
-		MonitorSelectStyle{},
-	); !derrors.IsNotSupported(
-		err,
-	) {
+	err = manager.DrawMonitorSelect(targets, MonitorSelectStyle{})
+	if !derrors.IsNotSupported(err) {
 		t.Errorf("DrawMonitorSelect with real targets returned %v, want CodeNotSupported", err)
 	}
 }

--- a/internal/core/infra/platform/capability_contract_test.go
+++ b/internal/core/infra/platform/capability_contract_test.go
@@ -1,0 +1,381 @@
+package platform_test
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	"github.com/y3owk1n/neru/internal/core/infra/platform"
+	"github.com/y3owk1n/neru/internal/core/ports"
+)
+
+// The capability matrix in ports/capability_presets.go is a hand-written
+// declaration, and until now nothing tied it to what the adapters actually do.
+// The existing capability tests prove the registry is internally consistent —
+// every field is registered, keys are unique, entries read the right field —
+// but a capability could claim "supported" while its adapter returned
+// CodeNotSupported, or claim "stub" while the feature had quietly been
+// implemented, and every one of those tests would still pass.
+//
+// That matters because the matrix is the external contract: it is what
+// `neru doctor` prints and what the IPC info response serializes. A user
+// debugging "why don't hints work on Linux" is reading it.
+//
+// These tests run on whichever platform they are compiled for, so in CI each
+// of macOS, Linux and Windows checks its own declaration against its own
+// adapters. Adding a stub on one platform without downgrading its status — or
+// implementing one without promoting it — fails there.
+
+// systemCapabilityProbe pairs a capability with a cheap, side-effect-free call
+// that exercises the same subsystem, so the declared status can be compared
+// against what the adapter really does.
+//
+// Only read-only probes belong here. Capabilities whose only entry point has a
+// side effect (moving the cursor, showing an overlay, injecting a key) are
+// deliberately absent — see TestCapabilities_ProbeCoverageIsDocumented, which
+// pins exactly which ones are and are not covered so the gap cannot widen
+// silently.
+type systemCapabilityProbe struct {
+	key   ports.CapabilityKey
+	read  func(ports.PlatformCapabilities) ports.FeatureCapability
+	probe func(context.Context, ports.SystemPort) error
+}
+
+func systemCapabilityProbes() []systemCapabilityProbe {
+	return []systemCapabilityProbe{
+		{
+			key:  ports.CapabilityProcess,
+			read: func(c ports.PlatformCapabilities) ports.FeatureCapability { return c.Process },
+			probe: func(ctx context.Context, port ports.SystemPort) error {
+				_, err := port.FocusedApplicationPID(ctx)
+
+				return err
+			},
+		},
+		{
+			key:  ports.CapabilityScreen,
+			read: func(c ports.PlatformCapabilities) ports.FeatureCapability { return c.Screen },
+			probe: func(ctx context.Context, port ports.SystemPort) error {
+				_, err := port.ScreenBounds(ctx)
+
+				return err
+			},
+		},
+		{
+			key:  ports.CapabilityCursor,
+			read: func(c ports.PlatformCapabilities) ports.FeatureCapability { return c.Cursor },
+			probe: func(ctx context.Context, port ports.SystemPort) error {
+				_, err := port.CursorPosition(ctx)
+
+				return err
+			},
+		},
+	}
+}
+
+// newSystemPort builds the platform's real SystemPort, or skips when the
+// environment genuinely cannot provide one.
+//
+// On Linux, NewSystemPort refuses to construct an adapter when no display
+// server is detected — a headless CI runner, a container, an SSH session — and
+// reports that as CodeNotSupported. That is correct behavior, not a failure, so
+// these tests skip rather than fail there. The skip is visible in the test
+// output, unlike a silently-passing assertion.
+//
+// The Linux capability surface is not left unchecked by that skip: its
+// backend-by-backend contract is asserted in the linux package itself, where
+// adapters are constructed directly and need no display. Any other error from
+// NewSystemPort is a real failure.
+func newSystemPort(t *testing.T) ports.SystemPort {
+	t.Helper()
+
+	systemPort, err := platform.NewSystemPort()
+	if err == nil {
+		return systemPort
+	}
+
+	if derrors.IsNotSupported(err) {
+		t.Skipf("no usable %s display backend in this environment: %v", runtime.GOOS, err)
+	}
+
+	t.Fatalf("NewSystemPort() error = %v, want nil", err)
+
+	return nil
+}
+
+// TestCapabilities_DeclaredStatusMatchesAdapterBehavior is the cross-check the
+// matrix never had: a capability declared supported must not answer
+// CodeNotSupported, and one declared stub must.
+//
+// Both directions are strict on every platform. That is only possible because
+// the adapters now report what is actually reachable at runtime rather than
+// what the build target intends — Linux downgrades screen, cursor and process
+// to stub when the native client stacks are absent (CGO_ENABLED=0) or the live
+// compositor has no implementation, the same way it already did for dark-mode
+// detection.
+func TestCapabilities_DeclaredStatusMatchesAdapterBehavior(t *testing.T) {
+	systemPort := newSystemPort(t)
+	capabilities := systemPort.Capabilities()
+	ctx := context.Background()
+
+	for _, probe := range systemCapabilityProbes() {
+		t.Run(string(probe.key), func(t *testing.T) {
+			declared := probe.read(capabilities)
+			err := probe.probe(ctx, systemPort)
+			notSupported := derrors.IsNotSupported(err)
+
+			switch declared.Status {
+			case ports.FeatureStatusSupported, ports.FeatureStatusHeadless:
+				if notSupported {
+					t.Errorf(
+						"capability %q is declared %q on %s but its adapter returned "+
+							"CodeNotSupported: %v",
+						probe.key, declared.Status, runtime.GOOS, err,
+					)
+				}
+
+			case ports.FeatureStatusStub:
+				if !notSupported {
+					t.Errorf(
+						"capability %q is declared %q on %s but its adapter did not return "+
+							"CodeNotSupported (got %v); a stub must report NotSupported explicitly "+
+							"rather than silently succeeding",
+						probe.key, declared.Status, runtime.GOOS, err,
+					)
+				}
+
+			default:
+				t.Errorf("capability %q has unknown status %q", probe.key, declared.Status)
+			}
+		})
+	}
+}
+
+// TestCapabilities_DowngradedEntriesExplainThemselves checks that a capability
+// reported as stubbed on a platform whose static preset calls it supported
+// carries a detail saying why, and what to do.
+//
+// A bare "stub" in `neru doctor` tells a user their feature is missing but not
+// whether that is fixable — installing a portal, using a CGO build, switching
+// compositor — which is the only thing they can act on.
+func TestCapabilities_DowngradedEntriesExplainThemselves(t *testing.T) {
+	live := newSystemPort(t).Capabilities()
+
+	staticPresets := map[string]ports.PlatformCapabilities{
+		"darwin":  ports.DarwinCapabilities(),
+		"linux":   ports.LinuxCapabilities(),
+		"windows": ports.WindowsCapabilities(),
+	}
+
+	preset, known := staticPresets[runtime.GOOS]
+	if !known {
+		t.Skipf("no static preset registered for %s", runtime.GOOS)
+	}
+
+	declared := make(map[ports.CapabilityKey]ports.FeatureCapability)
+	for _, entry := range preset.Entries() {
+		declared[entry.Key] = entry.FeatureCapability
+	}
+
+	for _, entry := range live.Entries() {
+		if entry.Status != ports.FeatureStatusStub {
+			continue
+		}
+
+		if declared[entry.Key].Status != ports.FeatureStatusSupported {
+			// Statically stubbed: its detail is already the static description.
+			continue
+		}
+
+		// Downgraded at runtime — the detail must differ from the static one,
+		// or the user is being shown a description of a feature that is not
+		// actually available to them.
+		if entry.Detail == declared[entry.Key].Detail {
+			t.Errorf(
+				"capability %q was downgraded to stub at runtime but still carries the "+
+					"static supported-description %q; it should explain the downgrade",
+				entry.Key, entry.Detail,
+			)
+		}
+
+		if entry.Detail == "" {
+			t.Errorf("capability %q was downgraded to stub with no explanation", entry.Key)
+		}
+	}
+}
+
+// TestCapabilities_PlatformLabelMatchesBuildTarget guards against a
+// copy-paste slip in the presets — a preset returning another platform's label
+// would make `neru doctor` misreport what it is running on.
+//
+// The label is either the bare GOOS or GOOS with a backend suffix: Linux
+// refines it to "linux/x11", "linux/wayland-wlroots" and so on, because which
+// backend is live is the first thing that matters when diagnosing Linux. Both
+// shapes are accepted; a different GOOS entirely is not.
+func TestCapabilities_PlatformLabelMatchesBuildTarget(t *testing.T) {
+	platform := newSystemPort(t).Capabilities().Platform
+
+	if platform == runtime.GOOS {
+		return
+	}
+
+	prefix := runtime.GOOS + "/"
+	if !strings.HasPrefix(platform, prefix) {
+		t.Errorf("Capabilities().Platform = %q, want %q or %q<backend>",
+			platform, runtime.GOOS, prefix)
+
+		return
+	}
+
+	if strings.TrimPrefix(platform, prefix) == "" {
+		t.Errorf("Capabilities().Platform = %q has an empty backend suffix", platform)
+	}
+}
+
+// TestCapabilities_EveryEntryHasAStatusAndDetail checks the surface that
+// actually reaches users. An entry with an empty status serializes as an empty
+// string in the IPC response, and one with no detail leaves `neru doctor`
+// printing a capability name with no explanation of what it means here.
+func TestCapabilities_EveryEntryHasAStatusAndDetail(t *testing.T) {
+	entries := newSystemPort(t).Capabilities().Entries()
+
+	if len(entries) == 0 {
+		t.Fatal("Capabilities().Entries() is empty")
+	}
+
+	validStatuses := map[ports.FeatureStatus]bool{
+		ports.FeatureStatusSupported: true,
+		ports.FeatureStatusHeadless:  true,
+		ports.FeatureStatusStub:      true,
+	}
+
+	for _, entry := range entries {
+		if !validStatuses[entry.Status] {
+			t.Errorf("capability %q has status %q, which is not one of supported/headless/stub",
+				entry.Key, entry.Status)
+		}
+
+		if entry.Detail == "" {
+			t.Errorf("capability %q has no detail; `neru doctor` would print it unexplained",
+				entry.Key)
+		}
+
+		if entry.Key == "" {
+			t.Errorf("capability with field %q has an empty wire key", entry.Field)
+		}
+	}
+}
+
+// TestCapabilities_ProbeCoverageIsDocumented records exactly which capabilities
+// the behavioral cross-check above covers and which it does not.
+//
+// It exists so the uncovered set is a deliberate, visible list rather than an
+// accident. Adding a capability without deciding whether it can be probed fails
+// here, which is the prompt to either write a probe or add it to the documented
+// exclusions with a reason.
+func TestCapabilities_ProbeCoverageIsDocumented(t *testing.T) {
+	// Capabilities with no side-effect-free entry point on SystemPort. Each
+	// needs a heavier fixture (a live overlay manager, an AX client, a uinput
+	// device) or has only a mutating entry point, so it is checked by that
+	// subsystem's own tests instead of here.
+	uncovered := map[ports.CapabilityKey]string{
+		ports.CapabilityAccessibility: "needs an AX client fixture; covered by internal/core/infra/accessibility",
+		ports.CapabilityOverlay:       "needs a live overlay manager; covered by internal/core/infra/overlay",
+		ports.CapabilityNotifications: "only entry point displays UI to the user",
+		ports.CapabilityGlobalHotkeys: "registration mutates global OS state",
+		ports.CapabilityKeyboardEventTap: "installing a tap mutates global OS state; " +
+			"covered by internal/core/infra/eventtap",
+		ports.CapabilityAppWatcher:        "requires a focus change to observe",
+		ports.CapabilityDarkModeDetection: "IsDarkMode returns no error, so NotSupported is unobservable",
+		ports.CapabilityTextInput:         "needs a live overlay window",
+		ports.CapabilityVision:            "a probe would trigger a screen-capture permission prompt",
+		ports.CapabilityKeyFeed:           "injects real keystrokes into the focused app",
+		ports.CapabilitySystray:           "needs a live run loop and adds a tray icon",
+	}
+
+	covered := make(map[ports.CapabilityKey]bool)
+	for _, probe := range systemCapabilityProbes() {
+		covered[probe.key] = true
+	}
+
+	for _, entry := range newSystemPort(t).Capabilities().Entries() {
+		reason, excused := uncovered[entry.Key]
+
+		switch {
+		case covered[entry.Key] && excused:
+			t.Errorf(
+				"capability %q is both probed and listed as uncovered; remove it from the exclusions",
+				entry.Key,
+			)
+
+		case !covered[entry.Key] && !excused:
+			t.Errorf(
+				"capability %q is neither probed by TestCapabilities_DeclaredStatusMatchesAdapterBehavior "+
+					"nor listed in the documented exclusions. Add a side-effect-free probe, or add it to "+
+					"`uncovered` with the reason it cannot have one.",
+				entry.Key,
+			)
+
+		case excused && reason == "":
+			t.Errorf("capability %q is excluded from probing with no stated reason", entry.Key)
+		}
+	}
+
+	// The exclusion list must not name capabilities that no longer exist —
+	// otherwise a renamed capability would silently become unprobed.
+	known := make(map[ports.CapabilityKey]bool)
+	for _, entry := range newSystemPort(t).Capabilities().Entries() {
+		known[entry.Key] = true
+	}
+
+	for key := range uncovered {
+		if !known[key] {
+			t.Errorf("exclusion list names %q, which is not a registered capability", key)
+		}
+	}
+}
+
+// TestCapabilities_StubsSurfaceNotSupportedNotNil states the rule that makes
+// degradation work at all: a stub must return an error callers can recognize
+// with IsNotSupported, not nil and not some other code. Callers branch on
+// exactly that predicate to fall back gracefully, so a stub returning a bare
+// error is treated as a real failure and surfaces to the user.
+func TestCapabilities_StubsSurfaceNotSupportedNotNil(t *testing.T) {
+	systemPort := newSystemPort(t)
+	capabilities := systemPort.Capabilities()
+	ctx := context.Background()
+
+	stubsFound := 0
+
+	for _, probe := range systemCapabilityProbes() {
+		if probe.read(capabilities).Status != ports.FeatureStatusStub {
+			continue
+		}
+
+		stubsFound++
+
+		err := probe.probe(ctx, systemPort)
+		if err == nil {
+			t.Errorf("stubbed capability %q returned nil; callers cannot detect the gap", probe.key)
+
+			continue
+		}
+
+		if !derrors.IsNotSupported(err) {
+			t.Errorf("stubbed capability %q returned %v (code %q), want CodeNotSupported",
+				probe.key, err, derrors.GetCode(err))
+		}
+
+		// errors.Is must agree with the helper, since some callers use it.
+		if !errors.Is(err, err) {
+			t.Errorf("stubbed capability %q returned an error that fails errors.Is against itself",
+				probe.key)
+		}
+	}
+
+	t.Logf("%s: %d of %d probed capabilities are stubbed",
+		runtime.GOOS, stubsFound, len(systemCapabilityProbes()))
+}

--- a/internal/core/infra/platform/linux/capabilities_linux_cgo.go
+++ b/internal/core/infra/platform/linux/capabilities_linux_cgo.go
@@ -1,0 +1,13 @@
+//go:build linux && cgo
+
+package linux
+
+// nativeBackendsCompiledIn reports whether the X11 and wlroots client stacks
+// were built into this binary.
+//
+// The screen, cursor and process capabilities all bottom out in those stacks
+// (Xlib for X11, the wlr-* Wayland protocols for wlroots), so a CGO_ENABLED=0
+// build links the _nocgo stubs instead and every one of them answers
+// CodeNotSupported no matter which compositor is running. Capabilities uses
+// this to report the truth rather than the build target's intent.
+const nativeBackendsCompiledIn = true

--- a/internal/core/infra/platform/linux/capabilities_linux_nocgo.go
+++ b/internal/core/infra/platform/linux/capabilities_linux_nocgo.go
@@ -1,0 +1,8 @@
+//go:build linux && !cgo
+
+package linux
+
+// nativeBackendsCompiledIn reports whether the X11 and wlroots client stacks
+// were built into this binary. See the cgo variant for why this gates the
+// screen, cursor and process capabilities.
+const nativeBackendsCompiledIn = false

--- a/internal/core/infra/platform/linux/capability_probes_linux_test.go
+++ b/internal/core/infra/platform/linux/capability_probes_linux_test.go
@@ -1,0 +1,226 @@
+//go:build linux
+
+//nolint:testpackage
+package linux
+
+// This is an internal test: reaching the probe registry needs its unexported
+// type.
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Capability probing runs each native call on its own goroutine so a wedged
+// display server cannot hang `neru doctor` or an IPC info request. Those native
+// calls cannot be canceled, so a probe that never returns keeps its goroutine
+// for the life of the process — and Capabilities is reached from two IPC
+// handlers in the long-lived daemon.
+//
+// Without a cap, every status or health request against a stuck backend would
+// start three more probes, growing goroutines and native handles without bound
+// for as long as the backend stayed wedged. These tests pin the cap at the
+// mechanism itself rather than through the adapter: on any real backend the
+// probes return immediately, so an adapter-level test would pass whether the
+// cap existed or not.
+
+const testProbeTimeout = 20 * time.Millisecond
+
+// errProbeFailed is a static error so probe results can be compared with
+// errors.Is.
+var errProbeFailed = errors.New("probe failed")
+
+// TestCapabilityProbes_WedgedProbeIsNotRestarted is the leak regression: while
+// one probe is stuck, further requests must not start another.
+func TestCapabilityProbes_WedgedProbeIsNotRestarted(t *testing.T) {
+	probes := newCapabilityProbes()
+
+	release := make(chan struct{})
+	defer close(release)
+
+	var starts atomic64
+
+	wedged := func() error {
+		starts.add(1)
+		<-release
+
+		return nil
+	}
+
+	// First request starts the probe and times out waiting for it.
+	if completed, _ := probes.run("wedged", testProbeTimeout, wedged); completed {
+		t.Fatal("a probe that never returns reported completion")
+	}
+
+	before := goroutineFloor()
+
+	const requests = 200
+
+	for range requests {
+		_, _ = probes.run("wedged", testProbeTimeout, wedged)
+	}
+
+	if got := starts.load(); got != 1 {
+		t.Errorf("probe was started %d times across %d requests, want exactly 1", got, requests+1)
+	}
+
+	after := goroutineFloor()
+
+	// One stuck goroutine is expected and unavoidable; hundreds are the leak.
+	const tolerance = 10
+
+	if after > before+tolerance {
+		t.Errorf(
+			"goroutines grew from %d to %d across %d requests; stuck probes are accumulating",
+			before, after, requests,
+		)
+	}
+}
+
+// TestCapabilityProbes_ReleasedProbeFreesTheSlot checks the cap is not a
+// one-way latch: once a stuck probe finally returns, probing resumes.
+func TestCapabilityProbes_ReleasedProbeFreesTheSlot(t *testing.T) {
+	probes := newCapabilityProbes()
+
+	release := make(chan struct{})
+
+	var starts atomic64
+
+	slow := func() error {
+		starts.add(1)
+		<-release
+
+		return nil
+	}
+
+	if completed, _ := probes.run("slow", testProbeTimeout, slow); completed {
+		t.Fatal("a blocked probe reported completion")
+	}
+
+	close(release)
+
+	// Wait for the slot to be handed back.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		completed, err := probes.run("slow", testProbeTimeout, func() error {
+			starts.add(1)
+
+			return nil
+		})
+
+		if completed && err == nil {
+			break
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatal("probe slot was never released after the blocked probe returned")
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got := starts.load(); got < 2 {
+		t.Errorf("probe ran %d times, want the slot to be reusable after release", got)
+	}
+}
+
+// TestCapabilityProbes_ReportsLastResultWhileBusy checks a request that arrives
+// while a probe is stuck reuses the previous answer rather than degrading the
+// capability to "timed out" on every subsequent call.
+func TestCapabilityProbes_ReportsLastResultWhileBusy(t *testing.T) {
+	probes := newCapabilityProbes()
+
+	// A completed run records its result.
+	completed, err := probes.run("feature", time.Second, func() error { return errProbeFailed })
+	if !completed {
+		t.Fatal("a probe that returns immediately reported no completion")
+	}
+
+	if !errors.Is(err, errProbeFailed) {
+		t.Fatalf("run returned %v, want %v", err, errProbeFailed)
+	}
+
+	// A later probe wedges; requests during it fall back to the recorded result.
+	release := make(chan struct{})
+	defer close(release)
+
+	if wedgedCompleted, _ := probes.run("feature", testProbeTimeout, func() error {
+		<-release
+
+		return nil
+	}); wedgedCompleted {
+		t.Fatal("a probe that never returns reported completion")
+	}
+
+	completed, err = probes.run("feature", testProbeTimeout, func() error { return nil })
+	if !completed {
+		t.Error("a request during a wedged probe reported no result despite an earlier one")
+	}
+
+	if !errors.Is(err, errProbeFailed) {
+		t.Errorf("request during a wedged probe returned %v, want the last known %v",
+			err, errProbeFailed)
+	}
+}
+
+// TestCapabilityProbes_SeparateFeaturesDoNotBlockEachOther checks the cap is
+// per feature: a wedged screen probe must not stop cursor or process reporting.
+func TestCapabilityProbes_SeparateFeaturesDoNotBlockEachOther(t *testing.T) {
+	probes := newCapabilityProbes()
+
+	release := make(chan struct{})
+	defer close(release)
+
+	if completed, _ := probes.run("screen", testProbeTimeout, func() error {
+		<-release
+
+		return nil
+	}); completed {
+		t.Fatal("a probe that never returns reported completion")
+	}
+
+	completed, err := probes.run("cursor", time.Second, func() error { return nil })
+	if !completed || err != nil {
+		t.Errorf("cursor probe returned (completed=%t, err=%v) while screen was wedged; "+
+			"features must not share a slot", completed, err)
+	}
+}
+
+// goroutineFloor returns the lowest goroutine count observed over a short
+// window, so a straggler still winding down is not mistaken for a leak.
+func goroutineFloor() int {
+	lowest := runtime.NumGoroutine()
+
+	for range 20 {
+		time.Sleep(5 * time.Millisecond)
+
+		if current := runtime.NumGoroutine(); current < lowest {
+			lowest = current
+		}
+	}
+
+	return lowest
+}
+
+// atomic64 is a minimal mutex-guarded counter, avoiding an import solely for a
+// test helper.
+type atomic64 struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (a *atomic64) add(delta int) {
+	a.mu.Lock()
+	a.n += delta
+	a.mu.Unlock()
+}
+
+func (a *atomic64) load() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.n
+}

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -90,79 +90,26 @@ func (s *SystemAdapter) Capabilities() ports.PlatformCapabilities {
 	// live-probed here rather than declared; Capabilities is only reached by
 	// `neru doctor` and the IPC info response, so the extra reads are cheap
 	// relative to how often it runs.
-	// Bounded so a wedged compositor cannot hang `neru doctor`, which is the
-	// command a user runs precisely when things are not working.
-	ctx, cancel := context.WithTimeout(context.Background(), capabilityProbeTimeout)
-	defer cancel()
-
-	capabilities.Process = s.probedCapability(capabilities.Process, "focused-app inspection",
+	capabilities.Process = s.probedCapability("focused-app inspection", capabilities.Process,
 		func() error {
-			_, err := s.FocusedApplicationPID(ctx)
+			_, err := s.FocusedApplicationPID(context.Background())
 
 			return err
 		})
-	capabilities.Screen = s.probedCapability(capabilities.Screen, "screen enumeration",
+	capabilities.Screen = s.probedCapability("screen enumeration", capabilities.Screen,
 		func() error {
-			_, err := s.ScreenBounds(ctx)
+			_, err := s.ScreenBounds(context.Background())
 
 			return err
 		})
-	capabilities.Cursor = s.probedCapability(capabilities.Cursor, "cursor tracking",
+	capabilities.Cursor = s.probedCapability("cursor tracking", capabilities.Cursor,
 		func() error {
-			_, err := s.CursorPosition(ctx)
+			_, err := s.CursorPosition(context.Background())
 
 			return err
 		})
 
 	return capabilities
-}
-
-// capabilityProbeTimeout bounds each live capability probe.
-const capabilityProbeTimeout = 2 * time.Second
-
-// probedCapability returns declared unchanged when probe succeeds, and a stub
-// carrying an actionable reason when probe reports the feature is unavailable.
-//
-// Only CodeNotSupported downgrades the status. A transient failure — the
-// compositor busy, a socket hiccup — leaves the capability as declared, because
-// the feature exists and the next call may well work; reporting it as a
-// permanent stub would send the user chasing a fix that is not needed.
-func (s *SystemAdapter) probedCapability(
-	declared ports.FeatureCapability,
-	feature string,
-	probe func() error,
-) ports.FeatureCapability {
-	err := probe()
-	if err == nil || !derrors.IsNotSupported(err) {
-		return declared
-	}
-
-	return ports.FeatureCapability{
-		Status: ports.FeatureStatusStub,
-		Detail: s.unavailableDetail(feature),
-	}
-}
-
-// unavailableDetail explains why a probed capability is unavailable, in terms
-// the user can act on.
-func (s *SystemAdapter) unavailableDetail(feature string) string {
-	if !nativeBackendsCompiledIn {
-		return feature + " is unavailable: this binary was built without CGO, so the X11 " +
-			"and wlroots client stacks are absent; use a CGO-enabled build"
-	}
-
-	if s.backend == "" {
-		return feature + " is unavailable: no display backend detected; start a session " +
-			"under X11, or a Wayland compositor with wlr-foreign-toplevel/layer-shell support"
-	}
-
-	if s.backend == backendX11 || s.waylandUsesWlrClientStack() {
-		return feature + " is unavailable on linux backend " + s.backend +
-			": the backend is supported but could not be reached (is the display server running?)"
-	}
-
-	return feature + " is not implemented on linux backend " + s.backend +
-		"; supported backends are x11, wayland-wlroots and wayland-kde"
 }
 
 // ConfigDir returns the Linux-specific configuration directory.
@@ -448,6 +395,103 @@ func (s *SystemAdapter) RequestScreenCapturePermission(
 	_ context.Context,
 ) ports.ScreenCaptureConsent {
 	return ports.ScreenCaptureGranted
+}
+
+// capabilityProbeTimeout bounds how long a single capability probe may take
+// before it is treated as unavailable.
+const capabilityProbeTimeout = 2 * time.Second
+
+// probedCapability reports declared when probe succeeds, and a stub explaining
+// why when it does not.
+//
+// Any probe failure downgrades the capability, not just CodeNotSupported. The
+// question `neru doctor` answers is "does this work right now?", and a backend
+// that is compiled in but cannot open its display fails with CodeActionFailed —
+// reporting that as "supported" would be the same lie this probing exists to
+// remove. The detail distinguishes the cases so the user knows whether to
+// install something, start a session, or look at a broken display server.
+func (s *SystemAdapter) probedCapability(
+	feature string,
+	declared ports.FeatureCapability,
+	probe func() error,
+) ports.FeatureCapability {
+	completed, err := probeWithin(capabilityProbeTimeout, probe)
+
+	switch {
+	case !completed:
+		return ports.FeatureCapability{
+			Status: ports.FeatureStatusStub,
+			Detail: feature + " is unavailable: the " + s.backendLabel() +
+				" backend did not respond within " + capabilityProbeTimeout.String() +
+				"; the display server may be wedged",
+		}
+	case err != nil:
+		return ports.FeatureCapability{
+			Status: ports.FeatureStatusStub,
+			Detail: s.unavailableDetail(feature, err),
+		}
+	default:
+		return declared
+	}
+}
+
+// unavailableDetail explains why a probed capability is unavailable, in terms
+// the user can act on.
+func (s *SystemAdapter) unavailableDetail(feature string, cause error) string {
+	if !nativeBackendsCompiledIn {
+		return feature + " is unavailable: this binary was built without CGO, so the X11 " +
+			"and wlroots client stacks are absent; use a CGO-enabled build"
+	}
+
+	if s.backend == "" {
+		return feature + " is unavailable: no display backend detected; start a session " +
+			"under X11, or a Wayland compositor with wlr-foreign-toplevel/layer-shell support"
+	}
+
+	if s.backend == backendX11 || s.waylandUsesWlrClientStack() {
+		// The backend is implemented, so this is a live failure rather than a
+		// gap — carry the underlying reason, which is the actionable part.
+		return feature + " is unavailable on linux backend " + s.backend + ": " + cause.Error()
+	}
+
+	return feature + " is not implemented on linux backend " + s.backend +
+		"; supported backends are x11, wayland-wlroots and wayland-kde"
+}
+
+// backendLabel names the backend for diagnostics, including the undetected case.
+func (s *SystemAdapter) backendLabel() string {
+	if s.backend == "" {
+		return "undetected"
+	}
+
+	return s.backend
+}
+
+// probeWithin runs probe, reporting whether it finished within timeout and, if
+// it did, the error it returned.
+//
+// The native screen, cursor and process calls do not observe a context — they
+// enter Xlib or a Wayland roundtrip and return when they return — so a context
+// deadline passed down to them would bound nothing. Running the probe on its
+// own goroutine is what actually keeps `neru doctor` and the IPC info handler
+// responsive. The channel is buffered so a probe that finishes late still
+// delivers and exits rather than leaking permanently; only a probe that never
+// returns holds its goroutine, which is strictly better than blocking the
+// caller forever.
+func probeWithin(timeout time.Duration, probe func() error) (bool, error) {
+	done := make(chan error, 1)
+
+	go func() { done <- probe() }()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-done:
+		return true, err
+	case <-timer.C:
+		return false, nil
+	}
 }
 
 // moveCursorDirect performs a single instantaneous cursor warp, routing to the

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
@@ -29,11 +30,12 @@ const (
 type SystemAdapter struct {
 	backend        string
 	cursorAnimator *smoothCursorAnimator
+	probes         *capabilityProbes
 }
 
 // NewSystemAdapter creates a new SystemAdapter.
 func NewSystemAdapter(backend string) *SystemAdapter {
-	adapter := &SystemAdapter{backend: backend}
+	adapter := &SystemAdapter{backend: backend, probes: newCapabilityProbes()}
 	adapter.cursorAnimator = newSmoothCursorAnimator(
 		adapter.currentCursorPosition,
 		adapter.moveCursorDirect,
@@ -415,7 +417,7 @@ func (s *SystemAdapter) probedCapability(
 	declared ports.FeatureCapability,
 	probe func() error,
 ) ports.FeatureCapability {
-	completed, err := probeWithin(capabilityProbeTimeout, probe)
+	completed, err := s.probes.run(feature, capabilityProbeTimeout, probe)
 
 	switch {
 	case !completed:
@@ -467,21 +469,72 @@ func (s *SystemAdapter) backendLabel() string {
 	return s.backend
 }
 
-// probeWithin runs probe, reporting whether it finished within timeout and, if
-// it did, the error it returned.
+// capabilityProbes serializes capability probing per feature.
 //
-// The native screen, cursor and process calls do not observe a context — they
-// enter Xlib or a Wayland roundtrip and return when they return — so a context
-// deadline passed down to them would bound nothing. Running the probe on its
-// own goroutine is what actually keeps `neru doctor` and the IPC info handler
-// responsive. The channel is buffered so a probe that finishes late still
-// delivers and exits rather than leaking permanently; only a probe that never
-// returns holds its goroutine, which is strictly better than blocking the
-// caller forever.
-func probeWithin(timeout time.Duration, probe func() error) (bool, error) {
+// A probe that times out leaves its goroutine blocked in a native call that
+// cannot be canceled. Without this, every subsequent doctor, status or health
+// request against a wedged display server would start three more, so goroutines
+// and native handles would grow without bound for as long as the backend stayed
+// stuck. Holding one slot per feature caps the outstanding probes at exactly
+// one each, however often capabilities are requested.
+type capabilityProbes struct {
+	mu    sync.Mutex
+	state map[string]*probeRun
+}
+
+// probeRun tracks a single feature's probe slot and its most recent result.
+type probeRun struct {
+	inFlight bool
+	haveLast bool
+	lastErr  error
+}
+
+func newCapabilityProbes() *capabilityProbes {
+	return &capabilityProbes{state: make(map[string]*probeRun)}
+}
+
+// run probes feature, returning whether a result is available and what it was.
+//
+// When a probe from an earlier request is still stuck, run does not start
+// another: it reports the previous result if there is one, so a transiently
+// slow backend keeps answering with its last known state instead of degrading
+// every capability to "timed out".
+func (p *capabilityProbes) run(
+	feature string,
+	timeout time.Duration,
+	probe func() error,
+) (bool, error) {
+	p.mu.Lock()
+
+	run, ok := p.state[feature]
+	if !ok {
+		run = &probeRun{}
+		p.state[feature] = run
+	}
+
+	if run.inFlight {
+		haveLast, lastErr := run.haveLast, run.lastErr
+		p.mu.Unlock()
+
+		return haveLast, lastErr
+	}
+
+	run.inFlight = true
+	p.mu.Unlock()
+
 	done := make(chan error, 1)
 
-	go func() { done <- probe() }()
+	go func() {
+		err := probe()
+
+		p.mu.Lock()
+		run.inFlight = false
+		run.haveLast = true
+		run.lastErr = err
+		p.mu.Unlock()
+
+		done <- err
+	}()
 
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()

--- a/internal/core/infra/platform/linux/system_linux_common.go
+++ b/internal/core/infra/platform/linux/system_linux_common.go
@@ -76,7 +76,93 @@ func (s *SystemAdapter) Capabilities() ports.PlatformCapabilities {
 	value, source, ok := darkModePreference()
 	capabilities.DarkModeDetection = darkModeCapability(value, source, ok)
 
+	// Screen, cursor and process support is decided by what this binary and
+	// this session can actually reach, not by the build target. The static
+	// Linux preset claims all three are supported, which is wrong for a
+	// CGO_ENABLED=0 build, for a compositor with no wlroots client stack, and
+	// for a session where the display cannot be opened at all: the adapter
+	// answers CodeNotSupported while `neru doctor` says "supported", which is
+	// exactly backwards from what a user debugging Linux needs.
+	//
+	// Each one is settled by calling the same read-only entry point the
+	// capability describes, so the reported status cannot disagree with what a
+	// caller will observe. This mirrors how dark-mode detection is already
+	// live-probed here rather than declared; Capabilities is only reached by
+	// `neru doctor` and the IPC info response, so the extra reads are cheap
+	// relative to how often it runs.
+	// Bounded so a wedged compositor cannot hang `neru doctor`, which is the
+	// command a user runs precisely when things are not working.
+	ctx, cancel := context.WithTimeout(context.Background(), capabilityProbeTimeout)
+	defer cancel()
+
+	capabilities.Process = s.probedCapability(capabilities.Process, "focused-app inspection",
+		func() error {
+			_, err := s.FocusedApplicationPID(ctx)
+
+			return err
+		})
+	capabilities.Screen = s.probedCapability(capabilities.Screen, "screen enumeration",
+		func() error {
+			_, err := s.ScreenBounds(ctx)
+
+			return err
+		})
+	capabilities.Cursor = s.probedCapability(capabilities.Cursor, "cursor tracking",
+		func() error {
+			_, err := s.CursorPosition(ctx)
+
+			return err
+		})
+
 	return capabilities
+}
+
+// capabilityProbeTimeout bounds each live capability probe.
+const capabilityProbeTimeout = 2 * time.Second
+
+// probedCapability returns declared unchanged when probe succeeds, and a stub
+// carrying an actionable reason when probe reports the feature is unavailable.
+//
+// Only CodeNotSupported downgrades the status. A transient failure — the
+// compositor busy, a socket hiccup — leaves the capability as declared, because
+// the feature exists and the next call may well work; reporting it as a
+// permanent stub would send the user chasing a fix that is not needed.
+func (s *SystemAdapter) probedCapability(
+	declared ports.FeatureCapability,
+	feature string,
+	probe func() error,
+) ports.FeatureCapability {
+	err := probe()
+	if err == nil || !derrors.IsNotSupported(err) {
+		return declared
+	}
+
+	return ports.FeatureCapability{
+		Status: ports.FeatureStatusStub,
+		Detail: s.unavailableDetail(feature),
+	}
+}
+
+// unavailableDetail explains why a probed capability is unavailable, in terms
+// the user can act on.
+func (s *SystemAdapter) unavailableDetail(feature string) string {
+	if !nativeBackendsCompiledIn {
+		return feature + " is unavailable: this binary was built without CGO, so the X11 " +
+			"and wlroots client stacks are absent; use a CGO-enabled build"
+	}
+
+	if s.backend == "" {
+		return feature + " is unavailable: no display backend detected; start a session " +
+			"under X11, or a Wayland compositor with wlr-foreign-toplevel/layer-shell support"
+	}
+
+	if s.backend == backendX11 || s.waylandUsesWlrClientStack() {
+		return feature + " is unavailable on linux backend " + s.backend +
+			": the backend is supported but could not be reached (is the display server running?)"
+	}
+
+	return feature + " is not implemented on linux backend " + s.backend +
+		"; supported backends are x11, wayland-wlroots and wayland-kde"
 }
 
 // ConfigDir returns the Linux-specific configuration directory.

--- a/internal/core/infra/platform/linux/system_stub_contract_linux_test.go
+++ b/internal/core/infra/platform/linux/system_stub_contract_linux_test.go
@@ -1,0 +1,386 @@
+//go:build linux
+
+package linux_test
+
+import (
+	"context"
+	"image"
+	"testing"
+
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	"github.com/y3owk1n/neru/internal/core/infra/platform/linux"
+)
+
+// SystemAdapter routes every screen, cursor and process query through a backend
+// switch, and falls through to a CodeNotSupported stub when the live backend is
+// neither X11 nor a wlroots-family Wayland stack (KWin and GNOME reach this
+// today for several of these).
+//
+// That fallthrough is load-bearing. Callers branch on derrors.IsNotSupported to
+// degrade gracefully — fall back to the active screen, skip a monitor query,
+// disable a mode — so a stub that returned a bare error would be reported to
+// the user as a real failure, and one that returned a zero value with nil would
+// be worse still: the caller would place hints at (0,0) on a screen it believes
+// is 0x0 rather than falling back.
+//
+// The methods here are exercised through an adapter built with a backend name
+// that matches no implemented backend, which is exactly the state a new or
+// unrecognised compositor produces. NewSystemAdapter takes the backend as a
+// plain string, so no compositor needs to be running for this to be meaningful.
+//
+// This file is tagged linux and therefore runs on the Linux CI runner. Adding a
+// backend, or implementing one of these methods, should make the corresponding
+// case fail here and prompt a matching update to the capability matrix in
+// ports/capability_presets.go — see internal/core/infra/platform's
+// TestCapabilities_DeclaredStatusMatchesAdapterBehavior.
+
+// unimplementedBackend is a backend name no dispatch branch recognises, so
+// every method falls through to its stub.
+const unimplementedBackend = "test-unimplemented-backend"
+
+// stubCall names a SystemAdapter method and invokes it, discarding any
+// non-error results so only the error contract is under test.
+type stubCall struct {
+	name string
+	call func(context.Context, *linux.SystemAdapter) error
+}
+
+func stubCalls() []stubCall {
+	return []stubCall{
+		{
+			name: "FocusedApplicationPID",
+			call: func(ctx context.Context, a *linux.SystemAdapter) error {
+				_, err := a.FocusedApplicationPID(ctx)
+
+				return err
+			},
+		},
+		{
+			name: "ScreenBounds",
+			call: func(ctx context.Context, a *linux.SystemAdapter) error {
+				_, err := a.ScreenBounds(ctx)
+
+				return err
+			},
+		},
+		{
+			name: "ScreenBoundsByName",
+			call: func(ctx context.Context, a *linux.SystemAdapter) error {
+				_, _, err := a.ScreenBoundsByName(ctx, "DP-1")
+
+				return err
+			},
+		},
+		{
+			name: "ScreenNames",
+			call: func(ctx context.Context, a *linux.SystemAdapter) error {
+				_, err := a.ScreenNames(ctx)
+
+				return err
+			},
+		},
+		{
+			name: "FocusedWindowBounds",
+			call: func(ctx context.Context, a *linux.SystemAdapter) error {
+				_, _, err := a.FocusedWindowBounds(ctx)
+
+				return err
+			},
+		},
+		{
+			name: "CursorPosition",
+			call: func(ctx context.Context, a *linux.SystemAdapter) error {
+				_, err := a.CursorPosition(ctx)
+
+				return err
+			},
+		},
+	}
+}
+
+// TestSystemAdapter_UnimplementedBackendReportsNotSupported is the core stub
+// contract: on a backend with no implementation, each method must report
+// CodeNotSupported rather than succeeding or failing some other way.
+func TestSystemAdapter_UnimplementedBackendReportsNotSupported(t *testing.T) {
+	adapter := linux.NewSystemAdapter(unimplementedBackend)
+	ctx := context.Background()
+
+	for _, testCase := range stubCalls() {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.call(ctx, adapter)
+			if err == nil {
+				t.Fatalf(
+					"%s on an unimplemented backend returned nil; callers cannot tell the "+
+						"feature is missing and will act on a zero value",
+					testCase.name,
+				)
+			}
+
+			if !derrors.IsNotSupported(err) {
+				t.Errorf(
+					"%s returned %v (code %q), want CodeNotSupported so callers can degrade "+
+						"via derrors.IsNotSupported",
+					testCase.name, err, derrors.GetCode(err),
+				)
+			}
+		})
+	}
+}
+
+// TestSystemAdapter_NotSupportedErrorNamesTheBackend checks the message carries
+// the backend name. This is the string a user sees in `neru doctor` output and
+// in logs; without it, "not yet implemented on linux backend" gives no clue
+// which compositor was detected, which is the first thing needed to act on it.
+func TestSystemAdapter_NotSupportedErrorNamesTheBackend(t *testing.T) {
+	adapter := linux.NewSystemAdapter(unimplementedBackend)
+	ctx := context.Background()
+
+	for _, testCase := range stubCalls() {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.call(ctx, adapter)
+			if err == nil {
+				t.Fatalf("%s returned nil, expected a NotSupported error", testCase.name)
+			}
+
+			if !contains(err.Error(), unimplementedBackend) {
+				t.Errorf("%s error %q does not name the backend %q",
+					testCase.name, err.Error(), unimplementedBackend)
+			}
+		})
+	}
+}
+
+// TestSystemAdapter_StubsDoNotPanicOnACanceledContext makes sure the stub path
+// is reached without touching the context in a way that panics. Config reload
+// and shutdown both cancel mid-flight, so these are called with dead contexts
+// in practice.
+func TestSystemAdapter_StubsDoNotPanicOnACanceledContext(t *testing.T) {
+	adapter := linux.NewSystemAdapter(unimplementedBackend)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for _, testCase := range stubCalls() {
+		t.Run(testCase.name, func(t *testing.T) {
+			// A panic here fails the subtest; the assertion is that some error
+			// comes back rather than a zero value with nil.
+			if err := testCase.call(ctx, adapter); err == nil {
+				t.Errorf("%s with a canceled context returned nil", testCase.name)
+			}
+		})
+	}
+}
+
+// TestSystemAdapter_PlatformLabelReflectsTheBackend pins the label used in
+// startup notices and diagnostics, including the empty-backend fallback.
+func TestSystemAdapter_PlatformLabelReflectsTheBackend(t *testing.T) {
+	tests := []struct {
+		backend string
+		want    string
+	}{
+		{unimplementedBackend, "linux/" + unimplementedBackend},
+		{"x11", "linux/x11"},
+		{"wayland-wlroots", "linux/wayland-wlroots"},
+		{"", "linux"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.want, func(t *testing.T) {
+			got := linux.NewSystemAdapter(testCase.backend).PlatformLabel()
+			if got != testCase.want {
+				t.Errorf("PlatformLabel() with backend %q = %q, want %q",
+					testCase.backend, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestSystemAdapter_CapabilitiesCarryTheBackendSuffix checks the capability
+// surface reports which backend is live, since that is what makes `neru doctor`
+// actionable on Linux.
+func TestSystemAdapter_CapabilitiesCarryTheBackendSuffix(t *testing.T) {
+	capabilities := linux.NewSystemAdapter(unimplementedBackend).Capabilities()
+
+	want := "linux/" + unimplementedBackend
+	if capabilities.Platform != want {
+		t.Errorf("Capabilities().Platform = %q, want %q", capabilities.Platform, want)
+	}
+
+	// An adapter with no detected backend still reports the bare platform
+	// rather than a dangling separator.
+	if got := linux.NewSystemAdapter("").Capabilities().Platform; got != "linux" {
+		t.Errorf("Capabilities().Platform with no backend = %q, want %q", got, "linux")
+	}
+}
+
+// TestSystemAdapter_CapabilitiesMatchBackendBehavior is the Linux half of the
+// capability cross-check.
+//
+// The platform-level test skips on a headless runner, because NewSystemPort
+// refuses to build an adapter with no display server. Here the adapter is
+// constructed directly for a named backend, so the declared-vs-actual contract
+// is asserted with no display and no compositor — which means it runs on every
+// Linux CI job rather than only on a developer's desktop.
+//
+// The rule is the same one the whole capability surface rests on: a capability
+// reported supported must not answer CodeNotSupported, and one reported stub
+// must.
+func TestSystemAdapter_CapabilitiesMatchBackendBehavior(t *testing.T) {
+	// Every backend name that reaches the dispatch, including ones with no
+	// implementation, so both sides of the contract are exercised.
+	backends := []string{unimplementedBackend, "", "x11", "wayland-wlroots", "wayland-kde"}
+
+	ctx := context.Background()
+
+	for _, backend := range backends {
+		name := backend
+		if name == "" {
+			name = "(undetected)"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			adapter := linux.NewSystemAdapter(backend)
+			capabilities := adapter.Capabilities()
+
+			checks := []struct {
+				key      string
+				declared func() bool
+				call     func() error
+			}{
+				{
+					key:      "process",
+					declared: func() bool { return capabilities.Process.Supported() },
+					call: func() error {
+						_, err := adapter.FocusedApplicationPID(ctx)
+
+						return err
+					},
+				},
+				{
+					key:      "screen",
+					declared: func() bool { return capabilities.Screen.Supported() },
+					call: func() error {
+						_, err := adapter.ScreenBounds(ctx)
+
+						return err
+					},
+				},
+				{
+					key:      "cursor",
+					declared: func() bool { return capabilities.Cursor.Supported() },
+					call: func() error {
+						_, err := adapter.CursorPosition(ctx)
+
+						return err
+					},
+				},
+			}
+
+			for _, check := range checks {
+				err := check.call()
+				notSupported := derrors.IsNotSupported(err)
+
+				switch {
+				case check.declared() && notSupported:
+					t.Errorf(
+						"backend %q declares %q supported but the adapter returned "+
+							"CodeNotSupported: %v",
+						backend, check.key, err,
+					)
+
+				case !check.declared() && !notSupported:
+					// A stubbed capability that answers anything other than
+					// NotSupported breaks caller fallback. Note this tolerates a
+					// real success only if the capability is declared supported.
+					t.Errorf(
+						"backend %q declares %q stubbed but the adapter did not return "+
+							"CodeNotSupported (got %v)",
+						backend, check.key, err,
+					)
+				}
+			}
+		})
+	}
+}
+
+// TestSystemAdapter_DowngradedCapabilitiesExplainWhy checks that when a
+// capability is downgraded from the static Linux preset, the detail says what
+// to do about it. "stub" alone tells a user their feature is missing but not
+// whether a CGO build, a different compositor, or nothing at all would fix it.
+func TestSystemAdapter_DowngradedCapabilitiesExplainWhy(t *testing.T) {
+	capabilities := linux.NewSystemAdapter(unimplementedBackend).Capabilities()
+
+	downgraded := []struct {
+		key  string
+		read func() (string, bool)
+	}{
+		{"process", func() (string, bool) {
+			return capabilities.Process.Detail, capabilities.Process.Supported()
+		}},
+		{"screen", func() (string, bool) {
+			return capabilities.Screen.Detail, capabilities.Screen.Supported()
+		}},
+		{"cursor", func() (string, bool) {
+			return capabilities.Cursor.Detail, capabilities.Cursor.Supported()
+		}},
+	}
+
+	for _, entry := range downgraded {
+		detail, supported := entry.read()
+
+		if supported {
+			t.Errorf("capability %q is reported supported on an unimplemented backend", entry.key)
+
+			continue
+		}
+
+		if detail == "" {
+			t.Errorf("capability %q was downgraded with no explanation", entry.key)
+
+			continue
+		}
+
+		// The detail must name the backend or the missing prerequisite, not
+		// merely restate that the feature is unavailable.
+		if !contains(detail, unimplementedBackend) && !contains(detail, "CGO") {
+			t.Errorf(
+				"capability %q detail %q neither names the backend nor the missing "+
+					"prerequisite, so it is not actionable",
+				entry.key, detail,
+			)
+		}
+	}
+}
+
+// TestSystemAdapter_MoveCursorToPointReportsNotSupported covers the one mutating
+// method worth pinning here. It is safe on an unimplemented backend precisely
+// because nothing is wired up to move — which is the behavior being asserted.
+func TestSystemAdapter_MoveCursorToPointReportsNotSupported(t *testing.T) {
+	adapter := linux.NewSystemAdapter(unimplementedBackend)
+
+	err := adapter.MoveCursorToPoint(context.Background(), image.Point{X: 10, Y: 10}, true)
+	if err == nil {
+		t.Fatal("MoveCursorToPoint on an unimplemented backend returned nil")
+	}
+
+	if !derrors.IsNotSupported(err) {
+		t.Errorf("MoveCursorToPoint returned %v (code %q), want CodeNotSupported",
+			err, derrors.GetCode(err))
+	}
+}
+
+// contains reports whether s contains substr, avoiding a strings import in a
+// file that otherwise needs none.
+func contains(s, substr string) bool {
+	if len(substr) == 0 {
+		return true
+	}
+
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/core/infra/platform/linux/system_stub_contract_linux_test.go
+++ b/internal/core/infra/platform/linux/system_stub_contract_linux_test.go
@@ -5,6 +5,7 @@ package linux_test
 import (
 	"context"
 	"image"
+	"strings"
 	"testing"
 
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
@@ -25,7 +26,7 @@ import (
 //
 // The methods here are exercised through an adapter built with a backend name
 // that matches no implemented backend, which is exactly the state a new or
-// unrecognised compositor produces. NewSystemAdapter takes the backend as a
+// unrecognized compositor produces. NewSystemAdapter takes the backend as a
 // plain string, so no compositor needs to be running for this to be meaningful.
 //
 // This file is tagged linux and therefore runs on the Linux CI runner. Adding a
@@ -34,7 +35,7 @@ import (
 // ports/capability_presets.go — see internal/core/infra/platform's
 // TestCapabilities_DeclaredStatusMatchesAdapterBehavior.
 
-// unimplementedBackend is a backend name no dispatch branch recognises, so
+// unimplementedBackend is a backend name no dispatch branch recognizes, so
 // every method falls through to its stub.
 const unimplementedBackend = "test-unimplemented-backend"
 
@@ -142,7 +143,7 @@ func TestSystemAdapter_NotSupportedErrorNamesTheBackend(t *testing.T) {
 				t.Fatalf("%s returned nil, expected a NotSupported error", testCase.name)
 			}
 
-			if !contains(err.Error(), unimplementedBackend) {
+			if !strings.Contains(err.Error(), unimplementedBackend) {
 				t.Errorf("%s error %q does not name the backend %q",
 					testCase.name, err.Error(), unimplementedBackend)
 			}
@@ -164,7 +165,8 @@ func TestSystemAdapter_StubsDoNotPanicOnACanceledContext(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			// A panic here fails the subtest; the assertion is that some error
 			// comes back rather than a zero value with nil.
-			if err := testCase.call(ctx, adapter); err == nil {
+			err := testCase.call(ctx, adapter)
+			if err == nil {
 				t.Errorf("%s with a canceled context returned nil", testCase.name)
 			}
 		})
@@ -342,7 +344,8 @@ func TestSystemAdapter_DowngradedCapabilitiesExplainWhy(t *testing.T) {
 
 		// The detail must name the backend or the missing prerequisite, not
 		// merely restate that the feature is unavailable.
-		if !contains(detail, unimplementedBackend) && !contains(detail, "CGO") {
+		if !strings.Contains(detail, unimplementedBackend) &&
+			!strings.Contains(detail, "CGO") {
 			t.Errorf(
 				"capability %q detail %q neither names the backend nor the missing "+
 					"prerequisite, so it is not actionable",
@@ -367,20 +370,4 @@ func TestSystemAdapter_MoveCursorToPointReportsNotSupported(t *testing.T) {
 		t.Errorf("MoveCursorToPoint returned %v (code %q), want CodeNotSupported",
 			err, derrors.GetCode(err))
 	}
-}
-
-// contains reports whether s contains substr, avoiding a strings import in a
-// file that otherwise needs none.
-func contains(s, substr string) bool {
-	if len(substr) == 0 {
-		return true
-	}
-
-	for i := 0; i+len(substr) <= len(s); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/core/infra/vision/adapter_stub_contract_other_test.go
+++ b/internal/core/infra/vision/adapter_stub_contract_other_test.go
@@ -1,0 +1,142 @@
+//go:build !darwin
+
+package vision_test
+
+import (
+	"context"
+	"image"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	"github.com/y3owk1n/neru/internal/core/infra/vision"
+)
+
+// The vision adapter is fully stubbed off macOS: the Vision framework and
+// ScreenCaptureKit have no equivalent elsewhere, so every method reports
+// CodeNotSupported.
+//
+// Pinning that matters more than it looks. The hint pipeline chooses between
+// the accessibility strategy and the vision strategy at runtime, and it decides
+// vision is unavailable by calling Health and checking IsNotSupported. If a
+// stub here started returning nil — say a refactor gave Health a default
+// "return nil" — the pipeline would select the vision strategy on Linux, then
+// get an empty element list from DetectElements and show the user no hints at
+// all, with no error to explain why.
+//
+// Tagged !darwin, so this runs on both the Linux and Windows CI runners.
+
+func TestVisionAdapter_AllMethodsReportNotSupportedOffDarwin(t *testing.T) {
+	adapter := vision.NewAdapter(nil)
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "Health",
+			call: func() error { return adapter.Health(ctx) },
+		},
+		{
+			name: "CaptureScreen",
+			call: func() error {
+				_, err := adapter.CaptureScreen(ctx)
+
+				return err
+			},
+		},
+		{
+			name: "DetectElements",
+			call: func() error {
+				_, err := adapter.DetectElements(
+					ctx,
+					image.Rect(0, 0, 100, 100),
+					config.DefaultConfig().Hints.Vision,
+					false,
+				)
+
+				return err
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.call()
+			if err == nil {
+				t.Fatalf(
+					"%s returned nil off darwin; the hint pipeline would select the vision "+
+						"strategy and then silently produce no hints",
+					testCase.name,
+				)
+			}
+
+			if !derrors.IsNotSupported(err) {
+				t.Errorf("%s returned %v (code %q), want CodeNotSupported",
+					testCase.name, err, derrors.GetCode(err))
+			}
+		})
+	}
+}
+
+// TestVisionAdapter_StubsReturnNoPartialResults checks the stubs hand back
+// nothing alongside their error. A caller that ignored the error and used the
+// result would otherwise act on a half-built value.
+func TestVisionAdapter_StubsReturnNoPartialResults(t *testing.T) {
+	adapter := vision.NewAdapter(nil)
+	ctx := context.Background()
+
+	elements, err := adapter.DetectElements(
+		ctx,
+		image.Rect(0, 0, 100, 100),
+		config.DefaultConfig().Hints.Vision,
+		true,
+	)
+	if err == nil {
+		t.Fatal("DetectElements returned nil error off darwin")
+	}
+
+	if elements != nil {
+		t.Errorf("DetectElements returned %d elements alongside its error, want nil",
+			len(elements))
+	}
+
+	capture, err := adapter.CaptureScreen(ctx)
+	if err == nil {
+		t.Fatal("CaptureScreen returned nil error off darwin")
+	}
+
+	if capture != nil {
+		t.Error("CaptureScreen returned an image alongside its error, want nil")
+	}
+}
+
+// TestVisionAdapter_StubsAreStableAcrossCalls guards against a stub that
+// succeeds once — for example one that lazily initializes some state and then
+// reports a different error, or none, on a second call.
+func TestVisionAdapter_StubsAreStableAcrossCalls(t *testing.T) {
+	adapter := vision.NewAdapter(nil)
+	ctx := context.Background()
+
+	for i := range 3 {
+		if err := adapter.Health(ctx); !derrors.IsNotSupported(err) {
+			t.Fatalf("Health call %d returned %v, want CodeNotSupported every time", i+1, err)
+		}
+	}
+}
+
+// TestVisionAdapter_NilLoggerIsAccepted covers the constructor contract shared
+// with every other adapter in the tree: a nil logger falls back to a no-op
+// rather than panicking on first use.
+func TestVisionAdapter_NilLoggerIsAccepted(t *testing.T) {
+	adapter := vision.NewAdapter(nil)
+	if adapter == nil {
+		t.Fatal("NewAdapter(nil) returned nil")
+	}
+
+	// Exercising a method proves the fallback logger is actually usable.
+	if err := adapter.Health(context.Background()); err == nil {
+		t.Error("Health returned nil off darwin")
+	}
+}

--- a/internal/core/infra/vision/adapter_stub_contract_other_test.go
+++ b/internal/core/infra/vision/adapter_stub_contract_other_test.go
@@ -120,7 +120,8 @@ func TestVisionAdapter_StubsAreStableAcrossCalls(t *testing.T) {
 	ctx := context.Background()
 
 	for i := range 3 {
-		if err := adapter.Health(ctx); !derrors.IsNotSupported(err) {
+		err := adapter.Health(ctx)
+		if !derrors.IsNotSupported(err) {
 			t.Fatalf("Health call %d returned %v, want CodeNotSupported every time", i+1, err)
 		}
 	}
@@ -136,7 +137,8 @@ func TestVisionAdapter_NilLoggerIsAccepted(t *testing.T) {
 	}
 
 	// Exercising a method proves the fallback logger is actually usable.
-	if err := adapter.Health(context.Background()); err == nil {
+	err := adapter.Health(context.Background())
+	if err == nil {
 		t.Error("Health returned nil off darwin")
 	}
 }

--- a/internal/ui/renderer_test.go
+++ b/internal/ui/renderer_test.go
@@ -1,0 +1,496 @@
+package ui_test
+
+import (
+	"errors"
+	"image"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/config"
+	domainGrid "github.com/y3owk1n/neru/internal/core/domain/grid"
+	"github.com/y3owk1n/neru/internal/core/infra/overlay"
+	"github.com/y3owk1n/neru/internal/core/infra/overlay/render/grid"
+	"github.com/y3owk1n/neru/internal/core/infra/overlay/render/hints"
+	"github.com/y3owk1n/neru/internal/core/infra/overlay/render/recursivegrid"
+	"github.com/y3owk1n/neru/internal/ui"
+)
+
+// errDraw is returned by the fake manager to check error propagation.
+var errDraw = errors.New("draw failed")
+
+// recursiveGridCall captures every argument DrawRecursiveGrid received. The
+// signature has seven consecutive int/string parameters, so recording them
+// individually is what makes a transposition detectable.
+type recursiveGridCall struct {
+	bounds         image.Rectangle
+	depth          int
+	keys           string
+	gridCols       int
+	gridRows       int
+	nextKeys       string
+	nextGridCols   int
+	nextGridRows   int
+	style          recursivegrid.Style
+	virtualPointer recursivegrid.VirtualPointerState
+}
+
+// fakeManager records what the renderer forwarded. It embeds NoOpManager so
+// that only the methods the renderer actually calls need overriding; if
+// ManagerInterface grows a method, this keeps compiling.
+type fakeManager struct {
+	overlay.NoOpManager
+
+	drawHintsErr error
+	drawGridErr  error
+	recursiveErr error
+
+	hintsArg      []*hints.Hint
+	hintsStyle    hints.StyleMode
+	hintsCalls    int
+	gridArg       *domainGrid.Grid
+	gridInput     string
+	gridStyle     grid.Style
+	gridCalls     int
+	subgridCell   *domainGrid.Cell
+	subgridStyle  grid.Style
+	matchesPrefix string
+	hideUnmatched bool
+	showCalls     int
+	clearCalls    int
+	resizeCalls   int
+	indicatorX    int
+	indicatorY    int
+	recursive     recursiveGridCall
+	recursiveHits int
+}
+
+func (m *fakeManager) DrawHintsWithStyle(hs []*hints.Hint, style hints.StyleMode) error {
+	m.hintsArg = hs
+	m.hintsStyle = style
+	m.hintsCalls++
+
+	return m.drawHintsErr
+}
+
+func (m *fakeManager) DrawGrid(g *domainGrid.Grid, input string, style grid.Style) error {
+	m.gridArg = g
+	m.gridInput = input
+	m.gridStyle = style
+	m.gridCalls++
+
+	return m.drawGridErr
+}
+
+func (m *fakeManager) ShowSubgrid(cell *domainGrid.Cell, style grid.Style) {
+	m.subgridCell = cell
+	m.subgridStyle = style
+}
+
+func (m *fakeManager) UpdateGridMatches(prefix string) { m.matchesPrefix = prefix }
+func (m *fakeManager) SetHideUnmatched(hide bool)      { m.hideUnmatched = hide }
+func (m *fakeManager) Show()                           { m.showCalls++ }
+func (m *fakeManager) Clear()                          { m.clearCalls++ }
+func (m *fakeManager) ResizeToActiveScreen()           { m.resizeCalls++ }
+
+func (m *fakeManager) DrawModeIndicator(x, y int) {
+	m.indicatorX = x
+	m.indicatorY = y
+}
+
+func (m *fakeManager) DrawRecursiveGrid(
+	bounds image.Rectangle,
+	depth int,
+	keys string,
+	gridCols int,
+	gridRows int,
+	nextKeys string,
+	nextGridCols int,
+	nextGridRows int,
+	style recursivegrid.Style,
+	virtualPointer recursivegrid.VirtualPointerState,
+) error {
+	m.recursive = recursiveGridCall{
+		bounds:         bounds,
+		depth:          depth,
+		keys:           keys,
+		gridCols:       gridCols,
+		gridRows:       gridRows,
+		nextKeys:       nextKeys,
+		nextGridCols:   nextGridCols,
+		nextGridRows:   nextGridRows,
+		style:          style,
+		virtualPointer: virtualPointer,
+	}
+	m.recursiveHits++
+
+	return m.recursiveErr
+}
+
+// staticTheme is a config.ThemeProvider with a fixed appearance, so the styles
+// built below depend only on the config values the test varies.
+type staticTheme struct{ dark bool }
+
+func (t staticTheme) IsDarkMode() bool { return t.dark }
+
+// styleSet is a trio of styles built from one config, used as a unit so that
+// "the renderer forwarded the right style" is checkable by equality.
+type styleSet struct {
+	hint      hints.StyleMode
+	grid      grid.Style
+	recursive recursivegrid.Style
+}
+
+// buildStyles derives a distinguishable style trio. Font size and border width
+// are carried through by BuildStyle on every platform, so varying them yields
+// styles that compare unequal wherever the test runs.
+func buildStyles(fontSize, borderWidth int) styleSet {
+	cfg := config.DefaultConfig()
+	theme := staticTheme{}
+
+	cfg.Hints.UI.FontSize = fontSize
+	cfg.Hints.UI.BorderWidth = borderWidth
+	cfg.Grid.UI.FontSize = fontSize
+	cfg.Grid.UI.BorderWidth = borderWidth
+	cfg.RecursiveGrid.UI.LineWidth = borderWidth
+
+	return styleSet{
+		hint:      hints.BuildStyle(cfg.Hints, theme),
+		grid:      grid.BuildStyle(cfg.Grid, theme),
+		recursive: recursivegrid.BuildStyle(cfg.RecursiveGrid, theme),
+	}
+}
+
+// TestBuildStyles_ProducesDistinguishableStyles guards the premise of every
+// style-forwarding assertion below: if two different configs happened to build
+// equal styles, those assertions would pass vacuously.
+func TestBuildStyles_ProducesDistinguishableStyles(t *testing.T) {
+	first := buildStyles(12, 1)
+	second := buildStyles(30, 6)
+
+	if first.hint == second.hint {
+		t.Error(
+			"hint styles built from different configs compare equal; style assertions would be vacuous",
+		)
+	}
+
+	if first.grid == second.grid {
+		t.Error(
+			"grid styles built from different configs compare equal; style assertions would be vacuous",
+		)
+	}
+
+	if first.recursive == second.recursive {
+		t.Error(
+			"recursive-grid styles built from different configs compare equal; style assertions would be vacuous",
+		)
+	}
+}
+
+func newRenderer(t *testing.T, styles styleSet) (*ui.OverlayRenderer, *fakeManager) {
+	t.Helper()
+
+	manager := &fakeManager{}
+
+	return ui.NewOverlayRenderer(manager, styles.hint, styles.grid, styles.recursive), manager
+}
+
+func TestOverlayRenderer_DrawHints_ForwardsHintsAndConfiguredStyle(t *testing.T) {
+	styles := buildStyles(12, 1)
+	renderer, manager := newRenderer(t, styles)
+
+	drawn := []*hints.Hint{
+		hints.NewHint("aa", image.Point{X: 1, Y: 2}, image.Point{X: 3, Y: 4}, ""),
+	}
+
+	err := renderer.DrawHints(drawn)
+	if err != nil {
+		t.Fatalf("DrawHints() error = %v, want nil", err)
+	}
+
+	if manager.hintsCalls != 1 {
+		t.Fatalf("DrawHintsWithStyle called %d times, want 1", manager.hintsCalls)
+	}
+
+	if len(manager.hintsArg) != 1 || manager.hintsArg[0] != drawn[0] {
+		t.Errorf(
+			"DrawHintsWithStyle received %v, want the caller's slice %v",
+			manager.hintsArg,
+			drawn,
+		)
+	}
+
+	if manager.hintsStyle != styles.hint {
+		t.Error("DrawHintsWithStyle received a style other than the configured hint style")
+	}
+}
+
+func TestOverlayRenderer_DrawHints_PropagatesManagerError(t *testing.T) {
+	renderer, manager := newRenderer(t, buildStyles(12, 1))
+	manager.drawHintsErr = errDraw
+
+	err := renderer.DrawHints(nil)
+	if !errors.Is(err, errDraw) {
+		t.Errorf("DrawHints() error = %v, want %v", err, errDraw)
+	}
+}
+
+func TestOverlayRenderer_DrawGrid_ForwardsGridInputAndConfiguredStyle(t *testing.T) {
+	styles := buildStyles(12, 1)
+	renderer, manager := newRenderer(t, styles)
+
+	testGrid := domainGrid.NewGrid("abc", image.Rect(0, 0, 100, 100), zap.NewNop())
+
+	err := renderer.DrawGrid(testGrid, "ab")
+	if err != nil {
+		t.Fatalf("DrawGrid() error = %v, want nil", err)
+	}
+
+	if manager.gridArg != testGrid {
+		t.Errorf("DrawGrid received grid %p, want the caller's grid %p", manager.gridArg, testGrid)
+	}
+
+	if manager.gridInput != "ab" {
+		t.Errorf("DrawGrid received input %q, want %q", manager.gridInput, "ab")
+	}
+
+	if manager.gridStyle != styles.grid {
+		t.Error("DrawGrid received a style other than the configured grid style")
+	}
+}
+
+func TestOverlayRenderer_DrawGrid_PropagatesManagerError(t *testing.T) {
+	renderer, manager := newRenderer(t, buildStyles(12, 1))
+	manager.drawGridErr = errDraw
+
+	err := renderer.DrawGrid(nil, "")
+	if !errors.Is(err, errDraw) {
+		t.Errorf("DrawGrid() error = %v, want %v", err, errDraw)
+	}
+}
+
+// TestOverlayRenderer_ShowSubgrid_UsesGridStyleNotRecursiveStyle pins which of
+// the three stored styles the subgrid path uses. Both grid and recursive-grid
+// styles are plausible choices at this call site, so an incorrect swap would
+// otherwise render subgrids with the wrong appearance silently.
+func TestOverlayRenderer_ShowSubgrid_UsesGridStyleNotRecursiveStyle(t *testing.T) {
+	styles := buildStyles(12, 1)
+	renderer, manager := newRenderer(t, styles)
+
+	testGrid := domainGrid.NewGrid("abc", image.Rect(0, 0, 100, 100), zap.NewNop())
+
+	cells := testGrid.Cells()
+	if len(cells) == 0 {
+		t.Fatal("test grid produced no cells")
+	}
+
+	renderer.ShowSubgrid(cells[0])
+
+	if manager.subgridCell != cells[0] {
+		t.Errorf("ShowSubgrid received cell %p, want %p", manager.subgridCell, cells[0])
+	}
+
+	if manager.subgridStyle != styles.grid {
+		t.Error("ShowSubgrid received a style other than the configured grid style")
+	}
+}
+
+// TestOverlayRenderer_DrawRecursiveGrid_ForwardsEveryArgumentInOrder is the
+// highest-value case in this file: the manager call takes seven consecutive
+// int/string parameters describing the current and next depth's layout, which
+// makes an accidental transposition both easy to write and invisible to the
+// compiler. Every value here is distinct so any swap changes the recorded call.
+func TestOverlayRenderer_DrawRecursiveGrid_ForwardsEveryArgumentInOrder(t *testing.T) {
+	styles := buildStyles(12, 1)
+	renderer, manager := newRenderer(t, styles)
+
+	want := recursiveGridCall{
+		bounds:       image.Rect(10, 20, 310, 220),
+		depth:        3,
+		keys:         "qwer",
+		gridCols:     4,
+		gridRows:     5,
+		nextKeys:     "asdf",
+		nextGridCols: 6,
+		nextGridRows: 7,
+		style:        styles.recursive,
+		virtualPointer: recursivegrid.VirtualPointerState{
+			Visible:   true,
+			Position:  image.Point{X: 42, Y: 43},
+			Size:      8,
+			FillColor: "#ff0000",
+			Char:      "x",
+			FontName:  "Menlo",
+		},
+	}
+
+	err := renderer.DrawRecursiveGrid(
+		want.bounds,
+		want.depth,
+		want.keys,
+		want.gridCols,
+		want.gridRows,
+		want.nextKeys,
+		want.nextGridCols,
+		want.nextGridRows,
+		want.virtualPointer,
+	)
+	if err != nil {
+		t.Fatalf("DrawRecursiveGrid() error = %v, want nil", err)
+	}
+
+	if manager.recursiveHits != 1 {
+		t.Fatalf("DrawRecursiveGrid called %d times, want 1", manager.recursiveHits)
+	}
+
+	got := manager.recursive
+
+	if got.bounds != want.bounds {
+		t.Errorf("bounds = %v, want %v", got.bounds, want.bounds)
+	}
+
+	if got.depth != want.depth {
+		t.Errorf("depth = %d, want %d", got.depth, want.depth)
+	}
+
+	if got.keys != want.keys {
+		t.Errorf("keys = %q, want %q", got.keys, want.keys)
+	}
+
+	if got.gridCols != want.gridCols {
+		t.Errorf("gridCols = %d, want %d", got.gridCols, want.gridCols)
+	}
+
+	if got.gridRows != want.gridRows {
+		t.Errorf("gridRows = %d, want %d", got.gridRows, want.gridRows)
+	}
+
+	if got.nextKeys != want.nextKeys {
+		t.Errorf("nextKeys = %q, want %q", got.nextKeys, want.nextKeys)
+	}
+
+	if got.nextGridCols != want.nextGridCols {
+		t.Errorf("nextGridCols = %d, want %d", got.nextGridCols, want.nextGridCols)
+	}
+
+	if got.nextGridRows != want.nextGridRows {
+		t.Errorf("nextGridRows = %d, want %d", got.nextGridRows, want.nextGridRows)
+	}
+
+	if got.virtualPointer != want.virtualPointer {
+		t.Errorf("virtualPointer = %+v, want %+v", got.virtualPointer, want.virtualPointer)
+	}
+
+	if got.style != styles.recursive {
+		t.Error("DrawRecursiveGrid received a style other than the configured recursive-grid style")
+	}
+}
+
+func TestOverlayRenderer_DrawRecursiveGrid_PropagatesManagerError(t *testing.T) {
+	renderer, manager := newRenderer(t, buildStyles(12, 1))
+	manager.recursiveErr = errDraw
+
+	err := renderer.DrawRecursiveGrid(
+		image.Rectangle{}, 0, "", 0, 0, "", 0, 0, recursivegrid.VirtualPointerState{},
+	)
+	if !errors.Is(err, errDraw) {
+		t.Errorf("DrawRecursiveGrid() error = %v, want %v", err, errDraw)
+	}
+}
+
+// TestOverlayRenderer_UpdateConfig_SwapsAllThreeStyles checks that a config
+// reload actually reaches subsequent draws. The renderer caches the styles by
+// value, so a missed assignment in UpdateConfig would leave one overlay
+// rendering with the pre-reload appearance indefinitely.
+func TestOverlayRenderer_UpdateConfig_SwapsAllThreeStyles(t *testing.T) {
+	before := buildStyles(12, 1)
+	after := buildStyles(30, 6)
+
+	renderer, manager := newRenderer(t, before)
+
+	renderer.UpdateConfig(after.hint, after.grid, after.recursive)
+
+	err := renderer.DrawHints(nil)
+	if err != nil {
+		t.Fatalf("DrawHints() error = %v", err)
+	}
+
+	if manager.hintsStyle != after.hint {
+		t.Error("DrawHints still used the pre-UpdateConfig hint style")
+	}
+
+	err = renderer.DrawGrid(nil, "")
+	if err != nil {
+		t.Fatalf("DrawGrid() error = %v", err)
+	}
+
+	if manager.gridStyle != after.grid {
+		t.Error("DrawGrid still used the pre-UpdateConfig grid style")
+	}
+
+	renderer.ShowSubgrid(nil)
+
+	if manager.subgridStyle != after.grid {
+		t.Error("ShowSubgrid still used the pre-UpdateConfig grid style")
+	}
+
+	err = renderer.DrawRecursiveGrid(
+		image.Rectangle{}, 0, "", 0, 0, "", 0, 0, recursivegrid.VirtualPointerState{},
+	)
+	if err != nil {
+		t.Fatalf("DrawRecursiveGrid() error = %v", err)
+	}
+
+	if manager.recursive.style != after.recursive {
+		t.Error("DrawRecursiveGrid still used the pre-UpdateConfig recursive-grid style")
+	}
+}
+
+// TestOverlayRenderer_PassThroughMethods covers the methods that carry no style
+// but must still reach the manager with their arguments intact.
+func TestOverlayRenderer_PassThroughMethods(t *testing.T) {
+	renderer, manager := newRenderer(t, buildStyles(12, 1))
+
+	renderer.UpdateGridMatches("abc")
+
+	if manager.matchesPrefix != "abc" {
+		t.Errorf("UpdateGridMatches forwarded %q, want %q", manager.matchesPrefix, "abc")
+	}
+
+	renderer.SetHideUnmatched(true)
+
+	if !manager.hideUnmatched {
+		t.Error("SetHideUnmatched(true) did not reach the manager")
+	}
+
+	renderer.SetHideUnmatched(false)
+
+	if manager.hideUnmatched {
+		t.Error("SetHideUnmatched(false) did not reach the manager")
+	}
+
+	renderer.Show()
+	renderer.Clear()
+	renderer.ResizeActive()
+
+	if manager.showCalls != 1 {
+		t.Errorf("Show() reached the manager %d times, want 1", manager.showCalls)
+	}
+
+	if manager.clearCalls != 1 {
+		t.Errorf("Clear() reached the manager %d times, want 1", manager.clearCalls)
+	}
+
+	if manager.resizeCalls != 1 {
+		t.Errorf("ResizeActive() reached the manager %d times, want 1", manager.resizeCalls)
+	}
+
+	renderer.DrawModeIndicator(11, 22)
+
+	if manager.indicatorX != 11 || manager.indicatorY != 22 {
+		t.Errorf(
+			"DrawModeIndicator forwarded (%d, %d), want (11, 22)",
+			manager.indicatorX, manager.indicatorY,
+		)
+	}
+}

--- a/justfile
+++ b/justfile
@@ -181,14 +181,43 @@ test-unit:
     @echo "Running unit tests..."
     go test -v ./...
 
-# Run a small cross-platform-safe test slice that avoids most native platform
-# integration requirements. Useful as a fast confidence check before or during
-
-# Linux/Windows work.
+# Run the cross-platform-safe test slice: every package that contains no
+# platform-tagged source at all, so its behavior is identical on macOS, Linux
+# and Windows. Useful as a fast confidence check before or during Linux/Windows
+# work — a failure here is a real cross-platform regression, not a
+# host-specific one.
+#
+# Keep this list in sync when adding a package; `just list-foundation-packages`
+# prints the set that currently qualifies.
 test-foundation:
     @echo "Running cross-platform foundation tests..."
-    go test ./internal/config ./internal/core/domain/action ./internal/core/ports
+    go test ./internal/config \
+        ./internal/app/components ./internal/app/components/scroll \
+        ./internal/app/services ./internal/app/services/modeindicator \
+        ./internal/app/services/stickyindicator \
+        ./internal/architecture ./internal/cli/cliutil \
+        ./internal/core/domain ./internal/core/domain/action \
+        ./internal/core/domain/element ./internal/core/domain/grid \
+        ./internal/core/domain/hint ./internal/core/domain/recursivegrid \
+        ./internal/core/domain/state ./internal/core/errors \
+        ./internal/core/infra/apptrace ./internal/core/infra/logger \
+        ./internal/core/infra/platform/mousestate \
+        ./internal/core/ports ./internal/core/ports/mocks \
+        ./internal/ui ./internal/ui/coordinates
     @echo "✓ Cross-platform foundation tests passed"
+
+# Print the packages that contain no platform-tagged source, i.e. the set
+# test-foundation should be running. Use it to spot drift after adding a package.
+list-foundation-packages:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for d in $(go list ./... | sed 's|github.com/y3owk1n/neru/||'); do
+        [ -d "$d" ] || continue
+        tagged=$(find "$d" -maxdepth 1 \( -name '*_darwin.go' -o -name '*_linux*.go' \
+            -o -name '*_windows.go' -o -name '*_other.go' \) | wc -l | tr -d ' ')
+        tests=$(find "$d" -maxdepth 1 -name '*_test.go' | wc -l | tr -d ' ')
+        [ "$tagged" = "0" ] && [ "$tests" != "0" ] && echo "./$d"
+    done
 
 # Run integration tests
 test-integration:
@@ -273,6 +302,85 @@ vet:
     @echo "Vetting code..."
     go vet ./...
     @echo "✓ Vet complete"
+
+# Vet the code as the other platforms see it.
+#
+# `just vet` only type-checks the host's build tags, so a change to shared code
+# that breaks the Linux or Windows build is invisible locally and only fails in
+# CI. This compiles every package *and its tests* for both other targets.
+#
+# CGO is off, so this covers the pure-Go and no-cgo backends. The cgo-only Linux
+# backends (X11, wlroots) still need a cross toolchain or CI to type-check.
+vet-cross:
+    @echo "Vetting for linux/amd64 (CGO off)..."
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go vet ./...
+    @echo "Vetting for windows/amd64 (CGO off)..."
+    GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet ./...
+    @echo "✓ Cross-platform vet complete"
+
+# Actually run the Linux test suite locally, in a container.
+#
+# This is the strongest cross-platform check available without pushing: it
+# executes the linux-tagged tests — the stub contracts, the backend dispatch,
+# the linux-only packages — rather than only type-checking them.
+#
+# The image mirrors the Linux CI job: same native dev packages, CGO enabled, and
+# headless (no DISPLAY / WAYLAND_DISPLAY), so what passes here is what CI sees.
+# Docker caches the image after the first run.
+#
+# Requires a running Docker daemon.
+test-linux:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Building the Linux CI-equivalent image (cached after first run)..."
+    docker build -q -t neru-linux-ci - >/dev/null <<'DOCKERFILE'
+    FROM golang:1.26
+    RUN apt-get update -qq && apt-get install -y -qq \
+        libcairo2-dev libwayland-dev libx11-dev libxtst-dev libxrandr-dev \
+        libxinerama-dev libxfixes-dev libxkbcommon-dev wayland-protocols \
+        libei-dev liboeffis-dev libxi-dev libxrender-dev libfontconfig1-dev \
+        pkg-config >/dev/null 2>&1
+    DOCKERFILE
+    echo "Running the Linux test suite (CGO on, headless)..."
+    docker run --rm -v "$PWD":/src -w /src \
+        -e CGO_ENABLED=1 -e GOCACHE=/tmp/gocache -e GOMODCACHE=/tmp/gomod \
+        neru-linux-ci go test -count=1 -timeout 900s ./...
+    echo "✓ Linux test suite passed"
+
+# Same as test-linux but with CGO off, exercising the no-cgo Linux backends.
+test-linux-nocgo:
+    @echo "Running the Linux test suite in a container (CGO off)..."
+    docker run --rm -v "$PWD":/src -w /src \
+        -e CGO_ENABLED=0 -e GOCACHE=/tmp/gocache -e GOMODCACHE=/tmp/gomod \
+        golang:1.26 go test -count=1 -timeout 600s ./...
+    @echo "✓ Linux no-cgo test suite passed"
+
+# Compile every package *and its test binary* for Windows.
+#
+# Windows cannot be executed from a macOS or Linux host, so this is the
+# strongest available check: it catches everything `go vet` does plus anything
+# that only fails when the test binary is linked.
+test-windows-compile:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Compiling Windows test binaries..."
+    failed=0
+    for pkg in $(go list ./...); do
+        if ! GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -o /dev/null "$pkg" >/tmp/neru-win.log 2>&1; then
+            if ! grep -q "no test files\|no non-test Go files\|build constraints exclude all Go files" /tmp/neru-win.log; then
+                echo "FAIL: $pkg"; cat /tmp/neru-win.log; failed=1
+            fi
+        fi
+    done
+    [ "$failed" = "0" ] || exit 1
+    echo "✓ Windows test binaries compile"
+
+# Everything that can be checked for other platforms without pushing.
+#
+# Deliberately excludes test-linux, which needs Docker — run that separately for
+# a real Linux execution rather than a type-check.
+check-cross: vet-cross test-windows-compile
+    @echo "✓ Cross-platform checks complete (run 'just test-linux' for a real Linux run)"
 
 # Download dependencies
 deps:

--- a/justfile
+++ b/justfile
@@ -220,9 +220,13 @@ list-foundation-packages:
     done
 
 # Run integration tests
+# -p 1 runs one package binary at a time. Integration tests drive the real
+# cursor, keyboard and overlay, so two packages running concurrently fight over
+# one physical input device: a click in one package's test moves the cursor out
+# from under another package's cursor assertion, and either side can lose.
 test-integration:
     @echo "Running integration tests..."
-    go test -tags=integration -v ./...
+    go test -tags=integration -p 1 -v ./...
 
 # Run with race detection
 test-race: test-race-unit test-race-integration
@@ -234,9 +238,10 @@ test-race-unit:
     go test -race -v ./...
 
 # Run integration tests with race detection
+# See test-integration for why -p 1 is required here.
 test-race-integration:
     @echo "Running integration tests with race detection..."
-    go test -tags=integration -race -v ./...
+    go test -tags=integration -race -p 1 -v ./...
 
 test-all: test test-race
 
@@ -375,12 +380,48 @@ test-windows-compile:
     [ "$failed" = "0" ] || exit 1
     echo "✓ Windows test binaries compile"
 
+# Lint the code as the other platforms see it.
+#
+# `just lint` only lints the host's build tags, so a linter complaint in
+# linux- or windows-tagged source is invisible locally and first appears as a
+# red CI job. Reproducing it needs the Linux toolchain (CGO on, native dev
+# headers), so this runs in the same container image the Linux CI job uses, with
+# the golangci-lint version pinned in .github/workflows/ci.yml.
+#
+# Requires a running Docker daemon.
+lint-cross:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Building the Linux lint image (cached after first run)..."
+    docker build -q -t neru-linux-ci - >/dev/null <<'BASE'
+    FROM golang:1.26
+    RUN apt-get update -qq && apt-get install -y -qq \
+        libcairo2-dev libwayland-dev libx11-dev libxtst-dev libxrandr-dev \
+        libxinerama-dev libxfixes-dev libxkbcommon-dev wayland-protocols \
+        libei-dev liboeffis-dev libxi-dev libxrender-dev libfontconfig1-dev \
+        pkg-config >/dev/null 2>&1
+    BASE
+    docker build -q -t neru-linux-lint - >/dev/null <<'LINT'
+    FROM neru-linux-ci
+    RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+    LINT
+    echo "Linting for linux/amd64 (CGO on)..."
+    docker run --rm -v "$PWD":/src -w /src \
+        -e GOCACHE=/tmp/gocache -e GOMODCACHE=/tmp/gomod -e GOLANGCI_LINT_CACHE=/tmp/glcache \
+        neru-linux-lint golangci-lint run
+    echo "Linting for windows/amd64 (CGO off)..."
+    docker run --rm -v "$PWD":/src -w /src \
+        -e GOOS=windows -e GOARCH=amd64 -e CGO_ENABLED=0 \
+        -e GOCACHE=/tmp/gocache -e GOMODCACHE=/tmp/gomod -e GOLANGCI_LINT_CACHE=/tmp/glcache \
+        neru-linux-lint golangci-lint run
+    echo "✓ Cross-platform lint complete"
+
 # Everything that can be checked for other platforms without pushing.
 #
-# Deliberately excludes test-linux, which needs Docker — run that separately for
-# a real Linux execution rather than a type-check.
+# Deliberately excludes lint-cross and test-linux, which need Docker — run those
+# separately for a real Linux lint and execution rather than a type-check.
 check-cross: vet-cross test-windows-compile
-    @echo "✓ Cross-platform checks complete (run 'just test-linux' for a real Linux run)"
+    @echo "✓ Cross-platform checks complete (run 'just lint-cross' and 'just test-linux' for real Linux runs)"
 
 # Download dependencies
 deps:


### PR DESCRIPTION
## Description

This PR fixes four defects and closes the gaps in the test suite that let them go unnoticed.

On Linux, `neru doctor` reported focused-app, screen and cursor support as available when it was not — a build without CGO, or a session on a compositor with no wlroots client stack, refuses those queries while the report still claimed they worked. Those capabilities are now determined by actually asking the running backend, so the report matches what happens when the feature is used, and the explanation names the missing prerequisite instead of describing a feature you do not have. The grid also left part of the screen unreachable when configured with a small character set; on a tall display with four characters the bottom band had no cells at all. It now covers the whole screen at every character-set size, with no change to the default configuration's layout. Separately, reloading configuration rebuilt the grid every time under the default settings, throwing away coordinate input in progress, and building a grid before logging was wired crashed the daemon.

The test work behind those findings removes the conditions that hid them. Twenty-six places in the darwin integration suite could not fail — they ran real code, logged whatever happened and reported success — and a guardrail now fails the build if that pattern returns. Platform stubs are pinned so one that stops reporting an unsupported operation is caught rather than silently treated as success, and waits on subscriber callbacks are bounded so a stall fails by name instead of running out a package timeout.

The Windows overlay backend is deliberately left unpinned: its unsupported path is only reachable when window creation fails, which cannot be forced from a test without spawning real windows on a CI runner.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [ ] Windows — N/A, no Windows-specific behavior changed; Windows is covered only by added compile-time checks.

## Type of Change

- [x] `fix` — Bug fix

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing configuration or CLI surface changed; the new recipes are documented by comments in the `justfile` itself.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command Changes

No user-facing CLI command, flag or configuration option is added, renamed or removed. Existing configuration files keep working untouched.

Contributor commands added to the `justfile`:

| Command | What it does |
| --- | --- |
| `just check-cross` | Everything checkable for other platforms without pushing: `vet-cross` plus `test-windows-compile`. |
| `just lint-cross` | Runs the pinned `golangci-lint` for `linux/amd64` (CGO on) and `windows/amd64` in the Linux CI image. Requires Docker. |
| `just vet-cross` | Vets every package and its tests for `linux/amd64` and `windows/amd64` (CGO off). |
| `just test-windows-compile` | Compiles every package *and its test binary* for Windows; catches link-time failures `go vet` misses. |
| `just test-linux` | Runs the Linux suite in a container mirroring the Linux CI job — same native dev packages, CGO on, headless. Requires Docker. |
| `just test-linux-nocgo` | Same, with CGO off, exercising the no-cgo Linux backends. |
| `just list-foundation-packages` | Prints the packages containing no platform-tagged source, i.e. the set `test-foundation` should run. |

`just test-foundation` now runs 22 packages instead of 3 — every package with no platform-tagged source, rather than a hand-picked subset.

`just test-integration` and `just test-race-integration` now pass `-p 1`, running one package binary at a time. Integration tests drive the real cursor, keyboard and overlay, so concurrent package binaries fight over one physical input device.

## Potentially Breaking Changes

**`neru doctor` output on Linux.** Capabilities that previously always printed `supported` for focused-app, screen and cursor may now print `stub` with an explanation, on builds or sessions where they genuinely do not work. This is the report becoming accurate rather than a behavior change — nothing that worked before stops working. It affects anyone parsing `neru doctor` output or the IPC info response, who may now see `stub` where they only ever saw `supported`.

**Grid coordinates with a small `grid.characters` set.** Fixing the coverage gap changes the chosen grid dimensions for small character sets, so the coordinate labelling those users see changes — for example a 4-character set on 1920x1080 goes from 232 cells to 240. Users with a small custom character set will find their muscle memory for specific coordinates no longer lands in the same place, and any script hard-coding grid coordinates would need updating. Configurations using the default 25-character alphabet are unaffected: cell counts and layout are identical to before, which the added tests assert.

Reasonable readings differ on whether either counts as breaking — no configuration becomes invalid and no command changes, but observable output does change for a narrow set of users. Flagging both rather than deciding silently.

## Additional Context

The Linux capability fix went through a wrong iteration worth recording. Inferring availability from the backend name plus a compile-time CGO flag looked correct and passed with CGO off, but still misreported with CGO on and no display, because opening the X11 display is what actually fails there. Deriving each capability from the same call it describes makes the two agree by construction rather than by keeping two code paths in sync.

The grid fix targets the specific cause rather than capping dimensions generally. Cells are emitted region by region and a clipped edge region forfeits its unused capacity; with a large alphabet there are far more region prefixes than the grid needs, so the waste is invisible, and with a small one they run out mid-grid. Only the case where prefixes would actually run out shrinks the grid, which is why large-alphabet cell counts are unchanged.

Two defects in the first revision of the capability probing were caught in review and are fixed in the follow-up commit. The probes passed a context deadline to calls that never observe one, so the timeout bounded nothing and a wedged display server could still hang the caller; each probe now runs on its own goroutine with a real timeout. And downgrading only on `CodeNotSupported` let a genuine failure through — a backend that is compiled in but cannot open its display fails with a different code, so a refused X11 connection was still reported as supported. Any probe failure now downgrades, with the underlying reason carried in the detail.

A third review round found that the goroutine-based timeout leaked: the native calls cannot be canceled, so a probe that never returns keeps its goroutine, and `Capabilities` is reached from two IPC handlers in the long-lived daemon — every status or health request against a wedged backend started three more. Probing is now serialized per feature, capping outstanding probes at one per capability however often capabilities are requested, with the slot released as soon as the blocked call returns. The first version of that regression test was itself vacuous — driven through the adapter, where probes return immediately, it passed with the cap removed — so it was rewritten against the probe registry directly and verified to fail without the fix.

Serialising the integration packages fixes a conflict that predates this PR: those tests drive one physical cursor, and the darwin suite's error-swallowing had been hiding the resulting failures. Tightening those assertions made it visible, so the fix belongs here.

Verification beyond the standard gate: the full suite was executed on Linux in a container matching the Linux CI job (CGO on, headless) and again with CGO off; `golangci-lint` was run for both Linux and Windows targets in that image; every package plus its test binary was compiled for Windows; and the integration suite was run six consecutive times to confirm the cursor contention is gone. The container runs are what caught the nil-logger panic, a test of my own that called the system port unconditionally (which would have failed the headless Linux CI job, since nothing else in the suite constructs it off darwin), and the linter complaints in platform-tagged source that the host-only lint never saw.
