### PR TITLE
feat(action): add `move_cell` for same-layer grid navigation

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -278,6 +278,11 @@ Takes only the [shared mode flags](#flags-shared-by-hints-grid-and-recursive_gri
 Grid size, labels, and appearance are configured under
 [`[grid]`](CONFIGURATION.md#grid).
 
+Typing a full label opens a 3x3 subgrid inside that cell. To correct an
+off-by-one label without retyping it, bind
+[`move_cell`](#neru-action-move_cell) — it moves the open subgrid to a
+neighbouring cell.
+
 **Examples**
 
 ```bash
@@ -302,6 +307,10 @@ neru recursive_grid [-a <action>] [-t] [-r] [--modifier <mods>]
 Each keypress subdivides the selected cell, so successive presses converge on a
 point. Depth limits and per-depth layout are configured under
 [`[recursive_grid]`](CONFIGURATION.md#recursive_grid).
+
+Backspace backtracks one level. To correct sideways instead of upwards, bind
+[`move_cell`](#neru-action-move_cell) — it slides the selection to a
+neighbouring cell without leaving the current depth.
 
 **Flags** — in addition to the [shared mode flags](#flags-shared-by-hints-grid-and-recursive_grid).
 
@@ -406,6 +415,10 @@ require a running daemon.
 neru action <subcommand> [flags]
 ```
 
+Each subcommand accepts only the flags documented in its own section. Passing
+any other flag fails with `ERR_INVALID_INPUT` and a message naming the actions
+that do accept it — flags are never accepted and then ignored.
+
 ## Targeting
 
 Point-targeted actions resolve their target in this order: the active mode
@@ -429,7 +442,7 @@ a hotkey binding string, or `neru action` directly.
 | Toggle   | `left_mouse_toggle`, `right_mouse_toggle`, `middle_mouse_toggle`                                    |
 | Movement | `move_mouse`, `move_mouse_relative`, `move_monitor`                                                 |
 | Scroll   | `scroll`, `scroll_up`, `scroll_down`, `scroll_left`, `scroll_right`, `page_up`, `page_down`, `go_top`, `go_bottom` |
-| Mode     | `reset`, `backspace`, `cycle_hint`, `wait_for_mode_exit`                                            |
+| Mode     | `reset`, `backspace`, `move_cell`, `cycle_hint`, `wait_for_mode_exit`                               |
 | Cursor   | `save_cursor_pos`, `restore_cursor_pos`, `hide_cursor`, `show_cursor`                               |
 | Keys     | `feed`                                                                                              |
 | Timing   | `sleep` — [hotkey bindings only](#action-sleep-hotkey-bindings-only)                                |
@@ -605,6 +618,56 @@ cursor to the new display.
 neru action move_monitor
 neru action move_monitor --previous
 neru action move_monitor --name "DELL U2720Q"
+```
+
+---
+
+## neru action move_cell
+
+Slide the active mode's selection to a neighbouring cell on the same layer.
+
+```
+neru action move_cell --direction left|right|up|down [--count <n>]
+```
+
+In **recursive-grid mode** the highlighted region moves at the current depth.
+Movement is spatial rather than confined to the region you drilled into: when
+the selection reaches the edge of its parent it crosses into the neighbouring
+one, and the depth you can backtrack through follows it. Once the grid has
+bottomed out (`max_depth` or `min_size_*`), the final cell moves instead.
+
+In **grid mode** an open subgrid moves to the neighbouring cell. Before a
+subgrid is open no cell is selected, so the action does nothing.
+
+Movement stops at the screen edge rather than wrapping. A `--count` that runs
+past the edge applies as many steps as fit. Modes with no cell selection —
+hints, scroll, idle — ignore the action.
+
+| Flag          | Type   | Default | Description                                    |
+| ------------- | ------ | ------- | ---------------------------------------------- |
+| `--direction` | string |         | Required. One of `left`, `right`, `up`, `down`. |
+| `--count`     | int    | `1`     | Number of cells to move. Must be at least 1.    |
+
+This action is held-key repeatable: with
+[`[held_repeat]`](CONFIGURATION.md#held_repeat) enabled (it is off by default),
+a hotkey bound to it slides continuously while the key is held.
+
+**Examples**
+
+```bash
+neru action move_cell --direction right
+neru action move_cell --direction up --count 3
+```
+
+Bound as hotkeys, using arrow keys because letters are already taken by cell
+selection:
+
+```toml
+[recursive_grid.hotkeys]
+"Left"  = "action move_cell --direction=left"
+"Right" = "action move_cell --direction=right"
+"Up"    = "action move_cell --direction=up"
+"Down"  = "action move_cell --direction=down"
 ```
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -503,7 +503,7 @@ All actions available in hotkeys. These also work as `neru action <name>` — se
 | Keyboard    | `feed`                                                                                 |
 | Hints       | `search_hints`, `cycle_hint`, `cycle_hint --backward`                                  |
 | Delay       | `sleep <duration>` — plain numbers are seconds (`0.5`), explicit units: `500ms`, `1s`  |
-| Mode        | `reset`, `backspace`                                                                   |
+| Mode        | `reset`, `backspace`, `move_cell --direction <dir>`                                    |
 | Composition | `wait_for_mode_exit` (with optional `--bail`), `save_cursor_pos`, `restore_cursor_pos` |
 | Cursor      | `hide_cursor`, `show_cursor`                                                           |
 
@@ -513,7 +513,8 @@ All actions available in hotkeys. These also work as `neru action <name>` — se
 - `mouse_down` and `mouse_up` are the original spellings of `left_mouse_down` and `left_mouse_up`. They still work in configs, but new configs should use the explicit names
 - Use `--bare` (e.g. `"action left_click --bare"`) to target the cursor position instead of the current mode selection (see [CLI.md](CLI.md#neru-action-left_click-right_click-middle_click))
 - `scroll_up` / `scroll_down` support `--steps` (e.g. `"action scroll_down --steps 200"`) to override `scroll_step` (see [CLI.md](CLI.md#neru-action-scroll_up-scroll_down-scroll_left-scroll_right))
-- `reset`, `backspace`, `search_hints`, `cycle_hint`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos`, `hide_cursor`, and `show_cursor` are not valid mode `--action` values — use `neru action ...` or in hotkeys as `"action ..."`
+- `move_cell` slides the grid or recursive-grid selection to a neighbouring cell on the same layer, e.g. `"action move_cell --direction=right"`. It takes an optional `--count`, and repeats while the key is held when [`[held_repeat]`](#held_repeat) is enabled (see [CLI.md](CLI.md#neru-action-move_cell))
+- `reset`, `backspace`, `move_cell`, `search_hints`, `cycle_hint`, `sleep`, `wait_for_mode_exit`, `save_cursor_pos`, `restore_cursor_pos`, `hide_cursor`, and `show_cursor` are not valid mode `--action` values — use `neru action ...` or in hotkeys as `"action ..."`
 - `sleep` is the exception among those: it works only in hotkey bindings (`"action sleep 0.5"`), **not** as a terminal command, and it cannot appear in a comma-separated chain. See [CLI.md](CLI.md#action-sleep-hotkey-bindings-only)
 
 #### Feed Keys
@@ -1361,7 +1362,7 @@ duration_per_pixel = 1.0
 
 ## [held_repeat]
 
-Repeatedly dispatches scroll, page, and relative-mouse-move actions while the key is held, with a configurable initial delay and repeat interval. Disable held-key repeat entirely by setting `enabled = false`.
+Repeatedly dispatches scroll, page, relative-mouse-move, and `move_cell` actions while the key is held, with a configurable initial delay and repeat interval. Disable held-key repeat entirely by setting `enabled = false`.
 
 | Option             | Type | Default | Description                              |
 | ------------------ | ---- | ------- | ---------------------------------------- |

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -42,11 +42,19 @@ const (
 	flagBail      = "--bail"
 	flagState     = "--state"
 	flagToggle    = "--toggle"
+	flagDirection = "--direction"
+	flagCount     = "--count"
+	flagModifier  = "--modifier"
+	flagX         = "--x"
+	flagY         = "--y"
+	flagDX        = "--dx"
+	flagDY        = "--dy"
+	flagSteps     = "--steps"
+	flagBackward  = "--backward"
 
 	msgActionServiceNotAvailable            = "action service not available"
 	msgModesHandlerNotAvailable             = "modes handler not available"
 	msgSelectionRequiresActiveSelection     = "--selection requires an active mode selection"
-	msgMoveMonitorDoesNotSupportTheseFlags  = "move_monitor does not support these flags"
 	msgSelectionAndBareCannotBeUsedTogether = "--selection and --bare cannot be used together"
 	msgStateOnlyOnClicks                    = "--state and --toggle are only supported with " +
 		"left_click, right_click, and middle_click"
@@ -111,12 +119,12 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 		}
 	}
 
-	if parsed.useBail && !action.IsWaitForModeExitAction(actionName) {
-		return ipc.Response{
-			Success: false,
-			Message: "--bail is only supported with wait_for_mode_exit",
-			Code:    ipc.CodeInvalidInput,
-		}
+	// Every action declares the flags it accepts (see actionFlagSupport), so
+	// this one check covers all of them and each handler only has to validate
+	// combinations of the flags it does accept.
+	flagSupportResp := rejectUnsupportedFlags(actionName, parsed)
+	if flagSupportResp != nil {
+		return *flagSupportResp
 	}
 
 	// A click action carrying --state or --toggle is a request for one half of
@@ -136,11 +144,15 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 	}
 
 	if action.IsResetAction(actionName) {
-		return h.handleResetAction(parsed)
+		return h.handleResetAction()
 	}
 
 	if action.IsBackspaceAction(actionName) {
-		return h.handleBackspaceAction(parsed)
+		return h.handleBackspaceAction()
+	}
+
+	if action.IsMoveCellAction(actionName) {
+		return h.handleMoveCellAction(parsed)
 	}
 
 	if action.IsWaitForModeExitAction(actionName) {
@@ -148,11 +160,11 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 	}
 
 	if action.IsSaveCursorPosAction(actionName) {
-		return h.handleSaveCursorPosAction(ctx, parsed)
+		return h.handleSaveCursorPosAction(ctx)
 	}
 
 	if action.IsRestoreCursorPosAction(actionName) {
-		return h.handleRestoreCursorPosAction(ctx, parsed)
+		return h.handleRestoreCursorPosAction(ctx)
 	}
 
 	if action.IsMoveMonitorAction(actionName) {
@@ -164,11 +176,11 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 	}
 
 	if action.IsSearchHintsAction(actionName) {
-		return h.handleSearchHintsAction(parsed)
+		return h.handleSearchHintsAction()
 	}
 
 	if action.IsHideCursorAction(actionName) || action.IsShowCursorAction(actionName) {
-		return h.handleCursorVisibilityAction(parsed, action.IsHideCursorAction(actionName))
+		return h.handleCursorVisibilityAction(action.IsHideCursorAction(actionName))
 	}
 
 	// Handle comma-separated action chains (e.g., "left_click,left_click")
@@ -190,7 +202,7 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 	isMoveMouse := actionName == string(action.NameMoveMouse)
 	isMoveMouseRelative := actionName == string(action.NameMoveMouseRelative)
 
-	flagErrResp := validateActionFlags(actionName, parsed, modifiers)
+	flagErrResp := validateActionFlags(actionName, parsed)
 	if flagErrResp != nil {
 		return *flagErrResp
 	}

--- a/internal/app/ipc_actions_cursor.go
+++ b/internal/app/ipc_actions_cursor.go
@@ -278,18 +278,7 @@ func (h *IPCControllerActions) currentSelectionPoint() (image.Point, bool) {
 	return h.modesHandler.CurrentSelectionPoint()
 }
 
-func (h *IPCControllerActions) handleSaveCursorPosAction(
-	ctx context.Context,
-	parsed parsedActionArgs,
-) ipc.Response {
-	if hasUnsupportedFlags(parsed) {
-		return ipc.Response{
-			Success: false,
-			Message: "save_cursor_pos does not support action flags",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
+func (h *IPCControllerActions) handleSaveCursorPosAction(ctx context.Context) ipc.Response {
 	if h.actionService == nil {
 		return ipc.Response{
 			Success: false,
@@ -315,18 +304,7 @@ func (h *IPCControllerActions) handleSaveCursorPosAction(
 	return ipc.Response{Success: true, Message: "cursor position saved", Code: ipc.CodeOK}
 }
 
-func (h *IPCControllerActions) handleRestoreCursorPosAction(
-	ctx context.Context,
-	parsed parsedActionArgs,
-) ipc.Response {
-	if hasUnsupportedFlags(parsed) {
-		return ipc.Response{
-			Success: false,
-			Message: "restore_cursor_pos does not support action flags",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
+func (h *IPCControllerActions) handleRestoreCursorPosAction(ctx context.Context) ipc.Response {
 	if h.actionService == nil {
 		return ipc.Response{
 			Success: false,
@@ -360,23 +338,7 @@ func (h *IPCControllerActions) handleRestoreCursorPosAction(
 	return ipc.Response{Success: true, Message: "cursor restored", Code: ipc.CodeOK}
 }
 
-func (h *IPCControllerActions) handleCursorVisibilityAction(
-	parsed parsedActionArgs,
-	hide bool,
-) ipc.Response {
-	if hasUnsupportedFlags(parsed) {
-		actionName := "show_cursor"
-		if hide {
-			actionName = "hide_cursor"
-		}
-
-		return ipc.Response{
-			Success: false,
-			Message: actionName + " does not support action flags",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
+func (h *IPCControllerActions) handleCursorVisibilityAction(hide bool) ipc.Response {
 	if h.modesHandler == nil {
 		return ipc.Response{
 			Success: false,
@@ -416,16 +378,6 @@ func (h *IPCControllerActions) handleMoveMonitorAction(
 	ctx context.Context,
 	parsed parsedActionArgs,
 ) ipc.Response {
-	if parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
-		parsed.hasCenter || parsed.modifierStr != "" ||
-		parsed.useSelection || parsed.useBare {
-		return ipc.Response{
-			Success: false,
-			Message: msgMoveMonitorDoesNotSupportTheseFlags,
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
 	if parsed.hasMonitorName {
 		if parsed.usePrevious {
 			return ipc.Response{

--- a/internal/app/ipc_actions_flags.go
+++ b/internal/app/ipc_actions_flags.go
@@ -1,0 +1,205 @@
+package app
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/y3owk1n/neru/internal/core/domain/action"
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+// Flag support is declarative: every action declares the flags it accepts and
+// rejectUnsupportedFlags refuses everything else, once, before dispatch.
+//
+// This replaces a per-handler reject list in each action handler. Those lists
+// were maintained by hand and had drifted: backspace silently accepted
+// --steps, --toggle and --backward because they were added to the parser after
+// the list was written. A flag with no home in this table is now rejected for
+// every action, so the failure mode of forgetting an entry is a rejection
+// rather than a silently ignored flag.
+
+// Flags shared by several actions, named so the table stays readable.
+var (
+	// pointTargetingFlags choose between the mode selection and the cursor.
+	pointTargetingFlags = []string{flagSelection, flagBare}
+	// clickFlags are accepted by the three click actions, which can be split
+	// into their press and release halves.
+	clickFlags = []string{flagModifier, flagSelection, flagBare, flagState, flagToggle}
+	// heldButtonFlags are accepted by the press/release/toggle actions, which
+	// already name a phase and so take no --state or --toggle.
+	heldButtonFlags = []string{flagModifier, flagSelection, flagBare}
+)
+
+// actionFlagSupport maps an action name to the flags it accepts.
+//
+// feed and sleep are absent on purpose: both consume their raw arguments
+// before flag parsing runs, so they never reach this check.
+var actionFlagSupport = map[string][]string{
+	string(action.NameLeftClick):   clickFlags,
+	string(action.NameRightClick):  clickFlags,
+	string(action.NameMiddleClick): clickFlags,
+
+	string(action.NameLeftMouseDown):     heldButtonFlags,
+	string(action.NameLeftMouseUp):       heldButtonFlags,
+	string(action.NameRightMouseDown):    heldButtonFlags,
+	string(action.NameRightMouseUp):      heldButtonFlags,
+	string(action.NameMiddleMouseDown):   heldButtonFlags,
+	string(action.NameMiddleMouseUp):     heldButtonFlags,
+	string(action.NameLeftMouseToggle):   heldButtonFlags,
+	string(action.NameRightMouseToggle):  heldButtonFlags,
+	string(action.NameMiddleMouseToggle): heldButtonFlags,
+	// The deprecated left-button spellings are still accepted from configs
+	// and IPC, so they need flag declarations too.
+	string(action.NameMouseDown): heldButtonFlags, //nolint:staticcheck // still accepted
+	string(action.NameMouseUp):   heldButtonFlags, //nolint:staticcheck // still accepted
+
+	string(action.NameMoveMouse): {
+		flagX, flagY, flagCenter, flagWindow, flagSelection, flagBare,
+	},
+	string(action.NameMoveMouseRelative): {flagDX, flagDY},
+	string(action.NameMoveMonitor):       {flagPrevious, flagName},
+	string(action.NameMoveCell):          {flagDirection, flagCount},
+
+	// The bare scroll name is only reachable from a hotkey string or raw IPC
+	// and takes no flags; the directional sub-actions below are the usable form.
+	string(action.NameScroll):      {},
+	string(action.NameScrollUp):    {flagSteps, flagSelection, flagBare},
+	string(action.NameScrollDown):  {flagSteps, flagSelection, flagBare},
+	string(action.NameScrollLeft):  {flagSteps, flagSelection, flagBare},
+	string(action.NameScrollRight): {flagSteps, flagSelection, flagBare},
+	string(action.NameGoTop):       pointTargetingFlags,
+	string(action.NameGoBottom):    pointTargetingFlags,
+	string(action.NamePageUp):      pointTargetingFlags,
+	string(action.NamePageDown):    pointTargetingFlags,
+
+	string(action.NameCycleHint):       {flagBackward},
+	string(action.NameWaitForModeExit): {flagBail},
+
+	string(action.NameReset):            {},
+	string(action.NameBackspace):        {},
+	string(action.NameSearchHints):      {},
+	string(action.NameSaveCursorPos):    {},
+	string(action.NameRestoreCursorPos): {},
+	string(action.NameHideCursor):       {},
+	string(action.NameShowCursor):       {},
+}
+
+// flagRejectionMessage overrides the generated message for flags whose
+// audience reads better as prose than as a list of every action name.
+var flagRejectionMessage = map[string]string{
+	flagState:     msgStateOnlyOnClicks,
+	flagToggle:    msgStateOnlyOnClicks,
+	flagModifier:  "--modifier is only supported with click and mouse button actions",
+	flagSelection: "--selection is only supported with move_mouse, scroll, and mouse button actions",
+	flagBare:      "--bare is only supported with move_mouse, scroll, and mouse button actions",
+}
+
+// rejectUnsupportedFlags refuses any flag the named action does not accept.
+//
+// Unknown action names are left alone so the dispatcher can report the name
+// itself, which is the more useful error.
+func rejectUnsupportedFlags(actionName string, parsed parsedActionArgs) *ipc.Response {
+	allowed, known := allowedFlagsFor(actionName)
+	if !known {
+		return nil
+	}
+
+	for _, flag := range parsed.presentFlags() {
+		if slices.Contains(allowed, flag) {
+			continue
+		}
+
+		return &ipc.Response{
+			Success: false,
+			Message: unsupportedFlagMessage(actionName, flag),
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	return nil
+}
+
+// allowedFlagsFor resolves the flags an action name accepts. For a
+// comma-separated chain it is the intersection over the chained actions, since
+// every one of them runs with the same flags. The second result is false when
+// any name is unknown.
+func allowedFlagsFor(actionName string) ([]string, bool) {
+	if !strings.Contains(actionName, ",") {
+		allowed, known := actionFlagSupport[actionName]
+
+		return allowed, known
+	}
+
+	var allowed []string
+
+	for index, name := range strings.Split(actionName, ",") {
+		flags, known := actionFlagSupport[strings.TrimSpace(name)]
+		if !known {
+			return nil, false
+		}
+
+		// Clone before narrowing: the table's slices are shared between
+		// actions, so DeleteFunc must not run on one of them in place.
+		if index == 0 {
+			allowed = slices.Clone(flags)
+
+			continue
+		}
+
+		allowed = slices.DeleteFunc(allowed, func(flag string) bool {
+			return !slices.Contains(flags, flag)
+		})
+	}
+
+	return allowed, true
+}
+
+// unsupportedFlagMessage explains why flag was refused, naming the actions
+// that do accept it so the user has somewhere to go.
+func unsupportedFlagMessage(actionName, flag string) string {
+	if message, ok := flagRejectionMessage[flag]; ok {
+		return message
+	}
+
+	audience := actionsAcceptingFlag(flag)
+	if len(audience) == 0 {
+		return fmt.Sprintf("%s is not supported by %s", flag, actionName)
+	}
+
+	return fmt.Sprintf(
+		"%s is only supported with %s",
+		flag,
+		strings.Join(audience, ", "),
+	)
+}
+
+// actionsAcceptingFlag lists, in stable order, the actions that accept flag.
+func actionsAcceptingFlag(flag string) []string {
+	var names []string
+
+	for name, flags := range actionFlagSupport {
+		if slices.Contains(flags, flag) {
+			names = append(names, name)
+		}
+	}
+
+	slices.Sort(names)
+
+	return names
+}
+
+// presentFlags returns the flags the caller supplied, in stable order.
+func (p *parsedActionArgs) presentFlags() []string {
+	return slices.Sorted(maps.Keys(p.present))
+}
+
+// markPresent records that flag appeared in the argument list.
+func (p *parsedActionArgs) markPresent(flag string) {
+	if p.present == nil {
+		p.present = make(map[string]bool, 1)
+	}
+
+	p.present[flag] = true
+}

--- a/internal/app/ipc_actions_flags_test.go
+++ b/internal/app/ipc_actions_flags_test.go
@@ -1,0 +1,302 @@
+//nolint:testpackage // Tests private IPC action flag tables.
+package app
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/domain/action"
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+const (
+	stepsThree      = "--steps=3"
+	resetAction     = "reset"
+	backspaceAction = "backspace"
+	sampleModKey    = "shift"
+)
+
+// TestActionFlagSupport_CoversEveryParsedFlag is the guard that keeps flag
+// validation fail-closed: a flag the parser understands but no action declares
+// would be accepted everywhere and silently ignored.
+func TestActionFlagSupport_CoversEveryParsedFlag(t *testing.T) {
+	declared := map[string]bool{}
+
+	for _, flags := range actionFlagSupport {
+		for _, flag := range flags {
+			declared[flag] = true
+		}
+	}
+
+	for flag := range actionFlagSpecs {
+		if !declared[flag] {
+			t.Errorf(
+				"flag %q is parsed but no action declares it in actionFlagSupport; "+
+					"add it to the action(s) that accept it",
+				flag,
+			)
+		}
+	}
+}
+
+// TestActionFlagSupport_DeclaresOnlyParsedFlags catches the reverse typo: a
+// table entry naming a flag the parser never produces would silently never
+// match.
+func TestActionFlagSupport_DeclaresOnlyParsedFlags(t *testing.T) {
+	for name, flags := range actionFlagSupport {
+		for _, flag := range flags {
+			if _, ok := actionFlagSpecs[flag]; !ok {
+				t.Errorf("action %q declares flag %q, which the parser does not parse", name, flag)
+			}
+		}
+	}
+}
+
+// TestActionFlagSupport_NamesAreKnownActions keeps the table from accumulating
+// entries for actions that no longer exist.
+func TestActionFlagSupport_NamesAreKnownActions(t *testing.T) {
+	for name := range actionFlagSupport {
+		if !action.IsKnownName(action.Name(name)) {
+			t.Errorf("actionFlagSupport has an entry for unknown action %q", name)
+		}
+	}
+}
+
+// TestActionFlagSupport_CoversEveryDispatchableAction lists the actions that
+// reach flag parsing. An action missing from actionFlagSupport is not rejected
+// (unknown names are left to the dispatcher), so it would accept every flag —
+// this test is what forces a new action to declare its flags.
+//
+// feed and sleep are intentionally absent: both consume their raw arguments
+// before flag parsing runs.
+func TestActionFlagSupport_CoversEveryDispatchableAction(t *testing.T) {
+	dispatchable := []action.Name{
+		action.NameLeftClick, action.NameRightClick, action.NameMiddleClick,
+		action.NameLeftMouseDown, action.NameLeftMouseUp,
+		action.NameRightMouseDown, action.NameRightMouseUp,
+		action.NameMiddleMouseDown, action.NameMiddleMouseUp,
+		action.NameLeftMouseToggle, action.NameRightMouseToggle,
+		action.NameMiddleMouseToggle,
+		action.NameMouseDown, action.NameMouseUp, //nolint:staticcheck // still accepted
+		action.NameMoveMouse, action.NameMoveMouseRelative, action.NameMoveMonitor,
+		action.NameMoveCell,
+		action.NameScroll,
+		action.NameScrollUp, action.NameScrollDown,
+		action.NameScrollLeft, action.NameScrollRight,
+		action.NameGoTop, action.NameGoBottom,
+		action.NamePageUp, action.NamePageDown,
+		action.NameReset, action.NameBackspace,
+		action.NameCycleHint, action.NameSearchHints,
+		action.NameWaitForModeExit,
+		action.NameSaveCursorPos, action.NameRestoreCursorPos,
+		action.NameHideCursor, action.NameShowCursor,
+	}
+
+	for _, name := range dispatchable {
+		if _, ok := actionFlagSupport[string(name)]; !ok {
+			t.Errorf("action %q has no actionFlagSupport entry, so it accepts every flag", name)
+		}
+	}
+}
+
+// TestParseActionArgs_MarksEveryFlagPresent proves the parser cannot record a
+// flag's value without also marking it present, which is what makes
+// rejectUnsupportedFlags see it.
+func TestParseActionArgs_MarksEveryFlagPresent(t *testing.T) {
+	for flag, spec := range actionFlagSpecs {
+		arg := flag
+		if spec.takesValue {
+			arg = flag + "=" + sampleFlagValue(flag)
+		}
+
+		parsed, parseErr := parseActionArgs([]string{arg})
+		if parseErr {
+			t.Errorf("parseActionArgs(%q) reported a parse error", arg)
+
+			continue
+		}
+
+		if !slices.Contains(parsed.presentFlags(), flag) {
+			t.Errorf("parseActionArgs(%q) did not mark %q present", arg, flag)
+		}
+	}
+}
+
+// sampleFlagValue returns a value the given flag accepts.
+func sampleFlagValue(flag string) string {
+	switch flag {
+	case flagModifier:
+		return sampleModKey
+	case flagName:
+		return "Display 1"
+	case flagState:
+		return stateDown
+	case flagDirection:
+		return dirLeftValue
+	default:
+		return "1"
+	}
+}
+
+// TestRejectUnsupportedFlags_RejectsFlagsAnActionDoesNotDeclare walks the whole
+// matrix: every action, every flag it does not declare.
+func TestRejectUnsupportedFlags_RejectsFlagsAnActionDoesNotDeclare(t *testing.T) {
+	for name, allowed := range actionFlagSupport {
+		for flag, spec := range actionFlagSpecs {
+			if slices.Contains(allowed, flag) {
+				continue
+			}
+
+			arg := flag
+			if spec.takesValue {
+				arg = flag + "=" + sampleFlagValue(flag)
+			}
+
+			parsed, parseErr := parseActionArgs([]string{arg})
+			if parseErr {
+				t.Fatalf("parseActionArgs(%q) reported a parse error", arg)
+			}
+
+			resp := rejectUnsupportedFlags(name, parsed)
+			if resp == nil {
+				t.Errorf("action %q accepted undeclared flag %q", name, flag)
+
+				continue
+			}
+
+			if resp.Code != ipc.CodeInvalidInput {
+				t.Errorf("action %q flag %q: code = %q, want %q",
+					name, flag, resp.Code, ipc.CodeInvalidInput)
+			}
+
+			if resp.Message == "" {
+				t.Errorf("action %q flag %q: empty rejection message", name, flag)
+			}
+		}
+	}
+}
+
+// TestRejectUnsupportedFlags_AcceptsDeclaredFlags is the other half: a declared
+// flag must pass.
+func TestRejectUnsupportedFlags_AcceptsDeclaredFlags(t *testing.T) {
+	for name, allowed := range actionFlagSupport {
+		for _, flag := range allowed {
+			spec := actionFlagSpecs[flag]
+
+			arg := flag
+			if spec.takesValue {
+				arg = flag + "=" + sampleFlagValue(flag)
+			}
+
+			parsed, parseErr := parseActionArgs([]string{arg})
+			if parseErr {
+				t.Fatalf("parseActionArgs(%q) reported a parse error", arg)
+			}
+
+			if resp := rejectUnsupportedFlags(name, parsed); resp != nil {
+				t.Errorf("action %q rejected its own flag %q: %s", name, flag, resp.Message)
+			}
+		}
+	}
+}
+
+// TestRejectUnsupportedFlags_ChainsIntersect checks that a comma-separated
+// chain accepts only the flags every action in it accepts.
+func TestRejectUnsupportedFlags_ChainsIntersect(t *testing.T) {
+	// --state is a click flag, so it survives a chain of clicks.
+	parsed, parseErr := parseActionArgs([]string{flagState + "=" + stateDown})
+	if parseErr {
+		t.Fatal("parseActionArgs(--state=down) reported a parse error")
+	}
+
+	if resp := rejectUnsupportedFlags("left_click,right_click", parsed); resp != nil {
+		t.Errorf("chain of clicks rejected --state: %s", resp.Message)
+	}
+
+	// left_mouse_down does not take --state, so the intersection drops it.
+	if resp := rejectUnsupportedFlags("left_click,left_mouse_down", parsed); resp == nil {
+		t.Error("chain containing left_mouse_down accepted --state")
+	}
+}
+
+// TestRejectUnsupportedFlags_IgnoresUnknownActions leaves an unknown action
+// name to the dispatcher, which reports the name rather than its flags.
+func TestRejectUnsupportedFlags_IgnoresUnknownActions(t *testing.T) {
+	parsed, parseErr := parseActionArgs([]string{"--x=1"})
+	if parseErr {
+		t.Fatal("parseActionArgs(--x=1) reported a parse error")
+	}
+
+	if resp := rejectUnsupportedFlags("not_an_action", parsed); resp != nil {
+		t.Errorf("unknown action produced a flag error: %s", resp.Message)
+	}
+}
+
+// TestHandleAction_RejectsFlagsThatUsedToBeIgnored pins the drift this
+// restructure fixes: these flags were silently accepted before, because each
+// handler kept its own hand-written reject list.
+func TestHandleAction_RejectsFlagsThatUsedToBeIgnored(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "backspace with steps", args: []string{backspaceAction, stepsThree}},
+		{name: "backspace with toggle", args: []string{backspaceAction, flagToggle}},
+		{name: "backspace with backward", args: []string{backspaceAction, flagBackward}},
+		{name: "reset with bail", args: []string{resetAction, flagBail}},
+		{name: "reset with direction", args: []string{resetAction, directionLeft}},
+		{name: "cycle_hint with count", args: []string{"cycle_hint", "--count=2"}},
+		{name: "hide_cursor with steps", args: []string{"hide_cursor", stepsThree}},
+		{name: "save_cursor_pos with toggle", args: []string{"save_cursor_pos", flagToggle}},
+		{name: "page_up with steps", args: []string{"page_up", stepsThree}},
+		{name: "move_mouse with dx", args: []string{moveMouse, "--dx=10", "--dy=10"}},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			controller := &IPCControllerActions{logger: zap.NewNop()}
+
+			resp := controller.handleAction(context.Background(), ipc.Command{
+				Action: actionCmd,
+				Args:   testCase.args,
+			})
+
+			if resp.Success {
+				t.Fatalf("handleAction(%v) expected rejection, got success", testCase.args)
+			}
+
+			if resp.Code != ipc.CodeInvalidInput {
+				t.Fatalf("code = %q, want %q", resp.Code, ipc.CodeInvalidInput)
+			}
+		})
+	}
+}
+
+// TestRejectUnsupportedFlags_ChainsDoNotMutateTheTable guards the aliasing
+// hazard in chain handling: the table's flag slices are shared between actions,
+// so narrowing them for a chain must work on a copy.
+func TestRejectUnsupportedFlags_ChainsDoNotMutateTheTable(t *testing.T) {
+	before := slices.Clone(actionFlagSupport[string(action.NameLeftClick)])
+
+	for range 3 {
+		parsed, parseErr := parseActionArgs([]string{flagState + "=" + stateDown})
+		if parseErr {
+			t.Fatal("parseActionArgs(--state=down) reported a parse error")
+		}
+
+		rejectUnsupportedFlags("left_click,left_mouse_down", parsed)
+		rejectUnsupportedFlags("left_click,right_click", parsed)
+	}
+
+	after := actionFlagSupport[string(action.NameLeftClick)]
+	if !slices.Equal(before, after) {
+		t.Fatalf("chain validation mutated the shared table: %v -> %v", before, after)
+	}
+
+	if !slices.Equal(clickFlags, before) {
+		t.Fatalf("chain validation mutated the shared clickFlags slice: %v", clickFlags)
+	}
+}

--- a/internal/app/ipc_actions_flow.go
+++ b/internal/app/ipc_actions_flow.go
@@ -102,15 +102,7 @@ func parseSleepDuration(durationStr string) (time.Duration, error) {
 	return time.Duration(secs * float64(time.Second)), nil
 }
 
-func (h *IPCControllerActions) handleResetAction(parsed parsedActionArgs) ipc.Response {
-	if hasUnsupportedFlags(parsed) {
-		return ipc.Response{
-			Success: false,
-			Message: "reset does not support action flags",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
+func (h *IPCControllerActions) handleResetAction() ipc.Response {
 	if h.modesHandler == nil {
 		return ipc.Response{
 			Success: false,
@@ -128,14 +120,6 @@ func (h *IPCControllerActions) handleWaitForModeExitAction(
 	ctx context.Context,
 	parsed parsedActionArgs,
 ) ipc.Response {
-	if hasUnsupportedFlags(parsed) {
-		return ipc.Response{
-			Success: false,
-			Message: "wait_for_mode_exit does not support these flags",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
 	if h.appState == nil {
 		return ipc.Response{
 			Success: false,
@@ -264,28 +248,10 @@ func (h *IPCControllerActions) handleActionChain(
 		modifiers |= stickyMods
 	}
 
-	// Reject coordinate flags (chains only support click actions at the cursor)
-	if parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
-		parsed.hasCenter || parsed.hasWindow || parsed.hasMonitorName || parsed.usePrevious {
-		return ipc.Response{
-			Success: false,
-			Message: "--x/--y/--dx/--dy/--center/--window flags are not supported in action chains",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
 	if parsed.useSelection && parsed.useBare {
 		return ipc.Response{
 			Success: false,
 			Message: msgSelectionAndBareCannotBeUsedTogether,
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if parsed.useBail {
-		return ipc.Response{
-			Success: false,
-			Message: "--bail is not supported in action chains",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}

--- a/internal/app/ipc_actions_keys.go
+++ b/internal/app/ipc_actions_keys.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
 )
@@ -127,15 +128,7 @@ func (h *IPCControllerActions) handleFeedToModeAction(args []string) ipc.Respons
 	}
 }
 
-func (h *IPCControllerActions) handleBackspaceAction(parsed parsedActionArgs) ipc.Response {
-	if hasUnsupportedFlags(parsed) {
-		return ipc.Response{
-			Success: false,
-			Message: "backspace does not support action flags",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
+func (h *IPCControllerActions) handleBackspaceAction() ipc.Response {
 	if h.modesHandler == nil {
 		return ipc.Response{
 			Success: false,
@@ -149,22 +142,53 @@ func (h *IPCControllerActions) handleBackspaceAction(parsed parsedActionArgs) ip
 	return ipc.Response{Success: true, Message: "mode backspace", Code: ipc.CodeOK}
 }
 
+// handleMoveCellAction slides the active mode's selection to a neighboring
+// cell on the same layer.
+func (h *IPCControllerActions) handleMoveCellAction(parsed parsedActionArgs) ipc.Response {
+	if !parsed.hasDirection {
+		return ipc.Response{
+			Success: false,
+			Message: "move_cell requires --direction (left, right, up, or down)",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	direction, dirErr := domain.ParseDirection(parsed.directionStr)
+	if dirErr != nil {
+		return ipc.Response{
+			Success: false,
+			Message: dirErr.Error(),
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	if h.modesHandler == nil {
+		return ipc.Response{
+			Success: false,
+			Message: msgModesHandlerNotAvailable,
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	count := 1
+	if parsed.hasCount {
+		count = parsed.countVal
+	}
+
+	h.modesHandler.MoveCellCurrentMode(direction, count)
+
+	return ipc.Response{
+		Success: true,
+		Message: "mode cell move " + direction.String(),
+		Code:    ipc.CodeOK,
+	}
+}
+
 // handleCycleHintAction cycles through visible hints in hints mode.
 func (h *IPCControllerActions) handleCycleHintAction(
 	ctx context.Context,
 	parsed parsedActionArgs,
 ) ipc.Response {
-	if parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
-		parsed.hasCenter || parsed.hasWindow || parsed.useSelection ||
-		parsed.useBare || parsed.hasMonitorName || parsed.usePrevious ||
-		parsed.modifierStr != "" {
-		return ipc.Response{
-			Success: false,
-			Message: "cycle_hint does not support these flags",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
 	if h.modesHandler == nil {
 		return ipc.Response{
 			Success: false,
@@ -196,15 +220,7 @@ func (h *IPCControllerActions) handleCycleHintAction(
 }
 
 // handleSearchHintsAction activates text search in hints mode.
-func (h *IPCControllerActions) handleSearchHintsAction(parsed parsedActionArgs) ipc.Response {
-	if hasUnsupportedFlags(parsed) || parsed.useBackward || parsed.hasWindow {
-		return ipc.Response{
-			Success: false,
-			Message: "search_hints does not support action flags",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
+func (h *IPCControllerActions) handleSearchHintsAction() ipc.Response {
 	if h.modesHandler == nil {
 		return ipc.Response{
 			Success: false,

--- a/internal/app/ipc_actions_move_cell_test.go
+++ b/internal/app/ipc_actions_move_cell_test.go
@@ -1,0 +1,209 @@
+//nolint:testpackage // Tests private IPC action parsing/dispatch helpers.
+package app
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+const (
+	moveCell      = "move_cell"
+	dirLeftValue  = "left"
+	directionLeft = flagDirection + "=" + dirLeftValue
+)
+
+func TestParseActionArgs_MoveCellFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		wantParseErr  bool
+		wantDirection string
+		wantCount     int
+		wantHasCount  bool
+	}{
+		{
+			name:          "equals form",
+			args:          []string{directionLeft, "--count=3"},
+			wantDirection: dirLeftValue,
+			wantCount:     3,
+			wantHasCount:  true,
+		},
+		{
+			name:          "space form",
+			args:          []string{"--direction", "up", "--count", "2"},
+			wantDirection: "up",
+			wantCount:     2,
+			wantHasCount:  true,
+		},
+		{
+			name:          "count is optional",
+			args:          []string{"--direction=right"},
+			wantDirection: "right",
+		},
+		{name: "empty direction", args: []string{"--direction="}, wantParseErr: true},
+		{name: "missing direction value", args: []string{"--direction"}, wantParseErr: true},
+		{name: "non-numeric count", args: []string{"--count=many"}, wantParseErr: true},
+		{name: "zero count", args: []string{"--count=0"}, wantParseErr: true},
+		{name: "negative count", args: []string{"--count=-2"}, wantParseErr: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			parsed, parseErr := parseActionArgs(testCase.args)
+
+			if parseErr != testCase.wantParseErr {
+				t.Fatalf(
+					"parseActionArgs(%v) parseErr = %v, want %v",
+					testCase.args,
+					parseErr,
+					testCase.wantParseErr,
+				)
+			}
+
+			if testCase.wantParseErr {
+				return
+			}
+
+			if parsed.directionStr != testCase.wantDirection {
+				t.Errorf("directionStr = %q, want %q", parsed.directionStr, testCase.wantDirection)
+			}
+
+			if parsed.hasCount != testCase.wantHasCount {
+				t.Errorf("hasCount = %v, want %v", parsed.hasCount, testCase.wantHasCount)
+			}
+
+			if parsed.countVal != testCase.wantCount {
+				t.Errorf("countVal = %d, want %d", parsed.countVal, testCase.wantCount)
+			}
+		})
+	}
+}
+
+func TestHandleAction_MoveCellRequiresDirection(t *testing.T) {
+	controller := &IPCControllerActions{logger: zap.NewNop()}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: actionCmd,
+		Args:   []string{moveCell},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(move_cell) without --direction expected rejection, got success")
+	}
+
+	if resp.Code != ipc.CodeInvalidInput {
+		t.Fatalf("code = %q, want %q", resp.Code, ipc.CodeInvalidInput)
+	}
+}
+
+func TestHandleAction_MoveCellRejectsUnknownDirection(t *testing.T) {
+	controller := &IPCControllerActions{logger: zap.NewNop()}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: actionCmd,
+		Args:   []string{moveCell, "--direction=sideways"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(move_cell --direction=sideways) expected rejection, got success")
+	}
+
+	if resp.Code != ipc.CodeInvalidInput {
+		t.Fatalf("code = %q, want %q", resp.Code, ipc.CodeInvalidInput)
+	}
+}
+
+func TestHandleAction_MoveCellRejectsUnsupportedFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "coordinates", args: []string{moveCell, directionLeft, "--x=10", "--y=10"}},
+		{name: "modifier", args: []string{moveCell, directionLeft, "--modifier=shift"}},
+		{name: "selection", args: []string{moveCell, directionLeft, flagSelection}},
+		{name: "steps", args: []string{moveCell, directionLeft, stepsThree}},
+		{name: "toggle", args: []string{moveCell, directionLeft, flagToggle}},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			controller := &IPCControllerActions{logger: zap.NewNop()}
+
+			resp := controller.handleAction(context.Background(), ipc.Command{
+				Action: actionCmd,
+				Args:   testCase.args,
+			})
+
+			if resp.Success {
+				t.Fatalf("handleAction(%v) expected rejection, got success", testCase.args)
+			}
+
+			if resp.Code != ipc.CodeInvalidInput {
+				t.Fatalf("code = %q, want %q", resp.Code, ipc.CodeInvalidInput)
+			}
+		})
+	}
+}
+
+func TestHandleAction_MoveCellFlagsRejectedOnOtherActions(t *testing.T) {
+	controller := &IPCControllerActions{logger: zap.NewNop()}
+
+	for _, args := range [][]string{
+		{leftClick, directionLeft},
+		{moveMouse, "--x=1", "--y=1", "--count=2"},
+	} {
+		resp := controller.handleAction(context.Background(), ipc.Command{
+			Action: actionCmd,
+			Args:   args,
+		})
+
+		if resp.Success {
+			t.Errorf("handleAction(%v) expected rejection, got success", args)
+		}
+
+		if resp.Code != ipc.CodeInvalidInput {
+			t.Errorf("handleAction(%v) code = %q, want %q", args, resp.Code, ipc.CodeInvalidInput)
+		}
+	}
+}
+
+func TestHandleAction_MoveCellWithoutModesHandler(t *testing.T) {
+	controller := &IPCControllerActions{logger: zap.NewNop()}
+
+	resp := controller.handleAction(context.Background(), ipc.Command{
+		Action: actionCmd,
+		Args:   []string{moveCell, "--direction=right"},
+	})
+
+	if resp.Success {
+		t.Fatal("handleAction(move_cell) with nil modes handler expected failure, got success")
+	}
+
+	if resp.Code != ipc.CodeActionFailed {
+		t.Fatalf("code = %q, want %q", resp.Code, ipc.CodeActionFailed)
+	}
+
+	if resp.Message != msgModesHandlerNotAvailable {
+		t.Fatalf("message = %q, want %q", resp.Message, msgModesHandlerNotAvailable)
+	}
+}
+
+func TestMoveCellDirectionsAreParseable(t *testing.T) {
+	// Every direction the CLI advertises has to survive the IPC round trip.
+	for _, name := range []string{"left", "right", "up", "down"} {
+		parsed, parseErr := parseActionArgs([]string{"--direction=" + name})
+		if parseErr {
+			t.Fatalf("parseActionArgs(--direction=%s) failed", name)
+		}
+
+		_, dirErr := domain.ParseDirection(parsed.directionStr)
+		if dirErr != nil {
+			t.Errorf("ParseDirection(%q) = %v, want no error", parsed.directionStr, dirErr)
+		}
+	}
+}

--- a/internal/app/ipc_actions_parse.go
+++ b/internal/app/ipc_actions_parse.go
@@ -29,6 +29,15 @@ type parsedActionArgs struct {
 	stateStr       string
 	hasState       bool
 	useToggle      bool
+	directionStr   string
+	hasDirection   bool
+	countVal       int
+	hasCount       bool
+
+	// present records every flag that appeared, keyed by its canonical
+	// spelling, so rejectUnsupportedFlags can refuse flags the action does
+	// not accept without each handler keeping its own list.
+	present map[string]bool
 }
 
 func shouldClearSelectionAfterMoveMouse(parsed parsedActionArgs, targetsSelection bool) bool {
@@ -43,7 +52,9 @@ func shouldClearSelectionAfterMoveMouse(parsed parsedActionArgs, targetsSelectio
 		parsed.useBare
 }
 
-// extractStringFlag extracts a string value from --flag=value or --flag value form.
+// extractStringFlag extracts a string value from --flag=value or --flag value
+// form. Used by handleSleepAction, which parses its own argument because sleep
+// runs before the shared flag parsing.
 // It returns the value, the updated index, and whether the extraction succeeded.
 func extractStringFlag(rawArgs []string, idx int, prefix string) (string, int, bool) {
 	arg := rawArgs[idx]
@@ -62,251 +73,202 @@ func extractStringFlag(rawArgs []string, idx int, prefix string) (string, int, b
 	return "", idx, false
 }
 
-// extractIntFlag extracts an integer value from --flag=value or --flag value form.
-// It returns the value, the updated index, and whether the extraction succeeded.
-func extractIntFlag(rawArgs []string, idx int, prefix string) (int, int, bool) {
-	s, newIdx, ok := extractStringFlag(rawArgs, idx, prefix)
-	if !ok {
-		return 0, newIdx, false
-	}
+// flagSpec describes how one action flag is parsed.
+//
+// The parser is driven by actionFlagSpecs rather than a switch so that
+// recording the flag as present cannot be forgotten: parseActionArgs marks
+// every flag it recognizes in one place. A flag that is parsed but never
+// marked would slip past rejectUnsupportedFlags and be silently ignored.
+type flagSpec struct {
+	// takesValue reports whether the flag consumes a value, written either as
+	// --flag=value or as --flag value.
+	takesValue bool
+	// apply records the flag on parsed and reports whether value is acceptable.
+	// For valueless flags, value is empty.
+	apply func(parsed *parsedActionArgs, value string) bool
+}
 
-	val, err := strconv.Atoi(s)
-	if err != nil {
-		return 0, newIdx, false
-	}
+// actionFlagSpecs is the set of flags `neru action` understands. Adding an
+// entry here is all it takes to parse a new flag; declaring which actions
+// accept it is a separate, mandatory step in actionFlagSupport.
+var actionFlagSpecs = map[string]flagSpec{
+	flagX: {
+		takesValue: true,
+		apply:      intoInt(func(p *parsedActionArgs, v int) { p.xVal, p.hasX = v, true }),
+	},
+	flagY: {
+		takesValue: true,
+		apply:      intoInt(func(p *parsedActionArgs, v int) { p.yVal, p.hasY = v, true }),
+	},
+	flagDX: {
+		takesValue: true,
+		apply:      intoInt(func(p *parsedActionArgs, v int) { p.deltaX, p.hasDX = v, true }),
+	},
+	flagDY: {
+		takesValue: true,
+		apply:      intoInt(func(p *parsedActionArgs, v int) { p.deltaY, p.hasDY = v, true }),
+	},
 
-	return val, newIdx, true
+	// --steps and --count are counts, so zero and negatives are rejected.
+	flagSteps: {takesValue: true, apply: intoPositiveInt(func(p *parsedActionArgs, v int) {
+		p.stepsOverride, p.hasSteps = v, true
+	})},
+	flagCount: {takesValue: true, apply: intoPositiveInt(func(p *parsedActionArgs, v int) {
+		p.countVal, p.hasCount = v, true
+	})},
+
+	flagModifier: {takesValue: true, apply: intoString(func(p *parsedActionArgs, v string) {
+		p.modifierStr = v
+	})},
+	flagName: {takesValue: true, apply: intoString(func(p *parsedActionArgs, v string) {
+		p.monitorName, p.hasMonitorName = v, true
+	})},
+	flagState: {takesValue: true, apply: intoString(func(p *parsedActionArgs, v string) {
+		p.stateStr, p.hasState = v, true
+	})},
+	flagDirection: {takesValue: true, apply: intoString(func(p *parsedActionArgs, v string) {
+		p.directionStr, p.hasDirection = v, true
+	})},
+
+	flagCenter:    {apply: intoFlag(func(p *parsedActionArgs) { p.hasCenter = true })},
+	flagWindow:    {apply: intoFlag(func(p *parsedActionArgs) { p.hasWindow = true })},
+	flagSelection: {apply: intoFlag(func(p *parsedActionArgs) { p.useSelection = true })},
+	flagBare:      {apply: intoFlag(func(p *parsedActionArgs) { p.useBare = true })},
+	flagToggle:    {apply: intoFlag(func(p *parsedActionArgs) { p.useToggle = true })},
+	flagPrevious:  {apply: intoFlag(func(p *parsedActionArgs) { p.usePrevious = true })},
+	flagBackward:  {apply: intoFlag(func(p *parsedActionArgs) { p.useBackward = true })},
+	flagBail:      {apply: intoFlag(func(p *parsedActionArgs) { p.useBail = true })},
+}
+
+// intoFlag adapts a valueless flag setter to flagSpec.apply.
+func intoFlag(set func(*parsedActionArgs)) func(*parsedActionArgs, string) bool {
+	return func(parsed *parsedActionArgs, _ string) bool {
+		set(parsed)
+
+		return true
+	}
+}
+
+// intoString adapts a string flag setter, rejecting an empty value.
+func intoString(set func(*parsedActionArgs, string)) func(*parsedActionArgs, string) bool {
+	return func(parsed *parsedActionArgs, value string) bool {
+		if value == "" {
+			return false
+		}
+
+		set(parsed, value)
+
+		return true
+	}
+}
+
+// intoInt adapts an integer flag setter. Negative values are allowed because
+// coordinates and deltas can point left or up.
+func intoInt(set func(*parsedActionArgs, int)) func(*parsedActionArgs, string) bool {
+	return func(parsed *parsedActionArgs, value string) bool {
+		number, err := strconv.Atoi(value)
+		if err != nil {
+			return false
+		}
+
+		set(parsed, number)
+
+		return true
+	}
+}
+
+// intoPositiveInt adapts an integer flag setter that requires a value of at
+// least one.
+func intoPositiveInt(set func(*parsedActionArgs, int)) func(*parsedActionArgs, string) bool {
+	return func(parsed *parsedActionArgs, value string) bool {
+		number, err := strconv.Atoi(value)
+		if err != nil || number <= 0 {
+			return false
+		}
+
+		set(parsed, number)
+
+		return true
+	}
 }
 
 // parseActionArgs parses flag arguments from an action IPC command.
-// Supports both --flag=value and --flag value forms.
+// Supports both --flag=value and --flag value forms. The second result reports
+// whether any argument was malformed.
 func parseActionArgs(rawArgs []string) (parsedActionArgs, bool) {
 	var parsed parsedActionArgs
 
 	parseErr := false
+
 	for idx := 0; idx < len(rawArgs); idx++ {
 		arg := rawArgs[idx]
-		switch {
-		case strings.HasPrefix(arg, "--modifier") && (arg == "--modifier" || arg[len("--modifier")] == '='):
-			val, newIdx, ok := extractStringFlag(rawArgs, idx, "--modifier")
-			idx = newIdx
 
-			if !ok || val == "" {
-				parseErr = true
+		name, inlineValue, hasInlineValue := strings.Cut(arg, "=")
 
-				break
-			}
-
-			parsed.modifierStr = val
-		case strings.HasPrefix(arg, "--x") && (arg == "--x" || arg[len("--x")] == '='):
-			val, newIdx, ok := extractIntFlag(rawArgs, idx, "--x")
-			idx = newIdx
-
-			if !ok {
-				parseErr = true
-
-				break
-			}
-
-			parsed.xVal = val
-			parsed.hasX = true
-		case strings.HasPrefix(arg, "--y") && (arg == "--y" || arg[len("--y")] == '='):
-			val, newIdx, ok := extractIntFlag(rawArgs, idx, "--y")
-			idx = newIdx
-
-			if !ok {
-				parseErr = true
-
-				break
-			}
-
-			parsed.yVal = val
-			parsed.hasY = true
-		case strings.HasPrefix(arg, "--dx") && (arg == "--dx" || arg[len("--dx")] == '='):
-			val, newIdx, ok := extractIntFlag(rawArgs, idx, "--dx")
-			idx = newIdx
-
-			if !ok {
-				parseErr = true
-
-				break
-			}
-
-			parsed.deltaX = val
-			parsed.hasDX = true
-		case strings.HasPrefix(arg, "--dy") && (arg == "--dy" || arg[len("--dy")] == '='):
-			val, newIdx, ok := extractIntFlag(rawArgs, idx, "--dy")
-			idx = newIdx
-
-			if !ok {
-				parseErr = true
-
-				break
-			}
-
-			parsed.deltaY = val
-			parsed.hasDY = true
-		case arg == flagCenter:
-			parsed.hasCenter = true
-		case arg == flagWindow:
-			parsed.hasWindow = true
-		case arg == flagSelection:
-			parsed.useSelection = true
-		case arg == flagBare:
-			parsed.useBare = true
-		case strings.HasPrefix(arg, flagState) && (arg == flagState || arg[len(flagState)] == '='):
-			val, newIdx, ok := extractStringFlag(rawArgs, idx, flagState)
-			idx = newIdx
-
-			if !ok || val == "" {
-				parseErr = true
-
-				break
-			}
-
-			parsed.stateStr = val
-			parsed.hasState = true
-		case arg == flagToggle:
-			parsed.useToggle = true
-		case arg == flagPrevious:
-			parsed.usePrevious = true
-		case arg == "--backward":
-			parsed.useBackward = true
-		case arg == flagBail:
-			parsed.useBail = true
-		case strings.HasPrefix(arg, flagName) && (arg == flagName || arg[len(flagName)] == '='):
-			val, newIdx, ok := extractStringFlag(rawArgs, idx, flagName)
-			idx = newIdx
-
-			if !ok || val == "" {
-				parseErr = true
-
-				break
-			}
-
-			parsed.monitorName = val
-			parsed.hasMonitorName = true
-		case strings.HasPrefix(arg, "--steps") && (arg == "--steps" || arg[len("--steps")] == '='):
-			val, newIdx, ok := extractIntFlag(rawArgs, idx, "--steps")
-			idx = newIdx
-
-			if !ok || val <= 0 {
-				parseErr = true
-
-				break
-			}
-
-			parsed.stepsOverride = val
-			parsed.hasSteps = true
-		default:
+		spec, known := actionFlagSpecs[name]
+		if !known {
+			// Non-flag arguments are left for the action handlers; an
+			// unrecognized flag is an error.
 			if strings.HasPrefix(arg, "--") {
 				parseErr = true
 			}
+
+			continue
 		}
+
+		value := ""
+
+		switch {
+		case !spec.takesValue:
+			if hasInlineValue {
+				parseErr = true
+
+				continue
+			}
+		case hasInlineValue:
+			value = inlineValue
+		// A following argument is the value only when it is not itself a flag,
+		// so a missing value cannot swallow the next flag.
+		case idx+1 < len(rawArgs) && !strings.HasPrefix(rawArgs[idx+1], "--"):
+			idx++
+			value = rawArgs[idx]
+		default:
+			parseErr = true
+
+			continue
+		}
+
+		if !spec.apply(&parsed, value) {
+			parseErr = true
+
+			continue
+		}
+
+		parsed.markPresent(name)
 	}
 
 	return parsed, parseErr
 }
 
-// validateActionFlags rejects flag combinations the named action cannot honor.
+// validateActionFlags rejects flag *combinations* the named action cannot
+// honor. Whether an action accepts a flag at all is settled earlier by
+// rejectUnsupportedFlags, so everything here is about flags that are
+// individually valid but contradict each other:
 //
-// Validation order matters:
-//  1. Reject coordinate flags on non-mouse-move actions.
-//  2. Reject --modifier on non-mouse-button actions.
-//  3. Reject --x/--y mixed with --dx/--dy (always invalid).
-//  4. Reject --center mixed with --dx/--dy (center uses --x/--y as offsets, not deltas).
-//  5. Reject --center on non-move_mouse actions.
-//  6. Reject --selection mixed with explicit move targeting.
-//  7. Require --x AND --y when --center is absent for move_mouse.
+//  1. --center mixed with --window.
+//  2. --selection mixed with --bare or with explicit move targeting.
+//  3. move_mouse requires --x AND --y when neither --center nor --window is given.
+//
+// Combinations of coordinate and delta flags (--x with --dx, --center with
+// --dx) are not checked here: no action declares both families, so
+// rejectUnsupportedFlags refuses them first.
 //
 // Note: --center with --x/--y is intentionally allowed — x/y act as offsets from center.
-//
-// modifiers are the explicitly requested ones; sticky modifiers are merged by
-// the caller afterwards so they cannot trip the --modifier check.
 func validateActionFlags(
 	actionName string,
 	parsed parsedActionArgs,
-	modifiers action.Modifiers,
 ) *ipc.Response {
 	isMoveMouse := actionName == string(action.NameMoveMouse)
-	isMoveMouseRelative := actionName == string(action.NameMoveMouseRelative)
-	isMouseButton := isMouseButtonActionName(actionName)
-	isPointTargetedAction := isMoveMouse || isMouseButton
-
-	// 1. Reject coordinate flags on non-mouse-move actions.
-	// 2. Reject --modifier on non-mouse-button actions.
-	// 3. Reject --x/--y mixed with --dx/--dy (always invalid).
-	// 4. Reject --center mixed with --dx/--dy (center uses --x/--y as offsets, not deltas).
-	// 5. Reject --center on non-move_mouse actions.
-	// 6. Reject --selection mixed with explicit move targeting.
-	// 7. Require --x AND --y when --center is absent for move_mouse.
-	// Note: --center with --x/--y is intentionally allowed — x/y act as offsets from center.
-
-	if !isMoveMouse && !isMoveMouseRelative &&
-		(parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY) {
-		return &ipc.Response{
-			Success: false,
-			Message: "--x/--y/--dx/--dy flags are only supported with move_mouse or move_mouse_relative",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if parsed.usePrevious || parsed.hasMonitorName {
-		return &ipc.Response{
-			Success: false,
-			Message: "--previous and --name are only supported with move_monitor",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if modifiers != 0 && !isMouseButton {
-		return &ipc.Response{
-			Success: false,
-			Message: "--modifier is only supported with click and mouse button actions",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if (isMoveMouse || isMoveMouseRelative) && (parsed.hasX || parsed.hasY) &&
-		(parsed.hasDX || parsed.hasDY) {
-		return &ipc.Response{
-			Success: false,
-			Message: "use either --x/--y or --dx/--dy, not both",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if parsed.hasCenter && (parsed.hasDX || parsed.hasDY) {
-		return &ipc.Response{
-			Success: false,
-			Message: "use either --center or --dx/--dy, not both",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if parsed.hasWindow && (parsed.hasDX || parsed.hasDY) {
-		return &ipc.Response{
-			Success: false,
-			Message: "use either --window or --dx/--dy, not both",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if parsed.hasCenter && !isMoveMouse {
-		return &ipc.Response{
-			Success: false,
-			Message: "--center is only supported with move_mouse",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if parsed.hasWindow && !isMoveMouse {
-		return &ipc.Response{
-			Success: false,
-			Message: "--window is only supported with move_mouse",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
 
 	if parsed.hasCenter && parsed.hasWindow {
 		return &ipc.Response{
@@ -320,22 +282,6 @@ func validateActionFlags(
 		return &ipc.Response{
 			Success: false,
 			Message: msgSelectionAndBareCannotBeUsedTogether,
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if parsed.useSelection && (!isMoveMouse && !isMouseButton) {
-		return &ipc.Response{
-			Success: false,
-			Message: "--selection is only supported with move_mouse, scroll, and mouse button actions",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if parsed.useBare && !isPointTargetedAction {
-		return &ipc.Response{
-			Success: false,
-			Message: "--bare is only supported with move_mouse, scroll, and mouse button actions",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}
@@ -360,10 +306,4 @@ func validateActionFlags(
 	}
 
 	return nil
-}
-
-func hasUnsupportedFlags(parsed parsedActionArgs) bool {
-	return parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
-		parsed.hasCenter || parsed.hasMonitorName || parsed.modifierStr != "" ||
-		parsed.useSelection || parsed.useBare || parsed.usePrevious
 }

--- a/internal/app/ipc_actions_scroll.go
+++ b/internal/app/ipc_actions_scroll.go
@@ -26,17 +26,6 @@ func (h *IPCControllerActions) handleScrollAction(
 		}
 	}
 
-	// Reject flags that are not applicable to scroll actions.
-	if parsed.hasX || parsed.hasY || parsed.hasDX || parsed.hasDY ||
-		parsed.hasCenter || parsed.hasMonitorName || parsed.modifierStr != "" ||
-		parsed.usePrevious {
-		return ipc.Response{
-			Success: false,
-			Message: "scroll actions do not support --x/--y/--dx/--dy/--center/--name/--modifier/--previous flags",
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
 	if parsed.useSelection && parsed.useBare {
 		return ipc.Response{
 			Success: false,
@@ -50,14 +39,6 @@ func (h *IPCControllerActions) handleScrollAction(
 		return ipc.Response{
 			Success: false,
 			Message: "unknown scroll action: " + actionName,
-			Code:    ipc.CodeInvalidInput,
-		}
-	}
-
-	if parsed.hasSteps && amount != services.ScrollAmountChar {
-		return ipc.Response{
-			Success: false,
-			Message: "--steps is only supported with scroll_up, scroll_down, scroll_left, and scroll_right",
 			Code:    ipc.CodeInvalidInput,
 		}
 	}

--- a/internal/app/ipc_actions_test.go
+++ b/internal/app/ipc_actions_test.go
@@ -103,7 +103,7 @@ func TestHandleAction_MoveMonitorRejectsUnsupportedFlags_X(t *testing.T) {
 		t.Fatal("handleAction(move_monitor --x) expected failure")
 	}
 
-	if resp.Message != msgMoveMonitorDoesNotSupportTheseFlags {
+	if resp.Message != "--x is only supported with move_mouse" {
 		t.Fatalf("unexpected error message: %q", resp.Message)
 	}
 }
@@ -123,7 +123,7 @@ func TestHandleAction_MoveMonitorRejectsUnsupportedFlags(t *testing.T) {
 		t.Fatal("handleAction(move_monitor --selection) expected failure")
 	}
 
-	if resp.Message != msgMoveMonitorDoesNotSupportTheseFlags {
+	if resp.Message != flagRejectionMessage[flagSelection] {
 		t.Fatalf("unexpected error message: %q", resp.Message)
 	}
 }
@@ -410,7 +410,7 @@ func TestHandleAction_MoveMouseRejectsWindowAndDX(t *testing.T) {
 		t.Fatal("handleAction(move_mouse --window --dx) expected failure")
 	}
 
-	if resp.Message != "use either --window or --dx/--dy, not both" {
+	if resp.Message != "--dx is only supported with move_mouse_relative" {
 		t.Fatalf("unexpected error message: %q", resp.Message)
 	}
 }
@@ -457,7 +457,7 @@ func TestHandleAction_PreviousRejectedOnNonMoveMonitor(t *testing.T) {
 		t.Fatal("handleAction(left_click --previous) expected failure")
 	}
 
-	if resp.Message != "--previous and --name are only supported with move_monitor" {
+	if resp.Message != "--previous is only supported with move_monitor" {
 		t.Fatalf("unexpected error message: %q", resp.Message)
 	}
 }
@@ -470,14 +470,14 @@ func TestHandleAction_NameRejectedOnNonMoveMonitor(t *testing.T) {
 
 	resp := controller.handleAction(context.Background(), ipc.Command{
 		Action: actionCmd,
-		Args:   []string{"reset", "--name=DELL"},
+		Args:   []string{resetAction, flagName + "=DELL"},
 	})
 
 	if resp.Success {
 		t.Fatal("handleAction(reset --name) expected failure")
 	}
 
-	if resp.Message != "reset does not support action flags" {
+	if resp.Message != "--name is only supported with move_monitor" {
 		t.Fatalf("unexpected error message: %q", resp.Message)
 	}
 }
@@ -504,7 +504,7 @@ func TestHandleAction_PreviousRejectedOnScrollAction(t *testing.T) {
 		t.Fatal("handleAction(scroll_down --previous) expected failure")
 	}
 
-	if resp.Message != "scroll actions do not support --x/--y/--dx/--dy/--center/--name/--modifier/--previous flags" {
+	if resp.Message != "--previous is only supported with move_monitor" {
 		t.Fatalf("unexpected error message: %q", resp.Message)
 	}
 }

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -705,6 +705,60 @@ func (h *Handler) BackspaceCurrentMode() {
 	}
 }
 
+// MoveCellCurrentMode slides the active mode's selection count cells in dir
+// without changing the active layer.
+//
+// Grid mode moves an open subgrid to the neighboring cell; recursive-grid
+// mode slides the highlighted region at the current depth, crossing into a
+// neighboring parent when it runs off the edge of its own. Modes with no cell
+// selection ignore it, as does a move that would leave the screen.
+func (h *Handler) MoveCellCurrentMode(dir domain.Direction, count int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	switch h.appState.CurrentMode() {
+	case domain.ModeGrid:
+		if h.grid == nil || h.grid.Manager == nil {
+			return
+		}
+
+		// The subgrid callback already sets the selection point, redraws the
+		// subgrid over the new cell, and moves the cursor when cursor-follow
+		// is on, so there is nothing left to do here.
+		h.grid.Manager.MoveDirection(dir, count)
+	case domain.ModeRecursiveGrid:
+		if h.recursiveGrid == nil || h.recursiveGrid.Manager == nil {
+			return
+		}
+
+		center, moved := h.recursiveGrid.Manager.MoveDirection(dir, count)
+		if !moved {
+			return
+		}
+
+		// The update callback set the selection point and redrew the overlay;
+		// only cursor tracking is left.
+		absoluteCenter := coordinates.ConvertToAbsoluteCoordinates(center, h.screenBounds)
+
+		if h.recursiveGrid.Context != nil &&
+			!h.recursiveGrid.Context.CursorFollowSelection() {
+			h.refreshRecursiveGridVirtualPointerLocked()
+
+			return
+		}
+
+		err := h.actionService.MoveCursorToPoint(h.ctx, absoluteCenter)
+		if err != nil {
+			h.logger.Error(
+				"Failed to move cursor after recursive-grid cell move",
+				zap.Error(err),
+			)
+		}
+	case domain.ModeIdle, domain.ModeHints, domain.ModeScroll, domain.ModeMonitorSelect:
+		// no-op
+	}
+}
+
 // StartHintSearch activates text filtering for hints mode.
 func (h *Handler) StartHintSearch() error {
 	h.mu.Lock()

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -549,7 +549,7 @@ func (h *Handler) startHeldRepeatLocked(key, bindKey string, actions []string) {
 }
 
 // isHeldRepeatAction reports whether the action list contains a single
-// held-repeatable action (scroll, page, or relative mouse move).
+// held-repeatable action (scroll, page, relative mouse move, or cell move).
 func isHeldRepeatAction(actions []string) bool {
 	if len(actions) != 1 {
 		return false

--- a/internal/cli/action.go
+++ b/internal/cli/action.go
@@ -26,7 +26,7 @@ Available subcommands:
   Scroll actions:   scroll_up, scroll_down, scroll_left, scroll_right,
                     go_top, go_bottom, page_up, page_down
   Mouse movement:   move_mouse, move_mouse_relative, move_monitor
-  Mode control:     reset, backspace, wait_for_mode_exit, cycle_hint
+  Mode control:     reset, backspace, move_cell, wait_for_mode_exit, cycle_hint
   Cursor saving:    save_cursor_pos, restore_cursor_pos
   Cursor visibility: hide_cursor, show_cursor
   Key injection:    feed
@@ -46,6 +46,7 @@ Examples:
   neru action middle_click --toggle             Press or release middle button
   neru action scroll_down --steps 5             Scroll down 5 steps
   neru action move_mouse --x 1920 --y 1080      Move to absolute position
+  neru action move_cell --direction right       Slide the selection one cell
   neru action feed ctrl+c                        Send Ctrl+C keystroke`,
 	DisableFlagParsing: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -408,6 +409,9 @@ at the current cursor location.`,
 // ActionCycleHintCmd cycles through visible hints in hints mode.
 var ActionCycleHintCmd = BuildCycleHintCommand()
 
+// ActionMoveCellCmd moves the active mode's selection to a neighboring cell.
+var ActionMoveCellCmd = BuildMoveCellCommand()
+
 func init() {
 	ActionCmd.AddCommand(ActionLeftClickCmd)
 	ActionCmd.AddCommand(ActionRightClickCmd)
@@ -437,6 +441,7 @@ func init() {
 	ActionCmd.AddCommand(ActionPageUpCmd)
 	ActionCmd.AddCommand(ActionPageDownCmd)
 	ActionCmd.AddCommand(ActionCycleHintCmd)
+	ActionCmd.AddCommand(ActionMoveCellCmd)
 	ActionCmd.AddCommand(ActionHideCursorCmd)
 	ActionCmd.AddCommand(ActionShowCursorCmd)
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -184,6 +184,7 @@ func TestCommandInitialization(t *testing.T) {
 		"page_up":             false,
 		"page_down":           false,
 		"move_monitor":        false,
+		"move_cell":           false,
 		"cycle_hint":          false,
 		"hide_cursor":         false,
 		"show_cursor":         false,

--- a/internal/cli/recursive_grid.go
+++ b/internal/cli/recursive_grid.go
@@ -18,6 +18,8 @@ Key mappings (warpd convention):
 Navigation:
   - Press cell key to narrow selection
   - Press backspace to backtrack
+  - Bind "action move_cell --direction=<dir>" to slide the selection to a
+    neighboring cell at the current depth
   - Press reset key (default: comma) to start over
   - Press exit key (default: escape) to exit mode
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/buildinfo"
 	"github.com/y3owk1n/neru/internal/cli/cliutil"
+	"github.com/y3owk1n/neru/internal/core/domain"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
 )
@@ -582,6 +583,63 @@ Positive values move right/down, negative values move left/up.`,
 	cmd.Flags().IntVar(&deltaY, "dy", 0, "Delta Y (pixels, positive=down, negative=up)")
 	_ = cmd.MarkFlagRequired("dx")
 	_ = cmd.MarkFlagRequired("dy")
+
+	return cmd
+}
+
+// BuildMoveCellCommand creates a move_cell cobra command that slides the
+// active mode's selection to a neighboring cell on the same layer.
+func BuildMoveCellCommand() *cobra.Command {
+	var (
+		direction string
+		count     int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "move_cell",
+		Short: "Move the current selection to a neighboring cell",
+		Long: `Slide the active mode's selection one cell in a direction, without
+changing the active layer.
+
+In recursive-grid mode the highlighted region moves at the current depth,
+crossing into a neighboring parent region when it reaches the edge of its
+own. In grid mode an open subgrid moves to the neighboring cell.
+
+Movement stops at the screen edge instead of wrapping, and does nothing in
+modes that have no cell selection.
+
+Examples:
+  neru action move_cell --direction right
+  neru action move_cell --direction up --count 3`,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return requiresRunningInstance()
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, dirErr := domain.ParseDirection(direction)
+			if dirErr != nil {
+				return dirErr
+			}
+
+			if count < 1 {
+				return derrors.New(
+					derrors.CodeInvalidInput,
+					"--count must be at least 1",
+				)
+			}
+
+			actionArgs := []string{
+				"move_cell",
+				"--direction=" + direction,
+				fmt.Sprintf("--count=%d", count),
+			}
+
+			return sendCommand(cmd, "action", actionArgs)
+		},
+	}
+
+	cmd.Flags().StringVar(&direction, "direction", "", "Direction to move (left, right, up, down)")
+	cmd.Flags().IntVar(&count, "count", 1, "Number of cells to move")
+	_ = cmd.MarkFlagRequired("direction")
 
 	return cmd
 }

--- a/internal/config/validators_hotkey_test.go
+++ b/internal/config/validators_hotkey_test.go
@@ -368,3 +368,67 @@ func TestValidateHotkeyBindings_ActionChains(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateHotkeys_MoveCell(t *testing.T) {
+	tests := []struct {
+		name    string
+		action  string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:   "equals form",
+			action: "action move_cell --direction=right",
+		},
+		{
+			name:   "space form",
+			action: "action move_cell --direction left",
+		},
+		{
+			name:   "with count",
+			action: "action move_cell --direction=up --count=2",
+		},
+		{
+			// Direction values are validated by the daemon when the action
+			// runs, not by config validation, which only knows action names.
+			name:   "unknown direction passes config validation",
+			action: "action move_cell --direction=sideways",
+		},
+		{
+			name:    "typo in the action name",
+			action:  "action move_cel --direction=right",
+			wantErr: true,
+			errMsg:  "unknown action subcommand: move_cel",
+		},
+		{
+			name:    "not chainable",
+			action:  "action left_click,move_cell",
+			wantErr: true,
+			errMsg:  "move_cell cannot be used in an action chain",
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.RecursiveGrid.Hotkeys = map[string]config.StringOrStringArray{
+				"Right": {testCase.action},
+			}
+
+			err := cfg.ValidateHotkeys()
+
+			if (err != nil) != testCase.wantErr {
+				t.Errorf("ValidateHotkeys() error = %v, wantErr %v", err, testCase.wantErr)
+			}
+
+			if testCase.wantErr && testCase.errMsg != "" && err != nil {
+				if !strings.Contains(err.Error(), testCase.errMsg) {
+					t.Errorf(
+						"ValidateHotkeys() error = %v, want error containing %q",
+						err,
+						testCase.errMsg,
+					)
+				}
+			}
+		})
+	}
+}

--- a/internal/core/domain/action/action.go
+++ b/internal/core/domain/action/action.go
@@ -380,6 +380,8 @@ const (
 	NameReset Name = "reset"
 	// NameBackspace performs a mode-aware backspace operation.
 	NameBackspace Name = "backspace"
+	// NameMoveCell slides the active mode's selection to a neighboring cell.
+	NameMoveCell Name = "move_cell"
 	// NameWaitForModeExit blocks until the current mode exits.
 	NameWaitForModeExit Name = "wait_for_mode_exit"
 	// NameSaveCursorPos saves the current cursor position for later restoration.
@@ -495,6 +497,11 @@ func IsBackspaceAction(name string) bool {
 	return Name(name) == NameBackspace
 }
 
+// IsMoveCellAction reports whether the given action is move_cell.
+func IsMoveCellAction(name string) bool {
+	return Name(name) == NameMoveCell
+}
+
 // IsWaitForModeExitAction reports whether the given action is wait_for_mode_exit.
 func IsWaitForModeExitAction(name string) bool {
 	return Name(name) == NameWaitForModeExit
@@ -558,7 +565,7 @@ func IsKnownName(name Name) bool {
 		NameMoveMouse,
 		NameMoveMouseRelative,
 		NameScroll,
-		NameReset, NameBackspace,
+		NameReset, NameBackspace, NameMoveCell,
 		NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
 		NameScrollUp, NameScrollDown, NameScrollLeft, NameScrollRight,
 		NameGoTop, NameGoBottom, NamePageUp, NamePageDown,
@@ -589,7 +596,8 @@ func IsScrollSubAction(name string) bool {
 		NameMiddleMouseDown, NameMiddleMouseUp,
 		NameLeftMouseToggle, NameRightMouseToggle, NameMiddleMouseToggle,
 		NameMoveMouse, NameMoveMouseRelative, NameScroll,
-		NameReset, NameBackspace, NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
+		NameReset, NameBackspace, NameMoveCell,
+		NameWaitForModeExit, NameSaveCursorPos, NameRestoreCursorPos,
 		NameMoveMonitor, NameFeed, NameSleep, NameCycleHint, NameSearchHints,
 		NameHideCursor, NameShowCursor:
 		return false
@@ -600,12 +608,13 @@ func IsScrollSubAction(name string) bool {
 
 // IsHeldRepeatAction reports whether the action name supports held-key repeat
 // (fires repeatedly while the key is held, with no initial delay).
-// Currently applies to scroll, page, and relative mouse move actions.
+// Currently applies to scroll, page, relative mouse move, and cell move actions.
 func IsHeldRepeatAction(name Name) bool {
 	switch name { //nolint:exhaustive
 	case NameScrollUp, NameScrollDown, NameScrollLeft, NameScrollRight,
 		NamePageUp, NamePageDown,
-		NameMoveMouseRelative:
+		NameMoveMouseRelative,
+		NameMoveCell:
 		return true
 	default:
 		return false
@@ -690,6 +699,7 @@ func (n Name) ToType() (Type, error) {
 		return TypeScroll, nil
 	case NameReset,
 		NameBackspace,
+		NameMoveCell,
 		NameWaitForModeExit,
 		NameSaveCursorPos,
 		NameRestoreCursorPos,

--- a/internal/core/domain/direction.go
+++ b/internal/core/domain/direction.go
@@ -1,0 +1,80 @@
+package domain
+
+import (
+	"strings"
+
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+)
+
+// Direction identifies one of the four cardinal directions used to slide the
+// current selection to a neighboring cell without changing the active layer.
+// It is shared by grid and recursive-grid navigation.
+type Direction uint8
+
+const (
+	// DirectionLeft moves the selection towards smaller X.
+	DirectionLeft Direction = iota
+	// DirectionRight moves the selection towards larger X.
+	DirectionRight
+	// DirectionUp moves the selection towards smaller Y.
+	DirectionUp
+	// DirectionDown moves the selection towards larger Y.
+	DirectionDown
+)
+
+// String returns the canonical lowercase name of the direction.
+func (d Direction) String() string {
+	switch d {
+	case DirectionLeft:
+		return "left"
+	case DirectionRight:
+		return "right"
+	case DirectionUp:
+		return "up"
+	case DirectionDown:
+		return "down"
+	default:
+		return UnknownDirection
+	}
+}
+
+// UnknownDirection is the string form of a Direction outside the known set.
+const UnknownDirection = "unknown"
+
+// Delta returns the unit step for the direction in screen coordinates
+// (global top-left origin, Y growing downward).
+func (d Direction) Delta() (int, int) {
+	switch d {
+	case DirectionLeft:
+		return -1, 0
+	case DirectionRight:
+		return 1, 0
+	case DirectionUp:
+		return 0, -1
+	case DirectionDown:
+		return 0, 1
+	default:
+		return 0, 0
+	}
+}
+
+// ParseDirection parses a user-supplied direction name. Parsing is
+// case-insensitive and tolerant of surrounding whitespace.
+func ParseDirection(name string) (Direction, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "left":
+		return DirectionLeft, nil
+	case "right":
+		return DirectionRight, nil
+	case "up":
+		return DirectionUp, nil
+	case "down":
+		return DirectionDown, nil
+	default:
+		return 0, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"invalid direction %q (expected left, right, up, or down)",
+			name,
+		)
+	}
+}

--- a/internal/core/domain/direction_test.go
+++ b/internal/core/domain/direction_test.go
@@ -1,0 +1,93 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/y3owk1n/neru/internal/core/domain"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+)
+
+const (
+	dirLeft  = "left"
+	dirRight = "right"
+	dirUp    = "up"
+	dirDown  = "down"
+)
+
+func TestParseDirection(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    domain.Direction
+		wantErr bool
+	}{
+		{name: dirLeft, input: dirLeft, want: domain.DirectionLeft},
+		{name: dirRight, input: dirRight, want: domain.DirectionRight},
+		{name: dirUp, input: dirUp, want: domain.DirectionUp},
+		{name: dirDown, input: dirDown, want: domain.DirectionDown},
+		{name: "uppercase", input: "RIGHT", want: domain.DirectionRight},
+		{name: "surrounding whitespace", input: "  " + dirDown + "  ", want: domain.DirectionDown},
+		{name: "empty", input: "", wantErr: true},
+		{name: "unknown", input: "sideways", wantErr: true},
+		{name: "abbreviation is not accepted", input: "l", wantErr: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := domain.ParseDirection(testCase.input)
+
+			if testCase.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, derrors.CodeInvalidInput, derrors.GetCode(err))
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+func TestDirection_Delta(t *testing.T) {
+	tests := []struct {
+		direction      domain.Direction
+		wantX          int
+		wantY          int
+		wantString     string
+		wantRoundTrips bool
+	}{
+		{domain.DirectionLeft, -1, 0, dirLeft, true},
+		{domain.DirectionRight, 1, 0, dirRight, true},
+		// Y grows downward in shared coordinates, so up is negative.
+		{domain.DirectionUp, 0, -1, dirUp, true},
+		{domain.DirectionDown, 0, 1, dirDown, true},
+		{domain.Direction(99), 0, 0, domain.UnknownDirection, false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.wantString, func(t *testing.T) {
+			deltaX, deltaY := testCase.direction.Delta()
+
+			assert.Equal(t, testCase.wantX, deltaX)
+			assert.Equal(t, testCase.wantY, deltaY)
+			assert.Equal(t, testCase.wantString, testCase.direction.String())
+
+			if !testCase.wantRoundTrips {
+				return
+			}
+
+			parsed, err := domain.ParseDirection(testCase.direction.String())
+			require.NoError(t, err)
+			assert.Equal(
+				t,
+				testCase.direction,
+				parsed,
+				"String and ParseDirection should round-trip",
+			)
+		})
+	}
+}

--- a/internal/core/domain/grid/grid.go
+++ b/internal/core/domain/grid/grid.go
@@ -939,6 +939,21 @@ func (g *Grid) CellByCoordinate(coordinate string) *Cell {
 	return nil
 }
 
+// CellForPoint returns the cell containing point, or nil when no cell does.
+//
+// Cells are emitted region by region and a region running off the right or
+// bottom edge is clipped, so the cells do not always tile the whole bounds —
+// a point inside Bounds can still land on no cell.
+func (g *Grid) CellForPoint(point image.Point) *Cell {
+	for _, cell := range g.cells {
+		if point.In(cell.bounds) {
+			return cell
+		}
+	}
+
+	return nil
+}
+
 // HasCoordinatePrefix returns true if any coordinate starts with the given prefix.
 func (g *Grid) HasCoordinatePrefix(prefix string) bool {
 	prefix = strings.ToUpper(prefix)

--- a/internal/core/domain/grid/manager.go
+++ b/internal/core/domain/grid/manager.go
@@ -188,6 +188,81 @@ func (m *Manager) HandleBackspace() (image.Point, bool) {
 	return image.Point{}, false
 }
 
+// MoveDirection slides the selected cell count cells in dir and redraws the
+// subgrid over the new cell. It only applies while a subgrid is open — before
+// that no cell is selected, so there is nothing to move.
+//
+// Returns the resulting cell center and whether anything moved.
+func (m *Manager) MoveDirection(dir domain.Direction, count int) (image.Point, bool) {
+	if !m.inSubgrid || m.selectedCell == nil || m.grid == nil {
+		return image.Point{}, false
+	}
+
+	count = max(count, 1)
+
+	moved := false
+
+	for range count {
+		next := m.neighbourCell(m.selectedCell, dir)
+		if next == nil {
+			break
+		}
+
+		m.selectedCell = next
+		// Backspace out of a subgrid restores the main-grid input from
+		// mainGridInput, so it has to track the cell we actually landed on.
+		m.mainGridInput = next.Coordinate()
+		moved = true
+	}
+
+	center := m.selectedCell.Center()
+
+	m.Logger.Debug("Grid directional move",
+		zap.String("direction", dir.String()),
+		zap.Int("count", count),
+		zap.Bool("moved", moved))
+
+	if !moved {
+		return center, false
+	}
+
+	// A subgrid selection is a single keypress, so no partial input survives
+	// the move.
+	m.SetCurrentInput("")
+
+	if m.onShowSub != nil {
+		m.onShowSub(m.selectedCell)
+	}
+
+	return center, true
+}
+
+// neighbourCell returns the cell one cell-width from cell in dir, or nil when
+// that lands outside the grid.
+func (m *Manager) neighbourCell(cell *Cell, dir domain.Direction) *Cell {
+	bounds := cell.Bounds()
+	if bounds.Empty() {
+		return nil
+	}
+
+	deltaX, deltaY := dir.Delta()
+	next := bounds.Add(image.Point{X: deltaX * bounds.Dx(), Y: deltaY * bounds.Dy()})
+
+	// Probe the middle of the shifted rectangle. Truncating division rather
+	// than the cell's stored center, which rounds up and would sit outside a
+	// one-pixel-wide or one-pixel-tall rectangle and resolve to the wrong cell.
+	target := image.Point{
+		X: next.Min.X + next.Dx()/CenterDivisor,
+		Y: next.Min.Y + next.Dy()/CenterDivisor,
+	}
+
+	if !target.In(m.grid.Bounds()) {
+		return nil
+	}
+
+	return m.grid.CellForPoint(target)
+}
+
 // hasMatchingCoordinate checks if any grid cell coordinate starts with the given prefix.
 func (m *Manager) hasMatchingCoordinate(prefix string) bool {
 	if m.grid == nil {

--- a/internal/core/domain/grid/move_test.go
+++ b/internal/core/domain/grid/move_test.go
@@ -1,0 +1,248 @@
+package grid_test
+
+import (
+	"image"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/domain/grid"
+	"github.com/y3owk1n/neru/internal/core/infra/logger"
+)
+
+// moveHarness wires a manager to a grid and records the cells the subgrid
+// callback is asked to draw.
+type moveHarness struct {
+	grid    *grid.Grid
+	manager *grid.Manager
+	shown   []*grid.Cell
+}
+
+func newMoveHarness(t *testing.T) *moveHarness {
+	t.Helper()
+
+	log := logger.Get()
+	harness := &moveHarness{
+		grid: grid.NewGrid("abcdefghijklmnopqrstuvwxyz", image.Rect(0, 0, 1000, 800), log),
+	}
+
+	harness.manager = grid.NewManager(
+		harness.grid,
+		domain.SubgridRows,
+		domain.SubgridCols,
+		"asdfghjkl",
+		func(bool) {},
+		func(cell *grid.Cell) { harness.shown = append(harness.shown, cell) },
+		log,
+	)
+
+	return harness
+}
+
+// openSubgrid types the coordinate of cell so the manager enters its subgrid.
+func (h *moveHarness) openSubgrid(t *testing.T, cell *grid.Cell) {
+	t.Helper()
+
+	for _, char := range cell.Coordinate() {
+		h.manager.HandleInput(string(char))
+	}
+
+	if len(h.shown) == 0 {
+		t.Fatalf("typing %q did not open a subgrid", cell.Coordinate())
+	}
+
+	if got := h.shown[len(h.shown)-1]; got.Coordinate() != cell.Coordinate() {
+		t.Fatalf("opened subgrid for %q, want %q", got.Coordinate(), cell.Coordinate())
+	}
+}
+
+// cellRightOf returns the cell one cell-width to the right of cell, or nil.
+func (h *moveHarness) cellRightOf(cell *grid.Cell) *grid.Cell {
+	return h.grid.CellForPoint(image.Point{
+		X: cell.Center().X + cell.Bounds().Dx(),
+		Y: cell.Center().Y,
+	})
+}
+
+// anInteriorCell returns a cell that has a neighbor to its right.
+func (h *moveHarness) anInteriorCell(t *testing.T) *grid.Cell {
+	t.Helper()
+
+	for _, cell := range h.grid.AllCells() {
+		if h.cellRightOf(cell) != nil {
+			return cell
+		}
+	}
+
+	t.Fatal("grid has no cell with a right neighbor")
+
+	return nil
+}
+
+// rightmostCell returns a cell on the right edge of the grid.
+func (h *moveHarness) rightmostCell(t *testing.T) *grid.Cell {
+	t.Helper()
+
+	var rightmost *grid.Cell
+
+	for _, cell := range h.grid.AllCells() {
+		if rightmost == nil || cell.Bounds().Max.X > rightmost.Bounds().Max.X {
+			rightmost = cell
+		}
+	}
+
+	if rightmost == nil {
+		t.Fatal("grid has no cells")
+	}
+
+	return rightmost
+}
+
+func TestManager_MoveDirection_MovesSubgridToNeighbouringCell(t *testing.T) {
+	harness := newMoveHarness(t)
+	start := harness.anInteriorCell(t)
+	want := harness.cellRightOf(start)
+
+	harness.openSubgrid(t, start)
+	shownBefore := len(harness.shown)
+
+	center, moved := harness.manager.MoveDirection(domain.DirectionRight, 1)
+
+	if !moved {
+		t.Fatal("MoveDirection(right) reported no movement")
+	}
+
+	if center != want.Center() {
+		t.Errorf("MoveDirection(right) center = %v, want %v", center, want.Center())
+	}
+
+	if len(harness.shown) != shownBefore+1 {
+		t.Fatalf("expected one subgrid redraw, got %d", len(harness.shown)-shownBefore)
+	}
+
+	if got := harness.shown[len(harness.shown)-1]; got.Coordinate() != want.Coordinate() {
+		t.Errorf("subgrid redrawn for %q, want %q", got.Coordinate(), want.Coordinate())
+	}
+}
+
+func TestManager_MoveDirection_IgnoredWithoutAnOpenSubgrid(t *testing.T) {
+	harness := newMoveHarness(t)
+
+	// Nothing typed yet: no cell is selected, so there is nothing to move.
+	if _, moved := harness.manager.MoveDirection(domain.DirectionRight, 1); moved {
+		t.Error("MoveDirection with no selection should report no movement")
+	}
+
+	// A partial coordinate is still not a selection.
+	harness.manager.HandleInput(string(harness.anInteriorCell(t).Coordinate()[0]))
+
+	if _, moved := harness.manager.MoveDirection(domain.DirectionRight, 1); moved {
+		t.Error("MoveDirection on a partial coordinate should report no movement")
+	}
+
+	if len(harness.shown) != 0 {
+		t.Errorf("expected no subgrid draws, got %d", len(harness.shown))
+	}
+}
+
+func TestManager_MoveDirection_StopsAtGridEdge(t *testing.T) {
+	harness := newMoveHarness(t)
+	edge := harness.rightmostCell(t)
+
+	harness.openSubgrid(t, edge)
+	shownBefore := len(harness.shown)
+
+	center, moved := harness.manager.MoveDirection(domain.DirectionRight, 1)
+
+	if moved {
+		t.Error("MoveDirection past the right edge should report no movement")
+	}
+
+	if center != edge.Center() {
+		t.Errorf("center = %v, want the unchanged %v", center, edge.Center())
+	}
+
+	if len(harness.shown) != shownBefore {
+		t.Error("a refused move should not redraw the subgrid")
+	}
+}
+
+func TestManager_MoveDirection_KeepsBackspaceInputInSync(t *testing.T) {
+	harness := newMoveHarness(t)
+	start := harness.anInteriorCell(t)
+	want := harness.cellRightOf(start)
+
+	harness.openSubgrid(t, start)
+
+	if _, moved := harness.manager.MoveDirection(domain.DirectionRight, 1); !moved {
+		t.Fatal("MoveDirection(right) reported no movement")
+	}
+
+	// Backspacing out of the subgrid restores the main-grid coordinate, which
+	// has to describe the cell the move landed on rather than the one first
+	// typed — otherwise the input no longer matches the highlighted cell.
+	harness.manager.HandleBackspace()
+
+	wantInput := want.Coordinate()[:len(want.Coordinate())-1]
+	if got := harness.manager.CurrentInput(); got != wantInput {
+		t.Errorf("input after backspace = %q, want %q", got, wantInput)
+	}
+
+	if !strings.HasPrefix(want.Coordinate(), harness.manager.CurrentInput()) {
+		t.Errorf(
+			"restored input %q is not a prefix of the selected cell %q",
+			harness.manager.CurrentInput(),
+			want.Coordinate(),
+		)
+	}
+}
+
+func TestManager_MoveDirection_Count(t *testing.T) {
+	harness := newMoveHarness(t)
+
+	start := harness.anInteriorCell(t)
+
+	second := harness.cellRightOf(start)
+	if second == nil {
+		t.Fatal("no first neighbor")
+	}
+
+	want := harness.cellRightOf(second)
+	if want == nil {
+		t.Skip("grid is too narrow for a two-cell move")
+	}
+
+	harness.openSubgrid(t, start)
+
+	center, moved := harness.manager.MoveDirection(domain.DirectionRight, 2)
+
+	if !moved {
+		t.Fatal("MoveDirection(right, 2) reported no movement")
+	}
+
+	if center != want.Center() {
+		t.Errorf("center = %v, want %v", center, want.Center())
+	}
+}
+
+func TestGrid_CellForPoint(t *testing.T) {
+	testGrid := grid.NewGrid(
+		"abcdefghijklmnopqrstuvwxyz",
+		image.Rect(0, 0, 1000, 800),
+		logger.Get(),
+	)
+
+	for _, cell := range testGrid.AllCells() {
+		if got := testGrid.CellForPoint(cell.Center()); got != cell {
+			t.Fatalf(
+				"CellForPoint(center of %q) returned %v, want the cell itself",
+				cell.Coordinate(),
+				got,
+			)
+		}
+	}
+
+	if got := testGrid.CellForPoint(image.Point{X: -1, Y: -1}); got != nil {
+		t.Errorf("CellForPoint outside the grid = %q, want nil", got.Coordinate())
+	}
+}

--- a/internal/core/domain/recursivegrid/manager.go
+++ b/internal/core/domain/recursivegrid/manager.go
@@ -210,6 +210,29 @@ func (m *Manager) HandleInput(key string) (image.Point, bool) {
 	return center, isComplete
 }
 
+// MoveDirection slides the current selection count cells in dir without
+// changing depth, and fires the update callback when the selection changed.
+// Returns the resulting selection center and whether anything moved.
+func (m *Manager) MoveDirection(dir domain.Direction, count int) (image.Point, bool) {
+	center, moved := m.grid.MoveDirection(dir, count)
+
+	m.Logger.Debug("Recursive-grid directional move",
+		zap.String("direction", dir.String()),
+		zap.Int("count", count),
+		zap.Int("depth", m.grid.CurrentDepth()),
+		zap.Bool("moved", moved))
+
+	if !moved {
+		return center, false
+	}
+
+	if m.onUpdate != nil {
+		m.onUpdate(center)
+	}
+
+	return center, true
+}
+
 // Reset clears the manager state and restores initial grid state.
 func (m *Manager) Reset() {
 	m.SetCurrentInput("")

--- a/internal/core/domain/recursivegrid/move.go
+++ b/internal/core/domain/recursivegrid/move.go
@@ -38,17 +38,6 @@ func (qg *RecursiveGrid) restore(state gridState) {
 	qg.hasFinalCell = state.hasFinalCell
 }
 
-// clampToRect pulls point inside rect. rectCenter rounds up, which puts the
-// "center" of a one-pixel-wide or one-pixel-tall rectangle outside it — the
-// probe point would then resolve to the wrong cell, skipping a cell and
-// drifting diagonally. rect must not be empty.
-func clampToRect(point image.Point, rect image.Rectangle) image.Point {
-	return image.Point{
-		X: min(max(point.X, rect.Min.X), rect.Max.X-1),
-		Y: min(max(point.Y, rect.Min.Y), rect.Max.Y-1),
-	}
-}
-
 // MoveDirection slides the current selection one cell in dir, repeated count
 // times, without changing the active depth. Movement is spatial rather than
 // confined to the parent's cells: the selection crosses into a neighboring
@@ -85,7 +74,11 @@ func (qg *RecursiveGrid) moveOnce(dir domain.Direction) bool {
 
 	deltaX, deltaY := dir.Delta()
 	next := rect.Add(image.Point{X: deltaX * rect.Dx(), Y: deltaY * rect.Dy()})
-	target := clampToRect(rectCenter(next), next)
+
+	// rectCenter keeps the probe inside next, which matters for one-pixel
+	// cells: an unclamped center would resolve to the cell beyond the one we
+	// mean, skipping a cell and drifting diagonally.
+	target := rectCenter(next)
 
 	// Stop at the screen edge. At depth 0 with no final cell the selection is
 	// the whole screen, so every direction lands outside and this is a no-op.

--- a/internal/core/domain/recursivegrid/move.go
+++ b/internal/core/domain/recursivegrid/move.go
@@ -1,0 +1,127 @@
+package recursivegrid
+
+import (
+	"image"
+	"slices"
+
+	"github.com/y3owk1n/neru/internal/core/domain"
+)
+
+// gridState captures everything MoveDirection mutates, so a step that cannot
+// be completed can be rolled back and leave the grid exactly as it was.
+type gridState struct {
+	currentBounds image.Rectangle
+	history       []image.Rectangle
+	depth         int
+	finalCell     Cell
+	hasFinalCell  bool
+}
+
+// snapshot copies the mutable navigation state. history is cloned because
+// Reset truncates the backing array in place.
+func (qg *RecursiveGrid) snapshot() gridState {
+	return gridState{
+		currentBounds: qg.currentBounds,
+		history:       slices.Clone(qg.history),
+		depth:         qg.depth,
+		finalCell:     qg.finalCell,
+		hasFinalCell:  qg.hasFinalCell,
+	}
+}
+
+// restore puts back a snapshot taken by snapshot.
+func (qg *RecursiveGrid) restore(state gridState) {
+	qg.currentBounds = state.currentBounds
+	qg.history = state.history
+	qg.depth = state.depth
+	qg.finalCell = state.finalCell
+	qg.hasFinalCell = state.hasFinalCell
+}
+
+// clampToRect pulls point inside rect. rectCenter rounds up, which puts the
+// "center" of a one-pixel-wide or one-pixel-tall rectangle outside it — the
+// probe point would then resolve to the wrong cell, skipping a cell and
+// drifting diagonally. rect must not be empty.
+func clampToRect(point image.Point, rect image.Rectangle) image.Point {
+	return image.Point{
+		X: min(max(point.X, rect.Min.X), rect.Max.X-1),
+		Y: min(max(point.Y, rect.Min.Y), rect.Max.Y-1),
+	}
+}
+
+// MoveDirection slides the current selection one cell in dir, repeated count
+// times, without changing the active depth. Movement is spatial rather than
+// confined to the parent's cells: the selection crosses into a neighboring
+// parent when it reaches the edge of its own, and the ancestor chain is
+// rebuilt to match, so backtracking afterwards stays correct.
+//
+// A step that would leave the initial bounds is refused, so movement stops at
+// the screen edge instead of wrapping. Counts below one are treated as one.
+//
+// Returns the resulting selection center and whether anything moved.
+func (qg *RecursiveGrid) MoveDirection(dir domain.Direction, count int) (image.Point, bool) {
+	count = max(count, 1)
+
+	moved := false
+
+	for range count {
+		if !qg.moveOnce(dir) {
+			break
+		}
+
+		moved = true
+	}
+
+	return qg.SelectionCenter(), moved
+}
+
+// moveOnce slides the selection by exactly one cell. It reports whether the
+// move happened; when it does not, the grid is left untouched.
+func (qg *RecursiveGrid) moveOnce(dir domain.Direction) bool {
+	rect := qg.EffectiveBounds()
+	if rect.Empty() {
+		return false
+	}
+
+	deltaX, deltaY := dir.Delta()
+	next := rect.Add(image.Point{X: deltaX * rect.Dx(), Y: deltaY * rect.Dy()})
+	target := clampToRect(rectCenter(next), next)
+
+	// Stop at the screen edge. At depth 0 with no final cell the selection is
+	// the whole screen, so every direction lands outside and this is a no-op.
+	if !target.In(qg.initialBounds) {
+		return false
+	}
+
+	previous := qg.snapshot()
+
+	// Re-walk from the root towards the target instead of patching bounds in
+	// place: ZoomToPoint resolves the containing cell at every depth using
+	// that depth's own layout, so per-depth overrides and remainder-sized
+	// cells come out right and the rebuilt history matches the new position.
+	qg.Reset()
+	qg.ZoomToPoint(target, previous.depth)
+
+	// Cells within a level can differ by a pixel, so a path that reached this
+	// depth before may bottom out one level early. Rather than silently
+	// landing at the wrong depth, refuse the move.
+	if qg.depth != previous.depth {
+		qg.restore(previous)
+
+		return false
+	}
+
+	if previous.hasFinalCell {
+		cell := qg.CellForPoint(target)
+		if cell < 0 {
+			qg.restore(previous)
+
+			return false
+		}
+
+		qg.finalCell = cell
+		qg.hasFinalCell = true
+	}
+
+	return true
+}

--- a/internal/core/domain/recursivegrid/move_test.go
+++ b/internal/core/domain/recursivegrid/move_test.go
@@ -405,3 +405,69 @@ func TestRecursiveGrid_MoveDirection_AfterScreenChange(t *testing.T) {
 	assert.Equal(t, image.Rect(400, 200, 600, 400), grid.EffectiveBounds(),
 		"movement should step by the remapped cell size")
 }
+
+// TestRecursiveGrid_SelectionCenter_StaysInsideOnePixelCells pins the invariant
+// every cursor target depends on: the reported center of a selection must lie
+// inside that selection. Rounding to nearest breaks it for a one-pixel cell,
+// which puts the cursor — and any action targeting it — on the cell next door.
+func TestRecursiveGrid_SelectionCenter_StaysInsideOnePixelCells(t *testing.T) {
+	t.Run("after a directional move", func(t *testing.T) {
+		grid := recursivegrid.NewRecursiveGridWithLayers(
+			image.Rect(0, 0, 9, 9),
+			1, 1, 10, 3, 3,
+			nil,
+		)
+
+		descend(t, grid, 0, 0)
+		require.Equal(t, image.Rect(0, 0, 1, 1), grid.CurrentBounds())
+
+		_, moved := grid.MoveDirection(domain.DirectionRight, 3)
+		require.True(t, moved)
+
+		bounds := grid.EffectiveBounds()
+		center := grid.SelectionCenter()
+
+		assert.Truef(t, center.In(bounds),
+			"selection center %v is outside the selected cell %v", center, bounds)
+	})
+
+	t.Run("after selecting a final cell", func(t *testing.T) {
+		// A minimum size of 2 stops subdivision while the cells drawn at that
+		// depth are still one pixel, so the final cell is one pixel.
+		grid := recursivegrid.NewRecursiveGridWithLayers(
+			image.Rect(0, 0, 9, 9),
+			2, 2, 10, 3, 3,
+			nil,
+		)
+
+		_, complete := grid.SelectCell(0)
+		require.False(t, complete)
+
+		center, complete := grid.SelectCell(4)
+		require.True(t, complete)
+
+		bounds := grid.CellBounds(4)
+		require.Equal(t, image.Rect(1, 1, 2, 2), bounds)
+
+		assert.Truef(t, center.In(bounds),
+			"selected point %v is outside the final cell %v", center, bounds)
+		assert.Equal(t, center, grid.SelectionCenter(),
+			"SelectionCenter should agree with the point SelectCell returned")
+	})
+
+	t.Run("every cell of a one-pixel grid", func(t *testing.T) {
+		grid := recursivegrid.NewRecursiveGridWithLayers(
+			image.Rect(0, 0, 3, 3),
+			1, 1, 10, 3, 3,
+			nil,
+		)
+
+		for cell := range recursivegrid.Cell(9) {
+			bounds := grid.CellBounds(cell)
+			center := grid.CellCenter(cell)
+
+			assert.Truef(t, center.In(bounds),
+				"cell %d center %v is outside its bounds %v", cell, center, bounds)
+		}
+	})
+}

--- a/internal/core/domain/recursivegrid/move_test.go
+++ b/internal/core/domain/recursivegrid/move_test.go
@@ -1,0 +1,407 @@
+package recursivegrid_test
+
+import (
+	"image"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/domain/recursivegrid"
+)
+
+// newMoveGrid builds a 900x900 grid divided 3x3 at every depth, so depth 1
+// cells are 300px and depth 2 cells are 100px.
+func newMoveGrid() *recursivegrid.RecursiveGrid {
+	return recursivegrid.NewRecursiveGridWithLayers(
+		image.Rect(0, 0, 900, 900),
+		1, 1, 10, 3, 3,
+		nil,
+	)
+}
+
+// descend selects the given cells in order, failing the test if the grid
+// bottoms out early.
+func descend(t *testing.T, grid *recursivegrid.RecursiveGrid, cells ...recursivegrid.Cell) {
+	t.Helper()
+
+	for _, cell := range cells {
+		_, complete := grid.SelectCell(cell)
+		require.False(t, complete, "grid bottomed out before the test could set up")
+	}
+}
+
+func TestRecursiveGrid_MoveDirection_WithinParent(t *testing.T) {
+	grid := newMoveGrid()
+	// Depth 1 top-left cell, then its own top-left: (0,0)-(100,100).
+	descend(t, grid, 0, 0)
+
+	center, moved := grid.MoveDirection(domain.DirectionRight, 1)
+
+	assert.True(t, moved, "moving right from the leftmost cell should succeed")
+	assert.Equal(t, image.Rect(100, 0, 200, 100), grid.CurrentBounds())
+	assert.Equal(t, image.Point{X: 150, Y: 50}, center)
+	assert.Equal(t, 2, grid.CurrentDepth(), "depth must not change")
+}
+
+func TestRecursiveGrid_MoveDirection_CrossesIntoNeighbouringParent(t *testing.T) {
+	grid := newMoveGrid()
+	// Depth 1 top-left cell, then its top-right: (200,0)-(300,100).
+	// The next cell to the right lives under a different depth-1 parent.
+	descend(t, grid, 0, 2)
+	require.Equal(t, image.Rect(200, 0, 300, 100), grid.CurrentBounds())
+
+	center, moved := grid.MoveDirection(domain.DirectionRight, 1)
+
+	assert.True(t, moved, "crossing a parent boundary should succeed")
+	assert.Equal(t, image.Rect(300, 0, 400, 100), grid.CurrentBounds())
+	assert.Equal(t, image.Point{X: 350, Y: 50}, center)
+	assert.Equal(t, 2, grid.CurrentDepth())
+}
+
+func TestRecursiveGrid_MoveDirection_RebuildsAncestors(t *testing.T) {
+	grid := newMoveGrid()
+	descend(t, grid, 0, 2)
+
+	_, moved := grid.MoveDirection(domain.DirectionRight, 1)
+	require.True(t, moved)
+
+	// The ancestor chain must follow the selection into the new parent,
+	// otherwise backtracking would surface a region that no longer contains
+	// the current bounds.
+	require.True(t, grid.Backtrack(), "history should still be intact after a move")
+	assert.Equal(t, image.Rect(300, 0, 600, 300), grid.CurrentBounds())
+	assert.Equal(t, 1, grid.CurrentDepth())
+
+	require.True(t, grid.Backtrack())
+	assert.Equal(t, image.Rect(0, 0, 900, 900), grid.CurrentBounds())
+	assert.Equal(t, 0, grid.CurrentDepth())
+}
+
+func TestRecursiveGrid_MoveDirection_StopsAtScreenEdge(t *testing.T) {
+	grid := newMoveGrid()
+	descend(t, grid, 0, 0)
+
+	before := grid.CurrentBounds()
+
+	center, moved := grid.MoveDirection(domain.DirectionLeft, 1)
+
+	assert.False(t, moved, "moving left off the screen should be refused")
+	assert.Equal(t, before, grid.CurrentBounds(), "a refused move must not change state")
+	assert.Equal(t, image.Point{X: 50, Y: 50}, center)
+}
+
+func TestRecursiveGrid_MoveDirection_NoOpAtDepthZero(t *testing.T) {
+	grid := newMoveGrid()
+
+	// Nothing is selected yet at depth 0: the selection is the whole screen,
+	// so a step of one screen width always lands outside.
+	for _, dir := range []domain.Direction{
+		domain.DirectionLeft,
+		domain.DirectionRight,
+		domain.DirectionUp,
+		domain.DirectionDown,
+	} {
+		_, moved := grid.MoveDirection(dir, 1)
+
+		assert.Falsef(t, moved, "move %s at depth 0 should be a no-op", dir)
+		assert.Equal(t, image.Rect(0, 0, 900, 900), grid.CurrentBounds())
+	}
+}
+
+func TestRecursiveGrid_MoveDirection_Count(t *testing.T) {
+	tests := []struct {
+		name      string
+		direction domain.Direction
+		count     int
+		want      image.Rectangle
+		wantMoved bool
+	}{
+		{
+			name:      "two cells right",
+			direction: domain.DirectionRight,
+			count:     2,
+			want:      image.Rect(200, 0, 300, 100),
+			wantMoved: true,
+		},
+		{
+			name:      "four cells down crosses a parent",
+			direction: domain.DirectionDown,
+			count:     4,
+			want:      image.Rect(0, 400, 100, 500),
+			wantMoved: true,
+		},
+		{
+			name:      "count below one is treated as one",
+			direction: domain.DirectionRight,
+			count:     0,
+			want:      image.Rect(100, 0, 200, 100),
+			wantMoved: true,
+		},
+		{
+			name:      "a move that cannot take its first step reports no movement",
+			direction: domain.DirectionUp,
+			count:     3,
+			want:      image.Rect(0, 0, 100, 100),
+			wantMoved: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			grid := newMoveGrid()
+			descend(t, grid, 0, 0)
+
+			_, moved := grid.MoveDirection(testCase.direction, testCase.count)
+
+			assert.Equal(t, testCase.wantMoved, moved)
+			assert.Equal(t, testCase.want, grid.CurrentBounds())
+			assert.Equal(t, 2, grid.CurrentDepth())
+		})
+	}
+}
+
+func TestRecursiveGrid_MoveDirection_PartialCountStopsAtEdge(t *testing.T) {
+	grid := newMoveGrid()
+	descend(t, grid, 0, 0)
+
+	// The 900px row holds nine 100px cells, so only eight of the twenty
+	// requested steps fit. The rest are dropped at the edge.
+	_, moved := grid.MoveDirection(domain.DirectionRight, 20)
+
+	assert.True(t, moved, "a partially applied move still counts as movement")
+	assert.Equal(t, image.Rect(800, 0, 900, 100), grid.CurrentBounds(),
+		"movement should stop on the last cell inside the screen")
+}
+
+func TestRecursiveGrid_MoveDirection_PerDepthLayouts(t *testing.T) {
+	// Depth 1 splits 2x2 rather than the default 3x3, so a depth-2 cell is
+	// 150px wide: movement has to read the layout of each depth it walks.
+	grid := recursivegrid.NewRecursiveGridWithLayers(
+		image.Rect(0, 0, 900, 900),
+		1, 1, 10, 3, 3,
+		map[int]recursivegrid.DepthLayout{1: {GridCols: 2, GridRows: 2}},
+	)
+
+	descend(t, grid, 0, 0)
+	require.Equal(t, image.Rect(0, 0, 150, 150), grid.CurrentBounds())
+
+	_, moved := grid.MoveDirection(domain.DirectionRight, 1)
+
+	assert.True(t, moved)
+	assert.Equal(t, image.Rect(150, 0, 300, 150), grid.CurrentBounds())
+	assert.Equal(t, 2, grid.CurrentDepth())
+}
+
+func TestRecursiveGrid_MoveDirection_MovesFinalCellAfterBottomingOut(t *testing.T) {
+	// minSize 200 lets depth 0 divide (300px cells) but not depth 1 (100px),
+	// so the depth-1 selection is a final cell that never becomes the bounds.
+	grid := recursivegrid.NewRecursiveGridWithLayers(
+		image.Rect(0, 0, 900, 900),
+		200, 200, 10, 3, 3,
+		nil,
+	)
+
+	_, complete := grid.SelectCell(0)
+	require.False(t, complete)
+
+	// Cell 4 is the middle of the depth-1 grid: (100,100)-(200,200).
+	center, complete := grid.SelectCell(4)
+	require.True(t, complete, "the grid should have bottomed out at depth 1")
+	require.Equal(t, image.Point{X: 150, Y: 150}, center)
+	require.True(t, grid.HasFinalCell())
+	require.Equal(t, image.Rect(100, 100, 200, 200), grid.EffectiveBounds())
+
+	// The move must step by the final cell, not by the much larger bounds.
+	center, moved := grid.MoveDirection(domain.DirectionRight, 1)
+
+	assert.True(t, moved)
+	assert.Equal(t, image.Point{X: 250, Y: 150}, center)
+	assert.Equal(t, image.Rect(200, 100, 300, 200), grid.EffectiveBounds())
+	assert.Equal(t, 1, grid.CurrentDepth())
+}
+
+func TestRecursiveGrid_MoveDirection_FinalCellCrossesIntoNeighbouringParent(t *testing.T) {
+	grid := recursivegrid.NewRecursiveGridWithLayers(
+		image.Rect(0, 0, 900, 900),
+		200, 200, 10, 3, 3,
+		nil,
+	)
+
+	_, complete := grid.SelectCell(0)
+	require.False(t, complete)
+
+	// Cell 5 is the middle-right of the depth-1 grid: (200,100)-(300,200),
+	// flush against the right edge of its parent.
+	_, complete = grid.SelectCell(5)
+	require.True(t, complete)
+
+	center, moved := grid.MoveDirection(domain.DirectionRight, 1)
+
+	assert.True(t, moved)
+	assert.Equal(t, image.Rect(300, 0, 600, 300), grid.CurrentBounds(),
+		"the parent should have moved with the final cell")
+	assert.Equal(t, image.Rect(300, 100, 400, 200), grid.EffectiveBounds())
+	assert.Equal(t, image.Point{X: 350, Y: 150}, center)
+}
+
+func TestRecursiveGrid_MoveDirection_RefusesWhenTargetDepthIsUnreachable(t *testing.T) {
+	// A 106px row split into three gives cells of 36, 35 and 35 pixels. With a
+	// minimum of 12, only the 36px parent can divide again (36/3 == 12), so a
+	// depth-2 selection cannot exist under the 35px neighbors.
+	grid := recursivegrid.NewRecursiveGridWithLayers(
+		image.Rect(0, 0, 106, 100),
+		12, 1, 10, 3, 1,
+		nil,
+	)
+
+	descend(t, grid, 0, 2)
+	require.Equal(t, image.Rect(24, 0, 36, 100), grid.CurrentBounds())
+
+	beforeBounds := grid.CurrentBounds()
+	beforeDepth := grid.CurrentDepth()
+
+	_, moved := grid.MoveDirection(domain.DirectionRight, 1)
+
+	assert.False(t, moved, "the move should be refused rather than land at a shallower depth")
+	assert.Equal(t, beforeBounds, grid.CurrentBounds(), "state must be rolled back intact")
+	assert.Equal(t, beforeDepth, grid.CurrentDepth())
+
+	// History survived the rolled-back re-walk.
+	require.True(t, grid.Backtrack())
+	assert.Equal(t, image.Rect(0, 0, 36, 100), grid.CurrentBounds())
+}
+
+func TestManager_MoveDirection_NotifiesOnlyWhenSomethingMoved(t *testing.T) {
+	updates := 0
+	manager := recursivegrid.NewManagerWithLayers(
+		image.Rect(0, 0, 900, 900),
+		"rtyfghvbn",
+		1, 1, 10, 3, 3,
+		nil, nil,
+		func(image.Point) { updates++ },
+		func(image.Point) {},
+		zap.NewNop(),
+	)
+
+	// Drill to the top-left 100x100 cell; each selection fires its own update.
+	manager.HandleInput("r")
+	manager.HandleInput("r")
+
+	updatesAfterSetup := updates
+
+	center, moved := manager.MoveDirection(domain.DirectionRight, 1)
+
+	require.True(t, moved)
+	assert.Equal(t, image.Point{X: 150, Y: 50}, center)
+	assert.Equal(t, updatesAfterSetup+1, updates, "a move should refresh the overlay")
+
+	// Against the left edge nothing moves, so nothing should be redrawn.
+	_, moved = manager.MoveDirection(domain.DirectionUp, 1)
+
+	assert.False(t, moved)
+	assert.Equal(t, updatesAfterSetup+1, updates, "a refused move should not redraw")
+}
+
+func TestRecursiveGrid_Backtrack_ClearsFinalCell(t *testing.T) {
+	grid := recursivegrid.NewRecursiveGridWithLayers(
+		image.Rect(0, 0, 900, 900),
+		200, 200, 10, 3, 3,
+		nil,
+	)
+
+	_, complete := grid.SelectCell(0)
+	require.False(t, complete)
+
+	_, complete = grid.SelectCell(4)
+	require.True(t, complete)
+	require.True(t, grid.HasFinalCell())
+
+	require.True(t, grid.Backtrack())
+
+	assert.False(t, grid.HasFinalCell(), "backtracking past a final cell should drop it")
+	assert.Equal(t, image.Rect(0, 0, 900, 900), grid.EffectiveBounds())
+}
+
+func TestRecursiveGrid_Reset_ClearsFinalCell(t *testing.T) {
+	grid := recursivegrid.NewRecursiveGridWithLayers(
+		image.Rect(0, 0, 900, 900),
+		200, 200, 10, 3, 3,
+		nil,
+	)
+
+	_, complete := grid.SelectCell(0)
+	require.False(t, complete)
+
+	_, complete = grid.SelectCell(4)
+	require.True(t, complete)
+
+	grid.Reset()
+
+	assert.False(t, grid.HasFinalCell())
+	assert.Equal(t, image.Rect(0, 0, 900, 900), grid.EffectiveBounds())
+	assert.Equal(t, 0, grid.CurrentDepth())
+}
+
+func TestRecursiveGrid_MoveDirection_SinglePixelCells(t *testing.T) {
+	// A 9px row split 3x3 twice bottoms out at one-pixel cells. rectCenter
+	// rounds up, so the center of a 1px cell sits outside it: probing from
+	// there used to skip a cell and drift diagonally.
+	grid := recursivegrid.NewRecursiveGridWithLayers(
+		image.Rect(0, 0, 9, 9),
+		1, 1, 10, 3, 3,
+		nil,
+	)
+
+	descend(t, grid, 0, 0)
+	require.Equal(t, image.Rect(0, 0, 1, 1), grid.CurrentBounds())
+
+	want := []image.Rectangle{
+		image.Rect(1, 0, 2, 1),
+		image.Rect(2, 0, 3, 1),
+		// Crossing into the neighboring parent at x=3.
+		image.Rect(3, 0, 4, 1),
+		image.Rect(4, 0, 5, 1),
+	}
+
+	for step, wantBounds := range want {
+		_, moved := grid.MoveDirection(domain.DirectionRight, 1)
+
+		require.Truef(t, moved, "step %d should have moved", step)
+		assert.Equalf(t, wantBounds, grid.CurrentBounds(),
+			"step %d moved by exactly one cell with no vertical drift", step)
+		assert.Equal(t, 2, grid.CurrentDepth())
+	}
+}
+
+func TestRecursiveGrid_MoveDirection_AfterScreenChange(t *testing.T) {
+	// A monitor switch or resolution change remaps the grid proportionally.
+	// The final cell has to survive that and still move by one cell on the
+	// new geometry.
+	grid := recursivegrid.NewRecursiveGridWithLayers(
+		image.Rect(0, 0, 900, 900),
+		200, 200, 10, 3, 3,
+		nil,
+	)
+
+	_, complete := grid.SelectCell(0)
+	require.False(t, complete)
+
+	_, complete = grid.SelectCell(4)
+	require.True(t, complete)
+	require.Equal(t, image.Rect(100, 100, 200, 200), grid.EffectiveBounds())
+
+	grid.RemapToNewBounds(image.Rect(0, 0, 1800, 1800))
+
+	require.True(t, grid.HasFinalCell(), "a screen change should not drop the selection")
+	assert.Equal(t, image.Rect(200, 200, 400, 400), grid.EffectiveBounds(),
+		"the final cell should scale with the new bounds")
+
+	_, moved := grid.MoveDirection(domain.DirectionRight, 1)
+
+	assert.True(t, moved)
+	assert.Equal(t, image.Rect(400, 200, 600, 400), grid.EffectiveBounds(),
+		"movement should step by the remapped cell size")
+}

--- a/internal/core/domain/recursivegrid/recursive_grid.go
+++ b/internal/core/domain/recursivegrid/recursive_grid.go
@@ -54,6 +54,13 @@ type RecursiveGrid struct {
 	gridRows      int                 // Default number of grid rows
 	depthLayouts  map[int]DepthLayout // Per-depth layout overrides (sparse)
 	history       []image.Rectangle   // Stack of previous bounds for backtracking
+	// finalCell is the cell picked once the grid could no longer be divided.
+	// SelectCell leaves currentBounds untouched on that path so backtracking
+	// still restores the correct ancestor, which means the user's actual
+	// position lives here rather than in currentBounds.
+	finalCell Cell
+	// hasFinalCell reports whether finalCell holds a live selection.
+	hasFinalCell bool
 }
 
 // NewRecursiveGrid creates a new recursive-grid starting with the given screen bounds
@@ -167,6 +174,14 @@ func (qg *RecursiveGrid) Divide() []image.Rectangle {
 	return ComputeGridCells(qg.currentBounds, layout.GridCols, layout.GridRows)
 }
 
+// rectCenter returns the center point of rect, rounded to nearest pixel.
+func rectCenter(rect image.Rectangle) image.Point {
+	return image.Point{
+		X: rect.Min.X + divRound(rect.Dx(), CenterDivisor),
+		Y: rect.Min.Y + divRound(rect.Dy(), CenterDivisor),
+	}
+}
+
 // CellCenter returns the center point of the specified cell, rounded to nearest pixel.
 func (qg *RecursiveGrid) CellCenter(cell Cell) image.Point {
 	cells := qg.Divide()
@@ -176,12 +191,7 @@ func (qg *RecursiveGrid) CellCenter(cell Cell) image.Point {
 		return qg.CurrentCenter()
 	}
 
-	selected := cells[idx]
-
-	return image.Point{
-		X: selected.Min.X + divRound(selected.Dx(), CenterDivisor),
-		Y: selected.Min.Y + divRound(selected.Dy(), CenterDivisor),
-	}
+	return rectCenter(cells[idx])
 }
 
 // SelectCell narrows the active area to the selected cell.
@@ -200,12 +210,15 @@ func (qg *RecursiveGrid) SelectCell(cell Cell) (image.Point, bool) {
 	selected := cells[idx]
 
 	// Compute center from the cell bounds before any state mutation.
-	center := image.Point{
-		X: selected.Min.X + divRound(selected.Dx(), CenterDivisor),
-		Y: selected.Min.Y + divRound(selected.Dy(), CenterDivisor),
-	}
+	center := rectCenter(selected)
 
 	if !qg.CanDivide() {
+		// The grid has bottomed out, so this cell is the final selection.
+		// Record it: currentBounds stays on the parent, so it is the only
+		// place the user's actual position is kept.
+		qg.finalCell = cell
+		qg.hasFinalCell = true
+
 		return center, true
 	}
 
@@ -235,10 +248,28 @@ func (qg *RecursiveGrid) CanDivide() bool {
 
 // CurrentCenter returns the center point of the current bounds, rounded to nearest pixel.
 func (qg *RecursiveGrid) CurrentCenter() image.Point {
-	return image.Point{
-		X: qg.currentBounds.Min.X + divRound(qg.currentBounds.Dx(), CenterDivisor),
-		Y: qg.currentBounds.Min.Y + divRound(qg.currentBounds.Dy(), CenterDivisor),
+	return rectCenter(qg.currentBounds)
+}
+
+// EffectiveBounds returns the rectangle the current selection occupies: the
+// final cell once the grid has bottomed out, otherwise the current bounds.
+// This is what same-layer movement steps by.
+func (qg *RecursiveGrid) EffectiveBounds() image.Rectangle {
+	if qg.hasFinalCell {
+		return qg.CellBounds(qg.finalCell)
 	}
+
+	return qg.currentBounds
+}
+
+// SelectionCenter returns the center of EffectiveBounds.
+func (qg *RecursiveGrid) SelectionCenter() image.Point {
+	return rectCenter(qg.EffectiveBounds())
+}
+
+// HasFinalCell reports whether a final (non-divisible) cell has been selected.
+func (qg *RecursiveGrid) HasFinalCell() bool {
+	return qg.hasFinalCell
 }
 
 // CurrentBounds returns the current active bounds.
@@ -283,6 +314,7 @@ func (qg *RecursiveGrid) Backtrack() bool {
 	qg.currentBounds = qg.history[lastIndex]
 	qg.history = qg.history[:lastIndex]
 	qg.depth--
+	qg.clearFinalCell()
 
 	return true
 }
@@ -297,6 +329,7 @@ func (qg *RecursiveGrid) Reset() {
 	qg.currentBounds = qg.initialBounds
 	qg.depth = 0
 	qg.history = qg.history[:0]
+	qg.clearFinalCell()
 }
 
 // RemapToNewBounds proportionally remaps all bounds (history + currentBounds)
@@ -408,4 +441,10 @@ func (qg *RecursiveGrid) ZoomToPoint(point image.Point, targetDepth int) (image.
 	}
 
 	return qg.CurrentCenter(), false
+}
+
+// clearFinalCell drops any recorded final-cell selection.
+func (qg *RecursiveGrid) clearFinalCell() {
+	qg.finalCell = 0
+	qg.hasFinalCell = false
 }

--- a/internal/core/domain/recursivegrid/recursive_grid.go
+++ b/internal/core/domain/recursivegrid/recursive_grid.go
@@ -174,11 +174,32 @@ func (qg *RecursiveGrid) Divide() []image.Rectangle {
 	return ComputeGridCells(qg.currentBounds, layout.GridCols, layout.GridRows)
 }
 
-// rectCenter returns the center point of rect, rounded to nearest pixel.
+// rectCenter returns the center point of rect, rounded to nearest pixel and
+// guaranteed to lie inside rect.
+//
+// The clamp matters only for a rectangle one pixel wide or tall: rounding to
+// nearest puts its "center" on the exclusive Max edge, which belongs to the
+// neighboring cell. Cursor targets derived from such a cell would then address
+// the cell next door, and recursive subdivision reaches one-pixel cells with
+// the default minimum cell size of 1.
 func rectCenter(rect image.Rectangle) image.Point {
-	return image.Point{
+	center := image.Point{
 		X: rect.Min.X + divRound(rect.Dx(), CenterDivisor),
 		Y: rect.Min.Y + divRound(rect.Dy(), CenterDivisor),
+	}
+
+	if rect.Empty() {
+		return center
+	}
+
+	return clampToRect(center, rect)
+}
+
+// clampToRect pulls point inside rect. rect must not be empty.
+func clampToRect(point image.Point, rect image.Rectangle) image.Point {
+	return image.Point{
+		X: min(max(point.X, rect.Min.X), rect.Max.X-1),
+		Y: min(max(point.Y, rect.Min.Y), rect.Max.Y-1),
 	}
 }
 


### PR DESCRIPTION
## Description

This PR adds a way to move the current selection to a neighbouring cell in grid and recursive-grid mode without changing the layer you are on. Previously the only way to correct a selection that landed one cell off was to backspace out of it and pick it again, which is the case where you most want a quick nudge.

Movement is spatial rather than confined to the region you drilled into: in recursive-grid mode the highlighted region moves at the current depth and crosses into a neighbouring parent region when it reaches the edge of its own, with the backtrack history rebuilt so backspace still walks back correctly. Once the grid can no longer subdivide, the final cell moves instead. In grid mode an open subgrid moves to the neighbouring cell. Movement stops at the screen edge rather than wrapping, and modes that have no cell selection ignore it.

The action ships unbound — nothing changes until you bind it — and hints and scroll mode are deliberately left alone.

https://github.com/user-attachments/assets/d0d61b54-2112-49ab-b15a-eb699698196e

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no OS-specific files added
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, pure domain logic with no platform capability
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command and configuration changes

One new action. No new configuration options, and no defaults change.

| Command | Flag | Type | Default | Description |
| --- | --- | --- | --- | --- |
| `neru action move_cell` | `--direction` | string | — | Required. One of `left`, `right`, `up`, `down`. |
| `neru action move_cell` | `--count` | int | `1` | Number of cells to move. Must be at least 1. |

It is usable anywhere an action name is: directly, or as a hotkey binding. There is no default binding, because every letter is already a cell key — arrow keys are the natural choice:

```toml
[recursive_grid.hotkeys]
"Left"  = "action move_cell --direction=left"
"Right" = "action move_cell --direction=right"
"Up"    = "action move_cell --direction=up"
"Down"  = "action move_cell --direction=down"
```

It is also held-key repeatable, so with `[held_repeat]` enabled (off by default) a bound key slides the selection continuously while held.

`move_cell` is not valid as a mode `--action` value and cannot appear in a comma-separated action chain, in line with the other mode-control actions.

## Potentially breaking

Action flags are now validated against a per-action table, so flags that were previously accepted and then ignored are rejected with `ERR_INVALID_INPUT`. This only affects invocations that were already doing nothing, but a script or hotkey passing a stray flag will now fail instead of running:

| Invocation | Before | After |
| --- | --- | --- |
| `neru action move_mouse --dx 10 --dy 10` | Moved the cursor to `(0, 0)` | Rejected — use `move_mouse_relative` |
| `neru action backspace --steps 3` | Ran, `--steps` ignored | Rejected |
| `neru action reset --toggle` | Ran, `--toggle` ignored | Rejected |
| `neru action page_up --steps 3` | Ran, `--steps` ignored | Rejected |

The fix in each case is to drop the flag, or to use the action it belongs to. Every flag that was documented for an action still works exactly as before — the table matches the synopses in `docs/CLI.md` action for action.

Whether this counts as breaking is a judgement call worth a second opinion: no invocation that did something useful changes behaviour, but the exit code for these malformed invocations changes from success to failure, which something could be checking.

## Additional Context

**Why re-walk from the root.** Recursive-grid movement steps the selection by its own width or height and then resolves the target from the root of the grid, rather than patching bounds in place. That resolves the containing cell at every depth using that depth's own layout, so per-depth `[[recursive_grid.layers]]` overrides and remainder-sized cells come out right and the rebuilt ancestor chain matches the new position. The cost is a handful of integer divides per move (~690ns, 7 allocations, measured on a 4K-sized grid), which is nothing at keypress rate. Movement is refused rather than applied when the re-walk cannot reach the original depth, which can happen when a neighbouring parent is a pixel narrower and bottoms out one level early.

**A rounding trap worth knowing about.** Cell centres round up, which puts the "centre" of a one-pixel cell outside it. Probing from there resolved to the wrong cell: moving right from a 1px cell skipped a cell *and* drifted down a row. This is reachable with the default `min_size_width`/`min_size_height` of 1 at deep levels. The probe point is now clamped inside the target region, and there is a regression test pinning single-pixel movement.

**Why the flag validation was reworked.** `move_cell` needed two new flags, and adding them meant editing seven separate hand-maintained reject lists, each a different subset of the flags. Those lists had already drifted — that is why `backspace` accepted `--steps`. Each action now declares its flags in one table, checked once before dispatch, and the parser is table-driven too so that recording a flag cannot be forgotten. The failure mode of omitting an entry is now a rejection rather than a silently ignored flag. That layer is net smaller despite gaining an action, and the guard tests assert every parsed flag is declared by some action, every declared flag is parsed, and every dispatchable action has an entry.
