### PR TITLE
feat(action): add `run` for ordered action sequences

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -21,6 +21,7 @@ The same content is available as manpages (`man neru`) after installation.
 - [Daemon lifecycle](#daemon-lifecycle) — `launch` · `start` · `stop` · `idle` · `status` · `doctor`
 - [Navigation modes](#navigation-modes) — `hints` · `grid` · `recursive_grid` · `scroll` · `monitor_select`
 - [Actions](#actions) — `action` and its subcommands
+- [Sequences](#sequences) — `run`
 - [Configuration commands](#configuration-commands) — `config`
 - [Runtime toggles](#runtime-toggles)
 - [Utilities](#utilities) — `roles` · `services` · `docs`
@@ -88,6 +89,7 @@ Accepted by every command.
 | [`scroll`](#neru-scroll)                                     | Vim-style scrolling             | Yes | All |
 | [`monitor_select`](#neru-monitor_select)                     | Jump the cursor to a display    | Yes | macOS · Linux |
 | [`action`](#actions)                                         | One-shot mouse/scroll/key input | Yes | All ² |
+| [`run`](#neru-run)                                           | Run several actions in order    | Yes | All |
 | [`config`](#configuration-commands)                          | Inspect and change config       | Mixed | All |
 | [`toggle-scroll-invert`](#neru-toggle-scroll-invert)         | Invert scroll direction         | Yes | All |
 | [`toggle-cursor-follow-selection`](#neru-toggle-cursor-follow-selection) | Toggle cursor follow | Yes | All |
@@ -211,7 +213,7 @@ listed under each command.
 | `--toggle`                 | `-t`      | bool   | `false`  | Exit to idle if this mode is already active, otherwise enter it.                                                    |
 | `--repeat`                 | `-r`      | bool   | `false`  | Re-enter the mode after the action instead of exiting. Requires `--action`.                                         |
 | `--modifier`               |           | string |          | Comma-separated modifiers held during the action: `cmd`, `super`, `meta`, `shift`, `alt`, `option`, `ctrl`. Requires `--action`. |
-| `--on-exit`                |           | string |          | Command run after the action completes and the mode exits. Uses hotkey-binding syntax (`'action left_click'`, `'exec notify-send done'`). Requires `--action`. Not run when the mode is left manually via escape or `neru idle`. |
+| `--on-exit`                |           | string |          | Step run after the action completes and the mode exits. Uses hotkey-binding syntax (`'action left_click'`, `'exec notify-send done'`). Repeat the flag to run several steps in order, as one [action sequence](#neru-run). Requires `--action`. Not run when the mode is left manually via escape or `neru idle`. |
 | `--cursor-selection-mode`  |           | string | `follow` | `follow` moves the real cursor to the selection; `hold` leaves it in place.                                          |
 
 ---
@@ -221,7 +223,7 @@ listed under each command.
 Label clickable elements and act on the one you type.
 
 ```
-neru hints [-a <action>] [-t] [-r] [--modifier <mods>] [--on-exit <command>]
+neru hints [-a <action>] [-t] [-r] [--modifier <mods>] [--on-exit <step>]...
            [--cursor-selection-mode follow|hold] [-s] [--hide-on-empty-search]
            [--role <roles>] [--text <text>] [--strategy axtree|vision]
            [--label-direction normal|reverse] [--split-word] [-d]
@@ -268,7 +270,7 @@ neru hints --debug
 Divide the screen into a labelled coordinate grid.
 
 ```
-neru grid [-a <action>] [-t] [-r] [--modifier <mods>] [--on-exit <command>]
+neru grid [-a <action>] [-t] [-r] [--modifier <mods>] [--on-exit <step>]...
           [--cursor-selection-mode follow|hold]
 ```
 
@@ -300,7 +302,7 @@ Narrow the screen recursively, one keypress per level.
 
 ```
 neru recursive_grid [-a <action>] [-t] [-r] [--modifier <mods>]
-                    [--on-exit <command>] [--cursor-selection-mode follow|hold]
+                    [--on-exit <step>]... [--cursor-selection-mode follow|hold]
                     [--zoom-to-depth <depth>]
 ```
 
@@ -862,6 +864,66 @@ To pause inside a shell script, use the shell's own `sleep`.
 
 ---
 
+# Sequences
+
+## neru run
+
+Run several actions in order, in a single call.
+
+```
+neru run <step> [step...]
+```
+
+Each argument is one step, written exactly as it would be written in a hotkey
+binding: an action (`action left_click`), a mode (`hints --action left_click`),
+or a shell command (`exec open -a Safari`). The daemon executes the steps in
+order.
+
+This is the same executor that runs a multi-action hotkey binding, so a
+sequence behaves identically whether it is written in `[hotkeys]`, passed to
+`--on-exit`, or run here. Reach for it from an external driver (skhd,
+Hammerspoon, a shell script) that would otherwise spawn one `neru` process per
+step and lose the sequencing rules between them.
+
+**Sequencing rules**
+
+- Steps run in order; blank steps are rejected.
+- A step that asks the sequence to stop ends it. Today that is
+  `action wait_for_mode_exit --bail` after a mode was cancelled — the command
+  then exits with `ERR_CHAIN_BAIL`.
+- Any other failing step is reported, and the remaining steps still run. The
+  command exits with `ERR_ACTION_FAILED` naming the first failure.
+- A sequence may start another sequence, up to five levels deep. Deeper
+  nesting is refused rather than recursing.
+
+**Timeouts**
+
+The sequence runs while the caller waits, so a sequence containing sleeps or
+`wait_for_mode_exit` can outlast the default 10-second IPC timeout. Raise it
+with the global `--timeout` flag; the daemon holds the reply until the sequence
+finishes, however long that takes.
+
+A sequence that is not worth waiting on at all — one that ends with an
+interactive mode, say — is better bound to a hotkey, which is dispatched in the
+background with no caller attached.
+
+**Examples**
+
+```bash
+# Save the cursor, pick a target, click it, then put the cursor back
+neru run "action save_cursor_pos" "hints --action left_click" \
+         "action wait_for_mode_exit" "action restore_cursor_pos"
+
+# Click, wait for the app to settle, then re-scan for hints
+neru --timeout 30 run "action left_click" "action sleep 0.8" hints
+
+# Stop early when the user escapes out of hints instead of selecting
+neru run "hints --action left_click" "action wait_for_mode_exit --bail" \
+         "exec notify-send clicked"
+```
+
+---
+
 # Configuration commands
 
 Full option reference: [CONFIGURATION.md](CONFIGURATION.md).
@@ -1189,6 +1251,17 @@ ctrl - f : neru hints
 ctrl - g : neru grid
 ctrl - r : neru hints --action right_click
 ctrl - t : neru hints --action left_click --repeat
+```
+
+**Run several steps as one unit**
+
+Chaining `neru` invocations with `&&` spawns a process and opens a connection
+per step. [`neru run`](#neru-run) sends the whole sequence once and the daemon
+executes it in order, under the same rules a hotkey binding gets:
+
+```bash
+neru run "action save_cursor_pos" "hints --action left_click" \
+         "action wait_for_mode_exit --bail" "action restore_cursor_pos"
 ```
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -547,7 +547,9 @@ Use `--mode` to route keys through Neru's active mode/action pipeline instead of
 "Ctrl+Z" = ["monitor_select", "action wait_for_mode_exit --bail", "recursive_grid"]
 ```
 
-Use `--bail` to abort the chain when the mode exits without a selection (e.g., user presses Escape). Without `--bail`, `wait_for_mode_exit` always succeeds and the chain continues.
+Use `--bail` to abort the chain when the mode exits without a selection (e.g., user presses Escape). Without `--bail`, `wait_for_mode_exit` always succeeds and the chain continues. A step that fails for any other reason is logged and the chain continues.
+
+An array like the ones above is an *action sequence*. The same sequence, with the same rules, can also be written as a mode's `--on-exit` (repeat the flag once per step) or run from a script with [`neru run`](CLI.md#neru-run) — one executor backs all three, so a sequence that works in one place works in the others.
 
 ---
 

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -31,6 +31,7 @@ command flags see [CLI.md](CLI.md).
 - [Edit Config File Directly](#edit-config-file-directly)
 - [Triggering Neru Actions from External Tools](#triggering-neru-actions-from-external-tools)
 - [Combining Hints with Other Actions](#combining-hints-with-other-actions)
+- [Run a Whole Workflow From One Command](#run-a-whole-workflow-from-one-command)
 - [Further Reading](#further-reading)
 
 ---
@@ -109,6 +110,18 @@ The old `restore_cursor_position` config field was removed. Compose the same beh
 ```
 
 This saves the cursor position, clicks, exits hints, waits for the mode to fully exit, then moves the cursor back.
+
+If the click comes from the mode's own `--action` rather than a key inside hints, put the tail in `--on-exit` instead. The flag is repeatable, so the whole sequence lives on the one binding that starts the mode:
+
+```toml
+[hotkeys]
+"Primary+Shift+Space" = [
+    "action save_cursor_pos",
+    "hints --action left_click --on-exit 'action restore_cursor_pos'",
+]
+```
+
+`--on-exit` steps run only after the action is fulfilled, so escaping out of hints leaves the cursor where you moved it rather than snapping it back.
 
 ## Custom Mouse Movement Step Size
 
@@ -437,6 +450,8 @@ neru hints
 
 This is handy when a Neru hotkey conflicts with an app's own shortcut and you'd rather let an external tool handle the trigger.
 
+For a whole workflow rather than a single action, see [Run a Whole Workflow From One Command](#run-a-whole-workflow-from-one-command).
+
 ## Combining Hints with Other Actions
 
 The `--action` flag on hints mode is not limited to `left_click`. You can pass other actions to change what happens when a hint label is completed:
@@ -448,6 +463,26 @@ The `--action` flag on hints mode is not limited to `left_click`. You can pass o
 ```
 
 Useful for apps where you frequently need a right-click menu (e.g. Finder, VS Code file tree) without moving your hands to the mouse.
+
+## Run a Whole Workflow From One Command
+
+A multi-action hotkey binding is an *action sequence*. `neru run` takes the same sequence from outside Neru, so a script or an external hotkey daemon can drive a workflow without spawning one `neru` process per step. Each argument is one step, written exactly as it would be written in a binding:
+
+```bash
+# Save the cursor, pick a target, click it, then put the cursor back
+neru run "action save_cursor_pos" "hints --action left_click" \
+         "action wait_for_mode_exit --bail" "action restore_cursor_pos"
+```
+
+`--bail` stops the sequence when you escape out of hints instead of selecting, so the trailing steps do not run and the command exits non-zero. Any other failing step is reported while the rest still run.
+
+Sequences that block — sleeps, `wait_for_mode_exit` — can outlast the default 10-second IPC timeout, so raise it for those:
+
+```bash
+neru --timeout 60 run "action left_click" "action sleep 0.8" hints
+```
+
+There is no upper bound beyond the one you pass: the daemon holds the reply until the sequence finishes. A sequence you do not want to wait on at all belongs in a hotkey binding instead, since bindings are dispatched in the background with no caller attached.
 
 ---
 

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -338,8 +338,8 @@ func initializeModeHandler(app *App) {
 			recursivegrid *components.RecursiveGridComponent
 		}
 		callbacks struct {
-			refreshHotkeys      func()
-			executeHotkeyAction func(key, actionStr string) error
+			refreshHotkeys        func()
+			executeActionSequence func(source string, steps []string)
 		}
 	}{
 		config:         cfg,
@@ -375,11 +375,11 @@ func initializeModeHandler(app *App) {
 			recursivegrid: app.recursiveGridComponent,
 		},
 		callbacks: struct {
-			refreshHotkeys      func()
-			executeHotkeyAction func(key, actionStr string) error
+			refreshHotkeys        func()
+			executeActionSequence func(source string, steps []string)
 		}{
-			refreshHotkeys:      func() { app.refreshHotkeysForAppOrCurrent("") },
-			executeHotkeyAction: app.executeHotkeyAction,
+			refreshHotkeys:        func() { app.refreshHotkeysForAppOrCurrent("") },
+			executeActionSequence: app.runActionSequence,
 		},
 	}
 
@@ -402,7 +402,7 @@ func initializeModeHandler(app *App) {
 		ScrollComponent:        deps.components.scroll,
 		RecursiveGridComponent: deps.components.recursivegrid,
 		RefreshHotkeys:         deps.callbacks.refreshHotkeys,
-		ExecuteHotkeyAction:    deps.callbacks.executeHotkeyAction,
+		ExecuteActionSequence:  deps.callbacks.executeActionSequence,
 		Shutdown:               app.Quit,
 		TextInput:              app.textInput,
 		System:                 app.systemPort,
@@ -427,9 +427,10 @@ func initializeIPCController(app *App) {
 		System:        app.systemPort,
 		// EventTap and IPCServer stay zero here; phase 8 fills them in
 		// through SetInfrastructure.
-		KeyFeed:      app.keyFeed,
-		ReloadConfig: app.ReloadConfig,
-		Logger:       app.logger,
+		KeyFeed:         app.keyFeed,
+		ReloadConfig:    app.ReloadConfig,
+		ExecuteSequence: app.executeActionSequence,
+		Logger:          app.logger,
 	})
 
 	// Set the config-set callback so runtime field changes propagate to

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -25,13 +25,8 @@ func actionsReferenceDisabledMode(actions []string, cfg *config.Config) bool {
 	gridStr := domain.ModeString(domain.ModeGrid)
 
 	recursiveGridStr := domain.ModeString(domain.ModeRecursiveGrid)
-	for _, actionStr := range actions {
-		trimmed := strings.TrimSpace(actionStr)
-		if trimmed == "" {
-			continue
-		}
-
-		mode := strings.Fields(trimmed)[0]
+	for _, actionStr := range flattenRunSteps(actions) {
+		mode := commandOf(actionStr)
 		switch {
 		case mode == hintsStr && !cfg.Hints.Enabled:
 			return true
@@ -219,29 +214,8 @@ func (a *App) dispatchHotkeyActionsAsync(key string, actions []string) {
 			}
 		}()
 
-		a.dispatchHotkeyActions(key, actions)
+		a.runActionSequence(key, actions)
 	}()
-}
-
-func (a *App) dispatchHotkeyActions(key string, actions []string) {
-	for _, actionStr := range actions {
-		trimmedAction := strings.TrimSpace(actionStr)
-		if trimmedAction == "" {
-			continue
-		}
-
-		executeHotkeyActionErr := a.executeHotkeyAction(key, trimmedAction)
-		if executeHotkeyActionErr != nil {
-			if derrors.IsCode(executeHotkeyActionErr, derrors.CodeChainBail) {
-				return
-			}
-
-			a.logger.Error("hotkey action failed",
-				zap.String("key", key),
-				zap.String("action", trimmedAction),
-				zap.Error(executeHotkeyActionErr))
-		}
-	}
 }
 
 func (a *App) startHotkeyRepeat(key string, actions []string) {
@@ -281,7 +255,7 @@ func (a *App) startHotkeyRepeat(key string, actions []string) {
 			}
 		}()
 
-		a.dispatchHotkeyActions(key, actions)
+		a.runActionSequence(key, actions)
 
 		initialTimer := time.NewTimer(time.Duration(cfg.InitialDelay) * time.Millisecond)
 		defer initialTimer.Stop()
@@ -300,7 +274,7 @@ func (a *App) startHotkeyRepeat(key string, actions []string) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				a.dispatchHotkeyActions(key, actions)
+				a.runActionSequence(key, actions)
 			}
 		}
 	}()
@@ -370,16 +344,10 @@ func hotkeyModifiersFromKey(key string) action.Modifiers {
 // actionsContainModeSwitch reports whether any action in the list is a
 // mode-switch action (hints, grid, recursive_grid, scroll, monitor_select).
 func actionsContainModeSwitch(actions []string) bool {
-	for _, actionStr := range actions {
-		trimmed := strings.TrimSpace(actionStr)
-		if trimmed == "" {
-			continue
-		}
-
+	for _, actionStr := range flattenRunSteps(actions) {
 		// The action format is "<mode_name>" with optional args, so split
 		// to get just the mode name for comparison.
-		mode := strings.Fields(trimmed)[0]
-		switch mode {
+		switch commandOf(actionStr) {
 		case domain.ModeString(domain.ModeHints),
 			domain.ModeString(domain.ModeGrid),
 			domain.ModeString(domain.ModeRecursiveGrid),
@@ -390,6 +358,58 @@ func actionsContainModeSwitch(actions []string) bool {
 	}
 
 	return false
+}
+
+// commandOf returns the command word of an action string, ignoring its flags.
+// It returns "" for a blank action.
+func commandOf(actionStr string) string {
+	fields := strings.Fields(strings.TrimSpace(actionStr))
+	if len(fields) == 0 {
+		return ""
+	}
+
+	return fields[0]
+}
+
+// flattenRunSteps expands "run <step>..." so that callers which inspect what a
+// binding does — mode-switch detection, disabled-mode skipping — see the steps
+// a run carries rather than the word "run". Blank actions are dropped.
+//
+// Expansion follows nesting as deep as the executor will, so a mode named below
+// the first run is not invisible to those checks.
+func flattenRunSteps(actions []string) []string {
+	return flattenRunStepsAtDepth(actions, 0)
+}
+
+// flattenRunStepsAtDepth expands the steps of one sequence, recursing into a
+// nested run until maxSequenceDepth. Past that depth the executor refuses to
+// start the sequence, so its steps never run and are left unexpanded — the
+// unexpanded "run ..." names no mode, which is exactly what the callers should
+// conclude about it.
+func flattenRunStepsAtDepth(actions []string, depth int) []string {
+	flattened := make([]string, 0, len(actions))
+
+	for _, actionStr := range actions {
+		trimmed := strings.TrimSpace(actionStr)
+		if trimmed == "" {
+			continue
+		}
+
+		if depth >= maxSequenceDepth || commandOf(trimmed) != domain.CommandRun {
+			flattened = append(flattened, trimmed)
+
+			continue
+		}
+
+		// splitArgs applies the same quoting rules the executor uses, so the
+		// steps seen here are the steps that will run.
+		flattened = append(
+			flattened,
+			flattenRunStepsAtDepth(splitArgs(trimmed)[1:], depth+1)...,
+		)
+	}
+
+	return flattened
 }
 
 func splitArgs(input string) []string {
@@ -433,12 +453,15 @@ func splitArgs(input string) []string {
 	return args
 }
 
-// executeHotkeyAction executes a hotkey action, which can be either a shell command or an IPC command.
-func (a *App) executeHotkeyAction(key, actionStr string) error {
+// executeHotkeyAction executes a single action step, which can be either a
+// shell command or an IPC command. ctx carries the action sequence's nesting
+// depth into the IPC handlers, so a step that starts another sequence can be
+// stopped before it recurses without bound.
+func (a *App) executeHotkeyAction(ctx context.Context, key, actionStr string) error {
 	actionStr = strings.TrimSpace(actionStr)
 
 	if actionStr == action.PrefixExec || strings.HasPrefix(actionStr, action.PrefixExec+" ") {
-		return a.executeShellCommand(key, actionStr)
+		return a.executeShellCommand(ctx, key, actionStr)
 	}
 
 	actionParts := splitArgs(actionStr)
@@ -458,7 +481,7 @@ func (a *App) executeHotkeyAction(key, actionStr string) error {
 	}
 
 	ipcResponse := a.ipcController.HandleCommand(
-		a.ctx,
+		ctx,
 		ipc.Command{Action: actionStr, Args: params},
 	)
 	if !ipcResponse.Success {
@@ -479,7 +502,7 @@ func (a *App) executeHotkeyAction(key, actionStr string) error {
 }
 
 // executeShellCommand executes a shell command triggered by a hotkey.
-func (a *App) executeShellCommand(key, actionStr string) error {
+func (a *App) executeShellCommand(ctx context.Context, key, actionStr string) error {
 	cmdString := strings.TrimSpace(strings.TrimPrefix(actionStr, action.PrefixExec))
 	if cmdString == "" {
 		a.logger.Error("hotkey exec has empty command", zap.String("key", key))
@@ -493,7 +516,7 @@ func (a *App) executeShellCommand(key, actionStr string) error {
 		zap.String("cmd", cmdString),
 	)
 
-	ctx, cancel := context.WithTimeout(a.ctx, domain.ShellCommandTimeout)
+	execCtx, cancel := context.WithTimeout(ctx, domain.ShellCommandTimeout)
 	defer cancel()
 
 	cfg := a.configSnapshot()
@@ -504,7 +527,7 @@ func (a *App) executeShellCommand(key, actionStr string) error {
 	args = append(args, shellArgs...)
 	args = append(args, cmdString)
 
-	command := exec.CommandContext(ctx, shell, args...) //nolint:gosec
+	command := exec.CommandContext(execCtx, shell, args...) //nolint:gosec
 
 	commandOutput, commandErr := command.CombinedOutput()
 	if commandErr != nil {

--- a/internal/app/hotkeys_test.go
+++ b/internal/app/hotkeys_test.go
@@ -2,9 +2,11 @@
 package app
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 )
 
@@ -245,5 +247,106 @@ func TestHotkeyActionsRepeatWhileHeldDisabled(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+// A binding may name a mode directly or carry it inside a "run" sequence.
+// Both spellings have to be visible to the callers that inspect a binding
+// before dispatching it, or a mode switch written as a sequence would skip
+// modifier suppression and the disabled-mode check.
+func TestBindingInspectionSeesModesInsideRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		actions        []string
+		wantModeSwitch bool
+	}{
+		{
+			name:           "direct mode",
+			actions:        []string{hintsStep},
+			wantModeSwitch: true,
+		},
+		{
+			name:           "mode inside run",
+			actions:        []string{"run 'action save_cursor_pos' '" + hintsStep + "'"},
+			wantModeSwitch: true,
+		},
+		{
+			// A run step may itself be a run, and the executor follows it, so a
+			// mode below the first level must still be visible here.
+			name:           "mode inside a nested run",
+			actions:        []string{`run 'run "hints"' 'action left_click'`},
+			wantModeSwitch: true,
+		},
+		{
+			name:           "run without a mode",
+			actions:        []string{"run 'action left_click' 'action sleep 0.2'"},
+			wantModeSwitch: false,
+		},
+		{
+			name:           "nested run without a mode",
+			actions:        []string{`run 'run "action left_click"' 'action sleep 0.2'`},
+			wantModeSwitch: false,
+		},
+		{
+			name:           "no mode at all",
+			actions:        []string{"action left_click", "exec true"},
+			wantModeSwitch: false,
+		},
+		{
+			name:           "blank actions",
+			actions:        []string{"", "   "},
+			wantModeSwitch: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := actionsContainModeSwitch(testCase.actions); got != testCase.wantModeSwitch {
+				t.Fatalf("actionsContainModeSwitch(%v) = %v, want %v",
+					testCase.actions, got, testCase.wantModeSwitch)
+			}
+		})
+	}
+}
+
+func TestActionsReferenceDisabledModeSeesModesInsideRun(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultConfig()
+	cfg.Hints.Enabled = false
+
+	actions := []string{"run 'action save_cursor_pos' '" + hintsStep + "'"}
+	if !actionsReferenceDisabledMode(actions, cfg) {
+		t.Fatal("a disabled mode inside a run step should be detected")
+	}
+
+	cfg.Hints.Enabled = true
+
+	if actionsReferenceDisabledMode(actions, cfg) {
+		t.Fatal("an enabled mode inside a run step should not be reported as disabled")
+	}
+}
+
+// The expansion must stop where the executor does: past the nesting limit a
+// sequence is refused, so its steps never run and must not be reported as
+// things the binding does.
+func TestFlattenRunSteps_StopsAtTheExecutorsNestingLimit(t *testing.T) {
+	t.Parallel()
+
+	mode := domain.ModeString(domain.ModeHints)
+	nested := []string{"run '" + mode + "'"}
+
+	got := flattenRunStepsAtDepth(nested, 0)
+	if !slices.Equal(got, []string{mode}) {
+		t.Fatalf("below the limit: got %v, want the nested step expanded", got)
+	}
+
+	got = flattenRunStepsAtDepth(nested, maxSequenceDepth)
+	if !slices.Equal(got, nested) {
+		t.Fatalf("at the limit: got %v, want the run left unexpanded", got)
 	}
 }

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -107,7 +107,7 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 	}
 
 	if action.Name(actionName) == action.NameSleep {
-		return h.handleSleepAction(cmd.Args[1:])
+		return h.handleSleepAction(ctx, cmd.Args[1:])
 	}
 
 	parsed, parseErr := parseActionArgs(cmd.Args[1:])

--- a/internal/app/ipc_actions_flow.go
+++ b/internal/app/ipc_actions_flow.go
@@ -24,7 +24,10 @@ const modeExitPollInterval = 10 * time.Millisecond
 // mode session.
 const modeExitTimeout = 5 * time.Minute
 
-func (h *IPCControllerActions) handleSleepAction(args []string) ipc.Response {
+func (h *IPCControllerActions) handleSleepAction(
+	ctx context.Context,
+	args []string,
+) ipc.Response {
 	durationStr := ""
 	for idx := 0; idx < len(args); idx++ {
 		arg := strings.TrimSpace(args[idx])
@@ -52,7 +55,22 @@ func (h *IPCControllerActions) handleSleepAction(args []string) ipc.Response {
 	}
 
 	h.logger.Debug("sleep action sleeping", zap.Duration("duration", duration))
-	time.Sleep(duration)
+
+	// Wait on a timer rather than time.Sleep so that a long pause inside an
+	// action sequence is released when the daemon shuts down instead of
+	// holding its goroutine to the end of the duration.
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ipc.Response{
+			Success: false,
+			Message: "sleep canceled: " + ctx.Err().Error(),
+			Code:    ipc.CodeActionFailed,
+		}
+	case <-timer.C:
+	}
 
 	return ipc.Response{
 		Success: true,

--- a/internal/app/ipc_controller.go
+++ b/internal/app/ipc_controller.go
@@ -43,6 +43,10 @@ type IPCController struct {
 	// If nil, the config is only updated in-memory.
 	SetConfigField func(ctx context.Context, key, value string) error
 
+	// ExecuteSequence runs an action sequence. If nil, the "run" command
+	// reports that sequencing is unavailable.
+	ExecuteSequence sequenceRunner
+
 	// Info handler for config updates
 	infoHandler *IPCControllerInfo
 
@@ -83,6 +87,9 @@ type IPCControllerDeps struct {
 	// ReloadConfig performs a full app-level config reload.
 	ReloadConfig func(ctx context.Context, configPath string) error
 
+	// ExecuteSequence runs an action sequence on behalf of the "run" command.
+	ExecuteSequence sequenceRunner
+
 	Logger *zap.Logger
 }
 
@@ -94,20 +101,21 @@ func NewIPCController(deps IPCControllerDeps) *IPCController {
 	}
 
 	ipcController := &IPCController{
-		HintService:   deps.HintService,
-		GridService:   deps.GridService,
-		ActionService: deps.ActionService,
-		ScrollService: deps.ScrollService,
-		ConfigService: deps.ConfigService,
-		AppState:      deps.AppState,
-		Modes:         deps.Modes,
-		System:        deps.System,
-		EventTap:      deps.EventTap,
-		IPCServer:     deps.IPCServer,
-		KeyFeed:       deps.KeyFeed,
-		ReloadConfig:  deps.ReloadConfig,
-		Logger:        logger.Named("ipc.controller"),
-		Handlers:      make(map[string]func(context.Context, ipc.Command) ipc.Response),
+		HintService:     deps.HintService,
+		GridService:     deps.GridService,
+		ActionService:   deps.ActionService,
+		ScrollService:   deps.ScrollService,
+		ConfigService:   deps.ConfigService,
+		AppState:        deps.AppState,
+		Modes:           deps.Modes,
+		System:          deps.System,
+		EventTap:        deps.EventTap,
+		IPCServer:       deps.IPCServer,
+		KeyFeed:         deps.KeyFeed,
+		ReloadConfig:    deps.ReloadConfig,
+		ExecuteSequence: deps.ExecuteSequence,
+		Logger:          logger.Named("ipc.controller"),
+		Handlers:        make(map[string]func(context.Context, ipc.Command) ipc.Response),
 	}
 
 	// Register command handlers
@@ -212,4 +220,8 @@ func (c *IPCController) registerHandlers(cfg *config.Config) {
 	// Register scroll handler
 	scrollHandler := NewIPCControllerScroll(c.AppState, c.ScrollService, c.Logger)
 	scrollHandler.RegisterHandlers(c.Handlers)
+
+	// Register action sequence handler
+	sequenceHandler := NewIPCControllerSequence(c.ExecuteSequence, c.Logger)
+	sequenceHandler.RegisterHandlers(c.Handlers)
 }

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -153,7 +153,7 @@ func (h *IPCControllerModes) modesUnavailableResponse() ipc.Response {
 type ModeActivationOptions struct {
 	Action                *string
 	Modifier              *string
-	OnExit                *string
+	OnExit                []string
 	Repeat                *bool
 	CursorFollowSelection *bool
 	ZoomToDepth           *int
@@ -311,9 +311,10 @@ func (h *IPCControllerModes) extractModeOptions(
 			startIdx++
 			actionArg := cmd.Args[startIdx]
 			opts.Action = &actionArg
+		// --on-exit is repeatable: each occurrence appends one step to the
+		// sequence that runs once the pending action is fulfilled.
 		case strings.HasPrefix(arg, "--on-exit="):
-			onExitArg := strings.TrimPrefix(arg, "--on-exit=")
-			opts.OnExit = &onExitArg
+			opts.OnExit = append(opts.OnExit, strings.TrimPrefix(arg, "--on-exit="))
 		case arg == "--on-exit":
 			if startIdx+1 >= len(cmd.Args) {
 				resp := ipc.Response{
@@ -326,8 +327,7 @@ func (h *IPCControllerModes) extractModeOptions(
 			}
 
 			startIdx++
-			onExitArg := cmd.Args[startIdx]
-			opts.OnExit = &onExitArg
+			opts.OnExit = append(opts.OnExit, cmd.Args[startIdx])
 		case strings.HasPrefix(arg, "--cursor-selection-mode="):
 			val, resp := parseCursorSelectionModeValue(
 				strings.TrimPrefix(arg, "--cursor-selection-mode="),

--- a/internal/app/ipc_handlers_onexit_test.go
+++ b/internal/app/ipc_handlers_onexit_test.go
@@ -1,0 +1,101 @@
+//nolint:testpackage // Tests private mode option parsing.
+package app
+
+import (
+	"slices"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+const (
+	// onExitTestFlag and onExitTestMode keep the repeated literals out of the
+	// table below.
+	onExitTestFlag = "--on-exit"
+	onExitTestMode = "hints"
+	onExitTestStep = "action sleep 0.2"
+)
+
+// --on-exit is repeatable so a mode can finish with a sequence rather than a
+// single command; each occurrence appends one step, in order.
+func TestExtractModeOptions_OnExitAccumulatesSteps(t *testing.T) {
+	t.Parallel()
+
+	handler := NewIPCControllerModes(nil, zap.NewNop())
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "space separated",
+			args: []string{
+				onExitTestMode,
+				onExitTestFlag,
+				onExitTestStep,
+				onExitTestFlag,
+				onExitTestMode,
+			},
+			want: []string{onExitTestStep, onExitTestMode},
+		},
+		{
+			name: "equals form",
+			args: []string{
+				onExitTestMode,
+				onExitTestFlag + "=" + onExitTestStep,
+				onExitTestFlag + "=" + onExitTestMode,
+			},
+			want: []string{onExitTestStep, onExitTestMode},
+		},
+		{
+			name: "mixed forms keep order",
+			args: []string{onExitTestMode, onExitTestFlag + "=first", onExitTestFlag, "second"},
+			want: []string{"first", "second"},
+		},
+		{
+			name: "omitted stays nil",
+			args: []string{onExitTestMode},
+			want: nil,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts, errResp := handler.extractModeOptions(ipc.Command{
+				Action: onExitTestMode,
+				Args:   testCase.args,
+			})
+			if errResp != nil {
+				t.Fatalf("extractModeOptions() error response: %+v", *errResp)
+			}
+
+			if !slices.Equal(opts.OnExit, testCase.want) {
+				t.Fatalf("OnExit = %v, want %v", opts.OnExit, testCase.want)
+			}
+		})
+	}
+}
+
+func TestExtractModeOptions_OnExitRequiresValue(t *testing.T) {
+	t.Parallel()
+
+	handler := NewIPCControllerModes(nil, zap.NewNop())
+
+	_, errResp := handler.extractModeOptions(ipc.Command{
+		Action: onExitTestMode,
+		Args:   []string{onExitTestMode, onExitTestFlag},
+	})
+
+	if errResp == nil {
+		t.Fatal("extractModeOptions() = nil error response, want a failure")
+	}
+
+	if errResp.Code != ipc.CodeInvalidInput {
+		t.Fatalf("code = %q, want %q", errResp.Code, ipc.CodeInvalidInput)
+	}
+}

--- a/internal/app/ipc_handlers_test.go
+++ b/internal/app/ipc_handlers_test.go
@@ -31,15 +31,15 @@ func newTestModesHandler(
 	// Only the fields this test needs; every other dependency is legitimately
 	// the zero value, which the deps struct expresses by omission.
 	return modes.NewHandler(modes.HandlerDeps{
-		Ctx:                 context.Background(),
-		Config:              cfg,
-		Logger:              logger,
-		AppState:            appState,
-		CursorState:         state.NewCursorState(),
-		ActionService:       actionService,
-		RefreshHotkeys:      func() {},
-		ExecuteHotkeyAction: func(string, string) error { return nil },
-		Shutdown:            func() {},
+		Ctx:                   context.Background(),
+		Config:                cfg,
+		Logger:                logger,
+		AppState:              appState,
+		CursorState:           state.NewCursorState(),
+		ActionService:         actionService,
+		RefreshHotkeys:        func() {},
+		ExecuteActionSequence: func(string, []string) {},
+		Shutdown:              func() {},
 	})
 }
 

--- a/internal/app/ipc_sequence.go
+++ b/internal/app/ipc_sequence.go
@@ -1,0 +1,119 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+// sequenceRunner executes an ordered list of action steps and reports what
+// happened. It is the daemon's action-sequence executor, injected so the IPC
+// layer does not reach back into the App.
+type sequenceRunner func(ctx context.Context, source string, steps []string) sequenceOutcome
+
+// IPCControllerSequence handles the "run" command, which executes an action
+// sequence on behalf of an external caller.
+//
+// Sequencing already backs every hotkey binding; this exposes the same
+// executor over IPC so that external drivers (skhd, Hammerspoon, shell
+// scripts) can compose steps in one call instead of paying a process spawn
+// per step and losing bail handling in between.
+type IPCControllerSequence struct {
+	run    sequenceRunner
+	logger *zap.Logger
+}
+
+// NewIPCControllerSequence creates a new sequence command handler. A nil runner
+// is valid: the command then reports that sequencing is unavailable, matching
+// how the other handlers treat a missing dependency.
+func NewIPCControllerSequence(run sequenceRunner, logger *zap.Logger) *IPCControllerSequence {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &IPCControllerSequence{run: run, logger: logger}
+}
+
+// RegisterHandlers registers the sequence command handlers.
+func (h *IPCControllerSequence) RegisterHandlers(
+	handlers map[string]func(context.Context, ipc.Command) ipc.Response,
+) {
+	handlers[domain.CommandRun] = h.handleRun
+}
+
+// handleRun executes the steps carried by the command, in order.
+func (h *IPCControllerSequence) handleRun(ctx context.Context, cmd ipc.Command) ipc.Response {
+	steps := nonBlankSteps(cmd.Args)
+	if len(steps) == 0 {
+		return ipc.Response{
+			Success: false,
+			Message: "run requires at least one action step (e.g., neru run 'action left_click' hints)",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	if h.run == nil {
+		return ipc.Response{
+			Success: false,
+			Message: "action sequences are not available",
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	h.logger.Debug("Running action sequence", zap.Int("steps", len(steps)))
+
+	outcome := h.run(ctx, domain.CommandRun, steps)
+
+	switch {
+	case outcome.bailed:
+		return ipc.Response{
+			Success: false,
+			Message: fmt.Sprintf(
+				"sequence stopped at step %d (%s): %s",
+				outcome.failedIndex,
+				outcome.failedStep,
+				outcome.err,
+			),
+			Code: ipc.CodeChainBail,
+		}
+	case outcome.err != nil:
+		return ipc.Response{
+			Success: false,
+			Message: fmt.Sprintf(
+				"step %d (%s) failed: %s",
+				outcome.failedIndex,
+				outcome.failedStep,
+				outcome.err,
+			),
+			Code: ipc.CodeActionFailed,
+		}
+	default:
+		return ipc.Response{
+			Success: true,
+			Message: fmt.Sprintf("ran %d step(s)", outcome.executed),
+			Code:    ipc.CodeOK,
+		}
+	}
+}
+
+// nonBlankSteps trims each step and drops the empty ones, so that a stray
+// separator in a binding does not count as a step.
+func nonBlankSteps(args []string) []string {
+	steps := make([]string, 0, len(args))
+
+	for _, arg := range args {
+		trimmed := strings.TrimSpace(arg)
+		if trimmed == "" {
+			continue
+		}
+
+		steps = append(steps, trimmed)
+	}
+
+	return steps
+}

--- a/internal/app/ipc_sequence_test.go
+++ b/internal/app/ipc_sequence_test.go
@@ -1,0 +1,169 @@
+//nolint:testpackage // Tests the private run-command handler.
+package app
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+// The steps these tests round-trip through the handler.
+const (
+	leftClickStep = "action left_click"
+	hintsStep     = "hints --action left_click"
+)
+
+func TestHandleRun_RequiresSteps(t *testing.T) {
+	t.Parallel()
+
+	handler := NewIPCControllerSequence(
+		func(context.Context, string, []string) sequenceOutcome {
+			t.Fatal("the executor must not run for an empty sequence")
+
+			return sequenceOutcome{}
+		},
+		zap.NewNop(),
+	)
+
+	for _, args := range [][]string{nil, {}, {"  ", ""}} {
+		resp := handler.handleRun(context.Background(), ipc.Command{Args: args})
+
+		if resp.Success || resp.Code != ipc.CodeInvalidInput {
+			t.Fatalf("handleRun(%v) = %+v, want an invalid-input failure", args, resp)
+		}
+	}
+}
+
+func TestHandleRun_ReportsMissingExecutor(t *testing.T) {
+	t.Parallel()
+
+	handler := NewIPCControllerSequence(nil, zap.NewNop())
+
+	resp := handler.handleRun(context.Background(), ipc.Command{Args: []string{"idle"}})
+
+	if resp.Success || resp.Code != ipc.CodeActionFailed {
+		t.Fatalf("handleRun() = %+v, want an action-failed response", resp)
+	}
+}
+
+func TestHandleRun_PassesTrimmedStepsToExecutor(t *testing.T) {
+	t.Parallel()
+
+	var got []string
+
+	handler := NewIPCControllerSequence(
+		func(_ context.Context, _ string, steps []string) sequenceOutcome {
+			got = slices.Clone(steps)
+
+			return sequenceOutcome{executed: len(steps)}
+		},
+		zap.NewNop(),
+	)
+
+	resp := handler.handleRun(context.Background(), ipc.Command{
+		Args: []string{" " + leftClickStep + " ", "", hintsStep},
+	})
+
+	if !resp.Success || resp.Code != ipc.CodeOK {
+		t.Fatalf("handleRun() = %+v, want success", resp)
+	}
+
+	want := []string{leftClickStep, hintsStep}
+	if !slices.Equal(got, want) {
+		t.Fatalf("executor received %v, want %v", got, want)
+	}
+}
+
+func TestHandleRun_ReportsBailAndFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		outcome  sequenceOutcome
+		wantCode string
+	}{
+		{
+			name: "bail",
+			outcome: sequenceOutcome{
+				err:         derrors.New(derrors.CodeChainBail, "mode exited without selection"),
+				failedStep:  "action wait_for_mode_exit --bail",
+				failedIndex: 2,
+				executed:    2,
+				bailed:      true,
+			},
+			wantCode: ipc.CodeChainBail,
+		},
+		{
+			name: "failed step",
+			outcome: sequenceOutcome{
+				err:         derrors.New(derrors.CodeIPCFailed, "boom"),
+				failedStep:  leftClickStep,
+				failedIndex: 1,
+				executed:    3,
+			},
+			wantCode: ipc.CodeActionFailed,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := NewIPCControllerSequence(
+				func(context.Context, string, []string) sequenceOutcome {
+					return testCase.outcome
+				},
+				zap.NewNop(),
+			)
+
+			resp := handler.handleRun(context.Background(), ipc.Command{Args: []string{"a", "b"}})
+
+			if resp.Success {
+				t.Fatalf("handleRun() = %+v, want failure", resp)
+			}
+
+			if resp.Code != testCase.wantCode {
+				t.Fatalf("code = %q, want %q", resp.Code, testCase.wantCode)
+			}
+
+			// The reporting has to name the step the caller wrote, not the
+			// position the sequence happened to reach.
+			if !strings.Contains(resp.Message, testCase.outcome.failedStep) {
+				t.Fatalf("message %q does not name the failing step", resp.Message)
+			}
+		})
+	}
+}
+
+// A sleep step inside a sequence must release its goroutine when the daemon
+// shuts down, rather than holding it for the rest of the duration.
+func TestHandleSleepAction_ReleasedOnCancel(t *testing.T) {
+	t.Parallel()
+
+	handler := &IPCControllerActions{logger: zap.NewNop()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan ipc.Response, 1)
+
+	go func() {
+		done <- handler.handleSleepAction(ctx, []string{"30s"})
+	}()
+
+	select {
+	case resp := <-done:
+		if resp.Success {
+			t.Fatalf("handleSleepAction() = %+v, want a canceled failure", resp)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleSleepAction() ignored a canceled context")
+	}
+}

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -20,7 +20,7 @@ func (h *Handler) activateGridModeWithAction(
 	modifier *string,
 	repeat *bool,
 	cursorFollowSelection *bool,
-	onExit *string,
+	onExit []string,
 ) {
 	// Detect refresh before validation so we can do partial cleanup on re-activation.
 	isRefresh := h.appState.CurrentMode() == domain.ModeGrid

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -84,14 +84,14 @@ type Handler struct {
 
 	// eventTap is nil until the app's phase 8 calls SetEventTap; every use
 	// goes through the nil-guarded helpers in eventtap.go.
-	eventTap            ports.EventTapPort
-	refreshHotkeys      func()
-	executeHotkeyAction func(key, actionStr string) error
-	shutdown            func()
-	refreshHintsTimer   *time.Timer
-	modeSession         uint64
-	hotkeyLastKey       string
-	hotkeyLastKeyTime   int64
+	eventTap              ports.EventTapPort
+	refreshHotkeys        func()
+	executeActionSequence func(source string, steps []string)
+	shutdown              func()
+	refreshHintsTimer     *time.Timer
+	modeSession           uint64
+	hotkeyLastKey         string
+	hotkeyLastKeyTime     int64
 
 	textInput                  ports.TextInputPort
 	hintSearchTextInputActive  bool
@@ -173,8 +173,11 @@ type HandlerDeps struct {
 
 	// RefreshHotkeys re-registers hotkeys for the focused app.
 	RefreshHotkeys func()
-	// ExecuteHotkeyAction runs a hotkey's action string.
-	ExecuteHotkeyAction func(key, actionStr string) error
+	// ExecuteActionSequence runs an ordered list of action steps. The daemon
+	// owns the sequencing rules (bail handling, error reporting), so a binding
+	// behaves the same whether it is dispatched from here or from anywhere
+	// else. source names the caller (a bind key, "on-exit") for logging.
+	ExecuteActionSequence func(source string, steps []string)
 	// Shutdown quits the daemon.
 	Shutdown func()
 
@@ -227,7 +230,7 @@ func NewHandler(deps HandlerDeps) *Handler {
 		recursiveGrid:          deps.RecursiveGridComponent,
 		screenBounds:           screenBounds,
 		refreshHotkeys:         deps.RefreshHotkeys,
-		executeHotkeyAction:    deps.ExecuteHotkeyAction,
+		executeActionSequence:  deps.ExecuteActionSequence,
 		shutdown:               deps.Shutdown,
 		textInput:              deps.TextInput,
 		themeProvider:          deps.System,

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -38,7 +38,7 @@ func (h *Handler) currentHintStyleLocked() hints.StyleMode {
 type ModeActivationOptions struct {
 	Action                *string
 	Modifier              *string
-	OnExit                *string
+	OnExit                []string
 	Repeat                *bool
 	CursorFollowSelection *bool
 	ZoomToDepth           *int
@@ -98,14 +98,14 @@ func (h *Handler) ActivateModeWithOptions(mode domain.Mode, opts ModeActivationO
 	// entry point for user-driven activations (IPC, hotkeys, systray); internal
 	// refreshes (repeat re-activation, space/screen change, cycle) bypass it and
 	// call the activate* helpers directly with a nil onExit to preserve the
-	// stored callback. An omitted --on-exit on a fresh external command must
-	// clear any callback left over from a prior activation of the same mode
-	// rather than inheriting it, so a later completed action does not run a stale
-	// command. A nil pointer here means "clear"; the empty value is a no-op at
+	// stored steps. An omitted --on-exit on a fresh external command must
+	// clear any steps left over from a prior activation of the same mode
+	// rather than inheriting them, so a later completed action does not run a
+	// stale command. A nil slice reaching those helpers means "preserve"; the
+	// non-nil empty slice substituted here means "clear", and it is a no-op at
 	// dispatch time.
 	if opts.OnExit == nil {
-		empty := ""
-		opts.OnExit = &empty
+		opts.OnExit = []string{}
 	}
 
 	modeImpl.Activate(opts)
@@ -158,7 +158,7 @@ func (h *Handler) activateHintModeWithAction(
 	strategy *string,
 	labelDirection *string,
 	splitWord *bool,
-	onExit *string,
+	onExit []string,
 ) {
 	h.activateHintModeInternal(
 		action,
@@ -195,7 +195,7 @@ func (h *Handler) activateHintModeInternal(
 	strategyOverride *string,
 	labelDirectionOverride *string,
 	splitWordOverride *bool,
-	onExit *string,
+	onExit []string,
 ) {
 	// Detect refresh before validation so we can clean up on failure
 	isRefresh := h.appState.CurrentMode() == domain.ModeHints

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -10,7 +10,6 @@ import (
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
-	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
 
 const (
@@ -294,7 +293,7 @@ func (h *Handler) stripStickyModifiersFromKey(key string, mods action.Modifiers)
 func (h *Handler) handleHotkey(key, bundleID string) (
 	[]string, string, bool,
 ) {
-	if h.executeHotkeyAction == nil {
+	if h.executeActionSequence == nil {
 		return nil, "", false
 	}
 
@@ -435,7 +434,7 @@ func (h *Handler) dispatchHotkeyActions(
 	// in hotkeys.go before any async dispatch occurs.
 
 	// Execute in a goroutine so the event tap callback returns quickly.
-	// This also avoids a deadlock: executeHotkeyAction may call
+	// This also avoids a deadlock: an action step may call
 	// ipcController.HandleCommand -> ActivateModeWithOptions which
 	// acquires h.mu, but we already hold it.
 	capturedKey := bindKey
@@ -451,24 +450,7 @@ func (h *Handler) dispatchHotkeyActions(
 			}
 		}()
 
-		for _, actionStr := range capturedActions {
-			trimmedAction := strings.TrimSpace(actionStr)
-			if trimmedAction == "" {
-				continue
-			}
-
-			err := h.executeHotkeyAction(capturedKey, trimmedAction)
-			if err != nil {
-				if derrors.IsCode(err, derrors.CodeChainBail) {
-					return
-				}
-
-				h.logger.Error("Hotkey action failed",
-					zap.String("key", capturedKey),
-					zap.String("action", trimmedAction),
-					zap.Error(err))
-			}
-		}
+		h.executeActionSequence(capturedKey, capturedActions)
 	}()
 }
 
@@ -529,20 +511,7 @@ func (h *Handler) startHeldRepeatLocked(key, bindKey string, actions []string) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				for _, actionStr := range capturedActions {
-					trimmedAction := strings.TrimSpace(actionStr)
-					if trimmedAction == "" {
-						continue
-					}
-
-					err := h.executeHotkeyAction(bindKey, trimmedAction)
-					if err != nil {
-						h.logger.Error("Held repeat action failed",
-							zap.String("key", bindKey),
-							zap.String("action", trimmedAction),
-							zap.Error(err))
-					}
-				}
+				h.executeActionSequence(bindKey, capturedActions)
 			}
 		}
 	}()

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -4,7 +4,8 @@ package modes
 import (
 	"context"
 	"image"
-	"sync/atomic"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/y3owk1n/neru/internal/core/domain/element"
 	domainhint "github.com/y3owk1n/neru/internal/core/domain/hint"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
-	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/infra/overlay"
 	hintscomponent "github.com/y3owk1n/neru/internal/core/infra/overlay/render/hints"
 )
@@ -55,10 +55,8 @@ func TestHandleKeyPressUsesStickyStrippedKeyForBindings(t *testing.T) {
 			domain.ModeRecursiveGrid: mode,
 		},
 		screenBounds: image.Rect(0, 0, 100, 100),
-		executeHotkeyAction: func(_, actionStr string) error {
-			hotkeyActions <- actionStr
-
-			return nil
+		executeActionSequence: func(_ string, steps []string) {
+			hotkeyActions <- strings.Join(steps, ",")
 		},
 	}
 	handler.modifierState.Toggle(action.ModCtrl)
@@ -103,10 +101,8 @@ func TestHandleKeyPressRoutesAllKeysToHintSearch(t *testing.T) {
 			Context: &hintscomponent.Context{},
 		},
 		modes: map[domain.Mode]Mode{},
-		executeHotkeyAction: func(_, actionStr string) error {
-			t.Fatalf("hotkey action should be skipped during hint search, got %q", actionStr)
-
-			return nil
+		executeActionSequence: func(_ string, steps []string) {
+			t.Fatalf("hotkey action should be skipped during hint search, got %v", steps)
 		},
 	}
 
@@ -166,10 +162,8 @@ func newHeldRepeatTestHandler() *Handler {
 		modes: map[domain.Mode]Mode{
 			domain.ModeRecursiveGrid: &recordingMode{keys: make(chan string, 1)},
 		},
-		screenBounds: image.Rect(0, 0, 100, 100),
-		executeHotkeyAction: func(_, _ string) error {
-			return nil
-		},
+		screenBounds:          image.Rect(0, 0, 100, 100),
+		executeActionSequence: func(_ string, _ []string) {},
 	}
 }
 
@@ -240,65 +234,38 @@ func TestHandleFedKeyPressPreservesPhysicalHeldRepeat(t *testing.T) {
 	handler.stopHeldRepeatLocked()
 }
 
-func TestDispatchHotkeyActions_AbortsOnBail(t *testing.T) {
+// The mode dispatcher hands the whole binding to the daemon's sequence
+// executor rather than stepping through it itself, so that a binding runs
+// under the same rules wherever it is dispatched from. The bail and
+// continue-on-error semantics are covered against the real executor in
+// internal/app.
+func TestDispatchHotkeyActions_ForwardsWholeSequence(t *testing.T) {
 	t.Parallel()
 
-	var callCount atomic.Int64
+	got := make(chan []string, 1)
 
 	handler := &Handler{
 		logger:   zap.NewNop(),
 		appState: state.NewAppState(),
-		executeHotkeyAction: func(_, actionStr string) error {
-			callCount.Add(1)
-
-			if callCount.Load() == 1 {
-				return derrors.New(derrors.CodeChainBail, "bail")
+		executeActionSequence: func(source string, steps []string) {
+			if source != "test-bind" {
+				t.Errorf("sequence source = %q, want %q", source, "test-bind")
 			}
 
-			return nil
+			got <- steps
 		},
 	}
 
-	handler.dispatchHotkeyActions("test-mode", "test-bind", "t", []string{"first", "second"})
+	want := []string{"first", "second"}
+	handler.dispatchHotkeyActions("test-mode", "test-bind", "t", want)
 
-	time.Sleep(50 * time.Millisecond)
-
-	if got := callCount.Load(); got != 1 {
-		t.Fatalf(
-			"executeHotkeyAction called %d times, want 1 (chain should abort on bail)",
-			got,
-		)
-	}
-}
-
-func TestDispatchHotkeyActions_ContinuesOnRegularError(t *testing.T) {
-	t.Parallel()
-
-	var callCount atomic.Int64
-
-	handler := &Handler{
-		logger:   zap.NewNop(),
-		appState: state.NewAppState(),
-		executeHotkeyAction: func(_, actionStr string) error {
-			callCount.Add(1)
-
-			if callCount.Load() == 1 {
-				return derrors.New(derrors.CodeIPCFailed, "generic error")
-			}
-
-			return nil
-		},
-	}
-
-	handler.dispatchHotkeyActions("test-mode", "test-bind", "t", []string{"first", "second"})
-
-	time.Sleep(50 * time.Millisecond)
-
-	if got := callCount.Load(); got != 2 {
-		t.Fatalf(
-			"executeHotkeyAction called %d times, want 2 (chain should continue on regular error)",
-			got,
-		)
+	select {
+	case steps := <-got:
+		if !slices.Equal(steps, want) {
+			t.Fatalf("forwarded steps = %v, want %v", steps, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the sequence to be dispatched")
 	}
 }
 

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/y3owk1n/neru/internal/core/domain"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
 	"github.com/y3owk1n/neru/internal/core/domain/state"
-	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	hintscomponent "github.com/y3owk1n/neru/internal/core/infra/overlay/render/hints"
 	"github.com/y3owk1n/neru/internal/ui/coordinates"
 )
@@ -141,9 +140,9 @@ func (h *Handler) executeActionAtPoint(
 	}
 }
 
-// currentModeOnExit returns the --on-exit action configured for the currently
-// active action mode, or nil when none is set or the mode has no context.
-func (h *Handler) currentModeOnExit() *string {
+// currentModeOnExit returns the --on-exit steps configured for the currently
+// active action mode, or nil when none are set or the mode has no context.
+func (h *Handler) currentModeOnExit() []string {
 	switch h.appState.CurrentMode() {
 	case domain.ModeHints:
 		if h.hints != nil && h.hints.Context != nil {
@@ -159,46 +158,34 @@ func (h *Handler) currentModeOnExit() *string {
 		}
 	case domain.ModeIdle, domain.ModeScroll, domain.ModeMonitorSelect:
 		// These modes do not support a pending --action, so there is no
-		// --on-exit action to run.
+		// --on-exit sequence to run.
 	}
 
 	return nil
 }
 
-// runOnExit dispatches the mode's --on-exit action after the pending action was
-// fulfilled. It reuses the hotkey action grammar ("action ...", "exec ...",
-// mode names) and runs asynchronously: executeHotkeyAction may route back
-// through IPC into ActivateModeWithOptions, which acquires h.mu — held by the
+// runOnExit dispatches the mode's --on-exit steps after the pending action was
+// fulfilled. They reuse the hotkey action grammar ("action ...", "exec ...",
+// mode names) and run asynchronously: a step may route back through IPC into
+// ActivateModeWithOptions, which acquires h.mu — held by the
 // executeActionAtPoint caller.
-func (h *Handler) runOnExit(onExit *string) {
-	if onExit == nil || h.executeHotkeyAction == nil {
+func (h *Handler) runOnExit(onExit []string) {
+	if len(onExit) == 0 || h.executeActionSequence == nil {
 		return
 	}
 
-	actionStr := strings.TrimSpace(*onExit)
-	if actionStr == "" {
-		return
-	}
+	steps := append([]string(nil), onExit...)
 
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
 				h.logger.Error("panic in on-exit handler",
 					zap.Any("recover", r),
-					zap.String("action", actionStr))
+					zap.Int("steps", len(steps)))
 			}
 		}()
 
-		err := h.executeHotkeyAction("on-exit", actionStr)
-		if err != nil {
-			if derrors.IsCode(err, derrors.CodeChainBail) {
-				return
-			}
-
-			h.logger.Error("on-exit action failed",
-				zap.String("action", actionStr),
-				zap.Error(err))
-		}
+		h.executeActionSequence("on-exit", steps)
 	}()
 }
 

--- a/internal/app/modes/mode_handlers_test.go
+++ b/internal/app/modes/mode_handlers_test.go
@@ -3,6 +3,7 @@ package modes
 
 import (
 	"image"
+	"slices"
 	"testing"
 	"time"
 
@@ -29,27 +30,25 @@ func TestExecuteActionAtPoint_NilActionNoop(t *testing.T) {
 	}
 }
 
-func TestRunOnExit_DispatchesActionString(t *testing.T) {
-	got := make(chan string, 1)
+func TestRunOnExit_DispatchesEveryStepInOrder(t *testing.T) {
+	got := make(chan []string, 1)
 	handler := &Handler{
 		logger: zap.NewNop(),
-		executeHotkeyAction: func(_, actionStr string) error {
-			got <- actionStr
-
-			return nil
+		executeActionSequence: func(_ string, steps []string) {
+			got <- steps
 		},
 	}
 
-	onExit := "exec notify-send done"
-	handler.runOnExit(&onExit)
+	onExit := []string{"action sleep 0.2", "exec notify-send done"}
+	handler.runOnExit(onExit)
 
 	select {
-	case a := <-got:
-		if a != onExit {
-			t.Fatalf("on-exit dispatched %q, want %q", a, onExit)
+	case steps := <-got:
+		if !slices.Equal(steps, onExit) {
+			t.Fatalf("on-exit dispatched %v, want %v", steps, onExit)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("on-exit action was not dispatched")
+		t.Fatal("on-exit sequence was not dispatched")
 	}
 }
 
@@ -57,21 +56,17 @@ func TestRunOnExit_NilAndEmptyNoop(t *testing.T) {
 	called := make(chan struct{}, 1)
 	handler := &Handler{
 		logger: zap.NewNop(),
-		executeHotkeyAction: func(_, _ string) error {
+		executeActionSequence: func(_ string, _ []string) {
 			called <- struct{}{}
-
-			return nil
 		},
 	}
 
 	handler.runOnExit(nil)
-
-	blank := "   "
-	handler.runOnExit(&blank)
+	handler.runOnExit([]string{})
 
 	select {
 	case <-called:
-		t.Fatal("on-exit should not dispatch for nil or blank action")
+		t.Fatal("on-exit should not dispatch for nil or empty steps")
 	case <-time.After(100 * time.Millisecond):
 	}
 }
@@ -97,40 +92,40 @@ func TestActivateModeWithOptions_OmittedOnExitClearsStaleCallback(t *testing.T) 
 	}
 
 	// An external activation that omits --on-exit must reach the mode with a
-	// non-nil, empty OnExit so the refresh branch clears any stored callback
-	// rather than preserving it.
+	// non-nil, empty OnExit so the refresh branch clears any stored steps
+	// rather than preserving them.
 	handler.ActivateModeWithOptions(domain.ModeGrid, ModeActivationOptions{})
 
 	if fake.lastOpts.OnExit == nil {
 		t.Fatal("expected omitted --on-exit to be normalized to a non-nil clear value")
 	}
 
-	if *fake.lastOpts.OnExit != "" {
-		t.Fatalf("expected normalized on-exit to be empty, got %q", *fake.lastOpts.OnExit)
+	if len(fake.lastOpts.OnExit) != 0 {
+		t.Fatalf("expected normalized on-exit to be empty, got %v", fake.lastOpts.OnExit)
 	}
 
-	// An explicit --on-exit must pass through untouched.
-	want := "exec foo"
-	handler.ActivateModeWithOptions(domain.ModeGrid, ModeActivationOptions{OnExit: &want})
+	// Explicit --on-exit steps must pass through untouched, in order.
+	want := []string{"exec foo", "action sleep 0.1"}
+	handler.ActivateModeWithOptions(domain.ModeGrid, ModeActivationOptions{OnExit: want})
 
-	if fake.lastOpts.OnExit == nil || *fake.lastOpts.OnExit != want {
-		t.Fatalf("expected on-exit %q to pass through, got %v", want, fake.lastOpts.OnExit)
+	if !slices.Equal(fake.lastOpts.OnExit, want) {
+		t.Fatalf("expected on-exit %v to pass through, got %v", want, fake.lastOpts.OnExit)
 	}
 }
 
 func TestCurrentModeOnExit(t *testing.T) {
-	hintsExit := "action left_click"
-	gridExit := "exec grid-done"
-	rgExit := domain.ModeString(domain.ModeRecursiveGrid)
+	hintsExit := []string{"action left_click", "action restore_cursor_pos"}
+	gridExit := []string{"exec grid-done"}
+	rgExit := []string{domain.ModeString(domain.ModeRecursiveGrid)}
 
 	hintsCtx := &hints.Context{}
-	hintsCtx.SetOnExit(&hintsExit)
+	hintsCtx.SetOnExit(hintsExit)
 
 	gridCtx := &grid.Context{}
-	gridCtx.SetOnExit(&gridExit)
+	gridCtx.SetOnExit(gridExit)
 
 	rgCtx := &recursivegrid.Context{}
-	rgCtx.SetOnExit(&rgExit)
+	rgCtx.SetOnExit(rgExit)
 
 	appState := state.NewAppState()
 	handler := &Handler{
@@ -142,7 +137,7 @@ func TestCurrentModeOnExit(t *testing.T) {
 
 	cases := []struct {
 		mode domain.Mode
-		want string
+		want []string
 	}{
 		{domain.ModeHints, hintsExit},
 		{domain.ModeGrid, gridExit},
@@ -152,8 +147,8 @@ func TestCurrentModeOnExit(t *testing.T) {
 		appState.SetMode(testCase.mode)
 
 		got := handler.currentModeOnExit()
-		if got == nil || *got != testCase.want {
-			t.Fatalf("currentModeOnExit() for %v = %v, want %q",
+		if !slices.Equal(got, testCase.want) {
+			t.Fatalf("currentModeOnExit() for %v = %v, want %v",
 				testCase.mode, got, testCase.want)
 		}
 	}

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -24,7 +24,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(
 	repeat *bool,
 	cursorFollowSelection *bool,
 	zoomToDepth *int,
-	onExit *string,
+	onExit []string,
 ) {
 	// Detect refresh before validation so we can do partial cleanup on re-activation.
 	isRefresh := h.appState.CurrentMode() == domain.ModeRecursiveGrid

--- a/internal/app/sequence.go
+++ b/internal/app/sequence.go
@@ -1,0 +1,154 @@
+package app
+
+import (
+	"context"
+	"strings"
+
+	"go.uber.org/zap"
+
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+)
+
+// maxSequenceDepth bounds how deeply one action sequence may invoke another.
+// Sequences nest because a step can itself be a "run" command, so a binding
+// that refers back to itself would otherwise recurse until the daemon runs out
+// of stack.
+const maxSequenceDepth = 5
+
+// sequenceDepthKey types the context value that carries the current nesting
+// depth. A struct key keeps the value private to this package.
+type sequenceDepthKey struct{}
+
+// sequenceDepth reports how many action sequences are already running above ctx.
+func sequenceDepth(ctx context.Context) int {
+	if ctx == nil {
+		return 0
+	}
+
+	depth, ok := ctx.Value(sequenceDepthKey{}).(int)
+	if !ok {
+		return 0
+	}
+
+	return depth
+}
+
+// withSequenceDepth returns a context carrying the given nesting depth.
+func withSequenceDepth(ctx context.Context, depth int) context.Context {
+	return context.WithValue(ctx, sequenceDepthKey{}, depth)
+}
+
+// sequenceOutcome reports what an action sequence did. Callers that answer a
+// client (the "run" command) turn it into a response; callers that answer
+// nobody (hotkeys) ignore it and rely on the logging done here.
+type sequenceOutcome struct {
+	// err is the bail error when bailed is set, otherwise the first step error.
+	err error
+	// failedStep is the step text that produced err.
+	failedStep string
+	// failedIndex is the 1-based position of failedStep among the steps that
+	// ran. Reporting needs it separately from executed, because a non-bailing
+	// failure does not stop the sequence.
+	failedIndex int
+	// executed counts the steps that ran, including one that failed or bailed.
+	executed int
+	// bailed reports whether a step asked the sequence to stop early.
+	bailed bool
+}
+
+// executeActionSequence runs steps in order through the hotkey action grammar
+// ("action ...", "exec ...", a mode name, and so on).
+//
+// This is the only place sequencing is implemented. Global hotkeys, per-mode
+// hotkeys, held-key repeat, a mode's --on-exit, and the "run" command all
+// funnel through it, so a sequence behaves the same wherever it is written. A
+// step that reports CodeChainBail stops the sequence; any other failure is
+// reported and the remaining steps still run.
+//
+// Steps execute against the app context rather than against ctx, so a blocking
+// step (wait_for_mode_exit) is still released at shutdown. The nesting depth is
+// the only thing carried over from ctx.
+func (a *App) executeActionSequence(
+	ctx context.Context,
+	source string,
+	steps []string,
+) sequenceOutcome {
+	var outcome sequenceOutcome
+
+	depth := sequenceDepth(ctx)
+	if depth >= maxSequenceDepth {
+		outcome.err = derrors.Newf(
+			derrors.CodeInvalidInput,
+			"action sequence nested deeper than %d levels",
+			maxSequenceDepth,
+		)
+
+		a.logger.Error("Action sequence nested too deeply",
+			zap.String("source", source),
+			zap.Int("depth", depth))
+
+		return outcome
+	}
+
+	stepCtx := a.sequenceStepContext(depth)
+
+	for _, step := range steps {
+		trimmedStep := strings.TrimSpace(step)
+		if trimmedStep == "" {
+			continue
+		}
+
+		outcome.executed++
+
+		stepErr := a.executeHotkeyAction(stepCtx, source, trimmedStep)
+		if stepErr == nil {
+			continue
+		}
+
+		if derrors.IsCode(stepErr, derrors.CodeChainBail) {
+			outcome.bailed = true
+			outcome.err = stepErr
+			outcome.failedStep = trimmedStep
+			outcome.failedIndex = outcome.executed
+
+			a.logger.Debug("Action sequence bailed",
+				zap.String("source", source),
+				zap.Int("step", outcome.executed))
+
+			return outcome
+		}
+
+		a.logger.Error("Action sequence step failed",
+			zap.String("source", source),
+			zap.String("action", trimmedStep),
+			zap.Error(stepErr))
+
+		if outcome.err == nil {
+			outcome.err = stepErr
+			outcome.failedStep = trimmedStep
+			outcome.failedIndex = outcome.executed
+		}
+	}
+
+	return outcome
+}
+
+// sequenceStepContext builds the context each step of a sequence runs under:
+// the app context, so shutdown releases a step that blocks, carrying the next
+// nesting depth.
+func (a *App) sequenceStepContext(depth int) context.Context {
+	base := a.ctx
+	if base == nil {
+		base = context.Background()
+	}
+
+	return withSequenceDepth(base, depth+1)
+}
+
+// runActionSequence executes a sequence and discards the outcome. It is the
+// entry point for callers that have nobody to report to — hotkeys, held-key
+// repeat, and a mode's --on-exit — all of which rely on the logging that
+// executeActionSequence already does.
+func (a *App) runActionSequence(source string, steps []string) {
+	a.executeActionSequence(a.ctx, source, steps)
+}

--- a/internal/app/sequence_test.go
+++ b/internal/app/sequence_test.go
@@ -1,0 +1,239 @@
+//nolint:testpackage // Tests the private action sequence executor.
+package app
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain/state"
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+// sequenceTestCommand is the fake IPC command the sequence tests dispatch, so
+// a step exercises the real executeHotkeyAction path without depending on any
+// service.
+const (
+	sequenceTestCommand = "step"
+
+	stepOne   = "step one"
+	stepTwo   = "step two"
+	stepThree = "step three"
+)
+
+// stepRecorder answers the fake step command, recording every step a sequence
+// dispatched and deciding how each one replies.
+type stepRecorder struct {
+	respond func(ctx context.Context, step string) ipc.Response
+	steps   []string
+	mu      sync.Mutex
+}
+
+func (r *stepRecorder) handle(ctx context.Context, cmd ipc.Command) ipc.Response {
+	step := strings.TrimSpace(cmd.Action + " " + strings.Join(cmd.Args, " "))
+
+	r.mu.Lock()
+	r.steps = append(r.steps, step)
+	r.mu.Unlock()
+
+	if r.respond == nil {
+		return ipc.Response{Success: true, Message: "ok", Code: ipc.CodeOK}
+	}
+
+	return r.respond(ctx, step)
+}
+
+func (r *stepRecorder) recorded() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return slices.Clone(r.steps)
+}
+
+// newSequenceTestApp builds a whitebox App whose IPC controller answers the
+// fake step command with the recorder. Everything the executor touches — the
+// logger, the app context, the controller — is real; only the command the
+// steps name is fake.
+func newSequenceTestApp(t *testing.T, recorder *stepRecorder) *App {
+	t.Helper()
+
+	logger := zap.NewNop()
+	cfg := config.DefaultConfig()
+	appState := state.NewAppState()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	application := &App{
+		ctx:      ctx,
+		logger:   logger,
+		config:   cfg,
+		appState: appState,
+		ipcController: NewIPCController(IPCControllerDeps{
+			ConfigService: config.NewService(cfg, "", logger, nil),
+			AppState:      appState,
+			Config:        cfg,
+			Logger:        logger,
+		}),
+	}
+
+	application.ipcController.Handlers[sequenceTestCommand] = recorder.handle
+
+	return application
+}
+
+func TestExecuteActionSequence_RunsEveryStepInOrder(t *testing.T) {
+	recorder := &stepRecorder{}
+	application := newSequenceTestApp(t, recorder)
+
+	steps := []string{stepOne, stepTwo, stepThree}
+
+	outcome := application.executeActionSequence(context.Background(), "test", steps)
+
+	if outcome.err != nil {
+		t.Fatalf("outcome.err = %v, want nil", outcome.err)
+	}
+
+	if outcome.executed != len(steps) {
+		t.Fatalf("executed = %d, want %d", outcome.executed, len(steps))
+	}
+
+	if got := recorder.recorded(); !slices.Equal(got, steps) {
+		t.Fatalf("dispatched %v, want %v", got, steps)
+	}
+}
+
+func TestExecuteActionSequence_SkipsBlankSteps(t *testing.T) {
+	recorder := &stepRecorder{}
+	application := newSequenceTestApp(t, recorder)
+
+	outcome := application.executeActionSequence(
+		context.Background(),
+		"test",
+		[]string{"", stepOne, "   ", stepTwo},
+	)
+
+	if outcome.executed != 2 {
+		t.Fatalf("executed = %d, want 2 (blank steps should not count)", outcome.executed)
+	}
+
+	want := []string{stepOne, stepTwo}
+	if got := recorder.recorded(); !slices.Equal(got, want) {
+		t.Fatalf("dispatched %v, want %v", got, want)
+	}
+}
+
+func TestExecuteActionSequence_StopsOnBail(t *testing.T) {
+	recorder := &stepRecorder{
+		respond: func(_ context.Context, step string) ipc.Response {
+			if step == stepTwo {
+				return ipc.Response{
+					Success: false,
+					Message: "mode exited without selection",
+					Code:    ipc.CodeChainBail,
+				}
+			}
+
+			return ipc.Response{Success: true, Code: ipc.CodeOK}
+		},
+	}
+	application := newSequenceTestApp(t, recorder)
+
+	outcome := application.executeActionSequence(
+		context.Background(),
+		"test",
+		[]string{stepOne, stepTwo, stepThree},
+	)
+
+	if !outcome.bailed {
+		t.Fatal("outcome.bailed = false, want true")
+	}
+
+	if outcome.executed != 2 || outcome.failedIndex != 2 {
+		t.Fatalf("executed = %d, failedIndex = %d, want 2 and 2",
+			outcome.executed, outcome.failedIndex)
+	}
+
+	want := []string{stepOne, stepTwo}
+	if got := recorder.recorded(); !slices.Equal(got, want) {
+		t.Fatalf("dispatched %v, want %v (a bail must stop the sequence)", got, want)
+	}
+}
+
+func TestExecuteActionSequence_ContinuesAfterStepFailure(t *testing.T) {
+	recorder := &stepRecorder{
+		respond: func(_ context.Context, step string) ipc.Response {
+			if step == stepOne {
+				return ipc.Response{
+					Success: false,
+					Message: "boom",
+					Code:    ipc.CodeActionFailed,
+				}
+			}
+
+			return ipc.Response{Success: true, Code: ipc.CodeOK}
+		},
+	}
+	application := newSequenceTestApp(t, recorder)
+
+	steps := []string{stepOne, stepTwo, stepThree}
+
+	outcome := application.executeActionSequence(context.Background(), "test", steps)
+
+	if outcome.bailed {
+		t.Fatal("outcome.bailed = true, want false for a regular failure")
+	}
+
+	if outcome.err == nil {
+		t.Fatal("outcome.err = nil, want the first step error")
+	}
+
+	if outcome.failedStep != stepOne || outcome.failedIndex != 1 {
+		t.Fatalf("failedStep = %q at %d, want %q at 1",
+			outcome.failedStep, outcome.failedIndex, stepOne)
+	}
+
+	if outcome.executed != len(steps) {
+		t.Fatalf("executed = %d, want %d (a regular failure must not stop the sequence)",
+			outcome.executed, len(steps))
+	}
+}
+
+// A step can start another sequence ("run" is itself an action), so the depth
+// carried through the step context is what stops a binding that refers back to
+// itself from recursing without bound.
+func TestExecuteActionSequence_StopsRunawayNesting(t *testing.T) {
+	var (
+		application *App
+		depth       int
+		depthMu     sync.Mutex
+	)
+
+	recorder := &stepRecorder{
+		respond: func(ctx context.Context, _ string) ipc.Response {
+			depthMu.Lock()
+			depth++
+			depthMu.Unlock()
+
+			application.executeActionSequence(ctx, "nested", []string{"step deeper"})
+
+			return ipc.Response{Success: true, Code: ipc.CodeOK}
+		},
+	}
+
+	application = newSequenceTestApp(t, recorder)
+
+	application.executeActionSequence(context.Background(), "test", []string{stepOne})
+
+	depthMu.Lock()
+	defer depthMu.Unlock()
+
+	if depth != maxSequenceDepth {
+		t.Fatalf("nested %d levels, want the guard to stop at %d", depth, maxSequenceDepth)
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -120,6 +120,7 @@ func TestCommandInitialization(t *testing.T) {
 		cliTestGrid:                      false,
 		"scroll":                         false,
 		cliTestAction:                    false,
+		"run <step> [step...]":           false,
 		cliTestStatus:                    false,
 		"doctor":                         false,
 		cliTestRoles:                     false,

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -11,6 +11,24 @@ import (
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
 
+// validateOnExitSteps trims each --on-exit value and rejects blank ones, so a
+// quoting mistake fails at the CLI rather than silently dropping a step from
+// the sequence that runs once the mode's action is fulfilled.
+func validateOnExitSteps(values []string) ([]string, error) {
+	steps := make([]string, 0, len(values))
+
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return nil, derrors.New(derrors.CodeInvalidInput, "--on-exit steps cannot be empty")
+		}
+
+		steps = append(steps, trimmed)
+	}
+
+	return steps, nil
+}
+
 // ModeConfig holds configuration for creating a mode command.
 type ModeConfig struct {
 	Name                     string
@@ -61,7 +79,12 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				return err
 			}
 
-			onExitFlag, err := cmd.Flags().GetString("on-exit")
+			onExitFlag, err := cmd.Flags().GetStringArray("on-exit")
+			if err != nil {
+				return err
+			}
+
+			onExitSteps, err := validateOnExitSteps(onExitFlag)
 			if err != nil {
 				return err
 			}
@@ -164,7 +187,7 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				)
 			}
 
-			if strings.TrimSpace(onExitFlag) != "" && actionFlag == "" {
+			if len(onExitSteps) > 0 && actionFlag == "" {
 				return derrors.New(
 					derrors.CodeInvalidInput,
 					"--on-exit requires --action (it runs only when the action is fulfilled)",
@@ -260,8 +283,8 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 				params = append(params, "--modifier="+modifierFlag)
 			}
 
-			if strings.TrimSpace(onExitFlag) != "" {
-				params = append(params, "--on-exit="+onExitFlag)
+			for _, step := range onExitSteps {
+				params = append(params, "--on-exit="+step)
 			}
 
 			if repeatFlag {
@@ -356,10 +379,10 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 		"",
 		"Comma-separated modifier keys to hold during action (cmd, super, meta, shift, alt, option, ctrl) (requires --action)",
 	)
-	cmd.Flags().String(
+	cmd.Flags().StringArray(
 		"on-exit",
-		"",
-		"Command to run after the action is fulfilled and the mode exits (same syntax as hotkeys, e.g. 'action left_click' or 'exec notify-send done'). Requires --action; not run on manual escape/idle",
+		nil,
+		"Step to run after the action is fulfilled and the mode exits (same syntax as hotkeys, e.g. 'action left_click' or 'exec notify-send done'). Repeat the flag to run several steps in order. Requires --action; not run on manual escape/idle",
 	)
 	cmd.Flags().String(
 		"cursor-selection-mode",

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/y3owk1n/neru/internal/core/domain"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+)
+
+// RunCmd is the CLI run command for executing a sequence of actions.
+var RunCmd = &cobra.Command{
+	Use:   "run <step> [step...]",
+	Short: "Run a sequence of actions in one call",
+	Long: `Run an ordered sequence of actions in a single call.
+
+Each argument is one step, written exactly as it would be written in a hotkey
+binding: an action ("action left_click"), a mode ("hints --action left_click"),
+or a shell command ("exec open -a Safari").
+
+The daemon runs the steps in order, so an external driver (skhd, Hammerspoon, a
+shell script) can compose a workflow without spawning one process per step. A
+step that asks the sequence to stop — "action wait_for_mode_exit --bail" after
+the mode was canceled — ends it; any other failing step is reported while the
+remaining steps still run.
+
+Sequences that block (sleeps, waits) can outlast the default IPC timeout. Raise
+it for those: neru --timeout 60 run ...
+
+Examples:
+  neru run "action save_cursor_pos" hints
+  neru run "action left_click" "action sleep 0.2" "action restore_cursor_pos"
+  neru run "hints --action left_click" "action wait_for_mode_exit --bail" "exec say done"`,
+	Args: validateRunArgs,
+	PreRunE: func(_ *cobra.Command, _ []string) error {
+		return requiresRunningInstance()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return sendCommand(cmd, domain.CommandRun, args)
+	},
+}
+
+// validateRunArgs rejects an empty sequence and blank steps, so a quoting
+// mistake fails at the CLI instead of silently running fewer steps.
+func validateRunArgs(_ *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return derrors.New(
+			derrors.CodeInvalidInput,
+			"run requires at least one action step (e.g., neru run 'action left_click' hints)",
+		)
+	}
+
+	for _, arg := range args {
+		if strings.TrimSpace(arg) == "" {
+			return derrors.New(derrors.CodeInvalidInput, "run steps cannot be empty")
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	RootCmd.AddCommand(RunCmd)
+}

--- a/internal/cli/run_internal_test.go
+++ b/internal/cli/run_internal_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"slices"
+	"testing"
+)
+
+// runTestStep is the step these tests reuse across cases.
+const runTestStep = "hints"
+
+func TestValidateRunArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "single step", args: []string{"action left_click"}},
+		{name: "several steps", args: []string{"action save_cursor_pos", runTestStep}},
+		{name: "no steps", args: nil, wantErr: true},
+		{name: "blank step", args: []string{runTestStep, "   "}, wantErr: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateRunArgs(nil, testCase.args)
+			if (err != nil) != testCase.wantErr {
+				t.Fatalf("validateRunArgs(%v) error = %v, wantErr = %v",
+					testCase.args, err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateOnExitSteps(t *testing.T) {
+	t.Parallel()
+
+	steps, err := validateOnExitSteps([]string{" action sleep 0.2 ", runTestStep})
+	if err != nil {
+		t.Fatalf("validateOnExitSteps() error = %v", err)
+	}
+
+	want := []string{"action sleep 0.2", runTestStep}
+	if !slices.Equal(steps, want) {
+		t.Fatalf("validateOnExitSteps() = %v, want %v", steps, want)
+	}
+
+	_, blankErr := validateOnExitSteps([]string{runTestStep, "  "})
+	if blankErr == nil {
+		t.Fatal("validateOnExitSteps() with a blank step = nil error, want a failure")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,8 @@ const (
 
 // Common action command constants.
 const (
+	// CmdRun runs the rest of the binding as an ordered action sequence.
+	CmdRun                         = "run"
 	CmdToggleCursorFollowSelection = "toggle-cursor-follow-selection"
 	CmdMoveMouseUp                 = "action move_mouse_relative --dx=0 --dy=-10"
 )

--- a/internal/config/validators_config_test.go
+++ b/internal/config/validators_config_test.go
@@ -26,6 +26,21 @@ func TestConfigValidateHotkeys_Valid(t *testing.T) {
 	}
 }
 
+// "run" carries its own steps as quoted arguments, so a binding that uses it
+// has to validate like any other command rather than being rejected as
+// unknown.
+func TestConfigValidateHotkeys_RunSequence(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Hints.Hotkeys["Enter"] = config.StringOrStringArray{
+		"run 'action left_click' 'action sleep 0.2' 'action restore_cursor_pos'",
+	}
+
+	err := cfg.ValidateHotkeys()
+	if err != nil {
+		t.Fatalf("ValidateHotkeys() unexpected error: %v", err)
+	}
+}
+
 func TestConfigValidateHotkeys_AppOverridePrefixConflict(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Hints.Hotkeys["gg"] = config.StringOrStringArray{config.CmdLeftClick}

--- a/internal/config/validators_hotkeys.go
+++ b/internal/config/validators_hotkeys.go
@@ -379,7 +379,12 @@ func validateHotkeyActionString(actionStr string) error {
 		ModeNameMonitorSelect,
 		"toggle-screen-share", CmdToggleCursorFollowSelection,
 		"toggle-scroll-invert",
-		"config":
+		"config",
+		// "run" takes its own steps as arguments. Each one is validated when
+		// the sequence executes, not here: the steps arrive as a single quoted
+		// string per step, so splitting them apart correctly is the runtime's
+		// job, not the validator's.
+		CmdRun:
 		return nil
 	default:
 		return derrors.Newf(derrors.CodeInvalidConfig, "unknown command: %s", trimmed)

--- a/internal/core/domain/domain_constants.go
+++ b/internal/core/domain/domain_constants.go
@@ -30,6 +30,7 @@ const (
 	CommandStart                       = "start"
 	CommandStop                        = "stop"
 	CommandAction                      = "action"
+	CommandRun                         = "run"
 	CommandStatus                      = "status"
 	CommandConfig                      = "config"
 	CommandReloadConfig                = "reload"

--- a/internal/core/infra/ipc/ipc.go
+++ b/internal/core/infra/ipc/ipc.go
@@ -31,6 +31,12 @@ const (
 	// ConnectionReadTimeout is the timeout for reading from a connection.
 	ConnectionReadTimeout = 30 * time.Second
 
+	// ConnectionWriteTimeout bounds how long the server waits to hand a
+	// response to a client that has stopped reading. It is applied after the
+	// handler returns, so a long-running command does not spend the budget the
+	// reply needs.
+	ConnectionWriteTimeout = 5 * time.Second
+
 	// PingTimeout is the timeout for ping operations.
 	PingTimeout = 500 * time.Millisecond
 
@@ -235,9 +241,12 @@ func (s *Server) handleConnection(connection net.Conn) {
 		s.wg.Done()
 	}()
 
-	connectionDeadline := connection.SetDeadline(time.Now().Add(ConnectionReadTimeout))
-	if connectionDeadline != nil {
-		logger.Error("Failed to set connection deadline", zap.Error(connectionDeadline))
+	// Only the read side is bounded here: this guards a client that connects
+	// and never sends a command. The write side gets its own deadline once the
+	// handler has finished, in writeResponse.
+	deadlineErr := connection.SetReadDeadline(time.Now().Add(ConnectionReadTimeout))
+	if deadlineErr != nil {
+		logger.Error("Failed to set connection read deadline", zap.Error(deadlineErr))
 
 		return
 	}
@@ -247,20 +256,31 @@ func (s *Server) handleConnection(connection net.Conn) {
 
 	encoder := json.NewEncoder(connection)
 
+	// reply sends one response and reports the outcome. A client that has
+	// already gone away is the expected end of a command that outlived its
+	// caller's patience, so it is logged quietly; anything else is a fault.
+	reply := func(response Response) {
+		writeErr := writeResponse(connection, encoder, response)
+		switch {
+		case writeErr == nil:
+		case isPeerGoneErr(writeErr):
+			logger.Debug("Client disconnected before response was sent", zap.Error(writeErr))
+		default:
+			logger.Error("Failed to encode response", zap.Error(writeErr))
+		}
+	}
+
 	var cmd Command
 
 	decodeCommandErr := decoder.Decode(&cmd)
 	if decodeCommandErr != nil {
 		logger.Error("Failed to decode command", zap.Error(decodeCommandErr))
 
-		encodeErr := encoder.Encode(Response{
+		reply(Response{
 			Success: false,
 			Message: fmt.Sprintf("failed to decode command: %v", decodeCommandErr),
 			Code:    CodeInvalidInput,
 		})
-		if encodeErr != nil {
-			logger.Error("Failed to encode error response", zap.Error(encodeErr))
-		}
 
 		return
 	}
@@ -278,7 +298,7 @@ func (s *Server) handleConnection(connection net.Conn) {
 			zap.String("client_version", cmd.Version),
 			zap.String("server_version", serverVersion))
 
-		encodeErr := encoder.Encode(Response{
+		reply(Response{
 			Version: serverVersion,
 			Success: false,
 			Message: fmt.Sprintf(
@@ -288,9 +308,6 @@ func (s *Server) handleConnection(connection net.Conn) {
 			),
 			Code: CodeVersionMismatch,
 		})
-		if encodeErr != nil {
-			logger.Error("Failed to encode version mismatch response", zap.Error(encodeErr))
-		}
 
 		return
 	}
@@ -299,19 +316,24 @@ func (s *Server) handleConnection(connection net.Conn) {
 	// Always include server version in response
 	response.Version = serverVersion
 
-	connectionDeadline = encoder.Encode(response)
-	if connectionDeadline != nil {
-		if isPeerGoneErr(connectionDeadline) {
-			// The client already disconnected before we could reply — almost
-			// always because it hit its own request timeout while the handler
-			// was still working. That is the client's decision, not a daemon
-			// fault, so log it quietly instead of as an error.
-			logger.Debug("Client disconnected before response was sent",
-				zap.Error(connectionDeadline))
-		} else {
-			logger.Error("Failed to encode response", zap.Error(connectionDeadline))
-		}
+	reply(response)
+}
+
+// writeResponse sends one response to the client.
+//
+// The deadline set when the connection was accepted budgets the whole exchange,
+// including however long the handler ran. Handlers are allowed to take longer
+// than that — an action sequence can sleep, or wait for the user to finish a
+// mode — so the reply is given its own window here. Without it, a slow but
+// perfectly successful command would have its reply refused before it was even
+// attempted, and the caller would see a timeout for work that did happen.
+func writeResponse(connection net.Conn, encoder *json.Encoder, response Response) error {
+	deadlineErr := connection.SetWriteDeadline(time.Now().Add(ConnectionWriteTimeout))
+	if deadlineErr != nil {
+		return deadlineErr
 	}
+
+	return encoder.Encode(response)
 }
 
 // isPeerGoneErr reports whether err is the expected result of writing to a

--- a/internal/core/infra/ipc/ipc_internal_test.go
+++ b/internal/core/infra/ipc/ipc_internal_test.go
@@ -1,0 +1,102 @@
+package ipc
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// A handler is free to outlive the deadline set when the connection was
+// accepted — an action sequence can sleep, or wait for the user to finish a
+// mode. The reply must still be attempted, or a command that succeeded would
+// be reported to its caller as a timeout.
+func TestWriteResponse_SendsAfterTheAcceptDeadlineHasPassed(t *testing.T) {
+	t.Parallel()
+
+	server, client := net.Pipe()
+
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = client.Close()
+	})
+
+	// Stand in for a handler that ran past the connection's original deadline.
+	setDeadlineErr := server.SetDeadline(time.Now().Add(-time.Second))
+	if setDeadlineErr != nil {
+		t.Fatalf("SetDeadline: %v", setDeadlineErr)
+	}
+
+	decoded := make(chan Response, 1)
+
+	go func() {
+		var response Response
+
+		decodeErr := json.NewDecoder(client).Decode(&response)
+		if decodeErr != nil {
+			close(decoded)
+
+			return
+		}
+
+		decoded <- response
+	}()
+
+	writeErr := writeResponse(
+		server,
+		json.NewEncoder(server),
+		Response{Success: true, Message: "ran 3 step(s)", Code: CodeOK},
+	)
+	if writeErr != nil {
+		t.Fatalf("writeResponse() error = %v, want the reply to be sent anyway", writeErr)
+	}
+
+	select {
+	case response, ok := <-decoded:
+		if !ok {
+			t.Fatal("client could not decode the response")
+		}
+
+		if !response.Success || response.Message != "ran 3 step(s)" {
+			t.Fatalf("client received %+v, want the response that was written", response)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the response never reached the client")
+	}
+}
+
+// The write side still has a bound of its own: a client that stops reading
+// must not pin the connection goroutine indefinitely.
+func TestWriteResponse_TimesOutWhenTheClientStopsReading(t *testing.T) {
+	t.Parallel()
+
+	server, client := net.Pipe()
+
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = client.Close()
+	})
+
+	// net.Pipe is unbuffered and nothing reads the client end, so the write
+	// blocks until the deadline writeResponse sets expires.
+	done := make(chan error, 1)
+
+	go func() {
+		done <- writeResponse(
+			server,
+			json.NewEncoder(server),
+			Response{Success: true, Code: CodeOK},
+		)
+	}()
+
+	select {
+	case writeErr := <-done:
+		var netErr net.Error
+		if !errors.As(writeErr, &netErr) || !netErr.Timeout() {
+			t.Fatalf("writeResponse() error = %v, want a timeout once nobody reads", writeErr)
+		}
+	case <-time.After(ConnectionWriteTimeout + 5*time.Second):
+		t.Fatal("writeResponse() never returned; the write deadline is not being applied")
+	}
+}

--- a/internal/core/infra/overlay/render/grid/context.go
+++ b/internal/core/infra/overlay/render/grid/context.go
@@ -11,7 +11,7 @@ import (
 type baseContext struct {
 	pendingAction         *string
 	pendingModifier       *string
-	onExit                *string
+	onExit                []string
 	repeat                bool
 	cursorFollowSelection bool
 	selectedPoint         image.Point
@@ -28,14 +28,14 @@ func (c *baseContext) PendingAction() *string {
 	return c.pendingAction
 }
 
-// SetOnExit sets the action string to run when the pending action is fulfilled
+// SetOnExit sets the action steps to run when the pending action is fulfilled
 // and the mode exits back to idle through the action path.
-func (c *baseContext) SetOnExit(onExit *string) {
+func (c *baseContext) SetOnExit(onExit []string) {
 	c.onExit = onExit
 }
 
-// OnExit returns the action string to run once the pending action is fulfilled.
-func (c *baseContext) OnExit() *string {
+// OnExit returns the action steps to run once the pending action is fulfilled.
+func (c *baseContext) OnExit() []string {
 	return c.onExit
 }
 

--- a/internal/core/infra/overlay/render/hints/context.go
+++ b/internal/core/infra/overlay/render/hints/context.go
@@ -9,7 +9,7 @@ import (
 type baseContext struct {
 	pendingAction          *string
 	pendingModifier        *string
-	onExit                 *string
+	onExit                 []string
 	repeat                 bool
 	cursorFollowSelection  bool
 	filterRoles            []string
@@ -30,14 +30,14 @@ func (c *baseContext) PendingAction() *string {
 	return c.pendingAction
 }
 
-// SetOnExit sets the action string to run when the pending action is fulfilled
+// SetOnExit sets the action steps to run when the pending action is fulfilled
 // and the mode exits back to idle through the action path.
-func (c *baseContext) SetOnExit(onExit *string) {
+func (c *baseContext) SetOnExit(onExit []string) {
 	c.onExit = onExit
 }
 
-// OnExit returns the action string to run once the pending action is fulfilled.
-func (c *baseContext) OnExit() *string {
+// OnExit returns the action steps to run once the pending action is fulfilled.
+func (c *baseContext) OnExit() []string {
 	return c.onExit
 }
 

--- a/internal/core/infra/overlay/render/recursivegrid/component.go
+++ b/internal/core/infra/overlay/render/recursivegrid/component.go
@@ -10,7 +10,7 @@ import (
 type baseContext struct {
 	pendingAction         *string
 	pendingModifier       *string
-	onExit                *string
+	onExit                []string
 	repeat                bool
 	cursorFollowSelection bool
 	selectedPoint         image.Point
@@ -27,14 +27,14 @@ func (c *baseContext) PendingAction() *string {
 	return c.pendingAction
 }
 
-// SetOnExit sets the action string to run when the pending action is fulfilled
+// SetOnExit sets the action steps to run when the pending action is fulfilled
 // and the mode exits back to idle through the action path.
-func (c *baseContext) SetOnExit(onExit *string) {
+func (c *baseContext) SetOnExit(onExit []string) {
 	c.onExit = onExit
 }
 
-// OnExit returns the action string to run once the pending action is fulfilled.
-func (c *baseContext) OnExit() *string {
+// OnExit returns the action steps to run once the pending action is fulfilled.
+func (c *baseContext) OnExit() []string {
 	return c.onExit
 }
 


### PR DESCRIPTION
## Description

This PR adds a way to run several actions in order as one unit, from a single command. `neru run "action save_cursor_pos" "hints --action left_click"` executes the steps in the daemon, so a script or an external hotkey daemon no longer has to spawn one `neru` process per step and hope the pieces line up.

Underneath, the same thing was implemented three separate times — for global hotkeys, for per-mode hotkeys, and for comma-separated click chains — with rules that had already begun to diverge. They now share one implementation, so a sequence behaves identically whether it is written in a hotkey binding, passed to a mode's `--on-exit`, or run from a script. As a result `--on-exit` can now take several steps instead of one, which collapses the multi-binding workaround that recipes needed for "click, wait, then do something else".

Two smaller fixes came out of the same area. A command that took longer than the connection's 30-second budget had its reply refused before it was attempted, so the caller saw a timeout for work that had actually completed; the read and write sides are now budgeted separately. And a `sleep` step ignored daemon shutdown, holding a goroutine until its duration elapsed.

This PR adds no new expressiveness beyond ordering — no conditionals, no variables, no retries. Failure semantics stay as they are today: a bail stops the sequence, any other failure is reported and the following steps still run.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature

## Command and configuration changes

**New command**

| Command | Description |
| --- | --- |
| `neru run <step> [step...]` | Runs the given steps in order. Each argument is one step in the hotkey action grammar: an action (`action left_click`), a mode (`hints --action left_click`), or a shell command (`exec open -a Safari`). |

```bash
neru run "action save_cursor_pos" "hints --action left_click" \
         "action wait_for_mode_exit --bail" "action restore_cursor_pos"
```

Exit status is `0` on success, `ERR_CHAIN_BAIL` when a step stopped the sequence, and `ERR_ACTION_FAILED` naming the first failing step otherwise.

**Changed flag**

| Flag | Before | Now |
| --- | --- | --- |
| `--on-exit` on `hints`, `grid`, `recursive_grid` | Single value | Repeatable; each occurrence appends one step, run in order |

```toml
[hotkeys]
"Primary+Shift+Space" = [
    "action save_cursor_pos",
    "hints --action left_click --on-exit 'action restore_cursor_pos'",
]
```

Existing configs keep working untouched: a single `--on-exit` behaves exactly as before, and it still runs only when the mode's action is fulfilled — never on escape or `neru idle`.

**New accepted value**

`run` is now valid as a hotkey binding action, alongside `hints`, `idle`, `exec` and the rest. It was previously rejected by config validation as an unknown command. Arrays remain the idiomatic spelling inside a config; this is for consistency, so a step that works in one place works everywhere.

## Potentially breaking

Two behaviour changes that a very unusual setup could notice. Neither has a migration; both are judgement calls worth a second opinion.

- **Repeated `--on-exit` in one mode invocation.** Previously the last occurrence won and the earlier ones were discarded; now all of them run, in order. Only affects a binding that already passes the flag more than once, which had no reason to exist since the extra values were silently dropped.
- **Held-key repeat and bail.** A held-repeat binding whose sequence bails now stops that tick's remaining steps instead of running them. Each tick still starts fresh, so repeating continues. This aligns held repeat with the other two dispatch paths, which already stopped on a bail — arguably a bug fix rather than a break, but it is a behaviour change in shipped code.

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no platform-specific code in this change
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new platform capability
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Why one executor.** The three implementations disagreed already: held-key repeat ran every step of a binding even after one asked the chain to stop, while the other two paths stopped. Consolidating fixes that by construction and makes the queued follow-ups — named macros, an explicit `--bail-on-error` — one change each instead of three with three chances to drift.

**Recursion.** Because a step can itself be a `run`, a binding can refer back to itself. Nesting depth travels in the step context and is refused past five levels. This is reachable in practice through `neru run "run ..."` and through `--on-exit 'run ...'`, neither of which passes through config validation.

**Connection deadlines.** The 30-second deadline set at accept was being spent by handler execution, which is not I/O. The read side keeps that budget, which is what guards a client that connects and never sends a command; the write side gets its own five-second window starting after the handler returns. The alternative considered — classifying the resulting `deadline exceeded` as a benign "peer gone" error — was rejected because it would have hidden dropped replies rather than delivered them, and would have made a genuinely stuck write look benign forever.

**Verification beyond the test suite.** Driven against a running daemon started with an empty `[hotkeys]` table: a 3-step sequence, a bail stopping the remaining steps, a failing step not stopping them, `run` nested one and two levels deep, `--on-exit` not firing on a cancelled mode and firing in order on a fulfilled one, and a 9-step sequence combining mode activation, fed keys, a blocking wait and cursor save/restore. A 37-second sequence returned its result normally, where it previously failed with a client timeout. `SIGTERM` during an in-flight `action sleep 60s` exited the daemon immediately and released the step. Race detector clean across the touched packages.

**Measured overhead.** Five steps as five separate invocations took 30–40 ms; the same five as one `neru run` took under 10 ms — roughly 6–7 ms of process spawn and connection setup per step, removed for every step after the first.
