### PR TITLE
feat(action): add `--bail-on-error` to stop a sequence at a failure

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -891,10 +891,48 @@ step and lose the sequencing rules between them.
 - A step that asks the sequence to stop ends it. Today that is
   `action wait_for_mode_exit --bail` after a mode was cancelled — the command
   then exits with `ERR_CHAIN_BAIL`.
-- Any other failing step is reported, and the remaining steps still run. The
+- A failing step is reported, and by default the remaining steps still run. The
   command exits with `ERR_ACTION_FAILED` naming the first failure.
+- To stop at a failure instead, end that step with `--bail-on-error`, or pass
+  `--stop-on-error` to make every step in the sequence fatal. See
+  [Failure policy](#failure-policy).
 - A sequence may start another sequence, up to five levels deep. Deeper
   nesting is refused rather than recursing.
+
+**Flags**
+
+| Flag              | Type | Default | Description                                                              |
+| ----------------- | ---- | ------- | ------------------------------------------------------------------------ |
+| `--stop-on-error` | bool | `false` | End the sequence at the first failing step, as if every step carried `--bail-on-error`. |
+
+### Failure policy
+
+By default a failing step is reported and the sequence carries on. That is
+rarely what a workflow wants: in `["action left_click", "idle"]` the mode exits
+even when the click failed.
+
+`--bail-on-error` marks one step as fatal. It is a sequencing directive rather
+than a flag of the action, so the daemon consumes it and the step runs without
+it. It must be the last thing in the step:
+
+```toml
+[hints.hotkeys]
+# Exit only if the click actually landed.
+"Shift+L" = ["action left_click --bail-on-error", "idle"]
+```
+
+```bash
+# Same policy for every step, without repeating the directive.
+neru run --stop-on-error "action left_click" "action restore_cursor_pos"
+```
+
+It works in any sequence — a hotkey binding, a mode's `--on-exit`, or `neru run`.
+Text that merely looks like the directive is left alone, so
+`exec sh -c "echo --bail-on-error"` still passes it through to the shell.
+
+A stopped sequence reports which step ended it and that the later steps did not
+run; a tolerated failure says the opposite, so the two are distinguishable by a
+script.
 
 **Timeouts**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -547,7 +547,17 @@ Use `--mode` to route keys through Neru's active mode/action pipeline instead of
 "Ctrl+Z" = ["monitor_select", "action wait_for_mode_exit --bail", "recursive_grid"]
 ```
 
-Use `--bail` to abort the chain when the mode exits without a selection (e.g., user presses Escape). Without `--bail`, `wait_for_mode_exit` always succeeds and the chain continues. A step that fails for any other reason is logged and the chain continues.
+Use `--bail` to abort the chain when the mode exits without a selection (e.g., user presses Escape). Without `--bail`, `wait_for_mode_exit` always succeeds and the chain continues.
+
+A step that fails for any other reason is logged and the chain continues. End that step with `--bail-on-error` to stop the chain there instead — useful when a later step should not happen unless the earlier one landed:
+
+```toml
+[hints.hotkeys]
+# Exit only if the click actually landed.
+"Shift+L" = ["action left_click --bail-on-error", "idle"]
+```
+
+`--bail-on-error` is a sequencing directive rather than a flag of the action, so it must come last in the step. See [CLI.md](CLI.md#failure-policy).
 
 An array like the ones above is an *action sequence*. The same sequence, with the same rules, can also be written as a mode's `--on-exit` (repeat the flag once per step) or run from a script with [`neru run`](CLI.md#neru-run) — one executor backs all three, so a sequence that works in one place works in the others.
 

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -97,6 +97,13 @@ The old `auto_exit_actions` config field was removed. Use a `hotkeys` array to c
 
 This works in any mode — hints, grid, recursive_grid, or scroll.
 
+By default the mode exits whether or not the click landed. Add `--bail-on-error` to the click so the sequence stops instead, leaving you in the mode to try again:
+
+```toml
+[hints.hotkeys]
+"Shift+L" = ["action left_click --bail-on-error", "idle"]
+```
+
 ## Restore Cursor Position After Mode Exit
 
 The old `restore_cursor_position` config field was removed. Compose the same behavior with action primitives:

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -429,7 +429,7 @@ func initializeIPCController(app *App) {
 		// through SetInfrastructure.
 		KeyFeed:         app.keyFeed,
 		ReloadConfig:    app.ReloadConfig,
-		ExecuteSequence: app.executeActionSequence,
+		ExecuteSequence: app.executeActionSequenceWithPolicy,
 		Logger:          app.logger,
 	})
 

--- a/internal/app/hotkeys_test.go
+++ b/internal/app/hotkeys_test.go
@@ -187,7 +187,7 @@ func TestHotkeyActionsRepeatWhileHeld(t *testing.T) {
 		},
 		{
 			name:    "click does not repeat",
-			actions: []string{"action left_click"},
+			actions: []string{leftClickStep},
 			want:    false,
 		},
 		{
@@ -286,12 +286,12 @@ func TestBindingInspectionSeesModesInsideRun(t *testing.T) {
 		},
 		{
 			name:           "nested run without a mode",
-			actions:        []string{`run 'run "action left_click"' 'action sleep 0.2'`},
+			actions:        []string{`run 'run leftClickStep' 'action sleep 0.2'`},
 			wantModeSwitch: false,
 		},
 		{
 			name:           "no mode at all",
-			actions:        []string{"action left_click", "exec true"},
+			actions:        []string{leftClickStep, "exec true"},
 			wantModeSwitch: false,
 		},
 		{

--- a/internal/app/ipc_sequence.go
+++ b/internal/app/ipc_sequence.go
@@ -11,10 +11,19 @@ import (
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
 )
 
-// sequenceRunner executes an ordered list of action steps and reports what
-// happened. It is the daemon's action-sequence executor, injected so the IPC
-// layer does not reach back into the App.
-type sequenceRunner func(ctx context.Context, source string, steps []string) sequenceOutcome
+// sequenceRunner executes an ordered list of action steps under a failure
+// policy and reports what happened. It is the daemon's action-sequence
+// executor, injected so the IPC layer does not reach back into the App.
+type sequenceRunner func(
+	ctx context.Context,
+	source string,
+	steps []string,
+	policy sequencePolicy,
+) sequenceOutcome
+
+// stopOnErrorFlag makes every step of a run fatal, so a script does not have to
+// repeat the per-step directive on each one.
+const stopOnErrorFlag = "--stop-on-error"
 
 // IPCControllerSequence handles the "run" command, which executes an action
 // sequence on behalf of an external caller.
@@ -48,7 +57,9 @@ func (h *IPCControllerSequence) RegisterHandlers(
 
 // handleRun executes the steps carried by the command, in order.
 func (h *IPCControllerSequence) handleRun(ctx context.Context, cmd ipc.Command) ipc.Response {
-	steps := nonBlankSteps(cmd.Args)
+	args, policy := splitSequencePolicy(cmd.Args)
+
+	steps := nonBlankSteps(args)
 	if len(steps) == 0 {
 		return ipc.Response{
 			Success: false,
@@ -67,9 +78,17 @@ func (h *IPCControllerSequence) handleRun(ctx context.Context, cmd ipc.Command) 
 
 	h.logger.Debug("Running action sequence", zap.Int("steps", len(steps)))
 
-	outcome := h.run(ctx, domain.CommandRun, steps)
+	outcome := h.run(ctx, domain.CommandRun, steps, policy)
 
 	switch {
+	case outcome.failedIndex == 0 && outcome.err != nil:
+		// The sequence was refused before any step ran, so there is no step to
+		// name — nesting too deeply is the only way to get here today.
+		return ipc.Response{
+			Success: false,
+			Message: "sequence did not run: " + outcome.err.Error(),
+			Code:    ipc.CodeInvalidInput,
+		}
 	case outcome.bailed:
 		return ipc.Response{
 			Success: false,
@@ -81,13 +100,34 @@ func (h *IPCControllerSequence) handleRun(ctx context.Context, cmd ipc.Command) 
 			),
 			Code: ipc.CodeChainBail,
 		}
-	case outcome.err != nil:
+	case outcome.stopped:
+		// Distinct from the case below: the steps after this one did not run,
+		// which a caller deciding what to clean up needs to know.
 		return ipc.Response{
 			Success: false,
 			Message: fmt.Sprintf(
-				"step %d (%s) failed: %s",
+				"sequence stopped at step %d (%s): %s",
 				outcome.failedIndex,
 				outcome.failedStep,
+				outcome.err,
+			),
+			Code: ipc.CodeActionFailed,
+		}
+	case outcome.err != nil:
+		// Only claim the sequence carried on when there was something after
+		// the failing step to carry on to.
+		tail := ""
+		if outcome.executed > outcome.failedIndex {
+			tail = ", later steps still ran"
+		}
+
+		return ipc.Response{
+			Success: false,
+			Message: fmt.Sprintf(
+				"step %d (%s) failed%s: %s",
+				outcome.failedIndex,
+				outcome.failedStep,
+				tail,
 				outcome.err,
 			),
 			Code: ipc.CodeActionFailed,
@@ -99,6 +139,26 @@ func (h *IPCControllerSequence) handleRun(ctx context.Context, cmd ipc.Command) 
 			Code:    ipc.CodeOK,
 		}
 	}
+}
+
+// splitSequencePolicy separates the sequence-wide policy flags from the steps.
+// The flags are consumed here rather than passed on, so a step never sees them.
+func splitSequencePolicy(args []string) ([]string, sequencePolicy) {
+	var policy sequencePolicy
+
+	remaining := make([]string, 0, len(args))
+
+	for _, arg := range args {
+		if strings.TrimSpace(arg) == stopOnErrorFlag {
+			policy.stopOnError = true
+
+			continue
+		}
+
+		remaining = append(remaining, arg)
+	}
+
+	return remaining, policy
 }
 
 // nonBlankSteps trims each step and drops the empty ones, so that a stray

--- a/internal/app/ipc_sequence_test.go
+++ b/internal/app/ipc_sequence_test.go
@@ -24,7 +24,7 @@ func TestHandleRun_RequiresSteps(t *testing.T) {
 	t.Parallel()
 
 	handler := NewIPCControllerSequence(
-		func(context.Context, string, []string) sequenceOutcome {
+		func(context.Context, string, []string, sequencePolicy) sequenceOutcome {
 			t.Fatal("the executor must not run for an empty sequence")
 
 			return sequenceOutcome{}
@@ -59,7 +59,7 @@ func TestHandleRun_PassesTrimmedStepsToExecutor(t *testing.T) {
 	var got []string
 
 	handler := NewIPCControllerSequence(
-		func(_ context.Context, _ string, steps []string) sequenceOutcome {
+		func(_ context.Context, _ string, steps []string, _ sequencePolicy) sequenceOutcome {
 			got = slices.Clone(steps)
 
 			return sequenceOutcome{executed: len(steps)}
@@ -117,7 +117,7 @@ func TestHandleRun_ReportsBailAndFailure(t *testing.T) {
 			t.Parallel()
 
 			handler := NewIPCControllerSequence(
-				func(context.Context, string, []string) sequenceOutcome {
+				func(context.Context, string, []string, sequencePolicy) sequenceOutcome {
 					return testCase.outcome
 				},
 				zap.NewNop(),
@@ -165,5 +165,112 @@ func TestHandleSleepAction_ReleasedOnCancel(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("handleSleepAction() ignored a canceled context")
+	}
+}
+
+// The sequence-wide flag is consumed by the handler, so it never reaches the
+// executor as a step, and it turns on the stop policy.
+func TestHandleRun_StopOnErrorFlagIsAPolicyNotAStep(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotSteps  []string
+		gotPolicy sequencePolicy
+	)
+
+	handler := NewIPCControllerSequence(
+		func(_ context.Context, _ string, steps []string, policy sequencePolicy) sequenceOutcome {
+			gotSteps = slices.Clone(steps)
+			gotPolicy = policy
+
+			return sequenceOutcome{executed: len(steps)}
+		},
+		zap.NewNop(),
+	)
+
+	resp := handler.handleRun(context.Background(), ipc.Command{
+		Args: []string{stopOnErrorFlag, leftClickStep, hintsStep},
+	})
+
+	if !resp.Success {
+		t.Fatalf("handleRun() = %+v, want success", resp)
+	}
+
+	if !gotPolicy.stopOnError {
+		t.Fatal("policy.stopOnError = false, want the flag to enable it")
+	}
+
+	want := []string{leftClickStep, hintsStep}
+	if !slices.Equal(gotSteps, want) {
+		t.Fatalf("executor received %v, want %v", gotSteps, want)
+	}
+}
+
+func TestHandleRun_StopOnErrorAloneIsNotASequence(t *testing.T) {
+	t.Parallel()
+
+	handler := NewIPCControllerSequence(
+		func(context.Context, string, []string, sequencePolicy) sequenceOutcome {
+			t.Fatal("the executor must not run when the flag is the only argument")
+
+			return sequenceOutcome{}
+		},
+		zap.NewNop(),
+	)
+
+	resp := handler.handleRun(context.Background(), ipc.Command{Args: []string{stopOnErrorFlag}})
+
+	if resp.Success || resp.Code != ipc.CodeInvalidInput {
+		t.Fatalf("handleRun() = %+v, want an invalid-input failure", resp)
+	}
+}
+
+// A sequence refused before it started has no step to point at, so the report
+// must not invent one.
+func TestHandleRun_ReportsASequenceThatNeverStarted(t *testing.T) {
+	t.Parallel()
+
+	handler := NewIPCControllerSequence(
+		func(context.Context, string, []string, sequencePolicy) sequenceOutcome {
+			return sequenceOutcome{
+				err:     derrors.New(derrors.CodeInvalidInput, "action sequence nested too deeply"),
+				stopped: true,
+			}
+		},
+		zap.NewNop(),
+	)
+
+	resp := handler.handleRun(context.Background(), ipc.Command{Args: []string{leftClickStep}})
+
+	if resp.Success || resp.Code != ipc.CodeInvalidInput {
+		t.Fatalf("handleRun() = %+v, want an invalid-input failure", resp)
+	}
+
+	if strings.Contains(resp.Message, "step 0") {
+		t.Fatalf("message %q names a step that does not exist", resp.Message)
+	}
+}
+
+// "later steps still ran" must only appear when there were later steps: a
+// tolerated failure on the final step leaves nothing after it.
+func TestHandleRun_DoesNotClaimLaterStepsRanWhenThereWereNone(t *testing.T) {
+	t.Parallel()
+
+	handler := NewIPCControllerSequence(
+		func(context.Context, string, []string, sequencePolicy) sequenceOutcome {
+			return sequenceOutcome{
+				err:         derrors.New(derrors.CodeIPCFailed, "boom"),
+				failedStep:  leftClickStep,
+				failedIndex: 1,
+				executed:    1,
+			}
+		},
+		zap.NewNop(),
+	)
+
+	resp := handler.handleRun(context.Background(), ipc.Command{Args: []string{leftClickStep}})
+
+	if strings.Contains(resp.Message, "later steps still ran") {
+		t.Fatalf("message %q claims steps ran after the last one", resp.Message)
 	}
 }

--- a/internal/app/sequence.go
+++ b/internal/app/sequence.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"go.uber.org/zap"
@@ -38,22 +39,92 @@ func withSequenceDepth(ctx context.Context, depth int) context.Context {
 	return context.WithValue(ctx, sequenceDepthKey{}, depth)
 }
 
+// bailOnErrorFlag marks a step whose failure ends the sequence. It is a
+// sequencing directive rather than an action flag: the executor consumes it,
+// and the step is dispatched without it.
+const bailOnErrorFlag = "--bail-on-error"
+
 // sequenceOutcome reports what an action sequence did. Callers that answer a
 // client (the "run" command) turn it into a response; callers that answer
 // nobody (hotkeys) ignore it and rely on the logging done here.
 type sequenceOutcome struct {
-	// err is the bail error when bailed is set, otherwise the first step error.
+	// err is the error that stopped the sequence when it stopped early,
+	// otherwise the first step error.
 	err error
 	// failedStep is the step text that produced err.
 	failedStep string
 	// failedIndex is the 1-based position of failedStep among the steps that
-	// ran. Reporting needs it separately from executed, because a non-bailing
-	// failure does not stop the sequence.
+	// ran. Reporting needs it separately from executed, because a failure that
+	// does not stop the sequence still leaves later steps to run.
 	failedIndex int
-	// executed counts the steps that ran, including one that failed or bailed.
+	// executed counts how far into the sequence execution reached, including a
+	// step that failed, bailed, or was rejected before it could run.
 	executed int
-	// bailed reports whether a step asked the sequence to stop early.
+	// bailed reports whether a step asked the sequence to stop by reporting
+	// CodeChainBail — a canceled mode rather than a fault.
 	bailed bool
+	// stopped reports whether the sequence ended before its last step, whether
+	// through a bail or a failure the step marked as fatal.
+	stopped bool
+}
+
+// sequencePolicy describes how a sequence treats a failing step.
+//
+// A policy applies to the steps of one sequence and does not cross into a
+// nested one: a step that is itself a "run" carries whatever policy that run
+// was given. The nested sequence's failure is still reported to the outer one,
+// so an outer stop-on-error still stops there.
+type sequencePolicy struct {
+	// stopOnError makes every step fatal, as if each carried the per-step
+	// directive. It is what "run --stop-on-error" applies.
+	stopOnError bool
+}
+
+// splitBailOnError separates the trailing bail-on-error directive from a step.
+//
+// The directive is recognized only as the final unquoted token, so a step that
+// merely carries the text as an argument keeps it: both
+// `exec sh -c "echo --bail-on-error"` and `exec printf '--bail-on-error'` are
+// passed through untouched.
+//
+// The directive anywhere else is an error rather than a silent pass-through.
+// Left in place it would reach the action's own flag parser, which reports
+// "invalid or missing flag value" without naming the flag — a much worse
+// message than saying where the directive belongs.
+func splitBailOnError(step string) (string, bool, error) {
+	step = strings.TrimSpace(step)
+
+	// Almost no step mentions the directive, and this runs for every step of
+	// every sequence, including on the key-press path. Reject the common case
+	// before tokenizing.
+	if !strings.Contains(step, bailOnErrorFlag) {
+		return step, false, nil
+	}
+
+	tokens := splitArgs(step)
+	if len(tokens) < 2 { //nolint:mnd // a lone directive is not a step.
+		return step, false, nil
+	}
+
+	if tokens[len(tokens)-1] == bailOnErrorFlag {
+		// A quoted final token leaves the step not ending in the bare text.
+		// The author wrote it as an argument, so hand it over as one.
+		if !strings.HasSuffix(step, bailOnErrorFlag) {
+			return step, false, nil
+		}
+
+		return strings.TrimSpace(strings.TrimSuffix(step, bailOnErrorFlag)), true, nil
+	}
+
+	if slices.Contains(tokens, bailOnErrorFlag) {
+		return step, false, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"%s must come last in a step",
+			bailOnErrorFlag,
+		)
+	}
+
+	return step, false, nil
 }
 
 // executeActionSequence runs steps in order through the hotkey action grammar
@@ -61,9 +132,12 @@ type sequenceOutcome struct {
 //
 // This is the only place sequencing is implemented. Global hotkeys, per-mode
 // hotkeys, held-key repeat, a mode's --on-exit, and the "run" command all
-// funnel through it, so a sequence behaves the same wherever it is written. A
-// step that reports CodeChainBail stops the sequence; any other failure is
-// reported and the remaining steps still run.
+// funnel through it, so a sequence behaves the same wherever it is written.
+//
+// A step that reports CodeChainBail stops the sequence. Any other failure is
+// reported and the remaining steps still run, unless the step was marked
+// fatal — with the trailing --bail-on-error directive, or by a policy that
+// marks every step — in which case the sequence stops there.
 //
 // Steps execute against the app context rather than against ctx, so a blocking
 // step (wait_for_mode_exit) is still released at shutdown. The nesting depth is
@@ -73,10 +147,24 @@ func (a *App) executeActionSequence(
 	source string,
 	steps []string,
 ) sequenceOutcome {
+	return a.executeActionSequenceWithPolicy(ctx, source, steps, sequencePolicy{})
+}
+
+// executeActionSequenceWithPolicy is executeActionSequence with an explicit
+// failure policy, for callers that set one for the whole sequence.
+func (a *App) executeActionSequenceWithPolicy(
+	ctx context.Context,
+	source string,
+	steps []string,
+	policy sequencePolicy,
+) sequenceOutcome {
 	var outcome sequenceOutcome
 
 	depth := sequenceDepth(ctx)
 	if depth >= maxSequenceDepth {
+		// Nothing ran, so there is no step to point at: executed and
+		// failedIndex stay zero and reporting says the sequence never started.
+		outcome.stopped = true
 		outcome.err = derrors.Newf(
 			derrors.CodeInvalidInput,
 			"action sequence nested deeper than %d levels",
@@ -98,22 +186,41 @@ func (a *App) executeActionSequence(
 			continue
 		}
 
+		dispatchStep, stepIsFatal, directiveErr := splitBailOnError(trimmedStep)
+		stepIsFatal = stepIsFatal || policy.stopOnError
+
 		outcome.executed++
 
-		stepErr := a.executeHotkeyAction(stepCtx, source, trimmedStep)
+		stepErr := directiveErr
+		if stepErr == nil {
+			stepErr = a.executeHotkeyAction(stepCtx, source, dispatchStep)
+		}
+
 		if stepErr == nil {
 			continue
 		}
 
-		if derrors.IsCode(stepErr, derrors.CodeChainBail) {
-			outcome.bailed = true
+		bailed := derrors.IsCode(stepErr, derrors.CodeChainBail)
+
+		// A malformed directive is always fatal: the step never ran, and
+		// carrying on would act on a sequence the author did not write.
+		if bailed || stepIsFatal || directiveErr != nil {
+			outcome.bailed = bailed
+			outcome.stopped = true
 			outcome.err = stepErr
 			outcome.failedStep = trimmedStep
 			outcome.failedIndex = outcome.executed
 
-			a.logger.Debug("Action sequence bailed",
-				zap.String("source", source),
-				zap.Int("step", outcome.executed))
+			if bailed {
+				a.logger.Debug("Action sequence bailed",
+					zap.String("source", source),
+					zap.Int("step", outcome.executed))
+			} else {
+				a.logger.Error("Action sequence stopped at a failed step",
+					zap.String("source", source),
+					zap.String("action", trimmedStep),
+					zap.Error(stepErr))
+			}
 
 			return outcome
 		}

--- a/internal/app/sequence_test.go
+++ b/internal/app/sequence_test.go
@@ -21,6 +21,8 @@ import (
 const (
 	sequenceTestCommand = "step"
 
+	failureMessage = "boom"
+
 	stepOne   = "step one"
 	stepTwo   = "step two"
 	stepThree = "step three"
@@ -235,5 +237,165 @@ func TestExecuteActionSequence_StopsRunawayNesting(t *testing.T) {
 
 	if depth != maxSequenceDepth {
 		t.Fatalf("nested %d levels, want the guard to stop at %d", depth, maxSequenceDepth)
+	}
+}
+
+// A step marked fatal ends the sequence, while an unmarked failure beside it
+// does not — that is the whole point of making the policy explicit per step.
+func TestExecuteActionSequence_StopsAtAFatalStep(t *testing.T) {
+	recorder := &stepRecorder{
+		respond: func(_ context.Context, step string) ipc.Response {
+			if step == stepTwo {
+				return ipc.Response{
+					Success: false,
+					Message: failureMessage,
+					Code:    ipc.CodeActionFailed,
+				}
+			}
+
+			return ipc.Response{Success: true, Code: ipc.CodeOK}
+		},
+	}
+	application := newSequenceTestApp(t, recorder)
+
+	outcome := application.executeActionSequence(
+		context.Background(),
+		"test",
+		[]string{stepOne, stepTwo + " " + bailOnErrorFlag, stepThree},
+	)
+
+	if !outcome.stopped {
+		t.Fatal("outcome.stopped = false, want the sequence to end at the fatal step")
+	}
+
+	if outcome.bailed {
+		t.Fatal("outcome.bailed = true, want false: a failure is not a chain bail")
+	}
+
+	// The directive is a sequencing instruction, so the step must be dispatched
+	// without it — the action's own flag parser would reject it.
+	want := []string{stepOne, stepTwo}
+	if got := recorder.recorded(); !slices.Equal(got, want) {
+		t.Fatalf("dispatched %v, want %v", got, want)
+	}
+}
+
+func TestExecuteActionSequence_StopOnErrorPolicyMarksEveryStep(t *testing.T) {
+	recorder := &stepRecorder{
+		respond: func(_ context.Context, step string) ipc.Response {
+			if step == stepOne {
+				return ipc.Response{
+					Success: false,
+					Message: failureMessage,
+					Code:    ipc.CodeActionFailed,
+				}
+			}
+
+			return ipc.Response{Success: true, Code: ipc.CodeOK}
+		},
+	}
+	application := newSequenceTestApp(t, recorder)
+
+	outcome := application.executeActionSequenceWithPolicy(
+		context.Background(),
+		"test",
+		[]string{stepOne, stepTwo},
+		sequencePolicy{stopOnError: true},
+	)
+
+	if !outcome.stopped || outcome.executed != 1 {
+		t.Fatalf("stopped = %v after %d steps, want a stop at the first",
+			outcome.stopped, outcome.executed)
+	}
+}
+
+func TestSplitBailOnError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		step      string
+		wantStep  string
+		wantFatal bool
+		wantErr   bool
+	}{
+		{
+			name:      "trailing directive is consumed",
+			step:      "action left_click " + bailOnErrorFlag,
+			wantStep:  leftClickStep,
+			wantFatal: true,
+		},
+		{
+			name:     "no directive",
+			step:     leftClickStep,
+			wantStep: leftClickStep,
+		},
+		{
+			// The text appears inside a quoted argument, so it belongs to the
+			// step rather than to the sequence.
+			name:     "quoted text is not a directive",
+			step:     `exec sh -c "echo ` + bailOnErrorFlag + `"`,
+			wantStep: `exec sh -c "echo ` + bailOnErrorFlag + `"`,
+		},
+		{
+			// Quoted as the final argument: the author wants the text, not the
+			// directive, so the step must reach the action unchanged.
+			name:     "quoted final token is an argument",
+			step:     `exec printf '` + bailOnErrorFlag + `'`,
+			wantStep: `exec printf '` + bailOnErrorFlag + `'`,
+		},
+		{
+			name:    "directive in the middle is rejected",
+			step:    "action left_click " + bailOnErrorFlag + " --bare",
+			wantErr: true,
+		},
+		{
+			name:     "directive alone is not a step",
+			step:     bailOnErrorFlag,
+			wantStep: bailOnErrorFlag,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotStep, gotFatal, gotErr := splitBailOnError(testCase.step)
+
+			if (gotErr != nil) != testCase.wantErr {
+				t.Fatalf("error = %v, wantErr = %v", gotErr, testCase.wantErr)
+			}
+
+			if testCase.wantErr {
+				return
+			}
+
+			if gotStep != testCase.wantStep || gotFatal != testCase.wantFatal {
+				t.Fatalf("splitBailOnError(%q) = (%q, %v), want (%q, %v)",
+					testCase.step, gotStep, gotFatal, testCase.wantStep, testCase.wantFatal)
+			}
+		})
+	}
+}
+
+// A misplaced directive must not be dispatched as though it were part of the
+// action, because the action's flag parser would reject it with a message that
+// says nothing about sequencing.
+func TestExecuteActionSequence_RejectsMisplacedDirective(t *testing.T) {
+	recorder := &stepRecorder{}
+	application := newSequenceTestApp(t, recorder)
+
+	outcome := application.executeActionSequence(
+		context.Background(),
+		"test",
+		[]string{stepOne + " " + bailOnErrorFlag + " --bare", stepTwo},
+	)
+
+	if !outcome.stopped || outcome.err == nil {
+		t.Fatalf("outcome = %+v, want a stop with an error", outcome)
+	}
+
+	if got := recorder.recorded(); len(got) != 0 {
+		t.Fatalf("dispatched %v, want nothing: the step was never valid", got)
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -25,19 +25,34 @@ step that asks the sequence to stop — "action wait_for_mode_exit --bail" after
 the mode was canceled — ends it; any other failing step is reported while the
 remaining steps still run.
 
+To stop at a failure instead, end that step with --bail-on-error, or pass
+--stop-on-error to make every step in the sequence fatal.
+
 Sequences that block (sleeps, waits) can outlast the default IPC timeout. Raise
 it for those: neru --timeout 60 run ...
 
 Examples:
   neru run "action save_cursor_pos" hints
   neru run "action left_click" "action sleep 0.2" "action restore_cursor_pos"
-  neru run "hints --action left_click" "action wait_for_mode_exit --bail" "exec say done"`,
+  neru run "hints --action left_click" "action wait_for_mode_exit --bail" "exec say done"
+  neru run "action left_click --bail-on-error" idle
+  neru run --stop-on-error "action left_click" "action restore_cursor_pos"`,
 	Args: validateRunArgs,
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return requiresRunningInstance()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return sendCommand(cmd, domain.CommandRun, args)
+		stopOnError, err := cmd.Flags().GetBool("stop-on-error")
+		if err != nil {
+			return err
+		}
+
+		params := args
+		if stopOnError {
+			params = append([]string{"--stop-on-error"}, args...)
+		}
+
+		return sendCommand(cmd, domain.CommandRun, params)
 	},
 }
 
@@ -61,5 +76,11 @@ func validateRunArgs(_ *cobra.Command, args []string) error {
 }
 
 func init() {
+	RunCmd.Flags().Bool(
+		"stop-on-error",
+		false,
+		"Stop the sequence at the first failing step, as if every step ended with --bail-on-error",
+	)
+
 	RootCmd.AddCommand(RunCmd)
 }


### PR DESCRIPTION
## Description

This PR lets a sequence stop at a failing step instead of always carrying on.

Until now every failure was tolerated: the step was reported and the sequence continued. The auto-exit binding the docs recommend, `["action left_click", "idle"]`, therefore leaves the mode even when the click never landed, and running the same steps from a script gave an exit status that disagreed with the side effects — it said "failed" while every later step had already run.

A step can now be marked fatal, and a whole sequence can be marked in one go. This works anywhere a sequence does: a hotkey binding, a mode's `--on-exit`, or the command line. The default is unchanged, so no existing configuration behaves differently unless it opts in.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature

## Command and configuration changes

**New step directive**

| Directive | Where | Description |
| --- | --- | --- |
| `--bail-on-error` | End of any step, in any sequence | The sequence stops if that step fails. Consumed by the daemon; the step itself runs without it. |

```toml
[hints.hotkeys]
# Exit only if the click actually landed.
"Shift+L" = ["action left_click --bail-on-error", "idle"]
```

It must be the last thing in the step. Placed anywhere else it is refused with `--bail-on-error must come last in a step`. Text that merely looks like the directive is left alone, so both `exec sh -c "echo --bail-on-error"` and `exec printf '--bail-on-error'` still pass it through as an argument.

**New flag**

| Flag | Command | Type | Default | Description |
| --- | --- | --- | --- | --- |
| `--stop-on-error` | `neru run` | bool | `false` | Marks every step fatal, so a script need not repeat the directive. |

```bash
neru run --stop-on-error "action left_click" "action restore_cursor_pos"
```

The flag also works when `run` is used inside a hotkey binding (`"run --stop-on-error 'action left_click' idle"`). It applies to the steps of that one sequence and does not cross into a nested `run`, though a nested sequence's failure is still reported outward, so an outer stop still stops.

Existing configs keep working untouched: without the directive or the flag, a failing step is reported and the sequence carries on exactly as before.

## Potentially breaking

Both are narrow, and both are judgement calls worth a second opinion.

- **A step that ends with the literal text `--bail-on-error` changes meaning.** `exec echo --bail-on-error` previously passed the word to `echo`; it is now read as the directive and `exec echo` runs with nothing. Quoting it (`exec echo '--bail-on-error'`) restores the old behaviour. Hard to imagine in a real config, but it is the same input meaning something different.
- **`neru run` failure messages changed, and one exit code with them.** A tolerated failure now reads `step N (…) failed, later steps still ran: …`, a stopped one `sequence stopped at step N (…): …`. A sequence refused before it started reports `sequence did not run: …` with `ERR_INVALID_INPUT` where it previously produced a malformed `step 0 () failed …` with `ERR_ACTION_FAILED`. Anything parsing that output — rather than the exit status, which is unchanged — needs adjusting.

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no platform-specific code in this change
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new platform capability
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Why the daemon consumes the directive.** Actions reject flags they do not recognise, so a sequencing instruction left in the step would fail inside the action. Recognition is quote-aware — only a final unquoted token counts — which is what keeps a step that carries the text as an argument working.

**Why a misplaced directive is refused by name.** Measured the alternative first: leaving it in place gives `invalid or missing flag value`, which does not even say which flag. The explicit message costs a few lines and points at the fix.

**Why the default was not flipped.** "Stop on failure" is probably what most people want, and now that the opt-in exists the switch is a one-line change. It would alter behaviour for every shipped config, though, so it is a versioning decision rather than one to fold in here.

**Review findings, fixed before this PR.** A quoted final argument was being misread as the directive; a sequence refused before starting reported a non-existent "step 0"; the "later steps still ran" clause was printed even when the failure was on the last step; and the directive check tokenised every step of every sequence, including on the key press path, where a substring test now short-circuits it.

**Verification beyond the test suite.** Driven against a running daemon started with an empty `[hotkeys]` table: the default tolerating a failure, the per-step directive stopping one, `--stop-on-error` stopping the whole sequence, the flag placed after the steps, a quoted argument passing through intact, a misplaced directive refused with nothing dispatched, and the flag alone rejected at the CLI. A config using both spellings validates clean. `SIGTERM` during an in-flight `action sleep 45s` still exits the daemon immediately and releases the step. Race detector clean across the touched packages.
