### PR TITLE
feat(config): add `[macros]` for named, reusable action sequences

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -45,6 +45,17 @@ text = "#E8EEFF"
 "Primary+Shift+C" = "recursive_grid"
 "Primary+Shift+S" = "scroll"
 
+# Macros — named action sequences, reused from any binding.
+# Written by hand, not recorded. $1, $2 ... are the call's arguments.
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#macros
+#
+# [macros]
+# click_and_exit = ["action left_click --bail-on-error", "idle"]
+# click_at = ["action move_mouse --x $1 --y $2", "action left_click"]
+#
+# [hints.hotkeys]
+# "Enter" = "macro click_and_exit"
+
 # Hint mode
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#hints
 [hints]

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -876,8 +876,9 @@ neru run <step> [step...]
 
 Each argument is one step, written exactly as it would be written in a hotkey
 binding: an action (`action left_click`), a mode (`hints --action left_click`),
-or a shell command (`exec open -a Safari`). The daemon executes the steps in
-order.
+a shell command (`exec open -a Safari`), or a named sequence from the
+[`[macros]`](CONFIGURATION.md#macros) table (`macro window_click 100 70`). The
+daemon executes the steps in order.
 
 This is the same executor that runs a multi-action hotkey binding, so a
 sequence behaves identically whether it is written in `[hotkeys]`, passed to
@@ -929,6 +930,11 @@ neru run --stop-on-error "action left_click" "action restore_cursor_pos"
 It works in any sequence — a hotkey binding, a mode's `--on-exit`, or `neru run`.
 Text that merely looks like the directive is left alone, so
 `exec sh -c "echo --bail-on-error"` still passes it through to the shell.
+
+The policy applies to the steps of one sequence. A step that runs a nested
+sequence — another `run`, or a [`macro`](CONFIGURATION.md#macros) — keeps its
+own policy inside; its overall failure is then reported to the caller as that
+one step failing, which an outer `--stop-on-error` or `--bail-on-error` acts on.
 
 A stopped sequence reports which step ended it and that the later steps did not
 run; a tolerated failure says the opposite, so the two are distinguishable by a

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -30,6 +30,7 @@ keeps its default. "The daemon" below means the process started by
 
 | Section                                       | Controls                                     |
 | --------------------------------------------- | -------------------------------------------- |
+| [`[macros]`](#macros)                         | Named action sequences reused across bindings |
 | [`[general]`](#general)                       | Global behaviour, passthrough, `exec` shell   |
 | [`[theme]`](#theme)                           | Base palette all components derive from       |
 | [`[hints]`](#hints)                           | Hints mode and element discovery              |
@@ -564,6 +565,70 @@ An array like the ones above is an *action sequence*. The same sequence, with th
 ---
 
 # Sections
+
+## [macros]
+
+Named action sequences. A macro is written once and invoked from any binding
+with `macro <name> [args...]`, which keeps a sequence used by several keys in
+one place instead of copied across them.
+
+These are written, not recorded: there is nothing to capture and replay, unlike
+the macros of a text editor. A macro is a named list of the same steps you would
+otherwise inline into the binding, with positional arguments.
+
+```toml
+[macros]
+# No arguments.
+click_and_exit = ["action left_click --bail-on-error", "idle"]
+
+# $1 and $2 are the first and second argument of the call.
+window_click = [
+    "action move_mouse --window --x -1000 --y -1000",
+    "action sleep 0.1",
+    "action move_mouse_relative --dx $1 --dy $2",
+    "action left_click",
+]
+
+[hints.hotkeys]
+"Enter" = "macro click_and_exit"
+
+[[app_configs]]
+bundle_id = "com.anthropic.claudefordesktop"
+hotkeys = { "Cmd+1" = "macro window_click 100 70" }
+```
+
+**Names** use letters, digits, `_` and `-`, and start with a letter.
+
+**Arguments** are positional: `$1`, `$2`, and so on, with `$$` for a literal
+dollar sign. Substitution is textual and happens before the step is split into
+arguments, so quote a placeholder that may contain spaces — `exec say "$1"` —
+exactly as you would in a shell.
+
+**Arity is checked when the config loads.** A call must pass exactly as many
+arguments as the body uses; an unknown name or the wrong count fails
+`neru config validate` rather than doing nothing when the key is pressed.
+
+The check reaches everywhere an action can be written: `[hotkeys]`, every
+`[<mode>.hotkeys]` table, the per-app overrides of both, the
+[Mission Control hooks](#hints), a macro body, and the steps carried inside a
+`run` or an `--on-exit`. So does the ordinary check that a step names a real
+command — a step is validated at whatever depth it appears.
+
+**A placeholder belongs in an argument, not in the command word.** A body step
+like `"$1 --action left_click"` is rejected at load, because a step whose
+command is only known at call time could not be validated at all.
+
+**A macro body is a sequence** like any other, so it can use
+[`--bail-on-error`](CLI.md#failure-policy), and it can call another macro. A
+macro that reaches itself is stopped by the same nesting limit that bounds
+`run` — five levels — rather than recursing.
+
+**A macro runs as a nested sequence**, so a failure inside it is reported to the
+caller as that one step failing. Mark the call with `--bail-on-error` when the
+rest of the calling sequence should not continue past it.
+
+Macros are not accepted as a mode's `--action`, which takes a mouse button
+name; use `--on-exit` for a sequence that follows the action.
 
 ## [general]
 

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -337,13 +337,24 @@ hotkeys = { "Cmd+1" = ["hints --role button --text Home --action left_click", "a
 
 Putting it together, a Claude view switcher scopes three keys to the app. `Cmd+1`, `Cmd+2`, and `Cmd+3` click the Home, Code, and Cowork buttons, each nudged to a different offset from the window's top-left corner:
 
+Only the offsets differ between the three, so name the sequence once in [`[macros]`](CONFIGURATION.md#macros) and pass them in:
+
 ```toml
+[macros]
+window_click = [
+    "action move_mouse --window --x -1000 --y -1000",
+    "action sleep 0.1",
+    "action move_mouse_relative --dx $1 --dy $2",
+    "action sleep 0.1",
+    "action left_click",
+]
+
 [[app_configs]]
 bundle_id = "com.anthropic.claudefordesktop"
 hotkeys = {
-    "Cmd+1" = ["action move_mouse --window --x -1000 --y -1000", "action sleep 0.1", "action move_mouse_relative --dx 100 --dy 70", "action sleep 0.1", "action left_click"],
-    "Cmd+2" = ["action move_mouse --window --x -1000 --y -1000", "action sleep 0.1", "action move_mouse_relative --dx 250 --dy 70", "action sleep 0.1", "action left_click"],
-    "Cmd+3" = ["action move_mouse --window --x -1000 --y -1000", "action sleep 0.1", "action move_mouse_relative --dx 400 --dy 70", "action sleep 0.1", "action left_click"]
+    "Cmd+1" = "macro window_click 100 70",
+    "Cmd+2" = "macro window_click 250 70",
+    "Cmd+3" = "macro window_click 400 70"
 }
 ```
 

--- a/internal/app/hotkeys.go
+++ b/internal/app/hotkeys.go
@@ -25,19 +25,19 @@ func actionsReferenceDisabledMode(actions []string, cfg *config.Config) bool {
 	gridStr := domain.ModeString(domain.ModeGrid)
 
 	recursiveGridStr := domain.ModeString(domain.ModeRecursiveGrid)
-	for _, actionStr := range flattenRunSteps(actions) {
-		mode := commandOf(actionStr)
-		switch {
+
+	return anyBindingStep(actions, cfg, func(step string) bool {
+		switch mode := commandOf(step); {
 		case mode == hintsStr && !cfg.Hints.Enabled:
 			return true
 		case mode == gridStr && !cfg.Grid.Enabled:
 			return true
 		case mode == recursiveGridStr && !cfg.RecursiveGrid.Enabled:
 			return true
+		default:
+			return false
 		}
-	}
-
-	return false
+	})
 }
 
 // registerHotkeys registers global hotkeys for the specified app bundle ID.
@@ -136,7 +136,7 @@ func (a *App) dispatchModeAwareHotkeyAsync(key string, globalActions []string) {
 
 		// Suppress hotkey modifiers synchronously so the per-mode event tap
 		// sees them as suppressed before the debounce timer can fire.
-		if actionsContainModeSwitch(actions) {
+		if actionsContainModeSwitch(actions, a.configSnapshot()) {
 			a.modes.SuppressModifiersForHotkey(hotkeyModifiersFromKey(key))
 		}
 	}
@@ -171,7 +171,7 @@ func (a *App) dispatchModeAwareHeldHotkey(key string, globalActions []string) {
 	// Suppress hotkey modifiers synchronously so the per-mode event tap
 	// sees them as suppressed before the debounce timer can fire.
 	// This must happen before the async dispatch or startHotkeyRepeat.
-	if a.modes != nil && actionsContainModeSwitch(actions) {
+	if a.modes != nil && actionsContainModeSwitch(actions, a.configSnapshot()) {
 		a.modes.SuppressModifiersForHotkey(hotkeyModifiersFromKey(key))
 	}
 
@@ -343,21 +343,21 @@ func hotkeyModifiersFromKey(key string) action.Modifiers {
 
 // actionsContainModeSwitch reports whether any action in the list is a
 // mode-switch action (hints, grid, recursive_grid, scroll, monitor_select).
-func actionsContainModeSwitch(actions []string) bool {
-	for _, actionStr := range flattenRunSteps(actions) {
+func actionsContainModeSwitch(actions []string, cfg *config.Config) bool {
+	return anyBindingStep(actions, cfg, func(step string) bool {
 		// The action format is "<mode_name>" with optional args, so split
 		// to get just the mode name for comparison.
-		switch commandOf(actionStr) {
+		switch commandOf(step) {
 		case domain.ModeString(domain.ModeHints),
 			domain.ModeString(domain.ModeGrid),
 			domain.ModeString(domain.ModeRecursiveGrid),
 			domain.ModeString(domain.ModeScroll),
 			domain.ModeString(domain.ModeMonitorSelect):
 			return true
+		default:
+			return false
 		}
-	}
-
-	return false
+	})
 }
 
 // commandOf returns the command word of an action string, ignoring its flags.
@@ -371,86 +371,102 @@ func commandOf(actionStr string) string {
 	return fields[0]
 }
 
-// flattenRunSteps expands "run <step>..." so that callers which inspect what a
-// binding does — mode-switch detection, disabled-mode skipping — see the steps
-// a run carries rather than the word "run". Blank actions are dropped.
+// maxInspectedSteps bounds how many steps a binding inspection will look at.
 //
-// Expansion follows nesting as deep as the executor will, so a mode named below
-// the first run is not invisible to those checks.
-func flattenRunSteps(actions []string) []string {
-	return flattenRunStepsAtDepth(actions, 0)
+// Expansion follows nested sequences, and a binding whose macros fan out into
+// each other multiplies at every level. That is a config nobody writes on
+// purpose, but the inspection runs on the key-press path, so it is bounded
+// rather than trusted: past the budget the answer is "no mode named here",
+// the same conclusion drawn for anything else that cannot be expanded.
+const maxInspectedSteps = 256
+
+// anyBindingStep reports whether pred holds for any step the binding will run,
+// looking inside the sequence constructs ("run", "macro") as deep as the
+// executor will follow them.
+//
+// It walks rather than expanding into a slice, so a match short-circuits and
+// nothing accumulates in memory — both callers only ever need the first hit.
+func anyBindingStep(actions []string, cfg *config.Config, pred func(step string) bool) bool {
+	budget := maxInspectedSteps
+
+	return anyBindingStepAtDepth(actions, cfg, 0, &budget, pred)
 }
 
-// flattenRunStepsAtDepth expands the steps of one sequence, recursing into a
-// nested run until maxSequenceDepth. Past that depth the executor refuses to
-// start the sequence, so its steps never run and are left unexpanded — the
-// unexpanded "run ..." names no mode, which is exactly what the callers should
-// conclude about it.
-func flattenRunStepsAtDepth(actions []string, depth int) []string {
-	flattened := make([]string, 0, len(actions))
-
+// anyBindingStepAtDepth walks the steps of one sequence, recursing into nested
+// ones until maxSequenceDepth. Past that depth the executor refuses to start
+// the sequence, so its steps never run and the construct is left unexpanded.
+func anyBindingStepAtDepth(
+	actions []string,
+	cfg *config.Config,
+	depth int,
+	budget *int,
+	pred func(step string) bool,
+) bool {
 	for _, actionStr := range actions {
 		trimmed := strings.TrimSpace(actionStr)
 		if trimmed == "" {
 			continue
 		}
 
-		if depth >= maxSequenceDepth || commandOf(trimmed) != domain.CommandRun {
-			flattened = append(flattened, trimmed)
+		if *budget <= 0 {
+			return false
+		}
+
+		*budget--
+
+		nested := nestedSteps(trimmed, cfg, depth)
+		if nested == nil {
+			if pred(trimmed) {
+				return true
+			}
 
 			continue
 		}
 
-		// splitArgs applies the same quoting rules the executor uses, so the
-		// steps seen here are the steps that will run.
-		flattened = append(
-			flattened,
-			flattenRunStepsAtDepth(splitArgs(trimmed)[1:], depth+1)...,
-		)
-	}
-
-	return flattened
-}
-
-func splitArgs(input string) []string {
-	var args []string
-
-	var current strings.Builder
-
-	inSingleQuote := false
-	inDoubleQuote := false
-
-	for _, char := range input {
-		switch char {
-		case '\'':
-			if !inDoubleQuote {
-				inSingleQuote = !inSingleQuote
-			} else {
-				current.WriteRune(char)
-			}
-		case '"':
-			if !inSingleQuote {
-				inDoubleQuote = !inDoubleQuote
-			} else {
-				current.WriteRune(char)
-			}
-		case ' ':
-			if inSingleQuote || inDoubleQuote {
-				current.WriteRune(char)
-			} else if current.Len() > 0 {
-				args = append(args, current.String())
-				current.Reset()
-			}
-		default:
-			current.WriteRune(char)
+		if anyBindingStepAtDepth(nested, cfg, depth+1, budget, pred) {
+			return true
 		}
 	}
 
-	if current.Len() > 0 {
-		args = append(args, current.String())
+	return false
+}
+
+// nestedSteps returns the steps a "run" or "macro" step carries, or nil when
+// the step is an ordinary action or cannot be expanded — an unknown macro, or
+// nesting the executor would refuse anyway.
+func nestedSteps(step string, cfg *config.Config, depth int) []string {
+	if depth >= maxSequenceDepth {
+		return nil
 	}
 
-	return args
+	// splitArgs applies the same quoting rules the executor uses, so the steps
+	// seen here are the steps that will run.
+	switch commandOf(step) {
+	case domain.CommandRun:
+		return splitArgs(step)[1:]
+	case config.MacroCommand:
+		if cfg == nil {
+			return nil
+		}
+
+		name, args, _ := config.ParseMacroCall(step)
+
+		body, defined := cfg.Macros[name]
+		if !defined {
+			return nil
+		}
+
+		return config.ExpandMacroSteps(body, args)
+	default:
+		return nil
+	}
+}
+
+// splitArgs tokenises an action step. The rules belong to the step grammar
+// rather than to the hotkey layer, so they live in the config package, which
+// also needs them to read macro calls during validation.
+func splitArgs(input string) []string {
+	return config.SplitStepArgs(input)
 }
 
 // executeHotkeyAction executes a single action step, which can be either a

--- a/internal/app/hotkeys_test.go
+++ b/internal/app/hotkeys_test.go
@@ -2,7 +2,6 @@
 package app
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/config"
@@ -257,6 +256,12 @@ func TestHotkeyActionsRepeatWhileHeldDisabled(t *testing.T) {
 func TestBindingInspectionSeesModesInsideRun(t *testing.T) {
 	t.Parallel()
 
+	cfg := config.DefaultConfig()
+	cfg.Macros = map[string]config.StringOrStringArray{
+		"open_hints": {"action save_cursor_pos", hintsStep},
+		"just_click": {leftClickStep},
+	}
+
 	tests := []struct {
 		name           string
 		actions        []string
@@ -278,6 +283,23 @@ func TestBindingInspectionSeesModesInsideRun(t *testing.T) {
 			name:           "mode inside a nested run",
 			actions:        []string{`run 'run "hints"' 'action left_click'`},
 			wantModeSwitch: true,
+		},
+		{
+			// A macro body is as much part of what the binding does as an
+			// inline step is.
+			name:           "mode inside a macro",
+			actions:        []string{"macro open_hints"},
+			wantModeSwitch: true,
+		},
+		{
+			name:           "macro without a mode",
+			actions:        []string{"macro just_click"},
+			wantModeSwitch: false,
+		},
+		{
+			name:           "unknown macro names no mode",
+			actions:        []string{"macro not_defined"},
+			wantModeSwitch: false,
 		},
 		{
 			name:           "run without a mode",
@@ -305,7 +327,10 @@ func TestBindingInspectionSeesModesInsideRun(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := actionsContainModeSwitch(testCase.actions); got != testCase.wantModeSwitch {
+			if got := actionsContainModeSwitch(
+				testCase.actions,
+				cfg,
+			); got != testCase.wantModeSwitch {
 				t.Fatalf("actionsContainModeSwitch(%v) = %v, want %v",
 					testCase.actions, got, testCase.wantModeSwitch)
 			}
@@ -331,22 +356,70 @@ func TestActionsReferenceDisabledModeSeesModesInsideRun(t *testing.T) {
 	}
 }
 
-// The expansion must stop where the executor does: past the nesting limit a
+// The walk must stop where the executor does: past the nesting limit a
 // sequence is refused, so its steps never run and must not be reported as
 // things the binding does.
-func TestFlattenRunSteps_StopsAtTheExecutorsNestingLimit(t *testing.T) {
+func TestAnyBindingStep_StopsAtTheExecutorsNestingLimit(t *testing.T) {
 	t.Parallel()
 
 	mode := domain.ModeString(domain.ModeHints)
-	nested := []string{"run '" + mode + "'"}
+	names := func(step string) bool { return step == mode }
 
-	got := flattenRunStepsAtDepth(nested, 0)
-	if !slices.Equal(got, []string{mode}) {
-		t.Fatalf("below the limit: got %v, want the nested step expanded", got)
+	budget := maxInspectedSteps
+	if !anyBindingStepAtDepth([]string{"run '" + mode + "'"}, nil, 0, &budget, names) {
+		t.Fatal("below the limit: expected the nested step to be visited")
 	}
 
-	got = flattenRunStepsAtDepth(nested, maxSequenceDepth)
-	if !slices.Equal(got, nested) {
-		t.Fatalf("at the limit: got %v, want the run left unexpanded", got)
+	budget = maxInspectedSteps
+	if anyBindingStepAtDepth(
+		[]string{"run '" + mode + "'"},
+		nil,
+		maxSequenceDepth,
+		&budget,
+		names,
+	) {
+		t.Fatal("at the limit: expected the run to be left unexpanded")
+	}
+}
+
+// A binding whose macros fan out into each other multiplies at every level,
+// and this runs on the key-press path, so the walk is bounded rather than
+// trusted.
+func TestAnyBindingStep_IsBounded(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultConfig()
+
+	// Each level expands into eight calls to the next, which without a budget
+	// would visit thousands of steps before answering.
+	fanOut := func(next string) config.StringOrStringArray {
+		steps := make([]string, 0, 8)
+		for range 8 {
+			steps = append(steps, "macro "+next)
+		}
+
+		return steps
+	}
+
+	cfg.Macros = map[string]config.StringOrStringArray{
+		"a": fanOut("b"),
+		"b": fanOut("c"),
+		"c": fanOut("d"),
+		"d": {leftClickStep},
+	}
+
+	visited := 0
+	counted := func(string) bool {
+		visited++
+
+		return false
+	}
+
+	if anyBindingStep([]string{"macro a"}, cfg, counted) {
+		t.Fatal("no step names a mode, want false")
+	}
+
+	if visited > maxInspectedSteps {
+		t.Fatalf("visited %d steps, want no more than the %d budget", visited, maxInspectedSteps)
 	}
 }

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -313,9 +313,9 @@ func (h *IPCControllerModes) extractModeOptions(
 			opts.Action = &actionArg
 		// --on-exit is repeatable: each occurrence appends one step to the
 		// sequence that runs once the pending action is fulfilled.
-		case strings.HasPrefix(arg, "--on-exit="):
-			opts.OnExit = append(opts.OnExit, strings.TrimPrefix(arg, "--on-exit="))
-		case arg == "--on-exit":
+		case strings.HasPrefix(arg, config.OnExitFlag+"="):
+			opts.OnExit = append(opts.OnExit, strings.TrimPrefix(arg, config.OnExitFlag+"="))
+		case arg == config.OnExitFlag:
 			if startIdx+1 >= len(cmd.Args) {
 				resp := ipc.Response{
 					Success: false,

--- a/internal/app/sequence.go
+++ b/internal/app/sequence.go
@@ -7,6 +7,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/config"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
 
@@ -193,7 +194,7 @@ func (a *App) executeActionSequenceWithPolicy(
 
 		stepErr := directiveErr
 		if stepErr == nil {
-			stepErr = a.executeHotkeyAction(stepCtx, source, dispatchStep)
+			stepErr = a.executeStep(stepCtx, source, dispatchStep)
 		}
 
 		if stepErr == nil {
@@ -238,6 +239,83 @@ func (a *App) executeActionSequenceWithPolicy(
 	}
 
 	return outcome
+}
+
+// executeStep runs one step of a sequence: a macro invocation expands to the
+// sequence it names, anything else is dispatched as an action.
+func (a *App) executeStep(ctx context.Context, source, step string) error {
+	name, args, isMacro := config.ParseMacroCall(step)
+	if !isMacro {
+		return a.executeHotkeyAction(ctx, source, step)
+	}
+
+	return a.executeMacro(ctx, name, args)
+}
+
+// executeMacro runs the named macro's steps as a nested sequence.
+//
+// Running it nested rather than splicing its steps into the caller keeps two
+// things honest: the depth guard sees the nesting, so a macro that invokes
+// itself is stopped like any other runaway sequence; and the caller reports
+// failures against the step the author actually wrote ("macro foo 1 2") rather
+// than against an expanded position they never saw.
+func (a *App) executeMacro(ctx context.Context, name string, args []string) error {
+	if name == "" {
+		return derrors.New(
+			derrors.CodeInvalidInput,
+			"macro requires a name (e.g. \"macro window_click 100 70\")",
+		)
+	}
+
+	// The table is read when the call runs, not pinned for the whole sequence,
+	// which is how every other step reads configuration — a scroll step takes
+	// the step size current at the time it fires. A reload mid-sequence
+	// therefore affects the calls after it, and a macro deleted by that reload
+	// fails here rather than running a definition the config no longer has.
+	// One body is read once and expanded once, so a single call is always
+	// internally consistent.
+	body, defined := a.configSnapshot().Macros[name]
+	if !defined {
+		return derrors.Newf(derrors.CodeInvalidInput, "no macro named %q", name)
+	}
+
+	if arity := config.MacroArity(body); len(args) != arity {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"macro %q takes %d argument(s), got %d",
+			name,
+			arity,
+			len(args),
+		)
+	}
+
+	// The nested sequence starts with its own policy: a macro decides for
+	// itself which of its steps are fatal, and its overall failure is what the
+	// caller sees.
+	outcome := a.executeActionSequenceWithPolicy(
+		ctx,
+		macroSource(name),
+		config.ExpandMacroSteps(body, args),
+		sequencePolicy{},
+	)
+
+	if outcome.err == nil {
+		return nil
+	}
+
+	// A bail inside a macro has to keep its meaning on the way out, or the
+	// caller would treat a canceled mode as an ordinary failure.
+	code := derrors.CodeActionFailed
+	if outcome.bailed {
+		code = derrors.CodeChainBail
+	}
+
+	return derrors.Wrapf(outcome.err, code, "macro %q", name)
+}
+
+// macroSource names a macro in logs the way it is written in the config.
+func macroSource(name string) string {
+	return config.MacroCommand + " " + name
 }
 
 // sequenceStepContext builds the context each step of a sequence runs under:

--- a/internal/app/sequence_test.go
+++ b/internal/app/sequence_test.go
@@ -22,6 +22,7 @@ const (
 	sequenceTestCommand = "step"
 
 	failureMessage = "boom"
+	bailMessage    = "mode exited without selection"
 
 	stepOne   = "step one"
 	stepTwo   = "step two"
@@ -136,7 +137,7 @@ func TestExecuteActionSequence_StopsOnBail(t *testing.T) {
 			if step == stepTwo {
 				return ipc.Response{
 					Success: false,
-					Message: "mode exited without selection",
+					Message: bailMessage,
 					Code:    ipc.CodeChainBail,
 				}
 			}
@@ -397,5 +398,189 @@ func TestExecuteActionSequence_RejectsMisplacedDirective(t *testing.T) {
 
 	if got := recorder.recorded(); len(got) != 0 {
 		t.Fatalf("dispatched %v, want nothing: the step was never valid", got)
+	}
+}
+
+// macroTestApp is a sequence test app whose config defines the given macros.
+func macroTestApp(t *testing.T, recorder *stepRecorder, macros map[string][]string) *App {
+	t.Helper()
+
+	application := newSequenceTestApp(t, recorder)
+
+	table := make(map[string]config.StringOrStringArray, len(macros))
+	for name, steps := range macros {
+		table[name] = steps
+	}
+
+	application.config.Macros = table
+
+	return application
+}
+
+func TestExecuteActionSequence_ExpandsAMacro(t *testing.T) {
+	recorder := &stepRecorder{}
+	application := macroTestApp(t, recorder, map[string][]string{
+		"two": {stepOne, stepTwo},
+	})
+
+	outcome := application.executeActionSequence(
+		context.Background(),
+		"test",
+		[]string{"macro two", stepThree},
+	)
+
+	if outcome.err != nil {
+		t.Fatalf("outcome.err = %v, want nil", outcome.err)
+	}
+
+	// The caller counts the step it wrote, not the steps the macro carried.
+	if outcome.executed != 2 {
+		t.Fatalf("executed = %d, want 2", outcome.executed)
+	}
+
+	want := []string{stepOne, stepTwo, stepThree}
+	if got := recorder.recorded(); !slices.Equal(got, want) {
+		t.Fatalf("dispatched %v, want %v", got, want)
+	}
+}
+
+func TestExecuteActionSequence_SubstitutesMacroArguments(t *testing.T) {
+	recorder := &stepRecorder{}
+	application := macroTestApp(t, recorder, map[string][]string{
+		"say": {"step $2 $1"},
+	})
+
+	application.executeActionSequence(
+		context.Background(),
+		"test",
+		[]string{"macro say alpha beta"},
+	)
+
+	want := []string{"step beta alpha"}
+	if got := recorder.recorded(); !slices.Equal(got, want) {
+		t.Fatalf("dispatched %v, want %v", got, want)
+	}
+}
+
+func TestExecuteActionSequence_RejectsBadMacroCalls(t *testing.T) {
+	tests := []struct {
+		name string
+		step string
+	}{
+		{name: "unknown macro", step: "macro nope"},
+		{name: "too few arguments", step: "macro needs_two alpha"},
+		{name: "too many arguments", step: "macro needs_two alpha beta gamma"},
+		{name: "no name", step: "macro"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			recorder := &stepRecorder{}
+			application := macroTestApp(t, recorder, map[string][]string{
+				"needs_two": {"step $1 $2"},
+			})
+
+			outcome := application.executeActionSequence(
+				context.Background(),
+				"test",
+				[]string{testCase.step},
+			)
+
+			if outcome.err == nil {
+				t.Fatalf("outcome.err = nil, want a rejection of %q", testCase.step)
+			}
+
+			if got := recorder.recorded(); len(got) != 0 {
+				t.Fatalf("dispatched %v, want nothing", got)
+			}
+		})
+	}
+}
+
+// A macro that invokes itself is a runaway sequence, and the depth guard is
+// what stops it — the same guard that bounds a nested run.
+func TestExecuteActionSequence_StopsASelfInvokingMacro(t *testing.T) {
+	recorder := &stepRecorder{}
+	application := macroTestApp(t, recorder, map[string][]string{
+		"loop": {stepOne, "macro loop"},
+	})
+
+	outcome := application.executeActionSequence(
+		context.Background(),
+		"test",
+		[]string{"macro loop"},
+	)
+
+	if outcome.err == nil {
+		t.Fatal("outcome.err = nil, want the depth guard to stop the recursion")
+	}
+
+	if got := len(recorder.recorded()); got != maxSequenceDepth-1 {
+		t.Fatalf("dispatched %d steps, want the guard to stop at %d", got, maxSequenceDepth-1)
+	}
+}
+
+// A canceled mode inside a macro must still read as a bail to the caller,
+// rather than as an ordinary failure it might carry on past.
+func TestExecuteActionSequence_PropagatesABailOutOfAMacro(t *testing.T) {
+	recorder := &stepRecorder{
+		respond: func(_ context.Context, step string) ipc.Response {
+			if step == stepOne {
+				return ipc.Response{
+					Success: false,
+					Message: bailMessage,
+					Code:    ipc.CodeChainBail,
+				}
+			}
+
+			return ipc.Response{Success: true, Code: ipc.CodeOK}
+		},
+	}
+	application := macroTestApp(t, recorder, map[string][]string{
+		"bails": {stepOne},
+	})
+
+	outcome := application.executeActionSequence(
+		context.Background(),
+		"test",
+		[]string{"macro bails", stepTwo},
+	)
+
+	if !outcome.bailed || !outcome.stopped {
+		t.Fatalf("outcome bailed=%v stopped=%v, want both", outcome.bailed, outcome.stopped)
+	}
+
+	if got := recorder.recorded(); !slices.Equal(got, []string{stepOne}) {
+		t.Fatalf("dispatched %v, want the sequence to stop after the macro", got)
+	}
+}
+
+// The bail directive is consumed before the call is parsed, so it must not be
+// mistaken for one of the macro's arguments.
+func TestExecuteActionSequence_BailDirectiveIsNotAMacroArgument(t *testing.T) {
+	recorder := &stepRecorder{
+		respond: func(_ context.Context, _ string) ipc.Response {
+			return ipc.Response{Success: false, Message: failureMessage, Code: ipc.CodeActionFailed}
+		},
+	}
+	application := macroTestApp(t, recorder, map[string][]string{
+		"needs_two": {"step $1 $2"},
+	})
+
+	outcome := application.executeActionSequence(
+		context.Background(),
+		"test",
+		[]string{"macro needs_two alpha beta " + bailOnErrorFlag, stepThree},
+	)
+
+	// The call is well-formed: it is the macro's own step that fails, and the
+	// directive makes that failure end the calling sequence.
+	if !outcome.stopped {
+		t.Fatalf("outcome = %+v, want the directive to stop the sequence", outcome)
+	}
+
+	want := []string{"step alpha beta"}
+	if got := recorder.recorded(); !slices.Equal(got, want) {
+		t.Fatalf("dispatched %v, want %v", got, want)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,12 @@ const (
 // Common action command constants.
 const (
 	// CmdRun runs the rest of the binding as an ordered action sequence.
-	CmdRun                         = "run"
+	CmdRun = "run"
+	// CmdMacro runs a named sequence from the [macros] table.
+	CmdMacro = MacroCommand
+	// OnExitFlag carries a step a mode runs once its action is fulfilled. It is
+	// repeatable, and its values are steps in their own right.
+	OnExitFlag                     = "--on-exit"
 	CmdToggleCursorFollowSelection = "toggle-cursor-follow-selection"
 	CmdMoveMouseUp                 = "action move_mouse_relative --dx=0 --dy=-10"
 )
@@ -177,23 +182,24 @@ var comboKeyAliases = map[string]string{
 
 // Config represents the complete application configuration structure.
 type Config struct {
-	General         GeneralConfig         `json:"general"         toml:"general"`
-	Theme           ThemeConfig           `json:"theme"           toml:"theme"`
-	Hotkeys         HotkeysConfig         `json:"hotkeys"         toml:"-"`
-	Hints           HintsConfig           `json:"hints"           toml:"hints"`
-	Grid            GridConfig            `json:"grid"            toml:"grid"`
-	RecursiveGrid   RecursiveGridConfig   `json:"recursiveGrid"   toml:"recursive_grid"`
-	MonitorSelect   MonitorSelectConfig   `json:"monitorSelect"   toml:"monitor_select"`
-	VirtualPointer  VirtualPointerConfig  `json:"virtualPointer"  toml:"virtual_pointer"`
-	MouseAction     MouseActionConfig     `json:"mouseAction"     toml:"mouse_action_indicator"`
-	Scroll          ScrollConfig          `json:"scroll"          toml:"scroll"`
-	ModeIndicator   ModeIndicatorConfig   `json:"modeIndicator"   toml:"mode_indicator"`
-	StickyModifiers StickyModifiersConfig `json:"stickyModifiers" toml:"sticky_modifiers"`
-	Logging         LoggingConfig         `json:"logging"         toml:"logging"`
-	SmoothCursor    SmoothCursorConfig    `json:"smoothCursor"    toml:"smooth_cursor"`
-	SmoothScroll    SmoothScrollConfig    `json:"smoothScroll"    toml:"smooth_scroll"`
-	HeldRepeat      HeldRepeatConfig      `json:"heldRepeat"      toml:"held_repeat"`
-	Systray         SystrayConfig         `json:"systray"         toml:"systray"`
+	General         GeneralConfig                  `json:"general"         toml:"general"`
+	Theme           ThemeConfig                    `json:"theme"           toml:"theme"`
+	Hotkeys         HotkeysConfig                  `json:"hotkeys"         toml:"-"`
+	Macros          map[string]StringOrStringArray `json:"macros"          toml:"macros"`
+	Hints           HintsConfig                    `json:"hints"           toml:"hints"`
+	Grid            GridConfig                     `json:"grid"            toml:"grid"`
+	RecursiveGrid   RecursiveGridConfig            `json:"recursiveGrid"   toml:"recursive_grid"`
+	MonitorSelect   MonitorSelectConfig            `json:"monitorSelect"   toml:"monitor_select"`
+	VirtualPointer  VirtualPointerConfig           `json:"virtualPointer"  toml:"virtual_pointer"`
+	MouseAction     MouseActionConfig              `json:"mouseAction"     toml:"mouse_action_indicator"`
+	Scroll          ScrollConfig                   `json:"scroll"          toml:"scroll"`
+	ModeIndicator   ModeIndicatorConfig            `json:"modeIndicator"   toml:"mode_indicator"`
+	StickyModifiers StickyModifiersConfig          `json:"stickyModifiers" toml:"sticky_modifiers"`
+	Logging         LoggingConfig                  `json:"logging"         toml:"logging"`
+	SmoothCursor    SmoothCursorConfig             `json:"smoothCursor"    toml:"smooth_cursor"`
+	SmoothScroll    SmoothScrollConfig             `json:"smoothScroll"    toml:"smooth_scroll"`
+	HeldRepeat      HeldRepeatConfig               `json:"heldRepeat"      toml:"held_repeat"`
+	Systray         SystrayConfig                  `json:"systray"         toml:"systray"`
 
 	// AppConfigs holds per-application overrides for global hotkeys, similar to
 	// per-mode [[<mode>.app_configs]].  Each entry can override or disable

--- a/internal/config/macros.go
+++ b/internal/config/macros.go
@@ -1,0 +1,193 @@
+package config
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// MacroCommand is the step keyword that invokes a named macro:
+// "macro <name> [args...]".
+const MacroCommand = "macro"
+
+// macroNamePattern is what a [macros] key may be called. Keeping names to
+// identifier characters means a call can be read by splitting on spaces: the
+// second token is the whole name, and everything after it is an argument.
+var macroNamePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
+
+// IsValidMacroName reports whether name may be used as a macro name.
+func IsValidMacroName(name string) bool {
+	return macroNamePattern.MatchString(name)
+}
+
+// MacroArity returns the number of arguments a macro body expects, which is
+// the highest positional placeholder it uses. A body with no placeholders
+// takes no arguments.
+func MacroArity(steps []string) int {
+	arity := 0
+
+	for _, step := range steps {
+		eachPlaceholder(step, func(index int, _, _ int) {
+			if index > arity {
+				arity = index
+			}
+		})
+	}
+
+	return arity
+}
+
+// ExpandMacroSteps substitutes positional arguments into a macro body. `$1` is
+// the first argument, `$$` is a literal dollar sign, and a placeholder with no
+// matching argument expands to nothing — validation rejects that case before it
+// can reach here.
+//
+// Substitution is textual and happens before the step is split into arguments,
+// so a placeholder that may contain spaces should be quoted in the body
+// (`exec say "$1"`), exactly as it would be in a shell.
+func ExpandMacroSteps(steps, args []string) []string {
+	expanded := make([]string, 0, len(steps))
+
+	for _, step := range steps {
+		expanded = append(expanded, expandMacroStep(step, args))
+	}
+
+	return expanded
+}
+
+// expandMacroStep substitutes the placeholders in one step.
+func expandMacroStep(step string, args []string) string {
+	var expanded strings.Builder
+
+	last := 0
+
+	eachPlaceholder(step, func(index, start, end int) {
+		expanded.WriteString(step[last:start])
+
+		if index == 0 {
+			// The escape for a literal dollar sign.
+			expanded.WriteString("$")
+		} else if index <= len(args) {
+			expanded.WriteString(args[index-1])
+		}
+
+		last = end
+	})
+
+	expanded.WriteString(step[last:])
+
+	return expanded.String()
+}
+
+// eachPlaceholder calls visit for every `$N` and `$$` in step, with the
+// 1-based argument index (0 for the `$$` escape) and the byte range the
+// placeholder occupies. Having one scanner keeps arity counting and expansion
+// from disagreeing about what a placeholder is.
+func eachPlaceholder(step string, visit func(index, start, end int)) {
+	for pos := 0; pos < len(step); pos++ {
+		if step[pos] != '$' {
+			continue
+		}
+
+		if pos+1 < len(step) && step[pos+1] == '$' {
+			visit(0, pos, pos+2) //nolint:mnd // the escape is two bytes.
+
+			pos++
+
+			continue
+		}
+
+		digits := pos + 1
+		for digits < len(step) && step[digits] >= '0' && step[digits] <= '9' {
+			digits++
+		}
+
+		if digits == pos+1 {
+			// A lone dollar sign is ordinary text.
+			continue
+		}
+
+		index, convErr := strconv.Atoi(step[pos+1 : digits])
+		if convErr != nil || index == 0 {
+			// Out of int range, or "$0", which names no argument.
+			continue
+		}
+
+		visit(index, pos, digits)
+
+		pos = digits - 1
+	}
+}
+
+// ParseMacroCall splits a step into the macro name and its arguments. The
+// second return value is false when the step does not invoke a macro at all.
+func ParseMacroCall(step string) (string, []string, bool) {
+	trimmed := strings.TrimSpace(step)
+
+	// This is asked of every step of every sequence, including on the
+	// key-press path, and almost none of them are macro calls. Rejecting them
+	// on a prefix keeps the step from being tokenised twice — once here and
+	// once when it is dispatched.
+	if !strings.HasPrefix(trimmed, MacroCommand) {
+		return "", nil, false
+	}
+
+	fields := SplitStepArgs(trimmed)
+	if len(fields) == 0 || fields[0] != MacroCommand {
+		return "", nil, false
+	}
+
+	if len(fields) == 1 {
+		return "", nil, true
+	}
+
+	return fields[1], fields[2:], true
+}
+
+// SplitStepArgs splits one action step into its arguments, honoring single
+// and double quotes so an argument may contain spaces. An unclosed quote ends
+// at the end of the step rather than being an error.
+//
+// This is the one definition of how a step is tokenised. The daemon dispatches
+// steps by it and config validation reads macro calls by it, so the two cannot
+// disagree about where an argument begins.
+func SplitStepArgs(input string) []string {
+	var args []string
+
+	var current strings.Builder
+
+	inSingleQuote := false
+	inDoubleQuote := false
+
+	for _, char := range input {
+		switch char {
+		case '\'':
+			if !inDoubleQuote {
+				inSingleQuote = !inSingleQuote
+			} else {
+				current.WriteRune(char)
+			}
+		case '"':
+			if !inSingleQuote {
+				inDoubleQuote = !inDoubleQuote
+			} else {
+				current.WriteRune(char)
+			}
+		case ' ':
+			if inSingleQuote || inDoubleQuote {
+				current.WriteRune(char)
+			} else if current.Len() > 0 {
+				args = append(args, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(char)
+		}
+	}
+
+	if current.Len() > 0 {
+		args = append(args, current.String())
+	}
+
+	return args
+}

--- a/internal/config/macros_test.go
+++ b/internal/config/macros_test.go
@@ -1,0 +1,409 @@
+package config_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+func TestMacroArity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		steps []string
+		want  int
+	}{
+		{name: "no placeholders", steps: []string{testActionLeftClick}, want: 0},
+		{name: "one placeholder", steps: []string{"action move_mouse --x $1"}, want: 1},
+		{
+			name:  "highest index across steps",
+			steps: []string{"action move_mouse --x $2", "exec say $1"},
+			want:  2,
+		},
+		{name: "repeated placeholder counts once", steps: []string{"exec say $1 $1"}, want: 1},
+		{name: "escaped dollar is not a placeholder", steps: []string{"exec echo $$1"}, want: 0},
+		{name: "lone dollar is text", steps: []string{"exec echo $ x"}, want: 0},
+		{name: "zero names no argument", steps: []string{"exec echo $0"}, want: 0},
+		{name: "multi-digit index", steps: []string{"exec echo $12"}, want: 12},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := config.MacroArity(testCase.steps); got != testCase.want {
+				t.Fatalf("MacroArity(%v) = %d, want %d", testCase.steps, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestExpandMacroSteps(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		steps []string
+		args  []string
+		want  []string
+	}{
+		{
+			name:  "positional substitution",
+			steps: []string{"action move_mouse_relative --dx $1 --dy $2"},
+			args:  []string{"100", "70"},
+			want:  []string{"action move_mouse_relative --dx 100 --dy 70"},
+		},
+		{
+			name:  "arguments may repeat and reorder",
+			steps: []string{"exec echo $2 $1 $2"},
+			args:  []string{"a", "b"},
+			want:  []string{"exec echo b a b"},
+		},
+		{
+			// Substitution is textual and happens before the step is split, so
+			// quoting in the body is what keeps an argument with spaces whole.
+			name:  "quoting in the body survives",
+			steps: []string{`exec say "$1"`},
+			args:  []string{"hello world"},
+			want:  []string{`exec say "hello world"`},
+		},
+		{
+			name:  "escaped dollar becomes a literal",
+			steps: []string{"exec echo $$1"},
+			args:  nil,
+			want:  []string{"exec echo $1"},
+		},
+		{
+			name:  "text without placeholders is untouched",
+			steps: []string{testActionLeftClick},
+			args:  []string{"unused"},
+			want:  []string{testActionLeftClick},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := config.ExpandMacroSteps(testCase.steps, testCase.args)
+			if !slices.Equal(got, testCase.want) {
+				t.Fatalf("ExpandMacroSteps(%v, %v) = %v, want %v",
+					testCase.steps, testCase.args, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestParseMacroCall(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		step     string
+		wantName string
+		wantArgs []string
+		wantCall bool
+	}{
+		{
+			name:     "name and arguments",
+			step:     "macro window_click 100 70",
+			wantName: "window_click",
+			wantArgs: []string{"100", "70"},
+			wantCall: true,
+		},
+		{
+			name:     "quoted argument stays whole",
+			step:     "macro greet 'hello world'",
+			wantName: "greet",
+			wantArgs: []string{"hello world"},
+			wantCall: true,
+		},
+		{name: "not a macro", step: testActionLeftClick},
+		{name: "macro without a name", step: "macro", wantCall: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotName, gotArgs, gotCall := config.ParseMacroCall(testCase.step)
+
+			if gotCall != testCase.wantCall || gotName != testCase.wantName {
+				t.Fatalf("ParseMacroCall(%q) = (%q, _, %v), want (%q, _, %v)",
+					testCase.step, gotName, gotCall, testCase.wantName, testCase.wantCall)
+			}
+
+			if !slices.Equal(gotArgs, testCase.wantArgs) {
+				t.Fatalf("args = %v, want %v", gotArgs, testCase.wantArgs)
+			}
+		})
+	}
+}
+
+// A mistyped macro name in a binding would otherwise do nothing at all at
+// press time, so it has to fail when the config is loaded.
+// errNoMacroNamed is the fragment reported for a call that names nothing.
+const (
+	errNoMacroNamed  = "no macro named"
+	errUnknownAction = "unknown action subcommand"
+)
+
+func TestValidateMacros(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		build   func(*config.Config)
+		name    string
+		wantErr string
+	}{
+		{
+			name: "valid definition and call",
+			build: func(cfg *config.Config) {
+				cfg.Macros = map[string]config.StringOrStringArray{
+					"click_at": {"action move_mouse --x $1 --y $2", testActionLeftClick},
+				}
+				cfg.Hints.Hotkeys["Enter"] = config.StringOrStringArray{"macro click_at 10 20"}
+			},
+		},
+		{
+			name: "unknown macro name",
+			build: func(cfg *config.Config) {
+				cfg.Hints.Hotkeys["Enter"] = config.StringOrStringArray{"macro nope"}
+			},
+			wantErr: errNoMacroNamed,
+		},
+		{
+			name: "wrong argument count",
+			build: func(cfg *config.Config) {
+				cfg.Macros = map[string]config.StringOrStringArray{
+					"click_at": {"action move_mouse --x $1 --y $2"},
+				}
+				cfg.Hints.Hotkeys["Enter"] = config.StringOrStringArray{"macro click_at 10"}
+			},
+			wantErr: "takes 2 argument(s), got 1",
+		},
+		{
+			name: "call from a macro body is checked too",
+			build: func(cfg *config.Config) {
+				cfg.Macros = map[string]config.StringOrStringArray{
+					"outer": {"macro missing"},
+				}
+			},
+			wantErr: errNoMacroNamed,
+		},
+		{
+			// A step is not always a leaf: "run" carries its own steps, and a
+			// mode command carries the steps of its --on-exit. A macro invoked
+			// from either is still a macro this config will run.
+			name: "call nested in a run",
+			build: func(cfg *config.Config) {
+				cfg.Hints.Hotkeys["Enter"] = config.StringOrStringArray{"run 'macro nope'"}
+			},
+			wantErr: errNoMacroNamed,
+		},
+		{
+			name: "call nested two runs deep",
+			build: func(cfg *config.Config) {
+				cfg.Hints.Hotkeys["Enter"] = config.StringOrStringArray{`run 'run "macro nope"'`}
+			},
+			wantErr: errNoMacroNamed,
+		},
+		{
+			name: "call in an --on-exit step",
+			build: func(cfg *config.Config) {
+				cfg.Hotkeys.Bindings = map[string][]string{
+					"Primary+Shift+Y": {"hints --action left_click --on-exit 'macro nope'"},
+				}
+			},
+			wantErr: errNoMacroNamed,
+		},
+		{
+			name: "wrong arity nested in a run",
+			build: func(cfg *config.Config) {
+				cfg.Macros = map[string]config.StringOrStringArray{
+					"needs_one": {"exec echo $1"},
+				}
+				cfg.Hints.Hotkeys["Enter"] = config.StringOrStringArray{"run 'macro needs_one a b'"}
+			},
+			wantErr: "takes 1 argument(s), got 2",
+		},
+		{
+			name: "valid call nested in a run",
+			build: func(cfg *config.Config) {
+				cfg.Macros = map[string]config.StringOrStringArray{
+					"real": {testActionLeftClick},
+				}
+				cfg.Hints.Hotkeys["Enter"] = config.StringOrStringArray{"run 'macro real'"}
+			},
+		},
+		{
+			name: "invalid macro name",
+			build: func(cfg *config.Config) {
+				cfg.Macros = map[string]config.StringOrStringArray{
+					"has space": {testActionLeftClick},
+				}
+			},
+			wantErr: "not a valid macro name",
+		},
+		{
+			name: "empty body",
+			build: func(cfg *config.Config) {
+				cfg.Macros = map[string]config.StringOrStringArray{"empty": {}}
+			},
+			wantErr: "at least one step",
+		},
+		{
+			name: "invalid step in a body",
+			build: func(cfg *config.Config) {
+				cfg.Macros = map[string]config.StringOrStringArray{
+					"bad": {"action not_an_action"},
+				}
+			},
+			wantErr: "unknown action subcommand",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.DefaultConfig()
+			testCase.build(cfg)
+
+			err := cfg.ValidateMacros()
+
+			if testCase.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateMacros() unexpected error: %v", err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("ValidateMacros() = nil, want an error containing %q", testCase.wantErr)
+			}
+
+			if !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+// Every action string the daemon can dispatch is checked when the config
+// loads, at whatever depth and on whatever surface it is written. Execution
+// has one path through the sequence executor; validation has to have the same
+// reach or a step that names nothing real reaches a running daemon.
+func TestValidate_CoversEveryActionSurface(t *testing.T) {
+	t.Parallel()
+
+	const unknownAction = "action bogus_thing"
+
+	missionControl := func(cfg *config.Config) {
+		cfg.Hints.DetectMissionControl = true
+		cfg.Hints.IncludeDockHints = true
+	}
+
+	tests := []struct {
+		build   func(*config.Config)
+		name    string
+		wantErr string
+	}{
+		{
+			name: "monitor_select table",
+			build: func(cfg *config.Config) {
+				cfg.MonitorSelect.Hotkeys = map[string]config.StringOrStringArray{
+					"x": {unknownAction},
+				}
+			},
+			wantErr: errUnknownAction,
+		},
+		{
+			name: "mission control activated hook",
+			build: func(cfg *config.Config) {
+				missionControl(cfg)
+				cfg.Hints.OnMissionControlActivated = config.StringOrStringArray{unknownAction}
+			},
+			wantErr: errUnknownAction,
+		},
+		{
+			name: "mission control deactivated hook",
+			build: func(cfg *config.Config) {
+				missionControl(cfg)
+				cfg.Hints.OnMissionControlDeactivated = config.StringOrStringArray{unknownAction}
+			},
+			wantErr: errUnknownAction,
+		},
+		{
+			name: "macro call in a mission control hook",
+			build: func(cfg *config.Config) {
+				missionControl(cfg)
+				cfg.Hints.OnMissionControlActivated = config.StringOrStringArray{"macro nope"}
+			},
+			wantErr: errNoMacroNamed,
+		},
+		{
+			name: "step nested in a run",
+			build: func(cfg *config.Config) {
+				cfg.Hints.Hotkeys["Enter"] = config.StringOrStringArray{
+					"run '" + unknownAction + "'",
+				}
+			},
+			wantErr: errUnknownAction,
+		},
+		{
+			name: "step nested in an --on-exit",
+			build: func(cfg *config.Config) {
+				cfg.Hints.Hotkeys["Enter"] = config.StringOrStringArray{
+					"hints --action left_click --on-exit '" + unknownAction + "'",
+				}
+			},
+			wantErr: errUnknownAction,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.DefaultConfig()
+			testCase.build(cfg)
+
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate() = nil, want an error containing %q", testCase.wantErr)
+			}
+
+			if !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+// The same surfaces must still accept what is valid, so the coverage above
+// cannot be passing by rejecting everything.
+func TestValidate_AcceptsValidActionsOnEverySurface(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultConfig()
+	cfg.Hints.DetectMissionControl = true
+	cfg.Hints.IncludeDockHints = true
+	cfg.Macros = map[string]config.StringOrStringArray{"real": {testActionLeftClick}}
+	cfg.Hints.OnMissionControlActivated = config.StringOrStringArray{"macro real"}
+	cfg.Hints.OnMissionControlDeactivated = config.StringOrStringArray{testActionLeftClick}
+	cfg.MonitorSelect.Hotkeys = map[string]config.StringOrStringArray{"x": {config.CmdIdle}}
+	cfg.Hints.Hotkeys["Enter"] = config.StringOrStringArray{
+		"run 'macro real'",
+		"hints --action left_click --on-exit 'macro real'",
+	}
+
+	err := cfg.Validate()
+	if err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -126,6 +126,13 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	// Validate macro definitions and every call to one. This runs last so a
+	// call is checked against a table that is already known to be sound.
+	err = c.ValidateMacros()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/config/validators_hotkeys.go
+++ b/internal/config/validators_hotkeys.go
@@ -49,6 +49,9 @@ func (c *Config) ValidateHotkeys() error {
 		{ModeNameGrid, c.Grid.Hotkeys},
 		{ModeNameRecursiveGrid, c.RecursiveGrid.Hotkeys},
 		{ModeNameScroll, c.Scroll.Hotkeys},
+		// monitor_select binds keys like the other modes and dispatches them
+		// through the same executor, so its table is checked like theirs.
+		{ModeNameMonitorSelect, c.MonitorSelect.Hotkeys},
 	}
 
 	for _, mode := range modeHotkeys {
@@ -384,7 +387,10 @@ func validateHotkeyActionString(actionStr string) error {
 		// the sequence executes, not here: the steps arrive as a single quoted
 		// string per step, so splitting them apart correctly is the runtime's
 		// job, not the validator's.
-		CmdRun:
+		CmdRun,
+		// "macro" is checked against the [macros] table by ValidateMacros,
+		// which needs the whole config rather than one action string.
+		CmdMacro:
 		return nil
 	default:
 		return derrors.Newf(derrors.CodeInvalidConfig, "unknown command: %s", trimmed)

--- a/internal/config/validators_macros.go
+++ b/internal/config/validators_macros.go
@@ -1,0 +1,317 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+)
+
+// ValidateMacros checks the [macros] table and every macro call in the
+// configuration.
+//
+// Calls are checked at load rather than when a key is pressed because a
+// binding runs in the background: a mistyped macro name would otherwise
+// produce nothing but a log line, with the key appearing to do nothing at all.
+func (c *Config) ValidateMacros() error {
+	for name, steps := range c.Macros {
+		err := validateMacroDefinition(name, steps)
+		if err != nil {
+			return err
+		}
+	}
+
+	return c.eachBindingAction(func(field, actionStr string) error {
+		return c.validateMacroCall(field, actionStr)
+	})
+}
+
+// validateMacroDefinition checks one entry of the [macros] table.
+func validateMacroDefinition(name string, steps []string) error {
+	if !IsValidMacroName(name) {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"macros.%s is not a valid macro name: use letters, digits, '_' and '-', starting with a letter",
+			name,
+		)
+	}
+
+	if len(steps) == 0 {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"macros.%s must have at least one step",
+			name,
+		)
+	}
+
+	for idx, step := range steps {
+		field := fmt.Sprintf("macros.%s[%d]", name, idx)
+
+		if strings.TrimSpace(step) == "" {
+			return derrors.Newf(derrors.CodeInvalidConfig, "%s must not be empty", field)
+		}
+
+		// A step is validated with its placeholders still in place. They only
+		// ever appear in flag values, which this check does not look at.
+		err := validateHotkeyActionString(step)
+		if err != nil {
+			return derrors.Wrapf(err, derrors.CodeInvalidConfig, "%s", field)
+		}
+	}
+
+	return nil
+}
+
+// maxValidatedNesting bounds how deep validation follows a step into the
+// sequences it carries. It mirrors the runtime nesting limit; a sequence deeper
+// than this is refused when it runs, so there is nothing to check below it.
+const maxValidatedNesting = 5
+
+// validateMacroCall checks a single action string, and the steps it carries.
+//
+// A step is not always a leaf: "run" holds its own steps, and a mode command
+// holds the steps of its --on-exit. A macro invoked from either of those is
+// still a macro this configuration will run, so it is checked the same way —
+// otherwise the load-time guarantee would hold everywhere except the two
+// places a sequence nests.
+func (c *Config) validateMacroCall(field, actionStr string) error {
+	return c.validateActionStep(field, actionStr, 0)
+}
+
+// validateActionStep checks one step and descends into any it carries.
+func (c *Config) validateActionStep(field, step string, depth int) error {
+	if depth >= maxValidatedNesting {
+		return nil
+	}
+
+	if stepCommand(step) == CmdRun {
+		for _, nested := range SplitStepArgs(strings.TrimSpace(step))[1:] {
+			err := c.validateActionStep(field, nested, depth+1)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	for _, nested := range onExitSteps(step) {
+		err := c.validateActionStep(field, nested, depth+1)
+		if err != nil {
+			return err
+		}
+	}
+
+	// A nested step is a step: it has to name a real command, exactly like one
+	// written directly in the binding. Reaching it only through this walk is
+	// why a step inside a run or an --on-exit went unchecked before.
+	if depth > 0 {
+		err := validateHotkeyActionString(step)
+		if err != nil {
+			return derrors.Wrapf(err, derrors.CodeInvalidConfig, "%s", field)
+		}
+	}
+
+	return c.checkMacroCall(field, step)
+}
+
+// stepCommand returns the command word of a step, ignoring its arguments.
+func stepCommand(step string) string {
+	fields := strings.Fields(strings.TrimSpace(step))
+	if len(fields) == 0 {
+		return ""
+	}
+
+	return fields[0]
+}
+
+// onExitSteps returns the steps a mode command carries in its --on-exit flags,
+// in either the separated or the "=" spelling. The flag is repeatable, so a
+// mode command may carry several.
+func onExitSteps(step string) []string {
+	if !strings.Contains(step, OnExitFlag) {
+		return nil
+	}
+
+	tokens := SplitStepArgs(strings.TrimSpace(step))
+
+	var steps []string
+
+	for idx := 0; idx < len(tokens); idx++ {
+		switch {
+		case tokens[idx] == OnExitFlag && idx+1 < len(tokens):
+			idx++
+
+			steps = append(steps, tokens[idx])
+		case strings.HasPrefix(tokens[idx], OnExitFlag+"="):
+			steps = append(steps, strings.TrimPrefix(tokens[idx], OnExitFlag+"="))
+		}
+	}
+
+	return steps
+}
+
+// checkMacroCall checks one step that invokes a macro. It is a no-op for any
+// other action.
+func (c *Config) checkMacroCall(field, actionStr string) error {
+	name, args, isCall := ParseMacroCall(actionStr)
+	if !isCall {
+		return nil
+	}
+
+	if name == "" {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"%s: macro requires a name (e.g. \"macro window_click 100 70\")",
+			field,
+		)
+	}
+
+	steps, defined := c.Macros[name]
+	if !defined {
+		return derrors.Newf(derrors.CodeInvalidConfig, "%s: no macro named %q", field, name)
+	}
+
+	arity := MacroArity(steps)
+	if len(args) != arity {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"%s: macro %q takes %d argument(s), got %d",
+			field,
+			name,
+			arity,
+			len(args),
+		)
+	}
+
+	return nil
+}
+
+// eachBindingAction calls visit for every action string the configuration can
+// dispatch: the global bindings, each mode's bindings, the per-app overrides of
+// both, and the bodies of the macros themselves.
+//
+// A macro can be invoked from any of these, so all of them have to be walked
+// for a call to be checked at load time.
+func (c *Config) eachBindingAction(visit func(field, actionStr string) error) error {
+	for key, actions := range c.Hotkeys.Bindings {
+		err := visitActions("hotkeys."+key, actions, visit)
+		if err != nil {
+			return err
+		}
+	}
+
+	for idx, appConfig := range c.AppConfigs {
+		field := fmt.Sprintf("app_configs[%d].hotkeys", idx)
+
+		err := visitTable(field, appConfig.Hotkeys, visit)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, mode := range c.modeBindingTables() {
+		err := visitTable(mode.field, mode.table, visit)
+		if err != nil {
+			return err
+		}
+	}
+
+	// The Mission Control hooks are action sequences like any binding — they
+	// are dispatched through the same executor when the transition fires, so a
+	// macro they name has to exist by the time it does.
+	hooks := []struct {
+		steps []string
+		field string
+	}{
+		{field: "hints.on_mission_control_activated", steps: c.Hints.OnMissionControlActivated},
+		{field: "hints.on_mission_control_deactivated", steps: c.Hints.OnMissionControlDeactivated},
+	}
+
+	for _, hook := range hooks {
+		err := visitActions(hook.field, hook.steps, visit)
+		if err != nil {
+			return err
+		}
+	}
+
+	for name, steps := range c.Macros {
+		err := visitActions("macros."+name, steps, visit)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// modeBindingTable names one table of bindings for reporting.
+type modeBindingTable struct {
+	table map[string]StringOrStringArray
+	field string
+}
+
+// modeBindingTables lists every per-mode binding table, including the per-app
+// overrides, so a walk cannot silently miss one.
+func (c *Config) modeBindingTables() []modeBindingTable {
+	tables := []modeBindingTable{
+		{field: ModeNameHints + ".hotkeys", table: c.Hints.Hotkeys},
+		{field: ModeNameGrid + ".hotkeys", table: c.Grid.Hotkeys},
+		{field: ModeNameRecursiveGrid + ".hotkeys", table: c.RecursiveGrid.Hotkeys},
+		{field: ModeNameScroll + ".hotkeys", table: c.Scroll.Hotkeys},
+		{field: ModeNameMonitorSelect + ".hotkeys", table: c.MonitorSelect.Hotkeys},
+	}
+
+	appTables := []struct {
+		configs  []AppConfig
+		modeName string
+	}{
+		{configs: c.Hints.AppConfigs, modeName: ModeNameHints},
+		{configs: c.Grid.AppConfigs, modeName: ModeNameGrid},
+		{configs: c.RecursiveGrid.AppConfigs, modeName: ModeNameRecursiveGrid},
+		{configs: c.Scroll.AppConfigs, modeName: ModeNameScroll},
+	}
+
+	for _, mode := range appTables {
+		for idx, appConfig := range mode.configs {
+			tables = append(tables, modeBindingTable{
+				field: fmt.Sprintf("%s.app_configs[%d].hotkeys", mode.modeName, idx),
+				table: appConfig.Hotkeys,
+			})
+		}
+	}
+
+	return tables
+}
+
+// visitTable applies visit to every action in a binding table.
+func visitTable(
+	field string,
+	table map[string]StringOrStringArray,
+	visit func(field, actionStr string) error,
+) error {
+	for key, actions := range table {
+		err := visitActions(field+"."+key, actions, visit)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// visitActions applies visit to every non-blank action in one binding.
+func visitActions(field string, actions []string, visit func(field, actionStr string) error) error {
+	for _, actionStr := range actions {
+		if strings.TrimSpace(actionStr) == "" {
+			continue
+		}
+
+		err := visit(field, actionStr)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

This PR adds named action sequences, so a sequence used by several keys is
written once instead of copied across them.

Previously the only way to share steps between bindings was to repeat them. The
per-app recipe in the tips guide for switching between views in one window
repeats the same five steps three times over, with only two numbers differing —
that recipe is now three one-line bindings and one definition.

A macro is invoked with `macro <name> [args...]` from anywhere a sequence step
is accepted: a hotkey binding, a mode's `--on-exit`, `neru run`, or another
macro. Arguments are positional. Calls are checked when the config loads rather
than when the key is pressed, because a binding runs in the background and
discards its result — a mistyped name would otherwise make the key appear to do
nothing at all.

This adds naming and argument substitution, and nothing else: no conditionals,
no state, no recording. A macro body is the same list of steps you would have
inlined into the binding.

Making the load-time check trustworthy meant giving validation the same reach
execution already has. That closed three surfaces which previously accepted any
action string at all — `monitor_select` bindings, both Mission Control hooks,
and every step nested inside a `run` or an `--on-exit`. Configurations that were
silently carrying a broken step there will now be reported; see
[Potentially breaking](#potentially-breaking).

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature

## Command and configuration changes

**New config table**

| Table | Description |
| --- | --- |
| `[macros]` | Named action sequences. Each key is a macro name, each value a step or list of steps. Optional; omitting it changes nothing. |

```toml
[macros]
click_and_exit = ["action left_click --bail-on-error", "idle"]
window_click = [
    "action move_mouse --window --x -1000 --y -1000",
    "action sleep 0.1",
    "action move_mouse_relative --dx $1 --dy $2",
    "action left_click",
]

[hints.hotkeys]
"Enter" = "macro click_and_exit"

[[app_configs]]
bundle_id = "com.example.someapp"
hotkeys = { "Cmd+1" = "macro window_click 100 70", "Cmd+2" = "macro window_click 250 70" }
```

**New step keyword**

| Step | Where | Description |
| --- | --- | --- |
| `macro <name> [args...]` | Any sequence: `[hotkeys]`, a per-mode table, a per-app override, `--on-exit`, `neru run`, another macro body | Runs the named sequence. |

**Rules a user needs to know**

- **Names** use letters, digits, `_` and `-`, and start with a letter.
- **Arguments** are positional: `$1`, `$2`, …, with `$$` for a literal dollar.
  Substitution is textual and happens before the step is split into arguments,
  so quote a placeholder that may contain spaces — `exec say "$1"` — as in a
  shell.
- **Arity is exact**, and checked at load: a call must pass as many arguments as
  the body's highest placeholder. An unknown name or the wrong count fails
  `neru config validate`.
- **A placeholder cannot be the command word.** `"$1 --action left_click"` as a
  body step is rejected at load, since a step whose command is known only at
  call time could not be validated at all.
- **A macro is not accepted as a mode's `--action`**, which takes a mouse-button
  name; use `--on-exit` for a sequence that follows the action.
- **A macro runs as a nested sequence**, so a failure inside it reaches the
  caller as that one step failing, and a `--bail-on-error` or `--stop-on-error`
  on the caller acts on it. The caller's policy does not apply inside the body.
- **A macro may call another macro**, and one that reaches itself is stopped by
  the same five-level nesting limit that bounds `run`.
- **Calls are checked wherever they are written**: `[hotkeys]`, every
  `[<mode>.hotkeys]` table, the per-app overrides of both,
  `hints.on_mission_control_activated` / `_deactivated`, a macro body, and the
  steps carried inside a `run` or an `--on-exit`.

Existing configs are unaffected: without a `[macros]` table nothing changes, and
a config written before this still loads and validates unchanged.

## Potentially breaking

Validation now reaches surfaces it did not before, so a configuration that
loads today can be reported as invalid after this change. **An invalid
configuration stops the daemon from starting**, so this is worth a deliberate
call rather than a footnote.

Three surfaces previously accepted any action string, checking nothing:

| Surface | Before | Now |
| --- | --- | --- |
| `[monitor_select.hotkeys]` | any string accepted | checked like every other mode table |
| `hints.on_mission_control_activated` / `_deactivated` | macro calls unchecked | checked like every other binding |
| Steps inside a `run` or an `--on-exit` | any string accepted | checked like a step written directly |

Who this affects: someone whose config contains a step that never worked — a
typo such as `run 'action lefft_click'`, or a `[monitor_select.hotkeys]` entry
naming an action that does not exist. That binding is already dead at runtime;
the change is that Neru now says so at load instead of failing silently when
the key is pressed.

What they do: run `neru config validate`, which names the offending field and
step, and fix or remove it. Every config shipped in `configs/`, including the
maintainer's own, validates unchanged.

The alternative — warning for one release and failing afterwards — would avoid
the upgrade cliff at the cost of two classes of validation error to explain.
I went with failing, because `[hints.hotkeys]` has always failed on a bogus
action and the surfaces that did not were the accident. Happy to switch it to a
warning if you would rather stage it.

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no platform-specific code in this change
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new platform capability
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — unit suite and the integration tests for the packages this touches; see Additional Context for the one suite that cannot run locally right now
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**On the name.** "Macro" carries a record-and-replay connotation from text
editors, which this is not; the docs say so where a reader will hit it. It was
kept over "workflow" — already used throughout the docs in its ordinary prose
sense, and suggestive of stages and state this does not have — and over
"sequence", which is the codebase's own word for the generic concept. The
parameterised-substitution sense of "macro" describes the implementation
exactly, and it is what comparable tools in this space call the same thing.

**Why nested rather than inlined.** Splicing a body into its caller would have
hidden the nesting from the depth guard, so a self-referential macro would
recurse freely, and would have reported failures against an expanded step index
the author never wrote. Running it as a nested sequence gets both for free.

**Why the tokenizer moved.** Validation has to read a call exactly as the daemon
dispatches one, or the two disagree about where an argument begins — the same
divergence the shared executor removed earlier. There is now one definition,
in the package that owns the config format, and the app delegates to it.

**Binding inspection.** The checks that decide modifier suppression and
disabled-mode skipping have to see a mode named inside a macro, or a binding
written as a macro would silently skip them. They now walk into bodies with
early return instead of expanding into a slice, and the walk is bounded: macros
that fan out into each other multiply at every level, and this runs on the
key-press path. Past the budget the answer is "no mode named here", the same
conclusion already drawn for anything that cannot be expanded.

**Known and deliberate.** A macro's steps can fan out at execution time — depth
is bounded, width is not — in the same way a very long hotkey array can; the
config does what it says. A macro that reaches itself reports one `macro "x":`
wrapper per level before the real cause, which is verbose but shows the chain.

**On the review that produced the validation work.** An automated review
flagged macro calls escaping validation in "Mission Control hooks". I checked,
found nothing by that name, and said so — wrongly: the grep I based that on was
truncated, and `hints.on_mission_control_activated` / `_deactivated` are real
action sequences dispatched through the same executor. The second flag was
correct. Rather than patch just that hook, the walk was extended to every
surface and every nesting level, which is what turned up `monitor_select` and
nested steps as well.

**Verification beyond the test suite.** Driven against a running daemon:
arguments substituted, a nested macro, an unknown name, the wrong argument
count, a self-invoking macro stopped by the depth guard, a failing body step
tolerated by default, the same step made fatal with `--bail-on-error` on the
call, `--stop-on-error` at the call site, and `--bail-on-error` correctly not
counted as one of the macro's arguments. A macro added after startup is picked
up by `neru config reload`, and `[macros]` survives a `neru config set` rewrite
intact. Race detector clean; no panics.

Each newly covered surface was probed before and after: a bogus action in
`[monitor_select.hotkeys]`, in either Mission Control hook, inside a `run`, and
inside an `--on-exit` all loaded clean before and are reported now, while the
valid form of each still passes. Two tests pin this — one that every surface
rejects a bad step, and one that every surface still accepts a good one, so the
coverage cannot pass by rejecting everything.

**One suite could not run locally.** `TestHintServiceIntegration` performs an
unbounded real accessibility scan of the focused window and hangs while the
screen is locked, which is where this machine was. It is unrelated to this
change — reproduced at `02c01dae` in a clean worktree — but it means the full
`just test` was not observed green end to end here; the unit suite and the
integration tests for `config`, `app` and `ipc` were.
