### PR TITLE
fix(config): report an invalid reload instead of blocking on the alert

### DIFF
--- a/internal/app/services/services_integration_darwin_test.go
+++ b/internal/app/services/services_integration_darwin_test.go
@@ -4,8 +4,10 @@ package services_test
 
 import (
 	"context"
+	"fmt"
 	"image"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -21,6 +23,49 @@ import (
 	"github.com/y3owk1n/neru/internal/core/infra/platform"
 	"github.com/y3owk1n/neru/internal/core/ports"
 )
+
+// realAdapterTimeout bounds how long these tests wait on the real system.
+//
+// They drive live accessibility APIs against whatever window happens to be
+// focused, and that call can take arbitrarily long — with the screen locked,
+// where the focused "app" is the login window, it does not return at all.
+const realAdapterTimeout = 30 * time.Second
+
+// startAdapterWatchdog ends the test run with a diagnosis if a real system
+// call never comes back. Each subtest starts its own: a test function holds
+// several, and one budget shared across them would eventually blame a locked
+// screen for what is only a slow machine. Setup outside a subtest is left to
+// the go test -timeout backstop.
+//
+// A context deadline cannot do this job: several adapters take a context and
+// discard it, and the ones that honor it check it only before starting work,
+// so nothing interrupts a call already blocked inside the platform API.
+// Panicking is what turns an indefinite hang into something a reader can act
+// on — the message names the likely cause, and the stack dump that comes with
+// it names the call that is stuck.
+func startAdapterWatchdog(t *testing.T) {
+	t.Helper()
+
+	finished := make(chan struct{})
+	t.Cleanup(func() { close(finished) })
+
+	name := t.Name()
+
+	go func() {
+		select {
+		case <-finished:
+		case <-time.After(realAdapterTimeout):
+			panic(fmt.Sprintf(
+				"%s: a real system adapter did not answer within %s. "+
+					"This usually means the screen is locked, or the focused app is not "+
+					"responding to accessibility queries, rather than a fault in the code "+
+					"under test. The stack below shows which call is blocked.",
+				name,
+				realAdapterTimeout,
+			))
+		}
+	}()
+}
 
 // testThemeProvider is a simple ThemeProvider mock for integration tests.
 type testThemeProvider struct {
@@ -69,6 +114,8 @@ func TestHintServiceIntegration(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("ShowHints integration", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		// This tests the full pipeline: accessibility -> hint generation -> overlay.
 		// Zero hints is a legitimate outcome (the machine may have no clickable
 		// elements on screen), but an error is not.
@@ -103,6 +150,8 @@ func TestHintServiceIntegration(t *testing.T) {
 	})
 
 	t.Run("ShowHints leaves NoOpManager-backed overlay idle", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		// initializeRealAdapters wires a NoOpManager whose Mode() is pinned to
 		// ModeIdle, and Adapter.IsVisible is defined as Mode() != idle. So the
 		// adapter must report not-visible no matter what was shown. If this
@@ -118,6 +167,8 @@ func TestHintServiceIntegration(t *testing.T) {
 	})
 
 	t.Run("HideHints integration", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		err := hintService.HideHints(ctx)
 		if err != nil {
 			t.Fatalf("HideHints failed: %v", err)
@@ -136,6 +187,8 @@ func TestHintServiceIntegration(t *testing.T) {
 	})
 
 	t.Run("Service health check", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		health := hintService.Health(ctx)
 		if health == nil {
 			t.Fatal("Health returned nil map")
@@ -180,6 +233,8 @@ func TestActionServiceIntegration(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("PerformActionAtPoint left click", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		err := actionService.PerformActionAtPoint(ctx, "left_click", image.Point{X: 100, Y: 100}, 0)
 		if err != nil {
 			t.Fatalf("PerformActionAtPoint(left_click) failed: %v", err)
@@ -187,6 +242,8 @@ func TestActionServiceIntegration(t *testing.T) {
 	})
 
 	t.Run("PerformActionAtPoint right click", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		err := actionService.PerformActionAtPoint(
 			ctx,
 			"right_click",
@@ -199,6 +256,8 @@ func TestActionServiceIntegration(t *testing.T) {
 	})
 
 	t.Run("PerformActionAtPoint rejects an unknown action", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		// The action string is parsed before any native call, so an unknown
 		// name must be reported rather than silently no-op'ing.
 		err := actionService.PerformActionAtPoint(
@@ -224,6 +283,8 @@ func TestActionServiceIntegration(t *testing.T) {
 	// concurrently, so each would intermittently fail the other.
 
 	t.Run("ExecuteAction on element", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		// This tests the element-based action execution
 		// Create a mock element using the constructor
 		testElement, err := element.NewElement(
@@ -262,6 +323,8 @@ func TestGridServiceIntegration(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("ShowGrid integration", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		err := gridService.ShowGrid(ctx)
 		if err != nil {
 			t.Fatalf("ShowGrid failed: %v", err)
@@ -276,6 +339,8 @@ func TestGridServiceIntegration(t *testing.T) {
 	})
 
 	t.Run("HideGrid integration", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		err := gridService.HideGrid(ctx)
 		if err != nil {
 			t.Fatalf("HideGrid failed: %v", err)
@@ -292,6 +357,8 @@ func TestGridServiceIntegration(t *testing.T) {
 	})
 
 	t.Run("Grid health check", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		health := gridService.Health(ctx)
 		if health == nil {
 			t.Fatal("Health returned nil map")
@@ -324,6 +391,8 @@ func TestScrollServiceIntegration(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Scroll integration", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		// Every direction/amount pair must reach the native scroll API without
 		// error, not just the one combination that happened to be wired up.
 		for _, dir := range []services.ScrollDirection{
@@ -346,6 +415,8 @@ func TestScrollServiceIntegration(t *testing.T) {
 	})
 
 	t.Run("Scroll honors a step override", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		err := scrollService.Scroll(
 			ctx,
 			services.ScrollDirectionDown,
@@ -358,6 +429,8 @@ func TestScrollServiceIntegration(t *testing.T) {
 	})
 
 	t.Run("SetInvertScroll round-trips", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		original := scrollService.IsScrollInverted()
 		t.Cleanup(func() { scrollService.SetInvertScroll(original) })
 
@@ -385,6 +458,8 @@ func TestScrollServiceIntegration(t *testing.T) {
 	})
 
 	t.Run("Hide integration", func(t *testing.T) {
+		startAdapterWatchdog(t)
+
 		err := scrollService.Hide(ctx)
 		if err != nil {
 			t.Fatalf("Hide failed: %v", err)

--- a/internal/config/embedded_config_test.go
+++ b/internal/config/embedded_config_test.go
@@ -41,22 +41,28 @@ func TestEmbeddedDefaultConfig_Validates(t *testing.T) {
 	}
 }
 
-// TestExampleConfigs_Validate loads every config under configs/ the way the
-// daemon would. These files are copied by users verbatim, so a stale role
-// vocabulary in one of them is shipped breakage that no other test sees —
-// only default-config.toml is embedded and reachable through configs.DefaultConfig.
+// shippedExampleConfigs are the configs the project publishes under configs/.
+//
+// They are listed rather than globbed because the directory is also a working
+// area: a local config kept there for testing is not a project artifact, and
+// its problems are not this suite's business. Adding an example here is the
+// deliberate step that puts it under test.
+var shippedExampleConfigs = []string{
+	"default-config.toml",
+	"grid-only-config.toml",
+	"hints-only-config.toml",
+	"recursive-grid-only-config.toml",
+}
+
+// TestExampleConfigs_Validate loads each shipped config the way the daemon
+// would. These files are copied by users verbatim, so a stale role vocabulary
+// in one of them is shipped breakage that no other test sees — only
+// default-config.toml is embedded and reachable through configs.DefaultConfig.
 func TestExampleConfigs_Validate(t *testing.T) {
-	paths, err := filepath.Glob(filepath.Join("..", "..", "configs", "*.toml"))
-	if err != nil {
-		t.Fatalf("failed to glob example configs: %v", err)
-	}
+	for _, name := range shippedExampleConfigs {
+		path := filepath.Join("..", "..", "configs", name)
 
-	if len(paths) == 0 {
-		t.Fatal("no example configs found; the glob path is probably wrong")
-	}
-
-	for _, path := range paths {
-		t.Run(filepath.Base(path), func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			svc := config.NewService(config.DefaultConfig(), path, zap.NewNop(), nil)
 
 			result := svc.LoadWithValidation(path)

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/BurntSushi/toml"
 	"go.uber.org/zap"
@@ -231,6 +232,10 @@ type Service struct {
 	watchers      []chan<- *Config
 	logger        *zap.Logger
 	alertProvider AlertProvider
+	// alertShowing keeps at most one validation alert outstanding. The dialog
+	// is modal and no longer blocks the reload, so without this a run of
+	// failed reloads would stack dialogs and park a goroutine behind each.
+	alertShowing atomic.Bool
 
 	// defaults is the base configuration used as the starting point by
 	// LoadWithValidation. It is initialized from defaultConfigForDecoding()

--- a/internal/config/service_app.go
+++ b/internal/config/service_app.go
@@ -8,6 +8,62 @@ import (
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 )
 
+// alertInvalidReload tells the user which file failed to load, without making
+// the reload wait for them to read it.
+//
+// The alert is a modal dialog on macOS. Shown inline, it held the reload until
+// someone dismissed it — so `neru config reload` reported a receive timeout,
+// which reads as a hung daemon rather than as a bad config file. Every reload
+// has someone waiting on it: the CLI, or the systray menu item. Only the
+// systray has no other way to learn the reload failed, so the alert stays, off
+// the reply's path.
+func (s *Service) alertInvalidReload(
+	ctx context.Context,
+	loadResult *LoadResult,
+	logger *zap.Logger,
+) {
+	if s.alertProvider == nil {
+		return
+	}
+
+	// Showing the alert inline used to serialize these: a second reload could
+	// not start until the first dialog was dismissed. Off the reply's path
+	// that no longer holds, so repeated failures would stack a dialog and park
+	// a goroutine each. One outstanding alert is enough — it names the file to
+	// fix, and fixing it is what the next reload reports on.
+	if !s.alertShowing.CompareAndSwap(false, true) {
+		logger.Debug("Config validation alert already showing; not queueing another")
+
+		return
+	}
+
+	// ShowAlert(ctx, title, message):
+	//   title   = human-readable error summary
+	//   message = config file path so the user knows which file to fix
+	title := loadResult.ValidationError.Error()
+	path := loadResult.ConfigPath
+
+	// The dialog outlives the request that spawned it, so it must not be torn
+	// down when that request's context is canceled.
+	alertCtx := context.WithoutCancel(ctx)
+
+	go func() {
+		defer func() {
+			s.alertShowing.Store(false)
+
+			if recovered := recover(); recovered != nil {
+				logger.Error("panic while showing the config alert",
+					zap.Any("recover", recovered))
+			}
+		}()
+
+		alertErr := s.alertProvider.ShowAlert(alertCtx, title, path)
+		if alertErr != nil {
+			logger.Warn("Failed to show config validation alert", zap.Error(alertErr))
+		}
+	}()
+}
+
 // ReloadWithAppContext reloads configuration with app-specific context and side effects.
 // This handles the app-specific logic for configuration reloading including:
 // - UI alerts for validation errors
@@ -25,16 +81,7 @@ func (s *Service) ReloadWithAppContext(
 			zap.Error(loadResult.ValidationError),
 			zap.String("config_path", loadResult.ConfigPath))
 
-		if s.alertProvider != nil {
-			// ShowAlert(ctx, title, message):
-			//   title   = human-readable error summary
-			//   message = config file path so the user knows which file to fix
-			_ = s.alertProvider.ShowAlert(
-				ctx,
-				loadResult.ValidationError.Error(),
-				loadResult.ConfigPath,
-			)
-		}
+		s.alertInvalidReload(ctx, loadResult, logger)
 
 		return loadResult, derrors.WrapConfigFailed(loadResult.ValidationError, "validate config")
 	}

--- a/internal/config/service_app_test.go
+++ b/internal/config/service_app_test.go
@@ -1,0 +1,182 @@
+package config_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// blockingAlertProvider stands in for the macOS alert, which is a modal dialog
+// that returns only once the user dismisses it.
+type blockingAlertProvider struct {
+	shown    chan struct{}
+	release  chan struct{}
+	showing  atomic.Bool
+	released bool
+}
+
+func newBlockingAlertProvider() *blockingAlertProvider {
+	return &blockingAlertProvider{
+		shown:   make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (p *blockingAlertProvider) ShowAlert(_ context.Context, _, _ string) error {
+	p.showing.Store(true)
+	defer p.showing.Store(false)
+
+	p.shown <- struct{}{}
+
+	<-p.release
+
+	return nil
+}
+
+// isShowing reports whether an alert is currently up.
+func (p *blockingAlertProvider) isShowing() bool {
+	return p.showing.Load()
+}
+
+func (p *blockingAlertProvider) dismiss() {
+	if !p.released {
+		p.released = true
+
+		close(p.release)
+	}
+}
+
+// A reload of an invalid config must report the error to whoever asked for it
+// rather than waiting behind the alert. Held inline, the dialog made
+// `neru config reload` fail with a receive timeout — the daemon looking hung
+// when the real problem was a bad config file.
+func TestReloadWithAppContext_DoesNotWaitForTheAlert(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	// An action no command provides, so validation fails on load.
+	invalid := "[hotkeys]\n\"Primary+Shift+Y\" = \"action bogus_thing\"\n"
+
+	writeErr := os.WriteFile(path, []byte(invalid), 0o600)
+	if writeErr != nil {
+		t.Fatalf("write config: %v", writeErr)
+	}
+
+	alert := newBlockingAlertProvider()
+	t.Cleanup(alert.dismiss)
+
+	service := config.NewService(config.DefaultConfig(), path, zap.NewNop(), alert)
+
+	reloaded := make(chan error, 1)
+
+	go func() {
+		_, err := service.ReloadWithAppContext(context.Background(), path, zap.NewNop())
+		reloaded <- err
+	}()
+
+	select {
+	case err := <-reloaded:
+		if err == nil {
+			t.Fatal("ReloadWithAppContext() = nil, want the validation error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReloadWithAppContext() blocked on the alert instead of reporting the error")
+	}
+
+	// The alert is still shown — it is the only feedback the systray menu
+	// item has — just not on the reply's path.
+	select {
+	case <-alert.shown:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the alert was never shown")
+	}
+}
+
+// Repeated failing reloads must not stack dialogs. Shown inline the alert
+// serialized them — a second reload could not start until the first was
+// dismissed — and moving it off the reply's path removed that, so the limit
+// has to be explicit.
+func TestReloadWithAppContext_ShowsOneAlertAtATime(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	invalid := "[hotkeys]\n\"Primary+Shift+Y\" = \"action bogus_thing\"\n"
+
+	writeErr := os.WriteFile(path, []byte(invalid), 0o600)
+	if writeErr != nil {
+		t.Fatalf("write config: %v", writeErr)
+	}
+
+	alert := newBlockingAlertProvider()
+	t.Cleanup(alert.dismiss)
+
+	service := config.NewService(config.DefaultConfig(), path, zap.NewNop(), alert)
+
+	const reloads = 5
+
+	for range reloads {
+		_, err := service.ReloadWithAppContext(context.Background(), path, zap.NewNop())
+		if err == nil {
+			t.Fatal("ReloadWithAppContext() = nil, want the validation error")
+		}
+	}
+
+	// The first alert is still up and undismissed, so no other may have been
+	// started behind it.
+	select {
+	case <-alert.shown:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first alert was never shown")
+	}
+
+	select {
+	case <-alert.shown:
+		t.Fatal("a second alert was queued while the first was still showing")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Once it is dismissed, a later failure is reported again rather than
+	// being suppressed for good.
+	alert.dismiss()
+
+	waitFor(t, func() bool { return !alert.isShowing() })
+
+	_, err := service.ReloadWithAppContext(context.Background(), path, zap.NewNop())
+	if err == nil {
+		t.Fatal("ReloadWithAppContext() = nil, want the validation error")
+	}
+
+	select {
+	case <-alert.shown:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no alert after the previous one was dismissed")
+	}
+}
+
+// waitFor polls until cond holds, so a test does not depend on how promptly a
+// goroutine is scheduled.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	t.Fatal("condition was not met in time")
+}


### PR DESCRIPTION
## Description

This PR fixes `neru config reload` reporting a timeout when the configuration is
invalid.

Reloading a config that fails validation showed a native alert from inside the
reload. On macOS that alert is modal, so the reload sat behind it until the
dialog was dismissed — and the CLI gave up first:

```
$ neru config reload
[IPC_FAILED] failed to send command: [TIMEOUT] receive timeout: neru may be unresponsive
```

The daemon was neither unresponsive nor wrong: it had already diagnosed the
problem precisely and kept the previous configuration. It just could not say so
until someone clicked a button. The alert now goes up alongside the reply
instead of in front of it, so the reload reports the validation error straight
away. The alert is still shown, because the systray's Reload item has no other
way to report a failure, and at most one alert is outstanding at a time.

This PR also fixes two things in the test suite that share a cause with the
reload — a local development loop reporting something other than what is
actually wrong. The darwin service integration tests get a watchdog, and the
example-config test stops treating every file in `configs/` as one the project
ships.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

The reload fix is platform-agnostic; the symptom is macOS-specific because that
is where the alert is modal. The test change is in a darwin-tagged file.

## Type of Change

- [x] `fix` — Bug fix

## Command and configuration changes

None. No option, command, flag, or default changes. `neru config reload` on an
invalid config now exits with the validation error it always had rather than a
timeout:

```
$ neru config reload
[IPC_FAILED] configuration validate configuration failed: … hints.hotkeys.x: unknown action subcommand: bogus_thing
```

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — the touched test file keeps its `integration && darwin` tags
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new platform capability
- [x] N/A — This PR does not touch platform-specific code — the reload change is shared code; only a darwin-tagged test file is otherwise involved

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — the full suite, integration included
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing interface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Why the alert stays.** Two things trigger a reload: the IPC path
(`neru config reload`, and `config set` / `config reset`, which reload to apply)
and the systray's Reload menu item. The IPC caller gets the error in its reply,
but the systray click has no reply to carry it, so removing the alert would make
that path fail silently. Detaching it from the reply keeps both honest. It runs
under a context derived with `context.WithoutCancel`, so completing the reply
cannot tear down a dialog the user is still reading.

**Why this surfaced now.** The previous change widened validation to cover
`monitor_select` bindings, both Mission Control hooks, and steps nested inside a
`run` or an `--on-exit`. That is a good change, but it means more reloads now
fail validation, and every one of them went through the blocking path. Traffic
through a door that sticks.

**The test change.** The darwin service integration tests drive live
accessibility APIs against whatever window is focused. When the screen is locked
the focused bundle is `com.apple.loginwindow` and that call does not return, so
`just test` stops there indefinitely with no output explaining why — I lost two
runs to it, and had to bisect against a clean worktree to establish it was
pre-existing rather than something I had introduced.

A context deadline cannot bound this, which is worth stating plainly because it
was my first attempt: several adapters take a `context.Context` and discard it
outright (`Scroll(_ context.Context, …)`), and those that do consult it check
only before starting work, so nothing interrupts a call already blocked inside
the platform API. Passing a deadline would have advertised a bound that does not
exist. A watchdog runs instead, one per subtest: if a subtest has not finished
within 30 seconds the run ends with a message naming the likely cause, and the
accompanying stack shows which call is stuck.

Per subtest rather than per test function, because a function holds several and
a shared budget would eventually blame a locked screen for what is only a slow
machine. Demonstrated with a 900ms budget and four subtests sleeping 400ms
each: shared, that panics with a false diagnosis; per subtest, it passes.
Forcing the budget to 1ns still ends the run with the diagnosis and a stack, so
a genuine hang is caught either way.

**On the accumulating alerts.** Showing the dialog inline had one property
worth keeping: it serialized failed reloads, since a second could not start
until the first was dismissed. Moving it off the reply's path removed that, so a
run of failures would have stacked dialogs and parked a goroutine behind each.
A single outstanding alert is now enforced; once dismissed, the next failure
alerts again rather than being suppressed for good.

**The example-config test.** It globbed `configs/*.toml`, but that directory is
also a working area: a config kept there for local testing was validated as
though the project published it, and failed the suite over a file that is not a
project artifact. The shipped examples are now listed explicitly, so the test
asserts what it means to assert — the configs users copy are valid. The tradeoff
is that adding a new example means adding it to that list, which is the
deliberate step that puts it under test.

**Verification.** A blocking alert provider stands in for the modal dialog in a
new test: the reload must return its error while the alert is still up, and the
alert must still be shown. Confirmed it fails against the previous inline
version — it hangs until the 5-second guard — and passes now. A second test
drives five failing reloads against an undismissed alert and asserts only one
was shown, then that dismissing it lets the next failure alert again; it fails
against the unguarded version. Race detector clean. The full `just test`,
integration suite included, is green with the screen unlocked.
