### PR TITLE
feat(cli): add `--json` output to `neru status`

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -168,10 +168,16 @@ Requires a running daemon. Returns to idle. No-op when no mode is active.
 Print the daemon state and current mode.
 
 ```
-neru status
+neru status [--json]
 ```
 
 Requires a running daemon.
+
+**Flags**
+
+| Flag     | Type | Default | Description                                     |
+| -------- | ---- | ------- | ----------------------------------------------- |
+| `--json` | bool | `false` | Print the status as a JSON object, for scripts. |
 
 **Output fields**
 
@@ -179,6 +185,33 @@ Requires a running daemon.
 | -------- | ------------------------------------------------------- |
 | `Status` | `running`, `disabled`                                   |
 | `Mode`   | `idle`, `hints`, `grid`, `recursive_grid`, `scroll`, `monitor_select` |
+
+**JSON output**
+
+`--json` prints the same state as an object, so a script does not have to parse
+the human form. The object goes to stdout on its own; errors go to stderr and
+set a non-zero exit status, so a pipeline never has to distinguish them:
+
+```bash
+$ neru status --json | jq -r .mode
+idle
+```
+
+The examples here and in [Tips & Tricks](TIPS_TRICKS.md) use
+[`jq`](https://jqlang.github.io/jq/) to read the object; any JSON tool does.
+
+| Key                                                     | Type   | Description                                              |
+| ------------------------------------------------------- | ------ | -------------------------------------------------------- |
+| `enabled`                                               | bool   | `false` after `neru stop`, `true` after `neru start`.     |
+| `mode`                                                  | string | The active mode, same values as `Mode` above.             |
+| `config`                                                | string | Path of the configuration file in use.                    |
+| `hints_enabled`, `grid_enabled`, `recursive_grid_enabled` | bool | Whether each mode is enabled in the configuration.        |
+| `capabilities`                                          | object | Per-subsystem support on this platform, as `neru doctor` reports it. |
+| `profile`                                               | object | The platform backend profile: which adapter serves each subsystem, and whether it needs CGO. |
+
+The six scalar keys above are the stable part of this output. `capabilities` and
+`profile` follow the platform support matrix and gain entries as subsystems are
+added, so read the keys you need rather than assuming the whole set.
 
 ---
 
@@ -1273,8 +1306,7 @@ compose with shell scripts and external hotkey daemons.
 **Toggle the daemon**
 
 ```bash
-STATUS=$(neru status | grep "Status:" | awk '{print $2}')
-if [ "$STATUS" = "running" ]; then
+if [ "$(neru status --json | jq -r .enabled)" = "true" ]; then
     neru stop
 else
     neru start

--- a/docs/TIPS_TRICKS.md
+++ b/docs/TIPS_TRICKS.md
@@ -438,15 +438,15 @@ This is useful for testing a config before committing it to your dotfiles, or fo
 Quickly open your config in an editor without hunting for the file path:
 
 ```bash
-neru status | grep Config | awk '{print $2}' | xargs nvim
+neru status --json | jq -r .config | xargs nvim
 ```
 
 Or if you would like to open a new window and edit the config:
 
 ```bash
 # both works the same except one uses ghostty cli and another uses macos open command
-ghostty -e bash -c "neru status | grep Config | awk '{print \$2}' | xargs nvim" # check if your terminal has equivalent cli support
-open -na Ghostty --args -e bash -c "neru status | grep Config | awk '{print \$2}' | xargs nvim" # this should generally work
+ghostty -e bash -c "neru status --json | jq -r .config | xargs nvim" # check if your terminal has equivalent cli support
+open -na Ghostty --args -e bash -c "neru status --json | jq -r .config | xargs nvim" # this should generally work
 ```
 
 You can wrap this in a shell alias or bind it to a key in your window manager / hotkey daemon.

--- a/internal/cli/cliutil/util.go
+++ b/internal/cli/cliutil/util.go
@@ -95,6 +95,27 @@ func NewOutputFormatter() *OutputFormatter {
 	return &OutputFormatter{}
 }
 
+// PrintJSON prints a command's payload as indented JSON, for callers that are
+// scripts rather than people.
+//
+// It prints the payload alone rather than the IPC envelope around it: a script
+// asking for the state wants the state, and a failed command reports through
+// the exit status and stderr as every other command does.
+func (f *OutputFormatter) PrintJSON(cmd *cobra.Command, data any) error {
+	encoded, encodeErr := json.MarshalIndent(data, "", "  ")
+	if encodeErr != nil {
+		return derrors.Wrap(
+			encodeErr,
+			derrors.CodeSerializationFailed,
+			"failed to marshal command output",
+		)
+	}
+
+	cmd.Println(string(encoded))
+
+	return nil
+}
+
 // PrintStatus prints status information in a formatted way.
 func (f *OutputFormatter) PrintStatus(cmd *cobra.Command, data any) error {
 	cmd.Println("Neru Status:")

--- a/internal/cli/cliutil/util_test.go
+++ b/internal/cli/cliutil/util_test.go
@@ -3,13 +3,17 @@ package cliutil
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
 
-const testCgoRequired = "cgo_required"
+const (
+	testCgoRequired    = "cgo_required"
+	testPlatformDarwin = "darwin"
+)
 
 func TestIsHealthyHealthStatus(t *testing.T) {
 	testCases := []struct {
@@ -93,5 +97,56 @@ func TestPrintProfile(t *testing.T) {
 		if !strings.Contains(got, expectedLine) {
 			t.Fatalf("PrintProfile output missing %q in:\n%s", expectedLine, got)
 		}
+	}
+}
+
+// The JSON form is what a script reads, so it must be the payload itself —
+// parseable, and without the IPC envelope wrapped around it.
+func TestPrintJSON(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+
+	formatter := NewOutputFormatter()
+
+	err := formatter.PrintJSON(cmd, map[string]any{
+		"enabled": true,
+		"mode":    "idle",
+		"nested":  map[string]any{"platform": testPlatformDarwin},
+	})
+	if err != nil {
+		t.Fatalf("PrintJSON() error = %v", err)
+	}
+
+	var decoded map[string]any
+
+	decodeErr := json.Unmarshal(output.Bytes(), &decoded)
+	if decodeErr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", decodeErr, output.String())
+	}
+
+	if decoded["mode"] != "idle" || decoded["enabled"] != true {
+		t.Fatalf("decoded = %v, want the payload verbatim", decoded)
+	}
+
+	if !strings.Contains(output.String(), "\n  \"mode\"") {
+		t.Fatalf("output is not indented for reading:\n%s", output.String())
+	}
+}
+
+// A payload that cannot be encoded has to surface as an error rather than as
+// empty output a script would read as success.
+func TestPrintJSON_ReportsUnencodablePayload(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+
+	err := NewOutputFormatter().PrintJSON(cmd, make(chan int))
+	if err == nil {
+		t.Fatal("PrintJSON() = nil, want an error for an unencodable payload")
 	}
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
-
 	"github.com/spf13/cobra"
 
 	"github.com/y3owk1n/neru/internal/core/domain"
@@ -58,19 +56,7 @@ var configDumpCmd = &cobra.Command{
 			return derrors.New(derrors.CodeIPCFailed, ipcResponse.Message)
 		}
 
-		// Marshal pretty JSON
-		ipcResponseData, ipcResponseDataErr := json.MarshalIndent(ipcResponse.Data, "", "  ")
-		if ipcResponseDataErr != nil {
-			return derrors.Wrap(
-				ipcResponseDataErr,
-				derrors.CodeSerializationFailed,
-				"failed to marshal config",
-			)
-		}
-
-		cmd.Println(string(ipcResponseData))
-
-		return nil
+		return formatter.PrintJSON(cmd, ipcResponse.Data)
 	},
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -11,11 +11,19 @@ var StatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show Neru daemon status",
 	Long: `Display whether Neru is running, the active mode, and the current
-configuration state (running or paused).`,
+configuration state (running or paused).
+
+Use --json to print the same information as a JSON object, for scripts and
+other tools that drive Neru.`,
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		return requiresRunningInstance()
 	},
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		asJSON, flagErr := cmd.Flags().GetBool("json")
+		if flagErr != nil {
+			return flagErr
+		}
+
 		communicator := cliutil.NewIPCCommunicator(timeoutSec)
 
 		ipcResponse, err := communicator.SendCommand("status", []string{})
@@ -27,10 +35,16 @@ configuration state (running or paused).`,
 			return communicator.HandleResponse(cmd, ipcResponse)
 		}
 
+		if asJSON {
+			return formatter.PrintJSON(cmd, ipcResponse.Data)
+		}
+
 		return formatter.PrintStatus(cmd, ipcResponse.Data)
 	},
 }
 
 func init() {
+	StatusCmd.Flags().Bool("json", false, "Print the status as a JSON object")
+
 	RootCmd.AddCommand(StatusCmd)
 }


### PR DESCRIPTION
## Description

This PR adds a machine-readable form of `neru status`, so anything driving Neru
from outside can read its state by field name instead of parsing the display
output.

Until now the only way to get the current mode or config path was to pick it out
of the human-formatted text. The documentation did exactly that in two places —
`neru status | grep Config | awk '{print $2}'` — which breaks as soon as a label
or a column changes. The daemon already answers with structured data; only the
rendering was human-only, so this exposes what was already there rather than
adding any new state.

The status object gains nothing beyond what the text form shows. Two fields a
script driving `neru run` would plausibly want — the current selection point and
the list of monitors — are deliberately not part of this change, since adding
them means new state in the payload and a separate decision about their shape.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature

## Command and configuration changes

**New flag**

| Flag | Command | Type | Default | Description |
| --- | --- | --- | --- | --- |
| `--json` | `neru status` | bool | `false` | Print the status as a JSON object instead of the display form. |

```bash
$ neru status --json | jq -r .mode
idle
```

**Keys, and which are stable**

| Key | Type | Description |
| --- | --- | --- |
| `enabled` | bool | `false` after `neru stop`, `true` after `neru start`. |
| `mode` | string | Active mode: `idle`, `hints`, `grid`, `recursive_grid`, `scroll`, `monitor_select`. |
| `config` | string | Path of the configuration file in use. |
| `hints_enabled`, `grid_enabled`, `recursive_grid_enabled` | bool | Whether each mode is enabled in the configuration. |
| `capabilities` | object | Per-subsystem support on this platform, as `neru doctor` reports it. |
| `profile` | object | Platform backend profile: which adapter serves each subsystem, and whether it needs CGO. |

The six scalar keys are documented as the stable part of this output.
`capabilities` and `profile` follow the platform support matrix and gain entries
as subsystems are added, so callers should read the keys they need rather than
assume the whole set. Worth a second opinion on that split — it is the part of
this change that becomes a promise.

No configuration options change, and no existing command output changes: the
display form of `neru status` is byte-for-byte what it was, and `config dump`
still prints exactly what it printed before.

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no platform-specific code in this change
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new platform capability
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — the full suite, integration included
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Why this was cheap.** The status handler already returns a structured payload
and the CLI rendered it as text. The flag chooses a different renderer for the
same data, so there is no new daemon state, no new IPC command, and nothing to
keep in sync between the two forms.

**One printer, not two.** `config dump` carried its own marshal-and-print block.
Both now go through the same helper, so the project cannot end up with two
encoders formatting JSON differently — the failure mode this codebase has been
consolidating away from elsewhere.

**Streams.** Cobra writes command output to stderr unless the program says
otherwise, which would have made `--json` invisible to a pipe. It works because
`fix(cli): write output to stdout so that they are pipeable` (#1047) set stdout
as the output; this change depends on that and was verified against it rather
than assumed. Confirmed with the daemon running and stopped: the object is alone
on stdout, errors are on stderr with a non-zero exit, and stdout is empty when
the command fails, so `neru status --json | jq` never receives a non-JSON line.

**The examples now need `jq`.** The two documentation recipes rewritten here
previously used only `grep` and `awk`. Parsing JSON with those is worse than the
problem, so the examples use `jq` and the reference says so and links it. Nothing
existing breaks: the display output those old recipes read is unchanged, so a
script already using them keeps working.

**Verification.** Two unit tests cover the printer — a payload round-trips
through the output and is indented for reading, and an unencodable payload
returns an error rather than printing nothing a script would read as success.
Against a live daemon: the object parses, is exactly one document, exits zero,
survives `2>/dev/null`, and the two rewritten documentation recipes were run
verbatim, including toggling the daemon and watching `enabled` flip.
