### PR TITLE
feat(cli): add `--state` to the toggles and a `macro` command

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -21,7 +21,7 @@ The same content is available as manpages (`man neru`) after installation.
 - [Daemon lifecycle](#daemon-lifecycle) — `launch` · `start` · `stop` · `idle` · `status` · `doctor`
 - [Navigation modes](#navigation-modes) — `hints` · `grid` · `recursive_grid` · `scroll` · `monitor_select`
 - [Actions](#actions) — `action` and its subcommands
-- [Sequences](#sequences) — `run`
+- [Sequences](#sequences) — `run` · `macro`
 - [Configuration commands](#configuration-commands) — `config`
 - [Runtime toggles](#runtime-toggles)
 - [Utilities](#utilities) — `roles` · `services` · `docs`
@@ -90,6 +90,7 @@ Accepted by every command.
 | [`monitor_select`](#neru-monitor_select)                     | Jump the cursor to a display    | Yes | macOS · Linux |
 | [`action`](#actions)                                         | One-shot mouse/scroll/key input | Yes | All ² |
 | [`run`](#neru-run)                                           | Run several actions in order    | Yes | All |
+| [`macro`](#neru-macro)                                       | Run a named sequence from config | Yes | All |
 | [`config`](#configuration-commands)                          | Inspect and change config       | Mixed | All |
 | [`toggle-scroll-invert`](#neru-toggle-scroll-invert)         | Invert scroll direction         | Yes | All |
 | [`toggle-cursor-follow-selection`](#neru-toggle-cursor-follow-selection) | Toggle cursor follow | Yes | All |
@@ -206,12 +207,35 @@ The examples here and in [Tips & Tricks](TIPS_TRICKS.md) use
 | `mode`                                                  | string | The active mode, same values as `Mode` above.             |
 | `config`                                                | string | Path of the configuration file in use.                    |
 | `hints_enabled`, `grid_enabled`, `recursive_grid_enabled` | bool | Whether each mode is enabled in the configuration.        |
+| `scroll_inverted`                                       | bool   | Set by [`toggle-scroll-invert`](#neru-toggle-scroll-invert). |
+| `hidden_for_screen_share`                               | bool   | Set by [`toggle-screen-share`](#neru-toggle-screen-share). `true` means hidden. |
+| `cursor_follow_selection`                               | bool or null | Set by [`toggle-cursor-follow-selection`](#neru-toggle-cursor-follow-selection). `null` when no mode is running. |
 | `capabilities`                                          | object | Per-subsystem support on this platform, as `neru doctor` reports it. |
 | `profile`                                               | object | The platform backend profile: which adapter serves each subsystem, and whether it needs CGO. |
 
-The six scalar keys above are the stable part of this output. `capabilities` and
-`profile` follow the platform support matrix and gain entries as subsystems are
-added, so read the keys you need rather than assuming the whole set.
+The nine scalar keys above are the stable part of this output. `capabilities`
+and `profile` follow the platform support matrix and gain entries as subsystems
+are added, so read the keys you need rather than assuming the whole set.
+
+### Reading the toggles
+
+The three `toggle-*` commands change state that would otherwise be invisible.
+Each reports under the key above, so a script can set a state with `--state` and
+confirm it:
+
+```bash
+neru toggle-scroll-invert --state on
+neru status --json | jq -r .scroll_inverted   # true
+```
+
+`cursor_follow_selection` is `null` rather than `false` when no mode is running,
+because the two are different answers: `false` is a running mode that is not
+following the selection, `null` is that there is nothing to follow it with.
+Test for it before treating the value as a boolean:
+
+```bash
+neru status --json | jq -r 'if .cursor_follow_selection == null then "no mode" else .cursor_follow_selection end'
+```
 
 ---
 
@@ -1001,6 +1025,52 @@ neru run "hints --action left_click" "action wait_for_mode_exit --bail" \
 
 ---
 
+## neru macro
+
+Run a named sequence from the [`[macros]`](CONFIGURATION.md#macros) table.
+
+```
+neru macro <name> [arg...]
+```
+
+Requires a running daemon. The daemon runs the macro exactly as it would when a
+hotkey binding invokes `macro <name>`, so a sequence written once is available
+to bindings and to external drivers alike.
+
+Arguments fill the macro's positional placeholders (`$1`, `$2`, …), and the
+count must match the highest placeholder the body uses. They are passed through
+as given, so an argument containing spaces or quotes needs no quoting beyond
+what the shell already does:
+
+```bash
+neru macro say_it "hello there"
+```
+
+This is why the command exists alongside `neru run "macro say_it 'hello there'"`,
+which would work for that example but requires quoting the whole call into one
+step — something no argument containing both kinds of quote survives.
+
+**Exit status**
+
+Same as [`neru run`](#neru-run): `ERR_INVALID_INPUT` for an unknown macro or the
+wrong number of arguments, `ERR_CHAIN_BAIL` when a step cancelled the sequence,
+`ERR_ACTION_FAILED` when a step failed.
+
+**Timeouts**
+
+A macro containing sleeps or `wait_for_mode_exit` can outlast the default
+10-second IPC timeout, exactly as a `run` can. Raise it with `--timeout`.
+
+**Examples**
+
+```bash
+neru macro window_click
+neru macro zoom_click 3
+neru --timeout 30 macro click_and_settle
+```
+
+---
+
 # Configuration commands
 
 Full option reference: [CONFIGURATION.md](CONFIGURATION.md).
@@ -1165,16 +1235,45 @@ effect only after a full daemon restart.
 Each toggle changes daemon state for the current session only; the configured
 value is restored on restart.
 
+## The `--state` flag
+
+All three `toggle-*` commands accept `--state`, which names the state to end up
+in instead of flipping whatever is there:
+
+| Value              | Effect                                       |
+| ------------------ | -------------------------------------------- |
+| `on`               | Turn it on, whether or not it already was.   |
+| `off`              | Turn it off, whether or not it already was.  |
+| `toggle` (default) | Flip it. Same as passing no flag.            |
+
+Flipping is the right default for a key binding, where you see the result and
+press again if it went the wrong way. A script has no such feedback loop: it
+cannot tell a state it set from one a stray keypress set, and a binding pressed
+twice leaves the daemon somewhere the script does not expect. `--state` makes
+these commands idempotent, and `neru status --json` reports every state they
+change — see [Reading the toggles](#reading-the-toggles).
+
+`--state toggle` exists so a value can be passed straight through without the
+caller special-casing the flip:
+
+```toml
+[macros]
+scroll_invert = ["toggle-scroll-invert --state $1"]
+```
+
+---
+
 ## neru toggle-scroll-invert
 
 Invert the scroll direction.
 
 ```
-neru toggle-scroll-invert
+neru toggle-scroll-invert [--state on|off|toggle]
 ```
 
 Requires a running daemon. Overrides `scroll.invert_scroll` until restart. Also
-available from the systray menu.
+available from the systray menu. Reported as `scroll_inverted` by
+`neru status --json`.
 
 ---
 
@@ -1183,11 +1282,17 @@ available from the systray menu.
 Toggle whether the real cursor follows the selection.
 
 ```
-neru toggle-cursor-follow-selection
+neru toggle-cursor-follow-selection [--state on|off|toggle]
 ```
 
 Requires a running daemon. Applies to the active hints, grid, or
 recursive_grid session.
+
+The preference belongs to that session rather than to the daemon, so unlike the
+other two toggles this one fails when no mode is running — including when
+`--state` names the state it wants, since there is nothing yet to hold it.
+Reported as `cursor_follow_selection` by `neru status --json`, and `null` while
+no mode is running.
 
 ---
 
@@ -1196,12 +1301,16 @@ recursive_grid session.
 Hide or show overlays on shared screens.
 
 ```
-neru toggle-screen-share
+neru toggle-screen-share [--state on|off|toggle]
 ```
 
 **Platforms:** macOS only.
 
 Requires a running daemon. Hidden overlays remain visible locally.
+
+`--state on` hides the overlay and `--state off` shows it, matching the
+`hidden_for_screen_share` field of `neru status --json`: the flag names the
+state that is reported, not the visibility.
 
 Implemented with the deprecated `NSWindow.sharingType` API, so effectiveness
 depends on the macOS version and the screen-sharing application:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -630,6 +630,15 @@ rest of the calling sequence should not continue past it.
 Macros are not accepted as a mode's `--action`, which takes a mouse button
 name; use `--on-exit` for a sequence that follows the action.
 
+**A macro is also reachable from outside**, with
+[`neru macro <name> [args...]`](CLI.md#neru-macro). The daemon runs it exactly
+as a binding does, so an external driver (skhd, Hammerspoon, a shell script)
+shares the same definition rather than keeping its own copy:
+
+```bash
+neru macro window_click 100 70
+```
+
 ## [general]
 
 Global behaviour that is not tied to a single mode: app exclusions, keyboard

--- a/internal/app/app_initialization_steps.go
+++ b/internal/app/app_initialization_steps.go
@@ -430,6 +430,7 @@ func initializeIPCController(app *App) {
 		KeyFeed:         app.keyFeed,
 		ReloadConfig:    app.ReloadConfig,
 		ExecuteSequence: app.executeActionSequenceWithPolicy,
+		ExecuteMacro:    app.executeMacro,
 		Logger:          app.logger,
 	})
 

--- a/internal/app/ipc_controller.go
+++ b/internal/app/ipc_controller.go
@@ -47,6 +47,10 @@ type IPCController struct {
 	// reports that sequencing is unavailable.
 	ExecuteSequence sequenceRunner
 
+	// ExecuteMacro runs a named macro. If nil, the "macro" command reports
+	// that macros are unavailable.
+	ExecuteMacro macroRunner
+
 	// Info handler for config updates
 	infoHandler *IPCControllerInfo
 
@@ -90,6 +94,9 @@ type IPCControllerDeps struct {
 	// ExecuteSequence runs an action sequence on behalf of the "run" command.
 	ExecuteSequence sequenceRunner
 
+	// ExecuteMacro runs a named macro on behalf of the "macro" command.
+	ExecuteMacro macroRunner
+
 	Logger *zap.Logger
 }
 
@@ -114,6 +121,7 @@ func NewIPCController(deps IPCControllerDeps) *IPCController {
 		KeyFeed:         deps.KeyFeed,
 		ReloadConfig:    deps.ReloadConfig,
 		ExecuteSequence: deps.ExecuteSequence,
+		ExecuteMacro:    deps.ExecuteMacro,
 		Logger:          logger.Named("ipc.controller"),
 		Handlers:        make(map[string]func(context.Context, ipc.Command) ipc.Response),
 	}
@@ -222,6 +230,6 @@ func (c *IPCController) registerHandlers(cfg *config.Config) {
 	scrollHandler.RegisterHandlers(c.Handlers)
 
 	// Register action sequence handler
-	sequenceHandler := NewIPCControllerSequence(c.ExecuteSequence, c.Logger)
+	sequenceHandler := NewIPCControllerSequence(c.ExecuteSequence, c.ExecuteMacro, c.Logger)
 	sequenceHandler.RegisterHandlers(c.Handlers)
 }

--- a/internal/app/ipc_handlers.go
+++ b/internal/app/ipc_handlers.go
@@ -745,13 +745,28 @@ func (h *IPCControllerModes) handleIdle(_ context.Context, _ ipc.Command) ipc.Re
 
 func (h *IPCControllerModes) handleToggleCursorFollowSelection(
 	_ context.Context,
-	_ ipc.Command,
+	cmd ipc.Command,
 ) ipc.Response {
 	if h.modes == nil {
 		return h.modesUnavailableResponse()
 	}
 
-	enabled, ok := h.modes.ToggleCursorFollowSelection()
+	desired, errResponse := parseToggleState(
+		domain.CommandToggleCursorFollowSelection,
+		cmd.Args,
+	)
+	if errResponse != nil {
+		return *errResponse
+	}
+
+	// The preference belongs to the active mode's session rather than to the
+	// daemon, so unlike the other two toggles this one has nothing to set when
+	// no mode is running — including when --state named the state it wants.
+	enabled, ok := applyToggleStateWithResult(
+		desired,
+		h.modes.ToggleCursorFollowSelection,
+		h.modes.SetCursorFollowSelection,
+	)
 	if !ok {
 		return ipc.Response{
 			Success: false,
@@ -769,6 +784,7 @@ func (h *IPCControllerModes) handleToggleCursorFollowSelection(
 		Success: true,
 		Message: "cursor_follow_selection " + state,
 		Code:    ipc.CodeOK,
+		Data:    map[string]bool{"following": enabled},
 	}
 }
 
@@ -865,10 +881,21 @@ func (h *IPCControllerOverlay) RegisterHandlers(
 
 func (h *IPCControllerOverlay) handleToggleScreenShare(
 	_ context.Context,
-	_ ipc.Command,
+	cmd ipc.Command,
 ) ipc.Response {
-	// Atomically toggle to avoid check-then-act race
-	newState := h.appState.ToggleHiddenForScreenShare()
+	desired, errResponse := parseToggleState(domain.CommandToggleScreenShare, cmd.Args)
+	if errResponse != nil {
+		return *errResponse
+	}
+
+	// --state names the reported state, so "on" is hidden. Naming it after the
+	// visibility instead would invert between the flag and the status field.
+	newState := applyToggleState(
+		desired,
+		// Atomically toggle to avoid check-then-act race
+		h.appState.ToggleHiddenForScreenShare,
+		h.appState.SetHiddenForScreenShare,
+	)
 
 	status := "visible"
 	if newState {
@@ -912,10 +939,19 @@ func (h *IPCControllerScroll) RegisterHandlers(
 
 func (h *IPCControllerScroll) handleToggleScrollInvert(
 	_ context.Context,
-	_ ipc.Command,
+	cmd ipc.Command,
 ) ipc.Response {
-	// Atomically toggle to avoid check-then-act race
-	newState := h.appState.ToggleScrollInverted()
+	desired, errResponse := parseToggleState(domain.CommandToggleScrollInvert, cmd.Args)
+	if errResponse != nil {
+		return *errResponse
+	}
+
+	newState := applyToggleState(
+		desired,
+		// Atomically toggle to avoid check-then-act race
+		h.appState.ToggleScrollInverted,
+		h.appState.SetScrollInverted,
+	)
 
 	if h.scrollService != nil {
 		h.scrollService.SetInvertScroll(newState)

--- a/internal/app/ipc_handlers_test.go
+++ b/internal/app/ipc_handlers_test.go
@@ -2,6 +2,7 @@ package app_test
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -243,5 +244,148 @@ func TestExtractModeOptions_ModifierEmptyList(t *testing.T) {
 	expectedMsg := "modifier values cannot be empty"
 	if !strings.Contains(resp.Message, expectedMsg) {
 		t.Fatalf("expected error message containing %q, got: %q", expectedMsg, resp.Message)
+	}
+}
+
+// newToggleTestController builds a controller over the real registration path,
+// so these tests exercise the wiring rather than a handler called directly.
+func newToggleTestController(
+	appState *state.AppState,
+	executeMacro func(context.Context, string, []string) error,
+) *app.IPCController {
+	cfg := config.DefaultConfig()
+	logger := zap.NewNop()
+	actionService := services.NewActionService(
+		&portmocks.MockAccessibilityPort{},
+		&portmocks.MockOverlayPort{},
+		&portmocks.MockSystemPort{},
+		logger,
+	)
+
+	return app.NewIPCController(app.IPCControllerDeps{
+		ActionService: actionService,
+		ConfigService: config.NewService(cfg, "", logger, nil),
+		AppState:      appState,
+		Config:        cfg,
+		Modes:         newTestModesHandler(cfg, logger, appState, actionService),
+		ExecuteMacro:  executeMacro,
+		Logger:        logger,
+	})
+}
+
+func TestHandleCommand_MacroReachesTheRunner(t *testing.T) {
+	var (
+		gotName string
+		gotArgs []string
+	)
+
+	controller := newToggleTestController(
+		state.NewAppState(),
+		func(_ context.Context, name string, args []string) error {
+			gotName, gotArgs = name, args
+
+			return nil
+		},
+	)
+
+	resp := controller.HandleCommand(context.Background(), ipc.Command{
+		Action: "macro",
+		Args:   []string{"window_click", "100", "70"},
+	})
+
+	if !resp.Success {
+		t.Fatalf("HandleCommand(macro) = %+v, want success", resp)
+	}
+
+	if gotName != "window_click" {
+		t.Fatalf("macro name = %q, want %q", gotName, "window_click")
+	}
+
+	if strings.Join(gotArgs, ",") != "100,70" {
+		t.Fatalf("macro args = %v, want [100 70]", gotArgs)
+	}
+}
+
+func TestHandleCommand_ToggleStateConvergesThroughTheController(t *testing.T) {
+	appState := state.NewAppState()
+	appState.SetScrollInverted(true)
+
+	controller := newToggleTestController(appState, nil)
+
+	// Asking twice for the same state must land there both times: that is what
+	// a script relies on and what a bare toggle cannot give it.
+	for range 2 {
+		resp := controller.HandleCommand(context.Background(), ipc.Command{
+			Action: "toggle-scroll-invert",
+			Args:   []string{"--state=off"},
+		})
+
+		if !resp.Success {
+			t.Fatalf("HandleCommand(toggle-scroll-invert) = %+v, want success", resp)
+		}
+
+		if appState.IsScrollInverted() {
+			t.Fatal("scroll inverted = true, want --state=off to converge on off")
+		}
+	}
+}
+
+func TestHandleCommand_StatusReportsTheToggles(t *testing.T) {
+	appState := state.NewAppState()
+	appState.SetScrollInverted(true)
+	appState.SetHiddenForScreenShare(true)
+
+	controller := newToggleTestController(appState, nil)
+
+	resp := controller.HandleCommand(context.Background(), ipc.Command{Action: "status"})
+	if !resp.Success {
+		t.Fatalf("HandleCommand(status) = %+v, want success", resp)
+	}
+
+	status, ok := resp.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("status data = %T, want map[string]any", resp.Data)
+	}
+
+	for key, want := range map[string]bool{
+		"scroll_inverted":         true,
+		"hidden_for_screen_share": true,
+	} {
+		got, isBool := status[key].(bool)
+		if !isBool {
+			t.Fatalf("status[%q] = %v (%T), want a bool", key, status[key], status[key])
+		}
+
+		if got != want {
+			t.Fatalf("status[%q] = %t, want %t", key, got, want)
+		}
+	}
+
+	// No mode is running, so the session-scoped toggle has no state to report.
+	// Null and false are different answers and the payload must not conflate
+	// them.
+	value, present := status["cursor_follow_selection"]
+	if !present {
+		t.Fatal("status is missing cursor_follow_selection")
+	}
+
+	if follow, isPointer := value.(*bool); !isPointer || follow != nil {
+		t.Fatalf("status[cursor_follow_selection] = %v, want nil while no mode runs", value)
+	}
+
+	// What a script actually reads is the encoded form, so pin that rather than
+	// the Go value: "neru status --json | jq .cursor_follow_selection" has to
+	// print null, not false and not a missing key.
+	encoded, encodeErr := json.Marshal(status)
+	if encodeErr != nil {
+		t.Fatalf("json.Marshal(status) error = %v", encodeErr)
+	}
+
+	if !strings.Contains(string(encoded), `"cursor_follow_selection":null`) {
+		t.Fatalf("encoded status does not report a null toggle:\n%s", encoded)
+	}
+
+	if !strings.Contains(string(encoded), `"scroll_inverted":true`) {
+		t.Fatalf("encoded status does not report the scroll toggle:\n%s", encoded)
 	}
 }

--- a/internal/app/ipc_info.go
+++ b/internal/app/ipc_info.go
@@ -178,6 +178,13 @@ func (h *IPCControllerInfo) handleStatus(_ context.Context, _ ipc.Command) ipc.R
 		"recursive_grid_enabled": cfg.RecursiveGrid.Enabled,
 		"capabilities":           capabilitiesMap(h.systemCapabilities()),
 		"profile":                profileMap(platform.CurrentProfile()),
+
+		// The runtime toggles. They are reported under the names the
+		// corresponding toggle-* command reports, so a caller can set one with
+		// --state and read back the field it just named.
+		"scroll_inverted":         h.appState.IsScrollInverted(),
+		"hidden_for_screen_share": h.appState.IsHiddenForScreenShare(),
+		"cursor_follow_selection": h.cursorFollowSelection(),
 	}
 
 	return ipc.Response{
@@ -186,6 +193,27 @@ func (h *IPCControllerInfo) handleStatus(_ context.Context, _ ipc.Command) ipc.R
 		Data:    status,
 		Code:    ipc.CodeOK,
 	}
+}
+
+// cursorFollowSelection reports the active mode's cursor-follow-selection
+// preference, or nil when no mode carries one.
+//
+// It is null rather than false in that case because the two are different
+// answers: false means a running mode is not following the selection, and null
+// means there is nothing to follow it with. A caller that treated the absence
+// as false would think it had read a state it can in fact only set once a mode
+// is running.
+func (h *IPCControllerInfo) cursorFollowSelection() *bool {
+	if h.modes == nil {
+		return nil
+	}
+
+	enabled, ok := h.modes.CursorFollowSelection()
+	if !ok {
+		return nil
+	}
+
+	return &enabled
 }
 
 func (h *IPCControllerInfo) handleConfig(ctx context.Context, cmd ipc.Command) ipc.Response {

--- a/internal/app/ipc_sequence.go
+++ b/internal/app/ipc_sequence.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/core/domain"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
 )
 
@@ -21,6 +22,16 @@ type sequenceRunner func(
 	policy sequencePolicy,
 ) sequenceOutcome
 
+// macroRunner runs one named macro with its arguments and reports what
+// happened. It is the same call the executor makes for a "macro" step, injected
+// so the IPC layer does not reach back into the App.
+//
+// It takes the arguments already split rather than a step string because the
+// CLI hands them over split, and reassembling them into one step only to split
+// it again would put every argument through a round of quoting it does not need
+// to survive.
+type macroRunner func(ctx context.Context, name string, args []string) error
+
 // stopOnErrorFlag makes every step of a run fatal, so a script does not have to
 // repeat the per-step directive on each one.
 const stopOnErrorFlag = "--stop-on-error"
@@ -33,19 +44,24 @@ const stopOnErrorFlag = "--stop-on-error"
 // scripts) can compose steps in one call instead of paying a process spawn
 // per step and losing bail handling in between.
 type IPCControllerSequence struct {
-	run    sequenceRunner
-	logger *zap.Logger
+	run      sequenceRunner
+	runMacro macroRunner
+	logger   *zap.Logger
 }
 
 // NewIPCControllerSequence creates a new sequence command handler. A nil runner
-// is valid: the command then reports that sequencing is unavailable, matching
-// how the other handlers treat a missing dependency.
-func NewIPCControllerSequence(run sequenceRunner, logger *zap.Logger) *IPCControllerSequence {
+// is valid: the corresponding command then reports that it is unavailable,
+// matching how the other handlers treat a missing dependency.
+func NewIPCControllerSequence(
+	run sequenceRunner,
+	runMacro macroRunner,
+	logger *zap.Logger,
+) *IPCControllerSequence {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 
-	return &IPCControllerSequence{run: run, logger: logger}
+	return &IPCControllerSequence{run: run, runMacro: runMacro, logger: logger}
 }
 
 // RegisterHandlers registers the sequence command handlers.
@@ -53,6 +69,71 @@ func (h *IPCControllerSequence) RegisterHandlers(
 	handlers map[string]func(context.Context, ipc.Command) ipc.Response,
 ) {
 	handlers[domain.CommandRun] = h.handleRun
+	handlers[domain.CommandMacro] = h.handleMacro
+}
+
+// handleMacro runs the macro named by the command's first argument, passing the
+// rest as its arguments.
+//
+// A macro is already reachable as a step ("neru run 'macro zoom 3'"), but only
+// by writing the call as one string. Going through this command instead keeps
+// the arguments as the caller passed them, so an argument containing spaces or
+// quotes does not have to survive being quoted into a step and split back out.
+func (h *IPCControllerSequence) handleMacro(ctx context.Context, cmd ipc.Command) ipc.Response {
+	if len(cmd.Args) == 0 || strings.TrimSpace(cmd.Args[0]) == "" {
+		return ipc.Response{
+			Success: false,
+			Message: "macro requires a name (e.g., neru macro window_click)",
+			Code:    ipc.CodeInvalidInput,
+		}
+	}
+
+	if h.runMacro == nil {
+		return ipc.Response{
+			Success: false,
+			Message: "macros are not available",
+			Code:    ipc.CodeActionFailed,
+		}
+	}
+
+	// Only the name is trimmed. The arguments are the macro's data rather than
+	// steps, so they are passed on exactly as given: trimming them would
+	// silently rewrite an argument whose padding matters, and dropping the
+	// blank ones would shift every later argument onto the wrong placeholder.
+	name, macroArgs := strings.TrimSpace(cmd.Args[0]), cmd.Args[1:]
+
+	h.logger.Debug("Running macro", zap.Int("args", len(macroArgs)))
+
+	macroErr := h.runMacro(ctx, name, macroArgs)
+	if macroErr == nil {
+		return ipc.Response{
+			Success: true,
+			Message: fmt.Sprintf("ran macro %q", name),
+			Code:    ipc.CodeOK,
+		}
+	}
+
+	return ipc.Response{
+		Success: false,
+		Message: macroErr.Error(),
+		Code:    macroFailureCode(macroErr),
+	}
+}
+
+// macroFailureCode maps a macro failure onto the IPC code that describes it.
+//
+// The distinctions matter to a caller: a bail is a canceled mode rather than a
+// fault, and an invalid call (no such macro, wrong number of arguments) is
+// worth telling apart from a step that ran and failed.
+func macroFailureCode(err error) string {
+	switch {
+	case derrors.IsCode(err, derrors.CodeChainBail):
+		return ipc.CodeChainBail
+	case derrors.IsCode(err, derrors.CodeInvalidInput):
+		return ipc.CodeInvalidInput
+	default:
+		return ipc.CodeActionFailed
+	}
 }
 
 // handleRun executes the steps carried by the command, in order.

--- a/internal/app/ipc_sequence_test.go
+++ b/internal/app/ipc_sequence_test.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/core/domain"
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
 )
@@ -29,6 +30,7 @@ func TestHandleRun_RequiresSteps(t *testing.T) {
 
 			return sequenceOutcome{}
 		},
+		nil,
 		zap.NewNop(),
 	)
 
@@ -44,7 +46,7 @@ func TestHandleRun_RequiresSteps(t *testing.T) {
 func TestHandleRun_ReportsMissingExecutor(t *testing.T) {
 	t.Parallel()
 
-	handler := NewIPCControllerSequence(nil, zap.NewNop())
+	handler := NewIPCControllerSequence(nil, nil, zap.NewNop())
 
 	resp := handler.handleRun(context.Background(), ipc.Command{Args: []string{"idle"}})
 
@@ -64,6 +66,7 @@ func TestHandleRun_PassesTrimmedStepsToExecutor(t *testing.T) {
 
 			return sequenceOutcome{executed: len(steps)}
 		},
+		nil,
 		zap.NewNop(),
 	)
 
@@ -120,6 +123,7 @@ func TestHandleRun_ReportsBailAndFailure(t *testing.T) {
 				func(context.Context, string, []string, sequencePolicy) sequenceOutcome {
 					return testCase.outcome
 				},
+				nil,
 				zap.NewNop(),
 			)
 
@@ -185,6 +189,7 @@ func TestHandleRun_StopOnErrorFlagIsAPolicyNotAStep(t *testing.T) {
 
 			return sequenceOutcome{executed: len(steps)}
 		},
+		nil,
 		zap.NewNop(),
 	)
 
@@ -215,6 +220,7 @@ func TestHandleRun_StopOnErrorAloneIsNotASequence(t *testing.T) {
 
 			return sequenceOutcome{}
 		},
+		nil,
 		zap.NewNop(),
 	)
 
@@ -237,6 +243,7 @@ func TestHandleRun_ReportsASequenceThatNeverStarted(t *testing.T) {
 				stopped: true,
 			}
 		},
+		nil,
 		zap.NewNop(),
 	)
 
@@ -265,6 +272,7 @@ func TestHandleRun_DoesNotClaimLaterStepsRanWhenThereWereNone(t *testing.T) {
 				executed:    1,
 			}
 		},
+		nil,
 		zap.NewNop(),
 	)
 
@@ -272,5 +280,175 @@ func TestHandleRun_DoesNotClaimLaterStepsRanWhenThereWereNone(t *testing.T) {
 
 	if strings.Contains(resp.Message, "later steps still ran") {
 		t.Fatalf("message %q claims steps ran after the last one", resp.Message)
+	}
+}
+
+func TestHandleMacro_RequiresAName(t *testing.T) {
+	t.Parallel()
+
+	handler := NewIPCControllerSequence(
+		nil,
+		func(context.Context, string, []string) error {
+			t.Fatal("the macro runner must not run without a name")
+
+			return nil
+		},
+		zap.NewNop(),
+	)
+
+	for _, args := range [][]string{nil, {}, {"  ", ""}} {
+		resp := handler.handleMacro(context.Background(), ipc.Command{Args: args})
+
+		if resp.Success || resp.Code != ipc.CodeInvalidInput {
+			t.Fatalf("handleMacro(%v) = %+v, want an invalid-input failure", args, resp)
+		}
+	}
+}
+
+func TestHandleMacro_ReportsMissingRunner(t *testing.T) {
+	t.Parallel()
+
+	handler := NewIPCControllerSequence(nil, nil, zap.NewNop())
+
+	resp := handler.handleMacro(context.Background(), ipc.Command{Args: []string{"zoom"}})
+
+	if resp.Success || resp.Code != ipc.CodeActionFailed {
+		t.Fatalf("handleMacro() = %+v, want an action-failed response", resp)
+	}
+}
+
+func TestHandleMacro_PassesArgumentsThroughUnsplit(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotName string
+		gotArgs []string
+	)
+
+	handler := NewIPCControllerSequence(
+		nil,
+		func(_ context.Context, name string, args []string) error {
+			gotName, gotArgs = name, slices.Clone(args)
+
+			return nil
+		},
+		zap.NewNop(),
+	)
+
+	// An argument containing spaces and both kinds of quote is exactly what a
+	// call written as one step string could not carry intact.
+	args := []string{"say_it", `hello "there" it's me`, "tail"}
+
+	resp := handler.handleMacro(context.Background(), ipc.Command{Args: args})
+	if !resp.Success {
+		t.Fatalf("handleMacro() = %+v, want success", resp)
+	}
+
+	if gotName != "say_it" {
+		t.Fatalf("macro name = %q, want %q", gotName, "say_it")
+	}
+
+	if !slices.Equal(gotArgs, args[1:]) {
+		t.Fatalf("macro args = %q, want %q", gotArgs, args[1:])
+	}
+}
+
+func TestHandleMacro_MapsFailureOntoTheCodeThatDescribesIt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		wantCode string
+	}{
+		{
+			name:     "unknown macro",
+			err:      derrors.New(derrors.CodeInvalidInput, `no macro named "nope"`),
+			wantCode: ipc.CodeInvalidInput,
+		},
+		{
+			// A canceled mode is not a fault, and a caller chaining calls
+			// needs to tell the two apart.
+			name:     "canceled mode",
+			err:      derrors.New(derrors.CodeChainBail, "mode exited without selection"),
+			wantCode: ipc.CodeChainBail,
+		},
+		{
+			name:     "step failed",
+			err:      derrors.New(derrors.CodeActionFailed, "click failed"),
+			wantCode: ipc.CodeActionFailed,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := NewIPCControllerSequence(
+				nil,
+				func(context.Context, string, []string) error {
+					return testCase.err
+				},
+				zap.NewNop(),
+			)
+
+			resp := handler.handleMacro(context.Background(), ipc.Command{Args: []string{"m"}})
+
+			if resp.Success {
+				t.Fatalf("handleMacro() = %+v, want failure", resp)
+			}
+
+			if resp.Code != testCase.wantCode {
+				t.Fatalf("code = %q, want %q", resp.Code, testCase.wantCode)
+			}
+
+			if !strings.Contains(resp.Message, testCase.err.Error()) {
+				t.Fatalf("message %q does not carry the underlying error", resp.Message)
+			}
+		})
+	}
+}
+
+func TestRegisterHandlers_RegistersRunAndMacro(t *testing.T) {
+	t.Parallel()
+
+	handlers := make(map[string]func(context.Context, ipc.Command) ipc.Response)
+
+	NewIPCControllerSequence(nil, nil, zap.NewNop()).RegisterHandlers(handlers)
+
+	for _, command := range []string{domain.CommandRun, domain.CommandMacro} {
+		if handlers[command] == nil {
+			t.Fatalf("no handler registered for %q", command)
+		}
+	}
+}
+
+// Macro arguments are data, not steps. Trimming them or dropping the blank ones
+// would rewrite an argument whose padding matters and shift every later
+// argument onto the wrong placeholder.
+func TestHandleMacro_PassesArgumentsThroughVerbatim(t *testing.T) {
+	t.Parallel()
+
+	var gotArgs []string
+
+	handler := NewIPCControllerSequence(
+		nil,
+		func(_ context.Context, _ string, args []string) error {
+			gotArgs = slices.Clone(args)
+
+			return nil
+		},
+		zap.NewNop(),
+	)
+
+	args := []string{"  say_it  ", " padded ", "", "third"}
+
+	resp := handler.handleMacro(context.Background(), ipc.Command{Args: args})
+	if !resp.Success {
+		t.Fatalf("handleMacro() = %+v, want success", resp)
+	}
+
+	if !slices.Equal(gotArgs, args[1:]) {
+		t.Fatalf("macro args = %q, want %q", gotArgs, args[1:])
 	}
 }

--- a/internal/app/ipc_toggles.go
+++ b/internal/app/ipc_toggles.go
@@ -1,0 +1,157 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+// The toggle commands (toggle-scroll-invert, toggle-screen-share,
+// toggle-cursor-follow-selection) flip a boolean. Flipping is the right default
+// for a key binding, where the user sees the result and presses again if it is
+// wrong, but it is the wrong primitive for a script: a driver that cannot read
+// the state can only guess at it, and a binding pressed twice by mistake leaves
+// the daemon somewhere the driver does not expect.
+//
+// --state lets those callers ask for the state they want instead. The states
+// are reported by "neru status --json" under the same names, so a driver can
+// check what it asked for.
+
+// toggleStateFlag names the state a toggle command should converge on.
+const toggleStateFlag = "--state"
+
+// The values toggleStateFlag accepts.
+const (
+	toggleStateOn     = "on"
+	toggleStateOff    = "off"
+	toggleStateToggle = "toggle"
+)
+
+// parseToggleState reads the optional --state flag from a toggle command.
+//
+// A nil state means "flip it": what a toggle command does with no flag, and
+// what --state toggle asks for explicitly. The explicit spelling exists so a
+// macro can pass the value straight through — "toggle-scroll-invert --state $1"
+// — without the caller having to special-case flipping.
+//
+// Both --state=on and --state on are accepted, matching how action flags are
+// written.
+func parseToggleState(command string, args []string) (*bool, *ipc.Response) {
+	var desired *bool
+
+	for idx := 0; idx < len(args); idx++ {
+		arg := strings.TrimSpace(args[idx])
+		if arg == "" {
+			continue
+		}
+
+		name, value, hasInlineValue := strings.Cut(arg, "=")
+		if name != toggleStateFlag {
+			return nil, unknownToggleArgResponse(command, arg)
+		}
+
+		if !hasInlineValue {
+			// A following argument is the value only when it is not itself a
+			// flag, so "--state --state=on" reports a missing value rather
+			// than swallowing the next flag as one.
+			if idx+1 >= len(args) || strings.HasPrefix(args[idx+1], "--") {
+				return nil, toggleStateValueResponse(command)
+			}
+
+			idx++
+			value = strings.TrimSpace(args[idx])
+		}
+
+		parsed, ok := parseToggleStateValue(value)
+		if !ok {
+			return nil, toggleStateValueResponse(command)
+		}
+
+		desired = parsed
+	}
+
+	return desired, nil
+}
+
+// parseToggleStateValue resolves one --state value. A nil state with ok true is
+// "toggle" — a valid request to flip, not a parse failure.
+func parseToggleStateValue(value string) (*bool, bool) {
+	switch value {
+	case toggleStateOn:
+		on := true
+
+		return &on, true
+	case toggleStateOff:
+		off := false
+
+		return &off, true
+	case toggleStateToggle:
+		return nil, true
+	default:
+		return nil, false
+	}
+}
+
+// applyToggleState resolves what a toggle command should end up at: the
+// requested state, or the opposite of the current one when none was requested.
+//
+// toggle is passed separately rather than derived from current because the
+// state types toggle atomically, and a check-then-act here would reintroduce
+// the race those methods exist to avoid.
+func applyToggleState(desired *bool, toggle func() bool, set func(bool)) bool {
+	if desired == nil {
+		return toggle()
+	}
+
+	set(*desired)
+
+	return *desired
+}
+
+// applyToggleStateWithResult is applyToggleState for state that may not exist
+// to change. Both callbacks report whether they found anything to act on, and
+// a false is passed straight through to the caller.
+func applyToggleStateWithResult(
+	desired *bool,
+	toggle func() (bool, bool),
+	set func(bool) (bool, bool),
+) (bool, bool) {
+	if desired == nil {
+		return toggle()
+	}
+
+	return set(*desired)
+}
+
+// toggleStateValueResponse reports a --state that named no valid state.
+func toggleStateValueResponse(command string) *ipc.Response {
+	return &ipc.Response{
+		Success: false,
+		Message: fmt.Sprintf(
+			"%s --state requires %s, %s, or %s",
+			command,
+			toggleStateOn,
+			toggleStateOff,
+			toggleStateToggle,
+		),
+		Code: ipc.CodeInvalidInput,
+	}
+}
+
+// unknownToggleArgResponse reports an argument a toggle command does not take.
+func unknownToggleArgResponse(command, arg string) *ipc.Response {
+	return &ipc.Response{
+		Success: false,
+		Message: fmt.Sprintf(
+			"%s does not accept %q (only %s %s|%s|%s)",
+			command,
+			arg,
+			toggleStateFlag,
+			toggleStateOn,
+			toggleStateOff,
+			toggleStateToggle,
+		),
+		Code: ipc.CodeInvalidInput,
+	}
+}

--- a/internal/app/ipc_toggles_test.go
+++ b/internal/app/ipc_toggles_test.go
@@ -1,0 +1,238 @@
+//nolint:testpackage // Tests the private toggle-state parsing and handlers.
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/core/domain"
+	"github.com/y3owk1n/neru/internal/core/domain/state"
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+)
+
+const (
+	// toggleCommand is the command name the parse tests report failures against.
+	toggleCommand = domain.CommandToggleScrollInvert
+
+	stateOnArg  = flagState + "=" + toggleStateOn
+	stateOffArg = flagState + "=" + toggleStateOff
+
+	// blankArg stands in for whitespace a caller may pass by accident.
+	blankArg = "   "
+)
+
+func TestParseToggleState_ResolvesEveryForm(t *testing.T) {
+	t.Parallel()
+
+	wantOn, wantOff := true, false
+
+	tests := []struct {
+		name string
+		args []string
+		want *bool
+	}{
+		{name: "no flag toggles", args: nil, want: nil},
+		{name: "empty args toggle", args: []string{"", blankArg}, want: nil},
+		{name: "inline on", args: []string{stateOnArg}, want: &wantOn},
+		{name: "inline off", args: []string{stateOffArg}, want: &wantOff},
+		{name: "separate on", args: []string{flagState, toggleStateOn}, want: &wantOn},
+		{name: "separate off", args: []string{flagState, toggleStateOff}, want: &wantOff},
+		{name: "explicit toggle", args: []string{flagState + "=" + toggleStateToggle}, want: nil},
+		{name: "last one wins", args: []string{stateOnArg, stateOffArg}, want: &wantOff},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, errResponse := parseToggleState(toggleCommand, testCase.args)
+			if errResponse != nil {
+				t.Fatalf("parseToggleState(%v) = %+v, want success", testCase.args, errResponse)
+			}
+
+			switch {
+			case testCase.want == nil && got != nil:
+				t.Fatalf("parseToggleState(%v) = %t, want toggle", testCase.args, *got)
+			case testCase.want != nil && got == nil:
+				t.Fatalf("parseToggleState(%v) = toggle, want %t", testCase.args, *testCase.want)
+			case testCase.want != nil && *got != *testCase.want:
+				t.Fatalf("parseToggleState(%v) = %t, want %t", testCase.args, *got, *testCase.want)
+			}
+		})
+	}
+}
+
+func TestParseToggleState_RejectsBadInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "unknown value", args: []string{flagState + "=maybe"}},
+		{name: "empty value", args: []string{flagState + "="}},
+		// The value is missing, not the next flag: swallowing it would turn a
+		// typo into a state change the caller never asked for.
+		{name: "flag as value", args: []string{flagState, stateOnArg}},
+		{name: "missing value at end", args: []string{flagState}},
+		{name: "unknown flag", args: []string{"--force"}},
+		{name: "bare argument", args: []string{"on"}},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, errResponse := parseToggleState(toggleCommand, testCase.args)
+			if errResponse == nil {
+				t.Fatalf("parseToggleState(%v) = %v, want a rejection", testCase.args, got)
+			}
+
+			if errResponse.Success || errResponse.Code != ipc.CodeInvalidInput {
+				t.Fatalf(
+					"parseToggleState(%v) = %+v, want invalid input",
+					testCase.args,
+					errResponse,
+				)
+			}
+
+			if !strings.Contains(errResponse.Message, toggleCommand) {
+				t.Fatalf("message %q does not name the command", errResponse.Message)
+			}
+		})
+	}
+}
+
+func TestHandleToggleScrollInvert_ConvergesOnRequestedState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		initial bool
+		args    []string
+		want    bool
+	}{
+		{name: "toggle from off", initial: false, args: nil, want: true},
+		{name: "toggle from on", initial: true, args: nil, want: false},
+		{name: "on from off", initial: false, args: []string{stateOnArg}, want: true},
+		// The point of --state: asking for the state you are already in is not
+		// a flip, so a repeated call does not undo itself.
+		{name: "on from on", initial: true, args: []string{stateOnArg}, want: true},
+		{name: "off from on", initial: true, args: []string{stateOffArg}, want: false},
+		{name: "off from off", initial: false, args: []string{stateOffArg}, want: false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			appState := state.NewAppState()
+			appState.SetScrollInverted(testCase.initial)
+
+			handler := NewIPCControllerScroll(appState, nil, zap.NewNop())
+
+			resp := handler.handleToggleScrollInvert(
+				context.Background(),
+				ipc.Command{Args: testCase.args},
+			)
+			if !resp.Success {
+				t.Fatalf("handleToggleScrollInvert(%v) = %+v, want success", testCase.args, resp)
+			}
+
+			if got := appState.IsScrollInverted(); got != testCase.want {
+				t.Fatalf("scroll inverted = %t, want %t", got, testCase.want)
+			}
+
+			assertToggleData(t, resp, "inverted", testCase.want)
+		})
+	}
+}
+
+func TestHandleToggleScrollInvert_RejectsBadState(t *testing.T) {
+	t.Parallel()
+
+	appState := state.NewAppState()
+	appState.SetScrollInverted(true)
+
+	handler := NewIPCControllerScroll(appState, nil, zap.NewNop())
+
+	resp := handler.handleToggleScrollInvert(
+		context.Background(),
+		ipc.Command{Args: []string{flagState + "=maybe"}},
+	)
+	if resp.Success || resp.Code != ipc.CodeInvalidInput {
+		t.Fatalf("handleToggleScrollInvert() = %+v, want invalid input", resp)
+	}
+
+	// A rejected command must not have changed anything on its way to failing.
+	if !appState.IsScrollInverted() {
+		t.Fatal("scroll inverted = false, want the state left untouched by a rejected command")
+	}
+}
+
+func TestHandleToggleScreenShare_ConvergesOnRequestedState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		initial bool
+		args    []string
+		want    bool
+	}{
+		{name: "toggle from visible", initial: false, args: nil, want: true},
+		{name: "toggle from hidden", initial: true, args: nil, want: false},
+		// "on" is the reported state (hidden), not the visibility.
+		{name: "on hides", initial: false, args: []string{stateOnArg}, want: true},
+		{
+			name:    "on from hidden",
+			initial: true,
+			args:    []string{flagState, toggleStateOn},
+			want:    true,
+		},
+		{name: "off shows", initial: true, args: []string{stateOffArg}, want: false},
+		{name: "off from visible", initial: false, args: []string{stateOffArg}, want: false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			appState := state.NewAppState()
+			appState.SetHiddenForScreenShare(testCase.initial)
+
+			handler := NewIPCControllerOverlay(appState, zap.NewNop())
+
+			resp := handler.handleToggleScreenShare(
+				context.Background(),
+				ipc.Command{Args: testCase.args},
+			)
+			if !resp.Success {
+				t.Fatalf("handleToggleScreenShare(%v) = %+v, want success", testCase.args, resp)
+			}
+
+			if got := appState.IsHiddenForScreenShare(); got != testCase.want {
+				t.Fatalf("hidden for screen share = %t, want %t", got, testCase.want)
+			}
+
+			assertToggleData(t, resp, "hidden", testCase.want)
+		})
+	}
+}
+
+// assertToggleData checks the boolean a toggle response reports back, which is
+// what a caller reads to confirm the state it asked for.
+func assertToggleData(t *testing.T, resp ipc.Response, key string, want bool) {
+	t.Helper()
+
+	data, ok := resp.Data.(map[string]bool)
+	if !ok {
+		t.Fatalf("response data = %T, want map[string]bool", resp.Data)
+	}
+
+	if got := data[key]; got != want {
+		t.Fatalf("response data[%q] = %t, want %t", key, got, want)
+	}
+}

--- a/internal/app/modes/selection.go
+++ b/internal/app/modes/selection.go
@@ -79,66 +79,140 @@ func (h *Handler) ClearCurrentSelectionPoint() bool {
 	return false
 }
 
-// ToggleCursorFollowSelection toggles cursor-follow-selection for the active mode.
-func (h *Handler) ToggleCursorFollowSelection() (bool, bool) {
+// cursorFollowContext is the part of a mode's context that carries the
+// session's cursor-follow-selection preference. Hints, grid, and recursive grid
+// each have their own context type; this is the shape they share, so the
+// preference can be read and written without knowing which mode is active.
+type cursorFollowContext interface {
+	CursorFollowSelection() bool
+	SetCursorFollowSelection(cursorFollowSelection bool)
+	ToggleCursorFollowSelection() bool
+}
+
+// CursorFollowSelection reports whether the active mode's session follows the
+// selection with the real cursor. The second result is false when no mode that
+// carries the preference is active, which is the same condition under which
+// toggling it is refused.
+func (h *Handler) CursorFollowSelection() (bool, bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	switch h.appState.CurrentMode() {
-	case domain.ModeHints:
-		if h.hints == nil || h.hints.Context == nil {
-			return false, false
-		}
-
-		return h.hints.Context.ToggleCursorFollowSelection(), true
-	case domain.ModeGrid:
-		if h.grid == nil || h.grid.Context == nil {
-			return false, false
-		}
-
-		enabled := h.grid.Context.ToggleCursorFollowSelection()
-
-		h.refreshGridVirtualPointerLocked()
-
-		if enabled {
-			if target, ok := h.grid.Context.SelectionPoint(); ok && h.actionService != nil {
-				moveCursorErr := h.actionService.MoveCursorToPoint(h.ctx, target)
-				if moveCursorErr != nil {
-					h.logger.Error("Failed to move cursor", zap.Error(moveCursorErr))
-				}
-			}
-		}
-
-		return enabled, true
-	case domain.ModeRecursiveGrid:
-		if h.recursiveGrid == nil || h.recursiveGrid.Context == nil {
-			return false, false
-		}
-
-		enabled := h.recursiveGrid.Context.ToggleCursorFollowSelection()
-
-		h.refreshRecursiveGridVirtualPointerLocked()
-
-		if enabled {
-			if target, ok := h.recursiveGrid.Context.SelectionPoint(); ok &&
-				h.actionService != nil {
-				moveCursorErr := h.actionService.MoveCursorToPoint(h.ctx, target)
-				if moveCursorErr != nil {
-					h.logger.Error("Failed to move cursor", zap.Error(moveCursorErr))
-				}
-			}
-		}
-
-		return enabled, true
-	case domain.ModeIdle:
-		return false, false
-	case domain.ModeScroll:
-		return false, false
-	case domain.ModeMonitorSelect:
+	modeContext, ok := h.cursorFollowContextLocked()
+	if !ok {
 		return false, false
 	}
 
-	return false, false
+	return modeContext.CursorFollowSelection(), true
+}
+
+// ToggleCursorFollowSelection toggles cursor-follow-selection for the active mode.
+func (h *Handler) ToggleCursorFollowSelection() (bool, bool) {
+	return h.applyCursorFollowSelection(nil)
+}
+
+// SetCursorFollowSelection turns cursor-follow-selection on or off for the
+// active mode, so a caller that knows which state it wants can converge on it
+// rather than flipping whatever is there.
+func (h *Handler) SetCursorFollowSelection(enabled bool) (bool, bool) {
+	return h.applyCursorFollowSelection(&enabled)
+}
+
+// applyCursorFollowSelection sets the preference to desired, or toggles it when
+// desired is nil, and reports the resulting value.
+//
+// Setting the preference to the value it already holds still runs the
+// after-effects below. That is what makes the setter idempotent in the way a
+// caller needs: "on" always ends with the cursor on the selection, whether or
+// not it was already following.
+func (h *Handler) applyCursorFollowSelection(desired *bool) (bool, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	modeContext, ok := h.cursorFollowContextLocked()
+	if !ok {
+		return false, false
+	}
+
+	var enabled bool
+
+	if desired == nil {
+		enabled = modeContext.ToggleCursorFollowSelection()
+	} else {
+		modeContext.SetCursorFollowSelection(*desired)
+
+		enabled = *desired
+	}
+
+	// Grid and recursive grid draw a virtual pointer that is hidden while the
+	// real cursor follows the selection, and both carry a selection point the
+	// cursor should jump to when it starts following. Hints has neither: its
+	// preference only affects the selections made after it.
+	switch h.appState.CurrentMode() {
+	case domain.ModeGrid:
+		h.refreshGridVirtualPointerLocked()
+		h.moveCursorToSelectionLocked(enabled, h.grid.Context.SelectionPoint)
+	case domain.ModeRecursiveGrid:
+		h.refreshRecursiveGridVirtualPointerLocked()
+		h.moveCursorToSelectionLocked(enabled, h.recursiveGrid.Context.SelectionPoint)
+	case domain.ModeHints, domain.ModeIdle, domain.ModeScroll, domain.ModeMonitorSelect:
+	}
+
+	return enabled, true
+}
+
+// cursorFollowContextLocked returns the active mode's cursor-follow context, or
+// false when the active mode does not carry the preference.
+func (h *Handler) cursorFollowContextLocked() (cursorFollowContext, bool) {
+	switch h.appState.CurrentMode() {
+	case domain.ModeHints:
+		if h.hints == nil || h.hints.Context == nil {
+			return nil, false
+		}
+
+		return h.hints.Context, true
+	case domain.ModeGrid:
+		if h.grid == nil || h.grid.Context == nil {
+			return nil, false
+		}
+
+		return h.grid.Context, true
+	case domain.ModeRecursiveGrid:
+		if h.recursiveGrid == nil || h.recursiveGrid.Context == nil {
+			return nil, false
+		}
+
+		return h.recursiveGrid.Context, true
+	case domain.ModeIdle:
+		return nil, false
+	case domain.ModeScroll:
+		return nil, false
+	case domain.ModeMonitorSelect:
+		return nil, false
+	}
+
+	return nil, false
+}
+
+// moveCursorToSelectionLocked moves the real cursor onto the mode's stored
+// selection point when the mode is following the selection. Turning the
+// preference off leaves the cursor where it is.
+func (h *Handler) moveCursorToSelectionLocked(
+	enabled bool,
+	selectionPoint func() (image.Point, bool),
+) {
+	if !enabled || h.actionService == nil {
+		return
+	}
+
+	target, ok := selectionPoint()
+	if !ok {
+		return
+	}
+
+	moveCursorErr := h.actionService.MoveCursorToPoint(h.ctx, target)
+	if moveCursorErr != nil {
+		h.logger.Error("Failed to move cursor", zap.Error(moveCursorErr))
+	}
 }
 
 func (h *Handler) refreshGridVirtualPointerLocked() {

--- a/internal/app/modes/selection_test.go
+++ b/internal/app/modes/selection_test.go
@@ -248,3 +248,97 @@ func TestClearCurrentSelectionPoint_ClearsOnlyActiveModeSelection(t *testing.T) 
 		t.Fatalf("grid selection = %v, %v; want (10,20), true", got, ok)
 	}
 }
+
+func TestSetCursorFollowSelection_ConvergesRatherThanFlipping(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial bool
+		set     bool
+	}{
+		{name: "on from off", initial: false, set: true},
+		// Setting the state it already holds must not flip it. This is the
+		// whole difference between the setter and the toggle.
+		{name: "on from on", initial: true, set: true},
+		{name: "off from on", initial: true, set: false},
+		{name: "off from off", initial: false, set: false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			appState := state.NewAppState()
+			appState.SetMode(domain.ModeHints)
+
+			handler := &Handler{
+				appState: appState,
+				logger:   zap.NewNop(),
+				hints: &components.HintsComponent{
+					Context: &hintscomponent.Context{},
+				},
+			}
+
+			handler.hints.Context.SetCursorFollowSelection(testCase.initial)
+
+			enabled, supported := handler.SetCursorFollowSelection(testCase.set)
+			if !supported {
+				t.Fatal("SetCursorFollowSelection() expected success in hints mode")
+			}
+
+			if enabled != testCase.set {
+				t.Fatalf("SetCursorFollowSelection(%t) = %t, want %t",
+					testCase.set, enabled, testCase.set)
+			}
+
+			if got := handler.hints.Context.CursorFollowSelection(); got != testCase.set {
+				t.Fatalf("context cursor follow = %t, want %t", got, testCase.set)
+			}
+		})
+	}
+}
+
+func TestCursorFollowSelection_ReadsWithoutChanging(t *testing.T) {
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeGrid)
+
+	handler := &Handler{
+		appState: appState,
+		logger:   zap.NewNop(),
+		grid: &components.GridComponent{
+			Context: &gridcomponent.Context{},
+		},
+	}
+
+	handler.grid.Context.SetCursorFollowSelection(true)
+
+	for range 2 {
+		enabled, supported := handler.CursorFollowSelection()
+		if !supported {
+			t.Fatal("CursorFollowSelection() expected success in grid mode")
+		}
+
+		if !enabled {
+			t.Fatal("CursorFollowSelection() = false, want the state left as it was read")
+		}
+	}
+}
+
+func TestCursorFollowSelection_ReportsUnsupportedWithoutAMode(t *testing.T) {
+	appState := state.NewAppState()
+	appState.SetMode(domain.ModeIdle)
+
+	handler := &Handler{
+		appState: appState,
+		logger:   zap.NewNop(),
+		hints: &components.HintsComponent{
+			Context: &hintscomponent.Context{},
+		},
+	}
+
+	if _, supported := handler.CursorFollowSelection(); supported {
+		t.Fatal("CursorFollowSelection() reported support in idle mode")
+	}
+
+	// Naming the state you want does not conjure a session to hold it.
+	if _, supported := handler.SetCursorFollowSelection(true); supported {
+		t.Fatal("SetCursorFollowSelection() reported support in idle mode")
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -121,6 +121,7 @@ func TestCommandInitialization(t *testing.T) {
 		"scroll":                         false,
 		cliTestAction:                    false,
 		"run <step> [step...]":           false,
+		"macro <name> [arg...]":          false,
 		cliTestStatus:                    false,
 		"doctor":                         false,
 		cliTestRoles:                     false,

--- a/internal/cli/cliutil/util.go
+++ b/internal/cli/cliutil/util.go
@@ -145,6 +145,7 @@ func (f *OutputFormatter) PrintStatus(cmd *cobra.Command, data any) error {
 		}
 
 		printProfile(cmd, statusData["profile"])
+		printToggles(cmd, statusData)
 	} else {
 		// Fallback to JSON output
 		jsonData, jsonDataErr := json.MarshalIndent(data, "  ", "  ")
@@ -311,6 +312,48 @@ func printDarkMode(cmd *cobra.Command, rawCapabilities any) {
 	}
 
 	cmd.Println("  Dark Mode: " + detail)
+}
+
+// Status payload keys for the runtime toggles, named as the daemon reports
+// them.
+const (
+	keyScrollInverted        = "scroll_inverted"
+	keyHiddenForScreenShare  = "hidden_for_screen_share"
+	keyCursorFollowSelection = "cursor_follow_selection"
+)
+
+// printToggles prints the runtime toggles that a toggle-* command can change.
+//
+// A toggle that carries no state is skipped rather than printed as off:
+// cursor-follow-selection only exists while a mode is running, and reading it
+// as "off" would suggest a state the daemon is not in.
+func printToggles(cmd *cobra.Command, statusData map[string]any) {
+	toggles := []struct {
+		label string
+		key   string
+	}{
+		{"Scroll inverted", keyScrollInverted},
+		{"Screen share hidden", keyHiddenForScreenShare},
+		{"Cursor follows selection", keyCursorFollowSelection},
+	}
+
+	for _, toggle := range toggles {
+		value, ok := statusData[toggle.key].(bool)
+		if !ok {
+			continue
+		}
+
+		cmd.Println("  " + toggle.label + ": " + yesNo(value))
+	}
+}
+
+// yesNo renders a toggle state for a human reader.
+func yesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+
+	return "no"
 }
 
 func printProfile(cmd *cobra.Command, rawProfile any) {

--- a/internal/cli/cliutil/util_test.go
+++ b/internal/cli/cliutil/util_test.go
@@ -150,3 +150,60 @@ func TestPrintJSON_ReportsUnencodablePayload(t *testing.T) {
 		t.Fatal("PrintJSON() = nil, want an error for an unencodable payload")
 	}
 }
+
+func TestPrintToggles(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+
+	printToggles(cmd, map[string]any{
+		keyScrollInverted:        true,
+		keyHiddenForScreenShare:  false,
+		keyCursorFollowSelection: true,
+	})
+
+	got := output.String()
+
+	expectedLines := []string{
+		"  Scroll inverted: yes",
+		"  Screen share hidden: no",
+		"  Cursor follows selection: yes",
+	}
+
+	for _, expectedLine := range expectedLines {
+		if !strings.Contains(got, expectedLine) {
+			t.Fatalf("printToggles output missing %q in:\n%s", expectedLine, got)
+		}
+	}
+}
+
+// A toggle with no state is skipped, not printed as off: cursor-follow-selection
+// is null while no mode is running, and "no" would name a state the daemon is
+// not in.
+func TestPrintToggles_SkipsAbsentState(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+
+	printToggles(cmd, map[string]any{
+		keyScrollInverted:        false,
+		keyHiddenForScreenShare:  false,
+		keyCursorFollowSelection: nil,
+	})
+
+	got := output.String()
+
+	if strings.Contains(got, "Cursor follows selection") {
+		t.Fatalf("printToggles printed a toggle that carries no state:\n%s", got)
+	}
+
+	if !strings.Contains(got, "  Scroll inverted: no") {
+		t.Fatalf("printToggles output missing the toggles that do carry state:\n%s", got)
+	}
+}

--- a/internal/cli/macro.go
+++ b/internal/cli/macro.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/core/domain"
+	derrors "github.com/y3owk1n/neru/internal/core/errors"
+)
+
+// MacroCmd is the CLI macro command for running a named sequence from [macros].
+var MacroCmd = &cobra.Command{
+	Use:   "macro <name> [arg...]",
+	Short: "Run a named sequence from the [macros] config table",
+	Long: `Run a macro defined in the [macros] table of the config file.
+
+A macro is an ordered sequence of steps under a name, with positional
+placeholders ($1, $2, ...) filled in by the arguments given here. The daemon
+runs it exactly as it would when a hotkey binding invokes "macro <name>", so a
+sequence written once is available to bindings and to external drivers (skhd,
+Hammerspoon, shell scripts) alike.
+
+Arguments are passed through as given, so one containing spaces needs no
+quoting beyond what the shell already does:
+
+  neru macro say_it "hello there"
+
+The number of arguments must match the highest placeholder the macro uses.
+
+Macros that block (sleeps, waits) can outlast the default IPC timeout. Raise it
+for those: neru --timeout 60 macro slow_one
+
+Examples:
+  neru macro window_click
+  neru macro zoom_click 3
+  neru macro open_and_click Safari left_click`,
+	Args: validateMacroArgs,
+	PreRunE: func(_ *cobra.Command, _ []string) error {
+		return requiresRunningInstance()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return sendCommand(cmd, domain.CommandMacro, args)
+	},
+}
+
+// validateMacroArgs rejects a call the daemon could only reject later, so a
+// typo fails here rather than after a round trip.
+func validateMacroArgs(_ *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return derrors.New(
+			derrors.CodeInvalidInput,
+			"macro requires a name (e.g., neru macro window_click)",
+		)
+	}
+
+	if !config.IsValidMacroName(strings.TrimSpace(args[0])) {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"invalid macro name %q: names start with a letter and may contain letters, digits, underscores, and dashes",
+			args[0],
+		)
+	}
+
+	return nil
+}
+
+func init() {
+	RootCmd.AddCommand(MacroCmd)
+}

--- a/internal/cli/macro_internal_test.go
+++ b/internal/cli/macro_internal_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import "testing"
+
+func TestValidateMacroArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "name only", args: []string{"window_click"}},
+		{name: "name with args", args: []string{"zoom_click", "3"}},
+		{name: "dashes and digits", args: []string{"zoom-click2"}},
+		// The arguments are the macro's, not the command's, so they are passed
+		// through whatever they contain.
+		{name: "argument with spaces", args: []string{"say_it", "hello there"}},
+		{name: "argument that looks like a flag", args: []string{"say_it", "--bail-on-error"}},
+		{name: "no name", args: nil, wantErr: true},
+		{name: "blank name", args: []string{"   "}, wantErr: true},
+		{name: "name with a space", args: []string{"window click"}, wantErr: true},
+		{name: "name starting with a digit", args: []string{"9lives"}, wantErr: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateMacroArgs(nil, testCase.args)
+			if (err != nil) != testCase.wantErr {
+				t.Fatalf("validateMacroArgs(%v) error = %v, wantErr %t",
+					testCase.args, err, testCase.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -205,6 +205,47 @@ func BuildSimpleCommand(use, short, long string, action string) *cobra.Command {
 	}
 }
 
+// BuildToggleCommand creates a cobra command for a runtime toggle, adding the
+// --state flag that asks for a state instead of flipping whatever is there.
+//
+// Flipping is right for a key binding, where the user sees the result and
+// presses again if it went the wrong way. A script has no such feedback loop,
+// so it needs to be able to name the state it wants — and to read it back from
+// "neru status --json", which reports every toggle these commands change.
+func BuildToggleCommand(use, short, long string, action string) *cobra.Command {
+	var state string
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Long:  long,
+		Args:  cobra.NoArgs,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return requiresRunningInstance()
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if state == "" {
+				return sendCommand(cmd, action, nil)
+			}
+
+			if state != "on" && state != "off" && state != "toggle" {
+				return derrors.Newf(
+					derrors.CodeInvalidInput,
+					"invalid --state %q: expected on, off, or toggle",
+					state,
+				)
+			}
+
+			return sendCommand(cmd, action, []string{"--state=" + state})
+		},
+	}
+
+	cmd.Flags().StringVar(&state, "state", "",
+		"State to converge on: on, off, or toggle (default: toggle)")
+
+	return cmd
+}
+
 // BuildActionCommand creates an action cobra command with the given parameters.
 func BuildActionCommand(
 	use, short, long string,

--- a/internal/cli/toggle_cursor_follow_selection.go
+++ b/internal/cli/toggle_cursor_follow_selection.go
@@ -3,10 +3,14 @@ package cli
 import "github.com/y3owk1n/neru/internal/core/domain"
 
 // ToggleCursorFollowSelectionCmd toggles cursor-follow-selection for the active mode session.
-var ToggleCursorFollowSelectionCmd = BuildSimpleCommand(
+var ToggleCursorFollowSelectionCmd = BuildToggleCommand(
 	"toggle-cursor-follow-selection",
 	"Toggle cursor-follow-selection in the active mode",
-	`Toggle whether the active hints, grid, or recursive-grid session follows the current selection with the real cursor.`,
+	`Toggle whether the active hints, grid, or recursive-grid session follows the current selection with the real cursor.
+
+Pass --state on or --state off to set the state instead of flipping it. The
+preference belongs to the running mode session, so the command fails when no
+mode is active and "neru status --json" reports cursor_follow_selection as null.`,
 	domain.CommandToggleCursorFollowSelection,
 )
 

--- a/internal/cli/toggle_screen_share.go
+++ b/internal/cli/toggle_screen_share.go
@@ -5,11 +5,14 @@ import (
 )
 
 // ToggleScreenShareCmd toggles overlay visibility in screen sharing.
-var ToggleScreenShareCmd = BuildSimpleCommand(
+var ToggleScreenShareCmd = BuildToggleCommand(
 	"toggle-screen-share",
 	"Toggle overlay visibility in screen sharing",
 	`Toggle whether the overlay is visible during screen sharing (Zoom, Google Meet, etc.).
-When hidden, the overlay will not appear in shared screens but remains visible locally.`,
+When hidden, the overlay will not appear in shared screens but remains visible locally.
+
+Pass --state on to hide the overlay from screen sharing and --state off to show
+it, matching the hidden_for_screen_share field of "neru status --json".`,
 	domain.CommandToggleScreenShare,
 )
 

--- a/internal/cli/toggle_scroll_invert.go
+++ b/internal/cli/toggle_scroll_invert.go
@@ -5,12 +5,15 @@ import (
 )
 
 // ToggleScrollInvertCmd toggles the scroll direction inversion setting.
-var ToggleScrollInvertCmd = BuildSimpleCommand(
+var ToggleScrollInvertCmd = BuildToggleCommand(
 	"toggle-scroll-invert",
 	"Toggle scroll direction inversion",
 	`Toggle whether scroll direction is inverted at runtime.
 Useful when using tools like Mos that reverse synthetic scroll events.
-The change is immediate and does not persist across restarts.`,
+The change is immediate and does not persist across restarts.
+
+Pass --state on or --state off to set the state instead of flipping it, and
+read it back from the scroll_inverted field of "neru status --json".`,
 	domain.CommandToggleScrollInvert,
 )
 

--- a/internal/core/domain/domain_constants.go
+++ b/internal/core/domain/domain_constants.go
@@ -25,12 +25,18 @@ const (
 )
 
 // IPC Commands.
+//
+// CommandMacro deliberately spells the same word as config.MacroCommand, which
+// names the step keyword inside a binding. A macro is invoked the same way
+// wherever it is written, so the two must not drift apart; they are separate
+// constants only because the domain package cannot import config.
 const (
 	CommandPing                        = "ping"
 	CommandStart                       = "start"
 	CommandStop                        = "stop"
 	CommandAction                      = "action"
 	CommandRun                         = "run"
+	CommandMacro                       = "macro"
 	CommandStatus                      = "status"
 	CommandConfig                      = "config"
 	CommandReloadConfig                = "reload"


### PR DESCRIPTION
## Description

Two changes closing the same gap: the daemon could do more than a script could ask it to, or find out about.

**The three `toggle-*` commands were write-only.** They flip state that nothing reported, so an external driver could only blind-flip — it could not tell a state it set from one a stray keypress set, and a binding pressed twice left the daemon somewhere it did not expect. They now accept `--state on|off|toggle`, and `neru status --json` reports every state they change:

```bash
neru toggle-scroll-invert --state on
neru status --json | jq -r .scroll_inverted   # true
```

New status keys: `scroll_inverted`, `hidden_for_screen_share`, `cursor_follow_selection`. `neru status` prints them for humans too.

**`macro` had no CLI entry point.** It was already a first-class step inside bindings and inside `run`, but a driver had to write `neru run "macro foo"`. `neru macro <name> [args...]` shares the daemon's executor and exit-code vocabulary with `neru run`.

## Related Issues

<!-- none -->

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Three decisions worth a reviewer's attention.

**`cursor_follow_selection` is `null`, not `false`, when no mode is running.** It turned out to be session-scoped rather than daemon-global — it lives on the active mode's context. `false` (a running mode not following the selection) and "there is no session to hold the preference" are different answers, and a script reading the absence as `false` would think it had read a state it can in fact only *set* once a mode is running. `--state` on that toggle fails without a mode for the same reason. There is a test pinning the encoded form, since `jq .cursor_follow_selection` printing `null` is the actual contract.

**Setting a state that already holds still runs the after-effects.** `--state on` always ends with the grid cursor on the selection, not only when the value changed. That is what makes it idempotent in the way a caller needs, and it is the one place the setter deliberately differs from a toggle.

**`--state on` for screen-share means hidden, not visible.** The flag names the state that gets reported, so the flag and the `hidden_for_screen_share` field never invert against each other.

`neru macro` is a dedicated IPC command rather than a wrapper around `neru run "macro ..."` because the arguments arrive already split. Reassembling them into one step and splitting it back out would put every argument through a round of quoting, and `SplitStepArgs` has no escape mechanism — an argument containing both `'` and `"` cannot survive it. Relatedly: only the macro name is trimmed. My first pass reused `nonBlankSteps` for the arguments, which is correct for steps and wrong for data — it silently rewrote padded arguments and shifted every later one onto the wrong placeholder. Fixed, with a test.

`ToggleCursorFollowSelection` grew a shared implementation with the new setter and getter, replacing three near-identical per-mode branches.

Three tests drive the real `IPCController` registration path rather than calling handlers directly, so the wiring is covered. **Not** verified against a live daemon — that means taking over the event tap on a real machine; the controller-level tests cover the round-trip the manual check would have exercised.