### PR TITLE
feat(action): add `--slot` for named cursor marks

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -210,12 +210,14 @@ The examples here and in [Tips & Tricks](TIPS_TRICKS.md) use
 | `scroll_inverted`                                       | bool   | Set by [`toggle-scroll-invert`](#neru-toggle-scroll-invert). |
 | `hidden_for_screen_share`                               | bool   | Set by [`toggle-screen-share`](#neru-toggle-screen-share). `true` means hidden. |
 | `cursor_follow_selection`                               | bool or null | Set by [`toggle-cursor-follow-selection`](#neru-toggle-cursor-follow-selection). `null` when no mode is running. |
+| `saved_cursor_slots`                                    | object | The occupied [cursor slots](#cursor-slots), each `{"x": …, "y": …}`. Empty object when none are saved. |
 | `capabilities`                                          | object | Per-subsystem support on this platform, as `neru doctor` reports it. |
 | `profile`                                               | object | The platform backend profile: which adapter serves each subsystem, and whether it needs CGO. |
 
-The nine scalar keys above are the stable part of this output. `capabilities`
-and `profile` follow the platform support matrix and gain entries as subsystems
-are added, so read the keys you need rather than assuming the whole set.
+Everything above except `capabilities` and `profile` is the stable part of this
+output. Those two follow the platform support matrix and gain entries as
+subsystems are added, so read the keys you need rather than assuming the whole
+set.
 
 ### Reading the toggles
 
@@ -873,8 +875,8 @@ recursive-grid backtracking.
 Cursor position and visibility.
 
 ```
-neru action save_cursor_pos
-neru action restore_cursor_pos
+neru action save_cursor_pos [--slot <name>]
+neru action restore_cursor_pos [--slot <name>]
 neru action hide_cursor
 neru action show_cursor
 ```
@@ -884,8 +886,53 @@ neru action show_cursor
 Windows.
 
 `save_cursor_pos` records the cursor position; `restore_cursor_pos` returns it
-there. `hide_cursor` and `show_cursor` control the visibility of the system
-cursor.
+there and consumes the record. `hide_cursor` and `show_cursor` control the
+visibility of the system cursor.
+
+**Flags**
+
+| Flag     | Type   | Default     | Description                                   |
+| -------- | ------ | ----------- | --------------------------------------------- |
+| `--slot` | string | `default`   | Named slot to save into or restore from.      |
+
+### Cursor slots
+
+A saved position goes into a named slot. Without `--slot` that slot is
+`default`, and `--slot default` means the same thing — the default has no
+privileges the others lack.
+
+Slots exist because one shared position is not enough once a sequence can
+invoke another one. A macro that saves the cursor, called from a sequence that
+also saved, would overwrite the caller's position; the caller's restore would
+then move the cursor somewhere it never asked for, with nothing to signal the
+collision. Give each one its own slot and they cannot interfere:
+
+```toml
+[macros]
+# Safe to call from a sequence that has itself saved the cursor.
+peek = [
+    "action save_cursor_pos --slot peek",
+    "action move_mouse --x 0 --y 0",
+    "action left_click",
+    "action restore_cursor_pos --slot peek",
+]
+```
+
+Slot names follow the same rule as macro names: start with a letter, then
+letters, digits, underscores, and dashes.
+
+**Restoring consumes the slot.** A second restore of the same slot finds
+nothing, succeeds, and moves nothing — so a sequence that restores twice is not
+an error a caller has to special-case. Save again to reuse the slot.
+
+The occupied slots are reported by `neru status --json`:
+
+```bash
+neru status --json | jq '.saved_cursor_slots'
+{
+  "default": { "x": 640, "y": 400 }
+}
+```
 
 ---
 

--- a/internal/app/ipc_actions.go
+++ b/internal/app/ipc_actions.go
@@ -2,9 +2,7 @@ package app
 
 import (
 	"context"
-	"image"
 	"strings"
-	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -26,9 +24,9 @@ type IPCControllerActions struct {
 	keyFeed       ports.KeyFeedPort
 	logger        *zap.Logger
 
-	savedCursorMu      sync.RWMutex
-	savedCursorPos     image.Point
-	savedCursorPresent bool
+	// cursorSlots holds the positions save_cursor_pos captured, by slot name.
+	// It is shared with the info handler, which reports the occupied slots.
+	cursorSlots *state.CursorSlots
 }
 
 const (
@@ -44,6 +42,7 @@ const (
 	flagToggle    = "--toggle"
 	flagDirection = "--direction"
 	flagCount     = "--count"
+	flagSlot      = "--slot"
 	flagModifier  = "--modifier"
 	flagX         = "--x"
 	flagY         = "--y"
@@ -51,6 +50,9 @@ const (
 	flagDY        = "--dy"
 	flagSteps     = "--steps"
 	flagBackward  = "--backward"
+
+	// slotDataKey names the slot a cursor action acted on, in its response data.
+	slotDataKey = "slot"
 
 	msgActionServiceNotAvailable            = "action service not available"
 	msgModesHandlerNotAvailable             = "modes handler not available"
@@ -72,14 +74,22 @@ func NewIPCControllerActions(
 	modesHandler *modes.Handler,
 	appState *state.AppState,
 	keyFeed ports.KeyFeedPort,
+	cursorSlots *state.CursorSlots,
 	logger *zap.Logger,
 ) *IPCControllerActions {
+	// A nil store would make every save panic rather than degrade, and the
+	// slots have no dependencies to be missing, so build one instead.
+	if cursorSlots == nil {
+		cursorSlots = state.NewCursorSlots()
+	}
+
 	return &IPCControllerActions{
 		actionService: actionService,
 		scrollService: scrollService,
 		modesHandler:  modesHandler,
 		appState:      appState,
 		keyFeed:       keyFeed,
+		cursorSlots:   cursorSlots,
 		logger:        logger,
 	}
 }
@@ -160,11 +170,11 @@ func (h *IPCControllerActions) handleAction(ctx context.Context, cmd ipc.Command
 	}
 
 	if action.IsSaveCursorPosAction(actionName) {
-		return h.handleSaveCursorPosAction(ctx)
+		return h.handleSaveCursorPosAction(ctx, parsed)
 	}
 
 	if action.IsRestoreCursorPosAction(actionName) {
-		return h.handleRestoreCursorPosAction(ctx)
+		return h.handleRestoreCursorPosAction(ctx, parsed)
 	}
 
 	if action.IsMoveMonitorAction(actionName) {

--- a/internal/app/ipc_actions_cursor.go
+++ b/internal/app/ipc_actions_cursor.go
@@ -2,12 +2,15 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"image"
+	"strings"
 
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/app/modes"
 	"github.com/y3owk1n/neru/internal/core/domain/action"
+	"github.com/y3owk1n/neru/internal/core/domain/state"
 	"github.com/y3owk1n/neru/internal/core/infra/ipc"
 )
 
@@ -278,13 +281,44 @@ func (h *IPCControllerActions) currentSelectionPoint() (image.Point, bool) {
 	return h.modesHandler.CurrentSelectionPoint()
 }
 
-func (h *IPCControllerActions) handleSaveCursorPosAction(ctx context.Context) ipc.Response {
+// resolveCursorSlot returns the slot a cursor action names, or an error
+// response when the name is not one.
+func resolveCursorSlot(parsed parsedActionArgs) (string, *ipc.Response) {
+	if !parsed.hasSlot {
+		return state.DefaultCursorSlot, nil
+	}
+
+	slot := strings.TrimSpace(parsed.slotName)
+	if !action.IsValidCursorSlotName(slot) {
+		return "", &ipc.Response{
+			Success: false,
+			Message: fmt.Sprintf(
+				"invalid --slot %q: names start with a letter and may contain "+
+					"letters, digits, underscores, and dashes",
+				parsed.slotName,
+			),
+			Code: ipc.CodeInvalidInput,
+		}
+	}
+
+	return slot, nil
+}
+
+func (h *IPCControllerActions) handleSaveCursorPosAction(
+	ctx context.Context,
+	parsed parsedActionArgs,
+) ipc.Response {
 	if h.actionService == nil {
 		return ipc.Response{
 			Success: false,
 			Message: "action service not available",
 			Code:    ipc.CodeActionFailed,
 		}
+	}
+
+	slot, slotErr := resolveCursorSlot(parsed)
+	if slotErr != nil {
+		return *slotErr
 	}
 
 	pos, posErr := h.actionService.CursorPosition(ctx)
@@ -296,15 +330,20 @@ func (h *IPCControllerActions) handleSaveCursorPosAction(ctx context.Context) ip
 		}
 	}
 
-	h.savedCursorMu.Lock()
-	h.savedCursorPos = pos
-	h.savedCursorPresent = true
-	h.savedCursorMu.Unlock()
+	h.cursorSlots.Save(slot, pos)
 
-	return ipc.Response{Success: true, Message: "cursor position saved", Code: ipc.CodeOK}
+	return ipc.Response{
+		Success: true,
+		Message: "cursor position saved to slot " + slot,
+		Code:    ipc.CodeOK,
+		Data:    map[string]string{slotDataKey: slot},
+	}
 }
 
-func (h *IPCControllerActions) handleRestoreCursorPosAction(ctx context.Context) ipc.Response {
+func (h *IPCControllerActions) handleRestoreCursorPosAction(
+	ctx context.Context,
+	parsed parsedActionArgs,
+) ipc.Response {
 	if h.actionService == nil {
 		return ipc.Response{
 			Success: false,
@@ -313,13 +352,23 @@ func (h *IPCControllerActions) handleRestoreCursorPosAction(ctx context.Context)
 		}
 	}
 
-	h.savedCursorMu.RLock()
-	initialPos := h.savedCursorPos
-	present := h.savedCursorPresent
-	h.savedCursorMu.RUnlock()
+	slot, slotErr := resolveCursorSlot(parsed)
+	if slotErr != nil {
+		return *slotErr
+	}
 
+	// A restore consumes the slot, so the read and the clear are one operation
+	// — two restores racing on the same slot must not both move the cursor.
+	// The slot stays consumed if the move then fails, which keeps a failed
+	// restore from leaving a stale mark for a later one to trip over.
+	initialPos, present := h.cursorSlots.Take(slot)
 	if !present {
-		return ipc.Response{Success: true, Message: "no saved cursor position", Code: ipc.CodeOK}
+		return ipc.Response{
+			Success: true,
+			Message: "no saved cursor position in slot " + slot,
+			Code:    ipc.CodeOK,
+			Data:    map[string]string{slotDataKey: slot},
+		}
 	}
 
 	moveErr := h.actionService.MoveCursorToPoint(ctx, initialPos)
@@ -331,11 +380,12 @@ func (h *IPCControllerActions) handleRestoreCursorPosAction(ctx context.Context)
 		}
 	}
 
-	h.savedCursorMu.Lock()
-	h.savedCursorPresent = false
-	h.savedCursorMu.Unlock()
-
-	return ipc.Response{Success: true, Message: "cursor restored", Code: ipc.CodeOK}
+	return ipc.Response{
+		Success: true,
+		Message: "cursor restored from slot " + slot,
+		Code:    ipc.CodeOK,
+		Data:    map[string]string{slotDataKey: slot},
+	}
 }
 
 func (h *IPCControllerActions) handleCursorVisibilityAction(hide bool) ipc.Response {

--- a/internal/app/ipc_actions_flags.go
+++ b/internal/app/ipc_actions_flags.go
@@ -80,8 +80,8 @@ var actionFlagSupport = map[string][]string{
 	string(action.NameReset):            {},
 	string(action.NameBackspace):        {},
 	string(action.NameSearchHints):      {},
-	string(action.NameSaveCursorPos):    {},
-	string(action.NameRestoreCursorPos): {},
+	string(action.NameSaveCursorPos):    {flagSlot},
+	string(action.NameRestoreCursorPos): {flagSlot},
 	string(action.NameHideCursor):       {},
 	string(action.NameShowCursor):       {},
 }

--- a/internal/app/ipc_actions_parse.go
+++ b/internal/app/ipc_actions_parse.go
@@ -33,6 +33,8 @@ type parsedActionArgs struct {
 	hasDirection   bool
 	countVal       int
 	hasCount       bool
+	slotName       string
+	hasSlot        bool
 
 	// present records every flag that appeared, keyed by its canonical
 	// spelling, so rejectUnsupportedFlags can refuse flags the action does
@@ -128,6 +130,9 @@ var actionFlagSpecs = map[string]flagSpec{
 	})},
 	flagDirection: {takesValue: true, apply: intoString(func(p *parsedActionArgs, v string) {
 		p.directionStr, p.hasDirection = v, true
+	})},
+	flagSlot: {takesValue: true, apply: intoString(func(p *parsedActionArgs, v string) {
+		p.slotName, p.hasSlot = v, true
 	})},
 
 	flagCenter:    {apply: intoFlag(func(p *parsedActionArgs) { p.hasCenter = true })},

--- a/internal/app/ipc_controller.go
+++ b/internal/app/ipc_controller.go
@@ -188,12 +188,18 @@ func (c *IPCController) registerHandlers(cfg *config.Config) {
 	// Initialize handler components
 	lifecycleHandler := NewIPCControllerLifecycle(c.AppState, c.Modes, c.Logger)
 	modesHandler := NewIPCControllerModes(c.Modes, c.Logger)
+	// The slots are IPC-session state with no dependencies, so the controller
+	// owns them: the actions handler writes them and the info handler reports
+	// them, and nothing outside this controller needs to reach them.
+	cursorSlots := state.NewCursorSlots()
+
 	actionsHandler := NewIPCControllerActions(
 		c.ActionService,
 		c.ScrollService,
 		c.Modes,
 		c.AppState,
 		c.KeyFeed,
+		cursorSlots,
 		c.Logger,
 	)
 	// SetConfigField stays zero here; SetConfigFieldCallback fills it in after
@@ -211,6 +217,7 @@ func (c *IPCController) registerHandlers(cfg *config.Config) {
 		EventTap:      c.EventTap,
 		IPCServer:     c.IPCServer,
 		ReloadConfig:  c.ReloadConfig,
+		CursorSlots:   cursorSlots,
 		Logger:        c.Logger,
 	})
 

--- a/internal/app/ipc_cursor_slots_test.go
+++ b/internal/app/ipc_cursor_slots_test.go
@@ -1,0 +1,212 @@
+//nolint:testpackage // Tests the private cursor-slot handlers.
+package app
+
+import (
+	"context"
+	"image"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/app/services"
+	"github.com/y3owk1n/neru/internal/core/domain/state"
+	"github.com/y3owk1n/neru/internal/core/infra/ipc"
+	portmocks "github.com/y3owk1n/neru/internal/core/ports/mocks"
+)
+
+// cursorSlotHarness drives the two cursor actions against a fake pointer, so a
+// test can say where the cursor is and see where a restore put it.
+type cursorSlotHarness struct {
+	handler *IPCControllerActions
+	// position is what the next save captures.
+	position image.Point
+	// moves records every point a restore moved the cursor to.
+	moves []image.Point
+}
+
+func newCursorSlotHarness(t *testing.T) *cursorSlotHarness {
+	t.Helper()
+
+	harness := &cursorSlotHarness{}
+
+	system := &portmocks.MockSystemPort{
+		CursorPositionFunc: func(context.Context) (image.Point, error) {
+			return harness.position, nil
+		},
+		MoveCursorToPointFunc: func(_ context.Context, point image.Point, _ bool) error {
+			harness.moves = append(harness.moves, point)
+
+			return nil
+		},
+	}
+
+	harness.handler = NewIPCControllerActions(
+		services.NewActionService(
+			&portmocks.MockAccessibilityPort{},
+			&portmocks.MockOverlayPort{},
+			system,
+			zap.NewNop(),
+		),
+		nil,
+		nil,
+		state.NewAppState(),
+		nil,
+		state.NewCursorSlots(),
+		zap.NewNop(),
+	)
+
+	return harness
+}
+
+// save captures the given position into the slot the args name.
+func (h *cursorSlotHarness) save(t *testing.T, at image.Point, args ...string) ipc.Response {
+	t.Helper()
+
+	h.position = at
+
+	return h.handler.handleAction(context.Background(), ipc.Command{
+		Args: append([]string{"save_cursor_pos"}, args...),
+	})
+}
+
+func (h *cursorSlotHarness) restore(t *testing.T, args ...string) ipc.Response {
+	t.Helper()
+
+	return h.handler.handleAction(context.Background(), ipc.Command{
+		Args: append([]string{"restore_cursor_pos"}, args...),
+	})
+}
+
+func TestCursorSlots_SaveAndRestoreRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	harness := newCursorSlotHarness(t)
+
+	saved := image.Point{X: 120, Y: 340}
+
+	if resp := harness.save(t, saved); !resp.Success {
+		t.Fatalf("save_cursor_pos = %+v, want success", resp)
+	}
+
+	if resp := harness.restore(t); !resp.Success {
+		t.Fatalf("restore_cursor_pos = %+v, want success", resp)
+	}
+
+	if len(harness.moves) != 1 || harness.moves[0] != saved {
+		t.Fatalf("cursor moves = %v, want exactly [%v]", harness.moves, saved)
+	}
+}
+
+// The reason named slots exist. A sequence that saves the cursor and then
+// invokes one that also saves used to lose the outer save silently, and the
+// outer restore then moved the cursor somewhere it never asked for.
+func TestCursorSlots_NamedSlotDoesNotClobberTheDefault(t *testing.T) {
+	t.Parallel()
+
+	harness := newCursorSlotHarness(t)
+
+	outer := image.Point{X: 10, Y: 20}
+	inner := image.Point{X: 900, Y: 800}
+
+	harness.save(t, outer)
+	harness.save(t, inner, "--slot=inner")
+
+	harness.restore(t, "--slot=inner")
+	harness.restore(t)
+
+	want := []image.Point{inner, outer}
+	if len(harness.moves) != len(want) {
+		t.Fatalf("cursor moves = %v, want %v", harness.moves, want)
+	}
+
+	for idx, point := range want {
+		if harness.moves[idx] != point {
+			t.Fatalf("cursor moves = %v, want %v", harness.moves, want)
+		}
+	}
+}
+
+// Restoring consumes the slot. A second restore is not an error — it simply has
+// nothing to move to, which keeps a sequence that restores twice from being a
+// failure a caller has to special-case.
+func TestCursorSlots_RestoreConsumesTheSlot(t *testing.T) {
+	t.Parallel()
+
+	harness := newCursorSlotHarness(t)
+
+	harness.save(t, image.Point{X: 5, Y: 5})
+	harness.restore(t)
+
+	resp := harness.restore(t)
+	if !resp.Success || resp.Code != ipc.CodeOK {
+		t.Fatalf("second restore_cursor_pos = %+v, want success", resp)
+	}
+
+	if len(harness.moves) != 1 {
+		t.Fatalf("cursor moves = %v, want the second restore to move nothing", harness.moves)
+	}
+}
+
+// "default" is an ordinary slot name, not a reserved word: naming it and
+// passing no flag have to be the same request, or a config author would have
+// two ways to mean one slot and no way to tell which they used.
+func TestCursorSlots_DefaultSlotIsAnOrdinaryName(t *testing.T) {
+	t.Parallel()
+
+	harness := newCursorSlotHarness(t)
+
+	saved := image.Point{X: 42, Y: 43}
+
+	harness.save(t, saved, "--slot="+state.DefaultCursorSlot)
+
+	if resp := harness.restore(t); !resp.Success {
+		t.Fatalf("restore_cursor_pos = %+v, want success", resp)
+	}
+
+	if len(harness.moves) != 1 || harness.moves[0] != saved {
+		t.Fatalf("cursor moves = %v, want [%v]", harness.moves, saved)
+	}
+}
+
+func TestCursorSlots_RejectsInvalidSlotNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		slot string
+	}{
+		{name: "empty", slot: "--slot="},
+		{name: "leading digit", slot: "--slot=9lives"},
+		{name: "looks like a flag", slot: "--slot=--center"},
+		{name: "dot", slot: "--slot=a.b"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			harness := newCursorSlotHarness(t)
+
+			resp := harness.save(t, image.Point{X: 1, Y: 1}, testCase.slot)
+			if resp.Success || resp.Code != ipc.CodeInvalidInput {
+				t.Fatalf("save_cursor_pos %s = %+v, want invalid input", testCase.slot, resp)
+			}
+		})
+	}
+}
+
+// The flag belongs to these two actions and nothing else, so an action that
+// does not take it must say so rather than ignore it.
+func TestCursorSlots_SlotIsRejectedOnOtherActions(t *testing.T) {
+	t.Parallel()
+
+	harness := newCursorSlotHarness(t)
+
+	resp := harness.handler.handleAction(context.Background(), ipc.Command{
+		Args: []string{leftClick, "--slot=here"},
+	})
+
+	if resp.Success || resp.Code != ipc.CodeInvalidInput {
+		t.Fatalf("left_click --slot = %+v, want invalid input", resp)
+	}
+}

--- a/internal/app/ipc_handlers_test.go
+++ b/internal/app/ipc_handlers_test.go
@@ -389,3 +389,65 @@ func TestHandleCommand_StatusReportsTheToggles(t *testing.T) {
 		t.Fatalf("encoded status does not report the scroll toggle:\n%s", encoded)
 	}
 }
+
+func TestHandleCommand_StatusReportsSavedCursorSlots(t *testing.T) {
+	controller := newToggleTestController(state.NewAppState(), nil)
+
+	// Empty is an empty object, not a null: a script indexing into it should
+	// not have to guard the container as well as the key.
+	before := statusField(t, controller, "saved_cursor_slots")
+	if slots, ok := before.(map[string]map[string]int); !ok || len(slots) != 0 {
+		t.Fatalf("saved_cursor_slots = %v (%T), want an empty object", before, before)
+	}
+
+	resp := controller.HandleCommand(context.Background(), ipc.Command{
+		Action: "action",
+		Args:   []string{"save_cursor_pos", "--slot=home"},
+	})
+	if !resp.Success {
+		t.Fatalf("save_cursor_pos = %+v, want success", resp)
+	}
+
+	after := statusField(t, controller, "saved_cursor_slots")
+
+	slots, ok := after.(map[string]map[string]int)
+	if !ok {
+		t.Fatalf("saved_cursor_slots = %T, want map[string]map[string]int", after)
+	}
+
+	home, present := slots["home"]
+	if !present {
+		t.Fatalf("saved_cursor_slots = %v, want an entry for home", slots)
+	}
+
+	// Lowercase x and y, not the X and Y that image.Point would encode.
+	if _, hasX := home["x"]; !hasX {
+		t.Fatalf("slot home = %v, want lowercase x and y keys", home)
+	}
+
+	if _, hasY := home["y"]; !hasY {
+		t.Fatalf("slot home = %v, want lowercase x and y keys", home)
+	}
+}
+
+// statusField reads one key out of the status payload.
+func statusField(t *testing.T, controller *app.IPCController, key string) any {
+	t.Helper()
+
+	resp := controller.HandleCommand(context.Background(), ipc.Command{Action: "status"})
+	if !resp.Success {
+		t.Fatalf("HandleCommand(status) = %+v, want success", resp)
+	}
+
+	status, ok := resp.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("status data = %T, want map[string]any", resp.Data)
+	}
+
+	value, present := status[key]
+	if !present {
+		t.Fatalf("status is missing %q", key)
+	}
+
+	return value
+}

--- a/internal/app/ipc_info.go
+++ b/internal/app/ipc_info.go
@@ -48,6 +48,7 @@ type IPCControllerInfo struct {
 	eventTap      ports.EventTapPort
 	ipcServer     ports.IPCPort
 	reloadConfig  func(ctx context.Context, configPath string) error
+	cursorSlots   *state.CursorSlots
 	logger        *zap.Logger
 
 	// configMu protects config from concurrent read/write.
@@ -85,6 +86,9 @@ type IPCControllerInfoDeps struct {
 	// SetConfigField applies a runtime config field change.
 	SetConfigField func(ctx context.Context, key, value string) error
 
+	// CursorSlots is the store save_cursor_pos writes to, reported by status.
+	CursorSlots *state.CursorSlots
+
 	Logger *zap.Logger
 }
 
@@ -104,6 +108,7 @@ func NewIPCControllerInfo(deps IPCControllerInfoDeps) *IPCControllerInfo {
 		ipcServer:      deps.IPCServer,
 		reloadConfig:   deps.ReloadConfig,
 		setConfigField: deps.SetConfigField,
+		cursorSlots:    deps.CursorSlots,
 		logger:         deps.Logger,
 	}
 }
@@ -185,6 +190,7 @@ func (h *IPCControllerInfo) handleStatus(_ context.Context, _ ipc.Command) ipc.R
 		"scroll_inverted":         h.appState.IsScrollInverted(),
 		"hidden_for_screen_share": h.appState.IsHiddenForScreenShare(),
 		"cursor_follow_selection": h.cursorFollowSelection(),
+		"saved_cursor_slots":      h.savedCursorSlots(),
 	}
 
 	return ipc.Response{
@@ -214,6 +220,27 @@ func (h *IPCControllerInfo) cursorFollowSelection() *bool {
 	}
 
 	return &enabled
+}
+
+// savedCursorSlots reports the occupied cursor slots and the position each
+// holds, as an object keyed by slot name.
+//
+// The points are re-keyed to lowercase x and y rather than encoded straight
+// from image.Point, whose fields marshal as X and Y — the rest of this payload
+// is snake_case, and the shape a script reads should not depend on how the
+// position happens to be stored.
+func (h *IPCControllerInfo) savedCursorSlots() map[string]map[string]int {
+	slots := map[string]map[string]int{}
+
+	if h.cursorSlots == nil {
+		return slots
+	}
+
+	for name, pos := range h.cursorSlots.Snapshot() {
+		slots[name] = map[string]int{"x": pos.X, "y": pos.Y}
+	}
+
+	return slots
 }
 
 func (h *IPCControllerInfo) handleConfig(ctx context.Context, cmd ipc.Command) ipc.Response {

--- a/internal/cli/action.go
+++ b/internal/cli/action.go
@@ -280,22 +280,78 @@ without a completed selection (e.g. user presses Escape).`,
 	return cmd
 }()
 
+// actionCmdName is the IPC command every action subcommand dispatches through.
+// It is spelled here rather than taken from domain.CommandAction because the
+// package-level helpers in root.go take a parameter named "action", which would
+// shadow the action package this file imports.
+const actionCmdName = "action"
+
+// BuildCursorSlotActionCommand creates an action cobra command for
+// save_cursor_pos or restore_cursor_pos, whose only flag is --slot.
+//
+// It does not go through buildActionCommand because that one always offers
+// --modifier, which the daemon rejects for these two actions: a command should
+// not advertise a flag its own daemon refuses.
+func BuildCursorSlotActionCommand(use, short, long string, params []string) *cobra.Command {
+	var slot string
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Long:  long,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return requiresRunningInstance()
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			args := make([]string, 0, len(params)+1)
+			args = append(args, params...)
+
+			if slot != "" {
+				if !action.IsValidCursorSlotName(slot) {
+					return derrors.Newf(
+						derrors.CodeInvalidInput,
+						"invalid --slot %q: names start with a letter and may contain "+
+							"letters, digits, underscores, and dashes",
+						slot,
+					)
+				}
+
+				args = append(args, "--slot="+slot)
+			}
+
+			return sendCommand(cmd, actionCmdName, args)
+		},
+	}
+
+	cmd.Flags().StringVar(&slot, "slot", "",
+		"Named slot to use instead of the default one")
+
+	return cmd
+}
+
 // ActionSaveCursorPosCmd saves cursor position for later restoration.
-var ActionSaveCursorPosCmd = BuildActionCommand(
+var ActionSaveCursorPosCmd = BuildCursorSlotActionCommand(
 	"save_cursor_pos",
 	"Save current cursor position",
-	`Save the current cursor position so it can be restored later with restore_cursor_pos.`,
+	`Save the current cursor position so it can be restored later with restore_cursor_pos.
+
+Without --slot the position goes to the slot named "default". Pass --slot to
+use a slot of your own, so a sequence that saves the cursor does not overwrite
+the save of a sequence it was invoked from. The occupied slots are reported by
+"neru status --json" under saved_cursor_slots.`,
 	[]string{"save_cursor_pos"},
-	false,
 )
 
 // ActionRestoreCursorPosCmd restores previously saved cursor position.
-var ActionRestoreCursorPosCmd = BuildActionCommand(
+var ActionRestoreCursorPosCmd = BuildCursorSlotActionCommand(
 	"restore_cursor_pos",
 	"Restore saved cursor position",
-	`Restore cursor position previously saved by save_cursor_pos.`,
+	`Restore cursor position previously saved by save_cursor_pos.
+
+Reads the slot named "default" unless --slot names another. Restoring consumes
+the slot, so a second restore of the same slot finds nothing and succeeds
+without moving the cursor.`,
 	[]string{"restore_cursor_pos"},
-	false,
 )
 
 // ActionHideCursorCmd hides the system cursor.

--- a/internal/core/domain/action/action.go
+++ b/internal/core/domain/action/action.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"regexp"
 	"strings"
 
 	derrors "github.com/y3owk1n/neru/internal/core/errors"
@@ -515,6 +516,17 @@ func IsSaveCursorPosAction(name string) bool {
 // IsRestoreCursorPosAction reports whether the given action is restore_cursor_pos.
 func IsRestoreCursorPosAction(name string) bool {
 	return Name(name) == NameRestoreCursorPos
+}
+
+// cursorSlotNamePattern is what a --slot value may be called. The rule matches
+// the one for macro names, so the two kinds of name a config author writes look
+// the same, and it keeps a mistyped flag (`--slot --center`) from quietly
+// becoming a slot rather than an error.
+var cursorSlotNamePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
+
+// IsValidCursorSlotName reports whether name may be used as a cursor slot.
+func IsValidCursorSlotName(name string) bool {
+	return cursorSlotNamePattern.MatchString(name)
 }
 
 // IsHideCursorAction reports whether the given action is hide_cursor.

--- a/internal/core/domain/state/cursor_slots.go
+++ b/internal/core/domain/state/cursor_slots.go
@@ -1,0 +1,78 @@
+package state
+
+import (
+	"image"
+	"maps"
+	"sync"
+)
+
+// DefaultCursorSlot is the slot a save or restore uses when none is named.
+//
+// It is an ordinary name rather than a reserved empty string, so the slots are
+// one flat namespace: the default has no privileges the others lack, and
+// `--slot default` and no flag at all are the same request. That also keeps the
+// status payload free of an empty JSON key.
+const DefaultCursorSlot = "default"
+
+// CursorSlots stores cursor positions under names.
+//
+// One unnamed slot was enough while only a hotkey binding could save a
+// position, because a binding runs to completion before the next one starts.
+// It stopped being enough once a sequence could invoke another one: an inner
+// macro that saves the cursor would overwrite the outer sequence's save, and
+// the outer restore would then move the cursor somewhere it never asked for —
+// silently, since neither side had any way to notice the collision.
+type CursorSlots struct {
+	mu    sync.RWMutex
+	slots map[string]image.Point
+}
+
+// NewCursorSlots creates an empty slot store.
+func NewCursorSlots() *CursorSlots {
+	return &CursorSlots{slots: make(map[string]image.Point)}
+}
+
+// Save stores pos under name, replacing whatever that slot held.
+func (c *CursorSlots) Save(name string, pos image.Point) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.slots == nil {
+		c.slots = make(map[string]image.Point)
+	}
+
+	c.slots[name] = pos
+}
+
+// Take removes the named slot and reports what it held.
+//
+// Reading and clearing are one operation because a restore consumes the slot:
+// were they separate, two restores racing on the same slot could both see it
+// occupied and both move the cursor.
+func (c *CursorSlots) Take(name string) (image.Point, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	pos, ok := c.slots[name]
+	if !ok {
+		return image.Point{}, false
+	}
+
+	delete(c.slots, name)
+
+	return pos, true
+}
+
+// Snapshot returns a copy of the occupied slots, for reporting. The result is
+// never nil, so a caller reporting it always has an object to encode rather
+// than sometimes a null.
+func (c *CursorSlots) Snapshot() map[string]image.Point {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.slots == nil {
+		return make(map[string]image.Point)
+	}
+
+	return maps.Clone(c.slots)
+}

--- a/internal/core/domain/state/cursor_slots_test.go
+++ b/internal/core/domain/state/cursor_slots_test.go
@@ -1,0 +1,124 @@
+package state_test
+
+import (
+	"image"
+	"sync"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/core/domain/state"
+)
+
+func TestCursorSlots_SaveAndTake(t *testing.T) {
+	t.Parallel()
+
+	slots := state.NewCursorSlots()
+
+	if _, ok := slots.Take("missing"); ok {
+		t.Fatal("Take() on an empty store reported a position")
+	}
+
+	want := image.Point{X: 7, Y: 9}
+	slots.Save("home", want)
+
+	got, ok := slots.Take("home")
+	if !ok {
+		t.Fatal("Take() did not find the saved position")
+	}
+
+	if got != want {
+		t.Fatalf("Take() = %v, want %v", got, want)
+	}
+
+	// Taking consumes it.
+	if _, ok := slots.Take("home"); ok {
+		t.Fatal("Take() found the position a previous Take should have consumed")
+	}
+}
+
+func TestCursorSlots_SlotsAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	slots := state.NewCursorSlots()
+
+	first := image.Point{X: 1, Y: 1}
+	second := image.Point{X: 2, Y: 2}
+
+	slots.Save("first", first)
+	slots.Save("second", second)
+	slots.Save("first", first) // A repeat save must not disturb the other slot.
+
+	if got, _ := slots.Take("second"); got != second {
+		t.Fatalf("Take(second) = %v, want %v", got, second)
+	}
+
+	if got, _ := slots.Take("first"); got != first {
+		t.Fatalf("Take(first) = %v, want %v", got, first)
+	}
+}
+
+// Exactly one caller may win a slot. Reading and clearing separately would let
+// two concurrent restores both see it occupied and both move the cursor.
+func TestCursorSlots_TakeIsExclusive(t *testing.T) {
+	t.Parallel()
+
+	const racers = 16
+
+	slots := state.NewCursorSlots()
+	slots.Save("contested", image.Point{X: 3, Y: 4})
+
+	var (
+		group     sync.WaitGroup
+		winnersMu sync.Mutex
+		winners   int
+	)
+
+	start := make(chan struct{})
+
+	for range racers {
+		group.Go(func() {
+			<-start
+
+			if _, ok := slots.Take("contested"); ok {
+				winnersMu.Lock()
+				winners++
+				winnersMu.Unlock()
+			}
+		})
+	}
+
+	close(start)
+	group.Wait()
+
+	if winners != 1 {
+		t.Fatalf("Take() succeeded for %d racers, want exactly 1", winners)
+	}
+}
+
+func TestCursorSlots_Snapshot(t *testing.T) {
+	t.Parallel()
+
+	slots := state.NewCursorSlots()
+
+	empty := slots.Snapshot()
+	if empty == nil {
+		t.Fatal("Snapshot() = nil, want an empty map so callers always have something to encode")
+	}
+
+	if len(empty) != 0 {
+		t.Fatalf("Snapshot() = %v, want empty", empty)
+	}
+
+	slots.Save("a", image.Point{X: 1, Y: 2})
+
+	snapshot := slots.Snapshot()
+	if len(snapshot) != 1 || snapshot["a"] != (image.Point{X: 1, Y: 2}) {
+		t.Fatalf("Snapshot() = %v, want one entry for a", snapshot)
+	}
+
+	// The snapshot is a copy: mutating it must not reach the store.
+	delete(snapshot, "a")
+
+	if _, ok := slots.Take("a"); !ok {
+		t.Fatal("mutating a snapshot removed the slot from the store")
+	}
+}


### PR DESCRIPTION
## Description

`save_cursor_pos` wrote to a single unnamed position. That was enough while only a hotkey binding could save one — a binding runs to completion before the next starts, so nothing else was ever holding the slot.

Sequences broke that assumption. A macro that saves the cursor, invoked from a sequence that also saved, overwrites the caller's position; the caller's restore then moves the cursor somewhere it never asked for. Neither side can notice: there is no error, just a pointer in the wrong place. Making macros invocable from outside in #1144 widened the door on it.

Both cursor actions now take `--slot <name>`, and each name is an independent position:

```toml
[macros]
# Safe to call from a sequence that has itself saved the cursor.
peek = [
    "action save_cursor_pos --slot peek",
    "action move_mouse --x 0 --y 0",
    "action left_click",
    "action restore_cursor_pos --slot peek",
]
```

`neru status --json` reports the occupied slots under `saved_cursor_slots`, so a script can read back what it saved.

## Related Issues

Follows on from #1144.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — see the note below
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Test status, stated plainly.** `just test-unit` is green, and `-tags=integration` passes for every package this PR touches. Three tests in `internal/core/infra/accessibility` fail on my machine — `TestAccessibilityAdapterIntegration`, `TestSmoothCursorSettlesOnTarget`, `TestDirectMoveOverridesInFlightAnimation` — but they fail identically on clean `main` with this branch stashed, so they are pre-existing and unrelated. They drive the real cursor and the live AX tree, so they need accessibility permission and an idle screen. Worth confirming they pass in CI.

**`default` is an ordinary slot name**, not a reserved empty string. So `--slot default` and passing no flag are the same request, and the status payload has no empty JSON key. A config author has one way to name the default slot rather than two.

**Restoring still consumes the slot**, as it always has — this PR does not change that contract. What did change is that the read and the clear are now one operation rather than a read, a move, and a clear. Concurrent restores of one slot could otherwise both see it occupied and both move the cursor; there is a race-detector test for the exclusivity. One consequence worth naming: a restore whose move then fails leaves the slot consumed, where before the position survived. That keeps a failed restore from leaving a stale mark for a later one to trip over, and `MoveCursorToPoint` failures are platform errors rather than transient ones — but it is a behavior change, so flag it if you'd rather it went the other way.

If persistent marks (restore without consuming) turn out to be wanted, that is a separate `--keep` flag rather than a change to this default.

**The two commands get a dedicated cobra builder** instead of going through `buildActionCommand`, which always offers `--modifier` — a flag the daemon rejects for these two actions. A command should not advertise a flag its own daemon refuses.

`TestCursorSlots_NamedSlotDoesNotClobberTheDefault` is a genuine regression test: under the old single slot it produces `[inner]` instead of `[inner, outer]`.