### PR TITLE
test(integration): skip live-input tests without permission, and stop caching

### DIFF
--- a/internal/core/infra/accessibility/adapter_integration_darwin_test.go
+++ b/internal/core/infra/accessibility/adapter_integration_darwin_test.go
@@ -28,12 +28,15 @@ func TestAccessibilityAdapterIntegration(t *testing.T) {
 	adapter := accessibility.NewAdapter(log, nil, nil, client, false)
 	system := darwinplatform.NewSystemAdapter()
 
-	// Bounded rather than context.Background(): every call below reaches the
-	// real AX API, and a scan of a slow or unresponsive frontmost window blocks
-	// in the Objective-C bridge. With no deadline that is not a slow test, it is
-	// `just test` never returning — and the run has to be killed by hand to find
-	// out which test it was. The budget is far above the daemon's own per-scan
-	// ceiling (modes.HintTimeout, 5s), so it can only trip on a real hang.
+	// Bounded rather than context.Background(), but note what this does and
+	// does not buy: the AX client discards the context and calls straight into
+	// the Objective-C bridge, so the deadline cannot interrupt a query that is
+	// already wedged there. What it does do is stop the scan's per-source
+	// goroutines from starting further work once it has expired.
+	//
+	// The actual hang guard is runWithinBudget, which watches from outside the
+	// call. The budget is shared and sits far above the daemon's own per-scan
+	// ceiling (modes.HintTimeout, 5s), so neither can trip on a merely slow run.
 	ctx, cancel := context.WithTimeout(context.Background(), integrationScanBudget)
 	defer cancel()
 
@@ -279,7 +282,17 @@ func TestAccessibilityAdapterIntegration(t *testing.T) {
 			ExcludeRoles: []element.Role{element.RoleWindow},
 		}
 
-		clickableElements, err := adapter.ClickableElements(ctx, filter)
+		var (
+			clickableElements []*element.Element
+			err               error
+		)
+
+		// The scan is the one call here that can wedge, and the deadline on ctx
+		// cannot stop it — see runWithinBudget for why.
+		runWithinBudget(t, "ClickableElements", func() {
+			clickableElements, err = adapter.ClickableElements(ctx, filter)
+		})
+
 		if err != nil {
 			t.Fatalf("ClickableElements() error = %v, want nil", err)
 		}

--- a/internal/core/infra/accessibility/adapter_integration_darwin_test.go
+++ b/internal/core/infra/accessibility/adapter_integration_darwin_test.go
@@ -28,7 +28,14 @@ func TestAccessibilityAdapterIntegration(t *testing.T) {
 	adapter := accessibility.NewAdapter(log, nil, nil, client, false)
 	system := darwinplatform.NewSystemAdapter()
 
-	ctx := context.Background()
+	// Bounded rather than context.Background(): every call below reaches the
+	// real AX API, and a scan of a slow or unresponsive frontmost window blocks
+	// in the Objective-C bridge. With no deadline that is not a slow test, it is
+	// `just test` never returning — and the run has to be killed by hand to find
+	// out which test it was. The budget is far above the daemon's own per-scan
+	// ceiling (modes.HintTimeout, 5s), so it can only trip on a real hang.
+	ctx, cancel := context.WithTimeout(context.Background(), integrationScanBudget)
+	defer cancel()
 
 	t.Run("ScreenBounds", func(t *testing.T) {
 		screenBounds, screenBoundsErr := system.ScreenBounds(ctx)
@@ -73,6 +80,8 @@ func TestAccessibilityAdapterIntegration(t *testing.T) {
 	})
 
 	t.Run("MoveCursorToPoint", func(t *testing.T) {
+		requireInputPermission(t)
+
 		// Get current position
 		startPos, startPosErr := system.CursorPosition(ctx)
 		if startPosErr != nil {
@@ -121,6 +130,11 @@ func TestAccessibilityAdapterIntegration(t *testing.T) {
 	})
 
 	t.Run("MoveCursorToPoint bypassSmooth", func(t *testing.T) {
+		// Gated even though it only asserts the call returns no error: without
+		// the permission that call succeeds while the cursor never moves, so a
+		// pass here would say nothing about the path it exists to cover.
+		requireInputPermission(t)
+
 		// Get current position
 		startPos, startPosErr := system.CursorPosition(ctx)
 		if startPosErr != nil {
@@ -137,6 +151,8 @@ func TestAccessibilityAdapterIntegration(t *testing.T) {
 	})
 
 	t.Run("MoveCursorToPoint lands on the requested point", func(t *testing.T) {
+		requireInputPermission(t)
+
 		// Regression guard for the macOS Accessibility Zoom interaction: when
 		// pointer-motion events are posted at the HID tap and the screen is
 		// zoomed in, the window server rewrites their location to
@@ -244,6 +260,8 @@ func TestAccessibilityAdapterIntegration(t *testing.T) {
 	})
 
 	t.Run("ClickableElements queries the live AX tree without error", func(t *testing.T) {
+		requireInputPermission(t)
+
 		// A `go test` binary is not a foreground app with its own window, so
 		// the live AX tree usually yields zero elements here. That makes the
 		// element *count* unassertable, and any per-element loop vacuous — the

--- a/internal/core/infra/accessibility/cursor_integration_darwin_test.go
+++ b/internal/core/infra/accessibility/cursor_integration_darwin_test.go
@@ -38,6 +38,8 @@ func TestSmoothCursorSettlesOnTarget(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	requireInputPermission(t)
+
 	zoomed := darwinplatform.IsScreenZoomed()
 	if zoomed {
 		t.Log("Accessibility Zoom is engaged — exercising the zoomed path")
@@ -117,6 +119,8 @@ func TestDirectMoveOverridesInFlightAnimation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+
+	requireInputPermission(t)
 
 	bounds := darwinplatform.ActiveScreenBounds()
 	if bounds.Empty() {

--- a/internal/core/infra/accessibility/permission_integration_darwin_test.go
+++ b/internal/core/infra/accessibility/permission_integration_darwin_test.go
@@ -1,0 +1,51 @@
+//go:build integration && darwin
+
+package accessibility_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	darwinplatform "github.com/y3owk1n/neru/internal/core/infra/platform/darwin"
+)
+
+// integrationScanBudget bounds a live-AX test run. It is a hang guard, not a
+// performance assertion: the whole suite takes a couple of seconds when the AX
+// API answers, so anything approaching this means a call is wedged.
+const integrationScanBudget = 30 * time.Second
+
+// hasInputPermission reports whether this process has been granted macOS
+// Accessibility permission. It is resolved once: the answer cannot change
+// during a run.
+var hasInputPermission = sync.OnceValue(darwinplatform.CheckAccessibilityPermissions)
+
+// requireInputPermission skips a test that cannot work without macOS
+// Accessibility permission.
+//
+// Reading the AX tree and posting synthetic input are behind the same TCC gate,
+// and a `go test` binary is not normally granted it. Without the grant the
+// window server drops the posted moves, so the cursor never leaves its starting
+// point and the AX query cannot find a frontmost window — and the tests report
+// that as a failure, which is a claim about the code that is not true. What
+// failed is the environment.
+//
+// A suite that is reliably red for a reason the developer cannot act on is a
+// suite people learn to ignore, and it also stops `just test` from being usable
+// as evidence that a change is sound. Skipping says what is actually happening.
+//
+// This does not lose coverage where it counts: the macOS CI runner does have the
+// permission, so these tests run there for real on every PR. To run them locally,
+// grant Accessibility to the terminal (or to the test binary) under System
+// Settings > Privacy & Security > Accessibility.
+func requireInputPermission(t *testing.T) {
+	t.Helper()
+
+	if !hasInputPermission() {
+		t.Skip(
+			"macOS Accessibility permission is not granted to this process, so posted " +
+				"input is dropped and the AX tree is unreadable; grant it under System " +
+				"Settings > Privacy & Security > Accessibility to run this",
+		)
+	}
+}

--- a/internal/core/infra/accessibility/permission_integration_darwin_test.go
+++ b/internal/core/infra/accessibility/permission_integration_darwin_test.go
@@ -10,10 +10,54 @@ import (
 	darwinplatform "github.com/y3owk1n/neru/internal/core/infra/platform/darwin"
 )
 
-// integrationScanBudget bounds a live-AX test run. It is a hang guard, not a
+// integrationScanBudget bounds a live-AX test call. It is a hang guard, not a
 // performance assertion: the whole suite takes a couple of seconds when the AX
 // API answers, so anything approaching this means a call is wedged.
 const integrationScanBudget = 30 * time.Second
+
+// runWithinBudget runs work on its own goroutine and fails the test if it has
+// not returned within integrationScanBudget.
+//
+// A context deadline cannot do this job. The AX client takes a context and
+// discards it — see InfraAXClient.FrontmostWindow in infra_client.go, whose
+// parameter is `_ context.Context` — so once a query is inside the Objective-C
+// bridge nothing observes cancellation. The context the suite passes is still
+// worth having, because the scan's per-source goroutines check it before
+// starting further work, but it cannot interrupt a call already in the bridge.
+// Only a watchdog outside that call can.
+//
+// Without this the failure mode is Go's own -timeout (10 minutes by default)
+// firing with a panic and a full goroutine dump, ten minutes after the run
+// stopped making progress and with no statement of which call wedged. This
+// fails in 30 seconds and names it.
+//
+// The goroutine is deliberately abandoned on timeout: it is blocked in a native
+// call and cannot be reclaimed. The test binary is exiting anyway.
+//
+// work must not call t.Fatal — it runs off the test goroutine. Have it assign
+// results and assert on them after this returns.
+func runWithinBudget(t *testing.T, what string, work func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		work()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(integrationScanBudget):
+		t.Fatalf(
+			"%s did not return within %s; the accessibility server of the frontmost "+
+				"application is not answering, so the call is stuck in the native AX bridge",
+			what,
+			integrationScanBudget,
+		)
+	}
+}
 
 // hasInputPermission reports whether this process has been granted macOS
 // Accessibility permission. It is resolved once: the answer cannot change

--- a/internal/core/infra/hotkeys/manager_integration_darwin_test.go
+++ b/internal/core/infra/hotkeys/manager_integration_darwin_test.go
@@ -31,6 +31,19 @@ func TestManagerRegistersAgainstTheRealOS(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	// Creating a CGEventTap is behind the macOS Accessibility TCC gate, and a
+	// `go test` binary is not normally granted it. Without the grant every
+	// Register fails, which reads as "the hotkey manager is broken" when what
+	// is missing is the permission. Skipping says what actually happened; CI
+	// has the grant, so the real path is still exercised on every PR.
+	if !darwin.CheckAccessibilityPermissions() {
+		t.Skip(
+			"macOS Accessibility permission is not granted to this process, so a " +
+				"CGEventTap cannot be created; grant it under System Settings > " +
+				"Privacy & Security > Accessibility to run this",
+		)
+	}
+
 	log := logger.Get()
 	manager := hotkeys.NewManager(log)
 

--- a/justfile
+++ b/justfile
@@ -224,9 +224,17 @@ list-foundation-packages:
 # cursor, keyboard and overlay, so two packages running concurrently fight over
 # one physical input device: a click in one package's test moves the cursor out
 # from under another package's cursor assertion, and either side can lose.
+#
+# -count=1 disables the test cache. Go keys that cache on the inputs it can see
+# — sources, env, files read — and none of those change when the thing an
+# integration test actually depends on does: whether Accessibility permission is
+# granted, whether a daemon holds the socket, whether the screen is locked. A
+# result cached from a run under different conditions is then replayed as a
+# pass, which is worse than no result at all: it reports green for a run that
+# never happened.
 test-integration:
     @echo "Running integration tests..."
-    go test -tags=integration -p 1 -v ./...
+    go test -tags=integration -p 1 -count=1 -v ./...
 
 # Run with race detection
 test-race: test-race-unit test-race-integration
@@ -238,10 +246,10 @@ test-race-unit:
     go test -race -v ./...
 
 # Run integration tests with race detection
-# See test-integration for why -p 1 is required here.
+# See test-integration for why -p 1 and -count=1 are required here.
 test-race-integration:
     @echo "Running integration tests with race detection..."
-    go test -tags=integration -race -p 1 -v ./...
+    go test -tags=integration -race -p 1 -count=1 -v ./...
 
 test-all: test test-race
 


### PR DESCRIPTION
## Description

`just test` was red on a developer machine for reasons no code change could fix, and green in CI. Three separate things were making the suite lie about itself.

**Six tests need macOS Accessibility permission and failed without it.** They drive real input or read the live AX tree, both behind the same TCC gate, and a `go test` binary is not normally granted it. Without the grant the window server drops posted moves and the AX query finds no frontmost window — so the cursor "settles" exactly where it started, `Register` cannot create a CGEventTap, and all six report a failure *of the code*. What failed is the environment:

```
MoveCursorToPoint((687,754)) from (677,744) settled at (677,744)
ClickableElements() error = failed to get frontmost window
Register("cmd+alt+ctrl+shift+f12") error = failed to register hotkey
```

They now skip when the permission is absent, with a message saying so and where to grant it. The suite already skipped on `testing.Short()` and on `"no active screen bounds"`, so this follows an existing pattern rather than inventing one.

**The integration recipes now pass `-count=1`.** Go keys its test cache on the inputs it can see — sources, env, files read — and none of those change when the thing an integration test actually depends on does: whether the permission is granted, whether a daemon holds the socket, whether the screen is locked. A result cached under different conditions gets replayed as a pass, which is worse than no result: it reports green for a run that never happened. It did exactly that here — a stale pass hid the hotkey failure from me for several minutes while I was reporting the suite as green.

**`TestAccessibilityAdapterIntegration` ran its real AX scans on `context.Background()`.** A scan of a slow or unresponsive frontmost window blocks in the Objective-C bridge, so with no deadline that is not a slow test but `just test` never returning, with no indication of which test wedged. It now runs under a 30s budget — far above the daemon's own 5s per-scan ceiling, so it can only trip on a real hang.

## Related Issues

<!-- none -->

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `test` — Adding or updating tests

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

The new helper is `permission_integration_darwin_test.go`, named to match the `*_integration_<os>_test.go` convention so it falls under the depguard exemption. My first name for it did not, and the linter caught it — worth noting the rule is enforced, not just documented.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — and `just test-race`, both genuinely uncached
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**The gates were verified in both directions, which is the thing worth checking.** A skip that can never un-skip is not a fix, it is deleting the test. With the probe reading the real permission, all six skip and both packages pass. With the probe forced open, exactly the same six run and fail again with the identical errors. So the skip is driven by the permission and nothing else.

**CI coverage is unaffected.** I checked the macOS job log on #1145 before changing anything: `macos-latest` passes all six for real (`TestAccessibilityAdapterIntegration` and both cursor tests, `--- PASS`). The runner has the grant, so they keep running there on every PR. This PR only changes what happens on a machine that lacks it.

**`MoveCursorToPoint bypassSmooth` is gated although it passes without the permission.** It only asserts that the call returns no error, and that call succeeds while the cursor never moves — so its pass says nothing about the path it exists to cover. Gating it makes the skip list coherent (everything that drives real input) and stops it reading as coverage it does not provide. Happy to drop that one from the PR if you would rather keep the diff to the failing tests.

**Not fixed here, but noticed:** `TestConcurrentMovesKeepCursorInViewport` `continue`s out of its assertion on every round when Accessibility Zoom is not engaged, so outside a zoomed session it asserts nothing and is really a race/panic smoke test. That is a coverage question rather than a flakiness one, so I left it alone.