### PR TITLE
fix(darwin): invalidate CGEventTap Mach port before releasing it

### DIFF
--- a/internal/adapter/platform/darwin/eventtap_darwin.m
+++ b/internal/adapter/platform/darwin/eventtap_darwin.m
@@ -759,6 +759,12 @@ void NeruDestroyHotkeyTap(HotkeyTapRef ref) {
 			CFRelease(tap->runLoopSource);
 		}
 		if (tap->eventTap) {
+			// CFRelease alone does not guarantee the underlying Mach port is
+			// torn down on the WindowServer/kernel side; CFMachPortInvalidate
+			// must be called first or the port can leak. This path runs on
+			// every app switch when per-app hotkey overrides are configured,
+			// so an un-invalidated port here leaks quickly.
+			CFMachPortInvalidate(tap->eventTap);
 			CFRelease(tap->eventTap);
 		}
 	};
@@ -1189,6 +1195,10 @@ void NeruDestroyEventTap(EventTap tap) {
 
 		// Release Core Foundation resources
 		if (context->eventTap) {
+			// See NeruDestroyHotkeyTap: invalidate the Mach port before
+			// releasing it, otherwise the underlying port can leak even
+			// though the CF wrapper's refcount reaches zero.
+			CFMachPortInvalidate(context->eventTap);
 			CFRelease(context->eventTap);
 			context->eventTap = NULL;
 		}


### PR DESCRIPTION
CFRelease on a CFMachPortRef does not guarantee the underlying Mach port is torn down; CFMachPortInvalidate must be called first or the port leaks. Both CGEventTap teardown paths (NeruDestroyHotkeyTap and NeruDestroyEventTap) released without invalidating first. NeruDestroyHotkeyTap runs on every app switch when per-app hotkey overrides are configured, so the leak compounds quickly.

Related: #1030

## Description

<!-- What does this PR do? Why is it needed? -->

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Target Platform

<!-- Check all that apply: -->

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [ ] Code formatted (`just fmt`)
- [ ] Linters pass (`just lint`)
- [ ] Tests pass (`just test`)
- [ ] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->
