### PR TITLE
fix(darwin): skip WindowServer work for healthy overlays on Space changes

### DIFF
--- a/internal/adapter/platform/darwin/overlay_darwin.m
+++ b/internal/adapter/platform/darwin/overlay_darwin.m
@@ -1755,6 +1755,9 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 - (void)reattachToAllSpacesIfVisible;
 @end
 
+// Coalesces bursts of invalidation notifications into one reattach cycle.
+static const int64_t kNeruWindowServerReattachDebounceNs = 300 * NSEC_PER_MSEC;
+
 #pragma mark - Overlay Window Controller Implementation
 
 @implementation OverlayWindowController
@@ -1788,47 +1791,65 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	return frame.size.width > 1.0 || frame.size.height > 1.0;
 }
 
-- (void)reattachToAllSpacesIfVisible {
+// Expensive recovery path for a genuinely invalidated window-server
+// attachment (wake, display reconfiguration) — never for routine Space
+// switches; `delayNs` absorbs notification bursts into one pending cycle.
+- (void)reattachToAllSpacesIfVisibleAfterDelay:(int64_t)delayNs {
 	if (!self.shouldBeVisible || ![self hasDrawableFrame] || self.windowServerReattachScheduled)
 		return;
 
 	self.windowServerReattachScheduled = YES;
-	[self.window orderOut:nil];
-	[self.window setCollectionBehavior:NSWindowCollectionBehaviorDefault];
-	dispatch_async(dispatch_get_main_queue(), ^{
-		self.windowServerReattachScheduled = NO;
-		if (!self.shouldBeVisible || ![self hasDrawableFrame])
+	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delayNs), dispatch_get_main_queue(), ^{
+		if (!self.shouldBeVisible || ![self hasDrawableFrame]) {
+			self.windowServerReattachScheduled = NO;
 			return;
+		}
 
-		self.needsWindowServerReattach = NO;
-		[self applyOverlayCollectionBehavior];
-		[self.window setIsVisible:YES];
-		[self.window orderFrontRegardless];
-		[self.window display];
-		[self.overlayView setNeedsDisplay:YES];
+		[self.window orderOut:nil];
+		[self.window setCollectionBehavior:NSWindowCollectionBehaviorDefault];
+		dispatch_async(dispatch_get_main_queue(), ^{
+			self.windowServerReattachScheduled = NO;
+			if (!self.shouldBeVisible || ![self hasDrawableFrame])
+				return;
+
+			self.needsWindowServerReattach = NO;
+			[self applyOverlayCollectionBehavior];
+			[self.window setIsVisible:YES];
+			[self.window orderFrontRegardless];
+			[self.window display];
+			[self.overlayView setNeedsDisplay:YES];
+		});
 	});
+}
+
+- (void)reattachToAllSpacesIfVisible {
+	[self reattachToAllSpacesIfVisibleAfterDelay:0];
+}
+
+// A healthy CanJoinAllSpaces window is already on the new Space, so a Space
+// change needs no WindowServer work; only repair a window macOS dropped.
+- (void)reassertOverlayOnActiveSpace {
+	if (!self.shouldBeVisible || ![self hasDrawableFrame] || self.windowServerReattachScheduled)
+		return;
+
+	if (self.window.isVisible && self.window.isOnActiveSpace)
+		return;
+
+	[self.window setLevel:kCGMaximumWindowLevel];
+	[self applyOverlayCollectionBehavior];
+	[self.window orderFrontRegardless];
+	[self.overlayView setNeedsDisplay:YES];
 }
 
 - (void)handleActiveSpaceDidChange:(NSNotification *)notification {
 	(void)notification;
-	if (!self.shouldBeVisible || ![self hasDrawableFrame] || self.windowServerReattachScheduled)
-		return;
-
 	if ([NSThread isMainThread]) {
-		[self.window setLevel:kCGMaximumWindowLevel];
-		[self applyOverlayCollectionBehavior];
-		[self.window orderFrontRegardless];
-		[self.overlayView setNeedsDisplay:YES];
+		[self reassertOverlayOnActiveSpace];
 		return;
 	}
 
 	dispatch_async(dispatch_get_main_queue(), ^{
-		if (!self.shouldBeVisible || ![self hasDrawableFrame] || self.windowServerReattachScheduled)
-			return;
-		[self.window setLevel:kCGMaximumWindowLevel];
-		[self applyOverlayCollectionBehavior];
-		[self.window orderFrontRegardless];
-		[self.overlayView setNeedsDisplay:YES];
+		[self reassertOverlayOnActiveSpace];
 	});
 }
 
@@ -1836,13 +1857,13 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	(void)notification;
 	if ([NSThread isMainThread]) {
 		self.needsWindowServerReattach = YES;
-		[self reattachToAllSpacesIfVisible];
+		[self reattachToAllSpacesIfVisibleAfterDelay:kNeruWindowServerReattachDebounceNs];
 		return;
 	}
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		self.needsWindowServerReattach = YES;
-		[self reattachToAllSpacesIfVisible];
+		[self reattachToAllSpacesIfVisibleAfterDelay:kNeruWindowServerReattachDebounceNs];
 	});
 }
 
@@ -2021,9 +2042,11 @@ void NeruHideOverlayWindow(OverlayWindow window) {
 
 	OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
 
+	// Hiding keeps the window-server attachment intact, so it must not set
+	// needsWindowServerReattach — only invalidation events (sleep, display
+	// reconfiguration) do.
 	if ([NSThread isMainThread]) {
 		controller.shouldBeVisible = NO;
-		controller.needsWindowServerReattach = YES;
 		[controller.window orderOut:nil];
 		// Shrink to 1x1 to release the large backing store (saves ~47MB per
 		// Retina-resolution full-screen window). The next resize/show call
@@ -2034,7 +2057,6 @@ void NeruHideOverlayWindow(OverlayWindow window) {
 		dispatch_async(dispatch_get_main_queue(), ^{
 			@autoreleasepool {
 				controller.shouldBeVisible = NO;
-				controller.needsWindowServerReattach = YES;
 				[controller.window orderOut:nil];
 				[controller.window setFrame:NSMakeRect(0, 0, 1, 1) display:NO];
 				[controller.overlayView setFrame:NSMakeRect(0, 0, 1, 1)];


### PR DESCRIPTION
## Description

This PR makes the Space-change handler a no-op when the window is still healthy (`isVisible && isOnActiveSpace`), a `CanJoinAllSpaces` window is already on the new Space, so nothing needs to happen. The expensive reattach is reserved for genuine attachment invalidation (wake, display reconfiguration), debounced 300 ms so notification bursts collapse into a single cycle, and hide/show no longer forces it. The repair paths from #936/#956/#962 are preserved: a window the window server actually dropped is still re-asserted on the next Space change, and sleep/wake still triggers the full reattach.

## Related Issues

Closes #1030

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
