### PR TITLE
fix(darwin): release AX elements leaked during accessibility priming

### DIFF
--- a/internal/adapter/accessibility/native/darwin/priming.go
+++ b/internal/adapter/accessibility/native/darwin/priming.go
@@ -36,6 +36,7 @@ func PrimeApplication(bundleID string, logger *zap.Logger) bool {
 
 		return false
 	}
+	defer app.Release()
 
 	return waitForAccessibility(app, logger)
 }
@@ -64,6 +65,22 @@ func hasUsableAccessibilityTree(root *Element, logger *zap.Logger) bool {
 
 	queue := []entry{{root, 0}}
 
+	// Children() hands over retained AXUIElementRefs; release everything this
+	// walk enqueues, but not the caller-owned root.
+	releaseVisited := func(el *Element) {
+		if el != root {
+			el.Release()
+		}
+	}
+
+	drainQueue := func() {
+		for _, pending := range queue {
+			if pending.el != nil {
+				releaseVisited(pending.el)
+			}
+		}
+	}
+
 	for len(queue) > 0 {
 		cur := queue[0]
 		queue = queue[1:]
@@ -74,6 +91,8 @@ func hasUsableAccessibilityTree(root *Element, logger *zap.Logger) bool {
 
 		info, err := cur.el.Info()
 		if err != nil || info == nil {
+			releaseVisited(cur.el)
+
 			continue
 		}
 
@@ -81,16 +100,22 @@ func hasUsableAccessibilityTree(root *Element, logger *zap.Logger) bool {
 
 		if _, ready := readyRoles[role]; ready {
 			logger.Info("Found usable accessibility tree", zap.String("role", role))
+			releaseVisited(cur.el)
+			drainQueue()
 
 			return true
 		}
 
 		if cur.depth >= maxPrimingDepth {
+			releaseVisited(cur.el)
+
 			continue
 		}
 
-		children, err := cur.el.Children(role)
-		if err != nil {
+		children, childrenErr := cur.el.Children(role)
+		releaseVisited(cur.el)
+
+		if childrenErr != nil {
 			continue
 		}
 


### PR DESCRIPTION
## Description

This PR fixes a huge memory leak where on every app activation while hints are enabled, the walk never releases anything. Every focus change will then leak the entire traversal for the whole lifetime, and it's very bad.

## Related Issues

Related to the lingering memory-growth reports on #1030.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
