### PR TITLE
docs: fix stale claims in AGENTS.md and the architecture guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Neru is a keyboard-driven navigation tool written in Go, with native bridges per
 
 ## Domain Concepts
 
-- **Mode**: Navigation context (hints, grid, recursive_grid, scroll, action)
+- **Mode**: Navigation context (hints, grid, recursive_grid, scroll, monitor_select; idle when none is active)
 - **Bridge**: Objective-C macOS integration layer
 - **Adapter**: Port implementation for external systems
 - **Port**: Interface definition for system capabilities (e.g., [accessibility.go](internal/ports/accessibility.go))
@@ -16,7 +16,7 @@ Neru follows a **Hexagonal Architecture (Ports and Adapters)**. All OS-specific 
 
 ### The "One Rule"
 
-**Non-darwin-tagged code must never import `internal/adapter/platform/darwin`.** This is enforced by `golangci-lint` using `depguard`.
+**Non-darwin-tagged code must never import `internal/adapter/platform/darwin`.** This is enforced twice: `depguard` in `.golangci.yml` and `internal/architecture/dependency_boundary_test.go` — `just lint` alone is not the only gate.
 
 ### File Organization for Platforms
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -376,20 +376,29 @@ in sync with reality — a stub reporting `supported` is a bug.
 
 ## Platform Boundaries in the CLI Layer
 
-**`neru services`** — `internal/cli/services.go` carries `//go:build darwin`
-because it drives `launchctl` and macOS `.plist` files. On other platforms the
-command is simply never registered. Adding Linux service management means a new
-`services_linux.go` with `//go:build linux` implementing install/uninstall/
-start/stop over `systemctl`, registered in its own `init()`.
+**`neru services`** — the command itself is shared:
+[services.go](../internal/cli/services.go) registers `ServicesCmd`
+unconditionally and delegates to unexported helpers (`installService`,
+`startService`, …). The helpers are a Tier-2 dispatch pair:
+[services_darwin.go](../internal/cli/services_darwin.go) (`//go:build darwin`)
+drives `launchctl` and `.plist` files, while
+[services_other.go](../internal/cli/services_other.go) (`//go:build !darwin`)
+returns `CodeNotSupported`. Adding Linux service management means carving a
+`services_linux.go` out of the `!darwin` slot and implementing the same helpers
+over `systemctl` — registration is already shared, so no new `init()` is
+needed.
 
-**`IsRunningFromAppBundle`** — [root.go](../internal/cli/root.go) delegates to a
-build-tagged `isRunningFromAppBundle()`. On macOS it detects
-`.app/Contents/MacOS` paths so the daemon auto-starts when double-clicked in
-Finder; elsewhere it returns false.
+**`IsRunningFromAppBundle`** — [root.go](../internal/cli/root.go) delegates to
+a build-tagged implementation: [root_darwin.go](../internal/cli/root_darwin.go)
+detects `.app/Contents/MacOS` paths so the daemon auto-starts when
+double-clicked in Finder, [root_windows.go](../internal/cli/root_windows.go)
+detects launches from Explorer / the Start Menu, and
+[root_other.go](../internal/cli/root_other.go) returns false.
 
-**Main-thread locking** — on macOS `cmd/neru/main.go` calls
-`runtime.LockOSThread()` before anything else, required by Cocoa. Non-macOS
-builds omit it. Never add `LockOSThread` to shared code.
+**Main-thread locking** — on macOS
+[main_darwin.go](../cmd/neru/main_darwin.go) calls `runtime.LockOSThread()`
+before anything else, required by Cocoa. Non-macOS builds omit it. Never add
+`LockOSThread` to shared code.
 
 ---
 


### PR DESCRIPTION
## Description

This PR fixes two entry-point docs drifted from the code and actively misleading.

## Related Issues

N/A

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)

## Type of Change

- [x] `docs` — Documentation only

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)