### PR TITLE
build: add just ci recipe and align the documented gate with CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,9 +39,8 @@
 ## General Checklist
 
 - [ ] Code formatted (`just fmt`)
-- [ ] Linters pass (`just lint`)
-- [ ] Tests pass (`just test`)
-- [ ] Build succeeds (`just build`)
+- [ ] `just ci` passes — the exact checks CI runs (format check, lint, vet,
+      tests including `-race`, vulnerability scan, build)
 - [ ] Tests added/updated for new or changed functionality
 - [ ] Documentation updated (if applicable)
 - [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,12 +70,23 @@ recommended path and provides every tool pre-configured.
     ```bash
     just fmt      # format Go and Objective-C
     just lint     # golangci-lint
-    just test     # unit + integration
+    just test     # unit + integration — see the warning below
     just build    # verify the build
     ```
 
-    Doing Linux or Windows work? Start with `just test-foundation` and
-    `just build-linux` / `just build-windows`.
+    > [!IMPORTANT]
+    > On macOS, `just test` includes integration tests that **drive your real
+    > cursor, keyboard, and overlays**, and they need Accessibility permission
+    > granted to your terminal (System Settings → Privacy & Security →
+    > Accessibility). Run `just test-unit` if you only want the safe subset,
+    > and quit any running `neru` daemon first — a live daemon holding the
+    > socket makes the IPC integration tests silently skip. Details in
+    > [DEVELOPMENT.md](docs/DEVELOPMENT.md#testing).
+
+    Before pushing, run **`just ci`** — it is exactly what CI gates your PR on,
+    and it is a superset of the checks above (adds `go vet`, a full `-race`
+    pass, and a vulnerability scan). Doing Linux or Windows work? Start with
+    `just test-foundation` and `just build-linux` / `just build-windows`.
 
 6. **Update the docs** in the same PR. Each fact has one home — the
    [documentation checklist](docs/CROSS_PLATFORM.md#documentation-checklist)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -226,8 +226,8 @@ live in [TESTING_PATTERNS.md](testing/TESTING_PATTERNS.md).
 ### What each layer covers
 
 **Unit** — hint generation, grid calculations, element filtering, action
-processing, mode transitions, config parsing/validation/defaults, CLI argument
-handling, and pure-logic benchmarks. These run everywhere.
+processing, mode transitions, config parsing/validation/defaults, and CLI
+argument handling. These run everywhere.
 
 **Integration** — today these are **macOS only**: real Accessibility and event
 tap APIs, global hotkey registration, overlay and window management, Unix socket
@@ -236,6 +236,26 @@ IPC, config file loading and reloading, and service-to-adapter coordination.
 reserved slots — no such tests exist yet, so Linux and Windows behavior is
 currently pinned by unit and contract tests alone. Adding real ones is one of
 the more valuable contributions available.
+
+### Running integration tests
+
+Integration tests exercise the **real OS**, and on macOS that has consequences
+worth knowing before your first run:
+
+- **They move your cursor and type keystrokes.** Don't run them while you're
+  typing in another window; the tests and you are sharing one physical input
+  device.
+- **Your terminal needs Accessibility permission** (System Settings → Privacy &
+  Security → Accessibility). Without it, accessibility- and event-tap-backed
+  tests fail with permission errors rather than skipping.
+- **Quit any running `neru` daemon first.** A live daemon holds the IPC socket,
+  which makes the IPC integration tests silently skip — a green run that tested
+  less than you think.
+- `just test-integration` runs with `-p 1` (one package at a time — concurrent
+  packages would fight over the one physical cursor) and `-count=1` (no test
+  cache — Go's cache can't see whether Accessibility was granted or a daemon
+  held the socket, so a cached pass may be from a run under different
+  conditions).
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -172,7 +172,9 @@ uninstall *ARGS:
 
 # Run tests
 
-# Run all tests (unit + integration)
+# Run all tests (unit + integration). On macOS the integration half drives the
+# real cursor and keyboard and needs Accessibility permission — see the
+# test-integration comment before running this for the first time.
 test: test-unit test-integration
     @echo "Running all tests..."
 
@@ -251,7 +253,14 @@ test-race-integration:
     @echo "Running integration tests with race detection..."
     go test -tags=integration -race -p 1 -count=1 -v ./...
 
+# Everything CI's test job runs: the full suite plain and again under -race
+# (four passes total: unit, integration, race-unit, race-integration).
 test-all: test test-race
+
+# Run the exact set of checks CI gates a pull request on, in the same order.
+# This is the real pre-push bar — `just test` alone is a subset of it.
+ci: fmt-check lint vet build test-all vuln
+    @echo "✓ All CI checks passed"
 
 # Check if files are formatted correctly
 fmt-check:


### PR DESCRIPTION
## Description

This PR makes the local bar and the CI bar the same thing. No CI workflow changes.

## Related Issues

N/A

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)

## Type of Change

- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)