### PR TITLE
fix(darwin): enable clang-tidy analysis and fix the findings

### DIFF
--- a/docs/go/OBJECTIVE_C.md
+++ b/docs/go/OBJECTIVE_C.md
@@ -120,25 +120,74 @@ Objective-C methods, private `static` helpers, and symbols not exported through 
 
 ## Memory Management
 
-For C interface objects:
+All Objective-C in this repo compiles with **ARC** (`-fobjc-arc`, set in
+`internal/adapter/platform/darwin/cgo_flags.go`). Never write `retain`,
+`release`, or `autorelease` — under ARC they are compile errors. What you do
+manage by hand is the two boundaries ARC cannot see across: the CGO boundary
+(Go holds a `void *`) and Core Foundation objects (`AX*`, `CG*`, `CF*`).
 
-- Use `retain`/`release`
-- Always balance `retain` with `release`
-- Use `autorelease` for return values
+### Handing an ObjC object to Go and back
+
+Go keeps native objects alive via an opaque `void *`. ARC doesn't know Go is
+holding a reference, so transfer ownership explicitly at the boundary:
 
 ```objc
+// Create: transfer ownership OUT of ARC — the Go side now owns +1.
 OverlayWindow NeruCreateOverlayWindow(void) {
     OverlayWindowController *controller = [[OverlayWindowController alloc] init];
-    [controller retain];
-    return (void *)controller;
+    return (__bridge_retained void *)controller;  // ARC will not release this
 }
 
+// Destroy: transfer ownership back INTO ARC, which releases it.
 void NeruDestroyOverlayWindow(OverlayWindow window) {
-    OverlayWindowController *controller = (OverlayWindowController *)window;
+    OverlayWindowController *controller = CFBridgingRelease(window);
     [controller.window close];
-    [controller release];
+    // controller released by ARC at end of scope
+}
+
+// Borrow: use the object without touching its refcount.
+void NeruShowOverlayWindow(OverlayWindow window) {
+    OverlayWindowController *controller = (__bridge OverlayWindowController *)window;
+    [controller showWindow:nil];
 }
 ```
+
+Real examples: `overlay_darwin.m` (`NeruCreateOverlayWindow` /
+`NeruDestroyOverlayWindow`, and the resize path that `CFRelease`s the old
+controller before storing a `__bridge_retained` replacement).
+
+### Core Foundation objects (AX*, CG*, CF*)
+
+CF types are **not managed by ARC**. Follow the Create/Copy rule: anything
+returned by a function named `Create` or `Copy` (including
+`AXUIElementCopyAttributeValue`) is +1 and you must `CFRelease` it exactly
+once.
+
+**The ownership rule at the CGO boundary:** every `AXUIElementRef` (or other CF
+ref) returned to Go through a `Neru*` function is **+1 retained, and the Go
+caller owns it**. On the Go side that means calling `Element.Release()` (or
+`ReleaseAll`) when done — including on every element a tree traversal enqueues
+but abandons. Leaked AX elements have been a recurring bug class here; when you
+write a traversal, account for every ref you were handed.
+
+### Mach ports
+
+`CFMachPortRef` wraps a kernel resource, and `CFRelease` alone leaks the port.
+Invalidate first:
+
+```objc
+CFMachPortInvalidate(tap->eventTap);  // releases the kernel port
+CFRelease(tap->eventTap);             // releases the CF wrapper
+```
+
+See `eventtap_darwin.m` for both call sites and the rationale.
+
+### Autorelease pools
+
+Long-running or Go-called code paths that allocate ObjC objects should wrap
+their work in `@autoreleasepool { ... }` — there is no ambient pool on threads
+Go creates. Drawing paths and traversal loops in `overlay_darwin.m` and the
+`accessibility_*` files show the pattern.
 
 ## Comments
 

--- a/internal/adapter/accessibility/native/darwin/element.go
+++ b/internal/adapter/accessibility/native/darwin/element.go
@@ -3,7 +3,7 @@
 package darwin
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../../../platform/darwin/accessibility.h"
 #include <stdlib.h>
 */
@@ -26,6 +26,13 @@ import (
 )
 
 // Element is a UI element in the macOS accessibility hierarchy.
+//
+// Element owns a +1 retained AXUIElementRef: every Element produced by this
+// package (lookups, Children, traversals) must be balanced with exactly one
+// Release (or ReleaseAll) call, including elements a traversal enqueues but
+// never uses. ARC does not manage AX refs, so a dropped Element is a leak of
+// a kernel-backed object. The rule is stated once at the top of
+// internal/adapter/platform/darwin/accessibility.h.
 type Element struct {
 	ref unsafe.Pointer
 }

--- a/internal/adapter/accessibility/native/darwin/tree.go
+++ b/internal/adapter/accessibility/native/darwin/tree.go
@@ -3,7 +3,7 @@
 package darwin
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../../../platform/darwin/accessibility.h"
 #include <stdlib.h>
 

--- a/internal/adapter/eventtap/darwin/tap.go
+++ b/internal/adapter/eventtap/darwin/tap.go
@@ -3,7 +3,7 @@
 package darwin
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../../platform/darwin/eventtap.h"
 #include <stdlib.h>
 

--- a/internal/adapter/keyfeed/keyfeed_darwin.go
+++ b/internal/adapter/keyfeed/keyfeed_darwin.go
@@ -3,7 +3,7 @@
 package keyfeed
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../platform/darwin/keyfeed.h"
 #include <stdlib.h>
 */

--- a/internal/adapter/overlay/render/grid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/grid/overlay_darwin.go
@@ -3,7 +3,7 @@
 package grid
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../../../platform/darwin/overlay.h"
 #include <stdlib.h>
 

--- a/internal/adapter/overlay/render/hints/overlay_darwin.go
+++ b/internal/adapter/overlay/render/hints/overlay_darwin.go
@@ -3,7 +3,7 @@
 package hints
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../../../platform/darwin/overlay.h"
 #include <stdlib.h>
 

--- a/internal/adapter/overlay/render/modeindicator/overlay_darwin.go
+++ b/internal/adapter/overlay/render/modeindicator/overlay_darwin.go
@@ -3,7 +3,7 @@
 package modeindicator
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../../../platform/darwin/overlay.h"
 #include <stdlib.h>
 */

--- a/internal/adapter/overlay/render/overlayutil/factory_darwin.go
+++ b/internal/adapter/overlay/render/overlayutil/factory_darwin.go
@@ -3,7 +3,7 @@
 package overlayutil
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../../../platform/darwin/overlay.h"
 */
 import "C"

--- a/internal/adapter/overlay/render/recursivegrid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/recursivegrid/overlay_darwin.go
@@ -3,7 +3,7 @@
 package recursivegrid
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../../../platform/darwin/overlay.h"
 #include <stdlib.h>
 

--- a/internal/adapter/overlay/render/stickyindicator/overlay_darwin.go
+++ b/internal/adapter/overlay/render/stickyindicator/overlay_darwin.go
@@ -3,7 +3,7 @@
 package stickyindicator
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../../../platform/darwin/overlay.h"
 #include <stdlib.h>
 */

--- a/internal/adapter/overlay/render/virtualpointer/overlay_darwin.go
+++ b/internal/adapter/overlay/render/virtualpointer/overlay_darwin.go
@@ -3,7 +3,7 @@
 package virtualpointer
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../../../platform/darwin/overlay.h"
 #include <stdlib.h>
 */

--- a/internal/adapter/platform/darwin/accessibility.h
+++ b/internal/adapter/platform/darwin/accessibility.h
@@ -11,6 +11,20 @@
 #import <ApplicationServices/ApplicationServices.h>
 #import <Foundation/Foundation.h>
 
+// OWNERSHIP RULE — read before adding or calling element functions.
+//
+// Every AXUIElementRef handed to Go through this header (returned as void *,
+// written into an out-array, or produced by a traversal) is +1 retained and
+// the Go caller owns it: the caller must eventually balance it with
+// NeruReleaseElement (Element.Release()/ReleaseAll on the Go side), exactly
+// once. Functions that only *borrow* a ref the caller passed in must not
+// change its refcount. Per-function @note comments below call out the cases
+// that also return malloc'd memory the caller must free().
+//
+// ARC does not manage AX*/CF* refs, so a traversal that enqueues elements and
+// abandons them leaks kernel-backed objects — account for every ref you were
+// handed (see docs/go/OBJECTIVE_C.md, "Memory Management").
+
 #pragma mark - Element Information
 
 /// Structure containing information about an accessibility element

--- a/internal/adapter/platform/darwin/accessibility_element_darwin.m
+++ b/internal/adapter/platform/darwin/accessibility_element_darwin.m
@@ -83,6 +83,9 @@ void *NeruGetApplicationByBundleId(const char *bundle_id) {
 
 	@autoreleasepool {
 		NSString *bundleIdStr = [NSString stringWithUTF8String:bundle_id];
+		if (!bundleIdStr) {
+			return NULL;
+		}
 		NSArray<NSRunningApplication *> *apps =
 		    [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleIdStr];
 
@@ -117,6 +120,9 @@ char *NeruDetectBundleType(const char *bundle_id) {
 
 	@autoreleasepool {
 		NSString *bundleIdStr = [NSString stringWithUTF8String:bundle_id];
+		if (!bundleIdStr) {
+			return NULL;
+		}
 
 		// Find the app bundle on disk: try LaunchServices (installed apps) first,
 		// then NSRunningApplication (running apps that may not be in LS database,

--- a/internal/adapter/platform/darwin/alert_darwin.m
+++ b/internal/adapter/platform/darwin/alert_darwin.m
@@ -80,7 +80,9 @@ static int showAlertOnMainThread(const char *errorMessage, const char *configPat
 	} else if (response == NSAlertSecondButtonReturn) {
 		NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
 		[pasteboard clearContents];
-		[pasteboard setString:path forType:NSPasteboardTypeString];
+		if (path) {
+			[pasteboard setString:path forType:NSPasteboardTypeString];
+		}
 		return 2;
 	}
 

--- a/internal/adapter/platform/darwin/eventtap_darwin.m
+++ b/internal/adapter/platform/darwin/eventtap_darwin.m
@@ -928,7 +928,10 @@ void NeruSetEventTapHotkeys(EventTap tap, const char **hotkeys, int count) {
 		NSMutableArray<NSString *> *newStrings = [NSMutableArray arrayWithCapacity:count];
 		for (int i = 0; i < count; i++) {
 			if (hotkeys[i] && strlen(hotkeys[i]) > 0) {
-				[newStrings addObject:[NSString stringWithUTF8String:hotkeys[i]]];
+				NSString *hotkeyStr = [NSString stringWithUTF8String:hotkeys[i]];
+				if (hotkeyStr) {
+					[newStrings addObject:hotkeyStr];
+				}
 			}
 		}
 		NSDictionary *newLookup = buildKeyLookupFromStrings(newStrings);
@@ -969,7 +972,10 @@ void NeruSetEventTapModifierPassthrough(EventTap tap, int enabled, const char **
 		NSMutableArray<NSString *> *newStrings = [NSMutableArray arrayWithCapacity:count];
 		for (int i = 0; i < count; i++) {
 			if (blacklistKeys[i] && strlen(blacklistKeys[i]) > 0) {
-				[newStrings addObject:[NSString stringWithUTF8String:blacklistKeys[i]]];
+				NSString *blacklistStr = [NSString stringWithUTF8String:blacklistKeys[i]];
+				if (blacklistStr) {
+					[newStrings addObject:blacklistStr];
+				}
 			}
 		}
 		NSDictionary *newLookup = buildKeyLookupFromStrings(newStrings);
@@ -1007,7 +1013,10 @@ void NeruSetEventTapInterceptedModifierKeys(EventTap tap, const char **keys, int
 		NSMutableArray<NSString *> *newStrings = [NSMutableArray arrayWithCapacity:count];
 		for (int i = 0; i < count; i++) {
 			if (keys[i] && strlen(keys[i]) > 0) {
-				[newStrings addObject:[NSString stringWithUTF8String:keys[i]]];
+				NSString *keyStr = [NSString stringWithUTF8String:keys[i]];
+				if (keyStr) {
+					[newStrings addObject:keyStr];
+				}
 			}
 		}
 		NSDictionary *newLookup = buildKeyLookupFromStrings(newStrings);

--- a/internal/adapter/platform/darwin/overlay_darwin.m
+++ b/internal/adapter/platform/darwin/overlay_darwin.m
@@ -3024,7 +3024,9 @@ void NeruUpdateGridMatchPrefix(OverlayWindow window, const char *prefix) {
 
 			// First pass: update all cells and track which ones changed.
 			// Use a stack-allocated array for small counts, heap for large.
+			// Zero the stack path so both paths start provably initialized.
 			BOOL stackFlags[256];
+			memset(stackFlags, 0, sizeof(stackFlags));
 			BOOL *changedFlags = cellCount <= 256 ? stackFlags : (BOOL *)calloc(cellCount, sizeof(BOOL));
 			NSUInteger changedCount = 0;
 			NSUInteger idx = 0;

--- a/internal/adapter/systray/darwin/systray_darwin.m
+++ b/internal/adapter/systray/darwin/systray_darwin.m
@@ -105,7 +105,9 @@ void NeruQuit(void) {
 		                                     subtype:0
 		                                       data1:0
 		                                       data2:0];
-		[NSApp postEvent:event atStart:YES];
+		if (event) {
+			[NSApp postEvent:event atStart:YES];
+		}
 	});
 }
 
@@ -132,7 +134,7 @@ void NeruSetIcon(const char *iconBytes, int length, bool isTemplate) {
 }
 
 void NeruSetTitle(const char *title) {
-	NSString *str = [NSString stringWithUTF8String:title];
+	NSString *str = [NSString stringWithUTF8String:title] ?: @"";
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		if (appDelegate && appDelegate.statusItem) {
@@ -142,7 +144,7 @@ void NeruSetTitle(const char *title) {
 }
 
 void NeruSetTooltip(const char *tooltip) {
-	NSString *str = [NSString stringWithUTF8String:tooltip];
+	NSString *str = [NSString stringWithUTF8String:tooltip] ?: @"";
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		if (appDelegate && appDelegate.statusItem) {
@@ -194,7 +196,7 @@ void runOnMainThread(void (^block)(void)) {
 #pragma mark - Menu Item Functions
 
 void NeruAddMenuItem(int menuId, const char *title, short disabled, short checked) {
-	NSString *titleStr = [NSString stringWithUTF8String:title];
+	NSString *titleStr = [NSString stringWithUTF8String:title] ?: @"";
 
 	runOnMainThread(^{
 		NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:titleStr action:@selector(itemClicked:) keyEquivalent:@""];
@@ -208,7 +210,7 @@ void NeruAddMenuItem(int menuId, const char *title, short disabled, short checke
 }
 
 void NeruAddSubMenuItem(int parentId, int menuId, const char *title, short disabled, short checked) {
-	NSString *titleStr = [NSString stringWithUTF8String:title];
+	NSString *titleStr = [NSString stringWithUTF8String:title] ?: @"";
 
 	runOnMainThread(^{
 		NSMenuItem *parent = findItemByTag(parentId);
@@ -285,7 +287,7 @@ void NeruSetItemDisabled(int menuId, short disabled) {
 }
 
 void NeruSetItemTitle(int menuId, const char *title) {
-	NSString *str = [NSString stringWithUTF8String:title];
+	NSString *str = [NSString stringWithUTF8String:title] ?: @"";
 
 	runOnMainThread(^{
 		NSMenuItem *item = findItemByTag(menuId);

--- a/internal/adapter/textinput/textinput_darwin.go
+++ b/internal/adapter/textinput/textinput_darwin.go
@@ -3,7 +3,7 @@
 package textinput
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #include "../platform/darwin/textinput.h"
 #include <stdlib.h>
 

--- a/internal/adapter/vision/adapter_darwin.go
+++ b/internal/adapter/vision/adapter_darwin.go
@@ -3,7 +3,7 @@
 package vision
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #cgo LDFLAGS: -framework Vision -framework CoreGraphics -framework Foundation
 #include "../platform/darwin/vision.h"
 #include <stdlib.h>

--- a/justfile
+++ b/justfile
@@ -302,13 +302,51 @@ fmt:
     @find internal/adapter \( -name "*.h" -o -name "*.m" -o -name "*.c" \) -exec sh -c 'case "$1" in *.c) af=file.c;; *) af=file.m;; esac; clang-format -i --style=file --assume-filename="$af" "$1"' _ {} \;
     @echo "✓ Format complete"
 
-# Lint code
-lint:
-    @echo "Linting code..."
+# Lint code (Go via golangci-lint, Objective-C via clang-tidy)
+lint: lint-go lint-objc
+
+# Lint Go code
+lint-go:
+    @echo "Linting Go code..."
     golangci-lint run
-    @echo "Linting Objective-C files..."
-    echo "Skipping Objective-C linting due to header issues"
-    @echo "✓ Lint complete"
+    @echo "✓ Go lint complete"
+
+# Lint Objective-C with the clang static analyzer (via clang-tidy, which
+# devbox's clang-tools provides). macOS only — the .m files need the macOS SDK.
+#
+# Excluded checks, each for a reason:
+#  - optin.osx.cocoa.localizability: Neru is not localized; user-facing
+#    strings are intentionally plain literals.
+#  - deadcode.DeadStores: the eventtap bridge deliberately copies old table
+#    refs to locals and nils them after unlocking so ARC releases the old
+#    tables outside the lock — the analyzer sees those stores as dead.
+#  - optin.performance.GCDAntipattern: permission prompts are called from Go
+#    through a synchronous bridge, so blocking on a semaphore is the contract.
+lint-objc:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "$(uname -s)" != "Darwin" ]; then
+        echo "Skipping Objective-C lint: requires the macOS SDK"
+        exit 0
+    fi
+    if ! command -v clang-tidy >/dev/null 2>&1; then
+        echo "clang-tidy not found — run inside 'devbox shell' (clang-tools provides it)" >&2
+        exit 1
+    fi
+    echo "Linting Objective-C files (clang-tidy)..."
+    SDK=$(xcrun --show-sdk-path)
+    CHECKS='-*,clang-analyzer-*,-clang-analyzer-optin.osx.cocoa.localizability*,-clang-analyzer-deadcode.DeadStores,-clang-analyzer-optin.performance.GCDAntipattern'
+    export SDK CHECKS
+    find internal -name '*.m' -print0 | xargs -0 -P 4 -n 1 bash -c '
+        out=$(clang-tidy --quiet --checks="$CHECKS" "$1" -- \
+            -x objective-c -fobjc-arc -fmodules -mmacosx-version-min=14.0 \
+            -isysroot "$SDK" 2>/dev/null)
+        if echo "$out" | grep -q "warning:"; then
+            echo "$out"
+            exit 1
+        fi
+    ' _
+    echo "✓ Objective-C lint complete"
 
 # Vet
 vet:


### PR DESCRIPTION
## Description

This PR adds `clang-tidy` along the linting flow.

## Related Issues

N/A
## Target Platform

- [x] macOS

## Type of Change

- [x] `fix` — Bug fix

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)