### PR TITLE
chore(darwin): remove systray tombstone files

### DIFF
--- a/internal/adapter/platform/darwin/systray_darwin.m
+++ b/internal/adapter/platform/darwin/systray_darwin.m
@@ -1,9 +1,0 @@
-// systray.m — this file is intentionally empty.
-//
-// The systray Objective-C implementation lives in internal/adapter/systray/systray.m
-// because CGo only compiles .c/.m files co-located with the Go package that
-// contains `import "C"`. Only the header (systray.h) is kept here to
-// consolidate all macOS headers in platform/darwin/.
-//
-// Do NOT add implementation here — it would cause duplicate symbol errors
-// with the copy in the systray package.

--- a/internal/adapter/systray/darwin/systray.h
+++ b/internal/adapter/systray/darwin/systray.h
@@ -1,3 +1,0 @@
-// This file has been moved to internal/adapter/platform/darwin/systray.h
-// This stub remains only to avoid breaking any stale includes.
-#include "../../platform/darwin/systray.h"

--- a/internal/adapter/systray/darwin/systray_darwin.m
+++ b/internal/adapter/systray/darwin/systray_darwin.m
@@ -4,8 +4,11 @@
 //
 //  Copyright © 2025 Neru. All rights reserved.
 //
+//  This implementation lives here (not in platform/darwin/) because CGo only
+//  compiles .m files co-located with the Go package that contains `import "C"`.
+//  The header stays in platform/darwin/ with the other macOS headers.
 
-#import "systray.h"
+#import "../../platform/darwin/systray.h"
 
 #import <Cocoa/Cocoa.h>
 


### PR DESCRIPTION
## Description

This PR removes two dead files in the one place the layout deliberately breaks its own header-location rule for systray.

## Related Issues

N/A

## Target Platform

- [x] macOS

## Type of Change

- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] N/A — no behavior change

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Build succeeds (`just build`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)