### PR TITLE
refactor(overlay): extract shared state base for overlay backends

### DIFF
--- a/internal/adapter/overlay/darwin/manager.go
+++ b/internal/adapter/overlay/darwin/manager.go
@@ -19,9 +19,7 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
-	"github.com/y3owk1n/neru/internal/adapter/overlay/render/modeindicator"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
-	"github.com/y3owk1n/neru/internal/adapter/overlay/render/stickyindicator"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/virtualpointer"
 	"github.com/y3owk1n/neru/internal/derrors"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
@@ -29,9 +27,6 @@ import (
 )
 
 const (
-	// DefaultSubscriberMapSize is the default size for subscriber map.
-	DefaultSubscriberMapSize = 4
-
 	// NSWindowSharingNone represents NSWindowSharingNone (0) - hidden from screen sharing.
 	NSWindowSharingNone = 0
 	// NSWindowSharingReadOnly represents NSWindowSharingReadOnly (1) - visible in screen sharing.
@@ -48,21 +43,16 @@ func boolToInt(v bool) int {
 
 // Manager manages multiple overlay windows.
 type Manager struct {
-	window            C.OverlayWindow
-	logger            *zap.Logger
-	mu                sync.RWMutex
-	mode              manager.Mode
-	subs              map[uint64]func(manager.StateChange)
-	nextID            uint64
-	hideInScreenShare bool
+	manager.Base
 
-	// Overlay renderers
-	hintOverlay            *hints.Overlay
-	gridOverlay            *grid.Overlay
-	modeIndicatorOverlay   *modeindicator.Overlay
-	recursiveGridOverlay   *recursivegrid.Overlay
-	stickyModifiersOverlay *stickyindicator.Overlay
-	virtualPointerOverlay  *virtualpointer.Overlay
+	window C.OverlayWindow
+	logger *zap.Logger
+
+	// shareMu guards hideInScreenShare. It is deliberately separate from the
+	// Base mode/subscriber mutex so SetSharingType can never contend with
+	// SwitchTo/Subscribe callers.
+	shareMu           sync.RWMutex
+	hideInScreenShare bool
 }
 
 var (
@@ -75,13 +65,9 @@ func Init(logger *zap.Logger) *Manager {
 	once.Do(func() {
 		window := C.NeruCreateOverlayWindow()
 		instance = &Manager{
+			Base:   manager.NewBase(logger),
 			window: window,
 			logger: logger,
-			mode:   manager.ModeIdle,
-			subs: make(
-				map[uint64]func(manager.StateChange),
-				DefaultSubscriberMapSize,
-			),
 		}
 	})
 
@@ -101,14 +87,6 @@ func (m *Manager) WindowPtr() unsafe.Pointer {
 // WaylandKeyboardChannel returns nil for macOS (not applicable).
 func (m *Manager) WaylandKeyboardChannel() <-chan string {
 	return nil
-}
-
-// Mode returns the current overlay mode.
-func (m *Manager) Mode() manager.Mode {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	return m.mode
 }
 
 // Logger returns the logger.
@@ -133,39 +111,39 @@ func (m *Manager) Show() {
 func (m *Manager) Hide() {
 	C.NeruHideOverlayWindow(m.window)
 
-	if m.modeIndicatorOverlay != nil {
-		m.modeIndicatorOverlay.Hide()
+	if m.ModeIndicatorOverlay() != nil {
+		m.ModeIndicatorOverlay().Hide()
 	}
 
-	if m.stickyModifiersOverlay != nil {
-		m.stickyModifiersOverlay.Hide()
+	if m.StickyModifiersOverlay() != nil {
+		m.StickyModifiersOverlay().Hide()
 	}
 
-	if m.recursiveGridOverlay != nil {
-		m.recursiveGridOverlay.Hide()
+	if m.RecursiveGridOverlay() != nil {
+		m.RecursiveGridOverlay().Hide()
 	}
 }
 
 // Clear clears the overlay window.
 func (m *Manager) Clear() {
 	C.NeruClearOverlay(m.window)
-	if m.gridOverlay != nil {
-		m.gridOverlay.Clear()
+	if m.GridOverlay() != nil {
+		m.GridOverlay().Clear()
 	}
-	if m.hintOverlay != nil {
-		m.hintOverlay.Clear()
-	}
-
-	if m.modeIndicatorOverlay != nil {
-		m.modeIndicatorOverlay.Clear()
+	if m.HintOverlay() != nil {
+		m.HintOverlay().Clear()
 	}
 
-	if m.stickyModifiersOverlay != nil {
-		m.stickyModifiersOverlay.Clear()
+	if m.ModeIndicatorOverlay() != nil {
+		m.ModeIndicatorOverlay().Clear()
 	}
 
-	if m.recursiveGridOverlay != nil {
-		m.recursiveGridOverlay.Clear()
+	if m.StickyModifiersOverlay() != nil {
+		m.StickyModifiersOverlay().Clear()
+	}
+
+	if m.RecursiveGridOverlay() != nil {
+		m.RecursiveGridOverlay().Clear()
 	}
 }
 
@@ -177,12 +155,12 @@ func (m *Manager) ClearCache() {}
 func (m *Manager) ResizeToActiveScreen() {
 	C.NeruResizeOverlayToActiveScreen(m.window)
 
-	if m.modeIndicatorOverlay != nil {
-		m.modeIndicatorOverlay.ResizeToActiveScreen()
+	if m.ModeIndicatorOverlay() != nil {
+		m.ModeIndicatorOverlay().ResizeToActiveScreen()
 	}
 
-	if m.stickyModifiersOverlay != nil {
-		m.stickyModifiersOverlay.ResizeToActiveScreen()
+	if m.StickyModifiersOverlay() != nil {
+		m.StickyModifiersOverlay().ResizeToActiveScreen()
 	}
 }
 
@@ -194,74 +172,35 @@ func (m *Manager) SetKeyboardCaptureEnabled(_ bool) {}
 // window-local coordinates and needs no global translation.
 func (m *Manager) SetActiveScreenOrigin(_ image.Point) {}
 
-// SwitchTo transitions the overlay to the specified mode and notifies subscribers.
-func (m *Manager) SwitchTo(next manager.Mode) {
-	m.mu.Lock()
-	prev := m.mode
-	if prev == next {
-		m.mu.Unlock()
-
-		return
-	}
-	m.mode = next
-	m.mu.Unlock()
-	if m.logger != nil {
-		m.logger.Debug(
-			"Overlay mode switch",
-			zap.String("prev", string(prev)),
-			zap.String("next", string(next)),
-		)
-	}
-	m.publish(manager.NewStateChange(prev, next))
-}
-
-// Subscribe registers a callback function to be notified of overlay mode changes.
-func (m *Manager) Subscribe(fn func(manager.StateChange)) uint64 {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.nextID++
-	id := m.nextID
-	m.subs[id] = fn
-
-	return id
-}
-
-// Unsubscribe removes a previously registered callback function.
-func (m *Manager) Unsubscribe(id uint64) {
-	m.mu.Lock()
-	delete(m.subs, id)
-	m.mu.Unlock()
-}
-
 // Destroy destroys the overlay window and cleans up all overlay resources.
 func (m *Manager) Destroy() {
 	// Clean up Go-side resources (callbackManager, styleCache, labelCache) for
 	// overlays that share the manager's window. We call Cleanup() instead of
 	// Destroy() because the shared window is destroyed below — calling each
 	// overlay's Destroy() would double-destroy the same native window.
-	if m.hintOverlay != nil {
-		m.hintOverlay.Cleanup()
-		m.hintOverlay = nil
+	if m.HintOverlay() != nil {
+		m.HintOverlay().Cleanup()
+		m.UseHintOverlay(nil)
 	}
-	if m.gridOverlay != nil {
-		m.gridOverlay.Cleanup()
-		m.gridOverlay = nil
+	if m.GridOverlay() != nil {
+		m.GridOverlay().Cleanup()
+		m.UseGridOverlay(nil)
 	}
-	if m.recursiveGridOverlay != nil {
-		m.recursiveGridOverlay.Cleanup()
-		m.recursiveGridOverlay = nil
+	if m.RecursiveGridOverlay() != nil {
+		m.RecursiveGridOverlay().Cleanup()
+		m.UseRecursiveGridOverlay(nil)
 	}
 
-	// manager.Mode indicator owns its own window, so use full Destroy().
-	if m.modeIndicatorOverlay != nil {
-		m.modeIndicatorOverlay.Destroy()
-		m.modeIndicatorOverlay = nil
+	// Mode indicator owns its own window, so use full Destroy().
+	if m.ModeIndicatorOverlay() != nil {
+		m.ModeIndicatorOverlay().Destroy()
+		m.UseModeIndicatorOverlay(nil)
 	}
 
 	// Sticky modifiers indicator owns its own window, so use full Destroy().
-	if m.stickyModifiersOverlay != nil {
-		m.stickyModifiersOverlay.Destroy()
-		m.stickyModifiersOverlay = nil
+	if m.StickyModifiersOverlay() != nil {
+		m.StickyModifiersOverlay().Destroy()
+		m.UseStickyModifiersOverlay(nil)
 	}
 
 	if m.window != nil {
@@ -270,76 +209,27 @@ func (m *Manager) Destroy() {
 	}
 }
 
-// UseHintOverlay sets the hint overlay renderer for centralized management.
-func (m *Manager) UseHintOverlay(o *hints.Overlay) {
-	m.hintOverlay = o
-}
+// UseVirtualPointerOverlay sets the cursor-following virtual pointer overlay
+// renderer, propagating the current screen-share visibility to it. Overrides
+// the Base method; the other renderers are registered through Base directly.
+func (m *Manager) UseVirtualPointerOverlay(overlay *virtualpointer.Overlay) {
+	m.Base.UseVirtualPointerOverlay(overlay)
 
-// UseGridOverlay sets the grid overlay renderer.
-func (m *Manager) UseGridOverlay(o *grid.Overlay) {
-	m.gridOverlay = o
-}
+	m.shareMu.RLock()
+	hideInScreenShare := m.hideInScreenShare
+	m.shareMu.RUnlock()
 
-// UseModeIndicatorOverlay sets the shared mode-indicator overlay renderer.
-func (m *Manager) UseModeIndicatorOverlay(o *modeindicator.Overlay) {
-	m.modeIndicatorOverlay = o
-}
-
-// UseStickyModifiersOverlay sets the sticky modifiers overlay renderer.
-func (m *Manager) UseStickyModifiersOverlay(o *stickyindicator.Overlay) {
-	m.stickyModifiersOverlay = o
-}
-
-// UseRecursiveGridOverlay sets the recursive-grid overlay renderer.
-func (m *Manager) UseRecursiveGridOverlay(o *recursivegrid.Overlay) {
-	m.recursiveGridOverlay = o
-}
-
-// UseVirtualPointerOverlay sets the cursor-following virtual pointer overlay renderer.
-func (m *Manager) UseVirtualPointerOverlay(o *virtualpointer.Overlay) {
-	m.virtualPointerOverlay = o
-
-	if o != nil && m.hideInScreenShare {
-		o.SetSharingType(true)
+	if overlay != nil && hideInScreenShare {
+		overlay.SetSharingType(true)
 	}
-}
-
-// HintOverlay returns the hint overlay renderer.
-func (m *Manager) HintOverlay() *hints.Overlay {
-	return m.hintOverlay
-}
-
-// GridOverlay returns the grid overlay renderer.
-func (m *Manager) GridOverlay() *grid.Overlay {
-	return m.gridOverlay
-}
-
-// ModeIndicatorOverlay returns the mode-indicator overlay renderer.
-func (m *Manager) ModeIndicatorOverlay() *modeindicator.Overlay {
-	return m.modeIndicatorOverlay
-}
-
-// StickyModifiersOverlay returns the sticky modifiers overlay renderer.
-func (m *Manager) StickyModifiersOverlay() *stickyindicator.Overlay {
-	return m.stickyModifiersOverlay
-}
-
-// RecursiveGridOverlay returns the recursive-grid overlay renderer.
-func (m *Manager) RecursiveGridOverlay() *recursivegrid.Overlay {
-	return m.recursiveGridOverlay
-}
-
-// VirtualPointerOverlay returns the cursor-following virtual pointer overlay renderer.
-func (m *Manager) VirtualPointerOverlay() *virtualpointer.Overlay {
-	return m.virtualPointerOverlay
 }
 
 // DrawHintsWithStyle draws hints with the specified style using the hint overlay renderer.
 func (m *Manager) DrawHintsWithStyle(hs []*hints.Hint, style hints.StyleMode) error {
-	if m.hintOverlay == nil {
+	if m.HintOverlay() == nil {
 		return nil
 	}
-	drawHintsErr := m.hintOverlay.DrawHintsWithStyle(hs, style)
+	drawHintsErr := m.HintOverlay().DrawHintsWithStyle(hs, style)
 	if drawHintsErr != nil {
 		return derrors.Wrap(
 			drawHintsErr,
@@ -358,11 +248,11 @@ func (m *Manager) DrawHintSearchInput(
 	frame hints.SearchInputFrame,
 	style hints.SearchInputStyle,
 ) error {
-	if m.hintOverlay == nil {
+	if m.HintOverlay() == nil {
 		return nil
 	}
 
-	err := m.hintOverlay.DrawSearchInput(query, resultCount, frame, style)
+	err := m.HintOverlay().DrawSearchInput(query, resultCount, frame, style)
 	if err != nil {
 		return derrors.Wrap(err, derrors.CodeOverlayFailed, "failed to draw hint search input")
 	}
@@ -372,16 +262,16 @@ func (m *Manager) DrawHintSearchInput(
 
 // HideHintSearchInput hides the hints search input.
 func (m *Manager) HideHintSearchInput() {
-	if m.hintOverlay == nil {
+	if m.HintOverlay() == nil {
 		return
 	}
 
-	m.hintOverlay.HideSearchInput()
+	m.HintOverlay().HideSearchInput()
 }
 
 // DrawModeIndicator renders a mode indicator using the shared overlay renderer.
 func (m *Manager) DrawModeIndicator(xCoordinate, yCoordinate int) {
-	if m.modeIndicatorOverlay == nil {
+	if m.ModeIndicatorOverlay() == nil {
 		return
 	}
 
@@ -390,12 +280,12 @@ func (m *Manager) DrawModeIndicator(xCoordinate, yCoordinate int) {
 		return
 	}
 
-	m.modeIndicatorOverlay.DrawModeIndicator(string(mode), xCoordinate, yCoordinate)
+	m.ModeIndicatorOverlay().DrawModeIndicator(string(mode), xCoordinate, yCoordinate)
 }
 
 // DrawStickyModifiersIndicator renders the sticky modifiers indicator using the sticky modifiers overlay renderer.
 func (m *Manager) DrawStickyModifiersIndicator(xCoordinate, yCoordinate int, symbols string) {
-	if m.stickyModifiersOverlay == nil {
+	if m.StickyModifiersOverlay() == nil {
 		return
 	}
 
@@ -404,16 +294,16 @@ func (m *Manager) DrawStickyModifiersIndicator(xCoordinate, yCoordinate int, sym
 		return
 	}
 
-	m.stickyModifiersOverlay.Draw(xCoordinate, yCoordinate, symbols)
+	m.StickyModifiersOverlay().Draw(xCoordinate, yCoordinate, symbols)
 }
 
 // DrawVirtualPointer renders the cursor-following virtual pointer overlay.
 func (m *Manager) DrawVirtualPointer(xCoordinate, yCoordinate, size int, fillColor string) {
-	if m.virtualPointerOverlay == nil {
+	if m.VirtualPointerOverlay() == nil {
 		return
 	}
 
-	m.virtualPointerOverlay.Draw(xCoordinate, yCoordinate, size, fillColor)
+	m.VirtualPointerOverlay().Draw(xCoordinate, yCoordinate, size, fillColor)
 }
 
 // DrawMouseActionIndicator renders a transient mouse action indicator in its own native window.
@@ -421,9 +311,9 @@ func (m *Manager) DrawMouseActionIndicator(
 	point image.Point,
 	style ports.MouseActionIndicatorStyle,
 ) {
-	m.mu.RLock()
+	m.shareMu.RLock()
 	hideInScreenShare := m.hideInScreenShare
-	m.mu.RUnlock()
+	m.shareMu.RUnlock()
 
 	backgroundColor := C.CString(style.BackgroundColor)
 	borderColor := C.CString(style.BorderColor)
@@ -456,10 +346,10 @@ func (m *Manager) DrawMouseActionIndicator(
 
 // DrawGrid renders a grid with the specified style using the grid overlay renderer.
 func (m *Manager) DrawGrid(g *domainGrid.Grid, input string, style grid.Style) error {
-	if m.gridOverlay == nil {
+	if m.GridOverlay() == nil {
 		return nil
 	}
-	drawGridErr := m.gridOverlay.DrawGrid(g, input, style)
+	drawGridErr := m.GridOverlay().DrawGrid(g, input, style)
 	if drawGridErr != nil {
 		return derrors.Wrap(drawGridErr, derrors.CodeOverlayFailed, "failed to draw grid")
 	}
@@ -480,10 +370,10 @@ func (m *Manager) DrawRecursiveGrid(
 	style recursivegrid.Style,
 	virtualPointer recursivegrid.VirtualPointerState,
 ) error {
-	if m.recursiveGridOverlay == nil {
+	if m.RecursiveGridOverlay() == nil {
 		return nil
 	}
-	drawRecursiveGridErr := m.recursiveGridOverlay.DrawRecursiveGrid(
+	drawRecursiveGridErr := m.RecursiveGridOverlay().DrawRecursiveGrid(
 		bounds,
 		depth,
 		keys,
@@ -508,26 +398,26 @@ func (m *Manager) DrawRecursiveGrid(
 
 // UpdateGridMatches updates the grid matches with the specified prefix.
 func (m *Manager) UpdateGridMatches(prefix string) {
-	if m.gridOverlay == nil {
+	if m.GridOverlay() == nil {
 		return
 	}
-	m.gridOverlay.UpdateMatches(prefix)
+	m.GridOverlay().UpdateMatches(prefix)
 }
 
 // ShowSubgrid shows a subgrid for the specified cell.
 func (m *Manager) ShowSubgrid(cell *domainGrid.Cell, style grid.Style) {
-	if m.gridOverlay == nil {
+	if m.GridOverlay() == nil {
 		return
 	}
-	m.gridOverlay.ShowSubgrid(cell, style)
+	m.GridOverlay().ShowSubgrid(cell, style)
 }
 
 // SetHideUnmatched sets whether to hide unmatched cells.
 func (m *Manager) SetHideUnmatched(hide bool) {
-	if m.gridOverlay == nil {
+	if m.GridOverlay() == nil {
 		return
 	}
-	m.gridOverlay.SetHideUnmatched(hide)
+	m.GridOverlay().SetHideUnmatched(hide)
 }
 
 // Flush is a no-op on macOS — indicator overlays use independent windows
@@ -538,13 +428,12 @@ func (m *Manager) Flush() {}
 // When hide is true, sets NSWindowSharingNone (hidden from screen share).
 // When hide is false, sets NSWindowSharingReadOnly (visible in screen share).
 //
-// Note: This method holds m.mu during the CGo call to C.NeruSetOverlaySharingType.
-// The C function uses dispatch_async (returns immediately), so this is safe.
-// If the C function were changed to dispatch_sync, this could deadlock with
-// main thread callers since SwitchTo/Subscribe/Unsubscribe also use m.mu.
+// shareMu is dedicated to this flag, so holding it across the CGo call cannot
+// contend with SwitchTo/Subscribe callers (and the C function dispatches
+// asynchronously anyway).
 func (m *Manager) SetSharingType(hide bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.shareMu.Lock()
+	defer m.shareMu.Unlock()
 
 	m.hideInScreenShare = hide
 
@@ -556,41 +445,26 @@ func (m *Manager) SetSharingType(hide bool) {
 	C.NeruSetOverlaySharingType(m.window, sharingType)
 
 	// Also update grid, recursive_grid, and mode indicator overlay windows if they exist
-	if m.gridOverlay != nil {
-		m.gridOverlay.SetSharingType(hide)
+	if m.GridOverlay() != nil {
+		m.GridOverlay().SetSharingType(hide)
 	}
-	if m.recursiveGridOverlay != nil {
-		m.recursiveGridOverlay.SetSharingType(hide)
+	if m.RecursiveGridOverlay() != nil {
+		m.RecursiveGridOverlay().SetSharingType(hide)
 	}
-	if m.modeIndicatorOverlay != nil {
-		m.modeIndicatorOverlay.SetSharingType(hide)
-	}
-
-	if m.stickyModifiersOverlay != nil {
-		m.stickyModifiersOverlay.SetSharingType(hide)
+	if m.ModeIndicatorOverlay() != nil {
+		m.ModeIndicatorOverlay().SetSharingType(hide)
 	}
 
-	if m.virtualPointerOverlay != nil {
-		m.virtualPointerOverlay.SetSharingType(hide)
+	if m.StickyModifiersOverlay() != nil {
+		m.StickyModifiersOverlay().SetSharingType(hide)
+	}
+
+	if m.VirtualPointerOverlay() != nil {
+		m.VirtualPointerOverlay().SetSharingType(hide)
 	}
 
 	if m.logger != nil {
 		m.logger.Info("Overlay screen share visibility toggled",
 			zap.Bool("hidden", hide))
-	}
-}
-
-// publish publishes a state change to all subscribers.
-func (m *Manager) publish(event manager.StateChange) {
-	m.mu.Lock()
-	subs := make([]func(manager.StateChange), len(m.subs))
-	index := 0
-	for _, sub := range m.subs {
-		subs[index] = sub
-		index++
-	}
-	m.mu.Unlock()
-	for _, sub := range subs {
-		sub(event)
 	}
 }

--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -18,7 +18,6 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/modeindicator"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/stickyindicator"
-	"github.com/y3owk1n/neru/internal/adapter/overlay/render/virtualpointer"
 	"github.com/y3owk1n/neru/internal/adapter/platform"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/derrors"
@@ -79,17 +78,13 @@ const (
 	linuxOverlayBackendUnknown        linuxOverlayBackend = "unknown"
 	linuxOverlayBackendX11            linuxOverlayBackend = "x11"
 	linuxOverlayBackendWaylandWlroots linuxOverlayBackend = "wayland-wlroots"
-	initialSubscriberCapacity                             = 4
 )
 
 // Manager manages overlay rendering on Linux.
 type Manager struct {
-	logger *zap.Logger
+	manager.Base
 
-	mu     sync.RWMutex
-	mode   manager.Mode
-	subs   map[uint64]func(manager.StateChange)
-	nextID uint64
+	logger *zap.Logger
 
 	// renderMu serializes all rendering dispatch to the backend overlays.
 	// On macOS the Objective-C bridge serializes via dispatch_async to the
@@ -115,13 +110,6 @@ type Manager struct {
 
 	keyboardCaptureEnabled bool
 
-	hintOverlay            *hints.Overlay
-	gridOverlay            *grid.Overlay
-	modeIndicatorOverlay   *modeindicator.Overlay
-	recursiveGridOverlay   *recursivegrid.Overlay
-	stickyModifiersOverlay *stickyindicator.Overlay
-	virtualPointerOverlay  *virtualpointer.Overlay
-
 	stickyBadgeRect    image.Rectangle
 	stickyBadgeVisible bool
 
@@ -138,12 +126,8 @@ var (
 // NewOverlayManager creates a new overlay Manager.
 func NewOverlayManager(logger *zap.Logger) *Manager {
 	instance := &Manager{
-		logger: logger,
-		mode:   manager.ModeIdle,
-		subs: make(
-			map[uint64]func(manager.StateChange),
-			initialSubscriberCapacity,
-		),
+		Base:                   manager.NewBase(logger),
+		logger:                 logger,
 		backend:                detectLinuxOverlayBackend(),
 		keyboardCaptureEnabled: true,
 	}
@@ -314,44 +298,6 @@ func (m *Manager) SetActiveScreenOrigin(origin image.Point) {
 	}
 }
 
-// SwitchTo switches to a new mode.
-func (m *Manager) SwitchTo(next manager.Mode) {
-	m.mu.Lock()
-
-	prev := m.mode
-	if prev == next {
-		m.mu.Unlock()
-
-		return
-	}
-
-	m.mode = next
-
-	m.mu.Unlock()
-
-	m.publish(manager.NewStateChange(prev, next))
-}
-
-// Subscribe registers a callback for mode changes.
-func (m *Manager) Subscribe(subFn func(manager.StateChange)) uint64 {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	m.nextID++
-	id := m.nextID
-	m.subs[id] = subFn
-
-	return id
-}
-
-// Unsubscribe removes a callback registration.
-func (m *Manager) Unsubscribe(id uint64) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	delete(m.subs, id)
-}
-
 // Destroy cleans up the overlay Manager.
 func (m *Manager) Destroy() {
 	// Capture and nil-out backend pointers under the lock, then release
@@ -393,14 +339,6 @@ func (m *Manager) Destroy() {
 	}
 }
 
-// Mode returns the current mode.
-func (m *Manager) Mode() manager.Mode {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	return m.mode
-}
-
 // WindowPtr returns the raw window pointer.
 func (m *Manager) WindowPtr() unsafe.Pointer {
 	if m.x11 != nil {
@@ -411,54 +349,6 @@ func (m *Manager) WindowPtr() unsafe.Pointer {
 
 	return nil
 }
-
-// UseHintOverlay sets the hints overlay.
-func (m *Manager) UseHintOverlay(o *hints.Overlay) {
-	m.hintOverlay = o
-}
-
-// UseGridOverlay sets the grid overlay.
-func (m *Manager) UseGridOverlay(o *grid.Overlay) {
-	m.gridOverlay = o
-}
-
-// UseModeIndicatorOverlay sets the mode indicator overlay.
-func (m *Manager) UseModeIndicatorOverlay(o *modeindicator.Overlay) {
-	m.modeIndicatorOverlay = o
-}
-
-// UseStickyModifiersOverlay sets the sticky modifiers overlay.
-func (m *Manager) UseStickyModifiersOverlay(o *stickyindicator.Overlay) {
-	m.stickyModifiersOverlay = o
-}
-
-// UseRecursiveGridOverlay sets the recursive grid overlay.
-func (m *Manager) UseRecursiveGridOverlay(o *recursivegrid.Overlay) {
-	m.recursiveGridOverlay = o
-}
-
-// UseVirtualPointerOverlay sets the cursor-following virtual pointer overlay.
-func (m *Manager) UseVirtualPointerOverlay(o *virtualpointer.Overlay) {
-	m.virtualPointerOverlay = o
-}
-
-// HintOverlay returns the hints overlay.
-func (m *Manager) HintOverlay() *hints.Overlay { return m.hintOverlay }
-
-// GridOverlay returns the grid overlay.
-func (m *Manager) GridOverlay() *grid.Overlay { return m.gridOverlay }
-
-// ModeIndicatorOverlay returns the mode indicator overlay.
-func (m *Manager) ModeIndicatorOverlay() *modeindicator.Overlay { return m.modeIndicatorOverlay }
-
-// StickyModifiersOverlay returns the sticky modifiers overlay.
-func (m *Manager) StickyModifiersOverlay() *stickyindicator.Overlay { return m.stickyModifiersOverlay }
-
-// RecursiveGridOverlay returns the recursive grid overlay.
-func (m *Manager) RecursiveGridOverlay() *recursivegrid.Overlay { return m.recursiveGridOverlay }
-
-// VirtualPointerOverlay returns the cursor-following virtual pointer overlay.
-func (m *Manager) VirtualPointerOverlay() *virtualpointer.Overlay { return m.virtualPointerOverlay }
 
 // OverlayCapabilities returns the feature capabilities.
 func (m *Manager) OverlayCapabilities() ports.FeatureCapability {
@@ -541,7 +431,7 @@ func (m *Manager) HideHintSearchInput() {}
 
 // DrawModeIndicator draws the mode indicator overlay.
 func (m *Manager) DrawModeIndicator(posX, posY int) {
-	if m.modeIndicatorOverlay == nil {
+	if m.ModeIndicatorOverlay() == nil {
 		return
 	}
 
@@ -552,7 +442,7 @@ func (m *Manager) DrawModeIndicator(posX, posY int) {
 
 	label, colors, style, ok := resolveModeIndicatorAppearance(
 		string(mode),
-		m.modeIndicatorOverlay,
+		m.ModeIndicatorOverlay(),
 	)
 	if !ok {
 		return
@@ -576,7 +466,7 @@ func (m *Manager) DrawModeIndicator(posX, posY int) {
 
 // DrawStickyModifiersIndicator draws the sticky modifiers indicator overlay.
 func (m *Manager) DrawStickyModifiersIndicator(posX, posY int, symbols string) {
-	if m.stickyModifiersOverlay == nil {
+	if m.StickyModifiersOverlay() == nil {
 		return
 	}
 
@@ -589,7 +479,7 @@ func (m *Manager) DrawStickyModifiersIndicator(posX, posY int, symbols string) {
 		return
 	}
 
-	colors, style, ok := resolveStickyIndicatorAppearance(m.stickyModifiersOverlay)
+	colors, style, ok := resolveStickyIndicatorAppearance(m.StickyModifiersOverlay())
 	if !ok {
 		return
 	}
@@ -615,8 +505,8 @@ func (m *Manager) DrawGrid(grid *domainGrid.Grid, input string, style grid.Style
 
 	if m.x11 != nil {
 		// Pass sublayer keys from grid overlay config so subgrid labels match config.
-		if m.gridOverlay != nil {
-			cfg := m.gridOverlay.Config()
+		if m.GridOverlay() != nil {
+			cfg := m.GridOverlay().Config()
 
 			keys := strings.TrimSpace(cfg.SublayerKeys)
 			if keys == "" {
@@ -631,8 +521,8 @@ func (m *Manager) DrawGrid(grid *domainGrid.Grid, input string, style grid.Style
 		return nil
 	} else if m.wlroots != nil {
 		// Pass sublayer keys from grid overlay config so subgrid labels match config.
-		if m.gridOverlay != nil {
-			cfg := m.gridOverlay.Config()
+		if m.GridOverlay() != nil {
+			cfg := m.GridOverlay().Config()
 
 			keys := strings.TrimSpace(cfg.SublayerKeys)
 			if keys == "" {
@@ -679,8 +569,8 @@ func (m *Manager) DrawRecursiveGrid(
 
 	animDurationMS := 50
 
-	if m.recursiveGridOverlay != nil {
-		animCfg := m.recursiveGridOverlay.Config().Animation
+	if m.RecursiveGridOverlay() != nil {
+		animCfg := m.RecursiveGridOverlay().Config().Animation
 		animEnabled = animCfg.Enabled
 		animDurationMS = animCfg.DurationMS
 	}
@@ -746,8 +636,8 @@ func (m *Manager) ShowSubgrid(cell *domainGrid.Cell, style grid.Style) {
 
 	if m.x11 != nil {
 		// Ensure sublayer keys are set from grid overlay config.
-		if m.gridOverlay != nil {
-			cfg := m.gridOverlay.Config()
+		if m.GridOverlay() != nil {
+			cfg := m.GridOverlay().Config()
 
 			keys := strings.TrimSpace(cfg.SublayerKeys)
 			if keys == "" {
@@ -760,8 +650,8 @@ func (m *Manager) ShowSubgrid(cell *domainGrid.Cell, style grid.Style) {
 		m.x11.ShowSubgrid(cell, style)
 	} else if m.wlroots != nil {
 		// Ensure sublayer keys are set from grid overlay config.
-		if m.gridOverlay != nil {
-			cfg := m.gridOverlay.Config()
+		if m.GridOverlay() != nil {
+			cfg := m.GridOverlay().Config()
 
 			keys := strings.TrimSpace(cfg.SublayerKeys)
 			if keys == "" {
@@ -1034,11 +924,11 @@ type overlayBadgeStyle struct {
 
 // DrawVirtualPointer renders the cursor-following virtual pointer overlay.
 func (m *Manager) DrawVirtualPointer(xCoordinate, yCoordinate, size int, fillColor string) {
-	if m.virtualPointerOverlay == nil {
+	if m.VirtualPointerOverlay() == nil {
 		return
 	}
 
-	m.virtualPointerOverlay.Draw(xCoordinate, yCoordinate, size, fillColor)
+	m.VirtualPointerOverlay().Draw(xCoordinate, yCoordinate, size, fillColor)
 }
 
 // DrawMouseActionIndicator animates a transient indicator at the click point on
@@ -1124,21 +1014,6 @@ func (m *Manager) clearModeIndicatorBadgeLocked() {
 
 	m.modeIndicatorBadgeVisible = false
 	m.modeIndicatorBadgeRect = image.Rectangle{}
-}
-
-func (m *Manager) publish(change manager.StateChange) {
-	m.mu.RLock()
-
-	subs := make([]func(manager.StateChange), 0, len(m.subs))
-	for _, fn := range m.subs {
-		subs = append(subs, fn)
-	}
-
-	m.mu.RUnlock()
-
-	for _, fn := range subs {
-		fn(change)
-	}
 }
 
 func resolveModeIndicatorAppearance(

--- a/internal/adapter/overlay/manager/base.go
+++ b/internal/adapter/overlay/manager/base.go
@@ -1,0 +1,163 @@
+package manager
+
+import (
+	"sync"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/modeindicator"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/stickyindicator"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/virtualpointer"
+)
+
+// defaultSubscriberCapacity sizes the subscriber map for the handful of
+// long-lived subscribers a session realistically has.
+const defaultSubscriberCapacity = 4
+
+// Base carries the state every overlay backend shares: the current mode, the
+// mode-change subscriber registry, and the render-component registry. Backends
+// embed it and initialize it with NewBase, keeping only genuinely
+// platform-specific behavior in their own methods.
+//
+// A backend may override an individual method to add platform behavior (the
+// darwin backend does this for UseVirtualPointerOverlay); the override should
+// still delegate to the Base method for the shared bookkeeping.
+type Base struct {
+	logger *zap.Logger
+
+	mu     sync.RWMutex
+	mode   Mode
+	subs   map[uint64]func(StateChange)
+	nextID uint64
+
+	hintOverlay            *hints.Overlay
+	gridOverlay            *grid.Overlay
+	modeIndicatorOverlay   *modeindicator.Overlay
+	recursiveGridOverlay   *recursivegrid.Overlay
+	stickyModifiersOverlay *stickyindicator.Overlay
+	virtualPointerOverlay  *virtualpointer.Overlay
+}
+
+// NewBase returns a Base ready for embedding. The logger may be nil.
+func NewBase(logger *zap.Logger) Base {
+	return Base{
+		logger: logger,
+		mode:   ModeIdle,
+		subs:   make(map[uint64]func(StateChange), defaultSubscriberCapacity),
+	}
+}
+
+// Mode returns the current overlay mode.
+func (b *Base) Mode() Mode {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return b.mode
+}
+
+// SwitchTo transitions to the given mode and notifies subscribers. Switching
+// to the mode already active is a no-op: subscribers only ever see real
+// transitions.
+func (b *Base) SwitchTo(next Mode) {
+	b.mu.Lock()
+
+	prev := b.mode
+	if prev == next {
+		b.mu.Unlock()
+
+		return
+	}
+
+	b.mode = next
+
+	b.mu.Unlock()
+
+	if b.logger != nil {
+		b.logger.Debug(
+			"Overlay mode switch",
+			zap.String("prev", string(prev)),
+			zap.String("next", string(next)),
+		)
+	}
+
+	b.publish(NewStateChange(prev, next))
+}
+
+// Subscribe registers a callback for overlay mode changes.
+func (b *Base) Subscribe(subscriber func(StateChange)) uint64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.nextID++
+	id := b.nextID
+	b.subs[id] = subscriber
+
+	return id
+}
+
+// Unsubscribe removes a previously registered callback.
+func (b *Base) Unsubscribe(id uint64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	delete(b.subs, id)
+}
+
+// UseHintOverlay sets the hints overlay renderer.
+func (b *Base) UseHintOverlay(o *hints.Overlay) { b.hintOverlay = o }
+
+// UseGridOverlay sets the grid overlay renderer.
+func (b *Base) UseGridOverlay(o *grid.Overlay) { b.gridOverlay = o }
+
+// UseModeIndicatorOverlay sets the mode-indicator overlay renderer.
+func (b *Base) UseModeIndicatorOverlay(o *modeindicator.Overlay) { b.modeIndicatorOverlay = o }
+
+// UseStickyModifiersOverlay sets the sticky modifiers overlay renderer.
+func (b *Base) UseStickyModifiersOverlay(
+	o *stickyindicator.Overlay,
+) {
+	b.stickyModifiersOverlay = o
+}
+
+// UseRecursiveGridOverlay sets the recursive-grid overlay renderer.
+func (b *Base) UseRecursiveGridOverlay(o *recursivegrid.Overlay) { b.recursiveGridOverlay = o }
+
+// UseVirtualPointerOverlay sets the cursor-following virtual pointer overlay renderer.
+func (b *Base) UseVirtualPointerOverlay(o *virtualpointer.Overlay) { b.virtualPointerOverlay = o }
+
+// HintOverlay returns the hints overlay renderer.
+func (b *Base) HintOverlay() *hints.Overlay { return b.hintOverlay }
+
+// GridOverlay returns the grid overlay renderer.
+func (b *Base) GridOverlay() *grid.Overlay { return b.gridOverlay }
+
+// ModeIndicatorOverlay returns the mode-indicator overlay renderer.
+func (b *Base) ModeIndicatorOverlay() *modeindicator.Overlay { return b.modeIndicatorOverlay }
+
+// StickyModifiersOverlay returns the sticky modifiers overlay renderer.
+func (b *Base) StickyModifiersOverlay() *stickyindicator.Overlay { return b.stickyModifiersOverlay }
+
+// RecursiveGridOverlay returns the recursive-grid overlay renderer.
+func (b *Base) RecursiveGridOverlay() *recursivegrid.Overlay { return b.recursiveGridOverlay }
+
+// VirtualPointerOverlay returns the cursor-following virtual pointer overlay renderer.
+func (b *Base) VirtualPointerOverlay() *virtualpointer.Overlay { return b.virtualPointerOverlay }
+
+// publish delivers a state change to every subscriber. Callbacks run outside
+// the lock so a subscriber may call back into the manager.
+func (b *Base) publish(event StateChange) {
+	b.mu.Lock()
+
+	subs := make([]func(StateChange), 0, len(b.subs))
+	for _, sub := range b.subs {
+		subs = append(subs, sub)
+	}
+	b.mu.Unlock()
+
+	for _, sub := range subs {
+		sub(event)
+	}
+}

--- a/internal/adapter/overlay/manager/base_test.go
+++ b/internal/adapter/overlay/manager/base_test.go
@@ -1,0 +1,63 @@
+package manager_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+)
+
+// TestBase_SwitchTo_NotifiesOnRealTransitionsOnly pins the transition
+// semantics every backend now shares: subscribers see each real mode change
+// exactly once, and switching to the already-active mode publishes nothing.
+// The three backends used to hand-roll this and had drifted on the
+// equal-mode case.
+func TestBase_SwitchTo_NotifiesOnRealTransitionsOnly(t *testing.T) {
+	t.Parallel()
+
+	base := manager.NewBase(nil)
+
+	var got []manager.StateChange
+
+	base.Subscribe(func(change manager.StateChange) {
+		got = append(got, change)
+	})
+
+	base.SwitchTo(manager.ModeHints)
+	base.SwitchTo(manager.ModeHints) // no-op: already active
+	base.SwitchTo(manager.ModeIdle)
+
+	if len(got) != 2 {
+		t.Fatalf("subscriber saw %d transitions, want 2", len(got))
+	}
+
+	if got[0].Prev() != manager.ModeIdle || got[0].Next() != manager.ModeHints {
+		t.Errorf("first transition = %s->%s, want idle->hints", got[0].Prev(), got[0].Next())
+	}
+
+	if got[1].Prev() != manager.ModeHints || got[1].Next() != manager.ModeIdle {
+		t.Errorf("second transition = %s->%s, want hints->idle", got[1].Prev(), got[1].Next())
+	}
+
+	if base.Mode() != manager.ModeIdle {
+		t.Errorf("Mode() = %s, want idle", base.Mode())
+	}
+}
+
+// TestBase_Unsubscribe_StopsDelivery pins that an unsubscribed callback is
+// never invoked again.
+func TestBase_Unsubscribe_StopsDelivery(t *testing.T) {
+	t.Parallel()
+
+	base := manager.NewBase(nil)
+
+	calls := 0
+	id := base.Subscribe(func(manager.StateChange) { calls++ })
+
+	base.SwitchTo(manager.ModeGrid)
+	base.Unsubscribe(id)
+	base.SwitchTo(manager.ModeIdle)
+
+	if calls != 1 {
+		t.Errorf("subscriber called %d times, want 1 (unsubscribed before second switch)", calls)
+	}
+}

--- a/internal/adapter/overlay/windows/manager.go
+++ b/internal/adapter/overlay/windows/manager.go
@@ -16,10 +16,7 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
-	"github.com/y3owk1n/neru/internal/adapter/overlay/render/modeindicator"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
-	"github.com/y3owk1n/neru/internal/adapter/overlay/render/stickyindicator"
-	"github.com/y3owk1n/neru/internal/adapter/overlay/render/virtualpointer"
 	winplatform "github.com/y3owk1n/neru/internal/adapter/platform/windows"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/derrors"
@@ -27,19 +24,13 @@ import (
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
-// Windows overlay manager backed by a layered Win32 HWND and GDI rendering of
-// grid, hints, and recursive-grid overlays.
+// Manager manages overlay rendering on Windows, backed by a layered Win32
+// HWND and GDI rendering of grid, hints, and recursive-grid overlays.
 // Does not implement keyboard capture (handled by the low-level keyboard hook).
-const winInitialSubscriberCapacity = 4
-
-// Manager manages overlay rendering on Windows.
 type Manager struct {
-	logger *zap.Logger
+	manager.Base
 
-	mu     sync.RWMutex
-	mode   manager.Mode
-	subs   map[uint64]func(manager.StateChange)
-	nextID uint64
+	logger *zap.Logger
 
 	renderMu sync.Mutex
 	win      *winOverlay
@@ -59,13 +50,6 @@ type Manager struct {
 	mouseWin *winplatform.OverlayWindow
 	// mouseActionCancel cancels any running mouse action animation.
 	mouseActionCancel context.CancelFunc
-
-	hintOverlay            *hints.Overlay
-	gridOverlay            *grid.Overlay
-	modeIndicatorOverlay   *modeindicator.Overlay
-	recursiveGridOverlay   *recursivegrid.Overlay
-	stickyModifiersOverlay *stickyindicator.Overlay
-	virtualPointerOverlay  *virtualpointer.Overlay
 }
 
 var (
@@ -76,9 +60,8 @@ var (
 // NewOverlayManager creates a new overlay Manager.
 func NewOverlayManager(logger *zap.Logger) *Manager {
 	return &Manager{
+		Base:   manager.NewBase(logger),
 		logger: logger,
-		mode:   manager.ModeIdle,
-		subs:   make(map[uint64]func(manager.StateChange), winInitialSubscriberCapacity),
 		win:    newWinOverlay(logger),
 	}
 }
@@ -193,37 +176,6 @@ func (m *Manager) ActiveScreenBounds() (image.Rectangle, bool) {
 	return m.win.screenBounds()
 }
 
-// SwitchTo switches overlay mode and notifies subscribers.
-func (m *Manager) SwitchTo(next manager.Mode) {
-	m.mu.Lock()
-	prev := m.mode
-	m.mode = next
-	m.mu.Unlock()
-
-	if prev != next {
-		m.publish(manager.NewStateChange(prev, next))
-	}
-}
-
-// Subscribe registers a callback for overlay mode changes.
-func (m *Manager) Subscribe(subFn func(manager.StateChange)) uint64 {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	m.nextID++
-	id := m.nextID
-	m.subs[id] = subFn
-
-	return id
-}
-
-// Unsubscribe removes a callback.
-func (m *Manager) Unsubscribe(id uint64) {
-	m.mu.Lock()
-	delete(m.subs, id)
-	m.mu.Unlock()
-}
-
 // Destroy destroys overlay resources.
 func (m *Manager) Destroy() {
 	m.renderMu.Lock()
@@ -255,14 +207,6 @@ func (m *Manager) Destroy() {
 	}
 }
 
-// Mode returns the current overlay mode.
-func (m *Manager) Mode() manager.Mode {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	return m.mode
-}
-
 // WindowPtr returns the native overlay window handle.
 func (m *Manager) WindowPtr() unsafe.Pointer {
 	if m.win == nil {
@@ -275,58 +219,6 @@ func (m *Manager) WindowPtr() unsafe.Pointer {
 // WaylandKeyboardChannel returns nil on Windows.
 func (m *Manager) WaylandKeyboardChannel() <-chan string {
 	return nil
-}
-
-// UseHintOverlay sets the hints overlay component.
-func (m *Manager) UseHintOverlay(o *hints.Overlay) { m.hintOverlay = o }
-
-// UseGridOverlay sets the grid overlay component.
-func (m *Manager) UseGridOverlay(o *grid.Overlay) { m.gridOverlay = o }
-
-// UseModeIndicatorOverlay sets the mode-indicator overlay component.
-func (m *Manager) UseModeIndicatorOverlay(o *modeindicator.Overlay) {
-	m.modeIndicatorOverlay = o
-}
-
-// UseStickyModifiersOverlay sets the sticky-modifiers overlay component.
-func (m *Manager) UseStickyModifiersOverlay(o *stickyindicator.Overlay) {
-	m.stickyModifiersOverlay = o
-}
-
-// UseRecursiveGridOverlay sets the recursive-grid overlay component.
-func (m *Manager) UseRecursiveGridOverlay(o *recursivegrid.Overlay) {
-	m.recursiveGridOverlay = o
-}
-
-// HintOverlay returns the hints overlay component.
-func (m *Manager) HintOverlay() *hints.Overlay { return m.hintOverlay }
-
-// GridOverlay returns the grid overlay component.
-func (m *Manager) GridOverlay() *grid.Overlay { return m.gridOverlay }
-
-// ModeIndicatorOverlay returns the mode-indicator overlay component.
-func (m *Manager) ModeIndicatorOverlay() *modeindicator.Overlay {
-	return m.modeIndicatorOverlay
-}
-
-// StickyModifiersOverlay returns the sticky-modifiers overlay component.
-func (m *Manager) StickyModifiersOverlay() *stickyindicator.Overlay {
-	return m.stickyModifiersOverlay
-}
-
-// RecursiveGridOverlay returns the recursive-grid overlay component.
-func (m *Manager) RecursiveGridOverlay() *recursivegrid.Overlay {
-	return m.recursiveGridOverlay
-}
-
-// UseVirtualPointerOverlay sets the cursor-following virtual pointer overlay renderer.
-func (m *Manager) UseVirtualPointerOverlay(o *virtualpointer.Overlay) {
-	m.virtualPointerOverlay = o
-}
-
-// VirtualPointerOverlay returns the cursor-following virtual pointer overlay renderer.
-func (m *Manager) VirtualPointerOverlay() *virtualpointer.Overlay {
-	return m.virtualPointerOverlay
 }
 
 // OverlayCapabilities reports Windows overlay support.
@@ -360,8 +252,8 @@ func (m *Manager) DrawHintsWithStyle(hintsSlice []*hints.Hint, style hints.Style
 
 	// Match the infra adapter and mode-indicator paths: rebuild from the hints
 	// overlay config when the caller passed an empty style (e.g. stale cache).
-	if style.BackgroundColor() == "" && m.hintOverlay != nil {
-		style = hints.BuildStyle(m.hintOverlay.Config(), nil)
+	if style.BackgroundColor() == "" && m.HintOverlay() != nil {
+		style = hints.BuildStyle(m.HintOverlay().Config(), nil)
 	}
 
 	// Shared activation may draw before the resize; enforce monitor bounds here.
@@ -455,7 +347,7 @@ func (m *Manager) HideHintSearchInput() {
 // avoids the clear-then-flush blink that occurs when drawing transient
 // badges into the shared full-screen overlay pixel buffer.
 func (m *Manager) DrawModeIndicator(cursorX, cursorY int) {
-	if m.modeIndicatorOverlay == nil {
+	if m.ModeIndicatorOverlay() == nil {
 		return
 	}
 
@@ -464,9 +356,9 @@ func (m *Manager) DrawModeIndicator(cursorX, cursorY int) {
 		return
 	}
 
-	cfg := m.modeIndicatorOverlay.IndicatorConfig()
+	cfg := m.ModeIndicatorOverlay().IndicatorConfig()
 
-	label := m.modeIndicatorOverlay.ResolveLabelText(string(mode))
+	label := m.ModeIndicatorOverlay().ResolveLabelText(string(mode))
 	if label == "" {
 		return
 	}
@@ -513,22 +405,22 @@ func (m *Manager) DrawModeIndicator(cursorX, cursorY int) {
 	m.indicatorWin.Clear()
 
 	// ResolveLabelText already returned non-empty, so the mode config exists.
-	modeCfg, _ := m.modeIndicatorOverlay.ResolveModeConfig(string(mode))
+	modeCfg, _ := m.ModeIndicatorOverlay().ResolveModeConfig(string(mode))
 	bgColor := modeCfg.BackgroundColor.ForThemeWithOverride(
 		cfg.UI.BackgroundColor,
-		m.modeIndicatorOverlay.ThemeProvider(),
+		m.ModeIndicatorOverlay().ThemeProvider(),
 		config.ModeIndicatorBackgroundColorLight,
 		config.ModeIndicatorBackgroundColorDark,
 	)
 	textColor := modeCfg.TextColor.ForThemeWithOverride(
 		cfg.UI.TextColor,
-		m.modeIndicatorOverlay.ThemeProvider(),
+		m.ModeIndicatorOverlay().ThemeProvider(),
 		config.ModeIndicatorTextColorLight,
 		config.ModeIndicatorTextColorDark,
 	)
 	borderColor := modeCfg.BorderColor.ForThemeWithOverride(
 		cfg.UI.BorderColor,
-		m.modeIndicatorOverlay.ThemeProvider(),
+		m.ModeIndicatorOverlay().ThemeProvider(),
 		config.ModeIndicatorBorderColorLight,
 		config.ModeIndicatorBorderColorDark,
 	)
@@ -576,11 +468,11 @@ func (m *Manager) DrawModeIndicator(cursorX, cursorY int) {
 // its own dedicated layered window, following the cursor without touching the
 // shared overlay.
 func (m *Manager) DrawStickyModifiersIndicator(cursorX, cursorY int, symbols string) {
-	if m.stickyModifiersOverlay == nil || symbols == "" {
+	if m.StickyModifiersOverlay() == nil || symbols == "" {
 		return
 	}
 
-	indicatorUI := m.stickyModifiersOverlay.UIConfig()
+	indicatorUI := m.StickyModifiersOverlay().UIConfig()
 	fontSize := float64(max(indicatorUI.FontSize, 1))
 
 	paddingX := resolveWinAutoPadding(fontSize, indicatorUI.PaddingX, true)
@@ -623,17 +515,17 @@ func (m *Manager) DrawStickyModifiersIndicator(cursorX, cursorY int, symbols str
 	m.stickyWin.Clear()
 
 	bgColor := indicatorUI.BackgroundColor.ForTheme(
-		m.stickyModifiersOverlay.ThemeProvider(),
+		m.StickyModifiersOverlay().ThemeProvider(),
 		config.StickyModifiersBackgroundColorLight,
 		config.StickyModifiersBackgroundColorDark,
 	)
 	textColor := indicatorUI.TextColor.ForTheme(
-		m.stickyModifiersOverlay.ThemeProvider(),
+		m.StickyModifiersOverlay().ThemeProvider(),
 		config.StickyModifiersTextColorLight,
 		config.StickyModifiersTextColorDark,
 	)
 	borderColor := indicatorUI.BorderColor.ForTheme(
-		m.stickyModifiersOverlay.ThemeProvider(),
+		m.StickyModifiersOverlay().ThemeProvider(),
 		config.StickyModifiersBorderColorLight,
 		config.StickyModifiersBorderColorDark,
 	)
@@ -681,11 +573,11 @@ func (m *Manager) DrawStickyModifiersIndicator(cursorX, cursorY int, symbols str
 
 // DrawVirtualPointer renders the cursor-following virtual pointer overlay.
 func (m *Manager) DrawVirtualPointer(xCoordinate, yCoordinate, size int, fillColor string) {
-	if m.virtualPointerOverlay == nil {
+	if m.VirtualPointerOverlay() == nil {
 		return
 	}
 
-	m.virtualPointerOverlay.Draw(xCoordinate, yCoordinate, size, fillColor)
+	m.VirtualPointerOverlay().Draw(xCoordinate, yCoordinate, size, fillColor)
 }
 
 // DrawMouseActionIndicator renders a transient mouse action indicator on the Windows overlay.
@@ -777,8 +669,8 @@ func (m *Manager) DrawGrid(gridValue *domainGrid.Grid, input string, style grid.
 		m.logger.Debug("manager DrawGrid", zap.Int("cells", cellCount))
 	}
 
-	if m.gridOverlay != nil {
-		cfg := m.gridOverlay.Config()
+	if m.GridOverlay() != nil {
+		cfg := m.GridOverlay().Config()
 
 		keys := strings.TrimSpace(cfg.SublayerKeys)
 		if keys == "" {
@@ -1010,12 +902,6 @@ func scaleColorAlpha(hexColor string, opacity float64) uint32 {
 	res := (newA << 24) | (redVal << 16) | (greenVal << 8) | blueVal //nolint:mnd
 
 	return res
-}
-
-func (m *Manager) publish(change manager.StateChange) {
-	for _, sub := range m.subs {
-		sub(change)
-	}
 }
 
 func (m *Manager) ensureWinOverlayLocked() {


### PR DESCRIPTION
## Description

This PR removes the second big block of per-platform duplication in the overlay layer: each of the three platform overlay managers carried its own copy of the mode/subscriber state machine and the render-component registry — about 400 near-identical lines. That shared state now lives in one place, and each platform keeps only its genuinely platform-specific behavior.

The copies had already drifted in two ways this PR heals. The three implementations of mode switching disagreed on what happens when switching to the already-active mode and on whether transitions are logged; the unified behavior is: an equal-mode switch notifies nobody, and real transitions are debug-logged on every platform. On Windows, subscriber callbacks were also being delivered by iterating the subscriber registry without holding its lock — a latent data race with concurrent subscribe/unsubscribe, now gone. New tests pin the unified transition semantics.

## Related Issues

N/A

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `refactor` — Code restructuring (no behavior change)

Behavior notes, both strictly narrower than before: on Windows an equal-mode switch no longer rewrites the stored mode (observationally identical) and the subscriber-iteration race is fixed; on macOS the screen-share flag now has its own lock, so it can no longer contend with mode-switch callers (previously called out in a comment as a hazard if the native call ever became synchronous).

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no capability surface changed

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build) — lint, lint-cross (0 issues), vet, build, cross-compile checks and unit suite run locally; full `-race`/integration passes run in CI
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no documented interface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

N/A
