### PR TITLE
refactor(eventtap): extract shared key and modifier vocabulary

### DIFF
--- a/internal/adapter/eventtap/linux/evdev_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_cgo.go
@@ -26,6 +26,7 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/overlay"
 	overlaymanager "github.com/y3owk1n/neru/internal/adapter/overlay/manager"
 	linux "github.com/y3owk1n/neru/internal/adapter/platform/linux"
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
 )
 
 const (
@@ -978,7 +979,7 @@ func (et *EventTap) handleWaylandEvdevEvent(
 		}
 
 		if et.stickyToggleEnabled() && et.stickyDetectionArmed() {
-			et.dispatchKey(linuxModifierToggleEvent(modifier, isDown))
+			et.dispatchKey(keyvocab.ModifierToggleEvent(modifier, isDown))
 		}
 
 		// Re-arm detection when the modifier state reaches a clean slate,
@@ -1023,7 +1024,7 @@ func (et *EventTap) handleWaylandEvdevEvent(
 
 		key := et.xkbEvdevKeyName(capture, event.code)
 		if key != "" {
-			if keyUp := linuxKeyUpEvent(key); keyUp != "" {
+			if keyUp := keyvocab.KeyUpEvent(key); keyUp != "" {
 				et.dispatchKey(keyUp)
 			}
 		}
@@ -1060,7 +1061,7 @@ func (et *EventTap) handleWaylandEvdevEvent(
 		return
 	}
 
-	key = normalizeLinuxKey(state.modifiers.prefix() + key)
+	key = keyvocab.NormalizeKey(state.modifiers.prefix() + key)
 	if key == "" {
 		return
 	}

--- a/internal/adapter/eventtap/linux/tap.go
+++ b/internal/adapter/eventtap/linux/tap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/overlay"
 	overlaymanager "github.com/y3owk1n/neru/internal/adapter/overlay/manager"
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
 )
 
 type pendingSyntheticModifierEvent struct {
@@ -309,7 +310,7 @@ func canonicalChordForMatch(chord string) string {
 	var hasShift, hasCtrl, hasAlt, hasCmd bool
 
 	for _, part := range parts[:len(parts)-1] {
-		switch canonicalLinuxModifier(part) {
+		switch keyvocab.CanonicalModifier(part) {
 		case evdevModifierShift:
 			hasShift = true
 		case evdevModifierCtrl:
@@ -362,7 +363,7 @@ func (et *EventTap) SetStickyModifierToggle(enabled bool) {
 
 // PostModifierEvent posts a modifier key event.
 func (et *EventTap) PostModifierEvent(modifier string, isDown bool) {
-	modifier = canonicalLinuxModifier(modifier)
+	modifier = keyvocab.CanonicalModifier(modifier)
 	if modifier == "" {
 		return
 	}
@@ -513,58 +514,12 @@ func (et *EventTap) dispatchLoop() {
 	}
 }
 
-// linuxKeyUpPrefix matches modes.keyUpPrefix — signals key release to stop held-key repeat.
-const linuxKeyUpPrefix = "__keyup_"
-
-// linuxKeyUpEvent formats a key-up notification for held-repeat actions (scroll, page, etc.).
-// Uses the base key (no modifier prefix) to match modes.Handler held-key tracking.
-func linuxKeyUpEvent(key string) string {
-	key = normalizeLinuxKey(key)
-	if key == "" {
-		return ""
-	}
-
-	parts := strings.Split(key, "+")
-	baseKey := parts[len(parts)-1]
-
-	return linuxKeyUpPrefix + baseKey
-}
-
 // stickyToggleEnabled returns whether sticky toggle is active.
 func (et *EventTap) stickyToggleEnabled() bool {
 	et.mu.RLock()
 	defer et.mu.RUnlock()
 
 	return et.stickyModifierToggle
-}
-
-func canonicalLinuxModifier(modifier string) string {
-	switch strings.ToLower(strings.TrimSpace(modifier)) {
-	case evdevModifierCmd, "command", evdevModifierAliasSuper, "meta":
-		return evdevModifierCmd
-	case evdevModifierShift:
-		return evdevModifierShift
-	case evdevModifierAlt, evdevModifierAliasOption:
-		return evdevModifierAlt
-	case evdevModifierCtrl, evdevModifierAliasControl:
-		return evdevModifierCtrl
-	default:
-		return ""
-	}
-}
-
-func linuxModifierToggleEvent(modifier string, isDown bool) string {
-	modifier = canonicalLinuxModifier(modifier)
-	if modifier == "" {
-		return ""
-	}
-
-	suffix := "up"
-	if isDown {
-		suffix = "down"
-	}
-
-	return "__modifier_" + modifier + "_" + suffix
 }
 
 func (et *EventTap) rememberSyntheticModifierEvent(modifier string, isDown bool) {
@@ -614,44 +569,4 @@ func (et *EventTap) consumeSyntheticModifierEvent(modifier string, isDown bool) 
 	et.syntheticModifierEvents = pending
 
 	return consumed
-}
-
-func normalizeLinuxKey(key string) string {
-	key = strings.TrimSpace(key)
-	if key == "" {
-		return ""
-	}
-
-	// Split modifiers from base key
-	parts := strings.Split(key, "+")
-	baseKey := parts[len(parts)-1]
-
-	switch strings.ToLower(baseKey) {
-	case "return":
-		baseKey = evdevKeyNameReturn
-	case "space":
-		baseKey = "Space"
-	case "tab":
-		baseKey = "Tab"
-	case "escape", "esc":
-		baseKey = evdevKeyNameEscape
-	case "backspace":
-		baseKey = "Delete"
-	case "left":
-		baseKey = evdevKeyNameLeft
-	case "right":
-		baseKey = "Right"
-	case "up":
-		baseKey = "Up"
-	case "down":
-		baseKey = "Down"
-	default:
-		if len([]rune(baseKey)) == 1 {
-			baseKey = strings.ToLower(baseKey)
-		}
-	}
-
-	parts[len(parts)-1] = baseKey
-
-	return strings.Join(parts, "+")
 }

--- a/internal/adapter/eventtap/linux/tap_test.go
+++ b/internal/adapter/eventtap/linux/tap_test.go
@@ -10,58 +10,6 @@ const (
 	chordShiftCtrl = "shift+ctrl+t"
 )
 
-func TestLinuxModifierToggleEventCanonicalizes(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name     string
-		modifier string
-		isDown   bool
-		want     string
-	}{
-		{
-			name:     "shift down",
-			modifier: evdevModifierShift,
-			isDown:   true,
-			want:     "__modifier_shift_down",
-		},
-		{
-			name:     "control alias up",
-			modifier: evdevModifierAliasControl,
-			isDown:   false,
-			want:     "__modifier_ctrl_up",
-		},
-		{
-			name:     "super alias down",
-			modifier: evdevModifierAliasSuper,
-			isDown:   true,
-			want:     "__modifier_cmd_down",
-		},
-		{
-			name:     "option alias up",
-			modifier: evdevModifierAliasOption,
-			isDown:   false,
-			want:     "__modifier_alt_up",
-		},
-		{name: "unknown", modifier: "fn", isDown: true, want: ""},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := linuxModifierToggleEvent(testCase.modifier, testCase.isDown)
-			if got != testCase.want {
-				t.Fatalf("linuxModifierToggleEvent(%q, %t) = %q, want %q",
-					testCase.modifier,
-					testCase.isDown,
-					got,
-					testCase.want)
-			}
-		})
-	}
-}
-
 func TestSyntheticModifierSuppressionConsumesOnce(t *testing.T) {
 	t.Parallel()
 
@@ -187,29 +135,5 @@ func TestSetModifierPassthroughDisabledStillMatchesBlacklist(t *testing.T) {
 
 	if eventTap.shouldPassthroughChord("Ctrl+y") {
 		t.Fatal("expected no passthrough while disabled")
-	}
-}
-
-func TestLinuxKeyUpEvent(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		press string
-		want  string
-	}{
-		{"j", "__keyup_j"},
-		{"Shift+j", "__keyup_j"},
-		{"k", "__keyup_k"},
-		{evdevKeyNameReturn, "__keyup_Return"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.press, func(t *testing.T) {
-			t.Parallel()
-
-			if got := linuxKeyUpEvent(tc.press); got != tc.want {
-				t.Fatalf("linuxKeyUpEvent(%q) = %q, want %q", tc.press, got, tc.want)
-			}
-		})
 	}
 }

--- a/internal/adapter/eventtap/linux/wayland_cgo.go
+++ b/internal/adapter/eventtap/linux/wayland_cgo.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay"
 	overlaymanager "github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
 )
 
 func (et *EventTap) runWayland() {
@@ -49,7 +50,7 @@ func (et *EventTap) runWayland() {
 				return
 			}
 
-			key = normalizeLinuxKey(key)
+			key = keyvocab.NormalizeKey(key)
 			if key == "" {
 				continue
 			}

--- a/internal/adapter/eventtap/linux/x11_cgo.go
+++ b/internal/adapter/eventtap/linux/x11_cgo.go
@@ -15,6 +15,7 @@ import (
 	"unsafe"
 
 	"github.com/y3owk1n/neru/internal/adapter/platform/linux"
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
 )
 
 const (
@@ -139,7 +140,7 @@ func (et *EventTap) runX11() {
 			}
 
 			if et.stickyToggleEnabled() && et.stickyDetectionArmed() {
-				et.dispatchKey(linuxModifierToggleEvent(modifier, isDown))
+				et.dispatchKey(keyvocab.ModifierToggleEvent(modifier, isDown))
 			}
 
 			// Re-arm when the modifier state reaches a clean slate, so
@@ -157,7 +158,7 @@ func (et *EventTap) runX11() {
 		}
 
 		if eventType == C.KeyRelease {
-			if keyUp := linuxKeyUpEvent(key); keyUp != "" {
+			if keyUp := keyvocab.KeyUpEvent(key); keyUp != "" {
 				et.dispatchKey(keyUp)
 			}
 
@@ -176,7 +177,7 @@ func x11KeyFromLookup(length C.int, buffer []C.char, keysym C.KeySym) string {
 		key = x11KeysymName(keysym)
 	}
 
-	return normalizeLinuxKey(key)
+	return keyvocab.NormalizeKey(key)
 }
 
 func x11KeysymName(keysym C.KeySym) string {

--- a/internal/adapter/eventtap/windows/tap.go
+++ b/internal/adapter/eventtap/windows/tap.go
@@ -11,9 +11,8 @@ import (
 
 	"github.com/y3owk1n/neru/internal/adapter/eventtap/tap"
 	winplatform "github.com/y3owk1n/neru/internal/adapter/platform/windows"
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
 )
-
-const windowsKeyUpPrefix = "__keyup_"
 
 // EventTap is a keyboard event interceptor on Windows.
 type EventTap struct {
@@ -173,16 +172,16 @@ func (et *EventTap) handleKey(key string, isUp bool) bool {
 		return false
 	}
 
-	if mod := normalizeWindowsModifier(key); mod != "" {
+	if mod := keyvocab.CanonicalModifier(key); mod != "" {
 		if et.stickyToggleEnabled() {
-			et.dispatchKey(windowsModifierToggleEvent(mod, !isUp))
+			et.dispatchKey(keyvocab.ModifierToggleEvent(mod, !isUp))
 		}
 
 		return false
 	}
 
 	if isUp {
-		if keyUp := windowsKeyUpEvent(key); keyUp != "" {
+		if keyUp := keyvocab.KeyUpEvent(key); keyUp != "" {
 			et.dispatchKey(keyUp)
 		}
 
@@ -193,7 +192,7 @@ func (et *EventTap) handleKey(key string, isUp bool) bool {
 	// to the application so system shortcuts like Ctrl+C, Alt+Tab, Win+D still
 	// work while a mode is active. The mode handler still receives the key for
 	// hotkey matching.
-	normalized := normalizeWindowsKey(key)
+	normalized := keyvocab.NormalizeKey(key)
 
 	lower := strings.ToLower(normalized)
 	if strings.Contains(lower, "ctrl+") || strings.Contains(lower, "alt+") ||
@@ -227,79 +226,4 @@ func (et *EventTap) stickyToggleEnabled() bool {
 	defer et.mu.RUnlock()
 
 	return et.stickyModifierToggle
-}
-
-func normalizeWindowsModifier(key string) string {
-	switch strings.ToLower(strings.TrimSpace(key)) {
-	case "ctrl", "control":
-		return "ctrl"
-	case "alt", "option":
-		return "alt"
-	case "shift":
-		return "shift"
-	case "cmd", "command", "win", "super", "meta":
-		return "cmd"
-	default:
-		return ""
-	}
-}
-
-func windowsModifierToggleEvent(modifier string, isDown bool) string {
-	suffix := "up"
-	if isDown {
-		suffix = "down"
-	}
-
-	return "__modifier_" + modifier + "_" + suffix
-}
-
-func windowsKeyUpEvent(key string) string {
-	key = normalizeWindowsKey(key)
-	if key == "" {
-		return ""
-	}
-
-	parts := strings.Split(key, "+")
-	baseKey := parts[len(parts)-1]
-
-	return windowsKeyUpPrefix + baseKey
-}
-
-func normalizeWindowsKey(key string) string {
-	key = strings.TrimSpace(key)
-	if key == "" {
-		return ""
-	}
-
-	parts := strings.Split(key, "+")
-	baseKey := parts[len(parts)-1]
-
-	switch strings.ToLower(baseKey) {
-	case "return", "enter":
-		baseKey = "Return"
-	case "space":
-		baseKey = "Space"
-	case "tab":
-		baseKey = "Tab"
-	case "escape", "esc":
-		baseKey = "Escape"
-	case "backspace":
-		baseKey = "Delete"
-	case "left":
-		baseKey = "Left"
-	case "right":
-		baseKey = "Right"
-	case "up":
-		baseKey = "Up"
-	case "down":
-		baseKey = "Down"
-	default:
-		if len([]rune(baseKey)) == 1 {
-			baseKey = strings.ToLower(baseKey)
-		}
-	}
-
-	parts[len(parts)-1] = baseKey
-
-	return strings.Join(parts, "+")
 }

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -10,13 +10,15 @@ import (
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/action"
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
 )
 
 const (
 	hotkeySequenceTimeout = 500 * time.Millisecond
 )
 
-const keyUpPrefix = "__keyup_"
+// keyUpPrefix aliases the shared wire vocabulary the event taps emit.
+const keyUpPrefix = keyvocab.KeyUpPrefix
 
 const (
 	keyPartCmd    = "cmd"

--- a/internal/app/modes/modifier_toggle.go
+++ b/internal/app/modes/modifier_toggle.go
@@ -8,9 +8,12 @@ import (
 
 	"github.com/y3owk1n/neru/internal/app/services/stickyindicator"
 	"github.com/y3owk1n/neru/internal/domain/action"
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
 )
 
-const modifierTogglePrefix = "__modifier_"
+// modifierTogglePrefix aliases the shared wire vocabulary so the many prefix
+// checks in this package stay short.
+const modifierTogglePrefix = keyvocab.ModifierTogglePrefix
 
 // modifierToggleDebounce is the short quiet window after modifier release
 // before we commit a sticky toggle. If a regular key arrives in this window,
@@ -41,27 +44,14 @@ var allStickyModifiers = []action.Modifiers{
 // or "__modifier_cmd_up" into the modifier and whether it's a down or up event.
 // Returns (modifier, isDown, ok).
 func parseModifierEvent(key string) (action.Modifiers, bool, bool) {
-	if !strings.HasPrefix(key, modifierTogglePrefix) {
+	name, isDown, ok := keyvocab.ParseModifierToggle(key)
+	if !ok {
 		return 0, false, false
 	}
 
-	suffix := strings.ToLower(strings.TrimPrefix(key, modifierTogglePrefix))
+	mod, known := modifierToggleMap[name]
 
-	if before, ok := strings.CutSuffix(suffix, "_down"); ok {
-		name := before
-		mod, ok := modifierToggleMap[name]
-
-		return mod, true, ok
-	}
-
-	if before, ok := strings.CutSuffix(suffix, "_up"); ok {
-		name := before
-		mod, ok := modifierToggleMap[name]
-
-		return mod, false, ok
-	}
-
-	return 0, false, false
+	return mod, isDown, known
 }
 
 // handleModifierToggle processes modifier down/up events for sticky toggle.

--- a/internal/app/modes/modifier_toggle_test.go
+++ b/internal/app/modes/modifier_toggle_test.go
@@ -32,12 +32,11 @@ func TestParseModifierEvent(t *testing.T) {
 		{"__modifier_alt_up", action.ModAlt, false, true},
 		{"__modifier_ctrl_up", action.ModCtrl, false, true},
 		{"__modifier_CMD_up", action.ModCmd, false, true},
-		// Invalid — when ok=false, mod and isDown are undefined;
-		// we test the actual return values for completeness.
+		// Invalid — ok=false always comes with zero values.
 		{"__modifier_shift", 0, false, false},
 		{"__modifier_cmd", 0, false, false},
-		{"__modifier_foo_down", 0, true, false}, // has _down suffix but unknown modifier
-		{"__modifier_foo_up", 0, false, false},  // has _up suffix but unknown modifier
+		{"__modifier_foo_down", 0, false, false}, // has _down suffix but unknown modifier
+		{"__modifier_foo_up", 0, false, false},   // has _up suffix but unknown modifier
 		{"__modifier", 0, false, false},
 		{"shift", 0, false, false},
 		{"cmd", 0, false, false},

--- a/internal/architecture/keyvocab_wire_test.go
+++ b/internal/architecture/keyvocab_wire_test.go
@@ -1,0 +1,64 @@
+package architecture_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
+)
+
+// nativeKeyEventEmitters lists the native sources that format the synthetic
+// "__keyup_"/"__modifier_" wire events with printf instead of going through
+// internal/domain/keyvocab (C and Objective-C cannot import it). Each entry
+// names the prefixes that file emits.
+var nativeKeyEventEmitters = map[string][]string{
+	"internal/adapter/platform/linux/overlay_wayland.c": {
+		keyvocab.KeyUpPrefix,
+		keyvocab.ModifierTogglePrefix,
+	},
+	"internal/adapter/platform/darwin/eventtap_darwin.m": {
+		keyvocab.KeyUpPrefix,
+		keyvocab.ModifierTogglePrefix,
+	},
+}
+
+// TestNativeKeyEventEmittersMatchKeyvocab pins the two native emitters to the
+// Go wire vocabulary. The synthetic key-up and modifier-toggle events cross a
+// language boundary as bare printf format strings; if the Go prefixes in
+// internal/domain/keyvocab ever change, this test fails on each native file
+// that still emits the old spelling, instead of the protocol silently
+// splitting between the taps and the mode handler.
+//
+// If this test fails because an emitter file was renamed or stopped emitting
+// events, update nativeKeyEventEmitters to match reality.
+func TestNativeKeyEventEmittersMatchKeyvocab(t *testing.T) {
+	t.Parallel()
+
+	root := findRepoRoot(t)
+
+	for relPath, prefixes := range nativeKeyEventEmitters {
+		content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(relPath)))
+		if err != nil {
+			t.Errorf(
+				"%s: cannot read native key-event emitter (renamed?): %v — update nativeKeyEventEmitters",
+				relPath,
+				err,
+			)
+
+			continue
+		}
+
+		source := string(content)
+		for _, prefix := range prefixes {
+			if !strings.Contains(source, prefix) {
+				t.Errorf(
+					"%s: does not contain wire prefix %q from internal/domain/keyvocab; "+
+						"the native emitter and the Go vocabulary must use the same spelling",
+					relPath, prefix,
+				)
+			}
+		}
+	}
+}

--- a/internal/domain/keyvocab/doc.go
+++ b/internal/domain/keyvocab/doc.go
@@ -1,0 +1,11 @@
+// Package keyvocab owns the key and modifier vocabulary shared between the
+// event-tap backends and the mode handler: canonical key and modifier
+// spellings, and the synthetic "__keyup_"/"__modifier_" wire events the taps
+// emit and the modes consume.
+//
+// Every producer and consumer of these strings must go through this package.
+// The two native emitters that cannot (the Wayland C overlay and the macOS
+// Objective-C event tap format the events with printf) are pinned to the same
+// prefixes by an architecture test, so a change here fails loudly instead of
+// silently splitting the protocol.
+package keyvocab

--- a/internal/domain/keyvocab/keyvocab.go
+++ b/internal/domain/keyvocab/keyvocab.go
@@ -1,0 +1,149 @@
+package keyvocab
+
+import "strings"
+
+const (
+	// KeyUpPrefix marks a synthetic key-release event ("__keyup_<base key>"),
+	// used to stop held-key repeat.
+	KeyUpPrefix = "__keyup_"
+
+	// ModifierTogglePrefix marks a synthetic modifier transition event
+	// ("__modifier_<name>_<down|up>"), used for sticky-modifier tracking.
+	ModifierTogglePrefix = "__modifier_"
+)
+
+// Canonical modifier names as they appear in configs, key strings and
+// modifier toggle events.
+const (
+	ModifierCmd   = "cmd"
+	ModifierShift = "shift"
+	ModifierAlt   = "alt"
+	ModifierCtrl  = "ctrl"
+)
+
+const (
+	toggleSuffixDown = "_down"
+	toggleSuffixUp   = "_up"
+)
+
+// NormalizeKey canonicalizes a key string of the form
+// "modifier+...+baseKey": named base keys get their canonical spelling
+// (return/enter -> Return, esc -> Escape, backspace -> Delete, ...) and
+// single-rune base keys are lowercased. Modifier segments pass through
+// untouched. Empty input normalizes to "".
+func NormalizeKey(key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ""
+	}
+
+	parts := strings.Split(key, "+")
+	baseKey := parts[len(parts)-1]
+
+	switch strings.ToLower(baseKey) {
+	case "return", "enter":
+		baseKey = "Return"
+	case "space":
+		baseKey = "Space"
+	case "tab":
+		baseKey = "Tab"
+	case "escape", "esc":
+		baseKey = "Escape"
+	case "backspace":
+		baseKey = "Delete"
+	case "left":
+		baseKey = "Left"
+	case "right":
+		baseKey = "Right"
+	case "up":
+		baseKey = "Up"
+	case "down":
+		baseKey = "Down"
+	default:
+		if len([]rune(baseKey)) == 1 {
+			baseKey = strings.ToLower(baseKey)
+		}
+	}
+
+	parts[len(parts)-1] = baseKey
+
+	return strings.Join(parts, "+")
+}
+
+// CanonicalModifier maps a modifier spelling (including platform aliases:
+// command/super/meta/win -> cmd, option -> alt, control -> ctrl) to its
+// canonical name, or "" when the input is not a modifier.
+func CanonicalModifier(modifier string) string {
+	switch strings.ToLower(strings.TrimSpace(modifier)) {
+	case ModifierCmd, "command", "super", "meta", "win":
+		return ModifierCmd
+	case ModifierShift:
+		return ModifierShift
+	case ModifierAlt, "option":
+		return ModifierAlt
+	case ModifierCtrl, "control":
+		return ModifierCtrl
+	default:
+		return ""
+	}
+}
+
+// KeyUpEvent formats the synthetic key-release event for a pressed key.
+// The event carries only the normalized base key (no modifier prefix), to
+// match how the mode handler tracks held keys. Returns "" for empty input.
+func KeyUpEvent(key string) string {
+	key = NormalizeKey(key)
+	if key == "" {
+		return ""
+	}
+
+	parts := strings.Split(key, "+")
+	baseKey := parts[len(parts)-1]
+
+	return KeyUpPrefix + baseKey
+}
+
+// ModifierToggleEvent formats the synthetic modifier transition event for a
+// modifier press (isDown true) or release. The modifier is canonicalized
+// first; a non-modifier input returns "".
+func ModifierToggleEvent(modifier string, isDown bool) string {
+	modifier = CanonicalModifier(modifier)
+	if modifier == "" {
+		return ""
+	}
+
+	if isDown {
+		return ModifierTogglePrefix + modifier + toggleSuffixDown
+	}
+
+	return ModifierTogglePrefix + modifier + toggleSuffixUp
+}
+
+// ParseModifierToggle decodes a modifier transition event back into its
+// canonical modifier name and direction. ok is false when the input is not a
+// well-formed toggle event for a known modifier.
+func ParseModifierToggle(event string) (string, bool, bool) {
+	if !strings.HasPrefix(event, ModifierTogglePrefix) {
+		return "", false, false
+	}
+
+	body := strings.ToLower(strings.TrimPrefix(event, ModifierTogglePrefix))
+
+	if name, found := strings.CutSuffix(body, toggleSuffixDown); found {
+		if canonical := CanonicalModifier(name); canonical != "" {
+			return canonical, true, true
+		}
+
+		return "", false, false
+	}
+
+	if name, found := strings.CutSuffix(body, toggleSuffixUp); found {
+		if canonical := CanonicalModifier(name); canonical != "" {
+			return canonical, false, true
+		}
+
+		return "", false, false
+	}
+
+	return "", false, false
+}

--- a/internal/domain/keyvocab/keyvocab_test.go
+++ b/internal/domain/keyvocab/keyvocab_test.go
@@ -1,0 +1,153 @@
+package keyvocab_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
+)
+
+const (
+	wantCmd    = "cmd"
+	wantKeyUpJ = "__keyup_j"
+)
+
+func TestNormalizeKey_CanonicalSpellings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "return", in: "return", want: "Return"},
+		{name: "enter aliases to Return", in: "enter", want: "Return"},
+		{name: "enter with modifiers", in: "ctrl+enter", want: "ctrl+Return"},
+		{name: "esc aliases to Escape", in: "esc", want: "Escape"},
+		{name: "backspace maps to Delete", in: "backspace", want: "Delete"},
+		{name: "single rune lowercased", in: "A", want: "a"},
+		{name: "modifiers pass through", in: "cmd+shift+K", want: "cmd+shift+k"},
+		{name: "named keys keep case", in: "Left", want: "Left"},
+		{name: "empty", in: "", want: ""},
+		{name: "whitespace only", in: "   ", want: ""},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := keyvocab.NormalizeKey(testCase.in); got != testCase.want {
+				t.Errorf("NormalizeKey(%q) = %q, want %q", testCase.in, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalModifier_Aliases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: wantCmd, want: wantCmd},
+		{in: "command", want: wantCmd},
+		{in: "super", want: wantCmd},
+		{in: "meta", want: wantCmd},
+		{in: "win", want: wantCmd},
+		{in: "Shift", want: "shift"},
+		{in: "option", want: "alt"},
+		{in: "control", want: "ctrl"},
+		{in: "hyper", want: ""},
+		{in: "", want: ""},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.in, func(t *testing.T) {
+			t.Parallel()
+
+			if got := keyvocab.CanonicalModifier(testCase.in); got != testCase.want {
+				t.Errorf("CanonicalModifier(%q) = %q, want %q", testCase.in, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestKeyUpEvent_UsesNormalizedBaseKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain key", in: "j", want: wantKeyUpJ},
+		{name: "strips modifiers", in: "cmd+shift+J", want: wantKeyUpJ},
+		{name: "named key normalized", in: "enter", want: "__keyup_Return"},
+		{name: "empty", in: "", want: ""},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := keyvocab.KeyUpEvent(testCase.in); got != testCase.want {
+				t.Errorf("KeyUpEvent(%q) = %q, want %q", testCase.in, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestModifierToggleEvent_RoundTripsThroughParse(t *testing.T) {
+	t.Parallel()
+
+	for _, modifier := range []string{wantCmd, "shift", "alt", "ctrl"} {
+		for _, isDown := range []bool{true, false} {
+			event := keyvocab.ModifierToggleEvent(modifier, isDown)
+
+			gotModifier, gotDown, ok := keyvocab.ParseModifierToggle(event)
+			if !ok {
+				t.Fatalf("ParseModifierToggle(%q) not ok", event)
+			}
+
+			if gotModifier != modifier || gotDown != isDown {
+				t.Errorf(
+					"round trip of (%s, %t) = (%s, %t)",
+					modifier,
+					isDown,
+					gotModifier,
+					gotDown,
+				)
+			}
+		}
+	}
+}
+
+func TestModifierToggleEvent_AliasAndInvalid(t *testing.T) {
+	t.Parallel()
+
+	if got := keyvocab.ModifierToggleEvent("option", true); got != "__modifier_alt_down" {
+		t.Errorf("ModifierToggleEvent(option, down) = %q, want __modifier_alt_down", got)
+	}
+
+	if got := keyvocab.ModifierToggleEvent("hyper", true); got != "" {
+		t.Errorf("ModifierToggleEvent(hyper, down) = %q, want empty", got)
+	}
+}
+
+func TestParseModifierToggle_Invalid(t *testing.T) {
+	t.Parallel()
+
+	for _, event := range []string{
+		"",
+		"j",
+		"__keyup_j",
+		"__modifier_",
+		"__modifier_hyper_down",
+		"__modifier_cmd_sideways",
+		"__modifier_cmd",
+	} {
+		if _, _, ok := keyvocab.ParseModifierToggle(event); ok {
+			t.Errorf("ParseModifierToggle(%q) ok = true, want false", event)
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR unifies the key and modifier vocabulary that the platform event taps emit and the mode handler consumes. Linux and Windows each carried their own copy of key normalization, modifier canonicalization, and the synthetic key-release / modifier-toggle event formatting, and the wire protocol between the taps and the modes existed only as repeated string literals across Go, C, and Objective-C — kept in sync by a comment.

The duplication had one real user-visible divergence, fixed here: on Windows a hotkey written as `enter` was accepted as an alias for `Return`, while on Linux it was not — the same config behaved differently per platform. Linux now accepts `enter` too. A new guardrail test pins the two native emitters, which cannot share the Go code, to the same wire spelling, so future vocabulary changes fail loudly instead of silently splitting the protocol between languages.

## Configuration changes

No options were added, removed, or renamed. One accepted value widens: on Linux, key bindings may now spell the Return key as `enter` (previously only `return`/`Return` worked there, while `enter` already worked on Windows). Existing configs keep working untouched.

## Related Issues

None — third item of the phase 2 dedup work from the contributor-experience audit (follows #1158, #1159).

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] Linux
- [x] Windows

## Type of Change

- [x] `refactor` — Code restructuring (no behavior change)

Behavior notes: Linux gains the `enter` alias (strictly widening); a malformed modifier-toggle event now parses as a plain failure with zero values instead of leaking half-parsed state (previously pinned by a test as explicitly undefined).

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no capability surface changed

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build) — lint, Docker `lint-cross` with full CGO (0 issues), vet, build, unit suite, and the full Linux test suite via `just test-linux` run locally; `-race`/integration passes run in CI
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no documented interface changed (the `enter` alias matches what docs already imply cross-platform)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The new domain package owns canonical modifier names (`cmd`/`shift`/`alt`/`ctrl` plus platform aliases), key-string normalization, and formatting/parsing of the `__keyup_`/`__modifier_` synthetic events. The two emitters that cannot import it — the Wayland C overlay and the macOS Objective-C event tap, which format events with printf — are pinned by the new architecture test rather than generated headers; the test names the files explicitly and tells you to update it if an emitter moves. The per-platform alias table used by Linux global hotkeys keeps its slightly wider vocabulary (e.g. `primary`) and is untouched.
