### PR TITLE
refactor(overlay): extract shared badge geometry and color math

### DIFF
--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -5,7 +5,6 @@ package linux
 import (
 	"image"
 	"math"
-	"strconv"
 	"strings"
 	"sync"
 	"unsafe"
@@ -13,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/modeindicator"
@@ -766,13 +766,13 @@ func monitorSelectPanelLayout(
 		)
 	}
 
-	labelW := estimateTextWidth(label, labelFont)
-	labelH := estimateTextHeight(labelFont)
+	labelW := badge.EstimateTextWidth(label, labelFont)
+	labelH := badge.EstimateTextHeight(labelFont)
 
 	subW, subH, gap := 0, 0, 0
 	if subtitle != "" {
-		subW = estimateTextWidth(subtitle, subFont)
-		subH = estimateTextHeight(subFont)
+		subW = badge.EstimateTextWidth(subtitle, subFont)
+		subH = badge.EstimateTextHeight(subFont)
 		gap = int(math.Round(float64(monitorSelectLabelGap) * scale))
 	}
 
@@ -843,11 +843,11 @@ type monitorSelectDrawSpec struct {
 
 func newMonitorSelectDrawSpec(style manager.MonitorSelectStyle) monitorSelectDrawSpec {
 	return monitorSelectDrawSpec{
-		backdrop:     parseHexColor(style.BackdropColor),
-		background:   parseHexColor(style.BackgroundColor),
-		border:       parseHexColor(style.BorderColor),
-		text:         parseHexColor(style.TextColor),
-		subtitleText: parseHexColor(style.SubtitleTextColor),
+		backdrop:     badge.ParseHexARGB(style.BackdropColor),
+		background:   badge.ParseHexARGB(style.BackgroundColor),
+		border:       badge.ParseHexARGB(style.BorderColor),
+		text:         badge.ParseHexARGB(style.TextColor),
+		subtitleText: badge.ParseHexARGB(style.SubtitleTextColor),
 		borderWidth:  float64(max(style.BorderWidth, 1)),
 		labelFont:    monitorSelectFontOr(style.FontSize, monitorSelectDefaultFont),
 		subtitleFont: monitorSelectFontOr(style.SubtitleFontSize, monitorSelectDefaultSubFont),
@@ -1038,7 +1038,7 @@ func resolveModeIndicatorAppearance(
 	theme := overlay.ThemeProvider()
 
 	colors := overlayColors{
-		background: parseHexColor(
+		background: badge.ParseHexARGB(
 			modeCfg.BackgroundColor.ForThemeWithOverride(
 				cfg.UI.BackgroundColor,
 				theme,
@@ -1046,7 +1046,7 @@ func resolveModeIndicatorAppearance(
 				config.ModeIndicatorBackgroundColorDark,
 			),
 		),
-		border: parseHexColor(
+		border: badge.ParseHexARGB(
 			modeCfg.BorderColor.ForThemeWithOverride(
 				cfg.UI.BorderColor,
 				theme,
@@ -1054,7 +1054,7 @@ func resolveModeIndicatorAppearance(
 				config.ModeIndicatorBorderColorDark,
 			),
 		),
-		text: parseHexColor(
+		text: badge.ParseHexARGB(
 			modeCfg.TextColor.ForThemeWithOverride(
 				cfg.UI.TextColor,
 				theme,
@@ -1088,21 +1088,21 @@ func resolveStickyIndicatorAppearance(
 	theme := overlay.ThemeProvider()
 
 	colors := overlayColors{
-		background: parseHexColor(
+		background: badge.ParseHexARGB(
 			cfg.BackgroundColor.ForTheme(
 				theme,
 				config.StickyModifiersBackgroundColorLight,
 				config.StickyModifiersBackgroundColorDark,
 			),
 		),
-		border: parseHexColor(
+		border: badge.ParseHexARGB(
 			cfg.BorderColor.ForTheme(
 				theme,
 				config.StickyModifiersBorderColorLight,
 				config.StickyModifiersBorderColorDark,
 			),
 		),
-		text: parseHexColor(
+		text: badge.ParseHexARGB(
 			cfg.TextColor.ForTheme(
 				theme,
 				config.StickyModifiersTextColorLight,
@@ -1124,42 +1124,13 @@ func resolveStickyIndicatorAppearance(
 	return colors, style, true
 }
 
-func resolveAutoPadding(fontSize float64, padding int, horizontal bool) int {
-	if padding >= 0 {
-		return padding
-	}
-
-	if horizontal {
-		return max(int(fontSize*autoPaddingHorizontalMultiplier), autoPaddingMinHorizontal)
-	}
-
-	return max(int(fontSize*autoPaddingVerticalMultiplier), autoPaddingMinVertical)
-}
-
-func estimateTextWidth(text string, fontSize float64) int {
-	return int(math.Ceil(float64(len([]rune(text))) * fontSize * textWidthMultiplier))
-}
-
-func estimateTextHeight(fontSize float64) int {
-	return int(math.Ceil(fontSize * textHeightMultiplier))
-}
-
 func badgeBounds(posX, posY int, text string, style overlayBadgeStyle) image.Rectangle {
-	fontSize := style.fontSize
-	if fontSize <= 0 {
-		fontSize = 14
-	}
-
-	paddingX := resolveAutoPadding(fontSize, style.paddingX, true)
-	paddingY := resolveAutoPadding(fontSize, style.paddingY, false)
-	width := estimateTextWidth(text, fontSize) + paddingX*paddingMultiplier
-	height := estimateTextHeight(fontSize) + paddingY*paddingMultiplier
-
-	return image.Rect(
-		posX+style.offsetX,
-		posY+style.offsetY,
-		posX+style.offsetX+width,
-		posY+style.offsetY+height,
+	return badge.Bounds(
+		posX, posY,
+		style.offsetX, style.offsetY,
+		text,
+		style.fontSize,
+		style.paddingX, style.paddingY,
 	)
 }
 
@@ -1291,26 +1262,4 @@ func expandRect(rect image.Rectangle, amount int) image.Rectangle {
 		rect.Max.X+amount,
 		rect.Max.Y+amount,
 	)
-}
-
-func parseHexColor(value string) uint32 {
-	value = strings.TrimPrefix(strings.TrimSpace(value), "#")
-	switch len(value) {
-	case hexColorLenShort:
-		value = "FF" + strings.Repeat(string(value[0]), hexColorRepeatCount) +
-			strings.Repeat(string(value[1]), hexColorRepeatCount) +
-			strings.Repeat(string(value[2]), hexColorRepeatCount)
-	case hexColorLenNoAlpha:
-		value = "FF" + value
-	case hexColorLenFull:
-	default:
-		return hexColorOpaque
-	}
-
-	parsed, err := strconv.ParseUint(value, 16, 32)
-	if err != nil {
-		return hexColorOpaque
-	}
-
-	return uint32(parsed)
 }

--- a/internal/adapter/overlay/linux/wayland_cgo.go
+++ b/internal/adapter/overlay/linux/wayland_cgo.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	gridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
 	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
@@ -379,8 +380,8 @@ func (o *wlrootsOverlay) DrawHints(
 			)
 			o.drawRect(
 				boundary,
-				parseHexColor(style.BoundaryBackgroundColor()),
-				parseHexColor(style.BoundaryBorderColor()),
+				badge.ParseHexARGB(style.BoundaryBackgroundColor()),
+				badge.ParseHexARGB(style.BoundaryBorderColor()),
 				float64(max(style.BoundaryBorderWidth(), 0)),
 			)
 		}
@@ -391,10 +392,10 @@ func (o *wlrootsOverlay) DrawHints(
 		}
 
 		label := hint.Label()
-		paddingX := resolveAutoPadding(fontSize, style.PaddingX(), true)
-		paddingY := resolveAutoPadding(fontSize, style.PaddingY(), false)
-		badgeWidth := estimateTextWidth(label, fontSize) + paddingX*paddingMultiplier
-		badgeHeight := estimateTextHeight(fontSize) + paddingY*paddingMultiplier
+		paddingX := badge.AutoPadding(fontSize, style.PaddingX(), true)
+		paddingY := badge.AutoPadding(fontSize, style.PaddingY(), false)
+		badgeWidth := badge.EstimateTextWidth(label, fontSize) + paddingX*paddingMultiplier
+		badgeHeight := badge.EstimateTextHeight(fontSize) + paddingY*paddingMultiplier
 
 		radius := style.BorderRadius()
 		if radius < 0 {
@@ -407,25 +408,25 @@ func (o *wlrootsOverlay) DrawHints(
 		// centered horizontally on it and placed above / on / below the center
 		// to match macOS; top/bottom placement also draws a connector arrow
 		// pointing back at the target.
-		badge, arrow, hasArrow := hintBadgePlacement(
+		badgeRect, arrow, hasArrow := hintBadgePlacement(
 			pos, badgeWidth, badgeHeight, radius, style.Placement(),
 		)
 
-		fill := parseHexColor(style.BackgroundColor())
-		border := parseHexColor(style.BorderColor())
+		fill := badge.ParseHexARGB(style.BackgroundColor())
+		border := badge.ParseHexARGB(style.BorderColor())
 		borderWidth := float64(max(style.BorderWidth(), 0))
 
 		// Badge and connector tail are drawn as one filled+stroked outline so
 		// translucent colors don't double-composite at the junction.
 		o.drawHintBadge(
-			badge, float64(radius), hintTailEdge(badge, arrow, hasArrow), arrow,
+			badgeRect, float64(radius), hintTailEdge(badgeRect, arrow, hasArrow), arrow,
 			fill, border, borderWidth,
 		)
 		o.drawTextCentered(
-			label, badge,
+			label, badgeRect,
 			style.FontFamily(),
 			fontSize,
-			parseHexColor(textColor),
+			badge.ParseHexARGB(textColor),
 		)
 	}
 
@@ -486,8 +487,8 @@ func (o *wlrootsOverlay) startMouseActionAnimation(
 ) {
 	startTime := time.Now()
 
-	fillBase := parseHexColor(style.BackgroundColor)
-	borderBase := parseHexColor(style.BorderColor)
+	fillBase := badge.ParseHexARGB(style.BackgroundColor)
+	borderBase := badge.ParseHexARGB(style.BorderColor)
 	lineWidth := float64(max(style.BorderWidth, 0))
 	baseSize := float64(max(style.Size, 1))
 	isSquare := style.Shape == "square"
@@ -963,7 +964,7 @@ func (o *wlrootsOverlay) drawVirtualPointer(vp recursivegridcomponent.VirtualPoi
 		vp.Position.Y+halfSize,
 	)
 	o.drawTextCentered(vpChar, vpBounds, fontName, fontSize,
-		parseHexColor(vp.FillColor))
+		badge.ParseHexARGB(vp.FillColor))
 }
 
 func (o *wlrootsOverlay) redrawGrid() {
@@ -1138,13 +1139,13 @@ func (o *wlrootsOverlay) drawLabelBackground(
 	style recursivegridcomponent.Style,
 ) {
 	fontSize := style.LabelFontSize()
-	paddingX := resolveAutoPadding(fontSize,
+	paddingX := badge.AutoPadding(fontSize,
 		style.LabelBackgroundPaddingX(), true)
-	paddingY := resolveAutoPadding(fontSize,
+	paddingY := badge.AutoPadding(fontSize,
 		style.LabelBackgroundPaddingY(), false)
-	width := estimateTextWidth(label, fontSize) +
+	width := badge.EstimateTextWidth(label, fontSize) +
 		paddingX*paddingMultiplier
-	height := estimateTextHeight(fontSize) +
+	height := badge.EstimateTextHeight(fontSize) +
 		paddingY*paddingMultiplier
 	rect := centeredRect(cell, width, height)
 	o.drawRect(rect, style.LabelBackgroundColorARGB(),

--- a/internal/adapter/overlay/linux/x11_cgo.go
+++ b/internal/adapter/overlay/linux/x11_cgo.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	gridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
 	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
@@ -364,8 +365,8 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 			)
 			o.drawRect(
 				boundary,
-				parseHexColor(style.BoundaryBackgroundColor()),
-				parseHexColor(style.BoundaryBorderColor()),
+				badge.ParseHexARGB(style.BoundaryBackgroundColor()),
+				badge.ParseHexARGB(style.BoundaryBorderColor()),
 				float64(max(style.BoundaryBorderWidth(), 0)),
 			)
 		}
@@ -380,10 +381,10 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 		// renders (which applies the same o.s() factor). Position stays in device
 		// pixels; the badge grows around the target.
 		sfont := fontSize * o.s()
-		paddingX := resolveAutoPadding(sfont, style.PaddingX(), true)
-		paddingY := resolveAutoPadding(sfont, style.PaddingY(), false)
-		badgeWidth := estimateTextWidth(label, sfont) + paddingX*paddingMultiplier
-		badgeHeight := estimateTextHeight(sfont) + paddingY*paddingMultiplier
+		paddingX := badge.AutoPadding(sfont, style.PaddingX(), true)
+		paddingY := badge.AutoPadding(sfont, style.PaddingY(), false)
+		badgeWidth := badge.EstimateTextWidth(label, sfont) + paddingX*paddingMultiplier
+		badgeHeight := badge.EstimateTextHeight(sfont) + paddingY*paddingMultiplier
 
 		radius := style.BorderRadius()
 		if radius < 0 {
@@ -396,25 +397,25 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 		// centered horizontally on it and placed above / on / below the center
 		// to match macOS; top/bottom placement also draws a connector arrow
 		// pointing back at the target.
-		badge, arrow, hasArrow := hintBadgePlacement(
+		badgeRect, arrow, hasArrow := hintBadgePlacement(
 			pos, badgeWidth, badgeHeight, radius, style.Placement(),
 		)
 
-		fill := parseHexColor(style.BackgroundColor())
-		border := parseHexColor(style.BorderColor())
+		fill := badge.ParseHexARGB(style.BackgroundColor())
+		border := badge.ParseHexARGB(style.BorderColor())
 		borderWidth := float64(max(style.BorderWidth(), 0))
 
 		// Badge and connector tail are drawn as one filled+stroked outline so
 		// translucent colors don't double-composite at the junction.
 		o.drawHintBadge(
-			badge, float64(radius), hintTailEdge(badge, arrow, hasArrow), arrow,
+			badgeRect, float64(radius), hintTailEdge(badgeRect, arrow, hasArrow), arrow,
 			fill, border, borderWidth,
 		)
 		o.drawTextCentered(
-			label, badge,
+			label, badgeRect,
 			style.FontFamily(),
 			fontSize,
-			parseHexColor(textColor),
+			badge.ParseHexARGB(textColor),
 		)
 	}
 
@@ -459,8 +460,8 @@ func (o *x11Overlay) startMouseActionAnimation(
 ) {
 	startTime := time.Now()
 
-	fillBase := parseHexColor(style.BackgroundColor)
-	borderBase := parseHexColor(style.BorderColor)
+	fillBase := badge.ParseHexARGB(style.BackgroundColor)
+	borderBase := badge.ParseHexARGB(style.BorderColor)
 	lineWidth := float64(max(style.BorderWidth, 0))
 	baseSize := float64(max(style.Size, 1)) * o.s()
 	isSquare := style.Shape == "square"
@@ -838,7 +839,7 @@ func (o *x11Overlay) drawVirtualPointer(vp recursivegridcomponent.VirtualPointer
 		vp.Position.Y+halfSize,
 	)
 	o.drawTextCentered(vpChar, vpBounds, fontName, fontSize,
-		parseHexColor(vp.FillColor))
+		badge.ParseHexARGB(vp.FillColor))
 }
 
 func (o *x11Overlay) redrawGrid() {
@@ -1017,13 +1018,13 @@ func (o *x11Overlay) drawLabelBackground(
 ) {
 	// Match the scaled font that drawTextCentered renders for the label.
 	fontSize := style.LabelFontSize() * o.s()
-	paddingX := resolveAutoPadding(fontSize,
+	paddingX := badge.AutoPadding(fontSize,
 		style.LabelBackgroundPaddingX(), true)
-	paddingY := resolveAutoPadding(fontSize,
+	paddingY := badge.AutoPadding(fontSize,
 		style.LabelBackgroundPaddingY(), false)
-	width := estimateTextWidth(label, fontSize) +
+	width := badge.EstimateTextWidth(label, fontSize) +
 		paddingX*paddingMultiplier
-	height := estimateTextHeight(fontSize) +
+	height := badge.EstimateTextHeight(fontSize) +
 		paddingY*paddingMultiplier
 	rect := centeredRect(cell, width, height)
 	o.drawRect(rect, style.LabelBackgroundColorARGB(),

--- a/internal/adapter/overlay/render/badge/badge.go
+++ b/internal/adapter/overlay/render/badge/badge.go
@@ -1,0 +1,137 @@
+package badge
+
+import (
+	"image"
+	"math"
+	"strconv"
+	"strings"
+)
+
+const (
+	hexOpaqueWhite = 0xFFFFFFFF
+	hexRepeatCount = 2
+	hexLenShort    = 3
+	hexLenNoAlpha  = 6
+	hexLenFull     = 8
+
+	autoPaddingHorizontalMultiplier = 0.6
+	autoPaddingVerticalMultiplier   = 0.35
+	autoPaddingMinHorizontal        = 6
+	autoPaddingMinVertical          = 4
+	textWidthMultiplier             = 0.7
+	textHeightMultiplier            = 1.4
+	paddingSideCount                = 2
+
+	fallbackFontSize = 14
+
+	halfDivisor = 2
+)
+
+// ParseHexARGB converts a "#RGB", "#RRGGBB" or "#AARRGGBB" color to packed
+// ARGB, returning opaque white for anything it cannot read.
+func ParseHexARGB(value string) uint32 {
+	value = strings.TrimPrefix(strings.TrimSpace(value), "#")
+
+	switch len(value) {
+	case hexLenShort:
+		value = "FF" + strings.Repeat(string(value[0]), hexRepeatCount) +
+			strings.Repeat(string(value[1]), hexRepeatCount) +
+			strings.Repeat(string(value[2]), hexRepeatCount)
+	case hexLenNoAlpha:
+		value = "FF" + value
+	case hexLenFull:
+	default:
+		return hexOpaqueWhite
+	}
+
+	parsed, err := strconv.ParseUint(value, 16, 32)
+	if err != nil {
+		return hexOpaqueWhite
+	}
+
+	return uint32(parsed)
+}
+
+// AutoPadding resolves a configured padding value against the font size.
+// Non-negative values are used as-is; negative values select an automatic
+// padding proportional to the font size with a floor.
+func AutoPadding(fontSize float64, padding int, horizontal bool) int {
+	if padding >= 0 {
+		return padding
+	}
+
+	if horizontal {
+		return max(int(fontSize*autoPaddingHorizontalMultiplier), autoPaddingMinHorizontal)
+	}
+
+	return max(int(fontSize*autoPaddingVerticalMultiplier), autoPaddingMinVertical)
+}
+
+// EstimateTextWidth estimates the rendered width of text at the given font
+// size, using the same rune-count heuristic on every platform.
+func EstimateTextWidth(text string, fontSize float64) int {
+	return int(math.Ceil(float64(len([]rune(text))) * fontSize * textWidthMultiplier))
+}
+
+// EstimateTextHeight estimates the rendered line height at the given font size.
+func EstimateTextHeight(fontSize float64) int {
+	return int(math.Ceil(fontSize * textHeightMultiplier))
+}
+
+// Size returns the outer badge width and height for text at the given font
+// size, applying auto padding on both axes.
+func Size(text string, fontSize float64, paddingX, paddingY int) (int, int) {
+	resolvedX := AutoPadding(fontSize, paddingX, true)
+	resolvedY := AutoPadding(fontSize, paddingY, false)
+
+	width := EstimateTextWidth(text, fontSize) + resolvedX*paddingSideCount
+	height := EstimateTextHeight(fontSize) + resolvedY*paddingSideCount
+
+	return width, height
+}
+
+// Bounds returns the badge rectangle anchored at (posX+offsetX, posY+offsetY)
+// and sized by Size. A non-positive font size falls back to a readable
+// default.
+func Bounds(
+	posX, posY, offsetX, offsetY int,
+	text string,
+	fontSize float64,
+	paddingX, paddingY int,
+) image.Rectangle {
+	if fontSize <= 0 {
+		fontSize = fallbackFontSize
+	}
+
+	width, height := Size(text, fontSize, paddingX, paddingY)
+
+	return image.Rect(
+		posX+offsetX,
+		posY+offsetY,
+		posX+offsetX+width,
+		posY+offsetY+height,
+	)
+}
+
+// BorderRadius resolves a configured border-radius value for the given
+// rectangle. Negative values select an automatic radius: autoCap limits the
+// auto-radius for badge-style corners (e.g. 6 px for hint badges); pass 0 for
+// a full pill shape (label backgrounds). Zero means sharp corners. Positive
+// values are clamped to half the smaller dimension.
+func BorderRadius(configured int, bounds image.Rectangle, autoCap float64) float64 {
+	maxRadius := float64(min(bounds.Dx(), bounds.Dy())) / halfDivisor
+
+	if configured < 0 {
+		if autoCap > 0 {
+			return min(maxRadius, autoCap)
+		}
+
+		return maxRadius
+	}
+
+	if configured == 0 {
+		return 0
+	}
+
+	return min(float64(configured), maxRadius)
+}

--- a/internal/adapter/overlay/render/badge/badge_test.go
+++ b/internal/adapter/overlay/render/badge/badge_test.go
@@ -1,0 +1,110 @@
+package badge_test
+
+import (
+	"image"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
+)
+
+const opaqueWhite = 0xFFFFFFFF
+
+func TestParseHexARGB_Notations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want uint32
+	}{
+		{name: "short RGB expands", in: "#abc", want: 0xFFAABBCC},
+		{name: "RRGGBB gets opaque alpha", in: "#102030", want: 0xFF102030},
+		{name: "AARRGGBB kept verbatim", in: "#80102030", want: 0x80102030},
+		{name: "no hash accepted", in: "102030", want: 0xFF102030},
+		{name: "whitespace trimmed", in: "  #102030  ", want: 0xFF102030},
+		{name: "bad length falls back to white", in: "#1020", want: opaqueWhite},
+		{name: "bad digits fall back to white", in: "#10203G", want: opaqueWhite},
+		{name: "empty falls back to white", in: "", want: opaqueWhite},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := badge.ParseHexARGB(testCase.in); got != testCase.want {
+				t.Errorf("ParseHexARGB(%q) = %#x, want %#x", testCase.in, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestAutoPadding_ExplicitAndAuto(t *testing.T) {
+	t.Parallel()
+
+	if got := badge.AutoPadding(20, 9, true); got != 9 {
+		t.Errorf("explicit padding = %d, want 9", got)
+	}
+
+	if got := badge.AutoPadding(20, -1, true); got != 12 {
+		t.Errorf("auto horizontal at 20pt = %d, want 12 (20*0.6)", got)
+	}
+
+	if got := badge.AutoPadding(20, -1, false); got != 7 {
+		t.Errorf("auto vertical at 20pt = %d, want 7 (20*0.35)", got)
+	}
+
+	// Floors apply for tiny fonts.
+	if got := badge.AutoPadding(4, -1, true); got != 6 {
+		t.Errorf("auto horizontal floor = %d, want 6", got)
+	}
+
+	if got := badge.AutoPadding(4, -1, false); got != 4 {
+		t.Errorf("auto vertical floor = %d, want 4", got)
+	}
+}
+
+func TestBounds_AnchorsAndFallbackFontSize(t *testing.T) {
+	t.Parallel()
+
+	got := badge.Bounds(100, 200, 10, 20, "ab", 10, 0, 0)
+
+	wantW := badge.EstimateTextWidth("ab", 10)
+	wantH := badge.EstimateTextHeight(10)
+	want := image.Rect(110, 220, 110+wantW, 220+wantH)
+
+	if got != want {
+		t.Errorf("Bounds = %v, want %v", got, want)
+	}
+
+	// Non-positive font size must not produce a zero-size badge.
+	fallback := badge.Bounds(0, 0, 0, 0, "ab", 0, -1, -1)
+	if fallback.Dx() == 0 || fallback.Dy() == 0 {
+		t.Errorf("Bounds with zero font size = %v, want non-empty", fallback)
+	}
+}
+
+func TestBorderRadius_Modes(t *testing.T) {
+	t.Parallel()
+
+	bounds := image.Rect(0, 0, 40, 20)
+
+	if got := badge.BorderRadius(0, bounds, 6); got != 0 {
+		t.Errorf("zero radius = %v, want 0 (sharp corners)", got)
+	}
+
+	if got := badge.BorderRadius(-1, bounds, 6); got != 6 {
+		t.Errorf("auto radius with cap = %v, want 6", got)
+	}
+
+	if got := badge.BorderRadius(-1, bounds, 0); got != 10 {
+		t.Errorf("auto radius uncapped = %v, want 10 (half the smaller side)", got)
+	}
+
+	if got := badge.BorderRadius(50, bounds, 0); got != 10 {
+		t.Errorf("oversized radius = %v, want clamp to 10", got)
+	}
+
+	if got := badge.BorderRadius(4, bounds, 0); got != 4 {
+		t.Errorf("explicit radius = %v, want 4", got)
+	}
+}

--- a/internal/adapter/overlay/render/badge/doc.go
+++ b/internal/adapter/overlay/render/badge/doc.go
@@ -1,0 +1,8 @@
+// Package badge holds the platform-neutral geometry and color math shared by
+// the overlay badge renderers: indicator badges, hint labels and grid text
+// backgrounds all size themselves from the same font-based estimates and read
+// colors from the same hex notation. The Linux (Cairo) and Windows (GDI)
+// managers and the shared render styles all call into here; keeping the math
+// in one place keeps badge sizing and color parsing identical across
+// platforms.
+package badge

--- a/internal/adapter/overlay/render/grid/style.go
+++ b/internal/adapter/overlay/render/grid/style.go
@@ -1,9 +1,7 @@
 package grid
 
 import (
-	"strconv"
-	"strings"
-
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/ports"
 )
@@ -12,12 +10,6 @@ const (
 	// minLineWidth keeps a hairline visible on backends that would otherwise
 	// round a zero-width stroke away.
 	minLineWidth = 1
-
-	invalidColor = 0xFFFFFFFF
-	hexPairCount = 2
-	colorLen3    = 3
-	colorLen6    = 6
-	colorLen8    = 8
 )
 
 // Style is the resolved visual styling for the grid overlay.
@@ -138,37 +130,12 @@ func BuildStyle(cfg config.GridConfig, theme config.ThemeProvider) Style {
 		showLabels: true,
 	}
 
-	style.backgroundColorARGB = parseHexARGB(style.backgroundColor)
-	style.textColorARGB = parseHexARGB(style.textColor)
-	style.matchedTextColorARGB = parseHexARGB(style.matchedTextColor)
-	style.matchedBackgroundColorARGB = parseHexARGB(style.matchedBackgroundColor)
-	style.matchedBorderColorARGB = parseHexARGB(style.matchedBorderColor)
-	style.borderColorARGB = parseHexARGB(style.borderColor)
+	style.backgroundColorARGB = badge.ParseHexARGB(style.backgroundColor)
+	style.textColorARGB = badge.ParseHexARGB(style.textColor)
+	style.matchedTextColorARGB = badge.ParseHexARGB(style.matchedTextColor)
+	style.matchedBackgroundColorARGB = badge.ParseHexARGB(style.matchedBackgroundColor)
+	style.matchedBorderColorARGB = badge.ParseHexARGB(style.matchedBorderColor)
+	style.borderColorARGB = badge.ParseHexARGB(style.borderColor)
 
 	return style
-}
-
-// parseHexARGB converts a "#RGB", "#RRGGBB" or "#AARRGGBB" color to packed
-// ARGB, returning opaque white for anything it cannot read.
-func parseHexARGB(value string) uint32 {
-	value = strings.TrimPrefix(strings.TrimSpace(value), "#")
-
-	switch len(value) {
-	case colorLen3:
-		value = "FF" + strings.Repeat(string(value[0]), hexPairCount) +
-			strings.Repeat(string(value[1]), hexPairCount) +
-			strings.Repeat(string(value[2]), hexPairCount)
-	case colorLen6:
-		value = "FF" + value
-	case colorLen8:
-	default:
-		return invalidColor
-	}
-
-	parsed, err := strconv.ParseUint(value, 16, 32)
-	if err != nil {
-		return invalidColor
-	}
-
-	return uint32(parsed)
 }

--- a/internal/adapter/overlay/render/grid/style_test.go
+++ b/internal/adapter/overlay/render/grid/style_test.go
@@ -4,6 +4,7 @@ package grid
 import (
 	"testing"
 
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	"github.com/y3owk1n/neru/internal/config"
 )
 
@@ -92,7 +93,7 @@ func TestStyle_ARGBAccessorsMatchTheHexValues(t *testing.T) {
 	}
 
 	for _, pair := range pairs {
-		if want := parseHexARGB(pair.hex); pair.argb != want {
+		if want := badge.ParseHexARGB(pair.hex); pair.argb != want {
 			t.Errorf("%s ARGB = %#08x, want %#08x (from %q)", pair.name, pair.argb, want, pair.hex)
 		}
 	}

--- a/internal/adapter/overlay/render/recursivegrid/style.go
+++ b/internal/adapter/overlay/render/recursivegrid/style.go
@@ -1,21 +1,13 @@
 package recursivegrid
 
 import (
-	"strconv"
-	"strings"
-
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
 const (
 	minLineWidth = 1
-
-	invalidColor = 0xFFFFFFFF
-	hexPairCount = 2
-	colorLen3    = 3
-	colorLen6    = 6
-	colorLen8    = 8
 )
 
 // Style is the resolved visual styling for the recursive-grid overlay.
@@ -288,36 +280,11 @@ func (s Style) ShowLabels() bool { return true }
 // as their last step, so no caller can produce a Style whose packed values
 // disagree with its hex ones.
 func (s Style) packColors() Style {
-	s.lineColorARGB = parseHexARGB(s.lineColor)
-	s.highlightColorARGB = parseHexARGB(s.highlightColor)
-	s.textColorARGB = parseHexARGB(s.textColor)
-	s.labelBackgroundColorARGB = parseHexARGB(s.labelBackgroundColor)
-	s.subKeyPreviewTextColorARGB = parseHexARGB(s.subKeyPreviewTextColor)
+	s.lineColorARGB = badge.ParseHexARGB(s.lineColor)
+	s.highlightColorARGB = badge.ParseHexARGB(s.highlightColor)
+	s.textColorARGB = badge.ParseHexARGB(s.textColor)
+	s.labelBackgroundColorARGB = badge.ParseHexARGB(s.labelBackgroundColor)
+	s.subKeyPreviewTextColorARGB = badge.ParseHexARGB(s.subKeyPreviewTextColor)
 
 	return s
-}
-
-// parseHexARGB converts a "#RGB", "#RRGGBB" or "#AARRGGBB" color to packed
-// ARGB, returning opaque white for anything it cannot read.
-func parseHexARGB(value string) uint32 {
-	value = strings.TrimPrefix(strings.TrimSpace(value), "#")
-
-	switch len(value) {
-	case colorLen3:
-		value = "FF" + strings.Repeat(string(value[0]), hexPairCount) +
-			strings.Repeat(string(value[1]), hexPairCount) +
-			strings.Repeat(string(value[2]), hexPairCount)
-	case colorLen6:
-		value = "FF" + value
-	case colorLen8:
-	default:
-		return invalidColor
-	}
-
-	parsed, err := strconv.ParseUint(value, 16, 32)
-	if err != nil {
-		return invalidColor
-	}
-
-	return uint32(parsed)
 }

--- a/internal/adapter/overlay/render/recursivegrid/style_test.go
+++ b/internal/adapter/overlay/render/recursivegrid/style_test.go
@@ -4,6 +4,7 @@ package recursivegrid
 import (
 	"testing"
 
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	"github.com/y3owk1n/neru/internal/config"
 )
 
@@ -107,7 +108,7 @@ func TestStyle_ARGBAccessorsMatchTheHexValues(t *testing.T) {
 	}
 
 	for _, pair := range pairs {
-		if want := parseHexARGB(pair.hex); pair.argb != want {
+		if want := badge.ParseHexARGB(pair.hex); pair.argb != want {
 			t.Errorf("%s ARGB = %#08x, want %#08x (from %q)", pair.name, pair.argb, want, pair.hex)
 		}
 	}

--- a/internal/adapter/overlay/windows/features.go
+++ b/internal/adapter/overlay/windows/features.go
@@ -4,10 +4,9 @@ package windows
 
 import (
 	"image"
-	"math"
-	"strconv"
 	"strings"
 
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
 	"github.com/y3owk1n/neru/internal/domain/recursivegrid"
@@ -82,16 +81,16 @@ func (o *winOverlay) DrawHints(
 				hint.Position().X+hint.Size().X/2,
 				hint.Position().Y+hint.Size().Y/2,
 			)
-			bdr := resolveWinBorderRadius(
+			bdr := badge.BorderRadius(
 				style.BoundaryBorderRadius(), boundary, winAutoRadiusBoundaryCap,
 			)
 			o.window.FillRoundedRect(
-				boundary, bdr, parseHexColorARGB(style.BoundaryBackgroundColor()),
+				boundary, bdr, badge.ParseHexARGB(style.BoundaryBackgroundColor()),
 			)
 
 			if bw := float64(max(style.BoundaryBorderWidth(), 0)); bw > 0 {
 				o.window.StrokeRoundedRect(
-					boundary, bdr, parseHexColorARGB(style.BoundaryBorderColor()), bw,
+					boundary, bdr, badge.ParseHexARGB(style.BoundaryBorderColor()), bw,
 				)
 			}
 		}
@@ -100,10 +99,13 @@ func (o *winOverlay) DrawHints(
 		// element's bounding box (hint.Bounds().Size()), so using it makes the
 		// badge as large as the element (e.g. oversized boxes over big buttons).
 		fontSize := float64(max(style.FontSize(), 1))
-		paddingX := resolveWinAutoPadding(fontSize, style.PaddingX(), true)
-		paddingY := resolveWinAutoPadding(fontSize, style.PaddingY(), false)
-		badgeWidth := estimateWinTextWidth(hint.Label(), fontSize) + paddingX*winPaddingMultiplier
-		badgeHeight := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
+		paddingX := badge.AutoPadding(fontSize, style.PaddingX(), true)
+		paddingY := badge.AutoPadding(fontSize, style.PaddingY(), false)
+		badgeWidth := badge.EstimateTextWidth(
+			hint.Label(),
+			fontSize,
+		) + paddingX*winPaddingMultiplier
+		badgeHeight := badge.EstimateTextHeight(fontSize) + paddingY*winPaddingMultiplier
 
 		// Anchor the badge at the element's top-left corner rather than its
 		// center so it does not cover the element's own content (e.g. the digit
@@ -118,14 +120,14 @@ func (o *winOverlay) DrawHints(
 			textColor = style.MatchedTextColor()
 		}
 
-		bdr := resolveWinBorderRadius(style.BorderRadius(), bounds, winAutoRadiusBadgeCap)
+		bdr := badge.BorderRadius(style.BorderRadius(), bounds, winAutoRadiusBadgeCap)
 		o.window.FillRoundedRect(
-			bounds, bdr, parseHexColorARGB(style.BackgroundColor()),
+			bounds, bdr, badge.ParseHexARGB(style.BackgroundColor()),
 		)
 
 		if bw := float64(max(style.BorderWidth(), 0)); bw > 0 {
 			o.window.StrokeRoundedRect(
-				bounds, bdr, parseHexColorARGB(style.BorderColor()), bw,
+				bounds, bdr, badge.ParseHexARGB(style.BorderColor()), bw,
 			)
 		}
 
@@ -134,7 +136,7 @@ func (o *winOverlay) DrawHints(
 			bounds,
 			ports.ResolveFont(style.FontFamily(), false),
 			fontSize,
-			parseHexColorARGB(textColor),
+			badge.ParseHexARGB(textColor),
 		)
 
 		// Composite this hint atomically so its content lands as a unit,
@@ -240,7 +242,7 @@ func (o *winOverlay) DrawRecursiveGrid(
 			vpBounds,
 			fontName,
 			fontSize,
-			parseHexColorARGB(virtualPointer.FillColor),
+			badge.ParseHexARGB(virtualPointer.FillColor),
 		)
 	}
 
@@ -274,10 +276,10 @@ func (o *winOverlay) drawRecursiveLabelBackground(
 	style recursivegridcomponent.Style,
 ) {
 	fontSize := style.LabelFontSize()
-	paddingX := resolveWinAutoPadding(fontSize, style.LabelBackgroundPaddingX(), true)
-	paddingY := resolveWinAutoPadding(fontSize, style.LabelBackgroundPaddingY(), false)
-	width := estimateWinTextWidth(label, fontSize) + paddingX*winPaddingMultiplier
-	height := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
+	paddingX := badge.AutoPadding(fontSize, style.LabelBackgroundPaddingX(), true)
+	paddingY := badge.AutoPadding(fontSize, style.LabelBackgroundPaddingY(), false)
+	width := badge.EstimateTextWidth(label, fontSize) + paddingX*winPaddingMultiplier
+	height := badge.EstimateTextHeight(fontSize) + paddingY*winPaddingMultiplier
 	rect := winCenteredRect(cell, width, height)
 
 	o.drawFilledRect(
@@ -285,7 +287,7 @@ func (o *winOverlay) drawRecursiveLabelBackground(
 		style.LabelBackgroundColorARGB(),
 		style.LineColorARGB(),
 		max(style.LabelBackgroundBorderWidthF(), 0),
-		resolveWinBorderRadius(style.LabelBackgroundBorderRadius(), rect, 0),
+		badge.BorderRadius(style.LabelBackgroundBorderRadius(), rect, 0),
 	)
 }
 
@@ -301,7 +303,7 @@ func (o *winOverlay) drawRecursiveSubKeyPreview(
 
 	previewRect := image.Rect(
 		cell.Min.X,
-		cell.Max.Y-estimateWinTextHeight(
+		cell.Max.Y-badge.EstimateTextHeight(
 			style.SubKeyPreviewFontSizeF(),
 		)-winSubKeyPreviewPaddingBottom,
 		cell.Max.X,
@@ -341,49 +343,6 @@ func shouldShowWinSubKeyPreview(cell image.Rectangle, style recursivegridcompone
 	return float64(cell.Dx()) >= threshold && float64(cell.Dy()) >= threshold
 }
 
-func resolveWinAutoPadding(fontSize float64, padding int, horizontal bool) int {
-	if padding >= 0 {
-		return padding
-	}
-
-	if horizontal {
-		return max(int(fontSize*winAutoPaddingHorizontalMultiplier), winAutoPaddingMinHorizontal)
-	}
-
-	return max(int(fontSize*winAutoPaddingVerticalMultiplier), winAutoPaddingMinVertical)
-}
-
-// resolveWinBorderRadius resolves a configured border-radius value for the
-// given rectangle. Negative values select an automatic radius: autoCap limits
-// the auto-radius for badge-style corners (e.g. 6 px for hint badges); pass 0
-// for a full pill shape (label backgrounds). Zero means sharp corners.
-// Positive values are clamped to half the smaller dimension.
-func resolveWinBorderRadius(configured int, bounds image.Rectangle, autoCap float64) float64 {
-	maxR := float64(min(bounds.Dx(), bounds.Dy())) / 2 //nolint:mnd // half the smaller dimension
-
-	if configured < 0 {
-		if autoCap > 0 {
-			return min(maxR, autoCap)
-		}
-
-		return maxR
-	}
-
-	if configured == 0 {
-		return 0
-	}
-
-	return min(float64(configured), maxR)
-}
-
-func estimateWinTextWidth(text string, fontSize float64) int {
-	return int(math.Ceil(float64(len([]rune(text))) * fontSize * winTextWidthMultiplier))
-}
-
-func estimateWinTextHeight(fontSize float64) int {
-	return int(math.Ceil(fontSize * winTextHeightMultiplier))
-}
-
 func winCenteredRect(cell image.Rectangle, width, height int) image.Rectangle {
 	centerX := cell.Min.X + cell.Dx()/winCenteredRectDivisor
 	centerY := cell.Min.Y + cell.Dy()/winCenteredRectDivisor
@@ -394,26 +353,4 @@ func winCenteredRect(cell image.Rectangle, width, height int) image.Rectangle {
 		centerX-width/winCenteredRectDivisor+width,
 		centerY-height/winCenteredRectDivisor+height,
 	)
-}
-
-func parseHexColorARGB(value string) uint32 {
-	value = strings.TrimPrefix(strings.TrimSpace(value), "#")
-	switch len(value) {
-	case winHexColorLenShort:
-		value = "FF" + strings.Repeat(string(value[0]), winHexRepeatCount) +
-			strings.Repeat(string(value[1]), winHexRepeatCount) +
-			strings.Repeat(string(value[2]), winHexRepeatCount)
-	case winHexColorLenNoAlpha:
-		value = "FF" + value
-	case winHexColorLenFull:
-	default:
-		return winHexColorOpaque
-	}
-
-	parsed, err := strconv.ParseUint(value, 16, 32)
-	if err != nil {
-		return winHexColorOpaque
-	}
-
-	return uint32(parsed)
 }

--- a/internal/adapter/overlay/windows/features_test.go
+++ b/internal/adapter/overlay/windows/features_test.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"testing"
 
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
 	"github.com/y3owk1n/neru/internal/config"
 )
@@ -31,9 +32,12 @@ func TestEstimateWinTextWidth(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := estimateWinTextWidth(testCase.text, testCase.fontSize); got != testCase.want {
+			if got := badge.EstimateTextWidth(
+				testCase.text,
+				testCase.fontSize,
+			); got != testCase.want {
 				t.Fatalf(
-					"estimateWinTextWidth(%q, %v) = %d, want %d",
+					"badge.EstimateTextWidth(%q, %v) = %d, want %d",
 					testCase.text,
 					testCase.fontSize,
 					got,
@@ -61,9 +65,9 @@ func TestEstimateWinTextHeight(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := estimateWinTextHeight(testCase.fontSize); got != testCase.want {
+			if got := badge.EstimateTextHeight(testCase.fontSize); got != testCase.want {
 				t.Fatalf(
-					"estimateWinTextHeight(%v) = %d, want %d",
+					"badge.EstimateTextHeight(%v) = %d, want %d",
 					testCase.fontSize,
 					got,
 					testCase.want,
@@ -95,9 +99,9 @@ func TestResolveWinAutoPadding(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := resolveWinAutoPadding(testCase.fontSize, testCase.padding, testCase.horizontal)
+			got := badge.AutoPadding(testCase.fontSize, testCase.padding, testCase.horizontal)
 			if got != testCase.want {
-				t.Fatalf("resolveWinAutoPadding(%v, %d, %v) = %d, want %d",
+				t.Fatalf("badge.AutoPadding(%v, %d, %v) = %d, want %d",
 					testCase.fontSize, testCase.padding, testCase.horizontal, got, testCase.want)
 			}
 		})
@@ -143,9 +147,9 @@ func TestParseHexColorARGB(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := parseHexColorARGB(testCase.value); got != testCase.want {
+			if got := badge.ParseHexARGB(testCase.value); got != testCase.want {
 				t.Fatalf(
-					"parseHexColorARGB(%q) = 0x%08X, want 0x%08X",
+					"badge.ParseHexARGB(%q) = 0x%08X, want 0x%08X",
 					testCase.value,
 					got,
 					testCase.want,

--- a/internal/adapter/overlay/windows/manager.go
+++ b/internal/adapter/overlay/windows/manager.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
@@ -291,8 +292,8 @@ func (m *Manager) DrawHintSearchInput(
 	width := frame.Width()
 
 	fontSize := float64(max(style.FontSize(), 1))
-	paddingX := resolveWinAutoPadding(fontSize, style.PaddingX(), true)
-	paddingY := resolveWinAutoPadding(fontSize, style.PaddingY(), false)
+	paddingX := badge.AutoPadding(fontSize, style.PaddingX(), true)
+	paddingY := badge.AutoPadding(fontSize, style.PaddingY(), false)
 
 	// / query  count /  format
 	label := "/ " + query
@@ -302,23 +303,23 @@ func (m *Manager) DrawHintSearchInput(
 		label += " /"
 	}
 
-	badgeWidth := estimateWinTextWidth(label, fontSize) + paddingX*winPaddingMultiplier
-	badgeHeight := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
+	badgeWidth := badge.EstimateTextWidth(label, fontSize) + paddingX*winPaddingMultiplier
+	badgeHeight := badge.EstimateTextHeight(fontSize) + paddingY*winPaddingMultiplier
 	bounds := image.Rect(pos.X, pos.Y, pos.X+max(badgeWidth, width), pos.Y+badgeHeight)
 
 	m.win.drawFilledRect(
 		bounds,
-		parseHexColorARGB(style.BackgroundColor()),
-		parseHexColorARGB(style.BorderColor()),
+		badge.ParseHexARGB(style.BackgroundColor()),
+		badge.ParseHexARGB(style.BorderColor()),
 		float64(max(style.BorderWidth(), 0)),
-		resolveWinBorderRadius(style.BorderRadius(), bounds, winAutoRadiusBadgeCap),
+		badge.BorderRadius(style.BorderRadius(), bounds, winAutoRadiusBadgeCap),
 	)
 	m.win.drawTextCentered(
 		label,
 		bounds,
 		style.FontFamily(),
 		fontSize,
-		parseHexColorARGB(style.TextColor()),
+		badge.ParseHexARGB(style.TextColor()),
 	)
 
 	m.win.flushOverlay("search-input")
@@ -370,10 +371,10 @@ func (m *Manager) DrawModeIndicator(cursorX, cursorY int) {
 	offsetY := cfg.UI.IndicatorYOffset
 	fontSize := float64(max(cfg.UI.FontSize, 1))
 
-	paddingX := resolveWinAutoPadding(fontSize, cfg.UI.PaddingX, true)
-	paddingY := resolveWinAutoPadding(fontSize, cfg.UI.PaddingY, false)
-	badgeWidth := estimateWinTextWidth(label, fontSize) + paddingX*winPaddingMultiplier
-	badgeHeight := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
+	paddingX := badge.AutoPadding(fontSize, cfg.UI.PaddingX, true)
+	paddingY := badge.AutoPadding(fontSize, cfg.UI.PaddingY, false)
+	badgeWidth := badge.EstimateTextWidth(label, fontSize) + paddingX*winPaddingMultiplier
+	badgeHeight := badge.EstimateTextHeight(fontSize) + paddingY*winPaddingMultiplier
 	borderWidth := max(cfg.UI.BorderWidth, 0)
 
 	posX := cursorX + offsetX - borderWidth
@@ -432,14 +433,14 @@ func (m *Manager) DrawModeIndicator(cursorX, cursorY int) {
 		badgeHeight+borderWidth,
 	)
 
-	indicatorRadius := resolveWinBorderRadius(
+	indicatorRadius := badge.BorderRadius(
 		cfg.UI.BorderRadius, badgeBounds, winAutoRadiusBadgeCap,
 	)
-	m.indicatorWin.FillRoundedRect(badgeBounds, indicatorRadius, parseHexColorARGB(bgColor))
+	m.indicatorWin.FillRoundedRect(badgeBounds, indicatorRadius, badge.ParseHexARGB(bgColor))
 
 	if borderWidth > 0 {
 		m.indicatorWin.StrokeRoundedRect(
-			badgeBounds, indicatorRadius, parseHexColorARGB(borderColor), float64(borderWidth),
+			badgeBounds, indicatorRadius, badge.ParseHexARGB(borderColor), float64(borderWidth),
 		)
 	}
 
@@ -448,7 +449,7 @@ func (m *Manager) DrawModeIndicator(cursorX, cursorY int) {
 		badgeBounds,
 		ports.ResolveFont(cfg.UI.FontFamily, true),
 		fontSize,
-		parseHexColorARGB(textColor),
+		badge.ParseHexARGB(textColor),
 	)
 
 	// Flush composites fills/strokes/texts into the pixel buffer and sends
@@ -475,10 +476,10 @@ func (m *Manager) DrawStickyModifiersIndicator(cursorX, cursorY int, symbols str
 	indicatorUI := m.StickyModifiersOverlay().UIConfig()
 	fontSize := float64(max(indicatorUI.FontSize, 1))
 
-	paddingX := resolveWinAutoPadding(fontSize, indicatorUI.PaddingX, true)
-	paddingY := resolveWinAutoPadding(fontSize, indicatorUI.PaddingY, false)
-	badgeWidth := estimateWinTextWidth(symbols, fontSize) + paddingX*winPaddingMultiplier
-	badgeHeight := estimateWinTextHeight(fontSize) + paddingY*winPaddingMultiplier
+	paddingX := badge.AutoPadding(fontSize, indicatorUI.PaddingX, true)
+	paddingY := badge.AutoPadding(fontSize, indicatorUI.PaddingY, false)
+	badgeWidth := badge.EstimateTextWidth(symbols, fontSize) + paddingX*winPaddingMultiplier
+	badgeHeight := badge.EstimateTextHeight(fontSize) + paddingY*winPaddingMultiplier
 	borderWidth := max(indicatorUI.BorderWidth, 0)
 
 	offsetX := indicatorUI.IndicatorXOffset
@@ -537,18 +538,18 @@ func (m *Manager) DrawStickyModifiersIndicator(cursorX, cursorY int, symbols str
 		badgeHeight+borderWidth,
 	)
 
-	stickyRadius := resolveWinBorderRadius(
+	stickyRadius := badge.BorderRadius(
 		indicatorUI.BorderRadius,
 		badgeBounds,
 		winAutoRadiusBadgeCap,
 	)
-	m.stickyWin.FillRoundedRect(badgeBounds, stickyRadius, parseHexColorARGB(bgColor))
+	m.stickyWin.FillRoundedRect(badgeBounds, stickyRadius, badge.ParseHexARGB(bgColor))
 
 	if borderWidth > 0 {
 		m.stickyWin.StrokeRoundedRect(
 			badgeBounds,
 			stickyRadius,
-			parseHexColorARGB(borderColor),
+			badge.ParseHexARGB(borderColor),
 			float64(borderWidth),
 		)
 	}
@@ -558,7 +559,7 @@ func (m *Manager) DrawStickyModifiersIndicator(cursorX, cursorY int, symbols str
 		badgeBounds,
 		ports.ResolveFont(indicatorUI.FontFamily, false),
 		fontSize,
-		parseHexColorARGB(textColor),
+		badge.ParseHexARGB(textColor),
 	)
 
 	err := m.stickyWin.Flush()
@@ -890,7 +891,7 @@ func ease(progressFraction float64, easing string) float64 {
 }
 
 func scaleColorAlpha(hexColor string, opacity float64) uint32 {
-	colorVal := parseHexColorARGB(hexColor)
+	colorVal := badge.ParseHexARGB(hexColor)
 	alphaVal := float64((colorVal >> 24) & 0xFF) //nolint:mnd
 	redVal := (colorVal >> 16) & 0xFF            //nolint:mnd
 	greenVal := (colorVal >> 8) & 0xFF           //nolint:mnd


### PR DESCRIPTION
## Description

This PR consolidates the badge math that was copied across the overlay layer. The hex color parser existed as four verbatim copies and the badge sizing heuristics (auto padding, text measurement, bounds, border-radius resolution) as two more per-platform copies with identical constants. Badges exist to look the same on every platform, so their math now lives in one shared, tested package instead of drifting independently.

Pure restructuring — no behavior change on any platform. New tests pin the color notations (`#RGB`, `#RRGGBB`, `#AARRGGBB`, and the opaque-white fallback for anything unreadable) and the geometry rules, which were previously untested on every platform.

## Related Issues

N/A

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] Linux
- [x] Windows

## Type of Change

- [x] `refactor` — Code restructuring (no behavior change)

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no capability surface changed

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build) — lint, Docker `lint-cross` with full CGO (0 issues), vet, build, unit suite, and the full Linux test suite via `just test-linux` run locally; `-race`/integration passes run in CI
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, internal restructuring only
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

N/A
