### PR TITLE
chore(ci): re-verify main after merges and cancel superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,25 @@ on:
             - "CHANGELOG.md"
             - ".release-please-manifest.json"
             - "release-please-config.json"
+    # Re-verify main after every merge: two individually green PRs can merge
+    # into a semantically broken combination, and nightly.yml publishes
+    # artifacts from main without running any tests of its own.
+    push:
+        branches: ["main"]
+        paths-ignore:
+            - "CHANGELOG.md"
+            - ".release-please-manifest.json"
+            - "release-please-config.json"
 name: CI
 permissions:
     contents: read
     pull-requests: read
+# A force-push to a PR branch obsoletes the in-flight run; without a
+# concurrency group each push stacks another full 17-job matrix behind it.
+# Runs on main are never canceled — every merge commit gets a full verdict.
+concurrency:
+    group: ci-${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
     checks:
         name: ${{ matrix.check }} (${{ matrix.os }})
@@ -38,10 +53,11 @@ jobs:
                       check: coverage
         runs-on: ${{ matrix.os }}
         steps:
+            # Default checkout: on pull_request events this tests the merge
+            # commit (PR + main combined), which is what will actually land —
+            # overriding repository/ref to the branch head skips that and is
+            # wrong for fork PRs. On push events it checks out the pushed ref.
             - uses: actions/checkout@v7
-              with:
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
-                  ref: ${{ github.head_ref }}
 
             # Install Linux system dependencies (Wayland, X11, Cairo, etc.)
             # Devbox doesn't pull *-dev outputs (https://github.com/jetify-com/devbox/issues/2761)

--- a/justfile
+++ b/justfile
@@ -491,7 +491,7 @@ check-cross: vet-cross test-windows-compile
 # vulnerability database is fetched at run time regardless.
 vuln:
     @echo "Scanning for known vulnerabilities..."
-    go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+    go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
     @echo "✓ No known vulnerabilities"
 
 # Run unit tests with coverage and print the total.


### PR DESCRIPTION
## Description

This PR closes three gaps in how CI protects the default branch. Until now nothing re-verified `main` after a merge — while the nightly workflow publishes artifacts from `main` without running any tests of its own, so two individually green PRs could merge into a broken combination and ship to the nightly prerelease unnoticed. CI now runs on every push to `main` as well as on PRs.

It also stops wasted and misleading runs: superseded PR runs are canceled when a branch is force-pushed (previously each push stacked another full 17-job matrix), runs on `main` are never canceled, and the checkout no longer overrides the ref to the PR branch head — meaning CI now tests the merge result that would actually land, which is also the correct shape for fork PRs. Finally, the vulnerability scanner is pinned to a fixed version instead of `latest`, so contributors and CI can no longer drift apart between runs.

## Related Issues

N/A

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)

## Type of Change

- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`) — N/A, workflow YAML and one justfile line
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build) — `just vuln` re-run green against the pinned version; YAML parse-validated; no Go code changed
- [x] Tests added/updated for new or changed functionality — N/A, CI configuration
- [x] Documentation updated (if applicable) — N/A
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The `concurrency` group keys on the ref and cancels in-progress runs only when the ref is not `main`, so merge commits always get a complete verdict. The `push: main` trigger carries the same `paths-ignore` as the PR trigger (changelog/manifest bumps from release automation don't re-run the matrix). `govulncheck` is pinned at `v1.6.0` — the current latest — and verified passing; bumping it in the future is a one-line justfile change that CI will validate.

One observation for a future PR rather than this one: the macOS `test` leg runs the integration suite on runners that have no Accessibility permission — whatever passes there passes for undocumented reasons. Splitting CI's test target into unit-everywhere / integration-where-meaningful deserves its own change.
