### PR TITLE
chore(lint): retire de-facto rejected linters and write the nolint policy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,8 @@ linters:
         - wrapcheck # Too strict
         - wsl # Deprecated
         - interfacebloat # Complex application with legitimate large interfaces
+        - nlreturn # De-facto rejected: it had accumulated 195 nolints before being disabled
+        - testpackage # In-package tests are used deliberately; it had accumulated 66 nolints
 
     settings:
         depguard:
@@ -120,5 +122,7 @@ linters:
                   disabled: false
 
 issues:
-    max-issues-per-linter: 0
-    max-same-issues: 0
+    # Bounded so a first lint run on a nonconforming branch is a readable
+    # report, not an unbounded wall. CI re-runs until clean either way.
+    max-issues-per-linter: 50
+    max-same-issues: 10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,14 @@ recommended path and provides every tool pre-configured.
    [documentation checklist](docs/CROSS_PLATFORM.md#documentation-checklist)
    says which file owns what, so please update the owner rather than restating
    it in a second place.
+
+    **On linters:** the linter set is strict on purpose, and `//nolint` is the
+    escape hatch, not the default. Use one only when the finding is a genuine
+    false positive or the compliant form would be clearly worse — always
+    with the specific linter named and a trailing `// reason`. If you find
+    yourself suppressing the same linter repeatedly, that linter may be wrong
+    for this codebase: propose disabling it in `.golangci.yml` (with the
+    reason recorded there) instead of scattering suppressions.
 7. **Commit** using [conventional commits](#commit-messages), then push and open
    a pull request.
 

--- a/internal/adapter/accessibility/adapter_concurrent_test.go
+++ b/internal/adapter/accessibility/adapter_concurrent_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage
 package accessibility
 
 import (

--- a/internal/adapter/accessibility/atspi/client_test.go
+++ b/internal/adapter/accessibility/atspi/client_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage // Exercises the unexported app_id matching helpers directly.
 package atspi
 
 import (

--- a/internal/adapter/accessibility/atspi/window_origin_test.go
+++ b/internal/adapter/accessibility/atspi/window_origin_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage // Exercises the unexported per-compositor origin helpers directly.
 package atspi
 
 import (

--- a/internal/adapter/accessibility/native/darwin/element.go
+++ b/internal/adapter/accessibility/native/darwin/element.go
@@ -258,7 +258,7 @@ func ApplicationByPID(pid int) *Element {
 // ApplicationByBundleID returns an application element identified by its bundle identifier.
 func ApplicationByBundleID(bundleID string) *Element {
 	cBundle := C.CString(bundleID)
-	defer C.free(unsafe.Pointer(cBundle)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cBundle))
 
 	ref := C.NeruGetApplicationByBundleId(cBundle)
 	if ref == nil {
@@ -285,11 +285,11 @@ func (e *Element) Info() (*ElementInfo, error) {
 		return nil, errGetInfoNil
 	}
 
-	cInfo := C.NeruGetElementInfo(e.ref) //nolint:nlreturn
+	cInfo := C.NeruGetElementInfo(e.ref)
 	if cInfo == nil {
 		return nil, errGetInfoFailed
 	}
-	defer C.NeruFreeElementInfo(cInfo) //nolint:nlreturn
+	defer C.NeruFreeElementInfo(cInfo)
 
 	info := &ElementInfo{
 		position: image.Point{
@@ -347,7 +347,7 @@ func (e *Element) Children(role string) ([]*Element, error) {
 
 	switch role {
 	case string(element.RoleList), string(element.RoleTable), string(element.RoleOutline):
-		ptr := unsafe.Pointer(C.NeruGetVisibleRows(e.ref, &count)) //nolint:nlreturn
+		ptr := unsafe.Pointer(C.NeruGetVisibleRows(e.ref, &count))
 		if ptr != nil && count > 0 {
 			rawChildren = ptr
 		} else {
@@ -355,10 +355,10 @@ func (e *Element) Children(role string) ([]*Element, error) {
 				C.free(ptr)
 			}
 
-			rawChildren = unsafe.Pointer(C.NeruGetChildren(e.ref, &count)) //nolint:nlreturn
+			rawChildren = unsafe.Pointer(C.NeruGetChildren(e.ref, &count))
 		}
 	default:
-		rawChildren = unsafe.Pointer(C.NeruGetChildren(e.ref, &count)) //nolint:nlreturn
+		rawChildren = unsafe.Pointer(C.NeruGetChildren(e.ref, &count))
 	}
 
 	if rawChildren == nil || count == 0 {
@@ -368,7 +368,7 @@ func (e *Element) Children(role string) ([]*Element, error) {
 
 		return nil, nil
 	}
-	defer C.free(rawChildren) //nolint:nlreturn
+	defer C.free(rawChildren)
 
 	countInt := int(count)
 	childSlice := (*[1 << 30]unsafe.Pointer)(rawChildren)[:countInt:countInt]
@@ -386,7 +386,7 @@ func (e *Element) SetFocus() error {
 		return errSetFocusNil
 	}
 
-	result := C.NeruSetFocus(e.ref) //nolint:nlreturn
+	result := C.NeruSetFocus(e.ref)
 	if result == 0 {
 		return errSetFocusFailed
 	}
@@ -401,9 +401,9 @@ func (e *Element) Attribute(name string) (string, error) {
 	}
 
 	cName := C.CString(name)
-	defer C.free(unsafe.Pointer(cName)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cName))
 
-	cValue := C.NeruGetElementAttribute(e.ref, cName) //nolint:nlreturn
+	cValue := C.NeruGetElementAttribute(e.ref, cName)
 	if cValue == nil {
 		return "", derrors.Newf(
 			derrors.CodeAccessibilityFailed,
@@ -439,7 +439,7 @@ func (e *Element) Hash() (uint64, error) {
 		return 0, derrors.New(derrors.CodeAccessibilityFailed, "element reference is nil")
 	}
 
-	hash := C.NeruGetElementHash(e.ref) //nolint:nlreturn
+	hash := C.NeruGetElementHash(e.ref)
 
 	return uint64(hash), nil
 }
@@ -468,7 +468,7 @@ func (e *Element) Equal(other *Element) bool {
 		return true
 	}
 
-	result := C.NeruAreElementsEqual(e.ref, other.ref) //nolint:nlreturn
+	result := C.NeruAreElementsEqual(e.ref, other.ref)
 
 	return result == 1
 }
@@ -495,7 +495,7 @@ func AllWindows() ([]*Element, error) {
 
 		return []*Element{}, nil
 	}
-	defer C.free(unsafe.Pointer(windows)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(windows))
 
 	countInt := int(count)
 	windowSlice := (*[1 << 30]unsafe.Pointer)(unsafe.Pointer(windows))[:countInt:countInt]
@@ -520,7 +520,7 @@ func FrontmostAndPopoverWindows() ([]*Element, error) {
 
 		return []*Element{}, nil
 	}
-	defer C.free(unsafe.Pointer(windows)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(windows))
 
 	countInt := int(count)
 	windowSlice := (*[1 << 30]unsafe.Pointer)(unsafe.Pointer(windows))[:countInt:countInt]
@@ -548,7 +548,7 @@ func (e *Element) MenuBar() *Element {
 	if e.ref == nil {
 		return nil
 	}
-	ref := C.NeruGetMenuBar(e.ref) //nolint:nlreturn
+	ref := C.NeruGetMenuBar(e.ref)
 	if ref == nil {
 		return nil
 	}
@@ -562,7 +562,7 @@ func (e *Element) ApplicationName() string {
 		return ""
 	}
 
-	cName := C.NeruGetApplicationName(e.ref) //nolint:nlreturn
+	cName := C.NeruGetApplicationName(e.ref)
 	if cName == nil {
 		return ""
 	}
@@ -577,7 +577,7 @@ func (e *Element) BundleIdentifier() string {
 		return ""
 	}
 
-	cBundleID := C.NeruGetBundleIdentifier(e.ref) //nolint:nlreturn
+	cBundleID := C.NeruGetBundleIdentifier(e.ref)
 	if cBundleID == nil {
 		return ""
 	}
@@ -592,7 +592,7 @@ func (e *Element) ScrollBounds() image.Rectangle {
 		return image.Rectangle{}
 	}
 
-	rect := C.NeruGetScrollBounds(e.ref) //nolint:nlreturn
+	rect := C.NeruGetScrollBounds(e.ref)
 
 	return image.Rectangle{
 		Min: image.Point{
@@ -719,7 +719,7 @@ func (e *Element) IsClickable(
 		// 3. Hit-test visibility as final gate for ALL clickable results
 		cRole := C.CString(info.Role())
 
-		defer C.free(unsafe.Pointer(cRole)) //nolint:nlreturn
+		defer C.free(unsafe.Pointer(cRole))
 
 		centerX := C.double(info.Position().X + info.Size().X/2)
 		centerY := C.double(info.Position().Y + info.Size().Y/2)
@@ -743,7 +743,7 @@ func (e *Element) IsClickable(
 			centerY,
 			C.bool(info.hasPressAction),
 			C.bool(info.hasShowMenuAction),
-			C.bool(info.preActionsFetched), //nolint:nlreturn
+			C.bool(info.preActionsFetched),
 		)
 
 		return result == 1
@@ -843,7 +843,7 @@ func DetectBundleType(bundleID string) string {
 	}
 
 	cBundleID := C.CString(bundleID)
-	defer C.free(unsafe.Pointer(cBundleID)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cBundleID))
 
 	result := C.NeruDetectBundleType(cBundleID)
 	typ := ""

--- a/internal/adapter/accessibility/native/linux/element_x11_cgo.go
+++ b/internal/adapter/accessibility/native/linux/element_x11_cgo.go
@@ -38,14 +38,14 @@ func linuxFocusedApplicationIdentity() (string, int) {
 	if display == nil {
 		return "", 0
 	}
-	defer C.neru_ax_close_display(display) //nolint:nlreturn
+	defer C.neru_ax_close_display(display)
 
 	var window C.Window
-	if C.neru_ax_get_active_window(display, &window) == 0 { //nolint:nlreturn
+	if C.neru_ax_get_active_window(display, &window) == 0 {
 		return "", 0
 	}
 
-	className := C.neru_ax_window_class(display, window) //nolint:nlreturn
+	className := C.neru_ax_window_class(display, window)
 
 	bundleID := ""
 	if className != nil {
@@ -54,7 +54,7 @@ func linuxFocusedApplicationIdentity() (string, int) {
 	}
 
 	var ok C.int
-	pid := int(C.neru_ax_window_pid(display, window, &ok)) //nolint:nlreturn
+	pid := int(C.neru_ax_window_pid(display, window, &ok))
 
 	return bundleID, pid
 }
@@ -82,9 +82,9 @@ func x11MoveMouseToPoint(point image.Point) error {
 	if err != nil {
 		return err
 	}
-	defer C.neru_ax_close_display(display) //nolint:nlreturn
+	defer C.neru_ax_close_display(display)
 
-	if C.neru_ax_move_pointer(display, C.int(point.X), C.int(point.Y)) == 0 { //nolint:nlreturn
+	if C.neru_ax_move_pointer(display, C.int(point.X), C.int(point.Y)) == 0 {
 		return derrors.Newf(
 			derrors.CodeActionFailed,
 			"failed to move X11 pointer to (%d, %d)",
@@ -101,10 +101,10 @@ func x11CurrentCursorPosition() image.Point {
 	if err != nil {
 		return image.Point{}
 	}
-	defer C.neru_ax_close_display(display) //nolint:nlreturn
+	defer C.neru_ax_close_display(display)
 
 	var x, y C.int
-	if C.neru_ax_query_pointer(display, &x, &y) == 0 { //nolint:nlreturn
+	if C.neru_ax_query_pointer(display, &x, &y) == 0 {
 		return image.Point{}
 	}
 
@@ -164,12 +164,12 @@ func x11MouseUp(button action.MouseButton, modifiers action.Modifiers) error {
 	if err != nil {
 		return err
 	}
-	defer C.neru_ax_close_display(display) //nolint:nlreturn
+	defer C.neru_ax_close_display(display)
 
 	// Runs before the display is closed: defers unwind last-in first-out.
 	defer x11ReleaseModifiers(display, modifiers)
 
-	if C.neru_ax_button(display, x11Button(button), 0) == 0 { //nolint:nlreturn
+	if C.neru_ax_button(display, x11Button(button), 0) == 0 {
 		return derrors.Newf(
 			derrors.CodeActionFailed,
 			"failed to release %s mouse button on X11",
@@ -185,7 +185,7 @@ func x11ScrollAtCursor(deltaX, deltaY int) error {
 	if err != nil {
 		return err
 	}
-	defer C.neru_ax_close_display(display) //nolint:nlreturn
+	defer C.neru_ax_close_display(display)
 
 	// X11 scrolling is simulated via discrete button clicks (4, 5, 6, 7).
 	// Incoming deltas are pixel-level values from the scroll service config
@@ -215,8 +215,8 @@ func x11ScrollAtCursor(deltaX, deltaY int) error {
 				button = 5
 			}
 
-			if C.neru_ax_button(display, button, 1) == 0 || //nolint:nlreturn
-				C.neru_ax_button(display, button, 0) == 0 { //nolint:nlreturn
+			if C.neru_ax_button(display, button, 1) == 0 ||
+				C.neru_ax_button(display, button, 0) == 0 {
 				return derrors.New(derrors.CodeActionFailed, "failed vertical scroll event on X11")
 			}
 		}
@@ -240,8 +240,8 @@ func x11ScrollAtCursor(deltaX, deltaY int) error {
 				button = 6
 			}
 
-			if C.neru_ax_button(display, button, 1) == 0 || //nolint:nlreturn
-				C.neru_ax_button(display, button, 0) == 0 { //nolint:nlreturn
+			if C.neru_ax_button(display, button, 1) == 0 ||
+				C.neru_ax_button(display, button, 0) == 0 {
 				return derrors.New(
 					derrors.CodeActionFailed,
 					"failed horizontal scroll event on X11",
@@ -264,13 +264,13 @@ func x11ClickButtonAtPoint(
 		return err
 	}
 
-	defer C.neru_ax_close_display(display) //nolint:nlreturn
+	defer C.neru_ax_close_display(display)
 
 	original := x11CurrentCursorPosition()
 	x11PressModifiers(display, modifiers)
 	defer x11ReleaseModifiers(display, modifiers)
 
-	if C.neru_ax_move_pointer(display, C.int(point.X), C.int(point.Y)) == 0 { //nolint:nlreturn
+	if C.neru_ax_move_pointer(display, C.int(point.X), C.int(point.Y)) == 0 {
 		return derrors.Newf(
 			derrors.CodeActionFailed,
 			"failed to move X11 pointer to (%d, %d)",
@@ -279,8 +279,8 @@ func x11ClickButtonAtPoint(
 		)
 	}
 
-	if C.neru_ax_button(display, button, 1) == 0 || //nolint:nlreturn
-		C.neru_ax_button(display, button, 0) == 0 { //nolint:nlreturn
+	if C.neru_ax_button(display, button, 1) == 0 ||
+		C.neru_ax_button(display, button, 0) == 0 {
 		return derrors.New(
 			derrors.CodeActionFailed,
 			"failed to dispatch X11 button click",
@@ -288,7 +288,7 @@ func x11ClickButtonAtPoint(
 	}
 
 	if restoreCursor {
-		_ = C.neru_ax_move_pointer(display, C.int(original.X), C.int(original.Y)) //nolint:nlreturn
+		_ = C.neru_ax_move_pointer(display, C.int(original.X), C.int(original.Y))
 	}
 
 	return nil
@@ -305,7 +305,7 @@ func x11MouseButtonAtPoint(
 	if err != nil {
 		return err
 	}
-	defer C.neru_ax_close_display(display) //nolint:nlreturn
+	defer C.neru_ax_close_display(display)
 
 	original := x11CurrentCursorPosition()
 	x11PressModifiers(display, modifiers)
@@ -318,7 +318,7 @@ func x11MouseButtonAtPoint(
 		defer x11ReleaseModifiers(display, modifiers)
 	}
 
-	if C.neru_ax_move_pointer(display, C.int(point.X), C.int(point.Y)) == 0 { //nolint:nlreturn
+	if C.neru_ax_move_pointer(display, C.int(point.X), C.int(point.Y)) == 0 {
 		// If we failed to move and modifiers are held for a mouse-down,
 		// release them now to avoid stuck modifier keys.
 		if isDown {
@@ -338,7 +338,7 @@ func x11MouseButtonAtPoint(
 		pressed = 1
 	}
 
-	if C.neru_ax_button(display, button, C.int(pressed)) == 0 { //nolint:nlreturn
+	if C.neru_ax_button(display, button, C.int(pressed)) == 0 {
 		// Release modifiers on failure to avoid stuck keys.
 		if isDown {
 			x11ReleaseModifiers(display, modifiers)
@@ -351,7 +351,7 @@ func x11MouseButtonAtPoint(
 	}
 
 	if restoreCursor {
-		_ = C.neru_ax_move_pointer(display, C.int(original.X), C.int(original.Y)) //nolint:nlreturn
+		_ = C.neru_ax_move_pointer(display, C.int(original.X), C.int(original.Y))
 	}
 
 	return nil

--- a/internal/adapter/accessibility/native/menubar_darwin_test.go
+++ b/internal/adapter/accessibility/native/menubar_darwin_test.go
@@ -1,6 +1,5 @@
 //go:build darwin
 
-//nolint:testpackage
 package native
 
 import (

--- a/internal/adapter/accessibility/native/windows/automation_integration_test.go
+++ b/internal/adapter/accessibility/native/windows/automation_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration && windows
 
-package windows //nolint:testpackage // exercises unexported enumerateClickableElements directly
+package windows
 
 import (
 	"testing"

--- a/internal/adapter/accessibility/native/windows/automation_test.go
+++ b/internal/adapter/accessibility/native/windows/automation_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package windows //nolint:testpackage // exercises unexported controlTypeName directly
+package windows
 
 import (
 	"maps"

--- a/internal/adapter/accessibility/native/windows/tree_test.go
+++ b/internal/adapter/accessibility/native/windows/tree_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package windows //nolint:testpackage // exercises unexported defaultClickableRoles
+package windows
 
 import (
 	"maps"

--- a/internal/adapter/appwatcher/platform_linux_test.go
+++ b/internal/adapter/appwatcher/platform_linux_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage // Exercises the unexported linuxAppWatcher poll/dispatch logic directly.
 package appwatcher
 
 import (

--- a/internal/adapter/eventtap/darwin/dispatch_test.go
+++ b/internal/adapter/eventtap/darwin/dispatch_test.go
@@ -1,6 +1,5 @@
 //go:build darwin
 
-//nolint:testpackage // This test validates internal queue/dispatcher behavior.
 package darwin
 
 import (

--- a/internal/adapter/eventtap/darwin/tap.go
+++ b/internal/adapter/eventtap/darwin/tap.go
@@ -161,7 +161,7 @@ func (et *EventTap) SetHotkeys(hotkeys []string) {
 		if hotkey != "" {
 			cHotkeys[index] = C.CString(hotkey)
 
-			defer C.free(unsafe.Pointer(cHotkeys[index])) //nolint:nlreturn
+			defer C.free(unsafe.Pointer(cHotkeys[index]))
 		} else {
 			cHotkeys[index] = nil
 		}
@@ -197,7 +197,7 @@ func (et *EventTap) SetModifierPassthrough(enabled bool, blacklist []string) {
 		if key != "" {
 			cKeys[index] = C.CString(key)
 
-			defer C.free(unsafe.Pointer(cKeys[index])) //nolint:nlreturn
+			defer C.free(unsafe.Pointer(cKeys[index]))
 		} else {
 			cKeys[index] = nil
 		}
@@ -238,7 +238,7 @@ func (et *EventTap) SetInterceptedModifierKeys(keys []string) {
 		if key != "" {
 			cKeys[index] = C.CString(key)
 
-			defer C.free(unsafe.Pointer(cKeys[index])) //nolint:nlreturn
+			defer C.free(unsafe.Pointer(cKeys[index]))
 		} else {
 			cKeys[index] = nil
 		}
@@ -305,7 +305,7 @@ func (et *EventTap) SetKeyboardLayout(layoutID string) bool {
 // modifier must be one of "cmd", "shift", "alt", "ctrl".
 func (et *EventTap) PostModifierEvent(modifier string, isDown bool) {
 	cModifier := C.CString(modifier)
-	defer C.free(unsafe.Pointer(cModifier)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cModifier))
 
 	cDown := C.int(0)
 	if isDown {

--- a/internal/adapter/eventtap/linux/evdev_keys_test.go
+++ b/internal/adapter/eventtap/linux/evdev_keys_test.go
@@ -1,6 +1,5 @@
 //go:build linux && cgo
 
-//nolint:testpackage // These tests validate unexported evdev translation helpers directly.
 package linux
 
 import (

--- a/internal/adapter/eventtap/linux/evdev_passthrough_test.go
+++ b/internal/adapter/eventtap/linux/evdev_passthrough_test.go
@@ -1,6 +1,5 @@
 //go:build linux && cgo
 
-//nolint:testpackage // These tests validate unexported evdev passthrough helpers directly.
 package linux
 
 import (

--- a/internal/adapter/eventtap/linux/evdev_xkb_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_xkb_cgo.go
@@ -22,7 +22,7 @@ func (et *EventTap) xkbEvdevKeyName(capture *waylandEvdevCapture, code uint16) s
 		(*C.neru_xkb_state)(capture.xkbState),
 		C.uint16_t(code),
 		&buf[0],
-		64, //nolint:nlreturn
+		64,
 	) == 0 {
 		return C.GoString(&buf[0])
 	}

--- a/internal/adapter/eventtap/linux/global_hotkey_keys_test.go
+++ b/internal/adapter/eventtap/linux/global_hotkey_keys_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package linux //nolint:testpackage // white-box: exercises the unexported canonicalChordSignature.
+package linux
 
 import "testing"
 

--- a/internal/adapter/eventtap/linux/tap_test.go
+++ b/internal/adapter/eventtap/linux/tap_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage
 package linux
 
 import "testing"

--- a/internal/adapter/eventtap/linux/x11_cgo.go
+++ b/internal/adapter/eventtap/linux/x11_cgo.go
@@ -33,7 +33,7 @@ func x11QueryModifierState(display *C.Display) linuxModifierState {
 	var state linuxModifierState
 
 	var keymap [32]C.char
-	C.XQueryKeymap(display, &keymap[0]) //nolint:nlreturn
+	C.XQueryKeymap(display, &keymap[0])
 
 	// Map X11 modifier keysyms → our canonical modifier names.
 	type modifierKeysym struct {
@@ -54,7 +54,7 @@ func x11QueryModifierState(display *C.Display) linuxModifierState {
 	}
 
 	for _, modKey := range modifierKeysyms {
-		keycode := C.XKeysymToKeycode(display, modKey.keysym) //nolint:nlreturn
+		keycode := C.XKeysymToKeycode(display, modKey.keysym)
 		if keycode == 0 {
 			continue
 		}
@@ -87,12 +87,12 @@ func (et *EventTap) runX11() {
 	if display == nil {
 		return
 	}
-	defer C.neru_eventtap_close(display) //nolint:nlreturn
+	defer C.neru_eventtap_close(display)
 
-	if C.neru_eventtap_grab_keyboard(display) != C.GrabSuccess { //nolint:nlreturn
+	if C.neru_eventtap_grab_keyboard(display) != C.GrabSuccess {
 		return
 	}
-	defer C.neru_eventtap_ungrab_keyboard(display) //nolint:nlreturn
+	defer C.neru_eventtap_ungrab_keyboard(display)
 
 	// Query the actual keyboard state after the grab so that modifiers
 	// held at grab time are counted in modState. Without this, initial
@@ -108,14 +108,14 @@ func (et *EventTap) runX11() {
 		default:
 		}
 
-		if C.neru_eventtap_pending(display) == 0 { //nolint:nlreturn
+		if C.neru_eventtap_pending(display) == 0 {
 			time.Sleep(x11PollingInterval)
 
 			continue
 		}
 
 		var event C.XEvent
-		eventType := C.neru_eventtap_next(display, &event) //nolint:nlreturn
+		eventType := C.neru_eventtap_next(display, &event)
 		if eventType != C.KeyPress && eventType != C.KeyRelease {
 			continue
 		}
@@ -128,7 +128,7 @@ func (et *EventTap) runX11() {
 			&buffer[0],
 			C.int(len(buffer)),
 			&keysym,
-			nil, //nolint:nlreturn
+			nil,
 		)
 
 		if modifier := x11ModifierName(keysym); modifier != "" {
@@ -288,7 +288,7 @@ func postLinuxModifierEvent(modifier string, isDown bool) bool {
 	}
 
 	cModifier := C.CString(modifier)
-	defer C.free(unsafe.Pointer(cModifier)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cModifier))
 
 	cDown := C.int(0)
 	if isDown {

--- a/internal/adapter/hotkeys/linux/x11_cgo.go
+++ b/internal/adapter/hotkeys/linux/x11_cgo.go
@@ -58,11 +58,11 @@ func (m *Manager) registerX11Hotkey(hotkeyID ports.HotkeyID, keyString string) e
 			state.root,
 			C.True,
 			C.GrabModeAsync,
-			C.GrabModeAsync, //nolint:nlreturn
+			C.GrabModeAsync,
 		)
 	}
-	C.XSelectInput(state.display, state.root, C.KeyPressMask) //nolint:nlreturn
-	C.XFlush(state.display)                                   //nolint:nlreturn
+	C.XSelectInput(state.display, state.root, C.KeyPressMask)
+	C.XFlush(state.display)
 
 	state.bindings[hotkeyID] = x11HotkeyBinding{keycode: C.int(keycode), modifiers: modifiers}
 	state.ids[x11BindingKey(keycode, modifiers)] = hotkeyID
@@ -86,14 +86,14 @@ func (m *Manager) unregisterX11Hotkey(hotkeyID ports.HotkeyID) {
 	}
 
 	for _, mask := range []C.uint{0, C.Mod2Mask, C.LockMask, C.Mod2Mask | C.LockMask} {
-		C.XUngrabKey( //nolint:nlreturn
+		C.XUngrabKey(
 			state.display,
 			binding.keycode,
 			binding.modifiers|mask,
-			state.root, //nolint:nlreturn
+			state.root,
 		)
 	}
-	C.XFlush(state.display) //nolint:nlreturn
+	C.XFlush(state.display)
 
 	delete(state.ids, x11BindingKey(C.uint(binding.keycode), binding.modifiers))
 	delete(state.bindings, hotkeyID)
@@ -119,7 +119,7 @@ func (m *Manager) unregisterAllX11Hotkeys() {
 		close(state.stopCh)
 		<-state.doneCh
 
-		C.XCloseDisplay(state.display) //nolint:nlreturn
+		C.XCloseDisplay(state.display)
 		x11States.Delete(m)
 	})
 }
@@ -144,7 +144,7 @@ func (m *Manager) ensureX11State() (*x11HotkeyState, error) {
 
 	state := &x11HotkeyState{
 		display:  display,
-		root:     C.neru_hotkeys_root_window(display), //nolint:nlreturn
+		root:     C.neru_hotkeys_root_window(display),
 		bindings: make(map[ports.HotkeyID]x11HotkeyBinding),
 		ids:      make(map[string]ports.HotkeyID),
 		stopCh:   make(chan struct{}),
@@ -170,20 +170,20 @@ func (m *Manager) runX11HotkeyLoop(state *x11HotkeyState) {
 		// blocking XNextEvent directly. This allows the stop channel to be
 		// checked between iterations, preventing a goroutine leak and a
 		// use-after-free when unregisterAllX11Hotkeys closes the display.
-		if C.neru_hotkeys_pending(state.display) == 0 { //nolint:nlreturn
+		if C.neru_hotkeys_pending(state.display) == 0 {
 			time.Sleep(x11HotkeyPollInterval)
 
 			continue
 		}
 
 		var event C.XEvent
-		C.XNextEvent(state.display, &event)           //nolint:nlreturn
-		if C.neru_xevent_type(&event) != C.KeyPress { //nolint:nlreturn
+		C.XNextEvent(state.display, &event)
+		if C.neru_xevent_type(&event) != C.KeyPress {
 			continue
 		}
 
-		keycode := C.neru_xkey_keycode(&event)                              //nolint:nlreturn
-		modifiers := C.neru_xkey_state(&event) &^ (C.Mod2Mask | C.LockMask) //nolint:nlreturn
+		keycode := C.neru_xkey_keycode(&event)
+		modifiers := C.neru_xkey_state(&event) &^ (C.Mod2Mask | C.LockMask)
 
 		// Hold m.mu while reading state.ids — Register/Unregister write
 		// to this map under the same lock, so an unguarded read here is a
@@ -245,7 +245,7 @@ func parseX11Hotkey(display *C.Display, keyString string) (C.uint, C.uint, error
 		)
 	}
 
-	keycode := C.XKeysymToKeycode(display, keysym) //nolint:nlreturn
+	keycode := C.XKeysymToKeycode(display, keysym)
 	if keycode == 0 {
 		return 0, 0, derrors.Newf(
 			derrors.CodeInvalidInput,
@@ -263,7 +263,7 @@ func x11KeysymFor(key string) C.KeySym {
 		letter := strings.ToLower(key)
 		cKey := C.CString(letter)
 
-		defer C.free(unsafe.Pointer(cKey)) //nolint:nlreturn
+		defer C.free(unsafe.Pointer(cKey))
 
 		return C.XStringToKeysym(cKey)
 	}
@@ -287,7 +287,7 @@ func x11KeysymFor(key string) C.KeySym {
 		return C.XK_Right
 	default:
 		cKey := C.CString(key)
-		defer C.free(unsafe.Pointer(cKey)) //nolint:nlreturn
+		defer C.free(unsafe.Pointer(cKey))
 
 		return C.XStringToKeysym(cKey)
 	}

--- a/internal/adapter/keyfeed/keyfeed_darwin.go
+++ b/internal/adapter/keyfeed/keyfeed_darwin.go
@@ -21,7 +21,7 @@ import (
 // when the daemon is running.
 func postKey(normalized string) error {
 	cKey := C.CString(normalized)
-	defer C.free(unsafe.Pointer(cKey)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cKey))
 
 	ret := C.NeruPostKeyFeed(cKey)
 	switch ret {

--- a/internal/adapter/logger/logger_path_test.go
+++ b/internal/adapter/logger/logger_path_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage
 package logger
 
 import (

--- a/internal/adapter/overlay/darwin/manager.go
+++ b/internal/adapter/overlay/darwin/manager.go
@@ -320,10 +320,10 @@ func (m *Manager) DrawMouseActionIndicator(
 	shape := C.CString(style.Shape)
 	easing := C.CString(style.Easing)
 
-	defer C.free(unsafe.Pointer(backgroundColor)) //nolint:nlreturn
-	defer C.free(unsafe.Pointer(borderColor))     //nolint:nlreturn
-	defer C.free(unsafe.Pointer(shape))           //nolint:nlreturn
-	defer C.free(unsafe.Pointer(easing))          //nolint:nlreturn
+	defer C.free(unsafe.Pointer(backgroundColor))
+	defer C.free(unsafe.Pointer(borderColor))
+	defer C.free(unsafe.Pointer(shape))
+	defer C.free(unsafe.Pointer(easing))
 
 	C.NeruShowMouseActionIndicator(
 		C.CGPoint{x: C.double(point.X), y: C.double(point.Y)},

--- a/internal/adapter/overlay/linux/animation_test.go
+++ b/internal/adapter/overlay/linux/animation_test.go
@@ -1,6 +1,6 @@
 //go:build linux && cgo
 
-package linux //nolint:testpackage // tests exercise unexported render helpers directly
+package linux
 
 import (
 	"image"

--- a/internal/adapter/overlay/linux/hint_arrow_test.go
+++ b/internal/adapter/overlay/linux/hint_arrow_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package linux //nolint:testpackage // tests exercise unexported render helpers directly
+package linux
 
 import (
 	"image"

--- a/internal/adapter/overlay/linux/stub_contract_test.go
+++ b/internal/adapter/overlay/linux/stub_contract_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage
 package linux
 
 import (

--- a/internal/adapter/overlay/linux/wayland_cgo.go
+++ b/internal/adapter/overlay/linux/wayland_cgo.go
@@ -503,10 +503,10 @@ func (o *wlrootsOverlay) startMouseActionAnimation(
 		border := applyOpacity(borderBase, opacity)
 
 		C.neru_wayland_overlay_dispatch_pending(o.raw)
-		bufIdx := C.neru_wayland_overlay_available_buffer(o.raw) //nolint:nlreturn
+		bufIdx := C.neru_wayland_overlay_available_buffer(o.raw)
 		if bufIdx < 0 {
 			C.neru_wayland_overlay_sync(o.raw)
-			bufIdx = C.neru_wayland_overlay_available_buffer(o.raw) //nolint:nlreturn
+			bufIdx = C.neru_wayland_overlay_available_buffer(o.raw)
 		}
 		if bufIdx < 0 {
 			return
@@ -595,10 +595,10 @@ func (o *wlrootsOverlay) selectAvailableBuffer() bool {
 		return false
 	}
 	C.neru_wayland_overlay_dispatch_pending(o.raw)
-	bufIdx := C.neru_wayland_overlay_available_buffer(o.raw) //nolint:nlreturn
+	bufIdx := C.neru_wayland_overlay_available_buffer(o.raw)
 	if bufIdx < 0 {
 		C.neru_wayland_overlay_sync(o.raw)
-		bufIdx = C.neru_wayland_overlay_available_buffer(o.raw) //nolint:nlreturn
+		bufIdx = C.neru_wayland_overlay_available_buffer(o.raw)
 	}
 	if bufIdx < 0 {
 		return false
@@ -666,7 +666,7 @@ func (o *wlrootsOverlay) keyboardPoller() {
 			o.displayMu.Lock()
 		}
 
-		if C.neru_wayland_overlay_poll(o.raw) < 0 { //nolint:nlreturn
+		if C.neru_wayland_overlay_poll(o.raw) < 0 {
 			if o.displayMu != nil {
 				o.displayMu.Unlock()
 			}
@@ -675,7 +675,7 @@ func (o *wlrootsOverlay) keyboardPoller() {
 		}
 
 		for {
-			key := C.neru_wayland_overlay_get_key(o.raw) //nolint:nlreturn
+			key := C.neru_wayland_overlay_get_key(o.raw)
 			if key == nil {
 				break
 			}
@@ -785,10 +785,10 @@ func (o *wlrootsOverlay) startGridAnimation(
 		}
 
 		C.neru_wayland_overlay_dispatch_pending(o.raw)
-		bufIdx := C.neru_wayland_overlay_available_buffer(o.raw) //nolint:nlreturn
+		bufIdx := C.neru_wayland_overlay_available_buffer(o.raw)
 		if bufIdx < 0 {
 			C.neru_wayland_overlay_sync(o.raw)
-			bufIdx = C.neru_wayland_overlay_available_buffer(o.raw) //nolint:nlreturn
+			bufIdx = C.neru_wayland_overlay_available_buffer(o.raw)
 		}
 		if bufIdx < 0 {
 			return false
@@ -1123,8 +1123,8 @@ func (o *wlrootsOverlay) drawTextCentered(
 	cText := C.CString(text)
 	cFontFamily := C.CString(fontFamily)
 
-	defer C.free(unsafe.Pointer(cText))       //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cFontFamily)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cText))
+	defer C.free(unsafe.Pointer(cFontFamily))
 
 	C.neru_wayland_overlay_text(
 		o.raw, cText, cFontFamily,

--- a/internal/adapter/overlay/linux/x11_cgo.go
+++ b/internal/adapter/overlay/linux/x11_cgo.go
@@ -71,7 +71,7 @@ func newX11Overlay(logger *zap.Logger) *x11Overlay {
 		return nil
 	}
 
-	scale := float64(C.neru_x11_overlay_scale(raw)) //nolint:nlreturn
+	scale := float64(C.neru_x11_overlay_scale(raw))
 	if scale <= 0 {
 		scale = 1
 	}
@@ -1001,8 +1001,8 @@ func (o *x11Overlay) drawTextCentered(
 	cText := C.CString(text)
 	cFontFamily := C.CString(fontFamily)
 
-	defer C.free(unsafe.Pointer(cText))       //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cFontFamily)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cText))
+	defer C.free(unsafe.Pointer(cFontFamily))
 
 	C.neru_x11_overlay_text(
 		o.raw, cText, cFontFamily,

--- a/internal/adapter/overlay/render/grid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/grid/overlay_darwin.go
@@ -247,14 +247,14 @@ func (o *Overlay) ShowVirtualPointer(
 	o.configMu.RUnlock()
 
 	cFillColor := C.CString(fillColor)
-	defer C.free(unsafe.Pointer(cFillColor)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cFillColor))
 
 	cLabelChar := C.CString(cfg.Char)
 	cFontFamily := C.CString(cfg.FontFamily)
 	cTextColor := C.CString(color)
-	defer C.free(unsafe.Pointer(cLabelChar))  //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cFontFamily)) //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cTextColor))  //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cLabelChar))
+	defer C.free(unsafe.Pointer(cFontFamily))
+	defer C.free(unsafe.Pointer(cTextColor))
 
 	indicatorStyle := C.CursorIndicatorStyle{
 		radius:     C.double(size),
@@ -423,7 +423,7 @@ func (o *Overlay) DrawGrid(grid *domainGrid.Grid, currentInput string, style Sty
 // UpdateMatches updates matched state without redrawing all cells.
 func (o *Overlay) UpdateMatches(prefix string) {
 	cPrefix := C.CString(prefix)
-	defer C.free(unsafe.Pointer(cPrefix)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cPrefix))
 	C.NeruUpdateGridMatchPrefix(o.window, cPrefix)
 }
 

--- a/internal/adapter/overlay/render/grid/style_test.go
+++ b/internal/adapter/overlay/render/grid/style_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // exercises the unexported style fields through BuildStyle.
 package grid
 
 import (

--- a/internal/adapter/overlay/render/hints/overlay_darwin.go
+++ b/internal/adapter/overlay/render/hints/overlay_darwin.go
@@ -213,20 +213,20 @@ func (o *Overlay) DrawSearchInput(
 	style SearchInputStyle,
 ) error {
 	cQuery := C.CString(query)
-	//nolint:nlreturn // C memory must be freed before return
+
 	defer C.free(unsafe.Pointer(cQuery))
 
 	cFontFamily := C.CString(style.FontFamily())
 	cBackgroundColor := C.CString(style.BackgroundColor())
 	cTextColor := C.CString(style.TextColor())
 	cBorderColor := C.CString(style.BorderColor())
-	//nolint:nlreturn // C memory must be freed before return
+
 	defer C.free(unsafe.Pointer(cFontFamily))
-	//nolint:nlreturn // C memory must be freed before return
+
 	defer C.free(unsafe.Pointer(cBackgroundColor))
-	//nolint:nlreturn // C memory must be freed before return
+
 	defer C.free(unsafe.Pointer(cTextColor))
-	//nolint:nlreturn // C memory must be freed before return
+
 	defer C.free(unsafe.Pointer(cBorderColor))
 
 	input := C.SearchInputData{
@@ -589,7 +589,7 @@ func (o *Overlay) hintsAreStructurallyEqual(hintsA, hintsB []*Hint) bool {
 // updateMatchesIncremental updates match states incrementally when input changes.
 func (o *Overlay) updateMatchesIncremental(newInput string) {
 	cPrefix := C.CString(newInput)
-	defer C.free(unsafe.Pointer(cPrefix)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cPrefix))
 
 	C.NeruUpdateHintMatchPrefix(o.window, cPrefix)
 

--- a/internal/adapter/overlay/render/hints/overlay_linux_test.go
+++ b/internal/adapter/overlay/render/hints/overlay_linux_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage
 package hints
 
 import (

--- a/internal/adapter/overlay/render/hints/overlay_windows_test.go
+++ b/internal/adapter/overlay/render/hints/overlay_windows_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package hints //nolint:testpackage
+package hints
 
 import (
 	"testing"

--- a/internal/adapter/overlay/render/overlayutil/util_test.go
+++ b/internal/adapter/overlay/render/overlayutil/util_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // This test validates internal lock-order behavior.
 package overlayutil
 
 import (

--- a/internal/adapter/overlay/render/recursivegrid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/recursivegrid/overlay_darwin.go
@@ -170,14 +170,14 @@ func (o *Overlay) ShowVirtualPointer(
 	o.configMu.RUnlock()
 
 	cFillColor := C.CString(fillColor)
-	defer C.free(unsafe.Pointer(cFillColor)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cFillColor))
 
 	cLabelChar := C.CString(cfg.Char)
 	cFontFamily := C.CString(cfg.FontFamily)
 	cTextColor := C.CString(color)
-	defer C.free(unsafe.Pointer(cLabelChar))  //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cFontFamily)) //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cTextColor))  //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cLabelChar))
+	defer C.free(unsafe.Pointer(cFontFamily))
+	defer C.free(unsafe.Pointer(cTextColor))
 
 	indicatorStyle := C.CursorIndicatorStyle{
 		radius:     C.double(size),

--- a/internal/adapter/overlay/render/recursivegrid/style_test.go
+++ b/internal/adapter/overlay/render/recursivegrid/style_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // exercises the unexported style fields through BuildStyle.
 package recursivegrid
 
 import (

--- a/internal/adapter/overlay/render/virtualpointer/overlay_darwin.go
+++ b/internal/adapter/overlay/render/virtualpointer/overlay_darwin.go
@@ -111,10 +111,10 @@ func (o *Overlay) Draw(xCoordinate, yCoordinate, size int, fillColor string) {
 		o.theme, config.VirtualPointerTextColorLight, config.VirtualPointerTextColorDark,
 	))
 
-	defer C.free(unsafe.Pointer(cFillColor))  //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cLabelChar))  //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cFontFamily)) //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cTextColor))  //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cFillColor))
+	defer C.free(unsafe.Pointer(cLabelChar))
+	defer C.free(unsafe.Pointer(cFontFamily))
+	defer C.free(unsafe.Pointer(cTextColor))
 
 	C.NeruPositionAndDrawVirtualPointer(
 		o.window,

--- a/internal/adapter/overlay/windows/features_test.go
+++ b/internal/adapter/overlay/windows/features_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package windows //nolint:testpackage // tests exercise unexported Win32 rendering helpers directly
+package windows
 
 import (
 	"image"

--- a/internal/adapter/platform/backend_linux_test.go
+++ b/internal/adapter/platform/backend_linux_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage // test covers unexported function
 package platform
 
 import "testing"

--- a/internal/adapter/platform/darwin/accessibility.go
+++ b/internal/adapter/platform/darwin/accessibility.go
@@ -31,13 +31,13 @@ func FocusedApplicationPID() (int, error) {
 	if ref == nil {
 		return 0, derrors.New(derrors.CodeAccessibilityFailed, "failed to get focused application")
 	}
-	defer C.NeruReleaseElement(ref) //nolint:nlreturn
+	defer C.NeruReleaseElement(ref)
 
-	info := C.NeruGetElementInfo(ref) //nolint:nlreturn
+	info := C.NeruGetElementInfo(ref)
 	if info == nil {
 		return 0, derrors.New(derrors.CodeAccessibilityFailed, "failed to get element info")
 	}
-	defer C.NeruFreeElementInfo(info) //nolint:nlreturn
+	defer C.NeruFreeElementInfo(info)
 
 	return int(info.pid), nil
 }
@@ -52,9 +52,9 @@ func ApplicationNameByPID(pid int) (string, error) {
 			pid,
 		)
 	}
-	defer C.NeruReleaseElement(ref) //nolint:nlreturn
+	defer C.NeruReleaseElement(ref)
 
-	cName := C.NeruGetApplicationName(ref) //nolint:nlreturn
+	cName := C.NeruGetApplicationName(ref)
 	if cName == nil {
 		return "", derrors.Newf(
 			derrors.CodeAccessibilityFailed,
@@ -77,9 +77,9 @@ func ApplicationBundleIDByPID(pid int) (string, error) {
 			pid,
 		)
 	}
-	defer C.NeruReleaseElement(ref) //nolint:nlreturn
+	defer C.NeruReleaseElement(ref)
 
-	cBundleID := C.NeruGetBundleIdentifier(ref) //nolint:nlreturn
+	cBundleID := C.NeruGetBundleIdentifier(ref)
 	if cBundleID == nil {
 		return "", derrors.Newf(
 			derrors.CodeAccessibilityFailed,
@@ -112,7 +112,7 @@ func HasClickAction(element unsafe.Pointer) bool {
 		0,     // centerY
 		false, // preHasPressAction
 		false, // preHasShowMenuAction
-		false, //nolint:nlreturn
+		false,
 	) != 0
 
 	return clickable
@@ -121,7 +121,7 @@ func HasClickAction(element unsafe.Pointer) bool {
 // SetApplicationAttribute sets an attribute on an application by its PID.
 func SetApplicationAttribute(pid int, attribute string, value bool) bool {
 	cAttr := C.CString(attribute)
-	defer C.free(unsafe.Pointer(cAttr)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cAttr))
 
 	val := 0
 	if value {

--- a/internal/adapter/platform/darwin/alert.go
+++ b/internal/adapter/platform/darwin/alert.go
@@ -41,8 +41,8 @@ const (
 func ShowConfigValidationError(errorMessage, configPath string) ConfigValidationChoice {
 	cError := C.CString(errorMessage)
 	cPath := C.CString(configPath)
-	defer C.free(unsafe.Pointer(cError)) //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cPath))  //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cError))
+	defer C.free(unsafe.Pointer(cPath))
 
 	return ConfigValidationChoice(C.NeruShowConfigValidationErrorAlert(cError, cPath))
 }
@@ -51,8 +51,8 @@ func ShowConfigValidationError(errorMessage, configPath string) ConfigValidation
 func ShowNotification(title, message string) {
 	cTitle := C.CString(title)
 	cMessage := C.CString(message)
-	defer C.free(unsafe.Pointer(cTitle))   //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cMessage)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cTitle))
+	defer C.free(unsafe.Pointer(cMessage))
 
 	C.NeruShowNotification(cTitle, cMessage)
 }
@@ -60,7 +60,7 @@ func ShowNotification(title, message string) {
 // ShowConfigOnboardingAlert displays a native macOS alert for new users without a config file.
 func ShowConfigOnboardingAlert(configPath string) ConfigOnboardingChoice {
 	cPath := C.CString(configPath)
-	defer C.free(unsafe.Pointer(cPath)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cPath))
 
 	return ConfigOnboardingChoice(C.NeruShowConfigOnboardingAlert(cPath))
 }

--- a/internal/adapter/platform/darwin/bridge.go
+++ b/internal/adapter/platform/darwin/bridge.go
@@ -92,7 +92,7 @@ func ParseKeyString(keyString string) (int, int, bool) {
 	log.Debug("Darwin: Parsing key string", zap.String("key_string", keyString))
 
 	cKeyString := C.CString(keyString)
-	defer C.free(unsafe.Pointer(cKeyString)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cKeyString))
 
 	var keyCode C.int
 	var modifiers C.int
@@ -268,8 +268,8 @@ func handleMissionControlDeactivated() {
 func HandleAppLaunch(appName, bundleID string) {
 	cName := C.CString(appName)
 	cBundle := C.CString(bundleID)
-	defer C.free(unsafe.Pointer(cName))   //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cBundle)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cName))
+	defer C.free(unsafe.Pointer(cBundle))
 
 	handleAppLaunch(cName, cBundle)
 }
@@ -278,8 +278,8 @@ func HandleAppLaunch(appName, bundleID string) {
 func HandleAppTerminate(appName, bundleID string) {
 	cName := C.CString(appName)
 	cBundle := C.CString(bundleID)
-	defer C.free(unsafe.Pointer(cName))   //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cBundle)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cName))
+	defer C.free(unsafe.Pointer(cBundle))
 
 	handleAppTerminate(cName, cBundle)
 }
@@ -288,8 +288,8 @@ func HandleAppTerminate(appName, bundleID string) {
 func HandleAppActivate(appName, bundleID string) {
 	cName := C.CString(appName)
 	cBundle := C.CString(bundleID)
-	defer C.free(unsafe.Pointer(cName))   //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cBundle)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cName))
+	defer C.free(unsafe.Pointer(cBundle))
 
 	handleAppActivate(cName, cBundle)
 }
@@ -298,8 +298,8 @@ func HandleAppActivate(appName, bundleID string) {
 func HandleAppDeactivate(appName, bundleID string) {
 	cName := C.CString(appName)
 	cBundle := C.CString(bundleID)
-	defer C.free(unsafe.Pointer(cName))   //nolint:nlreturn
-	defer C.free(unsafe.Pointer(cBundle)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cName))
+	defer C.free(unsafe.Pointer(cBundle))
 
 	handleAppDeactivate(cName, cBundle)
 }

--- a/internal/adapter/platform/darwin/cgo_slot_test.go
+++ b/internal/adapter/platform/darwin/cgo_slot_test.go
@@ -1,6 +1,5 @@
 //go:build darwin
 
-//nolint:testpackage // tests unexported cgoSlot internals
 package darwin
 
 import (

--- a/internal/adapter/platform/darwin/font_test.go
+++ b/internal/adapter/platform/darwin/font_test.go
@@ -1,6 +1,5 @@
 //go:build darwin
 
-//nolint:testpackage
 package darwin
 
 import "testing"

--- a/internal/adapter/platform/darwin/keymap.go
+++ b/internal/adapter/platform/darwin/keymap.go
@@ -49,7 +49,7 @@ func SetReferenceKeyboardLayout(inputSourceID string) bool {
 	var cLayoutID *C.char
 	if layoutID != "" {
 		cLayoutID = C.CString(layoutID)
-		defer C.free(unsafe.Pointer(cLayoutID)) //nolint:nlreturn
+		defer C.free(unsafe.Pointer(cLayoutID))
 	}
 
 	result := C.NeruSetReferenceKeyboardLayout(cLayoutID) != 0

--- a/internal/adapter/platform/darwin/screen.go
+++ b/internal/adapter/platform/darwin/screen.go
@@ -36,7 +36,7 @@ func ScreenNames() []string {
 	if cNames == nil {
 		return nil
 	}
-	defer C.free(unsafe.Pointer(cNames)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cNames))
 
 	totalLen := int(bufLen)
 	if totalLen == 0 {
@@ -69,7 +69,7 @@ func ScreenNames() []string {
 // screen matches.
 func ScreenBoundsByName(name string) (image.Rectangle, bool) {
 	cName := C.CString(name)
-	defer C.free(unsafe.Pointer(cName)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cName))
 
 	var found C.int
 

--- a/internal/adapter/platform/factory_linux_test.go
+++ b/internal/adapter/platform/factory_linux_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage
 package platform
 
 import (

--- a/internal/adapter/platform/linux/capability_probes_test.go
+++ b/internal/adapter/platform/linux/capability_probes_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage
 package linux
 
 import (

--- a/internal/adapter/platform/linux/font_cgo.go
+++ b/internal/adapter/platform/linux/font_cgo.go
@@ -108,11 +108,11 @@ func (r *fontconfigResolver) resolve(family string) string {
 	mapped := mapGenericAlias(family)
 
 	cFamily := C.CString(mapped)
-	defer C.free(unsafe.Pointer(cFamily)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cFamily))
 
 	matched := C.fc_match_family(cFamily)
 	if matched != nil {
-		defer C.free(unsafe.Pointer(matched)) //nolint:nlreturn
+		defer C.free(unsafe.Pointer(matched))
 
 		got := C.GoString(matched)
 		if got != "" {

--- a/internal/adapter/platform/linux/mouse_animator_test.go
+++ b/internal/adapter/platform/linux/mouse_animator_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage // Exercises the unexported smooth cursor animator directly.
 package linux
 
 import (

--- a/internal/adapter/platform/linux/system_dark_mode_test.go
+++ b/internal/adapter/platform/linux/system_dark_mode_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage // Exercises unexported helpers (scanINIValue, darkModeCapability).
 package linux
 
 import (

--- a/internal/adapter/platform/linux/system_focused_pid_test.go
+++ b/internal/adapter/platform/linux/system_focused_pid_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage // Exercises unexported app_id/PID matching helpers directly.
 package linux
 
 import (

--- a/internal/adapter/platform/linux/system_process_test.go
+++ b/internal/adapter/platform/linux/system_process_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage // Exercises unexported procfs helpers directly.
 package linux
 
 import (

--- a/internal/adapter/platform/linux/system_wayland_kde_cgo.go
+++ b/internal/adapter/platform/linux/system_wayland_kde_cgo.go
@@ -156,7 +156,7 @@ func (s *libeiState) execute(
 
 func libeiMoveAbs(posX, posY int) error {
 	return globalLibeiState.execute(
-		func(c *C.NeruEiClient) bool { return C.neru_ei_move_abs(c, C.int(posX), C.int(posY)) != 0 }, //nolint:nlreturn
+		func(c *C.NeruEiClient) bool { return C.neru_ei_move_abs(c, C.int(posX), C.int(posY)) != 0 },
 		func() error {
 			return derrors.Newf(
 				derrors.CodeActionFailed,
@@ -174,7 +174,7 @@ func libeiButton(button int, pressed bool) error {
 	}
 
 	return globalLibeiState.execute(
-		func(c *C.NeruEiClient) bool { return C.neru_ei_button(c, C.int(button), pressedInt) != 0 }, //nolint:nlreturn
+		func(c *C.NeruEiClient) bool { return C.neru_ei_button(c, C.int(button), pressedInt) != 0 },
 		func() error {
 			return derrors.New(derrors.CodeActionFailed, "libei failed to emit button event")
 		},
@@ -183,7 +183,7 @@ func libeiButton(button int, pressed bool) error {
 
 func libeiScroll(axis, delta int) error {
 	return globalLibeiState.execute(
-		func(c *C.NeruEiClient) bool { return C.neru_ei_scroll(c, C.int(axis), C.int(delta)) != 0 }, //nolint:nlreturn
+		func(c *C.NeruEiClient) bool { return C.neru_ei_scroll(c, C.int(axis), C.int(delta)) != 0 },
 		func() error {
 			return derrors.New(derrors.CodeActionFailed, "libei failed to emit scroll event")
 		},
@@ -197,7 +197,7 @@ func libeiKey(keycode int, pressed bool) error {
 	}
 
 	return globalLibeiState.execute(
-		func(c *C.NeruEiClient) bool { return C.neru_ei_key(c, C.int(keycode), pressedInt) != 0 }, //nolint:nlreturn
+		func(c *C.NeruEiClient) bool { return C.neru_ei_key(c, C.int(keycode), pressedInt) != 0 },
 		func() error {
 			return derrors.New(
 				derrors.CodeNotSupported,
@@ -230,7 +230,7 @@ func libeiHasKeyboard() (bool, bool) {
 		return false, false
 	}
 
-	return C.neru_ei_has_keyboard(globalLibeiState.client) != 0, false //nolint:nlreturn
+	return C.neru_ei_has_keyboard(globalLibeiState.client) != 0, false
 }
 
 // LibeiReset tears down the libei/RemoteDesktop portal session. The next input

--- a/internal/adapter/platform/linux/system_wayland_keyfeed_uinput_test.go
+++ b/internal/adapter/platform/linux/system_wayland_keyfeed_uinput_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage // Exercises the unexported uinput modifier-mapping helper directly.
 package linux
 
 import (

--- a/internal/adapter/platform/linux/system_wayland_modifiers_test.go
+++ b/internal/adapter/platform/linux/system_wayland_modifiers_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage // These tests exercise unexported dispatcher helpers directly.
 package linux
 
 import (

--- a/internal/adapter/platform/linux/system_wayland_wlroots_cgo.go
+++ b/internal/adapter/platform/linux/system_wayland_wlroots_cgo.go
@@ -57,14 +57,14 @@ var globalWlrootsState = &wlrootsState{}
 // returns a single default screen so the rest of the system has something to
 // work with.
 func readWlrootsScreens(client *C.NeruWlrootsClient) []wlrootsScreen {
-	count := int(C.neru_wlr_screen_count(client)) //nolint:nlreturn
+	count := int(C.neru_wlr_screen_count(client))
 	screens := make([]wlrootsScreen, 0, count)
 
 	for index := range count {
 		var posX, posY, width, height C.int
 
 		nameBuf := make([]C.char, wlrootsScreenNameBufferSize)
-		if C.neru_wlr_screen_info( //nolint:nlreturn
+		if C.neru_wlr_screen_info(
 			client,
 			C.int(index),
 			&posX,
@@ -72,7 +72,7 @@ func readWlrootsScreens(client *C.NeruWlrootsClient) []wlrootsScreen {
 			&width,
 			&height,
 			&nameBuf[0],
-			wlrootsScreenNameBufferSize, //nolint:nlreturn
+			wlrootsScreenNameBufferSize,
 		) != 0 {
 			name := C.GoString(&nameBuf[0])
 			if name == "" {
@@ -143,7 +143,7 @@ func wlrootsScreenEventFD() (int, bool) {
 		return -1, false
 	}
 
-	fd := C.neru_wlr_screen_event_fd(client) //nolint:nlreturn
+	fd := C.neru_wlr_screen_event_fd(client)
 	if fd < 0 {
 		return -1, false
 	}
@@ -179,7 +179,7 @@ func ensureWlrootsState() error {
 	// absence is no longer fatal: screen bounds and the overlay still come up
 	// via xdg_output + zwlr_layer_shell_v1, and pointer moves/clicks are routed
 	// through libei / the RemoteDesktop portal (connected lazily on first use).
-	hasVirtualPointer := C.neru_wlr_has_virtual_pointer(client) != 0 //nolint:nlreturn
+	hasVirtualPointer := C.neru_wlr_has_virtual_pointer(client) != 0
 
 	// Initialize cursor position to screen center. Wayland has no
 	// protocol to query global pointer position, so we track it
@@ -188,7 +188,7 @@ func ensureWlrootsState() error {
 
 	// Start dispatch thread after init_cursor to avoid reader_count
 	// conflicts with roundtrip calls during cursor discovery.
-	C.neru_wlr_start_dispatch(client) //nolint:nlreturn
+	C.neru_wlr_start_dispatch(client)
 
 	// Populate screen list from the client.
 	screens := readWlrootsScreens(client)
@@ -242,7 +242,7 @@ func wlrootsFocusedAppID() (string, bool) {
 	buf := make([]C.char, wlrootsFocusedAppIDBufferSize)
 	bufLen := C.int(wlrootsFocusedAppIDBufferSize)
 
-	if C.neru_wlr_focused_app_id(client, &buf[0], bufLen) == 0 { //nolint:nlreturn
+	if C.neru_wlr_focused_app_id(client, &buf[0], bufLen) == 0 {
 		return "", false
 	}
 
@@ -276,12 +276,12 @@ func wlrootsFocusedAppIdentity() (string, string, bool) {
 	appLen := C.int(wlrootsFocusedAppIDBufferSize)
 	titleLen := C.int(wlrootsFocusedTitleBufferSize)
 
-	found := C.neru_wlr_focused_app_identity( //nolint:nlreturn
+	found := C.neru_wlr_focused_app_identity(
 		client,
 		&appBuf[0],
 		appLen,
 		&titleBuf[0],
-		titleLen, //nolint:nlreturn
+		titleLen,
 	)
 	if found == 0 {
 		return "", "", false
@@ -310,7 +310,7 @@ func wlrootsFocusEventFD() (int, bool) {
 		return -1, false
 	}
 
-	fd := C.neru_wlr_focus_event_fd(client) //nolint:nlreturn
+	fd := C.neru_wlr_focus_event_fd(client)
 	if fd < 0 {
 		return -1, false
 	}
@@ -344,7 +344,7 @@ func wlrootsRefreshCursorPosition() error {
 	globalWlrootsState.mu.Lock()
 	defer globalWlrootsState.mu.Unlock()
 
-	if C.neru_wlr_refresh_cursor(globalWlrootsState.client) == 0 { //nolint:nlreturn
+	if C.neru_wlr_refresh_cursor(globalWlrootsState.client) == 0 {
 		return derrors.New(
 			derrors.CodeActionFailed,
 			"failed to refresh wlroots cursor position",
@@ -437,7 +437,7 @@ func wlrootsCursorPositionLocked() (image.Point, error) {
 	// No need to poll Wayland events — doing so previously triggered
 	// the pointer motion handler which corrupted the position cache.
 	var posX, posY C.int
-	initialized := C.neru_wlr_get_cursor(client, &posX, &posY) //nolint:nlreturn
+	initialized := C.neru_wlr_get_cursor(client, &posX, &posY)
 
 	// If cursor was never initialized, fall back to first screen center
 	if initialized == 0 {
@@ -467,7 +467,7 @@ func wlrootsMoveCursorToPoint(point image.Point) error {
 
 	client := globalWlrootsState.client
 
-	if C.neru_wlr_move_absolute(client, C.int(point.X), C.int(point.Y)) == 0 { //nolint:nlreturn
+	if C.neru_wlr_move_absolute(client, C.int(point.X), C.int(point.Y)) == 0 {
 		return derrors.Newf(
 			derrors.CodeActionFailed,
 			"failed to move wlroots virtual pointer to (%d, %d)",
@@ -490,7 +490,7 @@ func wlrootsMoveCursorBy(delta image.Point) error {
 
 	client := globalWlrootsState.client
 
-	if C.neru_wlr_move_relative(client, C.int(delta.X), C.int(delta.Y)) == 0 { //nolint:nlreturn
+	if C.neru_wlr_move_relative(client, C.int(delta.X), C.int(delta.Y)) == 0 {
 		return derrors.Newf(
 			derrors.CodeActionFailed,
 			"failed to move wlroots virtual pointer by (%d, %d)",
@@ -515,7 +515,7 @@ func wlrootsClick(point image.Point, button int) error {
 	client := globalWlrootsState.client
 
 	// Move to target.
-	if C.neru_wlr_move_absolute(client, C.int(point.X), C.int(point.Y)) == 0 { //nolint:nlreturn
+	if C.neru_wlr_move_absolute(client, C.int(point.X), C.int(point.Y)) == 0 {
 		return derrors.Newf(
 			derrors.CodeActionFailed,
 			"failed to move wlroots virtual pointer to (%d, %d)",
@@ -524,7 +524,7 @@ func wlrootsClick(point image.Point, button int) error {
 		)
 	}
 
-	if C.neru_wlr_click(client, C.int(button)) == 0 { //nolint:nlreturn
+	if C.neru_wlr_click(client, C.int(button)) == 0 {
 		return derrors.Newf(
 			derrors.CodeActionFailed,
 			"failed to perform wlroots click (button %d) at (%d, %d)",
@@ -550,7 +550,7 @@ func wlrootsButtonEvent(point image.Point, button int, pressed bool) error {
 	client := globalWlrootsState.client
 
 	// Move to target.
-	if C.neru_wlr_move_absolute(client, C.int(point.X), C.int(point.Y)) == 0 { //nolint:nlreturn
+	if C.neru_wlr_move_absolute(client, C.int(point.X), C.int(point.Y)) == 0 {
 		return derrors.Newf(
 			derrors.CodeActionFailed,
 			"failed to move wlroots virtual pointer to (%d, %d)",
@@ -564,7 +564,7 @@ func wlrootsButtonEvent(point image.Point, button int, pressed bool) error {
 		pressedInt = 1
 	}
 
-	if C.neru_wlr_button(client, C.int(button), C.int(pressedInt)) == 0 { //nolint:nlreturn
+	if C.neru_wlr_button(client, C.int(button), C.int(pressedInt)) == 0 {
 		return derrors.New(
 			derrors.CodeActionFailed,
 			"failed to perform wlroots button event",
@@ -586,7 +586,7 @@ func wlrootsButtonRelease(button int) error {
 
 	client := globalWlrootsState.client
 
-	if C.neru_wlr_button(client, C.int(button), 0) == 0 { //nolint:nlreturn
+	if C.neru_wlr_button(client, C.int(button), 0) == 0 {
 		return derrors.New(
 			derrors.CodeActionFailed,
 			"failed to release wlroots button",
@@ -610,7 +610,7 @@ func wlrootsScroll(axis, delta, discrete int) error {
 	client := globalWlrootsState.client
 	defer globalWlrootsState.mu.Unlock()
 
-	res := C.neru_wlr_scroll(client, C.int(axis), C.int(delta), C.int(discrete)) //nolint:nlreturn
+	res := C.neru_wlr_scroll(client, C.int(axis), C.int(delta), C.int(discrete))
 	if res == 0 {
 		return derrors.New(
 			derrors.CodeActionFailed,
@@ -647,7 +647,7 @@ func wlrootsScrollBatch(axis int, deltas, discretes []int) error {
 		C.int(axis),
 		&cDeltas[0],
 		&cDiscretes[0],
-		C.int(len(deltas)), //nolint:nlreturn
+		C.int(len(deltas)),
 	)
 	if res == 0 {
 		return derrors.New(
@@ -670,14 +670,14 @@ func wlrootsModifierEvent(modifier string, isDown bool) error {
 	defer globalWlrootsState.mu.Unlock()
 
 	cModifier := C.CString(modifier)
-	defer C.free(unsafe.Pointer(cModifier)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(cModifier))
 
 	cDown := C.int(0)
 	if isDown {
 		cDown = C.int(1)
 	}
 
-	if C.neru_wlr_modifier_event(client, cModifier, cDown) == 0 { //nolint:nlreturn
+	if C.neru_wlr_modifier_event(client, cModifier, cDown) == 0 {
 		return derrors.Newf(
 			derrors.CodeActionFailed,
 			"failed to post wlroots modifier event %q",
@@ -699,7 +699,7 @@ func wlrootsHasVirtualKeyboard() (bool, error) {
 	globalWlrootsState.mu.RLock()
 	defer globalWlrootsState.mu.RUnlock()
 
-	return C.neru_wlr_has_virtual_keyboard(globalWlrootsState.client) != 0, nil //nolint:nlreturn
+	return C.neru_wlr_has_virtual_keyboard(globalWlrootsState.client) != 0, nil
 }
 
 // wlrootsKey presses (pressed=true) or releases (pressed=false) a single key
@@ -719,7 +719,7 @@ func wlrootsKey(keycode uint32, pressed bool) error {
 		pressedInt = 1
 	}
 
-	if C.neru_wlr_key(client, C.uint32_t(keycode), C.int(pressedInt)) == 0 { //nolint:nlreturn
+	if C.neru_wlr_key(client, C.uint32_t(keycode), C.int(pressedInt)) == 0 {
 		return derrors.New(
 			derrors.CodeActionFailed,
 			"failed to post virtual keyboard key event",

--- a/internal/adapter/platform/linux/system_x11_cgo.go
+++ b/internal/adapter/platform/linux/system_x11_cgo.go
@@ -51,10 +51,10 @@ func x11CursorPosition() (image.Point, error) {
 	if err != nil {
 		return image.Point{}, err
 	}
-	defer C.neru_x11_close_display(display) //nolint:nlreturn
+	defer C.neru_x11_close_display(display)
 
 	var posX, posY C.int
-	if C.neru_x11_query_pointer(display, &posX, &posY) == 0 { //nolint:nlreturn
+	if C.neru_x11_query_pointer(display, &posX, &posY) == 0 {
 		return image.Point{}, derrors.New(
 			derrors.CodeActionFailed,
 			"failed to query X11 pointer position",
@@ -69,9 +69,9 @@ func x11MoveCursorToPoint(point image.Point) error {
 	if err != nil {
 		return err
 	}
-	defer C.neru_x11_close_display(display) //nolint:nlreturn
+	defer C.neru_x11_close_display(display)
 
-	if C.neru_x11_move_pointer(display, C.int(point.X), C.int(point.Y)) == 0 { //nolint:nlreturn
+	if C.neru_x11_move_pointer(display, C.int(point.X), C.int(point.Y)) == 0 {
 		return derrors.Newf(
 			derrors.CodeActionFailed,
 			"failed to move X11 pointer to (%d, %d)",
@@ -88,10 +88,10 @@ func x11FocusedApplicationPID() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer C.neru_x11_close_display(display) //nolint:nlreturn
+	defer C.neru_x11_close_display(display)
 
 	var window C.Window
-	if C.neru_x11_get_active_window(display, &window) == 0 { //nolint:nlreturn
+	if C.neru_x11_get_active_window(display, &window) == 0 {
 		return 0, derrors.New(
 			derrors.CodeActionFailed,
 			"failed to query _NET_ACTIVE_WINDOW on X11",
@@ -99,7 +99,7 @@ func x11FocusedApplicationPID() (int, error) {
 	}
 
 	var ok C.int
-	pid := C.neru_x11_get_window_pid(display, window, &ok) //nolint:nlreturn
+	pid := C.neru_x11_get_window_pid(display, window, &ok)
 	if ok == 0 {
 		return 0, derrors.New(
 			derrors.CodeActionFailed,
@@ -119,18 +119,18 @@ func x11FocusedAppID() (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	defer C.neru_x11_close_display(display) //nolint:nlreturn
+	defer C.neru_x11_close_display(display)
 
 	var window C.Window
-	if C.neru_x11_get_active_window(display, &window) == 0 { //nolint:nlreturn
+	if C.neru_x11_get_active_window(display, &window) == 0 {
 		return "", false
 	}
 
-	className := C.neru_x11_get_window_class(display, window) //nolint:nlreturn
+	className := C.neru_x11_get_window_class(display, window)
 	if className == nil {
 		return "", false
 	}
-	defer C.free(unsafe.Pointer(className)) //nolint:nlreturn
+	defer C.free(unsafe.Pointer(className))
 
 	appID := C.GoString(className)
 	if appID == "" {
@@ -161,7 +161,7 @@ func x11FocusEventFD() (int, bool) {
 		}
 	}
 
-	fd := C.neru_x11_focus_monitor_fd(x11FocusMonitorInst) //nolint:nlreturn
+	fd := C.neru_x11_focus_monitor_fd(x11FocusMonitorInst)
 	if fd < 0 {
 		return -1, false
 	}
@@ -191,7 +191,7 @@ func x11ScreenEventFD() (int, bool) {
 		}
 	}
 
-	fd := C.neru_x11_screen_monitor_fd(x11ScreenMonitorInst) //nolint:nlreturn
+	fd := C.neru_x11_screen_monitor_fd(x11ScreenMonitorInst)
 	if fd < 0 {
 		return -1, false
 	}
@@ -208,11 +208,11 @@ func x11FocusedWindowBounds() (image.Rectangle, bool, error) {
 	if err != nil {
 		return image.Rectangle{}, false, err
 	}
-	defer C.neru_x11_close_display(display) //nolint:nlreturn
+	defer C.neru_x11_close_display(display)
 
 	var posX, posY, width, height C.int
 	found := C.neru_x11_get_focused_window_bounds(
-		display, &posX, &posY, &width, &height, //nolint:nlreturn
+		display, &posX, &posY, &width, &height,
 	)
 	if found == 0 {
 		return image.Rectangle{}, false, nil
@@ -231,17 +231,17 @@ func x11Monitors() ([]x11Monitor, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer C.neru_x11_close_display(display) //nolint:nlreturn
+	defer C.neru_x11_close_display(display)
 
 	var count C.int
-	raw := C.neru_x11_get_monitors(display, &count) //nolint:nlreturn
+	raw := C.neru_x11_get_monitors(display, &count)
 	if raw == nil || count == 0 {
 		return nil, derrors.New(
 			derrors.CodeActionFailed,
 			"failed to enumerate X11 monitors via XRandR",
 		)
 	}
-	defer C.neru_x11_free_monitors(raw, count) //nolint:nlreturn
+	defer C.neru_x11_free_monitors(raw, count)
 
 	monitors := make([]x11Monitor, 0, int(count))
 	rawSlice := unsafe.Slice(raw, int(count))

--- a/internal/adapter/platform/profile_linux_test.go
+++ b/internal/adapter/platform/profile_linux_test.go
@@ -1,6 +1,5 @@
 //go:build linux
 
-//nolint:testpackage // Same-package tests cover unexported KDE profile helpers.
 package platform
 
 import "testing"

--- a/internal/adapter/platform/profile_test.go
+++ b/internal/adapter/platform/profile_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Same-package tests intentionally cover unexported backend detection helpers.
 package platform
 
 import "testing"

--- a/internal/adapter/platform/windows/input_test.go
+++ b/internal/adapter/platform/windows/input_test.go
@@ -1,6 +1,6 @@
 //go:build windows && (amd64 || arm64)
 
-package windows //nolint:testpackage // exercises unexported input/mouseInput struct layout
+package windows
 
 import (
 	"testing"

--- a/internal/adapter/platform/windows/keys_test.go
+++ b/internal/adapter/platform/windows/keys_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package windows //nolint:testpackage // exercises unexported key translation helpers directly
+package windows
 
 import (
 	"strconv"

--- a/internal/adapter/platform/windows/overlay_color_test.go
+++ b/internal/adapter/platform/windows/overlay_color_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package windows //nolint:testpackage // exercises unexported color-blend helpers directly
+package windows
 
 import "testing"
 

--- a/internal/adapter/platform/windows/win32_test.go
+++ b/internal/adapter/platform/windows/win32_test.go
@@ -1,6 +1,6 @@
 //go:build windows && (amd64 || arm64)
 
-package windows //nolint:testpackage // exercises unexported Win32 argument packing helper
+package windows
 
 import (
 	"image"

--- a/internal/adapter/systray/darwin/systray.go
+++ b/internal/adapter/systray/darwin/systray.go
@@ -92,14 +92,14 @@ func Quit() {
 // SetTitle sets the title of the system tray icon.
 func SetTitle(title string) {
 	cTitle := C.CString(title)
-	defer C.free(unsafe.Pointer(cTitle)) //nolint
+	defer C.free(unsafe.Pointer(cTitle))
 	C.NeruSetTitle(cTitle)
 }
 
 // SetTooltip sets the tooltip of the system tray icon.
 func SetTooltip(tooltip string) {
 	cTooltip := C.CString(tooltip)
-	defer C.free(unsafe.Pointer(cTooltip)) //nolint
+	defer C.free(unsafe.Pointer(cTooltip))
 	C.NeruSetTooltip(cTooltip)
 }
 
@@ -140,7 +140,7 @@ func AddMenuItem(title string) *MenuItem {
 	item.id = registerMenuItem(item)
 
 	cTitle := C.CString(title)
-	defer C.free(unsafe.Pointer(cTitle)) //nolint
+	defer C.free(unsafe.Pointer(cTitle))
 
 	C.NeruAddMenuItem(C.int(item.id), cTitle, C.short(0), C.short(0))
 
@@ -156,7 +156,7 @@ func (m *MenuItem) AddSubMenuItem(title string) *MenuItem {
 	item.id = registerMenuItem(item)
 
 	cTitle := C.CString(title)
-	defer C.free(unsafe.Pointer(cTitle)) //nolint
+	defer C.free(unsafe.Pointer(cTitle))
 
 	C.NeruAddSubMenuItem(C.int(m.id), C.int(item.id), cTitle, C.short(0), C.short(0))
 
@@ -169,7 +169,7 @@ func (m *MenuItem) SetTitle(title string) {
 	m.title = title
 	m.mu.Unlock()
 	cTitle := C.CString(title)
-	defer C.free(unsafe.Pointer(cTitle)) //nolint
+	defer C.free(unsafe.Pointer(cTitle))
 	C.NeruSetItemTitle(C.int(m.id), cTitle)
 }
 

--- a/internal/adapter/vision/adapter_darwin.go
+++ b/internal/adapter/vision/adapter_darwin.go
@@ -78,7 +78,7 @@ func (a *Adapter) DetectElements(
 		return nil, nil
 	}
 
-	defer C.NeruFreeVisionResult(result) //nolint:nlreturn
+	defer C.NeruFreeVisionResult(result)
 
 	count := int(result.count)
 	if count == 0 {
@@ -181,10 +181,10 @@ func (a *Adapter) CaptureScreen(_ context.Context) (*image.RGBA, error) {
 		return nil, derrors.New(derrors.CodeInternal, "failed to capture screen")
 	}
 
-	defer C.CGImageRelease(cgImage) //nolint:nlreturn
+	defer C.CGImageRelease(cgImage)
 
-	width := int(C.CGImageGetWidth(cgImage))   //nolint:nlreturn
-	height := int(C.CGImageGetHeight(cgImage)) //nolint:nlreturn
+	width := int(C.CGImageGetWidth(cgImage))
+	height := int(C.CGImageGetHeight(cgImage))
 
 	if width == 0 || height == 0 {
 		return nil, derrors.New(derrors.CodeInternal, "captured screen image has zero size")
@@ -195,7 +195,7 @@ func (a *Adapter) CaptureScreen(_ context.Context) (*image.RGBA, error) {
 
 	colorSpace := C.CGColorSpaceCreateDeviceRGB()
 
-	defer C.CGColorSpaceRelease(colorSpace) //nolint:nlreturn
+	defer C.CGColorSpaceRelease(colorSpace)
 
 	ctx := C.CGBitmapContextCreate(
 		unsafe.Pointer(&buf[0]),
@@ -204,13 +204,13 @@ func (a *Adapter) CaptureScreen(_ context.Context) (*image.RGBA, error) {
 		8, // bits per component
 		C.size_t(bytesPerRow),
 		colorSpace,
-		C.kCGImageAlphaPremultipliedLast, //nolint:nlreturn
+		C.kCGImageAlphaPremultipliedLast,
 	)
 
 	if uintptr(ctx) == 0 {
 		return nil, derrors.New(derrors.CodeInternal, "failed to create bitmap context")
 	}
-	defer C.CGContextRelease(ctx) //nolint:nlreturn
+	defer C.CGContextRelease(ctx)
 
 	// Draw the captured image into our context
 	C.CGContextDrawImage(ctx, C.CGRect{

--- a/internal/adapter/vision/classifier_test.go
+++ b/internal/adapter/vision/classifier_test.go
@@ -1,6 +1,6 @@
 //go:build !darwin || darwin
 
-package vision //nolint:testpackage // uses unexported regionClassifier
+package vision
 
 import (
 	"image"

--- a/internal/app/ipcctrl/actions_button_phase_test.go
+++ b/internal/app/ipcctrl/actions_button_phase_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private IPC action parsing/dispatch helpers.
 package ipcctrl
 
 import (

--- a/internal/app/ipcctrl/actions_flags_test.go
+++ b/internal/app/ipcctrl/actions_flags_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private IPC action flag tables.
 package ipcctrl
 
 import (

--- a/internal/app/ipcctrl/actions_move_cell_test.go
+++ b/internal/app/ipcctrl/actions_move_cell_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private IPC action parsing/dispatch helpers.
 package ipcctrl
 
 import (

--- a/internal/app/ipcctrl/actions_test.go
+++ b/internal/app/ipcctrl/actions_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private IPC action parsing/dispatch helpers.
 package ipcctrl
 
 import (

--- a/internal/app/ipcctrl/cursor_slots_test.go
+++ b/internal/app/ipcctrl/cursor_slots_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests the private cursor-slot handlers.
 package ipcctrl
 
 import (

--- a/internal/app/ipcctrl/handlers_onexit_test.go
+++ b/internal/app/ipcctrl/handlers_onexit_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private mode option parsing.
 package ipcctrl
 
 import (

--- a/internal/app/ipcctrl/modeoptions_test.go
+++ b/internal/app/ipcctrl/modeoptions_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // exercises the unexported flag parser directly.
 package ipcctrl
 
 import (

--- a/internal/app/ipcctrl/sequence_test.go
+++ b/internal/app/ipcctrl/sequence_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests the private run-command handler.
 package ipcctrl
 
 import (

--- a/internal/app/ipcctrl/toggles_test.go
+++ b/internal/app/ipcctrl/toggles_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests the private toggle-state parsing and handlers.
 package ipcctrl
 
 import (

--- a/internal/app/keybinding/binder_test.go
+++ b/internal/app/keybinding/binder_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private hotkey helper behavior.
 package keybinding
 
 import (

--- a/internal/app/keybinding/dispatch_test.go
+++ b/internal/app/keybinding/dispatch_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private hotkey dispatch/registration behavior.
 package keybinding
 
 import (

--- a/internal/app/label_direction_registration_test.go
+++ b/internal/app/label_direction_registration_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private initialization helpers directly.
 package app
 
 import (

--- a/internal/app/modes/cleanup_test.go
+++ b/internal/app/modes/cleanup_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private cleanup ordering.
 package modes
 
 import (

--- a/internal/app/modes/eventtap_test.go
+++ b/internal/app/modes/eventtap_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Exercises the unexported event-tap helpers on Handler.
 package modes
 
 import (

--- a/internal/app/modes/grid_test.go
+++ b/internal/app/modes/grid_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private grid handler behavior.
 package modes
 
 import (

--- a/internal/app/modes/indicator_polling_test.go
+++ b/internal/app/modes/indicator_polling_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private sticky-indicator anchor selection behavior.
 package modes
 
 import (

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // These tests validate unexported handler behavior directly.
 package modes
 
 import (

--- a/internal/app/modes/mode_handlers_test.go
+++ b/internal/app/modes/mode_handlers_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private mode handler methods.
 package modes
 
 import (

--- a/internal/app/modes/modifier_toggle_test.go
+++ b/internal/app/modes/modifier_toggle_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests internal function parseModifierEvent
 package modes
 
 import (

--- a/internal/app/modes/passthrough_test.go
+++ b/internal/app/modes/passthrough_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests internal method modeModifierKeys which is private
 package modes
 
 import (

--- a/internal/app/modes/recursive_grid_test.go
+++ b/internal/app/modes/recursive_grid_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private recursive-grid handler behavior.
 package modes
 
 import (

--- a/internal/app/modes/selection_test.go
+++ b/internal/app/modes/selection_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private mode selection helpers.
 package modes
 
 import (

--- a/internal/app/sequence_test.go
+++ b/internal/app/sequence_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests the private action sequence executor.
 package app
 
 import (

--- a/internal/cli/cliutil/util_test.go
+++ b/internal/cli/cliutil/util_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests unexported CLI formatter helpers directly.
 package cliutil
 
 import (

--- a/internal/config/service_helper_test.go
+++ b/internal/config/service_helper_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage // Tests private service helper methods.
 package config
 
 import (


### PR DESCRIPTION
## Description

This PR retires the two linters the codebase had already rejected in practice but never formally disabled.

## Related Issues

N/A

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)

## Type of Change

- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform behavior; the touched Go files only lose comment directives

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build) — lint (0 issues), Docker `lint-cross`, build and full unit suite run locally; `-race`/integration passes run in CI
- [x] Tests added/updated for new or changed functionality — N/A, comment-only code changes
- [x] Documentation updated (if applicable) — CONTRIBUTING gains the nolint policy
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

N/A
