### PR TITLE
refactor(modes): make the handler locking discipline compiler-enforced

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -305,13 +305,20 @@ safety. Location: `internal/adapter/platform/darwin/`; key files `bridge.go`,
 ## Mode Handler Locking
 
 `modes.Handler` has a single `mu sync.Mutex` serializing the event-tap thread
-against timer goroutines. The public entry points (`HandleKeyPress`,
-`ActivateMode`, `ExitMode`, …) take the lock and then call into modes.
+against timer goroutines, and the type is split so the compiler enforces the
+locking discipline: the outer `Handler` owns the mutexes and the exported
+entry points (`HandleKeyPress`, `ActivateMode`, `ExitMode`, …), each of which
+takes the lock and delegates into the embedded `handlerState` — which carries
+every field and every method that runs with the lock held, and deliberately
+has no mutex.
 
-**Consequently `Mode.Activate` / `HandleKey` / `Exit` all run with `h.mu`
-already held.** Inside them, use only the `*Locked` helpers —
-`setModeLocked`, `exitModeLocked`, `refreshGridVirtualPointerLocked`, … — never
-the public `SetMode*` / `ExitMode` methods, which would self-deadlock.
+**Consequently `Mode.Activate` / `HandleKey` / `Exit` all run with the lock
+already held.** Modes are built on `*handlerState`, so calling a locking entry
+point from inside one is a compile error rather than a self-deadlock. The one
+escape hatch is `handlerState.outer`, the back-reference to the owning
+`Handler`: it exists solely for deferred work (timers, goroutines, callbacks
+registered with the platform) whose callbacks must take the lock when they
+later fire — never call anything on it synchronously.
 
 There is one documented lock order: **`moveMonitorMu` → `h.mu`**, never the
 reverse.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -385,21 +385,22 @@ every per-activation override — `Action`, `Modifier`, `OnExit`, `Repeat`,
 field here rather than a new interface method.
 
 > **Locking contract.** `Activate`, `HandleKey`, and `Exit` are all called with
-> the handler's `h.mu` **already held** by the public entry point
-> (`ActivateMode`, `HandleKeyPress`, `ExitMode`). Inside a mode use only the
-> `*Locked` helpers (`setModeLocked`, `exitModeLocked`, …) — calling a public
-> `SetMode*` / `ExitMode` method self-deadlocks. Full lock ordering is in
+> the handler lock **already held** by the public entry point (`ActivateMode`,
+> `HandleKeyPress`, `ExitMode`). Modes are built on the inner `*handlerState`,
+> which has no mutex and no access to the locking entry points, so calling one
+> from locked context is a compile error. Deferred callbacks (timers,
+> goroutines) reach the lock through `handlerState.outer` — see
 > [ARCHITECTURE.md](ARCHITECTURE.md#mode-handler-locking).
 
 **Method contracts**
 
-- `Activate(opts)` — call `handler.setModeLocked()` to change app state, show
+- `Activate(opts)` — call `handler.setMode()` to change app state, show
   mode-specific overlays, initialize state from `opts`. Log activation at
   `info`; keep routing and redraw detail at `debug`.
 - `HandleKey(key)` — route a single key string (`"a"`, `"j"`, `"escape"`) to the
   right handler and update mode state.
 - `Exit()` — hide overlays, reset mode-specific state. Common cleanup is already
-  handled by `exitModeLocked`.
+  handled by `exitMode`.
 - `ModeType()` — return the `domain.Mode` enum value (e.g. `domain.ModeHints`).
 
 **Implementation pattern**
@@ -423,16 +424,16 @@ type ScrollMode struct {
     *GenericMode
 }
 
-func NewScrollMode(handler *Handler) *ScrollMode {
+func NewScrollMode(handler *handlerState) *ScrollMode {
     behavior := ModeBehavior{
-        ActivateFunc: func(handler *Handler, _ ModeActivationOptions) {
-            // Called with h.mu held — use *Locked helpers only.
-            handler.StartInteractiveScroll()
+        ActivateFunc: func(handler *handlerState, _ ModeActivationOptions) {
+            // Runs with the lock held; handlerState methods are safe to call.
+            handler.startInteractiveScroll()
             handler.startIndicatorPolling(domain.ModeScroll)
         },
-        ExitFunc: func(handler *Handler) {
+        ExitFunc: func(handler *handlerState) {
             handler.stopIndicatorPolling()
-            handler.stopHeldRepeatLocked()
+            handler.stopHeldRepeat()
             handler.clearAndHideOverlay()
             // ... reset mode-specific state
         },

--- a/internal/app/modes/base.go
+++ b/internal/app/modes/base.go
@@ -20,12 +20,12 @@ const (
 // baseMode provides common functionality for all mode implementations.
 // It contains the shared handler dependency and mode type.
 type baseMode struct {
-	handler  *Handler
+	handler  *handlerState
 	modeType domain.Mode
 }
 
 // newBaseMode creates a new base mode with the given handler and mode type.
-func newBaseMode(handler *Handler, modeType domain.Mode, modeName string) baseMode {
+func newBaseMode(handler *handlerState, modeType domain.Mode, modeName string) baseMode {
 	if handler == nil {
 		panic(modeName + ": handler cannot be nil")
 	}

--- a/internal/app/modes/cleanup.go
+++ b/internal/app/modes/cleanup.go
@@ -23,11 +23,11 @@ func (h *Handler) ExitMode() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	h.exitModeLocked()
+	h.exitMode()
 }
 
-// exitModeLocked exits the current mode. Caller must hold h.mu.
-func (h *Handler) exitModeLocked() {
+// exitMode exits the current mode. Caller must hold h.mu.
+func (h *handlerState) exitMode() {
 	if h.appState.CurrentMode() == domain.ModeIdle {
 		return
 	}
@@ -40,7 +40,7 @@ func (h *Handler) exitModeLocked() {
 }
 
 // performModeSpecificCleanup handles mode-specific cleanup logic.
-func (h *Handler) performModeSpecificCleanup() {
+func (h *handlerState) performModeSpecificCleanup() {
 	mode, exists := h.modes[h.appState.CurrentMode()]
 	if !exists {
 		h.cleanupDefaultMode()
@@ -52,7 +52,7 @@ func (h *Handler) performModeSpecificCleanup() {
 }
 
 // clearAndHideOverlay clears and hides the overlay manager.
-func (h *Handler) clearAndHideOverlay() {
+func (h *handlerState) clearAndHideOverlay() {
 	h.stopIndicatorPolling()
 
 	h.overlayManager.ClearCache()
@@ -60,8 +60,8 @@ func (h *Handler) clearAndHideOverlay() {
 }
 
 // cleanupHintsMode handles cleanup for hints mode.
-func (h *Handler) cleanupHintsMode() {
-	h.stopHintSearchTextInputLocked(false)
+func (h *handlerState) cleanupHintsMode() {
+	h.stopHintSearchTextInput(false)
 
 	resetErr := h.hints.Context.Reset()
 	if resetErr != nil {
@@ -74,7 +74,7 @@ func (h *Handler) cleanupHintsMode() {
 }
 
 // cleanupDefaultMode handles cleanup for default/unknown modes.
-func (h *Handler) cleanupDefaultMode() {
+func (h *handlerState) cleanupDefaultMode() {
 	// No domain-specific cleanup for other modes yet.
 	// But still clear and hide action overlay.
 	if overlay.Get() != nil {
@@ -84,7 +84,7 @@ func (h *Handler) cleanupDefaultMode() {
 }
 
 // cleanupGridMode handles cleanup for grid mode.
-func (h *Handler) cleanupGridMode() {
+func (h *handlerState) cleanupGridMode() {
 	// Only reset the base context fields (pendingAction, repeat).
 	// Do NOT call h.grid.Context.Reset() because it nils out
 	// gridInstance (a **domainGrid.Grid pointer-to-pointer that is
@@ -118,9 +118,9 @@ func (h *Handler) cleanupGridMode() {
 }
 
 // performCommonCleanup handles common cleanup logic for all modes.
-func (h *Handler) performCommonCleanup() {
+func (h *handlerState) performCommonCleanup() {
 	h.stopIndicatorPolling()
-	h.stopHeldRepeatLocked()
+	h.stopHeldRepeat()
 	h.overlayManager.Clear()
 	h.overlayManager.ClearCache()
 
@@ -146,7 +146,7 @@ func (h *Handler) performCommonCleanup() {
 
 	h.releaseHeldButtons()
 
-	h.setAppModeLocked(domain.ModeIdle)
+	h.setAppMode(domain.ModeIdle)
 
 	// Do NOT reset suppressedModifiers here — SuppressModifiersForHotkey was
 	// called synchronously by the hotkey dispatch path (dispatchModeAwareHeldHotkey
@@ -176,7 +176,7 @@ func (h *Handler) performCommonCleanup() {
 }
 
 // handleCursorRestoration finalizes transient cursor and scroll state on mode exit.
-func (h *Handler) handleCursorRestoration() {
+func (h *handlerState) handleCursorRestoration() {
 	h.cursorState.Reset()
 
 	// Always reset scroll context to ensure proper state cleanup when switching modes.
@@ -187,7 +187,7 @@ func (h *Handler) handleCursorRestoration() {
 // drag. It routes through the action service rather than reaching into the
 // accessibility infra package directly, and swallows the error because every
 // caller is already on a cleanup path where there is nothing left to abort.
-func (h *Handler) releaseHeldButtons() {
+func (h *handlerState) releaseHeldButtons() {
 	if h.actionService == nil {
 		return
 	}

--- a/internal/app/modes/cleanup_test.go
+++ b/internal/app/modes/cleanup_test.go
@@ -34,14 +34,14 @@ func TestPerformCommonCleanup_ReleasesStickyModifiersBeforeDisablingEventTap(t *
 		},
 	}
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		logger:         zap.NewNop(),
 		config:         &configpkg.Config{},
 		appState:       appState,
 		modifierState:  state.NewModifierState(),
 		overlayManager: &overlay.NoOpManager{},
 		eventTap:       eventTap,
-	}
+	})
 
 	handler.modifierState.Toggle(action.ModCtrl)
 	handler.performCommonCleanup()

--- a/internal/app/modes/cursor_darwin.go
+++ b/internal/app/modes/cursor_darwin.go
@@ -11,11 +11,11 @@ import "C"
 // CursorVisibilitySupported returns true on macOS where system cursor visibility control is available.
 func (h *Handler) CursorVisibilitySupported() bool { return true }
 
-func (h *Handler) hideSystemCursorNative() {
+func (h *handlerState) hideSystemCursorNative() {
 	C.NeruHideSystemCursor()
 }
 
-func (h *Handler) showSystemCursorNative() {
+func (h *handlerState) showSystemCursorNative() {
 	C.NeruShowSystemCursor()
 }
 

--- a/internal/app/modes/cursor_other.go
+++ b/internal/app/modes/cursor_other.go
@@ -5,9 +5,9 @@ package modes
 // CursorVisibilitySupported returns false on non-macOS platforms.
 func (h *Handler) CursorVisibilitySupported() bool { return false }
 
-func (h *Handler) hideSystemCursorNative() {}
+func (h *handlerState) hideSystemCursorNative() {}
 
-func (h *Handler) showSystemCursorNative() {}
+func (h *handlerState) showSystemCursorNative() {}
 
 // RehideSystemCursor is a no-op on non-macOS platforms.
 func (h *Handler) RehideSystemCursor() {}

--- a/internal/app/modes/cursor_visibility.go
+++ b/internal/app/modes/cursor_visibility.go
@@ -11,18 +11,18 @@ func (h *Handler) HideSystemCursor() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	h.hideSystemCursorLocked()
+	h.hideSystemCursor()
 }
 
-// hideSystemCursorLocked hides the system cursor. Caller must hold h.mu.
-func (h *Handler) hideSystemCursorLocked() {
+// hideSystemCursor hides the system cursor. Caller must hold h.mu.
+func (h *handlerState) hideSystemCursor() {
 	if h.systemCursorHidden {
 		return
 	}
 
 	h.hideSystemCursorNative()
 	h.systemCursorHidden = true
-	h.ensureCursorOverlayPollingLocked()
+	h.ensureCursorOverlayPolling()
 }
 
 // ShowSystemCursor shows the system cursor and hides the cursor-following virtual pointer.
@@ -30,42 +30,42 @@ func (h *Handler) ShowSystemCursor() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	h.showSystemCursorLocked()
+	h.showSystemCursor()
 }
 
-// showSystemCursorLocked shows the system cursor. Caller must hold h.mu.
-func (h *Handler) showSystemCursorLocked() {
+// showSystemCursor shows the system cursor. Caller must hold h.mu.
+func (h *handlerState) showSystemCursor() {
 	if !h.systemCursorHidden {
 		return
 	}
 
 	h.showSystemCursorNative()
 	h.systemCursorHidden = false
-	h.hideCursorFollowingVirtualPointerLocked()
-	h.stopCursorOverlayPollingIfIdleLocked()
+	h.hideCursorFollowingVirtualPointer()
+	h.stopCursorOverlayPollingIfIdle()
 }
 
-func (h *Handler) shouldShowCursorFollowingVirtualPointerLocked() bool {
+func (h *handlerState) shouldShowCursorFollowingVirtualPointer() bool {
 	return h.systemCursorHidden && h.config != nil
 }
 
-func (h *Handler) ensureCursorOverlayPollingLocked() {
-	if !h.shouldShowCursorFollowingVirtualPointerLocked() {
+func (h *handlerState) ensureCursorOverlayPolling() {
+	if !h.shouldShowCursorFollowingVirtualPointer() {
 		return
 	}
 
 	h.startIndicatorPolling(h.appState.CurrentMode())
 }
 
-func (h *Handler) stopCursorOverlayPollingIfIdleLocked() {
-	if h.shouldPollCursorOverlaysLocked(h.appState.CurrentMode()) {
+func (h *handlerState) stopCursorOverlayPollingIfIdle() {
+	if h.shouldPollCursorOverlays(h.appState.CurrentMode()) {
 		return
 	}
 
 	h.stopIndicatorPolling()
 }
 
-func (h *Handler) shouldPollCursorOverlaysLocked(mode domain.Mode) bool {
+func (h *handlerState) shouldPollCursorOverlays(mode domain.Mode) bool {
 	if h.config == nil {
 		return false
 	}
@@ -78,7 +78,7 @@ func (h *Handler) shouldPollCursorOverlaysLocked(mode domain.Mode) bool {
 		return true
 	}
 
-	return h.shouldShowCursorFollowingVirtualPointerLocked()
+	return h.shouldShowCursorFollowingVirtualPointer()
 }
 
 // cursorRehideInterval is the minimum interval between automatic cursor re-hide
@@ -109,7 +109,7 @@ func (h *Handler) rehideSystemCursor() {
 	h.RehideSystemCursor()
 }
 
-func (h *Handler) hideCursorFollowingVirtualPointerLocked() {
+func (h *handlerState) hideCursorFollowingVirtualPointer() {
 	if h.overlayManager == nil {
 		return
 	}

--- a/internal/app/modes/eventtap.go
+++ b/internal/app/modes/eventtap.go
@@ -24,12 +24,12 @@ func (h *Handler) SetEventTap(eventTap ports.EventTapPort) {
 // hasEventTap reports whether a tap is wired up, for call sites that need to
 // know before doing work rather than relying on the no-op behavior of the
 // methods above.
-func (h *Handler) hasEventTap() bool {
+func (h *handlerState) hasEventTap() bool {
 	return h.eventTap != nil
 }
 
 // enableEventTap starts keyboard capture.
-func (h *Handler) enableEventTap() {
+func (h *handlerState) enableEventTap() {
 	if h.eventTap == nil {
 		return
 	}
@@ -44,7 +44,7 @@ func (h *Handler) enableEventTap() {
 //
 // It uses a background context rather than h.ctx because it also runs on the
 // cleanup path, after h.ctx has been canceled.
-func (h *Handler) disableEventTap() {
+func (h *handlerState) disableEventTap() {
 	if h.eventTap == nil {
 		return
 	}
@@ -57,7 +57,7 @@ func (h *Handler) disableEventTap() {
 
 // setModifierPassthrough configures whether unbound modifier shortcuts pass
 // through to the focused application.
-func (h *Handler) setModifierPassthrough(enabled bool, blacklist []string) {
+func (h *handlerState) setModifierPassthrough(enabled bool, blacklist []string) {
 	if h.eventTap == nil {
 		return
 	}
@@ -67,7 +67,7 @@ func (h *Handler) setModifierPassthrough(enabled bool, blacklist []string) {
 
 // setInterceptedModifierKeys configures which modifier shortcuts the active
 // mode still wants consumed while passthrough is on.
-func (h *Handler) setInterceptedModifierKeys(keys []string) {
+func (h *handlerState) setInterceptedModifierKeys(keys []string) {
 	if h.eventTap == nil {
 		return
 	}
@@ -77,7 +77,7 @@ func (h *Handler) setInterceptedModifierKeys(keys []string) {
 
 // setPassthroughCallback registers a function invoked when a modifier shortcut
 // passes through. Pass nil to clear.
-func (h *Handler) setPassthroughCallback(callback func()) {
+func (h *handlerState) setPassthroughCallback(callback func()) {
 	if h.eventTap == nil {
 		return
 	}
@@ -86,7 +86,7 @@ func (h *Handler) setPassthroughCallback(callback func()) {
 }
 
 // setStickyModifierToggle enables or disables sticky modifier detection.
-func (h *Handler) setStickyModifierToggle(enabled bool) {
+func (h *handlerState) setStickyModifierToggle(enabled bool) {
 	if h.eventTap == nil {
 		return
 	}
@@ -95,7 +95,7 @@ func (h *Handler) setStickyModifierToggle(enabled bool) {
 }
 
 // postModifierEvent simulates a physical modifier press or release.
-func (h *Handler) postModifierEvent(modifier string, isDown bool) {
+func (h *handlerState) postModifierEvent(modifier string, isDown bool) {
 	if h.eventTap == nil {
 		return
 	}
@@ -109,7 +109,7 @@ func (h *Handler) postModifierEvent(modifier string, isDown bool) {
 // Backends that cannot answer (everything but the Linux Wayland evdev tap) do
 // not implement the extension, and the conservative false keeps capture — the
 // behavior that works everywhere.
-func (h *Handler) allowsOverlayKeyboardPassthrough() bool {
+func (h *handlerState) allowsOverlayKeyboardPassthrough() bool {
 	reporter, ok := h.eventTap.(ports.OverlayKeyboardPassthroughReporter)
 
 	return ok && reporter.AllowsOverlayKeyboardPassthrough()

--- a/internal/app/modes/eventtap_test.go
+++ b/internal/app/modes/eventtap_test.go
@@ -17,7 +17,7 @@ func newEventTapHandler(t *testing.T) *Handler {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	return &Handler{ctx: ctx, logger: zap.NewNop()}
+	return newHandlerWithState(handlerState{ctx: ctx, logger: zap.NewNop()})
 }
 
 // TestHandler_EventTapHelpersTolerateNilTap pins the nil-safety the whole

--- a/internal/app/modes/generic_mode.go
+++ b/internal/app/modes/generic_mode.go
@@ -7,13 +7,13 @@ import (
 // ModeBehavior defines the behavior-specific functions for a mode.
 type ModeBehavior struct {
 	// ActivateFunc handles mode activation (optional, defaults to standard activation)
-	ActivateFunc func(handler *Handler, opts ModeActivationOptions)
+	ActivateFunc func(handler *handlerState, opts ModeActivationOptions)
 
 	// HandleKeyFunc handles key processing (optional, defaults to standard key handling)
-	HandleKeyFunc func(handler *Handler, key string)
+	HandleKeyFunc func(handler *handlerState, key string)
 
 	// ExitFunc handles mode cleanup (optional, defaults to standard cleanup)
-	ExitFunc func(handler *Handler)
+	ExitFunc func(handler *handlerState)
 }
 
 // GenericMode provides a generic implementation of the Mode interface
@@ -26,7 +26,7 @@ type GenericMode struct {
 
 // NewGenericMode creates a new generic mode with the specified behavior.
 func NewGenericMode(
-	handler *Handler,
+	handler *handlerState,
 	modeType domain.Mode,
 	modeName string,
 	behavior ModeBehavior,
@@ -54,7 +54,7 @@ func (m *GenericMode) Activate(opts ModeActivationOptions) {
 			noZoom.ZoomToDepth = nil
 			m.handler.activateRecursiveGridModeWithAction(noZoom)
 		case domain.ModeScroll:
-			m.handler.StartInteractiveScroll()
+			m.handler.startInteractiveScroll()
 		case domain.ModeIdle:
 			// Idle mode doesn't need activation
 		case domain.ModeMonitorSelect:

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -16,7 +16,7 @@ import (
 )
 
 // activateGridModeWithAction activates grid mode with optional action parameter.
-func (h *Handler) activateGridModeWithAction(opts ModeActivationOptions) {
+func (h *handlerState) activateGridModeWithAction(opts ModeActivationOptions) {
 	// Detect refresh before validation so we can do partial cleanup on re-activation.
 	isRefresh := h.appState.CurrentMode() == domain.ModeGrid
 
@@ -28,7 +28,7 @@ func (h *Handler) activateGridModeWithAction(opts ModeActivationOptions) {
 	)
 	if !activated {
 		if isRefresh {
-			h.exitModeLocked()
+			h.exitMode()
 		}
 
 		return
@@ -44,7 +44,7 @@ func (h *Handler) activateGridModeWithAction(opts ModeActivationOptions) {
 		// The overlay is cleared unconditionally below.
 		h.stopIndicatorPolling()
 	} else {
-		h.exitModeLocked()
+		h.exitMode()
 	}
 
 	// Clear any previous overlay content (e.g., scroll highlights) before drawing grid.
@@ -73,7 +73,7 @@ func (h *Handler) activateGridModeWithAction(opts ModeActivationOptions) {
 		h.logger.Error("Failed to draw grid", zap.Error(drawGridErr))
 
 		if isRefresh {
-			h.exitModeLocked()
+			h.exitMode()
 		}
 
 		return
@@ -87,7 +87,7 @@ func (h *Handler) activateGridModeWithAction(opts ModeActivationOptions) {
 	applyGridOptions(h.grid.Context, opts, isRefresh)
 
 	h.grid.Context.ClearSelectionPoint()
-	h.refreshGridVirtualPointerLocked()
+	h.refreshGridVirtualPointer()
 
 	if opts.Action != nil {
 		h.logger.Debug("Grid mode activated with pending action",
@@ -98,7 +98,7 @@ func (h *Handler) activateGridModeWithAction(opts ModeActivationOptions) {
 	// Only set mode and enable event tap on initial activation;
 	// during refresh these are already in the correct state.
 	if !isRefresh {
-		h.setModeLocked(domain.ModeGrid, overlay.ModeGrid)
+		h.setMode(domain.ModeGrid, overlay.ModeGrid)
 	}
 
 	h.logger.Info("Grid mode activated", zap.String("action", actionString))
@@ -107,7 +107,7 @@ func (h *Handler) activateGridModeWithAction(opts ModeActivationOptions) {
 }
 
 // createGridInstance creates a new grid with proper bounds and characters.
-func (h *Handler) createGridInstance() *domainGrid.Grid {
+func (h *handlerState) createGridInstance() *domainGrid.Grid {
 	var screenBounds image.Rectangle
 
 	if h.system != nil {
@@ -143,7 +143,7 @@ func (h *Handler) createGridInstance() *domainGrid.Grid {
 }
 
 // updateGridOverlayConfig updates the grid overlay configuration.
-func (h *Handler) updateGridOverlayConfig() {
+func (h *handlerState) updateGridOverlayConfig() {
 	if h.grid.Overlay != nil {
 		h.grid.Overlay.SetConfig(h.config.Grid)
 	}
@@ -152,7 +152,7 @@ func (h *Handler) updateGridOverlayConfig() {
 // initializeGridManager initializes the grid manager with the new grid instance.
 // It sets up subgrid configuration, creates the manager with update callbacks for
 // overlay rendering and subgrid navigation, and configures the grid router.
-func (h *Handler) initializeGridManager(gridInstance *domainGrid.Grid) {
+func (h *handlerState) initializeGridManager(gridInstance *domainGrid.Grid) {
 	const defaultGridCharacters = "asdfghjkl"
 
 	// Defensive check for grid instance
@@ -239,7 +239,7 @@ func (h *Handler) initializeGridManager(gridInstance *domainGrid.Grid) {
 			hideUnmatched := h.config.Grid.HideUnmatched && len(input) > 0
 			h.renderer.SetHideUnmatched(hideUnmatched)
 			h.renderer.UpdateGridMatches(input)
-			h.refreshGridVirtualPointerLocked()
+			h.refreshGridVirtualPointer()
 		},
 		// Subgrid callback: moves cursor and shows subgrid overlay
 		func(cell *domainGrid.Cell) {
@@ -264,7 +264,7 @@ func (h *Handler) initializeGridManager(gridInstance *domainGrid.Grid) {
 
 				if !h.grid.Context.CursorFollowSelection() {
 					h.renderer.ShowSubgrid(cell)
-					h.refreshGridVirtualPointerLocked()
+					h.refreshGridVirtualPointer()
 
 					return
 				}
@@ -277,7 +277,7 @@ func (h *Handler) initializeGridManager(gridInstance *domainGrid.Grid) {
 
 			// Draw 3x3 subgrid inside selected cell
 			h.renderer.ShowSubgrid(cell)
-			h.refreshGridVirtualPointerLocked()
+			h.refreshGridVirtualPointer()
 		},
 		h.logger,
 	)

--- a/internal/app/modes/grid_test.go
+++ b/internal/app/modes/grid_test.go
@@ -42,7 +42,7 @@ func TestHandleGridModeKey_CompleteSelectionDoesNotMoveWhenCursorFollowSelection
 		zap.NewNop(),
 	)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		config: &config.Config{
 			Grid: config.GridConfig{
 				Enabled:    true,
@@ -69,7 +69,7 @@ func TestHandleGridModeKey_CompleteSelectionDoesNotMoveWhenCursorFollowSelection
 			Context: &gridcomponent.Context{},
 		},
 		screenBounds: image.Rect(0, 0, 100, 100),
-	}
+	})
 
 	handler.grid.Context.SetCursorFollowSelection(false)
 
@@ -99,7 +99,7 @@ func TestHandleGridModeKey_EnteringSubgridDoesNotMoveWhenCursorFollowSelectionDi
 		zap.NewNop(),
 	)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		config: &config.Config{
 			Grid: config.GridConfig{
 				Enabled:    true,
@@ -130,7 +130,7 @@ func TestHandleGridModeKey_EnteringSubgridDoesNotMoveWhenCursorFollowSelectionDi
 			recursivegridcomponent.Style{},
 		),
 		screenBounds: image.Rect(0, 0, 100, 100),
-	}
+	})
 
 	handler.initializeGridManager(gridInstance)
 	handler.grid.Router = domainGrid.NewRouter(handler.grid.Manager, zap.NewNop())

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -44,12 +44,38 @@ type Mode interface {
 	ModeType() domain.Mode
 }
 
-// Handler encapsulates mode-specific logic and dependencies.
+// Handler is the locked outer shell of the mode handler: it owns the mutexes
+// and the exported entry points, each of which takes mu and delegates to the
+// embedded handlerState. Methods on Handler may lock; methods on state may not.
 type Handler struct {
-	// mu serializes access to Handler state between the event tap callback thread
+	handlerState
+
+	// mu serializes access to handler state between the event tap callback thread
 	// and timer goroutines (e.g., refreshHintsTimer). All public entry points
 	// (HandleKeyPress, ActivateMode, ExitMode) and timer callbacks must hold this lock.
 	mu sync.Mutex
+
+	// moveMonitorMu serializes MoveMonitor invocations. Lock ordering is
+	// always moveMonitorMu -> h.mu (MoveMonitor holds this while calling
+	// refreshActiveModeOnNewScreen, which acquires h.mu via the
+	// Refresh*ForScreenChange helpers). Never acquire in the reverse order.
+	moveMonitorMu sync.Mutex
+}
+
+// state carries every field of the mode handler and every method that runs
+// with Handler.mu already held. It deliberately has no mutex: a state method
+// cannot lock, and it cannot reach the exported (locking) Handler surface, so
+// "caller must hold the lock" is enforced by the compiler instead of by the
+// old *Locked naming convention. Mode implementations receive a *state.
+//
+// The one escape hatch is outer, the back-reference to the owning Handler.
+// It exists solely so state methods can schedule deferred work (timers,
+// goroutines) whose callbacks must take the lock when they later fire. Never
+// call anything on outer synchronously from a state method — that is the
+// self-deadlock the split exists to prevent.
+type handlerState struct {
+	// outer is the owning Handler. Deferred callbacks only; see the type comment.
+	outer *Handler
 
 	config         *configpkg.Config
 	themeProvider  configpkg.ThemeProvider
@@ -105,12 +131,6 @@ type Handler struct {
 	suppressedUntil       time.Time
 	modifierFreshPress    map[action.Modifiers]bool
 	debounceNotify        chan struct{} // test-only: signaled when a debounce callback completes
-
-	// moveMonitorMu serializes MoveMonitor invocations. Lock ordering is
-	// always moveMonitorMu -> h.mu (MoveMonitor holds this while calling
-	// refreshActiveModeOnNewScreen, which acquires h.mu via the
-	// Refresh*ForScreenChange helpers). Never acquire in the reverse order.
-	moveMonitorMu sync.Mutex
 
 	// Indicator polling (shared by all modes)
 	indicatorTicker *time.Ticker
@@ -207,7 +227,9 @@ func NewHandler(deps HandlerDeps) *Handler {
 		}
 	}
 
-	handler := &Handler{
+	handler := &Handler{}
+	handler.handlerState = handlerState{
+		outer:                  handler,
 		ctx:                    deps.Ctx,
 		config:                 deps.Config,
 		logger:                 logger,
@@ -236,13 +258,15 @@ func NewHandler(deps HandlerDeps) *Handler {
 		cycleHintIndex:         -1,
 	}
 
-	// Initialize mode implementations
+	// Initialize mode implementations. Modes run with the lock already held,
+	// so they are built on the inner state and cannot re-enter the locked
+	// surface.
 	handler.modes = map[domain.Mode]Mode{
-		domain.ModeHints:         NewHintsMode(handler),
-		domain.ModeGrid:          NewGridMode(handler),
-		domain.ModeScroll:        NewScrollMode(handler),
-		domain.ModeRecursiveGrid: NewRecursiveGridMode(handler),
-		domain.ModeMonitorSelect: NewMonitorSelectMode(handler),
+		domain.ModeHints:         NewHintsMode(&handler.handlerState),
+		domain.ModeGrid:          NewGridMode(&handler.handlerState),
+		domain.ModeScroll:        NewScrollMode(&handler.handlerState),
+		domain.ModeRecursiveGrid: NewRecursiveGridMode(&handler.handlerState),
+		domain.ModeMonitorSelect: NewMonitorSelectMode(&handler.handlerState),
 	}
 
 	return handler
@@ -272,7 +296,7 @@ func (h *Handler) UpdateConfig(config *configpkg.Config) {
 // (origin 0,0); on backends whose overlay spans the whole desktop (Linux X11
 // and Wayland) the origin lets them translate that content onto the correct
 // monitor. It is a no-op where each screen owns an overlay window (macOS).
-func (h *Handler) setScreenBounds(bounds image.Rectangle) {
+func (h *handlerState) setScreenBounds(bounds image.Rectangle) {
 	h.screenBounds = bounds
 
 	if h.overlayManager != nil {
@@ -280,7 +304,7 @@ func (h *Handler) setScreenBounds(bounds image.Rectangle) {
 	}
 }
 
-func (h *Handler) focusedBundleID() string {
+func (h *handlerState) focusedBundleID() string {
 	if h.actionService == nil {
 		return ""
 	}
@@ -295,9 +319,8 @@ func (h *Handler) focusedBundleID() string {
 	return bundleID
 }
 
-// stopHeldRepeatLocked cancels any running held-key repeat goroutine.
-// Caller must hold h.mu.
-func (h *Handler) stopHeldRepeatLocked() {
+// stopHeldRepeat cancels any running held-key repeat goroutine.
+func (h *handlerState) stopHeldRepeat() {
 	if h.heldRepeatingCancel != nil {
 		h.heldRepeatingCancel()
 		h.heldRepeatingCancel = nil

--- a/internal/app/modes/handler_actions.go
+++ b/internal/app/modes/handler_actions.go
@@ -34,7 +34,7 @@ func (h *Handler) ResetCurrentMode() {
 					h.logger.Error("Failed to redraw grid after reset", zap.Error(err))
 				}
 
-				h.refreshGridVirtualPointerLocked()
+				h.refreshGridVirtualPointer()
 			}
 		}
 	case domain.ModeRecursiveGrid:
@@ -52,7 +52,7 @@ func (h *Handler) ResetCurrentMode() {
 
 			if h.recursiveGrid.Context != nil {
 				if !h.recursiveGrid.Context.CursorFollowSelection() {
-					h.refreshRecursiveGridVirtualPointerLocked()
+					h.refreshRecursiveGridVirtualPointer()
 
 					return
 				}
@@ -70,7 +70,7 @@ func (h *Handler) ResetCurrentMode() {
 		if h.monitorSelect != nil {
 			h.monitorSelect.input = ""
 			h.monitorSelect.selectedIndex = 0
-			h.redrawMonitorSelectLocked()
+			h.redrawMonitorSelect()
 		}
 	case domain.ModeIdle, domain.ModeHints, domain.ModeScroll:
 		// no-op
@@ -111,7 +111,7 @@ func (h *Handler) BackspaceCurrentMode() {
 
 			if h.recursiveGrid.Context != nil {
 				if !h.recursiveGrid.Context.CursorFollowSelection() {
-					h.refreshRecursiveGridVirtualPointerLocked()
+					h.refreshRecursiveGridVirtualPointer()
 
 					return
 				}
@@ -131,7 +131,7 @@ func (h *Handler) BackspaceCurrentMode() {
 	case domain.ModeMonitorSelect:
 		if h.monitorSelect != nil {
 			h.monitorSelect.Backspace()
-			h.redrawMonitorSelectLocked()
+			h.redrawMonitorSelect()
 		}
 	case domain.ModeIdle, domain.ModeScroll:
 		// no-op
@@ -175,7 +175,7 @@ func (h *Handler) MoveCellCurrentMode(dir domain.Direction, count int) {
 
 		if h.recursiveGrid.Context != nil &&
 			!h.recursiveGrid.Context.CursorFollowSelection() {
-			h.refreshRecursiveGridVirtualPointerLocked()
+			h.refreshRecursiveGridVirtualPointer()
 
 			return
 		}
@@ -197,7 +197,7 @@ func (h *Handler) StartHintSearch() error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	return h.startHintSearchLocked()
+	return h.startHintSearch()
 }
 
 // CycleHint cycles through visible hints in hints mode, selecting the next or previous one.
@@ -313,7 +313,7 @@ func (h *Handler) CycleHint(ctx context.Context, backward bool, executeAction bo
 	return nil
 }
 
-func (h *Handler) startHintSearchLocked() error {
+func (h *handlerState) startHintSearch() error {
 	if h.appState.CurrentMode() != domain.ModeHints {
 		return derrors.New(derrors.CodeInvalidInput, "search_hints requires hints mode")
 	}
@@ -326,7 +326,7 @@ func (h *Handler) startHintSearchLocked() error {
 		return derrors.New(derrors.CodeActionFailed, "hints not available")
 	}
 
-	h.stopHintSearchTextInputLocked(true)
+	h.stopHintSearchTextInput(true)
 	h.hints.Context.SetSearchQuery("")
 	h.hints.Context.SetSearchActive(true)
 
@@ -364,8 +364,8 @@ func (h *Handler) startHintSearchLocked() error {
 			h.ctx,
 			ports.TextInputCallbacks{
 				OnQueryChanged: func(query string) {
-					h.mu.Lock()
-					defer h.mu.Unlock()
+					h.outer.mu.Lock()
+					defer h.outer.mu.Unlock()
 
 					if h.appState.CurrentMode() != domain.ModeHints || h.hints == nil ||
 						h.hints.Context == nil {
@@ -380,8 +380,8 @@ func (h *Handler) startHintSearchLocked() error {
 					h.applyHintSearchFilter()
 				},
 				OnConfirm: func() {
-					h.mu.Lock()
-					defer h.mu.Unlock()
+					h.outer.mu.Lock()
+					defer h.outer.mu.Unlock()
 
 					if h.appState.CurrentMode() != domain.ModeHints {
 						return
@@ -390,8 +390,8 @@ func (h *Handler) startHintSearchLocked() error {
 					h.confirmHintSearch()
 				},
 				OnCancel: func() {
-					h.mu.Lock()
-					defer h.mu.Unlock()
+					h.outer.mu.Lock()
+					defer h.outer.mu.Unlock()
 
 					if h.appState.CurrentMode() != domain.ModeHints {
 						return
@@ -415,7 +415,7 @@ func (h *Handler) startHintSearchLocked() error {
 	return nil
 }
 
-func (h *Handler) stopHintSearchTextInputLocked(keepEventTapDisabled bool) {
+func (h *handlerState) stopHintSearchTextInput(keepEventTapDisabled bool) {
 	if h.hintSearchTextInputActive && h.textInput != nil {
 		// Use Background context since this may be called during cleanup,
 		// after h.ctx has already been canceled.

--- a/internal/app/modes/handler_refresh.go
+++ b/internal/app/modes/handler_refresh.go
@@ -79,14 +79,14 @@ func (h *Handler) RefreshHintsForScreenChange(
 	)
 	if showHintsErr != nil {
 		h.logger.Error("Failed to refresh hints after screen change", zap.Error(showHintsErr))
-		h.exitModeLocked()
+		h.exitMode()
 
 		return false
 	}
 
 	if len(domainHints) == 0 {
 		h.logger.Debug("No hints after screen change refresh")
-		h.exitModeLocked()
+		h.exitMode()
 
 		return false
 	}
@@ -96,7 +96,7 @@ func (h *Handler) RefreshHintsForScreenChange(
 	filtered := filterHintsForScreen(allHints, h.screenBounds)
 	if len(filtered) == 0 {
 		h.logger.Debug("No hints on active screen after filter; skipping refresh")
-		h.exitModeLocked()
+		h.exitMode()
 
 		return false
 	}
@@ -161,7 +161,7 @@ func (h *Handler) RefreshGridForScreenChange() bool {
 
 	// Ensure the virtual pointer is hidden (DrawGrid may clear cursorIndicatorVisible
 	// via NeruClearOverlay, but we explicitly hide it for consistency).
-	h.refreshGridVirtualPointerLocked()
+	h.refreshGridVirtualPointer()
 
 	return true
 }
@@ -216,7 +216,7 @@ func (h *Handler) RefreshRecursiveGridForScreenChange() bool {
 
 	// Redraw the overlay with the remapped grid.
 	h.updateRecursiveGridOverlay()
-	h.refreshRecursiveGridVirtualPointerLocked()
+	h.refreshRecursiveGridVirtualPointer()
 
 	return true
 }
@@ -260,7 +260,7 @@ func (h *Handler) RefreshHintsForThemeChange() bool {
 
 	drawHintsErr := h.overlayManager.DrawHintsWithStyle(
 		overlayHints,
-		h.currentHintStyleLocked(),
+		h.currentHintStyle(),
 	)
 	if drawHintsErr != nil {
 		h.logger.Error("Failed to refresh hints after theme change", zap.Error(drawHintsErr))
@@ -303,7 +303,7 @@ func (h *Handler) RefreshGridForThemeChange() bool {
 		return false
 	}
 
-	h.refreshGridVirtualPointerLocked()
+	h.refreshGridVirtualPointer()
 
 	return true
 }
@@ -322,7 +322,7 @@ func (h *Handler) RefreshRecursiveGridForThemeChange() bool {
 	}
 
 	h.updateRecursiveGridOverlay()
-	h.refreshRecursiveGridVirtualPointerLocked()
+	h.refreshRecursiveGridVirtualPointer()
 
 	return true
 }

--- a/internal/app/modes/handler_test_helper_test.go
+++ b/internal/app/modes/handler_test_helper_test.go
@@ -1,0 +1,11 @@
+package modes
+
+// newHandlerWithState builds a Handler around the given state for tests,
+// wiring the outer back-reference the way NewHandler does.
+func newHandlerWithState(st handlerState) *Handler {
+	handler := new(Handler)
+	st.outer = handler
+	handler.handlerState = st
+
+	return handler
+}

--- a/internal/app/modes/hintdraw.go
+++ b/internal/app/modes/hintdraw.go
@@ -9,13 +9,13 @@ import (
 	domainHint "github.com/y3owk1n/neru/internal/domain/hint"
 )
 
-// drawHintsLocked renders a hint set onto the overlay. It is the manager's
+// drawHints renders a hint set onto the overlay. It is the manager's
 // update callback, so it runs on activation, on every keystroke that narrows
 // the labels, and on reset.
 //
 // The caller must hold h.mu. SetHints, Reset and HandleInput already do; the
 // manager's debounced timer takes it through the mutex it was built with.
-func (h *Handler) drawHintsLocked(filteredHints []*domainHint.Interface) {
+func (h *handlerState) drawHints(filteredHints []*domainHint.Interface) {
 	if h.hints.Overlay == nil {
 		return
 	}
@@ -39,7 +39,7 @@ func (h *Handler) drawHintsLocked(filteredHints []*domainHint.Interface) {
 
 	drawHintsErr := h.overlayManager.DrawHintsWithStyle(
 		overlayHints,
-		h.currentHintStyleLocked(),
+		h.currentHintStyle(),
 	)
 	if drawHintsErr != nil {
 		h.logger.Error("Failed to update hints overlay", zap.Error(drawHintsErr))

--- a/internal/app/modes/hintoptions.go
+++ b/internal/app/modes/hintoptions.go
@@ -108,7 +108,7 @@ type hintOverrides struct {
 // context, which applyHintOptions has just written, so a refresh sees what the
 // mode was activated with rather than the empty options it carries. The raw
 // options are the fallback when there is no context.
-func (h *Handler) resolveHintOverrides(opts ModeActivationOptions) hintOverrides {
+func (h *handlerState) resolveHintOverrides(opts ModeActivationOptions) hintOverrides {
 	if h.hints != nil && h.hints.Context != nil {
 		return hintOverrides{
 			strategy:       h.hints.Context.StrategyOverride(),
@@ -126,8 +126,8 @@ func (h *Handler) resolveHintOverrides(opts ModeActivationOptions) hintOverrides
 
 // abandonHintActivation gives up on an activation. A refresh must also exit the
 // mode, or its overlay keeps showing labels that no longer point at anything.
-func (h *Handler) abandonHintActivation(isRefresh bool) {
+func (h *handlerState) abandonHintActivation(isRefresh bool) {
 	if isRefresh {
-		h.exitModeLocked()
+		h.exitMode()
 	}
 }

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -22,10 +22,10 @@ func debugElapsed(logger *zap.Logger, start time.Time, msg string, fields ...zap
 	logger.Debug(msg, append(fields, zap.Duration("elapsed", time.Since(start)))...)
 }
 
-// currentHintStyleLocked resolves theme-aware hint overlay colors from the live
+// currentHintStyle resolves theme-aware hint overlay colors from the live
 // config, matching search-input and mode-indicator draw paths. Caller must
 // hold h.mu.
-func (h *Handler) currentHintStyleLocked() hints.StyleMode {
+func (h *handlerState) currentHintStyle() hints.StyleMode {
 	style := hints.BuildStyle(h.config.Hints, h.themeProvider)
 	if h.hints != nil {
 		h.hints.Style = style
@@ -76,13 +76,13 @@ func (h *Handler) ActivateModeWithOptions(mode domain.Mode, opts ModeActivationO
 	// Toggle: if the mode is already active and --toggle was specified,
 	// exit to idle instead of re-activating
 	if opts.Toggle != nil && *opts.Toggle && h.appState.CurrentMode() == mode {
-		h.exitModeLocked()
+		h.exitMode()
 
 		return
 	}
 
 	if mode == domain.ModeIdle {
-		h.exitModeLocked()
+		h.exitMode()
 
 		return
 	}
@@ -146,7 +146,7 @@ func filterHintsForScreen(
 }
 
 // activateHintModeWithAction activates hint mode with optional action parameter.
-func (h *Handler) activateHintModeWithAction(opts ModeActivationOptions) {
+func (h *handlerState) activateHintModeWithAction(opts ModeActivationOptions) {
 	h.activateHintModeInternal(opts)
 
 	// Repeat is stored after activation, by which point the context exists.
@@ -158,7 +158,7 @@ func (h *Handler) activateHintModeWithAction(opts ModeActivationOptions) {
 // activateHintModeInternal activates hint mode with an optional action.
 // It handles mode validation, overlay positioning, element collection, hint
 // generation, and UI setup for hint-based navigation.
-func (h *Handler) activateHintModeInternal(opts ModeActivationOptions) {
+func (h *handlerState) activateHintModeInternal(opts ModeActivationOptions) {
 	// Detect refresh before validation so we can clean up on failure
 	isRefresh := h.appState.CurrentMode() == domain.ModeHints
 
@@ -198,7 +198,7 @@ func (h *Handler) activateHintModeInternal(opts ModeActivationOptions) {
 		// fails.
 		h.stopIndicatorPolling()
 	} else {
-		h.exitModeLocked()
+		h.exitMode()
 	}
 
 	if actionString == domain.UnknownAction {
@@ -265,7 +265,7 @@ func (h *Handler) activateHintModeInternal(opts ModeActivationOptions) {
 
 	var permissionOk bool
 
-	activeScreenBounds, bundleID, strategy, permissionOk = h.ensureScreenCapturePermissionsLocked(
+	activeScreenBounds, bundleID, strategy, permissionOk = h.ensureScreenCapturePermissions(
 		activeScreenBounds,
 		bundleID,
 		strategy,
@@ -329,15 +329,15 @@ func (h *Handler) activateHintModeInternal(opts ModeActivationOptions) {
 	// Note: Manager is created once and reused across activations (holds mutable state).
 	// Router is recreated each activation (stateless, needs fresh exit keys from config).
 	if h.hints.Context.Manager() == nil {
-		manager := domainHint.NewManager(h.logger, &h.mu)
-		manager.SetUpdateCallback(h.drawHintsLocked)
+		manager := domainHint.NewManager(h.logger, &h.outer.mu)
+		manager.SetUpdateCallback(h.drawHints)
 		h.hints.Context.SetManager(manager)
 	}
 
 	// Only set mode and enable event tap on initial activation;
 	// during refresh these are already in the correct state.
 	if !isRefresh {
-		h.setModeLocked(domain.ModeHints, overlay.ModeHints)
+		h.setMode(domain.ModeHints, overlay.ModeHints)
 	} else {
 		// During a refresh (e.g., after Cmd+Tab passthrough) the focused app
 		// may have changed. Re-sync the modifier passthrough blacklist so
@@ -353,7 +353,7 @@ func (h *Handler) activateHintModeInternal(opts ModeActivationOptions) {
 	setHintsErr := h.hints.Context.SetHints(hintCollection)
 	if setHintsErr != nil {
 		h.logger.Error("Failed to set hints in manager", zap.Error(setHintsErr))
-		h.exitModeLocked()
+		h.exitMode()
 
 		return
 	}
@@ -373,7 +373,7 @@ func (h *Handler) activateHintModeInternal(opts ModeActivationOptions) {
 	h.logger.Info("Hints mode activated", fields...)
 
 	if opts.Search != nil && *opts.Search {
-		err := h.startHintSearchLocked()
+		err := h.startHintSearch()
 		if err != nil {
 			h.logger.Error("Failed to start hint search on activation", zap.Error(err))
 		}
@@ -382,10 +382,10 @@ func (h *Handler) activateHintModeInternal(opts ModeActivationOptions) {
 	h.startIndicatorPolling(domain.ModeHints)
 }
 
-// ensureScreenCapturePermissionsLocked checks and requests screen capture permissions.
+// ensureScreenCapturePermissions checks and requests screen capture permissions.
 // It releases h.mu during the modal prompt to avoid blocking other threads.
 // Returns the updated activeScreenBounds, bundleID, strategy, and whether it is safe to proceed.
-func (h *Handler) ensureScreenCapturePermissionsLocked(
+func (h *handlerState) ensureScreenCapturePermissions(
 	activeScreenBounds image.Rectangle,
 	bundleID string,
 	strategy string,
@@ -400,11 +400,16 @@ func (h *Handler) ensureScreenCapturePermissionsLocked(
 	}
 
 	session := h.modeSession
-	h.mu.Unlock()
+
+	// Sanctioned mid-flight unlock: the permission request blocks on a modal
+	// dialog and the lock must not be held across it (see the SystemPort
+	// contract). The mode-session token below detects any state change that
+	// happened while unlocked, and the caller bails when it did.
+	h.outer.mu.Unlock()
 
 	consent := h.system.RequestScreenCapturePermission(h.ctx)
 
-	h.mu.Lock()
+	h.outer.mu.Lock()
 
 	// Check if state changed while we were unlocked.
 	if h.ctx.Err() != nil || h.modeSession != session {
@@ -422,7 +427,7 @@ func (h *Handler) ensureScreenCapturePermissionsLocked(
 	}
 
 	if consent == ports.ScreenCaptureCanceled {
-		h.exitModeLocked()
+		h.exitMode()
 
 		return activeScreenBounds, bundleID, strategy, false
 	}

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -18,14 +18,14 @@ const (
 // startIndicatorPolling starts a goroutine that polls the cursor position and
 // updates the mode indicator and sticky modifiers indicator overlays.
 // It is shared by all navigation modes.
-func (h *Handler) startIndicatorPolling(mode domain.Mode) {
+func (h *handlerState) startIndicatorPolling(mode domain.Mode) {
 	// If polling is already active, do not start another goroutine.
 	if h.indicatorTicker != nil || h.indicatorStopCh != nil {
 		return
 	}
 
-	// All callers hold h.mu, so we can call the *Locked helpers directly.
-	if h.config == nil || !h.shouldPollCursorOverlaysLocked(mode) {
+	// All callers hold h.mu, so state methods are callable directly.
+	if h.config == nil || !h.shouldPollCursorOverlays(mode) {
 		return
 	}
 	// Disable exclusive keyboard so scroll events pass through to applications
@@ -53,7 +53,7 @@ func (h *Handler) startIndicatorPolling(mode domain.Mode) {
 
 	h.indicatorTicker = ticker
 
-	go h.runIndicatorPolling(stopCh, doneCh, ticker)
+	go h.outer.runIndicatorPolling(stopCh, doneCh, ticker)
 }
 
 // runIndicatorPolling is the polling loop. It exits when stopCh closes.
@@ -127,7 +127,7 @@ func (h *Handler) pollIndicatorsOnce(ctx context.Context) {
 	snap := indicatorSnapshot{
 		showModeIndicator:  h.shouldShowModeIndicator(h.appState.CurrentMode()),
 		stickyEnabled:      h.stickyModifiersEnabled(),
-		showVirtualPointer: h.shouldShowCursorFollowingVirtualPointerLocked(),
+		showVirtualPointer: h.shouldShowCursorFollowingVirtualPointer(),
 	}
 
 	if snap.showVirtualPointer {
@@ -140,10 +140,10 @@ func (h *Handler) pollIndicatorsOnce(ctx context.Context) {
 		}
 	}
 
-	snap.stickyPoint = h.stickyIndicatorAnchorLocked(image.Pt(cursorX, cursorY))
+	snap.stickyPoint = h.stickyIndicatorAnchor(image.Pt(cursorX, cursorY))
 
 	if !image.Pt(cursorX, cursorY).In(h.screenBounds) && h.system != nil {
-		if h.adoptChangedScreenBoundsLocked(ctx) {
+		if h.adoptChangedScreenBounds(ctx) {
 			// h.mu is already released; skip the draw so the next tick works
 			// from the updated bounds.
 			return
@@ -162,10 +162,10 @@ func (h *Handler) pollIndicatorsOnce(ctx context.Context) {
 	h.overlayManager.Flush()
 }
 
-// adoptChangedScreenBoundsLocked re-reads the screen bounds and resizes the
+// adoptChangedScreenBounds re-reads the screen bounds and resizes the
 // indicator overlays when they changed. It reports true when it did so, in
 // which case it has already released h.mu; otherwise the lock is still held.
-func (h *Handler) adoptChangedScreenBoundsLocked(ctx context.Context) bool {
+func (h *Handler) adoptChangedScreenBounds(ctx context.Context) bool {
 	boundsCtx, boundsCancel := context.WithTimeout(ctx, indicatorPollTimeout)
 	newBounds, boundsErr := h.system.ScreenBounds(boundsCtx)
 
@@ -246,7 +246,7 @@ func (h *Handler) drawIndicators(snap indicatorSnapshot, cursorX, cursorY int) {
 
 // stopIndicatorPolling stops the indicator polling goroutine and cleans up
 // both mode indicator and sticky modifiers indicator overlays.
-func (h *Handler) stopIndicatorPolling() {
+func (h *handlerState) stopIndicatorPolling() {
 	// Restore keyboard capture if uinput scroll was active. Never re-enable it
 	// while an evdev keyboard grab owns the keyboard: on wlroots compositors the
 	// overlay's exclusive keyboard grab deactivates the focused app's toplevel,
@@ -277,9 +277,9 @@ func (h *Handler) stopIndicatorPolling() {
 		stickyInd.Clear()
 		stickyInd.Hide()
 	}
-	// All callers hold h.mu, so we can call the *Locked helpers directly.
-	if !h.shouldShowCursorFollowingVirtualPointerLocked() {
-		h.hideCursorFollowingVirtualPointerLocked()
+	// All callers hold h.mu, so state methods are callable directly.
+	if !h.shouldShowCursorFollowingVirtualPointer() {
+		h.hideCursorFollowingVirtualPointer()
 	}
 	// Clean up resources after loop has exited.
 	if h.indicatorTicker != nil {
@@ -288,7 +288,7 @@ func (h *Handler) stopIndicatorPolling() {
 	}
 }
 
-func (h *Handler) modeIndicatorEnabled(mode domain.Mode) bool {
+func (h *handlerState) modeIndicatorEnabled(mode domain.Mode) bool {
 	if h.config == nil {
 		return false
 	}
@@ -315,7 +315,7 @@ func (h *Handler) shouldShowModeIndicator(mode domain.Mode) bool {
 	return h.modeIndicatorEnabled(mode)
 }
 
-func (h *Handler) stickyIndicatorAnchorLocked(cursorPoint image.Point) image.Point {
+func (h *handlerState) stickyIndicatorAnchor(cursorPoint image.Point) image.Point {
 	switch h.appState.CurrentMode() {
 	case domain.ModeGrid:
 		if h.grid == nil || h.grid.Context == nil || h.grid.Context.CursorFollowSelection() {
@@ -349,7 +349,7 @@ func (h *Handler) stickyIndicatorAnchorLocked(cursorPoint image.Point) image.Poi
 // by type assertion: elsewhere the assertion fails and the call is a no-op,
 // which is the right behavior — no other backend's overlay takes the keyboard
 // away from the focused application in the first place.
-func setOverlayKeyboardCapture(h *Handler, enabled bool) {
+func setOverlayKeyboardCapture(h *handlerState, enabled bool) {
 	if !h.allowsOverlayKeyboardPassthrough() {
 		return
 	}

--- a/internal/app/modes/indicator_polling_test.go
+++ b/internal/app/modes/indicator_polling_test.go
@@ -17,18 +17,18 @@ func TestStickyIndicatorAnchor_UsesGridSelectionWhenCursorFollowDisabled(t *test
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeGrid)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState: appState,
 		logger:   zap.NewNop(),
 		grid: &components.GridComponent{
 			Context: &gridcomponent.Context{},
 		},
-	}
+	})
 
 	handler.grid.Context.SetCursorFollowSelection(false)
 	handler.grid.Context.SetSelectionPoint(image.Pt(40, 60))
 
-	got := handler.stickyIndicatorAnchorLocked(image.Pt(10, 20))
+	got := handler.stickyIndicatorAnchor(image.Pt(10, 20))
 
 	want := image.Pt(40, 60)
 	if got != want {
@@ -40,18 +40,18 @@ func TestStickyIndicatorAnchor_UsesRecursiveGridSelectionWhenCursorFollowDisable
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeRecursiveGrid)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState: appState,
 		logger:   zap.NewNop(),
 		recursiveGrid: &components.RecursiveGridComponent{
 			Context: &recursivegridcomponent.Context{},
 		},
-	}
+	})
 
 	handler.recursiveGrid.Context.SetCursorFollowSelection(false)
 	handler.recursiveGrid.Context.SetSelectionPoint(image.Pt(75, 25))
 
-	got := handler.stickyIndicatorAnchorLocked(image.Pt(10, 20))
+	got := handler.stickyIndicatorAnchor(image.Pt(10, 20))
 
 	want := image.Pt(75, 25)
 	if got != want {
@@ -63,18 +63,18 @@ func TestStickyIndicatorAnchor_UsesCursorWhenGridFollowsSelection(t *testing.T) 
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeGrid)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState: appState,
 		logger:   zap.NewNop(),
 		grid: &components.GridComponent{
 			Context: &gridcomponent.Context{},
 		},
-	}
+	})
 
 	handler.grid.Context.SetCursorFollowSelection(true)
 	handler.grid.Context.SetSelectionPoint(image.Pt(40, 60))
 
-	got := handler.stickyIndicatorAnchorLocked(image.Pt(10, 20))
+	got := handler.stickyIndicatorAnchor(image.Pt(10, 20))
 
 	want := image.Pt(10, 20)
 	if got != want {

--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -47,12 +47,12 @@ func (h *Handler) HandleFedKeyPress(key string) {
 	defer h.mu.Unlock()
 
 	repeatBefore := h.heldRepeatingKey
-	h.handleKeyPressLocked(key)
+	h.handleKeyPress(key)
 
 	// Only release a repeat this fed press just started; leave any pre-existing
 	// (physically held) repeat untouched.
 	if repeatBefore == "" && h.heldRepeatingKey != "" {
-		h.handleKeyPressLocked(keyUpPrefix + base)
+		h.handleKeyPress(keyUpPrefix + base)
 	}
 }
 
@@ -61,13 +61,13 @@ func (h *Handler) HandleKeyPress(key string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	h.handleKeyPressLocked(key)
+	h.handleKeyPress(key)
 }
 
-// handleKeyPressLocked contains the key-dispatch logic. The caller must hold
+// handleKeyPress contains the key-dispatch logic. The caller must hold
 // h.mu; the whole body runs under the lock so held-repeat and modifier-toggle
 // state stays consistent across the dispatch.
-func (h *Handler) handleKeyPressLocked(key string) {
+func (h *handlerState) handleKeyPress(key string) {
 	// Handle key-up events for held-key repeat suppression.
 	// The eventtap emits modifier-free key names on key-up, so we compare
 	// only the base key name (last segment after "+") case-insensitively.
@@ -79,7 +79,7 @@ func (h *Handler) handleKeyPressLocked(key string) {
 			}
 
 			if strings.EqualFold(releasedKey, baseHeld) {
-				h.stopHeldRepeatLocked()
+				h.stopHeldRepeat()
 			}
 		}
 
@@ -149,14 +149,14 @@ func (h *Handler) handleKeyPressLocked(key string) {
 	if rawKey != key {
 		if actions, bindKey, ok := h.handleHotkey(key, bundleID); ok {
 			if len(actions) > 0 {
-				h.maybeStartHeldRepeatLocked(key, bindKey, actions)
+				h.maybeStartHeldRepeat(key, bindKey, actions)
 			}
 
 			return
 		}
 	} else if actions, bindKey, ok := h.handleHotkey(rawKey, bundleID); ok {
 		if len(actions) > 0 {
-			h.maybeStartHeldRepeatLocked(rawKey, bindKey, actions)
+			h.maybeStartHeldRepeat(rawKey, bindKey, actions)
 		}
 
 		return
@@ -166,7 +166,7 @@ func (h *Handler) handleKeyPressLocked(key string) {
 }
 
 // handleModeSpecificKey handles mode-specific key processing.
-func (h *Handler) handleModeSpecificKey(key string) {
+func (h *handlerState) handleModeSpecificKey(key string) {
 	mode, exists := h.modes[h.appState.CurrentMode()]
 	if !exists {
 		return
@@ -178,7 +178,7 @@ func (h *Handler) handleModeSpecificKey(key string) {
 // modeHasAppHotkeyOverrides reports whether the given mode defines any per-app
 // hotkey overrides. That is the only situation requiring the focused app's
 // bundle ID to be resolved to select the correct per-mode hotkey table.
-func (h *Handler) modeHasAppHotkeyOverrides(mode domain.Mode) bool {
+func (h *handlerState) modeHasAppHotkeyOverrides(mode domain.Mode) bool {
 	switch mode {
 	case domain.ModeHints:
 		return h.config.Hints.HasAppHotkeyOverrides()
@@ -237,7 +237,7 @@ func (h *Handler) ModeHotkeyOverride(key string) ([]string, bool) {
 
 // stripStickyModifiersFromKey removes any currently active sticky modifiers from the
 // incoming key string so that physical injections don't break expected key bindings.
-func (h *Handler) stripStickyModifiersFromKey(key string, mods action.Modifiers) string {
+func (h *handlerState) stripStickyModifiersFromKey(key string, mods action.Modifiers) string {
 	parts := strings.Split(key, "+")
 	if len(parts) <= 1 {
 		return key
@@ -283,7 +283,7 @@ func (h *Handler) stripStickyModifiersFromKey(key string, mods action.Modifiers)
 // where no action is dispatched yet.
 // Caller must hold h.mu. The bundleID is the focused app's bundle identifier,
 // resolved once by the caller to avoid redundant accessibility IPC calls.
-func (h *Handler) handleHotkey(key, bundleID string) (
+func (h *handlerState) handleHotkey(key, bundleID string) (
 	[]string, string, bool,
 ) {
 	if h.executeActionSequence == nil {
@@ -403,7 +403,7 @@ func isHotkeySequenceStart(
 	return false
 }
 
-func (h *Handler) dispatchHotkeyActions(
+func (h *handlerState) dispatchHotkeyActions(
 	modeName string,
 	bindKey string,
 	rawKey string,
@@ -447,13 +447,13 @@ func (h *Handler) dispatchHotkeyActions(
 	}()
 }
 
-// maybeStartHeldRepeatLocked starts a custom repeat goroutine if the given
+// maybeStartHeldRepeat starts a custom repeat goroutine if the given
 // actions are held-repeatable (scroll, page, mouse move) and held-key
 // repeat is enabled in config.
 // actions is the already-resolved action list from handleHotkey.
 // bindKey is the normalised config-binding key (for consistent logging).
 // Caller must hold h.mu.
-func (h *Handler) maybeStartHeldRepeatLocked(key, bindKey string, actions []string) {
+func (h *handlerState) maybeStartHeldRepeat(key, bindKey string, actions []string) {
 	if h.heldRepeatingCancel != nil {
 		return
 	}
@@ -462,14 +462,14 @@ func (h *Handler) maybeStartHeldRepeatLocked(key, bindKey string, actions []stri
 		return
 	}
 
-	h.startHeldRepeatLocked(key, bindKey, actions)
+	h.startHeldRepeat(key, bindKey, actions)
 }
 
-// startHeldRepeatLocked launches a goroutine that dispatches the held-key
+// startHeldRepeat launches a goroutine that dispatches the held-key
 // action at heldRepeatInterval until the key-up event arrives.
 // bindKey is the normalised config-binding key (for consistent logging).
 // Caller must hold h.mu.
-func (h *Handler) startHeldRepeatLocked(key, bindKey string, actions []string) {
+func (h *handlerState) startHeldRepeat(key, bindKey string, actions []string) {
 	cfg := h.config.HeldRepeat
 
 	ctx, cancel := context.WithCancel(h.ctx)

--- a/internal/app/modes/key_dispatch_test.go
+++ b/internal/app/modes/key_dispatch_test.go
@@ -39,7 +39,7 @@ func TestHandleKeyPressUsesStickyStrippedKeyForBindings(t *testing.T) {
 	mode := &recordingMode{keys: make(chan string, 1)}
 	hotkeyActions := make(chan string, 1)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		config: &configpkg.Config{
 			RecursiveGrid: configpkg.RecursiveGridConfig{
 				Hotkeys: map[string]configpkg.StringOrStringArray{
@@ -57,7 +57,7 @@ func TestHandleKeyPressUsesStickyStrippedKeyForBindings(t *testing.T) {
 		executeActionSequence: func(_ string, steps []string) {
 			hotkeyActions <- strings.Join(steps, ",")
 		},
-	}
+	})
 	handler.modifierState.Toggle(action.ModCtrl)
 
 	handler.HandleKeyPress("Ctrl+c")
@@ -84,7 +84,7 @@ func TestHandleKeyPressRoutesAllKeysToHintSearch(t *testing.T) {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeHints)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		config: &configpkg.Config{
 			Hints: configpkg.HintsConfig{
 				Hotkeys: map[string]configpkg.StringOrStringArray{
@@ -103,7 +103,7 @@ func TestHandleKeyPressRoutesAllKeysToHintSearch(t *testing.T) {
 		executeActionSequence: func(_ string, steps []string) {
 			t.Fatalf("hotkey action should be skipped during hint search, got %v", steps)
 		},
-	}
+	})
 
 	elem, _ := element.NewElement(
 		"search",
@@ -141,7 +141,7 @@ func newHeldRepeatTestHandler() *Handler {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeRecursiveGrid)
 
-	return &Handler{
+	return newHandlerWithState(handlerState{
 		ctx: context.Background(),
 		config: &configpkg.Config{
 			RecursiveGrid: configpkg.RecursiveGridConfig{
@@ -163,7 +163,7 @@ func newHeldRepeatTestHandler() *Handler {
 		},
 		screenBounds:          image.Rect(0, 0, 100, 100),
 		executeActionSequence: func(_ string, _ []string) {},
-	}
+	})
 }
 
 // TestHandleFedKeyPressStopsOwnHeldRepeat verifies that a key injected via
@@ -230,7 +230,7 @@ func TestHandleFedKeyPressPreservesPhysicalHeldRepeat(t *testing.T) {
 	}
 
 	// Stop the still-running repeat goroutine so it does not outlive the test.
-	handler.stopHeldRepeatLocked()
+	handler.stopHeldRepeat()
 }
 
 // The mode dispatcher hands the whole binding to the daemon's sequence
@@ -243,7 +243,7 @@ func TestDispatchHotkeyActions_ForwardsWholeSequence(t *testing.T) {
 
 	got := make(chan []string, 1)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		logger:   zap.NewNop(),
 		appState: state.NewAppState(),
 		executeActionSequence: func(source string, steps []string) {
@@ -253,7 +253,7 @@ func TestDispatchHotkeyActions_ForwardsWholeSequence(t *testing.T) {
 
 			got <- steps
 		},
-	}
+	})
 
 	want := []string{"first", "second"}
 	handler.dispatchHotkeyActions("test-mode", "test-bind", "t", want)
@@ -334,11 +334,11 @@ func TestModeHotkeyOverride(t *testing.T) {
 			appState := state.NewAppState()
 			appState.SetMode(testCase.mode)
 
-			handler := &Handler{
+			handler := newHandlerWithState(handlerState{
 				config:   cfg,
 				logger:   zap.NewNop(),
 				appState: appState,
-			}
+			})
 
 			actions, ok := handler.ModeHotkeyOverride(testCase.key)
 			if ok != testCase.wantOK {

--- a/internal/app/modes/mode_handlers.go
+++ b/internal/app/modes/mode_handlers.go
@@ -19,7 +19,7 @@ import (
 // executeActionAtPoint executes a pending action at the given point and exits the mode.
 // When repeat is true and reActivateFunc is provided, the mode is re-activated
 // instead of exiting after performing the action.
-func (h *Handler) executeActionAtPoint(
+func (h *handlerState) executeActionAtPoint(
 	actionStr *string,
 	modifierStr *string,
 	point image.Point,
@@ -128,12 +128,12 @@ func (h *Handler) executeActionAtPoint(
 		h.appState.SetModeExitReason(state.ModeExitReasonCompleted)
 	}
 
-	// Capture the mode's --on-exit action before exitModeLocked clears the
+	// Capture the mode's --on-exit action before exitMode clears the
 	// context. It only runs when the action chain was fulfilled and the mode
 	// idled through this action path — never on manual escape or a switch.
 	onExit := h.currentModeOnExit()
 
-	h.exitModeLocked()
+	h.exitMode()
 
 	if !chainFailed {
 		h.runOnExit(onExit)
@@ -142,7 +142,7 @@ func (h *Handler) executeActionAtPoint(
 
 // currentModeOnExit returns the --on-exit steps configured for the currently
 // active action mode, or nil when none are set or the mode has no context.
-func (h *Handler) currentModeOnExit() []string {
+func (h *handlerState) currentModeOnExit() []string {
 	switch h.appState.CurrentMode() {
 	case domain.ModeHints:
 		if h.hints != nil && h.hints.Context != nil {
@@ -169,7 +169,7 @@ func (h *Handler) currentModeOnExit() []string {
 // mode names) and run asynchronously: a step may route back through IPC into
 // ActivateModeWithOptions, which acquires h.mu — held by the
 // executeActionAtPoint caller.
-func (h *Handler) runOnExit(onExit []string) {
+func (h *handlerState) runOnExit(onExit []string) {
 	if len(onExit) == 0 || h.executeActionSequence == nil {
 		return
 	}
@@ -190,7 +190,7 @@ func (h *Handler) runOnExit(onExit []string) {
 }
 
 // moveCursorAndHandleAction moves the cursor to a point and executes any pending action.
-func (h *Handler) moveCursorAndHandleAction(
+func (h *handlerState) moveCursorAndHandleAction(
 	point image.Point,
 	pendingAction *string,
 	pendingModifier *string,
@@ -220,7 +220,7 @@ func (h *Handler) moveCursorAndHandleAction(
 }
 
 // handleHintsModeKey handles key processing for hints mode.
-func (h *Handler) handleHintsModeKey(key string) {
+func (h *handlerState) handleHintsModeKey(key string) {
 	// Route hint-specific keys via domain hints router
 	if h.hints.Context.Router() == nil {
 		h.logger.Warn("Hints router is nil - ignoring key press until hints initialized")
@@ -293,7 +293,7 @@ func (h *Handler) handleHintsModeKey(key string) {
 }
 
 // handleSearchInputKey routes all keys while hint text search is active.
-func (h *Handler) handleSearchInputKey(key string) {
+func (h *handlerState) handleSearchInputKey(key string) {
 	if h.hints == nil || h.hints.Context == nil {
 		return
 	}
@@ -334,7 +334,7 @@ func (h *Handler) handleSearchInputKey(key string) {
 	h.applyHintSearchFilter()
 }
 
-func (h *Handler) applyHintSearchFilter() {
+func (h *handlerState) applyHintSearchFilter() {
 	ctx := h.hints.Context
 
 	sourceHints := ctx.SourceHints()
@@ -367,12 +367,12 @@ func (h *Handler) applyHintSearchFilter() {
 	h.cycleHintIndex = -1
 }
 
-func (h *Handler) confirmHintSearch() {
+func (h *handlerState) confirmHintSearch() {
 	if h.hints == nil || h.hints.Context == nil {
 		return
 	}
 
-	h.stopHintSearchTextInputLocked(false)
+	h.stopHintSearchTextInput(false)
 
 	ctx := h.hints.Context
 	ctx.SetSearchActive(false)
@@ -391,7 +391,7 @@ func (h *Handler) confirmHintSearch() {
 		}
 
 		go func() {
-			_ = h.CycleHint(h.ctx, false, true)
+			_ = h.outer.CycleHint(h.ctx, false, true)
 		}()
 	} else {
 		h.cancelHintSearch()
@@ -400,12 +400,12 @@ func (h *Handler) confirmHintSearch() {
 	h.cycleHintIndex = -1
 }
 
-func (h *Handler) cancelHintSearch() {
+func (h *handlerState) cancelHintSearch() {
 	if h.hints == nil || h.hints.Context == nil {
 		return
 	}
 
-	h.stopHintSearchTextInputLocked(false)
+	h.stopHintSearchTextInput(false)
 
 	ctx := h.hints.Context
 	ctx.SetSearchQuery("")
@@ -422,7 +422,7 @@ func (h *Handler) cancelHintSearch() {
 	h.cycleHintIndex = -1
 }
 
-func (h *Handler) drawHintSearchInput() {
+func (h *handlerState) drawHintSearchInput() {
 	if h.hints == nil || h.hints.Context == nil {
 		return
 	}
@@ -449,7 +449,7 @@ func (h *Handler) drawHintSearchInput() {
 	}
 }
 
-func (h *Handler) searchInputFrame() hintscomponent.SearchInputFrame {
+func (h *handlerState) searchInputFrame() hintscomponent.SearchInputFrame {
 	searchInputConfig := h.config.Hints.SearchInputUI
 	screenWidth := h.screenBounds.Dx()
 	screenHeight := h.screenBounds.Dy()
@@ -520,7 +520,7 @@ func estimatedSearchInputHeight(searchInputConfig configpkg.SearchInputUI) int {
 }
 
 // handleGridModeKey handles key processing for grid mode.
-func (h *Handler) handleGridModeKey(key string) {
+func (h *handlerState) handleGridModeKey(key string) {
 	if h.grid.Router == nil {
 		h.logger.Warn("Grid router is nil - ignoring key press until grid router initialized")
 
@@ -548,7 +548,7 @@ func (h *Handler) handleGridModeKey(key string) {
 		cursorFollowSelection := h.grid.Context.CursorFollowSelection()
 
 		if pendingAction == nil && !repeat && !cursorFollowSelection {
-			h.refreshGridVirtualPointerLocked()
+			h.refreshGridVirtualPointer()
 
 			return
 		}
@@ -573,7 +573,7 @@ func (h *Handler) handleGridModeKey(key string) {
 		h.grid.Context.SetSelectionPoint(absolutePoint)
 
 		if !h.grid.Context.CursorFollowSelection() {
-			h.refreshGridVirtualPointerLocked()
+			h.refreshGridVirtualPointer()
 
 			return
 		}

--- a/internal/app/modes/mode_handlers_test.go
+++ b/internal/app/modes/mode_handlers_test.go
@@ -17,10 +17,10 @@ import (
 )
 
 func TestExecuteActionAtPoint_NilActionNoop(t *testing.T) {
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		logger:      zap.NewNop(),
 		cursorState: state.NewCursorState(),
-	}
+	})
 
 	handler.executeActionAtPoint(nil, nil, point(10, 10), false, nil)
 
@@ -31,12 +31,12 @@ func TestExecuteActionAtPoint_NilActionNoop(t *testing.T) {
 
 func TestRunOnExit_DispatchesEveryStepInOrder(t *testing.T) {
 	got := make(chan []string, 1)
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		logger: zap.NewNop(),
 		executeActionSequence: func(_ string, steps []string) {
 			got <- steps
 		},
-	}
+	})
 
 	onExit := []string{"action sleep 0.2", "exec notify-send done"}
 	handler.runOnExit(onExit)
@@ -53,12 +53,12 @@ func TestRunOnExit_DispatchesEveryStepInOrder(t *testing.T) {
 
 func TestRunOnExit_NilAndEmptyNoop(t *testing.T) {
 	called := make(chan struct{}, 1)
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		logger: zap.NewNop(),
 		executeActionSequence: func(_ string, _ []string) {
 			called <- struct{}{}
 		},
-	}
+	})
 
 	handler.runOnExit(nil)
 	handler.runOnExit([]string{})
@@ -84,11 +84,11 @@ func (m *optsRecordingMode) ModeType() domain.Mode               { return m.mode
 
 func TestActivateModeWithOptions_OmittedOnExitClearsStaleCallback(t *testing.T) {
 	fake := &optsRecordingMode{modeType: domain.ModeGrid}
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		logger:   zap.NewNop(),
 		appState: state.NewAppState(),
 		modes:    map[domain.Mode]Mode{domain.ModeGrid: fake},
-	}
+	})
 
 	// An external activation that omits --on-exit must reach the mode with a
 	// non-nil, empty OnExit so the refresh branch clears any stored steps
@@ -127,12 +127,12 @@ func TestCurrentModeOnExit(t *testing.T) {
 	rgCtx.SetOnExit(rgExit)
 
 	appState := state.NewAppState()
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState:      appState,
 		hints:         &components.HintsComponent{Context: hintsCtx},
 		grid:          &components.GridComponent{Context: gridCtx},
 		recursiveGrid: &components.RecursiveGridComponent{Context: rgCtx},
-	}
+	})
 
 	cases := []struct {
 		mode domain.Mode

--- a/internal/app/modes/mode_setup.go
+++ b/internal/app/modes/mode_setup.go
@@ -9,18 +9,18 @@ import (
 )
 
 // CurrModeString returns the current mode as a string.
-func (h *Handler) CurrModeString() string {
+func (h *handlerState) CurrModeString() string {
 	return domain.ModeString(h.appState.CurrentMode())
 }
 
 // overlaySwitch switches the overlay mode.
-func (h *Handler) overlaySwitch(m overlay.Mode) {
+func (h *handlerState) overlaySwitch(m overlay.Mode) {
 	if h.overlayManager != nil {
 		h.overlayManager.SwitchTo(m)
 	}
 }
 
-func (h *Handler) setAppModeLocked(mode domain.Mode) {
+func (h *handlerState) setAppMode(mode domain.Mode) {
 	h.modeSession++
 	h.appState.SetMode(mode)
 
@@ -37,7 +37,7 @@ func (h *Handler) setAppModeLocked(mode domain.Mode) {
 	h.syncStickyModifierToggle(mode)
 }
 
-func (h *Handler) syncStickyModifierToggle(mode domain.Mode) {
+func (h *handlerState) syncStickyModifierToggle(mode domain.Mode) {
 	if !h.hasEventTap() {
 		return
 	}
@@ -64,7 +64,7 @@ func (h *Handler) SetModeIdle() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	h.setAppModeLocked(domain.ModeIdle)
+	h.setAppMode(domain.ModeIdle)
 
 	if h.hasEventTap() {
 		h.disableEventTap()
@@ -73,10 +73,10 @@ func (h *Handler) SetModeIdle() {
 	h.overlaySwitch(overlay.ModeIdle)
 }
 
-// setModeLocked sets the application mode, enables event tap, and switches overlay.
+// setMode sets the application mode, enables event tap, and switches overlay.
 // Caller must hold h.mu.
-func (h *Handler) setModeLocked(appMode domain.Mode, overlayMode overlay.Mode) {
-	h.setAppModeLocked(appMode)
+func (h *handlerState) setMode(appMode domain.Mode, overlayMode overlay.Mode) {
+	h.setAppMode(appMode)
 
 	if h.hasEventTap() {
 		h.enableEventTap()
@@ -86,7 +86,7 @@ func (h *Handler) setModeLocked(appMode domain.Mode, overlayMode overlay.Mode) {
 }
 
 // activateModeBase performs common activation steps for all modes.
-func (h *Handler) activateModeBase(
+func (h *handlerState) activateModeBase(
 	modeName string,
 	enabled bool,
 	actionEnum action.Type,
@@ -120,7 +120,7 @@ func (h *Handler) SetModeHints() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	h.setModeLocked(domain.ModeHints, overlay.ModeHints)
+	h.setMode(domain.ModeHints, overlay.ModeHints)
 }
 
 // SetModeGrid switches the application to grid mode for coordinate-based navigation.
@@ -130,7 +130,7 @@ func (h *Handler) SetModeGrid() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	h.setModeLocked(domain.ModeGrid, overlay.ModeGrid)
+	h.setMode(domain.ModeGrid, overlay.ModeGrid)
 }
 
 // SetModeRecursiveGrid switches the application to recursive-grid mode for recursive cell navigation.
@@ -140,7 +140,7 @@ func (h *Handler) SetModeRecursiveGrid() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	h.setModeLocked(domain.ModeRecursiveGrid, overlay.ModeRecursiveGrid)
+	h.setMode(domain.ModeRecursiveGrid, overlay.ModeRecursiveGrid)
 }
 
 // SetModeScroll switches the application to scroll mode for scroll-based navigation.
@@ -150,5 +150,5 @@ func (h *Handler) SetModeScroll() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	h.setModeLocked(domain.ModeScroll, overlay.ModeScroll)
+	h.setMode(domain.ModeScroll, overlay.ModeScroll)
 }

--- a/internal/app/modes/mode_wrappers.go
+++ b/internal/app/modes/mode_wrappers.go
@@ -11,7 +11,7 @@ type GridMode struct {
 }
 
 // NewGridMode creates a new grid mode implementation.
-func NewGridMode(handler *Handler) *GridMode {
+func NewGridMode(handler *handlerState) *GridMode {
 	return &GridMode{
 		GenericMode: NewGenericMode(handler, domain.ModeGrid, "GridMode", ModeBehavior{}),
 	}
@@ -24,7 +24,7 @@ type HintsMode struct {
 }
 
 // NewHintsMode creates a new hints mode implementation.
-func NewHintsMode(handler *Handler) *HintsMode {
+func NewHintsMode(handler *handlerState) *HintsMode {
 	return &HintsMode{
 		GenericMode: NewGenericMode(handler, domain.ModeHints, "HintsMode", ModeBehavior{}),
 	}

--- a/internal/app/modes/modifier_toggle.go
+++ b/internal/app/modes/modifier_toggle.go
@@ -57,7 +57,7 @@ func parseModifierEvent(key string) (action.Modifiers, bool, bool) {
 // handleModifierToggle processes modifier down/up events for sticky toggle.
 // A modifier becomes sticky when its down/up pair completes without any
 // intervening regular key, and pressing the same modifier again toggles it off.
-func (h *Handler) handleModifierToggle(key string) bool {
+func (h *handlerState) handleModifierToggle(key string) bool {
 	if !h.stickyModifiersEnabled() {
 		return false
 	}
@@ -204,7 +204,7 @@ func (h *Handler) handleModifierToggle(key string) bool {
 	return true
 }
 
-func (h *Handler) stopPendingModifierTimer(mod action.Modifiers) {
+func (h *handlerState) stopPendingModifierTimer(mod action.Modifiers) {
 	if h.pendingModifierTimers == nil {
 		return
 	}
@@ -217,7 +217,7 @@ func (h *Handler) stopPendingModifierTimer(mod action.Modifiers) {
 
 // scheduleModifierToggle starts a debounce timer that will toggle the given
 // modifier after modifierToggleDebounce unless canceled by a regular key press.
-func (h *Handler) scheduleModifierToggle(mod action.Modifiers, downTime time.Time) {
+func (h *handlerState) scheduleModifierToggle(mod action.Modifiers, downTime time.Time) {
 	if h.pendingModifierTimers == nil {
 		h.pendingModifierTimers = make(map[action.Modifiers]*time.Timer)
 	}
@@ -231,14 +231,14 @@ func (h *Handler) scheduleModifierToggle(mod action.Modifiers, downTime time.Tim
 		zap.Duration("delay", modifierToggleDebounce))
 
 	timer := time.AfterFunc(modifierToggleDebounce, func() {
-		h.mu.Lock()
-		defer h.mu.Unlock()
+		h.outer.mu.Lock()
+		defer h.outer.mu.Unlock()
 		defer h.notifyDebounceComplete()
 
 		// Guard against stale timer: if the mode session changed (user exited
 		// and re-entered a mode) while we were waiting, this timer belongs to
 		// a previous session and must not toggle anything. The primary cleanup
-		// path (cancelPendingModifierToggle via setAppModeLocked) already
+		// path (cancelPendingModifierToggle via setAppMode) already
 		// stops timers and nils pendingModifierKeys, but this check provides
 		// defense-in-depth in case a timer fires between the mode exit and the
 		// cancel — matching the pattern used by refreshHintsTimer.
@@ -298,7 +298,7 @@ func (h *Handler) scheduleModifierToggle(mod action.Modifiers, downTime time.Tim
 // notifyDebounceComplete sends a non-blocking signal on debounceNotify so
 // tests can synchronize with the timer callback. In production the channel
 // is nil and this is a no-op.
-func (h *Handler) notifyDebounceComplete() {
+func (h *handlerState) notifyDebounceComplete() {
 	if h.debounceNotify != nil {
 		select {
 		case h.debounceNotify <- struct{}{}:
@@ -313,7 +313,7 @@ func (h *Handler) notifyDebounceComplete() {
 // to prevent modifier UP events from starting debounce timers during a
 // mode switch. Resetting it here would undo the suppression before the
 // UP events arrive, causing unintended sticky modifier toggles.
-func (h *Handler) clearStickyModifiers() {
+func (h *handlerState) clearStickyModifiers() {
 	if h.modifierState == nil {
 		return
 	}
@@ -341,7 +341,7 @@ func (h *Handler) clearStickyModifiers() {
 	h.heldModifiers = 0
 }
 
-func (h *Handler) cancelPendingModifierToggle() {
+func (h *handlerState) cancelPendingModifierToggle() {
 	if len(h.pendingModifierKeys) > 0 {
 		h.pendingModifierKeys = nil
 		h.logger.Debug("Modifier tap canceled")
@@ -354,7 +354,7 @@ func (h *Handler) cancelPendingModifierToggle() {
 	}
 }
 
-func (h *Handler) markHeldModifiersUsedInChord() {
+func (h *handlerState) markHeldModifiersUsedInChord() {
 	h.expireSuppressedModifiersIfNeeded()
 
 	for _, mod := range allStickyModifiers {
@@ -429,7 +429,7 @@ func (h *Handler) SuppressModifiersForHotkey(mods action.Modifiers) {
 	}
 }
 
-func (h *Handler) expireSuppressedModifiersIfNeeded() {
+func (h *handlerState) expireSuppressedModifiersIfNeeded() {
 	if h.suppressedModifiers == 0 || h.suppressedUntil.IsZero() {
 		return
 	}
@@ -444,7 +444,7 @@ func (h *Handler) expireSuppressedModifiersIfNeeded() {
 	h.modifierFreshPress = nil
 }
 
-func (h *Handler) stickyModifiersEnabled() bool {
+func (h *handlerState) stickyModifiersEnabled() bool {
 	if h.config == nil {
 		return false
 	}
@@ -452,7 +452,7 @@ func (h *Handler) stickyModifiersEnabled() bool {
 	return h.config.StickyModifiers.Enabled
 }
 
-func (h *Handler) stickyModifiers() action.Modifiers {
+func (h *handlerState) stickyModifiers() action.Modifiers {
 	if h.modifierState == nil {
 		return 0
 	}

--- a/internal/app/modes/modifier_toggle_test.go
+++ b/internal/app/modes/modifier_toggle_test.go
@@ -80,7 +80,7 @@ func TestParseModifierEvent(t *testing.T) {
 // newTestHandler creates a minimal Handler suitable for testing sticky modifier behavior.
 // The debounceNotify channel is buffered so the timer callback never blocks.
 func newTestHandler() *Handler {
-	return &Handler{
+	return newHandlerWithState(handlerState{
 		logger:         zap.NewNop(),
 		modifierState:  state.NewModifierState(),
 		debounceNotify: make(chan struct{}, 16),
@@ -90,7 +90,7 @@ func newTestHandler() *Handler {
 				TapMaxDuration: 300,
 			},
 		},
-	}
+	})
 }
 
 // awaitDebounce blocks until the debounce timer callback signals completion.

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -319,7 +319,7 @@ func (h *Handler) refreshGridForMonitorMove(targetBounds image.Rectangle) {
 		return
 	}
 
-	h.refreshGridVirtualPointerLocked()
+	h.refreshGridVirtualPointer()
 	h.overlayManager.Show()
 }
 
@@ -348,7 +348,7 @@ func (h *Handler) refreshRecursiveGridForMonitorMove(targetBounds image.Rectangl
 	}
 
 	h.updateRecursiveGridOverlay()
-	h.refreshRecursiveGridVirtualPointerLocked()
+	h.refreshRecursiveGridVirtualPointer()
 	h.overlayManager.Show()
 }
 
@@ -414,7 +414,7 @@ func (h *Handler) refreshHintsForMonitorMove(
 	filtered := filterHintsForScreen(domainHints, targetBounds)
 	if len(filtered) == 0 {
 		h.logger.Warn("All hints filtered out on target monitor; exiting hints mode")
-		h.exitModeLocked()
+		h.exitMode()
 
 		return
 	}
@@ -424,7 +424,7 @@ func (h *Handler) refreshHintsForMonitorMove(
 	setHintsErr := h.hints.Context.SetHints(hintCollection)
 	if setHintsErr != nil {
 		h.logger.Error("Failed to set hints after monitor move", zap.Error(setHintsErr))
-		h.exitModeLocked()
+		h.exitMode()
 
 		return
 	}

--- a/internal/app/modes/monitor_select.go
+++ b/internal/app/modes/monitor_select.go
@@ -18,20 +18,20 @@ type MonitorSelectMode struct {
 }
 
 // NewMonitorSelectMode creates a new monitor_select mode implementation.
-func NewMonitorSelectMode(handler *Handler) *MonitorSelectMode {
+func NewMonitorSelectMode(handler *handlerState) *MonitorSelectMode {
 	return &MonitorSelectMode{
 		GenericMode: NewGenericMode(
 			handler,
 			domain.ModeMonitorSelect,
 			"MonitorSelectMode",
 			ModeBehavior{
-				ActivateFunc: func(handler *Handler, opts ModeActivationOptions) {
+				ActivateFunc: func(handler *handlerState, opts ModeActivationOptions) {
 					handler.activateMonitorSelectMode(opts)
 				},
-				HandleKeyFunc: func(handler *Handler, key string) {
+				HandleKeyFunc: func(handler *handlerState, key string) {
 					handler.handleMonitorSelectKey(key)
 				},
-				ExitFunc: func(handler *Handler) {
+				ExitFunc: func(handler *handlerState) {
 					handler.cleanupMonitorSelectMode()
 				},
 			},
@@ -39,7 +39,7 @@ func NewMonitorSelectMode(handler *Handler) *MonitorSelectMode {
 	}
 }
 
-func (h *Handler) activateMonitorSelectMode(_ ModeActivationOptions) {
+func (h *handlerState) activateMonitorSelectMode(_ ModeActivationOptions) {
 	err := h.validateModeActivation(
 		"",
 		domain.ModeNameMonitorSelect,
@@ -70,8 +70,8 @@ func (h *Handler) activateMonitorSelectMode(_ ModeActivationOptions) {
 			// Single monitor: auto-confirm immediately so that
 			// wait_for_mode_exit --bail chains see a completed selection.
 			h.appState.SetModeExitReason(state.ModeExitReasonCompleted)
-			h.exitModeLocked()
-			h.confirmMonitorSelectLocked(&monitors[0])
+			h.exitMode()
+			h.confirmMonitorSelect(&monitors[0])
 		} else {
 			h.logger.Debug("Skipping monitor_select activation; no selectable monitors")
 		}
@@ -79,10 +79,10 @@ func (h *Handler) activateMonitorSelectMode(_ ModeActivationOptions) {
 		return
 	}
 
-	h.exitModeLocked()
+	h.exitMode()
 	h.monitorSelect = session
 
-	err = h.showMonitorSelectLocked()
+	err = h.showMonitorSelect()
 	if err != nil {
 		h.monitorSelect = nil
 
@@ -95,26 +95,26 @@ func (h *Handler) activateMonitorSelectMode(_ ModeActivationOptions) {
 		return
 	}
 
-	h.setModeLocked(domain.ModeMonitorSelect, overlay.ModeMonitorSelect)
+	h.setMode(domain.ModeMonitorSelect, overlay.ModeMonitorSelect)
 	h.startIndicatorPolling(domain.ModeMonitorSelect)
 	h.logger.Info("Monitor select mode activated", zap.Int("targets", len(session.targets)))
 }
 
-func (h *Handler) handleMonitorSelectKey(key string) {
+func (h *handlerState) handleMonitorSelectKey(key string) {
 	if h.monitorSelect == nil {
 		return
 	}
 
 	if target := h.monitorSelect.HandleCharacter(key); target != nil {
-		h.confirmMonitorSelectLocked(target)
+		h.confirmMonitorSelect(target)
 
 		return
 	}
 
-	h.redrawMonitorSelectLocked()
+	h.redrawMonitorSelect()
 }
 
-func (h *Handler) confirmMonitorSelectLocked(target *monitorSelectTarget) {
+func (h *handlerState) confirmMonitorSelect(target *monitorSelectTarget) {
 	if target == nil {
 		return
 	}
@@ -126,7 +126,7 @@ func (h *Handler) confirmMonitorSelectLocked(target *monitorSelectTarget) {
 	}
 
 	h.appState.SetModeExitReason(state.ModeExitReasonCompleted)
-	h.exitModeLocked()
+	h.exitMode()
 
 	go func() {
 		if h.actionService == nil {
@@ -142,8 +142,8 @@ func (h *Handler) confirmMonitorSelectLocked(target *monitorSelectTarget) {
 	}()
 }
 
-func (h *Handler) cleanupMonitorSelectMode() {
-	err := h.hideMonitorSelectLocked()
+func (h *handlerState) cleanupMonitorSelectMode() {
+	err := h.hideMonitorSelect()
 	if err != nil && !derrors.IsNotSupported(err) {
 		h.logger.Debug("Failed to hide monitor_select overlay", zap.Error(err))
 	}
@@ -151,7 +151,7 @@ func (h *Handler) cleanupMonitorSelectMode() {
 	h.monitorSelect = nil
 }
 
-func (h *Handler) discoverMonitorsForSelection() ([]monitorSelectTarget, error) {
+func (h *handlerState) discoverMonitorsForSelection() ([]monitorSelectTarget, error) {
 	if h.system == nil {
 		return nil, derrors.New(
 			derrors.CodeNotSupported,
@@ -194,7 +194,7 @@ func (h *Handler) discoverMonitorsForSelection() ([]monitorSelectTarget, error) 
 	return monitors, nil
 }
 
-func (h *Handler) reportMonitorSelectNotSupported() {
+func (h *handlerState) reportMonitorSelectNotSupported() {
 	h.logger.Info("monitor_select is not supported on this platform")
 
 	if h.system != nil {

--- a/internal/app/modes/monitor_select_overlay.go
+++ b/internal/app/modes/monitor_select_overlay.go
@@ -6,12 +6,12 @@ import (
 	"github.com/y3owk1n/neru/internal/domain"
 )
 
-func (h *Handler) redrawMonitorSelectLocked() {
+func (h *handlerState) redrawMonitorSelect() {
 	if h.monitorSelect == nil {
 		return
 	}
 
-	err := h.showMonitorSelectLocked()
+	err := h.showMonitorSelect()
 	if err != nil {
 		h.logger.Debug("Failed to redraw monitor_select overlay", zap.Error(err))
 	}
@@ -27,5 +27,5 @@ func (h *Handler) RefreshMonitorSelectForThemeChange() {
 		return
 	}
 
-	h.redrawMonitorSelectLocked()
+	h.redrawMonitorSelect()
 }

--- a/internal/app/modes/monitor_select_overlay_darwin.go
+++ b/internal/app/modes/monitor_select_overlay_darwin.go
@@ -49,12 +49,12 @@ type monitorSelectRenderState struct {
 	Style   monitorSelectRenderStyle
 }
 
-func (h *Handler) showMonitorSelectLocked() error {
+func (h *handlerState) showMonitorSelect() error {
 	if h.monitorSelect == nil {
 		return nil
 	}
 
-	state := h.currentMonitorSelectRenderStateLocked()
+	state := h.currentMonitorSelectRenderState()
 	targets := state.Targets
 	style := state.Style
 
@@ -107,7 +107,7 @@ func (h *Handler) showMonitorSelectLocked() error {
 	return nil
 }
 
-func (h *Handler) hideMonitorSelectLocked() error {
+func (h *handlerState) hideMonitorSelect() error {
 	C.NeruHideMonitorSelectPanels()
 
 	return nil
@@ -156,7 +156,7 @@ func freeMonitorSelectStyle(styl C.MonitorSelectStyle) {
 	}
 }
 
-func (h *Handler) currentMonitorSelectRenderStateLocked() monitorSelectRenderState {
+func (h *handlerState) currentMonitorSelectRenderState() monitorSelectRenderState {
 	cfg := h.config.MonitorSelect
 	uiCfg := cfg.UI
 

--- a/internal/app/modes/monitor_select_overlay_linux.go
+++ b/internal/app/modes/monitor_select_overlay_linux.go
@@ -11,11 +11,11 @@ import (
 	"github.com/y3owk1n/neru/internal/derrors"
 )
 
-// showMonitorSelectLocked renders the interactive monitor picker on the shared
+// showMonitorSelect renders the interactive monitor picker on the shared
 // Linux overlay (X11 spanning window or wlroots per-output layer surfaces),
 // drawing one labeled panel per monitor. Unlike macOS's per-display NSPanels,
 // this reuses the same overlay the hints/grid modes draw on.
-func (h *Handler) showMonitorSelectLocked() error {
+func (h *handlerState) showMonitorSelect() error {
 	if h.monitorSelect == nil {
 		return nil
 	}
@@ -36,7 +36,7 @@ func (h *Handler) showMonitorSelectLocked() error {
 		)
 	}
 
-	targets, style := h.monitorSelectRenderDataLocked()
+	targets, style := h.monitorSelectRenderData()
 	if len(targets) == 0 {
 		selector.HideMonitorSelect()
 
@@ -46,7 +46,7 @@ func (h *Handler) showMonitorSelectLocked() error {
 	return selector.DrawMonitorSelect(targets, style)
 }
 
-func (h *Handler) hideMonitorSelectLocked() error {
+func (h *handlerState) hideMonitorSelect() error {
 	if selector, ok := overlay.Get().(overlaymanager.MonitorSelector); ok {
 		selector.HideMonitorSelect()
 	}
@@ -54,9 +54,9 @@ func (h *Handler) hideMonitorSelectLocked() error {
 	return nil
 }
 
-// monitorSelectRenderDataLocked maps the active monitor_select session and the
+// monitorSelectRenderData maps the active monitor_select session and the
 // resolved (theme-applied) config into the overlay's render types.
-func (h *Handler) monitorSelectRenderDataLocked() ([]overlay.MonitorSelectTarget, overlay.MonitorSelectStyle) {
+func (h *handlerState) monitorSelectRenderData() ([]overlay.MonitorSelectTarget, overlay.MonitorSelectStyle) {
 	uiCfg := h.config.MonitorSelect.UI
 	theme := h.themeProvider
 

--- a/internal/app/modes/monitor_select_overlay_other.go
+++ b/internal/app/modes/monitor_select_overlay_other.go
@@ -4,13 +4,13 @@ package modes
 
 import "github.com/y3owk1n/neru/internal/derrors"
 
-func (h *Handler) showMonitorSelectLocked() error {
+func (h *handlerState) showMonitorSelect() error {
 	return derrors.New(
 		derrors.CodeNotSupported,
 		"monitor_select overlay is only supported on darwin",
 	)
 }
 
-func (h *Handler) hideMonitorSelectLocked() error {
+func (h *handlerState) hideMonitorSelect() error {
 	return nil
 }

--- a/internal/app/modes/passthrough.go
+++ b/internal/app/modes/passthrough.go
@@ -17,7 +17,7 @@ import (
 // AX elements.
 const passthroughHintRefreshDelay = 300 * time.Millisecond
 
-func (h *Handler) syncModifierPassthrough(mode domain.Mode) {
+func (h *handlerState) syncModifierPassthrough(mode domain.Mode) {
 	enabled := h.config != nil &&
 		mode != domain.ModeIdle &&
 		h.config.General.PassthroughUnboundedKeys
@@ -62,7 +62,7 @@ func (h *Handler) syncModifierPassthrough(mode domain.Mode) {
 	h.setInterceptedModifierKeys(keys)
 }
 
-func (h *Handler) passthroughCallbackFor(mode domain.Mode, enabled bool) func() {
+func (h *handlerState) passthroughCallbackFor(mode domain.Mode, enabled bool) func() {
 	if !enabled {
 		return nil
 	}
@@ -70,13 +70,13 @@ func (h *Handler) passthroughCallbackFor(mode domain.Mode, enabled bool) func() 
 	session := h.modeSession
 
 	return func() {
-		h.handlePassthrough(mode, session)
+		h.outer.handlePassthrough(mode, session)
 	}
 }
 
 const initialCapacity = 16
 
-func (h *Handler) modeModifierKeys(mode domain.Mode, bundleID string) []string {
+func (h *handlerState) modeModifierKeys(mode domain.Mode, bundleID string) []string {
 	if h.config == nil || mode == domain.ModeIdle {
 		return nil
 	}
@@ -120,10 +120,10 @@ func (h *Handler) handlePassthrough(mode domain.Mode, session uint64) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	h.handlePassthroughLocked(mode, session)
+	h.passthroughTick(mode, session)
 }
 
-// handlePassthroughLocked is called when a modifier shortcut was passed through
+// passthroughTick is called when a modifier shortcut was passed through
 // to macOS while a mode was active. The mode/session arguments identify the
 // originating activation so stale callbacks can be ignored safely. Only hints
 // mode needs a refresh because its labels point at AX elements that may have
@@ -132,7 +132,7 @@ func (h *Handler) handlePassthrough(mode domain.Mode, session uint64) {
 // OS does with the shortcut.
 //
 // Caller must hold h.mu.
-func (h *Handler) handlePassthroughLocked(mode domain.Mode, session uint64) {
+func (h *handlerState) passthroughTick(mode domain.Mode, session uint64) {
 	if h.modeSession != session || h.appState.CurrentMode() != mode {
 		return
 	}
@@ -143,7 +143,7 @@ func (h *Handler) handlePassthroughLocked(mode domain.Mode, session uint64) {
 		h.logger.Debug("Exiting mode after passthrough",
 			zap.String("mode", domain.ModeString(mode)),
 			zap.Uint64("session", session))
-		h.exitModeLocked()
+		h.exitMode()
 
 		return
 	}
@@ -164,8 +164,8 @@ func (h *Handler) handlePassthroughLocked(mode domain.Mode, session uint64) {
 	timerSession := h.modeSession
 
 	timer = time.AfterFunc(passthroughHintRefreshDelay, func() {
-		h.mu.Lock()
-		defer h.mu.Unlock()
+		h.outer.mu.Lock()
+		defer h.outer.mu.Unlock()
 
 		// Guard against stale timer: if the user exited hints mode while we
 		// were waiting, or if hints was re-entered (new session), do not

--- a/internal/app/modes/passthrough_test.go
+++ b/internal/app/modes/passthrough_test.go
@@ -19,7 +19,7 @@ func TestModeModifierKeys_HintsIncludesModifierHotkeys(t *testing.T) {
 		"k":     {"action scroll_up"},
 	}
 
-	handler := &Handler{config: cfg}
+	handler := newHandlerWithState(handlerState{config: cfg})
 
 	got := handler.modeModifierKeys(domain.ModeHints, "")
 	want := []string{
@@ -41,7 +41,7 @@ func TestModeModifierKeys_ScrollIncludesOnlyModifierHotkeys(t *testing.T) {
 		"gg":       {"action go_top"},
 	}
 
-	handler := &Handler{config: cfg}
+	handler := newHandlerWithState(handlerState{config: cfg})
 
 	got := handler.modeModifierKeys(domain.ModeScroll, "")
 	want := []string{
@@ -61,14 +61,14 @@ func TestHandlePassthroughLocked_IgnoresStaleSession(t *testing.T) {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeHints)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		config:      cfg,
 		logger:      zap.NewNop(),
 		appState:    appState,
 		modeSession: 2,
-	}
+	})
 
-	handler.handlePassthroughLocked(domain.ModeHints, 1)
+	handler.passthroughTick(domain.ModeHints, 1)
 
 	if handler.refreshHintsTimer != nil {
 		t.Fatal("expected stale passthrough callback to be ignored")
@@ -82,12 +82,12 @@ func TestPassthroughCallbackFor_CapturesModeSession(t *testing.T) {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeHints)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		config:      cfg,
 		logger:      zap.NewNop(),
 		appState:    appState,
 		modeSession: 1,
-	}
+	})
 
 	callback := handler.passthroughCallbackFor(domain.ModeHints, true)
 	if callback == nil {
@@ -112,14 +112,14 @@ func TestHandlePassthroughLocked_SchedulesHintRefreshForMatchingSession(t *testi
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeHints)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		config:      cfg,
 		logger:      zap.NewNop(),
 		appState:    appState,
 		modeSession: 3,
-	}
+	})
 
-	handler.handlePassthroughLocked(domain.ModeHints, 3)
+	handler.passthroughTick(domain.ModeHints, 3)
 
 	if handler.refreshHintsTimer == nil {
 		t.Fatal("expected matching passthrough callback to schedule a hint refresh")

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -18,7 +18,7 @@ import (
 // activateRecursiveGridModeWithAction activates recursive-grid mode with optional action parameter
 // and optional zoom-to-depth. When zoomToDepth is set, the mode will automatically drill down to
 // the specified depth at the current cursor position before awaiting user input.
-func (h *Handler) activateRecursiveGridModeWithAction(opts ModeActivationOptions) {
+func (h *handlerState) activateRecursiveGridModeWithAction(opts ModeActivationOptions) {
 	// Detect refresh before validation so we can do partial cleanup on re-activation.
 	isRefresh := h.appState.CurrentMode() == domain.ModeRecursiveGrid
 
@@ -30,7 +30,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(opts ModeActivationOptions
 	)
 	if !activated {
 		if isRefresh {
-			h.exitModeLocked()
+			h.exitMode()
 		}
 
 		return
@@ -46,7 +46,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(opts ModeActivationOptions
 		// The overlay is cleared unconditionally below.
 		h.stopIndicatorPolling()
 	} else {
-		h.exitModeLocked()
+		h.exitMode()
 	}
 
 	h.overlayManager.Clear()
@@ -133,7 +133,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(opts ModeActivationOptions
 	// Only set mode and enable event tap on initial activation;
 	// during refresh these are already in the correct state.
 	if !isRefresh {
-		h.setModeLocked(domain.ModeRecursiveGrid, overlay.ModeRecursiveGrid)
+		h.setMode(domain.ModeRecursiveGrid, overlay.ModeRecursiveGrid)
 	}
 
 	h.logger.Info("Recursive-grid mode activated", zap.String("action", actionString))
@@ -142,7 +142,7 @@ func (h *Handler) activateRecursiveGridModeWithAction(opts ModeActivationOptions
 }
 
 // initializeRecursiveGridManager initializes the recursive-grid manager.
-func (h *Handler) initializeRecursiveGridManager(screenBounds image.Rectangle) {
+func (h *handlerState) initializeRecursiveGridManager(screenBounds image.Rectangle) {
 	// Ensure recursiveGrid component is initialized
 	if h.recursiveGrid == nil {
 		h.recursiveGrid = &components.RecursiveGridComponent{
@@ -192,7 +192,7 @@ func (h *Handler) initializeRecursiveGridManager(screenBounds image.Rectangle) {
 }
 
 // handleRecursiveGridKey handles key processing for recursive-grid mode.
-func (h *Handler) handleRecursiveGridKey(key string) {
+func (h *handlerState) handleRecursiveGridKey(key string) {
 	ctx := h.ctx
 
 	if h.recursiveGrid == nil || h.recursiveGrid.Manager == nil {
@@ -216,7 +216,7 @@ func (h *Handler) handleRecursiveGridKey(key string) {
 		cursorFollowSelection := h.recursiveGrid.Context.CursorFollowSelection()
 
 		if pendingAction == nil && !repeat && !cursorFollowSelection {
-			h.refreshRecursiveGridVirtualPointerLocked()
+			h.refreshRecursiveGridVirtualPointer()
 
 			return
 		}
@@ -254,7 +254,7 @@ func (h *Handler) handleRecursiveGridKey(key string) {
 }
 
 // updateRecursiveGridOverlay refreshes the visual overlay.
-func (h *Handler) updateRecursiveGridOverlay() {
+func (h *handlerState) updateRecursiveGridOverlay() {
 	if h.recursiveGrid == nil || h.recursiveGrid.Manager == nil {
 		return
 	}
@@ -296,7 +296,7 @@ func (h *Handler) updateRecursiveGridOverlay() {
 }
 
 // cleanupRecursiveGridMode handles cleanup for recursive-grid mode.
-func (h *Handler) cleanupRecursiveGridMode() {
+func (h *handlerState) cleanupRecursiveGridMode() {
 	if h.recursiveGrid != nil {
 		h.recursiveGrid.Context.Reset()
 
@@ -358,7 +358,7 @@ func applyRecursiveGridOptions(
 
 // selectRecursiveGridCenter marks the current grid's center as the selection
 // and moves the cursor there when it follows the selection.
-func (h *Handler) selectRecursiveGridCenter(cursorShouldFollow bool, moveFailMsg string) {
+func (h *handlerState) selectRecursiveGridCenter(cursorShouldFollow bool, moveFailMsg string) {
 	if h.recursiveGrid.Manager == nil {
 		return
 	}

--- a/internal/app/modes/recursive_grid_mode.go
+++ b/internal/app/modes/recursive_grid_mode.go
@@ -10,15 +10,15 @@ type RecursiveGridMode struct {
 }
 
 // NewRecursiveGridMode creates a new recursive-grid mode instance.
-func NewRecursiveGridMode(handler *Handler) *RecursiveGridMode {
+func NewRecursiveGridMode(handler *handlerState) *RecursiveGridMode {
 	behavior := ModeBehavior{
-		ActivateFunc: func(handler *Handler, opts ModeActivationOptions) {
+		ActivateFunc: func(handler *handlerState, opts ModeActivationOptions) {
 			handler.activateRecursiveGridModeWithAction(opts)
 		},
-		HandleKeyFunc: func(handler *Handler, key string) {
+		HandleKeyFunc: func(handler *handlerState, key string) {
 			handler.handleRecursiveGridKey(key)
 		},
-		ExitFunc: func(handler *Handler) {
+		ExitFunc: func(handler *handlerState) {
 			handler.cleanupRecursiveGridMode()
 		},
 	}

--- a/internal/app/modes/recursive_grid_test.go
+++ b/internal/app/modes/recursive_grid_test.go
@@ -25,7 +25,7 @@ func TestHandleRecursiveGridKey_CompleteSelectionDoesNotMoveWhenCursorFollowSele
 ) {
 	moveCount := 0
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		config: &config.Config{
 			RecursiveGrid: config.RecursiveGridConfig{
 				Enabled:       true,
@@ -57,7 +57,7 @@ func TestHandleRecursiveGridKey_CompleteSelectionDoesNotMoveWhenCursorFollowSele
 			Context: &componentrecursivegrid.Context{},
 		},
 		screenBounds: image.Rect(0, 0, 100, 100),
-	}
+	})
 
 	handler.initializeRecursiveGridManager(image.Rect(0, 0, 100, 100))
 	handler.recursiveGrid.Context.SetCursorFollowSelection(false)
@@ -84,7 +84,7 @@ func TestResetCurrentMode_RecursiveGridPreservesHoldMode(t *testing.T) {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeRecursiveGrid)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState: appState,
 		config: &config.Config{
 			RecursiveGrid: config.RecursiveGridConfig{
@@ -122,7 +122,7 @@ func TestResetCurrentMode_RecursiveGridPreservesHoldMode(t *testing.T) {
 			Context: &componentrecursivegrid.Context{},
 		},
 		screenBounds: image.Rect(0, 0, 100, 100),
-	}
+	})
 
 	handler.initializeRecursiveGridManager(image.Rect(0, 0, 100, 100))
 	handler.recursiveGrid.Context.SetCursorFollowSelection(false)

--- a/internal/app/modes/scroll.go
+++ b/internal/app/modes/scroll.go
@@ -11,7 +11,7 @@ import (
 
 // StartInteractiveScroll activates the interactive scroll mode,
 // showing the scroll overlay and enabling key handling for scrolling.
-func (h *Handler) StartInteractiveScroll() {
+func (h *handlerState) startInteractiveScroll() {
 	h.prepareForModeActivation()
 	h.cursorState.SkipNextRestore()
 
@@ -24,7 +24,7 @@ func (h *Handler) StartInteractiveScroll() {
 		// disable and subsequent re-enable (the root cause of missed
 		// scrolling keys when activating from grid mode).
 		h.performModeSpecificCleanup()
-		h.stopHeldRepeatLocked()
+		h.stopHeldRepeat()
 		h.overlayManager.Clear()
 		h.overlayManager.ClearCache()
 
@@ -58,11 +58,11 @@ func (h *Handler) StartInteractiveScroll() {
 
 	h.overlayManager.ResizeToActiveScreen()
 
-	h.setModeLocked(domain.ModeScroll, overlay.ModeScroll)
+	h.setMode(domain.ModeScroll, overlay.ModeScroll)
 
 	h.logger.Info("Interactive scroll activated")
 }
 
 // handleGenericScrollKey intentionally does nothing.
 // Scroll key behavior is fully driven by hotkeys.
-func (h *Handler) handleGenericScrollKey(_ string) {}
+func (h *handlerState) handleGenericScrollKey(_ string) {}

--- a/internal/app/modes/scroll_mode.go
+++ b/internal/app/modes/scroll_mode.go
@@ -11,16 +11,16 @@ type ScrollMode struct {
 }
 
 // NewScrollMode creates a new scroll mode implementation.
-func NewScrollMode(handler *Handler) *ScrollMode {
+func NewScrollMode(handler *handlerState) *ScrollMode {
 	behavior := ModeBehavior{
-		ActivateFunc: func(handler *Handler, _ ModeActivationOptions) {
+		ActivateFunc: func(handler *handlerState, _ ModeActivationOptions) {
 			// Scroll mode ignores activation options because it has a single activation flow.
-			handler.StartInteractiveScroll()
+			handler.startInteractiveScroll()
 			handler.startIndicatorPolling(domain.ModeScroll)
 		},
-		ExitFunc: func(handler *Handler) {
+		ExitFunc: func(handler *handlerState) {
 			handler.stopIndicatorPolling()
-			handler.stopHeldRepeatLocked()
+			handler.stopHeldRepeat()
 
 			handler.clearAndHideOverlay()
 

--- a/internal/app/modes/scroll_mode_test.go
+++ b/internal/app/modes/scroll_mode_test.go
@@ -1,18 +1,17 @@
-package modes_test
+package modes
 
 import (
 	"testing"
 
-	"github.com/y3owk1n/neru/internal/app/modes"
 	"github.com/y3owk1n/neru/internal/domain"
 )
 
 // Compile-time interface compliance check.
-var _ modes.Mode = (*modes.ScrollMode)(nil)
+var _ Mode = (*ScrollMode)(nil)
 
 func TestScrollMode_ModeType(t *testing.T) {
-	handler := &modes.Handler{}
-	mode := modes.NewScrollMode(handler)
+	handler := &handlerState{}
+	mode := NewScrollMode(handler)
 
 	if mode.ModeType() != domain.ModeScroll {
 		t.Errorf("Expected ModeScroll, got %v", mode.ModeType())
@@ -20,15 +19,15 @@ func TestScrollMode_ModeType(t *testing.T) {
 }
 
 func TestScrollMode_InterfaceCompliance(t *testing.T) {
-	handler := &modes.Handler{}
-	mode := modes.NewScrollMode(handler)
+	handler := &handlerState{}
+	mode := NewScrollMode(handler)
 
 	if mode == nil {
 		t.Fatal("Expected NewScrollMode to return a non-nil mode")
 	}
 
 	// Keep a runtime assertion in addition to the compile-time check above.
-	var interfaceMode modes.Mode = mode
+	var interfaceMode Mode = mode
 	if interfaceMode.ModeType() != domain.ModeScroll {
 		t.Errorf("Expected ModeScroll, got %v", interfaceMode.ModeType())
 	}

--- a/internal/app/modes/selection.go
+++ b/internal/app/modes/selection.go
@@ -54,7 +54,7 @@ func (h *Handler) ClearCurrentSelectionPoint() bool {
 		}
 
 		h.grid.Context.ClearSelectionPoint()
-		h.refreshGridVirtualPointerLocked()
+		h.refreshGridVirtualPointer()
 
 		return true
 	case domain.ModeRecursiveGrid:
@@ -63,7 +63,7 @@ func (h *Handler) ClearCurrentSelectionPoint() bool {
 		}
 
 		h.recursiveGrid.Context.ClearSelectionPoint()
-		h.refreshRecursiveGridVirtualPointerLocked()
+		h.refreshRecursiveGridVirtualPointer()
 
 		return true
 	case domain.ModeHints:
@@ -97,7 +97,7 @@ func (h *Handler) CursorFollowSelection() (bool, bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	modeContext, ok := h.cursorFollowContextLocked()
+	modeContext, ok := h.cursorFollowContext()
 	if !ok {
 		return false, false
 	}
@@ -128,7 +128,7 @@ func (h *Handler) applyCursorFollowSelection(desired *bool) (bool, bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	modeContext, ok := h.cursorFollowContextLocked()
+	modeContext, ok := h.cursorFollowContext()
 	if !ok {
 		return false, false
 	}
@@ -149,20 +149,20 @@ func (h *Handler) applyCursorFollowSelection(desired *bool) (bool, bool) {
 	// preference only affects the selections made after it.
 	switch h.appState.CurrentMode() {
 	case domain.ModeGrid:
-		h.refreshGridVirtualPointerLocked()
-		h.moveCursorToSelectionLocked(enabled, h.grid.Context.SelectionPoint)
+		h.refreshGridVirtualPointer()
+		h.moveCursorToSelection(enabled, h.grid.Context.SelectionPoint)
 	case domain.ModeRecursiveGrid:
-		h.refreshRecursiveGridVirtualPointerLocked()
-		h.moveCursorToSelectionLocked(enabled, h.recursiveGrid.Context.SelectionPoint)
+		h.refreshRecursiveGridVirtualPointer()
+		h.moveCursorToSelection(enabled, h.recursiveGrid.Context.SelectionPoint)
 	case domain.ModeHints, domain.ModeIdle, domain.ModeScroll, domain.ModeMonitorSelect:
 	}
 
 	return enabled, true
 }
 
-// cursorFollowContextLocked returns the active mode's cursor-follow context, or
+// cursorFollowContext returns the active mode's cursor-follow context, or
 // false when the active mode does not carry the preference.
-func (h *Handler) cursorFollowContextLocked() (cursorFollowContext, bool) {
+func (h *handlerState) cursorFollowContext() (cursorFollowContext, bool) {
 	switch h.appState.CurrentMode() {
 	case domain.ModeHints:
 		if h.hints == nil || h.hints.Context == nil {
@@ -193,10 +193,10 @@ func (h *Handler) cursorFollowContextLocked() (cursorFollowContext, bool) {
 	return nil, false
 }
 
-// moveCursorToSelectionLocked moves the real cursor onto the mode's stored
+// moveCursorToSelection moves the real cursor onto the mode's stored
 // selection point when the mode is following the selection. Turning the
 // preference off leaves the cursor where it is.
-func (h *Handler) moveCursorToSelectionLocked(
+func (h *handlerState) moveCursorToSelection(
 	enabled bool,
 	selectionPoint func() (image.Point, bool),
 ) {
@@ -215,7 +215,7 @@ func (h *Handler) moveCursorToSelectionLocked(
 	}
 }
 
-func (h *Handler) refreshGridVirtualPointerLocked() {
+func (h *handlerState) refreshGridVirtualPointer() {
 	if h.grid == nil || h.grid.Context == nil || h.grid.Overlay == nil {
 		return
 	}
@@ -233,7 +233,7 @@ func (h *Handler) refreshGridVirtualPointerLocked() {
 	h.grid.Overlay.ShowVirtualPointer(localPoint, style.fontSize, style.fillColor)
 }
 
-func (h *Handler) refreshRecursiveGridVirtualPointerLocked() {
+func (h *handlerState) refreshRecursiveGridVirtualPointer() {
 	if h.recursiveGrid == nil || h.recursiveGrid.Context == nil || h.recursiveGrid.Overlay == nil {
 		return
 	}
@@ -248,7 +248,7 @@ func (h *Handler) refreshRecursiveGridVirtualPointerLocked() {
 	h.recursiveGrid.Overlay.ShowVirtualPointer(state.Position, state.Size, state.FillColor)
 }
 
-func (h *Handler) currentRecursiveGridVirtualPointerState() componentrecursivegrid.VirtualPointerState {
+func (h *handlerState) currentRecursiveGridVirtualPointerState() componentrecursivegrid.VirtualPointerState {
 	if h.recursiveGrid == nil || h.recursiveGrid.Context == nil {
 		return componentrecursivegrid.VirtualPointerState{}
 	}
@@ -277,7 +277,7 @@ type virtualPointerStyle struct {
 	fontName  string
 }
 
-func (h *Handler) virtualPointerStyle() (virtualPointerStyle, bool) {
+func (h *handlerState) virtualPointerStyle() (virtualPointerStyle, bool) {
 	cfg := h.config.VirtualPointer
 
 	fillColor := cfg.UI.TextColor.ForTheme(

--- a/internal/app/modes/selection_test.go
+++ b/internal/app/modes/selection_test.go
@@ -21,7 +21,7 @@ func TestCurrentSelectionPoint_UsesActiveModeContext(t *testing.T) {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeRecursiveGrid)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState: appState,
 		hints:    &components.HintsComponent{},
 		grid: &components.GridComponent{
@@ -30,7 +30,7 @@ func TestCurrentSelectionPoint_UsesActiveModeContext(t *testing.T) {
 		recursiveGrid: &components.RecursiveGridComponent{
 			Context: &recursivegridcomponent.Context{},
 		},
-	}
+	})
 
 	handler.grid.Context.SetSelectionPoint(image.Point{X: 10, Y: 20})
 	handler.recursiveGrid.Context.SetSelectionPoint(image.Point{X: 30, Y: 40})
@@ -49,7 +49,7 @@ func TestToggleCursorFollowSelection_UpdatesOnlySupportedModes(t *testing.T) {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeGrid)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState: appState,
 		logger:   zap.NewNop(),
 		actionService: services.NewActionService(
@@ -64,7 +64,7 @@ func TestToggleCursorFollowSelection_UpdatesOnlySupportedModes(t *testing.T) {
 		grid: &components.GridComponent{
 			Context: &gridcomponent.Context{},
 		},
-	}
+	})
 
 	enabled, supported := handler.ToggleCursorFollowSelection()
 	if !supported {
@@ -95,7 +95,7 @@ func TestToggleCursorFollowSelection_MovesCursorToStoredGridSelectionWhenEnablin
 
 	var moved []image.Point
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState: appState,
 		logger:   zap.NewNop(),
 		actionService: services.NewActionService(
@@ -113,7 +113,7 @@ func TestToggleCursorFollowSelection_MovesCursorToStoredGridSelectionWhenEnablin
 		grid: &components.GridComponent{
 			Context: &gridcomponent.Context{},
 		},
-	}
+	})
 
 	handler.grid.Context.SetSelectionPoint(image.Point{X: 120, Y: 240})
 
@@ -137,7 +137,7 @@ func TestToggleCursorFollowSelection_DoesNotMoveCursorWhenDisabling(t *testing.T
 
 	moveCount := 0
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState: appState,
 		logger:   zap.NewNop(),
 		actionService: services.NewActionService(
@@ -155,7 +155,7 @@ func TestToggleCursorFollowSelection_DoesNotMoveCursorWhenDisabling(t *testing.T
 		grid: &components.GridComponent{
 			Context: &gridcomponent.Context{},
 		},
-	}
+	})
 
 	handler.grid.Context.SetCursorFollowSelection(true)
 	handler.grid.Context.SetSelectionPoint(image.Point{X: 120, Y: 240})
@@ -181,7 +181,7 @@ func TestToggleCursorFollowSelection_MovesCursorToStoredRecursiveGridSelectionWh
 
 	var moved []image.Point
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState: appState,
 		logger:   zap.NewNop(),
 		actionService: services.NewActionService(
@@ -199,7 +199,7 @@ func TestToggleCursorFollowSelection_MovesCursorToStoredRecursiveGridSelectionWh
 		recursiveGrid: &components.RecursiveGridComponent{
 			Context: &recursivegridcomponent.Context{},
 		},
-	}
+	})
 
 	handler.recursiveGrid.Context.SetSelectionPoint(image.Point{X: 33, Y: 66})
 
@@ -221,7 +221,7 @@ func TestClearCurrentSelectionPoint_ClearsOnlyActiveModeSelection(t *testing.T) 
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeRecursiveGrid)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState: appState,
 		grid: &components.GridComponent{
 			Context: &gridcomponent.Context{},
@@ -229,7 +229,7 @@ func TestClearCurrentSelectionPoint_ClearsOnlyActiveModeSelection(t *testing.T) 
 		recursiveGrid: &components.RecursiveGridComponent{
 			Context: &recursivegridcomponent.Context{},
 		},
-	}
+	})
 
 	handler.grid.Context.SetSelectionPoint(image.Point{X: 10, Y: 20})
 	handler.recursiveGrid.Context.SetSelectionPoint(image.Point{X: 30, Y: 40})
@@ -267,13 +267,13 @@ func TestSetCursorFollowSelection_ConvergesRatherThanFlipping(t *testing.T) {
 			appState := state.NewAppState()
 			appState.SetMode(domain.ModeHints)
 
-			handler := &Handler{
+			handler := newHandlerWithState(handlerState{
 				appState: appState,
 				logger:   zap.NewNop(),
 				hints: &components.HintsComponent{
 					Context: &hintscomponent.Context{},
 				},
-			}
+			})
 
 			handler.hints.Context.SetCursorFollowSelection(testCase.initial)
 
@@ -298,13 +298,13 @@ func TestCursorFollowSelection_ReadsWithoutChanging(t *testing.T) {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeGrid)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState: appState,
 		logger:   zap.NewNop(),
 		grid: &components.GridComponent{
 			Context: &gridcomponent.Context{},
 		},
-	}
+	})
 
 	handler.grid.Context.SetCursorFollowSelection(true)
 
@@ -324,13 +324,13 @@ func TestCursorFollowSelection_ReportsUnsupportedWithoutAMode(t *testing.T) {
 	appState := state.NewAppState()
 	appState.SetMode(domain.ModeIdle)
 
-	handler := &Handler{
+	handler := newHandlerWithState(handlerState{
 		appState: appState,
 		logger:   zap.NewNop(),
 		hints: &components.HintsComponent{
 			Context: &hintscomponent.Context{},
 		},
-	}
+	})
 
 	if _, supported := handler.CursorFollowSelection(); supported {
 		t.Fatal("CursorFollowSelection() reported support in idle mode")

--- a/internal/app/modes/validation.go
+++ b/internal/app/modes/validation.go
@@ -20,7 +20,11 @@ const (
 // validateModeActivation performs common validation checks before mode activation.
 // Returns an error if the mode cannot be activated.
 // If bundleID is non-empty, it is used directly for exclusion check (skips AX call).
-func (h *Handler) validateModeActivation(bundleID string, modeName string, modeEnabled bool) error {
+func (h *handlerState) validateModeActivation(
+	bundleID string,
+	modeName string,
+	modeEnabled bool,
+) error {
 	// Check for secure input mode first - this is a macOS security feature
 	// that blocks keyboard events when password fields are focused.
 	// On non-macOS platforms IsSecureInputEnabled always returns false.
@@ -73,13 +77,13 @@ func (h *Handler) validateModeActivation(bundleID string, modeName string, modeE
 
 // prepareForModeActivation performs common preparation steps before activating a mode.
 // This includes resetting scroll state and syncing any platform cursor cache.
-func (h *Handler) prepareForModeActivation() {
+func (h *handlerState) prepareForModeActivation() {
 	h.resetScrollContext()
 	h.syncCursorPositionForModeActivation()
 }
 
 // resetScrollContext resets scroll-related state to ensure clean mode transitions.
-func (h *Handler) resetScrollContext() {
+func (h *handlerState) resetScrollContext() {
 	if h.scroll.Context.IsActive() {
 		// Atomically reset scroll context to ensure clean transition
 		h.scroll.Context.Reset()
@@ -91,7 +95,7 @@ func (h *Handler) resetScrollContext() {
 // syncCursorPositionForModeActivation refreshes the adapter's cached cursor
 // position when the platform keeps one. Adapters that do not implement
 // ports.CursorSynchronizer are already authoritative, so there is nothing to do.
-func (h *Handler) syncCursorPositionForModeActivation() {
+func (h *handlerState) syncCursorPositionForModeActivation() {
 	syncer, ok := h.system.(ports.CursorSynchronizer)
 	if !ok {
 		return


### PR DESCRIPTION
## Description

This PR makes the mode handler's locking discipline compiler-enforced.

The handler is now two types: an outer shell that owns the mutexes and the exported entry points (each locks and delegates), and an embedded inner state that carries every field and every lock-held method — and deliberately has no mutex. Modes are built on the inner type, so calling a locking entry point from locked context is a compile error instead of a runtime self-deadlock, and the suffix convention is gone entirely. Deferred work (timers, goroutines, platform callbacks) reaches the lock through one documented escape hatch on the inner type, used at five sites, each preserving today's semantics exactly.

No behavior change is intended anywhere.

## Related Issues

N/A

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)

## Type of Change

- [x] `refactor` — Code restructuring (no behavior change)

One latent oddity surfaced by the migration and fixed here: an exported entry point that never locked and had no external callers (`StartInteractiveScroll`) is now an ordinary internal state method — observationally identical since nothing outside the package called it.

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — the cursor-visibility dispatch pair moved to the inner type on both its darwin and fallback sides
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no capability surface changed

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build) — lint, Docker `lint-cross`, the full Linux suite via `just test-linux`, `-race` on the app tree, full unit suite, integration-tagged vet, and build all run locally; the complete `-race`/integration passes run in CI
- [x] Tests added/updated for new or changed functionality — existing tests migrated to the new construction; coverage unchanged
- [x] Documentation updated (if applicable) — the locking sections of ARCHITECTURE.md and DEVELOPMENT.md (including the mode implementation example) describe the new shape

## Additional Context

Anatomy of the split: `Handler` keeps `mu`, `moveMonitorMu`, the 45 exported entry points, and the two genuine lock-choreography methods (the indicator poller's conditional-unlock resize, and the passthrough entry invoked by the event tap); `handlerState` carries the ~50 fields and ~90 lock-held methods. The `handlerState.outer` escape hatch appears at exactly five deferred sites (modifier-toggle debounce timer, hint-refresh timer, text-input session callbacks, the polling-goroutine spawn, and one fire-and-forget hint-cycle goroutine) plus the one pre-existing, session-token-guarded mid-flight unlock around the modal screen-capture permission dialog, which is now explained in a comment at the site. Reviewing the escape sites is the highest-value part of the review; `grep -n "outer\." internal/app/modes` lists all of them.
