### PR TITLE
fix(linux): honor XDG base directory environment variables

### DIFF
--- a/internal/adapter/logger/logger_path.go
+++ b/internal/adapter/logger/logger_path.go
@@ -27,8 +27,15 @@ func defaultLogFilePath() (string, error) {
 
 		logDir = filepath.Join(localAppData, "neru", "log")
 	default:
-		// the rest are Linux, BSD, etc.
-		logDir = filepath.Join(homeDir, ".local", "state", "neru", "log")
+		// The rest are Linux, BSD, etc.: honor $XDG_STATE_HOME per the XDG
+		// Base Directory spec (absolute values only), matching the Linux
+		// system adapter's LogDir.
+		stateHome := os.Getenv("XDG_STATE_HOME")
+		if !filepath.IsAbs(stateHome) {
+			stateHome = filepath.Join(homeDir, ".local", "state")
+		}
+
+		logDir = filepath.Join(stateHome, "neru", "log")
 	}
 
 	return filepath.Join(logDir, "app.log"), nil

--- a/internal/adapter/logger/logger_path_test.go
+++ b/internal/adapter/logger/logger_path_test.go
@@ -22,6 +22,8 @@ func TestDefaultLogFilePath(t *testing.T) {
 		t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
 	}
 
+	t.Setenv("XDG_STATE_HOME", "")
+
 	got, err := defaultLogFilePath()
 	if err != nil {
 		t.Fatalf("DefaultLogFilePath() error = %v", err)
@@ -62,5 +64,26 @@ func TestDefaultLogFilePathWindowsFallback(t *testing.T) {
 	want := filepath.Join(home, "AppData", "Local", "neru", "log", "app.log")
 	if got != want {
 		t.Fatalf("DefaultLogFilePath() fallback = %q, want %q", got, want)
+	}
+}
+
+// TestDefaultLogFilePathHonorsXDGStateHome pins that on platforms using the
+// XDG fallback branch, an absolute XDG_STATE_HOME redirects the default log
+// path, matching the Linux system adapter's LogDir.
+func TestDefaultLogFilePathHonorsXDGStateHome(t *testing.T) {
+	if runtime.GOOS == goosDarwin || runtime.GOOS == goosWindows {
+		t.Skip("XDG branch applies to the non-darwin, non-windows default only")
+	}
+
+	t.Setenv("XDG_STATE_HOME", "/custom/state")
+
+	got, err := defaultLogFilePath()
+	if err != nil {
+		t.Fatalf("DefaultLogFilePath() error = %v", err)
+	}
+
+	want := filepath.Join("/custom/state", "neru", "log", "app.log")
+	if got != want {
+		t.Fatalf("DefaultLogFilePath() = %q, want %q", got, want)
 	}
 }

--- a/internal/adapter/platform/linux/system_common.go
+++ b/internal/adapter/platform/linux/system_common.go
@@ -107,34 +107,53 @@ func (s *SystemAdapter) Capabilities() ports.PlatformCapabilities {
 	return capabilities
 }
 
-// ConfigDir returns the Linux-specific configuration directory.
+// xdgDir resolves an XDG base directory per the Base Directory spec: the
+// environment variable wins when set to an absolute path (relative values
+// must be ignored per the spec), otherwise the given default under $HOME.
+func xdgDir(envVar string, defaultParts ...string) (string, error) {
+	if dir := os.Getenv(envVar); filepath.IsAbs(dir) {
+		return dir, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(append([]string{home}, defaultParts...)...), nil
+}
+
+// ConfigDir returns the Linux-specific configuration directory,
+// honoring $XDG_CONFIG_HOME.
 func (s *SystemAdapter) ConfigDir() (string, error) {
-	home, err := os.UserHomeDir()
+	base, err := xdgDir("XDG_CONFIG_HOME", ".config")
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(home, ".config", "neru"), nil
+	return filepath.Join(base, "neru"), nil
 }
 
-// UserDataDir returns the Linux-specific user data directory.
+// UserDataDir returns the Linux-specific user data directory,
+// honoring $XDG_DATA_HOME.
 func (s *SystemAdapter) UserDataDir() (string, error) {
-	home, err := os.UserHomeDir()
+	base, err := xdgDir("XDG_DATA_HOME", ".local", "share")
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(home, ".local", "share", "neru"), nil
+	return filepath.Join(base, "neru"), nil
 }
 
-// LogDir returns the Linux-specific log directory.
+// LogDir returns the Linux-specific log directory,
+// honoring $XDG_STATE_HOME.
 func (s *SystemAdapter) LogDir() (string, error) {
-	home, err := os.UserHomeDir()
+	base, err := xdgDir("XDG_STATE_HOME", ".local", "state")
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(home, ".local", "state", "neru", "log"), nil
+	return filepath.Join(base, "neru", "log"), nil
 }
 
 // FocusedApplicationPID returns the PID of the currently focused application on Linux.

--- a/internal/adapter/platform/linux/system_dirs_test.go
+++ b/internal/adapter/platform/linux/system_dirs_test.go
@@ -1,0 +1,92 @@
+//go:build linux
+
+package linux
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestSystemAdapter_Dirs_HonorXDGBaseDirectories pins the XDG Base Directory
+// contract: an absolute env value wins, a relative value is ignored per the
+// spec, and an unset variable falls back to the spec default under $HOME.
+func TestSystemAdapter_Dirs_HonorXDGBaseDirectories(t *testing.T) {
+	adapter := &SystemAdapter{}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tests := []struct {
+		name    string
+		envVar  string
+		envVal  string
+		call    func() (string, error)
+		want    string
+		wantDef string
+	}{
+		{
+			name:    "ConfigDir",
+			envVar:  "XDG_CONFIG_HOME",
+			envVal:  "/custom/config",
+			call:    adapter.ConfigDir,
+			want:    "/custom/config/neru",
+			wantDef: filepath.Join(home, ".config", "neru"),
+		},
+		{
+			name:    "UserDataDir",
+			envVar:  "XDG_DATA_HOME",
+			envVal:  "/custom/data",
+			call:    adapter.UserDataDir,
+			want:    "/custom/data/neru",
+			wantDef: filepath.Join(home, ".local", "share", "neru"),
+		},
+		{
+			name:    "LogDir",
+			envVar:  "XDG_STATE_HOME",
+			envVal:  "/custom/state",
+			call:    adapter.LogDir,
+			want:    filepath.Join("/custom/state", "neru", "log"),
+			wantDef: filepath.Join(home, ".local", "state", "neru", "log"),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name+" honors absolute env", func(t *testing.T) {
+			t.Setenv(testCase.envVar, testCase.envVal)
+
+			got, err := testCase.call()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != testCase.want {
+				t.Errorf("got %q, want %q", got, testCase.want)
+			}
+		})
+
+		t.Run(testCase.name+" ignores relative env", func(t *testing.T) {
+			t.Setenv(testCase.envVar, "relative/path")
+
+			got, err := testCase.call()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != testCase.wantDef {
+				t.Errorf("got %q, want default %q", got, testCase.wantDef)
+			}
+		})
+
+		t.Run(testCase.name+" defaults when unset", func(t *testing.T) {
+			t.Setenv(testCase.envVar, "")
+
+			got, err := testCase.call()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != testCase.wantDef {
+				t.Errorf("got %q, want default %q", got, testCase.wantDef)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes Neru ignoring the XDG Base Directory environment variables on Linux. The configuration, data, and log directories were hardcoded to `~/.config`, `~/.local/share`, and `~/.local/state`, so users who relocate their XDG directories found Neru's files in the wrong place — even though the configuration reference already promises the XDG path as the first lookup location.

All three directories now follow the spec: an absolute environment value wins, a relative value is ignored (as the spec requires), and an unset variable falls back to the usual default under the home directory. Users with default setups see no change at all.

## Environment variables now honored

| Variable | Controls | Default when unset |
|---|---|---|
| `XDG_CONFIG_HOME` | config directory (`<dir>/neru/`) | `~/.config/neru/` |
| `XDG_DATA_HOME` | user data directory (`<dir>/neru/`) | `~/.local/share/neru/` |
| `XDG_STATE_HOME` | log directory (`<dir>/neru/log/`) | `~/.local/state/neru/log/` |

Existing configs and installs keep working untouched; only users who had set these variables (and were being ignored) see files move to where they asked.

## Related Issues

None — deferred-items phase of the contributor-experience audit (follows #1158–#1170).

## Target Platform

- [x] Linux

## Type of Change

- [x] `fix` — Bug fix

## Potential behavior change

If a user had `XDG_CONFIG_HOME` (or the data/state variables) set to a non-default absolute path, Neru now reads and writes under that path instead of the hardcoded one. Anyone in that situation who accumulated files at the old hardcoded location should move them to the XDG location once — which is the behavior they originally asked their environment for.

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, Linux-only behavior fix

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build) — Docker `lint-cross` and the full Linux test suite (including the new tests) run locally along with fmt/lint/check-cross; `-race`/integration passes run in CI
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, docs already describe the XDG lookup; the code now matches them
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
