### PR TITLE
refactor(app): fold internal/ui into internal/app/render

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,7 +134,6 @@ Cross the boundary through `ports.SystemPort` or a build-tagged dispatch pair
 graph TD
     subgraph "Presentation Layer"
         CLI[internal/cli]
-        UI[internal/ui]
     end
 
     subgraph "Application Layer"
@@ -160,7 +159,6 @@ graph TD
     Ports --> Domain
     Adapters -.->|Implements| Ports
     Platform -.->|Implements| Ports
-    UI --> Adapters
 ```
 
 ### Layer responsibilities
@@ -176,9 +174,10 @@ graph TD
   owns lifecycle and navigation modes.
 - **Adapters** (`internal/adapter`) — concrete port implementations on
   platform APIs.
-- **UI** (`internal/ui`) — coordinate transformation and the renderer facade
-  over the overlay adapter. The native overlay backends live in
-  `internal/adapter/overlay`, not here.
+- **Rendering facade** (`internal/app/render`) — the app-layer renderer that
+  drives the overlay adapter. The native overlay backends live in
+  `internal/adapter/overlay`, not here; pure coordinate math lives in
+  `internal/domain/geometry`.
 - **CLI** (`internal/cli`) — user commands, config loading, IPC to the daemon.
 
 A directory-by-directory map for placing new code is in

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -9,7 +9,7 @@ covers both sides of that:
   lives, and how to add to it.
 
 Every claim in Part 1 is derived from code under `internal/adapter/`,
-`internal/ui/`, and `internal/app/`. **If this document and the code
+`internal/app/`. **If this document and the code
 disagree, the code wins** — and the disagreement is a bug worth fixing here.
 
 **Related:** [Architecture](./ARCHITECTURE.md) · [Linux setup](./LINUX_SETUP.md) ·
@@ -612,7 +612,7 @@ enforced by
 | Rule                                                | Why |
 | --------------------------------------------------- | --- |
 | `internal/domain` imports no adapter, app, or UI | domain is pure Go; a domain package that needs an OS cannot be unit-tested |
-| `internal/{domain,ports,derrors,adapter}` never import `internal/app` or `internal/ui` | adapters implement ports; the hexagon has no upward edges |
+| `internal/{domain,ports,derrors,adapter}` never import `internal/app` | adapters implement ports; the hexagon has no upward edges |
 | app code reaches adapters only through ports        | only the composition root knows which adapter exists |
 
 The third rule has three deliberate escapes, all narrow:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -298,7 +298,7 @@ What belongs at which log level — and what must never be logged — is in
 | `internal/app/`            | Application orchestration, services, modes         |
 | `internal/app/components/` | Mode-specific overlay rendering                    |
 | `internal/app/modes/`      | Navigation mode implementations                    |
-| `internal/ui/`             | Coordinate conversion, abstract rendering          |
+| `internal/app/render/`     | The app-layer rendering facade over the overlays   |
 | `internal/cli/`            | Cobra CLI commands, IPC dispatch                   |
 | `internal/config/`         | TOML parsing, validation, defaults                 |
 
@@ -325,7 +325,7 @@ naming is in [CROSS_PLATFORM.md](CROSS_PLATFORM.md#file-layout-rules).
 **UI components**
 
 1. Create the component in `internal/app/components/`
-2. Implement rendering in `internal/ui/`
+2. Implement rendering in `internal/app/render/`
 3. macOS Objective-C goes in `internal/adapter/platform/darwin/` behind
    `//go:build darwin`, with a no-op stub elsewhere
 4. Register in `internal/app/component_factory.go` or

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app/ipcctrl"
 	"github.com/y3owk1n/neru/internal/app/keybinding"
 	"github.com/y3owk1n/neru/internal/app/modes"
+	"github.com/y3owk1n/neru/internal/app/render"
 	"github.com/y3owk1n/neru/internal/app/sequence"
 	"github.com/y3owk1n/neru/internal/app/services"
 	"github.com/y3owk1n/neru/internal/app/services/modeindicator"
@@ -21,7 +22,6 @@ import (
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/state"
 	"github.com/y3owk1n/neru/internal/ports"
-	"github.com/y3owk1n/neru/internal/ui"
 )
 
 // Mode is the current mode of the application.
@@ -112,7 +112,7 @@ type App struct {
 	// State subscriptions
 	screenShareSubscriptionID uint64
 
-	renderer *ui.OverlayRenderer
+	renderer *render.OverlayRenderer
 
 	ipcController *ipcctrl.Controller
 }

--- a/internal/app/getters.go
+++ b/internal/app/getters.go
@@ -6,9 +6,9 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	"github.com/y3owk1n/neru/internal/app/components/scroll"
+	"github.com/y3owk1n/neru/internal/app/render"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/ports"
-	"github.com/y3owk1n/neru/internal/ui"
 )
 
 // configSnapshot returns the current config pointer under a read lock.
@@ -83,7 +83,7 @@ func (a *App) HintsContext() *hints.Context {
 }
 
 // Renderer returns the overlay renderer.
-func (a *App) Renderer() *ui.OverlayRenderer {
+func (a *App) Renderer() *render.OverlayRenderer {
 	return a.renderer
 }
 

--- a/internal/app/modes/grid_test.go
+++ b/internal/app/modes/grid_test.go
@@ -12,11 +12,11 @@ import (
 	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
 	"github.com/y3owk1n/neru/internal/app/components"
+	"github.com/y3owk1n/neru/internal/app/render"
 	"github.com/y3owk1n/neru/internal/app/services"
 	"github.com/y3owk1n/neru/internal/config"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
 	portmocks "github.com/y3owk1n/neru/internal/ports/mocks"
-	"github.com/y3owk1n/neru/internal/ui"
 )
 
 func TestHandleGridModeKey_CompleteSelectionDoesNotMoveWhenCursorFollowSelectionDisabled(
@@ -123,7 +123,7 @@ func TestHandleGridModeKey_EnteringSubgridDoesNotMoveWhenCursorFollowSelectionDi
 		grid: &components.GridComponent{
 			Context: &gridcomponent.Context{},
 		},
-		renderer: ui.NewOverlayRenderer(
+		renderer: render.NewOverlayRenderer(
 			&overlaypkg.NoOpManager{},
 			hintscomponent.StyleMode{},
 			gridcomponent.Style{},

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
 	"github.com/y3owk1n/neru/internal/app/components"
+	"github.com/y3owk1n/neru/internal/app/render"
 	"github.com/y3owk1n/neru/internal/app/services"
 	"github.com/y3owk1n/neru/internal/app/services/modeindicator"
 	"github.com/y3owk1n/neru/internal/app/services/stickyindicator"
@@ -22,7 +23,6 @@ import (
 	"github.com/y3owk1n/neru/internal/domain/action"
 	"github.com/y3owk1n/neru/internal/domain/state"
 	"github.com/y3owk1n/neru/internal/ports"
-	"github.com/y3owk1n/neru/internal/ui"
 )
 
 // Mode defines the interface that all navigation modes must implement.
@@ -85,7 +85,7 @@ type handlerState struct {
 	cursorState    *state.CursorState
 	modifierState  *state.ModifierState
 	overlayManager overlay.ManagerInterface
-	renderer       *ui.OverlayRenderer
+	renderer       *render.OverlayRenderer
 	// New Services
 	hintService            *services.HintService
 	gridService            *services.GridService
@@ -175,7 +175,7 @@ type HandlerDeps struct {
 	CursorState *state.CursorState
 
 	OverlayManager overlay.ManagerInterface
-	Renderer       *ui.OverlayRenderer
+	Renderer       *render.OverlayRenderer
 
 	HintService            *services.HintService
 	GridService            *services.GridService

--- a/internal/app/modes/recursive_grid_test.go
+++ b/internal/app/modes/recursive_grid_test.go
@@ -12,12 +12,12 @@ import (
 	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	componentrecursivegrid "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
 	"github.com/y3owk1n/neru/internal/app/components"
+	"github.com/y3owk1n/neru/internal/app/render"
 	"github.com/y3owk1n/neru/internal/app/services"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/state"
 	portmocks "github.com/y3owk1n/neru/internal/ports/mocks"
-	"github.com/y3owk1n/neru/internal/ui"
 )
 
 func TestHandleRecursiveGridKey_CompleteSelectionDoesNotMoveWhenCursorFollowSelectionDisabled(
@@ -112,7 +112,7 @@ func TestResetCurrentMode_RecursiveGridPreservesHoldMode(t *testing.T) {
 			},
 			zap.NewNop(),
 		),
-		renderer: ui.NewOverlayRenderer(
+		renderer: render.NewOverlayRenderer(
 			&overlaypkg.NoOpManager{},
 			hintscomponent.StyleMode{},
 			gridcomponent.Style{},

--- a/internal/app/render/doc.go
+++ b/internal/app/render/doc.go
@@ -1,6 +1,8 @@
-// Package ui implements the user interface components for the Neru application.
+// Package render is the app-layer rendering facade: it owns the
+// OverlayRenderer that translates mode state into calls on the overlay
+// manager and the shared render styles.
 //
 // This package provides the visual interface layer for Neru, managing all aspects
 // of on-screen rendering and user interaction. It serves as the bridge between
 // the application's core logic and the visual elements displayed to users.
-package ui
+package render

--- a/internal/app/render/renderer.go
+++ b/internal/app/render/renderer.go
@@ -1,4 +1,4 @@
-package ui
+package render
 
 import (
 	"image"

--- a/internal/app/render/renderer_test.go
+++ b/internal/app/render/renderer_test.go
@@ -1,4 +1,4 @@
-package ui_test
+package render_test
 
 import (
 	"errors"
@@ -11,9 +11,9 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
+	"github.com/y3owk1n/neru/internal/app/render"
 	"github.com/y3owk1n/neru/internal/config"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
-	"github.com/y3owk1n/neru/internal/ui"
 )
 
 // errDraw is returned by the fake manager to check error propagation.
@@ -187,12 +187,12 @@ func TestBuildStyles_ProducesDistinguishableStyles(t *testing.T) {
 	}
 }
 
-func newRenderer(t *testing.T, styles styleSet) (*ui.OverlayRenderer, *fakeManager) {
+func newRenderer(t *testing.T, styles styleSet) (*render.OverlayRenderer, *fakeManager) {
 	t.Helper()
 
 	manager := &fakeManager{}
 
-	return ui.NewOverlayRenderer(manager, styles.hint, styles.grid, styles.recursive), manager
+	return render.NewOverlayRenderer(manager, styles.hint, styles.grid, styles.recursive), manager
 }
 
 func TestOverlayRenderer_DrawHints_ForwardsHintsAndConfiguredStyle(t *testing.T) {

--- a/internal/app/startup_phases.go
+++ b/internal/app/startup_phases.go
@@ -19,6 +19,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app/ipcctrl"
 	"github.com/y3owk1n/neru/internal/app/keybinding"
 	"github.com/y3owk1n/neru/internal/app/modes"
+	"github.com/y3owk1n/neru/internal/app/render"
 	"github.com/y3owk1n/neru/internal/app/services"
 	"github.com/y3owk1n/neru/internal/app/services/modeindicator"
 	"github.com/y3owk1n/neru/internal/app/services/stickyindicator"
@@ -28,7 +29,6 @@ import (
 	domainHint "github.com/y3owk1n/neru/internal/domain/hint"
 	"github.com/y3owk1n/neru/internal/domain/state"
 	"github.com/y3owk1n/neru/internal/ports"
-	"github.com/y3owk1n/neru/internal/ui"
 )
 
 // initializeInfrastructure sets up the core infrastructure components
@@ -300,7 +300,7 @@ func initializeRendererAndOverlays(app *App) {
 	gridStyle := grid.BuildStyle(cfg.Grid, app.systemPort)
 	recursiveGridStyle := recursivegrid.BuildStyle(cfg.RecursiveGrid, app.systemPort)
 
-	app.renderer = ui.NewOverlayRenderer(
+	app.renderer = render.NewOverlayRenderer(
 		app.overlayManager,
 		hintStyle,
 		gridStyle,
@@ -324,7 +324,7 @@ func initializeModeHandler(app *App) {
 		appState       *state.AppState
 		cursorState    *state.CursorState
 		overlayManager OverlayManager
-		renderer       *ui.OverlayRenderer
+		renderer       *render.OverlayRenderer
 		services       struct {
 			hint            *services.HintService
 			grid            *services.GridService

--- a/internal/architecture/layering_test.go
+++ b/internal/architecture/layering_test.go
@@ -26,7 +26,6 @@ func TestDomainStaysPure(t *testing.T) {
 	forbidden := []string{
 		"internal/adapter",
 		"internal/app",
-		"internal/ui",
 		"internal/cli",
 	}
 
@@ -77,8 +76,7 @@ func TestInfraDoesNotImportApp(t *testing.T) {
 		}
 
 		for _, imported := range importsOf(t, file.absPath) {
-			if !strings.HasPrefix(imported, "internal/app") &&
-				!strings.HasPrefix(imported, "internal/ui") {
+			if !strings.HasPrefix(imported, "internal/app") {
 				continue
 			}
 
@@ -220,7 +218,6 @@ func TestKnownLayeringExceptionsAreStillReal(t *testing.T) {
 
 func isApplicationLayer(relPath string) bool {
 	return strings.HasPrefix(relPath, "internal/app/") ||
-		strings.HasPrefix(relPath, "internal/ui/") ||
 		strings.HasPrefix(relPath, "internal/cli/") ||
 		strings.HasPrefix(relPath, "cmd/")
 }

--- a/justfile
+++ b/justfile
@@ -205,7 +205,7 @@ test-foundation:
         ./internal/adapter/logger \
         ./internal/adapter/platform/mousestate \
         ./internal/ports ./internal/ports/mocks \
-        ./internal/ui ./internal/domain/geometry
+        ./internal/app/render ./internal/domain/geometry
     @echo "✓ Cross-platform foundation tests passed"
 
 # Print the packages that contain no platform-tagged source, i.e. the set


### PR DESCRIPTION
## Description

This PR retires the last phantom layer in the package tree. A three-file package holding a single type — the rendering facade the app uses to drive the overlays — lived at the top level under a name that sounded like an architectural layer but wasn't one: it sat outside the hexagon's vocabulary, and the layering guardrail test had to special-case it in three places just to keep the rules coherent.

The facade now lives inside the app layer where it always conceptually belonged. The guardrail's special cases are deleted — the layering rules now have one less hole and describe the tree exactly — and the architecture docs' component diagram and layer tables match reality. Pure move; no behavior, commands, or config changed.

## Related Issues

None — deferred-items phase of the contributor-experience audit (follows #1158–#1172).

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)

## Type of Change

- [x] `refactor` — Code restructuring (no behavior change)

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build) — fmt, lint, Docker `lint-cross`, `check-cross`, build, full unit suite, and the architecture + foundation guardrails run locally; `-race`/integration passes run in CI
- [x] Tests added/updated for new or changed functionality — N/A, pure move; tests moved with the package
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Move map: `internal/ui` → `internal/app/render` (the `OverlayRenderer` type keeps its name; importers in the app wiring and mode handler updated). Deleted special cases in `internal/architecture/layering_test.go`: the forbidden-list entry, the app-layer prefix exemption, and the application-layer classifier branch. The doc-link guardrail drove out every stale path reference across ARCHITECTURE.md, DEVELOPMENT.md, CROSS_PLATFORM.md and the justfile's foundation-test list — four docs the move would otherwise have silently outdated.
