### PR TITLE
chore(ci): gate on an honest test profile for headless runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,9 +130,9 @@ jobs:
               if: matrix.check == 'build' && runner.os == 'macOS'
               run: devbox run -- just build
 
-            - name: Run just test-all
+            - name: Run just test-ci
               if: matrix.check == 'test' && runner.os == 'macOS'
-              run: devbox run -- just test-all
+              run: devbox run -- just test-ci
 
             - name: Run just vuln
               if: matrix.check == 'vuln' && runner.os == 'macOS'
@@ -172,9 +172,9 @@ jobs:
               run: just build
               shell: bash
 
-            - name: Run just test-all (native)
+            - name: Run just test-ci (native)
               if: matrix.check == 'test' && (runner.os == 'Windows' || runner.os == 'Linux')
-              run: just test-all
+              run: just test-ci
               shell: bash
 
             - name: Run just vuln (native)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,8 +84,10 @@ recommended path and provides every tool pre-configured.
     > [DEVELOPMENT.md](docs/DEVELOPMENT.md#testing).
 
     Before pushing, run **`just ci`** — it is exactly what CI gates your PR on,
-    and it is a superset of the checks above (adds `go vet`, a full `-race`
-    pass, and a vulnerability scan). Doing Linux or Windows work? Start with
+    and it is a superset of the checks above (adds `go vet`, a `-race` pass
+    over the unit suite, the CI profile of the integration suite, and a
+    vulnerability scan). For the deepest verification on a real desktop
+    session, `just test-all` runs full integration under `-race` too. Doing Linux or Windows work? Start with
     `just test-foundation` and `just build-linux` / `just build-windows`.
 
 6. **Update the docs** in the same PR. Each fact has one home — the

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -132,7 +132,8 @@ Wayland protocol generation and icon recipes.
 | Test    | `just test-race`             | Unit + integration with `-race`                 |
 | Test    | `just test-race-unit`        | Unit tests with `-race`                         |
 | Test    | `just test-race-integration` | Integration tests with `-race`                  |
-| Test    | `just test-all`              | `test` **and** `test-race` — the full sweep     |
+| Test    | `just test-all`              | `test` **and** `test-race` — the deepest sweep  |
+| Test    | `just test-ci`               | What CI gates on: unit, race-unit, short-integration |
 | Test    | `just coverage`              | Unit tests with coverage; prints the total      |
 | Test    | `just coverage-html`         | Coverage as a browsable `coverage.html`         |
 | Lint    | `just lint`                  | `golangci-lint run`                             |

--- a/internal/adapter/ipc/adapter_integration_test.go
+++ b/internal/adapter/ipc/adapter_integration_test.go
@@ -14,10 +14,6 @@ import (
 
 // TestIPCAdapterIntegration tests the IPC adapter with real server.
 func TestIPCAdapterIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
 	log := zap.NewNop()
 
 	// Dummy handler for testing
@@ -110,10 +106,6 @@ func TestIPCAdapterIntegration(t *testing.T) {
 
 // TestIPCAdapterContextCancellation tests context cancellation handling.
 func TestIPCAdapterContextCancellation(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
 	log := zap.NewNop()
 	handler := func(_ context.Context, _ ipc.Command) ipc.Response {
 		return ipc.Response{Success: true}

--- a/internal/cli/cli_integration_test.go
+++ b/internal/cli/cli_integration_test.go
@@ -63,10 +63,6 @@ func newMockAppState() *mockAppState {
 
 // TestCLIIntegration tests IPC communication with real infrastructure.
 func TestCLIIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
 	logger := logger.Get()
 	appState := newMockAppState()
 

--- a/internal/config/config_integration_test.go
+++ b/internal/config/config_integration_test.go
@@ -41,10 +41,6 @@ func serviceWithDefaultHotkeys(logger *zap.Logger) *loader.Service {
 // TestConfigFileOperationsIntegration tests real file system operations
 // for configuration loading and reloading to prevent file system regressions.
 func TestConfigFileOperationsIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping config file operations integration test in short mode")
-	}
-
 	// Create a temporary directory for test config files
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "test-config.toml")

--- a/justfile
+++ b/justfile
@@ -253,13 +253,35 @@ test-race-integration:
     @echo "Running integration tests with race detection..."
     go test -tags=integration -race -p 1 -count=1 -v ./...
 
-# Everything CI's test job runs: the full suite plain and again under -race
-# (four passes total: unit, integration, race-unit, race-integration).
+# The full test suite at maximum depth: everything plain and again under
+# -race (four passes: unit, integration, race-unit, race-integration). This
+# is the deep local bar for a real desktop session with Accessibility
+# granted; CI gates on test-ci below, which is the same minus the passes
+# that are meaningless on a headless runner.
 test-all: test test-race
 
+# Integration tests as CI runs them: -short makes tests that drive the real
+# cursor/keyboard or need OS permissions skip *explicitly* (via their
+# testing.Short guards) instead of passing for reasons nobody wrote down —
+# GitHub runners have no Accessibility grant and no interactive session.
+# Tests that touch real input or permissions must guard themselves with
+# testing.Short(); permission-free integration tests (config, logger, IPC,
+# CLI) still run fully.
+test-integration-ci:
+    @echo "Running integration tests (CI profile: -short)..."
+    go test -tags=integration -short -p 1 -count=1 ./...
+
+# Everything CI's test job runs: unit, unit under -race, and the CI profile
+# of the integration suite. Race coverage on the integration half is left to
+# test-all on real machines — on a permission-less runner it doubles the
+# runtime of the least meaningful pass.
+test-ci: test-unit test-race-unit test-integration-ci
+
 # Run the exact set of checks CI gates a pull request on, in the same order.
-# This is the real pre-push bar — `just test` alone is a subset of it.
-ci: fmt-check lint vet build test-all vuln
+# This is the real pre-push bar — `just test` alone is a subset of it. For
+# the deepest local verification (full integration + race passes on a real
+# desktop session) run `just test-all` as well.
+ci: fmt-check lint vet build test-ci vuln
     @echo "✓ All CI checks passed"
 
 # Check if files are formatted correctly


### PR DESCRIPTION
## Description

This PR makes CI's test gate honest about what a headless runner can actually verify. Until now CI ran the full four-pass suite — unit and integration, each plain and under the race detector — on runners with no Accessibility grant and no interactive session. The integration half passed there for reasons nobody had written down, and repeating it under the race detector doubled the runtime of the least meaningful pass.

CI now gates on a profile that runs the unit suite, the unit suite under the race detector, and the integration suite in short mode — where tests that drive the real cursor and keyboard or need OS permissions skip *explicitly* through their existing short-mode guards, while the permission-free integration tests (config loading, logging, IPC, CLI) still run in full. The deepest verification — full integration under the race detector on a real desktop session — remains available and documented for local runs.

## Command changes

| Command | Change |
|---|---|
| `just test-ci` | New: what CI gates on — `test-unit` + `test-race-unit` + `test-integration-ci` |
| `just test-integration-ci` | New: integration suite with `-short` (input/permission-dependent tests skip explicitly) |
| `just ci` | Now runs `test-ci` instead of `test-all`, staying an exact mirror of CI |
| `just test-all` | Unchanged; documented as the deepest local bar for real desktop sessions |

Existing invocations of `just test`, `just test-all`, and every other recipe keep working untouched.

## Related Issues

N/A

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)

## Type of Change

- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs — the new `test-integration-ci` profile ran locally (input-driving tests skipped via their guards, permission-free tests green), plus fmt, lint, architecture tests, and `check-cross`; workflow YAML parse-validated
- [x] Tests added/updated for new or changed functionality — N/A, CI configuration; the 28 existing `testing.Short()` guards are the mechanism
- [x] Documentation updated (if applicable) — DEVELOPMENT's task table and CONTRIBUTING's gate description
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Known limitation, recorded rather than hidden: integration tests that *lack* a short-mode guard still run on runners exactly as they did before this change — the skip contract only bites where guards exist (28 sites today). The new recipe's comment states the contract for new tests (anything touching real input or permissions must guard itself), and completing the guards on older tests is incremental follow-up that can ride along with normal work on those files. Race coverage over the integration suite intentionally moves to `just test-all` only: on a runner where the input paths skip, that pass re-races mostly the same code the unit race pass already covers.
