### PR TITLE
test(darwin): add a leak-regression test for AX element ownership

### DIFF
--- a/internal/adapter/accessibility/leak_integration_darwin_test.go
+++ b/internal/adapter/accessibility/leak_integration_darwin_test.go
@@ -1,0 +1,78 @@
+//go:build integration && darwin
+
+package accessibility_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/adapter/accessibility"
+	"github.com/y3owk1n/neru/internal/adapter/accessibility/native"
+	nativedarwin "github.com/y3owk1n/neru/internal/adapter/accessibility/native/darwin"
+	"github.com/y3owk1n/neru/internal/adapter/logger"
+	"github.com/y3owk1n/neru/internal/ports"
+)
+
+// leakWalkCount is how many full clickable-element scans the regression test
+// runs. The leak class this test pins (an element enqueued by a traversal and
+// never released) leaks per walk, so a handful of walks separates a real leak
+// from noise without slowing the suite.
+const leakWalkCount = 5
+
+// TestTreeWalk_ReleasesEveryElement pins the AX element ownership discipline:
+// every Element a tree walk constructs must be balanced by exactly one
+// Release, including elements a traversal enqueues but abandons. The live
+// wrapper count must return to its baseline after every walk — the leaks
+// fixed in #1150/#1152 (elements retained during priming and never released)
+// would fail this immediately.
+//
+// Requires Accessibility permission and a real focused application; skipped
+// in short mode per the CI test contract.
+func TestTreeWalk_ReleasesEveryElement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping input/permission-dependent integration test in short mode")
+	}
+
+	if !nativedarwin.CheckAccessibilityPermissions() {
+		t.Skip("Accessibility permission not granted; cannot walk a real tree")
+	}
+
+	log := logger.Get()
+	client := native.New(log, nil)
+	adapter := accessibility.NewAdapter(log, nil, nil, client, false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// One warmup walk: lazily-initialized singletons (system-wide element,
+	// cached application handles) may legitimately outlive the first walk.
+	warmupElements, warmupErr := adapter.ClickableElements(ctx, ports.DefaultElementFilter())
+	if warmupErr != nil {
+		t.Skipf("warmup walk failed (no scannable frontmost app?): %v", warmupErr)
+	}
+
+	_ = warmupElements
+
+	baseline := nativedarwin.LiveElementCount()
+
+	for walk := range leakWalkCount {
+		elements, err := adapter.ClickableElements(ctx, ports.DefaultElementFilter())
+		if err != nil {
+			t.Fatalf("walk %d: ClickableElements() error = %v", walk, err)
+		}
+
+		// The adapter returns domain elements, not live AX wrappers; the walk
+		// owns and must have already released every wrapper it created.
+		_ = elements
+
+		if live := nativedarwin.LiveElementCount(); live != baseline {
+			t.Fatalf(
+				"walk %d leaked AX element wrappers: live count %d, baseline %d — "+
+					"some traversal constructed Elements it never released "+
+					"(see the ownership rule in internal/adapter/platform/darwin/accessibility.h)",
+				walk, live, baseline,
+			)
+		}
+	}
+}

--- a/internal/adapter/accessibility/leak_integration_darwin_test.go
+++ b/internal/adapter/accessibility/leak_integration_darwin_test.go
@@ -5,7 +5,6 @@ package accessibility_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/y3owk1n/neru/internal/adapter/accessibility"
 	"github.com/y3owk1n/neru/internal/adapter/accessibility/native"
@@ -42,29 +41,37 @@ func TestTreeWalk_ReleasesEveryElement(t *testing.T) {
 	client := native.New(log, nil)
 	adapter := accessibility.NewAdapter(log, nil, nil, client, false)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), integrationScanBudget)
 	defer cancel()
 
 	// One warmup walk: lazily-initialized singletons (system-wide element,
 	// cached application handles) may legitimately outlive the first walk.
-	warmupElements, warmupErr := adapter.ClickableElements(ctx, ports.DefaultElementFilter())
+	// runWithinBudget is the hang guard — the AX client discards its context,
+	// so only a watchdog can catch a wedged native query.
+	var warmupErr error
+
+	runWithinBudget(t, "warmup ClickableElements walk", func() {
+		_, warmupErr = adapter.ClickableElements(ctx, ports.DefaultElementFilter())
+	})
+
 	if warmupErr != nil {
 		t.Skipf("warmup walk failed (no scannable frontmost app?): %v", warmupErr)
 	}
 
-	_ = warmupElements
-
 	baseline := nativedarwin.LiveElementCount()
 
 	for walk := range leakWalkCount {
-		elements, err := adapter.ClickableElements(ctx, ports.DefaultElementFilter())
-		if err != nil {
-			t.Fatalf("walk %d: ClickableElements() error = %v", walk, err)
-		}
+		var walkErr error
 
-		// The adapter returns domain elements, not live AX wrappers; the walk
-		// owns and must have already released every wrapper it created.
-		_ = elements
+		runWithinBudget(t, "measured ClickableElements walk", func() {
+			// The adapter returns domain elements, not live AX wrappers; the
+			// walk owns and must have already released every wrapper it made.
+			_, walkErr = adapter.ClickableElements(ctx, ports.DefaultElementFilter())
+		})
+
+		if walkErr != nil {
+			t.Fatalf("walk %d: ClickableElements() error = %v", walk, walkErr)
+		}
 
 		if live := nativedarwin.LiveElementCount(); live != baseline {
 			t.Fatalf(

--- a/internal/adapter/accessibility/leak_integration_darwin_test.go
+++ b/internal/adapter/accessibility/leak_integration_darwin_test.go
@@ -41,19 +41,27 @@ func TestTreeWalk_ReleasesEveryElement(t *testing.T) {
 	client := native.New(log, nil)
 	adapter := accessibility.NewAdapter(log, nil, nil, client, false)
 
-	ctx, cancel := context.WithTimeout(context.Background(), integrationScanBudget)
-	defer cancel()
+	// Each walk gets its own context matching the per-call budget: a shared
+	// deadline would expire cumulatively across six healthy scans and fail a
+	// later walk that never hung.
+	walkOnce := func(what string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), integrationScanBudget)
+		defer cancel()
+
+		var err error
+
+		runWithinBudget(t, what, func() {
+			_, err = adapter.ClickableElements(ctx, ports.DefaultElementFilter())
+		})
+
+		return err
+	}
 
 	// One warmup walk: lazily-initialized singletons (system-wide element,
 	// cached application handles) may legitimately outlive the first walk.
-	// runWithinBudget is the hang guard — the AX client discards its context,
-	// so only a watchdog can catch a wedged native query.
-	var warmupErr error
-
-	runWithinBudget(t, "warmup ClickableElements walk", func() {
-		_, warmupErr = adapter.ClickableElements(ctx, ports.DefaultElementFilter())
-	})
-
+	// runWithinBudget (inside walkOnce) is the hang guard — the AX client
+	// discards its context, so only a watchdog can catch a wedged native query.
+	warmupErr := walkOnce("warmup ClickableElements walk")
 	if warmupErr != nil {
 		t.Skipf("warmup walk failed (no scannable frontmost app?): %v", warmupErr)
 	}
@@ -61,14 +69,9 @@ func TestTreeWalk_ReleasesEveryElement(t *testing.T) {
 	baseline := nativedarwin.LiveElementCount()
 
 	for walk := range leakWalkCount {
-		var walkErr error
-
-		runWithinBudget(t, "measured ClickableElements walk", func() {
-			// The adapter returns domain elements, not live AX wrappers; the
-			// walk owns and must have already released every wrapper it made.
-			_, walkErr = adapter.ClickableElements(ctx, ports.DefaultElementFilter())
-		})
-
+		// The adapter returns domain elements, not live AX wrappers; the walk
+		// owns and must have already released every wrapper it made.
+		walkErr := walkOnce("measured ClickableElements walk")
 		if walkErr != nil {
 			t.Fatalf("walk %d: ClickableElements() error = %v", walk, walkErr)
 		}

--- a/internal/adapter/accessibility/native/darwin/element.go
+++ b/internal/adapter/accessibility/native/darwin/element.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	"go.uber.org/zap"
@@ -35,6 +36,26 @@ import (
 // internal/adapter/platform/darwin/accessibility.h.
 type Element struct {
 	ref unsafe.Pointer
+}
+
+// liveElements counts Elements constructed but not yet released. It exists
+// for the leak-regression integration test: a balanced walk must return the
+// count to its baseline. The counter is not a lifecycle mechanism — Release
+// remains the contract.
+var liveElements atomic.Int64
+
+// newElement wraps a +1 retained AXUIElementRef. Every construction goes
+// through here so LiveElementCount stays truthful.
+func newElement(ref unsafe.Pointer) *Element {
+	liveElements.Add(1)
+
+	return &Element{ref: ref}
+}
+
+// LiveElementCount reports how many Elements are currently alive (constructed
+// and not yet released). Test support; see liveElements.
+func LiveElementCount() int64 {
+	return liveElements.Load()
 }
 
 var (
@@ -232,7 +253,7 @@ func SystemWideElement() *Element {
 		return nil
 	}
 
-	return &Element{ref: ref}
+	return newElement(ref)
 }
 
 // FocusedApplication returns the currently focused application element.
@@ -242,7 +263,7 @@ func FocusedApplication() *Element {
 		return nil
 	}
 
-	return &Element{ref: ref}
+	return newElement(ref)
 }
 
 // ApplicationByPID returns an application element identified by its process ID.
@@ -252,7 +273,7 @@ func ApplicationByPID(pid int) *Element {
 		return nil
 	}
 
-	return &Element{ref: ref}
+	return newElement(ref)
 }
 
 // ApplicationByBundleID returns an application element identified by its bundle identifier.
@@ -265,7 +286,7 @@ func ApplicationByBundleID(bundleID string) *Element {
 		return nil
 	}
 
-	return &Element{ref: ref}
+	return newElement(ref)
 }
 
 // ElementAtPosition returns the UI element at the specified screen coordinates.
@@ -276,7 +297,7 @@ func ElementAtPosition(x, y int) *Element {
 		return nil
 	}
 
-	return &Element{ref: ref}
+	return newElement(ref)
 }
 
 // Info retrieves metadata and positioning information for the element.
@@ -374,7 +395,7 @@ func (e *Element) Children(role string) ([]*Element, error) {
 	childSlice := (*[1 << 30]unsafe.Pointer)(rawChildren)[:countInt:countInt]
 	children := make([]*Element, countInt)
 	for i := range children {
-		children[i] = &Element{ref: childSlice[i]}
+		children[i] = newElement(childSlice[i])
 	}
 
 	return children, nil
@@ -421,6 +442,7 @@ func (e *Element) Release() {
 	if e.ref != nil {
 		C.NeruReleaseElement(e.ref)
 		e.ref = nil
+		liveElements.Add(-1)
 	}
 }
 
@@ -481,7 +503,7 @@ func (e *Element) Clone() (*Element, error) {
 
 	C.NeruRetainElement(e.ref)
 
-	return &Element{ref: e.ref}, nil
+	return newElement(e.ref), nil
 }
 
 // AllWindows returns all windows of the focused application.
@@ -502,7 +524,7 @@ func AllWindows() ([]*Element, error) {
 	result := make([]*Element, countInt)
 
 	for index := range result {
-		result[index] = &Element{ref: windowSlice[index]}
+		result[index] = newElement(windowSlice[index])
 	}
 
 	return result, nil
@@ -527,7 +549,7 @@ func FrontmostAndPopoverWindows() ([]*Element, error) {
 	result := make([]*Element, countInt)
 
 	for index := range result {
-		result[index] = &Element{ref: windowSlice[index]}
+		result[index] = newElement(windowSlice[index])
 	}
 
 	return result, nil
@@ -540,7 +562,7 @@ func FrontmostWindow() *Element {
 		return nil
 	}
 
-	return &Element{ref: ref}
+	return newElement(ref)
 }
 
 // MenuBar returns the menu bar element for the given application element.
@@ -553,7 +575,7 @@ func (e *Element) MenuBar() *Element {
 		return nil
 	}
 
-	return &Element{ref: ref}
+	return newElement(ref)
 }
 
 // ApplicationName returns the application name.


### PR DESCRIPTION
## Description

This PR gives the accessibility layer's most persistent bug class a permanent tripwire. A new regression test runs several full clickable-element scans against a real accessibility tree and requires the number of live element wrappers to return to its baseline after every walk, the exact failure shape of both prior leaks, caught in seconds instead of in production memory growth.

To make that measurable, element construction is funneled through a single instrumented path that maintains an atomic live-wrapper count, decremented on release. The counter is explicitly test support, not a lifecycle mechanism — the release contract stated in the native header remains the rule, and the test's failure message points straight at it.

## Related Issues

Regression guard for the leak class fixed in #1150 and #1152.

## Target Platform

- [x] macOS

## Type of Change

- [x] `test` — Adding or updating tests

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — the test is `integration && darwin`; the instrumentation lives in the darwin-tagged wrapper
- [x] No darwin imports from untagged (shared) code — [The One Rule](docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changed

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build) — fmt, lint, `vet -tags=integration`, build, unit + architecture tests and `check-cross` run locally, plus a real run of the new test against a live tree (green); `-race`/short-integration passes run in CI
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, the ownership rule was already documented in `accessibility.h`; the test now enforces it
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Instrumentation shape: `newElement` is now the only construction path for the darwin `Element` wrapper (the previous eleven scattered struct literals all route through it), incrementing an atomic counter that `Release` decrements; `Clone` counts as a construction because it retains the underlying ref natively and hands the caller an independently-owned wrapper. `LiveElementCount` is the exported read hook. The test warms up once before taking its baseline so lazily-initialized singletons (system-wide element, cached app handles) don't read as leaks, runs five walks (the leak class leaks per walk, so five cleanly separates signal from noise), and skips honestly when Accessibility permission is absent or in short mode — following the CI test contract from #1174.
