### PR TITLE
test(mocks): record the hand-written decision and guard assertions

### DIFF
--- a/internal/architecture/platform_slots_test.go
+++ b/internal/architecture/platform_slots_test.go
@@ -44,7 +44,7 @@ func wholePlatformDirs(t *testing.T) map[string]string {
 	candidates := map[string]string{}
 
 	for _, file := range goFiles(t) {
-		if file.base == "doc.go" {
+		if file.base == docGoFile {
 			continue
 		}
 
@@ -248,7 +248,7 @@ func TestPlatformPackagesTagEveryFile(t *testing.T) {
 
 		// doc.go is allowed to stay untagged so `go vet ./...` can resolve the
 		// package on other hosts; it holds only the package comment.
-		if file.base == "doc.go" {
+		if file.base == docGoFile {
 			continue
 		}
 

--- a/internal/architecture/ports_test.go
+++ b/internal/architecture/ports_test.go
@@ -6,9 +6,13 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
+
+// docGoFile is the package-comment file name skipped by file-scanning checks.
+const docGoFile = "doc.go"
 
 var portsWithoutOwnMock = map[string]string{}
 
@@ -145,4 +149,50 @@ func typeDeclsIn(t *testing.T, dir string) []*ast.TypeSpec {
 	}
 
 	return specs
+}
+
+// TestEveryMockAssertsInterfaceSatisfaction requires each mock file to carry
+// a compile-time assertion tying the mock to its port
+// (var _ ports.X = (*MockX)(nil), plain or inside a var block). Without one,
+// a mock can drop or fumble a method and still compile on its own — the
+// break only surfaces at some consumer, far from the cause. The assertion
+// moves that failure into the mocks package itself.
+func TestEveryMockAssertsInterfaceSatisfaction(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := findRepoRoot(t)
+	mocksDir := filepath.Join(repoRoot, "internal", "ports", "mocks")
+
+	entries, err := os.ReadDir(mocksDir)
+	if err != nil {
+		t.Fatalf("reading mocks dir: %v", err)
+	}
+
+	assertion := regexp.MustCompile(`(?m)^(?:var )?\s*_ ports\.\w+\s*=`)
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") ||
+			name == docGoFile {
+			continue
+		}
+
+		content, readErr := os.ReadFile(filepath.Join(mocksDir, name))
+		if readErr != nil {
+			t.Fatalf("reading %s: %v", name, readErr)
+		}
+
+		if !strings.Contains(string(content), "Mock") {
+			continue
+		}
+
+		if !assertion.Match(content) {
+			t.Errorf(
+				"internal/ports/mocks/%s declares a mock but no compile-time "+
+					"interface assertion; add `var _ ports.<Port> = (*Mock<Port>)(nil)` "+
+					"so drift from the port fails in this package, not at a consumer",
+				name,
+			)
+		}
+	}
 }

--- a/internal/architecture/ports_test.go
+++ b/internal/architecture/ports_test.go
@@ -151,12 +151,14 @@ func typeDeclsIn(t *testing.T, dir string) []*ast.TypeSpec {
 	return specs
 }
 
-// TestEveryMockAssertsInterfaceSatisfaction requires each mock file to carry
-// a compile-time assertion tying the mock to its port
+// TestEveryMockAssertsInterfaceSatisfaction requires every mock type in the
+// mocks package to carry a compile-time assertion tying it to its interface
 // (var _ ports.X = (*MockX)(nil), plain or inside a var block). Without one,
 // a mock can drop or fumble a method and still compile on its own — the
 // break only surfaces at some consumer, far from the cause. The assertion
-// moves that failure into the mocks package itself.
+// moves that failure into the mocks package itself. The check is per mock
+// type, not per file, so a second mock added to an existing file cannot
+// hide behind the first one's assertion.
 func TestEveryMockAssertsInterfaceSatisfaction(t *testing.T) {
 	t.Parallel()
 
@@ -168,7 +170,11 @@ func TestEveryMockAssertsInterfaceSatisfaction(t *testing.T) {
 		t.Fatalf("reading mocks dir: %v", err)
 	}
 
-	assertion := regexp.MustCompile(`(?m)^(?:var )?\s*_ ports\.\w+\s*=`)
+	mockTypePattern := regexp.MustCompile(`(?m)^type (Mock\w+) struct`)
+	assertionPattern := regexp.MustCompile(`\(\*(Mock\w+)\)\(nil\)`)
+
+	declared := map[string]string{} // mock type -> file
+	asserted := map[string]bool{}
 
 	for _, entry := range entries {
 		name := entry.Name()
@@ -182,16 +188,26 @@ func TestEveryMockAssertsInterfaceSatisfaction(t *testing.T) {
 			t.Fatalf("reading %s: %v", name, readErr)
 		}
 
-		if !strings.Contains(string(content), "Mock") {
-			continue
+		for _, match := range mockTypePattern.FindAllStringSubmatch(string(content), -1) {
+			declared[match[1]] = name
 		}
 
-		if !assertion.Match(content) {
+		for _, match := range assertionPattern.FindAllStringSubmatch(string(content), -1) {
+			asserted[match[1]] = true
+		}
+	}
+
+	if len(declared) == 0 {
+		t.Fatal("found no mock types under internal/ports/mocks; the scan is broken")
+	}
+
+	for mockType, file := range declared {
+		if !asserted[mockType] {
 			t.Errorf(
-				"internal/ports/mocks/%s declares a mock but no compile-time "+
-					"interface assertion; add `var _ ports.<Port> = (*Mock<Port>)(nil)` "+
-					"so drift from the port fails in this package, not at a consumer",
-				name,
+				"internal/ports/mocks/%s declares %s but no compile-time interface "+
+					"assertion for it; add `var _ ports.<Interface> = (*%s)(nil)` so "+
+					"drift from the interface fails in this package, not at a consumer",
+				file, mockType, mockType,
 			)
 		}
 	}

--- a/internal/ports/mocks/doc.go
+++ b/internal/ports/mocks/doc.go
@@ -1,5 +1,19 @@
 // Package mocks provides mock implementations of port interfaces for testing.
 //
-// These mocks use function fields to allow tests to customize behavior.
-// Each mock provides sensible defaults when function fields are nil.
+// These mocks use function fields to allow tests to customize behavior: set
+// only the funcs a test cares about, and each mock supplies a sensible,
+// stateful default when a field is nil. Every mock carries a compile-time
+// interface-satisfaction assertion (var _ ports.X = (*MockX)(nil)), so a mock
+// cannot silently drift from its port, and the architecture tests require a
+// mock for every port with no exemptions.
+//
+// The mocks are hand-written by decision, not by omission. Generators
+// (mockgen, moq, counterfeiter) were considered and rejected: the func-field
+// pattern keeps call sites free of expectation DSLs, the curated defaults
+// (in-memory state, realistic zero values) are behavior a generator cannot
+// author, and no extra toolchain step stands between a contributor and a
+// green build. The cost — adding a port method means adding a func field and
+// a default by hand — is bounded by the guardrails: the compile-time
+// assertion and the architecture tests fail loudly until parity is restored.
+// Revisit only if the port surface grows far beyond its current size.
 package mocks


### PR DESCRIPTION
## Description

This PR improves the mocking experience. Mock generation was weighed against the hand-written function-field pattern and rejected: the curated stateful defaults are behavior a generator can't author, call sites stay free of expectation DSLs, and no extra toolchain step sits between a contributor and a green build. That decision, its reasoning, and the condition under which to revisit it are now recorded in the package documentation, so the next contributor who wonders "why no mockgen?" finds the answer where they'd ask it.

The one structural improvement worth making: the convention that every mock carries a compile-time assertion tying it to its port is now enforced by a new architecture test. All eleven mocks already comply — the test exists so the twelfth can't forget, making under-implementation fail inside the mocks package instead of at some distant consumer (which is exactly how the historical hand-rolled hotkey fakes drifted).

## Related Issues

N/A

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)

## Type of Change

- [x] `test` — Adding or updating tests

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build) — fmt, lint, architecture tests and `check-cross` run locally; the full profile runs in CI
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — the decision record lives in the mocks package comment, its one home
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The new guardrail scans `internal/ports/mocks/*.go` for the `var _ ports.<Port> = (*Mock<Port>)(nil)` assertion (plain or inside a `var` block) and fails with a message telling the author exactly what line to add. During the audit a grep artifact briefly suggested one mock lacked its assertion; verification showed all eleven comply (one uses the grouped-block form) — the test now makes that verification permanent. A small shared constant was extracted in the architecture tests to satisfy the string-duplication linter.
