### PR TITLE
refactor(overlay): unify linux x11/wayland overlays behind surface primitives

### DIFF
--- a/internal/adapter/overlay/linux/overlay_shared_cgo.go
+++ b/internal/adapter/overlay/linux/overlay_shared_cgo.go
@@ -1,0 +1,1045 @@
+//go:build linux && cgo
+
+package linux
+
+import (
+	"image"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
+	gridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
+	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
+	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
+	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
+	"github.com/y3owk1n/neru/internal/domain/recursivegrid"
+	"github.com/y3owk1n/neru/internal/ports"
+)
+
+// overlaySurface is the primitive contract a Linux overlay backend provides
+// to the shared drawing implementation. Everything above these primitives —
+// layout, animation, offsets, label logic — is identical between X11 and
+// Wayland and lives once on sharedOverlay; everything genuinely different
+// (buffer management, HiDPI scale, window lifecycle) lives behind this
+// interface. The shared code never touches cgo: primitives take Go types and
+// do their own C marshaling (including CString lifetimes).
+type overlaySurface interface {
+	// surfaceScale is the HiDPI factor applied to fonts, stroke widths and
+	// text-fitted geometry. X11 probes Xft.dpi; Wayland reports 1.
+	surfaceScale() float64
+
+	// ensureBuffers prepares the backend's drawing target without selecting
+	// it (Wayland's setup_buffers; a no-op on X11). Some paths call it
+	// without a subsequent frame selection — preserve that.
+	ensureBuffers()
+
+	// beginFrame makes a drawable target current, reporting false when none
+	// is available and the frame must be skipped (Wayland's buffer
+	// acquisition with one sync-retry; X11 always succeeds).
+	beginFrame() bool
+
+	// surfaceClear clears the current target without any buffer selection.
+	surfaceClear()
+
+	// clearFrame clears inside an animation frame (X11's double-buffered
+	// clear; plain clear on Wayland, which selected a buffer in beginFrame).
+	clearFrame()
+
+	surfaceClearRect(rect image.Rectangle)
+	surfaceFlush()
+	surfaceHide()
+
+	// showIndicator maps the dedicated click-indicator surface before its
+	// animation starts. Wayland must do this under the render lock and keep
+	// the surface keyboard-passive; X11 just maps the window.
+	showIndicator()
+
+	// finishIndicator unmaps the indicator when its animation completes; the
+	// caller holds the render lock. X11 also clears so no stale pixmap shows
+	// on the next map; Wayland must not clear an unselected buffer.
+	finishIndicator()
+
+	// syncBeforeAnimation flushes pending display work before a grid
+	// animation begins (Wayland sync; no-op on X11).
+	syncBeforeAnimation()
+
+	rectPrim(bounds image.Rectangle, fill, border uint32, lineWidth float64)
+	roundedRectPrim(bounds image.Rectangle, radius float64, fill, border uint32, lineWidth float64)
+	hintBadgePrim(
+		badgeRect image.Rectangle, radius float64, edge int, arrow hintArrowTriangle,
+		fill, border uint32, lineWidth float64,
+	)
+	textPrim(text, fontFamily string, centerX, centerY, fontSize float64, color uint32)
+}
+
+// sharedOverlay is the backend-independent half of a Linux overlay: all
+// drawing, layout and animation state plus the logic that drives the
+// overlaySurface primitives. X11 and Wayland embed it; their exported
+// methods are thin nil-guarded delegates (a promoted method called through a
+// nil backend pointer would panic before any receiver guard could run, and
+// the manager relies on nil-safe calls).
+type sharedOverlay struct {
+	srf overlaySurface
+
+	currentPrefix  string
+	hideUnmatched  bool
+	currentSubgrid *domainGrid.Cell
+	sublayerKeys   string
+	cachedGrid     *domainGrid.Grid
+	cachedStyle    gridcomponent.Style
+
+	// originOffset is the active screen's top-left origin in global device
+	// pixels. Grid, recursive-grid and hint content arrives in screen-local
+	// coordinates (origin 0,0); adding this offset places it on the correct
+	// monitor of the desktop-spanning overlay window. Absolute-coordinate draws
+	// (badges, monitor_select, the click indicator) do not apply it.
+	originOffset image.Point
+
+	// renderMu serializes rendering with the manager (and, on Wayland, with
+	// the keyboard poller's wl_display access). The manager owns the mutex
+	// object and holds it across synchronous draw calls; only the animation
+	// goroutines lock it here.
+	renderMu *sync.Mutex
+
+	cancelMu         sync.Mutex
+	animStop         chan struct{}
+	animDone         chan struct{}
+	hasLast          bool
+	lastBounds       image.Rectangle
+	lastCols         int
+	lastRows         int
+	lastDepth        int
+	lastRects        []image.Rectangle
+	currentAnimRects []image.Rectangle
+}
+
+func (o *sharedOverlay) setRenderMuShared(mu *sync.Mutex) {
+	o.renderMu = mu
+}
+
+func (o *sharedOverlay) hide() {
+	o.cancelAnimation()
+	o.srf.surfaceHide()
+}
+
+func (o *sharedOverlay) clear() {
+	o.cancelAnimation()
+	o.hasLast = false
+	o.srf.surfaceClear()
+}
+
+func (o *sharedOverlay) clearRect(rect image.Rectangle) {
+	o.srf.surfaceClearRect(rect)
+}
+
+func (o *sharedOverlay) updateGridMatches(prefix string) {
+	o.currentPrefix = strings.ToUpper(prefix)
+	o.redrawGrid()
+}
+
+func (o *sharedOverlay) showSubgrid(cell *domainGrid.Cell) {
+	o.currentSubgrid = cell
+	o.srf.ensureBuffers()
+	o.clear()
+
+	if !o.srf.beginFrame() {
+		return
+	}
+
+	o.drawSubgrid(cell.Bounds(), o.cachedStyle)
+	o.srf.surfaceFlush()
+}
+
+func (o *sharedOverlay) drawGrid(grid *domainGrid.Grid, input string, style gridcomponent.Style) {
+	o.cachedGrid = grid
+	o.cachedStyle = style
+	o.currentPrefix = strings.ToUpper(input)
+	o.currentSubgrid = nil
+
+	o.redrawGrid()
+}
+
+//nolint:mnd
+func (o *sharedOverlay) drawRecursiveGridWithSubKeyPreview(
+	bounds image.Rectangle,
+	depth int,
+	keys string,
+	gridCols int,
+	gridRows int,
+	nextKeys string,
+	nextGridCols int,
+	nextGridRows int,
+	style recursivegridcomponent.Style,
+	virtualPointer recursivegridcomponent.VirtualPointerState,
+	animEnabled bool,
+	animDurationMS int,
+) {
+	// Translate the screen-local bounds and virtual-pointer position onto the
+	// active monitor. Everything downstream (cell rects, animation from/to
+	// rects, the pointer) derives from these, so the whole frame lands on the
+	// right monitor.
+	bounds = o.offset(bounds)
+	virtualPointer.Position = virtualPointer.Position.Add(o.originOffset)
+
+	o.srf.ensureBuffers()
+
+	shouldAnimate := animEnabled && o.hasLast && depth != o.lastDepth &&
+		!o.lastBounds.Empty()
+
+	cellRects := recursivegrid.ComputeGridCells(bounds, gridCols, gridRows)
+
+	if shouldAnimate {
+		duration := time.Duration(animDurationMS) * time.Millisecond
+		if duration <= 0 {
+			duration = 50 * time.Millisecond
+		}
+
+		fromRects := o.buildFromRects(cellRects, bounds)
+		keyRunes := []rune(strings.ToUpper(keys))
+		nextKeyRunes := []rune(strings.ToUpper(nextKeys))
+
+		animStop := make(chan struct{})
+		animDone := make(chan struct{})
+		o.animStop = animStop
+		o.animDone = animDone
+
+		o.startGridAnimation(
+			fromRects, cellRects,
+			keyRunes, nextKeyRunes,
+			nextGridCols, nextGridRows,
+			style, virtualPointer,
+			duration, animStop, animDone,
+		)
+	} else {
+		o.clearAndDraw(
+			cellRects, keys,
+			nextKeys, nextGridCols, nextGridRows,
+			style, virtualPointer,
+		)
+	}
+
+	o.hasLast = true
+	o.lastBounds = bounds
+	o.lastCols = gridCols
+	o.lastRows = gridRows
+	o.lastDepth = depth
+	o.lastRects = make([]image.Rectangle, len(cellRects))
+	copy(o.lastRects, cellRects)
+}
+
+func (o *sharedOverlay) drawBadge(
+	posX, posY int,
+	text string,
+	colors overlayColors,
+	style overlayBadgeStyle,
+) {
+	o.srf.ensureBuffers()
+
+	fontSize := style.fontSize
+	if fontSize <= 0 {
+		fontSize = 14
+	}
+	// Size the badge from the scaled font so it fits the text drawTextCentered
+	// renders. The manager sizes its clear rect with the same factor (Scale()).
+	scaledStyle := style
+	scaledStyle.fontSize = fontSize * o.srf.surfaceScale()
+	rect := badgeBounds(posX, posY, text, scaledStyle)
+
+	o.drawRect(rect, colors.background, colors.border, max(style.borderWidth, 1))
+	o.drawTextCentered(text, rect, style.fontFamily, fontSize, colors.text)
+}
+
+// drawMonitorSelect renders one centered, labeled panel per monitor for the
+// interactive monitor picker. Panels reuse the existing rounded-rect + text
+// primitives (no dedicated C), and are sized from the scaled font (see
+// monitorSelectPanelLayout) so they stay legible on HiDPI. The label is drawn
+// with the matched/selected color when it has a matched prefix or is selected.
+func (o *sharedOverlay) drawMonitorSelect(
+	targets []manager.MonitorSelectTarget,
+	style manager.MonitorSelectStyle,
+) {
+	o.srf.ensureBuffers()
+	o.cancelAnimation()
+	o.hasLast = false
+
+	if !o.srf.beginFrame() {
+		return
+	}
+
+	o.srf.surfaceClear()
+
+	spec := newMonitorSelectDrawSpec(style)
+	for _, target := range targets {
+		if target.Bounds.Empty() {
+			continue
+		}
+
+		if spec.hasBackdrop {
+			o.drawRect(target.Bounds, spec.backdrop, 0, 0)
+		}
+
+		panel, labelRect, subtitleRect, radius := monitorSelectPanelLayout(
+			target.Bounds, target.Label, target.Subtitle, style, o.srf.surfaceScale(),
+		)
+		o.drawRoundedRect(panel, radius, spec.background, spec.border, spec.borderWidth)
+
+		o.drawTextCentered(target.Label, labelRect, style.FontFamily, spec.labelFont, spec.text)
+
+		if target.Subtitle != "" {
+			o.drawTextCentered(
+				target.Subtitle, subtitleRect,
+				monitorSelectSubtitleFamily(style), spec.subtitleFont, spec.subtitleText,
+			)
+		}
+	}
+
+	o.srf.surfaceFlush()
+}
+
+func (o *sharedOverlay) drawHints(
+	hintsSlice []*hintscomponent.Hint,
+	style hintscomponent.StyleMode,
+) {
+	o.srf.ensureBuffers()
+	o.cancelAnimation()
+	o.hasLast = false
+
+	if !o.srf.beginFrame() {
+		return
+	}
+
+	o.srf.surfaceClear()
+
+	fontSize := float64(max(style.FontSize(), 1))
+	for _, hint := range hintsSlice {
+		// hint.Position() is the element center in screen-local coordinates;
+		// translate it onto the active monitor.
+		pos := hint.Position().Add(o.originOffset)
+		if style.BoundaryHighlightEnabled() {
+			boundary := image.Rect(
+				pos.X-hint.Size().X/2,
+				pos.Y-hint.Size().Y/2,
+				pos.X+hint.Size().X/2,
+				pos.Y+hint.Size().Y/2,
+			)
+			o.drawRect(
+				boundary,
+				badge.ParseHexARGB(style.BoundaryBackgroundColor()),
+				badge.ParseHexARGB(style.BoundaryBorderColor()),
+				float64(max(style.BoundaryBorderWidth(), 0)),
+			)
+		}
+
+		textColor := style.TextColor()
+		if hint.MatchedPrefix() != "" {
+			textColor = style.MatchedTextColor()
+		}
+
+		label := hint.Label()
+		// Size the badge from the scaled font so it fits the text drawTextCentered
+		// renders (which applies the same surface scale). Position stays in device
+		// pixels; the badge grows around the target.
+		sfont := fontSize * o.srf.surfaceScale()
+		paddingX := badge.AutoPadding(sfont, style.PaddingX(), true)
+		paddingY := badge.AutoPadding(sfont, style.PaddingY(), false)
+		badgeWidth := badge.EstimateTextWidth(label, sfont) + paddingX*paddingMultiplier
+		badgeHeight := badge.EstimateTextHeight(sfont) + paddingY*paddingMultiplier
+
+		radius := style.BorderRadius()
+		if radius < 0 {
+			radius = min(badgeHeight/centeredRectDivisor, hintAutoRadiusMax)
+		}
+		// Cap the radius so a top/bottom badge keeps a flat edge for the tail.
+		radius = hintBadgeRadius(radius, badgeWidth, style.Placement())
+
+		// pos is the element center (set in modes/hints.go). The badge is
+		// centered horizontally on it and placed above / on / below the center
+		// to match macOS; top/bottom placement also draws a connector arrow
+		// pointing back at the target.
+		badgeRect, arrow, hasArrow := hintBadgePlacement(
+			pos, badgeWidth, badgeHeight, radius, style.Placement(),
+		)
+
+		fill := badge.ParseHexARGB(style.BackgroundColor())
+		border := badge.ParseHexARGB(style.BorderColor())
+		borderWidth := float64(max(style.BorderWidth(), 0))
+
+		// Badge and connector tail are drawn as one filled+stroked outline so
+		// translucent colors don't double-composite at the junction.
+		o.drawHintBadge(
+			badgeRect, float64(radius), hintTailEdge(badgeRect, arrow, hasArrow), arrow,
+			fill, border, borderWidth,
+		)
+		o.drawTextCentered(
+			label, badgeRect,
+			style.FontFamily(),
+			fontSize,
+			badge.ParseHexARGB(textColor),
+		)
+	}
+
+	o.srf.surfaceFlush()
+}
+
+// drawMouseActionIndicator animates a transient click indicator centered on
+// point. It runs on this overlay's dedicated indicator window, independent of
+// the mode overlay's show/hide lifecycle, so it survives the mode exit that
+// immediately follows a click.
+func (o *sharedOverlay) drawMouseActionIndicator(
+	point image.Point,
+	style ports.MouseActionIndicatorStyle,
+) {
+	// Cancel any in-flight indicator animation before starting a new one.
+	// (Must run without the render lock held: the animation goroutine may be
+	// blocked acquiring it, and cancelAnimation waits for the goroutine.)
+	o.cancelAnimation()
+
+	duration := time.Duration(style.DurationMS) * time.Millisecond
+	if duration <= 0 {
+		duration = defaultMouseActionDuration
+	}
+
+	o.srf.showIndicator()
+
+	animStop := make(chan struct{})
+	animDone := make(chan struct{})
+	o.animStop = animStop
+	o.animDone = animDone
+
+	o.startMouseActionAnimation(point, style, duration, animStop, animDone)
+}
+
+func (o *sharedOverlay) startMouseActionAnimation(
+	point image.Point,
+	style ports.MouseActionIndicatorStyle,
+	duration time.Duration,
+	stopCh chan struct{},
+	doneCh chan struct{},
+) {
+	startTime := time.Now()
+
+	fillBase := badge.ParseHexARGB(style.BackgroundColor)
+	borderBase := badge.ParseHexARGB(style.BorderColor)
+	lineWidth := float64(max(style.BorderWidth, 0))
+	baseSize := float64(max(style.Size, 1)) * o.srf.surfaceScale()
+	isSquare := style.Shape == "square"
+
+	renderFrame := func(rawProgress float64) {
+		if !o.srf.beginFrame() {
+			return
+		}
+
+		eased := applyEasing(style.Easing, rawProgress)
+		scale := max(lerp(style.StartScale, style.EndScale, eased), 0)
+		opacity := lerp(style.StartOpacity, style.EndOpacity, eased)
+		diameter := baseSize * scale
+		rect := mouseActionIndicatorRect(point, diameter)
+		fill := applyOpacity(fillBase, opacity)
+		border := applyOpacity(borderBase, opacity)
+
+		o.srf.clearFrame()
+
+		if isSquare {
+			o.drawRect(rect, fill, border, lineWidth)
+		} else {
+			o.drawRoundedRect(rect, diameter/centeredRectDivisor, fill, border, lineWidth)
+		}
+
+		o.srf.surfaceFlush()
+	}
+
+	go func() {
+		defer close(doneCh)
+		defer func() {
+			o.cancelMu.Lock()
+			if o.animStop == stopCh {
+				o.animStop = nil
+			}
+
+			if o.animDone == doneCh {
+				o.animDone = nil
+			}
+			o.cancelMu.Unlock()
+		}()
+
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+
+			elapsed := time.Since(startTime)
+			rawProgress := min(float64(elapsed)/float64(duration), 1.0)
+
+			renderStart := time.Now()
+
+			renderMu := o.renderMu
+			if renderMu != nil {
+				renderMu.Lock()
+				// Parent may have closed stopCh while we were waiting for the
+				// lock. Check here to avoid deadlock: parent holds the lock and
+				// waits for animDone; we hold nothing yet the parent needs.
+				select {
+				case <-stopCh:
+					renderMu.Unlock()
+
+					return
+				default:
+				}
+			}
+
+			renderFrame(rawProgress)
+
+			if renderMu != nil {
+				renderMu.Unlock()
+			}
+
+			if rawProgress >= 1.0 {
+				// Finished: unmap the dedicated window so the fully faded
+				// indicator does not linger on screen.
+				if renderMu != nil {
+					renderMu.Lock()
+				}
+
+				o.srf.finishIndicator()
+
+				if renderMu != nil {
+					renderMu.Unlock()
+				}
+
+				return
+			}
+
+			sleepFor := animationFrameDur - time.Since(renderStart)
+			if sleepFor > 0 {
+				select {
+				case <-stopCh:
+					return
+				case <-time.After(sleepFor):
+				}
+			}
+		}
+	}()
+}
+
+func (o *sharedOverlay) cancelAnimation() {
+	o.cancelMu.Lock()
+
+	var doneCh chan struct{}
+
+	if o.animStop != nil {
+		close(o.animStop)
+		o.animStop = nil
+	}
+
+	if o.animDone != nil {
+		doneCh = o.animDone
+		o.animDone = nil
+	}
+	o.cancelMu.Unlock()
+
+	if doneCh != nil {
+		<-doneCh
+	}
+}
+
+//nolint:mnd,varnamelen
+func (o *sharedOverlay) buildFromRects(
+	toRects []image.Rectangle,
+	bounds image.Rectangle,
+) []image.Rectangle {
+	if len(o.currentAnimRects) == len(toRects) {
+		from := make([]image.Rectangle, len(o.currentAnimRects))
+		copy(from, o.currentAnimRects)
+
+		return from
+	}
+
+	if len(o.lastRects) == len(toRects) {
+		from := make([]image.Rectangle, len(o.lastRects))
+		copy(from, o.lastRects)
+
+		return from
+	}
+
+	if o.lastBounds.Empty() {
+		from := make([]image.Rectangle, len(toRects))
+		for idx, rect := range toRects {
+			cx := rect.Min.X + rect.Dx()/2
+			cy := rect.Min.Y + rect.Dy()/2
+			from[idx] = image.Rect(cx, cy, cx, cy)
+		}
+
+		return from
+	}
+
+	fromBounds := o.lastBounds
+	fw := float64(fromBounds.Dx())
+	fh := float64(fromBounds.Dy())
+	dw := float64(bounds.Dx())
+	dh := float64(bounds.Dy())
+
+	from := make([]image.Rectangle, len(toRects))
+	for idx, rect := range toRects {
+		nx := (float64(rect.Min.X+rect.Dx()/2) - float64(bounds.Min.X)) / dw
+		ny := (float64(rect.Min.Y+rect.Dy()/2) - float64(bounds.Min.Y)) / dh
+		cx := int(float64(fromBounds.Min.X) + nx*fw)
+		cy := int(float64(fromBounds.Min.Y) + ny*fh)
+		rw := rect.Dx()
+		rh := rect.Dy()
+		from[idx] = image.Rect(
+			cx-rw/2, cy-rh/2,
+			cx+rw/2, cy+rh/2,
+		)
+	}
+
+	return from
+}
+
+func (o *sharedOverlay) startGridAnimation(
+	fromRects, toRects []image.Rectangle,
+	keyRunes, nextKeyRunes []rune,
+	nextGridCols, nextGridRows int,
+	style recursivegridcomponent.Style,
+	virtualPointer recursivegridcomponent.VirtualPointerState,
+	duration time.Duration,
+	stopCh chan struct{},
+	doneCh chan struct{},
+) {
+	o.srf.syncBeforeAnimation()
+
+	startTime := time.Now()
+
+	renderFrame := func(rawProgress float64) {
+		if rawProgress >= 1.0 {
+			rawProgress = 1.0
+		}
+
+		progress := easeInOut(rawProgress)
+
+		interpCells := make([]image.Rectangle, len(toRects))
+		for i := range toRects {
+			src := fromRects[i]
+			dst := toRects[i]
+			interpCells[i] = image.Rect(
+				int(lerp(float64(src.Min.X), float64(dst.Min.X), progress)),
+				int(lerp(float64(src.Min.Y), float64(dst.Min.Y), progress)),
+				int(lerp(float64(src.Max.X), float64(dst.Max.X), progress)),
+				int(lerp(float64(src.Max.Y), float64(dst.Max.Y), progress)),
+			)
+		}
+
+		if !o.srf.beginFrame() {
+			return
+		}
+
+		o.currentAnimRects = interpCells
+
+		o.srf.clearFrame()
+		o.drawFrame(
+			interpCells,
+			keyRunes,
+			nextKeyRunes,
+			nextGridCols,
+			nextGridRows,
+			style,
+			virtualPointer,
+		)
+	}
+
+	go func() {
+		defer close(doneCh)
+		defer func() {
+			o.cancelMu.Lock()
+			if o.animStop == stopCh {
+				o.animStop = nil
+			}
+
+			if o.animDone == doneCh {
+				o.animDone = nil
+			}
+			o.cancelMu.Unlock()
+		}()
+
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+
+			elapsed := time.Since(startTime)
+
+			rawProgress := float64(elapsed) / float64(duration)
+			if rawProgress >= 1.0 {
+				rawProgress = 1.0
+			}
+
+			renderStart := time.Now()
+
+			renderMu := o.renderMu
+			if renderMu != nil {
+				renderMu.Lock()
+				// Parent may have closed stopCh while we were waiting
+				// for the lock. Check here to avoid deadlock:
+				//   parent holds the render lock, waits for animDone
+				//   we   hold the render lock, parent waits for it
+				select {
+				case <-stopCh:
+					renderMu.Unlock()
+
+					return
+				default:
+				}
+			}
+
+			renderFrame(rawProgress)
+
+			if renderMu != nil {
+				renderMu.Unlock()
+			}
+
+			if rawProgress >= 1.0 {
+				return
+			}
+
+			renderDur := time.Since(renderStart)
+
+			sleepFor := animationFrameDur - renderDur
+			if sleepFor > 0 {
+				select {
+				case <-stopCh:
+					return
+				case <-time.After(sleepFor):
+				}
+			}
+		}
+	}()
+}
+
+func (o *sharedOverlay) clearAndDraw(
+	cellRects []image.Rectangle,
+	keys string,
+	nextKeys string, nextGridCols, nextGridRows int,
+	style recursivegridcomponent.Style,
+	virtualPointer recursivegridcomponent.VirtualPointerState,
+) {
+	o.currentAnimRects = nil
+
+	keyRunes := []rune(strings.ToUpper(keys))
+	nextKeyRunes := []rune(strings.ToUpper(nextKeys))
+
+	if !o.srf.beginFrame() {
+		return
+	}
+
+	o.srf.surfaceClear()
+	o.drawFrame(
+		cellRects,
+		keyRunes,
+		nextKeyRunes,
+		nextGridCols,
+		nextGridRows,
+		style,
+		virtualPointer,
+	)
+}
+
+func (o *sharedOverlay) drawFrame(
+	cellRects []image.Rectangle,
+	keyRunes, nextKeyRunes []rune,
+	nextGridCols, nextGridRows int,
+	style recursivegridcomponent.Style,
+	virtualPointer recursivegridcomponent.VirtualPointerState,
+) {
+	drawSubPreview := style.SubKeyPreview() && len(nextKeyRunes) > 0 &&
+		nextGridCols > 0 && nextGridRows > 0
+
+	for idx, cell := range cellRects {
+		if cell.Empty() {
+			continue
+		}
+
+		fill := style.HighlightColorARGB()
+		if fill == 0 {
+			fill = subgridCellBackground
+		}
+
+		o.drawRect(cell, fill, style.LineColorARGB(), style.LineWidthF())
+
+		if idx < len(keyRunes) {
+			label := style.LabelChar()
+			if label == "" {
+				label = string(keyRunes[idx])
+			}
+
+			if shouldShowLabel(cell, style) {
+				if style.LabelBackground() {
+					o.drawLabelBackground(label, cell, style)
+				}
+
+				o.drawTextCentered(
+					label, cell, style.FontFamily(),
+					style.LabelFontSize(), style.TextColorARGB(),
+				)
+			}
+
+			if drawSubPreview &&
+				shouldShowSubKeyPreview(cell, style, nextGridCols, nextGridRows) {
+				o.drawSubKeyMiniGrid(cell, nextKeyRunes,
+					nextGridCols, nextGridRows, style)
+			}
+		}
+	}
+
+	if virtualPointer.Visible {
+		o.drawVirtualPointer(virtualPointer)
+	}
+
+	o.srf.surfaceFlush()
+}
+
+//nolint:mnd,varnamelen
+func (o *sharedOverlay) drawVirtualPointer(vp recursivegridcomponent.VirtualPointerState) {
+	vpChar := vp.Char
+	if vpChar == "" {
+		vpChar = "\u25CF"
+	}
+
+	fontName := ports.ResolveFont(vp.FontName, false)
+	fontSize := float64(vp.Size)
+	halfSize := max(vp.Size/2, 1)
+	vpBounds := image.Rect(
+		vp.Position.X-halfSize,
+		vp.Position.Y-halfSize,
+		vp.Position.X+halfSize,
+		vp.Position.Y+halfSize,
+	)
+	o.drawTextCentered(vpChar, vpBounds, fontName, fontSize,
+		badge.ParseHexARGB(vp.FillColor))
+}
+
+func (o *sharedOverlay) redrawGrid() {
+	if o.cachedGrid == nil {
+		return
+	}
+
+	o.srf.ensureBuffers()
+
+	if !o.srf.beginFrame() {
+		return
+	}
+
+	o.srf.surfaceClear()
+	style := o.cachedStyle
+	prefix := o.currentPrefix
+
+	for _, cell := range o.cachedGrid.AllCells() {
+		label := strings.ToUpper(cell.Coordinate())
+
+		matched := strings.HasPrefix(label, prefix)
+		if o.hideUnmatched && prefix != "" && !matched {
+			continue
+		}
+
+		fill := style.BackgroundColorARGB()
+		text := style.TextColorARGB()
+
+		border := style.LineColorARGB()
+		if matched && prefix != "" {
+			fill = style.MatchedBackgroundColorARGB()
+			text = style.MatchedTextColorARGB()
+			border = style.MatchedBorderColorARGB()
+		}
+
+		cellBounds := o.offset(cell.Bounds())
+		o.drawRect(cellBounds, fill, border, style.LineWidth())
+		o.drawTextCentered(label, cellBounds,
+			style.FontFamily(), style.LabelFontSize(), text)
+	}
+
+	if o.currentSubgrid != nil {
+		o.drawSubgrid(o.currentSubgrid.Bounds(), style)
+	}
+
+	o.srf.surfaceFlush()
+}
+
+func (o *sharedOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Style) {
+	// bounds is screen-local; place the subgrid on the active monitor.
+	bounds = o.offset(bounds)
+
+	keyRunes := []rune("ASDFGHJKL")
+	if o.sublayerKeys != "" {
+		keyRunes = []rune(strings.ToUpper(o.sublayerKeys))
+	}
+
+	maxKeys := min(len(keyRunes), subgridCols*subgridRows)
+	xBreaks := make([]int, subgridCols+1)
+	yBreaks := make([]int, subgridRows+1)
+	xBreaks[0] = bounds.Min.X
+	yBreaks[0] = bounds.Min.Y
+
+	for i := 1; i <= subgridCols; i++ {
+		xBreaks[i] = bounds.Min.X + int(
+			float64(i)*float64(bounds.Dx())/float64(subgridCols)+
+				subgridHalfPixel,
+		)
+	}
+
+	for i := 1; i <= subgridRows; i++ {
+		yBreaks[i] = bounds.Min.Y + int(
+			float64(i)*float64(bounds.Dy())/float64(subgridRows)+
+				subgridHalfPixel,
+		)
+	}
+
+	xBreaks[subgridCols] = bounds.Max.X
+	yBreaks[subgridRows] = bounds.Max.Y
+
+	index := 0
+	for row := range subgridRows {
+		for col := range subgridCols {
+			if index >= maxKeys {
+				break
+			}
+
+			cell := image.Rect(
+				xBreaks[col], yBreaks[row],
+				xBreaks[col+1], yBreaks[row+1],
+			)
+			o.drawRect(cell, style.BackgroundColorARGB(),
+				style.LineColorARGB(), style.LineWidth())
+			o.drawTextCentered(
+				string(keyRunes[index]), cell,
+				style.FontFamily(),
+				style.LabelFontSize()*subgridFontScale,
+				style.TextColorARGB(),
+			)
+			index++
+		}
+	}
+}
+
+// setOriginOffset stores the active screen origin used to translate
+// screen-local grid/recursive-grid/hint coordinates onto the correct monitor.
+func (o *sharedOverlay) setOriginOffset(origin image.Point) {
+	o.originOffset = origin
+}
+
+// offset translates a screen-local rectangle into global desktop coordinates.
+func (o *sharedOverlay) offset(rect image.Rectangle) image.Rectangle {
+	return rect.Add(o.originOffset)
+}
+
+// Stroke widths scale with the HiDPI factor here so every draw path (grid,
+// hints, badges, indicator) gets consistent line weight without per-call-site
+// scaling. Element geometry that must fit scaled text is sized by the callers.
+func (o *sharedOverlay) drawRect(
+	bounds image.Rectangle,
+	fill uint32, border uint32, lineWidth float64,
+) {
+	o.srf.rectPrim(bounds, fill, border, lineWidth*o.srf.surfaceScale())
+}
+
+func (o *sharedOverlay) drawRoundedRect(
+	bounds image.Rectangle,
+	radius float64,
+	fill uint32, border uint32, lineWidth float64,
+) {
+	o.srf.roundedRectPrim(bounds, radius, fill, border, lineWidth*o.srf.surfaceScale())
+}
+
+func (o *sharedOverlay) drawHintBadge(
+	badgeRect image.Rectangle, radius float64, edge int, arrow hintArrowTriangle,
+	fill uint32, border uint32, lineWidth float64,
+) {
+	o.srf.hintBadgePrim(
+		badgeRect,
+		radius,
+		edge,
+		arrow,
+		fill,
+		border,
+		lineWidth*o.srf.surfaceScale(),
+	)
+}
+
+// drawTextCentered applies the HiDPI scale to the font size centrally, so every
+// label/badge caller passes its base (logical) font size and text renders at the
+// device-appropriate size. Callers that size geometry around the text must use
+// the same scaled font (fontSize * surfaceScale()).
+func (o *sharedOverlay) drawTextCentered(
+	text string, bounds image.Rectangle,
+	fontFamily string, fontSize float64, color uint32,
+) {
+	o.srf.textPrim(
+		text, fontFamily,
+		float64(bounds.Min.X+bounds.Dx()/2),
+		float64(bounds.Min.Y+bounds.Dy()/2),
+		fontSize*o.srf.surfaceScale(), color,
+	)
+}
+
+func (o *sharedOverlay) drawLabelBackground(
+	label string, cell image.Rectangle,
+	style recursivegridcomponent.Style,
+) {
+	// Match the scaled font that drawTextCentered renders for the label.
+	fontSize := style.LabelFontSize() * o.srf.surfaceScale()
+	paddingX := badge.AutoPadding(fontSize,
+		style.LabelBackgroundPaddingX(), true)
+	paddingY := badge.AutoPadding(fontSize,
+		style.LabelBackgroundPaddingY(), false)
+	width := badge.EstimateTextWidth(label, fontSize) +
+		paddingX*paddingMultiplier
+	height := badge.EstimateTextHeight(fontSize) +
+		paddingY*paddingMultiplier
+	rect := centeredRect(cell, width, height)
+	o.drawRect(rect, style.LabelBackgroundColorARGB(),
+		style.LineColorARGB(), max(style.LabelBackgroundBorderWidthF(), 0))
+}
+
+//nolint:mnd
+func (o *sharedOverlay) drawSubKeyMiniGrid(
+	cell image.Rectangle,
+	nextKeyRunes []rune,
+	nextGridCols int, nextGridRows int,
+	style recursivegridcomponent.Style,
+) {
+	subCells := recursivegrid.ComputeGridCells(cell, nextGridCols, nextGridRows)
+	centerIdx := -1
+
+	if nextGridCols%2 == 1 && nextGridRows%2 == 1 {
+		centerIdx = (nextGridRows/2)*nextGridCols + nextGridCols/2
+	}
+
+	subIndex := 0
+	for idx, subCell := range subCells {
+		if idx == centerIdx {
+			subIndex++
+
+			continue
+		}
+
+		if subIndex >= len(nextKeyRunes) {
+			return
+		}
+
+		subLabel := style.SubKeyPreviewLabelChar()
+		if subLabel == "" {
+			subLabel = string(nextKeyRunes[subIndex])
+		}
+
+		o.drawTextCentered(
+			subLabel, subCell,
+			style.FontFamily(), style.SubKeyPreviewFontSizeF(),
+			style.SubKeyPreviewTextColorARGB(),
+		)
+
+		subIndex++
+	}
+}

--- a/internal/adapter/overlay/linux/wayland_cgo.go
+++ b/internal/adapter/overlay/linux/wayland_cgo.go
@@ -11,7 +11,6 @@ import "C"
 
 import (
 	"image"
-	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -19,53 +18,35 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
-	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	gridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
 	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
 	_ "github.com/y3owk1n/neru/internal/adapter/platform/linux"
 	_ "github.com/y3owk1n/neru/internal/adapter/platform/linux/wlr_protocol"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
-	"github.com/y3owk1n/neru/internal/domain/recursivegrid"
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
-type wlrootsOverlay struct {
-	raw            *C.NeruWaylandOverlay
-	logger         *zap.Logger
-	currentPrefix  string
-	hideUnmatched  bool
-	currentSubgrid *domainGrid.Cell
-	sublayerKeys   string
-	cachedGrid     *domainGrid.Grid
-	cachedStyle    gridcomponent.Style
-
-	// originOffset is the active screen's top-left origin in global
-	// coordinates. Grid, recursive-grid and hint content arrives in
-	// screen-local coordinates (origin 0,0); adding this offset places it on
-	// the correct output of the desktop-spanning surface. Absolute-coordinate
-	// draws (badges, monitor_select, the click indicator) do not apply it.
-	originOffset image.Point
-
-	displayMu *sync.Mutex
-
-	stopCh chan struct{}
-	doneCh chan struct{}
-
-	cancelMu         sync.Mutex
-	animStop         chan struct{}
-	animDone         chan struct{}
-	hasLast          bool
-	lastBounds       image.Rectangle
-	lastCols         int
-	lastRows         int
-	lastDepth        int
-	lastRects        []image.Rectangle
-	currentAnimRects []image.Rectangle
-}
-
 func init() {
 	wlrootsKeyboardCh = make(chan string, keyboardChanBuffer)
+}
+
+// wlrootsOverlay is the wlroots layer-shell backend: the cgo connection, the
+// shared-memory buffer pool, the keyboard poller, and the overlaySurface
+// primitives. All drawing and animation logic lives on the embedded
+// sharedOverlay; the exported methods below are nil-guarded delegates into it
+// (the manager calls them on possibly-nil pointers).
+type wlrootsOverlay struct {
+	sharedOverlay
+
+	raw    *C.NeruWaylandOverlay
+	logger *zap.Logger
+
+	// stopCh/doneCh belong to the keyboard poller's lifecycle, distinct from
+	// the animation channels on sharedOverlay. Destroy closes stopCh exactly
+	// once and then waits on doneCh before tearing down the display.
+	stopCh chan struct{}
+	doneCh chan struct{}
 }
 
 func newWlrootsOverlay(logger *zap.Logger) *wlrootsOverlay {
@@ -75,12 +56,14 @@ func newWlrootsOverlay(logger *zap.Logger) *wlrootsOverlay {
 	}
 
 	C.neru_wayland_overlay_setup_buffers(raw)
+
 	overlay := &wlrootsOverlay{
 		raw:    raw,
 		logger: logger,
 		stopCh: make(chan struct{}),
 		doneCh: make(chan struct{}),
 	}
+	overlay.srf = overlay
 
 	return overlay
 }
@@ -106,34 +89,24 @@ func (o *wlrootsOverlay) Show() {
 
 func (o *wlrootsOverlay) Hide() {
 	if o != nil && o.raw != nil {
-		o.cancelAnimation()
-		C.neru_wayland_overlay_hide(o.raw)
+		o.hide()
 	}
 }
 
 func (o *wlrootsOverlay) Clear() {
 	if o != nil && o.raw != nil {
-		o.cancelAnimation()
-		o.hasLast = false
-		C.neru_wayland_overlay_clear(o.raw)
+		o.clear()
 	}
 }
 
 func (o *wlrootsOverlay) ClearRect(rect image.Rectangle) {
 	if o != nil && o.raw != nil && !rect.Empty() {
-		C.neru_wayland_overlay_clear_rect(
-			o.raw,
-			C.double(rect.Min.X),
-			C.double(rect.Min.Y),
-			C.double(rect.Dx()),
-			C.double(rect.Dy()),
-		)
+		o.clearRect(rect)
 	}
 }
 
-func (o *wlrootsOverlay) Resize() {
-	// Wayland layer shells auto-resize
-}
+// Resize is a no-op: Wayland layer shells auto-resize with their output.
+func (o *wlrootsOverlay) Resize() {}
 
 func (o *wlrootsOverlay) Destroy() {
 	if o == nil || o.raw == nil {
@@ -149,8 +122,11 @@ func (o *wlrootsOverlay) Destroy() {
 }
 
 func (o *wlrootsOverlay) UpdateGridMatches(prefix string) {
-	o.currentPrefix = strings.ToUpper(prefix)
-	o.redrawGrid()
+	if o == nil || o.raw == nil {
+		return
+	}
+
+	o.updateGridMatches(prefix)
 }
 
 func (o *wlrootsOverlay) ShowSubgrid(cell *domainGrid.Cell, _ gridcomponent.Style) {
@@ -158,17 +134,14 @@ func (o *wlrootsOverlay) ShowSubgrid(cell *domainGrid.Cell, _ gridcomponent.Styl
 		return
 	}
 
-	o.currentSubgrid = cell
-	C.neru_wayland_overlay_setup_buffers(o.raw)
-	o.Clear()
-	if !o.selectAvailableBuffer() {
-		return
-	}
-	o.drawSubgrid(cell.Bounds(), o.cachedStyle)
-	C.neru_wayland_overlay_flush(o.raw)
+	o.showSubgrid(cell)
 }
 
 func (o *wlrootsOverlay) SetHideUnmatched(hide bool) {
+	if o == nil {
+		return
+	}
+
 	o.hideUnmatched = hide
 }
 
@@ -176,12 +149,8 @@ func (o *wlrootsOverlay) DrawGrid(g *domainGrid.Grid, input string, style gridco
 	if o == nil || o.raw == nil || g == nil {
 		return
 	}
-	o.cachedGrid = g
-	o.cachedStyle = style
-	o.currentPrefix = strings.ToUpper(input)
-	o.currentSubgrid = nil
 
-	o.redrawGrid()
+	o.drawGrid(g, input, style)
 }
 
 func (o *wlrootsOverlay) DrawRecursiveGrid(
@@ -205,7 +174,6 @@ func (o *wlrootsOverlay) DrawRecursiveGrid(
 	)
 }
 
-//nolint:mnd
 func (o *wlrootsOverlay) DrawRecursiveGridWithSubKeyPreview(
 	bounds image.Rectangle,
 	depth int,
@@ -224,55 +192,11 @@ func (o *wlrootsOverlay) DrawRecursiveGridWithSubKeyPreview(
 		return
 	}
 
-	// Translate the screen-local bounds and virtual-pointer position onto the
-	// active output. Everything downstream (cell rects, animation from/to
-	// rects, the pointer) derives from these, so the whole frame lands on the
-	// right monitor.
-	bounds = o.offset(bounds)
-	virtualPointer.Position = virtualPointer.Position.Add(o.originOffset)
-
-	C.neru_wayland_overlay_setup_buffers(o.raw)
-	shouldAnimate := animEnabled && o.hasLast && depth != o.lastDepth &&
-		!o.lastBounds.Empty()
-	cellRects := recursivegrid.ComputeGridCells(bounds, gridCols, gridRows)
-
-	if shouldAnimate {
-		duration := time.Duration(animDurationMS) * time.Millisecond
-		if duration <= 0 {
-			duration = 50 * time.Millisecond
-		}
-
-		fromRects := o.buildFromRects(cellRects, bounds)
-		keyRunes := []rune(strings.ToUpper(keys))
-		nextKeyRunes := []rune(strings.ToUpper(nextKeys))
-
-		animStop := make(chan struct{})
-		animDone := make(chan struct{})
-		o.animStop = animStop
-		o.animDone = animDone
-
-		o.startGridAnimation(
-			fromRects, cellRects,
-			keyRunes, nextKeyRunes,
-			nextGridCols, nextGridRows,
-			style, virtualPointer,
-			duration, animStop, animDone,
-		)
-	} else {
-		o.clearAndDraw(
-			cellRects, keys, gridCols, gridRows,
-			nextKeys, nextGridCols, nextGridRows,
-			style, virtualPointer,
-		)
-	}
-
-	o.hasLast = true
-	o.lastBounds = bounds
-	o.lastCols = gridCols
-	o.lastRows = gridRows
-	o.lastDepth = depth
-	o.lastRects = make([]image.Rectangle, len(cellRects))
-	copy(o.lastRects, cellRects)
+	o.drawRecursiveGridWithSubKeyPreview(
+		bounds, depth, keys, gridCols, gridRows,
+		nextKeys, nextGridCols, nextGridRows,
+		style, virtualPointer, animEnabled, animDurationMS,
+	)
 }
 
 func (o *wlrootsOverlay) DrawBadge(
@@ -285,15 +209,7 @@ func (o *wlrootsOverlay) DrawBadge(
 		return
 	}
 
-	C.neru_wayland_overlay_setup_buffers(o.raw)
-	fontSize := style.fontSize
-	if fontSize <= 0 {
-		fontSize = 14
-	}
-	rect := badgeBounds(posX, posY, text, style)
-
-	o.drawRect(rect, colors.background, colors.border, max(style.borderWidth, 1))
-	o.drawTextCentered(text, rect, style.fontFamily, fontSize, colors.text)
+	o.drawBadge(posX, posY, text, colors, style)
 }
 
 func (o *wlrootsOverlay) Flush() {
@@ -303,10 +219,6 @@ func (o *wlrootsOverlay) Flush() {
 	C.neru_wayland_overlay_flush(o.raw)
 }
 
-// DrawMonitorSelect renders one centered, labeled panel per monitor for the
-// interactive monitor picker, drawing on the per-output layer-shell surfaces.
-// Wayland renders in logical coordinates and scales via the compositor buffer,
-// so the panel layout uses scale 1 (see monitorSelectPanelLayout).
 func (o *wlrootsOverlay) DrawMonitorSelect(
 	targets []manager.MonitorSelectTarget,
 	style manager.MonitorSelectStyle,
@@ -315,40 +227,7 @@ func (o *wlrootsOverlay) DrawMonitorSelect(
 		return
 	}
 
-	C.neru_wayland_overlay_setup_buffers(o.raw)
-	o.cancelAnimation()
-	o.hasLast = false
-	if !o.selectAvailableBuffer() {
-		return
-	}
-	C.neru_wayland_overlay_clear(o.raw)
-
-	spec := newMonitorSelectDrawSpec(style)
-	for _, target := range targets {
-		if target.Bounds.Empty() {
-			continue
-		}
-
-		if spec.hasBackdrop {
-			o.drawRect(target.Bounds, spec.backdrop, 0, 0)
-		}
-
-		panel, labelRect, subtitleRect, radius := monitorSelectPanelLayout(
-			target.Bounds, target.Label, target.Subtitle, style, 1,
-		)
-		o.drawRoundedRect(panel, radius, spec.background, spec.border, spec.borderWidth)
-
-		o.drawTextCentered(target.Label, labelRect, style.FontFamily, spec.labelFont, spec.text)
-
-		if target.Subtitle != "" {
-			o.drawTextCentered(
-				target.Subtitle, subtitleRect,
-				monitorSelectSubtitleFamily(style), spec.subtitleFont, spec.subtitleText,
-			)
-		}
-	}
-
-	C.neru_wayland_overlay_flush(o.raw)
+	o.drawMonitorSelect(targets, style)
 }
 
 func (o *wlrootsOverlay) DrawHints(
@@ -359,84 +238,9 @@ func (o *wlrootsOverlay) DrawHints(
 		return
 	}
 
-	C.neru_wayland_overlay_setup_buffers(o.raw)
-	o.cancelAnimation()
-	o.hasLast = false
-	if !o.selectAvailableBuffer() {
-		return
-	}
-	C.neru_wayland_overlay_clear(o.raw)
-	fontSize := float64(max(style.FontSize(), 1))
-	for _, hint := range hintsSlice {
-		// hint.Position() is the element center in screen-local coordinates;
-		// translate it onto the active output.
-		pos := hint.Position().Add(o.originOffset)
-		if style.BoundaryHighlightEnabled() {
-			boundary := image.Rect(
-				pos.X-hint.Size().X/2,
-				pos.Y-hint.Size().Y/2,
-				pos.X+hint.Size().X/2,
-				pos.Y+hint.Size().Y/2,
-			)
-			o.drawRect(
-				boundary,
-				badge.ParseHexARGB(style.BoundaryBackgroundColor()),
-				badge.ParseHexARGB(style.BoundaryBorderColor()),
-				float64(max(style.BoundaryBorderWidth(), 0)),
-			)
-		}
-
-		textColor := style.TextColor()
-		if hint.MatchedPrefix() != "" {
-			textColor = style.MatchedTextColor()
-		}
-
-		label := hint.Label()
-		paddingX := badge.AutoPadding(fontSize, style.PaddingX(), true)
-		paddingY := badge.AutoPadding(fontSize, style.PaddingY(), false)
-		badgeWidth := badge.EstimateTextWidth(label, fontSize) + paddingX*paddingMultiplier
-		badgeHeight := badge.EstimateTextHeight(fontSize) + paddingY*paddingMultiplier
-
-		radius := style.BorderRadius()
-		if radius < 0 {
-			radius = min(badgeHeight/centeredRectDivisor, hintAutoRadiusMax)
-		}
-		// Cap the radius so a top/bottom badge keeps a flat edge for the tail.
-		radius = hintBadgeRadius(radius, badgeWidth, style.Placement())
-
-		// pos is the element center (set in modes/hints.go). The badge is
-		// centered horizontally on it and placed above / on / below the center
-		// to match macOS; top/bottom placement also draws a connector arrow
-		// pointing back at the target.
-		badgeRect, arrow, hasArrow := hintBadgePlacement(
-			pos, badgeWidth, badgeHeight, radius, style.Placement(),
-		)
-
-		fill := badge.ParseHexARGB(style.BackgroundColor())
-		border := badge.ParseHexARGB(style.BorderColor())
-		borderWidth := float64(max(style.BorderWidth(), 0))
-
-		// Badge and connector tail are drawn as one filled+stroked outline so
-		// translucent colors don't double-composite at the junction.
-		o.drawHintBadge(
-			badgeRect, float64(radius), hintTailEdge(badgeRect, arrow, hasArrow), arrow,
-			fill, border, borderWidth,
-		)
-		o.drawTextCentered(
-			label, badgeRect,
-			style.FontFamily(),
-			fontSize,
-			badge.ParseHexARGB(textColor),
-		)
-	}
-
-	C.neru_wayland_overlay_flush(o.raw)
+	o.drawHints(hintsSlice, style)
 }
 
-// DrawMouseActionIndicator animates a transient click indicator centered on
-// point. It runs on this overlay's dedicated indicator surface, independent of
-// the mode overlay's show/hide lifecycle, so it survives the mode exit that
-// immediately follows a click.
 func (o *wlrootsOverlay) DrawMouseActionIndicator(
 	point image.Point,
 	style ports.MouseActionIndicatorStyle,
@@ -445,147 +249,100 @@ func (o *wlrootsOverlay) DrawMouseActionIndicator(
 		return
 	}
 
-	// Cancel any in-flight indicator animation before starting a new one.
-	// (Must run without displayMu held: the animation goroutine may be blocked
-	// acquiring displayMu, and cancelAnimation waits for it to exit.)
-	o.cancelAnimation()
-
-	duration := time.Duration(style.DurationMS) * time.Millisecond
-	if duration <= 0 {
-		duration = defaultMouseActionDuration
-	}
-
-	// The keyboard poller runs concurrently on this overlay's wl_display under
-	// displayMu, so the surface setup/show here must take the same lock — the
-	// Wayland client API is not thread-safe.
-	if o.displayMu != nil {
-		o.displayMu.Lock()
-	}
-	C.neru_wayland_overlay_setup_buffers(o.raw)
-	// The indicator must never steal keyboard focus from the app it decorates.
-	C.neru_wayland_overlay_set_keyboard_capture(o.raw, C.int(0))
-	C.neru_wayland_overlay_show(o.raw)
-	C.neru_wayland_overlay_sync(o.raw)
-	if o.displayMu != nil {
-		o.displayMu.Unlock()
-	}
-
-	animStop := make(chan struct{})
-	animDone := make(chan struct{})
-	o.animStop = animStop
-	o.animDone = animDone
-
-	o.startMouseActionAnimation(point, style, duration, animStop, animDone)
+	o.drawMouseActionIndicator(point, style)
 }
 
-func (o *wlrootsOverlay) startMouseActionAnimation(
-	point image.Point,
-	style ports.MouseActionIndicatorStyle,
-	duration time.Duration,
-	stopCh chan struct{},
-	doneCh chan struct{},
-) {
-	startTime := time.Now()
+// setDisplayMu wires the mutex that serializes wl_display access between
+// rendering and the keyboard poller — the Wayland client API is not
+// thread-safe. It is the Wayland-flavored name for the shared render mutex;
+// the manager passes the same lock it holds around synchronous draws.
+func (o *wlrootsOverlay) setDisplayMu(mu *sync.Mutex) {
+	o.setRenderMuShared(mu)
+}
 
-	fillBase := badge.ParseHexARGB(style.BackgroundColor)
-	borderBase := badge.ParseHexARGB(style.BorderColor)
-	lineWidth := float64(max(style.BorderWidth, 0))
-	baseSize := float64(max(style.Size, 1))
-	isSquare := style.Shape == "square"
-
-	renderFrame := func(rawProgress float64) {
-		eased := applyEasing(style.Easing, rawProgress)
-		scale := max(lerp(style.StartScale, style.EndScale, eased), 0)
-		opacity := lerp(style.StartOpacity, style.EndOpacity, eased)
-		diameter := baseSize * scale
-		rect := mouseActionIndicatorRect(point, diameter)
-		fill := applyOpacity(fillBase, opacity)
-		border := applyOpacity(borderBase, opacity)
-
-		C.neru_wayland_overlay_dispatch_pending(o.raw)
-		bufIdx := C.neru_wayland_overlay_available_buffer(o.raw)
-		if bufIdx < 0 {
-			C.neru_wayland_overlay_sync(o.raw)
-			bufIdx = C.neru_wayland_overlay_available_buffer(o.raw)
-		}
-		if bufIdx < 0 {
-			return
-		}
-		C.neru_wayland_overlay_select_buffer(o.raw, bufIdx)
-
-		C.neru_wayland_overlay_clear(o.raw)
-		if isSquare {
-			o.drawRect(rect, fill, border, lineWidth)
-		} else {
-			o.drawRoundedRect(rect, diameter/centeredRectDivisor, fill, border, lineWidth)
-		}
-		C.neru_wayland_overlay_flush(o.raw)
+func (o *wlrootsOverlay) setOriginOffset(origin image.Point) {
+	if o == nil {
+		return
 	}
 
-	go func() {
-		defer close(doneCh)
-		defer func() {
-			o.cancelMu.Lock()
-			if o.animStop == stopCh {
-				o.animStop = nil
+	o.sharedOverlay.setOriginOffset(origin)
+}
+
+// startPoller launches the keyboard poller goroutine. Called once per overlay
+// by the manager; the poller exits when Destroy closes stopCh.
+func (o *wlrootsOverlay) startPoller() {
+	go o.keyboardPoller()
+}
+
+// setKeyboardCaptureEnabled toggles whether the layer surface requests
+// exclusive keyboard focus. Disabled for the click indicator and whenever an
+// evdev grab already owns the keyboard (a layer-surface grab would deactivate
+// the focused toplevel).
+func (o *wlrootsOverlay) setKeyboardCaptureEnabled(enabled bool) {
+	if o == nil || o.raw == nil {
+		return
+	}
+
+	cEnabled := C.int(0)
+	if enabled {
+		cEnabled = 1
+	}
+
+	C.neru_wayland_overlay_set_keyboard_capture(o.raw, cEnabled)
+}
+
+// keyboardPoller pumps the wl_display for keyboard events and forwards decoded
+// keys to wlrootsKeyboardCh, taking the render mutex around every native call.
+func (o *wlrootsOverlay) keyboardPoller() {
+	defer close(o.doneCh)
+
+	const pollInterval = 5 * time.Millisecond
+
+	for {
+		select {
+		case <-o.stopCh:
+			return
+		default:
+		}
+
+		var keys []string
+
+		if o.renderMu != nil {
+			o.renderMu.Lock()
+		}
+
+		if C.neru_wayland_overlay_poll(o.raw) < 0 {
+			if o.renderMu != nil {
+				o.renderMu.Unlock()
 			}
-			if o.animDone == doneCh {
-				o.animDone = nil
-			}
-			o.cancelMu.Unlock()
-		}()
+
+			return
+		}
 
 		for {
-			select {
-			case <-stopCh:
-				return
-			default:
+			key := C.neru_wayland_overlay_get_key(o.raw)
+			if key == nil {
+				break
 			}
 
-			elapsed := time.Since(startTime)
-			rawProgress := min(float64(elapsed)/float64(duration), 1.0)
+			keys = append(keys, C.GoString(key))
+		}
 
-			renderStart := time.Now()
+		if o.renderMu != nil {
+			o.renderMu.Unlock()
+		}
 
-			if o.displayMu != nil {
-				o.displayMu.Lock()
+		if len(keys) > 0 {
+			for _, k := range keys {
 				select {
-				case <-stopCh:
-					o.displayMu.Unlock()
-
-					return
+				case wlrootsKeyboardCh <- k:
 				default:
 				}
 			}
-			renderFrame(rawProgress)
-			if o.displayMu != nil {
-				o.displayMu.Unlock()
-			}
-
-			if rawProgress >= 1.0 {
-				// Finished: unmap the dedicated surface so the fully faded
-				// indicator does not linger on screen.
-				if o.displayMu != nil {
-					o.displayMu.Lock()
-				}
-				C.neru_wayland_overlay_hide(o.raw)
-				if o.displayMu != nil {
-					o.displayMu.Unlock()
-				}
-
-				return
-			}
-
-			sleepFor := animationFrameDur - time.Since(renderStart)
-			if sleepFor > 0 {
-				select {
-				case <-stopCh:
-					return
-				case <-time.After(sleepFor):
-				}
-			}
+		} else {
+			time.Sleep(pollInterval)
 		}
-	}()
+	}
 }
 
 // selectAvailableBuffer picks a buffer that the compositor has released.
@@ -608,475 +365,80 @@ func (o *wlrootsOverlay) selectAvailableBuffer() bool {
 	return true
 }
 
-func (o *wlrootsOverlay) setDisplayMu(mu *sync.Mutex) {
-	o.displayMu = mu
+// --- overlaySurface primitives ---
+
+// surfaceScale is 1: Wayland renders in logical coordinates and the
+// compositor scales the buffer.
+func (o *wlrootsOverlay) surfaceScale() float64 { return 1 }
+
+func (o *wlrootsOverlay) ensureBuffers() {
+	C.neru_wayland_overlay_setup_buffers(o.raw)
 }
 
-func (o *wlrootsOverlay) startPoller() {
-	go o.keyboardPoller()
+// beginFrame makes a released shared-memory buffer current; reports false
+// when none is available and the frame must be dropped.
+func (o *wlrootsOverlay) beginFrame() bool {
+	return o.selectAvailableBuffer()
 }
 
-func (o *wlrootsOverlay) setKeyboardCaptureEnabled(enabled bool) {
-	if o == nil || o.raw == nil {
-		return
-	}
-
-	cEnabled := C.int(0)
-	if enabled {
-		cEnabled = 1
-	}
-
-	C.neru_wayland_overlay_set_keyboard_capture(o.raw, cEnabled)
-}
-
-func (o *wlrootsOverlay) cancelAnimation() {
-	o.cancelMu.Lock()
-
-	var doneCh chan struct{}
-	if o.animStop != nil {
-		close(o.animStop)
-		o.animStop = nil
-	}
-	if o.animDone != nil {
-		doneCh = o.animDone
-		o.animDone = nil
-	}
-	o.cancelMu.Unlock()
-
-	if doneCh != nil {
-		<-doneCh
-	}
-}
-
-func (o *wlrootsOverlay) keyboardPoller() {
-	defer close(o.doneCh)
-
-	const pollInterval = 5 * time.Millisecond
-
-	for {
-		select {
-		case <-o.stopCh:
-			return
-		default:
-		}
-
-		var keys []string
-
-		if o.displayMu != nil {
-			o.displayMu.Lock()
-		}
-
-		if C.neru_wayland_overlay_poll(o.raw) < 0 {
-			if o.displayMu != nil {
-				o.displayMu.Unlock()
-			}
-
-			return
-		}
-
-		for {
-			key := C.neru_wayland_overlay_get_key(o.raw)
-			if key == nil {
-				break
-			}
-
-			keys = append(keys, C.GoString(key))
-		}
-
-		if o.displayMu != nil {
-			o.displayMu.Unlock()
-		}
-
-		if len(keys) > 0 {
-			for _, k := range keys {
-				select {
-				case wlrootsKeyboardCh <- k:
-				default:
-				}
-			}
-		} else {
-			time.Sleep(pollInterval)
-		}
-	}
-}
-
-//nolint:mnd,varnamelen
-func (o *wlrootsOverlay) buildFromRects(
-	toRects []image.Rectangle,
-	bounds image.Rectangle,
-) []image.Rectangle {
-	if len(o.currentAnimRects) == len(toRects) {
-		from := make([]image.Rectangle, len(o.currentAnimRects))
-		copy(from, o.currentAnimRects)
-
-		return from
-	}
-
-	if len(o.lastRects) == len(toRects) {
-		from := make([]image.Rectangle, len(o.lastRects))
-		copy(from, o.lastRects)
-
-		return from
-	}
-
-	if o.lastBounds.Empty() {
-		from := make([]image.Rectangle, len(toRects))
-		for idx, rect := range toRects {
-			cx := rect.Min.X + rect.Dx()/2
-			cy := rect.Min.Y + rect.Dy()/2
-			from[idx] = image.Rect(cx, cy, cx, cy)
-		}
-
-		return from
-	}
-
-	fromBounds := o.lastBounds
-	fw := float64(fromBounds.Dx())
-	fh := float64(fromBounds.Dy())
-	dw := float64(bounds.Dx())
-	dh := float64(bounds.Dy())
-	from := make([]image.Rectangle, len(toRects))
-	for idx, rect := range toRects {
-		nx := (float64(rect.Min.X+rect.Dx()/2) - float64(bounds.Min.X)) / dw
-		ny := (float64(rect.Min.Y+rect.Dy()/2) - float64(bounds.Min.Y)) / dh
-		cx := int(float64(fromBounds.Min.X) + nx*fw)
-		cy := int(float64(fromBounds.Min.Y) + ny*fh)
-		rw := rect.Dx()
-		rh := rect.Dy()
-		from[idx] = image.Rect(
-			cx-rw/2, cy-rh/2,
-			cx+rw/2, cy+rh/2,
-		)
-	}
-
-	return from
-}
-
-func (o *wlrootsOverlay) startGridAnimation(
-	fromRects, toRects []image.Rectangle,
-	keyRunes, nextKeyRunes []rune,
-	nextGridCols, nextGridRows int,
-	style recursivegridcomponent.Style,
-	virtualPointer recursivegridcomponent.VirtualPointerState,
-	duration time.Duration,
-	stopCh chan struct{},
-	doneCh chan struct{},
-) {
-	C.neru_wayland_overlay_sync(o.raw)
-
-	startTime := time.Now()
-
-	renderFrame := func(rawProgress float64) bool {
-		if rawProgress >= 1.0 {
-			rawProgress = 1.0
-		}
-		progress := easeInOut(rawProgress)
-
-		interpCells := make([]image.Rectangle, len(toRects))
-		for i := range toRects {
-			src := fromRects[i]
-			dst := toRects[i]
-			interpCells[i] = image.Rect(
-				int(lerp(float64(src.Min.X), float64(dst.Min.X), progress)),
-				int(lerp(float64(src.Min.Y), float64(dst.Min.Y), progress)),
-				int(lerp(float64(src.Max.X), float64(dst.Max.X), progress)),
-				int(lerp(float64(src.Max.Y), float64(dst.Max.Y), progress)),
-			)
-		}
-
-		C.neru_wayland_overlay_dispatch_pending(o.raw)
-		bufIdx := C.neru_wayland_overlay_available_buffer(o.raw)
-		if bufIdx < 0 {
-			C.neru_wayland_overlay_sync(o.raw)
-			bufIdx = C.neru_wayland_overlay_available_buffer(o.raw)
-		}
-		if bufIdx < 0 {
-			return false
-		}
-		C.neru_wayland_overlay_select_buffer(o.raw, bufIdx)
-
-		o.currentAnimRects = interpCells
-
-		C.neru_wayland_overlay_clear(o.raw)
-		o.drawFrame(
-			interpCells, keyRunes, nextKeyRunes,
-			nextGridCols, nextGridRows, style, virtualPointer,
-		)
-
-		return true
-	}
-
-	go func() {
-		defer close(doneCh)
-		defer func() {
-			o.cancelMu.Lock()
-			if o.animStop == stopCh {
-				o.animStop = nil
-			}
-			if o.animDone == doneCh {
-				o.animDone = nil
-			}
-			o.cancelMu.Unlock()
-		}()
-
-		for {
-			select {
-			case <-stopCh:
-				return
-			default:
-			}
-
-			elapsed := time.Since(startTime)
-			rawProgress := float64(elapsed) / float64(duration)
-			if rawProgress >= 1.0 {
-				rawProgress = 1.0
-			}
-
-			renderStart := time.Now()
-
-			if o.displayMu != nil {
-				o.displayMu.Lock()
-				// Parent may have closed stopCh while we were waiting
-				// for the lock. Check here to avoid deadlock:
-				//   parent holds displayMu, waits for animDone
-				//   we   hold displayMu, parent waits for displayMu
-				select {
-				case <-stopCh:
-					o.displayMu.Unlock()
-
-					return
-				default:
-				}
-			}
-			_ = renderFrame(rawProgress)
-			if o.displayMu != nil {
-				o.displayMu.Unlock()
-			}
-
-			if rawProgress >= 1.0 {
-				return
-			}
-
-			renderDur := time.Since(renderStart)
-			sleepFor := animationFrameDur - renderDur
-			if sleepFor > 0 {
-				select {
-				case <-stopCh:
-					return
-				case <-time.After(sleepFor):
-				}
-			}
-		}
-	}()
-}
-
-func (o *wlrootsOverlay) clearAndDraw(
-	cellRects []image.Rectangle,
-	keys string, gridCols, gridRows int,
-	nextKeys string, nextGridCols, nextGridRows int,
-	style recursivegridcomponent.Style,
-	virtualPointer recursivegridcomponent.VirtualPointerState,
-) {
-	if o == nil || o.raw == nil {
-		return
-	}
-
-	o.currentAnimRects = nil
-
-	keyRunes := []rune(strings.ToUpper(keys))
-	nextKeyRunes := []rune(strings.ToUpper(nextKeys))
-
-	if !o.selectAvailableBuffer() {
-		return
-	}
+func (o *wlrootsOverlay) surfaceClear() {
 	C.neru_wayland_overlay_clear(o.raw)
-	o.drawFrame(cellRects, keyRunes, nextKeyRunes,
-		nextGridCols, nextGridRows, style, virtualPointer)
 }
 
-func (o *wlrootsOverlay) drawFrame(
-	cellRects []image.Rectangle,
-	keyRunes, nextKeyRunes []rune,
-	nextGridCols, nextGridRows int,
-	style recursivegridcomponent.Style,
-	virtualPointer recursivegridcomponent.VirtualPointerState,
-) {
-	drawSubPreview := style.SubKeyPreview() && len(nextKeyRunes) > 0 &&
-		nextGridCols > 0 && nextGridRows > 0
+// clearFrame is a plain clear: beginFrame already selected the buffer.
+func (o *wlrootsOverlay) clearFrame() {
+	C.neru_wayland_overlay_clear(o.raw)
+}
 
-	for idx, cell := range cellRects {
-		if cell.Empty() {
-			continue
-		}
+func (o *wlrootsOverlay) surfaceClearRect(rect image.Rectangle) {
+	C.neru_wayland_overlay_clear_rect(
+		o.raw,
+		C.double(rect.Min.X),
+		C.double(rect.Min.Y),
+		C.double(rect.Dx()),
+		C.double(rect.Dy()),
+	)
+}
 
-		fill := style.HighlightColorARGB()
-		if fill == 0 {
-			fill = subgridCellBackground
-		}
-
-		o.drawRect(cell, fill, style.LineColorARGB(), style.LineWidthF())
-		if idx < len(keyRunes) {
-			label := style.LabelChar()
-			if label == "" {
-				label = string(keyRunes[idx])
-			}
-
-			if shouldShowLabel(cell, style) {
-				if style.LabelBackground() {
-					o.drawLabelBackground(label, cell, style)
-				}
-
-				o.drawTextCentered(
-					label, cell, style.FontFamily(),
-					style.LabelFontSize(), style.TextColorARGB(),
-				)
-			}
-
-			if drawSubPreview &&
-				shouldShowSubKeyPreview(cell, style, nextGridCols, nextGridRows) {
-				o.drawSubKeyMiniGrid(cell, nextKeyRunes,
-					nextGridCols, nextGridRows, style)
-			}
-		}
-	}
-
-	if virtualPointer.Visible {
-		o.drawVirtualPointer(virtualPointer)
-	}
-
+func (o *wlrootsOverlay) surfaceFlush() {
 	C.neru_wayland_overlay_flush(o.raw)
 }
 
-//nolint:mnd,varnamelen
-func (o *wlrootsOverlay) drawVirtualPointer(vp recursivegridcomponent.VirtualPointerState) {
-	vpChar := vp.Char
-	if vpChar == "" {
-		vpChar = "\u25CF"
-	}
-
-	fontName := ports.ResolveFont(vp.FontName, false)
-	fontSize := float64(vp.Size)
-	halfSize := max(vp.Size/2, 1)
-	vpBounds := image.Rect(
-		vp.Position.X-halfSize,
-		vp.Position.Y-halfSize,
-		vp.Position.X+halfSize,
-		vp.Position.Y+halfSize,
-	)
-	o.drawTextCentered(vpChar, vpBounds, fontName, fontSize,
-		badge.ParseHexARGB(vp.FillColor))
+func (o *wlrootsOverlay) surfaceHide() {
+	C.neru_wayland_overlay_hide(o.raw)
 }
 
-func (o *wlrootsOverlay) redrawGrid() {
-	if o == nil || o.raw == nil || o.cachedGrid == nil {
-		return
+// showIndicator maps the indicator surface under the render lock — the
+// keyboard poller runs concurrently on this overlay's wl_display. The surface
+// must never steal keyboard focus from the app it decorates, so keyboard
+// capture is switched off before mapping.
+func (o *wlrootsOverlay) showIndicator() {
+	if o.renderMu != nil {
+		o.renderMu.Lock()
 	}
 
 	C.neru_wayland_overlay_setup_buffers(o.raw)
-	if !o.selectAvailableBuffer() {
-		return
-	}
-	C.neru_wayland_overlay_clear(o.raw)
-	style := o.cachedStyle
-	prefix := o.currentPrefix
+	C.neru_wayland_overlay_set_keyboard_capture(o.raw, C.int(0))
+	C.neru_wayland_overlay_show(o.raw)
+	C.neru_wayland_overlay_sync(o.raw)
 
-	for _, cell := range o.cachedGrid.AllCells() {
-		label := strings.ToUpper(cell.Coordinate())
-		matched := strings.HasPrefix(label, prefix)
-		if o.hideUnmatched && prefix != "" && !matched {
-			continue
-		}
-
-		fill := style.BackgroundColorARGB()
-		text := style.TextColorARGB()
-		border := style.LineColorARGB()
-		if matched && prefix != "" {
-			fill = style.MatchedBackgroundColorARGB()
-			text = style.MatchedTextColorARGB()
-			border = style.MatchedBorderColorARGB()
-		}
-		cellBounds := o.offset(cell.Bounds())
-		o.drawRect(cellBounds, fill, border, style.LineWidth())
-		o.drawTextCentered(label, cellBounds,
-			style.FontFamily(), style.LabelFontSize(), text)
-	}
-
-	if o.currentSubgrid != nil {
-		o.drawSubgrid(o.currentSubgrid.Bounds(), style)
-	}
-	C.neru_wayland_overlay_flush(o.raw)
-}
-
-func (o *wlrootsOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Style) {
-	// bounds is screen-local; place the subgrid on the active output.
-	bounds = o.offset(bounds)
-	keyRunes := []rune("ASDFGHJKL")
-	if o.sublayerKeys != "" {
-		keyRunes = []rune(strings.ToUpper(o.sublayerKeys))
-	}
-	maxKeys := min(len(keyRunes), subgridCols*subgridRows)
-	xBreaks := make([]int, subgridCols+1)
-	yBreaks := make([]int, subgridRows+1)
-	xBreaks[0] = bounds.Min.X
-	yBreaks[0] = bounds.Min.Y
-
-	for i := 1; i <= subgridCols; i++ {
-		xBreaks[i] = bounds.Min.X + int(
-			float64(i)*float64(bounds.Dx())/float64(subgridCols)+
-				subgridHalfPixel,
-		)
-	}
-	for i := 1; i <= subgridRows; i++ {
-		yBreaks[i] = bounds.Min.Y + int(
-			float64(i)*float64(bounds.Dy())/float64(subgridRows)+
-				subgridHalfPixel,
-		)
-	}
-	xBreaks[subgridCols] = bounds.Max.X
-	yBreaks[subgridRows] = bounds.Max.Y
-
-	index := 0
-	for row := range subgridRows {
-		for col := range subgridCols {
-			if index >= maxKeys {
-				break
-			}
-
-			cell := image.Rect(
-				xBreaks[col], yBreaks[row],
-				xBreaks[col+1], yBreaks[row+1],
-			)
-			o.drawRect(cell, style.BackgroundColorARGB(),
-				style.LineColorARGB(), style.LineWidth())
-			o.drawTextCentered(
-				string(keyRunes[index]), cell,
-				style.FontFamily(),
-				style.LabelFontSize()*subgridFontScale,
-				style.TextColorARGB(),
-			)
-			index++
-		}
+	if o.renderMu != nil {
+		o.renderMu.Unlock()
 	}
 }
 
-// setOriginOffset stores the active screen origin used to translate
-// screen-local grid/recursive-grid/hint coordinates onto the correct output.
-func (o *wlrootsOverlay) setOriginOffset(origin image.Point) {
-	if o == nil {
-		return
-	}
-
-	o.originOffset = origin
+// finishIndicator only hides: clearing would write into an unselected buffer.
+func (o *wlrootsOverlay) finishIndicator() {
+	C.neru_wayland_overlay_hide(o.raw)
 }
 
-// offset translates a screen-local rectangle into global desktop coordinates.
-func (o *wlrootsOverlay) offset(r image.Rectangle) image.Rectangle {
-	return r.Add(o.originOffset)
+func (o *wlrootsOverlay) syncBeforeAnimation() {
+	C.neru_wayland_overlay_sync(o.raw)
 }
 
-func (o *wlrootsOverlay) drawRect(
+func (o *wlrootsOverlay) rectPrim(
 	bounds image.Rectangle,
-	fill uint32, border uint32, lineWidth float64,
+	fill, border uint32, lineWidth float64,
 ) {
 	C.neru_wayland_overlay_rect(
 		o.raw,
@@ -1086,10 +448,10 @@ func (o *wlrootsOverlay) drawRect(
 	)
 }
 
-func (o *wlrootsOverlay) drawRoundedRect(
+func (o *wlrootsOverlay) roundedRectPrim(
 	bounds image.Rectangle,
 	radius float64,
-	fill uint32, border uint32, lineWidth float64,
+	fill, border uint32, lineWidth float64,
 ) {
 	C.neru_wayland_overlay_rounded_rect(
 		o.raw,
@@ -1100,14 +462,14 @@ func (o *wlrootsOverlay) drawRoundedRect(
 	)
 }
 
-func (o *wlrootsOverlay) drawHintBadge(
-	badge image.Rectangle, radius float64, edge int, arrow hintArrowTriangle,
-	fill uint32, border uint32, lineWidth float64,
+func (o *wlrootsOverlay) hintBadgePrim(
+	badgeRect image.Rectangle, radius float64, edge int, arrow hintArrowTriangle,
+	fill, border uint32, lineWidth float64,
 ) {
 	C.neru_wayland_overlay_hint_badge(
 		o.raw,
-		C.double(badge.Min.X), C.double(badge.Min.Y),
-		C.double(badge.Dx()), C.double(badge.Dy()),
+		C.double(badgeRect.Min.X), C.double(badgeRect.Min.Y),
+		C.double(badgeRect.Dx()), C.double(badgeRect.Dy()),
 		C.double(radius),
 		C.int(edge),
 		C.double(arrow.baseLeft.X), C.double(arrow.baseRight.X),
@@ -1116,9 +478,9 @@ func (o *wlrootsOverlay) drawHintBadge(
 	)
 }
 
-func (o *wlrootsOverlay) drawTextCentered(
-	text string, bounds image.Rectangle,
-	fontFamily string, fontSize float64, color uint32,
+func (o *wlrootsOverlay) textPrim(
+	text, fontFamily string,
+	centerX, centerY, fontSize float64, color uint32,
 ) {
 	cText := C.CString(text)
 	cFontFamily := C.CString(fontFamily)
@@ -1128,66 +490,8 @@ func (o *wlrootsOverlay) drawTextCentered(
 
 	C.neru_wayland_overlay_text(
 		o.raw, cText, cFontFamily,
-		C.double(bounds.Min.X+bounds.Dx()/2),
-		C.double(bounds.Min.Y+bounds.Dy()/2),
+		C.double(centerX),
+		C.double(centerY),
 		C.double(fontSize), C.uint(color),
 	)
-}
-
-func (o *wlrootsOverlay) drawLabelBackground(
-	label string, cell image.Rectangle,
-	style recursivegridcomponent.Style,
-) {
-	fontSize := style.LabelFontSize()
-	paddingX := badge.AutoPadding(fontSize,
-		style.LabelBackgroundPaddingX(), true)
-	paddingY := badge.AutoPadding(fontSize,
-		style.LabelBackgroundPaddingY(), false)
-	width := badge.EstimateTextWidth(label, fontSize) +
-		paddingX*paddingMultiplier
-	height := badge.EstimateTextHeight(fontSize) +
-		paddingY*paddingMultiplier
-	rect := centeredRect(cell, width, height)
-	o.drawRect(rect, style.LabelBackgroundColorARGB(),
-		style.LineColorARGB(), max(style.LabelBackgroundBorderWidthF(), 0))
-}
-
-//nolint:mnd
-func (o *wlrootsOverlay) drawSubKeyMiniGrid(
-	cell image.Rectangle,
-	nextKeyRunes []rune,
-	nextGridCols int, nextGridRows int,
-	style recursivegridcomponent.Style,
-) {
-	subCells := recursivegrid.ComputeGridCells(cell, nextGridCols, nextGridRows)
-	centerIdx := -1
-
-	if nextGridCols%2 == 1 && nextGridRows%2 == 1 {
-		centerIdx = (nextGridRows/2)*nextGridCols + nextGridCols/2
-	}
-
-	subIndex := 0
-	for idx, subCell := range subCells {
-		if idx == centerIdx {
-			subIndex++
-
-			continue
-		}
-
-		if subIndex >= len(nextKeyRunes) {
-			return
-		}
-
-		subLabel := style.SubKeyPreviewLabelChar()
-		if subLabel == "" {
-			subLabel = string(nextKeyRunes[subIndex])
-		}
-
-		o.drawTextCentered(
-			subLabel, subCell,
-			style.FontFamily(), style.SubKeyPreviewFontSizeF(),
-			style.SubKeyPreviewTextColorARGB(),
-		)
-		subIndex++
-	}
 }

--- a/internal/adapter/overlay/linux/x11_cgo.go
+++ b/internal/adapter/overlay/linux/x11_cgo.go
@@ -11,58 +11,34 @@ import "C"
 
 import (
 	"image"
-	"strings"
 	"sync"
-	"time"
 	"unsafe"
 
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
-	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	gridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
 	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
 	_ "github.com/y3owk1n/neru/internal/adapter/platform/linux"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
-	"github.com/y3owk1n/neru/internal/domain/recursivegrid"
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
+// x11Overlay is the X11 backend: the cgo connection, the HiDPI scale probe,
+// and the overlaySurface primitives. All drawing and animation logic lives on
+// the embedded sharedOverlay; the exported methods below are nil-guarded
+// delegates into it (the manager calls them on possibly-nil pointers).
 type x11Overlay struct {
+	sharedOverlay
+
 	raw *C.NeruX11Overlay
 	// scale is the desktop-wide HiDPI UI factor from Xft.dpi (>= 1.0). X11 has a
 	// single device-pixel coordinate space and no per-monitor scale, so hint/label
 	// positions stay in device pixels and only element sizes (fonts, stroke widths,
 	// badge geometry) are multiplied by this factor for legibility on HiDPI screens.
-	scale          float64
-	logger         *zap.Logger
-	currentPrefix  string
-	hideUnmatched  bool
-	currentSubgrid *domainGrid.Cell
-	sublayerKeys   string
-	cachedGrid     *domainGrid.Grid
-	cachedStyle    gridcomponent.Style
-
-	// originOffset is the active screen's top-left origin in global device
-	// pixels. Grid, recursive-grid and hint content arrives in screen-local
-	// coordinates (origin 0,0); adding this offset places it on the correct
-	// monitor of the desktop-spanning overlay window. Absolute-coordinate draws
-	// (badges, monitor_select, the click indicator) do not apply it.
-	originOffset image.Point
-
-	renderMu *sync.Mutex
-
-	cancelMu         sync.Mutex
-	animStop         chan struct{}
-	animDone         chan struct{}
-	hasLast          bool
-	lastBounds       image.Rectangle
-	lastCols         int
-	lastRows         int
-	lastDepth        int
-	lastRects        []image.Rectangle
-	currentAnimRects []image.Rectangle
+	scale  float64
+	logger *zap.Logger
 }
 
 func newX11Overlay(logger *zap.Logger) *x11Overlay {
@@ -76,7 +52,10 @@ func newX11Overlay(logger *zap.Logger) *x11Overlay {
 		scale = 1
 	}
 
-	return &x11Overlay{raw: raw, logger: logger, scale: scale}
+	overlay := &x11Overlay{raw: raw, logger: logger, scale: scale}
+	overlay.srf = overlay
+
+	return overlay
 }
 
 // Scale exposes the overlay's HiDPI scale so the manager can size badge
@@ -105,28 +84,19 @@ func (o *x11Overlay) Show() {
 
 func (o *x11Overlay) Hide() {
 	if o != nil && o.raw != nil {
-		o.cancelAnimation()
-		C.neru_x11_overlay_hide(o.raw)
+		o.hide()
 	}
 }
 
 func (o *x11Overlay) Clear() {
 	if o != nil && o.raw != nil {
-		o.cancelAnimation()
-		o.hasLast = false
-		C.neru_x11_overlay_clear(o.raw)
+		o.clear()
 	}
 }
 
 func (o *x11Overlay) ClearRect(rect image.Rectangle) {
 	if o != nil && o.raw != nil && !rect.Empty() {
-		C.neru_x11_overlay_clear_rect(
-			o.raw,
-			C.int(rect.Min.X),
-			C.int(rect.Min.Y),
-			C.int(rect.Dx()),
-			C.int(rect.Dy()),
-		)
+		o.clearRect(rect)
 	}
 }
 
@@ -145,8 +115,11 @@ func (o *x11Overlay) Destroy() {
 }
 
 func (o *x11Overlay) UpdateGridMatches(prefix string) {
-	o.currentPrefix = strings.ToUpper(prefix)
-	o.redrawGrid()
+	if o == nil || o.raw == nil {
+		return
+	}
+
+	o.updateGridMatches(prefix)
 }
 
 func (o *x11Overlay) ShowSubgrid(cell *domainGrid.Cell, _ gridcomponent.Style) {
@@ -154,13 +127,14 @@ func (o *x11Overlay) ShowSubgrid(cell *domainGrid.Cell, _ gridcomponent.Style) {
 		return
 	}
 
-	o.currentSubgrid = cell
-	o.Clear()
-	o.drawSubgrid(cell.Bounds(), o.cachedStyle)
-	C.neru_x11_overlay_flush(o.raw)
+	o.showSubgrid(cell)
 }
 
 func (o *x11Overlay) SetHideUnmatched(hide bool) {
+	if o == nil {
+		return
+	}
+
 	o.hideUnmatched = hide
 }
 
@@ -168,12 +142,8 @@ func (o *x11Overlay) DrawGrid(g *domainGrid.Grid, input string, style gridcompon
 	if o == nil || o.raw == nil || g == nil {
 		return
 	}
-	o.cachedGrid = g
-	o.cachedStyle = style
-	o.currentPrefix = strings.ToUpper(input)
-	o.currentSubgrid = nil
 
-	o.redrawGrid()
+	o.drawGrid(g, input, style)
 }
 
 func (o *x11Overlay) DrawRecursiveGrid(
@@ -197,7 +167,6 @@ func (o *x11Overlay) DrawRecursiveGrid(
 	)
 }
 
-//nolint:mnd
 func (o *x11Overlay) DrawRecursiveGridWithSubKeyPreview(
 	bounds image.Rectangle,
 	depth int,
@@ -216,55 +185,11 @@ func (o *x11Overlay) DrawRecursiveGridWithSubKeyPreview(
 		return
 	}
 
-	// Translate the screen-local bounds and virtual-pointer position onto the
-	// active monitor. Everything downstream (cell rects, animation from/to
-	// rects, the pointer) derives from these, so the whole frame lands on the
-	// right monitor.
-	bounds = o.offset(bounds)
-	virtualPointer.Position = virtualPointer.Position.Add(o.originOffset)
-
-	shouldAnimate := animEnabled && o.hasLast && depth != o.lastDepth &&
-		!o.lastBounds.Empty()
-
-	cellRects := recursivegrid.ComputeGridCells(bounds, gridCols, gridRows)
-
-	if shouldAnimate {
-		duration := time.Duration(animDurationMS) * time.Millisecond
-		if duration <= 0 {
-			duration = 50 * time.Millisecond
-		}
-
-		fromRects := o.buildFromRects(cellRects, bounds)
-		keyRunes := []rune(strings.ToUpper(keys))
-		nextKeyRunes := []rune(strings.ToUpper(nextKeys))
-
-		animStop := make(chan struct{})
-		animDone := make(chan struct{})
-		o.animStop = animStop
-		o.animDone = animDone
-
-		o.startGridAnimation(
-			fromRects, cellRects,
-			keyRunes, nextKeyRunes,
-			nextGridCols, nextGridRows,
-			style, virtualPointer,
-			duration, animStop, animDone,
-		)
-	} else {
-		o.clearAndDraw(
-			cellRects, keys, gridCols, gridRows,
-			nextKeys, nextGridCols, nextGridRows,
-			style, virtualPointer,
-		)
-	}
-
-	o.hasLast = true
-	o.lastBounds = bounds
-	o.lastCols = gridCols
-	o.lastRows = gridRows
-	o.lastDepth = depth
-	o.lastRects = make([]image.Rectangle, len(cellRects))
-	copy(o.lastRects, cellRects)
+	o.drawRecursiveGridWithSubKeyPreview(
+		bounds, depth, keys, gridCols, gridRows,
+		nextKeys, nextGridCols, nextGridRows,
+		style, virtualPointer, animEnabled, animDurationMS,
+	)
 }
 
 func (o *x11Overlay) DrawBadge(
@@ -277,18 +202,7 @@ func (o *x11Overlay) DrawBadge(
 		return
 	}
 
-	fontSize := style.fontSize
-	if fontSize <= 0 {
-		fontSize = 14
-	}
-	// Size the badge from the scaled font so it fits the text drawTextCentered
-	// renders. The manager sizes its clear rect with the same factor (Scale()).
-	scaledStyle := style
-	scaledStyle.fontSize = fontSize * o.s()
-	rect := badgeBounds(posX, posY, text, scaledStyle)
-
-	o.drawRect(rect, colors.background, colors.border, max(style.borderWidth, 1))
-	o.drawTextCentered(text, rect, style.fontFamily, fontSize, colors.text)
+	o.drawBadge(posX, posY, text, colors, style)
 }
 
 func (o *x11Overlay) Flush() {
@@ -298,11 +212,6 @@ func (o *x11Overlay) Flush() {
 	C.neru_x11_overlay_flush(o.raw)
 }
 
-// DrawMonitorSelect renders one centered, labeled panel per monitor for the
-// interactive monitor picker. Panels reuse the existing rounded-rect + text
-// primitives (no dedicated C), and are sized from the scaled font (see
-// monitorSelectPanelLayout) so they stay legible on HiDPI. The label is drawn
-// with the matched/selected color when it has a matched prefix or is selected.
 func (o *x11Overlay) DrawMonitorSelect(
 	targets []manager.MonitorSelectTarget,
 	style manager.MonitorSelectStyle,
@@ -311,36 +220,7 @@ func (o *x11Overlay) DrawMonitorSelect(
 		return
 	}
 
-	o.cancelAnimation()
-	o.hasLast = false
-	C.neru_x11_overlay_clear(o.raw)
-
-	spec := newMonitorSelectDrawSpec(style)
-	for _, target := range targets {
-		if target.Bounds.Empty() {
-			continue
-		}
-
-		if spec.hasBackdrop {
-			o.drawRect(target.Bounds, spec.backdrop, 0, 0)
-		}
-
-		panel, labelRect, subtitleRect, radius := monitorSelectPanelLayout(
-			target.Bounds, target.Label, target.Subtitle, style, o.s(),
-		)
-		o.drawRoundedRect(panel, radius, spec.background, spec.border, spec.borderWidth)
-
-		o.drawTextCentered(target.Label, labelRect, style.FontFamily, spec.labelFont, spec.text)
-
-		if target.Subtitle != "" {
-			o.drawTextCentered(
-				target.Subtitle, subtitleRect,
-				monitorSelectSubtitleFamily(style), spec.subtitleFont, spec.subtitleText,
-			)
-		}
-	}
-
-	C.neru_x11_overlay_flush(o.raw)
+	o.drawMonitorSelect(targets, style)
 }
 
 func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscomponent.StyleMode) {
@@ -348,84 +228,9 @@ func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscom
 		return
 	}
 
-	o.cancelAnimation()
-	o.hasLast = false
-	C.neru_x11_overlay_clear(o.raw)
-	fontSize := float64(max(style.FontSize(), 1))
-	for _, hint := range hintsSlice {
-		// hint.Position() is the element center in screen-local coordinates;
-		// translate it onto the active monitor.
-		pos := hint.Position().Add(o.originOffset)
-		if style.BoundaryHighlightEnabled() {
-			boundary := image.Rect(
-				pos.X-hint.Size().X/2,
-				pos.Y-hint.Size().Y/2,
-				pos.X+hint.Size().X/2,
-				pos.Y+hint.Size().Y/2,
-			)
-			o.drawRect(
-				boundary,
-				badge.ParseHexARGB(style.BoundaryBackgroundColor()),
-				badge.ParseHexARGB(style.BoundaryBorderColor()),
-				float64(max(style.BoundaryBorderWidth(), 0)),
-			)
-		}
-
-		textColor := style.TextColor()
-		if hint.MatchedPrefix() != "" {
-			textColor = style.MatchedTextColor()
-		}
-
-		label := hint.Label()
-		// Size the badge from the scaled font so it fits the text drawTextCentered
-		// renders (which applies the same o.s() factor). Position stays in device
-		// pixels; the badge grows around the target.
-		sfont := fontSize * o.s()
-		paddingX := badge.AutoPadding(sfont, style.PaddingX(), true)
-		paddingY := badge.AutoPadding(sfont, style.PaddingY(), false)
-		badgeWidth := badge.EstimateTextWidth(label, sfont) + paddingX*paddingMultiplier
-		badgeHeight := badge.EstimateTextHeight(sfont) + paddingY*paddingMultiplier
-
-		radius := style.BorderRadius()
-		if radius < 0 {
-			radius = min(badgeHeight/centeredRectDivisor, hintAutoRadiusMax)
-		}
-		// Cap the radius so a top/bottom badge keeps a flat edge for the tail.
-		radius = hintBadgeRadius(radius, badgeWidth, style.Placement())
-
-		// pos is the element center (set in modes/hints.go). The badge is
-		// centered horizontally on it and placed above / on / below the center
-		// to match macOS; top/bottom placement also draws a connector arrow
-		// pointing back at the target.
-		badgeRect, arrow, hasArrow := hintBadgePlacement(
-			pos, badgeWidth, badgeHeight, radius, style.Placement(),
-		)
-
-		fill := badge.ParseHexARGB(style.BackgroundColor())
-		border := badge.ParseHexARGB(style.BorderColor())
-		borderWidth := float64(max(style.BorderWidth(), 0))
-
-		// Badge and connector tail are drawn as one filled+stroked outline so
-		// translucent colors don't double-composite at the junction.
-		o.drawHintBadge(
-			badgeRect, float64(radius), hintTailEdge(badgeRect, arrow, hasArrow), arrow,
-			fill, border, borderWidth,
-		)
-		o.drawTextCentered(
-			label, badgeRect,
-			style.FontFamily(),
-			fontSize,
-			badge.ParseHexARGB(textColor),
-		)
-	}
-
-	C.neru_x11_overlay_flush(o.raw)
+	o.drawHints(hintsSlice, style)
 }
 
-// DrawMouseActionIndicator animates a transient click indicator centered on
-// point. It runs on this overlay's dedicated indicator window, independent of
-// the mode overlay's show/hide lifecycle, so it survives the mode exit that
-// immediately follows a click.
 func (o *x11Overlay) DrawMouseActionIndicator(
 	point image.Point,
 	style ports.MouseActionIndicatorStyle,
@@ -434,121 +239,7 @@ func (o *x11Overlay) DrawMouseActionIndicator(
 		return
 	}
 
-	// Cancel any in-flight indicator animation before starting a new one.
-	o.cancelAnimation()
-
-	duration := time.Duration(style.DurationMS) * time.Millisecond
-	if duration <= 0 {
-		duration = defaultMouseActionDuration
-	}
-
-	animStop := make(chan struct{})
-	animDone := make(chan struct{})
-	o.animStop = animStop
-	o.animDone = animDone
-
-	C.neru_x11_overlay_show(o.raw)
-	o.startMouseActionAnimation(point, style, duration, animStop, animDone)
-}
-
-func (o *x11Overlay) startMouseActionAnimation(
-	point image.Point,
-	style ports.MouseActionIndicatorStyle,
-	duration time.Duration,
-	stopCh chan struct{},
-	doneCh chan struct{},
-) {
-	startTime := time.Now()
-
-	fillBase := badge.ParseHexARGB(style.BackgroundColor)
-	borderBase := badge.ParseHexARGB(style.BorderColor)
-	lineWidth := float64(max(style.BorderWidth, 0))
-	baseSize := float64(max(style.Size, 1)) * o.s()
-	isSquare := style.Shape == "square"
-
-	renderFrame := func(rawProgress float64) {
-		eased := applyEasing(style.Easing, rawProgress)
-		scale := max(lerp(style.StartScale, style.EndScale, eased), 0)
-		opacity := lerp(style.StartOpacity, style.EndOpacity, eased)
-		diameter := baseSize * scale
-		rect := mouseActionIndicatorRect(point, diameter)
-		fill := applyOpacity(fillBase, opacity)
-		border := applyOpacity(borderBase, opacity)
-
-		C.neru_x11_overlay_clear_buffered(o.raw)
-		if isSquare {
-			o.drawRect(rect, fill, border, lineWidth)
-		} else {
-			o.drawRoundedRect(rect, diameter/centeredRectDivisor, fill, border, lineWidth)
-		}
-		C.neru_x11_overlay_flush(o.raw)
-	}
-
-	go func() {
-		defer close(doneCh)
-		defer func() {
-			o.cancelMu.Lock()
-			if o.animStop == stopCh {
-				o.animStop = nil
-			}
-			if o.animDone == doneCh {
-				o.animDone = nil
-			}
-			o.cancelMu.Unlock()
-		}()
-
-		for {
-			select {
-			case <-stopCh:
-				return
-			default:
-			}
-
-			elapsed := time.Since(startTime)
-			rawProgress := min(float64(elapsed)/float64(duration), 1.0)
-
-			renderStart := time.Now()
-
-			if o.renderMu != nil {
-				o.renderMu.Lock()
-				select {
-				case <-stopCh:
-					o.renderMu.Unlock()
-
-					return
-				default:
-				}
-			}
-			renderFrame(rawProgress)
-			if o.renderMu != nil {
-				o.renderMu.Unlock()
-			}
-
-			if rawProgress >= 1.0 {
-				// Finished: clear and unmap the dedicated window so the fully
-				// faded indicator does not linger on screen.
-				if o.renderMu != nil {
-					o.renderMu.Lock()
-				}
-				C.neru_x11_overlay_clear(o.raw)
-				C.neru_x11_overlay_hide(o.raw)
-				if o.renderMu != nil {
-					o.renderMu.Unlock()
-				}
-
-				return
-			}
-
-			sleepFor := animationFrameDur - time.Since(renderStart)
-			if sleepFor > 0 {
-				select {
-				case <-stopCh:
-					return
-				case <-time.After(sleepFor):
-				}
-			}
-		}
-	}()
+	o.drawMouseActionIndicator(point, style)
 }
 
 // s returns the overlay's HiDPI scale factor, guarding against a zero value.
@@ -561,442 +252,113 @@ func (o *x11Overlay) s() float64 {
 }
 
 func (o *x11Overlay) setRenderMu(mu *sync.Mutex) {
-	o.renderMu = mu
+	o.setRenderMuShared(mu)
 }
 
-func (o *x11Overlay) cancelAnimation() {
-	o.cancelMu.Lock()
-
-	var doneCh chan struct{}
-	if o.animStop != nil {
-		close(o.animStop)
-		o.animStop = nil
-	}
-	if o.animDone != nil {
-		doneCh = o.animDone
-		o.animDone = nil
-	}
-	o.cancelMu.Unlock()
-
-	if doneCh != nil {
-		<-doneCh
-	}
-}
-
-//nolint:mnd,varnamelen
-func (o *x11Overlay) buildFromRects(
-	toRects []image.Rectangle,
-	bounds image.Rectangle,
-) []image.Rectangle {
-	if len(o.currentAnimRects) == len(toRects) {
-		from := make([]image.Rectangle, len(o.currentAnimRects))
-		copy(from, o.currentAnimRects)
-
-		return from
-	}
-
-	if len(o.lastRects) == len(toRects) {
-		from := make([]image.Rectangle, len(o.lastRects))
-		copy(from, o.lastRects)
-
-		return from
-	}
-
-	if o.lastBounds.Empty() {
-		from := make([]image.Rectangle, len(toRects))
-		for idx, rect := range toRects {
-			cx := rect.Min.X + rect.Dx()/2
-			cy := rect.Min.Y + rect.Dy()/2
-			from[idx] = image.Rect(cx, cy, cx, cy)
-		}
-
-		return from
-	}
-
-	fromBounds := o.lastBounds
-	fw := float64(fromBounds.Dx())
-	fh := float64(fromBounds.Dy())
-	dw := float64(bounds.Dx())
-	dh := float64(bounds.Dy())
-	from := make([]image.Rectangle, len(toRects))
-	for idx, rect := range toRects {
-		nx := (float64(rect.Min.X+rect.Dx()/2) - float64(bounds.Min.X)) / dw
-		ny := (float64(rect.Min.Y+rect.Dy()/2) - float64(bounds.Min.Y)) / dh
-		cx := int(float64(fromBounds.Min.X) + nx*fw)
-		cy := int(float64(fromBounds.Min.Y) + ny*fh)
-		rw := rect.Dx()
-		rh := rect.Dy()
-		from[idx] = image.Rect(
-			cx-rw/2, cy-rh/2,
-			cx+rw/2, cy+rh/2,
-		)
-	}
-
-	return from
-}
-
-//nolint:varnamelen
-func (o *x11Overlay) startGridAnimation(
-	fromRects, toRects []image.Rectangle,
-	keyRunes, nextKeyRunes []rune,
-	nextGridCols, nextGridRows int,
-	style recursivegridcomponent.Style,
-	virtualPointer recursivegridcomponent.VirtualPointerState,
-	duration time.Duration,
-	stopCh chan struct{},
-	doneCh chan struct{},
-) {
-	startTime := time.Now()
-
-	renderFrame := func(rawProgress float64) {
-		if rawProgress >= 1.0 {
-			rawProgress = 1.0
-		}
-		progress := easeInOut(rawProgress)
-
-		interpCells := make([]image.Rectangle, len(toRects))
-		for i := range toRects {
-			src := fromRects[i]
-			dst := toRects[i]
-			interpCells[i] = image.Rect(
-				int(lerp(float64(src.Min.X), float64(dst.Min.X), progress)),
-				int(lerp(float64(src.Min.Y), float64(dst.Min.Y), progress)),
-				int(lerp(float64(src.Max.X), float64(dst.Max.X), progress)),
-				int(lerp(float64(src.Max.Y), float64(dst.Max.Y), progress)),
-			)
-		}
-
-		o.currentAnimRects = interpCells
-
-		C.neru_x11_overlay_clear_buffered(o.raw)
-		o.drawFrame(
-			interpCells,
-			keyRunes,
-			nextKeyRunes,
-			nextGridCols,
-			nextGridRows,
-			style,
-			virtualPointer,
-		)
-	}
-
-	go func() {
-		defer close(doneCh)
-		defer func() {
-			o.cancelMu.Lock()
-			if o.animStop == stopCh {
-				o.animStop = nil
-			}
-			if o.animDone == doneCh {
-				o.animDone = nil
-			}
-			o.cancelMu.Unlock()
-		}()
-
-		for {
-			select {
-			case <-stopCh:
-				return
-			default:
-			}
-
-			elapsed := time.Since(startTime)
-			rawProgress := float64(elapsed) / float64(duration)
-			if rawProgress >= 1.0 {
-				rawProgress = 1.0
-			}
-
-			renderStart := time.Now()
-
-			mu := o.renderMu
-			if mu != nil {
-				mu.Lock()
-				select {
-				case <-stopCh:
-					mu.Unlock()
-
-					return
-				default:
-				}
-			}
-			renderFrame(rawProgress)
-			if mu != nil {
-				mu.Unlock()
-			}
-
-			if rawProgress >= 1.0 {
-				return
-			}
-
-			renderDur := time.Since(renderStart)
-			sleepFor := animationFrameDur - renderDur
-			if sleepFor > 0 {
-				select {
-				case <-stopCh:
-					return
-				case <-time.After(sleepFor):
-				}
-			}
-		}
-	}()
-}
-
-func (o *x11Overlay) clearAndDraw(
-	cellRects []image.Rectangle,
-	keys string, gridCols, gridRows int,
-	nextKeys string, nextGridCols, nextGridRows int,
-	style recursivegridcomponent.Style,
-	virtualPointer recursivegridcomponent.VirtualPointerState,
-) {
-	if o == nil || o.raw == nil {
-		return
-	}
-
-	o.currentAnimRects = nil
-
-	keyRunes := []rune(strings.ToUpper(keys))
-	nextKeyRunes := []rune(strings.ToUpper(nextKeys))
-
-	C.neru_x11_overlay_clear(o.raw)
-	o.drawFrame(
-		cellRects,
-		keyRunes,
-		nextKeyRunes,
-		nextGridCols,
-		nextGridRows,
-		style,
-		virtualPointer,
-	)
-}
-
-func (o *x11Overlay) drawFrame(
-	cellRects []image.Rectangle,
-	keyRunes, nextKeyRunes []rune,
-	nextGridCols, nextGridRows int,
-	style recursivegridcomponent.Style,
-	virtualPointer recursivegridcomponent.VirtualPointerState,
-) {
-	drawSubPreview := style.SubKeyPreview() && len(nextKeyRunes) > 0 &&
-		nextGridCols > 0 && nextGridRows > 0
-
-	for idx, cell := range cellRects {
-		if cell.Empty() {
-			continue
-		}
-
-		fill := style.HighlightColorARGB()
-		if fill == 0 {
-			fill = subgridCellBackground
-		}
-
-		o.drawRect(cell, fill, style.LineColorARGB(), style.LineWidthF())
-		if idx < len(keyRunes) {
-			label := style.LabelChar()
-			if label == "" {
-				label = string(keyRunes[idx])
-			}
-
-			if shouldShowLabel(cell, style) {
-				if style.LabelBackground() {
-					o.drawLabelBackground(label, cell, style)
-				}
-
-				o.drawTextCentered(
-					label, cell, style.FontFamily(),
-					style.LabelFontSize(), style.TextColorARGB(),
-				)
-			}
-
-			if drawSubPreview &&
-				shouldShowSubKeyPreview(cell, style, nextGridCols, nextGridRows) {
-				o.drawSubKeyMiniGrid(cell, nextKeyRunes,
-					nextGridCols, nextGridRows, style)
-			}
-		}
-	}
-
-	if virtualPointer.Visible {
-		o.drawVirtualPointer(virtualPointer)
-	}
-
-	C.neru_x11_overlay_flush(o.raw)
-}
-
-//nolint:mnd,varnamelen
-func (o *x11Overlay) drawVirtualPointer(vp recursivegridcomponent.VirtualPointerState) {
-	vpChar := vp.Char
-	if vpChar == "" {
-		vpChar = "\u25CF"
-	}
-
-	fontName := ports.ResolveFont(vp.FontName, false)
-	fontSize := float64(vp.Size)
-	halfSize := max(vp.Size/2, 1)
-	vpBounds := image.Rect(
-		vp.Position.X-halfSize,
-		vp.Position.Y-halfSize,
-		vp.Position.X+halfSize,
-		vp.Position.Y+halfSize,
-	)
-	o.drawTextCentered(vpChar, vpBounds, fontName, fontSize,
-		badge.ParseHexARGB(vp.FillColor))
-}
-
-func (o *x11Overlay) redrawGrid() {
-	if o == nil || o.raw == nil || o.cachedGrid == nil {
-		return
-	}
-
-	C.neru_x11_overlay_clear(o.raw)
-	style := o.cachedStyle
-	prefix := o.currentPrefix
-
-	for _, cell := range o.cachedGrid.AllCells() {
-		label := strings.ToUpper(cell.Coordinate())
-		matched := strings.HasPrefix(label, prefix)
-		if o.hideUnmatched && prefix != "" && !matched {
-			continue
-		}
-
-		fill := style.BackgroundColorARGB()
-		text := style.TextColorARGB()
-		border := style.LineColorARGB()
-		if matched && prefix != "" {
-			fill = style.MatchedBackgroundColorARGB()
-			text = style.MatchedTextColorARGB()
-			border = style.MatchedBorderColorARGB()
-		}
-		cellBounds := o.offset(cell.Bounds())
-		o.drawRect(cellBounds, fill, border, style.LineWidth())
-		o.drawTextCentered(label, cellBounds,
-			style.FontFamily(), style.LabelFontSize(), text)
-	}
-
-	if o.currentSubgrid != nil {
-		o.drawSubgrid(o.currentSubgrid.Bounds(), style)
-	}
-	C.neru_x11_overlay_flush(o.raw)
-}
-
-func (o *x11Overlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Style) {
-	// bounds is screen-local; place the subgrid on the active monitor.
-	bounds = o.offset(bounds)
-	keyRunes := []rune("ASDFGHJKL")
-	if o.sublayerKeys != "" {
-		keyRunes = []rune(strings.ToUpper(o.sublayerKeys))
-	}
-	maxKeys := min(len(keyRunes), subgridCols*subgridRows)
-	xBreaks := make([]int, subgridCols+1)
-	yBreaks := make([]int, subgridRows+1)
-	xBreaks[0] = bounds.Min.X
-	yBreaks[0] = bounds.Min.Y
-
-	for i := 1; i <= subgridCols; i++ {
-		xBreaks[i] = bounds.Min.X + int(
-			float64(i)*float64(bounds.Dx())/float64(subgridCols)+
-				subgridHalfPixel,
-		)
-	}
-	for i := 1; i <= subgridRows; i++ {
-		yBreaks[i] = bounds.Min.Y + int(
-			float64(i)*float64(bounds.Dy())/float64(subgridRows)+
-				subgridHalfPixel,
-		)
-	}
-	xBreaks[subgridCols] = bounds.Max.X
-	yBreaks[subgridRows] = bounds.Max.Y
-
-	index := 0
-	for row := range subgridRows {
-		for col := range subgridCols {
-			if index >= maxKeys {
-				break
-			}
-
-			cell := image.Rect(
-				xBreaks[col], yBreaks[row],
-				xBreaks[col+1], yBreaks[row+1],
-			)
-			o.drawRect(cell, style.BackgroundColorARGB(),
-				style.LineColorARGB(), style.LineWidth())
-			o.drawTextCentered(
-				string(keyRunes[index]), cell,
-				style.FontFamily(),
-				style.LabelFontSize()*subgridFontScale,
-				style.TextColorARGB(),
-			)
-			index++
-		}
-	}
-}
-
-// Stroke widths scale with the HiDPI factor here so every draw path (grid,
-// hints, badges, indicator) gets consistent line weight without per-call-site
-// scaling. Element geometry that must fit scaled text is sized by the callers.
-// setOriginOffset stores the active screen origin used to translate
-// screen-local grid/recursive-grid/hint coordinates onto the correct monitor.
 func (o *x11Overlay) setOriginOffset(origin image.Point) {
 	if o == nil {
 		return
 	}
 
-	o.originOffset = origin
+	o.sharedOverlay.setOriginOffset(origin)
 }
 
-// offset translates a screen-local rectangle into global desktop coordinates.
-func (o *x11Overlay) offset(r image.Rectangle) image.Rectangle {
-	return r.Add(o.originOffset)
+// --- overlaySurface primitives ---
+
+func (o *x11Overlay) surfaceScale() float64 { return o.s() }
+
+// ensureBuffers is a no-op: X11 draws into a single server-side pixmap.
+func (o *x11Overlay) ensureBuffers() {}
+
+// beginFrame always succeeds: X11 has no buffer pool to run dry.
+func (o *x11Overlay) beginFrame() bool { return true }
+
+func (o *x11Overlay) surfaceClear() {
+	C.neru_x11_overlay_clear(o.raw)
 }
 
-func (o *x11Overlay) drawRect(
+// clearFrame uses the double-buffered clear so animation frames repaint
+// without flicker.
+func (o *x11Overlay) clearFrame() {
+	C.neru_x11_overlay_clear_buffered(o.raw)
+}
+
+func (o *x11Overlay) surfaceClearRect(rect image.Rectangle) {
+	C.neru_x11_overlay_clear_rect(
+		o.raw,
+		C.int(rect.Min.X),
+		C.int(rect.Min.Y),
+		C.int(rect.Dx()),
+		C.int(rect.Dy()),
+	)
+}
+
+func (o *x11Overlay) surfaceFlush() {
+	C.neru_x11_overlay_flush(o.raw)
+}
+
+func (o *x11Overlay) surfaceHide() {
+	C.neru_x11_overlay_hide(o.raw)
+}
+
+func (o *x11Overlay) showIndicator() {
+	C.neru_x11_overlay_show(o.raw)
+}
+
+// finishIndicator clears before unmapping so no stale pixmap shows on the
+// next map.
+func (o *x11Overlay) finishIndicator() {
+	C.neru_x11_overlay_clear(o.raw)
+	C.neru_x11_overlay_hide(o.raw)
+}
+
+func (o *x11Overlay) syncBeforeAnimation() {}
+
+func (o *x11Overlay) rectPrim(
 	bounds image.Rectangle,
-	fill uint32, border uint32, lineWidth float64,
+	fill, border uint32, lineWidth float64,
 ) {
 	C.neru_x11_overlay_rect(
 		o.raw,
 		C.double(bounds.Min.X), C.double(bounds.Min.Y),
 		C.double(bounds.Dx()), C.double(bounds.Dy()),
-		C.uint(fill), C.uint(border), C.double(lineWidth*o.s()),
+		C.uint(fill), C.uint(border), C.double(lineWidth),
 	)
 }
 
-func (o *x11Overlay) drawRoundedRect(
+func (o *x11Overlay) roundedRectPrim(
 	bounds image.Rectangle,
 	radius float64,
-	fill uint32, border uint32, lineWidth float64,
+	fill, border uint32, lineWidth float64,
 ) {
 	C.neru_x11_overlay_rounded_rect(
 		o.raw,
 		C.double(bounds.Min.X), C.double(bounds.Min.Y),
 		C.double(bounds.Dx()), C.double(bounds.Dy()),
 		C.double(radius),
-		C.uint(fill), C.uint(border), C.double(lineWidth*o.s()),
+		C.uint(fill), C.uint(border), C.double(lineWidth),
 	)
 }
 
-func (o *x11Overlay) drawHintBadge(
-	badge image.Rectangle, radius float64, edge int, arrow hintArrowTriangle,
-	fill uint32, border uint32, lineWidth float64,
+func (o *x11Overlay) hintBadgePrim(
+	badgeRect image.Rectangle, radius float64, edge int, arrow hintArrowTriangle,
+	fill, border uint32, lineWidth float64,
 ) {
 	C.neru_x11_overlay_hint_badge(
 		o.raw,
-		C.double(badge.Min.X), C.double(badge.Min.Y),
-		C.double(badge.Dx()), C.double(badge.Dy()),
+		C.double(badgeRect.Min.X), C.double(badgeRect.Min.Y),
+		C.double(badgeRect.Dx()), C.double(badgeRect.Dy()),
 		C.double(radius),
 		C.int(edge),
 		C.double(arrow.baseLeft.X), C.double(arrow.baseRight.X),
 		C.double(arrow.tip.X), C.double(arrow.tip.Y),
-		C.uint(fill), C.uint(border), C.double(lineWidth*o.s()),
+		C.uint(fill), C.uint(border), C.double(lineWidth),
 	)
 }
 
-// drawTextCentered applies the HiDPI scale to the font size centrally, so every
-// label/badge caller passes its base (logical) font size and text renders at the
-// device-appropriate size. Callers that size geometry around the text must use
-// the same scaled font (fontSize * o.s()).
-func (o *x11Overlay) drawTextCentered(
-	text string, bounds image.Rectangle,
-	fontFamily string, fontSize float64, color uint32,
+func (o *x11Overlay) textPrim(
+	text, fontFamily string,
+	centerX, centerY, fontSize float64, color uint32,
 ) {
 	cText := C.CString(text)
 	cFontFamily := C.CString(fontFamily)
@@ -1006,67 +368,8 @@ func (o *x11Overlay) drawTextCentered(
 
 	C.neru_x11_overlay_text(
 		o.raw, cText, cFontFamily,
-		C.double(bounds.Min.X+bounds.Dx()/2),
-		C.double(bounds.Min.Y+bounds.Dy()/2),
-		C.double(fontSize*o.s()), C.uint(color),
+		C.double(centerX),
+		C.double(centerY),
+		C.double(fontSize), C.uint(color),
 	)
-}
-
-func (o *x11Overlay) drawLabelBackground(
-	label string, cell image.Rectangle,
-	style recursivegridcomponent.Style,
-) {
-	// Match the scaled font that drawTextCentered renders for the label.
-	fontSize := style.LabelFontSize() * o.s()
-	paddingX := badge.AutoPadding(fontSize,
-		style.LabelBackgroundPaddingX(), true)
-	paddingY := badge.AutoPadding(fontSize,
-		style.LabelBackgroundPaddingY(), false)
-	width := badge.EstimateTextWidth(label, fontSize) +
-		paddingX*paddingMultiplier
-	height := badge.EstimateTextHeight(fontSize) +
-		paddingY*paddingMultiplier
-	rect := centeredRect(cell, width, height)
-	o.drawRect(rect, style.LabelBackgroundColorARGB(),
-		style.LineColorARGB(), max(style.LabelBackgroundBorderWidthF(), 0))
-}
-
-//nolint:mnd
-func (o *x11Overlay) drawSubKeyMiniGrid(
-	cell image.Rectangle,
-	nextKeyRunes []rune,
-	nextGridCols int, nextGridRows int,
-	style recursivegridcomponent.Style,
-) {
-	subCells := recursivegrid.ComputeGridCells(cell, nextGridCols, nextGridRows)
-	centerIdx := -1
-
-	if nextGridCols%2 == 1 && nextGridRows%2 == 1 {
-		centerIdx = (nextGridRows/2)*nextGridCols + nextGridCols/2
-	}
-
-	subIndex := 0
-	for idx, subCell := range subCells {
-		if idx == centerIdx {
-			subIndex++
-
-			continue
-		}
-
-		if subIndex >= len(nextKeyRunes) {
-			return
-		}
-
-		subLabel := style.SubKeyPreviewLabelChar()
-		if subLabel == "" {
-			subLabel = string(nextKeyRunes[subIndex])
-		}
-
-		o.drawTextCentered(
-			subLabel, subCell,
-			style.FontFamily(), style.SubKeyPreviewFontSizeF(),
-			style.SubKeyPreviewTextColorARGB(),
-		)
-		subIndex++
-	}
 }


### PR DESCRIPTION
## Description

This PR reworks the two Linux overlay backends so their drawing logic exists once instead of twice. A fix or feature on one backend silently didn't exist on the other until someone noticed.

All shared rendering, layout, multi-monitor offset and animation behavior now lives in one place, and each backend keeps only what is genuinely its own: how it acquires and clears drawing buffers, how it probes HiDPI scale, how its click-indicator surface maps and unmaps, and (on Wayland) the keyboard poller. Rendering behavior on both backends is unchanged, including the Wayland frame-drop-when-no-buffer semantics and the animation shutdown ordering that prevents a deadlock during mode exit.

## Related Issues

N/A

## Target Platform

- [x] Linux (X11)
- [x] Linux (Wayland)

## Type of Change

- [x] `refactor` — Code change that neither fixes a bug nor adds a feature

## Cross-Platform Checklist

- [x] Follows the platform file slots (`*_linux_x11.go`, `*_linux_wayland.go`, …) — the shared file and both backends stay in the existing Linux overlay adapter layout, build-tagged `linux && cgo`
- [x] Capability matrix untouched — N/A, no capability status changes
- [x] Docs updated — N/A, no documented fact changes; docs describe the adapter boundary, not this internal layout

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — plus the Docker-only checks this change actually exercises: `just lint-cross` (full-CGO Linux + Windows lint, 0 issues), `just test-linux`, `just test-linux-nocgo`
- [x] Tests added/updated for new or changed functionality — N/A, pure structural move; the existing stub contract test and Linux suites pin the behavior and needed zero changes
- [x] Documentation updated (if applicable) — N/A, see above
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The shared implementation drives a small unexported primitive interface per backend: HiDPI scale, buffer lifecycle (prepare, acquire-or-drop-frame, two clear variants), flush/hide, the indicator map/unmap pair, a pre-animation sync hook, and the four cgo draw calls. Backend-specific quirks were preserved deliberately rather than "cleaned up": Wayland's buffer acquisition retries once via a display sync then drops the frame; its indicator teardown hides without clearing (clearing would write into an unselected buffer) while X11 clears then hides; badge drawing prepares buffers without selecting a frame; and the animation goroutines re-check their stop channel after acquiring the render lock — removing that re-check deadlocks mode exit against a running animation.

Two design points worth reviewing: exported backend methods remain thin nil-guarded delegates instead of relying on Go method promotion, because a promoted method called through a nil backend pointer panics before any receiver guard can run and the overlay manager depends on nil-safe calls. And the X11-only HiDPI scale is now applied centrally in the shared draw helpers (fonts, stroke widths, text-fitted geometry) with Wayland reporting scale 1, replacing per-call-site multiplication — the rendered output is identical on both backends.
