### PR TITLE
feat(smooth_cursor): animate relative cursor moves with a fixed per-move duration

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -392,6 +392,12 @@ steps = 10                                  # Number of intermediate positions
 max_duration = 200                          # Maximum animation duration in ms
 duration_per_pixel = 0.1                    # Ms per pixel for adaptive duration
 
+# Smooth cursor for relative (keyboard-driven) movement, e.g. move_mouse_relative.
+# Uses a fixed duration per move so larger deltas move proportionally faster.
+[smooth_cursor.relative]
+enabled = false                             # Animate relative mouse movement (macOS only)
+duration = 50                               # Fixed animation duration per move in ms
+
 # Smooth scroll (animates scroll actions with eased chunking)
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#smooth_scroll
 [smooth_scroll]

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -391,12 +391,7 @@ move_mouse_enabled = false                  # Enable smooth mouse movement
 steps = 10                                  # Number of intermediate positions
 max_duration = 200                          # Maximum animation duration in ms
 duration_per_pixel = 0.1                    # Ms per pixel for adaptive duration
-
-# Smooth cursor for relative (keyboard-driven) movement, e.g. move_mouse_relative.
-# Uses a fixed duration per move so larger deltas move proportionally faster.
-[smooth_cursor.relative]
-enabled = false                             # Animate relative mouse movement (macOS only)
-duration = 50                               # Fixed animation duration per move in ms
+relative_duration = 50                      # Fixed duration per relative (hjkl) move in ms (macOS only)
 
 # Smooth scroll (animates scroll actions with eased chunking)
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#smooth_scroll

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -391,7 +391,7 @@ move_mouse_enabled = false                  # Enable smooth mouse movement
 steps = 10                                  # Number of intermediate positions
 max_duration = 200                          # Maximum animation duration in ms
 duration_per_pixel = 0.1                    # Ms per pixel for adaptive duration
-relative_duration = 50                      # Fixed duration per relative (hjkl) move in ms (macOS only)
+relative_movement_duration = 50             # Fixed duration per relative (hjkl) move in ms (macOS only)
 
 # Smooth scroll (animates scroll actions with eased chunking)
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#smooth_scroll

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -105,6 +105,7 @@ Every option not listed here behaves the same on all three platforms.
 | `[monitor_select]`                        | Yes   | Yes   | No      | Windows: the mode returns `ERR_NOT_SUPPORTED`.       |
 | `[virtual_pointer]`                       | Yes   | No    | No      | Ignored; pairs with macOS-only cursor hiding.        |
 | `[smooth_cursor]`                         | Yes   | Yes   | No      | Windows: cursor moves instantly.                     |
+| `[smooth_cursor.relative]`                | Yes   | No    | No      | Linux and Windows: relative moves stay instant.      |
 | `[smooth_scroll]`                         | Yes   | No    | No      | Linux and Windows: scrolling is instant.             |
 | `[recursive_grid.animation]`              | Yes   | Yes   | No      | Windows: depth transitions are not animated.         |
 
@@ -1419,6 +1420,37 @@ move_mouse_enabled = false
 steps = 10
 max_duration = 200
 duration_per_pixel = 0.1
+```
+
+### [smooth_cursor.relative]
+
+Animates relative (keyboard-driven) movement — `move_mouse_relative`, i.e. the
+default hjkl bindings. Off by default: relative moves warp instantly, as before.
+
+Jumps derive their duration from the distance (`duration_per_pixel`), which
+yields constant velocity — fine for a one-shot jump, but under held-key repeat
+it makes a 50px step no faster than a 10px one. Relative moves therefore use a
+**fixed duration per move**, so cursor speed scales with the delta. While an
+animation is still in flight, a new relative move extends its endpoint instead
+of restarting from the current position, so no part of a delta is lost under
+key repeat. `steps` is shared with `[smooth_cursor]`.
+
+Supported on macOS; on Linux and Windows relative moves always warp instantly.
+
+Composes with [`held_repeat` acceleration](#held_repeat): the accelerated
+deltas pass through unchanged, and since animation speed scales with the
+delta, the cursor speeds up over the ramp exactly as without animation — just
+smoothly.
+
+| Option     | Type | Default | Description                                     |
+| ---------- | ---- | ------- | ----------------------------------------------- |
+| `enabled`  | bool | `false` | Animate relative mouse movement                 |
+| `duration` | int  | `50`    | Fixed animation duration per move in ms (>= 1)  |
+
+```toml
+[smooth_cursor.relative]
+enabled = false
+duration = 50
 ```
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1413,7 +1413,7 @@ Animates cursor movement between positions. Supported on macOS and Linux
 | `steps`              | int   | `10`    | Number of animation steps          |
 | `max_duration`       | int   | `200`   | Max animation duration in ms       |
 | `duration_per_pixel` | float | `0.1`   | Ms per pixel for adaptive duration |
-| `relative_duration`  | int   | `50`    | Fixed duration per relative move in ms (>= 1) |
+| `relative_duration`  | int   | `50`    | Fixed duration per relative move in ms (>= 10) |
 
 ```toml
 [smooth_cursor]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -105,7 +105,7 @@ Every option not listed here behaves the same on all three platforms.
 | `[monitor_select]`                        | Yes   | Yes   | No      | Windows: the mode returns `ERR_NOT_SUPPORTED`.       |
 | `[virtual_pointer]`                       | Yes   | No    | No      | Ignored; pairs with macOS-only cursor hiding.        |
 | `[smooth_cursor]`                         | Yes   | Yes   | No      | Windows: cursor moves instantly.                     |
-| `[smooth_cursor.relative]`                | Yes   | No    | No      | Linux and Windows: relative moves stay instant.      |
+| `smooth_cursor.relative_duration`         | Yes   | No    | No      | Linux and Windows: relative moves stay instant.      |
 | `[smooth_scroll]`                         | Yes   | No    | No      | Linux and Windows: scrolling is instant.             |
 | `[recursive_grid.animation]`              | Yes   | Yes   | No      | Windows: depth transitions are not animated.         |
 
@@ -1413,6 +1413,7 @@ Animates cursor movement between positions. Supported on macOS and Linux
 | `steps`              | int   | `10`    | Number of animation steps          |
 | `max_duration`       | int   | `200`   | Max animation duration in ms       |
 | `duration_per_pixel` | float | `0.1`   | Ms per pixel for adaptive duration |
+| `relative_duration`  | int   | `50`    | Fixed duration per relative move in ms (>= 1) |
 
 ```toml
 [smooth_cursor]
@@ -1420,38 +1421,24 @@ move_mouse_enabled = false
 steps = 10
 max_duration = 200
 duration_per_pixel = 0.1
+relative_duration = 50
 ```
 
-### [smooth_cursor.relative]
-
-Animates relative (keyboard-driven) movement — `move_mouse_relative`, i.e. the
-default hjkl bindings. Off by default: relative moves warp instantly, as before.
-
-Jumps derive their duration from the distance (`duration_per_pixel`), which
-yields constant velocity — fine for a one-shot jump, but under held-key repeat
-it makes a 50px step no faster than a 10px one. Relative moves therefore use a
+`relative_duration` applies to relative (keyboard-driven) movement —
+`move_mouse_relative`, i.e. the default hjkl bindings. Jumps derive their
+duration from the distance (`duration_per_pixel`), which yields constant
+velocity — fine for a one-shot jump, but under held-key repeat it makes a 50px
+step no faster than a 10px one. Relative moves therefore animate with a
 **fixed duration per move**, so cursor speed scales with the delta. While an
 animation is still in flight, a new relative move extends its endpoint instead
 of restarting from the current position, so no part of a delta is lost under
-key repeat. `steps` is shared with `[smooth_cursor]`.
+key repeat.
 
-Supported on macOS; on Linux and Windows relative moves always warp instantly.
-
-Composes with [`held_repeat` acceleration](#held_repeat): the accelerated
-deltas pass through unchanged, and since animation speed scales with the
-delta, the cursor speeds up over the ramp exactly as without animation — just
-smoothly.
-
-| Option     | Type | Default | Description                                     |
-| ---------- | ---- | ------- | ----------------------------------------------- |
-| `enabled`  | bool | `false` | Animate relative mouse movement                 |
-| `duration` | int  | `50`    | Fixed animation duration per move in ms (>= 1)  |
-
-```toml
-[smooth_cursor.relative]
-enabled = false
-duration = 50
-```
+Relative animation is supported on macOS; on Linux and Windows relative moves
+always warp instantly. It composes with
+[`held_repeat` acceleration](#held_repeat): the accelerated deltas pass
+through unchanged, and since animation speed scales with the delta, the cursor
+speeds up over the ramp exactly as without animation — just smoothly.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -105,7 +105,7 @@ Every option not listed here behaves the same on all three platforms.
 | `[monitor_select]`                        | Yes   | Yes   | No      | Windows: the mode returns `ERR_NOT_SUPPORTED`.       |
 | `[virtual_pointer]`                       | Yes   | No    | No      | Ignored; pairs with macOS-only cursor hiding.        |
 | `[smooth_cursor]`                         | Yes   | Yes   | No      | Windows: cursor moves instantly.                     |
-| `smooth_cursor.relative_duration`         | Yes   | No    | No      | Linux and Windows: relative moves stay instant.      |
+| `smooth_cursor.relative_movement_duration` | Yes  | No    | No      | Linux and Windows: relative moves stay instant.      |
 | `[smooth_scroll]`                         | Yes   | No    | No      | Linux and Windows: scrolling is instant.             |
 | `[recursive_grid.animation]`              | Yes   | Yes   | No      | Windows: depth transitions are not animated.         |
 
@@ -1413,7 +1413,7 @@ Animates cursor movement between positions. Supported on macOS and Linux
 | `steps`              | int   | `10`    | Number of animation steps          |
 | `max_duration`       | int   | `200`   | Max animation duration in ms       |
 | `duration_per_pixel` | float | `0.1`   | Ms per pixel for adaptive duration |
-| `relative_duration`  | int   | `50`    | Fixed duration per relative move in ms (>= 10) |
+| `relative_movement_duration` | int | `50` | Fixed duration per relative move in ms (>= 10) |
 
 ```toml
 [smooth_cursor]
@@ -1421,10 +1421,10 @@ move_mouse_enabled = false
 steps = 10
 max_duration = 200
 duration_per_pixel = 0.1
-relative_duration = 50
+relative_movement_duration = 50
 ```
 
-`relative_duration` applies to relative (keyboard-driven) movement —
+`relative_movement_duration` applies to relative (keyboard-driven) movement —
 `move_mouse_relative`, i.e. the default hjkl bindings. Jumps derive their
 duration from the distance (`duration_per_pixel`), which yields constant
 velocity — fine for a one-shot jump, but under held-key repeat it makes a 50px

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -130,7 +130,7 @@ or no-op) · ❌ no code path
 | **Cursor move**               | ✅ `CGWarpMouseCursorPosition` | ✅ XTest         | ✅ `zwlr_virtual_pointer`    | ✅ libei                | ✅ `SetCursorPos`            |
 | **Mouse buttons / drag**      | ✅ `CGEventPost`         | ✅ XTest               | ✅ `zwlr_virtual_pointer`    | ✅ libei                | ✅ `SendInput`               |
 | **Scroll injection**          | ✅ both axes             | ✅ both axes           | ✅ both axes (uinput + virtual pointer) | ✅ libei     | ⚠️ vertical only             |
-| **Smooth cursor animation**   | ✅                       | ✅ opt-in              | ✅ opt-in                    | ✅ opt-in               | ❌                           |
+| **Smooth cursor animation**   | ✅ (incl. relative, opt-in) | ✅ opt-in, jumps only | ✅ opt-in, jumps only      | ✅ opt-in, jumps only   | ❌                           |
 | **Smooth scroll animation**   | ✅                       | ❌                     | ❌                           | ❌                      | ❌                           |
 | **Element discovery (hints)** | ✅ AXUIElement           | ⚠️ AT-SPI walk         | ⚠️ AT-SPI walk               | ⚠️ AT-SPI walk          | ⚠️ UIA, shallow tree         |
 | **Overlay**                   | ✅ NSPanel + CoreAnimation | ✅ X11 + Cairo       | ✅ layer-shell + Cairo       | ✅ layer-shell + Cairo  | ✅ layered HWND + GDI        |

--- a/internal/adapter/platform/darwin/mouse.go
+++ b/internal/adapter/platform/darwin/mouse.go
@@ -13,6 +13,7 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/platform/mousestate"
 	"github.com/y3owk1n/neru/internal/derrors"
 	"github.com/y3owk1n/neru/internal/domain/action"
+	"github.com/y3owk1n/neru/internal/domain/geometry"
 )
 
 // heldButtons records which mouse buttons Neru is currently holding down.
@@ -107,6 +108,41 @@ func MoveMouse(point image.Point, bypassSmooth bool) {
 // MoveMouseSmooth moves the mouse cursor smoothly to the specified point.
 func MoveMouseSmooth(end image.Point, steps int, eventType, button uint32) {
 	cursorAnimator.animateTo(end, steps, eventType, button)
+}
+
+// MoveMouseRelativeSmooth animates a relative cursor move with the fixed
+// per-move duration from smooth_cursor.relative. It reports handled == false
+// when relative animation is disabled or no config is wired, in which case the
+// caller falls back to its instant warp path.
+//
+// While an animation is in flight, the delta extends the pending endpoint
+// instead of restarting from the mid-animation cursor position, so no part of
+// a delta is lost under key repeat. The target is clamped to the active
+// screen, matching the warp fallback's clamping — and keeping the pending
+// endpoint from drifting off-screen when a key is held at a screen edge.
+func MoveMouseRelativeSmooth(delta image.Point) bool {
+	cfg := currentConfig()
+	if cfg == nil || !cfg.SmoothCursor.Relative.Enabled {
+		return false
+	}
+
+	bounds := ActiveScreenBounds()
+	eventType, button := dragEventType()
+	cursorAnimator.animateRelativeBy(
+		delta,
+		func(p image.Point) image.Point {
+			return image.Point{
+				X: geometry.ClampInt(p.X, bounds.Min.X, max(bounds.Max.X-1, bounds.Min.X)),
+				Y: geometry.ClampInt(p.Y, bounds.Min.Y, max(bounds.Max.Y-1, bounds.Min.Y)),
+			}
+		},
+		cfg.SmoothCursor.Steps,
+		cfg.SmoothCursor.Relative.Duration,
+		uint32(eventType),
+		uint32(button),
+	)
+
+	return true
 }
 
 // CursorPosition returns the current cursor position.

--- a/internal/adapter/platform/darwin/mouse.go
+++ b/internal/adapter/platform/darwin/mouse.go
@@ -111,7 +111,7 @@ func MoveMouseSmooth(end image.Point, steps int, eventType, button uint32) {
 }
 
 // MoveMouseRelativeSmooth animates a relative cursor move with the fixed
-// per-move duration smooth_cursor.relative_duration. It reports handled == false
+// per-move duration smooth_cursor.relative_movement_duration. It reports handled == false
 // when smooth cursor is disabled or no config is wired, in which case the
 // caller falls back to its instant warp path.
 //
@@ -137,7 +137,7 @@ func MoveMouseRelativeSmooth(delta image.Point) bool {
 			}
 		},
 		cfg.SmoothCursor.Steps,
-		cfg.SmoothCursor.RelativeDuration,
+		cfg.SmoothCursor.RelativeMovementDuration,
 		uint32(eventType),
 		uint32(button),
 	)

--- a/internal/adapter/platform/darwin/mouse.go
+++ b/internal/adapter/platform/darwin/mouse.go
@@ -111,8 +111,8 @@ func MoveMouseSmooth(end image.Point, steps int, eventType, button uint32) {
 }
 
 // MoveMouseRelativeSmooth animates a relative cursor move with the fixed
-// per-move duration from smooth_cursor.relative. It reports handled == false
-// when relative animation is disabled or no config is wired, in which case the
+// per-move duration smooth_cursor.relative_duration. It reports handled == false
+// when smooth cursor is disabled or no config is wired, in which case the
 // caller falls back to its instant warp path.
 //
 // While an animation is in flight, the delta extends the pending endpoint
@@ -122,7 +122,7 @@ func MoveMouseSmooth(end image.Point, steps int, eventType, button uint32) {
 // endpoint from drifting off-screen when a key is held at a screen edge.
 func MoveMouseRelativeSmooth(delta image.Point) bool {
 	cfg := currentConfig()
-	if cfg == nil || !cfg.SmoothCursor.Relative.Enabled {
+	if cfg == nil || !cfg.SmoothCursor.MoveMouseEnabled {
 		return false
 	}
 
@@ -137,7 +137,7 @@ func MoveMouseRelativeSmooth(delta image.Point) bool {
 			}
 		},
 		cfg.SmoothCursor.Steps,
-		cfg.SmoothCursor.Relative.Duration,
+		cfg.SmoothCursor.RelativeDuration,
 		uint32(eventType),
 		uint32(button),
 	)

--- a/internal/adapter/platform/darwin/mouse_animator.go
+++ b/internal/adapter/platform/darwin/mouse_animator.go
@@ -103,6 +103,54 @@ func (a *smoothCursorAnimator) pendingTarget() (image.Point, bool) {
 	return a.pendingEnd, a.hasPending
 }
 
+// settle finishes any in-flight animation immediately: the worker is canceled
+// and the cursor warps straight to the endpoint it was animating toward.
+// Position-dependent reads call this so an action firing mid-animation acts
+// at the point the user aimed for, without waiting the animation out.
+func (a *smoothCursorAnimator) settle() {
+	end, ok := a.takePendingForSettle()
+	if !ok {
+		return
+	}
+
+	eventType, button := dragEventType()
+	pos := C.CGPoint{x: C.double(end.X), y: C.double(end.Y)}
+	C.NeruMoveMouseWithTypeAndButton(pos, eventType, button)
+}
+
+// takePendingForSettle atomically ends the in-flight animation and hands back
+// its endpoint: the worker is canceled with the same generation bump as
+// stop() — so a step already past its checks is dropped rather than landing
+// after the settle warp — waiters are released, and the pending endpoint is
+// cleared. ok reports whether there was an animation to settle.
+func (a *smoothCursorAnimator) takePendingForSettle() (image.Point, bool) {
+	a.mu.Lock()
+
+	if !a.hasPending {
+		a.mu.Unlock()
+
+		return image.Point{}, false
+	}
+
+	end := a.pendingEnd
+	stopCh := a.stopCh
+	done := a.done
+	a.reqCh = nil
+	a.stopCh = nil
+	a.done = nil
+	a.generation++
+	a.hasPending = false
+
+	if stopCh != nil {
+		close(stopCh)
+	}
+	a.mu.Unlock()
+
+	done.close()
+
+	return end, true
+}
+
 // currentGeneration returns the animation generation in effect right now.
 func (a *smoothCursorAnimator) currentGeneration() uint64 {
 	a.mu.Lock()

--- a/internal/adapter/platform/darwin/mouse_animator.go
+++ b/internal/adapter/platform/darwin/mouse_animator.go
@@ -46,6 +46,7 @@ type cursorRequest struct {
 	button           uint32
 	maxDuration      int
 	durationPerPixel float64
+	fixedDuration    int // when > 0, overrides the distance-derived duration
 	done             *cursorAnimationDone
 }
 
@@ -57,6 +58,11 @@ type smoothCursorAnimator struct {
 	// generation is bumped by stop() to invalidate steps from the animation
 	// being canceled. See postIfCurrent.
 	generation uint64
+	// pendingEnd is the target of the animation currently in flight. Relative
+	// moves extend it instead of restarting from the mid-animation cursor
+	// position, so no part of a delta is lost under key repeat.
+	pendingEnd image.Point
+	hasPending bool
 }
 
 var cursorAnimator smoothCursorAnimator
@@ -75,6 +81,7 @@ func (a *smoothCursorAnimator) stop() {
 	// the zoom viewport — back toward the abandoned target. Bumping the
 	// generation under the same lock the worker posts under closes that window.
 	a.generation++
+	a.hasPending = false
 
 	if stopCh != nil {
 		close(stopCh)
@@ -82,6 +89,15 @@ func (a *smoothCursorAnimator) stop() {
 	a.mu.Unlock()
 
 	done.close()
+}
+
+// pendingTarget returns the endpoint of the animation currently in flight,
+// or ok == false when no animation is active.
+func (a *smoothCursorAnimator) pendingTarget() (image.Point, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.pendingEnd, a.hasPending
 }
 
 // currentGeneration returns the animation generation in effect right now.
@@ -151,37 +167,77 @@ func (a *smoothCursorAnimator) animateTo(end image.Point, steps int, eventType, 
 		done:             done,
 	}
 
-	reqCh := a.ensureWorker(done)
-	select {
-	case reqCh <- req:
-	default:
-		select {
-		case dropped := <-reqCh:
-			dropped.done.close()
-		default:
-		}
-		reqCh <- req
-	}
+	a.submit(req)
 }
 
-func (a *smoothCursorAnimator) ensureWorker(done *cursorAnimationDone) chan cursorRequest {
+// animateRelativeBy animates a relative move with a fixed duration,
+// independent of the distance, so that cursor speed scales with the per-move
+// delta instead of collapsing to the constant velocity the
+// distance-proportional duration would produce.
+//
+// The base is the pending endpoint of the animation in flight (falling back to
+// the live cursor position), extended by delta and clamped by the caller's
+// clamp. Base computation, bookkeeping, and submission all happen under one
+// lock hold: two concurrent relative movers therefore compose their deltas
+// instead of one silently overwriting the other's endpoint.
+func (a *smoothCursorAnimator) animateRelativeBy(
+	delta image.Point,
+	clamp func(image.Point) image.Point,
+	steps int,
+	durationMs int,
+	eventType, button uint32,
+) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	a.done = done
-
-	if a.reqCh != nil {
-		return a.reqCh
+	base := a.pendingEnd
+	if !a.hasPending {
+		base = CursorPosition()
 	}
 
-	reqCh := make(chan cursorRequest, 1)
-	stopCh := make(chan struct{})
-	a.reqCh = reqCh
-	a.stopCh = stopCh
+	a.submitLocked(cursorRequest{
+		end:           clamp(base.Add(delta)),
+		steps:         steps,
+		eventType:     eventType,
+		button:        button,
+		fixedDuration: durationMs,
+		done:          newCursorAnimationDone(),
+	})
+}
 
-	go a.run(reqCh, stopCh)
+func (a *smoothCursorAnimator) submit(req cursorRequest) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 
-	return reqCh
+	a.submitLocked(req)
+}
+
+// submitLocked records req as the pending animation and hands it to the
+// worker. Callers must hold a.mu. The channel send cannot block: the buffer
+// holds one request, the worker never takes a.mu around its receive, and
+// submitters are serialized by a.mu, so after the drop below a slot is free.
+func (a *smoothCursorAnimator) submitLocked(req cursorRequest) {
+	a.done = req.done
+	a.pendingEnd = req.end
+	a.hasPending = true
+
+	if a.reqCh == nil {
+		a.reqCh = make(chan cursorRequest, 1)
+		a.stopCh = make(chan struct{})
+
+		go a.run(a.reqCh, a.stopCh)
+	}
+
+	select {
+	case a.reqCh <- req:
+	default:
+		select {
+		case dropped := <-a.reqCh:
+			dropped.done.close()
+		default:
+		}
+		a.reqCh <- req
+	}
 }
 
 func (a *smoothCursorAnimator) run(reqCh <-chan cursorRequest, stopCh <-chan struct{}) {
@@ -211,6 +267,10 @@ restart:
 	distance := math.Hypot(float64(req.end.X-start.X), float64(req.end.Y-start.Y))
 
 	duration := math.Min(float64(req.maxDuration), distance*req.durationPerPixel)
+	if req.fixedDuration > 0 {
+		duration = float64(req.fixedDuration)
+	}
+
 	if duration < minAnimationDuration {
 		duration = minAnimationDuration
 	}
@@ -283,5 +343,6 @@ func (a *smoothCursorAnimator) clearDoneIfCurrent(done *cursorAnimationDone) {
 
 	if a.done == done {
 		a.done = nil
+		a.hasPending = false
 	}
 }

--- a/internal/adapter/platform/darwin/mouse_animator.go
+++ b/internal/adapter/platform/darwin/mouse_animator.go
@@ -16,8 +16,11 @@ import (
 )
 
 const (
-	minAnimationDuration = 10 // Minimum animation duration in ms
-	minStepDelay         = 1  // Minimum delay between steps in ms
+	// minAnimationDuration is the floor for every animation in ms. Mirrored by
+	// config.MinSmoothCursorRelativeDuration so the validator rejects
+	// relative_duration values this floor would silently round up.
+	minAnimationDuration = 10
+	minStepDelay         = 1 // Minimum delay between steps in ms
 )
 
 type cursorAnimationDone struct {
@@ -195,8 +198,16 @@ func (a *smoothCursorAnimator) animateRelativeBy(
 		base = CursorPosition()
 	}
 
+	end := clamp(base.Add(delta))
+	if end == base {
+		// Nothing to animate: the delta was zero or the clamp ate it at a
+		// screen edge. The in-flight animation (if any) already targets base,
+		// so submitting would only cancel and restart it.
+		return
+	}
+
 	a.submitLocked(cursorRequest{
-		end:           clamp(base.Add(delta)),
+		end:           end,
 		steps:         steps,
 		eventType:     eventType,
 		button:        button,

--- a/internal/adapter/platform/darwin/mouse_animator.go
+++ b/internal/adapter/platform/darwin/mouse_animator.go
@@ -13,14 +13,12 @@ import (
 	"math"
 	"sync"
 	"time"
+
+	"github.com/y3owk1n/neru/internal/config"
 )
 
 const (
-	// minAnimationDuration is the floor for every animation in ms. Mirrored by
-	// config.MinSmoothCursorRelativeDuration so the validator rejects
-	// relative_duration values this floor would silently round up.
-	minAnimationDuration = 10
-	minStepDelay         = 1 // Minimum delay between steps in ms
+	minStepDelay = 1 // Minimum delay between steps in ms
 )
 
 type cursorAnimationDone struct {
@@ -330,8 +328,8 @@ restart:
 		duration = float64(req.fixedDuration)
 	}
 
-	if duration < minAnimationDuration {
-		duration = minAnimationDuration
+	if duration < config.MinSmoothCursorAnimationDuration {
+		duration = config.MinSmoothCursorAnimationDuration
 	}
 
 	actualSteps := req.steps

--- a/internal/adapter/platform/darwin/mouse_animator_test.go
+++ b/internal/adapter/platform/darwin/mouse_animator_test.go
@@ -1,0 +1,122 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"image"
+	"sync"
+	"testing"
+)
+
+// testAnimator returns an animator whose request channel exists but has no
+// worker goroutine behind it. submitLocked then only queues (and drops) —
+// nothing consumes the requests, so no mouse events are posted during tests.
+func testAnimator() *smoothCursorAnimator {
+	return &smoothCursorAnimator{reqCh: make(chan cursorRequest, 1)}
+}
+
+func (a *smoothCursorAnimator) submitForTest(end image.Point) *cursorAnimationDone {
+	done := newCursorAnimationDone()
+
+	a.mu.Lock()
+	a.submitLocked(cursorRequest{end: end, done: done})
+	a.mu.Unlock()
+
+	return done
+}
+
+// TestCursorAnimator_PendingTarget pins the pending-target contract relative
+// moves build on: the endpoint of the animation in flight is visible while it
+// is pending and gone once the animation is stopped. Without it, each held-key
+// repeat would restart from the mid-animation cursor position and silently
+// drop the un-animated remainder of every delta.
+func TestCursorAnimator_PendingTarget(t *testing.T) {
+	animator := testAnimator()
+
+	if _, ok := animator.pendingTarget(); ok {
+		t.Fatal("pendingTarget() reported an animation before any was submitted")
+	}
+
+	end := image.Point{X: 120, Y: 80}
+	animator.submitForTest(end)
+
+	got, ok := animator.pendingTarget()
+	if !ok {
+		t.Fatal("pendingTarget() reported no animation while one is pending")
+	}
+
+	if got != end {
+		t.Fatalf("pendingTarget() = %v, want %v", got, end)
+	}
+
+	animator.stop()
+
+	if _, ok := animator.pendingTarget(); ok {
+		t.Fatal("pendingTarget() still reports an animation after stop()")
+	}
+}
+
+// TestCursorAnimator_ClearDoneIfCurrent_KeepsNewerPending guards the
+// completion path: finishing an older animation must not clear the pending
+// endpoint of a newer one that superseded it.
+func TestCursorAnimator_ClearDoneIfCurrent_KeepsNewerPending(t *testing.T) {
+	animator := testAnimator()
+
+	older := animator.submitForTest(image.Point{X: 10, Y: 10})
+
+	newerEnd := image.Point{X: 20, Y: 20}
+	newer := animator.submitForTest(newerEnd)
+
+	animator.clearDoneIfCurrent(older)
+
+	got, ok := animator.pendingTarget()
+	if !ok || got != newerEnd {
+		t.Fatalf("pendingTarget() = %v, %v after stale clear, want %v, true", got, ok, newerEnd)
+	}
+
+	animator.clearDoneIfCurrent(newer)
+
+	if _, ok := animator.pendingTarget(); ok {
+		t.Fatal("pendingTarget() still reports an animation after the current one completed")
+	}
+}
+
+// TestCursorAnimator_AnimateRelativeBy_ConcurrentDeltasCompose pins the
+// single-lock read-modify-write of animateRelativeBy: deltas from concurrent
+// movers (mode held-repeat and hotkey held-repeat are independent goroutines)
+// must all end up in the pending endpoint, none silently overwritten. Run
+// under -race, this also covers the submit/pendingTarget interleavings.
+func TestCursorAnimator_AnimateRelativeBy_ConcurrentDeltasCompose(t *testing.T) {
+	animator := testAnimator()
+
+	// Seed a pending animation so every animateRelativeBy extends the endpoint
+	// rather than reading the live cursor position.
+	animator.submitForTest(image.Point{})
+
+	const movers = 8
+
+	const deltasPerMover = 50
+
+	identity := func(p image.Point) image.Point { return p }
+
+	var waitGroup sync.WaitGroup
+	for range movers {
+		waitGroup.Go(func() {
+			for range deltasPerMover {
+				animator.animateRelativeBy(image.Point{X: 1, Y: 0}, identity, 1, 1, 0, 0)
+			}
+		})
+	}
+
+	waitGroup.Wait()
+
+	got, ok := animator.pendingTarget()
+	if !ok {
+		t.Fatal("pendingTarget() reported no animation after concurrent relative moves")
+	}
+
+	if want := movers * deltasPerMover; got.X != want {
+		t.Fatalf("pending endpoint X = %d after %d concurrent unit deltas, want %d (lost deltas)",
+			got.X, want, want)
+	}
+}

--- a/internal/adapter/platform/darwin/mouse_animator_test.go
+++ b/internal/adapter/platform/darwin/mouse_animator_test.go
@@ -156,3 +156,38 @@ func TestCursorAnimator_AnimateRelativeBy_ConcurrentDeltasCompose(t *testing.T) 
 			got.X, want, want)
 	}
 }
+
+// TestCursorAnimator_TakePendingForSettle pins the state transition behind
+// settle(): it hands back the in-flight endpoint exactly once, releases
+// waiters, invalidates queued steps, and reports ok == false on an idle
+// animator so no settle warp is posted when there is nothing to finish.
+func TestCursorAnimator_TakePendingForSettle(t *testing.T) {
+	animator := testAnimator()
+
+	if _, ok := animator.takePendingForSettle(); ok {
+		t.Fatal("takePendingForSettle() reported an animation on an idle animator")
+	}
+
+	end := image.Point{X: 30, Y: 40}
+	generation := animator.currentGeneration()
+	done := animator.submitForTest(end)
+
+	got, ok := animator.takePendingForSettle()
+	if !ok || got != end {
+		t.Fatalf("takePendingForSettle() = %v, %v, want %v, true", got, ok, end)
+	}
+
+	if _, ok := animator.pendingTarget(); ok {
+		t.Fatal("pendingTarget() still reports an animation after settle")
+	}
+
+	select {
+	case <-done.ch:
+	default:
+		t.Fatal("settle did not release the animation's waiters")
+	}
+
+	if animator.postIfCurrent(generation, end, 0, 0) {
+		t.Fatal("a step from the settled animation was still posted after settle")
+	}
+}

--- a/internal/adapter/platform/darwin/mouse_animator_test.go
+++ b/internal/adapter/platform/darwin/mouse_animator_test.go
@@ -81,6 +81,42 @@ func TestCursorAnimator_ClearDoneIfCurrent_KeepsNewerPending(t *testing.T) {
 	}
 }
 
+// TestCursorAnimator_AnimateRelativeBy_NoopKeepsAnimation pins the no-op
+// guard: a move whose endpoint equals the pending one — zero delta, or a
+// delta the screen-edge clamp ate — must not cancel and resubmit the
+// animation already heading there.
+func TestCursorAnimator_AnimateRelativeBy_NoopKeepsAnimation(t *testing.T) {
+	animator := testAnimator()
+
+	end := image.Point{X: 10, Y: 10}
+	animator.submitForTest(end)
+
+	identity := func(p image.Point) image.Point { return p }
+	animator.animateRelativeBy(image.Point{}, identity, 1, 50, 0, 0)
+
+	clampToEnd := func(image.Point) image.Point { return end }
+	animator.animateRelativeBy(image.Point{X: 5, Y: 0}, clampToEnd, 1, 50, 0, 0)
+
+	select {
+	case req := <-animator.reqCh:
+		if req.end != end {
+			t.Fatalf(
+				"queued request end = %v, want the original %v (no-op moves must not resubmit)",
+				req.end,
+				end,
+			)
+		}
+	default:
+		t.Fatal("original request missing from queue after no-op moves")
+	}
+
+	select {
+	case req := <-animator.reqCh:
+		t.Fatalf("no-op move enqueued an extra request with end %v", req.end)
+	default:
+	}
+}
+
 // TestCursorAnimator_AnimateRelativeBy_ConcurrentDeltasCompose pins the
 // single-lock read-modify-write of animateRelativeBy: deltas from concurrent
 // movers (mode held-repeat and hotkey held-repeat are independent goroutines)

--- a/internal/adapter/platform/darwin/system.go
+++ b/internal/adapter/platform/darwin/system.go
@@ -114,10 +114,11 @@ func (s *SystemAdapter) MoveCursorToPoint(
 	return nil
 }
 
-// MoveCursorBy animates a relative cursor move when smooth_cursor.relative is
-// enabled. It reports handled == false when relative animation is disabled,
-// sending the caller to its CursorPosition + MoveCursorToPoint fallback — the
-// instant warp that was always used before this option existed.
+// MoveCursorBy animates a relative cursor move when smooth cursor is enabled
+// (smooth_cursor.move_mouse_enabled). It reports handled == false when it is
+// disabled, sending the caller to its CursorPosition + MoveCursorToPoint
+// fallback — the instant warp that was always used before relative moves
+// gained animation.
 func (s *SystemAdapter) MoveCursorBy(
 	ctx context.Context,
 	delta image.Point,
@@ -199,5 +200,5 @@ func (s *SystemAdapter) RequestScreenCapturePermission(
 var _ ports.SystemPort = (*SystemAdapter)(nil)
 
 // Ensure SystemAdapter opts into relative cursor movement (animated relative
-// moves when smooth_cursor.relative is enabled).
+// moves when smooth cursor is enabled).
 var _ ports.RelativeCursorMover = (*SystemAdapter)(nil)

--- a/internal/adapter/platform/darwin/system.go
+++ b/internal/adapter/platform/darwin/system.go
@@ -114,6 +114,17 @@ func (s *SystemAdapter) MoveCursorToPoint(
 	return nil
 }
 
+// MoveCursorBy animates a relative cursor move when smooth_cursor.relative is
+// enabled. It reports handled == false when relative animation is disabled,
+// sending the caller to its CursorPosition + MoveCursorToPoint fallback — the
+// instant warp that was always used before this option existed.
+func (s *SystemAdapter) MoveCursorBy(
+	ctx context.Context,
+	delta image.Point,
+) (bool, error) {
+	return MoveMouseRelativeSmooth(delta), nil
+}
+
 // WaitForCursorIdle blocks until any in-flight cursor movement animation settles.
 func (s *SystemAdapter) WaitForCursorIdle(ctx context.Context) error {
 	return cursorAnimator.wait(ctx)
@@ -186,3 +197,7 @@ func (s *SystemAdapter) RequestScreenCapturePermission(
 
 // Ensure SystemAdapter implements ports.SystemPort.
 var _ ports.SystemPort = (*SystemAdapter)(nil)
+
+// Ensure SystemAdapter opts into relative cursor movement (animated relative
+// moves when smooth_cursor.relative is enabled).
+var _ ports.RelativeCursorMover = (*SystemAdapter)(nil)

--- a/internal/adapter/platform/darwin/system.go
+++ b/internal/adapter/platform/darwin/system.go
@@ -133,15 +133,24 @@ func (s *SystemAdapter) WaitForCursorIdle(ctx context.Context) error {
 
 // CursorPosition returns the current cursor position on macOS.
 //
-// Any in-flight cursor animation is settled first — stopped, with the cursor
-// warped straight to its endpoint — so a position-dependent action that fires
-// mid-animation (e.g. a click right after an animated relative move) acts at
-// the point the user aimed for instead of a mid-animation position, without
-// paying the animation's remaining duration in latency.
+// This is a pure read: an in-flight animation reports its mid-animation
+// position, which is what pollers like the mode-indicator follower need.
+// Callers resolving an action's target point use SettleCursor first.
 func (s *SystemAdapter) CursorPosition(ctx context.Context) (image.Point, error) {
+	return CursorPosition(), nil
+}
+
+// SettleCursor finishes any in-flight cursor animation immediately: the
+// worker is stopped and the cursor warps straight to the endpoint it was
+// animating toward. Action paths call this before resolving their target
+// point from the cursor, so an action firing mid-animation (e.g. a click
+// right after an animated relative move) acts at the point the user aimed
+// for — without paying the animation's remaining duration in latency, and
+// without disturbing pollers that merely observe the cursor.
+func (s *SystemAdapter) SettleCursor(ctx context.Context) error {
 	cursorAnimator.settle()
 
-	return CursorPosition(), nil
+	return nil
 }
 
 // IsDarkMode returns true if macOS Dark Mode is currently active.
@@ -210,3 +219,7 @@ var _ ports.SystemPort = (*SystemAdapter)(nil)
 // Ensure SystemAdapter opts into relative cursor movement (animated relative
 // moves when smooth cursor is enabled).
 var _ ports.RelativeCursorMover = (*SystemAdapter)(nil)
+
+// Ensure SystemAdapter opts into settling in-flight cursor animations before
+// position-dependent actions.
+var _ ports.CursorSettler = (*SystemAdapter)(nil)

--- a/internal/adapter/platform/darwin/system.go
+++ b/internal/adapter/platform/darwin/system.go
@@ -132,7 +132,15 @@ func (s *SystemAdapter) WaitForCursorIdle(ctx context.Context) error {
 }
 
 // CursorPosition returns the current cursor position on macOS.
+//
+// Any in-flight cursor animation is settled first — stopped, with the cursor
+// warped straight to its endpoint — so a position-dependent action that fires
+// mid-animation (e.g. a click right after an animated relative move) acts at
+// the point the user aimed for instead of a mid-animation position, without
+// paying the animation's remaining duration in latency.
 func (s *SystemAdapter) CursorPosition(ctx context.Context) (image.Point, error) {
+	cursorAnimator.settle()
+
 	return CursorPosition(), nil
 }
 

--- a/internal/app/ipcctrl/actions_cursor.go
+++ b/internal/app/ipcctrl/actions_cursor.go
@@ -238,7 +238,7 @@ func (h *ActionsHandler) resolveMouseActionPoint(
 func (h *ActionsHandler) resolveCurrentCursorPoint(
 	ctx context.Context,
 ) (image.Point, *ipc.Response) {
-	cursorPos, posErr := h.actionService.CursorPosition(ctx)
+	cursorPos, posErr := h.actionService.CursorPositionForAction(ctx)
 	if posErr != nil {
 		h.logger.Error("Failed to get cursor position", zap.Error(posErr))
 
@@ -321,7 +321,9 @@ func (h *ActionsHandler) handleSaveCursorPosAction(
 		return *slotErr
 	}
 
-	pos, posErr := h.actionService.CursorPosition(ctx)
+	// Settle any in-flight animation first: saving mid-animation would record
+	// a point the cursor was merely passing through, not the one aimed for.
+	pos, posErr := h.actionService.CursorPositionForAction(ctx)
 	if posErr != nil {
 		return ipc.Response{
 			Success: false,

--- a/internal/app/services/action_service.go
+++ b/internal/app/services/action_service.go
@@ -263,6 +263,22 @@ func (s *ActionService) MoveMouseRelative(
 	return s.MoveMouseTo(ctx, cursorPos.X+deltaX, cursorPos.Y+deltaY, shouldBypass)
 }
 
+// CursorPositionForAction returns the cursor position for resolving an
+// action's target point. Unlike CursorPosition it first settles any in-flight
+// cursor animation (ports.CursorSettler), so an action fired mid-animation
+// acts at the point the user aimed for instead of a mid-animation position.
+// Plain observers that must not cut animations short use CursorPosition.
+func (s *ActionService) CursorPositionForAction(ctx context.Context) (image.Point, error) {
+	if settler, ok := s.system.(ports.CursorSettler); ok {
+		err := settler.SettleCursor(ctx)
+		if err != nil {
+			s.logger.Warn("Failed to settle cursor animation", zap.Error(err))
+		}
+	}
+
+	return s.system.CursorPosition(ctx)
+}
+
 // CursorPosition returns the current cursor position.
 func (s *ActionService) CursorPosition(ctx context.Context) (image.Point, error) {
 	return s.system.CursorPosition(ctx)

--- a/internal/app/services/action_service.go
+++ b/internal/app/services/action_service.go
@@ -230,7 +230,7 @@ func (s *ActionService) ReleaseHeldButtons(ctx context.Context) error {
 // MoveMouseRelative moves the mouse cursor by the specified delta from the current position.
 // A ports.RelativeCursorMover implementation is consulted first and may apply
 // the delta itself (natively on Wayland, animated on macOS when
-// smooth_cursor.relative is enabled). bypassSmooth applies only to the
+// smooth_cursor.move_mouse_enabled is set). bypassSmooth applies only to the
 // read-then-warp fallback below it: when true, the fallback skips the jump
 // animator (used for keyboard-driven movements).
 func (s *ActionService) MoveMouseRelative(

--- a/internal/app/services/action_service.go
+++ b/internal/app/services/action_service.go
@@ -228,7 +228,11 @@ func (s *ActionService) ReleaseHeldButtons(ctx context.Context) error {
 }
 
 // MoveMouseRelative moves the mouse cursor by the specified delta from the current position.
-// If bypassSmooth is true, smooth cursor animation is skipped (used for keyboard-driven movements).
+// A ports.RelativeCursorMover implementation is consulted first and may apply
+// the delta itself (natively on Wayland, animated on macOS when
+// smooth_cursor.relative is enabled). bypassSmooth applies only to the
+// read-then-warp fallback below it: when true, the fallback skips the jump
+// animator (used for keyboard-driven movements).
 func (s *ActionService) MoveMouseRelative(
 	ctx context.Context,
 	deltaX, deltaY int,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -653,17 +653,18 @@ type LoggingConfig struct {
 
 // SmoothCursorConfig defines the smooth cursor movement settings.
 //
-// RelativeDuration applies to relative (keyboard-driven) movements such as
-// move_mouse_relative. Unlike jumps, these arrive as rapid small deltas under
-// key repeat, so their animation uses a fixed duration per move — speed then
-// scales with the delta — instead of the distance-proportional duration used
-// for jumps, which would clamp every delta to the same constant velocity.
+// RelativeMovementDuration applies to relative (keyboard-driven) movements
+// such as move_mouse_relative. Unlike jumps, these arrive as rapid small
+// deltas under key repeat, so their animation uses a fixed duration per move
+// — speed then scales with the delta — instead of the distance-proportional
+// duration used for jumps, which would clamp every delta to the same constant
+// velocity.
 type SmoothCursorConfig struct {
-	MoveMouseEnabled bool    `json:"moveMouseEnabled" toml:"move_mouse_enabled"`
-	Steps            int     `json:"steps"            toml:"steps"`
-	MaxDuration      int     `json:"maxDuration"      toml:"max_duration"`       // Max animation duration in ms
-	DurationPerPixel float64 `json:"durationPerPixel" toml:"duration_per_pixel"` // Ms per pixel for adaptive duration
-	RelativeDuration int     `json:"relativeDuration" toml:"relative_duration"`  // Fixed duration per relative move in ms
+	MoveMouseEnabled         bool    `json:"moveMouseEnabled"         toml:"move_mouse_enabled"`
+	Steps                    int     `json:"steps"                    toml:"steps"`
+	MaxDuration              int     `json:"maxDuration"              toml:"max_duration"`               // Max animation duration in ms
+	DurationPerPixel         float64 `json:"durationPerPixel"         toml:"duration_per_pixel"`         // Ms per pixel for adaptive duration
+	RelativeMovementDuration int     `json:"relativeMovementDuration" toml:"relative_movement_duration"` // Fixed duration per relative move in ms
 }
 
 // SmoothScrollConfig defines smooth scroll animation settings.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -652,23 +652,18 @@ type LoggingConfig struct {
 }
 
 // SmoothCursorConfig defines the smooth cursor movement settings.
+//
+// RelativeDuration applies to relative (keyboard-driven) movements such as
+// move_mouse_relative. Unlike jumps, these arrive as rapid small deltas under
+// key repeat, so their animation uses a fixed duration per move — speed then
+// scales with the delta — instead of the distance-proportional duration used
+// for jumps, which would clamp every delta to the same constant velocity.
 type SmoothCursorConfig struct {
-	MoveMouseEnabled bool                       `json:"moveMouseEnabled" toml:"move_mouse_enabled"`
-	Steps            int                        `json:"steps"            toml:"steps"`
-	MaxDuration      int                        `json:"maxDuration"      toml:"max_duration"`       // Max animation duration in ms
-	DurationPerPixel float64                    `json:"durationPerPixel" toml:"duration_per_pixel"` // Ms per pixel for adaptive duration
-	Relative         SmoothCursorRelativeConfig `json:"relative"         toml:"relative"`
-}
-
-// SmoothCursorRelativeConfig defines smooth cursor settings for relative
-// (keyboard-driven) movements such as move_mouse_relative. Unlike jumps, these
-// arrive as rapid small deltas under key repeat, so the animation uses a fixed
-// duration per move — speed then scales with the delta — instead of the
-// distance-proportional duration used for jumps, which would clamp every delta
-// to the same constant velocity.
-type SmoothCursorRelativeConfig struct {
-	Enabled  bool `json:"enabled"  toml:"enabled"`
-	Duration int  `json:"duration" toml:"duration"` // Fixed animation duration per move in ms
+	MoveMouseEnabled bool    `json:"moveMouseEnabled" toml:"move_mouse_enabled"`
+	Steps            int     `json:"steps"            toml:"steps"`
+	MaxDuration      int     `json:"maxDuration"      toml:"max_duration"`       // Max animation duration in ms
+	DurationPerPixel float64 `json:"durationPerPixel" toml:"duration_per_pixel"` // Ms per pixel for adaptive duration
+	RelativeDuration int     `json:"relativeDuration" toml:"relative_duration"`  // Fixed duration per relative move in ms
 }
 
 // SmoothScrollConfig defines smooth scroll animation settings.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -653,10 +653,22 @@ type LoggingConfig struct {
 
 // SmoothCursorConfig defines the smooth cursor movement settings.
 type SmoothCursorConfig struct {
-	MoveMouseEnabled bool    `json:"moveMouseEnabled" toml:"move_mouse_enabled"`
-	Steps            int     `json:"steps"            toml:"steps"`
-	MaxDuration      int     `json:"maxDuration"      toml:"max_duration"`       // Max animation duration in ms
-	DurationPerPixel float64 `json:"durationPerPixel" toml:"duration_per_pixel"` // Ms per pixel for adaptive duration
+	MoveMouseEnabled bool                       `json:"moveMouseEnabled" toml:"move_mouse_enabled"`
+	Steps            int                        `json:"steps"            toml:"steps"`
+	MaxDuration      int                        `json:"maxDuration"      toml:"max_duration"`       // Max animation duration in ms
+	DurationPerPixel float64                    `json:"durationPerPixel" toml:"duration_per_pixel"` // Ms per pixel for adaptive duration
+	Relative         SmoothCursorRelativeConfig `json:"relative"         toml:"relative"`
+}
+
+// SmoothCursorRelativeConfig defines smooth cursor settings for relative
+// (keyboard-driven) movements such as move_mouse_relative. Unlike jumps, these
+// arrive as rapid small deltas under key repeat, so the animation uses a fixed
+// duration per move — speed then scales with the delta — instead of the
+// distance-proportional duration used for jumps, which would clamp every delta
+// to the same constant velocity.
+type SmoothCursorRelativeConfig struct {
+	Enabled  bool `json:"enabled"  toml:"enabled"`
+	Duration int  `json:"duration" toml:"duration"` // Fixed animation duration per move in ms
 }
 
 // SmoothScrollConfig defines smooth scroll animation settings.

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -126,6 +126,11 @@ const (
 	// animations chain seamlessly under held-key repeat.
 	DefaultSmoothCursorRelativeDuration = 50
 
+	// MinSmoothCursorRelativeDuration is the smallest accepted
+	// relative_duration (ms). Mirrors the animator's minAnimationDuration
+	// floor (darwin adapter): anything below it would be silently rounded up.
+	MinSmoothCursorRelativeDuration = 10
+
 	// DefaultSmoothScrollSteps is the default smooth scroll steps.
 	DefaultSmoothScrollSteps = 20
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -121,15 +121,18 @@ const (
 	// DefaultSmoothCursorDurationPerPixel is the default ms per pixel for adaptive duration.
 	DefaultSmoothCursorDurationPerPixel = 0.1
 
-	// DefaultSmoothCursorRelativeDuration is the default fixed animation
-	// duration for relative moves (ms). Matches DefaultHeldRepeatInterval so
-	// animations chain seamlessly under held-key repeat.
-	DefaultSmoothCursorRelativeDuration = 50
+	// DefaultSmoothCursorRelativeMovementDuration is the default fixed
+	// animation duration for relative moves (ms). Matches
+	// DefaultHeldRepeatInterval so animations chain seamlessly under held-key
+	// repeat.
+	DefaultSmoothCursorRelativeMovementDuration = 50
 
-	// MinSmoothCursorRelativeDuration is the smallest accepted
-	// relative_duration (ms). Mirrors the animator's minAnimationDuration
-	// floor (darwin adapter): anything below it would be silently rounded up.
-	MinSmoothCursorRelativeDuration = 10
+	// MinSmoothCursorAnimationDuration is the floor for every smooth cursor
+	// animation in ms — the animator raises shorter animations to it. It is
+	// also the smallest accepted relative_movement_duration: anything below
+	// would be silently rounded up rather than honored, so the validator
+	// rejects it.
+	MinSmoothCursorAnimationDuration = 10
 
 	// DefaultSmoothScrollSteps is the default smooth scroll steps.
 	DefaultSmoothScrollSteps = 20
@@ -772,11 +775,11 @@ func defaultLogging() LoggingConfig {
 
 func defaultSmoothCursor() SmoothCursorConfig {
 	return SmoothCursorConfig{
-		MoveMouseEnabled: false,
-		Steps:            DefaultSmoothCursorSteps,
-		MaxDuration:      DefaultSmoothCursorMaxDuration,
-		DurationPerPixel: DefaultSmoothCursorDurationPerPixel,
-		RelativeDuration: DefaultSmoothCursorRelativeDuration,
+		MoveMouseEnabled:         false,
+		Steps:                    DefaultSmoothCursorSteps,
+		MaxDuration:              DefaultSmoothCursorMaxDuration,
+		DurationPerPixel:         DefaultSmoothCursorDurationPerPixel,
+		RelativeMovementDuration: DefaultSmoothCursorRelativeMovementDuration,
 	}
 }
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -771,10 +771,7 @@ func defaultSmoothCursor() SmoothCursorConfig {
 		Steps:            DefaultSmoothCursorSteps,
 		MaxDuration:      DefaultSmoothCursorMaxDuration,
 		DurationPerPixel: DefaultSmoothCursorDurationPerPixel,
-		Relative: SmoothCursorRelativeConfig{
-			Enabled:  false,
-			Duration: DefaultSmoothCursorRelativeDuration,
-		},
+		RelativeDuration: DefaultSmoothCursorRelativeDuration,
 	}
 }
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -121,6 +121,11 @@ const (
 	// DefaultSmoothCursorDurationPerPixel is the default ms per pixel for adaptive duration.
 	DefaultSmoothCursorDurationPerPixel = 0.1
 
+	// DefaultSmoothCursorRelativeDuration is the default fixed animation
+	// duration for relative moves (ms). Matches DefaultHeldRepeatInterval so
+	// animations chain seamlessly under held-key repeat.
+	DefaultSmoothCursorRelativeDuration = 50
+
 	// DefaultSmoothScrollSteps is the default smooth scroll steps.
 	DefaultSmoothScrollSteps = 20
 
@@ -766,6 +771,10 @@ func defaultSmoothCursor() SmoothCursorConfig {
 		Steps:            DefaultSmoothCursorSteps,
 		MaxDuration:      DefaultSmoothCursorMaxDuration,
 		DurationPerPixel: DefaultSmoothCursorDurationPerPixel,
+		Relative: SmoothCursorRelativeConfig{
+			Enabled:  false,
+			Duration: DefaultSmoothCursorRelativeDuration,
+		},
 	}
 }
 

--- a/internal/config/validators_boundary_test.go
+++ b/internal/config/validators_boundary_test.go
@@ -114,10 +114,10 @@ func visionIntBounds() []intBound {
 func smoothCursorIntBounds() []intBound {
 	return []intBound{
 		{
-			name:     "smooth_cursor.relative_duration",
-			set:      func(c *config.Config, v int) { c.SmoothCursor.RelativeDuration = v },
+			name:     "smooth_cursor.relative_movement_duration",
+			set:      func(c *config.Config, v int) { c.SmoothCursor.RelativeMovementDuration = v },
 			validate: (*config.Config).ValidateSmoothCursor,
-			minValid: config.MinSmoothCursorRelativeDuration,
+			minValid: config.MinSmoothCursorAnimationDuration,
 		},
 	}
 }

--- a/internal/config/validators_boundary_test.go
+++ b/internal/config/validators_boundary_test.go
@@ -117,7 +117,7 @@ func smoothCursorIntBounds() []intBound {
 			name:     "smooth_cursor.relative_duration",
 			set:      func(c *config.Config, v int) { c.SmoothCursor.RelativeDuration = v },
 			validate: (*config.Config).ValidateSmoothCursor,
-			minValid: 1,
+			minValid: config.MinSmoothCursorRelativeDuration,
 		},
 	}
 }

--- a/internal/config/validators_boundary_test.go
+++ b/internal/config/validators_boundary_test.go
@@ -109,13 +109,13 @@ func visionIntBounds() []intBound {
 
 // smoothCursorIntBounds covers the smooth cursor integer fields with an
 // inclusive lower limit. The relative duration is checked unconditionally —
-// not gated on enabled — because it is read straight by the animator on the
-// next relative move after a hot reload flips the toggle.
+// not gated on move_mouse_enabled — because it is read straight by the
+// animator on the next relative move after a hot reload flips the toggle.
 func smoothCursorIntBounds() []intBound {
 	return []intBound{
 		{
-			name:     "smooth_cursor.relative.duration",
-			set:      func(c *config.Config, v int) { c.SmoothCursor.Relative.Duration = v },
+			name:     "smooth_cursor.relative_duration",
+			set:      func(c *config.Config, v int) { c.SmoothCursor.RelativeDuration = v },
 			validate: (*config.Config).ValidateSmoothCursor,
 			minValid: 1,
 		},

--- a/internal/config/validators_boundary_test.go
+++ b/internal/config/validators_boundary_test.go
@@ -107,6 +107,25 @@ func visionIntBounds() []intBound {
 	}
 }
 
+// smoothCursorIntBounds covers the smooth cursor integer fields with an
+// inclusive lower limit. The relative duration is checked unconditionally —
+// not gated on enabled — because it is read straight by the animator on the
+// next relative move after a hot reload flips the toggle.
+func smoothCursorIntBounds() []intBound {
+	return []intBound{
+		{
+			name:     "smooth_cursor.relative.duration",
+			set:      func(c *config.Config, v int) { c.SmoothCursor.Relative.Duration = v },
+			validate: (*config.Config).ValidateSmoothCursor,
+			minValid: 1,
+		},
+	}
+}
+
+func TestConfig_SmoothCursorRelativeBoundaries(t *testing.T) {
+	runIntBounds(t, smoothCursorIntBounds())
+}
+
 // validBase returns a config that every validator accepts, so a failure in a
 // table case can only come from the single field that case changed.
 func validBase(t *testing.T) *config.Config {

--- a/internal/config/validators_pointer.go
+++ b/internal/config/validators_pointer.go
@@ -52,10 +52,10 @@ func (c *Config) ValidateSmoothCursor() error {
 		)
 	}
 
-	if c.SmoothCursor.Relative.Duration < 1 {
+	if c.SmoothCursor.RelativeDuration < 1 {
 		return derrors.New(
 			derrors.CodeInvalidConfig,
-			"smooth_cursor.relative.duration must be >= 1",
+			"smooth_cursor.relative_duration must be >= 1",
 		)
 	}
 

--- a/internal/config/validators_pointer.go
+++ b/internal/config/validators_pointer.go
@@ -52,14 +52,14 @@ func (c *Config) ValidateSmoothCursor() error {
 		)
 	}
 
-	// The animator floors every animation at 10ms (minAnimationDuration in the
-	// darwin adapter), so smaller values would be silently rounded up rather
-	// than honored; reject them instead.
-	if c.SmoothCursor.RelativeDuration < MinSmoothCursorRelativeDuration {
+	// The animator floors every animation at MinSmoothCursorAnimationDuration,
+	// so smaller values would be silently rounded up rather than honored;
+	// reject them instead.
+	if c.SmoothCursor.RelativeMovementDuration < MinSmoothCursorAnimationDuration {
 		return derrors.Newf(
 			derrors.CodeInvalidConfig,
-			"smooth_cursor.relative_duration must be >= %d",
-			MinSmoothCursorRelativeDuration,
+			"smooth_cursor.relative_movement_duration must be >= %d",
+			MinSmoothCursorAnimationDuration,
 		)
 	}
 

--- a/internal/config/validators_pointer.go
+++ b/internal/config/validators_pointer.go
@@ -52,10 +52,14 @@ func (c *Config) ValidateSmoothCursor() error {
 		)
 	}
 
-	if c.SmoothCursor.RelativeDuration < 1 {
-		return derrors.New(
+	// The animator floors every animation at 10ms (minAnimationDuration in the
+	// darwin adapter), so smaller values would be silently rounded up rather
+	// than honored; reject them instead.
+	if c.SmoothCursor.RelativeDuration < MinSmoothCursorRelativeDuration {
+		return derrors.Newf(
 			derrors.CodeInvalidConfig,
-			"smooth_cursor.relative_duration must be >= 1",
+			"smooth_cursor.relative_duration must be >= %d",
+			MinSmoothCursorRelativeDuration,
 		)
 	}
 

--- a/internal/config/validators_pointer.go
+++ b/internal/config/validators_pointer.go
@@ -52,6 +52,13 @@ func (c *Config) ValidateSmoothCursor() error {
 		)
 	}
 
+	if c.SmoothCursor.Relative.Duration < 1 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"smooth_cursor.relative.duration must be >= 1",
+		)
+	}
+
 	return nil
 }
 

--- a/internal/ports/system.go
+++ b/internal/ports/system.go
@@ -143,6 +143,21 @@ type RelativeCursorMover interface {
 	MoveCursorBy(ctx context.Context, delta image.Point) (handled bool, err error)
 }
 
+// CursorSettler is an optional SystemPort extension for platforms that
+// animate cursor movement asynchronously. SettleCursor finishes any in-flight
+// animation immediately — stopping it and placing the cursor at the endpoint
+// it was animating toward — so a position-dependent action that fires
+// mid-animation acts at the point the user aimed for.
+//
+// Callers resolving an action's target point from the cursor call this before
+// reading the position; plain observers (indicator followers, pollers) read
+// the position directly so animations are not cut short. Treat a missing
+// implementation as "already settled".
+type CursorSettler interface {
+	// SettleCursor finishes any in-flight cursor animation immediately.
+	SettleCursor(ctx context.Context) error
+}
+
 // CursorSynchronizer is an optional SystemPort extension for platforms whose
 // cursor position is cached client-side and can drift from the compositor's.
 //

--- a/internal/ports/system.go
+++ b/internal/ports/system.go
@@ -131,12 +131,15 @@ type SystemPort interface {
 //
 // Implemented by the Linux adapter, whose Wayland backends have no
 // authoritative cursor query — warping to position+delta would compound the
-// cache error, so the delta is applied directly. Fall back to CursorPosition +
-// MoveCursorToPoint when unimplemented or handled == false.
+// cache error, so the delta is applied directly. Also implemented by the
+// darwin adapter, which animates relative moves when smooth_cursor.relative
+// is enabled. Fall back to CursorPosition + MoveCursorToPoint when
+// unimplemented or handled == false.
 type RelativeCursorMover interface {
 	// MoveCursorBy moves the cursor by delta from its current position.
-	// It returns handled == false when this particular backend cannot apply
-	// the delta natively, which means the caller should use its fallback.
+	// It returns handled == false when this particular backend cannot — or,
+	// per configuration, chooses not to — apply the delta itself, which means
+	// the caller should use its fallback.
 	MoveCursorBy(ctx context.Context, delta image.Point) (handled bool, err error)
 }
 

--- a/internal/ports/system.go
+++ b/internal/ports/system.go
@@ -132,8 +132,8 @@ type SystemPort interface {
 // Implemented by the Linux adapter, whose Wayland backends have no
 // authoritative cursor query — warping to position+delta would compound the
 // cache error, so the delta is applied directly. Also implemented by the
-// darwin adapter, which animates relative moves when smooth_cursor.relative
-// is enabled. Fall back to CursorPosition + MoveCursorToPoint when
+// darwin adapter, which animates relative moves when smooth cursor is
+// enabled. Fall back to CursorPosition + MoveCursorToPoint when
 // unimplemented or handled == false.
 type RelativeCursorMover interface {
 	// MoveCursorBy moves the cursor by delta from its current position.


### PR DESCRIPTION
## Description

This PR makes smooth-cursor animation cover relative (keyboard-driven) mouse movement — the hjkl-style `move_mouse_relative` steps that previously always warped instantly even with `[smooth_cursor]` enabled. With `move_mouse_enabled = true`, all cursor movement now animates.

The motivation is visual ergonomics: a cursor that teleports in discrete steps under held-key repeat is hard to follow with the eyes; a short glide keeps it trackable and is noticeably less straining. Relative moves deliberately do not reuse the jump animation's distance-proportional duration: that math produces constant velocity, so a 50px step would move no faster than a 10px one. Instead each relative move animates over a fixed duration (`relative_movement_duration`, default 50ms), so cursor speed scales with the per-move delta — and composes naturally with `held_repeat` acceleration (#1120), whose growing deltas translate directly into growing speed. While an animation is in flight, the next delta extends its endpoint rather than restarting from the current position, so no part of a delta is lost under key repeat.

macOS only for now; on Linux and Windows relative moves stay instant (documented in the platform tables). With smooth cursor disabled (the default), behavior is completely unchanged.

## Related Issues

None. (CONTRIBUTING suggests an issue first for non-trivial changes — happy to open one for discussion and link it here if you prefer that flow.)

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code) — config surface only
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new port method: the darwin adapter opts into the existing optional relative-move extension, and where it does not apply callers take their existing instant-warp fallback, which is exactly the previous behavior.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config Changes

One new key under `[smooth_cursor]`; existing configs keep working unchanged. No new toggle — `move_mouse_enabled` now covers relative movement too (see behavior note below).

| Key | Type | Default | Meaning |
| --- | ---- | ------- | ------- |
| `smooth_cursor.relative_movement_duration` | int | `50` | Fixed animation duration per relative move in ms (>= 10), macOS only |

```toml
[smooth_cursor]
move_mouse_enabled = true
relative_movement_duration = 50   # matches the held_repeat interval so animations chain seamlessly
```

The key is settable at runtime via `neru config set` and hot-reloads like the rest of `[smooth_cursor]`.

To see it live: enable the snippet above, then hold a `move_mouse_relative` binding (default hjkl in pointer contexts) or run `neru action move_mouse_relative --dx=50 --dy=0`.

## Behavior Change for Existing Smooth-Cursor Users

Users who already run with `move_mouse_enabled = true` will see relative (hjkl) moves start animating after this change — previously they always warped. This is the intended reading of the option (smooth cursor covers cursor movement, full stop) and the default 50ms glide is subtle; there is currently no separate opt-out for relative moves while keeping jump animation. If that combination turns out to be wanted, an opt-out can be added later.

## Additional Context

Two alternatives were considered and rejected:

- **Distance thresholds** (animate small/large moves differently based on a configurable cutoff): the dispatcher already knows whether a move is a jump or a relative step, so a threshold would only reconstruct — imprecisely — information the code has. The semantic split keeps both animation models exact and needs no user calibration.
- **Reusing the jump animator as-is for relative moves**: rejected for the constant-velocity math above, and because restarting each repeat from the mid-animation cursor position silently discards the un-animated remainder of every delta, capping effective speed at `1 / duration_per_pixel` regardless of the configured step size.

The implementation is minimally invasive: no port signature changes, no behavior change unless smooth cursor is enabled. Endpoint extension is done atomically under the animator's existing lock so two concurrent held-repeat sources (mode repeat and hotkey repeat) compose their deltas instead of losing one — pinned by a new `-race` test with 8 concurrent movers. The pending endpoint is clamped to the active screen so holding a key at a screen edge cannot make the target drift off-screen and delay the way back.

Review update: the first revision introduced a separate `[smooth_cursor.relative]` section with its own `enabled` toggle; per review feedback this was folded under `move_mouse_enabled`, and the remaining single tuning key was flattened to `relative_movement_duration`.
