### PR TITLE
fix(scroll): anchor scrolls where the cursor is headed during animated moves

### DIFF
--- a/internal/app/services/scroll_service.go
+++ b/internal/app/services/scroll_service.go
@@ -75,6 +75,17 @@ func (s *ScrollService) Scroll(
 ) error {
 	deltaX, deltaY := s.calculateDelta(ctx, direction, amount, stepOverride)
 
+	// A scroll anchors to the window under the cursor: finish any in-flight
+	// cursor animation first (ports.CursorSettler), so a scroll fired
+	// mid-animation targets the window the user aimed for instead of one the
+	// cursor happens to be gliding over.
+	if settler, ok := s.system.(ports.CursorSettler); ok {
+		err := settler.SettleCursor(ctx)
+		if err != nil {
+			s.logger.Warn("Failed to settle cursor animation", zap.Error(err))
+		}
+	}
+
 	s.logger.Debug("Scrolling",
 		zap.Int("dir", int(direction)),
 		zap.Int("amount", int(amount)),

--- a/internal/app/services/scroll_service_test.go
+++ b/internal/app/services/scroll_service_test.go
@@ -488,3 +488,102 @@ func TestScrollService_UpdateConfig(t *testing.T) {
 		)
 	}
 }
+
+// settlingSystemPort is a MockSystemPort that also implements
+// ports.CursorSettler, recording settle calls so tests can pin ordering
+// against the scroll itself.
+type settlingSystemPort struct {
+	mocks.MockSystemPort
+
+	settleCalls int
+	settleErr   error
+}
+
+func (s *settlingSystemPort) SettleCursor(_ context.Context) error {
+	s.settleCalls++
+
+	return s.settleErr
+}
+
+// TestScrollService_Scroll_SettlesCursorBeforeScroll pins the interleaving fix
+// for scrolls fired during an animated relative cursor move: the in-flight
+// animation must be settled before the scroll is dispatched, so the scroll
+// anchors to the window the user aimed for rather than one the cursor was
+// gliding over mid-animation.
+func TestScrollService_Scroll_SettlesCursorBeforeScroll(t *testing.T) {
+	system := &settlingSystemPort{}
+
+	settledAtScrollTime := -1
+	mockAcc := &mocks.MockAccessibilityPort{
+		ScrollFunc: func(_ context.Context, _, _ int) error {
+			settledAtScrollTime = system.settleCalls
+
+			return nil
+		},
+	}
+
+	service := services.NewScrollService(
+		mockAcc,
+		&mocks.MockOverlayPort{},
+		system,
+		config.ScrollConfig{ScrollStep: 10, ScrollStepHalf: 30, ScrollStepFull: 50},
+		logger.Get(),
+	)
+
+	err := service.Scroll(
+		context.Background(),
+		services.ScrollDirectionDown,
+		services.ScrollAmountChar,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("Scroll() error = %v, want nil", err)
+	}
+
+	if settledAtScrollTime != 1 {
+		t.Errorf(
+			"settle calls observed at scroll time = %d, want 1 (settle must run before the scroll)",
+			settledAtScrollTime,
+		)
+	}
+}
+
+// TestScrollService_Scroll_SettleErrorDoesNotBlockScroll pins that a failing
+// settle degrades to the pre-settle behavior — the scroll still runs — rather
+// than turning a cosmetic animation problem into a lost user action.
+func TestScrollService_Scroll_SettleErrorDoesNotBlockScroll(t *testing.T) {
+	system := &settlingSystemPort{
+		settleErr: derrors.New(derrors.CodeActionFailed, "settle failed"),
+	}
+
+	scrolled := false
+	mockAcc := &mocks.MockAccessibilityPort{
+		ScrollFunc: func(_ context.Context, _, _ int) error {
+			scrolled = true
+
+			return nil
+		},
+	}
+
+	service := services.NewScrollService(
+		mockAcc,
+		&mocks.MockOverlayPort{},
+		system,
+		config.ScrollConfig{ScrollStep: 10, ScrollStepHalf: 30, ScrollStepFull: 50},
+		logger.Get(),
+	)
+
+	err := service.Scroll(
+		context.Background(),
+		services.ScrollDirectionDown,
+		services.ScrollAmountChar,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("Scroll() error = %v, want nil (settle failure must not fail the scroll)", err)
+	}
+
+	if !scrolled {
+		t.Error("Scroll() never reached the accessibility port after a settle error")
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes scrolls fired while a smooth cursor animation is still in flight. Previously such a scroll anchored to whatever window sat under the cursor's transient mid-animation position; since relative (hjkl) moves gained animation in #1179, the fast move-then-scroll motion could scroll the wrong window. A scroll now first finishes any in-flight animation — stopping it and placing the cursor at the endpoint it was headed for — so it always targets the window the user aimed at, with no added latency.

This is the same interleaving guarantee #1179 gave clicks, extended to scrolls. Platforms without animated cursor movement are unchanged, and if settling ever fails the scroll still goes through as before rather than being dropped.

## Related Issues

follow-up to #1179 

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS — the only platform that currently animates cursor moves, so the only place the fix is observable today
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `fix` — Bug fix

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config Changes

None. No new options, defaults, commands, or flags; existing configs keep working untouched.

## Additional Context

Two tests pin the behavior: one asserts the settle happens before the scroll dispatches (ordering, not just occurrence), the other asserts a settle failure degrades to the pre-fix behavior — the scroll still runs — so an animation problem can never eat a user action.

Two adjacent cases were considered and deliberately left unchanged:

- The smooth-scroll animator re-reads the cursor per chunk so a long scroll follows the cursor if it genuinely moves; that behavior is intentional and unaffected — settling happens once, before dispatch.
- The mode-exit safety release of held mouse buttons still cancels (rather than settles) an in-flight animation before releasing. That path is an emergency cleanup where "release immediately, wherever the cursor is" is arguably the right semantics; happy to revisit if drag drop-offs mid-animation turn out to matter in practice.
