### PR TITLE
feat(smooth_cursor): animate relative cursor moves on Linux

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -391,7 +391,7 @@ move_mouse_enabled = false                  # Enable smooth mouse movement
 steps = 10                                  # Number of intermediate positions
 max_duration = 200                          # Maximum animation duration in ms
 duration_per_pixel = 0.1                    # Ms per pixel for adaptive duration
-relative_movement_duration = 50             # Fixed duration per relative (hjkl) move in ms (macOS only)
+relative_movement_duration = 50             # Fixed duration per relative (hjkl) move in ms (macOS/Linux)
 
 # Smooth scroll (animates scroll actions with eased chunking)
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#smooth_scroll

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -105,7 +105,7 @@ Every option not listed here behaves the same on all three platforms.
 | `[monitor_select]`                        | Yes   | Yes   | No      | Windows: the mode returns `ERR_NOT_SUPPORTED`.       |
 | `[virtual_pointer]`                       | Yes   | No    | No      | Ignored; pairs with macOS-only cursor hiding.        |
 | `[smooth_cursor]`                         | Yes   | Yes   | No      | Windows: cursor moves instantly.                     |
-| `smooth_cursor.relative_movement_duration` | Yes  | No    | No      | Linux and Windows: relative moves stay instant.      |
+| `smooth_cursor.relative_movement_duration` | Yes  | Yes   | No      | Windows: relative moves stay instant.                |
 | `[smooth_scroll]`                         | Yes   | No    | No      | Linux and Windows: scrolling is instant.             |
 | `[recursive_grid.animation]`              | Yes   | Yes   | No      | Windows: depth transitions are not animated.         |
 
@@ -1434,8 +1434,10 @@ animation is still in flight, a new relative move extends its endpoint instead
 of restarting from the current position, so no part of a delta is lost under
 key repeat.
 
-Relative animation is supported on macOS; on Linux and Windows relative moves
-always warp instantly. It composes with
+Relative animation is supported on macOS and Linux (X11 and the Wayland
+wlroots/KDE backends; on wlroots the animation is applied as native relative
+motion, never as position warps). On Windows relative moves always warp
+instantly. It composes with
 [`held_repeat` acceleration](#held_repeat): the accelerated deltas pass
 through unchanged, and since animation speed scales with the delta, the cursor
 speeds up over the ramp exactly as without animation — just smoothly.

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -130,7 +130,7 @@ or no-op) · ❌ no code path
 | **Cursor move**               | ✅ `CGWarpMouseCursorPosition` | ✅ XTest         | ✅ `zwlr_virtual_pointer`    | ✅ libei                | ✅ `SetCursorPos`            |
 | **Mouse buttons / drag**      | ✅ `CGEventPost`         | ✅ XTest               | ✅ `zwlr_virtual_pointer`    | ✅ libei                | ✅ `SendInput`               |
 | **Scroll injection**          | ✅ both axes             | ✅ both axes           | ✅ both axes (uinput + virtual pointer) | ✅ libei     | ⚠️ vertical only             |
-| **Smooth cursor animation**   | ✅ (incl. relative, opt-in) | ✅ opt-in, jumps only | ✅ opt-in, jumps only      | ✅ opt-in, jumps only   | ❌                           |
+| **Smooth cursor animation**   | ✅ (incl. relative, opt-in) | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ❌                        |
 | **Smooth scroll animation**   | ✅                       | ❌                     | ❌                           | ❌                      | ❌                           |
 | **Element discovery (hints)** | ✅ AXUIElement           | ⚠️ AT-SPI walk         | ⚠️ AT-SPI walk               | ⚠️ AT-SPI walk          | ⚠️ UIA, shallow tree         |
 | **Overlay**                   | ✅ NSPanel + CoreAnimation | ✅ X11 + Cairo       | ✅ layer-shell + Cairo       | ✅ layer-shell + Cairo  | ✅ layered HWND + GDI        |
@@ -201,6 +201,16 @@ covers the same flows macOS animates — grid/recursive-grid cursor-follow,
 `move_mouse`, selection moves; clicks stay instant. On Wayland the interpolation
 start point comes from the client-side cursor cache, so a stale read only skews
 the glide path, never the landing point.
+
+Relative (hjkl) moves animate too, with the fixed per-move duration
+`smooth_cursor.relative_movement_duration`, matching macOS. X11 and KDE extend
+the absolute animator's pending endpoint; wlroots instead drains the delta in
+integer chunks through native relative motion
+([relative_animator.go](../internal/adapter/platform/linux/relative_animator.go)) —
+the animation never reads the client position cache, preserving the exactness
+that made wlroots apply deltas natively in the first place. Position-dependent
+actions (clicks, scrolls) settle the in-flight animation before acting, so an
+action fired mid-glide lands where the user aimed.
 
 ---
 
@@ -385,7 +395,7 @@ important thing to know before touching overlay code:
 | ---------------------------- | ------------------------------------ | ---------------------------------- | ---------------------------------- |
 | **Grid transition**          | CoreAnimation, ease-in-out @120Hz    | goroutine, smoothstep @120fps      | ❌                                 |
 | **Mouse action indicator**   | `CABasicAnimation` (scale + opacity) | goroutine, scale + opacity @120fps | goroutine, cubic easing @60fps     |
-| **Smooth cursor**            | ✅ configurable easing               | ✅ stepped warp (opt-in)           | ❌                                 |
+| **Smooth cursor**            | ✅ configurable easing               | ✅ stepped warp, incl. relative (opt-in) | ❌                           |
 | **Smooth scroll**            | ✅ ease-out cubic                    | ❌                                 | ❌                                 |
 
 ---

--- a/internal/adapter/platform/linux/mouse_animator.go
+++ b/internal/adapter/platform/linux/mouse_animator.go
@@ -51,6 +51,7 @@ type cursorRequest struct {
 	steps            int
 	maxDuration      int
 	durationPerPixel float64
+	fixedDuration    int // when > 0, overrides the distance-derived duration
 }
 
 // smoothCursorAnimator glides the cursor toward a target, matching the darwin
@@ -75,6 +76,12 @@ type smoothCursorAnimator struct {
 	stopCh chan struct{}
 	done   *cursorAnimationDone // current session completion; nil only between stop() and the next session
 	busy   bool                 // a session is in progress (worker actively draining toward a target)
+
+	// pendingEnd is the target of the animation currently in flight. Relative
+	// moves extend it instead of restarting from the (possibly stale) cursor
+	// position, so no part of a delta is lost under key repeat.
+	pendingEnd image.Point
+	hasPending bool
 
 	// injectSem is a size-1 semaphore serializing actual backend injection (one
 	// step at a time) and is the ordering handoff to stop(): the worker holds it
@@ -107,6 +114,7 @@ func (a *smoothCursorAnimator) stop() {
 	a.stopCh = nil
 	a.done = nil
 	a.busy = false
+	a.hasPending = false
 
 	if stopCh != nil {
 		close(stopCh)
@@ -121,6 +129,53 @@ func (a *smoothCursorAnimator) stop() {
 	// step that has not yet injected will see the closed stopCh (in stepMove) and
 	// skip. The caller's subsequent moveCursorDirect therefore lands last.
 	a.injectSem <- struct{}{}
+
+	<-a.injectSem
+}
+
+// pendingTarget returns the endpoint of the animation currently in flight,
+// or ok == false when no animation is active.
+func (a *smoothCursorAnimator) pendingTarget() (image.Point, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.pendingEnd, a.hasPending
+}
+
+// settle finishes any in-flight animation immediately: the worker is canceled
+// and the cursor warps straight to the endpoint it was animating toward.
+// Position-dependent actions call this so an action firing mid-animation acts
+// at the point the user aimed for, without waiting the animation out. The
+// warp happens under injectSem — the same fence stop() uses — so a canceled
+// step can never land after it.
+func (a *smoothCursorAnimator) settle() {
+	a.mu.Lock()
+
+	if !a.hasPending {
+		a.mu.Unlock()
+
+		return
+	}
+
+	end := a.pendingEnd
+	stopCh := a.stopCh
+	done := a.done
+	a.reqCh = nil
+	a.stopCh = nil
+	a.done = nil
+	a.busy = false
+	a.hasPending = false
+
+	if stopCh != nil {
+		close(stopCh)
+	}
+	a.mu.Unlock()
+
+	done.close()
+
+	a.injectSem <- struct{}{}
+
+	_ = a.move(end)
 
 	<-a.injectSem
 }
@@ -194,6 +249,52 @@ func (a *smoothCursorAnimator) animateTo(
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
+	a.submitLocked(req)
+}
+
+// animateRelativeBy animates a relative move with a fixed duration,
+// independent of the distance, so that cursor speed scales with the per-move
+// delta instead of collapsing to the constant velocity the
+// distance-proportional duration would produce.
+//
+// The base is the pending endpoint of the animation in flight (falling back
+// to the sampled cursor position), extended by delta and clamped by the
+// caller's clamp. Base computation, bookkeeping, and submission all happen
+// under one lock hold, so two concurrent relative movers compose their deltas
+// instead of one silently overwriting the other's endpoint.
+func (a *smoothCursorAnimator) animateRelativeBy(
+	delta image.Point,
+	clamp func(image.Point) image.Point,
+	steps int,
+	durationMs int,
+) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	base := a.pendingEnd
+	if !a.hasPending {
+		base = a.pos()
+	}
+
+	end := clamp(base.Add(delta))
+	if end == base {
+		// Nothing to animate: the delta was zero or the clamp ate it at a
+		// screen edge. The in-flight animation (if any) already targets base,
+		// so submitting would only cancel and restart it.
+		return
+	}
+
+	a.submitLocked(cursorRequest{
+		end:           end,
+		steps:         steps,
+		fixedDuration: durationMs,
+	})
+}
+
+// submitLocked records req as the pending animation target and hands it to
+// the worker, starting the worker and a fresh session completion when needed.
+// Callers must hold a.mu.
+func (a *smoothCursorAnimator) submitLocked(req cursorRequest) {
 	if a.reqCh == nil {
 		a.reqCh = make(chan cursorRequest, 1)
 		a.stopCh = make(chan struct{})
@@ -205,6 +306,9 @@ func (a *smoothCursorAnimator) animateTo(
 		a.done = newCursorAnimationDone()
 		a.busy = true
 	}
+
+	a.pendingEnd = req.end
+	a.hasPending = true
 
 	a.enqueueLocked(req)
 }
@@ -263,6 +367,10 @@ restart:
 	distance := math.Hypot(float64(req.end.X-start.X), float64(req.end.Y-start.Y))
 
 	duration := math.Min(float64(req.maxDuration), distance*req.durationPerPixel)
+	if req.fixedDuration > 0 {
+		duration = float64(req.fixedDuration)
+	}
+
 	if duration < minCursorAnimationDuration {
 		duration = minCursorAnimationDuration
 	}
@@ -358,6 +466,7 @@ func (a *smoothCursorAnimator) finishOrNext(
 
 	done := a.done
 	a.busy = false
+	a.hasPending = false
 	a.mu.Unlock()
 
 	done.close()

--- a/internal/adapter/platform/linux/mouse_animator_test.go
+++ b/internal/adapter/platform/linux/mouse_animator_test.go
@@ -344,3 +344,181 @@ func TestSmoothCursorAnimatorStopReleasesWaiter(t *testing.T) {
 		t.Fatalf("wait after stop returned error: %v", err)
 	}
 }
+
+// identityClamp passes points through unchanged, for tests that exercise
+// relative animation away from screen edges.
+func identityClamp(p image.Point) image.Point { return p }
+
+// TestSmoothCursorAnimatorPendingTargetLifecycle pins the pending-target
+// contract relative moves build on: the endpoint of the animation in flight
+// is visible while it is pending and gone once the animation is stopped.
+func TestSmoothCursorAnimatorPendingTargetLifecycle(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	if _, ok := animator.pendingTarget(); ok {
+		t.Fatal("pendingTarget() reported an animation before any was submitted")
+	}
+
+	// A slow glide so the session is still pending when we look.
+	target := image.Point{X: 400, Y: 300}
+	animator.animateTo(target, 10, 5000, 50)
+
+	got, ok := animator.pendingTarget()
+	if !ok || got != target {
+		t.Fatalf("pendingTarget() = %v, %v mid-animation, want %v, true", got, ok, target)
+	}
+
+	animator.stop()
+
+	if _, ok := animator.pendingTarget(); ok {
+		t.Fatal("pendingTarget() still reports an animation after stop()")
+	}
+}
+
+// TestSmoothCursorAnimatorRelativeLandsExactly pins that a relative move from
+// idle animates as a stepped glide and lands exactly on start+delta.
+func TestSmoothCursorAnimatorRelativeLandsExactly(t *testing.T) {
+	t.Parallel()
+
+	start := image.Point{X: 7, Y: 9}
+	rec := &recorder{start: start}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	delta := image.Point{X: 35, Y: -20}
+	animator.animateRelativeBy(delta, identityClamp, 5, 30)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	last, ok := rec.last()
+	if !ok {
+		t.Fatal("expected at least one move to be injected")
+	}
+
+	if want := start.Add(delta); last != want {
+		t.Fatalf("relative move landed on %v, want %v", last, want)
+	}
+
+	if rec.count() < 2 {
+		t.Fatalf("expected a stepped glide (>=2 moves), got %d", rec.count())
+	}
+}
+
+// TestSmoothCursorAnimatorRelativeExtendsPendingEndpoint pins the held-repeat
+// contract: a delta arriving mid-animation extends the pending endpoint
+// instead of restarting from the mid-glide position, and settle() warps
+// straight to the extended endpoint.
+func TestSmoothCursorAnimatorRelativeExtendsPendingEndpoint(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	// Long fixed durations so both deltas land in one pending session.
+	animator.animateRelativeBy(image.Point{X: 10, Y: 0}, identityClamp, 10, 5000)
+	animator.animateRelativeBy(image.Point{X: 15, Y: 5}, identityClamp, 10, 5000)
+
+	want := image.Point{X: 25, Y: 5}
+
+	if got, pending := animator.pendingTarget(); !pending || got != want {
+		t.Fatalf("pendingTarget() = %v, %v after two deltas, want %v, true", got, pending, want)
+	}
+
+	animator.settle()
+
+	if last, moved := rec.last(); !moved || last != want {
+		t.Fatalf("settle() warped to %v, %v, want %v, true", last, moved, want)
+	}
+
+	if _, pending := animator.pendingTarget(); pending {
+		t.Fatal("pendingTarget() still reports an animation after settle()")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait after settle returned error: %v", err)
+	}
+}
+
+// TestSmoothCursorAnimatorRelativeNoopKeepsAnimation pins the screen-edge
+// guard: a delta the clamp fully absorbs must not cancel and restart the
+// animation already heading to the pending endpoint.
+func TestSmoothCursorAnimatorRelativeNoopKeepsAnimation(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	end := image.Point{X: 50, Y: 0}
+	animator.animateRelativeBy(end, identityClamp, 10, 5000)
+
+	// Clamp everything back to the pending endpoint, as a screen edge would.
+	animator.animateRelativeBy(image.Point{X: 100, Y: 0}, func(image.Point) image.Point {
+		return end
+	}, 10, 5000)
+
+	got, ok := animator.pendingTarget()
+	if !ok || got != end {
+		t.Fatalf("pendingTarget() = %v, %v after clamped no-op, want %v, true", got, ok, end)
+	}
+
+	animator.stop()
+}
+
+// TestSmoothCursorAnimatorRelativeConcurrentDeltasCompose pins the
+// single-lock read-modify-write of animateRelativeBy: deltas from concurrent
+// movers must all end up in the final position, none silently overwritten.
+// The recorder's pos() returns the last landed point, so composition must
+// stay exact even across session boundaries.
+func TestSmoothCursorAnimatorRelativeConcurrentDeltasCompose(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	const movers = 8
+
+	const deltasPerMover = 25
+
+	var waitGroup sync.WaitGroup
+	for range movers {
+		waitGroup.Go(func() {
+			for range deltasPerMover {
+				animator.animateRelativeBy(image.Point{X: 1, Y: 0}, identityClamp, 2, 1)
+			}
+		})
+	}
+
+	waitGroup.Wait()
+
+	animator.settle()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	last, ok := rec.last()
+	if !ok {
+		t.Fatal("expected moves to be injected")
+	}
+
+	if want := movers * deltasPerMover; last.X != want {
+		t.Fatalf("final X = %d after %d concurrent unit deltas, want %d (lost deltas)",
+			last.X, want, want)
+	}
+}

--- a/internal/adapter/platform/linux/relative_animator.go
+++ b/internal/adapter/platform/linux/relative_animator.go
@@ -1,0 +1,302 @@
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"image"
+	"math"
+	"sync"
+	"time"
+)
+
+// relativeCursorAnimator animates relative cursor moves on backends whose
+// only trustworthy motion primitive is a native delta (Wayland wlroots, where
+// there is no authoritative cursor query and read-then-warp would compound
+// the client cache error). It never reads a position: the remaining delta is
+// drained in integer chunks that sum exactly to the requested total, each
+// posted as one native relative motion.
+//
+// A delta arriving while a drain is in flight is added to the remaining
+// total and the drain schedule restarts, so held-key repeat composes
+// losslessly — the wlroots twin of the absolute animator's pending-endpoint
+// extension. Completion is per session, mirroring smoothCursorAnimator, so
+// WaitForCursorIdle tracks the latest delta rather than an intermediate one.
+type relativeCursorAnimator struct {
+	moveBy func(image.Point) error
+
+	mu        sync.Mutex
+	remaining image.Point // un-posted delta of the drain in flight
+	stepsLeft int
+	stepDelay time.Duration
+	running   bool
+	stopCh    chan struct{}
+	done      *cursorAnimationDone // session completion; nil until the first session
+
+	// injectSem serializes backend injection and is the ordering handoff to
+	// stop()/settle(), exactly as in smoothCursorAnimator: the worker holds it
+	// across each chunk and re-checks stopCh under it, so once a canceler
+	// acquires the token no canceled chunk is mid-flight and none will start.
+	injectSem chan struct{}
+}
+
+func newRelativeCursorAnimator(moveBy func(image.Point) error) *relativeCursorAnimator {
+	return &relativeCursorAnimator{
+		moveBy:    moveBy,
+		injectSem: make(chan struct{}, 1),
+	}
+}
+
+// addDelta folds delta into the drain in flight (starting one when idle) and
+// restarts the schedule: the combined remainder drains over durationMs in at
+// most steps chunks. Chunks are integer subdivisions, so the posted motions
+// always sum exactly to the accumulated deltas — nothing is lost to rounding.
+func (a *relativeCursorAnimator) addDelta(delta image.Point, steps, durationMs int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.remaining = a.remaining.Add(delta)
+	if a.remaining == (image.Point{}) && !a.running {
+		return
+	}
+
+	duration := float64(durationMs)
+	if duration < minCursorAnimationDuration {
+		duration = minCursorAnimationDuration
+	}
+
+	actualSteps := steps
+	if actualSteps <= 0 {
+		actualSteps = defaultCursorSteps
+	}
+
+	maxSteps := max(int(duration/float64(minCursorStepDelay)), 1)
+	if actualSteps > maxSteps {
+		actualSteps = maxSteps
+	}
+
+	a.stepsLeft = actualSteps
+	stepDelayMs := max(int(math.Round(duration/float64(actualSteps))), minCursorStepDelay)
+	a.stepDelay = time.Duration(stepDelayMs) * time.Millisecond
+
+	if !a.running {
+		a.running = true
+		a.done = newCursorAnimationDone()
+		a.stopCh = make(chan struct{})
+
+		go a.run(a.stopCh)
+	}
+}
+
+// run drains the remaining delta one chunk per tick until it reaches zero,
+// then ends the session. All shared state is re-read under a.mu each tick, so
+// deltas folded in mid-drain are picked up on the next chunk.
+func (a *relativeCursorAnimator) run(stopCh chan struct{}) {
+	timer := time.NewTimer(time.Hour)
+
+	stopAndDrainTimer(timer)
+	defer timer.Stop()
+
+	for {
+		chunk, delay, ok := a.nextChunk(stopCh)
+		if !ok {
+			return
+		}
+
+		if chunk != (image.Point{}) && !a.stepChunk(chunk, stopCh) {
+			return
+		}
+
+		timer.Reset(delay)
+
+		select {
+		case <-stopCh:
+			stopAndDrainTimer(timer)
+
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+// nextChunk carves the next integer chunk off the remaining delta under a.mu.
+// It reports ok == false when this worker has been superseded (stopCh
+// identity, as in smoothCursorAnimator.finishOrNext) or when the drain is
+// complete, in which case it ends the session — keeping a.done referencing
+// the closed completion so a late WaitForCursorIdle still sees "idle".
+func (a *relativeCursorAnimator) nextChunk(
+	stopCh chan struct{},
+) (image.Point, time.Duration, bool) {
+	a.mu.Lock()
+
+	if a.stopCh != stopCh {
+		a.mu.Unlock()
+
+		return image.Point{}, 0, false
+	}
+
+	if a.remaining == (image.Point{}) {
+		done := a.done
+		a.running = false
+		a.stopCh = nil
+		a.mu.Unlock()
+
+		done.close()
+
+		return image.Point{}, 0, false
+	}
+
+	chunk := image.Point{
+		X: a.remaining.X / a.stepsLeft,
+		Y: a.remaining.Y / a.stepsLeft,
+	}
+	if a.stepsLeft <= 1 {
+		chunk = a.remaining
+	}
+
+	if a.stepsLeft > 1 {
+		a.stepsLeft--
+	}
+
+	delay := a.stepDelay
+	a.mu.Unlock()
+
+	return chunk, delay, true
+}
+
+// stepChunk posts one native relative motion while holding injectSem,
+// re-checking stopCh so a chunk cannot inject once the session is canceled.
+//
+// The chunk is deducted from the remaining delta only after it is posted, and
+// re-clamped against remaining at post time. Together these keep the drain's
+// core invariant — posted + remaining == accumulated deltas — through every
+// cancellation interleaving: a chunk canceled between selection and injection
+// was never deducted, so settle() flushes it; a chunk selected by a new
+// session while settle() was zeroing remaining clamps to zero and is skipped
+// rather than double-posted. Taking mu while holding injectSem is safe
+// because no caller acquires injectSem while holding mu. Best-effort like the
+// absolute animator's stepMove: a failed backend motion still counts as
+// posted.
+func (a *relativeCursorAnimator) stepChunk(chunk image.Point, stopCh <-chan struct{}) bool {
+	a.injectSem <- struct{}{}
+	defer func() { <-a.injectSem }()
+
+	select {
+	case <-stopCh:
+		return false
+	default:
+	}
+
+	a.mu.Lock()
+	chunk = image.Point{
+		X: clampTowardZero(chunk.X, a.remaining.X),
+		Y: clampTowardZero(chunk.Y, a.remaining.Y),
+	}
+	a.mu.Unlock()
+
+	if chunk == (image.Point{}) {
+		return true
+	}
+
+	_ = a.moveBy(chunk)
+
+	a.mu.Lock()
+	a.remaining = a.remaining.Sub(chunk)
+	a.mu.Unlock()
+
+	return true
+}
+
+// clampTowardZero limits step to the portion of remaining that shares its
+// sign, so a posted chunk can never exceed what is still owed on that axis —
+// including after opposite-sign deltas shrank or flipped the remainder.
+func clampTowardZero(step, remaining int) int {
+	if remaining >= 0 {
+		return min(max(step, 0), remaining)
+	}
+
+	return max(min(step, 0), remaining)
+}
+
+// settle finishes the drain in flight immediately: the worker is canceled and
+// the entire remaining delta is posted as one native relative motion, so an
+// action firing mid-drain acts where the user aimed.
+//
+// The remainder is read only after acquiring injectSem: a chunk mid-injection
+// finishes — including its deduction — before the read, and a chunk that had
+// been selected but not yet injected sees the closed stopCh, stays in
+// remaining, and is flushed here. Either way every accumulated delta is
+// posted exactly once.
+func (a *relativeCursorAnimator) settle() {
+	done := a.detachWorker()
+	done.close()
+
+	a.injectSem <- struct{}{}
+
+	a.mu.Lock()
+	remainder := a.remaining
+	a.remaining = image.Point{}
+	a.mu.Unlock()
+
+	if remainder != (image.Point{}) {
+		_ = a.moveBy(remainder)
+	}
+
+	<-a.injectSem
+}
+
+// stop cancels the drain in flight and discards the remaining delta. It is
+// called on paths where an absolute move supersedes the pending deltas — the
+// cursor is about to be placed somewhere explicit, so flushing would fight
+// the warp. Like settle it zeroes the remainder only after the injectSem
+// fence, so an in-flight chunk's deduction cannot drive remaining negative.
+func (a *relativeCursorAnimator) stop() {
+	done := a.detachWorker()
+	done.close()
+
+	a.injectSem <- struct{}{}
+
+	a.mu.Lock()
+	a.remaining = image.Point{}
+	a.mu.Unlock()
+
+	<-a.injectSem
+}
+
+// detachWorker cancels the current worker, returning the session completion
+// to close. The returned done is nil (a safe no-op to close) when no session
+// ever ran.
+func (a *relativeCursorAnimator) detachWorker() *cursorAnimationDone {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	done := a.done
+	stopCh := a.stopCh
+	a.stopCh = nil
+	a.running = false
+
+	if stopCh != nil {
+		close(stopCh)
+	}
+
+	return done
+}
+
+// wait blocks until the drain in flight settles or ctx is canceled, returning
+// immediately when no drain has ever run.
+func (a *relativeCursorAnimator) wait(ctx context.Context) error {
+	a.mu.Lock()
+	done := a.done
+	a.mu.Unlock()
+
+	if done == nil {
+		return nil
+	}
+
+	select {
+	case <-done.ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/adapter/platform/linux/relative_animator.go
+++ b/internal/adapter/platform/linux/relative_animator.go
@@ -22,6 +22,14 @@ import (
 // losslessly — the wlroots twin of the absolute animator's pending-endpoint
 // extension. Completion is per session, mirroring smoothCursorAnimator, so
 // WaitForCursorIdle tracks the latest delta rather than an intermediate one.
+//
+// Failure bound: animation reports success before motion completes (inherent
+// to any animated move; the absolute animator behaves the same), so when a
+// native injection fails mid-drain, at most the remainder of that one
+// gesture is lost — deliberately not stored and replayed later, which would
+// jump the cursor by stale motion after recovery. The failure is flagged on
+// the first failed chunk and every subsequent move stays on the loud direct
+// path until a success proves the backend recovered.
 type relativeCursorAnimator struct {
 	moveBy func(image.Point) error
 

--- a/internal/adapter/platform/linux/relative_animator.go
+++ b/internal/adapter/platform/linux/relative_animator.go
@@ -226,18 +226,25 @@ func (a *relativeCursorAnimator) stepChunk(chunk image.Point, stopCh <-chan stru
 	return true
 }
 
-// takeInjectionFailure reports whether a native motion failed since the last
-// call, clearing the flag. Callers use it to route the next relative move
-// through the direct (loud) native path; a success there doubles as proof of
-// recovery, re-arming animation for the call after.
-func (a *relativeCursorAnimator) takeInjectionFailure() bool {
+// injectionFailurePending reports whether a native motion has failed and no
+// recovery has been proven since. While it holds, callers route every
+// relative move through the direct (loud) native path, so a broken backend
+// keeps surfacing errors instead of alternating between loud probes and
+// silent animated losses.
+func (a *relativeCursorAnimator) injectionFailurePending() bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	failed := a.injectionFailed
-	a.injectionFailed = false
+	return a.injectionFailed
+}
 
-	return failed
+// clearInjectionFailure re-arms animation. Callers invoke it only after a
+// direct native motion succeeded — the proof the backend recovered.
+func (a *relativeCursorAnimator) clearInjectionFailure() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.injectionFailed = false
 }
 
 // clampTowardZero limits step to the portion of remaining that shares its

--- a/internal/adapter/platform/linux/relative_animator.go
+++ b/internal/adapter/platform/linux/relative_animator.go
@@ -33,6 +33,12 @@ type relativeCursorAnimator struct {
 	stopCh    chan struct{}
 	done      *cursorAnimationDone // session completion; nil until the first session
 
+	// injectionFailed is set when a native motion errors. The drain cannot
+	// return that error to anyone — the move call already reported handled —
+	// so the caller consumes this flag (takeInjectionFailure) and routes the
+	// next move through the direct native path, which fails loudly.
+	injectionFailed bool
+
 	// injectSem serializes backend injection and is the ordering handoff to
 	// stop()/settle(), exactly as in smoothCursorAnimator: the worker holds it
 	// across each chunk and re-checks stopCh under it, so once a canceler
@@ -198,13 +204,40 @@ func (a *relativeCursorAnimator) stepChunk(chunk image.Point, stopCh <-chan stru
 		return true
 	}
 
-	_ = a.moveBy(chunk)
+	err := a.moveBy(chunk)
+	if err != nil {
+		// A failed chunk is NOT counted as posted. The backend is broken
+		// (client disconnected, virtual pointer lost), so retrying would
+		// livelock the drain: end it instead, discard the rest of the gesture,
+		// and flag the failure so the caller's next move takes the direct
+		// native path — which surfaces the backend error loudly.
+		a.mu.Lock()
+		a.remaining = image.Point{}
+		a.injectionFailed = true
+		a.mu.Unlock()
+
+		return true
+	}
 
 	a.mu.Lock()
 	a.remaining = a.remaining.Sub(chunk)
 	a.mu.Unlock()
 
 	return true
+}
+
+// takeInjectionFailure reports whether a native motion failed since the last
+// call, clearing the flag. Callers use it to route the next relative move
+// through the direct (loud) native path; a success there doubles as proof of
+// recovery, re-arming animation for the call after.
+func (a *relativeCursorAnimator) takeInjectionFailure() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	failed := a.injectionFailed
+	a.injectionFailed = false
+
+	return failed
 }
 
 // clampTowardZero limits step to the portion of remaining that shares its
@@ -239,7 +272,12 @@ func (a *relativeCursorAnimator) settle() {
 	a.mu.Unlock()
 
 	if remainder != (image.Point{}) {
-		_ = a.moveBy(remainder)
+		err := a.moveBy(remainder)
+		if err != nil {
+			a.mu.Lock()
+			a.injectionFailed = true
+			a.mu.Unlock()
+		}
 	}
 
 	<-a.injectSem

--- a/internal/adapter/platform/linux/relative_animator_test.go
+++ b/internal/adapter/platform/linux/relative_animator_test.go
@@ -234,8 +234,8 @@ func failingMover(image.Point) error {
 // TestRelativeCursorAnimatorInjectionFailureEndsDrainAndFlags pins the
 // failure contract: a failed native motion is not counted as posted, the
 // drain ends instead of livelocking on a broken backend, waiters are
-// released, and the failure is flagged exactly once so the caller can route
-// the next move through the loud direct path.
+// released, and the failure stays flagged — sending every subsequent move
+// down the loud direct path — until recovery is explicitly proven.
 func TestRelativeCursorAnimatorInjectionFailureEndsDrainAndFlags(t *testing.T) {
 	t.Parallel()
 
@@ -251,12 +251,18 @@ func TestRelativeCursorAnimatorInjectionFailureEndsDrainAndFlags(t *testing.T) {
 		t.Fatalf("wait returned error: %v (drain must end, not livelock, on a broken backend)", err)
 	}
 
-	if !animator.takeInjectionFailure() {
-		t.Fatal("takeInjectionFailure() = false after a failed native motion")
+	if !animator.injectionFailurePending() {
+		t.Fatal("injectionFailurePending() = false after a failed native motion")
 	}
 
-	if animator.takeInjectionFailure() {
-		t.Fatal("takeInjectionFailure() did not clear the flag on read")
+	if !animator.injectionFailurePending() {
+		t.Fatal("injectionFailurePending() must stay set until recovery is proven")
+	}
+
+	animator.clearInjectionFailure()
+
+	if animator.injectionFailurePending() {
+		t.Fatal("injectionFailurePending() still set after clearInjectionFailure()")
 	}
 }
 
@@ -272,7 +278,7 @@ func TestRelativeCursorAnimatorSettleFlushFailureFlags(t *testing.T) {
 
 	animator.settle()
 
-	if !animator.takeInjectionFailure() {
-		t.Fatal("takeInjectionFailure() = false after a failed settle flush")
+	if !animator.injectionFailurePending() {
+		t.Fatal("injectionFailurePending() = false after a failed settle flush")
 	}
 }

--- a/internal/adapter/platform/linux/relative_animator_test.go
+++ b/internal/adapter/platform/linux/relative_animator_test.go
@@ -224,3 +224,55 @@ func TestMoveCursorBySmoothKeepsStubErrorLoud(t *testing.T) {
 			err, derrors.GetCode(err))
 	}
 }
+
+// failingMover errors on every native motion, simulating a lost virtual
+// pointer or disconnected compositor client.
+func failingMover(image.Point) error {
+	return derrors.New(derrors.CodeActionFailed, "virtual pointer lost")
+}
+
+// TestRelativeCursorAnimatorInjectionFailureEndsDrainAndFlags pins the
+// failure contract: a failed native motion is not counted as posted, the
+// drain ends instead of livelocking on a broken backend, waiters are
+// released, and the failure is flagged exactly once so the caller can route
+// the next move through the loud direct path.
+func TestRelativeCursorAnimatorInjectionFailureEndsDrainAndFlags(t *testing.T) {
+	t.Parallel()
+
+	animator := newRelativeCursorAnimator(failingMover)
+
+	animator.addDelta(image.Point{X: 40, Y: 0}, 4, 20)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v (drain must end, not livelock, on a broken backend)", err)
+	}
+
+	if !animator.takeInjectionFailure() {
+		t.Fatal("takeInjectionFailure() = false after a failed native motion")
+	}
+
+	if animator.takeInjectionFailure() {
+		t.Fatal("takeInjectionFailure() did not clear the flag on read")
+	}
+}
+
+// TestRelativeCursorAnimatorSettleFlushFailureFlags pins that a failed
+// settle flush is also flagged, so the loss is surfaced on the next move.
+func TestRelativeCursorAnimatorSettleFlushFailureFlags(t *testing.T) {
+	t.Parallel()
+
+	animator := newRelativeCursorAnimator(failingMover)
+
+	// A very slow drain so the remainder is still pending at settle time.
+	animator.addDelta(image.Point{X: 100, Y: 0}, 10, 10000)
+
+	animator.settle()
+
+	if !animator.takeInjectionFailure() {
+		t.Fatal("takeInjectionFailure() = false after a failed settle flush")
+	}
+}

--- a/internal/adapter/platform/linux/relative_animator_test.go
+++ b/internal/adapter/platform/linux/relative_animator_test.go
@@ -1,0 +1,226 @@
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"image"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// deltaRecorder captures the native relative motions a drain injects so tests
+// can assert on exactness without a compositor.
+type deltaRecorder struct {
+	mu     sync.Mutex
+	deltas []image.Point
+}
+
+func (r *deltaRecorder) moveBy(d image.Point) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.deltas = append(r.deltas, d)
+
+	return nil
+}
+
+func (r *deltaRecorder) sum() image.Point {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var total image.Point
+	for _, d := range r.deltas {
+		total = total.Add(d)
+	}
+
+	return total
+}
+
+func (r *deltaRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.deltas)
+}
+
+// TestRelativeCursorAnimatorDrainsExactly pins the core invariant: the posted
+// chunks sum exactly to the requested delta — nothing lost to rounding — and
+// the motion is chunked, not a single warp-sized jump.
+func TestRelativeCursorAnimatorDrainsExactly(t *testing.T) {
+	t.Parallel()
+
+	rec := &deltaRecorder{}
+	animator := newRelativeCursorAnimator(rec.moveBy)
+
+	delta := image.Point{X: 37, Y: -23}
+	animator.addDelta(delta, 5, 30)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	if got := rec.sum(); got != delta {
+		t.Fatalf("drained %v, want exactly %v", got, delta)
+	}
+
+	if rec.count() < 2 {
+		t.Fatalf("expected a chunked drain (>=2 motions), got %d", rec.count())
+	}
+}
+
+// TestRelativeCursorAnimatorComposesConcurrentDeltas pins that deltas folded
+// in from concurrent movers all reach the compositor — the drain equivalent
+// of the absolute animator's pending-endpoint extension.
+func TestRelativeCursorAnimatorComposesConcurrentDeltas(t *testing.T) {
+	t.Parallel()
+
+	rec := &deltaRecorder{}
+	animator := newRelativeCursorAnimator(rec.moveBy)
+
+	const movers = 8
+
+	const deltasPerMover = 25
+
+	var waitGroup sync.WaitGroup
+	for range movers {
+		waitGroup.Go(func() {
+			for range deltasPerMover {
+				animator.addDelta(image.Point{X: 1, Y: 0}, 2, 1)
+			}
+		})
+	}
+
+	waitGroup.Wait()
+
+	// Flush whatever is still draining, then everything must have landed.
+	animator.settle()
+
+	if want := (image.Point{X: movers * deltasPerMover}); rec.sum() != want {
+		t.Fatalf("drained %v after concurrent deltas, want %v (lost deltas)", rec.sum(), want)
+	}
+}
+
+// TestRelativeCursorAnimatorSettleFlushesRemainder pins settle(): an action
+// firing mid-drain must receive the full accumulated motion immediately, as
+// one final native flush, and waiters must be released.
+func TestRelativeCursorAnimatorSettleFlushesRemainder(t *testing.T) {
+	t.Parallel()
+
+	rec := &deltaRecorder{}
+	animator := newRelativeCursorAnimator(rec.moveBy)
+
+	// A very slow drain so most of the delta is still pending at settle time.
+	delta := image.Point{X: 100, Y: 60}
+	animator.addDelta(delta, 10, 10000)
+
+	animator.settle()
+
+	if got := rec.sum(); got != delta {
+		t.Fatalf("settle() flushed to %v, want exactly %v", got, delta)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait after settle returned error: %v", err)
+	}
+}
+
+// TestRelativeCursorAnimatorStopDiscardsRemainder pins stop(): an absolute
+// move superseding the drain discards what has not been posted yet, and no
+// canceled chunk lands after the stop fence.
+func TestRelativeCursorAnimatorStopDiscardsRemainder(t *testing.T) {
+	t.Parallel()
+
+	rec := &deltaRecorder{}
+	animator := newRelativeCursorAnimator(rec.moveBy)
+
+	total := image.Point{X: 100, Y: 0}
+	animator.addDelta(total, 10, 10000)
+
+	animator.stop()
+
+	if got := rec.sum(); got.X >= total.X {
+		t.Fatalf("stop() flushed the full delta (%v); the remainder must be discarded", got)
+	}
+
+	posted := rec.count()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if rec.count() != posted {
+		t.Fatalf("chunks kept landing after stop(): %d -> %d", posted, rec.count())
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait after stop returned error: %v", err)
+	}
+}
+
+// TestRelativeCursorAnimatorWaitIdle preserves the WaitForCursorIdle no-op
+// contract when no drain has ever run.
+func TestRelativeCursorAnimatorWaitIdle(t *testing.T) {
+	t.Parallel()
+
+	animator := newRelativeCursorAnimator((&deltaRecorder{}).moveBy)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait with no drain returned error: %v", err)
+	}
+}
+
+// smoothOnProvider serves a config with smooth cursor enabled, for tests that
+// exercise the animated MoveCursorBy paths.
+type smoothOnProvider struct{}
+
+func (smoothOnProvider) Get() *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.SmoothCursor.MoveMouseEnabled = true
+
+	return cfg
+}
+
+// TestMoveCursorBySmoothKeepsStubErrorLoud pins the CGO-off contract: with
+// smooth cursor enabled on a wlroots backend, MoveCursorBy must keep
+// surfacing the nocgo stub's CodeNotSupported instead of laundering it
+// through the best-effort drain, which drops injection errors by design.
+func TestMoveCursorBySmoothKeepsStubErrorLoud(t *testing.T) {
+	if nativeBackendsCompiledIn {
+		t.Skip("only meaningful on CGO-off builds, where the wlroots injector is the loud stub")
+	}
+
+	// No t.Parallel: this mutates the process-global config provider.
+	SetConfigProvider(smoothOnProvider{})
+	defer SetConfigProvider(nil)
+
+	adapter := NewSystemAdapter(backendWaylandWlroots)
+
+	handled, err := adapter.MoveCursorBy(context.Background(), image.Point{X: 5, Y: 0})
+	if !handled {
+		t.Fatal("MoveCursorBy on wlroots reported handled == false")
+	}
+
+	if !derrors.IsNotSupported(err) {
+		t.Errorf("MoveCursorBy returned %v (code %q), want CodeNotSupported",
+			err, derrors.GetCode(err))
+	}
+}

--- a/internal/adapter/platform/linux/system_common.go
+++ b/internal/adapter/platform/linux/system_common.go
@@ -344,13 +344,18 @@ func (s *SystemAdapter) MoveCursorBy(
 	// a silent no-op. Falling through keeps the error surfaced to the caller.
 	if cfg != nil && cfg.SmoothCursor.MoveMouseEnabled && nativeBackendsCompiledIn {
 		if s.backend == backendWaylandWlroots {
-			// A failed injection during the previous drain could not be
-			// surfaced (its move had already reported handled). Route this
-			// move through the direct native path instead: it returns the
-			// backend error loudly, and its success doubles as proof of
-			// recovery, re-arming animation for the next move.
-			if s.relativeAnimator.takeInjectionFailure() {
-				return true, wlrootsMoveCursorBy(delta)
+			// A failed injection during a drain could not be surfaced (its
+			// move had already reported handled). Until recovery is proven,
+			// route every move through the direct native path: it returns the
+			// backend error loudly, and only a success — the proof the
+			// backend recovered — re-arms animation.
+			if s.relativeAnimator.injectionFailurePending() {
+				err := wlrootsMoveCursorBy(delta)
+				if err == nil {
+					s.relativeAnimator.clearInjectionFailure()
+				}
+
+				return true, err
 			}
 
 			// Finish any absolute glide first so the delta drain composes from

--- a/internal/adapter/platform/linux/system_common.go
+++ b/internal/adapter/platform/linux/system_common.go
@@ -344,6 +344,15 @@ func (s *SystemAdapter) MoveCursorBy(
 	// a silent no-op. Falling through keeps the error surfaced to the caller.
 	if cfg != nil && cfg.SmoothCursor.MoveMouseEnabled && nativeBackendsCompiledIn {
 		if s.backend == backendWaylandWlroots {
+			// A failed injection during the previous drain could not be
+			// surfaced (its move had already reported handled). Route this
+			// move through the direct native path instead: it returns the
+			// backend error loudly, and its success doubles as proof of
+			// recovery, re-arming animation for the next move.
+			if s.relativeAnimator.takeInjectionFailure() {
+				return true, wlrootsMoveCursorBy(delta)
+			}
+
 			// Finish any absolute glide first so the delta drain composes from
 			// where that animation was headed, not against its remaining steps.
 			s.cursorAnimator.settle()

--- a/internal/adapter/platform/linux/system_common.go
+++ b/internal/adapter/platform/linux/system_common.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain/geometry"
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
@@ -28,9 +29,10 @@ const (
 
 // SystemAdapter is a Linux system adapter.
 type SystemAdapter struct {
-	backend        string
-	cursorAnimator *smoothCursorAnimator
-	probes         *capabilityProbes
+	backend          string
+	cursorAnimator   *smoothCursorAnimator
+	relativeAnimator *relativeCursorAnimator
+	probes           *capabilityProbes
 }
 
 // NewSystemAdapter creates a new SystemAdapter.
@@ -40,6 +42,10 @@ func NewSystemAdapter(backend string) *SystemAdapter {
 		adapter.currentCursorPosition,
 		adapter.moveCursorDirect,
 	)
+	// Only the wlroots backend drives the delta-drain animator (it is the one
+	// backend with native relative motion); constructing it unconditionally
+	// keeps every method a safe no-op elsewhere.
+	adapter.relativeAnimator = newRelativeCursorAnimator(wlrootsMoveCursorBy)
 
 	return adapter
 }
@@ -285,6 +291,11 @@ func (s *SystemAdapter) MoveCursorToPoint(
 	point image.Point,
 	bypassSmooth bool,
 ) error {
+	// An absolute move supersedes any pending relative deltas: the cursor is
+	// about to be placed somewhere explicit, so flushing the drain would only
+	// fight the warp. Discard it before either branch below.
+	s.relativeAnimator.stop()
+
 	cfg := currentLinuxConfig()
 	if cfg != nil && cfg.SmoothCursor.MoveMouseEnabled && !bypassSmooth {
 		s.cursorAnimator.animateTo(
@@ -308,13 +319,73 @@ func (s *SystemAdapter) MoveCursorToPoint(
 	return s.moveCursorDirect(point)
 }
 
-// MoveCursorBy uses native relative motion when the Wayland backend supports it.
-// The bool result reports whether the request was handled, allowing callers to
-// retain their absolute-position fallback on X11 and unsupported backends.
+// MoveCursorBy applies a relative cursor move. With smooth cursor enabled
+// (smooth_cursor.move_mouse_enabled) the move animates over the fixed
+// per-move duration smooth_cursor.relative_movement_duration:
+//
+//   - wlroots drains the delta in integer chunks through native relative
+//     motion — never reading the client position cache, whose staleness is
+//     why this backend applies deltas natively in the first place;
+//   - X11 and KDE extend the absolute animator's pending endpoint, exactly
+//     like macOS (KDE's fallback path was already cache-based absolute, so
+//     nothing is lost).
+//
+// With smooth cursor disabled, behavior is unchanged: wlroots posts one
+// native delta, everything else reports handled == false so callers keep
+// their absolute-position fallback.
 func (s *SystemAdapter) MoveCursorBy(
 	ctx context.Context,
 	delta image.Point,
 ) (bool, error) {
+	cfg := currentLinuxConfig()
+	// nativeBackendsCompiledIn gates the animated paths: on CGO-off builds the
+	// drain's injector is the loud CodeNotSupported stub, but the animator
+	// drops injection errors by design — animating would launder the stub into
+	// a silent no-op. Falling through keeps the error surfaced to the caller.
+	if cfg != nil && cfg.SmoothCursor.MoveMouseEnabled && nativeBackendsCompiledIn {
+		if s.backend == backendWaylandWlroots {
+			// Finish any absolute glide first so the delta drain composes from
+			// where that animation was headed, not against its remaining steps.
+			s.cursorAnimator.settle()
+			s.relativeAnimator.addDelta(
+				delta,
+				cfg.SmoothCursor.Steps,
+				cfg.SmoothCursor.RelativeMovementDuration,
+			)
+
+			return true, nil
+		}
+
+		if s.backend == backendX11 || s.backend == backendWaylandKDE {
+			bounds, err := s.ScreenBounds(ctx)
+			if err == nil {
+				s.cursorAnimator.animateRelativeBy(
+					delta,
+					func(point image.Point) image.Point {
+						return image.Point{
+							X: geometry.ClampInt(
+								point.X,
+								bounds.Min.X,
+								max(bounds.Max.X-1, bounds.Min.X),
+							),
+							Y: geometry.ClampInt(
+								point.Y,
+								bounds.Min.Y,
+								max(bounds.Max.Y-1, bounds.Min.Y),
+							),
+						}
+					},
+					cfg.SmoothCursor.Steps,
+					cfg.SmoothCursor.RelativeMovementDuration,
+				)
+
+				return true, nil
+			}
+			// Without bounds there is nothing to clamp against; fall through to
+			// the caller's fallback, which clamps at the service layer.
+		}
+	}
+
 	if s.backend == backendWaylandWlroots {
 		return true, wlrootsMoveCursorBy(delta)
 	}
@@ -324,9 +395,28 @@ func (s *SystemAdapter) MoveCursorBy(
 
 // WaitForCursorIdle blocks until any in-flight smooth cursor animation settles,
 // or ctx is canceled. It returns immediately when no animation is active — the
-// common case on the direct (non-smooth) move path.
+// common case on the direct (non-smooth) move path. Both animators are waited
+// on: the absolute glide and the wlroots relative-delta drain.
 func (s *SystemAdapter) WaitForCursorIdle(ctx context.Context) error {
-	return s.cursorAnimator.wait(ctx)
+	err := s.cursorAnimator.wait(ctx)
+	if err != nil {
+		return err
+	}
+
+	return s.relativeAnimator.wait(ctx)
+}
+
+// SettleCursor finishes any in-flight cursor animation immediately: the
+// absolute animator warps straight to the endpoint it was animating toward,
+// and the relative drain flushes its remaining delta in one native motion.
+// Action paths call this before resolving their target point from the
+// cursor, so an action firing mid-animation acts at the point the user aimed
+// for — without paying the animation's remaining duration in latency.
+func (s *SystemAdapter) SettleCursor(ctx context.Context) error {
+	s.cursorAnimator.settle()
+	s.relativeAnimator.settle()
+
+	return nil
 }
 
 // CursorPosition returns the current cursor position on Linux.
@@ -606,6 +696,7 @@ var _ ports.SystemPort = (*SystemAdapter)(nil)
 var (
 	_ ports.RelativeCursorMover = (*SystemAdapter)(nil)
 	_ ports.CursorSynchronizer  = (*SystemAdapter)(nil)
+	_ ports.CursorSettler       = (*SystemAdapter)(nil)
 )
 
 // darkModeSource names which input produced a color-scheme value.

--- a/internal/ports/system.go
+++ b/internal/ports/system.go
@@ -131,9 +131,10 @@ type SystemPort interface {
 //
 // Implemented by the Linux adapter, whose Wayland backends have no
 // authoritative cursor query — warping to position+delta would compound the
-// cache error, so the delta is applied directly. Also implemented by the
-// darwin adapter, which animates relative moves when smooth cursor is
-// enabled. Fall back to CursorPosition + MoveCursorToPoint when
+// cache error, so the delta is applied directly. The darwin and Linux
+// adapters also animate relative moves when smooth cursor is enabled (on
+// wlroots the animation itself stays in delta space for the same
+// cache-error reason). Fall back to CursorPosition + MoveCursorToPoint when
 // unimplemented or handled == false.
 type RelativeCursorMover interface {
 	// MoveCursorBy moves the cursor by delta from its current position.


### PR DESCRIPTION
## Description

This PR brings relative (hjkl) cursor animation to Linux, completing the smooth-cursor parity started in #1179. With `move_mouse_enabled = true`, keyboard-driven moves now glide with the same fixed per-move duration as on macOS — cursor speed scales with the per-move delta, held-key repeat extends the in-flight animation instead of losing deltas, and `held_repeat` acceleration shows up as visible speed. With smooth cursor disabled (the default), every backend behaves exactly as before.

All three supported Linux backends are covered: X11, Wayland wlroots, and Wayland KDE. Position-dependent actions (clicks, scrolls, cursor-slot saves) settle the in-flight animation before acting — the guarantee #1182 established — so an action fired mid-glide lands where the user aimed. GNOME is unchanged (no cursor injection path exists there).

## Related Issues

None — follow-up to #1179 (relative animation, macOS) and #1182 (settle before position-dependent actions).

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — all new/changed adapter files are `//go:build linux`
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule); the only new shared import is `internal/domain/geometry`
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new port method: Linux opts into the existing optional `CursorSettler` extension darwin already implements; Windows keeps its fallback. On CGO-off Linux builds the animated paths are bypassed so the wlroots stub's `CodeNotSupported` still reaches callers (pinned by a contract test that runs in the no-cgo suite).

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config Changes

No new keys. The existing `smooth_cursor.relative_movement_duration` (default `50`, ms) now takes effect on Linux as well as macOS; previously it was documented as macOS-only and ignored on Linux. Existing configs keep working untouched.

```toml
[smooth_cursor]
move_mouse_enabled = true
relative_movement_duration = 50
```

## Behavior Change for Existing Smooth-Cursor Users on Linux

Linux users already running `move_mouse_enabled = true` will see relative (hjkl) moves start animating — previously they always applied instantly. This is the same intended reading of the option that #1179 established on macOS (smooth cursor covers cursor movement, full stop); the default 50ms glide is subtle. There is no separate opt-out, matching macOS.

## Additional Context

The two animation models differ deliberately, and the split is the heart of the change:

- **X11 / KDE** mirror the macOS design: the existing jump animator gains a fixed-duration override and pending-endpoint bookkeeping, and a relative move extends the endpoint of the animation in flight under a single lock hold. KDE's relative fallback was already cache-based absolute positioning, so nothing is lost there.
- **wlroots** animates in **delta space**: a small drain worker splits the accumulated delta into integer chunks that sum exactly to the requested total, each posted as one native relative motion, and settling flushes the remainder in one final motion. The animation never reads the client-side position cache — the read-then-warp cache-compounding problem that made this backend apply deltas natively in the first place cannot be reintroduced by animation. The drain maintains the invariant "posted + remaining == accumulated" through every cancellation interleaving; chunks are re-validated against the remainder at injection time so a settle racing a new delta can neither lose nor double-post motion.

Verification: full Linux test suite green in the CI-equivalent Docker image with CGO on and off, the animator tests additionally under `-race`; CI-equivalent Linux lint (`just lint-cross`) reports 0 issues; macOS suite, macOS build, and Windows cross-build all green. The `platform-boundary-reviewer` profile was run on the diff; both of its findings (a CGO-off error-laundering path and Linux-side lint) are fixed in this PR, with the former pinned by the new contract test.
