### PR TITLE
docs: add a domain glossary and the first two decision records

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,58 @@
+# Neru
+
+Neru is a keyboard-driven, mouse-free navigation tool: every pointer action
+reachable from the keyboard, instantly. This file is the glossary — the words
+this repo uses for its own concepts, and the words it deliberately does not.
+
+Mode, Port / Adapter, Bridge and Semantic role are defined in `AGENTS.md`
+under Domain Concepts and are not repeated here; each fact has one home.
+
+## Language
+
+### Triggering work from the keyboard
+
+**Hotkey**:
+A key combination the daemon registers globally, so pressing it reaches Neru
+before the focused application sees it.
+_Avoid_: shortcut, accelerator
+
+**Binding**:
+The mapping from one hotkey to the ordered steps it runs.
+_Avoid_: keybinding, mapping
+
+**Step**:
+One unit of work written in a binding — a mode command, an action, a shell
+command, or a nested sequence.
+_Avoid_: action string, command, entry
+
+**Sequence**:
+An ordered list of steps run as one unit. A binding, a macro body, and a
+mode's `--on-exit` are all sequences, and all behave identically.
+_Avoid_: chain, pipeline, script
+
+**Macro**:
+A named, parameterised sequence that steps can invoke by name.
+_Avoid_: alias, function, snippet
+
+### Entering a mode
+
+**Mode command**:
+A step that names a navigation mode, written with flags — `hints --action
+left_click`. This is the text form, the thing a person writes in a binding or
+types after `neru`.
+_Avoid_: mode invocation, mode action string, launcher
+
+**Mode flag**:
+One named option a mode command accepts. Which modes accept a given flag is
+part of the flag's definition, not of the mode's.
+_Avoid_: option, param, arg, switch
+
+**Activation**:
+The typed intent to enter a mode: which mode, plus the value of every mode
+flag that was given. A mode command parses into an Activation; the CLI builds
+one directly from its flags; both reach the mode handler as the same value.
+_Avoid_: mode activation options, request, params, opts, config
+
+**Probe**:
+A read-only query reporting what a mode would target, without entering it.
+_Avoid_: debug mode, dry run, preview

--- a/docs/adr/0001-one-grammar-for-mode-commands.md
+++ b/docs/adr/0001-one-grammar-for-mode-commands.md
@@ -1,0 +1,62 @@
+# One grammar for mode commands
+
+**Status**: accepted
+
+A mode command (`hints --action left_click`) reaches the daemon from three
+places — the CLI, a hotkey binding, and a direct IPC caller — and each had
+grown its own reading of it. `internal/cli/mode_commands.go` validated fully,
+`internal/app/ipcctrl/modeoptions.go` validated partially and differently, and
+`internal/config/validators_hotkeys.go` stopped at the command word, so a
+typo'd binding was discoverable only by pressing the key. The three had already
+drifted: `--on-exit requires --action` existed CLI-side only, four error strings
+differed, and per-mode flag support was a CLI-only concept, so `grid --search`
+in a binding activated grid and dropped the flag in silence. We decided that one
+package under internal/domain owns the whole grammar — the flag vocabulary,
+which modes accept which flag, parsing, validation, and rendering back to
+arguments — and that the CLI, the IPC controller and the config validator all
+call it rather than each reading the command their own way.
+
+## Considered options
+
+**A typed payload on the wire instead of an argument list.** This would delete
+the CLI's render-then-reparse round trip outright. Rejected: `docs/CLI.md`
+documents `{"action":"hints","args":[]}` and invites scripts to use it, so the
+argument-list shape is public API. The hotkey path also has to parse text
+regardless — a binding is a string in `configs/default-config.toml` — so the
+parser would survive the change anyway and only the CLI would benefit.
+
+**Keep both validators and pin them with a test.** Cheaper, and it would catch
+future drift. Rejected because the drift has already happened and a test would
+have recorded rather than prevented it; the rules are cross-cutting enough
+(action vocabulary, flag co-dependencies, per-mode acceptance) that two
+implementations agreeing is a coincidence to be maintained, not a property.
+
+**A data-only flag descriptor with parse and render as switches**, exhaustiveness
+pinned by an `internal/architecture` test. This is the house style, and the
+guardrail suite is where this repo usually puts contracts. Rejected for this
+one case: a switch with a `default:` clause is precisely the shape that let the
+per-mode divergence go unnoticed, and here the compiler can do the job instead.
+Each flag descriptor therefore carries its own `Set` and `Render` closures, so
+adding a flag is one table entry and there is no branch to forget.
+
+## Consequences
+
+- A `domain` package knows CLI flag spellings. That reads backwards for a
+  hexagonal core, and it is deliberate: the flag names are the vocabulary the
+  user writes in `configs/default-config.toml`, not a delivery-mechanism detail.
+- The grammar cannot import `internal/config`, because config validates
+  bindings and so must import the grammar. The strategy, label-direction and
+  cursor-selection-mode constants move down out of `internal/config` and
+  `internal/app/modes` to make that possible.
+- Error messages are context-free, since one string now serves a shell user, an
+  IPC response and a config error. Advice that named `neru action X` on the CLI
+  and `action X` on the wire is reworded to be true in both.
+- `--debug` becomes its own IPC action rather than a mode flag. It never
+  activated anything — it short-circuited to a probe and returned a summary
+  string — and leaving it on the Activation would reintroduce a field that
+  means nothing to the handler.
+- The mode handler takes an Activation directly, so its three activation entry
+  points collapse to one and the field-by-field copying between two option
+  structs is deleted. `OnExit`'s nil-versus-empty contract (nil preserves prior
+  steps, empty clears them) survives that collapse and is pinned by the
+  round-trip test.

--- a/docs/adr/0002-severity-tiered-config-validation.md
+++ b/docs/adr/0002-severity-tiered-config-validation.md
@@ -1,0 +1,35 @@
+# Mode commands in bindings are validated at two severities
+
+**Status**: accepted
+
+Once the config validator reads mode commands (see
+[ADR 0001](0001-one-grammar-for-mode-commands.md)), it can reject bindings that
+load cleanly today. That is not free: when `Validate()` fails, `refuse` in
+`internal/config/loader/load.go` replaces the whole configuration with
+`config.DefaultConfig()` — not just the offending binding. A single mistyped
+flag would reset every binding, theme and setting the user had. We decided to
+split the new checks by whether the binding already works: an unknown flag is a
+load error, and a flag the named mode does not accept, or a flag whose
+co-dependency is unmet, is a warning.
+
+The line is drawn at what the user loses. A binding with an unknown flag is
+already dead — the argument is taken as a positional action and refused at press
+time, so the mode never activates — and `internal/config/validators_hotkeys.go`
+already fails the whole load for an unknown *command* in a binding. Treating an
+unknown flag the same way extends an existing rule rather than inventing a
+hazard. The other two classes describe bindings that work today minus one flag;
+demoting a working configuration to defaults over them would be a worse outcome
+than the bug being reported.
+
+## Consequences
+
+- `LoadResult` gains a warnings channel, and `neru config validate` prints
+  warnings instead of only ever saying "Configuration is valid". Without it a
+  warning is a `zap` line the CLI never shows, which would make the tier
+  meaningless for the command people run to check their config.
+- Upgrading with an unknown flag in a binding resets the configuration to
+  defaults. This is accepted as consistent with the existing unknown-command
+  behaviour, not as desirable. Narrowing the blast radius so an invalid binding
+  is dropped rather than failing the whole load would fix both, and is
+  deliberately left out of scope here — it changes how every config error
+  behaves, not just this one.


### PR DESCRIPTION
## Description

This PR adds a domain glossary and the repo's first two architecture decision records. Documentation only — no code changes.

`CONTEXT.md` is a glossary and nothing else. It names the concepts this project already has but had never written down: hotkeys, bindings, steps, sequences and macros on the input side, and mode commands, mode flags, activations and probes on the mode side. Each entry lists the words it deliberately rejects, so a review can argue about the design rather than about vocabulary. It defers to `AGENTS.md` for Mode, Port, Adapter, Bridge and Semantic role rather than restating them, keeping one home per fact.

`docs/adr/` starts with the two decisions behind the mode-command work tracked in #1185, both chosen for being hard to reverse and non-obvious from the code: 0001 records why the grammar for mode commands belongs in one module in the domain layer and why the IPC request keeps its argument-list shape; 0002 records why validating mode commands at config load is split by severity, which only makes sense once you know that a failed load replaces the user's whole configuration with defaults.

## Related Issues

Groundwork for #1185 and its tickets #1186–#1192, which reference both ADRs by path.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`) — N/A, no code in this PR
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, documentation only; the existing `internal/architecture` doc-link guardrail covers these files
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Both new files sit under guardrails that already exist. `TestDocLinks_DoNotPointAtMissingPaths` fails any markdown that puts a repository path in a code span when that path does not exist, which is why ADR 0001 names the not-yet-created module in prose rather than as inline code.

Neither file is a spec or a scratch pad. `CONTEXT.md` holds no implementation detail by design, and the ADRs record decisions and rejected alternatives rather than plans — the plan itself lives in #1185.

`docs/adr/` is new, so this also sets the format for future records: sequential numbering, a short statement of the decision and its reason, and optional sections only where they earn their place.
