### PR TITLE
refactor(domain): own the values a mode command's options accept

### DIFF
--- a/internal/app/ipcctrl/modeoptions.go
+++ b/internal/app/ipcctrl/modeoptions.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/y3owk1n/neru/internal/adapter/ipc"
-	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/action"
 	"github.com/y3owk1n/neru/internal/domain/modeflag"
 )
@@ -332,7 +332,7 @@ func validateModeOptions(opts ModeActivationOptions) *ipc.Response {
 // isValidStrategy reports whether v names a detection strategy: "axtree", the
 // default, or "vision".
 func isValidStrategy(v string) bool {
-	return v == config.StrategyAXTree || v == config.StrategyVision
+	return v == domain.StrategyAXTree || v == domain.StrategyVision
 }
 
 func parseStrategyValue(val string) (*string, *ipc.Response) {
@@ -352,7 +352,7 @@ func parseStrategyValue(val string) (*string, *ipc.Response) {
 // isValidLabelDirection checks that the given label direction value is one of
 // the accepted values: "normal" (default) or "reverse".
 func isValidLabelDirection(v string) bool {
-	return v == config.LabelDirectionReverse || v == config.LabelDirectionNormal
+	return v == domain.LabelDirectionReverse || v == domain.LabelDirectionNormal
 }
 
 func parseLabelDirectionValue(val string) (*string, *ipc.Response) {

--- a/internal/app/ipcctrl/modes.go
+++ b/internal/app/ipcctrl/modes.go
@@ -75,11 +75,11 @@ type ModeActivationOptions struct {
 // cursor-follow override, or returns an error response for invalid input.
 func parseCursorSelectionModeValue(value string) (*bool, *ipc.Response) {
 	switch value {
-	case "follow":
+	case domain.CursorSelectionModeFollow:
 		follow := true
 
 		return &follow, nil
-	case "hold":
+	case domain.CursorSelectionModeHold:
 		follow := false
 
 		return &follow, nil

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
-	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/derrors"
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/action"
@@ -391,7 +390,7 @@ func (h *handlerState) ensureScreenCapturePermissions(
 	strategy string,
 	strategyVal string,
 ) (image.Rectangle, string, string, bool) {
-	if strategy != config.StrategyVision {
+	if strategy != domain.StrategyVision {
 		return activeScreenBounds, bundleID, strategy, true
 	}
 

--- a/internal/app/modes/selection_mode.go
+++ b/internal/app/modes/selection_mode.go
@@ -2,13 +2,6 @@ package modes
 
 import "github.com/y3owk1n/neru/internal/domain"
 
-const (
-	// CursorSelectionModeFollow keeps the real cursor synced with the current selection.
-	CursorSelectionModeFollow = "follow"
-	// CursorSelectionModeHold keeps the real cursor stationary until explicit commit/move.
-	CursorSelectionModeHold = "hold"
-)
-
 func resolveCursorFollowSelection(mode domain.Mode, override *bool) bool {
 	if override != nil {
 		return *override

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/element"
 	"github.com/y3owk1n/neru/internal/domain/hint"
 	"github.com/y3owk1n/neru/internal/ports"
@@ -142,7 +143,7 @@ func (s *HintService) GenerateHints(
 		labelDirection = labelDirectionOverride
 	}
 
-	if splitWord && strategy != config.StrategyVision {
+	if splitWord && strategy != domain.StrategyVision {
 		return nil, derrors.New(
 			derrors.CodeInvalidInput,
 			"--split-word is only supported when resolved strategy is 'vision'",
@@ -155,7 +156,7 @@ func (s *HintService) GenerateHints(
 	)
 
 	switch strategy {
-	case config.StrategyVision:
+	case domain.StrategyVision:
 		elements = s.generateHintsVision(ctx, bundleID, filter, splitWord)
 	default:
 		elements, genErr = s.generateHintsAX(ctx, filter)

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/y3owk1n/neru/internal/app/services"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/element"
 	"github.com/y3owk1n/neru/internal/domain/hint"
 	"github.com/y3owk1n/neru/internal/ports"
@@ -545,7 +546,7 @@ func TestHintService_GenerateHintsVisionCombinesSupplementaryAndWindowElements(
 		nil,
 		nil,
 		"com.example.app",
-		config.StrategyVision,
+		domain.StrategyVision,
 		"",
 		false,
 	)
@@ -606,7 +607,7 @@ func TestHintService_GenerateHintsVisionWithNilPortReturnsSupplementaryElements(
 		nil,
 		nil,
 		"com.example.app",
-		config.StrategyVision,
+		domain.StrategyVision,
 		"",
 		false,
 	)
@@ -697,7 +698,7 @@ func TestHintService_GeneratorReturnsDirectionSpecificInstance(t *testing.T) {
 
 	// Each direction must resolve to its own generator instance, not the
 	// shared default.
-	gotReverse := service.Generator(config.LabelDirectionReverse)
+	gotReverse := service.Generator(domain.LabelDirectionReverse)
 	if gotReverse == nil {
 		t.Fatal("Generator(reverse) returned nil")
 	}
@@ -710,7 +711,7 @@ func TestHintService_GeneratorReturnsDirectionSpecificInstance(t *testing.T) {
 		)
 	}
 
-	gotNormal := service.Generator(config.LabelDirectionNormal)
+	gotNormal := service.Generator(domain.LabelDirectionNormal)
 	if gotNormal == nil {
 		t.Fatal("Generator(normal) returned nil")
 	}
@@ -816,7 +817,7 @@ func TestHintService_GenerateHintsPicksDirectionGenerator(t *testing.T) {
 	// The reverse algorithm fills all 4 single-char slots ([AA SA DA FA])
 	// before yielding a 2-char label ([AS]). The 1st and 5th labels (AA, AS)
 	// prove the override actually engaged.
-	hints, err = service.GenerateHints(ctx, nil, nil, "", "", config.LabelDirectionReverse, false)
+	hints, err = service.GenerateHints(ctx, nil, nil, "", "", domain.LabelDirectionReverse, false)
 	if err != nil {
 		t.Fatalf("GenerateHints() with reverse override unexpected error: %v", err)
 	}
@@ -949,7 +950,7 @@ func TestHintService_GenerateHintsRejectsSplitWordForNonVisionStrategy(t *testin
 		&mocks.MockSystemPort{},
 		generator,
 		config.HintsConfig{
-			Strategy: config.StrategyAXTree,
+			Strategy: domain.StrategyAXTree,
 		},
 		logger.Get(),
 		nil,
@@ -962,7 +963,7 @@ func TestHintService_GenerateHintsRejectsSplitWordForNonVisionStrategy(t *testin
 		nil,
 		nil,
 		"",
-		config.StrategyAXTree,
+		domain.StrategyAXTree,
 		"",
 		true, // splitWord
 	)

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/y3owk1n/neru/internal/app/modes"
 	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/action"
 	"github.com/y3owk1n/neru/internal/domain/modeflag"
 )
@@ -366,8 +366,8 @@ func readModeFlags(cmd *cobra.Command, config ModeConfig) (modeFlags, error) {
 // fail immediately rather than after a round trip.
 func (f modeFlags) validate() error {
 	if f.cursorSelectionMode != "" &&
-		f.cursorSelectionMode != modes.CursorSelectionModeFollow &&
-		f.cursorSelectionMode != modes.CursorSelectionModeHold {
+		f.cursorSelectionMode != domain.CursorSelectionModeFollow &&
+		f.cursorSelectionMode != domain.CursorSelectionModeHold {
 		return derrors.New(
 			derrors.CodeInvalidInput,
 			"--cursor-selection-mode must be either follow or hold",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/element"
 	"github.com/y3owk1n/neru/internal/domain/modeflag"
 )
@@ -429,23 +430,6 @@ type HintsVisionConfig struct {
 	GenericClickableMinConfidence float64 `json:"genericClickableMinConfidence" toml:"generic_clickable_min_confidence"`
 }
 
-// Strategy constants for element detection.
-const (
-	StrategyAXTree = "axtree"
-	StrategyVision = "vision"
-)
-
-// Label direction constants for hint label enumeration.
-const (
-	// LabelDirectionReverse spreads labels across the alphabet by varying the
-	// first character so same-prefix labels never cluster together.
-	LabelDirectionReverse = "reverse"
-
-	// LabelDirectionNormal uses the original prefix-avoidance algorithm that
-	// prefers shorter labels. This is the default.
-	LabelDirectionNormal = "normal"
-)
-
 // HintsConfig defines the visual and behavioral settings for hints mode.
 type HintsConfig struct {
 	Enabled           bool                `json:"enabled"           toml:"enabled"`
@@ -721,7 +705,7 @@ func (c *Config) baseHotkeysForMode(modeName string) map[string]StringOrStringAr
 func (c *HintsConfig) LabelDirectionForApp(bundleID string) string {
 	dir := c.MergedForApp(bundleID).LabelDirection
 	if dir == "" {
-		return LabelDirectionNormal
+		return domain.LabelDirectionNormal
 	}
 
 	return dir

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/action"
 	"github.com/y3owk1n/neru/internal/domain/element"
 )
@@ -403,9 +404,9 @@ func defaultHotkeys() HotkeysConfig {
 func defaultHints() HintsConfig {
 	return HintsConfig{
 		Enabled:        true,
-		Strategy:       StrategyAXTree,
+		Strategy:       domain.StrategyAXTree,
 		HintCharacters: "asdfghjkl",
-		LabelDirection: LabelDirectionNormal,
+		LabelDirection: domain.LabelDirectionNormal,
 		MaxDepth:       DefaultMaxDepth,
 		Hotkeys: map[string]StringOrStringArray{
 			KeyDisplayEscape:    {CmdIdle},

--- a/internal/config/hintsvalidation_internal_test.go
+++ b/internal/config/hintsvalidation_internal_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain"
+)
 
 // placementSideways is a placement no validator accepts.
 const placementSideways = "sideways"
@@ -256,7 +260,7 @@ func hintsCases() []hintsCase {
 		{
 			name: "vision detects nothing",
 			breakIt: func(c *Config) {
-				c.Hints.Strategy = StrategyVision
+				c.Hints.Strategy = domain.StrategyVision
 				c.Hints.Vision.DetectText = false
 				c.Hints.Vision.DetectRectangles = false
 			},

--- a/internal/config/validators_appconfig.go
+++ b/internal/config/validators_appconfig.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain"
 )
 
 // AppConfigFieldValidator is a callback for validating mode-specific fields in AppConfig.
@@ -201,22 +202,22 @@ func (c *Config) ValidateAppConfigs() error {
 			}
 
 			switch appConfig.Strategy {
-			case StrategyAXTree, StrategyVision, "":
+			case domain.StrategyAXTree, domain.StrategyVision, "":
 			default:
 				return derrors.Newf(
 					derrors.CodeInvalidConfig,
 					"hints.app_configs[%d].strategy must be %q or %q",
-					idx, StrategyAXTree, StrategyVision,
+					idx, domain.StrategyAXTree, domain.StrategyVision,
 				)
 			}
 
 			switch appConfig.LabelDirection {
-			case LabelDirectionReverse, LabelDirectionNormal, "":
+			case domain.LabelDirectionReverse, domain.LabelDirectionNormal, "":
 			default:
 				return derrors.Newf(
 					derrors.CodeInvalidConfig,
 					"hints.app_configs[%d].label_direction must be %q or %q",
-					idx, LabelDirectionReverse, LabelDirectionNormal,
+					idx, domain.LabelDirectionReverse, domain.LabelDirectionNormal,
 				)
 			}
 

--- a/internal/config/validators_hints.go
+++ b/internal/config/validators_hints.go
@@ -5,6 +5,7 @@ import (
 	"unicode"
 
 	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/element"
 )
 
@@ -348,22 +349,22 @@ func validateMissionControlSteps(field string, steps []string) error {
 // behaviors: how elements are found, and how labels are enumerated.
 func (c *Config) validateHintVocabulary() error {
 	switch c.Hints.Strategy {
-	case StrategyAXTree, StrategyVision, "":
+	case domain.StrategyAXTree, domain.StrategyVision, "":
 	default:
 		return derrors.Newf(
 			derrors.CodeInvalidConfig,
 			"hints.strategy must be %q or %q",
-			StrategyAXTree, StrategyVision,
+			domain.StrategyAXTree, domain.StrategyVision,
 		)
 	}
 
 	switch c.Hints.LabelDirection {
-	case LabelDirectionReverse, LabelDirectionNormal, "":
+	case domain.LabelDirectionReverse, domain.LabelDirectionNormal, "":
 	default:
 		return derrors.Newf(
 			derrors.CodeInvalidConfig,
 			"hints.label_direction must be %q or %q",
-			LabelDirectionReverse, LabelDirectionNormal,
+			domain.LabelDirectionReverse, domain.LabelDirectionNormal,
 		)
 	}
 

--- a/internal/domain/domain_constants.go
+++ b/internal/domain/domain_constants.go
@@ -53,6 +53,47 @@ const (
 	UnknownMode   = "unknown"
 )
 
+// The values a mode command's options accept.
+//
+// They live here rather than beside the configuration fields or the mode that
+// reads them because a mode command reaches the daemon from three places — the
+// CLI, a hotkey binding, and a direct IPC caller — and all three have to agree
+// on the vocabulary. Config validates bindings, so the module that parses a
+// mode command cannot import config; putting the values beneath both is what
+// lets every reader name the same constant.
+
+// Element detection strategies, the values hints.strategy accepts.
+const (
+	// StrategyAXTree walks the accessibility tree. This is the default.
+	StrategyAXTree = "axtree"
+
+	// StrategyVision detects elements from the screen image instead.
+	StrategyVision = "vision"
+)
+
+// Hint label enumeration orders, the values hints.label_direction accepts.
+const (
+	// LabelDirectionReverse spreads labels across the alphabet by varying the
+	// first character so same-prefix labels never cluster together.
+	LabelDirectionReverse = "reverse"
+
+	// LabelDirectionNormal uses the original prefix-avoidance algorithm that
+	// prefers shorter labels. This is the default.
+	LabelDirectionNormal = "normal"
+)
+
+// How the real cursor behaves while a selection is being made, the values
+// --cursor-selection-mode accepts.
+const (
+	// CursorSelectionModeFollow keeps the real cursor synced with the current
+	// selection.
+	CursorSelectionModeFollow = "follow"
+
+	// CursorSelectionModeHold keeps the real cursor stationary until an
+	// explicit commit or move.
+	CursorSelectionModeHold = "hold"
+)
+
 // Timeout constants.
 const (
 	ShellCommandTimeout = 30 * time.Second


### PR DESCRIPTION
## Description

This PR moves the values a mode command's options accept into the domain layer, so each one is declared exactly once.

The element detection strategies (`axtree`, `vision`) and hint label directions (`normal`, `reverse`) were declared in the configuration package; the cursor selection modes (`follow`, `hold`) were declared in the modes package, and the daemon compared against bare string literals rather than either. All six are vocabulary a user writes — in a config file, on the command line, or in a hotkey binding — so the configuration validators, the mode services, the IPC controller and the CLI all have to agree on them. They now name the same constants.

No behaviour changes. Every value, validator, default and error message is identical; this is a move plus the import churn it causes.

Two things fall out. The CLI no longer imports the modes package, which it did solely to read two string constants. And the module that will own how a mode command is parsed becomes possible at all: it has to be importable from the configuration package, which validates hotkey bindings, so it cannot import configuration itself and needs these values on a layer beneath both.

## Related Issues

Closes #1186. First ticket of #1185.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, no behaviour changes; the existing configuration, IPC and hint-service tests cover these values and were updated to the new names
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changes
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Configuration and Command Changes

None. `hints.strategy` still accepts `axtree` and `vision`, `hints.label_direction` still accepts `normal` and `reverse`, and `--cursor-selection-mode` still accepts `follow` and `hold`, spelled and defaulted exactly as before. Existing configs and scripts are untouched.

## Additional Context

Two smaller cleanups ride along because they are the same fact:

- The IPC controller compared `--cursor-selection-mode` against bare `"follow"` and `"hold"` literals rather than the modes package constants, making the daemon a third declaration site. It now uses the shared constants.
- The modes package file that held the cursor selection values keeps only the resolution logic that actually belongs to modes.

Worth knowing for review: the values are deliberately placed beside the existing mode and IPC-command constants, which already carry a note explaining that the domain package cannot import configuration. That constraint is the reason this move is a prerequisite rather than a tidy-up — see `docs/adr/0001-one-grammar-for-mode-commands.md` (#1193).
