### PR TITLE
fix(hints): restore --debug printing elements instead of drawing hints

### DIFF
--- a/internal/app/ipcctrl/modeflag_internal_test.go
+++ b/internal/app/ipcctrl/modeflag_internal_test.go
@@ -100,13 +100,14 @@ func probes() map[modeflag.Name]flagProbe {
 				return o.CursorFollowSelection != nil
 			},
 		},
-		// Debug is the one flag the daemon deliberately accepts and ignores:
-		// probing the focused window is work the CLI does. Recognizing it still
-		// matters, because an unrecognized bare word would be taken as the
-		// positional action instead.
+		// Debug is what makes hints short-circuit to a read-only probe instead
+		// of drawing the overlay, so the daemon has to record it like any
+		// other flag. It previously asserted only that --debug was not
+		// mistaken for the positional action, which the flag went on to
+		// satisfy while being dropped on the floor.
 		modeflag.Debug: {
 			args:    []string{"--debug"},
-			applied: func(o ModeActivationOptions) bool { return o.Action == nil },
+			applied: func(o ModeActivationOptions) bool { return o.Debug != nil && *o.Debug },
 		},
 	}
 }

--- a/internal/app/ipcctrl/modeoptions.go
+++ b/internal/app/ipcctrl/modeoptions.go
@@ -51,7 +51,7 @@ func readModeFlag(args *modeArgs, opts *ModeActivationOptions) *ipc.Response {
 		return setTrue(&opts.HideOnEmptySearch)
 
 	case args.is(modeflag.Debug):
-		return nil
+		return setTrue(&opts.Debug)
 
 	case args.is(modeflag.SplitWord):
 		return setTrue(&opts.SplitWord)


### PR DESCRIPTION
## Description

This PR fixes `neru hints --debug`, which since 1.50.0 has activated hints mode and drawn the overlay instead of probing the focused window and printing the clickable elements it finds.

The daemon recognised the flag while reading a mode command but never recorded it. The branch that short-circuits hints activation into the read-only probe checks whether the option was set, and nothing set it, so the probe was unreachable — the probe code itself was fine. Recording the flag like every other one restores the documented behaviour.

Affects both `--debug` and the `-d` short form, from the CLI and from any direct IPC caller. Fixed in 2 lines; the rest of the diff is the test that should have caught it.

## Related Issues

Fixes #1195. Regression from #1147, shipped in v1.50.0; the flag worked when added in #932.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, this restores documented behaviour rather than changing it
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Configuration and Command Changes

None. `neru hints --debug` and `neru hints -d` keep their spelling, their help text and their output format. This restores what the flag has always been documented to do.

## Additional Context

Worth a moment in review: the flag's existing test asserted the bug was intentional. It checked only that `--debug` was not mistaken for the positional action, with a comment stating the daemon "deliberately accepts and ignores" it because probing "is work the CLI does" — which the CLI does not do; it forwards the flag and prints whatever comes back. A flag dropped on the floor satisfied that assertion exactly as well as a working one, which is how the regression passed review.

The assertion now checks the option reaches the daemon. Reverting the one-line fix makes it fail for both `--debug` and `-d`, so it pins the behaviour rather than restating it.

A hotkey binding written as `hints --debug` is unaffected either way: the probe returns its summary in a response message, and the sequence executor discards response messages, so a probe from a binding produced no visible output before this change or after it. That case is addressed separately in #1187, which gives the probe its own IPC action.
