### PR TITLE
feat(config): catch a mistyped mode flag in a binding when the config loads

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1169,6 +1169,22 @@ neru config validate [-c <path>]
 Does not require a running daemon. Exits successfully when no config file is
 found, because Neru runs on built-in defaults in that case.
 
+It reads the flags of the mode commands in your bindings, so a mistyped flag is
+found here rather than when the key is pressed. A binding that will load and
+not do everything it says — `grid --search`, where grid has no search — is
+printed as a warning and still exits successfully:
+
+```
+Configuration is valid, with warnings:
+
+  hotkeys.Primary+Shift+G: grid does not accept --search
+
+These parts of the configuration load and will not take effect.
+```
+
+See [Global Hotkeys](CONFIGURATION.md#global-hotkeys) for which mistakes warn
+and which refuse the file.
+
 ---
 
 ## neru config set

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -377,6 +377,28 @@ missing — `--on-exit` without `--action`, for instance — are refused when th
 key is pressed rather than dropped in silence, with the message the CLI gives
 for the same mistake.
 
+**The flags are read when the config loads**, so a mistake is found by
+`neru config validate` rather than by pressing the key. What happens next
+depends on what the mistake costs:
+
+| In a binding                                                              | Result                                   |
+| ------------------------------------------------------------------------- | ---------------------------------------- |
+| A flag no mode has (`hints --serach`), or a value no flag takes (`--strategy=nonsense`) | The config fails to load and Neru runs on defaults |
+| A flag the named mode does not accept (`grid --search`)                   | Loads, and `neru config validate` warns  |
+| A flag whose partner is missing (`hints --repeat` with no `--action`)     | Loads, and `neru config validate` warns  |
+
+The first row is a binding that could not have activated anything either way,
+and it fails the load exactly as an unknown *command* in a binding already
+does. The other two describe a binding that works minus one flag, and losing
+your whole configuration over one of those would be worse than the flag doing
+nothing — so they are reported and left alone.
+
+The check reaches every table a binding can be written in, and a macro body.
+A step nested inside another one — the steps of a `run`, or of an `--on-exit` —
+is checked for the command it names, and its flags are read when it runs. A
+macro body step carrying a `$1` placeholder is left for the same reason: what
+fills it is only known when the macro is called.
+
 #### Merging Behavior
 
 | Config                 | Result                    |

--- a/internal/app/ipcctrl/modes.go
+++ b/internal/app/ipcctrl/modes.go
@@ -2,7 +2,6 @@ package ipcctrl
 
 import (
 	"context"
-	"errors"
 
 	"go.uber.org/zap"
 
@@ -88,12 +87,7 @@ func (h *ModesHandler) activationHandler(
 // domain error carries for callers — the code travels in the response's own
 // field instead, which is what a script branches on.
 func refusalFor(err error) ipc.Response {
-	message := err.Error()
-
-	domainErr, isDomainErr := errors.AsType[*derrors.Error](err)
-	if isDomainErr {
-		message = domainErr.Message()
-	}
+	message := derrors.Message(err)
 
 	code := ipc.CodeActionFailed
 	if derrors.IsCode(err, derrors.CodeInvalidInput) {

--- a/internal/cli/config_validate.go
+++ b/internal/cli/config_validate.go
@@ -60,9 +60,34 @@ func runConfigValidate(cmd *cobra.Command) error {
 		return &silentError{err: errConfigValidationFailed}
 	}
 
-	cmd.Println("Configuration is valid")
+	printValidationWarnings(cmd, loadResult.Warnings)
+
 	cmd.Println("")
 	cmd.Println("Config file: " + loadResult.ConfigPath)
 
 	return nil
+}
+
+// printValidationWarnings says what loaded and will not do what it says.
+//
+// This is the whole reason a warning is worth telling apart from a refusal: it
+// does not stop the configuration loading, so without a line here it would
+// exist only in the daemon's log, invisible to the command people run to check
+// their configuration.
+func printValidationWarnings(cmd *cobra.Command, warnings []string) {
+	if len(warnings) == 0 {
+		cmd.Println("Configuration is valid")
+
+		return
+	}
+
+	cmd.Println("Configuration is valid, with warnings:")
+	cmd.Println("")
+
+	for _, warning := range warnings {
+		cmd.Println("  " + warning)
+	}
+
+	cmd.Println("")
+	cmd.Println("These parts of the configuration load and will not take effect.")
 }

--- a/internal/cli/config_validate_internal_test.go
+++ b/internal/cli/config_validate_internal_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestRunConfigValidate_ReportsWhatLoadedAndWhatWillNotRun pins the reason a
+// warning is told apart from a refusal at all: it does not stop the
+// configuration loading, so unless this command prints it, it exists only in
+// the daemon's log and never reaches the person checking their config.
+func TestRunConfigValidate_ReportsWhatLoadedAndWhatWillNotRun(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    string
+		wantErr   bool
+		wantLines []string
+	}{
+		{
+			name:      "a clean configuration says only that it is valid",
+			config:    "[hotkeys]\n\"Primary+Shift+K\" = \"hints --action left_click\"\n",
+			wantLines: []string{"Configuration is valid"},
+		},
+		{
+			name:   "an inert flag is named and the configuration still loads",
+			config: "[hotkeys]\n\"Primary+Shift+K\" = \"grid --search\"\n",
+			wantLines: []string{
+				"Configuration is valid, with warnings:",
+				"hotkeys.Primary+Shift+K: grid does not accept --search",
+			},
+		},
+		{
+			name:      "an unknown flag is refused",
+			config:    "[hotkeys]\n\"Primary+Shift+K\" = \"hints --serach\"\n",
+			wantErr:   true,
+			wantLines: []string{"unknown flag: --serach"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+
+			writeErr := os.WriteFile(path, []byte(testCase.config), 0o600)
+			if writeErr != nil {
+				t.Fatalf("WriteFile: %v", writeErr)
+			}
+
+			// The command reads the file named by the global --config flag,
+			// which is the only way to point it at one; it is restored so the
+			// next test finds it as it was.
+			previous := configPath
+			configPath = path
+
+			defer func() { configPath = previous }()
+
+			out := &bytes.Buffer{}
+			cmd := &cobra.Command{}
+			cmd.SetOut(out)
+			cmd.SetErr(out)
+
+			err := runConfigValidate(cmd)
+			if (err != nil) != testCase.wantErr {
+				t.Fatalf("runConfigValidate() error = %v, wantErr = %v", err, testCase.wantErr)
+			}
+
+			for _, line := range testCase.wantLines {
+				if !strings.Contains(out.String(), line) {
+					t.Errorf("output = %q, want it to contain %q", out.String(), line)
+				}
+			}
+		})
+	}
+}

--- a/internal/config/AGENTS.md
+++ b/internal/config/AGENTS.md
@@ -9,3 +9,5 @@
 5. `configs/` examples (embedded and tested — stale examples break the build) and `docs/CONFIGURATION.md` (the single home for config reference facts).
 
 The `add-config-option` skill walks this end to end, plus tests. Fast check: `just test-foundation`.
+
+**Refusing costs the whole file.** A failed `Validate()` replaces the entire configuration with the defaults, not the offending line, so a check that would refuse a setting the user is living with belongs in the warnings channel instead: `ValidateWithWarnings` collects them, they ride out on `LoadResult`, and `neru config validate` prints them. The line between the two, and why it sits where it does, is ADR 0002 (`docs/adr/0002-severity-tiered-config-validation.md`). Everything else still refuses loudly — never silently clamp.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -680,6 +680,14 @@ type LoadResult struct {
 	Config          *Config
 	ValidationError error
 	ConfigPath      string
+
+	// Warnings are the parts of the loaded configuration that will not do what
+	// they say. The configuration loaded regardless — that is what separates
+	// one of these from ValidationError, which leaves the defaults running
+	// instead — so they are reported rather than acted on. They are empty
+	// whenever ValidationError is set: the configuration they described is not
+	// the one that ended up loaded.
+	Warnings []string
 }
 
 func (c *Config) baseHotkeysForMode(modeName string) map[string]StringOrStringArray {

--- a/internal/config/loader/load.go
+++ b/internal/config/loader/load.go
@@ -50,7 +50,9 @@ func (s *Service) LoadWithValidation(path string) *config.LoadResult {
 		return rejected
 	}
 
-	validateErr := result.Config.Validate()
+	warnings := &config.Warnings{}
+
+	validateErr := result.Config.ValidateWithWarnings(warnings)
 	if validateErr != nil {
 		wrapped := derrors.WrapConfigFailed(validateErr, "validate configuration")
 
@@ -58,6 +60,11 @@ func (s *Service) LoadWithValidation(path string) *config.LoadResult {
 
 		return refuse(result, wrapped)
 	}
+
+	// The override pass below validates again, for refusals only: an override
+	// sets a single scalar field and no scalar field is a binding, so it can
+	// neither add a warning nor answer one.
+	result.Warnings = warnings.Messages()
 
 	overrideErr := s.applyOverrideFile(result.Config, result.ConfigPath)
 	if overrideErr != nil {
@@ -73,6 +80,13 @@ func (s *Service) LoadWithValidation(path string) *config.LoadResult {
 		)
 	}
 
+	// Logged as well as reported, because a hot reload has no one to print to:
+	// the CLI shows these to whoever runs `neru config validate`, and the log
+	// is the only place a daemon that reloaded on its own can say them.
+	for _, warning := range result.Warnings {
+		s.logger.Warn("Configuration warning", zap.String("warning", warning))
+	}
+
 	s.logger.Info("Configuration loaded successfully")
 
 	removeLauncherBindingsForDisabledModes(result.Config)
@@ -85,6 +99,10 @@ func (s *Service) LoadWithValidation(path string) *config.LoadResult {
 func refuse(result *config.LoadResult, err error) *config.LoadResult {
 	result.ValidationError = err
 	result.Config = config.DefaultConfig()
+
+	// The warnings were about the file that was refused, not about the defaults
+	// now running, so they go with it.
+	result.Warnings = nil
 
 	return result
 }

--- a/internal/config/loader/loadgolden_test.go
+++ b/internal/config/loader/loadgolden_test.go
@@ -34,6 +34,11 @@ type loadSnapshot struct {
 	// A refused config still comes back populated, so recording only the config
 	// would let a refusal read as a clean load.
 	ValidationError string `json:"validationError"`
+
+	// Warnings are the parts of the file that loaded and will not do what they
+	// say. Recorded alongside the delta so a case can show both at once: that
+	// the binding is there, and that it was reported.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // fixedHotkeyDefaults is the binding set every case starts from.
@@ -143,6 +148,26 @@ font_size = 42
 bundle_id = "com.apple.Safari"
 [app_configs.hints.ui]
 font_size = 21
+`,
+		},
+		{
+			// The binding works minus the flag, so it keeps working: the delta
+			// shows it loaded, and the warning says what it will not do.
+			// Refusing it would cost the user every other binding in the file.
+			name: "a binding with an inert flag loads and warns",
+			config: `
+[hotkeys]
+"Primary+Shift+K" = "grid --search"
+"Primary+Shift+J" = "hints --repeat"
+`,
+		},
+		{
+			// A flag nothing knows was never going to activate anything, so
+			// this is refused like the unknown command it resembles.
+			name: "a binding with an unknown flag is refused",
+			config: `
+[hotkeys]
+"Primary+Shift+K" = "hints --serach --action=bogus"
 `,
 		},
 		{
@@ -297,6 +322,7 @@ func TestLoadWithValidation_MatchesItsSnapshot(t *testing.T) {
 				snapshot.ValidationError = result.ValidationError.Error()
 			} else {
 				snapshot.Delta = configDelta(t, baseline.Config, result.Config)
+				snapshot.Warnings = result.Warnings
 			}
 
 			encoded, marshalErr := json.MarshalIndent(snapshot, "", "  ")

--- a/internal/config/loader/testdata/load/a binding with an inert flag loads and warns.json
+++ b/internal/config/loader/testdata/load/a binding with an inert flag loads and warns.json
@@ -1,0 +1,13 @@
+{
+  "delta": [
+    "+ .hotkeys.bindings.Primary+Shift+J[0] = \"hints --repeat\"",
+    "+ .hotkeys.bindings.Primary+Shift+K[0] = \"grid --search\"",
+    "- .hotkeys.bindings.Primary+Shift+G[0] = \"grid\"",
+    "- .hotkeys.bindings.Primary+Shift+Space[0] = \"hints\""
+  ],
+  "validationError": "",
+  "warnings": [
+    "hotkeys.Primary+Shift+J: --repeat requires --action",
+    "hotkeys.Primary+Shift+K: grid does not accept --search"
+  ]
+}

--- a/internal/config/loader/testdata/load/a binding with an unknown flag is refused.json
+++ b/internal/config/loader/testdata/load/a binding with an unknown flag is refused.json
@@ -1,0 +1,4 @@
+{
+  "delta": [],
+  "validationError": "[INVALID_CONFIG] configuration validate configuration failed: [INVALID_CONFIG] hotkeys.Primary+Shift+K: unknown flag: --serach"
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -9,8 +9,16 @@ import (
 	"github.com/y3owk1n/neru/internal/derrors"
 )
 
-// Validate validates the configuration.
+// Validate validates the configuration, reporting only what stops it loading.
+// It is the form every caller that can act on nothing else uses.
 func (c *Config) Validate() error {
+	return c.ValidateWithWarnings(nil)
+}
+
+// ValidateWithWarnings validates the configuration and collects, into warnings,
+// the parts of it that load and will not do what they say. A nil sink discards
+// them; see [Warnings] for why the two are told apart at all.
+func (c *Config) ValidateWithWarnings(warnings *Warnings) error {
 	if c == nil {
 		return derrors.New(derrors.CodeInvalidConfig, "configuration cannot be nil")
 	}
@@ -131,7 +139,9 @@ func (c *Config) Validate() error {
 		return err
 	}
 
-	return nil
+	// Read the flags of every mode command, now that the bindings holding them
+	// are known to be well formed.
+	return c.ValidateModeCommands(warnings)
 }
 
 // ValidateHotkeyBindings validates the top-level [hotkeys] key format and action strings.

--- a/internal/config/validators_hotkeys.go
+++ b/internal/config/validators_hotkeys.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/derrors"
 	"github.com/y3owk1n/neru/internal/domain/action"
+	"github.com/y3owk1n/neru/internal/domain/modecmd"
 )
 
 var validModifiers = map[string]bool{
@@ -373,14 +374,18 @@ func validateHotkeyActionString(actionStr string) error {
 		return derrors.Newf(derrors.CodeInvalidConfig, "unknown action subcommand: %s", name)
 	}
 
-	// Mode commands may include flags (e.g. "hints --action left_click").
-	// Split on space and validate the first word as a known root/mode command.
+	// Mode commands may include flags (e.g. "hints --action left_click"). Only
+	// the command word is judged here: the flags after it are read by
+	// ValidateModeCommands, which weighs what it finds rather than refusing all
+	// of it.
 	cmd := strings.Fields(trimmed)[0]
 
+	if _, isMode := modecmd.LookupMode(cmd); isMode {
+		return nil
+	}
+
 	switch cmd {
-	case "idle", ModeNameHints, ModeNameGrid, ModeNameScroll, ModeNameRecursiveGrid,
-		ModeNameMonitorSelect,
-		"toggle-screen-share", CmdToggleCursorFollowSelection,
+	case "toggle-screen-share", CmdToggleCursorFollowSelection,
 		"toggle-scroll-invert",
 		"config",
 		// "run" takes its own steps as arguments. Each one is validated when

--- a/internal/config/validators_modecmd.go
+++ b/internal/config/validators_modecmd.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/modecmd"
+)
+
+// ValidateModeCommands reads every mode command in the configuration through
+// the grammar that will run it, so a flag that would be refused when the key
+// is pressed is found before it ever is.
+//
+// What is refused here and what is only warned about is ADR 0002's split. A
+// refused configuration is replaced by the defaults in full, so that is spent
+// only on a binding that could not have run at all — one naming a flag nothing
+// knows, or a value no flag can carry. A binding that runs minus one flag is
+// left loading and reported through warnings, which reach the user through
+// `neru config validate` rather than only the log.
+//
+// A step nested inside another one — the steps an --on-exit carries, or the
+// steps of a "run" — is checked for the command it names, by
+// validateHotkeyActionString, and not for its flags. Reading those would mean
+// reading a step out of the argument list it was quoted into, which is the
+// runtime's job at the moment it dispatches them.
+func (c *Config) ValidateModeCommands(warnings *Warnings) error {
+	return c.eachBindingAction(func(field, actionStr string) error {
+		mode, args, isModeCommand := parseModeCommand(actionStr)
+		if !isModeCommand {
+			return nil
+		}
+
+		reported, err := modecmd.Diagnose(mode, args)
+		if err != nil {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%s: %s",
+				field,
+				derrors.Message(err),
+			)
+		}
+
+		for _, warning := range reported {
+			warnings.Addf("%s: %s", field, derrors.Message(warning))
+		}
+
+		return nil
+	})
+}
+
+// parseModeCommand splits a step into the mode it enters and the arguments it
+// enters it with. The last return value is false for a step that is not a mode
+// command at all, which most steps are not.
+//
+// Tokenising with SplitStepArgs is what makes this the same reading the daemon
+// does: a step is dispatched by splitting it exactly this way and handing the
+// rest to the grammar.
+func parseModeCommand(actionStr string) (domain.Mode, []string, bool) {
+	step := strings.TrimSpace(actionStr)
+
+	// A macro body is only whole once it is called, and what fills its holes is
+	// unknown here. A placeholder only ever appears in a flag's value, so a
+	// step carrying one is left to be read when it is expanded.
+	if hasPlaceholder(step) {
+		return domain.ModeIdle, nil, false
+	}
+
+	tokens := SplitStepArgs(step)
+	if len(tokens) == 0 {
+		return domain.ModeIdle, nil, false
+	}
+
+	mode, isMode := modecmd.LookupMode(tokens[0])
+	if !isMode {
+		return domain.ModeIdle, nil, false
+	}
+
+	return mode, tokens[1:], true
+}
+
+// hasPlaceholder reports whether a step is written with a macro argument in it.
+func hasPlaceholder(step string) bool {
+	found := false
+
+	eachPlaceholder(step, func(_, _, _ int) { found = true })
+
+	return found
+}

--- a/internal/config/validators_modecmd_test.go
+++ b/internal/config/validators_modecmd_test.go
@@ -1,0 +1,178 @@
+package config_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// stepGridSearch is a binding step that loads and does not do what it says:
+// grid makes a selection by coordinates and has no search of its own.
+const stepGridSearch = "grid --search"
+
+// TestValidateModeCommands_WarnsWithoutRefusing pins the severity split where a
+// user meets it: a binding that works minus one flag keeps loading, and what it
+// will not do is reported instead.
+//
+// Refusing these would replace the whole configuration with the defaults, so
+// one inert flag would cost the user every binding, theme and setting they
+// wrote.
+func TestValidateModeCommands_WarnsWithoutRefusing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		breakIt func(*config.Config)
+		want    []string
+	}{
+		{
+			name: "flag the mode does not accept",
+			breakIt: func(cfg *config.Config) {
+				cfg.Hotkeys.Bindings = map[string][]string{"g": {stepGridSearch}}
+			},
+			want: []string{"hotkeys.g: grid does not accept --search"},
+		},
+		{
+			name: "unmet flag dependency",
+			breakIt: func(cfg *config.Config) {
+				cfg.Hotkeys.Bindings = map[string][]string{"h": {"hints --repeat"}}
+			},
+			want: []string{"hotkeys.h: --repeat requires --action"},
+		},
+		{
+			// Every table a mode command can be written in is read, not only
+			// the global one.
+			name: "a mode's own hotkey table",
+			breakIt: func(cfg *config.Config) {
+				cfg.Hints.Hotkeys["q"] = config.StringOrStringArray{stepGridSearch}
+			},
+			want: []string{"hints.hotkeys.q: grid does not accept --search"},
+		},
+		{
+			name: "a macro body",
+			breakIt: func(cfg *config.Config) {
+				cfg.Macros = map[string]config.StringOrStringArray{
+					"click": {stepGridSearch},
+				}
+			},
+			want: []string{"macros.click: grid does not accept --search"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.DefaultConfig()
+			testCase.breakIt(cfg)
+
+			warnings := &config.Warnings{}
+
+			err := cfg.ValidateWithWarnings(warnings)
+			if err != nil {
+				t.Fatalf("ValidateWithWarnings() refused the configuration: %v", err)
+			}
+
+			if got := warnings.Messages(); !slices.Equal(got, testCase.want) {
+				t.Errorf("warnings = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestValidateModeCommands_RefusesAnUnreadableCommand pins the other tier: a
+// binding naming a flag nothing knows never activated anything, so refusing it
+// takes away nothing that worked. An unknown *command* in a binding already
+// fails the whole load, so this extends a rule rather than inventing one.
+func TestValidateModeCommands_RefusesAnUnreadableCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		step string
+		want string
+	}{
+		{
+			name: "mistyped flag",
+			step: "hints --serach --action=bogus",
+			want: "hotkeys.k: unknown flag: --serach",
+		},
+		{
+			name: "unusable value",
+			step: "hints --strategy=nonsense",
+			want: "hotkeys.k: --strategy requires axtree or vision",
+		},
+		{
+			name: "action no mode can perform",
+			step: "hints --action=move_mouse",
+			want: `hotkeys.k: "move_mouse" cannot be used as a mode action`,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.DefaultConfig()
+			cfg.Hotkeys.Bindings = map[string][]string{"k": {testCase.step}}
+
+			warnings := &config.Warnings{}
+
+			err := cfg.ValidateWithWarnings(warnings)
+			if err == nil {
+				t.Fatal("ValidateWithWarnings() accepted a binding that cannot run")
+			}
+
+			if got := err.Error(); !strings.Contains(got, testCase.want) {
+				t.Errorf("error = %q, want it to contain %q", got, testCase.want)
+			}
+
+			if got := warnings.Messages(); len(got) > 0 {
+				t.Errorf("warnings = %q, want none alongside a refusal", got)
+			}
+		})
+	}
+}
+
+// TestValidateModeCommands_LeavesMacroPlaceholdersAlone pins that a macro body
+// is not judged on the arguments it has not been given yet. A placeholder only
+// ever stands in for a flag's value, and what fills it is known when the macro
+// is called, not when it is written.
+func TestValidateModeCommands_LeavesMacroPlaceholdersAlone(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultConfig()
+	cfg.Macros = map[string]config.StringOrStringArray{"click": {"hints --action $1"}}
+	cfg.Hotkeys.Bindings = map[string][]string{"m": {"macro click left_click"}}
+
+	warnings := &config.Warnings{}
+
+	err := cfg.ValidateWithWarnings(warnings)
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() refused a macro body: %v", err)
+	}
+
+	if got := warnings.Messages(); len(got) > 0 {
+		t.Errorf("warnings = %q, want none", got)
+	}
+}
+
+// TestValidateModeCommands_AcceptsTheDefaults pins that a configuration nobody
+// has broken reports as valid with nothing to say. The defaults are the one
+// configuration every user starts from, so a warning here would reach everyone.
+func TestValidateModeCommands_AcceptsTheDefaults(t *testing.T) {
+	t.Parallel()
+
+	warnings := &config.Warnings{}
+
+	err := config.DefaultConfig().ValidateWithWarnings(warnings)
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() refused the defaults: %v", err)
+	}
+
+	if got := warnings.Messages(); len(got) > 0 {
+		t.Errorf("warnings = %q, want none", got)
+	}
+}

--- a/internal/config/warnings.go
+++ b/internal/config/warnings.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"fmt"
+	"slices"
+)
+
+// Warnings collects what a configuration says that will not happen.
+//
+// A warning is for a setting that is written well enough to load and will not
+// do what it reads as — a binding naming a flag its mode has no use for, say.
+// Refusing the load over one would be worse than the bug: a refused
+// configuration is replaced by the defaults, so the user loses every binding,
+// theme and setting they wrote over one line that mostly works (ADR 0002).
+//
+// The list travels out on a [LoadResult] so `neru config validate` can print
+// it. A warning that only reached the log would be invisible to the command
+// people run to check their configuration, which would leave the whole tier
+// meaningless.
+//
+// A nil *Warnings collects nothing, so a caller that only acts on a refusal
+// can validate without one.
+type Warnings struct {
+	messages []string
+}
+
+// Addf records one warning, worded as advice about the field it names.
+func (w *Warnings) Addf(format string, args ...any) {
+	if w == nil {
+		return
+	}
+
+	w.messages = append(w.messages, fmt.Sprintf(format, args...))
+}
+
+// Messages returns what was collected, sorted.
+//
+// Sorted because most of a configuration lives in maps: the same file walked
+// twice reports the same warnings in a different order, and a user comparing
+// two runs of `neru config validate` should not have to notice that nothing
+// changed. The order that results groups a field's warnings together.
+func (w *Warnings) Messages() []string {
+	if w == nil || len(w.messages) == 0 {
+		return nil
+	}
+
+	sorted := slices.Clone(w.messages)
+	slices.Sort(sorted)
+
+	return sorted
+}

--- a/internal/derrors/errors.go
+++ b/internal/derrors/errors.go
@@ -205,6 +205,25 @@ func IsCode(err error, code Code) bool {
 	return false
 }
 
+// Message returns the sentence an error says, without the code a domain error
+// carries alongside it.
+//
+// The code is for a caller to branch on and travels in whatever field the
+// caller answers with; the sentence is what a person reads. Every door that
+// shows an error to someone — an IPC response, a configuration warning —
+// shows it through this, so the same fault reads the same wherever it surfaces.
+func Message(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	if domainErr, ok := errors.AsType[*Error](err); ok {
+		return domainErr.Message()
+	}
+
+	return err.Error()
+}
+
 // GetCode extracts the error code from an error, or returns CodeInternal if not a domain error.
 func GetCode(err error) Code {
 	if domainErr, ok := errors.AsType[*Error](err); ok {

--- a/internal/domain/modecmd/diagnose.go
+++ b/internal/domain/modecmd/diagnose.go
@@ -1,0 +1,40 @@
+package modecmd
+
+import "github.com/y3owk1n/neru/internal/domain"
+
+// Diagnose reads a mode command the way [Parse] does and reports what is wrong
+// with it in two parts: the error is the command being unreadable, and the
+// warnings are the ways a readable command will not do everything it says.
+//
+// It is for the one reader that cannot spend the two the same way. A
+// configuration that fails to load is replaced by the defaults — every
+// binding, theme and setting, not the offending line — so that is spent only
+// on a command that could not have run at all: one naming a flag nothing
+// knows, or a value no flag can carry. A command that runs minus one flag is
+// left loading, and reported instead (ADR 0002).
+//
+// Everywhere a mode is actually entered, [Parse] is the door and every fault
+// below is a refusal. The sentences are the same either way, so the same
+// mistake reads the same whether it was typed, sent over the socket, or found
+// in a binding.
+func Diagnose(mode domain.Mode, args []string) ([]error, error) {
+	activation, unsupported, err := read(mode, args)
+	if err != nil {
+		return nil, err
+	}
+
+	// A command holding both an unreadable value and an inert flag is
+	// unreadable: there is nothing left to weigh once it cannot run.
+	valueErr := validateValues(activation)
+	if valueErr != nil {
+		return nil, valueErr
+	}
+
+	warnings := make([]error, 0, len(unsupported))
+
+	for _, name := range unsupported {
+		warnings = append(warnings, notAccepted(mode, name))
+	}
+
+	return append(warnings, unmetDependencies(activation)...), nil
+}

--- a/internal/domain/modecmd/diagnose_test.go
+++ b/internal/domain/modecmd/diagnose_test.go
@@ -1,0 +1,299 @@
+package modecmd_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/modecmd"
+)
+
+// modeNameGrid is the mode's own name, which a caller modeled on the CLI's
+// traffic repeats as the first argument.
+const modeNameGrid = "grid"
+
+// TestDiagnose_WarnsAboutACommandThatStillRuns pins the faults a configuration
+// is told about rather than refused for: a flag the mode has no use for, and a
+// flag written without the one it depends on. Both describe a binding that
+// works minus one flag, and refusing the load would cost the user every other
+// binding they wrote.
+func TestDiagnose_WarnsAboutACommandThatStillRuns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode domain.Mode
+		args []string
+		want []string
+	}{
+		{
+			name: "flag the mode does not accept",
+			mode: domain.ModeGrid,
+			args: []string{argSearch},
+			want: []string{msgGridRejectsSearch},
+		},
+		{
+			// The value belongs to the flag that was dropped, so it is stepped
+			// over. Left where it was, "vision" would be read as the positional
+			// action and the command would be refused for naming one no mode
+			// can perform.
+			name: "value of a flag the mode does not accept",
+			mode: domain.ModeGrid,
+			args: []string{flagStrategy, "vision"},
+			want: []string{"grid does not accept --strategy"},
+		},
+		{
+			// The flag after it is not its value: stepping over "--search"
+			// here would drop a flag in silence, which is the whole failure
+			// this package exists to remove.
+			name: "a flag written where the dropped flag's value would be",
+			mode: domain.ModeGrid,
+			args: []string{flagStrategy, argSearch},
+			want: []string{
+				"grid does not accept --strategy",
+				msgGridRejectsSearch,
+			},
+		},
+		{
+			name: "action on a mode that makes no selection",
+			mode: domain.ModeScroll,
+			args: []string{flagAction, leftClick},
+			want: []string{"scroll does not accept --action"},
+		},
+		{
+			name: "repeat without action",
+			mode: domain.ModeHints,
+			args: []string{flagRepeat},
+			want: []string{msgRepeatNeedsAction},
+		},
+		{
+			name: "on-exit without action",
+			mode: domain.ModeHints,
+			args: []string{"--on-exit=" + stepLeftClick},
+			want: []string{
+				"--on-exit requires --action (it runs only when the action is fulfilled)",
+			},
+		},
+		{
+			name: "modifier without action",
+			mode: domain.ModeHints,
+			args: []string{argModifierCmd},
+			want: []string{"--modifier requires --action"},
+		},
+		{
+			name: "hide-on-empty-search without search",
+			mode: domain.ModeHints,
+			args: []string{flagHideOnEmpty},
+			want: []string{"--hide-on-empty-search requires --search"},
+		},
+		{
+			// Every fault is reported, not just the first: a user fixing their
+			// configuration should see the whole of what is wrong with a
+			// binding rather than one fault per edit.
+			name: "several at once",
+			mode: domain.ModeGrid,
+			args: []string{argSearch, argZoomToDepth2, flagRepeat},
+			want: []string{
+				msgGridRejectsSearch,
+				"grid does not accept --zoom-to-depth",
+				msgRepeatNeedsAction,
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			warnings, err := modecmd.Diagnose(testCase.mode, testCase.args)
+			if err != nil {
+				t.Fatalf("Diagnose(%v) refused the command: %v", testCase.args, err)
+			}
+
+			if got := messages(warnings); !slices.Equal(got, testCase.want) {
+				t.Errorf("warnings = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestDiagnose_RefusesACommandThatCouldNotRun pins the other side of the split:
+// a command naming a flag nothing knows, or a value no flag can carry, never
+// activated anything, so refusing the configuration takes nothing away that
+// worked.
+func TestDiagnose_RefusesACommandThatCouldNotRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode domain.Mode
+		args []string
+		want string
+	}{
+		{
+			name: "a flag nothing knows",
+			mode: domain.ModeHints,
+			args: []string{flagMistyped, "--action=bogus"},
+			want: "unknown flag: --serach",
+		},
+		{
+			name: "stray argument",
+			mode: domain.ModeHints,
+			args: []string{leftClick, "stray"},
+			want: "unexpected argument: stray",
+		},
+		{
+			name: "argument to a mode that takes none",
+			mode: domain.ModeIdle,
+			args: []string{leftClick},
+			want: "unexpected argument: left_click",
+		},
+		{
+			name: "missing value",
+			mode: domain.ModeHints,
+			args: []string{flagAction},
+			want: "--action requires a value",
+		},
+		{
+			name: "unusable value",
+			mode: domain.ModeHints,
+			args: []string{argBadStrategy},
+			want: msgStrategyValue,
+		},
+		{
+			name: "empty modifier list",
+			mode: domain.ModeHints,
+			args: []string{argAction, "--modifier=,"},
+			want: "modifier values cannot be empty",
+		},
+		{
+			// The command cannot run, so there is nothing left to weigh: the
+			// inert --repeat is not reported alongside it.
+			name: "unusable action outweighs a warning",
+			mode: domain.ModeHints,
+			args: []string{flagRepeat, "--action=nonsense"},
+			want: "invalid action: nonsense",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			warnings, err := modecmd.Diagnose(testCase.mode, testCase.args)
+			if err == nil {
+				t.Fatalf("Diagnose(%v) was accepted; want a refusal", testCase.args)
+			}
+
+			// A prefix, so the action vocabulary can be pinned without
+			// repeating the whole list of action names it ends with.
+			if got := message(err); !strings.HasPrefix(got, testCase.want) {
+				t.Errorf("message = %q, want it to start with %q", got, testCase.want)
+			}
+
+			if len(warnings) > 0 {
+				t.Errorf("warnings = %q, want none alongside a refusal", messages(warnings))
+			}
+		})
+	}
+}
+
+// TestDiagnose_AcceptsACleanCommand pins that a command with nothing wrong with
+// it produces neither, for every mode. A configuration made only of these is
+// what "valid" has to keep meaning.
+func TestDiagnose_AcceptsACleanCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		mode domain.Mode
+		args []string
+	}{
+		{domain.ModeHints, nil},
+		{domain.ModeHints, []string{argAction, argSearch, flagHideOnEmpty, argModifierCmd}},
+		{domain.ModeGrid, []string{modeNameGrid, argAction, argOnExitStep}},
+		{domain.ModeRecursiveGrid, []string{argZoomToDepth2, argToggle}},
+		{domain.ModeScroll, []string{argToggle}},
+		{domain.ModeMonitorSelect, []string{argToggle}},
+		{domain.ModeIdle, nil},
+	}
+
+	for _, testCase := range tests {
+		t.Run(domain.ModeString(testCase.mode), func(t *testing.T) {
+			t.Parallel()
+
+			warnings, err := modecmd.Diagnose(testCase.mode, testCase.args)
+			if err != nil {
+				t.Fatalf("Diagnose(%v) refused a clean command: %v", testCase.args, err)
+			}
+
+			if len(warnings) > 0 {
+				t.Errorf("warnings = %q, want none", messages(warnings))
+			}
+		})
+	}
+}
+
+// TestDiagnose_SaysWhatParseSays pins that weighing a fault does not reword it:
+// the sentence a configuration prints is the one the daemon and the command
+// line give for the same mistake.
+func TestDiagnose_SaysWhatParseSays(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode domain.Mode
+		args []string
+	}{
+		{name: "unsupported flag", mode: domain.ModeGrid, args: []string{argSearch}},
+		{name: "unmet dependency", mode: domain.ModeHints, args: []string{flagRepeat}},
+		{name: "a flag nothing knows", mode: domain.ModeHints, args: []string{flagMistyped}},
+		{name: "unusable value", mode: domain.ModeHints, args: []string{argBadStrategy}},
+		{
+			name: "unusable action",
+			mode: domain.ModeHints,
+			args: []string{"--action=move_mouse"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			warnings, diagnoseErr := modecmd.Diagnose(testCase.mode, testCase.args)
+
+			_, parseErr := modecmd.Parse(testCase.mode, testCase.args)
+			if parseErr == nil {
+				t.Fatalf("Parse(%v) was accepted; want a refusal", testCase.args)
+			}
+
+			got := ""
+
+			switch {
+			case diagnoseErr != nil:
+				got = message(diagnoseErr)
+			case len(warnings) > 0:
+				got = message(warnings[0])
+			default:
+				t.Fatalf(
+					"Diagnose(%v) reported nothing; want the fault Parse refuses",
+					testCase.args,
+				)
+			}
+
+			if want := message(parseErr); got != want {
+				t.Errorf("Diagnose says %q, Parse says %q", got, want)
+			}
+		})
+	}
+}
+
+// messages returns what each reported fault says, without the error code.
+func messages(reported []error) []string {
+	said := make([]string, 0, len(reported))
+	for _, one := range reported {
+		said = append(said, message(one))
+	}
+
+	return said
+}

--- a/internal/domain/modecmd/flags.go
+++ b/internal/domain/modecmd/flags.go
@@ -334,7 +334,27 @@ var (
 
 	// recursiveGridOnly is the one flag about zooming.
 	recursiveGridOnly = []domain.Mode{domain.ModeRecursiveGrid}
+
+	// modes is every mode a mode command can name: the ones a user enters, and
+	// idle, which is how they leave.
+	modes = append(slices.Clone(enterableModes), domain.ModeIdle)
 )
+
+// LookupMode returns the mode a command word names.
+//
+// It is exported for the reader that has to decide whether something is a mode
+// command before it can be parsed: a configuration holds its bindings as text,
+// and the word it recognizes has to be the word the daemon dispatches on, or
+// the two would disagree about which steps are even mode commands.
+func LookupMode(word string) (domain.Mode, bool) {
+	for _, mode := range modes {
+		if domain.ModeString(mode) == word {
+			return mode, true
+		}
+	}
+
+	return domain.ModeIdle, false
+}
 
 // descriptors is the vocabulary, in the order a rendering writes it and the
 // documentation lists it.

--- a/internal/domain/modecmd/modecmd_test.go
+++ b/internal/domain/modecmd/modecmd_test.go
@@ -20,17 +20,28 @@ const (
 	flagOnExit       = "--on-exit"
 	flagRole         = "--role"
 	flagRepeat       = "--repeat"
+	flagStrategy     = "--strategy"
 	flagHideOnEmpty  = "--hide-on-empty-search"
 	argAction        = "--action=left_click"
 	argSearch        = "--search"
 	argToggle        = "--toggle"
 	argOnExitStep    = "--on-exit=action left_click"
+	argModifierCmd   = "--modifier=cmd"
+	argBadStrategy   = "--strategy=nonsense"
+	argZoomToDepth2  = "--zoom-to-depth=2"
+	flagMistyped     = "--serach"
 	stepLeftClick    = "action left_click"
 	directionReverse = "reverse"
 
 	// msgZoomToDepth is the one message that flag gives, whichever way its
 	// value is unusable.
 	msgZoomToDepth = "--zoom-to-depth requires a non-negative integer"
+
+	// The messages both this file and the diagnosis cases pin, so that the two
+	// readings of the same command are held to the same sentence.
+	msgRepeatNeedsAction = "--repeat requires --action"
+	msgStrategyValue     = "--strategy requires axtree or vision"
+	msgGridRejectsSearch = "grid does not accept --search"
 )
 
 // flagCase is one flag together with proof that parsing it took effect.
@@ -66,7 +77,7 @@ func flagCases() map[modecmd.Flag]flagCase {
 		// A modifier is held during the action, so it needs one to hold it for.
 		modecmd.FlagModifier: {
 			mode:    domain.ModeHints,
-			args:    []string{argAction, "--modifier=cmd"},
+			args:    []string{argAction, argModifierCmd},
 			applied: func(a modecmd.Activation) bool { return a.Modifier != nil },
 			build: func(a *modecmd.Activation) {
 				a.Action = new(leftClick)
@@ -518,7 +529,7 @@ func TestParse_RefusesFlagsTheModeDoesNotAccept(t *testing.T) {
 			name: "search on grid",
 			mode: domain.ModeGrid,
 			args: []string{argSearch},
-			want: "grid does not accept --search",
+			want: msgGridRejectsSearch,
 		},
 		{
 			name: "action on scroll",
@@ -541,7 +552,7 @@ func TestParse_RefusesFlagsTheModeDoesNotAccept(t *testing.T) {
 		{
 			name: "zoom-to-depth on hints",
 			mode: domain.ModeHints,
-			args: []string{"--zoom-to-depth=2"},
+			args: []string{argZoomToDepth2},
 			want: "hints does not accept --zoom-to-depth",
 		},
 	}
@@ -577,7 +588,7 @@ func TestParse_RefusesUnknownArguments(t *testing.T) {
 		{
 			name: "mistyped flag",
 			mode: domain.ModeHints,
-			args: []string{"--serach"},
+			args: []string{flagMistyped},
 			want: "unknown flag: --serach",
 		},
 		{
@@ -649,11 +660,11 @@ func TestParse_RefusalMessages(t *testing.T) {
 			[]string{"--zoom-to-depth=deep"},
 			msgZoomToDepth,
 		},
-		{domain.ModeHints, []string{"--strategy"}, "--strategy requires axtree or vision"},
+		{domain.ModeHints, []string{flagStrategy}, msgStrategyValue},
 		{
 			domain.ModeHints,
-			[]string{"--strategy=nonsense"},
-			"--strategy requires axtree or vision",
+			[]string{argBadStrategy},
+			msgStrategyValue,
 		},
 		{
 			domain.ModeHints,
@@ -721,7 +732,7 @@ func TestValidate_EnforcesFlagDependencies(t *testing.T) {
 			name: "repeat without action",
 			mode: domain.ModeHints,
 			args: []string{flagRepeat},
-			want: "--repeat requires --action",
+			want: msgRepeatNeedsAction,
 		},
 		{
 			name: "on-exit without action",
@@ -732,7 +743,7 @@ func TestValidate_EnforcesFlagDependencies(t *testing.T) {
 		{
 			name: "modifier without action",
 			mode: domain.ModeHints,
-			args: []string{"--modifier=cmd"},
+			args: []string{argModifierCmd},
 			want: "--modifier requires --action",
 		},
 		{
@@ -838,7 +849,7 @@ func TestValidate_RefusesAFlagTheModeDoesNotAccept(t *testing.T) {
 		t.Fatal("Validate() accepted --search on grid; want a refusal")
 	}
 
-	if want := "grid does not accept --search"; message(err) != want {
+	if want := msgGridRejectsSearch; message(err) != want {
 		t.Errorf("message = %q, want %q", message(err), want)
 	}
 }

--- a/internal/domain/modecmd/parse.go
+++ b/internal/domain/modecmd/parse.go
@@ -24,8 +24,36 @@ const (
 // exported separately for the caller that builds an activation from typed
 // flags and never parses a string.
 func Parse(mode domain.Mode, args []string) (Activation, error) {
+	activation, unsupported, err := read(mode, args)
+	if err != nil {
+		return Activation{}, err
+	}
+
+	if len(unsupported) > 0 {
+		return Activation{}, notAccepted(mode, unsupported[0])
+	}
+
+	err = Validate(activation)
+	if err != nil {
+		return Activation{}, err
+	}
+
+	return activation, nil
+}
+
+// read reads the arguments into the activation they describe, and hands back
+// the flags the named mode does not accept rather than stopping at the first
+// one.
+//
+// Reading past such a flag is what lets [Diagnose] weigh a whole command:
+// every caller that enters a mode refuses the first of them, and the one
+// caller that does not — a configuration deciding what a mistake costs — needs
+// all of them.
+func read(mode domain.Mode, args []string) (Activation, []Flag, error) {
 	activation := Activation{Mode: mode}
 	rest := withoutModeName(mode, args)
+
+	var unsupported []Flag
 
 	for index := 0; index < len(rest); index++ {
 		arg := rest[index]
@@ -33,10 +61,18 @@ func Parse(mode domain.Mode, args []string) (Activation, error) {
 		descriptor, known := match(arg)
 
 		switch {
+		case known && !descriptor.AcceptedBy(mode):
+			// Read for its shape and then dropped. Stepping over the value it
+			// was written with is what keeps the rest of the command readable:
+			// left where it is, that value would be taken as the positional
+			// action.
+			unsupported = append(unsupported, descriptor.name)
+			index += skipped(descriptor, rest, index)
+
 		case known:
-			consumed, err := apply(descriptor, mode, &activation, rest, index)
+			consumed, err := apply(descriptor, &activation, rest, index)
 			if err != nil {
-				return Activation{}, err
+				return Activation{}, nil, err
 			}
 
 			index += consumed
@@ -44,7 +80,7 @@ func Parse(mode domain.Mode, args []string) (Activation, error) {
 		case looksLikeAFlag(arg):
 			// Taking it as the positional action instead is how a typo used to
 			// travel all the way to the mode as an unusable action name.
-			return Activation{}, invalid(msgUnknownFlag + arg)
+			return Activation{}, nil, invalid(msgUnknownFlag + arg)
 
 		case activation.Action == nil && accepts(FlagAction, mode):
 			// An argument matching no flag is the positional action, which is
@@ -54,31 +90,21 @@ func Parse(mode domain.Mode, args []string) (Activation, error) {
 			activation.Action = &positional
 
 		default:
-			return Activation{}, invalid(msgUnexpectedArg + arg)
+			return Activation{}, nil, invalid(msgUnexpectedArg + arg)
 		}
 	}
 
-	err := Validate(activation)
-	if err != nil {
-		return Activation{}, err
-	}
-
-	return activation, nil
+	return activation, unsupported, nil
 }
 
 // apply reads the flag positioned at index into the activation and reports how
 // many further arguments it consumed.
 func apply(
 	descriptor Descriptor,
-	mode domain.Mode,
 	activation *Activation,
 	args []string,
 	index int,
 ) (int, error) {
-	if !descriptor.AcceptedBy(mode) {
-		return 0, notAccepted(mode, descriptor.name)
-	}
-
 	if !descriptor.TakesValue() {
 		// A value attached to a flag that carries none is the flag's own to
 		// refuse. Reading it here is what stops it from being dropped: the
@@ -112,6 +138,31 @@ func valueAt(descriptor Descriptor, args []string, index int) (string, int, erro
 	}
 
 	return args[index+1], 1, nil
+}
+
+// skipped reports how many further arguments a flag occupies whose value is
+// never going to be read, which is the flag the mode does not accept.
+//
+// It reads the value the same way applying the flag would, so the two cannot
+// disagree about where it ends, and stops short of one case: another flag is
+// never this one's value, whatever it was written next to. Stepping over
+// "--search" in "grid --strategy --search" would drop a flag in silence, which
+// is the failure this package exists to remove.
+func skipped(descriptor Descriptor, args []string, index int) int {
+	if !descriptor.TakesValue() {
+		return 0
+	}
+
+	_, consumed, err := valueAt(descriptor, args, index)
+	if err != nil || consumed == 0 {
+		return 0
+	}
+
+	if _, isAFlag := match(args[index+consumed]); isAFlag {
+		return 0
+	}
+
+	return consumed
 }
 
 // withoutModeName drops the mode's own name when the caller repeated it as the

--- a/internal/domain/modecmd/validate.go
+++ b/internal/domain/modecmd/validate.go
@@ -34,12 +34,12 @@ func Validate(activation Activation) error {
 		return acceptanceErr
 	}
 
-	dependencyErr := validateDependencies(activation)
-	if dependencyErr != nil {
-		return dependencyErr
+	unmet := unmetDependencies(activation)
+	if len(unmet) > 0 {
+		return unmet[0]
 	}
 
-	return validateAction(activation)
+	return validateValues(activation)
 }
 
 // validateAcceptance refuses a flag the named mode has no use for.
@@ -63,30 +63,69 @@ func validateAcceptance(activation Activation) error {
 	return nil
 }
 
-// validateDependencies refuses the flags that are only meaningful alongside
-// another one. They are checked after parsing because a flag may be written
-// before the one it depends on.
-func validateDependencies(activation Activation) error {
-	hasAction := activation.Action != nil
+// dependency is a flag that only means something alongside another one: what
+// it looks like to have been written alone, and the sentence that says so.
+type dependency struct {
+	unmet   func(Activation) bool
+	message string
+}
 
-	if isTrue(activation.Repeat) && !hasAction {
-		return invalid(msgRepeatRequiresAction)
+// dependencies are the co-dependency rules, in the order they are reported.
+//
+// They are a table rather than a run of conditions because they have two
+// readers that need different amounts of them: [Validate] refuses at the
+// first, and [Diagnose] weighs every one.
+var dependencies = []dependency{
+	{
+		unmet:   func(a Activation) bool { return isTrue(a.Repeat) && a.Action == nil },
+		message: msgRepeatRequiresAction,
+	},
+	{
+		unmet:   func(a Activation) bool { return a.OnExit != nil && a.Action == nil },
+		message: msgOnExitRequiresAction,
+	},
+	{
+		unmet:   func(a Activation) bool { return isTrue(a.HideOnEmptySearch) && !isTrue(a.Search) },
+		message: msgHideOnEmptySearchRequiresSearch,
+	},
+	{
+		unmet:   func(a Activation) bool { return a.Modifier != nil && a.Action == nil },
+		message: msgModifierRequiresAction,
+	},
+}
+
+// unmetDependencies lists the flags that were written without the flag they
+// are only meaningful alongside. They are judged after parsing because a flag
+// may be written before the one it depends on.
+func unmetDependencies(activation Activation) []error {
+	var unmet []error
+
+	for _, rule := range dependencies {
+		if rule.unmet(activation) {
+			unmet = append(unmet, invalid(rule.message))
+		}
 	}
 
-	if activation.OnExit != nil && !hasAction {
-		return invalid(msgOnExitRequiresAction)
+	return unmet
+}
+
+// validateValues refuses a value a flag was given that it cannot carry. Unlike
+// an unmet dependency, nothing about the rest of the command can make one of
+// these mean anything.
+func validateValues(activation Activation) error {
+	modifierErr := validateModifier(activation)
+	if modifierErr != nil {
+		return modifierErr
 	}
 
-	if isTrue(activation.HideOnEmptySearch) && !isTrue(activation.Search) {
-		return invalid(msgHideOnEmptySearchRequiresSearch)
-	}
+	return validateAction(activation)
+}
 
+// validateModifier refuses a --modifier value that names no modifier key. An
+// empty one is named separately: it parses, and holds nothing.
+func validateModifier(activation Activation) error {
 	if activation.Modifier == nil {
 		return nil
-	}
-
-	if !hasAction {
-		return invalid(msgModifierRequiresAction)
 	}
 
 	modifiers, err := action.ParseModifiers(*activation.Modifier)


### PR DESCRIPTION
## Description

This PR makes `neru config validate` read the flags of the mode commands in
your bindings, instead of stopping at the command word. `"hints --serach"`
used to pass validation clean and then do nothing when the key was pressed;
now it is reported before the key is ever pressed, with the same wording the
command line gives for the same mistake.

Not every mistake costs the same, so they are split by whether the binding
already worked. A binding naming a flag nothing knows, or a value no flag can
carry, never activated anything, and now fails the load exactly as an unknown
*command* in a binding already does. A binding that works minus one flag —
a flag the named mode has no use for, or a flag written without the one it
depends on — keeps loading and is reported as a warning, because replacing
someone's whole configuration with the defaults over one of those would be
worse than the bug. Warnings ride out with the load and are printed by
`neru config validate`; a warning that only reached the daemon log would be
invisible to the command people run to check their config.

One deliberate limit: a mode command nested inside another step — the steps
of a `run`, or of an `--on-exit` — is still checked only for the command it
names, and a macro body step carrying a `$1` placeholder is left alone, since
what fills it is known only when the macro is called.

## Related Issues

Closes #1191. Part of #1185 (change 4 of 5); the tiering is recorded in
ADR 0002.

## Command output changes

`neru config validate` is the only command whose output changes. A clean
config still prints `Configuration is valid` and exits 0. A config with
warnings also exits 0, and now prints:

```
Configuration is valid, with warnings:

  hotkeys.Primary+Shift+G: grid does not accept --search

These parts of the configuration load and will not take effect.
```

No config option, command, subcommand, flag, or environment variable is added,
renamed, or removed. No mode command changes which flags it accepts.

## Potentially breaking

A configuration that loads today can stop loading after this change, and a
failed load means Neru runs on the built-in defaults until it is fixed.

**What breaks:** a binding, macro body, or Mission Control hook whose mode
command names a flag no mode has (`"hints --serach"`), or gives a flag a value
it cannot carry (`"hints --strategy=nonsense"`, `"hints --action=move_mouse"`).

**Who it affects:** anyone whose config contains one. Every such binding was
already dead — the mode refuses to activate on that command today — so nothing
that worked stops working; the file simply now fails loudly at load instead of
quietly at press time.

**What they do:** run `neru config validate`, which names the binding and the
flag, and fix or delete the flag.

Bindings in the warning tier — `"grid --search"`, `"hints --repeat"` without
an `--action` — are explicitly *not* breaking: they load exactly as before.

Note the issue scopes the load-error tier to unknown flags only. Unusable flag
*values* are included here on the same reasoning ADR 0002 gives (the binding
could not have run either way), which widens the announced break slightly —
flagging it for a maintainer call. The alternative is to demote them to
warnings, which is a small change if preferred.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no OS-specific code
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changed
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The rules live in one place. The grammar module gained a second reading of a
mode command that reports every fault it finds instead of stopping at the
first, split into the ones that leave the command unreadable and the ones that
leave it readable and partly inert. The configuration decides what each tier
costs; the grammar decides what the sentence says, so the CLI, the daemon and
`neru config validate` cannot drift apart on wording. A test pins that the two
readings give the identical sentence for the same mistake.

Reading past a flag the mode does not accept meant stepping over the value it
was written with, which introduced a way to swallow a following flag —
`"grid --strategy --search"` would have reported the first and silently
dropped the second. Another flag is never taken as a value; both are reported.

Tests: the rules and their exact messages are asserted at the grammar seam;
the load path gets two golden cases, one per tier, the warning case showing
the binding still loaded; the CLI seam covers what the command prints. The
severity split is also noted in the config area guide, which previously said
validation always refuses.
