### PR TITLE
docs(cli): generate the mode-flag reference from the flags the binary accepts

### DIFF
--- a/.agents/skills/add-cli-command/SKILL.md
+++ b/.agents/skills/add-cli-command/SKILL.md
@@ -33,6 +33,20 @@ wrong even when it compiles.
 6. **Docs**: update `docs/CLI.md`. It is the single home for CLI reference
    facts.
 
+## Mode flags are different
+
+A flag on a mode command (`hints --action left_click`) is not registered by
+hand. It is one entry in the descriptor table in `internal/domain/modecmd`,
+carrying its own parse, its own render, and the modes that accept it — that
+entry is what offers the flag on the command line, what the daemon and the
+config validator read it with, and what writes its row in the reference.
+
+After adding, removing or re-wording one, run `just genflagref` to rewrite the
+generated region of `docs/CLI.md`. An architecture test
+(`internal/architecture/mode_flag_contract_test.go`) fails while a descriptor
+is unregistered or missing from that region, and while a mode command offers a
+flag the table never declared.
+
 ## Tests
 
 - Command wiring and flag parsing: follow the table-driven patterns in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ just test-foundation    # fast cross-platform-safe slice (config, action, ports)
 just lint               # golangci-lint + clang-tidy on .m files (macOS)
 just fmt                # golangci-lint fmt, then clang-format on .h/.m/.c
 just genman             # man pages via ./cmd/genman
+just genflagref         # mode-flag reference in docs/CLI.md via ./cmd/genflagref
 ```
 
 Pre-commit gate: `just fmt && just lint && just test && just build`. Before pushing: `just ci` — exactly what CI gates on (adds `vet`, `-race`, `vuln`).
@@ -53,6 +54,7 @@ internal/app        wiring, lifecycle, modes, services, IPC controller
 internal/domain     pure logic: hint, grid, recursivegrid, element, action, state, modecmd
 internal/ports      interface contracts + `mocks/`
 internal/derrors    the shared error vocabulary (package name is `derrors`)
+internal/flagref    renders the mode-flag reference in docs/CLI.md from the modecmd descriptor table
 internal/adapter    adapters: accessibility, eventtap, hotkeys, overlay, ipc, vision, systray, platform/*
 internal/config     TOML schema, defaults, validators, theme (+ loader)
 internal/architecture   guardrail tests for package boundaries

--- a/cmd/genflagref/main.go
+++ b/cmd/genflagref/main.go
@@ -1,0 +1,58 @@
+// Package main is the entry point for the genflagref command, which writes the
+// mode-flag reference into a documentation page from the grammar's descriptor
+// table.
+//
+// It is the writing half of the same contract the guardrail test in
+// internal/architecture reads: the test fails when a page is out of date, and
+// this is what brings it back.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/y3owk1n/neru/internal/flagref"
+)
+
+func main() {
+	if len(os.Args) < 2 { //nolint:mnd
+		fmt.Fprintf(os.Stderr, "Usage: genflagref <markdown-file>\n")
+		os.Exit(1)
+	}
+
+	path := os.Args[1]
+
+	contents, err := os.ReadFile(path) //nolint:gosec // the path is a build argument
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", path, err)
+		os.Exit(1)
+	}
+
+	updated, err := flagref.Rewrite(string(contents))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error rendering the mode-flag reference: %v\n", err)
+		os.Exit(1)
+	}
+
+	if updated == string(contents) {
+		fmt.Printf("✓ %s already lists every mode flag\n", path) //nolint:forbidigo
+
+		return
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading the mode of %s: %v\n", path, err)
+		os.Exit(1)
+	}
+
+	// The page's own mode is kept: a generated region does not make the file
+	// the generator's to re-permission.
+	err = os.WriteFile(path, []byte(updated), info.Mode().Perm())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing %s: %v\n", path, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("✓ Mode-flag reference written to %s\n", path) //nolint:forbidigo
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -33,7 +33,9 @@ The same content is available as manpages (`man neru`) after installation.
 ## How to read this reference
 
 Every command is documented in the same shape: a one-line purpose, a synopsis,
-a description, a flag table, and examples.
+a description, a flag table, and examples. The navigation modes share one flag
+table, the [mode flag reference](#mode-flag-reference), which is generated from
+the source that registers those flags.
 
 **Synopsis notation**
 
@@ -264,19 +266,62 @@ from the capability matrix described in
 Modes take over the keyboard until you select a target or exit. All five
 require a running daemon.
 
-## Flags shared by hints, grid, and recursive_grid
+## Mode flag reference
 
-These three modes accept the same selection flags. Mode-specific flags are
-listed under each command.
+Every flag a mode command accepts, and which modes accept it. The same command
+is understood identically wherever it is written — typed after `neru`, as a
+step in a [hotkey binding](CONFIGURATION.md#hotkeys), or sent over the
+[IPC socket](#ipc-protocol) — so a flag listed here works in all three, and a
+flag a mode is not listed for is refused rather than ignored.
 
-| Flag                       | Shorthand | Type   | Default  | Description                                                                                                       |
-| -------------------------- | --------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------- |
-| `--action`                 | `-a`      | string |          | Mouse-button action to perform on selection — see [action names](#action-names) for the accepted set. Commas chain multiple actions (`left_click,left_click` is a double-click). |
-| `--toggle`                 | `-t`      | bool   | `false`  | Exit to idle if this mode is already active, otherwise enter it.                                                    |
-| `--repeat`                 | `-r`      | bool   | `false`  | Re-enter the mode after the action instead of exiting. Requires `--action`.                                         |
-| `--modifier`               |           | string |          | Comma-separated modifiers held during the action: `cmd`, `super`, `meta`, `shift`, `alt`, `option`, `ctrl`. Requires `--action`. |
-| `--on-exit`                |           | string |          | Step run after the action completes and the mode exits. Uses hotkey-binding syntax (`'action left_click'`, `'exec notify-send done'`). Repeat the flag to run several steps in order, as one [action sequence](#neru-run). Requires `--action`. Not run when the mode is left manually via escape or `neru idle`. |
-| `--cursor-selection-mode`  |           | string | `follow` | `follow` moves the real cursor to the selection; `hold` leaves it in place.                                          |
+A flag written more than once replaces its earlier value, unless the value
+column says it is repeatable, in which case each occurrence adds to the last.
+`--action` may also be given positionally: `hints left_click`. `neru idle`
+appears in no row — it leaves a mode rather than entering one, so it accepts
+nothing.
+
+<!-- BEGIN GENERATED MODE FLAGS: edit internal/domain/modecmd, then run `just genflagref` -->
+
+| Flag | Shorthand | Value | Modes | Description |
+| ---- | --------- | ----- | ----- | ----------- |
+| `--action` | `-a` | value | `hints` · `grid` · `recursive_grid` | Mouse button action to perform on the selection (left_click, right_click, middle_click, left_mouse_down, left_mouse_up, right_mouse_down, right_mouse_up, middle_mouse_down, middle_mouse_up, left_mouse_toggle, right_mouse_toggle, middle_mouse_toggle). Commas chain multiple actions (e.g. left_click,left_click for double-click). Other actions, such as scroll or move_mouse, are actions in their own right and need no mode |
+| `--modifier` |  | value | `hints` · `grid` · `recursive_grid` | Comma-separated modifier keys to hold during action (cmd, super, meta, shift, alt, option, ctrl) (requires --action) |
+| `--on-exit` |  | value, repeatable | `hints` · `grid` · `recursive_grid` | Step to run after the action is fulfilled and the mode exits (same syntax as hotkeys, e.g. 'action left_click' or 'exec notify-send done'). Repeat the flag to run several steps in order. Requires --action; not run on manual escape/idle |
+| `--repeat` | `-r` | none | `hints` · `grid` · `recursive_grid` | Re-activate mode after performing the action (requires --action) |
+| `--toggle` | `-t` | none | `hints` · `grid` · `recursive_grid` · `scroll` · `monitor_select` | Toggle mode on/off (exit to idle if already active) |
+| `--search` | `-s` | none | `hints` | Show search input when the mode is activated |
+| `--hide-on-empty-search` |  | none | `hints` | Hide all hints when search query is empty (requires --search) |
+| `--role` |  | value, repeatable | `hints` | Filter by AX role (comma-separated: AXButton,AXLink). Repeat the flag to add more |
+| `--text` |  | value, repeatable | `hints` | Filter elements by text content (comma-separated, case-insensitive substring match). Repeat the flag to add more |
+| `--strategy` |  | value | `hints` | Element detection strategy: axtree (macOS AX API) or vision (Vision Framework) |
+| `--label-direction` |  | value | `hints` | Hint label enumeration: normal (default, prefix-avoidance, prefers shorter labels) or reverse (spreads labels across the alphabet) |
+| `--split-word` |  | none | `hints` | Split detected text into word-level regions (requires vision strategy) |
+| `--zoom-to-depth` |  | value | `recursive_grid` | Auto-zoom to the given depth (a non-negative integer) in recursive-grid at the current cursor position |
+| `--cursor-selection-mode` |  | value | `hints` · `grid` · `recursive_grid` | How the real cursor should behave during selection: follow or hold |
+
+<!-- END GENERATED MODE FLAGS -->
+
+**Where the values come from**
+
+- `--action` takes the mouse-button [action names](#action-names). Commas chain
+  several, so `left_click,left_click` is a double-click.
+- `--on-exit` takes a step in hotkey-binding syntax, and several of them make
+  one [action sequence](#neru-run). The steps do not run when the mode is left
+  manually via escape or `neru idle`.
+- `--role` takes the role vocabulary listed by [`neru roles`](#neru-roles).
+- `--text` matches case-insensitively on a substring, and several values match
+  any of them.
+- `--label-direction` is explained under
+  [Choosing a label direction](CONFIGURATION.md#choosing-a-label-direction).
+- `--strategy vision` and `--split-word` are macOS only. See
+  [Accessibility and hints](CROSS_PLATFORM.md#accessibility-and-hints).
+
+**Where the defaults come from**
+
+A flag left out inherits the configuration rather than a zero value:
+`--strategy` from [`hints.strategy`](CONFIGURATION.md#hints) and
+`--label-direction` from `hints.label_direction`. `--cursor-selection-mode`
+defaults to `follow`, and a presence-only flag left out asks for nothing.
 
 ---
 
@@ -285,10 +330,7 @@ listed under each command.
 Label clickable elements and act on the one you type.
 
 ```
-neru hints [-a <action>] [-t] [-r] [--modifier <mods>] [--on-exit <step>]...
-           [--cursor-selection-mode follow|hold] [-s] [--hide-on-empty-search]
-           [--role <roles>] [--text <text>] [--strategy axtree|vision]
-           [--label-direction normal|reverse] [--split-word] [-d]
+neru hints [flags]
 ```
 
 Scans the focused window for interactive elements and overlays a short letter
@@ -299,26 +341,21 @@ is macOS-only and detects on-screen text and rectangles via the Vision
 framework. Coverage per platform is documented in
 [CROSS_PLATFORM.md](CROSS_PLATFORM.md#accessibility-and-hints).
 
-**Flags** — in addition to the [shared mode flags](#flags-shared-by-hints-grid-and-recursive_grid).
+**Flags** — every flag listed for `hints` in the
+[mode flag reference](#mode-flag-reference), plus the probe below.
 
-| Flag                     | Shorthand | Type   | Default  | Description                                                                                     |
-| ------------------------ | --------- | ------ | -------- | ------------------------------------------------------------------------------------------------- |
-| `--search`               | `-s`      | bool   | `false`  | Show the search input when the mode activates.                                                    |
-| `--hide-on-empty-search` |           | bool   | `false`  | Hide all hints while the search query is empty. Requires `--search`.                              |
-| `--role`                 |           | string |          | Only hint elements whose role matches. Comma-separated, or repeat the flag. Accepts the vocabulary listed by [`neru roles`](#neru-roles). |
-| `--text`                 |           | string |          | Only hint elements whose text matches. Comma-separated (OR) or repeat the flag, case-insensitive substring match.    |
-| `--strategy`             |           | string | `axtree` | Element detection strategy: `axtree` or `vision`. `vision` is macOS only. Overrides `hints.strategy`. |
-| `--label-direction`      |           | string | `normal` | Label enumeration: `normal` or `reverse`. Overrides `hints.label_direction`. See [Choosing a label direction](CONFIGURATION.md#choosing-a-label-direction). |
-| `--split-word`           |           | bool   | `false`  | Split detected text into word-level regions. Requires `--strategy vision`, so macOS only.          |
-| `--debug`                | `-d`      | bool   | `false`  | Print the elements that would be hinted, with a count and a sample, without showing the overlay.  |
+| Flag      | Shorthand | Type | Default | Description                                                                                     |
+| --------- | --------- | ---- | ------- | ------------------------------------------------------------------------------------------------- |
+| `--debug` | `-d`      | bool | `false` | Print the elements that would be hinted, with a count and a sample, without showing the overlay.  |
 
-`--debug` runs a probe rather than activating hints, so it cannot be combined
-with a flag that only describes an activation — `--action`, `--modifier`,
-`--on-exit`, `--repeat`, `--toggle`, `--search`, `--hide-on-empty-search`,
-`--label-direction` or `--cursor-selection-mode`. It does accept the flags that
-decide which elements are collected: `--role`, `--text`, `--strategy` and
-`--split-word`. On the wire a probe is its own command; see
-[IPC protocol](#ipc-protocol).
+`--debug` runs a probe rather than activating hints, so it is not a mode flag:
+it is absent from the reference above, unknown inside a hotkey binding, and
+cannot be combined with a flag that only describes an activation — `--action`,
+`--modifier`, `--on-exit`, `--repeat`, `--toggle`, `--search`,
+`--hide-on-empty-search`, `--label-direction` or `--cursor-selection-mode`. It
+does accept the flags that decide which elements are collected: `--role`,
+`--text`, `--strategy` and `--split-word`. On the wire a probe is its own
+command; see [IPC protocol](#ipc-protocol).
 
 **Examples**
 
@@ -340,12 +377,13 @@ neru hints --debug
 Divide the screen into a labelled coordinate grid.
 
 ```
-neru grid [-a <action>] [-t] [-r] [--modifier <mods>] [--on-exit <step>]...
-          [--cursor-selection-mode follow|hold]
+neru grid [flags]
 ```
 
 Overlays a grid of labelled cells. Typing a cell label moves the cursor there.
-Takes only the [shared mode flags](#flags-shared-by-hints-grid-and-recursive_grid).
+
+**Flags** — every flag listed for `grid` in the
+[mode flag reference](#mode-flag-reference).
 
 Grid size, labels, and appearance are configured under
 [`[grid]`](CONFIGURATION.md#grid).
@@ -371,9 +409,7 @@ neru grid --action left_click --on-exit 'exec notify-send clicked'
 Narrow the screen recursively, one keypress per level.
 
 ```
-neru recursive_grid [-a <action>] [-t] [-r] [--modifier <mods>]
-                    [--on-exit <step>]... [--cursor-selection-mode follow|hold]
-                    [--zoom-to-depth <depth>]
+neru recursive_grid [flags]
 ```
 
 Each keypress subdivides the selected cell, so successive presses converge on a
@@ -384,11 +420,12 @@ Backspace backtracks one level. To correct sideways instead of upwards, bind
 [`move_cell`](#neru-action-move_cell) — it slides the selection to a
 neighbouring cell without leaving the current depth.
 
-**Flags** — in addition to the [shared mode flags](#flags-shared-by-hints-grid-and-recursive_grid).
+**Flags** — every flag listed for `recursive_grid` in the
+[mode flag reference](#mode-flag-reference).
 
-| Flag              | Type | Default | Description                                                                                                       |
-| ----------------- | ---- | ------- | ------------------------------------------------------------------------------------------------------------------- |
-| `--zoom-to-depth` | int  |         | Drill to this depth at the current cursor position on activation. Stops early if the grid cannot subdivide further (minimum cell size or maximum depth). Negative values are rejected. |
+`--zoom-to-depth` drills at the current cursor position as the mode activates.
+It stops early if the grid cannot subdivide further, at the minimum cell size
+or the maximum depth.
 
 **Examples**
 
@@ -406,12 +443,11 @@ neru recursive_grid --zoom-to-depth 3 --action left_click
 Scroll at the cursor with vim-style keys.
 
 ```
-neru scroll [-t]
+neru scroll [flags]
 ```
 
-| Flag       | Shorthand | Type | Default | Description                                        |
-| ---------- | --------- | ---- | ------- | -------------------------------------------------- |
-| `--toggle` | `-t`      | bool | `false` | Exit to idle if scroll mode is active, else enter.  |
+**Flags** — every flag listed for `scroll` in the
+[mode flag reference](#mode-flag-reference).
 
 **Default key bindings**
 
@@ -447,7 +483,7 @@ neru scroll --toggle
 Move the cursor to another display.
 
 ```
-neru monitor_select [-t]
+neru monitor_select [flags]
 ```
 
 **Platforms:** macOS · Linux. Not implemented on Windows, where it returns
@@ -456,9 +492,8 @@ neru monitor_select [-t]
 Opens a labelled panel on each display. Typing a label moves the cursor to that
 display. The current display is excluded.
 
-| Flag       | Shorthand | Type | Default | Description                                            |
-| ---------- | --------- | ---- | ------- | ------------------------------------------------------ |
-| `--toggle` | `-t`      | bool | `false` | Exit to idle if the mode is active, else enter it.      |
+**Flags** — every flag listed for `monitor_select` in the
+[mode flag reference](#mode-flag-reference).
 
 **Default key bindings**
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -143,6 +143,7 @@ Wayland protocol generation and icon recipes.
 | Format  | `just fmt`                   | Format Go and Objective-C                       |
 | Format  | `just fmt-check`             | Check Objective-C formatting                    |
 | Docs    | `just genman`                | Generate man pages                              |
+| Docs    | `just genflagref`            | Rewrite the mode-flag reference in `docs/CLI.md` |
 | Clean   | `just clean`                 | Remove build artifacts                          |
 
 Targeting a single package or test:
@@ -335,6 +336,11 @@ overrides → validation → examples → docs) is documented in
 **CLI commands** — cobra command in `internal/cli/` (registered in an
 `init()`), the matching IPC handler in `internal/app/ipcctrl/`, `just genman`,
 and [CLI.md](CLI.md); the `add-cli-command` skill walks it step by step.
+
+**Mode flags** — one entry in the descriptor table in
+`internal/domain/modecmd`, then `just genflagref`. The entry is what registers
+the flag on every command that accepts it and what writes its row in
+[CLI.md](CLI.md); an architecture test fails while either is missing.
 
 ### Dependency injection
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/tc-hib/go-winres v0.3.3
 	go.uber.org/goleak v1.3.0
@@ -28,7 +29,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tc-hib/winres v0.3.1 // indirect
 	github.com/urfave/cli/v2 v2.27.7 // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect

--- a/internal/app/simulation_journey_test.go
+++ b/internal/app/simulation_journey_test.go
@@ -500,6 +500,106 @@ func TestSimulation_HintsRepeatJourney(t *testing.T) {
 	sim.waitMode(domain.ModeIdle)
 }
 
+// TestSimulation_HintsFlaggedBindingJourney covers a binding that carries a
+// whole activation rather than a bare action: what to do, what to hold while
+// doing it, and what to run once it is done.
+//
+// Each flag is asserted where a user would notice it — which button was
+// clicked, what was held, and what ran afterwards. A flag that parses and then
+// goes missing between the binding and the mode is invisible to the grammar's
+// own tests, because the command still reads correctly and the mode still
+// activates; this is the seam where it shows up.
+func TestSimulation_HintsFlaggedBindingJourney(t *testing.T) {
+	cfg := simConfig()
+	cfg.Hotkeys.Bindings[hintsHotkey] = []string{
+		"hints --action=right_click --modifier=shift --on-exit='action left_click'",
+	}
+
+	save := simElement(t, "save", image.Rect(100, 100, 220, 140), "Save")
+	sim := newSimHarness(t, cfg, []*element.Element{save})
+
+	sim.pressHotkey(hintsHotkey)
+	sim.waitMode(domain.ModeHints)
+	sim.waitFor("hints drawn", func() bool { return sim.overlay.hintDrawCount() > 0 })
+
+	sim.typeLabel(sim.overlay.lastHintLabels()[0])
+
+	// The selection performs the action, and the exit step then runs where the
+	// selection left the cursor.
+	sim.waitFor("the action and its exit step both ran", func() bool {
+		return len(sim.ax.recordedClicks()) == 2
+	})
+
+	clicks := sim.ax.recordedClicks()
+
+	selection, onExit := clicks[0], clicks[1]
+
+	if selection.action != action.TypeRightClick {
+		t.Errorf("--action=right_click produced %v", selection.action)
+	}
+
+	if selection.modifiers != action.ModShift {
+		t.Errorf("--modifier=shift produced modifiers %v", selection.modifiers)
+	}
+
+	if selection.point != save.Center() {
+		t.Errorf("click landed at %v, expected element center %v",
+			selection.point, save.Center())
+	}
+
+	if onExit.action != action.TypeLeftClick {
+		t.Errorf("--on-exit='action left_click' produced %v", onExit.action)
+	}
+
+	if onExit.point != save.Center() {
+		t.Errorf("the exit step clicked at %v, expected the selection %v",
+			onExit.point, save.Center())
+	}
+
+	sim.waitMode(domain.ModeIdle)
+}
+
+// TestSimulation_RefusedBindingActivatesNothing covers the other half: a
+// binding the grammar refuses enters no mode and draws nothing.
+//
+// Both refusals are ones a user used to experience as Neru being unreliable
+// rather than as a mistake they had made. A typo activated the mode and did
+// nothing else; "grid --search" activated grid and dropped the flag in silence,
+// so the search input a user was waiting for never appeared. Refusing the whole
+// command is what makes that a mistake somebody can find.
+func TestSimulation_RefusedBindingActivatesNothing(t *testing.T) {
+	tests := map[string]struct {
+		hotkey  string
+		binding string
+		mode    domain.Mode
+	}{
+		"a mistyped flag":                 {hintsHotkey, "hints --sarch", domain.ModeHints},
+		"a flag the mode does not accept": {gridHotkey, "grid --search", domain.ModeGrid},
+	}
+
+	for name, testCase := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := simConfig()
+			cfg.Hotkeys.Bindings[testCase.hotkey] = []string{testCase.binding}
+
+			sim := newSimHarness(t, cfg, threeButtons(t))
+
+			sim.pressHotkey(testCase.hotkey)
+			sim.neverMode(testCase.mode, 250*time.Millisecond)
+
+			if sim.overlay.isVisible() {
+				t.Errorf("%q showed the overlay; a refused command activates nothing",
+					testCase.binding)
+			}
+
+			if sim.overlay.hintDrawCount() != 0 || sim.overlay.lastGrid() != nil {
+				t.Errorf("%q drew a mode; a refused command activates nothing",
+					testCase.binding)
+			}
+		})
+	}
+}
+
 // TestSimulation_RecursiveGridJourney covers the recursive grid: activation
 // draws the full-screen grid, and choosing a cell redraws zoomed into that
 // cell's bounds.

--- a/internal/architecture/layering_test.go
+++ b/internal/architecture/layering_test.go
@@ -52,13 +52,15 @@ func TestDomainStaysPure(t *testing.T) {
 }
 
 // innerLayers are the packages beneath the application layer: the pure domain,
-// the port contracts, the shared error vocabulary, and the adapters that
-// implement the ports. Nothing here may reach up.
+// the port contracts, the shared error vocabulary, the adapters that implement
+// the ports, and the renderer that publishes the domain's own vocabulary as
+// documentation. Nothing here may reach up.
 var innerLayers = []string{
 	"internal/domain/",
 	"internal/ports/",
 	"internal/derrors/",
 	"internal/adapter/",
+	"internal/flagref/",
 }
 
 // TestInfraDoesNotImportApp pins the direction of the hexagon: adapters

--- a/internal/architecture/mode_flag_contract_test.go
+++ b/internal/architecture/mode_flag_contract_test.go
@@ -1,0 +1,298 @@
+package architecture_test
+
+import (
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/y3owk1n/neru/internal/cli"
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/modecmd"
+	"github.com/y3owk1n/neru/internal/flagref"
+)
+
+// A mode flag is declared once, in the grammar's descriptor table. That
+// declaration is what registers the flag on the command line, decides which
+// modes accept it, and writes its row in the published reference.
+//
+// "Declared once" is only worth anything if the other two follow, and they
+// followed by diligence until these tests: a flag added to the table without
+// being registered was a flag the daemon accepted and nobody could type, and
+// one missing from the reference was documentation that quietly disagreed with
+// the binary. Both are now build failures.
+
+// cliOwnedFlag is a flag a mode command may offer without the grammar
+// declaring it: which modes may offer it, and why it is not in the table.
+//
+// The modes are named rather than left open because a flag outside the grammar
+// is exactly what per-mode divergence looks like. Allowing "debug" everywhere
+// would let it be hand-added to grid — a flag offered by one command and
+// understood by nothing — which is what this whole contract exists to catch.
+type cliOwnedFlag struct {
+	name string
+
+	// modes may offer this flag. Empty means every mode may.
+	modes  []domain.Mode
+	reason string
+}
+
+// offeredBy reports whether this mode is one of the modes allowed to offer the
+// flag.
+func (f cliOwnedFlag) offeredBy(mode domain.Mode) bool {
+	return len(f.modes) == 0 || slices.Contains(f.modes, mode)
+}
+
+// flagsOwnedByTheCLI are the flags a mode command registers that the grammar
+// deliberately does not hold.
+//
+// The list is spelled out rather than pattern-matched so that adding to it is a
+// decision somebody writes down. A flag that reaches a mode belongs in the
+// descriptor table; a flag that does something else has to say what it does and
+// where it is allowed.
+var flagsOwnedByTheCLI = []cliOwnedFlag{
+	{
+		name:   "debug",
+		modes:  []domain.Mode{domain.ModeHints},
+		reason: "asks for a read-only probe rather than an activation, so it travels as its own IPC action",
+	},
+	{
+		name:   "help",
+		reason: "cobra's own, offered by every command",
+	},
+}
+
+// ownedByTheCLI returns what this test knows about a flag the grammar does not
+// declare.
+func ownedByTheCLI(name string) (cliOwnedFlag, bool) {
+	for _, owned := range flagsOwnedByTheCLI {
+		if owned.name == name {
+			return owned, true
+		}
+	}
+
+	return cliOwnedFlag{}, false
+}
+
+// TestModeCommands_RegisterExactlyWhatTheGrammarDeclares pins the command line
+// to the vocabulary in both directions: every flag a mode accepts is offered by
+// that mode's command, spelled and explained as declared, and every flag a
+// command offers is one the grammar declares or one this test knows the reason
+// for.
+//
+// The second direction is the one that keeps the contract honest. Without it a
+// contributor can re-add a hand-written flag literal to a single command, which
+// is exactly the divergence the grammar was introduced to end.
+func TestModeCommands_RegisterExactlyWhatTheGrammarDeclares(t *testing.T) {
+	commands := modeCommands(t)
+
+	for _, mode := range modecmd.Modes() {
+		name := domain.ModeString(mode)
+
+		command, registered := commands[name]
+		if !registered {
+			t.Errorf(
+				"the grammar names mode %q but no command enters it; "+
+					"build one with cli.BuildModeCommand",
+				name,
+			)
+
+			continue
+		}
+
+		assertOffersWhatTheModeAccepts(t, mode, command)
+		assertOffersNothingUndeclared(t, mode, command)
+	}
+}
+
+// assertOffersWhatTheModeAccepts checks the descriptor table against one
+// command: accepted flags are offered, unaccepted ones are not, and the
+// spelling and wording are the vocabulary's rather than the command's.
+func assertOffersWhatTheModeAccepts(t *testing.T, mode domain.Mode, command *cobra.Command) {
+	t.Helper()
+
+	name := domain.ModeString(mode)
+
+	for _, descriptor := range modecmd.All() {
+		flag := command.Flags().Lookup(descriptor.Name().String())
+
+		if !descriptor.AcceptedBy(mode) {
+			if flag != nil {
+				t.Errorf("%s does not accept %s but its command offers it; "+
+					"a flag offered and then dropped is indistinguishable from one that does not work",
+					name, descriptor.Name().Long())
+			}
+
+			continue
+		}
+
+		if flag == nil {
+			t.Errorf("%s accepts %s but its command does not offer it",
+				name, descriptor.Name().Long())
+
+			continue
+		}
+
+		if flag.Shorthand != descriptor.Short() {
+			t.Errorf("%s on %s has shorthand %q, want %q from the vocabulary",
+				descriptor.Name().Long(), name, flag.Shorthand, descriptor.Short())
+		}
+
+		if flag.Usage != descriptor.Usage() {
+			t.Errorf("%s on %s is explained as %q, want the vocabulary's own wording",
+				descriptor.Name().Long(), name, flag.Usage)
+		}
+	}
+}
+
+// assertOffersNothingUndeclared checks the other direction: a flag on a mode
+// command that the grammar never declared, and one the CLI owns appearing on a
+// mode it was never meant for.
+func assertOffersNothingUndeclared(t *testing.T, mode domain.Mode, command *cobra.Command) {
+	t.Helper()
+
+	name := domain.ModeString(mode)
+
+	command.Flags().VisitAll(func(flag *pflag.Flag) {
+		if _, declared := modecmd.Lookup(modecmd.Flag(flag.Name)); declared {
+			return
+		}
+
+		owned, allowed := ownedByTheCLI(flag.Name)
+		if !allowed {
+			t.Errorf(
+				"the %s command offers --%s, which the grammar does not declare; "+
+					"add it to the descriptor table in internal/domain/modecmd so every "+
+					"door reads it the same way",
+				name,
+				flag.Name,
+			)
+
+			return
+		}
+
+		if !owned.offeredBy(mode) {
+			t.Errorf(
+				"the %s command offers --%s, which is the CLI's own (%s) and belongs "+
+					"only on %s",
+				name,
+				flag.Name,
+				owned.reason,
+				modeNames(owned.modes),
+			)
+		}
+	})
+}
+
+// modeNames spells a list of modes the way a user writes them.
+func modeNames(modes []domain.Mode) string {
+	names := make([]string, 0, len(modes))
+	for _, mode := range modes {
+		names = append(names, domain.ModeString(mode))
+	}
+
+	return strings.Join(names, ", ")
+}
+
+// TestModeFlagReference_IsGeneratedFromTheDescriptorTable pins the published
+// reference to the same table.
+//
+// It regenerates each page's flag region and compares: a descriptor added,
+// removed or re-worded without regenerating fails here rather than shipping a
+// page that describes a binary nobody built.
+//
+// Every page carrying the markers is checked, rather than the one that carries
+// them today. The generator writes whatever page it is pointed at, and a second
+// one that nothing checked would be the drift this exists to end, in a new
+// place.
+func TestModeFlagReference_IsGeneratedFromTheDescriptorTable(t *testing.T) {
+	published := 0
+
+	for _, doc := range markdownFiles(t, findRepoRoot(t)) {
+		contents, err := os.ReadFile(doc.absPath)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", doc.relPath, err)
+		}
+
+		document := string(contents)
+		if !strings.Contains(document, flagref.BeginMarker) {
+			continue
+		}
+
+		published++
+
+		assertReferenceIsCurrent(t, doc.relPath, document)
+	}
+
+	if published == 0 {
+		t.Errorf(
+			"no page carries the mode-flag reference; add the %q marker to the page "+
+				"that documents the mode commands",
+			flagref.BeginMarker,
+		)
+	}
+}
+
+// assertReferenceIsCurrent checks one page: every declared flag has a row, and
+// the whole region is what the descriptor table renders today.
+func assertReferenceIsCurrent(t *testing.T, name, document string) {
+	t.Helper()
+
+	region, err := flagref.Region(document)
+	if err != nil {
+		t.Errorf("%s: %v", name, err)
+
+		return
+	}
+
+	for _, descriptor := range modecmd.All() {
+		if !strings.Contains(region, "`"+descriptor.Name().Long()+"`") {
+			t.Errorf(
+				"%s is missing from the mode-flag reference in %s; run `just genflagref`",
+				descriptor.Name().Long(),
+				name,
+			)
+		}
+	}
+
+	regenerated, err := flagref.Rewrite(document)
+	if err != nil {
+		t.Errorf("%s: %v", name, err)
+
+		return
+	}
+
+	if regenerated != document {
+		t.Errorf(
+			"the mode-flag reference in %s is out of date with the descriptor table; "+
+				"run `just genflagref` (the region is generated — do not edit it by hand)",
+			name,
+		)
+	}
+}
+
+// modeCommands returns the commands that enter a mode, keyed by the word they
+// are invoked by.
+//
+// They are discovered from the root command rather than listed, so a mode
+// command added later is held to the same contract without an edit here.
+func modeCommands(t *testing.T) map[string]*cobra.Command {
+	t.Helper()
+
+	found := map[string]*cobra.Command{}
+
+	for _, command := range cli.RootCmd.Commands() {
+		if _, isMode := modecmd.LookupMode(command.Name()); isMode {
+			found[command.Name()] = command
+		}
+	}
+
+	if len(found) == 0 {
+		t.Fatal("no mode commands are registered on the root command")
+	}
+
+	return found
+}

--- a/internal/cli/mode_command_builder_internal_test.go
+++ b/internal/cli/mode_command_builder_internal_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/y3owk1n/neru/internal/derrors"
 	"github.com/y3owk1n/neru/internal/domain"
-	"github.com/y3owk1n/neru/internal/domain/modecmd"
 )
 
 // The values these cases repeat, spelled out once so a case still pins the
@@ -23,9 +22,10 @@ const (
 // modeCommands are the six commands the builder produces, each against the mode
 // it enters.
 //
-// What a mode command accepts is the grammar's answer, so these cases ask each
-// real command whether it offers what its mode accepts — the half the grammar's
-// own tests cannot see.
+// Which flags each one offers is not asserted here: that the command line
+// registers exactly what the grammar declares is a contract rather than a
+// behavior, and it is pinned in internal/architecture alongside the published
+// reference it has to agree with.
 func modeCommands() map[domain.Mode]*cobra.Command {
 	return map[domain.Mode]*cobra.Command{
 		domain.ModeHints:         HintsCmd,
@@ -34,54 +34,6 @@ func modeCommands() map[domain.Mode]*cobra.Command {
 		domain.ModeScroll:        ScrollCmd,
 		domain.ModeMonitorSelect: MonitorSelectCmd,
 		domain.ModeIdle:          IdleCmd,
-	}
-}
-
-// TestModeCommands_OfferExactlyWhatTheModeAccepts pins both halves at once: a
-// flag the mode accepts is offered, spelled and explained as the grammar
-// declares it, and a flag it does not accept is not offered at all.
-//
-// The second half is the one that matters to a user. A flag a mode has no use
-// for used to be accepted on the command line and dropped further down, which
-// is indistinguishable from the flag not working.
-func TestModeCommands_OfferExactlyWhatTheModeAccepts(t *testing.T) {
-	t.Parallel()
-
-	for mode, cmd := range modeCommands() {
-		t.Run(domain.ModeString(mode), func(t *testing.T) {
-			t.Parallel()
-
-			for _, descriptor := range modecmd.All() {
-				flag := cmd.Flags().Lookup(descriptor.Name().String())
-				accepted := descriptor.AcceptedBy(mode)
-
-				if accepted && flag == nil {
-					t.Errorf("%s accepts %s but the command does not offer it",
-						domain.ModeString(mode), descriptor.Name().Long())
-
-					continue
-				}
-
-				if !accepted {
-					if flag != nil {
-						t.Errorf("%s does not accept %s but the command offers it",
-							domain.ModeString(mode), descriptor.Name().Long())
-					}
-
-					continue
-				}
-
-				if flag.Shorthand != descriptor.Short() {
-					t.Errorf("%s shorthand = %q, want %q from the vocabulary",
-						descriptor.Name().Long(), flag.Shorthand, descriptor.Short())
-				}
-
-				if flag.Usage != descriptor.Usage() {
-					t.Errorf("%s is explained as %q, want the vocabulary's own wording",
-						descriptor.Name().Long(), flag.Usage)
-				}
-			}
-		})
 	}
 }
 

--- a/internal/domain/modecmd/flags.go
+++ b/internal/domain/modecmd/flags.go
@@ -297,6 +297,18 @@ func (d Descriptor) AcceptedBy(mode domain.Mode) bool {
 	return slices.Contains(d.modes, mode)
 }
 
+// AcceptedModes returns the modes that accept this flag, in the order the
+// vocabulary declares them.
+//
+// [Descriptor.AcceptedBy] answers the question a reader with a mode in hand
+// asks. This answers the one a reader without a mode asks — the published flag
+// reference lists which modes take a flag, and reading that from the same
+// declaration is what stops the document from claiming a mode the binary does
+// not offer it on.
+func (d Descriptor) AcceptedModes() []domain.Mode {
+	return slices.Clone(d.modes)
+}
+
 // Match reports whether arg is this flag in any spelling: long, short, or
 // either with a value attached.
 func (d Descriptor) Match(arg string) bool {
@@ -339,6 +351,17 @@ var (
 	// idle, which is how they leave.
 	modes = append(slices.Clone(enterableModes), domain.ModeIdle)
 )
+
+// Modes returns every mode a mode command can name, idle included.
+//
+// It is exported for the reader that has to answer "is every mode accounted
+// for?" rather than "what does this one accept?" — the guardrail that pins a
+// command to the vocabulary needs the list to walk, and reading it from here is
+// what makes a mode added to the grammar and forgotten on the command line a
+// build failure.
+func Modes() []domain.Mode {
+	return slices.Clone(modes)
+}
 
 // LookupMode returns the mode a command word names.
 //

--- a/internal/flagref/doc.go
+++ b/internal/flagref/doc.go
@@ -1,0 +1,18 @@
+// Package flagref renders the published mode-flag reference from the grammar's
+// descriptor table.
+//
+// The reference is the table in docs/CLI.md that says which flags a mode
+// command accepts. It was kept by hand, which made it a promise rather than a
+// fact: a flag added to internal/domain/modecmd appeared in the binary and not
+// in the document, and a reader had no way to tell which of the two was wrong.
+//
+// Rendering it from the same declaration removes that gap. The document keeps
+// its prose — what a flag is for in context, where its default comes from, what
+// else to read — and gives up only the list itself, which is the part that
+// drifted.
+//
+// [Rewrite] replaces the generated region of a document, so the generator
+// writes it and the guardrail test in internal/architecture compares against
+// it. A document that is out of date fails the build rather than misleading a
+// reader.
+package flagref

--- a/internal/flagref/reference.go
+++ b/internal/flagref/reference.go
@@ -1,0 +1,162 @@
+package flagref
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/modecmd"
+)
+
+// The comments delimiting the generated region of a document.
+//
+// They name the command that writes the region, because the first thing a
+// reader who wants to change a row needs to know is that editing it here would
+// be overwritten.
+const (
+	BeginMarker = "<!-- BEGIN GENERATED MODE FLAGS: edit internal/domain/modecmd, then run `just genflagref` -->"
+	EndMarker   = "<!-- END GENERATED MODE FLAGS -->"
+)
+
+// The words the value column uses for each shape a flag is written in.
+const (
+	valueNone       = "none"
+	valueOne        = "value"
+	valueRepeatable = "value, repeatable"
+	valueUnknown    = "unknown"
+)
+
+// separator joins the modes that accept a flag. A middle dot rather than a
+// comma, because several of the descriptions contain commas of their own.
+const separator = " · "
+
+// Table renders every mode flag as one markdown row, in the order the
+// vocabulary declares them.
+//
+// The columns are what the declaration knows: how the flag is written, whether
+// it carries a value, which modes accept it, and the one sentence that says
+// what it does — the same sentence a command line's help prints, so the
+// document and the binary cannot describe a flag differently.
+func Table() string {
+	var out strings.Builder
+
+	out.WriteString("| Flag | Shorthand | Value | Modes | Description |\n")
+	out.WriteString("| ---- | --------- | ----- | ----- | ----------- |\n")
+
+	for _, descriptor := range modecmd.All() {
+		fmt.Fprintf(
+			&out,
+			"| `%s` | %s | %s | %s | %s |\n",
+			descriptor.Name().Long(),
+			shorthand(descriptor),
+			value(descriptor),
+			modes(descriptor),
+			cell(descriptor.Usage()),
+		)
+	}
+
+	return out.String()
+}
+
+// Rewrite returns the document with its generated region rewritten, and
+// reports a document that has no region to write into.
+//
+// Everything outside the markers is left exactly as it was: the reference is
+// one table inside a hand-written page, not the page.
+func Rewrite(document string) (string, error) {
+	begin, end, err := bounds(document)
+	if err != nil {
+		return "", err
+	}
+
+	return document[:begin] + "\n\n" + Table() + "\n" + document[end:], nil
+}
+
+// Region returns what a document currently holds between the markers.
+//
+// [Rewrite] answers "what should this page say?"; this answers "what does it
+// say?", which is what a reader reporting a page's contents back — a guardrail
+// naming the flag it could not find — needs. Both read the markers here, so
+// there is one answer to where the region starts.
+func Region(document string) (string, error) {
+	begin, end, err := bounds(document)
+	if err != nil {
+		return "", err
+	}
+
+	return document[begin:end], nil
+}
+
+// bounds locates the generated region: the offset just past the opening marker
+// and the offset of the closing one.
+func bounds(document string) (int, int, error) {
+	begin := strings.Index(document, BeginMarker)
+	if begin < 0 {
+		return 0, 0, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"document has no generated mode-flag region; add the %q marker",
+			BeginMarker,
+		)
+	}
+
+	begin += len(BeginMarker)
+
+	end := strings.Index(document, EndMarker)
+	if end < begin {
+		return 0, 0, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"document has no closing mode-flag marker after the opening one; add %q",
+			EndMarker,
+		)
+	}
+
+	return begin, end, nil
+}
+
+// shorthand renders the single-letter alias, or nothing when the flag has none.
+func shorthand(descriptor modecmd.Descriptor) string {
+	if descriptor.Short() == "" {
+		return ""
+	}
+
+	return "`-" + descriptor.Short() + "`"
+}
+
+// value says whether the flag is written with a value, and whether writing it
+// twice adds or replaces. The two are one question to a reader deciding how to
+// write the flag, so they share a column.
+func value(descriptor modecmd.Descriptor) string {
+	switch descriptor.Kind() {
+	case modecmd.KindPresence:
+		return valueNone
+	case modecmd.KindValue:
+		return valueOne
+	case modecmd.KindList:
+		return valueRepeatable
+	}
+
+	// Unreachable while every shape is answered above. Saying so in the
+	// document rather than silently rendering an empty cell is what makes a
+	// shape nobody taught this renderer about visible.
+	return valueUnknown
+}
+
+// modes lists the modes that accept the flag, spelled as a user writes them.
+func modes(descriptor modecmd.Descriptor) string {
+	accepted := descriptor.AcceptedModes()
+
+	names := make([]string, 0, len(accepted))
+	for _, mode := range accepted {
+		names = append(names, "`"+domain.ModeString(mode)+"`")
+	}
+
+	return strings.Join(names, separator)
+}
+
+// cell escapes what a markdown table cell cannot hold literally. A pipe in a
+// flag's description would otherwise end the cell early and shift every column
+// after it.
+func cell(text string) string {
+	return strings.ReplaceAll(text, "|", `\|`)
+}

--- a/internal/flagref/reference_test.go
+++ b/internal/flagref/reference_test.go
@@ -1,0 +1,119 @@
+package flagref_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/flagref"
+)
+
+// page is a document shaped like the one this writes into: prose, a region to
+// fill, and prose after it.
+const page = "# CLI Reference\n\nBefore.\n\n" +
+	flagref.BeginMarker + "\n\nstale\n\n" + flagref.EndMarker + "\n\nAfter.\n"
+
+// TestRegion_ReadsBackWhatWasWritten pins the two halves against each other: a
+// reader asking what a page says has to be reading the same span the writer
+// wrote, or a guardrail built on the pair would report the wrong page as wrong.
+//
+// That every declared flag has a row is asserted against the published page in
+// internal/architecture, where a missing row is a fact about the repository
+// rather than about this function.
+func TestRegion_ReadsBackWhatWasWritten(t *testing.T) {
+	t.Parallel()
+
+	updated, err := flagref.Rewrite(page)
+	if err != nil {
+		t.Fatalf("Rewrite() error = %v", err)
+	}
+
+	region, err := flagref.Region(updated)
+	if err != nil {
+		t.Fatalf("Region() error = %v", err)
+	}
+
+	if !strings.Contains(region, flagref.Table()) {
+		t.Error("Region() did not read back the table Rewrite() wrote")
+	}
+
+	if strings.Contains(region, "Before.") || strings.Contains(region, "After.") {
+		t.Errorf("Region() reached outside the markers: %q", region)
+	}
+}
+
+// TestRewrite_ReplacesOnlyTheRegion pins what a generator may touch. The page
+// around the markers is somebody's prose, and rewriting it would make running
+// the generator a change nobody asked for.
+func TestRewrite_ReplacesOnlyTheRegion(t *testing.T) {
+	t.Parallel()
+
+	updated, err := flagref.Rewrite(page)
+	if err != nil {
+		t.Fatalf("Rewrite() error = %v", err)
+	}
+
+	if strings.Contains(updated, "stale") {
+		t.Error("the previous contents of the region survived")
+	}
+
+	for _, kept := range []string{"# CLI Reference", "Before.", "After."} {
+		if !strings.Contains(updated, kept) {
+			t.Errorf("Rewrite() dropped %q from outside the region", kept)
+		}
+	}
+
+	if !strings.Contains(updated, flagref.Table()) {
+		t.Error("Rewrite() did not write the table into the region")
+	}
+}
+
+// TestRewrite_IsIdempotent is what lets the guardrail compare rather than
+// regenerate: applying to an up-to-date page has to be a no-op, or every page
+// would read as out of date.
+func TestRewrite_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	once, err := flagref.Rewrite(page)
+	if err != nil {
+		t.Fatalf("Rewrite() error = %v", err)
+	}
+
+	twice, err := flagref.Rewrite(once)
+	if err != nil {
+		t.Fatalf("Rewrite() error on the second pass = %v", err)
+	}
+
+	if twice != once {
+		t.Error("Rewrite() changed an already-current page")
+	}
+}
+
+// TestRewrite_RefusesAPageWithNoRegion covers the mistake a contributor makes
+// once: pointing the generator at a page that has no region to write into.
+// Silently appending a table, or silently doing nothing, both leave the page
+// wrong.
+func TestRewrite_RefusesAPageWithNoRegion(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"no markers at all": "# CLI Reference\n\nNothing to fill.\n",
+		"never closed":      "# CLI Reference\n\n" + flagref.BeginMarker + "\n",
+		"closed first":      flagref.EndMarker + "\n" + flagref.BeginMarker + "\n",
+	}
+
+	for name, document := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := flagref.Rewrite(document)
+			if err == nil {
+				t.Fatal("Rewrite() accepted a page with no region to write into")
+			}
+
+			if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+				t.Errorf("Rewrite() error = %v, want invalid input", err)
+			}
+		})
+	}
+}

--- a/justfile
+++ b/justfile
@@ -328,6 +328,13 @@ genman OUTPUT_DIR="build/man":
     go run ./cmd/genman {{ OUTPUT_DIR }}
     @echo "✓ Man pages generated in {{ OUTPUT_DIR }}/"
 
+# Rewrite the mode-flag reference from the grammar's descriptor table.
+# Run after adding, removing or re-wording a mode flag; the architecture
+# guardrail fails while the page is out of date.
+genflagref:
+    @echo "Generating the mode-flag reference..."
+    go run ./cmd/genflagref docs/CLI.md
+
 # Clean build artifacts
 clean:
     @echo "Cleaning build artifacts..."


### PR DESCRIPTION
## Description

This PR removes the last place a mode command's flags were written down by
hand. The flag tables for hints, grid, recursive_grid, scroll and
monitor_select were kept by hand in five separate command sections, so a flag
added to a mode reached the binary without reaching the documentation — and a
reader had no way to tell which of the two was right.

There is now one mode flag reference, generated from the same declaration that
registers those flags on the command line, and rewritten by `just genflagref`.
The per-command sections keep their prose and point at it. The mode synopses
stop re-listing flags that are documented one section above, so they cannot
drift either.

Two architecture guardrails hold the arrangement: one fails when a declared
flag is not offered by exactly the modes that accept it, when a command offers
a flag nothing declared, or when a mode has no command at all; the other
regenerates every page carrying the reference and fails while any of them is
stale. Two new simulation journeys cover the other end — a hotkey binding
carrying flags, asserting each one took effect, and a binding the grammar
refuses, asserting nothing activates and nothing is drawn.

## Related Issues

Closes #1192

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Command and documentation surface

No command, flag, config key or default changes. Every flag the binary accepts
before this PR it accepts after, spelled the same way.

One new development command:

```bash
just genflagref     # rewrites the generated region of docs/CLI.md
```

Run it after adding, removing or re-wording a mode flag. The architecture test
fails while the page is out of date, and names the flag that is missing.

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The guardrails were checked by breaking them on purpose and reverting:

- a flag declared without regenerating the page fails the reference test,
  naming the flag;
- a flag hand-registered on a command fails the registration test on every
  command that offers it;
- a declared flag skipped during registration fails it the other way;
- the CLI-owned `--debug` hand-added to grid fails, because the exemption is
  scoped to the modes allowed to offer it rather than to the flag name.

The flagged simulation journey was likewise checked against a deliberately
dropped modifier, so it is not passing vacuously.

The generated table gives up the per-flag `Default` column the hand-written
tables carried, since a declaration cannot render a configured default; those
defaults now live in prose under the table. `pflag` moves from an indirect to a
direct dependency — the registration guardrail enumerates a command's flags.
