### PR TITLE
refactor(overlay): let the overlay say it is headless instead of guessing

### DIFF
--- a/docs/adr/0003-overlay-frame-port.md
+++ b/docs/adr/0003-overlay-frame-port.md
@@ -48,10 +48,11 @@ are declarative; updates — hot, already narrow, already correct — are not.
 - **Startup phases move.** `internal/app/new.go` is a numbered,
   individually-unwound sequence; several overlay phases collapse into one
   inside the adapter. The unwind path has to stay exact.
-- **Headless detection needs a new signal.** `component_factory_headless.go`
-  decides headless by `WindowPtr() == nil`. With `WindowPtr` gone this becomes
-  an explicit capability — better, but it is a behaviour change on the Linux
-  and CI paths and wants a test before the move.
+- **Headless detection has a new signal.** Done ahead of the move in #1205:
+  `component_factory_headless.go` asked `WindowPtr() == nil`, and now asks the
+  overlay through the optional `manager.HeadlessReporter` capability, pinned by
+  tests on the no-op, macOS and Linux managers. Removing `WindowPtr` is a
+  deletion here, not a redesign.
 - **The port's threading contract stays "may block; never call under
   `h.mu`".** Draws are `dispatch_async` on macOS and hold `renderMu`
   synchronously on Linux; that asymmetry is left alone here. Modes compute

--- a/internal/adapter/overlay/darwin/manager.go
+++ b/internal/adapter/overlay/darwin/manager.go
@@ -84,6 +84,17 @@ func (m *Manager) WindowPtr() unsafe.Pointer {
 	return unsafe.Pointer(m.window)
 }
 
+// Ensure the manager keeps declaring the optional headless capability: without
+// this, a signature drift would silently downgrade it to "can render" instead
+// of failing to compile.
+var _ manager.HeadlessReporter = (*Manager)(nil)
+
+// Headless reports whether the overlay window failed to be created, leaving
+// nothing for the render overlays to draw on.
+func (m *Manager) Headless() bool {
+	return m == nil || m.window == nil
+}
+
 // WaylandKeyboardChannel returns nil for macOS (not applicable).
 func (m *Manager) WaylandKeyboardChannel() <-chan string {
 	return nil

--- a/internal/adapter/overlay/darwin/manager_headless_test.go
+++ b/internal/adapter/overlay/darwin/manager_headless_test.go
@@ -1,0 +1,40 @@
+//go:build darwin
+
+package darwin_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/darwin"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+)
+
+// TestManager_WithoutAWindowDeclaresItselfHeadless pins what a macOS manager
+// reports when it has no overlay window: nothing for the render overlays to
+// draw on. The component factory reads that declaration before it builds them,
+// and building them against a window that was never created crashes on the
+// first CGo call.
+//
+// A zero-value Manager is exactly that state; Init is deliberately avoided,
+// being a process-global singleton that creates a real NSWindow.
+func TestManager_WithoutAWindowDeclaresItselfHeadless(t *testing.T) {
+	tests := map[string]*darwin.Manager{
+		"no window created": {},
+		"nil manager":       nil,
+	}
+
+	for name, mgr := range tests {
+		t.Run(name, func(t *testing.T) {
+			var overlayManager manager.Interface = mgr
+
+			reporter, ok := overlayManager.(manager.HeadlessReporter)
+			if !ok {
+				t.Fatal("the darwin manager does not implement HeadlessReporter")
+			}
+
+			if !reporter.Headless() {
+				t.Error("Headless() = false; there is no window for an overlay to draw on")
+			}
+		})
+	}
+}

--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -350,6 +350,18 @@ func (m *Manager) WindowPtr() unsafe.Pointer {
 	return nil
 }
 
+// Ensure the manager keeps declaring the optional headless capability: without
+// this, a signature drift would silently downgrade it to "can render" instead
+// of failing to compile.
+var _ manager.HeadlessReporter = (*Manager)(nil)
+
+// Headless reports whether no backend surface was created — no display server
+// was detected, the backend failed to initialize, or this is a build without
+// cgo — leaving nothing for the render overlays to draw on.
+func (m *Manager) Headless() bool {
+	return m == nil || (m.x11 == nil && m.wlroots == nil)
+}
+
 // OverlayCapabilities returns the feature capabilities.
 func (m *Manager) OverlayCapabilities() ports.FeatureCapability {
 	switch m.backend {

--- a/internal/adapter/overlay/linux/stub_contract_test.go
+++ b/internal/adapter/overlay/linux/stub_contract_test.go
@@ -113,6 +113,39 @@ func TestLinuxOverlayManager_DrawCallsAreSafeWithRealArguments(t *testing.T) {
 	}
 }
 
+// TestLinuxOverlayManager_NoBackendDeclaresItselfHeadless pins the other half
+// of the no-backend contract: a Manager with no surface has to say so, because
+// the component factory reads that declaration before it builds the render
+// overlays, and it must not hand the app components this Manager has no way to
+// draw.
+//
+// The nil case follows the package's nil-guarded-delegate rule rather than
+// blessing a typed nil: NewOverlayManager returns a nil *Manager when no
+// display is detected, and the accessor that wraps it does not yet guard that,
+// so Headless can be reached on a nil receiver and must answer rather than
+// panic.
+func TestLinuxOverlayManager_NoBackendDeclaresItselfHeadless(t *testing.T) {
+	tests := map[string]*Manager{
+		"no backend attached": noBackendManager(),
+		"nil manager":         nil,
+	}
+
+	for name, mgr := range tests {
+		t.Run(name, func(t *testing.T) {
+			var overlayManager manager.Interface = mgr
+
+			reporter, ok := overlayManager.(manager.HeadlessReporter)
+			if !ok {
+				t.Fatal("the Linux manager does not implement HeadlessReporter")
+			}
+
+			if !reporter.Headless() {
+				t.Error("Headless() = false; there is no surface for an overlay to draw on")
+			}
+		})
+	}
+}
+
 // TestLinuxOverlayManager_StubsAreRepeatable guards against a stub that reports
 // NotSupported once and then changes its answer — the mode handler retries a
 // draw on screen-change events, and an inconsistent answer would let a later

--- a/internal/adapter/overlay/manager/manager.go
+++ b/internal/adapter/overlay/manager/manager.go
@@ -60,8 +60,12 @@ func (sc StateChange) Next() Mode {
 // NoOpManager is a no-op implementation of Interface for headless environments.
 type NoOpManager struct{}
 
-// Ensure NoOpManager always implements Interface.
-var _ Interface = (*NoOpManager)(nil)
+// Ensure NoOpManager always implements Interface, and keeps declaring the
+// optional headless capability the component factory reads.
+var (
+	_ Interface        = (*NoOpManager)(nil)
+	_ HeadlessReporter = (*NoOpManager)(nil)
+)
 
 // WaylandKeyboardChannel returns nil channel.
 func (n *NoOpManager) WaylandKeyboardChannel() <-chan string { return nil }
@@ -101,6 +105,9 @@ func (n *NoOpManager) Mode() Mode { return ModeIdle }
 
 // WindowPtr returns nil.
 func (n *NoOpManager) WindowPtr() unsafe.Pointer { return nil }
+
+// Headless reports that the no-op manager has no surface to render on.
+func (n *NoOpManager) Headless() bool { return true }
 
 // UseHintOverlay is a no-op implementation.
 func (n *NoOpManager) UseHintOverlay(o *hints.Overlay) {}
@@ -228,6 +235,20 @@ func (n *NoOpManager) OverlayCapabilities() ports.FeatureCapability {
 // where the contract is declared, so overlay capability reporting shares one
 // vocabulary with the rest of the platform surface.
 type CapabilityReporter = ports.OverlayCapabilityReporter
+
+// HeadlessReporter is the optional extension a manager implements when it can
+// state that it has no surface to draw on — a no-op manager, or a backend that
+// found no display server to attach to.
+//
+// It exists because the render overlays are built against a native surface: on
+// a headless manager there is nothing to build them on, and the caller has to
+// know that before it tries. Reach it by type assertion and treat a manager
+// that does not implement it as able to render, the same way every other
+// optional overlay capability works.
+type HeadlessReporter interface {
+	// Headless reports whether this manager has no surface to render on.
+	Headless() bool
+}
 
 // KeyboardCaptureController is the optional extension a backend implements
 // when its overlay surface can hold or release the keyboard.

--- a/internal/adapter/overlay/manager/manager_test.go
+++ b/internal/adapter/overlay/manager/manager_test.go
@@ -93,6 +93,23 @@ func TestNoOpManager_ReportsEmptyState(t *testing.T) {
 	}
 }
 
+// TestNoOpManager_DeclaresItselfHeadless pins the capability the component
+// factory reads before it builds render overlays. An overlay manager that
+// cannot render has to say so; if the no-op manager stopped declaring it, the
+// factory would try to build overlays on a surface that does not exist.
+func TestNoOpManager_DeclaresItselfHeadless(t *testing.T) {
+	var noOp manager.Interface = &manager.NoOpManager{}
+
+	reporter, ok := noOp.(manager.HeadlessReporter)
+	if !ok {
+		t.Fatal("the no-op manager does not implement HeadlessReporter")
+	}
+
+	if !reporter.Headless() {
+		t.Error("Headless() = false; the no-op manager has no surface to render on")
+	}
+}
+
 // TestNoOpManager_SubscriptionIsInert pins that a subscriber can be registered
 // and removed. A caller that subscribes on a headless run must not be left
 // holding an id it cannot unsubscribe.

--- a/internal/adapter/overlay/vocabulary.go
+++ b/internal/adapter/overlay/vocabulary.go
@@ -25,6 +25,8 @@ type (
 	MonitorSelectTarget = manager.MonitorSelectTarget
 	// CapabilityReporter reports a manager's runtime support state.
 	CapabilityReporter = manager.CapabilityReporter
+	// HeadlessReporter declares a manager that has no surface to render on.
+	HeadlessReporter = manager.HeadlessReporter
 )
 
 // Overlay modes.

--- a/internal/app/component_factory_headless.go
+++ b/internal/app/component_factory_headless.go
@@ -2,9 +2,19 @@
 
 package app
 
-// headless returns true when the overlay manager has no real native window
-// handle. Creating an overlay with a nil window pointer would crash on any
-// platform call (CGo, X11), so callers must bail out early.
+import "github.com/y3owk1n/neru/internal/adapter/overlay"
+
+// headless returns true when the overlay manager declares that it has no
+// surface to render on, in which case callers must not build render overlays
+// against it. On macOS that is a crash guard — the overlays are CGo objects
+// built on a window that was never created. Elsewhere they are inert stubs, so
+// the guard instead keeps the app from holding components the manager has no
+// way to draw.
+//
+// The manager states it through the optional HeadlessReporter capability,
+// reached by type assertion; a manager that does not implement it can render.
 func (f *ComponentFactory) headless() bool {
-	return f.overlayManager.WindowPtr() == nil
+	reporter, ok := f.overlayManager.(overlay.HeadlessReporter)
+
+	return ok && reporter.Headless()
 }

--- a/internal/app/component_factory_headless_test.go
+++ b/internal/app/component_factory_headless_test.go
@@ -1,0 +1,65 @@
+//go:build darwin || linux
+
+package app_test
+
+// The component factory must not build render overlays when the overlay
+// manager has no surface for them: every draw through them reaches a native
+// API (CGo, X11) that the manager never opened. Which managers those are is
+// something the manager states, not something the factory infers from a window
+// handle it happens to be able to see.
+
+import (
+	"testing"
+	"unsafe"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay"
+	"github.com/y3owk1n/neru/internal/app"
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// declaredHeadlessManager hands out a window handle and still declares itself
+// headless. The two disagree deliberately: the factory has to believe the
+// declaration, which is the whole difference between asking and guessing.
+type declaredHeadlessManager struct {
+	overlay.NoOpManager
+}
+
+// notAWindow stands in for a handle the factory must ignore. It is never
+// dereferenced — the point is only that it is not nil.
+var notAWindow = new(byte)
+
+func (m *declaredHeadlessManager) WindowPtr() unsafe.Pointer {
+	return unsafe.Pointer(notAWindow)
+}
+
+func (m *declaredHeadlessManager) Headless() bool { return true }
+
+// lightTheme is a fixed appearance so building a hint style needs no system.
+type lightTheme struct{}
+
+func (lightTheme) IsDarkMode() bool { return false }
+
+func TestComponentFactory_SkipsOverlaysADeclaredHeadlessManagerCannotDraw(t *testing.T) {
+	factory := app.NewComponentFactory(
+		config.DefaultConfig(),
+		zap.NewNop(),
+		&declaredHeadlessManager{},
+		lightTheme{},
+	)
+
+	component, err := factory.CreateHintsComponent(app.ComponentCreationOptions{
+		OverlayType: "hints",
+	})
+	if err != nil {
+		t.Fatalf("CreateHintsComponent returned %v, want nil", err)
+	}
+
+	if component.Overlay != nil {
+		t.Error(
+			"a hints overlay was built for a manager that declared itself headless; " +
+				"the factory read the window handle instead of the declaration",
+		)
+	}
+}

--- a/internal/app/component_factory_headless_windows.go
+++ b/internal/app/component_factory_headless_windows.go
@@ -2,9 +2,12 @@
 
 package app
 
-// headless always returns false on Windows. Mode and sticky indicator overlays
-// are config/theme data holders that do not create native windows, so the
-// headless guard is unnecessary.
+// headless always returns false on Windows, and the Windows overlay manager
+// deliberately does not declare the HeadlessReporter capability at all. Its
+// surface is recreated on demand at draw time, so having no window when
+// components are built is not a verdict on whether it can render — and the
+// render overlays here are inert stubs that only store the handle they are
+// given, so building them against a missing surface costs nothing.
 func (f *ComponentFactory) headless() bool {
 	return false
 }

--- a/internal/app/simulation_harness_test.go
+++ b/internal/app/simulation_harness_test.go
@@ -76,8 +76,8 @@ func simElement(
 
 // simOverlayManager records what the app draws. It embeds the headless
 // NoOpManager so it satisfies the full manager contract and only overrides
-// what the journeys assert on. WindowPtr stays nil, which keeps the component
-// factory on its headless path (no native overlay construction).
+// what the journeys assert on. It declares itself headless, which keeps the
+// component factory on its headless path (no native overlay construction).
 type simOverlayManager struct {
 	overlay.NoOpManager
 
@@ -94,8 +94,16 @@ type simOverlayManager struct {
 }
 
 // Ensure the recorder implements the optional monitor-select extension the
-// same way the darwin and Linux backends do.
-var _ overlaymanager.MonitorSelector = (*simOverlayManager)(nil)
+// same way the darwin and Linux backends do, and declares itself headless the
+// way a backend with no surface does.
+var (
+	_ overlaymanager.MonitorSelector  = (*simOverlayManager)(nil)
+	_ overlaymanager.HeadlessReporter = (*simOverlayManager)(nil)
+)
+
+// Headless states outright what the journeys rely on: there is no native
+// surface here, so the component factory must not build render overlays.
+func (m *simOverlayManager) Headless() bool { return true }
 
 func (m *simOverlayManager) DrawMonitorSelect(
 	targets []overlay.MonitorSelectTarget,


### PR DESCRIPTION
## Description

This PR reworks how Neru decides it has no display to draw on. Until now that
was guessed: if the overlay had no native window handle, the app assumed a
headless environment and skipped building the overlays that render hints,
grids and indicators. The overlay now states it outright — an overlay that
cannot render says so, and the app asks rather than infers.

Nothing changes for a user: the same environments are headless afterwards, and
the same overlays are drawn everywhere else. One edge improves — a Linux
session with no display server detected used to crash the startup path that
made this guess, and now reports itself headless cleanly.

This lands ahead of #1203, which removes the window handle from the app layer
entirely; that removal is now a deletion rather than a redesign.

## Related Issues

Closes #1205. Prefactor for #1203; unblocks #1209.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [ ] Windows — no behaviour change; the Windows path never made this guess

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this adds an optional capability reached by type assertion, so a backend that does not declare it needs no stub
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — the overlay decision record no
      longer describes headless detection as an open problem
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The declaration is an optional capability reached by type assertion, matching
how every other optional overlay capability works, so the shared contract does
not grow a method that only some backends can answer. A manager that does not
declare it is treated as able to render; every manager in the tree declares it.

Two deliberate deviations, both worth a look:

- The one behaviour that is not identical is the nil case on Linux. When no
  display server is detected the overlay manager comes back nil inside a
  non-nil interface; asking it for a window handle panicked, and asking it
  whether it is headless answers yes. That is an improvement rather than
  parity, and there is a test pinning it.
- Windows deliberately does not consult the declaration. Its indicator
  overlays are configuration and theme data that never create native windows,
  so there is nothing there to skip; the comment now says that outright rather
  than leaving it implied.

Tests pin that the no-op manager, a Linux manager with no backend, and a macOS
manager with no window all report themselves headless, and that the component
factory believes a declaration even when a window handle is present — the last
one fails against the previous handle-based implementation, which is what makes
it worth having. Each implementing manager also carries a compile-time
assertion, so a signature drift fails the build instead of quietly downgrading
that platform to "can render".

Two pre-existing problems surfaced while doing this and are deliberately left
alone, since both change behaviour beyond what this is:

- On Linux the accessor that builds the process-wide overlay manager can hand
  shared code a nil manager wrapped in a non-nil interface, which the sibling
  accessor eight lines below explicitly guards against. The nil guards added
  here make one call site answer instead of panicking; the rest of that surface
  still dereferences it. Worth its own fix.
- The macOS manager reports overlays as available unconditionally, so if the
  overlay window ever failed to be created, `neru doctor` would say supported
  while the app draws nothing. There is already a vocabulary for that state,
  and Linux answers the same condition a third way. Reconciling what the
  capability matrix reports is a separate call.
