### PR TITLE
refactor(app): delete the overlay-staleness flags nothing reads

### DIFF
--- a/internal/app/getters.go
+++ b/internal/app/getters.go
@@ -85,13 +85,6 @@ func (a *App) GetConfigPath() string {
 	return p
 }
 
-// SetHintOverlayNeedsRefresh sets the hint overlay needs refresh flag.
-func (a *App) SetHintOverlayNeedsRefresh(
-	value bool,
-) {
-	a.appState.SetHintOverlayNeedsRefresh(value)
-}
-
 // GridContext returns the grid context.
 func (a *App) GridContext() *grid.Context {
 	if a.gridComponent == nil {

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -271,9 +271,9 @@ func (a *App) processScreenChange() {
 	// against a concurrent ExitMode between the snapshot and the actual work.
 	currentMode := a.appState.CurrentMode()
 
-	// Only log and adjust overlays if we are in an active mode.
-	// In Idle mode, we just want to update the needs-refresh flags (handled by sub-handlers)
-	// but avoid showing the overlay window which happens in ResizeToActiveScreen.
+	// Only log and adjust overlays if we are in an active mode. In Idle mode
+	// there is nothing on screen to adjust, and we must avoid showing the
+	// overlay window, which is what ResizeToActiveScreen would do.
 	isIdle := currentMode == domain.ModeIdle
 	if !isIdle {
 		a.logger.Debug("Screen parameters changed; adjusting overlays")
@@ -306,8 +306,6 @@ func (a *App) handleGridScreenChange(cfg *config.Config, currentMode domain.Mode
 	}
 
 	if currentMode != domain.ModeGrid {
-		a.appState.SetGridOverlayNeedsRefresh(true)
-
 		return false
 	}
 
@@ -343,8 +341,6 @@ func (a *App) handleHintScreenChange(
 	}
 
 	if currentMode != domain.ModeHints {
-		a.appState.SetHintOverlayNeedsRefresh(true)
-
 		return false
 	}
 
@@ -369,8 +365,6 @@ func (a *App) handleRecursiveGridScreenChange(cfg *config.Config, currentMode do
 	}
 
 	if currentMode != domain.ModeRecursiveGrid {
-		a.appState.SetRecursiveGridOverlayNeedsRefresh(true)
-
 		return false
 	}
 

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -48,8 +48,6 @@ func (h *handlerState) activateGridModeWithAction(activation modecmd.Activation)
 		h.exitMode()
 	}
 
-	h.appState.SetGridOverlayNeedsRefresh(false)
-
 	gridInstance := h.createGridInstance()
 
 	// Reset the grid manager state when setting up the grid.

--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -146,8 +146,6 @@ func (h *handlerState) activateHintModeInternal(activation modecmd.Activation) {
 		h.clearOverlayFrame()
 	}
 
-	h.appState.SetHintOverlayNeedsRefresh(false)
-
 	if h.hints != nil && h.hints.Context != nil {
 		applyHintFlags(h.hints.Context, activation, isRefresh)
 	}

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -50,8 +50,6 @@ func (h *handlerState) activateRecursiveGridModeWithAction(activation modecmd.Ac
 		h.exitMode()
 	}
 
-	h.appState.SetRecursiveGridOverlayNeedsRefresh(false)
-
 	// Get screen bounds
 	var screenBounds image.Rectangle
 

--- a/internal/domain/state/app_state.go
+++ b/internal/domain/state/app_state.go
@@ -41,13 +41,10 @@ type AppState struct {
 	nextCallbackID             uint64
 
 	// Operational flags
-	hotkeysRegistered                bool
-	screenChangeProcessing           bool
-	screenChangePendingRetry         bool
-	gridOverlayNeedsRefresh          bool
-	hintOverlayNeedsRefresh          bool
-	recursiveGridOverlayNeedsRefresh bool
-	hotkeyRefreshPending             bool
+	hotkeysRegistered        bool
+	screenChangeProcessing   bool
+	screenChangePendingRetry bool
+	hotkeyRefreshPending     bool
 }
 
 // NewAppState creates a new AppState with default values.
@@ -451,54 +448,6 @@ func (s *AppState) FinishScreenChangeProcessing() bool {
 	}
 
 	return retry
-}
-
-// GridOverlayNeedsRefresh returns whether the grid overlay needs refresh.
-func (s *AppState) GridOverlayNeedsRefresh() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	return s.gridOverlayNeedsRefresh
-}
-
-// SetGridOverlayNeedsRefresh sets the grid overlay refresh flag.
-func (s *AppState) SetGridOverlayNeedsRefresh(needs bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.gridOverlayNeedsRefresh = needs
-}
-
-// HintOverlayNeedsRefresh returns whether the hint overlay needs refresh.
-func (s *AppState) HintOverlayNeedsRefresh() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	return s.hintOverlayNeedsRefresh
-}
-
-// SetHintOverlayNeedsRefresh sets the hint overlay refresh flag.
-func (s *AppState) SetHintOverlayNeedsRefresh(needs bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.hintOverlayNeedsRefresh = needs
-}
-
-// RecursiveGridOverlayNeedsRefresh returns whether the recursive-grid overlay needs refresh.
-func (s *AppState) RecursiveGridOverlayNeedsRefresh() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	return s.recursiveGridOverlayNeedsRefresh
-}
-
-// SetRecursiveGridOverlayNeedsRefresh sets the recursive-grid overlay refresh flag.
-func (s *AppState) SetRecursiveGridOverlayNeedsRefresh(needs bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.recursiveGridOverlayNeedsRefresh = needs
 }
 
 // HotkeyRefreshPending returns whether a hotkey refresh is pending.

--- a/internal/domain/state/app_state_test.go
+++ b/internal/domain/state/app_state_test.go
@@ -392,66 +392,6 @@ func TestAppState_ScreenChangeProcessing_MutualExclusion(t *testing.T) {
 	}
 }
 
-func TestAppState_GridOverlayNeedsRefresh(t *testing.T) {
-	_state := state.NewAppState()
-
-	if _state.GridOverlayNeedsRefresh() {
-		t.Error("Expected grid overlay refresh to be false initially")
-	}
-
-	_state.SetGridOverlayNeedsRefresh(true)
-
-	if !_state.GridOverlayNeedsRefresh() {
-		t.Error("Expected grid overlay to need refresh")
-	}
-
-	_state.SetGridOverlayNeedsRefresh(false)
-
-	if _state.GridOverlayNeedsRefresh() {
-		t.Error("Expected grid overlay to not need refresh")
-	}
-}
-
-func TestAppState_HintOverlayNeedsRefresh(t *testing.T) {
-	_state := state.NewAppState()
-
-	if _state.HintOverlayNeedsRefresh() {
-		t.Error("Expected hint overlay refresh to be false initially")
-	}
-
-	_state.SetHintOverlayNeedsRefresh(true)
-
-	if !_state.HintOverlayNeedsRefresh() {
-		t.Error("Expected hint overlay to need refresh")
-	}
-
-	_state.SetHintOverlayNeedsRefresh(false)
-
-	if _state.HintOverlayNeedsRefresh() {
-		t.Error("Expected hint overlay to not need refresh")
-	}
-}
-
-func TestAppState_RecursiveGridOverlayNeedsRefresh(t *testing.T) {
-	_state := state.NewAppState()
-
-	if _state.RecursiveGridOverlayNeedsRefresh() {
-		t.Error("Expected recursive-grid overlay refresh to be false initially")
-	}
-
-	_state.SetRecursiveGridOverlayNeedsRefresh(true)
-
-	if !_state.RecursiveGridOverlayNeedsRefresh() {
-		t.Error("Expected recursive-grid overlay to need refresh")
-	}
-
-	_state.SetRecursiveGridOverlayNeedsRefresh(false)
-
-	if _state.RecursiveGridOverlayNeedsRefresh() {
-		t.Error("Expected recursive-grid overlay to not need refresh")
-	}
-}
-
 func TestAppState_HotkeyRefreshPending(t *testing.T) {
 	_state := state.NewAppState()
 


### PR DESCRIPTION
## Description

This PR removes three pieces of internal state that recorded whether an overlay had gone stale while a different navigation mode was active. They were written on every screen change and cleared on every mode activation, but nothing ever read them — the lazy refresh they were meant to drive was never built.

Nothing observable changes, because nothing observable depended on them. What changes is that someone reading the screen-change path no longer finds state that looks like a working staleness mechanism and is not one.

The behaviour the flags hinted at — refreshing a mode's overlay on next activation when the display changed while it was inactive — is filed separately with stated behaviour rather than inferred from dead state, and is deliberately not implemented here.

## Related Issues

Closes #1225. Follow-up filed as #1233. Parent spec: #1224.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no build-tagged file is touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no imports change
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or platform capability changes
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — the three round-trip unit tests covering the deleted state are deleted rather than adapted; no test is added, because no behaviour is added
- [x] Documentation updated (if applicable) — N/A, the mechanism was never documented
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Why deleted rather than wired up.** A boolean set by a display observer and cleared on activation cannot distinguish "the display changed" from "the display changed and changed back", so it is the wrong shape for the job even if the job is wanted. The follow-up issue proposes comparing actual display geometry instead.

**How "no behaviour change" was proven.** The existing simulation journeys in the app package are the proof, and they pass unedited — no journey needed a single line changed, which the parent spec treats as the pass condition for this kind of change. Each deletion also leaves its enclosing branch semantically identical: the write sites sat in branches that already returned early, and the clear sites were unconditional stores nothing read.

**Locking.** The three deleted call sites in the modes package ran under the handler mutex and took the application-state mutex inside it. Removing them only unwinds that nesting; no lock ordering changes, no new edge is introduced, and no timer, goroutine, or callback is added or altered.

**Noticed but deliberately not fixed here.** With the flag writes gone, the three per-mode screen-change functions in the app layer are visibly three near-identical shapes. Collapsing them is exactly what #1232 covers, so it is left alone rather than pre-empted.
