### PR TITLE
test(app): cover a display change with simulation journeys

### DIFF
--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -197,7 +197,7 @@ func (a *App) setupAppWatcherCallbacks() {
 
 	// Watch for display parameter changes (monitor unplug/plug, resolution changes)
 	a.appWatcher.OnScreenParametersChanged(func() {
-		a.handleScreenParametersChange()
+		a.HandleScreenParametersChange()
 	})
 
 	// Watch for Mission Control activated events
@@ -234,8 +234,16 @@ func (a *App) setupAppWatcherCallbacks() {
 	a.appWatcher.SetMCDetection(a.configSnapshot().Hints.DetectMissionControl)
 }
 
-// handleScreenParametersChange responds to display configuration changes by updating overlays.
-func (a *App) handleScreenParametersChange() {
+// HandleScreenParametersChange is the app's entry point for a display
+// configuration change — a monitor plugged in or unplugged, a resolution
+// change, a laptop waking to a different arrangement: the platform screen
+// observers call it, and the simulation harness drives it the same way.
+//
+// It responds by putting whichever mode is on screen back onto the display as
+// it now is, and it is re-entrant by design: an event arriving while one is
+// being handled is coalesced into a single retry rather than processed
+// concurrently.
+func (a *App) HandleScreenParametersChange() {
 	if !a.appState.TrySetScreenChangeProcessing() {
 		return
 	}

--- a/internal/app/simulation_harness_test.go
+++ b/internal/app/simulation_harness_test.go
@@ -393,6 +393,14 @@ func (m *simOverlayPort) searchInputDrawCount() int {
 	return len(m.searchQueries)
 }
 
+// monitorDrawCount reports how many times the monitor picker was drawn.
+func (m *simOverlayPort) monitorDrawCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return len(m.monitorDraws)
+}
+
 func (m *simOverlayPort) lastMonitorTargets() []ports.MonitorSelectTarget {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/app/simulation_harness_test.go
+++ b/internal/app/simulation_harness_test.go
@@ -43,9 +43,22 @@ const (
 	simPollInterval    = 2 * time.Millisecond
 )
 
+// defaultDisplayName is the name of the fixture desktop's single display.
+const defaultDisplayName = "SimDisplay"
+
 // simScreen is the fixture display: a single 1920x1080 screen at the global
 // origin, so screen-local and global coordinates coincide.
 var simScreen = image.Rect(0, 0, 1920, 1080)
+
+// simScreenResized is that same display after a resolution change. Every
+// element in the journey fixtures still falls inside it, so what a display
+// change does to a mode is not confused with elements dropping off the screen.
+var simScreenResized = image.Rect(0, 0, 1280, 720)
+
+// simDisplayResized is the whole fixture desktop after that change.
+func simDisplayResized() simDisplay {
+	return simDisplay{name: defaultDisplayName, bounds: simScreenResized}
+}
 
 // simElement builds a clickable fixture element or fails the test.
 func simElement(
@@ -118,6 +131,9 @@ type simOverlayPort struct {
 	subgridCells  []*domainGrid.Cell
 	searchQueries []string
 	stickySymbols []string
+
+	// gridPointers is the pointer each grid surface was last asked to draw.
+	gridPointers map[domain.Mode]ports.GridPointer
 
 	// indicatorVisible is the visibility each indicator was last asked for.
 	// An indicator draws through its own call rather than a frame, so this —
@@ -219,7 +235,20 @@ func (m *simOverlayPort) ShowGridSubgrid(cell *domainGrid.Cell) {
 	m.subgridCells = append(m.subgridCells, cell)
 }
 
-func (m *simOverlayPort) UpdateGridPointer(_ domain.Mode, _ ports.GridPointer) {}
+// UpdateGridPointer records the pointer stand-in a grid surface draws where
+// the selection is. For a user whose cursor does not follow the selection it
+// is the only thing on screen saying where that selection is, so a journey
+// reads it to watch one appear and a stale one go away.
+func (m *simOverlayPort) UpdateGridPointer(mode domain.Mode, pointer ports.GridPointer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.gridPointers == nil {
+		m.gridPointers = make(map[domain.Mode]ports.GridPointer)
+	}
+
+	m.gridPointers[mode] = pointer
+}
 
 func (m *simOverlayPort) DrawModeIndicator(_, _ int) {}
 
@@ -252,7 +281,23 @@ func (m *simOverlayPort) Flush() {}
 
 func (m *simOverlayPort) IsVisible() bool { return m.isVisible() }
 
-func (m *simOverlayPort) Refresh(_ context.Context) error { return nil }
+// Refresh sizes the overlay to the display that is now active, which brings it
+// up: it is the same resize the window sequence performs on its way to putting
+// a frame on screen, so a surface that was not on screen is afterwards. That
+// is the whole reason the screen-change path refuses to call it while idle
+// ("Resizing the overlay when idle would cause it to become visible",
+// lifecycle.go), and modeling it as silent success is what would let that
+// guard be deleted without a journey noticing.
+//
+// It puts no content there, so it draws no mode and is not a show.
+func (m *simOverlayPort) Refresh(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.visible = true
+
+	return nil
+}
 
 func (m *simOverlayPort) ApplyConfig(cfg *config.Config) {
 	m.mu.Lock()
@@ -419,6 +464,20 @@ func (m *simOverlayPort) lastHintLabels() []string {
 	return labels
 }
 
+// lastHintScreen returns the display the most recent hints frame was drawn
+// against, and whether one was ever drawn. A screen change is only complete
+// when this is the display the user is now looking at.
+func (m *simOverlayPort) lastHintScreen() (image.Rectangle, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.hintFrames) == 0 {
+		return image.Rectangle{}, false
+	}
+
+	return m.hintFrames[len(m.hintFrames)-1].Screen, true
+}
+
 func (m *simOverlayPort) lastGrid() *domainGrid.Grid {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -462,6 +521,17 @@ func (m *simOverlayPort) lastHideUnmatched() (bool, bool) {
 	}
 
 	return m.hideUnmatched[len(m.hideUnmatched)-1], true
+}
+
+// lastGridPointer reports the pointer a grid surface was last asked to draw,
+// and whether it was ever asked at all.
+func (m *simOverlayPort) lastGridPointer(mode domain.Mode) (ports.GridPointer, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	pointer, drawn := m.gridPointers[mode]
+
+	return pointer, drawn
 }
 
 // subgridCount reports how many subgrids were opened.
@@ -600,6 +670,15 @@ func (a *simAXPort) IsAppExcluded(_ context.Context, _ string) bool {
 
 func (a *simAXPort) PrimeApplication(_ context.Context, _ string) (bool, error) {
 	return true, nil
+}
+
+// setElements replaces the accessibility tree, the way a display change that
+// relaid out or closed windows leaves it.
+func (a *simAXPort) setElements(elements []*element.Element) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.elements = elements
 }
 
 func (a *simAXPort) setExcluded(excluded bool) {
@@ -743,6 +822,7 @@ type simHarness struct {
 	cursor     *simCursor
 	hotkeys    *simHotkeyPort
 	tap        *mocks.MockEventTapPort
+	desktop    *simDesktop
 	runDone    chan error
 }
 
@@ -751,6 +831,24 @@ type simHarness struct {
 func (h *simHarness) switchToDarkMode() {
 	h.appearance.Store(true)
 	h.app.HandleThemeChange(true)
+}
+
+// changeScreen rearranges the fixture desktop to the given displays and
+// notifies the app the way a platform screen-parameters observer does — a
+// monitor plugged in or unplugged, or a resolution change.
+//
+// The new arrangement is in place before the notification, so everything the
+// app reads while handling it sees the new displays, as it would on a real
+// desktop.
+func (h *simHarness) changeScreen(displays ...simDisplay) {
+	h.t.Helper()
+
+	if len(displays) == 0 {
+		h.t.Fatal("changeScreen needs at least one display")
+	}
+
+	h.desktop.set(displays)
+	h.app.HandleScreenParametersChange()
 }
 
 // simConfig returns the default config with the standard mode bindings set
@@ -779,6 +877,28 @@ type simDisplay struct {
 	bounds image.Rectangle
 }
 
+// simDesktop is the fixture desktop's display arrangement. A display
+// configuration change rearranges it while the app is reading it, so it is
+// held behind a mutex rather than closed over as a fixed slice.
+type simDesktop struct {
+	mu       sync.Mutex
+	displays []simDisplay
+}
+
+func (d *simDesktop) set(displays []simDisplay) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.displays = slices.Clone(displays)
+}
+
+func (d *simDesktop) all() []simDisplay {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return slices.Clone(d.displays)
+}
+
 // newSimHarness builds and starts the real app wired to the simulation fakes
 // on a single default display.
 func newSimHarness(
@@ -789,7 +909,7 @@ func newSimHarness(
 	tb.Helper()
 
 	return newSimHarnessWithDisplays(tb, cfg, elements, []simDisplay{
-		{name: "SimDisplay", bounds: simScreen},
+		{name: defaultDisplayName, bounds: simScreen},
 	})
 }
 
@@ -853,18 +973,22 @@ func buildSimHarness(
 	)}
 	hotkeys := &simHotkeyPort{}
 	tap := &mocks.MockEventTapPort{}
+	desktop := &simDesktop{}
+	desktop.set(displays)
 
 	// The active screen is wherever the cursor currently is, matching how the
 	// real system port resolves it.
 	activeBounds := func() image.Rectangle {
+		current := desktop.all()
+
 		pos := cursor.position()
-		for _, display := range displays {
+		for _, display := range current {
 			if pos.In(display.bounds) {
 				return display.bounds
 			}
 		}
 
-		return displays[0].bounds
+		return current[0].bounds
 	}
 
 	system := &mocks.MockSystemPort{
@@ -875,7 +999,7 @@ func buildSimHarness(
 			return activeBounds(), nil
 		},
 		ScreenBoundsByNameFunc: func(_ context.Context, name string) (image.Rectangle, bool, error) {
-			for _, display := range displays {
+			for _, display := range desktop.all() {
 				if display.name == name {
 					return display.bounds, true, nil
 				}
@@ -884,8 +1008,10 @@ func buildSimHarness(
 			return image.Rectangle{}, false, nil
 		},
 		ScreenNamesFunc: func(_ context.Context) ([]string, error) {
-			names := make([]string, len(displays))
-			for idx, display := range displays {
+			current := desktop.all()
+
+			names := make([]string, len(current))
+			for idx, display := range current {
 				names[idx] = display.name
 			}
 
@@ -930,6 +1056,7 @@ func buildSimHarness(
 		cursor:     cursor,
 		hotkeys:    hotkeys,
 		tap:        tap,
+		desktop:    desktop,
 		runDone:    make(chan error, 1),
 	}
 

--- a/internal/app/simulation_journey_test.go
+++ b/internal/app/simulation_journey_test.go
@@ -1748,6 +1748,48 @@ func TestSimulation_ScreenChangeWithNothingToDrawExitsTheMode(t *testing.T) {
 	sim.waitMode(domain.ModeGrid)
 }
 
+// TestSimulation_ThemeChangeRedrawsMonitorSelect closes the theme-change set:
+// every other mode that draws is already pinned redrawing itself when the
+// system switches between light and dark, and the monitor picker is the one
+// that was not.
+//
+// It draws on panels of its own rather than the shared surface, so nothing
+// about the other modes picking the new theme up brings it along: left out, it
+// is the one overlay a user finds still in the old theme.
+//
+// That the overlay re-resolves every Style for the change is not mode-specific
+// and is pinned once, in TestSimulation_ThemeChangeReachesVisibleOverlay. What
+// only the picker can answer for is being drawn again afterwards, which is what
+// this asserts.
+func TestSimulation_ThemeChangeRedrawsMonitorSelect(t *testing.T) {
+	sim := newSimHarnessWithDisplays(t, monitorSelectConfig(), nil, []simDisplay{
+		{name: mainDisplayName, bounds: simScreen},
+		{name: secondDisplayName, bounds: image.Rect(1920, 0, 3840, 1080)},
+	})
+
+	sim.pressHotkey(monitorSelectHotkey)
+	sim.waitMode(domain.ModeMonitorSelect)
+	sim.waitFor("monitor panels drawn", func() bool {
+		return len(sim.overlay.lastMonitorTargets()) == 2
+	})
+
+	drawsBefore := sim.overlay.monitorDrawCount()
+
+	sim.switchToDarkMode()
+
+	sim.waitFor("the monitor picker redrawn after the theme change", func() bool {
+		return sim.overlay.monitorDrawCount() > drawsBefore
+	})
+
+	if got := len(sim.overlay.lastMonitorTargets()); got != 2 {
+		t.Errorf("the picker came back with %d panels, want 2", got)
+	}
+
+	if got := sim.app.CurrentMode(); got != domain.ModeMonitorSelect {
+		t.Errorf("mode after the theme change = %v, want monitor select", got)
+	}
+}
+
 // localBounds is a display in the overlay's screen-local space, which is what
 // the grid surfaces are drawn in.
 func localBounds(screen image.Rectangle) image.Rectangle {

--- a/internal/app/simulation_journey_test.go
+++ b/internal/app/simulation_journey_test.go
@@ -1470,3 +1470,300 @@ func TestSimulation_MonitorMoveRedrawsTheModeOnTheNewDisplay(t *testing.T) {
 		t.Fatalf("mode after monitor move = %v, want grid", sim.app.CurrentMode())
 	}
 }
+
+// TestSimulation_ScreenChangeWhileIdleLeavesTheOverlayHidden pins the quietest
+// display change there is: plugging a monitor in with no mode open must not
+// flash an overlay at the user.
+//
+// Idle is the state a user is in almost all of the time, so this is the screen
+// change that happens most; the overlay window coming up for it would be
+// visible on every dock, undock and wake.
+func TestSimulation_ScreenChangeWhileIdleLeavesTheOverlayHidden(t *testing.T) {
+	sim := newSimHarness(t, simConfig(), threeButtons(t))
+
+	if sim.app.CurrentMode() != domain.ModeIdle {
+		t.Fatalf("the app started in mode %v, want idle", sim.app.CurrentMode())
+	}
+
+	showsBefore := sim.overlay.showCount()
+
+	sim.changeScreen(simDisplayResized())
+
+	if sim.overlay.isVisible() {
+		t.Error("the screen change put the overlay on screen while the app was idle")
+	}
+
+	if drawn := sim.overlay.drawnModeNames(); len(drawn) != 0 {
+		t.Errorf("the screen change drew %v while the app was idle, want nothing", drawn)
+	}
+
+	if got := sim.overlay.showCount(); got != showsBefore {
+		t.Errorf("overlay shows = %d after an idle screen change, want %d", got, showsBefore)
+	}
+
+	if got := sim.app.CurrentMode(); got != domain.ModeIdle {
+		t.Errorf("mode after an idle screen change = %v, want idle", got)
+	}
+}
+
+// TestSimulation_ScreenChangeRegeneratesHintsOnTheNewScreen covers the
+// heaviest thing a display change does: hints are open when the arrangement
+// changes, and the labels a user is looking at have to come from the
+// accessibility tree as it is now, drawn against the display as it is now.
+//
+// Stale labels here are worse than none: they point at positions that no
+// longer exist, so typing one moves the cursor somewhere the user did not
+// choose. The journey therefore changes the tree along with the display and
+// asserts the drawn labels followed it.
+func TestSimulation_ScreenChangeRegeneratesHintsOnTheNewScreen(t *testing.T) {
+	sim := newSimHarness(t, simConfig(), threeButtons(t))
+
+	sim.pressHotkey(hintsHotkey)
+	sim.waitMode(domain.ModeHints)
+	sim.waitFor("hints drawn", func() bool { return sim.overlay.hintDrawCount() > 0 })
+
+	if got := len(sim.overlay.lastHintLabels()); got != 3 {
+		t.Fatalf("hints drawn for %d elements before the screen change, want 3", got)
+	}
+
+	drawsBefore := sim.overlay.hintDrawCount()
+	cursorBefore := sim.cursor.position()
+	movesBefore := sim.cursor.moveCount()
+
+	// The display change relaid out the windows: one of the three buttons is
+	// gone from the tree.
+	sim.ax.setElements([]*element.Element{
+		simElement(t, "save", image.Rect(100, 100, 220, 140), "Save"),
+		simElement(t, "cancel", image.Rect(300, 100, 420, 140), "Cancel"),
+	})
+
+	sim.changeScreen(simDisplayResized())
+
+	sim.waitFor("hints redrawn after the screen change", func() bool {
+		return sim.overlay.hintDrawCount() > drawsBefore
+	})
+
+	if got := len(sim.overlay.lastHintLabels()); got != 2 {
+		t.Errorf(
+			"hints drawn for %d elements after the screen change, want 2: the collection was not regenerated",
+			got,
+		)
+	}
+
+	screen, drawn := sim.overlay.lastHintScreen()
+	if !drawn || screen != simScreenResized {
+		t.Errorf("hints drawn against screen %v (drawn = %v), want %v",
+			screen, drawn, simScreenResized)
+	}
+
+	if !sim.overlay.isVisible() {
+		t.Error("the screen change left the hints overlay off the screen")
+	}
+
+	// The user chose none of this: a display changing under them must leave
+	// their pointer where they put it.
+	if got := sim.cursor.moveCount(); got != movesBefore {
+		t.Errorf(
+			"the cursor was moved %d times by the screen change, from %v to %v; it must stay where the user left it",
+			got-movesBefore,
+			cursorBefore,
+			sim.cursor.position(),
+		)
+	}
+
+	if got := sim.app.CurrentMode(); got != domain.ModeHints {
+		t.Errorf("mode after the screen change = %v, want hints", got)
+	}
+}
+
+// TestSimulation_ScreenChangeRebuildsGridAndClearsSelection covers the grid
+// half: the cells a user is about to type have to describe the display as it
+// now is, and the selection they made on the display that is gone has to go
+// with it — a cell coordinate from the old layout selects a different point on
+// the new one.
+//
+// The selection is read off the pointer the grid draws for it, so the journey
+// turns cursor-follow off first ("`"): with the cursor following, the selection
+// has nothing on screen of its own.
+func TestSimulation_ScreenChangeRebuildsGridAndClearsSelection(t *testing.T) {
+	sim := newSimHarness(t, simConfig(), nil)
+
+	sim.pressHotkey(gridHotkey)
+	sim.waitMode(domain.ModeGrid)
+	sim.waitFor("grid drawn", func() bool { return sim.overlay.lastGrid() != nil })
+
+	if got, want := sim.overlay.lastGrid().Bounds(), localBounds(simScreen); got != want {
+		t.Fatalf("grid drawn over %v before the screen change, want %v", got, want)
+	}
+
+	sim.press("`") // stop the cursor following the selection
+
+	cells := sim.overlay.lastGrid().Cells()
+	if len(cells) == 0 {
+		t.Fatal("grid drawn with zero cells")
+	}
+
+	sim.typeLabel(cells[len(cells)/2].Coordinate())
+
+	sim.waitFor("the selection is on screen", func() bool {
+		pointer, drawn := sim.overlay.lastGridPointer(domain.ModeGrid)
+
+		return drawn && pointer.Visible
+	})
+
+	drawsBefore := sim.overlay.gridDrawCount()
+
+	sim.changeScreen(simDisplayResized())
+
+	sim.waitFor("grid redrawn after the screen change", func() bool {
+		return sim.overlay.gridDrawCount() > drawsBefore
+	})
+
+	if got, want := sim.overlay.lastGrid().Bounds(), localBounds(simScreenResized); got != want {
+		t.Errorf("grid drawn over %v after the screen change, want %v: it was not rebuilt",
+			got, want)
+	}
+
+	if pointer, _ := sim.overlay.lastGridPointer(domain.ModeGrid); pointer.Visible {
+		t.Errorf(
+			"the selection at %v survived the screen change; it points at a place on a display that is gone",
+			pointer.Position,
+		)
+	}
+
+	if !sim.overlay.isVisible() {
+		t.Error("the screen change left the grid off the screen")
+	}
+
+	if got := sim.app.CurrentMode(); got != domain.ModeGrid {
+		t.Errorf("mode after the screen change = %v, want grid", got)
+	}
+}
+
+// TestSimulation_ScreenChangePreservesTheZoomedRegion covers what a display
+// change must not cost a recursive-grid user: the region they have already
+// zoomed into. Recursive grid is a sequence of narrowing choices, so throwing
+// the region away would throw their progress away with it — the mode is
+// remapped onto the new display rather than restarted on it.
+//
+// "The same region" means the same fraction of the display, which is what the
+// journey asserts: the zoomed rectangle covers the same proportion of the
+// smaller screen as it did of the larger one.
+func TestSimulation_ScreenChangePreservesTheZoomedRegion(t *testing.T) {
+	sim := newSimHarness(t, simConfig(), nil)
+
+	sim.pressHotkey(recursiveGridHotkey)
+	sim.waitMode(domain.ModeRecursiveGrid)
+	sim.waitFor("recursive grid drawn", func() bool {
+		_, ok := sim.overlay.lastRecursiveGridBounds()
+
+		return ok
+	})
+
+	// "r" is the top-left cell of the default 3x3 key layout.
+	sim.press("r")
+
+	topLeftThird := image.Rect(0, 0, simScreen.Dx()/3+1, simScreen.Dy()/3+1)
+	sim.waitFor("grid zoomed into the top-left cell", func() bool {
+		bounds, ok := sim.overlay.lastRecursiveGridBounds()
+
+		return ok && bounds.In(topLeftThird)
+	})
+
+	zoomed, _ := sim.overlay.lastRecursiveGridBounds()
+	drawsBefore := sim.overlay.recursiveGridDrawCount()
+
+	sim.changeScreen(simDisplayResized())
+
+	sim.waitFor("recursive grid redrawn after the screen change", func() bool {
+		return sim.overlay.recursiveGridDrawCount() > drawsBefore
+	})
+
+	remapped, drawn := sim.overlay.lastRecursiveGridBounds()
+	if !drawn {
+		t.Fatal("the recursive grid was never drawn")
+	}
+
+	if remapped.Empty() {
+		t.Fatalf("the zoomed region collapsed to %v; there is nothing left to pick from", remapped)
+	}
+
+	// The same fraction of the display, on both axes, to within a pixel of
+	// rounding.
+	expected := image.Rect(
+		scaleAxis(zoomed.Min.X, simScreen.Dx(), simScreenResized.Dx()),
+		scaleAxis(zoomed.Min.Y, simScreen.Dy(), simScreenResized.Dy()),
+		scaleAxis(zoomed.Max.X, simScreen.Dx(), simScreenResized.Dx()),
+		scaleAxis(zoomed.Max.Y, simScreen.Dy(), simScreenResized.Dy()),
+	)
+
+	if !boundsWithin(remapped, expected, 1) {
+		t.Errorf(
+			"the region zoomed to %v on a %v screen came back as %v on a %v one, want about %v",
+			zoomed, localBounds(simScreen), remapped, localBounds(simScreenResized), expected,
+		)
+	}
+
+	if !sim.overlay.isVisible() {
+		t.Error("the screen change left the recursive grid off the screen")
+	}
+
+	if got := sim.app.CurrentMode(); got != domain.ModeRecursiveGrid {
+		t.Errorf("mode after the screen change = %v, want recursive grid", got)
+	}
+}
+
+// TestSimulation_ScreenChangeWithNothingToDrawExitsTheMode pins the failure
+// path: the display changed, hints were regenerated for it, and this time the
+// accessibility tree has nothing to offer — the window the labels belonged to
+// went with the display.
+//
+// Leaving the mode running would strand the user in hints with the old
+// display's labels on screen, so the mode is left instead and the overlay comes
+// down. Idle with nothing drawn is recoverable; a mode showing labels that
+// point nowhere is not.
+func TestSimulation_ScreenChangeWithNothingToDrawExitsTheMode(t *testing.T) {
+	sim := newSimHarness(t, simConfig(), threeButtons(t))
+
+	sim.pressHotkey(hintsHotkey)
+	sim.waitMode(domain.ModeHints)
+	sim.waitFor("hints on screen", func() bool {
+		return sim.overlay.hintDrawCount() > 0 && sim.overlay.isVisible()
+	})
+
+	// The display change took the window the hints belonged to with it.
+	sim.ax.setElements(nil)
+
+	sim.changeScreen(simDisplayResized())
+
+	sim.waitMode(domain.ModeIdle)
+
+	sim.waitFor("the overlay came down with the mode", func() bool {
+		return !sim.overlay.isVisible() && len(sim.overlay.drawnModeNames()) == 0
+	})
+
+	// The app is still usable afterwards: a mode that needs no elements still
+	// activates.
+	sim.pressHotkey(gridHotkey)
+	sim.waitMode(domain.ModeGrid)
+}
+
+// localBounds is a display in the overlay's screen-local space, which is what
+// the grid surfaces are drawn in.
+func localBounds(screen image.Rectangle) image.Rectangle {
+	return image.Rect(0, 0, screen.Dx(), screen.Dy())
+}
+
+// scaleAxis maps a coordinate from a display of size from to one of size to.
+func scaleAxis(value, from, to int) int {
+	return value * to / from
+}
+
+// boundsWithin reports whether every edge of got is within tolerance pixels of
+// the same edge of want.
+func boundsWithin(got, want image.Rectangle, tolerance int) bool {
+	within := func(a, b int) bool { return a-b <= tolerance && b-a <= tolerance }
+
+	return within(got.Min.X, want.Min.X) && within(got.Min.Y, want.Min.Y) &&
+		within(got.Max.X, want.Max.X) && within(got.Max.Y, want.Max.Y)
+}

--- a/internal/domain/state/app_state_test.go
+++ b/internal/domain/state/app_state_test.go
@@ -286,7 +286,7 @@ func TestAppState_ScreenChangeProcessing_ConcurrentStress(t *testing.T) {
 		wins      sync.Map
 		waitGroup sync.WaitGroup
 	)
-	// Simulate the real handleScreenParametersChange pattern:
+	// Simulate the real HandleScreenParametersChange pattern:
 	// each goroutine tries to acquire, processes in a loop draining retries,
 	// then releases.
 


### PR DESCRIPTION
## Description

This PR adds behaviour coverage for what happens when the display configuration changes underneath an open mode — plugging in a monitor, unplugging one, changing resolution, or a laptop waking to a different arrangement. That path runs the heaviest per-mode work in the product, and nothing tested any of it, so a regression in it reached users unnoticed. Nothing a user does behaves differently after this PR; what changes is that the behaviour is now pinned.

Six new user journeys drive the real app through a display change and assert on what a user would see: hints regenerate against the new screen without moving the cursor, grid rebuilds and drops the selection made on the display that is gone, recursive grid keeps the region already zoomed into, a change while idle leaves the overlay hidden, and a change that leaves nothing to draw exits the mode rather than stranding an overlay. The sixth closes a gap on the other side: the monitor picker was the only mode that draws whose light/dark refresh had no journey.

The one non-test change is that the app now exposes its screen-parameters-changed entry point, which the platform display observers already call — the same shape and role as the existing exported theme-change entry point, which is what makes a display change drivable at the same seam as everything else. Deliberate limitation: the journeys pin behaviour exactly as it is today rather than behaviour that might be preferred, because their job is to let the follow-up restructuring prove it changed nothing.

## Related Issues

Closes #1226

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no build-tagged file is touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or platform capability changes
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changes; no config option, command, flag or environment variable is added, renamed or removed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Each journey was mutation-checked rather than assumed: the relevant production line was removed one at a time and the journey confirmed to fail. That included the idle one, whose first version could not fail — the guard it names exists because sizing the overlay to the active display brings it up, and the fixture overlay was modelling that as silent success. The fixture now models the resize, and deleting the idle guard fails the journey.

Two things the journeys deliberately do not claim. The grid journey turns cursor-follow off first, because with the cursor following the selection there is nothing on screen that says where the selection is; the default-config interaction between a display change and the real cursor is therefore only pinned for hints, where the assertion is that the cursor does not move at all. And the monitor-picker theme journey asserts only that the picker is drawn again — that the overlay re-resolves its styles is mode-independent and already pinned once elsewhere, so repeating it here would be a second assertion on the same fact.
