### PR TITLE
fix(modes): stop the monitor-move lock test failing on a busy machine

### DIFF
--- a/docs/adr/0004-mode-lifecycle-dispatch-under-one-lock-hold.md
+++ b/docs/adr/0004-mode-lifecycle-dispatch-under-one-lock-hold.md
@@ -85,7 +85,7 @@ of keeping mode knowledge in a switch the modes work exists to delete.
   under the same lock. What it buys is the end of a real data race — the
   session's filter roles, strategy and label-direction overrides were read with
   no lock held while a concurrent mode exit reset them. That is pinned by
-  `TestRefreshActiveModeOnNewScreen_ReadsTheModeSessionUnderTheHandlerLock`,
+  `TestRefreshActiveModeForMonitorMove_ReadsTheModeSessionUnderTheHandlerLock`,
   which fails under `-race` against the dispatch this ADR replaces.
 - **The hold is now as long as the slowest refresh**, so that refresh had to
   be given a bound. The hints walk gets the same `HintTimeout` budget the

--- a/internal/app/modes/monitor_test.go
+++ b/internal/app/modes/monitor_test.go
@@ -23,6 +23,10 @@ import (
 // tests. Its contents do not matter; only that it is not where the mode was.
 var targetDisplay = image.Rect(1920, 0, 3840, 1080)
 
+// monitorMoveFilterRole is a role a hint session was activated with: exiting
+// the mode resets it, which is the state a concurrent refresh reads.
+const monitorMoveFilterRole = "button"
+
 // newMonitorMoveHintsHandler builds a handler with hints mode active and
 // enough wiring for the monitor-move refresh to run end to end: a hint service
 // to regenerate against, a hints context holding the session's flags, and the
@@ -59,15 +63,15 @@ func newMonitorMoveHintsHandler(regenerations *atomic.Int64) *Handler {
 	})
 
 	handler.appState.SetMode(domain.ModeHints)
-	handler.hints.Context.SetFilterRoles([]string{"button"})
+	handler.hints.Context.SetFilterRoles([]string{monitorMoveFilterRole})
 
 	return handler
 }
 
-// TestRefreshActiveModeOnNewScreen_ReadsTheModeSessionUnderTheHandlerLock is
-// the concurrency test the modes area guide asks of a locking change: it must
-// fail under -race if the monitor-move dispatch reads a mode's session state
-// outside h.mu.
+// TestRefreshActiveModeForMonitorMove_ReadsTheModeSessionUnderTheHandlerLock
+// is the concurrency test the modes area guide asks of a locking change: it
+// must fail under -race if the monitor-move dispatch reads a mode's session
+// state outside h.mu.
 //
 // A monitor move races a mode exit by construction — the warp is animated and
 // the user can press escape during it — and the two touch the same fields.
@@ -78,33 +82,66 @@ func newMonitorMoveHintsHandler(regenerations *atomic.Int64) *Handler {
 // was taken and the race detector saw it. Dispatching under one hold is what
 // closes it, so this test is the guard on that hold rather than on the
 // refresh's result.
-func TestRefreshActiveModeOnNewScreen_ReadsTheModeSessionUnderTheHandlerLock(t *testing.T) {
+//
+// How often the two loops below actually meet is the scheduler's business, so
+// the refresh is proven to reach a session up front rather than by asserting on
+// a count the scheduler decides.
+func TestRefreshActiveModeForMonitorMove_ReadsTheModeSessionUnderTheHandlerLock(t *testing.T) {
 	var regenerations atomic.Int64
 
 	handler := newMonitorMoveHintsHandler(&regenerations)
 
+	// A refresh reaches the session at all — asserted on its own, before the two
+	// loops below, because whether either of them ever catches the other
+	// mid-round is up to the scheduler. Without this the whole test could pass
+	// on a dispatch that never reached a session.
+	handler.refreshActiveModeForMonitorMove(context.Background(), targetDisplay)
+
+	if regenerations.Load() == 0 {
+		t.Fatal("a monitor-move refresh did not reach an open hints session")
+	}
+
+	regenerations.Store(0)
+
 	const rounds = 200
 
 	start := make(chan struct{})
+	done := make(chan struct{})
 
 	var waitGroup sync.WaitGroup
 
 	waitGroup.Go(func() {
 		<-start
 
+		defer close(done)
+
 		for range rounds {
-			// Re-enter hints so the next exit has a session to tear down,
-			// the way a repeating activation does. Exiting is the locked
-			// writer: it resets the session flags the refresh reads.
+			// Re-enter hints so the next exit has a session to tear down, the
+			// way a repeating activation does. Both sides of the round are
+			// locked writers — an activation and an exit — and the exit resets
+			// the session flags the refresh reads.
+			handler.mu.Lock()
 			handler.appState.SetMode(domain.ModeHints)
+			handler.hints.Context.SetFilterRoles([]string{monitorMoveFilterRole})
+			handler.mu.Unlock()
+
 			handler.ExitMode()
 		}
 	})
 
+	// The refresher runs flat out for as long as the mode is being entered and
+	// exited, rather than for a round count of its own: under the race detector
+	// the exit side is much the slower of the two.
 	waitGroup.Go(func() {
 		<-start
 
-		for range rounds {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+
 			handler.refreshActiveModeForMonitorMove(context.Background(), targetDisplay)
 		}
 	})
@@ -112,22 +149,23 @@ func TestRefreshActiveModeOnNewScreen_ReadsTheModeSessionUnderTheHandlerLock(t *
 	close(start)
 	waitGroup.Wait()
 
-	// Without this the test could pass by never refreshing anything: the
-	// window it guards only exists while a refresh is reading the session a
-	// concurrent exit is clearing.
-	if regenerations.Load() == 0 {
-		t.Fatal("no monitor-move refresh reached the hints session, so nothing raced")
-	}
+	// Reported rather than asserted: the exit side re-locks the moment it
+	// unlocks, so how many of the concurrent refreshes find a session open is
+	// the scheduler's decision. Asserting on it makes the test flaky rather
+	// than strict — the guarantee that a refresh reaches a session at all is
+	// the one made before the loops started.
+	t.Logf("%d of the concurrent refreshes reached an open session", regenerations.Load())
 
 	if got := handler.appState.CurrentMode(); got != domain.ModeIdle {
 		t.Fatalf("mode after the last exit = %v, want idle", got)
 	}
 }
 
-// TestRefreshActiveModeOnNewScreen_LeavesTheOverlayAloneWhileIdle pins the arm
-// the mode map answers by having no entry: a move with nothing open must not
-// bring a frame back up, which is what the deleted idle switch arm used to say.
-func TestRefreshActiveModeOnNewScreen_LeavesTheOverlayAloneWhileIdle(t *testing.T) {
+// TestRefreshActiveModeForMonitorMove_LeavesTheOverlayAloneWhileIdle pins the
+// arm the mode map answers by having no entry: a move with nothing open must
+// not bring a frame back up, which is what the deleted idle switch arm used to
+// say.
+func TestRefreshActiveModeForMonitorMove_LeavesTheOverlayAloneWhileIdle(t *testing.T) {
 	overlay := &portmocks.MockOverlayPort{}
 
 	handler := newHandlerWithState(handlerState{


### PR DESCRIPTION
## Description

This PR fixes a test that failed for reasons unrelated to what it guards. The
monitor-move locking test runs a mode exit and a monitor-move refresh against
each other, then asserted that at least one refresh had actually reached the
hints session. Whether that happens is the scheduler's decision, so on a
constrained or loaded machine the test correctly reported it had observed
nothing — and failed. Measured on `main`: 10 failures in 20 runs at
`GOMAXPROCS=1`, passing reliably at default parallelism, which is why it went
green through five pull requests.

A refresh is now proven to reach the session once before the concurrent loops
start, which needs no cooperation from the scheduler, and the count those loops
produce is logged instead of asserted. Nothing about what the test guards
changes: it still fails under `-race` if the monitor-move dispatch reads a
mode's session outside the handler lock.

Both tests in the file are also renamed after the function they actually cover,
which became `refreshActiveModeForMonitorMove` in #1238, along with the one
reference to the old name in ADR 0004.

## Related Issues

Closes #1242

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no OS-specific files touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, test-only change in shared code
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changed
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — the ADR 0004 reference to the renamed test
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Before:** 10 failures in 20 runs at `GOMAXPROCS=1 -race`, reproducing the
issue's report exactly.

**After:** 40/40 green at `GOMAXPROCS=1`, 40/40 at default parallelism, green
across `-cpu=1,2,4`. The whole `internal/app/modes` package is also green at
`-count=10` under `GOMAXPROCS=1`, so this was the only scheduler-sensitive test
in the area.

**The guard was checked, not assumed.** With the lock hold removed from the
monitor-move dispatch, the race detector fires on 20 runs out of 20 at default
parallelism — and the reported race is the real one, an `ExitMode` write against
the refresh's read of the session's filter roles, not an artefact of the test's
own writes. At `GOMAXPROCS=1` detection is 4 runs in 20: the interleaving window
is narrower with one processor, and it is worth knowing that this package running
under one processor would weaken the guard. That is a property of the race
window rather than of this change — the previous version of the test detected it
0 times in 8 there, because it failed on the scheduler assertion first.

Worth noting the failure direction was the safe one — the test reported it could
not observe the path rather than passing falsely — but a test that reddens for
reasons unrelated to the behaviour it guards trains people to re-run rather than
read.
