### PR TITLE
docs: name the keymap and focused app, and record how focus is learned

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,20 @@ _Avoid_: chain, pipeline, script
 A named, parameterised sequence that steps can invoke by name.
 _Avoid_: alias, function, snippet
 
+**Focused app**:
+The application the operating system currently routes keystrokes to. Neru
+names it by the platform's application identifier, and uses it to decide which
+per-app overrides apply.
+_Avoid_: frontmost app, active app, current app, bundle ID as a bare noun
+
+**Keymap**:
+The [[Binding]]s in force right now — the ones the current mode answers to, or
+the global ones when no mode is active, with the [[Focused app]]'s overrides
+already applied. A keymap is settled when the mode, the focused app or the
+configuration changes, not when a key arrives; a keystroke consults one, it
+never builds one.
+_Avoid_: dispatch table, hotkey map, resolved config, keymap table
+
 ### Entering a mode
 
 **Mode command**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,7 +45,8 @@ The [[Binding]]s in force right now — the ones the current mode answers to, or
 the global ones when no mode is active, with the [[Focused app]]'s overrides
 already applied. A keymap is settled when the mode, the focused app or the
 configuration changes, not when a key arrives; a keystroke consults one, it
-never builds one.
+never builds one. That is the rule the word carries, and the decision behind
+it is ADR 0005; key dispatch still resolves per keystroke until that lands.
 _Avoid_: dispatch table, hotkey map, resolved config, keymap table
 
 ### Entering a mode

--- a/docs/adr/0005-the-focused-app-is-published-not-polled.md
+++ b/docs/adr/0005-the-focused-app-is-published-not-polled.md
@@ -1,0 +1,96 @@
+# The focused app is published, not polled
+
+**Status**: proposed
+
+Resolving a per-mode hotkey asks the operating system which application is
+focused, on the keystroke that needs it, with `h.mu` held
+(`app/modes/key_dispatch.go:141-144`, `handler.go:429-442`). On macOS that is
+`AXUIElementCopyAttributeValue` against the system-wide element
+(`accessibility_element_darwin.m:25-48`) — a message to another process, in a
+repo that never calls `AXUIElementSetMessagingTimeout`, through a client that
+discards the context it is given (`accessibility/native/client.go:78`). We
+decided that the app watcher **publishes** the focused app into a cell the mode
+handler owns, and that the [[Keymap]] — the bindings in force for the current
+mode with that app's overrides applied — is **settled** when the mode, the
+focused app or the configuration changes. A keystroke consults a keymap; it
+never builds one, and it never asks the operating system anything.
+
+The part worth recording is the line this draws, because the obvious reading —
+"no accessibility work under `h.mu`" — is false here and ADR 0004 makes it
+false on purpose: the activation path and the screen-change path both walk the
+accessibility tree under that lock. The line is **a one-shot the user is
+waiting on may block under the lock; a keystroke may not block at all.** A
+person who pressed the hints hotkey is waiting for hints and a walk that stalls
+is visible as the thing they asked for being slow. A person typing a hint label
+is not waiting on anything, and the same stall is the daemon freezing — mode
+exit included, since it takes the same lock.
+
+## Considered options
+
+- **Bound the query with a context deadline.** The first answer, and it does
+  not work: the context is discarded before the C call, so a deadline has
+  nothing to check between itself and the thing that blocks. ADR 0004's
+  `HintTimeout` is real only because `darwin/tree.go` checks `ctx.Done()`
+  between nodes — it bounds a walk, never one message. A genuine bound needs
+  `AXUIElementSetMessagingTimeout` in the darwin bridge, which is a change to
+  every accessibility call in the process and is filed on its own.
+- **Memoize inside the accessibility adapter.** Smallest diff, and it makes
+  every caller faster without any of them asking. Rejected: `hints.go:157` and
+  the scroll and hint services need a fresh answer at activation, and a cache
+  behind a port method changes what they get without changing what they say.
+  The staleness belongs to the keymap, which can state it, not to the port.
+- **Settle synchronously from the watcher callback.** Rejected on the locking
+  contract. `Watcher.dispatchAppEvent` calls its callbacks inline under
+  `w.mu.RLock()`, and on macOS the notification arrives on the main queue.
+  `internal/app/modes/AGENTS.md` records that the `dispatch_sync` in
+  `clearFrameForMonitorMove` is safe only while nothing on the main queue takes
+  `h.mu`. So the callback publishes into an atomic cell and takes no lock; the
+  handler settles lazily inside a locked entry point it was going to enter
+  anyway.
+- **Defer the update to mode exit, as the global hotkey path already does.**
+  `handleAppActivation` defers hotkey *registration* during a mode
+  (`app/lifecycle.go:301-309`), and copying that would have been free.
+  Rejected: the stated reason for that deferral is re-entry during OS hotkey
+  registration, which settling an in-memory keymap does not do, and the case it
+  would break — passthrough out of a mode into another app, then keep
+  navigating — is the case per-app hotkeys exist for.
+- **Normalize hotkey tables at config load, as a separate earlier change.**
+  Rejected once the pipeline was read: `loader/load.go` has no derivation step,
+  so this invents one, and it has to run on every path that builds a `Config`
+  — the loader, `DefaultConfig()`, `config set`, every test literal — or key
+  matching differs between a loaded config and a default one. The normalized
+  index has one hot consumer, and the keymap already exists to hold it.
+
+## Consequences
+
+- **Staleness is bounded by watcher latency, and that is a real bound only
+  where a watcher exists.** darwin and Linux have one; Windows and `other` get
+  an empty `platformStartWatcher()`, so there the keymap settles by asking.
+  That is affordable precisely there: `FocusedApplication` on Windows is
+  `GetForegroundWindow` plus `GetWindowThreadProcessId`
+  (`platform/windows/win32.go:351-366`) — local, and unable to block on another
+  process. The hazard this ADR removes is specific to cross-process
+  accessibility, which is also specific to the two platforms that can be told
+  about focus instead of asking. One `resolveFocusedApp` covers both: read the
+  cell when it is fed, ask when it is not. `docs/CROSS_PLATFORM.md` gains the
+  row.
+- **`handlerState.focusedBundleID` is deleted.** Leaving it would leave the
+  regression writable; deleting it means the only way to learn the focused app
+  inside the handler is the published cell. Callers that legitimately need a
+  fresh answer reach the service directly with their own context, as
+  `hints.go:157` and `hints_debug.go:33` already do.
+- **The cell will be reached for by things that cannot tolerate stale.** This
+  is the trap, and it is why this is written down rather than left to the diff:
+  once one consumer reads "the focused app" from a cell, the next one will too,
+  including ones that must not. The cell is named and documented for the keymap;
+  a consumer that needs the truth asks the port.
+- **The keymap is what makes this a deepening rather than a cache.**
+  `syncModifierPassthrough` merges the same bindings twice more
+  (`passthrough.go:45,106`) on the same triggers; those reads come from the
+  settled keymap. Delete the keymap and you lose the single answer to "what is
+  bound right now", not merely some speed.
+- **The claim is reliability, not measured latency.** The cost removed is a
+  call with no upper bound, on a path that holds the lock every other path
+  needs. How many microseconds it also saves is unmeasured, and the change ships
+  with a benchmark and a harness assertion that a keystroke inside a mode makes
+  zero focused-app calls, rather than with a number in the subject line.


### PR DESCRIPTION
## Description

This PR adds two words to the glossary and records one decision. The glossary had
no term for the bindings that are in force at a given moment, nor for the
application the operating system routes keystrokes to, so every discussion of
per-app hotkeys reinvented both — usually as "dispatch table" and "frontmost
app". Those are now **Keymap** and **Focused app**, each with the terms to avoid.

The decision record covers how Neru learns which application is focused.
Resolving a per-mode hotkey currently asks the operating system on the keystroke
that needs the answer, with the mode handler's lock held, and on macOS that
question is a message to another process — so an application that is slow to
answer can stall a keystroke, and the mode exit behind it. The record documents
publishing the focused app from the application watcher and settling the keymap
when the mode, the focused app or the configuration changes, and it lists the
five alternatives that were rejected.

Documentation only — no behaviour changes, and the code the record describes is
not written yet. It is marked **proposed**, and moves to accepted in the change
that implements it.

## Related Issues

Unblocks #1245 and #1246, which both cite this record and this vocabulary.
Closes nothing.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no code in this PR
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no code in this PR
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no code in this PR
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, docs-only: ran `just fmt-check` and `just lint`, both clean. No Go or Objective-C files changed, so the test, vet, vuln and build stages have nothing in this diff to exercise.
- [x] Tests added/updated for new or changed functionality — N/A, documentation only
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The record's reasoning depends on two facts that are easy to miss when reading
the code, and both are cited in it:

- The accessibility client discards the context it is handed before making the
  native call, so a Go deadline around the focused-application query cannot fire
  — there is nothing between the deadline and the thing that blocks. This is the
  same point the accessibility-deadline rule added to the mode handler's guide
  file in #1248 makes, arrived at independently; the record and that rule agree.
- The application watcher invokes its callbacks inline, under its own read lock,
  and on macOS on the main queue. The mode handler's guide file records that
  nothing running on the main queue may take the handler lock, which is why the
  decision has the watcher publish into a lock-free cell rather than settle the
  keymap itself.

Worth flagging for review: the record draws a line that reads, at first glance,
as a contradiction of ADR 0004 — that record deliberately holds the handler lock
across a whole accessibility tree walk. The line is not "no accessibility work
under the lock" but "a one-shot the user is waiting on may block under the lock
if it carries a deadline; a keystroke may not block at all". If that framing is
wrong, this is the cheapest possible moment to say so, before anything is built
on it.
