### PR TITLE
test(app): pin what a keystroke costs while a mode is active

### DIFF
--- a/internal/app/simulation_benchmark_test.go
+++ b/internal/app/simulation_benchmark_test.go
@@ -9,18 +9,26 @@ package app_test
 // application through the simulation harness, so a keystroke costs everything
 // it costs in production except the native draw.
 //
-// One iteration is exactly one keystroke. Getting back to an empty input costs
-// a keystroke of its own, and that one is deliberately outside the timer: it
-// is dispatched on a goroutine (backspace is a mode hotkey), so timing it
-// would measure a scheduler rather than the key path.
+// One iteration is exactly one keystroke. Where getting back to where the
+// iteration started costs a keystroke of its own, that one is deliberately
+// outside the timer: it is dispatched on a goroutine (backspace is a mode
+// hotkey), so timing it would measure a scheduler rather than the key path.
+//
+// The hints benchmark measures the other thing a keystroke can cost: with
+// per-app hotkey overrides declared, deciding what a key is bound to asks the
+// operating system which application is focused, and on macOS that is a
+// message to another process made under the lock that serializes key handling.
+// None of these gate continuous integration — a timing threshold on a
+// three-operating-system matrix is a source of flakes, and the durable
+// guarantee is the call count the journeys assert, not the nanoseconds.
 
 import (
 	"image"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/domain"
 )
 
@@ -30,6 +38,15 @@ const backspaceKey = "Backspace"
 
 // benchSettleTimeout bounds the untimed wait for a backspace to land.
 const benchSettleTimeout = 2 * time.Second
+
+// benchHintElements is the size of the hint set the hints keystroke is
+// measured against: more elements than there are hint characters, so the labels
+// are the mixed one- and two-character set a real screen produces.
+const benchHintElements = 12
+
+// unmatchedHintKey is a letter outside the default hint alphabet, so it is a
+// prefix of no label on screen.
+const unmatchedHintKey = "z"
 
 // BenchmarkGridNarrowingKeystroke measures one narrowing keystroke in grid
 // mode: the event tap hands a key to the handler, the grid manager matches it,
@@ -112,6 +129,82 @@ func BenchmarkRecursiveGridKeystroke(b *testing.B) {
 	}
 }
 
+// BenchmarkHintsKeystroke measures one keystroke in hints mode — the mode a
+// user spends most of their keystrokes in — configured the way that makes a
+// keystroke expensive: the mode declares per-app hotkey overrides, so before
+// the handler can decide what the key is bound to it asks the operating system
+// which application is focused, holding the lock that serializes key handling
+// while it waits. Leaving the overrides out would quietly measure the cheap
+// path and report a better number for the same code.
+//
+// The key it presses is a prefix of no label, and that is the point rather than
+// a shortcut: it pays for the whole key path — the focused-app query, the
+// keymap resolution, the hint filter and the redraw — and leaves the drawn set
+// exactly as it found it, so every iteration measures the same keystroke and
+// none of them needs untimed work in between. A narrowing keystroke could not:
+// changing how many hints are drawn is a structural change, which the hint
+// manager deliberately debounces onto a timer, so its redraw would land outside
+// the iteration that caused it and the reset between iterations would cost far
+// more than the thing being measured.
+func BenchmarkHintsKeystroke(b *testing.B) {
+	cfg := simConfig()
+	cfg.Hints.AppConfigs = []config.AppConfig{
+		perAppHotkeyOverride(simFixtureBundleID, unpressedOverrideKey, "action left_click"),
+	}
+
+	sim := newSimHarness(b, cfg, manyButtons(b, benchHintElements))
+
+	sim.pressHotkey(hintsHotkey)
+	sim.waitMode(domain.ModeHints)
+	sim.waitFor("hints drawn", func() bool { return sim.overlay.hintDrawCount() > 0 })
+
+	if labeled := len(sim.overlay.lastHintLabels()); labeled != benchHintElements {
+		b.Fatalf("hints drawn for %d of %d elements; the fixture is not the one being measured",
+			labeled, benchHintElements)
+	}
+
+	drawsBefore := sim.overlay.hintDrawCount()
+	movesBefore := sim.cursor.moveCount()
+	queriesBefore := sim.ax.focusedAppQueryCount()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		sim.press(unmatchedHintKey)
+	}
+
+	b.StopTimer()
+
+	if mode := sim.app.CurrentMode(); mode != domain.ModeHints {
+		b.Fatalf("benchmark left hints mode for %s; the numbers are not hints'",
+			domain.ModeString(mode))
+	}
+
+	// A key that matched a label would have selected an element and moved the
+	// cursor — a different, and much more expensive, path than the one claimed.
+	if moved := sim.cursor.moveCount() - movesBefore; moved != 0 {
+		b.Fatalf("cursor moved %d times; the keystrokes selected hints instead of missing them",
+			moved)
+	}
+
+	// Each keystroke repaints the full set exactly once. Anything else means
+	// the iterations were not the keystroke this claims to measure.
+	if drawn := sim.overlay.hintDrawCount() - drawsBefore; drawn != b.N {
+		b.Fatalf("hints redrawn %d times for %d keystrokes; the keystrokes did not all reach "+
+			"the surface", drawn, b.N)
+	}
+
+	// The expensive path, stated in the currency it is expensive in: one
+	// question to the operating system per keystroke. This is the number ADR
+	// 0005 exists to drive to zero, so the change that earns that edits it here
+	// as well as in the journey that pins it.
+	if asked := sim.ax.focusedAppQueryCount() - queriesBefore; asked != b.N {
+		b.Fatalf("%d keystrokes asked which app is focused %d times, want %d; the benchmark "+
+			"did not measure the path it claims to", b.N, asked, b.N)
+	}
+}
+
 // clearGridNarrowing takes the grid back to an empty input without leaving the
 // mode. Backspace is a mode hotkey, so the app runs it on a goroutine and this
 // waits for it to land.
@@ -149,22 +242,4 @@ func settle(sim *simHarness, desc string, cond func() bool) {
 	}
 
 	sim.t.Fatalf("timed out waiting for %s", desc)
-}
-
-// firstGridLabelKey returns the lower-case first character of a drawn cell's
-// label — the key a user would press to start narrowing to it.
-func firstGridLabelKey(sim *simHarness) string {
-	grid := sim.overlay.lastGrid()
-
-	cells := grid.Cells()
-	if len(cells) == 0 {
-		sim.t.Fatal("grid drawn with zero cells")
-	}
-
-	label := cells[0].Coordinate()
-	if label == "" {
-		sim.t.Fatal("grid cell drawn without a label")
-	}
-
-	return strings.ToLower(string([]rune(label)[0]))
 }

--- a/internal/app/simulation_harness_test.go
+++ b/internal/app/simulation_harness_test.go
@@ -599,6 +599,17 @@ type simAXPort struct {
 	elementActions []action.Type
 	scrolls        []image.Point
 	releases       int
+
+	// focusedApp is which application the fixture desktop routes keystrokes
+	// to, and focusedAppQueries how many times the app asked for it.
+	//
+	// Both exist because asking is not free on a real desktop: on macOS it is a
+	// message to another process, so an application that is busy or wedged
+	// answers slowly or not at all. How many times a single keystroke asks is
+	// therefore a property a user can be stalled by, and a journey that counts
+	// it is stating what a keystroke costs rather than describing it.
+	focusedApp        string
+	focusedAppQueries int
 }
 
 var _ ports.AccessibilityPort = (*simAXPort)(nil)
@@ -666,7 +677,12 @@ func (a *simAXPort) ReleaseHeldButtons(_ context.Context) error {
 }
 
 func (a *simAXPort) FocusedAppBundleID(_ context.Context) (string, error) {
-	return simFixtureBundleID, nil
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.focusedAppQueries++
+
+	return a.focusedApp, nil
 }
 
 func (a *simAXPort) IsAppExcluded(_ context.Context, _ string) bool {
@@ -687,6 +703,24 @@ func (a *simAXPort) setElements(elements []*element.Element) {
 	defer a.mu.Unlock()
 
 	a.elements = elements
+}
+
+// setFocusedApp changes which application the fixture desktop reports as
+// focused, the way switching applications does on a real one.
+func (a *simAXPort) setFocusedApp(bundleID string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.focusedApp = bundleID
+}
+
+// focusedAppQueryCount reports how many times the app has asked which
+// application is focused.
+func (a *simAXPort) focusedAppQueryCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.focusedAppQueries
 }
 
 func (a *simAXPort) setExcluded(excluded bool) {
@@ -830,8 +864,25 @@ type simHarness struct {
 	cursor     *simCursor
 	hotkeys    *simHotkeyPort
 	tap        *mocks.MockEventTapPort
-	desktop    *simDesktop
-	runDone    chan error
+	// watcher is the platform application watcher: the thing that tells Neru
+	// the user switched applications. A journey drives a focus change through
+	// it rather than by poking the accessibility fake alone, because the
+	// activation event is the half of a focus change that reaches the app.
+	watcher *mocks.MockAppWatcherPort
+	desktop *simDesktop
+	runDone chan error
+}
+
+// focusApp switches the fixture desktop to another application: the desktop
+// answers with it from now on, and the platform watcher announces the
+// activation the way it does when the user brings an application to the front.
+//
+// The desktop is switched before the announcement, so everything the app reads
+// while handling it sees the application the user is now in, as it would on a
+// real desktop.
+func (h *simHarness) focusApp(appName, bundleID string) {
+	h.ax.setFocusedApp(bundleID)
+	h.watcher.EmitActivate(appName, bundleID)
 }
 
 // switchToDarkMode flips the fixture desktop's appearance and notifies the app
@@ -877,6 +928,39 @@ func simConfig() *config.Config {
 	}
 
 	return cfg
+}
+
+// unpressedOverrideKey is what a per-app override that exists only to open the
+// focused-app path is bound to. Nothing presses it: declaring an override at
+// all is what makes a keystroke resolve the focused app, so the binding's key
+// is deliberately one no journey types.
+const unpressedOverrideKey = "F13"
+
+// perAppHotkeyOverride is one mode's per-app hotkey override: the steps the
+// given key runs while that application is focused.
+func perAppHotkeyOverride(bundleID, key string, steps ...string) config.AppConfig {
+	return config.AppConfig{
+		BundleID: bundleID,
+		Hotkeys:  map[string]config.StringOrStringArray{key: steps},
+	}
+}
+
+// firstGridLabelKey returns the lower-case first character of a drawn cell's
+// label — the key a user would press to start narrowing to it.
+func firstGridLabelKey(sim *simHarness) string {
+	grid := sim.overlay.lastGrid()
+
+	cells := grid.Cells()
+	if len(cells) == 0 {
+		sim.t.Fatal("grid drawn with zero cells")
+	}
+
+	label := cells[0].Coordinate()
+	if label == "" {
+		sim.t.Fatal("grid cell drawn without a label")
+	}
+
+	return strings.ToLower(string([]rune(label)[0]))
 }
 
 // simDisplay is one monitor of the simulated desktop.
@@ -974,8 +1058,9 @@ func buildSimHarness(
 		tb.Fatal("buildSimHarness needs at least one display")
 	}
 
-	axPort := &simAXPort{elements: elements}
+	axPort := &simAXPort{elements: elements, focusedApp: simFixtureBundleID}
 	appearance := &atomic.Bool{}
+	watcher := &mocks.MockAppWatcherPort{}
 	cursor := &simCursor{pos: displays[0].bounds.Min.Add(
 		image.Point{X: displays[0].bounds.Dx() / 2, Y: displays[0].bounds.Dy() / 2},
 	)}
@@ -1045,7 +1130,7 @@ func buildSimHarness(
 		app.WithEventTap(tap),
 		app.WithTextInput(&mocks.MockTextInputPort{}),
 		app.WithIPCServer(&mocks.MockIPCPort{}),
-		app.WithWatcher(&mocks.MockAppWatcherPort{}),
+		app.WithWatcher(watcher),
 		app.WithHotkeyService(hotkeys),
 		app.WithOverlayPort(overlayPort),
 		app.WithSystemPort(system),
@@ -1064,6 +1149,7 @@ func buildSimHarness(
 		cursor:     cursor,
 		hotkeys:    hotkeys,
 		tap:        tap,
+		watcher:    watcher,
 		desktop:    desktop,
 		runDone:    make(chan error, 1),
 	}

--- a/internal/app/simulation_journey_test.go
+++ b/internal/app/simulation_journey_test.go
@@ -28,6 +28,13 @@ const (
 	scrollHotkey = "Primary+Shift+S"
 )
 
+// The second fixture application, so a journey can switch away from the one
+// the fixture desktop starts focused on.
+const (
+	simOtherAppBundleID = "com.example.otherapp"
+	simOtherAppName     = "Other App"
+)
+
 // threeButtons is a fixture of three well-separated clickable elements.
 func threeButtons(t *testing.T) []*element.Element {
 	t.Helper()
@@ -439,8 +446,8 @@ const recursiveGridHotkey = "Primary+Shift+C"
 
 // manyButtons builds a count-sized grid of well-separated clickable buttons,
 // enough to force multi-character hint labels.
-func manyButtons(t *testing.T, count int) []*element.Element {
-	t.Helper()
+func manyButtons(tb testing.TB, count int) []*element.Element {
+	tb.Helper()
 
 	elements := make([]*element.Element, 0, count)
 	for index := range count {
@@ -449,7 +456,7 @@ func manyButtons(t *testing.T, count int) []*element.Element {
 		bounds := image.Rect(100+col*200, 100+row*100, 220+col*200, 140+row*100)
 		elements = append(
 			elements,
-			simElement(t, fmt.Sprintf("btn-%d", index), bounds, fmt.Sprintf("Button %d", index)),
+			simElement(tb, fmt.Sprintf("btn-%d", index), bounds, fmt.Sprintf("Button %d", index)),
 		)
 	}
 
@@ -2042,6 +2049,137 @@ func TestSimulation_ThemeChangeRedrawsMonitorSelect(t *testing.T) {
 
 	if got := sim.app.CurrentMode(); got != domain.ModeMonitorSelect {
 		t.Errorf("mode after the theme change = %v, want monitor select", got)
+	}
+}
+
+// TestSimulation_KeystrokeAsksWhichAppIsFocused pins what one keystroke inside
+// a mode costs today in questions to the operating system: exactly one when the
+// active mode declares per-app hotkey overrides, and none at all when it does
+// not.
+//
+// The first number is a baseline, not an invariant — ADR 0005 is the decision
+// to drive it to zero by having the focused app published instead of asked for,
+// and the change that earns it is the change that edits this number.
+//
+// Asking which application is focused is the only thing on the keystroke path
+// that leaves the process — on macOS it is a message to another application,
+// which can be busy or wedged — and the handler holds the lock that serializes
+// key handling, mode exit included, while it waits. The count is therefore
+// what a user can be stalled by, which is why it is asserted here rather than
+// described somewhere.
+//
+// The second direction is the cheap path a mode with no overrides already
+// takes, which nothing tested before: a refactor that dropped that gate would
+// make every keystroke in every mode pay, invisibly.
+//
+// Grid mode drives both directions because it needs no accessibility tree of
+// its own: nothing else in the keystroke being measured has any reason to ask
+// which app is focused, so the count belongs to key dispatch and to nothing
+// else.
+func TestSimulation_KeystrokeAsksWhichAppIsFocused(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  func() *config.Config
+		want int
+	}{
+		{
+			name: "mode declares per-app overrides",
+			cfg: func() *config.Config {
+				cfg := simConfig()
+				cfg.Grid.AppConfigs = []config.AppConfig{
+					perAppHotkeyOverride(
+						simFixtureBundleID,
+						unpressedOverrideKey,
+						"action left_click",
+					),
+				}
+
+				return cfg
+			},
+			want: 1,
+		},
+		{
+			name: "mode declares none",
+			cfg:  simConfig,
+			want: 0,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			sim := newSimHarness(t, testCase.cfg(), nil)
+
+			sim.pressHotkey(gridHotkey)
+			sim.waitMode(domain.ModeGrid)
+			sim.waitFor("grid drawn", func() bool { return sim.overlay.lastGrid() != nil })
+
+			// Entering the mode is allowed to ask; this measures the keystroke
+			// after it, so the count starts from a mode already on screen.
+			queriesBefore := sim.ax.focusedAppQueryCount()
+
+			sim.press(firstGridLabelKey(sim))
+
+			sim.waitFor("grid narrowed to what was typed", func() bool {
+				prefix, narrowed := sim.overlay.lastMatchPrefix()
+
+				return narrowed && prefix != ""
+			})
+
+			if got := sim.ax.focusedAppQueryCount() - queriesBefore; got != testCase.want {
+				t.Errorf(
+					"one keystroke asked which app is focused %d times, want %d",
+					got, testCase.want,
+				)
+			}
+		})
+	}
+}
+
+// TestSimulation_FocusChangeMidModeRebindsTheKey covers switching applications
+// without leaving the mode — passing a shortcut through to the system and
+// landing somewhere else is the ordinary way it happens — and pins what the
+// next keystroke does: it runs the binding the newly focused application's
+// overrides put on that key, not the one the mode was opened under.
+//
+// That is what per-app bindings mean, and it is the behavior most at risk
+// from anything that decides the keymap once and keeps it. The journey drives
+// the change the way the platform does, through a watcher activation event and
+// a desktop that now answers with the other application, so it stays true of
+// whichever half the handler learns from.
+func TestSimulation_FocusChangeMidModeRebindsTheKey(t *testing.T) {
+	const sharedKey = "j"
+
+	// The two applications bind the same key to a different mode, so which
+	// mode the user lands in says which application's overrides were in force.
+	cfg := simConfig()
+	cfg.Grid.AppConfigs = []config.AppConfig{
+		perAppHotkeyOverride(simFixtureBundleID, sharedKey, config.ModeNameScroll),
+		perAppHotkeyOverride(simOtherAppBundleID, sharedKey, config.ModeNameRecursiveGrid),
+	}
+
+	sim := newSimHarness(t, cfg, nil)
+
+	sim.pressHotkey(gridHotkey)
+	sim.waitMode(domain.ModeGrid)
+	sim.waitFor("grid drawn", func() bool { return sim.overlay.lastGrid() != nil })
+
+	sim.focusApp(simOtherAppName, simOtherAppBundleID)
+
+	sim.press(sharedKey)
+
+	sim.waitFor("a binding for the shared key to run", func() bool {
+		return sim.app.CurrentMode() != domain.ModeGrid
+	})
+
+	if got := sim.app.CurrentMode(); got != domain.ModeRecursiveGrid {
+		t.Fatalf(
+			"pressing %q after switching to %s entered %s, want %s: the key still means what "+
+				"it meant in the application the mode was opened in",
+			sharedKey,
+			simOtherAppName,
+			domain.ModeString(got),
+			domain.ModeString(domain.ModeRecursiveGrid),
+		)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR records, in code, what a keystroke inside a navigation mode currently
costs. While a mode is active and that mode declares per-app hotkey overrides,
every keystroke asks the operating system which application is focused before it
can decide what the key is bound to — on macOS that is a message to another
process, made while the lock that serializes key handling and mode exit is held.
Nothing measured that, and nothing pinned it, so a change to it could only be
argued in prose.

A journey now asserts the number out loud: one focused-app query per keystroke
when the active mode declares per-app overrides, and none at all when it does
not — the cheap path that existed but had no test. A second journey states the
behaviour that has to survive any change here: switch applications without
leaving the mode, and the next keystroke runs the newly focused application's
binding. A keystroke inside hints mode gets a benchmark alongside the two that
already exist for the grids, reporting allocations as well as time.

Nothing a user can observe changes, and no production code changes: the whole
diff is the simulation harness, its benchmarks and its journeys. The benchmarks
are deliberately not wired into `just ci` — a timing threshold on a
three-operating-system matrix is a source of flakes, and the durable guarantee
here is the call count, not the nanoseconds.

## Related Issues

Closes #1245. Sets up #1246, which moves the query off the keystroke path and
flips the pinned count from one to zero.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no platform-specific files touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no new imports
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port changes
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Baseline numbers on an M3 (`go test -run XXX -bench Benchmark ./internal/app/`),
for the follow-up to be measured against:

```
BenchmarkGridNarrowingKeystroke-8    161661    7360 ns/op    2122 B/op     74 allocs/op
BenchmarkRecursiveGridKeystroke-8    293194    4080 ns/op    1658 B/op     64 allocs/op
BenchmarkHintsKeystroke-8            233994    5083 ns/op    3747 B/op    125 allocs/op
```

The hints benchmark also fails unless each of its keystrokes asked which
application is focused exactly once, so it cannot quietly measure the cheap path
and report a better number for the same code. That is the second place the
follow-up has to edit the number.

Two choices worth a reviewer's eye:

- The hints benchmark presses a key that is a prefix of no label. A narrowing
  keystroke changes how many hints are drawn, which the hint manager
  deliberately debounces onto a timer, so its redraw would land outside the
  iteration that caused it and the untimed reset between iterations would cost
  far more than the thing being measured. A key that matches nothing pays for
  the whole key path and leaves the drawn set exactly as it found it, so every
  iteration measures the same keystroke.
- The call-count journey runs in grid mode rather than hints, because grid needs
  no accessibility tree of its own: nothing else in the keystroke being measured
  has any reason to ask which application is focused, so the count belongs to
  key dispatch and to nothing else.

The focus-change journey drives the change the way the platform does — the
watcher announces an activation and the fixture desktop answers with the new
application from then on — so it stays honest whichever half of that a later
implementation learns from.
