### PR TITLE
test(darwin): stop the callback-slot test failing on a busy machine

### DIFF
--- a/internal/adapter/platform/darwin/cgo_slot.go
+++ b/internal/adapter/platform/darwin/cgo_slot.go
@@ -93,6 +93,19 @@ func (s *cgoSlot[T]) withValid(callback func(T)) {
 	callback(target)
 }
 
+// dispatchIfValid invokes callback with target when gen is still the live
+// generation. It is the body the async dispatch goroutine runs, named rather
+// than inline so a test can drive it at the moment a concurrent clear lands —
+// the window between scheduling the dispatch and running it is the one this
+// re-check exists to close, and a test cannot force it from outside.
+func (s *cgoSlot[T]) dispatchIfValid(target T, gen uint64, callback func(T)) {
+	if !s.stillValid(gen) {
+		return
+	}
+
+	callback(target)
+}
+
 // withValidAsync invokes callback in a new goroutine when the snapshot is still valid.
 func (s *cgoSlot[T]) withValidAsync(callback func(T)) {
 	target, gen, ok := s.snapshot()
@@ -100,11 +113,5 @@ func (s *cgoSlot[T]) withValidAsync(callback func(T)) {
 		return
 	}
 
-	go func() {
-		if !s.stillValid(gen) {
-			return
-		}
-
-		callback(target)
-	}()
+	go s.dispatchIfValid(target, gen, callback)
 }

--- a/internal/adapter/platform/darwin/cgo_slot_test.go
+++ b/internal/adapter/platform/darwin/cgo_slot_test.go
@@ -77,6 +77,126 @@ func TestCgoSlotWithValidAsyncRejectsStaleGeneration(t *testing.T) {
 	}
 }
 
+// TestCgoSlotDispatchesAValidSnapshot pins the half of the generation guard
+// that says yes: a snapshot nothing invalidated must actually reach its
+// callback, on both dispatch paths.
+//
+// Every other dispatch assertion in this file is negative — "want 0 calls" —
+// so without this one a stillValid that rejected everything would pass the
+// whole package. The async wait is bounded rather than slept on: the timeout
+// is a failure bound, not a race window, so a loaded runner is slow here, not
+// red.
+func TestCgoSlotDispatchesAValidSnapshot(t *testing.T) {
+	var (
+		slot      cgoSlot[int]
+		syncCalls atomic.Int32
+	)
+
+	slot.Set(1)
+
+	slot.withValid(func(value int) {
+		if value != 1 {
+			t.Errorf("withValid dispatched value %d, want 1", value)
+		}
+
+		syncCalls.Add(1)
+	})
+
+	if got := syncCalls.Load(); got != 1 {
+		t.Fatalf("withValid dispatched %d times for a valid snapshot, want 1", got)
+	}
+
+	dispatched := make(chan int, 1)
+
+	slot.withValidAsync(func(value int) {
+		dispatched <- value
+	})
+
+	select {
+	case value := <-dispatched:
+		if value != 1 {
+			t.Fatalf("withValidAsync dispatched value %d, want 1", value)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("withValidAsync never dispatched a valid snapshot")
+	}
+}
+
+// TestCgoSlotStaleSnapshotDoesNotDispatchAcrossGoroutines pins the guarantee
+// the generation counter exists for: a reader holding a snapshot taken before
+// a concurrent clear must not dispatch it.
+//
+// The interleaving is driven rather than hoped for. The reader takes its
+// snapshot and hands the generation to the writer, the writer clears the slot
+// and says so, and only then does the reader check validity — the exact order
+// that makes the snapshot stale, on every schedule and every machine.
+func TestCgoSlotStaleSnapshotDoesNotDispatchAcrossGoroutines(t *testing.T) {
+	var (
+		slot       cgoSlot[int]
+		dispatched atomic.Int32
+		waitGroup  sync.WaitGroup
+	)
+
+	slot.Set(1)
+
+	held := make(chan uint64)
+	cleared := make(chan struct{})
+
+	waitGroup.Add(2)
+
+	// The reader: what withValidAsync's goroutine does, with the window
+	// between taking the snapshot and checking it opened deliberately.
+	go func() {
+		defer waitGroup.Done()
+
+		value, generation, ok := slot.snapshot()
+		if !ok {
+			t.Error("snapshot of a slot holding a value reported empty")
+			close(held)
+
+			return
+		}
+
+		if value != 1 {
+			t.Errorf("snapshot value = %d, want 1", value)
+		}
+
+		held <- generation
+
+		<-cleared
+
+		// The dispatch guard itself: the callback runs only for a generation
+		// the slot still recognizes. By now the clear has happened, so this
+		// must not fire.
+		if slot.stillValid(generation) {
+			dispatched.Add(1)
+		}
+	}()
+
+	// The writer: clears only once the reader is holding its snapshot.
+	go func() {
+		defer waitGroup.Done()
+
+		<-held
+		slot.Set(0)
+		close(cleared)
+	}()
+
+	waitGroup.Wait()
+
+	if got := dispatched.Load(); got != 0 {
+		t.Fatalf("stale snapshot dispatched %d times, want 0", got)
+	}
+}
+
+// TestCgoSlotConcurrentSetAndDispatch soaks the snapshot/validity pair against
+// a writer toggling the slot, under the race detector.
+//
+// It asserts only what holds under every schedule: an active snapshot always
+// carries a value. Whether any given reader is caught mid-round by the writer
+// is the scheduler's decision, so the counts are reported rather than asserted
+// — asserting on them is what made this test fail green changes on a loaded
+// runner. Both directions of the guard have deterministic tests above.
 func TestCgoSlotConcurrentSetAndDispatch(t *testing.T) {
 	var (
 		slot      cgoSlot[int]
@@ -100,6 +220,12 @@ func TestCgoSlotConcurrentSetAndDispatch(t *testing.T) {
 					continue
 				}
 
+				if value == 0 {
+					t.Error("an active snapshot carried a cleared value")
+
+					return
+				}
+
 				// Encourage interleaving so concurrent Set(0)/Set(1) updates can
 				// invalidate this snapshot before stillValid checks it.
 				runtime.Gosched()
@@ -110,9 +236,7 @@ func TestCgoSlotConcurrentSetAndDispatch(t *testing.T) {
 					continue
 				}
 
-				if value != 0 {
-					calls.Add(1)
-				}
+				calls.Add(1)
 			}
 		}()
 	}
@@ -136,11 +260,6 @@ func TestCgoSlotConcurrentSetAndDispatch(t *testing.T) {
 
 	waitGroup.Wait()
 
-	if calls.Load() == 0 {
-		t.Fatal("expected at least one dispatch while slot holds a value")
-	}
-
-	if staleSeen.Load() == 0 {
-		t.Fatal("expected at least one stale snapshot invalidated by concurrent clear")
-	}
+	t.Logf("%d snapshots dispatched, %d invalidated before their validity check",
+		calls.Load(), staleSeen.Load())
 }

--- a/internal/adapter/platform/darwin/cgo_slot_test.go
+++ b/internal/adapter/platform/darwin/cgo_slot_test.go
@@ -128,8 +128,13 @@ func TestCgoSlotDispatchesAValidSnapshot(t *testing.T) {
 //
 // The interleaving is driven rather than hoped for. The reader takes its
 // snapshot and hands the generation to the writer, the writer clears the slot
-// and says so, and only then does the reader check validity — the exact order
-// that makes the snapshot stale, on every schedule and every machine.
+// and says so, and only then does the reader dispatch — the exact order that
+// makes the snapshot stale, on every schedule and every machine.
+//
+// The reader stands in for the goroutine withValidAsync spawns, and runs the
+// same guard that goroutine runs rather than a copy of it: that window cannot
+// be forced through withValidAsync from outside, so driving the shared body
+// directly is what keeps the guard covered.
 func TestCgoSlotStaleSnapshotDoesNotDispatchAcrossGoroutines(t *testing.T) {
 	var (
 		slot       cgoSlot[int]
@@ -144,8 +149,8 @@ func TestCgoSlotStaleSnapshotDoesNotDispatchAcrossGoroutines(t *testing.T) {
 
 	waitGroup.Add(2)
 
-	// The reader: what withValidAsync's goroutine does, with the window
-	// between taking the snapshot and checking it opened deliberately.
+	// The reader: withValidAsync's dispatch goroutine, with the window between
+	// taking the snapshot and running the dispatch opened deliberately.
 	go func() {
 		defer waitGroup.Done()
 
@@ -165,12 +170,11 @@ func TestCgoSlotStaleSnapshotDoesNotDispatchAcrossGoroutines(t *testing.T) {
 
 		<-cleared
 
-		// The dispatch guard itself: the callback runs only for a generation
-		// the slot still recognizes. By now the clear has happened, so this
-		// must not fire.
-		if slot.stillValid(generation) {
+		// The guarded dispatch itself, the same call the async goroutine
+		// makes. By now the clear has happened, so the callback must not run.
+		slot.dispatchIfValid(value, generation, func(int) {
 			dispatched.Add(1)
-		}
+		})
 	}()
 
 	// The writer: clears only once the reader is holding its snapshot.


### PR DESCRIPTION
## Description

This PR fixes a macOS test that could fail on a loaded machine while the code
it covers was perfectly correct. The test checked that a callback holding a
stale snapshot is refused, but it tried to produce the necessary interleaving
by yielding and hoping — so when the scheduler declined the race, the test
failed a green change. That is what happened on CI to an unrelated pull
request, which then passed on a re-run with no code change.

The interleaving is now driven rather than hoped for: the reader hands its
snapshot over, the writer clears only once it is held, and validity is checked
only after that. The race happens on every schedule and every machine, so the
assertion is exact instead of hopeful. The unsynchronised soak stays for its
race-detector value, but now asserts only what holds under every schedule and
reports its counts instead of asserting them.

It also closes a hole in the guarantee the slot exists to make. The dispatch
that runs on another goroutine re-checks validity before firing, because a
clear can land between scheduling the work and running it — but that re-check
had no test, on this branch or on `main`. Deleting it left the whole package
green. The window cannot be forced from outside, so the dispatch body is now a
named method the test can run directly at the moment a clear lands.

Nothing about Neru's runtime behaviour changes.

## Related Issues

Closes #1253

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability changes; the change is confined to darwin-tagged files
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changes
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**The old failure reproduces, and the new tests survive it.** Loading the
machine with 24 busy processes and running the old test 100 times reproduces
the exact CI failure. The same load against the new tests passes 100 runs
plain and 30 runs under `-race`.

**The positive half of the guarantee is now covered too.** The old test
asserted that at least one dispatch happened, and dropping that assertion
alongside the flaky one would have left every dispatch assertion in the
package negative — a validity check that rejected *everything* would have
passed the whole suite. A separate deterministic test now pins that a snapshot
nothing invalidated does reach its callback, on both the synchronous and
asynchronous paths. Both directions were confirmed by hand-breaking the
validity check each way and watching exactly the right test go red.

**Mutation evidence.** Three ways to break the guard, all three now caught:
making the validity check always accept fails the stale test (and the existing
invalidation test), always reject fails the dispatch test, and deleting the
goroutine-side re-check fails the stale test. That last one is the case this
PR adds coverage for — on `main` it left the entire package green.

**Why `test` and not `fix`.** The prior art named in the issue (#1247) shipped
as a `fix`, but nothing a user can observe changes here, and `test` — like the
`refactor` commit alongside it — keeps this out of the release changelog.
Happy to retype it if you would rather it appear there.
