### PR TITLE
fix(config): report an inert held-repeat acceleration setting in config validate

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1548,6 +1548,11 @@ currently the sole valid entry: anything else is a config error rather than a bi
 that silently never accelerates. An empty `accel_targets` while `accel_enabled = true` is
 rejected for the same reason. Scroll and page keep their fixed step.
 
+`accel_enabled = true` while `enabled = false` is not an error: acceleration scales a
+repeat, so with no repeat to scale it simply does nothing, and refusing the file would
+stop you turning held-key repeat off without also unwinding the settings under it.
+`neru config validate` reports it as a warning instead.
+
 ---
 
 ## [systray]

--- a/internal/config/loader/load.go
+++ b/internal/config/loader/load.go
@@ -61,24 +61,30 @@ func (s *Service) LoadWithValidation(path string) *config.LoadResult {
 		return refuse(result, wrapped)
 	}
 
-	// The override pass below validates again, for refusals only: an override
-	// sets a single scalar field and no scalar field is a binding, so it can
-	// neither add a warning nor answer one.
+	// The override pass validates the config again, warnings included, and its
+	// reading replaces this one rather than adding to it: an override sets a
+	// scalar, and a scalar can make a setting elsewhere in the file inert —
+	// `neru config set held_repeat.enabled false` is enough to answer for an
+	// accel_enabled the user wrote months ago — or answer a warning this pass
+	// raised, which merging the two would leave standing. So what rides out is
+	// read from the config the daemon will actually run.
+	//
+	// That holds because every warning comes from ValidateWithWarnings, which
+	// both passes run in full; the phases above this sink report by refusing,
+	// so there is nothing of theirs to lose. A warning raised outside it would
+	// have to be re-raised here.
+	if overridePath := overrideFileToLayer(result.ConfigPath); overridePath != "" {
+		overrideWarnings := &config.Warnings{}
+
+		overrideErr := s.applyOverrideFile(result.Config, overridePath, overrideWarnings)
+		if overrideErr != nil {
+			return refuse(result, overrideErr)
+		}
+
+		warnings = overrideWarnings
+	}
+
 	result.Warnings = warnings.Messages()
-
-	overrideErr := s.applyOverrideFile(result.Config, result.ConfigPath)
-	if overrideErr != nil {
-		return refuse(result, overrideErr)
-	}
-
-	// Settings that are valid alone but inert in context warn rather than fail:
-	// rejecting them would stop someone switching a feature off without also
-	// unwinding the settings beneath it.
-	if result.Config.HeldRepeat.AccelEnabled && !result.Config.HeldRepeat.Enabled {
-		s.logger.Warn(
-			"held_repeat.accel_enabled has no effect while held_repeat.enabled is false",
-		)
-	}
 
 	// Logged as well as reported, because a hot reload has no one to print to:
 	// the CLI shows these to whoever runs `neru config validate`, and the log
@@ -472,23 +478,35 @@ func (s *Service) validateNestedHotkeys(raw map[string]any) *config.LoadResult {
 	return nil
 }
 
-// applyOverrideFile layers the file `neru config set` writes over the config,
-// so a runtime change outlives a restart. The result is validated again: a
-// field that is fine alone can still contradict one the config file set.
-func (s *Service) applyOverrideFile(cfg *config.Config, configPath string) error {
+// overrideFileToLayer names the file `neru config set` writes, or "" when there
+// is none to layer: it exists only once a runtime change has been persisted.
+func overrideFileToLayer(configPath string) string {
 	overridePath := OverridePath(configPath)
 	if overridePath == "" {
-		return nil
+		return ""
 	}
 
-	// Optional: it exists only once `neru config set` has written one.
 	overrideStat, statErr := os.Stat(overridePath)
 
 	layerable := statErr == nil && !overrideStat.IsDir()
 	if !layerable {
-		return nil
+		return ""
 	}
 
+	return overridePath
+}
+
+// applyOverrideFile layers the file `neru config set` writes over the config,
+// so a runtime change outlives a restart. The result is validated again: a
+// field that is fine alone can still contradict one the config file set.
+//
+// What it collects into warnings is the whole reading of the overridden config,
+// so the caller replaces its own with it rather than adding to it.
+func (s *Service) applyOverrideFile(
+	cfg *config.Config,
+	overridePath string,
+	warnings *config.Warnings,
+) error {
 	s.logger.Info("Loading config overrides from", zap.String("path", overridePath))
 
 	_, decodeErr := toml.DecodeFile(overridePath, cfg)
@@ -504,7 +522,7 @@ func (s *Service) applyOverrideFile(cfg *config.Config, configPath string) error
 
 	cfg.ResolveThemeDefaults()
 
-	validateErr := cfg.Validate()
+	validateErr := cfg.ValidateWithWarnings(warnings)
 	if validateErr != nil {
 		wrapped := derrors.WrapConfigFailed(validateErr, "validate configuration with overrides")
 

--- a/internal/config/loader/load_warnings_test.go
+++ b/internal/config/loader/load_warnings_test.go
@@ -1,0 +1,187 @@
+package loader_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/config/loader"
+)
+
+// accelInertWarning is what a configuration that turns acceleration on without
+// the repeat it would scale is told.
+const accelInertWarning = "held_repeat.accel_enabled has no effect while held_repeat.enabled is false"
+
+// TestLoadWithValidation_ReportsAnInertAccelSetting pins the whole path the
+// warnings tier exists for: the file loads, the setting stays, and the reason
+// it will do nothing rides out on the result so `neru config validate` can
+// print it (ADR 0002, ADR 0006).
+func TestLoadWithValidation_ReportsAnInertAccelSetting(t *testing.T) {
+	result, logs := loadWithObservedLogger(t, `
+[held_repeat]
+enabled = false
+accel_enabled = true
+`, "")
+
+	if result.ValidationError != nil {
+		t.Fatalf("an inert setting was refused: %v", result.ValidationError)
+	}
+
+	if !slices.Contains(result.Warnings, accelInertWarning) {
+		t.Errorf("result.Warnings = %q, want it to contain %q", result.Warnings, accelInertWarning)
+	}
+
+	// The setting the user wrote survives: a warning reports, it does not undo.
+	if !result.Config.HeldRepeat.AccelEnabled {
+		t.Error("held_repeat.accel_enabled was cleared, want it left as written")
+	}
+
+	// Said once. The daemon logs everything on the result, so a check that also
+	// logs on its own would say it twice to whoever reads the log.
+	if got := countLogged(logs, accelInertWarning); got != 1 {
+		t.Errorf("the warning was logged %d times, want exactly 1", got)
+	}
+}
+
+// TestLoadWithValidation_ReadsAnInertAccelSettingAfterOverrides pins that the
+// reading is taken from the configuration the daemon will run on. `neru config
+// set held_repeat.enabled false` writes an override, and that alone is enough
+// to make an accel_enabled the user wrote months ago inert.
+func TestLoadWithValidation_ReadsAnInertAccelSettingAfterOverrides(t *testing.T) {
+	result, logs := loadWithObservedLogger(t, `
+[held_repeat]
+enabled = true
+accel_enabled = true
+`, `
+[held_repeat]
+enabled = false
+`)
+
+	if result.ValidationError != nil {
+		t.Fatalf("an inert setting was refused: %v", result.ValidationError)
+	}
+
+	if !slices.Contains(result.Warnings, accelInertWarning) {
+		t.Errorf("result.Warnings = %q, want it to contain %q", result.Warnings, accelInertWarning)
+	}
+
+	if got := countLogged(logs, accelInertWarning); got != 1 {
+		t.Errorf("the warning was logged %d times, want exactly 1", got)
+	}
+}
+
+// TestLoadWithValidation_AnOverrideAnswersAnInertAccelSetting is why the second
+// reading replaces the first rather than adding to it. Turning held-key repeat
+// back on is the answer to the warning, so a merge would leave it standing and
+// `neru config validate` would report a problem the user had just fixed.
+func TestLoadWithValidation_AnOverrideAnswersAnInertAccelSetting(t *testing.T) {
+	result, logs := loadWithObservedLogger(t, `
+[held_repeat]
+enabled = false
+accel_enabled = true
+`, `
+[held_repeat]
+enabled = true
+`)
+
+	if result.ValidationError != nil {
+		t.Fatalf("the config was refused: %v", result.ValidationError)
+	}
+
+	if slices.Contains(result.Warnings, accelInertWarning) {
+		t.Errorf("result.Warnings = %q, want the override to have answered it", result.Warnings)
+	}
+
+	if got := countLogged(logs, accelInertWarning); got != 0 {
+		t.Errorf("the answered warning was logged %d times, want none", got)
+	}
+}
+
+// TestLoadWithValidation_RereadsWarningsAfterAnOverride pins the other side of
+// that replacement: an override answers only what it touches, so a warning the
+// config file earned must be read again and still be there.
+func TestLoadWithValidation_RereadsWarningsAfterAnOverride(t *testing.T) {
+	result, _ := loadWithObservedLogger(t, `
+[hotkeys]
+"Primary+Shift+J" = "hints --repeat"
+`, `
+[hints.ui]
+font_size = 30
+`)
+
+	if result.ValidationError != nil {
+		t.Fatalf("the config was refused: %v", result.ValidationError)
+	}
+
+	want := "hotkeys.Primary+Shift+J: --repeat requires --action"
+	if !slices.Contains(result.Warnings, want) {
+		t.Errorf("result.Warnings = %q, want it to contain %q", result.Warnings, want)
+	}
+}
+
+// loadWithObservedLogger writes a config file, and an override file when one is
+// given, then loads them the way the daemon does with a logger that records.
+func loadWithObservedLogger(
+	t *testing.T,
+	configTOML, overrideTOML string,
+) (*config.LoadResult, *observer.ObservedLogs) {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	writeErr := os.WriteFile(path, []byte(configTOML), 0o600)
+	if writeErr != nil {
+		t.Fatalf("WriteFile: %v", writeErr)
+	}
+
+	if overrideTOML != "" {
+		overrideErr := os.WriteFile(
+			filepath.Join(dir, "config.override.toml"),
+			[]byte(overrideTOML),
+			0o600,
+		)
+		if overrideErr != nil {
+			t.Fatalf("WriteFile override: %v", overrideErr)
+		}
+	}
+
+	core, logs := observer.New(zap.WarnLevel)
+
+	result := loader.NewService(nil, path, zap.New(core), nil).LoadWithValidation(path)
+	if result == nil || result.Config == nil {
+		t.Fatalf("LoadWithValidation returned no config")
+	}
+
+	return result, logs
+}
+
+// countLogged reports how many entries mention text, in the message or in any
+// of its fields, so a check that logs on its own is not hidden by wording.
+func countLogged(logs *observer.ObservedLogs, text string) int {
+	count := 0
+
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, text) {
+			count++
+
+			continue
+		}
+
+		for _, field := range entry.Context {
+			if strings.Contains(field.String, text) {
+				count++
+
+				break
+			}
+		}
+	}
+
+	return count
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -115,7 +115,7 @@ func (c *Config) ValidateWithWarnings(warnings *Warnings) error {
 	}
 
 	// Validate held-key repeat settings
-	err = c.ValidateHeldRepeat()
+	err = c.ValidateHeldRepeat(warnings)
 	if err != nil {
 		return err
 	}

--- a/internal/config/validators_boundary_test.go
+++ b/internal/config/validators_boundary_test.go
@@ -152,7 +152,9 @@ func assertConfigValid(t *testing.T, cfg *config.Config, what string) {
 		"ValidateMouseAction":     (*config.Config).ValidateMouseAction,
 		"ValidateSmoothCursor":    (*config.Config).ValidateSmoothCursor,
 		"ValidateSmoothScroll":    (*config.Config).ValidateSmoothScroll,
-		"ValidateHeldRepeat":      (*config.Config).ValidateHeldRepeat,
+		// Warnings are not what this asserts: the sink is nil so only a refusal
+		// can fail the case.
+		"ValidateHeldRepeat": func(c *config.Config) error { return c.ValidateHeldRepeat(nil) },
 	}
 
 	for name, validate := range validators {

--- a/internal/config/validators_held_repeat_test.go
+++ b/internal/config/validators_held_repeat_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"math"
+	"slices"
 	"testing"
 	"time"
 
@@ -11,7 +12,7 @@ import (
 func TestConfigValidateHeldRepeat_AccelDefaults(t *testing.T) {
 	cfg := config.DefaultConfig()
 
-	err := cfg.ValidateHeldRepeat()
+	err := cfg.ValidateHeldRepeat(nil)
 	if err != nil {
 		t.Fatalf("ValidateHeldRepeat() unexpected error: %v", err)
 	}
@@ -84,11 +85,57 @@ func TestConfigValidateHeldRepeat_AccelInvalid(t *testing.T) {
 			cfg := config.DefaultConfig()
 			tt.mutate(cfg)
 
-			err := cfg.ValidateHeldRepeat()
+			err := cfg.ValidateHeldRepeat(nil)
 			if err == nil {
 				t.Error("ValidateHeldRepeat() expected error, got nil")
 			}
 		})
+	}
+}
+
+// TestConfigValidateHeldRepeat_AccelWithoutRepeatWarns pins which tier the
+// cross-field rule sits in. Acceleration only ever scales a repeat, so turning
+// it on without repeat itself does nothing — but refusing the file over it
+// would replace every other setting in it with the defaults (ADR 0002), and
+// reporting it to the log alone would hide it from `neru config validate`,
+// which is the command someone runs to find exactly this (ADR 0006).
+func TestConfigValidateHeldRepeat_AccelWithoutRepeatWarns(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.HeldRepeat.Enabled = false
+	cfg.HeldRepeat.AccelEnabled = true
+
+	warnings := &config.Warnings{}
+
+	err := cfg.ValidateWithWarnings(warnings)
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() refused a configuration that loads: %v", err)
+	}
+
+	want := []string{
+		"held_repeat.accel_enabled has no effect while held_repeat.enabled is false",
+	}
+
+	if got := warnings.Messages(); !slices.Equal(got, want) {
+		t.Errorf("warnings = %q, want %q", got, want)
+	}
+}
+
+// TestConfigValidateHeldRepeat_AccelWithRepeatIsSilent is the other half: the
+// warning names a combination, so it must not fire on the one that works.
+func TestConfigValidateHeldRepeat_AccelWithRepeatIsSilent(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.HeldRepeat.Enabled = true
+	cfg.HeldRepeat.AccelEnabled = true
+
+	warnings := &config.Warnings{}
+
+	err := cfg.ValidateWithWarnings(warnings)
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() refused the working combination: %v", err)
+	}
+
+	if got := warnings.Messages(); len(got) > 0 {
+		t.Errorf("warnings = %q, want none", got)
 	}
 }
 

--- a/internal/config/validators_pointer.go
+++ b/internal/config/validators_pointer.go
@@ -86,8 +86,18 @@ func (c *Config) ValidateSmoothScroll() error {
 	return nil
 }
 
-// ValidateHeldRepeat validates held-key repeat settings.
-func (c *Config) ValidateHeldRepeat() error {
+// ValidateHeldRepeat validates held-key repeat settings, collecting into
+// warnings the ones that load and will not do anything.
+//
+// The split is ADR 0002's. A value out of range could not have run at all, so
+// it is refused. A setting that is valid on its own and inert in context —
+// acceleration turned on while the repeat it would scale is off — is left
+// loading and reported, because refusing it would stop someone switching
+// held-key repeat off without also unwinding every setting beneath it.
+//
+// The report goes through the sink rather than the log so it reaches
+// `neru config validate`; see [Warnings] for why the two are told apart.
+func (c *Config) ValidateHeldRepeat(warnings *Warnings) error {
 	if c.HeldRepeat.InitialDelay < 0 {
 		return derrors.New(derrors.CodeInvalidConfig, "held_repeat.initial_delay_ms must be >= 0")
 	}
@@ -127,6 +137,12 @@ func (c *Config) ValidateHeldRepeat() error {
 					string(action.NameMoveMouseRelative)+", got: "+target,
 			)
 		}
+	}
+
+	if c.HeldRepeat.AccelEnabled && !c.HeldRepeat.Enabled {
+		warnings.Addf(
+			"held_repeat.accel_enabled has no effect while held_repeat.enabled is false",
+		)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

This PR fixes a configuration mistake that Neru noticed but never told you
about. Turning on held-key repeat acceleration while held-key repeat itself is
off does nothing — acceleration only ever scales a repeat — and until now that
was reported to the daemon log alone, so `neru config validate` printed
"Configuration is valid" and moved on.

The check now runs as part of validation and travels out with the loaded
configuration, so the CLI prints it as a warning. The wording is unchanged. The
file still loads and the setting is left exactly as written: refusing it would
replace the whole configuration with the defaults over one line that mostly
works, which is the split ADR 0002 draws. It is also still logged, once, for a
daemon that reloaded on its own and has nobody to print to.

One deliberate limitation: `neru config set` itself stays silent. Setting
`held_repeat.enabled = false` that way accepts the change without mentioning the
now-inert `accel_enabled`; you see it on the next `neru config validate` or in
the daemon log on reload.

## Related Issues

Part of #1255 (item 1 of three; items 2 and 3 ship separately).

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no platform-specific code touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no new imports
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port changes
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config surface

No option is added, renamed, removed, or given a new default, and no accepted
value changes. Every configuration that was valid before is valid now.

What changes is what `neru config validate` says about one combination:

```toml
[held_repeat]
enabled = false
accel_enabled = true
```

Before: `Configuration is valid`. After:

```
Configuration is valid, with warnings:

  held_repeat.accel_enabled has no effect while held_repeat.enabled is false

These parts of the configuration load and will not take effect.
```

`neru config validate` still exits 0 — a warning is not a refusal. Anyone
scripting against its output should know it can now print this block for a
configuration it previously called clean.

`docs/CONFIGURATION.md` records the combination and says it is warned about
rather than rejected.

## Additional Context

The rule this restores is the one ADR 0006 pinned: a cross-field check a user
could act on rides out on the load result, not the log. This was the first such
rule added after ADR 0002 built that tier, and it bypassed it.

Two things beyond the one-line move are worth a look:

- **The warning is read after `neru config set` overrides are layered on, not
  before.** That is where the old check ran, so keeping it there avoids a
  regression: `neru config set held_repeat.enabled false` is enough on its own
  to make an `accel_enabled` written months ago inert. The override pass now
  validates with warnings collected, and its reading *replaces* the first
  pass's rather than adding to it — otherwise `neru config set
  held_repeat.enabled true` would leave a warning standing for a problem it had
  just fixed. Both directions are covered by tests. This works because every
  warning originates in `ValidateWithWarnings`, which both passes run in full;
  the comment at the call site says so, because a warning raised anywhere else
  would need re-raising there.
- **The held-repeat validator now takes the warnings sink**, the way the mode
  command validator already did. Its existing refusals are untouched; callers
  that only care about refusals pass nil, as before.

`docs/adr/0006-config-options-get-guardrails-not-generation.md` describes this
gap in the present tense, with line numbers into the old code. Left alone on
purpose — ADRs in this repo record a decision at a point in time and are added
rather than amended — but a reader hitting that paragraph after this lands will
find the code has moved on.
