### PR TITLE
refactor(config): declare the grid row and column label defaults explicitly

### DIFF
--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -511,6 +511,14 @@ func defaultGrid() GridConfig {
 
 		Characters:   "abcdefghijklmnpqrstuvwxyz",
 		SublayerKeys: "abcdefghijklmnpqrstuvwxyz",
+
+		// Empty is the meaning, not a missing default: "" tells the grid to
+		// infer its row and column labels from the characters it is drawn
+		// with, so shipping a value here would take that inference away
+		// from everyone who only sets characters.
+		RowLabels: "",
+		ColLabels: "",
+
 		Hotkeys: map[string]StringOrStringArray{
 			KeyDisplayEscape:    {CmdIdle},
 			"`":                 {CmdToggleCursorFollowSelection},


### PR DESCRIPTION
## Description

This PR gives `grid.row_labels` and `grid.col_labels` the explicit defaults they
were missing. Both options were declared in the config schema and then never
mentioned again anywhere in the config package — no default, no platform
override, no validator — so they relied on Go's zero value rather than on a
stated one.

Nothing changes about what loads. `""` is already what those options are when a
user does not set them, and it stays `""`. What changes is that the answer is
now written down where the rest of the grid defaults live, together with a note
recording that `""` is the meaning and not an oversight: it tells the grid to
infer its row and column labels from the characters it is drawn with. Today
someone asking "what is `grid.row_labels` when I leave it out?" has to find that
out by reading a consumer package.

This is deliberately a declaration fix only. Moving the inference itself into
the config layer is a real behaviour change and belongs to #1258.

## Related Issues

Part of #1255 (item 2). Items 1 and 3 of that issue land separately, so this
does not close it.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no OS-specific files touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no imports added
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or platform capability involved
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, the produced
      configuration is byte-identical before and after, so there is no new
      behaviour a test could distinguish
- [x] Documentation updated (if applicable) — N/A, `docs/CONFIGURATION.md`
      already documents both options with default `""`, and this makes the code
      agree with it
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Configuration surface

No option is added, renamed or removed, and every existing config file keeps
working unchanged.

| Option | Type | Default | Meaning of the default |
| --- | --- | --- | --- |
| `grid.row_labels` | string | `""` (unchanged) | infer row labels from the grid characters |
| `grid.col_labels` | string | `""` (unchanged) | infer column labels from the grid characters |

## Additional Context

`docs/adr/0006-config-options-get-guardrails-not-generation.md` names these two
options as the one confirmed defect behind its explicit-default guardrail: the
option chain in `internal/config/AGENTS.md` says every field gets an explicit
default, and these two were the exception.

Two adjacent gaps are knowingly left alone. Neither option appears in the
`configs/` examples — that is one of the four cosmetic example gaps ADR 0006
measured, and it belongs with the guardrail tests in #1256. And the inference
itself still lives in a consumer rather than in config, which is #1258.
