### PR TITLE
test(config): run the config loader package in the foundation test slice

### DIFF
--- a/justfile
+++ b/justfile
@@ -193,7 +193,7 @@ test-unit:
 # prints the set that currently qualifies.
 test-foundation:
     @echo "Running cross-platform foundation tests..."
-    go test ./internal/config \
+    go test ./internal/config ./internal/config/loader \
         ./internal/app/components ./internal/app/components/scroll \
         ./internal/app/services ./internal/app/services/modeindicator \
         ./internal/app/services/stickyindicator \
@@ -205,7 +205,7 @@ test-foundation:
         ./internal/adapter/logger \
         ./internal/adapter/platform/mousestate \
         ./internal/ports ./internal/ports/mocks \
-        ./internal/app/render ./internal/domain/geometry
+        ./internal/domain/geometry
     @echo "✓ Cross-platform foundation tests passed"
 
 # Print the packages that contain no platform-tagged source, i.e. the set


### PR DESCRIPTION
## Description

This PR adds the config loader package to `just test-foundation`, the documented fast check for config work. That slice was silently skipping the loader — the hot-reload, persistence and set-field logic — even though the package contains no platform-tagged source and `just list-foundation-packages` already reported it as eligible. The list is hand-kept, and it had drifted.

This PR also removes a stale entry for a package that was deleted in #1221 without the recipe being updated. That entry meant `just test-foundation` failed outright with a missing-directory error, on `main`, before this change. `just ci` runs a different test profile and never invokes `test-foundation`, which is why CI stayed green while the recipe was broken. Removing the dead entry is what lets the recipe pass, so it is required by this ticket's own acceptance criterion rather than incidental cleanup — but it is a logically separate fix, and reviewers should look at it as one.

No shipped code changes, and no test was added or altered — this only changes which existing packages the recipe runs.

## Related Issues

Closes #1255

This is the third and last of the three items in #1255. Items 1 and 2 shipped separately as #1260 and #1261. Closing #1255 unblocks #1256 and #1258.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no source files change.
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no imports change.
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or adapter changes.
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, no behavior changes; this changes which existing packages a recipe runs.
- [x] Documentation updated (if applicable) — N/A, no document enumerates the foundation package set; the justfile recipe is its only home.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

`test` is hidden from the changelog, which is the honest outcome here — nothing user-facing changes.

Verified before and after: `just list-foundation-packages` lists the loader package as eligible, and `just test-foundation` now runs it and passes. `just ci` exited 0 in this worktree.

Diffing the eligible set against the recipe turned up nine other genuinely tag-free packages that `test-foundation` does not list: the overlay badge renderer, held-repeat, the IPC controller, keybinding, the indicator and virtual-pointer services, the key vocabulary, mode commands, and the flag reference. They are deliberately **not** added here — that is beyond this ticket and worth its own issue. Note that `just list-foundation-packages` also reports several false positives, because it detects platform-specific code by filename suffix only: packages that are platform-specific by directory, or gated by a file-level `//go:build !darwin` constraint, still look eligible to it. That heuristic gap may itself be worth a follow-up.
