### PR TITLE
test(config): fail the build when an option has no example line

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -77,6 +77,10 @@ include_stage_manager_hints = false
 include_pip_hints = false
 include_screen_capture_hints = false
 detect_mission_control = false
+# Actions to run when Mission Control opens and closes. Left commented out
+# because they have no default: an empty value here would claim one.
+# on_mission_control_activated = "idle"     # A single action, or an array of them
+# on_mission_control_deactivated = ["hints"]
 clickable_roles = [
     ## Semantic role names. They resolve to each platform's native
     ## accessibility vocabulary, so this list works on macOS, Linux and Windows.
@@ -174,6 +178,8 @@ generic_clickable_min_confidence = 0.5       # Minimum confidence for generic cl
 enabled = true
 characters = "abcdefghijklmnpqrstuvwxyz"    # Primary grid labels
 sublayer_keys = "abcdefghijklmnpqrstuvwxyz" # Subgrid labels (fallback to characters)
+row_labels = ""                             # Custom row labels (empty = infer from characters)
+col_labels = ""                             # Custom column labels (empty = infer from characters)
 live_match_update = true                    # Highlight cells as you type
 hide_unmatched = true                       # Hide non-matching cells
 prewarm_enabled = true                      # Pre-compute grid on startup (~1.5MB RAM)

--- a/configs/embed.go
+++ b/configs/embed.go
@@ -6,3 +6,19 @@ import _ "embed"
 //
 //go:embed default-config.toml
 var DefaultConfig []byte
+
+// ShippedExamples are the configs the project publishes under configs/.
+//
+// They are listed rather than globbed because the directory is also a working
+// area: a local config kept there for testing is not a project artifact, and
+// its problems are not this suite's business. Adding an example here is the
+// deliberate step that puts it under test.
+//
+// Only default-config.toml is embedded, through DefaultConfig above; the rest
+// are read from disk by the tests that check them.
+var ShippedExamples = []string{
+	"default-config.toml",
+	"grid-only-config.toml",
+	"hints-only-config.toml",
+	"recursive-grid-only-config.toml",
+}

--- a/internal/architecture/config_example_test.go
+++ b/internal/architecture/config_example_test.go
@@ -1,0 +1,492 @@
+package architecture_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/y3owk1n/neru/configs"
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// defaultExample is the one shipped config meant to show every option. The
+// other three demonstrate a single mode and are deliberately partial, so only
+// this one is held to the completeness rule.
+const defaultExample = "default-config.toml"
+
+// Why an option can be missing from the example, in the order the rules apply.
+const (
+	// A config.Color is written as one value; its light/dark leaves are what
+	// ResolveThemeDefaults() fills in from the theme palette.
+	exemptColorLeaf = "leaf beneath a config.Color field"
+	// A collection that ships empty has nothing to show. Writing it out would
+	// put a bare [] in the example and assert nothing.
+	exemptEmptyCollection = "collection option that is empty by default"
+	// The same rule reaching the keys of a repeated table nobody ships entries
+	// for. This is what exempts the app_configs and layers sub-fields — the
+	// bulk of the legitimate absences — so it is named rather than folded into
+	// the reason above, which is untrue of a leaf.
+	exemptInsideEmptyCollection = "sub-field of a collection option that is empty by default"
+)
+
+// exemptedOptions is the named allowlist: an option with no example line and
+// no structural reason to lack one. It ships empty on purpose, so that the
+// first entry is a decision someone writes a reason for rather than a line
+// appended to a list that was never empty.
+//
+// TestConfigExampleExemptionsStayHonest fails on an entry that stopped being
+// needed, so this list can only shrink.
+var exemptedOptions = map[string]string{}
+
+// minSchemaOptions guards against a vacuous pass. The walk below finds roughly
+// 350 leaf options today; a reflection bug that returned none would satisfy
+// every assertion in this file without anyone noticing.
+const minSchemaOptions = 200
+
+// colorType is the named struct the by-type exemption keys on. Color has
+// exactly Light and Dark (internal/config/color.go), so matching the type
+// reaches those two leaves and nothing else — ThemeConfig.Light and .Dark are
+// ThemePalette, and stay under the normal rule. TestConfigExampleExemptions-
+// StayHonest pins that shape, because a third leaf would widen the exemption
+// without anyone deciding it should.
+var colorType = reflect.TypeFor[config.Color]()
+
+// colorLeaves are the two names the by-type exemption skips.
+var colorLeaves = []string{"light", "dark"}
+
+// stringOrArrayType is a slice in Go and one value in TOML: it unmarshals from
+// a bare string as readily as from an array (internal/config/keys.go). The
+// by-kind exemption is about collections, and this is not one — a nil default
+// means the option has no default, not that it ships empty.
+var stringOrArrayType = reflect.TypeFor[config.StringOrStringArray]()
+
+// bareKey matches an unquoted TOML key, the form every schema option takes.
+// Quoted keys belong to the hotkey and macro tables, whose vocabulary is the
+// user's rather than the schema's.
+var bareKey = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
+
+// configOption is one leaf of the schema, addressed the way a user writes it.
+type configOption struct {
+	path string
+	// exemption is why the option needs no example line, or "" when it needs one.
+	exemption string
+}
+
+// configSchema is config.Config reflected into TOML terms.
+type configSchema struct {
+	t       *testing.T
+	options []configOption
+	// known holds every path a shipped example may legitimately write,
+	// intermediate tables included.
+	known map[string]bool
+	// opaque holds the prefixes whose children the user names rather than the
+	// schema: the hotkey tables and the macro table.
+	opaque []string
+}
+
+// TestConfigOptionsAppearInTheDefaultExample pins the example TOML to the
+// schema. That file is what a user copies, so an option missing from it is one
+// most users never learn exists — and forgetting the line failed nothing,
+// because TOML has no opinion about the keys a file leaves out.
+//
+// The exemption rule is the whole design here. 161 of the 165 absences on the
+// day this landed were correct, so a naive assertion would be 97% false
+// positives; see docs/adr/0006-config-options-get-guardrails-not-generation.md.
+func TestConfigOptionsAppearInTheDefaultExample(t *testing.T) {
+	schema := reflectConfigSchema(t)
+	present := defaultExampleKeyPaths(t)
+
+	for _, option := range schema.options {
+		// Rules 1 and 2, structural, applied during the walk.
+		if option.exemption != "" {
+			continue
+		}
+
+		// Rule 3, named.
+		if _, ok := exemptedOptions[option.path]; ok {
+			continue
+		}
+
+		if present[option.path] {
+			continue
+		}
+
+		t.Errorf(
+			"config option %q has no line in configs/%s; add one — commented out "+
+				"if the option has no default, since an uncommented empty value "+
+				"asserts a default that does not exist",
+			option.path, defaultExample,
+		)
+	}
+}
+
+// TestShippedExamplesWriteOnlySchemaKeys catches the drift running the other
+// way. TOML decoding ignores a key the schema does not have, silently, so a
+// misspelled key in an example is a dead line that looks like it works — to
+// the reviewer, and then to every user who copies the file.
+func TestShippedExamplesWriteOnlySchemaKeys(t *testing.T) {
+	schema := reflectConfigSchema(t)
+	root := findRepoRoot(t)
+
+	for _, name := range configs.ShippedExamples {
+		t.Run(name, func(t *testing.T) {
+			written := decodedKeyPaths(t, filepath.Join(root, "configs", name), schema)
+
+			for _, path := range written {
+				if schema.known[path] {
+					continue
+				}
+
+				t.Errorf(
+					"configs/%s writes %q, which the config schema has no key for; "+
+						"the decoder drops it silently, so the line does nothing",
+					name, path,
+				)
+			}
+		})
+	}
+}
+
+// TestConfigExampleExemptionsStayHonest keeps the exemptions from outliving
+// what they describe. The by-kind rule needs no companion — it is recomputed
+// from the defaults on every run, so a collection that gains a non-empty
+// default stops being exempt by itself. The other two are claims about the
+// code, and claims rot.
+func TestConfigExampleExemptionsStayHonest(t *testing.T) {
+	schema := reflectConfigSchema(t)
+	present := defaultExampleKeyPaths(t)
+
+	// The by-type rule skips every leaf beneath a config.Color. That is only
+	// precise while Color is exactly these two leaves.
+	var leaves []string
+
+	for field := range colorType.Fields() {
+		name, _ := tomlFieldName(t, colorType, field)
+		leaves = append(leaves, name)
+	}
+
+	if !slices.Equal(leaves, colorLeaves) {
+		t.Errorf(
+			"config.Color now writes %v, not %v; the by-type exemption skips "+
+				"every leaf beneath a Color field, so a new one would be exempted "+
+				"without anyone deciding it should be",
+			leaves, colorLeaves,
+		)
+	}
+
+	// The named allowlist can only shrink.
+	isOption := make(map[string]bool, len(schema.options))
+	for _, option := range schema.options {
+		isOption[option.path] = true
+	}
+
+	for path, reason := range exemptedOptions {
+		switch {
+		case !isOption[path]:
+			t.Errorf(
+				"exemptedOptions names %q, which is not a config option; "+
+					"drop the entry (%s)",
+				path, reason,
+			)
+		case present[path]:
+			t.Errorf(
+				"exemptedOptions names %q, which configs/%s now writes; "+
+					"drop the entry (%s)",
+				path, defaultExample, reason,
+			)
+		}
+	}
+}
+
+// reflectConfigSchema walks config.Config against its defaults. The defaults
+// are needed because the second exemption asks whether a collection ships
+// empty, which the type alone cannot answer.
+func reflectConfigSchema(t *testing.T) *configSchema {
+	t.Helper()
+
+	defaults := config.DefaultConfig()
+	schema := &configSchema{t: t, known: make(map[string]bool)}
+
+	value := reflect.ValueOf(*defaults)
+	schema.walkStruct(value.Type(), value, "", "")
+
+	if len(schema.options) < minSchemaOptions {
+		t.Fatalf(
+			"reflected only %d config options, expected at least %d; "+
+				"the walk is broken and every check here would pass vacuously",
+			len(schema.options), minSchemaOptions,
+		)
+	}
+
+	return schema
+}
+
+func (s *configSchema) walkStruct(typ reflect.Type, val reflect.Value, prefix, exemption string) {
+	for index := range typ.NumField() {
+		field := typ.Field(index)
+		if !field.IsExported() {
+			continue
+		}
+
+		name, freeForm := tomlFieldName(s.t, typ, field)
+		path := joinPath(prefix, name)
+
+		s.known[path] = true
+
+		if freeForm {
+			// The struct decoder never sees these — internal/config/loader/
+			// load.go reads them off the raw map, because their keys are the
+			// key combinations the user invents. Nothing below is a schema path.
+			s.opaque = append(s.opaque, path)
+
+			continue
+		}
+
+		fieldVal := reflect.Value{}
+		if val.IsValid() {
+			fieldVal = val.Field(index)
+		}
+
+		s.walkValue(field.Type, fieldVal, path, exemption)
+	}
+}
+
+func (s *configSchema) walkValue(typ reflect.Type, val reflect.Value, path, exemption string) {
+	switch {
+	case typ.Kind() == reflect.Pointer:
+		// An optional override: its shape is the pointed-to type, and a nil
+		// default says nothing about whether the option needs a line.
+		s.walkValue(typ.Elem(), reflect.Value{}, path, exemption)
+	case typ == colorType:
+		// Exemption 1, structural by type.
+		for _, leaf := range colorLeaves {
+			s.record(joinPath(path, leaf), exemptColorLeaf)
+		}
+	case typ == stringOrArrayType:
+		s.record(path, exemption)
+	case typ.Kind() == reflect.Struct:
+		s.walkStruct(typ, val, path, exemption)
+	case typ.Kind() == reflect.Slice, typ.Kind() == reflect.Map:
+		s.walkCollection(typ, val, path, exemption)
+	default:
+		s.record(path, exemption)
+	}
+}
+
+func (s *configSchema) walkCollection(
+	typ reflect.Type,
+	val reflect.Value,
+	path, exemption string,
+) {
+	// Exemption 2, structural by kind.
+	if exemption == "" && (!val.IsValid() || val.Len() == 0) {
+		exemption = exemptEmptyCollection
+	}
+
+	s.record(path, exemption)
+
+	if typ.Kind() == reflect.Map {
+		// Map keys are the user's, not the schema's.
+		s.opaque = append(s.opaque, path)
+
+		return
+	}
+
+	// A repeated table ([[app_configs]], [[layers]]) still has a declared
+	// shape, and the keys an example writes under it are checked against it.
+	elem := typ.Elem()
+	for elem.Kind() == reflect.Pointer {
+		elem = elem.Elem()
+	}
+
+	if elem.Kind() != reflect.Struct || elem == colorType {
+		return
+	}
+
+	inherited := exemption
+	if inherited == exemptEmptyCollection {
+		inherited = exemptInsideEmptyCollection
+	}
+
+	s.walkStruct(elem, reflect.Value{}, path, inherited)
+}
+
+func (s *configSchema) record(path, exemption string) {
+	s.known[path] = true
+	s.options = append(s.options, configOption{path: path, exemption: exemption})
+}
+
+func (s *configSchema) isOpaque(path string) bool {
+	return slices.ContainsFunc(s.opaque, func(prefix string) bool {
+		return path == prefix || strings.HasPrefix(path, prefix+".")
+	})
+}
+
+func joinPath(prefix, name string) string {
+	if prefix == "" {
+		return name
+	}
+
+	return prefix + "." + name
+}
+
+// tomlFieldName returns the name a field is written under and whether its
+// contents are free-form. A toml:"-" field is still written in a config file —
+// the hotkey tables are the reason the tag is there — so its name comes from
+// the json tag, and everything below it is the user's vocabulary.
+func tomlFieldName(t *testing.T, owner reflect.Type, field reflect.StructField) (string, bool) {
+	t.Helper()
+
+	name, _, _ := strings.Cut(field.Tag.Get("toml"), ",")
+
+	switch name {
+	case "":
+		t.Fatalf(
+			"%s.%s carries no toml tag; the schema cannot name it, so no "+
+				"projection of it can be checked",
+			owner.Name(), field.Name,
+		)
+	case "-":
+		jsonName, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if jsonName == "" || jsonName == "-" {
+			t.Fatalf(
+				"%s.%s is toml:\"-\" with no json name to fall back on",
+				owner.Name(), field.Name,
+			)
+		}
+
+		return jsonName, true
+	}
+
+	return name, false
+}
+
+func defaultExampleKeyPaths(t *testing.T) map[string]bool {
+	t.Helper()
+
+	return exampleKeyPaths(t, filepath.Join(findRepoRoot(t), "configs", defaultExample))
+}
+
+// exampleKeyPaths reads the option paths an example file writes, counting
+// commented-out lines. Some options have no default, and an uncommented empty
+// value would assert one that does not exist, so the example documents their
+// shape with the line commented out.
+//
+// Live and commented lines carry their own table cursor. A commented block
+// names its own table — the macro example does — and letting that header
+// retarget the live keys below it would file a real option under a table it is
+// not in, which fails open: the option reads as absent, or worse, a phantom
+// path marks a genuinely missing one present.
+func exampleKeyPaths(t *testing.T, path string) map[string]bool {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+
+	present := make(map[string]bool)
+	liveTable, commentedTable := "", ""
+
+	for raw := range strings.SplitSeq(string(contents), "\n") {
+		trimmed := strings.TrimSpace(raw)
+		commented := strings.HasPrefix(trimmed, "#")
+		line := strings.TrimSpace(strings.TrimLeft(trimmed, "#"))
+
+		if table, isHeader := tableHeader(line); isHeader {
+			commentedTable = table
+
+			if !commented {
+				liveTable = table
+			}
+
+			continue
+		}
+
+		key, _, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+
+		key = strings.TrimSpace(key)
+		if !bareKey.MatchString(key) {
+			continue
+		}
+
+		table := liveTable
+		if commented {
+			table = commentedTable
+		}
+
+		present[joinPath(table, key)] = true
+	}
+
+	return present
+}
+
+// tableHeader reads a [table] or [[array.of.tables]] header.
+func tableHeader(line string) (string, bool) {
+	switch {
+	case strings.HasPrefix(line, "[["):
+		return strings.TrimSuffix(strings.TrimPrefix(line, "[["), "]]"), true
+	case strings.HasPrefix(line, "["):
+		return strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"), true
+	}
+
+	return "", false
+}
+
+// decodedKeyPaths returns the paths the TOML decoder actually reads out of an
+// example. Going through the decoder rather than the text is the point: these
+// are exactly the keys a user's copy would carry, expanded the same way.
+func decodedKeyPaths(t *testing.T, path string, schema *configSchema) []string {
+	t.Helper()
+
+	var raw map[string]any
+
+	_, err := toml.DecodeFile(path, &raw)
+	if err != nil {
+		t.Fatalf("failed to decode %s: %v", path, err)
+	}
+
+	var paths []string
+
+	collectKeyPaths(raw, "", schema, &paths)
+	slices.Sort(paths)
+
+	return paths
+}
+
+func collectKeyPaths(node map[string]any, prefix string, schema *configSchema, out *[]string) {
+	for key, value := range node {
+		path := joinPath(prefix, key)
+
+		*out = append(*out, path)
+
+		if schema.isOpaque(path) {
+			continue
+		}
+
+		switch typed := value.(type) {
+		case map[string]any:
+			collectKeyPaths(typed, path, schema, out)
+		case []map[string]any:
+			for _, entry := range typed {
+				collectKeyPaths(entry, path, schema, out)
+			}
+		case []any:
+			// A repeated table decodes here when its entries are heterogeneous.
+			for _, entry := range typed {
+				if table, ok := entry.(map[string]any); ok {
+					collectKeyPaths(table, path, schema, out)
+				}
+			}
+		}
+	}
+}

--- a/internal/architecture/doc.go
+++ b/internal/architecture/doc.go
@@ -2,6 +2,7 @@
 // shape honest. Prose rules alone don't hold; each rule here fails `just test`
 // when broken. Layering, the darwin One Rule, platform file slots, port mocks,
 // cgo includes, doc links, comment paths, and test quality each have a file
-// named for them. Exemption lists are self-checking: a companion test fails
+// named for them, as does the pairing between the config schema and the
+// example TOML. Exemption lists are self-checking: a companion test fails
 // when an entry stops being real, so a list can only shrink.
 package architecture

--- a/internal/config/embedded_config_test.go
+++ b/internal/config/embedded_config_test.go
@@ -42,25 +42,12 @@ func TestEmbeddedDefaultConfig_Validates(t *testing.T) {
 	}
 }
 
-// shippedExampleConfigs are the configs the project publishes under configs/.
-//
-// They are listed rather than globbed because the directory is also a working
-// area: a local config kept there for testing is not a project artifact, and
-// its problems are not this suite's business. Adding an example here is the
-// deliberate step that puts it under test.
-var shippedExampleConfigs = []string{
-	"default-config.toml",
-	"grid-only-config.toml",
-	"hints-only-config.toml",
-	"recursive-grid-only-config.toml",
-}
-
 // TestExampleConfigs_Validate loads each shipped config the way the daemon
 // would. These files are copied by users verbatim, so a stale role vocabulary
 // in one of them is shipped breakage that no other test sees — only
 // default-config.toml is embedded and reachable through configs.DefaultConfig.
 func TestExampleConfigs_Validate(t *testing.T) {
-	for _, name := range shippedExampleConfigs {
+	for _, name := range configs.ShippedExamples {
 		path := filepath.Join("..", "..", "configs", name)
 
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR makes a config option that never reached the example file fail CI instead of shipping quietly. Both `internal/config/AGENTS.md` and the `add-config-option` skill told contributors that stale examples break the build; nothing compared the schema to `configs/default-config.toml`, so leaving a key out passed every check. Two guardrails now run in the foundation test slice: one asserts every option in the schema has a line in the default example, the other asserts every key any shipped example writes actually exists in the schema — TOML drops unknown keys silently, so a typo in an example is a dead line that nobody, including the user who copies the file, ever notices.

The first guardrail is mostly its exemption rule. Of the 165 schema leaves absent from the example, 161 are correctly absent: colour leaves the theme resolver fills in, and the sub-fields of repeated tables that ship empty. Two structural rules cover those, applied by type and then by kind; a third, named allowlist ships empty on purpose, so the first entry is a decision someone writes a reason for. Four options were genuinely missing and are now written: the grid's custom row and column labels as live lines, and the two Mission Control hooks commented out, since they have no default and an uncommented empty value would assert one.

The deliberate limitation: only `configs/default-config.toml` is held to completeness. The other three shipped examples demonstrate a single mode each and are meant to be partial, so they are only checked in the other direction.

## Related Issues

Closes #1256

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, `docs/CONFIGURATION.md` already documented all four options; the drift ran one direction only, and reconciling the two guides is #1257
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config changes

Four lines added to `configs/default-config.toml`. No schema, default, or validation change — every existing config file keeps working, and each of these already had a row in `docs/CONFIGURATION.md`.

```toml
[grid]
row_labels = ""    # Custom row labels (empty = infer from characters)
col_labels = ""    # Custom column labels (empty = infer from characters)

[hints]
# on_mission_control_activated = "idle"     # A single action, or an array of them
# on_mission_control_deactivated = ["hints"]
```

The two Mission Control hooks stay commented out because their default is `nil`. Writing them uncommented would claim a default that does not exist.

## Additional Context

**Both guardrails were watched failing before merge**, since a guardrail nobody has seen fail is not known to work:

- Deleting a single key — `hide_unmatched` from `[grid]` — failed the first guardrail with `config option "grid.hide_unmatched" has no line in configs/default-config.toml`. Deleting `border_radius` from `[hints.ui]` failed it the same way. Restored, green.
- Adding a misspelled key — `enable_gcc` under `[grid]` — failed the second with `configs/default-config.toml writes "grid.enable_gcc", which the config schema has no key for; the decoder drops it silently, so the line does nothing`. A typo planted in `grid-only-config.toml` failed that file's subtest too, confirming the check reaches the three examples that are not embedded. Both restored, green.

The reflection walk reproduces the measurement in `docs/adr/0006-config-options-get-guardrails-not-generation.md` exactly: 350 leaf options, 100 of them colour leaves, and — before the four lines were added — exactly the four options the issue names as genuinely missing.

One judgement call worth a look. The by-kind exemption skips collection options that are empty by default, and `StringOrStringArray` is declared as a string slice. Taken literally that would exempt the two Mission Control hooks, and the example lines for them would document rather than pin. The type unmarshals from a bare TOML string as readily as from an array, so it is one value in TOML rather than a collection, and it is carved out of that exemption — which is also what makes the walk's "genuinely missing" set come out as the four the issue counted rather than two.

The shipped-example list moves out of the config test package so both suites read one copy; membership is unchanged, and `author-config.toml` and `test.toml` stay out of it and untouched, as personal artifacts rather than project ones.

Two smaller things a reviewer may want to check. A third test keeps the exemptions honest, in the idiom the guardrail package already documents — it fails if the named allowlist names something that no longer needs exempting, and if the colour type ever grows a third leaf, since the by-type exemption would silently widen with it. And the presence scan tracks commented and live table headers on separate cursors: a commented block names its own table, and letting that header retarget the live keys below it would file a real option under a table it is not in, failing open.
