### PR TITLE
fix(config): keep the grid labelled from the characters it is built with

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -258,6 +258,7 @@ To revert all overrides at once, delete the override file and run `neru config r
 - **`app_configs`**: Per-app overrides can't be set via `config set` (edit `config.toml` directly).
 - **Override file hotkeys**: If you manually edit the override file to add a `[hotkeys]` section, those bindings won't be loaded. The override file is intended for typed field overrides from `config set` — hotkey changes belong in `config.toml`.
 - **Array replacement**: Array fields are replaced wholesale, not appended.
+- **Derived values**: Settings computed from other settings when the config is loaded — the theme colors filled in from `[theme]`, and `grid.row_labels` / `grid.col_labels` inferred from `grid.characters` — are not recomputed by `config set`, because it applies in memory rather than re-reading the file. So `neru config set grid.characters "qwerty"` relabels the grid on the next `neru config reload` or restart, not immediately. The value is persisted either way, so nothing is lost by reloading.
 - **`config reload`**: Re-reading from disk re-applies the override file, but any in-memory-only changes (e.g. before this feature existed) are lost.
 
 ---
@@ -1014,8 +1015,8 @@ Cursor behavior is chosen per invocation: `neru grid --cursor-selection-mode fol
 | `enabled`           | bool   | `true`                        | Enable/disable grid mode    |
 | `characters`        | string | `"abcdefghijklmnpqrstuvwxyz"` | Primary grid labels         |
 | `sublayer_keys`     | string | same as `characters`          | Subgrid labels              |
-| `row_labels`        | string | `""`                          | Custom row labels           |
-| `col_labels`        | string | `""`                          | Custom column labels        |
+| `row_labels`        | string | `""`                          | Custom row labels; empty is resolved at load time to the labels inferred from `characters` |
+| `col_labels`        | string | `""`                          | Custom column labels; empty is resolved the same way as `row_labels`                       |
 | `live_match_update` | bool   | `true`                        | Highlight cells as you type |
 | `hide_unmatched`    | bool   | `true`                        | Hide non-matching cells     |
 | `prewarm_enabled`   | bool   | `true`                        | Pre-compute grid on startup |

--- a/internal/app/components/types.go
+++ b/internal/app/components/types.go
@@ -38,24 +38,16 @@ func (g *GridComponent) UpdateConfig(cfg *config.Config, logger *zap.Logger) {
 			// Recreate grid if characters or labels changed
 			oldGrid := g.Manager.Grid()
 			if oldGrid != nil && cfg.Grid.Characters != "" {
-				// Empty row/column labels in config mean "infer from
-				// characters", which is what NewGridWithLabels does when it
-				// builds the grid. Resolve them the same way before comparing:
-				// the grid stores the inferred labels, so comparing those
-				// against a bare "" would never match and every config reload
-				// would rebuild the grid — discarding in-flight grid input —
-				// even when nothing about the labels changed.
-				newCharacters := strings.ToUpper(cfg.Grid.Characters)
-
-				newRowLabels := newCharacters
-				if cfg.Grid.RowLabels != "" {
-					newRowLabels = strings.ToUpper(cfg.Grid.RowLabels)
-				}
-
-				newColLabels := newCharacters
-				if cfg.Grid.ColLabels != "" {
-					newColLabels = strings.ToUpper(cfg.Grid.ColLabels)
-				}
+				// The config arrives with its labels already resolved to the
+				// ones in use (config.ResolveGridLabels), and the grid stores
+				// the same resolved form, so this is a plain comparison. It
+				// used to infer the labels here, which is the only place that
+				// rule existed — and getting it wrong rebuilt the grid on every
+				// reload, discarding the user's in-flight coordinate input.
+				characters := cfg.GridCharacters()
+				newCharacters := strings.ToUpper(characters)
+				newRowLabels := cfg.Grid.RowLabels
+				newColLabels := cfg.Grid.ColLabels
 
 				charactersChanged := newCharacters != oldGrid.Characters()
 				rowLabelsChanged := newRowLabels != oldGrid.RowLabels()
@@ -67,7 +59,7 @@ func (g *GridComponent) UpdateConfig(cfg *config.Config, logger *zap.Logger) {
 						zap.Bool("rowLabelsChanged", rowLabelsChanged),
 						zap.Bool("colLabelsChanged", colLabelsChanged))
 					newGrid := domainGrid.NewGridWithLabels(
-						cfg.Grid.Characters,
+						characters,
 						cfg.Grid.RowLabels,
 						cfg.Grid.ColLabels,
 						oldGrid.Bounds(),

--- a/internal/app/components/types_test.go
+++ b/internal/app/components/types_test.go
@@ -40,13 +40,17 @@ func newGridComponent(
 }
 
 // gridConfig returns a default config with the grid enabled and the given
-// labels applied.
+// labels applied, resolved the way the loader resolves one before any consumer
+// sees it. UpdateConfig reads the labels rather than inferring them, so a
+// fixture that skipped the resolution would be testing a config the daemon
+// never runs on.
 func gridConfig(characters, rowLabels, colLabels string) *config.Config {
 	cfg := config.DefaultConfig()
 	cfg.Grid.Enabled = true
 	cfg.Grid.Characters = characters
 	cfg.Grid.RowLabels = rowLabels
 	cfg.Grid.ColLabels = colLabels
+	cfg.ResolveGridLabels()
 
 	return cfg
 }
@@ -141,12 +145,12 @@ func TestGridComponent_UpdateConfig_RecreatesGridOnLabelChanges(t *testing.T) {
 // TestGridComponent_UpdateConfig_DefaultConfigReloadKeepsGrid is a regression
 // test for a spurious rebuild on every `neru config reload`.
 //
-// The default config leaves RowLabels and ColLabels empty, meaning "infer from
+// A config file that leaves row_labels and col_labels empty means "infer from
 // characters". The grid stores the *inferred* labels, so comparing them against
 // the bare "" from config never matched and the grid was rebuilt on every
 // reload — throwing away the user's in-flight coordinate input while grid mode
-// was open. The comparison now resolves empty labels the same way the grid
-// constructor does.
+// was open. Since the option is resolved at load time, DefaultConfig() already
+// carries the inferred labels and the comparison is a plain one.
 func TestGridComponent_UpdateConfig_DefaultConfigReloadKeepsGrid(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Grid.Enabled = true

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -15,6 +15,14 @@ import (
 // app-level reconfiguration (component updates, hotkey re-registration, etc.).
 // This mirrors the reload path but operates on the in-memory config rather
 // than re-reading from disk.
+//
+// Derived values are the limit of that mirroring. Normalizing what was typed
+// comes along; re-deriving does not, because a derived value already written
+// over the raw one cannot say whether the user wrote it, and only a read of
+// the whole file can. So `neru config set grid.characters` relabels the grid
+// on the next reload rather than at once, the same way `neru config set
+// theme.*` recolours only then. The change is persisted before either, so a
+// restart is correct; what is stale is this process until it reloads.
 func (a *App) SetConfigField(ctx context.Context, key, value string) error {
 	a.prepareForConfigUpdate()
 
@@ -35,6 +43,10 @@ func (a *App) SetConfigField(ctx context.Context, key, value string) error {
 
 		return setErr
 	}
+
+	// A field change can land on a derived value, and what arrives is the
+	// string the user typed rather than the form the daemon holds it in.
+	newCfg.ResolveGridLabels()
 
 	// Validate the new config.
 	valErr := newCfg.Validate()

--- a/internal/app/ipcctrl/controller_test.go
+++ b/internal/app/ipcctrl/controller_test.go
@@ -393,3 +393,36 @@ func TestIPCController_UpdateConfig(t *testing.T) {
 			newCfg.Hints.Enabled, updatedCfg.Hints.Enabled)
 	}
 }
+
+// TestIPCController_HandleConfigSet_GridLabelsStayResolved pins that a runtime
+// change to the grid labels leaves the config holding the labels in use rather
+// than the string as typed. The config carries the resolved form since the
+// option stopped being inferred by its consumers, and a raw value slipped in
+// here reads as a change on every subsequent reload — rebuilding the grid and
+// discarding whatever coordinate the user was part-way through typing.
+func TestIPCController_HandleConfigSet_GridLabelsStayResolved(t *testing.T) {
+	controller := newTestController()
+
+	ctx := context.Background()
+
+	commandResponse := controller.HandleCommand(ctx, ipc.Command{
+		Action: domain.CommandConfigSet,
+		Args:   []string{"grid.row_labels", "xy"},
+	})
+
+	if !commandResponse.Success {
+		t.Fatalf("Expected success=true, got %v: %s",
+			commandResponse.Success, commandResponse.Message)
+	}
+
+	cfgResp := controller.HandleCommand(ctx, ipc.Command{Action: domain.CommandConfig})
+
+	cfg, ok := cfgResp.Data.(*config.Config)
+	if !ok || cfg == nil {
+		t.Fatal("Failed to read config after set")
+	}
+
+	if cfg.Grid.RowLabels != "XY" {
+		t.Errorf("Expected grid.row_labels=%q, got %q", "XY", cfg.Grid.RowLabels)
+	}
+}

--- a/internal/app/ipcctrl/info_config.go
+++ b/internal/app/ipcctrl/info_config.go
@@ -87,6 +87,10 @@ func (h *InfoHandler) handleConfigSetNoReload(
 		}
 	}
 
+	// A field change can land on a derived value, and what arrives is the
+	// string the user typed rather than the form the daemon holds it in.
+	newCfg.ResolveGridLabels()
+
 	// Skip Validate() here so interdependent fields (e.g. grid_cols + keys)
 	// can be updated incrementally before a final "neru config reload".
 	h.configService.Replace(newCfg)
@@ -187,6 +191,10 @@ func (h *InfoHandler) handleConfigSetInMemory(
 			Code:    ipc.CodeInvalidInput,
 		}
 	}
+
+	// A field change can land on a derived value, and what arrives is the
+	// string the user typed rather than the form the daemon holds it in.
+	newCfg.ResolveGridLabels()
 
 	updateErr := h.configService.Update(newCfg)
 	if updateErr != nil {

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -118,13 +118,8 @@ func (h *handlerState) createGridInstance() *domainGrid.Grid {
 	// Normalize normalizedBounds to window-local coordinates using helper function
 	normalizedBounds := geometry.NormalizeToLocalCoordinates(screenBounds)
 
-	characters := h.config.Grid.Characters
-	if strings.TrimSpace(characters) == "" {
-		characters = h.config.Hints.HintCharacters
-	}
-
 	gridInstance := domainGrid.NewGridWithLabels(
-		characters,
+		h.config.GridCharacters(),
 		h.config.Grid.RowLabels,
 		h.config.Grid.ColLabels,
 		normalizedBounds,
@@ -158,7 +153,7 @@ func (h *handlerState) initializeGridManager(gridInstance *domainGrid.Grid) {
 
 		bounds := image.Rect(0, 0, screenBounds.Dx(), screenBounds.Dy())
 		gridInstance = domainGrid.NewGridWithLabels(
-			h.config.Grid.Characters,
+			h.config.GridCharacters(),
 			h.config.Grid.RowLabels,
 			h.config.Grid.ColLabels,
 			bounds,

--- a/internal/app/modes/grid_labels_test.go
+++ b/internal/app/modes/grid_labels_test.go
@@ -1,0 +1,159 @@
+package modes
+
+import (
+	"context"
+	"image"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/app/components"
+	gridcomponent "github.com/y3owk1n/neru/internal/app/components/grid"
+	"github.com/y3owk1n/neru/internal/config"
+	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
+	portmocks "github.com/y3owk1n/neru/internal/ports/mocks"
+)
+
+// gridLabelHintChars is the hint alphabet these fixtures fall back to, and
+// gridLabelHintLabels the labels a grid built from it carries.
+const (
+	gridLabelHintChars  = "qwerty"
+	gridLabelHintLabels = "QWERTY"
+)
+
+// TestCreateGridInstance_UsesTheResolvedLabels is the invariant the config-side
+// resolution rests on: the labels the config carries have to be the labels the
+// grid is built with. They are resolved from the characters a grid is built
+// from, so a call site that reached for a different character set would draw a
+// grid the configuration does not describe.
+func TestCreateGridInstance_UsesTheResolvedLabels(t *testing.T) {
+	testCases := []struct {
+		name           string
+		gridCharacters string
+		hintCharacters string
+		rowLabels      string
+		colLabels      string
+		wantCharacters string
+	}{
+		{
+			name:           "labels inferred from the grid characters",
+			gridCharacters: "asdf",
+			hintCharacters: gridLabelHintChars,
+			wantCharacters: "ASDF",
+		},
+		{
+			name:           "labels the user configured",
+			gridCharacters: "asdf",
+			hintCharacters: gridLabelHintChars,
+			rowLabels:      "xy",
+			colLabels:      "zw",
+			wantCharacters: "ASDF",
+		},
+		{
+			name:           "labels inferred through the hint-characters fallback",
+			gridCharacters: "",
+			hintCharacters: gridLabelHintChars,
+			wantCharacters: gridLabelHintLabels,
+		},
+		{
+			name:           "labels inferred from a character set too short to label with",
+			gridCharacters: "a",
+			hintCharacters: gridLabelHintChars,
+			wantCharacters: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.Grid.Enabled = true
+			cfg.Grid.Characters = testCase.gridCharacters
+			cfg.Hints.HintCharacters = testCase.hintCharacters
+			cfg.Grid.RowLabels = testCase.rowLabels
+			cfg.Grid.ColLabels = testCase.colLabels
+			cfg.ResolveGridLabels()
+
+			handler := newGridLabelHandler(cfg)
+
+			gridInstance := handler.createGridInstance()
+
+			if got := gridInstance.RowLabels(); got != cfg.Grid.RowLabels {
+				t.Errorf("grid RowLabels() = %q, want config's %q", got, cfg.Grid.RowLabels)
+			}
+
+			if got := gridInstance.ColLabels(); got != cfg.Grid.ColLabels {
+				t.Errorf("grid ColLabels() = %q, want config's %q", got, cfg.Grid.ColLabels)
+			}
+
+			if got := gridInstance.Characters(); got != testCase.wantCharacters {
+				t.Errorf("grid Characters() = %q, want %q", got, testCase.wantCharacters)
+			}
+		})
+	}
+}
+
+// TestInitializeGridManager_FallbackGridUsesTheResolvedLabels covers the
+// defensive branch that builds its own grid when handed none. It reached for
+// grid.characters directly while the path above reached for the hint
+// characters when those were blank, so the two disagreed about what the grid
+// was labeled from — invisible while the labels were inferred at draw time
+// from whichever set was passed, and a wrong grid once they are resolved once.
+func TestInitializeGridManager_FallbackGridUsesTheResolvedLabels(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.Enabled = true
+	cfg.Grid.Characters = ""
+	cfg.Hints.HintCharacters = gridLabelHintChars
+	cfg.Grid.RowLabels = ""
+	cfg.Grid.ColLabels = ""
+	cfg.ResolveGridLabels()
+
+	handler := newGridLabelHandler(cfg)
+
+	handler.initializeGridManager(nil)
+
+	built := handler.grid.Manager.Grid()
+	if built == nil {
+		t.Fatal("initializeGridManager(nil) left the manager without a grid")
+	}
+
+	if got := built.RowLabels(); got != cfg.Grid.RowLabels {
+		t.Errorf("fallback grid RowLabels() = %q, want config's %q", got, cfg.Grid.RowLabels)
+	}
+
+	if got := built.ColLabels(); got != cfg.Grid.ColLabels {
+		t.Errorf("fallback grid ColLabels() = %q, want config's %q", got, cfg.Grid.ColLabels)
+	}
+
+	if got := built.Characters(); got != gridLabelHintLabels {
+		t.Errorf(
+			"fallback grid Characters() = %q, want %q — the same set the labels were "+
+				"resolved from",
+			got, gridLabelHintLabels,
+		)
+	}
+}
+
+// newGridLabelHandler builds the least handler these tests need. The screen
+// has to be a real one: a grid with no area short-circuits to a minimal grid
+// that carries no labels at all, which would pass these assertions vacuously.
+func newGridLabelHandler(cfg *config.Config) *Handler {
+	var gridInstance *domainGrid.Grid
+
+	gridContext := &gridcomponent.Context{}
+	gridContext.SetGridInstance(&gridInstance)
+
+	screen := image.Rect(0, 0, 1920, 1080)
+
+	return newHandlerWithState(handlerState{
+		config: cfg,
+		logger: zap.NewNop(),
+		grid:   &components.GridComponent{Context: gridContext},
+		system: &portmocks.MockSystemPort{
+			ScreenBoundsFunc: func(_ context.Context) (image.Rectangle, error) {
+				return screen, nil
+			},
+		},
+		overlayPort:  &portmocks.MockOverlayPort{},
+		screenBounds: screen,
+	})
+}

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -314,13 +314,8 @@ func (h *handlerState) refreshGridForMonitorMove(targetBounds image.Rectangle) {
 	h.setScreenBounds(targetBounds)
 	normalizedBounds := geometry.NormalizeToLocalCoordinates(targetBounds)
 
-	characters := h.config.Grid.Characters
-	if strings.TrimSpace(characters) == "" {
-		characters = h.config.Hints.HintCharacters
-	}
-
 	gridInstance := domainGrid.NewGridWithLabels(
-		characters,
+		h.config.GridCharacters(),
 		h.config.Grid.RowLabels,
 		h.config.Grid.ColLabels,
 		normalizedBounds,

--- a/internal/config/config_platform.go
+++ b/internal/config/config_platform.go
@@ -5,12 +5,17 @@ func DefaultConfig() *Config {
 	cfg := newDefaultConfig()
 	applyPlatformDefaults(cfg)
 	cfg.ResolveThemeDefaults()
+	cfg.ResolveGridLabels()
 
 	return cfg
 }
 
 // DefaultConfigForDecoding returns the defaults used as the TOML decode
 // target: platform-adjusted, without theme resolution or launcher hotkeys.
+//
+// Leaving the derived values alone is what makes it a decode target. Resolved
+// grid labels here would read as labels the user configured, so the file's own
+// grid.characters would decode over the characters and leave the labels behind.
 func DefaultConfigForDecoding() *Config {
 	cfg := newDefaultConfig()
 	applyPlatformDefaults(cfg)

--- a/internal/config/grid_labels.go
+++ b/internal/config/grid_labels.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"strings"
+
+	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
+)
+
+// GridCharacters is the coordinate character set a grid is actually built
+// from: grid.characters, falling back to hints.hint_characters when it is
+// blank. ValidateGrid refuses a blank grid.characters while grid is enabled,
+// so the fallback is a floor rather than a configuration a user runs on — but
+// it is the floor every grid construction already stood on, and naming it once
+// here is what lets the resolved labels below agree with the grid at every
+// call site rather than at most of them.
+func (c *Config) GridCharacters() string {
+	if strings.TrimSpace(c.Grid.Characters) == "" {
+		return c.Hints.HintCharacters
+	}
+
+	return c.Grid.Characters
+}
+
+// ResolveGridLabels settles grid.row_labels and grid.col_labels to the labels
+// the grid will actually be drawn with, so that reading the option answers the
+// question rather than starting one. An empty value means "infer from
+// characters", and that meaning used to be implemented in a consumer
+// (internal/app/components) where no other reader could see it.
+//
+// It is derived, not defaulted: it has to run after the whole configuration is
+// assembled, because the characters it reads can come from the config file or
+// from the override file layered on top. That is the same reason
+// ResolveThemeDefaults runs where it does, and it is why the declared default
+// in newDefaultConfig() stays the empty string — the empty string is what the
+// user writes, not what the daemon runs on.
+//
+// Running it again is harmless — settled labels settle to themselves — so a
+// runtime field change can re-run it to normalize what was typed. What a
+// second run cannot do is *re-infer*: a settled label is indistinguishable
+// from one the user wrote, so once the labels are filled in, a later change to
+// the characters no longer carries them along. That is why the inferring run
+// has to be the one that sees the whole configuration.
+//
+// It writes to the Config, so it belongs beside the code that assembled it,
+// on a Config no other goroutine can see yet — the mode handler reads these
+// fields under its own lock.
+func (c *Config) ResolveGridLabels() {
+	c.Grid.RowLabels, c.Grid.ColLabels = domainGrid.ResolveLabels(
+		c.GridCharacters(),
+		c.Grid.RowLabels,
+		c.Grid.ColLabels,
+	)
+}

--- a/internal/config/grid_labels_test.go
+++ b/internal/config/grid_labels_test.go
@@ -1,0 +1,91 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// gridLabelHintChars is the hint alphabet the grid falls back to when
+// grid.characters is blank.
+const gridLabelHintChars = "qwerty"
+
+// TestResolveGridLabels pins the answer to "what is grid.row_labels when
+// unset?". Before this resolution existed the answer lived in a consumer, so
+// every other reader had to reimplement it; these cases are the rule itself.
+func TestResolveGridLabels(t *testing.T) {
+	testCases := []struct {
+		name           string
+		gridCharacters string
+		hintCharacters string
+		rowLabels      string
+		colLabels      string
+		wantRowLabels  string
+		wantColLabels  string
+	}{
+		{
+			name:           "unset labels are inferred from the grid characters",
+			gridCharacters: "asdfghjkl",
+			hintCharacters: gridLabelHintChars,
+			wantRowLabels:  "ASDFGHJKL",
+			wantColLabels:  "ASDFGHJKL",
+		},
+		{
+			name:           "configured labels are kept, uppercased",
+			gridCharacters: "asdfghjkl",
+			hintCharacters: gridLabelHintChars,
+			rowLabels:      "abc",
+			colLabels:      "def",
+			wantRowLabels:  "ABC",
+			wantColLabels:  "DEF",
+		},
+		{
+			name:           "one configured label leaves the other inferred",
+			gridCharacters: "asdf",
+			hintCharacters: gridLabelHintChars,
+			rowLabels:      "xy",
+			wantRowLabels:  "XY",
+			wantColLabels:  "ASDF",
+		},
+		{
+			name:           "blank grid characters infer from the hint characters",
+			gridCharacters: "   ",
+			hintCharacters: gridLabelHintChars,
+			wantRowLabels:  "QWERTY",
+			wantColLabels:  "QWERTY",
+		},
+		{
+			name:           "a character set too short to label anything infers a-z",
+			gridCharacters: "a",
+			hintCharacters: gridLabelHintChars,
+			wantRowLabels:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+			wantColLabels:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.Grid.Characters = testCase.gridCharacters
+			cfg.Hints.HintCharacters = testCase.hintCharacters
+			cfg.Grid.RowLabels = testCase.rowLabels
+			cfg.Grid.ColLabels = testCase.colLabels
+
+			cfg.ResolveGridLabels()
+
+			if cfg.Grid.RowLabels != testCase.wantRowLabels {
+				t.Errorf(
+					"Grid.RowLabels = %q, want %q",
+					cfg.Grid.RowLabels, testCase.wantRowLabels,
+				)
+			}
+
+			if cfg.Grid.ColLabels != testCase.wantColLabels {
+				t.Errorf(
+					"Grid.ColLabels = %q, want %q",
+					cfg.Grid.ColLabels, testCase.wantColLabels,
+				)
+			}
+		})
+	}
+}

--- a/internal/config/loader/grid_labels_test.go
+++ b/internal/config/loader/grid_labels_test.go
@@ -1,0 +1,172 @@
+package loader_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/config/loader"
+)
+
+// testGridChars is the character set the fixtures configure, and
+// testGridLabels the labels a grid built from it carries.
+const (
+	testGridChars  = "asdf"
+	testGridLabels = "ASDF"
+)
+
+// gridConfigWithCharacters is a config file that sets nothing but the grid
+// coordinate characters, so the labels a load produces are the derivation
+// under test and not something the file said.
+func gridConfigWithCharacters(characters string) string {
+	return "[grid]\nenabled = true\ncharacters = \"" + characters + "\"\n"
+}
+
+// TestLoadResolvesGridLabels pins that a loaded config answers "what labels is
+// the grid using" itself. The option means "infer from characters" when it is
+// empty, and until this resolution existed that meaning was implemented in a
+// consumer rather than in the config the consumer was handed.
+func TestLoadResolvesGridLabels(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+
+	writeErr := os.WriteFile(configPath, []byte(gridConfigWithCharacters(testGridChars)), 0o600)
+	if writeErr != nil {
+		t.Fatalf("failed to write config: %v", writeErr)
+	}
+
+	service := loader.NewService(config.DefaultConfig(), configPath, zap.NewNop(), nil)
+
+	result := service.LoadWithValidation(configPath)
+	if result.ValidationError != nil {
+		t.Fatalf("load failed: %v", result.ValidationError)
+	}
+
+	if result.Config.Grid.RowLabels != testGridLabels {
+		t.Errorf("Grid.RowLabels = %q, want %q", result.Config.Grid.RowLabels, testGridLabels)
+	}
+
+	if result.Config.Grid.ColLabels != testGridLabels {
+		t.Errorf("Grid.ColLabels = %q, want %q", result.Config.Grid.ColLabels, testGridLabels)
+	}
+}
+
+// TestReloadReresolvesGridLabels is the hazard the resolution introduces. The
+// fallback used to be re-read on every use, so a characters change carried the
+// labels with it for free; settling the labels once at load means a reload
+// that changes characters has to settle them again, or the daemon keeps
+// drawing a grid labeled from a character set the user has replaced.
+func TestReloadReresolvesGridLabels(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+
+	writeErr := os.WriteFile(configPath, []byte(gridConfigWithCharacters(testGridChars)), 0o600)
+	if writeErr != nil {
+		t.Fatalf("failed to write config: %v", writeErr)
+	}
+
+	service := loader.NewService(config.DefaultConfig(), configPath, zap.NewNop(), nil)
+
+	first := service.LoadWithValidation(configPath)
+	if first.ValidationError != nil {
+		t.Fatalf("first load failed: %v", first.ValidationError)
+	}
+
+	if first.Config.Grid.RowLabels != testGridLabels {
+		t.Fatalf("Grid.RowLabels = %q, want %q", first.Config.Grid.RowLabels, testGridLabels)
+	}
+
+	rewriteErr := os.WriteFile(configPath, []byte(gridConfigWithCharacters("qwer")), 0o600)
+	if rewriteErr != nil {
+		t.Fatalf("failed to rewrite config: %v", rewriteErr)
+	}
+
+	second := service.LoadWithValidation(configPath)
+	if second.ValidationError != nil {
+		t.Fatalf("second load failed: %v", second.ValidationError)
+	}
+
+	if second.Config.Grid.RowLabels != "QWER" {
+		t.Errorf(
+			"after reload Grid.RowLabels = %q, want %q",
+			second.Config.Grid.RowLabels, "QWER",
+		)
+	}
+
+	if second.Config.Grid.ColLabels != "QWER" {
+		t.Errorf(
+			"after reload Grid.ColLabels = %q, want %q",
+			second.Config.Grid.ColLabels, "QWER",
+		)
+	}
+}
+
+// TestLoadResolvesGridLabelsAfterOverrides pins the ordering. The override
+// file is layered after the config file is validated, so labels settled before
+// that layer would be settled from characters the daemon does not run on —
+// which is what `neru config set grid.characters` writes.
+func TestLoadResolvesGridLabelsAfterOverrides(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+	overridePath := loader.OverridePath(configPath)
+
+	writeErr := os.WriteFile(configPath, []byte(gridConfigWithCharacters(testGridChars)), 0o600)
+	if writeErr != nil {
+		t.Fatalf("failed to write config: %v", writeErr)
+	}
+
+	overrideErr := os.WriteFile(
+		overridePath,
+		[]byte(gridConfigWithCharacters("zxcv")),
+		0o600,
+	)
+	if overrideErr != nil {
+		t.Fatalf("failed to write override: %v", overrideErr)
+	}
+
+	service := loader.NewService(config.DefaultConfig(), configPath, zap.NewNop(), nil)
+
+	result := service.LoadWithValidation(configPath)
+	if result.ValidationError != nil {
+		t.Fatalf("load failed: %v", result.ValidationError)
+	}
+
+	if result.Config.Grid.RowLabels != "ZXCV" {
+		t.Errorf(
+			"Grid.RowLabels = %q, want %q (the override's characters)",
+			result.Config.Grid.RowLabels, "ZXCV",
+		)
+	}
+}
+
+// TestLoadKeepsConfiguredGridLabels guards the other direction: resolution
+// fills the option in, it does not take it over.
+func TestLoadKeepsConfiguredGridLabels(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+
+	contents := gridConfigWithCharacters(testGridChars) + "row_labels = \"xy\"\n"
+
+	writeErr := os.WriteFile(configPath, []byte(contents), 0o600)
+	if writeErr != nil {
+		t.Fatalf("failed to write config: %v", writeErr)
+	}
+
+	service := loader.NewService(config.DefaultConfig(), configPath, zap.NewNop(), nil)
+
+	result := service.LoadWithValidation(configPath)
+	if result.ValidationError != nil {
+		t.Fatalf("load failed: %v", result.ValidationError)
+	}
+
+	if result.Config.Grid.RowLabels != "XY" {
+		t.Errorf("Grid.RowLabels = %q, want %q", result.Config.Grid.RowLabels, "XY")
+	}
+
+	if result.Config.Grid.ColLabels != testGridLabels {
+		t.Errorf("Grid.ColLabels = %q, want %q", result.Config.Grid.ColLabels, testGridLabels)
+	}
+}

--- a/internal/config/loader/load.go
+++ b/internal/config/loader/load.go
@@ -84,6 +84,11 @@ func (s *Service) LoadWithValidation(path string) *config.LoadResult {
 		warnings = overrideWarnings
 	}
 
+	// After the override layer, because the characters the labels are inferred
+	// from can come from either file, and exactly once, because a resolved
+	// label is indistinguishable from one the user wrote.
+	result.Config.ResolveGridLabels()
+
 	result.Warnings = warnings.Messages()
 
 	// Logged as well as reported, because a hot reload has no one to print to:

--- a/internal/domain/grid/grid.go
+++ b/internal/domain/grid/grid.go
@@ -273,6 +273,22 @@ func newGridAlphabet(characters, rowLabels, colLabels string) gridAlphabet {
 	return gridAlphabet{characters: upper, chars: chars, rowChars: rowChars, colChars: colChars}
 }
 
+// ResolveLabels answers the row and column labels a grid built from these
+// arguments will actually use, so a caller can hold that answer instead of
+// re-deriving it. Empty labels are inferred from characters, which is itself
+// replaced by a-z when it is empty or too short to label anything — that
+// second step is why the answer is worth asking for rather than assuming
+// "empty means characters".
+//
+// Passing the result back into NewGridWithLabels builds the same grid as
+// passing the empty strings did, which is what lets config.ResolveGridLabels
+// settle the option at load time.
+func ResolveLabels(characters, rowLabels, colLabels string) (string, string) {
+	alpha := newGridAlphabet(characters, rowLabels, colLabels)
+
+	return string(alpha.rowChars), string(alpha.colChars)
+}
+
 // newGridFromCells assembles a Grid and its lookup indexes from finished cells.
 func newGridFromCells(alpha gridAlphabet, bounds image.Rectangle, cells []*Cell) *Grid {
 	index := make(map[string]*Cell, len(cells))


### PR DESCRIPTION
## Description

This PR makes the grid's row and column label options answer for themselves. Both are declared as empty strings meaning "infer from the grid characters", but that meaning was implemented in one consumer, so the configuration the rest of the daemon was handed did not say what labels the grid was using — anything else that wanted to know had to reimplement the rule.

The option is now settled where it is declared. A loaded configuration carries the labels the grid is actually drawn with, the consumer that inferred them is gone, and the three places that build a grid all ask the configuration the same question rather than each deciding for itself which character set the labels come from. One of them disagreed with the other two, which was invisible while every construction inferred its own labels and wrong the moment they are settled once.

This changes runtime behaviour, which the two guardrail PRs before it did not. The deliberate limitation: changing the grid characters through `neru config set` relabels the grid on the next reload rather than at once.

## Related Issues

Closes #1258

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no build-tagged file is touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no new import crosses a platform boundary
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability is added
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config surface

No key is added, renamed or removed, and every existing config file keeps working unchanged. What changes is what two existing keys hold once the configuration is loaded:

| Key | Written as | Held as, after this PR |
| --- | --- | --- |
| `grid.row_labels` | `""` (the default) | the labels inferred from `grid.characters`, upper-cased |
| `grid.col_labels` | `""` (the default) | the labels inferred from `grid.characters`, upper-cased |

Writing a value still wins, and is still upper-cased:

```toml
[grid]
characters = "asdfghjkl"   # row_labels and col_labels become "ASDFGHJKL"
row_labels = "xy"          # ...unless written, in which case "XY"
```

Two edge cases stop misbehaving as a result. A `grid.characters` shorter than two characters falls back to the built-in a–z alphabet, and the configuration now reports that alphabet instead of the too-short set. A `grid.characters` of nothing but whitespace no longer rebuilds the grid — discarding in-flight coordinate input — on every reload.

## Potentially breaking

`neru config set grid.characters <value>` no longer relabels an open grid immediately. It applies on the next `neru config reload` or restart. Setting `grid.row_labels` or `grid.col_labels` directly still applies at once.

- **Who this affects**: anyone changing the grid alphabet through `config set` rather than by editing `config.toml`. Editing the file is unaffected — the file watcher reloads, and a reload re-settles the labels.
- **What they do about it**: run `neru config reload` after the `config set`, or restart. The value is persisted to the override file before either, so nothing is lost.
- **Why**: re-inferring reads the whole configuration, and a label that has been settled cannot say whether the user wrote it, so it cannot be re-derived from an in-memory copy — and `config set` deliberately does not re-read from disk. Theme colours have behaved this way since they became derived values; this is the same limitation reaching a second option, and it is noted in `docs/CONFIGURATION.md` under the `config set` limitations. Fixing the class properly is its own ticket, not a heuristic here.

## Additional Context

**The audit came first.** Four places read the labels. Only one branched on the empty string — the consumer named in the issue and in ADR 0006 — and it is deleted. The two mode-side readers pass the strings straight into the grid constructor, which does the inferring itself, so a pre-settled value reaches exactly the same grid. Nothing depends on reading `""`.

**Which "characters" the labels reflect.** Three candidates existed: the raw `grid.characters`; that value falling back to `hints.hint_characters` when blank; and the built-in a–z alphabet the grid substitutes for a character set too short to label with. The settled value reflects all three, in that order, because the ticket asks for the labels *in use* and that is the chain the grid itself walks — the resolution calls into the grid's own answer rather than restating it, so the two cannot drift apart. Validation refuses a blank `grid.characters` while grid mode is enabled, so the hint-character step is a floor rather than something a running configuration sits on; the a–z step is reachable, since a one-character `grid.characters` validates.

**Where it runs.** Alongside the theme resolution: inside the default configuration, and once at the end of the load, *after* the runtime override layer. Before the override layer it would settle from characters the daemon does not run on. Tests pin the reload case, the override case, and that a written value survives both.

**Two review findings, both fixed here.** A runtime `neru config set grid.row_labels xy` used to leave the typed string in the live configuration while the grid drew `XY`, which read as a label change on every reload afterwards and rebuilt the grid — discarding in-flight coordinate input. The runtime set path now normalizes what was typed; there is a test for it. The second was that the `config set` consequence lived only in a code comment, and it now has its documented home.

**Found and not fixed.** No validator covers `row_labels` / `col_labels`, so a one-character or duplicate label set is still accepted; that is pre-existing and refusing a setting a user is living with is the warnings tier's business, per ADR 0002. The three subgrid-breakpoint implementations still disagree about a neighbouring fallback — macOS falls back to the grid characters, Linux and Windows to a hard-coded `ASDFGHJKL`, and the mode layer to a lowercase `asdfghjkl` — with no test pinning any of them. Untouched here; it is cross-platform work and wants its own ticket.
