### PR TITLE
test(config): fail the build when a validator or a default is never reached

### DIFF
--- a/.agents/skills/add-config-option/SKILL.md
+++ b/.agents/skills/add-config-option/SKILL.md
@@ -90,7 +90,9 @@ intentionally requires a restart, say so in the docs.
 
 ```bash
 just test-foundation    # the fast cross-platform-safe slice
-go test ./internal/config/... ./internal/architecture/
 ```
+
+That one recipe now runs every package this skill's guardrails live in — the
+config package, its loader, and `internal/architecture`.
 
 Then the standard pre-commit gate from AGENTS.md.

--- a/.agents/skills/add-config-option/SKILL.md
+++ b/.agents/skills/add-config-option/SKILL.md
@@ -7,37 +7,76 @@ description: "Add or change a Neru config.toml option end to end: struct field, 
 
 Config changes fail in review when one link of the chain is missing — a default
 that exists on macOS but not Linux, a validator that never runs, or an example
-file that still shows the old key. Walk every step; none are optional.
+file that still shows the old key. `internal/config/AGENTS.md` states the
+contract and which test fails per link; this is the order to do it in.
 
-## The chain
+Four steps are universal. Then check the conditional four — the ones that turn
+a one-line option into a nine-file one, and that no guide used to name.
+
+## The universal four
 
 1. **Schema.** Add the struct field in `internal/config/config.go` with a
    `toml:"snake_case_name"` tag matching the surrounding section. Follow the
    existing nesting — options live in their feature's sub-struct, not at root.
 2. **Shared default.** Set it in `newDefaultConfig()` in
-   `internal/config/config_defaults.go`. Every field gets an explicit default;
-   zero values by omission are how drift starts.
-3. **Platform overrides.** If any platform needs a different default, set it in
-   `applyPlatformDefaults()` in the matching `config_<os>.go`
-   (`config_darwin.go`, `config_linux.go`, `config_windows.go`,
-   `config_other.go`). Both layers are reached via `DefaultConfig()` in
-   `config_platform.go` — never call `newDefaultConfig()` directly from
-   feature code.
-4. **Validation.** Add checks to the relevant `Validate*` method in
-   `internal/config/validators_*.go` (hints, grid, style, hotkeys, macros,
-   pointer, appconfig, …). Invalid values must fail validation with a clear
-   message, not get silently clamped. New enum-ish strings get an allowlist.
-5. **Hot reload.** Config is hot-reloadable via `internal/config/loader`
-   (load/watch/persist/set-field). If the option should be settable at runtime
-   with `neru config set`, confirm the field path resolves through the loader's
-   set-field lookup; if it intentionally requires a restart, say so in the docs.
-6. **Examples.** Update `configs/default-config.toml` and any other example in
-   `configs/` that shows the affected section (`author-config.toml`,
-   `hints-only-config.toml`, …). These are embedded and tested
-   (`embedded_config_test.go`), so stale examples break the build — good.
-7. **Docs.** Update `docs/CONFIGURATION.md`. That file is the single home for
-   config reference facts; do not also describe the option in ARCHITECTURE or
-   README.
+   `internal/config/config_defaults.go`. Assign the field by name even when the
+   value you assign is the zero value, and say in a comment what the zero
+   means: a zero nobody wrote cannot be told from a forgotten one.
+   `TestEverySchemaFieldHasAnExplicitDefault` fails on an omission.
+3. **Example.** Add the line to `configs/default-config.toml`, which is the file
+   a user copies. Comment it out if the option has no default — an uncommented
+   empty value asserts a default that does not exist.
+   `TestConfigOptionsAppearInTheDefaultExample` fails when the line is missing.
+   Update the mode-specific examples (`grid-only-config.toml`,
+   `hints-only-config.toml`, `recursive-grid-only-config.toml`) only if they
+   show the affected section; they are deliberately partial, and only their
+   *keys* are checked, by `TestShippedExamplesWriteOnlySchemaKeys`. Those four
+   are the whole shipped set — `configs/embed.go` lists them, and anything else
+   in `configs/` is a working file rather than a project artifact. Only
+   `default-config.toml` is embedded; the rest are read from disk by the tests
+   that check them.
+4. **Docs.** Add the row to `docs/CONFIGURATION.md`. That file is the single
+   home for config reference facts; do not also describe the option in
+   ARCHITECTURE or README. **No test catches a missing row** — this is the one
+   universal link a reviewer has to check by eye.
+
+Steps 2 and 3 exempt three shapes, and an option with one of them passes both
+tests whether or not you do the work: the `light`/`dark` leaves under a `Color`,
+a collection that ships empty, and any field of a repeated table nobody ships
+entries for (`app_configs`, `layers`). Do the work anyway — see
+`internal/config/AGENTS.md`.
+
+## The conditional four
+
+Each is skippable, and each is a whole file when it is not.
+
+- **Platform override.** If a platform needs a different default, set it in
+  `applyPlatformDefaults()` in the matching `config_<os>.go`
+  (`config_darwin.go`, `config_linux.go`, `config_windows.go`,
+  `config_other.go`). Both layers are reached via `DefaultConfig()` in
+  `config_platform.go` — never call `newDefaultConfig()` directly from feature
+  code. Nothing checks this; pin the difference in a test.
+- **Validator.** Add checks to the relevant `Validate*` method on `*Config` in
+  `internal/config/validators_*.go` (hints, grid, style, hotkeys, macros,
+  pointer, appconfig, …). Invalid values must fail validation with a clear
+  message, not get silently clamped; new enum-ish strings get an allowlist. A
+  brand-new `Validate*` method must be called from `ValidateWithWarnings` in
+  `validate.go`, or `TestEveryConfigValidatorRunsInTheLadder` fails.
+- **Derivation helper.** If the value the daemon runs on is not the value the
+  user writes, resolve it once after the configuration is assembled rather than
+  in each consumer — `internal/config/grid_labels.go` and `held_repeat.go` are
+  the worked examples. The declared default stays what a user would type.
+- **Cross-field rule.** If the option only makes sense alongside another, and a
+  user could act on the mismatch, collect it into `Warnings` so it rides out on
+  `LoadResult` and reaches `neru config validate`. `logger.Warn` reaches nobody
+  (ADR 0002, `docs/adr/0002-severity-tiered-config-validation.md`).
+
+## Hot reload
+
+Config is hot-reloadable via `internal/config/loader` (load/watch/persist/
+set-field). If the option should be settable at runtime with `neru config set`,
+confirm the field path resolves through the loader's set-field lookup; if it
+intentionally requires a restart, say so in the docs.
 
 ## Tests
 
@@ -50,8 +89,8 @@ file that still shows the old key. Walk every step; none are optional.
 ## Verify
 
 ```bash
-just test-foundation    # fast: config + action + ports slice
-go test ./internal/config/...
+just test-foundation    # the fast cross-platform-safe slice
+go test ./internal/config/... ./internal/architecture/
 ```
 
 Then the standard pre-commit gate from AGENTS.md.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Hard rules that apply everywhere:
 
 Runtime shape: a daemon plus a thin CLI. `neru launch` starts the daemon; other commands dial a Unix socket (`$TMPDIR/neru.sock`, 0600) or Windows named pipe — transport in `internal/adapter/ipc`, handlers in `internal/app/ipcctrl`. New user-facing behavior usually needs a CLI command, an IPC handler, and the service/mode work behind it (the `add-cli-command` skill walks it). Startup is a numbered, individually-unwound phase sequence in `internal/app/new.go`. Input flow: native event tap → `adapter/eventtap` → `app/modes/handler.go` → active `Mode` → `app/services/*` → adapter → native API.
 
-Configuration is hot-reloadable TOML; adding an option touches a five-link chain — read `internal/config/AGENTS.md` or use the `add-config-option` skill.
+Configuration is hot-reloadable TOML; adding an option touches four links every time and up to four more when it needs them, with a guardrail test behind most of them — read `internal/config/AGENTS.md` or use the `add-config-option` skill.
 
 ## Conventions
 

--- a/internal/architecture/config_chain_test.go
+++ b/internal/architecture/config_chain_test.go
@@ -1,0 +1,486 @@
+package architecture_test
+
+import (
+	"go/ast"
+	"maps"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// validatorLadder is the method that runs every config validator in order. A
+// validator this one does not call never runs, whatever it checks.
+const validatorLadder = "ValidateWithWarnings"
+
+// validatorPrefix is the naming convention the ladder's steps share. It is what
+// makes the set of validators discoverable at all: there is no interface, no
+// table and no registration, only the name.
+const validatorPrefix = "Validate"
+
+// plainValidator is the ladder's other entry point, which delegates to it. Its
+// name happens to equal validatorPrefix; the two are spelled separately because
+// one names a method and the other a naming convention.
+const plainValidator = "Validate"
+
+// defaultsBuilder is the function that assembles the shared defaults. Every
+// schema field has to be assigned by name somewhere it reaches.
+const defaultsBuilder = "newDefaultConfig"
+
+// ladderEntryPoints are the Validate* methods that are the ladder rather than a
+// step in it, mapped to why they cannot appear inside it.
+//
+// TestValidatorLadderExemptionsStayHonest fails on an entry that stopped
+// describing the code, so this list can only shrink.
+var ladderEntryPoints = map[string]string{
+	plainValidator:  "the plain entry point; it delegates to " + validatorLadder,
+	validatorLadder: "the ladder itself, which cannot be a step in itself",
+}
+
+// exemptedDefaults is the named allowlist for the explicit-default rule, keyed
+// Type.Field: a schema field with no assignment in the defaults and no
+// structural reason to lack one. It ships empty on purpose, so that the first
+// entry is a decision someone writes a reason for rather than a line appended
+// to a list that was never empty.
+//
+// TestConfigDefaultExemptionsStayHonest fails on an entry that stopped being
+// needed, so this list can only shrink.
+var exemptedDefaults = map[string]string{}
+
+// minSchemaFields guards against a vacuous pass, the same way
+// minSchemaOptions does for the example checks. The walk finds a few hundred
+// fields today; a reflection bug that returned none would satisfy every
+// assertion here without anyone noticing.
+const minSchemaFields = 150
+
+// minLadderSteps guards the other walk. An AST pass that matched nothing —
+// because the ladder was renamed, or the receiver stopped being c — would
+// report a perfectly wired ladder made of no validators at all.
+const minLadderSteps = 15
+
+// TestEveryConfigValidatorRunsInTheLadder pins the validator link of the option
+// chain (internal/config/AGENTS.md): a validator that is written but never
+// called is indistinguishable, to a user, from one that was never written.
+//
+// Nothing is unwired today and this test finds nothing on the day it lands;
+// that is the bargain, and
+// docs/adr/0006-config-options-get-guardrails-not-generation.md is the answer
+// to "what was this for". It is an AST pass rather than reflection because the
+// ladder is a hand-ordered sequence of calls, and only the source says which
+// calls it makes.
+func TestEveryConfigValidatorRunsInTheLadder(t *testing.T) {
+	declared := declaredConfigValidators(t)
+	called := validatorsCalledByLadder(t)
+
+	if len(called) < minLadderSteps {
+		t.Fatalf(
+			"found only %d validator calls in Config.%s, expected at least %d; "+
+				"the AST walk is broken and this check would pass vacuously",
+			len(called), validatorLadder, minLadderSteps,
+		)
+	}
+
+	for _, name := range declared {
+		if called[name] {
+			continue
+		}
+
+		if _, isEntryPoint := ladderEntryPoints[name]; isEntryPoint {
+			continue
+		}
+
+		t.Errorf(
+			"Config.%s is declared in internal/config but never called by Config.%s, "+
+				"so it never runs; add it to the ladder, or delete it",
+			name, validatorLadder,
+		)
+	}
+}
+
+// TestValidatorLadderExemptionsStayHonest keeps the two exemptions from
+// outliving what they describe. Both are claims about the code, and claims rot:
+// an entry point that stopped delegating is a validator nobody runs, wearing an
+// exemption that says it is fine.
+func TestValidatorLadderExemptionsStayHonest(t *testing.T) {
+	declared := declaredConfigValidators(t)
+	called := validatorsCalledByLadder(t)
+
+	for name, reason := range ladderEntryPoints {
+		switch {
+		case !slices.Contains(declared, name):
+			t.Errorf(
+				"ladderEntryPoints names Config.%s, which is not a %s* method on *Config; "+
+					"drop the entry (%s)",
+				name, validatorPrefix, reason,
+			)
+		case called[name]:
+			t.Errorf(
+				"ladderEntryPoints names Config.%s, which Config.%s now calls; "+
+					"drop the entry (%s)",
+				name, validatorLadder, reason,
+			)
+		}
+	}
+
+	// The plain entry point is exempt because it delegates. If it ever grew a
+	// ladder of its own, the exemption would be hiding a second one.
+	if !methodCalls(t, configMethodDecl(t, plainValidator), validatorLadder) {
+		t.Errorf(
+			"Config.%s no longer calls Config.%s; it is exempt from the wiring "+
+				"check only because it delegates, so it now hides whatever it does instead",
+			plainValidator, validatorLadder,
+		)
+	}
+}
+
+// TestEverySchemaFieldHasAnExplicitDefault pins the second universal link of
+// the option chain (internal/config/AGENTS.md): every field the schema declares
+// is assigned a value by name in the shared defaults, rather than inheriting
+// Go's zero value by omission.
+//
+// Reflection alone cannot tell a deliberate zero from a forgotten one — both
+// read as "". grid.row_labels and grid.col_labels were the forgotten kind for
+// as long as the guide claimed otherwise, with their real meaning living in a
+// consumer, so the question this asks is whether the source names the field,
+// not what value it ends up with.
+func TestEverySchemaFieldHasAnExplicitDefault(t *testing.T) {
+	missing := undefaultedSchemaFields(t)
+
+	for _, key := range slices.Sorted(maps.Keys(missing)) {
+		// Rule 3, named. Rules 1 and 2 are structural and already applied.
+		if _, exempt := exemptedDefaults[key]; exempt {
+			continue
+		}
+
+		field := missing[key]
+
+		t.Errorf(
+			"%s is assigned by name at %d of the %d places %s() builds a %s, so "+
+				"config option %q takes Go's zero value by omission; assign it at "+
+				"each one, even where the value assigned is that same zero — a zero "+
+				"nobody wrote cannot be told from a forgotten one",
+			key, field.setAt, field.sites, defaultsBuilder, field.owner, field.path,
+		)
+	}
+}
+
+// TestConfigDefaultExemptionsStayHonest keeps the named allowlist from
+// outliving what it describes. The structural exemptions need no companion
+// here: both are recomputed from the live defaults on every run, so a field
+// that stops qualifying stops being exempt by itself.
+func TestConfigDefaultExemptionsStayHonest(t *testing.T) {
+	missing := undefaultedSchemaFields(t)
+
+	for key, reason := range exemptedDefaults {
+		if _, needed := missing[key]; !needed {
+			t.Errorf(
+				"exemptedDefaults names %s, which is no longer a schema field without "+
+					"a default; drop the entry (%s)",
+				key, reason,
+			)
+		}
+	}
+}
+
+// undefaultedField is a schema field the shared defaults leave unstated, with
+// the tally that says how badly: sites is how many times the builder writes a
+// literal of the owning struct, setAt how many of those name the field.
+type undefaultedField struct {
+	schemaField
+
+	setAt int
+	sites int
+}
+
+// undefaultedSchemaFields returns every schema field the shared defaults do not
+// assign by name at every literal of its owning struct, keyed Type.Field.
+//
+// It is keyed by declaration rather than by TOML path because that is the shape
+// of the fix: the mode indicator's per-mode table is one struct reached five
+// times, and one missing line in the defaults is one thing to correct, not
+// five. The path of one place it shows up rides along for the failure message.
+func undefaultedSchemaFields(t *testing.T) map[string]undefaultedField {
+	t.Helper()
+
+	schema := reflectConfigSchema(t)
+	sites := defaultLiteralSites(t)
+
+	if len(schema.fields) < minSchemaFields {
+		t.Fatalf(
+			"reflected only %d schema fields, expected at least %d; the walk is "+
+				"broken and this check would pass vacuously",
+			len(schema.fields), minSchemaFields,
+		)
+	}
+
+	missing := make(map[string]undefaultedField)
+
+	for _, field := range schema.fields {
+		// Rules 1 and 2, structural, applied during the reflection walk.
+		if field.exemption != "" {
+			continue
+		}
+
+		literals := sites[field.owner]
+
+		setAt := 0
+
+		for _, fields := range literals {
+			if fields[field.name] {
+				setAt++
+			}
+		}
+
+		if len(literals) > 0 && setAt == len(literals) {
+			continue
+		}
+
+		key := field.owner + "." + field.name
+		if _, seen := missing[key]; !seen {
+			missing[key] = undefaultedField{
+				schemaField: field,
+				setAt:       setAt,
+				sites:       len(literals),
+			}
+		}
+	}
+
+	return missing
+}
+
+// declaredConfigValidators names every Validate* method declared on *Config
+// across the config package, sorted so failures read in a stable order.
+func declaredConfigValidators(t *testing.T) []string {
+	t.Helper()
+
+	var names []string
+
+	for _, file := range parsedConfigPackage(t) {
+		for _, decl := range file.Decls {
+			funcDecl, isFunc := decl.(*ast.FuncDecl)
+			if !isFunc || !isConfigMethod(funcDecl) {
+				continue
+			}
+
+			if strings.HasPrefix(funcDecl.Name.Name, validatorPrefix) {
+				names = append(names, funcDecl.Name.Name)
+			}
+		}
+	}
+
+	slices.Sort(names)
+
+	return names
+}
+
+// validatorsCalledByLadder names every Validate* method the ladder calls on its
+// own receiver. A call on anything else is not a step of this ladder.
+func validatorsCalledByLadder(t *testing.T) map[string]bool {
+	t.Helper()
+
+	ladder := configMethodDecl(t, validatorLadder)
+	receiver := receiverName(ladder)
+	called := make(map[string]bool)
+
+	ast.Inspect(ladder.Body, func(node ast.Node) bool {
+		name := methodCallOnReceiver(node, receiver)
+		if strings.HasPrefix(name, validatorPrefix) {
+			called[name] = true
+		}
+
+		return true
+	})
+
+	return called
+}
+
+// methodCalls reports whether a method calls another one on its own receiver.
+func methodCalls(t *testing.T, decl *ast.FuncDecl, method string) bool {
+	t.Helper()
+
+	receiver := receiverName(decl)
+	found := false
+
+	ast.Inspect(decl.Body, func(node ast.Node) bool {
+		if methodCallOnReceiver(node, receiver) == method {
+			found = true
+		}
+
+		return !found
+	})
+
+	return found
+}
+
+// methodCallOnReceiver names the method a node calls on the given receiver, or
+// "" when the node is not such a call.
+func methodCallOnReceiver(node ast.Node, receiver string) string {
+	call, isCall := node.(*ast.CallExpr)
+	if !isCall {
+		return ""
+	}
+
+	selector, isSelector := call.Fun.(*ast.SelectorExpr)
+	if !isSelector {
+		return ""
+	}
+
+	ident, isIdent := selector.X.(*ast.Ident)
+	if !isIdent || ident.Name != receiver {
+		return ""
+	}
+
+	return selector.Sel.Name
+}
+
+// isConfigMethod reports whether a declaration is a method on Config, pointer
+// receiver or not.
+func isConfigMethod(decl *ast.FuncDecl) bool {
+	if decl.Recv == nil || len(decl.Recv.List) == 0 {
+		return false
+	}
+
+	return receiverTypeName(decl.Recv.List[0].Type) == "Config"
+}
+
+// receiverName is the identifier a method refers to its receiver by.
+func receiverName(decl *ast.FuncDecl) string {
+	if decl.Recv == nil || len(decl.Recv.List) == 0 || len(decl.Recv.List[0].Names) == 0 {
+		return ""
+	}
+
+	return decl.Recv.List[0].Names[0].Name
+}
+
+// configMethodDecl finds one method on Config by name, failing when it is gone
+// — a renamed ladder must break this suite loudly rather than leave it checking
+// nothing. It insists on the receiver because the package has more than one
+// Validate: Color carries its own.
+func configMethodDecl(t *testing.T, name string) *ast.FuncDecl {
+	t.Helper()
+
+	for _, file := range parsedConfigPackage(t) {
+		for _, decl := range file.Decls {
+			funcDecl, isFunc := decl.(*ast.FuncDecl)
+			if isFunc && isConfigMethod(funcDecl) && funcDecl.Name.Name == name {
+				return funcDecl
+			}
+		}
+	}
+
+	t.Fatalf(
+		"internal/config declares no Config.%s; it was renamed or removed, and "+
+			"the guardrail that reads it now checks nothing",
+		name,
+	)
+
+	return nil
+}
+
+// defaultLiteralSites reads the shared defaults as the source states them: for
+// each schema struct, one set of field names per composite literal of it that
+// newDefaultConfig() reaches.
+//
+// Per literal rather than merged per type, because merging lets two literals of
+// one struct cover for each other — each omitting a field the other sets, and
+// neither stating a default. That is the exact shape the mode indicator table
+// had when this check first ran, five literals deep.
+//
+// It follows plain function calls out of newDefaultConfig() because the builder
+// is written as one — defaultGrid(), defaultHints() and the rest are that
+// function's body, split up. Platform overrides are deliberately not followed:
+// applyPlatformDefaults() adjusts a default that already exists, and a field
+// that only a platform sets has no shared default at all.
+func defaultLiteralSites(t *testing.T) map[string][]map[string]bool {
+	t.Helper()
+
+	files := parsedConfigPackage(t)
+
+	declarations := make(map[string]*ast.FuncDecl)
+
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			funcDecl, isFunc := decl.(*ast.FuncDecl)
+			if isFunc && funcDecl.Recv == nil {
+				declarations[funcDecl.Name.Name] = funcDecl
+			}
+		}
+	}
+
+	sites := make(map[string][]map[string]bool)
+	visited := make(map[string]bool)
+
+	var walk func(name string)
+
+	walk = func(name string) {
+		decl, declared := declarations[name]
+		if !declared || visited[name] {
+			return
+		}
+
+		visited[name] = true
+
+		ast.Inspect(decl.Body, func(node ast.Node) bool {
+			switch typed := node.(type) {
+			case *ast.CompositeLit:
+				recordLiteralSite(typed, sites)
+			case *ast.CallExpr:
+				if callee, isIdent := typed.Fun.(*ast.Ident); isIdent {
+					walk(callee.Name)
+				}
+			}
+
+			return true
+		})
+	}
+
+	walk(defaultsBuilder)
+
+	if len(sites) == 0 {
+		t.Fatalf(
+			"found no struct literals under %s(); the AST walk is broken",
+			defaultsBuilder,
+		)
+	}
+
+	return sites
+}
+
+// recordLiteralSite notes the fields one keyed literal of a named struct type
+// sets. A literal whose type is not a bare name is skipped — an unkeyed or
+// elided one names nothing, and the schema structs are never written that way.
+// Skipping fails closed: an unread literal makes its fields look undefaulted,
+// which reports, rather than making them look defaulted, which would not.
+func recordLiteralSite(lit *ast.CompositeLit, sites map[string][]map[string]bool) {
+	ident, isIdent := lit.Type.(*ast.Ident)
+	if !isIdent {
+		return
+	}
+
+	fields := make(map[string]bool)
+
+	for _, element := range lit.Elts {
+		pair, isPair := element.(*ast.KeyValueExpr)
+		if !isPair {
+			continue
+		}
+
+		if key, isKey := pair.Key.(*ast.Ident); isKey {
+			fields[key.Name] = true
+		}
+	}
+
+	sites[ident.Name] = append(sites[ident.Name], fields)
+}
+
+// parsedConfigPackage parses every non-test Go file in internal/config,
+// platform files included: the validators are spread across a dozen of them.
+// Build tags are not honored, so a Validate* method declared for one platform
+// only would be demanded of the shared ladder. There are none today, and the
+// demand would be the right one to raise — a validator that runs on one
+// platform and silently not on another is the failure this file exists for.
+func parsedConfigPackage(t *testing.T) []*ast.File {
+	t.Helper()
+
+	return parsedGoFiles(t, filepath.Join(findRepoRoot(t), "internal", "config"))
+}

--- a/internal/architecture/config_example_test.go
+++ b/internal/architecture/config_example_test.go
@@ -78,10 +78,29 @@ type configOption struct {
 	exemption string
 }
 
+// schemaField is one struct field the walk passes through, intermediate tables
+// included, addressed the way Go declares it.
+//
+// The example checks work in TOML terms because an example file does; the
+// explicit-default check in config_chain_test.go has to speak Go, because what
+// it reads is a composite literal. Both come off this one walk rather than two,
+// so a schema the reflection cannot reach is invisible to neither or to both.
+type schemaField struct {
+	// owner is the name of the struct type that declares the field.
+	owner string
+	// name is the Go field name, which is what a default assigns by.
+	name string
+	// path is the TOML path, for a failure a reader can act on.
+	path string
+	// exemption is why the field needs no explicit default, or "" when it does.
+	exemption string
+}
+
 // configSchema is config.Config reflected into TOML terms.
 type configSchema struct {
 	t       *testing.T
 	options []configOption
+	fields  []schemaField
 	// known holds every path a shipped example may legitimately write,
 	// intermediate tables included.
 	known map[string]bool
@@ -239,6 +258,31 @@ func (s *configSchema) walkStruct(typ reflect.Type, val reflect.Value, prefix, e
 
 		s.known[path] = true
 
+		fieldVal := reflect.Value{}
+		if val.IsValid() {
+			fieldVal = val.Field(index)
+		}
+
+		// A collection that ships empty is exempt from needing an explicit
+		// default for the same reason it is exempt from needing an example
+		// line: nil and empty are the same collection to every reader of it,
+		// so there is no forgotten-versus-deliberate to tell apart. That is
+		// also the rule's limit — a collection meant to ship non-empty, whose
+		// default was forgotten, reads as empty and gets forgiven. A scalar
+		// gets no such pass, which is the point: grid.row_labels defaulting to
+		// "" by omission is exactly what this must not forgive.
+		fieldExemption := exemption
+		if fieldExemption == "" && isEmptyCollection(field.Type, fieldVal) {
+			fieldExemption = exemptEmptyCollection
+		}
+
+		s.fields = append(s.fields, schemaField{
+			owner:     typ.Name(),
+			name:      field.Name,
+			path:      path,
+			exemption: fieldExemption,
+		})
+
 		if freeForm {
 			// The struct decoder never sees these — internal/config/loader/
 			// load.go reads them off the raw map, because their keys are the
@@ -246,11 +290,6 @@ func (s *configSchema) walkStruct(typ reflect.Type, val reflect.Value, prefix, e
 			s.opaque = append(s.opaque, path)
 
 			continue
-		}
-
-		fieldVal := reflect.Value{}
-		if val.IsValid() {
-			fieldVal = val.Field(index)
 		}
 
 		s.walkValue(field.Type, fieldVal, path, exemption)
@@ -285,7 +324,7 @@ func (s *configSchema) walkCollection(
 	path, exemption string,
 ) {
 	// Exemption 2, structural by kind.
-	if exemption == "" && (!val.IsValid() || val.Len() == 0) {
+	if exemption == "" && isEmptyCollection(typ, val) {
 		exemption = exemptEmptyCollection
 	}
 
@@ -489,4 +528,20 @@ func collectKeyPaths(node map[string]any, prefix string, schema *configSchema, o
 			}
 		}
 	}
+}
+
+// isEmptyCollection reports whether a default value is a slice or map that
+// ships empty. A StringOrStringArray is excluded: it is a slice in Go and one
+// value in TOML, so an empty one is an option with no default rather than a
+// collection with an empty one.
+func isEmptyCollection(typ reflect.Type, val reflect.Value) bool {
+	if typ == stringOrArrayType {
+		return false
+	}
+
+	if typ.Kind() != reflect.Slice && typ.Kind() != reflect.Map {
+		return false
+	}
+
+	return !val.IsValid() || val.Len() == 0
 }

--- a/internal/architecture/doc.go
+++ b/internal/architecture/doc.go
@@ -2,7 +2,9 @@
 // shape honest. Prose rules alone don't hold; each rule here fails `just test`
 // when broken. Layering, the darwin One Rule, platform file slots, port mocks,
 // cgo includes, doc links, comment paths, and test quality each have a file
-// named for them, as does the pairing between the config schema and the
-// example TOML. Exemption lists are self-checking: a companion test fails
-// when an entry stops being real, so a list can only shrink.
+// named for them, as do the two halves of the config option chain: the pairing
+// between the schema and the example TOML, and the links no projection can
+// show — every validator reaching the ladder, every field reaching a default.
+// Exemption lists are self-checking: a companion test fails when an entry
+// stops being real, so a list can only shrink.
 package architecture

--- a/internal/architecture/overlay_frame_test.go
+++ b/internal/architecture/overlay_frame_test.go
@@ -28,7 +28,7 @@ func TestFrameCarriesDomainValuesOnly(t *testing.T) {
 	repoRoot := findRepoRoot(t)
 	portsDir := filepath.Join(repoRoot, "internal", "ports")
 
-	files := parsedPortFiles(t, portsDir)
+	files := parsedGoFiles(t, portsDir)
 
 	frames := frameTypeNames(files)
 	if len(frames) == 0 {
@@ -200,8 +200,8 @@ func typeSpecsIn(file *ast.File) []*ast.TypeSpec {
 	return specs
 }
 
-// parsedPortFiles parses every non-test Go file in the ports package.
-func parsedPortFiles(t *testing.T, dir string) []*ast.File {
+// parsedGoFiles parses every non-test Go file in one package directory.
+func parsedGoFiles(t *testing.T, dir string) []*ast.File {
 	t.Helper()
 
 	entries, err := os.ReadDir(dir)

--- a/internal/config/AGENTS.md
+++ b/internal/config/AGENTS.md
@@ -1,12 +1,26 @@
 # Config — the option chain
 
-`~/.config/neru/config.toml`, hot-reloadable via `loader/` (load/watch/persist/set-field). Adding or changing an option touches every link; none are optional:
+`~/.config/neru/config.toml`, hot-reloadable via `loader/` (load/watch/persist/set-field).
 
-1. Struct field in `config.go` (`toml:"snake_case"`, nested in its feature's sub-struct).
-2. Shared default in `newDefaultConfig()` (`config_defaults.go`) — every field gets an explicit default.
-3. Platform overrides in `applyPlatformDefaults()` in `config_<os>.go`; both layers reached only via `DefaultConfig()` (`config_platform.go`).
-4. Validation in the matching `validators_*.go` `Validate*` method — reject invalid values loudly, never silently clamp.
-5. `configs/` examples (embedded and tested — stale examples break the build) and `docs/CONFIGURATION.md` (the single home for config reference facts).
+Adding or changing an option touches **four links every time, and up to four more when the option needs them**. The split is the part worth knowing. The universal four are projections of one declaration, and three of them have a guardrail test in `internal/architecture` that fails when you skip them. The conditional four are real code that has to be written either way — which is why generating the chain would buy back less than the file count suggests (`docs/adr/0006-config-options-get-guardrails-not-generation.md`).
+
+## Universal — every option
+
+1. **Struct field** in `config.go` (`toml:"snake_case"`, nested in its feature's sub-struct). The source of truth the rest of the chain is checked against.
+2. **Shared default** in `newDefaultConfig()` (`config_defaults.go`). Every field is assigned by name, even when the value assigned is the zero value — a zero nobody wrote cannot be told from a forgotten one. Miss it and `TestEverySchemaFieldHasAnExplicitDefault` fails.
+3. **Example line** in `configs/default-config.toml`, commented out when the option has no default. Miss it and `TestConfigOptionsAppearInTheDefaultExample` fails. Misspell a key in any of the four shipped examples and `TestShippedExamplesWriteOnlySchemaKeys` fails — the decoder drops an unknown key in silence, so a typo there is a dead line that looks like it works.
+4. **Reference row** in `docs/CONFIGURATION.md`, the single home for config reference facts. **No test enforces this one** — the other three are checked, this one is not: matching a Go field to a prose row is the fuzziest match of the four, and ADR 0006 declined it. It is on you and the reviewer.
+
+## Conditional — only when the option needs it
+
+- **Platform override** in `applyPlatformDefaults()` in `config_<os>.go`; both layers are reached only via `DefaultConfig()` (`config_platform.go`), never `newDefaultConfig()` directly. No guardrail sees a per-platform difference — pin it in a test by hand.
+- **Validator**, in the matching `validators_*.go` `Validate*` method on `*Config` — reject invalid values loudly, never silently clamp. Nothing forces an option to have one, but a validator that exists and is not called by `ValidateWithWarnings` fails `TestEveryConfigValidatorRunsInTheLadder`, because a validator nobody calls never runs.
+- **Derivation helper**, when the value the daemon runs on is not the value the user writes (`grid_labels.go`, `held_repeat.go`, `ResolveThemeDefaults()` in `theme_palette.go`). It runs once the whole configuration is assembled — file, override file and platform layer all in — so the declared default stays the value a user would have typed, not the resolved one.
+- **Cross-field rule**, when two settings only make sense together. If a user could act on it, it rides out on `LoadResult.Warnings` and reaches `neru config validate`; `logger.Warn` reaches nobody (ADR 0002).
+
+`held_repeat.accel_*` needed all four conditional links, which is how one option came to touch nine files.
+
+**What the guardrails do not reach.** Links 2 and 3 exempt three shapes, and an option with one of them can skip both with nothing failing: the `light`/`dark` leaves under a `Color` (`ResolveThemeDefaults()` fills those), a collection that ships empty, and every field of a repeated table nobody ships entries for (`app_configs`, `layers`). The exemptions are structural and recomputed from the live defaults each run, and the named allowlist beside each is empty — adding to it is a decision that wants a written reason (ADR 0006). If your option is one of those shapes, the reviewer is the only check.
 
 The `add-config-option` skill walks this end to end, plus tests. Fast check: `just test-foundation`.
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -655,28 +655,39 @@ func defaultMouseAction() MouseActionConfig {
 	}
 }
 
+// Whether a mode's indicator shows by default, named so the table below reads
+// as a table rather than as a column of bare booleans.
+const (
+	indicatorShown  = true
+	indicatorHidden = false
+)
+
+// defaultModeIndicatorMode is one mode's row of the indicator table. Enabled
+// and Text differ per mode; the three color overrides do not, and writing them
+// once here is what keeps their default a stated one.
+func defaultModeIndicatorMode(enabled bool, text string) ModeIndicatorModeConfig {
+	return ModeIndicatorModeConfig{
+		Enabled: enabled,
+		Text:    text,
+
+		// Empty is the meaning, not a missing default: an unset per-mode color
+		// inherits the matching [mode_indicator.ui] value, light and dark leg
+		// independently (Color.ForThemeWithOverride). Shipping a value here
+		// would take that inheritance away from everyone who only styles the
+		// shared block.
+		BackgroundColor: Color{},
+		TextColor:       Color{},
+		BorderColor:     Color{},
+	}
+}
+
 func defaultModeIndicator() ModeIndicatorConfig {
 	return ModeIndicatorConfig{
-		Scroll: ModeIndicatorModeConfig{
-			Enabled: true,
-			Text:    "Scroll",
-		},
-		Hints: ModeIndicatorModeConfig{
-			Enabled: false,
-			Text:    "Hints",
-		},
-		Grid: ModeIndicatorModeConfig{
-			Enabled: false,
-			Text:    "Grid",
-		},
-		RecursiveGrid: ModeIndicatorModeConfig{
-			Enabled: false,
-			Text:    "Recursive Grid",
-		},
-		MonitorSelect: ModeIndicatorModeConfig{
-			Enabled: false,
-			Text:    "Monitor Select",
-		},
+		Scroll:        defaultModeIndicatorMode(indicatorShown, "Scroll"),
+		Hints:         defaultModeIndicatorMode(indicatorHidden, "Hints"),
+		Grid:          defaultModeIndicatorMode(indicatorHidden, "Grid"),
+		RecursiveGrid: defaultModeIndicatorMode(indicatorHidden, "Recursive Grid"),
+		MonitorSelect: defaultModeIndicatorMode(indicatorHidden, "Monitor Select"),
 		UI: ModeIndicatorUI{
 			FontSize:         DefaultScrollFontSize,
 			FontFamily:       "",


### PR DESCRIPTION
## Description

This PR makes two more links of the config option chain fail loudly when they are skipped, and rewrites the two config guides to say only what is now actually enforced.

A validator that is written but never called from the validation ladder never runs, and a setting with no line in the shared defaults quietly takes Go's zero value — which is how `grid.row_labels` came to have its real meaning living in a consumer rather than in the config. Two new guardrail tests read the source for exactly those two things, and both had to read the source rather than the types: the ladder is a hand-ordered sequence of calls, and a deliberate zero cannot be told from a forgotten one unless you can see whether anyone wrote it. Each ships with a self-checking exemption list, so an exemption that stops describing the code fails too.

The defaults guardrail found one real gap on the way in: the mode indicator's five per-mode entries left their three color overrides unwritten. The zero was deliberate — an unset per-mode color inherits the matching `[mode_indicator.ui]` value — but that meaning was only visible in the three overlay managers that resolve it. Those defaults are now written down, with no change to any value.

Deliberate limitation: the reference table in the configuration docs is still checked by eye. Matching a Go field to a prose row is the fuzziest of the projections, and ADR 0006 declined it; both guides now say so plainly rather than implying otherwise.

## Related Issues

Closes #1257

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no OS-specific files touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port work here
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config Surface

No option is added, renamed, or removed, and no accepted value or default changes. Every existing config file keeps working exactly as before.

For the record, the five per-mode indicator color options whose defaults are now written down explicitly — all five keep their previous behaviour of inheriting `[mode_indicator.ui]` when unset:

```toml
[mode_indicator.scroll]         # and .hints, .grid, .recursive_grid, .monitor_select
background_color = ""           # unset -> inherits [mode_indicator.ui].background_color
text_color       = ""           # unset -> inherits [mode_indicator.ui].text_color
border_color     = ""           # unset -> inherits [mode_indicator.ui].border_color
```

## Additional Context

Both guardrails were watched failing before being trusted, the way the previous ticket in this sequence required.

- Deleting `ValidateScroll` from the ladder: *"Config.ValidateScroll is declared in internal/config but never called by Config.ValidateWithWarnings, so it never runs; add it to the ladder, or delete it."*
- Making the plain entry point stop delegating: *"Config.Validate no longer calls Config.ValidateWithWarnings; it is exempt from the wiring check only because it delegates, so it now hides whatever it does instead."*
- Deleting two grid defaults: *"GridConfig.SublayerKeys is assigned by name at 0 of the 1 places newDefaultConfig() builds a GridConfig, so config option `grid.sublayer_keys` takes Go's zero value by omission…"*
- Dropping one field from one of the two theme palette literals: *"ThemePalette.Text is assigned by name at 1 of the 2 places newDefaultConfig() builds a ThemePalette…"*
- Planting stale entries in each exemption list: both companion tests named the entry and told me to drop it.

Three things worth a maintainer's eye:

1. **The empty-collection exemption is the load-bearing judgement call.** A collection that ships empty is not required to be assigned by name, because nil and empty are the same collection to every reader — there is no forgotten-versus-deliberate to tell apart. That forgives five fields today (`macros`, three `app_configs` slices, `recursive_grid.layers`), so "removing a default fails the test" holds for scalars and structs but not for those. Its limit is written into the test: a collection *meant* to ship non-empty whose default was forgotten reads as empty and gets forgiven. Scalars get no such pass, which is what keeps the `grid.row_labels` case caught. The named allowlist beside it ships empty, per ADR 0006, and both guides now say plainly which shapes the guardrails do not reach.

2. **The defaults check reads every literal of a struct, not their union.** Merging by type would let two literals of one struct cover for each other, each omitting a field the other sets — which is exactly the shape the mode indicator table had, five literals deep. Only `Color` and `ThemePalette` are built more than once today, so the stricter rule costs nothing now and closes the hole that made this defect possible.

3. **`ValidateMacros` still runs last only by comment.** The ordering constraint noted in ADR 0006 is not pinned here, because the issue did not ask for it — and as written the comment is already slightly off: `ValidateModeCommands` runs after `ValidateMacros`. Worth its own change if the ladder is ever restructured into a table.

The chain the guides now describe is four universal links (schema field, shared default, example line, reference row) and four conditional ones (platform override, validator, derivation helper, cross-field rule). The old five-links-versus-seven-steps disagreement came from nobody having drawn that line; the root guide's own "five-link chain" is corrected here too.
