### PR TITLE
fix(config): report a grid label set that leaves cells unreachable

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1026,6 +1026,24 @@ Cursor behavior is chosen per invocation: `neru grid --cursor-selection-mode fol
 | `prewarm_enabled`   | bool   | `true`                        | Pre-compute grid on startup |
 | `enable_gc`         | bool   | `false`                       | Periodic memory cleanup     |
 
+**The label sets are checked when the config loads.** `characters`, `row_labels`
+and `col_labels` all name cells you then have to type, so `neru config validate`
+warns when one of them holds a single character, the same character twice (case
+is folded — `aA` is one character written twice), or a character that cannot be
+typed: whitespace or a control character. None of these stops a grid being built
+— a short `characters` is replaced by `a-z`, short labels cap the grid to the
+cells they can name, and a repeat leaves one cell answering to nobody — so the
+configuration still loads and the warning is where you hear about it. A label
+left empty is checked as the `characters` it is inferred from and reported under
+that name, so one mistake is reported once.
+
+Two neighbouring rules are older and stricter, and refuse the file rather than
+warn: `characters` cannot be empty, and neither `characters` nor `sublayer_keys`
+may contain a character outside ASCII. `row_labels` and `col_labels` warn about
+non-ASCII instead. `sublayer_keys` is not checked for the three faults above:
+only its first 9 characters are drawn, and the rest are dropped, so a repeat
+among them costs nothing.
+
 ### UI
 
 | Option                     | Type   | Default | Description                          |

--- a/internal/config/grid_labels.go
+++ b/internal/config/grid_labels.go
@@ -21,6 +21,22 @@ func (c *Config) GridCharacters() string {
 	return c.Grid.Characters
 }
 
+// inferredGridKeys is what an empty grid.row_labels, grid.col_labels or
+// grid.sublayer_keys settles to: the characters the grid is built from, in the
+// case they are drawn in, or a-z when that set is too small to label with.
+//
+// It is one function because two callers have to agree on it. The derivation
+// fills the blank fields with it, and the validator recognizes a resolved value
+// by it — a value equal to this one was inferred rather than written, and a
+// fault in it belongs to grid.characters, under the name that is in the user's
+// file. Two copies of that rule could drift into reporting a fault twice, or
+// under a field the user never wrote.
+func (c *Config) inferredGridKeys() string {
+	keys, _ := domainGrid.ResolveLabels(c.GridCharacters(), "", "")
+
+	return keys
+}
+
 // ResolveGridLabels settles grid.row_labels and grid.col_labels to the labels
 // the grid will actually be drawn with, so that reading the option answers the
 // question rather than starting one. An empty value means "infer from

--- a/internal/config/grid_sublayer_keys.go
+++ b/internal/config/grid_sublayer_keys.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"strings"
-
-	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
 )
 
 // ResolveSublayerKeys settles grid.sublayer_keys to the keys a subgrid will
@@ -45,6 +43,5 @@ func (c *Config) ResolveSublayerKeys() {
 	// keyless subgrid under a labeled grid. ValidateGrid refuses a blank
 	// grid.characters, so this is a floor rather than a configuration a user
 	// runs on; `neru config set --no-reload` is the path that skips it.
-	keys, _ := domainGrid.ResolveLabels(c.GridCharacters(), "", "")
-	c.Grid.SublayerKeys = keys
+	c.Grid.SublayerKeys = c.inferredGridKeys()
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -75,7 +75,7 @@ func (c *Config) ValidateWithWarnings(warnings *Warnings) error {
 	}
 
 	// Validate grid settings
-	err = c.ValidateGrid()
+	err = c.ValidateGrid(warnings)
 	if err != nil {
 		return err
 	}

--- a/internal/config/validators_boundary_test.go
+++ b/internal/config/validators_boundary_test.go
@@ -46,7 +46,7 @@ func fontSizeBounds() []intBound {
 		{
 			name:     "grid.ui.font_size",
 			set:      func(c *config.Config, v int) { c.Grid.UI.FontSize = v },
-			validate: (*config.Config).ValidateGrid,
+			validate: func(c *config.Config) error { return c.ValidateGrid(nil) },
 			minValid: 1, maxValid: math.MaxInt32,
 			enable: func(c *config.Config) { c.Grid.Enabled = true },
 		},
@@ -144,7 +144,7 @@ func assertConfigValid(t *testing.T, cfg *config.Config, what string) {
 
 	validators := map[string]func(*config.Config) error{
 		"ValidateHints":           (*config.Config).ValidateHints,
-		"ValidateGrid":            (*config.Config).ValidateGrid,
+		"ValidateGrid":            func(c *config.Config) error { return c.ValidateGrid(nil) },
 		"ValidateMonitorSelect":   (*config.Config).ValidateMonitorSelect,
 		"ValidateStickyModifiers": (*config.Config).ValidateStickyModifiers,
 		"ValidateRecursiveGrid":   (*config.Config).ValidateRecursiveGrid,

--- a/internal/config/validators_grid.go
+++ b/internal/config/validators_grid.go
@@ -8,8 +8,9 @@ import (
 	"github.com/y3owk1n/neru/internal/derrors"
 )
 
-// ValidateGrid validates the grid configuration.
-func (c *Config) ValidateGrid() error {
+// ValidateGrid validates the grid configuration, warning about the key sets
+// that load and leave part of the grid unreachable; see [warnGridKeySets].
+func (c *Config) ValidateGrid(warnings *Warnings) error {
 	if !c.Grid.Enabled {
 		return nil
 	}
@@ -71,7 +72,157 @@ func (c *Config) ValidateGrid() error {
 		return err
 	}
 
+	c.warnGridKeySets(warnings)
+
 	return nil
+}
+
+// gridKeySet is one set of characters a grid is labeled from, and what a set
+// too short to label with costs that particular field — which differs, so the
+// warning cannot word it once: a short grid.characters is replaced wholesale by
+// a-z, while short labels are used as they are and cap the grid to what they
+// can name.
+type gridKeySet struct {
+	field    string
+	keys     string
+	tooShort string
+}
+
+// warnGridKeySets reports the character sets a grid is labeled from that will
+// not label the grid the user asked for: too short to name every row or column,
+// a character used twice, or one that cannot be typed.
+//
+// It warns rather than refuses because none of the three stops a grid being
+// built — the grid is capped, relabelled, or has one cell that answers to
+// nobody — and refusing would replace the user's whole configuration with the
+// defaults over a label set they can fix in one line (ADR 0002). The refusals
+// above are unchanged: an empty or non-ASCII grid.characters still costs the
+// load, and this pass is what the fields it does not cover now get instead of
+// nothing.
+//
+// It is the tier the neighboring hints.hint_characters does not use — that one
+// refuses the same three shapes. The difference is that these labels are
+// derived: leave row_labels empty and the value validated is the one the
+// derivation wrote, and refusing a configuration over a line the user never
+// wrote is the shape ADR 0002 exists to avoid.
+//
+// grid.sublayer_keys is deliberately not here. The runtime trims, uppercases and
+// caps it at the number of subgrid cells (domain/grid.SubgridKeys), so which of
+// its characters are used at all depends on a subgrid size the mode layer owns
+// and this package cannot see — a warning from here would report faults in
+// characters that are never drawn.
+//
+// It reads the resolved labels rather than the written ones, because those are
+// what the grid is now drawn with (ResolveGridLabels): the written value is
+// legitimately empty and means "infer from characters".
+func (c *Config) warnGridKeySets(warnings *Warnings) {
+	warnGridKeySet(warnings, gridKeySet{
+		field:    "grid.characters",
+		keys:     c.Grid.Characters,
+		tooShort: "so the grid is labeled a-z instead",
+	})
+
+	// A resolved label equal to what an empty one settles to was inferred from
+	// grid.characters rather than written, so a fault in it is a fault in
+	// grid.characters — reported there, under the one name that is actually in
+	// the user's file. Reported against every field it reached, one mistake
+	// would read as three, two of them naming a line the user cannot go and fix.
+	inferred := c.inferredGridKeys()
+
+	for _, labels := range []gridKeySet{
+		{field: "grid.row_labels", keys: c.Grid.RowLabels},
+		{field: "grid.col_labels", keys: c.Grid.ColLabels},
+	} {
+		if labels.keys == inferred {
+			continue
+		}
+
+		labels.tooShort = "so the grid is capped to the cells they can name"
+		warnGridKeySet(warnings, labels)
+	}
+}
+
+// warnGridKeySet reports what one character set will not do. An empty set is
+// silent: it is the written value of a label the derivation has not settled
+// yet, and it means "infer", not "label with nothing".
+func warnGridKeySet(warnings *Warnings, set gridKeySet) {
+	if set.keys == "" {
+		return
+	}
+
+	chars := []rune(set.keys)
+
+	if len(chars) < MinCharactersLength {
+		warnings.Addf(
+			"%s has %d character and needs at least %d, %s",
+			set.field, len(chars), MinCharactersLength, set.tooShort,
+		)
+	}
+
+	warnDuplicateGridKeys(warnings, set.field, chars)
+	warnUntypeableGridKeys(warnings, set.field, chars)
+}
+
+// warnDuplicateGridKeys reports each character a key set repeats, once, on the
+// second occurrence, so that a character written three times is one thing wrong
+// rather than two.
+//
+// Case is folded because matching is: "aA" is one label written twice, and the
+// second of the two cells it names cannot be reached. The character is reported
+// folded too — the grid draws its labels upper-cased, so that is the form the
+// user is looking for on screen.
+func warnDuplicateGridKeys(warnings *Warnings, field string, chars []rune) {
+	seen := make(map[rune]struct{}, len(chars))
+	reported := make(map[rune]struct{})
+
+	for _, char := range chars {
+		upper := unicode.ToUpper(char)
+
+		_, duplicate := seen[upper]
+		if !duplicate {
+			seen[upper] = struct{}{}
+
+			continue
+		}
+
+		// A character written three times is one thing wrong, not two.
+		_, done := reported[upper]
+		if done {
+			continue
+		}
+
+		reported[upper] = struct{}{}
+
+		warnings.Addf(
+			"%s uses %q more than once, so two cells answer to the same keystroke",
+			field, upper,
+		)
+	}
+}
+
+// warnUntypeableGridKeys reports the characters in a key set that a user cannot
+// press: whitespace, control characters, and anything outside ASCII, which the
+// overlay may have no glyph for and a keyboard may have no key for.
+func warnUntypeableGridKeys(warnings *Warnings, field string, chars []rune) {
+	reported := make(map[rune]struct{})
+
+	for _, char := range chars {
+		if char <= unicode.MaxASCII && unicode.IsPrint(char) && !unicode.IsSpace(char) {
+			continue
+		}
+
+		if _, done := reported[char]; done {
+			continue
+		}
+
+		reported[char] = struct{}{}
+
+		warnings.Addf(
+			"%s contains %q, which cannot be typed as a grid label, "+
+				"so the cells it names cannot be reached",
+			field, char,
+		)
+	}
 }
 
 // ValidateMonitorSelect validates the monitor_select configuration.

--- a/internal/config/validators_grid_labels_test.go
+++ b/internal/config/validators_grid_labels_test.go
@@ -1,0 +1,298 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// validateGridWithWarnings runs the whole ladder and returns what it collected,
+// failing the test if the configuration was refused. Every case here describes a
+// file that loads: the point of the tier is that a label set the grid cannot use
+// costs the user the label set, not the rest of their configuration (ADR 0002).
+func validateGridWithWarnings(t *testing.T, cfg *config.Config) []string {
+	t.Helper()
+
+	warnings := &config.Warnings{}
+
+	err := cfg.ValidateWithWarnings(warnings)
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() refused a configuration that loads: %v", err)
+	}
+
+	return warnings.Messages()
+}
+
+// warningsMentioning returns the collected warnings that name a field, so a case
+// asserts about the field it changed rather than about the whole list.
+func warningsMentioning(warnings []string, field string) []string {
+	var found []string
+
+	for _, warning := range warnings {
+		if strings.Contains(warning, field) {
+			found = append(found, warning)
+		}
+	}
+
+	return found
+}
+
+// TestConfigValidateGrid_ResolvedLabelsAreSilent is the half that must not fire.
+// The default labels are the ones inferred from grid.characters, and a user who
+// wrote nothing must hear nothing — a warning naming a field that is not in
+// their file sends them looking for a line they never wrote.
+func TestConfigValidateGrid_ResolvedLabelsAreSilent(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	if cfg.Grid.RowLabels == "" || cfg.Grid.ColLabels == "" {
+		t.Fatalf("DefaultConfig() left labels unresolved (row %q, col %q); "+
+			"this test would then be checking the raw-empty case instead",
+			cfg.Grid.RowLabels, cfg.Grid.ColLabels)
+	}
+
+	if got := validateGridWithWarnings(t, cfg); len(got) > 0 {
+		t.Errorf("warnings = %q, want none", got)
+	}
+}
+
+// TestConfigValidateGrid_RawEmptyLabelsAreSilent covers the other shape a
+// configuration can be in: the value the user wrote, before the derivation
+// settles it. An empty label set means "infer from characters", so it is
+// nothing to warn about — checking the raw value rather than the resolved one
+// would warn on every configuration that leaves the option alone.
+func TestConfigValidateGrid_RawEmptyLabelsAreSilent(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.RowLabels = ""
+	cfg.Grid.ColLabels = ""
+	cfg.Grid.SublayerKeys = ""
+
+	if got := validateGridWithWarnings(t, cfg); len(got) > 0 {
+		t.Errorf("warnings = %q, want none", got)
+	}
+}
+
+// TestConfigValidateGrid_ShortLabelsWarn pins the too-short case. One label
+// cannot name more than one row, so a grid taller than a single cell has rows
+// the user cannot reach.
+func TestConfigValidateGrid_ShortLabelsWarn(t *testing.T) {
+	tests := []struct {
+		name  string
+		set   func(*config.Config)
+		field string
+	}{
+		{
+			name:  "row labels",
+			set:   func(c *config.Config) { c.Grid.RowLabels = "A" },
+			field: "grid.row_labels",
+		},
+		{
+			name:  "col labels",
+			set:   func(c *config.Config) { c.Grid.ColLabels = "A" },
+			field: "grid.col_labels",
+		},
+		{
+			name:  "characters",
+			set:   func(c *config.Config) { c.Grid.Characters = "a" },
+			field: "grid.characters",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			testCase.set(cfg)
+
+			got := warningsMentioning(validateGridWithWarnings(t, cfg), testCase.field)
+			if len(got) != 1 {
+				t.Fatalf("warnings for %s = %q, want exactly one", testCase.field, got)
+			}
+
+			if !strings.Contains(got[0], "at least") {
+				t.Errorf("warning %q does not say how many characters are needed", got[0])
+			}
+		})
+	}
+}
+
+// TestConfigValidateGrid_ShortSetsSayWhatTheyCost keeps the two too-short
+// warnings from wearing each other's consequence. A short grid.characters is
+// not used at all — the grid is relabelled a-z — while short labels are used as
+// written and cap the grid instead, and a warning that swapped the two would
+// send the user to fix the wrong thing.
+func TestConfigValidateGrid_ShortSetsSayWhatTheyCost(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.Characters = "a"
+
+	got := warningsMentioning(validateGridWithWarnings(t, cfg), "grid.characters")
+	if len(got) != 1 {
+		t.Fatalf("warnings for grid.characters = %q, want exactly one", got)
+	}
+
+	if !strings.Contains(got[0], "a-z") {
+		t.Errorf("warning %q does not say the grid is labeled a-z instead", got[0])
+	}
+
+	cfg = config.DefaultConfig()
+	cfg.Grid.RowLabels = "a"
+
+	got = warningsMentioning(validateGridWithWarnings(t, cfg), "grid.row_labels")
+	if len(got) != 1 {
+		t.Fatalf("warnings for grid.row_labels = %q, want exactly one", got)
+	}
+
+	if strings.Contains(got[0], "a-z") {
+		t.Errorf("warning %q claims labels the user wrote are replaced, which they are not", got[0])
+	}
+}
+
+// TestConfigValidateGrid_SublayerKeysAreNotCheckedHere pins the decision issue
+// #1271 left open. The runtime trims, uppercases and caps sublayer_keys at the
+// number of subgrid cells, so a fault past that cap is in a character that is
+// never drawn — and this package cannot see the subgrid size to tell the two
+// apart. Silence here is the choice, not an oversight.
+func TestConfigValidateGrid_SublayerKeysAreNotCheckedHere(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.SublayerKeys = "a a"
+
+	got := warningsMentioning(validateGridWithWarnings(t, cfg), "grid.sublayer_keys")
+	if len(got) > 0 {
+		t.Errorf("warnings for grid.sublayer_keys = %q, want none", got)
+	}
+}
+
+// TestConfigValidateGrid_DuplicateLabelsWarn pins the duplicate case. Matching
+// folds case, so a repeat makes two rows answer to the same keystroke and only
+// one of them can win.
+func TestConfigValidateGrid_DuplicateLabelsWarn(t *testing.T) {
+	tests := []struct {
+		name  string
+		set   func(*config.Config)
+		field string
+	}{
+		{
+			name:  "row labels",
+			set:   func(c *config.Config) { c.Grid.RowLabels = "aba" },
+			field: "grid.row_labels",
+		},
+		{
+			name:  "col labels repeated case-insensitively",
+			set:   func(c *config.Config) { c.Grid.ColLabels = "abA" },
+			field: "grid.col_labels",
+		},
+		{
+			name:  "characters",
+			set:   func(c *config.Config) { c.Grid.Characters = "abb" },
+			field: "grid.characters",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			testCase.set(cfg)
+
+			got := warningsMentioning(validateGridWithWarnings(t, cfg), testCase.field)
+			if len(got) != 1 {
+				t.Fatalf("warnings for %s = %q, want exactly one", testCase.field, got)
+			}
+		})
+	}
+}
+
+// TestConfigValidateGrid_RepeatedCharacterIsReportedOnce keeps the report
+// proportional to the fault: a label set that repeats one character three times
+// is one thing wrong, not two.
+func TestConfigValidateGrid_RepeatedCharacterIsReportedOnce(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.RowLabels = "aaab"
+
+	got := warningsMentioning(validateGridWithWarnings(t, cfg), "grid.row_labels")
+	if len(got) != 1 {
+		t.Fatalf("warnings for grid.row_labels = %q, want exactly one", got)
+	}
+}
+
+// TestConfigValidateGrid_UntypeableLabelsWarn covers the characters that load
+// and cannot be pressed: whitespace, control characters and anything outside
+// ASCII, none of which a user can type at a label prompt.
+func TestConfigValidateGrid_UntypeableLabelsWarn(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels string
+	}{
+		{name: "space", labels: "a b"},
+		{name: "tab", labels: "a\tb"},
+		{name: "non-ascii", labels: "abé"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.Grid.RowLabels = testCase.labels
+
+			got := warningsMentioning(validateGridWithWarnings(t, cfg), "grid.row_labels")
+			if len(got) != 1 {
+				t.Fatalf("warnings for grid.row_labels = %q, want exactly one", got)
+			}
+		})
+	}
+}
+
+// TestConfigValidateGrid_InferredLabelsReportTheirSource is what keeps one
+// mistake from reading as four. Labels left empty are the characters, so a fault
+// in grid.characters reaches row_labels, col_labels and sublayer_keys as well —
+// and reporting it against all four would name three fields the user never
+// wrote and cannot fix.
+func TestConfigValidateGrid_InferredLabelsReportTheirSource(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.Characters = "abb"
+	cfg.Grid.RowLabels = ""
+	cfg.Grid.ColLabels = ""
+	cfg.Grid.SublayerKeys = ""
+	cfg.ResolveDerived()
+
+	got := validateGridWithWarnings(t, cfg)
+
+	if len(got) != 1 {
+		t.Fatalf("warnings = %q, want exactly one naming grid.characters", got)
+	}
+
+	if !strings.Contains(got[0], "grid.characters") {
+		t.Errorf("warning = %q, want it to name grid.characters", got[0])
+	}
+}
+
+// TestConfigValidateGrid_WrittenLabelsAreReportedThemselves is the other side of
+// that rule: a label set the user did write is judged on its own, whatever
+// grid.characters says.
+func TestConfigValidateGrid_WrittenLabelsAreReportedThemselves(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.RowLabels = "xyx"
+	cfg.ResolveDerived()
+
+	got := validateGridWithWarnings(t, cfg)
+
+	want := 1
+	if len(got) != want {
+		t.Fatalf("warnings = %q, want %d naming grid.row_labels", got, want)
+	}
+
+	if !strings.Contains(got[0], "grid.row_labels") {
+		t.Errorf("warning = %q, want it to name grid.row_labels", got[0])
+	}
+}
+
+// TestConfigValidateGrid_DisabledGridIsSilent keeps the warnings consistent with
+// the refusals around them: ValidateGrid returns early for a disabled grid so a
+// user can leave a section they do not use alone, and a warning that fired
+// anyway would be advice about a mode that never runs.
+func TestConfigValidateGrid_DisabledGridIsSilent(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.Enabled = false
+	cfg.Grid.RowLabels = "A"
+
+	if got := validateGridWithWarnings(t, cfg); len(got) > 0 {
+		t.Errorf("warnings = %q, want none for a disabled grid", got)
+	}
+}


### PR DESCRIPTION
## Description

This PR makes `neru config validate` report a grid label set the grid cannot
be fully driven from. `grid.row_labels` and `grid.col_labels` had no
validation at all, so any string was accepted — a single character, the same
character twice, or whitespace. That was tolerable while they were raw input
that was re-read on every draw, but they are now settled when the config
loads and hold the labels the grid is actually drawn with, so a bad value is
what ends up on screen.

Three faults are now reported: a set with a single character, a character used
twice (case is not distinct, so `aA` counts), and a character that cannot be
typed — whitespace or a control character. Each leaves part of the grid
unreachable without stopping a grid being built, so all three are warnings and
the configuration still loads; refusing would replace every other setting in
the file with the defaults over one line. `grid.characters` is checked the same
way, and a label left empty is checked as the characters it is inferred from,
so one mistake is reported once and under a field that is really in the file.

## Related Issues

Closes #1271

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no OS-specific code
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port changes
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config surface

No option is added, removed or renamed, and no default changes. What changes is
what `neru config validate` says about four existing keys under `[grid]`:

| Key | Before | After |
| --- | --- | --- |
| `characters` | empty or non-ASCII refused; nothing else checked | also warns on one character, a repeat, or an untypeable character |
| `row_labels` | nothing checked | warns on one character, a repeat, or an untypeable character |
| `col_labels` | nothing checked | warns on one character, a repeat, or an untypeable character |
| `sublayer_keys` | non-ASCII refused | unchanged |

Every configuration that loaded before still loads, and nothing that was
refused before is now accepted. A file with one of these faults keeps working
exactly as it did — it just says so now:

```toml
[grid]
characters = "a"       # warns: needs at least 2, so the grid is labeled a-z instead
row_labels = "aba"     # warns: uses 'A' more than once
col_labels = "x y"     # warns: contains ' ', which cannot be typed as a grid label
```

A hot reload logs the same warnings, since a daemon that reloaded on its own
has nobody to print to.

## Additional Context

Two decisions worth a reviewer's eye.

**`sublayer_keys` is deliberately left out.** The issue asked whether the same
checks belong on it. They do not, as things stand: the runtime trims,
upper-cases and caps it at the number of subgrid cells, so whether a repeat in
it costs anything depends on where in the string it falls — and the subgrid
size is owned by the mode layer, which the config package cannot see. Checking
the whole string would report faults in characters that are never drawn.
Making that checkable means giving the subgrid its shape as a shared constant,
which is a change of its own.

**The fourth failure mode in the issue — labels colliding with the keys that
leave or change the mode — is not implemented,** because it needs a decision
the issue does not settle. Bindings are deliberately live across a whole mode
(that is how #1034 was answered), so a warning on every grid binding that
shares a letter with the alphabet would fire on the recommended configuration
as readily as on a broken one. Happy to add it under whatever rule you want to
draw, in this PR or a follow-up.

The remaining three failure modes the issue listed are covered, and the tier is
ADR 0002's: warn, do not refuse, unless the value cannot produce a grid at all.
The existing refusals in this section are untouched.
