### PR TITLE
fix(grid): drop o from the alphabet a misconfigured grid falls back to

### DIFF
--- a/internal/app/modes/grid_labels_test.go
+++ b/internal/app/modes/grid_labels_test.go
@@ -3,6 +3,7 @@ package modes
 import (
 	"context"
 	"image"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -61,7 +62,7 @@ func TestCreateGridInstance_UsesTheResolvedLabels(t *testing.T) {
 			name:           "labels inferred from a character set too short to label with",
 			gridCharacters: "a",
 			hintCharacters: gridLabelHintChars,
-			wantCharacters: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+			wantCharacters: strings.ToUpper(domainGrid.DefaultCharacters),
 		},
 	}
 

--- a/internal/app/modes/grid_sublayer_keys_test.go
+++ b/internal/app/modes/grid_sublayer_keys_test.go
@@ -49,7 +49,8 @@ func TestInitializeGridManager_AcceptsTheKeysTheOverlayDraws(t *testing.T) {
 		},
 		{
 			// The floor. Nothing is configured anywhere, so the grid labels
-			// itself a-z and the subgrid has to follow it there rather than be
+			// itself from the default alphabet and the subgrid has to follow it
+			// there rather than be
 			// drawn with nothing.
 			name: "no keys, no grid characters and no hint characters",
 		},

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -7,6 +7,7 @@ import (
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/action"
 	"github.com/y3owk1n/neru/internal/domain/element"
+	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
 )
 
 const (
@@ -509,8 +510,12 @@ func defaultGrid() GridConfig {
 	return GridConfig{
 		Enabled: true,
 
-		Characters:   "abcdefghijklmnpqrstuvwxyz",
-		SublayerKeys: "abcdefghijklmnpqrstuvwxyz",
+		// Assigned from the domain constant rather than written out, because
+		// the grid falls back to that same set when the configured characters
+		// cannot label anything. Two literals is what they were, and they
+		// drifted (see grid.DefaultCharacters).
+		Characters:   domainGrid.DefaultCharacters,
+		SublayerKeys: domainGrid.DefaultCharacters,
 
 		// Empty is the meaning, not a missing default: "" tells the grid to
 		// infer its row and column labels from the characters it is drawn

--- a/internal/config/grid_labels_test.go
+++ b/internal/config/grid_labels_test.go
@@ -1,9 +1,11 @@
 package config_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/config"
+	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
 )
 
 // What a grid is built from: gridLabelHintChars is the hint alphabet it falls
@@ -17,12 +19,14 @@ const (
 )
 
 // What each of those settles to: the labels a grid built from it carries, and
-// the a-z floor for a set too short to label with.
+// the floor for a set too short to label with, read from the constant rather
+// than spelled out so a copy here cannot pass while the two disagree.
 const (
 	gridLabelsFromGridChars = "ASDFGHJKL"
 	gridLabelsFromHintChars = "QWERTY"
-	gridLabelsFloor         = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 )
+
+var gridLabelsFloor = strings.ToUpper(domainGrid.DefaultCharacters)
 
 // TestResolveGridLabels pins the answer to "what is grid.row_labels when
 // unset?". Before this resolution existed the answer lived in a consumer, so
@@ -69,7 +73,7 @@ func TestResolveGridLabels(t *testing.T) {
 			wantColLabels:  gridLabelsFromHintChars,
 		},
 		{
-			name:           "a character set too short to label anything infers a-z",
+			name:           "a character set too short to label anything infers the default alphabet",
 			gridCharacters: "a",
 			hintCharacters: gridLabelHintChars,
 			wantRowLabels:  gridLabelsFloor,

--- a/internal/config/grid_sublayer_keys.go
+++ b/internal/config/grid_sublayer_keys.go
@@ -39,9 +39,10 @@ func (c *Config) ResolveSublayerKeys() {
 
 	// The characters the grid is *labeled* with rather than the ones it was
 	// configured with, which is the same question ResolveGridLabels asks and
-	// has to get the same answer: those two settle to a-z when the configured
-	// set is blank or too short to label with, and a subgrid resolved to the
-	// blank set instead would be drawn with nothing and accept nothing — a
+	// has to get the same answer: those two settle to grid.DefaultCharacters
+	// when the configured set is blank or too short to label with, and a
+	// subgrid resolved to the blank set instead would be drawn with nothing
+	// and accept nothing — a
 	// keyless subgrid under a labeled grid. ValidateGrid refuses a blank
 	// grid.characters, so this is a floor rather than a configuration a user
 	// runs on; `neru config set --no-reload` is the path that skips it.

--- a/internal/config/grid_sublayer_keys_test.go
+++ b/internal/config/grid_sublayer_keys_test.go
@@ -50,7 +50,8 @@ func TestResolveSublayerKeys(t *testing.T) {
 			want:           gridLabelsFromHintChars,
 		},
 		{
-			// Nothing left to infer from. The grid still labels itself a-z, so
+			// Nothing left to infer from. The grid still labels itself from
+			// the default alphabet, so
 			// resolving to the blank set here would draw a subgrid with no keys
 			// on it under a grid that has them.
 			name:           "no characters anywhere still leaves a subgrid to navigate",

--- a/internal/domain/grid/default_characters_test.go
+++ b/internal/domain/grid/default_characters_test.go
@@ -1,0 +1,18 @@
+package grid_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain/grid"
+)
+
+// TestDefaultCharacters_OmitsO pins the one thing the constant itself cannot
+// say: `o` is left out on purpose, because it is hard to tell from `0` at label
+// size. Sharing the constant makes the config default and the fallback the same
+// set; this is what keeps that set from quietly growing an `o` back.
+func TestDefaultCharacters_OmitsO(t *testing.T) {
+	if strings.ContainsAny(grid.DefaultCharacters, "oO") {
+		t.Errorf("DefaultCharacters = %q, want no o", grid.DefaultCharacters)
+	}
+}

--- a/internal/domain/grid/grid.go
+++ b/internal/domain/grid/grid.go
@@ -27,6 +27,16 @@ const (
 	// MinCharactersLength is the minimum length for characters.
 	MinCharactersLength = 2
 
+	// DefaultCharacters is the alphabet a grid is labeled from: a-z without
+	// `o`, which is hard to tell from `0` at label size. It is both the
+	// shipped default for grid.characters and grid.sublayer_keys (config
+	// assigns them from this constant) and the set newGridAlphabet falls back
+	// to when the configured one cannot label anything. Those were two
+	// literals and they drifted — the fallback kept the `o` the default had
+	// dropped — so they are one constant now, and a user who misconfigures
+	// grid.characters cannot be shown a character the default excludes.
+	DefaultCharacters = "abcdefghijklmnpqrstuvwxyz"
+
 	// MinGridCols is the minimum number of grid columns.
 	MinGridCols = 2
 
@@ -244,18 +254,19 @@ type gridAlphabet struct {
 	colChars   []rune
 }
 
-// newGridAlphabet uppercases the character sets and falls back to a-z when the
-// coordinate set is empty or too small to label anything.
+// newGridAlphabet uppercases the character sets and falls back to
+// DefaultCharacters when the coordinate set is empty or too small to label
+// anything.
 func newGridAlphabet(characters, rowLabels, colLabels string) gridAlphabet {
 	if characters == "" {
-		characters = "abcdefghijklmnopqrstuvwxyz"
+		characters = DefaultCharacters
 	}
 
 	upper := strings.ToUpper(characters)
 	chars := []rune(upper)
 
 	if len(chars) < MinCharactersLength {
-		upper = strings.ToUpper("abcdefghijklmnopqrstuvwxyz")
+		upper = strings.ToUpper(DefaultCharacters)
 		chars = []rune(upper)
 	}
 
@@ -276,8 +287,8 @@ func newGridAlphabet(characters, rowLabels, colLabels string) gridAlphabet {
 // ResolveLabels answers the row and column labels a grid built from these
 // arguments will actually use, so a caller can hold that answer instead of
 // re-deriving it. Empty labels are inferred from characters, which is itself
-// replaced by a-z when it is empty or too short to label anything — that
-// second step is why the answer is worth asking for rather than assuming
+// replaced by DefaultCharacters when it is empty or too short to label
+// anything — that second step is why the answer is worth asking for rather than assuming
 // "empty means characters".
 //
 // Passing the result back into NewGridWithLabels builds the same grid as

--- a/internal/domain/grid/grid_test.go
+++ b/internal/domain/grid/grid_test.go
@@ -11,7 +11,9 @@ import (
 
 const (
 	testCharacters = "ABC"
-	alphabet       = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	// allLetters is a 26-character input, not the set a grid falls back to —
+	// that one is grid.DefaultCharacters, which leaves `o` out.
+	allLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 )
 
 func TestGrid_Initialization(t *testing.T) {
@@ -24,7 +26,7 @@ func TestGrid_Initialization(t *testing.T) {
 	}{
 		{
 			name:      "standard 1080p",
-			chars:     alphabet,
+			chars:     allLetters,
 			bounds:    image.Rect(0, 0, 1920, 1080),
 			wantCells: 26 * 26, // 2 chars depth
 		},
@@ -155,7 +157,7 @@ func TestCalculateOptimalGrid(t *testing.T) {
 		{"normal characters", testCharacters, 3, 3},
 		{"empty string", "", 9, 9},
 		{"single character", "A", 9, 9},
-		{"long string", alphabet, 26, 26},
+		{"long string", allLetters, 26, 26},
 	}
 
 	for _, testCase := range tests {
@@ -198,10 +200,11 @@ func TestGrid_InvalidBounds(t *testing.T) {
 func TestGrid_EmptyCharacters(t *testing.T) {
 	logger := logger.Get()
 	bounds := image.Rect(0, 0, 300, 300)
+	fallback := strings.ToUpper(grid.DefaultCharacters)
 
-	// Empty characters should default to alphabet
+	// Empty characters should default to the fallback alphabet
 	gridInstance := grid.NewGrid("", bounds, logger)
-	if gridInstance.Characters() != alphabet {
+	if gridInstance.Characters() != fallback {
 		t.Errorf(
 			"Empty characters should default to alphabet, got %q",
 			gridInstance.Characters(),
@@ -210,7 +213,7 @@ func TestGrid_EmptyCharacters(t *testing.T) {
 
 	// Single character should also default
 	gridInstance = grid.NewGrid("A", bounds, logger)
-	if gridInstance.Characters() != alphabet {
+	if gridInstance.Characters() != fallback {
 		t.Errorf(
 			"Single character should default to alphabet, got %q",
 			gridInstance.Characters(),


### PR DESCRIPTION
## Description

This PR fixes the alphabet a grid falls back to when the characters it is
configured with are too short to label anything. That fallback was a plain
a-z, while the shipped default deliberately leaves `o` out — at label size it
is hard to tell from `0`. So a user who set `grid.characters` to a single
character was shown the one character the project had decided not to ship.

The two alphabets were separate string literals and drifted apart. They are
one definition now, which the config default is assigned from, so the set a
grid can be labelled from cannot grow a second copy that falls behind. Some
neighbouring comments and a test-case name still described the fallback as
"a-z" and were corrected in the same change.

Latent before this PR: the fallback only runs on a character set shorter than
the minimum, and the shipped default is not, so nobody reaches it without
editing `grid.characters` first.

## Related Issues

Closes #1272

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no OS-specific files touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changed
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, the documented default value is unchanged
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config surface

No config change. `grid.characters` and `grid.sublayer_keys` keep the same
default, `"abcdefghijklmnpqrstuvwxyz"` — it is now assigned from the shared
definition rather than written out a second time. Existing config files keep
working, and `docs/CONFIGURATION.md` and the shipped examples already state
this value.

What changes for a user is only the case the default does not cover: with a
`grid.characters` too short to label with, the grid is now labelled from that
same alphabet instead of a-z, so no `o` appears on screen.

## Additional Context

The issue asked whether this wanted the guardrail treatment of ADR 0006 — a
test that fails when the two alphabets diverge — or whether one definition
makes such a test redundant. Redundant, so there is none: an assignment cannot
drift. The one test added pins the thing the definition itself cannot state,
which is that leaving `o` out is deliberate.

The issue also suggested folding `hints.hint_characters` into the same change.
That one already has a single home — the duplicate constant it mentions was
removed in #1275 — so there was nothing to fold.
