### PR TITLE
fix(grid): stop a repeated character drawing cells nothing can select

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1032,17 +1032,26 @@ warns when one of them holds a single character, the same character twice (case
 is folded — `aA` is one character written twice), or a character that cannot be
 typed: whitespace or a control character. None of these stops a grid being built
 — a short `characters` is replaced by `a-z`, short labels cap the grid to the
-cells they can name, and a repeat leaves one cell answering to nobody — so the
-configuration still loads and the warning is where you hear about it. A label
-left empty is checked as the `characters` it is inferred from and reported under
-that name, so one mistake is reported once.
+cells they can name, and a repeat is dropped — so the configuration still loads
+and the warning is where you hear about it. A label left empty is checked as the
+`characters` it is inferred from and reported under that name, so one mistake is
+reported once.
+
+**A repeat is dropped, never drawn.** Every set a grid is labelled from is read as
+its distinct characters, `sublayer_keys` included, so the grid is built from `ab`
+whether you wrote `ab`, `aab` or `aAb`. That is why the repeat is worth a warning
+rather than a refusal: what it costs is a shorter alphabet, not a cell you can see
+and cannot click. Note that dropping repeats is also what can leave a set too
+short — `characters = "aa"` has one usable character, so it falls back to `a-z`,
+and both facts are reported.
 
 Two neighbouring rules are older and stricter, and refuse the file rather than
 warn: `characters` cannot be empty, and neither `characters` nor `sublayer_keys`
 may contain a character outside ASCII. `row_labels` and `col_labels` warn about
 non-ASCII instead. `sublayer_keys` is not checked for the three faults above:
-only its first 9 characters are drawn, and the rest are dropped, so a repeat
-among them costs nothing.
+only its first 9 characters are drawn, so which of them matter depends on the
+subgrid rather than on the option — a set of exactly 9 with a repeat in it leaves
+one subgrid cell unlabelled, which is visible on screen in a way a warning is not.
 
 ### UI
 

--- a/internal/app/components/types.go
+++ b/internal/app/components/types.go
@@ -1,8 +1,6 @@
 package components
 
 import (
-	"strings"
-
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/app/components/grid"
@@ -44,10 +42,15 @@ func (g *GridComponent) UpdateConfig(cfg *config.Config, logger *zap.Logger) {
 				// used to infer the labels here, which is the only place that
 				// rule existed — and getting it wrong rebuilt the grid on every
 				// reload, discarding the user's in-flight coordinate input.
+				// Each side asked of the grid rather than compared as written,
+				// which is the same rule one step further on: the grid drops a
+				// character a set repeats, so a set that gained only a repeat is
+				// the set already in use, and comparing the strings would rebuild
+				// on every reload for the rest of that config's life.
 				characters := cfg.GridCharacters()
-				newCharacters := strings.ToUpper(characters)
-				newRowLabels := cfg.Grid.RowLabels
-				newColLabels := cfg.Grid.ColLabels
+				newCharacters := domainGrid.ResolveCharacters(characters)
+				newRowLabels := string(domainGrid.DistinctKeys(cfg.Grid.RowLabels))
+				newColLabels := string(domainGrid.DistinctKeys(cfg.Grid.ColLabels))
 
 				charactersChanged := newCharacters != oldGrid.Characters()
 				rowLabelsChanged := newRowLabels != oldGrid.RowLabels()

--- a/internal/app/components/types_test.go
+++ b/internal/app/components/types_test.go
@@ -67,7 +67,10 @@ func TestGridComponent_UpdateConfig_RecreatesGridOnLabelChanges(t *testing.T) {
 		characters, rowLabels, colLabels string
 		// newCharacters etc. are what the reloaded config carries.
 		newCharacters, newRowLabels, newColLabels string
-		wantRecreate                              bool
+		// wantCharacters is the set the grid must end up describing, for the
+		// cases where that is not just newCharacters upper-cased.
+		wantCharacters string
+		wantRecreate   bool
 	}{
 		{
 			name:       "identical config keeps the existing grid",
@@ -105,6 +108,25 @@ func TestGridComponent_UpdateConfig_RecreatesGridOnLabelChanges(t *testing.T) {
 			newCharacters: testCharacters, newRowLabels: "AB", newColLabels: "cd",
 			wantRecreate: false,
 		},
+		{
+			// A repeat is dropped when the grid is built, so a set that only
+			// gained one is the same set. Comparing the string as written would
+			// see a change on every reload and rebuild the grid each time.
+			name:       "a character listed twice keeps the existing grid",
+			characters: testCharacters, rowLabels: "", colLabels: "",
+			newCharacters: "abcda", newRowLabels: "", newColLabels: "",
+			wantCharacters: "ABCD",
+			wantRecreate:   false,
+		},
+		{
+			// The same for a label set, which the derivation settles with its
+			// repeats still in it so the config can report them: the grid dropped
+			// the repeat, so the two describe the same labels.
+			name:       "a row label listed twice keeps the existing grid",
+			characters: testCharacters, rowLabels: "ab", colLabels: "cd",
+			newCharacters: testCharacters, newRowLabels: "aba", newColLabels: "cd",
+			wantRecreate: false,
+		},
 	}
 
 	for _, testCase := range tests {
@@ -135,7 +157,12 @@ func TestGridComponent_UpdateConfig_RecreatesGridOnLabelChanges(t *testing.T) {
 
 			// Whether or not it was rebuilt, the grid must end up describing
 			// the labels the reloaded config asked for.
-			if got, want := after.Characters(), upper(testCase.newCharacters); got != want {
+			want := testCase.wantCharacters
+			if want == "" {
+				want = upper(testCase.newCharacters)
+			}
+
+			if got := after.Characters(); got != want {
 				t.Errorf("Characters() = %q, want %q", got, want)
 			}
 		})

--- a/internal/config/validators_grid.go
+++ b/internal/config/validators_grid.go
@@ -6,6 +6,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/y3owk1n/neru/internal/derrors"
+	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
 )
 
 // ValidateGrid validates the grid configuration, warning about the key sets
@@ -93,9 +94,10 @@ type gridKeySet struct {
 // a character used twice, or one that cannot be typed.
 //
 // It warns rather than refuses because none of the three stops a grid being
-// built — the grid is capped, relabelled, or has one cell that answers to
-// nobody — and refusing would replace the user's whole configuration with the
-// defaults over a label set they can fix in one line (ADR 0002). The refusals
+// built — the grid is capped, relabelled, labeled from a shorter set than was
+// written, or has one cell that answers to a key nobody can press — and refusing
+// would replace the user's whole configuration with the defaults over a label set
+// they can fix in one line (ADR 0002). The refusals
 // above are unchanged: an empty or non-ASCII grid.characters still costs the
 // load, and this pass is what the fields it does not cover now get instead of
 // nothing.
@@ -152,10 +154,16 @@ func warnGridKeySet(warnings *Warnings, set gridKeySet) {
 
 	chars := []rune(set.keys)
 
-	if len(chars) < MinCharactersLength {
+	// Counted after the repeats come out, because that is the count the grid
+	// applies its floor to (domain/grid.newGridAlphabet): "aa" is two characters
+	// written and one character to label with, and reading the written length
+	// here would let it reach the a-z fallback without a word said.
+	usable := len(domainGrid.DistinctKeys(set.keys))
+
+	if usable < MinCharactersLength {
 		warnings.Addf(
-			"%s has %d character and needs at least %d, %s",
-			set.field, len(chars), MinCharactersLength, set.tooShort,
+			"%s has %d usable character and needs at least %d, %s",
+			set.field, usable, MinCharactersLength, set.tooShort,
 		)
 	}
 
@@ -167,10 +175,12 @@ func warnGridKeySet(warnings *Warnings, set gridKeySet) {
 // second occurrence, so that a character written three times is one thing wrong
 // rather than two.
 //
-// Case is folded because matching is: "aA" is one label written twice, and the
-// second of the two cells it names cannot be reached. The character is reported
-// folded too — the grid draws its labels upper-cased, so that is the form the
-// user is looking for on screen.
+// Case is folded because matching is: "aA" is one label written twice. The grid
+// drops the second one (domain/grid.DistinctKeys) rather than labeling a cell
+// nothing can reach, so what the repeat costs is the size of the set the grid is
+// labeled from — which is why this is worth saying even though nothing is broken
+// by it. The character is reported folded too: the grid draws its labels
+// upper-cased, so that is the form the user is looking for on screen.
 func warnDuplicateGridKeys(warnings *Warnings, field string, chars []rune) {
 	seen := make(map[rune]struct{}, len(chars))
 	reported := make(map[rune]struct{})
@@ -194,7 +204,8 @@ func warnDuplicateGridKeys(warnings *Warnings, field string, chars []rune) {
 		reported[upper] = struct{}{}
 
 		warnings.Addf(
-			"%s uses %q more than once, so two cells answer to the same keystroke",
+			"%s uses %q more than once; the repeat is dropped, "+
+				"so the grid is labeled from fewer characters than the option lists",
 			field, upper,
 		)
 	}

--- a/internal/config/validators_grid_labels_test.go
+++ b/internal/config/validators_grid_labels_test.go
@@ -213,6 +213,30 @@ func TestConfigValidateGrid_RepeatedCharacterIsReportedOnce(t *testing.T) {
 	}
 }
 
+// TestConfigValidateGrid_RepeatsThatLeaveTooFewCharactersWarn covers the two
+// faults that arrive as one. Repeats come out before the grid applies its floor
+// (domain/grid.newGridAlphabet), so "aa" is a set of two characters that can
+// label with one, and the grid replaces it with a-z: the repeat and the set being
+// too short are both true, and counting the written length would have reported
+// neither.
+func TestConfigValidateGrid_RepeatsThatLeaveTooFewCharactersWarn(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.Characters = "aa"
+
+	got := warningsMentioning(validateGridWithWarnings(t, cfg), "grid.characters")
+
+	want := 2
+	if len(got) != want {
+		t.Fatalf("warnings for grid.characters = %q, want %d", got, want)
+	}
+
+	for _, expected := range []string{"more than once", "usable character"} {
+		if !strings.Contains(strings.Join(got, "\n"), expected) {
+			t.Errorf("warnings = %q, want one mentioning %q", got, expected)
+		}
+	}
+}
+
 // TestConfigValidateGrid_UntypeableLabelsWarn covers the characters that load
 // and cannot be pressed: whitespace, control characters and anything outside
 // ASCII, none of which a user can type at a label prompt.

--- a/internal/domain/grid/distinct_keys.go
+++ b/internal/domain/grid/distinct_keys.go
@@ -1,0 +1,43 @@
+package grid
+
+import "strings"
+
+// DistinctKeys is the key set a written one means: upper-cased, in the order it
+// was written, with every character that appears again dropped.
+//
+// It exists because a grid resolves a typed key to a position by finding it, and
+// finding it stops at the first one. A character written twice therefore named
+// two places and reached one: nine subgrid labels over eight reachable points,
+// or — through the coordinate alphabet, where a label is several characters —
+// sixteen cells all called AAAA. The second one of each pair was drawn, was
+// typed, and did nothing.
+//
+// Case-folded, because that is the comparison every reader of these sets makes
+// (the manager upper-cases a key before matching it), so "aA" is one key in
+// exactly the way "aa" is. It is the rule hints.hint_characters has always had —
+// validateHintCharacters refuses a repeat outright — arrived at from the other
+// side: the grid drops the repeat instead of refusing the configuration, and the
+// config warns about it (config.ValidateGrid), because refusing a grid costs the
+// whole file (ADR 0002).
+//
+// Exported so the config can ask what a written set comes to — how short the
+// grid's alphabet ends up, which is what its floor and its warning are about —
+// rather than working it out from a second copy of this rule.
+func DistinctKeys(keys string) []rune {
+	upper := strings.ToUpper(keys)
+	distinct := make([]rune, 0, len(upper))
+
+	seen := make(map[rune]struct{}, len(upper))
+
+	for _, key := range upper {
+		_, repeat := seen[key]
+		if repeat {
+			continue
+		}
+
+		seen[key] = struct{}{}
+		distinct = append(distinct, key)
+	}
+
+	return distinct
+}

--- a/internal/domain/grid/grid.go
+++ b/internal/domain/grid/grid.go
@@ -24,7 +24,9 @@ const (
 	// AspectRatioAdjustment is the adjustment factor for extreme aspect ratios.
 	AspectRatioAdjustment = 1.2
 
-	// MinCharactersLength is the minimum length for characters.
+	// MinCharactersLength is the fewest distinct characters a grid can be
+	// labeled from — distinct, because repeats are dropped before the floor is
+	// applied (newGridAlphabet).
 	MinCharactersLength = 2
 
 	// DefaultCharacters is the alphabet a grid is labeled from: a-z without
@@ -254,34 +256,40 @@ type gridAlphabet struct {
 	colChars   []rune
 }
 
-// newGridAlphabet uppercases the character sets and falls back to
-// DefaultCharacters when the coordinate set is empty or too small to label
-// anything.
+// newGridAlphabet uppercases the character sets, drops the characters they
+// repeat, and falls back to DefaultCharacters when the coordinate set is left
+// too small to label anything with.
+//
+// The repeats go here rather than at each of the three sets in turn because this
+// is the one place all three are read from — a coordinate is built from chars,
+// rowChars and colChars together (DistinctKeys says what a repeat costs).
+//
+// Dropping them can be what makes a set too small — "aa" is one character, not
+// two — so the floor is applied to what is left, not to what was written.
 func newGridAlphabet(characters, rowLabels, colLabels string) gridAlphabet {
-	if characters == "" {
-		characters = DefaultCharacters
-	}
-
-	upper := strings.ToUpper(characters)
-	chars := []rune(upper)
+	chars := DistinctKeys(characters)
 
 	if len(chars) < MinCharactersLength {
-		upper = strings.ToUpper(DefaultCharacters)
-		chars = []rune(upper)
+		chars = DistinctKeys(DefaultCharacters)
 	}
 
 	rowChars := chars
 	colChars := chars
 
 	if rowLabels != "" {
-		rowChars = []rune(strings.ToUpper(rowLabels))
+		rowChars = DistinctKeys(rowLabels)
 	}
 
 	if colLabels != "" {
-		colChars = []rune(strings.ToUpper(colLabels))
+		colChars = DistinctKeys(colLabels)
 	}
 
-	return gridAlphabet{characters: upper, chars: chars, rowChars: rowChars, colChars: colChars}
+	return gridAlphabet{
+		characters: string(chars),
+		chars:      chars,
+		rowChars:   rowChars,
+		colChars:   colChars,
+	}
 }
 
 // ResolveLabels answers the row and column labels a grid built from these
@@ -291,13 +299,43 @@ func newGridAlphabet(characters, rowLabels, colLabels string) gridAlphabet {
 // anything — that second step is why the answer is worth asking for rather than assuming
 // "empty means characters".
 //
+// A label set that was written comes back upper-cased and otherwise as it was,
+// repeats and all, even though the grid will drop those (newGridAlphabet). What
+// the derivation settles is what the *user asked for*, and a repeat is the one
+// part of that a reader still needs: config.warnGridKeySets reads these fields
+// to tell the user a character was dropped, and it runs after the derivation, so
+// dropping it here would leave nothing to report and the grid quietly labeled
+// with a set nobody chose.
+//
 // Passing the result back into NewGridWithLabels builds the same grid as
 // passing the empty strings did, which is what lets config.ResolveGridLabels
 // settle the option at load time.
 func ResolveLabels(characters, rowLabels, colLabels string) (string, string) {
-	alpha := newGridAlphabet(characters, rowLabels, colLabels)
+	alpha := newGridAlphabet(characters, "", "")
 
-	return string(alpha.rowChars), string(alpha.colChars)
+	return settleLabels(rowLabels, alpha.chars), settleLabels(colLabels, alpha.chars)
+}
+
+// settleLabels is one label set's answer: what was written, upper-cased, or the
+// characters the grid falls back on when nothing was.
+func settleLabels(labels string, inferred []rune) string {
+	if labels == "" {
+		return string(inferred)
+	}
+
+	return strings.ToUpper(labels)
+}
+
+// ResolveCharacters answers the coordinate characters a grid built from this set
+// will report ([Grid.Characters]): upper-cased, with repeats dropped, and
+// replaced by DefaultCharacters when what is left is too short to label with.
+//
+// It is for the caller comparing a reloaded configuration against the grid it is
+// already running — a set that differs from the live one only by a repeat or a
+// letter's case is the same set, and treating it as a change rebuilds the grid
+// and discards whatever coordinate the user was halfway through typing.
+func ResolveCharacters(characters string) string {
+	return newGridAlphabet(characters, "", "").characters
 }
 
 // newGridFromCells assembles a Grid and its lookup indexes from finished cells.

--- a/internal/domain/grid/grid_invariants_test.go
+++ b/internal/domain/grid/grid_invariants_test.go
@@ -27,8 +27,12 @@ func gridSizes() []image.Rectangle {
 	}
 }
 
+// gridAlphabets covers the sizes a coordinate set comes in, plus one that lists
+// a character twice: a repeat used to reach the labeling pass as an extra
+// character, and every invariant below broke on it at once — two cells sharing a
+// coordinate, an index smaller than the cell count, cells nothing can address.
 func gridAlphabets() []string {
-	return []string{"ab", "abcd", "asdfghjkl", "abcdefghijklmnopqrstuvwxyz"}
+	return []string{"ab", "aab", "abcd", "asdfghjkl", "abcdefghijklmnopqrstuvwxyz"}
 }
 
 func newTestGrid(bounds image.Rectangle, characters string) *grid.Grid {

--- a/internal/domain/grid/grid_test.go
+++ b/internal/domain/grid/grid_test.go
@@ -221,6 +221,44 @@ func TestGrid_EmptyCharacters(t *testing.T) {
 	}
 }
 
+// TestGrid_RepeatedCharactersLabelOnce pins what a coordinate set that lists a
+// character twice builds: the grid the distinct characters build. A repeat used
+// to widen the alphabet the labeling pass counted on, which drew coordinates
+// twice over and left every cell past the first one carrying them unreachable —
+// `characters = "aab"` put 16 different cells under `AAAA`.
+func TestGrid_RepeatedCharactersLabelOnce(t *testing.T) {
+	log := logger.Get()
+	bounds := image.Rect(0, 0, 1000, 800)
+
+	repeated := grid.NewGrid("aab", bounds, log)
+	distinct := grid.NewGrid("ab", bounds, log)
+
+	if repeated.Characters() != distinct.Characters() {
+		t.Errorf(
+			"Characters() = %q, want %q — the repeat is not a character",
+			repeated.Characters(), distinct.Characters(),
+		)
+	}
+
+	if len(repeated.Cells()) != len(distinct.Cells()) {
+		t.Errorf(
+			"a grid built from %q has %d cells, one built from %q has %d",
+			"aab", len(repeated.Cells()), "ab", len(distinct.Cells()),
+		)
+	}
+}
+
+// TestGrid_RepeatsCanLeaveTooFewCharacters covers the floor the dedupe lands on:
+// a set that is only repeats has one distinct character, which cannot label a
+// grid at all, so it falls back like any other set too short to label with.
+func TestGrid_RepeatsCanLeaveTooFewCharacters(t *testing.T) {
+	gridInstance := grid.NewGrid("aA", image.Rect(0, 0, 300, 300), logger.Get())
+
+	if want := strings.ToUpper(grid.DefaultCharacters); gridInstance.Characters() != want {
+		t.Errorf("Characters() = %q, want the fallback %q", gridInstance.Characters(), want)
+	}
+}
+
 func TestGrid_WithCustomLabels(t *testing.T) {
 	logger := logger.Get()
 	bounds := image.Rect(0, 0, 300, 300)

--- a/internal/domain/grid/subgrid_keys.go
+++ b/internal/domain/grid/subgrid_keys.go
@@ -22,8 +22,13 @@ import "strings"
 // a user gets by pointing sublayer_keys at their whole alphabet, and refusing
 // the configuration over it would cost them the grid. The keys that name a cell
 // are the keys, and the rest were never drawn.
+//
+// A key written twice is one key (DistinctKeys), and the repeat is dropped
+// before the cap rather than after, so the cells that do get a label get a
+// working one: selection finds a key by its first index, so the second label
+// drawn for a repeated key selected the first label's cell.
 func SubgridKeys(keys string, cells int) []rune {
-	runes := []rune(strings.ToUpper(strings.TrimSpace(keys)))
+	runes := DistinctKeys(strings.TrimSpace(keys))
 
 	return runes[:max(0, min(len(runes), cells))]
 }

--- a/internal/domain/grid/subgrid_keys_test.go
+++ b/internal/domain/grid/subgrid_keys_test.go
@@ -48,6 +48,16 @@ func TestSubgridKeys(t *testing.T) {
 			keys: "",
 			want: "",
 		},
+		{
+			name: "a key listed twice is one key",
+			keys: "aabcdefgh",
+			want: "ABCDEFGH",
+		},
+		{
+			name: "a repeat is dropped whichever case it is written in",
+			keys: "aAbB",
+			want: "AB",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -103,6 +113,38 @@ func TestManager_AcceptsExactlyTheKeysTheSubgridIsDrawnWith(t *testing.T) {
 		if _, selected := manager.HandleInput(string(key)); selected {
 			t.Errorf("subgrid selected on %q, which no cell is drawn with", string(key))
 		}
+	}
+}
+
+// TestManager_EveryDrawnSubgridKeySelectsItsOwnPoint is what a duplicated key
+// costs. Selection resolves a key by its first index, so a key listed twice used
+// to draw a second label over a second cell and then send both presses to the
+// first one: nine labels, eight reachable points, and no way to tell which of
+// the two was dead.
+func TestManager_EveryDrawnSubgridKeySelectsItsOwnPoint(t *testing.T) {
+	// Nine keys, one of them written twice, so the set fills the subgrid only if
+	// the repeat counts as a key.
+	const configured = "aabcdefgh"
+
+	drawn := grid.SubgridKeys(configured, subgridCells)
+
+	points := make(map[image.Point]rune, len(drawn))
+
+	for _, key := range drawn {
+		manager := newSubgridKeyManager(t, configured)
+
+		point, selected := manager.HandleInput(string(key))
+		if !selected {
+			t.Errorf("subgrid refused %q, which it is drawn with", string(key))
+
+			continue
+		}
+
+		if previous, shared := points[point]; shared {
+			t.Errorf("keys %q and %q both select %v", string(previous), string(key), point)
+		}
+
+		points[point] = key
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes a grid that draws cells you can never select. The sets a grid is
labelled from counted a character written twice as two characters, but typing one
resolves to the first cell carrying it, so the later cells were drawn, accepted the
keystroke, and did nothing. With nine subgrid keys where one repeats, nine labels
appeared over eight reachable points; with `characters = "aab"`, sixteen different
cells all answered to the same coordinate.

Every set a grid is labelled from is now read as its distinct characters, so a
repeat costs a shorter alphabet instead of a dead cell. The configuration is not
refused over one — a failed validation replaces the whole file with the defaults,
and #1280 already reports the repeat as a warning, which is where a user hears
about it.

Dropping repeats also changes what "too short to label with" means, so that
warning counts the characters that survive: `characters = "aa"` has one usable
character and falls back to `a-z`, which used to happen in silence. The duplicate
warning stopped claiming that two cells answer to the same keystroke, because
after this they no longer do.

## Related Issues

Closes #1276

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no
      OS-specific files are touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) —
      N/A, no port gains a platform-specific implementation
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config surface

No option is added, renamed or removed, and no default changes. What changes is
how the values of four existing options are read — all four are now sets of
distinct characters, case folded:

| Option              | Written              | Grid is built from |
| ------------------- | -------------------- | ------------------ |
| `grid.characters`   | `"aab"` / `"aAb"`    | `AB`               |
| `grid.sublayer_keys`| `"aabcdefgh"`        | `ABCDEFGH`         |
| `grid.row_labels`   | `"aba"`              | `AB`               |
| `grid.col_labels`   | `"aba"`              | `AB`               |

Every configuration without a repeat in those four options is unaffected, which
includes the shipped defaults.

`neru config validate` output changes for configurations that do have one:

```
$ neru config validate
Configuration is valid, with warnings:

  grid.characters has 1 usable character and needs at least 2, so the grid is labeled a-z instead
  grid.characters uses 'A' more than once; the repeat is dropped, so the grid is labeled from fewer characters than the option lists
```

The wording of the duplicate warning changed (it described the old behaviour), and
the too-short warning now says "usable character" and fires on a set whose repeats
leave it short — `characters = "aa"` reported nothing before.

## Potentially breaking

Only for a configuration that already repeats a character in one of those four
options, and only in the direction of fixing it:

- **The grid may be labelled differently.** A repeated character shortens the
  alphabet, and label length and cell count follow from it, so coordinates in a
  grid built from a repeat can differ from the ones drawn before. Anyone in that
  position was previously looking at cells that could not be clicked, so muscle
  memory built on those labels was already unreliable.
- **`characters = "aa"`-shaped values now reach the `a-z` fallback.** One distinct
  character cannot label a grid; before, two identical ones produced a grid where
  every cell shared a coordinate. The fix is to write two different characters.

Nothing to migrate: the fix is to remove the repeat, and `neru config validate`
names the character to remove.

## Additional Context

**Why de-duplicate rather than refuse.** #1276 left the choice open between
refusing the value, warning about it, and dropping the repeat. Refusing costs the
user every binding, theme and setting in the file over one character (ADR 0002),
and #1280 landed the warning while this was being written — so this PR is the
remaining piece, the behaviour, and it leans on that warning for the reporting.

**Why the derivation keeps the repeats.** `grid.row_labels` and `grid.col_labels`
are settled before validation runs, so if the derivation dropped the repeat there
would be nothing left for #1280's warning to find and the grid would quietly use a
set the user did not choose. The written value is kept as written, and the grid
drops the repeat where it is built.

**A reload bug fixed on the way.** The check that decides whether a configuration
reload has to rebuild the grid compared the written characters against the ones the
live grid resolved to. Once repeats are dropped those two stopped matching, so a
configuration containing one would have rebuilt the grid on every reload and thrown
away a half-typed coordinate; each side now asks the grid what a set comes to.

**`grid.sublayer_keys` is still not in the warning pass.** #1280 left it out
deliberately, and this PR does not reverse that: its repeats are dropped like every
other set's, so a subgrid never draws a key that selects another cell's point, but a
set of exactly nine keys with a repeat leaves one subgrid cell unlabelled rather
than reported. That gap belongs to whichever change revisits it.

**On screenshots.** The visible effect needs a deliberately misconfigured grid, and
what it looks like is the absence of a phantom label, so the evidence is in the
tests instead: one measures that every drawn subgrid key selects its own point, and
the grid invariants now run over an alphabet with a repeat in it, which fails on
`main` with sixteen cells sharing a coordinate.
