### PR TITLE
fix(overlay): resolve generic font names the same way on every platform

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -117,3 +117,15 @@ _Avoid_: pill, chip, tag
 An overlay's resolved appearance: configuration combined with the current
 light/dark theme. Resolved once, at the adapter boundary.
 _Avoid_: theme, palette, config
+
+### Computing the same thing twice
+
+**Shared derivation**:
+A value more than one layer computes from the same inputs and must compute
+identically: where a grid cell is drawn and where the cursor lands inside it,
+what a written font name means. A shared derivation has exactly one
+implementation, and it lives at the lowest layer that has more than one
+caller — not in the domain by default. Where the second implementation is in
+Objective-C, Go cannot be the one implementation, so the copies are pinned by
+a test instead. ADR 0007 has the reasoning.
+_Avoid_: helper, util, common code, shared logic

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -162,8 +162,8 @@ reasoning.
 
 ² macOS and Linux resolve font *families* through the OS (NSFont, fontconfig).
 Windows only maps the generic aliases `sans` / `serif` / `mono` to Segoe UI /
-Cambria / Consolas and passes every other name through verbatim; an unavailable
-family falls back to whatever GDI substitutes.
+Cambria / Consolas and passes every other name straight to GDI without checking
+it; an unavailable family falls back to whatever GDI substitutes.
 
 Which names count as generic is the same on all three: `sans`, `sans serif`,
 `serif`, `mono`, `monospace` and the empty string, matched ignoring case,

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -165,6 +165,16 @@ Windows only maps the generic aliases `sans` / `serif` / `mono` to Segoe UI /
 Cambria / Consolas and passes every other name through verbatim; an unavailable
 family falls back to whatever GDI substitutes.
 
+Which names count as generic is the same on all three: `sans`, `sans serif`,
+`serif`, `mono`, `monospace` and the empty string, matched ignoring case,
+surrounding whitespace and the separator between words — `sans-serif`,
+`sans_serif` and `sansserif` are one name. Every other family name is passed to
+the platform trimmed. One parser answers that for all three
+(`internal/adapter/platform/fontgeneric`, ADR 0007); what each generic resolves
+to is the platform's own — Helvetica Neue / Times New Roman / Menlo on macOS,
+DejaVu Sans / DejaVu Serif / DejaVu Sans Mono on Linux, the Windows families
+above.
+
 ### Notes on the ⚠️ entries
 
 **Focused app on Wayland.** wlroots and KWin resolve the focused window through

--- a/docs/adr/0007-a-shared-derivation-has-one-implementation.md
+++ b/docs/adr/0007-a-shared-derivation-has-one-implementation.md
@@ -1,0 +1,93 @@
+# A shared derivation has one implementation
+
+**Status**: accepted
+
+The same arithmetic is written once per platform backend in several places
+here, and the copies are not kept honest by anything. Two live instances. The
+subgrid breakpoints — where the nine cells of a 3×3 subgrid fall inside one
+grid cell — exist four times: once in the domain, deciding where the cursor
+lands (`internal/domain/grid/manager.go`), and once per overlay backend,
+deciding where the cell is drawn (`internal/adapter/overlay/render/grid/overlay_darwin.go`,
+`internal/adapter/overlay/linux/overlay_shared_cgo.go`,
+`internal/adapter/overlay/windows/overlay.go`), with the 0.5 they round by
+declared five times over. They agree today; nothing makes them, and
+a disagreement is a cursor that lands somewhere other than the cell a person
+selected. The font generic-alias parser existed three times and **did** diverge:
+`sans_serif` resolved on macOS and Windows and fell through as a literal family
+name on Linux, whitespace was trimmed on Linux only, and the Windows copy had a
+`case "sans-serif"` its own normalisation had already made unreachable.
+
+We decided the rule this repo had already been following twice without naming
+it: **a value more than one layer computes from the same inputs has exactly
+one implementation, and it lives at the lowest layer that has more than one
+caller.** *Shared derivation* is the word for such a value; `CONTEXT.md`
+carries it.
+
+The part worth recording is the second half — *lowest layer with more than one
+caller*, not "the domain". Nothing outside the three platform font resolvers
+cares what "sans" means, so the parser this ADR ships with went to
+`internal/adapter/platform/fontgeneric`, an untagged package among tagged
+siblings, and each backend kept the one thing that is genuinely its own: which
+concrete family its sans, serif and mono are. Both precedents say the same.
+`internal/adapter/overlay/render/badge` is untagged, tested, and imported by the
+Linux and Windows backends and both render style packages — badge sizing is not
+a domain concept, it is a thing every renderer has to agree on.
+`internal/domain/grid/subgrid_keys.go` is in the domain because the set a
+subgrid is drawn with and the set it is navigated by have to be one set, and one
+of those callers is the domain. Neither package was created by this ADR; they
+are the precedent, not the exception.
+
+## Considered options
+
+- **Put every shared derivation in `internal/domain`.** The reading the
+  hexagon suggests, and it is too strong. It would move fontconfig-flavoured
+  alias vocabulary — "sans", "monospace", the fontconfig spelling of a font
+  request — into the pure core to serve three adapters and nobody else, and the
+  next contributor would reasonably read that as licence for the domain to
+  learn about GDI. The domain earns a derivation when the domain is one of the
+  callers, which is exactly why `SubgridKeys` is there and `fontgeneric` is not.
+- **Leave the copies and pin them with a cross-package test.** Cheaper than any
+  move, and it is the right answer in exactly one place (below). Rejected as the
+  default: a test that asserts four implementations agree still ships four
+  implementations to maintain, and it can only compare the cases somebody
+  thought to write down. The font parser is the demonstration — the three
+  copies were close enough to look deliberate and different enough to be a bug.
+- **Extract pure-but-private logic for testability alone.** The Windows
+  software rasterizer — ~310 lines of alpha blending and SDF rounded-box maths
+  in `internal/adapter/platform/windows/overlay.go` — is pure Go, platform-free
+  in everything but its build tag, and it stays where it is. It has one caller
+  and no second implementation to disagree with, and `.github/workflows/ci.yml`
+  already runs `test` on all three operating systems, so it is testable today;
+  nobody has written the tests. Extracting it would buy a package boundary and a
+  test suite the maintainer cannot run locally, which is how tests rot.
+  Divergence is the problem this ADR addresses. Build tags are not.
+- **Move the Objective-C copies into Go too, for completeness.** Rejected, and
+  the exclusion is deliberate rather than pending — see below.
+
+## Consequences
+
+- **The rule stops at the language boundary.** Hint badge placement geometry is
+  written in Objective-C (`hintRectForPlacement:` in
+  `internal/adapter/platform/darwin/overlay_darwin.m`) and cannot call Go. Where
+  the second implementation is in another language, Go cannot be the one
+  implementation, and what this rule asks for there is a test pinning the copies
+  together, not a deletion. Moving that geometry into Go would mean changing what
+  crosses the cgo boundary — that is the overlay-port work, and doing it under
+  this rule would be that redesign arriving without its design. No such pinning
+  test exists yet: this ADR states what is owed, and the placement vocabulary
+  written four times in Go against the enum in `internal/adapter/platform/darwin/overlay.h`
+  is the first candidate.
+- **"Lowest layer with more than one caller" is a judgement someone has to
+  make, and it moves.** A derivation with one caller is not shared and should
+  stay private; the second caller is what triggers the move, and the move is
+  cheap precisely because it is a pure function. The failure mode this invites
+  is a `common` package that collects everything a second caller ever touched —
+  which is why `CONTEXT.md` lists *helper*, *util*, *common code* and *shared
+  logic* as the words to avoid. A shared derivation is named for what it
+  derives.
+- **This ADR ships one instance and leaves two known ones standing.** The font
+  parser is collapsed here (#1286). The subgrid breakpoints and the 3×3 written
+  five times are filed separately (#1287), because they touch the drawing path on every
+  backend and deserve their own diff. Naming the rule before finishing the work
+  is the point: the next platform backend should not have to infer it from two
+  packages that never explained themselves.

--- a/internal/adapter/platform/darwin/font.go
+++ b/internal/adapter/platform/darwin/font.go
@@ -40,8 +40,8 @@ func NewFontResolver() ports.FontResolver {
 
 // nsFontResolver implements ports.FontResolver for macOS. Generic
 // aliases are translated to concrete macOS families; everything else
-// is passed through to the C layer, which already performs the full
-// NSFont + NSFontManager resolution chain.
+// is passed through trimmed to the C layer, which already performs the
+// full NSFont + NSFontManager resolution chain.
 type nsFontResolver struct {
 	mu    sync.RWMutex
 	cache map[string]string

--- a/internal/adapter/platform/darwin/font.go
+++ b/internal/adapter/platform/darwin/font.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/y3owk1n/neru/internal/adapter/platform/fontgeneric"
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
@@ -19,11 +20,18 @@ const (
 	defaultDarwinSerif = "Times New Roman"
 )
 
+// darwinFamilies is what the generic aliases mean on macOS.
+var darwinFamilies = fontgeneric.Families{
+	Sans:  defaultDarwinSans,
+	Serif: defaultDarwinSerif,
+	Mono:  defaultDarwinMono,
+}
+
 // NewFontResolver returns a macOS-backed ports.FontResolver. The Go-side
-// resolver maps generic aliases to known macOS families. User-supplied
-// names are returned unchanged so the existing C/Objective-C layer
-// (which already does PostScript and family lookups via NSFontManager)
-// can verify and weight-resolve them.
+// resolver maps generic aliases (platform/fontgeneric) to known macOS
+// families. A family somebody named is passed on as written, trimmed, so the
+// existing C/Objective-C layer (which already does PostScript and family
+// lookups via NSFontManager) can verify and weight-resolve it.
 func NewFontResolver() ports.FontResolver {
 	return &nsFontResolver{
 		cache: make(map[string]string),
@@ -55,32 +63,11 @@ func (r *nsFontResolver) Resolve(family string, bold bool) string {
 
 	r.mu.RUnlock()
 
-	resolved := mapDarwinGenericAlias(family)
+	resolved := darwinFamilies.Resolve(family)
 
 	r.mu.Lock()
 	r.cache[key] = resolved
 	r.mu.Unlock()
 
 	return resolved
-}
-
-// mapDarwinGenericAlias translates fontconfig-style generic names (and
-// empty input) to a concrete macOS family. Case-, whitespace-, and
-// separator-insensitive (spaces, hyphens, and underscores all
-// normalize to the same key). Non-generic names are returned unchanged
-// so the C layer can verify them via NSFontManager.
-func mapDarwinGenericAlias(family string) string {
-	normalized := strings.NewReplacer(" ", "", "-", "", "_", "").Replace(
-		strings.ToLower(strings.TrimSpace(family)),
-	)
-	switch normalized {
-	case "", "sans", "sansserif":
-		return defaultDarwinSans
-	case "serif":
-		return defaultDarwinSerif
-	case "mono", "monospace":
-		return defaultDarwinMono
-	default:
-		return family
-	}
 }

--- a/internal/adapter/platform/darwin/font_test.go
+++ b/internal/adapter/platform/darwin/font_test.go
@@ -4,43 +4,48 @@ package darwin
 
 import "testing"
 
-func TestMapDarwinGenericAlias_EmptyDefaultsToSans(t *testing.T) {
-	if got := mapDarwinGenericAlias(""); got != defaultDarwinSans {
-		t.Fatalf("expected %q for empty input, got %q", defaultDarwinSans, got)
-	}
-}
-
-func TestMapDarwinGenericAlias_GenericAliases(t *testing.T) {
+func TestNSFontResolver_GenericAliases(t *testing.T) {
+	// Which spellings count as generic is pinned by the shared parser
+	// (platform/fontgeneric); this pins what each generic means on macOS.
 	cases := map[string]string{
 		"":           defaultDarwinSans,
 		"sans":       defaultDarwinSans,
-		"Sans":       defaultDarwinSans,
-		"sans-serif": defaultDarwinSans,
 		"Sans Serif": defaultDarwinSans,
-		"SANSSERIF":  defaultDarwinSans,
+		"sans_serif": defaultDarwinSans,
 		"serif":      defaultDarwinSerif,
-		"Serif":      defaultDarwinSerif,
-		"mono":       defaultDarwinMono,
 		"Monospace":  defaultDarwinMono,
 		"   mono   ": defaultDarwinMono,
 	}
 
 	for input, want := range cases {
 		t.Run(input, func(t *testing.T) {
-			if got := mapDarwinGenericAlias(input); got != want {
-				t.Fatalf("mapDarwinGenericAlias(%q) = %q, want %q", input, got, want)
+			fontResolver := &nsFontResolver{cache: make(map[string]string)}
+
+			if got := fontResolver.Resolve(input, false); got != want {
+				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
 			}
 		})
 	}
 }
 
-func TestMapDarwinGenericAlias_NonGenericPassesThrough(t *testing.T) {
-	// Non-generic names are passed through to the C layer unchanged so
-	// NSFontManager can verify and weight-resolve them.
-	for _, input := range []string{"JetBrains Mono", "SF Mono", "Helvetica Neue"} {
-		if got := mapDarwinGenericAlias(input); got != input {
-			t.Fatalf("mapDarwinGenericAlias(%q) = %q, want %q", input, got, input)
-		}
+func TestNSFontResolver_NonGenericPassesThroughTrimmed(t *testing.T) {
+	// Non-generic names are passed through to the C layer so NSFontManager
+	// can verify and weight-resolve them, with only the surrounding
+	// whitespace removed.
+	cases := map[string]string{
+		"JetBrains Mono": "JetBrains Mono",
+		"SF Mono":        "SF Mono",
+		"  Helvetica  ":  "Helvetica",
+	}
+
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			fontResolver := &nsFontResolver{cache: make(map[string]string)}
+
+			if got := fontResolver.Resolve(input, false); got != want {
+				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
+			}
+		})
 	}
 }
 
@@ -58,13 +63,5 @@ func TestNSFontResolver_CachesByFamily(t *testing.T) {
 
 	if len(fontResolver.cache) != 1 {
 		t.Fatalf("expected exactly one cache entry, got %d", len(fontResolver.cache))
-	}
-}
-
-func TestNSFontResolver_EmptyDefaultsToSans(t *testing.T) {
-	fontResolver := &nsFontResolver{cache: make(map[string]string)}
-
-	if got := fontResolver.Resolve("", false); got != defaultDarwinSans {
-		t.Fatalf("expected empty input to resolve to %q, got %q", defaultDarwinSans, got)
 	}
 }

--- a/internal/adapter/platform/fontgeneric/doc.go
+++ b/internal/adapter/platform/fontgeneric/doc.go
@@ -1,0 +1,11 @@
+// Package fontgeneric reads a written font family name and says which family
+// to ask the platform's font system for: the platform's sans, serif or
+// monospaced face when the name is a generic alias, and the name itself when
+// it is a family somebody named.
+//
+// Every platform font resolver needs that reading and none of them needs a
+// different one — a person who writes "sans_serif" in their configuration
+// means the same thing on macOS, Linux and Windows. Each backend supplies
+// only the part that is genuinely its own: which concrete family its sans,
+// serif and mono are. ADR 0007 has the reasoning.
+package fontgeneric

--- a/internal/adapter/platform/fontgeneric/families.go
+++ b/internal/adapter/platform/fontgeneric/families.go
@@ -1,0 +1,36 @@
+package fontgeneric
+
+// Families are the concrete families one platform uses for the generic
+// aliases. Which family a generic resolves to is a platform decision — macOS
+// answers "sans" with Helvetica Neue and Linux with DejaVu Sans — so the
+// values are declared by each backend; only the reading of the written name
+// is shared.
+type Families struct {
+	// Sans is the family a name asking for sans-serif resolves to. The empty
+	// name asks for this one.
+	Sans string
+	// Serif is the family a name asking for serif resolves to.
+	Serif string
+	// Mono is the family a name asking for monospace resolves to.
+	Mono string
+}
+
+// Resolve returns the family to ask the platform's font system for: this
+// platform's family when the written name is a generic alias, and the name
+// itself, trimmed, when it is a family somebody named.
+func (f Families) Resolve(family string) string {
+	asked, trimmed := parse(family)
+
+	switch asked {
+	case classSans:
+		return f.Sans
+	case classSerif:
+		return f.Serif
+	case classMono:
+		return f.Mono
+	case classNamed:
+		return trimmed
+	default:
+		return trimmed
+	}
+}

--- a/internal/adapter/platform/fontgeneric/families_test.go
+++ b/internal/adapter/platform/fontgeneric/families_test.go
@@ -1,0 +1,80 @@
+package fontgeneric_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/platform/fontgeneric"
+)
+
+// testFamilies stands in for a platform's three concrete families. The values
+// are deliberately no platform's, so a passing test cannot be passing because
+// it happened to agree with one backend's constants.
+var testFamilies = fontgeneric.Families{
+	Sans:  "Test Sans",
+	Serif: "Test Serif",
+	Mono:  "Test Mono",
+}
+
+func TestFamilies_Resolve_GenericAliases(t *testing.T) {
+	// Every spelling of a generic asks for the same face: case, surrounding
+	// whitespace and the separator between the words are all ignored. The
+	// empty name asks for sans.
+	cases := map[string]string{
+		"":            testFamilies.Sans,
+		"   ":         testFamilies.Sans,
+		"sans":        testFamilies.Sans,
+		"Sans":        testFamilies.Sans,
+		"SANS":        testFamilies.Sans,
+		"  sans  ":    testFamilies.Sans,
+		"sansserif":   testFamilies.Sans,
+		"sans serif":  testFamilies.Sans,
+		"sans-serif":  testFamilies.Sans,
+		"sans_serif":  testFamilies.Sans,
+		"Sans Serif":  testFamilies.Sans,
+		"SANS_SERIF":  testFamilies.Sans,
+		"serif":       testFamilies.Serif,
+		"Serif":       testFamilies.Serif,
+		"  serif  ":   testFamilies.Serif,
+		"mono":        testFamilies.Mono,
+		"Mono":        testFamilies.Mono,
+		"monospace":   testFamilies.Mono,
+		"Monospace":   testFamilies.Mono,
+		"mono space":  testFamilies.Mono,
+		"mono-space":  testFamilies.Mono,
+		"mono_space":  testFamilies.Mono,
+		"   mono   ":  testFamilies.Mono,
+		"MONO  SPACE": testFamilies.Mono,
+	}
+
+	for written, want := range cases {
+		t.Run(written, func(t *testing.T) {
+			if got := testFamilies.Resolve(written); got != want {
+				t.Fatalf("Resolve(%q) = %q, want %q", written, got, want)
+			}
+		})
+	}
+}
+
+func TestFamilies_Resolve_NamedFamilyPassesThroughTrimmed(t *testing.T) {
+	// A family somebody named is handed on as written, with only the
+	// surrounding whitespace removed: the platform's font system is the one
+	// that knows whether it exists.
+	cases := map[string]string{
+		"  Arial  ":        "Arial",
+		"\tJetBrains Mono": "JetBrains Mono",
+		"SF Mono\n":        "SF Mono",
+		// Only the outside is trimmed.
+		"Helvetica  Neue": "Helvetica  Neue",
+		// A generic spelling is a generic only when that is the whole name.
+		"sans2":    "sans2",
+		"serifish": "serifish",
+	}
+
+	for written, want := range cases {
+		t.Run(written, func(t *testing.T) {
+			if got := testFamilies.Resolve(written); got != want {
+				t.Fatalf("Resolve(%q) = %q, want %q", written, got, want)
+			}
+		})
+	}
+}

--- a/internal/adapter/platform/fontgeneric/parse.go
+++ b/internal/adapter/platform/fontgeneric/parse.go
@@ -1,0 +1,46 @@
+package fontgeneric
+
+import "strings"
+
+// class is what a written font family name asks for.
+type class int
+
+const (
+	// classNamed means the name asks for one particular family, spelled out —
+	// "JetBrains Mono". What that family resolves to is the platform font
+	// system's business, not this package's.
+	classNamed class = iota
+	// classSans means the name asks for the sans-serif face the platform
+	// prefers. The empty name asks for this one.
+	classSans
+	// classSerif means the name asks for the serif face the platform prefers.
+	classSerif
+	// classMono means the name asks for the monospaced face the platform
+	// prefers.
+	classMono
+)
+
+// separators are the characters people write between the words of a generic
+// alias. All three spellings mean the same thing, so they are removed before
+// matching rather than enumerated as separate cases.
+var separators = strings.NewReplacer(" ", "", "-", "", "_", "")
+
+// parse classifies a written font family name, returning what it asks for and
+// the name itself, trimmed. Matching ignores case, surrounding whitespace and
+// the separators between words, so "sans serif", "Sans-Serif", "sans_serif"
+// and "SANSSERIF" all ask for the same face; the empty name asks for sans.
+// Anything else is a family somebody named.
+func parse(family string) (class, string) {
+	trimmed := strings.TrimSpace(family)
+
+	switch separators.Replace(strings.ToLower(trimmed)) {
+	case "", "sans", "sansserif":
+		return classSans, trimmed
+	case "serif":
+		return classSerif, trimmed
+	case "mono", "monospace":
+		return classMono, trimmed
+	default:
+		return classNamed, trimmed
+	}
+}

--- a/internal/adapter/platform/linux/font_cgo.go
+++ b/internal/adapter/platform/linux/font_cgo.go
@@ -105,7 +105,7 @@ func (r *fontconfigResolver) Resolve(family string, bold bool) string {
 // concrete family, then asks fontconfig to match it. If fontconfig
 // cannot match the family at all, it falls back to a hardcoded default.
 func (r *fontconfigResolver) resolve(family string) string {
-	mapped := mapGenericAlias(family)
+	mapped := linuxFamilies.Resolve(family)
 
 	cFamily := C.CString(mapped)
 	defer C.free(unsafe.Pointer(cFamily))

--- a/internal/adapter/platform/linux/font_common.go
+++ b/internal/adapter/platform/linux/font_common.go
@@ -2,7 +2,7 @@
 
 package linux
 
-import "strings"
+import "github.com/y3owk1n/neru/internal/adapter/platform/fontgeneric"
 
 const (
 	// defaultLinuxSans is the baseline Linux sans-serif family used when
@@ -15,25 +15,22 @@ const (
 	defaultLinuxSerif = "DejaVu Serif"
 )
 
-// mapGenericAlias translates fontconfig-style generic names (and empty
-// input) to a known-good Linux family. Case- and whitespace-insensitive.
-// Non-generic names are returned unchanged (trimmed) so the CGO path
-// can ask fontconfig to verify them.
-func mapGenericAlias(family string) string {
-	switch strings.ToLower(strings.TrimSpace(family)) {
-	case "", "sans", "sans-serif", "sans serif", "sansserif":
-		return defaultLinuxSans
-	case "serif":
-		return defaultLinuxSerif
-	case "mono", "monospace":
-		return defaultLinuxMono
-	default:
-		return strings.TrimSpace(family)
-	}
+// linuxFamilies is what the generic aliases mean on Linux.
+var linuxFamilies = fontgeneric.Families{
+	Sans:  defaultLinuxSans,
+	Serif: defaultLinuxSerif,
+	Mono:  defaultLinuxMono,
 }
 
 // defaultForMapped returns the last-resort hardcoded family for a mapped
-// generic, falling back to the sans-serif default.
+// family, falling back to the sans-serif default.
+//
+// It matches on the mapped family rather than asking fontgeneric what the
+// written name was, which looks like the same question and is not: a person
+// who writes "DejaVu Serif" and has no DejaVu installed keeps the serif
+// baseline here, where classifying the name again would hand them the sans
+// one. Both answers are a hardcoded string for a font that is missing either
+// way, so this keeps the one it has always given.
 func defaultForMapped(mapped string) string {
 	switch mapped {
 	case defaultLinuxSerif:

--- a/internal/adapter/platform/linux/font_common_test.go
+++ b/internal/adapter/platform/linux/font_common_test.go
@@ -1,0 +1,66 @@
+//go:build linux
+
+package linux
+
+import "testing"
+
+func TestLinuxFamilies_Resolve_GenericAliases(t *testing.T) {
+	// Which spellings count as generic is pinned by the shared parser
+	// (platform/fontgeneric); this pins what each generic means on Linux.
+	cases := map[string]string{
+		"":           defaultLinuxSans,
+		"sans":       defaultLinuxSans,
+		"Sans Serif": defaultLinuxSans,
+		"sans_serif": defaultLinuxSans,
+		"serif":      defaultLinuxSerif,
+		"Monospace":  defaultLinuxMono,
+		"   mono   ": defaultLinuxMono,
+	}
+
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := linuxFamilies.Resolve(input); got != want {
+				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestLinuxFamilies_Resolve_NamedFamilyPassesThroughTrimmed(t *testing.T) {
+	// Non-generic names are handed to fontconfig to verify, with only the
+	// surrounding whitespace removed.
+	cases := map[string]string{
+		"JetBrains Mono": "JetBrains Mono",
+		"Comic Sans MS":  "Comic Sans MS",
+		"  DejaVu Sans ": "DejaVu Sans",
+	}
+
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := linuxFamilies.Resolve(input); got != want {
+				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestDefaultForMapped_KeepsTheBaselineThatWasMapped(t *testing.T) {
+	// When fontconfig matches nothing at all, a mapped baseline is kept and
+	// anything else falls back to sans. The input is a family already mapped,
+	// not what the user wrote.
+	cases := map[string]string{
+		defaultLinuxSans:  defaultLinuxSans,
+		defaultLinuxSerif: defaultLinuxSerif,
+		defaultLinuxMono:  defaultLinuxMono,
+		"Iosevka":         defaultLinuxSans,
+		"":                defaultLinuxSans,
+	}
+
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := defaultForMapped(input); got != want {
+				t.Fatalf("defaultForMapped(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}

--- a/internal/adapter/platform/linux/font_nocgo.go
+++ b/internal/adapter/platform/linux/font_nocgo.go
@@ -19,5 +19,5 @@ type passthroughResolver struct{}
 
 // Resolve implements ports.FontResolver.
 func (passthroughResolver) Resolve(family string, _ bool) string {
-	return mapGenericAlias(family)
+	return linuxFamilies.Resolve(family)
 }

--- a/internal/adapter/platform/linux/font_nocgo_test.go
+++ b/internal/adapter/platform/linux/font_nocgo_test.go
@@ -4,46 +4,6 @@ package linux
 
 import "testing"
 
-func TestMapGenericAlias_EmptyDefaultsToSans(t *testing.T) {
-	if got := mapGenericAlias(""); got != defaultLinuxSans {
-		t.Fatalf("expected %q for empty input, got %q", defaultLinuxSans, got)
-	}
-}
-
-func TestMapGenericAlias_GenericAliases(t *testing.T) {
-	cases := map[string]string{
-		"sans":       defaultLinuxSans,
-		"Sans":       defaultLinuxSans,
-		"SANS":       defaultLinuxSans,
-		"sans-serif": defaultLinuxSans,
-		"Sans Serif": defaultLinuxSans,
-		"SANSSERIF":  defaultLinuxSans,
-		"serif":      defaultLinuxSerif,
-		"Serif":      defaultLinuxSerif,
-		"mono":       defaultLinuxMono,
-		"Monospace":  defaultLinuxMono,
-		"   mono   ": defaultLinuxMono,
-	}
-
-	for input, want := range cases {
-		t.Run(input, func(t *testing.T) {
-			if got := mapGenericAlias(input); got != want {
-				t.Fatalf("mapGenericAlias(%q) = %q, want %q", input, got, want)
-			}
-		})
-	}
-}
-
-func TestMapGenericAlias_NonGenericPassesThrough(t *testing.T) {
-	// Non-generic names are returned unchanged (trimmed) so the CGO path
-	// can ask fontconfig to verify them.
-	for _, input := range []string{"JetBrains Mono", "DejaVu Sans", "Comic Sans MS"} {
-		if got := mapGenericAlias(input); got != input {
-			t.Fatalf("mapGenericAlias(%q) = %q, want %q", input, got, input)
-		}
-	}
-}
-
 func TestPassthroughResolver_CachesByFamily(t *testing.T) {
 	r := passthroughResolver{}
 

--- a/internal/adapter/platform/windows/font.go
+++ b/internal/adapter/platform/windows/font.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/y3owk1n/neru/internal/adapter/platform/fontgeneric"
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
@@ -14,6 +15,13 @@ const (
 	defaultWindowsMono  = "Consolas"
 	defaultWindowsSerif = "Cambria"
 )
+
+// windowsFamilies is what the generic aliases mean on Windows.
+var windowsFamilies = fontgeneric.Families{
+	Sans:  defaultWindowsSans,
+	Serif: defaultWindowsSerif,
+	Mono:  defaultWindowsMono,
+}
 
 // NewFontResolver returns a Windows-backed ports.FontResolver.
 func NewFontResolver() ports.FontResolver {
@@ -43,29 +51,11 @@ func (r *winFontResolver) Resolve(family string, bold bool) string {
 
 	r.mu.RUnlock()
 
-	resolved := mapWindowsGenericAlias(family)
+	resolved := windowsFamilies.Resolve(family)
 
 	r.mu.Lock()
 	r.cache[key] = resolved
 	r.mu.Unlock()
 
 	return resolved
-}
-
-// mapWindowsGenericAlias translates generic font names and empty input to
-// concrete Windows font families. Non-generic names pass through unchanged.
-func mapWindowsGenericAlias(family string) string {
-	normalized := strings.NewReplacer(" ", "", "-", "", "_", "").Replace(
-		strings.ToLower(strings.TrimSpace(family)),
-	)
-	switch normalized {
-	case "", "sans", "sansserif", "sans-serif":
-		return defaultWindowsSans
-	case "serif":
-		return defaultWindowsSerif
-	case "mono", "monospace":
-		return defaultWindowsMono
-	default:
-		return family
-	}
 }

--- a/internal/adapter/platform/windows/font_test.go
+++ b/internal/adapter/platform/windows/font_test.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+package windows
+
+import "testing"
+
+func TestWinFontResolver_GenericAliases(t *testing.T) {
+	// Which spellings count as generic is pinned by the shared parser
+	// (platform/fontgeneric); this pins what each generic means on Windows.
+	cases := map[string]string{
+		"":           defaultWindowsSans,
+		"sans":       defaultWindowsSans,
+		"Sans Serif": defaultWindowsSans,
+		"sans_serif": defaultWindowsSans,
+		"serif":      defaultWindowsSerif,
+		"Monospace":  defaultWindowsMono,
+		"   mono   ": defaultWindowsMono,
+	}
+
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			fontResolver := &winFontResolver{cache: make(map[string]string)}
+
+			if got := fontResolver.Resolve(input, false); got != want {
+				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestWinFontResolver_NamedFamilyPassesThroughTrimmed(t *testing.T) {
+	// A family somebody named is handed to GDI as written, with only the
+	// surrounding whitespace removed; GDI substitutes if it is missing.
+	cases := map[string]string{
+		"JetBrains Mono":    "JetBrains Mono",
+		"  Comic Sans MS  ": "Comic Sans MS",
+	}
+
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			fontResolver := &winFontResolver{cache: make(map[string]string)}
+
+			if got := fontResolver.Resolve(input, false); got != want {
+				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestWinFontResolver_CachesByFamily(t *testing.T) {
+	fontResolver := &winFontResolver{cache: make(map[string]string)}
+
+	for range 3 {
+		if got := fontResolver.Resolve("sans", true); got != defaultWindowsSans {
+			t.Fatalf("expected generic alias to resolve to %q, got %q", defaultWindowsSans, got)
+		}
+	}
+
+	fontResolver.mu.RLock()
+	defer fontResolver.mu.RUnlock()
+
+	if len(fontResolver.cache) != 1 {
+		t.Fatalf("expected exactly one cache entry, got %d", len(fontResolver.cache))
+	}
+}

--- a/internal/ports/font.go
+++ b/internal/ports/font.go
@@ -11,9 +11,10 @@ type FontResolver interface {
 	//
 	//   - empty input maps to a sensible default sans-serif family
 	//   - generic aliases ("Sans", "Sans Serif", "Serif", "Monospace", ...) are
-	//     mapped to a known-good installed family
-	//   - other family names are returned unchanged when installed; missing
-	//     families fall back to the resolved generic family
+	//     mapped to a known-good installed family; every platform reads the
+	//     same spellings (adapter/platform/fontgeneric)
+	//   - other family names are returned as written, trimmed, when installed;
+	//     missing families fall back to the resolved generic family
 	//   - bold is reserved for future weight-specific resolution and is
 	//     currently ignored by all implementations
 	Resolve(family string, bold bool) string


### PR DESCRIPTION
## Description

This PR fixes generic font names meaning different things on different
platforms. Writing `sans_serif` as your font family worked on macOS and
Windows and silently failed on Linux, where the name went to fontconfig as a
literal family nobody has installed — the same for `mono_space` and
`mono-space`. A family name with stray spaces around it was trimmed on Linux
and passed through with the spaces everywhere else.

All three read a written font name the same way now: `sans`, `sans serif`,
`sans-serif`, `sans_serif` and `sansserif` are one name, matching ignores case
and surrounding whitespace, the empty name still means the platform's sans
default, and any other family name reaches the platform trimmed. Which
concrete family each generic resolves to is unchanged and still per-platform —
Helvetica Neue / Times New Roman / Menlo on macOS, the DejaVu faces on Linux,
Segoe UI / Cambria / Consolas on Windows.

This also lands the vocabulary the follow-up work is built on: a **Shared
derivation** entry in the glossary and ADR 0007, which records where a
derivation that several layers compute should live and why the rule stops at
the Objective-C boundary.

## Config surface

No option is added, removed or renamed. The accepted *values* of every
existing `font_family` / `subtitle_font_family` option widen:

| Written value | Before | Now |
| --- | --- | --- |
| `sans`, `serif`, `mono`, `monospace`, `""` | generic on all three | unchanged |
| `sans-serif`, `sans serif`, `sansserif` | generic on all three | unchanged |
| `sans_serif`, `mono space`, `mono-space`, `mono_space` | generic on macOS and Windows, a literal family name on Linux | generic on all three |
| `"  Fira Sans  "` | trimmed on Linux, passed through with the spaces on macOS and Windows | trimmed on all three |

Every value that resolved to a font before still resolves to the same font, so
existing configurations are unaffected.

## Related Issues

Closes #1286

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `fix` — Bug fix

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port method is added or changed; all three backends already implement font resolution.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

- The shared parser is an untagged package inside the platform adapter layer,
  not in the domain: nothing outside the three font resolvers cares what
  "sans" means. That placement rule is what ADR 0007 records, with the two
  packages that already follow it as the precedent.
- Its tests are untagged too, so they run on every CI leg rather than one. The
  per-platform tests that remain pin only what each platform's sans, serif and
  mono are; Windows gained a small one, which is the first test that file has
  had.
- The Linux last-resort fallback (used only when fontconfig matches nothing at
  all) is deliberately **not** collapsed into the shared parser. It keys off
  the already-mapped family, which is not the same question as classifying the
  written name: somebody who writes `DejaVu Serif` with no DejaVu installed
  keeps the serif fallback today, and re-classifying would quietly hand them
  the sans one. It stays as it was, now with a test and a comment saying why.
- `just lint-cross` was run as well as `just ci`, since the host lint is blind
  to the Linux and Windows build tags this change touches.
