### PR TITLE
refactor(grid): compute subgrid cells in one place

### DIFF
--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -32,9 +32,6 @@ const (
 	hexColorLenShort                       = 3
 	hexColorLenNoAlpha                     = 6
 	hexColorLenFull                        = 8
-	subgridCols                            = 3
-	subgridRows                            = 3
-	subgridHalfPixel                       = 0.5
 	subgridFontScale                       = 0.7
 	subgridLineWidth                       = 1
 	keyboardChanBuffer                     = 64

--- a/internal/adapter/overlay/linux/overlay_shared_cgo.go
+++ b/internal/adapter/overlay/linux/overlay_shared_cgo.go
@@ -13,6 +13,7 @@ import (
 	gridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
 	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
+	"github.com/y3owk1n/neru/internal/domain"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
 	"github.com/y3owk1n/neru/internal/domain/recursivegrid"
 	"github.com/y3owk1n/neru/internal/ports"
@@ -874,51 +875,26 @@ func (o *sharedOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.
 
 	// The keys the subgrid is drawn with, which are the keys the mode layer
 	// selects on (internal/domain/grid/subgrid_keys.go).
-	keyRunes := domainGrid.SubgridKeys(o.sublayerKeys, subgridCols*subgridRows)
-	maxKeys := len(keyRunes)
-	xBreaks := make([]int, subgridCols+1)
-	yBreaks := make([]int, subgridRows+1)
-	xBreaks[0] = bounds.Min.X
-	yBreaks[0] = bounds.Min.Y
+	keyRunes := domainGrid.SubgridKeys(o.sublayerKeys, domainGrid.MaxKeyIndex)
 
-	for i := 1; i <= subgridCols; i++ {
-		xBreaks[i] = bounds.Min.X + int(
-			float64(i)*float64(bounds.Dx())/float64(subgridCols)+
-				subgridHalfPixel,
+	// The rectangles they are drawn on, which are the rectangles the mode layer
+	// moves the cursor into (internal/domain/grid/subgrid_cells.go).
+	cells := domainGrid.SubgridCells(bounds, domain.SubgridRows, domain.SubgridCols)
+
+	// One cell per key, and fewer keys than cells is a configuration that
+	// leaves the last cells unlabelled: the key set is capped at the same count
+	// the division produces, which is what MaxKeyIndex is.
+	for index, key := range keyRunes {
+		cell := cells[index]
+
+		o.drawRect(cell, style.BackgroundColorARGB(),
+			style.LineColorARGB(), style.LineWidth())
+		o.drawTextCentered(
+			string(key), cell,
+			style.FontFamily(),
+			style.LabelFontSize()*subgridFontScale,
+			style.TextColorARGB(),
 		)
-	}
-
-	for i := 1; i <= subgridRows; i++ {
-		yBreaks[i] = bounds.Min.Y + int(
-			float64(i)*float64(bounds.Dy())/float64(subgridRows)+
-				subgridHalfPixel,
-		)
-	}
-
-	xBreaks[subgridCols] = bounds.Max.X
-	yBreaks[subgridRows] = bounds.Max.Y
-
-	index := 0
-	for row := range subgridRows {
-		for col := range subgridCols {
-			if index >= maxKeys {
-				break
-			}
-
-			cell := image.Rect(
-				xBreaks[col], yBreaks[row],
-				xBreaks[col+1], yBreaks[row+1],
-			)
-			o.drawRect(cell, style.BackgroundColorARGB(),
-				style.LineColorARGB(), style.LineWidth())
-			o.drawTextCentered(
-				string(keyRunes[index]), cell,
-				style.FontFamily(),
-				style.LabelFontSize()*subgridFontScale,
-				style.TextColorARGB(),
-			)
-			index++
-		}
 	}
 }
 

--- a/internal/adapter/overlay/render/grid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/grid/overlay_darwin.go
@@ -24,15 +24,13 @@ import (
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/overlayutil"
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/domain"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
 )
 
 const (
 	// DefaultGridLinesCount is the default number of grid lines.
 	DefaultGridLinesCount = 4
-
-	// RoundingFactor is the factor for rounding.
-	RoundingFactor = 0.5
 
 	// NSWindowSharingNone represents NSWindowSharingNone (0) - hidden from screen sharing.
 	NSWindowSharingNone = 0
@@ -439,13 +437,9 @@ func (o *Overlay) ShowSubgrid(cell *domainGrid.Cell, style Style) {
 	// draw call so that freeLabelCache cannot free labels mid-draw.
 	o.drawMu.RLock()
 
-	// Subgrid is always 3x3
-	const rows = 3
-	const cols = 3
-
 	// The keys this subgrid is drawn with, which are the keys the mode layer
 	// selects on (internal/domain/grid/subgrid_keys.go).
-	chars := domainGrid.SubgridKeys(keys, rows*cols)
+	chars := domainGrid.SubgridKeys(keys, domainGrid.MaxKeyIndex)
 	count := len(chars)
 
 	tmpCells := subgridCellSlicePool.Get()
@@ -467,42 +461,24 @@ func (o *Overlay) ShowSubgrid(cell *domainGrid.Cell, style Style) {
 	}
 	labels := *labelsPtr
 
-	cellBounds := cell.Bounds()
-	// Build breakpoints that evenly distribute remainders to fully cover the cell
-	xBreaks := make([]int, cols+1)
-	yBreaks := make([]int, rows+1)
-	xBreaks[0] = cellBounds.Min.X
-	yBreaks[0] = cellBounds.Min.Y
-	for breakIndex := 1; breakIndex <= cols; breakIndex++ {
-		// round(i * width / cols)
-		val := float64(breakIndex) * float64(cellBounds.Dx()) / float64(cols)
-		xBreaks[breakIndex] = cellBounds.Min.X + int(val+RoundingFactor)
-	}
-	for breakIndex := 1; breakIndex <= rows; breakIndex++ {
-		val := float64(breakIndex) * float64(cellBounds.Dy()) / float64(rows)
-		yBreaks[breakIndex] = cellBounds.Min.Y + int(val+RoundingFactor)
-	}
+	// The rectangles those keys are drawn on, which are the rectangles the mode
+	// layer moves the cursor into (internal/domain/grid/subgrid_cells.go).
+	subCells := domainGrid.SubgridCells(cell.Bounds(), domain.SubgridRows, domain.SubgridCols)
 
-	// Ensure last break exactly matches bounds max to avoid 1px drift
-	xBreaks[cols] = cellBounds.Max.X
-	yBreaks[rows] = cellBounds.Max.Y
-
+	// One cell per key, and fewer keys than cells is a configuration that
+	// leaves the last cells unlabelled: the key set is capped at the same count
+	// the division produces, which is what MaxKeyIndex is.
 	for cellIndex := range cells {
-		rowIndex := cellIndex / cols
-		colIndex := cellIndex % cols
 		label := string(chars[cellIndex])
 		labels[cellIndex] = o.getOrCacheLabel(label)
-		left := xBreaks[colIndex]
-		right := xBreaks[colIndex+1]
-		top := yBreaks[rowIndex]
-		bottom := yBreaks[rowIndex+1]
+		subCell := subCells[cellIndex]
 
 		var gridCell C.GridCell
 		gridCell.label = labels[cellIndex]
-		gridCell.bounds.origin.x = C.double(left)
-		gridCell.bounds.origin.y = C.double(top)
-		gridCell.bounds.size.width = C.double(right - left)
-		gridCell.bounds.size.height = C.double(bottom - top)
+		gridCell.bounds.origin.x = C.double(subCell.Min.X)
+		gridCell.bounds.origin.y = C.double(subCell.Min.Y)
+		gridCell.bounds.size.width = C.double(subCell.Dx())
+		gridCell.bounds.size.height = C.double(subCell.Dy())
 		gridCell.isMatched = C.int(0)
 		gridCell.isSubgrid = C.int(1)           // Mark as subgrid cell
 		gridCell.matchedPrefixLength = C.int(0) // Subgrid cells don't have matched prefixes

--- a/internal/adapter/overlay/windows/overlay.go
+++ b/internal/adapter/overlay/windows/overlay.go
@@ -12,6 +12,7 @@ import (
 	gridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
 	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	winplatform "github.com/y3owk1n/neru/internal/adapter/platform/windows"
+	"github.com/y3owk1n/neru/internal/domain"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
 	"github.com/y3owk1n/neru/internal/ports"
 )
@@ -19,9 +20,6 @@ import (
 // Win32 overlay backend used by the Windows overlay manager for grid rendering.
 // Does not manage singleton lifecycle or mode subscriptions.
 const (
-	winSubgridCols      = 3
-	winSubgridRows      = 3
-	winSubgridHalfPixel = 0.5
 	winSubgridFontScale = 0.7
 )
 
@@ -386,52 +384,26 @@ func (o *winOverlay) flushOverlay(context string) {
 func (o *winOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Style) {
 	// The keys the subgrid is drawn with, which are the keys the mode layer
 	// selects on (internal/domain/grid/subgrid_keys.go).
-	keyRunes := domainGrid.SubgridKeys(o.sublayerKeys, winSubgridCols*winSubgridRows)
-	maxKeys := len(keyRunes)
+	keyRunes := domainGrid.SubgridKeys(o.sublayerKeys, domainGrid.MaxKeyIndex)
 
-	xBreaks := make([]int, winSubgridCols+1)
-	yBreaks := make([]int, winSubgridRows+1)
-	xBreaks[0] = bounds.Min.X
+	// The rectangles they are drawn on, which are the rectangles the mode layer
+	// moves the cursor into (internal/domain/grid/subgrid_cells.go).
+	cells := domainGrid.SubgridCells(bounds, domain.SubgridRows, domain.SubgridCols)
 
-	yBreaks[0] = bounds.Min.Y
-	for i := 1; i <= winSubgridCols; i++ {
-		xBreaks[i] = bounds.Min.X + int(
-			float64(i)*float64(bounds.Dx())/float64(winSubgridCols)+winSubgridHalfPixel,
+	// One cell per key, and fewer keys than cells is a configuration that
+	// leaves the last cells unlabelled: the key set is capped at the same count
+	// the division produces, which is what MaxKeyIndex is.
+	for index, key := range keyRunes {
+		cell := cells[index]
+
+		o.drawCellBorder(cell, style.LineColorARGB(), style.LineWidth())
+		o.drawTextCentered(
+			string(key),
+			cell,
+			ports.ResolveFont(style.FontFamily(), false),
+			style.LabelFontSize()*winSubgridFontScale,
+			style.TextColorARGB(),
 		)
-	}
-
-	for i := 1; i <= winSubgridRows; i++ {
-		yBreaks[i] = bounds.Min.Y + int(
-			float64(i)*float64(bounds.Dy())/float64(winSubgridRows)+winSubgridHalfPixel,
-		)
-	}
-
-	xBreaks[winSubgridCols] = bounds.Max.X
-	yBreaks[winSubgridRows] = bounds.Max.Y
-
-	index := 0
-	for row := range winSubgridRows {
-		for col := range winSubgridCols {
-			if index >= maxKeys {
-				break
-			}
-
-			cell := image.Rect(
-				xBreaks[col],
-				yBreaks[row],
-				xBreaks[col+1],
-				yBreaks[row+1],
-			)
-			o.drawCellBorder(cell, style.LineColorARGB(), style.LineWidth())
-			o.drawTextCentered(
-				string(keyRunes[index]),
-				cell,
-				ports.ResolveFont(style.FontFamily(), false),
-				style.LabelFontSize()*winSubgridFontScale,
-				style.TextColorARGB(),
-			)
-			index++
-		}
 	}
 }
 

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -158,16 +158,11 @@ func (h *handlerState) initializeGridManager(gridInstance *domainGrid.Grid) {
 		)
 	}
 
-	const (
-		subRows = 3
-		subCols = 3
-	)
-
 	// Create grid manager with callbacks for overlay updates and subgrid navigation
 	h.grid.Manager = domainGrid.NewManager(
 		gridInstance,
-		subRows,
-		subCols,
+		domain.SubgridRows,
+		domain.SubgridCols,
 		// The keys the subgrid is drawn with, resolved once by the config
 		// (config.ResolveSublayerKeys) so that the set accepted here is the set
 		// the overlay draws.

--- a/internal/architecture/subgrid_cells_test.go
+++ b/internal/architecture/subgrid_cells_test.go
@@ -1,0 +1,91 @@
+package architecture_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// subgridCellDecider is the one package allowed to work out where the cells of
+// a subgrid fall: it is where SubgridCells lives, and the manager there is one
+// of the callers whose answer has to be that one.
+const subgridCellDecider = "internal/domain/grid"
+
+// subgridKeySetCall and subgridCellSetCall are the two answers a subgrid is
+// drawn from — which keys it has, and which rectangles they sit on.
+const (
+	subgridKeySetCall  = "SubgridKeys"
+	subgridCellSetCall = "SubgridCells"
+)
+
+// TestSubgridCellsAreComputedOnce keeps the cell a person sees and the point
+// the cursor lands in the same rectangle. The breakpoint arithmetic that
+// divides a grid cell into a subgrid was written four times — once in the
+// manager, deciding where the cursor goes, and once in each overlay backend,
+// deciding where the cell is drawn — with the 0.5 it rounds by declared under
+// three names. They agreed by coincidence, and a copy that drifted would draw
+// a cell in one place and click in another with no test to notice (#1287).
+//
+// The shape it catches is a backend that asks which keys a subgrid has and
+// then works out its own rectangles for them: outside the package that owns
+// both answers, the two calls travel together. That is a tripwire on the way
+// back to a second implementation rather than proof there is only one — a
+// backend that called SubgridCells and then ignored it would pass — but it is
+// the check that reaches the Linux and Windows drawing code from a macOS host,
+// which no unit test on this machine compiles.
+func TestSubgridCellsAreComputedOnce(t *testing.T) {
+	fileSet := token.NewFileSet()
+	checked := 0
+
+	for _, file := range goFiles(t) {
+		if file.dir == subgridCellDecider {
+			continue
+		}
+
+		parsed, parseErr := parser.ParseFile(
+			fileSet,
+			file.absPath,
+			nil,
+			parser.SkipObjectResolution,
+		)
+		if parseErr != nil {
+			t.Fatalf("ParseFile(%s) error = %v", file.relPath, parseErr)
+		}
+
+		for _, decl := range parsed.Decls {
+			funcDecl, isFunc := decl.(*ast.FuncDecl)
+			if !isFunc || funcDecl.Body == nil {
+				continue
+			}
+
+			if !callsAnyMethod(funcDecl.Body, []string{subgridKeySetCall}) {
+				continue
+			}
+
+			checked++
+
+			if callsAnyMethod(funcDecl.Body, []string{subgridCellSetCall}) {
+				continue
+			}
+
+			t.Errorf(
+				"%s: %s draws a subgrid's keys but not its cells; the rectangles "+
+					"come from grid.%s, because the manager moves the cursor into "+
+					"the same ones and a second answer here is a cell drawn "+
+					"somewhere other than where it clicks",
+				file.relPath, funcDecl.Name.Name, subgridCellSetCall,
+			)
+		}
+	}
+
+	// Every backend renaming its draw would otherwise leave this passing over
+	// nothing, which is the failure mode a guardrail can least afford.
+	if checked == 0 {
+		t.Errorf(
+			"found no function outside %s calling %s; the walk is broken and this "+
+				"check would pass vacuously",
+			subgridCellDecider, subgridKeySetCall,
+		)
+	}
+}

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -214,12 +214,6 @@ const (
 	// MinGridRows is the minimum grid rows.
 	MinGridRows = 2
 
-	// MaxKeyIndex is the maximum key index.
-	MaxKeyIndex = 9
-
-	// RoundingFactor is the rounding factor.
-	RoundingFactor = 0.5
-
 	// CenterDivisor is the center calculation divisor.
 	CenterDivisor = 2
 

--- a/internal/domain/grid/grid.go
+++ b/internal/domain/grid/grid.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/domain"
 )
 
 const (
@@ -58,11 +60,13 @@ const (
 	// Real display bounds are well under this value (typical max is ~30000).
 	MaxDisplayDimension = 50000
 
-	// MaxKeyIndex is the maximum key index.
-	MaxKeyIndex = 9
-
-	// RoundingFactor is the factor for rounding.
-	RoundingFactor = 0.5
+	// MaxKeyIndex is how many cells the subgrid every overlay draws has, and so
+	// the index no key of it reaches. It is what those overlays cap their key
+	// set at (SubgridKeys), which is why it is derived from the shipped
+	// dimensions rather than written: the cells a backend draws and the keys it
+	// draws on them have to be counted the same way, and a 9 written by hand is
+	// a second answer waiting for the day the subgrid stops being 3x3.
+	MaxKeyIndex = domain.SubgridRows * domain.SubgridCols
 
 	// CenterDivisor is the divisor for center calculation.
 	CenterDivisor = 2

--- a/internal/domain/grid/manager.go
+++ b/internal/domain/grid/manager.go
@@ -324,47 +324,25 @@ func (m *Manager) handleSubgridSelection(key string) (image.Point, bool) {
 	if keyIndex < 0 {
 		return image.Point{}, false
 	}
-	// Validate key index for 3x3 subgrid
-	if keyIndex >= MaxKeyIndex {
+	// The cells this subgrid is divided into, which are the cells every overlay
+	// backend draws (internal/domain/grid/subgrid_cells.go), so the cursor
+	// lands in the cell the key was written on.
+	cells := SubgridCells(m.selectedCell.bounds, m.subRows, m.subCols)
+
+	// A key past the last cell names nothing. The bound is this manager's own
+	// cell count rather than the shipped subgrid's, because the manager is
+	// built with the row and column count it was handed: a fixed bound would
+	// refuse keys a larger subgrid had drawn.
+	if keyIndex >= len(cells) {
 		return image.Point{}, false
 	}
 
-	// Convert linear index to 2D subgrid coordinates
-	rowIndex := keyIndex / m.subCols
-	colIndex := keyIndex % m.subCols
-	cellBounds := m.selectedCell.bounds
-
-	// Compute subgrid breakpoints for even division of the cell
-	xBreaks := make([]int, m.subCols+1)
-	yBreaks := make([]int, m.subRows+1)
-	xBreaks[0] = cellBounds.Min.X
-	yBreaks[0] = cellBounds.Min.Y
-
-	for breakIndex := 1; breakIndex <= m.subCols; breakIndex++ {
-		val := float64(breakIndex) * float64(cellBounds.Dx()) / float64(m.subCols)
-		xBreaks[breakIndex] = cellBounds.Min.X + int(val+RoundingFactor)
-	}
-
-	for breakIndex := 1; breakIndex <= m.subRows; breakIndex++ {
-		val := float64(breakIndex) * float64(cellBounds.Dy()) / float64(m.subRows)
-		yBreaks[breakIndex] = cellBounds.Min.Y + int(val+RoundingFactor)
-	}
-
-	// Ensure exact coverage of cell bounds
-	xBreaks[m.subCols] = cellBounds.Max.X
-	yBreaks[m.subRows] = cellBounds.Max.Y
-
 	// Calculate center point of the selected subgrid cell, rounded to nearest pixel
-	left := xBreaks[colIndex]
-	right := xBreaks[colIndex+1]
-	top := yBreaks[rowIndex]
-	bottom := yBreaks[rowIndex+1]
-	dx := right - left
-	dy := bottom - top
-	xCoordinate := left + gridRound(dx)
-	yCoordinate := top + gridRound(dy)
+	selected := cells[keyIndex]
+	xCoordinate := selected.Min.X + gridRound(selected.Dx())
+	yCoordinate := selected.Min.Y + gridRound(selected.Dy())
 	m.Logger.Debug("Grid manager: Subgrid selection complete",
-		zap.Int("row", rowIndex), zap.Int("col", colIndex),
+		zap.Int("row", keyIndex/m.subCols), zap.Int("col", keyIndex%m.subCols),
 		zap.Int("x", xCoordinate), zap.Int("y", yCoordinate))
 	// m.Reset()
 	return image.Point{X: xCoordinate, Y: yCoordinate}, true

--- a/internal/domain/grid/subgrid_cells.go
+++ b/internal/domain/grid/subgrid_cells.go
@@ -1,0 +1,73 @@
+package grid
+
+import "image"
+
+// roundingFactor is what a positive quotient is offset by before it is
+// truncated, which rounds it to the nearest whole pixel. It is written once
+// here because a break rounded one way and drawn the other is the whole
+// problem SubgridCells exists to remove.
+const roundingFactor = 0.5
+
+// SubgridCells is the set of rectangles a subgrid divides one cell into, in the
+// order its keys name them: left to right, then top to bottom, so that the
+// cell at index i is the cell SubgridKeys names at index i.
+//
+// It exists because those rectangles decide two different things and have to
+// decide them the same way. The manager computes them to answer where the
+// cursor goes when a subgrid key is pressed; every overlay backend computed
+// them again to answer where the cell is drawn. Four copies, agreeing by
+// coincidence — and a copy that drifted would draw a cell in one place and
+// click in another, which is the one failure a person cannot see coming and no
+// test was watching for.
+//
+// The breaks are rounded rather than truncated so that the columns of a cell
+// that does not divide evenly differ by at most a pixel instead of collecting
+// the whole remainder in the last one, and the last break is the cell's own far
+// edge rather than the rounded value, so the subgrid covers the cell exactly:
+// no seam a click can fall into and no cell drawn a pixel past its parent.
+//
+// Rows and columns are parameters rather than the shipped 3x3
+// (domain.SubgridRows, domain.SubgridCols) because the manager already carries
+// its own, and a function that baked the constant in would leave it computing
+// its answer somewhere else the moment that stopped being true.
+//
+// A subgrid with no rows or no columns has no cells, which is what a caller
+// that has not been configured yet gets instead of a panic.
+func SubgridCells(bounds image.Rectangle, rows, cols int) []image.Rectangle {
+	if rows < 1 || cols < 1 {
+		return nil
+	}
+
+	xBreaks := make([]int, cols+1)
+	yBreaks := make([]int, rows+1)
+
+	for index := range xBreaks {
+		xBreaks[index] = bounds.Min.X + roundedBreak(index, bounds.Dx(), cols)
+	}
+
+	for index := range yBreaks {
+		yBreaks[index] = bounds.Min.Y + roundedBreak(index, bounds.Dy(), rows)
+	}
+
+	xBreaks[cols] = bounds.Max.X
+	yBreaks[rows] = bounds.Max.Y
+
+	cells := make([]image.Rectangle, 0, rows*cols)
+
+	for row := range rows {
+		for col := range cols {
+			cells = append(cells, image.Rect(
+				xBreaks[col], yBreaks[row],
+				xBreaks[col+1], yBreaks[row+1],
+			))
+		}
+	}
+
+	return cells
+}
+
+// roundedBreak is the offset of the index'th of divisions evenly spaced breaks
+// across length, rounded to the nearest pixel.
+func roundedBreak(index, length, divisions int) int {
+	return int(float64(index)*float64(length)/float64(divisions) + roundingFactor)
+}

--- a/internal/domain/grid/subgrid_cells_test.go
+++ b/internal/domain/grid/subgrid_cells_test.go
@@ -1,0 +1,205 @@
+package grid_test
+
+import (
+	"image"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/grid"
+)
+
+// TestSubgridCells pins the rectangles a subgrid divides a cell into. The
+// numbers here are worked by hand rather than recomputed from the formula, so
+// that a change to the formula has to disagree with them.
+func TestSubgridCells(t *testing.T) {
+	testCases := []struct {
+		name   string
+		bounds image.Rectangle
+		rows   int
+		cols   int
+		want   []image.Rectangle
+	}{
+		{
+			name:   "a cell that divides evenly divides into equal thirds",
+			bounds: image.Rect(0, 0, 300, 150),
+			rows:   domain.SubgridRows,
+			cols:   domain.SubgridCols,
+			want: []image.Rectangle{
+				image.Rect(0, 0, 100, 50),
+				image.Rect(100, 0, 200, 50),
+				image.Rect(200, 0, 300, 50),
+				image.Rect(0, 50, 100, 100),
+				image.Rect(100, 50, 200, 100),
+				image.Rect(200, 50, 300, 100),
+				image.Rect(0, 100, 100, 150),
+				image.Rect(100, 100, 200, 150),
+				image.Rect(200, 100, 300, 150),
+			},
+		},
+		{
+			// 10 wide over 3 columns rounds each break to the nearest pixel —
+			// 10/3 = 3.33 rounds to 3, 20/3 = 6.67 rounds to 7 — so the odd
+			// pixel lands in the middle column rather than at one end.
+			name:   "a cell that does not divide evenly rounds each break",
+			bounds: image.Rect(0, 0, 10, 8),
+			rows:   domain.SubgridRows,
+			cols:   domain.SubgridCols,
+			want: []image.Rectangle{
+				image.Rect(0, 0, 3, 3),
+				image.Rect(3, 0, 7, 3),
+				image.Rect(7, 0, 10, 3),
+				image.Rect(0, 3, 3, 5),
+				image.Rect(3, 3, 7, 5),
+				image.Rect(7, 3, 10, 5),
+				image.Rect(0, 5, 3, 8),
+				image.Rect(3, 5, 7, 8),
+				image.Rect(7, 5, 10, 8),
+			},
+		},
+		{
+			// The same 10x8 cell, moved to where a grid cell actually sits.
+			name:   "a cell away from the origin divides where it is",
+			bounds: image.Rect(100, 50, 110, 58),
+			rows:   domain.SubgridRows,
+			cols:   domain.SubgridCols,
+			want: []image.Rectangle{
+				image.Rect(100, 50, 103, 53),
+				image.Rect(103, 50, 107, 53),
+				image.Rect(107, 50, 110, 53),
+				image.Rect(100, 53, 103, 55),
+				image.Rect(103, 53, 107, 55),
+				image.Rect(107, 53, 110, 55),
+				image.Rect(100, 55, 103, 58),
+				image.Rect(103, 55, 107, 58),
+				image.Rect(107, 55, 110, 58),
+			},
+		},
+		{
+			// Not the shipped subgrid: the manager carries its own row and
+			// column count, so the shape has to come from the caller.
+			name:   "a subgrid that is not square divides by its own counts",
+			bounds: image.Rect(0, 0, 9, 5),
+			rows:   2,
+			cols:   4,
+			want: []image.Rectangle{
+				image.Rect(0, 0, 2, 3),
+				image.Rect(2, 0, 5, 3),
+				image.Rect(5, 0, 7, 3),
+				image.Rect(7, 0, 9, 3),
+				image.Rect(0, 3, 2, 5),
+				image.Rect(2, 3, 5, 5),
+				image.Rect(5, 3, 7, 5),
+				image.Rect(7, 3, 9, 5),
+			},
+		},
+		{
+			name:   "a cell narrower than its columns still gives one cell per key",
+			bounds: image.Rect(0, 0, 2, 2),
+			rows:   domain.SubgridRows,
+			cols:   domain.SubgridCols,
+			want: []image.Rectangle{
+				image.Rect(0, 0, 1, 1),
+				image.Rect(1, 0, 1, 1),
+				image.Rect(1, 0, 2, 1),
+				image.Rect(0, 1, 1, 1),
+				image.Rect(1, 1, 1, 1),
+				image.Rect(1, 1, 2, 1),
+				image.Rect(0, 1, 1, 2),
+				image.Rect(1, 1, 1, 2),
+				image.Rect(1, 1, 2, 2),
+			},
+		},
+		{
+			name:   "a subgrid with no rows has no cells",
+			bounds: image.Rect(0, 0, 300, 150),
+			rows:   0,
+			cols:   domain.SubgridCols,
+			want:   nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := grid.SubgridCells(testCase.bounds, testCase.rows, testCase.cols)
+			if len(got) != len(testCase.want) {
+				t.Fatalf("SubgridCells(%v, %d, %d) returned %d cells, want %d",
+					testCase.bounds, testCase.rows, testCase.cols, len(got), len(testCase.want))
+			}
+
+			for index, want := range testCase.want {
+				if got[index] != want {
+					t.Errorf("cell %d = %v, want %v", index, got[index], want)
+				}
+			}
+		})
+	}
+}
+
+// TestSubgridCells_CoversTheCellExactly is the property the worked examples
+// above are instances of, checked across the widths a rounded division has
+// anything to say about. A subgrid that stopped short of its parent's far edge
+// would leave a strip of the cell no key reaches, and one that overshot would
+// draw over the cell next door.
+func TestSubgridCells_CoversTheCellExactly(t *testing.T) {
+	const origin = 37
+
+	for size := 1; size <= 64; size++ {
+		bounds := image.Rect(origin, origin, origin+size, origin+size)
+		cells := grid.SubgridCells(bounds, domain.SubgridRows, domain.SubgridCols)
+
+		if len(cells) != domain.SubgridRows*domain.SubgridCols {
+			t.Fatalf("a %dx%d cell divided into %d cells, want %d",
+				size, size, len(cells), domain.SubgridRows*domain.SubgridCols)
+		}
+
+		if first := cells[0]; first.Min != bounds.Min {
+			t.Errorf("a %dx%d cell starts its subgrid at %v, want %v",
+				size, size, first.Min, bounds.Min)
+		}
+
+		if last := cells[len(cells)-1]; last.Max != bounds.Max {
+			t.Errorf("a %dx%d cell ends its subgrid at %v, want %v",
+				size, size, last.Max, bounds.Max)
+		}
+
+		for index := 1; index < len(cells); index++ {
+			previous, current := cells[index-1], cells[index]
+
+			if index%domain.SubgridCols != 0 && previous.Max.X != current.Min.X {
+				t.Errorf("a %dx%d cell leaves a seam between columns at %d and %d",
+					size, size, previous.Max.X, current.Min.X)
+			}
+
+			if index%domain.SubgridCols == 0 && previous.Max.Y != current.Min.Y {
+				t.Errorf("a %dx%d cell leaves a seam between rows at %d and %d",
+					size, size, previous.Max.Y, current.Min.Y)
+			}
+		}
+	}
+}
+
+// TestManager_SubgridSelectionLandsInsideTheCellItDrew is the stake: the
+// rectangles an overlay draws and the point a keypress moves the cursor to are
+// the same arithmetic, so the cursor has to land in the cell the key was
+// written on. Four copies of that arithmetic used to agree by coincidence.
+func TestManager_SubgridSelectionLandsInsideTheCellItDrew(t *testing.T) {
+	const configured = "asdfghjkl"
+
+	drawn := grid.SubgridKeys(configured, domain.SubgridRows*domain.SubgridCols)
+
+	for index, key := range drawn {
+		manager, opened := newSubgridKeyManager(t, configured)
+
+		cells := grid.SubgridCells(opened, domain.SubgridRows, domain.SubgridCols)
+
+		point, selected := manager.HandleInput(string(key))
+		if !selected {
+			t.Fatalf("subgrid refused %q, which it is drawn with", string(key))
+		}
+
+		if !point.In(cells[index]) {
+			t.Errorf("key %q draws %v but moves the cursor to %v",
+				string(key), cells[index], point)
+		}
+	}
+}

--- a/internal/domain/grid/subgrid_keys_test.go
+++ b/internal/domain/grid/subgrid_keys_test.go
@@ -9,10 +9,6 @@ import (
 	"github.com/y3owk1n/neru/internal/domain/grid"
 )
 
-// subgridCells is the size of the subgrid these cases label — the one every
-// caller in the repo draws, since all three surfaces and the manager are 3x3.
-const subgridCells = domain.SubgridRows * domain.SubgridCols
-
 // TestSubgridKeys pins the answer to "which keys does a subgrid have?". It used
 // to be answered once per overlay backend and once more by the manager, each
 // with its own trimming, its own case and its own cap, and nothing made the set
@@ -62,24 +58,32 @@ func TestSubgridKeys(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if got := string(grid.SubgridKeys(testCase.keys, subgridCells)); got != testCase.want {
+			if got := string(
+				grid.SubgridKeys(testCase.keys, grid.MaxKeyIndex),
+			); got != testCase.want {
 				t.Errorf("SubgridKeys(%q) = %q, want %q", testCase.keys, got, testCase.want)
 			}
 		})
 	}
 }
 
-// TestSubgridKeys_CapAgreesWithTheSelectionBound keeps the two ends of the cap
-// together. SubgridKeys drops keys past the caller's last cell, and
-// handleSubgridSelection separately refuses any key index at or past
-// MaxKeyIndex; if that bound and the cell count ever disagree, a key the
-// overlay drew is a key the manager refuses — the drawn/accepted split this
-// replaced, reappearing inside the domain.
-func TestSubgridKeys_CapAgreesWithTheSelectionBound(t *testing.T) {
-	if grid.MaxKeyIndex != subgridCells {
+// TestSubgridKeys_CapAgreesWithTheCellsThereAre keeps the two ends of the cap
+// together. Every overlay caps its key set at MaxKeyIndex and then draws those
+// keys on the rectangles SubgridCells hands back; if the constant and the
+// division ever disagree, a backend draws a label with no cell under it or a
+// cell with no label on it. Both are answers to "how big is the subgrid?", and
+// this is where they have to be one answer.
+func TestSubgridKeys_CapAgreesWithTheCellsThereAre(t *testing.T) {
+	divided := grid.SubgridCells(
+		image.Rect(0, 0, 300, 150),
+		domain.SubgridRows,
+		domain.SubgridCols,
+	)
+
+	if grid.MaxKeyIndex != len(divided) {
 		t.Errorf(
-			"selection refuses key indexes at or past %d but the subgrid has %d cells",
-			grid.MaxKeyIndex, subgridCells,
+			"overlays cap the key set at %d but the subgrid divides into %d cells",
+			grid.MaxKeyIndex, len(divided),
 		)
 	}
 }
@@ -93,14 +97,14 @@ func TestManager_AcceptsExactlyTheKeysTheSubgridIsDrawnWith(t *testing.T) {
 	// More keys than cells, so the cap is exercised rather than assumed.
 	const configured = "asdfghjklzxc"
 
-	drawn := grid.SubgridKeys(configured, subgridCells)
+	drawn := grid.SubgridKeys(configured, grid.MaxKeyIndex)
 	if len(drawn) != domain.SubgridRows*domain.SubgridCols {
 		t.Fatalf("SubgridKeys(%q) drew %d keys, want %d", configured, len(drawn),
 			domain.SubgridRows*domain.SubgridCols)
 	}
 
 	for _, key := range drawn {
-		manager := newSubgridKeyManager(t, configured)
+		manager, _ := newSubgridKeyManager(t, configured)
 
 		if _, selected := manager.HandleInput(string(key)); !selected {
 			t.Errorf("subgrid refused %q, which it is drawn with", string(key))
@@ -108,7 +112,7 @@ func TestManager_AcceptsExactlyTheKeysTheSubgridIsDrawnWith(t *testing.T) {
 	}
 
 	for _, key := range "ZXC" {
-		manager := newSubgridKeyManager(t, configured)
+		manager, _ := newSubgridKeyManager(t, configured)
 
 		if _, selected := manager.HandleInput(string(key)); selected {
 			t.Errorf("subgrid selected on %q, which no cell is drawn with", string(key))
@@ -126,12 +130,12 @@ func TestManager_EveryDrawnSubgridKeySelectsItsOwnPoint(t *testing.T) {
 	// the repeat counts as a key.
 	const configured = "aabcdefgh"
 
-	drawn := grid.SubgridKeys(configured, subgridCells)
+	drawn := grid.SubgridKeys(configured, grid.MaxKeyIndex)
 
 	points := make(map[image.Point]rune, len(drawn))
 
 	for _, key := range drawn {
-		manager := newSubgridKeyManager(t, configured)
+		manager, _ := newSubgridKeyManager(t, configured)
 
 		point, selected := manager.HandleInput(string(key))
 		if !selected {
@@ -149,12 +153,16 @@ func TestManager_EveryDrawnSubgridKeySelectsItsOwnPoint(t *testing.T) {
 }
 
 // newSubgridKeyManager returns a manager sitting in an open subgrid, so the
-// next key it is handed is a subgrid selection.
-func newSubgridKeyManager(t *testing.T, subKeys string) *grid.Manager {
+// next key it is handed is a subgrid selection, along with the bounds of the
+// cell that subgrid was opened on — the rectangle an overlay would have been
+// handed to draw it in.
+func newSubgridKeyManager(t *testing.T, subKeys string) (*grid.Manager, image.Rectangle) {
 	t.Helper()
 
 	log := logger.Get()
 	testGrid := grid.NewGrid("abcdefghijklmnopqrstuvwxyz", image.Rect(0, 0, 1000, 800), log)
+
+	var opened image.Rectangle
 
 	manager := grid.NewManager(
 		testGrid,
@@ -162,7 +170,7 @@ func newSubgridKeyManager(t *testing.T, subKeys string) *grid.Manager {
 		domain.SubgridCols,
 		subKeys,
 		func(bool) {},
-		func(*grid.Cell) {},
+		func(cell *grid.Cell) { opened = cell.Bounds() },
 		log,
 	)
 
@@ -175,5 +183,9 @@ func newSubgridKeyManager(t *testing.T, subKeys string) *grid.Manager {
 		manager.HandleInput(string(char))
 	}
 
-	return manager
+	if opened.Empty() {
+		t.Fatal("the manager did not open a subgrid on any cell")
+	}
+
+	return manager, opened
 }


### PR DESCRIPTION
## Description

This PR reworks how the cells of a subgrid are worked out, so that the cell you
see and the point the cursor moves to when you press its key can no longer
disagree. Typing a full grid label opens a 3x3 subgrid inside that cell; until
now the rectangles it is divided into were computed four separate times — once
by the mode layer to decide where the cursor goes, and once by each of the
macOS, Linux and Windows overlays to decide where the cell is drawn. The four
agreed, but nothing made them agree, so any one of them drifting would have
drawn a cell in one place and clicked in another.

There is one answer now, and every one of those four asks it for the answer.
The arithmetic is unchanged, so nothing about where a subgrid key sends the
cursor moves — a randomised comparison against the four originals over 200,000
rectangle-and-size combinations produced identical cells and identical
selection points, and the existing grid journey tests are unchanged. The 3x3
the subgrid ships as is now written down once instead of five times, with the
key cap derived from it rather than the number 9 typed out by hand.

No user-visible behaviour changes, and no configuration changes: subgrid
geometry is still fixed at 3x3 and deliberately not configurable.

## Related Issues

Closes #1287

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `refactor` — Code restructuring (no behavior change)

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability changed; all three backends gained a call, none gained a contract.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, nothing a user reads or writes changed; the 3x3 subgrid is already documented as such.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

`just lint-cross` was run as well as `just ci`, because two of the four copies
removed sit behind `linux` and `windows` build tags that `just lint` cannot
see. Both were clean.

Three things are worth a reviewer's attention:

**The domain now bounds subgrid selection by its own cell count rather than by
the fixed constant.** The constant is 9 whatever row and column count the
manager was built with, so a manager built any other size would have refused
keys its overlay had drawn — latent rather than live, since nothing builds one,
but the refactor made the contradiction explicit and it seemed wrong to leave
it that way.

**A guardrail test travels with this.** Two of the three drawing backends
cannot be compiled on a macOS host, so nothing a unit test can do would notice
one of them growing its own arithmetic back. An architecture test parses the
tree regardless of build tags and fails if a function asks which keys a subgrid
has without asking where its cells are. It carries the same vacuity guard as
its neighbour, so a rename cannot leave it passing over nothing.

**One neighbour is deliberately untouched.** The recursive grid divides a
rectangle into cells too, and does it with a different remainder policy — it
gives the spare pixels to the first cells, where the subgrid rounds each
boundary. Both cover their rectangle exactly and both keep cells within a pixel
of each other, but they are not the same division, so they were not merged:
doing so would have moved where subgrid keys send the cursor, which this PR
sets out not to do. Worth a follow-up decision about whether two policies is
right, rather than a silent change here.
