### PR TITLE
refactor(overlay): compute the recursive-grid label maths in one place

### DIFF
--- a/internal/adapter/overlay/linux/animation_cgo.go
+++ b/internal/adapter/overlay/linux/animation_cgo.go
@@ -110,7 +110,7 @@ func applyOpacity(color uint32, opacity float64) uint32 {
 // indicator of the given diameter centered on point. A circle indicator is
 // drawn as a rounded rect with radius = diameter/2 within this box.
 func mouseActionIndicatorRect(point image.Point, diameter float64) image.Rectangle {
-	half := diameter / centeredRectDivisor
+	half := diameter / halfDivisor
 	minX := int(math.Round(float64(point.X) - half))
 	minY := int(math.Round(float64(point.Y) - half))
 	maxX := int(math.Round(float64(point.X) + half))

--- a/internal/adapter/overlay/linux/cgo_helpers.go
+++ b/internal/adapter/overlay/linux/cgo_helpers.go
@@ -8,31 +8,15 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
 )
 
-func centeredRect(cell image.Rectangle, width, height int) image.Rectangle {
-	centerX := cell.Min.X + cell.Dx()/centeredRectDivisor
-	centerY := cell.Min.Y + cell.Dy()/centeredRectDivisor
-
-	return image.Rect(
-		centerX-width/centeredRectDivisor,
-		centerY-height/centeredRectDivisor,
-		centerX-width/centeredRectDivisor+width,
-		centerY-height/centeredRectDivisor+height,
-	)
-}
-
-func shouldShowLabel(
-	cell image.Rectangle,
-	style recursivegrid.Style,
-) bool {
-	if style.LabelAutohideMultiplier() <= 0 {
-		return true
-	}
-
-	threshold := style.LabelFontSize() * style.LabelAutohideMultiplier()
-
-	return float64(cell.Dx()) >= threshold && float64(cell.Dy()) >= threshold
-}
-
+// shouldShowSubKeyPreview reports whether the sub-key mini-grid this backend
+// draws inside a cell is legible enough to be worth drawing: every sub-cell
+// must reach sub_key_preview_autohide_multiplier x the preview font size.
+//
+// Unlike the label autohide threshold (recursivegrid.Style.ShowLabelIn) this
+// is not shared with the Windows backend, because the two do not draw the same
+// thing: Windows draws a single preview label along the bottom of the cell and
+// measures the cell, this backend and the macOS one draw a mini-grid and
+// measure a sub-cell.
 func shouldShowSubKeyPreview(
 	cell image.Rectangle,
 	style recursivegrid.Style,

--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -42,7 +42,7 @@ const (
 	autoPaddingMinVertical                 = 4
 	textWidthMultiplier                    = 0.7
 	textHeightMultiplier                   = 1.4
-	centeredRectDivisor                    = 2
+	halfDivisor                            = 2
 	centeredRectHalf                       = 0.5
 	paddingMultiplier                      = 2
 	// hintPlacementGap is the pixel gap between a hint badge and its target
@@ -784,17 +784,17 @@ func monitorSelectPanelLayout(
 		panelH = maxH
 	}
 
-	centerX := monitor.Min.X + monitor.Dx()/centeredRectDivisor
-	centerY := monitor.Min.Y + monitor.Dy()/centeredRectDivisor
+	centerX := monitor.Min.X + monitor.Dx()/halfDivisor
+	centerY := monitor.Min.Y + monitor.Dy()/halfDivisor
 	panel := image.Rect(
-		centerX-panelW/centeredRectDivisor, centerY-panelH/centeredRectDivisor,
-		centerX+panelW/centeredRectDivisor, centerY+panelH/centeredRectDivisor,
+		centerX-panelW/halfDivisor, centerY-panelH/halfDivisor,
+		centerX+panelW/halfDivisor, centerY+panelH/halfDivisor,
 	)
 
 	// Corner radius: auto = min(panelH/2, 16), matching darwin.
 	radius := float64(style.BorderRadius) * scale
 	if style.BorderRadius < 0 {
-		radius = math.Min(float64(panelH)/centeredRectDivisor, monitorSelectMaxRadius*scale)
+		radius = math.Min(float64(panelH)/halfDivisor, monitorSelectMaxRadius*scale)
 	}
 
 	// Vertically center the label (+ subtitle) block within the panel.
@@ -803,7 +803,7 @@ func monitorSelectPanelLayout(
 		totalTextH += gap + subH
 	}
 
-	textTop := panel.Min.Y + (panelH-totalTextH)/centeredRectDivisor
+	textTop := panel.Min.Y + (panelH-totalTextH)/halfDivisor
 
 	labelRect := image.Rect(panel.Min.X, textTop, panel.Max.X, textTop+labelH)
 
@@ -1185,7 +1185,7 @@ func hintBadgeRadius(radius, badgeWidth int, placement string) int {
 		return radius
 	}
 
-	maxRadius := max(badgeWidth/centeredRectDivisor-hintArrowMinHalfBase, 0)
+	maxRadius := max(badgeWidth/halfDivisor-hintArrowMinHalfBase, 0)
 
 	if radius > maxRadius {
 		return maxRadius
@@ -1223,8 +1223,8 @@ func hintBadgePlacement(
 	badgeWidth, badgeHeight, radius int,
 	placement string,
 ) (image.Rectangle, hintArrowTriangle, bool) {
-	halfW := badgeWidth / centeredRectDivisor
-	halfH := badgeHeight / centeredRectDivisor
+	halfW := badgeWidth / halfDivisor
+	halfH := badgeHeight / halfDivisor
 	centerX := target.X
 	centerY := target.Y
 

--- a/internal/adapter/overlay/linux/overlay_shared_cgo.go
+++ b/internal/adapter/overlay/linux/overlay_shared_cgo.go
@@ -350,7 +350,7 @@ func (o *sharedOverlay) drawHints(
 
 		radius := style.BorderRadius()
 		if radius < 0 {
-			radius = min(badgeHeight/centeredRectDivisor, hintAutoRadiusMax)
+			radius = min(badgeHeight/halfDivisor, hintAutoRadiusMax)
 		}
 		// Cap the radius so a top/bottom badge keeps a flat edge for the tail.
 		radius = hintBadgeRadius(radius, badgeWidth, style.Placement())
@@ -445,7 +445,7 @@ func (o *sharedOverlay) startMouseActionAnimation(
 		if isSquare {
 			o.drawRect(rect, fill, border, lineWidth)
 		} else {
-			o.drawRoundedRect(rect, diameter/centeredRectDivisor, fill, border, lineWidth)
+			o.drawRoundedRect(rect, diameter/halfDivisor, fill, border, lineWidth)
 		}
 
 		o.srf.surfaceFlush()
@@ -777,7 +777,7 @@ func (o *sharedOverlay) drawFrame(
 				label = string(keyRunes[idx])
 			}
 
-			if shouldShowLabel(cell, style) {
+			if style.ShowLabelIn(cell) {
 				if style.LabelBackground() {
 					o.drawLabelBackground(label, cell, style)
 				}
@@ -972,7 +972,7 @@ func (o *sharedOverlay) drawLabelBackground(
 		paddingX*paddingMultiplier
 	height := badge.EstimateTextHeight(fontSize) +
 		paddingY*paddingMultiplier
-	rect := centeredRect(cell, width, height)
+	rect := badge.CenteredIn(cell, width, height)
 	o.drawRect(rect, style.LabelBackgroundColorARGB(),
 		style.LineColorARGB(), max(style.LabelBackgroundBorderWidthF(), 0))
 }

--- a/internal/adapter/overlay/render/badge/badge.go
+++ b/internal/adapter/overlay/render/badge/badge.go
@@ -113,6 +113,22 @@ func Bounds(
 	)
 }
 
+// CenteredIn returns a width x height rectangle centered inside container.
+//
+// The centering is integer arithmetic and truncates toward the container's
+// origin on an odd container or badge dimension, so a label plate lands on the
+// same pixel on every backend. A badge larger than its container overhangs it
+// rather than being clamped: the callers draw label plates, and a plate that
+// outgrew its cell is the autohide threshold's problem, not this function's.
+func CenteredIn(container image.Rectangle, width, height int) image.Rectangle {
+	centerX := container.Min.X + container.Dx()/halfDivisor
+	centerY := container.Min.Y + container.Dy()/halfDivisor
+	originX := centerX - width/halfDivisor
+	originY := centerY - height/halfDivisor
+
+	return image.Rect(originX, originY, originX+width, originY+height)
+}
+
 // BorderRadius resolves a configured border-radius value for the given
 // rectangle. Negative values select an automatic radius: autoCap limits the
 // auto-radius for badge-style corners (e.g. 6 px for hint badges); pass 0 for

--- a/internal/adapter/overlay/render/badge/badge_test.go
+++ b/internal/adapter/overlay/render/badge/badge_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
+	"github.com/y3owk1n/neru/internal/config"
 )
 
 const opaqueWhite = 0xFFFFFFFF
@@ -18,13 +19,28 @@ func TestParseHexARGB_Notations(t *testing.T) {
 		want uint32
 	}{
 		{name: "short RGB expands", in: "#abc", want: 0xFFAABBCC},
+		{name: "short RGB expands to primary", in: "#F00", want: 0xFFFF0000},
 		{name: "RRGGBB gets opaque alpha", in: "#102030", want: 0xFF102030},
+		{name: "RRGGBB primary gets opaque alpha", in: "#FF0000", want: 0xFFFF0000},
 		{name: "AARRGGBB kept verbatim", in: "#80102030", want: 0x80102030},
 		{name: "no hash accepted", in: "102030", want: 0xFF102030},
+		{name: "no hash AARRGGBB accepted", in: "80FF0000", want: 0x80FF0000},
 		{name: "whitespace trimmed", in: "  #102030  ", want: 0xFF102030},
 		{name: "bad length falls back to white", in: "#1020", want: opaqueWhite},
+		{name: "bad length non-hex falls back to white", in: "zzzz", want: opaqueWhite},
 		{name: "bad digits fall back to white", in: "#10203G", want: opaqueWhite},
+		{name: "unparseable RRGGBB falls back to white", in: "GGGGGG", want: opaqueWhite},
 		{name: "empty falls back to white", in: "", want: opaqueWhite},
+		{
+			name: "hints light background default",
+			in:   config.HintsBackgroundColorLight,
+			want: 0xF2EEF2FF,
+		},
+		{
+			name: "hints dark background default",
+			in:   config.HintsBackgroundColorDark,
+			want: 0xF20A1338,
+		},
 	}
 
 	for _, testCase := range tests {
@@ -41,25 +57,110 @@ func TestParseHexARGB_Notations(t *testing.T) {
 func TestAutoPadding_ExplicitAndAuto(t *testing.T) {
 	t.Parallel()
 
-	if got := badge.AutoPadding(20, 9, true); got != 9 {
-		t.Errorf("explicit padding = %d, want 9", got)
+	tests := []struct {
+		name       string
+		fontSize   float64
+		padding    int
+		horizontal bool
+		want       int
+	}{
+		{name: "explicit padding wins", fontSize: 20, padding: 9, horizontal: true, want: 9},
+		{
+			name:       "explicit padding wins at 14pt",
+			fontSize:   14,
+			padding:    5,
+			horizontal: true,
+			want:       5,
+		},
+		{name: "explicit zero padding", fontSize: 14, padding: 0, horizontal: false, want: 0},
+		{name: "auto horizontal at 20pt", fontSize: 20, padding: -1, horizontal: true, want: 12},
+		{name: "auto vertical at 20pt", fontSize: 20, padding: -1, horizontal: false, want: 7},
+		{name: "auto horizontal at 14pt", fontSize: 14, padding: -1, horizontal: true, want: 8},
+		{
+			name:       "auto vertical at 14pt meets the floor",
+			fontSize:   14,
+			padding:    -1,
+			horizontal: false,
+			want:       4,
+		},
+		{name: "auto horizontal floor at 4pt", fontSize: 4, padding: -1, horizontal: true, want: 6},
+		{name: "auto vertical floor at 4pt", fontSize: 4, padding: -1, horizontal: false, want: 4},
+		{name: "auto horizontal floor at 5pt", fontSize: 5, padding: -1, horizontal: true, want: 6},
+		{name: "auto vertical floor at 5pt", fontSize: 5, padding: -1, horizontal: false, want: 4},
 	}
 
-	if got := badge.AutoPadding(20, -1, true); got != 12 {
-		t.Errorf("auto horizontal at 20pt = %d, want 12 (20*0.6)", got)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := badge.AutoPadding(testCase.fontSize, testCase.padding, testCase.horizontal)
+			if got != testCase.want {
+				t.Errorf("AutoPadding(%v, %d, %v) = %d, want %d",
+					testCase.fontSize, testCase.padding, testCase.horizontal, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestEstimateTextWidth_RuneCountHeuristic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		text     string
+		fontSize float64
+		want     int
+	}{
+		{name: "empty", text: "", fontSize: 14, want: 0},
+		{
+			name:     "two char label",
+			text:     "AB",
+			fontSize: 14,
+			want:     20,
+		}, // ceil(2 * 14 * 0.7) = ceil(19.6)
+		{name: "three char label", text: "ABC", fontSize: 20, want: 42}, // 3 * 20 * 0.7 = 42
+		{name: "single char", text: "A", fontSize: 10, want: 7},         // 1 * 10 * 0.7 = 7
 	}
 
-	if got := badge.AutoPadding(20, -1, false); got != 7 {
-		t.Errorf("auto vertical at 20pt = %d, want 7 (20*0.35)", got)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := badge.EstimateTextWidth(testCase.text, testCase.fontSize)
+			if got != testCase.want {
+				t.Errorf("EstimateTextWidth(%q, %v) = %d, want %d",
+					testCase.text, testCase.fontSize, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestEstimateTextHeight_LineHeightHeuristic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fontSize float64
+		want     int
+	}{
+		{name: "font 14", fontSize: 14, want: 20}, // ceil(14 * 1.4) = ceil(19.6)
+		{name: "font 10", fontSize: 10, want: 14}, // 10 * 1.4 = 14
+		{name: "font 20", fontSize: 20, want: 28}, // 20 * 1.4 = 28
 	}
 
-	// Floors apply for tiny fonts.
-	if got := badge.AutoPadding(4, -1, true); got != 6 {
-		t.Errorf("auto horizontal floor = %d, want 6", got)
-	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-	if got := badge.AutoPadding(4, -1, false); got != 4 {
-		t.Errorf("auto vertical floor = %d, want 4", got)
+			if got := badge.EstimateTextHeight(testCase.fontSize); got != testCase.want {
+				t.Errorf(
+					"EstimateTextHeight(%v) = %d, want %d",
+					testCase.fontSize,
+					got,
+					testCase.want,
+				)
+			}
+		})
 	}
 }
 
@@ -80,6 +181,77 @@ func TestBounds_AnchorsAndFallbackFontSize(t *testing.T) {
 	fallback := badge.Bounds(0, 0, 0, 0, "ab", 0, -1, -1)
 	if fallback.Dx() == 0 || fallback.Dy() == 0 {
 		t.Errorf("Bounds with zero font size = %v, want non-empty", fallback)
+	}
+}
+
+func TestCenteredIn_CentersAndKeepsSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		container     image.Rectangle
+		width, height int
+		want          image.Rectangle
+	}{
+		{
+			name:      "even container and badge",
+			container: image.Rect(0, 0, 100, 100),
+			width:     20,
+			height:    10,
+			want:      image.Rect(40, 45, 60, 55),
+		},
+		{
+			name:      "offset container",
+			container: image.Rect(200, 300, 300, 400),
+			width:     20,
+			height:    10,
+			want:      image.Rect(240, 345, 260, 355),
+		},
+		{
+			name:      "odd container truncates toward the origin",
+			container: image.Rect(0, 0, 101, 101),
+			width:     10,
+			height:    10,
+			want:      image.Rect(45, 45, 55, 55),
+		},
+		{
+			name:      "odd badge truncates toward the origin",
+			container: image.Rect(0, 0, 100, 100),
+			width:     11,
+			height:    11,
+			want:      image.Rect(45, 45, 56, 56),
+		},
+		{
+			name:      "badge larger than container overhangs symmetrically",
+			container: image.Rect(0, 0, 10, 10),
+			width:     30,
+			height:    20,
+			want:      image.Rect(-10, -5, 20, 15),
+		},
+		{
+			name:      "negative container coordinates",
+			container: image.Rect(-100, -100, -50, -50),
+			width:     10,
+			height:    10,
+			want:      image.Rect(-80, -80, -70, -70),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := badge.CenteredIn(testCase.container, testCase.width, testCase.height)
+			if got != testCase.want {
+				t.Errorf("CenteredIn(%v, %d, %d) = %v, want %v",
+					testCase.container, testCase.width, testCase.height, got, testCase.want)
+			}
+
+			if got.Dx() != testCase.width || got.Dy() != testCase.height {
+				t.Errorf("CenteredIn size = %dx%d, want %dx%d",
+					got.Dx(), got.Dy(), testCase.width, testCase.height)
+			}
+		})
 	}
 }
 

--- a/internal/adapter/overlay/render/recursivegrid/style.go
+++ b/internal/adapter/overlay/render/recursivegrid/style.go
@@ -1,6 +1,8 @@
 package recursivegrid
 
 import (
+	"image"
+
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/ports"
@@ -186,6 +188,28 @@ func (s Style) SubKeyPreviewAutohideMultiplier() float64 {
 // hides itself.
 func (s Style) LabelAutohideMultiplier() float64 {
 	return s.labelAutohideMultiplier
+}
+
+// ShowLabelIn reports whether a cell is large enough for its key label to be
+// worth drawing: both cell dimensions must reach
+// label_autohide_multiplier x the label font size. A non-positive multiplier
+// disables autohide, so the label always shows.
+//
+// The Cairo and GDI backends both call this, and they have to answer the same
+// way — a cell one labels and the other leaves blank is the same configuration
+// producing two different screens. The macOS backend asks the same question in
+// Objective-C (drawGridLabel: in
+// internal/adapter/platform/darwin/overlay_darwin.m), so Go cannot be its one
+// implementation; it agrees today and nothing yet pins it, which is the test
+// ADR 0007 says is owed where the second implementation is in another language.
+func (s Style) ShowLabelIn(cell image.Rectangle) bool {
+	if s.labelAutohideMultiplier <= 0 {
+		return true
+	}
+
+	threshold := s.LabelFontSize() * s.labelAutohideMultiplier
+
+	return float64(cell.Dx()) >= threshold && float64(cell.Dy()) >= threshold
 }
 
 // SubKeyPreviewTextColor returns the preview label color as a hex string.

--- a/internal/adapter/overlay/render/recursivegrid/style_test.go
+++ b/internal/adapter/overlay/render/recursivegrid/style_test.go
@@ -1,6 +1,7 @@
 package recursivegrid
 
 import (
+	"image"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
@@ -85,6 +86,92 @@ func TestBuildStyle_CarriesTheToggles(t *testing.T) {
 		if got := style.SubKeyPreview(); got != want {
 			t.Errorf("SubKeyPreview() = %v, want %v", got, want)
 		}
+	}
+}
+
+// TestStyle_ShowLabelIn pins the label autohide threshold every backend draws
+// by: label_autohide_multiplier x the label font size, compared against both
+// cell dimensions, with a non-positive multiplier meaning "always show".
+//
+// The Cairo and GDI backends both call this, so the cases run in every job
+// rather than only where a particular backend is built.
+func TestStyle_ShowLabelIn(t *testing.T) {
+	tests := []struct {
+		name       string
+		cell       image.Rectangle
+		fontSize   int
+		multiplier float64
+		want       bool
+	}{
+		{
+			name:       "zero multiplier always shows",
+			cell:       image.Rect(0, 0, 1, 1),
+			fontSize:   100,
+			multiplier: 0,
+			want:       true,
+		},
+		{
+			name:       "negative multiplier always shows",
+			cell:       image.Rect(0, 0, 1, 1),
+			fontSize:   100,
+			multiplier: -2,
+			want:       true,
+		},
+		{
+			name:       "cell clears the threshold on both axes",
+			cell:       image.Rect(0, 0, 30, 30),
+			fontSize:   10,
+			multiplier: 2, // threshold 20
+			want:       true,
+		},
+		{
+			name:       "cell exactly on the threshold shows",
+			cell:       image.Rect(0, 0, 20, 20),
+			fontSize:   10,
+			multiplier: 2, // threshold 20
+			want:       true,
+		},
+		{
+			name:       "cell below the threshold hides",
+			cell:       image.Rect(0, 0, 30, 30),
+			fontSize:   20,
+			multiplier: 2, // threshold 40
+			want:       false,
+		},
+		{
+			name:       "narrow cell hides even when tall enough",
+			cell:       image.Rect(0, 0, 19, 100),
+			fontSize:   10,
+			multiplier: 2, // threshold 20
+			want:       false,
+		},
+		{
+			name:       "short cell hides even when wide enough",
+			cell:       image.Rect(0, 0, 100, 19),
+			fontSize:   10,
+			multiplier: 2, // threshold 20
+			want:       false,
+		},
+		{
+			name:       "offset cell is measured by its size, not its position",
+			cell:       image.Rect(500, 700, 530, 730),
+			fontSize:   10,
+			multiplier: 2, // threshold 20
+			want:       true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			style := NewStyle(StyleOptions{
+				FontSize:                testCase.fontSize,
+				LabelAutohideMultiplier: testCase.multiplier,
+			})
+
+			if got := style.ShowLabelIn(testCase.cell); got != testCase.want {
+				t.Errorf("ShowLabelIn(%v) = %v, want %v", testCase.cell, got, testCase.want)
+			}
+		})
 	}
 }
 

--- a/internal/adapter/overlay/windows/features.go
+++ b/internal/adapter/overlay/windows/features.go
@@ -27,7 +27,7 @@ const (
 	winAutoPaddingMinVertical          = 4
 	winTextWidthMultiplier             = 0.7
 	winTextHeightMultiplier            = 1.4
-	winCenteredRectDivisor             = 2
+	winHalfDivisor                     = 2
 	winPaddingMultiplier               = 2
 	winSubKeyPreviewPaddingBottom      = 4
 	winAutoRadiusBadgeCap              = 6.0
@@ -111,8 +111,8 @@ func (o *winOverlay) DrawHints(
 		// center so it does not cover the element's own content (e.g. the digit
 		// on a calculator button). hint.Position() is the element center and
 		// hint.Size() its bounds, so the top-left is center minus half-size.
-		originX := hint.Position().X - hint.Size().X/winCenteredRectDivisor
-		originY := hint.Position().Y - hint.Size().Y/winCenteredRectDivisor
+		originX := hint.Position().X - hint.Size().X/winHalfDivisor
+		originY := hint.Position().Y - hint.Size().Y/winHalfDivisor
 		bounds := image.Rect(originX, originY, originX+badgeWidth, originY+badgeHeight)
 
 		textColor := style.TextColor()
@@ -200,7 +200,7 @@ func (o *winOverlay) DrawRecursiveGrid(
 				label = string(keyRunes[idx])
 			}
 
-			if shouldShowWinLabel(cell, style) {
+			if style.ShowLabelIn(cell) {
 				if style.LabelBackground() {
 					o.drawRecursiveLabelBackground(label, cell, style)
 				}
@@ -280,7 +280,7 @@ func (o *winOverlay) drawRecursiveLabelBackground(
 	paddingY := badge.AutoPadding(fontSize, style.LabelBackgroundPaddingY(), false)
 	width := badge.EstimateTextWidth(label, fontSize) + paddingX*winPaddingMultiplier
 	height := badge.EstimateTextHeight(fontSize) + paddingY*winPaddingMultiplier
-	rect := winCenteredRect(cell, width, height)
+	rect := badge.CenteredIn(cell, width, height)
 
 	o.drawFilledRect(
 		rect,
@@ -319,16 +319,14 @@ func (o *winOverlay) drawRecursiveSubKeyPreview(
 	)
 }
 
-func shouldShowWinLabel(cell image.Rectangle, style recursivegridcomponent.Style) bool {
-	if style.LabelAutohideMultiplier() <= 0 {
-		return true
-	}
-
-	threshold := style.LabelFontSize() * style.LabelAutohideMultiplier()
-
-	return float64(cell.Dx()) >= threshold && float64(cell.Dy()) >= threshold
-}
-
+// shouldShowWinSubKeyPreview reports whether the single preview label this
+// backend draws along the bottom of a cell is worth drawing: the cell must
+// reach sub_key_preview_autohide_multiplier x the preview font size.
+//
+// Unlike the label autohide threshold (recursivegridcomponent.Style.ShowLabelIn)
+// this is not shared with the Linux backend, because the two do not draw the
+// same thing: Linux and macOS draw a mini-grid of the next level's keys and
+// measure a sub-cell, this backend draws one label and measures the cell.
 func shouldShowWinSubKeyPreview(cell image.Rectangle, style recursivegridcomponent.Style) bool {
 	if !style.SubKeyPreview() {
 		return false
@@ -341,16 +339,4 @@ func shouldShowWinSubKeyPreview(cell image.Rectangle, style recursivegridcompone
 	threshold := style.SubKeyPreviewFontSizeF() * style.SubKeyPreviewAutohideMultiplier()
 
 	return float64(cell.Dx()) >= threshold && float64(cell.Dy()) >= threshold
-}
-
-func winCenteredRect(cell image.Rectangle, width, height int) image.Rectangle {
-	centerX := cell.Min.X + cell.Dx()/winCenteredRectDivisor
-	centerY := cell.Min.Y + cell.Dy()/winCenteredRectDivisor
-
-	return image.Rect(
-		centerX-width/winCenteredRectDivisor,
-		centerY-height/winCenteredRectDivisor,
-		centerX-width/winCenteredRectDivisor+width,
-		centerY-height/winCenteredRectDivisor+height,
-	)
 }

--- a/internal/adapter/overlay/windows/features_test.go
+++ b/internal/adapter/overlay/windows/features_test.go
@@ -6,159 +6,18 @@ import (
 	"image"
 	"testing"
 
-	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
-	"github.com/y3owk1n/neru/internal/config"
 )
 
-// Unit tests for the pure Win32 hint/recursive-grid rendering helpers.
-// Does not cover GDI drawing (see overlay integration tests on WIN-VM).
-func TestEstimateWinTextWidth(t *testing.T) {
-	t.Parallel()
+// Unit tests for the Win32-only rendering decisions. Does not cover GDI
+// drawing (see overlay integration tests on WIN-VM), and no longer covers the
+// untagged render/badge and render/recursivegrid maths — those tests live
+// beside the code they test so they run on every CI leg, not only this one.
 
-	tests := []struct {
-		name     string
-		text     string
-		fontSize float64
-		want     int
-	}{
-		{"empty", "", 14, 0},
-		{"two char label", "AB", 14, 20},    // ceil(2 * 14 * 0.7) = ceil(19.6)
-		{"three char label", "ABC", 20, 42}, // 3 * 20 * 0.7 = 42
-		{"single char", "A", 10, 7},         // 1 * 10 * 0.7 = 7
-	}
-
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			if got := badge.EstimateTextWidth(
-				testCase.text,
-				testCase.fontSize,
-			); got != testCase.want {
-				t.Fatalf(
-					"badge.EstimateTextWidth(%q, %v) = %d, want %d",
-					testCase.text,
-					testCase.fontSize,
-					got,
-					testCase.want,
-				)
-			}
-		})
-	}
-}
-
-func TestEstimateWinTextHeight(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		fontSize float64
-		want     int
-	}{
-		{"font 14", 14, 20}, // ceil(14 * 1.4) = ceil(19.6)
-		{"font 10", 10, 14}, // 10 * 1.4 = 14
-		{"font 20", 20, 28}, // 20 * 1.4 = 28
-	}
-
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			if got := badge.EstimateTextHeight(testCase.fontSize); got != testCase.want {
-				t.Fatalf(
-					"badge.EstimateTextHeight(%v) = %d, want %d",
-					testCase.fontSize,
-					got,
-					testCase.want,
-				)
-			}
-		})
-	}
-}
-
-func TestResolveWinAutoPadding(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		fontSize   float64
-		padding    int
-		horizontal bool
-		want       int
-	}{
-		{"explicit padding wins", 14, 5, true, 5},
-		{"explicit zero padding", 14, 0, false, 0},
-		{"auto horizontal large font", 14, -1, true, 8}, // int(14*0.6)=8 > min 6
-		{"auto horizontal min floor", 5, -1, true, 6},   // int(5*0.6)=3 -> min 6
-		{"auto vertical large font", 14, -1, false, 4},  // int(14*0.35)=4 == min 4
-		{"auto vertical min floor", 5, -1, false, 4},    // int(5*0.35)=1 -> min 4
-	}
-
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := badge.AutoPadding(testCase.fontSize, testCase.padding, testCase.horizontal)
-			if got != testCase.want {
-				t.Fatalf("badge.AutoPadding(%v, %d, %v) = %d, want %d",
-					testCase.fontSize, testCase.padding, testCase.horizontal, got, testCase.want)
-			}
-		})
-	}
-}
-
-func TestWinCenteredRect(t *testing.T) {
-	t.Parallel()
-
-	cell := image.Rect(0, 0, 100, 100)
-	got := winCenteredRect(cell, 20, 10)
-	want := image.Rect(40, 45, 60, 55)
-
-	if got != want {
-		t.Fatalf("winCenteredRect = %v, want %v", got, want)
-	}
-
-	if got.Dx() != 20 || got.Dy() != 10 {
-		t.Fatalf("winCenteredRect size = %dx%d, want 20x10", got.Dx(), got.Dy())
-	}
-}
-
-func TestParseHexColorARGB(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		value string
-		want  uint32
-	}{
-		{"full argb", "80FF0000", 0x80FF0000},
-		{"hints light background", config.HintsBackgroundColorLight, 0xF2EEF2FF},
-		{"hints dark background", config.HintsBackgroundColorDark, 0xF20A1338},
-		{"rgb no alpha gets opaque", "#FF0000", 0xFFFF0000},
-		{"short form expands", "#F00", 0xFFFF0000},
-		{"short form mixed", "#abc", 0xFFAABBCC},
-		{"empty is opaque white", "", 0xFFFFFFFF},
-		{"invalid length is opaque white", "zzzz", 0xFFFFFFFF},
-		{"unparseable is opaque white", "GGGGGG", 0xFFFFFFFF},
-	}
-
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			if got := badge.ParseHexARGB(testCase.value); got != testCase.want {
-				t.Fatalf(
-					"badge.ParseHexARGB(%q) = 0x%08X, want 0x%08X",
-					testCase.value,
-					got,
-					testCase.want,
-				)
-			}
-		})
-	}
-}
-
+// TestShouldShowWinSubKeyPreview pins the threshold for the single preview
+// label this backend draws along the bottom of a cell. It stays here because
+// it measures the whole cell: Linux and macOS draw a mini-grid instead and
+// measure a sub-cell, so this predicate is genuinely this backend's own.
 func TestShouldShowWinSubKeyPreview(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

This PR removes a duplicate. Linux and Windows each carried their own copy of two pieces of recursive-grid drawing arithmetic — whether a cell is large enough for its key label to be worth drawing, and where a label plate sits inside its cell. The two copies were identical apart from names picked to dodge a symbol clash, which meant `label_autohide_multiplier` could have started meaning different things on the two platforms the moment somebody fixed one of them. Both now have a single implementation in the untagged render layer the two backends already import, following the shared-derivation rule from ADR 0007 that landed with #1290 and #1292.

Nothing changes on screen. This is a pure move: the thresholds, the comparisons and the integer truncation are all preserved exactly, and `label_autohide_multiplier` keeps meaning what it means today on both platforms. macOS computes the equivalents in Objective-C and is deliberately out of scope — ADR 0007 records why the rule stops at the language boundary.

One deliberate limitation: the **sub-key-preview** thresholds are left as two implementations, against the letter of the issue's first acceptance criterion. See *Additional Context* — the issue's premise that they are byte-identical copies turns out not to hold, and collapsing them would move pixels.

## Related Issues

Closes #1288

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this PR adds no port capability; it moves existing pure arithmetic between packages.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing config, command or behaviour surface changes.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Why the sub-key-preview thresholds stayed apart.** The issue describes the two label-autohide predicates and the two centering functions as "byte-identical apart from the names they were given to dodge a symbol clash". That holds for the label-autohide and centering pairs, and both are collapsed here. It does not hold for the sub-key-preview pair, which are not two copies of one derivation — they gate different drawings:

| | what it draws | what it measures |
|---|---|---|
| Linux, macOS | a mini-grid of the next level's keys | one **sub-cell** (cell size ÷ next grid's cols/rows) |
| Windows | a single preview label along the bottom of the cell | the whole **cell** |

Git history confirms they were written independently and were never the same (Linux arrived with #1089, Windows with #932). Merging them would need one behaviour to win and would move pixels on the losing platform, so both are left in place with a comment at each site explaining why. **The underlying question is a real one and worth its own issue**: Windows draws a materially smaller sub-key preview than the other two backends. That is a feature gap, not a threshold bug, and it is not something this refactor should decide.

**Where the shared code went.** The autohide threshold became a method on the recursive-grid render style, so the call sites read as a question about the style rather than a free function taking one. The centering went to the badge package next to the text-sizing maths it is always paired with — that package is ADR 0007's own named precedent for this layer. Neither is a `common`/`util` bucket.

**One rename, for honesty.** Both backends had a `centeredRectDivisor` / `winCenteredRectDivisor` constant. The functions they were named after are gone, but the constants have unrelated callers (hint origins, monitor-select panels, arrow geometry), so they are renamed to `halfDivisor` / `winHalfDivisor` rather than deleted. This is why `manager.go` and `animation_cgo.go` appear in the diff.

**An unpinned third copy, now named.** macOS asks the same label-autohide question in Objective-C and agrees today, but nothing holds it there. ADR 0007 says what is owed in that case is a pinning test rather than a deletion; no such test exists yet, so the shared function's doc comment names darwin as the unpinned copy instead of claiming a parity the code does not enforce.

**Verification.** Neither backend compiles on the macOS host this was written on, and `just lint` is blind to both build tags. In addition to `just ci`: `just lint-cross` (linux/amd64 with CGO on, and windows/amd64) reports 0 issues on both legs; `just test-linux` executes the real Linux suite in the CI container; `just test-windows-compile` builds the Windows test binaries. The moved logic itself now lives in untagged packages, so its tests run on all three legs rather than one.

**Test relocation.** Five test functions moved out of the windows-tagged overlay package, not four — the issue counts four, but the hex-colour test was also exercising only the shared badge package. Every case they asserted survives; the badge package's existing tables absorbed them, and the cases that were genuinely new to the shared functions (odd dimensions, negative coordinates, a badge larger than its cell, the autohide boundary conditions) are pinned alongside. The one Windows-tagged test that remains is the sub-key-preview threshold, which stays because it measures the cell rather than a sub-cell and is genuinely that backend's own.
