### PR TITLE
refactor(hints): declare the hint-placement vocabulary once

### DIFF
--- a/docs/adr/0007-a-shared-derivation-has-one-implementation.md
+++ b/docs/adr/0007-a-shared-derivation-has-one-implementation.md
@@ -73,10 +73,15 @@ are the precedent, not the exception.
   implementation, and what this rule asks for there is a test pinning the copies
   together, not a deletion. Moving that geometry into Go would mean changing what
   crosses the cgo boundary — that is the overlay-port work, and doing it under
-  this rule would be that redesign arriving without its design. No such pinning
-  test exists yet: this ADR states what is owed, and the placement vocabulary
-  written four times in Go against the enum in `internal/adapter/platform/darwin/overlay.h`
-  is the first candidate.
+  this rule would be that redesign arriving without its design. The first such
+  pin landed with the placement vocabulary (#1289): the three values are
+  declared once in Go, and `internal/architecture/hint_placement_vocabulary_test.go`
+  holds that declaration, the macros in `internal/adapter/platform/darwin/overlay.h`
+  and the `HintPlacement` enum to the same numbering. It pins *which placement
+  each value means*, not where the badge is then drawn — `hintRectForPlacement:`
+  remains a single Objective-C implementation with no Go counterpart to
+  disagree with. One copy of this kind is still owed a pin: the recursive-grid
+  label-autohide rule (#1298).
 - **"Lowest layer with more than one caller" is a judgement someone has to
   make, and it moves.** A derivation with one caller is not shared and should
   stay private; the second caller is what triggers the move, and the move is

--- a/internal/adapter/overlay/linux/hint_arrow_test.go
+++ b/internal/adapter/overlay/linux/hint_arrow_test.go
@@ -5,6 +5,8 @@ package linux
 import (
 	"image"
 	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
 )
 
 // Unit tests for the pure hint badge/arrow placement math shared by the X11 and
@@ -12,7 +14,7 @@ import (
 // tests; here we only assert the geometry the C draw calls receive.
 func TestHintBadgePlacement_CenterHasNoArrow(t *testing.T) {
 	target := image.Pt(100, 100)
-	badge, arrow, hasArrow := hintBadgePlacement(target, 40, 20, 4, "center")
+	badge, arrow, hasArrow := hintBadgePlacement(target, 40, 20, 4, config.HintPlacementCenter)
 
 	if hasArrow {
 		t.Fatalf("center placement should not draw an arrow, got %+v", arrow)
@@ -36,7 +38,13 @@ func TestHintBadgePlacement_UnknownPlacementHasNoArrow(t *testing.T) {
 func TestHintBadgePlacement_Bottom(t *testing.T) {
 	target := image.Pt(200, 150)
 	badgeWidth, badgeHeight, radius := 40, 20, 4
-	badge, arrow, hasArrow := hintBadgePlacement(target, badgeWidth, badgeHeight, radius, "bottom")
+	badge, arrow, hasArrow := hintBadgePlacement(
+		target,
+		badgeWidth,
+		badgeHeight,
+		radius,
+		config.HintPlacementBottom,
+	)
 
 	if !hasArrow {
 		t.Fatal("bottom placement should draw an arrow")
@@ -85,7 +93,13 @@ func TestHintBadgePlacement_Bottom(t *testing.T) {
 func TestHintBadgePlacement_Top(t *testing.T) {
 	target := image.Pt(200, 150)
 	badgeWidth, badgeHeight, radius := 40, 20, 4
-	badge, arrow, hasArrow := hintBadgePlacement(target, badgeWidth, badgeHeight, radius, "top")
+	badge, arrow, hasArrow := hintBadgePlacement(
+		target,
+		badgeWidth,
+		badgeHeight,
+		radius,
+		config.HintPlacementTop,
+	)
 
 	if !hasArrow {
 		t.Fatal("top placement should draw an arrow")
@@ -126,7 +140,13 @@ func TestHintBadgePlacement_ArrowBaseClampedToFlatEdge(t *testing.T) {
 	target := image.Pt(50, 50)
 	badgeWidth, badgeHeight, radius := 14, 20, 6
 
-	badge, arrow, hasArrow := hintBadgePlacement(target, badgeWidth, badgeHeight, radius, "bottom")
+	badge, arrow, hasArrow := hintBadgePlacement(
+		target,
+		badgeWidth,
+		badgeHeight,
+		radius,
+		config.HintPlacementBottom,
+	)
 	if !hasArrow {
 		t.Fatal("expected an arrow")
 	}
@@ -144,7 +164,7 @@ func TestHintBadgePlacement_ArrowBaseClampedToFlatEdge(t *testing.T) {
 func TestHintTailEdge(t *testing.T) {
 	target := image.Pt(200, 150)
 
-	badge, arrow, hasArrow := hintBadgePlacement(target, 40, 20, 4, "bottom")
+	badge, arrow, hasArrow := hintBadgePlacement(target, 40, 20, 4, config.HintPlacementBottom)
 	if edge := hintTailEdge(badge, arrow, hasArrow); edge != hintTailTop {
 		t.Errorf(
 			"bottom placement (arrow points up) should merge the tail into the top edge, got %d",
@@ -152,7 +172,7 @@ func TestHintTailEdge(t *testing.T) {
 		)
 	}
 
-	badge, arrow, hasArrow = hintBadgePlacement(target, 40, 20, 4, "top")
+	badge, arrow, hasArrow = hintBadgePlacement(target, 40, 20, 4, config.HintPlacementTop)
 	if edge := hintTailEdge(badge, arrow, hasArrow); edge != hintTailBottom {
 		t.Errorf(
 			"top placement (arrow points down) should merge the tail into the bottom edge, got %d",
@@ -160,7 +180,7 @@ func TestHintTailEdge(t *testing.T) {
 		)
 	}
 
-	badge, arrow, hasArrow = hintBadgePlacement(target, 40, 20, 4, "center")
+	badge, arrow, hasArrow = hintBadgePlacement(target, 40, 20, 4, config.HintPlacementCenter)
 	if edge := hintTailEdge(badge, arrow, hasArrow); edge != hintTailNone {
 		t.Errorf("center placement should have no tail, got %d", edge)
 	}
@@ -168,19 +188,23 @@ func TestHintTailEdge(t *testing.T) {
 
 func TestHintBadgeRadius_ReservesTailFlatEdge(t *testing.T) {
 	// Center placement is never capped — the tail doesn't exist there.
-	if got := hintBadgeRadius(100, 40, "center"); got != 100 {
+	if got := hintBadgeRadius(100, 40, config.HintPlacementCenter); got != 100 {
 		t.Errorf("center radius should be unchanged, got %d", got)
 	}
 
 	// A radius large enough to consume the whole flat edge is capped so the
 	// connector tail still has somewhere to attach.
 	// halfW = 20, so max = 20 - hintArrowMinHalfBase.
-	if got, want := hintBadgeRadius(1000, 40, "bottom"), 20-hintArrowMinHalfBase; got != want {
+	if got, want := hintBadgeRadius(
+		1000,
+		40,
+		config.HintPlacementBottom,
+	), 20-hintArrowMinHalfBase; got != want {
 		t.Errorf("oversized radius = %d, want capped to %d", got, want)
 	}
 
 	// A normal radius that already leaves room is left untouched.
-	if got := hintBadgeRadius(6, 40, "top"); got != 6 {
+	if got := hintBadgeRadius(6, 40, config.HintPlacementTop); got != 6 {
 		t.Errorf("normal radius should be unchanged, got %d", got)
 	}
 }
@@ -193,8 +217,14 @@ func TestHintBadgePlacement_FullPillKeepsTail(t *testing.T) {
 	target := image.Pt(200, 150)
 	badgeWidth, badgeHeight := 40, 24
 
-	radius := hintBadgeRadius(1000, badgeWidth, "bottom")
-	badge, arrow, hasArrow := hintBadgePlacement(target, badgeWidth, badgeHeight, radius, "bottom")
+	radius := hintBadgeRadius(1000, badgeWidth, config.HintPlacementBottom)
+	badge, arrow, hasArrow := hintBadgePlacement(
+		target,
+		badgeWidth,
+		badgeHeight,
+		radius,
+		config.HintPlacementBottom,
+	)
 
 	if !hasArrow {
 		t.Fatal("full-pill bottom placement should still draw a tail")

--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -48,10 +48,6 @@ const (
 	// hintPlacementGap is the pixel gap between a hint badge and its target
 	// point for top/bottom placement, mirroring the macOS overlay.
 	hintPlacementGap = 1
-	// Hint badge placement values (hints.ui.placement); "center" needs no
-	// constant as it is the implicit default branch.
-	placementTop    = "top"
-	placementBottom = "bottom"
 	// hintAutoRadiusMax caps the auto (border_radius = -1) hint badge corner
 	// radius so labels get a subtle rounded corner rather than a full pill,
 	// matching the macOS overlay's MIN(height/2, 6).
@@ -1181,7 +1177,7 @@ type hintArrowTriangle struct {
 // consumes the flat edge and the renderer drops the tail entirely. Center
 // placement (no tail) and radii that already leave room are returned unchanged.
 func hintBadgeRadius(radius, badgeWidth int, placement string) int {
-	if placement != placementTop && placement != placementBottom {
+	if placement != config.HintPlacementTop && placement != config.HintPlacementBottom {
 		return radius
 	}
 
@@ -1218,6 +1214,10 @@ func hintTailEdge(badge image.Rectangle, arrow hintArrowTriangle, hasArrow bool)
 // radius is the badge's already-resolved corner radius; it keeps the arrow base
 // on the badge's flat edge rather than over a rounded corner. hasArrow is false
 // for center or unrecognized placements, which draw no arrow.
+//
+// The placement strings are config's declaration of the vocabulary
+// (config.HintPlacements), not a spelling of its own: a value the validator
+// accepts is a value this switch recognizes.
 func hintBadgePlacement(
 	target image.Point,
 	badgeWidth, badgeHeight, radius int,
@@ -1229,11 +1229,11 @@ func hintBadgePlacement(
 	centerY := target.Y
 
 	switch placement {
-	case placementTop:
+	case config.HintPlacementTop:
 		// Badge sits above the target, offset by the gap plus arrow height so
 		// the arrow has room to point down at the target.
 		centerY = target.Y - hintPlacementGap - hintArrowHeight - halfH
-	case placementBottom:
+	case config.HintPlacementBottom:
 		// Badge sits below the target; arrow points up at the target.
 		centerY = target.Y + hintPlacementGap + hintArrowHeight + halfH
 	default:
@@ -1260,14 +1260,14 @@ func hintBadgePlacement(
 	var arrow hintArrowTriangle
 
 	switch placement {
-	case placementBottom:
+	case config.HintPlacementBottom:
 		baseY := badge.Min.Y
 		arrow = hintArrowTriangle{
 			baseLeft:  image.Pt(centerX-halfBase, baseY),
 			tip:       image.Pt(centerX, baseY-hintArrowHeight),
 			baseRight: image.Pt(centerX+halfBase, baseY),
 		}
-	case placementTop:
+	case config.HintPlacementTop:
 		baseY := badge.Max.Y
 		arrow = hintArrowTriangle{
 			baseLeft:  image.Pt(centerX-halfBase, baseY),

--- a/internal/adapter/overlay/render/hints/overlay_darwin.go
+++ b/internal/adapter/overlay/render/hints/overlay_darwin.go
@@ -48,13 +48,22 @@ func boolToInt(v bool) int {
 	return 0
 }
 
+// hintPlacementValue translates a configured placement into the constant the
+// Objective-C overlay switches on. The strings are config's declaration of the
+// vocabulary; the constants come from the header that
+// internal/architecture/hint_placement_vocabulary_test.go pins the Objective-C
+// enum to.
+//
+// An unset or unrecognized placement draws at the default: validation refuses
+// anything else long before a draw, so that branch belongs to the zero value
+// rather than being a second opinion about what is valid.
 func hintPlacementValue(placement string) int {
 	switch placement {
-	case "top":
+	case config.HintPlacementTop:
 		return int(C.HINT_PLACEMENT_TOP)
-	case "center":
+	case config.HintPlacementCenter:
 		return int(C.HINT_PLACEMENT_CENTER)
-	case "bottom", "":
+	case config.HintPlacementBottom:
 		return int(C.HINT_PLACEMENT_BOTTOM)
 	default:
 		return int(C.HINT_PLACEMENT_BOTTOM)

--- a/internal/adapter/overlay/render/hints/overlay_darwin_test.go
+++ b/internal/adapter/overlay/render/hints/overlay_darwin_test.go
@@ -1,0 +1,54 @@
+//go:build darwin
+
+package hints
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// TestHintPlacementValue_EveryPlacementMapsToItsOwnConstant is the macOS half
+// of the placement pin. The architecture test keeps the C header and the
+// Objective-C enum agreeing about the numbers; this keeps the translation
+// honest, because an unrecognized placement falls through to the default here
+// rather than failing. A placement added to config.HintPlacements() and not to
+// this switch would validate, reach the overlay and draw at the bottom.
+func TestHintPlacementValue_EveryPlacementMapsToItsOwnConstant(t *testing.T) {
+	t.Parallel()
+
+	byValue := make(map[int]string)
+
+	for _, placement := range config.HintPlacements() {
+		value := hintPlacementValue(placement)
+
+		clashing, taken := byValue[value]
+		if taken {
+			t.Errorf(
+				"placements %q and %q both draw as C constant %d; "+
+					"hintPlacementValue is missing a case",
+				clashing, placement, value,
+			)
+		}
+
+		byValue[value] = placement
+	}
+}
+
+// TestHintPlacementValue_UnsetDrawsTheDefault pins the empty string to the
+// same constant the declared default resolves to, so a configuration that
+// reaches the overlay before validation settles it still draws where the
+// documented default says.
+func TestHintPlacementValue_UnsetDrawsTheDefault(t *testing.T) {
+	t.Parallel()
+
+	unset := hintPlacementValue("")
+
+	fallback := hintPlacementValue(config.HintPlacementDefault)
+	if unset != fallback {
+		t.Errorf(
+			"hintPlacementValue(\"\") = %d, want %d (the value of %q)",
+			unset, fallback, config.HintPlacementDefault,
+		)
+	}
+}

--- a/internal/adapter/platform/darwin/overlay.h
+++ b/internal/adapter/platform/darwin/overlay.h
@@ -16,7 +16,11 @@
 /// Overlay window handle
 typedef void *OverlayWindow;
 
-/// Hint placement constants (must match HintPlacement enum in overlay_darwin.m)
+/// Hint placement constants. Go reads these through cgo and passes one with
+/// every hint draw; the HintPlacement enum in overlay_darwin.m is what the
+/// drawing code compares against, so the two must agree. That is pinned by
+/// internal/architecture/hint_placement_vocabulary_test.go, which also checks
+/// both against the one Go declaration of the vocabulary (config.HintPlacements).
 #define HINT_PLACEMENT_TOP 1
 #define HINT_PLACEMENT_CENTER 2
 #define HINT_PLACEMENT_BOTTOM 3

--- a/internal/adapter/platform/darwin/overlay_darwin.m
+++ b/internal/adapter/platform/darwin/overlay_darwin.m
@@ -117,6 +117,9 @@ static const CGFloat kHintArrowWidthMultiplier = 3.5;
 /// Vertical gap between the arrow tip and the target element.
 static const CGFloat kHintArrowGap = 1.0;
 
+/// Where a hint badge sits relative to its element. These values must equal the
+/// HINT_PLACEMENT_* macros in overlay.h, which is what Go passes in; the pin is
+/// internal/architecture/hint_placement_vocabulary_test.go.
 typedef NS_ENUM(NSInteger, HintPlacement) {
 	HintPlacementTop = 1,
 	HintPlacementCenter = 2,

--- a/internal/architecture/hint_placement_vocabulary_test.go
+++ b/internal/architecture/hint_placement_vocabulary_test.go
@@ -1,0 +1,233 @@
+package architecture_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// The three native spellings of one hint placement. The C header is what Go
+// reads through cgo, so the compiler keeps the macro *names* honest; nothing
+// keeps the Objective-C enum the drawing code switches on, and nothing keeps
+// the macro each Go placement is translated to.
+const (
+	hintPlacementHeader      = "internal/adapter/platform/darwin/overlay.h"
+	hintPlacementSource      = "internal/adapter/platform/darwin/overlay_darwin.m"
+	hintPlacementTranslator  = "internal/adapter/overlay/render/hints/overlay_darwin.go"
+	hintPlacementEnum        = "HintPlacement"
+	hintPlacementMacroPrefix = "HINT_PLACEMENT_"
+
+	// hintPlacementFunc is the function in hintPlacementTranslator that turns a
+	// configured placement into the constant handed to the overlay.
+	hintPlacementFunc = "hintPlacementValue"
+
+	// hintPlacementDeclaration names the Go side in failure messages, so a
+	// reader is sent to the declaration rather than to this test.
+	hintPlacementDeclaration = "config.HintPlacements()"
+)
+
+// TestHintPlacementVocabularyIsPinnedAcrossTheLanguageBoundary keeps a
+// placement that validates a placement that draws.
+//
+// `hints.ui.placement` is declared once in Go (config.HintPlacements), and the
+// default, the validator, the macOS renderer and the Linux overlay all read
+// that declaration. The values then cross into Objective-C, where the header
+// macros Go reads and the enum overlay_darwin.m switches on were held together
+// by a comment saying they must match. This is ADR 0007's deliberate exception
+// to the one-implementation rule: Go cannot be the implementation of an
+// Objective-C enum, so the copies get a pin instead of a deletion
+// (docs/adr/0007-a-shared-derivation-has-one-implementation.md).
+//
+// It fails on three shapes: a Go placement with no native constant, a header
+// macro and an enum member that disagree on a number, and a native constant
+// nothing in Go names. The last one is what catches a placement deleted from
+// Go and left behind in the native code.
+func TestHintPlacementVocabularyIsPinnedAcrossTheLanguageBoundary(t *testing.T) {
+	t.Parallel()
+
+	macros := cHeaderIntConstants(t, hintPlacementHeader)
+	members := objcEnumIntConstants(t, hintPlacementSource, hintPlacementEnum)
+
+	placements := config.HintPlacements()
+	if len(placements) == 0 {
+		t.Fatal("config.HintPlacements() is empty; there is no vocabulary to pin")
+	}
+
+	for _, placement := range placements {
+		macro := hintPlacementMacroPrefix + strings.ToUpper(placement)
+
+		macroValue, hasMacro := macros[macro]
+		if !hasMacro {
+			t.Errorf(
+				"%s: no `#define %s`, but config.HintPlacements() accepts %q",
+				hintPlacementHeader, macro, placement,
+			)
+
+			continue
+		}
+
+		member := hintPlacementEnum + nativeEnumMemberName(placement)
+
+		memberValue, hasMember := members[member]
+		if !hasMember {
+			t.Errorf(
+				"%s: enum %s has no member %s, but %s defines %s",
+				hintPlacementSource, hintPlacementEnum, member, hintPlacementHeader, macro,
+			)
+
+			continue
+		}
+
+		if macroValue != memberValue {
+			t.Errorf(
+				"placement %q: %s is %d in %s but %s is %d in %s; "+
+					"Go passes the header value and the drawing code compares the enum, "+
+					"so a mismatch draws the wrong placement",
+				placement,
+				macro, macroValue, hintPlacementHeader,
+				member, memberValue, hintPlacementSource,
+			)
+		}
+	}
+
+	assertNativeConstantCount(
+		t, hintPlacementHeader, hintPlacementMacroPrefix, macros,
+		len(placements), hintPlacementDeclaration,
+	)
+	assertNativeConstantCount(
+		t, hintPlacementSource, hintPlacementEnum, members,
+		len(placements), hintPlacementDeclaration,
+	)
+}
+
+// TestHintPlacementTranslationMatchesTheVocabulary closes the last link in the
+// chain: Go string, C macro, Objective-C enum. The test above pins the macro to
+// the enum, but the macOS renderer is what decides *which* macro a placement
+// becomes, and swapping two arms of that switch would leave every other check
+// green while hints drew above the elements they should sit below.
+//
+// It reads the switch rather than calling it, because the function is behind a
+// darwin build tag and cgo, and this package has to reach it from any host.
+func TestHintPlacementTranslationMatchesTheVocabulary(t *testing.T) {
+	t.Parallel()
+
+	translated := parseHintPlacementSwitch(t)
+
+	for _, placement := range config.HintPlacements() {
+		constant := hintPlacementEnum + nativeEnumMemberName(placement)
+
+		macro, translatedHere := translated[constant]
+		if !translatedHere {
+			t.Errorf(
+				"%s: %s has no `case config.%s:`, so %q draws at the default "+
+					"instead of its own placement",
+				hintPlacementTranslator, hintPlacementFunc, constant, placement,
+			)
+
+			continue
+		}
+
+		want := hintPlacementMacroPrefix + strings.ToUpper(placement)
+		if macro != want {
+			t.Errorf(
+				"%s: %s translates config.%s to C.%s, want C.%s",
+				hintPlacementTranslator, hintPlacementFunc, constant, macro, want,
+			)
+		}
+	}
+}
+
+// parseHintPlacementSwitch returns the placement constant each case of
+// hintPlacementValue returns a macro for, keyed by the config constant's name
+// ("HintPlacementTop") and valued by the macro's ("HINT_PLACEMENT_TOP"). The
+// default case has no config constant to key on and is skipped: it is the
+// unset value's branch, which the darwin-only test in the renderer's own
+// package pins.
+func parseHintPlacementSwitch(t *testing.T) map[string]string {
+	t.Helper()
+
+	fileSet := token.NewFileSet()
+
+	parsed, err := parser.ParseFile(
+		fileSet,
+		filepath.Join(findRepoRoot(t), filepath.FromSlash(hintPlacementTranslator)),
+		nil,
+		parser.SkipObjectResolution,
+	)
+	if err != nil {
+		t.Fatalf("%s: cannot parse (renamed?): %v", hintPlacementTranslator, err)
+	}
+
+	translated := make(map[string]string)
+	found := false
+
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		funcDecl, isFunc := node.(*ast.FuncDecl)
+		if !isFunc || funcDecl.Name.Name != hintPlacementFunc {
+			return true
+		}
+
+		found = true
+
+		ast.Inspect(funcDecl, func(inner ast.Node) bool {
+			clause, isClause := inner.(*ast.CaseClause)
+			if !isClause {
+				return true
+			}
+
+			collectHintPlacementCase(clause, translated)
+
+			return true
+		})
+
+		return false
+	})
+
+	if !found {
+		t.Fatalf(
+			"%s: no func %s (renamed?); the placement translation is unpinned",
+			hintPlacementTranslator, hintPlacementFunc,
+		)
+	}
+
+	return translated
+}
+
+// collectHintPlacementCase records one `case config.HintPlacementX: return
+// int(C.HINT_PLACEMENT_Y)` clause.
+func collectHintPlacementCase(clause *ast.CaseClause, into map[string]string) {
+	macro := ""
+
+	ast.Inspect(clause, func(node ast.Node) bool {
+		selector, isSelector := node.(*ast.SelectorExpr)
+		if !isSelector {
+			return true
+		}
+
+		if ident, isIdent := selector.X.(*ast.Ident); isIdent && ident.Name == "C" {
+			macro = selector.Sel.Name
+		}
+
+		return true
+	})
+
+	if macro == "" {
+		return
+	}
+
+	for _, expr := range clause.List {
+		selector, isSelector := expr.(*ast.SelectorExpr)
+		if !isSelector {
+			continue
+		}
+
+		if ident, isIdent := selector.X.(*ast.Ident); isIdent && ident.Name == "config" {
+			into[selector.Sel.Name] = macro
+		}
+	}
+}

--- a/internal/architecture/native_constants_test.go
+++ b/internal/architecture/native_constants_test.go
@@ -1,0 +1,175 @@
+package architecture_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// cDefinePattern matches an integer `#define NAME 1` in a C header, ignoring
+// macros defined as anything but a plain decimal literal.
+var cDefinePattern = regexp.MustCompile(
+	`(?m)^#define[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]+(-?[0-9]+)[ \t]*$`,
+)
+
+// objcEnumPattern matches the opening line of a `typedef NS_ENUM(type, Name) {`
+// declaration; the enum's name is substituted in when the pattern is built.
+const objcEnumPattern = `NS_ENUM\([^,]+,[ \t]*%s\)[ \t]*\{`
+
+// objcEnumMemberPattern matches one `Member = 1,` line inside an enum body.
+var objcEnumMemberPattern = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)[ \t]*=[ \t]*(-?[0-9]+)`)
+
+// cHeaderIntConstants returns every `#define NAME <int>` in the C header at
+// repoRelPath, keyed by macro name. Macros defined as anything else are
+// skipped, so a header of mixed macros yields only the numeric ones.
+func cHeaderIntConstants(t *testing.T, repoRelPath string) map[string]int64 {
+	t.Helper()
+
+	source := readNativeSource(t, repoRelPath)
+	constants := make(map[string]int64)
+
+	for _, match := range cDefinePattern.FindAllStringSubmatch(source, -1) {
+		constants[match[1]] = parseNativeInt(t, repoRelPath, match[1], match[2])
+	}
+
+	return constants
+}
+
+// objcEnumIntConstants returns the members of the `typedef NS_ENUM(_, enumName)`
+// declared in the Objective-C source at repoRelPath, keyed by member name. It
+// fails the test when the enum is not there at all, because a renamed enum is
+// the same drift this pin exists to catch.
+func objcEnumIntConstants(t *testing.T, repoRelPath, enumName string) map[string]int64 {
+	t.Helper()
+
+	source := readNativeSource(t, repoRelPath)
+
+	declaration := regexp.MustCompile(
+		fmt.Sprintf(objcEnumPattern, regexp.QuoteMeta(enumName)),
+	)
+
+	opening := declaration.FindStringIndex(source)
+	if opening == nil {
+		t.Fatalf(
+			"%s: no `NS_ENUM(..., %s) {` declaration (renamed or removed?)",
+			repoRelPath,
+			enumName,
+		)
+	}
+
+	body := source[opening[1]:]
+
+	end := strings.Index(body, "}")
+	if end < 0 {
+		t.Fatalf("%s: enum %s is never closed by `}`", repoRelPath, enumName)
+	}
+
+	members := make(map[string]int64)
+
+	for _, match := range objcEnumMemberPattern.FindAllStringSubmatch(body[:end], -1) {
+		members[match[1]] = parseNativeInt(t, repoRelPath, match[1], match[2])
+	}
+
+	return members
+}
+
+// readNativeSource reads a repo-relative native source file, failing with a
+// message that names the likely cause: these pins address files by path, so a
+// rename shows up here rather than as a silent pass over nothing.
+//
+// It is the entry point every language-boundary pin in this package shares.
+// ADR 0007 (docs/adr/0007-a-shared-derivation-has-one-implementation.md) lets
+// a native copy of a Go declaration exist — Go cannot be the one
+// implementation for a .m file — and asks for a test holding the copies
+// together instead of a deletion. Writing a second such pin means reading the
+// native source through here and then matching whatever shape the copy takes:
+// cHeaderIntConstants and objcEnumIntConstants below cover the two shapes that
+// exist today, a numeric macro and an NS_ENUM member, and a copy that is a
+// rule rather than a constant brings its own pattern rather than a second
+// reader. The label-autohide copy that ADR 0007 still owes a pin (#1298) is
+// that third shape.
+func readNativeSource(t *testing.T, repoRelPath string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(filepath.Join(findRepoRoot(t), filepath.FromSlash(repoRelPath)))
+	if err != nil {
+		t.Fatalf("%s: cannot read native source (renamed?): %v", repoRelPath, err)
+	}
+
+	return string(content)
+}
+
+// assertNativeConstantCount fails when a native source declares more (or
+// fewer) constants sharing a prefix than the Go declaration has values. It is
+// the half of a pin that catches a value deleted from Go and left behind in
+// the native code, which comparing each Go value against the native side
+// cannot see. goDeclaration names the Go side in the failure message.
+//
+// A native source that gains an unrelated constant under the same prefix — a
+// _COUNT or _DEFAULT sentinel, say — fails here too. That is intended: a
+// sentinel sharing the vocabulary's prefix is exactly the thing a reader would
+// mistake for a member of it, and adding one should be a decision, not a
+// silent pass.
+func assertNativeConstantCount(
+	t *testing.T,
+	repoRelPath, prefix string,
+	constants map[string]int64,
+	want int,
+	goDeclaration string,
+) {
+	t.Helper()
+
+	var declared []string
+
+	for name := range constants {
+		if strings.HasPrefix(name, prefix) {
+			declared = append(declared, name)
+		}
+	}
+
+	if len(declared) != want {
+		sort.Strings(declared)
+
+		t.Errorf(
+			"%s: declares %d %s* constants (%s) but %s has %d values",
+			repoRelPath, len(declared), prefix, strings.Join(declared, ", "), goDeclaration, want,
+		)
+	}
+}
+
+// nativeEnumMemberName spells a Go vocabulary value the way Objective-C names
+// an enum member: "bottom" becomes "Bottom", "top_left" becomes "TopLeft".
+// Underscore-separated values are handled because the config vocabularies next
+// to the ones pinned here use that spelling.
+func nativeEnumMemberName(value string) string {
+	var built strings.Builder
+
+	for word := range strings.SplitSeq(value, "_") {
+		if word == "" {
+			continue
+		}
+
+		built.WriteString(strings.ToUpper(word[:1]))
+		built.WriteString(word[1:])
+	}
+
+	return built.String()
+}
+
+// parseNativeInt converts a matched native literal, naming the constant it
+// belongs to if it somehow does not fit an int64.
+func parseNativeInt(t *testing.T, repoRelPath, name, literal string) int64 {
+	t.Helper()
+
+	value, err := strconv.ParseInt(literal, 10, 64)
+	if err != nil {
+		t.Fatalf("%s: %s = %q is not an integer: %v", repoRelPath, name, literal, err)
+	}
+
+	return value
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,9 +73,6 @@ const (
 	CmdMoveMouseRight = "action move_mouse_relative --dx=10 --dy=0"
 )
 
-// Placement strings for UI configuration.
-const placementBottom = "bottom"
-
 // DisabledSentinel is a special action value that removes a default hotkey binding.
 // Use it in [hotkeys] or [<mode>.hotkeys] to disable a specific default:
 //

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -427,7 +427,7 @@ func defaultHints() HintsConfig {
 			PaddingX:         DefaultHintPaddingX,
 			PaddingY:         DefaultHintPaddingY,
 			BorderWidth:      1,
-			Placement:        "bottom",
+			Placement:        HintPlacementDefault,
 			BackgroundColor:  Color{},
 			TextColor:        Color{},
 			MatchedTextColor: Color{},

--- a/internal/config/hint_placement.go
+++ b/internal/config/hint_placement.go
@@ -1,0 +1,42 @@
+package config
+
+// The values `hints.ui.placement` accepts: where a hint badge sits relative to
+// the element it labels.
+//
+// This is the one declaration of that vocabulary. It was written out four
+// times — the default, the validator, the macOS hint renderer and the Linux
+// overlay each spelled the three strings for itself — and a spelling missed in
+// one of them is a placement that validates and then does not draw. It lives
+// here rather than in the domain because no domain code places a badge: the
+// callers are this package and the two overlay backends, and this package is
+// the lowest layer all of them already reach (ADR 0007,
+// docs/adr/0007-a-shared-derivation-has-one-implementation.md).
+//
+// The values cross into Objective-C as well, where the macOS overlay compares
+// them as an enum. Go cannot be the implementation of that copy, so
+// internal/architecture/hint_placement_vocabulary_test.go pins it to this
+// declaration instead.
+const (
+	// HintPlacementTop draws the badge above its element, with a connector
+	// arrow pointing down at it.
+	HintPlacementTop = "top"
+
+	// HintPlacementCenter draws the badge over the middle of its element, with
+	// no connector arrow.
+	HintPlacementCenter = "center"
+
+	// HintPlacementBottom draws the badge below its element, with a connector
+	// arrow pointing up at it. This is the default.
+	HintPlacementBottom = "bottom"
+)
+
+// HintPlacementDefault is the placement a configuration that does not name one
+// is settled to.
+const HintPlacementDefault = HintPlacementBottom
+
+// HintPlacements returns every accepted `hints.ui.placement` value, in the
+// order docs/CONFIGURATION.md lists them. Callers get a fresh slice, so a
+// consumer that sorts or filters cannot reach the vocabulary itself.
+func HintPlacements() []string {
+	return []string{HintPlacementTop, HintPlacementCenter, HintPlacementBottom}
+}

--- a/internal/config/hintsvalidation_internal_test.go
+++ b/internal/config/hintsvalidation_internal_test.go
@@ -33,97 +33,97 @@ func hintsCases() []hintsCase {
 			name:      "clean",
 			breakIt:   func(*Config) {},
 			message:   "",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "no clickable roles",
 			breakIt:   func(c *Config) { c.Hints.ClickableRoles = nil },
 			message:   "[INVALID_CONFIG] hints.clickable_roles cannot be empty when hints are enabled",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "bad clickable role",
 			breakIt:   func(c *Config) { c.Hints.ClickableRoles = []string{"!!"} },
 			message:   "[INVALID_CONFIG] hints.clickable_roles: unknown role \"!!\" (run `neru roles` for the accepted role names)",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "empty hint chars",
 			breakIt:   func(c *Config) { c.Hints.HintCharacters = "  " },
 			message:   "[INVALID_CONFIG] hint_characters cannot be empty",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "one hint char",
 			breakIt:   func(c *Config) { c.Hints.HintCharacters = "a" },
 			message:   "[INVALID_CONFIG] hint_characters must contain at least 2 characters",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "non-ascii hint chars",
 			breakIt:   func(c *Config) { c.Hints.HintCharacters = "a\u00e9" },
 			message:   "[INVALID_CONFIG] hint_characters can only contain ASCII characters",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "duplicate hint chars",
 			breakIt:   func(c *Config) { c.Hints.HintCharacters = "aA" },
 			message:   "[INVALID_CONFIG] hint_characters contains duplicate character 'A'",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "bad ui color",
 			breakIt:   func(c *Config) { c.Hints.UI.BackgroundColor = badColor() },
 			message:   "[INVALID_CONFIG] hints.ui.background_color (light) has invalid color format: nope",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "bad search color",
 			breakIt:   func(c *Config) { c.Hints.SearchInputUI.BackgroundColor = badColor() },
 			message:   "[INVALID_CONFIG] hints.search_input_ui.background_color (light) has invalid color format: nope",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "bad boundary color",
 			breakIt:   func(c *Config) { c.Hints.BoundaryHighlight.BorderColor = badColor() },
 			message:   "[INVALID_CONFIG] hints.boundary_highlight.border_color (light) has invalid color format: nope",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "font size zero",
 			breakIt:   func(c *Config) { c.Hints.UI.FontSize = 0 },
 			message:   "[INVALID_CONFIG] hints.ui.font_size must be between 1 and 2147483647",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "font size huge",
 			breakIt:   func(c *Config) { c.Hints.UI.FontSize = 100000 },
 			message:   "",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "negative border radius",
 			breakIt:   func(c *Config) { c.Hints.UI.BorderRadius = -5 },
 			message:   "[INVALID_CONFIG] hints.ui.border_radius must be at least -1",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "negative padding x",
 			breakIt:   func(c *Config) { c.Hints.UI.PaddingX = -5 },
 			message:   "[INVALID_CONFIG] hints.ui.padding_x must be at least -1",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "negative padding y",
 			breakIt:   func(c *Config) { c.Hints.UI.PaddingY = -5 },
 			message:   "[INVALID_CONFIG] hints.ui.padding_y must be at least -1",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "negative border width",
 			breakIt:   func(c *Config) { c.Hints.UI.BorderWidth = -1 },
 			message:   "[INVALID_CONFIG] hints.ui.border_width must be non-negative",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "bad placement",
@@ -135,67 +135,67 @@ func hintsCases() []hintsCase {
 			name:      "empty placement defaults",
 			breakIt:   func(c *Config) { c.Hints.UI.Placement = "" },
 			message:   "",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "search font size zero",
 			breakIt:   func(c *Config) { c.Hints.SearchInputUI.FontSize = 0 },
 			message:   "[INVALID_CONFIG] hints.search_input_ui.font_size must be between 1 and 2147483647",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "search negative radius",
 			breakIt:   func(c *Config) { c.Hints.SearchInputUI.BorderRadius = -5 },
 			message:   "[INVALID_CONFIG] hints.search_input_ui.border_radius must be at least -1",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "search negative padding x",
 			breakIt:   func(c *Config) { c.Hints.SearchInputUI.PaddingX = -5 },
 			message:   "[INVALID_CONFIG] hints.search_input_ui.padding_x must be at least -1",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "search negative padding y",
 			breakIt:   func(c *Config) { c.Hints.SearchInputUI.PaddingY = -5 },
 			message:   "[INVALID_CONFIG] hints.search_input_ui.padding_y must be at least -1",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "search negative border width",
 			breakIt:   func(c *Config) { c.Hints.SearchInputUI.BorderWidth = -1 },
 			message:   "[INVALID_CONFIG] hints.search_input_ui.border_width must be non-negative",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "boundary negative border width",
 			breakIt:   func(c *Config) { c.Hints.BoundaryHighlight.BorderWidth = -1 },
 			message:   "[INVALID_CONFIG] hints.boundary_highlight.border_width must be non-negative",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "boundary negative radius",
 			breakIt:   func(c *Config) { c.Hints.BoundaryHighlight.BorderRadius = -5 },
 			message:   "[INVALID_CONFIG] hints.boundary_highlight.border_radius must be at least -1",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "bad search position",
 			breakIt:   func(c *Config) { c.Hints.SearchInputUI.Position = "nowhere" },
 			message:   "[INVALID_CONFIG] hints.search_input_ui.position must be one of top_left, top_center, top_right, center, bottom_left, bottom_center, bottom_right",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "search width zero",
 			breakIt:   func(c *Config) { c.Hints.SearchInputUI.Width = 0 },
 			message:   "[INVALID_CONFIG] hints.search_input_ui.width must be at least 1",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "negative max depth",
 			breakIt:   func(c *Config) { c.Hints.MaxDepth = -1 },
 			message:   "[INVALID_CONFIG] hints.max_depth must be at least 0",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name: "mc actions without detect",
@@ -204,7 +204,7 @@ func hintsCases() []hintsCase {
 				c.Hints.OnMissionControlActivated = []string{"hints"}
 			},
 			message:   "[INVALID_CONFIG] hints.on_mission_control_activated/deactivated requires hints.detect_mission_control = true",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name: "detect without dock",
@@ -213,7 +213,7 @@ func hintsCases() []hintsCase {
 				c.Hints.IncludeDockHints = false
 			},
 			message:   "[INVALID_CONFIG] hints.detect_mission_control requires hints.include_dock_hints = true (dock windows are the only element source available during Mission Control)",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name: "empty mc activated step",
@@ -223,7 +223,7 @@ func hintsCases() []hintsCase {
 				c.Hints.OnMissionControlActivated = []string{"  "}
 			},
 			message:   "[INVALID_CONFIG] hints.on_mission_control_activated[0] cannot be empty",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name: "bad mc activated step",
@@ -233,7 +233,7 @@ func hintsCases() []hintsCase {
 				c.Hints.OnMissionControlActivated = []string{"not_a_command"}
 			},
 			message:   "[INVALID_CONFIG] hints.on_mission_control_activated[0]: [INVALID_CONFIG] unknown command: not_a_command",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name: "empty mc deactivated step",
@@ -243,19 +243,19 @@ func hintsCases() []hintsCase {
 				c.Hints.OnMissionControlDeactivated = []string{"  "}
 			},
 			message:   "[INVALID_CONFIG] hints.on_mission_control_deactivated[0] cannot be empty",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "bad strategy",
 			breakIt:   func(c *Config) { c.Hints.Strategy = "telepathy" },
 			message:   "[INVALID_CONFIG] hints.strategy must be \"axtree\" or \"vision\"",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name:      "bad label direction",
 			breakIt:   func(c *Config) { c.Hints.LabelDirection = placementSideways },
 			message:   "[INVALID_CONFIG] hints.label_direction must be \"reverse\" or \"normal\"",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name: "vision detects nothing",
@@ -265,7 +265,7 @@ func hintsCases() []hintsCase {
 				c.Hints.Vision.DetectRectangles = false
 			},
 			message:   "[INVALID_CONFIG] hints.vision must enable detect_text or detect_rectangles",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name: "bad boundary width AND bad search position",
@@ -274,7 +274,7 @@ func hintsCases() []hintsCase {
 				c.Hints.SearchInputUI.Position = "nowhere"
 			},
 			message:   "[INVALID_CONFIG] hints.boundary_highlight.border_width must be non-negative",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name: "bad search border width AND bad boundary width",
@@ -283,7 +283,7 @@ func hintsCases() []hintsCase {
 				c.Hints.BoundaryHighlight.BorderWidth = -1
 			},
 			message:   "[INVALID_CONFIG] hints.search_input_ui.border_width must be non-negative",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name: "bad chars AND bad color",
@@ -292,7 +292,7 @@ func hintsCases() []hintsCase {
 				c.Hints.UI.BackgroundColor = badColor()
 			},
 			message:   "[INVALID_CONFIG] hint_characters must contain at least 2 characters",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 		{
 			name: "bad strategy AND bad label direction",
@@ -301,7 +301,7 @@ func hintsCases() []hintsCase {
 				c.Hints.LabelDirection = placementSideways
 			},
 			message:   "[INVALID_CONFIG] hints.strategy must be \"axtree\" or \"vision\"",
-			placement: placementBottom,
+			placement: HintPlacementBottom,
 		},
 	}
 }

--- a/internal/config/validators_hints.go
+++ b/internal/config/validators_hints.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"slices"
 	"strings"
 	"unicode"
 
@@ -182,18 +183,30 @@ func (c *Config) validateHintLabelUI() error {
 		return derrors.New(derrors.CodeInvalidConfig, "hints.ui.border_width must be non-negative")
 	}
 
-	switch c.Hints.UI.Placement {
-	case "top", "center", placementBottom:
-	case "":
-		c.Hints.UI.Placement = placementBottom
-	default:
-		return derrors.New(
-			derrors.CodeInvalidConfig,
-			"hints.ui.placement must be one of top, center, "+placementBottom,
-		)
+	return c.settleHintPlacement()
+}
+
+// settleHintPlacement defaults an unset hints.ui.placement and refuses any
+// value the vocabulary does not name. Both the accepted set and the error
+// message read HintPlacements(), so a placement added there is accepted here
+// without this function being touched.
+func (c *Config) settleHintPlacement() error {
+	if c.Hints.UI.Placement == "" {
+		c.Hints.UI.Placement = HintPlacementDefault
+
+		return nil
 	}
 
-	return nil
+	placements := HintPlacements()
+	if slices.Contains(placements, c.Hints.UI.Placement) {
+		return nil
+	}
+
+	return derrors.Newf(
+		derrors.CodeInvalidConfig,
+		"hints.ui.placement must be one of %s",
+		strings.Join(placements, ", "),
+	)
 }
 
 // validateHintSearchInputGeometry checks the size and shape of the search input.


### PR DESCRIPTION
## Description

This PR reworks how the three hint placements are declared, without changing where any of them draws. `top`, `center` and `bottom` were spelled out four separate times in Go — once for the default, once for the validator that accepts them, once for the macOS hint renderer and once for the Linux overlay. Nothing held those four together, so adding or renaming a placement meant finding all four, and a spelling missed in one of them produced a value that passed validation and then quietly drew somewhere else. They are now declared once, and all four read that declaration.

The same values cross into Objective-C, where the constants Go passes in and the enum the macOS overlay compares against were kept in step by a comment saying they must match. That copy has to exist — Go cannot be the implementation of an Objective-C enum — so it gets a guardrail instead: tests that fail if the enum, the constants and the Go declaration ever disagree, or if a placement is translated to the wrong one on its way to the overlay. They run on any host, and were verified to have teeth by breaking each link in turn and watching them fail.

Deliberate limitation: Windows still ignores `hints.ui.placement` entirely. That is a gap in the overlay port rather than a vocabulary problem, and it is out of scope here.

## Related Issues

Closes #1289

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [x] `refactor` — Code restructuring (no behavior change)

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability changed; this moves existing constants.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — `docs/CONFIGURATION.md` needed no change (no option, value or default changed); ADR 0007 did, since it recorded that this pin did not exist yet.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config and command surface

Nothing changes for a user. `hints.ui.placement` still accepts exactly `top`, `center` and `bottom`, still defaults to `bottom`, and the message an invalid value produces is unchanged word for word:

```toml
[hints.ui]
placement = "bottom"   # top, center, bottom
```

Existing config files keep working.

## Additional Context

`just lint-cross` was run as well as `just ci`, because `just lint` does not see files behind the `linux` and `windows` build tags and this touches the Linux overlay.

The vocabulary is declared in the config package rather than the domain: no domain code places a badge, and the callers are config itself plus the two overlay backends, which makes config the lowest layer all of them already reach. That is the placement rule from ADR 0007, which also records why the Objective-C copy is pinned rather than deleted.

The guardrail's native-source reader is written as the shared entry point for a second pin of this kind rather than something to reinvent — #1298 owes the same treatment to the Objective-C label-autohide copy, and the doc comment says so, including that its copy is a rule rather than a constant and so brings its own matching. That test is not implemented here.

One gap is deliberately left open and worth knowing about: on Linux, a placement the overlay does not recognise falls through to drawing centred with no arrow, so a fourth value added to the vocabulary would be accepted, get its native constants — and silently draw centred on Linux with nothing failing. Closing that means making `center` an explicit branch there rather than the fall-through it is today, which is a change to the Linux drawing path and did not belong in a no-behaviour-change diff.
