### PR TITLE
docs(config): say that font_family accepts generic font aliases

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -4,6 +4,11 @@
 # Full config reference: https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md
 # Full CLI reference: https://github.com/y3owk1n/neru/blob/main/docs/CLI.md
 
+# Most font_family options below take a generic alias as well as an installed
+# family name; the config reference above marks which, and the accepted aliases
+# are listed here:
+# https://github.com/y3owk1n/neru/blob/main/docs/CROSS_PLATFORM.md#capability-matrix
+
 # General settings
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#general
 [general]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -853,7 +853,7 @@ hints.clickable_roles: unknown role "AXButton": use "button"
 | Option               | Type   | Default    | Description                                |
 | -------------------- | ------ | ---------- | ------------------------------------------ |
 | `font_size`          | int    | `10`       | Font size in points                        |
-| `font_family`        | string | `""`       | Font family (empty = system default)       |
+| `font_family`        | string | `""`       | Font family (empty = system default); [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
 | `border_radius`      | int    | `-1`       | Corner radius (-1 = auto)                  |
 | `padding_x`          | int    | `-1`       | Horizontal padding (-1 = auto)             |
 | `padding_y`          | int    | `-1`       | Vertical padding (-1 = auto)               |
@@ -1058,7 +1058,7 @@ one subgrid cell unlabelled, which is visible on screen in a way a warning is no
 | Option                     | Type   | Default | Description                          |
 | -------------------------- | ------ | ------- | ------------------------------------ |
 | `font_size`                | int    | `10`    | Font size in points                  |
-| `font_family`              | string | `""`    | Font family (empty = system default) |
+| `font_family`              | string | `""`    | Font family (empty = system default); [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
 | `border_width`             | int    | `1`     | Border width in pixels               |
 | `background_color`         | color  | derived | Cell background                      |
 | `text_color`               | color  | derived | Label text                           |
@@ -1135,7 +1135,7 @@ layers = [
 | Option                                | Type   | Default | Description                                                                  |
 | ------------------------------------- | ------ | ------- | ---------------------------------------------------------------------------- |
 | `font_size`                           | int    | `10`    | Font size                                                                    |
-| `font_family`                         | string | `""`    | Font family (empty = system default)                                         |
+| `font_family`                         | string | `""`    | Font family (empty = system default); [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
 | `line_width`                          | int    | `1`     | Grid line width                                                              |
 | `line_color`                          | color  | derived | Grid line color                                                              |
 | `highlight_color`                     | color  | derived | Selected cell highlight                                                      |
@@ -1407,7 +1407,7 @@ text = "Monitor Select"
 | Option               | Type   | Default | Description                             |
 | -------------------- | ------ | ------- | --------------------------------------- |
 | `font_size`          | int    | `10`    | Font size                               |
-| `font_family`        | string | `""`    | Font family (empty = system default)    |
+| `font_family`        | string | `""`    | Font family (empty = system default); [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
 | `background_color`   | color  | derived | Background with alpha                   |
 | `text_color`         | color  | derived | Text color                              |
 | `border_color`       | color  | derived | Border color                            |
@@ -1445,7 +1445,7 @@ Tap modifiers inside a mode to make them sticky for subsequent actions.
 | Option               | Type   | Default | Description                            |
 | -------------------- | ------ | ------- | -------------------------------------- |
 | `font_size`          | int    | `10`    | Font size                              |
-| `font_family`        | string | `""`    | Font family (empty = system default)   |
+| `font_family`        | string | `""`    | Font family (empty = system default); [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
 | `background_color`   | color  | derived | Background with alpha                  |
 | `text_color`         | color  | derived | Text color                             |
 | `border_color`       | color  | derived | Border color                           |


### PR DESCRIPTION
## Description

This PR fixes a discoverability gap in the config reference: every `font_family` row said only that an empty value means the system font, so nobody reading `docs/CONFIGURATION.md` could tell that generic aliases such as a sans, serif or monospace name are accepted and resolve to a sensible family on macOS, Linux and Windows.

The `font_family` rows for hints, grid, recursive grid, the mode indicator and sticky modifiers now say generic aliases are accepted and link to the section of `docs/CROSS_PLATFORM.md` that owns the vocabulary. The accepted spellings and their per-platform resolutions are deliberately not repeated here: that page is their single home, and a copy would start drifting immediately. The shipped example config gains one pointer in its header rather than a comment repeated nine times.

Three rows are deliberately left as they were — `font_family` and `subtitle_font_family` under `[monitor_select.ui]`, and `font_family` under `[virtual_pointer.ui]`. Those three font paths never reach the shared alias resolver, so on macOS a generic alias there is treated as a literal family name and silently falls back to the system font. Documenting them alongside the rest would have advertised behaviour that does not happen; that gap is a code fix, not a docs fix, and is worth its own issue.

## Related Issues

Closes #1291

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`) — N/A, no Go or Objective-C files changed
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, documentation only; no behaviour changed
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config Surface

No option is added, renamed or removed, and no default or accepted value changes — the aliases documented here have been accepted since #1290. The rows now reading differently are `font_family` under `[hints.ui]`, `[grid.ui]`, `[recursive_grid.ui]`, `[mode_indicator.ui]` and `[sticky_modifiers.ui]`. Every existing config keeps working unchanged.

## Additional Context

`[hints.search_input_ui]` has no `font_family` row of its own — it already documents its visual options by pointing at the hints UI table, so it inherits the note.

The generated man pages were checked and need no change: `./cmd/genman` renders the CLI commands and flags, and documents no config options, so the gap does not exist there.

On the three excluded rows: the monitor-select and virtual-pointer styles pass the configured family straight to the platform layer. On macOS that means an unresolvable name falls back to the system font, so an alias does nothing; on Linux the drawing layer happens to understand the canonical generic names but not the separator variants; monitor select is unsupported on Windows. Wiring those two paths through the same resolver as everything else would make all nine rows true, and is left for a follow-up so this stays a documentation change.
