### PR TITLE
fix(darwin): build on Apple clang 15

### DIFF
--- a/internal/adapter/platform/darwin/keymap_darwin.m
+++ b/internal/adapter/platform/darwin/keymap_darwin.m
@@ -45,9 +45,15 @@ static NSDictionary<NSNumber *, NSString *> *gKeyCodeToCharShiftedCaps = nil;
 static dispatch_block_t gLayoutChangeDebounceBlock = nil;
 
 /// optional callback invoked after layout maps are rebuilt
-static _Atomic(KeymapLayoutChangeCallback) gLayoutChangeCallback = NULL;
+///
+/// The null pointer is spelled as an explicit cast rather than NULL: Apple
+/// clang 15 — the newest toolchain available on macOS 14.4 and earlier —
+/// rejects NULL, 0 and nil alike as compile-time constant initializers for an
+/// _Atomic function pointer. A cast to the pointer type is accepted by every
+/// clang, so this builds on old and new toolchains both.
+static _Atomic(KeymapLayoutChangeCallback) gLayoutChangeCallback = (KeymapLayoutChangeCallback)0;
 /// second callback slot for Go-level layout change notifications
-static _Atomic(KeymapLayoutChangeCallback) gLayoutChangeCallback2 = NULL;
+static _Atomic(KeymapLayoutChangeCallback) gLayoutChangeCallback2 = (KeymapLayoutChangeCallback)0;
 
 #pragma mark - UCKeyTranslate Helper
 

--- a/internal/adapter/platform/darwin/keymap_darwin.m
+++ b/internal/adapter/platform/darwin/keymap_darwin.m
@@ -45,7 +45,19 @@ static NSDictionary<NSNumber *, NSString *> *gKeyCodeToCharShiftedCaps = nil;
 static dispatch_block_t gLayoutChangeDebounceBlock = nil;
 
 /// optional callback invoked after layout maps are rebuilt
+/// empty layout-change callback slot
 ///
+/// Spelled as a cast rather than NULL: Apple clang 15 — the newest toolchain
+/// available on macOS 14.4 and earlier — rejects NULL, 0 and nil alike as
+/// compile-time constant initializers for an _Atomic function pointer. A cast
+/// to the pointer type is accepted by every clang, so this builds on old and
+/// new toolchains both.
+#define KEYMAP_NO_LAYOUT_CALLBACK ((KeymapLayoutChangeCallback)0)
+
+/// optional callback invoked after layout maps are rebuilt
+static _Atomic(KeymapLayoutChangeCallback) gLayoutChangeCallback = KEYMAP_NO_LAYOUT_CALLBACK;
+/// second callback slot for Go-level layout change notifications
+static _Atomic(KeymapLayoutChangeCallback) gLayoutChangeCallback2 = KEYMAP_NO_LAYOUT_CALLBACK;
 /// The null pointer is spelled as an explicit cast rather than NULL: Apple
 /// clang 15 — the newest toolchain available on macOS 14.4 and earlier —
 /// rejects NULL, 0 and nil alike as compile-time constant initializers for an

--- a/internal/adapter/platform/darwin/keymap_darwin.m
+++ b/internal/adapter/platform/darwin/keymap_darwin.m
@@ -58,14 +58,6 @@ static dispatch_block_t gLayoutChangeDebounceBlock = nil;
 static _Atomic(KeymapLayoutChangeCallback) gLayoutChangeCallback = KEYMAP_NO_LAYOUT_CALLBACK;
 /// second callback slot for Go-level layout change notifications
 static _Atomic(KeymapLayoutChangeCallback) gLayoutChangeCallback2 = KEYMAP_NO_LAYOUT_CALLBACK;
-/// The null pointer is spelled as an explicit cast rather than NULL: Apple
-/// clang 15 — the newest toolchain available on macOS 14.4 and earlier —
-/// rejects NULL, 0 and nil alike as compile-time constant initializers for an
-/// _Atomic function pointer. A cast to the pointer type is accepted by every
-/// clang, so this builds on old and new toolchains both.
-static _Atomic(KeymapLayoutChangeCallback) gLayoutChangeCallback = (KeymapLayoutChangeCallback)0;
-/// second callback slot for Go-level layout change notifications
-static _Atomic(KeymapLayoutChangeCallback) gLayoutChangeCallback2 = (KeymapLayoutChangeCallback)0;
 
 #pragma mark - UCKeyTranslate Helper
 


### PR DESCRIPTION
## Description

This PR makes Neru build on Macs running macOS 14.4 or earlier. On those
releases the newest Xcode Apple offers ships clang 15, and the build fails
outright with "initializer element is not a compile-time constant" — so
contributors on that hardware cannot compile the project at all. Newer
toolchains accept the same code, and CI only runs the newest macOS, so nothing
catches it.

One global in the keyboard-layout code starts out empty in a way clang 15 will
not accept as a constant. Spelling the same empty value differently satisfies
clang 15 and every newer clang alike. There is no behaviour change: the value
is identical, only its notation differs.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code
- [x] Stub implementations added for other platforms — N/A, this is a
      one-token change inside an existing darwin-only file.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`) — `fmt-check` confirms the Objective-C
      formatting is clean.
- [x] `just ci` passes — with one exception: `lint-objc` could not run here
      because `clang-tidy` is not available on this machine. Every other step
      (`fmt-check`, `lint-go`, `vet`, `build`, `test-ci` including `-race`,
      `vuln`) exited 0.
- [x] Tests added/updated for new or changed functionality — N/A, a compile-time
      notation change with no reachable behaviour to assert; the build itself is
      the test, and it is what was failing.
- [x] Documentation updated (if applicable) — N/A.
- [x] Commit messages follow conventional commits

## Additional Context

Reproduced on macOS 14.3.1 with Apple clang 15.0.0 (Xcode 15.1), where the
build failed before this change and succeeds after it. Both toolchains
available on that machine — Xcode 15.1 and Command Line Tools 15.3 — are
clang 15 and both rejected it, so switching between them is not a workaround.

For anyone hitting this: Apple clang 16 first ships with Xcode 16, which
requires macOS 14.5, so on 14.4 and earlier there is no Apple toolchain that
compiles the current code.

Three spellings of the empty value are rejected by clang 15 and only a cast is
accepted; the cast was chosen over dropping the initializer entirely so the
intent stays visible at the declaration.
