### PR TITLE
fix(accessibility): stop priming from opening status-bar menus

### DIFF
--- a/internal/adapter/accessibility/native/darwin/priming.go
+++ b/internal/adapter/accessibility/native/darwin/priming.go
@@ -27,6 +27,23 @@ var readyRoles = map[string]struct{}{
 	"AXScrollArea": {},
 }
 
+// menuRoles are the AX roles this walk must not descend into. Reading
+// kAXChildrenAttribute on a menu bar item is what makes AppKit build — and
+// display — the menu behind it, so walking them does not observe the
+// application, it operates it: for a status-bar app such as a clipboard
+// manager, priming pops the menu open on the user's screen.
+//
+// The walk roots at the application element, which is what puts AXMenuBar in
+// reach in the first place; AXMenu and AXMenuItem are here because an already
+// open menu can also hang off a window. Nothing is lost by stopping: a
+// readyRole is web content, and web content never lives inside a menu.
+var menuRoles = map[string]struct{}{
+	"AXMenuBar":     {},
+	"AXMenuBarItem": {},
+	"AXMenu":        {},
+	"AXMenuItem":    {},
+}
+
 // PrimeApplication warms an application's accessibility tree so the first hint
 // scan does not pay for a cold one. It reports whether the tree became ready.
 func PrimeApplication(bundleID string, logger *zap.Logger) bool {
@@ -97,6 +114,14 @@ func hasUsableAccessibilityTree(root *Element, logger *zap.Logger) bool {
 		}
 
 		role := info.Role()
+
+		// Stop before the menu subtree rather than after: asking for its
+		// children is itself the side effect.
+		if _, isMenu := menuRoles[role]; isMenu {
+			releaseVisited(cur.el)
+
+			continue
+		}
 
 		if _, ready := readyRoles[role]; ready {
 			logger.Info("Found usable accessibility tree", zap.String("role", role))

--- a/internal/adapter/accessibility/native/darwin/priming_test.go
+++ b/internal/adapter/accessibility/native/darwin/priming_test.go
@@ -1,0 +1,38 @@
+//go:build darwin
+
+package darwin
+
+import "testing"
+
+// The priming walk roots at the application element, so the menu bar is in
+// reach of it. Reading a menu bar item's children is not an observation —
+// AppKit builds and displays the menu behind it — so a status-bar app gets its
+// menu popped open on the user's screen every time priming runs. These pin the
+// guard that stops the walk before that happens.
+
+// TestMenuRolesCoverTheStatusItemPath pins the two roles that stand between the
+// application element and a status item's menu. Losing either one puts the walk
+// back on the path that opens it.
+func TestMenuRolesCoverTheStatusItemPath(t *testing.T) {
+	for _, role := range []string{"AXMenuBar", "AXMenuBarItem", "AXMenu", "AXMenuItem"} {
+		if _, ok := menuRoles[role]; !ok {
+			t.Errorf("menuRoles is missing %q, so the priming walk would descend into it", role)
+		}
+	}
+}
+
+// TestMenuRolesCannotMaskAReadyRole is the invariant that makes the guard free:
+// a role the walk refuses to enter must never be the role it is looking for,
+// or skipping it would turn a ready tree into a timeout. Web content never
+// lives inside a menu, so the two sets are disjoint by construction — this
+// fails if a later edit breaks that.
+func TestMenuRolesCannotMaskAReadyRole(t *testing.T) {
+	for role := range menuRoles {
+		if _, ready := readyRoles[role]; ready {
+			t.Errorf(
+				"%q is both a menu role and a ready role, so the guard hides a primed tree",
+				role,
+			)
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes Neru repeatedly reopening the menu of a status-bar app while it
is running. With a clipboard manager whose history is a menu bar menu, opening
that menu once and then dismissing it makes it come straight back, and it keeps
coming back however many times you close it — until Neru is quit.

The cause is the accessibility warm-up Neru runs whenever an application is
activated. That walk starts at the application itself, so it reaches the menu
bar, and asking a menu bar item for its contents does not read the menu — it
makes macOS build and show it. The walk also repeats for several seconds for
any app without web content, so it keeps reopening the menu for the whole
window, and each dismissal counts as a fresh activation that starts the walk
again. That is the loop.

The warm-up now stops at menus instead of descending into them. It is looking
for web content, and web content is never inside a menu, so nothing it needs
becomes unreachable — warm-up still succeeds for Chromium and Gecko apps, which
is the only reason it exists.

## Related Issues

None — found while using Neru, not filed separately.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code
- [x] Stub implementations added for other platforms — N/A, the non-darwin
      warm-up already reports ready immediately and has no tree walk to guard.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — with one exception: `lint-objc` could not run here
      because `clang-tidy` is not available on this machine, and this PR
      changes no Objective-C. Every other step (`fmt-check`, `lint-go`, `vet`,
      `build`, `test-ci` including `-race`, `vuln`) exited 0.
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing option or
      command changes.
- [x] Commit messages follow conventional commits

## Additional Context

Measured on macOS 14.3.1 with Maccy 0.31, whose clipboard history is a status
bar menu. Each trial opens the menu, waits, dismisses it by activating another
app, then watches for eight seconds to see whether it returns:

- dismissed 1s after opening, before this change: comes back, and then survives
  six further dismissals over twelve seconds
- dismissed 8s after opening, before this change: 0/3 come back — by then the
  warm-up has given up on its own
- Neru not running, dismissed after 1s: 0/3 come back
- quitting Neru while the menu is stuck open: one dismissal closes it for good
- dismissed 1s after opening, with this change: 0/5 come back, across two runs

The dwell-time split is what identifies the warm-up specifically rather than
app activation in general: the reopen only happens inside the retry window.

Warm-up was confirmed to still work afterwards — it reports a usable tree for
Microsoft Edge, as before.

Two adjacent things this PR deliberately leaves alone, both arguably worth
their own change:

- The excluded-apps list does not cover this walk, so excluding an app does not
  stop Neru from reading its accessibility tree on activation.
- The walk spends its full retry budget on every app that will never expose web
  content, which is most of them.
