### PR TITLE
fix(overlay): resolve each font family name from its own spelling

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -175,6 +175,12 @@ to is the platform's own — Helvetica Neue / Times New Roman / Menlo on macOS,
 DejaVu Sans / DejaVu Serif / DejaVu Sans Mono on Linux, the Windows families
 above.
 
+Where an answer is remembered — macOS, Windows and the fontconfig-backed Linux
+resolver — it is remembered under the family name exactly as written
+(`internal/adapter/platform/fontcache`); the non-CGO Linux build re-derives it
+each time. Either way what a name resolves to depends on that name alone and
+never on what was resolved before it.
+
 ### Notes on the ⚠️ entries
 
 **Focused app on Wayland.** wlroots and KWin resolve the focused window through

--- a/internal/adapter/platform/darwin/font.go
+++ b/internal/adapter/platform/darwin/font.go
@@ -3,9 +3,7 @@
 package darwin
 
 import (
-	"strings"
-	"sync"
-
+	"github.com/y3owk1n/neru/internal/adapter/platform/fontcache"
 	"github.com/y3owk1n/neru/internal/adapter/platform/fontgeneric"
 	"github.com/y3owk1n/neru/internal/ports"
 )
@@ -33,9 +31,7 @@ var darwinFamilies = fontgeneric.Families{
 // existing C/Objective-C layer (which already does PostScript and family
 // lookups via NSFontManager) can verify and weight-resolve it.
 func NewFontResolver() ports.FontResolver {
-	return &nsFontResolver{
-		cache: make(map[string]string),
-	}
+	return &nsFontResolver{cache: fontcache.New(darwinFamilies.Resolve)}
 }
 
 // nsFontResolver implements ports.FontResolver for macOS. Generic
@@ -43,31 +39,12 @@ func NewFontResolver() ports.FontResolver {
 // is passed through trimmed to the C layer, which already performs the
 // full NSFont + NSFontManager resolution chain.
 type nsFontResolver struct {
-	mu    sync.RWMutex
-	cache map[string]string
+	cache *fontcache.Resolver
 }
 
 // Resolve implements ports.FontResolver.
 func (r *nsFontResolver) Resolve(family string, bold bool) string {
 	_ = bold // weight is enforced at the C layer
 
-	key := strings.ToLower(strings.TrimSpace(family))
-
-	r.mu.RLock()
-
-	if cached, ok := r.cache[key]; ok {
-		r.mu.RUnlock()
-
-		return cached
-	}
-
-	r.mu.RUnlock()
-
-	resolved := darwinFamilies.Resolve(family)
-
-	r.mu.Lock()
-	r.cache[key] = resolved
-	r.mu.Unlock()
-
-	return resolved
+	return r.cache.Resolve(family)
 }

--- a/internal/adapter/platform/darwin/font_test.go
+++ b/internal/adapter/platform/darwin/font_test.go
@@ -19,7 +19,7 @@ func TestNSFontResolver_GenericAliases(t *testing.T) {
 
 	for input, want := range cases {
 		t.Run(input, func(t *testing.T) {
-			fontResolver := &nsFontResolver{cache: make(map[string]string)}
+			fontResolver := NewFontResolver()
 
 			if got := fontResolver.Resolve(input, false); got != want {
 				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
@@ -40,7 +40,7 @@ func TestNSFontResolver_NonGenericPassesThroughTrimmed(t *testing.T) {
 
 	for input, want := range cases {
 		t.Run(input, func(t *testing.T) {
-			fontResolver := &nsFontResolver{cache: make(map[string]string)}
+			fontResolver := NewFontResolver()
 
 			if got := fontResolver.Resolve(input, false); got != want {
 				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
@@ -49,19 +49,16 @@ func TestNSFontResolver_NonGenericPassesThroughTrimmed(t *testing.T) {
 	}
 }
 
-func TestNSFontResolver_CachesByFamily(t *testing.T) {
-	fontResolver := &nsFontResolver{cache: make(map[string]string)}
+func TestNSFontResolver_AnswersEachSpellingFromItsOwnName(t *testing.T) {
+	// Caching must not rewrite a caller's spelling; the shared rule is pinned
+	// on every CI leg in platform/fontcache, this pins that macOS uses it.
+	fontResolver := NewFontResolver()
 
-	for range 3 {
-		if got := fontResolver.Resolve("sans", true); got != defaultDarwinSans {
-			t.Fatalf("expected generic alias to resolve to %q, got %q", defaultDarwinSans, got)
-		}
+	if got := fontResolver.Resolve("Arial", false); got != "Arial" {
+		t.Fatalf("Resolve(%q) = %q, want %q", "Arial", got, "Arial")
 	}
 
-	fontResolver.mu.RLock()
-	defer fontResolver.mu.RUnlock()
-
-	if len(fontResolver.cache) != 1 {
-		t.Fatalf("expected exactly one cache entry, got %d", len(fontResolver.cache))
+	if got := fontResolver.Resolve("ARIAL", false); got != "ARIAL" {
+		t.Fatalf("Resolve(%q) = %q, want %q", "ARIAL", got, "ARIAL")
 	}
 }

--- a/internal/adapter/platform/fontcache/cache.go
+++ b/internal/adapter/platform/fontcache/cache.go
@@ -1,0 +1,45 @@
+package fontcache
+
+import "sync"
+
+// Resolver answers what family a written font family name resolves to,
+// remembering each answer so the platform's font system is asked once per
+// name. It is safe for concurrent use.
+type Resolver struct {
+	mu      sync.RWMutex
+	entries map[string]string
+	resolve func(family string) string
+}
+
+// New returns a Resolver that remembers what resolve answers.
+func New(resolve func(family string) string) *Resolver {
+	return &Resolver{
+		entries: make(map[string]string),
+		resolve: resolve,
+	}
+}
+
+// Resolve returns the family that family resolves to, asking the wrapped
+// resolution on the first request for that name and remembering its answer for
+// later ones.
+//
+// A name is remembered exactly as it was written, so a caller is always
+// answered from its own spelling: resolving "Arial" and then "ARIAL" resolves
+// both, rather than answering the second from the first one's entry.
+func (r *Resolver) Resolve(family string) string {
+	r.mu.RLock()
+	cached, ok := r.entries[family]
+	r.mu.RUnlock()
+
+	if ok {
+		return cached
+	}
+
+	resolved := r.resolve(family)
+
+	r.mu.Lock()
+	r.entries[family] = resolved
+	r.mu.Unlock()
+
+	return resolved
+}

--- a/internal/adapter/platform/fontcache/cache_test.go
+++ b/internal/adapter/platform/fontcache/cache_test.go
@@ -1,0 +1,105 @@
+package fontcache_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/platform/fontcache"
+)
+
+func TestResolver_ResolvesOncePerWrittenName(t *testing.T) {
+	calls := 0
+	resolver := fontcache.New(func(family string) string {
+		calls++
+
+		return strings.TrimSpace(family)
+	})
+
+	for range 3 {
+		if got := resolver.Resolve("JetBrains Mono"); got != "JetBrains Mono" {
+			t.Fatalf("Resolve() = %q, want %q", got, "JetBrains Mono")
+		}
+	}
+
+	if calls != 1 {
+		t.Fatalf("resolved %d times, want 1", calls)
+	}
+}
+
+func TestResolver_AnswerNeverDependsOnWhatWasAskedBefore(t *testing.T) {
+	// The rule this package exists for: an answer is a function of the name
+	// asked for and nothing else. Remembering an answer under a normalised
+	// name while storing the written one would hand the second caller the
+	// first caller's spelling, which is the order-dependent behavior #1293
+	// removed.
+	spellings := []string{"Arial", "ARIAL", "arial", "  Arial  "}
+
+	for _, first := range spellings {
+		t.Run(first, func(t *testing.T) {
+			resolver := fontcache.New(strings.TrimSpace)
+
+			resolver.Resolve(first)
+
+			for _, second := range spellings {
+				want := strings.TrimSpace(second)
+
+				if got := resolver.Resolve(second); got != want {
+					t.Fatalf(
+						"after Resolve(%q), Resolve(%q) = %q, want %q",
+						first,
+						second,
+						got,
+						want,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestResolver_SecondSpellingIsResolvedOnItsOwn(t *testing.T) {
+	// The documented price of remembering a name as written: a second spelling
+	// of the same family is a second name, resolved rather than answered from
+	// the first one's entry.
+	calls := 0
+	resolver := fontcache.New(func(family string) string {
+		calls++
+
+		return strings.TrimSpace(family)
+	})
+
+	resolver.Resolve("Arial")
+	resolver.Resolve("ARIAL")
+
+	if calls != 2 {
+		t.Fatalf("resolved %d times for two spellings, want 2", calls)
+	}
+}
+
+func TestResolver_ConcurrentResolveIsSafe(t *testing.T) {
+	var mu sync.Mutex
+
+	resolver := fontcache.New(func(family string) string {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return strings.TrimSpace(family)
+	})
+
+	var waitGroup sync.WaitGroup
+
+	for _, family := range []string{"Arial", "ARIAL", "Menlo", "  Menlo  "} {
+		for range 8 {
+			waitGroup.Go(func() {
+				want := strings.TrimSpace(family)
+
+				if got := resolver.Resolve(family); got != want {
+					t.Errorf("Resolve(%q) = %q, want %q", family, got, want)
+				}
+			})
+		}
+	}
+
+	waitGroup.Wait()
+}

--- a/internal/adapter/platform/fontcache/doc.go
+++ b/internal/adapter/platform/fontcache/doc.go
@@ -1,0 +1,16 @@
+// Package fontcache remembers what a platform font resolver answered for a
+// written font family name, so the platform's font system is asked once per
+// name rather than once per frame.
+//
+// It exists as one implementation because remembering an answer must not
+// change it. Every platform resolver carried its own copy of this cache, and
+// each of them keyed it on a lowercased, trimmed name while storing the answer
+// for the name as written: after somebody resolved "Arial", a later "ARIAL"
+// was answered "Arial" — the first caller's spelling, not its own. The answer
+// was a function of what had been asked before, which is the one thing a cache
+// may never be. ADR 0007 has the reasoning for collapsing the copies.
+//
+// A name is therefore remembered exactly as it was written. Two spellings of
+// one family cost two entries — a bounded price, since family names come from
+// configuration — and each caller is answered from its own name.
+package fontcache

--- a/internal/adapter/platform/linux/font_cgo.go
+++ b/internal/adapter/platform/linux/font_cgo.go
@@ -53,10 +53,9 @@ static char *fc_match_family(const char *family) {
 import "C"
 
 import (
-	"strings"
-	"sync"
 	"unsafe"
 
+	"github.com/y3owk1n/neru/internal/adapter/platform/fontcache"
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
@@ -64,9 +63,10 @@ import (
 // Each (family) tuple is resolved on first use and cached for the
 // lifetime of the process.
 func NewFontResolver() ports.FontResolver {
-	return &fontconfigResolver{
-		cache: make(map[string]string),
-	}
+	resolver := &fontconfigResolver{}
+	resolver.cache = fontcache.New(resolver.resolve)
+
+	return resolver
 }
 
 // fontconfigResolver implements ports.FontResolver using libfontconfig.
@@ -74,31 +74,14 @@ func NewFontResolver() ports.FontResolver {
 // fontconfig to verify user-supplied names, and falls back to a hardcoded
 // default when fontconfig cannot resolve a family at all.
 type fontconfigResolver struct {
-	mu    sync.RWMutex
-	cache map[string]string
+	cache *fontcache.Resolver
 }
 
 // Resolve implements ports.FontResolver.
 func (r *fontconfigResolver) Resolve(family string, bold bool) string {
 	_ = bold // reserved for future weight-specific resolution
 
-	key := strings.ToLower(strings.TrimSpace(family))
-
-	r.mu.RLock()
-	if cached, ok := r.cache[key]; ok {
-		r.mu.RUnlock()
-
-		return cached
-	}
-	r.mu.RUnlock()
-
-	resolved := r.resolve(family)
-
-	r.mu.Lock()
-	r.cache[key] = resolved
-	r.mu.Unlock()
-
-	return resolved
+	return r.cache.Resolve(family)
 }
 
 // resolve performs the actual lookup. It first maps the input to a

--- a/internal/adapter/platform/windows/font.go
+++ b/internal/adapter/platform/windows/font.go
@@ -3,9 +3,7 @@
 package windows
 
 import (
-	"strings"
-	"sync"
-
+	"github.com/y3owk1n/neru/internal/adapter/platform/fontcache"
 	"github.com/y3owk1n/neru/internal/adapter/platform/fontgeneric"
 	"github.com/y3owk1n/neru/internal/ports"
 )
@@ -25,37 +23,16 @@ var windowsFamilies = fontgeneric.Families{
 
 // NewFontResolver returns a Windows-backed ports.FontResolver.
 func NewFontResolver() ports.FontResolver {
-	return &winFontResolver{
-		cache: make(map[string]string),
-	}
+	return &winFontResolver{cache: fontcache.New(windowsFamilies.Resolve)}
 }
 
 type winFontResolver struct {
-	mu    sync.RWMutex
-	cache map[string]string
+	cache *fontcache.Resolver
 }
 
 // Resolve implements ports.FontResolver.
 func (r *winFontResolver) Resolve(family string, bold bool) string {
 	_ = bold
 
-	key := strings.ToLower(strings.TrimSpace(family))
-
-	r.mu.RLock()
-
-	if cached, ok := r.cache[key]; ok {
-		r.mu.RUnlock()
-
-		return cached
-	}
-
-	r.mu.RUnlock()
-
-	resolved := windowsFamilies.Resolve(family)
-
-	r.mu.Lock()
-	r.cache[key] = resolved
-	r.mu.Unlock()
-
-	return resolved
+	return r.cache.Resolve(family)
 }

--- a/internal/adapter/platform/windows/font_test.go
+++ b/internal/adapter/platform/windows/font_test.go
@@ -19,7 +19,7 @@ func TestWinFontResolver_GenericAliases(t *testing.T) {
 
 	for input, want := range cases {
 		t.Run(input, func(t *testing.T) {
-			fontResolver := &winFontResolver{cache: make(map[string]string)}
+			fontResolver := NewFontResolver()
 
 			if got := fontResolver.Resolve(input, false); got != want {
 				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
@@ -38,7 +38,7 @@ func TestWinFontResolver_NamedFamilyPassesThroughTrimmed(t *testing.T) {
 
 	for input, want := range cases {
 		t.Run(input, func(t *testing.T) {
-			fontResolver := &winFontResolver{cache: make(map[string]string)}
+			fontResolver := NewFontResolver()
 
 			if got := fontResolver.Resolve(input, false); got != want {
 				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
@@ -47,19 +47,16 @@ func TestWinFontResolver_NamedFamilyPassesThroughTrimmed(t *testing.T) {
 	}
 }
 
-func TestWinFontResolver_CachesByFamily(t *testing.T) {
-	fontResolver := &winFontResolver{cache: make(map[string]string)}
+func TestWinFontResolver_AnswersEachSpellingFromItsOwnName(t *testing.T) {
+	// Caching must not rewrite a caller's spelling; the shared rule is pinned
+	// on every CI leg in platform/fontcache, this pins that Windows uses it.
+	fontResolver := NewFontResolver()
 
-	for range 3 {
-		if got := fontResolver.Resolve("sans", true); got != defaultWindowsSans {
-			t.Fatalf("expected generic alias to resolve to %q, got %q", defaultWindowsSans, got)
-		}
+	if got := fontResolver.Resolve("Arial", false); got != "Arial" {
+		t.Fatalf("Resolve(%q) = %q, want %q", "Arial", got, "Arial")
 	}
 
-	fontResolver.mu.RLock()
-	defer fontResolver.mu.RUnlock()
-
-	if len(fontResolver.cache) != 1 {
-		t.Fatalf("expected exactly one cache entry, got %d", len(fontResolver.cache))
+	if got := fontResolver.Resolve("ARIAL", false); got != "ARIAL" {
+		t.Fatalf("Resolve(%q) = %q, want %q", "ARIAL", got, "ARIAL")
 	}
 }

--- a/internal/ports/font.go
+++ b/internal/ports/font.go
@@ -5,7 +5,9 @@ import "sync"
 // FontResolver resolves a user-supplied font family to a real, installed font
 // family on the host system. Implementations handle generic aliases
 // (e.g. "Sans", "Monospace"), verify family availability, and apply
-// platform-specific fallback chains. Results are cached internally.
+// platform-specific fallback chains. Results may be cached internally
+// (adapter/platform/fontcache); caching never changes an answer, so what a
+// name resolves to depends on that name alone.
 type FontResolver interface {
 	// Resolve returns a family name guaranteed to be usable on this platform.
 	//

--- a/justfile
+++ b/justfile
@@ -203,6 +203,7 @@ test-foundation:
         ./internal/domain/hint ./internal/domain/recursivegrid \
         ./internal/domain/state ./internal/derrors \
         ./internal/adapter/logger \
+        ./internal/adapter/platform/fontcache \
         ./internal/adapter/platform/mousestate \
         ./internal/ports ./internal/ports/mocks \
         ./internal/domain/geometry


### PR DESCRIPTION
## Description

This PR removes an order-dependent answer from font resolution. Every platform
remembered which font family a name resolved to, but remembered it under a
lowercased, trimmed version of that name while storing the answer for the name
as written — so once a configuration had resolved `Arial`, a later request for
`ARIAL` was answered `Arial`, the earlier spelling rather than its own. Which
font rendered was the same either way, because macOS, fontconfig and Windows
all match family names without regard to case; what differed was the name each
caller got back, and it differed by whoever asked first.

An answer is now remembered under the name exactly as it was written, so what a
name resolves to depends on that name alone and never on what was resolved
before it. The three copies of that remembering are one implementation now,
sitting next to the shared reading of generic names that landed in #1290 — the
same shared-derivation rule from ADR 0007.

Nothing changes on screen: resolution itself is untouched, and the only cost of
the new rule is that two spellings of one family occupy two remembered entries
instead of one, on names that come from a configuration file.

## Related Issues

Closes #1293

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this PR adds no port capability; it moves an existing cache between packages.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The rule is pinned where it runs on every CI leg rather than only on the
platform that owns a resolver: the shared package carries the tests that an
answer never depends on what was asked before it and that a second spelling is
resolved on its own, and macOS and Windows each keep a small test that they are
wired to it. The pins were checked by putting the old keying back and watching
them fail — the shared tests fail three ways, and the macOS wiring test fails
with them.

The issue left two answers open: preserve what was written, or canonicalise
deliberately. Preserving is the one the port already documented ("returned as
written, trimmed") and the only one available without adding a canonical-name
lookup on macOS and Windows, which would have been the behaviour change the
issue did not authorise.

Two deliberate limitations. The fontconfig-backed Linux resolver has no test of
its own here: it answers with fontconfig's own matched family name for either
spelling, so nothing is observable there to tell the two rules apart, and after
the collapse it has no keying decision left to get wrong. And the non-CGO Linux
build has no cache at all — it re-derives the same answer each time, which the
documentation now says rather than claiming all three remember.

Verified beyond `just ci`: `just lint-cross` and `just check-cross` for the
Windows and Linux build tags that `just lint` cannot see, plus the full Linux
suite with CGO on in the CI-equivalent container.
