### PR TITLE
refactor(domain): carry a grid's rows and columns in one value

### DIFF
--- a/internal/adapter/overlay/linux/overlay_shared_cgo.go
+++ b/internal/adapter/overlay/linux/overlay_shared_cgo.go
@@ -189,7 +189,10 @@ func (o *sharedOverlay) drawRecursiveGridWithSubKeyPreview(
 	shouldAnimate := animEnabled && o.hasLast && depth != o.lastDepth &&
 		!o.lastBounds.Empty()
 
-	cellRects := recursivegrid.ComputeGridCells(bounds, gridCols, gridRows)
+	cellRects := recursivegrid.ComputeGridCells(
+		bounds,
+		domain.GridDimensions{Rows: gridRows, Cols: gridCols},
+	)
 
 	if shouldAnimate {
 		duration := time.Duration(animDurationMS) * time.Millisecond
@@ -879,7 +882,7 @@ func (o *sharedOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.
 
 	// The rectangles they are drawn on, which are the rectangles the mode layer
 	// moves the cursor into (internal/domain/grid/subgrid_cells.go).
-	cells := domainGrid.SubgridCells(bounds, domain.SubgridRows, domain.SubgridCols)
+	cells := domainGrid.SubgridCells(bounds, domain.SubgridDimensions())
 
 	// One cell per key, and fewer keys than cells is a configuration that
 	// leaves the last cells unlabelled: the key set is capped at the same count
@@ -984,7 +987,10 @@ func (o *sharedOverlay) drawSubKeyMiniGrid(
 	nextGridCols int, nextGridRows int,
 	style recursivegridcomponent.Style,
 ) {
-	subCells := recursivegrid.ComputeGridCells(cell, nextGridCols, nextGridRows)
+	subCells := recursivegrid.ComputeGridCells(
+		cell,
+		domain.GridDimensions{Rows: nextGridRows, Cols: nextGridCols},
+	)
 	centerIdx := -1
 
 	if nextGridCols%2 == 1 && nextGridRows%2 == 1 {

--- a/internal/adapter/overlay/render/grid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/grid/overlay_darwin.go
@@ -463,7 +463,7 @@ func (o *Overlay) ShowSubgrid(cell *domainGrid.Cell, style Style) {
 
 	// The rectangles those keys are drawn on, which are the rectangles the mode
 	// layer moves the cursor into (internal/domain/grid/subgrid_cells.go).
-	subCells := domainGrid.SubgridCells(cell.Bounds(), domain.SubgridRows, domain.SubgridCols)
+	subCells := domainGrid.SubgridCells(cell.Bounds(), domain.SubgridDimensions())
 
 	// One cell per key, and fewer keys than cells is a configuration that
 	// leaves the last cells unlabelled: the key set is capped at the same count

--- a/internal/adapter/overlay/render/recursivegrid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/recursivegrid/overlay_darwin.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/overlayutil"
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/recursivegrid"
 )
 
@@ -311,7 +312,10 @@ func (o *Overlay) DrawRecursiveGrid(
 	o.drawMu.RLock()
 
 	// Compute cell positions using the shared helper (same as Divide()).
-	cellRects := recursivegrid.ComputeGridCells(bounds, gridCols, gridRows)
+	cellRects := recursivegrid.ComputeGridCells(
+		bounds,
+		domain.GridDimensions{Rows: gridRows, Cols: gridCols},
+	)
 
 	cells := make([]C.GridCell, keyCount)
 

--- a/internal/adapter/overlay/windows/features.go
+++ b/internal/adapter/overlay/windows/features.go
@@ -9,6 +9,7 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/recursivegrid"
 	"github.com/y3owk1n/neru/internal/ports"
 )
@@ -184,7 +185,10 @@ func (o *winOverlay) DrawRecursiveGrid(
 
 	keyRunes := []rune(strings.ToUpper(keys))
 
-	cellRects := recursivegrid.ComputeGridCells(bounds, gridCols, gridRows)
+	cellRects := recursivegrid.ComputeGridCells(
+		bounds,
+		domain.GridDimensions{Rows: gridRows, Cols: gridCols},
+	)
 	for idx, cell := range cellRects {
 		if style.HighlightColorARGB() != 0 {
 			o.window.FillRect(cell, style.HighlightColorARGB())

--- a/internal/adapter/overlay/windows/overlay.go
+++ b/internal/adapter/overlay/windows/overlay.go
@@ -388,7 +388,7 @@ func (o *winOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Sty
 
 	// The rectangles they are drawn on, which are the rectangles the mode layer
 	// moves the cursor into (internal/domain/grid/subgrid_cells.go).
-	cells := domainGrid.SubgridCells(bounds, domain.SubgridRows, domain.SubgridCols)
+	cells := domainGrid.SubgridCells(bounds, domain.SubgridDimensions())
 
 	// One cell per key, and fewer keys than cells is a configuration that
 	// leaves the last cells unlabelled: the key set is capped at the same count

--- a/internal/app/component_factory.go
+++ b/internal/app/component_factory.go
@@ -72,8 +72,7 @@ func (f *ComponentFactory) CreateGridComponent() *components.GridComponent {
 	// Create grid manager with callbacks
 	component.Manager = domainGrid.NewManager(
 		nil,
-		domain.SubgridRows,
-		domain.SubgridCols,
+		domain.SubgridDimensions(),
 		// The keys the subgrid is drawn with, resolved once by the config
 		// (config.ResolveSublayerKeys).
 		f.config.Grid.SublayerKeys,

--- a/internal/app/components/types_test.go
+++ b/internal/app/components/types_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/app/components"
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/domain"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
 )
 
@@ -34,7 +35,14 @@ func newGridComponent(
 		log,
 	)
 
-	manager := domainGrid.NewManager(initial, 2, 2, characters, nil, nil, log)
+	manager := domainGrid.NewManager(
+		initial,
+		domain.GridDimensions{Rows: 2, Cols: 2},
+		characters,
+		nil,
+		nil,
+		log,
+	)
 
 	return &components.GridComponent{Manager: manager}
 }
@@ -240,7 +248,14 @@ func TestGridComponent_UpdateConfig_NilManagerAndGrid(t *testing.T) {
 	})
 
 	t.Run("manager with nil grid", func(t *testing.T) {
-		manager := domainGrid.NewManager(nil, 2, 2, testCharacters, nil, nil, zap.NewNop())
+		manager := domainGrid.NewManager(
+			nil,
+			domain.GridDimensions{Rows: 2, Cols: 2},
+			testCharacters,
+			nil,
+			nil,
+			zap.NewNop(),
+		)
 		component := &components.GridComponent{Manager: manager}
 
 		component.UpdateConfig(gridConfig("wxyz", "", ""), zap.NewNop())

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -161,8 +161,7 @@ func (h *handlerState) initializeGridManager(gridInstance *domainGrid.Grid) {
 	// Create grid manager with callbacks for overlay updates and subgrid navigation
 	h.grid.Manager = domainGrid.NewManager(
 		gridInstance,
-		domain.SubgridRows,
-		domain.SubgridCols,
+		domain.SubgridDimensions(),
 		// The keys the subgrid is drawn with, resolved once by the config
 		// (config.ResolveSublayerKeys) so that the set accepted here is the set
 		// the overlay draws.

--- a/internal/app/modes/grid_test.go
+++ b/internal/app/modes/grid_test.go
@@ -11,6 +11,7 @@ import (
 	gridcomponent "github.com/y3owk1n/neru/internal/app/components/grid"
 	"github.com/y3owk1n/neru/internal/app/services"
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/domain"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
 	"github.com/y3owk1n/neru/internal/domain/modecmd"
 	portmocks "github.com/y3owk1n/neru/internal/ports/mocks"
@@ -31,8 +32,7 @@ func TestHandleGridModeKey_CompleteSelectionDoesNotMoveWhenCursorFollowSelection
 
 	manager := domainGrid.NewManager(
 		gridInstance,
-		3,
-		3,
+		domain.GridDimensions{Rows: 3, Cols: 3},
 		"asdfghjkl",
 		nil,
 		nil,

--- a/internal/domain/domain_constants.go
+++ b/internal/domain/domain_constants.go
@@ -110,12 +110,6 @@ const (
 	DefaultExitKey = "Escape"
 )
 
-// Grid subgrid dimensions.
-const (
-	SubgridRows = 3
-	SubgridCols = 3
-)
-
 // BaseManager provides common functionality for domain managers.
 // It contains shared fields and methods used across different domain managers.
 type BaseManager struct {

--- a/internal/domain/grid/manager.go
+++ b/internal/domain/grid/manager.go
@@ -21,16 +21,20 @@ type Manager struct {
 	inSubgrid     bool
 	selectedCell  *Cell
 	// Subgrid configuration
-	subRows int
-	subCols int
+	subDims domain.GridDimensions
 	subKeys string
 }
 
 // NewManager creates a new grid manager with the specified configuration.
+//
+// subDims is the shape of the subgrid a cell opens into. It is one value rather
+// than a row count beside a column count because it is handed straight to
+// SubgridCells, which decides where a subgrid key sends the cursor: an adjacent
+// pair here would just be the transposition SubgridCells no longer has, one
+// call up (#1294).
 func NewManager(
 	grid *Grid,
-	subRows int,
-	subCols int,
+	subDims domain.GridDimensions,
 	subKeys string,
 	onUpdate func(redraw bool),
 	onShowSub func(cell *Cell),
@@ -50,9 +54,8 @@ func NewManager(
 		labelLength: labelLength,
 		onUpdate:    onUpdate,
 		onShowSub:   onShowSub,
-		subRows:     subRows,
-		subCols:     subCols,
-		subKeys:     string(SubgridKeys(subKeys, subRows*subCols)),
+		subDims:     subDims,
+		subKeys:     string(SubgridKeys(subKeys, subDims.CellCount())),
 	}
 }
 
@@ -153,7 +156,7 @@ func (m *Manager) UpdateGrid(g *Grid) {
 // the set an overlay draws (SubgridKeys), so the keys accepted here are the
 // keys the user can see.
 func (m *Manager) UpdateSubKeys(subKeys string) {
-	m.subKeys = string(SubgridKeys(subKeys, m.subRows*m.subCols))
+	m.subKeys = string(SubgridKeys(subKeys, m.subDims.CellCount()))
 }
 
 // HandleBackspace applies grid backspace behavior: delete one input character,
@@ -327,7 +330,7 @@ func (m *Manager) handleSubgridSelection(key string) (image.Point, bool) {
 	// The cells this subgrid is divided into, which are the cells every overlay
 	// backend draws (internal/domain/grid/subgrid_cells.go), so the cursor
 	// lands in the cell the key was written on.
-	cells := SubgridCells(m.selectedCell.bounds, m.subRows, m.subCols)
+	cells := SubgridCells(m.selectedCell.bounds, m.subDims)
 
 	// A key past the last cell names nothing. The bound is this manager's own
 	// cell count rather than the shipped subgrid's, because the manager is
@@ -342,7 +345,7 @@ func (m *Manager) handleSubgridSelection(key string) (image.Point, bool) {
 	xCoordinate := selected.Min.X + gridRound(selected.Dx())
 	yCoordinate := selected.Min.Y + gridRound(selected.Dy())
 	m.Logger.Debug("Grid manager: Subgrid selection complete",
-		zap.Int("row", keyIndex/m.subCols), zap.Int("col", keyIndex%m.subCols),
+		zap.Int("row", keyIndex/m.subDims.Cols), zap.Int("col", keyIndex%m.subDims.Cols),
 		zap.Int("x", xCoordinate), zap.Int("y", yCoordinate))
 	// m.Reset()
 	return image.Point{X: xCoordinate, Y: yCoordinate}, true

--- a/internal/domain/grid/manager_test.go
+++ b/internal/domain/grid/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/adapter/logger"
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/grid"
 )
 
@@ -18,7 +19,7 @@ func TestGridManager_RouterIntegration(t *testing.T) {
 	// Create grid manager
 	gridManager := grid.NewManager(
 		testGrid,
-		3, 3, "asdf",
+		domain.GridDimensions{Rows: 3, Cols: 3}, "asdf",
 		func(redraw bool) {
 			// Update callback
 		},
@@ -118,7 +119,14 @@ func TestManager_CurrentInput(t *testing.T) {
 	logger := logger.Get()
 	testGrid := grid.NewGrid("ABCD", image.Rect(0, 0, 100, 100), logger)
 
-	manager := grid.NewManager(testGrid, 2, 2, "12", nil, nil, logger)
+	manager := grid.NewManager(
+		testGrid,
+		domain.GridDimensions{Rows: 2, Cols: 2},
+		"12",
+		nil,
+		nil,
+		logger,
+	)
 
 	// Initially empty
 	if input := manager.CurrentInput(); input != "" {
@@ -138,7 +146,14 @@ func TestManager_Reset(t *testing.T) {
 	// Use unique parameters to avoid cache conflicts
 	testGrid := grid.NewGrid("ABCD", image.Rect(0, 0, 50, 50), logger)
 
-	manager := grid.NewManager(testGrid, 2, 2, "12", nil, nil, logger)
+	manager := grid.NewManager(
+		testGrid,
+		domain.GridDimensions{Rows: 2, Cols: 2},
+		"12",
+		nil,
+		nil,
+		logger,
+	)
 
 	manager.HandleInput("A")
 
@@ -157,7 +172,14 @@ func TestManager_IgnoresNonSingleCharKey(t *testing.T) {
 	logger := logger.Get()
 	testGrid := grid.NewGrid("ABC", image.Rect(0, 0, 300, 300), logger)
 
-	manager := grid.NewManager(testGrid, 2, 2, "12", nil, nil, logger)
+	manager := grid.NewManager(
+		testGrid,
+		domain.GridDimensions{Rows: 2, Cols: 2},
+		"12",
+		nil,
+		nil,
+		logger,
+	)
 
 	// Type a valid character
 	manager.HandleInput("A")
@@ -186,7 +208,14 @@ func TestManager_AcceptsNonLetterCharacters(t *testing.T) {
 	// Create grid with only numbers and symbols
 	testGrid := grid.NewGrid("123!@", image.Rect(0, 0, 500, 500), logger)
 
-	manager := grid.NewManager(testGrid, 2, 2, "ab", nil, nil, logger)
+	manager := grid.NewManager(
+		testGrid,
+		domain.GridDimensions{Rows: 2, Cols: 2},
+		"ab",
+		nil,
+		nil,
+		logger,
+	)
 
 	// Test that numbers are accepted
 	_, complete := manager.HandleInput("1")
@@ -223,7 +252,14 @@ func TestManager_CustomLabelsWithSymbols(t *testing.T) {
 		t.Errorf("ValidCharacters() = %q, should contain ','", validChars)
 	}
 
-	manager := grid.NewManager(testGrid, 2, 2, "ab", nil, nil, logger)
+	manager := grid.NewManager(
+		testGrid,
+		domain.GridDimensions{Rows: 2, Cols: 2},
+		"ab",
+		nil,
+		nil,
+		logger,
+	)
 
 	// Test that regular characters work
 	_, complete := manager.HandleInput("A")
@@ -295,7 +331,7 @@ func TestGridManager_ResetSilentClearsInputWithoutCallback(t *testing.T) {
 
 	manager := grid.NewManager(
 		testGrid,
-		3, 3, "asdf",
+		domain.GridDimensions{Rows: 3, Cols: 3}, "asdf",
 		func(_ bool) { updates++ },
 		func(_ *grid.Cell) {},
 		logger,
@@ -323,7 +359,7 @@ func TestGridManager_ResetClearsInputAndFiresCallback(t *testing.T) {
 
 	manager := grid.NewManager(
 		testGrid,
-		3, 3, "asdf",
+		domain.GridDimensions{Rows: 3, Cols: 3}, "asdf",
 		func(redraw bool) { redraws = append(redraws, redraw) },
 		func(_ *grid.Cell) {},
 		logger,
@@ -347,7 +383,14 @@ func TestManager_InputValidation(t *testing.T) {
 
 	// Create a simple grid with known coordinates: AA, AB, AC, BA, BB, BC, CA, CB, CC
 	testGrid := grid.NewGrid("ABC", image.Rect(0, 0, 100, 100), logger)
-	manager := grid.NewManager(testGrid, 2, 2, "ab", nil, nil, logger)
+	manager := grid.NewManager(
+		testGrid,
+		domain.GridDimensions{Rows: 2, Cols: 2},
+		"ab",
+		nil,
+		nil,
+		logger,
+	)
 
 	// Test 1: Valid first character should be accepted
 	_, complete := manager.HandleInput("A")
@@ -436,7 +479,14 @@ func TestManager_PrefixValidationRegression(t *testing.T) {
 
 	// Create a grid with known coordinates: AA, AB, BA, BB (for "AB" characters)
 	testGrid := grid.NewGrid("AB", image.Rect(0, 0, 100, 100), logger)
-	manager := grid.NewManager(testGrid, 2, 2, "ab", nil, nil, logger)
+	manager := grid.NewManager(
+		testGrid,
+		domain.GridDimensions{Rows: 2, Cols: 2},
+		"ab",
+		nil,
+		nil,
+		logger,
+	)
 
 	// Get all coordinates
 	cells := testGrid.AllCells()

--- a/internal/domain/grid/move_test.go
+++ b/internal/domain/grid/move_test.go
@@ -28,8 +28,7 @@ func newMoveHarness(t *testing.T) *moveHarness {
 
 	harness.manager = grid.NewManager(
 		harness.grid,
-		domain.SubgridRows,
-		domain.SubgridCols,
+		domain.SubgridDimensions(),
 		"asdfghjkl",
 		func(bool) {},
 		func(cell *grid.Cell) { harness.shown = append(harness.shown, cell) },

--- a/internal/domain/grid/router_test.go
+++ b/internal/domain/grid/router_test.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/grid"
 )
 
@@ -14,7 +15,14 @@ func TestGridRouter_RouteKey(t *testing.T) {
 
 	// Create a simple grid for testing
 	testGrid := grid.NewGrid("ABCD", image.Rect(0, 0, 100, 100), logger)
-	manager := grid.NewManager(testGrid, 3, 3, "123456789", nil, nil, logger)
+	manager := grid.NewManager(
+		testGrid,
+		domain.GridDimensions{Rows: 3, Cols: 3},
+		"123456789",
+		nil,
+		nil,
+		logger,
+	)
 	router := grid.NewRouter(manager, logger)
 
 	tests := []struct {
@@ -65,7 +73,14 @@ func TestGridRouter_EscapeKey(t *testing.T) {
 
 	// Create a simple grid for testing
 	testGrid := grid.NewGrid("ABCD", image.Rect(0, 0, 100, 100), logger)
-	manager := grid.NewManager(testGrid, 3, 3, "123456789", nil, nil, logger)
+	manager := grid.NewManager(
+		testGrid,
+		domain.GridDimensions{Rows: 3, Cols: 3},
+		"123456789",
+		nil,
+		nil,
+		logger,
+	)
 	router := grid.NewRouter(manager, logger)
 
 	// Escape is handled by top-level custom hotkeys now, not router.

--- a/internal/domain/grid/subgrid_cells.go
+++ b/internal/domain/grid/subgrid_cells.go
@@ -1,6 +1,10 @@
 package grid
 
-import "image"
+import (
+	"image"
+
+	"github.com/y3owk1n/neru/internal/domain"
+)
 
 // roundingFactor is what a positive quotient is offset by before it is
 // truncated, which rounds it to the nearest whole pixel. It is written once
@@ -26,14 +30,22 @@ const roundingFactor = 0.5
 // edge rather than the rounded value, so the subgrid covers the cell exactly:
 // no seam a click can fall into and no cell drawn a pixel past its parent.
 //
-// Rows and columns are parameters rather than the shipped 3x3
-// (domain.SubgridRows, domain.SubgridCols) because the manager already carries
-// its own, and a function that baked the constant in would leave it computing
-// its answer somewhere else the moment that stopped being true.
+// The dimensions are a parameter rather than the shipped 3x3
+// (domain.SubgridDimensions) because the manager already carries its own, and a
+// function that baked the constant in would leave it computing its answer
+// somewhere else the moment that stopped being true. They arrive together as a
+// domain.GridDimensions rather than as a row count and a column count because
+// recursivegrid.ComputeGridCells divides a rectangle too, and the two used to
+// take their counts in opposite orders — a transposed call was invisible while
+// every grid was square (#1294).
+//
+// This division is deliberately not recursivegrid.ComputeGridCells, whose doc
+// comment says how the two differ and why merging them is not on the table.
 //
 // A subgrid with no rows or no columns has no cells, which is what a caller
 // that has not been configured yet gets instead of a panic.
-func SubgridCells(bounds image.Rectangle, rows, cols int) []image.Rectangle {
+func SubgridCells(bounds image.Rectangle, dims domain.GridDimensions) []image.Rectangle {
+	rows, cols := dims.Rows, dims.Cols
 	if rows < 1 || cols < 1 {
 		return nil
 	}
@@ -52,7 +64,7 @@ func SubgridCells(bounds image.Rectangle, rows, cols int) []image.Rectangle {
 	xBreaks[cols] = bounds.Max.X
 	yBreaks[rows] = bounds.Max.Y
 
-	cells := make([]image.Rectangle, 0, rows*cols)
+	cells := make([]image.Rectangle, 0, dims.CellCount())
 
 	for row := range rows {
 		for col := range cols {

--- a/internal/domain/grid/subgrid_cells_test.go
+++ b/internal/domain/grid/subgrid_cells_test.go
@@ -15,15 +15,13 @@ func TestSubgridCells(t *testing.T) {
 	testCases := []struct {
 		name   string
 		bounds image.Rectangle
-		rows   int
-		cols   int
+		dims   domain.GridDimensions
 		want   []image.Rectangle
 	}{
 		{
 			name:   "a cell that divides evenly divides into equal thirds",
 			bounds: image.Rect(0, 0, 300, 150),
-			rows:   domain.SubgridRows,
-			cols:   domain.SubgridCols,
+			dims:   domain.SubgridDimensions(),
 			want: []image.Rectangle{
 				image.Rect(0, 0, 100, 50),
 				image.Rect(100, 0, 200, 50),
@@ -42,8 +40,7 @@ func TestSubgridCells(t *testing.T) {
 			// pixel lands in the middle column rather than at one end.
 			name:   "a cell that does not divide evenly rounds each break",
 			bounds: image.Rect(0, 0, 10, 8),
-			rows:   domain.SubgridRows,
-			cols:   domain.SubgridCols,
+			dims:   domain.SubgridDimensions(),
 			want: []image.Rectangle{
 				image.Rect(0, 0, 3, 3),
 				image.Rect(3, 0, 7, 3),
@@ -60,8 +57,7 @@ func TestSubgridCells(t *testing.T) {
 			// The same 10x8 cell, moved to where a grid cell actually sits.
 			name:   "a cell away from the origin divides where it is",
 			bounds: image.Rect(100, 50, 110, 58),
-			rows:   domain.SubgridRows,
-			cols:   domain.SubgridCols,
+			dims:   domain.SubgridDimensions(),
 			want: []image.Rectangle{
 				image.Rect(100, 50, 103, 53),
 				image.Rect(103, 50, 107, 53),
@@ -79,8 +75,7 @@ func TestSubgridCells(t *testing.T) {
 			// column count, so the shape has to come from the caller.
 			name:   "a subgrid that is not square divides by its own counts",
 			bounds: image.Rect(0, 0, 9, 5),
-			rows:   2,
-			cols:   4,
+			dims:   domain.GridDimensions{Rows: 2, Cols: 4},
 			want: []image.Rectangle{
 				image.Rect(0, 0, 2, 3),
 				image.Rect(2, 0, 5, 3),
@@ -95,8 +90,7 @@ func TestSubgridCells(t *testing.T) {
 		{
 			name:   "a cell narrower than its columns still gives one cell per key",
 			bounds: image.Rect(0, 0, 2, 2),
-			rows:   domain.SubgridRows,
-			cols:   domain.SubgridCols,
+			dims:   domain.SubgridDimensions(),
 			want: []image.Rectangle{
 				image.Rect(0, 0, 1, 1),
 				image.Rect(1, 0, 1, 1),
@@ -112,18 +106,17 @@ func TestSubgridCells(t *testing.T) {
 		{
 			name:   "a subgrid with no rows has no cells",
 			bounds: image.Rect(0, 0, 300, 150),
-			rows:   0,
-			cols:   domain.SubgridCols,
+			dims:   domain.GridDimensions{Rows: 0, Cols: domain.SubgridCols},
 			want:   nil,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			got := grid.SubgridCells(testCase.bounds, testCase.rows, testCase.cols)
+			got := grid.SubgridCells(testCase.bounds, testCase.dims)
 			if len(got) != len(testCase.want) {
-				t.Fatalf("SubgridCells(%v, %d, %d) returned %d cells, want %d",
-					testCase.bounds, testCase.rows, testCase.cols, len(got), len(testCase.want))
+				t.Fatalf("SubgridCells(%v, %+v) returned %d cells, want %d",
+					testCase.bounds, testCase.dims, len(got), len(testCase.want))
 			}
 
 			for index, want := range testCase.want {
@@ -145,7 +138,7 @@ func TestSubgridCells_CoversTheCellExactly(t *testing.T) {
 
 	for size := 1; size <= 64; size++ {
 		bounds := image.Rect(origin, origin, origin+size, origin+size)
-		cells := grid.SubgridCells(bounds, domain.SubgridRows, domain.SubgridCols)
+		cells := grid.SubgridCells(bounds, domain.SubgridDimensions())
 
 		if len(cells) != domain.SubgridRows*domain.SubgridCols {
 			t.Fatalf("a %dx%d cell divided into %d cells, want %d",
@@ -190,7 +183,43 @@ func TestManager_SubgridSelectionLandsInsideTheCellItDrew(t *testing.T) {
 	for index, key := range drawn {
 		manager, opened := newSubgridKeyManager(t, configured)
 
-		cells := grid.SubgridCells(opened, domain.SubgridRows, domain.SubgridCols)
+		cells := grid.SubgridCells(opened, domain.SubgridDimensions())
+
+		point, selected := manager.HandleInput(string(key))
+		if !selected {
+			t.Fatalf("subgrid refused %q, which it is drawn with", string(key))
+		}
+
+		if !point.In(cells[index]) {
+			t.Errorf("key %q draws %v but moves the cursor to %v",
+				string(key), cells[index], point)
+		}
+	}
+}
+
+// TestManager_SubgridSelectionLandsInsideTheCellItDrew_NonSquare is the same
+// stake on a subgrid whose two counts differ, which is the only shape that can
+// tell a row count from a column count. The shipped subgrid is 3x3, so a
+// manager that had its two counts the wrong way round would divide the cell
+// into exactly the same nine rectangles and this whole file would still pass —
+// the mistake would surface only for whoever configured a subgrid that was not
+// square, and would look like a rendering bug rather than a swapped pair.
+func TestManager_SubgridSelectionLandsInsideTheCellItDrew_NonSquare(t *testing.T) {
+	// Four columns over two rows, and eight keys to name the eight cells.
+	dims := domain.GridDimensions{Rows: 2, Cols: 4}
+
+	const configured = "asdfghjk"
+
+	drawn := grid.SubgridKeys(configured, dims.CellCount())
+	if len(drawn) != dims.CellCount() {
+		t.Fatalf("SubgridKeys(%q) drew %d keys, want %d",
+			configured, len(drawn), dims.CellCount())
+	}
+
+	for index, key := range drawn {
+		manager, opened := newSubgridManager(t, dims, configured)
+
+		cells := grid.SubgridCells(opened, dims)
 
 		point, selected := manager.HandleInput(string(key))
 		if !selected {

--- a/internal/domain/grid/subgrid_keys_test.go
+++ b/internal/domain/grid/subgrid_keys_test.go
@@ -76,8 +76,7 @@ func TestSubgridKeys(t *testing.T) {
 func TestSubgridKeys_CapAgreesWithTheCellsThereAre(t *testing.T) {
 	divided := grid.SubgridCells(
 		image.Rect(0, 0, 300, 150),
-		domain.SubgridRows,
-		domain.SubgridCols,
+		domain.SubgridDimensions(),
 	)
 
 	if grid.MaxKeyIndex != len(divided) {
@@ -159,6 +158,19 @@ func TestManager_EveryDrawnSubgridKeySelectsItsOwnPoint(t *testing.T) {
 func newSubgridKeyManager(t *testing.T, subKeys string) (*grid.Manager, image.Rectangle) {
 	t.Helper()
 
+	return newSubgridManager(t, domain.SubgridDimensions(), subKeys)
+}
+
+// newSubgridManager is newSubgridKeyManager for a subgrid of any shape: it
+// drives the manager into a cell's subgrid and hands back the manager and the
+// rectangle that subgrid covers.
+func newSubgridManager(
+	t *testing.T,
+	dims domain.GridDimensions,
+	subKeys string,
+) (*grid.Manager, image.Rectangle) {
+	t.Helper()
+
 	log := logger.Get()
 	testGrid := grid.NewGrid("abcdefghijklmnopqrstuvwxyz", image.Rect(0, 0, 1000, 800), log)
 
@@ -166,8 +178,7 @@ func newSubgridKeyManager(t *testing.T, subKeys string) (*grid.Manager, image.Re
 
 	manager := grid.NewManager(
 		testGrid,
-		domain.SubgridRows,
-		domain.SubgridCols,
+		dims,
 		subKeys,
 		func(bool) {},
 		func(cell *grid.Cell) { opened = cell.Bounds() },

--- a/internal/domain/grid_dimensions.go
+++ b/internal/domain/grid_dimensions.go
@@ -1,0 +1,48 @@
+package domain
+
+// Grid subgrid dimensions.
+const (
+	SubgridRows = 3
+	SubgridCols = 3
+)
+
+// GridDimensions is the shape of a rectangular grid: how many rows of cells it
+// has and how many columns. It is the one thing every division of a rectangle
+// into cells needs beyond the rectangle itself.
+//
+// It is a type rather than two int parameters because the domain divides
+// rectangles into grids twice — grid.SubgridCells rounds each break, and
+// recursivegrid.ComputeGridCells hands the spare pixels to the first cells —
+// and the two used to spell the pair in opposite orders. Every caller passes
+// equal counts today (the subgrid is a fixed 3x3, the recursive grid a
+// configured square), so a transposed call compiled, drew the right cells and
+// clicked the right point; the first non-square grid would have turned it into
+// what looked like a rendering bug. Carrying the two counts together means
+// there is no longer a pair to put in the wrong order, and each count is named
+// at the point it is written down.
+//
+// It lives here rather than in either grid package because both of them divide
+// rectangles and neither can import the other. This is the lowest layer with
+// more than one caller — the rule ADR 0007 names.
+type GridDimensions struct {
+	// Rows is how many rows of cells the grid has.
+	Rows int
+	// Cols is how many columns of cells the grid has.
+	Cols int
+}
+
+// SubgridDimensions is the shape of the subgrid a grid cell opens into.
+//
+// It is a function rather than a variable so that no caller can reshape the
+// shipped subgrid for everyone else, and it exists so that the overlay backends
+// ask for that shape by name instead of each pairing up the two constants
+// themselves.
+func SubgridDimensions() GridDimensions {
+	return GridDimensions{Rows: SubgridRows, Cols: SubgridCols}
+}
+
+// CellCount is how many cells a grid of these dimensions has, which is also how
+// many keys it needs.
+func (d GridDimensions) CellCount() int {
+	return d.Rows * d.Cols
+}

--- a/internal/domain/recursivegrid/compute_grid_cells_test.go
+++ b/internal/domain/recursivegrid/compute_grid_cells_test.go
@@ -1,0 +1,104 @@
+package recursivegrid_test
+
+import (
+	"image"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/recursivegrid"
+)
+
+// TestComputeGridCells pins the rectangles a recursive-grid level divides its
+// bounds into. The numbers are worked by hand rather than recomputed from the
+// formula, so a change to the formula has to disagree with them.
+//
+// Every case here is deliberately non-square, and the two dimensions are
+// deliberately different in the remainder they leave. A division that read the
+// row count as the column count would have to produce these same rectangles to
+// pass, and it cannot: a 5-column, 2-row grid of a 13x7 rectangle and a
+// 2-column, 5-row one share neither their cell count per row nor their edges.
+func TestComputeGridCells(t *testing.T) {
+	testCases := []struct {
+		name   string
+		bounds image.Rectangle
+		dims   domain.GridDimensions
+		want   []image.Rectangle
+	}{
+		{
+			// 13 across 5 columns is 2 each with 3 spare, which go to the
+			// first three columns: 3, 3, 3, 2, 2. 7 down 2 rows is 3 each
+			// with 1 spare, which goes to the first row: 4, 3.
+			name:   "spare pixels go to the first cells of each axis",
+			bounds: image.Rect(0, 0, 13, 7),
+			dims:   domain.GridDimensions{Rows: 2, Cols: 5},
+			want: []image.Rectangle{
+				image.Rect(0, 0, 3, 4),
+				image.Rect(3, 0, 6, 4),
+				image.Rect(6, 0, 9, 4),
+				image.Rect(9, 0, 11, 4),
+				image.Rect(11, 0, 13, 4),
+				image.Rect(0, 4, 3, 7),
+				image.Rect(3, 4, 6, 7),
+				image.Rect(6, 4, 9, 7),
+				image.Rect(9, 4, 11, 7),
+				image.Rect(11, 4, 13, 7),
+			},
+		},
+		{
+			// The transpose of the case above, on the same bounds: 13 across
+			// 2 columns is 6 each with 1 spare (7, 6), and 7 down 5 rows is
+			// 1 each with 2 spare (2, 2, 1, 1, 1). Nothing about the answer
+			// resembles the one above.
+			name:   "swapping the two counts divides the same bounds differently",
+			bounds: image.Rect(0, 0, 13, 7),
+			dims:   domain.GridDimensions{Rows: 5, Cols: 2},
+			want: []image.Rectangle{
+				image.Rect(0, 0, 7, 2),
+				image.Rect(7, 0, 13, 2),
+				image.Rect(0, 2, 7, 4),
+				image.Rect(7, 2, 13, 4),
+				image.Rect(0, 4, 7, 5),
+				image.Rect(7, 4, 13, 5),
+				image.Rect(0, 5, 7, 6),
+				image.Rect(7, 5, 13, 6),
+				image.Rect(0, 6, 7, 7),
+				image.Rect(7, 6, 13, 7),
+			},
+		},
+		{
+			// The same non-square division, moved to where a monitor that is
+			// not the primary one actually sits.
+			name:   "bounds away from the origin divide where they are",
+			bounds: image.Rect(100, 50, 113, 57),
+			dims:   domain.GridDimensions{Rows: 2, Cols: 5},
+			want: []image.Rectangle{
+				image.Rect(100, 50, 103, 54),
+				image.Rect(103, 50, 106, 54),
+				image.Rect(106, 50, 109, 54),
+				image.Rect(109, 50, 111, 54),
+				image.Rect(111, 50, 113, 54),
+				image.Rect(100, 54, 103, 57),
+				image.Rect(103, 54, 106, 57),
+				image.Rect(106, 54, 109, 57),
+				image.Rect(109, 54, 111, 57),
+				image.Rect(111, 54, 113, 57),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := recursivegrid.ComputeGridCells(testCase.bounds, testCase.dims)
+			if len(got) != len(testCase.want) {
+				t.Fatalf("ComputeGridCells(%v, %+v) returned %d cells, want %d",
+					testCase.bounds, testCase.dims, len(got), len(testCase.want))
+			}
+
+			for index, want := range testCase.want {
+				if got[index] != want {
+					t.Errorf("cell %d = %v, want %v", index, got[index], want)
+				}
+			}
+		})
+	}
+}

--- a/internal/domain/recursivegrid/recursive_grid.go
+++ b/internal/domain/recursivegrid/recursive_grid.go
@@ -2,6 +2,8 @@ package recursivegrid
 
 import (
 	"image"
+
+	"github.com/y3owk1n/neru/internal/domain"
 )
 
 const (
@@ -129,13 +131,25 @@ func (qg *RecursiveGrid) GridRows() int {
 // single level differ in size by at most 1 pixel and the grid fills the entire
 // bounds contiguously without gaps. This is the single source of truth for cell
 // positions shared by Divide() and all platform overlay renderers.
-func ComputeGridCells(bounds image.Rectangle, cols, rows int) []image.Rectangle {
+//
+// The dimensions arrive together as a domain.GridDimensions rather than as a
+// row count and a column count so that there is no pair of ints to transpose:
+// grid.SubgridCells divides a rectangle too, and the two used to take their
+// counts in opposite orders (#1294).
+//
+// This division is deliberately not grid.SubgridCells. It gives the spare
+// pixels of an uneven division to the first cells, where the subgrid rounds
+// each break instead; both are correct for their caller and merging them would
+// move where a key sends the cursor.
+func ComputeGridCells(bounds image.Rectangle, dims domain.GridDimensions) []image.Rectangle {
+	rows, cols := dims.Rows, dims.Cols
+
 	baseW := bounds.Dx() / cols
 	baseH := bounds.Dy() / rows
 	remW := bounds.Dx() % cols
 	remH := bounds.Dy() % rows
 
-	cells := make([]image.Rectangle, cols*rows)
+	cells := make([]image.Rectangle, dims.CellCount())
 
 	currentY := bounds.Min.Y
 	for row := range rows {
@@ -171,7 +185,13 @@ func ComputeGridCells(bounds image.Rectangle, cols, rows int) []image.Rectangle 
 func (qg *RecursiveGrid) Divide() []image.Rectangle {
 	layout := qg.LayoutForDepth(qg.depth)
 
-	return ComputeGridCells(qg.currentBounds, layout.GridCols, layout.GridRows)
+	// The one place this grid's column and row counts are paired up, so a
+	// transposition here is a transposition everywhere the recursive grid
+	// divides — which is what the non-square Divide tests are watching.
+	return ComputeGridCells(
+		qg.currentBounds,
+		domain.GridDimensions{Rows: layout.GridRows, Cols: layout.GridCols},
+	)
 }
 
 // rectCenter returns the center point of rect, rounded to nearest pixel and


### PR DESCRIPTION
## Description

This PR removes a way to break the grid that nothing would have caught. Two
places in Neru divide a rectangle into cells — the subgrid a grid cell opens
into, and each level of the recursive grid — and both were told how many rows
and how many columns to use as two plain numbers, in opposite orders. Because
every grid Neru ships is square (the subgrid is always 3×3, the recursive grid
a configured square), handing those two numbers over the wrong way round
changed nothing: it compiled, drew the right cells, and moved the cursor to the
right place. The first person to configure a recursive grid that was not square
would have seen cells drawn in the wrong shape and had no reason to suspect a
swapped pair.

Both divisions now take the shape as a single value that names its rows and its
columns, so there is no longer a pair to put in the wrong order — a swap is a
compile error rather than a bug waiting for a non-square grid. Nothing moves on
screen: both divisions produce exactly the rectangles they produced before,
including their deliberately different handling of a division that does not come
out even, and grid and recursive-grid keys still land the cursor in the cell they
were drawn on.

The one thing this does not make impossible is writing the two counts into that
value under the wrong names at a call site; that stays a visible, labelled
mistake rather than an invisible positional one, and the tests below catch it
everywhere the domain does it.

## Related Issues

Closes #1294

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability changed; the three overlay backends only adopt the new argument type.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no documented fact changed; nothing in `docs/` named either division.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**The two divisions are still two divisions.** They answer different questions —
one hands the spare pixels of an uneven division to the first cells, the other
rounds each break — and merging them would move where a subgrid key sends the
cursor, which #1287 established is a change nobody asked for. Neither arithmetic
body changed.

**Where the shape type lives.** `internal/domain`, because both grid packages
divide rectangles and neither can import the other: the lowest layer with more
than one caller, which is the rule ADR 0007 names.

**The guardrails were watched failing.** Transposing the arguments at a real
call site now fails to compile. Transposing the two counts inside the one place
the recursive grid pairs them up fails 34 tests, including the existing
non-square `Divide` cases. Transposing them inside the grid manager fails the new
non-square subgrid test. Each of those was done deliberately, observed, and
reverted.

**New tests.** Each division gets worked-by-hand rectangles for a deliberately
non-square grid — including, for the recursive grid, the same bounds divided
both ways round, so the two answers are on the record as different. The grid
manager gets a non-square subgrid journey asserting the cursor lands in the cell
each key was drawn on. All of them are plain unit tests in `internal/domain`, so
they run on every CI leg.

**Slightly beyond the issue.** The grid manager used to be constructed with its
subgrid's row and column counts as an adjacent pair of numbers, and that pair
existed only to be handed to the division. Leaving it would have moved the
transposition one call up rather than removing it, so it takes the shape value
too.

**Known residual.** The recursive-grid overlay backends still receive their
column and row counts as separate numbers through the drawing path, so each one
pairs them up itself at the call site. Converting that path means changing what
the overlay port carries and what four layers of the drawing chain take — worth
its own issue, not this one.
