### PR TITLE
docs(cross-platform): say what sub_key_preview draws on each platform

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -251,6 +251,8 @@ label_background_border_radius = -1
 label_background_border_width = 1
 label_char = ""                             # Override cell labels with a single character (e.g. "·"); empty = use key
 label_autohide_multiplier = 1.5             # Hide labels when cell < fontSize × multiplier (0 = disable)
+# The two sub-key preview options below behave differently on Windows:
+# https://github.com/y3owk1n/neru/blob/main/docs/CROSS_PLATFORM.md#mode-coverage
 sub_key_preview = false                     # Draw miniature key grid inside each cell
 sub_key_preview_font_size = 8
 sub_key_preview_autohide_multiplier = 1.5

--- a/configs/recursive-grid-only-config.toml
+++ b/configs/recursive-grid-only-config.toml
@@ -28,7 +28,9 @@ label_background_padding_x = -1
 label_background_padding_y = -1
 label_background_border_radius = -1
 label_background_border_width = 1
-# Sub-key preview: draw a miniature key grid inside each cell
+# Sub-key preview: draw a miniature key grid inside each cell. Behaves
+# differently on Windows:
+# https://github.com/y3owk1n/neru/blob/main/docs/CROSS_PLATFORM.md#mode-coverage
 sub_key_preview = false
 sub_key_preview_font_size = 8
 sub_key_preview_text_color = { light = "#465FBC", dark = "#6E82D6" }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1148,9 +1148,9 @@ layers = [
 | `label_background_border_width`       | int    | `1`     | Label border width                                                           |
 | `label_char`                          | string | `""`    | Override all cell labels with a single character (e.g. `·`); empty = use key |
 | `label_autohide_multiplier`           | float  | `1.5`   | Hide labels when cell < fontSize × multiplier (0 = disable)                  |
-| `sub_key_preview`                     | bool   | `false` | Show sub-key previews in cells                                               |
+| `sub_key_preview`                     | bool   | `false` | Show sub-key previews in cells; [Windows draws a different aid](CROSS_PLATFORM.md#mode-coverage) |
 | `sub_key_preview_font_size`           | int    | `8`     | Sub-key preview font size                                                    |
-| `sub_key_preview_autohide_multiplier` | float  | `1.5`   | Autohide threshold multiplier                                                |
+| `sub_key_preview_autohide_multiplier` | float  | `1.5`   | Autohide threshold multiplier; [measured against a different rectangle on Windows](CROSS_PLATFORM.md#mode-coverage) |
 | `sub_key_preview_text_color`          | color  | derived | Sub-key preview text color                                                   |
 | `sub_key_preview_label_char`          | string | `""`    | Override sub-key labels with a single character (e.g. `·`); empty = use key  |
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -451,10 +451,10 @@ discovery rather than the mode itself.
 | **Hints**         | Search input badge             | ✅                         | ❌ no-op                   | ✅                          |
 | **Hints**         | Label arrow / tail             | ✅ NSBezierPath            | ✅ Cairo triangle          | ❌                          |
 | **Grid**          | Transition animation           | ✅                         | ✅                         | ❌                          |
-| **Grid**          | Sub-key preview                | ✅ centered mini-grid      | ✅ centered mini-grid      | ⚠️ single-line bottom text  |
 | **Grid**          | Virtual pointer indicator      | ✅                         | ❌ no-op                   | ❌ no-op                    |
 | **Recursive grid**| Transition animation           | ✅                         | ✅                         | ❌                          |
 | **Recursive grid**| Virtual pointer indicator      | ✅                         | ✅                         | ✅                          |
+| **Recursive grid**| Sub-key preview                | ✅ mini-grid of next keys  | ✅ mini-grid of next keys  | ⚠️ single bottom label, see below |
 | **Scroll**        | Smooth scroll animation        | ✅                         | ❌                         | ❌                          |
 | **Monitor select**| Whole mode                     | ✅ native panels           | ✅ Cairo panels            | 🟡 `CodeNotSupported`       |
 
@@ -467,6 +467,32 @@ actions on grid cells, subgrid zoom, backtracking, and every scroll granularity.
 > cursor is hidden — is separate from the recursive-grid indicator above and is
 > macOS-only: `virtualpointer.Overlay` is a no-op on every non-darwin build, and
 > it is paired with `CGDisplayHideCursor`, which has no equivalent elsewhere.
+
+> **`recursive_grid.ui.sub_key_preview` is one option with two drawings.** macOS
+> and Linux divide each cell by the *next* level's grid dimensions and draw the
+> key that selects each sub-cell in its own place, so the preview shows **where**
+> each key lands. Windows is handed the same next-level keys and dimensions and
+> discards them: it draws one label along the bottom of the cell — the cell's own
+> label, or `sub_key_preview_label_char` when that is set — which conveys the
+> preview font and colour but none of the next level's keys. It also draws that
+> label at the deepest level, where there is no next level to preview and the
+> other two draw nothing.
+>
+> `sub_key_preview_autohide_multiplier` inherits the split, because each backend
+> measures the rectangle it actually draws into. macOS and Linux require one
+> **sub-cell** — the cell divided by the next level's dimensions — to reach
+> `sub_key_preview_font_size × multiplier` in both width and height; Windows
+> requires the **whole cell** to. The same configured number therefore stops
+> showing the preview at very different cell sizes: with a 3×3 next level,
+> Windows keeps drawing down to a cell a third of the width and height at which
+> macOS and Linux have already given up. Treat the value as platform-specific
+> rather than assuming one number behaves the same everywhere.
+>
+> Bringing the Windows drawing in line is tracked as
+> [#1297](https://github.com/y3owk1n/neru/issues/1297); until it lands the two
+> autohide predicates stay separate on purpose, because they gate different
+> drawings and answer different questions
+> ([#1288](https://github.com/y3owk1n/neru/issues/1288)).
 
 ---
 
@@ -515,6 +541,8 @@ Work that is genuinely missing, as opposed to deliberately platform-specific.
 8. Horizontal scroll — `ScrollAtCursor` ignores `deltaX`
 9. `monitor_select` mode — returns `CodeNotSupported`
 10. Font resolution — alias mapping only, no system font enumeration
+11. Recursive-grid sub-key preview — a single bottom label rather than the
+    mini-grid the other platforms draw ([Mode Coverage](#mode-coverage))
 
 **macOS**
 


### PR DESCRIPTION
## Description

This PR fixes a documentation gap that left Windows users guessing. Turning on the recursive-grid sub-key preview draws a miniature grid of the next level's keys inside every cell on macOS and Linux, but a single label along the bottom of the cell on Windows — and nothing on any page said so, so the only way to find out was to enable it and look.

The cross-platform guide now carries that entry: what each platform actually draws, that Windows keeps drawing the label at the deepest level where the other two draw nothing, and that the autohide multiplier is measured against a single sub-cell on macOS and Linux but against the whole cell on Windows — so the same configured number stops showing the preview at very different cell sizes. The config reference and the two shipped example configs link to that entry instead of repeating it, so there is one place to keep correct.

Documentation only: no behaviour changes, and the Windows drawing itself is left alone and tracked separately.

## Related Issues

Closes #1296. The Windows drawing is tracked as #1297; the reason the two autohide predicates are deliberately not shared is #1288.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Config Surface

No option is added, removed, renamed, or given a new default. Two existing options gain documentation of behaviour that already ships:

| Option | Behaviour being documented |
| ------ | -------------------------- |
| `recursive_grid.ui.sub_key_preview` | macOS and Linux draw a mini-grid of the next level's keys inside each cell; Windows draws one label along the bottom of the cell, and also draws it at the deepest level where there is no next level to preview |
| `recursive_grid.ui.sub_key_preview_autohide_multiplier` | Multiplied against `sub_key_preview_font_size` and compared against one sub-cell on macOS and Linux, against the whole cell on Windows |

Existing config files keep working unchanged.

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, documentation only; no code changed
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Every claim in the new entry was read out of the three backends rather than inferred from the option name. Worth a second pair of eyes:

- Windows is handed the next level's keys and dimensions by the shared overlay interface and discards them, which is why its preview cannot show where each key lands and why it is not gated on a next level existing. macOS and Linux both gate on it, so at maximum depth Windows alone still paints a label.
- The autohide split is real arithmetic, not a rounding difference: with a 3×3 next level, Windows keeps drawing down to a cell a third of the width and height at which macOS and Linux have already stopped.

Two small corrections rode along, both in service of the entry being findable and correct. The capability row was filed under **Grid** although the option exists only under `[recursive_grid.ui]`, so it moved to **Recursive grid**; and the Windows Known Gaps list gained a one-line pointer, since the file's own documentation checklist routes a discovered gap there.

Deliberately not done: the entry says the preview echoes the cell's own label on Windows, but does not mention that both mini-grid backends skip the centre sub-cell of an odd×odd layout. That is shared behaviour on macOS and Linux rather than a platform divergence, so it does not belong on this page.
