### PR TITLE
test(overlay): hold the macOS label-autohide rule to the shared one

### DIFF
--- a/docs/adr/0007-a-shared-derivation-has-one-implementation.md
+++ b/docs/adr/0007-a-shared-derivation-has-one-implementation.md
@@ -80,8 +80,13 @@ are the precedent, not the exception.
   and the `HintPlacement` enum to the same numbering. It pins *which placement
   each value means*, not where the badge is then drawn — `hintRectForPlacement:`
   remains a single Objective-C implementation with no Go counterpart to
-  disagree with. One copy of this kind is still owed a pin: the recursive-grid
-  label-autohide rule (#1298).
+  disagree with. The second such pin landed with the recursive-grid
+  label-autohide rule (#1298), where the copy is a rule rather than a constant:
+  `internal/architecture/label_autohide_rule_test.go` reads the Objective-C
+  guard in `drawGridLabel:` into something it can run, and holds its answer to
+  `recursivegrid.Style.ShowLabelIn` over the cases that separate them — the
+  multiplier that disables autohide, the threshold itself, and each cell
+  dimension one pixel under it.
 - **"Lowest layer with more than one caller" is a judgement someone has to
   make, and it moves.** A derivation with one caller is not shared and should
   stay private; the second caller is what triggers the move, and the move is
@@ -90,9 +95,11 @@ are the precedent, not the exception.
   which is why `CONTEXT.md` lists *helper*, *util*, *common code* and *shared
   logic* as the words to avoid. A shared derivation is named for what it
   derives.
-- **This ADR ships one instance and leaves two known ones standing.** The font
+- **This ADR shipped one instance and left two known ones standing.** The font
   parser is collapsed here (#1286). The subgrid breakpoints and the 3×3 written
-  five times are filed separately (#1287), because they touch the drawing path on every
-  backend and deserve their own diff. Naming the rule before finishing the work
+  five times were filed separately (#1287), because they touch the drawing path on every
+  backend and deserved their own diff; they were collapsed in #1292, where the
+  mode layer and all three overlays came to ask `internal/domain/grid` for the
+  cells rather than divide the rectangle themselves. Naming the rule before finishing the work
   is the point: the next platform backend should not have to infer it from two
   packages that never explained themselves.

--- a/internal/adapter/overlay/render/recursivegrid/style.go
+++ b/internal/adapter/overlay/render/recursivegrid/style.go
@@ -200,8 +200,9 @@ func (s Style) LabelAutohideMultiplier() float64 {
 // producing two different screens. The macOS backend asks the same question in
 // Objective-C (drawGridLabel: in
 // internal/adapter/platform/darwin/overlay_darwin.m), so Go cannot be its one
-// implementation; it agrees today and nothing yet pins it, which is the test
-// ADR 0007 says is owed where the second implementation is in another language.
+// implementation; ADR 0007 asks for a test holding that copy to this one
+// instead, and internal/architecture/label_autohide_rule_test.go is it — change
+// the rule here and that test fails until the Objective-C copy follows.
 func (s Style) ShowLabelIn(cell image.Rectangle) bool {
 	if s.labelAutohideMultiplier <= 0 {
 		return true

--- a/internal/adapter/platform/darwin/overlay_darwin.m
+++ b/internal/adapter/platform/darwin/overlay_darwin.m
@@ -1575,6 +1575,10 @@ typedef NS_ENUM(NSInteger, HintPlacement) {
 	// Skip main label when cells are too small to render legibly.
 	// Each cell must be at least (multiplier × font size) in both dimensions.
 	// A multiplier of 0 disables autohide.
+	// This is the same rule as recursivegrid.Style.ShowLabelIn, which the Linux
+	// and Windows recursive-grid overlays call; the pin is
+	// internal/architecture/label_autohide_rule_test.go, and it reads this
+	// guard by its shape, so a rewrite fails it even when the behaviour holds.
 	if (self.gridLabelAutohideMultiplier > 0) {
 		CGFloat minCell = self.gridFont.pointSize * self.gridLabelAutohideMultiplier;
 		if (cellRect.size.width < minCell || cellRect.size.height < minCell)

--- a/internal/architecture/label_autohide_rule_test.go
+++ b/internal/architecture/label_autohide_rule_test.go
@@ -1,0 +1,799 @@
+package architecture_test
+
+import (
+	"fmt"
+	"image"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
+)
+
+// The two sides of the recursive-grid label-autohide rule.
+const (
+	labelAutohideNativeSource = "internal/adapter/platform/darwin/overlay_darwin.m"
+
+	// labelAutohideNativeMethod is the Objective-C method the rule lives in,
+	// named in failure messages so a reader lands on the copy rather than on
+	// this test.
+	labelAutohideNativeMethod = "drawGridLabel:"
+
+	// labelAutohideGoDeclaration names the Go side the same way.
+	labelAutohideGoDeclaration = "recursivegrid.Style.ShowLabelIn"
+)
+
+// TestLabelAutohideRuleIsPinnedAcrossTheLanguageBoundary keeps the macOS
+// overlay hiding the same labels as every other backend.
+//
+// Whether a recursive-grid cell is big enough for its key label is one question
+// with one shared answer: recursivegrid.Style.ShowLabelIn, which the Cairo and
+// GDI backends both call. macOS asks it in Objective-C, inside drawGridLabel:,
+// and cannot call Go. This is ADR 0007's deliberate exception to the
+// one-implementation rule
+// (docs/adr/0007-a-shared-derivation-has-one-implementation.md): where the
+// second implementation is in another language, what the rule asks for is a
+// test holding the copies together rather than a deletion.
+//
+// The copy is a rule and not a constant, so it is pinned by running it. The
+// Objective-C source is read into something this test can evaluate, and its
+// answer is compared against the shared Go one over cases that straddle every
+// edge the rule has: the multiplier that disables it, the threshold itself, and
+// each cell dimension one pixel under. A disagreement is one configuration
+// labeling a cell on macOS and leaving it blank everywhere else.
+func TestLabelAutohideRuleIsPinnedAcrossTheLanguageBoundary(t *testing.T) {
+	t.Parallel()
+
+	rule := readNativeLabelAutohideRule(t)
+
+	for _, disagreement := range labelAutohideDisagreements(rule) {
+		t.Errorf(
+			"%s: %s and %s disagree on %s\n\t%s draws the label: %t\n\t%s draws it: %t\n\tthe rule read from %s is: %s",
+			labelAutohideNativeSource,
+			labelAutohideNativeMethod,
+			labelAutohideGoDeclaration,
+			disagreement.testCase.describe(),
+			labelAutohideNativeMethod,
+			disagreement.native,
+			labelAutohideGoDeclaration,
+			disagreement.shared,
+			labelAutohideNativeSource,
+			rule,
+		)
+	}
+}
+
+// TestLabelAutohideRulePinCatchesNativeDrift keeps the pin above from passing
+// over a rule that has moved.
+//
+// A pin is only worth its line count if the cases it runs can tell the copies
+// apart, and the cases are chosen by hand: drop the width comparison and every
+// square cell still agrees. So each way the Objective-C rule could plausibly
+// drift is applied to the rule this pin actually read, and the mutant has to
+// disagree with the shared implementation somewhere. Mutating the rule rather
+// than the source text keeps this honest across a reformat of the .m file, and
+// keeps "we broke it by hand once and watched it fail" from being the only
+// evidence the guardrail has teeth.
+func TestLabelAutohideRulePinCatchesNativeDrift(t *testing.T) {
+	t.Parallel()
+
+	rule := readNativeLabelAutohideRule(t)
+
+	drifted := []struct {
+		name  string
+		apply func(nativeLabelAutohideRule) nativeLabelAutohideRule
+	}{
+		{
+			name:  "the first cell dimension no longer compared",
+			apply: func(rule nativeLabelAutohideRule) nativeLabelAutohideRule { return rule.withoutDimension(0) },
+		},
+		{
+			name:  "the second cell dimension no longer compared",
+			apply: func(rule nativeLabelAutohideRule) nativeLabelAutohideRule { return rule.withoutDimension(1) },
+		},
+		{
+			name:  "a cell exactly on the threshold hidden instead of drawn",
+			apply: func(rule nativeLabelAutohideRule) nativeLabelAutohideRule { return rule.withHideOperator("<=") },
+		},
+		{
+			name: "the multiplier check inverted, so autohide applies when it is disabled",
+			apply: func(rule nativeLabelAutohideRule) nativeLabelAutohideRule {
+				return rule.withGuardOperator("<=")
+			},
+		},
+		{
+			name: "the threshold taken from the font size alone",
+			apply: func(rule nativeLabelAutohideRule) nativeLabelAutohideRule {
+				return rule.withThresholdFactor(1, "1")
+			},
+		},
+		{
+			name: "the multiplier admitted only above 1, so smaller ones stop hiding anything",
+			apply: func(rule nativeLabelAutohideRule) nativeLabelAutohideRule {
+				return rule.withGuardBound("1")
+			},
+		},
+		{
+			name: "the two dimensions joined by && , so a cell hides only when both are under",
+			apply: func(rule nativeLabelAutohideRule) nativeLabelAutohideRule {
+				return rule.withHideJoin("&&")
+			},
+		},
+		{
+			name: "the dimensions compared for equality instead of order",
+			apply: func(rule nativeLabelAutohideRule) nativeLabelAutohideRule {
+				return rule.withHideOperator("==")
+			},
+		},
+	}
+
+	for _, drift := range drifted {
+		mutant := drift.apply(rule)
+
+		if len(labelAutohideDisagreements(mutant)) == 0 {
+			t.Errorf(
+				"no case tells %s apart from %s: %s would pass the pin\n\tthe drifted rule is: %s",
+				drift.name, labelAutohideGoDeclaration, labelAutohideNativeSource, mutant,
+			)
+		}
+	}
+}
+
+// TestLabelAutohideRulePinReportsARuleItCannotRead pins the other half of the
+// guardrail: a native rule this pin cannot read must be reported, never
+// skipped. A pin that reads nothing and passes is worse than no pin, because
+// it reads as coverage.
+//
+// This is where the pin's one deliberate cost sits. It reads a single shape,
+// and a rewrite that keeps the behavior — folding the multiplier check into
+// the comparison the way drawSubKeyPreviewInCellRect: writes it, say — fails
+// here rather than being understood. Teaching it every equivalent spelling of
+// the same rule is more machinery than the copy is worth; failing loudly and
+// naming the shape it expected leaves the next author a one-line change to
+// this file, which the same author is already making to the .m one.
+func TestLabelAutohideRulePinReportsARuleItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	unreadable := []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "the method renamed",
+			source: "- (void)drawGridCaption:(NSString *)label {\n\treturn;\n}\n",
+		},
+		{
+			name: "the guard folded into the comparison",
+			source: nativeLabelAutohideMethodSource(
+				"\tCGFloat minCell = self.gridFont.pointSize * self.gridLabelAutohideMultiplier;\n" +
+					"\tif (self.gridLabelAutohideMultiplier > 0 && (cellRect.size.width < minCell || cellRect.size.height < minCell))\n" +
+					"\t\treturn;",
+			),
+		},
+		{
+			name: "the threshold measured against an operand this pin cannot value",
+			source: nativeLabelAutohideMethodSource(
+				"\tif (self.gridLabelAutohideMultiplier > 0) {\n" +
+					"\t\tCGFloat minCell = self.gridSubKeyFont.pointSize * self.gridLabelAutohideMultiplier;\n" +
+					"\t\tif (cellRect.size.width < minCell || cellRect.size.height < minCell)\n" +
+					"\t\t\treturn;\n" +
+					"\t}",
+			),
+		},
+	}
+
+	for _, source := range unreadable {
+		if _, problem := parseNativeLabelAutohideRule(source.source); problem == "" {
+			t.Errorf(
+				"parsing accepted a source with %s; the pin would then run a rule it never read",
+				source.name,
+			)
+		}
+	}
+}
+
+// labelAutohideInputs are the four values the rule is a function of.
+type labelAutohideInputs struct {
+	fontSize   float64
+	multiplier float64
+	cellWidth  float64
+	cellHeight float64
+}
+
+// labelAutohideOperands binds every name the Objective-C rule is allowed to
+// mention to the input it stands for. It is the pin's vocabulary: a rule
+// reading anything else is one this test cannot evaluate, and parsing says so
+// rather than guessing a value.
+var labelAutohideOperands = map[string]func(labelAutohideInputs) float64{
+	"self.gridLabelAutohideMultiplier": func(inputs labelAutohideInputs) float64 {
+		return inputs.multiplier
+	},
+	"self.gridFont.pointSize": func(inputs labelAutohideInputs) float64 { return inputs.fontSize },
+	"cellRect.size.width":     func(inputs labelAutohideInputs) float64 { return inputs.cellWidth },
+	"cellRect.size.height":    func(inputs labelAutohideInputs) float64 { return inputs.cellHeight },
+}
+
+// labelAutohideComparators are the comparisons the rule may be written with.
+// Parsing rejects anything outside this set, so evaluating a parsed comparison
+// never has to decide what an unknown operator means.
+var labelAutohideComparators = map[string]func(left, right float64) bool{
+	"<":  func(left, right float64) bool { return left < right },
+	"<=": func(left, right float64) bool { return left <= right },
+	">":  func(left, right float64) bool { return left > right },
+	">=": func(left, right float64) bool { return left >= right },
+	"==": func(left, right float64) bool { return left == right },
+	"!=": func(left, right float64) bool { return left != right },
+}
+
+// labelAutohideCase is one question put to both implementations of the rule.
+//
+// It carries integers where labelAutohideInputs carries floats, because these
+// are the units the shared implementation is actually asked in — a cell is a
+// pixel rectangle and a font size is a whole number of points. Widening them
+// here would let a case be written that no configuration can produce.
+type labelAutohideCase struct {
+	name       string
+	fontSize   int
+	multiplier float64
+	cellWidth  int
+	cellHeight int
+}
+
+// inputs values the case for the native rule.
+func (testCase labelAutohideCase) inputs() labelAutohideInputs {
+	return labelAutohideInputs{
+		fontSize:   float64(testCase.fontSize),
+		multiplier: testCase.multiplier,
+		cellWidth:  float64(testCase.cellWidth),
+		cellHeight: float64(testCase.cellHeight),
+	}
+}
+
+// describe spells the case out in full, so a failure carries the configuration
+// that produced it rather than a case name to go looking for.
+func (testCase labelAutohideCase) describe() string {
+	return fmt.Sprintf(
+		"%s (label font size %d, multiplier %g, cell %dx%d)",
+		testCase.name, testCase.fontSize, testCase.multiplier,
+		testCase.cellWidth, testCase.cellHeight,
+	)
+}
+
+// labelAutohideDisagreement is one case the two implementations answer
+// differently.
+type labelAutohideDisagreement struct {
+	testCase labelAutohideCase
+	native   bool
+	shared   bool
+}
+
+// labelAutohideCases are the questions both implementations are asked.
+//
+// They exist to separate the rules that could plausibly be written here, not to
+// cover an input space: each dimension is taken one pixel under the threshold
+// on its own, because a rule comparing only one of them agrees on every square
+// cell; the threshold is landed on exactly, because >= and > differ nowhere
+// else; and a multiplier below 1 is asked, because a guard that admitted only
+// multipliers above 1 agrees everywhere else.
+// TestLabelAutohideRulePinCatchesNativeDrift is what keeps this list honest.
+//
+// One part of the rule no case here can reach: with a cell size and a font size
+// both non-negative, dropping the multiplier guard entirely answers exactly as
+// the guard does, on every input either implementation can be handed. That half
+// is pinned by shape instead — parsing requires the guard to be there, and
+// reports its absence.
+func labelAutohideCases() []labelAutohideCase {
+	return []labelAutohideCase{
+		{
+			name:       "a zero multiplier disables autohide",
+			fontSize:   100,
+			multiplier: 0,
+			cellWidth:  1,
+			cellHeight: 1,
+		},
+		{
+			name:       "a negative multiplier disables autohide",
+			fontSize:   100,
+			multiplier: -2,
+			cellWidth:  1,
+			cellHeight: 1,
+		},
+		{
+			name:       "a cell exactly on the threshold",
+			fontSize:   20,
+			multiplier: 1.5,
+			cellWidth:  30,
+			cellHeight: 30,
+		},
+		{
+			name:       "a cell one pixel under on width",
+			fontSize:   20,
+			multiplier: 1.5,
+			cellWidth:  29,
+			cellHeight: 30,
+		},
+		{
+			name:       "a cell one pixel under on height",
+			fontSize:   20,
+			multiplier: 1.5,
+			cellWidth:  30,
+			cellHeight: 29,
+		},
+		{
+			name:       "a cell under on both dimensions",
+			fontSize:   20,
+			multiplier: 1.5,
+			cellWidth:  4,
+			cellHeight: 4,
+		},
+		{
+			name:       "a cell far over the threshold",
+			fontSize:   20,
+			multiplier: 1.5,
+			cellWidth:  400,
+			cellHeight: 400,
+		},
+		{name: "a wide, short cell", fontSize: 10, multiplier: 2, cellWidth: 400, cellHeight: 19},
+		{name: "a tall, narrow cell", fontSize: 10, multiplier: 2, cellWidth: 19, cellHeight: 400},
+		{
+			name:       "a threshold falling between two pixels, cell under it",
+			fontSize:   10,
+			multiplier: 1.55,
+			cellWidth:  15,
+			cellHeight: 16,
+		},
+		{
+			name:       "a threshold falling between two pixels, cell over it",
+			fontSize:   10,
+			multiplier: 1.55,
+			cellWidth:  16,
+			cellHeight: 16,
+		},
+		{
+			name:       "a multiplier no cell on screen clears",
+			fontSize:   20,
+			multiplier: 100,
+			cellWidth:  400,
+			cellHeight: 400,
+		},
+		{
+			name:       "a multiplier below 1, cell under the threshold it sets",
+			fontSize:   20,
+			multiplier: 0.5,
+			cellWidth:  8,
+			cellHeight: 8,
+		},
+		{
+			name:       "a multiplier below 1, cell over the threshold it sets",
+			fontSize:   20,
+			multiplier: 0.5,
+			cellWidth:  12,
+			cellHeight: 12,
+		},
+	}
+}
+
+// labelAutohideDisagreements runs every case through the native rule and
+// through the shared Go implementation, and returns the cases they answer
+// differently.
+func labelAutohideDisagreements(rule nativeLabelAutohideRule) []labelAutohideDisagreement {
+	var disagreements []labelAutohideDisagreement
+
+	for _, testCase := range labelAutohideCases() {
+		style := recursivegrid.NewStyle(recursivegrid.StyleOptions{
+			FontSize:                testCase.fontSize,
+			LabelAutohideMultiplier: testCase.multiplier,
+		})
+
+		shared := style.ShowLabelIn(image.Rect(0, 0, testCase.cellWidth, testCase.cellHeight))
+
+		native := rule.showsLabel(testCase.inputs())
+		if native == shared {
+			continue
+		}
+
+		disagreements = append(disagreements, labelAutohideDisagreement{
+			testCase: testCase,
+			native:   native,
+			shared:   shared,
+		})
+	}
+
+	return disagreements
+}
+
+// nativeLabelAutohideComparison is one `a < b` of the Objective-C rule. Each
+// side is either an operand in labelAutohideOperands, the threshold the rule
+// declares, or a numeric literal.
+type nativeLabelAutohideComparison struct {
+	left  string
+	op    string
+	right string
+}
+
+// String spells the comparison the way the Objective-C source writes it.
+func (comparison nativeLabelAutohideComparison) String() string {
+	return fmt.Sprintf("%s %s %s", comparison.left, comparison.op, comparison.right)
+}
+
+// holds evaluates the comparison against the values bound so far.
+func (comparison nativeLabelAutohideComparison) holds(values map[string]float64) bool {
+	return labelAutohideComparators[comparison.op](
+		labelAutohideValue(comparison.left, values),
+		labelAutohideValue(comparison.right, values),
+	)
+}
+
+// nativeLabelAutohideRule is the Objective-C label-autohide rule in the only
+// form a Go test can hold it to: something it can run.
+//
+// Nothing here is an expectation. Every field is read out of the .m file, and
+// the shared Go implementation is the only expectation this pin has — which is
+// what makes the pin bidirectional: change either side alone and the two stop
+// answering alike.
+type nativeLabelAutohideRule struct {
+	// guard decides whether autohide applies at all; when it does not hold, the
+	// label is drawn whatever size the cell is.
+	guard nativeLabelAutohideComparison
+
+	// thresholdName is what the rule calls the size a cell must reach, and
+	// thresholdFactors are the two things it multiplies to get there.
+	thresholdName    string
+	thresholdFactors [2]string
+
+	// hideWhen are the comparisons that skip the label, joined by hideJoin
+	// ("||" or "&&").
+	hideWhen []nativeLabelAutohideComparison
+	hideJoin string
+}
+
+// String renders the rule back as one sentence, so a failure shows what was
+// read out of the source rather than only that it disagreed.
+func (rule nativeLabelAutohideRule) String() string {
+	skips := make([]string, 0, len(rule.hideWhen))
+	for _, comparison := range rule.hideWhen {
+		skips = append(skips, comparison.String())
+	}
+
+	return fmt.Sprintf(
+		"when %s, %s = %s * %s and the label is skipped if %s",
+		rule.guard, rule.thresholdName,
+		rule.thresholdFactors[0], rule.thresholdFactors[1],
+		strings.Join(skips, " "+rule.hideJoin+" "),
+	)
+}
+
+// showsLabel answers the question the shared implementation answers: is this
+// cell big enough for its label to be drawn?
+func (rule nativeLabelAutohideRule) showsLabel(inputs labelAutohideInputs) bool {
+	values := make(map[string]float64, len(labelAutohideOperands)+1)
+	for name, read := range labelAutohideOperands {
+		values[name] = read(inputs)
+	}
+
+	if !rule.guard.holds(values) {
+		return true
+	}
+
+	values[rule.thresholdName] = labelAutohideValue(rule.thresholdFactors[0], values) *
+		labelAutohideValue(rule.thresholdFactors[1], values)
+
+	return !rule.hidesLabel(values)
+}
+
+// hidesLabel folds the skip comparisons together the way the source joins them.
+func (rule nativeLabelAutohideRule) hidesLabel(values map[string]float64) bool {
+	all := rule.hideJoin == "&&"
+	hides := all
+
+	for _, comparison := range rule.hideWhen {
+		if all {
+			hides = hides && comparison.holds(values)
+
+			continue
+		}
+
+		hides = hides || comparison.holds(values)
+	}
+
+	return hides
+}
+
+// withoutDimension drops one of the compared cell dimensions, standing for a
+// rule that stopped measuring it.
+func (rule nativeLabelAutohideRule) withoutDimension(index int) nativeLabelAutohideRule {
+	kept := make([]nativeLabelAutohideComparison, 0, len(rule.hideWhen))
+
+	for position, comparison := range rule.hideWhen {
+		if position != index {
+			kept = append(kept, comparison)
+		}
+	}
+
+	rule.hideWhen = kept
+
+	return rule
+}
+
+// withHideOperator rewrites how every cell dimension is compared against the
+// threshold.
+func (rule nativeLabelAutohideRule) withHideOperator(op string) nativeLabelAutohideRule {
+	rewritten := make([]nativeLabelAutohideComparison, 0, len(rule.hideWhen))
+
+	for _, comparison := range rule.hideWhen {
+		comparison.op = op
+		rewritten = append(rewritten, comparison)
+	}
+
+	rule.hideWhen = rewritten
+
+	return rule
+}
+
+// withHideJoin rewrites how the cell dimensions are joined, standing for a rule
+// that hides a cell only when both are under the threshold rather than either.
+func (rule nativeLabelAutohideRule) withHideJoin(join string) nativeLabelAutohideRule {
+	rule.hideJoin = join
+
+	return rule
+}
+
+// withGuardOperator rewrites how the multiplier decides whether autohide
+// applies.
+func (rule nativeLabelAutohideRule) withGuardOperator(op string) nativeLabelAutohideRule {
+	rule.guard.op = op
+
+	return rule
+}
+
+// withGuardBound rewrites the value the multiplier is measured against to
+// decide whether autohide applies.
+func (rule nativeLabelAutohideRule) withGuardBound(bound string) nativeLabelAutohideRule {
+	rule.guard.right = bound
+
+	return rule
+}
+
+// withThresholdFactor rewrites one of the two things the threshold is a product
+// of.
+func (rule nativeLabelAutohideRule) withThresholdFactor(
+	index int,
+	factor string,
+) nativeLabelAutohideRule {
+	rule.thresholdFactors[index] = factor
+
+	return rule
+}
+
+// labelAutohideValue reads a token that parsing has already accepted: a bound
+// name, or a numeric literal.
+func labelAutohideValue(token string, values map[string]float64) float64 {
+	if value, bound := values[token]; bound {
+		return value
+	}
+
+	literal, _ := strconv.ParseFloat(token, 64)
+
+	return literal
+}
+
+// nativeLabelAutohideMethodPattern matches the opening line of the
+// drawGridLabel: definition that carries the rule. The four-argument
+// forwarder above it and the two declarations in the @interface are excluded
+// by the alpha: argument and by refusing to cross a `;` or a brace.
+var nativeLabelAutohideMethodPattern = regexp.MustCompile(
+	`(?m)^- \(void\)drawGridLabel:[^{};]*alpha:\(CGFloat\)alpha[ \t]*\{`,
+)
+
+// nativeLabelAutohideMethodEndPattern matches the closing brace of an
+// Objective-C method definition, which sits in the first column.
+var nativeLabelAutohideMethodEndPattern = regexp.MustCompile(`(?m)^\}`)
+
+// labelAutohideComparisonOperators is the alternation every comparison in the
+// rule is read with; the longer spellings come first so `<=` is never read as
+// `<`.
+const labelAutohideComparisonOperators = `(<=|>=|==|!=|<|>)`
+
+// nativeLabelAutohideRulePattern matches the whole guard: the multiplier check,
+// the threshold it declares, and the comparison that skips the label.
+var nativeLabelAutohideRulePattern = regexp.MustCompile(
+	`if[ \t]*\([ \t]*([\w.]+)[ \t]*` + labelAutohideComparisonOperators + `[ \t]*([-\w.]+)[ \t]*\)[ \t]*\{\s*` +
+		`CGFloat[ \t]+(\w+)[ \t]*=[ \t]*([\w.]+)[ \t]*\*[ \t]*([\w.]+)[ \t]*;\s*` +
+		`if[ \t]*\(([^()]+)\)\s*\{?\s*return[ \t]*;\s*\}?\s*\}`,
+)
+
+// nativeLabelAutohideTermPattern matches one comparison of the skip condition.
+var nativeLabelAutohideTermPattern = regexp.MustCompile(
+	`^[ \t]*([-\w.]+)[ \t]*` + labelAutohideComparisonOperators + `[ \t]*([-\w.]+)[ \t]*$`,
+)
+
+// readNativeLabelAutohideRule reads the rule out of the macOS overlay, failing
+// the test when it cannot — a rule this pin cannot read is a rule it cannot
+// hold to the shared one, and passing quietly there would be worse than having
+// no pin at all.
+func readNativeLabelAutohideRule(t *testing.T) nativeLabelAutohideRule {
+	t.Helper()
+
+	rule, problem := parseNativeLabelAutohideRule(readNativeSource(t, labelAutohideNativeSource))
+	if problem != "" {
+		t.Fatalf("%s: %s", labelAutohideNativeSource, problem)
+	}
+
+	return rule
+}
+
+// parseNativeLabelAutohideRule reads the label-autohide rule out of an
+// Objective-C source. The second result describes why the rule could not be
+// read, and is empty when it could — an error value would buy nothing here,
+// since the only caller turns it straight into a test failure.
+func parseNativeLabelAutohideRule(source string) (nativeLabelAutohideRule, string) {
+	body, problem := nativeLabelAutohideMethodBody(source)
+	if problem != "" {
+		return nativeLabelAutohideRule{}, problem
+	}
+
+	matches := nativeLabelAutohideRulePattern.FindAllStringSubmatch(body, -1)
+
+	if len(matches) != 1 {
+		return nativeLabelAutohideRule{}, fmt.Sprintf(
+			"%s holds %d autohide guards shaped `if (<multiplier> <op> <literal>) { CGFloat <threshold> = <a> * <b>; if (<comparisons>) return; }`, want exactly 1 (rewritten?)",
+			labelAutohideNativeMethod,
+			len(matches),
+		)
+	}
+
+	match := matches[0]
+
+	rule := nativeLabelAutohideRule{
+		guard: nativeLabelAutohideComparison{
+			left:  match[1],
+			op:    match[2],
+			right: match[3],
+		},
+		thresholdName:    match[4],
+		thresholdFactors: [2]string{match[5], match[6]},
+	}
+
+	rule.hideWhen, rule.hideJoin, problem = parseNativeLabelAutohideCondition(match[7])
+	if problem != "" {
+		return nativeLabelAutohideRule{}, problem
+	}
+
+	return rule, validateNativeLabelAutohideRule(rule)
+}
+
+// nativeLabelAutohideMethodBody returns the body of the drawGridLabel:
+// definition the rule lives in. Addressing it by name means a rename surfaces
+// here rather than as a silent pass over a method that no longer exists.
+func nativeLabelAutohideMethodBody(source string) (string, string) {
+	header := nativeLabelAutohideMethodPattern.FindStringIndex(source)
+	if header == nil {
+		return "", "no `- (void)drawGridLabel:...alpha:(CGFloat)alpha {` definition to read the autohide rule from (renamed?)"
+	}
+
+	body := source[header[1]:]
+
+	end := nativeLabelAutohideMethodEndPattern.FindStringIndex(body)
+	if end == nil {
+		return "", fmt.Sprintf("the %s definition is never closed", labelAutohideNativeMethod)
+	}
+
+	return body[:end[0]], ""
+}
+
+// parseNativeLabelAutohideCondition splits the skip condition into its
+// comparisons and the operator joining them.
+func parseNativeLabelAutohideCondition(
+	condition string,
+) ([]nativeLabelAutohideComparison, string, string) {
+	join := "||"
+	if !strings.Contains(condition, join) && strings.Contains(condition, "&&") {
+		join = "&&"
+	}
+
+	if strings.Contains(condition, "||") && strings.Contains(condition, "&&") {
+		return nil, "", fmt.Sprintf(
+			"the skip condition `%s` mixes || and &&, which this pin does not read",
+			strings.TrimSpace(condition),
+		)
+	}
+
+	var comparisons []nativeLabelAutohideComparison
+
+	for term := range strings.SplitSeq(condition, join) {
+		parsed := nativeLabelAutohideTermPattern.FindStringSubmatch(term)
+		if parsed == nil {
+			return nil, "", fmt.Sprintf(
+				"`%s` in the skip condition is not a comparison this pin reads",
+				strings.TrimSpace(term),
+			)
+		}
+
+		comparisons = append(comparisons, nativeLabelAutohideComparison{
+			left: parsed[1], op: parsed[2], right: parsed[3],
+		})
+	}
+
+	return comparisons, join, ""
+}
+
+// validateNativeLabelAutohideRule checks that every name and operator the rule
+// was written with is one this pin can evaluate. It is what stops a rewritten
+// rule from being run with a value invented for it.
+func validateNativeLabelAutohideRule(rule nativeLabelAutohideRule) string {
+	// The guard is evaluated before the threshold exists, which is also true of
+	// the Objective-C it was read from — the threshold is declared inside the
+	// guard. A guard naming it would be valued at nothing rather than reported.
+	if rule.guard.left == rule.thresholdName || rule.guard.right == rule.thresholdName {
+		return fmt.Sprintf(
+			"the guard `%s` reads %s, which the rule only declares inside it",
+			rule.guard, rule.thresholdName,
+		)
+	}
+
+	comparisons := append([]nativeLabelAutohideComparison{rule.guard}, rule.hideWhen...)
+
+	tokens := []string{rule.thresholdFactors[0], rule.thresholdFactors[1]}
+
+	for _, comparison := range comparisons {
+		if _, known := labelAutohideComparators[comparison.op]; !known {
+			return fmt.Sprintf(
+				"`%s` compares with %q, which this pin does not read",
+				comparison,
+				comparison.op,
+			)
+		}
+
+		tokens = append(tokens, comparison.left, comparison.right)
+	}
+
+	for _, token := range tokens {
+		if _, bound := labelAutohideOperands[token]; bound {
+			continue
+		}
+
+		if token == rule.thresholdName {
+			continue
+		}
+
+		_, parseErr := strconv.ParseFloat(token, 64)
+		if parseErr == nil {
+			continue
+		}
+
+		return fmt.Sprintf(
+			"the rule reads %s, which this pin cannot value; it knows %s, the threshold it declares, and numeric literals",
+			token,
+			strings.Join(sortedLabelAutohideOperands(), ", "),
+		)
+	}
+
+	return ""
+}
+
+// sortedLabelAutohideOperands lists the pin's vocabulary in a stable order for
+// failure messages.
+func sortedLabelAutohideOperands() []string {
+	names := make([]string, 0, len(labelAutohideOperands))
+	for name := range labelAutohideOperands {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+// nativeLabelAutohideMethodSource wraps a body in the method definition the
+// parser looks for, so a test can hand it a rule shaped differently from the
+// one in the tree.
+func nativeLabelAutohideMethodSource(body string) string {
+	return "- (void)drawGridLabel:(NSString *)label\n" +
+		"             inCellRect:(NSRect)cellRect\n" +
+		"              isMatched:(BOOL)isMatched\n" +
+		"    matchedPrefixLength:(int)matchedPrefixLength\n" +
+		"                  alpha:(CGFloat)alpha {\n" +
+		body + "\n}\n"
+}

--- a/internal/architecture/native_constants_test.go
+++ b/internal/architecture/native_constants_test.go
@@ -91,8 +91,8 @@ func objcEnumIntConstants(t *testing.T, repoRelPath, enumName string) map[string
 // cHeaderIntConstants and objcEnumIntConstants below cover the two shapes that
 // exist today, a numeric macro and an NS_ENUM member, and a copy that is a
 // rule rather than a constant brings its own pattern rather than a second
-// reader. The label-autohide copy that ADR 0007 still owes a pin (#1298) is
-// that third shape.
+// reader. label_autohide_rule_test.go is that third shape: it reads its copy
+// through here and then runs it, because a rule has no constant to compare.
 func readNativeSource(t *testing.T, repoRelPath string) string {
 	t.Helper()
 


### PR DESCRIPTION
## Description

This PR adds a guardrail so the macOS overlay cannot quietly start hiding
different recursive-grid key labels from Linux and Windows. Whether a cell is
big enough for its label is one rule — a multiplier times the label font size,
which both cell dimensions have to reach, with a non-positive multiplier
meaning "always show" — and it is written twice: once in shared Go that the
Linux and Windows overlays call, and once in Objective-C for macOS. The two
agreed, but nothing held them there, so a change to either would have shown one
person a labelled cell and another a blank one from the same configuration.

The Objective-C rule is now read out of the source and run against the same
questions as the shared one, and any answer they give differently fails the
build. Nothing changes on screen and no option changes meaning.

One deliberate limitation: the guardrail reads the Objective-C rule by its
shape, so rewriting that code in a way that keeps the behaviour fails the test
until the guardrail is taught the new shape. That is the cost of pinning a rule
that lives in another language, and the failure names exactly what it expected
to find.

## Related Issues

Closes #1298

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `test` — Adding or updating tests

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no new Go file is build-tagged; the guardrail reads the macOS source as text so it runs on every host.
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability changed.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — ADR 0007 records this pin as landed, and its stale line about earlier work is corrected; no user-facing doc changed, because no behaviour or option did.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

This is the second of the two language-boundary pins ADR 0007 owes, after the
hint-placement vocabulary. That one pinned constants, which two small
extractors could read; this copy is a comparison rule with a runtime property,
so no constant extractor could be aimed at it. It brings its own reader
instead, and shares the native-source entry point with the first pin.

Nothing in the test is a hand-written expectation. The Objective-C rule is
parsed into something the test can evaluate, and the shared Go implementation
is the only expectation — which makes the pin bidirectional: change either side
alone and the two stop answering alike.

The teeth were verified two ways. By hand, seven breaks to the real Objective-C
source — the comparison loosened, one of the two dimensions dropped, the
multiplier check inverted, its bound raised so smaller multipliers stopped
hiding anything, the threshold taken from another font, the method renamed, and
the guard folded into the comparison — each failed with a message naming the
case and the two sides. And durably, in the test file itself: one test mutates
the rule it read and fails if no case can tell the mutant apart from the shared
implementation, so the case list cannot rot into one that agrees with
everything. The raised-bound break is the one that first slipped through, and
the case that catches it was added because of it.

One part of the rule is pinned by shape rather than by behaviour, and the test
says so: with a cell size and a font size both non-negative, deleting the
multiplier guard outright answers identically to keeping it on every input
either implementation can be handed. Reading the guard's presence is what
catches that.

`just lint-cross` was run alongside `just ci`, since the guardrail package now
compiles against a renderer that has a macOS-specific file.

Two things noticed and deliberately left alone. The sub-key preview autohide
threshold is the same shape of language-boundary copy — Linux Go and macOS
Objective-C measure a sub-cell exactly the same way — and it has no pin; ADR
0007 does not name it, so this PR does not claim the boundary is now fully
covered. (Windows measuring the whole cell instead is a documented, deliberate
difference, not a copy that drifted.) And ADR 0007's context and
considered-options sections still describe the pre-#1292 state in the present
tense; that is the situation the decision was taken in, so past-tensing it
would rewrite the record rather than correct it — only the consequences
section, which tracks landed-versus-owed work, is updated here.
