### PR TITLE
test(architecture): compile the foundation walk against the pruning helper

### DIFF
--- a/internal/architecture/foundation_slice_test.go
+++ b/internal/architecture/foundation_slice_test.go
@@ -290,7 +290,7 @@ func goPackageDirs(t *testing.T) []packageDir {
 			}
 
 			if entry.IsDir() {
-				if isSkippedWalkDir(entry.Name()) {
+				if isSkippedWalkDir(repoRoot, path) {
 					return filepath.SkipDir
 				}
 


### PR DESCRIPTION
## Description

This PR restores `main` to a compiling state. Two changes that were each green on their own merge commit combined into a broken one: #1316 gave the helper that prunes other checkouts out of repository walks an extra argument, and #1317 added a new caller written against the old signature. Since they landed, the architecture guardrail package has failed to build, so any test run covering it reports a build failure instead of results.

The fix passes the walk root alongside the directory path, matching every other caller. No guardrail changes what it checks.

## Related Issues

None. The breakage is the combination of #1316 and #1317, neither of which is wrong on its own.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, this repairs an existing guardrail's call site; there is no new behaviour to cover
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Worth noting for its own sake: the CI run on `main` for #1317 did report this failure. Nothing merged on top of it in the meantime, but the window between "main is red" and "someone notices" is exactly the gap that lets a second unrelated change look like the culprit.

The combination was not reachable from either PR's own checks — GitHub tests each PR against its merge commit with `main` as it stood at the time, and neither signature nor caller was touched by the other's diff.
