### PR TITLE
refactor(overlay): compute point-centered rectangles in one place

### DIFF
--- a/docs/adr/0007-a-shared-derivation-has-one-implementation.md
+++ b/docs/adr/0007-a-shared-derivation-has-one-implementation.md
@@ -103,3 +103,21 @@ are the precedent, not the exception.
   cells rather than divide the rectangle themselves. Naming the rule before finishing the work
   is the point: the next platform backend should not have to infer it from two
   packages that never explained themselves.
+- **A near-miss earns a second name, not one implementation.** #1299 finished
+  the centering sweep #1288 started, and what it turned on is a pixel. Two
+  forms of "put this rectangle on that point" were in use: `center ± half`, and
+  the `center - half, + size` the shared `badge.CenteredIn` already spoke. They
+  agree on the near edge always and on the far edge only when the dimension is
+  even, so collapsing them would have moved the monitor-select panel's right
+  edge and a hint badge's by a pixel. Both are named now — `badge.CenteredOn`
+  beside `badge.CenteredIn`, each doc comment pointing at the other — and the
+  sites that hang a static rectangle on a point (hint badges, the hint boundary
+  highlight, the monitor-select panel) call one of them on both Linux and
+  Windows. The animated indicators are left out on purpose, and each says so
+  where it is written: the virtual pointer floors its half at one pixel, and
+  the mouse-action indicator rounds a float diameter on Linux and places a
+  native window on Windows, so neither is this derivation wearing a different
+  spelling. This rule asks for one implementation per derivation; two
+  derivations that merely look alike are the case where the honest answer is to
+  say so out loud, because a near-miss is exactly what a later reader
+  "simplifies".

--- a/internal/adapter/overlay/linux/animation_cgo.go
+++ b/internal/adapter/overlay/linux/animation_cgo.go
@@ -109,6 +109,10 @@ func applyOpacity(color uint32, opacity float64) uint32 {
 // mouseActionIndicatorRect returns the square bounding box of a mouse-action
 // indicator of the given diameter centered on point. A circle indicator is
 // drawn as a rounded rect with radius = diameter/2 within this box.
+//
+// Not badge.CenteredOn: the diameter animates as a float and each edge is
+// rounded separately, which keeps the odd pixel that integer halving drops —
+// the box has to track a growing circle smoothly rather than land on a pixel.
 func mouseActionIndicatorRect(point image.Point, diameter float64) image.Rectangle {
 	half := diameter / halfDivisor
 	minX := int(math.Round(float64(point.X) - half))

--- a/internal/adapter/overlay/linux/hint_arrow_test.go
+++ b/internal/adapter/overlay/linux/hint_arrow_test.go
@@ -161,6 +161,26 @@ func TestHintBadgePlacement_ArrowBaseClampedToFlatEdge(t *testing.T) {
 	}
 }
 
+// TestHintBadgePlacement_OddBadgeSizeDropsItsLastPixel pins the rounding the
+// badge is placed with. The badge hangs on its target point as center ± half,
+// so a badge sized to an odd width or height is drawn one pixel short of that
+// size. The alternative rounding (badge.CenteredIn's center - half, + size)
+// would keep that pixel and move the badge's right and bottom edges, so this
+// test is what stops the two being swapped.
+func TestHintBadgePlacement_OddBadgeSizeDropsItsLastPixel(t *testing.T) {
+	target := image.Pt(100, 100)
+
+	centered, _, _ := hintBadgePlacement(target, 41, 21, 4, config.HintPlacementCenter)
+	if want := image.Rect(80, 90, 120, 110); centered != want {
+		t.Errorf("center placement badge = %v, want %v", centered, want)
+	}
+
+	below, _, _ := hintBadgePlacement(target, 41, 21, 4, config.HintPlacementBottom)
+	if want := image.Rect(80, 106, 120, 126); below != want {
+		t.Errorf("bottom placement badge = %v, want %v", below, want)
+	}
+}
+
 func TestHintTailEdge(t *testing.T) {
 	target := image.Pt(200, 150)
 

--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -25,26 +25,14 @@ import (
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
+// subgridCellBackground is the translucent fill painted behind a subgrid cell.
+const subgridCellBackground uint32 = 0x10000000
+
 const (
-	subgridCellBackground           uint32 = 0x10000000
-	hexColorOpaque                  uint32 = 0xFFFFFFFF
-	hexColorRepeatCount                    = 2
-	hexColorLenShort                       = 3
-	hexColorLenNoAlpha                     = 6
-	hexColorLenFull                        = 8
-	subgridFontScale                       = 0.7
-	subgridLineWidth                       = 1
-	keyboardChanBuffer                     = 64
-	badgePaddingSides                      = 2
-	autoPaddingHorizontalMultiplier        = 0.6
-	autoPaddingVerticalMultiplier          = 0.35
-	autoPaddingMinHorizontal               = 6
-	autoPaddingMinVertical                 = 4
-	textWidthMultiplier                    = 0.7
-	textHeightMultiplier                   = 1.4
-	halfDivisor                            = 2
-	centeredRectHalf                       = 0.5
-	paddingMultiplier                      = 2
+	subgridFontScale   = 0.7
+	keyboardChanBuffer = 64
+	halfDivisor        = 2
+	paddingMultiplier  = 2
 	// hintPlacementGap is the pixel gap between a hint badge and its target
 	// point for top/bottom placement, mirroring the macOS overlay.
 	hintPlacementGap = 1
@@ -780,12 +768,15 @@ func monitorSelectPanelLayout(
 		panelH = maxH
 	}
 
-	centerX := monitor.Min.X + monitor.Dx()/halfDivisor
-	centerY := monitor.Min.Y + monitor.Dy()/halfDivisor
-	panel := image.Rect(
-		centerX-panelW/halfDivisor, centerY-panelH/halfDivisor,
-		centerX+panelW/halfDivisor, centerY+panelH/halfDivisor,
+	// The panel hangs on the monitor's center point rather than being fitted
+	// into the monitor rectangle: badge.CenteredOn, not badge.CenteredIn. The
+	// two differ by a pixel on an odd panel size, and this is the one the panel
+	// has always been drawn with.
+	center := image.Pt(
+		monitor.Min.X+monitor.Dx()/halfDivisor,
+		monitor.Min.Y+monitor.Dy()/halfDivisor,
 	)
+	panel := badge.CenteredOn(center, panelW, panelH)
 
 	// Corner radius: auto = min(panelH/2, 16), matching darwin.
 	radius := float64(style.BorderRadius) * scale
@@ -1226,7 +1217,8 @@ func hintBadgePlacement(
 	halfW := badgeWidth / halfDivisor
 	halfH := badgeHeight / halfDivisor
 	centerX := target.X
-	centerY := target.Y
+
+	var centerY int
 
 	switch placement {
 	case config.HintPlacementTop:
@@ -1237,12 +1229,15 @@ func hintBadgePlacement(
 		// Badge sits below the target; arrow points up at the target.
 		centerY = target.Y + hintPlacementGap + hintArrowHeight + halfH
 	default:
-		badge := image.Rect(centerX-halfW, centerY-halfH, centerX+halfW, centerY+halfH)
-
-		return badge, hintArrowTriangle{}, false
+		return badge.CenteredOn(target, badgeWidth, badgeHeight), hintArrowTriangle{}, false
 	}
 
-	badge := image.Rect(centerX-halfW, centerY-halfH, centerX+halfW, centerY+halfH)
+	// The badge hangs on the target point rather than being fitted into the
+	// element's box: badge.CenteredOn, not badge.CenteredIn. The two differ by
+	// a pixel on an odd badge size, and this is the one hints have always been
+	// drawn with. halfW and halfH stay because the arrow and the top/bottom
+	// offset are measured from them, not from the rectangle.
+	badgeRect := badge.CenteredOn(image.Pt(centerX, centerY), badgeWidth, badgeHeight)
 
 	// Keep the arrow base within the badge's flat edge (inside the corner
 	// radius). The caller caps the radius (see hintBadgeRadius) so a flat edge
@@ -1254,21 +1249,21 @@ func hintBadgePlacement(
 	}
 
 	if halfBase < 1 {
-		return badge, hintArrowTriangle{}, false
+		return badgeRect, hintArrowTriangle{}, false
 	}
 
 	var arrow hintArrowTriangle
 
 	switch placement {
 	case config.HintPlacementBottom:
-		baseY := badge.Min.Y
+		baseY := badgeRect.Min.Y
 		arrow = hintArrowTriangle{
 			baseLeft:  image.Pt(centerX-halfBase, baseY),
 			tip:       image.Pt(centerX, baseY-hintArrowHeight),
 			baseRight: image.Pt(centerX+halfBase, baseY),
 		}
 	case config.HintPlacementTop:
-		baseY := badge.Max.Y
+		baseY := badgeRect.Max.Y
 		arrow = hintArrowTriangle{
 			baseLeft:  image.Pt(centerX-halfBase, baseY),
 			tip:       image.Pt(centerX, baseY+hintArrowHeight),
@@ -1276,7 +1271,7 @@ func hintBadgePlacement(
 		}
 	}
 
-	return badge, arrow, true
+	return badgeRect, arrow, true
 }
 
 func expandRect(rect image.Rectangle, amount int) image.Rectangle {

--- a/internal/adapter/overlay/linux/monitor_select_test.go
+++ b/internal/adapter/overlay/linux/monitor_select_test.go
@@ -1,0 +1,44 @@
+//go:build linux
+
+package linux
+
+import (
+	"image"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+)
+
+// TestMonitorSelectPanelLayout_OddPanelWidthDropsItsLastPixel pins the rounding
+// the panel is placed with. The panel hangs on the monitor's center point as
+// center ± half, so a panel sized to an odd width is drawn one pixel narrower
+// than that width — here a 7 px wide panel lands 6 px wide. Fitting it into the
+// monitor rectangle instead (badge.CenteredIn) would keep that pixel and move
+// the panel's right edge, so this test is what stops the two being swapped.
+func TestMonitorSelectPanelLayout_OddPanelWidthDropsItsLastPixel(t *testing.T) {
+	t.Parallel()
+
+	monitor := image.Rect(0, 0, 100, 100)
+	style := manager.MonitorSelectStyle{FontSize: 10}
+
+	panel, labelRect, subtitleRect, radius := monitorSelectPanelLayout(
+		monitor, "A", "", style, 1,
+	)
+
+	// Label 7 px wide, 14 px tall, no padding: a 7x14 panel centered on (50, 50).
+	if want := image.Rect(47, 43, 53, 57); panel != want {
+		t.Errorf("panel = %v, want %v", panel, want)
+	}
+
+	if want := image.Rect(47, 43, 53, 57); labelRect != want {
+		t.Errorf("label rect = %v, want %v", labelRect, want)
+	}
+
+	if !subtitleRect.Empty() {
+		t.Errorf("subtitle rect = %v, want empty", subtitleRect)
+	}
+
+	if radius != 0 {
+		t.Errorf("radius = %v, want 0", radius)
+	}
+}

--- a/internal/adapter/overlay/linux/overlay_shared_cgo.go
+++ b/internal/adapter/overlay/linux/overlay_shared_cgo.go
@@ -322,12 +322,7 @@ func (o *sharedOverlay) drawHints(
 		// translate it onto the active monitor.
 		pos := hint.Position().Add(o.originOffset)
 		if style.BoundaryHighlightEnabled() {
-			boundary := image.Rect(
-				pos.X-hint.Size().X/2,
-				pos.Y-hint.Size().Y/2,
-				pos.X+hint.Size().X/2,
-				pos.Y+hint.Size().Y/2,
-			)
+			boundary := badge.CenteredOn(pos, hint.Size().X, hint.Size().Y)
 			o.drawRect(
 				boundary,
 				badge.ParseHexARGB(style.BoundaryBackgroundColor()),
@@ -815,6 +810,8 @@ func (o *sharedOverlay) drawVirtualPointer(vp recursivegridcomponent.VirtualPoin
 
 	fontName := ports.ResolveFont(vp.FontName, false)
 	fontSize := float64(vp.Size)
+	// Not badge.CenteredOn: the half is floored at 1 so a pointer configured to
+	// size 0 or 1 still has a box to draw its glyph in.
 	halfSize := max(vp.Size/2, 1)
 	vpBounds := image.Rect(
 		vp.Position.X-halfSize,

--- a/internal/adapter/overlay/render/badge/badge.go
+++ b/internal/adapter/overlay/render/badge/badge.go
@@ -120,6 +120,10 @@ func Bounds(
 // same pixel on every backend. A badge larger than its container overhangs it
 // rather than being clamped: the callers draw label plates, and a plate that
 // outgrew its cell is the autohide threshold's problem, not this function's.
+//
+// This is not CenteredOn with the container's center substituted for the
+// point: this one keeps the requested size, CenteredOn drops the last pixel of
+// an odd one. See CenteredOn.
 func CenteredIn(container image.Rectangle, width, height int) image.Rectangle {
 	centerX := container.Min.X + container.Dx()/halfDivisor
 	centerY := container.Min.Y + container.Dy()/halfDivisor
@@ -127,6 +131,28 @@ func CenteredIn(container image.Rectangle, width, height int) image.Rectangle {
 	originY := centerY - height/halfDivisor
 
 	return image.Rect(originX, originY, originX+width, originY+height)
+}
+
+// CenteredOn returns the rectangle spanning half of width and half of height
+// either side of center: what a backend draws when it hangs something on a
+// point rather than fitting it into a container — a hint badge on its target
+// element, the monitor-select panel on its monitor.
+//
+// It is deliberately not CenteredIn's point form, and the two are not
+// interchangeable. This is center ± half, so an odd width or height loses its
+// last pixel — a 41-wide badge is drawn 40 wide — where CenteredIn is
+// center - half, + size and keeps it. Both put the near edge on the same
+// pixel, which is what makes the difference easy to miss: only the far edge
+// moves, and only on odd sizes. This function exists so that pixel is a
+// documented choice rather than something the next reader "simplifies" away.
+func CenteredOn(center image.Point, width, height int) image.Rectangle {
+	halfWidth := width / halfDivisor
+	halfHeight := height / halfDivisor
+
+	return image.Rect(
+		center.X-halfWidth, center.Y-halfHeight,
+		center.X+halfWidth, center.Y+halfHeight,
+	)
 }
 
 // BorderRadius resolves a configured border-radius value for the given

--- a/internal/adapter/overlay/render/badge/badge_test.go
+++ b/internal/adapter/overlay/render/badge/badge_test.go
@@ -255,6 +255,126 @@ func TestCenteredIn_CentersAndKeepsSize(t *testing.T) {
 	}
 }
 
+func TestCenteredOn_SpansHalfEitherSideOfThePoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		center        image.Point
+		width, height int
+		want          image.Rectangle
+	}{
+		{
+			name:   "even size keeps the requested size",
+			center: image.Pt(100, 100),
+			width:  40,
+			height: 20,
+			want:   image.Rect(80, 90, 120, 110),
+		},
+		{
+			name:   "odd width drops its last pixel",
+			center: image.Pt(100, 100),
+			width:  41,
+			height: 20,
+			want:   image.Rect(80, 90, 120, 110),
+		},
+		{
+			name:   "odd height drops its last pixel",
+			center: image.Pt(100, 100),
+			width:  40,
+			height: 21,
+			want:   image.Rect(80, 90, 120, 110),
+		},
+		{
+			name:   "odd center coordinates shift the whole rectangle",
+			center: image.Pt(101, 99),
+			width:  40,
+			height: 20,
+			want:   image.Rect(81, 89, 121, 109),
+		},
+		{
+			name:   "negative center coordinates",
+			center: image.Pt(-100, -40),
+			width:  30,
+			height: 10,
+			want:   image.Rect(-115, -45, -85, -35),
+		},
+		{
+			name:   "zero size collapses onto the point",
+			center: image.Pt(7, 9),
+			width:  0,
+			height: 0,
+			want:   image.Rect(7, 9, 7, 9),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := badge.CenteredOn(testCase.center, testCase.width, testCase.height)
+			if got != testCase.want {
+				t.Errorf("CenteredOn(%v, %d, %d) = %v, want %v",
+					testCase.center, testCase.width, testCase.height, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestCenteredOn_IsNotCenteredInOnOddSizes pins the near-miss the two functions
+// are: they agree on the near edge always and on the far edge only when both
+// dimensions are even, so swapping one for the other silently moves a panel or
+// badge edge by a pixel on odd sizes.
+func TestCenteredOn_IsNotCenteredInOnOddSizes(t *testing.T) {
+	t.Parallel()
+
+	container := image.Rect(0, 0, 100, 100)
+	center := image.Pt(50, 50)
+
+	tests := []struct {
+		name          string
+		width, height int
+		wantOn        image.Rectangle
+		wantIn        image.Rectangle
+	}{
+		{
+			name:   "even dimensions agree",
+			width:  40,
+			height: 20,
+			wantOn: image.Rect(30, 40, 70, 60),
+			wantIn: image.Rect(30, 40, 70, 60),
+		},
+		{
+			name:   "odd dimensions disagree on the far edge only",
+			width:  41,
+			height: 21,
+			wantOn: image.Rect(30, 40, 70, 60),
+			wantIn: image.Rect(30, 40, 71, 61),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotOn := badge.CenteredOn(center, testCase.width, testCase.height)
+			if gotOn != testCase.wantOn {
+				t.Errorf("CenteredOn = %v, want %v", gotOn, testCase.wantOn)
+			}
+
+			gotIn := badge.CenteredIn(container, testCase.width, testCase.height)
+			if gotIn != testCase.wantIn {
+				t.Errorf("CenteredIn = %v, want %v", gotIn, testCase.wantIn)
+			}
+
+			if gotOn.Min != gotIn.Min {
+				t.Errorf("near edges must agree: CenteredOn %v, CenteredIn %v",
+					gotOn.Min, gotIn.Min)
+			}
+		})
+	}
+}
+
 func TestBorderRadius_Modes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/overlay/windows/features.go
+++ b/internal/adapter/overlay/windows/features.go
@@ -17,24 +17,12 @@ import (
 // Win32/GDI rendering for hints and recursive-grid overlays on Windows.
 // Does not own window lifecycle or grid rendering (see overlay.go).
 const (
-	winHexColorOpaque                  = 0xFFFFFFFF
-	winHexRepeatCount                  = 2
-	winHexColorLenShort                = 3
-	winHexColorLenNoAlpha              = 6
-	winHexColorLenFull                 = 8
-	winAutoPaddingHorizontalMultiplier = 0.6
-	winAutoPaddingVerticalMultiplier   = 0.35
-	winAutoPaddingMinHorizontal        = 6
-	winAutoPaddingMinVertical          = 4
-	winTextWidthMultiplier             = 0.7
-	winTextHeightMultiplier            = 1.4
-	winHalfDivisor                     = 2
-	winPaddingMultiplier               = 2
-	winSubKeyPreviewPaddingBottom      = 4
-	winAutoRadiusBadgeCap              = 6.0
-	winAutoRadiusBoundaryCap           = 4.0
-	winMouseActionSquareRadiusScale    = 0.18
-	winMouseActionMinSquareRadius      = 2.0
+	winPaddingMultiplier            = 2
+	winSubKeyPreviewPaddingBottom   = 4
+	winAutoRadiusBadgeCap           = 6.0
+	winAutoRadiusBoundaryCap        = 4.0
+	winMouseActionSquareRadiusScale = 0.18
+	winMouseActionMinSquareRadius   = 2.0
 )
 
 // DrawHints renders the hint overlay using GDI, mirroring the cross-platform
@@ -75,23 +63,22 @@ func (o *winOverlay) DrawHints(
 			continue
 		}
 
+		// The element's own box, rebuilt from what the hint carries:
+		// hint.Position() is the element center and hint.Size() its bounds. The
+		// boundary highlight draws it and the badge is anchored to its corner.
+		element := badge.CenteredOn(hint.Position(), hint.Size().X, hint.Size().Y)
+
 		if style.BoundaryHighlightEnabled() {
-			boundary := image.Rect(
-				hint.Position().X-hint.Size().X/2,
-				hint.Position().Y-hint.Size().Y/2,
-				hint.Position().X+hint.Size().X/2,
-				hint.Position().Y+hint.Size().Y/2,
-			)
 			bdr := badge.BorderRadius(
-				style.BoundaryBorderRadius(), boundary, winAutoRadiusBoundaryCap,
+				style.BoundaryBorderRadius(), element, winAutoRadiusBoundaryCap,
 			)
 			o.window.FillRoundedRect(
-				boundary, bdr, badge.ParseHexARGB(style.BoundaryBackgroundColor()),
+				element, bdr, badge.ParseHexARGB(style.BoundaryBackgroundColor()),
 			)
 
 			if bw := float64(max(style.BoundaryBorderWidth(), 0)); bw > 0 {
 				o.window.StrokeRoundedRect(
-					boundary, bdr, badge.ParseHexARGB(style.BoundaryBorderColor()), bw,
+					element, bdr, badge.ParseHexARGB(style.BoundaryBorderColor()), bw,
 				)
 			}
 		}
@@ -110,11 +97,14 @@ func (o *winOverlay) DrawHints(
 
 		// Anchor the badge at the element's top-left corner rather than its
 		// center so it does not cover the element's own content (e.g. the digit
-		// on a calculator button). hint.Position() is the element center and
-		// hint.Size() its bounds, so the top-left is center minus half-size.
-		originX := hint.Position().X - hint.Size().X/winHalfDivisor
-		originY := hint.Position().Y - hint.Size().Y/winHalfDivisor
-		bounds := image.Rect(originX, originY, originX+badgeWidth, originY+badgeHeight)
+		// on a calculator button) — deliberately not badge.CenteredIn, which
+		// would put the badge in the middle of the element.
+		bounds := image.Rect(
+			element.Min.X,
+			element.Min.Y,
+			element.Min.X+badgeWidth,
+			element.Min.Y+badgeHeight,
+		)
 
 		textColor := style.TextColor()
 		if hint.MatchedPrefix() != "" {
@@ -233,6 +223,8 @@ func (o *winOverlay) DrawRecursiveGrid(
 		fontName := ports.ResolveFont(virtualPointer.FontName, false)
 
 		fontSize := float64(virtualPointer.Size)
+		// Not badge.CenteredOn: the half is floored at 1 so a pointer
+		// configured to size 0 or 1 still has a box to draw its glyph in.
 		halfSize := max(virtualPointer.Size/2, 1) //nolint:mnd
 
 		vpBounds := image.Rect(

--- a/internal/adapter/overlay/windows/manager.go
+++ b/internal/adapter/overlay/windows/manager.go
@@ -627,6 +627,9 @@ func (m *Manager) DrawMouseActionIndicator(
 	winSize := int(maxIndicatorSize) + int(borderWidth)*2 + paddingFactor
 	halfWinSize := winSize / 2 //nolint:mnd // divide by 2
 
+	// Not badge.CenteredOn: this places a native window, which takes an origin
+	// and a size rather than a rectangle, and the animation inside it measures
+	// from the same half.
 	posX := point.X - halfWinSize
 	posY := point.Y - halfWinSize
 


### PR DESCRIPTION
## Description

This PR removes the last duplicates of a piece of overlay arithmetic. Linux and Windows each hung a rectangle on a point with their own hand-written maths — the hint badge on its target, the boundary highlight around an element, the monitor-select panel on its monitor — and every one of those was a copy of the same two lines. They now share one implementation, next to the one the previous sweep already added for fitting a badge inside a container.

Nothing moves on screen, on any platform. The two forms of "centre this on that" are not interchangeable: one keeps the requested size, the other spans half either side of the point and so loses the last pixel of an odd width or height. They agree on the near edge and differ only on the far one, which is why the difference was easy to miss. Both are named now, each pointing at the other, and every converted site kept the exact rounding it already had — proven by tests over odd sizes at the shared function and at both Linux sites.

One deliberate limitation: the animated indicators are left alone. The virtual pointer floors its half at one pixel so a size-0 pointer still draws, and the mouse-action indicator rounds a float diameter on Linux and places a native window on Windows. None of those is this derivation in different handwriting, and each now carries a comment saying so rather than being silently skipped. macOS computes its equivalents in Objective-C and is out of scope — ADR 0007 records why the rule stops at the language boundary.

## Related Issues

Closes #1299

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this PR adds no port capability; it moves existing pure arithmetic into a package both backends already import.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — ADR 0007 records what the sweep finished and why the two forms stayed two.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Which of the three named sites were the same question.** The issue names three point-centering variants and says the monitor-select panel is not a drop-in. Reading them, the split runs differently: the panel and the Linux hint badge are *both* written as `center ± half`, so neither is a drop-in for the container-fitting helper, and the Windows hint origin is not a centering at all — it reconstructs the element's own box from the centre point and size the hint carries, then anchors the badge at its corner. What all three share is the point-to-rectangle step, so that is what moved: a second named derivation beside the first, `CenteredOn` next to `CenteredIn`, with each doc comment warning about the other. Collapsing them into one would have moved the panel's right edge and a hint badge's by a pixel, which the issue rules out.

**Two extra call sites.** The boundary-highlight rectangle on each backend is the same derivation, written a third and fourth time, and is converted here too. Without them the shared function would have had callers on one backend only, which by ADR 0007's own rule would put it in the Linux package rather than the shared one. Both conversions are byte-identical arithmetic.

**Verification.** Where a site was converted, the rectangles were compared rather than assumed. The shared function carries a table over even, odd, negative and zero sizes, plus a test asserting exactly how it differs from the container-fitting one — same near edge, far edge one pixel short, and only on odd sizes. On the Linux side, two characterization tests pin the exact rectangles (a 41x21 badge, a 7 px wide panel drawn 6 px wide); both were written against `main`, run green there, and run green after the move. Neither backend compiles on the macOS host this was written on, so in addition to `just ci`: `just lint-cross` reports 0 issues on both legs, `just test-linux` and `just test-linux-nocgo` run the real Linux suites, and `just test-windows-compile` links the Windows test binaries.

**Dead constants.** `centeredRectHalf` is gone, and so are 13 other constants in the same file and 11 in the Windows one — all leftovers from #1295 moving the hex-colour and text-sizing maths into the shared package, all verified declaration-only repo-wide across build tags and test files. `winHalfDivisor` went too: converting its only two uses left it declaration-only as well.

**Two things spotted and left alone.** Linux and Windows draw a hint badge and its boundary highlight one pixel narrower than macOS does on an odd size — macOS keeps that pixel, because it does the same arithmetic in floating point with the full size. That is a real cross-platform difference, it predates this PR, and closing it means moving pixels, so it wants its own issue. Separately, the Windows backend never reads `hints.placement`: it always anchors the badge at the element's top-left corner and draws no connector arrow, where macOS and Linux honour `top` / `center` / `bottom`. That is a feature gap rather than a rounding one, and it is not in the ownership table in `docs/CROSS_PLATFORM.md`.
