### PR TITLE
refactor(hints): declare the search input's position vocabulary once

### DIFF
--- a/internal/adapter/overlay/adapter.go
+++ b/internal/adapter/overlay/adapter.go
@@ -652,22 +652,22 @@ func searchInputFrame(
 	centered := (screenWidth-width)/config.DefaultSearchInputCenterDivisor + layout.XOffset
 
 	switch layout.Position {
-	case overlayHints.SearchInputTopCenter:
+	case config.SearchInputPositionTopCenter:
 		xOffset = centered
-	case overlayHints.SearchInputTopRight:
+	case config.SearchInputPositionTopRight:
 		xOffset = screenWidth - width - layout.XOffset
-	case overlayHints.SearchInputCenter:
+	case config.SearchInputPositionCenter:
 		xOffset = centered
 		yOffset = (screenHeight-height)/config.DefaultSearchInputCenterDivisor + layout.YOffset
-	case overlayHints.SearchInputBottomLeft:
+	case config.SearchInputPositionBottomLeft:
 		yOffset = screenHeight - height - layout.YOffset
-	case overlayHints.SearchInputBottomCenter:
+	case config.SearchInputPositionBottomCenter:
 		xOffset = centered
 		yOffset = screenHeight - height - layout.YOffset
-	case overlayHints.SearchInputBottomRight:
+	case config.SearchInputPositionBottomRight:
 		xOffset = screenWidth - width - layout.XOffset
 		yOffset = screenHeight - height - layout.YOffset
-	case overlayHints.SearchInputTopLeft:
+	case config.SearchInputPositionTopLeft:
 		fallthrough
 	default:
 	}

--- a/internal/adapter/overlay/adapter_test.go
+++ b/internal/adapter/overlay/adapter_test.go
@@ -785,10 +785,6 @@ func TestAdapterFrame_ReportsACanceledContext(t *testing.T) {
 	}
 }
 
-// searchInputTopLeft is the anchor the placement tests start from: the one
-// where the configured offsets are the position, with no edge maths.
-const searchInputTopLeft renderhints.SearchInputPosition = "top_left"
-
 // searchStyles is a StyleSource that resolves only the search input's
 // geometry, which is the half of the Style the placement depends on.
 type searchStyles struct {
@@ -802,10 +798,36 @@ func (s searchStyles) Style() overlay.Style {
 	return overlay.Style{HintSearchLayout: s.layout}
 }
 
+// wantSearchInputBounds is where a 200x40 input with a 10/20 inset lands on a
+// 1000x800 screen for each accepted anchor, worked out from the anchor's name
+// rather than from the code: top_left is the insets themselves, a centered axis
+// is the space left over halved and then inset the same way, and a far edge is
+// the screen less the box less the inset.
+//
+// It is keyed by config.SearchInputPositions() and the test below fails when
+// the two disagree, so a position added to the vocabulary has to be given a
+// place here — which is the same as saying it has to be given one in the
+// overlay, since an anchor the placement does not recognize falls through to
+// the top left.
+func wantSearchInputBounds() map[string]image.Rectangle {
+	return map[string]image.Rectangle{
+		config.SearchInputPositionTopLeft:      image.Rect(10, 20, 210, 60),
+		config.SearchInputPositionTopCenter:    image.Rect(410, 20, 610, 60),
+		config.SearchInputPositionTopRight:     image.Rect(790, 20, 990, 60),
+		config.SearchInputPositionCenter:       image.Rect(410, 400, 610, 440),
+		config.SearchInputPositionBottomLeft:   image.Rect(10, 740, 210, 780),
+		config.SearchInputPositionBottomCenter: image.Rect(410, 740, 610, 780),
+		config.SearchInputPositionBottomRight:  image.Rect(790, 740, 990, 780),
+	}
+}
+
 // TestAdapterHintSearchBounds_PlacesTheInputFromConfiguration pins where the
-// search input lands for each configured anchor. The maths moved out of the
-// mode layer with #1210 — a caller says which screen, and the overlay says
-// where on it, because the IME field has to be put over the same rectangle.
+// search input lands for each accepted anchor. The maths moved out of the mode
+// layer with #1210 — a caller says which screen, and the overlay says where on
+// it, because the IME field has to be put over the same rectangle.
+//
+// It walks config.SearchInputPositions() rather than a list of its own, so an
+// anchor the validator accepts and the overlay does not place fails here.
 func TestAdapterHintSearchBounds_PlacesTheInputFromConfiguration(t *testing.T) {
 	t.Parallel()
 
@@ -818,49 +840,33 @@ func TestAdapterHintSearchBounds_PlacesTheInputFromConfiguration(t *testing.T) {
 		YOffset: 20,
 	}
 
-	tests := []struct {
-		name     string
-		position renderhints.SearchInputPosition
-		want     image.Rectangle
-	}{
-		{
-			name:     "top left is the offsets themselves",
-			position: searchInputTopLeft,
-			want:     image.Rect(10, 20, 210, 60),
-		},
-		{
-			name:     "top center centers horizontally",
-			position: "top_center",
-			want:     image.Rect(410, 20, 610, 60),
-		},
-		{
-			name:     "top right measures from the right edge",
-			position: "top_right",
-			want:     image.Rect(790, 20, 990, 60),
-		},
-		{
-			name:     "center centers on both axes",
-			position: "center",
-			want:     image.Rect(410, 400, 610, 440),
-		},
-		{
-			name:     "bottom right measures from both far edges",
-			position: "bottom_right",
-			want:     image.Rect(790, 740, 990, 780),
-		},
+	positions := config.SearchInputPositions()
+	if len(positions) == 0 {
+		t.Fatal("config.SearchInputPositions() is empty; there is no vocabulary to place")
 	}
 
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
+	wanted := wantSearchInputBounds()
+	if len(wanted) != len(positions) {
+		t.Errorf("%d placements expected for %d accepted positions",
+			len(wanted), len(positions))
+	}
+
+	for _, position := range positions {
+		t.Run(position, func(t *testing.T) {
 			t.Parallel()
 
+			want, expected := wanted[position]
+			if !expected {
+				t.Fatalf("%q is accepted but no placement is expected for it", position)
+			}
+
 			styles := searchStyles{layout: layout}
-			styles.layout.Position = testCase.position
+			styles.layout.Position = position
 
 			adapter := overlay.NewAdapter(newScreenManager(), styles, zap.NewNop())
 
-			if got := adapter.HintSearchBounds(screen); got != testCase.want {
-				t.Errorf("HintSearchBounds() = %v, want %v", got, testCase.want)
+			if got := adapter.HintSearchBounds(screen); got != want {
+				t.Errorf("HintSearchBounds() = %v, want %v", got, want)
 			}
 		})
 	}
@@ -873,7 +879,7 @@ func TestAdapterHintSearchBounds_KeepsTheInputOnScreen(t *testing.T) {
 	t.Parallel()
 
 	styles := searchStyles{layout: overlay.SearchInputLayout{
-		Position: searchInputTopLeft,
+		Position: config.SearchInputPositionTopLeft,
 		Width:    200,
 		Height:   40,
 		XOffset:  5000,
@@ -898,7 +904,7 @@ func TestAdapterDrawHintSearch_PutsTheQueryAndCountWhereTheStyleSaid(t *testing.
 
 	manager := newScreenManager()
 	styles := searchStyles{layout: overlay.SearchInputLayout{
-		Position: searchInputTopLeft,
+		Position: config.SearchInputPositionTopLeft,
 		Width:    200,
 		Height:   40,
 		XOffset:  10,

--- a/internal/adapter/overlay/render/hints/types.go
+++ b/internal/adapter/overlay/render/hints/types.go
@@ -45,30 +45,6 @@ func (h *Hint) MatchedPrefix() string {
 	return h.matchedPrefix
 }
 
-// SearchInputPosition identifies where the hints search UI is anchored.
-type SearchInputPosition string
-
-// SearchInputTopLeft is the top-left position for search input.
-const SearchInputTopLeft SearchInputPosition = "top_left"
-
-// SearchInputTopCenter is the top-center position for search input.
-const SearchInputTopCenter SearchInputPosition = "top_center"
-
-// SearchInputTopRight is the top-right position for search input.
-const SearchInputTopRight SearchInputPosition = "top_right"
-
-// SearchInputCenter is the center position for search input.
-const SearchInputCenter SearchInputPosition = "center"
-
-// SearchInputBottomLeft is the bottom-left position for search input.
-const SearchInputBottomLeft SearchInputPosition = "bottom_left"
-
-// SearchInputBottomCenter is the bottom-center position for search input.
-const SearchInputBottomCenter SearchInputPosition = "bottom_center"
-
-// SearchInputBottomRight is the bottom-right position for search input.
-const SearchInputBottomRight SearchInputPosition = "bottom_right"
-
 // SearchInputFrame describes the search UI geometry in overlay-local coordinates.
 type SearchInputFrame struct {
 	position image.Point

--- a/internal/adapter/overlay/style.go
+++ b/internal/adapter/overlay/style.go
@@ -29,10 +29,11 @@ type Style struct {
 // draw because it changes when the configuration does and not otherwise; the
 // screen it is placed against arrives with each draw.
 type SearchInputLayout struct {
-	// Position names the corner or edge the input is anchored to. It is the
-	// typed value, not the configured string: the Style is resolved once so
-	// that a draw does no conversion.
-	Position hints.SearchInputPosition
+	// Position names the corner or edge the input is anchored to: one of the
+	// values `hints.search_input_ui.position` accepts
+	// (config.SearchInputPositions), carried through as written rather than
+	// respelled here.
+	Position string
 	// Width and Height are the input's size in pixels.
 	Width  int
 	Height int
@@ -280,7 +281,7 @@ func buildSearchInputLayout(cfg config.SearchInputUI) SearchInputLayout {
 		config.DefaultSearchInputHeightPadding
 
 	return SearchInputLayout{
-		Position: hints.SearchInputPosition(cfg.Position),
+		Position: cfg.Position,
 		Width:    width,
 		Height:   height,
 		XOffset:  cfg.XOffset,

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -440,7 +440,7 @@ func defaultHints() HintsConfig {
 			PaddingX:        DefaultHintPaddingX,
 			PaddingY:        DefaultHintPaddingY,
 			BorderWidth:     1,
-			Position:        "bottom_center",
+			Position:        SearchInputPositionDefault,
 			XOffset:         0,
 			YOffset:         DefaultSearchInputYOffset,
 			Width:           DefaultSearchInputWidth,

--- a/internal/config/hintsvalidation_internal_test.go
+++ b/internal/config/hintsvalidation_internal_test.go
@@ -306,6 +306,29 @@ func hintsCases() []hintsCase {
 	}
 }
 
+// TestValidateHints_AcceptsEverySearchInputPosition holds the validator to the
+// vocabulary rather than to a list of its own: every value
+// SearchInputPositions() names has to validate, so a position added there and
+// not to the check is caught here instead of at the draw.
+func TestValidateHints_AcceptsEverySearchInputPosition(t *testing.T) {
+	positions := SearchInputPositions()
+	if len(positions) == 0 {
+		t.Fatal("SearchInputPositions() is empty; there is no vocabulary to validate against")
+	}
+
+	for _, position := range positions {
+		t.Run(position, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Hints.SearchInputUI.Position = position
+
+			validateErr := cfg.ValidateHints()
+			if validateErr != nil {
+				t.Errorf("ValidateHints() = %v, want nil for position %q", validateErr, position)
+			}
+		})
+	}
+}
+
 // ValidateHints reports the first problem it finds, so which problem a user is
 // told about depends on the order the checks run in. These cases record the
 // message for one broken setting at a time, and for a few configs broken in more

--- a/internal/config/search_input_position.go
+++ b/internal/config/search_input_position.go
@@ -1,0 +1,61 @@
+package config
+
+// The values `hints.search_input_ui.position` accepts: which corner or edge of
+// the screen the hints search box is anchored to.
+//
+// This is the one declaration of that vocabulary. The seven strings were
+// written three times — the validator's accepted set, the message it refuses an
+// unknown value with, and the render layer's constants — and a spelling missed
+// in one of them is either a position that validates and then draws somewhere
+// else, or a message that lies about what is accepted. It lives here rather
+// than in the render package because the validator and the renderer both need
+// it and this package is the lower of the two (ADR 0007,
+// docs/adr/0007-a-shared-derivation-has-one-implementation.md).
+const (
+	// SearchInputPositionTopLeft anchors the box to the top-left corner, where
+	// the configured offsets are its position outright.
+	SearchInputPositionTopLeft = "top_left"
+
+	// SearchInputPositionTopCenter centers the box horizontally along the top
+	// edge.
+	SearchInputPositionTopCenter = "top_center"
+
+	// SearchInputPositionTopRight anchors the box to the top-right corner.
+	SearchInputPositionTopRight = "top_right"
+
+	// SearchInputPositionCenter centers the box on both axes.
+	SearchInputPositionCenter = "center"
+
+	// SearchInputPositionBottomLeft anchors the box to the bottom-left corner.
+	SearchInputPositionBottomLeft = "bottom_left"
+
+	// SearchInputPositionBottomCenter centers the box horizontally along the
+	// bottom edge. This is the default.
+	SearchInputPositionBottomCenter = "bottom_center"
+
+	// SearchInputPositionBottomRight anchors the box to the bottom-right
+	// corner.
+	SearchInputPositionBottomRight = "bottom_right"
+)
+
+// SearchInputPositionDefault is the anchor a configuration that does not name
+// one is shipped with. Unlike `hints.ui.placement`, an unset value is refused
+// rather than settled — this is the default written into the defaults, not a
+// fallback the validator applies.
+const SearchInputPositionDefault = SearchInputPositionBottomCenter
+
+// SearchInputPositions returns every accepted `hints.search_input_ui.position`
+// value, in the order docs/CONFIGURATION.md lists them. Callers get a fresh
+// slice, so a consumer that sorts or filters cannot reach the vocabulary
+// itself.
+func SearchInputPositions() []string {
+	return []string{
+		SearchInputPositionTopLeft,
+		SearchInputPositionTopCenter,
+		SearchInputPositionTopRight,
+		SearchInputPositionCenter,
+		SearchInputPositionBottomLeft,
+		SearchInputPositionBottomCenter,
+		SearchInputPositionBottomRight,
+	}
+}

--- a/internal/config/validators_hints.go
+++ b/internal/config/validators_hints.go
@@ -275,16 +275,16 @@ func (c *Config) validateHintBoundaryHighlight() error {
 }
 
 // validateHintSearchInputPlacement checks where the search input sits and how
-// wide it is.
+// wide it is. Both the accepted set and the error message read
+// SearchInputPositions(), so a position added there is accepted here — and
+// named in the message — without this function being touched.
 func (c *Config) validateHintSearchInputPlacement() error {
-	switch c.Hints.SearchInputUI.Position {
-	case "top_left", "top_center", "top_right",
-		"center",
-		"bottom_left", "bottom_center", "bottom_right":
-	default:
-		return derrors.New(
+	positions := SearchInputPositions()
+	if !slices.Contains(positions, c.Hints.SearchInputUI.Position) {
+		return derrors.Newf(
 			derrors.CodeInvalidConfig,
-			"hints.search_input_ui.position must be one of top_left, top_center, top_right, center, bottom_left, bottom_center, bottom_right",
+			"hints.search_input_ui.position must be one of %s",
+			strings.Join(positions, ", "),
 		)
 	}
 


### PR DESCRIPTION
## Description

This PR reworks how the seven places the hint search box can sit are declared, without moving the box. `top_left`, `top_center`, `top_right`, `center`, `bottom_left`, `bottom_center` and `bottom_right` were spelled out three separate times — once in the check that accepts them, once in the message a rejected value produces, and once in the overlay that draws the box. Nothing held those three together, so adding or renaming an anchor meant finding all three, and a spelling missed in one of them produced either a value that passed validation and then drew somewhere else, or an error message that lied about what was accepted. They are now declared once, and all three read that declaration — the message in particular is now built from it rather than typed out, so it cannot go stale.

Two guardrails come with it: an anchor the check accepts has to validate, and it has to have a place on screen of its own. Both walk the declaration rather than a list of their own, so an eighth anchor added tomorrow fails loudly until it has been given somewhere to draw, instead of quietly drawing in the top-left corner. Both were verified to have teeth by adding a value to the vocabulary and watching them fail.

Deliberate limitation: nothing pins the declaration to the seven values spelled out in prose in `docs/CONFIGURATION.md` and `configs/default-config.toml`. That is the same gap the hint-placement vocabulary has, and closing it is a docs-generation question rather than part of this change.

## Related Issues

Closes #1301

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `refactor` — Code restructuring (no behavior change)

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, every file touched is untagged shared code, and the search input's position is resolved once in the shared overlay for every backend.
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability changed; this moves existing constants.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no option, value or default changed, so `docs/CONFIGURATION.md` needed nothing.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config and command surface

Nothing changes for a user. `hints.search_input_ui.position` still accepts exactly the same seven values, still defaults to `bottom_center`, and the message an invalid value produces is unchanged word for word:

```toml
[hints.search_input_ui]
position = "bottom_center"   # top_left, top_center, top_right, center, bottom_left, bottom_center, bottom_right
```

Existing config files keep working.

## Additional Context

The vocabulary is declared in the config package rather than the domain, for the same reason the hint placements are: no domain code places a search box, and the callers are config itself plus the overlay that draws it, which makes config the lowest layer both already reach. That is the placement rule from ADR 0007.

This is the pure-Go half of what #1289 did — the values never cross into Objective-C, so there is no copy in another language to pin and no architecture test owed. The render layer's own string type went with its constants: with the values declared once in config, it carried no values of its own and bought no type safety, and the placement it mirrors has always been a plain string. The overlay's placement test now walks the declaration and asserts a worked-out rectangle per anchor, so it catches both an anchor with nowhere to draw and an anchor drawing in the wrong corner.

One gap is left open on purpose and worth knowing about: an anchor the overlay does not recognise falls through to the top-left corner rather than failing. That is what the new test exists to catch at build time, but it stays true at runtime, and making it explicit would be a change to the drawing path rather than to the vocabulary.
