### PR TITLE
fix(overlay): keep odd-sized badges at their full size

### DIFF
--- a/internal/adapter/overlay/linux/hint_arrow_test.go
+++ b/internal/adapter/overlay/linux/hint_arrow_test.go
@@ -161,22 +161,16 @@ func TestHintBadgePlacement_ArrowBaseClampedToFlatEdge(t *testing.T) {
 	}
 }
 
-// TestHintBadgePlacement_OddBadgeSizeDropsItsLastPixel pins the rounding the
-// badge is placed with. The badge hangs on its target point as center ± half,
-// so a badge sized to an odd width or height is drawn one pixel short of that
-// size. The alternative rounding (badge.CenteredIn's center - half, + size)
-// would keep that pixel and move the badge's right and bottom edges, so this
-// test is what stops the two being swapped.
-func TestHintBadgePlacement_OddBadgeSizeDropsItsLastPixel(t *testing.T) {
+func TestHintBadgePlacement_OddBadgeSizeKeepsItsSize(t *testing.T) {
 	target := image.Pt(100, 100)
 
 	centered, _, _ := hintBadgePlacement(target, 41, 21, 4, config.HintPlacementCenter)
-	if want := image.Rect(80, 90, 120, 110); centered != want {
+	if want := image.Rect(80, 90, 121, 111); centered != want {
 		t.Errorf("center placement badge = %v, want %v", centered, want)
 	}
 
 	below, _, _ := hintBadgePlacement(target, 41, 21, 4, config.HintPlacementBottom)
-	if want := image.Rect(80, 106, 120, 126); below != want {
+	if want := image.Rect(80, 106, 121, 127); below != want {
 		t.Errorf("bottom placement badge = %v, want %v", below, want)
 	}
 }

--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -768,10 +768,7 @@ func monitorSelectPanelLayout(
 		panelH = maxH
 	}
 
-	// The panel hangs on the monitor's center point rather than being fitted
-	// into the monitor rectangle: badge.CenteredOn, not badge.CenteredIn. The
-	// two differ by a pixel on an odd panel size, and this is the one the panel
-	// has always been drawn with.
+	// The panel hangs on the monitor's center point.
 	center := image.Pt(
 		monitor.Min.X+monitor.Dx()/halfDivisor,
 		monitor.Min.Y+monitor.Dy()/halfDivisor,
@@ -1232,11 +1229,8 @@ func hintBadgePlacement(
 		return badge.CenteredOn(target, badgeWidth, badgeHeight), hintArrowTriangle{}, false
 	}
 
-	// The badge hangs on the target point rather than being fitted into the
-	// element's box: badge.CenteredOn, not badge.CenteredIn. The two differ by
-	// a pixel on an odd badge size, and this is the one hints have always been
-	// drawn with. halfW and halfH stay because the arrow and the top/bottom
-	// offset are measured from them, not from the rectangle.
+	// halfW and halfH stay because the arrow and the top/bottom offset are
+	// measured from them, not from the rectangle.
 	badgeRect := badge.CenteredOn(image.Pt(centerX, centerY), badgeWidth, badgeHeight)
 
 	// Keep the arrow base within the badge's flat edge (inside the corner

--- a/internal/adapter/overlay/linux/monitor_select_test.go
+++ b/internal/adapter/overlay/linux/monitor_select_test.go
@@ -9,13 +9,7 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
 )
 
-// TestMonitorSelectPanelLayout_OddPanelWidthDropsItsLastPixel pins the rounding
-// the panel is placed with. The panel hangs on the monitor's center point as
-// center ± half, so a panel sized to an odd width is drawn one pixel narrower
-// than that width — here a 7 px wide panel lands 6 px wide. Fitting it into the
-// monitor rectangle instead (badge.CenteredIn) would keep that pixel and move
-// the panel's right edge, so this test is what stops the two being swapped.
-func TestMonitorSelectPanelLayout_OddPanelWidthDropsItsLastPixel(t *testing.T) {
+func TestMonitorSelectPanelLayout_OddPanelWidthKeepsItsSize(t *testing.T) {
 	t.Parallel()
 
 	monitor := image.Rect(0, 0, 100, 100)
@@ -26,11 +20,11 @@ func TestMonitorSelectPanelLayout_OddPanelWidthDropsItsLastPixel(t *testing.T) {
 	)
 
 	// Label 7 px wide, 14 px tall, no padding: a 7x14 panel centered on (50, 50).
-	if want := image.Rect(47, 43, 53, 57); panel != want {
+	if want := image.Rect(47, 43, 54, 57); panel != want {
 		t.Errorf("panel = %v, want %v", panel, want)
 	}
 
-	if want := image.Rect(47, 43, 53, 57); labelRect != want {
+	if want := image.Rect(47, 43, 54, 57); labelRect != want {
 		t.Errorf("label rect = %v, want %v", labelRect, want)
 	}
 

--- a/internal/adapter/overlay/render/badge/badge.go
+++ b/internal/adapter/overlay/render/badge/badge.go
@@ -120,39 +120,19 @@ func Bounds(
 // same pixel on every backend. A badge larger than its container overhangs it
 // rather than being clamped: the callers draw label plates, and a plate that
 // outgrew its cell is the autohide threshold's problem, not this function's.
-//
-// This is not CenteredOn with the container's center substituted for the
-// point: this one keeps the requested size, CenteredOn drops the last pixel of
-// an odd one. See CenteredOn.
 func CenteredIn(container image.Rectangle, width, height int) image.Rectangle {
 	centerX := container.Min.X + container.Dx()/halfDivisor
 	centerY := container.Min.Y + container.Dy()/halfDivisor
-	originX := centerX - width/halfDivisor
-	originY := centerY - height/halfDivisor
 
-	return image.Rect(originX, originY, originX+width, originY+height)
+	return CenteredOn(image.Pt(centerX, centerY), width, height)
 }
 
-// CenteredOn returns the rectangle spanning half of width and half of height
-// either side of center: what a backend draws when it hangs something on a
-// point rather than fitting it into a container — a hint badge on its target
-// element, the monitor-select panel on its monitor.
-//
-// It is deliberately not CenteredIn's point form, and the two are not
-// interchangeable. This is center ± half, so an odd width or height loses its
-// last pixel — a 41-wide badge is drawn 40 wide — where CenteredIn is
-// center - half, + size and keeps it. Both put the near edge on the same
-// pixel, which is what makes the difference easy to miss: only the far edge
-// moves, and only on odd sizes. This function exists so that pixel is a
-// documented choice rather than something the next reader "simplifies" away.
+// CenteredOn returns a width x height rectangle centered on a point.
 func CenteredOn(center image.Point, width, height int) image.Rectangle {
-	halfWidth := width / halfDivisor
-	halfHeight := height / halfDivisor
+	originX := center.X - width/halfDivisor
+	originY := center.Y - height/halfDivisor
 
-	return image.Rect(
-		center.X-halfWidth, center.Y-halfHeight,
-		center.X+halfWidth, center.Y+halfHeight,
-	)
+	return image.Rect(originX, originY, originX+width, originY+height)
 }
 
 // BorderRadius resolves a configured border-radius value for the given

--- a/internal/adapter/overlay/render/badge/badge_test.go
+++ b/internal/adapter/overlay/render/badge/badge_test.go
@@ -255,7 +255,7 @@ func TestCenteredIn_CentersAndKeepsSize(t *testing.T) {
 	}
 }
 
-func TestCenteredOn_SpansHalfEitherSideOfThePoint(t *testing.T) {
+func TestCenteredOn_CentersAndKeepsSize(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -272,18 +272,18 @@ func TestCenteredOn_SpansHalfEitherSideOfThePoint(t *testing.T) {
 			want:   image.Rect(80, 90, 120, 110),
 		},
 		{
-			name:   "odd width drops its last pixel",
+			name:   "odd width keeps the requested size",
 			center: image.Pt(100, 100),
 			width:  41,
 			height: 20,
-			want:   image.Rect(80, 90, 120, 110),
+			want:   image.Rect(80, 90, 121, 110),
 		},
 		{
-			name:   "odd height drops its last pixel",
+			name:   "odd height keeps the requested size",
 			center: image.Pt(100, 100),
 			width:  40,
 			height: 21,
-			want:   image.Rect(80, 90, 120, 110),
+			want:   image.Rect(80, 90, 120, 111),
 		},
 		{
 			name:   "odd center coordinates shift the whole rectangle",
@@ -317,15 +317,16 @@ func TestCenteredOn_SpansHalfEitherSideOfThePoint(t *testing.T) {
 				t.Errorf("CenteredOn(%v, %d, %d) = %v, want %v",
 					testCase.center, testCase.width, testCase.height, got, testCase.want)
 			}
+
+			if got.Dx() != testCase.width || got.Dy() != testCase.height {
+				t.Errorf("CenteredOn size = %dx%d, want %dx%d",
+					got.Dx(), got.Dy(), testCase.width, testCase.height)
+			}
 		})
 	}
 }
 
-// TestCenteredOn_IsNotCenteredInOnOddSizes pins the near-miss the two functions
-// are: they agree on the near edge always and on the far edge only when both
-// dimensions are even, so swapping one for the other silently moves a panel or
-// badge edge by a pixel on odd sizes.
-func TestCenteredOn_IsNotCenteredInOnOddSizes(t *testing.T) {
+func TestCenteredOn_MatchesCenteredIn(t *testing.T) {
 	t.Parallel()
 
 	container := image.Rect(0, 0, 100, 100)
@@ -345,10 +346,10 @@ func TestCenteredOn_IsNotCenteredInOnOddSizes(t *testing.T) {
 			wantIn: image.Rect(30, 40, 70, 60),
 		},
 		{
-			name:   "odd dimensions disagree on the far edge only",
+			name:   "odd dimensions agree",
 			width:  41,
 			height: 21,
-			wantOn: image.Rect(30, 40, 70, 60),
+			wantOn: image.Rect(30, 40, 71, 61),
 			wantIn: image.Rect(30, 40, 71, 61),
 		},
 	}
@@ -367,9 +368,8 @@ func TestCenteredOn_IsNotCenteredInOnOddSizes(t *testing.T) {
 				t.Errorf("CenteredIn = %v, want %v", gotIn, testCase.wantIn)
 			}
 
-			if gotOn.Min != gotIn.Min {
-				t.Errorf("near edges must agree: CenteredOn %v, CenteredIn %v",
-					gotOn.Min, gotIn.Min)
+			if gotOn != gotIn {
+				t.Errorf("CenteredOn = %v, CenteredIn = %v", gotOn, gotIn)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

This PR keeps odd-sized hint badges and target highlights at their requested dimensions on Linux and Windows. Their right and bottom edges now extend by one pixel when needed, matching macOS while leaving even-sized geometry unchanged.

The same size-preserving centering rule now applies wherever a rectangle is centered on a point.

## Related Issues

Closes #1326

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new platform capability
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no documentation surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

Not included. The one-pixel difference is covered by exact rectangle assertions.

## Additional Context

Odd-sized hint badges and target highlights gain one pixel on their right and/or bottom edge on Linux and Windows. Even sizes do not move. Linux monitor-selection panels use the same rule and preserve their configured odd width as well.
