### PR TITLE
fix(linux): report a hint placement the overlay cannot draw

### DIFF
--- a/internal/adapter/overlay/linux/hint_arrow_test.go
+++ b/internal/adapter/overlay/linux/hint_arrow_test.go
@@ -6,7 +6,9 @@ import (
 	"image"
 	"testing"
 
+	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/derrors"
 )
 
 // Unit tests for the pure hint badge/arrow placement math shared by the X11 and
@@ -14,7 +16,7 @@ import (
 // tests; here we only assert the geometry the C draw calls receive.
 func TestHintBadgePlacement_CenterHasNoArrow(t *testing.T) {
 	target := image.Pt(100, 100)
-	badge, arrow, hasArrow := hintBadgePlacement(target, 40, 20, 4, config.HintPlacementCenter)
+	badge, arrow, hasArrow := hintBadgePlacement(target, 40, 20, 4, hintBadgeOnTarget)
 
 	if hasArrow {
 		t.Fatalf("center placement should not draw an arrow, got %+v", arrow)
@@ -29,9 +31,113 @@ func TestHintBadgePlacement_CenterHasNoArrow(t *testing.T) {
 	}
 }
 
-func TestHintBadgePlacement_UnknownPlacementHasNoArrow(t *testing.T) {
-	if _, _, hasArrow := hintBadgePlacement(image.Pt(10, 10), 40, 20, 4, "floating"); hasArrow {
-		t.Fatal("unrecognized placement should not draw an arrow")
+// TestResolveHintBadgeOffset_EveryPlacementInTheVocabulary pins this overlay to
+// config's declaration of the vocabulary: every value `hints.ui.placement`
+// accepts has to resolve to an offset here. A placement added to
+// config.HintPlacements() without a branch below fails this test rather than
+// drawing a badge in a placement nobody chose.
+func TestResolveHintBadgeOffset_EveryPlacementInTheVocabulary(t *testing.T) {
+	want := map[string]hintBadgeOffset{
+		config.HintPlacementTop:    hintBadgeAbove,
+		config.HintPlacementCenter: hintBadgeOnTarget,
+		config.HintPlacementBottom: hintBadgeBelow,
+	}
+
+	for _, placement := range config.HintPlacements() {
+		t.Run(placement, func(t *testing.T) {
+			offset, err := resolveHintBadgeOffset(placement)
+			if err != nil {
+				t.Fatalf("resolveHintBadgeOffset(%q) error = %v, want an offset", placement, err)
+			}
+
+			if offset != want[placement] {
+				t.Errorf(
+					"resolveHintBadgeOffset(%q) = %v, want %v",
+					placement,
+					offset,
+					want[placement],
+				)
+			}
+		})
+	}
+
+	if len(want) != len(config.HintPlacements()) {
+		t.Fatalf(
+			"the vocabulary has %d values but this test maps %d; every one needs an expected offset",
+			len(config.HintPlacements()),
+			len(want),
+		)
+	}
+}
+
+// TestResolveHintBadgeOffset_UnsetDrawsTheDefault pins the empty string to the
+// offset the declared default resolves to, matching what the macOS renderer
+// answers it (TestHintPlacementValue_UnsetDrawsTheDefault). A style can reach
+// an overlay before a configuration settles it, and a hint that draws on macOS
+// and vanishes on Linux would be this package disagreeing with that one.
+func TestResolveHintBadgeOffset_UnsetDrawsTheDefault(t *testing.T) {
+	unset, err := resolveHintBadgeOffset("")
+	if err != nil {
+		t.Fatalf(`resolveHintBadgeOffset("") error = %v, want the default's offset`, err)
+	}
+
+	fallback, err := resolveHintBadgeOffset(config.HintPlacementDefault)
+	if err != nil {
+		t.Fatalf("resolveHintBadgeOffset(%q) error = %v", config.HintPlacementDefault, err)
+	}
+
+	if unset != fallback {
+		t.Errorf(`resolveHintBadgeOffset("") = %v, want %v (the offset of %q)`,
+			unset, fallback, config.HintPlacementDefault)
+	}
+}
+
+// TestResolveHintBadgeOffset_UnknownPlacementIsNotSupported pins the other half:
+// a value outside the vocabulary is refused, not drawn. It used to be drawn
+// centered, which made a placement with no Linux branch indistinguishable from
+// `center` — silent everywhere and wrong on screen.
+func TestResolveHintBadgeOffset_UnknownPlacementIsNotSupported(t *testing.T) {
+	offset, err := resolveHintBadgeOffset("floating")
+	if err == nil {
+		t.Fatalf("resolveHintBadgeOffset(%q) = %v, nil; an unrecognized placement must be refused",
+			"floating", offset)
+	}
+
+	if !derrors.IsNotSupported(err) {
+		t.Errorf("resolveHintBadgeOffset returned %v (code %q), want CodeNotSupported",
+			err, derrors.GetCode(err))
+	}
+}
+
+// TestLinuxOverlayManager_UnknownHintPlacementIsRefusedNotDrawn pins where that
+// refusal reaches a caller: the draw call the mode handler makes, before a
+// single badge is painted. A backend is attached here on purpose — with none,
+// every draw already reports CodeNotSupported and the assertion would prove
+// nothing about the placement.
+func TestLinuxOverlayManager_UnknownHintPlacementIsRefusedNotDrawn(t *testing.T) {
+	mgr := &Manager{x11: &x11Overlay{}}
+
+	cfg := config.DefaultConfig()
+	cfg.Hints.UI.Placement = "floating"
+
+	err := mgr.DrawHintsWithStyle(nil, hintscomponent.BuildStyle(cfg.Hints, nil))
+	if !derrors.IsNotSupported(err) {
+		t.Errorf(
+			"DrawHintsWithStyle with an unrecognized placement returned %v (code %q), "+
+				"want CodeNotSupported: the hints would be drawn centered instead",
+			err, derrors.GetCode(err),
+		)
+	}
+
+	// The vocabulary's own values still draw. A guard that refused everything
+	// would pass the assertion above and blank the hints overlay.
+	for _, placement := range config.HintPlacements() {
+		cfg.Hints.UI.Placement = placement
+
+		drawErr := mgr.DrawHintsWithStyle(nil, hintscomponent.BuildStyle(cfg.Hints, nil))
+		if drawErr != nil {
+			t.Errorf("DrawHintsWithStyle(%q) = %v, want nil", placement, drawErr)
+		}
 	}
 }
 
@@ -43,7 +149,7 @@ func TestHintBadgePlacement_Bottom(t *testing.T) {
 		badgeWidth,
 		badgeHeight,
 		radius,
-		config.HintPlacementBottom,
+		hintBadgeBelow,
 	)
 
 	if !hasArrow {
@@ -98,7 +204,7 @@ func TestHintBadgePlacement_Top(t *testing.T) {
 		badgeWidth,
 		badgeHeight,
 		radius,
-		config.HintPlacementTop,
+		hintBadgeAbove,
 	)
 
 	if !hasArrow {
@@ -145,7 +251,7 @@ func TestHintBadgePlacement_ArrowBaseClampedToFlatEdge(t *testing.T) {
 		badgeWidth,
 		badgeHeight,
 		radius,
-		config.HintPlacementBottom,
+		hintBadgeBelow,
 	)
 	if !hasArrow {
 		t.Fatal("expected an arrow")
@@ -164,12 +270,12 @@ func TestHintBadgePlacement_ArrowBaseClampedToFlatEdge(t *testing.T) {
 func TestHintBadgePlacement_OddBadgeSizeKeepsItsSize(t *testing.T) {
 	target := image.Pt(100, 100)
 
-	centered, _, _ := hintBadgePlacement(target, 41, 21, 4, config.HintPlacementCenter)
+	centered, _, _ := hintBadgePlacement(target, 41, 21, 4, hintBadgeOnTarget)
 	if want := image.Rect(80, 90, 121, 111); centered != want {
 		t.Errorf("center placement badge = %v, want %v", centered, want)
 	}
 
-	below, _, _ := hintBadgePlacement(target, 41, 21, 4, config.HintPlacementBottom)
+	below, _, _ := hintBadgePlacement(target, 41, 21, 4, hintBadgeBelow)
 	if want := image.Rect(80, 106, 121, 127); below != want {
 		t.Errorf("bottom placement badge = %v, want %v", below, want)
 	}
@@ -178,7 +284,7 @@ func TestHintBadgePlacement_OddBadgeSizeKeepsItsSize(t *testing.T) {
 func TestHintTailEdge(t *testing.T) {
 	target := image.Pt(200, 150)
 
-	badge, arrow, hasArrow := hintBadgePlacement(target, 40, 20, 4, config.HintPlacementBottom)
+	badge, arrow, hasArrow := hintBadgePlacement(target, 40, 20, 4, hintBadgeBelow)
 	if edge := hintTailEdge(badge, arrow, hasArrow); edge != hintTailTop {
 		t.Errorf(
 			"bottom placement (arrow points up) should merge the tail into the top edge, got %d",
@@ -186,7 +292,7 @@ func TestHintTailEdge(t *testing.T) {
 		)
 	}
 
-	badge, arrow, hasArrow = hintBadgePlacement(target, 40, 20, 4, config.HintPlacementTop)
+	badge, arrow, hasArrow = hintBadgePlacement(target, 40, 20, 4, hintBadgeAbove)
 	if edge := hintTailEdge(badge, arrow, hasArrow); edge != hintTailBottom {
 		t.Errorf(
 			"top placement (arrow points down) should merge the tail into the bottom edge, got %d",
@@ -194,7 +300,7 @@ func TestHintTailEdge(t *testing.T) {
 		)
 	}
 
-	badge, arrow, hasArrow = hintBadgePlacement(target, 40, 20, 4, config.HintPlacementCenter)
+	badge, arrow, hasArrow = hintBadgePlacement(target, 40, 20, 4, hintBadgeOnTarget)
 	if edge := hintTailEdge(badge, arrow, hasArrow); edge != hintTailNone {
 		t.Errorf("center placement should have no tail, got %d", edge)
 	}
@@ -202,7 +308,7 @@ func TestHintTailEdge(t *testing.T) {
 
 func TestHintBadgeRadius_ReservesTailFlatEdge(t *testing.T) {
 	// Center placement is never capped — the tail doesn't exist there.
-	if got := hintBadgeRadius(100, 40, config.HintPlacementCenter); got != 100 {
+	if got := hintBadgeRadius(100, 40, hintBadgeOnTarget); got != 100 {
 		t.Errorf("center radius should be unchanged, got %d", got)
 	}
 
@@ -212,13 +318,13 @@ func TestHintBadgeRadius_ReservesTailFlatEdge(t *testing.T) {
 	if got, want := hintBadgeRadius(
 		1000,
 		40,
-		config.HintPlacementBottom,
+		hintBadgeBelow,
 	), 20-hintArrowMinHalfBase; got != want {
 		t.Errorf("oversized radius = %d, want capped to %d", got, want)
 	}
 
 	// A normal radius that already leaves room is left untouched.
-	if got := hintBadgeRadius(6, 40, config.HintPlacementTop); got != 6 {
+	if got := hintBadgeRadius(6, 40, hintBadgeAbove); got != 6 {
 		t.Errorf("normal radius should be unchanged, got %d", got)
 	}
 }
@@ -231,13 +337,13 @@ func TestHintBadgePlacement_FullPillKeepsTail(t *testing.T) {
 	target := image.Pt(200, 150)
 	badgeWidth, badgeHeight := 40, 24
 
-	radius := hintBadgeRadius(1000, badgeWidth, config.HintPlacementBottom)
+	radius := hintBadgeRadius(1000, badgeWidth, hintBadgeBelow)
 	badge, arrow, hasArrow := hintBadgePlacement(
 		target,
 		badgeWidth,
 		badgeHeight,
 		radius,
-		config.HintPlacementBottom,
+		hintBadgeBelow,
 	)
 
 	if !hasArrow {

--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -407,29 +407,56 @@ func (m *Manager) OverlayCapabilities() ports.FeatureCapability {
 }
 
 // DrawHintsWithStyle draws the hints overlay using the active Linux backend.
+//
+// The placement is resolved once, before anything is drawn: it is the same for
+// every badge in the frame, and a placement this overlay cannot draw is
+// reported rather than approximated. Drawing every hint centered instead would
+// leave the user looking at labels in a placement they did not choose, with
+// nothing anywhere saying so.
 func (m *Manager) DrawHintsWithStyle(hintsSlice []*hints.Hint, style hints.StyleMode) error {
+	if m.x11 == nil && m.wlroots == nil {
+		return derrors.New(
+			derrors.CodeNotSupported,
+			"overlay hints not implemented on linux backend",
+		)
+	}
+
+	// Canceling first keeps the refusal below from leaving an animation
+	// painting the surface this draw was about to replace.
 	if m.wlroots != nil {
 		m.wlroots.cancelAnimation()
-	} else if m.x11 != nil {
+	} else {
 		m.x11.cancelAnimation()
+	}
+
+	offset, offsetErr := resolveHintBadgeOffset(style.Placement())
+	if offsetErr != nil {
+		// The error reaches the mode handler, which degrades quietly on
+		// CodeNotSupported — so say it here too, or a placement this overlay
+		// cannot draw costs the user every hint with only a debug line to
+		// explain it. The placement is a fixed configuration keyword.
+		if m.logger != nil {
+			m.logger.Warn(
+				"hint placement not drawn by the linux overlay",
+				zap.String("placement", style.Placement()),
+			)
+		}
+
+		return offsetErr
 	}
 
 	m.renderMu.Lock()
 	defer m.renderMu.Unlock()
 
 	if m.x11 != nil {
-		m.x11.DrawHints(hintsSlice, style)
+		m.x11.DrawHints(hintsSlice, style, offset)
 
 		return nil
 	}
 
-	if m.wlroots != nil {
-		m.wlroots.DrawHints(hintsSlice, style)
+	m.wlroots.DrawHints(hintsSlice, style, offset)
 
-		return nil
-	}
-
-	return derrors.New(derrors.CodeNotSupported, "overlay hints not implemented on linux backend")
+	return nil
 }
 
 // DrawHintSearchInput draws the hints search input using the active Linux backend.
@@ -1159,13 +1186,65 @@ type hintArrowTriangle struct {
 	baseRight image.Point
 }
 
-// hintBadgeRadius caps the badge corner radius for top/bottom placement so the
-// badge always keeps a flat top/bottom edge wide enough for the connector tail
-// to attach to. Without this, a large configured radius (e.g. a full pill)
-// consumes the flat edge and the renderer drops the tail entirely. Center
-// placement (no tail) and radii that already leave room are returned unchanged.
-func hintBadgeRadius(radius, badgeWidth int, placement string) int {
-	if placement != config.HintPlacementTop && placement != config.HintPlacementBottom {
+// hintBadgeOffset is everything a `hints.ui.placement` value decides for this
+// overlay: where a hint badge sits relative to the point it labels, and so
+// whether there is a connector arrow at all. The drawing code takes one of
+// these rather than the configured string, so a placement string it has no
+// branch for cannot reach it.
+type hintBadgeOffset int
+
+const (
+	// hintBadgeOnTarget draws the badge over the target point, with no arrow.
+	hintBadgeOnTarget hintBadgeOffset = iota
+	// hintBadgeAbove draws the badge above the target, with an arrow hanging
+	// off its bottom edge and pointing down at the target.
+	hintBadgeAbove
+	// hintBadgeBelow draws the badge below the target, with an arrow on its top
+	// edge pointing up at the target.
+	hintBadgeBelow
+)
+
+// resolveHintBadgeOffset maps a configured placement onto the offset this
+// overlay draws it with. It is the one place the placement vocabulary is read
+// here, and every value config.HintPlacements() declares has a branch.
+//
+// Anything else is refused rather than drawn. The switch used to treat an
+// unrecognized value as its default case, which drew a centered badge with no
+// arrow — right for `center` by coincidence, and silent for a placement added
+// to the vocabulary without a Linux branch: it would validate, be forced to
+// exist on macOS, and then draw centered here with nothing failing anywhere.
+//
+// The empty string is not one of those: it is a style that reached the overlay
+// before a configuration settled it, and it draws at the documented default —
+// the same answer the macOS renderer gives it (`hintPlacementValue`), so a
+// draw that beats the first Apply puts hints in the same place on both.
+func resolveHintBadgeOffset(placement string) (hintBadgeOffset, error) {
+	if placement == "" {
+		placement = config.HintPlacementDefault
+	}
+
+	switch placement {
+	case config.HintPlacementTop:
+		return hintBadgeAbove, nil
+	case config.HintPlacementCenter:
+		return hintBadgeOnTarget, nil
+	case config.HintPlacementBottom:
+		return hintBadgeBelow, nil
+	default:
+		return hintBadgeOnTarget, derrors.New(
+			derrors.CodeNotSupported,
+			"hint placement is not drawn by the linux overlay",
+		)
+	}
+}
+
+// hintBadgeRadius caps the badge corner radius for an offset badge so it always
+// keeps a flat top/bottom edge wide enough for the connector tail to attach to.
+// Without this, a large configured radius (e.g. a full pill) consumes the flat
+// edge and the renderer drops the tail entirely. A badge on its target has no
+// tail, and radii that already leave room are returned unchanged.
+func hintBadgeRadius(radius, badgeWidth int, offset hintBadgeOffset) int {
+	if offset == hintBadgeOnTarget {
 		return radius
 	}
 
@@ -1194,22 +1273,22 @@ func hintTailEdge(badge image.Rectangle, arrow hintArrowTriangle, hasArrow bool)
 }
 
 // hintBadgePlacement computes the badge rect for a hint given its target point
-// (the element center) and, for top/bottom placement, the connector arrow that
-// visually ties the badge to the target. It centralizes the placement math
-// shared by the X11 and Wayland overlays so both stay in lockstep with the
-// macOS overlay's arrow behavior.
+// (the element center) and, for an offset badge, the connector arrow that
+// visually ties it back to the target. It centralizes the placement math shared
+// by the X11 and Wayland overlays so both stay in lockstep with the macOS
+// overlay's arrow behavior.
 //
 // radius is the badge's already-resolved corner radius; it keeps the arrow base
 // on the badge's flat edge rather than over a rounded corner. hasArrow is false
-// for center or unrecognized placements, which draw no arrow.
+// for a badge drawn on its target, which needs nothing to tie it to one.
 //
-// The placement strings are config's declaration of the vocabulary
-// (config.HintPlacements), not a spelling of its own: a value the validator
-// accepts is a value this switch recognizes.
+// It takes the resolved offset rather than the configured placement string, so
+// there is no unrecognized case for it to answer: resolveHintBadgeOffset
+// refuses one before a draw begins.
 func hintBadgePlacement(
 	target image.Point,
 	badgeWidth, badgeHeight, radius int,
-	placement string,
+	offset hintBadgeOffset,
 ) (image.Rectangle, hintArrowTriangle, bool) {
 	halfW := badgeWidth / halfDivisor
 	halfH := badgeHeight / halfDivisor
@@ -1217,16 +1296,18 @@ func hintBadgePlacement(
 
 	var centerY int
 
-	switch placement {
-	case config.HintPlacementTop:
+	switch offset {
+	case hintBadgeOnTarget:
+		// The badge covers the target, so there is nothing for an arrow to
+		// point at.
+		return badge.CenteredOn(target, badgeWidth, badgeHeight), hintArrowTriangle{}, false
+	case hintBadgeAbove:
 		// Badge sits above the target, offset by the gap plus arrow height so
 		// the arrow has room to point down at the target.
 		centerY = target.Y - hintPlacementGap - hintArrowHeight - halfH
-	case config.HintPlacementBottom:
+	case hintBadgeBelow:
 		// Badge sits below the target; arrow points up at the target.
 		centerY = target.Y + hintPlacementGap + hintArrowHeight + halfH
-	default:
-		return badge.CenteredOn(target, badgeWidth, badgeHeight), hintArrowTriangle{}, false
 	}
 
 	// halfW and halfH stay because the arrow and the top/bottom offset are
@@ -1246,23 +1327,17 @@ func hintBadgePlacement(
 		return badgeRect, hintArrowTriangle{}, false
 	}
 
-	var arrow hintArrowTriangle
+	// Only the two offset placements reach here, and they are mirror images:
+	// the arrow leaves the edge of the badge that faces the target.
+	baseY, tipY := badgeRect.Min.Y, badgeRect.Min.Y-hintArrowHeight
+	if offset == hintBadgeAbove {
+		baseY, tipY = badgeRect.Max.Y, badgeRect.Max.Y+hintArrowHeight
+	}
 
-	switch placement {
-	case config.HintPlacementBottom:
-		baseY := badgeRect.Min.Y
-		arrow = hintArrowTriangle{
-			baseLeft:  image.Pt(centerX-halfBase, baseY),
-			tip:       image.Pt(centerX, baseY-hintArrowHeight),
-			baseRight: image.Pt(centerX+halfBase, baseY),
-		}
-	case config.HintPlacementTop:
-		baseY := badgeRect.Max.Y
-		arrow = hintArrowTriangle{
-			baseLeft:  image.Pt(centerX-halfBase, baseY),
-			tip:       image.Pt(centerX, baseY+hintArrowHeight),
-			baseRight: image.Pt(centerX+halfBase, baseY),
-		}
+	arrow := hintArrowTriangle{
+		baseLeft:  image.Pt(centerX-halfBase, baseY),
+		tip:       image.Pt(centerX, tipY),
+		baseRight: image.Pt(centerX+halfBase, baseY),
 	}
 
 	return badgeRect, arrow, true

--- a/internal/adapter/overlay/linux/overlay_shared_cgo.go
+++ b/internal/adapter/overlay/linux/overlay_shared_cgo.go
@@ -305,6 +305,7 @@ func (o *sharedOverlay) drawMonitorSelect(
 func (o *sharedOverlay) drawHints(
 	hintsSlice []*hintscomponent.Hint,
 	style hintscomponent.StyleMode,
+	offset hintBadgeOffset,
 ) {
 	o.srf.ensureBuffers()
 	o.cancelAnimation()
@@ -350,15 +351,15 @@ func (o *sharedOverlay) drawHints(
 		if radius < 0 {
 			radius = min(badgeHeight/halfDivisor, hintAutoRadiusMax)
 		}
-		// Cap the radius so a top/bottom badge keeps a flat edge for the tail.
-		radius = hintBadgeRadius(radius, badgeWidth, style.Placement())
+		// Cap the radius so an offset badge keeps a flat edge for the tail.
+		radius = hintBadgeRadius(radius, badgeWidth, offset)
 
 		// pos is the element center (set in modes/hints.go). The badge is
 		// centered horizontally on it and placed above / on / below the center
-		// to match macOS; top/bottom placement also draws a connector arrow
-		// pointing back at the target.
+		// to match macOS; an offset badge also draws a connector arrow pointing
+		// back at the target.
 		badgeRect, arrow, hasArrow := hintBadgePlacement(
-			pos, badgeWidth, badgeHeight, radius, style.Placement(),
+			pos, badgeWidth, badgeHeight, radius, offset,
 		)
 
 		fill := badge.ParseHexARGB(style.BackgroundColor())

--- a/internal/adapter/overlay/linux/wayland_cgo.go
+++ b/internal/adapter/overlay/linux/wayland_cgo.go
@@ -233,12 +233,13 @@ func (o *wlrootsOverlay) DrawMonitorSelect(
 func (o *wlrootsOverlay) DrawHints(
 	hintsSlice []*hintscomponent.Hint,
 	style hintscomponent.StyleMode,
+	offset hintBadgeOffset,
 ) {
 	if o == nil || o.raw == nil {
 		return
 	}
 
-	o.drawHints(hintsSlice, style)
+	o.drawHints(hintsSlice, style, offset)
 }
 
 func (o *wlrootsOverlay) DrawMouseActionIndicator(

--- a/internal/adapter/overlay/linux/wayland_nocgo.go
+++ b/internal/adapter/overlay/linux/wayland_nocgo.go
@@ -42,7 +42,11 @@ func (o *wlrootsOverlay) ShowSubgrid(*domainGrid.Cell, gridcomponent.Style)     
 func (o *wlrootsOverlay) SetHideUnmatched(bool)                                  {}
 func (o *wlrootsOverlay) setOriginOffset(image.Point)                            {}
 func (o *wlrootsOverlay) DrawGrid(*domainGrid.Grid, string, gridcomponent.Style) {}
-func (o *wlrootsOverlay) DrawHints([]*hintscomponent.Hint, hintscomponent.StyleMode) {
+func (o *wlrootsOverlay) DrawHints(
+	[]*hintscomponent.Hint,
+	hintscomponent.StyleMode,
+	hintBadgeOffset,
+) {
 }
 
 func (o *wlrootsOverlay) DrawRecursiveGrid(

--- a/internal/adapter/overlay/linux/x11_cgo.go
+++ b/internal/adapter/overlay/linux/x11_cgo.go
@@ -223,12 +223,16 @@ func (o *x11Overlay) DrawMonitorSelect(
 	o.drawMonitorSelect(targets, style)
 }
 
-func (o *x11Overlay) DrawHints(hintsSlice []*hintscomponent.Hint, style hintscomponent.StyleMode) {
+func (o *x11Overlay) DrawHints(
+	hintsSlice []*hintscomponent.Hint,
+	style hintscomponent.StyleMode,
+	offset hintBadgeOffset,
+) {
 	if o == nil || o.raw == nil {
 		return
 	}
 
-	o.drawHints(hintsSlice, style)
+	o.drawHints(hintsSlice, style, offset)
 }
 
 func (o *x11Overlay) DrawMouseActionIndicator(

--- a/internal/adapter/overlay/linux/x11_nocgo.go
+++ b/internal/adapter/overlay/linux/x11_nocgo.go
@@ -40,7 +40,7 @@ func (o *x11Overlay) ShowSubgrid(*domainGrid.Cell, gridcomponent.Style)      {}
 func (o *x11Overlay) SetHideUnmatched(bool)                                  {}
 func (o *x11Overlay) setOriginOffset(image.Point)                            {}
 func (o *x11Overlay) DrawGrid(*domainGrid.Grid, string, gridcomponent.Style) {}
-func (o *x11Overlay) DrawHints([]*hintscomponent.Hint, hintscomponent.StyleMode) {
+func (o *x11Overlay) DrawHints([]*hintscomponent.Hint, hintscomponent.StyleMode, hintBadgeOffset) {
 }
 
 func (o *x11Overlay) DrawRecursiveGrid(


### PR DESCRIPTION
## Description

This PR fixes a hint placement on Linux being drawn as if it were `center` when the overlay has no way to draw it. Until now the Linux overlay recognised `top` and `bottom` and treated everything else as its fallback, painting a centred badge with no connector arrow. That happened to be right for `center`, but it meant any placement the overlay did not know how to draw would silently come out centred, with nothing failing anywhere to say so.

`center` is now a placement the overlay draws on purpose rather than by falling through, and a placement it cannot draw is reported as unsupported — and logged as a warning — before a single hint is painted, the same way every other unsupported overlay operation is reported. Nothing changes for anyone using `top`, `center` or `bottom`: all three land in exactly the same pixels as before, and a hints draw that arrives before any configuration has been applied still uses the documented default, as it already did on macOS.

## Related Issues

Closes #1302

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — the cgo and no-cgo Linux backends both carry the change; no other platform is touched
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, the accepted values of `hints.ui.placement` are unchanged, so no reference row moves
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Because `just lint` and `just test` skip `//go:build linux` files on macOS, this branch was also checked with `just check-cross`, `just lint-cross` (real Linux and Windows golangci-lint in Docker) and `just test-linux` (the Linux suite executed with CGO on, headless) — all green.

The placement is resolved once per draw rather than once per hint, so the per-keystroke hint redraw does one string comparison for the whole frame instead of two per label. Because the drawing code now takes a resolved value rather than the configured string, `exhaustive` also fails the build if a fourth placement is ever added without a Linux branch — the developer-facing half of the same guarantee.

An unset placement — a style that reaches the overlay before any configuration has been applied — keeps drawing at the documented default rather than being refused, matching what the macOS renderer already answers it. Without that, the same unsettled style would draw hints on macOS and nothing on Linux.

The same fall-through shape still exists in the macOS hint renderer, where an unrecognised placement draws as `bottom`. It is out of scope here and left alone.
