### PR TITLE
feat(nix): add services.neru.settings TOML configuration support

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -138,6 +138,7 @@ Use the nix-darwin module for system-wide installation:
 - `services.neru.package` - Package to use (default: `pkgs.neru` for latest version) or `pkgs.neru-source` for building from source
 - `services.neru.config` - Inline TOML configuration (default: uses `configs/default-config.toml`)
 - `services.neru.configFile` - Path to existing config file (default: `null`, takes precedence over `config`)
+- `services.neru.settings` - TOML configuration expressed as a Nix attribute set (default: `{}`, takes precedence over `config`)
 - `services.neru.launchd.enable` - Enable the launchd agent (default: `true`)
 - `services.neru.launchd.keepAlive` - Keep the launchd service alive (default: `true`)
 - `services.neru.extraEnvironment` - Additional environment variables for the launchd service (default: `{}`; includes a sensible `PATH` with Nix binary directories)
@@ -252,6 +253,7 @@ Use the NixOS module for system-wide installation on Linux:
 - `services.neru.package` - Package to use (default: `pkgs.neru`; uses release artifact on Linux, builds from source if unavailable)
 - `services.neru.config` - Inline TOML configuration (default: uses `configs/default-config.toml`)
 - `services.neru.configFile` - Path to existing config file (default: `null`, takes precedence over `config`)
+- `services.neru.settings` - TOML configuration expressed as a Nix attribute set (default: `{}`, takes precedence over `config`)
 - `services.neru.systemd.restart` - Systemd restart policy (default: `"on-failure"`)
 - `services.neru.systemd.restartSec` - Seconds to wait before restarting (default: `5`)
 - `services.neru.extraEnvironment` - Additional environment variables for the systemd service (default: `{}`; includes a sensible `PATH` with Nix binary directories)
@@ -363,6 +365,7 @@ Use the home-manager module for user-specific installation on macOS or Linux:
 - `services.neru.package` - Package to use (default: `pkgs.neru`; uses release artifact on Linux, builds from source if unavailable)
 - `services.neru.config` - Inline TOML configuration (default: uses `configs/default-config.toml`)
 - `services.neru.configFile` - Path to existing config file (default: `null`, takes precedence over `config`)
+- `services.neru.settings` - TOML configuration expressed as a Nix attribute set (default: `{}`, takes precedence over `config`)
 - `services.neru.launchd.enable` - Enable the launchd agent on macOS (default: `true`)
 - `services.neru.launchd.keepAlive` - Keep the launchd service alive on macOS (default: `true`)
 - `services.neru.systemd.enable` - Enable the systemd user service on Linux (default: `true`)
@@ -458,6 +461,21 @@ Or with home-manager:
      "Primary+'" = "grid left_click"
      "Primary+Shift+S" = "scroll"
   '';
+}
+```
+
+**Custom hotkeys using `services.neru.settings`(home-manager):**
+
+```nix
+{
+  services.neru.enable = true;
+  services.neru.settings = {
+	hotkeys = {
+	  "Primary+;" = "hints left_click";
+	  "Primary+'" = "grid left_click";
+	  "Primary+Shift+S" = "scroll";
+	};
+  };
 }
 ```
 

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -93,6 +93,29 @@ in
           ThrottleInterval = 10;
         };
       };
+
+	  assertions = [
+        # Fail if user set more than one configuration source
+        {
+          assertion =
+            (lib.count (x: x) [
+              (cfg.settings != {})
+              (cfg.configFile != null)
+              (cfg.config != builtins.readFile ../configs/default-config.toml)
+            ])
+            <= 1;
+
+          message = ''
+            services.neru: only one of the following options may be set:
+              - services.neru.settings
+              - services.neru.config
+              - services.neru.configFile
+
+            Please choose a single configuration source.
+          '';
+        }
+      ];
+
     }
   );
 }

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -6,8 +6,13 @@
 }:
 let
   cfg = config.services.neru;
+  tomlFormat = pkgs.formats.toml {};
   configFile =
-    if cfg.configFile != null then cfg.configFile else pkgs.writeText "config.toml" cfg.config;
+    if cfg.configFile != null
+    then cfg.configFile
+    else if cfg.settings != {}
+	then tomlFormat.generate "config.toml" cfg.settings
+    else pkgs.writeText "config.toml" cfg.config;
   effectiveEnv = {
     PATH = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
   }
@@ -27,6 +32,13 @@ in
         type = lib.types.nullOr lib.types.path;
         default = null;
         description = "Path to existing config.toml configuration file. Takes precedence over config option.";
+      };
+	  settings = lib.mkOption {
+        inherit (tomlFormat) type;
+        default = {};
+        description = ''
+          Configuration of neru in nix programming language
+        '';
       };
       launchd = {
         enable = lib.mkEnableOption "the launchd agent managing the Neru process" // {

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -6,6 +6,7 @@
 }:
 let
   cfg = config.services.neru;
+  tomlFormat = pkgs.formats.toml {};
   defaultPath = lib.concatStringsSep ":" (
     [
       "${config.home.homeDirectory}/.nix-profile/bin"
@@ -55,6 +56,14 @@ in
         type = lib.types.nullOr lib.types.path;
         default = null;
         description = "Path to existing config.toml configuration file. Takes precedence over config option.";
+      };
+	
+	  settings = lib.mkOption {
+        inherit (tomlFormat) type;
+        default = {};
+        description = ''
+          Configuration of neru in nix programming language
+        '';
       };
 
       launchd = {
@@ -139,8 +148,15 @@ in
     home.packages = [ cfg.package ];
 
     # Generate config file - either from text or source file
-    xdg.configFile."neru/config.toml" =
-      if cfg.configFile != null then { source = cfg.configFile; } else { text = cfg.config; };
+	xdg.configFile."neru/config.toml" =
+      if cfg.configFile != null
+      then {source = cfg.configFile;}
+      else if cfg.settings != {}
+      then {
+        source = tomlFormat.generate "config.toml" cfg.settings;
+      }
+      else {text = cfg.config;};
+
 
     # Launch agent for macOS
     launchd.agents.neru = lib.mkIf pkgs.stdenv.isDarwin {

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -198,5 +198,28 @@ in
         WantedBy = [ "graphical-session.target" ];
       };
     };
+
+	assertions = [
+      # Fail if user set more than one configuration source
+      {
+        assertion =
+          (lib.count (x: x) [
+            (cfg.settings != {})
+            (cfg.configFile != null)
+            (cfg.config != builtins.readFile ../configs/default-config.toml)
+          ])
+          <= 1;
+
+        message = ''
+          programs.neru: only one of the following options may be set:
+            - programs.neru.settings
+            - programs.neru.config
+            - programs.neru.configFile
+
+          Please choose a single configuration source.
+        '';
+      }
+    ];
+
   };
 }

--- a/nix/nixos.nix
+++ b/nix/nixos.nix
@@ -6,8 +6,13 @@
 }:
 let
   cfg = config.services.neru;
+  tomlFormat = pkgs.formats.toml {};
   configFile =
-    if cfg.configFile != null then cfg.configFile else pkgs.writeText "config.toml" cfg.config;
+    if cfg.configFile != null
+    then cfg.configFile
+    else if cfg.settings != {}
+	then tomlFormat.generate "config.toml" cfg.settings
+    else pkgs.writeText "config.toml" cfg.config;
   effectiveEnv = {
     PATH = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin";
   }
@@ -42,6 +47,13 @@ in
         type = lib.types.nullOr lib.types.path;
         default = null;
         description = "Path to existing config.toml configuration file. Takes precedence over config option.";
+      };
+	  settings = lib.mkOption {
+        inherit (tomlFormat) type;
+        default = {};
+        description = ''
+          Configuration of neru in nix programming language
+        '';
       };
       systemd = {
         restart = lib.mkOption {

--- a/nix/nixos.nix
+++ b/nix/nixos.nix
@@ -108,6 +108,28 @@ in
           Nice = -10;
         };
       };
+	  assertions = [
+        # Fail if user set more than one configuration source
+        {
+          assertion =
+            (lib.count (x: x) [
+              (cfg.settings != {})
+              (cfg.configFile != null)
+              (cfg.config != builtins.readFile ../configs/default-config.toml)
+            ])
+            <= 1;
+
+          message = ''
+            services.neru: only one of the following options may be set:
+              - services.neru.settings
+              - services.neru.config
+              - services.neru.configFile
+
+            Please choose a single configuration source.
+          '';
+        }
+      ];
+
     }
   );
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds the option `services.neru.settings`, allowing TOML configuration to be expressed as a Nix attribute set instead of requiring inline TOML.

This follows the same approach used by other Nix programs such as Aerospace and Atuin, where TOML-based configuration can be represented as native Nix attribute sets.


<details>

<summary>EXAMPLE</summary>

### EXAMPLE
```nix
{
  services.neru.settings = {
    hotkeys = {
      "Ctrl+F" = "recursive_grid --cursor-selection-mode hold";
      "Primary+Shift+K" = "recursive_grid left_click";
    };
    
    recursive_grid = {
      enabled = true;
      grid_cols = 3;
    };
  };
} 
```
converts to:

```TOML
[hotkeys]
"Ctrl+F" = "recursive_grid --cursor-selection-mode hold"
"Primary+Shift+K" = "recursive_grid left_click"

[recursive_grid]
enabled = true
grid_cols = 3
```
</details>

It also adds an assertion to ensure that at most one configuration format (`configFile`, `config`, or `settings`) is specified at a time, preventing ambiguous or conflicting configurations. If this approach is not preferred, I am happy to adjust it or remove the assertion.

<details>

<summary>EXAMPLE</summary>

### EXAMPLE

```nix
{
  services.neru.settings = {
    hotkeys = {
      "Ctrl+F" = "recursive_grid --cursor-selection-mode hold";
    };
  };

  services.neru.configFile = ./config.toml;
}
```

will result in 

```zsh
error:
       … while evaluating the attribute 'optionalValue.value'
         at «github:nixos/nixpkgs/e72e4f2»/lib/modules.nix:1312:5:
         1311|
         1312|     optionalValue = if isDefined then { value = mergedValue; } else { };
             |     ^
         1313|   };

       … while evaluating a branch condition
         at «github:nixos/nixpkgs/e72e4f2»/lib/modules.nix:1312:21:
         1311|
         1312|     optionalValue = if isDefined then { value = mergedValue; } else { };
             |                     ^
         1313|   };

       … while evaluating definitions from `/nix/store/vis2cx3p66plx6zjvj0yycqhykic8dqs-source/modules/system':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error:
       Failed assertions:
       - services.neru: only one of the following options may be set:
         - services.neru.settings
         - services.neru.config
         - services.neru.configFile

       Please choose a single configuration source.
```

</details>


> [!NOTE]
> This has been tested with Darwin + Home Manager on my Mac mini. NixOS support has been added but remains untested.

## Related Issues
none
<!-- Link related issues: Closes #123, Fixes #456 -->

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

<!-- If your PR touches OS-specific code, verify the following. Check N/A if not applicable. -->

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`) — not applicable (Nix-only changes)
- [x] `just ci` passes — not applicable (Nix-only changes)
- [x] Tests added/updated for new or changed functionality — not applicable
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

This is my first open-source contribution, so feedback is very welcome. I would appreciate any suggestions on how I can improve future contributions.