### PR TITLE
docs(cross-platform): say that hint placement does nothing on Windows

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -137,6 +137,8 @@ border_radius = -1                          # -1 = auto pill
 padding_x = -1                              # -1 = auto based on font size
 padding_y = -1                              # -1 = auto based on font size
 border_width = 1
+# The placement option below has no effect on Windows:
+# https://github.com/y3owk1n/neru/blob/main/docs/CROSS_PLATFORM.md#mode-coverage
 placement = "bottom"                        # top, center, bottom
 
 [hints.search_input_ui]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -858,7 +858,7 @@ hints.clickable_roles: unknown role "AXButton": use "button"
 | `padding_x`          | int    | `-1`       | Horizontal padding (-1 = auto)             |
 | `padding_y`          | int    | `-1`       | Vertical padding (-1 = auto)               |
 | `border_width`       | int    | `1`        | Border width in pixels                     |
-| `placement`          | string | `"bottom"` | Label placement: `top`, `center`, `bottom` |
+| `placement`          | string | `"bottom"` | Label placement: `top`, `center`, `bottom`; [no effect on Windows](CROSS_PLATFORM.md#mode-coverage) |
 | `background_color`   | color  | derived    | Background color                           |
 | `text_color`         | color  | derived    | Text color                                 |
 | `matched_text_color` | color  | derived    | Text color for matched characters          |

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -450,6 +450,7 @@ discovery rather than the mode itself.
 | **Hints**         | Menubar / dock elements        | ✅                         | 🟡                         | 🟡                          |
 | **Hints**         | Search input badge             | ✅                         | ❌ no-op                   | ✅                          |
 | **Hints**         | Label arrow / tail             | ✅ NSBezierPath            | ✅ Cairo triangle          | ❌                          |
+| **Hints**         | Label placement                | ✅ top / center / bottom   | ✅ top / center / bottom   | ❌ ignored, see below       |
 | **Grid**          | Transition animation           | ✅                         | ✅                         | ❌                          |
 | **Grid**          | Virtual pointer indicator      | ✅                         | ❌ no-op                   | ❌ no-op                    |
 | **Recursive grid**| Transition animation           | ✅                         | ✅                         | ❌                          |
@@ -467,6 +468,26 @@ actions on grid cells, subgrid zoom, backtracking, and every scroll granularity.
 > cursor is hidden — is separate from the recursive-grid indicator above and is
 > macOS-only: `virtualpointer.Overlay` is a no-op on every non-darwin build, and
 > it is paired with `CGDisplayHideCursor`, which has no equivalent elsewhere.
+
+> **`hints.ui.placement` is honoured on two platforms of three.** macOS and
+> Linux both read it and offset the badge from the target point at the
+> element's centre, keeping it horizontally centred there: `top` puts the badge
+> above that point with a connector arrow pointing down at it, `center` over it
+> with no arrow, `bottom` below it with an arrow pointing up (the default).
+> Windows reads the value nowhere. Its `DrawHints` anchors every badge at the
+> element's **top-left corner**, growing right and down from it, and draws the
+> same thing whichever of the three values is configured — so a Windows user
+> gets none of the three, not one of them, and no connector arrow either (the
+> **Label arrow / tail** row). The value still validates on Windows: all three
+> are accepted, so nothing warns and nothing errors, and the option is simply
+> inert.
+>
+> Drawing the three placements on Windows is tracked as
+> [#1303](https://github.com/y3owk1n/neru/issues/1303); it needs a Windows
+> contributor. The values themselves are unambiguous — they are declared once
+> in Go and pinned across the Objective-C chain
+> ([#1289](https://github.com/y3owk1n/neru/issues/1289)) — so what is missing
+> is the drawing, not the vocabulary.
 
 > **`recursive_grid.ui.sub_key_preview` is one option with two drawings.** macOS
 > and Linux divide each cell by the *next* level's grid dimensions and draw the
@@ -543,6 +564,9 @@ Work that is genuinely missing, as opposed to deliberately platform-specific.
 10. Font resolution — alias mapping only, no system font enumeration
 11. Recursive-grid sub-key preview — a single bottom label rather than the
     mini-grid the other platforms draw ([Mode Coverage](#mode-coverage))
+12. Hint badge placement — `hints.ui.placement` has no effect; the badge is
+    always anchored at the element's top-left corner
+    ([Mode Coverage](#mode-coverage))
 
 **macOS**
 


### PR DESCRIPTION
## Description

This PR documents that the hint badge placement option does nothing on Windows.
The option is accepted on all three platforms and validates the same way
everywhere, but only macOS and Linux actually draw the three placements. On
Windows the hint badge is always anchored at the top-left corner of the element
it labels, whichever value is set, and no connector arrow is drawn at all — so a
Windows user setting it got no error and no effect, and nothing in the docs said
so.

The cross-platform guide now carries the entry: a parity-table row, a note
spelling out what each platform actually draws, and a known-gaps line for
Windows. The config reference and the shipped example config link to it rather
than restating it.

**This is the documentation half of #1303 only.** Making the Windows overlay
honour `top`, `center` and `bottom` is not in this PR and remains open on
#1303, pending a Windows contributor — which is why the issue is referenced
rather than closed.

## Related Issues

Refs #1303 — intentionally not a closing keyword; the implementation half of
that issue is still outstanding.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code) — documentation
      only; no code changes on any platform
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no code changed
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no code changed
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no code changed
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, see Additional Context
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Configuration surface

No schema change. `hints.ui.placement` keeps its type, its default and all
three accepted values on every platform; existing configs keep working
unchanged, and nothing new warns or errors. Only what the docs say about it
changes:

| Where | What changed |
| --- | --- |
| `docs/CROSS_PLATFORM.md` | New **Hints / Label placement** row in Mode Coverage, a note on what each platform draws, and Windows known-gap 12 |
| `docs/CONFIGURATION.md` | The `placement` row now links to the cross-platform entry |
| `configs/default-config.toml` | Comment above `placement` pointing at the same entry |

```toml
[hints.ui]
placement = "bottom" # top, center, bottom — no effect on Windows
```

## Additional Context

The claim was checked against the code rather than taken from the issue. The
Windows hint draw never reads the placement value; the macOS and Linux draws
both do, and both offset the badge from the element's centre point with a
connector arrow. That difference — centre-relative with an arrow versus
top-left corner with none — is what the note describes, and it is deliberately
narrower than "Windows draws it somewhere else": on a small element the Windows
badge can also overflow the element's bounds.

No guardrail test was added. The repo does pin some doc facts with tests, but
those pin a documented list against a vocabulary declared in code
(`role_vocabulary_docs_test.go` is the pattern). There is no existing pattern
for pinning "backend X ignores option Y", and a test asserting the Windows draw
never reads placement would be an anti-guardrail — it would fail exactly when
someone implements #1303, which is the outcome we want. The same-class change
for `recursive_grid.ui.sub_key_preview` (#1296) added no test either.

`just ci` was run in full and exited 0, on this branch rebased on the current
`main`.
