### PR TITLE
fix(linux): fall back to the generic font when the configured family is not installed

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -165,6 +165,21 @@ Windows only maps the generic aliases `sans` / `serif` / `mono` to Segoe UI /
 Cambria / Consolas and passes every other name straight to GDI without checking
 it; an unavailable family falls back to whatever GDI substitutes.
 
+A family somebody named resolves to **that name**: the answer is the family the
+config asked for, not the family the platform would render in its place. The one
+exception is Linux with fontconfig, the only backend that can tell an installed
+family from a missing one — a missing one falls back to DejaVu Sans rather than
+to fontconfig's own substitution for the name, so `font_family = "Arial"`
+without Arial installed reports DejaVu Sans and not the Liberation Sans
+`fc-match Arial` names. It is the sans baseline whatever face the name asked
+for: the serif and mono baselines are what the `serif` and `mono` aliases
+resolve to, so a missing `Times New Roman` also lands on DejaVu Sans. Where the
+baseline is itself missing, fontconfig chooses that machine's generic, so the
+fallback is always a family it has. macOS, Windows, the non-CGO Linux build, and a CGO build whose
+fontconfig cannot be consulted at all check nothing: they hand the written name
+to NSFont / GDI / Cairo, which substitute when the text is drawn — as Cairo does
+on Linux too, for whichever name it is given.
+
 Which names count as generic is the same on all three: `sans`, `sans serif`,
 `serif`, `mono`, `monospace` and the empty string, matched ignoring case,
 surrounding whitespace and the separator between words — `sans-serif`,

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -234,13 +234,23 @@ main-run-loop test harness is documented in
 processing, mode transitions, config parsing/validation/defaults, and CLI
 argument handling. These run everywhere.
 
-**Integration** — today these are **macOS only**: real Accessibility and event
-tap APIs, global hotkey registration, overlay and window management, Unix socket
-IPC, config file loading and reloading, and service-to-adapter coordination.
-`*_integration_linux_test.go` and `*_integration_windows_test.go` are the
-reserved slots — no such tests exist yet, so Linux and Windows behavior is
-currently pinned by unit and contract tests alone. Adding real ones is one of
-the more valuable contributions available.
+**Integration** — almost all of these are **macOS**: real Accessibility and
+event tap APIs, global hotkey registration, overlay and window management, Unix
+socket IPC, config file loading and reloading, and service-to-adapter
+coordination. Linux has exactly one so far — the fontconfig font resolver
+(`internal/adapter/platform/linux/font_integration_linux_test.go`, which reads
+what is installed with `fc-list` and skips where fontconfig has nothing to
+report) — and Windows has none, so behavior on both is otherwise pinned by unit
+and contract tests alone. Adding real ones is one of the more valuable
+contributions available.
+
+No `just` recipe runs the Linux ones: `just test-linux` runs the container
+without the `integration` tag, and `just test-integration` runs on the host.
+Until there is a recipe, run them the way the container recipe does and add the
+tag — `docker run --rm -v "$PWD":/src -w /src -e CGO_ENABLED=1 neru-linux-ci go
+test -tags=integration ./...` — on an image with fonts and `fc-list` installed
+(`fontconfig fonts-dejavu-core`). CI covers them on `ubuntu-latest`, where
+`just test-ci` runs the integration suite natively.
 
 ### Running integration tests
 

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -359,11 +359,13 @@ Set a font with modifier glyphs:
 font_family = "Your installed symbol-capable font"
 ```
 
-Verify candidates with fontconfig:
+Check the family is installed — a family fontconfig does not have falls back to
+the DejaVu generic rather than to fontconfig's substitute for it
+([font resolution](CROSS_PLATFORM.md#capability-matrix)), so the name has to be
+one `fc-list` reports:
 
 ```bash
-fc-match "sans-serif"
-fc-match "monospace"
+fc-list : family | grep -i "your font"
 ```
 
 Paste `❖⇧⌥⌃` into a text editor to confirm the font renders before relying on it

--- a/internal/adapter/platform/linux/font_cgo.go
+++ b/internal/adapter/platform/linux/font_cgo.go
@@ -6,12 +6,59 @@ package linux
 #include <fontconfig/fontconfig.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
-// Returns the family name that fontconfig matches for the given input,
-// or NULL if it cannot be resolved. The returned string is a heap
-// allocation; the caller must free it.
-static char *fc_match_family(const char *family) {
+// Reports whether fontconfig knows a font whose family is the given name,
+// compared the way fontconfig compares family names (ignoring case and
+// blanks). Returns 1 when the family is installed, 0 when it is not, and -1
+// when fontconfig cannot be consulted at all.
+//
+// This lists fonts rather than matching one: FcFontMatch always answers with
+// something, so it can say what would render but never whether the family
+// asked for is the family that would.
+static int fc_family_installed(const char *family) {
+	if (!family || !*family) {
+		return 0;
+	}
+	if (!FcInit()) {
+		return -1;
+	}
+
+	FcPattern *pat = FcPatternCreate();
+	if (!pat) {
+		return -1;
+	}
+
+	if (!FcPatternAddString(pat, FC_FAMILY, (const FcChar8 *)family)) {
+		FcPatternDestroy(pat);
+
+		return -1;
+	}
+
+	FcObjectSet *props = FcObjectSetBuild(FC_FAMILY, (char *)NULL);
+	if (!props) {
+		FcPatternDestroy(pat);
+
+		return -1;
+	}
+
+	FcFontSet *fonts = FcFontList(NULL, pat, props);
+	FcObjectSetDestroy(props);
+	FcPatternDestroy(pat);
+
+	if (!fonts) {
+		return -1;
+	}
+
+	int installed = fonts->nfont > 0 ? 1 : 0;
+	FcFontSetDestroy(fonts);
+
+	return installed;
+}
+
+// Returns the family name fontconfig would render for the given input, or NULL
+// if it cannot be resolved. The returned string is a heap allocation; the
+// caller must free it.
+static char *fc_substitute_family(const char *family) {
 	if (!family || !*family) {
 		return NULL;
 	}
@@ -70,9 +117,9 @@ func NewFontResolver() ports.FontResolver {
 }
 
 // fontconfigResolver implements ports.FontResolver using libfontconfig.
-// It maps generic aliases to known-good installed families, asks
-// fontconfig to verify user-supplied names, and falls back to a hardcoded
-// default when fontconfig cannot resolve a family at all.
+// It maps generic aliases to known-good installed families and asks
+// fontconfig whether a user-supplied family is installed, falling back to
+// this platform's generic family when it is not.
 type fontconfigResolver struct {
 	cache *fontcache.Resolver
 }
@@ -84,24 +131,80 @@ func (r *fontconfigResolver) Resolve(family string, bold bool) string {
 	return r.cache.Resolve(family)
 }
 
-// resolve performs the actual lookup. It first maps the input to a
-// concrete family, then asks fontconfig to match it. If fontconfig
-// cannot match the family at all, it falls back to a hardcoded default.
+// resolve performs the actual lookup. It maps the input to a concrete family
+// and asks fontconfig whether that family is installed: if it is, that is the
+// answer — the name as the caller wrote it, which is what ports.FontResolver
+// promises and what macOS and Windows return. If it is not, the answer is this
+// platform's generic family for it, handed to fontconfig so that a machine
+// without the DejaVu baseline still gets a family it has.
+//
+// The question deliberately is not "what would fontconfig render for this
+// name": fontconfig always matches something, so asking that way answers a
+// missing "Arial" with whatever it substitutes and leaves the caller unable to
+// tell a family it has from one it does not. Substitution still happens where
+// it belongs — Pango and Cairo do it when the text is drawn.
 func (r *fontconfigResolver) resolve(family string) string {
 	mapped := linuxFamilies.Resolve(family)
 
-	cFamily := C.CString(mapped)
-	defer C.free(unsafe.Pointer(cFamily))
+	presence := lookUpFamily(mapped)
 
-	matched := C.fc_match_family(cFamily)
-	if matched != nil {
-		defer C.free(unsafe.Pointer(matched))
-
-		got := C.GoString(matched)
-		if got != "" {
-			return got
-		}
+	if presence == familyMissing {
+		return substituteFamily(defaultForMapped(mapped))
 	}
 
-	return defaultForMapped(mapped)
+	// familyPresent, or familyUnknown: nothing can be verified on a machine
+	// whose fontconfig cannot be consulted at all, so that case behaves like
+	// the non-CGO build — map the generics, pass the rest through as written.
+	return mapped
+}
+
+// familyPresence is what fontconfig can say about a family. An unusable
+// fontconfig is not the same answer as a family that is missing, so the two
+// are not one boolean.
+type familyPresence int
+
+const (
+	// familyUnknown means fontconfig could not be consulted at all.
+	familyUnknown familyPresence = iota
+	// familyMissing means fontconfig has no font of that family.
+	familyMissing
+	// familyPresent means fontconfig has the family installed.
+	familyPresent
+)
+
+// lookUpFamily asks fontconfig whether it has the given family.
+func lookUpFamily(family string) familyPresence {
+	cFamily := C.CString(family)
+	defer C.free(unsafe.Pointer(cFamily))
+
+	switch C.fc_family_installed(cFamily) {
+	case 1:
+		return familyPresent
+	case 0:
+		return familyMissing
+	default:
+		return familyUnknown
+	}
+}
+
+// substituteFamily returns the family fontconfig would render for the given
+// one, and the family itself when fontconfig has nothing to say. It is asked
+// only about the hardcoded baselines, so what it substitutes for a machine
+// without DejaVu is that machine's own generic.
+func substituteFamily(family string) string {
+	cFamily := C.CString(family)
+	defer C.free(unsafe.Pointer(cFamily))
+
+	matched := C.fc_substitute_family(cFamily)
+	if matched == nil {
+		return family
+	}
+
+	defer C.free(unsafe.Pointer(matched))
+
+	if got := C.GoString(matched); got != "" {
+		return got
+	}
+
+	return family
 }

--- a/internal/adapter/platform/linux/font_common_test.go
+++ b/internal/adapter/platform/linux/font_common_test.go
@@ -45,7 +45,7 @@ func TestLinuxFamilies_Resolve_NamedFamilyPassesThroughTrimmed(t *testing.T) {
 }
 
 func TestDefaultForMapped_KeepsTheBaselineThatWasMapped(t *testing.T) {
-	// When fontconfig matches nothing at all, a mapped baseline is kept and
+	// When fontconfig says the family is missing, a mapped baseline is kept and
 	// anything else falls back to sans. The input is a family already mapped,
 	// not what the user wrote.
 	cases := map[string]string{

--- a/internal/adapter/platform/linux/font_integration_linux_test.go
+++ b/internal/adapter/platform/linux/font_integration_linux_test.go
@@ -1,0 +1,214 @@
+//go:build integration && linux && cgo
+
+package linux
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/ports"
+)
+
+// missingFamily is a family name no machine has installed. It has to be absent
+// for the fallback case to mean anything, so the test verifies that rather than
+// trusting it.
+const missingFamily = "Neru No Such Font Family 4f2a"
+
+func TestFontconfigResolver_Resolve_GenericAliasesGiveAnInstalledFamily(t *testing.T) {
+	// Which spellings count as generic is pinned by the shared parser
+	// (platform/fontgeneric); what matters here is that each one resolves to a
+	// family this machine has.
+	aliases := []string{
+		"", "sans", "Sans Serif", "sans-serif", "sans_serif",
+		"serif", "mono", "monospace",
+	}
+
+	installed := installedFamilies(t)
+	resolver := NewFontResolver()
+
+	for _, alias := range aliases {
+		name := alias
+		if name == "" {
+			name = "empty"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			got := resolver.Resolve(alias, false)
+
+			if !isInstalled(installed, got) {
+				t.Fatalf(
+					"Resolve(%q) = %q, which no installed family matches; a "+
+						"generic alias must resolve to a family this machine has",
+					alias,
+					got,
+				)
+			}
+		})
+	}
+}
+
+func TestFontconfigResolver_Resolve_InstalledFamilyComesBackAsWritten(t *testing.T) {
+	installed := installedFamilies(t)
+	family := aFamilyWorthRespelling(t, installed)
+	resolver := NewFontResolver()
+
+	// The respellings are the cases that separate the two rules: fontconfig
+	// matches them all (its family comparison ignores case and blanks) and
+	// reports the family's own capitalisation, where the port promises back the
+	// name the caller wrote.
+	cases := map[string]string{
+		family:                              family,
+		"  " + family + "  ":                family,
+		strings.ToLower(family):             strings.ToLower(family),
+		strings.ReplaceAll(family, " ", ""): strings.ReplaceAll(family, " ", ""),
+	}
+
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := resolver.Resolve(input, false); got != want {
+				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestFontconfigResolver_Resolve_MissingFamilyFallsBackToTheResolvedGeneric(t *testing.T) {
+	installed := installedFamilies(t)
+	if isInstalled(installed, missingFamily) {
+		t.Skipf("%q is installed here; the fallback cannot be exercised", missingFamily)
+	}
+
+	// Names a stock fontconfig carries a substitution rule for. On a machine
+	// that has none of them they are the sharp version of the missing-family
+	// case: fontconfig answers each with a different family's name, so
+	// reporting what fontconfig matched and falling back to the generic are
+	// visibly different answers.
+	substituted := []string{"Helvetica", "Arial", "Times New Roman", "Courier New"}
+
+	resolver := NewFontResolver()
+	want := theResolvedGeneric(t, installed, resolver)
+
+	missing := []string{missingFamily}
+
+	for _, family := range substituted {
+		if !isInstalled(installed, family) {
+			missing = append(missing, family)
+		}
+	}
+
+	for _, family := range missing {
+		t.Run(family, func(t *testing.T) {
+			got := resolver.Resolve(family, false)
+
+			if got != want {
+				t.Fatalf(
+					"Resolve(%q) = %q, want the resolved generic %q — a family "+
+						"that is not installed falls back to the generic, not "+
+						"to whatever fontconfig would substitute for it",
+					family,
+					got,
+					want,
+				)
+			}
+
+			if !isInstalled(installed, got) {
+				t.Fatalf("Resolve(%q) = %q, which no installed family matches", family, got)
+			}
+		})
+	}
+}
+
+// theResolvedGeneric is the family a missing one falls back to: the Linux sans
+// baseline on any machine that has it, which is the answer stated outright
+// rather than read back out of the resolver. Only where the baseline itself is
+// missing does it have to ask, since what fontconfig substitutes there is the
+// machine's own business.
+func theResolvedGeneric(t *testing.T, installed []string, resolver ports.FontResolver) string {
+	t.Helper()
+
+	if isInstalled(installed, defaultLinuxSans) {
+		return defaultLinuxSans
+	}
+
+	return resolver.Resolve("sans", false)
+}
+
+// installedFamilies asks fontconfig which families this machine has, through
+// fc-list rather than through the resolver: every case here needs to know what
+// is installed, and the code under test cannot be the one to say. Skips when
+// fontconfig has nothing to report, which is a machine the cases cannot run on
+// rather than a failure.
+func installedFamilies(t *testing.T) []string {
+	t.Helper()
+
+	_, lookErr := exec.LookPath("fc-list")
+	if lookErr != nil {
+		t.Skipf("fc-list is not installed, so what fontconfig has cannot be read: %v", lookErr)
+	}
+
+	listed, listErr := exec.CommandContext(
+		t.Context(), "fc-list", "--format", "%{family}\n",
+	).Output()
+	if listErr != nil {
+		t.Fatalf("fc-list error = %v", listErr)
+	}
+
+	var families []string
+
+	for line := range strings.SplitSeq(string(listed), "\n") {
+		// A font carrying several family names is printed as one
+		// comma-separated line; each of them is installed.
+		for family := range strings.SplitSeq(line, ",") {
+			if trimmed := strings.TrimSpace(family); trimmed != "" {
+				families = append(families, trimmed)
+			}
+		}
+	}
+
+	if len(families) == 0 {
+		t.Skip("no fonts are installed on this machine")
+	}
+
+	return families
+}
+
+// aFamilyWorthRespelling returns an installed family that can be asked for in a
+// spelling other than its own — one with capitals to lower and a space to
+// remove, so the respellings are different strings from the name fontconfig
+// holds.
+func aFamilyWorthRespelling(t *testing.T, installed []string) string {
+	t.Helper()
+
+	for _, family := range installed {
+		if family != strings.ToLower(family) && strings.Contains(family, " ") {
+			return family
+		}
+	}
+
+	t.Skip("no installed family has both capitals and a space to respell")
+
+	return ""
+}
+
+// isInstalled reports whether any installed family is the given name, compared
+// the way fontconfig compares family names: ignoring case and blanks.
+func isInstalled(installed []string, family string) bool {
+	for _, candidate := range installed {
+		if sameFamily(candidate, family) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// sameFamily compares two family names ignoring case and blanks, which is what
+// fontconfig's own family comparison does.
+func sameFamily(a, b string) bool {
+	fold := func(name string) string {
+		return strings.ToLower(strings.ReplaceAll(name, " ", ""))
+	}
+
+	return fold(a) == fold(b)
+}

--- a/internal/adapter/platform/linux/font_nocgo.go
+++ b/internal/adapter/platform/linux/font_nocgo.go
@@ -6,9 +6,12 @@ import "github.com/y3owk1n/neru/internal/ports"
 
 // NewFontResolver returns a fontconfig-less ports.FontResolver. It still
 // maps generic aliases to the Linux baseline families so non-CGO builds
-// behave deterministically, but cannot verify whether a user-supplied
-// family is installed. CGO builds (the default) get a full fontconfig
-// adapter in font_linux_cgo.go.
+// behave deterministically, and returns every other family as written — the
+// same answer the fontconfig build gives for a family that is installed. What
+// it cannot do is see that a family is missing, so nothing falls back to the
+// generic here; Cairo substitutes when the text is drawn, as it does for macOS
+// and Windows. CGO builds (the default) get the fontconfig adapter in
+// font_cgo.go.
 func NewFontResolver() ports.FontResolver {
 	return &passthroughResolver{}
 }

--- a/internal/ports/font.go
+++ b/internal/ports/font.go
@@ -4,8 +4,9 @@ import "sync"
 
 // FontResolver resolves a user-supplied font family to a real, installed font
 // family on the host system. Implementations handle generic aliases
-// (e.g. "Sans", "Monospace"), verify family availability, and apply
-// platform-specific fallback chains. Results may be cached internally
+// (e.g. "Sans", "Monospace"), may verify family availability where the
+// platform can see it, and apply platform-specific fallback chains. Results
+// may be cached internally
 // (adapter/platform/fontcache); caching never changes an answer, so what a
 // name resolves to depends on that name alone.
 type FontResolver interface {
@@ -15,8 +16,15 @@ type FontResolver interface {
 	//   - generic aliases ("Sans", "Sans Serif", "Serif", "Monospace", ...) are
 	//     mapped to a known-good installed family; every platform reads the
 	//     same spellings (adapter/platform/fontgeneric)
-	//   - other family names are returned as written, trimmed, when installed;
-	//     missing families fall back to the resolved generic family
+	//   - other family names are returned as written, trimmed: the answer is
+	//     the family the caller asked for, not the family the platform would
+	//     render in its place
+	//   - the one exception is a family the platform can see is not installed,
+	//     which falls back to the resolved generic family. Only the
+	//     fontconfig-backed Linux resolver can see that; macOS, Windows and
+	//     the non-CGO Linux build check nothing, pass the written name on, and
+	//     leave substitution to the native text layer, which does it when the
+	//     text is drawn either way
 	//   - bold is reserved for future weight-specific resolution and is
 	//     currently ignored by all implementations
 	Resolve(family string, bold bool) string


### PR DESCRIPTION
## Description

This PR fixes what a configured font family resolves to on Linux. The answer
used to be whatever fontconfig would render for the name, which meant it could
be a different font's name entirely: a family that is not installed came back as
fontconfig's substitute for it, and an installed one came back in fontconfig's
capitalisation rather than as it was written. macOS and Windows hand back the
name the config asked for, and the port contract described only them.

Linux now asks fontconfig whether the family is installed rather than what it
would render. An installed family resolves to the name as written, trimmed, like
the other platforms; one that is not installed falls back to the DejaVu generic.
Generic aliases (`sans`, `serif`, `mono`, empty) are unchanged and still resolve
to a family the machine actually has.

The deliberate limitation: the fallback is the sans baseline whatever face the
missing name asked for, so a missing `Times New Roman` lands on DejaVu Sans
rather than on a serif. That is the fallback the resolver has always applied
when fontconfig matched nothing at all; this change only widens when it is
reached.

## Related Issues

Closes #1310

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, the resolver port has no error channel; the no-CGO Linux twin already exists and its contract is restated to match
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Potentially breaking

Nothing changes for a config naming a font that is installed, and nothing
changes for the generic aliases. What changes is a config naming a font this
machine does not have: `font_family = "Arial"` without Arial installed used to
render Liberation Sans (fontconfig's metric-compatible substitute) and now
renders DejaVu Sans. Anyone relying on that substitution should name the family
they actually want — `fc-list : family | grep -i arial` lists what is installed.
No config file stops loading and no option changes shape.

## Additional Context

- The resolver asks `FcFontList` (which never substitutes) instead of
  `FcFontMatch` (which always matches something). Substitution still happens
  where it belongs: Cairo and Pango substitute for whatever name they are given
  when the text is drawn, so an installed family renders exactly as before.
- Where fontconfig cannot be consulted at all, nothing can be verified, so the
  CGO build now behaves like the no-CGO one and passes the written name through.
  It previously returned the hardcoded baseline.
- The fontconfig resolver had no test of any kind. It now has an
  integration-tagged one (`integration && linux && cgo`) covering the generic
  aliases, an installed family asked for in several spellings, and missing
  families including the ones a stock fontconfig has substitution rules for. It
  reads what is installed with `fc-list` rather than from the code under test,
  and skips where fontconfig has nothing to report.
- No `just` recipe runs Linux integration tests today — `just test-linux` omits
  the tag and `just test-integration` runs on the host — so `docs/DEVELOPMENT.md`
  now records how to run them in a container until there is one. They were run
  that way for this PR, and CI's `ubuntu-latest` job covers them natively.
- Gates run: `just ci`, `just lint-cross`, `just test-linux`,
  `just test-linux-nocgo`, plus the integration suite in the CI-equivalent
  container with fonts and `fc-list` installed.
