### PR TITLE
refactor(ports): resolve a font family from its name alone

### DIFF
--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -1090,7 +1090,7 @@ func resolveModeIndicatorAppearance(
 	}
 
 	style := overlayBadgeStyle{
-		fontFamily:  ports.ResolveFont(cfg.UI.FontFamily, true),
+		fontFamily:  ports.ResolveFont(cfg.UI.FontFamily),
 		fontSize:    float64(max(cfg.UI.FontSize, 1)),
 		paddingX:    cfg.UI.PaddingX,
 		paddingY:    cfg.UI.PaddingY,
@@ -1137,7 +1137,7 @@ func resolveStickyIndicatorAppearance(
 	}
 
 	style := overlayBadgeStyle{
-		fontFamily:  ports.ResolveFont(cfg.FontFamily, false),
+		fontFamily:  ports.ResolveFont(cfg.FontFamily),
 		fontSize:    float64(max(cfg.FontSize, 1)),
 		paddingX:    cfg.PaddingX,
 		paddingY:    cfg.PaddingY,

--- a/internal/adapter/overlay/render/grid/style.go
+++ b/internal/adapter/overlay/render/grid/style.go
@@ -95,7 +95,7 @@ func (s Style) MatchedBorderColorARGB() uint32 { return s.matchedBorderColorARGB
 func BuildStyle(cfg config.GridConfig, theme config.ThemeProvider) Style {
 	style := Style{
 		fontSize:    cfg.UI.FontSize,
-		fontFamily:  ports.ResolveFont(cfg.UI.FontFamily, true),
+		fontFamily:  ports.ResolveFont(cfg.UI.FontFamily),
 		borderWidth: cfg.UI.BorderWidth,
 		backgroundColor: cfg.UI.BackgroundColor.ForTheme(
 			theme,

--- a/internal/adapter/overlay/render/hints/style.go
+++ b/internal/adapter/overlay/render/hints/style.go
@@ -82,7 +82,7 @@ func (s StyleMode) BoundaryBorderColor() string { return s.boundaryBorderColor }
 func BuildStyle(cfg config.HintsConfig, theme config.ThemeProvider) StyleMode {
 	return StyleMode{
 		fontSize:     cfg.UI.FontSize,
-		fontFamily:   ports.ResolveFont(cfg.UI.FontFamily, true),
+		fontFamily:   ports.ResolveFont(cfg.UI.FontFamily),
 		borderRadius: cfg.UI.BorderRadius,
 		paddingX:     cfg.UI.PaddingX,
 		paddingY:     cfg.UI.PaddingY,

--- a/internal/adapter/overlay/render/hints/types.go
+++ b/internal/adapter/overlay/render/hints/types.go
@@ -113,7 +113,7 @@ func (s SearchInputStyle) BorderColor() string { return s.borderColor }
 func BuildSearchInputStyle(cfg config.HintsConfig, theme config.ThemeProvider) SearchInputStyle {
 	return SearchInputStyle{
 		fontSize:     cfg.SearchInputUI.FontSize,
-		fontFamily:   ports.ResolveFont(cfg.SearchInputUI.FontFamily, false),
+		fontFamily:   ports.ResolveFont(cfg.SearchInputUI.FontFamily),
 		borderRadius: cfg.SearchInputUI.BorderRadius,
 		paddingX:     cfg.SearchInputUI.PaddingX,
 		paddingY:     cfg.SearchInputUI.PaddingY,

--- a/internal/adapter/overlay/render/modeindicator/overlay_darwin.go
+++ b/internal/adapter/overlay/render/modeindicator/overlay_darwin.go
@@ -181,7 +181,7 @@ func (o *Overlay) DrawModeIndicator(mode string, xCoordinate, yCoordinate int) {
 	// Use cached style strings to avoid repeated allocations and fix use-after-free
 	cachedStyle := o.styleCache.Get(func(cached *overlayutil.CachedStyle) {
 		cached.FontFamily = unsafe.Pointer(
-			C.CString(ports.ResolveFont(o.indicatorConfig.UI.FontFamily, true)),
+			C.CString(ports.ResolveFont(o.indicatorConfig.UI.FontFamily)),
 		)
 		cached.BgColor = unsafe.Pointer(
 			C.CString(

--- a/internal/adapter/overlay/render/recursivegrid/style.go
+++ b/internal/adapter/overlay/render/recursivegrid/style.go
@@ -239,7 +239,7 @@ func BuildStyle(cfg config.RecursiveGridConfig, theme config.ThemeProvider) Styl
 			config.RecursiveGridTextColorDark,
 		),
 		fontSize:        cfg.UI.FontSize,
-		fontFamily:      ports.ResolveFont(cfg.UI.FontFamily, true),
+		fontFamily:      ports.ResolveFont(cfg.UI.FontFamily),
 		labelBackground: cfg.UI.LabelBackground,
 		labelBackgroundColor: cfg.UI.LabelBackgroundColor.ForTheme(
 			theme,

--- a/internal/adapter/overlay/render/stickyindicator/overlay_darwin.go
+++ b/internal/adapter/overlay/render/stickyindicator/overlay_darwin.go
@@ -138,7 +138,7 @@ func (o *Overlay) Draw(xCoordinate, yCoordinate int, symbols string) {
 
 	cachedStyle := o.styleCache.Get(func(cached *overlayutil.CachedStyle) {
 		cached.FontFamily = unsafe.Pointer(
-			C.CString(ports.ResolveFont(o.uiConfig.FontFamily, false)),
+			C.CString(ports.ResolveFont(o.uiConfig.FontFamily)),
 		)
 		cached.BgColor = unsafe.Pointer(
 			C.CString(

--- a/internal/adapter/overlay/style.go
+++ b/internal/adapter/overlay/style.go
@@ -261,7 +261,7 @@ func buildVirtualPointerStyle(
 		// Through the shared resolver, like every other overlay's family: a
 		// generic alias reaches the platform as a family it can actually find
 		// rather than as a name nothing is installed under (#1305).
-		FontFamily: ports.ResolveFont(cfg.UI.FontFamily, false),
+		FontFamily: ports.ResolveFont(cfg.UI.FontFamily),
 	}
 }
 
@@ -316,11 +316,11 @@ func buildMonitorSelectStyle(cfg *config.Config, theme config.ThemeProvider) Mon
 		SubtitleFontSize: uiCfg.SubtitleFontSize,
 		// Both families go through the shared resolver, like every other
 		// overlay's, so a generic alias reaches the platform as a family it can
-		// actually find (#1305). Weight travels with the request — the label is
-		// drawn bold and the subtitle is not — even though no resolver weights
-		// on it yet.
-		FontFamily:         ports.ResolveFont(uiCfg.FontFamily, true),
-		SubtitleFontFamily: ports.ResolveFont(subtitleFamily, false),
+		// actually find (#1305). The label is drawn bold and the subtitle is
+		// not, but weight is the drawing layer's business: resolution answers
+		// on the family name alone.
+		FontFamily:         ports.ResolveFont(uiCfg.FontFamily),
+		SubtitleFontFamily: ports.ResolveFont(subtitleFamily),
 		BorderRadius:       uiCfg.BorderRadius,
 		PaddingX:           uiCfg.PaddingX,
 		PaddingY:           uiCfg.PaddingY,

--- a/internal/adapter/overlay/style_test.go
+++ b/internal/adapter/overlay/style_test.go
@@ -337,7 +337,7 @@ func TestStyleResolver_ConcurrentApplyAndRead(t *testing.T) {
 // apart from one copied straight out of the configuration.
 type markerFontResolver struct{}
 
-func (markerFontResolver) Resolve(family string, _ bool) string {
+func (markerFontResolver) Resolve(family string) string {
 	return "resolved(" + family + ")"
 }
 

--- a/internal/adapter/overlay/windows/features.go
+++ b/internal/adapter/overlay/windows/features.go
@@ -125,7 +125,7 @@ func (o *winOverlay) DrawHints(
 		o.window.DrawTextCentered(
 			hint.Label(),
 			bounds,
-			ports.ResolveFont(style.FontFamily(), false),
+			ports.ResolveFont(style.FontFamily()),
 			fontSize,
 			badge.ParseHexARGB(textColor),
 		)
@@ -202,7 +202,7 @@ func (o *winOverlay) DrawRecursiveGrid(
 				o.drawTextCentered(
 					label,
 					cell,
-					ports.ResolveFont(style.FontFamily(), false),
+					ports.ResolveFont(style.FontFamily()),
 					style.LabelFontSize(),
 					style.TextColorARGB(),
 				)
@@ -312,7 +312,7 @@ func (o *winOverlay) drawRecursiveSubKeyPreview(
 	o.drawTextCentered(
 		previewLabel,
 		previewRect,
-		ports.ResolveFont(style.FontFamily(), false),
+		ports.ResolveFont(style.FontFamily()),
 		style.SubKeyPreviewFontSizeF(),
 		style.SubKeyPreviewTextColorARGB(),
 	)

--- a/internal/adapter/overlay/windows/manager.go
+++ b/internal/adapter/overlay/windows/manager.go
@@ -464,7 +464,7 @@ func (m *Manager) DrawModeIndicator(cursorX, cursorY int) {
 	m.indicatorWin.DrawTextCentered(
 		label,
 		badgeBounds,
-		ports.ResolveFont(cfg.UI.FontFamily, true),
+		ports.ResolveFont(cfg.UI.FontFamily),
 		fontSize,
 		badge.ParseHexARGB(textColor),
 	)
@@ -574,7 +574,7 @@ func (m *Manager) DrawStickyModifiersIndicator(cursorX, cursorY int, symbols str
 	m.stickyWin.DrawTextCentered(
 		symbols,
 		badgeBounds,
-		ports.ResolveFont(indicatorUI.FontFamily, false),
+		ports.ResolveFont(indicatorUI.FontFamily),
 		fontSize,
 		badge.ParseHexARGB(textColor),
 	)

--- a/internal/adapter/overlay/windows/overlay.go
+++ b/internal/adapter/overlay/windows/overlay.go
@@ -342,7 +342,7 @@ func (o *winOverlay) redrawGridWithoutFlush() {
 			o.drawTextCentered(
 				label,
 				cell.Bounds(),
-				ports.ResolveFont(style.FontFamily(), false),
+				ports.ResolveFont(style.FontFamily()),
 				style.LabelFontSize(),
 				text,
 			)
@@ -400,7 +400,7 @@ func (o *winOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Sty
 		o.drawTextCentered(
 			string(key),
 			cell,
-			ports.ResolveFont(style.FontFamily(), false),
+			ports.ResolveFont(style.FontFamily()),
 			style.LabelFontSize()*winSubgridFontScale,
 			style.TextColorARGB(),
 		)

--- a/internal/adapter/platform/darwin/font.go
+++ b/internal/adapter/platform/darwin/font.go
@@ -43,8 +43,6 @@ type nsFontResolver struct {
 }
 
 // Resolve implements ports.FontResolver.
-func (r *nsFontResolver) Resolve(family string, bold bool) string {
-	_ = bold // weight is enforced at the C layer
-
+func (r *nsFontResolver) Resolve(family string) string {
 	return r.cache.Resolve(family)
 }

--- a/internal/adapter/platform/darwin/font_test.go
+++ b/internal/adapter/platform/darwin/font_test.go
@@ -21,7 +21,7 @@ func TestNSFontResolver_GenericAliases(t *testing.T) {
 		t.Run(input, func(t *testing.T) {
 			fontResolver := NewFontResolver()
 
-			if got := fontResolver.Resolve(input, false); got != want {
+			if got := fontResolver.Resolve(input); got != want {
 				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
 			}
 		})
@@ -42,7 +42,7 @@ func TestNSFontResolver_NonGenericPassesThroughTrimmed(t *testing.T) {
 		t.Run(input, func(t *testing.T) {
 			fontResolver := NewFontResolver()
 
-			if got := fontResolver.Resolve(input, false); got != want {
+			if got := fontResolver.Resolve(input); got != want {
 				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
 			}
 		})
@@ -54,11 +54,11 @@ func TestNSFontResolver_AnswersEachSpellingFromItsOwnName(t *testing.T) {
 	// on every CI leg in platform/fontcache, this pins that macOS uses it.
 	fontResolver := NewFontResolver()
 
-	if got := fontResolver.Resolve("Arial", false); got != "Arial" {
+	if got := fontResolver.Resolve("Arial"); got != "Arial" {
 		t.Fatalf("Resolve(%q) = %q, want %q", "Arial", got, "Arial")
 	}
 
-	if got := fontResolver.Resolve("ARIAL", false); got != "ARIAL" {
+	if got := fontResolver.Resolve("ARIAL"); got != "ARIAL" {
 		t.Fatalf("Resolve(%q) = %q, want %q", "ARIAL", got, "ARIAL")
 	}
 }

--- a/internal/adapter/platform/linux/font_cgo.go
+++ b/internal/adapter/platform/linux/font_cgo.go
@@ -107,8 +107,8 @@ import (
 )
 
 // NewFontResolver returns a fontconfig-backed ports.FontResolver.
-// Each (family) tuple is resolved on first use and cached for the
-// lifetime of the process.
+// Each family is resolved on first use and cached for the lifetime of the
+// process.
 func NewFontResolver() ports.FontResolver {
 	resolver := &fontconfigResolver{}
 	resolver.cache = fontcache.New(resolver.resolve)
@@ -125,9 +125,7 @@ type fontconfigResolver struct {
 }
 
 // Resolve implements ports.FontResolver.
-func (r *fontconfigResolver) Resolve(family string, bold bool) string {
-	_ = bold // reserved for future weight-specific resolution
-
+func (r *fontconfigResolver) Resolve(family string) string {
 	return r.cache.Resolve(family)
 }
 

--- a/internal/adapter/platform/linux/font_integration_linux_test.go
+++ b/internal/adapter/platform/linux/font_integration_linux_test.go
@@ -34,7 +34,7 @@ func TestFontconfigResolver_Resolve_GenericAliasesGiveAnInstalledFamily(t *testi
 		}
 
 		t.Run(name, func(t *testing.T) {
-			got := resolver.Resolve(alias, false)
+			got := resolver.Resolve(alias)
 
 			if !isInstalled(installed, got) {
 				t.Fatalf(
@@ -66,7 +66,7 @@ func TestFontconfigResolver_Resolve_InstalledFamilyComesBackAsWritten(t *testing
 
 	for input, want := range cases {
 		t.Run(input, func(t *testing.T) {
-			if got := resolver.Resolve(input, false); got != want {
+			if got := resolver.Resolve(input); got != want {
 				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
 			}
 		})
@@ -99,7 +99,7 @@ func TestFontconfigResolver_Resolve_MissingFamilyFallsBackToTheResolvedGeneric(t
 
 	for _, family := range missing {
 		t.Run(family, func(t *testing.T) {
-			got := resolver.Resolve(family, false)
+			got := resolver.Resolve(family)
 
 			if got != want {
 				t.Fatalf(
@@ -131,7 +131,7 @@ func theResolvedGeneric(t *testing.T, installed []string, resolver ports.FontRes
 		return defaultLinuxSans
 	}
 
-	return resolver.Resolve("sans", false)
+	return resolver.Resolve("sans")
 }
 
 // installedFamilies asks fontconfig which families this machine has, through

--- a/internal/adapter/platform/linux/font_nocgo.go
+++ b/internal/adapter/platform/linux/font_nocgo.go
@@ -21,6 +21,6 @@ func NewFontResolver() ports.FontResolver {
 type passthroughResolver struct{}
 
 // Resolve implements ports.FontResolver.
-func (passthroughResolver) Resolve(family string, _ bool) string {
+func (passthroughResolver) Resolve(family string) string {
 	return linuxFamilies.Resolve(family)
 }

--- a/internal/adapter/platform/linux/font_nocgo_test.go
+++ b/internal/adapter/platform/linux/font_nocgo_test.go
@@ -9,7 +9,7 @@ func TestPassthroughResolver_CachesByFamily(t *testing.T) {
 
 	// Repeated calls with the same input should not mutate behaviour.
 	for range 3 {
-		if got := r.Resolve("sans", true); got != defaultLinuxSans {
+		if got := r.Resolve("sans"); got != defaultLinuxSans {
 			t.Fatalf("expected generic alias to resolve to %q, got %q", defaultLinuxSans, got)
 		}
 	}
@@ -18,7 +18,7 @@ func TestPassthroughResolver_CachesByFamily(t *testing.T) {
 func TestPassthroughResolver_EmptyDefaultsToSans(t *testing.T) {
 	r := passthroughResolver{}
 
-	if got := r.Resolve("", false); got != defaultLinuxSans {
+	if got := r.Resolve(""); got != defaultLinuxSans {
 		t.Fatalf("expected empty input to resolve to %q, got %q", defaultLinuxSans, got)
 	}
 }

--- a/internal/adapter/platform/windows/font.go
+++ b/internal/adapter/platform/windows/font.go
@@ -31,8 +31,6 @@ type winFontResolver struct {
 }
 
 // Resolve implements ports.FontResolver.
-func (r *winFontResolver) Resolve(family string, bold bool) string {
-	_ = bold
-
+func (r *winFontResolver) Resolve(family string) string {
 	return r.cache.Resolve(family)
 }

--- a/internal/adapter/platform/windows/font_test.go
+++ b/internal/adapter/platform/windows/font_test.go
@@ -21,7 +21,7 @@ func TestWinFontResolver_GenericAliases(t *testing.T) {
 		t.Run(input, func(t *testing.T) {
 			fontResolver := NewFontResolver()
 
-			if got := fontResolver.Resolve(input, false); got != want {
+			if got := fontResolver.Resolve(input); got != want {
 				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
 			}
 		})
@@ -40,7 +40,7 @@ func TestWinFontResolver_NamedFamilyPassesThroughTrimmed(t *testing.T) {
 		t.Run(input, func(t *testing.T) {
 			fontResolver := NewFontResolver()
 
-			if got := fontResolver.Resolve(input, false); got != want {
+			if got := fontResolver.Resolve(input); got != want {
 				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
 			}
 		})
@@ -52,11 +52,11 @@ func TestWinFontResolver_AnswersEachSpellingFromItsOwnName(t *testing.T) {
 	// on every CI leg in platform/fontcache, this pins that Windows uses it.
 	fontResolver := NewFontResolver()
 
-	if got := fontResolver.Resolve("Arial", false); got != "Arial" {
+	if got := fontResolver.Resolve("Arial"); got != "Arial" {
 		t.Fatalf("Resolve(%q) = %q, want %q", "Arial", got, "Arial")
 	}
 
-	if got := fontResolver.Resolve("ARIAL", false); got != "ARIAL" {
+	if got := fontResolver.Resolve("ARIAL"); got != "ARIAL" {
 		t.Fatalf("Resolve(%q) = %q, want %q", "ARIAL", got, "ARIAL")
 	}
 }

--- a/internal/ports/font.go
+++ b/internal/ports/font.go
@@ -25,9 +25,7 @@ type FontResolver interface {
 	//     the non-CGO Linux build check nothing, pass the written name on, and
 	//     leave substitution to the native text layer, which does it when the
 	//     text is drawn either way
-	//   - bold is reserved for future weight-specific resolution and is
-	//     currently ignored by all implementations
-	Resolve(family string, bold bool) string
+	Resolve(family string) string
 }
 
 var (
@@ -52,14 +50,14 @@ func SetFontResolver(resolver FontResolver) {
 
 // ResolveFont is a convenience wrapper around the active FontResolver. Returns
 // the input unchanged when no resolver has been installed (e.g. in tests).
-func ResolveFont(family string, bold bool) string {
+func ResolveFont(family string) string {
 	fontResolverMu.RLock()
 
 	r := fontResolver
 
 	fontResolverMu.RUnlock()
 
-	return r.Resolve(family, bold)
+	return r.Resolve(family)
 }
 
 // noopFontResolver is the default resolver. It returns the input unchanged so
@@ -67,4 +65,4 @@ func ResolveFont(family string, bold bool) string {
 type noopFontResolver struct{}
 
 // Resolve returns the input family unchanged.
-func (noopFontResolver) Resolve(family string, _ bool) string { return family }
+func (noopFontResolver) Resolve(family string) string { return family }

--- a/internal/ports/font_test.go
+++ b/internal/ports/font_test.go
@@ -13,7 +13,7 @@ type fakeResolver struct {
 	last  string
 }
 
-func (f *fakeResolver) Resolve(family string, _ bool) string {
+func (f *fakeResolver) Resolve(family string) string {
 	f.calls++
 	f.last = family
 
@@ -24,11 +24,11 @@ func TestResolveFont_DefaultNoopReturnsInput(t *testing.T) {
 	ports.SetFontResolver(nil)
 	t.Cleanup(func() { ports.SetFontResolver(nil) })
 
-	if got := ports.ResolveFont("Anything", true); got != "Anything" {
+	if got := ports.ResolveFont("Anything"); got != "Anything" {
 		t.Fatalf("expected input to be returned unchanged, got %q", got)
 	}
 
-	if got := ports.ResolveFont("", false); got != "" {
+	if got := ports.ResolveFont(""); got != "" {
 		t.Fatalf("expected empty input to be returned unchanged, got %q", got)
 	}
 }
@@ -39,7 +39,7 @@ func TestResolveFont_DispatchesToInstalledResolver(t *testing.T) {
 	ports.SetFontResolver(fake)
 	t.Cleanup(func() { ports.SetFontResolver(nil) })
 
-	if got := ports.ResolveFont("JetBrains Mono", true); got != "RESOLVED:JetBrains Mono" {
+	if got := ports.ResolveFont("JetBrains Mono"); got != "RESOLVED:JetBrains Mono" {
 		t.Fatalf("expected resolver to be called, got %q", got)
 	}
 
@@ -57,7 +57,7 @@ func TestResolveFont_NilResetRestoresNoop(t *testing.T) {
 	ports.SetFontResolver(nil)
 	t.Cleanup(func() { ports.SetFontResolver(nil) })
 
-	if got := ports.ResolveFont("X", false); got != "X" {
+	if got := ports.ResolveFont("X"); got != "X" {
 		t.Fatalf("expected noop default after reset, got %q", got)
 	}
 }


### PR DESCRIPTION
## Description

This PR removes a font-weight flag from Neru's font resolution that every
platform already ignored. Asking for a font family no longer means passing a
bold/regular choice alongside the name — resolution answers from the family
name alone, which is what it has always done.

Nothing changes for a user: no configuration key, command, or rendered output
is affected. Bold text is still drawn bold, because weight was never decided
here — each platform's drawing layer picks the face when the text is drawn, and
it still does. The flag was documented as "reserved for future weight-specific
resolution", and it can come back when a feature actually needs it, with a
designed meaning rather than a guessed one.

## Related Issues

Closes #1311

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `refactor` — Code restructuring (no behavior change)

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — no
      files added or moved; every touched file keeps its existing build tag
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — no imports added anywhere in the diff
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) —
      N/A, this port returns a string with no error channel and has no
      unsupported-capability stub; the two passthrough implementations keep
      their existing contract tests
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — the existing font
      resolution tests are updated to the narrowed signature; no new behaviour
      to cover
- [x] Documentation updated (if applicable) — N/A, no document described the
      removed flag; the capability matrix and its font-resolution footnote
      already describe family resolution only
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Because this signature only exists behind build tags on two of the three
platforms, the change was checked beyond the host gate: `just vet-cross`,
`just test-windows-compile`, `just lint-cross` (CGO-enabled Linux lint) and
`just test-linux` (the full Linux suite in a container, which is the only place
the fontconfig-backed resolver actually compiles and runs) all pass.

One thing this PR deliberately leaves alone: on Windows, several draw paths ask
the resolver again for a family name that was already resolved when the style
was built, once per hint or grid cell. That is a pre-existing redundancy rather
than something this change introduces, and untangling it is a separate piece of
work.
