### PR TITLE
build: ignore agent worktrees parked under .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ config.toml
 # Agent-guide local overrides (see AGENTS.md)
 AGENTS.local.md
 CLAUDE.local.md
+
+# Agent worktrees: whole checkouts of this repository parked inside it. The rest
+# of .claude/ stays tracked — settings.json, the agent definitions and the
+# skills symlink are pinned by internal/architecture/agent_contract_test.go.
+.claude/worktrees/

--- a/internal/architecture/agent_contract_test.go
+++ b/internal/architecture/agent_contract_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -95,6 +96,68 @@ func TestAgentSkillsStayCanonical(t *testing.T) {
 		filepath.Join(repoRoot, ".claude", "skills"),
 		filepath.Join("..", ".agents", "skills"),
 	)
+}
+
+// TestAgentWorktreesStayIgnored pins the other half of the agent-worktree
+// contract: agent tooling parks whole checkouts of this repository under
+// .claude/worktrees, and git must ignore that path. Untracked, each one shows
+// in git status — so the tree is never clean while agent work is in progress —
+// and `git add -A` sweeps a second checkout into the index.
+//
+// The rule has two sides, and the ignore entry has to satisfy both: it names
+// worktrees beneath .claude rather than .claude itself, because settings.json,
+// the agent definitions and the skills symlink stay tracked.
+//
+// Pruning the path from the walks in this package (isSkippedWalkDir) is a
+// separate concern: a directory git ignores is still a directory a guardrail
+// walks.
+func TestAgentWorktreesStayIgnored(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+
+	content, err := os.ReadFile(filepath.Join(repoRoot, ".gitignore"))
+	if err != nil {
+		t.Fatalf("reading .gitignore: %v", err)
+	}
+
+	// The path the entry has to name, taken from the walks' own constant so the
+	// two cannot drift, and the directory above it — the shortcut that would
+	// ignore the tracked agent files along with the worktrees, taking
+	// TestAgentSkillsStayCanonical's subject with it.
+	worktreesPattern := filepath.ToSlash(agentWorktreeDir)
+	claudePattern := filepath.ToSlash(filepath.Dir(agentWorktreeDir))
+
+	found := false
+
+	for line := range strings.SplitSeq(string(content), "\n") {
+		pattern := strings.TrimSpace(line)
+
+		if pattern == "" || strings.HasPrefix(pattern, "#") {
+			continue
+		}
+
+		// Surrounding slashes are decoration for a pattern already anchored to
+		// the directory .gitignore sits in, so trimming them collapses
+		// ".claude/worktrees", "/.claude/worktrees/" and the two mixtures onto
+		// one spelling. A negation ("!") survives the trim and matches neither,
+		// which is what we want.
+		switch strings.Trim(pattern, "/") {
+		case worktreesPattern:
+			found = true
+		case claudePattern:
+			t.Errorf(
+				".gitignore ignores %q, which untracks the agent guide layout; "+
+					"name worktrees beneath it instead",
+				pattern,
+			)
+		}
+	}
+
+	if !found {
+		t.Error(
+			".gitignore does not ignore .claude/worktrees; agent checkouts parked " +
+				"there show as untracked and `git add -A` stages them",
+		)
+	}
 }
 
 // assertSymlinkTarget fails the test unless path is a symlink pointing at


### PR DESCRIPTION
## Description

This PR stops agent worktrees from showing up as untracked changes in the repository. Tooling parks whole checkouts of this repo under `.claude/worktrees/`, and until now nothing ignored that path — so `git status` was never clean while any agent work was in progress, and `git add -A` would sweep a second full checkout into the index.

Git now ignores `.claude/worktrees/` while the rest of `.claude/` stays tracked, so `settings.json`, the agent definitions and the `skills` symlink are unaffected. A guardrail test pins both halves of that: the entry has to be there, and it must not be widened to `.claude/` wholesale, which would untrack the agent guide layout the architecture suite exists to verify.

Deliberate limitation: this only stops git from *tracking* those directories. Keeping the architecture guardrails from *walking* them was a separate change (#1315), already shipped.

## Related Issues

Closes #1318

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling — the commit itself uses `build`, the closest type in `release-please-config.json`; it is hidden from the changelog either way

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no platform-specific code in this change
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no imports changed
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port behaviour added
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing docs describe the ignore rules; the rationale lives in a comment beside the entry
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The guardrail reads the ignore file and pins the entry itself rather than shelling out to git, which matches how the neighbouring agent-layout guardrails work; git's actual behaviour was verified by hand instead, as below.

Verified against a real scratch worktree created under `.claude/worktrees/`: `git status --porcelain` stayed clean, `git add -A` staged nothing from it, `git ls-files .claude` still listed the settings file, the agent definitions and the `skills` symlink, and the architecture suite passed with the worktree present. The new guardrail was also checked in the failing direction by widening the entry to `.claude/`, which makes both of its assertions fire.
