### PR TITLE
test(app): stop the simulation journeys failing on a busy CI runner

### DIFF
--- a/internal/app/simulation_harness_test.go
+++ b/internal/app/simulation_harness_test.go
@@ -38,11 +38,87 @@ import (
 	"github.com/y3owk1n/neru/internal/ports/mocks"
 )
 
+const simFixtureBundleID = "com.example.simfixture"
+
+// --- wait budgets ----------------------------------------------------------
+//
+// Every journey below waits on the same shape of thing: in-process
+// asynchronous work — a hotkey callback, a goroutine the app started, a mode
+// transition queued behind the handler lock — that finishes in single-digit
+// milliseconds on an idle machine. So a wait's budget is not an estimate of
+// how long its step takes. It is headroom against the machine, plus, where the
+// awaited thing has a duration of its own, that duration.
+//
+// Two things move the machine side of it, and only one of them is fixable with
+// a number:
+//
+//   - The race detector instruments every memory access, which is why the
+//     -race pass is where a fixed budget runs out first. That is a bounded,
+//     knowable factor, so simWaitHeadroom scales by simRaceSlowdown.
+//   - A loaded shared runner can deschedule this process for whole seconds
+//     regardless of how little work it has left. No budget survives that by
+//     being bigger, so waitForWithin does not rely on one: it evaluates the
+//     condition and only then looks at the clock, so the last thing a wait
+//     does before giving up is ask again. A wait therefore fails only on work
+//     that has not happened — never on work that happened while the process
+//     was not running. Of the two halves of #1324, that is the half no bigger
+//     number could have bought.
+//
+// What the budget buys after that is the case where the work is genuinely
+// still coming, and what it costs is how long a genuinely hung journey takes
+// to report — which is why it is seconds and not minutes.
+//
+// Adding a journey: call waitFor and inherit simWaitHeadroom. Reach for
+// waitForWithin only when what you are awaiting has its own duration — a
+// configured repeat interval, a sampling window — and write that duration into
+// the call as `simWaitHeadroom + <it>`, so the headroom stays one thing and
+// the journey's own timing stays visible. Growing simWaitHeadroom to cover one
+// slow wait puts every other journey's hang detection behind it.
 const (
-	simFixtureBundleID = "com.example.simfixture"
-	simWaitTimeout     = 5 * time.Second
-	simPollInterval    = 2 * time.Millisecond
+	// simWaitHeadroomBase is the machine headroom one wait gets on an
+	// uninstrumented build. The work these journeys await completes in
+	// single-digit milliseconds, so this is roughly three orders of magnitude
+	// of slack — sized for a shared runner having a bad minute, not for the
+	// work.
+	simWaitHeadroomBase = 5 * time.Second
+
+	// simRaceSlowdown is how much further to stretch a wait budget when the
+	// binary carries the race detector. The detector's documented cost is a
+	// 2-20x slowdown; 4 sits inside that on top of a base that is already
+	// mostly slack, and it is applied once, here, so no journey has to know
+	// how it was built.
+	simRaceSlowdown = 4
+
+	// simPollInterval is how often a wait re-asks its condition. Short enough
+	// that a journey is not measuring the poller, long enough that a hundred
+	// waits do not busy-spin a constrained CPU away from the app they are
+	// waiting on.
+	simPollInterval = 2 * time.Millisecond
+
+	// simShutdownBudgetBase is what Stop() gets to unwind every startup phase
+	// and return from Run(). It is a budget of its own rather than a reuse of
+	// the wait headroom because it covers a different thing: not one
+	// asynchronous hop, but the whole application coming down.
+	simShutdownBudgetBase = 5 * time.Second
 )
+
+// simWaitHeadroom is the default budget for a single waitFor, and
+// simShutdownBudget the one the harness gives a stopping app; both are stated
+// above in idle-machine terms and scaled here, once.
+var (
+	simWaitHeadroom   = simScaleForRace(simWaitHeadroomBase)
+	simShutdownBudget = simScaleForRace(simShutdownBudgetBase)
+)
+
+// simScaleForRace stretches a budget stated for an uninstrumented build to
+// what the same wait needs under -race.
+func simScaleForRace(budget time.Duration) time.Duration {
+	if !simRaceDetectorEnabled {
+		return budget
+	}
+
+	return budget * simRaceSlowdown
+}
 
 // defaultDisplayName is the name of the fixture desktop's single display.
 const defaultDisplayName = "SimDisplay"
@@ -1189,8 +1265,8 @@ func buildSimHarness(
 				!derrors.IsCode(runErr, derrors.CodeContextCanceled) {
 				tb.Errorf("Run() returned an unexpected error after Stop(): %v", runErr)
 			}
-		case <-time.After(simWaitTimeout):
-			tb.Errorf("app did not stop within %v", simWaitTimeout)
+		case <-time.After(simShutdownBudget):
+			tb.Errorf("app did not stop within %v", simShutdownBudget)
 		}
 
 		application.Cleanup()
@@ -1234,20 +1310,41 @@ func (h *simHarness) typeLabel(label string) {
 	}
 }
 
-// waitFor polls cond until it holds or the harness timeout elapses.
+// waitFor polls cond until it holds, giving it the default machine headroom.
 func (h *simHarness) waitFor(desc string, cond func() bool) {
 	h.t.Helper()
 
-	deadline := time.Now().Add(simWaitTimeout)
-	for time.Now().Before(deadline) {
+	h.waitForWithin(simWaitHeadroom, desc, cond)
+}
+
+// waitForWithin polls cond until it holds or budget elapses.
+//
+// The order of the two checks is the load-bearing part: cond is evaluated
+// first and the clock consulted only after it comes back false, so however far
+// past the budget a descheduled poll wakes up, the condition is still asked
+// once more before the wait gives up. A journey therefore fails on work that
+// did not happen, never on work that happened while this process was starved
+// of a CPU — the flake #1324 reported.
+//
+// The budget is therefore when a wait stops trying, not a ceiling on how long
+// it takes: a wait can outlast it by one evaluation of cond, which matters
+// only for a condition that is itself slow to answer.
+func (h *simHarness) waitForWithin(budget time.Duration, desc string, cond func() bool) {
+	h.t.Helper()
+
+	deadline := time.Now().Add(budget)
+
+	for {
 		if cond() {
 			return
 		}
 
+		if !time.Now().Before(deadline) {
+			h.t.Fatalf("timed out after %v waiting for %s", budget, desc)
+		}
+
 		time.Sleep(simPollInterval)
 	}
-
-	h.t.Fatalf("timed out after %v waiting for %s", simWaitTimeout, desc)
 }
 
 // waitMode waits for the app to reach the given mode.
@@ -1262,6 +1359,14 @@ func (h *simHarness) waitMode(mode domain.Mode) {
 // neverMode asserts the app does not enter the given mode within the window.
 // Absence can only be checked for a bounded time; the window is generous
 // relative to the (in-process, no-IO) activation path it guards against.
+//
+// Deliberately not scaled by simScaleForRace, unlike every wait budget above.
+// A wait is scaled because slowness turns it into a failure; this window's
+// failure mode is the opposite one — a starved process watches nothing and
+// passes vacuously — and stretching the window does not fix that, because a
+// starved four seconds is as empty as a starved 250 milliseconds. It would
+// only add real seconds to every -race run. The window a caller writes is the
+// window it gets.
 func (h *simHarness) neverMode(mode domain.Mode, window time.Duration) {
 	h.t.Helper()
 

--- a/internal/app/simulation_journey_test.go
+++ b/internal/app/simulation_journey_test.go
@@ -1083,10 +1083,21 @@ func TestSimulation_StickyModifierClick(t *testing.T) {
 // TestSimulation_HeldRepeatScroll covers held-key repeat: holding j keeps
 // scrolling on the configured interval, and the key release stops it.
 func TestSimulation_HeldRepeatScroll(t *testing.T) {
+	const (
+		repeatDelayMS    = 5
+		repeatIntervalMS = 5
+		// scrollsAwaited is enough repeats to say the engine is running rather
+		// than that the key was handled once.
+		scrollsAwaited = 4
+		// stopSampleWindow is how long the stop check lets the engine run
+		// between its two samples.
+		stopSampleWindow = 100 * time.Millisecond
+	)
+
 	cfg := simConfig()
 	cfg.HeldRepeat.Enabled = true
-	cfg.HeldRepeat.InitialDelay = 5
-	cfg.HeldRepeat.Interval = 5
+	cfg.HeldRepeat.InitialDelay = repeatDelayMS
+	cfg.HeldRepeat.Interval = repeatIntervalMS
 
 	sim := newSimHarness(t, cfg, nil)
 
@@ -1096,20 +1107,41 @@ func TestSimulation_HeldRepeatScroll(t *testing.T) {
 	// Key down without a release: the repeat engine takes over.
 	sim.press("j")
 
-	sim.waitFor("held key repeated at least 4 scrolls", func() bool {
-		return len(sim.ax.recordedScrolls()) >= 4
-	})
+	// Unlike every other wait in these journeys, this one is waiting on a
+	// timer: the first scroll cannot arrive before the initial delay and each
+	// one after it costs an interval, however fast the machine is. That
+	// duration is stated on top of the headroom rather than absorbed into it,
+	// so a journey that turns the interval up does not silently eat the slack
+	// every other wait is relying on.
+	repeatRunUp := repeatDelayMS*time.Millisecond +
+		(scrollsAwaited-1)*repeatIntervalMS*time.Millisecond
 
-	// Release stops the repeat: wait for two identical samples 100ms apart.
+	sim.waitForWithin(
+		simWaitHeadroom+repeatRunUp,
+		fmt.Sprintf("held key repeated at least %d scrolls", scrollsAwaited),
+		func() bool {
+			return len(sim.ax.recordedScrolls()) >= scrollsAwaited
+		},
+	)
+
+	// Release stops the repeat: wait for two identical samples a
+	// stopSampleWindow apart. Each attempt at that costs the window, and the
+	// first one may still catch a scroll dispatched before the release landed,
+	// so the budget carries room for the sample that fails and the one that
+	// confirms.
 	sim.press("__keyup_j")
 
-	sim.waitFor("repeat stopped after key release", func() bool {
-		before := len(sim.ax.recordedScrolls())
+	sim.waitForWithin(
+		simWaitHeadroom+2*stopSampleWindow,
+		"repeat stopped after key release",
+		func() bool {
+			before := len(sim.ax.recordedScrolls())
 
-		time.Sleep(100 * time.Millisecond)
+			time.Sleep(stopSampleWindow)
 
-		return len(sim.ax.recordedScrolls()) == before
-	})
+			return len(sim.ax.recordedScrolls()) == before
+		},
+	)
 
 	sim.press("Escape")
 	sim.waitMode(domain.ModeIdle)

--- a/internal/app/simulation_wait_norace_test.go
+++ b/internal/app/simulation_wait_norace_test.go
@@ -1,0 +1,8 @@
+//go:build !race
+
+package app_test
+
+// simRaceDetectorEnabled reports whether this test binary was built with
+// -race. See the //go:build race half of this pair for why it is a build
+// constraint rather than a measurement.
+const simRaceDetectorEnabled = false

--- a/internal/app/simulation_wait_race_test.go
+++ b/internal/app/simulation_wait_race_test.go
@@ -1,0 +1,11 @@
+//go:build race
+
+package app_test
+
+// simRaceDetectorEnabled reports whether this test binary was built with
+// -race. There is no runtime query for it, so it is answered by the build
+// constraint the toolchain sets — the only honest way to know, and the reason
+// the wait budgets never try to infer it from wall-clock measurements, which
+// on a loaded runner say "slow" for reasons that have nothing to do with the
+// race detector.
+const simRaceDetectorEnabled = true

--- a/internal/app/simulation_wait_test.go
+++ b/internal/app/simulation_wait_test.go
@@ -1,0 +1,38 @@
+package app_test
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSimHarness_WaitForWithinAsksTheConditionAfterTheBudgetIsSpent pins the
+// property that keeps the journeys off the flake list (#1324): a wait fails
+// only on work that has not happened.
+//
+// It is written as the shape a loaded runner produces rather than by loading
+// one. A poll sleeps, the runner takes the CPU away for longer than the whole
+// budget, and the poll wakes to a deadline already in the past — with the
+// awaited work long since done. Handing waitForWithin a budget that is already
+// spent is exactly that moment, minus the waiting: a wait that consults the
+// clock before the condition never asks it at all and fails the journey, and
+// one that asks first sees the work and returns.
+func TestSimHarness_WaitForWithinAsksTheConditionAfterTheBudgetIsSpent(t *testing.T) {
+	sim := &simHarness{t: t}
+
+	const spent = -time.Second
+
+	asked := 0
+
+	sim.waitForWithin(spent, "work that finished while the process was starved", func() bool {
+		asked++
+
+		return true
+	})
+
+	if asked == 0 {
+		t.Fatal(
+			"waitForWithin returned without asking its condition once the budget was spent; " +
+				"a journey descheduled past its deadline then fails on work that did happen",
+		)
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes the simulation journeys failing on busy CI runners for reasons that have nothing to do with the change under test. A single five-second budget served every wait in every journey, and it ran out twice in eleven consecutive pull requests — both times on a package the change never touched, both times green on rerun. A red check that has to be investigated and dismissed is what teaches people to rerun red checks without reading them.

Two things replace that one number. A wait now asks whether the work is done and only then looks at the clock, so a poll that wakes up late — because the runner took the CPU away, not because the work was slow — still sees work that finished; a journey fails only on work that did not happen. And the budget is stated for an ordinary build and stretched once, in one place, when the binary carries the race detector, which is where a fixed budget ran out first. Where a wait needs more because the thing it awaits has a duration of its own, it says so at that wait instead of growing the shared number.

The deliberate limitation: absence checks (asserting a mode is *not* entered) are left unscaled. Stretching them cannot fix their failure mode — a starved process watches nothing and passes vacuously however long the window is — so they would only cost every `-race` run real seconds. That is stated where they live. Nothing outside the test harness changes, and a genuinely hung journey still reports in five seconds, twenty under `-race`.

## Related Issues

Closes #1324

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, the only build tags added are the `race` / `!race` pair that answers whether the test binary carries the race detector.
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or platform code is touched.
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing documentation covers the test harness; the reasoning lives at the top of the harness, where the next journey is written.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**How the loaded-runner criterion was verified.** On an 8-core machine, the journeys were run under `-race` with `GOMAXPROCS=1` and 24, 48 and 64 spinning CPU burners, driving the load average to roughly 20-23. Every pass was green; the two-count run took ten seconds against four when idle. `GOMAXPROCS=1 go test -race -count=3` was also green.

**How hang detection was verified.** A throwaway journey waiting on a condition that never becomes true was measured at 5.0s without `-race` and 20.0s with it, then removed.

**Cost to CI.** None measurable: the `-race` pass over `internal/app` is 4.4s before and after. Budgets only cost time when a wait actually fails.

**Why the race detector is detected by build tag rather than measured.** A wall-clock calibration says "slow" for reasons that have nothing to do with instrumentation, which is the exact confusion this change exists to remove. The multiplier is 4, inside the detector's documented 2-20x range and on top of a base that is already about three orders of magnitude more than the work needs.

**One property is pinned by a test of its own**, so the ordering that fixes the starvation case cannot be quietly reverted: a wait handed a budget that is already spent, with its work already done, must still return rather than fail. It fails on the old ordering and passes on the new one.
