### PR TITLE
build: scope the golangci-lint cache to the checkout it runs in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ config.toml
 
 .direnv/
 
+# golangci-lint cache. The justfile points it here so every checkout gets its
+# own and none can poison another's — see the GOLANGCI_LINT_CACHE comment there.
+.golangci-cache/
+
 # Agent-guide local overrides (see AGENTS.md)
 AGENTS.local.md
 CLAUDE.local.md

--- a/internal/architecture/repo_walk_test.go
+++ b/internal/architecture/repo_walk_test.go
@@ -23,8 +23,13 @@ const bulkWalkFloor = 10
 const keptGoFile = "internal/domain/keep.go"
 
 // skippedWalkDirNames are the directory names every repository walk in this
-// package skips: version control, build outputs and vendored third-party code,
-// none of which contain first-party source subject to these guardrails.
+// package skips: version control, build outputs, the golangci-lint cache the
+// justfile keeps in the checkout, and vendored third-party code, none of which
+// contain first-party source subject to these guardrails.
+//
+// The lint cache earns its place twice over: it holds thousands of files, and
+// golangci-lint trims it while it runs, so a walk crossing it during a
+// concurrent lint can fail on a file that vanished mid-walk.
 //
 // This is the only such list in the package. doc_links_test.go used to carry a
 // second one naming .devbox, .opencode and demos as well; those three are not
@@ -33,7 +38,7 @@ const keptGoFile = "internal/domain/keep.go"
 // consolidation of where the rule lives. That list never did any work of its
 // own — the root-and-docs rule beside it had already excluded all three.
 var skippedWalkDirNames = map[string]bool{
-	".git": true, "bin": true, "build": true,
+	".git": true, ".golangci-cache": true, "bin": true, "build": true,
 	"node_modules": true, "vendor": true,
 }
 
@@ -228,6 +233,10 @@ func TestRepoWalk_SkipsOtherCheckoutsOnly(t *testing.T) {
 	// The names pruned before nested checkouts were a concern, still pruned.
 	writeWalkFile(t, root, "vendor/dep/keep.go")
 	writeWalkFile(t, root, "node_modules/dep/index.js")
+
+	// The lint cache the justfile parks in the checkout, which golangci-lint
+	// trims underneath a walk that wanders into it.
+	writeWalkFile(t, root, ".golangci-cache/00/00deadbeef-a")
 
 	want := []string{
 		".claude/skills/create-pr/SKILL.md",

--- a/justfile
+++ b/justfile
@@ -364,7 +364,25 @@ clean:
     rm -rf build/
     rm -rf *.app
     rm -f cmd/neru/rsrc_windows_*.syso
+    rm -rf "{{ GOLANGCI_LINT_CACHE }}"
     @echo "✓ Clean complete"
+
+# Where golangci-lint keeps its cache, scoped to this checkout.
+#
+# Its default is one host-level directory shared by every checkout on the
+# machine, and the agent worktrees parked under .claude/worktrees/ are separate
+# checkouts of this repository. They all wrote to that one cache, so removing a
+# worktree left entries behind naming files under a directory that no longer
+# exists, and the next `just fmt` in another checkout reported them as a lint
+# failure against a real-looking path — nothing wrong with the code, and no hint
+# in the message that the cache was the problem.
+#
+# Keeping the cache in the checkout gives each one its own, keeps repeat lints
+# warm (it persists between runs, and `just clean` is what removes it), and lets
+# a removed checkout take its cache with it rather than leaving one behind to go
+# stale. It is gitignored. The containerized lint-cross recipe passes its own
+# value to the container and is unaffected.
+export GOLANGCI_LINT_CACHE := justfile_directory() / ".golangci-cache"
 
 # Format code
 fmt:


### PR DESCRIPTION
## Description

This PR fixes lint failures that name files in directories which no longer
exist. `just fmt` and `just lint` used golangci-lint's default cache — a single
directory shared by every checkout of this repository on the machine. Two
checkouts linting the same file paths wrote into one cache, so deleting one
checkout left entries behind pointing at its files, and the next `just fmt`
anywhere else on the machine reported them as a lint failure against a
real-looking path, with nothing in the message to suggest the cache was at
fault.

Each checkout now gets its own cache, at `.golangci-cache/` inside it and
gitignored, so no checkout can see another's entries and a deleted checkout
takes its cache with it. It still persists between runs, so repeat lints stay
warm — a second `just lint` here finishes in about a second — and `just clean`
is what removes it. The containerized `just lint-cross` is unchanged; it already
kept its cache inside its container.

The architecture guardrails' repository walk skips the new directory. Without
that they would walk several thousand cache files on every run, and because the
walk fails the suite on any error it meets while golangci-lint trims its cache
as it runs, a walk crossing it during a concurrent lint could fail on a file
that vanished underneath it — the same ghost failure this PR sets out to remove.

## Related Issues

Closes #1349

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — the walk-pruning
      guardrail gained a fixture for the cache directory (it fails without the
      prune). The justfile side has no seam a Go test can reach; it was verified
      by running the recipes and inspecting where the cache landed.
- [x] Documentation updated (if applicable) — N/A, no doc names the lint cache
      location; the reasoning lives beside the assignment in the justfile.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Verified rather than reasoned about: `golangci-lint cache status` under the new
environment reports the in-checkout directory after both `just fmt` and
`just lint`, deleting it and re-running either recipe repopulates it, a second
lint run stays cached at roughly a second, `just clean` removes it, and
`just --evaluate GOLANGCI_LINT_CACHE` against a copy of the justfile in another
directory resolves to that directory — which is the per-checkout property.

In-checkout was chosen over a keyed directory under the host cache because it is
self-cleaning: removing a worktree removes its cache instead of leaving an
orphan behind to go stale, which is the failure mode this PR is about. The cost
is roughly 20 MB per checkout and one more `.gitignore` entry. The value is a
plain `justfile_directory()` join with no environment override, so the
`rm -rf` in `just clean` can only ever point inside the checkout.
