### PR TITLE
fix(linux): stop reporting a hint search input the overlay never draws

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -463,7 +463,7 @@ discovery rather than the mode itself.
 | **Hints**         | Element discovery              | ✅ full AX tree            | ⚠️ AT-SPI, toolkit-dependent | ⚠️ UIA, shallow tree      |
 | **Hints**         | `vision` strategy + per-app overrides | ✅                  | ❌ macOS-only              | ❌ macOS-only               |
 | **Hints**         | Menubar / dock elements        | ✅                         | 🟡                         | 🟡                          |
-| **Hints**         | Search input badge             | ✅                         | ❌ no-op                   | ✅                          |
+| **Hints**         | Search input badge             | ✅                         | 🟡 `CodeNotSupported`      | ✅                          |
 | **Hints**         | Label arrow / tail             | ✅ NSBezierPath            | ✅ Cairo triangle          | ❌                          |
 | **Hints**         | Label placement                | ✅ top / center / bottom   | ✅ top / center / bottom   | ❌ ignored, see below       |
 | **Grid**          | Transition animation           | ✅                         | ✅                         | ❌                          |
@@ -561,7 +561,9 @@ Work that is genuinely missing, as opposed to deliberately platform-specific.
 1. Native notifications and alerts — stubs; target freedesktop D-Bus notifications
 2. Smooth scroll animation — not implemented
 3. GNOME/Mutter Wayland — unsupported; the daemon refuses to start
-4. Hints search input badge — no-op in the overlay manager
+4. Hints search input badge — not drawn; the overlay manager reports
+   `CodeNotSupported` and the query goes on reaching hints through the event
+   tap's key stream
 5. Secure input detection — always false
 6. Wayland global hotkeys — need `input`-group access and a CGO build
 

--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -460,17 +460,37 @@ func (m *Manager) DrawHintsWithStyle(hintsSlice []*hints.Hint, style hints.Style
 	return nil
 }
 
-// DrawHintSearchInput draws the hints search input using the active Linux backend.
+// DrawHintSearchInput reports that no Linux backend draws the hints search
+// input.
+//
+// Unlike the draws above, the refusal does not depend on a surface: the badge
+// is unimplemented here, so attaching X11 or wlroots changes nothing. Returning
+// nil told the caller a query and a result count were on screen when nothing
+// was — the same silent no-op the platform guide forbids, on a call that
+// already has an error channel to say it with. Hint search itself keeps
+// working: the caller degrades on CodeNotSupported and the query still comes
+// through the event tap's key stream, which is what the Linux TextInput
+// capability already promises (`ports/capability_presets.go`).
 func (m *Manager) DrawHintSearchInput(
 	_ string,
 	_ int,
 	_ hints.SearchInputFrame,
 	_ hints.SearchInputStyle,
 ) error {
-	return nil
+	return derrors.New(
+		derrors.CodeNotSupported,
+		"overlay hint search input not implemented on linux backend",
+	)
 }
 
 // HideHintSearchInput hides the hints search input.
+//
+// It keeps its errorless signature deliberately (#1328). The two directions are
+// not symmetric: a draw makes a claim about what is on screen and the error
+// channel is the only place to withdraw it, while hiding claims nothing that
+// could be untrue here — nothing was ever painted, so there is nothing left on
+// screen and this genuinely succeeded. Widening it would hand every platform a
+// return value no caller could act on, on a call that runs from teardown.
 func (m *Manager) HideHintSearchInput() {}
 
 // DrawModeIndicator draws the mode indicator overlay.

--- a/internal/adapter/overlay/linux/stub_contract_test.go
+++ b/internal/adapter/overlay/linux/stub_contract_test.go
@@ -67,6 +67,16 @@ func TestLinuxOverlayManager_DrawCallsReportNotSupportedWithNoBackend(t *testing
 				return m.DrawMonitorSelect(nil, manager.MonitorSelectStyle{})
 			},
 		},
+		{
+			name: "DrawHintSearchInput",
+			call: func(m *Manager) error {
+				return m.DrawHintSearchInput(
+					"sav", 1,
+					hints.NewSearchInputFrame(image.Pt(10, 10), 200),
+					hints.SearchInputStyle{},
+				)
+			},
+		},
 	}
 
 	for _, testCase := range tests {
@@ -115,6 +125,36 @@ func TestLinuxOverlayManager_DrawCallsAreSafeWithRealArguments(t *testing.T) {
 	err = mgr.DrawMonitorSelect(targets, manager.MonitorSelectStyle{})
 	if !derrors.IsNotSupported(err) {
 		t.Errorf("DrawMonitorSelect with real targets returned %v, want CodeNotSupported", err)
+	}
+}
+
+// TestLinuxOverlayManager_HintSearchInputIsUnsupportedWithABackendToo pins what
+// separates the search input from every other draw above: those report
+// CodeNotSupported because there is no surface to draw on, so attaching a
+// backend would make them succeed. This one is not implemented at all — no
+// Linux backend draws the badge — so a surface changes nothing, and reporting
+// success once one exists would put the mode handler back where this started.
+func TestLinuxOverlayManager_HintSearchInputIsUnsupportedWithABackendToo(t *testing.T) {
+	tests := map[string]*Manager{
+		"x11 attached": {backend: linuxOverlayBackendX11, x11: &x11Overlay{}},
+		"wlroots attached": {
+			backend: linuxOverlayBackendWaylandWlroots,
+			wlroots: &wlrootsOverlay{},
+		},
+	}
+
+	for name, mgr := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := mgr.DrawHintSearchInput(
+				"sav", 1,
+				hints.NewSearchInputFrame(image.Pt(10, 10), 200),
+				hints.SearchInputStyle{},
+			)
+			if !derrors.IsNotSupported(err) {
+				t.Errorf("DrawHintSearchInput returned %v (code %q), want CodeNotSupported",
+					err, derrors.GetCode(err))
+			}
+		})
 	}
 }
 

--- a/internal/adapter/overlay/manager/manager.go
+++ b/internal/adapter/overlay/manager/manager.go
@@ -171,12 +171,20 @@ type Interface interface {
 	ConfigureComponents(cfg *config.Config, pointer PointerAppearance)
 
 	DrawHintsWithStyle(hs []*hints.Hint, style hints.StyleMode) error
+	// DrawHintSearchInput draws the query and result count over the hints
+	// surface. A backend that draws no such badge reports CodeNotSupported —
+	// nil means it is on screen, and a backend that answers nil without drawing
+	// leaves the mode handler with no way to know (#1328).
 	DrawHintSearchInput(
 		query string,
 		resultCount int,
 		frame hints.SearchInputFrame,
 		style hints.SearchInputStyle,
 	) error
+	// HideHintSearchInput takes that badge off the surface. It reports nothing
+	// on purpose: a backend that never drew one has nothing left on screen, so
+	// there is no failure for it to report, and no caller could act on one from
+	// a call that runs at teardown (#1328).
 	HideHintSearchInput()
 	DrawModeIndicator(x, y int)
 	DrawStickyModifiersIndicator(x, y int, symbols string)

--- a/internal/app/simulation_harness_test.go
+++ b/internal/app/simulation_harness_test.go
@@ -183,6 +183,10 @@ type simOverlayPort struct {
 	// monitor picker: showing that frame reports CodeNotSupported, the way an
 	// adapter over a backend without the capability does.
 	refuseMonitorSelect bool
+	// refuseHintSearch stands in for a backend that draws no hint search
+	// badge: the draw reports CodeNotSupported, the way the Linux overlay does
+	// for a search input no backend there implements.
+	refuseHintSearch bool
 
 	mu sync.Mutex
 	// visible is whether the overlay is on screen; shows counts how many times
@@ -271,11 +275,19 @@ func (m *simOverlayPort) ClearFrame(_ context.Context) error {
 
 func (m *simOverlayPort) SetActiveScreen(_ image.Rectangle) {}
 
+// DrawHintSearch records the query the search input was asked to show. A
+// refusing overlay records the ask too and then reports CodeNotSupported —
+// what a journey observes there is that the user was asked for, not that
+// anything was drawn.
 func (m *simOverlayPort) DrawHintSearch(search ports.HintSearch) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	m.searchQueries = append(m.searchQueries, search.Query)
+
+	if m.refuseHintSearch {
+		return derrors.New(derrors.CodeNotSupported, "no hint search input on this backend")
+	}
 
 	return nil
 }
@@ -463,7 +475,11 @@ func (m *simOverlayPort) indicatorVisibility(indicator ports.Indicator) (bool, b
 	return visible, asked
 }
 
-func (m *simOverlayPort) searchInputDrawCount() int {
+// searchInputAskCount reports how many times the overlay was asked to show the
+// search input. It counts asks rather than draws because a refusing overlay
+// records the ask and then declines it, and "search is open" is what a journey
+// needs to observe either way.
+func (m *simOverlayPort) searchInputAskCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1100,6 +1116,25 @@ func newSimHarnessWithDisplays(
 	recorder := &simOverlayPort{}
 
 	return buildSimHarness(tb, cfg, elements, displays, recorder, recorder)
+}
+
+// newSimHarnessRefusingHintSearch builds the app on an overlay that draws
+// everything except the hint search badge, which it refuses with
+// CodeNotSupported — the Linux overlay's answer for a search input no backend
+// there implements. The recorder is kept, because what this stands up is a
+// mode that has to go on working without it.
+func newSimHarnessRefusingHintSearch(
+	tb testing.TB,
+	cfg *config.Config,
+	elements []*element.Element,
+) *simHarness {
+	tb.Helper()
+
+	recorder := &simOverlayPort{refuseHintSearch: true}
+
+	return buildSimHarness(tb, cfg, elements, []simDisplay{
+		{name: defaultDisplayName, bounds: simScreen},
+	}, recorder, recorder)
 }
 
 // newSimHarnessHeadlessOverlay builds the app on an overlay with no surface

--- a/internal/app/simulation_journey_test.go
+++ b/internal/app/simulation_journey_test.go
@@ -468,40 +468,58 @@ func manyButtons(tb testing.TB, count int) []*element.Element {
 // TestSimulation_HintsSearchJourney covers text search: "/" opens search,
 // typing a query narrows the hints to matching elements, Return confirms,
 // and selecting the surviving label lands on the matched element.
+//
+// The second case runs the identical journey on an overlay that reports
+// CodeNotSupported for the search input — the Linux overlay, where no backend
+// draws that badge (#1328). The user sees no "/ sav 1 /" box and loses nothing
+// else: the query still reaches the hints through the event tap's key stream.
+// A refusal that surfaced as a failed mode, or that stopped the keystrokes
+// getting through, is what this second case pins.
 func TestSimulation_HintsSearchJourney(t *testing.T) {
-	elements := threeButtons(t)
-	sim := newSimHarness(t, simConfig(), elements)
-
-	sim.pressHotkey(hintsHotkey)
-	sim.waitMode(domain.ModeHints)
-	sim.waitFor("hints drawn", func() bool { return sim.overlay.hintDrawCount() > 0 })
-
-	// "/" dispatches search_hints asynchronously; wait for the search input to
-	// appear before typing, or the query characters would be read as labels.
-	sim.press("/")
-	sim.waitFor("search input shown", func() bool {
-		return sim.overlay.searchInputDrawCount() > 0
-	})
-
-	sim.typeLabel("sav") // matches only the "Save" button title
-
-	sim.waitFor("hints narrowed to the query", func() bool {
-		return len(sim.overlay.lastHintLabels()) == 1
-	})
-
-	sim.press("Return")
-
-	labels := sim.overlay.lastHintLabels()
-	if len(labels) != 1 {
-		t.Fatalf("expected one hint after confirmed search, got %v", labels)
+	overlays := map[string]func(testing.TB, *config.Config, []*element.Element) *simHarness{
+		"search input drawn":   newSimHarness,
+		"search input refused": newSimHarnessRefusingHintSearch,
 	}
 
-	sim.typeLabel(labels[0])
+	for name, newHarness := range overlays {
+		t.Run(name, func(t *testing.T) {
+			elements := threeButtons(t)
+			sim := newHarness(t, simConfig(), elements)
 
-	saveCenter := elements[0].Center()
-	sim.waitFor("cursor on the searched element", func() bool {
-		return sim.cursor.position() == saveCenter
-	})
+			sim.pressHotkey(hintsHotkey)
+			sim.waitMode(domain.ModeHints)
+			sim.waitFor("hints drawn", func() bool { return sim.overlay.hintDrawCount() > 0 })
+
+			// "/" dispatches search_hints asynchronously; wait for search to be
+			// open before typing, or the query characters would be read as
+			// labels. The wait is on the ask rather than on anything drawn,
+			// because the refusing overlay draws nothing.
+			sim.press("/")
+			sim.waitFor("search input asked for", func() bool {
+				return sim.overlay.searchInputAskCount() > 0
+			})
+
+			sim.typeLabel("sav") // matches only the "Save" button title
+
+			sim.waitFor("hints narrowed to the query", func() bool {
+				return len(sim.overlay.lastHintLabels()) == 1
+			})
+
+			sim.press("Return")
+
+			labels := sim.overlay.lastHintLabels()
+			if len(labels) != 1 {
+				t.Fatalf("expected one hint after confirmed search, got %v", labels)
+			}
+
+			sim.typeLabel(labels[0])
+
+			saveCenter := elements[0].Center()
+			sim.waitFor("cursor on the searched element", func() bool {
+				return sim.cursor.position() == saveCenter
+			})
+		})
+	}
 }
 
 // TestSimulation_HintsTwoCharLabels covers label generation past the

--- a/internal/ports/overlay.go
+++ b/internal/ports/overlay.go
@@ -293,10 +293,20 @@ type OverlayPort interface {
 	// DrawHintSearch draws the hint search input over the hints frame. Like
 	// RedrawFrame it is an update rather than a transition: it fires on every
 	// keystroke typed into the search, over an overlay already on screen.
+	//
+	// An overlay that draws no search input reports CodeNotSupported, which is
+	// degradation rather than failure: search itself is unaffected, because the
+	// query reaches the hints through the event tap's key stream and not
+	// through this. Callers branch on IsNotSupported (#1328).
 	DrawHintSearch(search HintSearch) error
 
 	// HideHintSearch takes the search input off the screen, leaving the hint
 	// labels behind it where they are.
+	//
+	// It reports nothing, and deliberately so (#1328): unlike the draw, it
+	// makes no claim about the screen that could turn out to be untrue — an
+	// overlay that never drew a search input has nothing left to take off — and
+	// it runs from teardown, where no caller could act on an answer anyway.
 	HideHintSearch()
 
 	// HintSearchBounds reports where the search input sits on a screen. The


### PR DESCRIPTION
## Description

This PR fixes the Linux overlay claiming it had drawn the hint search box when it
had drawn nothing. No Linux backend paints that box — the one showing the query
and how many hints still match — so on Linux, opening hint search has always left
the screen looking exactly as it did before. The overlay reported the draw as a
success anyway, which meant nothing in the daemon, and nothing in a log, could
say the box was missing.

The overlay now reports the search box as unsupported instead. Hint search itself
is unchanged for users on every platform: typing still narrows the hints through
the normal key stream, Return still confirms, Escape still cancels. What changes
is that the missing box is now stated rather than silently swallowed, which is
what lets it be fixed later and what keeps `neru doctor`'s picture of the
platform honest.

Deliberate limitation: this does not implement the search box on Linux — that
stays a roadmap item, and the platform docs now record it as a reported stub
rather than a silent no-op.

## Related Issues

Closes #1328

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code) — N/A, the behaviour change is Linux-only; the shared code touched is a test journey
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [x] `fix` — Bug fix

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**The hide call keeps its errorless signature — recorded rather than changed.**
The issue asks for a ruling on this and the ruling is to leave it. The two
directions are not symmetric: a draw makes a claim about what is on screen, and
its error return is the only place to withdraw that claim, while hiding claims
nothing that could turn out to be untrue — an overlay that never drew the box
has nothing left to take off, so it genuinely succeeded. Widening it would hand
every platform a return value no caller could act on, from a call that runs at
teardown. The rationale is recorded on the port declaration, on the backend
interface, and on the Linux implementation, so it does not get re-litigated at
whichever of the three a future reader lands on first.

**The refusal does not depend on a surface.** Unlike the other Linux draws, which
report unsupported because there is no display to draw on, this one is
unimplemented — so it answers the same way with a backend attached. There is a
contract test for both cases, and the existing hint-search journey now runs a
second time over an overlay that refuses the box, which is what proves a user
loses the box and nothing else. That second case was confirmed to have teeth: it
fails if the refusal is allowed to cancel the search.

**Verified beyond `just ci`** (which runs macOS-tagged code only): `just
lint-cross` and `just test-linux` both pass, so the new Linux-tagged contract
test is a test that actually executes.

No screenshots: the user-visible change on Linux is that nothing appears, which
is what already happened.
