### PR TITLE
fix(app): notice the first application switch after the daemon starts

### DIFF
--- a/docs/adr/0005-the-focused-app-is-published-not-polled.md
+++ b/docs/adr/0005-the-focused-app-is-published-not-polled.md
@@ -74,6 +74,17 @@ exit included, since it takes the same lock.
   about focus instead of asking. One `resolveFocusedApp` covers both: read the
   cell when it is fed, ask when it is not. `docs/CROSS_PLATFORM.md` gains the
   row.
+- **Publishing only works while something is listening, so the order the daemon
+  starts in became load-bearing.** Polling was self-healing: whoever asked got
+  an answer, however late they asked. A publication has one delivery and no
+  retry, so a watcher started before `App.Run` registers its activation callback
+  drops what it reports, and on Linux — where the watcher samples once as it
+  starts and reports only changes after that — the lost sample is not
+  re-reported until the user switches application again. Until then the keymap
+  settles by asking, which is what this ADR set out to avoid, and per-app
+  overrides bind to whatever was focused when the mode opened. #1348 is that
+  bug; `app/lifecycle.go` registers before it starts, and the simulation journey
+  pins the order.
 - **`handlerState.focusedBundleID` is deleted.** Leaving it would leave the
   regression writable; deleting it means the only way to learn the focused app
   inside the handler is the published cell. Callers that legitimately need a

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -69,15 +69,38 @@ func (a *App) Run() error {
 
 	a.logger.Info("IPC server started")
 
-	a.appWatcher.Start()
-	a.logger.Info("App watcher started")
+	// These three are ordered, not merely sequential, and the order is starting
+	// the watcher last: an activation it delivers reaches both of the things
+	// above it, and neither absorbs one until it has run. Registering after the
+	// watcher started meant a dropped activation, which nothing retries — ADR
+	// 0005 has the consequence, #1348 was the bug, and
+	// TestSimulation_TheAppHearsFocusChangesFromTheMomentItWatchesForThem pins
+	// it. Registering the hotkeys after it would hand the same activation a
+	// binder holding nothing, and the refresh here would then re-register the
+	// global table over the per-app one it had just installed
+	// (keybinding/binder.go).
+	//
+	// Only the registrations belong ahead of this; nothing that can block does.
+	// The observers below reach a session bus on Linux, and putting a bus round
+	// trip in front of the watcher and the hotkeys would delay the daemon
+	// accepting its first chord to hurry up something nothing is waiting on.
+	a.registerAppWatcherCallbacks()
 
 	a.hotkeys.RefreshFor("")
 	a.logger.Info("Hotkeys initialized")
 
-	a.setupSleepObserver()
+	a.appWatcher.Start()
+	a.logger.Info("App watcher started")
 
-	a.setupAppWatcherCallbacks()
+	// Watch for theme changes (Dark Mode / Light Mode) so theme-aware label
+	// colors follow without a restart.
+	a.setupThemeObserver()
+
+	// Gate Mission Control detection at all levels using config. It stays after
+	// the hotkeys are live because what it arms can run an action sequence.
+	a.appWatcher.SetMCDetection(cfg.Hints.DetectMissionControl)
+
+	a.setupSleepObserver()
 
 	if cfg.Grid.EnableGC {
 		ctx, cancel := context.WithCancel(a.ctx)
@@ -188,8 +211,10 @@ func (a *App) adaptiveGC() bool {
 	}
 }
 
-// setupAppWatcherCallbacks configures callbacks for application watcher events.
-func (a *App) setupAppWatcherCallbacks() {
+// registerAppWatcherCallbacks registers the handlers for application watcher
+// events. It only registers — everything here has to be in place before the
+// watcher starts, so nothing that can block belongs in it (see Run).
+func (a *App) registerAppWatcherCallbacks() {
 	a.appWatcher.OnActivate(func(_, bundleID string) {
 		a.handleAppActivation(bundleID)
 	})
@@ -224,13 +249,6 @@ func (a *App) setupAppWatcherCallbacks() {
 			)
 		}
 	})
-
-	// Watch for macOS theme changes (Dark Mode / Light Mode) to update
-	// theme-aware label colors without requiring restart.
-	a.setupThemeObserver()
-
-	// Gate Mission Control detection at all levels using config
-	a.appWatcher.SetMCDetection(a.configSnapshot().Hints.DetectMissionControl)
 }
 
 // HandleScreenParametersChange is the app's entry point for a display

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -97,8 +97,11 @@ func (a *App) Run() error {
 	a.setupThemeObserver()
 
 	// Gate Mission Control detection at all levels using config. It stays after
-	// the hotkeys are live because what it arms can run an action sequence.
-	a.appWatcher.SetMCDetection(cfg.Hints.DetectMissionControl)
+	// the hotkeys are live because what it arms can run an action sequence, and
+	// it reads the configuration now rather than the snapshot taken at the top
+	// of Run: the IPC server is already accepting a reload by this point, and
+	// nothing applies this setting again afterwards.
+	a.appWatcher.SetMCDetection(a.configSnapshot().Hints.DetectMissionControl)
 
 	a.setupSleepObserver()
 

--- a/internal/app/simulation_harness_test.go
+++ b/internal/app/simulation_harness_test.go
@@ -1307,7 +1307,13 @@ func buildSimHarness(
 		application.Cleanup()
 	})
 
-	sim.waitFor("app running", application.IsEnabled)
+	// Wait for the app watcher to be running, not for IsEnabled: the app is
+	// enabled before Run is entered at all, so waiting on that waited for
+	// nothing and a journey could drive the fixture desktop before the app was
+	// listening. Run starts the watcher last of the three steps that have to be
+	// in place first (lifecycle.go), so this says exactly that a focus change
+	// from here on is one the app hears — and no more than that.
+	sim.waitFor("the app watcher running", watcher.Started)
 
 	return sim
 }

--- a/internal/app/simulation_journey_test.go
+++ b/internal/app/simulation_journey_test.go
@@ -2192,6 +2192,46 @@ func TestSimulation_KeystrokeAsksWhichAppIsFocused(t *testing.T) {
 	}
 }
 
+// TestSimulation_TheAppHearsFocusChangesFromTheMomentItWatchesForThem is the
+// precondition the two journeys below it rest on, and #1348 is what happens
+// without it: the daemon started the application watcher and made the hotkeys
+// live before it registered the callback activations are delivered to, so an
+// application switch in that window reached nobody, was never retried, and left
+// the journey below entering the mode the *previous* application bound the key
+// to. ADR 0005 carries why a dropped publication is unrecoverable rather than
+// merely late.
+//
+// Worth stating what it is not, because the intermittency points elsewhere and
+// #1348 named two suspects: neither goroutine `handleAppActivation` starts is
+// involved. Publication is a lock-free cell write on the caller's goroutine, so
+// it is already in place before the keystroke that reads it; the passthrough
+// refresh only reads; and the hotkey refresh is deferred outright while a mode
+// is open. What was intermittent was whether the daemon had finished starting,
+// not what it did once it had.
+//
+// It asserts the order rather than the symptom because the order is what makes
+// the symptom impossible: whether the window is wide enough to fall into is a
+// property of the machine, and CI found it on a busy runner.
+func TestSimulation_TheAppHearsFocusChangesFromTheMomentItWatchesForThem(t *testing.T) {
+	sim := newSimHarness(t, simConfig(), nil)
+
+	// The harness already waits for this, and asking again is what keeps the
+	// assertion below from passing vacuously if that ever stops being true.
+	registered, started := sim.watcher.ActivateCallbacksAtStart()
+	if !started {
+		t.Fatal("the app watcher was never started")
+	}
+
+	if registered == 0 {
+		t.Error(
+			"the app watcher was started before anything registered for activations: " +
+				"an application switch reported in that window is dropped and never " +
+				"retried, so per-app hotkey overrides go on binding to the application " +
+				"the mode was opened in",
+		)
+	}
+}
+
 // TestSimulation_FocusChangeMidModeRebindsTheKey covers switching applications
 // without leaving the mode — passing a shortcut through to the system and
 // landing somewhere else is the ordinary way it happens — and pins what the

--- a/internal/ports/mocks/appwatcher.go
+++ b/internal/ports/mocks/appwatcher.go
@@ -17,6 +17,13 @@ type MockAppWatcherPort struct {
 	stopped     bool
 	mcDetection bool
 
+	// activateCallbacksAtStart is how many activate callbacks were registered
+	// when Start was called. It is that instant rather than the count now
+	// because a watcher started before anything registered drops what it
+	// reports until something does, and nothing goes back for a dropped
+	// activation.
+	activateCallbacksAtStart int
+
 	activateCallbacks   []ports.AppEventCallback
 	deactivateCallbacks []ports.AppEventCallback
 	terminateCallbacks  []ports.AppEventCallback
@@ -31,6 +38,7 @@ func (m *MockAppWatcherPort) Start() {
 	defer m.mu.Unlock()
 
 	m.started = true
+	m.activateCallbacksAtStart = len(m.activateCallbacks)
 }
 
 // Stop implements ports.AppWatcherPort.
@@ -103,6 +111,15 @@ func (m *MockAppWatcherPort) Started() bool {
 	defer m.mu.Unlock()
 
 	return m.started
+}
+
+// ActivateCallbacksAtStart reports how many activate callbacks were registered
+// at the moment Start was called, and false when Start has not been called.
+func (m *MockAppWatcherPort) ActivateCallbacksAtStart() (int, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.activateCallbacksAtStart, m.started
 }
 
 // Stopped reports whether Stop was called.


### PR DESCRIPTION
## Description

This PR fixes the daemon missing the first application switch after it starts. It began watching for switches, and accepted its first hotkey, before it had registered the handler those switches are delivered to — so a switch reported in that window reached nobody, and nothing goes back for one that was missed. On Linux the effect lasts longest: the watcher takes a single sample as it starts and reports only changes after that, so the sample that went missing is not re-reported until the user switches application again.

What that cost the user is per-app hotkey overrides binding to the wrong application. While nothing has been reported, the bindings in force are settled against whichever application was focused when the mode was opened, so a key pressed after switching ran the meaning it had in the application they had just left. Startup now registers the handler first, brings the hotkeys up next, and starts the watcher last, which also stops a switch arriving mid-startup from having its per-app hotkey registration overwritten by the daemon's own initial one.

The window is narrow and only reachable in the first moments after launch, so most users would have seen this as an occasional oddity rather than a reproducible one. It is what made `TestSimulation_FocusChangeMidModeRebindsTheKey` fail intermittently on CI.

## Related Issues

Closes #1348

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `fix` — Bug fix

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no OS-specific file is added or changed.
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port contract changes.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Three things worth a reviewer's attention.

**Why the startup order is the cause, and not the test.** The issue ruled out the obvious reading — a missing wait between the simulated focus change and the keystroke — and it was right to: publication is a lock-free write on the same goroutine as the keystroke, so there is no publish/read gap. It is not either of the two goroutines the issue pointed at either; one only reads, and the other is deferred outright while a mode is open. Injecting a delay between the daemon making its hotkeys live and registering its watcher handler reproduces the reported failure verbatim on the first run, and the fix makes it pass under a 300ms delay in the same place.

**The simulation harness was waiting for nothing.** It gated on the app reporting itself enabled, which is true before the startup sequence is entered at all, so journeys could drive the fixture desktop before the daemon was listening. It now waits for the watcher to be running — the last of the three steps the fix orders — which is a real barrier rather than a wait that would have hidden the bug. The counterfactual holds: with that gate in place but the production order reverted, the new pin test still fails.

**The rest of the old startup block stayed where it was.** Only the event registrations moved ahead of the watcher; the theme observer and Mission Control gating did not, because the theme observer reaches a session bus on Linux and a bus round trip in front of the watcher and the hotkeys would delay the daemon accepting its first chord.

The change also adds a pin test asserting the order directly rather than the symptom, since whether the window is wide enough to fall into is a property of the machine. ADR 0005 gains the consequence that made the ordering load-bearing: publishing has one delivery and no retry, where polling was self-healing.
