### PR TITLE
fix(linux): honour the corner radius on hint boundaries and recursive-grid labels

### DIFF
--- a/internal/adapter/overlay/linux/corner_radius_test.go
+++ b/internal/adapter/overlay/linux/corner_radius_test.go
@@ -1,0 +1,221 @@
+//go:build linux && cgo
+
+package linux
+
+import (
+	"image"
+	"testing"
+
+	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
+	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/domain"
+)
+
+// recordedRect is one rectangle a shared draw handed to its backend. rounded
+// tells the two primitives apart: a shape drawn through rectPrim has no radius
+// to report, and that is exactly the bug these tests pin — a corner radius the
+// configuration accepts but the draw never passes on.
+type recordedRect struct {
+	bounds  image.Rectangle
+	radius  float64
+	rounded bool
+}
+
+// recordingSurface is an overlaySurface that draws nothing and remembers what
+// it was asked to draw. It stands in for Cairo so these tests need no display,
+// and it observes the shared drawing code at the one boundary the backends see.
+type recordingSurface struct {
+	scale float64
+	rects []recordedRect
+}
+
+func (s *recordingSurface) surfaceScale() float64 { return s.scale }
+
+func (s *recordingSurface) ensureBuffers() {}
+
+func (s *recordingSurface) beginFrame() bool { return true }
+
+func (s *recordingSurface) surfaceClear() {}
+
+func (s *recordingSurface) clearFrame() {}
+
+func (s *recordingSurface) surfaceClearRect(image.Rectangle) {}
+
+func (s *recordingSurface) surfaceFlush() {}
+
+func (s *recordingSurface) surfaceHide() {}
+
+func (s *recordingSurface) showIndicator() {}
+
+func (s *recordingSurface) finishIndicator() {}
+
+func (s *recordingSurface) syncBeforeAnimation() {}
+
+func (s *recordingSurface) rectPrim(bounds image.Rectangle, _, _ uint32, _ float64) {
+	s.rects = append(s.rects, recordedRect{bounds: bounds})
+}
+
+func (s *recordingSurface) roundedRectPrim(
+	bounds image.Rectangle, radius float64, _, _ uint32, _ float64,
+) {
+	s.rects = append(s.rects, recordedRect{bounds: bounds, radius: radius, rounded: true})
+}
+
+func (s *recordingSurface) hintBadgePrim(
+	image.Rectangle, float64, int, hintArrowTriangle, uint32, uint32, float64,
+) {
+}
+
+func (s *recordingSurface) textPrim(_, _ string, _, _, _ float64, _ uint32) {}
+
+// TestSharedOverlay_DrawHints_BoundaryHighlightHonoursItsBorderRadius pins
+// hints.boundary_highlight.border_radius to the shape Linux draws. The expected
+// radii are the ones macOS (overlay_darwin.m, auto = 4 clamped to half the
+// shorter side) and Windows (winAutoRadiusBoundaryCap) resolve the same
+// configuration to: a boundary that is a rounded pill on two platforms and a
+// square box on the third is the same config producing two different screens.
+func TestSharedOverlay_DrawHints_BoundaryHighlightHonoursItsBorderRadius(t *testing.T) {
+	t.Parallel()
+
+	// A 100x40 element: half its shorter side is 20, so the auto radius caps at
+	// 4 and an oversized configured radius clamps to 20.
+	const (
+		elementWidth  = 100
+		elementHeight = 40
+	)
+
+	center := image.Pt(200, 200)
+	wantBounds := image.Rect(150, 180, 250, 220)
+
+	tests := []struct {
+		name       string
+		configured int
+		wantRadius float64
+	}{
+		{name: "auto resolves to the boundary cap", configured: -1, wantRadius: 4},
+		{name: "zero keeps sharp corners", configured: 0, wantRadius: 0},
+		{name: "a configured radius is drawn", configured: 8, wantRadius: 8},
+		{name: "an oversized radius clamps to the shape", configured: 999, wantRadius: 20},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.DefaultConfig()
+			cfg.Hints.BoundaryHighlight.Enabled = true
+			cfg.Hints.BoundaryHighlight.BorderRadius = testCase.configured
+
+			surface := &recordingSurface{scale: 1}
+			overlay := &sharedOverlay{srf: surface}
+
+			overlay.drawHints(
+				[]*hintscomponent.Hint{
+					hintscomponent.NewHint(
+						"a", center, image.Pt(elementWidth, elementHeight), "",
+					),
+				},
+				hintscomponent.BuildStyle(cfg.Hints, nil),
+				hintBadgeOnTarget,
+			)
+
+			if len(surface.rects) != 1 {
+				t.Fatalf("drew %d rectangles, want 1 (the boundary highlight)", len(surface.rects))
+			}
+
+			boundary := surface.rects[0]
+			if boundary.bounds != wantBounds {
+				t.Errorf("boundary bounds = %v, want %v", boundary.bounds, wantBounds)
+			}
+
+			if !boundary.rounded {
+				t.Fatal("boundary was drawn with the sharp-cornered primitive, " +
+					"so its configured radius reaches nothing")
+			}
+
+			if boundary.radius != testCase.wantRadius {
+				t.Errorf("boundary radius = %v, want %v", boundary.radius, testCase.wantRadius)
+			}
+		})
+	}
+}
+
+// TestSharedOverlay_DrawFrame_LabelBackgroundHonoursItsBorderRadius pins
+// recursive_grid.ui.label_background_border_radius the same way. The auto value
+// is a full pill here rather than a capped corner: that is what the shared
+// resolver documents for a label background and what Windows draws with it.
+// macOS resolves the same -1 to MIN(height/2, 6) in drawGridLabel: — these
+// cases assert the resolver Linux now shares with Windows, not agreement with
+// that third copy.
+func TestSharedOverlay_DrawFrame_LabelBackgroundHonoursItsBorderRadius(t *testing.T) {
+	t.Parallel()
+
+	// Font 20 with explicit padding gives a 20x32 plate: half its shorter side
+	// is 10, which is both the full-pill radius and the clamp ceiling.
+	const (
+		labelFontSize = 20
+		paddingX      = 3
+		paddingY      = 2
+	)
+
+	cell := image.Rect(0, 0, 200, 200)
+	wantBounds := image.Rect(90, 84, 110, 116)
+
+	tests := []struct {
+		name       string
+		configured int
+		wantRadius float64
+	}{
+		{name: "auto resolves to a full pill", configured: -1, wantRadius: 10},
+		{name: "zero keeps sharp corners", configured: 0, wantRadius: 0},
+		{name: "a configured radius is drawn", configured: 4, wantRadius: 4},
+		{name: "an oversized radius clamps to the plate", configured: 999, wantRadius: 10},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			style := recursivegridcomponent.NewStyle(recursivegridcomponent.StyleOptions{
+				FontSize:                    labelFontSize,
+				LabelBackground:             true,
+				LabelBackgroundPaddingX:     paddingX,
+				LabelBackgroundPaddingY:     paddingY,
+				LabelBackgroundBorderRadius: testCase.configured,
+			})
+
+			surface := &recordingSurface{scale: 1}
+			overlay := &sharedOverlay{srf: surface}
+
+			overlay.drawFrame(
+				[]image.Rectangle{cell},
+				[]rune{'A'},
+				nil,
+				domain.GridDimensions{},
+				style,
+				recursivegridcomponent.VirtualPointerState{},
+			)
+
+			// The cell itself is drawn first, the label plate on top of it.
+			if len(surface.rects) != 2 {
+				t.Fatalf("drew %d rectangles, want 2 (the cell and its label plate)",
+					len(surface.rects))
+			}
+
+			plate := surface.rects[1]
+			if plate.bounds != wantBounds {
+				t.Errorf("label plate bounds = %v, want %v", plate.bounds, wantBounds)
+			}
+
+			if !plate.rounded {
+				t.Fatal("the label plate was drawn with the sharp-cornered primitive, " +
+					"so its configured radius reaches nothing")
+			}
+
+			if plate.radius != testCase.wantRadius {
+				t.Errorf("label plate radius = %v, want %v", plate.radius, testCase.wantRadius)
+			}
+		})
+	}
+}

--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -41,6 +41,12 @@ const (
 	// radius so labels get a subtle rounded corner rather than a full pill,
 	// matching the macOS overlay's MIN(height/2, 6).
 	hintAutoRadiusMax = 6
+	// hintBoundaryAutoRadiusMax caps the auto
+	// (boundary_highlight.border_radius = -1) corner radius of the element
+	// boundary, matching the macOS overlay's 4.0 fallback and the Windows
+	// winAutoRadiusBoundaryCap. An element box is much larger than a badge, so
+	// without the cap the auto radius would round it into an oval.
+	hintBoundaryAutoRadiusMax = 4
 	// hintArrowHeight is the height in pixels of the triangular connector arrow
 	// drawn between a hint badge and its target for top/bottom placement,
 	// mirroring the macOS overlay's tooltip arrow. hintArrowHalfBase is half the

--- a/internal/adapter/overlay/linux/overlay_shared_cgo.go
+++ b/internal/adapter/overlay/linux/overlay_shared_cgo.go
@@ -319,8 +319,11 @@ func (o *sharedOverlay) drawHints(
 		pos := hint.Position().Add(o.originOffset)
 		if style.BoundaryHighlightEnabled() {
 			boundary := badge.CenteredOn(pos, hint.Size().X, hint.Size().Y)
-			o.drawRect(
+			o.drawRoundedRect(
 				boundary,
+				badge.BorderRadius(
+					style.BoundaryBorderRadius(), boundary, hintBoundaryAutoRadiusMax,
+				),
 				badge.ParseHexARGB(style.BoundaryBackgroundColor()),
 				badge.ParseHexARGB(style.BoundaryBorderColor()),
 				float64(max(style.BoundaryBorderWidth(), 0)),
@@ -969,7 +972,14 @@ func (o *sharedOverlay) drawLabelBackground(
 	height := badge.EstimateTextHeight(fontSize) +
 		paddingY*paddingMultiplier
 	rect := badge.CenteredIn(cell, width, height)
-	o.drawRect(rect, style.LabelBackgroundColorARGB(),
+	// A zero auto cap means a full pill: left at -1, the plate rounds to its
+	// own half height. That is what the shared resolver documents for a label
+	// background and what Windows draws. macOS caps the same auto radius at
+	// 6 px (drawGridLabel: in overlay_darwin.m) — a divergence that predates
+	// this call site and is not settled here.
+	o.drawRoundedRect(rect,
+		badge.BorderRadius(style.LabelBackgroundBorderRadius(), rect, 0),
+		style.LabelBackgroundColorARGB(),
 		style.LineColorARGB(), max(style.LabelBackgroundBorderWidthF(), 0))
 }
 


### PR DESCRIPTION
## Description

This PR fixes two corner-radius settings that the Linux overlay accepted and
validated but never drew with. On Linux the hint target boundary and the
recursive-grid label plate were painted with square corners no matter what the
configuration said, while macOS and Windows drew both as rounded pills. Because
both options default to `-1` ("auto"), the difference showed up on a default
config as soon as either feature was switched on — nothing had to be set for it
to be wrong.

Both shapes are now drawn with their configured radius, resolved through the
same shared resolver Windows already uses, so `-1` means the same automatic
radius everywhere: a subtle 4 px corner on an element boundary, a full pill on a
label plate. An explicit radius is clamped to the shape it is drawn on, and `0`
still means square corners.

One deliberate limitation: the resolved radius is not multiplied by the HiDPI
surface scale, matching the hint badge next to it. On a scaled X11 display an
explicit radius therefore renders smaller than the same number on macOS. That
predates this change and is left alone rather than fixed in passing.

## Related Issues

Closes #1335

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Config Surface

No option is added, renamed or removed — two existing ones simply start working
on Linux. Existing configuration files keep working; the only change a user sees
is the shape on screen.

| Option | Default | What Linux does now |
| --- | --- | --- |
| `hints.boundary_highlight.border_radius` | `-1` | `-1` rounds the element boundary by 4 px (capped at half its shorter side); `0` is square; a positive value is clamped to half the shorter side |
| `recursive_grid.ui.label_background_border_radius` | `-1` | `-1` rounds the label plate into a full pill; `0` is square; a positive value is clamped to half the plate's shorter side |

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this fills in a Linux draw call; the other two backends already drew both shapes
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes: neither reference carried a Linux caveat, and the "boundary highlight is shared" line in `docs/CROSS_PLATFORM.md` becomes true as written
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

`just lint-cross` and the containerised Linux test suite are both clean — these
are `linux`-tagged files that the macOS `just lint` and `just test` never
compile. The new tests are `//go:build linux && cgo` and run on the Linux CI job.

Two things worth a reviewer's eye:

- **macOS resolves the label plate's `-1` differently.** `drawGridLabel:` caps
  that auto radius at 6 px, while the shared resolver — and therefore Windows,
  and now Linux — rounds a label plate into a full pill. For the plate size the
  new tests use, macOS would draw 6 where Linux draws 10. This PR follows the
  shared resolver, because that is what the issue asked for and what the
  resolver's own contract documents; it does not touch the Objective-C copy.
  Happy to flip Linux to the 6 px cap instead if the macOS shape is the intended
  one — that is a one-line change, but it is a decision, not a fix. The boundary
  highlight has no such disagreement: all three resolve `-1` to 4 px.
- **The auto cap is still declared per backend.** `4` now exists in three
  places (Linux, Windows, the Objective-C bridge), as `6` already did for hint
  badges. Collapsing those into the shared badge package is the ADR 0007 move
  and touches all three backends, so it is left for its own change.
