### PR TITLE
docs(config): correct where the in-frame virtual pointer is configured

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -103,7 +103,7 @@ Every option not listed here behaves the same on all three platforms.
 | `hints.on_mission_control_deactivated`    | Yes   | No    | No      | Never fires.                                         |
 | `[hints.search_input_ui]`                 | Yes   | No    | Yes     | Linux: search filtering works, but the input badge is not drawn. |
 | `[monitor_select]`                        | Yes   | Yes   | No      | Windows: the mode returns `ERR_NOT_SUPPORTED`.       |
-| `[virtual_pointer]`                       | Yes   | No    | No      | Ignored; pairs with macOS-only cursor hiding.        |
+| `[virtual_pointer]`                       | Yes   | Partial | Partial | Linux and Windows: the standalone overlay is not drawn (it pairs with macOS-only cursor hiding), but these options still style the recursive-grid in-frame pointer. |
 | `[smooth_cursor]`                         | Yes   | Yes   | No      | Windows: cursor moves instantly.                     |
 | `smooth_cursor.relative_movement_duration` | Yes  | Yes   | No      | Windows: relative moves stay instant.                |
 | `[smooth_scroll]`                         | Yes   | No    | No      | Linux and Windows: scrolling is instant.             |
@@ -1286,12 +1286,16 @@ backdrop_color = ""
 ## [virtual_pointer]
 
 A small character rendered at the cursor position when the system cursor is
-hidden.
+hidden — the standalone virtual-pointer overlay.
 
-**Platforms:** macOS only. This section pairs with `hide_cursor`, which has no
-cross-platform equivalent, so it is a no-op on Linux and Windows. The separate
-virtual-pointer indicator drawn inside the recursive-grid overlay works on all
-platforms and is configured under [`[recursive_grid]`](#recursive_grid).
+**Platforms:** macOS only for that standalone overlay. It pairs with
+`hide_cursor`, which has no cross-platform equivalent, so it is a no-op on Linux
+and Windows. The separate virtual-pointer indicator drawn inside the
+recursive-grid overlay works on all platforms, and it takes its character, size,
+family and color from these same `[virtual_pointer.ui]` options — there is no
+pointer option under `[recursive_grid]`. Grid mode draws its in-frame indicator
+from them too; which platforms draw which is in the
+[mode coverage matrix](CROSS_PLATFORM.md#mode-coverage).
 
 ### UI
 


### PR DESCRIPTION
## Description

This PR fixes a wrong pointer in the configuration reference. The
`[virtual_pointer]` section told readers that the virtual-pointer indicator
drawn inside the recursive-grid overlay was configured under `[recursive_grid]`.
There is no pointer option there — that indicator takes its character, size,
family and color from `[virtual_pointer.ui]`, the same keys the standalone
cursor-replacement overlay uses. Anyone who followed the old text went looking
for options that do not exist.

The same section's platform note is now accurate in both directions: the
standalone overlay is still macOS only (it pairs with `hide_cursor`, which has
no cross-platform equivalent), while the indicator drawn inside the
recursive-grid overlay works everywhere. The platform-differences table near the
top of the file described the whole `[virtual_pointer]` section as ignored on
Linux and Windows, which was only ever true of the standalone overlay; that row
now says what actually happens on each platform.

Documentation only — no option was added, renamed, or removed, and no behaviour
changed. Which platforms draw the in-frame indicator in which mode is left to
the mode-coverage matrix in `docs/CROSS_PLATFORM.md`, which owns that fact,
rather than restated here.

## Related Issues

Closes #1338

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no code changed
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no code changed
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no code changed
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, documentation only
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Every claim in the rewritten paragraph was checked against the code rather than
edited as prose: the overlay style resolver builds the pointer's appearance from
the `[virtual_pointer]` config for both the standalone overlay and the in-frame
indicator, and neither the recursive-grid config struct nor its UI struct has a
pointer field.

Also checked for the same wrong pointer and confirmed clean, so they needed no
edit: `configs/default-config.toml` (its comment already links to the
`#virtual_pointer` section), the generated man pages (`just genman` — only the
`hide_cursor` page mentions a virtual pointer, with no section claim),
`docs/CLI.md`, and `docs/CROSS_PLATFORM.md`.

`just ci` was run in full and exited 0 on the current `main`, not the docs-only
fast path.
