### PR TITLE
perf(windows): stop re-resolving the font family on every drawn overlay label

### DIFF
--- a/internal/adapter/overlay/windows/features.go
+++ b/internal/adapter/overlay/windows/features.go
@@ -11,7 +11,6 @@ import (
 	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/recursivegrid"
-	"github.com/y3owk1n/neru/internal/ports"
 )
 
 // Win32/GDI rendering for hints and recursive-grid overlays on Windows.
@@ -122,10 +121,14 @@ func (o *winOverlay) DrawHints(
 			)
 		}
 
+		// The window's own text call rather than drawTextCentered, so the
+		// label lands inside this hint's composite boundary — but the family
+		// arrives resolved here for the same reason drawTextCentered
+		// documents, and this is the surface that redraws on every keystroke.
 		o.window.DrawTextCentered(
 			hint.Label(),
 			bounds,
-			ports.ResolveFont(style.FontFamily()),
+			style.FontFamily(),
 			fontSize,
 			badge.ParseHexARGB(textColor),
 		)
@@ -202,7 +205,7 @@ func (o *winOverlay) DrawRecursiveGrid(
 				o.drawTextCentered(
 					label,
 					cell,
-					ports.ResolveFont(style.FontFamily()),
+					style.FontFamily(),
 					style.LabelFontSize(),
 					style.TextColorARGB(),
 				)
@@ -312,7 +315,7 @@ func (o *winOverlay) drawRecursiveSubKeyPreview(
 	o.drawTextCentered(
 		previewLabel,
 		previewRect,
-		ports.ResolveFont(style.FontFamily()),
+		style.FontFamily(),
 		style.SubKeyPreviewFontSizeF(),
 		style.SubKeyPreviewTextColorARGB(),
 	)

--- a/internal/adapter/overlay/windows/overlay.go
+++ b/internal/adapter/overlay/windows/overlay.go
@@ -14,7 +14,6 @@ import (
 	winplatform "github.com/y3owk1n/neru/internal/adapter/platform/windows"
 	"github.com/y3owk1n/neru/internal/domain"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
-	"github.com/y3owk1n/neru/internal/ports"
 )
 
 // Win32 overlay backend used by the Windows overlay manager for grid rendering.
@@ -342,7 +341,7 @@ func (o *winOverlay) redrawGridWithoutFlush() {
 			o.drawTextCentered(
 				label,
 				cell.Bounds(),
-				ports.ResolveFont(style.FontFamily()),
+				style.FontFamily(),
 				style.LabelFontSize(),
 				text,
 			)
@@ -400,7 +399,7 @@ func (o *winOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Sty
 		o.drawTextCentered(
 			string(key),
 			cell,
-			ports.ResolveFont(style.FontFamily()),
+			style.FontFamily(),
 			style.LabelFontSize()*winSubgridFontScale,
 			style.TextColorARGB(),
 		)
@@ -428,6 +427,20 @@ func (o *winOverlay) drawCellBorder(
 	o.window.StrokeRect(bounds, border, lineWidth)
 }
 
+// drawTextCentered draws text in the family it is given, and resolves
+// nothing. This is the one statement of that rule for this backend; every
+// label it draws is drawn from here.
+//
+// Every family that reaches a label comes off a Style the overlay's
+// StyleResolver built, and that is the one place ports.ResolveFont runs
+// (#1305). Resolving again would be a global RWMutex read and a font-cache
+// lookup per drawn label for an answer that cannot change. The Styles this
+// backend caches to redraw from are the resolver's too: ClearCache zeroes
+// each one together with the grid or hint slice it belongs to, and a zeroed
+// Style paints nothing anyway — its font size and colors are zero as well.
+//
+// The mode and sticky-modifier indicator badges do still resolve, because
+// they read raw configuration rather than a Style.
 func (o *winOverlay) drawTextCentered(
 	text string,
 	bounds image.Rectangle,


### PR DESCRIPTION
## Description

This PR removes redundant font-family resolution from the Windows overlay's drawing code. Every label the Windows backend drew — hint badges, grid cell labels, subgrid keys, recursive-grid labels and their sub-key previews — asked the process-wide font resolver what family to use, once per label, even though the answer had already been settled when the configuration or theme last changed. On the surfaces that redraw while you type, that was a lock and a cache lookup per drawn label on every keystroke.

The overlay now draws with the family it was handed. Nothing renders differently: resolving an already-resolved family returns it unchanged on Windows, so the removed call was answering with its own input. macOS and Linux are untouched, and so are the mode and sticky-modifier indicator badges on every platform — those read raw configuration rather than a resolved style, so they still resolve, which is correct.

## Related Issues

Closes #1342

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability changes; this only removes calls from an existing `windows`-tagged backend
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, no behaviour changes and no new branches; the existing `windows`-tagged unit tests and `just test-windows-compile` cover the touched files
- [x] Documentation updated (if applicable) — N/A, the rule this change brings the backend into line with is already documented in `internal/adapter/overlay/AGENTS.md`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

### The resolved-family invariant, verified

The acceptance criterion is that every `Style` reaching those five draw sites carries a family the `StyleResolver` already resolved. Traced end to end:

1. The platform font resolver is installed at the end of startup phase 1 (`internal/app/startup_phases.go`), before phase 2 constructs the style resolver (`internal/app/wiring.go`) — so the very first resolve already has it, not the no-op passthrough.
2. `StyleResolver.resolve` is the only producer of the three drawn style values, and it builds each via `hints.BuildStyle` / `grid.BuildStyle` / `recursivegrid.BuildStyle`, each of which sets its `fontFamily` field from `ports.ResolveFont`. Config reload (`Apply`) and theme change (`Refresh`) re-run the same path.
3. The three style types keep their fields unexported, so nothing else can populate a family. The one other exported constructor, `recursivegrid.NewStyle`, is documented as being for tests and has no production caller.
4. Every draw reaches the backend from `internal/adapter/overlay/adapter.go`, which reads `ResolvedStyle(a.styles)` at each call — hints, grid, subgrid and recursive grid — and `*StyleResolver` is the only production implementation of that interface.
5. The two styles the Windows backend caches to redraw from — the grid style and the last hint style — are set only by the draw calls above, and cleared to their zero value together with the grid and hint slices they belong to. The hint replay sites refuse to draw when the hint slice is nil. The grid redraw returns early when the cached grid is nil. The one path without a companion guard is the subgrid draw, which reads the cached grid style rather than the resolved one it is handed; it is unreachable with a zeroed style (a subgrid is only opened from an active grid frame, which sets the cache), and a zeroed style paints nothing regardless — its font size, line width and colors are all zero too.

No path was found where an unresolved family reaches a draw site.

### Why nothing renders differently

On Windows, resolution maps generic aliases (and the empty name) to Segoe UI, Cambria or Consolas, and returns any other name trimmed. None of those three concrete families is itself a generic alias, so resolving an already-resolved family is the identity — the removed call could only ever return its input.

### Noticed and deliberately left alone

The subgrid draw ignores the resolved grid style it is passed and uses its own cached copy — and the two Linux backends ignore that same parameter in the same way. It is harmless today and outside this change; worth a separate look at whether the parameter should be used or dropped.

Nothing fails the build if a resolve creeps back into a Windows draw path — the rule stays documented in `internal/adapter/overlay/AGENTS.md` and restated in a comment at the one place every label is drawn from. A guardrail test under `internal/architecture` would be the cheapest way to make it stick, but adding one is more than this issue asked for.

### Verification

`just ci`, `just lint-cross` and `just vet-cross` all pass, plus `just build-windows` and `just test-windows-compile`. There is no screenshot: the change is Windows-only and produces identical pixels by construction.
