### PR TITLE
chore(modes): correct the stale comment on the hidden-cursor flag

### DIFF
--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -176,7 +176,10 @@ type handlerState struct {
 	indicatorStopCh chan struct{}
 	indicatorDoneCh chan struct{}
 
-	// systemCursorHidden tracks whether hide_cursor (or hints virtual pointer) is active.
+	// systemCursorHidden tracks whether the hide_cursor action is holding the
+	// system cursor hidden. It is also what gates the standalone
+	// cursor-following virtual pointer that stands in for it; the in-frame
+	// pointers the grid modes draw are unrelated and no mode sets this.
 	systemCursorHidden bool
 
 	// lastCursorRehideTime records the last time RehideSystemCursor was called


### PR DESCRIPTION
## Description

This PR corrects a stale comment on the mode handler's "system cursor is hidden"
flag. The comment claimed hints mode could turn that state on, which the call
graph does not support: the flag is set in exactly one place, reached from one
exported entry point, whose only caller is the `hide_cursor` action handler.
Nothing in hints mode reaches it.

The comment now says what the flag actually means — the `hide_cursor` action is
holding the system cursor hidden — and that it is what gates the standalone
cursor-following virtual pointer, while the in-frame pointers the grid modes
draw are a separate thing. No behaviour changes.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no files added or retagged
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no imports changed
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changed
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, comment-only change with no behaviour to test
- [x] Documentation updated (if applicable) — N/A, no user-facing documentation describes this internal flag
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The three call-graph hops that make the old wording wrong: the flag is set only
by the unexported hide helper in the modes package; that helper's only caller is
the exported `HideSystemCursor`; and that entry point's only caller is the
`hide_cursor` IPC action. `just lint-cross` was run as well, since the
neighbouring files in that directory are build-tagged.
