### PR TITLE
docs(config): say what an empty font_family actually asks for

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -131,7 +131,7 @@ visible_check_enabled = false
 
 [hints.ui]
 font_size = 10
-font_family = ""                            # Empty = system font
+font_family = ""                            # Empty = the platform's sans, per the aliases above
 border_radius = -1                          # -1 = auto pill
 padding_x = -1                              # -1 = auto based on font size
 padding_y = -1                              # -1 = auto based on font size
@@ -142,7 +142,7 @@ placement = "bottom"                        # top, center, bottom
 
 [hints.search_input_ui]
 font_size = 10
-font_family = ""                            # Empty = system font
+font_family = ""                            # Empty = the platform's sans, per the aliases above
 border_radius = -1                          # -1 = auto pill
 padding_x = -1                              # -1 = auto based on font size
 padding_y = -1                              # -1 = auto based on font size

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -853,7 +853,7 @@ hints.clickable_roles: unknown role "AXButton": use "button"
 | Option               | Type   | Default    | Description                                |
 | -------------------- | ------ | ---------- | ------------------------------------------ |
 | `font_size`          | int    | `10`       | Font size in points                        |
-| `font_family`        | string | `""`       | Font family (empty = system default); [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
+| `font_family`        | string | `""`       | Font family; [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted, empty among them — it asks for the platform's sans family |
 | `border_radius`      | int    | `-1`       | Corner radius (-1 = auto)                  |
 | `padding_x`          | int    | `-1`       | Horizontal padding (-1 = auto)             |
 | `padding_y`          | int    | `-1`       | Vertical padding (-1 = auto)               |
@@ -1058,7 +1058,7 @@ one subgrid cell unlabelled, which is visible on screen in a way a warning is no
 | Option                     | Type   | Default | Description                          |
 | -------------------------- | ------ | ------- | ------------------------------------ |
 | `font_size`                | int    | `10`    | Font size in points                  |
-| `font_family`              | string | `""`    | Font family (empty = system default); [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
+| `font_family`              | string | `""`    | Font family; [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted, empty among them — it asks for the platform's sans family |
 | `border_width`             | int    | `1`     | Border width in pixels               |
 | `background_color`         | color  | derived | Cell background                      |
 | `text_color`               | color  | derived | Label text                           |
@@ -1135,7 +1135,7 @@ layers = [
 | Option                                | Type   | Default | Description                                                                  |
 | ------------------------------------- | ------ | ------- | ---------------------------------------------------------------------------- |
 | `font_size`                           | int    | `10`    | Font size                                                                    |
-| `font_family`                         | string | `""`    | Font family (empty = system default); [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
+| `font_family`                         | string | `""`    | Font family; [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted, empty among them — it asks for the platform's sans family |
 | `line_width`                          | int    | `1`     | Grid line width                                                              |
 | `line_color`                          | color  | derived | Grid line color                                                              |
 | `highlight_color`                     | color  | derived | Selected cell highlight                                                      |
@@ -1241,7 +1241,7 @@ Interactive display picking mode. Shows per-monitor overlay badges labelled with
 | Key                    | Default       | Description                       |
 | ---------------------- | ------------- | --------------------------------- |
 | `font_size`            | `96`          | Badge label font size             |
-| `font_family`          | `""` (system) | Badge label font family; [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
+| `font_family`          | `""` (sans)   | Badge label font family; [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted, empty among them — it asks for the platform's sans family |
 | `subtitle_font_size`   | `18`          | Monitor name subtitle font size   |
 | `subtitle_font_family` | `""` (label's) | Subtitle font family, defaulting to the label's; [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
 | `border_radius`        | `-1` (auto)   | Badge corner radius               |
@@ -1303,7 +1303,7 @@ from them too; which platforms draw which is in the
 | ------------- | ------ | ------- | ---------------------------- |
 | `char`        | string | `"●"`   | Character to display         |
 | `font_size`   | int    | `8`     | Font size in points          |
-| `font_family` | string | `""`    | Font family (empty = system default); [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
+| `font_family` | string | `""`    | Font family; [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted, empty among them — it asks for the platform's sans family |
 | `text_color`  | color  | derived | Character color              |
 
 ```toml
@@ -1411,7 +1411,7 @@ text = "Monitor Select"
 | Option               | Type   | Default | Description                             |
 | -------------------- | ------ | ------- | --------------------------------------- |
 | `font_size`          | int    | `10`    | Font size                               |
-| `font_family`        | string | `""`    | Font family (empty = system default); [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
+| `font_family`        | string | `""`    | Font family; [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted, empty among them — it asks for the platform's sans family |
 | `background_color`   | color  | derived | Background with alpha                   |
 | `text_color`         | color  | derived | Text color                              |
 | `border_color`       | color  | derived | Border color                            |
@@ -1449,7 +1449,7 @@ Tap modifiers inside a mode to make them sticky for subsequent actions.
 | Option               | Type   | Default | Description                            |
 | -------------------- | ------ | ------- | -------------------------------------- |
 | `font_size`          | int    | `10`    | Font size                              |
-| `font_family`        | string | `""`    | Font family (empty = system default); [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted |
+| `font_family`        | string | `""`    | Font family; [generic aliases](CROSS_PLATFORM.md#capability-matrix) accepted, empty among them — it asks for the platform's sans family |
 | `background_color`   | color  | derived | Background with alpha                  |
 | `text_color`         | color  | derived | Text color                             |
 | `border_color`       | color  | derived | Border color                           |


### PR DESCRIPTION
## Description

This PR corrects what the configuration reference says an empty `font_family`
does. Every `font_family` row described leaving the value empty as "the system
default", which is not what happens: the empty string is one of the generic
font aliases, and it asks for the platform's sans family — Helvetica Neue on
macOS, which is specifically not the macOS system UI font, so the page promised
a face you would never get.

Each row now says the empty value is one of the generic aliases and asks for the
platform's sans family, and links to the cross-platform guide, which is the one
place that records what each generic resolves to per platform. The
`[monitor_select]` badge row, which carried the same claim in its shorter
`""` (system) form, is swept in and now reads `""` (sans); its
`subtitle_font_family` neighbour already said `""` (label's), which is accurate
and is left alone. The two matching comments in the shipped default config are
corrected the same way; the generated man pages were checked and never carried
the claim.

Deliberate limitation: the per-platform family names are not repeated in the
configuration reference, so a reader who wants the concrete face still has to
follow the link.

## Related Issues

Closes #1339

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, documentation only
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no Go code changed
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port work
- [x] N/A — This PR does not touch platform-specific code

## Config Surface

No option is added, renamed or removed, and no default changes. What changes is
the description of the existing `font_family` default in every section that has
one — `[hints.ui]`, `[hints.search_input_ui]`, `[grid.ui]`,
`[recursive_grid.ui]`, `[monitor_select.ui]`, `[virtual_pointer.ui]`,
`[mode_indicator.ui]` and `[sticky_modifiers.ui]`. The default is still `""`,
and every existing config keeps behaving exactly as it does today; only the
documented meaning of that default is corrected.

```toml
[hints.ui]
font_family = ""   # asks for the platform's sans family, like `sans` does
```

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, no behaviour changed
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Verified against the resolver rather than the prose: the shared parser groups
the empty name with `sans` and `sans-serif`, and each backend declares its own
sans (Helvetica Neue, DejaVu Sans, Segoe UI). Those names are deliberately not
repeated in the configuration reference — the cross-platform guide owns them, so
restating them here would start drifting the first time a backend changes its
answer. The generated man pages were regenerated and grepped: they never
mentioned font families, so nothing there needed fixing.
