### PR TITLE
chore(config): correct the stale comment on the virtual pointer options

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -563,7 +563,8 @@ type VirtualPointerUI struct {
 	TextColor  Color  `json:"textColor"  toml:"text_color"`
 }
 
-// VirtualPointerConfig defines settings for the hold-mode virtual pointer.
+// VirtualPointerConfig styles the standalone pointer drawn when the system
+// cursor is hidden, plus the in-frame grid and recursive-grid indicators.
 type VirtualPointerConfig struct {
 	UI VirtualPointerUI `json:"ui" toml:"ui"`
 }


### PR DESCRIPTION
## Description

This PR corrects a stale comment on the virtual pointer configuration block.
The comment described the options as settings "for the hold-mode virtual
pointer" — naming a mode that does not exist anywhere in the project's
vocabulary, which is hints, grid, recursive grid, scroll and monitor select.
The phrase traces back to #666 and this was its last live occurrence outside
the changelog.

It was also too narrow: these options style three pointers, not one. The
comment now says so — the standalone pointer drawn when the system cursor is
hidden, plus the in-frame indicators the grid and recursive-grid overlays
draw. That scope is the one #1359 settled and wrote into the configuration
reference. No behaviour changes.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no files added or retagged
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no imports changed
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changed
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, comment-only change with no behaviour to test
- [x] Documentation updated (if applicable) — N/A, the configuration reference already carries this scope from #1359
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The three sinks are visible in one place: the overlay's component
configuration hands the same resolved appearance to the grid overlay, the
recursive-grid overlay and the standalone pointer overlay. The standalone one
is the only one gated on the system cursor being hidden, and it is macOS-only
because it pairs with `hide_cursor`; the two in-frame indicators draw on all
platforms. The comment stays platform-neutral rather than repeating that
split, which the configuration reference already documents. `just lint-cross`
was run as well.
