### PR TITLE
refactor(overlay): drop the Linux recursive-grid draw that nothing calls

### DIFF
--- a/internal/adapter/overlay/linux/overlay_shared_cgo.go
+++ b/internal/adapter/overlay/linux/overlay_shared_cgo.go
@@ -109,7 +109,6 @@ type sharedOverlay struct {
 	animDone         chan struct{}
 	hasLast          bool
 	lastBounds       image.Rectangle
-	lastDims         domain.GridDimensions
 	lastDepth        int
 	lastRects        []image.Rectangle
 	currentAnimRects []image.Rectangle
@@ -220,7 +219,6 @@ func (o *sharedOverlay) drawRecursiveGridWithSubKeyPreview(
 
 	o.hasLast = true
 	o.lastBounds = bounds
-	o.lastDims = dims
 	o.lastDepth = depth
 	o.lastRects = make([]image.Rectangle, len(cellRects))
 	copy(o.lastRects, cellRects)

--- a/internal/adapter/overlay/linux/wayland_cgo.go
+++ b/internal/adapter/overlay/linux/wayland_cgo.go
@@ -154,25 +154,6 @@ func (o *wlrootsOverlay) DrawGrid(g *domainGrid.Grid, input string, style gridco
 	o.drawGrid(g, input, style)
 }
 
-func (o *wlrootsOverlay) DrawRecursiveGrid(
-	bounds image.Rectangle,
-	depth int,
-	keys string,
-	dims domain.GridDimensions,
-	nextKeys string,
-	nextDims domain.GridDimensions,
-	style recursivegridcomponent.Style,
-	virtualPointer recursivegridcomponent.VirtualPointerState,
-	animEnabled bool,
-	animDurationMS int,
-) {
-	o.DrawRecursiveGridWithSubKeyPreview(
-		bounds, depth, keys, dims,
-		nextKeys, nextDims,
-		style, virtualPointer, animEnabled, animDurationMS,
-	)
-}
-
 func (o *wlrootsOverlay) DrawRecursiveGridWithSubKeyPreview(
 	bounds image.Rectangle,
 	depth int,

--- a/internal/adapter/overlay/linux/wayland_nocgo.go
+++ b/internal/adapter/overlay/linux/wayland_nocgo.go
@@ -50,20 +50,6 @@ func (o *wlrootsOverlay) DrawHints(
 ) {
 }
 
-func (o *wlrootsOverlay) DrawRecursiveGrid(
-	image.Rectangle,
-	int,
-	string,
-	domain.GridDimensions,
-	string,
-	domain.GridDimensions,
-	recursivegridcomponent.Style,
-	recursivegridcomponent.VirtualPointerState,
-	bool,
-	int,
-) {
-}
-
 func (o *wlrootsOverlay) DrawRecursiveGridWithSubKeyPreview(
 	image.Rectangle,
 	int,

--- a/internal/adapter/overlay/linux/x11_cgo.go
+++ b/internal/adapter/overlay/linux/x11_cgo.go
@@ -147,25 +147,6 @@ func (o *x11Overlay) DrawGrid(g *domainGrid.Grid, input string, style gridcompon
 	o.drawGrid(g, input, style)
 }
 
-func (o *x11Overlay) DrawRecursiveGrid(
-	bounds image.Rectangle,
-	depth int,
-	keys string,
-	dims domain.GridDimensions,
-	nextKeys string,
-	nextDims domain.GridDimensions,
-	style recursivegridcomponent.Style,
-	virtualPointer recursivegridcomponent.VirtualPointerState,
-	animEnabled bool,
-	animDurationMS int,
-) {
-	o.DrawRecursiveGridWithSubKeyPreview(
-		bounds, depth, keys, dims,
-		nextKeys, nextDims,
-		style, virtualPointer, animEnabled, animDurationMS,
-	)
-}
-
 func (o *x11Overlay) DrawRecursiveGridWithSubKeyPreview(
 	bounds image.Rectangle,
 	depth int,

--- a/internal/adapter/overlay/linux/x11_nocgo.go
+++ b/internal/adapter/overlay/linux/x11_nocgo.go
@@ -44,20 +44,6 @@ func (o *x11Overlay) DrawGrid(*domainGrid.Grid, string, gridcomponent.Style) {}
 func (o *x11Overlay) DrawHints([]*hintscomponent.Hint, hintscomponent.StyleMode, hintBadgeOffset) {
 }
 
-func (o *x11Overlay) DrawRecursiveGrid(
-	image.Rectangle,
-	int,
-	string,
-	domain.GridDimensions,
-	string,
-	domain.GridDimensions,
-	recursivegridcomponent.Style,
-	recursivegridcomponent.VirtualPointerState,
-	bool,
-	int,
-) {
-}
-
 func (o *x11Overlay) DrawRecursiveGridWithSubKeyPreview(
 	image.Rectangle,
 	int,


### PR DESCRIPTION
## Description

This PR removes dead code from the Linux overlay backend. Both Linux surfaces declared a recursive-grid draw, on both build configurations, that no code path could reach: the overlay manager settles the animation flag and duration itself before it draws, so it always takes the sub-key-preview variant — which is now the only recursive-grid entry point on the backend.

The shared Linux surface also kept a record of the last drawn cell counts that nothing ever read. That is gone too; the rest of the last-draw state is still what the zoom animation animates from.

Nothing changes on screen, on any backend. This is a deletion only — 68 lines, no additions.

## Related Issues

Closes #1344

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — unchanged; the edited files keep their existing `linux && cgo` / `linux && !cgo` tags
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no capability was added or removed; the no-backend Linux manager still reports `CodeNotSupported` for a recursive-grid draw and the existing contract test still pins it
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, nothing is added and no behaviour changed; the deleted code had no test of its own
- [x] Documentation updated (if applicable) — N/A, no documented capability or status changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Verified before deleting: no interface in the package declared the removed method (the surfaces are held as concrete pointers and never boxed), and the contract test that pins the no-backend `CodeNotSupported` behaviour exercises the manager, not the surfaces — so neither an interface nor a test needed changing to make this compile, which was the issue's own tripwire for a wrong analysis.

One drift worth noting against the issue text: it names two separate fields holding the last drawn column and row counts. #1343 has since merged those into a single value, still written and never read, and that single field is what this PR removes — so the acceptance criterion reads true, just against a field that has been renamed since the issue was filed.

Gates run green in this worktree: `just ci`, `just lint-cross`, `just test-linux` and `just test-linux-nocgo`, covering both the `linux && cgo` and `linux && !cgo` builds.
