### PR TITLE
refactor(recursive-grid): name the selection callbacks, don't order them

### DIFF
--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -184,20 +184,20 @@ func (h *handlerState) initializeRecursiveGridManager(screenBounds image.Rectang
 		},
 		depthLayouts,
 		depthKeys,
-		// Update callback
-		func(center image.Point) {
-			absoluteCenter := geometry.ConvertToAbsoluteCoordinates(center, h.screenBounds)
-			if h.recursiveGrid != nil && h.recursiveGrid.Context != nil {
-				h.recursiveGrid.Context.SetSelectionPoint(absoluteCenter)
-			}
+		recursivegrid.SelectionCallbacks{
+			OnUpdate: func(center image.Point) {
+				absoluteCenter := geometry.ConvertToAbsoluteCoordinates(center, h.screenBounds)
+				if h.recursiveGrid != nil && h.recursiveGrid.Context != nil {
+					h.recursiveGrid.Context.SetSelectionPoint(absoluteCenter)
+				}
 
-			h.updateRecursiveGridOverlay()
-		},
-		// Complete callback
-		func(point image.Point) {
-			h.logger.Debug("Recursive-grid selection complete",
-				zap.Int("x", point.X),
-				zap.Int("y", point.Y))
+				h.updateRecursiveGridOverlay()
+			},
+			OnComplete: func(point image.Point) {
+				h.logger.Debug("Recursive-grid selection complete",
+					zap.Int("x", point.X),
+					zap.Int("y", point.Y))
+			},
 		},
 		h.logger,
 	)

--- a/internal/domain/recursivegrid/manager.go
+++ b/internal/domain/recursivegrid/manager.go
@@ -15,12 +15,11 @@ import (
 type Manager struct {
 	domain.BaseManager
 
-	grid       *RecursiveGrid
-	keys       string                // Default key mapping (e.g., "rtyfghvbn")
-	depthKeys  map[int]string        // Per-depth key overrides (sparse)
-	dims       domain.GridDimensions // Default shape at depths with no override
-	onUpdate   func(image.Point)     // Callback for overlay updates
-	onComplete func(image.Point)     // Callback when selection is complete
+	grid      *RecursiveGrid
+	keys      string                // Default key mapping (e.g., "rtyfghvbn")
+	depthKeys map[int]string        // Per-depth key overrides (sparse)
+	dims      domain.GridDimensions // Default shape at depths with no override
+	callbacks SelectionCallbacks    // What the selection tells its owner
 }
 
 // NewManager creates a recursive-grid manager with default dimensions (3×3)
@@ -28,8 +27,7 @@ type Manager struct {
 func NewManager(
 	screenBounds image.Rectangle,
 	keys string,
-	onUpdate func(image.Point),
-	onComplete func(image.Point),
+	callbacks SelectionCallbacks,
 	logger *zap.Logger,
 ) *Manager {
 	return NewManagerWithLayers(
@@ -40,8 +38,7 @@ func NewManager(
 		10, //nolint:mnd
 		DefaultDimensions(),
 		nil, nil,
-		onUpdate,
-		onComplete,
+		callbacks,
 		logger,
 	)
 }
@@ -51,7 +48,8 @@ func NewManager(
 // to use default dimensions at all depths.
 //
 // dims arrives as one value rather than a column count beside a row count so
-// that a caller cannot hand over the two in the wrong order (#1313).
+// that a caller cannot hand over the two in the wrong order (#1313), and
+// callbacks arrives as one value for the same reason (#1346).
 func NewManagerWithLayers(
 	screenBounds image.Rectangle,
 	keys string,
@@ -59,8 +57,7 @@ func NewManagerWithLayers(
 	dims domain.GridDimensions,
 	depthLayouts map[int]DepthLayout,
 	depthKeys map[int]string,
-	onUpdate func(image.Point),
-	onComplete func(image.Point),
+	callbacks SelectionCallbacks,
 	logger *zap.Logger,
 ) *Manager {
 	// Use default grid dimensions if either is invalid (< 1) or if the grid
@@ -154,11 +151,10 @@ func NewManagerWithLayers(
 			dims,
 			depthLayouts,
 		),
-		keys:       strings.ToLower(keys),
-		depthKeys:  normalizedDepthKeys,
-		dims:       dims,
-		onUpdate:   onUpdate,
-		onComplete: onComplete,
+		keys:      strings.ToLower(keys),
+		depthKeys: normalizedDepthKeys,
+		dims:      dims,
+		callbacks: callbacks,
 	}
 }
 
@@ -191,16 +187,16 @@ func (m *Manager) HandleInput(key string) (image.Point, bool) {
 	// If complete, call the completion callback and skip the overlay update
 	// because SelectCell returns early without changing bounds/depth.
 	if isComplete {
-		if m.onComplete != nil {
-			m.onComplete(center)
+		if m.callbacks.OnComplete != nil {
+			m.callbacks.OnComplete(center)
 		}
 
 		return center, isComplete
 	}
 
 	// Trigger update for visual feedback
-	if m.onUpdate != nil {
-		m.onUpdate(center)
+	if m.callbacks.OnUpdate != nil {
+		m.callbacks.OnUpdate(center)
 	}
 
 	return center, isComplete
@@ -222,8 +218,8 @@ func (m *Manager) MoveDirection(dir domain.Direction, count int) (image.Point, b
 		return center, false
 	}
 
-	if m.onUpdate != nil {
-		m.onUpdate(center)
+	if m.callbacks.OnUpdate != nil {
+		m.callbacks.OnUpdate(center)
 	}
 
 	return center, true
@@ -326,15 +322,15 @@ func (m *Manager) ZoomToPoint(point image.Point, targetDepth int) (image.Point, 
 	m.SetCurrentInput("")
 
 	if isComplete {
-		if m.onComplete != nil {
-			m.onComplete(center)
+		if m.callbacks.OnComplete != nil {
+			m.callbacks.OnComplete(center)
 		}
 
 		return center, true
 	}
 
-	if m.onUpdate != nil {
-		m.onUpdate(center)
+	if m.callbacks.OnUpdate != nil {
+		m.callbacks.OnUpdate(center)
 	}
 
 	return center, false

--- a/internal/domain/recursivegrid/manager_test.go
+++ b/internal/domain/recursivegrid/manager_test.go
@@ -18,8 +18,10 @@ func TestNewManager(t *testing.T) {
 	manager := recursivegrid.NewManager(
 		bounds,
 		"rtyfghvbn",
-		func(image.Point) {},
-		func(point image.Point) {},
+		recursivegrid.SelectionCallbacks{
+			OnUpdate:   func(image.Point) {},
+			OnComplete: func(image.Point) {},
+		},
 		logger,
 	)
 
@@ -34,8 +36,7 @@ func TestNewManagerDefaultKeys(t *testing.T) {
 	manager := recursivegrid.NewManager(
 		bounds,
 		"", // Empty keys - should use default
-		nil,
-		nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 
@@ -60,8 +61,9 @@ func TestManagerHandleInputCellSelection(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		nil, nil,
-		func(image.Point) { updateCalled = true },
-		nil,
+		recursivegrid.SelectionCallbacks{
+			OnUpdate: func(image.Point) { updateCalled = true },
+		},
 		logger,
 	)
 
@@ -86,8 +88,7 @@ func TestManagerHandleInputEscapeKey(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		nil, nil,
-		nil,
-		nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 
@@ -109,8 +110,7 @@ func TestManagerReset(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		nil, nil,
-		nil,
-		nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 
@@ -139,8 +139,7 @@ func TestManagerHandleInputBacktrack(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		nil, nil,
-		nil,
-		nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 
@@ -171,8 +170,9 @@ func TestManagerHandleInputUnmappedKey(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		nil, nil,
-		func(image.Point) { updateCalled = true },
-		nil,
+		recursivegrid.SelectionCallbacks{
+			OnUpdate: func(image.Point) { updateCalled = true },
+		},
 		logger,
 	)
 
@@ -199,10 +199,11 @@ func TestManagerHandleInputCompletion(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		nil, nil,
-		nil,
-		func(p image.Point) {
-			completeCalled = true
-			completePoint = p
+		recursivegrid.SelectionCallbacks{
+			OnComplete: func(p image.Point) {
+				completeCalled = true
+				completePoint = p
+			},
 		},
 		logger,
 	)
@@ -245,8 +246,10 @@ func TestManagerHandleInputMaxDepth(t *testing.T) {
 		2, // maxDepth
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		nil, nil,
-		func(image.Point) {},
-		func(point image.Point) { completeCalled = true },
+		recursivegrid.SelectionCallbacks{
+			OnUpdate:   func(image.Point) {},
+			OnComplete: func(image.Point) { completeCalled = true },
+		},
 		logger,
 	)
 
@@ -287,8 +290,9 @@ func TestManagerWithLayers_NonSquare3x2(t *testing.T) {
 		10,       // maxDepth
 		domain.GridDimensions{Rows: 2, Cols: 3},
 		nil, nil,
-		func(image.Point) { updateCalled = true },
-		nil,
+		recursivegrid.SelectionCallbacks{
+			OnUpdate: func(image.Point) { updateCalled = true },
+		},
 		logger,
 	)
 	assert.Equal(t, 3, manager.GridCols())
@@ -316,8 +320,7 @@ func TestManagerWithLayers_InvalidColsOnly_FallsBack(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 3, Cols: 0}, // invalid column count
 		nil, nil,
-		nil,
-		nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 	// After fallback, should use default dimensions with default keys
@@ -337,8 +340,7 @@ func TestManagerWithLayers_SingleColumnValid(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 3, Cols: 1},
 		nil, nil,
-		nil,
-		nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 
@@ -360,8 +362,7 @@ func TestManagerWithLayers_1x1_FallsBack(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 1, Cols: 1},
 		nil, nil,
-		nil,
-		nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 	assert.Equal(t, recursivegrid.DefaultGridCols, manager.GridCols())
@@ -383,8 +384,7 @@ func TestManagerWithLayers_InvalidRowsOnly_FallsBack(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 0, Cols: 3}, // invalid row count
 		nil, nil,
-		nil,
-		nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 	assert.Equal(t, recursivegrid.DefaultGridCols, manager.GridCols())
@@ -399,8 +399,7 @@ func TestHandleInput_InvalidKeyLength_FallsBackToDefault(t *testing.T) {
 	manager := recursivegrid.NewManager(
 		screenBounds,
 		keys,
-		nil,
-		nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 	assert.Equal(
@@ -429,7 +428,7 @@ func TestNewManagerWithLayers_MismatchedDepthKeys_DropsOrphan(t *testing.T) {
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		depthLayouts,
 		depthKeys,
-		nil, nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 	// At depth 0, should use default keys since the orphan override was dropped
@@ -453,7 +452,7 @@ func TestNewManagerWithLayers_MismatchedDepthLayouts_DropsOrphan(t *testing.T) {
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		depthLayouts,
 		depthKeys,
-		nil, nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 	// At depth 0, should use defaults since the orphan layout override was dropped
@@ -479,7 +478,7 @@ func TestNewManagerWithLayers_KeyCountMismatch_DropsOverride(t *testing.T) {
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		depthLayouts,
 		depthKeys,
-		nil, nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 	// At depth 0, should use defaults since the mismatched override was dropped
@@ -504,7 +503,7 @@ func TestNewManagerWithLayers_ConsistentOverride_Works(t *testing.T) {
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		depthLayouts,
 		depthKeys,
-		nil, nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 	// At depth 0, should use the override
@@ -531,8 +530,7 @@ func TestManagerHandleInput_KeyToCellLiteralSpaceKey(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		nil, nil,
-		func(image.Point) {},
-		nil,
+		recursivegrid.SelectionCallbacks{OnUpdate: func(image.Point) {}},
 		logger,
 	)
 	// Pressing the literal space should map to cell index 2 (bottom-left).
@@ -555,8 +553,7 @@ func TestManagerHandleInput_KeyToCellNormalizesFullwidthChars(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		nil, nil,
-		func(image.Point) {},
-		nil,
+		recursivegrid.SelectionCallbacks{OnUpdate: func(image.Point) {}},
 		logger,
 	)
 	// Fullwidth 'u' (U+FF55) should normalize to halfwidth 'u' and match cell 0.
@@ -580,8 +577,7 @@ func TestHandleInput_ValidMultibyteKeys(t *testing.T) {
 		10,
 		domain.GridDimensions{Rows: 2, Cols: 2},
 		nil, nil,
-		nil,
-		nil,
+		recursivegrid.SelectionCallbacks{},
 		logger,
 	)
 	assert.Equal(

--- a/internal/domain/recursivegrid/move_test.go
+++ b/internal/domain/recursivegrid/move_test.go
@@ -281,8 +281,10 @@ func TestManager_MoveDirection_NotifiesOnlyWhenSomethingMoved(t *testing.T) {
 		"rtyfghvbn",
 		1, 1, 10, domain.GridDimensions{Rows: 3, Cols: 3},
 		nil, nil,
-		func(image.Point) { updates++ },
-		func(image.Point) {},
+		recursivegrid.SelectionCallbacks{
+			OnUpdate:   func(image.Point) { updates++ },
+			OnComplete: func(image.Point) {},
+		},
 		zap.NewNop(),
 	)
 

--- a/internal/domain/recursivegrid/selection_callbacks.go
+++ b/internal/domain/recursivegrid/selection_callbacks.go
@@ -1,0 +1,25 @@
+package recursivegrid
+
+import "image"
+
+// SelectionCallbacks is what a recursive-grid selection tells its owner: the
+// selection moved, and the selection resolved. Both carry the point the
+// selection now names, and either may be nil when the owner has nothing to do
+// with that event.
+//
+// They travel together as one value rather than as two adjacent func(image.Point)
+// parameters because they are identically typed and semantically opposite, so a
+// transposed pair compiled and failed nothing (#1346) — the same hazard the row
+// and column counts in the same constructor had before GridDimensions closed it
+// (#1313). Carrying them together means there is no longer a pair to put in the
+// wrong order, and each callback is named at the point it is written down.
+type SelectionCallbacks struct {
+	// OnUpdate fires every time the selection is refined without resolving:
+	// a cell chosen at a depth that can still divide, or a directional move
+	// within the current depth. It is the overlay's cue to redraw.
+	OnUpdate func(image.Point)
+	// OnComplete fires once, when the selection resolves — the keystroke at
+	// the final depth, or a zoom that runs out of divisions. Nothing is
+	// redrawn afterwards; the point it carries is the answer.
+	OnComplete func(image.Point)
+}

--- a/internal/domain/recursivegrid/selection_callbacks_test.go
+++ b/internal/domain/recursivegrid/selection_callbacks_test.go
@@ -1,0 +1,114 @@
+package recursivegrid_test
+
+import (
+	"image"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/recursivegrid"
+)
+
+// The two callback names a selectionEvent can carry.
+const (
+	updateCallback   = "update"
+	completeCallback = "complete"
+)
+
+// selectionEvent is one callback firing, recorded with the callback that fired
+// it so that a transposition shows up as the wrong name rather than as a
+// missing call.
+type selectionEvent struct {
+	callback string
+	point    image.Point
+}
+
+// recordSelections returns callbacks that append to log in the order they fire.
+func recordSelections(log *[]selectionEvent) recursivegrid.SelectionCallbacks {
+	return recursivegrid.SelectionCallbacks{
+		OnUpdate: func(point image.Point) {
+			*log = append(*log, selectionEvent{callback: updateCallback, point: point})
+		},
+		OnComplete: func(point image.Point) {
+			*log = append(*log, selectionEvent{callback: completeCallback, point: point})
+		},
+	}
+}
+
+// TestManager_HandleInput_SelectionCallbacksAreNotInterchangeable pins which of
+// the two selection callbacks fires for which event. Both take a point and
+// neither returns anything, so wiring the update handler where the complete
+// handler belongs still compiles once they are inside a struct; what separates
+// them is *when* they fire. This records both in one ordered log so a
+// transposition is a failure rather than a silently different overlay.
+func TestManager_HandleInput_SelectionCallbacksAreNotInterchangeable(t *testing.T) {
+	var log []selectionEvent
+
+	manager := recursivegrid.NewManagerWithLayers(
+		image.Rect(0, 0, 100, 100),
+		"uijk",
+		50, 50, 10, // min size 50 leaves exactly one refinement before the resolve
+		domain.GridDimensions{Rows: 2, Cols: 2},
+		nil, nil,
+		recordSelections(&log),
+		zap.NewNop(),
+	)
+
+	// A refinement: the 100x100 root narrows to its top-left 50x50 cell.
+	_, completed := manager.HandleInput("u")
+	require.False(t, completed, "the first selection refines rather than resolves")
+
+	// That 50x50 cell cannot divide (halving it falls under the 50px minimum),
+	// so the next keystroke resolves the selection.
+	_, completed = manager.HandleInput("k")
+	require.True(t, completed, "the selection at the final depth resolves")
+
+	assert.Equal(t, []selectionEvent{
+		{callback: updateCallback, point: image.Point{X: 25, Y: 25}},
+		{callback: completeCallback, point: image.Point{X: 38, Y: 38}},
+	}, log, "a refinement is an update and a resolution is a completion; neither is the other")
+}
+
+// TestManager_ZoomToPoint_SelectionCallbacksAreNotInterchangeable pins the same
+// distinction on the manager's other caller of the pair, which chooses between
+// the two on the same isComplete answer.
+func TestManager_ZoomToPoint_SelectionCallbacksAreNotInterchangeable(t *testing.T) {
+	newManager := func(log *[]selectionEvent) *recursivegrid.Manager {
+		return recursivegrid.NewManagerWithLayers(
+			image.Rect(0, 0, 100, 100),
+			"uijk",
+			50, 50, 10,
+			domain.GridDimensions{Rows: 2, Cols: 2},
+			nil, nil,
+			recordSelections(log),
+			zap.NewNop(),
+		)
+	}
+
+	t.Run("stopping short of the target depth is an update", func(t *testing.T) {
+		var log []selectionEvent
+
+		_, completed := newManager(&log).ZoomToPoint(image.Point{X: 10, Y: 10}, 1)
+
+		require.False(t, completed, "depth 1 is reachable, so the zoom has not resolved")
+		assert.Equal(t, []selectionEvent{
+			{callback: updateCallback, point: image.Point{X: 25, Y: 25}},
+		}, log)
+	})
+
+	t.Run("running out of divisions is a completion", func(t *testing.T) {
+		var log []selectionEvent
+
+		// Depth 2 is unreachable: the 50x50 cell at depth 1 cannot divide, so
+		// the zoom stops there and resolves.
+		_, completed := newManager(&log).ZoomToPoint(image.Point{X: 10, Y: 10}, 2)
+
+		require.True(t, completed, "the zoom ran out of divisions before the target depth")
+		assert.Equal(t, []selectionEvent{
+			{callback: completeCallback, point: image.Point{X: 25, Y: 25}},
+		}, log)
+	})
+}


### PR DESCRIPTION
## Description

This PR reworks how the recursive grid is told about a selection. It was built
from two handlers handed over side by side — one for "the selection moved", one
for "the selection resolved" — which had the same signature and opposite
meanings, so wiring them the wrong way round compiled clean and nothing caught
it. The two now travel as a single value whose fields name what each handler is
for, so every place that wires one says which one it is wiring.

There is no behaviour change: the grid refines, redraws and resolves exactly as
it did, and every existing test that pins that behaviour still passes unchanged.
A new pair of tests records which handler fires for a refinement and which for a
resolution, so a future transposition fails the suite instead of shipping as
visibly broken selection.

The deliberate limitation is that this makes the mistake loud rather than
impossible — see Additional Context.

## Related Issues

Closes #1346

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no build-tagged files touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no new imports
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changed
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, nothing user-facing changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Which shape, and why.** The issue offered a two-field struct or two distinct
named function types. This takes the struct, because it is the shape #1313
already established one parameter earlier in the same constructor when the row
and column counts became one value: same problem, same answer, one convention
rather than two. It also reads better at the many call sites that only care
about one of the two handlers — most of the tests wire an update handler and
nothing else, which is a single named field rather than a positional `nil`.

**Honest about the guarantee.** Both fields still have the same function type,
so this makes a swap *caught*, not *impossible*. A transposition written out
with field names still compiles; what it no longer does is hide, because the
name and the body sit next to each other. A positional swap is caught by `go
vet`'s `composites` check, which rejects unkeyed literals of imported struct
types — and every call site is outside the package. Named function types would
have closed the keyed case too, at the cost of a second convention for the same
hazard; that trade seemed the wrong way round while the row/column conversion is
the precedent. The issue notes this is the smaller half of the #1313 hazard
anyway: the two handlers differ in *when* they fire, so a transposition shows up
as visibly broken selection rather than as a silent geometry error.

**Coverage.** All 26 call sites are migrated — the one production site, the
delegating convenience constructor, and 24 in tests. Each kept exactly which
handler it had wired, including the sites that deliberately pass a no-op rather
than nothing.

**Reviews run.** `deadlock-reviewer` over the diff (no locking-contract change:
the handlers still fire synchronously from the same locked contexts, and the
update handler still reaches the overlay under the handler lock, which is the
documented grid-surface case). `just lint-cross` is green for linux/amd64 and
windows/amd64 as well as the local macOS `just lint`.
