### PR TITLE
refactor(recursive-grid): give the unusable-dimension fallback one implementation

### DIFF
--- a/internal/adapter/overlay/render/recursivegrid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/recursivegrid/overlay_darwin.go
@@ -288,18 +288,18 @@ func (o *Overlay) DrawRecursiveGrid(
 		)
 	}
 
-	// Use the provided dimensions and calculate key count
-	keyCount := dims.CellCount()
-
-	// Validate grid dimensions (must be at least 1, and total cells >= 2)
-	if dims.Cols < recursivegrid.MinGridDimension ||
-		dims.Rows < recursivegrid.MinGridDimension ||
-		dims.CellCount() < 2 {
-		// Fall back to the default shape if invalid or degenerate (1×1)
-		dims = recursivegrid.DefaultDimensions()
-		keyCount = dims.CellCount()
+	// A shape that cannot narrow anything is replaced with the default one;
+	// recursivegrid.UsableDimensions owns that rule for the manager and for
+	// this draw alike. The key mapping goes with it: the one handed over was
+	// cut for the shape being replaced, so it is the wrong length for the
+	// fallback and would leave cells unlabelled.
+	usableDims, asGiven := recursivegrid.UsableDimensions(dims)
+	if !asGiven {
 		keys = recursivegrid.DefaultKeys
 	}
+
+	dims = usableDims
+	keyCount := dims.CellCount()
 
 	// Validate keys length matches grid dimensions
 	keyRunes := []rune(keys)

--- a/internal/app/modes/recursive_grid_test.go
+++ b/internal/app/modes/recursive_grid_test.go
@@ -147,6 +147,97 @@ func TestRecursiveGridFrame_NonSquareGridKeepsRowsAndColumnsApart(t *testing.T) 
 	}
 }
 
+// TestRecursiveGridFrame_DegenerateShapeReachesEveryBackendAsTheDefault is what
+// makes "every backend draws the same thing" true for a shape that cannot
+// narrow anything (#1345).
+//
+// Only macOS corrects such a shape in its draw. Linux and Windows guard the
+// division and nothing more: a side of zero or less stops their draw entirely,
+// and a 1x1 divides into one cell over the whole region that no key can narrow.
+// That difference is unreachable, and this is where it is held unreachable: the
+// manager replaces an unusable shape before anything is drawn, so the frame
+// every backend is handed already carries a usable one and the key mapping that
+// fits it. If the fallback ever moved out of the domain and into the macOS draw
+// alone, this fails rather than the two other platforms quietly drawing
+// something a person cannot navigate.
+func TestRecursiveGridFrame_DegenerateShapeReachesEveryBackendAsTheDefault(t *testing.T) {
+	testCases := []struct {
+		name string
+		cols int
+		rows int
+		keys string
+	}{
+		{name: "one cell cannot narrow", cols: 1, rows: 1, keys: "u"},
+		{name: "no columns", cols: 0, rows: 3, keys: "rtyfghvbn"},
+		{name: "no rows", cols: 3, rows: 0, keys: "rtyfghvbn"},
+		{name: "nothing configured at all", cols: 0, rows: 0, keys: ""},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			overlay := &portmocks.MockOverlayPort{}
+
+			handler := newHandlerWithState(handlerState{
+				config: &config.Config{
+					RecursiveGrid: config.RecursiveGridConfig{
+						Enabled:       true,
+						GridCols:      testCase.cols,
+						GridRows:      testCase.rows,
+						Keys:          testCase.keys,
+						MinSizeWidth:  5,
+						MinSizeHeight: 5,
+						MaxDepth:      5,
+						Hotkeys:       map[string]config.StringOrStringArray{},
+						UI:            config.RecursiveGridUI{},
+					},
+				},
+				overlayPort: overlay,
+				recursiveGrid: &components.RecursiveGridComponent{
+					Context: &componentrecursivegrid.Context{},
+				},
+				screenBounds: image.Rect(0, 0, 300, 300),
+			})
+
+			handler.initializeRecursiveGridManager(image.Rect(0, 0, 300, 300))
+			handler.updateRecursiveGridOverlay()
+
+			frames := overlay.Frames()
+			if len(frames) != 1 {
+				t.Fatalf("overlay received %d frame(s), want 1", len(frames))
+			}
+
+			frame, isRecursiveGrid := frames[0].(ports.RecursiveGridFrame)
+			if !isRecursiveGrid {
+				t.Fatalf("overlay received a %T, want ports.RecursiveGridFrame", frames[0])
+			}
+
+			if got, want := frame.Layout.Dimensions, recursivegrid.DefaultDimensions(); got != want {
+				t.Errorf("Layout.Dimensions = %+v, want %+v", got, want)
+			}
+
+			if got, want := frame.Layout.Keys, recursivegrid.DefaultKeys; got != want {
+				t.Errorf("Layout.Keys = %q, want %q", got, want)
+			}
+
+			// The division is what a backend actually paints, and every
+			// backend runs this same one over the frame's dimensions. A
+			// 300x300 screen in the default 3x3 gives nine 100x100 cells.
+			cells := recursivegrid.ComputeGridCells(frame.Bounds, frame.Layout.Dimensions)
+			if len(cells) != 9 {
+				t.Fatalf("the frame's dimensions divide into %d cells, want 9", len(cells))
+			}
+
+			if got, want := cells[0], image.Rect(0, 0, 100, 100); got != want {
+				t.Errorf("first drawn cell = %v, want %v", got, want)
+			}
+
+			if got, want := cells[8], image.Rect(200, 200, 300, 300); got != want {
+				t.Errorf("last drawn cell = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func TestResetCurrentMode_RecursiveGridPreservesHoldMode(t *testing.T) {
 	moveCount := 0
 

--- a/internal/cli/recursive_grid.go
+++ b/internal/cli/recursive_grid.go
@@ -9,12 +9,13 @@ var RecursiveGridCmd = BuildModeCommand(ModeConfig{
 	Short:   "Activate recursive-grid navigation mode",
 	Long: `Recursive-grid mode provides recursive cell-based navigation.
 
-The screen is divided into NxN cells (default 2x2, keys: u,i,j,k).
+The screen is divided into a grid of cells (default 3x3, keys: r,t,y,f,g,h,v,b,n).
 Each selection recursively narrows the active area until minimum size is reached.
 
-Key mappings (warpd convention):
-  u = upper-left cell    i = upper-right cell
-  j = lower-left cell    k = lower-right cell
+Key mappings (default 3x3 grid, left to right then top to bottom):
+  r = upper-left    t = upper-middle    y = upper-right
+  f = middle-left   g = center          h = middle-right
+  v = lower-left    b = lower-middle    n = lower-right
 
 Navigation:
   - Press cell key to narrow selection

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -536,10 +536,11 @@ type RecursiveGridConfig struct {
 	Enabled bool `json:"enabled" toml:"enabled"`
 	// Animation configures native depth transition animations for recursive-grid on supported platforms.
 	Animation RecursiveGridAnimationConfig `json:"animation" toml:"animation"`
-	// Grid dimensions: columns and rows (default: 2x2)
+	// Grid dimensions: columns and rows (default: 3x3)
 	GridCols int `json:"gridCols" toml:"grid_cols"`
 	GridRows int `json:"gridRows" toml:"grid_rows"`
-	// Key bindings (warpd convention for 2x2: u=TL, i=TR, j=BL, k=BR)
+	// Key bindings, one per cell, left to right then top to bottom
+	// (default: rtyfghvbn for the 3x3 grid above)
 	Keys string          `json:"keys" toml:"keys"`
 	UI   RecursiveGridUI `json:"ui"   toml:"ui"`
 	// Behavior

--- a/internal/domain/recursivegrid/manager.go
+++ b/internal/domain/recursivegrid/manager.go
@@ -60,15 +60,17 @@ func NewManagerWithLayers(
 	callbacks SelectionCallbacks,
 	logger *zap.Logger,
 ) *Manager {
-	// Use default grid dimensions if either is invalid (< 1) or if the grid
-	// is degenerate (1×1 cannot subdivide). Reset both to default for consistency.
-	if dims.Cols < MinGridDimension || dims.Rows < MinGridDimension ||
-		dims.CellCount() < 2 {
+	// A shape that cannot narrow anything is replaced with the default one.
+	// UsableDimensions owns that rule; what belongs here is naming the values
+	// it rejected, which it cannot report once it has replaced them.
+	usableDims, asGiven := UsableDimensions(dims)
+	if !asGiven {
 		logger.Warn("Invalid grid dimensions, using default",
 			zap.Int("provided_cols", dims.Cols),
 			zap.Int("provided_rows", dims.Rows))
-		dims = DefaultDimensions()
 	}
+
+	dims = usableDims
 
 	// Use default keys if not provided
 	if strings.TrimSpace(keys) == "" {

--- a/internal/domain/recursivegrid/recursive_grid.go
+++ b/internal/domain/recursivegrid/recursive_grid.go
@@ -7,8 +7,6 @@ import (
 )
 
 const (
-	// MinGridDimension is the minimum allowed value for grid columns or rows.
-	MinGridDimension = 1
 	// DefaultGridCols is the default recursive-grid column count.
 	DefaultGridCols = 3
 	// DefaultGridRows is the default recursive-grid row count.

--- a/internal/domain/recursivegrid/usable_dimensions.go
+++ b/internal/domain/recursivegrid/usable_dimensions.go
@@ -1,0 +1,58 @@
+package recursivegrid
+
+import "github.com/y3owk1n/neru/internal/domain"
+
+// The two limits a recursive-grid shape has to clear. They live here because
+// UsableDimensions is the only thing that applies them.
+const (
+	// MinGridDimension is the minimum allowed value for grid columns or rows.
+	MinGridDimension = 1
+	// MinUsableCellCount is the smallest number of cells a recursive grid can
+	// narrow with. One cell is a selection that selects the whole region, so
+	// the grid would never bottom out.
+	MinUsableCellCount = 2
+)
+
+// UsableDimensions answers the shape a recursive grid can actually be drawn and
+// navigated with, given the shape it was asked for. It returns the shape to use
+// and whether that is the one it was given: a pair with fewer than
+// MinGridDimension columns or rows, or fewer than MinUsableCellCount cells,
+// cannot narrow anything, so DefaultDimensions() comes back instead and the
+// second return is false.
+//
+// The whole pair is replaced rather than the offending half, because half a
+// configured shape is a shape nobody chose and no key mapping is the right
+// length for.
+//
+// This is the one implementation of the *fallback* (ADR 0007). It lived here
+// and in the macOS draw, and the two copies had drifted: only one of them
+// logged, only one of them reset the key mapping alongside the shape, and the
+// macOS copy's comment still named a default the constants had moved off
+// (#1345). Callers keep what is genuinely theirs — the manager warns with the
+// values it rejected, and the macOS draw reaches for DefaultKeys when this
+// reports a replacement, because a key mapping cut for the configured shape
+// does not fit the fallback.
+//
+// Two weaker tests of the same limits are left standing on purpose, and naming
+// them is the honest form of that claim:
+//
+//   - config.ValidateRecursiveGrid states both limits and *refuses* — a shape a
+//     user wrote is answered by telling them their configuration is wrong, not
+//     by quietly navigating a grid they did not ask for. It is the reason a
+//     degenerate shape does not reach a Manager in the first place.
+//   - The Linux and Windows draws test only that neither side is zero or less,
+//     and return rather than fall back, so they draw nothing for a zero side
+//     and one unnarrowable cell for a 1x1. They are not corrected here because
+//     that would be a behavior change on two platforms rather than a
+//     refactor; what makes it moot is that the two answers above run first, and
+//     TestRecursiveGridFrame_DegenerateShapeReachesEveryBackendAsTheDefault
+//     (internal/app/modes) pins that no backend is ever handed a shape this
+//     would have replaced.
+func UsableDimensions(dims domain.GridDimensions) (domain.GridDimensions, bool) {
+	if dims.Cols < MinGridDimension || dims.Rows < MinGridDimension ||
+		dims.CellCount() < MinUsableCellCount {
+		return DefaultDimensions(), false
+	}
+
+	return dims, true
+}

--- a/internal/domain/recursivegrid/usable_dimensions_test.go
+++ b/internal/domain/recursivegrid/usable_dimensions_test.go
@@ -1,0 +1,136 @@
+package recursivegrid_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/recursivegrid"
+)
+
+// TestUsableDimensions pins the rule that decides whether a configured
+// recursive-grid shape can be navigated at all, and what it is replaced with
+// when it cannot. It was written twice — once in the manager and once in the
+// macOS draw — and the copies had already drifted (#1345), so what this covers
+// is the whole rule rather than either site's reading of it.
+//
+// The expected shapes are literals rather than DefaultDimensions() so that a
+// change to the default constants has to disagree with them.
+func TestUsableDimensions(t *testing.T) {
+	testCases := []struct {
+		name     string
+		dims     domain.GridDimensions
+		want     domain.GridDimensions
+		wantUsed bool
+	}{
+		{
+			name:     "square grid is usable as given",
+			dims:     domain.GridDimensions{Rows: 3, Cols: 3},
+			want:     domain.GridDimensions{Rows: 3, Cols: 3},
+			wantUsed: true,
+		},
+		{
+			name:     "non-square grid is usable as given",
+			dims:     domain.GridDimensions{Rows: 2, Cols: 5},
+			want:     domain.GridDimensions{Rows: 2, Cols: 5},
+			wantUsed: true,
+		},
+		{
+			// Two cells is the smallest shape that can narrow anything, and
+			// it is usable in either orientation.
+			name:     "a single row of two cells is usable",
+			dims:     domain.GridDimensions{Rows: 1, Cols: 2},
+			want:     domain.GridDimensions{Rows: 1, Cols: 2},
+			wantUsed: true,
+		},
+		{
+			name:     "a single column of two cells is usable",
+			dims:     domain.GridDimensions{Rows: 2, Cols: 1},
+			want:     domain.GridDimensions{Rows: 2, Cols: 1},
+			wantUsed: true,
+		},
+		{
+			// 1x1 has the right shape and cannot subdivide: selecting its one
+			// cell narrows nothing, so the grid never bottoms out.
+			name:     "1x1 is degenerate and falls back",
+			dims:     domain.GridDimensions{Rows: 1, Cols: 1},
+			want:     domain.GridDimensions{Rows: 3, Cols: 3},
+			wantUsed: false,
+		},
+		{
+			name:     "zero columns falls back",
+			dims:     domain.GridDimensions{Rows: 3, Cols: 0},
+			want:     domain.GridDimensions{Rows: 3, Cols: 3},
+			wantUsed: false,
+		},
+		{
+			name:     "zero rows falls back",
+			dims:     domain.GridDimensions{Rows: 0, Cols: 3},
+			want:     domain.GridDimensions{Rows: 3, Cols: 3},
+			wantUsed: false,
+		},
+		{
+			name:     "the zero value falls back",
+			dims:     domain.GridDimensions{},
+			want:     domain.GridDimensions{Rows: 3, Cols: 3},
+			wantUsed: false,
+		},
+		{
+			name:     "negative columns falls back",
+			dims:     domain.GridDimensions{Rows: 3, Cols: -2},
+			want:     domain.GridDimensions{Rows: 3, Cols: 3},
+			wantUsed: false,
+		},
+		{
+			name:     "negative rows falls back",
+			dims:     domain.GridDimensions{Rows: -2, Cols: 3},
+			want:     domain.GridDimensions{Rows: 3, Cols: 3},
+			wantUsed: false,
+		},
+		{
+			// Both negative multiply to a positive cell count, so the cell
+			// count alone cannot reject this pair.
+			name:     "both dimensions negative falls back",
+			dims:     domain.GridDimensions{Rows: -3, Cols: -3},
+			want:     domain.GridDimensions{Rows: 3, Cols: 3},
+			wantUsed: false,
+		},
+		{
+			// The whole pair is replaced, not just the offending half: a grid
+			// of 7 columns and no rows would otherwise become 7x3, a shape
+			// nobody configured and no key mapping matches.
+			name:     "one bad dimension replaces both",
+			dims:     domain.GridDimensions{Rows: 0, Cols: 7},
+			want:     domain.GridDimensions{Rows: 3, Cols: 3},
+			wantUsed: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, asGiven := recursivegrid.UsableDimensions(testCase.dims)
+			if got != testCase.want {
+				t.Errorf("UsableDimensions(%+v) = %+v, want %+v",
+					testCase.dims, got, testCase.want)
+			}
+
+			if asGiven != testCase.wantUsed {
+				t.Errorf("UsableDimensions(%+v) reported as-given %t, want %t",
+					testCase.dims, asGiven, testCase.wantUsed)
+			}
+		})
+	}
+}
+
+// TestUsableDimensions_FallbackIsTheDefaultShape holds the replacement to the
+// shape the rest of the package falls back to, so the two cannot drift apart
+// even though the case table above spells the numbers out.
+func TestUsableDimensions_FallbackIsTheDefaultShape(t *testing.T) {
+	got, asGiven := recursivegrid.UsableDimensions(domain.GridDimensions{Rows: 1, Cols: 1})
+	if asGiven {
+		t.Fatal("UsableDimensions() reported a 1x1 grid as given")
+	}
+
+	if want := recursivegrid.DefaultDimensions(); got != want {
+		t.Errorf("UsableDimensions() fell back to %+v, want %+v", got, want)
+	}
+}


### PR DESCRIPTION
## Description

The rule that decides whether a recursive-grid shape can narrow anything — at
least one column, at least one row, at least two cells, otherwise the default —
was written twice, and the two copies had drifted. The manager logged the values
it rejected; the macOS draw did not, but reset the key mapping alongside the
shape, and its comment still named a 2x2 default the constants moved off long
ago. This gives the rule one implementation, `recursivegrid.UsableDimensions`,
and has both sites call it. Each keeps what is genuinely its own: the manager
warns with the values it rejected, and the macOS draw reaches for `DefaultKeys`
when the shape it was handed is replaced.

No behaviour changes anywhere. The macOS draw still falls back on exactly the
same pairs, still resets the keys, and still computes the key count from the
shape it ends up with — the count is now computed once, after the fallback,
instead of before it and again inside the branch, which is the same number both
ways.

The stale defaults the ticket asked to be swept out went further than the one
comment: `recursive_grid.grid_cols`/`grid_rows` were documented in
`config.go` as defaulting to 2x2 with warpd's `u/i/j/k` keys, and `neru
recursive_grid --help` told users the same thing. Both defaults have been 3x3
with `rtyfghvbn` since #404. `configs/default-config.toml` and
`docs/CONFIGURATION.md` were already right.

## The Linux/Windows question: no

**Linux and Windows keep the guard they have and do not call
`UsableDimensions`.** Their guard is `dims.Cols <= 0 || dims.Rows <= 0`
(`linux/x11_cgo.go`, `linux/wayland_cgo.go`, `windows/features.go`), which is a
guard on the division and nothing more: a side of zero or less stops the draw,
and a 1x1 passes it and paints one cell over the whole region that no key can
narrow. macOS instead replaces the shape and draws the default 3x3. Making the
other two correct their input would be a user-visible behaviour change on two
platforms, which is more than a refactor ticket should carry.

The reason it costs nothing to say no is that the difference is unreachable, and
this PR is where that is now held rather than assumed.
`Config.ValidateRecursiveGrid` refuses a degenerate `grid_cols`/`grid_rows` pair
and a degenerate `layers` entry outright — `CodeInvalidConfig`, so the whole
configuration is rejected — and every draw path is fed by
`recursivegrid.Manager`, which replaces an unusable shape before anything is
drawn. So the frame each backend is handed already carries a usable pair and a
key mapping that fits it, and all three divide it with the same
`ComputeGridCells`.
`TestRecursiveGridFrame_DegenerateShapeReachesEveryBackendAsTheDefault` pins
that: it drives the real mode path with four degenerate configurations and
asserts the frame that reaches the port carries the default 3x3 shape, the
default keys, and the nine cells every backend then paints. If the fallback ever
moved out of the domain into the macOS draw alone, that test fails rather than
Linux and Windows quietly drawing something a person cannot navigate.

That leaves macOS's own fallback as defence for a `Manager` built by something
other than the mode layer, which is what the extracted rule now documents.

## Related Issues

Closes #1345

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

macOS is ticked because the darwin render file is the second call site; nothing
it does changed.

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — the darwin file kept its tag; no new tagged file
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — the new package member is in `internal/domain`, imported by the darwin file rather than the other way round
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changed
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — the CLI help and the config
      struct comments that named the wrong default
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

`just lint-cross` passes for linux/amd64 (CGO on) and windows/amd64 as well —
`just lint` is blind to those build tags, and the two backends this PR
deliberately leaves alone both sit behind them.

## Additional Context

**Where the rule lives, and why there.** ADR 0007 puts a shared derivation at
the lowest layer with more than one caller, "not in the domain by default". Here
the domain *is* one of the callers — `recursivegrid.Manager` falls back before
it builds a grid — so `internal/domain/recursivegrid` is where it goes, the way
`SubgridKeys` did and `fontgeneric` did not.

**Why the signature reports rather than corrects silently.** `UsableDimensions`
returns the shape to use and whether that is the shape it was given, because
both callers do something with the answer and neither does the same thing: the
manager logs the values it rejected, which it cannot do after they have been
replaced, and the macOS draw swaps the key mapping. A function that only
returned the corrected pair would have pushed both of those back into a
re-derived comparison at each site — which is the drift this removes.

**Why the whole pair is replaced.** Both copies already did this, and the test
table now says why: a configured 7 columns with 0 rows becoming 7x3 would be a
shape nobody chose and no key mapping is the right length for.

**One place for the *fallback*, not for the limits — and the survivors are
named.** Two weaker tests of the same limits are still in the tree, and
`UsableDimensions`'s doc comment inventories both rather than claiming they do
not exist, the way ADR 0007 asks an unpinned copy to be named. One is
`ValidateRecursiveGrid` (`internal/config/validators_grid.go`), which *refuses*
a shape a user wrote instead of replacing it, so they are told their file is
wrong. The other is the Linux and Windows draw guard described above. Neither is
a second silent correction, which is the thing this removes.

**One thing the boundary review turned up and this PR does not fix.**
`internal/config/config_defaults.go` declares the same two numbers a second time
(`DefaultRecursiveGridMinGridCols/Rows = 1`, `DefaultRecursiveGridMinTotalCells
= 2`), and nothing makes them agree with the domain's. The obvious collapse —
defining the config constants from the domain ones — is not available:
`internal/domain/recursivegrid` imports `internal/config`, so the dependency
would be a cycle. Untangling that is its own change, not this one.

**What I did not touch.** ADR 0007's "shipped one instance and left two known
ones standing" paragraph is the inventory of what *that* ADR knew about; this
copy was not one of the two, so it is not added there. The `TopLeft`…
`BottomRight` cell constants in `recursive_grid.go` still document themselves as
2x2-only, which is true of them — they are cell indices, not a default.
