### PR TITLE
fix(eventtap): make numpad Enter match Return bindings on macOS and stop numpad Clear firing delete

### DIFF
--- a/internal/adapter/platform/darwin/keymap.go
+++ b/internal/adapter/platform/darwin/keymap.go
@@ -41,6 +41,34 @@ func keymapLayoutChangeBridge() {
 	})
 }
 
+// KeyCodeToCharacter returns the key string the event tap would produce for a
+// raw virtual key code with the given CGEventFlags: a character ("a", "5", "."),
+// or a named key for keys that fold to one (numpad Enter -> "Return"). Returns
+// "" when the key code does not resolve. It exists so tests can pin the
+// keycode-translation contract from Go.
+func KeyCodeToCharacter(keyCode uint16, flags uint64) string {
+	cStr := C.NeruCopyKeyCodeToCharacter(C.CGKeyCode(keyCode), C.CGEventFlags(flags))
+	if cStr == nil {
+		return ""
+	}
+	defer C.free(unsafe.Pointer(cStr))
+
+	return C.GoString(cStr)
+}
+
+// KeyCodeToName returns the layout-independent name for a raw virtual key
+// code ("Return", "Escape", "A"), or "" when the key code has none. It exists
+// so tests can pin the keycode-translation contract from Go.
+func KeyCodeToName(keyCode uint16) string {
+	cStr := C.NeruCopyKeyCodeToName(C.CGKeyCode(keyCode))
+	if cStr == nil {
+		return ""
+	}
+	defer C.free(unsafe.Pointer(cStr))
+
+	return C.GoString(cStr)
+}
+
 // SetReferenceKeyboardLayout configures the key translation reference layout.
 // Pass an empty inputSourceID to use automatic fallback resolution.
 // Returns false only when a non-empty layout ID was provided but could not be resolved.

--- a/internal/adapter/platform/darwin/keymap.h
+++ b/internal/adapter/platform/darwin/keymap.h
@@ -162,10 +162,20 @@ NSString *NeruKeyCodeToName(CGKeyCode keyCode);
 /// Map keycode to character with shift/capslock handling
 /// Uses UCKeyTranslate to respect Colemak, Dvorak, etc. while bypassing IME.
 /// Falls back to US QWERTY if layout translation fails.
+/// Numpad keys with a named-key equivalent return the named key instead of a
+/// raw control character ("Return" for numpad Enter, "Clear" for numpad Clear).
 /// @param keyCode Key code
 /// @param flags Event flags (for shift/capslock detection)
-/// @return Character string or nil if not found
+/// @return Character string or named key, nil if not found
 NSString *NeruKeyCodeToCharacter(CGKeyCode keyCode, CGEventFlags flags);
+
+/// C-string copy of NeruKeyCodeToCharacter for the CGO boundary.
+/// @return Malloc'd UTF-8 string the caller must free(), or NULL if not found
+char *NeruCopyKeyCodeToCharacter(CGKeyCode keyCode, CGEventFlags flags);
+
+/// C-string copy of NeruKeyCodeToName for the CGO boundary.
+/// @return Malloc'd UTF-8 string the caller must free(), or NULL if not found
+char *NeruCopyKeyCodeToName(CGKeyCode keyCode);
 
 /// Rebuild layout-aware key maps after a keyboard layout change.
 /// Called automatically via kTISNotifySelectedKeyboardInputSourceChanged.

--- a/internal/adapter/platform/darwin/keymap_darwin.m
+++ b/internal/adapter/platform/darwin/keymap_darwin.m
@@ -8,6 +8,7 @@
 #import "keymap.h"
 
 #include <stdatomic.h>
+#include <string.h>
 
 #pragma mark - Static Data
 
@@ -664,6 +665,13 @@ static void initializeSpecialKeyMaps(void) {
 	codeToName[@(kKeyCodeReturn)] = @"Return";
 	codeToName[@(kKeyCodeDelete)] = @"Delete";
 
+	// Numpad keys with a named-key equivalent fold to it (issue #1372), the
+	// way the Wayland keymap folds KP_Enter -> Return. Only the code-to-name
+	// direction learns them: name-to-code must keep resolving "Return" to the
+	// main Return key for key synthesis.
+	codeToName[@(kKeyCodeNumpadEnter)] = @"Return";
+	codeToName[@(kKeyCodeNumpadClear)] = @"Clear";
+
 	gSpecialCodeToNameMap = [codeToName copy];
 }
 
@@ -1019,6 +1027,20 @@ NSString *NeruKeyCodeToName(CGKeyCode keyCode) {
 	return map[@(keyCode)];
 }
 
+char *NeruCopyKeyCodeToCharacter(CGKeyCode keyCode, CGEventFlags flags) {
+	@autoreleasepool {
+		NSString *result = NeruKeyCodeToCharacter(keyCode, flags);
+		return result ? strdup(result.UTF8String) : NULL;
+	}
+}
+
+char *NeruCopyKeyCodeToName(CGKeyCode keyCode) {
+	@autoreleasepool {
+		NSString *result = NeruKeyCodeToName(keyCode);
+		return result ? strdup(result.UTF8String) : NULL;
+	}
+}
+
 NSString *NeruKeyCodeToCharacter(CGKeyCode keyCode, CGEventFlags flags) {
 	initializeKeyMaps();
 	ensureLayoutMapsInitialized();
@@ -1032,7 +1054,11 @@ NSString *NeruKeyCodeToCharacter(CGKeyCode keyCode, CGEventFlags flags) {
 	case kKeyCodeTab:
 		return @"\t";
 
-	// Numpad keys are layout-independent
+	// Numpad keys are layout-independent. Keys with a named-key equivalent
+	// fold to it, the way the Wayland keymap folds KP_Enter -> Return
+	// (wayland_keymap.c) — a raw control character here would either match
+	// no binding ("\x03") or impersonate the Delete key ("\x7f"). "Clear"
+	// is not a bindable named key; it deliberately matches nothing.
 	case kKeyCodeNumpadDot:
 		return @".";
 	case kKeyCodeNumpadMultiply:
@@ -1040,11 +1066,11 @@ NSString *NeruKeyCodeToCharacter(CGKeyCode keyCode, CGEventFlags flags) {
 	case kKeyCodeNumpadPlus:
 		return @"+";
 	case kKeyCodeNumpadClear:
-		return @"\x7f";
+		return @"Clear";
 	case kKeyCodeNumpadDivide:
 		return @"/";
 	case kKeyCodeNumpadEnter:
-		return @"\x03";
+		return @"Return";
 	case kKeyCodeNumpadMinus:
 		return @"-";
 	case kKeyCodeNumpadEquals:

--- a/internal/adapter/platform/darwin/keymap_integration_darwin_test.go
+++ b/internal/adapter/platform/darwin/keymap_integration_darwin_test.go
@@ -1,0 +1,131 @@
+//go:build integration && darwin
+
+package darwin_test
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/platform/darwin"
+)
+
+// Pin the main thread during package init so TestMain still runs on it.
+func init() {
+	runtime.LockOSThread()
+}
+
+// TestMain services the macOS main run loop while the tests run. Building the
+// keyboard layout maps happens on the main queue, which nothing drains in a
+// plain `go test` binary (see runloop.go).
+func TestMain(m *testing.M) {
+	os.Exit(darwin.RunMainLoopForTesting(m.Run))
+}
+
+// Virtual key codes under test, mirroring the KeyCode enum in keymap.h.
+const (
+	keyCodeReturn       = 36 // main-keyboard Return
+	keyCodeDelete       = 51 // main-keyboard Delete (backspace position)
+	keyCodeNumpadDot    = 65
+	keyCodeNumpadClear  = 71
+	keyCodeNumpadEnter  = 76
+	keyCodeNumpadEquals = 81
+	keyCodeNumpad0      = 82
+	keyCodeNumpad5      = 87
+	keyCodeNumpad9      = 92
+	keyCodeNumpadDivide = 75
+	keyCodeNumpadMinus  = 78
+	keyCodeNumpadPlus   = 69
+	keyCodeNumpadStar   = 67
+)
+
+// Named-key spellings the event tap emits on the wire.
+const (
+	namedKeyReturn = "Return"
+	namedKeyClear  = "Clear"
+)
+
+// TestKeymap_KeyCodeToCharacter_NumpadFoldsToNamedKeys pins issue #1372: the
+// numpad keys with a named-key equivalent must fold to it, the way the Wayland
+// keymap folds KP_Enter -> Return, instead of surfacing raw control characters
+// ("\x03" for numpad Enter, "\x7f" for numpad Clear) that either match no
+// binding or impersonate the Delete key.
+func TestKeymap_KeyCodeToCharacter_NumpadFoldsToNamedKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		keyCode uint16
+		want    string
+	}{
+		{"numpad Enter folds to Return", keyCodeNumpadEnter, namedKeyReturn},
+		{"numpad Clear folds to Clear", keyCodeNumpadClear, namedKeyClear},
+		{"numpad digit 0 stays a digit", keyCodeNumpad0, "0"},
+		{"numpad digit 5 stays a digit", keyCodeNumpad5, "5"},
+		{"numpad digit 9 stays a digit", keyCodeNumpad9, "9"},
+		{"numpad dot stays a dot", keyCodeNumpadDot, "."},
+		{"numpad plus stays an operator", keyCodeNumpadPlus, "+"},
+		{"main-keyboard Return keeps its carriage-return character", keyCodeReturn, "\r"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := darwin.KeyCodeToCharacter(testCase.keyCode, 0)
+			if got != testCase.want {
+				t.Errorf(
+					"KeyCodeToCharacter(%d, 0) = %q, want %q",
+					testCase.keyCode,
+					got,
+					testCase.want,
+				)
+			}
+		})
+	}
+}
+
+// TestKeymap_KeyCodeToName_NumpadFoldsToNamedKeys pins the modifier-combo
+// path of issue #1372: the event tap resolves "Cmd+..." / "Shift+..." combos
+// through the keycode-to-name map, so numpad Enter must name "Return" there
+// too or Cmd+NumpadEnter degrades to a bare character event.
+func TestKeymap_KeyCodeToName_NumpadFoldsToNamedKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		keyCode uint16
+		want    string
+	}{
+		{"numpad Enter names Return", keyCodeNumpadEnter, namedKeyReturn},
+		{"numpad Clear names Clear", keyCodeNumpadClear, namedKeyClear},
+		{"main-keyboard Return still names Return", keyCodeReturn, namedKeyReturn},
+		{"main-keyboard Delete still names Delete", keyCodeDelete, "Delete"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := darwin.KeyCodeToName(testCase.keyCode)
+			if got != testCase.want {
+				t.Errorf("KeyCodeToName(%d) = %q, want %q", testCase.keyCode, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestKeymap_KeyCodeToCharacter_NumpadEmitsNoControlCharacters pins the
+// acceptance criterion that no raw control character reaches key comparison
+// from the numpad path.
+func TestKeymap_KeyCodeToCharacter_NumpadEmitsNoControlCharacters(t *testing.T) {
+	numpadKeyCodes := []uint16{
+		keyCodeNumpadDot, keyCodeNumpadStar, keyCodeNumpadPlus, keyCodeNumpadClear,
+		keyCodeNumpadDivide, keyCodeNumpadEnter, keyCodeNumpadMinus, keyCodeNumpadEquals,
+		keyCodeNumpad0, 83, 84, 85, 86, keyCodeNumpad5, 88, 89, 91, keyCodeNumpad9,
+	}
+
+	for _, keyCode := range numpadKeyCodes {
+		got := darwin.KeyCodeToCharacter(keyCode, 0)
+		for _, r := range got {
+			if r < 0x20 || r == 0x7f {
+				t.Errorf(
+					"KeyCodeToCharacter(%d, 0) = %q contains control character %U",
+					keyCode, got, r,
+				)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes the macOS numpad: pressing numpad Enter now triggers a
Return/Enter binding (previously it matched nothing and the press was
swallowed), and pressing numpad Clear no longer triggers a binding written
for the Delete key. Numpad digits and operators keep behaving as before, and
main-keyboard Return and Delete are unchanged.

Both keys used to surface internally as raw control characters instead of
named keys. They now fold to named keys the way the Wayland backend already
folds keypad Enter to Return, in every path: plain press, Shift and
Cmd/Alt/Ctrl combos, and key release. Numpad Clear folds to a deliberately
unbindable name, so it does nothing rather than impersonating another key.

## Related Issues

Closes #1372

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, darwin-internal key translation; no port contract changed
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, behaviour now matches what
      ADR 0008 already records; no capability-status change
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The fold lives entirely in the macOS keymap layer (both the character
translation and the keycode-to-name table the modifier-combo paths use), so
the event tap needed no changes. New integration tests pin the translation
contract from Go, including that no raw control character can come off the
numpad path.

Numpad Clear is intentionally not bindable: it emits a name outside the
named-key vocabulary. Making it bindable is a vocabulary decision that
belongs with the keyvocab consolidation (#1370), not this fix. The two
Objective-C key-name tables remain unpinned against each other until #1374.
