### PR TITLE
fix(hints): make search_field and switch produce hints on macOS

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -799,14 +799,14 @@ name resolves here, and `neru roles --explain` to see how your own config resolv
 | `link`         | `AXLink`               | `link`                                  | `Hyperlink`           |
 | `checkbox`     | `AXCheckBox`           | `check box`, `check menu item`          | `CheckBox`            |
 | `radio`        | `AXRadioButton`        | `radio button`, `radio menu item`       | `RadioButton`         |
-| `switch`       | `AXSwitch`             | `switch`, `toggle button`               | —                     |
+| `switch`       | `AXSwitch` †           | `switch`, `toggle button`               | —                     |
 | `disclosure`   | `AXDisclosureTriangle` | —                                       | —                     |
 | `text_field`   | `AXTextField`          | `entry`, `password text`                | `Edit`                |
 | `text_area`    | `AXTextArea`           | `entry`                                 | `Edit`                |
-| `search_field` | `AXSearchField`        | `entry`                                 | `Edit`                |
+| `search_field` | `AXSearchField` †      | `entry`                                 | `Edit`                |
 | `slider`       | `AXSlider`             | `slider`                                | `Slider`              |
 | `stepper`      | `AXIncrementor`        | `spin button`                           | `Spinner`             |
-| `tab`          | `AXTabButton`          | `page tab`                              | `TabItem`             |
+| `tab`          | `AXTabButton` †        | `page tab`                              | `TabItem`             |
 | `menu_item`    | `AXMenuItem`           | `menu item`                             | `MenuItem`            |
 | `menubar_item` | `AXMenuBarItem`        | —                                       | —                     |
 | `dock_item`    | `AXDockItem`           | —                                       | —                     |
@@ -817,10 +817,15 @@ name resolves here, and `neru roles --explain` to see how your own config resolv
 | `static_text`  | `AXStaticText`         | `static`, `label`, `text`               | `Text`                |
 | `heading`      | `AXHeading`            | `heading`                               | —                     |
 | `color_well`   | `AXColorWell`          | `color chooser`                         | —                     |
-| `toolbar_button` | `AXToolbarButton`    | —                                       | —                     |
+| `toolbar_button` | `AXToolbarButton` †  | —                                       | —                     |
 
 A `—` means the platform has no equivalent; that entry is ignored there and reported by
 `neru roles --explain` and `neru doctor`.
+
+† A subrole, not a role: AppKit reports these names in the element's *subrole* while the
+role stays generic — a search field is an `AXTextField` with subrole `AXSearchField`, a
+SwiftUI toggle an `AXCheckBox` with subrole `AXSwitch`. Neru matches configured names
+against both the role and the subrole, so these entries work as written.
 
 #### Native roles
 

--- a/internal/adapter/accessibility/native/darwin/element.go
+++ b/internal/adapter/accessibility/native/darwin/element.go
@@ -239,6 +239,27 @@ func (ei *ElementInfo) PID() int {
 	return ei.pid
 }
 
+// matchesRoleFilter reports whether the element satisfies a configured role
+// filter. AppKit declares several vocabulary names as subroles rather than
+// roles (element.AXSubroleNames) — a search field is AXTextField /
+// AXSearchField, a SwiftUI toggle AXCheckBox / AXSwitch — so a configured
+// name matches when it appears in either attribute. The result is a single
+// yes/no per element: an element whose role and subrole are both configured
+// is still one hint target.
+func (ei *ElementInfo) matchesRoleFilter(allowed map[string]struct{}) bool {
+	if _, ok := allowed[ei.role]; ok {
+		return true
+	}
+
+	if ei.subrole == "" {
+		return false
+	}
+
+	_, ok := allowed[ei.subrole]
+
+	return ok
+}
+
 // CheckAccessibilityPermissions verifies that the application has been granted accessibility permissions.
 func CheckAccessibilityPermissions() bool {
 	result := C.NeruCheckAccessibilityPermissions()
@@ -719,13 +740,14 @@ func (e *Element) IsClickable(
 		}
 	}
 
-	// Check roles
+	// Check roles (and subroles: several AX vocabulary names only ever
+	// appear in AXSubrole — see ElementInfo.matchesRoleFilter).
 	var isRoleAllowed bool
 	if len(allowedRoles) > 0 {
-		_, isRoleAllowed = allowedRoles[info.Role()]
+		isRoleAllowed = info.matchesRoleFilter(allowedRoles)
 	} else {
 		clickableRolesMu.RLock()
-		_, isRoleAllowed = clickableRoles[info.Role()]
+		isRoleAllowed = info.matchesRoleFilter(clickableRoles)
 		clickableRolesMu.RUnlock()
 	}
 

--- a/internal/adapter/accessibility/native/darwin/element_test.go
+++ b/internal/adapter/accessibility/native/darwin/element_test.go
@@ -1,0 +1,114 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain/element"
+)
+
+// AppKit reports several vocabulary names — AXSearchField, AXSwitch,
+// AXToolbarButton, AXTabButton — as subroles: the element's AXRole is
+// something more generic and the configured name arrives in AXSubrole
+// (element.AXSubroleNames). These pin the role filter that IsClickable
+// applies, through the same ElementInfo bundle the AX bridge fills in.
+
+func TestElementInfo_MatchesRoleFilter_Subroles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		role    string
+		subrole string
+		allowed []string
+		want    bool
+	}{
+		{
+			name:    "search_field alone matches an AppKit search field by subrole",
+			role:    string(element.RoleTextField),
+			subrole: string(element.RoleSearchField),
+			allowed: []string{string(element.RoleSearchField)},
+			want:    true,
+		},
+		{
+			name:    "switch alone matches a SwiftUI toggle by subrole",
+			role:    string(element.RoleCheckBox),
+			subrole: string(element.RoleSwitch),
+			allowed: []string{string(element.RoleSwitch)},
+			want:    true,
+		},
+		{
+			name:    "toolbar_button matches a toolbar button by subrole",
+			role:    string(element.RoleButton),
+			subrole: string(element.RoleToolbarButton),
+			allowed: []string{string(element.RoleToolbarButton)},
+			want:    true,
+		},
+		{
+			name:    "tab matches an AppKit tab button by subrole",
+			role:    string(element.RoleRadioButton),
+			subrole: string(element.RoleTabButton),
+			allowed: []string{string(element.RoleTabButton)},
+			want:    true,
+		},
+		{
+			name:    "role matching still works without a subrole",
+			role:    string(element.RoleButton),
+			subrole: "",
+			allowed: []string{string(element.RoleButton)},
+			want:    true,
+		},
+		{
+			name:    "plain text field does not match search_field",
+			role:    string(element.RoleTextField),
+			subrole: "",
+			allowed: []string{string(element.RoleSearchField)},
+			want:    false,
+		},
+		{
+			name:    "unrelated subrole does not match",
+			role:    string(element.RoleTextField),
+			subrole: "AXSecureTextField",
+			allowed: []string{string(element.RoleSearchField)},
+			want:    false,
+		},
+		{
+			// The filter is a single yes/no per element, so a search field
+			// stays one hint target when text_field and search_field are
+			// both configured.
+			name:    "text_field and search_field together still yield one match",
+			role:    string(element.RoleTextField),
+			subrole: string(element.RoleSearchField),
+			allowed: []string{string(element.RoleTextField), string(element.RoleSearchField)},
+			want:    true,
+		},
+		{
+			name:    "empty filter matches nothing",
+			role:    string(element.RoleTextField),
+			subrole: string(element.RoleSearchField),
+			allowed: nil,
+			want:    false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			allowed := make(map[string]struct{}, len(testCase.allowed))
+			for _, name := range testCase.allowed {
+				allowed[name] = struct{}{}
+			}
+
+			info := NewElementInfo(testCase.role, testCase.subrole, "")
+
+			if got := info.matchesRoleFilter(allowed); got != testCase.want {
+				t.Errorf(
+					"matchesRoleFilter(role=%q, subrole=%q, allowed=%v) = %v, want %v",
+					testCase.role, testCase.subrole, testCase.allowed, got, testCase.want,
+				)
+			}
+		})
+	}
+}

--- a/internal/architecture/role_vocabulary_docs_test.go
+++ b/internal/architecture/role_vocabulary_docs_test.go
@@ -35,6 +35,30 @@ func TestConfigurationDocsCoverTheRoleVocabulary(t *testing.T) {
 	}
 }
 
+// TestConfigurationDocsMarkTheAXSubroleNames keeps the documented role table
+// honest about the AX names AppKit declares as subroles: an element reports
+// them in its subrole while its role stays generic, and the table is where a
+// user would otherwise learn the wrong shape.
+func TestConfigurationDocsMarkTheAXSubroleNames(t *testing.T) {
+	docPath := filepath.Join(findRepoRoot(t), "docs", "CONFIGURATION.md")
+
+	contents, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", docPath, err)
+	}
+
+	doc := string(contents)
+
+	for name := range element.AXSubroleNames {
+		if !strings.Contains(doc, "`"+name+"` †") {
+			t.Errorf(
+				"docs/CONFIGURATION.md does not mark `%s` with the subrole footnote †",
+				name,
+			)
+		}
+	}
+}
+
 // TestConfigurationDocsUseTheCurrentRoleVocabulary catches documentation that
 // still tells users to write native role names without a vocabulary prefix,
 // which is now a configuration error.

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -73,8 +73,20 @@ func runRolesList(cmd *cobra.Command) {
 	for _, mapping := range element.RoleVocabulary {
 		native := mapping.Native(vocabulary)
 
-		expansion := strings.Join(native, ", ")
-		if len(native) == 0 {
+		names := make([]string, len(native))
+		for index, name := range native {
+			names[index] = name
+			// AppKit declares some AX names as subroles: an element carries
+			// them in AXSubrole while its AXRole stays generic, and neru
+			// matches them against both. Say so, or the column misdescribes
+			// what an element reports as its role.
+			if vocabulary == element.VocabularyAX && element.AXSubroleNames[name] {
+				names[index] = name + " (subrole)"
+			}
+		}
+
+		expansion := strings.Join(names, ", ")
+		if len(names) == 0 {
 			expansion = "— no equivalent on this platform"
 		}
 

--- a/internal/cli/roles_test.go
+++ b/internal/cli/roles_test.go
@@ -102,6 +102,25 @@ func TestRolesCmd_ListsEverySemanticRole(t *testing.T) {
 	}
 }
 
+// TestRolesCmd_MarksAXSubroleNames checks that the listing tells a macOS user
+// which AX names are subroles. AppKit delivers those names in AXSubrole while
+// AXRole stays generic, so the mark is how the expansion column stays an
+// honest description of what an element reports.
+func TestRolesCmd_MarksAXSubroleNames(t *testing.T) {
+	vocabulary, supported := element.CurrentVocabulary()
+	if !supported || vocabulary != element.VocabularyAX {
+		t.Skipf("AX names are only listed on macOS, not %s", runtime.GOOS)
+	}
+
+	output := runRolesCmd(t, writeRolesConfig(t, `["button"]`))
+
+	for name := range element.AXSubroleNames {
+		if !strings.Contains(output, name+" (subrole)") {
+			t.Errorf("neru roles output does not mark %q as a subrole:\n%s", name, output)
+		}
+	}
+}
+
 // TestRolesCmd_ExplainReportsEveryEntry covers the --explain path, including
 // the entries that do not apply on this platform — the case the command exists
 // to make visible.

--- a/internal/domain/element/vocabulary.go
+++ b/internal/domain/element/vocabulary.go
@@ -103,6 +103,13 @@ type RoleMapping struct {
 	Semantic SemanticRole
 	// AX lists the macOS role names this semantic role expands to.
 	AX []string
+	// AXIsSubrole marks that AppKit declares this mapping's AX names as
+	// subroles (NSAccessibilitySubrole constants in
+	// NSAccessibilityConstants.h), not roles: an element reports such a name
+	// in its AXSubrole attribute while its AXRole stays something more
+	// generic, so the macOS matcher compares configured names against the
+	// subrole as well as the role. AXSubroleNames collects the marked names.
+	AXIsSubrole bool
 	// ATSPI lists the Linux AT-SPI role names this semantic role expands to.
 	ATSPI []string
 	// UIA lists the Windows UI Automation control-type programmatic names this
@@ -177,7 +184,9 @@ var RoleVocabulary = []RoleMapping{
 	},
 	{
 		Semantic: SemanticSwitch,
-		AX:       []string{string(RoleSwitch)},
+		// SwiftUI toggles report AXCheckBox / AXSwitch.
+		AX:          []string{string(RoleSwitch)},
+		AXIsSubrole: true,
 		// ATSPI_ROLE_SWITCH is the dedicated role (GTK4 GtkSwitch and friends);
 		// older toolkits still report a toggle button.
 		ATSPI: []string{"switch", "toggle button"},
@@ -200,9 +209,11 @@ var RoleVocabulary = []RoleMapping{
 	},
 	{
 		Semantic: SemanticSearchField,
-		AX:       []string{string(RoleSearchField)},
-		ATSPI:    []string{atspiRoleEntry},
-		UIA:      []string{uiaControlEdit},
+		// AppKit search fields report AXTextField / AXSearchField.
+		AX:          []string{string(RoleSearchField)},
+		AXIsSubrole: true,
+		ATSPI:       []string{atspiRoleEntry},
+		UIA:         []string{uiaControlEdit},
 	},
 	{
 		Semantic: SemanticSlider,
@@ -218,9 +229,11 @@ var RoleVocabulary = []RoleMapping{
 	},
 	{
 		Semantic: SemanticTab,
-		AX:       []string{string(RoleTabButton)},
-		ATSPI:    []string{"page tab"},
-		UIA:      []string{"TabItem"},
+		// AppKit tab buttons report AXRadioButton / AXTabButton.
+		AX:          []string{string(RoleTabButton)},
+		AXIsSubrole: true,
+		ATSPI:       []string{"page tab"},
+		UIA:         []string{"TabItem"},
 	},
 	{
 		Semantic: SemanticMenuItem,
@@ -278,9 +291,30 @@ var RoleVocabulary = []RoleMapping{
 	},
 	{
 		Semantic: SemanticToolbarButton,
-		AX:       []string{string(RoleToolbarButton)},
+		// Toolbar buttons report AXButton / AXToolbarButton.
+		AX:          []string{string(RoleToolbarButton)},
+		AXIsSubrole: true,
 	},
 }
+
+// AXSubroleNames collects the AX names RoleVocabulary marks with AXIsSubrole:
+// the names AppKit delivers in AXSubrole rather than AXRole. None of them is
+// also declared as a role, which is what keeps the matcher's two comparisons
+// from colliding.
+var AXSubroleNames = func() map[string]bool {
+	names := make(map[string]bool)
+	for _, mapping := range RoleVocabulary {
+		if !mapping.AXIsSubrole {
+			continue
+		}
+
+		for _, name := range mapping.AX {
+			names[name] = true
+		}
+	}
+
+	return names
+}()
 
 // DefaultClickableRoles is the role list neru ships as the default value of
 // hints.clickable_roles. It is also the fallback an accessibility backend uses

--- a/internal/domain/element/vocabulary_test.go
+++ b/internal/domain/element/vocabulary_test.go
@@ -669,3 +669,50 @@ func TestResolveRoles_SemanticNamesAreCaseSensitive(t *testing.T) {
 		t.Errorf("ResolveRoles(Button) = %v, want it rejected as unknown", got.Native)
 	}
 }
+
+// TestAXSubroleNames_PinTheAppKitSubroleDeclarations pins the AX names in the
+// vocabulary that AppKit declares as subroles (NSAccessibilitySubrole
+// constants), not roles: elements carry them in AXSubrole, so the macOS
+// matcher must compare them against the element's subrole or they match
+// nothing. The expected set comes from NSAccessibilityConstants.h
+// (SearchField, Switch, ToolbarButton, TabButton — all Subrole constants,
+// none declared as a role).
+func TestAXSubroleNames_PinTheAppKitSubroleDeclarations(t *testing.T) {
+	t.Parallel()
+
+	want := []string{"AXSearchField", "AXSwitch", "AXTabButton", "AXToolbarButton"}
+
+	got := make([]string, 0, len(element.AXSubroleNames))
+	for name := range element.AXSubroleNames {
+		got = append(got, name)
+	}
+
+	slices.Sort(got)
+
+	if !slices.Equal(got, want) {
+		t.Errorf("AXSubroleNames = %v, want %v", got, want)
+	}
+}
+
+// TestAXSubroleNames_DoNotDoubleAsRoleNames guards the invariant the macOS
+// matcher relies on: a configured name is compared against both the role and
+// the subrole, which stays unambiguous only while no AX name appears in the
+// vocabulary as a role in one mapping and a subrole in another.
+func TestAXSubroleNames_DoNotDoubleAsRoleNames(t *testing.T) {
+	t.Parallel()
+
+	for _, mapping := range element.RoleVocabulary {
+		if mapping.AXIsSubrole {
+			continue
+		}
+
+		for _, name := range mapping.AX {
+			if element.AXSubroleNames[name] {
+				t.Errorf(
+					"%q is a plain role name in mapping %q but also marked as a subrole",
+					name, mapping.Semantic,
+				)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes hint matching on macOS for controls that AppKit reports through a subrole: with `hints.clickable_roles = ["switch"]` alone, SwiftUI toggles now get hints, and `search_field` alone now matches AppKit search fields. Previously these vocabulary entries matched nothing on macOS — a search field reports a generic text-field role with the search-field name in its subrole, and matching compared the role only — so they silently worked only when broader defaults like `text_field` and `checkbox` were also configured.

macOS matching now compares configured names against the element's subrole as well as its role. The decision stays a single yes/no per element, so configuring `text_field` and `search_field` together still produces one hint per search field, never two. The role table in `docs/CONFIGURATION.md` and the `neru roles` listing now say which macOS names are subroles, and guard tests keep both in step with the vocabulary.

One deliberate limitation: `tab` and `toolbar_button` were given the same treatment on SDK evidence — the macOS SDK declares all four names (search field, switch, toolbar button, tab button) as subrole constants and none as a role — but only search fields and toggles were confirmed by a live probe; toolbar and tab buttons remain unprobed in a running app.

## Related Issues

Closes #1373

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `fix` — Bug fix

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changed; Linux and Windows resolve these entries to genuine roles already

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command Output Changes

`neru roles` now appends `(subrole)` to the macOS names that AppKit delivers in an element's subrole, e.g. `search_field  AXSearchField (subrole)`. No config key, flag, or accepted value changed; existing configs keep working unchanged.

## Additional Context

Two scope notes. First, the `(subrole)` mark in `neru roles` is a third user-visible surface beyond the matcher and the docs table — added so the listing does not misdescribe what an element actually reports as its role. Second, the matcher compares every configured name against the subrole, not just the four vocabulary names, so prefixed native entries such as `ax:AXSecureTextField` now also match by subrole; this is wider than the minimum fix, and deliberate — the role and subrole namespaces do not collide, and a prefixed subrole entry that matched nothing was the same bug in another spelling.
