### PR TITLE
fix(eventtap): make PageUp, PageDown, Home and End work on X11 and Windows

### DIFF
--- a/internal/adapter/eventtap/linux/x11_cgo.go
+++ b/internal/adapter/eventtap/linux/x11_cgo.go
@@ -200,6 +200,17 @@ func x11KeysymName(keysym C.KeySym) string {
 		return "Up"
 	case C.XK_Down:
 		return "Down"
+	// Like the function keys below, the navigation keys produce no character
+	// from XLookupString, so this lookup is the only way they reach the
+	// handler. The names match the evdev and Wayland backends.
+	case C.XK_Home:
+		return evdevKeyNameHome
+	case C.XK_End:
+		return evdevKeyNameEnd
+	case C.XK_Page_Up:
+		return evdevKeyNamePageUp
+	case C.XK_Page_Down:
+		return evdevKeyNamePageDown
 	default:
 		return x11FunctionKeysymName(keysym)
 	}

--- a/internal/adapter/eventtap/linux/x11_keys_test.go
+++ b/internal/adapter/eventtap/linux/x11_keys_test.go
@@ -1,0 +1,73 @@
+//go:build linux && cgo
+
+package linux
+
+import "testing"
+
+// X11 keysym values for the navigation keys, from X11/keysym.h. The production
+// lookup names them through cgo, which a test file cannot do (`go test` rejects
+// cgo in in-package test files), so the protocol constants are pinned here as
+// literals — they are frozen X11 protocol numbers. Untyped constants convert to
+// the cgo parameter type at the call site.
+const (
+	x11KeysymHome     = 0xFF50 // XK_Home
+	x11KeysymPageUp   = 0xFF55 // XK_Page_Up / XK_Prior
+	x11KeysymPageDown = 0xFF56 // XK_Page_Down / XK_Next
+	x11KeysymEnd      = 0xFF57 // XK_End
+)
+
+// TestX11KeyFromLookupNavigationKeys pins the navigation keys on the X11 tap.
+// XLookupString yields no character for them, so the keysym lookup is the only
+// path by which they reach the handler, and the name it returns has to be the
+// spelling config validation accepts. The evdev backend is checked against the
+// same literal so both Linux taps keep emitting the one spelling.
+func TestX11KeyFromLookupNavigationKeys(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		got       string
+		evdevCode uint16
+		want      string
+	}{
+		{
+			name:      "page up",
+			got:       x11KeyFromLookup(0, nil, x11KeysymPageUp),
+			evdevCode: evdevKeyPageUp,
+			want:      "PageUp",
+		},
+		{
+			name:      "page down",
+			got:       x11KeyFromLookup(0, nil, x11KeysymPageDown),
+			evdevCode: evdevKeyPageDown,
+			want:      "PageDown",
+		},
+		{
+			name:      "home",
+			got:       x11KeyFromLookup(0, nil, x11KeysymHome),
+			evdevCode: evdevKeyHome,
+			want:      "Home",
+		},
+		{
+			name:      "end",
+			got:       x11KeyFromLookup(0, nil, x11KeysymEnd),
+			evdevCode: evdevKeyEnd,
+			want:      "End",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if testCase.got != testCase.want {
+				t.Fatalf("x11KeyFromLookup() = %q, want %q", testCase.got, testCase.want)
+			}
+
+			if got := evdevKeyName(testCase.evdevCode); got != testCase.want {
+				t.Fatalf("evdevKeyName(%d) = %q, want %q",
+					testCase.evdevCode, got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/adapter/platform/windows/keys.go
+++ b/internal/adapter/platform/windows/keys.go
@@ -23,6 +23,10 @@ const (
 	vkReturn   = 0x0D
 	vkEscape   = 0x1B
 	vkSpace    = 0x20
+	vkPrior    = 0x21
+	vkNext     = 0x22
+	vkEnd      = 0x23
+	vkHome     = 0x24
 	vkLeft     = 0x25
 	vkUp       = 0x26
 	vkRight    = 0x27
@@ -134,6 +138,16 @@ func KeyNameFromVirtualKey(virtualKey uint32) string {
 		return "Up"
 	case vkDown:
 		return "Down"
+	// MapVirtualKey yields no character for the navigation keys, so this table
+	// is the only path that names them. The names match the Linux backends.
+	case vkPrior:
+		return "PageUp"
+	case vkNext:
+		return "PageDown"
+	case vkHome:
+		return "Home"
+	case vkEnd:
+		return "End"
 	case vkDelete:
 		return "Delete"
 	case vkLShift, vkRShift:
@@ -325,6 +339,14 @@ func nameToVirtualKey(name string) (uint32, bool) {
 		return vkUp, true
 	case "down":
 		return vkDown, true
+	case "pageup":
+		return vkPrior, true
+	case "pagedown":
+		return vkNext, true
+	case "home":
+		return vkHome, true
+	case "end":
+		return vkEnd, true
 	default:
 		if vk, ok := functionKeyVirtualKey(lowered); ok {
 			return vk, true

--- a/internal/adapter/platform/windows/keys_test.go
+++ b/internal/adapter/platform/windows/keys_test.go
@@ -97,6 +97,50 @@ func TestFunctionKeyRoundTrip(t *testing.T) {
 	}
 }
 
+// TestNavigationKeyRoundTrip pins the navigation keys on Windows. They are
+// documented as valid on every platform and the other backends emit them, so
+// the hook has to name them and a global hotkey has to register them rather
+// than fail with errUnsupportedHotkeyKey. MapVirtualKey yields no character for
+// these codes, so the explicit table is the only path that names them.
+func TestNavigationKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		virtualKey uint32
+		want       string
+	}{
+		{name: "page up", virtualKey: vkPrior, want: "PageUp"},
+		{name: "page down", virtualKey: vkNext, want: "PageDown"},
+		{name: "home", virtualKey: vkHome, want: "Home"},
+		{name: "end", virtualKey: vkEnd, want: "End"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := KeyNameFromVirtualKey(testCase.virtualKey); got != testCase.want {
+				t.Fatalf("KeyNameFromVirtualKey(%#x) = %q, want %q",
+					testCase.virtualKey, got, testCase.want)
+			}
+
+			// Config files and the CLI both accept lowercase spellings.
+			for _, spelling := range []string{testCase.want, strings.ToLower(testCase.want)} {
+				mods, virtualKey, err := ParseHotkeyString(spelling)
+				if err != nil {
+					t.Fatalf("ParseHotkeyString(%q) = %v, want no error", spelling, err)
+				}
+
+				if mods != 0 || virtualKey != testCase.virtualKey {
+					t.Fatalf("ParseHotkeyString(%q) = mods %#x vk %#x, want mods 0 vk %#x",
+						spelling, mods, virtualKey, testCase.virtualKey)
+				}
+			}
+		})
+	}
+}
+
 func TestFunctionKeyOutOfRange(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

This PR fixes the four navigation keys — `PageUp`, `PageDown`, `Home` and `End` — doing nothing under X11 and Windows. Configuration validation has always accepted them on every platform, and the evdev and Wayland backends have always emitted them, but the X11 tap dropped those key presses and the Windows keyboard hook never named them, so a binding on any of the four was silently dead. On Windows a global hotkey on one of them was rejected outright as an unsupported key.

Both backends now report the same spellings the rest of Neru already uses, and Windows registers global hotkeys on them. Nothing else about key handling changes: no new spelling was introduced, so an existing configuration keeps working exactly as written and simply starts firing on the platforms where it used to be ignored.

Deliberate limitation: this covers the two backends named in the issue. Under X11, a *global* hotkey (one that fires while no mode is active) on `PageUp` or `PageDown` still fails to register — that path resolves key names through a separate X11 lookup that does not know Neru's spelling, and is left for a follow-up.

## Related Issues

Closes #1371

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new capability is introduced; this closes a gap in two existing backends against a vocabulary the shared code already validates.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, `docs/CONFIGURATION.md` and `docs/CLI.md` already list these keys as valid everywhere with no platform caveat; this change makes those rows true rather than needing to change them.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Both backends were checked beyond a type-check: the Linux test suite was executed in the CI-equivalent container (CGO on, headless), and `just lint-cross` covers the linux and windows build tags. The Windows test is compiled locally and executed by the Windows CI leg.

The X11 test pins the keysym numbers as literals rather than naming them through cgo, because `go test` rejects cgo in an in-package test file. They are frozen X11 protocol constants, and pinning them is what makes the test able to disagree with the production lookup. The test also asserts the evdev backend answers the same name for the same key, so the two Linux taps cannot drift apart on a spelling.

Background on why one vocabulary being written in several places produced this class of silent failure: `docs/adr/0008-a-vocabulary-has-one-home.md`.
