### PR TITLE
fix(config): warn when a clickable role draws nothing on this platform

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1217,6 +1217,10 @@ Configuration is valid, with warnings:
 These parts of the configuration load and will not take effect.
 ```
 
+A clickable role that this platform's accessibility vocabulary has no name for
+— the shape a configuration written on another machine has — is reported the
+same way; see [Clickable roles](CONFIGURATION.md#clickable-roles).
+
 See [Global Hotkeys](CONFIGURATION.md#global-hotkeys) for which mistakes warn
 and which refuse the file.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -819,8 +819,11 @@ name resolves here, and `neru roles --explain` to see how your own config resolv
 | `color_well`   | `AXColorWell`          | `color chooser`                         | —                     |
 | `toolbar_button` | `AXToolbarButton` †  | —                                       | —                     |
 
-A `—` means the platform has no equivalent; that entry is ignored there and reported by
-`neru roles --explain` and `neru doctor`.
+A `—` means the platform has no equivalent; that entry is ignored there. `neru config
+validate` warns about one as soon as your `clickable_roles` differs from the shipped list
+— the shipped list itself stays silent, since it is one list for every platform — and
+`neru roles --explain` and `neru doctor` report it either way. An application's
+`additional_clickable_roles` are always your own, so those are always reported.
 
 † A subrole, not a role: AppKit reports these names in the element's *subrole* while the
 role stays generic — a search field is an `AXTextField` with subrole `AXSearchField`, a

--- a/internal/config/hintsvalidation_internal_test.go
+++ b/internal/config/hintsvalidation_internal_test.go
@@ -321,7 +321,7 @@ func TestValidateHints_AcceptsEverySearchInputPosition(t *testing.T) {
 			cfg := DefaultConfig()
 			cfg.Hints.SearchInputUI.Position = position
 
-			validateErr := cfg.ValidateHints()
+			validateErr := cfg.ValidateHints(nil)
 			if validateErr != nil {
 				t.Errorf("ValidateHints() = %v, want nil for position %q", validateErr, position)
 			}
@@ -346,7 +346,7 @@ func TestValidateHints_ReportsTheFirstProblem(t *testing.T) {
 			cfg := DefaultConfig()
 			testCase.breakIt(cfg)
 
-			validateErr := cfg.ValidateHints()
+			validateErr := cfg.ValidateHints(nil)
 
 			message := ""
 			if validateErr != nil {

--- a/internal/config/loader/load_roles_test.go
+++ b/internal/config/loader/load_roles_test.go
@@ -1,0 +1,82 @@
+package loader_test
+
+import (
+	"runtime"
+	"slices"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain/element"
+)
+
+// TestLoadWithValidation_ReportsARoleThisPlatformCannotExpress is the report a
+// user gets for the configuration this whole tier was built for: one written on
+// a machine whose accessibility vocabulary has a role, carried to one whose
+// vocabulary does not. The file loads, every other role keeps working, and the
+// dead entry rides out on the result so `neru config validate` says so instead
+// of "Configuration is valid" (#1376).
+//
+// The role has to be chosen per machine, and on macOS there is none to choose:
+// every mapping in the vocabulary carries an AX name, so the diagnostic cannot
+// arise there. What the pass reports on each platform is pinned without a
+// machine to run it on in internal/config.
+func TestLoadWithValidation_ReportsARoleThisPlatformCannotExpress(t *testing.T) {
+	role, exists := roleWithNoNativeEquivalentHere()
+	if !exists {
+		t.Skipf("every semantic role resolves on %s", runtime.GOOS)
+	}
+
+	result, _ := loadWithObservedLogger(t, `
+[hints]
+clickable_roles = ["button", "`+role+`"]
+`, "")
+
+	if result.ValidationError != nil {
+		t.Fatalf("a role that only fails to apply was refused: %v", result.ValidationError)
+	}
+
+	want := `hints.clickable_roles: "` + role + `" has no equivalent on ` +
+		runtime.GOOS + " and is ignored"
+	if !slices.Contains(result.Warnings, want) {
+		t.Errorf("result.Warnings = %q, want it to contain %q", result.Warnings, want)
+	}
+
+	// The entry the user wrote survives: a warning reports, it does not undo.
+	if !slices.Contains(result.Config.Hints.ClickableRoles, role) {
+		t.Errorf("hints.clickable_roles = %q, want it left as written",
+			result.Config.Hints.ClickableRoles)
+	}
+}
+
+// TestLoadWithValidation_LeavesTheShippedRolesSilent is the gate that keeps the
+// warning above from reaching everyone. The shipped role list is one list for
+// every platform and several of its roles have no Linux or Windows equivalent,
+// so a file that does not touch hints.clickable_roles must load without a word
+// about them on any machine.
+func TestLoadWithValidation_LeavesTheShippedRolesSilent(t *testing.T) {
+	result, _ := loadWithObservedLogger(t, `
+[hints.ui]
+font_size = 21
+`, "")
+
+	if result.ValidationError != nil {
+		t.Fatalf("a configuration on the shipped roles was refused: %v", result.ValidationError)
+	}
+
+	if len(result.Warnings) > 0 {
+		t.Errorf("result.Warnings = %q, want none for the roles neru ships", result.Warnings)
+	}
+}
+
+// roleWithNoNativeEquivalentHere returns the first semantic role that resolves
+// to nothing on the running platform, and false when every one of them
+// resolves.
+func roleWithNoNativeEquivalentHere() (string, bool) {
+	for _, mapping := range element.RoleVocabulary {
+		entry := string(mapping.Semantic)
+		if len(element.ResolveRolesForCurrentPlatform([]string{entry}).Native) == 0 {
+			return entry, true
+		}
+	}
+
+	return "", false
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -57,7 +57,7 @@ func (c *Config) ValidateWithWarnings(warnings *Warnings, written WrittenConfig)
 		return err
 	}
 
-	err = c.ValidateHints()
+	err = c.ValidateHints(warnings)
 	if err != nil {
 		return err
 	}

--- a/internal/config/validators_boundary_test.go
+++ b/internal/config/validators_boundary_test.go
@@ -34,13 +34,13 @@ func fontSizeBounds() []intBound {
 		{
 			name:     "hints.ui.font_size",
 			set:      func(c *config.Config, v int) { c.Hints.UI.FontSize = v },
-			validate: (*config.Config).ValidateHints,
+			validate: func(c *config.Config) error { return c.ValidateHints(nil) },
 			minValid: 1, maxValid: math.MaxInt32,
 		},
 		{
 			name:     "hints.search_input_ui.font_size",
 			set:      func(c *config.Config, v int) { c.Hints.SearchInputUI.FontSize = v },
-			validate: (*config.Config).ValidateHints,
+			validate: func(c *config.Config) error { return c.ValidateHints(nil) },
 			minValid: 1, maxValid: math.MaxInt32,
 		},
 		{
@@ -96,13 +96,13 @@ func visionIntBounds() []intBound {
 		{
 			name:     "hints.vision.request_timeout_ms",
 			set:      func(c *config.Config, v int) { c.Hints.Vision.RequestTimeoutMS = v },
-			validate: (*config.Config).ValidateHints,
+			validate: func(c *config.Config) error { return c.ValidateHints(nil) },
 			minValid: 1,
 		},
 		{
 			name:     "hints.vision.rectangle_max_candidates",
 			set:      func(c *config.Config, v int) { c.Hints.Vision.RectangleMaxCandidates = v },
-			validate: (*config.Config).ValidateHints,
+			validate: func(c *config.Config) error { return c.ValidateHints(nil) },
 			minValid: 1,
 		},
 	}
@@ -144,7 +144,7 @@ func assertConfigValid(t *testing.T, cfg *config.Config, what string) {
 	t.Helper()
 
 	validators := map[string]func(*config.Config) error{
-		"ValidateHints":           (*config.Config).ValidateHints,
+		"ValidateHints":           func(c *config.Config) error { return c.ValidateHints(nil) },
 		"ValidateGrid":            func(c *config.Config) error { return c.ValidateGrid(nil, config.WrittenConfig{}) },
 		"ValidateMonitorSelect":   (*config.Config).ValidateMonitorSelect,
 		"ValidateStickyModifiers": (*config.Config).ValidateStickyModifiers,
@@ -310,14 +310,14 @@ func TestConfig_UnitFloatBoundaries(t *testing.T) {
 			for _, value := range []float64{-0.001, -1, 1.001, 2} {
 				cfg := validBase(t)
 				bound.set(cfg, value)
-				assertRejected(t, cfg.ValidateHints(), bound.name, value)
+				assertRejected(t, cfg.ValidateHints(nil), bound.name, value)
 			}
 
 			// 1.0 is the inclusive upper bound for both variants.
 			cfg := validBase(t)
 			bound.set(cfg, 1)
 
-			err := cfg.ValidateHints()
+			err := cfg.ValidateHints(nil)
 			if err != nil {
 				t.Errorf("%s = 1 (the inclusive maximum) was rejected: %v", bound.name, err)
 			}
@@ -326,7 +326,7 @@ func TestConfig_UnitFloatBoundaries(t *testing.T) {
 			cfg = validBase(t)
 			bound.set(cfg, 0)
 
-			err = cfg.ValidateHints()
+			err = cfg.ValidateHints(nil)
 			if bound.inclusiveZero {
 				if err != nil {
 					t.Errorf("%s = 0 was rejected, but this field allows zero: %v", bound.name, err)
@@ -339,7 +339,7 @@ func TestConfig_UnitFloatBoundaries(t *testing.T) {
 			cfg = validBase(t)
 			bound.set(cfg, 0.5)
 
-			err = cfg.ValidateHints()
+			err = cfg.ValidateHints(nil)
 			if err != nil {
 				t.Errorf("%s = 0.5 was rejected: %v", bound.name, err)
 			}
@@ -385,28 +385,28 @@ func TestConfig_AspectPairBoundaries(t *testing.T) {
 			for _, value := range []float64{0, -0.5} {
 				cfg := validBase(t)
 				pair.setMin(cfg, value)
-				assertRejected(t, cfg.ValidateHints(), pair.name+" min", value)
+				assertRejected(t, cfg.ValidateHints(nil), pair.name+" min", value)
 			}
 
 			// A non-positive maximum is rejected.
 			for _, value := range []float64{0, -0.5} {
 				cfg := validBase(t)
 				pair.setMax(cfg, value)
-				assertRejected(t, cfg.ValidateHints(), pair.name+" max", value)
+				assertRejected(t, cfg.ValidateHints(nil), pair.name+" max", value)
 			}
 
 			// min > max is rejected even when both are positive.
 			cfg := validBase(t)
 			pair.setMin(cfg, 5)
 			pair.setMax(cfg, 2)
-			assertRejected(t, cfg.ValidateHints(), pair.name+" min>max", "5 > 2")
+			assertRejected(t, cfg.ValidateHints(nil), pair.name+" min>max", "5 > 2")
 
 			// min == max is the inclusive edge and must be accepted.
 			cfg = validBase(t)
 			pair.setMin(cfg, 2)
 			pair.setMax(cfg, 2)
 
-			err := cfg.ValidateHints()
+			err := cfg.ValidateHints(nil)
 			if err != nil {
 				t.Errorf("%s with min == max == 2 was rejected: %v", pair.name, err)
 			}
@@ -429,31 +429,31 @@ func visionSizeThresholds() []intBound {
 		{
 			name:     "hints.vision.button_icon_max_size",
 			set:      func(c *config.Config, v int) { c.Hints.Vision.ButtonIconMaxSize = v },
-			validate: (*config.Config).ValidateHints,
+			validate: func(c *config.Config) error { return c.ValidateHints(nil) },
 			minValid: 1,
 		},
 		{
 			name:     "hints.vision.link_max_height",
 			set:      func(c *config.Config, v int) { c.Hints.Vision.LinkMaxHeight = v },
-			validate: (*config.Config).ValidateHints,
+			validate: func(c *config.Config) error { return c.ValidateHints(nil) },
 			minValid: 1,
 		},
 		{
 			name:     "hints.vision.link_min_width",
 			set:      func(c *config.Config, v int) { c.Hints.Vision.LinkMinWidth = v },
-			validate: (*config.Config).ValidateHints,
+			validate: func(c *config.Config) error { return c.ValidateHints(nil) },
 			minValid: 1,
 		},
 		{
 			name:     "hints.vision.image_min_size",
 			set:      func(c *config.Config, v int) { c.Hints.Vision.ImageMinSize = v },
-			validate: (*config.Config).ValidateHints,
+			validate: func(c *config.Config) error { return c.ValidateHints(nil) },
 			minValid: 1,
 		},
 		{
 			name:     "hints.vision.checkbox_max_size",
 			set:      func(c *config.Config, v int) { c.Hints.Vision.CheckboxMaxSize = v },
-			validate: (*config.Config).ValidateHints,
+			validate: func(c *config.Config) error { return c.ValidateHints(nil) },
 			minValid: 1,
 		},
 	}
@@ -468,14 +468,14 @@ func TestConfig_VisionLinkMinAspectBoundary(t *testing.T) {
 	for _, value := range []float64{0, -0.1, -1} {
 		cfg := validBase(t)
 		cfg.Hints.Vision.LinkMinAspect = value
-		assertRejected(t, cfg.ValidateHints(), "hints.vision.link_min_aspect", value)
+		assertRejected(t, cfg.ValidateHints(nil), "hints.vision.link_min_aspect", value)
 	}
 
 	for _, value := range []float64{0.001, 1, 10} {
 		cfg := validBase(t)
 		cfg.Hints.Vision.LinkMinAspect = value
 
-		err := cfg.ValidateHints()
+		err := cfg.ValidateHints(nil)
 		if err != nil {
 			t.Errorf("hints.vision.link_min_aspect = %v was rejected: %v", value, err)
 		}
@@ -490,7 +490,7 @@ func TestConfig_VisionRequiresADetector(t *testing.T) {
 	cfg.Hints.Vision.DetectText = false
 	cfg.Hints.Vision.DetectRectangles = false
 
-	assertRejected(t, cfg.ValidateHints(), "hints.vision detectors", "both disabled")
+	assertRejected(t, cfg.ValidateHints(nil), "hints.vision detectors", "both disabled")
 
 	// Either one alone is enough.
 	for _, useText := range []bool{true, false} {
@@ -498,7 +498,7 @@ func TestConfig_VisionRequiresADetector(t *testing.T) {
 		cfg.Hints.Vision.DetectText = useText
 		cfg.Hints.Vision.DetectRectangles = !useText
 
-		err := cfg.ValidateHints()
+		err := cfg.ValidateHints(nil)
 		if err != nil {
 			t.Errorf("vision with detect_text=%t, detect_rectangles=%t was rejected: %v",
 				useText, !useText, err)

--- a/internal/config/validators_config_test.go
+++ b/internal/config/validators_config_test.go
@@ -174,28 +174,28 @@ func TestConfigValidateHints_DuplicateHintChars(t *testing.T) {
 
 	cfg.Hints.HintCharacters = "ab"
 
-	err := cfg.ValidateHints()
+	err := cfg.ValidateHints(nil)
 	if err != nil {
 		t.Fatalf("ValidateHints() unexpected error for unique chars: %v", err)
 	}
 
 	cfg.Hints.HintCharacters = "aab"
 
-	err = cfg.ValidateHints()
+	err = cfg.ValidateHints(nil)
 	if err == nil {
 		t.Fatal("ValidateHints() expected error for duplicate hint_characters")
 	}
 
 	cfg.Hints.HintCharacters = "aba"
 
-	err = cfg.ValidateHints()
+	err = cfg.ValidateHints(nil)
 	if err == nil {
 		t.Fatal("ValidateHints() expected error for duplicate hint_characters (non-adjacent)")
 	}
 
 	cfg.Hints.HintCharacters = "aA"
 
-	err = cfg.ValidateHints()
+	err = cfg.ValidateHints(nil)
 	if err == nil {
 		t.Fatal("ValidateHints() expected error for case-insensitive duplicate hint_characters")
 	}
@@ -206,14 +206,14 @@ func TestConfigValidateHints_AsciiHintChars(t *testing.T) {
 
 	cfg.Hints.HintCharacters = "ab"
 
-	err := cfg.ValidateHints()
+	err := cfg.ValidateHints(nil)
 	if err != nil {
 		t.Fatalf("ValidateHints() unexpected error: %v", err)
 	}
 
 	cfg.Hints.HintCharacters = "aé"
 
-	err = cfg.ValidateHints()
+	err = cfg.ValidateHints(nil)
 	if err == nil {
 		t.Fatal("ValidateHints() expected error for non-ASCII hint_characters")
 	}

--- a/internal/config/validators_hints.go
+++ b/internal/config/validators_hints.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"runtime"
 	"slices"
 	"strings"
@@ -11,12 +12,19 @@ import (
 	"github.com/y3owk1n/neru/internal/domain/element"
 )
 
-// The two places a clickable-role list is written. Both a refusal and a warning
-// name one of them, and a user matching a report to a line in their file is
-// what the names are for, so they are spelled once.
+// The places a clickable-role list is written, spelled once because a user
+// matching a report to the line in their file is what the names are for.
+//
+// A warning about an application's list carries the index, the way every other
+// app_configs diagnostic names one (validators_appconfig.go): a file with
+// several overrides otherwise reports every one of them under the same name and
+// leaves the user to find which. The refusal keeps the flat spelling it has
+// always had — that is a message users may have seen, and it is not what this
+// change is about.
 const (
-	fieldClickableRoles           = "hints.clickable_roles"
-	fieldAdditionalClickableRoles = "hints.app_configs.additional_clickable_roles"
+	fieldClickableRoles              = "hints.clickable_roles"
+	fieldAdditionalClickableRoles    = "hints.app_configs.additional_clickable_roles"
+	fieldAppAdditionalClickableRoles = "hints.app_configs[%d].additional_clickable_roles"
 )
 
 // validateClickableRoles rejects role entries that name neither a semantic role
@@ -75,10 +83,10 @@ func (c *Config) warnUnresolvableClickableRoles(warnings *Warnings, goos string)
 		warnUnresolvableRoles(warnings, fieldClickableRoles, c.Hints.ClickableRoles, goos)
 	}
 
-	for _, appConfig := range c.Hints.AppConfigs {
+	for idx, appConfig := range c.Hints.AppConfigs {
 		warnUnresolvableRoles(
 			warnings,
-			fieldAdditionalClickableRoles,
+			fmt.Sprintf(fieldAppAdditionalClickableRoles, idx),
 			appConfig.AdditionalClickable,
 			goos,
 		)

--- a/internal/config/validators_hints.go
+++ b/internal/config/validators_hints.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"runtime"
 	"slices"
 	"strings"
 	"unicode"
@@ -10,10 +11,19 @@ import (
 	"github.com/y3owk1n/neru/internal/domain/element"
 )
 
+// The two places a clickable-role list is written. Both a refusal and a warning
+// name one of them, and a user matching a report to a line in their file is
+// what the names are for, so they are spelled once.
+const (
+	fieldClickableRoles           = "hints.clickable_roles"
+	fieldAdditionalClickableRoles = "hints.app_configs.additional_clickable_roles"
+)
+
 // validateClickableRoles rejects role entries that name neither a semantic role
-// nor a native role in a known vocabulary. Entries that are well-formed but
-// belong to another platform are accepted silently here and reported by
-// `neru roles` / `neru doctor`, so one config can serve several machines.
+// nor a native role in a known vocabulary. Entries that are well-formed but do
+// not apply to this machine are not refused here, so one config can serve
+// several: those go to [Config.warnUnresolvableClickableRoles] or, for a native
+// entry addressed to another platform, to `neru roles` / `neru doctor`.
 func validateClickableRoles(field string, roles []string) error {
 	resolution := element.ResolveRolesForCurrentPlatform(roles)
 
@@ -30,17 +40,82 @@ func validateClickableRoles(field string, roles []string) error {
 	)
 }
 
+// warnUnresolvableClickableRoles reports the configured roles that name nothing
+// this platform's accessibility vocabulary can express, so `neru config
+// validate` stops calling a configuration valid when part of it draws no hints
+// at all (ADR 0002's tier, ADR 0008).
+//
+// Such an entry is not refused — a list written on a Mac and carried to a
+// Windows machine is the shape the semantic vocabulary exists to allow, and
+// refusing it would replace the user's whole configuration with the defaults
+// over a line that costs them one role. Entries addressed to another platform's
+// vocabulary ("atspi:push button" on macOS) stay silent for the same reason:
+// those are the other machine's lines and are expected to be there.
+//
+// The shipped list is exempt, and that gate is the point of this pass rather
+// than a detail of it. hints.clickable_roles ships one list for every platform
+// and several of its roles have no Linux or Windows counterpart, so reporting
+// them would greet every user of two platforms with a complaint about a file
+// they never wrote. A list that differs from the shipped one, on the other
+// hand, is a list the user wrote out in full — the option replaces rather than
+// merges — so every entry in it is a line they can go and edit.
+//
+// The blind spot the gate buys is a user who types the shipped list out
+// verbatim and is told nothing. That is the same trade #1281 named for the
+// derived grid labels: comparing against what the default would be is right for
+// the common case and knowingly wrong for the one person who wrote it by hand.
+// Unlike the labels there is no written configuration to ask instead — the
+// option's default is a list, not the blank that means "infer" — so the
+// comparison is the answer rather than a fallback.
+//
+// An application's extra roles are never shipped, so there is nothing to
+// compare a list of those against: every entry in one is the user's own.
+func (c *Config) warnUnresolvableClickableRoles(warnings *Warnings, goos string) {
+	if !clickableRolesAreShipped(c.Hints.ClickableRoles) {
+		warnUnresolvableRoles(warnings, fieldClickableRoles, c.Hints.ClickableRoles, goos)
+	}
+
+	for _, appConfig := range c.Hints.AppConfigs {
+		warnUnresolvableRoles(
+			warnings,
+			fieldAdditionalClickableRoles,
+			appConfig.AdditionalClickable,
+			goos,
+		)
+	}
+}
+
+// clickableRolesAreShipped reports whether a role list is the one neru ships,
+// which is the list a user who has never touched the option is running.
+func clickableRolesAreShipped(roles []string) bool {
+	return slices.Equal(roles, DefaultConfig().Hints.ClickableRoles)
+}
+
+// warnUnresolvableRoles reports the entries of one role list that this
+// platform's vocabulary has no name for, one warning each so a list with two
+// dead entries does not hide one behind the other.
+func warnUnresolvableRoles(warnings *Warnings, field string, roles []string, goos string) {
+	for _, diagnostic := range element.ResolveRoles(roles, goos).Diagnostics {
+		if diagnostic.Kind != element.RoleDiagnosticNoNativeEquivalent {
+			continue
+		}
+
+		warnings.Addf("%s: %s", field, diagnostic.Message())
+	}
+}
+
 // ValidateHints checks the hints configuration, reporting the first problem it
-// finds.
+// finds and collecting, into warnings, the parts of it that load and will draw
+// no hints. A nil sink discards them; see [Warnings].
 //
 // The order the checks run in is the order a user sees their mistakes, so it is
 // listed here rather than left implicit in one long body. It is also why the
 // search-input checks come in two parts with the boundary-highlight checks
 // between them: that is where they have always run, and moving them would change
 // which problem a config with several is told about first.
-func (c *Config) ValidateHints() error {
+func (c *Config) ValidateHints(warnings *Warnings) error {
 	checks := []func() error{
-		c.validateHintClickableRoles,
+		func() error { return c.validateHintClickableRoles(warnings) },
 		c.validateHintCharacters,
 		c.validateHintColors,
 		c.validateHintLabelUI,
@@ -65,26 +140,32 @@ func (c *Config) ValidateHints() error {
 
 // validateHintClickableRoles checks the roles hints are drawn for, including the
 // extra roles an individual application adds.
-func (c *Config) validateHintClickableRoles() error {
+//
+// The refusals run first and to the end: an entry naming no role at all is the
+// whole file's problem, and a configuration that is going to be replaced by the
+// defaults has nothing to be advised about.
+func (c *Config) validateHintClickableRoles(warnings *Warnings) error {
 	if c.Hints.Enabled && len(c.Hints.ClickableRoles) == 0 {
 		return derrors.New(derrors.CodeInvalidConfig,
 			"hints.clickable_roles cannot be empty when hints are enabled")
 	}
 
-	rolesErr := validateClickableRoles("hints.clickable_roles", c.Hints.ClickableRoles)
+	rolesErr := validateClickableRoles(fieldClickableRoles, c.Hints.ClickableRoles)
 	if rolesErr != nil {
 		return rolesErr
 	}
 
 	for _, appConfig := range c.Hints.AppConfigs {
 		appRolesErr := validateClickableRoles(
-			"hints.app_configs.additional_clickable_roles",
+			fieldAdditionalClickableRoles,
 			appConfig.AdditionalClickable,
 		)
 		if appRolesErr != nil {
 			return appRolesErr
 		}
 	}
+
+	c.warnUnresolvableClickableRoles(warnings, runtime.GOOS)
 
 	return nil
 }

--- a/internal/config/validators_hints_roles_internal_test.go
+++ b/internal/config/validators_hints_roles_internal_test.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"slices"
+	"testing"
+)
+
+// The platform a role list is judged against is an argument to the pass rather
+// than something a test can arrange, so these run against the unexported form
+// that takes one. The alternative is a suite that can only assert this
+// behavior on the two platforms where it happens — a semantic role with no
+// native equivalent cannot exist on macOS, where every mapping carries an AX
+// name — which would leave the primary platform's CI blind to it.
+const (
+	goosDarwin  = "darwin"
+	goosLinux   = "linux"
+	goosWindows = "windows"
+)
+
+// A role every platform can express, as the company an unresolvable one keeps:
+// a list is only reported entry by entry if the rest of it survives.
+const testRoleButton = "button"
+
+// TestConfig_WarnUnresolvableClickableRoles_NamesEntriesThatResolveToNothing
+// pins what a user is told about a role that this platform's accessibility
+// vocabulary has no counterpart for: the entry is named, and so is the field it
+// was written in.
+func TestConfig_WarnUnresolvableClickableRoles_NamesEntriesThatResolveToNothing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		goos  string
+		roles []string
+		want  []string
+	}{
+		{
+			// AT-SPI has no disclosure triangle; the other two resolve.
+			name:  "a role AT-SPI cannot express",
+			goos:  goosLinux,
+			roles: []string{testRoleButton, "disclosure", "link"},
+			want: []string{
+				`hints.clickable_roles: "disclosure" has no equivalent on linux and is ignored`,
+			},
+		},
+		{
+			// UI Automation has neither, and each is reported on its own so a
+			// list with two mistakes does not hide one behind the other.
+			name:  "two roles UI Automation cannot express",
+			goos:  goosWindows,
+			roles: []string{"menu_button", testRoleButton, "switch"},
+			want: []string{
+				`hints.clickable_roles: "menu_button" has no equivalent on windows and is ignored`,
+				`hints.clickable_roles: "switch" has no equivalent on windows and is ignored`,
+			},
+		},
+		{
+			name:  "roles this platform can express",
+			goos:  goosLinux,
+			roles: []string{testRoleButton, "link", "text_field"},
+			want:  nil,
+		},
+		{
+			// A native entry addressed to another platform is how one
+			// configuration serves several machines, and stays silent on
+			// purpose: it is not a mistake, it is the other machine's line.
+			name:  "a native entry belonging to another platform",
+			goos:  goosDarwin,
+			roles: []string{testRoleButton, "atspi:push button", "uia:Button"},
+			want:  nil,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := DefaultConfig()
+			cfg.Hints.ClickableRoles = testCase.roles
+
+			warnings := &Warnings{}
+			cfg.warnUnresolvableClickableRoles(warnings, testCase.goos)
+
+			if got := warnings.Messages(); !slices.Equal(got, testCase.want) {
+				t.Errorf("warnings = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestConfig_WarnUnresolvableClickableRoles_LeavesTheShippedListAlone is the
+// gate the whole pass hangs on. The roles neru ships are one list for every
+// platform, and some of them resolve to nothing on Linux and Windows — warning
+// about those would greet every user of two platforms with a complaint about a
+// file they have not written a line of.
+func TestConfig_WarnUnresolvableClickableRoles_LeavesTheShippedListAlone(t *testing.T) {
+	t.Parallel()
+
+	for _, goos := range []string{goosDarwin, goosLinux, goosWindows} {
+		t.Run(goos, func(t *testing.T) {
+			t.Parallel()
+
+			warnings := &Warnings{}
+			DefaultConfig().warnUnresolvableClickableRoles(warnings, goos)
+
+			if got := warnings.Messages(); len(got) > 0 {
+				t.Errorf("warnings = %q, want none for the shipped roles", got)
+			}
+		})
+	}
+}
+
+// TestConfig_WarnUnresolvableClickableRoles_ReadsAnApplicationsExtraRoles pins
+// the other place a role list is written. An application's extra roles are
+// never shipped, so every entry in one is the user's own and there is nothing
+// to compare against.
+func TestConfig_WarnUnresolvableClickableRoles_ReadsAnApplicationsExtraRoles(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.Hints.AppConfigs = []AppConfig{{
+		BundleID:            "com.apple.Safari",
+		AdditionalClickable: []string{testRoleButton, "toolbar_button"},
+	}}
+
+	warnings := &Warnings{}
+	cfg.warnUnresolvableClickableRoles(warnings, goosLinux)
+
+	want := []string{
+		`hints.app_configs.additional_clickable_roles: ` +
+			`"toolbar_button" has no equivalent on linux and is ignored`,
+	}
+	if got := warnings.Messages(); !slices.Equal(got, want) {
+		t.Errorf("warnings = %q, want %q", got, want)
+	}
+}

--- a/internal/config/validators_hints_roles_internal_test.go
+++ b/internal/config/validators_hints_roles_internal_test.go
@@ -113,22 +113,32 @@ func TestConfig_WarnUnresolvableClickableRoles_LeavesTheShippedListAlone(t *test
 // TestConfig_WarnUnresolvableClickableRoles_ReadsAnApplicationsExtraRoles pins
 // the other place a role list is written. An application's extra roles are
 // never shipped, so every entry in one is the user's own and there is nothing
-// to compare against.
+// to compare against — and each list is named with its index, so a file with
+// several overrides says which one to go and edit rather than reporting them
+// all under one name.
 func TestConfig_WarnUnresolvableClickableRoles_ReadsAnApplicationsExtraRoles(t *testing.T) {
 	t.Parallel()
 
 	cfg := DefaultConfig()
-	cfg.Hints.AppConfigs = []AppConfig{{
-		BundleID:            "com.apple.Safari",
-		AdditionalClickable: []string{testRoleButton, "toolbar_button"},
-	}}
+	cfg.Hints.AppConfigs = []AppConfig{
+		{
+			BundleID:            "com.apple.Safari",
+			AdditionalClickable: []string{testRoleButton, "toolbar_button"},
+		},
+		{
+			BundleID:            "com.apple.Terminal",
+			AdditionalClickable: []string{"disclosure"},
+		},
+	}
 
 	warnings := &Warnings{}
 	cfg.warnUnresolvableClickableRoles(warnings, goosLinux)
 
 	want := []string{
-		`hints.app_configs.additional_clickable_roles: ` +
+		`hints.app_configs[0].additional_clickable_roles: ` +
 			`"toolbar_button" has no equivalent on linux and is ignored`,
+		`hints.app_configs[1].additional_clickable_roles: ` +
+			`"disclosure" has no equivalent on linux and is ignored`,
 	}
 	if got := warnings.Messages(); !slices.Equal(got, want) {
 		t.Errorf("warnings = %q, want %q", got, want)

--- a/internal/config/validators_hints_roles_test.go
+++ b/internal/config/validators_hints_roles_test.go
@@ -69,7 +69,7 @@ func TestValidateWithWarnings_ReportsAnApplicationRoleThisPlatformCannotExpress(
 	}
 
 	want := []string{
-		`hints.app_configs.additional_clickable_roles: "` + role +
+		`hints.app_configs[0].additional_clickable_roles: "` + role +
 			`" has no equivalent on ` + runtime.GOOS + " and is ignored",
 	}
 	if got := warnings.Messages(); !slices.Equal(got, want) {

--- a/internal/config/validators_hints_roles_test.go
+++ b/internal/config/validators_hints_roles_test.go
@@ -1,0 +1,146 @@
+package config_test
+
+import (
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/domain/element"
+)
+
+// TestValidateWithWarnings_ReportsARoleThisPlatformCannotExpress is the whole
+// path a user sees: a role written in the file, a configuration that still
+// loads, and a warning riding out on the sink `neru config validate` prints
+// from. Which role that is depends on the machine, and on macOS there is none
+// — every mapping carries an AX name — which is why the pass itself is pinned
+// per platform in the package's own tests.
+func TestValidateWithWarnings_ReportsARoleThisPlatformCannotExpress(t *testing.T) {
+	t.Parallel()
+
+	role, exists := roleWithNoNativeEquivalentHere()
+	if !exists {
+		t.Skipf("every semantic role resolves on %s", runtime.GOOS)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Hints.ClickableRoles = []string{TestRoleButton, role}
+
+	warnings := &config.Warnings{}
+
+	err := cfg.ValidateWithWarnings(warnings, config.WrittenConfig{})
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() refused a role that only fails to apply: %v", err)
+	}
+
+	want := []string{
+		`hints.clickable_roles: "` + role + `" has no equivalent on ` + runtime.GOOS +
+			" and is ignored",
+	}
+	if got := warnings.Messages(); !slices.Equal(got, want) {
+		t.Errorf("warnings = %q, want %q", got, want)
+	}
+}
+
+// TestValidateWithWarnings_ReportsAnApplicationRoleThisPlatformCannotExpress
+// pins the same for the roles an individual application adds, which is the
+// other half of the surface and the one a configuration copied between machines
+// most often carries.
+func TestValidateWithWarnings_ReportsAnApplicationRoleThisPlatformCannotExpress(t *testing.T) {
+	t.Parallel()
+
+	role, exists := roleWithNoNativeEquivalentHere()
+	if !exists {
+		t.Skipf("every semantic role resolves on %s", runtime.GOOS)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Hints.AppConfigs = []config.AppConfig{{
+		BundleID:            bundleExample,
+		AdditionalClickable: []string{role},
+	}}
+
+	warnings := &config.Warnings{}
+
+	err := cfg.ValidateWithWarnings(warnings, config.WrittenConfig{})
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() refused a role that only fails to apply: %v", err)
+	}
+
+	want := []string{
+		`hints.app_configs.additional_clickable_roles: "` + role +
+			`" has no equivalent on ` + runtime.GOOS + " and is ignored",
+	}
+	if got := warnings.Messages(); !slices.Equal(got, want) {
+		t.Errorf("warnings = %q, want %q", got, want)
+	}
+}
+
+// TestValidateWithWarnings_LeavesRolesThisPlatformCanExpressSilent pins the
+// other half of the report: a user who has rewritten both role lists, and whose
+// every entry resolves, is told nothing. A warning tier that also fires on
+// configurations with nothing wrong with them teaches people to ignore it.
+func TestValidateWithWarnings_LeavesRolesThisPlatformCanExpressSilent(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultConfig()
+	cfg.Hints.ClickableRoles = []string{TestRoleButton, TestRoleLink}
+	cfg.Hints.AppConfigs = []config.AppConfig{{
+		BundleID:            bundleExample,
+		AdditionalClickable: []string{TestRoleTextField},
+	}}
+
+	warnings := &config.Warnings{}
+
+	err := cfg.ValidateWithWarnings(warnings, config.WrittenConfig{})
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() refused a resolvable configuration: %v", err)
+	}
+
+	if got := warnings.Messages(); len(got) > 0 {
+		t.Errorf("warnings = %q, want none", got)
+	}
+}
+
+// TestValidateWithWarnings_KeepsRefusingAnUnknownRole pins the tier line: an
+// entry naming no role at all is still the whole file's problem, and a refusal
+// says nothing on the side. Warnings describe the configuration that loaded,
+// and this one did not.
+func TestValidateWithWarnings_KeepsRefusingAnUnknownRole(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultConfig()
+	cfg.Hints.ClickableRoles = []string{TestRoleButton, "AXButton"}
+
+	warnings := &config.Warnings{}
+
+	err := cfg.ValidateWithWarnings(warnings, config.WrittenConfig{})
+	if err == nil {
+		t.Fatal("ValidateWithWarnings() accepted a role name nothing recognizes")
+	}
+
+	if got := err.Error(); !strings.Contains(got, `unknown role "AXButton"`) {
+		t.Errorf("error = %q, want it to name the unknown role", got)
+	}
+
+	if got := warnings.Messages(); len(got) > 0 {
+		t.Errorf("warnings = %q, want none alongside a refusal", got)
+	}
+}
+
+// roleWithNoNativeEquivalentHere returns the first semantic role that resolves
+// to nothing on the running platform, and false when every one of them
+// resolves. It reads the vocabulary rather than naming a role, so a mapping
+// that gains a native name stops being this test's example instead of failing
+// it for the wrong reason.
+func roleWithNoNativeEquivalentHere() (string, bool) {
+	for _, mapping := range element.RoleVocabulary {
+		entry := string(mapping.Semantic)
+		if len(element.ResolveRolesForCurrentPlatform([]string{entry}).Native) == 0 {
+			return entry, true
+		}
+	}
+
+	return "", false
+}

--- a/internal/config/validators_hints_test.go
+++ b/internal/config/validators_hints_test.go
@@ -17,7 +17,7 @@ func TestValidateHints_EnabledRequiresClickableRoles(t *testing.T) {
 	cfg.Hints.Enabled = true
 	cfg.Hints.ClickableRoles = nil
 
-	err := cfg.ValidateHints()
+	err := cfg.ValidateHints(nil)
 	if err == nil {
 		t.Fatal("ValidateHints() expected error when enabled and clickable_roles is empty")
 	}
@@ -27,7 +27,7 @@ func TestValidateHints_BoundaryHighlightGeometry(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Hints.BoundaryHighlight.BorderWidth = -1
 
-	err := cfg.ValidateHints()
+	err := cfg.ValidateHints(nil)
 	if err == nil {
 		t.Fatal("ValidateHints() expected error for negative boundary border width")
 	}
@@ -35,7 +35,7 @@ func TestValidateHints_BoundaryHighlightGeometry(t *testing.T) {
 	cfg = config.DefaultConfig()
 	cfg.Hints.BoundaryHighlight.BorderRadius = -1
 
-	err = cfg.ValidateHints()
+	err = cfg.ValidateHints(nil)
 	if err != nil {
 		t.Fatalf("ValidateHints() expected no error for -1 (auto) border radius, got %v", err)
 	}
@@ -52,7 +52,7 @@ func TestValidateHints_UIPlacement(t *testing.T) {
 		cfg := config.DefaultConfig()
 		cfg.Hints.UI.Placement = placement
 
-		err := cfg.ValidateHints()
+		err := cfg.ValidateHints(nil)
 		if err != nil {
 			t.Fatalf("ValidateHints() expected placement %q to be valid, got %v", placement, err)
 		}
@@ -62,7 +62,7 @@ func TestValidateHints_UIPlacement(t *testing.T) {
 
 	cfg.Hints.UI.Placement = "floating"
 
-	err := cfg.ValidateHints()
+	err := cfg.ValidateHints(nil)
 	if err == nil {
 		t.Fatal("ValidateHints() expected error for invalid hints.ui.placement")
 	}
@@ -73,7 +73,7 @@ func TestValidateHints_PositiveUnitFloat(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Hints.Vision.MergeIOUThreshold = 0.0
 
-	err := cfg.ValidateHints()
+	err := cfg.ValidateHints(nil)
 	if err == nil {
 		t.Fatal("ValidateHints() expected error for 0.0 merge_iou_threshold")
 	}
@@ -82,7 +82,7 @@ func TestValidateHints_PositiveUnitFloat(t *testing.T) {
 	cfg = config.DefaultConfig()
 	cfg.Hints.Vision.ButtonMinConfidence = 0.0
 
-	err = cfg.ValidateHints()
+	err = cfg.ValidateHints(nil)
 	if err == nil {
 		t.Fatal("ValidateHints() expected error for 0.0 button_min_confidence")
 	}
@@ -91,7 +91,7 @@ func TestValidateHints_PositiveUnitFloat(t *testing.T) {
 	cfg = config.DefaultConfig()
 	cfg.Hints.Vision.GenericClickableMinConfidence = 0.0
 
-	err = cfg.ValidateHints()
+	err = cfg.ValidateHints(nil)
 	if err == nil {
 		t.Fatal("ValidateHints() expected error for 0.0 generic_clickable_min_confidence")
 	}
@@ -100,7 +100,7 @@ func TestValidateHints_PositiveUnitFloat(t *testing.T) {
 	cfg = config.DefaultConfig()
 	cfg.Hints.Vision.MinimumConfidence = 0.0
 
-	err = cfg.ValidateHints()
+	err = cfg.ValidateHints(nil)
 	if err != nil {
 		t.Fatalf("ValidateHints() expected no error for 0.0 minimum_confidence, got %v", err)
 	}
@@ -124,7 +124,7 @@ func TestValidateHints_LabelDirection(t *testing.T) {
 			cfg := config.DefaultConfig()
 			cfg.Hints.LabelDirection = testCase.direction
 
-			err := cfg.ValidateHints()
+			err := cfg.ValidateHints(nil)
 			if testCase.wantErr && err == nil {
 				t.Fatalf(
 					"ValidateHints() expected error for label_direction=%q, got nil",


### PR DESCRIPTION
## Description

This PR fixes `neru config validate` reporting "Configuration is valid" for a
configuration that asks for hints on a control this machine cannot recognise.
Six of the semantic role names have no counterpart in one of the native
accessibility vocabularies, so a role list written on a Mac and carried to a
Linux or Windows machine could contain entries that produce no hints at all —
rightly not refused, but the reason never left the debug log and the answer
lived only in `neru roles --explain`.

Such an entry is now reported as a configuration warning: the command names the
entry and the setting it was written in, prints it under "Configuration is
valid, with warnings", and still exits 0. Nothing is refused that was not
refused before, and a configuration whose roles all resolve stays silent.

The deliberate limitation: the report starts once your role list differs from
the one neru ships. The shipped list is one list for every platform and some of
its roles have no Linux or Windows equivalent, so reporting those would greet
users who never touched the option with a complaint about a file they never
wrote. A user who types the shipped list out by hand is therefore told nothing.

## Related Issues

Closes #1376

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `fix` — Bug fix

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no OS-specific files
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port involved
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Configuration surface

No option is added, renamed or removed, and no default changes. Two existing
settings gain a warning:

| Setting | When it warns |
| --- | --- |
| `hints.clickable_roles` | your list differs from the shipped default and one of its entries has no equivalent on this platform |
| `hints.app_configs[N].additional_clickable_roles` | any entry has no equivalent on this platform; the warning carries the application's index |

Every configuration that loaded before still loads, unchanged. On a Linux
machine, for example:

```toml
[hints]
clickable_roles = ["button", "link", "disclosure"]
```

```
Configuration is valid, with warnings:

  hints.clickable_roles: "disclosure" has no equivalent on linux and is ignored

These parts of the configuration load and will not take effect.
```

A native entry addressed to another platform (`atspi:push button` on macOS)
stays silent as before — that is how one file serves several machines.

## Additional Context

- The severity is ADR 0002's: an entry like this costs the user one role, and
  refusing it would replace their whole configuration with the defaults. The
  warning rides out on the load result rather than going to `logger.Warn`,
  which is the bypass ADR 0006 recorded as making the tier meaningless.
- The exemption for the shipped list is the same trade #1281 named for the
  derived grid labels: comparing against what the default would be is right for
  the common case and knowingly wrong for the person who wrote the default out
  by hand. Unlike the labels there is no written configuration to consult
  instead, since the option's default is a list rather than a blank meaning
  "infer" — that reasoning sits in a comment where the comparison happens.
- That the shipped roles contain entries resolving to nothing on Linux and
  Windows at all is deliberately left alone here; this PR only stops the report
  from being silent.
- The diagnostic cannot arise on macOS — every mapping in the vocabulary
  carries an AX name — so the end-to-end tests that need a dead role skip
  there, and what the pass reports on each platform is pinned per platform,
  without a machine to run it on, in `internal/config`.
