### PR TITLE
fix(config): name the application whose clickable role is rejected

### DIFF
--- a/internal/config/validators_hints.go
+++ b/internal/config/validators_hints.go
@@ -15,15 +15,12 @@ import (
 // The places a clickable-role list is written, spelled once because a user
 // matching a report to the line in their file is what the names are for.
 //
-// A warning about an application's list carries the index, the way every other
-// app_configs diagnostic names one (validators_appconfig.go): a file with
-// several overrides otherwise reports every one of them under the same name and
-// leaves the user to find which. The refusal keeps the flat spelling it has
-// always had — that is a message users may have seen, and it is not what this
-// change is about.
+// Both tiers of a report about an application's list carry the index, the way
+// every other app_configs diagnostic names one (validators_appconfig.go): a
+// file with several overrides otherwise reports every one of them under the
+// same name and leaves the user to find which.
 const (
 	fieldClickableRoles              = "hints.clickable_roles"
-	fieldAdditionalClickableRoles    = "hints.app_configs.additional_clickable_roles"
 	fieldAppAdditionalClickableRoles = "hints.app_configs[%d].additional_clickable_roles"
 )
 
@@ -163,9 +160,9 @@ func (c *Config) validateHintClickableRoles(warnings *Warnings) error {
 		return rolesErr
 	}
 
-	for _, appConfig := range c.Hints.AppConfigs {
+	for idx, appConfig := range c.Hints.AppConfigs {
 		appRolesErr := validateClickableRoles(
-			fieldAdditionalClickableRoles,
+			fmt.Sprintf(fieldAppAdditionalClickableRoles, idx),
 			appConfig.AdditionalClickable,
 		)
 		if appRolesErr != nil {

--- a/internal/config/validators_hints_roles_test.go
+++ b/internal/config/validators_hints_roles_test.go
@@ -129,6 +129,37 @@ func TestValidateWithWarnings_KeepsRefusingAnUnknownRole(t *testing.T) {
 	}
 }
 
+// TestValidateWithWarnings_NamesTheApplicationWhoseRoleIsUnknown pins the
+// refusal's half of the same question the warning above answers: which of a
+// file's overrides to go and edit. Two of them are configured and the second is
+// the one at fault, so a message that named the field without the index — or
+// named the first one — fails here.
+func TestValidateWithWarnings_NamesTheApplicationWhoseRoleIsUnknown(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultConfig()
+	cfg.Hints.AppConfigs = []config.AppConfig{
+		{
+			BundleID:            bundleExample,
+			AdditionalClickable: []string{TestRoleTextField},
+		},
+		{
+			BundleID:            bundleOther,
+			AdditionalClickable: []string{"AXButton"},
+		},
+	}
+
+	err := cfg.ValidateWithWarnings(&config.Warnings{}, config.WrittenConfig{})
+	if err == nil {
+		t.Fatal("ValidateWithWarnings() accepted a role name nothing recognizes")
+	}
+
+	want := `hints.app_configs[1].additional_clickable_roles: unknown role "AXButton"`
+	if got := err.Error(); !strings.Contains(got, want) {
+		t.Errorf("error = %q, want it to contain %q", got, want)
+	}
+}
+
 // roleWithNoNativeEquivalentHere returns the first semantic role that resolves
 // to nothing on the running platform, and false when every one of them
 // resolves. It reads the vocabulary rather than naming a role, so a mapping

--- a/internal/config/validators_hints_test.go
+++ b/internal/config/validators_hints_test.go
@@ -10,6 +10,7 @@ const (
 	dirNormal     = "normal"
 	dirReverse    = "reverse"
 	bundleExample = "com.example"
+	bundleOther   = "com.example.other"
 )
 
 func TestValidateHints_EnabledRequiresClickableRoles(t *testing.T) {


### PR DESCRIPTION
## Description

This PR fixes an error message that told a user one of their per-application
role lists was wrong without saying which one. A config with several
application overrides reported every unknown role under the same flat field
name, so the only way to find the offending block was to try them one at a
time.

The refusal now names the application by its position in the file, the same
way the warning printed beside it and every other per-application diagnostic
already do. The message for the top-level role list is unchanged, and nothing
that loaded before loads differently — only the wording of a refusal changes.

## Related Issues

Closes #1386

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no tagged files touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or adapter involved
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no reference doc quotes this message
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Diagnostic Output

No config option, command or flag changes. The only user-visible change is the
field name in one refusal, for a config that is already being rejected:

Before:

```
hints.app_configs.additional_clickable_roles: unknown role "AXButton": use "button"
```

After:

```
hints.app_configs[1].additional_clickable_roles: unknown role "AXButton": use "button"
```

Anyone grepping logs for the old flat spelling would stop matching, which is
the extent of the breakage — the configs that produce it were already being
refused.

## Additional Context

The warning tier learned the index in #1383, which deliberately left the
refusal beside it alone as pre-existing user-visible output. Two tiers of one
validator disagreeing about how to address the same field is worse than either
convention on its own, so this closes the gap rather than reverting the other
half.

The refusal still stops at the first bad list, unlike the warning pass which
reports every one — that asymmetry is the documented shape of `ValidateHints`
(a configuration about to be replaced by the defaults has nothing to be
advised about) and is left as it is.
