### PR TITLE
fix: stop warning about a logger flush that never could succeed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tc-hib/go-winres v0.3.3
 	go.uber.org/goleak v1.3.0
+	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
@@ -32,7 +33,6 @@ require (
 	github.com/tc-hib/winres v0.3.1 // indirect
 	github.com/urfave/cli/v2 v2.27.7 // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/image v0.43.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/internal/adapter/logger/logger.go
+++ b/internal/adapter/logger/logger.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"go.uber.org/zap"
@@ -196,16 +195,9 @@ func Sync() error {
 	defer logFileMu.RUnlock()
 
 	if globalLogger != nil {
-		err := globalLogger.Sync()
+		err := genuineSyncFailure(globalLogger.Sync())
 		if err != nil {
-			// Ignore common sync errors that occur when stdout/stderr is a
-			// pipe or terminal:
-			//   - "invalid argument" (EINVAL on Linux)
-			//   - "inappropriate ioctl for device" (ENOTSUP on macOS)
-			if !strings.Contains(err.Error(), "invalid argument") &&
-				!strings.Contains(err.Error(), "inappropriate ioctl for device") {
-				return derrors.Wrap(err, derrors.CodeLoggingFailed, "failed to sync logger")
-			}
+			return derrors.Wrap(err, derrors.CodeLoggingFailed, "failed to sync logger")
 		}
 	}
 
@@ -219,13 +211,9 @@ func Close() error {
 	defer logFileMu.Unlock()
 
 	if globalLogger != nil {
-		err := globalLogger.Sync()
+		err := genuineSyncFailure(globalLogger.Sync())
 		if err != nil {
-			// Ignore common sync errors that occur during shutdown
-			if !strings.Contains(err.Error(), "invalid argument") &&
-				!strings.Contains(err.Error(), "inappropriate ioctl for device") {
-				return derrors.Wrap(err, derrors.CodeLoggingFailed, "failed to sync logger")
-			}
+			return derrors.Wrap(err, derrors.CodeLoggingFailed, "failed to sync logger")
 		}
 
 		globalLogger = nil

--- a/internal/adapter/logger/logger_test.go
+++ b/internal/adapter/logger/logger_test.go
@@ -145,10 +145,23 @@ func (w syncStubWriter) Write(p []byte) (int, error) { return len(p), nil }
 func (w syncStubWriter) Sync() error { return w.syncErr }
 
 // stdStreamSyncErr is what os.Stderr.Sync() returns when stderr is a pipe
-// rather than a syncable device — the zap-on-stderr caveat that floods test
-// teardown with warnings.
+// rather than a flushable destination — the zap-on-stderr caveat that floods
+// test teardown with warnings.
 func stdStreamSyncErr(errno syscall.Errno) error {
-	return &fs.PathError{Op: "sync", Path: "/dev/stderr", Err: errno}
+	return &fs.PathError{Op: "sync", Path: os.Stderr.Name(), Err: errno}
+}
+
+// requirePipedStderr skips a test whose premise is that this binary's stderr
+// cannot be flushed. That holds for the pipe or terminal a test run normally
+// has; a run redirected straight to a file is the case where such a failure is
+// real and reported, so there is nothing to assert here.
+func requirePipedStderr(t *testing.T) {
+	t.Helper()
+
+	info, err := os.Stderr.Stat()
+	if err == nil && info.Mode().IsRegular() {
+		t.Skip("stderr is redirected to a regular file, so a failed flush of it is a real failure")
+	}
 }
 
 func TestSyncAndClose_IgnoreStandardStreamSyncFailure(t *testing.T) {
@@ -163,6 +176,8 @@ func TestSyncAndClose_IgnoreStandardStreamSyncFailure(t *testing.T) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
+			requirePipedStderr(t)
+
 			logger.Reset()
 			t.Cleanup(logger.Reset)
 

--- a/internal/adapter/logger/logger_test.go
+++ b/internal/adapter/logger/logger_test.go
@@ -2,9 +2,13 @@ package logger_test
 
 import (
 	"bytes"
+	"errors"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 
 	"go.uber.org/zap"
@@ -123,6 +127,127 @@ func TestWith(t *testing.T) {
 	childLogger := logger.With(zap.String("component", "test"))
 	if childLogger == nil {
 		t.Error("With() returned nil")
+	}
+}
+
+// errSinkFailed stands in for a sink that genuinely failed to flush.
+var errSinkFailed = errors.New("sink failed to flush")
+
+// syncStubWriter is a console sink whose Sync always fails with syncErr. It
+// implements zapcore.WriteSyncer, so Init installs it verbatim and the failure
+// surfaces through the package's own Sync/Close.
+type syncStubWriter struct {
+	syncErr error
+}
+
+func (w syncStubWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func (w syncStubWriter) Sync() error { return w.syncErr }
+
+// stdStreamSyncErr is what os.Stderr.Sync() returns when stderr is a pipe
+// rather than a syncable device — the zap-on-stderr caveat that floods test
+// teardown with warnings.
+func stdStreamSyncErr(errno syscall.Errno) error {
+	return &fs.PathError{Op: "sync", Path: "/dev/stderr", Err: errno}
+}
+
+func TestSyncAndClose_IgnoreStandardStreamSyncFailure(t *testing.T) {
+	tests := []struct {
+		name  string
+		errno syscall.Errno
+	}{
+		{name: "bad file descriptor", errno: syscall.EBADF},
+		{name: "invalid argument", errno: syscall.EINVAL},
+		{name: "inappropriate ioctl for device", errno: syscall.ENOTTY},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			logger.Reset()
+			t.Cleanup(logger.Reset)
+
+			initErr := logger.Init(
+				"info", "", true, 10, 5, 30,
+				syncStubWriter{syncErr: stdStreamSyncErr(testCase.errno)},
+			)
+			if initErr != nil {
+				t.Fatalf("Init() error = %v", initErr)
+			}
+
+			syncErr := logger.Sync()
+			if syncErr != nil {
+				t.Errorf("Sync() error = %v, want nil", syncErr)
+			}
+
+			closeErr := logger.Close()
+			if closeErr != nil {
+				t.Errorf("Close() error = %v, want nil", closeErr)
+			}
+		})
+	}
+}
+
+func TestSyncAndClose_ReportGenuineSinkFailure(t *testing.T) {
+	logger.Reset()
+	t.Cleanup(logger.Reset)
+
+	initErr := logger.Init("info", "", true, 10, 5, 30, syncStubWriter{syncErr: errSinkFailed})
+	if initErr != nil {
+		t.Fatalf("Init() error = %v", initErr)
+	}
+
+	syncErr := logger.Sync()
+	if !errors.Is(syncErr, errSinkFailed) {
+		t.Errorf("Sync() error = %v, want it to wrap %v", syncErr, errSinkFailed)
+	}
+
+	closeErr := logger.Close()
+	if !errors.Is(closeErr, errSinkFailed) {
+		t.Errorf("Close() error = %v, want it to wrap %v", closeErr, errSinkFailed)
+	}
+}
+
+// A log-file sink that fails to sync stays a real failure even when its errno
+// matches the standard-stream caveat: only the standard streams get the benefit
+// of the doubt.
+func TestSyncAndClose_ReportFileSinkFailureWithSameErrno(t *testing.T) {
+	fileSyncErr := &fs.PathError{
+		Op:   "sync",
+		Path: filepath.Join(t.TempDir(), "neru.log"),
+		Err:  syscall.EBADF,
+	}
+
+	logger.Reset()
+	t.Cleanup(logger.Reset)
+
+	initErr := logger.Init("info", "", true, 10, 5, 30, syncStubWriter{syncErr: fileSyncErr})
+	if initErr != nil {
+		t.Fatalf("Init() error = %v", initErr)
+	}
+
+	syncErr := logger.Sync()
+	if !errors.Is(syncErr, fileSyncErr) {
+		t.Errorf("Sync() error = %v, want it to wrap %v", syncErr, fileSyncErr)
+	}
+
+	closeErr := logger.Close()
+	if !errors.Is(closeErr, fileSyncErr) {
+		t.Errorf("Close() error = %v, want it to wrap %v", closeErr, fileSyncErr)
+	}
+}
+
+// The teardown path that floods the gate: Get() builds a fallback development
+// logger on os.Stderr, and closing it must stay quiet even when the test
+// binary's stderr is a pipe that cannot be synced.
+func TestClose_QuietOnFallbackStderrLogger(t *testing.T) {
+	logger.Reset()
+	t.Cleanup(logger.Reset)
+
+	logger.Get().Info("teardown smoke check")
+
+	closeErr := logger.Close()
+	if closeErr != nil {
+		t.Errorf("Close() error = %v, want nil for the stderr fallback logger", closeErr)
 	}
 }
 

--- a/internal/adapter/logger/syncerror.go
+++ b/internal/adapter/logger/syncerror.go
@@ -15,16 +15,22 @@ const syncOp = "sync"
 // genuineSyncFailure returns the part of a zap Sync error that is a real sink
 // failure, or nil when there is none.
 //
-// Syncing the process's standard streams is expected to fail whenever they are
-// not a syncable device — a pipe, a terminal, or a descriptor already torn down
-// by an exiting test binary. That is the long-standing zap-on-stdout/stderr
+// Flushing the process's standard streams is expected to fail whenever they are
+// not a flushable destination — a pipe, a terminal, or a descriptor already torn
+// down by an exiting test binary. That is the long-standing zap-on-stdout/stderr
 // caveat (uber-go/zap#328, #370), not a lost log line, so those errors are
-// dropped here. Every other error — a log file that failed to flush, above all
-// — is returned unchanged so callers still report it.
+// dropped here. Every other error — a log file that failed to flush, above all —
+// is returned unchanged so callers still report it.
 //
 // zap combines the per-sink errors of a tee core with multierr, so each error is
 // classified individually and only the survivors are returned.
 func genuineSyncFailure(err error) error {
+	return genuineSyncFailureFor(err, os.Stdout, os.Stderr)
+}
+
+// genuineSyncFailureFor is genuineSyncFailure against an explicit set of
+// standard streams, so tests can supply streams they control.
+func genuineSyncFailureFor(err error, streams ...*os.File) error {
 	if err == nil {
 		return nil
 	}
@@ -32,7 +38,7 @@ func genuineSyncFailure(err error) error {
 	var failures error
 
 	for _, sinkErr := range multierr.Errors(err) {
-		if isStandardStreamSyncError(sinkErr) {
+		if isUnflushableStreamError(sinkErr, streams) {
 			continue
 		}
 
@@ -42,23 +48,45 @@ func genuineSyncFailure(err error) error {
 	return failures
 }
 
-// isStandardStreamSyncError reports whether err is a failed sync of stdout or
-// stderr with one of the errnos those streams produce when they cannot be
-// synced at all.
-func isStandardStreamSyncError(err error) bool {
+// isUnflushableStreamError reports whether err is a failed flush of one of the
+// given streams, with one of the errnos a stream raises when it cannot be
+// flushed at all, on a destination that could never have been flushed anyway.
+func isUnflushableStreamError(err error, streams []*os.File) bool {
 	var pathErr *fs.PathError
 
 	if !errors.As(err, &pathErr) || pathErr.Op != syncOp {
 		return false
 	}
 
-	if pathErr.Path != os.Stdout.Name() && pathErr.Path != os.Stderr.Name() {
+	// EINVAL: pipes on Linux. ENOTTY: terminals and pipes on macOS.
+	// EBADF: the descriptor is already gone, as during process teardown.
+	unflushableErrno := errors.Is(pathErr, syscall.EINVAL) ||
+		errors.Is(pathErr, syscall.ENOTTY) ||
+		errors.Is(pathErr, syscall.EBADF)
+	if !unflushableErrno {
 		return false
 	}
 
-	// EINVAL: pipes on Linux. ENOTTY: terminals and pipes on macOS.
-	// EBADF: the descriptor is already gone, as during process teardown.
-	return errors.Is(pathErr, syscall.EINVAL) ||
-		errors.Is(pathErr, syscall.ENOTTY) ||
-		errors.Is(pathErr, syscall.EBADF)
+	for _, stream := range streams {
+		if pathErr.Path == stream.Name() {
+			return isUnflushable(stream)
+		}
+	}
+
+	return false
+}
+
+// isUnflushable reports whether a flush of stream could never have succeeded.
+// The standard streams keep their name (/dev/stdout, /dev/stderr) when they are
+// redirected, so the name alone says nothing: a redirect to a regular file is
+// flushable, and a failure there is real and must be reported. A stream whose
+// descriptor is already gone counts as unflushable — there is nothing left to
+// flush it to.
+func isUnflushable(stream *os.File) bool {
+	info, err := stream.Stat()
+	if err != nil {
+		return true
+	}
+
+	return !info.Mode().IsRegular()
 }

--- a/internal/adapter/logger/syncerror.go
+++ b/internal/adapter/logger/syncerror.go
@@ -1,0 +1,64 @@
+package logger
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"syscall"
+
+	"go.uber.org/multierr"
+)
+
+// syncOp is the Op an *fs.PathError carries when a flush to the sink failed.
+const syncOp = "sync"
+
+// genuineSyncFailure returns the part of a zap Sync error that is a real sink
+// failure, or nil when there is none.
+//
+// Syncing the process's standard streams is expected to fail whenever they are
+// not a syncable device — a pipe, a terminal, or a descriptor already torn down
+// by an exiting test binary. That is the long-standing zap-on-stdout/stderr
+// caveat (uber-go/zap#328, #370), not a lost log line, so those errors are
+// dropped here. Every other error — a log file that failed to flush, above all
+// — is returned unchanged so callers still report it.
+//
+// zap combines the per-sink errors of a tee core with multierr, so each error is
+// classified individually and only the survivors are returned.
+func genuineSyncFailure(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var failures error
+
+	for _, sinkErr := range multierr.Errors(err) {
+		if isStandardStreamSyncError(sinkErr) {
+			continue
+		}
+
+		failures = multierr.Append(failures, sinkErr)
+	}
+
+	return failures
+}
+
+// isStandardStreamSyncError reports whether err is a failed sync of stdout or
+// stderr with one of the errnos those streams produce when they cannot be
+// synced at all.
+func isStandardStreamSyncError(err error) bool {
+	var pathErr *fs.PathError
+
+	if !errors.As(err, &pathErr) || pathErr.Op != syncOp {
+		return false
+	}
+
+	if pathErr.Path != os.Stdout.Name() && pathErr.Path != os.Stderr.Name() {
+		return false
+	}
+
+	// EINVAL: pipes on Linux. ENOTTY: terminals and pipes on macOS.
+	// EBADF: the descriptor is already gone, as during process teardown.
+	return errors.Is(pathErr, syscall.EINVAL) ||
+		errors.Is(pathErr, syscall.ENOTTY) ||
+		errors.Is(pathErr, syscall.EBADF)
+}

--- a/internal/adapter/logger/syncerror_test.go
+++ b/internal/adapter/logger/syncerror_test.go
@@ -1,0 +1,61 @@
+package logger
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"syscall"
+	"testing"
+
+	"go.uber.org/multierr"
+)
+
+// errFileSinkFailed stands in for a log file that failed to flush.
+var errFileSinkFailed = errors.New("log file failed to flush")
+
+// A tee core reports its sinks with multierr: the standard-stream noise must be
+// dropped without taking the file sink's real failure with it.
+func TestGenuineSyncFailure_KeepsRealFailureFromCombinedError(t *testing.T) {
+	stdStreamErr := &fs.PathError{Op: syncOp, Path: os.Stderr.Name(), Err: syscall.EBADF}
+
+	combined := multierr.Append(stdStreamErr, errFileSinkFailed)
+
+	got := genuineSyncFailure(combined)
+	if !errors.Is(got, errFileSinkFailed) {
+		t.Errorf("genuineSyncFailure() = %v, want it to keep %v", got, errFileSinkFailed)
+	}
+
+	if errors.Is(got, stdStreamErr) {
+		t.Errorf("genuineSyncFailure() = %v, want the standard-stream error dropped", got)
+	}
+}
+
+func TestGenuineSyncFailure_NilWhenEverySinkErrorIsStandardStreamNoise(t *testing.T) {
+	combined := multierr.Append(
+		&fs.PathError{Op: syncOp, Path: os.Stderr.Name(), Err: syscall.EBADF},
+		&fs.PathError{Op: syncOp, Path: os.Stdout.Name(), Err: syscall.ENOTTY},
+	)
+
+	got := genuineSyncFailure(combined)
+	if got != nil {
+		t.Errorf("genuineSyncFailure() = %v, want nil", got)
+	}
+}
+
+// Only a failed *sync* of a standard stream is noise — anything else about those
+// streams is a real error.
+func TestGenuineSyncFailure_KeepsNonSyncStandardStreamError(t *testing.T) {
+	writeErr := &fs.PathError{Op: "write", Path: os.Stderr.Name(), Err: syscall.EBADF}
+
+	got := genuineSyncFailure(writeErr)
+	if !errors.Is(got, writeErr) {
+		t.Errorf("genuineSyncFailure() = %v, want it to keep %v", got, writeErr)
+	}
+}
+
+func TestGenuineSyncFailure_NilForNil(t *testing.T) {
+	got := genuineSyncFailure(nil)
+	if got != nil {
+		t.Errorf("genuineSyncFailure(nil) = %v, want nil", got)
+	}
+}

--- a/internal/adapter/logger/syncerror_test.go
+++ b/internal/adapter/logger/syncerror_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
 
@@ -13,43 +14,111 @@ import (
 // errFileSinkFailed stands in for a log file that failed to flush.
 var errFileSinkFailed = errors.New("log file failed to flush")
 
-// A tee core reports its sinks with multierr: the standard-stream noise must be
-// dropped without taking the file sink's real failure with it.
-func TestGenuineSyncFailure_KeepsRealFailureFromCombinedError(t *testing.T) {
-	stdStreamErr := &fs.PathError{Op: syncOp, Path: os.Stderr.Name(), Err: syscall.EBADF}
+// pipeStream returns a stream standing in for a standard stream that has been
+// piped — the shape a test binary's stderr has, and one a flush can never
+// succeed on.
+func pipeStream(t *testing.T) *os.File {
+	t.Helper()
 
-	combined := multierr.Append(stdStreamErr, errFileSinkFailed)
-
-	got := genuineSyncFailure(combined)
-	if !errors.Is(got, errFileSinkFailed) {
-		t.Errorf("genuineSyncFailure() = %v, want it to keep %v", got, errFileSinkFailed)
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
 	}
 
-	if errors.Is(got, stdStreamErr) {
-		t.Errorf("genuineSyncFailure() = %v, want the standard-stream error dropped", got)
+	t.Cleanup(func() {
+		_ = writer.Close()
+		_ = reader.Close()
+	})
+
+	return writer
+}
+
+// regularFileStream returns a stream standing in for a standard stream that has
+// been redirected to a real file, which a flush can and should succeed on.
+func regularFileStream(t *testing.T) *os.File {
+	t.Helper()
+
+	file, err := os.Create(filepath.Join(t.TempDir(), "redirected.log"))
+	if err != nil {
+		t.Fatalf("os.Create() error = %v", err)
+	}
+
+	t.Cleanup(func() { _ = file.Close() })
+
+	return file
+}
+
+func syncFailure(stream *os.File, errno syscall.Errno) *fs.PathError {
+	return &fs.PathError{Op: syncOp, Path: stream.Name(), Err: errno}
+}
+
+// A tee core reports its sinks with multierr: the unflushable-stream noise must
+// be dropped without taking the file sink's real failure with it.
+func TestGenuineSyncFailure_KeepsRealFailureFromCombinedError(t *testing.T) {
+	stream := pipeStream(t)
+
+	combined := multierr.Append(syncFailure(stream, syscall.EBADF), errFileSinkFailed)
+
+	got := genuineSyncFailureFor(combined, stream)
+	if !errors.Is(got, errFileSinkFailed) {
+		t.Errorf("genuineSyncFailureFor() = %v, want it to keep %v", got, errFileSinkFailed)
+	}
+
+	if errors.Is(got, syscall.EBADF) {
+		t.Errorf("genuineSyncFailureFor() = %v, want the stream error dropped", got)
 	}
 }
 
-func TestGenuineSyncFailure_NilWhenEverySinkErrorIsStandardStreamNoise(t *testing.T) {
+func TestGenuineSyncFailure_NilWhenEverySinkErrorIsStreamNoise(t *testing.T) {
+	first, second := pipeStream(t), pipeStream(t)
+
 	combined := multierr.Append(
-		&fs.PathError{Op: syncOp, Path: os.Stderr.Name(), Err: syscall.EBADF},
-		&fs.PathError{Op: syncOp, Path: os.Stdout.Name(), Err: syscall.ENOTTY},
+		syncFailure(first, syscall.EBADF),
+		syncFailure(second, syscall.ENOTTY),
 	)
 
-	got := genuineSyncFailure(combined)
+	got := genuineSyncFailureFor(combined, first, second)
 	if got != nil {
-		t.Errorf("genuineSyncFailure() = %v, want nil", got)
+		t.Errorf("genuineSyncFailureFor() = %v, want nil", got)
 	}
 }
 
-// Only a failed *sync* of a standard stream is noise — anything else about those
-// streams is a real error.
-func TestGenuineSyncFailure_KeepsNonSyncStandardStreamError(t *testing.T) {
-	writeErr := &fs.PathError{Op: "write", Path: os.Stderr.Name(), Err: syscall.EBADF}
+// A standard stream keeps its name when it is redirected, so a real file behind
+// it must still be reported — the name alone must not buy silence.
+func TestGenuineSyncFailure_ReportsFailureOnRedirectedRegularFile(t *testing.T) {
+	stream := regularFileStream(t)
 
-	got := genuineSyncFailure(writeErr)
+	failure := syncFailure(stream, syscall.EBADF)
+
+	got := genuineSyncFailureFor(failure, stream)
+	if !errors.Is(got, failure) {
+		t.Errorf("genuineSyncFailureFor() = %v, want it to keep %v", got, failure)
+	}
+}
+
+// Only a failed *flush* of a stream is noise — anything else about it is a real
+// error.
+func TestGenuineSyncFailure_KeepsNonSyncStreamError(t *testing.T) {
+	stream := pipeStream(t)
+
+	writeErr := &fs.PathError{Op: "write", Path: stream.Name(), Err: syscall.EBADF}
+
+	got := genuineSyncFailureFor(writeErr, stream)
 	if !errors.Is(got, writeErr) {
-		t.Errorf("genuineSyncFailure() = %v, want it to keep %v", got, writeErr)
+		t.Errorf("genuineSyncFailureFor() = %v, want it to keep %v", got, writeErr)
+	}
+}
+
+// A flush failure with an errno that says the destination is fine stays a real
+// failure whatever the stream is.
+func TestGenuineSyncFailure_KeepsUnexpectedErrnoOnStream(t *testing.T) {
+	stream := pipeStream(t)
+
+	failure := syncFailure(stream, syscall.EIO)
+
+	got := genuineSyncFailureFor(failure, stream)
+	if !errors.Is(got, failure) {
+		t.Errorf("genuineSyncFailureFor() = %v, want it to keep %v", got, failure)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes a shutdown warning that fired when nothing had gone wrong. Whenever Neru's console output was a pipe, a terminal, or a descriptor already being torn down, flushing it fails by design — and the shutdown path reported that as `Warning: failed to close logger`. A full `just ci` run printed roughly 128 of those lines, which is exactly the noise that trains a reader to skim past warnings.

Now a flush failure is only treated as expected when it is the process's own standard output or standard error, it failed with one of the errnos those streams raise when they cannot be flushed at all, *and* the destination behind them is something that could never have been flushed anyway. Anything else still reports: a log file that genuinely fails to flush is reported even when it fails with the same errno, and so is output redirected to a real file, which the previous text-matching check would have suppressed.

Deliberate limitation: a stream whose descriptor is already gone is treated as expected noise even if it was pointing at a real file, since at that point there is nothing left to flush to.

## Related Issues

Closes #1380

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no platform-tagged files added
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changed
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing option, command or documented behaviour changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Evidence: on `main`, the verbose test legs printed 62 of these lines each (two legs, matching the ~128 in the issue). On this branch a full `just ci` run exits 0 with zero `failed to close logger` lines in its output.

Tests pin both directions so this cannot quietly become a blanket suppression later: a standard-stream flush failure (each of the three errnos) is silent, a sink that fails for any other reason is reported, a log-file sink that fails with the *same* errno as the standard-stream case is still reported, and a stream redirected to a real file is still reported even though it keeps the standard-stream name.

The classification is by error type — the stream's own path plus the errno — rather than by substring, so the two pre-existing text matches (`invalid argument`, `inappropriate ioctl for device`) are gone; those matched any sink, including a real log file. zap combines a tee core's per-sink errors with `multierr`, so each sink error is classified individually and only the real failures are returned; `go.uber.org/multierr` moves from an indirect to a direct dependency for that (same version, already in the module graph via zap).
