### PR TITLE
build: say what to run when build-linux cannot cross-compile

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -934,8 +934,31 @@ platform work:
 - `just release-ci-linux <arch> <version>` / `just release-ci-windows <arch>
   <version>` — the tagged release binaries CI produces.
 
-Cross-compiled binaries build from any host, but only the target OS can run
-`just test` meaningfully — integration tests are tagged per-OS.
+Only the target OS can run `just test` meaningfully — integration tests are
+tagged per-OS.
+
+### `just build-linux` needs a Linux-targeting C compiler
+
+`just build-windows` cross-compiles from any host, because Windows is a CGO-off
+build. `just build-linux` does not: Linux needs CGO for the X11 and Wayland
+backends, which drags in Go's own cgo runtime (`linux_syscall.c`,
+`gcc_<arch>.S`). A macOS clang compiles that against the macOS SDK and fails.
+
+The recipe checks the compiler's target triple up front and refuses with the
+alternatives rather than failing inside Go's runtime. From a macOS host, use:
+
+- `just lint-cross` — compiles and lints the linux/amd64 build with CGO on, in
+  Docker
+- `just check-cross` — a fast CGO-off type-check of the Linux and Windows
+  builds, no Docker needed
+- `CGO_ENABLED=0 GOOS=linux GOARCH=<arch> go build ./cmd/neru` — a pure-Go Linux
+  binary. The CGO-only backends compile out, so it is not the shipped product
+
+`just build-linux` still runs on a Linux host, and on any host whose `CC` is a
+Linux cross toolchain. The guard fails open — it only refuses when the compiler
+positively reports a non-Linux target — so it never blocks a build that would
+have worked. The tagged Linux release binaries are built by CI on a native Linux
+runner (`just release-ci-linux`).
 
 ### `just lint` only sees your own platform
 
@@ -953,8 +976,9 @@ with a second value is reported by `unparam`. Those are artifacts of the
 no-cgo build, not real findings — CI lints Linux with cgo enabled. Findings in
 plain-`linux` files (`funcorder`, `godoclint`, `revive`, and similar) are real.
 
-The cgo-only Linux paths cannot be linted from a non-Linux host at all. CI is
-the check for those.
+The cgo-only Linux paths need a real Linux toolchain, so the host cannot lint
+them directly. `just lint-cross` runs them in the same container image the Linux
+CI job uses; without Docker, CI is the check for those.
 
 ## Linux Backend Model
 

--- a/justfile
+++ b/justfile
@@ -29,12 +29,50 @@ build:
     {{ if os() == "windows" { "CGO_ENABLED=0" } else { "CGO_ENABLED=1" } }} go build -ldflags="{{ LDFLAGS }}" -o bin/neru{{ if os() == "windows" { ".exe" } else { "" } }} ./cmd/neru
     @echo "✓ Build complete: bin/neru"
 
-# Build a Linux binary. Must run on a Linux host (CGO required for native backends).
+# Build a Linux binary. Needs a C compiler that targets linux/ARCH.
+#
+# The Linux build turns CGO on for the X11 and Wayland backends, which also
+# drags in Go's own cgo runtime (linux_syscall.c, gcc_amd64.S). A macOS clang
+# compiles those against the macOS SDK and dies in a wall of assembler errors,
+# so this recipe asks the compiler what it targets before starting, and names
+# the supported alternatives when the answer is not Linux. Point CC at a
+# Linux-targeting cross compiler and the build runs.
+#
+# Two deliberate soft spots: the arch half of the triple is only checked for the
+# arches Neru ships (amd64, arm64), and a compiler that cannot answer
+# -dumpmachine gets the benefit of the doubt. Both fail open, so the guard never
+# blocks a build that would have worked.
 build-linux ARCH="amd64":
-    @echo "Building Neru for linux/{{ ARCH }}..."
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # CC is what cgo actually runs, and it may carry flags ("clang --target=...",
+    # "ccache gcc"), so it stays unquoted on the -dumpmachine call.
+    cc=${CC:-$(go env CC)}
+    triple=$($cc -dumpmachine 2>/dev/null || true)
+    case "{{ ARCH }}" in
+        amd64) linux_triple='^(x86_64|amd64)-.*linux' ;;
+        arm64) linux_triple='^(aarch64|arm64)-.*linux' ;;
+        *) linux_triple='linux' ;;
+    esac
+    if [[ -n "$triple" ]] && ! echo "$triple" | grep -Eq "$linux_triple"; then
+        echo "error: cannot build linux/{{ ARCH }} with CGO here — the C compiler ($cc) targets $triple." >&2
+        echo "       Neru's Linux build needs CGO for the X11 and Wayland backends, so Go's own cgo" >&2
+        echo "       runtime is compiled too, against the host SDK, and fails." >&2
+        echo "" >&2
+        echo "Supported alternatives:" >&2
+        echo "  just lint-cross    compiles and lints the Linux build (amd64) with CGO on, in Docker" >&2
+        echo "  just check-cross   fast type-check of the Linux and Windows builds, CGO off, no Docker" >&2
+        echo "  CGO_ENABLED=0 GOOS=linux GOARCH={{ ARCH }} go build ./cmd/neru" >&2
+        echo "                     pure-Go Linux binary; the CGO-only backends compile out, so it is" >&2
+        echo "                     not the shipped product (docs/CROSS_PLATFORM.md#cgo-guidance)" >&2
+        echo "" >&2
+        echo "Have a Linux cross toolchain? Re-run with CC=<linux-targeting-compiler>." >&2
+        exit 1
+    fi
+    echo "Building Neru for linux/{{ ARCH }}..."
     mkdir -p bin
     CGO_ENABLED=1 GOOS=linux GOARCH={{ ARCH }} go build -ldflags="{{ LDFLAGS }}" -o bin/neru-linux-{{ ARCH }} ./cmd/neru
-    @echo "✓ Build complete: bin/neru-linux-{{ ARCH }}"
+    echo "✓ Build complete: bin/neru-linux-{{ ARCH }}"
 
 # Generate Windows resource files (.syso) for embedding the app icon and manifest.
 #


### PR DESCRIPTION
## Description

This PR fixes `just build-linux` on macOS hosts. It used to turn CGO on, hand Go's own cgo runtime to the macOS clang, and die in several hundred lines of assembler and implicit-declaration errors against the macOS SDK — with nothing in the output pointing at a way forward.

The recipe now asks the C compiler what it targets before it starts building, and when the answer is not Linux it stops with the three routes that actually work from macOS: the Docker-backed cross lint, the CGO-off cross check, and a pure-Go Linux build (with a note that the CGO-only backends compile out of that one, so it is not the shipped product). `docs/CROSS_PLATFORM.md`, which owns platform build-status facts, previously claimed "cross-compiled binaries build from any host"; it now describes what is actually true.

The deliberate limitation: this makes the recipe honest rather than making it work. Making it genuinely cross-compile would mean adding a Linux cross toolchain to the documented dev setup, which is a maintainer call, so it is not attempted here. The guard fails open in both directions — it only refuses when the compiler positively reports a non-Linux target, and it only checks the architecture half of the triple for the arches Neru ships (amd64, arm64) — so it can never block a build that would have succeeded. A Linux host, CI, and anyone with `CC` pointed at a real cross toolchain are all unaffected.

## Related Issues

Closes #1379

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no Go files touched
- [x] No darwin imports from untagged (shared) code — N/A, no Go files touched
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no Go files touched
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, the change is a `just` recipe guard; verified by hand (see below) since no test tier drives the justfile
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command changes

No config options or CLI flags change. One `just` recipe changes its behaviour:

| Invocation | Before | After |
| --- | --- | --- |
| `just build-linux [ARCH]` on a Linux host | builds | builds, unchanged |
| `just build-linux [ARCH]` with `CC` set to a Linux cross compiler | builds | builds, unchanged |
| `just build-linux [ARCH]` on macOS | ~300 lines of clang errors, exit 1 | one actionable message, exit 1 |

`just release-ci-linux`, which produces the tagged release binaries on a native Linux runner, does not go through this recipe and is untouched.

## Additional Context

**Why fail honestly rather than make it work.** Three options were considered. A real cross-CGO toolchain (musl-cross, zig cc) would work but adds a dependency to the documented dev setup — a maintainer decision, not one to smuggle in through a justfile. Routing the recipe through Docker would work but silently turns a build command into a container build, and Docker is only an optional dependency here. Silently falling back to `CGO_ENABLED=0` was rejected as the worst option: it would drop a file named `bin/neru-linux-amd64` on disk that is missing the X11, Wayland, and evdev backends — a different product wearing the shipped product's name. The repo's own rule that platform stubs must be loud rather than silent points the same way.

**Verified by hand on macOS 15 / arm64,** since `just ci` does not include `build-linux`:

- reproduced the original failure on a clean `main` before changing anything;
- `just build-linux` and `just build-linux arm64` now print the new message and exit 1;
- a `CC` reporting `x86_64-linux-gnu` passes the guard and reaches `go build`, confirming a real cross toolchain is not blocked;
- a `CC` that cannot answer `-dumpmachine` also passes the guard, and Go reports its own error — the fail-open path;
- every alternative named in the message was run and passes: `just lint-cross` (0 issues, both targets), `just check-cross`, and `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/neru`;
- `just ci` passes.

**Checked and rejected:** whether Go consults `CC_FOR_${GOOS}_${GOARCH}` ahead of `CC`, which would have made the guard read the wrong variable. On Go 1.26 it does not — setting it (with and without `CC` present) leaves the build using `CC`, while setting `CC` takes effect immediately. The guard reads `CC`, falling back to `go env CC`, which is what cgo actually runs.

**Adjacent, not fixed here** (reported separately rather than widened into this PR): five places still tell contributors and agents to run `just build-linux` as a routine cross-check, which has never worked on macOS — `internal/adapter/platform/AGENTS.md`, `.agents/skills/add-platform-feature/SKILL.md`, `CONTRIBUTING.md`, and `docs/DEVELOPMENT.md` in two spots, one of which still carries the "cross-compiled binaries build from any host" claim this PR removed from `docs/CROSS_PLATFORM.md`. They should point at `just check-cross` / `just lint-cross` instead.
