### PR TITLE
feat(config): let hotkey bindings use the Insert key

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -337,14 +337,14 @@ which of the two applies to your session.
 
 **Available keys** (the `Key` part after modifiers):
 
-| Category   | Keys                                                               |
-| ---------- | ------------------------------------------------------------------ |
-| Letters    | `a`–`z`, `A`–`Z`                                                   |
-| Numbers    | `0`–`9`                                                            |
-| Symbols    | `` ` ``, `-`, `=`, `[`, `]`, `\`, `;`, `'`, `,`, `.`, `/`          |
-| Named      | `Space`, `Return`, `Enter`, `Escape`, `Tab`, `Delete`, `Backspace` |
-| Navigation | `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown` |
-| Function   | `F1`–`F24` (`F21`–`F24` on Linux and Windows only)                 |
+| Category   | Keys                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------- |
+| Letters    | `a`–`z`, `A`–`Z`                                                                                        |
+| Numbers    | `0`–`9`                                                                                                 |
+| Symbols    | `` ` ``, `-`, `=`, `[`, `]`, `\`, `;`, `'`, `,`, `.`, `/`                                               |
+| Named      | `Space`, `Return`, `Enter`, `Escape`, `Tab`, `Delete`, `Backspace`                                      |
+| Navigation | `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown`, `Insert` (Linux Wayland/evdev only) |
+| Function   | `F1`–`F24` (`F21`–`F24` on Linux and Windows only)                                                      |
 
 See [CLI.md](CLI.md#neru-action-feed) for a full key reference with key codes and platform behavior.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/element"
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
 	"github.com/y3owk1n/neru/internal/domain/modecmd"
 )
 
@@ -25,15 +26,16 @@ const (
 	ModeNameMonitorSelect = "monitor_select"
 )
 
-// Display-form key name constants used in config files and maps.
+// Display-form key name constants used in config files and maps. The spellings
+// come from internal/domain/keyvocab, which declares the named-key vocabulary.
 const (
-	KeyDisplaySpace     = "Space"
-	KeyDisplayEscape    = "Escape"
-	KeyDisplayBackspace = "Backspace"
-	KeyDisplayDown      = "Down"
-	KeyDisplayLeft      = "Left"
-	KeyDisplayRight     = "Right"
-	KeyReturn           = "Return"
+	KeyDisplaySpace     = keyvocab.KeySpace
+	KeyDisplayEscape    = keyvocab.KeyEscape
+	KeyDisplayBackspace = keyvocab.KeyBackspace
+	KeyDisplayDown      = keyvocab.KeyDown
+	KeyDisplayLeft      = keyvocab.KeyLeft
+	KeyDisplayRight     = keyvocab.KeyRight
+	KeyReturn           = keyvocab.KeyReturn
 )
 
 // Common action command constants.
@@ -85,99 +87,22 @@ const DisabledSentinel = "__disabled__"
 // "config.override.toml", and "my-neru.toml" produces "my-neru.override.toml".
 const OverrideSuffix = ".override.toml"
 
-// Key name constants for normalization.
-// These are the canonical lowercase forms used throughout the codebase.
+// The comparison forms the control characters a tap delivers resolve to, and
+// the modifier names. These are not a listing of the named keys —
+// internal/domain/keyvocab declares those, and every other named key reaches
+// its comparison form by being lowercased rather than by being named here.
 const (
 	minimumModifierParts = 2
 	KeyNameEscape        = "escape"
 	KeyNameReturn        = "return"
 	KeyNameTab           = "tab"
 	KeyNameSpace         = "space"
-	KeyNameBackspace     = "backspace"
 	KeyNameDelete        = "delete"
-	KeyNameHome          = "home"
-	KeyNameEnd           = "end"
-	KeyNamePageUp        = "pageup"
-	KeyNamePageDown      = "pagedown"
-	KeyNameUp            = "up"
-	KeyNameDown          = "down"
-	KeyNameLeft          = "left"
-	KeyNameRight         = "right"
 	modifierNameCmd      = "cmd"
 	modifierNameCtrl     = "ctrl"
 	modifierNameAlt      = "alt"
 	modifierNameShift    = "shift"
 )
-
-// validNamedKeys is the canonical set of all named keys the system supports.
-// Every validator, normalizer, and key parser should reference this set via the
-// public helpers (IsValidNamedKey, CanonicalNamedKeyForm) instead of maintaining
-// its own ad-hoc list. The keys are stored in their display form (the casing
-// that the event tap / config files use).
-//
-// The variable is unexported to prevent accidental mutation by other packages.
-var validNamedKeys = map[string]bool{
-	// Special keys
-	KeyDisplaySpace:     true,
-	KeyReturn:           true,
-	"Enter":             true, // alias for Return
-	KeyDisplayEscape:    true,
-	"Tab":               true,
-	"Delete":            true,
-	KeyDisplayBackspace: true, // alias for Delete on macOS
-	// Navigation keys
-	"Up":            true,
-	KeyDisplayDown:  true,
-	KeyDisplayLeft:  true,
-	KeyDisplayRight: true,
-	"Home":          true,
-	"End":           true,
-	"PageUp":        true,
-	"PageDown":      true,
-	// Function keys
-	"F1":  true,
-	"F2":  true,
-	"F3":  true,
-	"F4":  true,
-	"F5":  true,
-	"F6":  true,
-	"F7":  true,
-	"F8":  true,
-	"F9":  true,
-	"F10": true,
-	"F11": true,
-	"F12": true,
-	"F13": true,
-	"F14": true,
-	"F15": true,
-	"F16": true,
-	"F17": true,
-	"F18": true,
-	"F19": true,
-	"F20": true,
-	// F21-F24 have no macOS virtual keycode (Carbon stops at F20), so they are
-	// Linux/Windows only. They stay in the shared set so a config file can be
-	// shared across platforms without failing validation.
-	"F21": true,
-	"F22": true,
-	"F23": true,
-	"F24": true,
-}
-
-// validNamedKeysLower is a precomputed lowercase lookup for IsValidNamedKey.
-var validNamedKeysLower map[string]bool
-
-// namedKeyDisplayForm maps lowercase key names to their canonical display form
-// (e.g. "pagedown" → "PageDown", "f1" → "F1"). Used by CanonicalNamedKeyForm.
-var namedKeyDisplayForm map[string]string
-
-// comboKeyAliases maps alias key names to their canonical forms.
-// Used by normalizeKeyAliasesInCombo to resolve the final segment of compound keys.
-var comboKeyAliases = map[string]string{
-	"enter":     "return",
-	"backspace": "delete",
-	"esc":       "escape",
-}
 
 // Config is the complete application configuration structure.
 type Config struct {

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
 )
 
 // StringOrStringArray is a type that can unmarshal from either a TOML string
@@ -43,20 +44,10 @@ func (s *StringOrStringArray) UnmarshalTOML(value any) error {
 	return nil
 }
 
-func init() {
-	validNamedKeysLower = make(map[string]bool, len(validNamedKeys))
-	namedKeyDisplayForm = make(map[string]string, len(validNamedKeys))
-
-	for k := range validNamedKeys {
-		lower := strings.ToLower(k)
-		validNamedKeysLower[lower] = true
-		namedKeyDisplayForm[lower] = k
-	}
-}
-
-// IsValidNamedKey checks whether a key name is a recognized named key (case-insensitive).
+// IsValidNamedKey checks whether a key name is a recognized named key
+// (case-insensitive). The set it asks is declared in internal/domain/keyvocab.
 func IsValidNamedKey(key string) bool {
-	return validNamedKeysLower[strings.ToLower(key)]
+	return keyvocab.IsNamedKey(key)
 }
 
 // CanonicalNamedKeyForm returns the canonical display form of a named key
@@ -64,13 +55,7 @@ func IsValidNamedKey(key string) bool {
 // If the key is not a recognized named key, it returns the input unchanged
 // and false as the second return value.
 func CanonicalNamedKeyForm(key string) (string, bool) {
-	display, displayOk := namedKeyDisplayForm[strings.ToLower(key)]
-
-	if !displayOk {
-		return key, false
-	}
-
-	return display, displayOk
+	return keyvocab.NamedKeyDisplay(key)
 }
 
 // NormalizeKeyForComparison puts escape sequences and key names into one form,
@@ -85,28 +70,27 @@ func NormalizeKeyForComparison(key string) string {
 	key = normalizeFullwidthChars(key)
 	key = strings.ToLower(key)
 
-	// Handle escape sequences and aliases that map to a different canonical form.
+	// Handle the control characters a tap delivers instead of a key name.
 	switch key {
-	case "\x1b", "esc":
+	case "\x1b":
 		return KeyNameEscape
-	case "\r", "enter":
+	case "\r":
 		return KeyNameReturn
 	case "\t":
 		return KeyNameTab
 	case " ":
 		return KeyNameSpace
-	case "\x08", "\x7f", KeyNameBackspace:
+	case "\x08", "\x7f":
 		// On macOS, the Delete key (above Return) sends \x7f.
 		// \x08 is the ASCII BS control character (rarely generated on macOS but included for completeness).
-		// Treat "delete", "backspace", \x7f, and \x08 as synonyms for user-friendly matching.
+		// Treat \x7f and \x08 as synonyms of "delete" for user-friendly matching.
 		return KeyNameDelete
 	}
 
-	// Normalize key aliases inside modifier combos.
-	// The switch above only handles bare "enter" / "backspace" etc., but users may
-	// write "Shift+Enter" which lowercases to "shift+enter". The event tap always
-	// produces the canonical form "shift+return", so we must resolve the alias here.
-	key = normalizeKeyAliasesInCombo(key)
+	// Resolve a key-name alias to the key it means, bare ("enter") or at the end
+	// of a combo ("shift+enter"). The event tap always produces the canonical
+	// form, so a binding written with an alias has to reach the same string.
+	key = normalizeKeyAliases(key)
 
 	// Normalize modifier aliases like "Primary" to the platform-native token
 	// so shared config can map to Cmd on macOS and Ctrl elsewhere.
@@ -162,21 +146,28 @@ func normalizeModifierTokenForOS(token, goos string) string {
 	}
 }
 
-// normalizeKeyAliasesInCombo resolves key name aliases inside modifier combos.
-// e.g. "shift+enter" → "shift+return", "cmd+backspace" → "cmd+delete".
-// Only applies to compound keys (containing "+"); bare keys are handled by the
-// switch in NormalizeKeyForComparison.
-// Splits on the last "+" and only normalizes the final segment to avoid mangling
-// modifier names or canonical forms that share a prefix (e.g. "escape" vs "esc").
-func normalizeKeyAliasesInCombo(key string) string {
+// normalizeKeyAliases resolves a key-name alias to the key it means, in the
+// lowercase comparison form: "enter" → "return", "cmd+backspace" →
+// "cmd+delete", "esc" → "escape". The aliases are keyvocab's, so config does
+// not carry a second list of them.
+//
+// Only the base key — the segment after the last "+", or the whole string when
+// there is none — is a candidate. A modifier name is never an alias, and
+// splitting on the last "+" keeps a canonical form from being mangled into one
+// that shares its prefix ("escape" vs "esc").
+//
+// This is a deliberate near-miss of keyvocab.NormalizeKey (ADR 0007): both
+// resolve the same aliases from the same declaration, but they canonicalize to
+// different forms — NormalizeKey produces the display spelling a tap emits,
+// this produces the lowercase form a keystroke is matched in. Calling
+// NormalizeKey and lowercasing would also trim the key, which comparison must
+// not do.
+func normalizeKeyAliases(key string) string {
 	idx := strings.LastIndex(key, "+")
-	if idx < 0 {
-		return key
-	}
+	prefix, base := key[:idx+1], key[idx+1:]
 
-	prefix, suffix := key[:idx+1], key[idx+1:]
-	if canonical, ok := comboKeyAliases[suffix]; ok {
-		return prefix + canonical
+	if means, isAlias := keyvocab.ResolveAlias(base); isAlias {
+		return prefix + strings.ToLower(means)
 	}
 
 	return key

--- a/internal/config/validators_hotkey_test.go
+++ b/internal/config/validators_hotkey_test.go
@@ -42,6 +42,27 @@ func TestValidateHotkey(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			// evdev and Wayland emit Insert, so a binding may name it.
+			name:      "valid Insert key",
+			hotkey:    "Insert",
+			fieldName: testHotkeyFieldName,
+			wantErr:   false,
+		},
+		{
+			name:      "valid Insert in a modifier combo",
+			hotkey:    "Cmd+Insert",
+			fieldName: testHotkeyFieldName,
+			wantErr:   false,
+		},
+		{
+			// A modifier-shaped key with per-platform semantics, declined by
+			// ADR 0008.
+			name:      "CapsLock is not a named key",
+			hotkey:    "CapsLock",
+			fieldName: testHotkeyFieldName,
+			wantErr:   true,
+		},
+		{
 			name:      "valid Option modifier",
 			hotkey:    "Option+D",
 			fieldName: testHotkeyFieldName,

--- a/internal/domain/keyvocab/doc.go
+++ b/internal/domain/keyvocab/doc.go
@@ -1,11 +1,17 @@
 // Package keyvocab owns the key and modifier vocabulary shared between the
-// event-tap backends and the mode handler: canonical key and modifier
-// spellings, and the synthetic "__keyup_"/"__modifier_" wire events the taps
-// emit and the modes consume.
+// event-tap backends, the configuration validators and the mode handler: the
+// named keys and their aliases, the canonical modifier spellings, and the
+// synthetic "__keyup_"/"__modifier_" wire events the taps emit and the modes
+// consume.
 //
-// Every producer and consumer of these strings must go through this package.
-// The two native emitters that cannot (the Wayland C overlay and the macOS
-// Objective-C event tap format the events with printf) are pinned to the same
-// prefixes by an architecture test, so a change here fails loudly instead of
-// silently splitting the protocol.
+// This is the one home for those names (ADR 0008,
+// docs/adr/0008-a-vocabulary-has-one-home.md): a named key is added here and
+// nowhere else, and every producer and consumer of these strings goes through
+// this package. internal/config's validators and normalizers read the
+// declaration rather than keeping a set of their own.
+//
+// The native emitters that cannot import it (the Wayland C overlay and the
+// macOS Objective-C event tap format the events with printf) are pinned to the
+// same prefixes by an architecture test, so a change here fails loudly instead
+// of silently splitting the protocol.
 package keyvocab

--- a/internal/domain/keyvocab/keyvocab.go
+++ b/internal/domain/keyvocab/keyvocab.go
@@ -27,10 +27,11 @@ const (
 )
 
 // NormalizeKey canonicalizes a key string of the form
-// "modifier+...+baseKey": named base keys get their canonical spelling
-// (return/enter -> Return, esc -> Escape, backspace -> Delete, ...) and
-// single-rune base keys are lowercased. Modifier segments pass through
-// untouched. Empty input normalizes to "".
+// "modifier+...+baseKey": an alias base key becomes the key it means
+// (enter -> Return, esc -> Escape, backspace -> Delete), every other named base
+// key gets its display spelling (pagedown -> PageDown), and single-rune base
+// keys are lowercased. Anything else passes through unchanged, as do modifier
+// segments. Empty input normalizes to "".
 func NormalizeKey(key string) string {
 	key = strings.TrimSpace(key)
 	if key == "" {
@@ -38,36 +39,27 @@ func NormalizeKey(key string) string {
 	}
 
 	parts := strings.Split(key, "+")
-	baseKey := parts[len(parts)-1]
-
-	switch strings.ToLower(baseKey) {
-	case "return", "enter":
-		baseKey = "Return"
-	case "space":
-		baseKey = "Space"
-	case "tab":
-		baseKey = "Tab"
-	case "escape", "esc":
-		baseKey = "Escape"
-	case "backspace":
-		baseKey = "Delete"
-	case "left":
-		baseKey = "Left"
-	case "right":
-		baseKey = "Right"
-	case "up":
-		baseKey = "Up"
-	case "down":
-		baseKey = "Down"
-	default:
-		if len([]rune(baseKey)) == 1 {
-			baseKey = strings.ToLower(baseKey)
-		}
-	}
-
-	parts[len(parts)-1] = baseKey
+	parts[len(parts)-1] = normalizeBaseKey(parts[len(parts)-1])
 
 	return strings.Join(parts, "+")
+}
+
+// normalizeBaseKey canonicalizes the key a combo ends in, reading the named-key
+// declaration rather than listing spellings a second time.
+func normalizeBaseKey(baseKey string) string {
+	if means, isAlias := ResolveAlias(baseKey); isAlias {
+		return means
+	}
+
+	if display, isNamed := NamedKeyDisplay(baseKey); isNamed {
+		return display
+	}
+
+	if len([]rune(baseKey)) == 1 {
+		return strings.ToLower(baseKey)
+	}
+
+	return baseKey
 }
 
 // CanonicalModifier maps a modifier spelling (including platform aliases:

--- a/internal/domain/keyvocab/keyvocab_test.go
+++ b/internal/domain/keyvocab/keyvocab_test.go
@@ -19,16 +19,23 @@ func TestNormalizeKey_CanonicalSpellings(t *testing.T) {
 		in   string
 		want string
 	}{
-		{name: "return", in: "return", want: "Return"},
-		{name: "enter aliases to Return", in: "enter", want: "Return"},
-		{name: "enter with modifiers", in: "ctrl+enter", want: "ctrl+Return"},
-		{name: "esc aliases to Escape", in: "esc", want: "Escape"},
-		{name: "backspace maps to Delete", in: "backspace", want: "Delete"},
+		{name: "return", in: "return", want: keyReturn},
+		{name: "enter aliases to Return", in: nameEnter, want: keyReturn},
+		{name: "enter with modifiers", in: "ctrl+" + nameEnter, want: "ctrl+" + keyReturn},
+		{name: "esc aliases to Escape", in: nameEsc, want: keyEscape},
+		{name: "backspace maps to Delete", in: nameBackspace, want: keyDelete},
 		{name: "single rune lowercased", in: "A", want: "a"},
 		{name: "modifiers pass through", in: "cmd+shift+K", want: "cmd+shift+k"},
-		{name: "named keys keep case", in: "Left", want: "Left"},
+		{name: "named keys keep case", in: keyLeft, want: keyLeft},
 		{name: "empty", in: "", want: ""},
 		{name: "whitespace only", in: "   ", want: ""},
+		// Every named key gets its display spelling, not just the handful the
+		// normalizer used to special-case.
+		{name: namePageDown, in: namePageDown, want: keyPageDown},
+		{name: "home", in: "HOME", want: "Home"},
+		{name: "function key", in: "f13", want: "F13"},
+		{name: nameInsert, in: nameInsert, want: keyInsert},
+		{name: "unknown multi-rune passes through", in: "Fn", want: "Fn"},
 	}
 
 	for _, testCase := range tests {
@@ -82,7 +89,7 @@ func TestKeyUpEvent_UsesNormalizedBaseKey(t *testing.T) {
 	}{
 		{name: "plain key", in: "j", want: wantKeyUpJ},
 		{name: "strips modifiers", in: "cmd+shift+J", want: wantKeyUpJ},
-		{name: "named key normalized", in: "enter", want: "__keyup_Return"},
+		{name: "named key normalized", in: nameEnter, want: keyvocab.KeyUpPrefix + keyReturn},
 		{name: "empty", in: "", want: ""},
 	}
 

--- a/internal/domain/keyvocab/named_keys.go
+++ b/internal/domain/keyvocab/named_keys.go
@@ -1,0 +1,150 @@
+package keyvocab
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// The named keys, in the display form a config file writes and the event taps
+// emit. A key that is neither one of these nor a single character is not a key
+// Neru binds.
+const (
+	KeySpace     = "Space"
+	KeyReturn    = "Return"
+	KeyEnter     = "Enter" // means Return
+	KeyEscape    = "Escape"
+	KeyTab       = "Tab"
+	KeyDelete    = "Delete"
+	KeyBackspace = "Backspace" // means Delete
+	KeyUp        = "Up"
+	KeyDown      = "Down"
+	KeyLeft      = "Left"
+	KeyRight     = "Right"
+	KeyHome      = "Home"
+	KeyEnd       = "End"
+	KeyPageUp    = "PageUp"
+	KeyPageDown  = "PageDown"
+	KeyInsert    = "Insert"
+)
+
+// shorthandEscape is the one spelling that resolves to a named key without
+// being one. It is deliberately absent from namedKeys: a keystroke arriving as
+// "esc" compares equal to Escape, while a binding written "esc" is refused, so
+// a config file has exactly one spelling for the key.
+const shorthandEscape = "esc"
+
+// functionKeyCount closes the function key range. F21-F24 have no macOS virtual
+// keycode (Carbon stops at F20), so they reach a binding only on Linux and
+// Windows. They stay in the shared set so one config file can be shared across
+// platforms without failing validation.
+const functionKeyCount = 24
+
+// CapsLock is deliberately not here: a modifier-shaped key with per-platform
+// semantics nobody has asked for (docs/adr/0008-a-vocabulary-has-one-home.md).
+var namedKeys = buildNamedKeys()
+
+// namedKeyAliases maps a spelling to the named key it means. Enter and
+// Backspace are named keys in their own right — a config file may write either,
+// and a diagnostic echoes back what was written — that mean Return and Delete.
+var namedKeyAliases = map[string]string{
+	KeyEnter:        KeyReturn,
+	KeyBackspace:    KeyDelete,
+	shorthandEscape: KeyEscape,
+}
+
+// namedKeyDisplay indexes the set by lowercase spelling, and aliasTargets does
+// the same for the aliases. Both are derived from the declarations above, so a
+// key is added in exactly one place.
+var (
+	namedKeyDisplay = lowercaseIndex(namedKeys)
+	aliasTargets    = lowercaseAliases(namedKeyAliases)
+)
+
+func buildNamedKeys() []string {
+	keys := []string{
+		KeySpace,
+		KeyReturn,
+		KeyEnter,
+		KeyEscape,
+		KeyTab,
+		KeyDelete,
+		KeyBackspace,
+		KeyUp,
+		KeyDown,
+		KeyLeft,
+		KeyRight,
+		KeyHome,
+		KeyEnd,
+		KeyPageUp,
+		KeyPageDown,
+		KeyInsert,
+	}
+
+	for index := 1; index <= functionKeyCount; index++ {
+		keys = append(keys, "F"+strconv.Itoa(index))
+	}
+
+	return keys
+}
+
+func lowercaseIndex(keys []string) map[string]string {
+	index := make(map[string]string, len(keys))
+	for _, key := range keys {
+		index[strings.ToLower(key)] = key
+	}
+
+	return index
+}
+
+func lowercaseAliases(aliases map[string]string) map[string]string {
+	index := make(map[string]string, len(aliases))
+	for alias, means := range aliases {
+		index[strings.ToLower(alias)] = means
+	}
+
+	return index
+}
+
+// IsNamedKey reports whether name is one of the named keys, case-insensitively.
+// A single character key ("j") is not a named key, and neither is a modifier
+// combo — callers that accept those check for them separately.
+func IsNamedKey(name string) bool {
+	_, ok := namedKeyDisplay[strings.ToLower(name)]
+
+	return ok
+}
+
+// NamedKeyDisplay returns the display spelling of a named key ("pagedown" →
+// "PageDown", "f1" → "F1"). An alias keeps its own spelling — "enter" is
+// "Enter", not "Return" — because this answers how to write a key, not which
+// key it means; ResolveAlias answers that. A name that is not a named key comes
+// back unchanged with ok false.
+func NamedKeyDisplay(name string) (string, bool) {
+	display, ok := namedKeyDisplay[strings.ToLower(name)]
+	if !ok {
+		return name, false
+	}
+
+	return display, true
+}
+
+// ResolveAlias returns the named key an alias means, in display form ("enter" →
+// "Return", "backspace" → "Delete", "esc" → "Escape"). ok is false for anything
+// that is not an alias, including a named key that means itself.
+func ResolveAlias(name string) (string, bool) {
+	means, ok := aliasTargets[strings.ToLower(name)]
+
+	return means, ok
+}
+
+// NamedKeys returns every named key in display form, sorted. It exists so the
+// set can be checked against a written-out list rather than sampled: the pin in
+// this package's tests reads it, which is what makes an entry added here fail
+// loudly instead of quietly widening the vocabulary.
+func NamedKeys() []string {
+	keys := slices.Clone(namedKeys)
+	slices.Sort(keys)
+
+	return keys
+}

--- a/internal/domain/keyvocab/named_keys_test.go
+++ b/internal/domain/keyvocab/named_keys_test.go
@@ -1,0 +1,166 @@
+package keyvocab_test
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
+)
+
+// Spellings the tests in this package assert against, written out rather than
+// read from the table under test. The key* constants are display forms — the
+// spelling a config file writes — and the name* constants are the lowercase
+// inputs a caller may pass instead.
+const (
+	keyReturn    = "Return"
+	keyEnter     = "Enter"
+	keyEscape    = "Escape"
+	keyDelete    = "Delete"
+	keyLeft      = "Left"
+	keyBackspace = "Backspace"
+	keyInsert    = "Insert"
+	keyPageDown  = "PageDown"
+
+	nameEnter     = "enter"
+	nameBackspace = "backspace"
+	nameInsert    = "insert"
+	namePageDown  = "pagedown"
+	nameEsc       = "esc"
+)
+
+// documentedNamedKeys is the vocabulary as docs/CONFIGURATION.md lists it,
+// written out rather than derived from the table under test.
+func documentedNamedKeys() []string {
+	keys := []string{
+		"Space", keyReturn, keyEnter, keyEscape, "Tab", keyDelete, keyBackspace,
+		"Up", "Down", keyLeft, "Right", "Home", "End", "PageUp", keyPageDown,
+		keyInsert,
+	}
+	for index := 1; index <= 24; index++ {
+		keys = append(keys, "F"+strconv.Itoa(index))
+	}
+
+	return keys
+}
+
+// TestNamedKeys_IsExactlyTheDocumentedSet is the pin: the declared vocabulary
+// and the one docs/CONFIGURATION.md promises are the same set, so adding a key
+// in one place without the other fails here rather than in a config file.
+func TestNamedKeys_IsExactlyTheDocumentedSet(t *testing.T) {
+	t.Parallel()
+
+	want := documentedNamedKeys()
+	slices.Sort(want)
+
+	if got := keyvocab.NamedKeys(); !slices.Equal(got, want) {
+		t.Errorf("NamedKeys() = %v, want %v", got, want)
+	}
+}
+
+// TestIsNamedKey_TheDeclaredSet checks every documented spelling is recognized,
+// case-insensitively.
+func TestIsNamedKey_TheDeclaredSet(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range documentedNamedKeys() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if !keyvocab.IsNamedKey(name) {
+				t.Errorf("IsNamedKey(%q) = false, want true", name)
+			}
+
+			if !keyvocab.IsNamedKey(strings.ToLower(name)) {
+				t.Errorf("IsNamedKey(%q) = false, want true", strings.ToLower(name))
+			}
+		})
+	}
+}
+
+// TestIsNamedKey_OutsideTheSet pins the closed edges of the vocabulary: the
+// function key range stops at F24, "esc" is a comparison shorthand rather than
+// a spelling a binding may use, and CapsLock is declined (ADR 0008).
+func TestIsNamedKey_OutsideTheSet(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"F0", "F25", nameEsc, "Esc", "CapsLock", "", "Meh"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if keyvocab.IsNamedKey(name) {
+				t.Errorf("IsNamedKey(%q) = true, want false", name)
+			}
+		})
+	}
+}
+
+// TestNamedKeyDisplay_KeepsTheSpellingWritten checks that an alias reports its
+// own display form rather than the key it means: "Enter" is what a config file
+// wrote and what a diagnostic should echo back.
+func TestNamedKeyDisplay_KeepsTheSpellingWritten(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: namePageDown, want: keyPageDown},
+		{in: "UP", want: "Up"},
+		{in: "f1", want: "F1"},
+		{in: nameEnter, want: keyEnter},
+		{in: nameBackspace, want: keyBackspace},
+		{in: nameInsert, want: keyInsert},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.in, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := keyvocab.NamedKeyDisplay(testCase.in)
+			if !ok || got != testCase.want {
+				t.Errorf(
+					"NamedKeyDisplay(%q) = (%q, %t), want (%q, true)",
+					testCase.in, got, ok, testCase.want,
+				)
+			}
+		})
+	}
+
+	if got, ok := keyvocab.NamedKeyDisplay("nope"); ok || got != "nope" {
+		t.Errorf(`NamedKeyDisplay("nope") = (%q, %t), want ("nope", false)`, got, ok)
+	}
+}
+
+// TestResolveAlias_MeansAnotherKey pins the two aliases the vocabulary carries
+// plus the "esc" shorthand, and that a key meaning itself is not an alias.
+func TestResolveAlias_MeansAnotherKey(t *testing.T) {
+	t.Parallel()
+
+	aliases := map[string]string{
+		keyEnter:      keyReturn,
+		nameEnter:     keyReturn,
+		keyBackspace:  keyDelete,
+		nameBackspace: keyDelete,
+		nameEsc:       keyEscape,
+		"ESC":         keyEscape,
+	}
+
+	for spelling, want := range aliases {
+		t.Run(spelling, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := keyvocab.ResolveAlias(spelling)
+			if !ok || got != want {
+				t.Errorf("ResolveAlias(%q) = (%q, %t), want (%q, true)", spelling, got, ok, want)
+			}
+		})
+	}
+
+	for _, notAnAlias := range []string{keyReturn, keyDelete, keyEscape, "Up", "j", ""} {
+		if got, ok := keyvocab.ResolveAlias(notAnAlias); ok {
+			t.Errorf("ResolveAlias(%q) = (%q, true), want ok = false", notAnAlias, got)
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR lets a hotkey binding use the `Insert` key. The Linux event taps have
always delivered it, but writing it in a config file was refused with
`has invalid key 'Insert' in modifier combo`, so the key was unreachable.

Behind that, this PR reworks where the key spellings Neru recognises are
written down. Two places each claimed to be the one that owned them, and only
one of them actually ran — which is how `Insert` came to be emitted by one half
of Neru and rejected by the other. There is now a single declaration, and the
validators and normalizers read it instead of keeping a copy. Every other key
spelling means exactly what it did before; only `Insert` is newly accepted.

The one deliberate limitation: `Insert` reaches a binding on Linux only. macOS
and Windows do not deliver the key yet, the same way `F21`–`F24` are Linux and
Windows only. It is accepted everywhere so one config file can be shared across
platforms without failing validation, which is how the existing gap already
works.

## Related Issues

Closes #1370

Implements the key-name half of
`docs/adr/0008-a-vocabulary-has-one-home.md`. The Objective-C copies of the
same table are pinned separately in #1374.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Config Surface

One new accepted value, no new options and no changed defaults.

`Insert` may now be written wherever a key name is accepted — a bare binding or
the key at the end of a modifier combo, in `[hotkeys]` or any `[<mode>.hotkeys]`
table:

```toml
[scroll.hotkeys]
"Insert"     = "action page_down"
"Cmd+Insert" = "action go_top"
```

Existing config files keep working unchanged: no spelling was removed, no
accepted spelling changed meaning, and `esc` remains a keystroke shorthand
rather than a spelling a binding may use, exactly as before. `CapsLock` is
still refused — ADR 0008 records why.

`docs/CONFIGURATION.md` lists `Insert` in the available-keys table, marked
Linux only.

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no build-tagged file is touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or platform capability changes
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

`just lint-cross` also passes, since the change is read by the Linux and
Windows event taps.

## Additional Context

Worth a reviewer's attention:

- **The behaviour-identity claim was checked, not assumed.** The pre-change
  validators and normalizers were replayed verbatim against the new ones over a
  corpus of every named key in three casings, each alone and behind five
  modifier prefixes, plus the control characters and the fullwidth forms. The
  only differences are `Insert` becoming valid, and the tap-side normalizer now
  giving already-valid keys their documented capitalisation (`pagedown` →
  `PageDown`) where it previously passed them through. That second one is
  invisible: every tap already emits the capitalised form, and the one place the
  result is compared downstream compares case-insensitively.
- **`esc` is deliberately not part of the set.** It resolves to `Escape` when a
  keystroke is compared, but a binding written `esc` is still refused. That
  asymmetry is pre-existing and preserved on purpose rather than tidied away,
  since accepting it would widen the config surface this PR is not meant to
  touch.
- **Two Go tables were left alone on purpose.** The Windows and Wayland
  name-to-keycode tables spell keys out again, but they run in the opposite
  direction — which keys Neru can *type* for `neru action feed`, not which keys
  it recognises. They are the same class as the Objective-C tables #1374 owns,
  and changing them would change what `neru action feed` accepts.
