### PR TITLE
fix: only excuse a failed flush of output that is provably gone

### DIFF
--- a/internal/adapter/logger/syncerror.go
+++ b/internal/adapter/logger/syncerror.go
@@ -81,11 +81,12 @@ func isUnflushableStreamError(err error, streams []*os.File) bool {
 // redirected, so the name alone says nothing: a redirect to a regular file is
 // flushable, and a failure there is real and must be reported. A stream whose
 // descriptor is already gone counts as unflushable — there is nothing left to
-// flush it to.
+// flush it to — but a stream that cannot be inspected for any other reason is
+// given no benefit of the doubt.
 func isUnflushable(stream *os.File) bool {
 	info, err := stream.Stat()
 	if err != nil {
-		return true
+		return errors.Is(err, syscall.EBADF) || errors.Is(err, os.ErrClosed)
 	}
 
 	return !info.Mode().IsRegular()

--- a/internal/adapter/logger/syncerror_test.go
+++ b/internal/adapter/logger/syncerror_test.go
@@ -96,6 +96,24 @@ func TestGenuineSyncFailure_ReportsFailureOnRedirectedRegularFile(t *testing.T) 
 	}
 }
 
+// A stream whose descriptor is already gone has nothing left to flush to, even
+// when it was pointing at a real file.
+func TestGenuineSyncFailure_NilForClosedStream(t *testing.T) {
+	stream := regularFileStream(t)
+
+	failure := syncFailure(stream, syscall.EBADF)
+
+	closeErr := stream.Close()
+	if closeErr != nil {
+		t.Fatalf("Close() error = %v", closeErr)
+	}
+
+	got := genuineSyncFailureFor(failure, stream)
+	if got != nil {
+		t.Errorf("genuineSyncFailureFor() = %v, want nil", got)
+	}
+}
+
 // Only a failed *flush* of a stream is noise — anything else about it is a real
 // error.
 func TestGenuineSyncFailure_KeepsNonSyncStreamError(t *testing.T) {


### PR DESCRIPTION
## Description

This PR tightens the shutdown-warning fix from #1388, which merged while a second automated review comment on it was still open.

That change stops warning about a flush of Neru's own console output when the destination is something a flush could never have worked on. Deciding that required inspecting the destination — and when the inspection itself failed, for any reason, the destination was assumed unflushable and the failure was dropped. Redirected output that failed to flush for an unrelated reason could therefore be silently discarded. Now only a descriptor that is provably gone earns that silence, which is what the behaviour was documented as doing; anything else is reported.

In practice this is a very narrow window — inspecting an open descriptor essentially only fails when it is gone — so this is a correctness tightening rather than a fix for something users have hit.

## Related Issues

Follow-up to #1388 (which closed #1380).

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no platform-tagged files
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changed
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing option, command or documented behaviour changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

A test pins the remaining silent case: a stream whose descriptor is already closed is still treated as expected noise, because there is nothing left to flush to. A full `just ci` run on this branch exits 0 and still emits zero `failed to close logger` lines, so the original noise fix is intact.
