### PR TITLE
fix(linux): let X11 global hotkeys use PageUp, PageDown, Home and End

### DIFF
--- a/internal/adapter/hotkeys/linux/x11_cgo.go
+++ b/internal/adapter/hotkeys/linux/x11_cgo.go
@@ -17,6 +17,7 @@ import (
 
 	_ "github.com/y3owk1n/neru/internal/adapter/platform/linux"
 	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
@@ -257,6 +258,17 @@ func parseX11Hotkey(display *C.Display, keyString string) (C.uint, C.uint, error
 	return C.uint(keycode), modifiers, nil
 }
 
+// x11KeysymFor resolves the base key of a hotkey to the X11 keysym a grab
+// needs. The keys below are mapped here rather than left to XStringToKeysym,
+// which knows X11's own spellings ("Page_Up", "Prior") and not Neru's: a name
+// from the vocabulary resolves only where this switch says it does, and "Home"
+// and "End" landing on the right keysym through XStringToKeysym is a
+// coincidence of spelling, not a contract.
+//
+// The rest fall through to XStringToKeysym: punctuation, and the named keys
+// X11 spells the same way Neru does — Delete, Insert and F1-F24. "Backspace"
+// is the one named key neither path resolves, since X11 spells it "BackSpace";
+// that gap predates this switch and is untouched here.
 func x11KeysymFor(key string) C.KeySym {
 	key = strings.TrimSpace(key)
 	if len(key) == 1 {
@@ -268,29 +280,66 @@ func x11KeysymFor(key string) C.KeySym {
 		return C.XStringToKeysym(cKey)
 	}
 
-	switch strings.ToLower(key) {
-	case "space":
+	name := x11CanonicalKeyName(key)
+
+	switch name {
+	case keyvocab.KeySpace:
 		return C.XK_space
-	case "return", "enter":
+	case keyvocab.KeyReturn, keyvocab.KeyEnter:
 		return C.XK_Return
-	case "tab":
+	case keyvocab.KeyTab:
 		return C.XK_Tab
-	case "escape", "esc":
+	case keyvocab.KeyEscape:
 		return C.XK_Escape
-	case "up":
+	case keyvocab.KeyUp:
 		return C.XK_Up
-	case "down":
+	case keyvocab.KeyDown:
 		return C.XK_Down
-	case "left":
+	case keyvocab.KeyLeft:
 		return C.XK_Left
-	case "right":
+	case keyvocab.KeyRight:
 		return C.XK_Right
+	case keyvocab.KeyHome:
+		return C.XK_Home
+	case keyvocab.KeyEnd:
+		return C.XK_End
+	case keyvocab.KeyPageUp:
+		return C.XK_Page_Up
+	case keyvocab.KeyPageDown:
+		return C.XK_Page_Down
 	default:
-		cKey := C.CString(key)
+		cKey := C.CString(name)
 		defer C.free(unsafe.Pointer(cKey))
 
 		return C.XStringToKeysym(cKey)
 	}
+}
+
+// x11CanonicalKeyName gives a written key name its vocabulary spelling
+// ("pageup" -> "PageUp"), so the switch above compares against the named-key
+// declaration instead of a second set of lowercase literals. A name the
+// vocabulary does not know is returned unchanged for XStringToKeysym to try.
+//
+// This is keyvocab.NormalizeKey minus the alias fold, which is how the hotkey
+// strings reaching this adapter were already canonicalized — config's
+// CanonicalHotkeyForPlatform display-cases the base key without folding
+// aliases — and it is what a grab needs: a grab names a physical key, and the
+// vocabulary's aliases cross keys that X11 keeps apart. Folding "Backspace" to
+// "Delete" the way the taps do would resolve XK_Delete and grab the
+// forward-delete key for a binding written "Backspace". So a named key keeps
+// its own spelling here — "Enter" does not become "Return", though both are
+// mapped above — and only "esc", which the vocabulary deliberately keeps out of
+// the named-key set, resolves through its alias.
+func x11CanonicalKeyName(key string) string {
+	if display, isNamed := keyvocab.NamedKeyDisplay(key); isNamed {
+		return display
+	}
+
+	if means, isAlias := keyvocab.ResolveAlias(key); isAlias {
+		return means
+	}
+
+	return key
 }
 
 func x11BindingKey(keycode C.uint, modifiers C.uint) string {

--- a/internal/adapter/hotkeys/linux/x11_keysym_test.go
+++ b/internal/adapter/hotkeys/linux/x11_keysym_test.go
@@ -1,0 +1,106 @@
+//go:build linux && cgo
+
+package linux
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
+)
+
+// X11 keysym values from X11/keysym.h. The production lookup names them through
+// cgo, which a test file cannot do (`go test` rejects cgo in in-package test
+// files), so the protocol constants are pinned here as literals — they are
+// frozen X11 protocol numbers. Untyped constants compare against the cgo return
+// type at the call site. The X11 event tap pins the same four navigation
+// keysyms for the same reason in eventtap/linux/x11_keys_test.go.
+const (
+	x11KeysymSpace    = 0x0020 // XK_space
+	x11KeysymTab      = 0xFF09 // XK_Tab
+	x11KeysymReturn   = 0xFF0D // XK_Return
+	x11KeysymEscape   = 0xFF1B // XK_Escape
+	x11KeysymHome     = 0xFF50 // XK_Home
+	x11KeysymLeft     = 0xFF51 // XK_Left
+	x11KeysymUp       = 0xFF52 // XK_Up
+	x11KeysymRight    = 0xFF53 // XK_Right
+	x11KeysymDown     = 0xFF54 // XK_Down
+	x11KeysymPageUp   = 0xFF55 // XK_Page_Up / XK_Prior
+	x11KeysymPageDown = 0xFF56 // XK_Page_Down / XK_Next
+	x11KeysymEnd      = 0xFF57 // XK_End
+	x11KeysymF5       = 0xFFC2 // XK_F5
+	x11KeysymJ        = 0x006A // XK_j
+)
+
+// TestX11KeysymFor_NavigationKeys pins the four navigation keys on the X11
+// global-hotkey path. The names come from the named-key vocabulary — the
+// spellings a config file writes and the taps emit — and the keysyms from the
+// X11 protocol, so this fails if either side stops agreeing with the other.
+// XStringToKeysym knows "Page_Up" and "Prior", not Neru's "PageUp", so these
+// only resolve when the lookup maps them itself.
+func TestX11KeysymFor_NavigationKeys(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		key  string
+		want uint32
+	}{
+		{name: "page up", key: keyvocab.KeyPageUp, want: x11KeysymPageUp},
+		{name: "page down", key: keyvocab.KeyPageDown, want: x11KeysymPageDown},
+		{name: "home", key: keyvocab.KeyHome, want: x11KeysymHome},
+		{name: "end", key: keyvocab.KeyEnd, want: x11KeysymEnd},
+		{name: "lowercased page up", key: "pageup", want: x11KeysymPageUp},
+		{name: "lowercased page down", key: "pagedown", want: x11KeysymPageDown},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := uint32(x11KeysymFor(testCase.key)); got != testCase.want {
+				t.Fatalf("x11KeysymFor(%q) = %#x, want %#x", testCase.key, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestX11KeysymFor_ExistingSpellings pins the keys that resolved before the
+// navigation keys joined the switch. The lookup now canonicalizes through the
+// named-key vocabulary rather than lowercasing in place, so every spelling a
+// hotkey could already be written in has to keep landing on the same keysym —
+// including the ones that resolve through XStringToKeysym rather than the
+// switch (a function key, a single letter).
+func TestX11KeysymFor_ExistingSpellings(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		key  string
+		want uint32
+	}{
+		{name: "space", key: keyvocab.KeySpace, want: x11KeysymSpace},
+		{name: "return", key: keyvocab.KeyReturn, want: x11KeysymReturn},
+		{name: "enter means return", key: keyvocab.KeyEnter, want: x11KeysymReturn},
+		{name: "tab", key: keyvocab.KeyTab, want: x11KeysymTab},
+		{name: "escape", key: keyvocab.KeyEscape, want: x11KeysymEscape},
+		{name: "esc shorthand", key: "esc", want: x11KeysymEscape},
+		{name: "lowercased escape", key: "escape", want: x11KeysymEscape},
+		{name: "up", key: keyvocab.KeyUp, want: x11KeysymUp},
+		{name: "down", key: keyvocab.KeyDown, want: x11KeysymDown},
+		{name: "left", key: keyvocab.KeyLeft, want: x11KeysymLeft},
+		{name: "right", key: keyvocab.KeyRight, want: x11KeysymRight},
+		{name: "function key", key: "F5", want: x11KeysymF5},
+		{name: "single letter", key: "j", want: x11KeysymJ},
+		{name: "uppercase single letter", key: "J", want: x11KeysymJ},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := uint32(x11KeysymFor(testCase.key)); got != testCase.want {
+				t.Fatalf("x11KeysymFor(%q) = %#x, want %#x", testCase.key, got, testCase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes global hotkeys on X11 refusing the four navigation keys. Binding
a global hotkey to `PageUp` or `PageDown` failed to register — X11 spells those
keys `Page_Up` and `Prior`, so asking X11 to resolve Neru's spelling produced
nothing and the binding was rejected as invalid input. The same keys already
worked as mode keys and on every other backend, so a person could bind
`PageDown` inside a mode but not globally, on X11 only.

The four navigation keys are now mapped explicitly. `Home` and `End` did
already register, but only because Neru and X11 happen to spell them the same
way; they no longer rely on that coincidence. Key names are also matched
through the shared named-key vocabulary instead of being lowercased in place,
so the hotkey path and the config layer agree on what a key is called.

One deliberate limitation: `Backspace` still cannot be used as an X11 global
hotkey, because X11 spells it `BackSpace`. That gap predates this change and is
left alone rather than folded in — the code comment now says so instead of
leaving the next reader to rediscover it.

## Related Issues

Closes #1384

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this changes a key lookup inside an already-supported capability; the existing no-cgo twin already returns `CodeNotSupported` and no new symbol crosses the boundary
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, the key reference in
      `docs/CONFIGURATION.md` already lists these keys as available; this makes
      the code match what is documented
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The change was developed test-first: the new test failed on `PageUp` and
`PageDown` before the fix and passed for `Home` and `End`, which is exactly the
coincidence described above. A second test pins every spelling that already
resolved, since the lookup path changed for all of them.

Both files are `//go:build linux && cgo`, invisible to `just lint` and
`just test` on a macOS host, so they were also run in the containerised Linux
path: `just lint-cross` (0 issues, Linux CGO-on and Windows) and `just test-linux`
(full suite green).

Two adjacent things noticed and deliberately not touched:

- `docs/CONFIGURATION.md`'s available-keys table ends its navigation row with
  `Insert` (Linux Wayland/evdev only)`, which can be read as scoping either
  `Insert` alone or the whole row. Pre-existing ambiguity, worth one wording
  pass sometime.
- The name-to-keysym table here and the keysym-to-name table in the X11 event
  tap are inverse mappings with different sources of truth for the same keys.
  Not a problem today; they can drift.
