### PR TITLE
fix(eventtap): make the keypad navigation keys work on X11 with NumLock off

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -343,7 +343,7 @@ which of the two applies to your session.
 | Numbers    | `0`–`9`                                                                                                 |
 | Symbols    | `` ` ``, `-`, `=`, `[`, `]`, `\`, `;`, `'`, `,`, `.`, `/`                                               |
 | Named      | `Space`, `Return`, `Enter`, `Escape`, `Tab`, `Delete`, `Backspace`                                      |
-| Navigation | `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown`, `Insert` (Linux Wayland/evdev only) |
+| Navigation | `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown`, `Insert` (Linux only; on X11 the keypad Insert key) |
 | Function   | `F1`–`F24` (`F21`–`F24` on Linux and Windows only)                                                      |
 
 See [CLI.md](CLI.md#neru-action-feed) for a full key reference with key codes and platform behavior.

--- a/internal/adapter/eventtap/linux/x11_cgo.go
+++ b/internal/adapter/eventtap/linux/x11_cgo.go
@@ -180,6 +180,22 @@ func x11KeyFromLookup(length C.int, buffer []C.char, keysym C.KeySym) string {
 	return keyvocab.NormalizeKey(key)
 }
 
+// x11KeypadBeginName is what the keypad's center key answers with NumLock off.
+// It has no navigation function, and the digit it carries is the name the
+// Wayland keymap gives it.
+const x11KeypadBeginName = "5"
+
+// x11KeysymName maps the keysyms XLookupString produces no character for onto
+// the names Neru binds. A key with no entry here is dropped.
+//
+// The keypad reports keysyms of its own while NumLock is off, and they mean the
+// same keys as their main-keyboard equivalents — so they fold onto the same
+// names, the ones neru_normalize_xkb_name already gives them
+// (internal/adapter/platform/linux/wayland_keymap.c). That keeps one physical
+// key reaching one binding across the Linux backends, since the evdev tap reads
+// its names from that same table. With NumLock on the keypad reports KP_0
+// through KP_9 and the operators instead, which XLookupString does resolve to
+// characters; those never reach this lookup and deliberately have no case here.
 func x11KeysymName(keysym C.KeySym) string {
 	switch keysym {
 	case C.XK_Return:
@@ -192,25 +208,33 @@ func x11KeysymName(keysym C.KeySym) string {
 		return evdevKeyNameEscape
 	case C.XK_BackSpace:
 		return "Backspace"
-	case C.XK_Left:
+	case C.XK_Left, C.XK_KP_Left:
 		return evdevKeyNameLeft
-	case C.XK_Right:
+	case C.XK_Right, C.XK_KP_Right:
 		return "Right"
-	case C.XK_Up:
+	case C.XK_Up, C.XK_KP_Up:
 		return "Up"
-	case C.XK_Down:
+	case C.XK_Down, C.XK_KP_Down:
 		return "Down"
 	// Like the function keys below, the navigation keys produce no character
 	// from XLookupString, so this lookup is the only way they reach the
 	// handler. The names match the evdev and Wayland backends.
-	case C.XK_Home:
+	case C.XK_Home, C.XK_KP_Home:
 		return evdevKeyNameHome
-	case C.XK_End:
+	case C.XK_End, C.XK_KP_End:
 		return evdevKeyNameEnd
-	case C.XK_Page_Up:
+	case C.XK_Page_Up, C.XK_KP_Page_Up:
 		return evdevKeyNamePageUp
-	case C.XK_Page_Down:
+	case C.XK_Page_Down, C.XK_KP_Page_Down:
 		return evdevKeyNamePageDown
+	// Keypad-only, for want of a main-keyboard equivalent that reaches this
+	// lookup: XLookupString answers the main Delete key with a character.
+	case C.XK_KP_Insert:
+		return evdevKeyNameInsert
+	case C.XK_KP_Delete:
+		return evdevKeyNameDelete
+	case C.XK_KP_Begin:
+		return x11KeypadBeginName
 	default:
 		return x11FunctionKeysymName(keysym)
 	}

--- a/internal/adapter/eventtap/linux/x11_keys_test.go
+++ b/internal/adapter/eventtap/linux/x11_keys_test.go
@@ -16,6 +16,24 @@ const (
 	x11KeysymEnd      = 0xFF57 // XK_End
 )
 
+// The keypad keysyms X11 reports while NumLock is off, pinned the same way.
+const (
+	x11KeysymKPHome     = 0xFF95 // XK_KP_Home
+	x11KeysymKPLeft     = 0xFF96 // XK_KP_Left
+	x11KeysymKPUp       = 0xFF97 // XK_KP_Up
+	x11KeysymKPRight    = 0xFF98 // XK_KP_Right
+	x11KeysymKPDown     = 0xFF99 // XK_KP_Down
+	x11KeysymKPPageUp   = 0xFF9A // XK_KP_Page_Up / XK_KP_Prior
+	x11KeysymKPPageDown = 0xFF9B // XK_KP_Page_Down / XK_KP_Next
+	x11KeysymKPEnd      = 0xFF9C // XK_KP_End
+	x11KeysymKPBegin    = 0xFF9D // XK_KP_Begin
+	x11KeysymKPInsert   = 0xFF9E // XK_KP_Insert
+	x11KeysymKPDelete   = 0xFF9F // XK_KP_Delete
+	x11KeysymKP0        = 0xFFB0 // XK_KP_0
+	x11KeysymKP5        = 0xFFB5 // XK_KP_5
+	x11KeysymKP9        = 0xFFB9 // XK_KP_9
+)
+
 // TestX11KeyFromLookupNavigationKeys pins the navigation keys on the X11 tap.
 // XLookupString yields no character for them, so the keysym lookup is the only
 // path by which they reach the handler, and the name it returns has to be the
@@ -67,6 +85,78 @@ func TestX11KeyFromLookupNavigationKeys(t *testing.T) {
 			if got := evdevKeyName(testCase.evdevCode); got != testCase.want {
 				t.Fatalf("evdevKeyName(%d) = %q, want %q",
 					testCase.evdevCode, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestX11KeyFromLookupKeypadNavigationKeys pins the keypad half of the same
+// vocabulary. With NumLock off the keypad reports its own KP_ keysyms, and
+// XLookupString yields no character for any of them, so the keysym lookup is
+// again the only path to the handler. The names are copied from the fold table
+// neru_normalize_xkb_name applies to these keysyms
+// (internal/adapter/platform/linux/wayland_keymap.c) — the table the Wayland
+// and evdev taps both read — so this is what pins the X11 tap to it.
+func TestX11KeyFromLookupKeypadNavigationKeys(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "keypad home", got: x11KeyFromLookup(0, nil, x11KeysymKPHome), want: "Home"},
+		{name: "keypad end", got: x11KeyFromLookup(0, nil, x11KeysymKPEnd), want: "End"},
+		{name: "keypad page up", got: x11KeyFromLookup(0, nil, x11KeysymKPPageUp), want: "PageUp"},
+		{
+			name: "keypad page down",
+			got:  x11KeyFromLookup(0, nil, x11KeysymKPPageDown),
+			want: "PageDown",
+		},
+		{name: "keypad left", got: x11KeyFromLookup(0, nil, x11KeysymKPLeft), want: "Left"},
+		{name: "keypad right", got: x11KeyFromLookup(0, nil, x11KeysymKPRight), want: "Right"},
+		{name: "keypad up", got: x11KeyFromLookup(0, nil, x11KeysymKPUp), want: "Up"},
+		{name: "keypad down", got: x11KeyFromLookup(0, nil, x11KeysymKPDown), want: "Down"},
+		{name: "keypad insert", got: x11KeyFromLookup(0, nil, x11KeysymKPInsert), want: "Insert"},
+		{name: "keypad delete", got: x11KeyFromLookup(0, nil, x11KeysymKPDelete), want: "Delete"},
+		{name: "keypad begin", got: x11KeyFromLookup(0, nil, x11KeysymKPBegin), want: "5"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if testCase.got != testCase.want {
+				t.Fatalf("x11KeyFromLookup() = %q, want %q", testCase.got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestX11KeyFromLookupKeypadDigits pins the other half of the NumLock
+// question. With NumLock on the keypad reports KP_0 through KP_9, and
+// XLookupString resolves those to digit characters — so the digit a person
+// types comes from the character branch of x11KeyFromLookup, never from the
+// keysym lookup. The lookup must therefore stay silent on them: a name here
+// would let the fold speak for a key the character branch already answers.
+func TestX11KeyFromLookupKeypadDigits(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		got  string
+	}{
+		{name: "keypad 0", got: x11KeyFromLookup(0, nil, x11KeysymKP0)},
+		{name: "keypad 5", got: x11KeyFromLookup(0, nil, x11KeysymKP5)},
+		{name: "keypad 9", got: x11KeyFromLookup(0, nil, x11KeysymKP9)},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if testCase.got != "" {
+				t.Fatalf("x11KeyFromLookup() = %q, want %q", testCase.got, "")
 			}
 		})
 	}


### PR DESCRIPTION
## Description

This PR fixes the numeric keypad doing nothing under X11 while NumLock is off.
Pressing the keypad's Home, End, PageUp, PageDown or arrow keys was dropped
before any binding could see it, so the same physical key that works on
Wayland, on the evdev backend and on the main keyboard was simply dead there.

Those keys now reach a binding under the same names their main-keyboard
equivalents produce, which is what the Wayland backend has always done for
them — keypad Insert and Delete come along, and the keypad's center key
answers with the digit it carries, exactly as on Wayland. With NumLock on the
keypad still types digits and operators: that path never went through the
lookup this PR changes, and is untouched.

Deliberate limitation: this covers the keypad only. The main-keyboard Insert
key is still dropped under X11 — a separate gap of the same shape as the one
#1382 closed for the other navigation keys — so under X11 a binding on
`Insert` now fires from the keypad but still not from the main Insert key.
The key reference says so rather than overstating it.

## Related Issues

Closes #1385

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new capability: this closes a gap in one backend against a vocabulary the shared code already validates and the other backends already emit.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Key reference change

No key spelling is added or renamed, so every existing configuration keeps
working exactly as written and simply starts firing on the keypad. One row of
the available-keys table in `docs/CONFIGURATION.md` moves:

| Before                              | After                                               |
| ----------------------------------- | --------------------------------------------------- |
| `Insert` (Linux Wayland/evdev only) | `Insert` (Linux only; on X11 the keypad Insert key) |

`Home`, `End`, `PageUp`, `PageDown` and the arrows carry no platform caveat in
that table and needed none: this makes the row that was already written true
on one more keyboard.

## Additional Context

The names are copied from the fold table the Wayland keymap already applies to
these keysyms rather than chosen fresh, so the two Linux taps cannot answer
differently for one physical key — the evdev tap reads its names from that same
table. Keypad Enter and the keypad operators needed nothing: X11 already
resolves those to characters that key comparison folds to the right names.

Two tests were added next to the ones #1382 left: one pinning each keypad
keysym to the name it must produce, one pinning that the keypad digits get no
name from that lookup — which is what makes a future entry that would hijack a
NumLock-on digit fail loudly. Both pin the keysym numbers as literals for the
same reason #1382 did: `go test` rejects cgo in an in-package test file, and a
lookup that named its own constants could not disagree with itself.

Verified beyond a type-check: the full Linux test suite was executed in the
CI-equivalent container (CGO on, headless), `just lint-cross` covers the linux
and windows build tags, and `just ci` passed on the host. The Linux CI leg runs
the new tests for real.

Background on why one vocabulary written in several places produces this class
of silent failure: `docs/adr/0008-a-vocabulary-has-one-home.md`.
