### PR TITLE
fix: close the log file even when shutdown cannot flush the logger

### DIFF
--- a/internal/adapter/logger/logger.go
+++ b/internal/adapter/logger/logger.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/term"
@@ -22,8 +23,11 @@ const (
 var (
 	// globalLogger is the global logger instance.
 	globalLogger *zap.Logger
-	logFile      *lumberjack.Logger
-	logFileMu    sync.RWMutex
+	// logFile is the rotating file sink underneath the global logger, held as an
+	// io.WriteCloser because writing to it and closing it is all this package
+	// asks of it — and because a test can then stand in for it.
+	logFile   io.WriteCloser
+	logFileMu sync.RWMutex
 )
 
 // Init configures and initializes the global logger with the specified settings.
@@ -206,30 +210,47 @@ func Sync() error {
 
 // Close releases all logger resources and ensures all pending log entries are written.
 // It synchronizes the logger and closes the log file if file logging is enabled.
+//
+// Every teardown step runs even when an earlier one fails, and the failures are
+// reported together: a logger that could not be flushed still gets its log file
+// closed and its global cleared, rather than leaking the file handle behind a
+// stale logger. Close therefore leaves nothing behind to close twice, so the
+// second Close of a shutdown path that already failed is a quiet no-op.
 func Close() error {
 	logFileMu.Lock()
 	defer logFileMu.Unlock()
 
+	var failures error
+
 	if globalLogger != nil {
-		err := genuineSyncFailure(globalLogger.Sync())
-		if err != nil {
-			return derrors.Wrap(err, derrors.CodeLoggingFailed, "failed to sync logger")
-		}
+		failures = appendLoggingFailure(
+			failures,
+			genuineSyncFailure(globalLogger.Sync()),
+			"failed to sync logger",
+		)
 
 		globalLogger = nil
 	}
 
 	if logFile != nil {
 		// lumberjack.Logger doesn't have a Sync method, but Close will flush
-		err := logFile.Close()
-		if err != nil {
-			return derrors.Wrap(err, derrors.CodeLoggingFailed, "failed to close log file")
-		}
+		failures = appendLoggingFailure(failures, logFile.Close(), "failed to close log file")
 
 		logFile = nil
 	}
 
-	return nil
+	return failures
+}
+
+// appendLoggingFailure adds err, under the given message, to the failures a
+// teardown has collected so far. A step that succeeded adds nothing, so the
+// caller can run every step and report whatever the run collected.
+func appendLoggingFailure(failures, err error, message string) error {
+	if err == nil {
+		return failures
+	}
+
+	return multierr.Append(failures, derrors.Wrap(err, derrors.CodeLoggingFailed, message))
 }
 
 // Debug logs a debug-level message with optional structured fields.

--- a/internal/adapter/logger/logger_internal_test.go
+++ b/internal/adapter/logger/logger_internal_test.go
@@ -1,0 +1,174 @@
+package logger
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+)
+
+// errSyncSinkFailed stands in for a sink whose flush genuinely failed — the one
+// case Close() must report without abandoning the rest of the teardown.
+var errSyncSinkFailed = errors.New("sink failed to flush")
+
+// errLogFileCloseFailed stands in for a log file that failed to close.
+var errLogFileCloseFailed = errors.New("log file failed to close")
+
+// failingSyncWriter is a console sink whose Sync always fails. Init installs a
+// zapcore.WriteSyncer verbatim, so the failure surfaces through Close().
+type failingSyncWriter struct{}
+
+func (failingSyncWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func (failingSyncWriter) Sync() error { return errSyncSinkFailed }
+
+// spyLogFile stands in for the rotating log file, counting the closes it gets
+// and optionally failing them.
+type spyLogFile struct {
+	closes   int
+	closeErr error
+}
+
+func (s *spyLogFile) Write(p []byte) (int, error) { return len(p), nil }
+
+func (s *spyLogFile) Close() error {
+	s.closes++
+
+	return s.closeErr
+}
+
+// initWithLogFile puts the package into the state a running daemon is in: a
+// global logger over the given console sink, plus a log file underneath it.
+func initWithLogFile(t *testing.T, consoleWriter io.Writer, file *spyLogFile) {
+	t.Helper()
+
+	Reset()
+	t.Cleanup(resetAll)
+
+	initErr := Init("info", "", true, 10, 5, 30, consoleWriter)
+	if initErr != nil {
+		t.Fatalf("Init() error = %v", initErr)
+	}
+
+	logFileMu.Lock()
+	defer logFileMu.Unlock()
+
+	logFile = file
+}
+
+// resetAll clears every piece of package state a test may have installed.
+func resetAll() {
+	logFileMu.Lock()
+	defer logFileMu.Unlock()
+
+	globalLogger = nil
+	logFile = nil
+}
+
+// assertTornDown checks that Close() left no logger or log file behind.
+func assertTornDown(t *testing.T) {
+	t.Helper()
+
+	logFileMu.RLock()
+	defer logFileMu.RUnlock()
+
+	if globalLogger != nil {
+		t.Error("Close() left the global logger set")
+	}
+
+	if logFile != nil {
+		t.Error("Close() left the log file set")
+	}
+}
+
+// A sync failure must not cost the teardown below it: the log file is still
+// closed and the global logger still cleared, and the failure is still reported.
+func TestClose_SyncFailureStillTearsDown(t *testing.T) {
+	file := &spyLogFile{}
+
+	initWithLogFile(t, failingSyncWriter{}, file)
+
+	closeErr := Close()
+	if !errors.Is(closeErr, errSyncSinkFailed) {
+		t.Errorf("Close() error = %v, want it to wrap %v", closeErr, errSyncSinkFailed)
+	}
+
+	if file.closes != 1 {
+		t.Errorf("log file closed %d times, want 1", file.closes)
+	}
+
+	assertTornDown(t)
+}
+
+// Both teardown steps can fail; Close() reports both, not just the first.
+func TestClose_ReportsEveryTeardownFailure(t *testing.T) {
+	file := &spyLogFile{closeErr: errLogFileCloseFailed}
+
+	initWithLogFile(t, failingSyncWriter{}, file)
+
+	closeErr := Close()
+	if !errors.Is(closeErr, errSyncSinkFailed) {
+		t.Errorf(
+			"Close() error = %v, want it to wrap the sync failure %v",
+			closeErr,
+			errSyncSinkFailed,
+		)
+	}
+
+	if !errors.Is(closeErr, errLogFileCloseFailed) {
+		t.Errorf(
+			"Close() error = %v, want it to wrap the log file failure %v",
+			closeErr,
+			errLogFileCloseFailed,
+		)
+	}
+
+	assertTornDown(t)
+}
+
+// Close() runs on the shutdown path, where a second call after a failed one is
+// ordinary: it must report nothing and must not close the log file twice.
+func TestClose_SecondCloseAfterFailureIsQuiet(t *testing.T) {
+	file := &spyLogFile{closeErr: errLogFileCloseFailed}
+
+	initWithLogFile(t, failingSyncWriter{}, file)
+
+	firstErr := Close()
+	if firstErr == nil {
+		t.Fatal("Close() error = nil, want the teardown failures")
+	}
+
+	secondErr := Close()
+	if secondErr != nil {
+		t.Errorf("second Close() error = %v, want nil", secondErr)
+	}
+
+	if file.closes != 1 {
+		t.Errorf("log file closed %d times, want 1", file.closes)
+	}
+}
+
+// A teardown with nothing to report stays silent.
+func TestClose_QuietWhenEveryStepSucceeds(t *testing.T) {
+	file := &spyLogFile{}
+
+	initWithLogFile(t, &nopSyncWriter{}, file)
+
+	closeErr := Close()
+	if closeErr != nil {
+		t.Errorf("Close() error = %v, want nil", closeErr)
+	}
+
+	if file.closes != 1 {
+		t.Errorf("log file closed %d times, want 1", file.closes)
+	}
+
+	assertTornDown(t)
+}
+
+// nopSyncWriter is a console sink that flushes cleanly.
+type nopSyncWriter struct {
+	bytes.Buffer
+}
+
+func (*nopSyncWriter) Sync() error { return nil }


### PR DESCRIPTION
## Description

This PR fixes a shutdown that gave up halfway. When Neru exited and the logger genuinely could not be flushed, shutdown reported that failure and stopped there — the rotating log file was never closed and the global logger was left in place, so the very run that told you flushing had failed also leaked the handle on its own log file.

Shutdown now attempts every teardown step and reports whatever it collected, so a failed flush no longer costs the steps below it: the log file is closed and the logger released either way, and both failures surface together when more than one step fails. Nothing is left behind afterwards, so a second shutdown pass following a failed one is quiet rather than repeating the work.

## Related Issues

Closes #1393

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no OS-specific files touched
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no platform capability involved
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing config, command, or documented behaviour changes
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Written test-first: the new tests pin that a failed flush still closes the log file and clears the logger, that two failing steps both get reported, and that a second shutdown neither reports nor closes anything again. All three fail against the previous behaviour.

The failures are combined with `multierr`, which this package already uses to classify the per-sink errors zap reports, and each one keeps the domain error code it had. A single failure is still returned exactly as before, so the only caller — which prints a warning during shutdown — reads the same as it did, and gains the second sentence only when a second step also fails.

The one shape change: the log file is now held as an `io.WriteCloser` rather than as the rotating-file type directly. Writing and closing is all this package asks of it, and it is what lets a test stand in for the file and observe that it really is closed after a failed flush — the acceptance criterion is otherwise unobservable without unportable file-descriptor probing.

Deliberately out of scope: logger initialisation has a similar stop-at-first-failure path when it replaces an existing log file. That is a startup path where failing loudly and early is the wanted behaviour, and the issue does not ask for it.
