### PR TITLE
fix(eventtap): make the keypad work on Linux when the keyboard layout cannot be read

### DIFF
--- a/internal/adapter/eventtap/linux/evdev_keys.go
+++ b/internal/adapter/eventtap/linux/evdev_keys.go
@@ -65,6 +65,7 @@ const (
 	evdevKeyDot        uint16 = 52
 	evdevKeySlash      uint16 = 53
 	evdevKeyRightShift uint16 = 54
+	evdevKeyKPAsterisk uint16 = 55
 	evdevKeyLeftAlt    uint16 = 56
 	evdevKeySpace      uint16 = 57
 	evdevKeyF1         uint16 = 59
@@ -77,9 +78,24 @@ const (
 	evdevKeyF8         uint16 = 66
 	evdevKeyF9         uint16 = 67
 	evdevKeyF10        uint16 = 68
+	evdevKeyKP7        uint16 = 71
+	evdevKeyKP8        uint16 = 72
+	evdevKeyKP9        uint16 = 73
+	evdevKeyKPMinus    uint16 = 74
+	evdevKeyKP4        uint16 = 75
+	evdevKeyKP5        uint16 = 76
+	evdevKeyKP6        uint16 = 77
+	evdevKeyKPPlus     uint16 = 78
+	evdevKeyKP1        uint16 = 79
+	evdevKeyKP2        uint16 = 80
+	evdevKeyKP3        uint16 = 81
+	evdevKeyKP0        uint16 = 82
+	evdevKeyKPDot      uint16 = 83
 	evdevKeyF11        uint16 = 87
 	evdevKeyF12        uint16 = 88
+	evdevKeyKPEnter    uint16 = 96
 	evdevKeyRightCtrl  uint16 = 97
+	evdevKeyKPSlash    uint16 = 98
 	evdevKeyRightAlt   uint16 = 100
 	evdevKeyHome       uint16 = 102
 	evdevKeyUp         uint16 = 103
@@ -173,6 +189,10 @@ var evdevModifierNames = map[uint16]string{
 	evdevKeyRightMeta:  evdevModifierCmd,
 }
 
+// evdevKeyNames names a raw evdev key code without consulting a keyboard
+// layout. It is the fallback the evdev tap drops to when xkb state creation
+// fails, and the only table the global hotkey reader has; a code with no entry
+// here reaches nothing.
 var evdevKeyNames = map[uint16]string{
 	evdevKeyA:          "a",
 	evdevKeyB:          "b",
@@ -260,6 +280,40 @@ var evdevKeyNames = map[uint16]string{
 	evdevKeyPageUp:     evdevKeyNamePageUp,
 	evdevKeyPageDown:   evdevKeyNamePageDown,
 	evdevKeyInsert:     evdevKeyNameInsert,
+
+	// The keypad. Every name below is the one neru_normalize_xkb_name gives
+	// the keysym this key reports with NumLock off
+	// (internal/adapter/platform/linux/wayland_keymap.c) — the table the
+	// Wayland tap reads and the X11 keysym lookup was copied from — so one
+	// physical key reaches one binding whichever Linux tap is running.
+	//
+	// NumLock off is the only state this table can answer for: the kernel
+	// reports the same code either way, and resolving the digit is exactly the
+	// layout work this table has no keymap to do. The keys whose keysym does
+	// not change with NumLock — the operators, the keypad Enter, and the center
+	// key, whose KP_Begin fold is the digit it carries — are therefore right in
+	// both states. The ten dual-function keys are right only with NumLock off,
+	// which for the tap is the degraded half of an already-degraded path but
+	// for the global hotkey reader is the only answer it has: a Home hotkey is
+	// reachable from the keypad and a keypad 7 typed with NumLock on can reach
+	// it. Naming them a third way rather than Wayland's would trade that for a
+	// keypad no Linux backend agrees about.
+	evdevKeyKPAsterisk: "*",
+	evdevKeyKPMinus:    "-",
+	evdevKeyKPPlus:     "+",
+	evdevKeyKPSlash:    "/",
+	evdevKeyKPEnter:    evdevKeyNameReturn,
+	evdevKeyKP5:        "5",
+	evdevKeyKP7:        evdevKeyNameHome,
+	evdevKeyKP8:        evdevKeyNameUp,
+	evdevKeyKP9:        evdevKeyNamePageUp,
+	evdevKeyKP4:        evdevKeyNameLeft,
+	evdevKeyKP6:        evdevKeyNameRight,
+	evdevKeyKP1:        evdevKeyNameEnd,
+	evdevKeyKP2:        evdevKeyNameDown,
+	evdevKeyKP3:        evdevKeyNamePageDown,
+	evdevKeyKP0:        evdevKeyNameInsert,
+	evdevKeyKPDot:      evdevKeyNameDelete,
 }
 
 type evdevModifierState struct {

--- a/internal/adapter/eventtap/linux/evdev_keys_test.go
+++ b/internal/adapter/eventtap/linux/evdev_keys_test.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
 )
 
 const asyncTimeout = time.Second
@@ -72,6 +74,92 @@ func TestEvdevKeyNameFunctionKeysContiguous(t *testing.T) {
 		if got := evdevKeyName(code); got != want {
 			t.Errorf("evdevKeyName(%d) = %q, want %q", code, got, want)
 		}
+	}
+}
+
+// keypadKeyNameCases is the keypad half of the fallback table, written out.
+// The codes are literals from linux/input-event-codes.h — frozen kernel ABI
+// numbers, pinned here rather than read back from the declaration under test —
+// and each `keysym` records which keysym the keypad reports for that key with
+// NumLock off, so the `want` column can be checked against the fold table
+// neru_normalize_xkb_name applies to it
+// (internal/adapter/platform/linux/wayland_keymap.c). Every name below is
+// copied from that table; none is chosen here.
+var keypadKeyNameCases = []struct {
+	name   string
+	keysym string
+	code   uint16
+	want   string
+}{
+	// NumLock-independent (see evdevKeyNames for why the split matters).
+	{name: "KEY_KPASTERISK", keysym: "KP_Multiply", code: 55, want: "*"},
+	{name: "KEY_KPMINUS", keysym: "KP_Subtract", code: 74, want: "-"},
+	{name: "KEY_KPPLUS", keysym: "KP_Add", code: 78, want: "+"},
+	{name: "KEY_KPENTER", keysym: "KP_Enter", code: 96, want: evdevKeyNameReturn},
+	{name: "KEY_KPSLASH", keysym: "KP_Divide", code: 98, want: "/"},
+
+	// Dual-function, named for what they do with NumLock off.
+	{name: "KEY_KP7", keysym: "KP_Home", code: 71, want: evdevKeyNameHome},
+	{name: "KEY_KP8", keysym: "KP_Up", code: 72, want: evdevKeyNameUp},
+	{name: "KEY_KP9", keysym: "KP_Page_Up", code: 73, want: evdevKeyNamePageUp},
+	{name: "KEY_KP4", keysym: "KP_Left", code: 75, want: evdevKeyNameLeft},
+	{name: "KEY_KP6", keysym: "KP_Right", code: 77, want: evdevKeyNameRight},
+	{name: "KEY_KP1", keysym: "KP_End", code: 79, want: evdevKeyNameEnd},
+	{name: "KEY_KP2", keysym: "KP_Down", code: 80, want: evdevKeyNameDown},
+	{name: "KEY_KP3", keysym: "KP_Page_Down", code: 81, want: evdevKeyNamePageDown},
+	{name: "KEY_KP0", keysym: "KP_Insert", code: 82, want: evdevKeyNameInsert},
+	{name: "KEY_KPDOT", keysym: "KP_Delete", code: 83, want: evdevKeyNameDelete},
+
+	// Dual-function and NumLock-independent anyway: KP_Begin folds to the digit
+	// the key carries, which is what KP_5 gives.
+	{name: "KEY_KP5", keysym: "KP_Begin", code: 76, want: "5"},
+}
+
+// TestEvdevKeyName_Keypad pins the keypad on the fallback the evdev tap uses
+// when xkb state creation fails. Without these the keypad reaches the handler
+// as nothing at all on that path, while the Wayland and X11 taps both name it.
+func TestEvdevKeyName_Keypad(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range keypadKeyNameCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := evdevKeyName(testCase.code); got != testCase.want {
+				t.Fatalf("evdevKeyName(%d) = %q, want %q (%s folds to it)",
+					testCase.code, got, testCase.want, testCase.keysym)
+			}
+		})
+	}
+}
+
+// TestEvdevKeyName_KeypadNamesAreVocabularySpellings checks the other half of
+// naming the keypad: the dispatch path runs every name through
+// keyvocab.NormalizeKey, and a name that is neither a named key nor a single
+// character survives it unchanged and then matches no binding. That is the
+// silent failure ADR 0008 was written about, so it is pinned rather than
+// assumed. It says nothing about whether a chord can be *written* with the
+// name — "+" is a single character and also the chord separator.
+func TestEvdevKeyName_KeypadNamesAreVocabularySpellings(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range keypadKeyNameCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			name := evdevKeyName(testCase.code)
+			if got := keyvocab.NormalizeKey(name); got != name {
+				t.Fatalf("NormalizeKey(%q) = %q, want it unchanged", name, got)
+			}
+
+			if !keyvocab.IsNamedKey(name) && len([]rune(name)) != 1 {
+				t.Fatalf(
+					"evdevKeyName(%d) = %q, which is neither a named key nor a single character",
+					testCase.code,
+					name,
+				)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes the keypad going dead on Linux when Neru cannot read the
keyboard layout. Neru's evdev keyboard reader normally resolves a key through
the compositor's layout, and falls back to a built-in table when that layout
cannot be created; the built-in table had no keypad keys at all, so on that
fallback every keypad key produced nothing — no binding fired and nothing was
reported. The same table is the only one the global hotkey reader has ever
used, so keypad keys never reached a global hotkey either.

The keypad now produces the same names there that Neru's Wayland and X11
keyboard paths already produce: the arrows, Home, End, PageUp, PageDown,
Insert and Delete a keypad types with NumLock off, `Return` for the keypad
Enter, the four operator keys, and `5` for the keypad's center key. Every name
is copied from the existing Wayland fold table rather than chosen here, so one
physical key reaches one binding whichever Linux backend is running.

The deliberate limitation: this table has no keymap and cannot see NumLock,
which is exactly the work the missing layout would have done, so the ten
dual-function keys are named for their NumLock-off meaning in both states. For
the tap that is the degraded half of an already-degraded path, but the global
hotkey reader has no other path — a `Home` global hotkey is now reachable from
the keypad, and a keypad 7 typed with NumLock on can reach it.

## Related Issues

Closes #1399

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this adds entries to an existing Linux-only lookup table, not a new port capability
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no key name is added to or
      removed from the documented vocabulary; the keypad reaches names
      `docs/CONFIGURATION.md` already lists
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Written test-first: the sixteen keypad codes were pinned as failing cases
before the table changed, each carrying the keysym it reports with NumLock off
so its name can be checked against the Wayland fold table it was copied from.
A second test holds every keypad name to the shared named-key vocabulary, so a
name that would validate but never match a binding fails loudly.

Because a macOS host cannot run Linux-tagged tests, these were exercised in the
containerised Linux path (`just test-linux` equivalent, plus `just lint-cross`
for both the Linux and Windows tags) as well as `just ci`.

Three things found next to this and deliberately left alone:

- `"5"` for the keypad's center key is now written twice in the same Go
  package — once here and once as a named constant on the X11 side, which
  landed with #1395. The X11 file is claimed by #1392, and the collapse is a
  one-line change there (that file already reads this one's name constants
  across the same tag boundary), so it is reported rather than done.
- The keypad half of the Wayland fold table now has three Go transcriptions —
  the X11 keysym cascade, this table, and the test tables that mirror both —
  and none is pinned to the C source the way `internal/architecture` pins the
  macOS key-name tables. ADR 0007 asks for that pin where deletion cannot
  reach; it is a follow-up, not a rider on a bug fix.
- A keypad `+` is named `+` here because Wayland and X11 name it that, but `+`
  is also the chord separator, so it cannot be written as a binding on any
  Linux backend and its synthetic key-release event carries an empty base key.
  Pre-existing and identical on the other two paths.
