### PR TITLE
fix(linux): let X11 global hotkeys use Backspace

### DIFF
--- a/internal/adapter/hotkeys/linux/x11_cgo.go
+++ b/internal/adapter/hotkeys/linux/x11_cgo.go
@@ -265,10 +265,16 @@ func parseX11Hotkey(display *C.Display, keyString string) (C.uint, C.uint, error
 // and "End" landing on the right keysym through XStringToKeysym is a
 // coincidence of spelling, not a contract.
 //
-// The rest fall through to XStringToKeysym: punctuation, and the named keys
-// X11 spells the same way Neru does — Delete, Insert and F1-F24. "Backspace"
-// is the one named key neither path resolves, since X11 spells it "BackSpace";
-// that gap predates this switch and is untouched here.
+// "Backspace" is the same story with a sharper edge: X11 spells it "BackSpace",
+// so it resolved through neither path, and the repair that suggests itself —
+// folding the name through the vocabulary's aliases — grabs the wrong physical
+// key, for the reason x11CanonicalKeyName below sets out. Delete and Insert are
+// mapped alongside it rather than left to their matching spellings, so a reader
+// sees the three editing keys and their distinct keysyms in one place.
+//
+// The rest fall through to XStringToKeysym: punctuation, and F1-F24, where
+// X11's own name for the key is the name Neru writes. Those are pinned by test
+// across the range instead of restating 24 spellings here.
 func x11KeysymFor(key string) C.KeySym {
 	key = strings.TrimSpace(key)
 	if len(key) == 1 {
@@ -291,6 +297,12 @@ func x11KeysymFor(key string) C.KeySym {
 		return C.XK_Tab
 	case keyvocab.KeyEscape:
 		return C.XK_Escape
+	case keyvocab.KeyBackspace:
+		return C.XK_BackSpace
+	case keyvocab.KeyDelete:
+		return C.XK_Delete
+	case keyvocab.KeyInsert:
+		return C.XK_Insert
 	case keyvocab.KeyUp:
 		return C.XK_Up
 	case keyvocab.KeyDown:

--- a/internal/adapter/hotkeys/linux/x11_keysym_test.go
+++ b/internal/adapter/hotkeys/linux/x11_keysym_test.go
@@ -3,6 +3,8 @@
 package linux
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/domain/keyvocab"
@@ -15,20 +17,24 @@ import (
 // type at the call site. The X11 event tap pins the same four navigation
 // keysyms for the same reason in eventtap/linux/x11_keys_test.go.
 const (
-	x11KeysymSpace    = 0x0020 // XK_space
-	x11KeysymTab      = 0xFF09 // XK_Tab
-	x11KeysymReturn   = 0xFF0D // XK_Return
-	x11KeysymEscape   = 0xFF1B // XK_Escape
-	x11KeysymHome     = 0xFF50 // XK_Home
-	x11KeysymLeft     = 0xFF51 // XK_Left
-	x11KeysymUp       = 0xFF52 // XK_Up
-	x11KeysymRight    = 0xFF53 // XK_Right
-	x11KeysymDown     = 0xFF54 // XK_Down
-	x11KeysymPageUp   = 0xFF55 // XK_Page_Up / XK_Prior
-	x11KeysymPageDown = 0xFF56 // XK_Page_Down / XK_Next
-	x11KeysymEnd      = 0xFF57 // XK_End
-	x11KeysymF5       = 0xFFC2 // XK_F5
-	x11KeysymJ        = 0x006A // XK_j
+	x11KeysymSpace     = 0x0020 // XK_space
+	x11KeysymBackSpace = 0xFF08 // XK_BackSpace
+	x11KeysymTab       = 0xFF09 // XK_Tab
+	x11KeysymReturn    = 0xFF0D // XK_Return
+	x11KeysymEscape    = 0xFF1B // XK_Escape
+	x11KeysymHome      = 0xFF50 // XK_Home
+	x11KeysymLeft      = 0xFF51 // XK_Left
+	x11KeysymUp        = 0xFF52 // XK_Up
+	x11KeysymRight     = 0xFF53 // XK_Right
+	x11KeysymDown      = 0xFF54 // XK_Down
+	x11KeysymPageUp    = 0xFF55 // XK_Page_Up / XK_Prior
+	x11KeysymPageDown  = 0xFF56 // XK_Page_Down / XK_Next
+	x11KeysymEnd       = 0xFF57 // XK_End
+	x11KeysymInsert    = 0xFF63 // XK_Insert
+	x11KeysymF1        = 0xFFBE // XK_F1
+	x11KeysymF24       = 0xFFD5 // XK_F24
+	x11KeysymDelete    = 0xFFFF // XK_Delete
+	x11KeysymJ         = 0x006A // XK_j
 )
 
 // TestX11KeysymFor_NavigationKeys pins the four navigation keys on the X11
@@ -64,12 +70,47 @@ func TestX11KeysymFor_NavigationKeys(t *testing.T) {
 	}
 }
 
+// TestX11KeysymFor_EditingKeys pins Backspace, Delete and Insert, and pins them
+// together because the first two are the pair a hotkey can get wrong without
+// noticing. X11 spells the erase-left key "BackSpace", so Neru's "Backspace"
+// resolves only when the lookup maps it; and the vocabulary makes "Backspace"
+// an alias of "Delete", so a lookup that folded aliases would grab X11's
+// forward-delete key instead. Both spellings must reach their own keysym, and
+// neither may reach the other's.
+func TestX11KeysymFor_EditingKeys(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		key  string
+		want uint32
+	}{
+		{name: "backspace", key: keyvocab.KeyBackspace, want: x11KeysymBackSpace},
+		{name: "lowercased backspace", key: "backspace", want: x11KeysymBackSpace},
+		{name: "delete", key: keyvocab.KeyDelete, want: x11KeysymDelete},
+		{name: "lowercased delete", key: "delete", want: x11KeysymDelete},
+		{name: "insert", key: keyvocab.KeyInsert, want: x11KeysymInsert},
+		{name: "lowercased insert", key: "insert", want: x11KeysymInsert},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := uint32(x11KeysymFor(testCase.key)); got != testCase.want {
+				t.Fatalf("x11KeysymFor(%q) = %#x, want %#x", testCase.key, got, testCase.want)
+			}
+		})
+	}
+}
+
 // TestX11KeysymFor_ExistingSpellings pins the keys that resolved before the
 // navigation keys joined the switch. The lookup now canonicalizes through the
 // named-key vocabulary rather than lowercasing in place, so every spelling a
 // hotkey could already be written in has to keep landing on the same keysym —
 // including the ones that resolve through XStringToKeysym rather than the
-// switch (a function key, a single letter).
+// switch. The function keys, the other fallback resolvers, have a test of their
+// own below.
 func TestX11KeysymFor_ExistingSpellings(t *testing.T) {
 	t.Parallel()
 
@@ -89,7 +130,6 @@ func TestX11KeysymFor_ExistingSpellings(t *testing.T) {
 		{name: "down", key: keyvocab.KeyDown, want: x11KeysymDown},
 		{name: "left", key: keyvocab.KeyLeft, want: x11KeysymLeft},
 		{name: "right", key: keyvocab.KeyRight, want: x11KeysymRight},
-		{name: "function key", key: "F5", want: x11KeysymF5},
 		{name: "single letter", key: "j", want: x11KeysymJ},
 		{name: "uppercase single letter", key: "J", want: x11KeysymJ},
 	}
@@ -103,4 +143,99 @@ func TestX11KeysymFor_ExistingSpellings(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestX11KeysymFor_FunctionKeys walks the whole function-key range rather than
+// sampling it. F1-F24 are the one group the lookup leaves to XStringToKeysym,
+// because X11's own name for each of them is the name Neru writes; restating 24
+// spellings in the switch to say so would be noise, so the claim is checked
+// here instead, for every key in the range and in both the spellings a config
+// file can use.
+//
+// XK_F1 through XK_F35 are one contiguous block in keysymdef.h, which is what
+// makes the expected value computable rather than a list; the ends of Neru's
+// range are pinned as literals above so a wrong base cannot go unnoticed.
+func TestX11KeysymFor_FunctionKeys(t *testing.T) {
+	t.Parallel()
+
+	functionKeys := functionKeyNames(t)
+
+	for index, key := range functionKeys {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			want := uint32(x11KeysymF1 + index)
+
+			for _, spelling := range []string{key, strings.ToLower(key)} {
+				if got := uint32(x11KeysymFor(spelling)); got != want {
+					t.Fatalf("x11KeysymFor(%q) = %#x, want %#x", spelling, got, want)
+				}
+			}
+		})
+	}
+
+	last := functionKeys[len(functionKeys)-1]
+	if got := uint32(x11KeysymFor(last)); got != x11KeysymF24 {
+		t.Fatalf("last function key %q = %#x, want %#x", last, got, x11KeysymF24)
+	}
+}
+
+// TestX11KeysymFor_EveryNamedKeyResolves is the net under the tests above: a
+// named key the vocabulary accepts but this lookup cannot resolve is a binding
+// `neru config validate` calls fine and a grab then rejects with
+// CodeInvalidInput, which is how "Backspace" reached a release. Adding a name to
+// keyvocab without teaching X11 about it fails here rather than in someone's
+// config.
+func TestX11KeysymFor_EveryNamedKeyResolves(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range keyvocab.NamedKeys() {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			if x11KeysymFor(key) == 0 {
+				t.Fatalf("named key %q resolves to no X11 keysym", key)
+			}
+		})
+	}
+}
+
+// functionKeyNames returns the function keys the vocabulary declares, in F1..Fn
+// order, so the range is read from its one home rather than restated here.
+func functionKeyNames(t *testing.T) []string {
+	t.Helper()
+
+	byNumber := make(map[int]string)
+	highest := 0
+
+	for _, key := range keyvocab.NamedKeys() {
+		if !strings.HasPrefix(key, "F") {
+			continue
+		}
+
+		number, err := strconv.Atoi(strings.TrimPrefix(key, "F"))
+		if err != nil || number < 1 {
+			continue
+		}
+
+		byNumber[number] = key
+		highest = max(highest, number)
+	}
+
+	if highest == 0 {
+		t.Fatal("no function keys found in the named-key vocabulary")
+	}
+
+	names := make([]string, 0, highest)
+
+	for number := 1; number <= highest; number++ {
+		key, ok := byNumber[number]
+		if !ok {
+			t.Fatalf("function key range has a hole at F%d", number)
+		}
+
+		names = append(names, key)
+	}
+
+	return names
 }


### PR DESCRIPTION
## Description

Binding a global hotkey to `Backspace` on X11 failed to register. `neru config
validate` accepted the binding — `Backspace` is a named key — and then the grab
died at runtime with `CodeInvalidInput`, because X11 spells the key `BackSpace`
and neither the explicit switch in `x11KeysymFor` nor its `XStringToKeysym`
fallback resolved Neru's spelling. The comment #1394 left in that file named the
gap; this closes it.

`Backspace` is now mapped explicitly to `XK_BackSpace`. The obvious repair is
the wrong one and stays refused: folding the name through the vocabulary's
aliases resolves `Backspace` to `Delete`, which on X11 is the forward-delete
key — a different physical key — so the lookup keeps reading `NamedKeyDisplay`
before `ResolveAlias`, as #1394 set it up to.

On the ticket's "related but separate" question: `Delete` and `Insert` are now
mapped explicitly too. They already resolved, but only because X11 spells them
the way Neru does, and `Delete` in particular is the key `Backspace` can be
mistaken for — the two belong in the reader's eye as one group that cannot drift
into each other. `F1`–`F24` are deliberately left on the `XStringToKeysym`
fallback: 24 switch cases restating X11's own name for each key would be table
noise. Instead the whole range is walked by test — every key, in both spellings
a config file can use — so nothing in it rests on an unchecked coincidence.

There is also now a net under all of it: a test asserting that every name in
`keyvocab.NamedKeys()` resolves to some X11 keysym. A named key the validator
accepts and this lookup cannot resolve is exactly the failure this ticket is
about, and adding one to the vocabulary should fail in CI rather than in
someone's config.

## Related Issues

Closes #1398

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this changes a key lookup inside an already-supported capability; no new symbol crosses the boundary and the existing no-cgo twin is untouched
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, `docs/CONFIGURATION.md`
      already lists `Backspace` among the bindable named keys; this makes the
      code match what is documented
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Developed test-first. `TestX11KeysymFor_EditingKeys` failed on both `Backspace`
rows before the fix and passed on `Delete` and `Insert` — which is exactly the
coincidence the ticket describes, visible in the test output. The vocabulary
guard was checked the same way: with the switch case reverted it fails on
`Backspace` on its own, so it really is a net and not a restatement of the
cases below it.

Two adjacent things noticed and deliberately not touched:

- `docs/CONFIGURATION.md`'s key table annotates `Insert` as "Linux only; on X11
  the keypad Insert key". That is true of the event tap, which reaches Insert
  only through `XK_KP_Insert`, but not of the global-hotkey path, where main
  Insert already resolved before this PR and still does. Pre-existing wording
  that reads as if it scoped both.
- `internal/adapter/platform/windows/keys.go` has the mirror of this bug:
  `case "backspace", "delete": return vkBack` collapses the two into one virtual
  key, so a Windows `Delete` hotkey grabs Backspace. Left alone — it is another
  ticket's file.

Both changed files are `//go:build linux && cgo`, invisible to `just lint` and
`just test` on a macOS host, so they were also run through the containerised
Linux path: `just lint-cross` (0 issues, Linux CGO-on and Windows) and
`just test-linux` (full suite green), alongside `just ci` on the host.
