### PR TITLE
fix(eventtap): make the Insert key work on X11 and on Windows

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -343,7 +343,7 @@ which of the two applies to your session.
 | Numbers    | `0`–`9`                                                                                                 |
 | Symbols    | `` ` ``, `-`, `=`, `[`, `]`, `\`, `;`, `'`, `,`, `.`, `/`                                               |
 | Named      | `Space`, `Return`, `Enter`, `Escape`, `Tab`, `Delete`, `Backspace`                                      |
-| Navigation | `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown`, `Insert` (Linux only; on X11 the keypad Insert key) |
+| Navigation | `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown`, `Insert` (Linux and Windows only)   |
 | Function   | `F1`–`F24` (`F21`–`F24` on Linux and Windows only)                                                      |
 
 See [CLI.md](CLI.md#neru-action-feed) for a full key reference with key codes and platform behavior.

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -580,7 +580,14 @@ Work that is genuinely missing, as opposed to deliberately platform-specific.
 
 **macOS**
 
-No known functional gaps; it is the reference implementation.
+1. Named keys without a Carbon keycode — `Insert` and `F21`–`F24` validate but
+   never fire, because Carbon declares no virtual key code for them. They stay
+   in the shared key vocabulary so one config file works on every platform
+   ([ADR 0008](./adr/0008-a-vocabulary-has-one-home.md)), and the absence is
+   pinned by `internal/architecture/named_key_tables_test.go` — the day macOS
+   grows a keycode, that test fails.
+
+Otherwise none; macOS is the reference implementation.
 
 ---
 

--- a/docs/adr/0008-a-vocabulary-has-one-home.md
+++ b/docs/adr/0008-a-vocabulary-has-one-home.md
@@ -25,9 +25,12 @@ Those four are the state this ADR was written against, and three are now
 fixed: the navigation keys reach X11 and Windows (#1382), the macOS numpad
 folds to named keys (#1377), and `Insert` validates everywhere (#1390). The
 paragraph above is kept as written because the decision below was made against
-it, and because the shape it describes outlived the instances — `Insert` is
-now the accepted spelling that X11, Windows and macOS all drop, which is the
-same failure wearing the opposite sign.
+it, and because the shape it describes outlived the instances — `Insert`
+became the accepted spelling that X11, Windows and macOS all dropped, the same
+failure wearing the opposite sign. X11 and Windows emit it now (#1392), and
+macOS is the one backend left. That one is not the same failure: Carbon
+declares no Insert virtual key code, so it is the documented F21–F24 gap under
+another name.
 
 The element roles have the opposite shape: one real home —
 `internal/domain/element`'s `RoleVocabulary` table, with per-platform coverage

--- a/internal/adapter/eventtap/linux/x11_cgo.go
+++ b/internal/adapter/eventtap/linux/x11_cgo.go
@@ -227,10 +227,11 @@ func x11KeysymName(keysym C.KeySym) string {
 		return evdevKeyNamePageUp
 	case C.XK_Page_Down, C.XK_KP_Page_Down:
 		return evdevKeyNamePageDown
-	// Keypad-only, for want of a main-keyboard equivalent that reaches this
-	// lookup: XLookupString answers the main Delete key with a character.
-	case C.XK_KP_Insert:
+	case C.XK_Insert, C.XK_KP_Insert:
 		return evdevKeyNameInsert
+	// Keypad-only, for want of a main-keyboard equivalent that reaches this
+	// lookup: XLookupString answers the main Delete key with a character, and
+	// the keypad's center key has no main-keyboard counterpart at all.
 	case C.XK_KP_Delete:
 		return evdevKeyNameDelete
 	case C.XK_KP_Begin:

--- a/internal/adapter/eventtap/linux/x11_keys_test.go
+++ b/internal/adapter/eventtap/linux/x11_keys_test.go
@@ -14,6 +14,7 @@ const (
 	x11KeysymPageUp   = 0xFF55 // XK_Page_Up / XK_Prior
 	x11KeysymPageDown = 0xFF56 // XK_Page_Down / XK_Next
 	x11KeysymEnd      = 0xFF57 // XK_End
+	x11KeysymInsert   = 0xFF63 // XK_Insert
 )
 
 // The keypad keysyms X11 reports while NumLock is off, pinned the same way.
@@ -71,6 +72,12 @@ func TestX11KeyFromLookupNavigationKeys(t *testing.T) {
 			got:       x11KeyFromLookup(0, nil, x11KeysymEnd),
 			evdevCode: evdevKeyEnd,
 			want:      "End",
+		},
+		{
+			name:      "insert",
+			got:       x11KeyFromLookup(0, nil, x11KeysymInsert),
+			evdevCode: evdevKeyInsert,
+			want:      "Insert",
 		},
 	}
 

--- a/internal/adapter/platform/windows/keys.go
+++ b/internal/adapter/platform/windows/keys.go
@@ -31,6 +31,7 @@ const (
 	vkUp       = 0x26
 	vkRight    = 0x27
 	vkDown     = 0x28
+	vkInsert   = 0x2D
 	vkDelete   = 0x2E
 	vkLShift   = 0xA0
 	vkRShift   = 0xA1
@@ -148,6 +149,8 @@ func KeyNameFromVirtualKey(virtualKey uint32) string {
 		return "Home"
 	case vkEnd:
 		return "End"
+	case vkInsert:
+		return "Insert"
 	case vkDelete:
 		return "Delete"
 	case vkLShift, vkRShift:
@@ -347,6 +350,8 @@ func nameToVirtualKey(name string) (uint32, bool) {
 		return vkHome, true
 	case "end":
 		return vkEnd, true
+	case "insert":
+		return vkInsert, true
 	default:
 		if vk, ok := functionKeyVirtualKey(lowered); ok {
 			return vk, true

--- a/internal/adapter/platform/windows/keys_test.go
+++ b/internal/adapter/platform/windows/keys_test.go
@@ -101,7 +101,9 @@ func TestFunctionKeyRoundTrip(t *testing.T) {
 // documented as valid on every platform and the other backends emit them, so
 // the hook has to name them and a global hotkey has to register them rather
 // than fail with errUnsupportedHotkeyKey. MapVirtualKey yields no character for
-// these codes, so the explicit table is the only path that names them.
+// these codes, so the explicit table is the only path that names them. Insert
+// is here for the same reason; macOS carries no entry for it, which
+// internal/architecture/named_key_tables_test.go states and pins.
 func TestNavigationKeyRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -114,6 +116,7 @@ func TestNavigationKeyRoundTrip(t *testing.T) {
 		{name: "page down", virtualKey: vkNext, want: "PageDown"},
 		{name: "home", virtualKey: vkHome, want: "Home"},
 		{name: "end", virtualKey: vkEnd, want: "End"},
+		{name: "insert", virtualKey: vkInsert, want: "Insert"},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/domain/keyvocab/named_keys.go
+++ b/internal/domain/keyvocab/named_keys.go
@@ -25,7 +25,10 @@ const (
 	KeyEnd       = "End"
 	KeyPageUp    = "PageUp"
 	KeyPageDown  = "PageDown"
-	KeyInsert    = "Insert"
+	// KeyInsert has no macOS virtual keycode (Carbon declares none), so it
+	// reaches a binding only on Linux and Windows. It stays in the shared set
+	// for the same reason F21-F24 do.
+	KeyInsert = "Insert"
 )
 
 // shorthandEscape is the one spelling that resolves to a named key without


### PR DESCRIPTION
## Description

This PR fixes the Insert key doing nothing on X11 and on Windows. `Insert`
became a valid key name on every platform in #1390 because the Linux evdev and
Wayland backends already delivered it, which left the opposite problem: the
binding was accepted, and three of the five backends dropped the keystroke
without a word. Under X11 and on Windows, pressing Insert now fires the binding
written for it, and on Windows an `Insert` global hotkey registers instead of
being refused. Nothing about the macOS behaviour changes.

macOS is the deliberate limitation. Carbon declares no Insert virtual key code,
so an Insert binding still reaches a keystroke only on Linux and Windows —
exactly the documented shape of the existing `F21`–`F24` gap, which the
architecture pin added in #1396 already states and enforces. The key stays valid
everywhere so one config file remains shareable across platforms; the docs row
and the vocabulary declaration now say where it actually works.

## Related Issues

Closes #1392

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this adds an entry to two existing key-name tables rather than a port capability; the macOS absence is a keycode gap, documented and pinned, not a stub.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config and command surface

No new or renamed options. One key name changes where it works:

| Written in `config.toml` | Before                          | After                     |
| ------------------------ | ------------------------------- | ------------------------- |
| `Insert`                 | validates everywhere; fires only on Linux evdev and Wayland | validates everywhere; fires on Linux (evdev, Wayland, X11) and Windows |

Existing configs keep working — nothing that was accepted before is refused now.

```toml
[hotkeys]
"Insert" = "hints"
```

`docs/CONFIGURATION.md` previously annotated the key `(Linux only; on X11 the
keypad Insert key)`; that qualifier described this bug and is now
`(Linux and Windows only)`, matching the wording the `F21`–`F24` row already
uses. `internal/domain/keyvocab` gained the same note at the declaration, where
the F-key gap is already recorded.

## Additional Context

- The X11 half joins main-keyboard `XK_Insert` to the keypad `XK_KP_Insert` case
  #1395 added, and the "keypad-only" comment moves down to the two cases it
  still describes. The name is the one the shared keymap fold table already
  gives the key, so one physical key reaches one binding across all three Linux
  taps. No new name canonicalisation was introduced — the alias hazard recorded
  in #1394 does not arise, since `Insert` has no vocabulary alias.
- The Windows half names `VK_INSERT` in the hook's table and resolves `insert`
  for `RegisterHotKey`, following #1382's precedent for the navigation keys, so
  both the tap path and the global-hotkey path work.
- Tests were written first and observed failing: the X11 case was run red then
  green in the Linux CI-equivalent container (`just test-linux`). The Windows
  test cannot execute on a macOS host, so it is compile-verified here
  (`just check-cross`) and runs for real on the Windows CI leg. `just lint-cross`
  is also clean for both linux/amd64 and windows/amd64.
- ADR 0008's status paragraph tracked `Insert` as "the accepted spelling that
  X11, Windows and macOS all drop". That is now true of macOS alone, so that
  status paragraph is updated in place, the way it was when the three earlier
  defects shipped. The original problem statement above it stays untouched, as
  it says it should. `docs/CROSS_PLATFORM.md` gained a matching Known Gaps
  entry under macOS — that file owns gap status, and it still claimed macOS had
  none; the entry covers `F21`–`F24` as well, which was already true and
  unrecorded.
- Adjacent, not fixed here: the `neru action feed` key table in `docs/CLI.md`
  lists neither `insert` nor `pagedown`, the latter missing since #1382. That
  table describes key *synthesis*, a different path from the taps this PR
  changes, so correcting it is left as its own change.
