### PR TITLE
test(architecture): keep the macOS overlay stack linked to its bridge

### DIFF
--- a/internal/adapter/overlay/darwin/manager.go
+++ b/internal/adapter/overlay/darwin/manager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/virtualpointer"
+	_ "github.com/y3owk1n/neru/internal/adapter/platform/darwin" // links the Objective-C behind overlay.h (ADR 0009)
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/derrors"
 	"github.com/y3owk1n/neru/internal/domain"

--- a/internal/adapter/overlay/render/grid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/grid/overlay_darwin.go
@@ -23,6 +23,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/overlayutil"
+	// The overlay.h included above only declares its symbols; importing the
+	// bridge is what links the Objective-C that defines them (ADR 0009).
+	_ "github.com/y3owk1n/neru/internal/adapter/platform/darwin"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/domain"
 	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"

--- a/internal/adapter/overlay/render/hints/overlay_darwin.go
+++ b/internal/adapter/overlay/render/hints/overlay_darwin.go
@@ -21,6 +21,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/overlayutil"
+	// The overlay.h included above only declares its symbols; importing the
+	// bridge is what links the Objective-C that defines them (ADR 0009).
+	_ "github.com/y3owk1n/neru/internal/adapter/platform/darwin"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/derrors"
 )

--- a/internal/adapter/overlay/render/modeindicator/overlay_darwin.go
+++ b/internal/adapter/overlay/render/modeindicator/overlay_darwin.go
@@ -16,6 +16,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/overlayutil"
+	// The overlay.h included above only declares its symbols; importing the
+	// bridge is what links the Objective-C that defines them (ADR 0009).
+	_ "github.com/y3owk1n/neru/internal/adapter/platform/darwin"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/ports"

--- a/internal/adapter/overlay/render/overlayutil/factory_darwin.go
+++ b/internal/adapter/overlay/render/overlayutil/factory_darwin.go
@@ -13,6 +13,11 @@ import (
 
 	"go.uber.org/zap"
 
+	// The overlay.h included above only declares its symbols; importing the
+	// bridge is what links the Objective-C that defines them (ADR 0009). It
+	// belongs here rather than in util.go, which carries no build tag and so
+	// may not name a platform package at all.
+	_ "github.com/y3owk1n/neru/internal/adapter/platform/darwin"
 	"github.com/y3owk1n/neru/internal/derrors"
 )
 

--- a/internal/adapter/overlay/render/recursivegrid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/recursivegrid/overlay_darwin.go
@@ -21,6 +21,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/overlayutil"
+	// The overlay.h included above only declares its symbols; importing the
+	// bridge is what links the Objective-C that defines them (ADR 0009).
+	_ "github.com/y3owk1n/neru/internal/adapter/platform/darwin"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/recursivegrid"

--- a/internal/adapter/overlay/render/stickyindicator/overlay_darwin.go
+++ b/internal/adapter/overlay/render/stickyindicator/overlay_darwin.go
@@ -16,6 +16,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/overlayutil"
+	// The overlay.h included above only declares its symbols; importing the
+	// bridge is what links the Objective-C that defines them (ADR 0009).
+	_ "github.com/y3owk1n/neru/internal/adapter/platform/darwin"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/ports"
 )

--- a/internal/adapter/overlay/render/virtualpointer/overlay_darwin.go
+++ b/internal/adapter/overlay/render/virtualpointer/overlay_darwin.go
@@ -16,6 +16,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/overlayutil"
+	// The overlay.h included above only declares its symbols; importing the
+	// bridge is what links the Objective-C that defines them (ADR 0009).
+	_ "github.com/y3owk1n/neru/internal/adapter/platform/darwin"
 	"github.com/y3owk1n/neru/internal/config"
 )
 

--- a/internal/architecture/cgo_includes_test.go
+++ b/internal/architecture/cgo_includes_test.go
@@ -218,6 +218,18 @@ type bridgeConsumer struct {
 // binary, and a test binary that fails to link says so on the spot, in the
 // package being tested.
 //
+// The judgement is per package, not per build constraint, which is the
+// granularity the rule is stated at: it does not ask whether the file holding
+// the include and the file holding the import are compiled together. For the
+// darwin bridge nothing can slip through that gap — the One Rule allows the
+// import only in a darwin-tagged file or a darwin/ directory, and depguard and
+// TestNonDarwinFilesDoNotImportDarwinPlatformPackage both enforce it. For a
+// bridge with no such rule the mismatch is a build failure rather than a
+// missing symbol, because a package tagged for one OS cannot import another
+// OS's bridge at all. Evaluating constraints here would mean resolving every
+// file against every GOOS and cgo setting, for a case neither bridge can
+// currently reach.
+//
 // Reaching the archive transitively instead is what this forbids, and the
 // failure it prevents is the expensive kind: the whole overlay render tree
 // once arrived through overlay/render/overlayutil/native, so refactoring

--- a/internal/architecture/cgo_includes_test.go
+++ b/internal/architecture/cgo_includes_test.go
@@ -1,7 +1,11 @@
 package architecture_test
 
 import (
+	"fmt"
+	"go/parser"
+	"go/token"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -29,6 +33,11 @@ var cgoSourceExtensions = map[string]bool{
 // against rules that are not ours. Widening a guardrail is a decision of its
 // own: the answer to a new tree wanting the check is to name it here.
 var cgoSourceRoots = []string{"internal/", "cmd/"}
+
+// bridgePackageDirPrefix is where a bridge lives: internal/adapter/platform/
+// <os>/. A relative #include that resolves below it is a bridge header, and
+// the directory it resolves into is the bridge package.
+const bridgePackageDirPrefix = "internal/adapter/platform/"
 
 // nativeCgoFloor is the fewest .h/.m/.c files the native bridges hold. The
 // files a relative #include can appear in are mostly Go, so the floor on the
@@ -132,7 +141,7 @@ func TestCgoIncludes_NativeBridgePointsAtThePlatformPackages(t *testing.T) {
 		}
 
 		// Files inside the platform packages include their own headers.
-		if strings.Contains(file.rel, "internal/adapter/platform/") {
+		if strings.HasPrefix(file.rel, bridgePackageDirPrefix) {
 			return
 		}
 
@@ -160,4 +169,154 @@ func TestCgoIncludes_NativeBridgePointsAtThePlatformPackages(t *testing.T) {
 	})
 
 	assertWalkedAtLeast(t, "sources outside the platform packages", checked, bulkWalkFloor)
+}
+
+// modulePath is this module's import path, which is what turns a directory in
+// the checkout into the import a Go file states for it.
+const modulePath = "github.com/y3owk1n/neru"
+
+// bridgeConsumerFloor is the fewest package-to-bridge edges expected in the
+// checkout — one per bridge a package includes a header of. Nineteen packages
+// hold one today; below half of that, the matching has stopped recognizing
+// them rather than the repo having stopped including headers.
+const bridgeConsumerFloor = 10
+
+// compiledNativeExtensions are the files that make a package compile objects
+// of its own. A .h is not one of them: a header declares symbols and defines
+// none, so a package holding only headers still has an archive to link and
+// still owes the import.
+var compiledNativeExtensions = map[string]bool{".m": true, ".c": true}
+
+// bridgeConsumer is what one package outside the bridges did with them: the
+// bridges it includes a header of (with the file that does, for the failure
+// message), the bridges it imports, and whether it compiles native source of
+// its own.
+type bridgeConsumer struct {
+	includes   map[string]string
+	imports    map[string]bool
+	ownsNative bool
+}
+
+// TestCgoIncludes_HeaderConsumersLinkTheBridge pins the second half of the
+// bridge boundary. TestCgoIncludes_NativeBridgePointsAtThePlatformPackages
+// above pins where a header may be reached *from*; this pins that the compiled
+// objects behind that header are actually linked into the binary.
+//
+// Including a header only declares the symbols. What links the Objective-C or
+// C that defines them is importing the bridge's Go package, whether or not any
+// Go symbol there is called — so a package that includes a bridge header
+// states that import directly, and a blank import is the right form when it
+// calls nothing (ADR 0009, and *Bridge* in CONTEXT.md).
+//
+// A package that compiles native source of its own is exempt, because it needs
+// the header and not the archive: internal/adapter/systray/darwin builds
+// systray_darwin.m in its own package and reaches platform/darwin not at all.
+// That is the rule stated rather than an exception carved for it — the rule is
+// about linkage, and a package holding its own .m has nothing to link.
+//
+// Test files are left out of both halves. What has to link here is the shipped
+// binary, and a test binary that fails to link says so on the spot, in the
+// package being tested.
+//
+// Reaching the archive transitively instead is what this forbids, and the
+// failure it prevents is the expensive kind: the whole overlay render tree
+// once arrived through overlay/render/overlayutil/native, so refactoring
+// overlayutil to stop needing that shim would have broken eight packages at
+// once, on macOS only, with an undefined-symbol error naming none of them.
+func TestCgoIncludes_HeaderConsumersLinkTheBridge(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	fileSet := token.NewFileSet()
+	checked := 0
+
+	consumers := map[string]*bridgeConsumer{}
+
+	consumerFor := func(dir string) *bridgeConsumer {
+		if consumers[dir] == nil {
+			consumers[dir] = &bridgeConsumer{
+				includes: map[string]string{},
+				imports:  map[string]bool{},
+			}
+		}
+
+		return consumers[dir]
+	}
+
+	walkRepoFiles(t, repoRoot, func(file repoFile) {
+		if !isCgoSource(file) || strings.HasSuffix(file.name, "_test.go") {
+			return
+		}
+
+		// The bridges include their own headers, and their Go files are the
+		// package the rule points at.
+		if strings.HasPrefix(file.rel, bridgePackageDirPrefix) {
+			return
+		}
+
+		checked++
+
+		if compiledNativeExtensions[filepath.Ext(file.name)] {
+			consumerFor(file.dir).ownsNative = true
+		}
+
+		content, readErr := os.ReadFile(file.abs)
+		if readErr != nil {
+			t.Fatalf("ReadFile(%s) error = %v", file.rel, readErr)
+		}
+
+		for _, match := range relativeIncludePattern.FindAllStringSubmatch(string(content), -1) {
+			bridgeDir := path.Dir(path.Join(file.dir, match[1]))
+			if !strings.HasPrefix(bridgeDir, bridgePackageDirPrefix) {
+				continue
+			}
+
+			consumerFor(file.dir).includes[bridgeDir] = file.rel
+		}
+
+		if isNativeSource(file) {
+			return
+		}
+
+		parsed, parseErr := parser.ParseFile(fileSet, file.abs, nil, parser.ImportsOnly)
+		if parseErr != nil {
+			t.Fatalf("ParseFile(%s) error = %v", file.rel, parseErr)
+		}
+
+		for _, imported := range parsed.Imports {
+			importPath := strings.Trim(imported.Path.Value, `"`)
+
+			bridgeDir, isModuleImport := strings.CutPrefix(importPath, modulePath+"/")
+			if !isModuleImport || !strings.HasPrefix(bridgeDir, bridgePackageDirPrefix) {
+				continue
+			}
+
+			consumerFor(file.dir).imports[bridgeDir] = true
+		}
+	})
+
+	var offenders []string
+
+	edges := 0
+
+	for consumerDir, consumer := range consumers {
+		for bridgeDir, includingFile := range consumer.includes {
+			edges++
+
+			if consumer.ownsNative || consumer.imports[bridgeDir] {
+				continue
+			}
+
+			offenders = append(offenders, fmt.Sprintf(
+				"%s\t%s includes a header of %s; add `import _ %q` to a file "+
+					"built for that platform",
+				includingFile, consumerDir, bridgeDir, modulePath+"/"+bridgeDir,
+			))
+		}
+	}
+
+	reportOffenders(t, offenders,
+		"package includes a bridge header, compiles no native source of its "+
+			"own, and never imports the bridge whose objects that header declares")
+
+	assertWalkedAtLeast(t, "sources that could include a bridge header", checked, bulkWalkFloor)
+	assertWalkedAtLeast(t, "package-to-bridge include edges", edges, bridgeConsumerFloor)
 }


### PR DESCRIPTION
## Description

This PR removes a hidden dependency in the macOS overlay stack that could have broken every overlay at once. The overlay windows — hints, both grids, the indicators and the virtual pointer — are drawn by native macOS code, and eight of the packages that draw them were only reaching that code by accident, through a small helper they happen to share. Tidying that helper away, which looks like a harmless cleanup, would have stopped the whole overlay stack linking on macOS, with a build error naming none of the packages that actually broke.

Each of the eight now states that dependency for itself, and a new guardrail keeps it stated: a package that uses the native bridge's headers, and compiles no native code of its own, has to name the bridge directly. Running it costs nothing at build time and it fails with the file, the package and the exact line to add. A package that ships its own native code is exempt because it has nothing to link, and that falls out of the rule rather than being written in by name.

Nothing changes for users at runtime: this is a build-time dependency being made explicit, plus the test that holds it there.

## Related Issues

Closes #1405

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code) — the guardrail itself is untagged and runs on every CI leg
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability changed
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, the decision and the vocabulary entry it belongs to are already on `main`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

This implements ADR 0009 (`docs/adr/0009-a-bridge-interface-is-its-headers.md`). Its status stays `proposed`: the ADR's remaining consequence is still open as #1407, and the flip belongs to whichever of the set lands last.

The guardrail was written before the imports and watched to fail on exactly the eight packages, then watched to pass; removing any one of them again reproduces the failure. It counts what it walked and fails rather than passing green over an empty walk, matching the other guardrails in that package.

The build-tagged dispatch pair under the overlay utilities is deliberately untouched — it is the prescribed way for untagged code to cross to a platform package, and the ADR keeps it. The blank imports are the terse form in one file and the two-line form in the rest only because two of the repo's formatters disagree about a doc comment inside that particular import block.

Also verified with `just lint-cross`, since the host lint is blind to the Linux and Windows build tags.
