### PR TITLE
test(architecture): pin the macOS callback context struct to its Go twin

### DIFF
--- a/docs/adr/0007-a-shared-derivation-has-one-implementation.md
+++ b/docs/adr/0007-a-shared-derivation-has-one-implementation.md
@@ -102,8 +102,8 @@ are the precedent, not the exception.
   predicate. The pin now runs the shared Go rule and reads only the Objective-C
   one, exactly as the label-autohide pin beside it does.
 - **The exception is the half of this rule deletion cannot enforce, so what is
-  pinned is inventoried here.** Six language-boundary copies are pinned as of
-  #1402: the three named above, plus the synthetic key-up and modifier-toggle
+  pinned is inventoried here.** Seven language-boundary copies are pinned as of
+  #1407: the three named above, plus the synthetic key-up and modifier-toggle
   wire prefixes, which `internal/adapter/platform/darwin/eventtap_darwin.m` and
   `internal/adapter/platform/linux/overlay_wayland.c` format with `printf`
   because neither can import `internal/domain/keyvocab`, held to that package by
@@ -157,6 +157,27 @@ are the precedent, not the exception.
   reason is a join rather than a judgement: `evdevKeyNames` answers by kernel
   key code, and only for the keypad does the tree say which keysym a code
   reports, which is what `keypadKeyNameCases` is.
+
+  The seventh is neither a constant, a rule nor a list but a *layout*, and it
+  is the one whose Go side this package can link. `callbackContext`
+  (`internal/adapter/platform/darwin/callback_context.h`) is allocated on the C
+  heap, retained across two `dispatch_async` hops, and cast straight to
+  `overlayutil.CallbackContext` by the `//export`ed Go side that reads it back;
+  a disagreement is a callback ID and a generation read from the wrong offsets,
+  and nothing fails to compile.
+  `internal/architecture/callback_context_layout_test.go` holds the two to the
+  same field names, order and integer widths. It reads the header through
+  `readNativeSource` like every pin here and *reflects* over the Go struct
+  rather than parsing it, which is the state the sub-key-preview pin above
+  reached only after #1297 gave its Go copy an untagged home: `overlayutil`
+  never had a build tag, so the Go side can be linked on every CI leg, and
+  `reflect` answers with the field order and width the cast actually depends on
+  rather than with the spelling the declaration happens to use. What the pin
+  buys differs by leg, because the cgo allocator in
+  `internal/adapter/platform/darwin/cstring.go` already catches some of these
+  as compile errors on macOS and nothing catches any of them off it; which
+  cases are left to the pin is written in the pin's own doc comment, where
+  someone editing it will read it.
 
   That list is the complete set of *pinned* copies, and it is deliberately not a
   claim that no others exist — sweeping for them while writing the sub-key

--- a/docs/adr/0009-a-bridge-interface-is-its-headers.md
+++ b/docs/adr/0009-a-bridge-interface-is-its-headers.md
@@ -1,6 +1,6 @@
 # A bridge's interface is its headers, not its Go API
 
-**Status**: proposed
+**Status**: accepted
 
 `internal/adapter/platform/darwin` compiles roughly 5,400 lines of Objective-C
 that no `.go` file in the package includes: `overlay.h` and its 3,920-line
@@ -99,12 +99,16 @@ shape, and *Bridge* in `CONTEXT.md` is written for both.
   are callback targets means following `//export` reachability, and every
   approximation of that either misses the case it exists for or fires on
   innocent vars. The contract carries this one, not a test.
-- `callback_context.h:13` says its struct *"matches overlayutil.CallbackContext
-  in Go"*, a layout pinned across the language boundary by a comment, with the
-  two halves in packages that cannot see each other. It joins ADR 0007's
-  inventory as a pin, using the `readNativeSource` entry point
-  `native_constants_test.go` already publishes. This is a missed case of a
-  convention that already runs, not a new one.
+- `callback_context.h` said its struct *"matches overlayutil.CallbackContext in
+  Go"* — a layout pinned across the language boundary by a comment, with the two
+  halves in packages that cannot see each other. It joins ADR 0007's inventory
+  as a pin instead, reading the header through the `readNativeSource` entry
+  point `native_constants_test.go` already publishes, and the comment now points
+  at that pin rather than standing in for it. This is a missed case of a
+  convention that already runs, not a new one. The one thing it settled that
+  this decision had assumed: the Go half is *not* behind a build tag, so it is
+  linked and reflected over rather than read as text, and only the header is a
+  reading. ADR 0007's inventory carries the detail.
 - *Bridge* moves into `CONTEXT.md` and carries this rule; the one-line
   definition under `AGENTS.md` Domain Concepts goes, because each fact has one
   home.

--- a/internal/adapter/platform/darwin/callback_context.h
+++ b/internal/adapter/platform/darwin/callback_context.h
@@ -10,8 +10,13 @@
 
 #import <stdint.h>
 
-/// Async overlay resize callback context (matches overlayutil.CallbackContext in Go).
-/// Allocated on the C heap so native code can retain it across dispatch boundaries.
+/// Async overlay resize callback context. Allocated on the C heap so native
+/// code can retain it across dispatch boundaries, and cast straight to
+/// overlayutil.CallbackContext by the Go side that reads it back.
+///
+/// The two layouts are held together by
+/// internal/architecture/callback_context_layout_test.go, which pins the field
+/// names, their order and their widths. Change one side there and it fails.
 typedef struct {
 	uint64_t callbackID;
 	uint64_t generation;

--- a/internal/architecture/callback_context_layout_test.go
+++ b/internal/architecture/callback_context_layout_test.go
@@ -1,0 +1,527 @@
+package architecture_test
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/overlayutil"
+)
+
+// The two declarations of one struct. The resize completion path allocates it
+// on the C heap, native code retains it across two dispatch_async hops, and the
+// //export-ed Go side casts the raw pointer straight to the Go type and
+// dereferences it — so the layouts are not merely similar, they are the same
+// bytes read twice.
+const (
+	callbackContextHeader = "internal/adapter/platform/darwin/callback_context.h"
+
+	// callbackContextTypedef is the C typedef's name. Addressing it by name is
+	// what makes a rename fail here rather than pass over nothing.
+	callbackContextTypedef = "callbackContext"
+
+	// nativeIntSuffix is what C spells a fixed-width integer with and Go does
+	// not, so a failure message can name a width in either vocabulary.
+	nativeIntSuffix = "_t"
+)
+
+// callbackContextGoType names the Go side in failure messages, so a reader is
+// sent to the declaration rather than to this test. It is asked of the linked
+// type rather than written down, because a hand-written copy of a name is the
+// kind of thing this file exists to distrust.
+var callbackContextGoType = reflect.TypeFor[overlayutil.CallbackContext]().String()
+
+// callbackContextField is one field of either declaration: the name it is
+// written with, and its width spelled the way Go spells it.
+//
+// Both sides are reduced to this before anything is compared, so the comparison
+// is over layout rather than over two vocabularies.
+type callbackContextField struct {
+	name string
+
+	// goType is the fixed-width integer type the field is, in Go's spelling —
+	// "uint64" for a Go uint64 and for a C uint64_t alike.
+	goType string
+}
+
+// TestCallbackContextLayoutIsPinnedAcrossTheLanguageBoundary holds
+// callback_context.h's struct to overlayutil.CallbackContext.
+//
+// This is ADR 0007's deliberate exception to the one-implementation rule: Go
+// cannot be the implementation of a C struct that native code allocates and
+// retains, so the copies get a pin instead of a deletion
+// (docs/adr/0007-a-shared-derivation-has-one-implementation.md). What makes
+// this copy worth pinning is that a disagreement is silent — nothing fails to
+// compile, and no cast is checked. A callback ID and a generation would be read
+// from the wrong offsets, validated against the registry in
+// internal/adapter/overlay/render/overlayutil/util.go, and then dropped as
+// stale or dispatched on garbage.
+//
+// It fails on the mistakes that happen: a field added to one side, the two
+// fields reordered, a type widened or narrowed, and a field renamed on one
+// side. The Go side is reflected over rather than read as text, because this
+// package can link it — overlayutil carries no build tag, and reflection is
+// what the //export-ed cast actually depends on. The C side has no such
+// counterpart off macOS and is read through readNativeSource, the entry point
+// every language-boundary pin here shares.
+//
+// What is left for it to catch on macOS is narrower than what it catches
+// elsewhere, and worth being clear about. MallocCallbackContext
+// (internal/adapter/platform/darwin/cstring.go) names the struct and both
+// members through cgo, so on a macOS build a renamed struct, a renamed member
+// and a changed width are already compile errors — verified by making each of
+// those three edits. The reorder is not: both members are uint64 and cgo
+// assigns them by name, so swapping them compiles and every other leg has no
+// cgo at all. That is the case this pin is the only reader of.
+func TestCallbackContextLayoutIsPinnedAcrossTheLanguageBoundary(t *testing.T) {
+	t.Parallel()
+
+	native := readCallbackContextHeader(t)
+	goSide := goCallbackContextFields(t, reflect.TypeFor[overlayutil.CallbackContext]())
+
+	for _, problem := range callbackContextProblems(native, goSide) {
+		t.Error(problem)
+	}
+}
+
+// TestCallbackContextLayoutPinCatchesDrift is the ticket's acceptance check,
+// kept rather than performed once: each way the two declarations could move
+// apart is applied to a copy of what the pin read, and the pin has to tell it
+// from the tree.
+//
+// The Go drifts are whole struct types declared here and reflected over the way
+// the real one is, so what they exercise is the reader as well as the
+// comparison. The C drifts are applied to the fields parsed out of the header,
+// which keeps this honest across a reformat of it.
+func TestCallbackContextLayoutPinCatchesDrift(t *testing.T) {
+	t.Parallel()
+
+	native := readCallbackContextHeader(t)
+	goSide := goCallbackContextFields(t, reflect.TypeFor[overlayutil.CallbackContext]())
+
+	for _, drift := range callbackContextDrifts(t) {
+		drifted := drift.apply(native, goSide)
+
+		if callbackContextProblems(drifted.native, drifted.goSide) == nil {
+			t.Errorf(
+				"no check tells %s apart from the declarations in the tree: %s would pass the pin",
+				drift.name, drift.where,
+			)
+		}
+	}
+}
+
+// TestCallbackContextLayoutPinReportsADeclarationItCannotRead pins the other
+// half of the guardrail: a declaration this pin cannot read must be reported,
+// never skipped. A pin that reads nothing and passes is worse than no pin,
+// because it reads as coverage.
+//
+// The Go side needs no case here — it is linked rather than read, so renaming
+// or moving overlayutil.CallbackContext fails to compile, which is the loudest
+// form of this failure. The C side is text, and the cost of reading text is
+// that the pin reads one spelling: rewriting the struct in an equivalent shape
+// fails here rather than being understood, and the failure names the shape it
+// expected.
+func TestCallbackContextLayoutPinReportsADeclarationItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	header := readNativeSource(t, callbackContextHeader)
+
+	for _, unreadable := range callbackContextUnreadableHeaders(t, header) {
+		if _, problem := parseCallbackContextHeader(unreadable.header); problem == "" {
+			t.Errorf(
+				"parsing accepted a header with %s; the pin would then hold a struct it never read",
+				unreadable.name,
+			)
+		}
+	}
+}
+
+// callbackContextDrift is one way the two declarations could plausibly move
+// apart.
+type callbackContextDrift struct {
+	name  string
+	where string
+	apply func(native, goSide []callbackContextField) callbackContextLayouts
+}
+
+// callbackContextLayouts is what the pin compares: the C fields and the Go
+// fields, each in declaration order.
+type callbackContextLayouts struct {
+	native []callbackContextField
+	goSide []callbackContextField
+}
+
+// callbackContextDrifts are the drifts the pin has to catch. The Go ones are
+// read out of a deliberately mismatched struct type, which is the ticket's
+// "add a field to one side only" and "reorder the two fields" written down.
+func callbackContextDrifts(t *testing.T) []callbackContextDrift {
+	t.Helper()
+
+	goDrift := func(name string, value any) callbackContextDrift {
+		return callbackContextDrift{
+			name:  name,
+			where: callbackContextGoType,
+			apply: func(native, _ []callbackContextField) callbackContextLayouts {
+				return callbackContextLayouts{
+					native: native,
+					goSide: goCallbackContextFields(t, reflect.TypeOf(value)),
+				}
+			},
+		}
+	}
+
+	return append(
+		[]callbackContextDrift{
+			goDrift("a third field added to the Go struct", struct {
+				CallbackID uint64
+				Generation uint64
+				Deadline   uint64
+			}{}),
+			goDrift("the two Go fields reordered", struct {
+				Generation uint64
+				CallbackID uint64
+			}{}),
+			goDrift("a Go field narrowed", struct {
+				CallbackID uint32
+				Generation uint64
+			}{}),
+			goDrift("a Go field renamed", struct {
+				CallbackHandle uint64
+				Generation     uint64
+			}{}),
+			goDrift("a Go field dropped", struct {
+				CallbackID uint64
+			}{}),
+		},
+		callbackContextNativeDrifts()...,
+	)
+}
+
+// callbackContextNativeDrifts are the same drifts on the C side, applied to the
+// fields parsed out of the header.
+func callbackContextNativeDrifts() []callbackContextDrift {
+	nativeDrift := func(name string, mutate func([]callbackContextField) []callbackContextField) callbackContextDrift {
+		return callbackContextDrift{
+			name:  name,
+			where: callbackContextHeader,
+			apply: func(native, goSide []callbackContextField) callbackContextLayouts {
+				return callbackContextLayouts{
+					native: mutate(append([]callbackContextField(nil), native...)),
+					goSide: goSide,
+				}
+			},
+		}
+	}
+
+	return []callbackContextDrift{
+		nativeDrift(
+			"a third field added to the C struct",
+			func(fields []callbackContextField) []callbackContextField {
+				return append(fields, callbackContextField{name: "deadline", goType: "uint64"})
+			},
+		),
+		nativeDrift(
+			"the two C fields reordered",
+			func(fields []callbackContextField) []callbackContextField {
+				return []callbackContextField{fields[1], fields[0]}
+			},
+		),
+		nativeDrift(
+			"a C field narrowed",
+			func(fields []callbackContextField) []callbackContextField {
+				fields[1].goType = "uint32"
+
+				return fields
+			},
+		),
+		nativeDrift(
+			"a C field renamed",
+			func(fields []callbackContextField) []callbackContextField {
+				fields[0].name = "callbackHandle"
+
+				return fields
+			},
+		),
+		nativeDrift(
+			"a C field dropped",
+			func(fields []callbackContextField) []callbackContextField {
+				return fields[:1]
+			},
+		),
+	}
+}
+
+// callbackContextUnreadableHeader is one rewrite of the header this pin must
+// report rather than read past.
+type callbackContextUnreadableHeader struct {
+	name   string
+	header string
+}
+
+// callbackContextUnreadableHeaders doctors the header into shapes this pin does
+// not read.
+func callbackContextUnreadableHeaders(
+	t *testing.T,
+	header string,
+) []callbackContextUnreadableHeader {
+	t.Helper()
+
+	return []callbackContextUnreadableHeader{
+		{
+			name: "the struct renamed",
+			header: mustRewrite(t, header,
+				"} "+callbackContextTypedef+";",
+				"} overlayCallbackContext;",
+			),
+		},
+		{
+			name: "the struct given a tag instead of a typedef name",
+			header: mustRewrite(t, header,
+				"typedef struct {",
+				"struct callbackContext {",
+			),
+		},
+		{
+			name: "a field of a width this pin does not read",
+			header: mustRewrite(t, header,
+				"uint64_t callbackID;",
+				"unsigned long callbackID;",
+			),
+		},
+		{
+			name: "a field whose width is hidden behind an alias",
+			header: mustRewrite(t, header,
+				"uint64_t generation;",
+				"neru_generation_t generation;",
+			),
+		},
+		{
+			name: "the struct emptied",
+			header: mustRewrite(t, header,
+				"\tuint64_t callbackID;\n\tuint64_t generation;\n",
+				"",
+			),
+		},
+	}
+}
+
+// callbackContextProblems is every disagreement between the two declarations.
+//
+// Fields are compared by position, because position is what the cast reads: two
+// uint64 fields swapped is a callback ID validated as a generation, and no
+// count or name check would see it.
+func callbackContextProblems(native, goSide []callbackContextField) []string {
+	var problems []string
+
+	if len(native) != len(goSide) {
+		problems = append(problems, fmt.Sprintf(
+			"%s declares %d field(s) (%s) and %s has %d (%s); "+
+				"the C struct is cast straight to the Go one, so a field on one side only "+
+				"shifts every field after it",
+			callbackContextHeader, len(native), callbackContextFieldList(native, nativeIntSuffix),
+			callbackContextGoType, len(goSide), callbackContextFieldList(goSide, ""),
+		))
+	}
+
+	for index := range min(len(native), len(goSide)) {
+		problems = append(
+			problems,
+			callbackContextFieldProblems(index, native[index], goSide[index])...)
+	}
+
+	return problems
+}
+
+// callbackContextFieldProblems compares the two declarations' field at one
+// position.
+func callbackContextFieldProblems(index int, native, goSide callbackContextField) []string {
+	var problems []string
+
+	if want := nativeFieldSpelling(goSide.name); native.name != want {
+		problems = append(problems, fmt.Sprintf(
+			"field %d is %s.%s in Go and %s in %s; a renamed or reordered field is read "+
+				"from the offset the other one is written to",
+			index, callbackContextGoType, goSide.name, native.name, callbackContextHeader,
+		))
+	}
+
+	if native.goType != goSide.goType {
+		problems = append(problems, fmt.Sprintf(
+			"field %d is %s in %s and %s%s in %s; the widths have to agree or every "+
+				"field after it is read from the wrong offset",
+			index, goSide.goType, callbackContextGoType,
+			native.goType, nativeIntSuffix, callbackContextHeader,
+		))
+	}
+
+	return problems
+}
+
+// callbackContextFieldList spells a declaration for a failure message, in the
+// vocabulary that declaration is written in: suffix is what its language spells
+// a fixed-width integer with, so the C side reads uint64_t and the Go side
+// uint64 rather than both reading whichever this pin compares them as.
+func callbackContextFieldList(fields []callbackContextField, suffix string) string {
+	if len(fields) == 0 {
+		return "none"
+	}
+
+	spelled := make([]string, 0, len(fields))
+	for _, field := range fields {
+		spelled = append(spelled, field.goType+suffix+" "+field.name)
+	}
+
+	return strings.Join(spelled, ", ")
+}
+
+// nativeFieldSpelling spells a Go field name the way the C struct writes it:
+// "CallbackID" becomes "callbackID". The C side lowercases the initial and
+// keeps the rest, which is what both fields there do today. A Go field whose
+// name does not survive that — a leading initialism like "ID" — would fail
+// here, and the fix is to spell the rule for it rather than to loosen it.
+//
+// This is not nativeEnumMemberName (native_constants_test.go) wearing a
+// different name: that one asks how Objective-C spells a value a *person*
+// writes in the config, and answers by capitalising. This asks how C spells a
+// Go struct field, and answers by lowercasing. One question each, opposite
+// directions.
+func nativeFieldSpelling(goName string) string {
+	if goName == "" {
+		return ""
+	}
+
+	return strings.ToLower(goName[:1]) + goName[1:]
+}
+
+// callbackContextStructPattern matches the typedef this pin reads, by the name
+// it is typedef'd to. A struct renamed, given a tag instead, or split into
+// members this pattern does not span is reported rather than passed over.
+//
+// The body admits no brace of its own, which is what makes the name the thing
+// being addressed: were another struct to be declared above this one in the
+// header, the match would begin at that one's opening brace and swallow it.
+var callbackContextStructPattern = regexp.MustCompile(
+	`typedef struct \{([^{}]*)\}[ \t]*` + regexp.QuoteMeta(callbackContextTypedef) + `;`,
+)
+
+// callbackContextFieldPattern matches one `uint64_t callbackID;` member. Only
+// the fixed-width types <stdint.h> declares are read: those are the ones whose
+// width is the same on every ABI, which is the whole reason the C side of a
+// shared struct is written with them.
+var callbackContextFieldPattern = regexp.MustCompile(
+	`^(u?int(?:8|16|32|64))_t[ \t]+([A-Za-z_][A-Za-z0-9_]*);(?:[ \t]*//.*)?$`,
+)
+
+// readCallbackContextHeader reads the C declaration out of the tree, failing
+// the test when it cannot.
+func readCallbackContextHeader(t *testing.T) []callbackContextField {
+	t.Helper()
+
+	fields, problem := parseCallbackContextHeader(readNativeSource(t, callbackContextHeader))
+	if problem != "" {
+		t.Fatal(problem)
+	}
+
+	return fields
+}
+
+// parseCallbackContextHeader reads the struct's members in declaration order.
+// The second result describes why they could not be read, and is empty when
+// they could — an error value would buy nothing here, since the only callers
+// turn it straight into a test failure.
+func parseCallbackContextHeader(header string) ([]callbackContextField, string) {
+	body := callbackContextStructPattern.FindStringSubmatch(header)
+	if body == nil {
+		return nil, fmt.Sprintf(
+			"%s: no `typedef struct { ... } %s;` declaration (renamed or moved?); "+
+				"the layout %s is cast to would be pinned by nothing",
+			callbackContextHeader, callbackContextTypedef, callbackContextGoType,
+		)
+	}
+
+	var fields []callbackContextField
+
+	for line := range strings.SplitSeq(body[1], "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+
+		member := callbackContextFieldPattern.FindStringSubmatch(trimmed)
+		if member == nil {
+			return nil, fmt.Sprintf(
+				"%s: `%s` is a member this pin does not read; it reads "+
+					"`<u>intN_t name;` members, whose width is the same on every ABI",
+				callbackContextHeader, trimmed,
+			)
+		}
+
+		fields = append(fields, callbackContextField{name: member[2], goType: member[1]})
+	}
+
+	if len(fields) == 0 {
+		return nil, fmt.Sprintf(
+			"%s: %s declares no members this pin can read",
+			callbackContextHeader, callbackContextTypedef,
+		)
+	}
+
+	return fields, ""
+}
+
+// goCallbackContextFields reads a Go struct's fields in declaration order.
+//
+// reflect is what the C side has no counterpart for and what the //export-ed
+// cast depends on: the field order here is the order of the bytes, and the Kind
+// is the real width even where the declaration spells it as a named type.
+func goCallbackContextFields(t *testing.T, structType reflect.Type) []callbackContextField {
+	t.Helper()
+
+	if structType.Kind() != reflect.Struct {
+		t.Fatalf("%s is a %s, not a struct", callbackContextGoType, structType.Kind())
+	}
+
+	fields := make([]callbackContextField, 0, structType.NumField())
+
+	for field := range structType.Fields() {
+		if field.Anonymous {
+			t.Fatalf(
+				"%s embeds %s; this pin reads named fields, because an embedded "+
+					"struct's members are laid out here but written elsewhere",
+				callbackContextGoType, field.Type,
+			)
+		}
+
+		if !goFixedWidthKinds[field.Type.Kind()] {
+			t.Fatalf(
+				"%s.%s is a %s; this pin reads fixed-width integer fields, which are "+
+					"the ones a C struct can be laid out to match",
+				callbackContextGoType, field.Name, field.Type.Kind(),
+			)
+		}
+
+		fields = append(fields, callbackContextField{
+			name: field.Name, goType: field.Type.Kind().String(),
+		})
+	}
+
+	return fields
+}
+
+// goFixedWidthKinds are the field kinds a struct shared with C may be laid out
+// from, and each Kind names itself the way its declaration spells it. int, uint
+// and uintptr are left out on purpose: their width is the platform's, which is
+// exactly what such a struct must not depend on.
+var goFixedWidthKinds = map[reflect.Kind]bool{
+	reflect.Int8:   true,
+	reflect.Int16:  true,
+	reflect.Int32:  true,
+	reflect.Int64:  true,
+	reflect.Uint8:  true,
+	reflect.Uint16: true,
+	reflect.Uint32: true,
+	reflect.Uint64: true,
+}

--- a/internal/architecture/callback_context_layout_test.go
+++ b/internal/architecture/callback_context_layout_test.go
@@ -305,6 +305,14 @@ func callbackContextUnreadableHeaders(
 				"",
 			),
 		},
+		{
+			name: "an old copy of the struct left commented out beside it",
+			header: mustRewrite(t, header,
+				"typedef struct {",
+				"/* typedef struct {\n\tuint32_t callbackID;\n} "+
+					callbackContextTypedef+"; */\n\ntypedef struct {",
+			),
+		},
 	}
 }
 
@@ -403,6 +411,7 @@ func nativeFieldSpelling(goName string) string {
 // The body admits no brace of its own, which is what makes the name the thing
 // being addressed: were another struct to be declared above this one in the
 // header, the match would begin at that one's opening brace and swallow it.
+// Every match is read, not the first — see parseCallbackContextHeader for why.
 var callbackContextStructPattern = regexp.MustCompile(
 	`typedef struct \{([^{}]*)\}[ \t]*` + regexp.QuoteMeta(callbackContextTypedef) + `;`,
 )
@@ -433,8 +442,8 @@ func readCallbackContextHeader(t *testing.T) []callbackContextField {
 // they could — an error value would buy nothing here, since the only callers
 // turn it straight into a test failure.
 func parseCallbackContextHeader(header string) ([]callbackContextField, string) {
-	body := callbackContextStructPattern.FindStringSubmatch(header)
-	if body == nil {
+	declarations := callbackContextStructPattern.FindAllStringSubmatch(header, -1)
+	if declarations == nil {
 		return nil, fmt.Sprintf(
 			"%s: no `typedef struct { ... } %s;` declaration (renamed or moved?); "+
 				"the layout %s is cast to would be pinned by nothing",
@@ -442,9 +451,25 @@ func parseCallbackContextHeader(header string) ([]callbackContextField, string) 
 		)
 	}
 
+	// Reading text rather than preprocessed C, this pin cannot tell a
+	// declaration the compiler sees from one inside a block comment or an
+	// inactive #if. What it can do is refuse to choose: a header spelling the
+	// typedef twice is reported, so an old copy left commented out beside a new
+	// one fails here instead of being silently pinned in the new one's place. A
+	// header carrying only a commented-out copy is the case this does not
+	// cover, and cgo does — MallocCallbackContext names the type.
+	if len(declarations) > 1 {
+		return nil, fmt.Sprintf(
+			"%s: %d `typedef struct { ... } %s;` declarations; this pin reads text "+
+				"rather than preprocessed C, so it cannot say which one the compiler "+
+				"sees, and pinning the wrong one reads as coverage",
+			callbackContextHeader, len(declarations), callbackContextTypedef,
+		)
+	}
+
 	var fields []callbackContextField
 
-	for line := range strings.SplitSeq(body[1], "\n") {
+	for line := range strings.SplitSeq(declarations[0][1], "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" || strings.HasPrefix(trimmed, "//") {
 			continue

--- a/internal/architecture/doc.go
+++ b/internal/architecture/doc.go
@@ -8,6 +8,9 @@
 //
 //   - agent_contract_test.go — the agent guide layout: an AGENTS.md beside
 //     every CLAUDE.md symlink, .agents/skills canonical, worktrees ignored.
+//   - callback_context_layout_test.go — the C callback context struct and the
+//     Go struct it is cast to have the same fields, in the same order, at the
+//     same widths.
 //   - cgo_includes_test.go — relative #include paths resolve, and native
 //     headers are reached through internal/adapter/platform/<os>/.
 //   - comment_paths_test.go — a path header, or a comment pointing at a


### PR DESCRIPTION
## Description

This PR adds a guardrail that keeps the macOS overlay's async resize callback
working. The completion path allocates a small record on the C heap, native
code holds it across two dispatch hops, and the Go side reads it back by
casting the raw pointer to its own struct. The two declarations of that record
live in packages that cannot see each other, and until now only a comment said
they had to match — so a field added, reordered, renamed or widened on one side
would have compiled cleanly and then been read from the wrong offsets, ending
as a resize completion silently dropped or dispatched against the wrong
operation.

The guardrail holds the two declarations to the same field names, the same
order and the same integer widths, and fails loudly if either one is renamed or
moved rather than quietly passing over nothing. It also keeps itself honest:
one test applies every way the two could drift and requires the pin to catch
each, and another rewrites the C declaration into shapes the pin does not read
and requires it to report them.

The deliberate limitation is that the C side is read as text, so it recognises
one spelling of the declaration. Rewriting the struct in an equivalent shape
fails the pin rather than being understood — the failure names the shape it
expected, which is the trade every language-boundary pin in this repo makes.

## Related Issues

Closes #1407

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no build-tagged file changes; the only platform edit is a comment in an existing header.
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability changes.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**One acceptance criterion was answered differently, on purpose.** The issue
asks for both sides to be read as text "so it runs on every CI leg rather than
only on macOS", on the reasoning that the Go side sits behind a build tag. It
does not — that declaration is untagged and links on every leg. So the C header
is read as text through the shared reader every language-boundary pin here
already uses, and the Go side is reflected over instead. That satisfies the
intent (the pin runs on all three legs, verified by vetting the package for
linux and windows) and is stricter about the two things the issue actually asks
for: reflection reports the real field order and the real width, and a renamed
or moved Go declaration becomes a compile error rather than a skipped read.

**What the pin adds per platform, stated in the test itself.** On macOS the
cgo allocator already names the struct and both members, so a rename or a
changed width is a compile error today — each of those three edits was made and
watched to fail. The reorder is not caught there: both members are the same
width and cgo assigns them by name. Off macOS no cgo is built at all. The
reorder, and every case on the other two legs, is what this pin is the only
reader of.

**ADR bookkeeping.** The pin joins ADR 0007's inventory of pinned
language-boundary copies as its seventh entry. ADR 0009 moves from proposed to
accepted: this was the last of its three tickets, with #1405 and #1406 already
closed and merged.
