### PR TITLE
docs: correct the cursor-move and smooth-cursor capability rows

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -128,7 +128,7 @@ or no-op) · ❌ no code path
 | **App watcher (focus change)**| ✅ NSWorkspace observer  | ✅ event-driven        | ✅ event-driven              | ✅ event-driven         | 🟡                           |
 | **Keymap learns the focused app** | ✅ published by the watcher | ✅ published by the watcher | ✅ published by the watcher | ✅ published by the watcher | ⚠️ asked when the keymap settles ¹ |
 | **Cursor position**           | ✅ `CGEventGetLocation`  | ✅ `XQueryPointer`     | ✅ sync-surface trick        | ✅ sync-surface trick   | ✅ `GetCursorPos`            |
-| **Cursor move**               | ✅ `CGWarpMouseCursorPosition` | ✅ XTest         | ✅ `zwlr_virtual_pointer`    | ✅ libei                | ✅ `SetCursorPos`            |
+| **Cursor move**               | ✅ `CGEventPost` ([`postMouseMoveLocked`](../internal/adapter/platform/darwin/accessibility_mouse_darwin.m)) | ✅ XTest (`XTestFakeMotionEvent`) | ✅ `zwlr_virtual_pointer` | ✅ libei                | ✅ `SetCursorPos`            |
 | **Mouse buttons / drag**      | ✅ `CGEventPost`         | ✅ XTest               | ✅ `zwlr_virtual_pointer`    | ✅ libei                | ✅ `SendInput`               |
 | **Scroll injection**          | ✅ both axes             | ✅ both axes           | ✅ both axes (uinput + virtual pointer) | ✅ libei     | ⚠️ vertical only             |
 | **Smooth cursor animation**   | ✅ (incl. relative, opt-in) | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ❌                        |
@@ -265,13 +265,13 @@ scroll — is dispatched through the shared `InfraAXClient.PerformAction`. The
 dispatch, the action set, and the mode logic that drives it are platform-neutral
 Go; only the final injection primitive differs:
 
-| Platform              | Primitive                                                      |
-| --------------------- | -------------------------------------------------------------- |
-| macOS                 | `CGEventPost` (+ `CGWarpMouseCursorPosition` for moves)         |
-| Linux X11             | XTest (`XWarpPointer`, buttons 1/2/3, scroll buttons 4/5)       |
-| Linux Wayland wlroots | `zwlr_virtual_pointer` (+ `/dev/uinput` for scroll)             |
-| Linux Wayland KDE     | libei via `org.freedesktop.portal.RemoteDesktop`                |
-| Windows               | `SendInput` / `SetCursorPos`                                    |
+| Platform              | Primitive                                                                    |
+| --------------------- | ---------------------------------------------------------------------------- |
+| macOS                 | `CGEventPost` (`kCGEventMouseMoved` / `*MouseDragged` for moves)              |
+| Linux X11             | XTest (`XTestFakeMotionEvent`, buttons 1/2/3, scroll 4/5 vert. + 6/7 horiz.)  |
+| Linux Wayland wlroots | `zwlr_virtual_pointer` (+ `/dev/uinput` for scroll)                           |
+| Linux Wayland KDE     | libei via `org.freedesktop.portal.RemoteDesktop`                              |
+| Windows               | `SendInput` / `SetCursorPos`                                                  |
 
 **The one behavioral difference:** Windows `ScrollAtCursor` ignores `deltaX`, so
 horizontal scrolling is a no-op there. Everything else behaves the same on all
@@ -445,7 +445,7 @@ important thing to know before touching overlay code:
 | ---------------------------- | ------------------------------------ | ---------------------------------- | ---------------------------------- |
 | **Grid transition**          | CoreAnimation, ease-in-out @120Hz    | goroutine, smoothstep @120fps      | ❌                                 |
 | **Mouse action indicator**   | `CABasicAnimation` (scale + opacity) | goroutine, scale + opacity @120fps | goroutine, cubic easing @60fps     |
-| **Smooth cursor**            | ✅ configurable easing               | ✅ stepped warp, incl. relative (opt-in) | ❌                           |
+| **Smooth cursor**            | ✅ stepped linear interpolation      | ✅ stepped linear interpolation    | ❌                                 |
 | **Smooth scroll**            | ✅ ease-out cubic                    | ❌                                 | ❌                                 |
 
 ---


### PR DESCRIPTION
## Description

This PR fixes four false statements in the cross-platform capability
documentation about how Neru moves the cursor and what smooth cursor movement
actually does.

The table advertised "configurable easing" for smooth cursor on macOS. Neru has
no easing in cursor movement on any platform — macOS and Linux both step through
a plain linear interpolation, and the smooth-cursor config has no easing key, so
the table promised an option nobody could write. The same two rows named two
APIs this project never calls: macOS was credited with warping the cursor when it
actually posts synthetic mouse events (a difference other applications can
observe), and X11 was credited with a pointer warp when it injects fake motion
events instead.

Nothing about Neru's behaviour changes — only the description of it. The
neighbouring cells in both rows were rechecked against the source in the same
pass and were already correct, so they are left alone.

## Related Issues

Closes #1414

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no code changed
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no code changed
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no code changed
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality — N/A, documentation only; the existing doc-links guardrail covers the new link
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Every replacement wording was verified against the source rather than against
the issue text. Before/after per cell, with the evidence:

**`docs/CROSS_PLATFORM.md:448` — Animation table, "Smooth cursor"**

- macOS: `✅ configurable easing` → `✅ stepped linear interpolation`
- Linux: `✅ stepped warp, incl. relative (opt-in)` → `✅ stepped linear interpolation`
- Windows: `❌` — checked, correct, unchanged

Both animators compute `progress := float64(step) / float64(actualSteps)` and
lerp: `internal/adapter/platform/darwin/mouse_animator.go:362-366` and
`internal/adapter/platform/linux/mouse_animator.go:402-406`. Neither file
contains an easing function. `SmoothCursorConfig`
(`internal/config/config.go:570-576`) has four keys — enabled, steps, max
duration, duration-per-pixel, plus the relative duration — and no easing key.
Windows has no animator at all: `MoveCursorToPoint` ignores the bypass flag and
calls straight through (`internal/adapter/platform/windows/system.go:175-186`),
and `WaitForCursorIdle` is a no-op (`:189-191`). The "incl. relative, opt-in"
qualifier was dropped from this row because the capability row at `:134` already
states it for every platform, and `move_mouse_enabled` defaults to `false`
(`internal/config/config_defaults.go:797`).

**`docs/CROSS_PLATFORM.md:131` — capability matrix, "Cursor move"**

- macOS: `✅ CGWarpMouseCursorPosition` → ``✅ `CGEventPost` (linked to the file that posts it)``
- Linux X11: `✅ XTest` → ``✅ XTest (`XTestFakeMotionEvent`)``
- Wayland wlroots / KDE / Windows: checked, correct, unchanged

`CGWarpMouseCursorPosition` appears nowhere in the repository. macOS builds a
mouse event and posts it at the session tap:
`internal/adapter/platform/darwin/accessibility_mouse_darwin.m:51-58` calling
`:42`, with the tap location pinned at
`internal/adapter/platform/darwin/accessibility_constants.h:30`. X11:
`internal/adapter/platform/linux/x11_accessibility.c:111` and
`internal/adapter/platform/linux/x11_system.c:37`. wlroots:
`internal/adapter/platform/linux/wlroots_client.c:1267`. KDE:
`internal/adapter/platform/linux/libei_client.c:286`. Windows:
`internal/adapter/platform/windows/win32.go:104`.

**`docs/CROSS_PLATFORM.md:270-271` — injection-primitive table**

The same two false API names appear a second time here, so they are corrected in
the same pass:

- macOS: ``CGEventPost` (+ `CGWarpMouseCursorPosition` for moves)` → ``CGEventPost` (`kCGEventMouseMoved` / `*MouseDragged` for moves)``
- Linux X11: ``XTest (`XWarpPointer`, buttons 1/2/3, scroll buttons 4/5)`` → ``XTest (`XTestFakeMotionEvent`, buttons 1/2/3, scroll 4/5 vert. + 6/7 horiz.)``

`XWarpPointer` also appears nowhere in the repository. The X11 button numbers
were correct (`internal/adapter/accessibility/native/linux/element_x11_cgo.go:26-28`),
but the scroll pair was incomplete: vertical uses buttons 4/5 (`:211,215`) and
horizontal uses 6/7 (`:236,240`), while the row above already claims both axes.

**Checked and deliberately left alone:** the other three Animation rows.
Grid transition on macOS really is a `kCAMediaTimingFunctionEaseInEaseOut` curve
at 120 Hz (`internal/adapter/platform/darwin/overlay_darwin.m:570-578,726`) and
smoothstep at 120 fps on Linux
(`internal/adapter/overlay/linux/animation_cgo.go:12,37-53`); the mouse action
indicator is `CABasicAnimation` scale plus opacity on macOS
(`internal/adapter/platform/darwin/overlay_darwin.m:3849,3855`) and a 60 fps
goroutine on Windows whose default easing is cubic
(`internal/adapter/overlay/windows/manager.go:848,930-959`, default `ease_out`
at `internal/config/config_defaults.go:652`); smooth scroll on macOS is genuinely
ease-out cubic (`internal/adapter/platform/darwin/scroll_animator.go:152-154`),
and Linux and Windows genuinely have none.

No capability status was added to `docs/ARCHITECTURE.md`; this file remains the
single owner of status.
