### PR TITLE
feat(eventtap): let a mode bind the physical mouse buttons

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -345,8 +345,32 @@ which of the two applies to your session.
 | Named      | `Space`, `Return`, `Enter`, `Escape`, `Tab`, `Delete`, `Backspace`                                      |
 | Navigation | `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown`, `Insert` (Linux and Windows only)   |
 | Function   | `F1`–`F24` (`F21`–`F24` on Linux and Windows only)                                                      |
+| Mouse      | `MouseLeft`, `MouseRight`, `MouseMiddle` (macOS only, mode tables only — see below)                     |
 
 See [CLI.md](CLI.md#neru-action-feed) for a full key reference with key codes and platform behavior.
+
+**Mouse buttons** are reported only while a mode is active, so they belong in a
+per-mode hotkey table. Writing one in the global `[hotkeys]` table is refused
+with an error rather than accepted and silently never fired. They also behave
+differently from keys in two ways:
+
+- **The click is never swallowed.** The binding runs *in addition to* the click
+  reaching the application underneath, so the click still does whatever it
+  normally would.
+- **Modifiers are not encoded.** `Cmd`-click and `Shift`-click both report
+  `MouseLeft`; there is no `Cmd+MouseLeft`.
+
+Clicks that Neru itself performs (`action left_click`, `--action left_click`) do
+not trigger these, so a binding cannot recurse into itself.
+
+The main use is dismissing an overlay when you click with a real mouse — handy
+if a pointing device or a keyboard with a mouse-button key sits alongside
+keyboard navigation:
+
+```toml
+[recursive_grid.hotkeys]
+"MouseLeft" = "idle"    # Clicking anywhere closes the grid
+```
 
 Multi-key sequences (e.g. `gg`, `ab`) are supported for per-mode hotkeys with a 500ms timeout.
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -138,6 +138,7 @@ or no-op) · ❌ no code path
 | **Global hotkeys**            | ✅ per-key CGEventTap    | ✅ `XGrabKey`          | ⚠️ passive evdev read        | ⚠️ passive evdev read   | ✅ `RegisterHotKey`          |
 | **Keyboard capture**          | ✅ CGEventTap            | ✅ `XGrabKeyboard`     | ✅ evdev grab (wl-keyboard fallback) | ✅ evdev grab   | ✅ `WH_KEYBOARD_LL`          |
 | **Modifier passthrough**      | ✅                       | ❌                     | ✅ evdev backend only        | ✅ evdev backend only   | ❌                           |
+| **Mouse buttons as bindings** | ✅ CGEventTap, observed  | ❌                     | ❌                           | ❌                      | ❌                           |
 | **Dark mode detection**       | ✅ Cocoa appearance      | ✅ xdg appearance portal | ✅ xdg appearance portal   | ✅ kdeglobals + portal  | ✅ registry                  |
 | **Font resolution**           | ✅ NSFont                | ✅ fontconfig          | ✅ fontconfig                | ✅ fontconfig           | ⚠️ generic-alias map only ²  |
 | **System tray**               | ✅ NSStatusItem          | ✅ D-Bus StatusNotifierItem | ✅ StatusNotifierItem        | ✅ StatusNotifierItem   | ✅ Win32 notification area   |

--- a/internal/adapter/hotkeys/linux/x11_keysym_test.go
+++ b/internal/adapter/hotkeys/linux/x11_keysym_test.go
@@ -193,6 +193,18 @@ func TestX11KeysymFor_EveryNamedKeyResolves(t *testing.T) {
 		t.Run(key, func(t *testing.T) {
 			t.Parallel()
 
+			// A mouse button is a named key that is not a keystroke, so there
+			// is no keysym for it to resolve to and none should be invented.
+			// The invariant this test protects is about a key a grab could
+			// reject; a button never reaches a grab at all. X11 reports
+			// buttons through pointer events rather than the keyboard, so
+			// binding one on Linux is a no-op today — the same shape as
+			// F21-F24 and Insert, which the vocabulary carries on macOS
+			// precisely so one config file works on every platform.
+			if keyvocab.IsMouseButton(key) {
+				t.Skipf("%q is a mouse button, not a keystroke: no X11 keysym names it", key)
+			}
+
 			if x11KeysymFor(key) == 0 {
 				t.Fatalf("named key %q resolves to no X11 keysym", key)
 			}

--- a/internal/adapter/platform/darwin/accessibility_mouse_darwin.m
+++ b/internal/adapter/platform/darwin/accessibility_mouse_darwin.m
@@ -32,11 +32,21 @@
 /// last leaves the cursor and the viewport agreeing.
 static os_unfair_lock mouseMoveLock = OS_UNFAIR_LOCK_INIT;
 
+/// Marks events Neru posts itself, so the mode event tap can tell its own
+/// synthetic clicks apart from ones the user physically produced. Must match
+/// the marker in keyfeed_darwin.m and the check in eventTapCallback.
+static const int neruSyntheticMouseEventMarker = 0x1337;
+
 /// Pan the zoom viewport to reveal a point and post an event positioned there
 /// @param event Event to post; its location must already be set to position
 /// @param position Position the event acts at
 static void postPositionedEventLocked(CGEventRef event, CGPoint position) {
 	os_unfair_lock_lock(&mouseMoveLock);
+
+	// Tag before posting so the event tap ignores it. Every synthetic mouse
+	// event Neru emits funnels through here, so this is the single point that
+	// keeps `action left_click` from being mistaken for a physical click.
+	CGEventSetIntegerValueField(event, kCGEventSourceUserData, neruSyntheticMouseEventMarker);
 
 	NeruEnsureZoomViewportContainsPoint(position);
 	CGEventPost(kNeruMouseEventTapLocation, event);

--- a/internal/adapter/platform/darwin/eventtap_darwin.m
+++ b/internal/adapter/platform/darwin/eventtap_darwin.m
@@ -588,6 +588,37 @@ CGEventRef eventTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef 
 			return event;
 		}
 
+		// Physical mouse buttons are reported to the active mode as the named keys
+		// "MouseLeft", "MouseRight" and "MouseMiddle", so they can be bound in a
+		// mode's [<mode>.hotkeys] table like any other key.
+		//
+		// Two deliberate differences from key handling:
+		//   - The event is always returned, never swallowed. A mode reacting to a
+		//     click must not stop that click from reaching the app underneath.
+		//   - Modifiers are not encoded into the name. Cmd-click and Shift-click are
+		//     ordinary system gestures, and a mode that wants to exit on a click
+		//     wants to do so however the click was modified.
+		//
+		// Events Neru posted itself already returned above via the 0x1337 marker
+		// check, so `action left_click` cannot trigger these.
+		if (type == kCGEventLeftMouseDown || type == kCGEventRightMouseDown || type == kCGEventOtherMouseDown) {
+			NSString *buttonName = nil;
+			if (type == kCGEventLeftMouseDown) {
+				buttonName = @"MouseLeft";
+			} else if (type == kCGEventRightMouseDown) {
+				buttonName = @"MouseRight";
+			} else if (CGEventGetIntegerValueField(event, kCGMouseEventButtonNumber) == 2) {
+				// Only button 2 is the middle button; buttons 3+ stay unbindable.
+				buttonName = @"MouseMiddle";
+			}
+
+			if (buttonName && context->callback) {
+				context->callback([buttonName UTF8String], context->userData);
+			}
+
+			return event;
+		}
+
 		if (type == kCGEventKeyUp) {
 			CGKeyCode keyCode = (CGKeyCode)CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
 			NSString *keyName = specialKeyName(keyCode);
@@ -867,8 +898,14 @@ EventTap NeruCreateEventTap(EventTapCallback callback, void *userData) {
 
 	context->pendingAddSourceBlock = nil;
 
-	// Create the event tap
-	CGEventMask eventMask = (1 << kCGEventKeyDown) | (1 << kCGEventKeyUp) | (1 << kCGEventFlagsChanged);
+	// Create the event tap.
+	//
+	// Mouse-down types are observed, never consumed: they let a mode react to a
+	// physical click (e.g. binding "MouseLeft" = "idle" so clicking dismisses the
+	// overlay) while the click itself still reaches the application underneath.
+	CGEventMask eventMask = (1 << kCGEventKeyDown) | (1 << kCGEventKeyUp) | (1 << kCGEventFlagsChanged) |
+	                        (1 << kCGEventLeftMouseDown) | (1 << kCGEventRightMouseDown) |
+	                        (1 << kCGEventOtherMouseDown);
 	context->eventTap = CGEventTapCreate(
 	    kCGSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionDefault, eventMask, eventTapCallback, context);
 

--- a/internal/architecture/named_key_tables_test.go
+++ b/internal/architecture/named_key_tables_test.go
@@ -96,7 +96,20 @@ var darwinNamedKeyGaps = map[string]string{
 	keyvocab.KeyInsert: "Carbon declares no Insert virtual key code, " +
 		"so an Insert binding reaches a keystroke only on Linux and Windows — " +
 		"the same shape as the F21-F24 gap (docs/adr/0008-a-vocabulary-has-one-home.md)",
+	keyvocab.KeyMouseLeft:   mouseButtonsAreNotKeystrokes,
+	keyvocab.KeyMouseRight:  mouseButtonsAreNotKeystrokes,
+	keyvocab.KeyMouseMiddle: mouseButtonsAreNotKeystrokes,
 }
+
+// mouseButtonsAreNotKeystrokes is the reason the mouse buttons are missing from
+// the macOS keyboard tables, and it is a different shape from the other gaps:
+// F21-F24 and Insert are keys Carbon happens not to declare a code for, while a
+// mouse button has no virtual key code to declare. The tap names one straight
+// from the mouse event type rather than through specialKeyName, so neither
+// keyboard table carries it and neither should grow an entry.
+const mouseButtonsAreNotKeystrokes = "a mouse button is not a keystroke and has " +
+	"no virtual key code; the event tap names it from the mouse event type " +
+	"rather than through the keyboard tables"
 
 // TestDarwinNamedKeyTablesArePinnedToTheVocabulary keeps macOS binding the keys
 // Neru says it binds.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
 )
 
 // Validate validates the configuration, reporting only what stops it loading.
@@ -190,6 +191,22 @@ func (c *Config) ValidateHotkeyBindings() error {
 		err := ValidateHotkey(key, fieldName)
 		if err != nil {
 			return err
+		}
+
+		// A global hotkey is resolved to a virtual key code, which no mouse
+		// button has. Left to validate, the binding would parse and then never
+		// fire — the silent failure a mode binding exists to avoid. Refusing
+		// keeps the behavior these keys already had before the vocabulary
+		// carried them, so no configuration that loads today stops loading.
+		if keyvocab.IsMouseButton(key) {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%s cannot bind a mouse button (%s); mouse buttons are reported "+
+					"only while a mode is active, so bind them in a mode's "+
+					"[<mode>.hotkeys] table instead",
+				fieldName,
+				strings.Join(keyvocab.MouseButtons(), ", "),
+			)
 		}
 
 		if len(actions) == 0 {

--- a/internal/config/validators_mouse_button_test.go
+++ b/internal/config/validators_mouse_button_test.go
@@ -1,0 +1,79 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// mouseButtonKeys are the buttons the macOS event tap reports, in the spelling a
+// config file writes.
+var mouseButtonKeys = []string{"MouseLeft", "MouseRight", "MouseMiddle"}
+
+// TestValidateHotkey_AcceptsMouseButtons covers the syntax gate a mode binding
+// passes through: a mouse button is a named key, so it is accepted bare. It is
+// only ever emitted bare — the tap does not encode modifiers into the name — so
+// bare is the shape that has to validate.
+func TestValidateHotkey_AcceptsMouseButtons(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range mouseButtonKeys {
+		err := config.ValidateHotkey(key, testHotkeyFieldName)
+		if err != nil {
+			t.Errorf("ValidateHotkey(%q) = %v, want nil", key, err)
+		}
+	}
+}
+
+// TestValidateHotkeys_ModeTablesAcceptMouseButtons is the binding path a user
+// actually writes: a mouse button bound in a mode's table loads.
+func TestValidateHotkeys_ModeTablesAcceptMouseButtons(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range mouseButtonKeys {
+		cfg := config.DefaultConfig()
+		cfg.RecursiveGrid.Hotkeys[key] = config.StringOrStringArray{"idle"}
+
+		err := cfg.ValidateHotkeys()
+		if err != nil {
+			t.Errorf("recursive_grid.hotkeys.%s = %v, want nil", key, err)
+		}
+	}
+}
+
+// TestValidate_GlobalHotkeysRefuseMouseButtons pins the refusal. A global hotkey
+// is resolved to a virtual key code and a mouse button has none, so accepting
+// one would produce a binding that parses and never fires. The refusal also
+// keeps the behavior these spellings already had before the vocabulary carried
+// them, so no configuration that loads today stops loading.
+func TestValidate_GlobalHotkeysRefuseMouseButtons(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range mouseButtonKeys {
+		cfg := config.DefaultConfig()
+		if cfg.Hotkeys.Bindings == nil {
+			cfg.Hotkeys.Bindings = map[string][]string{}
+		}
+
+		cfg.Hotkeys.Bindings[key] = []string{"idle"}
+
+		err := cfg.Validate()
+		if err == nil {
+			t.Errorf("hotkeys.%s validated, want refusal", key)
+
+			continue
+		}
+
+		// Pin the reason, so the test cannot pass on some unrelated refusal,
+		// and the redirection, because a refusal that does not say where the
+		// binding does belong leaves the reader nowhere to go.
+		if !strings.Contains(err.Error(), "mouse button") {
+			t.Errorf("hotkeys.%s error %q is not the mouse-button refusal", key, err)
+		}
+
+		if !strings.Contains(err.Error(), "[<mode>.hotkeys]") {
+			t.Errorf("hotkeys.%s error %q does not say where to bind it instead", key, err)
+		}
+	}
+}

--- a/internal/domain/keyvocab/named_keys.go
+++ b/internal/domain/keyvocab/named_keys.go
@@ -29,7 +29,42 @@ const (
 	// reaches a binding only on Linux and Windows. It stays in the shared set
 	// for the same reason F21-F24 do.
 	KeyInsert = "Insert"
+	// KeyMouseLeft, KeyMouseRight and KeyMouseMiddle are the physical mouse
+	// buttons. They are named keys because a mode binds them the way it binds a
+	// key, but they are not keystrokes: no virtual keycode names them, and only
+	// the macOS tap reports them today. Two consequences callers rely on — a
+	// mode observes a button without consuming it, so the click still reaches
+	// the application underneath, and a button carries no modifier prefix, so a
+	// modified click reports the button alone.
+	KeyMouseLeft   = "MouseLeft"
+	KeyMouseRight  = "MouseRight"
+	KeyMouseMiddle = "MouseMiddle"
 )
+
+// mouseButtons is the subset of the vocabulary that names a mouse button
+// rather than a keystroke. It exists so the global-hotkey validator can refuse
+// one: a global hotkey is resolved to a virtual keycode, which no mouse button
+// has, so a binding written there would parse and then never fire.
+var mouseButtons = []string{KeyMouseLeft, KeyMouseRight, KeyMouseMiddle}
+
+// IsMouseButton reports whether name is one of the mouse buttons,
+// case-insensitively.
+func IsMouseButton(name string) bool {
+	lowered := strings.ToLower(name)
+
+	return slices.ContainsFunc(mouseButtons, func(button string) bool {
+		return strings.ToLower(button) == lowered
+	})
+}
+
+// MouseButtons returns every mouse button in display form, sorted, so a caller
+// listing them in a diagnostic reads the declaration rather than restating it.
+func MouseButtons() []string {
+	buttons := slices.Clone(mouseButtons)
+	slices.Sort(buttons)
+
+	return buttons
+}
 
 // shorthandEscape is the one spelling that resolves to a named key without
 // being one. It is deliberately absent from namedKeys: a keystroke arriving as
@@ -82,6 +117,9 @@ func buildNamedKeys() []string {
 		KeyPageUp,
 		KeyPageDown,
 		KeyInsert,
+		KeyMouseLeft,
+		KeyMouseRight,
+		KeyMouseMiddle,
 	}
 
 	for index := 1; index <= functionKeyCount; index++ {

--- a/internal/domain/keyvocab/named_keys_test.go
+++ b/internal/domain/keyvocab/named_keys_test.go
@@ -23,6 +23,10 @@ const (
 	keyInsert    = "Insert"
 	keyPageDown  = "PageDown"
 
+	keyMouseLeft   = "MouseLeft"
+	keyMouseRight  = "MouseRight"
+	keyMouseMiddle = "MouseMiddle"
+
 	nameEnter     = "enter"
 	nameBackspace = "backspace"
 	nameInsert    = "insert"
@@ -37,6 +41,7 @@ func documentedNamedKeys() []string {
 		"Space", keyReturn, keyEnter, keyEscape, "Tab", keyDelete, keyBackspace,
 		"Up", "Down", keyLeft, "Right", "Home", "End", "PageUp", keyPageDown,
 		keyInsert,
+		keyMouseLeft, keyMouseRight, keyMouseMiddle,
 	}
 	for index := 1; index <= 24; index++ {
 		keys = append(keys, "F"+strconv.Itoa(index))


### PR DESCRIPTION
## Description

This PR adds the physical mouse buttons to the key vocabulary, so a mode can bind them the way it binds a key. Until now the mode event tap watched keyboard events only, so a click from a real mouse — or from a keyboard key that sends one — was invisible to the active mode: the click landed, the overlay stayed up, and dismissing it took a second keystroke.

A mode now observes a button press without consuming it, so the binding runs *in addition to* the click reaching the application underneath. Clicks Neru performs itself are marked and ignored, so a binding cannot recurse into its own action. Modifiers are deliberately not encoded into the name — a modified click reports the button alone — because a mode that wants to react to a click wants to react however the click was modified.

Only the macOS tap reports these today; the buttons stay in the shared vocabulary the way `Insert` and F21–F24 do, so one config file still validates on every platform.

## Related Issues

Closes #1417

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — the new code sits in existing `_darwin.m` sources, which carry no Go build tag of their own
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, nothing new is added to a port; the Linux and Windows taps simply never emit these names, the same shape as `Insert` and F21–F24
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config surface

Three new named keys, valid in any mode's hotkey table:

| Key | Fires on |
| --- | --- |
| `MouseLeft` | physical left button press |
| `MouseRight` | physical right button press |
| `MouseMiddle` | physical middle button press (button 2 only) |

```toml
[recursive_grid.hotkeys]
"MouseLeft" = "idle"    # clicking anywhere closes the grid
```

They are reported only while a mode is active, so they belong in a mode table. Writing one in the global `[hotkeys]` table is **refused with an error** naming the mode tables instead — a global hotkey resolves to a virtual key code and a mouse button has none, so accepting it would produce a binding that parses and never fires.

No existing option changes, no default changes, and every configuration that loads today still loads: these spellings were already refused as an invalid key format before the vocabulary carried them, so the global-table refusal preserves the behavior they already had.

## Additional Context

**Why bindable keys rather than a setting.** A boolean such as `exit_on_external_click` would answer only the one question, could not express right- or middle-click, and would add a config option. Making the buttons bindable adds none, composes with macros, and works in every mode.

**Telling a physical click from Neru's own.** The tap already ignores events Neru posts, by a marker the keyboard feed sets. The mouse path was not setting it; it is now set in the single helper every synthetic mouse event is posted through, which is what keeps `action left_click` from firing a `MouseLeft` binding.

**Middle button.** Only button number 2 is named `MouseMiddle`; buttons 3 and up stay unbindable rather than being folded onto the middle button.

**Why macOS only.** Not a platform limitation, just a different amount of work, so this PR stays scoped to the platform it can verify. The macOS tap is session-wide and was already receiving these events and discarding them by mask, so widening the mask was the change. The evdev capture is device-scoped to keyboards — a device qualifies by reporting Q/W/E/R/Space/Enter, which a mouse does not — so buttons would need a new device class to enumerate and hotplug-track, and a non-grabbing read path, since the existing capture is an exclusive `EVIOCGRAB` and a button must not be consumed. X11 would need raw XInput2 button events on top of that, and Windows a second low-level hook beside the keyboard one. Happy to follow up on any of these if they are wanted.

**Testing.** `just ci` passes locally, and so do the containerized cross-platform runs: `just test-linux` (CGO on), `just test-linux-nocgo`, `just lint-cross` and `just test-windows-compile`.

The Linux run is what caught the one real cross-platform consequence. `TestX11KeysymFor_EveryNamedKeyResolves` asserts every named key resolves to an X11 keysym, and a mouse button has none — the three new keys failed it. That test is tagged `linux && cgo`, so a macOS-only `just ci` does not compile it. Mouse buttons are now skipped there with the reason recorded: the invariant is about a key a grab could reject, and a button never reaches a grab. Verified in both directions — the three fail without the skip and pass with it.

Beyond the suites, the three buttons were exercised by hand on macOS 15.7.4 against recursive grid: each dismissed the overlay while the click still reached the application underneath.
