### PR TITLE
fix(overlay): stop Linux crashing when the overlay is torn down mid-animation

### DIFF
--- a/internal/adapter/overlay/linux/animation_test.go
+++ b/internal/adapter/overlay/linux/animation_test.go
@@ -87,3 +87,21 @@ func TestMouseActionIndicatorRect(t *testing.T) {
 		t.Errorf("indicator rect size = %dx%d, want 36x36", rect.Dx(), rect.Dy())
 	}
 }
+
+// Every method a Linux overlay backend exposes to the manager survives a nil
+// receiver, because the manager dispatches on possibly-nil backend pointers.
+// cancelAnimation was the one exception: it took cancelMu straight off the
+// receiver.
+func TestSharedOverlay_CancelAnimation_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("cancelAnimation panicked on a nil receiver: %v", recovered)
+		}
+	}()
+
+	var overlay *sharedOverlay
+
+	overlay.cancelAnimation()
+}

--- a/internal/adapter/overlay/linux/manager.go
+++ b/internal/adapter/overlay/linux/manager.go
@@ -166,13 +166,7 @@ func (m *Manager) Show() {
 
 // Hide hides the overlay.
 func (m *Manager) Hide() {
-	// Cancel any running animation before acquiring renderMu to avoid
-	// deadlock with the animation goroutine.
-	if m.wlroots != nil {
-		m.wlroots.cancelAnimation()
-	} else if m.x11 != nil {
-		m.x11.cancelAnimation()
-	}
+	m.cancelBackendAnimation()
 
 	m.renderMu.Lock()
 	defer m.renderMu.Unlock()
@@ -208,11 +202,7 @@ func (m *Manager) SetKeyboardCaptureEnabled(enabled bool) {
 
 // Clear clears the overlay content.
 func (m *Manager) Clear() {
-	if m.wlroots != nil {
-		m.wlroots.cancelAnimation()
-	} else if m.x11 != nil {
-		m.x11.cancelAnimation()
-	}
+	m.cancelBackendAnimation()
 
 	m.renderMu.Lock()
 	defer m.renderMu.Unlock()
@@ -409,19 +399,16 @@ func (m *Manager) OverlayCapabilities() ports.FeatureCapability {
 // leave the user looking at labels in a placement they did not choose, with
 // nothing anywhere saying so.
 func (m *Manager) DrawHintsWithStyle(hintsSlice []*hints.Hint, style hints.StyleMode) error {
-	if m.x11 == nil && m.wlroots == nil {
+	// Canceling first keeps the refusal below from leaving an animation
+	// painting the surface this draw was about to replace, and the same call
+	// answers whether there is a backend to draw on — so this refusal reads
+	// the backend pointers under renderMu instead of beside it.
+	attached := m.cancelBackendAnimation()
+	if !attached {
 		return derrors.New(
 			derrors.CodeNotSupported,
 			"overlay hints not implemented on linux backend",
 		)
-	}
-
-	// Canceling first keeps the refusal below from leaving an animation
-	// painting the surface this draw was about to replace.
-	if m.wlroots != nil {
-		m.wlroots.cancelAnimation()
-	} else {
-		m.x11.cancelAnimation()
 	}
 
 	offset, offsetErr := resolveHintBadgeOffset(style.Placement())
@@ -589,14 +576,7 @@ func (m *Manager) DrawRecursiveGrid(
 	style recursivegrid.Style,
 	virtualPointer recursivegrid.VirtualPointerState,
 ) error {
-	// Cancel any running animation before acquiring renderMu to avoid
-	// deadlock: the animation goroutine may be waiting for renderMu and
-	// won't see the stop signal until it runs a full loop iteration.
-	if m.wlroots != nil {
-		m.wlroots.cancelAnimation()
-	} else if m.x11 != nil {
-		m.x11.cancelAnimation()
-	}
+	m.cancelBackendAnimation()
 
 	m.renderMu.Lock()
 	defer m.renderMu.Unlock()
@@ -874,11 +854,7 @@ func (m *Manager) DrawMonitorSelect(
 	targets []manager.MonitorSelectTarget,
 	style manager.MonitorSelectStyle,
 ) error {
-	if m.wlroots != nil {
-		m.wlroots.cancelAnimation()
-	} else if m.x11 != nil {
-		m.x11.cancelAnimation()
-	}
+	m.cancelBackendAnimation()
 
 	m.renderMu.Lock()
 	defer m.renderMu.Unlock()
@@ -1006,6 +982,38 @@ func (m *Manager) HideIndicator(indicator ports.Indicator) {
 	case ports.VirtualPointerIndicator:
 		// Returned above.
 	}
+}
+
+// cancelBackendAnimation stops any animation the attached backend is running,
+// and reports whether there was a backend attached to cancel on.
+//
+// Destroy nils both backend pointers under renderMu, so this call reads them
+// under it too — and then releases the lock before canceling, because the
+// cancel waits for the animation goroutine to exit and that goroutine takes
+// renderMu on every frame.
+//
+// Capturing each pointer once is what makes that read synchronized without
+// widening the hold. Reading the field twice — once to nil-test it, once to
+// make the call — would leave the nil test meaningless: a concurrent Destroy
+// landing between the two hands a nil backend to cancelAnimation, which is
+// promoted from the embedded sharedOverlay and so dereferences the receiver
+// before any guard inside it can run.
+func (m *Manager) cancelBackendAnimation() bool {
+	m.renderMu.Lock()
+	x11 := m.x11
+	wlroots := m.wlroots
+	m.renderMu.Unlock()
+
+	switch {
+	case wlroots != nil:
+		wlroots.cancelAnimation()
+	case x11 != nil:
+		x11.cancelAnimation()
+	default:
+		return false
+	}
+
+	return true
 }
 
 // overlayScale returns the active backend's HiDPI UI scale. The X11 overlay

--- a/internal/adapter/overlay/linux/overlay_shared_cgo.go
+++ b/internal/adapter/overlay/linux/overlay_shared_cgo.go
@@ -521,7 +521,21 @@ func (o *sharedOverlay) startMouseActionAnimation(
 	}()
 }
 
+// cancelAnimation stops a running animation and waits for its goroutine to
+// exit. The caller must not hold renderMu: the goroutine takes it on every
+// frame and would never reach the stop signal.
+//
+// The nil-receiver guard matches every other method a backend exposes to the
+// manager, and buys consistency rather than safety: this one is promoted from
+// the embedded sharedOverlay, so calling it through a nil *x11Overlay /
+// *wlrootsOverlay panics on the promotion before the guard runs (see
+// ../AGENTS.md). What keeps a nil backend out of here is Manager.cancelBackendAnimation,
+// which captures the pointer under renderMu.
 func (o *sharedOverlay) cancelAnimation() {
+	if o == nil {
+		return
+	}
+
 	o.cancelMu.Lock()
 
 	var doneCh chan struct{}

--- a/internal/adapter/overlay/linux/shutdown_race_test.go
+++ b/internal/adapter/overlay/linux/shutdown_race_test.go
@@ -1,0 +1,155 @@
+//go:build linux
+
+package linux
+
+import (
+	"image"
+	"sync"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
+	"github.com/y3owk1n/neru/internal/domain"
+)
+
+const (
+	// concurrentDestroyRounds is how many fresh Managers each case races. A
+	// shutdown race only reports when the two goroutines actually overlap, so
+	// one round proves nothing; the case repeats until they do.
+	concurrentDestroyRounds = 200
+
+	raceScreenWidth  = 800
+	raceScreenHeight = 600
+	raceGridSide     = 2
+)
+
+// attachedBackend builds a Manager with one backend attached. The overlay is a
+// zero value on purpose: every backend method short-circuits on a nil native
+// handle, so these cases need no display server and the only thing left under
+// test is the Manager's own locking around the backend pointer.
+type attachedBackend struct {
+	name   string
+	attach func() *Manager
+}
+
+func attachedBackends() []attachedBackend {
+	return []attachedBackend{
+		{
+			name: "x11",
+			attach: func() *Manager {
+				return &Manager{backend: linuxOverlayBackendX11, x11: &x11Overlay{}}
+			},
+		},
+		{
+			name: "wlroots",
+			attach: func() *Manager {
+				return &Manager{
+					backend: linuxOverlayBackendWaylandWlroots,
+					wlroots: &wlrootsOverlay{},
+				}
+			},
+		},
+	}
+}
+
+// cancelingCall is one exported Manager entry point that stops a running
+// animation before it takes renderMu, named so a failure says which one lost
+// the race.
+type cancelingCall struct {
+	name string
+	call func(*Manager)
+}
+
+func cancelingCalls() []cancelingCall {
+	return []cancelingCall{
+		{name: "Hide", call: func(mgr *Manager) { mgr.Hide() }},
+		{name: "Clear", call: func(mgr *Manager) { mgr.Clear() }},
+		{
+			name: "DrawHintsWithStyle",
+			call: func(mgr *Manager) {
+				_ = mgr.DrawHintsWithStyle(nil, hints.StyleMode{})
+			},
+		},
+		{
+			name: "DrawRecursiveGrid",
+			call: func(mgr *Manager) {
+				dims := domain.GridDimensions{Rows: raceGridSide, Cols: raceGridSide}
+				_ = mgr.DrawRecursiveGrid(
+					image.Rect(0, 0, raceScreenWidth, raceScreenHeight),
+					0,
+					"ab", dims,
+					"cd", dims,
+					recursivegrid.Style{},
+					recursivegrid.VirtualPointerState{},
+				)
+			},
+		},
+		{
+			name: "DrawMonitorSelect",
+			call: func(mgr *Manager) {
+				_ = mgr.DrawMonitorSelect(nil, manager.MonitorSelectStyle{})
+			},
+		},
+	}
+}
+
+// Destroy nils both backend pointers under renderMu, so a call that reads them
+// beside the lock races it — and a call that reads twice, once to nil-test and
+// once to dispatch, hands a nil backend to cancelAnimation and panics. The
+// reasoning is on Manager.cancelBackendAnimation, which is what these calls now
+// go through.
+//
+// Each round also asserts Destroy's post-condition: whatever raced it, the
+// Manager must end up with no backend attached. The primary oracle, though, is
+// the race detector plus the absence of a panic, so run this with -race —
+// without the detector it only fails on the interleaving that actually
+// dereferences nil, which is rare enough to look green.
+func TestManager_Destroy_RacedByCancelingCalls(t *testing.T) {
+	t.Parallel()
+
+	for _, backend := range attachedBackends() {
+		for _, entry := range cancelingCalls() {
+			t.Run(backend.name+"/"+entry.name, func(t *testing.T) {
+				t.Parallel()
+
+				for range concurrentDestroyRounds {
+					mgr := backend.attach()
+
+					raceAgainstDestroy(mgr, entry.call)
+
+					if !mgr.Headless() {
+						t.Fatalf(
+							"%s left a backend attached after Destroy returned; "+
+								"the overlay would go on drawing into a torn-down surface",
+							entry.name,
+						)
+					}
+				}
+			})
+		}
+	}
+}
+
+// raceAgainstDestroy releases one Manager call and Destroy together on two
+// goroutines and returns once both have finished.
+func raceAgainstDestroy(mgr *Manager, call func(*Manager)) {
+	var released sync.WaitGroup
+
+	released.Add(1)
+
+	var finished sync.WaitGroup
+
+	finished.Go(func() {
+		released.Wait()
+		call(mgr)
+	})
+
+	finished.Go(func() {
+		released.Wait()
+		mgr.Destroy()
+	})
+
+	released.Done()
+	finished.Wait()
+}


### PR DESCRIPTION
## Description

This PR fixes a crash that could take the daemon down while it shuts down on Linux. Hiding or clearing the overlay, and every draw that first has to stop a running animation, read which overlay backend is attached without holding the render lock — while teardown was detaching it under that same lock. Lose the race and the shutdown path stops an animation on a backend that has just been torn down and panics. It needed an animation to be in flight at exactly the moment the overlay was destroyed, so it was rare rather than absent, and the race detector flagged it on every run.

Those calls now read the attached backend under the render lock and release the lock before stopping the animation, which is what teardown already did — so the deadlock that the unlocked read was avoiding (the animation goroutine takes the render lock on every frame and would never see the stop signal) does not come back. Nothing changes for a user beyond the crash not happening; there is no behaviour, configuration or command change.

Deliberate limitation: this fixes only the calls that stop an animation. Two other Linux overlay calls — the one that reports whether a display surface exists and the one that hands out the native window handle — still read the same pointers outside the lock. Neither can crash, because they never reach through a torn-down backend, but a race detector run that exercises them alongside shutdown will still report them. They are noted below rather than fixed here.

## Related Issues

Closes #1412

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new capability; the no-cgo Linux twins already exist and are unchanged.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changed; see the note on ADR 0010 below.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**What was verified locally, and what only CI's Linux leg can confirm.** Every line of this change is behind `//go:build linux`, so on a macOS host `just ci` compiles none of it. It was run anyway and passes, but the real verification was done in Docker:

- `just lint-cross` — clean for linux/amd64 with CGO on, and for windows/amd64.
- `just test-linux` and `just test-linux-nocgo` — the full suite passes with CGO on and off, so the new test runs against both the real backends and their no-cgo twins.
- `go test -race -count=4` on the overlay package in the same container. The new test was confirmed to **fail first**: against the unfixed code it reported a data race in 8 of its 10 cases. It passes after the fix.

What that leaves for CI is the leg itself — a different container, different scheduler timings, and `-race` over the whole tree rather than one package. The race is a genuine interleaving, not a deterministic one, so the case count is what makes it reliable rather than lucky; a much slower or much more serialized runner is the one place this could behave differently from what was measured here.

**Test shape.** The test attaches a backend whose native handle is nil, so it needs no display server and every backend method short-circuits — what is left under test is only the manager's locking around the pointer. Its oracle is the race detector plus the absence of a panic, with a post-condition per round that teardown really did detach the backend whatever raced it.

**ADR 0010 needs a follow-up edit that this PR deliberately does not make.** Its final consequence bullet records this race as "out of scope, and a real defect", and names the animation-cancel call as the one backend method without a nil-receiver guard. Both sentences are now false, and the line references in that bullet have moved. The ADR is owned by the follow-up that flips it to accepted, so it is left alone here rather than edited by two changes at once.

**One frame of added wait, in the worst case.** These calls used to stop the animation and only then queue for the render lock, so by the time they queued no animation frame could be holding it. They now take the lock once first, which on Wayland can queue behind one animation frame that is doing a compositor roundtrip. It is bounded at a single frame, on a path that was already about to wait for that same animation to finish, and when nothing is animating both acquisitions are uncontended — but it is a real addition to a path the mode handler runs under its own lock, so worth a reviewer's eye.

**Adjacent, not fixed — three things a reviewer may want as follow-ups.**

1. Three other Linux overlay calls still read the backend pointers with no lock: the headless report, the capability report and the native window handle. None reaches through a detached backend, so they degrade to a detector-visible race rather than a crash, and all three are on startup or reporting paths rather than the shutdown path this issue names.
2. Below the manager, four shared drawing paths still stop an animation while the render lock is held — which is the cycle this fix's own comment describes. It is unreachable today only because the mode handler serializes every caller, and one of those paths (showing a subgrid) has no pre-cancel guarding it at all. Pre-existing and untouched here; it wants its own change and its own test.
3. Refusing a hint draw is decided just before the lock is retaken, so a teardown landing in that window makes the draw paint nothing and still report success. The callee's own nil guard is what keeps it from crashing. Same shape, same window as before this PR.
4. A click indicator arriving after teardown lazily rebuilds its own overlay connection, which nothing then tears down — a small leak at exit, independent of this race.
