### PR TITLE
fix(darwin): stop macOS actions firing at a point the cursor has left

### DIFF
--- a/internal/adapter/platform/darwin/mouse_animator.go
+++ b/internal/adapter/platform/darwin/mouse_animator.go
@@ -40,6 +40,10 @@ func (d *cursorAnimationDone) close() {
 	})
 }
 
+// cursorRequest is a single "animate to end" target. It carries no completion
+// object of its own: completion is tracked per animation *session* (see
+// smoothCursorAnimator), so coalescing a superseded target never releases a
+// waiter early.
 type cursorRequest struct {
 	end              image.Point
 	steps            int
@@ -48,14 +52,40 @@ type cursorRequest struct {
 	maxDuration      int
 	durationPerPixel float64
 	fixedDuration    int // when > 0, overrides the distance-derived duration
-	done             *cursorAnimationDone
 }
 
+// smoothCursorAnimator glides the cursor toward a target: one worker
+// goroutine, latest-target-wins, and a completion channel WaitForCursorIdle
+// blocks on.
+//
+// Completion is per session — every target arriving mid-session shares one
+// completion, so a waiter tracks the latest target rather than being released
+// when an intermediate one is superseded. A move, wait, act sequence
+// (ActionService) would otherwise act at a point the cursor had already left.
 type smoothCursorAnimator struct {
+	// pos samples the live cursor position and post emits one move event.
+	// Both are injected so the worker loop can be driven without cgo: the
+	// animator is otherwise only observable through the events it posts to the
+	// window server. Production wires them to CoreGraphics in cursorAnimator.
+	//
+	// Both may be called with a.mu held (post always is, so the check and the
+	// post cannot be split — see postIfCurrent), so neither may call back into
+	// the animator. The production pair are plain cgo calls, which is what
+	// makes that safe; a substitute must be too.
+	pos  func() image.Point
+	post func(point image.Point, eventType, button uint32)
+
 	mu     sync.Mutex
 	reqCh  chan cursorRequest
 	stopCh chan struct{}
-	done   *cursorAnimationDone
+	// done is the current session's completion; nil only between stop() and
+	// the next session. After a session ends naturally it keeps referencing
+	// the closed completion, so a late waiter still sees "idle".
+	done *cursorAnimationDone
+	// busy reports that a session is in progress — the worker is still
+	// draining toward a target. A target submitted while busy joins that
+	// session instead of starting a new completion.
+	busy bool
 	// generation is bumped by stop() to invalidate steps from the animation
 	// being canceled. See postIfCurrent.
 	generation uint64
@@ -66,7 +96,21 @@ type smoothCursorAnimator struct {
 	hasPending bool
 }
 
-var cursorAnimator smoothCursorAnimator
+func newSmoothCursorAnimator(
+	pos func() image.Point,
+	post func(point image.Point, eventType, button uint32),
+) *smoothCursorAnimator {
+	return &smoothCursorAnimator{pos: pos, post: post}
+}
+
+// postCursorMoveEvent posts one cursor move (or drag) event through
+// CoreGraphics. It is the production half of the animator's post seam.
+func postCursorMoveEvent(point image.Point, eventType, button uint32) {
+	pos := C.CGPoint{x: C.double(point.X), y: C.double(point.Y)}
+	C.NeruPostMouseMoveEventWithButton(pos, C.CGEventType(eventType), C.CGMouseButton(button))
+}
+
+var cursorAnimator = newSmoothCursorAnimator(CursorPosition, postCursorMoveEvent)
 
 func (a *smoothCursorAnimator) stop() {
 	a.mu.Lock()
@@ -82,6 +126,7 @@ func (a *smoothCursorAnimator) stop() {
 	// the zoom viewport — back toward the abandoned target. Bumping the
 	// generation under the same lock the worker posts under closes that window.
 	a.generation++
+	a.busy = false
 	a.hasPending = false
 
 	if stopCh != nil {
@@ -137,6 +182,7 @@ func (a *smoothCursorAnimator) takePendingForSettle() (image.Point, bool) {
 	a.stopCh = nil
 	a.done = nil
 	a.generation++
+	a.busy = false
 	a.hasPending = false
 
 	if stopCh != nil {
@@ -173,8 +219,7 @@ func (a *smoothCursorAnimator) postIfCurrent(
 		return false
 	}
 
-	pos := C.CGPoint{x: C.double(point.X), y: C.double(point.Y)}
-	C.NeruPostMouseMoveEventWithButton(pos, C.CGEventType(eventType), C.CGMouseButton(button))
+	a.post(point, eventType, button)
 
 	return true
 }
@@ -205,18 +250,14 @@ func (a *smoothCursorAnimator) animateTo(end image.Point, steps int, eventType, 
 		durationPerPixel = cfg.SmoothCursor.DurationPerPixel
 	}
 
-	done := newCursorAnimationDone()
-	req := cursorRequest{
+	a.submit(cursorRequest{
 		end:              end,
 		steps:            steps,
 		eventType:        eventType,
 		button:           button,
 		maxDuration:      maxDuration,
 		durationPerPixel: durationPerPixel,
-		done:             done,
-	}
-
-	a.submit(req)
+	})
 }
 
 // animateRelativeBy animates a relative move with a fixed duration,
@@ -241,7 +282,7 @@ func (a *smoothCursorAnimator) animateRelativeBy(
 
 	base := a.pendingEnd
 	if !a.hasPending {
-		base = CursorPosition()
+		base = a.pos()
 	}
 
 	end := clamp(base.Add(delta))
@@ -258,7 +299,6 @@ func (a *smoothCursorAnimator) animateRelativeBy(
 		eventType:     eventType,
 		button:        button,
 		fixedDuration: durationMs,
-		done:          newCursorAnimationDone(),
 	})
 }
 
@@ -269,15 +309,10 @@ func (a *smoothCursorAnimator) submit(req cursorRequest) {
 	a.submitLocked(req)
 }
 
-// submitLocked records req as the pending animation and hands it to the
-// worker. Callers must hold a.mu. The channel send cannot block: the buffer
-// holds one request, the worker never takes a.mu around its receive, and
-// submitters are serialized by a.mu, so after the drop below a slot is free.
+// submitLocked records req as the pending animation target and hands it to the
+// worker, starting the worker and a fresh session completion when needed.
+// Callers must hold a.mu.
 func (a *smoothCursorAnimator) submitLocked(req cursorRequest) {
-	a.done = req.done
-	a.pendingEnd = req.end
-	a.hasPending = true
-
 	if a.reqCh == nil {
 		a.reqCh = make(chan cursorRequest, 1)
 		a.stopCh = make(chan struct{})
@@ -285,16 +320,42 @@ func (a *smoothCursorAnimator) submitLocked(req cursorRequest) {
 		go a.run(a.reqCh, a.stopCh)
 	}
 
+	if !a.busy {
+		a.done = newCursorAnimationDone()
+		a.busy = true
+	}
+
+	a.pendingEnd = req.end
+	a.hasPending = true
+
+	a.enqueueLocked(req)
+}
+
+// enqueueLocked places req on the worker channel, coalescing so only the latest
+// target survives. Callers must hold a.mu.
+//
+// The buffer holds one request and, under the lock, we are the only producer
+// while the worker is the only consumer (it removes, never adds), so after
+// draining a stale target the follow-up send cannot block — it stays a plain
+// send rather than another non-blocking one, because submitLocked has already
+// published req.end as the pending endpoint and a dropped target would leave
+// pendingTarget() naming a point nothing is animating toward. Targets carry no
+// completion object, so dropping a superseded one is a plain discard — the
+// shared session completion is untouched, and its waiters stay attached to the
+// target that replaced it.
+func (a *smoothCursorAnimator) enqueueLocked(req cursorRequest) {
 	select {
 	case a.reqCh <- req:
+		return
 	default:
-		select {
-		case dropped := <-a.reqCh:
-			dropped.done.close()
-		default:
-		}
-		a.reqCh <- req
 	}
+
+	select {
+	case <-a.reqCh:
+	default:
+	}
+
+	a.reqCh <- req
 }
 
 func (a *smoothCursorAnimator) run(reqCh <-chan cursorRequest, stopCh <-chan struct{}) {
@@ -320,7 +381,7 @@ func (a *smoothCursorAnimator) runRequest(
 ) {
 restart:
 	generation := a.currentGeneration()
-	start := CursorPosition()
+	start := a.pos()
 	distance := math.Hypot(float64(req.end.X-start.X), float64(req.end.Y-start.Y))
 
 	duration := math.Min(float64(req.maxDuration), distance*req.durationPerPixel)
@@ -348,11 +409,8 @@ restart:
 	for step := 1; step <= actualSteps; step++ {
 		select {
 		case <-stopCh:
-			req.done.close()
-
 			return
 		case nextReq := <-reqCh:
-			req.done.close()
 			req = nextReq
 
 			goto restart
@@ -365,9 +423,9 @@ restart:
 			Y: int(float64(start.Y) + float64(req.end.Y-start.Y)*progress),
 		}
 
+		// A false answer means stop() or settle() bumped the generation; both
+		// already closed this session's completion, so the worker just leaves.
 		if !a.postIfCurrent(generation, intermediate, req.eventType, req.button) {
-			req.done.close()
-
 			return
 		}
 
@@ -376,12 +434,11 @@ restart:
 			select {
 			case <-stopCh:
 				stopAndDrainTimer(timer)
-				req.done.close()
 
 				return
 			case nextReq := <-reqCh:
 				stopAndDrainTimer(timer)
-				req.done.close()
+
 				req = nextReq
 
 				goto restart
@@ -390,16 +447,48 @@ restart:
 		}
 	}
 
-	req.done.close()
-	a.clearDoneIfCurrent(req.done)
+	// Target reached. Continue the same session if a newer target is already
+	// queued; otherwise the session ends and its waiters are released.
+	next, ok := a.finishOrNext(reqCh, stopCh)
+	if ok {
+		req = next
+
+		goto restart
+	}
 }
 
-func (a *smoothCursorAnimator) clearDoneIfCurrent(done *cursorAnimationDone) {
+// finishOrNext, called once a target is reached, either hands back the next
+// queued target to continue the current session, or ends the session by
+// closing its completion (keeping a.done referencing the closed completion so
+// a late waiter still sees "idle"). It no-ops when this worker has been
+// superseded by a stop()/settle()/restart, detected via stopCh identity, so a
+// stale worker never closes a newer session's completion.
+func (a *smoothCursorAnimator) finishOrNext(
+	reqCh <-chan cursorRequest,
+	stopCh <-chan struct{},
+) (cursorRequest, bool) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
 
-	if a.done == done {
-		a.done = nil
-		a.hasPending = false
+	if a.stopCh != stopCh {
+		a.mu.Unlock()
+
+		return cursorRequest{}, false
 	}
+
+	select {
+	case next := <-reqCh:
+		a.mu.Unlock()
+
+		return next, true
+	default:
+	}
+
+	done := a.done
+	a.busy = false
+	a.hasPending = false
+	a.mu.Unlock()
+
+	done.close()
+
+	return cursorRequest{}, false
 }

--- a/internal/adapter/platform/darwin/mouse_animator_test.go
+++ b/internal/adapter/platform/darwin/mouse_animator_test.go
@@ -3,26 +3,117 @@
 package darwin
 
 import (
+	"context"
 	"image"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/domain/action"
 )
+
+// cursorRecorder stands in for the window server: it captures every move the
+// animator posts, and answers pos() with the last posted point so a glide
+// composes across requests the way a real cursor does.
+type cursorRecorder struct {
+	mu     sync.Mutex
+	posted []image.Point
+	events [][2]uint32 // {eventType, button} per posted move
+	start  image.Point
+}
+
+func (r *cursorRecorder) pos() image.Point {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.posted) > 0 {
+		return r.posted[len(r.posted)-1]
+	}
+
+	return r.start
+}
+
+func (r *cursorRecorder) post(point image.Point, eventType, button uint32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.posted = append(r.posted, point)
+	r.events = append(r.events, [2]uint32{eventType, button})
+}
+
+func (r *cursorRecorder) last() (image.Point, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.posted) == 0 {
+		return image.Point{}, false
+	}
+
+	return r.posted[len(r.posted)-1], true
+}
+
+func (r *cursorRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.posted)
+}
+
+func (r *cursorRecorder) postedEvents() [][2]uint32 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([][2]uint32(nil), r.events...)
+}
+
+// workerAnimator returns an animator backed by a real worker goroutine, with
+// the cursor position and the move post routed into rec instead of cgo.
+func workerAnimator(rec *cursorRecorder) *smoothCursorAnimator {
+	return newSmoothCursorAnimator(rec.pos, rec.post)
+}
 
 // testAnimator returns an animator whose request channel exists but has no
 // worker goroutine behind it. submitLocked then only queues (and drops) —
 // nothing consumes the requests, so no mouse events are posted during tests.
 func testAnimator() *smoothCursorAnimator {
-	return &smoothCursorAnimator{reqCh: make(chan cursorRequest, 1)}
+	animator := newSmoothCursorAnimator(
+		func() image.Point { return image.Point{} },
+		func(image.Point, uint32, uint32) {},
+	)
+	animator.reqCh = make(chan cursorRequest, 1)
+
+	return animator
 }
 
+// submitForTest queues one target and hands back the completion of the session
+// it joined, so a test can assert on when waiters are released.
 func (a *smoothCursorAnimator) submitForTest(end image.Point) *cursorAnimationDone {
-	done := newCursorAnimationDone()
-
 	a.mu.Lock()
-	a.submitLocked(cursorRequest{end: end, done: done})
-	a.mu.Unlock()
+	defer a.mu.Unlock()
 
-	return done
+	a.submitLocked(cursorRequest{end: end})
+
+	return a.done
+}
+
+// animateForTest submits an animation with explicit timing. It stands in for
+// animateTo, which reads max_duration / duration_per_pixel from the process
+// config; a test needs to choose them so the glide reliably outlives the
+// requests that supersede it.
+func (a *smoothCursorAnimator) animateForTest(
+	end image.Point,
+	steps, maxDuration int,
+	durationPerPixel float64,
+	eventType, button uint32,
+) {
+	a.submit(cursorRequest{
+		end:              end,
+		steps:            steps,
+		eventType:        eventType,
+		button:           button,
+		maxDuration:      maxDuration,
+		durationPerPixel: durationPerPixel,
+	})
 }
 
 // TestCursorAnimator_PendingTarget pins the pending-target contract relative
@@ -56,28 +147,70 @@ func TestCursorAnimator_PendingTarget(t *testing.T) {
 	}
 }
 
-// TestCursorAnimator_ClearDoneIfCurrent_KeepsNewerPending guards the
-// completion path: finishing an older animation must not clear the pending
-// endpoint of a newer one that superseded it.
-func TestCursorAnimator_ClearDoneIfCurrent_KeepsNewerPending(t *testing.T) {
+// TestCursorAnimator_FinishOrNext guards the completion path. Reaching a
+// target ends the session only when nothing newer is queued — a target that
+// superseded this one continues the same session, keeping its waiters
+// attached — and a worker left over from a canceled session must not close a
+// newer session's completion.
+func TestCursorAnimator_FinishOrNext(t *testing.T) {
 	animator := testAnimator()
+	animator.stopCh = make(chan struct{})
 
-	older := animator.submitForTest(image.Point{X: 10, Y: 10})
+	animator.submitForTest(image.Point{X: 10, Y: 10})
 
 	newerEnd := image.Point{X: 20, Y: 20}
-	newer := animator.submitForTest(newerEnd)
+	done := animator.submitForTest(newerEnd)
 
-	animator.clearDoneIfCurrent(older)
-
-	got, ok := animator.pendingTarget()
-	if !ok || got != newerEnd {
-		t.Fatalf("pendingTarget() = %v, %v after stale clear, want %v, true", got, ok, newerEnd)
+	// A worker whose session was already canceled must leave this one alone.
+	if _, ok := animator.finishOrNext(animator.reqCh, make(chan struct{})); ok {
+		t.Fatal("a superseded worker was handed the current session's next target")
 	}
 
-	animator.clearDoneIfCurrent(newer)
+	if got, pending := animator.pendingTarget(); !pending || got != newerEnd {
+		t.Fatalf(
+			"pendingTarget() = %v, %v after a stale finish, want %v, true",
+			got,
+			pending,
+			newerEnd,
+		)
+	}
+
+	select {
+	case <-done.ch:
+		t.Fatal("a superseded worker closed the current session's completion")
+	default:
+	}
+
+	// The queued newer target continues the session rather than ending it.
+	next, continued := animator.finishOrNext(animator.reqCh, animator.stopCh)
+	if !continued || next.end != newerEnd {
+		t.Fatalf(
+			"finishOrNext() = %v, %v, want the queued target %v, true",
+			next.end,
+			continued,
+			newerEnd,
+		)
+	}
+
+	select {
+	case <-done.ch:
+		t.Fatal("the session completed while a newer target was still queued")
+	default:
+	}
+
+	// Nothing left to animate: the session ends and its waiters are released.
+	if _, ok := animator.finishOrNext(animator.reqCh, animator.stopCh); ok {
+		t.Fatal("finishOrNext() handed back a target on an empty queue")
+	}
+
+	select {
+	case <-done.ch:
+	default:
+		t.Fatal("the session completion was not closed once the last target was reached")
+	}
 
 	if _, ok := animator.pendingTarget(); ok {
-		t.Fatal("pendingTarget() still reports an animation after the current one completed")
+		t.Fatal("pendingTarget() still reports an animation after the session completed")
 	}
 }
 
@@ -189,5 +322,186 @@ func TestCursorAnimator_TakePendingForSettle(t *testing.T) {
 
 	if animator.postIfCurrent(generation, end, 0, 0) {
 		t.Fatal("a step from the settled animation was still posted after settle")
+	}
+}
+
+// TestCursorAnimator_WaiterTracksSupersedingTarget guards the coalescing race,
+// mirroring Linux's TestSmoothCursorAnimatorWaiterTracksSupersedingTarget: a
+// waiter that attaches
+// while an earlier target animates must not be released until the cursor
+// reaches the *latest* target, even when the queued target is superseded
+// mid-flight. With per-request completion this waiter returned early at the
+// intermediate/previous position, and ActionService — which moves, waits, then
+// acts — performed its action at a point the cursor had already left.
+func TestCursorAnimator_WaiterTracksSupersedingTarget(t *testing.T) {
+	rec := &cursorRecorder{}
+
+	// Slow the posts so the animation spans the follow-up submissions.
+	slowPost := func(point image.Point, eventType, button uint32) {
+		time.Sleep(2 * time.Millisecond)
+		rec.post(point, eventType, button)
+	}
+
+	animator := newSmoothCursorAnimator(rec.pos, slowPost)
+	defer animator.stop()
+
+	final := image.Point{X: 900, Y: 900}
+
+	// Start a long first animation, then attach a waiter mid-flight.
+	animator.animateForTest(image.Point{X: 120, Y: 120}, 20, 400, 1.0, 0, 0)
+
+	waitResult := make(chan error, 1)
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		waitResult <- animator.wait(ctx)
+	}()
+
+	// Supersede the target twice while the session is still animating.
+	time.Sleep(6 * time.Millisecond)
+	animator.animateForTest(image.Point{X: 500, Y: 500}, 20, 400, 1.0, 0, 0)
+	time.Sleep(6 * time.Millisecond)
+	animator.animateForTest(final, 20, 400, 1.0, 0, 0)
+
+	err := <-waitResult
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	last, ok := rec.last()
+	if !ok {
+		t.Fatal("expected at least one move to be posted")
+	}
+
+	if last != final {
+		t.Fatalf(
+			"waiter released before reaching the superseding target: got %v want %v",
+			last,
+			final,
+		)
+	}
+}
+
+// TestCursorAnimator_WaitAfterSettledReturnsImmediately pins that a waiter
+// attaching after the cursor has come to rest is not left blocking on the
+// completed session.
+func TestCursorAnimator_WaitAfterSettledReturnsImmediately(t *testing.T) {
+	rec := &cursorRecorder{}
+	animator := workerAnimator(rec)
+
+	defer animator.stop()
+
+	target := image.Point{X: 60, Y: 40}
+	animator.animateForTest(target, 6, 60, 0.1, 0, 0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	if last, ok := rec.last(); !ok || last != target {
+		t.Fatalf("animation landed on %v, %v, want %v, true", last, ok, target)
+	}
+
+	// The session is over; a late waiter must not block on it.
+	lateCtx, lateCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer lateCancel()
+
+	lateErr := animator.wait(lateCtx)
+	if lateErr != nil {
+		t.Fatalf("wait on a settled animator returned error: %v", lateErr)
+	}
+}
+
+// TestCursorAnimator_StopHaltsPostsAndReleasesWaiter pins the cancellation
+// window: a waiter already blocked on the running session is released by
+// stop() rather than left hanging, and once stop() returns no further step
+// from the canceled animation may reach the window server.
+func TestCursorAnimator_StopHaltsPostsAndReleasesWaiter(t *testing.T) {
+	rec := &cursorRecorder{}
+	animator := workerAnimator(rec)
+
+	// Long glide so the waiter attaches, and stop() lands, mid-animation.
+	animator.animateForTest(image.Point{X: 5000, Y: 5000}, 200, 5000, 5.0, 0, 0)
+
+	waitResult := make(chan error, 1)
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		waitResult <- animator.wait(ctx)
+	}()
+
+	// The session is still running, so the waiter must still be blocked —
+	// otherwise stop() releasing it below would prove nothing.
+	select {
+	case <-waitResult:
+		t.Fatal("wait returned while the animation was still in flight")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	animator.stop()
+
+	select {
+	case err := <-waitResult:
+		if err != nil {
+			t.Fatalf("wait after stop returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop() did not release the blocked waiter")
+	}
+
+	settled := rec.count()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := rec.count(); got != settled {
+		t.Fatalf("%d step(s) posted after stop() returned, want none", got-settled)
+	}
+}
+
+// TestCursorAnimator_DragEventTypeReachesEveryStep pins the darwin-only drag
+// path: a move issued while a mouse button is held must post every step as a
+// drag of that button, or the application never sees the drag.
+func TestCursorAnimator_DragEventTypeReachesEveryStep(t *testing.T) {
+	rec := &cursorRecorder{}
+	animator := workerAnimator(rec)
+
+	defer animator.stop()
+
+	// The pair MoveMouse threads through while a button is held.
+	drag := eventsForButton(action.ButtonRight)
+	want := [2]uint32{uint32(drag.dragged), uint32(drag.button)}
+
+	animator.animateForTest(image.Point{X: 90, Y: 90}, 6, 60, 0.5, want[0], want[1])
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	events := rec.postedEvents()
+	if len(events) == 0 {
+		t.Fatal("expected at least one move to be posted")
+	}
+
+	for index, event := range events {
+		if event != want {
+			t.Fatalf(
+				"step %d posted {eventType, button} = %v, want the drag pair %v",
+				index,
+				event,
+				want,
+			)
+		}
 	}
 }


### PR DESCRIPTION
## Description

This PR fixes macOS acting on a stale cursor position when smooth cursor is
turned on. Neru has several flows that move the cursor, wait for it to stop,
and only then click, scroll or move again. Until now the wait ended early
whenever a second move arrived while the first was still gliding: the waiter
was released at whatever intermediate point the cursor had reached, and the
action that followed fired there instead of at the target. It showed up in
sequences with two move steps, and in a move racing an indicator reposition.

Waiting now tracks the cursor rather than a particular target. A waiter
attached while any move is in flight is released when the cursor comes to
rest, whichever target it ends up resting on. Linux has behaved this way
since #1183; macOS now matches it.

The deliberate limitation is the flip side of the same change: the wait is
genuinely longer than it used to be. While something keeps feeding new cursor
targets — a held movement key, for instance — the session stays open and a
waiter stays blocked until the movement stops, bounded only by the caller's
context. Users with `smooth_cursor.move_mouse_enabled = false` see no change
at all, because nothing animates and there is no window to wait through.

## Related Issues

Closes #1411

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no capability is added or removed; this changes the timing of an existing macOS capability, so no platform gains or loses anything to stub.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no documented fact changes. The capability rows in `docs/CROSS_PLATFORM.md` describe status, not completion timing, and the Linux paragraph's claim that its animator "mirrors the darwin animator" is more true after this than before.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**This is a behaviour change on macOS, not a refactor.** A waiter is released
later than it was. I checked every caller of the move-then-wait pair before
changing it, and none depends on the early release: the two mode-layer callers
(monitor move, monitor-select confirm) pass `bypassSmooth`, which cancels any
animation and warps, so their wait was already returning immediately; the five
IPC-layer callers all wait and then act on the *explicit* point they just
asked for, which is exactly the case the early release was getting wrong. No
caller reads the cursor position after the wait to decide where to act.
ADR 0004 already established that the monitor path holds no handler lock
across the wait, so a longer wait cannot extend a lock hold.

**Testing.** The test that pins the fix could not be written against the old
code: the darwin animator's test helper deliberately starts no worker, so no
test ever reached the animation loop, and the loop called CoreGraphics
directly. The cursor-position read and the move post are now injected as
function values — the same shape Linux uses — so a test can drive the real
worker and observe posted positions without cgo. The new test mirrors the
Linux one it is named after; it was verified red against the pre-fix
completion model (released at an intermediate point, `(30,30)` instead of the
final `(900,900)`) and green after. Three more tests cover the paths the fix
must not regress: a late waiter still returning immediately, cancellation
still halting posts and releasing a blocked waiter, and the macOS-only drag
event type and button reaching every step of an animated move.

**The two animators stay separate.** This makes darwin's completion model
match Linux's, so the two files now look more alike than they did — but they
are not merged, and shouldn't be. They still diverge on drag support, on
settle latency (darwin warps to the endpoint, Linux returns immediately), and
on cancellation mechanism (generation counter vs. semaphore). ADR 0007's
"a near-miss earns a second name" covers exactly this case.

**One thing left deliberately untouched:** the settle path still calls
CoreGraphics directly rather than going through the injected post, so its warp
is not covered by a test. Its session bookkeeping is covered separately, and
extending the seam further wasn't needed for this fix.
