### PR TITLE
refactor(linux): read the smooth-cursor animation floor from one place

### DIFF
--- a/internal/adapter/platform/linux/mouse_animator.go
+++ b/internal/adapter/platform/linux/mouse_animator.go
@@ -8,15 +8,30 @@ import (
 	"math"
 	"sync"
 	"time"
+
+	"github.com/y3owk1n/neru/internal/config"
 )
 
+// The animation floor itself is not declared here: every smooth-cursor
+// animation is floored at config.MinSmoothCursorAnimationDuration, the same
+// constant ValidateSmoothCursor rejects a shorter relative_movement_duration
+// against, so the validator and the animator cannot disagree about what the
+// daemon will honor. darwin's animator reads it the same way.
 const (
-	// minCursorAnimationDuration is the floor for a single move so even a
-	// zero-distance request settles promptly instead of instantly.
-	minCursorAnimationDuration = 10 // ms
-	// minCursorStepDelay is the shortest gap between injected steps.
+	// minCursorStepDelay is the shortest gap between injected steps — a
+	// scheduling floor on this animator's own timer, not a config value. No
+	// config option declares it and none derives from it (darwin likewise
+	// keeps its own minStepDelay local), so there is nothing here for a
+	// config change to desync from and it stays local.
 	minCursorStepDelay = 1 // ms
-	// defaultCursorSteps is used when the config value is unset (<= 0).
+	// defaultCursorSteps is the step count used when a caller passes none
+	// (<= 0). It equals config.DefaultSmoothCursorSteps today, and that is a
+	// coincidence rather than a derivation: both smooth-cursor call sites
+	// pass cfg.SmoothCursor.Steps, which ValidateSmoothCursor already
+	// requires to be >= 1, so no validated config can reach this fallback at
+	// all. It answers a different question — what step count to use for a
+	// caller that supplied a nonsense one — and moving the config default
+	// must not move it.
 	defaultCursorSteps = 10
 )
 
@@ -371,8 +386,8 @@ restart:
 		duration = float64(req.fixedDuration)
 	}
 
-	if duration < minCursorAnimationDuration {
-		duration = minCursorAnimationDuration
+	if duration < config.MinSmoothCursorAnimationDuration {
+		duration = config.MinSmoothCursorAnimationDuration
 	}
 
 	actualSteps := req.steps

--- a/internal/adapter/platform/linux/mouse_animator_test.go
+++ b/internal/adapter/platform/linux/mouse_animator_test.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/y3owk1n/neru/internal/config"
 )
 
 // recorder captures the moves an animator injects so tests can assert on the
@@ -85,6 +87,50 @@ func TestSmoothCursorAnimatorLandsOnTarget(t *testing.T) {
 
 	if rec.count() < 2 {
 		t.Fatalf("expected a stepped glide (>=2 moves), got %d", rec.count())
+	}
+}
+
+// TestSmoothCursorAnimatorFloorsShortAnimationsAtConfigMinimum pins the floor
+// this animator applies to config.MinSmoothCursorAnimationDuration — the same
+// constant ValidateSmoothCursor rejects a shorter relative_movement_duration
+// against, so the value the validator promises to honor is the value the
+// animator honors.
+//
+// It reads the floor back out of behavior rather than comparing constants: a
+// below-floor duration asked for in far more steps than the floor can schedule
+// collapses to one step per minCursorStepDelay of the floor, so the number of
+// injected moves *is* the floor. Move the config constant and this expectation
+// moves with it; re-introduce a local copy that disagrees and this fails.
+func TestSmoothCursorAnimatorFloorsShortAnimationsAtConfigMinimum(t *testing.T) {
+	t.Parallel()
+
+	wantSteps := config.MinSmoothCursorAnimationDuration / minCursorStepDelay
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	animator.animateRelativeBy(
+		image.Point{X: 4 * wantSteps, Y: 0},
+		func(point image.Point) image.Point { return point },
+		wantSteps*100,
+		1,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	if got := rec.count(); got != wantSteps {
+		t.Fatalf(
+			"injected %d steps for a below-floor animation, want %d "+
+				"(config.MinSmoothCursorAnimationDuration / minCursorStepDelay)",
+			got,
+			wantSteps,
+		)
 	}
 }
 

--- a/internal/adapter/platform/linux/relative_animator.go
+++ b/internal/adapter/platform/linux/relative_animator.go
@@ -8,6 +8,8 @@ import (
 	"math"
 	"sync"
 	"time"
+
+	"github.com/y3owk1n/neru/internal/config"
 )
 
 // relativeCursorAnimator animates relative cursor moves on backends whose
@@ -75,8 +77,8 @@ func (a *relativeCursorAnimator) addDelta(delta image.Point, steps, durationMs i
 	}
 
 	duration := float64(durationMs)
-	if duration < minCursorAnimationDuration {
-		duration = minCursorAnimationDuration
+	if duration < config.MinSmoothCursorAnimationDuration {
+		duration = config.MinSmoothCursorAnimationDuration
 	}
 
 	actualSteps := steps

--- a/internal/adapter/platform/linux/relative_animator_test.go
+++ b/internal/adapter/platform/linux/relative_animator_test.go
@@ -77,6 +77,44 @@ func TestRelativeCursorAnimatorDrainsExactly(t *testing.T) {
 	}
 }
 
+// TestRelativeCursorAnimatorFloorsShortDrainsAtConfigMinimum is the drain twin
+// of TestSmoothCursorAnimatorFloorsShortAnimationsAtConfigMinimum: this
+// animator floors a below-floor drain at the same
+// config.MinSmoothCursorAnimationDuration, so a gesture asked for in more
+// chunks than the floor can schedule posts exactly one chunk per
+// minCursorStepDelay of the floor. Exactness of the drained total is
+// TestRelativeCursorAnimatorDrainsExactly's question, not this one's.
+func TestRelativeCursorAnimatorFloorsShortDrainsAtConfigMinimum(t *testing.T) {
+	t.Parallel()
+
+	wantChunks := config.MinSmoothCursorAnimationDuration / minCursorStepDelay
+
+	rec := &deltaRecorder{}
+	animator := newRelativeCursorAnimator(rec.moveBy)
+
+	// Sized so every scheduled chunk carries at least one pixel; a chunk that
+	// rounded to zero would post nothing and undercount the schedule.
+	delta := image.Point{X: 10 * wantChunks, Y: 0}
+	animator.addDelta(delta, wantChunks*100, 1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	if got := rec.count(); got != wantChunks {
+		t.Fatalf(
+			"posted %d chunks for a below-floor drain, want %d "+
+				"(config.MinSmoothCursorAnimationDuration / minCursorStepDelay)",
+			got,
+			wantChunks,
+		)
+	}
+}
+
 // TestRelativeCursorAnimatorComposesConcurrentDeltas pins that deltas folded
 // in from concurrent movers all reach the compositor — the drain equivalent
 // of the absolute animator's pending-endpoint extension.


### PR DESCRIPTION
## Description

This PR removes a duplicate copy of the smooth-cursor animation floor on Linux. Every smooth-cursor animation is floored at a minimum duration, and Linux declared that minimum for itself while the validator that rejects a shorter configured relative-movement duration read it from the configuration layer. The two matched only because someone typed the same number twice — raising the shared minimum would have left Linux quietly flooring durations its own validator had just accepted, honouring them on macOS and ignoring them on Linux, with nothing failing to announce it.

Both Linux cursor animators now read the single shared minimum, exactly as the macOS animator already does. The values are equal today, so there is no behaviour change at any currently valid configuration; what changes is that they can no longer drift apart.

Two neighbouring constants were checked and deliberately left alone, each with its reason recorded in the code: the shortest gap between injected animation steps is this animator's own timer granularity with no configuration counterpart at all, and the fallback step count equals the shipped default only by coincidence — no validated configuration can reach it, because the validator already requires a step count of at least one and both callers pass the configured value. Folding either would have been the coincidence-as-derivation mistake ADR 0007 warns about.

## Related Issues

Closes #1413

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port method or capability changes; this only single-sources a constant already used on both platforms.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the exact checks CI runs (format check, lint, vet,
      tests including `-race`, vulnerability scan, build)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no capability status, mechanism or configuration reference fact changed.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**What was verified locally, and what only CI can confirm.** The changed files are all behind `//go:build linux`, so a macOS host does not compile a line of them and `just ci`'s lint is blind to them. Three gates were run and all passed: `just ci` on the host, `just lint-cross` (linux/amd64 with CGO on, in Docker), and `just test-linux` (the real Linux suite with CGO on, in Docker, mirroring the CI Linux job). The Docker legs are what actually built and executed this change. They mirror the CI Linux job rather than being it, so the Linux leg on this PR is still the authority; the macOS and Windows legs exercise no changed code.

**The new tests read the floor back out of behaviour rather than comparing two constants.** A below-floor duration requested in far more steps than the floor can schedule collapses to one step per unit of the minimum step delay, so the number of injected moves *is* the floor. The expectation is derived from the shared constant, so moving that constant moves both the animator and the expectation together. This was checked by temporarily raising the shared minimum — the tests still passed — and then additionally reintroducing a hardcoded local floor, which failed them, confirming the pin catches exactly the desync this PR removes.

**Adjacent, deliberately not fixed here.** The duration-to-schedule arithmetic (floor, step count, step delay) still exists as separate copies in the two Linux animators and in the macOS one; only the floor inside it is now single-sourced. The 2026-08-09 review that produced this ticket declined collapsing the animators, so that is left standing rather than widened into this diff.
