### PR TITLE
docs: stop the contributor first hour promising things that are not true

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -31,7 +31,8 @@ the usual ones.
 
 1. Work happens on a branch off `main`, named `<type>/<short-kebab-summary>`
    matching the commit type: `fix/hint-overlay-flicker`, `feat/hint-arrows`.
-2. Run the full gate — it is exactly what CI runs, so surprises surface here:
+2. Run the full gate — the same recipes CI gates on, run on your host only,
+   where CI runs them on macOS, Linux and Windows:
 
    ```bash
    just ci

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,7 +44,9 @@
       scan, build); CI runs them on macOS, Linux and Windows
 - [ ] Tests added/updated for new or changed functionality
 - [ ] Documentation updated (if applicable)
-- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
+- [ ] PR title is a [conventional commit](https://www.conventionalcommits.org/)
+      subject written for users — this PR squash-merges, so the title is what
+      Release Please ships in the changelog, not the commits on the branch
 
 ## Screenshots / Recordings
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,9 @@ issues, so reports stay confidential.
 
 Set up your environment by following
 [DEVELOPMENT.md](docs/DEVELOPMENT.md#development-setup) — Devbox is the
-recommended path and provides every tool pre-configured.
+recommended path and provides the toolchain pre-configured. On Linux, read the
+prerequisites there first: Devbox does not cover the system packages a CGO
+build links against.
 
 ---
 
@@ -234,9 +236,7 @@ and don't submit changes you can't explain.
 
 ## Good First Contributions
 
-Not sure where to start? Issues labeled
-[`good first issue`](https://github.com/y3owk1n/neru/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-are curated to be well-scoped for newcomers. Beyond those:
+Not sure where to start? Any of these are welcome:
 
 - 🐛 Bug fixes — check the [open issues](https://github.com/y3owk1n/neru/issues)
 - 📝 Documentation improvements or typo fixes

--- a/README.md
+++ b/README.md
@@ -286,11 +286,11 @@ and pull requests are very welcome.
 
 ```bash
 git checkout -b feature/your-feature
-just ci   # everything CI checks, locally
+just ci   # the same recipes CI gates on, on your host only
 # open a pull request
 ```
 
-→ [Contributing Guide](CONTRIBUTING.md) · [Development Guide](docs/DEVELOPMENT.md) · [Good first issues](https://github.com/y3owk1n/neru/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+→ [Contributing Guide](CONTRIBUTING.md) · [Development Guide](docs/DEVELOPMENT.md)
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -43,13 +43,21 @@ Then from a second terminal:
 ./bin/neru hints        # should show hint overlays
 ```
 
+> [!IMPORTANT]
+> On macOS this needs Accessibility permission granted to whichever app starts
+> the daemon — your terminal, when you run `./bin/neru launch` by hand. Without
+> it the smoke test reports an accessibility error instead of drawing overlays.
+> Same grant, same place as for the integration tests: see
+> [Running integration tests](#running-integration-tests).
+
 There is no `just run` recipe — build first, then launch the daemon directly.
 The CLI talks to the running daemon over a socket, so both halves come from the
 same `./bin/neru` binary.
 
 For end-user installation (Homebrew, Nix, prebuilt binaries) see
-[INSTALLATION.md](INSTALLATION.md); for preparing a Linux host see
-[LINUX_SETUP.md](LINUX_SETUP.md).
+[INSTALLATION.md](INSTALLATION.md); on Linux,
+[LINUX_SETUP.md](LINUX_SETUP.md) covers both preparing the host and the
+[build dependencies](LINUX_SETUP.md#build-dependencies) a source build needs.
 
 ---
 
@@ -59,13 +67,17 @@ For end-user installation (Homebrew, Nix, prebuilt binaries) see
 
 - **Go 1.26+** — [Install Go](https://golang.org/dl/)
 - **Xcode Command Line Tools** (macOS) — `xcode-select --install`
+- **Build dependencies** (Linux) — the system `-dev`/`-devel` packages a CGO
+  build links against, listed for apt, dnf and pacman in
+  [LINUX_SETUP.md](LINUX_SETUP.md#build-dependencies). Install them before your
+  first build, including under Devbox.
 - **Just** — command runner — [install](https://github.com/casey/just)
 - **golangci-lint** — linter — [install](https://golangci-lint.run/usage/install/)
 
 ### Option A: Devbox (recommended)
 
 [Devbox](https://www.jetify.com/devbox) provides an isolated environment with
-every tool pre-configured:
+the toolchain below pre-configured:
 
 ```bash
 curl -fsSL https://get.jetify.com/devbox | bash
@@ -79,6 +91,13 @@ in the repo root takes over whenever you `cd` in.
 
 Devbox manages Go 1.26+, gopls, gotools, gofumpt, golines, golangci-lint, just,
 and clang-tools (for CGo).
+
+On Linux it is not enough on its own: Devbox does not pull the `-dev` outputs a
+CGO build links against
+([jetify-com/devbox#2761](https://github.com/jetify-com/devbox/issues/2761)),
+so install the system packages listed in
+[LINUX_SETUP.md](LINUX_SETUP.md#build-dependencies) first — `just build` fails
+in the compiler without them.
 
 ### Option B: Manual installation
 


### PR DESCRIPTION
## Description

This PR fixes five things the repo tells a new contributor in their first hour
that are not true. Each is discovered only by acting on it, which is the
criterion [ADR 0012](../blob/main/docs/adr/0012-the-first-hour-must-not-lie.md)
selected them by.

What changes for a contributor: the `good first issue` links in the README and
CONTRIBUTING are gone, so nobody lands on an empty query (deleting the link was
chosen over relabelling — curating real starter issues is editorial work with
no deadline). `just ci` is no longer described as the exact checks CI runs in
the README and the `create-pr` skill; both now use the wording the other homes
already carry — the same recipes, on your host only, where CI runs them on
macOS, Linux and Windows. Quick Start now warns that its `./bin/neru hints`
smoke test needs macOS Accessibility permission granted to the terminal that
starts the daemon, linking the section that already explains the grant.
Prerequisites gains the Linux build dependencies and links
`LINUX_SETUP.md#build-dependencies`, the Devbox section says plainly that it
does not pull the `-dev` outputs a CGO build needs, and Quick Start's caption
no longer reads as runtime-only setup. The PR template's conventional-commits
checkbox now names the squash title, which is what Release Please actually
reads.

Deliberate limitation: no package list is duplicated. `LINUX_SETUP.md` stays
the single home for the apt/dnf/pacman lists; everything else points at it.

## Related Issues

Closes #1442

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, tests including a unit `-race` pass, vulnerability
      scan, build); CI runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality — N/A, docs only;
      the existing `doc_links` and `guide_test_citations` guardrails cover it
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

The issue's line numbers were captured before #1438 landed, so each claim was
re-grepped rather than trusted. That surfaced two occurrences the issue did not
list, both genuine instances of the same claims: `README.md`'s
`just ci   # everything CI checks, locally`, and `CONTRIBUTING.md`'s "provides
every tool pre-configured". Both are corrected here.

Left alone deliberately: `AGENTS.md` and `CONTRIBUTING.md`'s *Commit Messages*
section still say the commit subject is what ships in the changelog. That is
guidance to write conventional commits, which stands; only the PR template's
verification checkbox pointed at the wrong artifact, and that is what ADR 0012
ruled on.
