### PR TITLE
build(justfile): give every recipe an accurate summary in just --list

### DIFF
--- a/internal/architecture/doc.go
+++ b/internal/architecture/doc.go
@@ -39,6 +39,9 @@
 //     by naming it, and every test name or test file it names resolves.
 //   - hint_placement_vocabulary_test.go — the hint placement vocabulary is the
 //     same on both sides of the Go/Objective-C boundary.
+//   - justfile_doc_test.go — every recipe just --list shows declares its own
+//     one-line summary, rather than inheriting whichever line of the comment
+//     block above it just happens to read.
 //   - keyvocab_wire_test.go — the native key event emitters and keyvocab agree
 //     on what they put on the wire.
 //   - label_autohide_rule_test.go — the label autohide rule is pinned across

--- a/internal/architecture/foundation_slice_test.go
+++ b/internal/architecture/foundation_slice_test.go
@@ -391,12 +391,16 @@ func recipePackages(t *testing.T, recipes justRecipes) []string {
 // justRecipes is the justfile read as a graph, keyed by recipe name.
 type justRecipes map[string]justRecipe
 
-// justRecipe is one recipe: the indented lines under its header, and the
-// recipes running it runs — its header dependencies plus any `just <name>` call
-// in that body.
+// justRecipe is one recipe: the indented lines under its header, the
+// attributes declared immediately above it, and the recipes running it runs —
+// its header dependencies plus any `just <name>` call in that body.
 type justRecipe struct {
 	body string
 	runs []string
+	// attributes is the `[…]` lines between the recipe's comment block and its
+	// header, joined as they appear. justfile_doc_test.go reads the declared
+	// summary out of them.
+	attributes string
 }
 
 // mustFind returns a recipe, failing the test when the justfile has none by
@@ -484,39 +488,57 @@ func justHeaderLine(line string) (string, []string, bool) {
 func parseJustfile(t *testing.T) justRecipes {
 	t.Helper()
 
+	recipes := parseJustfileText(readRepoFile(t, justfileName))
+	if len(recipes) == 0 {
+		t.Fatalf("%s defines no recipes; the header match is broken", justfileName)
+	}
+
+	return recipes
+}
+
+// parseJustfileText is parseJustfile over text already in hand, so a guardrail
+// can hold the parser itself to a fixture rather than only to the checkout.
+func parseJustfileText(text string) justRecipes {
 	var (
 		recipes = justRecipes{}
 		bodies  = map[string][]string{}
+		pending string
 		current string
 	)
 
-	for line := range strings.Lines(readRepoFile(t, justfileName)) {
+	for line := range strings.Lines(text) {
 		line = strings.TrimRight(line, "\n")
 
 		switch {
+		// A blank line ends an attribute run. `just` requires an attribute to
+		// sit directly above the header it decorates and errors on anything
+		// between, so a pending attribute separated from one decorates nothing.
 		case line == "":
+			pending = ""
 		case strings.HasPrefix(line, " "), strings.HasPrefix(line, "\t"):
 			if current != "" {
 				bodies[current] = append(bodies[current], line)
 			}
-		// A comment or an attribute in column one interrupts nothing: the
-		// recipe it decorates has not started yet.
-		case strings.HasPrefix(line, "#"), strings.HasPrefix(line, "["):
+		// A comment in column one interrupts nothing: the recipe it decorates
+		// has not started yet. It does end an attribute run, for the reason
+		// above.
+		case strings.HasPrefix(line, "#"):
+			pending = ""
+		case strings.HasPrefix(line, "["):
+			pending += line + "\n"
 		default:
 			name, deps, isHeader := justHeaderLine(line)
 			if !isHeader {
 				current = ""
+				pending = ""
 
 				continue
 			}
 
 			current = name
-			recipes[name] = justRecipe{runs: deps}
+			recipes[name] = justRecipe{runs: deps, attributes: pending}
+			pending = ""
 		}
-	}
-
-	if len(recipes) == 0 {
-		t.Fatalf("%s defines no recipes; the header match is broken", justfileName)
 	}
 
 	for name, lines := range bodies {

--- a/internal/architecture/justfile_doc_test.go
+++ b/internal/architecture/justfile_doc_test.go
@@ -1,0 +1,258 @@
+package architecture_test
+
+import (
+	"maps"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// This guardrail pins what `just --list` says about each recipe.
+//
+// `just` documents a recipe from the last contiguous comment line above it,
+// and this justfile writes rationale paragraphs there, so for twenty-six of
+// fifty-odd recipes the listed text was the tail of a sentence: `build`
+// advertised itself as "X11/Wayland native backends). Windows currently builds
+// with CGO disabled.", `list-foundation-packages` as "check could see.". Which
+// line `just` happens to read is a function of where someone put a blank line,
+// so the layout fix does not hold either — `build` had one and still rendered
+// wrong.
+//
+// Nothing caught it. The justfile parses, every recipe runs, `just lint` is
+// silent and every test passes with the list wrong, which is how it stayed
+// wrong for months and is exactly the breach ADR 0011 says earns a guardrail.
+// docs/DEVELOPMENT.md names `just --list` as how a newcomer sees what the
+// project can do, so the orient step of the first hour was reading as noise.
+//
+// The fix is a declaration rather than a layout: every recipe `just --list`
+// shows carries its own `[doc('…')]` attribute, which overrides the comment
+// block entirely and leaves the prose above it exactly where it is.
+//
+// This reads the justfile as text and never runs `just`, per ADR 0011: the
+// tests in this package hold on every CI leg regardless of what is installed.
+const firstHourADR = "docs/adr/0012-the-first-hour-must-not-lie.md"
+
+// maxSummaryColumns is the widest summary a recipe may declare.
+//
+// It caps the summary text, not the line `just --list` prints, and the
+// difference is deliberate. `just` pads every signature out to the widest one
+// it will align — signatures past 50 columns are dropped from the alignment
+// and get their summary on a line of their own — which today is `generate-icons
+// APP_ICON TRAY_ACTIVE TRAY_DISABLED` at 49. That puts the summary column at
+// 56, so an 80-column terminal leaves 24 for the text. Summaries that short are
+// labels rather than sentences, and they would be a downgrade for the entries
+// that already read correctly today at 40 to 76 columns.
+//
+// So the rule this width states is that a summary is one line and not a
+// paragraph. Past it the text is rationale, and rationale belongs in the
+// comment block above the recipe — which the attribute deliberately leaves
+// alone.
+const maxSummaryColumns = 80
+
+// minListedRecipes guards against a vacuous pass. The justfile lists fifty-odd
+// recipes; a parser that matched none — a header pattern that stopped
+// resolving, a renamed justfile — would satisfy every assertion below while
+// checking nothing at all.
+const minListedRecipes = 40
+
+// docAttributePattern captures the text of a `[doc('…')]` attribute, in either
+// quoting. Both are read: a single-quoted string is raw, so it cannot carry an
+// apostrophe, and the double-quoted form is the only way to write a summary
+// that needs one. The capture is the source text, so an escape in a
+// double-quoted summary counts its backslash toward the width — a summary near
+// enough the cap for that to matter is over it in spirit anyway.
+var docAttributePattern = regexp.MustCompile(
+	`\bdoc\(\s*(?:'([^']*)'|"((?:[^"\\]|\\.)*)")\s*\)`,
+)
+
+// privateAttributePattern matches the `[private]` attribute, which hides a
+// recipe from `just --list`. It is matched as a whole word between the
+// brackets and commas that delimit an attribute list.
+var privateAttributePattern = regexp.MustCompile(`[\[,]\s*private\s*[,\]]`)
+
+// TestEveryListedRecipeDeclaresItsSummary fails when a recipe `just --list`
+// shows has no summary of its own, so the listed text falls back to whatever
+// line of prose happens to sit above it.
+func TestEveryListedRecipeDeclaresItsSummary(t *testing.T) {
+	recipes := parseJustfile(t)
+
+	listed := 0
+
+	for _, name := range slices.Sorted(maps.Keys(recipes)) {
+		if !recipeIsListed(name, recipes[name]) {
+			continue
+		}
+
+		listed++
+
+		summary, declared := recipeSummary(recipes[name])
+
+		fault := summaryFault(summary, declared)
+		if fault == "" {
+			continue
+		}
+
+		t.Errorf(
+			"the %s recipe in %s %s; declare a one-line [doc('…')] summary of "+
+				"what the recipe does on every recipe `just --list` shows, and "+
+				"leave the comment block above it alone (%s)",
+			name, justfileName, fault, firstHourADR,
+		)
+	}
+
+	assertWalkedAtLeast(t, "recipes `just --list` shows", listed, minListedRecipes)
+}
+
+// justfileSummaryFixture is a justfile holding one recipe of each shape the
+// rule has an answer for. It is text rather than a temporary file because the
+// parser reads text, and because a fixture `just` never runs cannot drift into
+// depending on `just` being installed.
+var justfileSummaryFixture = `# Prose about the good recipe, wrapped over
+# more than one line, as this justfile writes it.
+[doc('Build the development binary into bin/neru.')]
+good:
+    @echo good
+
+# Prose whose tail is what ` + "`just --list`" + ` would show.
+bare:
+    @echo bare
+
+[doc('')]
+empty:
+    @echo empty
+
+[doc('` + overlongFixtureSummary + `')]
+overlong:
+    @echo overlong
+
+[no-exit-message, doc('Carry the summary beside another attribute.')]
+combined:
+    @echo combined
+
+[doc("Quote it the other way, which is how a summary carries an apostrophe.")]
+doublequoted:
+    @echo doublequoted
+
+[private]
+[doc('Hidden from just --list, so it owes no summary.')]
+hidden:
+    @echo hidden
+
+_underscored:
+    @echo underscored
+`
+
+// overlongFixtureSummary is one column past the cap, which is the only width
+// that proves where the cap is.
+var overlongFixtureSummary = strings.Repeat("x", maxSummaryColumns+1)
+
+// TestJustfileSummaryRule_RejectsWhatItMustReject holds the rule to each shape
+// it has to separate: a recipe with no attribute at all, one declaring an
+// empty string, one declaring a paragraph, and — in the other direction — the
+// recipes `just --list` never shows, which owe nothing.
+//
+// The real justfile can only ever show the rule passing. A rule that quietly
+// stopped rejecting anything would pass there too, forever.
+func TestJustfileSummaryRule_RejectsWhatItMustReject(t *testing.T) {
+	recipes := parseJustfileText(justfileSummaryFixture)
+
+	tests := []struct {
+		recipe   string
+		listed   bool
+		rejected bool
+	}{
+		{recipe: "good", listed: true, rejected: false},
+		{recipe: "combined", listed: true, rejected: false},
+		{recipe: "doublequoted", listed: true, rejected: false},
+		{recipe: "bare", listed: true, rejected: true},
+		{recipe: "empty", listed: true, rejected: true},
+		{recipe: "overlong", listed: true, rejected: true},
+		{recipe: "hidden", listed: false, rejected: false},
+		{recipe: "_underscored", listed: false, rejected: false},
+	}
+
+	// Exact, not a floor: the fixture declares one recipe per case below, so a
+	// parser that merged two of them or invented one is a parser this test can
+	// no longer speak for.
+	if len(recipes) != len(tests) {
+		t.Fatalf(
+			"the fixture parsed to %d recipes, want %d; the parser is not reading "+
+				"the fixture the way it reads the justfile",
+			len(recipes), len(tests),
+		)
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.recipe, func(t *testing.T) {
+			recipe, defined := recipes[testCase.recipe]
+			if !defined {
+				t.Fatalf("the fixture defines no %s recipe", testCase.recipe)
+			}
+
+			if got := recipeIsListed(testCase.recipe, recipe); got != testCase.listed {
+				t.Fatalf("recipeIsListed(%s) = %t, want %t", testCase.recipe, got, testCase.listed)
+			}
+
+			if !testCase.listed {
+				return
+			}
+
+			summary, declared := recipeSummary(recipe)
+
+			fault := summaryFault(summary, declared)
+			if (fault != "") != testCase.rejected {
+				t.Errorf(
+					"summaryFault for %s = %q, want rejected = %t",
+					testCase.recipe, fault, testCase.rejected,
+				)
+			}
+		})
+	}
+}
+
+// recipeIsListed reports whether `just --list` shows the recipe, which is the
+// only place a declared summary is read and so the only place one is owed. A
+// leading underscore and the `[private]` attribute both hide one.
+func recipeIsListed(name string, recipe justRecipe) bool {
+	if strings.HasPrefix(name, "_") {
+		return false
+	}
+
+	return !privateAttributePattern.MatchString(recipe.attributes)
+}
+
+// recipeSummary returns the text of the recipe's `[doc('…')]` attribute and
+// whether it declares one at all. The two are separate answers: a recipe with
+// no attribute and one declaring an empty string are different mistakes, and
+// the failure message says which.
+func recipeSummary(recipe justRecipe) (string, bool) {
+	match := docAttributePattern.FindStringSubmatch(recipe.attributes)
+	if match == nil {
+		return "", false
+	}
+
+	// One of the two quotings matched; the other capture is empty.
+	return match[1] + match[2], true
+}
+
+// summaryFault returns why a declared summary fails the rule, phrased to slot
+// into the failure message, or the empty string when it passes.
+func summaryFault(summary string, declared bool) string {
+	switch {
+	case !declared:
+		return "declares no [doc('…')] attribute, so `just --list` shows whatever " +
+			"comment line happens to sit above it"
+	case strings.TrimSpace(summary) == "":
+		return "declares an empty summary, which lists as a bare `#`"
+	case utf8.RuneCountInString(summary) > maxSummaryColumns:
+		return "declares a summary of " +
+			strconv.Itoa(utf8.RuneCountInString(summary)) +
+			" columns, past the " + strconv.Itoa(maxSummaryColumns) +
+			"-column line a summary has to fit"
+	default:
+		return ""
+	}
+}

--- a/justfile
+++ b/justfile
@@ -17,12 +17,14 @@ MACOSX_DEPLOYMENT_TARGET := "14.0"
 LDFLAGS := "-s -w -X github.com/y3owk1n/neru/internal/buildinfo.Version=" + VERSION + " -X github.com/y3owk1n/neru/internal/buildinfo.GitCommit=" + GIT_COMMIT + " -X github.com/y3owk1n/neru/internal/buildinfo.BuildDate=" + BUILD_DATE
 
 # Default build
+[doc('Build the development binary; what plain `just` with no recipe runs.')]
 default: build
 
 # Build the application (development)
 # Uses CGO on macOS (required for Objective-C bridge) and Linux (required for
 
 # X11/Wayland native backends). Windows currently builds with CGO disabled.
+[doc('Build the development binary into bin/neru, CGO on except on Windows.')]
 build:
     @echo "Building Neru..."
     @echo "Version: {{ VERSION }}"
@@ -42,6 +44,7 @@ build:
 # arches Neru ships (amd64, arm64), and a compiler that cannot answer
 # -dumpmachine gets the benefit of the doubt. Both fail open, so the guard never
 # blocks a build that would have worked.
+[doc('Build a Linux binary with CGO; needs a Linux-targeting C compiler.')]
 build-linux ARCH="amd64":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -78,6 +81,7 @@ build-linux ARCH="amd64":
 #
 # Must be run before go build on/for Windows.  The .syso files are written into
 # cmd/neru/ so go build picks them up automatically.
+[doc('Generate the Windows icon and manifest .syso files into cmd/neru/.')]
 generate-winres ARCH="amd64":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -95,6 +99,7 @@ generate-winres ARCH="amd64":
 # Build a Windows binary from any host.
 # This produces a binary with grid, recursive grid, scroll, global hotkeys,
 # mouse injection, IPC, and initial UIA accessibility.
+[doc('Build a Windows binary from any host, with CGO off.')]
 build-windows ARCH="amd64":
     @echo "Building Neru for windows/{{ ARCH }}..."
     mkdir -p bin
@@ -105,6 +110,7 @@ build-windows ARCH="amd64":
 # Build a macOS binary for the current host.
 
 # macOS requires CGO because the native bridge is part of the real product.
+[doc('Build a macOS binary for this host, native bridge included.')]
 build-darwin:
     @echo "Building Neru for macOS..."
     mkdir -p bin
@@ -112,6 +118,7 @@ build-darwin:
     @echo "✓ Build complete: bin/neru-darwin"
 
 # Build with optimizations for release
+[doc('Build an optimized, trimpath release binary into bin/neru.')]
 release:
     @echo "Building release version..."
     @echo "Version: {{ VERSION }}"
@@ -121,6 +128,7 @@ release:
     @echo "✓ Release build complete: bin/neru"
 
 # Build with custom version
+[doc('Build a release binary stamped with the version you pass.')]
 build-version VERSION_OVERRIDE:
     @echo "Building Neru with custom version..."
     CGO_ENABLED=1 go build -ldflags="-s -w -X github.com/y3owk1n/neru/internal/buildinfo.Version={{ VERSION_OVERRIDE }} -X github.com/y3owk1n/neru/internal/buildinfo.GitCommit={{ GIT_COMMIT }} -X github.com/y3owk1n/neru/internal/buildinfo.BuildDate={{ BUILD_DATE }}" -trimpath -o bin/neru ./cmd/neru
@@ -129,6 +137,7 @@ build-version VERSION_OVERRIDE:
 # Build a macOS release artifact for CI on a native macOS host.
 
 # Usage: just release-ci-darwin arm64 v1.2.3
+[doc('Build the macOS release artifact, on a native macOS host.')]
 release-ci-darwin ARCH VERSION_OVERRIDE:
     @echo "Building release artifact (darwin/{{ ARCH }}) for CI..."
     @echo "Version: {{ VERSION_OVERRIDE }}"
@@ -141,6 +150,7 @@ release-ci-darwin ARCH VERSION_OVERRIDE:
 # Build a Linux release artifact for CI on a native Linux host.
 
 # Usage: just release-ci-linux amd64 v1.2.3
+[doc('Build the Linux release artifact, on a native Linux host.')]
 release-ci-linux ARCH VERSION_OVERRIDE:
     @echo "Building release artifact (linux/{{ ARCH }}) for CI..."
     @echo "Version: {{ VERSION_OVERRIDE }}"
@@ -153,6 +163,7 @@ release-ci-linux ARCH VERSION_OVERRIDE:
 # Build a Windows release artifact for CI.
 
 # Usage: just release-ci-windows amd64 v1.2.3
+[doc('Build the Windows release artifact, from any host.')]
 release-ci-windows ARCH VERSION_OVERRIDE:
     @echo "Building release artifact (windows/{{ ARCH }}) for CI..."
     @echo "Version: {{ VERSION_OVERRIDE }}"
@@ -164,6 +175,7 @@ release-ci-windows ARCH VERSION_OVERRIDE:
     @echo "✓ Release artifact for windows/{{ ARCH }} built successfully"
 
 # Bundle the application
+[doc('Build, then package and ad-hoc sign build/Neru.app.')]
 bundle: release
     @echo "Bundling Neru..."
     mkdir -p build/Neru.app/Contents/{MacOS,Resources}
@@ -183,6 +195,7 @@ bundle: release
 # first: `just bundle` (macOS), `just build` (Linux), `just build-windows`
 # (Windows). Pass -y to accept every prompt non-interactively (`just install -y`).
 # On Windows this runs under a bash such as Git Bash.
+[doc('Install a built Neru with the platform script in scripts/.')]
 install *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -198,6 +211,7 @@ install *ARGS:
 # every prompt non-interactively, and --purge to also remove your config and
 # logs (they are kept otherwise, so -y alone can never delete your config.toml).
 # On Windows this runs under a bash such as Git Bash.
+[doc('Undo `just install`; your config survives unless you pass --purge.')]
 uninstall *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -213,10 +227,12 @@ uninstall *ARGS:
 # Run all tests (unit + integration). Desktop-safe: tests that would drive the
 # real cursor, keyboard or overlays skip themselves here — run `just
 # test-desktop` to include them when you can hand the machine over.
+[doc('Run the unit and integration tests, leaving the desktop alone.')]
 test: test-unit test-integration
     @echo "Running all tests..."
 
 # Run unit tests
+[doc('Run the unit tests.')]
 test-unit:
     @echo "Running unit tests..."
     go test -v ./...
@@ -234,6 +250,7 @@ test-unit:
 #
 # CI runs this recipe too, via test-ci, so a list that no longer resolves fails
 # the build rather than only the next person to type it.
+[doc('Run the test slice whose behavior is identical on all three platforms.')]
 test-foundation:
     @echo "Running cross-platform foundation tests..."
     go test ./internal/config ./internal/config/loader \
@@ -268,6 +285,7 @@ test-foundation:
 # second time here is what let the old version of this recipe report packages
 # that were platform-specific by directory or by a //go:build line no filename
 # check could see.
+[doc('Print the package list the test-foundation recipe should be running.')]
 list-foundation-packages:
     @NERU_LIST_FOUNDATION=1 go test -count=1 -v \
         -run TestFoundationSliceMatchesTheRecipe ./internal/architecture | grep '^\./'
@@ -288,6 +306,7 @@ list-foundation-packages:
 # result cached from a run under different conditions is then replayed as a
 # pass, which is worse than no result at all: it reports green for a run that
 # never happened.
+[doc('Run the integration tests, minus the ones that drive the desktop.')]
 test-integration:
     @echo "Running integration tests (desktop-safe)..."
     go test -tags=integration -p 1 -count=1 -v ./...
@@ -296,21 +315,25 @@ test-integration:
 # desktop: the cursor moves, real clicks and scrolls land, overlays flash, and
 # an event tap briefly intercepts the keyboard. Hand the machine over while it
 # runs. Needs Accessibility permission (System Settings > Privacy & Security).
+[doc('Run every integration test, including the ones that drive the desktop.')]
 test-desktop:
     @echo "Running integration tests (including desktop-driving tests)..."
     NERU_DESKTOP_TESTS=1 go test -tags=integration -p 1 -count=1 -v ./...
 
 # Run with race detection
+[doc('Run the unit and integration tests under the race detector.')]
 test-race: test-race-unit test-race-integration
     @echo "Running tests with race detection..."
 
 # Run unit tests with race detection
+[doc('Run the unit tests under the race detector.')]
 test-race-unit:
     @echo "Running unit tests with race detection..."
     go test -race -v ./...
 
 # Run integration tests with race detection
 # See test-integration for why -p 1 and -count=1 are required here.
+[doc('Run the integration tests under the race detector.')]
 test-race-integration:
     @echo "Running integration tests with race detection..."
     go test -tags=integration -race -p 1 -count=1 -v ./...
@@ -321,6 +344,7 @@ test-race-integration:
 # desktop session with Accessibility granted — it takes over the cursor and
 # keyboard while it runs. CI gates on test-ci below, which is the same minus
 # the passes that are meaningless on a headless runner.
+[doc('Run every suite, plain and under -race, desktop-driving tests included.')]
 test-all:
     NERU_DESKTOP_TESTS=1 just test test-race
 
@@ -331,6 +355,7 @@ test-all:
 # Tests that touch real input or permissions must guard themselves with
 # testing.Short(); permission-free integration tests (config, logger, IPC,
 # CLI) still run fully.
+[doc('Run the integration tests the way CI does, under -short.')]
 test-integration-ci:
     @echo "Running integration tests (CI profile: -short)..."
     go test -tags=integration -short -p 1 -count=1 ./...
@@ -348,6 +373,7 @@ test-integration-ci:
 # TestFoundationSliceRunsInCI keeps it reachable from here; the workflow invokes
 # this recipe on macOS, Linux and Windows alike, which is where a slice claiming
 # to be cross-platform-safe should be proven.
+[doc('Run every test suite CI runs: foundation, unit, unit -race, integration.')]
 test-ci: test-foundation test-unit test-race-unit test-integration-ci
 
 # Run the set of checks CI gates a pull request on, in the same order, on this
@@ -355,10 +381,12 @@ test-ci: test-foundation test-unit test-race-unit test-integration-ci
 # here is one leg of three. This is the real pre-push bar — `just test` alone
 # is a subset of it. For the deepest local verification (full integration +
 # race passes on a real desktop session) run `just test-all` as well.
+[doc('Run the checks CI gates a pull request on, on this host only.')]
 ci: fmt-check lint vet build test-ci vuln
     @echo "✓ All CI checks passed"
 
 # Check if files are formatted correctly
+[doc('Check that the Objective-C sources are clang-format clean.')]
 fmt-check:
     #!/usr/bin/env bash
     echo "Not checking formatting for go files... It will be checked in lint"
@@ -384,6 +412,7 @@ fmt-check:
     echo "✓ All Objective-C files are properly formatted"
 
 # Generate man pages
+[doc('Generate the man pages into OUTPUT_DIR.')]
 genman OUTPUT_DIR="build/man":
     @echo "Generating man pages..."
     go run ./cmd/genman {{ OUTPUT_DIR }}
@@ -392,11 +421,13 @@ genman OUTPUT_DIR="build/man":
 # Rewrite the mode-flag reference from the grammar's descriptor table.
 # Run after adding, removing or re-wording a mode flag; the architecture
 # guardrail fails while the page is out of date.
+[doc('Rewrite the mode-flag reference in docs/CLI.md from the grammar.')]
 genflagref:
     @echo "Generating the mode-flag reference..."
     go run ./cmd/genflagref docs/CLI.md
 
 # Clean build artifacts
+[doc('Delete the build outputs, the app bundles and the lint cache.')]
 clean:
     @echo "Cleaning build artifacts..."
     rm -rf bin/
@@ -424,6 +455,7 @@ clean:
 export GOLANGCI_LINT_CACHE := justfile_directory() / ".golangci-cache"
 
 # Format code
+[doc('Format the Go sources with golangci-lint and the Objective-C ones.')]
 fmt:
     @echo "Formatting Go files..."
     golangci-lint fmt
@@ -433,9 +465,11 @@ fmt:
     @echo "✓ Format complete"
 
 # Lint code (Go via golangci-lint, Objective-C via clang-tidy)
+[doc('Lint the Go and the Objective-C sources.')]
 lint: lint-go lint-objc
 
 # Lint Go code
+[doc('Lint the Go sources with golangci-lint.')]
 lint-go:
     @echo "Linting Go code..."
     golangci-lint run
@@ -452,6 +486,7 @@ lint-go:
 #    tables outside the lock — the analyzer sees those stores as dead.
 #  - optin.performance.GCDAntipattern: permission prompts are called from Go
 #    through a synchronous bridge, so blocking on a semaphore is the contract.
+[doc('Lint the Objective-C sources with the clang analyzer; macOS only.')]
 lint-objc:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -479,6 +514,7 @@ lint-objc:
     echo "✓ Objective-C lint complete"
 
 # Vet
+[doc('Run go vet over the host build.')]
 vet:
     @echo "Vetting code..."
     go vet ./...
@@ -492,6 +528,7 @@ vet:
 #
 # CGO is off, so this covers the pure-Go and no-cgo backends. The cgo-only Linux
 # backends (X11, wlroots) still need a cross toolchain or CI to type-check.
+[doc('Run go vet over the Linux and Windows builds too, with CGO off.')]
 vet-cross:
     @echo "Vetting for linux/amd64 (CGO off)..."
     GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go vet ./...
@@ -510,6 +547,7 @@ vet-cross:
 # Docker caches the image after the first run.
 #
 # Requires a running Docker daemon.
+[doc('Run the Linux test suite in a CI-equivalent container; needs Docker.')]
 test-linux:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -529,6 +567,7 @@ test-linux:
     echo "✓ Linux test suite passed"
 
 # Same as test-linux but with CGO off, exercising the no-cgo Linux backends.
+[doc('Run the Linux test suite in a container with CGO off; needs Docker.')]
 test-linux-nocgo:
     @echo "Running the Linux test suite in a container (CGO off)..."
     docker run --rm -v "$PWD":/src -w /src \
@@ -541,6 +580,7 @@ test-linux-nocgo:
 # Windows cannot be executed from a macOS or Linux host, so this is the
 # strongest available check: it catches everything `go vet` does plus anything
 # that only fails when the test binary is linked.
+[doc('Compile every package and its test binary for Windows.')]
 test-windows-compile:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -565,6 +605,7 @@ test-windows-compile:
 # the golangci-lint version pinned in .github/workflows/ci.yml.
 #
 # Requires a running Docker daemon.
+[doc('Lint the Linux and Windows builds in a container; needs Docker.')]
 lint-cross:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -596,6 +637,7 @@ lint-cross:
 #
 # Deliberately excludes lint-cross and test-linux, which need Docker — run those
 # separately for a real Linux lint and execution rather than a type-check.
+[doc('Type-check the Linux and Windows builds; no Docker, no cross toolchain.')]
 check-cross: vet-cross test-windows-compile
     @echo "✓ Cross-platform checks complete (run 'just lint-cross' and 'just test-linux' for real Linux runs)"
 
@@ -610,6 +652,7 @@ check-cross: vet-cross test-windows-compile
 # The tool is fetched at @latest rather than pinned: its value is knowing about
 # vulnerabilities published after the pin would have been written, and the
 # vulnerability database is fetched at run time regardless.
+[doc('Scan the dependencies for known vulnerabilities with govulncheck.')]
 vuln:
     @echo "Scanning for known vulnerabilities..."
     go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
@@ -626,6 +669,7 @@ vuln:
 # thoroughly exercised from a neighbouring package reads as zero. The action
 # sequence executor measured 0% that way and 77% this way; nothing about the
 # tests changed, only which package was asked.
+[doc('Run the unit tests with coverage and print the total.')]
 coverage:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -635,11 +679,13 @@ coverage:
     echo "✓ Coverage profile written to coverage.txt"
 
 # Render the coverage profile as a browsable HTML report.
+[doc('Render the coverage profile as a browsable HTML report.')]
 coverage-html: coverage
     go tool cover -html=coverage.txt -o coverage.html
     @echo "✓ Coverage report written to coverage.html"
 
 # Download dependencies
+[doc('Download the module dependencies and tidy go.mod.')]
 deps:
     @echo "Downloading dependencies..."
     go mod download
@@ -647,12 +693,14 @@ deps:
     @echo "✓ Dependencies updated"
 
 # Verify dependencies
+[doc('Verify the downloaded module dependencies against go.sum.')]
 verify:
     @echo "Verifying dependencies..."
     go mod verify
     @echo "✓ Dependencies verified"
 
 # Generate icon.icns from a source PNG (e.g., just generate-icns icon-1024.png)
+[doc('Generate resources/icon.icns from a source PNG.')]
 generate-icns SOURCE:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -677,6 +725,7 @@ generate-icns SOURCE:
 # Resizes to 44×44 pixels (22pt @2x retina for macOS menu bar)
 
 # Usage: just generate-tray-icons active.png disabled.png
+[doc('Generate the two 44x44 systray icons from source PNGs.')]
 generate-tray-icons ACTIVE DISABLED:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -691,6 +740,7 @@ generate-tray-icons ACTIVE DISABLED:
 # Generate all icons from source PNGs
 
 # Usage: just generate-icons app-icon.png tray-active.png tray-disabled.png
+[doc('Generate the app icon and both systray icons from source PNGs.')]
 generate-icons APP_ICON TRAY_ACTIVE TRAY_DISABLED:
     just generate-icns {{ APP_ICON }}
     just generate-tray-icons {{ TRAY_ACTIVE }} {{ TRAY_DISABLED }}
@@ -711,6 +761,7 @@ PROTOCOL_DIR := "protocol"
 WLR_PROTOCOL_DIR := "internal/adapter/platform/linux/wlr_protocol"
 
 # Download Wayland protocol XMLs from canonical upstream repositories
+[doc('Download the Wayland protocol XMLs from their upstream repositories.')]
 fetch-protocols:
     @echo "Fetching Wayland protocol XMLs..."
     mkdir -p {{ PROTOCOL_DIR }}
@@ -726,6 +777,7 @@ fetch-protocols:
     @echo "✓ Protocol XMLs downloaded to {{ PROTOCOL_DIR }}/"
 
 # Generate wayland-scanner files from XMLs
+[doc('Generate the wayland-scanner headers and code from the XMLs.')]
 generate-protocols:
     @echo "Generating wayland-scanner protocol files..."
     mkdir -p {{ WLR_PROTOCOL_DIR }}
@@ -768,5 +820,6 @@ generate-protocols:
     @echo "✓ Protocol files generated in {{ WLR_PROTOCOL_DIR }}/"
 
 # Download and generate all Wayland protocols
+[doc('Download the Wayland protocol XMLs and generate their code.')]
 generate-all-protocols: fetch-protocols generate-protocols
     @echo "✓ All Wayland protocols downloaded and generated"


### PR DESCRIPTION
## Description

This PR fixes `just --list`, which described 26 of the 53 recipes with the tail
of a sentence: `build` advertised itself as "*X11/Wayland native backends).
Windows currently builds with CGO disabled.*", `list-foundation-packages` as
"*check could see.*", and `test` as a fragment opening on an unmatched
backtick. Nothing was mistyped — `just` reads only the last contiguous comment
line before a recipe, and this justfile writes multi-line rationale there, so
the listed text was whichever line a blank happened to leave last.

Every recipe now declares its own one-line summary with a `[doc('…')]`
attribute, which overrides the comment block entirely. The rationale comments
are untouched and stay exactly where they were, so `just --list` reads as 53
summaries and the listed text no longer moves when someone edits the prose
above it.

A guardrail in `internal/architecture` reads the justfile as text — it never
shells out to `just` — and fails when a recipe `just --list` shows declares no
summary, declares an empty one, or declares a paragraph. One deliberate
limitation: the width rule caps the summary text rather than the rendered list
line, for the reason in Additional Context.

## Related Issues

Closes #1439

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, tests including a unit `-race` pass, vulnerability
      scan, build); CI runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — the recipe summaries are the
      documentation this changes, and no markdown page quotes `just --list`
      output
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Why a guardrail.** ADR 0012 decides that recipe documentation is declared
rather than inferred from layout, and that it earns a guardrail by ADR 0011's
criterion: the justfile parses, every recipe runs, `just lint` is silent and
every test passes with the list wrong, which is how it stayed wrong for months.
The new test was mutation-checked against the real justfile — deleting a
summary, emptying one, and inflating one each fail with their own message.

**The one judgement call: what "too long" means.** The issue asks the guardrail
to fail on a summary "long enough to wrap in `just --list` at 80 columns".
Taken as the rendered line, that is unreachable. `just` pads every signature to
the widest one it will align — `generate-icons APP_ICON TRAY_ACTIVE
TRAY_DISABLED`, 49 columns — so the summary column starts at 56 and an
80-column terminal leaves 24 columns of text. Summaries that short are labels,
not sentences, and they would be a downgrade for the 27 entries that already
read correctly today at 40 to 76 columns. So the constant caps the summary text
at 80, with the arithmetic written out beside it, and the honest consequence is
that every rendered line still wraps on an 80-column terminal (they run 105 to
128 columns). If you would rather the rule bite on wrapping, a rendered-line
budget of around 120 columns is a one-line change plus a reflow of the four
longest summaries — that number is yours to pick, not mine.

**Recipe count.** The issue and ADR say 52 recipes; there are 53 today, all
public, and all 53 carry a summary.

**Shared parser.** The justfile parser `foundation_slice_test.go` already owned
now also records the attributes above each recipe, and is split so a fixture
can be parsed as text. There is deliberately no second justfile parser in the
package — though the parser arguably now wants a file of its own, the way the
shared repo walk and the shared native-constant reader have one.
