### PR TITLE
test(justfile): stop printing every passing test on a green unit run

### DIFF
--- a/justfile
+++ b/justfile
@@ -232,10 +232,27 @@ test: test-unit test-integration
     @echo "Running all tests..."
 
 # Run unit tests
+#
+# No -v here or on test-race-unit, and test-foundation has never carried one,
+# while test-integration, test-desktop and test-race-integration below keep
+# theirs (test-integration-ci has never had one either). The asymmetry is
+# deliberate — ADR 0012 (docs/adr/0012-the-first-hour-must-not-lie.md) decided
+# it, so read that before "fixing" the inconsistency.
+#
+# `go test` prints a failing test's name and its full output without -v, so on
+# the unit suites the flag adds the passing lines and nothing else: one line
+# per test where a green run needs one per package, and noise around the part
+# that matters when it is red. The three recipes that keep it are the ones
+# where that per-test line is progress — they run -p 1 serialized, skip
+# heavily on headless runners, and have hung.
+#
+# The intuitive split — quiet locally, verbose in CI — is not available:
+# test-ci is a composition of other recipes and never invokes `go test`
+# itself, so there is no seam between the two audiences to hang a switch on.
 [doc('Run the unit tests.')]
 test-unit:
     @echo "Running unit tests..."
-    go test -v ./...
+    go test ./...
 
 # Run the cross-platform-safe test slice: every package that contains no
 # platform-tagged source at all, so its behavior is identical on macOS, Linux
@@ -326,10 +343,11 @@ test-race: test-race-unit test-race-integration
     @echo "Running tests with race detection..."
 
 # Run unit tests with race detection
+# See test-unit for why this recipe carries no -v and the integration ones do.
 [doc('Run the unit tests under the race detector.')]
 test-race-unit:
     @echo "Running unit tests with race detection..."
-    go test -race -v ./...
+    go test -race ./...
 
 # Run integration tests with race detection
 # See test-integration for why -p 1 and -count=1 are required here.


### PR DESCRIPTION
## Description

This PR stops the unit test recipes from printing a line for every passing
test. On a green tree `just test-unit` printed close to ten thousand lines to
say `ok`; it now prints 90, and a full `just ci` run prints under 350. Nothing is
lost on a failure: `go test` already prints a failing test's
name and its full output without `-v`, verified here by planting a deliberately
failing test and confirming it is still named — with its log lines — by
`just test-unit`, `just test-foundation` and the `-race` pass.

The integration recipes deliberately keep `-v`, and that asymmetry is now
written down in `justfile` next to the recipe that lost it, citing ADR 0012.
They run serialized, skip heavily on headless runners and have hung before, so
there the per-test line is progress rather than noise. The obvious alternative
— quiet locally, verbose in CI — is not available, because `test-ci` composes
other recipes instead of invoking `go test` itself, so there is no seam between
the two audiences.

## Related Issues

Closes #1440

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no Go sources change
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no Go sources change
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no ports change
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`) — `just ci`'s format check and lint both
      pass; `just fmt` does not touch `justfile`
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, tests including a unit `-race` pass, vulnerability
      scan, build); CI runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality — N/A, this changes
      how the test recipes report, not what they test; `internal/architecture`'s
      justfile guardrail still passes and `just --list` is unchanged
- [x] Documentation updated (if applicable) — N/A, no document described the
      unit recipes as verbose
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

Two premises in the issue turned out to be wrong about the tree, and the fix is
smaller than the issue implies. `test-foundation` has never carried `-v`, so
"remove it from `test-foundation`" was already satisfied; and
`test-integration-ci` has never carried one either, so "retain it on
`test-integration-ci`" cannot be met by retaining anything. Nothing was added
there — the ADR says the integration recipes *keep* `-v`, not that they gain
it, and adding it to the one CI-facing integration pass would push thousands of
lines back into the CI log. Both facts are recorded in the new comment so the
next reader is not left guessing.

Measured on this host, at the parent commit: `go test -v ./...` 9,803 lines
against 91 without; `go test -v ./internal/...` 9,799 against 84. The issue's
9,782/84 figures were taken before #1444 landed and drifted only by the tests
added since.
