### PR TITLE
fix(darwin): stop an unmodified scroll inheriting held modifiers

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -287,8 +287,11 @@ three platforms.
 
 **Modifiers on a scroll** reach the injection primitive by two different routes,
 because only one of the primitives has a field for them. macOS stamps
-`CGEventSetFlags` on the scroll event — and on every chunk of a smooth-scroll
-animation, since a zoom applied to the first frame only is not a zoom. The other
+`CGEventSetFlags` on the scroll event — always, the empty set included, because a
+NULL-source event is born carrying whatever the combined session state currently
+holds, so an unstamped scroll inherits ambient modifiers rather than carrying
+none — and on every chunk of a smooth-scroll animation, since a zoom applied to
+the first frame only is not a zoom. The other
 three press the real key, scroll, and release it. On Wayland that forces a
 choice: the modifier can only go out on the virtual keyboard (libei on KDE),
 while the fast path for the scroll is the uinput device, so a modified scroll
@@ -586,6 +589,12 @@ Work that is genuinely missing, as opposed to deliberately platform-specific.
    tap's key stream
 5. Secure input detection — always false
 6. Wayland global hotkeys — need `input`-group access and a CGO build
+7. X11 unmodified scroll — a scroll with no `--modifier` presses nothing, so the
+   `XTestFakeButtonEvent` still carries whatever the X server records the user as
+   physically holding. Binding `Ctrl+J` to a plain `scroll_down` therefore sends
+   ctrl+scroll for as long as ctrl is down. macOS forces the empty set onto the
+   event instead; a real-key backend has no per-event field to zero, so closing
+   this means reading the live key state through `XQueryKeymap` in the C bridge
 
 **Windows**
 

--- a/internal/adapter/platform/darwin/accessibility_screen_darwin.m
+++ b/internal/adapter/platform/darwin/accessibility_screen_darwin.m
@@ -160,12 +160,13 @@ int NeruScrollAtPoint(CGPoint pos, int deltaX, int deltaY, CGEventFlags flags) {
 			return 0;
 
 		CGEventSetLocation(scrollEvent, pos);
-		// Only stamp a non-empty set. Unlike a click, which clears the flags to
-		// guarantee a clean press, an unmodified scroll leaves whatever the
-		// created event already carries alone — that is what scrolling did
-		// before modifiers existed here, and nothing asked for it to change.
-		if (flags != 0)
-			CGEventSetFlags(scrollEvent, flags);
+		// Stamp unconditionally, zero included. A NULL-source event is born
+		// carrying the combined session state's modifier flags, so skipping this
+		// for an empty set does not produce an unmodified scroll — it produces
+		// whatever the system currently believes is held, which is how a plain
+		// scroll_down ended up zooming after a Ctrl+J binding. Every other
+		// positioned event Neru posts clears its flags the same way.
+		CGEventSetFlags(scrollEvent, flags);
 		CGEventPost(kNeruMouseEventTapLocation, scrollEvent);
 		CFRelease(scrollEvent);
 		return 1;


### PR DESCRIPTION
## Description

This PR fixes a scroll on macOS arriving at the application with a modifier the
user did not ask for. A scroll that specifies no modifier now sends no modifier,
whatever keys happen to be down at the time.

Previously an unmodified scroll left the event's modifier flags untouched rather
than clearing them, and a freshly created scroll event starts out carrying
whatever the system currently believes is held. So with `Ctrl+J` bound to a
modified scroll and `j` bound to a plain one, pressing `j` while ctrl was still
down sent ctrl+scroll — which zooms in Figma, browsers and most design tools
instead of scrolling. It cleared when the mode was restarted, which is what made
it look like stuck state rather than an event carrying the wrong flags.

This also documents the equivalent gap on X11, which has the same symptom by a
different route and is not fixed here: a backend that presents a modifier as a
real key press has no per-event field to zero, so an unmodified scroll still
rides whatever the user is physically holding. Closing that means reading the
live key state in the X11 bridge.

## Related Issues

None — reported directly against the behaviour shipped in #1449.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new port method or capability; this changes the body of an existing macOS-only entry point
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality — N/A, see Additional Context; the behaviour is not reachable from a Go test
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

**No test, and no seam for one.** The conditional lived entirely in the native
entry point, past the last layer a Go test can observe: the daemon log shows the
scroll being requested with an empty modifier set all the way to the adapter
while the application still zoomed. Verifying it needs a posted event on a real
desktop and an application to observe it; a unit test could only assert that the
stamping call is made, which restates the fix rather than catching the bug — and
would have stayed green through it. Flagging the absence so it is not read as an
oversight.

**Why it surfaced now.** The conditional shipped in #1449 with an explicit
rationale: an unmodified scroll should leave the created event alone, because
that is what scrolling did before modifiers existed on this path. That reasoning
held while a scroll could never be modified. Once the empty set started meaning
"explicitly unmodified" rather than "no opinion", leaving the flags alone became
wrong. Every other positioned event the darwin bridge posts — cursor moves,
mouse up, each click — already clears its flags for the same reason.

**Scope of the sweep.** Every event creation site in the darwin bridge that
posts was checked; scroll was the only one that skipped the stamp. Both callers
are covered, including the per-chunk emission of a smooth-scroll animation.
