### PR TITLE
ci(linux): run the desktop test tier against headless sway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,17 @@ jobs:
                     # numbers that differ only by which build tags were active.
                     - os: macos-latest
                       check: coverage
+                    # The desktop-driving test tier, on the blessed Linux stack
+                    # of ADR 0013: sway with the wlroots headless backend. What
+                    # this leg covers and what it does not is stated in
+                    # docs/DEVELOPMENT.md, with the rest of the test tiers.
+                    - os: ubuntu-latest
+                      check: desktop
         runs-on: ${{ matrix.os }}
+        # The desktop leg is advisory, for the reason docs/DEVELOPMENT.md gives.
+        # Making it blocking is deleting this key and adding
+        # "desktop (ubuntu-latest)" to the branch protection rule.
+        continue-on-error: ${{ matrix.check == 'desktop' }}
         steps:
             # Default checkout: on pull_request events this tests the merge
             # commit (PR + main combined), which is what will actually land —
@@ -181,3 +191,252 @@ jobs:
               if: matrix.check == 'vuln' && (runner.os == 'Windows' || runner.os == 'Linux')
               run: just vuln
               shell: bash
+
+            # ---------------------------------------------------------------
+            # The headless-sway desktop leg: everything below runs only for
+            # matrix.check == 'desktop'. It stands up the session the desktop
+            # tier needs — a wlroots compositor, a session bus, and AT-SPI on
+            # it — and runs the tier against it. What that covers and what it
+            # does not is in docs/DEVELOPMENT.md.
+            # ---------------------------------------------------------------
+
+            - name: Install headless desktop session
+              if: matrix.check == 'desktop'
+              run: |
+                  sudo apt-get install -y \
+                    sway \
+                    dbus-x11 \
+                    at-spi2-core \
+                    wayland-utils
+
+            - name: Start sway, session bus and AT-SPI
+              if: matrix.check == 'desktop'
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  # A Wayland compositor puts its socket in XDG_RUNTIME_DIR and
+                  # refuses a world-readable one. The runner has neither.
+                  runtime_dir="${RUNNER_TEMP}/xdg-runtime"
+                  mkdir -p "$runtime_dir"
+                  chmod 700 "$runtime_dir"
+
+                  # A session bus first: AT-SPI's bus launcher is activated on
+                  # it, and every later step inherits the address through
+                  # GITHUB_ENV.
+                  eval "$(dbus-launch --sh-syntax)"
+
+                  cat > "${RUNNER_TEMP}/sway.conf" <<'SWAYCONF'
+                  # Xwayland is off deliberately. It would set DISPLAY, and
+                  # neru's Linux backend detection would then have an X11 answer
+                  # available on the one job whose purpose is the wlroots
+                  # Wayland stack.
+                  xwayland disable
+                  output HEADLESS-1 resolution 1920x1080 position 0 0
+                  SWAYCONF
+
+                  # WLR_RENDERER=pixman because the runner has no /dev/dri for
+                  # the GLES2 renderer to open.
+                  WLR_BACKENDS=headless \
+                  WLR_RENDERER=pixman \
+                  WLR_LIBINPUT_NO_DEVICES=1 \
+                  XDG_RUNTIME_DIR="$runtime_dir" \
+                  XDG_SESSION_TYPE=wayland \
+                  XDG_CURRENT_DESKTOP=sway \
+                  setsid sway -c "${RUNNER_TEMP}/sway.conf" -d \
+                    > "${RUNNER_TEMP}/sway.log" 2>&1 &
+
+                  socket=""
+                  for _ in $(seq 1 100); do
+                    socket=$(find "$runtime_dir" -maxdepth 1 -name 'wayland-*' \
+                      ! -name '*.lock' -print -quit)
+                    [ -n "$socket" ] && break
+                    sleep 0.2
+                  done
+                  if [ -z "$socket" ]; then
+                    echo "sway never created a Wayland socket. Its log:" >&2
+                    cat "${RUNNER_TEMP}/sway.log" >&2
+                    exit 1
+                  fi
+
+                  # The IPC socket lands alongside the Wayland one, but "lands
+                  # alongside" is an assumption rather than an ordering sway
+                  # promises, so it gets the same wait and the same diagnostic.
+                  swaysock=""
+                  for _ in $(seq 1 50); do
+                    swaysock=$(find "$runtime_dir" -maxdepth 1 \
+                      -name 'sway-ipc.*.sock' -print -quit)
+                    [ -n "$swaysock" ] && break
+                    sleep 0.2
+                  done
+                  if [ -z "$swaysock" ]; then
+                    echo "sway never created an IPC socket. Its log:" >&2
+                    cat "${RUNNER_TEMP}/sway.log" >&2
+                    exit 1
+                  fi
+
+                  # at-spi2-core ships its launcher in libexec, and the
+                  # directory moved between releases, so ask rather than assume.
+                  launcher=""
+                  for candidate in \
+                    /usr/libexec/at-spi-bus-launcher \
+                    /usr/lib/at-spi2-core/at-spi-bus-launcher \
+                    /usr/lib/at-spi2/at-spi-bus-launcher; do
+                    if [ -x "$candidate" ]; then
+                      launcher="$candidate"
+                      break
+                    fi
+                  done
+                  if [ -z "$launcher" ]; then
+                    echo "at-spi-bus-launcher not found; AT-SPI would be absent" >&2
+                    exit 1
+                  fi
+                  XDG_RUNTIME_DIR="$runtime_dir" \
+                  setsid "$launcher" --launch-immediately \
+                    > "${RUNNER_TEMP}/at-spi.log" 2>&1 &
+
+                  {
+                    echo "XDG_RUNTIME_DIR=$runtime_dir"
+                    echo "WAYLAND_DISPLAY=$(basename "$socket")"
+                    echo "SWAYSOCK=$swaysock"
+                    echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
+                    echo "XDG_SESSION_TYPE=wayland"
+                    echo "XDG_CURRENT_DESKTOP=sway"
+                  } >> "$GITHUB_ENV"
+
+            # The tier is only worth its runtime if the session really is the
+            # blessed stack, so this asserts the two globals neru's wlroots
+            # paths bind (overlay_wayland.c, wlroots_client.h), that CGO is on,
+            # and that the accessibility bus answers. A missing one fails here,
+            # where it reads as a broken environment rather than as test
+            # failures.
+            - name: Verify the session is the blessed stack
+              if: matrix.check == 'desktop'
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  swaymsg -t get_outputs
+                  wayland-info > "${RUNNER_TEMP}/wayland-info.log"
+                  for global in zwlr_layer_shell_v1 zwlr_virtual_pointer_manager_v1; do
+                    if ! grep -q "$global" "${RUNNER_TEMP}/wayland-info.log"; then
+                      echo "compositor does not advertise $global" >&2
+                      exit 1
+                    fi
+                    echo "advertised: $global"
+                  done
+
+                  # ADR 0013 blesses the CGO build; the CGO-off Linux build is a
+                  # near-total stub, and a green run of it would prove nothing.
+                  cgo=$(go env CGO_ENABLED)
+                  if [ "$cgo" != "1" ]; then
+                    echo "CGO_ENABLED=$cgo; the blessed stack is the CGO build" >&2
+                    exit 1
+                  fi
+
+                  # at-spi-bus-launcher was backgrounded a step ago and the bus
+                  # is D-Bus-activated, so the first ask can arrive early.
+                  for attempt in $(seq 1 25); do
+                    if dbus-send --session --print-reply --dest=org.a11y.Bus \
+                      /org/a11y/bus org.a11y.Bus.GetAddress; then
+                      break
+                    fi
+                    if [ "$attempt" = "25" ]; then
+                      echo "the accessibility bus never answered. Its log:" >&2
+                      cat "${RUNNER_TEMP}/at-spi.log" >&2
+                      exit 1
+                    fi
+                    sleep 0.4
+                  done
+
+            - name: Run just test-desktop
+              if: matrix.check == 'desktop'
+              shell: bash
+              timeout-minutes: 40
+              run: |
+                  set -euo pipefail
+                  just test-desktop 2>&1 | tee "${RUNNER_TEMP}/test-desktop.log"
+
+            # A skip in this tier is a claim that Linux behavior went unchecked,
+            # which is the thing the job exists to make visible — so skips and
+            # failures are counted into the job summary rather than left in
+            # 20,000 lines of -v output nobody opens.
+            - name: Report skips and failures
+              if: always() && matrix.check == 'desktop'
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  log="${RUNNER_TEMP}/test-desktop.log"
+                  if [ ! -f "$log" ]; then
+                    echo "The desktop tier never ran; see the session steps above." \
+                      >> "$GITHUB_STEP_SUMMARY"
+                    exit 0
+                  fi
+                  skips=$(grep -c -- '--- SKIP: ' "$log" || true)
+                  fails=$(grep -c -- '--- FAIL: ' "$log" || true)
+                  # A package that fails to build reports FAIL with no failing
+                  # test in it, so the per-test count alone would read as green.
+                  badpkgs=$(grep -c '^FAIL[[:space:]]' "$log" || true)
+                  {
+                    echo "### Linux desktop tier (headless sway) — advisory"
+                    echo ""
+                    echo "Advisory: this leg does not gate the merge button."
+                    echo "See docs/DEVELOPMENT.md for what it covers."
+                    echo ""
+                    echo "| | Count |"
+                    echo "| --- | --- |"
+                    echo "| \`--- FAIL:\` lines | ${fails} |"
+                    echo "| Packages reporting FAIL | ${badpkgs} |"
+                    echo "| Skipped tests | ${skips} |"
+                    echo ""
+                    if [ "$badpkgs" != "0" ]; then
+                      echo "#### Packages"
+                      echo ""
+                      echo '```'
+                      grep '^FAIL[[:space:]]' "$log"
+                      echo '```'
+                      echo ""
+                    fi
+                    if [ "$fails" != "0" ]; then
+                      echo "#### Failures"
+                      echo ""
+                      echo '```'
+                      grep -- '--- FAIL: ' "$log" | sed 's/^[[:space:]]*//'
+                      echo '```'
+                      echo ""
+                    fi
+                    if [ "$skips" != "0" ]; then
+                      echo "#### Skips, with the reason each gave"
+                      echo ""
+                      echo '```'
+                      # go test -v prints what t.Skip logged *before* the
+                      # result line, so the reason is the line already gone
+                      # past — hence the one-line lookback rather than getline.
+                      awk '
+                        /--- SKIP: /{
+                          name = $0
+                          sub(/^[[:space:]]*/, "", name)
+                          print name
+                          if (prev ~ /^[[:space:]]+[^[:space:]]+\.go:[0-9]+:/) {
+                            reason = prev
+                            sub(/^[[:space:]]*/, "", reason)
+                            print "    " reason
+                          }
+                        }
+                        { prev = $0 }
+                      ' "$log"
+                      echo '```'
+                    fi
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Upload desktop tier logs
+              if: always() && matrix.check == 'desktop'
+              uses: actions/upload-artifact@v7
+              with:
+                  name: linux-desktop-logs
+                  path: |
+                      ${{ runner.temp }}/test-desktop.log
+                      ${{ runner.temp }}/sway.log
+                      ${{ runner.temp }}/at-spi.log
+                      ${{ runner.temp }}/wayland-info.log
+                  if-no-files-found: warn
+                  retention-days: 14

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -200,6 +200,55 @@ Watch mode, if you have [entr](https://eradman.com/entrproject/):
 find . -name "*.go" | entr -r just test
 ```
 
+### What the headless-sway job covers, and what it does not
+
+CI carries one leg `just ci` has no counterpart for: **`desktop (ubuntu-latest)`**
+in `.github/workflows/ci.yml`. It starts sway on the wlroots headless backend
+with a session D-Bus and AT-SPI on it, and runs `just test-desktop` — the tier
+that drives the real cursor, keyboard and overlays, and which runs on no other
+platform in CI at all. A disposable runner is the one place that tier is safe:
+the reason it is opt-in locally is that it commandeers the machine, and there
+is no desktop here to commandeer.
+
+What it covers is the **blessed stack** of
+[ADR 0013](adr/0013-parity-is-measured-in-words-not-subsystems.md): wlroots
+Wayland with a CGO build. It asserts the session really is that stack before it
+runs anything — the compositor must advertise `zwlr_layer_shell_v1` and
+`zwlr_virtual_pointer_manager_v1`, `CGO_ENABLED` must be 1, and the
+accessibility bus must answer — so a broken environment fails as a broken
+environment rather than as a wall of test failures that look like Neru's.
+
+What it does not cover:
+
+- **Linux desktop-driving behavior, yet.** Every test that reads
+  `NERU_DESKTOP_TESTS` today is a macOS one, and Linux has a single integration
+  test at all — the fontconfig resolver. So this leg currently proves the
+  environment exists and re-runs the suite inside it; it starts paying the
+  moment a Linux `*_integration_linux_test.go` lands. That is the point of
+  building it first: a Linux desktop test written before anything can execute
+  it is a test written on faith.
+- **X11 and KDE.** Xwayland is disabled in the session on purpose, so `DISPLAY`
+  is unset and backend detection has only the Wayland answer. An Xvfb leg is
+  worth having and is deliberately second — under ADR 0013 X11 owes capability
+  parity rather than behavioral parity.
+- **Anything needing device access.** The runner has no `/dev/dri` (the
+  compositor runs the pixman renderer) and no `input` group membership, so the
+  evdev-backed paths cannot run.
+- **A verdict.** The leg is **advisory**: `continue-on-error` keeps it off the
+  merge button, and its result is a job summary counting failures, packages
+  reporting `FAIL`, and every skip with the reason it gave. It is advisory
+  because it is the first job here to stand up infrastructure of its own — a
+  compositor, a session bus and an accessibility bus — and a flake in any of
+  the three would red a pull request for a reason that has nothing to do with
+  it, on a tier whose stability nothing has measured yet.
+
+Making it blocking is two moves, and both are the maintainer's: delete
+`continue-on-error` from the job, and add `desktop (ubuntu-latest)` to the
+branch protection rule — a repository setting, not a file in this tree. ADR 0013
+makes that flip part of Linux graduating from Beta to Stable, alongside the
+Linux entries in
+[Known Gaps](CROSS_PLATFORM.md#known-gaps) being empty.
+
 ---
 
 ## Building
@@ -293,7 +342,9 @@ Until there is a recipe, run them the way the container recipe does and add the
 tag — `docker run --rm -v "$PWD":/src -w /src -e CGO_ENABLED=1 neru-linux-ci go
 test -tags=integration ./...` — on an image with fonts and `fc-list` installed
 (`fontconfig fonts-dejavu-core`). CI covers them on `ubuntu-latest`, where
-`just test-ci` runs the integration suite natively.
+`just test-ci` runs the integration suite natively, and again on the
+headless-sway leg, which runs `just test-desktop` inside a real wlroots session
+— see [What the headless-sway job covers](#what-the-headless-sway-job-covers-and-what-it-does-not).
 
 ### Running integration tests
 


### PR DESCRIPTION
## Description

This PR adds a CI job that runs Neru's desktop-driving test tier against a real
Linux desktop session — sway on the wlroots headless backend, with a session
D-Bus and AT-SPI on it. That tier (`just test-desktop`) previously ran on no
platform in CI at all, and the Linux runner had no display server, so every
Linux test that would touch one skipped silently. Linux behaviour was
unobservable to the project, which is how a config option could reach the
schema, the validators and the docs without a single Linux code path reading
it.

The job asserts the session really is the blessed stack of ADR 0013 before it
runs anything — the compositor must advertise `zwlr_layer_shell_v1` and
`zwlr_virtual_pointer_manager_v1`, `CGO_ENABLED` must be 1, and the
accessibility bus must answer — so a broken environment fails as a broken
environment rather than as a wall of test failures that look like Neru's. Skips
and failures are counted into the job summary, each skip with the reason it
gave, and the full logs are uploaded as an artifact.

The deliberate limitation: the job is **advisory**, not required for merge. It
is the first job here to stand up infrastructure of its own, and a flake in the
compositor, the bus or the a11y bus would red a pull request for a reason that
has nothing to do with it. Making it blocking is a maintainer action in two
parts — delete `continue-on-error` from the job, and add
`desktop (ubuntu-latest)` to the branch protection rule, which is a repository
setting rather than a file in this tree.

## Related Issues

Closes #1452
Part of #1466

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no Go source changes
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no Go source changes
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or adapter changes
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality — N/A, this enables an existing test tier rather than adding tests
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

**It was verified before landing, not on faith.** The session bootstrap and the
tier were run inside an Ubuntu 24.04 container with sway headless, using the
step bodies extracted verbatim from the workflow: the compositor came up, both
wlroots globals were advertised, the accessibility bus answered, and the tier
reported **4108 passed, 0 failed, 3 skipped**. The three skips are all
legitimate platform skips — a Windows-only log-path test, a CGO-off-only stub
test, and a macOS-only AX role listing — and the job summary now prints each
with the reason it gave. So the issue's expectation of "failures rather than a
green run" did not materialise, and there is nothing to link to a parity issue
yet.

**Which is worth being precise about, because it bounds what this job proves
today.** Every test that reads `NERU_DESKTOP_TESTS` is a macOS one, and Linux
has a single integration test in the whole tree — the fontconfig resolver. So
the leg currently proves the environment exists and re-runs the suite inside
it. It starts paying the moment a Linux desktop-driving test lands, which is
exactly why it goes first: such a test written before anything can execute it
would be a test written on faith. `docs/DEVELOPMENT.md` says this plainly
rather than overselling the coverage.

**Deliberate scoping.** X11 is out — Xwayland is disabled in the session on
purpose so `DISPLAY` stays unset and backend detection has only the Wayland
answer. Under ADR 0013 X11 owes capability parity rather than behavioural
parity, so an Xvfb leg is a separate, later piece of work.

**Why the existing matrix rather than a separate job.** The desktop leg reuses
the `checks` job's checkout, the Linux system-dependency install, the Go setup
and the `just` install. A standalone job would need none of the six
`if: matrix.check == 'desktop'` guards, but would duplicate the eleven-package
apt list — a maintained list going out of sync is a worse failure than a
repeated conditional.
