### PR TITLE
feat(linux): show notifications and alerts through freedesktop D-Bus

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -65,7 +65,7 @@ reference implementation, and a gap on this platform is a bug.
 
 **Beta** — good for daily driving. Every navigation mode works and behaves the
 same as it does on a stable platform; what is missing sits around the edges
-(notifications, alerts, a few animations) rather than in your way.
+(a few animations, the OCR hint strategy) rather than in your way.
 
 **Alpha** — worth trying, not yet worth switching to. Core navigation works, but
 hint coverage is incomplete and per-app config does not re-apply on focus
@@ -157,8 +157,8 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Dark mode detection**       | ✅ Cocoa appearance      | ✅ xdg appearance portal | ✅ xdg appearance portal   | ✅ kdeglobals + portal  | ✅ registry                  |
 | **Font resolution**           | ✅ NSFont                | ✅ fontconfig          | ✅ fontconfig                | ✅ fontconfig           | ⚠️ generic-alias map only ²  |
 | **System tray**               | ✅ NSStatusItem          | ✅ D-Bus StatusNotifierItem | ✅ StatusNotifierItem        | ✅ StatusNotifierItem   | ✅ Win32 notification area   |
-| **Native alerts**             | ✅ NSAlert               | 🟡                     | 🟡                           | 🟡                      | ✅ `MessageBoxW`             |
-| **Native notifications**      | ✅ UNNotification        | 🟡                     | 🟡                           | 🟡                      | 🟡                           |
+| **Native alerts**             | ✅ NSAlert               | ⚠️ D-Bus, not modal    | ⚠️ D-Bus, not modal          | ⚠️ D-Bus, not modal     | ✅ `MessageBoxW`             |
+| **Native notifications**      | ✅ UNNotification        | ✅ `org.freedesktop.Notifications` | ✅ `org.freedesktop.Notifications` | ✅ `org.freedesktop.Notifications` | 🟡          |
 | **Secure input detection**    | ✅                       | ➖ always false        | ➖ always false              | ➖ always false         | ➖ always false              |
 | **System cursor hide**        | ✅ `CGDisplayHideCursor` | ➖                     | ➖                           | ➖                      | ➖                           |
 | **`monitor_select` mode**     | ✅ native panels         | ✅ Cairo panels        | ✅ Cairo panels              | ✅ Cairo panels         | 🟡 `CodeNotSupported`        |
@@ -249,6 +249,22 @@ points at the build, and is warned about once, since no retry changes how the
 binary was compiled. Both name the same fallback — bind `neru <mode>` as a
 compositor keybinding. While a mode is active the in-mode event tap grabs the
 same devices, so the listener naturally goes quiet until the mode exits.
+
+**Native alerts on Linux.** Notifications and alerts both go to the session's
+freedesktop notification daemon over D-Bus — the same session bus the tray's
+StatusNotifierItem uses, in pure Go, so a `CGO_ENABLED=0` build shows them too.
+An alert differs from a notification only in insistence: critical urgency and no
+expiry, which the specification requires a daemon to leave on screen until it is
+dismissed. What it is *not* is modal. macOS's `NSAlert` stops the world and
+returns which button was pressed; no ordinary Wayland or X11 client can do that,
+so a Linux alert informs rather than asks, and callers that would have branched
+on the answer take the safe default. The two startup alerts are where that shows
+up: a missing config file starts Neru on built-in defaults and says so, instead
+of offering create / defaults / quit. Delivery depends on a notification daemon
+running (mako, dunst, or the desktop's own); with none, `ShowNotification` and
+`ShowAlert` report `CodeNotSupported` naming what is absent, `neru doctor`
+probes the session and downgrades the notifications row with a line saying what
+to install, and the two startup alerts fall back to stderr.
 
 **Smooth cursor animation on Linux.** Off by default; opt in with
 `smooth_cursor.move_mouse_enabled` (the same cross-platform `SmoothCursorConfig`
@@ -751,49 +767,45 @@ command — that means less here than it does on macOS, whether or not the
 
 **Linux**
 
-1. Native notifications and alerts — both stubs; target freedesktop D-Bus
-   notifications. `ShowNotification` has an empty body and no error to carry,
-   `ShowAlert` returns `CodeNotSupported`, and the config-onboarding and
-   validation-error alerts silently return defaults instead of prompting
-2. `neru services` — no systemd user unit, so install/uninstall/start/stop/
+1. `neru services` — no systemd user unit, so install/uninstall/start/stop/
    restart/status all return `CodeNotSupported` where macOS writes a launchd
    plist. Scope is systemd; other init systems stay `CodeNotSupported`
-3. `neru docs` — returns `CodeNotSupported` although the tray already opens
+2. `neru docs` — returns `CodeNotSupported` although the tray already opens
    URLs through `xdg-open` in the same repo
-4. Smooth scroll animation — not implemented, and `smooth_scroll.*` is parsed,
+3. Smooth scroll animation — not implemented, and `smooth_scroll.*` is parsed,
    validated and then silently ignored. Spike `REL_WHEEL_HI_RES` (uinput),
    continuous `wl_pointer` axis values and libei scroll deltas before
    committing
-5. Hints search input badge — not drawn; the overlay manager reports
+4. Hints search input badge — not drawn; the overlay manager reports
    `CodeNotSupported` and the query goes on reaching hints through the event
    tap's key stream
-6. Screen capture — no code path anywhere in the tree. Prerequisite for the OCR
+5. Screen capture — no code path anywhere in the tree. Prerequisite for the OCR
    strategy below and the missing half of `ports.Vision`. Take it per backend:
    `wlr-screencopy` on wlroots, `XGetImage` on X11, the portal only for KDE
-7. `vision` hint strategy — no engine. Met by linking one through
+6. `vision` hint strategy — no engine. Met by linking one through
    `#cgo pkg-config`, as every other native dependency here is, with the engine
    added to the required Linux library list and its language data checked at
    use so a missing `tessdata` reports `CodeNotSupported` naming what is
    absent. Note the strategy is wider than OCR: macOS also runs rectangle
    detection and saliency, which no OCR engine answers, so
    `hints.vision.detect_rectangles` and the four `rectangle_*` options are
-   declared macOS-only and Linux `vision` is text-only. Needs 6
-8. X11 unmodified scroll — a scroll with no `--modifier` presses nothing, so the
+   declared macOS-only and Linux `vision` is text-only. Needs 5
+7. X11 unmodified scroll — a scroll with no `--modifier` presses nothing, so the
    `XTestFakeButtonEvent` still carries whatever the X server records the user as
    physically holding. Binding `Ctrl+J` to a plain `scroll_down` therefore sends
    ctrl+scroll for as long as ctrl is down. macOS forces the empty set onto the
    event instead; a real-key backend has no per-event field to zero, so closing
    this means reading the live key state through `XQueryKeymap` in the C bridge
-9. KDE RemoteDesktop portal grant — does not survive a daemon restart, so the
+8. KDE RemoteDesktop portal grant — does not survive a daemon restart, so the
    consent prompt returns on every start
-10. Grid virtual-pointer indicator — a no-op on Linux, while recursive grid
-    draws it on all three platforms
-11. `FocusedWindowBounds` — returns not-found on KWin, so callers silently fall
+9. Grid virtual-pointer indicator — a no-op on Linux, while recursive grid
+   draws it on all three platforms
+10. `FocusedWindowBounds` — returns not-found on KWin, so callers silently fall
     back to the active screen
-12. Wayland global hotkeys — a setup requirement rather than missing code: they
+11. Wayland global hotkeys — a setup requirement rather than missing code: they
     need `input`-group membership and a CGO build. Failing loudly with the
     remedy, and documenting it as a first-class setup step, is the work
-13. Tail — the tray tooltip is a no-op (dbusmenu carries no such property), the
+12. Tail — the tray tooltip is a no-op (dbusmenu carries no such property), the
     tray has one icon for both running and paused states where macOS has two,
     and the `CGO_ENABLED=0` build should announce its boundary once at startup
     rather than failing feature by feature

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -260,9 +260,11 @@ returns which button was pressed; no ordinary Wayland or X11 client can do that,
 so a Linux alert informs rather than asks, and callers that would have branched
 on the answer take the safe default. The two startup alerts are where that shows
 up: a missing config file starts Neru on built-in defaults and says so, instead
-of offering create / defaults / quit. Delivery depends on a notification daemon
-running (mako, dunst, or the desktop's own); with none, `ShowNotification` and
-`ShowAlert` report `CodeNotSupported` naming what is absent, `neru doctor`
+of offering create / defaults / quit. Delivery depends on the session having a
+notification daemon (mako, dunst, or the desktop's own) — either running, or
+registered with the bus to be started on demand, which is how most desktops ship
+theirs and which `neru doctor` counts as present. With none, `ShowNotification`
+and `ShowAlert` report `CodeNotSupported` naming what is absent, `neru doctor`
 probes the session and downgrades the notifications row with a line saying what
 to install, and the two startup alerts fall back to stderr.
 

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -313,8 +313,9 @@ systemctl --user enable --now neru
    fallbacks where the portal is unavailable.
 4. **Notifications** — Delivered over `org.freedesktop.Notifications` on the
    session bus, so a notification daemon (mako, dunst, or your desktop's own)
-   has to be running. What Neru does when none is, and why an alert is not
-   modal here: "Native alerts on Linux" under the
+   has to be running — or installed as a D-Bus service the bus starts on
+   demand, as most desktops ship theirs. What Neru does when neither, and why
+   an alert is not modal here: "Native alerts on Linux" under the
    [Capability Matrix](./CROSS_PLATFORM.md#capability-matrix).
 5. **Wayland modified clicks** — Need `evdev` access (see [keyboard permissions](#wayland-keyboard-capture-permissions)).
 6. **Monitor hotplug** — Adding/removing a monitor is tracked live (RandR on X11,

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -311,7 +311,11 @@ systemctl --user enable --now neru
    by app. DE-specific coordinate details: [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md).
 3. **Dark mode** — Via `org.freedesktop.appearance` portal, with session-specific
    fallbacks where the portal is unavailable.
-4. **Notifications** — May log instead of using `org.freedesktop.Notifications`.
+4. **Notifications** — Delivered over `org.freedesktop.Notifications` on the
+   session bus, so a notification daemon (mako, dunst, or your desktop's own)
+   has to be running. What Neru does when none is, and why an alert is not
+   modal here: "Native alerts on Linux" under the
+   [Capability Matrix](./CROSS_PLATFORM.md#capability-matrix).
 5. **Wayland modified clicks** — Need `evdev` access (see [keyboard permissions](#wayland-keyboard-capture-permissions)).
 6. **Monitor hotplug** — Adding/removing a monitor is tracked live (RandR on X11,
    `wl_output` on Wayland) and the overlay follows; a relaunch is only needed for a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -40,7 +40,7 @@ wlroots Wayland with a CGO build, with a closed set of macOS-only exemptions.
 
 The two largest open areas:
 
-- **Linux** — freedesktop notifications and alerts across all backends, and
+- **Linux** — screen capture and the OCR hint strategy it unblocks, and
   persisting the KDE RemoteDesktop portal grant across daemon restarts.
 - **Windows** — foreground-window and display-hotplug events, which currently
   block per-app config re-application and monitor tracking.

--- a/internal/adapter/platform/darwin/system.go
+++ b/internal/adapter/platform/darwin/system.go
@@ -188,8 +188,14 @@ func (s *SystemAdapter) ShowAlert(ctx context.Context, title, message string) er
 }
 
 // ShowNotification displays a lightweight toast/banner notification on macOS.
-func (s *SystemAdapter) ShowNotification(title, message string) {
+//
+// The UserNotifications path is fire-and-forget, so this returns as soon as
+// the request is handed to the notification center; there is no failure to
+// report at this point and it always reports success.
+func (s *SystemAdapter) ShowNotification(_ context.Context, title, message string) error {
 	ShowNotification(title, message)
+
+	return nil
 }
 
 // CheckScreenCapturePermission reports whether macOS screen recording is

--- a/internal/adapter/platform/factory_linux.go
+++ b/internal/adapter/platform/factory_linux.go
@@ -3,6 +3,10 @@
 package platform
 
 import (
+	"context"
+	"fmt"
+	"os"
+
 	"github.com/y3owk1n/neru/internal/adapter/platform/linux"
 	"github.com/y3owk1n/neru/internal/ports"
 )
@@ -25,13 +29,49 @@ func NewFontResolver() ports.FontResolver {
 	return linux.NewFontResolver()
 }
 
-// ShowConfigOnboardingAlert is a stub on Linux.
-func ShowConfigOnboardingAlert(_ string) int {
+// ShowConfigOnboardingAlert tells a first-time user that Neru started on
+// built-in defaults, and how to get a config file, then answers with that
+// choice.
+//
+// macOS asks the question in a modal NSAlert and waits — create, use defaults,
+// or quit. Linux answers it instead of asking, deliberately. A modal dialog
+// here needs a toolkit Neru does not link or a helper (zenity, kdialog) a
+// minimal wlroots session need not have, so the honest choices were a prompt
+// that may never appear or a message plus a safe default. Blocking startup on
+// a dialog nobody can see is worse than starting; a keyboard-driven tool whose
+// first act is to seize the session for a question is worse still. So the
+// question is answered the way the user could only have answered it after
+// being asked — run, on defaults, changing nothing on disk — and they are told
+// what happened and what to type.
+func ShowConfigOnboardingAlert(configPath string) int {
+	title := "Neru is running on built-in defaults"
+	message := "No configuration file at " + configPath +
+		". Run `neru config init` to create one."
+
+	// Bounded by the adapter's own notify deadline; these run before the daemon
+	// is up, so a wedged session bus costs a moment rather than the launch.
+	err := linux.ShowAlert(context.Background(), title, message)
+	if err != nil {
+		// Onboarding has no other channel: nothing upstream prints this, so a
+		// session with no notification daemon would otherwise learn nothing.
+		fmt.Fprintf(os.Stderr, "⚠️  %s.\n%s\n\n", title, message)
+	}
+
 	return ConfigOnboardingDefaults
 }
 
-// ShowConfigValidationErrorAlert is a stub on Linux.
-func ShowConfigValidationErrorAlert(_, _ string) int {
+// ShowConfigValidationErrorAlert puts a rejected configuration in front of the
+// user before Neru exits, then answers as the dismissed macOS dialog does.
+//
+// It is a notification rather than a dialog for the reasons above; the alert
+// shape it uses stays on screen until dismissed, so a message that arrives
+// while the user is looking elsewhere is still there when they look back.
+func ShowConfigValidationErrorAlert(errorMessage, configPath string) int {
+	// The launcher has already written the same failure to stderr, so a
+	// missing notification daemon costs the desktop copy rather than the
+	// message — nothing to fall back to here.
+	_ = linux.ShowAlert(context.Background(), "Neru could not load "+configPath, errorMessage)
+
 	return ConfigValidationOK
 }
 

--- a/internal/adapter/platform/linux/system_common.go
+++ b/internal/adapter/platform/linux/system_common.go
@@ -6,6 +6,7 @@ package linux
 import (
 	"bufio"
 	"context"
+	"errors"
 	"image"
 	"io"
 	"os"
@@ -83,6 +84,12 @@ func (s *SystemAdapter) Capabilities() ports.PlatformCapabilities {
 
 	value, source, ok := darkModePreference()
 	capabilities.DarkModeDetection = darkModeCapability(value, source, ok)
+
+	// Notifications are live-probed for the same reason dark mode is: the code
+	// path exists on every backend, but whether the user will see anything
+	// depends on a notification daemon being installed, which is a session fact
+	// rather than a build one.
+	capabilities.Notifications = s.notificationCapability(capabilities.Notifications)
 
 	// Screen, cursor and process support is what this binary and session can
 	// actually reach, not what the build target intends — the static preset is
@@ -491,15 +498,20 @@ func (s *SystemAdapter) IsSecureInputEnabled() bool {
 // ShowSecureInputNotification is a no-op on Linux — secure input is a macOS-only concept.
 func (s *SystemAdapter) ShowSecureInputNotification() {}
 
-// ShowAlert displays a native system alert on Linux.
-// TODO(linux): implement using libnotify, zenity, or kdialog.
+// ShowAlert displays a message the user has to dismiss, through the session's
+// freedesktop notification daemon. Delivery does not depend on the display
+// server, so every Linux backend takes the same path; see alertNotification
+// for why this is a critical-urgency notification rather than a modal dialog.
 func (s *SystemAdapter) ShowAlert(ctx context.Context, title, message string) error {
-	return derrors.New(derrors.CodeNotSupported, "ShowAlert not yet implemented on linux")
+	return ShowAlert(ctx, title, message)
 }
 
-// ShowNotification displays a lightweight notification on Linux.
-// TODO(linux): implement using org.freedesktop.Notifications D-Bus interface.
-func (s *SystemAdapter) ShowNotification(title, message string) {}
+// ShowNotification displays a lightweight notification through the session's
+// freedesktop notification daemon, reporting CodeNotSupported when the session
+// has no bus or no daemon to show it rather than dropping the message.
+func (s *SystemAdapter) ShowNotification(ctx context.Context, title, message string) error {
+	return ShowNotification(ctx, title, message)
+}
 
 // CheckScreenCapturePermission reports true: Linux does not gate screen capture
 // behind a permission.
@@ -551,6 +563,67 @@ func (s *SystemAdapter) probedCapability(
 	default:
 		return declared
 	}
+}
+
+// notificationFeature names the notification probe's slot in capabilityProbes,
+// and opens the detail it reports.
+const notificationFeature = "desktop notifications"
+
+// notificationCapability live-probes whether a notification daemon is
+// reachable right now. The question a user runs `neru doctor` to answer is
+// "will I see notifications?", and on Linux that is answered by the session
+// rather than by this code: every backend can send one, and a session with no
+// daemon shows none. Reporting the static "supported" there would be the same
+// lie the empty ShowNotification body used to tell.
+//
+// It shares the probe slots and the budget with probedCapability but not its
+// body: that one explains a failure in terms of the display-server backend,
+// which decides nothing here — notifications are a session-bus service every
+// backend reaches the same way. The budget has to be the full one because the
+// first probe of a daemon's life pays for the session-bus connect as well as
+// the question, and reporting "could not be confirmed" on a session where
+// notifications work is the same dishonesty in the other direction.
+func (s *SystemAdapter) notificationCapability(
+	declared ports.FeatureCapability,
+) ports.FeatureCapability {
+	completed, err := s.probes.run(
+		notificationFeature,
+		capabilityProbeTimeout,
+		func() error {
+			ctx, cancel := context.WithTimeout(context.Background(), capabilityProbeTimeout)
+			defer cancel()
+
+			return sessionNotifier.daemonReachable(ctx)
+		},
+	)
+
+	switch {
+	case !completed:
+		return ports.FeatureCapability{
+			Status: ports.FeatureStatusStub,
+			Detail: notificationFeature + " could not be confirmed: the session bus did not " +
+				"answer within " + capabilityProbeTimeout.String(),
+		}
+	case err != nil:
+		return ports.FeatureCapability{
+			Status: ports.FeatureStatusStub,
+			Detail: notificationFeature + " are unavailable: " + userFacingReason(err),
+		}
+	default:
+		return declared
+	}
+}
+
+// userFacingReason unwraps a domain error to the sentence written for the
+// user, leaving the "[CODE] …" prefix out of a capability detail that `neru
+// doctor` prints verbatim.
+func userFacingReason(err error) string {
+	var domainErr *derrors.Error
+	if errors.As(err, &domainErr) {
+		return domainErr.Message()
+	}
+
+	return err.Error()
 }
 
 // unavailableDetail explains why a probed capability is unavailable, in terms

--- a/internal/adapter/platform/linux/system_notifications.go
+++ b/internal/adapter/platform/linux/system_notifications.go
@@ -132,14 +132,24 @@ type notifier struct {
 	connect func() (*dbus.Conn, error)
 
 	mu sync.Mutex
-	// conn is the connection a completed dial produced, kept so the ordinary
-	// path after the first notification dials nothing.
+	// conn is the connection the last dial produced, kept so the ordinary path
+	// after the first notification dials nothing. A dial that fails clears it,
+	// so no caller is ever handed a connection that is known to be gone.
 	conn *dbus.Conn
-	// dialErr is what the last completed dial reported.
-	dialErr error
-	// dialDone is non-nil while a dial is in flight, and is closed when it
-	// finishes. Callers wait on it rather than starting a second dial.
-	dialDone chan struct{}
+	// dialing is the dial in flight, and nil when none is. Callers wait on it
+	// rather than starting a second dial.
+	dialing *dialAttempt
+}
+
+// dialAttempt is one attempt to reach the session bus and the outcome every
+// caller that waited on it reads. conn and err are written once, before done is
+// closed, and read only after it closes — that close is what publishes them, so
+// a caller sees the result of the dial it actually waited on rather than
+// whatever the notifier's fields hold by the time it is scheduled.
+type dialAttempt struct {
+	done chan struct{}
+	conn *dbus.Conn
+	err  error
 }
 
 // sessionNotifier is the process-wide notifier. dbus.SessionBus hands back one
@@ -265,6 +275,11 @@ func daemonReachableFrom(owned bool, activatable []string) bool {
 // notification and a `neru doctor` probe from spoiling each other. A
 // connection that succeeds is kept, so the ordinary path after the first
 // notification dials nothing at all.
+//
+// A dial that fails is reported as a failure even when a connection was cached
+// before it: the cached one had already disconnected — that is what started
+// this dial — so handing it back would have the caller talk into a dead
+// transport and report the daemon rejecting a message that never left.
 func (n *notifier) session(ctx context.Context) (*dbus.Conn, error) {
 	n.mu.Lock()
 
@@ -275,53 +290,55 @@ func (n *notifier) session(ctx context.Context) (*dbus.Conn, error) {
 		return conn, nil
 	}
 
-	if n.dialDone == nil {
-		n.dialDone = make(chan struct{})
-		go n.dial(n.dialDone)
+	attempt := n.dialing
+	if attempt == nil {
+		attempt = &dialAttempt{done: make(chan struct{})}
+		n.dialing = attempt
+
+		go n.dial(attempt)
 	}
 
-	dialed := n.dialDone
 	n.mu.Unlock()
 
 	select {
-	case <-dialed:
+	case <-attempt.done:
 	case <-ctx.Done():
 		return nil, derrors.Wrap(ctx.Err(), derrors.CodeTimeout, dialTimedOutDetail)
 	}
 
-	n.mu.Lock()
-	conn, err := n.conn, n.dialErr
-	n.mu.Unlock()
-
-	if conn != nil {
-		return conn, nil
+	if attempt.err != nil {
+		return nil, derrors.Wrap(attempt.err, derrors.CodeNotSupported, noSessionBusDetail)
 	}
 
-	if err != nil {
-		return nil, derrors.Wrap(err, derrors.CodeNotSupported, noSessionBusDetail)
+	if attempt.conn == nil {
+		return nil, derrors.New(derrors.CodeNotSupported, noSessionBusDetail)
 	}
 
-	return nil, derrors.New(derrors.CodeNotSupported, noSessionBusDetail)
+	return attempt.conn, nil
 }
 
 // dial performs the one uncancellable connect and publishes its outcome by
-// closing done. It clears the in-flight marker first, so the next caller after
-// a failed dial retries rather than reading a stale answer forever.
-func (n *notifier) dial(done chan struct{}) {
+// closing the attempt's done channel. It clears the in-flight marker, so the
+// next caller after a failed dial retries rather than reading a stale answer
+// forever, and replaces the cached connection with whatever this dial produced
+// — nothing, when it failed, since the connection it was replacing is gone.
+func (n *notifier) dial(attempt *dialAttempt) {
 	conn, err := n.connect()
+
+	attempt.conn, attempt.err = conn, err
 
 	n.mu.Lock()
 
-	n.dialErr = err
-	n.dialDone = nil
-
+	n.conn = nil
 	if err == nil {
 		n.conn = conn
 	}
 
+	n.dialing = nil
+
 	n.mu.Unlock()
 
-	close(done)
+	close(attempt.done)
 }
 
 // withNotifyDeadline bounds the round trip. A caller's own deadline wins — it
@@ -343,6 +360,14 @@ func withNotifyDeadline(ctx context.Context) (context.Context, context.CancelFun
 func notifyError(err error) error {
 	if isMissingDaemon(err) {
 		return derrors.Wrap(err, derrors.CodeNotSupported, noDaemonDetail)
+	}
+
+	// The connection went away between the check that it was live and this
+	// call. That is the session bus being gone, not a daemon refusing anything,
+	// and saying so is what sends the user to the right place; the next call
+	// redials, because the cached connection no longer reports itself connected.
+	if errors.Is(err, dbus.ErrClosed) {
+		return derrors.Wrap(err, derrors.CodeNotSupported, noSessionBusDetail)
 	}
 
 	if errors.Is(err, context.DeadlineExceeded) {

--- a/internal/adapter/platform/linux/system_notifications.go
+++ b/internal/adapter/platform/linux/system_notifications.go
@@ -1,0 +1,348 @@
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// Desktop notifications and alerts for every Linux backend.
+//
+// Notifications are a session-bus service rather than a display-server
+// capability, so one implementation serves X11, wlroots and KDE alike — over
+// the same session bus the tray's StatusNotifierItem already speaks. None of
+// it is cgo, so the CGO_ENABLED=0 build shows notifications too and there is
+// no _nocgo twin to keep in step.
+//
+// A session with no notification daemon is an ordinary state on a minimal
+// wlroots setup, so every path here says why it could not deliver rather than
+// returning nil: a caller that cannot tell "shown" from "dropped" has nothing
+// to fall back to.
+const (
+	// notifyBusName is the well-known name a notification daemon owns.
+	notifyBusName = "org.freedesktop.Notifications"
+	// notifyObjectPath is the object every such daemon exports.
+	notifyObjectPath = dbus.ObjectPath("/org/freedesktop/Notifications")
+	// notifyMethod is the spec's single delivery method.
+	notifyMethod = "org.freedesktop.Notifications.Notify"
+	// notifyAppName is the application name daemons group our messages under.
+	notifyAppName = "Neru"
+	// nameHasOwnerMethod answers whether anything owns a well-known name.
+	nameHasOwnerMethod = "org.freedesktop.DBus.NameHasOwner"
+	// serviceUnknownError and nameHasNoOwnerError are the two bus errors that
+	// mean "nobody is listening" rather than "the daemon refused this".
+	serviceUnknownError = "org.freedesktop.DBus.Error.ServiceUnknown"
+	nameHasNoOwnerError = "org.freedesktop.DBus.Error.NameHasNoOwner"
+	// urgencyHint is the hint key carrying the urgency level.
+	urgencyHint = "urgency"
+	// noNotificationIcon leaves app_icon empty: Neru installs no icon under a
+	// name every icon theme has, and daemons substitute their own.
+	noNotificationIcon = ""
+	// noCallFlags sends a plain method call — a reply is what makes the
+	// failure observable, so NO_REPLY_EXPECTED is exactly what must not be set.
+	noCallFlags = 0
+)
+
+// Urgency levels from the freedesktop Desktop Notification Specification.
+const (
+	urgencyNormal   byte = 1
+	urgencyCritical byte = 2
+)
+
+// Expiry timeouts in milliseconds, from the same specification: -1 leaves the
+// choice to the daemon, 0 keeps the notification up until it is dismissed.
+const (
+	expireDaemonChoice int32 = -1
+	expireNever        int32 = 0
+)
+
+// replacesNothing is the replaces_id that asks for a new notification instead
+// of an update to an earlier one. Neru keeps no notification ids, so nothing
+// it sends supersedes anything it sent before.
+const replacesNothing uint32 = 0
+
+// notifyTimeout caps one round trip when the caller's context carries no
+// deadline of its own. A daemon being D-Bus activated may take a moment; one
+// that will never answer must not hold the caller, which is the tray's menu
+// loop or the startup path.
+const notifyTimeout = 2 * time.Second
+
+// The two reasons delivery fails that a user can act on, phrased for them:
+// nothing to talk to, or nobody listening.
+const (
+	noSessionBusDetail = "no reachable D-Bus session bus on this linux session, so " +
+		notifyBusName + " cannot be asked to show anything"
+	noDaemonDetail = "no notification daemon is running on this linux session; nothing owns " +
+		notifyBusName + " — start one (mako, dunst, or the desktop's own)"
+	dialTimedOutDetail = "the D-Bus session bus on this linux session did not accept a " +
+		"connection in time"
+)
+
+// notification is one desktop notification as this adapter sends it: what the
+// user reads, how insistently, and for how long.
+type notification struct {
+	summary string
+	body    string
+	urgency byte
+	expire  int32
+}
+
+// toastNotification is the lightweight shape ShowNotification sends: normal
+// urgency, and the daemon's own idea of how long to leave it up.
+func toastNotification(title, message string) notification {
+	return notification{
+		summary: title,
+		body:    message,
+		urgency: urgencyNormal,
+		expire:  expireDaemonChoice,
+	}
+}
+
+// alertNotification is the shape ShowAlert sends. macOS takes the session over
+// with a modal NSAlert; no ordinary Wayland or X11 client can do that, so the
+// nearest honest equivalent is a critical-urgency notification that stays on
+// screen until it is dismissed — the one urgency the specification requires a
+// daemon not to expire on its own.
+func alertNotification(title, message string) notification {
+	return notification{
+		summary: title,
+		body:    message,
+		urgency: urgencyCritical,
+		expire:  expireNever,
+	}
+}
+
+// notifier delivers notifications over the session bus. The connector is a
+// field rather than a direct dbus.SessionBus call so the no-bus and no-daemon
+// paths stay testable on a machine that has both.
+type notifier struct {
+	connect func() (*dbus.Conn, error)
+
+	mu sync.Mutex
+	// conn is the connection a completed dial produced, kept so the ordinary
+	// path after the first notification dials nothing.
+	conn *dbus.Conn
+	// dialErr is what the last completed dial reported.
+	dialErr error
+	// dialDone is non-nil while a dial is in flight, and is closed when it
+	// finishes. Callers wait on it rather than starting a second dial.
+	dialDone chan struct{}
+}
+
+// sessionNotifier is the process-wide notifier. dbus.SessionBus hands back one
+// shared connection per process, so this reuses the session bus the tray also
+// dials rather than opening a second one.
+var sessionNotifier = &notifier{connect: dbus.SessionBus}
+
+// ShowNotification shows a lightweight desktop notification through the
+// session's notification daemon, reporting CodeNotSupported when there is no
+// session bus or no daemon to show it.
+func ShowNotification(ctx context.Context, title, message string) error {
+	return sessionNotifier.send(ctx, toastNotification(title, message))
+}
+
+// ShowAlert shows a message that stays on screen until the user dismisses it,
+// reporting CodeNotSupported when there is no session bus or no daemon to show
+// it. See alertNotification for why this is not a modal dialog.
+func ShowAlert(ctx context.Context, title, message string) error {
+	return sessionNotifier.send(ctx, alertNotification(title, message))
+}
+
+// send delivers one notification, mapping every failure to a code a caller can
+// branch on. It never reports success it did not observe: the call waits for
+// the daemon's reply rather than firing it off with NO_REPLY_EXPECTED, which
+// is the whole difference between this and the empty body it replaces.
+func (n *notifier) send(ctx context.Context, note notification) error {
+	callCtx, cancel := withNotifyDeadline(ctx)
+	defer cancel()
+
+	conn, err := n.session(callCtx)
+	if err != nil {
+		return err
+	}
+
+	call := conn.Object(notifyBusName, notifyObjectPath).CallWithContext(
+		callCtx,
+		notifyMethod,
+		noCallFlags,
+		notifyAppName,
+		replacesNothing,
+		noNotificationIcon,
+		note.summary,
+		note.body,
+		[]string{},
+		map[string]dbus.Variant{urgencyHint: dbus.MakeVariant(note.urgency)},
+		note.expire,
+	)
+	if call.Err != nil {
+		return notifyError(call.Err)
+	}
+
+	return nil
+}
+
+// daemonReachable reports nil when a notification daemon currently owns the
+// notification name, and why not otherwise. It asks the bus daemon rather than
+// sending a notification, so `neru doctor` can answer "will I see
+// notifications?" without putting one on screen.
+func (n *notifier) daemonReachable(ctx context.Context) error {
+	callCtx, cancel := withNotifyDeadline(ctx)
+	defer cancel()
+
+	conn, err := n.session(callCtx)
+	if err != nil {
+		return err
+	}
+
+	var owned bool
+
+	err = conn.BusObject().
+		CallWithContext(callCtx, nameHasOwnerMethod, noCallFlags, notifyBusName).
+		Store(&owned)
+	if err != nil {
+		return notifyError(err)
+	}
+
+	if !owned {
+		return derrors.New(derrors.CodeNotSupported, noDaemonDetail)
+	}
+
+	return nil
+}
+
+// session returns a live session-bus connection, bounded by ctx.
+//
+// The dial has to be bounded separately from the call because dbus.SessionBus
+// takes no context: the connect, the auth handshake and the Hello round trip
+// are all uncancellable, so a bus that accepts a connection and then stops
+// answering blocks the caller forever. It therefore runs on a goroutine the
+// caller can abandon, bounded by each caller's own deadline rather than by the
+// dial. One dial exists at a time — godbus serializes them on its own lock, so
+// a second could do nothing but wait behind the first — and later callers
+// share its outcome instead of being turned away, which is what keeps a tray
+// notification and a `neru doctor` probe from spoiling each other. A
+// connection that succeeds is kept, so the ordinary path after the first
+// notification dials nothing at all.
+func (n *notifier) session(ctx context.Context) (*dbus.Conn, error) {
+	n.mu.Lock()
+
+	if n.conn != nil && n.conn.Connected() {
+		conn := n.conn
+		n.mu.Unlock()
+
+		return conn, nil
+	}
+
+	if n.dialDone == nil {
+		n.dialDone = make(chan struct{})
+		go n.dial(n.dialDone)
+	}
+
+	dialed := n.dialDone
+	n.mu.Unlock()
+
+	select {
+	case <-dialed:
+	case <-ctx.Done():
+		return nil, derrors.Wrap(ctx.Err(), derrors.CodeTimeout, dialTimedOutDetail)
+	}
+
+	n.mu.Lock()
+	conn, err := n.conn, n.dialErr
+	n.mu.Unlock()
+
+	if conn != nil {
+		return conn, nil
+	}
+
+	if err != nil {
+		return nil, derrors.Wrap(err, derrors.CodeNotSupported, noSessionBusDetail)
+	}
+
+	return nil, derrors.New(derrors.CodeNotSupported, noSessionBusDetail)
+}
+
+// dial performs the one uncancellable connect and publishes its outcome by
+// closing done. It clears the in-flight marker first, so the next caller after
+// a failed dial retries rather than reading a stale answer forever.
+func (n *notifier) dial(done chan struct{}) {
+	conn, err := n.connect()
+
+	n.mu.Lock()
+
+	n.dialErr = err
+	n.dialDone = nil
+
+	if err == nil {
+		n.conn = conn
+	}
+
+	n.mu.Unlock()
+
+	close(done)
+}
+
+// withNotifyDeadline bounds the round trip. A caller's own deadline wins — it
+// knows what it can afford to wait — and one is imposed otherwise so a wedged
+// daemon cannot hold the caller open.
+func withNotifyDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
+	_, ok := ctx.Deadline()
+	if ok {
+		return context.WithCancel(ctx)
+	}
+
+	return context.WithTimeout(ctx, notifyTimeout)
+}
+
+// notifyError classifies a failed call so callers can tell a session that
+// cannot show notifications at all from a daemon that refused this one.
+// CodeNotSupported is reserved for the former, because that is what callers
+// degrade on; a rejected message is a live failure and stays one.
+func notifyError(err error) error {
+	if isMissingDaemon(err) {
+		return derrors.Wrap(err, derrors.CodeNotSupported, noDaemonDetail)
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return derrors.Wrap(
+			err,
+			derrors.CodeTimeout,
+			"the linux notification daemon did not answer in time",
+		)
+	}
+
+	return derrors.Wrap(
+		err,
+		derrors.CodeActionFailed,
+		"the linux notification daemon rejected the message",
+	)
+}
+
+// isMissingDaemon reports whether a bus error means nothing owns the
+// notification name. godbus yields dbus.Error by value on a client call and by
+// pointer from NewError, so both are matched.
+func isMissingDaemon(err error) bool {
+	var name string
+
+	var busError dbus.Error
+
+	var busErrorPtr *dbus.Error
+
+	switch {
+	case errors.As(err, &busError):
+		name = busError.Name
+	case errors.As(err, &busErrorPtr):
+		name = busErrorPtr.Name
+	default:
+		return false
+	}
+
+	return name == serviceUnknownError || name == nameHasNoOwnerError
+}

--- a/internal/adapter/platform/linux/system_notifications.go
+++ b/internal/adapter/platform/linux/system_notifications.go
@@ -5,6 +5,7 @@ package linux
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"time"
 
@@ -36,6 +37,10 @@ const (
 	notifyAppName = "Neru"
 	// nameHasOwnerMethod answers whether anything owns a well-known name.
 	nameHasOwnerMethod = "org.freedesktop.DBus.NameHasOwner"
+	// listActivatableNamesMethod lists the names the bus can start on demand.
+	// A daemon installed as a D-Bus service owns nothing until the first call
+	// reaches it, so ownership alone answers the wrong question.
+	listActivatableNamesMethod = "org.freedesktop.DBus.ListActivatableNames"
 	// serviceUnknownError and nameHasNoOwnerError are the two bus errors that
 	// mean "nobody is listening" rather than "the daemon refused this".
 	serviceUnknownError = "org.freedesktop.DBus.Error.ServiceUnknown"
@@ -79,8 +84,9 @@ const notifyTimeout = 2 * time.Second
 const (
 	noSessionBusDetail = "no reachable D-Bus session bus on this linux session, so " +
 		notifyBusName + " cannot be asked to show anything"
-	noDaemonDetail = "no notification daemon is running on this linux session; nothing owns " +
-		notifyBusName + " — start one (mako, dunst, or the desktop's own)"
+	noDaemonDetail = "no notification daemon on this linux session; nothing owns " +
+		notifyBusName + ", and the session bus has no service registered to start one " +
+		"on demand — install or start one (mako, dunst, or the desktop's own)"
 	dialTimedOutDetail = "the D-Bus session bus on this linux session did not accept a " +
 		"connection in time"
 )
@@ -188,10 +194,16 @@ func (n *notifier) send(ctx context.Context, note notification) error {
 	return nil
 }
 
-// daemonReachable reports nil when a notification daemon currently owns the
-// notification name, and why not otherwise. It asks the bus daemon rather than
+// daemonReachable reports nil when a notification the user sent now would
+// reach a daemon, and why not otherwise. It asks the bus daemon rather than
 // sending a notification, so `neru doctor` can answer "will I see
 // notifications?" without putting one on screen.
+//
+// Two questions, because ownership alone answers a narrower one than the user
+// asked. A daemon shipped as a D-Bus service — which is how most desktops ship
+// theirs — owns nothing until something calls it, and the bus starts it on the
+// first Notify. Reporting that session as having no notifications would send a
+// user off to install what they already have.
 func (n *notifier) daemonReachable(ctx context.Context) error {
 	callCtx, cancel := withNotifyDeadline(ctx)
 	defer cancel()
@@ -210,11 +222,34 @@ func (n *notifier) daemonReachable(ctx context.Context) error {
 		return notifyError(err)
 	}
 
-	if !owned {
+	if owned {
+		return nil
+	}
+
+	var activatable []string
+
+	err = conn.BusObject().
+		CallWithContext(callCtx, listActivatableNamesMethod, noCallFlags).
+		Store(&activatable)
+	if err != nil {
+		// The bus could not say what it can start, and nothing owns the name:
+		// the last thing known is that nobody is listening, so that is what is
+		// reported rather than a guess in either direction.
+		return derrors.Wrap(err, derrors.CodeNotSupported, noDaemonDetail)
+	}
+
+	if !daemonReachableFrom(owned, activatable) {
 		return derrors.New(derrors.CodeNotSupported, noDaemonDetail)
 	}
 
 	return nil
+}
+
+// daemonReachableFrom turns the bus's two answers into the one the user asked
+// for: a notification sent now would reach a daemon if one holds the name, and
+// equally if the bus would start one on being asked.
+func daemonReachableFrom(owned bool, activatable []string) bool {
+	return owned || slices.Contains(activatable, notifyBusName)
 }
 
 // session returns a live session-bus connection, bounded by ctx.

--- a/internal/adapter/platform/linux/system_notifications_integration_linux_test.go
+++ b/internal/adapter/platform/linux/system_notifications_integration_linux_test.go
@@ -1,0 +1,223 @@
+//go:build integration && linux
+
+package linux_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/y3owk1n/neru/internal/adapter/platform/linux"
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// The freedesktop Desktop Notification Specification, spelled out here rather
+// than imported from the adapter: this test is the independent statement of
+// what has to go on the wire, so sharing the adapter's constants would let a
+// wrong name pass on both sides.
+const (
+	notificationsName   = "org.freedesktop.Notifications"
+	notificationsPath   = dbus.ObjectPath("/org/freedesktop/Notifications")
+	criticalUrgency     = byte(2)
+	normalUrgency       = byte(1)
+	neverExpires        = int32(0)
+	daemonChoosesExpiry = int32(-1)
+)
+
+// notifyCall is one delivered Notify, in the argument order the specification
+// fixes.
+type notifyCall struct {
+	appName  string
+	replaces uint32
+	icon     string
+	summary  string
+	body     string
+	actions  []string
+	hints    map[string]dbus.Variant
+	expire   int32
+}
+
+// fakeDaemon stands in for mako, dunst or a desktop's own daemon: it owns the
+// notification name for the length of the test and records what arrives.
+type fakeDaemon struct {
+	calls chan notifyCall
+}
+
+// Notify is the spec's single method. godbus exports it by name and derives the
+// signature from these parameters, so a wrong order or type here fails the call
+// exactly as a real daemon would.
+func (d *fakeDaemon) Notify(
+	appName string,
+	replaces uint32,
+	icon, summary, body string,
+	actions []string,
+	hints map[string]dbus.Variant,
+	expire int32,
+) (uint32, *dbus.Error) {
+	d.calls <- notifyCall{
+		appName:  appName,
+		replaces: replaces,
+		icon:     icon,
+		summary:  summary,
+		body:     body,
+		actions:  actions,
+		hints:    hints,
+		expire:   expire,
+	}
+
+	return 1, nil
+}
+
+// startFakeDaemon owns the notification name on the session bus for this test.
+// It skips rather than fails when there is no bus (a container or an ssh
+// session) or when a real daemon already owns the name — neither says anything
+// about the code under test.
+//
+// That makes the delivery tests and TestShowNotification_ReportsASessionWithNoDaemon
+// mutually exclusive by construction, which is the point: a session either has
+// something able to show a notification or it does not, and each test covers
+// the state its machine is actually in. Between a developer desktop and CI both
+// halves get exercised.
+func startFakeDaemon(t *testing.T) *fakeDaemon {
+	t.Helper()
+
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		t.Skipf("no D-Bus session bus on this machine: %v", err)
+	}
+
+	daemon := &fakeDaemon{calls: make(chan notifyCall, 1)}
+
+	err = conn.Export(daemon, notificationsPath, notificationsName)
+	if err != nil {
+		t.Fatalf("exporting the fake notification daemon failed: %v", err)
+	}
+
+	reply, err := conn.RequestName(notificationsName, dbus.NameFlagDoNotQueue)
+	if err != nil {
+		t.Fatalf("requesting %s failed: %v", notificationsName, err)
+	}
+
+	if reply != dbus.RequestNameReplyPrimaryOwner {
+		t.Skipf("%s is already owned by a real notification daemon", notificationsName)
+	}
+
+	t.Cleanup(func() {
+		_, _ = conn.ReleaseName(notificationsName)
+		_ = conn.Export(nil, notificationsPath, notificationsName)
+	})
+
+	return daemon
+}
+
+// awaitNotification returns the delivered call, failing rather than hanging if
+// nothing arrives.
+func (d *fakeDaemon) awaitNotification(t *testing.T) notifyCall {
+	t.Helper()
+
+	select {
+	case call := <-d.calls:
+		return call
+	case <-time.After(5 * time.Second):
+		t.Fatal("no Notify reached the daemon within 5s")
+
+		return notifyCall{}
+	}
+}
+
+// TestShowNotification_ReachesTheFreedesktopDaemon is the wire-level check the
+// unit tests cannot make: that the arguments Neru sends are the ones a real
+// notification daemon accepts, in the order and types the specification fixes.
+// A signature mistake here is invisible to a compiler and silent at runtime —
+// the message simply never appears.
+func TestShowNotification_ReachesTheFreedesktopDaemon(t *testing.T) {
+	daemon := startFakeDaemon(t)
+
+	err := linux.ShowNotification(context.Background(), "Neru", "Scroll invert: on")
+	if err != nil {
+		t.Fatalf("ShowNotification failed against a live daemon: %v", err)
+	}
+
+	call := daemon.awaitNotification(t)
+
+	if call.summary != "Neru" {
+		t.Errorf("summary = %q, want %q", call.summary, "Neru")
+	}
+
+	if call.body != "Scroll invert: on" {
+		t.Errorf("body = %q, want %q", call.body, "Scroll invert: on")
+	}
+
+	if urgency, ok := call.hints["urgency"].Value().(byte); !ok || urgency != normalUrgency {
+		t.Errorf("urgency hint = %v, want %d", call.hints["urgency"].Value(), normalUrgency)
+	}
+
+	if call.expire != daemonChoosesExpiry {
+		t.Errorf("expire_timeout = %d, want %d (daemon's choice)",
+			call.expire, daemonChoosesExpiry)
+	}
+}
+
+// TestShowNotification_ReportsASessionWithNoDaemon is the other half, and the
+// state this change exists for: a session bus that works and nothing owning the
+// notification name — an ordinary minimal wlroots setup. The bus answers
+// ServiceUnknown, and that has to reach the caller as CodeNotSupported instead
+// of being swallowed the way the empty body swallowed it.
+func TestShowNotification_ReportsASessionWithNoDaemon(t *testing.T) {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		t.Skipf("no D-Bus session bus on this machine: %v", err)
+	}
+
+	var owned bool
+
+	err = conn.BusObject().
+		Call("org.freedesktop.DBus.NameHasOwner", 0, notificationsName).
+		Store(&owned)
+	if err != nil {
+		t.Fatalf("asking the bus who owns %s failed: %v", notificationsName, err)
+	}
+
+	if owned {
+		t.Skipf("%s is owned here, so the no-daemon path cannot be exercised", notificationsName)
+	}
+
+	err = linux.ShowNotification(context.Background(), "Neru", "nobody is listening")
+	if err == nil {
+		t.Fatal("ShowNotification with no daemon returned nil; the message was dropped silently")
+	}
+
+	if !derrors.IsNotSupported(err) {
+		t.Errorf("ShowNotification returned %v (code %q), want CodeNotSupported",
+			err, derrors.GetCode(err))
+	}
+}
+
+// TestShowAlert_ReachesTheDaemonAndStaysUp pins the decision Linux made about
+// alerts: macOS blocks the user with a modal NSAlert, and the stand-in is a
+// critical-urgency notification with no expiry, so a config error cannot scroll
+// away before it is read.
+func TestShowAlert_ReachesTheDaemonAndStaysUp(t *testing.T) {
+	daemon := startFakeDaemon(t)
+
+	err := linux.ShowAlert(context.Background(), "Neru could not load the config", "line 3")
+	if err != nil {
+		t.Fatalf("ShowAlert failed against a live daemon: %v", err)
+	}
+
+	call := daemon.awaitNotification(t)
+
+	if urgency, ok := call.hints["urgency"].Value().(byte); !ok || urgency != criticalUrgency {
+		t.Errorf(
+			"urgency hint = %v, want %d (critical)",
+			call.hints["urgency"].Value(),
+			criticalUrgency,
+		)
+	}
+
+	if call.expire != neverExpires {
+		t.Errorf("expire_timeout = %d, want %d (never)", call.expire, neverExpires)
+	}
+}

--- a/internal/adapter/platform/linux/system_notifications_integration_linux_test.go
+++ b/internal/adapter/platform/linux/system_notifications_integration_linux_test.go
@@ -4,6 +4,7 @@ package linux_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -182,6 +183,24 @@ func TestShowNotification_ReportsASessionWithNoDaemon(t *testing.T) {
 
 	if owned {
 		t.Skipf("%s is owned here, so the no-daemon path cannot be exercised", notificationsName)
+	}
+
+	// A name nothing owns is not the same as a name nothing answers: a daemon
+	// shipped as a D-Bus service owns nothing until the bus starts it on this
+	// very call, and there the notification arrives. Only a session where the
+	// bus would start nothing either is the one this test is about.
+	var activatable []string
+
+	err = conn.BusObject().
+		Call("org.freedesktop.DBus.ListActivatableNames", 0).
+		Store(&activatable)
+	if err != nil {
+		t.Fatalf("asking the bus what it can start failed: %v", err)
+	}
+
+	if slices.Contains(activatable, notificationsName) {
+		t.Skipf("%s is D-Bus activatable here, so a notification would start a daemon",
+			notificationsName)
 	}
 
 	err = linux.ShowNotification(context.Background(), "Neru", "nobody is listening")

--- a/internal/adapter/platform/linux/system_notifications_test.go
+++ b/internal/adapter/platform/linux/system_notifications_test.go
@@ -5,6 +5,7 @@ package linux
 import (
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,29 @@ var errNoBus = errors.New("dbus: couldn't determine address of session bus")
 // is what a daemon started outside a desktop session sees.
 func unreachableNotifier() *notifier {
 	return &notifier{connect: func() (*dbus.Conn, error) { return nil, errNoBus }}
+}
+
+// idleTransport is enough of a connection for godbus to build a *dbus.Conn
+// around without a session bus. Nothing is ever sent over it: the tests using
+// it need a connection they can close, to stand for one the bus dropped.
+type idleTransport struct{}
+
+func (idleTransport) Read([]byte) (int, error)    { return 0, io.EOF }
+func (idleTransport) Write(p []byte) (int, error) { return len(p), nil }
+func (idleTransport) Close() error                { return nil }
+
+// openConn is a connection that reports itself connected until it is closed.
+func openConn(t *testing.T) *dbus.Conn {
+	t.Helper()
+
+	conn, err := dbus.NewConn(idleTransport{})
+	if err != nil {
+		t.Fatalf("building a test connection failed: %v", err)
+	}
+
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
 }
 
 // TestNotifier_SendReportsNotSupportedWithoutASessionBus is the loud-stub pin
@@ -123,6 +147,71 @@ func TestNotifier_SendGivesUpOnADialThatNeverReturns(t *testing.T) {
 	}
 }
 
+// TestNotifier_SessionReportsAFailedRedialRatherThanTheDroppedConnection pins
+// what the cached connection is worth once the session bus goes away. A logind
+// session ending, a bus restart or a suspend all drop it, and the notifier then
+// holds a connection nothing can be sent over. Handing that back would have the
+// caller talk into a dead transport and report the daemon rejecting a message
+// that never left — sending a user to look at a daemon that is fine.
+func TestNotifier_SessionReportsAFailedRedialRatherThanTheDroppedConnection(t *testing.T) {
+	dropped := openConn(t)
+	redialed := openConn(t)
+
+	dials := 0
+
+	reconnecting := &notifier{
+		connect: func() (*dbus.Conn, error) {
+			dials++
+
+			switch dials {
+			case 1:
+				return dropped, nil
+			case 2:
+				return nil, errNoBus
+			default:
+				return redialed, nil
+			}
+		},
+	}
+
+	first, err := reconnecting.session(context.Background())
+	if err != nil {
+		t.Fatalf("the first session dial failed: %v", err)
+	}
+
+	if first != dropped {
+		t.Fatal("session returned a connection the dial did not produce")
+	}
+
+	// The bus goes away under the cached connection, and the redial fails.
+	_ = dropped.Close()
+
+	_, err = reconnecting.session(context.Background())
+	if err == nil {
+		t.Fatal("session handed back the dropped connection instead of reporting the failed redial")
+	}
+
+	if !derrors.IsNotSupported(err) {
+		t.Errorf("session returned %v (code %q), want CodeNotSupported naming the session bus",
+			err, derrors.GetCode(err))
+	}
+
+	if !strings.Contains(err.Error(), notifyBusName) {
+		t.Errorf("error %q does not say what could not be reached", err.Error())
+	}
+
+	// A failed dial leaves nothing cached, so the session coming back is picked
+	// up rather than the failure sticking for the rest of the daemon's life.
+	third, err := reconnecting.session(context.Background())
+	if err != nil {
+		t.Fatalf("session did not recover once the bus came back: %v", err)
+	}
+
+	if third != redialed {
+		t.Error("session returned a stale connection after a successful redial")
+	}
+}
+
 // TestNotifier_DaemonReachableReportsNotSupportedWithoutASessionBus keeps the
 // `neru doctor` probe honest in the same session: a capability that cannot be
 // confirmed must not answer "reachable".
@@ -171,6 +260,11 @@ func TestNotifyError_ClassifiesWhatTheCallerCanActOn(t *testing.T) {
 			name: "the daemon never answered",
 			err:  context.DeadlineExceeded,
 			want: derrors.CodeTimeout,
+		},
+		{
+			name: "the connection went away mid-call",
+			err:  dbus.ErrClosed,
+			want: derrors.CodeNotSupported,
 		},
 	}
 

--- a/internal/adapter/platform/linux/system_notifications_test.go
+++ b/internal/adapter/platform/linux/system_notifications_test.go
@@ -188,6 +188,50 @@ func TestNotifyError_ClassifiesWhatTheCallerCanActOn(t *testing.T) {
 	}
 }
 
+// TestDaemonReachableFrom_CountsAServiceTheBusWouldStart pins the question the
+// probe is actually asking. Most desktops ship their notification daemon as a
+// D-Bus service, which owns nothing until the first Notify starts it, so
+// ownership alone would have `neru doctor` send a user to install what they
+// already have — and the message they would see says to install a daemon.
+func TestDaemonReachableFrom_CountsAServiceTheBusWouldStart(t *testing.T) {
+	tests := []struct {
+		name        string
+		owned       bool
+		activatable []string
+		want        bool
+	}{
+		{
+			name:  "a running daemon owns the name",
+			owned: true,
+			want:  true,
+		},
+		{
+			name:        "nothing owns it, but the bus would start one",
+			activatable: []string{"org.freedesktop.portal.Desktop", notifyBusName},
+			want:        true,
+		},
+		{
+			name:        "nothing owns it and nothing would be started",
+			activatable: []string{"org.freedesktop.portal.Desktop"},
+			want:        false,
+		},
+		{
+			name: "the bus can start nothing at all",
+			want: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := daemonReachableFrom(testCase.owned, testCase.activatable)
+			if got != testCase.want {
+				t.Errorf("daemonReachableFrom(%t, %v) = %t, want %t",
+					testCase.owned, testCase.activatable, got, testCase.want)
+			}
+		})
+	}
+}
+
 // TestIsMissingDaemon_MatchesBothGodbusErrorShapes guards the reason the check
 // is written twice: godbus yields dbus.Error by value from a client call and
 // *dbus.Error from NewError, and matching only one shape would classify a

--- a/internal/adapter/platform/linux/system_notifications_test.go
+++ b/internal/adapter/platform/linux/system_notifications_test.go
@@ -1,0 +1,271 @@
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// errNoBus stands in for whatever godbus reports when there is no session bus
+// to reach — the message never matters, only that connecting failed.
+var errNoBus = errors.New("dbus: couldn't determine address of session bus")
+
+// unreachableNotifier is a notifier whose session bus cannot be reached, which
+// is what a daemon started outside a desktop session sees.
+func unreachableNotifier() *notifier {
+	return &notifier{connect: func() (*dbus.Conn, error) { return nil, errNoBus }}
+}
+
+// TestNotifier_SendReportsNotSupportedWithoutASessionBus is the loud-stub pin
+// for the path this change exists to close: ShowNotification used to have an
+// empty body, so a dropped message was indistinguishable from a delivered one.
+// Anything that cannot be shown must come back as CodeNotSupported, never nil.
+func TestNotifier_SendReportsNotSupportedWithoutASessionBus(t *testing.T) {
+	sends := map[string]notification{
+		"toast": toastNotification("Neru", "something happened"),
+		"alert": alertNotification("Neru", "something went wrong"),
+	}
+
+	for name, note := range sends {
+		t.Run(name, func(t *testing.T) {
+			err := unreachableNotifier().send(context.Background(), note)
+			if err == nil {
+				t.Fatal("send with no session bus returned nil; the message was dropped silently")
+			}
+
+			if !derrors.IsNotSupported(err) {
+				t.Errorf("send returned %v (code %q), want CodeNotSupported so callers can degrade",
+					err, derrors.GetCode(err))
+			}
+
+			if !strings.Contains(err.Error(), notifyBusName) {
+				t.Errorf("error %q does not name %q, so it does not say what is missing",
+					err.Error(), notifyBusName)
+			}
+		})
+	}
+}
+
+// TestNotifier_SendGivesUpOnADialThatNeverReturns pins why the dial runs on
+// its own goroutine rather than inline: dbus.SessionBus takes no context, so a
+// bus that accepts the connection and then stops answering would park the
+// caller forever. The tray calls this from the loop that also carries Quit, and
+// the config alerts call it before the daemon is up.
+func TestNotifier_SendGivesUpOnADialThatNeverReturns(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	// Each dial announces itself, so a second one is observable.
+	dials := make(chan struct{}, 2)
+
+	wedged := &notifier{
+		connect: func() (*dbus.Conn, error) {
+			dials <- struct{}{}
+
+			<-release
+
+			return nil, errNoBus
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	sent := make(chan error, 1)
+
+	go func() {
+		sent <- wedged.send(ctx, toastNotification("Neru", "anyone there"))
+	}()
+
+	select {
+	case err := <-sent:
+		if err == nil {
+			t.Fatal("send against a wedged session bus returned nil")
+		}
+
+		if !derrors.IsCode(err, derrors.CodeTimeout) {
+			t.Errorf("send returned %v (code %q), want CodeTimeout", err, derrors.GetCode(err))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("send waited on a dial that never returns; a wedged bus would hang the caller")
+	}
+
+	select {
+	case <-dials:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no dial was ever started")
+	}
+
+	// The dial is still outstanding. The next caller shares it — bounded by its
+	// own deadline rather than by the dial — instead of starting a second one,
+	// which godbus would only queue behind the first anyway.
+	secondCtx, cancelSecond := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelSecond()
+
+	second := wedged.send(secondCtx, toastNotification("Neru", "still there"))
+	if !derrors.IsCode(second, derrors.CodeTimeout) {
+		t.Errorf("a second send while the first dial is outstanding returned %v (code %q), "+
+			"want CodeTimeout", second, derrors.GetCode(second))
+	}
+
+	select {
+	case <-dials:
+		t.Error("a second send started its own dial rather than sharing the outstanding one")
+	default:
+	}
+}
+
+// TestNotifier_DaemonReachableReportsNotSupportedWithoutASessionBus keeps the
+// `neru doctor` probe honest in the same session: a capability that cannot be
+// confirmed must not answer "reachable".
+func TestNotifier_DaemonReachableReportsNotSupportedWithoutASessionBus(t *testing.T) {
+	err := unreachableNotifier().daemonReachable(context.Background())
+	if err == nil {
+		t.Fatal("daemonReachable with no session bus returned nil")
+	}
+
+	if !derrors.IsNotSupported(err) {
+		t.Errorf("daemonReachable returned %v (code %q), want CodeNotSupported",
+			err, derrors.GetCode(err))
+	}
+}
+
+// TestNotifyError_ClassifiesWhatTheCallerCanActOn separates the two cases that
+// look alike on the wire and mean different things to a caller: nobody is
+// listening (degrade), versus the daemon refused this message (a live
+// failure). Misclassifying the second as CodeNotSupported would have callers
+// stop trying to notify for the rest of the session.
+func TestNotifyError_ClassifiesWhatTheCallerCanActOn(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want derrors.Code
+	}{
+		{
+			name: "no daemon owns the name",
+			err:  dbus.Error{Name: serviceUnknownError, Body: []any{"no such service"}},
+			want: derrors.CodeNotSupported,
+		},
+		{
+			name: "the name has no owner",
+			err:  dbus.Error{Name: nameHasNoOwnerError, Body: []any{"no owner"}},
+			want: derrors.CodeNotSupported,
+		},
+		{
+			name: "a daemon replied with an error",
+			err: dbus.Error{
+				Name: "org.freedesktop.DBus.Error.InvalidArgs",
+				Body: []any{"bad args"},
+			},
+			want: derrors.CodeActionFailed,
+		},
+		{
+			name: "the daemon never answered",
+			err:  context.DeadlineExceeded,
+			want: derrors.CodeTimeout,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := notifyError(testCase.err)
+			if err == nil {
+				t.Fatal("notifyError returned nil for a failed call")
+			}
+
+			if got := derrors.GetCode(err); got != testCase.want {
+				t.Errorf("notifyError(%v) has code %q, want %q", testCase.err, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestIsMissingDaemon_MatchesBothGodbusErrorShapes guards the reason the check
+// is written twice: godbus yields dbus.Error by value from a client call and
+// *dbus.Error from NewError, and matching only one shape would classify a
+// missing daemon as a live failure.
+func TestIsMissingDaemon_MatchesBothGodbusErrorShapes(t *testing.T) {
+	byValue := dbus.Error{Name: serviceUnknownError}
+	byPointer := dbus.NewError(serviceUnknownError, nil)
+
+	if !isMissingDaemon(byValue) {
+		t.Error("a dbus.Error value naming ServiceUnknown was not recognized as a missing daemon")
+	}
+
+	if !isMissingDaemon(byPointer) {
+		t.Error("a *dbus.Error naming ServiceUnknown was not recognized as a missing daemon")
+	}
+
+	if isMissingDaemon(errNoBus) {
+		t.Error("a plain error was mistaken for a missing daemon")
+	}
+}
+
+// TestAlertNotification_StaysUpUntilDismissed pins the decision this change
+// made about what an alert is on Linux: macOS blocks the user with a modal
+// NSAlert, and the Linux stand-in is a critical-urgency notification with no
+// expiry. A daemon may expire a normal-urgency message on its own, so a config
+// error delivered as a toast is one the user can miss entirely.
+func TestAlertNotification_StaysUpUntilDismissed(t *testing.T) {
+	alert := alertNotification("title", "body")
+
+	if alert.urgency != urgencyCritical {
+		t.Errorf("alert urgency = %d, want %d (critical)", alert.urgency, urgencyCritical)
+	}
+
+	if alert.expire != expireNever {
+		t.Errorf("alert expiry = %d, want %d (never)", alert.expire, expireNever)
+	}
+
+	toast := toastNotification("title", "body")
+
+	if toast.urgency != urgencyNormal {
+		t.Errorf("toast urgency = %d, want %d (normal)", toast.urgency, urgencyNormal)
+	}
+
+	if toast.expire != expireDaemonChoice {
+		t.Errorf("toast expiry = %d, want %d (daemon's choice)", toast.expire, expireDaemonChoice)
+	}
+}
+
+// TestWithNotifyDeadline_KeepsTheCallersDeadline checks the bound: a caller
+// that stated what it can afford keeps it, and one that did not gets a cap, so
+// no path can wait on a wedged daemon forever.
+func TestWithNotifyDeadline_KeepsTheCallersDeadline(t *testing.T) {
+	callerDeadline := time.Now().Add(time.Hour)
+
+	ctx, cancel := context.WithDeadline(context.Background(), callerDeadline)
+	defer cancel()
+
+	bounded, cancelBounded := withNotifyDeadline(ctx)
+	defer cancelBounded()
+
+	kept, hasDeadline := bounded.Deadline()
+	if !hasDeadline {
+		t.Fatal("withNotifyDeadline dropped the caller's deadline")
+	}
+
+	if !kept.Equal(callerDeadline) {
+		t.Errorf("deadline = %v, want the caller's %v", kept, callerDeadline)
+	}
+
+	capped, cancelCapped := withNotifyDeadline(context.Background())
+	defer cancelCapped()
+
+	deadline, hasDeadline := capped.Deadline()
+	if !hasDeadline {
+		t.Fatal("withNotifyDeadline left a deadline-less context unbounded")
+	}
+
+	if remaining := time.Until(deadline); remaining > notifyTimeout {
+		t.Errorf("imposed deadline is %v away, want at most %v", remaining, notifyTimeout)
+	}
+}

--- a/internal/adapter/platform/profile.go
+++ b/internal/adapter/platform/profile.go
@@ -171,7 +171,8 @@ func linuxProfile(ds DisplayServer) Profile {
 		Notifications: BackendPlan{
 			Name:      "freedesktop notifications",
 			BuildMode: BuildModePureGo,
-			Notes:     "D-Bus notifications should be achievable without CGO",
+			Notes: "org.freedesktop.Notifications over the session bus, on every backend " +
+				"and with no CGO; needs a notification daemon running",
 		},
 	}
 }

--- a/internal/adapter/platform/windows/system.go
+++ b/internal/adapter/platform/windows/system.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/y3owk1n/neru/internal/derrors"
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
@@ -226,9 +227,16 @@ func (s *SystemAdapter) ShowAlert(_ context.Context, title, message string) erro
 	return nil
 }
 
-// ShowNotification displays a lightweight notification on Windows.
+// ShowNotification reports CodeNotSupported on Windows: there is no toast
+// implementation yet, and the port carries an error precisely so a caller is
+// told the message was dropped rather than assuming it was shown.
 // TODO(windows): implement using Windows Toast Notifications API.
-func (s *SystemAdapter) ShowNotification(title, message string) {}
+func (s *SystemAdapter) ShowNotification(_ context.Context, title, message string) error {
+	return derrors.New(
+		derrors.CodeNotSupported,
+		"ShowNotification not yet implemented on windows; target toast notifications",
+	)
+}
 
 // CheckScreenCapturePermission reports true: Windows does not gate screen capture
 // behind a permission.

--- a/internal/app/components/systray/systray.go
+++ b/internal/app/components/systray/systray.go
@@ -362,9 +362,34 @@ func (c *Component) handleVersionCopy() {
 	writeToClipboardErr := clipboard.WriteAll(buildinfo.Version)
 	if writeToClipboardErr != nil {
 		c.logger.Error("Error copying version to clipboard", zap.Error(writeToClipboardErr))
-	} else if c.system != nil {
-		c.system.ShowNotification("Neru", "Version copied to clipboard")
+	} else {
+		c.notify("Version copied to clipboard")
 	}
+}
+
+// notify puts a short message in front of the user, and reports it when the
+// platform could not. A tray toggle whose only feedback is a notification is
+// silent twice over if the notification is dropped without a word — which is
+// what a Linux session with no notification daemon does.
+//
+// It runs off the menu loop. Showing a notification is a session-bus round
+// trip on Linux, and the loop it would park is the same one that carries every
+// later menu click, Quit included; nothing here reads the result, so waiting
+// for it buys the user nothing and costs them the menu.
+//
+// Only the failure is logged: the message is UI text, which never goes to a
+// log (root AGENTS.md, Conventions).
+func (c *Component) notify(message string) {
+	if c.system == nil {
+		return
+	}
+
+	go func() {
+		err := c.system.ShowNotification(c.ctx, "Neru", message)
+		if err != nil {
+			c.logger.Warn("Could not show a tray notification", zap.Error(err))
+		}
+	}()
 }
 
 // handleToggleEnable toggles the enabled state of the application.
@@ -408,9 +433,7 @@ func (c *Component) handleToggleScreenShare() {
 		status = "hidden"
 	}
 
-	if c.system != nil {
-		c.system.ShowNotification("Neru", "Screen share visibility: "+status)
-	}
+	c.notify("Screen share visibility: " + status)
 }
 
 // updateScreenShareMenuItem updates the screen share menu item text based on state.
@@ -432,9 +455,7 @@ func (c *Component) handleToggleScrollInvert() {
 		status = "on"
 	}
 
-	if c.system != nil {
-		c.system.ShowNotification("Neru", "Scroll invert: "+status)
-	}
+	c.notify("Scroll invert: " + status)
 }
 
 // updateScrollInvertMenuItem updates the scroll invert menu item text based on state.

--- a/internal/app/ipcctrl/info_health.go
+++ b/internal/app/ipcctrl/info_health.go
@@ -180,6 +180,17 @@ func capabilitiesMap(capabilities ports.PlatformCapabilities) map[string]any {
 		out[string(ports.CapabilityDarkModeDetection)+detailSuffix] = detail
 	}
 
+	// Notifications get the same treatment, gated on the status rather than on
+	// the platform: "stub" alone does not tell a user whether a daemon to
+	// install, a build to change, or nothing at all would fix it, while the
+	// supported detail only restates the mechanism and is left out. Linux
+	// probes a live reason into this; the other platforms carry a static one,
+	// and either is worth the line when the capability is not there.
+	if detail := capabilities.Notifications.Detail; detail != "" &&
+		!capabilities.Notifications.Supported() {
+		out[string(ports.CapabilityNotifications)+detailSuffix] = detail
+	}
+
 	return out
 }
 

--- a/internal/app/modes/monitor_select.go
+++ b/internal/app/modes/monitor_select.go
@@ -253,7 +253,24 @@ func (h *handlerState) discoverMonitorsForSelection() ([]monitorSelectTarget, er
 func (h *handlerState) reportMonitorSelectNotSupported() {
 	h.logger.Info("monitor_select is not supported on this platform")
 
-	if h.system != nil {
-		h.system.ShowNotification("neru monitor_select", "Not supported on this platform")
+	if h.system == nil {
+		return
 	}
+
+	// This runs under h.mu, and showing a notification is a session-bus round
+	// trip on Linux — a blocking call the locking contract keeps off the lock.
+	// The goroutine touches no handler state, only values read here, and a
+	// notification that cannot be shown is reported rather than dropped.
+	system, logger, ctx := h.system, h.logger, h.ctx
+
+	go func() {
+		err := system.ShowNotification(
+			ctx,
+			"neru monitor_select",
+			"Not supported on this platform",
+		)
+		if err != nil {
+			logger.Warn("Could not notify that monitor_select is unsupported", zap.Error(err))
+		}
+	}()
 }

--- a/internal/app/modes/monitor_select_test.go
+++ b/internal/app/modes/monitor_select_test.go
@@ -1,0 +1,100 @@
+package modes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+	portmocks "github.com/y3owk1n/neru/internal/ports/mocks"
+)
+
+// notifyWait bounds each side of the handoff. It only has to outlast a
+// goroutine start on a loaded machine, so anything longer just slows a failure
+// down.
+const notifyWait = 2 * time.Second
+
+// TestHandlerState_ReportMonitorSelectNotSupported_NotifiesOffTheLock pins the
+// reason the notification is handed to a goroutine. Since ShowNotification
+// gained an error it is a session-bus round trip on Linux, and this runs from
+// activateMonitorSelectMode with h.mu held — the one place the locking contract
+// forbids a blocking call, because h.mu serializes key handling. A notification
+// daemon that never answers must cost the user nothing, and the message must
+// still be attempted.
+func TestHandlerState_ReportMonitorSelectNotSupported_NotifiesOffTheLock(t *testing.T) {
+	attempted := make(chan struct{}, 1)
+	wedged := make(chan struct{})
+
+	defer close(wedged)
+
+	system := &portmocks.MockSystemPort{
+		ShowNotificationFunc: func(_ context.Context, _, _ string) error {
+			attempted <- struct{}{}
+			// A notification daemon that has stopped answering.
+			<-wedged
+
+			return derrors.New(derrors.CodeNotSupported, "no notification daemon")
+		},
+	}
+
+	handler := newHandlerWithState(handlerState{
+		system: system,
+		ctx:    context.Background(),
+		logger: zap.NewNop(),
+	})
+
+	returned := make(chan struct{})
+
+	go func() {
+		handler.mu.Lock()
+		defer handler.mu.Unlock()
+
+		handler.reportMonitorSelectNotSupported()
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(notifyWait):
+		t.Fatal(
+			"reportMonitorSelectNotSupported waited on the notification while holding h.mu; " +
+				"a wedged notification daemon would freeze key handling",
+		)
+	}
+
+	select {
+	case <-attempted:
+	case <-time.After(notifyWait):
+		t.Fatal("the notification was never attempted, so the user is told nothing")
+	}
+}
+
+// TestHandlerState_ReportMonitorSelectNotSupported_SurvivesNoSystemPort covers
+// the daemon built without a system port. Nothing can be notified, so the
+// report must return under the lock rather than reaching a nil port — the
+// assertion is that it comes back at all, since the failure mode is a panic
+// inside a locked entry point.
+func TestHandlerState_ReportMonitorSelectNotSupported_SurvivesNoSystemPort(t *testing.T) {
+	handler := newHandlerWithState(handlerState{
+		ctx:    context.Background(),
+		logger: zap.NewNop(),
+	})
+
+	returned := make(chan struct{})
+
+	go func() {
+		handler.mu.Lock()
+		defer handler.mu.Unlock()
+
+		handler.reportMonitorSelectNotSupported()
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(notifyWait):
+		t.Fatal("reportMonitorSelectNotSupported did not return with no system port to notify")
+	}
+}

--- a/internal/cli/cliutil/util.go
+++ b/internal/cli/cliutil/util.go
@@ -201,6 +201,7 @@ func (f *OutputFormatter) PrintHealth(cmd *cobra.Command, success bool, data any
 
 	printProfile(cmd, healthData["profile"])
 	printDarkMode(cmd, healthData["capabilities"])
+	printNotifications(cmd, healthData["capabilities"])
 
 	cmd.Println()
 	// Print component checks
@@ -312,6 +313,25 @@ func printDarkMode(cmd *cobra.Command, rawCapabilities any) {
 	}
 
 	cmd.Println("  Dark Mode: " + detail)
+}
+
+// printNotifications renders a "Notifications:" metadata line when the daemon
+// populated notifications_detail, which it does exactly when notifications are
+// unavailable — so the line appears only when there is something to do about
+// it. On Linux that reason is probed live and names the daemon to install; on
+// the other platforms it names what is unbuilt.
+func printNotifications(cmd *cobra.Command, rawCapabilities any) {
+	capabilities, ok := rawCapabilities.(map[string]any)
+	if !ok {
+		return
+	}
+
+	detail := stringValue(capabilities["notifications_detail"])
+	if detail == "" {
+		return
+	}
+
+	cmd.Println("  Notifications: " + detail)
 }
 
 // Status payload keys for the runtime toggles, named as the daemon reports

--- a/internal/ports/capability_presets.go
+++ b/internal/ports/capability_presets.go
@@ -76,8 +76,14 @@ func LinuxCapabilities() PlatformCapabilities {
 		Overlay: supportedCapability(
 			"native overlays available via X11 windows or Wayland layer-shell + Cairo",
 		),
-		Notifications: stubCapability(
-			"native notifications not implemented yet; target freedesktop notifications",
+		// Live-probed by the Linux SystemAdapter, which downgrades this to a
+		// stub when nothing owns the notification name on the session bus.
+		// See linux.SystemAdapter.notificationCapability.
+		Notifications: supportedCapability(
+			"notifications and alerts delivered to the session's freedesktop " +
+				"notification daemon over D-Bus (org.freedesktop.Notifications); " +
+				"an alert is a critical-urgency notification that stays until " +
+				"dismissed, not a modal dialog",
 		),
 		GlobalHotkeys: supportedCapability(
 			"global hotkeys available via X11 XGrabKey; on Wayland via a passive " +

--- a/internal/ports/capability_presets_test.go
+++ b/internal/ports/capability_presets_test.go
@@ -31,19 +31,24 @@ func TestNonDarwinCapabilities_ReportStubbedFeatures(t *testing.T) {
 		name                string
 		capabilities        ports.PlatformCapabilities
 		accessibilityStatus ports.FeatureStatus
+		notificationsStatus ports.FeatureStatus
 	}{
 		// Linux discovers clickable elements via an AT-SPI (D-Bus) tree walk;
-		// Windows discovers them via UI Automation. Notifications remain stubbed
-		// on both (asserted below).
+		// Windows discovers them via UI Automation. Linux notifications go to
+		// the freedesktop notification daemon over the same session bus, so the
+		// preset is supported and the adapter downgrades it live when no daemon
+		// is running; Windows has no toast implementation at all.
 		{
 			name:                "linux",
 			capabilities:        ports.LinuxCapabilities(),
 			accessibilityStatus: ports.FeatureStatusSupported,
+			notificationsStatus: ports.FeatureStatusSupported,
 		},
 		{
 			name:                "windows",
 			capabilities:        ports.WindowsCapabilities(),
 			accessibilityStatus: ports.FeatureStatusSupported,
+			notificationsStatus: ports.FeatureStatusStub,
 		},
 	}
 
@@ -61,10 +66,11 @@ func TestNonDarwinCapabilities_ReportStubbedFeatures(t *testing.T) {
 				)
 			}
 
-			if testCase.capabilities.Notifications.Status != ports.FeatureStatusStub {
+			if testCase.capabilities.Notifications.Status != testCase.notificationsStatus {
 				t.Fatalf(
-					"Notifications status = %q, want stub",
+					"Notifications status = %q, want %q",
 					testCase.capabilities.Notifications.Status,
+					testCase.notificationsStatus,
 				)
 			}
 		})

--- a/internal/ports/mocks/system.go
+++ b/internal/ports/mocks/system.go
@@ -29,7 +29,7 @@ type MockSystemPort struct {
 	IsSecureInputEnabledFunc           func() bool
 	ShowSecureInputNotificationFunc    func()
 	ShowAlertFunc                      func(ctx context.Context, title, message string) error
-	ShowNotificationFunc               func(title, message string)
+	ShowNotificationFunc               func(ctx context.Context, title, message string) error
 	CapabilitiesFunc                   func() ports.PlatformCapabilities
 	PlatformLabelFunc                  func() string
 	HealthFunc                         func(ctx context.Context) error
@@ -227,10 +227,12 @@ func (m *MockSystemPort) ShowAlert(ctx context.Context, title, message string) e
 }
 
 // ShowNotification is a mock implementation.
-func (m *MockSystemPort) ShowNotification(title, message string) {
+func (m *MockSystemPort) ShowNotification(ctx context.Context, title, message string) error {
 	if m.ShowNotificationFunc != nil {
-		m.ShowNotificationFunc(title, message)
+		return m.ShowNotificationFunc(ctx, title, message)
 	}
+
+	return nil
 }
 
 // Capabilities is a mock implementation.

--- a/internal/ports/system.go
+++ b/internal/ports/system.go
@@ -125,7 +125,16 @@ type SystemPort interface {
 	ShowAlert(ctx context.Context, title, message string) error
 
 	// ShowNotification displays a lightweight toast/banner notification.
-	ShowNotification(title, message string)
+	//
+	// It carries an error because a notification is not always deliverable:
+	// on Linux the session's notification daemon may be absent, which is an
+	// ordinary state on a minimal compositor session, and a caller that
+	// cannot tell "shown" from "dropped" has nothing to fall back to.
+	// Platforms with no notification path at all report CodeNotSupported.
+	//
+	// Returning nil means the platform accepted the message, not that the
+	// user has seen it — delivery can still be asynchronous.
+	ShowNotification(ctx context.Context, title, message string) error
 }
 
 // RelativeCursorMover is an optional SystemPort extension: move the cursor by


### PR DESCRIPTION
## Description

This PR makes Neru talk to Linux users. Notifications were dropped in silence — the Linux implementation had an empty body and no error to carry, so a caller could not tell "shown" from "did nothing" — alerts refused outright, and the config onboarding and validation-error paths quietly returned the fallback a person would only have chosen after being asked. All three now go to the session's freedesktop notification daemon over D-Bus, on the same session bus the tray already uses, in pure Go on every backend, so a `CGO_ENABLED=0` build shows them too.

An alert on Linux is deliberately not a modal dialog. No ordinary Wayland or X11 client can stop the session the way macOS's `NSAlert` does, and the alternatives were a prompt that needs a helper a minimal wlroots session need not have, or a message plus a safe default. So an alert is a critical-urgency notification that stays on screen until it is dismissed, and the two startup alerts inform rather than ask: a missing config file starts Neru on built-in defaults and says so, changing nothing on disk, instead of offering create / defaults / quit.

Where no notification daemon is running — an ordinary state on a minimal compositor session — the failure is now visible rather than swallowed. Notifications report `CodeNotSupported` naming what is absent, `neru doctor` probes the session live and downgrades the notifications capability with a line saying what to install, and the startup alerts fall back to stderr.

## Related Issues

Closes #1455

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — exited 0 in this worktree. Also `just lint-cross` (Linux CGO-on and Windows), `just test-linux` (Linux CGO-on container), the same suite with `CGO_ENABLED=0`, and the new tests under `-race` against a real session bus in a container
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

### Port signature change

`ShowNotification` gained a context and an error. That is the point of the change — without one, a dropped message is indistinguishable from a delivered one, and reporting the drop is what the platform guide requires — but it touches all three platforms and the port mock:

- **macOS** returns nil. The `UserNotifications` path is genuinely fire-and-forget and there is nothing to report at the point of the call.
- **Windows** now returns `CodeNotSupported` instead of doing nothing. Behaviour change beyond the signature, and the honest one: it has no toast implementation, and its Known Gaps entry already says so.
- **Callers** now handle the error. The tray logs the failure and shows the notification off its menu loop, so a wedged daemon cannot park the loop that also carries Quit. `monitor_select` hands it to a goroutine, because it runs under the mode handler's lock and a session-bus round trip is exactly the blocking call that contract keeps off it.

The message text is never logged — only the failure — per the logging rule in `AGENTS.md`.

### Why the config alerts became a notification plus a default

The two startup alerts had to choose a shape rather than a port. A blocking modal would need a toolkit Neru does not link or an installed helper (`zenity`, `kdialog`) that is not guaranteed, and blocking startup on a dialog that may never appear is worse than starting. A keyboard-driven tool whose first act is to seize the session for a question is worse still. So they answer as the user could only have answered after being asked — run on defaults, change nothing on disk — and say what happened and what to type. Onboarding falls back to stderr when the notification cannot be delivered; the validation-error path does not need to, because the launcher already prints the same failure there.

### Bounding the session bus

`dbus.SessionBus` takes no context: the connect, auth and Hello round trip are uncancellable, so a bus that accepts a connection and then stops answering would park the caller forever. The dial therefore runs on a goroutine each caller can abandon under its own deadline, one dial at a time — godbus serializes them anyway — with later callers sharing its outcome, and a successful connection kept so the ordinary path dials nothing.

### Capability reporting

The Linux notifications capability is now live-probed the way dark mode already is, because whether a notification appears depends on a daemon being installed rather than on any code here — a static "supported" would be the same kind of lie the empty body told. `neru doctor` prints the reason only when the capability is unavailable, which is when there is something to do about it.

### Documentation

The capability matrix rows for **Native alerts** (⚠️, not modal) and **Native notifications** (✅) are updated, Linux Known Gaps entry 1 is removed and the list renumbered, and the generated platform-support region is untouched. `docs/LINUX_SETUP.md` gains the host dependency; `docs/ROADMAP.md` no longer names this as one of the two largest open Linux areas.

### Not breaking

No config option, command, flag or environment variable changes. `ShowNotification` is an internal port, not a user-facing surface.
