### PR TITLE
feat(linux): manage the daemon as a systemd user unit

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -375,14 +375,14 @@ sync with reality; the policy and per-platform status live in
 **`neru services`** — the command itself is shared:
 [services.go](../internal/cli/services.go) registers `ServicesCmd`
 unconditionally and delegates to unexported helpers (`installService`,
-`startService`, …). The helpers are a Tier-2 dispatch pair:
+`startService`, …). The helpers are a Tier-2 dispatch set:
 [services_darwin.go](../internal/cli/services_darwin.go) (`//go:build darwin`)
-drives `launchctl` and `.plist` files, while
-[services_other.go](../internal/cli/services_other.go) (`//go:build !darwin`)
-returns `CodeNotSupported`. Adding Linux service management means carving a
-`services_linux.go` out of the `!darwin` slot and implementing the same helpers
-over `systemctl` — registration is already shared, so no new `init()` is
-needed.
+drives `launchctl` and `.plist` files,
+[services_linux.go](../internal/cli/services_linux.go) (`//go:build linux`)
+drives `systemctl --user` and a unit file, and
+[services_other.go](../internal/cli/services_other.go)
+(`//go:build !darwin && !linux`) returns `CodeNotSupported`. Registration is
+shared, so a platform joining the set adds one file and no `init()`.
 
 **`IsRunningFromAppBundle`** — [root.go](../internal/cli/root.go) delegates to
 a build-tagged implementation: [root_darwin.go](../internal/cli/root_darwin.go)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -98,7 +98,7 @@ Accepted by every command.
 | [`toggle-cursor-follow-selection`](#neru-toggle-cursor-follow-selection) | Toggle cursor follow | Yes | All |
 | [`toggle-screen-share`](#neru-toggle-screen-share)           | Hide overlays while sharing     | Yes | macOS |
 | [`roles`](#neru-roles)                                       | List the role vocabulary        | No  | All |
-| [`services`](#neru-services)                                 | Manage the system service       | No  | macOS |
+| [`services`](#neru-services)                                 | Manage the system service       | No  | macOS · Linux |
 | [`docs`](#neru-docs)                                         | Open documentation in a browser | No  | macOS |
 
 ¹ Element discovery quality differs by platform: a full accessibility tree on
@@ -1510,19 +1510,28 @@ Manage Neru as a system service that starts on login.
 neru services install|uninstall|start|stop|restart|status
 ```
 
-**Platforms:** macOS only, using launchd. Other platforms return
-`ERR_NOT_SUPPORTED`. When
-Neru was installed through Nix, Homebrew, or another package manager, use that
-tool's service manager instead.
+**Platforms:** macOS, using a launchd user agent, and Linux, using a systemd
+user unit. Windows returns `ERR_NOT_SUPPORTED`. When Neru was installed through
+Nix, Homebrew, home-manager, or another package manager that manages the service
+itself, use that tool instead — on Linux, `install` and `uninstall` both refuse
+rather than touching a unit Neru did not write.
 
 | Subcommand  | Description                                |
 | ----------- | ------------------------------------------ |
-| `install`   | Install and load the launchd service        |
-| `uninstall` | Unload and remove the service               |
+| `install`   | Write the service definition and enable it for login |
+| `uninstall` | Disable the service and remove its definition |
 | `start`     | Start the service                           |
 | `stop`      | Stop the service                            |
 | `restart`   | Restart the service                         |
-| `status`    | Report whether the service is loaded and running |
+| `status`    | Report whether the service is installed and running |
+
+The definition is a launchd plist in `~/Library/LaunchAgents` on macOS and a
+systemd user unit on Linux; where the Linux unit is written, what it contains,
+and what happens on a machine booted by another init system are in
+[LINUX_SETUP.md](LINUX_SETUP.md#systemd-user-service).
+
+`status` reports a machine where the service was never installed as exactly
+that, rather than failing.
 
 ---
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -165,6 +165,7 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Native hint-search field**  | ✅ NSTextField overlay   | 🟡 key-stream fallback | 🟡 key-stream fallback       | 🟡 key-stream fallback  | 🟡 key-stream fallback       |
 | **Vision / OCR detection**    | ✅ Vision framework      | ❌                     | ❌                           | ❌                      | ❌                           |
 | **Key feed (`neru key`)**     | ✅ `CGEventPost`         | ✅ uinput               | ✅ uinput / virtual-keyboard | ✅ uinput               | 🟡 `CodeNotSupported`        |
+| **Service management (`neru services`)** | ✅ launchd user agent | ⚠️ systemd user unit only ³ | ⚠️ systemd user unit only ³ | ⚠️ systemd user unit only ³ | 🟡 `CodeNotSupported` |
 
 ¹ Per-app hotkey overrides need to know which application is focused. Where the
 app watcher fires, it publishes that identity to the mode handler and the keymap
@@ -211,6 +212,12 @@ resolver — it is remembered under the family name exactly as written
 (`internal/adapter/platform/fontcache`); the non-CGO Linux build re-derives it
 each time. Either way what a name resolves to depends on that name alone and
 never on what was resolved before it.
+
+³ The Linux columns of this table are display servers, and service management is
+the one row whose limit sits on a different axis: it needs **systemd**, on every
+Linux backend alike. A machine booted by runit, OpenRC or s6 gets
+`CodeNotSupported` from every `neru services` subcommand — a stated boundary
+rather than a gap, see "Service management on Linux" below.
 
 ### Notes on the ⚠️ entries
 
@@ -267,6 +274,22 @@ theirs and which `neru doctor` counts as present. With none, `ShowNotification`
 and `ShowAlert` report `CodeNotSupported` naming what is absent, `neru doctor`
 probes the session and downgrades the notifications row with a line saying what
 to install, and the two startup alerts fall back to stderr.
+
+**Service management on Linux.** The mechanism is a **systemd user unit**
+anchored on `graphical-session.target` — `After=` and `WantedBy=` it because
+every backend needs a display server and starting before one exists would only
+produce a crash loop, `PartOf=` it so a logout/login cycle restarts the daemon
+instead of leaving an orphan attached to a display that is gone.
+
+Coverage is **systemd and no other init system**: runit, OpenRC and s6 report
+`CodeNotSupported` naming systemd, which
+[ADR 0013](./adr/0013-parity-is-measured-in-words-not-subsystems.md) records as a
+stated boundary rather than a gap. What answers the question is systemd's own
+runtime marker, `/run/systemd/system`, not `systemctl` on `PATH` — that binary
+ships in packages installed on machines running something else. `status` on a
+machine where the unit was never installed says so instead of failing. Where the
+unit is written and how a user drives it:
+[LINUX_SETUP.md](./LINUX_SETUP.md#systemd-user-service).
 
 **Smooth cursor animation on Linux.** Off by default; opt in with
 `smooth_cursor.move_mouse_enabled` (the same cross-platform `SmoothCursorConfig`
@@ -769,45 +792,42 @@ command — that means less here than it does on macOS, whether or not the
 
 **Linux**
 
-1. `neru services` — no systemd user unit, so install/uninstall/start/stop/
-   restart/status all return `CodeNotSupported` where macOS writes a launchd
-   plist. Scope is systemd; other init systems stay `CodeNotSupported`
-2. `neru docs` — returns `CodeNotSupported` although the tray already opens
+1. `neru docs` — returns `CodeNotSupported` although the tray already opens
    URLs through `xdg-open` in the same repo
-3. Smooth scroll animation — not implemented, and `smooth_scroll.*` is parsed,
+2. Smooth scroll animation — not implemented, and `smooth_scroll.*` is parsed,
    validated and then silently ignored. Spike `REL_WHEEL_HI_RES` (uinput),
    continuous `wl_pointer` axis values and libei scroll deltas before
    committing
-4. Hints search input badge — not drawn; the overlay manager reports
+3. Hints search input badge — not drawn; the overlay manager reports
    `CodeNotSupported` and the query goes on reaching hints through the event
    tap's key stream
-5. Screen capture — no code path anywhere in the tree. Prerequisite for the OCR
+4. Screen capture — no code path anywhere in the tree. Prerequisite for the OCR
    strategy below and the missing half of `ports.Vision`. Take it per backend:
    `wlr-screencopy` on wlroots, `XGetImage` on X11, the portal only for KDE
-6. `vision` hint strategy — no engine. Met by linking one through
+5. `vision` hint strategy — no engine. Met by linking one through
    `#cgo pkg-config`, as every other native dependency here is, with the engine
    added to the required Linux library list and its language data checked at
    use so a missing `tessdata` reports `CodeNotSupported` naming what is
    absent. Note the strategy is wider than OCR: macOS also runs rectangle
    detection and saliency, which no OCR engine answers, so
    `hints.vision.detect_rectangles` and the four `rectangle_*` options are
-   declared macOS-only and Linux `vision` is text-only. Needs 5
-7. X11 unmodified scroll — a scroll with no `--modifier` presses nothing, so the
+   declared macOS-only and Linux `vision` is text-only. Needs 4
+6. X11 unmodified scroll — a scroll with no `--modifier` presses nothing, so the
    `XTestFakeButtonEvent` still carries whatever the X server records the user as
    physically holding. Binding `Ctrl+J` to a plain `scroll_down` therefore sends
    ctrl+scroll for as long as ctrl is down. macOS forces the empty set onto the
    event instead; a real-key backend has no per-event field to zero, so closing
    this means reading the live key state through `XQueryKeymap` in the C bridge
-8. KDE RemoteDesktop portal grant — does not survive a daemon restart, so the
+7. KDE RemoteDesktop portal grant — does not survive a daemon restart, so the
    consent prompt returns on every start
-9. Grid virtual-pointer indicator — a no-op on Linux, while recursive grid
+8. Grid virtual-pointer indicator — a no-op on Linux, while recursive grid
    draws it on all three platforms
-10. `FocusedWindowBounds` — returns not-found on KWin, so callers silently fall
-    back to the active screen
-11. Wayland global hotkeys — a setup requirement rather than missing code: they
+9. `FocusedWindowBounds` — returns not-found on KWin, so callers silently fall
+   back to the active screen
+10. Wayland global hotkeys — a setup requirement rather than missing code: they
     need `input`-group membership and a CGO build. Failing loudly with the
     remedy, and documenting it as a first-class setup step, is the work
-12. Tail — the tray tooltip is a no-op (dbusmenu carries no such property), the
+11. Tail — the tray tooltip is a no-op (dbusmenu carries no such property), the
     tray has one icon for both running and paused states where macOS has two,
     and the `CGO_ENABLED=0` build should announce its boundary once at startup
     rather than failing feature by feature
@@ -820,10 +840,11 @@ widens.
 
 **Not Linux gaps**, and deliberately so: secure input detection and system
 cursor hide are [Platform Exclusives](#platform-exclusives); GNOME/Mutter
-Wayland and Cosmic are supported-desktop decisions, not capabilities; and X11
+Wayland and Cosmic are supported-desktop decisions, not capabilities; X11
 modifier passthrough is impossible for the display server rather than unbuilt —
 `XGrabKeyboard` is all-or-nothing and `XSendEvent` is ignored by most
-applications.
+applications; and `neru services` on a non-systemd init is a stated boundary,
+not unfinished work.
 
 **Windows**
 
@@ -837,6 +858,8 @@ applications.
 8. Horizontal scroll — `ScrollAtCursor` ignores `deltaX`
 9. `monitor_select` mode — returns `CodeNotSupported`
 10. Font resolution — alias mapping only, no system font enumeration
+11. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
+    installs a launchd agent and Linux a systemd user unit
 
 **macOS**
 

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -276,28 +276,81 @@ excluded_apps = ["firefox", "chromium-browser", "code"]
 
 ### systemd user service
 
-`neru services install/start/stop` is macOS-only. On Linux, use systemd:
+`neru services` manages the daemon for you. One command installs a systemd user
+unit, enables it for every login, and starts it now:
 
 ```bash
-mkdir -p ~/.config/systemd/user
-cat > ~/.config/systemd/user/neru.service << EOF
-[Unit]
-Description=Neru keyboard navigation daemon
-After=graphical-session.target
-PartOf=graphical-session.target
-
-[Service]
-ExecStart=%h/.local/bin/neru launch
-Restart=on-failure
-RestartSec=5
-
-[Install]
-WantedBy=graphical-session.target
-EOF
-
-systemctl --user daemon-reload
-systemctl --user enable --now neru
+neru services install
 ```
+
+The other subcommands drive the same unit:
+
+```bash
+neru services status      # installed? running? enabled at login?
+neru services stop        # stop now, still starts on next login
+neru services start
+neru services restart
+neru services uninstall   # disable and remove the unit
+```
+
+**What it writes.** `neru.service`, under `$XDG_CONFIG_HOME/systemd/user` —
+`~/.config/systemd/user` unless you set that variable to an absolute path, which
+is the same base directory Neru resolves `config.toml` from. `ExecStart` is the
+resolved path of the `neru` binary you ran `install` with, so run
+`neru services uninstall && neru services install` after moving the binary.
+Why it is anchored on `graphical-session.target`, and why other init systems are
+out of scope: ["Service management on Linux"](./CROSS_PLATFORM.md#capability-matrix).
+
+**Your session has to export itself first.** A systemd *user* manager starts
+before your compositor and inherits nothing from it, so unless the session
+imports its own variables, `neru launch` runs with no `WAYLAND_DISPLAY`,
+`DISPLAY`, `XDG_CURRENT_DESKTOP` or compositor socket, and Neru cannot find a
+display server to drive. Most desktop environments (GNOME, KDE Plasma) and
+session wrappers (`uwsm`) do this for you. A bare compositor started from a TTY
+does not — add it to your compositor config, before anything that depends on it:
+
+```
+# sway (~/.config/sway/config)
+exec systemctl --user import-environment \
+  WAYLAND_DISPLAY DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE
+exec dbus-update-activation-environment --systemd \
+  WAYLAND_DISPLAY DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE
+exec systemctl --user start graphical-session.target
+```
+
+Hyprland, niri and River take the same three lines with their own socket
+variable (`HYPRLAND_INSTANCE_SIGNATURE`, `NIRI_SOCKET`) in place of `SWAYSOCK`.
+
+**If it does not start.** `graphical-session.target` is reached only if
+something in your session activates it — the third `exec` above is what does it
+for a bare compositor. Check both:
+
+```bash
+systemctl --user status neru.service
+systemctl --user is-active graphical-session.target
+```
+
+If the target is inactive and you would rather not wire the session up, run
+`neru launch` from your compositor's autostart instead.
+
+**Other init systems.** Service management covers systemd only. On a machine
+booted by runit, OpenRC or s6, every `neru services` subcommand reports
+`ERR_NOT_SUPPORTED`; run `neru launch` from your session's own supervisor or
+autostart. This is a stated boundary rather than a missing feature — see
+[ADR 0013](./adr/0013-parity-is-measured-in-words-not-subsystems.md).
+
+**Installed through a package manager?** If Nix, home-manager or your
+distribution already ships a `neru.service`, manage it there. `neru services`
+stays out of the way in both directions: `install` refuses rather than
+overwriting a unit it did not write, and `uninstall` refuses rather than
+deleting one — a store symlink at Neru's own path, or a unit sitting elsewhere
+on systemd's search path.
+
+**Relocated `$XDG_CONFIG_HOME`?** Set it in your session, not only in a shell
+rc: the user manager fixed its unit search path at login, so a directory it
+never heard of is one it will never read. `neru services install` checks the
+manager's own search path and says so rather than writing a unit that would sit
+there unloaded.
 
 ---
 

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -339,12 +339,17 @@ booted by runit, OpenRC or s6, every `neru services` subcommand reports
 autostart. This is a stated boundary rather than a missing feature — see
 [ADR 0013](./adr/0013-parity-is-measured-in-words-not-subsystems.md).
 
-**Installed through a package manager?** If Nix, home-manager or your
-distribution already ships a `neru.service`, manage it there. `neru services`
-stays out of the way in both directions: `install` refuses rather than
+**Installed through a package manager, or wrote the unit yourself?** If Nix,
+home-manager or your distribution already ships a `neru.service` — or you wrote
+one by hand from an older version of this guide — manage it there. `neru
+services` stays out of the way in both directions: `install` refuses rather than
 overwriting a unit it did not write, and `uninstall` refuses rather than
-deleting one — a store symlink at Neru's own path, or a unit sitting elsewhere
-on systemd's search path.
+disabling or deleting one. Ownership is read out of the file rather than assumed
+from its path: every unit Neru installs opens with
+``# Installed by `neru services install` ``, and a `neru.service` without that
+line is one Neru will not touch, wherever it sits. Remove yours the way you
+created it (`systemctl --user disable --now neru.service` and delete the file),
+then `neru services install` writes Neru's own in its place.
 
 **Relocated `$XDG_CONFIG_HOME`?** Set it in your session, not only in a shell
 rc: the user manager fixed its unit search path at login, so a directory it

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -6,15 +6,19 @@ import (
 
 // ServicesCmd is the CLI services command for managing the system service.
 //
-// macOS: backed by launchd.
+// macOS: backed by a launchd user agent.
+// Linux: backed by a systemd user unit; other init systems return
+// CodeNotSupported.
 // Other platforms: stubbed and returns CodeNotSupported until implemented.
 var ServicesCmd = &cobra.Command{
 	Use:   "services",
-	Short: "Manage the Neru system service (macOS launchd)",
+	Short: "Manage the Neru system service (macOS launchd, Linux systemd)",
 	Long: `Manage the Neru system service for automatic startup on login.
 
-On macOS, this manages a launchd plist so Neru starts automatically
-when you log in. Available on macOS only.
+On macOS this manages a launchd agent, and on Linux a systemd user unit
+ordered after graphical-session.target, so Neru starts automatically once
+your graphical session is up. Linux service management covers systemd
+only; other init systems report ERR_NOT_SUPPORTED.
 
 Subcommands:
   install     Install and load the system service
@@ -29,7 +33,7 @@ Subcommands:
 var ServicesInstallCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install and load the system service",
-	Long:  `Install the Neru launchd service so it starts automatically on login. Creates the plist file and loads it with launchctl.`,
+	Long:  `Install the Neru service so it starts automatically on login: a launchd plist loaded with launchctl on macOS, a systemd user unit enabled with systemctl --user on Linux.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := installService()
 		if err != nil {
@@ -46,7 +50,7 @@ var ServicesInstallCmd = &cobra.Command{
 var ServicesUninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Unload and remove the system service",
-	Long:  `Unload the Neru launchd service and remove its plist file. Neru will no longer start automatically on login.`,
+	Long:  `Unload the Neru service and remove the file that describes it — the launchd plist on macOS, the systemd user unit on Linux. Neru will no longer start automatically on login.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := uninstallService()
 		if err != nil {
@@ -63,7 +67,7 @@ var ServicesUninstallCmd = &cobra.Command{
 var ServicesStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the system service",
-	Long:  `Start the Neru launchd service (loads the plist with launchctl). The daemon will begin running in the background.`,
+	Long:  `Start the installed Neru service. The daemon will begin running in the background.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := startService()
 		if err != nil {
@@ -80,7 +84,7 @@ var ServicesStartCmd = &cobra.Command{
 var ServicesStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop the system service",
-	Long:  `Stop the Neru launchd service (unloads the plist with launchctl). The daemon process will be terminated.`,
+	Long:  `Stop the installed Neru service. The daemon process will be terminated; the service stays installed and starts again on your next login.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := stopService()
 		if err != nil {
@@ -97,7 +101,7 @@ var ServicesStopCmd = &cobra.Command{
 var ServicesRestartCmd = &cobra.Command{
 	Use:   "restart",
 	Short: "Restart the system service",
-	Long:  `Stop then immediately start the Neru launchd service. Useful after configuration changes or to recover from an unresponsive state.`,
+	Long:  `Stop then immediately start the Neru service. Useful after configuration changes or to recover from an unresponsive state.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := restartService()
 		if err != nil {
@@ -114,7 +118,7 @@ var ServicesRestartCmd = &cobra.Command{
 var ServicesStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Check the status of the system service",
-	Long:  `Check whether the Neru launchd service is currently loaded and running. Displays the service PID if active.`,
+	Long:  `Check whether the Neru service is installed and running. A machine where it was never installed is reported as such rather than as an error.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.Println(statusService())
 

--- a/internal/cli/services_integration_linux_test.go
+++ b/internal/cli/services_integration_linux_test.go
@@ -94,6 +94,120 @@ func TestStatusService_ReportsNotInstalledWhenTheUnitIsAbsent(t *testing.T) {
 	}
 }
 
+// shadowSystemctl puts a systemctl on PATH ahead of the real one, failing for
+// the verb named in failVerb — or for every verb when that is empty — and
+// succeeding silently otherwise.
+//
+// It is what lets an unreachable or uncooperative user manager be tested
+// without one: the failures that matter here (a stale session bus, a manager
+// that never started) cannot be provoked on a working machine, and the
+// alternative — driving the real manager into a failure — is exactly what a
+// test must not do to a developer's session.
+func shadowSystemctl(t *testing.T, failVerb string) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	const script = `#!/bin/sh
+for arg in "$@"; do
+	if [ -z "$NERU_FAKE_SYSTEMCTL_FAIL" ] || [ "$arg" = "$NERU_FAKE_SYSTEMCTL_FAIL" ]; then
+		echo "fake systemctl: cannot $arg" >&2
+		exit 1
+	fi
+done
+exit 0
+`
+
+	err := os.WriteFile(filepath.Join(dir, "systemctl"), []byte(script), 0o755)
+	if err != nil {
+		t.Fatalf("WriteFile(systemctl) error = %v", err)
+	}
+
+	t.Setenv("NERU_FAKE_SYSTEMCTL_FAIL", failVerb)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestUninstallService_ReportsSystemdFailures pins that an uninstall which did
+// not finish says so.
+//
+// A discarded `disable --now` error is an uninstall that prints success while
+// the daemon keeps running and the unit stays enabled for the next login, which
+// is the worst of the three outcomes: the user believes the machine is in a
+// state it is not in.
+func TestUninstallService_ReportsSystemdFailures(t *testing.T) {
+	requireSystemdMachine(t)
+
+	testCases := []struct {
+		name           string
+		failVerb       string
+		writeUnit      bool
+		wantErr        bool
+		wantUnitAtPath bool
+	}{
+		{
+			name:           "disable fails, so the unit file is left where it was",
+			failVerb:       "disable",
+			writeUnit:      true,
+			wantErr:        true,
+			wantUnitAtPath: true,
+		},
+		{
+			name:      "the reload after removal fails and is still reported",
+			failVerb:  "daemon-reload",
+			writeUnit: true,
+			wantErr:   true,
+		},
+		{
+			// Nothing installed anywhere: an uninstall with nothing to do stays
+			// a no-op rather than becoming an error now that failures surface.
+			name: "no unit installed, and systemd unreachable besides",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			shadowSystemctl(t, testCase.failVerb)
+
+			unitPath, err := serviceUnitPath()
+			if err != nil {
+				t.Fatalf("serviceUnitPath() error = %v", err)
+			}
+
+			if testCase.writeUnit {
+				err = os.MkdirAll(filepath.Dir(unitPath), unitDirPerm)
+				if err != nil {
+					t.Fatalf("MkdirAll() error = %v", err)
+				}
+
+				err = os.WriteFile(
+					unitPath,
+					[]byte(renderServiceUnit("/usr/local/bin/neru")),
+					unitFilePerm,
+				)
+				if err != nil {
+					t.Fatalf("WriteFile(%s) error = %v", unitPath, err)
+				}
+			}
+
+			gotErr := uninstallService()
+			if (gotErr != nil) != testCase.wantErr {
+				t.Fatalf("uninstallService() error = %v, wantErr %v", gotErr, testCase.wantErr)
+			}
+
+			_, statErr := os.Stat(unitPath)
+			if gotAtPath := statErr == nil; gotAtPath != testCase.wantUnitAtPath {
+				t.Errorf(
+					"unit present at %s = %v, want %v",
+					unitPath,
+					gotAtPath,
+					testCase.wantUnitAtPath,
+				)
+			}
+		})
+	}
+}
+
 // TestInstallService_RoundTripsThroughSystemd is the end-to-end claim: the unit
 // Neru writes is one systemd accepts, enables and forgets again.
 //

--- a/internal/cli/services_integration_linux_test.go
+++ b/internal/cli/services_integration_linux_test.go
@@ -1,0 +1,192 @@
+//go:build integration && linux
+
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// requireSystemdMachine skips unless systemd booted this machine, which is the
+// only configuration `neru services` claims on Linux.
+func requireSystemdMachine(t *testing.T) {
+	t.Helper()
+
+	if !systemdIsInit(systemdRuntimeMarker) {
+		t.Skip("skipping: this machine was not booted by systemd")
+	}
+}
+
+// requireNoExistingUnit skips when the machine already has a neru.service, so a
+// test never disturbs a real installation.
+func requireNoExistingUnit(t *testing.T, unitPath string) {
+	t.Helper()
+
+	if serviceUnitExists(unitPath) {
+		t.Skip("skipping: this machine already has a neru.service user unit")
+	}
+}
+
+// TestRenderServiceUnit_IsAcceptedBySystemdAnalyze parses the unit Neru writes
+// with systemd's own parser.
+//
+// Every other test here can pass while the unit is subtly wrong — a directive
+// spelled the way the documentation spells the concept rather than the way
+// systemd spells the key is accepted by every string comparison and ignored by
+// systemd. `systemd-analyze verify` is the only reader whose opinion counts,
+// and it reports an unparsed directive on stderr while still exiting 0, so the
+// diagnostics are the assertion rather than the exit status.
+func TestRenderServiceUnit_IsAcceptedBySystemdAnalyze(t *testing.T) {
+	analyze, err := exec.LookPath("systemd-analyze")
+	if err != nil {
+		t.Skip("skipping: systemd-analyze is not installed")
+	}
+
+	// The verifier resolves ExecStart, so the unit points at a binary that
+	// really exists — the test binary itself.
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() error = %v", err)
+	}
+
+	unitPath := filepath.Join(t.TempDir(), serviceUnitName)
+
+	err = os.WriteFile(unitPath, []byte(renderServiceUnit(binary)), unitFilePerm)
+	if err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", unitPath, err)
+	}
+
+	output, err := exec.CommandContext(t.Context(), analyze, "verify", unitPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("systemd-analyze verify error = %v, output:\n%s", err, output)
+	}
+
+	if diagnostics := strings.TrimSpace(string(output)); diagnostics != "" {
+		t.Errorf("systemd-analyze verify reported diagnostics:\n%s", diagnostics)
+	}
+}
+
+// TestStatusService_ReportsNotInstalledWhenTheUnitIsAbsent pins the acceptance
+// criterion that matters most on a fresh machine: asking about a service nobody
+// installed is answered, not refused.
+func TestStatusService_ReportsNotInstalledWhenTheUnitIsAbsent(t *testing.T) {
+	requireSystemdMachine(t)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	unitPath, err := serviceUnitPath()
+	if err != nil {
+		t.Fatalf("serviceUnitPath() error = %v", err)
+	}
+
+	requireNoExistingUnit(t, unitPath)
+
+	status := statusService()
+	if !strings.Contains(status, "Service not installed") {
+		t.Errorf("statusService() = %q, want it to report that nothing is installed", status)
+	}
+
+	if !strings.Contains(status, unitPath) {
+		t.Errorf("statusService() = %q, want it to name %q", status, unitPath)
+	}
+}
+
+// TestInstallService_RoundTripsThroughSystemd is the end-to-end claim: the unit
+// Neru writes is one systemd accepts, enables and forgets again.
+//
+// It installs a real user unit and starts it, so it belongs to the tier that is
+// allowed to take the machine over. The unit it installs points at the test
+// binary, which exits immediately — the round trip is about systemd accepting
+// and enabling the unit, not about the daemon staying up.
+func TestInstallService_RoundTripsThroughSystemd(t *testing.T) {
+	if os.Getenv("NERU_DESKTOP_TESTS") == "" {
+		t.Skip("skipping machine-modifying test; run `just test-desktop` to include it")
+	}
+
+	requireSystemdMachine(t)
+
+	// A machine systemd booted still need not have a *user* manager reachable
+	// from this session — CI runners routinely do not — and every step below
+	// talks to one.
+	_, reachErr := systemctl("list-units", "--type=service")
+	if reachErr != nil {
+		t.Skip("skipping: no systemd user manager is reachable from this session")
+	}
+
+	unitPath, err := serviceUnitPath()
+	if err != nil {
+		t.Fatalf("serviceUnitPath() error = %v", err)
+	}
+
+	requireNoExistingUnit(t, unitPath)
+
+	t.Cleanup(func() {
+		uninstallErr := uninstallService()
+		if uninstallErr != nil {
+			t.Errorf("uninstallService() error = %v", uninstallErr)
+		}
+
+		_, statErr := os.Stat(unitPath)
+		if !os.IsNotExist(statErr) {
+			t.Errorf(
+				"unit file still present at %s after uninstall (stat error = %v)",
+				unitPath,
+				statErr,
+			)
+		}
+
+		status := statusService()
+		if !strings.Contains(status, "Service not installed") {
+			t.Errorf(
+				"statusService() after uninstall = %q, want it to report nothing installed",
+				status,
+			)
+		}
+	})
+
+	err = installService()
+	if err != nil {
+		t.Fatalf("installService() error = %v", err)
+	}
+
+	_, statErr := os.Stat(unitPath)
+	if statErr != nil {
+		t.Fatalf("unit file missing at %s after install: %v", unitPath, statErr)
+	}
+
+	enabled := systemctlWord("is-enabled")
+	if enabled != "enabled" {
+		t.Errorf("is-enabled = %q, want %q", enabled, "enabled")
+	}
+
+	status := statusService()
+	if !strings.Contains(status, "Service installed") {
+		t.Errorf("statusService() = %q, want it to report an installed unit", status)
+	}
+
+	reinstallErr := installService()
+	if reinstallErr == nil {
+		t.Error("installService() on top of an existing unit succeeded, want a refusal")
+	}
+
+	// The three verbs that only forward to systemctl. They are checked against
+	// the installed unit rather than for a resulting run state: the unit points
+	// at the test binary, which exits as soon as it is started, so what is being
+	// claimed here is that systemd accepts each job.
+	for _, verb := range []struct {
+		name string
+		call func() error
+	}{
+		{name: "stop", call: stopService},
+		{name: "start", call: startService},
+		{name: "restart", call: restartService},
+	} {
+		verbErr := verb.call()
+		if verbErr != nil {
+			t.Errorf("%sService() error = %v", verb.name, verbErr)
+		}
+	}
+}

--- a/internal/cli/services_internal_linux_test.go
+++ b/internal/cli/services_internal_linux_test.go
@@ -111,7 +111,21 @@ func TestRequireOwnUnit_RefusesAUnitNeruDidNotWrite(t *testing.T) {
 
 	ownUnit := filepath.Join(dir, "own.service")
 
-	err := os.WriteFile(ownUnit, []byte("[Unit]\n"), 0o600)
+	err := os.WriteFile(ownUnit, []byte(renderServiceUnit("/usr/local/bin/neru")), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// A unit somebody wrote by hand at Neru's own path — the snippet the setup
+	// guide told users to write before `neru services` could do it for them.
+	// Nothing but its contents tells it apart from one Neru installed.
+	handWrittenUnit := filepath.Join(dir, "hand-written.service")
+
+	err = os.WriteFile(
+		handWrittenUnit,
+		[]byte("[Unit]\nDescription=neru\n\n[Service]\nExecStart=/usr/local/bin/neru launch\n"),
+		0o600,
+	)
 	if err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
@@ -131,6 +145,12 @@ func TestRequireOwnUnit_RefusesAUnitNeruDidNotWrite(t *testing.T) {
 		wantErr        bool
 	}{
 		{name: "a file Neru wrote", unitPath: ownUnit, knownToSystemd: true},
+		{
+			name:           "a regular file carrying no marker of Neru's",
+			unitPath:       handWrittenUnit,
+			knownToSystemd: true,
+			wantErr:        true,
+		},
 		{
 			name:           "a package manager's symlink",
 			unitPath:       linkedUnit,

--- a/internal/cli/services_internal_linux_test.go
+++ b/internal/cli/services_internal_linux_test.go
@@ -280,10 +280,70 @@ func TestRenderServiceUnit_AnchorsOnTheGraphicalSession(t *testing.T) {
 		"After=graphical-session.target",
 		"PartOf=graphical-session.target",
 		"WantedBy=graphical-session.target",
-		"ExecStart=/usr/local/bin/neru launch",
+		`ExecStart="/usr/local/bin/neru" launch`,
 	} {
 		if !strings.Contains(unit, want) {
 			t.Errorf("rendered unit is missing %q:\n%s", want, unit)
 		}
+	}
+}
+
+// TestRenderServiceUnit_EscapesTheExecutablePath pins that the path systemd
+// executes is the path Neru was run from, byte for byte, whatever is in it.
+//
+// The two characters that matter are not exotic: a space makes systemd read one
+// path as a command plus an argument, and a percent makes it resolve a
+// specifier — %h expands, and a specifier systemd does not know fails the whole
+// unit load.
+func TestRenderServiceUnit_EscapesTheExecutablePath(t *testing.T) {
+	testCases := []struct {
+		name       string
+		binaryPath string
+		want       string
+	}{
+		{
+			name:       "an ordinary path is quoted and otherwise untouched",
+			binaryPath: "/usr/local/bin/neru",
+			want:       `ExecStart="/usr/local/bin/neru" launch`,
+		},
+		{
+			name:       "a space stays one path instead of becoming two words",
+			binaryPath: "/opt/my apps/neru",
+			want:       `ExecStart="/opt/my apps/neru" launch`,
+		},
+		{
+			name:       "a percent is written as the literal systemd reads back",
+			binaryPath: "/opt/100%/neru",
+			want:       `ExecStart="/opt/100%%/neru" launch`,
+		},
+		{
+			name:       "a specifier systemd knows is not left for it to expand",
+			binaryPath: "/home/%h/bin/neru",
+			want:       `ExecStart="/home/%%h/bin/neru" launch`,
+		},
+		{
+			name:       "a backslash is escaped, since quoting turns it into one",
+			binaryPath: `/opt/we\ird/neru`,
+			want:       `ExecStart="/opt/we\\ird/neru" launch`,
+		},
+		{
+			name:       "a double quote is escaped rather than closing the quoting",
+			binaryPath: `/opt/"quoted"/neru`,
+			want:       `ExecStart="/opt/\"quoted\"/neru" launch`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			unit := renderServiceUnit(testCase.binaryPath)
+			if !strings.Contains(unit, testCase.want) {
+				t.Errorf(
+					"renderServiceUnit(%q) is missing %q:\n%s",
+					testCase.binaryPath,
+					testCase.want,
+					unit,
+				)
+			}
+		})
 	}
 }

--- a/internal/cli/services_internal_linux_test.go
+++ b/internal/cli/services_internal_linux_test.go
@@ -1,0 +1,289 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+const (
+	// testHome and testDefaultUnitPath stand in for a machine that never set
+	// $XDG_CONFIG_HOME.
+	testHome            = "/home/tester"
+	testDefaultUnitPath = testHome + "/.config/systemd/user/neru.service"
+)
+
+func TestSystemdIsInit_ReadsTheRuntimeMarker(t *testing.T) {
+	runtimeDir := t.TempDir()
+
+	regularFile := filepath.Join(runtimeDir, "file")
+
+	err := os.WriteFile(regularFile, nil, 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	testCases := []struct {
+		name   string
+		marker string
+		want   bool
+	}{
+		{name: "marker directory present", marker: runtimeDir, want: true},
+		{name: "marker absent", marker: filepath.Join(runtimeDir, "absent"), want: false},
+		{name: "marker is a regular file", marker: regularFile, want: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := systemdIsInit(testCase.marker); got != testCase.want {
+				t.Errorf("systemdIsInit(%q) = %v, want %v", testCase.marker, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestErrNotSystemd_NamesSystemdAndTheDocs(t *testing.T) {
+	err := errNotSystemd("install")
+
+	if !derrors.IsNotSupported(err) {
+		t.Fatalf("errNotSystemd() code = %v, want %v", err, derrors.CodeNotSupported)
+	}
+
+	message := err.Error()
+	for _, want := range []string{"install", "systemd", "runit", "docs/LINUX_SETUP.md"} {
+		if !strings.Contains(message, want) {
+			t.Errorf("errNotSystemd() message = %q, want it to mention %q", message, want)
+		}
+	}
+}
+
+func TestServiceUnitPath_HonorsXDGConfigHome(t *testing.T) {
+	testCases := []struct {
+		name          string
+		xdgConfigHome string
+		home          string
+		want          string
+	}{
+		{
+			name:          "absolute XDG_CONFIG_HOME wins",
+			xdgConfigHome: "/var/tmp/xdg",
+			home:          testHome,
+			want:          "/var/tmp/xdg/systemd/user/neru.service",
+		},
+		{
+			name:          "unset falls back to ~/.config",
+			xdgConfigHome: "",
+			home:          testHome,
+			want:          testDefaultUnitPath,
+		},
+		{
+			name:          "relative XDG_CONFIG_HOME is ignored per the spec",
+			xdgConfigHome: "relative/config",
+			home:          testHome,
+			want:          testDefaultUnitPath,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", testCase.xdgConfigHome)
+			t.Setenv("HOME", testCase.home)
+
+			got, err := serviceUnitPath()
+			if err != nil {
+				t.Fatalf("serviceUnitPath() error = %v", err)
+			}
+
+			if got != testCase.want {
+				t.Errorf("serviceUnitPath() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestRequireOwnUnit_RefusesAUnitNeruDidNotWrite(t *testing.T) {
+	dir := t.TempDir()
+
+	ownUnit := filepath.Join(dir, "own.service")
+
+	err := os.WriteFile(ownUnit, []byte("[Unit]\n"), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// What nix and home-manager leave at the same path: a link into the store.
+	linkedUnit := filepath.Join(dir, "linked.service")
+
+	err = os.Symlink("/nix/store/whatever/neru.service", linkedUnit)
+	if err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	testCases := []struct {
+		name           string
+		unitPath       string
+		knownToSystemd bool
+		wantErr        bool
+	}{
+		{name: "a file Neru wrote", unitPath: ownUnit, knownToSystemd: true},
+		{
+			name:           "a package manager's symlink",
+			unitPath:       linkedUnit,
+			knownToSystemd: true,
+			wantErr:        true,
+		},
+		{
+			name:           "absent here, but systemd knows one elsewhere",
+			unitPath:       filepath.Join(dir, "absent.service"),
+			knownToSystemd: true,
+			wantErr:        true,
+		},
+		{
+			name:     "nothing installed anywhere",
+			unitPath: filepath.Join(dir, "absent.service"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			gotErr := requireOwnUnit(testCase.unitPath, testCase.knownToSystemd)
+			if (gotErr != nil) != testCase.wantErr {
+				t.Errorf(
+					"requireOwnUnit(%q, %v) error = %v, wantErr %v",
+					testCase.unitPath,
+					testCase.knownToSystemd,
+					gotErr,
+					testCase.wantErr,
+				)
+			}
+		})
+	}
+}
+
+func TestUnitDirIsScanned_MatchesWholeDirectories(t *testing.T) {
+	// One real `systemctl --user show -p UnitPath --value` answer, trimmed.
+	const searchPath = "/home/tester/.config/systemd/user.control " +
+		"/home/tester/.config/systemd/user /etc/systemd/user " +
+		"/usr/local/share/systemd/user /usr/lib/systemd/user"
+
+	testCases := []struct {
+		name    string
+		unitDir string
+		want    bool
+	}{
+		{name: "listed directory", unitDir: "/home/tester/.config/systemd/user", want: true},
+		{
+			name:    "listed, written unclean",
+			unitDir: "/home/tester/.config/systemd/user/",
+			want:    true,
+		},
+		{
+			name:    "relocated XDG the manager never saw",
+			unitDir: "/srv/cfg/systemd/user",
+			want:    false,
+		},
+		{
+			name:    "prefix of a listed directory is not a match",
+			unitDir: "/home/tester/.config",
+			want:    false,
+		},
+		{
+			// A space in the name makes the search path ambiguous, and an
+			// ambiguous answer must not refuse an install that would work.
+			name:    "directory with a space gets the benefit of the doubt",
+			unitDir: "/srv/my configs/systemd/user",
+			want:    false,
+		},
+		{
+			name:    "directory with a space that the search path does contain",
+			unitDir: "/home/tester/.config/systemd/user /etc",
+			want:    true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := unitDirIsScanned(testCase.unitDir, searchPath)
+			if got != testCase.want {
+				t.Errorf("unitDirIsScanned(%q) = %v, want %v", testCase.unitDir, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestDescribeServiceStatus_NamesEveryState(t *testing.T) {
+	const docsURL = "https://example.invalid/LINUX_SETUP.md"
+
+	unitPath := testDefaultUnitPath
+
+	testCases := []struct {
+		name  string
+		state serviceUnitState
+		want  string
+	}{
+		{
+			name:  "no systemd on the machine",
+			state: serviceUnitState{unitPath: unitPath},
+			want: "Service management requires systemd; this machine was not " +
+				"booted by systemd, so there is no user unit to report on — see " +
+				docsURL,
+		},
+		{
+			name:  "systemd, but the unit was never installed",
+			state: serviceUnitState{systemdBooted: true, unitPath: unitPath},
+			want: "Service not installed: no unit at " + unitPath +
+				" — run `neru services install` to create it",
+		},
+		{
+			name: "installed, running and enabled",
+			state: serviceUnitState{
+				systemdBooted: true,
+				installed:     true,
+				unitPath:      unitPath,
+				active:        "active",
+				enabled:       "enabled",
+			},
+			want: "Service installed: active, enabled at login",
+		},
+		{
+			name: "installed, stopped and not enabled",
+			state: serviceUnitState{
+				systemdBooted: true,
+				installed:     true,
+				unitPath:      unitPath,
+				active:        "inactive",
+				enabled:       "disabled",
+			},
+			want: "Service installed: inactive, disabled at login",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := describeServiceStatus(testCase.state, docsURL)
+			if got != testCase.want {
+				t.Errorf("describeServiceStatus() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestRenderServiceUnit_AnchorsOnTheGraphicalSession(t *testing.T) {
+	unit := renderServiceUnit("/usr/local/bin/neru")
+
+	for _, want := range []string{
+		"After=graphical-session.target",
+		"PartOf=graphical-session.target",
+		"WantedBy=graphical-session.target",
+		"ExecStart=/usr/local/bin/neru launch",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("rendered unit is missing %q:\n%s", want, unit)
+		}
+	}
+}

--- a/internal/cli/services_linux.go
+++ b/internal/cli/services_linux.go
@@ -442,14 +442,32 @@ func uninstallService() error {
 		return err
 	}
 
-	err = requireOwnUnit(unitPath, serviceUnitExists(unitPath))
+	installed := serviceUnitExists(unitPath)
+
+	err = requireOwnUnit(unitPath, installed)
 	if err != nil {
 		return err
 	}
 
-	// Best effort: a unit that was never enabled, or a user manager that has
-	// already forgotten it, must not stop the file from being removed.
-	_, _ = systemctl("disable", "--now", serviceUnitName)
+	// Nothing to uninstall is not a failure, and it is the one case where there
+	// is no unit for systemd to be asked about — asking anyway would fail on a
+	// unit that does not exist and turn a no-op into an error.
+	if !installed {
+		return nil
+	}
+
+	// Everything past here is reported rather than swallowed. `disable --now`
+	// is idempotent over a unit that was never enabled or is already stopped,
+	// so a failure here is a real one — an unreachable user manager, usually —
+	// and hiding it would leave the daemon running and the unit still enabled
+	// for the next login while the CLI printed success.
+	err = runSystemctl(
+		"stop and disable the service (the unit file at "+unitPath+" was left in place)",
+		"disable", "--now", serviceUnitName,
+	)
+	if err != nil {
+		return err
+	}
 
 	err = os.Remove(unitPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -460,9 +478,11 @@ func uninstallService() error {
 		)
 	}
 
-	_, _ = systemctl("daemon-reload")
-
-	return nil
+	return runSystemctl(
+		"reload the systemd user manager after removing "+unitPath+
+			" (run `systemctl --user daemon-reload` once it is reachable)",
+		"daemon-reload",
+	)
 }
 
 // driveService is start, stop and restart, which are the three subcommands

--- a/internal/cli/services_linux.go
+++ b/internal/cli/services_linux.go
@@ -72,7 +72,32 @@ WantedBy=graphical-session.target
 // renderServiceUnit fills the unit template with the absolute path of the
 // binary that is installing itself.
 func renderServiceUnit(binaryPath string) string {
-	return strings.ReplaceAll(serviceUnitTemplate, "NERU_BINARY_PATH", binaryPath)
+	return strings.ReplaceAll(
+		serviceUnitTemplate,
+		"NERU_BINARY_PATH",
+		systemdQuoteExecPath(binaryPath),
+	)
+}
+
+// systemdQuoteExecPath spells a filesystem path the way an Exec line reads one
+// back unchanged.
+//
+// A Linux path may hold any byte but / and NUL, and two of them are load
+// bearing to systemd. Whitespace splits an Exec line into words, so
+// /opt/my apps/neru would be read as the command /opt/my with the argument
+// apps/neru; double quotes are what hold it together, and inside them a
+// backslash opens a C-style escape, so a literal backslash or quote has to
+// double up. A percent opens a specifier, which is resolved before the line is
+// split and regardless of quoting — %h would silently become the home
+// directory, %y would fail the unit load — and %% is the literal one.
+func systemdQuoteExecPath(path string) string {
+	escaped := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		`%`, `%%`,
+	).Replace(path)
+
+	return `"` + escaped + `"`
 }
 
 // systemdIsInit reports whether systemd booted this machine, by the presence of

--- a/internal/cli/services_linux.go
+++ b/internal/cli/services_linux.go
@@ -1,0 +1,511 @@
+//go:build linux
+
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/buildinfo"
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// Service management on Linux is a systemd user unit, and only that. Neru is a
+// per-session daemon that needs a display server, so it belongs to the user
+// manager rather than the system one, and the graphical session is what it is
+// ordered against. Other init systems refuse loudly and name systemd
+// (docs/adr/0013-parity-is-measured-in-words-not-subsystems.md).
+const (
+	// serviceUnitName is the unit systemd knows Neru by. It is also what a user
+	// types into every `systemctl --user` command they run by hand, so it stays
+	// the plain program name rather than a reverse-DNS label.
+	serviceUnitName = "neru.service"
+
+	// systemdRuntimeMarker is the directory systemd creates when it is PID 1.
+	// It is what sd_booted(3) checks, and the only reliable answer to "is this
+	// a systemd machine" — `systemctl` sitting on PATH says nothing, since the
+	// binary ships in packages installed on machines running another init.
+	systemdRuntimeMarker = "/run/systemd/system"
+
+	// linuxServicesDocs is the page a user is sent to when service management
+	// cannot help them.
+	linuxServicesDocs = "docs/LINUX_SETUP.md"
+
+	unitDirPerm  = 0o755
+	unitFilePerm = 0o644
+)
+
+// systemctlTimeout bounds every call to the user manager. `enable --now` starts
+// a Type=simple service, so nothing here legitimately waits on the daemon
+// coming up; the budget is for `daemon-reload` on a busy machine.
+const systemctlTimeout = 15 * time.Second
+
+// serviceUnitTemplate is the systemd user unit Neru installs.
+//
+// The anchor is graphical-session.target rather than default.target: every
+// Linux backend needs a display server, so starting before one exists would
+// only produce a crash loop. After= orders it behind the session, WantedBy=
+// starts it with each new session, and PartOf= stops it when that session ends
+// — together they are what makes the unit survive a logout/login cycle rather
+// than linger as an orphan attached to a display that is gone.
+const serviceUnitTemplate = `[Unit]
+Description=Neru keyboard-driven mouse replacement daemon
+Documentation=https://github.com/y3owk1n/neru
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=NERU_BINARY_PATH launch
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target
+`
+
+// renderServiceUnit fills the unit template with the absolute path of the
+// binary that is installing itself.
+func renderServiceUnit(binaryPath string) string {
+	return strings.ReplaceAll(serviceUnitTemplate, "NERU_BINARY_PATH", binaryPath)
+}
+
+// systemdIsInit reports whether systemd booted this machine, by the presence of
+// its runtime marker directory.
+func systemdIsInit(markerDir string) bool {
+	info, err := os.Stat(markerDir)
+
+	return err == nil && info.IsDir()
+}
+
+// errNotSystemd is the refusal every subcommand returns on a machine systemd
+// did not boot. Neru manages a systemd user unit and nothing else, so the
+// message names the one init system that is supported instead of implying the
+// operation might work after some setup.
+func errNotSystemd(action string) error {
+	return derrors.Newf(
+		derrors.CodeNotSupported,
+		"services %s manages a systemd user unit, and this machine was not booted "+
+			"by systemd; other init systems (runit, OpenRC, s6) are not supported — "+
+			"start `neru launch` from your session or supervisor instead, see %s",
+		action,
+		buildinfo.DocsURL(linuxServicesDocs, buildinfo.Version),
+	)
+}
+
+// requireSystemd is the first line of every subcommand.
+func requireSystemd(action string) error {
+	if !systemdIsInit(systemdRuntimeMarker) {
+		return errNotSystemd(action)
+	}
+
+	return nil
+}
+
+// serviceUnitPath is where the unit file is written: the systemd user unit
+// directory under the XDG config home the daemon already honors, so a user who
+// relocated $XDG_CONFIG_HOME finds the unit beside their config rather than in
+// a second place nothing else in Neru uses.
+func serviceUnitPath() (string, error) {
+	configHome, err := xdgConfigHome()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(configHome, "systemd", "user", serviceUnitName), nil
+}
+
+// xdgConfigHome resolves $XDG_CONFIG_HOME per the Base Directory specification:
+// the variable wins only when it is set to an absolute path — a relative value
+// must be ignored — and otherwise the default is ~/.config.
+func xdgConfigHome() (string, error) {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); filepath.IsAbs(dir) {
+		return dir, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, ".config"), nil
+}
+
+// getBinaryPath resolves the running binary to a real path, because a unit file
+// outlives whatever PATH or symlink the install was run through.
+func getBinaryPath() (string, error) {
+	execPath, err := os.Executable()
+	if err != nil {
+		return "", derrors.Wrap(err, derrors.CodeConfigIOFailed, "failed to locate the neru binary")
+	}
+
+	resolved, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return "", derrors.Wrap(
+			err,
+			derrors.CodeConfigIOFailed,
+			"failed to resolve the neru binary path",
+		)
+	}
+
+	return resolved, nil
+}
+
+// systemctl runs a `systemctl --user` subcommand, returning its combined output
+// so a failure can quote systemd's own explanation instead of an exit code.
+func systemctl(args ...string) (string, error) {
+	// A user manager that has gone away — a stale DBUS_SESSION_BUS_ADDRESS
+	// inherited over SSH is the usual way — leaves systemctl waiting on a bus
+	// that will never answer. `status` is the subcommand a person runs when
+	// things are already broken, so it has to come back with something.
+	ctx, cancel := context.WithTimeout(context.Background(), systemctlTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "systemctl", append([]string{"--user"}, args...)...)
+
+	output, err := cmd.CombinedOutput()
+
+	return strings.TrimSpace(string(output)), err
+}
+
+// runSystemctl is systemctl for the callers that only need the error, with
+// systemd's own explanation folded into it. attempt reads as the tail of
+// "failed to …", so it is a verb phrase rather than a single word.
+func runSystemctl(attempt string, args ...string) error {
+	output, err := systemctl(args...)
+	if err == nil {
+		return nil
+	}
+
+	if output == "" {
+		return derrors.Wrapf(err, derrors.CodeExecFailed, "failed to %s", attempt)
+	}
+
+	return derrors.Wrapf(err, derrors.CodeExecFailed, "failed to %s: %s", attempt, output)
+}
+
+// serviceUnitExists reports whether a neru.service user unit exists at all: the
+// one Neru writes, or one a package manager (nix, home-manager, a distribution
+// package) placed on systemd's search path. `systemctl --user cat` is what
+// answers the second, and it is also what fails when there is no user manager
+// to ask — which is why the file check comes first.
+func serviceUnitExists(unitPath string) bool {
+	_, statErr := os.Stat(unitPath)
+	if statErr == nil {
+		return true
+	}
+
+	_, catErr := systemctl("cat", serviceUnitName)
+
+	return catErr == nil
+}
+
+func installService() error {
+	err := requireSystemd("install")
+	if err != nil {
+		return err
+	}
+
+	unitPath, err := serviceUnitPath()
+	if err != nil {
+		return err
+	}
+
+	if serviceUnitExists(unitPath) {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"a %s user unit already exists (Neru's own lives at %s); "+
+				"uninstall it — or the package manager installation that provides it, "+
+				"such as nix or home-manager — before installing again",
+			serviceUnitName,
+			unitPath,
+		)
+	}
+
+	err = requireScannedUnitDir(filepath.Dir(unitPath))
+	if err != nil {
+		return err
+	}
+
+	binPath, err := getBinaryPath()
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(filepath.Dir(unitPath), unitDirPerm)
+	if err != nil {
+		return derrors.Wrap(
+			err,
+			derrors.CodeConfigIOFailed,
+			"failed to create the systemd user unit directory",
+		)
+	}
+
+	err = os.WriteFile(unitPath, []byte(renderServiceUnit(binPath)), unitFilePerm)
+	if err != nil {
+		return derrors.Wrap(
+			err,
+			derrors.CodeConfigIOFailed,
+			"failed to write the systemd user unit",
+		)
+	}
+
+	// A unit file systemd never accepted is worse than no unit file: it blocks
+	// the next install and starts nothing, so the write is undone — and the
+	// manager told about the removal, or it goes on holding a unit whose file
+	// is gone.
+	err = enableService()
+	if err != nil {
+		_ = os.Remove(unitPath)
+		_, _ = systemctl("daemon-reload")
+
+		return err
+	}
+
+	return nil
+}
+
+// requireScannedUnitDir refuses an install into a directory the user manager
+// will not read.
+//
+// The manager fixed its unit search path from its own environment when the
+// session began. A $XDG_CONFIG_HOME exported in a shell rc afterwards moves
+// where Neru writes without moving where systemd looks, and the symptom —
+// `enable` reporting that a unit just written does not exist — names neither
+// half of the mismatch. Asking the manager for its search path turns that into
+// one sentence. A manager that cannot be reached at all answers nothing, and
+// the install proceeds so that `enable` is what reports it.
+func requireScannedUnitDir(unitDir string) error {
+	searchPath, err := systemctl("show", "--property=UnitPath", "--value")
+	if err != nil {
+		return nil //nolint:nilerr // no manager to ask; enable is what reports it
+	}
+
+	if unitDirIsScanned(unitDir, searchPath) {
+		return nil
+	}
+
+	return derrors.Newf(
+		derrors.CodeInvalidInput,
+		"systemd's user manager does not scan %s, so a unit written there would never "+
+			"load; its search path was fixed when your session started, and "+
+			"$XDG_CONFIG_HOME is %q in this shell. Unset it here, or export it in your "+
+			"session and run `systemctl --user import-environment XDG_CONFIG_HOME` "+
+			"followed by `systemctl --user daemon-reexec`",
+		unitDir,
+		os.Getenv("XDG_CONFIG_HOME"),
+	)
+}
+
+// unitDirIsScanned reports whether dir appears in a `systemctl show -p UnitPath`
+// answer, which is the search path spelled as space-separated directories.
+//
+// That spelling has no escaping, so a directory whose own name contains a space
+// cannot be told from two directories. There the substring hit is inconclusive
+// rather than a match — and an inconclusive answer says yes, because refusing an
+// install that would have worked is the worse of the two mistakes.
+func unitDirIsScanned(unitDir, searchPath string) bool {
+	cleaned := filepath.Clean(unitDir)
+	if slices.Contains(strings.Fields(searchPath), cleaned) {
+		return true
+	}
+
+	return strings.Contains(cleaned, " ") && strings.Contains(searchPath, cleaned)
+}
+
+// requireOwnUnit is the mirror of install's refusal, on the way back out: it
+// stops `uninstall` from disabling or deleting a neru.service somebody else
+// owns.
+//
+// Neru's own installs are a plain file it wrote. Nix and home-manager put a
+// symlink into the store at the same path, and a distribution package puts a
+// real unit somewhere else on the search path entirely — deleting the first and
+// disabling the second both look like success while breaking a setup Neru does
+// not manage. knownToSystemd says whether the manager can resolve a
+// neru.service at all, which is the only way to tell "nothing installed" (fine,
+// uninstall is a no-op) from "installed elsewhere" (refuse).
+func requireOwnUnit(unitPath string, knownToSystemd bool) error {
+	info, err := os.Lstat(unitPath)
+	if err != nil {
+		if knownToSystemd {
+			return derrors.Newf(
+				derrors.CodeInvalidInput,
+				"a %s user unit exists, but not at %s, so Neru did not install it; "+
+					"remove it through whatever put it on systemd's search path "+
+					"(a distribution package, nix, or home-manager)",
+				serviceUnitName,
+				unitPath,
+			)
+		}
+
+		return nil
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"%s is a symlink, so Neru did not write it — a package manager such as "+
+				"nix or home-manager did; disable the service there instead",
+			unitPath,
+		)
+	}
+
+	return nil
+}
+
+// enableService is the half of install that talks to systemd: reload so the new
+// file is seen, then enable --now so it starts in this session and in every
+// session after it.
+func enableService() error {
+	err := runSystemctl("reload the systemd user manager", "daemon-reload")
+	if err != nil {
+		return err
+	}
+
+	return runSystemctl("enable the service", "enable", "--now", serviceUnitName)
+}
+
+func uninstallService() error {
+	err := requireSystemd("uninstall")
+	if err != nil {
+		return err
+	}
+
+	unitPath, err := serviceUnitPath()
+	if err != nil {
+		return err
+	}
+
+	err = requireOwnUnit(unitPath, serviceUnitExists(unitPath))
+	if err != nil {
+		return err
+	}
+
+	// Best effort: a unit that was never enabled, or a user manager that has
+	// already forgotten it, must not stop the file from being removed.
+	_, _ = systemctl("disable", "--now", serviceUnitName)
+
+	err = os.Remove(unitPath)
+	if err != nil && !os.IsNotExist(err) {
+		return derrors.Wrap(
+			err,
+			derrors.CodeConfigIOFailed,
+			"failed to remove the systemd user unit",
+		)
+	}
+
+	_, _ = systemctl("daemon-reload")
+
+	return nil
+}
+
+// driveService is start, stop and restart, which are the three subcommands
+// whose name is also the systemctl verb — so the word is written once rather
+// than three times per subcommand.
+func driveService(verb string) error {
+	err := requireSystemd(verb)
+	if err != nil {
+		return err
+	}
+
+	return runSystemctl(verb+" the service", verb, serviceUnitName)
+}
+
+func startService() error {
+	return driveService("start")
+}
+
+func stopService() error {
+	return driveService("stop")
+}
+
+func restartService() error {
+	return driveService("restart")
+}
+
+// serviceUnitState is everything `neru services status` reports, gathered
+// before any of it is put into words. Keeping the two apart is what lets the
+// wording be tested on a machine with no systemd to ask.
+type serviceUnitState struct {
+	// systemdBooted is false on a machine running another init, where nothing
+	// below can be true.
+	systemdBooted bool
+	// installed is whether a neru.service user unit exists at all — ours, or
+	// one a package manager placed on systemd's search path.
+	installed bool
+	// unitPath is where Neru writes its unit, whether or not it is there yet.
+	unitPath string
+	// active and enabled are systemctl's own words ("active", "inactive",
+	// "failed"; "enabled", "disabled", "static"), passed through rather than
+	// translated so they match what `systemctl --user status` shows.
+	active  string
+	enabled string
+}
+
+// describeServiceStatus puts a gathered state into one line.
+//
+// A machine with no unit installed is not a failure, and neither is one systemd
+// did not boot: both are ordinary answers to "what is the service doing", so
+// they read as statements of fact with the next step attached rather than as
+// errors. `status` is the one subcommand with no error to carry a code, so the
+// non-systemd answer carries the documentation link the other five put in their
+// CodeNotSupported instead.
+func describeServiceStatus(state serviceUnitState, docsURL string) string {
+	if !state.systemdBooted {
+		return "Service management requires systemd; this machine was not " +
+			"booted by systemd, so there is no user unit to report on — see " +
+			docsURL
+	}
+
+	if !state.installed {
+		return "Service not installed: no unit at " + state.unitPath +
+			" — run `neru services install` to create it"
+	}
+
+	return "Service installed: " + state.active + ", " + state.enabled + " at login"
+}
+
+func statusService() string {
+	docsURL := buildinfo.DocsURL(linuxServicesDocs, buildinfo.Version)
+
+	unitPath, err := serviceUnitPath()
+	if err != nil {
+		return "Service status unavailable: " + err.Error()
+	}
+
+	state := serviceUnitState{
+		systemdBooted: systemdIsInit(systemdRuntimeMarker),
+		unitPath:      unitPath,
+	}
+
+	if !state.systemdBooted {
+		return describeServiceStatus(state, docsURL)
+	}
+
+	state.installed = serviceUnitExists(unitPath)
+	if !state.installed {
+		return describeServiceStatus(state, docsURL)
+	}
+
+	state.active = systemctlWord("is-active")
+	state.enabled = systemctlWord("is-enabled")
+
+	return describeServiceStatus(state, docsURL)
+}
+
+// systemctlWord reads a one-word query such as is-active or is-enabled.
+// Both exit non-zero for a perfectly ordinary answer ("inactive", "disabled"),
+// so the word on stdout is the result and the exit status is not.
+func systemctlWord(query string) string {
+	output, _ := systemctl(query, serviceUnitName)
+	if output == "" {
+		return "unknown"
+	}
+
+	return output
+}

--- a/internal/cli/services_linux.go
+++ b/internal/cli/services_linux.go
@@ -45,6 +45,14 @@ const (
 // coming up; the budget is for `daemon-reload` on a busy machine.
 const systemctlTimeout = 15 * time.Second
 
+// serviceUnitMarker is the line Neru writes into every unit it installs, and
+// the only positive evidence that a neru.service is Neru's to disable and
+// delete. The path cannot supply that evidence: the hand-written unit this
+// feature replaces — the one LINUX_SETUP.md used to spell out — sits at exactly
+// this path under exactly this name, and so does anything a user or a
+// configuration tool wrote there by the same instructions.
+const serviceUnitMarker = "# Installed by `neru services install`"
+
 // serviceUnitTemplate is the systemd user unit Neru installs.
 //
 // The anchor is graphical-session.target rather than default.target: every
@@ -53,7 +61,11 @@ const systemctlTimeout = 15 * time.Second
 // starts it with each new session, and PartOf= stops it when that session ends
 // — together they are what makes the unit survive a logout/login cycle rather
 // than linger as an orphan attached to a display that is gone.
-const serviceUnitTemplate = `[Unit]
+const serviceUnitTemplate = serviceUnitMarker + `
+# Neru rewrites this file on install and deletes it on uninstall. A neru.service
+# without the line above is one Neru leaves alone.
+
+[Unit]
 Description=Neru keyboard-driven mouse replacement daemon
 Documentation=https://github.com/y3owk1n/neru
 After=graphical-session.target
@@ -347,13 +359,16 @@ func unitDirIsScanned(unitDir, searchPath string) bool {
 // stops `uninstall` from disabling or deleting a neru.service somebody else
 // owns.
 //
-// Neru's own installs are a plain file it wrote. Nix and home-manager put a
-// symlink into the store at the same path, and a distribution package puts a
-// real unit somewhere else on the search path entirely — deleting the first and
-// disabling the second both look like success while breaking a setup Neru does
-// not manage. knownToSystemd says whether the manager can resolve a
-// neru.service at all, which is the only way to tell "nothing installed" (fine,
-// uninstall is a no-op) from "installed elsewhere" (refuse).
+// Nix and home-manager put a symlink into the store at Neru's own path, a
+// distribution package puts a real unit somewhere else on the search path
+// entirely, and a user following the setup guide that predates this feature
+// wrote a plain file at that same path by hand — deleting any of the three
+// looks like success while breaking a setup Neru does not manage. Being a
+// regular file at the right path says nothing, so ownership is read out of the
+// file: the marker line Neru writes is the one thing only an install puts
+// there. knownToSystemd says whether the manager can resolve a neru.service at
+// all, which is the only way to tell "nothing installed" (fine, uninstall is a
+// no-op) from "installed elsewhere" (refuse).
 func requireOwnUnit(unitPath string, knownToSystemd bool) error {
 	info, err := os.Lstat(unitPath)
 	if err != nil {
@@ -377,6 +392,27 @@ func requireOwnUnit(unitPath string, knownToSystemd bool) error {
 			"%s is a symlink, so Neru did not write it — a package manager such as "+
 				"nix or home-manager did; disable the service there instead",
 			unitPath,
+		)
+	}
+
+	contents, err := os.ReadFile(unitPath)
+	if err != nil {
+		return derrors.Wrapf(
+			err,
+			derrors.CodeConfigIOFailed,
+			"failed to read the systemd user unit at %s to check whether Neru wrote it",
+			unitPath,
+		)
+	}
+
+	if !strings.Contains(string(contents), serviceUnitMarker) {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"%s carries no %q line, so Neru did not write it — a hand-written unit or "+
+				"a configuration tool did; remove it there, and `neru services install` "+
+				"will write Neru's own in its place",
+			unitPath,
+			serviceUnitMarker,
 		)
 	}
 

--- a/internal/cli/services_other.go
+++ b/internal/cli/services_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 package cli
 
@@ -6,24 +6,36 @@ import (
 	"github.com/y3owk1n/neru/internal/derrors"
 )
 
+// unsupportedServices is the one sentence every subcommand says on a platform
+// with no service manager behind it. macOS drives a launchd agent and Linux a
+// systemd user unit; nothing else does, so the refusal names both rather than
+// leaving a reader to guess which platform they are missing out on.
+func unsupportedServices(action string) error {
+	return derrors.New(
+		derrors.CodeNotSupported,
+		"services "+action+" is supported on macOS (launchd) and Linux (systemd "+
+			"user units) only",
+	)
+}
+
 func installService() error {
-	return derrors.New(derrors.CodeNotSupported, "services install is only supported on macOS")
+	return unsupportedServices("install")
 }
 
 func uninstallService() error {
-	return derrors.New(derrors.CodeNotSupported, "services uninstall is only supported on macOS")
+	return unsupportedServices("uninstall")
 }
 
 func startService() error {
-	return derrors.New(derrors.CodeNotSupported, "services start is only supported on macOS")
+	return unsupportedServices("start")
 }
 
 func stopService() error {
-	return derrors.New(derrors.CodeNotSupported, "services stop is only supported on macOS")
+	return unsupportedServices("stop")
 }
 
 func restartService() error {
-	return derrors.New(derrors.CodeNotSupported, "services restart is only supported on macOS")
+	return unsupportedServices("restart")
 }
 
 func statusService() string {

--- a/internal/cli/services_stub_contract_other_test.go
+++ b/internal/cli/services_stub_contract_other_test.go
@@ -1,0 +1,54 @@
+//go:build !darwin && !linux
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// TestServicesStubsRefuseLoudly pins the fallback slot's half of the contract in
+// internal/adapter/platform/AGENTS.md: a subcommand with no service manager
+// behind it returns CodeNotSupported, never nil.
+//
+// Nothing else in the tree covers it — cli_test.go deliberately skips the
+// services subcommands because on a real platform they have side effects — so
+// without this a rewrite of the stubs could quietly start returning success.
+func TestServicesStubsRefuseLoudly(t *testing.T) {
+	testCases := []struct {
+		name string
+		call func() error
+	}{
+		{name: "install", call: installService},
+		{name: "uninstall", call: uninstallService},
+		{name: "start", call: startService},
+		{name: "stop", call: stopService},
+		{name: "restart", call: restartService},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.call()
+			if !derrors.IsNotSupported(err) {
+				t.Fatalf("%sService() error = %v, want %v",
+					testCase.name, err, derrors.CodeNotSupported)
+			}
+
+			if !strings.Contains(err.Error(), testCase.name) {
+				t.Errorf("%sService() message = %q, want it to name the subcommand",
+					testCase.name, err.Error())
+			}
+		})
+	}
+}
+
+// TestStatusServiceSaysItIsUnsupported covers the one subcommand whose signature
+// carries no error, so the refusal has to be in the words.
+func TestStatusServiceSaysItIsUnsupported(t *testing.T) {
+	status := statusService()
+	if !strings.Contains(status, "not supported") {
+		t.Errorf("statusService() = %q, want it to say service management is unsupported", status)
+	}
+}


### PR DESCRIPTION
## Description

This PR makes `neru services` work on Linux. Every one of its six subcommands used to refuse with `ERR_NOT_SUPPORTED` there, so the first thing a daily driver does after a first successful launch — arrange for Neru to come back on the next login — meant writing a systemd unit by hand from a snippet in the setup guide. Now `neru services install` writes that unit, enables it for every login, and starts it, and the other five subcommands drive it.

The unit is ordered after `graphical-session.target` because every Linux backend needs a display server, `WantedBy` it so it starts with each session, and `PartOf` it so a logout/login cycle restarts the daemon rather than leaving an orphan attached to a display that is gone. It is written under `$XDG_CONFIG_HOME/systemd/user` — the same base directory the daemon already resolves `config.toml` from, honoring the variable only when it is absolute, as the Base Directory spec requires.

The deliberate limitation is **systemd only**: on a machine booted by runit, OpenRC or s6 every subcommand returns `ERR_NOT_SUPPORTED` naming systemd and linking the setup guide, which [ADR 0013](https://github.com/y3owk1n/neru/blob/main/docs/adr/0013-parity-is-measured-in-words-not-subsystems.md) records as a stated boundary rather than a gap. Windows is unchanged and still refuses.

## Related Issues

Closes #1456. Part of #1466 (Linux parity).

## Command surface

No new commands or flags — the six existing subcommands stop refusing on Linux.

```bash
neru services install     # write ~/.config/systemd/user/neru.service, enable --now
neru services status      # installed? active? enabled at login?
neru services start
neru services stop
neru services restart
neru services uninstall   # disable --now, remove the unit
```

Behaviour worth knowing:

| Situation | What happens |
| --- | --- |
| Machine not booted by systemd | Every subcommand returns `ERR_NOT_SUPPORTED` naming systemd and linking `LINUX_SETUP.md` |
| Unit never installed | `status` says so and names the path it would live at — an answer, not an error |
| A `neru.service` already exists (nix, home-manager, a distro package) | `install` refuses; `uninstall` refuses too, rather than deleting a store symlink or disabling somebody else's unit |
| `$XDG_CONFIG_HOME` set only in a shell rc | `install` asks the user manager for its unit search path and refuses with the mismatch spelled out, instead of writing a unit systemd would never read |
| `enable` fails after the file is written | The file is removed and the manager reloaded, so a failed install leaves nothing behind |

`ERR_NOT_SUPPORTED` on macOS and Windows is unchanged, so nothing that worked before stops working. The hand-written unit in `LINUX_SETUP.md` that this replaces still works if a user already has it — `install` will refuse while it is there, which is the intended behaviour, and the docs say to uninstall it first.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — the fallback slot was retagged `!darwin && !linux` and now names both supported platforms in its message, with a new stub contract test pinning that it refuses rather than returning nil

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — exited 0 in this worktree. `just lint-cross` was run as well, since a macOS lint cannot see `//go:build linux` files, and the Linux test suite was executed in the CI-equivalent container
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

**Why `graphical-session.target` and not `default.target`.** Starting before a display server exists would only produce a restart loop. The three directives do different jobs and all three are needed: `After=` orders, `WantedBy=` is what `enable` hangs the unit off, and `PartOf=` is what makes logout stop it so the next login starts it clean.

**Sessions have to export themselves.** A systemd *user* manager starts before the compositor and inherits nothing from it, so without `systemctl --user import-environment` the daemon would start with no `WAYLAND_DISPLAY` or compositor socket and find nothing to drive. Desktop environments and `uwsm` do this already; a bare compositor from a TTY does not, so `LINUX_SETUP.md` now spells out the three `exec` lines a sway/Hyprland/niri config needs. This is the most likely reason an install looks like it worked and the daemon still is not there.

**What the tests cover.** The unit-file rendering, the XDG path resolution, the systemd detection, the search-path check and the status wording are plain unit tests. Two real-OS tests are non-invasive: one hands the rendered unit to `systemd-analyze verify` and fails on any diagnostic — the only reader whose opinion on a directive spelling counts — and one asserts `status` reports "not installed" on a machine with no unit. The full install/enable/uninstall round trip modifies the machine, so it gates on `NERU_DESKTOP_TESTS` alongside the cursor-driving tests, and skips when a `neru.service` already exists so it can never disturb a real installation.

**Docs.** Status and mechanism went to `CROSS_PLATFORM.md` (a new matrix row marked ⚠️ with a footnote, because the limit sits on an init-system axis the Linux columns do not have, plus the Known Gaps entry removed and the list renumbered); the user flow to `LINUX_SETUP.md`, replacing the hand-written unit snippet; the command surface to `CLI.md`. `ARCHITECTURE.md`'s description of the CLI dispatch set was stale the moment `services_other.go` was retagged, so it names the new file and tag now.
