### PR TITLE
fix(linux): keep the KDE remote desktop grant across daemon restarts

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -917,20 +917,19 @@ command — that means less here than it does on macOS, whether or not the
    use and reports `CodeNotSupported` naming itself. Its only pixel source is
    the portal's ScreenCast session, whose frames arrive over PipeWire — a new
    required system library, so closing this adds `libpipewire-0.3` to the Linux
-   dependency list, the packaging and the CI images. It may share a solution
-   with entry 2, which already holds a portal session. It is also what keeps
-   the `vision` hint strategy off KDE: the engine is linked on every backend,
-   and KWin is the one with no pixels to hand it
-2. KDE RemoteDesktop portal grant — does not survive a daemon restart, so the
-   consent prompt returns on every start
-3. Grid virtual-pointer indicator — a no-op on Linux, while recursive grid
+   dependency list, the packaging and the CI images. It may reuse the
+   RemoteDesktop session the input path already holds, which persists its grant
+   with a restore token and so has already paid the consent prompt. It is also
+   what keeps the `vision` hint strategy off KDE: the engine is linked on every
+   backend, and KWin is the one with no pixels to hand it
+2. Grid virtual-pointer indicator — a no-op on Linux, while recursive grid
    draws it on all three platforms
-4. `FocusedWindowBounds` — returns not-found on KWin, so callers silently fall
+3. `FocusedWindowBounds` — returns not-found on KWin, so callers silently fall
    back to the active screen
-5. Wayland global hotkeys — a setup requirement rather than missing code: they
+4. Wayland global hotkeys — a setup requirement rather than missing code: they
    need `input`-group membership and a CGO build. Failing loudly with the
    remedy, and documenting it as a first-class setup step, is the work
-6. Tail — the tray tooltip is a no-op (dbusmenu carries no such property), the
+5. Tail — the tray tooltip is a no-op (dbusmenu carries no such property), the
    tray has one icon for both running and paused states where macOS has two,
    and the `CGO_ENABLED=0` build should announce its boundary once at startup
    rather than failing feature by feature

--- a/docs/LINUX_DESKTOPS.md
+++ b/docs/LINUX_DESKTOPS.md
@@ -72,11 +72,13 @@ one-liner below now greps for it, so you can confirm it on your own KWin.
 
 ### Setup notes (beyond LINUX_SETUP.md)
 
-1. **RemoteDesktop consent** — the first input in a session shows a "Remote
-   Control" portal prompt. Approve it once per daemon lifetime. The prompt
-   **reappears on every fresh daemon start** (reboot, logout, relaunch):
-   `liboeffis` does not expose restore-token / `persist_mode`, so KDE cannot
-   persist the grant across launches.
+1. **RemoteDesktop consent** — the first daemon start on a machine shows a
+   "Remote Control" portal prompt. Approve it once and later starts reuse the
+   same grant with no prompt: Neru asks the portal to persist the session and
+   keeps the restore token it hands back in
+   `$XDG_STATE_HOME/neru/remote-desktop.token` (`~/.local/state/neru/…` by
+   default), readable by you alone. Deleting that file, or revoking the
+   permission in System Settings, brings the prompt back on the next start.
 2. **Hotkeys** — Neru's own `[hotkeys]` config works on KDE Wayland when the
    daemon can read `/dev/input` (see
    [Global hotkeys on Wayland](#global-hotkeys-on-wayland)). If you would rather
@@ -96,9 +98,6 @@ one-liner below now greps for it, so you can confirm it on your own KWin.
 
 ### Known issues
 
-- **Consent re-prompt every daemon launch** — see above. Planned follow-up:
-  drive `org.freedesktop.portal.RemoteDesktop` directly with a stored
-  `restore_token` + `persist_mode` instead of relying on `liboeffis` alone.
 - **Modifier keys need a keyboard device from the portal** — if the grant
   includes only a pointer device, modified clicks degrade.
 - **Key feeding needs a keyboard device from the portal** — `action feed`
@@ -115,6 +114,11 @@ one-liner below now greps for it, so you can confirm it on your own KWin.
 Approve the consent dialog before the connect times out. If denied, revoke and
 re-grant in System Settings (Apps & Window Management / portal permissions).
 Confirm the portal services are running.
+
+A grant that was revoked while Neru still held its restore token needs no
+manual cleanup: the stored token is dropped on the first refusal and the prompt
+is shown once more, on that same start. If you would rather start clean, delete
+`~/.local/state/neru/remote-desktop.token`.
 
 **"compositor does not support zwlr_virtual_pointer_v1" on KDE**
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,8 +41,7 @@ wlroots Wayland with a CGO build, with a closed set of macOS-only exemptions.
 The two largest open areas:
 
 - **Linux** — screen capture on KDE, which is the one backend the OCR hint
-  strategy cannot reach, and persisting the KDE RemoteDesktop portal grant
-  across daemon restarts.
+  strategy cannot reach.
 - **Windows** — foreground-window and display-hotplug events, which currently
   block per-app config re-application and monitor tracking.
 

--- a/internal/adapter/platform/linux/libei_client.c
+++ b/internal/adapter/platform/linux/libei_client.c
@@ -153,16 +153,22 @@ static int ensure_emulating(NeruEiClient *c, struct ei_device *device, int resum
 }
 
 // attach_eis wires a libei sender context onto an already-open EIS socket and
-// pumps the event loop until the devices are usable. It takes ownership of
-// eis_fd in every case: on success libei closes it at teardown, and on failure
-// it is closed here or by the ei_unref the caller's neru_ei_disconnect does.
-// Returns 1 when the client is ready to emit, 0 otherwise.
-static int attach_eis(NeruEiClient *c, int eis_fd, int64_t deadline) {
+// pumps the event loop until the devices are usable. Returns 1 when the client
+// is ready to emit, 0 otherwise.
+//
+// owns_fd says whether this call is responsible for eis_fd when libei never
+// takes it. It must be 0 on the liboeffis path, where the descriptor belongs to
+// struct oeffis and closing it here would leave oeffis_unref closing it a second
+// time, and 1 on the ConnectToEIS path, where the caller handed the descriptor
+// over and nothing else will ever close it. Once ei_setup_backend_fd has been
+// called libei owns the descriptor either way and closes it at ei_unref.
+static int attach_eis(NeruEiClient *c, int eis_fd, int owns_fd, int64_t deadline) {
 	// 1) libei sender context attached to the EIS fd.
 	c->ei = ei_new_sender(NULL);
 	if (!c->ei) {
-		// Nothing took the fd, so nothing else will close it.
-		close(eis_fd);
+		if (owns_fd) {
+			close(eis_fd);
+		}
 		return 0;
 	}
 	ei_configure_name(c->ei, "neru");
@@ -255,7 +261,8 @@ NeruEiClient *neru_ei_connect(int timeout_ms) {
 		}
 	}
 
-	if (!attach_eis(c, eis_fd, deadline)) {
+	// owns_fd = 0: the descriptor belongs to struct oeffis until libei takes it.
+	if (!attach_eis(c, eis_fd, 0, deadline)) {
 		neru_ei_disconnect(c);
 		return NULL;
 	}
@@ -276,7 +283,8 @@ NeruEiClient *neru_ei_connect_fd(int eis_fd, int timeout_ms) {
 
 	int64_t deadline = now_ms() + (timeout_ms > 0 ? timeout_ms : 30000);
 
-	if (!attach_eis(c, eis_fd, deadline)) {
+	// owns_fd = 1: the caller handed the descriptor over and keeps no copy.
+	if (!attach_eis(c, eis_fd, 1, deadline)) {
 		neru_ei_disconnect(c);
 		return NULL;
 	}

--- a/internal/adapter/platform/linux/libei_client.c
+++ b/internal/adapter/platform/linux/libei_client.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 struct NeruEiClient {
 	struct oeffis *oeffis;
@@ -151,57 +152,29 @@ static int ensure_emulating(NeruEiClient *c, struct ei_device *device, int resum
 	return 1;
 }
 
-NeruEiClient *neru_ei_connect(int timeout_ms) {
-	NeruEiClient *c = calloc(1, sizeof(*c));
-	if (!c) {
-		return NULL;
-	}
-
-	int64_t deadline = now_ms() + (timeout_ms > 0 ? timeout_ms : 30000);
-
-	// 1) Portal session via liboeffis -> EIS fd.
-	c->oeffis = oeffis_new(NULL);
-	if (!c->oeffis) {
-		neru_ei_disconnect(c);
-		return NULL;
-	}
-	oeffis_create_session(c->oeffis, OEFFIS_DEVICE_POINTER | OEFFIS_DEVICE_KEYBOARD);
-
-	int eis_fd = -1;
-	int ofd = oeffis_get_fd(c->oeffis);
-	while (eis_fd < 0) {
-		if (wait_readable(ofd, deadline) != 1) {
-			neru_ei_disconnect(c);
-			return NULL;
-		}
-		oeffis_dispatch(c->oeffis);
-		enum oeffis_event_type ev = oeffis_get_event(c->oeffis);
-		if (ev == OEFFIS_EVENT_CONNECTED_TO_EIS) {
-			eis_fd = oeffis_get_eis_fd(c->oeffis);
-		} else if (ev == OEFFIS_EVENT_DISCONNECTED || ev == OEFFIS_EVENT_CLOSED) {
-			neru_ei_disconnect(c);
-			return NULL;
-		}
-	}
-
-	// 2) libei sender context attached to the EIS fd.
+// attach_eis wires a libei sender context onto an already-open EIS socket and
+// pumps the event loop until the devices are usable. It takes ownership of
+// eis_fd in every case: on success libei closes it at teardown, and on failure
+// it is closed here or by the ei_unref the caller's neru_ei_disconnect does.
+// Returns 1 when the client is ready to emit, 0 otherwise.
+static int attach_eis(NeruEiClient *c, int eis_fd, int64_t deadline) {
+	// 1) libei sender context attached to the EIS fd.
 	c->ei = ei_new_sender(NULL);
 	if (!c->ei) {
-		neru_ei_disconnect(c);
-		return NULL;
+		// Nothing took the fd, so nothing else will close it.
+		close(eis_fd);
+		return 0;
 	}
 	ei_configure_name(c->ei, "neru");
 	if (ei_setup_backend_fd(c->ei, eis_fd) != 0) {
-		neru_ei_disconnect(c);
-		return NULL;
+		return 0;
 	}
 
-	// 3) Pump the event loop until the absolute pointer is resumed.
+	// 2) Pump the event loop until the absolute pointer is resumed.
 	int efd = ei_get_fd(c->ei);
 	while (!c->pointer_resumed) {
 		if (wait_readable(efd, deadline) != 1) {
-			neru_ei_disconnect(c);
-			return NULL;
+			return 0;
 		}
 		ei_dispatch(c->ei);
 		drain(c);
@@ -228,7 +201,7 @@ NeruEiClient *neru_ei_connect(int timeout_ms) {
 		}
 	}
 
-	// 3b) Give the keyboard device a brief extra window to appear after the
+	// 3) Give the keyboard device a brief extra window to appear after the
 	// pointer. The portal may advertise both devices but the keyboard add/resume
 	// events can arrive slightly later. If keyboard was not granted by the portal
 	// this loop simply times out in ~1 s and the connection still succeeds so
@@ -242,6 +215,70 @@ NeruEiClient *neru_ei_connect(int timeout_ms) {
 			ei_dispatch(c->ei);
 			drain(c);
 		}
+	}
+
+	return 1;
+}
+
+NeruEiClient *neru_ei_connect(int timeout_ms) {
+	NeruEiClient *c = calloc(1, sizeof(*c));
+	if (!c) {
+		return NULL;
+	}
+
+	int64_t deadline = now_ms() + (timeout_ms > 0 ? timeout_ms : 30000);
+
+	// Portal session via liboeffis -> EIS fd. This path cannot restore an
+	// earlier grant (liboeffis exposes no restore token), so it prompts on
+	// every start; neru_ei_connect_fd is the path that does not.
+	c->oeffis = oeffis_new(NULL);
+	if (!c->oeffis) {
+		neru_ei_disconnect(c);
+		return NULL;
+	}
+	oeffis_create_session(c->oeffis, OEFFIS_DEVICE_POINTER | OEFFIS_DEVICE_KEYBOARD);
+
+	int eis_fd = -1;
+	int ofd = oeffis_get_fd(c->oeffis);
+	while (eis_fd < 0) {
+		if (wait_readable(ofd, deadline) != 1) {
+			neru_ei_disconnect(c);
+			return NULL;
+		}
+		oeffis_dispatch(c->oeffis);
+		enum oeffis_event_type ev = oeffis_get_event(c->oeffis);
+		if (ev == OEFFIS_EVENT_CONNECTED_TO_EIS) {
+			eis_fd = oeffis_get_eis_fd(c->oeffis);
+		} else if (ev == OEFFIS_EVENT_DISCONNECTED || ev == OEFFIS_EVENT_CLOSED) {
+			neru_ei_disconnect(c);
+			return NULL;
+		}
+	}
+
+	if (!attach_eis(c, eis_fd, deadline)) {
+		neru_ei_disconnect(c);
+		return NULL;
+	}
+
+	return c;
+}
+
+NeruEiClient *neru_ei_connect_fd(int eis_fd, int timeout_ms) {
+	if (eis_fd < 0) {
+		return NULL;
+	}
+
+	NeruEiClient *c = calloc(1, sizeof(*c));
+	if (!c) {
+		close(eis_fd);
+		return NULL;
+	}
+
+	int64_t deadline = now_ms() + (timeout_ms > 0 ? timeout_ms : 30000);
+
+	if (!attach_eis(c, eis_fd, deadline)) {
+		neru_ei_disconnect(c);
+		return NULL;
 	}
 
 	return c;

--- a/internal/adapter/platform/linux/libei_client.h
+++ b/internal/adapter/platform/linux/libei_client.h
@@ -12,9 +12,25 @@ typedef struct NeruEiClient NeruEiClient;
 
 // Establish a RemoteDesktop portal session and a libei sender context, blocking
 // until the absolute-pointer device is ready or timeout_ms elapses. The portal
-// shows a one-time consent dialog the user must approve. Returns NULL on
-// denial, timeout, or any setup failure.
+// shows a consent dialog the user must approve. Returns NULL on denial,
+// timeout, or any setup failure.
+//
+// liboeffis exposes no restore token, so the session this opens cannot be
+// reused after a restart and the dialog appears on every start. It is the
+// fallback for a session the Go-side portal handshake could not open; the
+// reusable path is neru_ei_connect_fd.
 NeruEiClient *neru_ei_connect(int timeout_ms);
+
+// Attach a libei sender context to an EIS socket the caller already obtained
+// from org.freedesktop.portal.RemoteDesktop.ConnectToEIS, blocking until the
+// absolute-pointer device is ready or timeout_ms elapses. This is the path that
+// can reuse a stored grant, because the Go caller runs the portal handshake and
+// can present a restore token there.
+//
+// Takes ownership of eis_fd unconditionally: on success libei closes it at
+// teardown, and on failure it is closed before returning NULL. Returns NULL on
+// timeout or any setup failure.
+NeruEiClient *neru_ei_connect_fd(int eis_fd, int timeout_ms);
 
 // Tear down the libei context and portal session.
 void neru_ei_disconnect(NeruEiClient *c);

--- a/internal/adapter/platform/linux/portal_remotedesktop.go
+++ b/internal/adapter/platform/linux/portal_remotedesktop.go
@@ -116,7 +116,7 @@ const portalHandleTokenBytes = 8
 func openRemoteDesktopSession(ctx context.Context, restoreToken string) (portalGrant, error) {
 	conn, err := dialPortalBus(ctx)
 	if err != nil {
-		return portalGrant{}, failedBeforePresenting(err)
+		return portalGrant{}, unrelatedToStoredGrant(err)
 	}
 
 	grant, err := negotiateRemoteDesktop(ctx, conn, restoreToken)
@@ -241,7 +241,7 @@ func negotiateRemoteDesktop(
 	// stored grant cannot be blamed for.
 	names := conn.Names()
 	if len(names) == 0 {
-		return portalGrant{}, failedBeforePresenting(derrors.New(
+		return portalGrant{}, unrelatedToStoredGrant(derrors.New(
 			derrors.CodeActionFailed,
 			"the D-Bus session bus assigned no unique name, so no portal request "+
 				"could be listened for",
@@ -267,7 +267,7 @@ func negotiateRemoteDesktop(
 	if err != nil {
 		conn.RemoveSignal(requester.signals)
 
-		return portalGrant{}, failedBeforePresenting(derrors.Wrap(
+		return portalGrant{}, unrelatedToStoredGrant(derrors.Wrap(
 			err,
 			derrors.CodeActionFailed,
 			"could not subscribe to the RemoteDesktop portal's replies",
@@ -289,10 +289,12 @@ func negotiateRemoteDesktop(
 
 	session, err := createRemoteDesktopSession(ctx, requester)
 	if err != nil {
-		return portalGrant{}, failedBeforePresenting(err)
+		return portalGrant{}, unrelatedToStoredGrant(err)
 	}
 
-	// From here the token is in play: SelectDevices is the call that carries it.
+	// The token is in play across the next two calls: SelectDevices carries it
+	// and Start consumes it, so a refusal from either is the one signal there is
+	// that the stored grant is no longer good. Their errors go back unmarked.
 	err = selectRemoteDesktopDevices(ctx, requester, session, restoreToken)
 	if err != nil {
 		closeRemoteDesktopSession(conn, session)
@@ -307,11 +309,13 @@ func negotiateRemoteDesktop(
 		return portalGrant{}, err
 	}
 
+	// Past Start the grant is complete and a fresh token is already in hand, so
+	// a socket the portal will not produce says nothing about the stored one.
 	eisFD, err := connectToEIS(ctx, requester, session)
 	if err != nil {
 		closeRemoteDesktopSession(conn, session)
 
-		return portalGrant{}, err
+		return portalGrant{}, unrelatedToStoredGrant(err)
 	}
 
 	return portalGrant{

--- a/internal/adapter/platform/linux/portal_remotedesktop.go
+++ b/internal/adapter/platform/linux/portal_remotedesktop.go
@@ -1,0 +1,583 @@
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// The org.freedesktop.portal.RemoteDesktop handshake, spoken directly over the
+// session bus.
+//
+// liboeffis already wraps this handshake, and the libei client used it until
+// this file existed. It is not used for the session establishment path any
+// more, for one reason: its API exposes no restore token
+// (oeffis_create_session takes a device mask and nothing else), so every
+// session it opens is a fresh grant and every daemon start shows KDE's "Remote
+// Control" consent dialog. The token is negotiated in SelectDevices and handed
+// back by Start, both of which liboeffis owns, so reusing a grant means owning
+// the four D-Bus calls here. Everything past the EIS socket — device binding,
+// event emission — is still libei's.
+//
+// The connection is deliberately private rather than the process-wide
+// dbus.SessionBus() the notifier and the tray share: the portal ties the
+// session's lifetime to the connection that created it, so closing this one is
+// how a session is ended, and it must not be a connection anything else needs.
+const (
+	// portalBusName is the well-known name xdg-desktop-portal owns.
+	portalBusName = "org.freedesktop.portal.Desktop"
+	// portalObjectPath is the object every portal interface is exported on.
+	portalObjectPath = dbus.ObjectPath("/org/freedesktop/portal/desktop")
+	// portalRequestPathPrefix opens the object path a Request is exported on.
+	// The remainder is our unique bus name and the handle token we chose, which
+	// is what lets a listener be in place before the call is even made.
+	portalRequestPathPrefix = "/org/freedesktop/portal/desktop/request/"
+	// portalRequestNamespace is the path namespace every Request lives under,
+	// matched once so all four calls below share one match rule.
+	portalRequestNamespace = dbus.ObjectPath("/org/freedesktop/portal/desktop/request")
+	// portalRequestInterface carries the Response signal a Request answers with.
+	portalRequestInterface = "org.freedesktop.portal.Request"
+	// portalResponseSignal is that signal's member name.
+	portalResponseSignal = "Response"
+	// portalSessionCloseMethod ends a session explicitly, rather than leaving
+	// the portal to notice the connection went away.
+	portalSessionCloseMethod = "org.freedesktop.portal.Session.Close"
+)
+
+// The four RemoteDesktop methods one session needs, in the order they run.
+const (
+	remoteDesktopCreateSession = "org.freedesktop.portal.RemoteDesktop.CreateSession"
+	remoteDesktopSelectDevices = "org.freedesktop.portal.RemoteDesktop.SelectDevices"
+	remoteDesktopStart         = "org.freedesktop.portal.RemoteDesktop.Start"
+	remoteDesktopConnectToEIS  = "org.freedesktop.portal.RemoteDesktop.ConnectToEIS"
+)
+
+// Device types from the RemoteDesktop specification's `types` bitmask.
+const (
+	portalDeviceKeyboard uint32 = 1
+	portalDevicePointer  uint32 = 2
+)
+
+// portalPersistUntilRevoked is persist_mode 2: the grant survives until the
+// user revokes it. Mode 1 persists only while the application runs, which is
+// precisely the restart this file exists to survive.
+const portalPersistUntilRevoked uint32 = 2
+
+// Response codes from the portal's Request::Response signal.
+const (
+	portalResponseSuccess  uint32 = 0
+	portalResponseCanceled uint32 = 1
+	portalResponseEnded    uint32 = 2
+)
+
+// portalHandleTokenKey is the option every Request-answering call carries: the
+// token the portal builds the Request's object path from.
+const portalHandleTokenKey = "handle_token"
+
+// portalNoParentWindow is the parent_window identifier Start takes. Neru has no
+// toplevel to parent the dialog to — its overlays are layer-shell surfaces —
+// so the portal places the dialog itself.
+const portalNoParentWindow = ""
+
+// noPortalCallFlags sends a plain method call: the reply is what carries the
+// Request handle, so NO_REPLY_EXPECTED is exactly what must not be set.
+const noPortalCallFlags = 0
+
+// portalSignalBuffer sizes the channel Response signals arrive on. Four is one
+// per call in the handshake with room to spare; godbus never blocks on a full
+// channel, so this only decides how often it defers a delivery.
+const portalSignalBuffer = 4
+
+// portalHandleTokenBytes is the entropy behind one handle token. The token only
+// has to be unique among this connection's in-flight requests, so this is
+// generous rather than load-bearing.
+const portalHandleTokenBytes = 8
+
+// openRemoteDesktopSession runs the RemoteDesktop handshake and returns the EIS
+// socket libei injects through.
+//
+// When restoreToken is not empty the portal is asked to restore the grant it
+// names, which is what keeps the consent dialog off the screen on a restart. A
+// token the portal will not accept is not an error here: the specification says
+// an unrestorable token is ignored and the user prompted normally, and the
+// caller handles the backends that refuse instead.
+//
+// Every step is bounded by ctx, including the bus dial, which godbus cannot
+// cancel on its own — see dialPortalBus.
+func openRemoteDesktopSession(ctx context.Context, restoreToken string) (portalGrant, error) {
+	conn, err := dialPortalBus(ctx)
+	if err != nil {
+		return portalGrant{}, err
+	}
+
+	grant, err := negotiateRemoteDesktop(ctx, conn, restoreToken)
+	if err != nil {
+		_ = conn.Close()
+
+		return portalGrant{}, err
+	}
+
+	return grant, nil
+}
+
+// dialPortalBus connects to the session bus without letting an unresponsive bus
+// hold the caller.
+//
+// dbus.ConnectSessionBus takes no context: the connect, the auth handshake and
+// the Hello round trip are all uncancellable, so a bus that accepts a
+// connection and then stops answering would block until it answers. The mid-
+// action input path reaches this while holding the keyboard grab, so blocking
+// there freezes every global hotkey — the dial therefore runs on a goroutine
+// the caller can abandon, and whatever it eventually produces is closed rather
+// than leaked.
+func dialPortalBus(ctx context.Context) (*dbus.Conn, error) {
+	type dialed struct {
+		conn *dbus.Conn
+		err  error
+	}
+
+	done := make(chan dialed, 1)
+
+	go func() {
+		conn, err := dbus.ConnectSessionBus()
+		done <- dialed{conn: conn, err: err}
+	}()
+
+	select {
+	case result := <-done:
+		if result.err != nil {
+			return nil, derrors.Wrap(
+				result.err,
+				derrors.CodeNotSupported,
+				"no reachable D-Bus session bus, so the RemoteDesktop portal "+
+					"cannot be asked for an input session",
+			)
+		}
+
+		return result.conn, nil
+	case <-ctx.Done():
+		go func() {
+			result := <-done
+			if result.conn != nil {
+				_ = result.conn.Close()
+			}
+		}()
+
+		return nil, derrors.Wrap(
+			ctx.Err(),
+			derrors.CodeTimeout,
+			"the D-Bus session bus did not accept a connection in time",
+		)
+	}
+}
+
+// negotiateRemoteDesktop runs CreateSession, SelectDevices, Start and
+// ConnectToEIS on conn, in that order, and returns the grant they produced.
+func negotiateRemoteDesktop(
+	ctx context.Context,
+	conn *dbus.Conn,
+	restoreToken string,
+) (portalGrant, error) {
+	names := conn.Names()
+	if len(names) == 0 {
+		return portalGrant{}, derrors.New(
+			derrors.CodeActionFailed,
+			"the D-Bus session bus assigned no unique name, so no portal request "+
+				"could be listened for",
+		)
+	}
+
+	requester := &portalRequester{
+		conn:    conn,
+		portal:  conn.Object(portalBusName, portalObjectPath),
+		sender:  names[0],
+		signals: make(chan *dbus.Signal, portalSignalBuffer),
+	}
+
+	conn.Signal(requester.signals)
+
+	// One match rule covers all three Request-answering calls, because every
+	// Request the portal creates for us lives under the same path namespace.
+	err := conn.AddMatchSignalContext(ctx,
+		dbus.WithMatchInterface(portalRequestInterface),
+		dbus.WithMatchMember(portalResponseSignal),
+		dbus.WithMatchPathNamespace(portalRequestNamespace),
+	)
+	if err != nil {
+		conn.RemoveSignal(requester.signals)
+
+		return portalGrant{}, derrors.Wrap(
+			err,
+			derrors.CodeActionFailed,
+			"could not subscribe to the RemoteDesktop portal's replies",
+		)
+	}
+
+	// Nothing after the handshake answers on a Request, so the subscription is
+	// dropped either way rather than left delivering into a channel with no
+	// reader for the daemon's lifetime.
+	defer func() {
+		_ = conn.RemoveMatchSignal(
+			dbus.WithMatchInterface(portalRequestInterface),
+			dbus.WithMatchMember(portalResponseSignal),
+			dbus.WithMatchPathNamespace(portalRequestNamespace),
+		)
+
+		conn.RemoveSignal(requester.signals)
+	}()
+
+	session, err := createRemoteDesktopSession(ctx, requester)
+	if err != nil {
+		return portalGrant{}, err
+	}
+
+	err = selectRemoteDesktopDevices(ctx, requester, session, restoreToken)
+	if err != nil {
+		closeRemoteDesktopSession(conn, session)
+
+		return portalGrant{}, err
+	}
+
+	newToken, err := startRemoteDesktopSession(ctx, requester, session)
+	if err != nil {
+		closeRemoteDesktopSession(conn, session)
+
+		return portalGrant{}, err
+	}
+
+	eisFD, err := connectToEIS(ctx, requester, session)
+	if err != nil {
+		closeRemoteDesktopSession(conn, session)
+
+		return portalGrant{}, err
+	}
+
+	return portalGrant{
+		eisFD:        eisFD,
+		restoreToken: newToken,
+		close: func() {
+			closeRemoteDesktopSession(conn, session)
+
+			_ = conn.Close()
+		},
+	}, nil
+}
+
+// createRemoteDesktopSession performs step 1 and returns the session handle the
+// remaining three calls address.
+func createRemoteDesktopSession(
+	ctx context.Context,
+	requester *portalRequester,
+) (dbus.ObjectPath, error) {
+	results, err := requester.call(ctx, remoteDesktopCreateSession,
+		map[string]dbus.Variant{
+			"session_handle_token": dbus.MakeVariant(portalHandleToken()),
+		})
+	if err != nil {
+		return "", err
+	}
+
+	session, ok := portalSessionHandle(results)
+	if !ok {
+		return "", derrors.New(
+			derrors.CodeActionFailed,
+			"the RemoteDesktop portal created a session but named no session handle",
+		)
+	}
+
+	return session, nil
+}
+
+// selectRemoteDesktopDevices performs step 2, which is where the restore token
+// is presented and where persistence is asked for.
+func selectRemoteDesktopDevices(
+	ctx context.Context,
+	requester *portalRequester,
+	session dbus.ObjectPath,
+	restoreToken string,
+) error {
+	_, err := requester.call(ctx, remoteDesktopSelectDevices,
+		portalSelectDevicesOptions(restoreToken), session)
+
+	return err
+}
+
+// startRemoteDesktopSession performs step 3 — the call that shows the consent
+// dialog when there is nothing to restore — and returns the restore token for
+// next time, which is empty when the portal declined to persist the grant.
+func startRemoteDesktopSession(
+	ctx context.Context,
+	requester *portalRequester,
+	session dbus.ObjectPath,
+) (string, error) {
+	results, err := requester.call(ctx, remoteDesktopStart,
+		map[string]dbus.Variant{},
+		session, portalNoParentWindow)
+	if err != nil {
+		return "", err
+	}
+
+	// A portal that grants the session without persisting it returns no token.
+	// That is a supported answer, not a failure: input works, and the next
+	// start prompts again.
+	token, _ := results["restore_token"].Value().(string)
+
+	return token, nil
+}
+
+// connectToEIS performs step 4. Unlike the three before it this is a plain
+// method call — it answers with the socket directly instead of through a
+// Request — and the file descriptor it returns belongs to the caller.
+func connectToEIS(
+	ctx context.Context,
+	requester *portalRequester,
+	session dbus.ObjectPath,
+) (int, error) {
+	var socket dbus.UnixFD
+
+	err := requester.portal.CallWithContext(
+		ctx,
+		remoteDesktopConnectToEIS,
+		noPortalCallFlags,
+		session,
+		map[string]dbus.Variant{},
+	).Store(&socket)
+	if err != nil {
+		return 0, derrors.Wrap(
+			err,
+			derrors.CodeActionFailed,
+			"the RemoteDesktop portal granted a session but would not hand over an "+
+				"EIS socket to inject through",
+		)
+	}
+
+	return int(socket), nil
+}
+
+// closeRemoteDesktopSession ends a session explicitly. The portal would notice
+// the connection closing eventually, but a session left open until then holds a
+// grant the user can see in their portal settings.
+//
+// It expects no reply, which is what makes it safe to call from anywhere: a
+// teardown reaches this from the suspend/resume reset that runs on the
+// goroutine holding the keyboard grab, and waiting for a wedged portal to
+// acknowledge a close there would freeze every hotkey for as long as it took.
+// There is nothing to learn from the reply anyway — the session is being
+// abandoned either way.
+func closeRemoteDesktopSession(conn *dbus.Conn, session dbus.ObjectPath) {
+	_ = conn.Object(portalBusName, session).
+		Call(portalSessionCloseMethod, dbus.FlagNoReplyExpected).Err
+}
+
+// portalRequester issues portal calls whose answer arrives as a Request
+// Response signal rather than as the method's own reply.
+type portalRequester struct {
+	conn    *dbus.Conn
+	portal  dbus.BusObject
+	sender  string
+	signals chan *dbus.Signal
+}
+
+// call makes one portal call and waits for the Request it creates to answer.
+//
+// It mints the handle token itself and writes it into options, because the
+// object path the answer arrives on is derived from that token: a caller that
+// chose one and then passed a different one in the options would wait on a path
+// nothing ever answers. The subscription covering that path is already in place
+// before the call goes out, which is what the portal specification prescribes to
+// close the race where the Response beats the method reply.
+func (r *portalRequester) call(
+	ctx context.Context,
+	method string,
+	options map[string]dbus.Variant,
+	args ...any,
+) (map[string]dbus.Variant, error) {
+	handleToken := portalHandleToken()
+	options[portalHandleTokenKey] = dbus.MakeVariant(handleToken)
+
+	var handle dbus.ObjectPath
+
+	err := r.portal.CallWithContext(
+		ctx,
+		method,
+		noPortalCallFlags,
+		append(append([]any{}, args...), options)...,
+	).Store(&handle)
+	if err != nil {
+		return nil, derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"the RemoteDesktop portal refused %s",
+			method,
+		)
+	}
+
+	// The portal answers on the path it chose. That is normally the derived one
+	// — which is why the subscription could be set up first — but the returned
+	// handle is what is authoritative, so it is what the wait matches on.
+	if handle == "" {
+		handle = portalRequestPath(r.sender, handleToken)
+	}
+
+	return r.await(ctx, handle, method)
+}
+
+// await blocks until the Request at handle answers, or ctx runs out.
+func (r *portalRequester) await(
+	ctx context.Context,
+	handle dbus.ObjectPath,
+	method string,
+) (map[string]dbus.Variant, error) {
+	responseName := portalRequestInterface + "." + portalResponseSignal
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, derrors.Wrapf(
+				ctx.Err(),
+				derrors.CodeTimeout,
+				"the RemoteDesktop portal did not answer %s in time",
+				method,
+			)
+		case signal, open := <-r.signals:
+			if !open {
+				return nil, derrors.Newf(
+					derrors.CodeActionFailed,
+					"the D-Bus session bus closed while waiting for %s",
+					method,
+				)
+			}
+
+			if signal.Path != handle || signal.Name != responseName {
+				continue
+			}
+
+			code, results, err := decodePortalResponse(signal)
+			if err != nil {
+				return nil, err
+			}
+
+			err = portalResponseError(code)
+			if err != nil {
+				return nil, err
+			}
+
+			return results, nil
+		}
+	}
+}
+
+// decodePortalResponse reads the (response code, results) pair a Response
+// signal carries.
+func decodePortalResponse(signal *dbus.Signal) (uint32, map[string]dbus.Variant, error) {
+	const responseBodyLength = 2
+
+	if len(signal.Body) < responseBodyLength {
+		return 0, nil, derrors.New(
+			derrors.CodeActionFailed,
+			"the RemoteDesktop portal sent a malformed reply",
+		)
+	}
+
+	code, ok := signal.Body[0].(uint32)
+	if !ok {
+		return 0, nil, derrors.New(
+			derrors.CodeActionFailed,
+			"the RemoteDesktop portal sent a reply with no response code",
+		)
+	}
+
+	results, _ := signal.Body[1].(map[string]dbus.Variant)
+
+	return code, results, nil
+}
+
+// portalResponseError turns a Response code into the error the restore policy
+// branches on. A canceled request is separated from every other failure because
+// it is the user's own answer, and a second dialog would only ask them again.
+func portalResponseError(code uint32) error {
+	switch code {
+	case portalResponseSuccess:
+		return nil
+	case portalResponseCanceled:
+		return errPortalRequestCanceled
+	case portalResponseEnded:
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"the RemoteDesktop portal ended the request before it was answered",
+		)
+	default:
+		return derrors.Newf(
+			derrors.CodeActionFailed,
+			"the RemoteDesktop portal answered with an unknown response code %d",
+			code,
+		)
+	}
+}
+
+// portalSelectDevicesOptions builds the options for SelectDevices: which
+// devices are wanted, how long the grant should last, and which grant to
+// restore. The handle token is added by portalRequester.call, which owns it.
+//
+// The restore token is omitted rather than sent empty when there is nothing to
+// restore, so a portal backend that validates the key it was handed does not
+// refuse the ordinary first run.
+func portalSelectDevicesOptions(restoreToken string) map[string]dbus.Variant {
+	options := map[string]dbus.Variant{
+		"types":        dbus.MakeVariant(portalDeviceKeyboard | portalDevicePointer),
+		"persist_mode": dbus.MakeVariant(portalPersistUntilRevoked),
+	}
+
+	if restoreToken != "" {
+		options["restore_token"] = dbus.MakeVariant(restoreToken)
+	}
+
+	return options
+}
+
+// portalSessionHandle reads the session handle out of a CreateSession reply.
+// The specification types it as a string, and some portal implementations send
+// an object path instead, so both are accepted.
+func portalSessionHandle(results map[string]dbus.Variant) (dbus.ObjectPath, bool) {
+	value, ok := results["session_handle"]
+	if !ok {
+		return "", false
+	}
+
+	switch handle := value.Value().(type) {
+	case string:
+		return dbus.ObjectPath(handle), handle != ""
+	case dbus.ObjectPath:
+		return handle, handle != ""
+	default:
+		return "", false
+	}
+}
+
+// portalRequestPath derives the object path a Request answers on, per the
+// portal specification: the sender's unique name with its leading colon removed
+// and its dots replaced by underscores, followed by the handle token.
+func portalRequestPath(sender, handleToken string) dbus.ObjectPath {
+	element := strings.ReplaceAll(strings.TrimPrefix(sender, ":"), ".", "_")
+
+	return dbus.ObjectPath(portalRequestPathPrefix + element + "/" + handleToken)
+}
+
+// portalHandleToken returns a token unique among this connection's requests and
+// legal as a D-Bus object path element — the portal pastes it straight into
+// one, so anything outside [A-Za-z0-9_] would have the call rejected.
+func portalHandleToken() string {
+	buffer := make([]byte, portalHandleTokenBytes)
+
+	// crypto/rand.Read is documented never to fail on any supported platform.
+	_, _ = rand.Read(buffer)
+
+	return "neru_" + hex.EncodeToString(buffer)
+}

--- a/internal/adapter/platform/linux/portal_remotedesktop.go
+++ b/internal/adapter/platform/linux/portal_remotedesktop.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"strings"
+	"sync"
 
 	"github.com/godbus/dbus/v5"
 
@@ -114,7 +116,7 @@ const portalHandleTokenBytes = 8
 func openRemoteDesktopSession(ctx context.Context, restoreToken string) (portalGrant, error) {
 	conn, err := dialPortalBus(ctx)
 	if err != nil {
-		return portalGrant{}, err
+		return portalGrant{}, failedBeforePresenting(err)
 	}
 
 	grant, err := negotiateRemoteDesktop(ctx, conn, restoreToken)
@@ -127,8 +129,24 @@ func openRemoteDesktopSession(ctx context.Context, restoreToken string) (portalG
 	return grant, nil
 }
 
+// dialedBus is one outcome of the uncancellable session-bus dial.
+type dialedBus struct {
+	conn *dbus.Conn
+	err  error
+}
+
+// portalDialer holds the one bus dial that may be outstanding at a time.
+type portalDialer struct {
+	mu       sync.Mutex
+	inFlight bool
+}
+
+// portalBusDialer is process-wide because the thing it caps is process-wide:
+// one wedged session bus, however many callers walk into it.
+var portalBusDialer = &portalDialer{}
+
 // dialPortalBus connects to the session bus without letting an unresponsive bus
-// hold the caller.
+// hold the caller, and without starting a second dial while one is stuck.
 //
 // dbus.ConnectSessionBus takes no context: the connect, the auth handshake and
 // the Hello round trip are all uncancellable, so a bus that accepts a
@@ -137,18 +155,18 @@ func openRemoteDesktopSession(ctx context.Context, restoreToken string) (portalG
 // there freezes every global hotkey — the dial therefore runs on a goroutine
 // the caller can abandon, and whatever it eventually produces is closed rather
 // than leaked.
+//
+// Abandoning is not enough on its own. Every mid-action input operation reaches
+// this while no session is established, so a wedged bus would otherwise buy one
+// more orphaned goroutine and half-open connection per keypress. The same rule
+// the capability probes follow applies here — one outstanding attempt, never
+// restarted while it is stuck — so a caller that arrives to find a dial already
+// hanging is refused immediately rather than adding to the pile.
 func dialPortalBus(ctx context.Context) (*dbus.Conn, error) {
-	type dialed struct {
-		conn *dbus.Conn
-		err  error
+	done, err := portalBusDialer.start()
+	if err != nil {
+		return nil, err
 	}
-
-	done := make(chan dialed, 1)
-
-	go func() {
-		conn, err := dbus.ConnectSessionBus()
-		done <- dialed{conn: conn, err: err}
-	}()
 
 	select {
 	case result := <-done:
@@ -178,6 +196,39 @@ func dialPortalBus(ctx context.Context) (*dbus.Conn, error) {
 	}
 }
 
+// start launches the dial, or refuses when one is already outstanding.
+func (d *portalDialer) start() (<-chan dialedBus, error) {
+	d.mu.Lock()
+
+	if d.inFlight {
+		d.mu.Unlock()
+
+		return nil, derrors.New(
+			derrors.CodeTimeout,
+			"an earlier connection to the D-Bus session bus is still unanswered, "+
+				"so the RemoteDesktop portal cannot be reached yet",
+		)
+	}
+
+	d.inFlight = true
+
+	d.mu.Unlock()
+
+	done := make(chan dialedBus, 1)
+
+	go func() {
+		conn, err := dbus.ConnectSessionBus()
+
+		d.mu.Lock()
+		d.inFlight = false
+		d.mu.Unlock()
+
+		done <- dialedBus{conn: conn, err: err}
+	}()
+
+	return done, nil
+}
+
 // negotiateRemoteDesktop runs CreateSession, SelectDevices, Start and
 // ConnectToEIS on conn, in that order, and returns the grant they produced.
 func negotiateRemoteDesktop(
@@ -185,13 +236,16 @@ func negotiateRemoteDesktop(
 	conn *dbus.Conn,
 	restoreToken string,
 ) (portalGrant, error) {
+	// Everything up to and including CreateSession runs before SelectDevices
+	// presents the restore token, so each failure below is marked as one the
+	// stored grant cannot be blamed for.
 	names := conn.Names()
 	if len(names) == 0 {
-		return portalGrant{}, derrors.New(
+		return portalGrant{}, failedBeforePresenting(derrors.New(
 			derrors.CodeActionFailed,
 			"the D-Bus session bus assigned no unique name, so no portal request "+
 				"could be listened for",
-		)
+		))
 	}
 
 	requester := &portalRequester{
@@ -213,11 +267,11 @@ func negotiateRemoteDesktop(
 	if err != nil {
 		conn.RemoveSignal(requester.signals)
 
-		return portalGrant{}, derrors.Wrap(
+		return portalGrant{}, failedBeforePresenting(derrors.Wrap(
 			err,
 			derrors.CodeActionFailed,
 			"could not subscribe to the RemoteDesktop portal's replies",
-		)
+		))
 	}
 
 	// Nothing after the handshake answers on a Request, so the subscription is
@@ -235,9 +289,10 @@ func negotiateRemoteDesktop(
 
 	session, err := createRemoteDesktopSession(ctx, requester)
 	if err != nil {
-		return portalGrant{}, err
+		return portalGrant{}, failedBeforePresenting(err)
 	}
 
+	// From here the token is in play: SelectDevices is the call that carries it.
 	err = selectRemoteDesktopDevices(ctx, requester, session, restoreToken)
 	if err != nil {
 		closeRemoteDesktopSession(conn, session)
@@ -350,15 +405,56 @@ func connectToEIS(
 		map[string]dbus.Variant{},
 	).Store(&socket)
 	if err != nil {
-		return 0, derrors.Wrap(
+		return 0, portalCallFailed(
 			err,
-			derrors.CodeActionFailed,
 			"the RemoteDesktop portal granted a session but would not hand over an "+
 				"EIS socket to inject through",
 		)
 	}
 
 	return int(socket), nil
+}
+
+// portalCallFailed phrases a failed portal method call.
+//
+// It deliberately does not wrap the bus error itself. A D-Bus error body is
+// written by the portal backend and can quote the option it rejected, and one
+// of the options sent here is a restore token — a credential that must not
+// reach an error a caller may print or log. The error *name* says what went
+// wrong without quoting anything we sent, so that is what is carried.
+//
+// A call that ran out of time is reported as a timeout rather than a refusal,
+// which is what keeps a slow portal from being mistaken for one that rejected
+// the stored grant (see storedGrantPresumedDead).
+func portalCallFailed(err error, message string) error {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return derrors.New(derrors.CodeTimeout, message+", and the request ran out of time")
+	}
+
+	name := busErrorName(err)
+	if name != "" {
+		return derrors.New(derrors.CodeActionFailed, message+" ("+name+")")
+	}
+
+	return derrors.New(derrors.CodeActionFailed, message)
+}
+
+// busErrorName reduces a D-Bus error to its name, and reports "" for anything
+// that is not one. godbus yields dbus.Error by value on a client call and by
+// pointer from NewError, so both are matched.
+func busErrorName(err error) string {
+	var busError dbus.Error
+
+	var busErrorPtr *dbus.Error
+
+	switch {
+	case errors.As(err, &busError):
+		return busError.Name
+	case errors.As(err, &busErrorPtr):
+		return busErrorPtr.Name
+	default:
+		return ""
+	}
 }
 
 // closeRemoteDesktopSession ends a session explicitly. The portal would notice
@@ -411,12 +507,7 @@ func (r *portalRequester) call(
 		append(append([]any{}, args...), options)...,
 	).Store(&handle)
 	if err != nil {
-		return nil, derrors.Wrapf(
-			err,
-			derrors.CodeActionFailed,
-			"the RemoteDesktop portal refused %s",
-			method,
-		)
+		return nil, portalCallFailed(err, "the RemoteDesktop portal refused "+method)
 	}
 
 	// The portal answers on the path it chose. That is normally the derived one

--- a/internal/adapter/platform/linux/portal_remotedesktop_test.go
+++ b/internal/adapter/platform/linux/portal_remotedesktop_test.go
@@ -3,11 +3,15 @@
 package linux
 
 import (
+	"context"
 	"errors"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/godbus/dbus/v5"
+
+	"github.com/y3owk1n/neru/internal/derrors"
 )
 
 // TestPortalRequestPath_DerivesTheHandleFromTheSenderName pins the object-path
@@ -114,6 +118,78 @@ func TestPortalSelectDevicesOptions_AsksForAPersistentKeyboardAndPointer(t *test
 	token, isString := options["restore_token"].Value().(string)
 	if !isString || token != storedToken {
 		t.Errorf("restore_token = %v, want the stored token", options["restore_token"])
+	}
+}
+
+// TestPortalCallFailed_KeepsTheBusErrorBodyOutOfTheMessage is a privacy
+// guard, not a phrasing one. One of the options this code sends the portal is
+// a restore token, and a backend that quotes a rejected option back in its
+// error body would carry that credential into an error a caller may log. Only
+// the error name is allowed through.
+func TestPortalCallFailed_KeepsTheBusErrorBodyOutOfTheMessage(t *testing.T) {
+	busError := dbus.Error{
+		Name: "org.freedesktop.portal.Error.InvalidArgument",
+		Body: []any{"restore_token 'secret-credential' is not valid"},
+	}
+
+	err := portalCallFailed(busError, "the portal refused SelectDevices")
+	if err == nil {
+		t.Fatal("portalCallFailed() = nil, want an error")
+	}
+
+	if strings.Contains(err.Error(), "secret-credential") {
+		t.Errorf("error carries the bus error body: %q", err.Error())
+	}
+
+	if !strings.Contains(err.Error(), busError.Name) {
+		t.Errorf("error = %q, want it to name %q", err.Error(), busError.Name)
+	}
+}
+
+// TestPortalCallFailed_ReportsARanOutOfTimeCallAsATimeout matters because the
+// restore policy branches on the code: a slow portal reported as a refusal
+// would have the stored grant thrown away and the user prompted, for a failure
+// that never reached the portal at all.
+func TestPortalCallFailed_ReportsARanOutOfTimeCallAsATimeout(t *testing.T) {
+	err := portalCallFailed(context.DeadlineExceeded, "the portal refused Start")
+
+	if !derrors.IsCode(err, derrors.CodeTimeout) {
+		t.Errorf("portalCallFailed(DeadlineExceeded) code = %q, want %q",
+			derrors.GetCode(err), derrors.CodeTimeout)
+	}
+
+	if storedGrantPresumedDead(err) {
+		t.Error("a timed-out call marks the stored grant dead, want it kept")
+	}
+}
+
+// TestDialPortalBus_DoesNotStartASecondDialWhileOneIsStuck pins the rule the
+// capability probes already follow: an uncancellable native-ish call that has
+// wedged gets one outstanding attempt, not one per caller. Every mid-action
+// input operation reaches this while no session is up, so restarting would buy
+// an orphaned goroutine and a half-open connection per keypress.
+func TestDialPortalBus_DoesNotStartASecondDialWhileOneIsStuck(t *testing.T) {
+	dialer := &portalDialer{}
+
+	first, err := dialer.start()
+	if err != nil {
+		t.Fatalf("first start() error = %v", err)
+	}
+
+	_, err = dialer.start()
+	if err == nil {
+		t.Fatal("second start() error = nil, want a refusal while one is outstanding")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeTimeout) {
+		t.Errorf("second start() code = %q, want %q", derrors.GetCode(err), derrors.CodeTimeout)
+	}
+
+	// Drain the real dial so the test leaves no goroutine behind, and close
+	// whatever it produced — this machine may well have a session bus.
+	result := <-first
+	if result.conn != nil {
+		_ = result.conn.Close()
 	}
 }
 

--- a/internal/adapter/platform/linux/portal_remotedesktop_test.go
+++ b/internal/adapter/platform/linux/portal_remotedesktop_test.go
@@ -1,0 +1,156 @@
+//go:build linux
+
+package linux
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// TestPortalRequestPath_DerivesTheHandleFromTheSenderName pins the object-path
+// convention the portal specification states, because getting it wrong is a
+// silent hang rather than an error: the Response signal is emitted on the path
+// derived from our unique bus name, and a listener on any other path simply
+// never fires.
+func TestPortalRequestPath_DerivesTheHandleFromTheSenderName(t *testing.T) {
+	tests := []struct {
+		name        string
+		sender      string
+		handleToken string
+		want        dbus.ObjectPath
+	}{
+		{
+			name:        "unique name loses its colon and gains underscores",
+			sender:      ":1.42",
+			handleToken: "neru_1",
+			want:        "/org/freedesktop/portal/desktop/request/1_42/neru_1",
+		},
+		{
+			name:        "every dot is replaced, not just the first",
+			sender:      ":1.2.3",
+			handleToken: "tok",
+			want:        "/org/freedesktop/portal/desktop/request/1_2_3/tok",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := portalRequestPath(testCase.sender, testCase.handleToken)
+			if got != testCase.want {
+				t.Errorf("portalRequestPath(%q, %q) = %q, want %q",
+					testCase.sender, testCase.handleToken, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestPortalHandleToken_IsAValidObjectPathElement guards the other half of the
+// same hazard: the token is pasted into an object path, and a character the
+// D-Bus specification does not allow there makes the portal reject the whole
+// call.
+func TestPortalHandleToken_IsAValidObjectPathElement(t *testing.T) {
+	valid := regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+	seen := make(map[string]bool)
+
+	for range 32 {
+		token := portalHandleToken()
+		if !valid.MatchString(token) {
+			t.Fatalf("portalHandleToken() = %q, want only [A-Za-z0-9_]", token)
+		}
+
+		if seen[token] {
+			t.Fatalf("portalHandleToken() repeated %q; a reused handle would "+
+				"collide with an in-flight request", token)
+		}
+
+		seen[token] = true
+	}
+}
+
+// TestPortalSelectDevicesOptions_OmitsTheRestoreTokenWhenThereIsNothingToRestore
+// keeps an empty string out of the options map. A portal that validates the key
+// it was given would refuse the call outright, which would turn "no grant
+// stored yet" — the ordinary first run — into a hard failure.
+func TestPortalSelectDevicesOptions_OmitsTheRestoreTokenWhenThereIsNothingToRestore(
+	t *testing.T,
+) {
+	options := portalSelectDevicesOptions("")
+
+	if _, ok := options["restore_token"]; ok {
+		t.Errorf("options carry a restore_token key with nothing to restore: %v", options)
+	}
+}
+
+// TestPortalSelectDevicesOptions_AsksForAPersistentKeyboardAndPointer pins the
+// three values the whole feature rests on: both device types, and a persistence
+// mode that outlives the process — persist_mode 1 would keep the grant only
+// while this daemon runs, which is exactly the restart that fails today.
+func TestPortalSelectDevicesOptions_AsksForAPersistentKeyboardAndPointer(t *testing.T) {
+	options := portalSelectDevicesOptions(storedToken)
+
+	types, isUint := options["types"].Value().(uint32)
+	if !isUint {
+		t.Fatalf("types option = %v, want a uint32", options["types"])
+	}
+
+	if types != portalDeviceKeyboard|portalDevicePointer {
+		t.Errorf("types = %#b, want keyboard and pointer (%#b)",
+			types, portalDeviceKeyboard|portalDevicePointer)
+	}
+
+	persist, isUint := options["persist_mode"].Value().(uint32)
+	if !isUint {
+		t.Fatalf("persist_mode option = %v, want a uint32", options["persist_mode"])
+	}
+
+	if persist != portalPersistUntilRevoked {
+		t.Errorf("persist_mode = %d, want %d", persist, portalPersistUntilRevoked)
+	}
+
+	token, isString := options["restore_token"].Value().(string)
+	if !isString || token != storedToken {
+		t.Errorf("restore_token = %v, want the stored token", options["restore_token"])
+	}
+}
+
+// TestPortalResponseError_SeparatesCancelationFromFailure pins the mapping the
+// restore policy branches on. A canceled request is the user's own answer and
+// must not be met with a second dialog; anything else is a failure the policy
+// may fall back from.
+func TestPortalResponseError_SeparatesCancelationFromFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     uint32
+		wantErr  bool
+		canceled bool
+	}{
+		{name: "success", code: portalResponseSuccess},
+		{name: "user canceled", code: portalResponseCanceled, wantErr: true, canceled: true},
+		{name: "ended by other means", code: portalResponseEnded, wantErr: true},
+		{name: "unknown code", code: 99, wantErr: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := portalResponseError(testCase.code)
+
+			if (err != nil) != testCase.wantErr {
+				t.Fatalf(
+					"portalResponseError(%d) = %v, wantErr %v",
+					testCase.code,
+					err,
+					testCase.wantErr,
+				)
+			}
+
+			if got := errors.Is(err, errPortalRequestCanceled); got != testCase.canceled {
+				t.Errorf("errors.Is(err, errPortalRequestCanceled) = %v, want %v",
+					got, testCase.canceled)
+			}
+		})
+	}
+}

--- a/internal/adapter/platform/linux/portal_restore_token.go
+++ b/internal/adapter/platform/linux/portal_restore_token.go
@@ -1,0 +1,143 @@
+//go:build linux
+
+package linux
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Persistence for the RemoteDesktop portal's restore token.
+//
+// The token is what turns KDE's "Remote Control" consent prompt from a
+// per-start interruption into a one-time grant: the portal hands one back when
+// a session is started with persist_mode set, and a later session that presents
+// it is restored without asking the user again.
+//
+// It is a credential, and it is treated as one. Presenting the token replays a
+// grant that lets its holder move the pointer and press keys in this user's
+// session, so it is written owner-readable only, under the user's own state
+// directory, and it is never logged, never put in an error message, and never
+// reported through `neru doctor`. Nothing in this file or its callers formats
+// the value into anything a human or a log file will see.
+const (
+	// restoreTokenFileMode keeps the token readable by its owner alone.
+	restoreTokenFileMode os.FileMode = 0o600
+	// restoreTokenDirMode keeps the directory holding it owner-only too, so a
+	// token is not discoverable by listing the directory either.
+	restoreTokenDirMode os.FileMode = 0o700
+	// restoreTokenFileName is the token's file inside Neru's state directory.
+	// XDG_STATE_HOME is the right base: the token is state that should survive
+	// a restart, is specific to this machine's portal, and is neither
+	// configuration the user edits nor data worth carrying to another host.
+	restoreTokenFileName = "remote-desktop.token"
+	// restoreTokenTempPattern names the temporary file a save writes before
+	// renaming it into place.
+	restoreTokenTempPattern = ".remote-desktop.token.*"
+)
+
+// restoreTokenStore holds the portal grant's restore token across daemon
+// restarts. It is an interface so the establish policy — restore, and prompt
+// once when the stored token is refused — is testable without a filesystem.
+type restoreTokenStore interface {
+	// load returns the stored token, or "" when none is stored or it cannot be
+	// read. An unreadable token is indistinguishable from an absent one to the
+	// caller by design: both mean "ask the portal to prompt".
+	load() string
+	// save replaces the stored token.
+	save(token string) error
+	// clear removes the stored token. Clearing when nothing is stored is not an
+	// error, so callers clear on refusal without first asking what they hold.
+	clear() error
+}
+
+// fileRestoreTokenStore stores the token in a file under Neru's state
+// directory.
+type fileRestoreTokenStore struct {
+	path string
+}
+
+var _ restoreTokenStore = (*fileRestoreTokenStore)(nil)
+
+// newFileRestoreTokenStore resolves the token's path from the XDG base
+// directories, honoring XDG_STATE_HOME exactly as LogDir does. It creates
+// nothing: the directory is made on the first save, so a session that never
+// reaches the portal leaves no trace.
+func newFileRestoreTokenStore() (*fileRestoreTokenStore, error) {
+	base, err := xdgDir("XDG_STATE_HOME", ".local", "state")
+	if err != nil {
+		return nil, err
+	}
+
+	return &fileRestoreTokenStore{
+		path: filepath.Join(base, "neru", restoreTokenFileName),
+	}, nil
+}
+
+// load reads the stored token, trimming surrounding whitespace so a trailing
+// newline never reaches the portal as part of the value.
+func (s *fileRestoreTokenStore) load() string {
+	contents, err := os.ReadFile(s.path)
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(string(contents))
+}
+
+// save writes the token owner-readable only.
+//
+// It writes a fresh temporary file and renames it over the target rather than
+// truncating in place, for two reasons: the new file carries this package's
+// mode regardless of what the old one had, so a token left loose by an earlier
+// version or by a user's editor is tightened rather than inherited; and a
+// crash mid-write leaves the previous token intact instead of a truncated one
+// the portal would refuse.
+func (s *fileRestoreTokenStore) save(token string) error {
+	dir := filepath.Dir(s.path)
+
+	err := os.MkdirAll(dir, restoreTokenDirMode)
+	if err != nil {
+		return err
+	}
+
+	temp, err := os.CreateTemp(dir, restoreTokenTempPattern)
+	if err != nil {
+		return err
+	}
+
+	// From here on the temporary file must not be left behind on any path.
+	defer func() { _ = os.Remove(temp.Name()) }()
+
+	err = temp.Chmod(restoreTokenFileMode)
+	if err != nil {
+		_ = temp.Close()
+
+		return err
+	}
+
+	_, err = temp.WriteString(token)
+	if err != nil {
+		_ = temp.Close()
+
+		return err
+	}
+
+	err = temp.Close()
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(temp.Name(), s.path)
+}
+
+// clear removes the stored token, treating an already-absent file as success.
+func (s *fileRestoreTokenStore) clear() error {
+	err := os.Remove(s.path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
+}

--- a/internal/adapter/platform/linux/portal_restore_token_test.go
+++ b/internal/adapter/platform/linux/portal_restore_token_test.go
@@ -1,0 +1,156 @@
+//go:build linux
+
+package linux
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// storeUnderTempState builds a store rooted in a throwaway XDG_STATE_HOME, so
+// the permission assertions below measure what the store creates rather than
+// whatever the developer's real state directory happens to carry.
+func storeUnderTempState(t *testing.T) (*fileRestoreTokenStore, string) {
+	t.Helper()
+
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+
+	store, err := newFileRestoreTokenStore()
+	if err != nil {
+		t.Fatalf("newFileRestoreTokenStore() error = %v", err)
+	}
+
+	return store, filepath.Join(state, "neru")
+}
+
+// TestFileRestoreTokenStore_SaveWritesATokenOnlyItsOwnerCanRead is the reason
+// this store exists rather than a plain os.WriteFile call: a RemoteDesktop
+// restore token is a credential that replays a granted input session, so any
+// other user on the machine being able to read it would hand them the grant.
+func TestFileRestoreTokenStore_SaveWritesATokenOnlyItsOwnerCanRead(t *testing.T) {
+	store, dir := storeUnderTempState(t)
+
+	err := store.save("token-abc")
+	if err != nil {
+		t.Fatalf("save() error = %v", err)
+	}
+
+	info, err := os.Stat(store.path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+
+	if got := info.Mode().Perm(); got != restoreTokenFileMode {
+		t.Errorf("token file mode = %v, want %v", got, restoreTokenFileMode)
+	}
+
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat token directory: %v", err)
+	}
+
+	if got := dirInfo.Mode().Perm(); got != restoreTokenDirMode {
+		t.Errorf("token directory mode = %v, want %v", got, restoreTokenDirMode)
+	}
+
+	if got := store.load(); got != "token-abc" {
+		t.Errorf("load() = %q, want %q", got, "token-abc")
+	}
+}
+
+// TestFileRestoreTokenStore_SaveTightensPermissionsOnALooseFile covers the
+// upgrade path: a token file left world-readable by an earlier write (or by a
+// user's own tinkering) must not stay that way just because the path already
+// exists.
+func TestFileRestoreTokenStore_SaveTightensPermissionsOnALooseFile(t *testing.T) {
+	store, dir := storeUnderTempState(t)
+
+	err := os.MkdirAll(dir, restoreTokenDirMode)
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	err = os.WriteFile(store.path, []byte("stale"), 0o644)
+	if err != nil {
+		t.Fatalf("seed loose token file: %v", err)
+	}
+
+	err = store.save("token-xyz")
+	if err != nil {
+		t.Fatalf("save() error = %v", err)
+	}
+
+	info, err := os.Stat(store.path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+
+	if got := info.Mode().Perm(); got != restoreTokenFileMode {
+		t.Errorf("token file mode = %v, want %v", got, restoreTokenFileMode)
+	}
+
+	if got := store.load(); got != "token-xyz" {
+		t.Errorf("load() = %q, want %q", got, "token-xyz")
+	}
+}
+
+// TestFileRestoreTokenStore_LoadReportsNoTokenWhenNoneIsStored pins the
+// first-run answer: an absent file is the ordinary state before the first
+// grant, not a failure, and the caller reads it as "prompt the user".
+func TestFileRestoreTokenStore_LoadReportsNoTokenWhenNoneIsStored(t *testing.T) {
+	store, _ := storeUnderTempState(t)
+
+	if got := store.load(); got != "" {
+		t.Errorf("load() = %q, want empty", got)
+	}
+}
+
+// TestFileRestoreTokenStore_ClearRemovesTheStoredToken pins both halves of the
+// refusal path: the dead token goes away, and clearing again is not an error —
+// the caller clears on every refusal without first asking whether it stored
+// anything.
+func TestFileRestoreTokenStore_ClearRemovesTheStoredToken(t *testing.T) {
+	store, _ := storeUnderTempState(t)
+
+	err := store.save("token-abc")
+	if err != nil {
+		t.Fatalf("save() error = %v", err)
+	}
+
+	err = store.clear()
+	if err != nil {
+		t.Fatalf("clear() error = %v", err)
+	}
+
+	if got := store.load(); got != "" {
+		t.Errorf("load() after clear = %q, want empty", got)
+	}
+
+	err = store.clear()
+	if err != nil {
+		t.Errorf("clear() on an already-cleared store error = %v, want nil", err)
+	}
+}
+
+// TestFileRestoreTokenStore_LoadIgnoresSurroundingWhitespace keeps a token
+// written with a trailing newline — by us, or by a user inspecting the file —
+// from being replayed with the newline attached, which the portal would refuse.
+func TestFileRestoreTokenStore_LoadIgnoresSurroundingWhitespace(t *testing.T) {
+	store, dir := storeUnderTempState(t)
+
+	err := os.MkdirAll(dir, restoreTokenDirMode)
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	err = os.WriteFile(store.path, []byte("  token-abc\n"), restoreTokenFileMode)
+	if err != nil {
+		t.Fatalf("seed token file: %v", err)
+	}
+
+	if got := store.load(); got != "token-abc" {
+		t.Errorf("load() = %q, want %q", got, "token-abc")
+	}
+}

--- a/internal/adapter/platform/linux/portal_session.go
+++ b/internal/adapter/platform/linux/portal_session.go
@@ -1,0 +1,159 @@
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"errors"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// The policy that turns a stored restore token into a session without a
+// consent prompt, and decides what to do when the stored token no longer
+// works.
+//
+// It is separated from the D-Bus handshake below it because the handshake is
+// the part no test on this repository's development platform can drive — it
+// needs a live xdg-desktop-portal with a KDE backend — while "which token do we
+// present, and how many times do we ask" is a decision with three inputs and
+// no I/O.
+
+// errPortalRequestCanceled reports that the user answered the portal's consent
+// dialog with "no". It is distinguished from every other failure because it is
+// the one refusal that a second prompt would simply repeat back at them.
+var errPortalRequestCanceled = errors.New("the remote desktop consent request was canceled")
+
+// errPortalGrantYieldedNoDevices reports that the portal handed over a session
+// but no input device ever came up on it. The grant itself was fine, so a
+// second handshake through any other path would ask the same portal for the
+// same devices and get the same answer — at the cost of another dialog.
+var errPortalGrantYieldedNoDevices = errors.New(
+	"the granted remote desktop session brought up no input device",
+)
+
+// portalGrant is one established RemoteDesktop grant: the EIS socket libei
+// injects through, and the token that restores the same grant next time.
+type portalGrant struct {
+	// eisFD is the file descriptor of the EIS socket. Ownership passes to the
+	// caller, which hands it to libei.
+	eisFD int
+	// restoreToken restores this grant on a later start, and is empty when the
+	// portal declined to persist it. It is a credential: see
+	// portal_restore_token.go for what that means in this package.
+	restoreToken string
+	// close ends the portal session and releases the D-Bus connection holding
+	// it. The EIS fd is not closed here — libei owns it once it is handed over.
+	close func()
+}
+
+// portalOpener establishes a RemoteDesktop grant, restoring the session that
+// restoreToken names when it is not empty.
+type portalOpener func(ctx context.Context, restoreToken string) (portalGrant, error)
+
+// establishPortalGrant opens a RemoteDesktop grant, reusing the stored one when
+// there is one to reuse.
+//
+// It attempts the portal at most twice, ever. The first attempt presents
+// whatever token is stored; if that is refused the token is dropped and one
+// fresh attempt prompts the user. There is no third attempt and no backoff:
+// a portal that refuses a prompt the user just answered will refuse it again,
+// and looping on it would sit in front of the daemon's startup.
+//
+// Whatever token the grant hands back is stored, because a restore token is
+// invalidated by the use that consumes it — keeping the presented one would
+// restore exactly once and prompt on every start after that.
+func establishPortalGrant(
+	ctx context.Context,
+	store restoreTokenStore,
+	open portalOpener,
+) (portalGrant, error) {
+	stored := store.load()
+
+	grant, err := open(ctx, stored)
+	if err == nil {
+		persistRestoreToken(store, grant.restoreToken)
+
+		return grant, nil
+	}
+
+	// Nothing was presented, so no stored grant can be blamed and a second
+	// attempt would repeat the first exactly. Nor when the failure was not the
+	// token's fault — see storedGrantPresumedDead.
+	if stored == "" || !storedGrantPresumedDead(err) {
+		return portalGrant{}, err
+	}
+
+	// The stored token is presumed revoked or expired. Drop it, so the next
+	// start begins clean rather than replaying a credential that failed, and
+	// prompt exactly once.
+	_ = store.clear()
+
+	grant, err = open(ctx, "")
+	if err != nil {
+		return portalGrant{}, err
+	}
+
+	persistRestoreToken(store, grant.restoreToken)
+
+	return grant, nil
+}
+
+// storedGrantPresumedDead reports whether a failed restore attempt should be
+// blamed on the token it presented — which is what decides whether the token is
+// thrown away and the user asked afresh.
+//
+// Only failures the portal itself produced count. Two do not, and treating
+// them as the token's fault would throw away a grant that still works and buy
+// a consent prompt on the next start with it:
+//
+//   - the user canceled the dialog, which says nothing about the token and
+//     which a second prompt would only ask again;
+//   - the session bus was unreachable or the handshake ran out of time, where
+//     nothing ever reached the portal to refuse anything.
+func storedGrantPresumedDead(err error) bool {
+	switch {
+	case errors.Is(err, errPortalRequestCanceled):
+		return false
+	case derrors.IsCode(err, derrors.CodeTimeout), derrors.IsNotSupported(err):
+		return false
+	default:
+		return true
+	}
+}
+
+// promptingFallbackAllowed reports whether a failed handshake may be followed
+// by a second attempt that would put a consent dialog on screen.
+//
+// Two failures forbid it, and both for the same reason — the dialog would buy
+// nothing. A request the user canceled has already been answered, and asking
+// again is the consent fatigue this whole file exists to remove; a grant that
+// came up with no input device was not a consent problem at all, and a second
+// handshake would ask the same portal for the same devices.
+//
+// It is a predicate rather than an inline check because the fallback it guards
+// lives in the cgo-only file, where no test can reach it.
+func promptingFallbackAllowed(err error) bool {
+	return !errors.Is(err, errPortalRequestCanceled) &&
+		!errors.Is(err, errPortalGrantYieldedNoDevices)
+}
+
+// persistRestoreToken records the token this grant handed back, or clears the
+// store when it handed back none — a portal that granted the session without
+// persisting it leaves the presented token spent, and a spent token is worse
+// than no token because it costs a refused attempt before the prompt.
+//
+// A store that cannot be written is not an error the caller should see: the
+// session in hand is live and usable, and the cost of the failure is one
+// consent prompt on the next start, which is the behavior this change replaces
+// rather than a new failure. Refusing a grant the user just approved because a
+// state directory is read-only would be the worse trade.
+func persistRestoreToken(store restoreTokenStore, token string) {
+	if token == "" {
+		_ = store.clear()
+
+		return
+	}
+
+	_ = store.save(token)
+}

--- a/internal/adapter/platform/linux/portal_session.go
+++ b/internal/adapter/platform/linux/portal_session.go
@@ -24,6 +24,34 @@ import (
 // the one refusal that a second prompt would simply repeat back at them.
 var errPortalRequestCanceled = errors.New("the remote desktop consent request was canceled")
 
+// errPortalGrantNotPresented reports that a handshake failed before the stored
+// restore token was ever put in front of the portal. Nothing refused the token,
+// because nothing was shown it — so it is kept.
+var errPortalGrantNotPresented = errors.New(
+	"the stored grant was never presented to the portal",
+)
+
+// notPresentedError marks a failure as having happened before the token was
+// presented. It is transparent on purpose: the message and the derrors code are
+// the wrapped error's, so only the extra question this type answers is new.
+type notPresentedError struct {
+	err error
+}
+
+func (e notPresentedError) Error() string { return e.err.Error() }
+
+func (e notPresentedError) Unwrap() error { return e.err }
+
+func (e notPresentedError) Is(target error) bool { return target == errPortalGrantNotPresented }
+
+// failedBeforePresenting marks err as a failure the stored token cannot be
+// blamed for. Every step before SelectDevices is one: the bus dial, the reply
+// subscription and CreateSession all run before the token is sent, so a failure
+// in any of them says nothing about whether the grant is still good.
+func failedBeforePresenting(err error) error {
+	return notPresentedError{err: err}
+}
+
 // errPortalGrantYieldedNoDevices reports that the portal handed over a session
 // but no input device ever came up on it. The grant itself was fine, so a
 // second handshake through any other path would ask the same portal for the
@@ -103,16 +131,21 @@ func establishPortalGrant(
 // blamed on the token it presented — which is what decides whether the token is
 // thrown away and the user asked afresh.
 //
-// Only failures the portal itself produced count. Two do not, and treating
-// them as the token's fault would throw away a grant that still works and buy
-// a consent prompt on the next start with it:
+// Only a refusal of the token itself counts. Three failures do not, and
+// treating any of them as the token's fault would throw away a grant that still
+// works and buy a consent prompt on the next start with it:
 //
+//   - the handshake never got as far as presenting the token — the bus dial,
+//     the reply subscription and CreateSession all run before SelectDevices
+//     sends it, so nothing had been shown the token to refuse;
 //   - the user canceled the dialog, which says nothing about the token and
 //     which a second prompt would only ask again;
-//   - the session bus was unreachable or the handshake ran out of time, where
-//     nothing ever reached the portal to refuse anything.
+//   - the call ran out of time or the session bus was unreachable, which is the
+//     portal not answering rather than the portal saying no.
 func storedGrantPresumedDead(err error) bool {
 	switch {
+	case errors.Is(err, errPortalGrantNotPresented):
+		return false
 	case errors.Is(err, errPortalRequestCanceled):
 		return false
 	case derrors.IsCode(err, derrors.CodeTimeout), derrors.IsNotSupported(err):

--- a/internal/adapter/platform/linux/portal_session.go
+++ b/internal/adapter/platform/linux/portal_session.go
@@ -24,32 +24,41 @@ import (
 // the one refusal that a second prompt would simply repeat back at them.
 var errPortalRequestCanceled = errors.New("the remote desktop consent request was canceled")
 
-// errPortalGrantNotPresented reports that a handshake failed before the stored
-// restore token was ever put in front of the portal. Nothing refused the token,
-// because nothing was shown it — so it is kept.
-var errPortalGrantNotPresented = errors.New(
-	"the stored grant was never presented to the portal",
+// errPortalFailureUnrelatedToGrant reports a handshake failure the stored
+// restore token cannot be blamed for, so the token is kept.
+var errPortalFailureUnrelatedToGrant = errors.New(
+	"the remote desktop handshake failed for a reason unrelated to the stored grant",
 )
 
-// notPresentedError marks a failure as having happened before the token was
-// presented. It is transparent on purpose: the message and the derrors code are
-// the wrapped error's, so only the extra question this type answers is new.
-type notPresentedError struct {
+// unrelatedError marks such a failure. It is transparent on purpose: the
+// message and the derrors code are the wrapped error's, so the only new thing
+// is the extra question this type answers.
+type unrelatedError struct {
 	err error
 }
 
-func (e notPresentedError) Error() string { return e.err.Error() }
+func (e unrelatedError) Error() string { return e.err.Error() }
 
-func (e notPresentedError) Unwrap() error { return e.err }
+func (e unrelatedError) Unwrap() error { return e.err }
 
-func (e notPresentedError) Is(target error) bool { return target == errPortalGrantNotPresented }
+func (e unrelatedError) Is(target error) bool { return target == errPortalFailureUnrelatedToGrant }
 
-// failedBeforePresenting marks err as a failure the stored token cannot be
-// blamed for. Every step before SelectDevices is one: the bus dial, the reply
-// subscription and CreateSession all run before the token is sent, so a failure
-// in any of them says nothing about whether the grant is still good.
-func failedBeforePresenting(err error) error {
-	return notPresentedError{err: err}
+// unrelatedToStoredGrant marks err as a failure that says nothing about the
+// stored token. Two stretches of the handshake qualify, at either end of it:
+//
+//   - everything before SelectDevices — the bus dial, the reply subscription,
+//     CreateSession — because the token has not been sent yet, so nothing has
+//     been shown it to refuse;
+//   - ConnectToEIS, because by then the grant is complete: the portal has
+//     started the session and handed back a fresh token, and a socket it will
+//     not produce is not a credential problem.
+//
+// What is left in between is SelectDevices and Start, the two calls that carry
+// the token and consume it. A failure there is treated as the token's fault,
+// deliberately erring toward one extra consent prompt rather than toward a
+// daemon that can never establish a session again.
+func unrelatedToStoredGrant(err error) error {
+	return unrelatedError{err: err}
 }
 
 // errPortalGrantYieldedNoDevices reports that the portal handed over a session
@@ -131,20 +140,20 @@ func establishPortalGrant(
 // blamed on the token it presented — which is what decides whether the token is
 // thrown away and the user asked afresh.
 //
-// Only a refusal of the token itself counts. Three failures do not, and
-// treating any of them as the token's fault would throw away a grant that still
-// works and buy a consent prompt on the next start with it:
+// Only a refusal by one of the two calls that carry the token counts. Three
+// failures do not, and treating any of them as the token's fault would throw
+// away a grant that still works and buy a consent prompt on the next start
+// with it:
 //
-//   - the handshake never got as far as presenting the token — the bus dial,
-//     the reply subscription and CreateSession all run before SelectDevices
-//     sends it, so nothing had been shown the token to refuse;
+//   - a step that never had the token in its hands, at either end of the
+//     handshake — see unrelatedToStoredGrant;
 //   - the user canceled the dialog, which says nothing about the token and
 //     which a second prompt would only ask again;
 //   - the call ran out of time or the session bus was unreachable, which is the
 //     portal not answering rather than the portal saying no.
 func storedGrantPresumedDead(err error) bool {
 	switch {
-	case errors.Is(err, errPortalGrantNotPresented):
+	case errors.Is(err, errPortalFailureUnrelatedToGrant):
 		return false
 	case errors.Is(err, errPortalRequestCanceled):
 		return false

--- a/internal/adapter/platform/linux/portal_session_test.go
+++ b/internal/adapter/platform/linux/portal_session_test.go
@@ -236,41 +236,53 @@ func TestEstablishPortalGrant_DoesNotPromptAgainWhenTheUserCanceled(t *testing.T
 	}
 }
 
-// TestEstablishPortalGrant_KeepsTheStoredTokenWhenTheHandshakeNeverPresentedIt
-// covers the failures that happen before SelectDevices carries the token: the
-// bus dial, the reply subscription, CreateSession. They surface as ordinary
-// action failures, so without the marking they would look exactly like the
-// portal refusing the grant — and would spend a perfectly good one.
-func TestEstablishPortalGrant_KeepsTheStoredTokenWhenTheHandshakeNeverPresentedIt(
-	t *testing.T,
-) {
-	store := &fakeTokenStore{token: storedToken}
-	failure := failedBeforePresenting(
-		derrors.New(derrors.CodeActionFailed, "could not subscribe to the portal's replies"),
-	)
-	opener := &recordingOpener{t: t, answers: []openerAnswer{{err: failure}}}
-
-	_, err := establishPortalGrant(context.Background(), store, opener.open)
-	if err == nil {
-		t.Fatal("establishPortalGrant() error = nil, want the handshake's failure")
+// TestEstablishPortalGrant_KeepsTheStoredTokenWhenTheFailureWasNotItsFault
+// covers the steps at either end of the handshake that never had the token in
+// their hands — the bus dial, the reply subscription and CreateSession before
+// it is sent, ConnectToEIS after the grant is already complete. They surface as
+// ordinary action failures, so without the marking they would look exactly like
+// the portal refusing the grant, and would spend a perfectly good one.
+func TestEstablishPortalGrant_KeepsTheStoredTokenWhenTheFailureWasNotItsFault(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+	}{
+		{name: "before the token is sent", reason: "could not subscribe to the portal's replies"},
+		{name: "after the grant completes", reason: "would not hand over an EIS socket"},
 	}
 
-	if len(opener.presented) != 1 {
-		t.Errorf("portal attempts = %d, want 1", len(opener.presented))
-	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &fakeTokenStore{token: storedToken}
+			failure := unrelatedToStoredGrant(
+				derrors.New(derrors.CodeActionFailed, testCase.reason),
+			)
+			opener := &recordingOpener{t: t, answers: []openerAnswer{{err: failure}}}
 
-	if store.cleared != 0 {
-		t.Errorf("stored token cleared %d times, want 0", store.cleared)
-	}
+			_, err := establishPortalGrant(context.Background(), store, opener.open)
+			if err == nil {
+				t.Fatal("establishPortalGrant() error = nil, want the handshake's failure")
+			}
 
-	// The marking must not swallow what the failure actually said, or a user
-	// reading the error learns nothing about why the session did not come up.
-	if !derrors.IsCode(err, derrors.CodeActionFailed) {
-		t.Errorf("error code = %q, want %q", derrors.GetCode(err), derrors.CodeActionFailed)
-	}
+			if len(opener.presented) != 1 {
+				t.Errorf("portal attempts = %d, want 1", len(opener.presented))
+			}
 
-	if !strings.Contains(err.Error(), "could not subscribe") {
-		t.Errorf("error = %q, want it to carry the underlying reason", err.Error())
+			if store.cleared != 0 {
+				t.Errorf("stored token cleared %d times, want 0", store.cleared)
+			}
+
+			// The marking must not swallow what the failure actually said, or a
+			// user reading the error learns nothing about why nothing came up.
+			if !derrors.IsCode(err, derrors.CodeActionFailed) {
+				t.Errorf("error code = %q, want %q",
+					derrors.GetCode(err), derrors.CodeActionFailed)
+			}
+
+			if !strings.Contains(err.Error(), testCase.reason) {
+				t.Errorf("error = %q, want it to carry the underlying reason", err.Error())
+			}
+		})
 	}
 }
 

--- a/internal/adapter/platform/linux/portal_session_test.go
+++ b/internal/adapter/platform/linux/portal_session_test.go
@@ -5,6 +5,7 @@ package linux
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/derrors"
@@ -232,6 +233,44 @@ func TestEstablishPortalGrant_DoesNotPromptAgainWhenTheUserCanceled(t *testing.T
 
 	if store.cleared != 0 {
 		t.Errorf("stored token cleared %d times, want 0", store.cleared)
+	}
+}
+
+// TestEstablishPortalGrant_KeepsTheStoredTokenWhenTheHandshakeNeverPresentedIt
+// covers the failures that happen before SelectDevices carries the token: the
+// bus dial, the reply subscription, CreateSession. They surface as ordinary
+// action failures, so without the marking they would look exactly like the
+// portal refusing the grant — and would spend a perfectly good one.
+func TestEstablishPortalGrant_KeepsTheStoredTokenWhenTheHandshakeNeverPresentedIt(
+	t *testing.T,
+) {
+	store := &fakeTokenStore{token: storedToken}
+	failure := failedBeforePresenting(
+		derrors.New(derrors.CodeActionFailed, "could not subscribe to the portal's replies"),
+	)
+	opener := &recordingOpener{t: t, answers: []openerAnswer{{err: failure}}}
+
+	_, err := establishPortalGrant(context.Background(), store, opener.open)
+	if err == nil {
+		t.Fatal("establishPortalGrant() error = nil, want the handshake's failure")
+	}
+
+	if len(opener.presented) != 1 {
+		t.Errorf("portal attempts = %d, want 1", len(opener.presented))
+	}
+
+	if store.cleared != 0 {
+		t.Errorf("stored token cleared %d times, want 0", store.cleared)
+	}
+
+	// The marking must not swallow what the failure actually said, or a user
+	// reading the error learns nothing about why the session did not come up.
+	if !derrors.IsCode(err, derrors.CodeActionFailed) {
+		t.Errorf("error code = %q, want %q", derrors.GetCode(err), derrors.CodeActionFailed)
+	}
+
+	if !strings.Contains(err.Error(), "could not subscribe") {
+		t.Errorf("error = %q, want it to carry the underlying reason", err.Error())
 	}
 }
 

--- a/internal/adapter/platform/linux/portal_session_test.go
+++ b/internal/adapter/platform/linux/portal_session_test.go
@@ -1,0 +1,329 @@
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// Tokens the fakes below hand around. They are opaque to the policy: what each
+// test asserts is which one was presented and which one was kept.
+const (
+	storedToken  = "stored-token"
+	revokedToken = "revoked-token"
+	nextToken    = "next-token"
+	freshToken   = "fresh-token"
+)
+
+// Failures the scripted portal answers with. Static so the no-retry test can
+// assert the caller sees the very error the second attempt produced.
+var (
+	errNotRestorable = errors.New("session could not be restored")
+	errPortalRefused = errors.New("portal refused")
+	errStoreReadOnly = errors.New("read-only state directory")
+)
+
+// fakeTokenStore is a restoreTokenStore that records what the policy did to it.
+type fakeTokenStore struct {
+	token   string
+	saved   []string
+	cleared int
+	saveErr error
+}
+
+func (f *fakeTokenStore) load() string { return f.token }
+
+func (f *fakeTokenStore) save(token string) error {
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+
+	f.token = token
+	f.saved = append(f.saved, token)
+
+	return nil
+}
+
+func (f *fakeTokenStore) clear() error {
+	f.token = ""
+	f.cleared++
+
+	return nil
+}
+
+// recordingOpener replays a scripted sequence of portal answers and records the
+// restore token each attempt presented. A test that expects one attempt scripts
+// one answer, so an unexpected extra attempt fails loudly rather than reading
+// past the end of the script.
+type recordingOpener struct {
+	t         *testing.T
+	answers   []openerAnswer
+	presented []string
+}
+
+type openerAnswer struct {
+	grant portalGrant
+	err   error
+}
+
+func (r *recordingOpener) open(_ context.Context, restoreToken string) (portalGrant, error) {
+	r.t.Helper()
+
+	if len(r.presented) >= len(r.answers) {
+		r.t.Fatalf(
+			"portal opened %d times, script has %d answers",
+			len(r.presented)+1,
+			len(r.answers),
+		)
+	}
+
+	answer := r.answers[len(r.presented)]
+	r.presented = append(r.presented, restoreToken)
+
+	return answer.grant, answer.err
+}
+
+// grantWithToken builds a portal answer carrying a fresh restore token.
+func grantWithToken(token string) openerAnswer {
+	return openerAnswer{grant: portalGrant{eisFD: 7, restoreToken: token}}
+}
+
+// TestEstablishPortalGrant_RestoresTheStoredGrantWithoutPrompting is the whole
+// point of the ticket: a restart presents the token it stored last time and the
+// portal restores the session, so the user sees no consent dialog.
+func TestEstablishPortalGrant_RestoresTheStoredGrantWithoutPrompting(t *testing.T) {
+	store := &fakeTokenStore{token: storedToken}
+	opener := &recordingOpener{t: t, answers: []openerAnswer{grantWithToken(nextToken)}}
+
+	grant, err := establishPortalGrant(context.Background(), store, opener.open)
+	if err != nil {
+		t.Fatalf("establishPortalGrant() error = %v", err)
+	}
+
+	if grant.eisFD != 7 {
+		t.Errorf("grant.eisFD = %d, want 7", grant.eisFD)
+	}
+
+	if len(opener.presented) != 1 || opener.presented[0] != storedToken {
+		t.Errorf("portal attempts = %q, want one attempt presenting the stored token",
+			opener.presented)
+	}
+
+	if store.cleared != 0 {
+		t.Errorf("stored token cleared %d times, want 0", store.cleared)
+	}
+}
+
+// TestEstablishPortalGrant_StoresTheTokenTheGrantReturned pins the half that
+// makes the restore repeatable. A restore token is invalidated by the use that
+// consumes it, so a session that keeps the token it presented would restore
+// exactly once and prompt forever after.
+func TestEstablishPortalGrant_StoresTheTokenTheGrantReturned(t *testing.T) {
+	store := &fakeTokenStore{token: storedToken}
+	opener := &recordingOpener{t: t, answers: []openerAnswer{grantWithToken(nextToken)}}
+
+	_, err := establishPortalGrant(context.Background(), store, opener.open)
+	if err != nil {
+		t.Fatalf("establishPortalGrant() error = %v", err)
+	}
+
+	if len(store.saved) != 1 || store.saved[0] != nextToken {
+		t.Errorf("tokens saved = %q, want the token the grant returned", store.saved)
+	}
+}
+
+// TestEstablishPortalGrant_ClearsTheStoredTokenWhenTheGrantIsNotPersistent
+// covers a portal that grants the session but declines to persist it — the
+// token that was just presented is spent, so keeping it would have the next
+// start replay a credential that cannot work.
+func TestEstablishPortalGrant_ClearsTheStoredTokenWhenTheGrantIsNotPersistent(t *testing.T) {
+	store := &fakeTokenStore{token: storedToken}
+	opener := &recordingOpener{t: t, answers: []openerAnswer{grantWithToken("")}}
+
+	_, err := establishPortalGrant(context.Background(), store, opener.open)
+	if err != nil {
+		t.Fatalf("establishPortalGrant() error = %v", err)
+	}
+
+	if store.cleared != 1 {
+		t.Errorf("stored token cleared %d times, want 1", store.cleared)
+	}
+
+	if len(store.saved) != 0 {
+		t.Errorf("tokens saved = %q, want none", store.saved)
+	}
+}
+
+// TestEstablishPortalGrant_PromptsOnceWhenTheStoredTokenIsRefused is the
+// revoked-or-expired path: exactly two attempts, the second presenting nothing
+// so the portal prompts, and the dead token dropped rather than retried.
+func TestEstablishPortalGrant_PromptsOnceWhenTheStoredTokenIsRefused(t *testing.T) {
+	store := &fakeTokenStore{token: revokedToken}
+	opener := &recordingOpener{t: t, answers: []openerAnswer{
+		{err: errNotRestorable},
+		grantWithToken(freshToken),
+	}}
+
+	grant, err := establishPortalGrant(context.Background(), store, opener.open)
+	if err != nil {
+		t.Fatalf("establishPortalGrant() error = %v", err)
+	}
+
+	if grant.eisFD != 7 {
+		t.Errorf("grant.eisFD = %d, want 7", grant.eisFD)
+	}
+
+	want := []string{revokedToken, ""}
+	if len(opener.presented) != len(want) ||
+		opener.presented[0] != want[0] || opener.presented[1] != want[1] {
+		t.Errorf("portal attempts = %q, want %q", opener.presented, want)
+	}
+
+	if store.cleared != 1 {
+		t.Errorf("stored token cleared %d times, want 1", store.cleared)
+	}
+
+	if len(store.saved) != 1 || store.saved[0] != freshToken {
+		t.Errorf("tokens saved = %q, want the token the fresh grant returned", store.saved)
+	}
+}
+
+// TestEstablishPortalGrant_DoesNotRetryAfterTheFreshPromptFails is the
+// no-retry-loop half. The script carries two answers, so a third attempt fails
+// the test rather than being tolerated.
+func TestEstablishPortalGrant_DoesNotRetryAfterTheFreshPromptFails(t *testing.T) {
+	store := &fakeTokenStore{token: revokedToken}
+	opener := &recordingOpener{t: t, answers: []openerAnswer{
+		{err: errNotRestorable},
+		{err: errPortalRefused},
+	}}
+
+	_, err := establishPortalGrant(context.Background(), store, opener.open)
+	if !errors.Is(err, errPortalRefused) {
+		t.Fatalf("establishPortalGrant() error = %v, want %v", err, errPortalRefused)
+	}
+
+	if len(opener.presented) != 2 {
+		t.Errorf("portal attempts = %d, want 2", len(opener.presented))
+	}
+}
+
+// TestEstablishPortalGrant_DoesNotPromptAgainWhenTheUserCanceled keeps a
+// refusal the user made themselves from being answered with a second dialog.
+// A canceled request says nothing about the stored token, so it is kept.
+func TestEstablishPortalGrant_DoesNotPromptAgainWhenTheUserCanceled(t *testing.T) {
+	store := &fakeTokenStore{token: storedToken}
+	opener := &recordingOpener{t: t, answers: []openerAnswer{
+		{err: errPortalRequestCanceled},
+	}}
+
+	_, err := establishPortalGrant(context.Background(), store, opener.open)
+	if !errors.Is(err, errPortalRequestCanceled) {
+		t.Fatalf("establishPortalGrant() error = %v, want cancelation", err)
+	}
+
+	if len(opener.presented) != 1 {
+		t.Errorf("portal attempts = %d, want 1", len(opener.presented))
+	}
+
+	if store.cleared != 0 {
+		t.Errorf("stored token cleared %d times, want 0", store.cleared)
+	}
+}
+
+// TestEstablishPortalGrant_KeepsTheStoredTokenWhenNothingReachedThePortal is
+// the other half of "prompt once": a bus that could not be reached and a
+// handshake that ran out of time are not the token's fault, so throwing it away
+// would spend a working grant — and buy a consent prompt on the next start —
+// for a failure that had nothing to do with it.
+func TestEstablishPortalGrant_KeepsTheStoredTokenWhenNothingReachedThePortal(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "no session bus", err: derrors.New(derrors.CodeNotSupported, "no session bus")},
+		{name: "handshake timed out", err: derrors.New(derrors.CodeTimeout, "no answer in time")},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &fakeTokenStore{token: storedToken}
+			opener := &recordingOpener{t: t, answers: []openerAnswer{{err: testCase.err}}}
+
+			_, err := establishPortalGrant(context.Background(), store, opener.open)
+			if err == nil {
+				t.Fatal("establishPortalGrant() error = nil, want the portal's failure")
+			}
+
+			if len(opener.presented) != 1 {
+				t.Errorf("portal attempts = %d, want 1", len(opener.presented))
+			}
+
+			if store.cleared != 0 {
+				t.Errorf("stored token cleared %d times, want 0", store.cleared)
+			}
+		})
+	}
+}
+
+// TestPromptingFallbackAllowed_RefusesToReAskAUserWhoSaidNo guards the second
+// place a dialog could be raised: the KDE input path falls back to the
+// liboeffis handshake when its own portal attempt fails, and that handshake
+// always prompts. Falling back after a cancelation would ask the user the same
+// question twice in one start.
+func TestPromptingFallbackAllowed_RefusesToReAskAUserWhoSaidNo(t *testing.T) {
+	if promptingFallbackAllowed(errPortalRequestCanceled) {
+		t.Error("a canceled consent request allows a prompting fallback, want refused")
+	}
+
+	if promptingFallbackAllowed(errPortalGrantYieldedNoDevices) {
+		t.Error("a device-less grant allows a prompting fallback, want refused")
+	}
+
+	if !promptingFallbackAllowed(errPortalRefused) {
+		t.Error("a portal failure refuses a prompting fallback, want allowed")
+	}
+}
+
+// TestEstablishPortalGrant_PromptsWhenNothingIsStored covers the first run:
+// one attempt, presenting no token, and the token it comes back with stored.
+func TestEstablishPortalGrant_PromptsWhenNothingIsStored(t *testing.T) {
+	store := &fakeTokenStore{}
+	opener := &recordingOpener{t: t, answers: []openerAnswer{grantWithToken("first-token")}}
+
+	_, err := establishPortalGrant(context.Background(), store, opener.open)
+	if err != nil {
+		t.Fatalf("establishPortalGrant() error = %v", err)
+	}
+
+	if len(opener.presented) != 1 || opener.presented[0] != "" {
+		t.Errorf("portal attempts = %q, want one attempt presenting no token",
+			opener.presented)
+	}
+
+	if len(store.saved) != 1 || store.saved[0] != "first-token" {
+		t.Errorf("tokens saved = %q, want the token the grant returned", store.saved)
+	}
+}
+
+// TestEstablishPortalGrant_KeepsTheGrantWhenTheTokenCannotBeStored pins the
+// degradation: an unwritable state directory costs the user a prompt on the
+// next start, which is strictly better than refusing the session they just
+// approved.
+func TestEstablishPortalGrant_KeepsTheGrantWhenTheTokenCannotBeStored(t *testing.T) {
+	store := &fakeTokenStore{saveErr: errStoreReadOnly}
+	opener := &recordingOpener{t: t, answers: []openerAnswer{grantWithToken(nextToken)}}
+
+	grant, err := establishPortalGrant(context.Background(), store, opener.open)
+	if err != nil {
+		t.Fatalf("establishPortalGrant() error = %v", err)
+	}
+
+	if grant.eisFD != 7 {
+		t.Errorf("grant.eisFD = %d, want 7", grant.eisFD)
+	}
+}

--- a/internal/adapter/platform/linux/system_wayland_kde_cgo.go
+++ b/internal/adapter/platform/linux/system_wayland_kde_cgo.go
@@ -10,7 +10,9 @@ package linux
 import "C"
 
 import (
+	"context"
 	"sync"
+	"time"
 
 	"github.com/y3owk1n/neru/internal/derrors"
 )
@@ -29,6 +31,11 @@ const libeiConnectTimeoutMs = 1500
 // consent dialog appears while no overlay is up, giving the user a comfortable
 // window to find and approve the one-time "Remote Control" prompt. Once
 // approved here, every later action reuses the session with no further wait.
+//
+// It is also the only place the prompt is expected to be paid at all: warm-up
+// presents the stored restore token, so a restart normally establishes the
+// session with no dialog and well inside this budget. The long timeout is what
+// the first grant on a machine costs, not what every start costs.
 const libeiWarmupTimeoutMs = 120000
 
 // libeiState owns the libei/RemoteDesktop session used for input injection on
@@ -38,7 +45,12 @@ const libeiWarmupTimeoutMs = 120000
 type libeiState struct {
 	mu     sync.Mutex
 	client *C.NeruEiClient
-	ready  bool
+	// closePortal ends the RemoteDesktop session this client injects through
+	// and drops the bus connection holding it. It is nil when the session came
+	// from the liboeffis fallback below, which owns its session inside the C
+	// client and tears it down with neru_ei_disconnect.
+	closePortal func()
+	ready       bool
 }
 
 var globalLibeiState = &libeiState{}
@@ -50,26 +62,112 @@ func (s *libeiState) ensureLocked() error {
 
 // ensureLockedTimeout establishes the portal session with an explicit connect
 // timeout. The caller holds mu.
+//
+// The whole budget is one deadline, shared by both attempts below, so a session
+// never costs more wall clock than the caller allowed — which is what keeps the
+// mid-action path from freezing the goroutine holding the keyboard grab even
+// when the portal is unresponsive.
 func (s *libeiState) ensureLockedTimeout(timeoutMs int) error {
 	if s.ready {
 		return nil
 	}
 
-	client := C.neru_ei_connect(C.int(timeoutMs))
+	deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
+
+	client, closePortal, portalErr := connectViaPortal(deadline)
+	if portalErr == nil {
+		s.client, s.closePortal, s.ready = client, closePortal, true
+
+		return nil
+	}
+
+	// A refusal the user made themselves is final. The fallback below opens a
+	// second session and would put the same dialog back in front of them, which
+	// is the one outcome worse than having no session.
+	if !promptingFallbackAllowed(portalErr) {
+		return libeiSessionError(portalErr)
+	}
+
+	// Fall back to the liboeffis handshake inside the C client. It cannot reuse
+	// a grant, so it costs the user a consent prompt, but a session that
+	// prompts is worth far more than no session at all — and this is the path
+	// every KDE install used before restore existed, so a portal Neru's own
+	// handshake cannot drive still works exactly as well as it used to.
+	remainingMs := int(time.Until(deadline).Milliseconds())
+	if remainingMs <= 0 {
+		return libeiSessionError(portalErr)
+	}
+
+	client = C.neru_ei_connect(C.int(remainingMs))
 	if client == nil {
-		return derrors.New(
+		return libeiSessionError(portalErr)
+	}
+
+	s.client, s.closePortal, s.ready = client, nil, true
+
+	return nil
+}
+
+// connectViaPortal runs Neru's own RemoteDesktop handshake — the one that can
+// present a stored restore token — and attaches libei to the EIS socket it
+// yields. It returns the C client and the function that ends the session.
+//
+// The EIS file descriptor's ownership passes to neru_ei_connect_fd, which
+// closes it on every path, so nothing here closes it: the portal session is
+// what this function still has to unwind.
+func connectViaPortal(deadline time.Time) (*C.NeruEiClient, func(), error) {
+	store, err := newFileRestoreTokenStore()
+	if err != nil {
+		return nil, nil, derrors.Wrap(
+			err,
 			derrors.CodeActionFailed,
-			"could not establish a libei input session via the RemoteDesktop "+
-				"portal; approve the one-time \"Remote Control\" consent prompt "+
-				"(KDE Plasma routes input through xdg-desktop-portal because KWin "+
-				"does not implement zwlr_virtual_pointer_v1)",
+			"could not resolve where to keep the RemoteDesktop portal grant",
 		)
 	}
 
-	s.client = client
-	s.ready = true
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
 
-	return nil
+	grant, err := establishPortalGrant(ctx, store, openRemoteDesktopSession)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Whatever is left of the budget, the socket is handed over rather than
+	// short-circuited on: neru_ei_connect_fd is the only thing that closes the
+	// descriptor, so a branch that skipped it would leak one per attempt. A
+	// budget already spent buys a call that gives up immediately, which is what
+	// was wanted anyway — and the floor is 1, because the C side reads a
+	// non-positive timeout as "use the default", which is 30 seconds.
+	remainingMs := max(int(time.Until(deadline).Milliseconds()), 1)
+
+	client := C.neru_ei_connect_fd(C.int(grant.eisFD), C.int(remainingMs))
+	if client == nil {
+		grant.close()
+
+		return nil, nil, derrors.Wrap(
+			errPortalGrantYieldedNoDevices,
+			derrors.CodeActionFailed,
+			"the RemoteDesktop portal granted a session but no pointer device came "+
+				"up on it",
+		)
+	}
+
+	return client, grant.close, nil
+}
+
+// libeiSessionError phrases the failure for the user, carrying the portal's own
+// reason as the cause. Nothing here can name the restore token: the token never
+// reaches an error value, by construction (portal_restore_token.go).
+func libeiSessionError(cause error) error {
+	return derrors.Wrap(
+		cause,
+		derrors.CodeActionFailed,
+		"could not establish a libei input session via the RemoteDesktop "+
+			"portal; approve the one-time \"Remote Control\" consent prompt "+
+			"(KDE Plasma routes input through xdg-desktop-portal because KWin "+
+			"does not implement zwlr_virtual_pointer_v1)",
+	)
 }
 
 // libeiEnsure establishes the portal session without injecting input. The
@@ -78,6 +176,13 @@ func (s *libeiState) ensureLockedTimeout(timeoutMs int) error {
 // past the IPC timeout. This is the only path allowed to hold mu across the
 // long consent wait; mid-action input uses tryAcquire so it never blocks here.
 // libeiEnsure brings up the libei session this backend injects through.
+//
+// It is also where a stored grant is restored, which is why restoring belongs
+// here and not on the first action: the handshake runs on the startup
+// goroutine, before any keyboard grab exists, and by the time a mode can ask
+// for input the session is already up. The mid-action path can still establish
+// one — after a suspend/resume reset, say — but it does so under the short
+// budget above, never the warm-up one.
 //
 // This file is the KDE Plasma input slot, sibling to the wlroots one. KWin does
 // not implement zwlr_virtual_pointer_v1, so input goes through libei via the
@@ -259,9 +364,17 @@ func LibeiReset() {
 		return
 	}
 
+	// libei first: it owns the EIS socket, and closing the portal session out
+	// from under it would leave the client emitting into a dead transport for
+	// as long as the teardown takes.
 	if globalLibeiState.client != nil {
 		C.neru_ei_disconnect(globalLibeiState.client)
 		globalLibeiState.client = nil
+	}
+
+	if globalLibeiState.closePortal != nil {
+		globalLibeiState.closePortal()
+		globalLibeiState.closePortal = nil
 	}
 
 	globalLibeiState.ready = false

--- a/internal/adapter/platform/profile_linux.go
+++ b/internal/adapter/platform/profile_linux.go
@@ -31,7 +31,8 @@ func linuxKDEProfile() Profile {
 		},
 		KeyboardCapture: BackendPlan{
 			Name: "evdev capture + key injection via uinput when /dev/uinput is writable, " +
-				"else libei via RemoteDesktop portal (consent per daemon launch)",
+				"else libei via RemoteDesktop portal (one-time consent, restored from " +
+				"a stored grant on later starts)",
 		},
 		Overlay: BackendPlan{
 			Name: "wlr-layer-shell via KWin",

--- a/internal/adapter/vision/adapter_linux.go
+++ b/internal/adapter/vision/adapter_linux.go
@@ -166,7 +166,7 @@ func (a *Adapter) CaptureScreen(ctx context.Context) (*image.RGBA, error) {
 // KWin advertises no wlr-screencopy and so cannot be captured today, but that
 // is a fact about the running compositor rather than about the label, and it is
 // discovered where the rest of the tree discovers it: at the capture, which
-// fails naming KWin (Known Gaps Linux entry 2).
+// fails naming KWin (Known Gaps Linux entry 1).
 //
 // The recognition half catches the failure a user can actually fix: tesseract
 // language data is a separate distribution package from the library Neru links,


### PR DESCRIPTION
## Description

This PR stops KDE Plasma asking for "Remote Control" consent on every daemon
start. The grant is now persisted: Neru asks the RemoteDesktop portal to keep
the session until you revoke it, stores the token the portal hands back, and
presents that token on the next start — so a reboot, a logout, a crash or a
config reload that restarts the daemon reuses the grant with no dialog. The
first start on a machine still prompts once, as it always did.

A grant that has been revoked or has expired is handled without a loop: the
stored token is dropped and the user is prompted exactly once more, on that
same start. Only a refusal of the token itself costs it that. A refusal the
user made themselves is taken at face value — no second dialog — and a failure
that never got as far as offering the token (no session bus, a reply
subscription that would not install, a call that ran out of time) leaves the
stored grant alone rather than spending a working one on an unrelated problem.
The token lives in `~/.local/state/neru/remote-desktop.token` (honouring
`XDG_STATE_HOME`), written owner-readable only, and it is never logged and
never put in an error message — a failed portal call reports the D-Bus error's
name rather than its body, so a backend that quotes a rejected option cannot
carry the credential into a log.

The deliberate limitation: this could not be exercised against a live KDE
session. It is verified by unit tests over the restore policy and the token
store, by a full CGO Linux build, lint and test run in a container, and by
`just ci` — but the D-Bus handshake itself has only been checked against the
portal specification, not against a running `xdg-desktop-portal-kde`.

## Related Issues

Closes #1462

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, the new code is reached only from the existing KDE input slot, whose CGO-off twin already refuses; no new port or capability is introduced
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

**Nothing a user writes changes.** No config option, command, flag or
environment variable is added, renamed or given a new default, and existing
configs behave exactly as before. The one new file on disk is the token above,
which Neru creates and manages itself; deleting it simply brings the prompt
back on the next start.

**Why the portal handshake moved into Go.** `liboeffis`, which the libei client
used to open the session with, exposes no restore token — its session API takes
a device mask and nothing else — and the token is negotiated in `SelectDevices`
and returned by `Start`, both of which it owns. Reusing a grant therefore meant
speaking the four RemoteDesktop D-Bus calls directly, over the same session bus
the notification, tray and AT-SPI paths already use. Everything past the EIS
socket is still libei's.

**`liboeffis` is kept as a fallback rather than removed.** If Neru's own
handshake cannot open a session, the old path still runs inside the remaining
budget — it prompts, so it is strictly worse, but it is the path every KDE
install used before this change, and keeping it means a portal implementation
this handshake cannot drive is no worse off than it is today. Both attempts
share one deadline, so a session never costs more wall clock than the caller
allowed. Once the new path is confirmed on real hardware, dropping the fallback
and the `liboeffis` dependency with it is a clean follow-up.

**Timing.** Establishing the session is still warm-up's job, and that is where
the restore happens on an ordinary start — on the startup goroutine, before any
keyboard grab exists. The mid-action path can still establish one (after the
suspend/resume reset, say), as it could before, and every step of it is now
bounded by the caller's short budget: the bus dial runs on a goroutine the
caller can abandon, which the previous native path could not do, and ending a
session expects no reply so a wedged portal cannot hold the grab. Only one bus
dial is ever outstanding, so a bus that accepts a connection and then stops
answering costs one abandoned goroutine rather than one per keypress.

**Unchanged:** a grant that comes back without a keyboard device still reports
`CodeNotSupported` from key injection, with the same message.

**Verified with:** `just ci` on macOS, plus `just lint-cross`, `just
test-linux` and `just test-linux-nocgo` in Docker for the Linux-tagged and
CGO-only paths this touches.
