### PR TITLE
feat(linux): show a paused tray icon and announce a no-CGO build

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -156,7 +156,7 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Modifier passthrough**      | ✅                       | ❌                     | ✅ evdev backend only        | ✅ evdev backend only   | ❌                           |
 | **Dark mode detection**       | ✅ Cocoa appearance      | ✅ xdg appearance portal | ✅ xdg appearance portal   | ✅ kdeglobals + portal  | ✅ registry                  |
 | **Font resolution**           | ✅ NSFont                | ✅ fontconfig          | ✅ fontconfig                | ✅ fontconfig           | ⚠️ generic-alias map only ²  |
-| **System tray**               | ✅ NSStatusItem          | ✅ D-Bus StatusNotifierItem | ✅ StatusNotifierItem        | ✅ StatusNotifierItem   | ✅ Win32 notification area   |
+| **System tray**               | ✅ NSStatusItem ⁹        | ✅ D-Bus StatusNotifierItem ⁹ | ✅ StatusNotifierItem ⁹      | ✅ StatusNotifierItem ⁹ | ✅ Win32 notification area ⁹ |
 | **Native alerts**             | ✅ NSAlert               | ⚠️ D-Bus, not modal    | ⚠️ D-Bus, not modal          | ⚠️ D-Bus, not modal     | ✅ `MessageBoxW`             |
 | **Native notifications**      | ✅ UNNotification        | ✅ `org.freedesktop.Notifications` | ✅ `org.freedesktop.Notifications` | ✅ `org.freedesktop.Notifications` | 🟡          |
 | **Secure input detection**    | ✅                       | ➖ always false        | ➖ always false              | ➖ always false         | ➖ always false              |
@@ -342,6 +342,30 @@ user's own release a no-op at the master keyboard, so a modifier released during
 an injected scroll is pressed back and reads as held until it is pressed and
 released once more. Restoring is the deliberate bias: the opposite one drops a
 modifier the user is still holding out of everything they do next.
+
+⁹ **The tray icon carries the paused state on every platform**, because the
+tray is the only place a user can see that Neru is paused without pressing a
+key. macOS swaps between two hand-drawn template glyphs, which the menu bar
+themes for it. A host that renders icon bytes literally — the SNI hosts on
+Linux, the Win32 notification area — cannot restyle anything for us, so it is
+handed the brand tile desaturated and flattened towards grey, derived from the
+running tile itself ([icon/paused.go](../internal/adapter/systray/icon/paused.go))
+so the two can never drift apart. It is a color change rather than a
+translucency one on purpose: the icon bytes reach Win32 with straight alpha
+where GDI's icon path wants it premultiplied, so a faded tile would render at
+the host's discretion rather than ours.
+
+**Hover text works everywhere and is the tray icon's**, not a menu item's:
+`NSStatusItem.toolTip`, the SNI `ToolTip` property, and `NOTIFYICONDATA.szTip`
+all carry the "Neru - Running" / "Neru - Paused" string, which is the only
+tooltip `ports.SystrayPort` declares. Per-item menu tooltips are a different
+thing, and Neru sets none — `com.canonical.dbusmenu` defines no per-item
+tooltip property at all (an item carries `label`, `enabled`, `visible`,
+`icon-data` and the `toggle-*` pair), so `MenuItem.SetTooltip` in
+[systray/linux/systray.go](../internal/adapter/systray/linux/systray.go) is an
+empty body by protocol rather than unfinished work, as is its Win32
+popup-menu twin. The macOS backend has no such method at all. Nothing a user
+can hover therefore differs between the three.
 
 ### Notes on the ⚠️ entries
 
@@ -935,10 +959,6 @@ command — that means less here than it does on macOS, whether or not the
 2. Wayland global hotkeys — a setup requirement rather than missing code: they
    need `input`-group membership and a CGO build. Failing loudly with the
    remedy, and documenting it as a first-class setup step, is the work
-3. Tail — the tray tooltip is a no-op (dbusmenu carries no such property), the
-   tray has one icon for both running and paused states where macOS has two,
-   and the `CGO_ENABLED=0` build should announce its boundary once at startup
-   rather than failing feature by feature
 
 The gaps above are the work; what a person writes and finds inert *today* is
 [Platform Support Per Word](#platform-support-per-word), which is generated
@@ -953,6 +973,20 @@ modifier passthrough is impossible for the display server rather than unbuilt �
 `XGrabKeyboard` is all-or-nothing and `XSendEvent` is ignored by most
 applications; and `neru services` on a non-systemd init is a stated boundary,
 not unfinished work.
+
+**The `CGO_ENABLED=0` Linux build is outside the boundary too**, and says so
+itself. It is a distribution convenience for a configuration macOS does not
+offer at all: cursor, clicks, scroll, hotkeys, keyboard capture, overlay,
+screen enumeration, display hotplug, focused app, `neru key` and the `vision`
+strategy are all `CodeNotSupported` mirrors there, so the daemon starts and
+then fails feature by feature. It therefore announces what kind of build it is once at
+startup — naming what will not work and how to leave it — rather than letting a
+user discover the boundary one keystroke at a time
+([ADR 0012](./adr/0012-the-first-hour-must-not-lie.md),
+[ADR 0013](./adr/0013-parity-is-measured-in-words-not-subsystems.md)). A CGO
+build never prints it: a warning every ordinary run carries is one people learn
+to scroll past. The tray, notifications and alerts are pure Go and keep
+working, which is exactly why the build exists.
 
 **Windows**
 

--- a/internal/adapter/systray/icon/doc.go
+++ b/internal/adapter/systray/icon/doc.go
@@ -4,4 +4,9 @@
 // embedding package's own directory, and both the Linux and Windows trays draw
 // the same brand icon. Embedding it twice would put the same PNG in the tree
 // twice and let the two copies drift.
+//
+// The paused variants live here for the same reason: macOS ships a second
+// hand-drawn template glyph, and the tile the other hosts show while Neru is
+// paused is derived from the running tile rather than exported a second time
+// (paused.go).
 package icon

--- a/internal/adapter/systray/icon/paused.go
+++ b/internal/adapter/systray/icon/paused.go
@@ -1,0 +1,109 @@
+package icon
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"sync"
+)
+
+// Coefficients of the Rec. 601 luma formula, the perceptual weighting a
+// desaturated tile needs so the glyph keeps the contrast it had against the
+// tile behind it. A flat channel average would sink the blue tile and the
+// white glyph towards each other.
+const (
+	lumaRed   = 0.299
+	lumaGreen = 0.587
+	lumaBlue  = 0.114
+
+	// neutralGray is what the desaturated tile is mixed towards, and
+	// pausedContrast is how much of its own contrast survives the mix. Flat is
+	// the tray's oldest idiom for "this is not running": three fifths leaves
+	// the glyph readable against the tile while putting both far enough from
+	// the running colors to tell apart at 22 pixels.
+	//
+	// Contrast rather than opacity, deliberately. A translucent tile would
+	// depend on the host compositing it correctly, and the Win32 notification
+	// area is handed these bytes with straight alpha where GDI's icon path
+	// wants it premultiplied — a latent difference that today only touches the
+	// tile's anti-aliased corners, and that fading the whole tile would put on
+	// screen. This transform leaves every alpha value exactly as the running
+	// tile has it.
+	neutralGray    = 128.0
+	pausedContrast = 0.6
+)
+
+// BrandPaused returns the Brand tile as it appears while Neru is paused:
+// desaturated and flattened, the same artwork at the same size.
+//
+// It is derived from Brand rather than shipped as a second asset so the two
+// can never drift — the paused tile is the running tile by construction, and a
+// new brand tile needs no second export. macOS answers this question with a
+// pair of hand-drawn template glyphs instead (see trayicon_darwin.go); those
+// are white-on-transparent and would be invisible in a tray host that renders
+// icon bytes literally, which is the whole reason this derivation exists.
+//
+// The derivation runs at most once, on the first paused state of the process:
+// the tray sets an icon on every toggle, and a decode-transform-encode per
+// toggle would put PNG work on a path the user is waiting on. Its input is an
+// embedded asset and TestBrandPaused runs the transform over it, so the
+// fallback below is unreachable short of a corrupt binary — and it hands back
+// the running tile rather than nothing, because a tray showing the wrong state
+// is still better than a tray with no icon in it.
+func BrandPaused() []byte {
+	return brandPaused()
+}
+
+// brandPaused derives the paused tile once and remembers it.
+var brandPaused = sync.OnceValue(func() []byte {
+	flattened, err := flattenToPaused(Brand)
+	if err != nil {
+		return Brand
+	}
+
+	return flattened
+})
+
+// flattenToPaused decodes a PNG tile, desaturates and flattens it, and
+// re-encodes it.
+func flattenToPaused(tile []byte) ([]byte, error) {
+	src, err := png.Decode(bytes.NewReader(tile))
+	if err != nil {
+		return nil, err
+	}
+
+	bounds := src.Bounds()
+	dst := image.NewNRGBA(bounds)
+
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			dst.Set(x, y, pausedPixel(src.At(x, y)))
+		}
+	}
+
+	var out bytes.Buffer
+
+	err = png.Encode(&out, dst)
+	if err != nil {
+		return nil, err
+	}
+
+	return out.Bytes(), nil
+}
+
+// pausedPixel desaturates one pixel and flattens its contrast, leaving its
+// alpha untouched.
+func pausedPixel(c color.Color) color.NRGBA {
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA) //nolint:forcetypeassert // NRGBAModel converts to color.NRGBA by definition.
+
+	luma := lumaRed*float64(nrgba.R) + lumaGreen*float64(nrgba.G) + lumaBlue*float64(nrgba.B)
+	gray := uint8(luma*pausedContrast + neutralGray*(1-pausedContrast))
+
+	return color.NRGBA{
+		R: gray,
+		G: gray,
+		B: gray,
+		A: nrgba.A,
+	}
+}

--- a/internal/adapter/systray/icon/paused_test.go
+++ b/internal/adapter/systray/icon/paused_test.go
@@ -1,0 +1,80 @@
+package icon_test
+
+import (
+	"bytes"
+	"image"
+	"image/png"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/systray/icon"
+)
+
+// decodeTile decodes an embedded or derived tray asset.
+func decodeTile(t *testing.T, name string, data []byte) image.Image {
+	t.Helper()
+
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("%s is not a decodable PNG: %v", name, err)
+	}
+
+	return img
+}
+
+// TestBrandPaused pins what the paused tray tile owes a user: it is a real PNG
+// of the running tile's size, it is visibly not the running tile, and it is
+// still there — a transform that erased the artwork would leave the tray
+// showing nothing at all, which is the invisible-state bug in a new costume.
+func TestBrandPaused(t *testing.T) {
+	paused := icon.BrandPaused()
+
+	if bytes.Equal(paused, icon.Brand) {
+		t.Fatal(
+			"paused tile is byte-identical to the running tile; the paused state stays invisible",
+		)
+	}
+
+	running := decodeTile(t, "Brand", icon.Brand)
+	pausedImg := decodeTile(t, "BrandPaused", paused)
+
+	if pausedImg.Bounds() != running.Bounds() {
+		t.Errorf(
+			"paused tile bounds = %v, want the running tile's %v",
+			pausedImg.Bounds(),
+			running.Bounds(),
+		)
+	}
+
+	var opaque int
+
+	bounds := pausedImg.Bounds()
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			_, _, _, a := pausedImg.At(x, y).RGBA()
+			if a > 0 {
+				opaque++
+			}
+		}
+	}
+
+	if opaque*4 < bounds.Dx()*bounds.Dy() {
+		t.Errorf(
+			"paused tile has %d visible pixels of %d; the artwork was erased rather than dimmed",
+			opaque,
+			bounds.Dx()*bounds.Dy(),
+		)
+	}
+}
+
+// TestBrandPaused_IsStable pins that the derivation is computed once and the
+// same bytes come back on every call: the tray sets an icon on every state
+// change, and a fresh encode per call would put PNG work on that path.
+func TestBrandPaused_IsStable(t *testing.T) {
+	first := icon.BrandPaused()
+
+	second := icon.BrandPaused()
+
+	if &first[0] != &second[0] {
+		t.Error("BrandPaused re-derived the tile; callers expect a cached asset")
+	}
+}

--- a/internal/adapter/systray/linux/systray.go
+++ b/internal/adapter/systray/linux/systray.go
@@ -120,8 +120,12 @@ func (m *MenuItem) SetTitle(title string) {
 	bumpMenu()
 }
 
-// SetTooltip sets the menu item tooltip (Linux, no-op: dbusmenu has no per-item
-// tooltip property).
+// SetTooltip sets the menu item tooltip (Linux). It is an empty body by
+// protocol, not by omission: com.canonical.dbusmenu defines no per-item
+// tooltip property, so there is nothing to send and nothing for a tray host to
+// render. Nothing in Neru calls it; the tray icon's own hover text is the
+// package-level SetTooltip below, which works. docs/CROSS_PLATFORM.md owns the
+// full statement, as footnote 9 of the Capability Matrix.
 func (m *MenuItem) SetTooltip(tooltip string) {}
 
 // SetIcon sets the menu item icon (Linux).

--- a/internal/app/buildboundary.go
+++ b/internal/app/buildboundary.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/adapter/platform"
+)
+
+// noCGOLinuxUnavailable is what a CGO_ENABLED=0 Linux daemon cannot do. Every
+// entry is a `CodeNotSupported` mirror of a backend that needs native linkage,
+// so the list is the boundary itself rather than a summary of it.
+var noCGOLinuxUnavailable = []string{
+	"cursor position and movement",
+	"clicks and drags",
+	"scrolling",
+	"global hotkeys",
+	"keyboard capture",
+	"overlay drawing",
+	"screen enumeration and display-hotplug events",
+	"the focused application",
+	"key injection (`neru key`)",
+	"the vision hint strategy",
+}
+
+// announceBuildBoundary says once, at startup, that this build sits outside
+// the parity boundary — and says nothing at all when it does not.
+//
+// ADR 0013 puts the CGO_ENABLED=0 Linux build outside that boundary: it is a
+// distribution convenience for a configuration macOS does not offer, and it
+// starts perfectly well before failing feature by feature. ADR 0012's
+// criterion is that the first hour must not lie, and a daemon that reports
+// itself running while every keystroke reaches a stub is the lie in its purest
+// form. So the boundary is stated up front, with what it costs and how to
+// leave it.
+//
+// It is a warning rather than an error because the build is a supported
+// artifact, and it is emitted from exactly one place so the blessed stack
+// never hears it: a warning every ordinary run prints is one people learn to
+// scroll past.
+func announceBuildBoundary(logger *zap.Logger, targetOS platform.OS, cgoEnabled bool) {
+	if targetOS != platform.Linux || cgoEnabled {
+		return
+	}
+
+	logger.Warn(
+		"This is a CGO_ENABLED=0 Linux build: it runs, but nothing that reaches the display server does",
+		zap.Strings("unavailable", noCGOLinuxUnavailable),
+		zap.String(
+			"remedy",
+			"install the Linux build dependencies (docs/LINUX_SETUP.md) and rebuild with CGO_ENABLED=1",
+		),
+	)
+}

--- a/internal/app/buildboundary_cgo.go
+++ b/internal/app/buildboundary_cgo.go
@@ -1,0 +1,9 @@
+//go:build cgo
+
+package app
+
+// cgoEnabled reports whether this binary was built with cgo. It is the one
+// fact announceBuildBoundary cannot learn at runtime: every native backend is
+// selected by the same tag, so by the time a call fails the boundary has
+// already cost the user a keystroke.
+const cgoEnabled = true

--- a/internal/app/buildboundary_nocgo.go
+++ b/internal/app/buildboundary_nocgo.go
@@ -1,0 +1,7 @@
+//go:build !cgo
+
+package app
+
+// cgoEnabled reports whether this binary was built with cgo; see the cgo twin
+// of this file.
+const cgoEnabled = false

--- a/internal/app/buildboundary_test.go
+++ b/internal/app/buildboundary_test.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/y3owk1n/neru/internal/adapter/platform"
+)
+
+// TestAnnounceBuildBoundary pins ADR 0012's criterion applied to a build
+// variant: a CGO_ENABLED=0 Linux daemon starts and then fails feature by
+// feature, so it must say once, up front, what kind of build it is — and no
+// other build may say it, or the warning is noise the blessed stack teaches
+// people to ignore.
+func TestAnnounceBuildBoundary(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetOS   platform.OS
+		cgoEnabled bool
+		wantWarn   bool
+	}{
+		{
+			name:       "linux build without cgo announces its boundary",
+			targetOS:   platform.Linux,
+			cgoEnabled: false,
+			wantWarn:   true,
+		},
+		{
+			name:       "linux build with cgo says nothing",
+			targetOS:   platform.Linux,
+			cgoEnabled: true,
+		},
+		{
+			name:       "windows build without cgo says nothing",
+			targetOS:   platform.Windows,
+			cgoEnabled: false,
+		},
+		{
+			name:       "darwin build says nothing",
+			targetOS:   platform.Darwin,
+			cgoEnabled: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.DebugLevel)
+
+			announceBuildBoundary(zap.New(core), testCase.targetOS, testCase.cgoEnabled)
+
+			entries := logs.All()
+
+			if !testCase.wantWarn {
+				if len(entries) != 0 {
+					t.Fatalf("announced %d entries on a supported build: %v", len(entries), entries)
+				}
+
+				return
+			}
+
+			if len(entries) != 1 {
+				t.Fatalf("want exactly one announcement, got %d: %v", len(entries), entries)
+			}
+
+			entry := entries[0]
+
+			if entry.Level != zapcore.WarnLevel {
+				t.Errorf("announcement level = %v, want warn", entry.Level)
+			}
+
+			if !strings.Contains(entry.Message, "CGO_ENABLED=0") {
+				t.Errorf("announcement does not name the build: %q", entry.Message)
+			}
+
+			unavailable := fmt.Sprint(entry.ContextMap()["unavailable"])
+			if unavailable == "" || unavailable == "[]" {
+				t.Fatalf("announcement names nothing that will not work: %v", entry.ContextMap())
+			}
+
+			// A list that omits the capabilities a person reaches for first
+			// leaves them discovering the boundary one keystroke at a time,
+			// which is the whole failure this announcement exists to end.
+			for _, want := range []string{"global hotkeys", "overlay"} {
+				if !strings.Contains(unavailable, want) {
+					t.Errorf("announcement does not name %q as unavailable: %v", want, unavailable)
+				}
+			}
+
+			if entry.ContextMap()["remedy"] == "" {
+				t.Error("announcement offers no remedy")
+			}
+		})
+	}
+}

--- a/internal/app/components/systray/systray_test.go
+++ b/internal/app/components/systray/systray_test.go
@@ -1,6 +1,7 @@
 package systray_test
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -124,6 +125,50 @@ func TestComponent_OnReady(t *testing.T) {
 
 			t.Errorf("OnReady() built no %q item; got %v", want, titles)
 		}
+	}
+}
+
+// trayIconAtReady builds the menu for one enabled state and returns the icon
+// the tray was left showing.
+func trayIconAtReady(t *testing.T, enabled bool) []byte {
+	t.Helper()
+
+	tray := &portmocks.MockSystrayPort{}
+	component := systray.NewComponent(
+		&mockApp{isEnabled: enabled},
+		tray,
+		nil,
+		zaptest.NewLogger(t),
+	)
+
+	component.OnReady()
+
+	t.Cleanup(component.OnExit)
+
+	icon, _ := tray.Icon()
+
+	return icon
+}
+
+// TestComponent_OnReady_ShowsADistinctIconWhilePaused pins the one place a
+// user can see that Neru is paused without pressing a key. Every platform owes
+// two tray icons — macOS a second template glyph, the tray hosts that render
+// bytes literally a greyed tile — and showing one icon for both states makes the
+// state invisible.
+func TestComponent_OnReady_ShowsADistinctIconWhilePaused(t *testing.T) {
+	running := trayIconAtReady(t, true)
+	paused := trayIconAtReady(t, false)
+
+	if len(running) == 0 {
+		t.Fatal("the tray was left with no icon while running")
+	}
+
+	if len(paused) == 0 {
+		t.Fatal("the tray was left with no icon while paused")
+	}
+
+	if bytes.Equal(running, paused) {
+		t.Error("the tray shows the same icon running and paused; the paused state is invisible")
 	}
 }
 

--- a/internal/app/components/systray/trayicon_other.go
+++ b/internal/app/components/systray/trayicon_other.go
@@ -7,8 +7,14 @@ import "github.com/y3owk1n/neru/internal/adapter/systray/icon"
 // trayIconFor returns the tray icon bytes and template flag for the given
 // enabled state. Windows and Linux tray hosts render icon bytes literally, so
 // they get the colored brand tile — the macOS template glyph is
-// white-on-transparent and would be invisible there. Neither platform has a
-// distinct paused variant yet, so both states share the brand tile.
+// white-on-transparent and would be invisible there. Paused is the same tile
+// desaturated and flattened towards grey, since a host that renders bytes
+// literally cannot restyle an icon for us the way a template image lets macOS
+// restyle its own.
 func trayIconFor(enabled bool) ([]byte, bool) {
-	return icon.Brand, false
+	if enabled {
+		return icon.Brand, false
+	}
+
+	return icon.BrandPaused(), false
 }

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -60,6 +60,11 @@ func (a *App) Run() error {
 		zap.String("log_level", cfg.Logging.LogLevel),
 		zap.Bool("file_logging", !cfg.Logging.DisableFileLogging))
 
+	// Immediately after the identity line and before anything can fail: a build
+	// outside the parity boundary says so once, here, rather than one stubbed
+	// keystroke at a time.
+	announceBuildBoundary(a.logger, platform.CurrentOS(), cgoEnabled)
+
 	err := a.ipcServer.Start(a.ctx)
 	if err != nil {
 		a.logger.Error("Failed to start IPC server", zap.Error(err))

--- a/internal/ports/mocks/systray.go
+++ b/internal/ports/mocks/systray.go
@@ -79,6 +79,15 @@ func (m *MockSystrayPort) Tooltip() string {
 	return m.tooltip
 }
 
+// Icon returns the last icon passed to SetIcon and whether it was set as a
+// macOS template image.
+func (m *MockSystrayPort) Icon() ([]byte, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.icon, m.iconIsTemplate
+}
+
 // Items returns the top-level items created so far.
 func (m *MockSystrayPort) Items() []*MockSystrayMenuItem {
 	m.mu.Lock()

--- a/justfile
+++ b/justfile
@@ -292,6 +292,7 @@ test-foundation:
         ./internal/adapter/platform/fontgeneric \
         ./internal/adapter/platform/modifierstate \
         ./internal/adapter/platform/mousestate \
+        ./internal/adapter/systray/icon \
         ./internal/ports ./internal/ports/mocks \
         ./internal/domain/geometry
     @echo "✓ Cross-platform foundation tests passed"


### PR DESCRIPTION
## Description

This PR closes the last three small divergences on the Linux side of the parity
list, none of which was worth its own change.

The tray now looks different when Neru is paused. macOS already swapped between
two menu-bar glyphs, but the tray hosts that render icon bytes literally — the
Linux StatusNotifierItem hosts and the Windows notification area — showed the
same colored tile whether Neru was running or paused, so the one place you can
see that state without pressing a key showed nothing. Paused is now that same
tile, desaturated and flattened towards grey; it is derived from the running
tile at runtime, so a future brand change updates both at once.

A Linux build made with CGO turned off now says so once at startup, naming what
will not work in it — cursor, clicks, scrolling, global hotkeys, keyboard
capture, overlay, screen enumeration and hotplug, focused-app detection and the
vision hint strategy — and how to get a working build. Until now such a daemon
started cleanly and then failed one keystroke at a time. A normal CGO build
prints nothing, so the supported stack never learns to scroll past the warning.
The limitation is that this is a startup log line, not a refusal to run: the
no-CGO build is a supported distribution artifact and still runs the tray,
notifications and alerts.

Finally, the Linux menu-item tooltip that has always been an empty method now
records why — the dbusmenu protocol defines no per-item tooltip property — and
the capability matrix documents it alongside the tray icon's own hover text,
which works everywhere. Nothing a user can hover changes.

## Related Issues

Closes #1465

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, nothing here adds a platform capability; the new build-tagged pair is a compile-time constant with both halves defined
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

Beyond `just ci` on macOS, the full test suite was run in a container against
`linux/amd64` twice — once with CGO on and once with CGO off — since the two
behaviours this adds only show up there.

The paused tile is derived rather than exported as a second asset so the pair
cannot drift, and it is computed at most once per process, on the first pause,
rather than on every toggle. It greys the tile instead of fading it: the icon
bytes reach the Windows notification area with straight alpha where GDI's icon
path expects it premultiplied, which today only affects the tile's
anti-aliased corners, and a translucent tile would have put that difference on
screen. Worth a second opinion from someone with a Windows tray in front of
them.

The announcement's list of what will not work is written by hand rather than
derived from the capability registry `neru doctor` reports; closing a no-CGO
gap therefore means editing both. That was the cheaper trade for a message
meant to be read by a person, but it is worth a look. Relatedly, `neru doctor`
still reports the key-feed capability as supported on a no-CGO Linux build,
where every other cgo-blocked entry names the requirement in its detail string
— pre-existing, and left alone here.

`docs/CROSS_PLATFORM.md` loses the Known Gaps "Tail" entry these three closed
and gains a Capability Matrix footnote covering what the tray shows and what it
cannot; the no-CGO boundary is recorded beside the other deliberate exclusions.
