### PR TITLE
ci(linux): run the desktop test tier under Xvfb as well as sway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,17 +51,34 @@ jobs:
                     # numbers that differ only by which build tags were active.
                     - os: macos-latest
                       check: coverage
-                    # The desktop-driving test tier, on the blessed Linux stack
-                    # of ADR 0013: sway with the wlroots headless backend. What
-                    # this leg covers and what it does not is stated in
+                    # The desktop-driving test tier, once per Linux display
+                    # stack. `desktop` is the blessed stack of ADR 0013 — sway
+                    # on the wlroots headless backend, where parity is a
+                    # behavioral claim. `desktop-x11` is the same tier under
+                    # Xvfb, where ADR 0013 asks for capability parity instead:
+                    # a lower bar than behavior, but not the zero bar it had
+                    # while nothing observed X11 at all.
+                    #
+                    # Every step below is shared between the two legs except
+                    # the one that starts the display server and the one that
+                    # asserts it; `session_packages` is that difference in apt
+                    # form, and `session` is the name the job summary prints.
+                    # What each leg covers and what it does not is stated in
                     # docs/DEVELOPMENT.md, with the rest of the test tiers.
                     - os: ubuntu-latest
                       check: desktop
+                      session: headless sway (wlroots Wayland)
+                      session_packages: sway wayland-utils
+                    - os: ubuntu-latest
+                      check: desktop-x11
+                      session: Xvfb with openbox (X11)
+                      session_packages: xvfb x11-utils openbox
         runs-on: ${{ matrix.os }}
-        # The desktop leg is advisory, for the reason docs/DEVELOPMENT.md gives.
-        # Making it blocking is deleting this key and adding
-        # "desktop (ubuntu-latest)" to the branch protection rule.
-        continue-on-error: ${{ matrix.check == 'desktop' }}
+        # Both desktop legs are advisory, for the reason docs/DEVELOPMENT.md
+        # gives. Making one blocking is excluding it from this expression and
+        # adding its job name — "desktop (ubuntu-latest)" or
+        # "desktop-x11 (ubuntu-latest)" — to the branch protection rule.
+        continue-on-error: ${{ startsWith(matrix.check, 'desktop') }}
         steps:
             # Default checkout: on pull_request events this tests the merge
             # commit (PR + main combined), which is what will actually land —
@@ -195,30 +212,39 @@ jobs:
               shell: bash
 
             # ---------------------------------------------------------------
-            # The headless-sway desktop leg: everything below runs only for
-            # matrix.check == 'desktop'. It stands up the session the desktop
-            # tier needs — a wlroots compositor, a session bus, and AT-SPI on
-            # it — and runs the tier against it. What that covers and what it
-            # does not is in docs/DEVELOPMENT.md.
+            # The desktop legs: everything below runs only for a matrix.check
+            # starting with 'desktop'. It stands up the session the desktop
+            # tier needs — a display server, a session bus, and AT-SPI on it —
+            # and runs the tier against it. Only the two display-server steps
+            # differ between the wlroots and X11 legs; the bus, AT-SPI, the
+            # CGO and a11y assertions, the tier itself, the reporting and the
+            # log artifact are one copy each. What the legs cover and what they
+            # do not is in docs/DEVELOPMENT.md.
             # ---------------------------------------------------------------
 
-            - name: Install headless desktop session
-              if: matrix.check == 'desktop'
+            - name: Install the desktop session
+              if: startsWith(matrix.check, 'desktop')
+              env:
+                  SESSION_PACKAGES: ${{ matrix.session_packages }}
               run: |
+                  # Word-splitting SESSION_PACKAGES is the point: it is the one
+                  # per-leg difference in an otherwise shared install.
+                  # shellcheck disable=SC2086
                   sudo apt-get install -y \
-                    sway \
                     dbus-x11 \
                     at-spi2-core \
-                    wayland-utils
+                    $SESSION_PACKAGES
 
-            - name: Start sway, session bus and AT-SPI
-              if: matrix.check == 'desktop'
+            - name: Start the session bus
+              if: startsWith(matrix.check, 'desktop')
               shell: bash
               run: |
                   set -euo pipefail
 
                   # A Wayland compositor puts its socket in XDG_RUNTIME_DIR and
-                  # refuses a world-readable one. The runner has neither.
+                  # refuses a world-readable one. The runner has neither. X11
+                  # does not need it, but a session without one is not a session
+                  # either stack should be tested in.
                   runtime_dir="${RUNNER_TEMP}/xdg-runtime"
                   mkdir -p "$runtime_dir"
                   chmod 700 "$runtime_dir"
@@ -228,11 +254,22 @@ jobs:
                   # GITHUB_ENV.
                   eval "$(dbus-launch --sh-syntax)"
 
+                  {
+                    echo "XDG_RUNTIME_DIR=$runtime_dir"
+                    echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
+                  } >> "$GITHUB_ENV"
+
+            - name: Start sway
+              if: matrix.check == 'desktop'
+              shell: bash
+              run: |
+                  set -euo pipefail
+
                   cat > "${RUNNER_TEMP}/sway.conf" <<'SWAYCONF'
                   # Xwayland is off deliberately. It would set DISPLAY, and
                   # neru's Linux backend detection would then have an X11 answer
                   # available on the one job whose purpose is the wlroots
-                  # Wayland stack.
+                  # Wayland stack. X11 gets its own leg instead.
                   xwayland disable
                   output HEADLESS-1 resolution 1920x1080 position 0 0
                   SWAYCONF
@@ -242,7 +279,6 @@ jobs:
                   WLR_BACKENDS=headless \
                   WLR_RENDERER=pixman \
                   WLR_LIBINPUT_NO_DEVICES=1 \
-                  XDG_RUNTIME_DIR="$runtime_dir" \
                   XDG_SESSION_TYPE=wayland \
                   XDG_CURRENT_DESKTOP=sway \
                   setsid sway -c "${RUNNER_TEMP}/sway.conf" -d \
@@ -250,7 +286,7 @@ jobs:
 
                   socket=""
                   for _ in $(seq 1 100); do
-                    socket=$(find "$runtime_dir" -maxdepth 1 -name 'wayland-*' \
+                    socket=$(find "$XDG_RUNTIME_DIR" -maxdepth 1 -name 'wayland-*' \
                       ! -name '*.lock' -print -quit)
                     [ -n "$socket" ] && break
                     sleep 0.2
@@ -266,7 +302,7 @@ jobs:
                   # promises, so it gets the same wait and the same diagnostic.
                   swaysock=""
                   for _ in $(seq 1 50); do
-                    swaysock=$(find "$runtime_dir" -maxdepth 1 \
+                    swaysock=$(find "$XDG_RUNTIME_DIR" -maxdepth 1 \
                       -name 'sway-ipc.*.sock' -print -quit)
                     [ -n "$swaysock" ] && break
                     sleep 0.2
@@ -276,6 +312,81 @@ jobs:
                     cat "${RUNNER_TEMP}/sway.log" >&2
                     exit 1
                   fi
+
+                  {
+                    echo "WAYLAND_DISPLAY=$(basename "$socket")"
+                    echo "SWAYSOCK=$swaysock"
+                    echo "XDG_SESSION_TYPE=wayland"
+                    echo "XDG_CURRENT_DESKTOP=sway"
+                  } >> "$GITHUB_ENV"
+
+            # Xvfb is a bare X server: it serves the extensions neru's X11
+            # paths call (XTEST for injection, XFIXES for the click-through
+            # overlay shape, RANDR for screen enumeration) but it is not a
+            # window manager, and EWMH properties are a window manager's job.
+            # Without one the root window has no _NET_SUPPORTED at all, so
+            # x11_system.c and x11_accessibility.c — which both read
+            # _NET_ACTIVE_WINDOW to answer "what is focused" — would find
+            # nothing and the leg would report a session no user runs. openbox
+            # is the smallest EWMH-aware answer in the archive; the verify step
+            # below turns that reasoning into an assertion rather than a claim.
+            - name: Start Xvfb and a window manager
+              if: matrix.check == 'desktop-x11'
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  display=":99"
+
+                  # 1920x1080x24 mirrors the sway leg's output so both legs
+                  # answer the same screen geometry to XRandR and to
+                  # wlr-output-management.
+                  setsid Xvfb "$display" -screen 0 1920x1080x24 -nolisten tcp \
+                    +extension RANDR +extension XTEST +extension XFIXES \
+                    > "${RUNNER_TEMP}/xvfb.log" 2>&1 &
+
+                  for attempt in $(seq 1 100); do
+                    if DISPLAY="$display" xdpyinfo > /dev/null 2>&1; then
+                      break
+                    fi
+                    if [ "$attempt" = "100" ]; then
+                      echo "Xvfb never accepted a connection on $display. Its log:" >&2
+                      cat "${RUNNER_TEMP}/xvfb.log" >&2
+                      exit 1
+                    fi
+                    sleep 0.2
+                  done
+
+                  DISPLAY="$display" setsid openbox \
+                    > "${RUNNER_TEMP}/openbox.log" 2>&1 &
+
+                  # The window manager owns _NET_SUPPORTED, so its appearance on
+                  # the root window is the readiness signal — openbox having
+                  # been exec'd is not the same thing.
+                  for attempt in $(seq 1 100); do
+                    if DISPLAY="$display" xprop -root _NET_SUPPORTED 2>/dev/null \
+                      | grep -q _NET_ACTIVE_WINDOW; then
+                      break
+                    fi
+                    if [ "$attempt" = "100" ]; then
+                      echo "openbox never claimed EWMH on $display. Its log:" >&2
+                      cat "${RUNNER_TEMP}/openbox.log" >&2
+                      exit 1
+                    fi
+                    sleep 0.2
+                  done
+
+                  {
+                    echo "DISPLAY=$display"
+                    echo "XDG_SESSION_TYPE=x11"
+                    echo "XDG_CURRENT_DESKTOP=openbox"
+                  } >> "$GITHUB_ENV"
+
+            - name: Start AT-SPI
+              if: startsWith(matrix.check, 'desktop')
+              shell: bash
+              run: |
+                  set -euo pipefail
 
                   # at-spi2-core ships its launcher in libexec, and the
                   # directory moved between releases, so ask rather than assume.
@@ -293,25 +404,14 @@ jobs:
                     echo "at-spi-bus-launcher not found; AT-SPI would be absent" >&2
                     exit 1
                   fi
-                  XDG_RUNTIME_DIR="$runtime_dir" \
                   setsid "$launcher" --launch-immediately \
                     > "${RUNNER_TEMP}/at-spi.log" 2>&1 &
 
-                  {
-                    echo "XDG_RUNTIME_DIR=$runtime_dir"
-                    echo "WAYLAND_DISPLAY=$(basename "$socket")"
-                    echo "SWAYSOCK=$swaysock"
-                    echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
-                    echo "XDG_SESSION_TYPE=wayland"
-                    echo "XDG_CURRENT_DESKTOP=sway"
-                  } >> "$GITHUB_ENV"
-
             # The tier is only worth its runtime if the session really is the
             # blessed stack, so this asserts the two globals neru's wlroots
-            # paths bind (overlay_wayland.c, wlroots_client.h), that CGO is on,
-            # and that the accessibility bus answers. A missing one fails here,
-            # where it reads as a broken environment rather than as test
-            # failures.
+            # paths bind (overlay_wayland.c, wlroots_client.h). A missing one
+            # fails here, where it reads as a broken environment rather than as
+            # test failures.
             - name: Verify the session is the blessed stack
               if: matrix.check == 'desktop'
               shell: bash
@@ -326,6 +426,47 @@ jobs:
                     fi
                     echo "advertised: $global"
                   done
+
+            # The X11 counterpart of the step above: the extensions neru's X11
+            # code calls, and the EWMH property that decides whether a window
+            # manager was needed here. It was: a bare Xvfb has no
+            # _NET_SUPPORTED, so this assertion fails without openbox running,
+            # which is what makes the previous step's window manager evidence
+            # rather than superstition.
+            - name: Verify the session is a usable X11 stack
+              if: matrix.check == 'desktop-x11'
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  xdpyinfo > "${RUNNER_TEMP}/xdpyinfo.log"
+                  # The extension list is the block between those two headings;
+                  # matching the whole file would let "RANDR" in a screen's
+                  # description stand in for the extension itself.
+                  offered=$(sed -n '/number of extensions:/,/^default screen number/p' \
+                    "${RUNNER_TEMP}/xdpyinfo.log")
+                  for extension in XTEST XFIXES RANDR; do
+                    if ! printf '%s\n' "$offered" \
+                      | grep -q "^[[:space:]]*${extension}\$"; then
+                      echo "X server does not offer the $extension extension" >&2
+                      exit 1
+                    fi
+                    echo "offered: $extension"
+                  done
+
+                  supported="${RUNNER_TEMP}/net-supported.log"
+                  xprop -root _NET_SUPPORTED > "$supported"
+                  if ! grep -q _NET_ACTIVE_WINDOW "$supported"; then
+                    echo "no EWMH window manager owns this display" >&2
+                    cat "$supported" >&2
+                    exit 1
+                  fi
+                  echo "EWMH: _NET_ACTIVE_WINDOW is supported"
+
+            - name: Verify CGO and the accessibility bus
+              if: startsWith(matrix.check, 'desktop')
+              shell: bash
+              run: |
+                  set -euo pipefail
 
                   # ADR 0013 blesses the CGO build; the CGO-off Linux build is a
                   # near-total stub, and a green run of it would prove nothing.
@@ -350,8 +491,14 @@ jobs:
                     sleep 0.4
                   done
 
+            # Both legs run this tier on a desktop with nothing focused, which
+            # is a state no other job here reaches: the X11 leg found a real
+            # defect in it on its first run (#1495, the X11 sibling of #1493),
+            # fixed before this leg landed. Capability status is
+            # docs/CROSS_PLATFORM.md's to state; docs/DEVELOPMENT.md says what
+            # these legs cover and what they do not.
             - name: Run just test-desktop
-              if: matrix.check == 'desktop'
+              if: startsWith(matrix.check, 'desktop')
               shell: bash
               timeout-minutes: 40
               run: |
@@ -359,33 +506,58 @@ jobs:
                   just test-desktop 2>&1 | tee "${RUNNER_TEMP}/test-desktop.log"
 
             # A skip in this tier is a claim that Linux behavior went unchecked,
-            # which is the thing the job exists to make visible — so skips and
-            # failures are counted into the job summary rather than left in
-            # 20,000 lines of -v output nobody opens.
-            - name: Report skips and failures
-              if: always() && matrix.check == 'desktop'
+            # which is the thing the job exists to make visible — so executions,
+            # skips and failures are counted into the job summary rather than
+            # left in 20,000 lines of -v output nobody opens.
+            #
+            # The counts are also a floor, not decoration: a leg that skips its
+            # way to green is worth less than no leg at all, so this step fails
+            # when nothing executed, and when a test skipped because it could
+            # not see the display server this job exists to provide.
+            - name: Report what ran, skipped and failed
+              if: always() && startsWith(matrix.check, 'desktop')
               shell: bash
+              env:
+                  SESSION: ${{ matrix.session }}
               run: |
                   set -euo pipefail
                   log="${RUNNER_TEMP}/test-desktop.log"
                   if [ ! -f "$log" ]; then
-                    echo "The desktop tier never ran; see the session steps above." \
+                    echo "The ${SESSION} desktop tier never ran; see the session steps above." \
                       >> "$GITHUB_STEP_SUMMARY"
-                    exit 0
+                    echo "::error::the desktop tier never ran under ${SESSION}"
+                    exit 1
                   fi
+                  passes=$(grep -c -- '--- PASS: ' "$log" || true)
                   skips=$(grep -c -- '--- SKIP: ' "$log" || true)
                   fails=$(grep -c -- '--- FAIL: ' "$log" || true)
+                  # Executed means started, so a failure counts. Passes alone
+                  # would report "this leg ran nothing" for a run where
+                  # everything ran and everything broke, which is the opposite
+                  # of the truth and the opposite of what the floor is for.
+                  executed=$((passes + fails))
                   # A package that fails to build reports FAIL with no failing
                   # test in it, so the per-test count alone would read as green.
                   badpkgs=$(grep -c '^FAIL[[:space:]]' "$log" || true)
+                  # The skip reason a test gives when neither DISPLAY nor
+                  # WAYLAND_DISPLAY reached it — owned by
+                  # screencapture_integration_linux_test.go. On this job that is
+                  # never a property of the test; it means the session steps
+                  # above built a display server the test process never saw.
+                  # Anchored to the file:line a t.Skip reason carries, so the
+                  # phrase appearing anywhere else in 20,000 lines of -v output
+                  # is not mistaken for one.
+                  blind=$(grep -c -E '_test\.go:[0-9]+: no display server' "$log" || true)
                   {
-                    echo "### Linux desktop tier (headless sway) — advisory"
+                    echo "### Linux desktop tier — ${SESSION} — advisory"
                     echo ""
                     echo "Advisory: this leg does not gate the merge button."
                     echo "See docs/DEVELOPMENT.md for what it covers."
                     echo ""
                     echo "| | Count |"
                     echo "| --- | --- |"
+                    echo "| Executed (PASS + FAIL lines, subtests included) | ${executed} |"
+                    echo "| Passed | ${passes} |"
                     echo "| \`--- FAIL:\` lines | ${fails} |"
                     echo "| Packages reporting FAIL | ${badpkgs} |"
                     echo "| Skipped tests | ${skips} |"
@@ -427,18 +599,42 @@ jobs:
                         { prev = $0 }
                       ' "$log"
                       echo '```'
+                      echo ""
+                    fi
+                    if [ "$executed" = "0" ] || [ "$blind" != "0" ]; then
+                      echo "#### This leg proved nothing"
+                      echo ""
+                      echo "It is failing on its own floor, not on a test:"
+                      echo "an executed count of zero, or a test that could not"
+                      echo "see the display server this job exists to provide."
                     fi
                   } >> "$GITHUB_STEP_SUMMARY"
 
+                  if [ "$executed" = "0" ]; then
+                    echo "::error::the desktop tier executed no tests under ${SESSION}"
+                    exit 1
+                  fi
+                  if [ "$blind" != "0" ]; then
+                    echo "::error::${blind} test(s) skipped for want of a display server under ${SESSION}; the session never reached the test process"
+                    exit 1
+                  fi
+
             - name: Upload desktop tier logs
-              if: always() && matrix.check == 'desktop'
+              if: always() && startsWith(matrix.check, 'desktop')
               uses: actions/upload-artifact@v7
               with:
-                  name: linux-desktop-logs
+                  # linux-desktop-logs for the sway leg, linux-desktop-x11-logs
+                  # for the X11 one: artifact names are unique per run, so the
+                  # two legs cannot share one.
+                  name: linux-${{ matrix.check }}-logs
                   path: |
                       ${{ runner.temp }}/test-desktop.log
                       ${{ runner.temp }}/sway.log
                       ${{ runner.temp }}/at-spi.log
                       ${{ runner.temp }}/wayland-info.log
+                      ${{ runner.temp }}/xvfb.log
+                      ${{ runner.temp }}/openbox.log
+                      ${{ runner.temp }}/xdpyinfo.log
+                      ${{ runner.temp }}/net-supported.log
                   if-no-files-found: warn
                   retention-days: 14

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -211,6 +211,13 @@ platform in CI at all. A disposable runner is the one place that tier is safe:
 the reason it is opt-in locally is that it commandeers the machine, and there
 is no desktop here to commandeer.
 
+It has a sibling, **`desktop-x11 (ubuntu-latest)`**, which runs the same tier
+against the other Linux display stack and is described
+[below](#what-the-xvfb-x11-leg-covers-and-what-it-does-not). The two are one
+matrix entry apiece and share everything but their display server: the session
+bus, AT-SPI, the CGO and accessibility assertions, the tier itself, the
+reporting and the log artifact are one copy each.
+
 What it covers is the **blessed stack** of
 [ADR 0013](adr/0013-parity-is-measured-in-words-not-subsystems.md): wlroots
 Wayland with a CGO build. It asserts the session really is that stack before it
@@ -227,9 +234,8 @@ What it does not cover:
   smooth-scroll claim in ADR 0013's amendment is checked rather than argued.
   Everything else that reads `NERU_DESKTOP_TESTS` is still a macOS test.
 - **X11 and KDE.** Xwayland is disabled in the session on purpose, so `DISPLAY`
-  is unset and backend detection has only the Wayland answer. An Xvfb leg is
-  worth having and is deliberately second — under ADR 0013 X11 owes capability
-  parity rather than behavioral parity.
+  is unset and backend detection has only the Wayland answer. X11 has its own
+  leg now — see below. KDE has none; nothing in CI runs KWin.
 - **Anything needing device access.** The runner has no `/dev/dri` (the
   compositor runs the pixman renderer) and no `input` group membership, so the
   evdev-backed paths cannot run. The compositor would not see them either:
@@ -237,8 +243,12 @@ What it does not cover:
   devices, so nothing written to a uinput device reaches it whatever the
   permissions are. What is observable here is the `zwlr_virtual_pointer` path.
 - **A verdict.** The leg is **advisory**: `continue-on-error` keeps it off the
-  merge button, and its result is a job summary counting failures, packages
-  reporting `FAIL`, and every skip with the reason it gave. It is advisory
+  merge button, and its result is a job summary counting executed tests,
+  failures, packages reporting `FAIL`, and every skip with the reason it gave.
+  Those counts are a floor as well as a report — the step fails if nothing
+  executed, or if a test skipped because it could not see the display server
+  the job exists to provide, because a leg that skips its way to green is worth
+  less than no leg at all. It is advisory
   because it is the first job here to stand up infrastructure of its own — a
   compositor, a session bus and an accessibility bus — and a flake in any of
   the three would red a pull request for a reason that has nothing to do with
@@ -250,6 +260,62 @@ branch protection rule — a repository setting, not a file in this tree. ADR 00
 makes that flip part of Linux graduating from Beta to Stable, alongside the
 Linux entries in
 [Known Gaps](CROSS_PLATFORM.md#known-gaps) being empty.
+
+### What the Xvfb X11 leg covers, and what it does not
+
+**`desktop-x11 (ubuntu-latest)`** runs the same `just test-desktop` tier against
+the other Linux display stack: Xvfb, a window manager, a session D-Bus and
+AT-SPI. Under ADR 0013 X11 owes **capability** parity rather than behavioral
+parity — a lower bar than the wlroots leg's, but not the zero bar it had while
+nothing observed X11 at all.
+
+What it covers is the X11 half of every subsystem that has two implementations,
+which is a separate body of code rather than a fallback: XTest for pointer and
+key injection, `XGrabKey` for global hotkeys, `XGrabKeyboard` for capture,
+XRandR for screen enumeration, `XGetImage` for screen capture, XFixes for the
+click-through overlay shape, `_NET_ACTIVE_WINDOW` and `WM_CLASS` for focused-app
+identity, and one global `Xft.dpi` resource for scaling instead of per-output
+Wayland scale factors. As on the wlroots leg, the session is asserted before the
+tier runs: the server must offer XTEST, XFIXES and RANDR, an EWMH window manager
+must own the root window, `CGO_ENABLED` must be 1, and the accessibility bus
+must answer.
+
+**A window manager is required, and that was settled rather than assumed.**
+Under a bare Xvfb, `xprop -root _NET_SUPPORTED` answers `no such atom on any
+window` — the root window carries exactly one property, `_XKB_RULES_NAMES`, so
+there is no EWMH on the display at all and every path that reads
+`_NET_ACTIVE_WINDOW` would find nothing. With openbox running, `_NET_SUPPORTED`
+lists `_NET_ACTIVE_WINDOW` among 80-odd atoms. openbox is the smallest EWMH-aware
+window manager in the archive, so it is what the job starts, and the verify step
+asserts the property rather than trusting the package: the leg fails as a broken
+environment if the window manager is ever dropped or fails to claim the display.
+
+What it does not cover:
+
+- **Behavioral parity.** ADR 0013 does not promise X11 the wlroots leg's bar,
+  and this leg is not evidence that it meets it.
+- **A focused window.** The session runs a window manager but no client, so
+  `_NET_ACTIVE_WINDOW` is unset — the same empty-desktop state the sway leg is
+  in, deliberately, so the two legs answer the same question. The mechanism is
+  proven present; which application is focused is not exercised.
+- **Anything needing device access**, for the same reasons as the sway leg: no
+  `/dev/dri`, no `input` group.
+- **A verdict**, and for the same reason — `continue-on-error`, the same
+  counting-and-floor summary, and `desktop-x11 (ubuntu-latest)` is the name to
+  add to branch protection to change that.
+
+**It found a defect on its first run, which is the point.** Because the session
+has a window manager and no client, `internal/adapter/platform`'s capability
+contract — `TestCapabilities_DeclaredStatusMatchesAdapterBehavior` and
+`TestCapabilities_StubsSurfaceNotSupportedNotNil` — runs against a live X11
+desktop with nothing focused, a state no other job here reaches. It failed
+there: the X11 arm answered a failed query where a stub owes `CodeNotSupported`,
+filed as [#1495](https://github.com/y3owk1n/neru/issues/1495), the X11 sibling
+of [#1493](https://github.com/y3owk1n/neru/issues/1493). That fix landed first
+and the leg is green on it. What the `process` capability is classified as, and
+what each way of having no focused window now answers, is stated once in the
+[capability matrix](CROSS_PLATFORM.md#capability-matrix) and its notes — this
+leg runs the contract that pins it rather than restating its verdict.
 
 ---
 
@@ -344,9 +410,10 @@ Until there is a recipe, run them the way the container recipe does and add the
 tag — `docker run --rm -v "$PWD":/src -w /src -e CGO_ENABLED=1 neru-linux-ci go
 test -tags=integration ./...` — on an image with fonts and `fc-list` installed
 (`fontconfig fonts-dejavu-core`). CI covers them on `ubuntu-latest`, where
-`just test-ci` runs the integration suite natively, and again on the
-headless-sway leg, which runs `just test-desktop` inside a real wlroots session
-— see [What the headless-sway job covers](#what-the-headless-sway-job-covers-and-what-it-does-not).
+`just test-ci` runs the integration suite natively, and again on the two desktop
+legs, which run `just test-desktop` inside a real wlroots session and a real X11
+one — see [What the headless-sway job covers](#what-the-headless-sway-job-covers-and-what-it-does-not)
+and [What the Xvfb X11 leg covers](#what-the-xvfb-x11-leg-covers-and-what-it-does-not).
 
 ### Running integration tests
 


### PR DESCRIPTION
## Description

This PR adds a second CI leg for the Linux desktop-driving test tier, this time
against X11: Xvfb, an EWMH window manager, a session D-Bus and AT-SPI. Until
now the only Linux session anything in this project could observe was wlroots
Wayland, so a regression in the X11 half of every two-implementation subsystem —
injection, hotkeys, capture, screen enumeration, focused-app identity, overlay
shaping, scaling — was invisible.

It extends the leg #1452 built rather than standing a second one beside it. The
two are one matrix entry apiece and share every step except the one that starts
the display server and the one that asserts it: the session bus, AT-SPI, the CGO
and accessibility-bus assertions, `just test-desktop` itself, the reporting and
the log artifact are one copy each.

The leg found a real defect on its first run — that was #1495, which has since
landed. Rebased onto it, **both legs are green**. Both stay advisory, so neither
gates the merge button.

## Related Issues

Closes #1469
Part of #1466

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no Go source changes
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, no Go source changes
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or adapter changes
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality — N/A, this runs an existing tier in a new session rather than adding tests
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

**How much actually ran under X11.** On this branch's head, rebased onto #1495
([run 31581907720](https://github.com/y3owk1n/neru/actions/runs/31581907720)):
**4519 tests executed, 6 skipped** — 4519 passed, **0** `--- FAIL:` lines, 0
packages reporting `FAIL`. The sway leg on the same commit executed 4518 and
skipped 7, also with 0 failures. Both legs are green.

The two legs see the same 4525 tests and differ only in which of them their
session makes reachable, in both directions:

- X11 skips two smooth-scroll measurements that only mean something on the
  wlroots injection path.
- sway skips
  `TestX11FocusedApplicationPID_AWindowManagerIsNeverMistakenForNoWindowManager`
  — the test #1495 added, which asserts a rule about a live X11 root window and
  therefore **only ever executes on this leg**. It passes here. That is the
  clearest statement of what this leg is for: without it that test has nowhere
  to run.
- sway also skips the two no-backend scroll-modifier contract tests, which the
  X11 binary reached and passed.

None of the six X11 skips is the display server going unseen: two are the
wlroots smooth-scroll measurements above, one is Windows-only, one is
CGO-off-only, one is macOS-only role listing, and one wants a systemd user
manager the runner does not offer. The number of tests that skipped for want of
a display server is zero — which the job checks rather than hopes.

**A window manager is required, and that was settled rather than assumed.**
Under a bare Xvfb, `xprop -root _NET_SUPPORTED` answers `no such atom on any
window`: the root window carries exactly one property, `_XKB_RULES_NAMES`, so
there is no EWMH on the display at all and every path reading
`_NET_ACTIVE_WINDOW` would find nothing. With openbox running the same query
lists `_NET_ACTIVE_WINDOW` among 80-odd atoms. openbox is the smallest
EWMH-aware window manager in the archive, so that is what the job starts — and
the verify step asserts the property rather than trusting the package, so the
leg fails as a broken environment if the window manager is ever dropped.

**The defect this found, and what happened to it.**
`internal/adapter/platform`'s capability contract failed under X11 on the first
run of this leg: `TestCapabilities_DeclaredStatusMatchesAdapterBehavior/process`
and `TestCapabilities_StubsSurfaceNotSupportedNotNil` both reported the `process`
capability answering a failed query for an unfocused desktop where a stub owes
`CodeNotSupported` — filed as #1495, the X11 sibling of #1493, which covers the
same conflation in the compositor-CLI paths and would not have touched this one.
#1495 shipped in #1499 and this branch is rebased onto it; both tests now pass
on the X11 leg. What the capability is classified as stays
[docs/CROSS_PLATFORM.md](https://github.com/y3owk1n/neru/blob/main/docs/CROSS_PLATFORM.md#capability-matrix)'s
to say, and `docs/DEVELOPMENT.md` points there rather than restating it.

**Why the session has a window manager but no client window.** The sway leg runs
a compositor with nothing mapped on it, and this leg matches that on purpose, so
the two answer the same question about the same desktop state. Mapping a client
would have turned the leg green by giving `_NET_ACTIVE_WINDOW` something to
point at, which would have hidden the defect above rather than fixed it.

**A leg that runs nothing now fails.** The reporting step counts executed tests
as well as skips and failures, and treats those counts as a floor for both legs:
it fails if nothing executed, and it fails if a test skipped because it could not
see the display server the job exists to provide. A leg that skips its way to
green is worth less than no leg at all.

**Verified locally before CI as well**, in an Ubuntu 24.04 container using the
session steps extracted from the workflow — that is where the bare-Xvfb versus
with-openbox EWMH evidence above comes from.
