### PR TITLE
fix: make a held scroll key travel as far as the same number of presses

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1552,6 +1552,14 @@ wheel notches, and an application is free to scale those two differently. So
 turning the animation on can change how far a `scroll_down` reaches in a given
 application, and `scroll.scroll_step` is the setting to trim if it does.
 
+The same holds for a key held down under [`[held_repeat]`](#held_repeat). A
+repeat tick preempts the animation still in flight, and folds whatever that
+animation had not yet sent into its own, so N repeats travel as far as N
+discrete presses — on X11, within a wheel notch per repeat, since nothing there
+can express a fraction of one. A binding with a *different* modifier set still
+cancels outright: a plain `scroll_down` arriving mid-zoom finishes unmodified,
+and the zoom's remaining distance is dropped rather than sent as a plain scroll.
+
 | Option               | Type  | Default | Description                        |
 | -------------------- | ----- | ------- | ---------------------------------- |
 | `enabled`            | bool  | `false` | Enable smooth scrolling            |

--- a/internal/adapter/accessibility/native/linux/scroll_animator.go
+++ b/internal/adapter/accessibility/native/linux/scroll_animator.go
@@ -126,7 +126,12 @@ type scrollSession interface {
 // X11 scroll is button clicks, and a scroll_step_full of a million pixels would
 // otherwise be tens of thousands of them). Zero means uncapped, which is what a
 // continuous backend takes.
-func scrollChunks(delta, steps int, granularity float64, maxUnits int) []float64 {
+//
+// delta is a float rather than the integer the caller's action carries because
+// a request can arrive holding the undelivered remainder of the one it
+// preempted (see composeUndelivered), and that remainder is a position on an
+// eased curve.
+func scrollChunks(delta float64, steps int, granularity float64, maxUnits int) []float64 {
 	if steps <= 0 {
 		steps = defaultScrollSteps
 	}
@@ -136,7 +141,7 @@ func scrollChunks(delta, steps int, granularity float64, maxUnits int) []float64
 		return chunks
 	}
 
-	total := float64(delta)
+	total := delta
 
 	if granularity > 0 && maxUnits > 0 {
 		ceiling := float64(maxUnits) * granularity
@@ -186,12 +191,40 @@ func scrollChunks(delta, steps int, granularity float64, maxUnits int) []float64
 // a request preempts whatever is in flight: a plain scroll_down arriving
 // mid-zoom cancels the zoom and finishes unmodified, which is what the second
 // binding asked for. darwin's animator carries them for the same reason.
+//
+// The deltas are floats although every caller's action is in whole pixels: a
+// request that preempts a same-modifier one absorbs its undelivered remainder,
+// which is a point on an eased curve rather than a whole pixel.
 type scrollRequest struct {
-	deltaX, deltaY   int
+	deltaX, deltaY   float64
 	modifiers        action.Modifiers
 	steps            int
 	maxDuration      int
 	durationPerPixel float64
+}
+
+// composeUndelivered folds the part of inflight that never went out — remX,
+// remY — into the request preempting it, but only when the two ask for the same
+// modifiers.
+//
+// Same modifiers is the held-repeat case, since a repeat re-sends the binding
+// it is repeating: without this, every tick throws away whatever the previous
+// tick had not yet injected, and holding a scroll key travels visibly less than
+// the same number of discrete presses.
+//
+// Different modifiers is the deliberate cancel scrollRequest documents: a plain
+// scroll_down arriving mid-zoom finishes unmodified. Carrying the zoom's
+// remainder into it would inject that distance as a plain scroll the user never
+// asked for, so it is dropped exactly as before.
+func composeUndelivered(next, inflight scrollRequest, remX, remY float64) scrollRequest {
+	if next.modifiers != inflight.modifiers {
+		return next
+	}
+
+	next.deltaX += remX
+	next.deltaY += remY
+
+	return next
 }
 
 // scrollAnimator spreads a scroll over time on one worker goroutine, with the
@@ -257,8 +290,8 @@ func (a *scrollAnimator) animate(
 	durationPerPixel float64,
 ) {
 	req := scrollRequest{
-		deltaX:           deltaX,
-		deltaY:           deltaY,
+		deltaX:           float64(deltaX),
+		deltaY:           float64(deltaY),
 		modifiers:        modifiers,
 		steps:            steps,
 		maxDuration:      maxDuration,
@@ -278,12 +311,16 @@ func (a *scrollAnimator) animate(
 	a.enqueueLocked(req)
 }
 
-// enqueueLocked places req on the worker channel, coalescing so only the latest
-// request survives. The caller must hold a.mu.
+// enqueueLocked places req on the worker channel, folding in a request the
+// worker has not taken yet. The caller must hold a.mu.
 //
 // Under the lock we are the only producer and the worker is the only consumer,
-// so after draining a superseded request the buffer is empty and the follow-up
-// send cannot block.
+// so after draining the buffer is empty and the follow-up send cannot block.
+//
+// A request still sitting in the buffer has had none of its delta injected, so
+// composeUndelivered folds all of it in — on the same rule the worker applies
+// when a request preempts it mid-animation, which is what keeps the two seams
+// from disagreeing about whether a same-modifier scroll can be dropped.
 func (a *scrollAnimator) enqueueLocked(req scrollRequest) {
 	select {
 	case a.reqCh <- req:
@@ -292,7 +329,8 @@ func (a *scrollAnimator) enqueueLocked(req scrollRequest) {
 	}
 
 	select {
-	case <-a.reqCh:
+	case queued := <-a.reqCh:
+		req = composeUndelivered(req, queued, queued.deltaX, queued.deltaY)
 	default:
 	}
 
@@ -409,7 +447,16 @@ func (a *scrollAnimator) runOnce(
 		case <-stopCh:
 			return scrollRequest{}, false
 		case next := <-reqCh:
-			return next, true
+			// Chunks from step on have not gone out. What the schedule already
+			// declined to send is absent from them by construction, and stays
+			// dropped: the sub-unit residue a granular backend cannot express,
+			// which a discrete press drops too — so a held key and the same
+			// number of presses still land within one wheel notch per tick of
+			// each other on X11 — and the distance past maxUnits, which is a
+			// rate ceiling no animation was going to deliver.
+			return composeUndelivered(
+				next, req, sumFrom(chunksX, step), sumFrom(chunksY, step),
+			), true
 		default:
 		}
 
@@ -447,7 +494,11 @@ func (a *scrollAnimator) runOnce(
 		case next := <-reqCh:
 			stopAndDrainScrollTimer(timer)
 
-			return next, true
+			// This chunk has gone out; the undelivered remainder starts at the
+			// next one.
+			return composeUndelivered(
+				next, req, sumFrom(chunksX, step+1), sumFrom(chunksY, step+1),
+			), true
 		case <-timer.C:
 		}
 	}
@@ -455,11 +506,23 @@ func (a *scrollAnimator) runOnce(
 	return scrollRequest{}, false
 }
 
+// sumFrom totals the chunks from index on — the part of a schedule that has not
+// been injected yet.
+func sumFrom(chunks []float64, from int) float64 {
+	var total float64
+
+	for _, chunk := range chunks[from:] {
+		total += chunk
+	}
+
+	return total
+}
+
 // scrollScheduleTiming turns a request's configuration into a step count and
 // the gap between steps, using the same arithmetic darwin's animator does so
 // one configuration produces one animation on both.
 func scrollScheduleTiming(req scrollRequest) (int, time.Duration) {
-	magnitude := math.Hypot(float64(req.deltaX), float64(req.deltaY))
+	magnitude := math.Hypot(req.deltaX, req.deltaY)
 
 	duration := math.Min(float64(req.maxDuration), magnitude*req.durationPerPixel)
 	if duration < minScrollAnimationDuration {

--- a/internal/adapter/accessibility/native/linux/scroll_animator_test.go
+++ b/internal/adapter/accessibility/native/linux/scroll_animator_test.go
@@ -77,7 +77,7 @@ func sum(values []float64) float64 {
 func TestScrollChunks_TravelsTheRequestedDistance(t *testing.T) {
 	tests := []struct {
 		name  string
-		delta int
+		delta float64
 		steps int
 	}{
 		{name: "one line down", delta: -50, steps: 20},
@@ -94,8 +94,8 @@ func TestScrollChunks_TravelsTheRequestedDistance(t *testing.T) {
 				t.Fatalf("got %d chunks, want %d", len(chunks), test.steps)
 			}
 
-			if got := sum(chunks); math.Abs(got-float64(test.delta)) > 1e-9 {
-				t.Errorf("chunks total %v, want %d", got, test.delta)
+			if got := sum(chunks); math.Abs(got-test.delta) > 1e-9 {
+				t.Errorf("chunks total %v, want %v", got, test.delta)
 			}
 		})
 	}
@@ -150,7 +150,7 @@ func TestScrollChunks_SendsAOneUnitScrollImmediately(t *testing.T) {
 	const notch = scrollPixelsPerNotch
 
 	// Shorter than a notch, exactly a notch, and the shipped scroll_step.
-	for _, delta := range []int{10, -10, 1, -1, notch, -notch, 50, -50} {
+	for _, delta := range []float64{10, -10, 1, -1, notch, -notch, 50, -50} {
 		chunks := scrollChunks(delta, 20, notch, maxScrollUnitsPerRequest)
 
 		want := float64(notch)
@@ -159,11 +159,11 @@ func TestScrollChunks_SendsAOneUnitScrollImmediately(t *testing.T) {
 		}
 
 		if got := sum(chunks); got != want {
-			t.Errorf("scrollChunks(%d, …) totals %v, want %v", delta, got, want)
+			t.Errorf("scrollChunks(%v, …) totals %v, want %v", delta, got, want)
 		}
 
 		if chunks[0] != want {
-			t.Errorf("scrollChunks(%d, …) puts %v on the first step, want the whole %v "+
+			t.Errorf("scrollChunks(%v, …) puts %v on the first step, want the whole %v "+
 				"— a one-notch scroll must not be delayed", delta, chunks[0], want)
 		}
 	}
@@ -373,6 +373,320 @@ func TestScrollAnimator_Animate_AbandonsAnAnimationOnTheFirstFailedChunk(t *test
 	if len(session.chunks) != 1 {
 		t.Errorf("the animation injected %d chunks against a failing backend, want 1",
 			len(session.chunks))
+	}
+}
+
+// loggedChunk is one injected chunk together with the modifier set the session
+// that carried it was opened with.
+type loggedChunk struct {
+	deltaX, deltaY float64
+	modifiers      action.Modifiers
+}
+
+// scrollLog records every chunk across every session the animator opens. A
+// preempting request opens its own session, so the modifier set is what tells
+// the two runs apart.
+type scrollLog struct {
+	mu     sync.Mutex
+	gran   float64
+	chunks []loggedChunk
+}
+
+func (l *scrollLog) begin(modifiers action.Modifiers) (scrollSession, error) {
+	return &loggingScrollSession{log: l, modifiers: modifiers}, nil
+}
+
+func (l *scrollLog) traveled() float64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	var total float64
+
+	for _, chunk := range l.chunks {
+		total += chunk.deltaY
+	}
+
+	return total
+}
+
+func (l *scrollLog) traveledWith(modifiers action.Modifiers) float64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	var total float64
+
+	for _, chunk := range l.chunks {
+		if chunk.modifiers == modifiers {
+			total += chunk.deltaY
+		}
+	}
+
+	return total
+}
+
+func (l *scrollLog) count() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return len(l.chunks)
+}
+
+type loggingScrollSession struct {
+	log       *scrollLog
+	modifiers action.Modifiers
+}
+
+func (s *loggingScrollSession) granularity() float64 { return s.log.gran }
+
+func (s *loggingScrollSession) inject(deltaX, deltaY float64) error {
+	s.log.mu.Lock()
+	defer s.log.mu.Unlock()
+
+	s.log.chunks = append(
+		s.log.chunks,
+		loggedChunk{deltaX: deltaX, deltaY: deltaY, modifiers: s.modifiers},
+	)
+
+	return nil
+}
+
+func (s *loggingScrollSession) close() {}
+
+// The shipped smooth_scroll defaults, which are what makes the truncation
+// visible: the animation runs for max_duration (180ms) while held_repeat fires
+// every 50ms, so most of each tick's travel is still unsent when the next tick
+// arrives.
+const (
+	scrollTestSteps            = 20
+	scrollTestMaxDuration      = 180
+	scrollTestDurationPerPixel = 1.0
+	scrollTestRepeatInterval   = 50 * time.Millisecond
+	scrollTestHalfPage         = -500
+)
+
+// TestScrollAnimator_Animate_HeldRepeatTravelsAsFarAsDiscretePresses is the
+// property the whole animation rests on, restated for a key held down:
+// switching smooth scroll on changes how a held scroll key looks, never how far
+// it goes. Each repeat tick preempts the animation still in flight, and before
+// the undelivered remainder was composed into it, most of every tick's travel
+// was thrown away. darwin's animator carries the same test.
+func TestScrollAnimator_Animate_HeldRepeatTravelsAsFarAsDiscretePresses(t *testing.T) {
+	const ticks = 10
+
+	// A continuous backend (Wayland): granularity 0, so the chunks carry the
+	// distance exactly and the total is the requested one rather than a whole
+	// number of wheel notches.
+	log := &scrollLog{}
+	animator := newScrollAnimator(log.begin)
+
+	t.Cleanup(animator.stop)
+
+	for range ticks {
+		animator.animate(
+			0,
+			scrollTestHalfPage,
+			0,
+			scrollTestSteps,
+			scrollTestMaxDuration,
+			scrollTestDurationPerPixel,
+		)
+		time.Sleep(scrollTestRepeatInterval)
+	}
+
+	want := float64(ticks * scrollTestHalfPage)
+
+	// The last tick's animation is still draining; the run is only equal to the
+	// same number of discrete presses once it finishes.
+	waitFor(t, func() bool { return math.Abs(log.traveled()-want) < 1e-6 })
+
+	if got := log.traveled(); math.Abs(got-want) > 1e-6 {
+		t.Errorf("%d held-repeat ticks traveled %v, want %v (the same %d discrete presses)",
+			ticks, got, want, ticks)
+	}
+}
+
+// TestScrollAnimator_Animate_HeldRepeatOnAGranularBackend is the X11 half of
+// the same property, and the one where it cannot be exact: a wheel button is
+// one notch and there is no fraction of one to send, so each request's schedule
+// leaves a sub-notch residue behind. A discrete press drops that residue too,
+// which is what keeps the two comparable — the held run has to land within one
+// notch per tick of the same number of presses, not merely somewhere short of
+// them. Truncating each tick's remainder instead put it 40% short.
+func TestScrollAnimator_Animate_HeldRepeatOnAGranularBackend(t *testing.T) {
+	const (
+		ticks = 10
+		notch = scrollPixelsPerNotch
+	)
+
+	log := &scrollLog{gran: notch}
+	animator := newScrollAnimator(log.begin)
+
+	t.Cleanup(animator.stop)
+
+	for range ticks {
+		animator.animate(
+			0,
+			scrollTestHalfPage,
+			0,
+			scrollTestSteps,
+			scrollTestMaxDuration,
+			scrollTestDurationPerPixel,
+		)
+		time.Sleep(scrollTestRepeatInterval)
+	}
+
+	var (
+		asked     = float64(ticks * -scrollTestHalfPage)
+		tolerance = float64(ticks * notch)
+	)
+
+	// The last tick is still draining, so the floor is what has to be waited
+	// for; the ceiling holds at every instant, since no schedule can send more
+	// than was asked for.
+	waitFor(t, func() bool { return -log.traveled() >= asked-tolerance })
+
+	time.Sleep(60 * time.Millisecond)
+
+	if got := -log.traveled(); got > asked {
+		t.Errorf("%d held-repeat ticks traveled %v, more than the %v asked for",
+			ticks, got, asked)
+	}
+}
+
+// TestScrollAnimator_Animate_KeepsTheBacklogBounded covers the risk composition
+// introduces: the animation (180ms) outlives the repeat interval (50ms), so
+// undelivered delta accumulates across ticks. It has to self-limit — duration is
+// capped at max_duration, so a larger pending delta drains over the same window
+// and the delivery rate rises with the backlog. Without that a long hold would
+// keep scrolling long after the key came up.
+func TestScrollAnimator_Animate_KeepsTheBacklogBounded(t *testing.T) {
+	const (
+		ticks = 15
+		// Steady state is ~0.6 of one tick's delta at these settings, so four
+		// ticks' worth is loose enough to absorb scheduler jitter — and an
+		// uncomposed backlog, which grows by ~0.4 of a tick's delta every tick,
+		// still crosses it well inside the run.
+		maxBacklog = 4 * -scrollTestHalfPage
+	)
+
+	log := &scrollLog{}
+	animator := newScrollAnimator(log.begin)
+
+	t.Cleanup(animator.stop)
+
+	for tick := 1; tick <= ticks; tick++ {
+		animator.animate(
+			0,
+			scrollTestHalfPage,
+			0,
+			scrollTestSteps,
+			scrollTestMaxDuration,
+			scrollTestDurationPerPixel,
+		)
+		time.Sleep(scrollTestRepeatInterval)
+
+		backlog := -(float64(tick*scrollTestHalfPage) - log.traveled())
+		if backlog > maxBacklog {
+			t.Fatalf("after %d ticks %v pixels are still undelivered, more than the %d ceiling: "+
+				"the backlog is not converging", tick, backlog, maxBacklog)
+		}
+	}
+}
+
+// TestScrollAnimator_Animate_DropsTheRemainderOnADifferentModifierSet pins the
+// half of the rule that must not change: a plain scroll_down arriving mid-zoom
+// cancels the zoom and finishes unmodified, which is what the second binding
+// asked for. Carrying the zoom's undelivered distance into it would emit that
+// distance as a plain scroll nobody asked for — and on Linux the modifier is a
+// real key, so the two runs are two sessions.
+func TestScrollAnimator_Animate_DropsTheRemainderOnADifferentModifierSet(t *testing.T) {
+	const (
+		zoom  = -4000
+		plain = -100
+	)
+
+	log := &scrollLog{}
+	animator := newScrollAnimator(log.begin)
+
+	t.Cleanup(animator.stop)
+
+	// Long enough that the preempting request certainly lands mid-animation.
+	animator.animate(0, zoom, action.ModCtrl, 40, 2000, 1.0)
+
+	waitFor(t, func() bool { return log.count() > 0 })
+
+	animator.animate(0, plain, 0, scrollTestSteps, scrollTestMaxDuration, 1.0)
+
+	waitFor(t, func() bool { return math.Abs(log.traveledWith(0)-plain) < 1e-6 })
+
+	// Give the animator room to post more than it should before asserting.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := log.traveledWith(0); math.Abs(got-plain) > 1e-6 {
+		t.Errorf("the unmodified scroll traveled %v, want exactly %d — "+
+			"the canceled zoom's remainder leaked into it", got, plain)
+	}
+
+	if got := log.traveledWith(action.ModCtrl); got == zoom {
+		t.Errorf("the zoom traveled its full %v; the plain scroll was supposed to cancel it", got)
+	}
+}
+
+// TestScrollAnimator_EnqueueLocked_ComposesAQueuedRequest covers the other seam
+// a delta can be dropped at: a request the worker has not taken yet is replaced
+// wholesale by the next one. None of it has been injected, so all of it folds
+// into the replacement — under the same modifier rule the worker applies.
+func TestScrollAnimator_EnqueueLocked_ComposesAQueuedRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		queuedMod action.Modifiers
+		nextMod   action.Modifiers
+		wantY     float64
+	}{
+		{name: "same modifiers compose", queuedMod: 0, nextMod: 0, wantY: -80},
+		{
+			name:      "same non-zero modifiers compose",
+			queuedMod: action.ModCtrl,
+			nextMod:   action.ModCtrl,
+			wantY:     -80,
+		},
+		{name: "different modifiers replace", queuedMod: action.ModCtrl, nextMod: 0, wantY: -50},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// No worker: nothing consumes the channel, so the test owns both
+			// requests and this never runs.
+			animator := newScrollAnimator(
+				func(_ action.Modifiers) (scrollSession, error) {
+					return &fakeScrollSession{}, nil
+				},
+			)
+			animator.reqCh = make(chan scrollRequest, 1)
+
+			animator.enqueueLocked(scrollRequest{deltaY: -30, modifiers: test.queuedMod})
+			animator.enqueueLocked(scrollRequest{deltaY: -50, modifiers: test.nextMod})
+
+			select {
+			case got := <-animator.reqCh:
+				if got.deltaY != test.wantY {
+					t.Errorf("queued request deltaY = %v, want %v", got.deltaY, test.wantY)
+				}
+
+				if got.modifiers != test.nextMod {
+					t.Errorf("queued request modifiers = %v, want the preempting %v",
+						got.modifiers, test.nextMod)
+				}
+			default:
+				t.Fatal("nothing was queued")
+			}
+
+			select {
+			case extra := <-animator.reqCh:
+				t.Fatalf("a second request (%v) survived the coalesce", extra.deltaY)
+			default:
+			}
+		})
 	}
 }
 

--- a/internal/adapter/accessibility/native/linux/scroll_animator_test.go
+++ b/internal/adapter/accessibility/native/linux/scroll_animator_test.go
@@ -632,6 +632,47 @@ func TestScrollAnimator_Animate_DropsTheRemainderOnADifferentModifierSet(t *test
 	}
 }
 
+// TestScrollAnimator_Animate_AReversalNetsTheTwoDeltas is the same rule read
+// backwards, and the case composition is most often suspected of breaking: a
+// scroll_up landing mid-scroll_down inherits a *negative* remainder, so the new
+// animation travels less than its own delta — or not at all.
+//
+// That is the point. The pair asked for -600 then +600, which is a net zero,
+// and the first animation has already sent part of its -600. Ignoring the
+// remainder would inject the whole +600 on top of what went out and leave the
+// page above where it started, which is the same truncation bug facing the
+// other way. Conserving the requested total is what makes a reversal land where
+// the two presses said. darwin's animator carries the same test.
+func TestScrollAnimator_Animate_AReversalNetsTheTwoDeltas(t *testing.T) {
+	const stride = 600
+
+	log := &scrollLog{}
+	animator := newScrollAnimator(log.begin)
+
+	t.Cleanup(animator.stop)
+
+	// Long enough that the reversal certainly lands mid-animation.
+	animator.animate(0, -stride, 0, 40, 2000, 1.0)
+
+	waitFor(t, func() bool { return log.count() > 0 })
+
+	if got := log.traveled(); got >= 0 {
+		t.Fatalf("the first animation traveled %v before the reversal, want some downward travel",
+			got)
+	}
+
+	animator.animate(0, stride, 0, 40, 2000, 1.0)
+
+	waitFor(t, func() bool { return math.Abs(log.traveled()) < 1e-6 })
+
+	// Give the animator room to overshoot before believing the zero.
+	time.Sleep(80 * time.Millisecond)
+
+	if got := log.traveled(); math.Abs(got) > 1e-6 {
+		t.Errorf("a scroll of -%d reversed by +%d netted %v, want 0", stride, stride, got)
+	}
+}
+
 // TestScrollAnimator_EnqueueLocked_ComposesAQueuedRequest covers the other seam
 // a delta can be dropped at: a request the worker has not taken yet is replaced
 // wholesale by the next one. None of it has been injected, so all of it folds

--- a/internal/adapter/platform/darwin/scroll_animator.go
+++ b/internal/adapter/platform/darwin/scroll_animator.go
@@ -8,6 +8,7 @@ package darwin
 import "C"
 
 import (
+	"image"
 	"math"
 	"sync"
 	"time"
@@ -19,6 +20,11 @@ const (
 	minScrollAnimationDuration = 10 // Minimum animation duration in ms
 	minScrollStepDelay         = 1  // Minimum delay between steps in ms
 	easeOutCubicExponent       = 3  // Exponent for ease-out cubic easing
+	// defaultScrollSteps answers a caller that supplied a nonsense step count
+	// (<= 0). ValidateSmoothScroll already requires steps >= 1, so no validated
+	// configuration reaches it; it exists so a direct caller cannot divide by
+	// zero. Linux's animator keeps the same fallback.
+	defaultScrollSteps = 12
 )
 
 // scrollRequest is one animated scroll. The modifier set belongs to the
@@ -35,12 +41,36 @@ type scrollRequest struct {
 }
 
 type scrollAnimator struct {
+	// pos samples the live cursor position and post emits one scroll chunk
+	// there. Both are injected so the schedule can be driven without cgo — the
+	// animator is otherwise only observable through the events it posts to the
+	// window server — mirroring smoothCursorAnimator's pos/post pair.
+	//
+	// Neither may call back into the animator; the production pair are plain
+	// cgo calls, which is what makes that safe.
+	pos  func() image.Point
+	post func(at image.Point, deltaX, deltaY int, modifiers action.Modifiers)
+
 	mu     sync.Mutex
 	reqCh  chan scrollRequest
 	stopCh chan struct{}
 }
 
-var scrollAnim scrollAnimator
+// postScrollEvent posts one scroll chunk at point through CoreGraphics. It is
+// the production half of the animator's post seam.
+func postScrollEvent(at image.Point, deltaX, deltaY int, modifiers action.Modifiers) {
+	cgPos := C.CGPoint{x: C.double(at.X), y: C.double(at.Y)}
+	C.NeruScrollAtPoint(cgPos, C.int(deltaX), C.int(deltaY), modifiersToCGEventFlags(modifiers))
+}
+
+var scrollAnim = newScrollAnimator(CursorPosition, postScrollEvent)
+
+func newScrollAnimator(
+	pos func() image.Point,
+	post func(at image.Point, deltaX, deltaY int, modifiers action.Modifiers),
+) *scrollAnimator {
+	return &scrollAnimator{pos: pos, post: post}
+}
 
 func (a *scrollAnimator) stop() {
 	a.mu.Lock()
@@ -70,34 +100,46 @@ func (a *scrollAnimator) animate(
 		durationPerPixel: durationPerPixel,
 	}
 
-	reqCh := a.ensureWorker()
-	select {
-	case reqCh <- req:
-	default:
-		select {
-		case <-reqCh:
-		default:
-		}
-		reqCh <- req
-	}
-}
-
-func (a *scrollAnimator) ensureWorker() chan scrollRequest {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if a.reqCh != nil {
-		return a.reqCh
+	if a.reqCh == nil {
+		a.reqCh = make(chan scrollRequest, 1)
+		a.stopCh = make(chan struct{})
+
+		go a.run(a.reqCh, a.stopCh)
 	}
 
-	reqCh := make(chan scrollRequest, 1)
-	stopCh := make(chan struct{})
-	a.reqCh = reqCh
-	a.stopCh = stopCh
+	a.enqueueLocked(req)
+}
 
-	go a.run(reqCh, stopCh)
+// enqueueLocked places req on the worker channel, folding in a queued request
+// the worker has not taken yet. The caller must hold a.mu.
+//
+// Under the lock we are the only producer and the worker is the only consumer,
+// so after draining the buffer is empty and the follow-up send cannot block.
+//
+// A request still sitting in the buffer has had none of its delta delivered, so
+// composeUndelivered folds all of it in — on the same rule the worker applies
+// when a request preempts it mid-animation, which is what keeps the two seams
+// from disagreeing about whether a same-modifier scroll can be dropped.
+func (a *scrollAnimator) enqueueLocked(req scrollRequest) {
+	select {
+	case a.reqCh <- req:
+		return
+	default:
+	}
 
-	return reqCh
+	select {
+	case queued := <-a.reqCh:
+		req = composeUndelivered(req, queued, queued.deltaX, queued.deltaY)
+	default:
+	}
+
+	select {
+	case a.reqCh <- req:
+	default:
+	}
 }
 
 func (a *scrollAnimator) run(reqCh <-chan scrollRequest, stopCh <-chan struct{}) {
@@ -115,21 +157,37 @@ func (a *scrollAnimator) run(reqCh <-chan scrollRequest, stopCh <-chan struct{})
 	}
 }
 
+// runRequest animates one request to completion, or until a newer one preempts
+// it — in which case the preempting request is played next, carrying whatever
+// composeUndelivered folded into it.
 func (a *scrollAnimator) runRequest(
 	req scrollRequest,
 	reqCh <-chan scrollRequest,
 	stopCh <-chan struct{},
 	timer *time.Timer,
 ) {
-restart:
+	for {
+		next, restart := a.runOnce(req, reqCh, stopCh, timer)
+		if !restart {
+			return
+		}
+
+		req = next
+	}
+}
+
+// runOnce plays one request's schedule. It reports the request that preempted
+// this one, if any.
+func (a *scrollAnimator) runOnce(
+	req scrollRequest,
+	reqCh <-chan scrollRequest,
+	stopCh <-chan struct{},
+	timer *time.Timer,
+) (scrollRequest, bool) {
 	magnitude := math.Hypot(float64(req.deltaX), float64(req.deltaY))
 	if magnitude == 0 {
-		return
+		return scrollRequest{}, false
 	}
-
-	// Recomputed after every restart, so a request that preempts this one
-	// stamps its own modifiers on the chunks that remain.
-	flags := modifiersToCGEventFlags(req.modifiers)
 
 	duration := math.Min(float64(req.maxDuration), magnitude*req.durationPerPixel)
 	if duration < minScrollAnimationDuration {
@@ -138,7 +196,7 @@ restart:
 
 	actualSteps := req.steps
 	if actualSteps <= 0 {
-		actualSteps = 12
+		actualSteps = defaultScrollSteps
 	}
 
 	maxSteps := max(int(duration/float64(minScrollStepDelay)), 1)
@@ -150,19 +208,20 @@ restart:
 
 	stepDelay := time.Duration(stepDelayMs) * time.Millisecond
 
-	var prevX, prevY int
+	// sentX/sentY is what has actually gone out. The curve is eased on the
+	// cumulative position and each chunk is the difference between two points
+	// on it, so at the last step they equal the request's delta exactly — which
+	// is what makes req.delta - sent the undelivered remainder.
+	var sentX, sentY int
 
 	for step := 1; step <= actualSteps; step++ {
 		select {
 		case <-stopCh:
-			return
-		case req = <-reqCh:
-			goto restart
+			return scrollRequest{}, false
+		case next := <-reqCh:
+			return composeUndelivered(next, req, req.deltaX-sentX, req.deltaY-sentY), true
 		default:
 		}
-
-		cursorPos := CursorPosition()
-		cgPos := C.CGPoint{x: C.double(cursorPos.X), y: C.double(cursorPos.Y)}
 
 		t := float64(step) / float64(actualSteps)
 		eased := 1 - math.Pow(1-t, easeOutCubicExponent)
@@ -170,12 +229,14 @@ restart:
 		targetX := int(math.Round(float64(req.deltaX) * eased))
 		targetY := int(math.Round(float64(req.deltaY) * eased))
 
-		chunkX := targetX - prevX
-		chunkY := targetY - prevY
-		prevX = targetX
-		prevY = targetY
+		chunkX := targetX - sentX
+		chunkY := targetY - sentY
+		sentX = targetX
+		sentY = targetY
 
-		C.NeruScrollAtPoint(cgPos, C.int(chunkX), C.int(chunkY), flags)
+		// The modifiers travel with every chunk, so a request that preempts
+		// this one stamps its own on the chunks that remain.
+		a.post(a.pos(), chunkX, chunkY, req.modifiers)
 
 		if step < actualSteps {
 			timer.Reset(stepDelay)
@@ -183,15 +244,42 @@ restart:
 			case <-stopCh:
 				stopAndDrainTimer(timer)
 
-				return
-			case req = <-reqCh:
+				return scrollRequest{}, false
+			case next := <-reqCh:
 				stopAndDrainTimer(timer)
 
-				goto restart
+				return composeUndelivered(next, req, req.deltaX-sentX, req.deltaY-sentY), true
 			case <-timer.C:
 			}
 		}
 	}
+
+	return scrollRequest{}, false
+}
+
+// composeUndelivered folds the part of inflight that never went out — remX,
+// remY — into the request preempting it, but only when the two ask for the same
+// modifiers.
+//
+// Same modifiers is the held-repeat case, since a repeat re-sends the binding
+// it is repeating: without this, every tick throws away whatever the previous
+// tick had not yet emitted, and holding a scroll key travels visibly less than
+// the same number of discrete presses.
+//
+// Different modifiers is the deliberate cancel scrollRequest documents: a plain
+// scroll_down arriving mid-zoom finishes unmodified, which is what the second
+// binding asked for. Carrying the zoom's remainder into it would emit that
+// distance as a plain scroll — a scroll the user never asked for — so it is
+// dropped exactly as before.
+func composeUndelivered(next, inflight scrollRequest, remX, remY int) scrollRequest {
+	if next.modifiers != inflight.modifiers {
+		return next
+	}
+
+	next.deltaX += remX
+	next.deltaY += remY
+
+	return next
 }
 
 func stopAndDrainTimer(timer *time.Timer) {

--- a/internal/adapter/platform/darwin/scroll_animator_test.go
+++ b/internal/adapter/platform/darwin/scroll_animator_test.go
@@ -215,6 +215,47 @@ func TestScrollAnimator_Animate_DropsTheRemainderOnADifferentModifierSet(t *test
 	}
 }
 
+// TestScrollAnimator_Animate_AReversalNetsTheTwoDeltas is the same rule read
+// backwards, and the case composition is most often suspected of breaking: a
+// scroll_up landing mid-scroll_down inherits a *negative* remainder, so the new
+// animation travels less than its own delta — or not at all.
+//
+// That is the point. The pair asked for -600 then +600, which is a net zero,
+// and the first animation has already sent part of its -600. Ignoring the
+// remainder would deliver the whole +600 on top of what went out and leave the
+// page above where it started, which is the same truncation bug facing the
+// other way. Conserving the requested total is what makes a reversal land where
+// the two presses said.
+func TestScrollAnimator_Animate_AReversalNetsTheTwoDeltas(t *testing.T) {
+	const stride = 600
+
+	rec := &scrollRecorder{}
+	animator := newScrollAnimator(rec.pos, rec.post)
+
+	t.Cleanup(animator.stop)
+
+	// Long enough that the reversal certainly lands mid-animation.
+	animator.animate(0, -stride, 0, 40, 2000, 1.0)
+
+	waitForScroll(t, func() bool { return rec.count() > 0 })
+
+	if got := rec.traveled(); got >= 0 {
+		t.Fatalf("the first animation traveled %d before the reversal, want some downward travel",
+			got)
+	}
+
+	animator.animate(0, stride, 0, 40, 2000, 1.0)
+
+	waitForScroll(t, func() bool { return rec.traveled() == 0 })
+
+	// Give the animator room to overshoot before believing the zero.
+	time.Sleep(80 * time.Millisecond)
+
+	if got := rec.traveled(); got != 0 {
+		t.Errorf("a scroll of -%d reversed by +%d netted %d, want 0", stride, stride, got)
+	}
+}
+
 // TestScrollAnimator_EnqueueLocked_ComposesAQueuedRequest covers the other seam
 // a delta can be dropped at: a request the worker has not taken yet is replaced
 // wholesale by the next one. None of it has been delivered, so all of it folds

--- a/internal/adapter/platform/darwin/scroll_animator_test.go
+++ b/internal/adapter/platform/darwin/scroll_animator_test.go
@@ -1,0 +1,271 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"image"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/domain/action"
+)
+
+// scrollChunk is one posted scroll, with the modifier set it was stamped with.
+type scrollChunk struct {
+	deltaX, deltaY int
+	modifiers      action.Modifiers
+}
+
+// scrollRecorder stands in for the window server: it captures every chunk the
+// animator posts so a test can total the distance actually traveled.
+type scrollRecorder struct {
+	mu     sync.Mutex
+	chunks []scrollChunk
+}
+
+func (r *scrollRecorder) pos() image.Point { return image.Point{X: 100, Y: 100} }
+
+func (r *scrollRecorder) post(_ image.Point, deltaX, deltaY int, modifiers action.Modifiers) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.chunks = append(r.chunks, scrollChunk{deltaX: deltaX, deltaY: deltaY, modifiers: modifiers})
+}
+
+// traveledWith totals the vertical distance posted under exactly modifiers.
+func (r *scrollRecorder) traveledWith(modifiers action.Modifiers) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var total int
+
+	for _, chunk := range r.chunks {
+		if chunk.modifiers == modifiers {
+			total += chunk.deltaY
+		}
+	}
+
+	return total
+}
+
+// traveled totals the vertical distance posted, whatever the modifiers.
+func (r *scrollRecorder) traveled() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var total int
+
+	for _, chunk := range r.chunks {
+		total += chunk.deltaY
+	}
+
+	return total
+}
+
+func (r *scrollRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.chunks)
+}
+
+// The shipped smooth_scroll defaults, which are what makes the truncation
+// visible: the animation runs for max_duration (180ms) while held_repeat fires
+// every 50ms, so most of each tick's travel is still unsent when the next tick
+// arrives.
+const (
+	scrollTestSteps            = 20
+	scrollTestMaxDuration      = 180
+	scrollTestDurationPerPixel = 1.0
+	scrollTestRepeatInterval   = 50 * time.Millisecond
+	scrollTestHalfPage         = -500
+)
+
+// waitForScroll polls until the condition holds, failing rather than hanging.
+func waitForScroll(t *testing.T, condition func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	t.Fatal("the condition never held within 5s")
+}
+
+// TestScrollAnimator_Animate_HeldRepeatTravelsAsFarAsDiscretePresses is the
+// property the whole fix rests on: switching smooth scroll on changes how a
+// held scroll key looks, never how far it goes. Each repeat tick preempts the
+// animation still in flight, and before the remainder was composed in, roughly
+// 70% of every tick's travel was thrown away.
+func TestScrollAnimator_Animate_HeldRepeatTravelsAsFarAsDiscretePresses(t *testing.T) {
+	const ticks = 10
+
+	rec := &scrollRecorder{}
+	animator := newScrollAnimator(rec.pos, rec.post)
+
+	t.Cleanup(animator.stop)
+
+	for range ticks {
+		animator.animate(
+			0,
+			scrollTestHalfPage,
+			0,
+			scrollTestSteps,
+			scrollTestMaxDuration,
+			scrollTestDurationPerPixel,
+		)
+		time.Sleep(scrollTestRepeatInterval)
+	}
+
+	want := ticks * scrollTestHalfPage
+
+	// The last tick's animation is still draining; the run is only equal to the
+	// same number of discrete presses once it finishes.
+	waitForScroll(t, func() bool { return rec.traveled() == want })
+
+	if got := rec.traveled(); got != want {
+		t.Errorf("%d held-repeat ticks traveled %d, want %d (the same %d discrete presses)",
+			ticks, got, want, ticks)
+	}
+}
+
+// TestScrollAnimator_Animate_KeepsTheBacklogBounded covers the risk composition
+// introduces: the animation (180ms) outlives the repeat interval (50ms), so
+// undelivered delta accumulates across ticks. It has to self-limit — duration is
+// capped at max_duration, so a larger pending delta drains over the same window
+// and the delivery rate rises with the backlog — and that convergence is worth a
+// test rather than an assumption. Without it a long hold would keep scrolling
+// long after the key came up.
+func TestScrollAnimator_Animate_KeepsTheBacklogBounded(t *testing.T) {
+	const (
+		ticks = 15
+		// Steady state is ~0.6 of one tick's delta at these settings, so four
+		// ticks' worth is loose enough to absorb scheduler jitter — and an
+		// uncomposed backlog, which grows by ~0.4 of a tick's delta every tick,
+		// still crosses it well inside the run.
+		maxBacklog = 4 * -scrollTestHalfPage
+	)
+
+	rec := &scrollRecorder{}
+	animator := newScrollAnimator(rec.pos, rec.post)
+
+	t.Cleanup(animator.stop)
+
+	for tick := 1; tick <= ticks; tick++ {
+		animator.animate(
+			0,
+			scrollTestHalfPage,
+			0,
+			scrollTestSteps,
+			scrollTestMaxDuration,
+			scrollTestDurationPerPixel,
+		)
+		time.Sleep(scrollTestRepeatInterval)
+
+		backlog := -(tick*scrollTestHalfPage - rec.traveled())
+		if backlog > maxBacklog {
+			t.Fatalf("after %d ticks %d pixels are still undelivered, more than the %d ceiling: "+
+				"the backlog is not converging", tick, backlog, maxBacklog)
+		}
+	}
+}
+
+// TestScrollAnimator_Animate_DropsTheRemainderOnADifferentModifierSet pins the
+// half of the rule that must not change: a plain scroll_down arriving mid-zoom
+// cancels the zoom and finishes unmodified, which is what the second binding
+// asked for. Carrying the zoom's undelivered distance into it would emit that
+// distance as a plain scroll nobody asked for.
+func TestScrollAnimator_Animate_DropsTheRemainderOnADifferentModifierSet(t *testing.T) {
+	const (
+		zoom  = -4000
+		plain = -100
+	)
+
+	rec := &scrollRecorder{}
+	animator := newScrollAnimator(rec.pos, rec.post)
+
+	t.Cleanup(animator.stop)
+
+	// Long enough that the preempting request certainly lands mid-animation.
+	animator.animate(0, zoom, action.ModCtrl, 40, 2000, 1.0)
+
+	waitForScroll(t, func() bool { return rec.count() > 0 })
+
+	animator.animate(0, plain, 0, scrollTestSteps, scrollTestMaxDuration, 1.0)
+
+	waitForScroll(t, func() bool { return rec.traveledWith(0) == plain })
+
+	// Give the animator room to post more than it should before asserting.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := rec.traveledWith(0); got != plain {
+		t.Errorf("the unmodified scroll traveled %d, want exactly %d — "+
+			"the canceled zoom's remainder leaked into it", got, plain)
+	}
+
+	if got := rec.traveledWith(action.ModCtrl); got == zoom {
+		t.Errorf("the zoom traveled its full %d; the plain scroll was supposed to cancel it", got)
+	}
+}
+
+// TestScrollAnimator_EnqueueLocked_ComposesAQueuedRequest covers the other seam
+// a delta can be dropped at: a request the worker has not taken yet is replaced
+// wholesale by the next one. None of it has been delivered, so all of it folds
+// into the replacement — under the same modifier rule the worker applies.
+func TestScrollAnimator_EnqueueLocked_ComposesAQueuedRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		queuedMod action.Modifiers
+		nextMod   action.Modifiers
+		wantY     int
+	}{
+		{name: "same modifiers compose", queuedMod: 0, nextMod: 0, wantY: -80},
+		{
+			name: "same non-zero modifiers compose", queuedMod: action.ModCtrl,
+			nextMod: action.ModCtrl, wantY: -80,
+		},
+		{name: "different modifiers replace", queuedMod: action.ModCtrl, nextMod: 0, wantY: -50},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// No worker: nothing consumes the channel, so the test owns both
+			// requests and no scroll is posted.
+			animator := newScrollAnimator(
+				func() image.Point { return image.Point{} },
+				func(image.Point, int, int, action.Modifiers) {},
+			)
+			animator.reqCh = make(chan scrollRequest, 1)
+
+			animator.enqueueLocked(scrollRequest{deltaY: -30, modifiers: test.queuedMod})
+			animator.enqueueLocked(scrollRequest{deltaY: -50, modifiers: test.nextMod})
+
+			select {
+			case got := <-animator.reqCh:
+				if got.deltaY != test.wantY {
+					t.Errorf("queued request deltaY = %d, want %d", got.deltaY, test.wantY)
+				}
+
+				if got.modifiers != test.nextMod {
+					t.Errorf("queued request modifiers = %v, want the preempting %v",
+						got.modifiers, test.nextMod)
+				}
+			default:
+				t.Fatal("nothing was queued")
+			}
+
+			select {
+			case extra := <-animator.reqCh:
+				t.Fatalf("a second request (%d) survived the coalesce", extra.deltaY)
+			default:
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes a held scroll key travelling noticeably less far than the same
number of discrete presses when `smooth_scroll` and `held_repeat` are both
enabled. Each repeat tick used to cancel the animation still in flight and
throw away whatever it had not yet sent — with the shipped defaults the
animation runs for 180ms while a repeat fires every 50ms, so roughly 70% of
every tick's travel was discarded. A tick now folds the undelivered remainder
of the animation it preempts into its own, so N repeats travel the distance N
presses would.

Composition applies only when the preempting scroll asks for the *same*
modifiers. A binding with a different modifier set still cancels outright — a
plain `scroll_down` arriving mid-zoom finishes unmodified and the zoom's
remaining distance is dropped rather than emitted as a plain scroll nobody
asked for. Turning `smooth_scroll` off is unaffected: that path was never
animated.

Two deliberate limitations. On X11 a wheel button is one notch and there is no
fraction of one to send, so each tick still leaves a sub-notch residue behind —
a discrete press leaves the same residue, so the two stay within one notch per
tick of each other rather than matching exactly. And the X11 ceiling on events
per scroll (50 notches) now applies to a composed delta, so a `scroll_step`
already close to that ceiling can hit it once a remainder is folded in; the
clipped distance is deliberately not carried forward, since it is a rate limit
no animation was going to deliver.

## Related Issues

Closes #1475

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability changed; Windows already injects scrolls in one step and has no animator to fix
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

No config surface changes: no option added, renamed, removed, or given a new
default. `docs/CONFIGURATION.md` gains a paragraph under `[smooth_scroll]`
stating what a held key now does, beside the existing claim that the animation
changes how a scroll looks rather than how far it goes.

**Why composition is conditional.** Mirroring the cursor animator, which
composes unconditionally, was rejected: it would emit a cancelled zoom's
leftover distance as a plain scroll, contradicting the behaviour the scroll
request type documents. Flushing the remainder as one discrete chunk before
restarting was rejected too: at `interval_ms = 50` that injects a visible jump
twenty times a second, which is the opposite of what `smooth_scroll` is for.

**Two seams, one rule.** Besides the in-flight animation, a scroll can also be
dropped while queued for the worker but not yet picked up. Both seams now apply
the same modifier-matched composition, so they cannot disagree about whether a
same-modifier scroll may be discarded. On macOS the queue hand-off moved under
the animator's lock to make the read-modify-write atomic, matching what the
cursor animator and the Linux scroll animator already do.

**Backlog convergence.** Because the animation outlives the repeat interval,
undelivered delta accumulates across ticks. It self-limits: duration is capped
at `max_duration`, so a larger pending delta drains over the same window and
the delivery rate rises with the backlog, settling at roughly 0.6 of one tick's
delta. Both platforms carry a test that fails if the backlog stops converging,
and the "as far as N presses" tests only pass once the final animation has
drained the whole remainder on key release.

**Testing.** The macOS animator gained an injected cursor-position/post pair —
the same seam the cursor animator in that package already uses — so its
schedule can be driven without cgo. Beyond `just ci`, the Linux suite and the
Linux and Windows cross-lint were run in containers.
