### PR TITLE
refactor(linux): share one shm-file helper across the Wayland backends

### DIFF
--- a/internal/adapter/platform/linux/overlay_wayland.c
+++ b/internal/adapter/platform/linux/overlay_wayland.c
@@ -1,5 +1,6 @@
 #include "overlay_wayland.h"
 
+#include "shm_file.h"
 #include "wlr_protocol/fractional-scale-v1.h"
 #include "wlr_protocol/layer-shell.h"
 #include "wlr_protocol/viewporter.h"
@@ -7,8 +8,6 @@
 #include "wlr_protocol/xdg-shell.h"
 
 #include <cairo/cairo.h>
-#include <errno.h>
-#include <fcntl.h>
 #include <math.h>
 #include <poll.h>
 #include <stdio.h>
@@ -60,38 +59,6 @@ static const char *neru_modifier_name_from_keysym(xkb_keysym_t keysym) {
 	default:
 		return NULL;
 	}
-}
-
-// Create anonymous shared memory
-static int create_shm_file(off_t size) {
-	int ret, fd;
-
-#ifdef __NR_memfd_create
-	fd = syscall(__NR_memfd_create, "neru-overlay-shm", 0);
-	if (fd >= 0) {
-		do {
-			ret = ftruncate(fd, size);
-		} while (ret < 0 && errno == EINTR);
-		if (ret >= 0)
-			return fd;
-		close(fd);
-	}
-#endif
-
-	// Fallback if no memfd
-	char name[] = "/tmp/neru-shm-XXXXXX";
-	fd = mkstemp(name);
-	if (fd < 0)
-		return -1;
-	unlink(name);
-	do {
-		ret = ftruncate(fd, size);
-	} while (ret < 0 && errno == EINTR);
-	if (ret < 0) {
-		close(fd);
-		return -1;
-	}
-	return fd;
 }
 
 static void neru_layer_surface_configure(
@@ -600,7 +567,7 @@ static int neru_create_single_buffer(
     NeruWaylandOverlay *overlay, NeruWaylandOverlayScreen *scr, int buf_idx, int buf_width, int buf_height, int stride,
     double scale) {
 	size_t buf_size = (size_t)stride * (size_t)buf_height;
-	int fd = create_shm_file(buf_size);
+	int fd = neru_shm_file_create("neru-overlay-shm", buf_size);
 	if (fd < 0)
 		return -1;
 

--- a/internal/adapter/platform/linux/shm_file.c
+++ b/internal/adapter/platform/linux/shm_file.c
@@ -1,0 +1,60 @@
+#include "shm_file.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+// ftruncate is interruptible, and a signal landing mid-call leaves the
+// descriptor at its old length rather than the size the caller asked for —
+// which surfaces later as a short mapping, not as an error. Retrying on EINTR
+// is what every caller wants, so it lives here once.
+//
+// A size above OFF_T_MAX wraps to a negative length, which ftruncate rejects
+// with EINVAL; no caller can reach it, and the failure is loud if one ever
+// does.
+static int neru_shm_file_truncate(int fd, size_t size) {
+	int rc;
+
+	do {
+		rc = ftruncate(fd, (off_t)size);
+	} while (rc < 0 && errno == EINTR);
+
+	return rc;
+}
+
+int neru_shm_file_create(const char *name, size_t size) {
+#ifdef __NR_memfd_create
+	int memfd = (int)syscall(__NR_memfd_create, name, 0);
+	if (memfd >= 0) {
+		if (neru_shm_file_truncate(memfd, size) >= 0) {
+			return memfd;
+		}
+
+		close(memfd);
+	}
+#else
+	(void)name;
+#endif
+
+	// The file is unlinked the moment it exists, so this path is never visible
+	// to anything but the mkstemp collision check — `name` labels the memfd
+	// above, and there is nothing here for it to label.
+	char path[] = "/tmp/neru-shm-XXXXXX";
+
+	int fd = mkstemp(path);
+	if (fd < 0) {
+		return -1;
+	}
+
+	unlink(path);
+
+	if (neru_shm_file_truncate(fd, size) < 0) {
+		close(fd);
+
+		return -1;
+	}
+
+	return fd;
+}

--- a/internal/adapter/platform/linux/shm_file.c
+++ b/internal/adapter/platform/linux/shm_file.c
@@ -48,7 +48,15 @@ int neru_shm_file_create(const char *name, size_t size) {
 		return -1;
 	}
 
-	unlink(path);
+	// Refusing on a failed unlink is the whole difference between this fallback
+	// and a named file full of screen pixels sitting in /tmp. Every caller
+	// already degrades on -1, and a /tmp that mkstemp could write but not
+	// unlink is broken enough that failing is the honest answer.
+	if (unlink(path) < 0) {
+		close(fd);
+
+		return -1;
+	}
 
 	if (neru_shm_file_truncate(fd, size) < 0) {
 		close(fd);

--- a/internal/adapter/platform/linux/shm_file.h
+++ b/internal/adapter/platform/linux/shm_file.h
@@ -1,0 +1,24 @@
+#ifndef SHM_FILE_H
+#define SHM_FILE_H
+
+#include <stddef.h>
+
+// neru_shm_file_create returns a file descriptor onto `size` bytes of
+// anonymous shared memory, ready to hand to wl_shm_create_pool. Returns -1 on
+// failure; the caller owns the descriptor and closes it.
+//
+// The buffer comes from memfd_create where the kernel headers know the
+// syscall, and from an immediately unlinked file under /tmp where they do not,
+// so every backend gets a buffer on targets that predate memfd. The fallback
+// is a real file: unreachable by path the moment it exists, but backed by
+// whatever /tmp is, which anonymous memory is not. Every caller writes screen
+// content into it, so a caller that must never let those bytes reach a disk
+// wants its own path rather than this one — no caller has that constraint
+// today, and memfd has been in kernel headers since 3.17.
+//
+// `name` labels the memfd for debugging — it is what shows up as /memfd:<name>
+// in /proc/<pid>/fd — and must not be NULL. The fallback has nothing to label:
+// its file is unlinked before anyone could look.
+int neru_shm_file_create(const char *name, size_t size);
+
+#endif /* SHM_FILE_H */

--- a/internal/adapter/platform/linux/wlroots_client.c
+++ b/internal/adapter/platform/linux/wlroots_client.c
@@ -6,13 +6,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
-#include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
 
-// Include wlroots protocol headers relative to this package.
+// Include the sibling bridge headers and the wlroots protocol headers
+// relative to this package.
+#include "shm_file.h"
 #include "wlr_protocol/foreign-toplevel.h"
 #include "wlr_protocol/layer-shell.h"
 #include "wlr_protocol/relative-pointer-unstable-v1.h"
@@ -268,36 +269,6 @@ typedef struct {
 
 static int neru_wlr_discovery_attach_buffer(NeruWlrootsClient *c, NeruCursorDiscoverySurface *surface);
 
-static int neru_wlr_create_shm_file(off_t size) {
-	int ret;
-
-#ifdef __NR_memfd_create
-	int fd = syscall(__NR_memfd_create, "neru-cursor-discovery-shm", 0);
-	if (fd >= 0) {
-		do {
-			ret = ftruncate(fd, size);
-		} while (ret < 0 && errno == EINTR);
-		if (ret >= 0)
-			return fd;
-		close(fd);
-	}
-#endif
-
-	char name[] = "/tmp/neru-cursor-discovery-XXXXXX";
-	fd = mkstemp(name);
-	if (fd < 0)
-		return -1;
-	unlink(name);
-	do {
-		ret = ftruncate(fd, size);
-	} while (ret < 0 && errno == EINTR);
-	if (ret < 0) {
-		close(fd);
-		return -1;
-	}
-	return fd;
-}
-
 static void neru_wlr_discovery_configure(
     void *data, struct zwlr_layer_surface_v1 *layer_surface, uint32_t serial, uint32_t width, uint32_t height) {
 	NeruCursorDiscoverySurface *surface = (NeruCursorDiscoverySurface *)data;
@@ -328,7 +299,7 @@ static int neru_wlr_discovery_attach_buffer(NeruWlrootsClient *c, NeruCursorDisc
 
 	size_t stride = (size_t)surface->width * 4u;
 	surface->shm_size = stride * (size_t)surface->height;
-	int fd = neru_wlr_create_shm_file((off_t)surface->shm_size);
+	int fd = neru_shm_file_create("neru-cursor-discovery-shm", surface->shm_size);
 	if (fd < 0)
 		return 0;
 

--- a/internal/adapter/platform/linux/wlroots_screencopy.c
+++ b/internal/adapter/platform/linux/wlroots_screencopy.c
@@ -2,6 +2,7 @@
 
 #include "common_defs.h"
 #include "screencapture.h"
+#include "shm_file.h"
 #include "wlr_protocol/screencopy.h"
 #include "wlr_protocol/xdg-output.h"
 
@@ -11,7 +12,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
-#include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
 #include <wayland-client.h>
@@ -352,27 +352,6 @@ static int neru_screencopy_roundtrip(NeruScreencopyCtx *ctx, int64_t deadline) {
 	return ok;
 }
 
-static int neru_screencopy_shm_file(size_t size) {
-	int fd = (int)syscall(__NR_memfd_create, "neru-screencopy-shm", 0);
-	if (fd < 0) {
-		return -1;
-	}
-
-	int rc;
-
-	do {
-		rc = ftruncate(fd, (off_t)size);
-	} while (rc < 0 && errno == EINTR);
-
-	if (rc < 0) {
-		close(fd);
-
-		return -1;
-	}
-
-	return fd;
-}
-
 // neru_screencopy_select_output finds the output that wholly contains the
 // requested region and writes the region in that output's local logical
 // coordinates. Returns NULL when no single output contains it.
@@ -515,7 +494,7 @@ static int neru_screencopy_copy_frame(
 
 	size_t size = (size_t)mapping;
 
-	int fd = neru_screencopy_shm_file(size);
+	int fd = neru_shm_file_create("neru-screencopy-shm", size);
 	if (fd < 0) {
 		return NERU_CAPTURE_ERR_ALLOC;
 	}


### PR DESCRIPTION
## Description

This PR reworks how the Linux Wayland backends allocate the shared-memory
buffer they hand to the compositor. Three of them — the overlay, the wlroots
cursor-discovery surface, and the screencopy screen grab — each carried their
own hand-copied version of the same routine, and the copies had already
drifted apart. The two older ones fell back to a temporary file on kernels
whose headers predate `memfd_create`; the newest one, added with the wlroots
screencopy path, did not, so on such a target a screen capture failed where an
overlay draw succeeded. Nobody chose that difference — it is what copying a
routine by hand costs on the third repetition.

All three now share one routine. Screencopy gains the portability fallback the
other two already had, and the retry that keeps a signal arriving mid-allocation
from silently producing a short buffer is written once instead of three times.
Nothing else changes for a user: the buffers are the same size, the failure
paths return the same values, and the debug labels each backend puts on its
buffer are preserved.

Two deliberate consequences of the consolidation:

- The fallback path's temporary-file name is now the same for every caller
  rather than one per backend. The file is unlinked the instant it is created,
  so nothing can ever see the name.
- The fallback now refuses when it cannot remove that temporary file, where all
  three originals carried on regardless. That was the one case where screen
  content could land in a file that persists on disk under a name — small, but
  the whole point of the fallback is that it does not. Callers already handle
  the failure, and reaching it needs a `/tmp` that accepts a new file but will
  not let it be removed.

## Related Issues

Closes #1479

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — the
      new `.c`/`.h` pair sits in the single-platform `platform/linux` directory
      and compiles through the one `linux && cgo` unit, like every other `.c`
      there
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) —
      N/A, this is internal C behind existing Go entry points; no port surface
      changed, so the existing `_nocgo.go` twins still cover it
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality — N/A, no behaviour
      changed and the code is C reached only from a live Wayland session; the
      compile-time gates below are what cover it
- [x] Documentation updated (if applicable) — N/A, no capability status or
      user-facing surface moved, so the ownership table in
      `docs/CROSS_PLATFORM.md` is unaffected
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

Verification beyond the gate, since this is C that a macOS host never compiles:

- `just lint-cross` — clean (Linux amd64 with CGO on, which is what actually
  compiles these files).
- The new file compiles warning-free under `-Wall -Wextra -Wconversion
  -Wsign-conversion -Wpedantic` on GCC 14, exercised twice: once normally, and
  once with `__NR_memfd_create` forcibly undefined so the fallback branch gets
  the same sweep.

Two decisions worth a sentence each:

- The shared routine takes a `size_t`, which is the type all three call sites
  already computed. That puts the one signed conversion inside the routine
  instead of at two of the three calls, and makes a negative size
  unrepresentable at the boundary.
- The keymap-file helper next door in the wlroots client is left alone. It
  writes a keymap into a temporary file rather than sizing a buffer, and
  folding it in would widen the shared routine to serve two jobs.

Neither path sets close-on-exec — that is unchanged from before, and is now in
one place rather than three if it is ever worth revisiting.
