### PR TITLE
fix(linux): report the notification backend KDE actually has

### DIFF
--- a/internal/adapter/platform/profile.go
+++ b/internal/adapter/platform/profile.go
@@ -33,6 +33,11 @@ const (
 const (
 	defaultPrimaryModifier                 = "ctrl"
 	backendPlanNameX11OrCompositorSpecific = "x11 or compositor-specific backend"
+	// notificationDaemonCaveat is the freedesktop backend's only precondition,
+	// in one phrasing. Every Linux profile states it, and the backend is the
+	// same one on all of them, so they say it in the same words rather than
+	// each inventing its own.
+	notificationDaemonCaveat = "needs a notification daemon running"
 )
 
 // BackendPlan describes the intended backend family for one subsystem and
@@ -172,7 +177,7 @@ func linuxProfile(ds DisplayServer) Profile {
 			Name:      "freedesktop notifications",
 			BuildMode: BuildModePureGo,
 			Notes: "org.freedesktop.Notifications over the session bus, on every backend " +
-				"and with no CGO; needs a notification daemon running",
+				"and with no CGO; " + notificationDaemonCaveat,
 		},
 	}
 }

--- a/internal/adapter/platform/profile_linux.go
+++ b/internal/adapter/platform/profile_linux.go
@@ -18,6 +18,10 @@ func linuxProfileForCurrentBackend() Profile {
 	return linuxProfile(backend.displayServer())
 }
 
+// Every plan here carries a Name only. This profile describes one live stack to
+// the user running on it, so the contributor-facing BuildMode/Notes pair the
+// target-by-target profiles use has nothing to add: the answer is whatever the
+// KDE backend already does.
 func linuxKDEProfile() Profile {
 	return Profile{
 		OS:              Linux,
@@ -38,7 +42,7 @@ func linuxKDEProfile() Profile {
 			Name: "wlr-layer-shell via KWin",
 		},
 		Notifications: BackendPlan{
-			Name: "not implemented",
+			Name: "freedesktop notifications (" + notificationDaemonCaveat + ")",
 		},
 	}
 }

--- a/internal/adapter/platform/profile_linux_test.go
+++ b/internal/adapter/platform/profile_linux_test.go
@@ -2,7 +2,10 @@
 
 package platform
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // sessionTypeWayland is what a Wayland login session writes into
 // XDG_SESSION_TYPE. No detector reads it any more; the cases below set it to
@@ -129,7 +132,35 @@ func TestLinuxKDEProfile(t *testing.T) {
 		t.Fatal("Overlay.Name should describe wlr-layer-shell via KWin")
 	}
 
-	if got.Notifications.Name != "not implemented" {
-		t.Fatalf("Notifications.Name = %q, want not implemented", got.Notifications.Name)
+	// Notifications are a session-bus service, so the KDE stack gets the same
+	// freedesktop backend every other Linux backend gets (#1471). This plan read
+	// "not implemented" long after it shipped and doctor read that to the user
+	// (#1486), so the assertions below pin the agreement rather than a string:
+	// KDE names the backend linuxProfile names, and states the one precondition
+	// it has in the words linuxProfile states it in.
+	x11Notifications := linuxProfile(DisplayServerX11).Notifications
+
+	if !strings.Contains(got.Notifications.Name, x11Notifications.Name) {
+		t.Fatalf(
+			"Notifications.Name = %q, want it to name the %q backend",
+			got.Notifications.Name,
+			x11Notifications.Name,
+		)
+	}
+
+	if !strings.Contains(x11Notifications.Notes, notificationDaemonCaveat) {
+		t.Fatalf(
+			"linuxProfile Notifications.Notes = %q, want it to state %q",
+			x11Notifications.Notes,
+			notificationDaemonCaveat,
+		)
+	}
+
+	if !strings.Contains(got.Notifications.Name, notificationDaemonCaveat) {
+		t.Fatalf(
+			"Notifications.Name = %q, want it to state %q",
+			got.Notifications.Name,
+			notificationDaemonCaveat,
+		)
 	}
 }


### PR DESCRIPTION
## Description

This PR fixes `neru doctor` telling a KDE Plasma Wayland user that desktop
notifications are not implemented. They have worked on every Linux backend
since the freedesktop notification support shipped, but the KDE profile's
description of the notification backend was never updated, so the diagnostic
output reported a working feature as absent.

Doctor now names the freedesktop backend on KDE and states its one
precondition — a notification daemon has to be running — in the same words the
X11/wlroots profile already uses, so the two cannot drift apart again.

This is a description-only change: nothing about how notifications are
delivered changes, and the live capability probe that downgrades the
notifications row when no daemon answers is untouched.

## Related Issues

Closes #1486

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability is added; only a doctor-facing description changes
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, `docs/CROSS_PLATFORM.md`
      already lists `org.freedesktop.Notifications` as supported on KDE; this
      change brings the code into line with what the docs already say
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

The KDE profile describes one live stack to the user running on it, so each of
its entries carries a user-facing description only, without the build-mode and
notes fields the target-by-target profiles use for contributors. The daemon
caveat therefore sits in the description rather than in the notes field —
which is also the only one of the two that `neru doctor` prints.

`just ci` was run on macOS. The KDE profile lives behind a Linux build tag, so
its test was additionally executed under `GOOS=linux` in a container; the
macOS gate type-checks it but cannot run it.
