### PR TITLE
fix(nix): stop the Linux source build failing on a rejected pipewire cflag

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -235,6 +235,14 @@ else
         apple-sdk_15
       ];
 
+    # pipewire's libspa-0.2.pc carries `-fno-strict-overflow` in its Cflags, and
+    # libpipewire-0.3 pulls it in via Requires. cgo refuses any pkg-config flag
+    # outside its allowlist, and that one is not on it, so the linux adapter
+    # fails to build until cgo is told the flag is safe.
+    env = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+      CGO_CFLAGS_ALLOW = "-fno-strict-overflow";
+    };
+
     # Allow Go to use any available toolchain
     preBuild = ''
       export GOTOOLCHAIN=auto


### PR DESCRIPTION
## Description

This PR fixes the Nix source build on Linux, which stopped compiling once pipewire started advertising a compiler flag that cgo refuses to accept from pkg-config.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [ ] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

No Go code changes, so `just ci` was not the meaningful gate here. Verified instead by building the source package on `aarch64-linux` against the exact pipewire that carries the flag, and by confirming the `aarch64-darwin` derivation evaluates without the allowance so macOS builds are unchanged.
