### PR TITLE
docs(linux): record parity as complete and keep Beta until it is proven in use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,19 @@ jobs:
                       session: Xvfb with openbox (X11)
                       session_packages: xvfb x11-utils openbox
         runs-on: ${{ matrix.os }}
-        # Both desktop legs are advisory, for the reason docs/DEVELOPMENT.md
-        # gives. Making one blocking is excluding it from this expression and
-        # adding its job name — "desktop (ubuntu-latest)" or
-        # "desktop-x11 (ubuntu-latest)" — to the branch protection rule.
-        continue-on-error: ${{ startsWith(matrix.check, 'desktop') }}
+        # Both desktop legs block. They are the only jobs that observe Linux
+        # behavior at all — Neru is developed on macOS, where none of it can
+        # run — so ADR 0013's promises are worth exactly as much as the jobs
+        # that check them, and an advisory job nobody has to read is not a
+        # check. The two legs owe different bars (behavioral parity on the
+        # blessed stack, capability parity on X11), which is a statement about
+        # what the tests assert, not about whether a suite that passes today may
+        # start failing unnoticed.
+        #
+        # They earned it on a measurement rather than a feeling: 40 runs each
+        # across pull requests and main with no failing step. Job-level
+        # `continue-on-error` reports a failed job as successful, so that was
+        # counted from step conclusions. docs/DEVELOPMENT.md carries the detail.
         steps:
             # Default checkout: on pull_request events this tests the merge
             # commit (PR + main combined), which is what will actually land —
@@ -543,9 +551,9 @@ jobs:
                   # is not mistaken for one.
                   blind=$(grep -c -E '_test\.go:[0-9]+: no display server' "$log" || true)
                   {
-                    echo "### Linux desktop tier — ${SESSION} — advisory"
+                    echo "### Linux desktop tier — ${SESSION}"
                     echo ""
-                    echo "Advisory: this leg does not gate the merge button."
+                    echo "Blocking: a failure here reds the pull request."
                     echo "See docs/DEVELOPMENT.md for what it covers."
                     echo ""
                     echo "| | Count |"

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -60,12 +60,14 @@ disagree, the code wins** — and the disagreement is a bug worth fixing here.
 
 Three words carry the whole promise, so they are worth pinning down:
 
-**Stable** — fully featured. Everything Neru does works here. This is the
-reference implementation, and a gap on this platform is a bug.
+**Stable** — fully featured *and* proven in use. Everything Neru does works
+here, and it has been exercised long enough that a gap is a surprise rather
+than an expectation. A gap on this platform is a bug.
 
 **Beta** — good for daily driving. Every navigation mode works and behaves the
-same as it does on a stable platform; what is missing sits around the edges
-(a few animations, a setup step for Wayland hotkeys) rather than in your way.
+same as it does on a stable platform. A platform is beta either because
+something is still missing, or because what is there has not yet been proven
+outside CI. Which one applies is stated per platform below.
 
 **Alpha** — worth trying, not yet worth switching to. Core navigation works, but
 hint coverage is incomplete and per-app config does not re-apply on focus
@@ -75,10 +77,23 @@ Every claim behind these labels is enumerated in the
 [Capability Matrix](#capability-matrix) and [Known Gaps](#known-gaps). If a
 label and the matrix disagree, the matrix is right.
 
-**Linux moves from Beta to Stable** when its [Known Gaps](#known-gaps) entries
-are empty for the blessed stack and the headless-sway CI job is green and
-required for merge — not before, and not on a judgment call
-([ADR 0013](./adr/0013-parity-is-measured-in-words-not-subsystems.md)).
+**Linux parity is complete.** Every option, mode flag, action and command means
+on the blessed stack what it means on macOS, [Known Gaps](#known-gaps) carries
+no Linux entry, and the headless-sway job gates merges. That was the whole of
+[ADR 0013](./adr/0013-parity-is-measured-in-words-not-subsystems.md)'s promise,
+and it is kept.
+
+**Linux stays Beta anyway**, because parity is a claim about coverage and
+Stable is a claim about reliability. Fourteen capabilities landed in a
+fortnight on a platform the maintainer does not daily-drive, each proven by a
+CI job rather than by use. Coverage is what a checklist can establish; that
+these hold up on a real compositor, under a real workload, over weeks of
+ordinary use, is not.
+
+**Linux moves to Stable** after six consecutive releases in which no
+`platform: linux` bug is filed that a macOS user would not also hit —
+`gh issue list --label "platform: linux" --label bug`. Not before, and still
+not on a judgment call.
 
 ### Per-platform
 
@@ -1020,9 +1035,14 @@ command — that means less here than it does on macOS, whether or not the
 
 **Linux**
 
-1. Wayland global hotkeys — a setup requirement rather than missing code: they
-   need `input`-group membership and a CGO build. Failing loudly with the
-   remedy, and documenting it as a first-class setup step, is the work
+None — parity is complete on the blessed stack.
+[What the labels mean](#what-the-labels-mean) says why the label is still Beta.
+
+The `input`-group membership Wayland global hotkeys need is a host setup step
+rather than a gap, and belongs here only if it stops being one: Neru warns with
+the remedy that fits when the listener cannot start, and
+[LINUX_SETUP.md](./LINUX_SETUP.md#install-time-environment-adjustments) carries
+it as install-time item 2.
 
 The gaps above are the work; what a person writes and finds inert *today* is
 [Platform Support Per Word](#platform-support-per-word), which is generated

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -90,10 +90,27 @@ CI job rather than by use. Coverage is what a checklist can establish; that
 these hold up on a real compositor, under a real workload, over weeks of
 ordinary use, is not.
 
-**Linux moves to Stable** after six consecutive releases in which no
-`platform: linux` bug is filed that a macOS user would not also hit —
-`gh issue list --label "platform: linux" --label bug`. Not before, and still
-not on a judgment call.
+**Linux moves to Stable** after six consecutive releases in which no Linux-only
+bug is filed — one a macOS user would not also hit. Count bugs *filed* in that
+window rather than ones still open at the end of it: a bug found and fixed still
+happened, and it is evidence about the platform either way.
+
+```bash
+since=$(gh release view <tag-six-back> --json publishedAt --jq .publishedAt)
+gh issue list --state all --label "platform: linux" --label bug \
+  --search "created:>=${since%%T*}"
+```
+
+That query returns candidates, not an answer, and two things it cannot do a
+person must. It cannot tell a Linux-only bug from one macOS shares, so read what
+comes back and discount anything that is really a cross-platform bug wearing a
+platform label. And it sees only what was labelled — a Linux bug filed without
+`platform: linux` is invisible to it, so this is worth no more than the triage
+feeding it.
+
+Reading an individual bug is a judgment; whether the label flips is not. That
+distinction is the whole point — see
+[ADR 0013](./adr/0013-parity-is-measured-in-words-not-subsystems.md).
 
 ### Per-platform
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -242,24 +242,28 @@ What it does not cover:
   `WLR_LIBINPUT_NO_DEVICES=1` on the headless backend means it reads no input
   devices, so nothing written to a uinput device reaches it whatever the
   permissions are. What is observable here is the `zwlr_virtual_pointer` path.
-- **A verdict.** The leg is **advisory**: `continue-on-error` keeps it off the
-  merge button, and its result is a job summary counting executed tests,
-  failures, packages reporting `FAIL`, and every skip with the reason it gave.
-  Those counts are a floor as well as a report — the step fails if nothing
-  executed, or if a test skipped because it could not see the display server
-  the job exists to provide, because a leg that skips its way to green is worth
-  less than no leg at all. It is advisory
-  because it is the first job here to stand up infrastructure of its own — a
-  compositor, a session bus and an accessibility bus — and a flake in any of
-  the three would red a pull request for a reason that has nothing to do with
-  it, on a tier whose stability nothing has measured yet.
+Its result is a job summary counting executed tests, failures, packages
+reporting `FAIL`, and every skip with the reason it gave. Those counts are a
+floor as well as a report — the step fails if nothing executed, or if a test
+skipped because it could not see the display server the job exists to provide,
+because a leg that skips its way to green is worth less than no leg at all.
 
-Making it blocking is two moves, and both are the maintainer's: delete
-`continue-on-error` from the job, and add `desktop (ubuntu-latest)` to the
-branch protection rule — a repository setting, not a file in this tree. ADR 0013
-makes that flip part of Linux graduating from Beta to Stable, alongside the
-Linux entries in
-[Known Gaps](CROSS_PLATFORM.md#known-gaps) being empty.
+**Both desktop legs block.** They started advisory, because they were the first
+jobs here to stand up infrastructure of their own — a compositor, a session bus
+and an accessibility bus — and a flake in any of the three would have redded a
+pull request for a reason that had nothing to do with it, on a tier whose
+stability nothing had measured yet. That last clause is what changed: across 40
+runs each on pull requests and `main`, neither leg had a failing step, so the
+flake rate stopped being an unknown and became a number. Job-level
+`continue-on-error` reports a failed job as successful, so that count was taken
+from step conclusions rather than job ones.
+
+It matters that they block. Neru is developed on macOS, where none of the
+behavior these legs exercise can run, so ADR 0013's promises are worth exactly
+as much as the jobs that check them — and an advisory job that nobody has to
+read is not a check. The two legs owe different bars, and that difference is
+about what the tests assert rather than about what a failure means: a suite that
+passes today and starts failing tomorrow is a regression at either bar.
 
 ### What the Xvfb X11 leg covers, and what it does not
 
@@ -300,9 +304,9 @@ What it does not cover:
   proven present; which application is focused is not exercised.
 - **Anything needing device access**, for the same reasons as the sway leg: no
   `/dev/dri`, no `input` group.
-- **A verdict**, and for the same reason — `continue-on-error`, the same
-  counting-and-floor summary, and `desktop-x11 (ubuntu-latest)` is the name to
-  add to branch protection to change that.
+
+It does deliver a verdict: this leg blocks too, on the same measurement. A lower
+bar is a smaller set of claims, not a weaker consequence for breaking one.
 
 **It found a defect on its first run, which is the point.** Because the session
 has a window manager and no client, `internal/adapter/platform`'s capability

--- a/docs/adr/0013-parity-is-measured-in-words-not-subsystems.md
+++ b/docs/adr/0013-parity-is-measured-in-words-not-subsystems.md
@@ -293,10 +293,19 @@ with no criterion either never moves or moves on a feeling" is exactly the
 failure a nervous maintainer reaches for when the checklist runs out, and
 replacing a firing criterion with a judgment call would be this ADR defeated on
 its last page. The replacement is falsifiable: Linux moves to Stable after six
-consecutive releases in which no `platform: linux` bug is filed that a macOS
-user would not also hit, which `gh issue list` answers. Releases rather than
+consecutive releases in which no Linux-only bug is filed. Releases rather than
 calendar time, so a pause in shipping pauses the clock — exposure is the thing
-being measured, and an unreleased month provides none.
+being measured, and an unreleased month provides none. Bugs *filed* in the
+window rather than still open at the end of it, because a bug found and fixed
+still happened; the query that finds them is in `CROSS_PLATFORM.md`, along with
+the two things it hands back to a person rather than settling.
+
+Falsifiable is not the same as mechanical, and the difference is worth stating
+so the next reader does not mistake one for the other. Whether an individual bug
+is Linux-only is a reading, and no label makes it otherwise. What this criterion
+removes is the judgment that actually rotted the old one: whether the platform
+*feels* ready. Six releases and a countable set of bugs is an answer a
+maintainer can be wrong about but cannot indefinitely defer.
 
 Two limits, recorded rather than papered over:
 

--- a/docs/adr/0013-parity-is-measured-in-words-not-subsystems.md
+++ b/docs/adr/0013-parity-is-measured-in-words-not-subsystems.md
@@ -191,7 +191,10 @@ that promise broken, and the matrix is structurally unable to see it.
   flips when the Linux entries in Known Gaps are empty for the blessed stack
   and the sway CI job is green and required for merge. A label with no
   criterion either never moves or moves on a feeling; fourteen tickets with no
-  defined end state is how "beta" becomes permanent.
+  defined end state is how "beta" becomes permanent. *(Amended: both halves came
+  true and the label did not flip. This criterion gated Stable on parity while
+  observing in the same sentence that Stable was parity restated — see the
+  second amendment at the end.)*
 - **Two new words in `CONTEXT.md`.** *Parity* and *Blessed stack*. The first
   because the word is the decision and it was previously used loosely enough to
   mean either measure; the second because without it *Parity* has to re-explain
@@ -257,3 +260,55 @@ the same day otherwise:
   contract), and the uinput `REL_WHEEL_HI_RES` route, which that job cannot
   observe at all. An Xvfb harness would let the X11 half be checked rather than
   argued.
+
+## Amendment: Stable was parity restated, so it could not gate on parity
+
+The graduation criterion this ADR set has been met and is not being honoured as
+written. Both halves came true — the Linux entries in Known Gaps are empty for
+the blessed stack, and the headless-sway job blocks merges — and Linux stays
+Beta. That is a change to this ADR rather than a lapse from it, and the reason
+is in the consequence itself.
+
+"Linux graduates on a stated criterion" observed that `CROSS_PLATFORM.md`
+defined **Stable** as "fully featured — a gap on this platform is a bug", which
+is "nearly a restatement of parity", and then adopted that definition as the
+trigger anyway. So the label was always going to flip the moment parity closed,
+and not because Linux had been shown to be reliable — because Stable had never
+been defined as reliable. The criterion measured coverage twice and exposure
+never. Parity closing is what made that visible; nothing about the fourteen
+tickets went wrong.
+
+So the two claims separate. **Parity** is a claim about coverage: every name a
+person can write means here what it means on macOS, provable against a
+checklist, and now true. **Stable** is a claim about reliability, which no
+checklist establishes — fourteen capabilities landed in a fortnight on a
+platform the maintainer does not daily-drive, each proven by a CI job rather
+than by use, and a CI job cannot tell us how they behave on a real compositor
+under a real workload over weeks. `CROSS_PLATFORM.md` now defines Stable as
+"fully featured *and* proven in use", which is the definition it should have
+carried before it was pressed into service as a gate.
+
+The discipline this ADR insisted on survives intact, because it has to. "A label
+with no criterion either never moves or moves on a feeling" is exactly the
+failure a nervous maintainer reaches for when the checklist runs out, and
+replacing a firing criterion with a judgment call would be this ADR defeated on
+its last page. The replacement is falsifiable: Linux moves to Stable after six
+consecutive releases in which no `platform: linux` bug is filed that a macOS
+user would not also hit, which `gh issue list` answers. Releases rather than
+calendar time, so a pause in shipping pauses the clock — exposure is the thing
+being measured, and an unreleased month provides none.
+
+Two limits, recorded rather than papered over:
+
+- **It can graduate on silence.** If few people run Neru on Linux, no bugs are
+  filed and the criterion passes for want of users rather than want of defects.
+  This is not fixable — user counts are not observable from here — and the
+  alternative, a gate on adoption we cannot measure, is worse than a gate that
+  can be satisfied quietly. A platform generating no reports is at least
+  generating no harm.
+- **Performance is not in the criterion, because nothing measures it.** "Latency
+  is the product", and the only benchmarks in the tree run through the
+  platform-neutral simulation harness in `internal/app/simulation_benchmark_test.go`
+  — there is no Linux latency measurement to gate on. A performance bar with no
+  benchmark behind it is the judgment call under a different name. Gating on it
+  means building the measurement first.


### PR DESCRIPTION
## Description

This PR closes out the Linux parity sequence. It records that parity is complete, removes a Known Gaps entry describing work that had already shipped when it was written, makes both Linux desktop CI legs gate the merge button, and — deliberately — leaves Linux labelled Beta.

That last part is the substance. ADR 0013 said Linux graduates to Stable when Known Gaps is empty for the blessed stack and the sway job blocks merges. Both are now true, and Linux is still not Stable, because the criterion gated Stable on parity while noting in the same sentence that Stable was defined as parity restated. It was always going to fire the moment parity closed, and not because Linux had been shown to be reliable. Fourteen capabilities landed in a fortnight on a platform the maintainer does not daily-drive, each proven by a CI job rather than by use.

So the two claims separate. **Parity** is coverage — every name a person can write means here what it means on macOS — and it is done. **Stable** is reliability, and now says so: "fully featured *and* proven in use". Linux moves to Stable after six consecutive releases in which no `platform: linux` bug is filed that a macOS user would not also hit. That stays checkable on purpose; a label with no criterion is how beta becomes permanent.

## Related Issues

Closes #1466

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code) — N/A, this is documentation and CI configuration; no code changes
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — exited 0 in this worktree, twice
- [x] Tests added/updated for new or changed functionality — N/A, no code changes; the CI change is the test surface and is described below
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

**Why the hotkeys gap entry was wrong.** It said "failing loudly with the remedy, and documenting it as a first-class setup step, is the work". Both halves had shipped. The loud failure landed in #1432 on 2026-08-10, splitting the no-cgo refusal from the permissions one so each gets advice that can actually help, pinned by four tests. The setup step landed in #1133 on 2026-07-31 as install-time item 2 in `LINUX_SETUP.md`. The entry was authored on 2026-08-11 in the ADR 0013 commit, after both — written as a catalogue of what parity means rather than from a check of the tree. `CROSS_PLATFORM.md` contradicted itself as a result: its prose body already described the behaviour in the past tense, 300 lines above the entry calling it unbuilt. The replacement text says why the setup step is not a gap, so the entry does not get re-added by the next person who notices hotkeys need configuring.

**Why both CI legs now block.** The stated reason they were advisory was "a tier whose stability nothing has measured yet". Measured: 40 runs each across pull requests and `main`, no failing step on either leg. Job-level `continue-on-error` reports a failed job as successful, so that came from step conclusions rather than job ones. The X11 leg runs 4,692 passing tests with 8 skips, so it is a real suite rather than a token one. X11 owes capability parity rather than behavioral parity, but that governs what the tests assert, not what a failure means — a suite that passes today and starts failing tomorrow is a regression at either bar.

**Two limits recorded rather than papered over**, both in the ADR amendment. The criterion can graduate on silence: if few people run Neru on Linux, no bugs are filed and it passes for want of users rather than want of defects. That is not fixable from here, and a gate on adoption we cannot measure would be worse. And performance is deliberately not in the criterion — "latency is the product", but the only benchmarks in the tree run through the platform-neutral simulation harness, so there is no Linux latency measurement to gate on. A performance bar with no benchmark behind it is a judgment call under another name; gating on it means building the measurement first.

**One repository setting is not in this diff.** Removing `continue-on-error` stops the legs from passing when they fail, but the two job names still have to be added to the `main` ruleset's required status checks for them to gate. That is a settings change rather than a file, and best applied at merge so it does not block unrelated open PRs.

**Bundling.** Three changes in one PR, at the maintainer's request: they are one act of closing out the spec, and splitting them would leave `main` briefly stating a criterion it had already met.
