### PR TITLE
fix(linux): report where the focused window is now on KDE, not where it was

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -713,7 +713,7 @@ a session that backend did not identify:
 
 | Compositor | Source                                                       | Limits                                                                                                                    |
 | ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| KDE / KWin | KWin script pushing focused-window geometry over D-Bus ([platform/kwin](../internal/adapter/platform/kwin)) | The script reports on **activation** and nothing else, so the cache lags in two ways: a window moved or resized without a focus change keeps its old rectangle until focus returns to it, and once a window has been seen the cache never empties — after the last one closes, the focused-window answer is the rectangle the dead window had rather than "nothing is focused". The AT-SPI origin path catches the first through its frame-size check; `FocusedWindowBounds` has no such signal. |
+| KDE / KWin | KWin script pushing focused-window geometry over D-Bus ([platform/kwin](../internal/adapter/platform/kwin)) | The script reports on activation, on the focused window's geometry changing, and on it going away, so the cache follows a drag, resize, tile or maximize and empties when the desktop is focused or the last window closes. It lives inside the compositor, so Neru watches `org.kde.KWin` on the session bus and reinstalls it when KWin restarts. A drag reports its final rectangle rather than every frame, so a query made mid-drag reads the position the drag started from. |
 | niri       | `niri msg -j focused-window` / `focused-output`              | Floating and fullscreen windows only. **Tiled** windows — including a maximized column (`Mod+F`) — expose no on-screen position ([niri#2381](https://github.com/niri-wm/niri/issues/2381)), so hints are misaligned there. |
 | Sway       | `swaymsg -t get_tree`, focused node `rect` + `window_rect`   | —                                                                                                                          |
 | Hyprland   | `hyprctl -j activewindow` `at` / `size`                      | —                                                                                                                          |
@@ -722,6 +722,22 @@ a session that backend did not identify:
 Each source verifies the reported window size matches the AT-SPI frame (a focus
 change can race the query) and is best-effort: an unavailable origin degrades to
 unoffset window-relative coordinates rather than misplacing hints.
+
+The KWin source checks identity as well as size, because its rectangle is a
+cache rather than a live query. The script reports the window's `resourceClass`,
+`resourceName` and caption alongside the geometry, and the AT-SPI frame carries
+the focused app_id and title it was selected with — both read from KWin, so a
+disagreement means the cached rectangle belongs to a different window, including
+a second window of the same application at the same size, which size alone
+cannot tell apart.
+
+Both comparisons are written to be sure before they refuse, because a false
+reject unoffsets hints that were placed correctly while a false accept costs no
+more than having no check at all. Either identifier may be the one that matches
+the app_id (they disagree for XWayland windows), the app_id comparison tolerates
+reverse-DNS spelling, the caption comparison accepts a prefix in either
+direction (KWin appends its own shortcut and `<2>` suffixes), and an identity
+neither side reported is not a mismatch.
 
 **A compositor that did not answer is not a compositor with no origin.** The
 three CLI sources go through

--- a/docs/LINUX_DESKTOPS.md
+++ b/docs/LINUX_DESKTOPS.md
@@ -49,6 +49,10 @@ focused-window geometry over D-Bus to translate them into global compositor
 space — the same script every other focused-window answer here reads (see
 [window-origin offsets](CROSS_PLATFORM.md#accessibility-and-hints)).
 
+A `kwin --replace` or a Plasma crash takes that script with it; see the KWin row
+under [window-origin offsets](CROSS_PLATFORM.md#accessibility-and-hints) for what
+happens then.
+
 ### Protocol support (KWin 6.6.4, measured)
 
 | Protocol                              | Purpose                   | KWin 6.6.4 |

--- a/internal/adapter/accessibility/atspi/client.go
+++ b/internal/adapter/accessibility/atspi/client.go
@@ -301,11 +301,14 @@ func (c *Client) ClickableNodes(
 		return nil, nil
 	}
 
-	// Validate the cached KWin origin against the frame actually being walked
-	// (by size): a stale origin from a previous window would offset every hint
-	// to the wrong screen position. When the frame extents are unavailable the
-	// origin cannot be validated, so no offset is applied at all — unoffset
-	// hints beat hints offset to a previous window or monitor.
+	// Validate the compositor's origin against the frame actually being walked:
+	// an origin from a different window would offset every hint to the wrong
+	// screen position. The frame is described by its size and by the focused
+	// identity it was selected with, so a source that can compare identities
+	// (KWin) can tell apart two windows that a size comparison cannot. When the
+	// frame extents are unavailable the origin cannot be validated at all, so no
+	// offset is applied — unoffset hints beat hints offset to a previous window
+	// or monitor.
 	var (
 		offX, offY int
 		haveOrigin bool
@@ -313,9 +316,12 @@ func (c *Client) ClickableNodes(
 
 	frameRect, frameOK := c.extents(ctx, conn, win.ref)
 	if frameOK {
-		origin, originKnown, originErr := c.windowOrigin.originFor(
-			frameRect.Dx(), frameRect.Dy(),
-		)
+		origin, originKnown, originErr := c.windowOrigin.originFor(windowFrame{
+			Width:        frameRect.Dx(),
+			Height:       frameRect.Dy(),
+			FocusedAppID: win.focusedAppID,
+			FocusedTitle: win.focusedTitle,
+		})
 		if originErr != nil {
 			// The two ways of having no origin are not the same event. A
 			// compositor that answered and has none to give is routine, and

--- a/internal/adapter/accessibility/atspi/client_test.go
+++ b/internal/adapter/accessibility/atspi/client_test.go
@@ -10,9 +10,11 @@ import (
 )
 
 const (
-	appIDFirefox = "org.mozilla.firefox"
-	appKonsole   = "konsole"
-	titleEditor  = "Editor"
+	appIDFirefox     = "org.mozilla.firefox"
+	appKonsole       = "konsole"
+	appKonsoleDotted = "org.kde.konsole"
+	appFirefox       = "firefox"
+	titleEditor      = "Editor"
 )
 
 func TestAppMatchesFocusedID(t *testing.T) {
@@ -25,8 +27,8 @@ func TestAppMatchesFocusedID(t *testing.T) {
 		{"reverse-dns app_id vs display name", "Firefox", appIDFirefox, true},
 		{"bare app_id case-insensitive", "Helium", "helium", true},
 		{"exact match", appKonsole, appKonsole, true},
-		{"reverse-dns both sides", "org.kde.konsole", appKonsole, true},
-		{"kde reverse-dns app_id", "Konsole", "org.kde.konsole", true},
+		{"reverse-dns both sides", appKonsoleDotted, appKonsole, true},
+		{"kde reverse-dns app_id", "Konsole", appKonsoleDotted, true},
 		{"no match", "Unnamed", appIDFirefox, false},
 		{"empty atspi name", "", appIDFirefox, false},
 		{"empty app_id", "Firefox", "", false},
@@ -49,7 +51,7 @@ func TestLastDotSegment(t *testing.T) {
 		in   string
 		want string
 	}{
-		{"org.mozilla.firefox", "firefox"},
+		{"org.mozilla.firefox", appFirefox},
 		{"helium", ""},
 		{"trailing.", ""},
 		{"", ""},

--- a/internal/adapter/accessibility/atspi/hyprland_geometry.go
+++ b/internal/adapter/accessibility/atspi/hyprland_geometry.go
@@ -34,7 +34,7 @@ type hyprlandWindow struct {
 	Size []int `json:"size"`
 }
 
-func (h *hyprlandOriginSource) originFor(frameW, frameH int) (image.Point, bool, error) {
+func (h *hyprlandOriginSource) originFor(frame windowFrame) (image.Point, bool, error) {
 	var win hyprlandWindow
 
 	err := compositorcli.Query(&win, "hyprctl", "-j", "activewindow")
@@ -42,7 +42,7 @@ func (h *hyprlandOriginSource) originFor(frameW, frameH int) (image.Point, bool,
 		return image.Point{}, false, err
 	}
 
-	origin, ok := hyprlandComputeOrigin(win, frameW, frameH, h.logger)
+	origin, ok := hyprlandComputeOrigin(win, frame.Width, frame.Height, h.logger)
 
 	return origin, ok, nil
 }

--- a/internal/adapter/accessibility/atspi/kwin_origin.go
+++ b/internal/adapter/accessibility/atspi/kwin_origin.go
@@ -82,6 +82,14 @@ func (s *kwinOriginSource) start() { s.geometry.EnsureStarted() }
 // is missing. One geometry source answering one way here and another there is
 // what having one geometry source is for.
 func (s *kwinOriginSource) originFor(frame windowFrame) (image.Point, bool, error) {
+	// Asked on every activation rather than once at construction, for the same
+	// reason the focused-window arm asks on every call: the bridge can lose its
+	// install after having one — KWin restarting takes the script with it — and
+	// a source that only ever tried at startup would spend the rest of the
+	// session placing hints window-relative. It is free once installed and never
+	// blocks, so the mode handler's lock is not held on anything.
+	s.geometry.EnsureStarted()
+
 	window, cached, err := s.geometry.Focused()
 	if err != nil {
 		return image.Point{}, false, derrors.Wrap(

--- a/internal/adapter/accessibility/atspi/kwin_origin.go
+++ b/internal/adapter/accessibility/atspi/kwin_origin.go
@@ -4,6 +4,7 @@ package atspi
 
 import (
 	"image"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -17,9 +18,20 @@ import (
 // bridge SystemPort.FocusedWindowBounds reads, because it is the same fact.
 // This file is only the AT-SPI half of it: turning the cached rectangle into
 // the origin that offsets window-relative element coordinates.
+
+// kwinGeometry is the part of the bridge this source uses. It is named here so
+// the rules for accepting or rejecting a cached window can be tested without a
+// KWin — which is the only way they can be tested at all, since the bridge is
+// process-wide by design and a test that pushed into it would be pushing into
+// every other test's cache too.
+type kwinGeometry interface {
+	EnsureStarted()
+	Focused() (kwin.Window, bool, error)
+}
+
 type kwinOriginSource struct {
 	logger   *zap.Logger
-	geometry *kwin.Geometry
+	geometry kwinGeometry
 }
 
 func newKWinOriginSource(logger *zap.Logger) *kwinOriginSource {
@@ -35,14 +47,28 @@ func newKWinOriginSource(logger *zap.Logger) *kwinOriginSource {
 
 func (s *kwinOriginSource) start() { s.geometry.EnsureStarted() }
 
-// originFor returns the cached origin only when the cached client size matches
-// the given AT-SPI frame size within windowOriginSizeTolerance. The cache is fed
-// by KWin focus events; if KWin missed a transition (or deliberately ignored a
-// transient surface that became the active AT-SPI frame) the cached origin
-// belongs to a different window, and offsetting by it would land every hint at
-// the previous window's screen position. A size mismatch is the cheapest
-// reliable staleness signal, so callers then fall back to unoffset
-// (window-relative) coordinates.
+// originFor returns the cached origin only when the cached window is the window
+// the given frame describes.
+//
+// The cache is fed by KWin, and the frame was selected from AT-SPI, so nothing
+// guarantees the two are the same window: if KWin ignored a transient surface
+// that became the active AT-SPI frame, or a transition reached one of them
+// first, the cached origin belongs to a different window and offsetting by it
+// would land every hint at that window's screen position. Two checks stand
+// between the cache and that outcome, in order of how much they can tell apart:
+//
+//   - Identity. KWin reports which window its rectangle belongs to, and the
+//     frame carries the compositor's focused-toplevel identity it was selected
+//     with. Both descriptions come from KWin, so a disagreement is conclusive:
+//     the rectangle is some other window's.
+//   - Size, within windowOriginSizeTolerance. It is the only check available
+//     when the identity is not — and it cannot separate two windows that happen
+//     to be the same size (#972), which is why it is no longer the only one.
+//
+// Neither check refuses when it has nothing to compare. An identity the
+// compositor never reported is not a mismatch, and treating it as one would
+// leave every hint on such a session unoffset — a far larger failure than the
+// one being closed here.
 //
 // A bridge that could not be installed is reported rather than folded into that
 // same answer. The degradation is identical — an unoffset hint either way — but
@@ -55,8 +81,8 @@ func (s *kwinOriginSource) start() { s.geometry.EnsureStarted() }
 // person has to do about it is not check a permission but install a script that
 // is missing. One geometry source answering one way here and another there is
 // what having one geometry source is for.
-func (s *kwinOriginSource) originFor(frameW, frameH int) (image.Point, bool, error) {
-	rect, cached, err := s.geometry.Bounds()
+func (s *kwinOriginSource) originFor(frame windowFrame) (image.Point, bool, error) {
+	window, cached, err := s.geometry.Focused()
 	if err != nil {
 		return image.Point{}, false, derrors.Wrap(
 			err,
@@ -69,14 +95,97 @@ func (s *kwinOriginSource) originFor(frameW, frameH int) (image.Point, bool, err
 		return image.Point{}, false, nil
 	}
 
-	if absInt(rect.Dx()-frameW) > windowOriginSizeTolerance ||
-		absInt(rect.Dy()-frameH) > windowOriginSizeTolerance {
+	if !s.isFrameWindow(window, frame) {
+		return image.Point{}, false, nil
+	}
+
+	rect := window.Rect
+	if absInt(rect.Dx()-frame.Width) > windowOriginSizeTolerance ||
+		absInt(rect.Dy()-frame.Height) > windowOriginSizeTolerance {
 		s.logger.Debug("KWin origin rejected: cached size does not match AT-SPI frame",
 			zap.Int("cachedW", rect.Dx()), zap.Int("cachedH", rect.Dy()),
-			zap.Int("frameW", frameW), zap.Int("frameH", frameH))
+			zap.Int("frameW", frame.Width), zap.Int("frameH", frame.Height))
 
 		return image.Point{}, false, nil
 	}
 
 	return rect.Min, true, nil
+}
+
+// isFrameWindow reports whether the window KWin cached is the one the frame was
+// selected for, as far as their two identities can say.
+//
+// Both identities originate in KWin — the cached one is a script reading
+// resourceClass, resourceName and caption; the frame's is the same compositor's
+// wlr-foreign-toplevel-management app_id and title — so where both sides have
+// something to say, a disagreement means two different windows.
+//
+// Where either side is silent the answer is yes. X11 and GNOME have no
+// foreign-toplevel protocol to read an identity from at all, and a KWin version
+// that reports no identifiers is not thereby reporting a different window.
+// Refusing on a missing identity would turn a check that closes a rare
+// misplacement into one that unoffsets every hint on a whole session.
+//
+// The same asymmetry governs how tolerant each comparison is. A false accept
+// costs at most what this check cost before it existed; a false reject unoffsets
+// hints that were placed correctly. So each comparison is written to be sure
+// before it refuses.
+func (s *kwinOriginSource) isFrameWindow(window kwin.Window, frame windowFrame) bool {
+	if !kwinAppMatches(window, frame.FocusedAppID) {
+		s.logger.Debug("KWin origin rejected: cached window is a different application")
+
+		return false
+	}
+
+	if !kwinTitleMatches(window.Title, frame.FocusedTitle) {
+		s.logger.Debug("KWin origin rejected: cached window is a different window " +
+			"of the focused application")
+
+		return false
+	}
+
+	return true
+}
+
+// kwinAppMatches reports whether either of KWin's two identifiers for the cached
+// window names the compositor's focused application.
+//
+// Either is allowed to be the match because the two disagree for some windows —
+// an XWayland Firefox is resourceClass "firefox" and resourceName "navigator" —
+// and which of them the foreign-toplevel app_id was built from is KWin's
+// business, not something to be guessed at here. Each comparison is the tolerant
+// one AT-SPI frame selection already uses, since the same application is spelled
+// "konsole" in one vocabulary and "org.kde.konsole" in another.
+func kwinAppMatches(window kwin.Window, appID string) bool {
+	if appID == "" || (window.Class == "" && window.Name == "") {
+		return true
+	}
+
+	return appMatchesFocusedID(window.Class, appID) || appMatchesFocusedID(window.Name, appID)
+}
+
+// kwinTitleMatches reports whether KWin's caption and the compositor's focused
+// title describe one window.
+//
+// A prefix counts as a match, in either direction, because KWin's caption is the
+// window's title plus a suffix it adds itself — a window shortcut, a hostname, a
+// "<2>" when two windows share a title — and nothing here can know whether the
+// foreign-toplevel title was built before or after that suffix was appended. An
+// exact comparison would therefore reject every activation of a window that has
+// one, permanently unoffsetting its hints.
+//
+// What survives is what this comparison is for: two windows of one application
+// showing different documents have titles that are not prefixes of each other,
+// and that is the case size alone cannot separate (#972). Two windows whose
+// titles agree up to a "<2>" are not separated — but neither is anything else
+// about them, which frame selection already says of identical titles.
+func kwinTitleMatches(caption, focusedTitle string) bool {
+	caption = strings.TrimSpace(caption)
+	focused := strings.TrimSpace(focusedTitle)
+
+	if caption == "" || focused == "" {
+		return true
+	}
+
+	return strings.HasPrefix(caption, focused) || strings.HasPrefix(focused, caption)
 }

--- a/internal/adapter/accessibility/atspi/kwin_origin_test.go
+++ b/internal/adapter/accessibility/atspi/kwin_origin_test.go
@@ -1,0 +1,289 @@
+//go:build linux
+
+package atspi
+
+import (
+	"errors"
+	"image"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/adapter/platform/kwin"
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+const (
+	// titleKonsoleBash is the caption of the window the tests below cache.
+	titleKonsoleBash = "~ : bash"
+
+	// nameFirefoxX11 is Firefox's resourceName, which is not its resourceClass
+	// — the disagreement that makes matching either identifier necessary.
+	nameFirefoxX11 = "navigator"
+)
+
+// errTestKWinAbsent stands in for whatever kept the bridge from installing. The
+// origin source only has to carry it back, so the wording is deliberately not
+// the bridge's own: what is pinned is that any reason survives the wrap.
+var errTestKWinAbsent = errors.New("the KWin geometry script could not be loaded")
+
+// fakeKWinGeometry stands in for the process-wide bridge, so what the KWin
+// origin source does with a cached window can be decided in a test rather than
+// by whatever a KDE session happened to be doing.
+type fakeKWinGeometry struct {
+	window kwin.Window
+	cached bool
+	err    error
+}
+
+func (f fakeKWinGeometry) EnsureStarted() {}
+
+func (f fakeKWinGeometry) Focused() (kwin.Window, bool, error) {
+	return f.window, f.cached, f.err
+}
+
+func kwinSourceWith(geometry kwinGeometry) *kwinOriginSource {
+	return &kwinOriginSource{logger: zap.NewNop(), geometry: geometry}
+}
+
+// cachedKonsole is a window KWin reported, sized to match the frame every test
+// below asks about, so size is never what decides the answer.
+func cachedKonsole(title string) kwin.Window {
+	return kwin.Window{
+		Rect:  image.Rect(100, 50, 900, 650),
+		Class: appKonsole,
+		Title: title,
+	}
+}
+
+// konsoleFrame is the AT-SPI frame those tests are walking: the same size, and
+// the compositor identity it was selected with.
+func konsoleFrame(appID, title string) windowFrame {
+	return windowFrame{Width: 800, Height: 600, FocusedAppID: appID, FocusedTitle: title}
+}
+
+// TestKWinOriginSource_OriginForOffsetsByTheMatchingWindow is the ordinary case:
+// the cache and the frame describe one window, so hints are placed at its screen
+// position.
+func TestKWinOriginSource_OriginForOffsetsByTheMatchingWindow(t *testing.T) {
+	source := kwinSourceWith(fakeKWinGeometry{
+		window: cachedKonsole(titleKonsoleBash),
+		cached: true,
+	})
+
+	origin, ok, err := source.originFor(konsoleFrame(appKonsole, titleKonsoleBash))
+	if !ok || err != nil {
+		t.Fatalf("originFor() = (%v, %v, %v), want the cached origin", origin, ok, err)
+	}
+
+	if want := image.Pt(100, 50); origin != want {
+		t.Errorf("originFor() = %v, want %v", origin, want)
+	}
+}
+
+// TestKWinOriginSource_OriginForRejectsAnotherApplication covers the case size
+// alone already caught only by luck. Two windows of different applications can
+// be the same size, and offsetting by the wrong one puts every hint in this
+// window at the other window's screen position.
+func TestKWinOriginSource_OriginForRejectsAnotherApplication(t *testing.T) {
+	source := kwinSourceWith(fakeKWinGeometry{
+		window: cachedKonsole(titleKonsoleBash),
+		cached: true,
+	})
+
+	origin, ok, err := source.originFor(konsoleFrame("kate", "untitled — Kate"))
+	if ok || err != nil {
+		t.Fatalf("originFor() = (%v, %v, %v), want no origin and no error — the "+
+			"cached rectangle belongs to another window, and hints fall back to "+
+			"window-relative rather than to the wrong screen position", origin, ok, err)
+	}
+}
+
+// TestKWinOriginSource_OriginForRejectsASiblingWindow is #972 exactly: two
+// windows of the same application, the same size, so the size check passes and
+// the origin is the other window's. Only the title separates them.
+func TestKWinOriginSource_OriginForRejectsASiblingWindow(t *testing.T) {
+	source := kwinSourceWith(fakeKWinGeometry{
+		window: cachedKonsole(titleKonsoleBash),
+		cached: true,
+	})
+
+	origin, ok, err := source.originFor(konsoleFrame(appKonsole, "/var/log : less"))
+	if ok || err != nil {
+		t.Fatalf("originFor() = (%v, %v, %v), want no origin — two same-sized "+
+			"windows of one application are what the size check cannot tell apart",
+			origin, ok, err)
+	}
+}
+
+// TestKWinOriginSource_OriginForToleratesIdentifierSpelling keeps the identity
+// check from rejecting windows that match.
+//
+// The two sides read the same application through different vocabularies —
+// KWin's resourceClass and resourceName, and the foreign-toplevel app_id built
+// from one of them — which spell it differently often enough that an exact
+// comparison against either alone would refuse working sessions. A false reject
+// costs unoffset hints on every activation of that window; a false accept costs
+// no more than having no check.
+func TestKWinOriginSource_OriginForToleratesIdentifierSpelling(t *testing.T) {
+	cases := []struct {
+		name  string
+		class string
+		app   string
+		appID string
+	}{
+		{"identical", appKonsole, appKonsole, appKonsole},
+		{"different case", "Konsole", appKonsole, appKonsole},
+		{"reverse-dns on the compositor side", appKonsole, appKonsole, appKonsoleDotted},
+		{"reverse-dns on the script side", appKonsoleDotted, appKonsole, appKonsole},
+		// An XWayland window's two identifiers disagree, and the app_id is
+		// built from whichever one KWin chose. Matching either is what keeps
+		// the choice from being something this check has to guess.
+		{"app_id built from resourceClass", appFirefox, nameFirefoxX11, appFirefox},
+		{"app_id built from resourceName", appFirefox, nameFirefoxX11, nameFirefoxX11},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			window := cachedKonsole(titleKonsoleBash)
+			window.Class, window.Name = testCase.class, testCase.app
+
+			source := kwinSourceWith(fakeKWinGeometry{window: window, cached: true})
+
+			_, ok, err := source.originFor(konsoleFrame(testCase.appID, titleKonsoleBash))
+			if !ok || err != nil {
+				t.Errorf("originFor() = (%v, %v) for class %q / name %q against "+
+					"app_id %q, want the origin",
+					ok, err, testCase.class, testCase.app, testCase.appID)
+			}
+		})
+	}
+}
+
+// TestKWinTitleMatches pins where the title comparison draws its line.
+//
+// KWin's caption is the window's title plus a suffix it adds itself — a window
+// shortcut, a hostname, a "<2>" when two windows share a title — and nothing
+// here knows whether the foreign-toplevel title was built before or after that
+// suffix. So a prefix in either direction is a match: an exact comparison would
+// unoffset every hint in a window that has a shortcut assigned, forever, to
+// close a case it was never the only defense against.
+func TestKWinTitleMatches(t *testing.T) {
+	cases := []struct {
+		name    string
+		caption string
+		focused string
+		want    bool
+	}{
+		{"identical", titleKonsoleBash, titleKonsoleBash, true},
+		{"whitespace only", "  ~ : bash ", titleKonsoleBash, true},
+		{"kwin appended a shortcut suffix", "Kate {Ctrl+1}", "Kate", true},
+		{"the compositor carried the suffix", "Kate", "Kate {Ctrl+1}", true},
+		{"different documents", "notes.md — Kate", "main.go — Kate", false},
+		{"different applications entirely", titleKonsoleBash, "untitled — Kate", false},
+		{"no caption to compare", "", titleKonsoleBash, true},
+		{"no focused title to compare", titleKonsoleBash, "", true},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := kwinTitleMatches(testCase.caption, testCase.focused); got != testCase.want {
+				t.Errorf("kwinTitleMatches(%q, %q) = %v, want %v",
+					testCase.caption, testCase.focused, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestKWinOriginSource_OriginForAcceptsAnAbsentIdentity is the half that keeps
+// this check from being worse than what it replaces.
+//
+// A missing identity is not a mismatch: X11 and GNOME expose no
+// foreign-toplevel protocol to read one from, and a KWin that reports no class
+// or caption has not thereby reported a different window. Refusing here would
+// unoffset every hint on a whole session to close a rare misplacement.
+func TestKWinOriginSource_OriginForAcceptsAnAbsentIdentity(t *testing.T) {
+	cases := []struct {
+		name   string
+		window kwin.Window
+		frame  windowFrame
+	}{
+		{
+			name:   "the compositor reported no identity",
+			window: cachedKonsole(titleKonsoleBash),
+			frame:  konsoleFrame("", ""),
+		},
+		{
+			name:   "the script reported no identifiers or caption",
+			window: kwin.Window{Rect: image.Rect(100, 50, 900, 650)},
+			frame:  konsoleFrame(appKonsole, titleKonsoleBash),
+		},
+		{
+			name:   "only the titles are missing",
+			window: cachedKonsole(""),
+			frame:  konsoleFrame(appKonsole, ""),
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			source := kwinSourceWith(fakeKWinGeometry{window: testCase.window, cached: true})
+
+			_, ok, err := source.originFor(testCase.frame)
+			if !ok || err != nil {
+				t.Errorf("originFor() = (%v, %v), want the origin — an identity "+
+					"nobody reported is not a mismatch", ok, err)
+			}
+		})
+	}
+}
+
+// TestKWinOriginSource_OriginForStillRejectsASizeMismatch keeps the older check
+// in place. It is the only one available when there is no identity to compare,
+// and a window resized between the AT-SPI read and the cache is a mismatch the
+// identities agree about.
+func TestKWinOriginSource_OriginForStillRejectsASizeMismatch(t *testing.T) {
+	window := cachedKonsole(titleKonsoleBash)
+	window.Rect = image.Rect(100, 50, 1300, 950)
+
+	source := kwinSourceWith(fakeKWinGeometry{window: window, cached: true})
+
+	origin, ok, err := source.originFor(konsoleFrame(appKonsole, titleKonsoleBash))
+	if ok || err != nil {
+		t.Fatalf("originFor() = (%v, %v, %v), want no origin", origin, ok, err)
+	}
+}
+
+// TestKWinOriginSource_OriginForReportsNothingCachedAsAnAnswer covers the state
+// a clear leaves behind. Nothing is focused, which is the compositor answering,
+// so hints go window-relative without anyone being told something is broken.
+func TestKWinOriginSource_OriginForReportsNothingCachedAsAnAnswer(t *testing.T) {
+	source := kwinSourceWith(fakeKWinGeometry{})
+
+	origin, ok, err := source.originFor(konsoleFrame(appKonsole, titleKonsoleBash))
+	if ok || err != nil {
+		t.Fatalf("originFor() = (%v, %v, %v), want (empty, false, nil)", origin, ok, err)
+	}
+}
+
+// TestKWinOriginSource_OriginForReportsAFailedInstall keeps a broken bridge
+// distinguishable from an idle one. Both leave hints window-relative, and only
+// one is something a person can fix — so the reason has to reach the caller
+// rather than be folded into "no origin".
+func TestKWinOriginSource_OriginForReportsAFailedInstall(t *testing.T) {
+	source := kwinSourceWith(fakeKWinGeometry{err: errTestKWinAbsent})
+
+	_, ok, err := source.originFor(konsoleFrame(appKonsole, titleKonsoleBash))
+	if ok {
+		t.Fatal("originFor() reported an origin from a bridge that never installed")
+	}
+
+	if !errors.Is(err, errTestKWinAbsent) {
+		t.Errorf("originFor() error = %v, want it to carry %v", err, errTestKWinAbsent)
+	}
+
+	if !derrors.IsNotSupported(err) {
+		t.Errorf("originFor() code = %v, want %v — what a person has to do about "+
+			"this is not check a permission", derrors.GetCode(err), derrors.CodeNotSupported)
+	}
+}

--- a/internal/adapter/accessibility/atspi/niri_geometry.go
+++ b/internal/adapter/accessibility/atspi/niri_geometry.go
@@ -53,7 +53,7 @@ type niriOutput struct {
 // (niri#2381). Without it there is no origin to compute, so the second query is
 // never made — and a focused-output query that would have failed cannot turn
 // niri's ordinary layout into a reported failure on every activation.
-func (n *niriOriginSource) originFor(frameW, frameH int) (image.Point, bool, error) {
+func (n *niriOriginSource) originFor(frame windowFrame) (image.Point, bool, error) {
 	var win niriWindow
 
 	winErr := compositorcli.Query(&win, "niri", "msg", "-j", "focused-window")
@@ -61,7 +61,7 @@ func (n *niriOriginSource) originFor(frameW, frameH int) (image.Point, bool, err
 		return image.Point{}, false, winErr
 	}
 
-	tileX, tileY, ok := niriOriginTile(win, frameW, frameH, n.logger)
+	tileX, tileY, ok := niriOriginTile(win, frame.Width, frame.Height, n.logger)
 	if !ok {
 		return image.Point{}, false, nil
 	}

--- a/internal/adapter/accessibility/atspi/sway_geometry.go
+++ b/internal/adapter/accessibility/atspi/sway_geometry.go
@@ -66,7 +66,7 @@ func findFocused(node *swayNode) *swayNode {
 	return nil
 }
 
-func (s *swayOriginSource) originFor(frameW, frameH int) (image.Point, bool, error) {
+func (s *swayOriginSource) originFor(frame windowFrame) (image.Point, bool, error) {
 	var tree swayNode
 
 	err := compositorcli.Query(&tree, "swaymsg", "-t", "get_tree")
@@ -74,7 +74,7 @@ func (s *swayOriginSource) originFor(frameW, frameH int) (image.Point, bool, err
 		return image.Point{}, false, err
 	}
 
-	origin, ok := swayComputeOrigin(&tree, frameW, frameH, s.logger)
+	origin, ok := swayComputeOrigin(&tree, frame.Width, frame.Height, s.logger)
 
 	return origin, ok, nil
 }

--- a/internal/adapter/accessibility/atspi/window_origin.go
+++ b/internal/adapter/accessibility/atspi/window_origin.go
@@ -81,23 +81,42 @@ func absInt(v int) int {
 	return v
 }
 
+// windowFrame describes the AT-SPI frame an origin is being asked for. A source
+// answers about "the focused window", and this is everything the caller knows
+// about the window it is actually going to walk — so it is also how a source
+// checks that the two are the same window.
+type windowFrame struct {
+	// Width and Height are the frame's AT-SPI extents. Every source compares
+	// them against the size the compositor reports, within
+	// windowOriginSizeTolerance.
+	Width, Height int
+
+	// FocusedAppID and FocusedTitle are the compositor's focused-toplevel
+	// identity, captured when this frame was selected and by the same
+	// wlr-foreign-toplevel-management read that selected it. Both are empty on
+	// X11 and GNOME, where there is no such protocol to ask — an identity a
+	// source cannot have is not a mismatch, so a source that uses these must
+	// fall through to the size check rather than refuse.
+	FocusedAppID string
+	FocusedTitle string
+}
+
 // windowOriginSource supplies the focused window's on-screen origin so AT-SPI
 // window-relative element coordinates can be offset into screen coordinates.
 type windowOriginSource interface {
 	// start performs any one-time setup. Best-effort; failures are logged.
 	start()
-	// originFor returns the focused window's screen origin, but only when its
-	// size matches the given AT-SPI frame extents within
-	// windowOriginSizeTolerance.
+	// originFor returns the focused window's screen origin, but only when the
+	// window it belongs to is the one the given frame describes.
 	//
 	// The three answers are distinct. An origin with ok is what the compositor
 	// said. ok=false with no error is the compositor answering that it has no
-	// origin to give — nothing focused, a stale cached rectangle, or a niri
-	// window whose tiling gives it no on-screen position. A non-nil error is
-	// the source failing to answer at all, which callers must not read as the
-	// second: both fall back to unoffset coordinates, and only one of them is
-	// something a person can fix.
-	originFor(frameW, frameH int) (origin image.Point, ok bool, err error)
+	// origin to give — nothing focused, a rectangle belonging to a different
+	// window, or a niri window whose tiling gives it no on-screen position. A
+	// non-nil error is the source failing to answer at all, which callers must
+	// not read as the second: both fall back to unoffset coordinates, and only
+	// one of them is something a person can fix.
+	originFor(frame windowFrame) (origin image.Point, ok bool, err error)
 }
 
 // noWindowOrigin is the source for a session no compositor bridge belongs on:
@@ -140,7 +159,7 @@ func (s noWindowOrigin) start() {
 // "Stubs are loud"). It is the same refusal SystemPort.FocusedWindowBounds
 // gives such a session, for the same reason: hints land window-relative either
 // way, and only one of the two says so.
-func (s noWindowOrigin) originFor(_, _ int) (image.Point, bool, error) {
+func (s noWindowOrigin) originFor(_ windowFrame) (image.Point, bool, error) {
 	if s.backend == platform.BackendX11 {
 		return image.Point{}, false, nil
 	}

--- a/internal/adapter/accessibility/atspi/window_origin_test.go
+++ b/internal/adapter/accessibility/atspi/window_origin_test.go
@@ -276,7 +276,8 @@ func TestWindowOriginSource_ReportsAFailedQueryInsteadOfDroppingTheOffset(t *tes
 		t.Run(testCase.name, func(t *testing.T) {
 			fakeCompositorCLIs(t, testCase.scripts)
 
-			origin, known, err := testCase.source(zap.NewNop()).originFor(frameW, frameH)
+			origin, known, err := testCase.source(zap.NewNop()).
+				originFor(windowFrame{Width: frameW, Height: frameH})
 
 			if testCase.wantNamed != "" {
 				if err == nil {
@@ -362,7 +363,8 @@ func TestClient_ReportOriginFailure_SaysOneSteadyReasonOnce(t *testing.T) {
 func TestNiriOriginSource_KeepsATiledWindowAnAnswer(t *testing.T) {
 	fakeCompositorCLIs(t, niriCLI(`{"layout":{"window_size":[946,942]}}`, ""))
 
-	origin, ok, err := newNiriOriginSource(zap.NewNop()).originFor(frameW, frameH)
+	origin, ok, err := newNiriOriginSource(zap.NewNop()).
+		originFor(windowFrame{Width: frameW, Height: frameH})
 	if ok || err != nil {
 		t.Fatalf("originFor() = (%v, %v, %v), want no origin and no error — a "+
 			"tiled window has none to give, and saying so must not warn on every "+

--- a/internal/adapter/platform/kwin/geometry.go
+++ b/internal/adapter/platform/kwin/geometry.go
@@ -8,8 +8,6 @@ import (
 	"image"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -27,12 +25,8 @@ const (
 	scriptingPath  = "/Scripting"
 	scriptingIface = "org.kde.kwin.Scripting"
 
-	dbusNameHasOwner = "org.freedesktop.DBus.NameHasOwner"
-
-	// UpdateActiveWindow payload is "x,y,w,h,resourceClass": up to 5 fields,
-	// with the geometry minimum being the first 4 (resourceClass is optional).
-	payloadParts    = 5
-	payloadMinParts = 4
+	dbusIface        = "org.freedesktop.DBus"
+	dbusNameHasOwner = dbusIface + ".NameHasOwner"
 
 	// The geometry script is only readable/writable by the owner.
 	scriptFileMode = 0o600
@@ -57,56 +51,38 @@ const scriptFileName = "neru-kwin-geometry.js"
 // answers and only one of them should send a caller to the active screen.
 var errKWinAbsent = errors.New("org.kde.KWin is not on the session bus")
 
-// geometryScript is loaded into KWin. It reports the focused window's client
-// geometry (content rect, excludes the titlebar so it aligns 1:1 with the
-// AT-SPI content origin). It ignores Neru's own overlay so that activating the
-// hint overlay does not overwrite the real window's geometry.
+// Window is what KWin last said about the focused window: where it is, and
+// which window it is.
 //
-// neruIgnore filters out non-application surfaces that briefly take activation
-// but are never hint targets: panels/docks/OSD/popups/tooltips/utility windows
-// (caught by KWin's window-type flags), plus a few known transient classes
-// (the XWayland video bridge, plasmashell, and the portal consent dialog).
-// Without this, focus flicking to e.g. plasmashell or the RemoteDesktop consent
-// dialog would clobber the real window origin and mis-offset hint clicks.
-// Accessing an absent KWin property yields undefined (falsy), so listing extra
-// type flags is safe across KWin versions.
-const geometryScript = `
-function neruIgnore(c) {
-    if (!c) return true;
-    if (c.resourceClass == "neru") return true;
-    if (c.specialWindow || c.dock || c.desktopWindow || c.splash ||
-        c.utility || c.toolbar || c.menu || c.dropdownMenu || c.popupMenu ||
-        c.tooltip || c.notification || c.criticalNotification ||
-        c.onScreenDisplay || c.comboBox || c.dndIcon) return true;
-    var cls = ("" + c.resourceClass).toLowerCase();
-    if (cls == "xwaylandvideobridge" || cls == "plasmashell" ||
-        cls == "org.kde.plasmashell" ||
-        cls == "org.freedesktop.impl.portal.desktop.kde") return true;
-    return false;
+// The identity travels with the rectangle because a caller pairing the
+// rectangle with something of its own — the AT-SPI frame it is about to walk —
+// has no other way to tell that the two describe the same window.
+//
+// Class, Name and Title are KWin's resourceClass, resourceName and caption, and
+// any of them can be empty: they are a correlation key, never a requirement.
+// Both application identifiers are here because they disagree for some windows
+// (an XWayland Firefox is class "firefox" and name "navigator") and a reader
+// comparing against a third spelling of the same application should be able to
+// match either.
+type Window struct {
+	Rect  image.Rectangle
+	Class string
+	Name  string
+	Title string
 }
-function neruPush(c) {
-    if (neruIgnore(c)) return;
-    var g = c.clientGeometry ? c.clientGeometry : c.frameGeometry;
-    if (!g) return;
-    callDBus("org.neru.KWinBridge", "/org/neru/KWinBridge", "org.neru.KWinBridge",
-             "UpdateActiveWindow",
-             "" + Math.round(g.x) + "," + Math.round(g.y) + "," +
-             Math.round(g.width) + "," + Math.round(g.height) + "," + c.resourceClass);
-}
-workspace.windowActivated.connect(neruPush);
-neruPush(workspace.activeWindow);
-`
 
-// Geometry caches the focused window's on-screen client rectangle, fed by the
-// KWin script through the exported D-Bus method. It answers two questions from
-// that one cache: the window's origin (AT-SPI reports element coordinates
-// relative to it on Wayland) and the window's rectangle
-// (SystemPort.FocusedWindowBounds).
+// Geometry caches the focused window, fed by the KWin script through the
+// exported D-Bus methods. It answers two questions from that one cache: the
+// window's origin (AT-SPI reports element coordinates relative to it on
+// Wayland) and the window's rectangle (SystemPort.FocusedWindowBounds).
 type Geometry struct {
 	// logger is whatever the first caller with one handed in. Both callers
 	// reach this through Shared and only one of them carries a logger, so it
 	// is set once and read from any goroutine.
 	logger atomic.Pointer[zap.Logger]
+
+	// watching is the restart watch's one-shot claim (restart_watch.go).
+	watching claim
 
 	startMu   sync.Mutex
 	starting  bool
@@ -114,7 +90,7 @@ type Geometry struct {
 	warned    bool
 
 	mu       sync.RWMutex
-	rect     image.Rectangle
+	window   Window
 	valid    bool
 	startErr error
 }
@@ -166,73 +142,107 @@ func (g *Geometry) EnsureStarted() {
 	}
 }
 
-// UpdateActiveWindow is the exported D-Bus method the KWin script calls. The
-// payload is "x,y,w,h,resourceClass" (a single string, to avoid KWin number
-// marshaling quirks).
+// UpdateActiveWindow is the exported D-Bus method the KWin script calls when
+// there is a focused window to report. The payload is
+// "x,y,w,h,resourceClass,resourceName,caption" (a single string, to avoid KWin
+// number marshaling quirks).
 //
 // A push that does not describe a window on screen is dropped rather than
 // cached: the previous geometry is a better answer than an empty rectangle,
-// which a caller cannot tell from a real one.
+// which a caller cannot tell from a real one. That is why there is a second
+// method — ClearActiveWindow — for the case where the previous geometry is not
+// an answer at all.
 func (g *Geometry) UpdateActiveWindow(payload string) *dbus.Error {
-	parts := strings.SplitN(payload, ",", payloadParts)
-	if len(parts) < payloadMinParts {
+	window, ok := parseWindowPayload(payload)
+	if !ok {
 		return nil
-	}
-
-	originX, errX := strconv.Atoi(strings.TrimSpace(parts[0]))
-	originY, errY := strconv.Atoi(strings.TrimSpace(parts[1]))
-	width, errW := strconv.Atoi(strings.TrimSpace(parts[2]))
-	height, errH := strconv.Atoi(strings.TrimSpace(parts[3]))
-
-	if errX != nil || errY != nil || errW != nil || errH != nil {
-		return nil //nolint:nilerr // best-effort: malformed payloads are ignored, not surfaced to KWin.
-	}
-
-	if width <= 0 || height <= 0 {
-		return nil
-	}
-
-	class := ""
-	if len(parts) == payloadParts {
-		class = parts[4]
 	}
 
 	g.mu.Lock()
-	g.rect, g.valid = image.Rect(originX, originY, originX+width, originY+height), true
+	g.window, g.valid = window, true
 	g.mu.Unlock()
 
+	// The title is a window's contents by any reasonable reading — a document
+	// name, a chat, a page — so it is correlated with and never logged. The
+	// class is an application identity, which the app watcher already logs.
 	g.log().Debug("KWin active window geometry",
-		zap.Int("x", originX), zap.Int("y", originY),
-		zap.Int("w", width), zap.Int("h", height),
-		zap.String("class", class))
+		zap.Int("x", window.Rect.Min.X), zap.Int("y", window.Rect.Min.Y),
+		zap.Int("w", window.Rect.Dx()), zap.Int("h", window.Rect.Dy()),
+		zap.String("class", window.Class))
 
 	return nil
 }
 
-// Bounds returns the focused window's on-screen client rectangle as KWin last
-// reported it.
+// ClearActiveWindow is the exported D-Bus method the KWin script calls when
+// activation has left every window it can report on: the desktop is focused,
+// the focused window was minimized, or the last one closed.
 //
-// The three answers are distinct on purpose. A rectangle with ok is what KWin
+// It is a separate method rather than a shape of UpdateActiveWindow's payload
+// because the two say opposite things about the cache. A malformed or
+// degenerate push is a push that failed, and the previous rectangle survives it
+// as the best available answer. This is KWin saying the previous rectangle
+// describes nothing on screen, and keeping it would answer "the focused window
+// is here" with a rectangle no window is in — the confidently wrong answer this
+// bridge exists to end.
+//
+// Emptying the cache is not a failure: the bridge is installed and working, and
+// what it reports is that nothing is focused. Callers widen to the active
+// screen knowingly, which is what they should do.
+//
+// The reason is a fixed word from the script naming which of those happened. It
+// takes an argument at all so the call has the same shape as UpdateActiveWindow
+// — a KWin script's callDBus with no arguments would be the one call here whose
+// marshaling nothing has ever exercised, and a clear that silently failed would
+// restore exactly the stale rectangle this method exists to remove.
+func (g *Geometry) ClearActiveWindow(reason string) *dbus.Error {
+	g.invalidate()
+
+	g.log().Debug("KWin reports no focused window", zap.String("reason", reason))
+
+	return nil
+}
+
+// Focused returns the focused window as KWin last reported it.
+//
+// The three answers are distinct on purpose. A window with ok is what KWin
 // says. ok=false with no error means the bridge is installed (or installing for
-// the first time) and has been told about no window — the desktop is focused,
-// or activation has not moved since the daemon started. A non-nil error means
-// the bridge could not be installed, which is the one case a caller must not
-// read as "there is no focused window".
+// the first time) and has nothing to report — the desktop is focused, the
+// focused window was minimized or closed, or activation has not moved since the
+// daemon started. A non-nil error means the bridge could not be installed,
+// which is the one case a caller must not read as "there is no focused window".
 //
 // A retry already in flight does not soften the last failure into that middle
 // answer. It is the failure that is true right now, and reporting "installing"
 // on every call would hide a session with no KWin behind a permanent maybe —
 // the silent widening to the active screen this bridge exists to end. The
 // reason is cleared the moment an attempt supersedes it.
-func (g *Geometry) Bounds() (image.Rectangle, bool, error) {
+func (g *Geometry) Focused() (Window, bool, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
 	if g.valid {
-		return g.rect, true, nil
+		return g.window, true, nil
 	}
 
-	return image.Rectangle{}, false, g.startErr
+	return Window{}, false, g.startErr
+}
+
+// Bounds returns just the focused window's on-screen client rectangle, for the
+// caller that has nothing to correlate it against — SystemPort.FocusedWindowBounds
+// answers about "the focused window" as such, so KWin's own answer to that is
+// the whole of it. It carries Focused's three answers unchanged.
+func (g *Geometry) Bounds() (image.Rectangle, bool, error) {
+	window, ok, err := g.Focused()
+
+	return window.Rect, ok, err
+}
+
+// invalidate empties the cache without saying anything about why. It is what a
+// clear and a compositor restart have in common.
+func (g *Geometry) invalidate() {
+	g.mu.Lock()
+	g.window, g.valid = Window{}, false
+	g.mu.Unlock()
 }
 
 // adoptLogger takes the first real logger offered and keeps it. Callers reach
@@ -314,6 +324,14 @@ func (g *Geometry) endStart(err error) {
 	g.recordAttempt(err)
 }
 
+// forgetInstall puts the bridge back where it was before it ever installed
+// anything, so the next EnsureStarted actually tries.
+func (g *Geometry) forgetInstall() {
+	g.startMu.Lock()
+	g.installed = false
+	g.startMu.Unlock()
+}
+
 // recordAttempt publishes an attempt's outcome without releasing the claim, for
 // the failures the installer is about to retry itself.
 //
@@ -341,17 +359,22 @@ func (g *Geometry) recordAttempt(err error) {
 	}
 }
 
-// install exports the D-Bus receiver and loads the KWin script.
+// install arms the restart watch, then exports the D-Bus receiver and loads the
+// KWin script.
 //
-// KWin's presence is checked before anything leaves this process. The bridge is
-// reached from a backend decision, not from an environment guess, but a
-// KDE-labeled session with no running KWin would otherwise still own a bus
-// name and write a script into $XDG_RUNTIME_DIR for nobody to read (#1430).
+// KWin's presence is checked before anything is exported. The bridge is reached
+// from a backend decision, not from an environment guess, but a KDE-labeled
+// session with no running KWin would otherwise still own a bus name and write a
+// script into $XDG_RUNTIME_DIR for nobody to read (#1430). The watch is armed
+// ahead of that check on purpose — watchKWin says why it is not the same kind
+// of act.
 func (g *Geometry) install() error {
 	conn, err := dbus.SessionBus()
 	if err != nil {
 		return fmt.Errorf("session bus: %w", err)
 	}
+
+	g.watchKWin(conn)
 
 	var hasOwner bool
 

--- a/internal/adapter/platform/kwin/geometry.go
+++ b/internal/adapter/platform/kwin/geometry.go
@@ -89,6 +89,12 @@ type Geometry struct {
 	installed bool
 	warned    bool
 
+	// installer is what one attempt runs. It is a field rather than a method
+	// call so a test can drive the whole claim-and-generation machinery —
+	// including the reinstall that a retired attempt has to schedule — without
+	// a session bus to install into.
+	installer func() error
+
 	// generation counts how many times what an install attempt is *about* has
 	// stopped being true — KWin changing hands underneath one in flight. An
 	// attempt carries the generation it began in and publishes nothing unless
@@ -127,6 +133,7 @@ func Shared(logger *zap.Logger) *Geometry {
 
 func newGeometry(logger *zap.Logger) *Geometry {
 	geometry := &Geometry{}
+	geometry.installer = geometry.install
 	geometry.adoptLogger(logger)
 
 	return geometry
@@ -286,7 +293,7 @@ func (g *Geometry) log() *zap.Logger {
 // happens, so Bounds keeps naming the current reason rather than going quiet
 // for the length of the backoff.
 func (g *Geometry) start(generation uint64) {
-	g.runInstall(generation, g.install, installRetryBackoff)
+	g.runInstall(generation, g.installer, installRetryBackoff)
 }
 
 // runInstall is start's loop with its two dependencies passed in, so the retry
@@ -329,13 +336,19 @@ func (g *Geometry) beginStart() (uint64, bool) {
 // endStart records the last attempt of a sequence and releases the claim, so
 // the next caller can retry a failure and none can repeat a success.
 //
-// An attempt from a superseded generation releases the claim and says nothing
-// else. It was about a compositor that has since changed hands, so its success
-// is not evidence that this one is installed, and its outcome must not overwrite
-// what the departure recorded — a stale success would otherwise leave an empty
-// cache with no reason, which reads as an unfocused desktop and sends callers
-// silently back to the active screen. It leaves nothing installed, so the next
-// caller starts an attempt about the compositor that is actually there.
+// An attempt from a superseded generation publishes nothing. It was about a
+// compositor that has since changed hands, so its success is not evidence that
+// this one is installed, and its outcome must not overwrite what the departure
+// recorded — a stale success would otherwise leave an empty cache with no
+// reason, which reads as an unfocused desktop and sends callers silently back to
+// the active screen.
+//
+// It schedules a fresh attempt on its way out instead, because it was holding
+// the claim for the whole time it was stale: a compositor that arrived in that
+// window found the claim taken, could not start an installer of its own, and has
+// nobody else coming. Leaving that to the next caller would mean the request
+// that discovers it is the one that pays, which for the AT-SPI origin is a
+// screenful of hints placed window-relative.
 func (g *Geometry) endStart(generation uint64, err error) {
 	g.startMu.Lock()
 	g.starting = false
@@ -349,6 +362,7 @@ func (g *Geometry) endStart(generation uint64, err error) {
 
 	if !current {
 		g.log().Debug("KWin geometry install finished for a compositor that has since gone")
+		g.EnsureStarted()
 
 		return
 	}

--- a/internal/adapter/platform/kwin/geometry.go
+++ b/internal/adapter/platform/kwin/geometry.go
@@ -89,6 +89,14 @@ type Geometry struct {
 	installed bool
 	warned    bool
 
+	// generation counts how many times what an install attempt is *about* has
+	// stopped being true — KWin changing hands underneath one in flight. An
+	// attempt carries the generation it began in and publishes nothing unless
+	// that is still the current one, so a success against a compositor that has
+	// since gone cannot mark the bridge installed or erase the record of its
+	// going. Guarded by startMu.
+	generation uint64
+
 	mu       sync.RWMutex
 	window   Window
 	valid    bool
@@ -137,8 +145,8 @@ func newGeometry(logger *zap.Logger) *Geometry {
 // the activation path and nothing else. The install converging without a caller
 // is what start covers.
 func (g *Geometry) EnsureStarted() {
-	if g.beginStart() {
-		go g.start()
+	if generation, ok := g.beginStart(); ok {
+		go g.start(generation)
 	}
 }
 
@@ -277,59 +285,88 @@ func (g *Geometry) log() *zap.Logger {
 // does not stack a second installer; each failure is still published as it
 // happens, so Bounds keeps naming the current reason rather than going quiet
 // for the length of the backoff.
-func (g *Geometry) start() {
-	g.runInstall(g.install, installRetryBackoff)
+func (g *Geometry) start(generation uint64) {
+	g.runInstall(generation, g.install, installRetryBackoff)
 }
 
 // runInstall is start's loop with its two dependencies passed in, so the retry
 // policy can be tested without a session bus or a wall-clock wait.
-func (g *Geometry) runInstall(install func() error, backoff time.Duration) {
+func (g *Geometry) runInstall(
+	generation uint64,
+	install func() error,
+	backoff time.Duration,
+) {
 	for attempt := range installRetries + 1 {
 		err := install()
 		if err == nil || attempt == installRetries {
-			g.endStart(err)
+			g.endStart(generation, err)
 
 			return
 		}
 
-		g.recordAttempt(err)
+		g.recordAttempt(generation, err)
 		time.Sleep(backoff << attempt)
 	}
 }
 
-// beginStart claims the right to run an install attempt. It is false when one
-// is already in flight or the script is installed, so callers can ask on every
-// request without stacking attempts or reinstalling.
-func (g *Geometry) beginStart() bool {
+// beginStart claims the right to run an install attempt and hands back the
+// generation that attempt is about. It is false when one is already in flight or
+// the script is installed, so callers can ask on every request without stacking
+// attempts or reinstalling.
+func (g *Geometry) beginStart() (uint64, bool) {
 	g.startMu.Lock()
 	defer g.startMu.Unlock()
 
 	if g.starting || g.installed {
-		return false
+		return 0, false
 	}
 
 	g.starting = true
 
-	return true
+	return g.generation, true
 }
 
 // endStart records the last attempt of a sequence and releases the claim, so
 // the next caller can retry a failure and none can repeat a success.
-func (g *Geometry) endStart(err error) {
+//
+// An attempt from a superseded generation releases the claim and says nothing
+// else. It was about a compositor that has since changed hands, so its success
+// is not evidence that this one is installed, and its outcome must not overwrite
+// what the departure recorded — a stale success would otherwise leave an empty
+// cache with no reason, which reads as an unfocused desktop and sends callers
+// silently back to the active screen. It leaves nothing installed, so the next
+// caller starts an attempt about the compositor that is actually there.
+func (g *Geometry) endStart(generation uint64, err error) {
 	g.startMu.Lock()
 	g.starting = false
-	g.installed = err == nil
+	current := generation == g.generation
+
+	if current {
+		g.installed = err == nil
+	}
+
 	g.startMu.Unlock()
 
-	g.recordAttempt(err)
+	if !current {
+		g.log().Debug("KWin geometry install finished for a compositor that has since gone")
+
+		return
+	}
+
+	g.recordAttempt(generation, err)
 }
 
 // forgetInstall puts the bridge back where it was before it ever installed
-// anything, so the next EnsureStarted actually tries.
-func (g *Geometry) forgetInstall() {
+// anything and retires every attempt in flight, returning the generation that
+// replaces them so the caller can speak for the new state itself.
+func (g *Geometry) forgetInstall() uint64 {
 	g.startMu.Lock()
+	defer g.startMu.Unlock()
+
 	g.installed = false
-	g.startMu.Unlock()
+	g.generation++
+
+	return g.generation
 }
 
 // recordAttempt publishes an attempt's outcome without releasing the claim, for
@@ -339,8 +376,17 @@ func (g *Geometry) forgetInstall() {
 // loud once, since the error reaches every later caller anyway and a session
 // with no KWin would otherwise warn on every hint activation. A success clears
 // the reason: it described a condition that has passed.
-func (g *Geometry) recordAttempt(err error) {
+//
+// A superseded generation publishes nothing, for the reason endStart gives.
+func (g *Geometry) recordAttempt(generation uint64, err error) {
 	g.startMu.Lock()
+
+	if generation != g.generation {
+		g.startMu.Unlock()
+
+		return
+	}
+
 	firstFailure := err != nil && !g.warned
 	g.warned = g.warned || err != nil
 	g.startMu.Unlock()

--- a/internal/adapter/platform/kwin/geometry_test.go
+++ b/internal/adapter/platform/kwin/geometry_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 // errTestInstallFailed stands in for whatever kept the KWin script from being
-// installed; Bounds only has to carry it back, not interpret it.
-var errTestInstallFailed = errors.New("org.kde.KWin is not on the session bus")
+// installed. It is deliberately not errKWinAbsent: what is pinned is that the
+// reason reaches the caller verbatim, whatever it happens to be.
+var errTestInstallFailed = errors.New("the session bus refused the connection")
 
 // TestGeometry_BoundsBeforeAnyUpdate pins the cold answer. Nothing has been
 // pushed yet, so the bridge reports "nothing to say" — not a zero rectangle a
@@ -89,8 +90,8 @@ func TestGeometry_UpdateActiveWindowRejectsUnusablePayloads(t *testing.T) {
 }
 
 // TestGeometry_UpdateActiveWindowAcceptsAMissingResourceClass keeps the geometry
-// working when the class is absent — it is a diagnostic, not part of the
-// answer.
+// working when the class is absent — it is a correlation key, not part of the
+// answer, and a KWin version that reports no class must still report a window.
 func TestGeometry_UpdateActiveWindowAcceptsAMissingResourceClass(t *testing.T) {
 	geometry := newGeometry(zap.NewNop())
 
@@ -99,6 +100,101 @@ func TestGeometry_UpdateActiveWindowAcceptsAMissingResourceClass(t *testing.T) {
 	rect, ok, err := geometry.Bounds()
 	if !ok || err != nil || rect != image.Rect(0, 0, 1920, 1080) {
 		t.Errorf("Bounds() = (%v, %v, %v), want the pushed rectangle", rect, ok, err)
+	}
+}
+
+// TestGeometry_FocusedCarriesTheWindowIdentity pins the half of the payload the
+// AT-SPI origin path correlates with. Without it a cached rectangle can only be
+// checked by size, and two same-sized windows are indistinguishable (#972).
+//
+// The caption is last in the payload because it is the one field that can
+// contain a comma, so a title with one has to survive the split whole.
+func TestGeometry_FocusedCarriesTheWindowIdentity(t *testing.T) {
+	geometry := newGeometry(zap.NewNop())
+
+	_ = geometry.UpdateActiveWindow(
+		"100,50,800,600,konsole,konsole,one, two and three — Konsole")
+
+	window, ok, err := geometry.Focused()
+	if !ok || err != nil {
+		t.Fatalf("Focused() = (%v, %v, %v), want a window", window, ok, err)
+	}
+
+	want := Window{
+		Rect:  image.Rect(100, 50, 900, 650),
+		Class: "konsole",
+		Name:  "konsole",
+		Title: "one, two and three — Konsole",
+	}
+	if window != want {
+		t.Errorf("Focused() = %+v, want %+v", window, want)
+	}
+}
+
+// TestGeometry_ClearActiveWindowEmptiesTheCache is the other half of the fix
+// this bridge needed: a rectangle that has stopped describing anything.
+//
+// KWin reported on activation and nothing else, so once a window had been seen
+// the cache could never empty — after the last one closed, "where is the
+// focused window" was answered with the rectangle the dead window had. Emptying
+// it is not a failure and must not be reported as one: the bridge is installed
+// and working, and what it has to say is that nothing is focused.
+func TestGeometry_ClearActiveWindowEmptiesTheCache(t *testing.T) {
+	geometry := newGeometry(zap.NewNop())
+
+	_ = geometry.UpdateActiveWindow("100,50,800,600,konsole,konsole,Konsole")
+
+	dbusErr := geometry.ClearActiveWindow("closed")
+	if dbusErr != nil {
+		t.Fatalf("ClearActiveWindow returned %v, want nil", dbusErr)
+	}
+
+	rect, ok, err := geometry.Bounds()
+	if ok || err != nil {
+		t.Fatalf("Bounds() after a clear = (%v, %v, %v), want (empty, false, nil) — "+
+			"nothing is focused, which is an answer and not a failure", rect, ok, err)
+	}
+}
+
+// TestGeometry_UpdateAfterAClearReportsAgain keeps a clear from being terminal.
+// Focus leaving every window is the ordinary state of a desktop between two
+// windows, not the end of the bridge's usefulness.
+func TestGeometry_UpdateAfterAClearReportsAgain(t *testing.T) {
+	geometry := newGeometry(zap.NewNop())
+
+	_ = geometry.UpdateActiveWindow("100,50,800,600,konsole,konsole,Konsole")
+	_ = geometry.ClearActiveWindow("desktop")
+	_ = geometry.UpdateActiveWindow("10,20,300,400,kate,kate,Kate")
+
+	rect, ok, err := geometry.Bounds()
+	if !ok || err != nil || rect != image.Rect(10, 20, 310, 420) {
+		t.Errorf("Bounds() = (%v, %v, %v), want the newly pushed rectangle", rect, ok, err)
+	}
+}
+
+// TestGeometry_ClearActiveWindowIsNotAMalformedPush pins the distinction the
+// two methods exist to draw.
+//
+// A malformed push is a push that failed, and the previous rectangle survives
+// it as the best available answer. A clear is KWin saying that rectangle
+// describes nothing on screen. Collapsing them — a clear expressed as an empty
+// payload, say — would make one of the two behave as the other.
+func TestGeometry_ClearActiveWindowIsNotAMalformedPush(t *testing.T) {
+	geometry := newGeometry(zap.NewNop())
+
+	_ = geometry.UpdateActiveWindow("100,50,800,600,konsole,konsole,Konsole")
+	_ = geometry.UpdateActiveWindow("")
+
+	_, cached, _ := geometry.Bounds()
+	if !cached {
+		t.Fatal("a malformed push emptied the cache; only a clear may do that")
+	}
+
+	_ = geometry.ClearActiveWindow("closed")
+
+	_, cached, _ = geometry.Bounds()
+	if cached {
+		t.Error("a clear left the previous rectangle in place")
 	}
 }
 

--- a/internal/adapter/platform/kwin/geometry_test.go
+++ b/internal/adapter/platform/kwin/geometry_test.go
@@ -10,6 +10,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// initialGeneration is the generation a bridge that has seen no compositor
+// change is on, which is what an attempt started before any of them carries.
+const initialGeneration = 0
+
 // errTestInstallFailed stands in for whatever kept the KWin script from being
 // installed. It is deliberately not errKWinAbsent: what is pinned is that the
 // reason reaches the caller verbatim, whatever it happens to be.
@@ -205,7 +209,7 @@ func TestGeometry_ClearActiveWindowIsNotAMalformedPush(t *testing.T) {
 func TestGeometry_BoundsReportsAFailedInstall(t *testing.T) {
 	geometry := newGeometry(zap.NewNop())
 
-	geometry.endStart(errTestInstallFailed)
+	geometry.endStart(initialGeneration, errTestInstallFailed)
 
 	_, ok, err := geometry.Bounds()
 	if ok {
@@ -223,7 +227,7 @@ func TestGeometry_BoundsReportsAFailedInstall(t *testing.T) {
 func TestGeometry_BoundsPrefersLiveGeometryOverAStaleFailure(t *testing.T) {
 	geometry := newGeometry(zap.NewNop())
 
-	geometry.endStart(errTestInstallFailed)
+	geometry.endStart(initialGeneration, errTestInstallFailed)
 	_ = geometry.UpdateActiveWindow("10,20,300,400,kate")
 
 	rect, ok, err := geometry.Bounds()
@@ -244,23 +248,23 @@ func TestGeometry_BoundsPrefersLiveGeometryOverAStaleFailure(t *testing.T) {
 func TestGeometry_BeginStartRetriesUntilTheScriptIsInstalled(t *testing.T) {
 	geometry := newGeometry(zap.NewNop())
 
-	if !geometry.beginStart() {
+	if _, ok := geometry.beginStart(); !ok {
 		t.Fatal("the first caller was not allowed to install")
 	}
 
-	if geometry.beginStart() {
+	if _, ok := geometry.beginStart(); ok {
 		t.Error("a second caller started a duplicate install while one was in flight")
 	}
 
-	geometry.endStart(errTestInstallFailed)
+	geometry.endStart(initialGeneration, errTestInstallFailed)
 
-	if !geometry.beginStart() {
+	if _, ok := geometry.beginStart(); !ok {
 		t.Fatal("a failed install was never retried; the daemon would run blind until restart")
 	}
 
-	geometry.endStart(nil)
+	geometry.endStart(initialGeneration, nil)
 
-	if geometry.beginStart() {
+	if _, ok := geometry.beginStart(); ok {
 		t.Error("an installed script was reinstalled")
 	}
 }
@@ -271,10 +275,10 @@ func TestGeometry_ASuccessfulRetryClearsTheRecordedReason(t *testing.T) {
 	geometry := newGeometry(zap.NewNop())
 
 	geometry.beginStart()
-	geometry.endStart(errTestInstallFailed)
+	geometry.endStart(initialGeneration, errTestInstallFailed)
 
 	geometry.beginStart()
-	geometry.endStart(nil)
+	geometry.endStart(initialGeneration, nil)
 
 	_, ok, err := geometry.Bounds()
 	if ok || err != nil {
@@ -305,8 +309,8 @@ func TestGeometry_RunInstallRetriesWithoutWaitingForACaller(t *testing.T) {
 		return nil
 	}
 
-	geometry.beginStart()
-	geometry.runInstall(install, 0)
+	generation, _ := geometry.beginStart()
+	geometry.runInstall(generation, install, 0)
 
 	if attempts != 3 {
 		t.Fatalf(
@@ -320,7 +324,7 @@ func TestGeometry_RunInstallRetriesWithoutWaitingForACaller(t *testing.T) {
 		t.Fatalf("Bounds() after a successful retry = (%v, %v), want (false, nil)", ok, err)
 	}
 
-	if geometry.beginStart() {
+	if _, ok := geometry.beginStart(); ok {
 		t.Error("an installed script was reinstalled")
 	}
 }
@@ -340,8 +344,8 @@ func TestGeometry_RunInstallStopsRetryingAndReportsTheReason(t *testing.T) {
 		return errTestInstallFailed
 	}
 
-	geometry.beginStart()
-	geometry.runInstall(install, 0)
+	generation, _ := geometry.beginStart()
+	geometry.runInstall(generation, install, 0)
 
 	if attempts != installRetries+1 {
 		t.Fatalf("install ran %d times, want %d", attempts, installRetries+1)
@@ -352,7 +356,7 @@ func TestGeometry_RunInstallStopsRetryingAndReportsTheReason(t *testing.T) {
 		t.Fatalf("Bounds() = (%v, %v), want the recorded reason", ok, err)
 	}
 
-	if !geometry.beginStart() {
+	if _, ok := geometry.beginStart(); !ok {
 		t.Error("a bounded retry that gave up also stopped the next caller from trying")
 	}
 }
@@ -379,8 +383,8 @@ func TestGeometry_RunInstallReportsEachFailureAsItHappens(t *testing.T) {
 		return errTestInstallFailed
 	}
 
-	geometry.beginStart()
-	geometry.runInstall(install, 0)
+	generation, _ := geometry.beginStart()
+	geometry.runInstall(generation, install, 0)
 
 	if !errors.Is(duringBackoff, errTestInstallFailed) {
 		t.Errorf("Bounds() between attempts = %v, want the failure already recorded", duringBackoff)

--- a/internal/adapter/platform/kwin/payload.go
+++ b/internal/adapter/platform/kwin/payload.go
@@ -1,0 +1,82 @@
+//go:build linux
+
+package kwin
+
+import (
+	"image"
+	"strconv"
+	"strings"
+)
+
+// The wire format between the KWin script and this package.
+//
+// It is one comma-separated string rather than typed D-Bus arguments because
+// the sender is JavaScript inside KWin, whose number marshaling is not worth
+// depending on. Parsing it is kept apart from the D-Bus method that receives it
+// so that what counts as a usable push can be decided — and tested — without
+// standing up a bus.
+
+const (
+	// UpdateActiveWindow payload is
+	// "x,y,w,h,resourceClass,resourceName,caption": up to 7 fields, with the
+	// geometry minimum being the first 4. The caption is last because it is the
+	// one field that can contain a comma, and the split keeps the remainder
+	// there.
+	payloadParts    = 7
+	payloadMinParts = 4
+
+	// The identity fields, indexed as the ones a payload may stop short of.
+	// Both application identifiers are carried because neither is reliably the
+	// one a reader will be comparing against: KWin's own foreign-toplevel app_id
+	// is built from one of them, and which one differs by window (an XWayland
+	// Firefox is resourceClass "firefox" and resourceName "navigator").
+	payloadClassField = 4
+	payloadNameField  = 5
+	payloadTitleField = 6
+)
+
+// parseWindowPayload turns a push from the script into a window, or reports
+// that there is nothing usable in it.
+//
+// The script is remote code as far as this process is concerned, so every way a
+// payload can fail to describe a window on screen — too few fields, a
+// non-numeric coordinate, a zero or negative area — is one answer: not usable.
+// What the caller does with that is keep whatever it already had, which is why
+// this says nothing about the previous window and cannot be told to clear one.
+func parseWindowPayload(payload string) (Window, bool) {
+	parts := strings.SplitN(payload, ",", payloadParts)
+	if len(parts) < payloadMinParts {
+		return Window{}, false
+	}
+
+	originX, errX := strconv.Atoi(strings.TrimSpace(parts[0]))
+	originY, errY := strconv.Atoi(strings.TrimSpace(parts[1]))
+	width, errW := strconv.Atoi(strings.TrimSpace(parts[2]))
+	height, errH := strconv.Atoi(strings.TrimSpace(parts[3]))
+
+	if errX != nil || errY != nil || errW != nil || errH != nil {
+		return Window{}, false
+	}
+
+	if width <= 0 || height <= 0 {
+		return Window{}, false
+	}
+
+	return Window{
+		Rect:  image.Rect(originX, originY, originX+width, originY+height),
+		Class: payloadField(parts, payloadClassField),
+		Name:  payloadField(parts, payloadNameField),
+		Title: payloadField(parts, payloadTitleField),
+	}, true
+}
+
+// payloadField reads an optional trailing payload field. The identity fields
+// are the ones a payload may stop short of — they are a correlation key, and a
+// KWin version that reports none of them should still report a rectangle.
+func payloadField(parts []string, index int) string {
+	if index >= len(parts) {
+		return ""
+	}
+
+	return parts[index]
+}

--- a/internal/adapter/platform/kwin/restart_watch.go
+++ b/internal/adapter/platform/kwin/restart_watch.go
@@ -162,10 +162,14 @@ func kwinOwnerFrom(signal *dbus.Signal) (string, bool) {
 // bridge answering one way. The next successful install clears it.
 func (g *Geometry) kwinOwnerChanged(owner string) {
 	g.invalidate()
-	g.forgetInstall()
+
+	// Retiring the attempts in flight is what makes the reason below stick: one
+	// of them may be an install against the compositor that just left, and
+	// without this its outcome would land afterwards and overwrite this.
+	generation := g.forgetInstall()
 
 	if owner == "" {
-		g.recordAttempt(errKWinAbsent)
+		g.recordAttempt(generation, errKWinAbsent)
 
 		return
 	}

--- a/internal/adapter/platform/kwin/restart_watch.go
+++ b/internal/adapter/platform/kwin/restart_watch.go
@@ -1,0 +1,176 @@
+//go:build linux
+
+package kwin
+
+import (
+	"sync"
+
+	"github.com/godbus/dbus/v5"
+	"go.uber.org/zap"
+)
+
+// Noticing that KWin came or went.
+//
+// A script lives inside the compositor, so `kwin --replace`, a Plasma crash or
+// a session-wide restart takes it with it. Nothing else here would hear about
+// that: no push would arrive again, and an installed bridge never reinstalls —
+// so the cache would stay frozen at the last rectangle and serve it as the
+// truth for the rest of the daemon's life, which is the same confidently wrong
+// answer the bridge was written to end, reached by a different route.
+
+const (
+	dbusNameOwnerMember = "NameOwnerChanged"
+	dbusNameOwnerSignal = dbusIface + "." + dbusNameOwnerMember
+
+	// NameOwnerChanged carries (name, oldOwner, newOwner).
+	nameOwnerArgs     = 3
+	nameOwnerNewIndex = 2
+
+	// ownerSignalBuffer is the restart watch's queue. It is not sized for
+	// NameOwnerChanged, which fires about org.kde.KWin once a session: this is
+	// the process-wide session connection, so godbus delivers everything
+	// *anything* in this process subscribed to into this channel too, and the
+	// buffer is what keeps the common case off godbus's overflow path (a
+	// goroutine per signal — it defers rather than drops).
+	ownerSignalBuffer = 32
+)
+
+// claim is a one-shot flag: the first taker gets it and everyone after is told
+// no, until whoever holds it gives it back. It exists so setup that must happen
+// once cannot happen twice when two callers race, without each such flag
+// growing its own mutex and its own pair of methods.
+type claim struct {
+	mu   sync.Mutex
+	held bool
+}
+
+// take reports whether the caller is the one that should do the work.
+func (c *claim) take() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.held {
+		return false
+	}
+
+	c.held = true
+
+	return true
+}
+
+// release hands the claim back, for a taker that could not finish.
+func (c *claim) release() {
+	c.mu.Lock()
+	c.held = false
+	c.mu.Unlock()
+}
+
+// watchKWin asks the bus to say when org.kde.KWin changes hands. Losing the
+// name empties the cache, because a window on a compositor that no longer
+// exists is not anywhere; gaining it installs the script into the new one.
+//
+// It is armed before KWin's presence is checked, not after the script loads,
+// because the session where it matters most is the one where there is no KWin
+// to install into yet: a daemon starting with the session reaches this before
+// the compositor is on the bus, and a watch armed only on success would be
+// armed only where it was least needed. Without it that daemon still recovers —
+// the next caller retries the install — but recovery would wait for someone to
+// ask, which for the AT-SPI origin means the person who asks pays for it with a
+// screenful of misplaced hints.
+//
+// This is the one thing the bridge does before knowing KWin is there, and it
+// stays inside what #1430 asked for: a match rule is a subscription, not a
+// claim. Nothing is exported, no name is owned, and nothing is written to disk
+// until KWin has answered for itself.
+//
+// The watch is armed once and outlives any number of restarts.
+func (g *Geometry) watchKWin(conn *dbus.Conn) {
+	if !g.watching.take() {
+		return
+	}
+
+	matchErr := conn.AddMatchSignal(
+		dbus.WithMatchInterface(dbusIface),
+		dbus.WithMatchMember(dbusNameOwnerMember),
+		dbus.WithMatchArg(0, scriptingDest),
+	)
+	if matchErr != nil {
+		g.watching.release()
+		g.log().Debug("KWin restart watch unavailable", zap.Error(matchErr))
+
+		return
+	}
+
+	signals := make(chan *dbus.Signal, ownerSignalBuffer)
+	conn.Signal(signals)
+
+	go g.serveOwnerChanges(signals)
+}
+
+// serveOwnerChanges runs for the daemon's life, which is the same life the
+// compositor it watches has.
+func (g *Geometry) serveOwnerChanges(signals <-chan *dbus.Signal) {
+	for signal := range signals {
+		owner, ok := kwinOwnerFrom(signal)
+		if !ok {
+			continue
+		}
+
+		g.kwinOwnerChanged(owner)
+	}
+}
+
+// kwinOwnerFrom reads a NameOwnerChanged for org.kde.KWin and returns its new
+// owner, empty when the name was released.
+//
+// The signal channel is filtered by a match rule, but a match rule is a request
+// to the bus rather than a guarantee about what arrives: this connection is the
+// process-wide session bus, so anything else that subscribes on it is delivered
+// here too. The shape is therefore checked rather than assumed.
+func kwinOwnerFrom(signal *dbus.Signal) (string, bool) {
+	if signal == nil || signal.Name != dbusNameOwnerSignal || len(signal.Body) < nameOwnerArgs {
+		return "", false
+	}
+
+	name, nameOK := signal.Body[0].(string)
+	if !nameOK || name != scriptingDest {
+		return "", false
+	}
+
+	owner, ownerOK := signal.Body[nameOwnerNewIndex].(string)
+	if !ownerOK {
+		return "", false
+	}
+
+	return owner, true
+}
+
+// kwinOwnerChanged reacts to KWin leaving or joining the bus.
+//
+// Both directions empty the cache and forget the install, because both mean the
+// script that was feeding it is gone. Only one of them has somewhere to install
+// a new one.
+//
+// A departure also records why, rather than leaving an empty cache to speak for
+// itself. An empty cache with no reason means "the bridge works and nothing is
+// focused", and a compositor that is not on the bus is the other answer
+// entirely — the one errKWinAbsent exists to name. The focused-window arm would
+// reach that answer on its own, because every call there reinstalls and the
+// attempt fails loudly; the AT-SPI origin arm would not, because it installs
+// once at construction and would spend the gap degrading silently with nothing
+// for the log to say. Recording it here is what keeps the two arms of one
+// bridge answering one way. The next successful install clears it.
+func (g *Geometry) kwinOwnerChanged(owner string) {
+	g.invalidate()
+	g.forgetInstall()
+
+	if owner == "" {
+		g.recordAttempt(errKWinAbsent)
+
+		return
+	}
+
+	g.log().Debug("KWin is on the session bus; installing the geometry script")
+
+	g.EnsureStarted()
+}

--- a/internal/adapter/platform/kwin/restart_watch_test.go
+++ b/internal/adapter/platform/kwin/restart_watch_test.go
@@ -30,7 +30,7 @@ func TestGeometry_KWinLeavingTheBusReportsWhyRatherThanEmptying(t *testing.T) {
 	geometry := newGeometry(zap.NewNop())
 
 	geometry.beginStart()
-	geometry.endStart(nil)
+	geometry.endStart(initialGeneration, nil)
 	_ = geometry.UpdateActiveWindow("100,50,800,600,konsole,konsole,Konsole")
 
 	geometry.kwinOwnerChanged("")
@@ -45,9 +45,51 @@ func TestGeometry_KWinLeavingTheBusReportsWhyRatherThanEmptying(t *testing.T) {
 			"an empty cache with no reason reads as an unfocused desktop", err)
 	}
 
-	if !geometry.beginStart() {
+	if _, ok := geometry.beginStart(); !ok {
 		t.Error("a bridge whose compositor restarted still counted itself installed, " +
 			"so nothing would ever reinstall the script")
+	}
+}
+
+// TestGeometry_AnInstallFromBeforeADepartureIsNotBelieved closes the race that
+// would undo everything the departure just recorded.
+//
+// An install is several D-Bus round trips, so KWin can release its name while
+// one is still running — which is exactly what `kwin --replace` during daemon
+// startup does. That attempt can then succeed, and if it were believed it would
+// mark the bridge installed and clear the reason, leaving an empty cache with no
+// error: "the bridge works and nothing is focused", for a compositor that is not
+// there. Callers would widen to the active screen believing they had asked.
+//
+// It must also leave nothing installed, so the next caller starts an attempt
+// about the compositor that is actually there rather than being told one is
+// already in place.
+func TestGeometry_AnInstallFromBeforeADepartureIsNotBelieved(t *testing.T) {
+	geometry := newGeometry(zap.NewNop())
+
+	stale, ok := geometry.beginStart()
+	if !ok {
+		t.Fatal("the first caller was not allowed to install")
+	}
+
+	geometry.kwinOwnerChanged("")
+
+	// The attempt that was already in flight now finishes, successfully.
+	geometry.endStart(stale, nil)
+
+	_, cached, err := geometry.Bounds()
+	if cached {
+		t.Error("a stale install left a window cached for a departed compositor")
+	}
+
+	if !errors.Is(err, errKWinAbsent) {
+		t.Errorf("Bounds() error = %v, want the departure to still be the reason — "+
+			"a stale success must not erase it", err)
+	}
+
+	if _, again := geometry.beginStart(); !again {
+		t.Error("a stale install marked the bridge installed, so nothing would " +
+			"ever install into the compositor that comes back")
 	}
 }
 
@@ -59,8 +101,11 @@ func TestGeometry_KWinReturningToTheBusClearsTheReason(t *testing.T) {
 
 	geometry.kwinOwnerChanged("")
 
-	geometry.beginStart()
-	geometry.endStart(nil)
+	// The reinstall that follows a return is about the compositor that is there
+	// now, so it carries the generation the return put the bridge on and is
+	// believed — unlike the stale attempt in the test above.
+	generation, _ := geometry.beginStart()
+	geometry.endStart(generation, nil)
 
 	_, ok, err := geometry.Bounds()
 	if ok || err != nil {

--- a/internal/adapter/platform/kwin/restart_watch_test.go
+++ b/internal/adapter/platform/kwin/restart_watch_test.go
@@ -5,13 +5,22 @@ package kwin
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/godbus/dbus/v5"
 	"go.uber.org/zap"
 )
 
-// testKWinOwner is a bus name KWin could hold; only whether it is empty matters.
-const testKWinOwner = ":1.42"
+const (
+	// testKWinOwner is a bus name KWin could hold; only whether it is empty
+	// matters.
+	testKWinOwner = ":1.42"
+
+	// installScheduleWait bounds how long a scheduled install may take to reach
+	// its installer. It is a failure deadline, not a delay: the happy path
+	// returns as soon as the goroutine runs.
+	installScheduleWait = 2 * time.Second
+)
 
 // TestGeometry_KWinLeavingTheBusReportsWhyRatherThanEmptying covers the
 // staleness a restart causes, and what has to be said about it.
@@ -67,6 +76,20 @@ func TestGeometry_KWinLeavingTheBusReportsWhyRatherThanEmptying(t *testing.T) {
 func TestGeometry_AnInstallFromBeforeADepartureIsNotBelieved(t *testing.T) {
 	geometry := newGeometry(zap.NewNop())
 
+	// The replacement the retired attempt schedules is held at the door, so
+	// what is asserted below is the state the departure left rather than
+	// whatever that replacement went on to publish.
+	scheduled, release := make(chan struct{}, 1), make(chan struct{})
+	geometry.installer = func() error {
+		scheduled <- struct{}{}
+
+		<-release
+
+		return nil
+	}
+
+	defer close(release)
+
 	stale, ok := geometry.beginStart()
 	if !ok {
 		t.Fatal("the first caller was not allowed to install")
@@ -77,6 +100,13 @@ func TestGeometry_AnInstallFromBeforeADepartureIsNotBelieved(t *testing.T) {
 	// The attempt that was already in flight now finishes, successfully.
 	geometry.endStart(stale, nil)
 
+	select {
+	case <-scheduled:
+	case <-time.After(installScheduleWait):
+		t.Fatal("a stale install left nothing installed and scheduled nothing, so " +
+			"the bridge would sit idle until some request happened along")
+	}
+
 	_, cached, err := geometry.Bounds()
 	if cached {
 		t.Error("a stale install left a window cached for a departed compositor")
@@ -86,10 +116,41 @@ func TestGeometry_AnInstallFromBeforeADepartureIsNotBelieved(t *testing.T) {
 		t.Errorf("Bounds() error = %v, want the departure to still be the reason — "+
 			"a stale success must not erase it", err)
 	}
+}
 
-	if _, again := geometry.beginStart(); !again {
-		t.Error("a stale install marked the bridge installed, so nothing would " +
-			"ever install into the compositor that comes back")
+// TestGeometry_ARetiredInstallSchedulesTheOneItBlocked covers a compositor that
+// leaves and comes back while an install is still running.
+//
+// The return finds the claim held by the attempt that is now stale, so it cannot
+// start the replacement itself and nothing else is coming. The stale attempt is
+// therefore the one that has to schedule it on its way out — otherwise the
+// bridge sits uninstalled, reporting the departure as the reason, until some
+// request happens along and pays for the discovery.
+func TestGeometry_ARetiredInstallSchedulesTheOneItBlocked(t *testing.T) {
+	geometry := newGeometry(zap.NewNop())
+
+	installs := make(chan struct{}, 1)
+	geometry.installer = func() error {
+		installs <- struct{}{}
+
+		return nil
+	}
+
+	stale, ok := geometry.beginStart()
+	if !ok {
+		t.Fatal("the first caller was not allowed to install")
+	}
+
+	geometry.kwinOwnerChanged("")
+	geometry.kwinOwnerChanged(testKWinOwner)
+
+	geometry.endStart(stale, nil)
+
+	select {
+	case <-installs:
+	case <-time.After(installScheduleWait):
+		t.Fatal("a compositor came back while an install was in flight and nothing " +
+			"ever installed into it")
 	}
 }
 

--- a/internal/adapter/platform/kwin/restart_watch_test.go
+++ b/internal/adapter/platform/kwin/restart_watch_test.go
@@ -1,0 +1,162 @@
+//go:build linux
+
+package kwin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+	"go.uber.org/zap"
+)
+
+// testKWinOwner is a bus name KWin could hold; only whether it is empty matters.
+const testKWinOwner = ":1.42"
+
+// TestGeometry_KWinLeavingTheBusReportsWhyRatherThanEmptying covers the
+// staleness a restart causes, and what has to be said about it.
+//
+// The script lives inside KWin, so `kwin --replace` or a Plasma crash takes it
+// with it. Nothing would arrive again, and an installed bridge never retries —
+// so without this the cache would stay frozen at the last rectangle and serve
+// it as the truth for the rest of the daemon's life, which is the same
+// confidently wrong answer reached by a different route.
+//
+// Emptying it is only half the answer. An empty cache with no reason means the
+// bridge works and nothing is focused, which would send a caller to the active
+// screen believing it had asked and been told — the silent widening this bridge
+// exists to end. A compositor that is not on the bus has to say so.
+func TestGeometry_KWinLeavingTheBusReportsWhyRatherThanEmptying(t *testing.T) {
+	geometry := newGeometry(zap.NewNop())
+
+	geometry.beginStart()
+	geometry.endStart(nil)
+	_ = geometry.UpdateActiveWindow("100,50,800,600,konsole,konsole,Konsole")
+
+	geometry.kwinOwnerChanged("")
+
+	rect, ok, err := geometry.Bounds()
+	if ok {
+		t.Fatalf("Bounds() after KWin left = (%v, %v), want no window", rect, ok)
+	}
+
+	if !errors.Is(err, errKWinAbsent) {
+		t.Errorf("Bounds() error = %v, want it to name the absent compositor — "+
+			"an empty cache with no reason reads as an unfocused desktop", err)
+	}
+
+	if !geometry.beginStart() {
+		t.Error("a bridge whose compositor restarted still counted itself installed, " +
+			"so nothing would ever reinstall the script")
+	}
+}
+
+// TestGeometry_KWinReturningToTheBusClearsTheReason keeps the departure from
+// outliving itself: a compositor that came back is not an absent one, and the
+// reinstall that follows is what says so.
+func TestGeometry_KWinReturningToTheBusClearsTheReason(t *testing.T) {
+	geometry := newGeometry(zap.NewNop())
+
+	geometry.kwinOwnerChanged("")
+
+	geometry.beginStart()
+	geometry.endStart(nil)
+
+	_, ok, err := geometry.Bounds()
+	if ok || err != nil {
+		t.Fatalf("Bounds() after a reinstall = (%v, %v), want (false, nil) — "+
+			"installed, with nothing reported yet", ok, err)
+	}
+}
+
+// TestKWinOwnerFrom_ReadsOnlyKWinOwnerChanges keeps the restart watch from
+// acting on somebody else's traffic.
+//
+// The match rule is a request to the bus, not a guarantee about what arrives:
+// this is the process-wide session connection, so every other subscription on
+// it is delivered here too. A stray signal read as "KWin restarted" would empty
+// a good cache and reinstall the script for no reason.
+func TestKWinOwnerFrom_ReadsOnlyKWinOwnerChanges(t *testing.T) {
+	cases := []struct {
+		name      string
+		signal    *dbus.Signal
+		wantOwner string
+		wantOK    bool
+	}{
+		{
+			name: "kwin acquired the name",
+			signal: &dbus.Signal{
+				Name: dbusNameOwnerSignal,
+				Body: []any{scriptingDest, "", testKWinOwner},
+			},
+			wantOwner: testKWinOwner,
+			wantOK:    true,
+		},
+		{
+			name: "kwin released the name",
+			signal: &dbus.Signal{
+				Name: dbusNameOwnerSignal,
+				Body: []any{scriptingDest, testKWinOwner, ""},
+			},
+			wantOK: true,
+		},
+		{
+			name: "another name changed hands",
+			signal: &dbus.Signal{
+				Name: dbusNameOwnerSignal,
+				Body: []any{"org.kde.plasmashell", "", ":1.9"},
+			},
+		},
+		{
+			name: "another signal entirely",
+			signal: &dbus.Signal{
+				Name: "org.freedesktop.portal.Request.Response",
+				Body: []any{scriptingDest, "", testKWinOwner},
+			},
+		},
+		{
+			name:   "truncated body",
+			signal: &dbus.Signal{Name: dbusNameOwnerSignal, Body: []any{scriptingDest, ""}},
+		},
+		{
+			name: "body of the wrong type",
+			signal: &dbus.Signal{
+				Name: dbusNameOwnerSignal,
+				Body: []any{scriptingDest, "", 42},
+			},
+		},
+		{name: "no signal at all"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			owner, ok := kwinOwnerFrom(testCase.signal)
+			if ok != testCase.wantOK || owner != testCase.wantOwner {
+				t.Errorf("kwinOwnerFrom() = (%q, %v), want (%q, %v)",
+					owner, ok, testCase.wantOwner, testCase.wantOK)
+			}
+		})
+	}
+}
+
+// TestClaim_TakeAdmitsOneHolderAtATime pins what keeps the installer's retries
+// and every later reinstall from each adding a match rule and a goroutine that
+// live as long as the daemon does — while still letting an arming that failed
+// be tried again.
+func TestClaim_TakeAdmitsOneHolderAtATime(t *testing.T) {
+	var watching claim
+
+	if !watching.take() {
+		t.Fatal("the first caller was not allowed to arm the restart watch")
+	}
+
+	if watching.take() {
+		t.Error("a second caller armed the restart watch again")
+	}
+
+	watching.release()
+
+	if !watching.take() {
+		t.Error("a watch that could not be armed was never retried")
+	}
+}

--- a/internal/adapter/platform/kwin/script.go
+++ b/internal/adapter/platform/kwin/script.go
@@ -1,0 +1,145 @@
+//go:build linux
+
+package kwin
+
+// The KWin script, and nothing else. It is JavaScript running inside the
+// compositor rather than Go running here, and the rules it plays by are KWin's
+// — so it is kept apart from the Go that receives what it sends.
+
+// geometryScript is loaded into KWin. It reports the focused window's client
+// geometry (content rect, excludes the titlebar so it aligns 1:1 with the
+// AT-SPI content origin), and its identity, so a reader can tell which window
+// the rectangle belongs to.
+//
+// It is driven by three families of signal, because activation alone describes
+// only how a window's rectangle *starts*:
+//
+//   - activation (workspace.windowActivated) — which window to report on.
+//   - geometry (clientGeometryChanged / frameGeometryChanged, and
+//     interactiveMoveResizeFinished) — a window dragged, resized, tiled or
+//     maximized without ever losing focus. Without these the cache is a
+//     snapshot taken at the last focus change, and everything the user did to
+//     the window since is reported at its old position.
+//   - disappearance (workspace.windowRemoved, minimizedChanged, and activation
+//     going to nothing) — without these the cache can never empty, so after
+//     the last window closes the answer is still the dead window's rectangle
+//     rather than "nothing is focused".
+//
+// The geometry handlers are connected once per window at windowAdded rather
+// than connected and disconnected as focus moves: the handler is two property
+// reads when the window is not the active one, and it never holds a reference
+// to a window KWin is destroying. Windows already open when the script loads
+// are picked up from workspace.stackingOrder.
+//
+// Two things are deliberately *not* reported. A drag is skipped while it is in
+// progress (c.move / c.resize) because KWin emits a geometry signal per frame
+// and each one would be a D-Bus message off the compositor thread; the final
+// rectangle arrives on interactiveMoveResizeFinished. And a push identical to
+// the last one is dropped, which covers the client/frame geometry signals
+// arriving in pairs for one change.
+//
+// Three details are load-bearing and easy to undo by accident:
+//
+//   - **The desktop is tested before neruTransient, not after.** KWin defines
+//     isSpecialWindow() as isDesktop() || isDock() || …, and KDE's desktop is a
+//     plasmashell window — so the specialWindow flag and the class list below
+//     would each swallow it, and the clear would never fire. Activating the
+//     desktop is precisely how KDE says no application window is focused, which
+//     is the opposite of what a transient surface says.
+//   - **Every property reaching the payload goes through neruStr.** Absent KWin
+//     properties are undefined, which is falsy and therefore safe in a guard —
+//     but concatenating it yields the string "undefined", which the Go side
+//     cannot tell from a window that really is called that. It would then read
+//     as an identity that was reported and disagrees, and reject this window's
+//     origin on every activation for as long as the session lasts.
+//   - **A window that stops being reportable re-reads who is active** rather
+//     than clearing outright (neruRefocus). Minimizing a background window must
+//     not empty a cache that still describes the focused one.
+//
+// neruTransient filters out non-application surfaces that briefly take
+// activation but are never hint targets: panels/docks/OSD/popups/tooltips/
+// utility windows (caught by KWin's window-type flags), plus a few known
+// transient classes (the XWayland video bridge, plasmashell, and the portal
+// consent dialog). Focus landing on one of those keeps the last real window
+// cached rather than clobbering it — without this, focus flicking to e.g.
+// plasmashell or the RemoteDesktop consent dialog would mis-offset hint clicks.
+//
+// Accessing an absent KWin property yields undefined (falsy) and an absent
+// signal yields undefined too, so the extra type flags and the guarded
+// connects are both safe across KWin versions.
+const geometryScript = `
+function neruStr(v) {
+    return (v === undefined || v === null) ? "" : "" + v;
+}
+function neruTransient(c) {
+    if (neruStr(c.resourceClass) == "neru") return true;
+    if (c.specialWindow || c.dock || c.splash ||
+        c.utility || c.toolbar || c.menu || c.dropdownMenu || c.popupMenu ||
+        c.tooltip || c.notification || c.criticalNotification ||
+        c.onScreenDisplay || c.comboBox || c.dndIcon) return true;
+    var cls = neruStr(c.resourceClass).toLowerCase();
+    if (cls == "xwaylandvideobridge" || cls == "plasmashell" ||
+        cls == "org.kde.plasmashell" ||
+        cls == "org.freedesktop.impl.portal.desktop.kde") return true;
+    return false;
+}
+var neruLast = "";
+function neruCall(method, payload) {
+    callDBus("org.neru.KWinBridge", "/org/neru/KWinBridge", "org.neru.KWinBridge",
+             method, payload);
+}
+function neruClear(reason) {
+    if (neruLast === "") return;
+    neruLast = "";
+    neruCall("ClearActiveWindow", reason);
+}
+function neruPush(c) {
+    var g = c.clientGeometry ? c.clientGeometry : c.frameGeometry;
+    if (!g) return;
+    var payload = "" + Math.round(g.x) + "," + Math.round(g.y) + "," +
+                  Math.round(g.width) + "," + Math.round(g.height) + "," +
+                  neruStr(c.resourceClass) + "," + neruStr(c.resourceName) + "," +
+                  neruStr(c.caption);
+    if (payload === neruLast) return;
+    neruLast = payload;
+    neruCall("UpdateActiveWindow", payload);
+}
+function neruReportable(c) {
+    return c.active && !c.desktopWindow && !neruTransient(c);
+}
+function neruActivated(c) {
+    if (!c) { neruClear("unfocused"); return; }
+    if (c.desktopWindow) { neruClear("desktop"); return; }
+    if (neruTransient(c)) return;
+    neruPush(c);
+}
+function neruRefocus(gone, reason) {
+    var active = workspace.activeWindow;
+    if (!active || active === gone) { neruClear(reason); return; }
+    neruActivated(active);
+}
+function neruWatch(c) {
+    if (!c) return;
+    var onGeometry = function () {
+        if (c.move || c.resize) return;
+        if (!neruReportable(c)) return;
+        neruPush(c);
+    };
+    if (c.clientGeometryChanged) c.clientGeometryChanged.connect(onGeometry);
+    if (c.frameGeometryChanged) c.frameGeometryChanged.connect(onGeometry);
+    if (c.interactiveMoveResizeFinished)
+        c.interactiveMoveResizeFinished.connect(function () {
+            if (neruReportable(c)) neruPush(c);
+        });
+    if (c.minimizedChanged)
+        c.minimizedChanged.connect(function () {
+            if (c.minimized) neruRefocus(c, "minimized");
+        });
+}
+workspace.windowAdded.connect(neruWatch);
+workspace.windowActivated.connect(neruActivated);
+workspace.windowRemoved.connect(function (c) { neruRefocus(c, "closed"); });
+var neruOpen = workspace.stackingOrder;
+for (var neruI = 0; neruI < neruOpen.length; neruI++) neruWatch(neruOpen[neruI]);
+neruActivated(workspace.activeWindow);
+`

--- a/internal/adapter/platform/linux/system_focused_window.go
+++ b/internal/adapter/platform/linux/system_focused_window.go
@@ -111,9 +111,11 @@ func waylandFocusedWindowBounds(backend string) (image.Rectangle, bool, error) {
 // on its own, so a session bus that was not up yet is usually resolved before
 // anything asks rather than at the expense of whoever asks first.
 //
-// Nothing leaves this process on a session that is not running KWin: the
-// install probes for it on the bus before it exports, owns a name or writes a
-// script (#1430).
+// Nothing is exported, owned or written on a session that is not running KWin:
+// the install probes for it on the bus before it does any of those (#1430). It
+// does subscribe to the bus first, so it hears a compositor that starts after
+// the daemon — which is a subscription rather than a claim, and the KWin bridge
+// says why that is the one thing worth doing ahead of the probe.
 func warmFocusedWindowSource(backend string) {
 	if backend != backendWaylandKDE {
 		return


### PR DESCRIPTION
## Description

This PR fixes anything scoped to "the focused window" answering with a stale
rectangle on KDE Plasma. The bridge that answers where the focused window is
only ever heard about activation, so a window dragged, resized, tiled or
maximized without losing focus kept its old position, and once any window had
been seen the answer never emptied — after the last one closed, "where is the
focused window" was still the rectangle the dead window had. Hints landed at the
old position, and `neru action move_mouse --window` moved the pointer there.

The bridge now also hears the focused window's geometry change and hears it go
away, so the answer follows a drag, a resize, a tile or a maximize, and empties
when the desktop is focused, the window is minimized, or the last one closes. It
also survives the compositor restarting: what Neru installs lives inside KWin,
so a `kwin --replace` or a Plasma crash used to leave the cached rectangle
frozen and served as the truth for the rest of the session. Neru now notices and
reinstalls, with nothing to restart by hand.

Separately, the cached rectangle now carries which window it belongs to. It was
matched to the window being read by size alone, so two same-sized windows were
indistinguishable and hints meant for one could be offset to the other's screen
position. Where either side reports no identity — nothing does on X11 or GNOME —
the check stands aside rather than refusing: a wrong refusal costs misplaced
hints on every activation, while a wrong acceptance costs no more than having no
check at all.

One deliberate limitation: a drag reports its final rectangle rather than every
frame, so a query made mid-drag reads the position the drag started from.

## Related Issues

Closes #972.

Also removes the two limitations #1489 documented and left behind — a window
moved or resized without a focus change, and the answer never emptying after the
last window closed.

## Target Platform

<!-- Check all that apply: -->

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) —
      the window-origin contract widened, and the compositor with no source of
      its own still refuses by name rather than reporting an absent window
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

**No KDE machine was available.** Everything Go-side is under unit test,
including the cache emptying, the compositor-restart handling and every branch
of the identity check. The compositor script itself cannot be tested in this
repo at all, so it is written against the KWin 6 scripting API and reviewed
rather than run. Three things are worth a look on a real session: move a window
without refocusing it and check the pointer lands in it; close the last window
and check the answer becomes "nothing focused" rather than the dead rectangle;
minimize a *background* window and check hints in the focused one stay in place.

**Everything here is Linux build-tagged,** so `just lint-cross` and the
containerised Linux suites (CGO on and CGO off) were run alongside `just ci`.

**Nothing user-facing changes** — no config option, command, flag or
environment variable is added, renamed or given a new meaning, and no existing
config or invocation behaves differently. The bridge's internal message format
did gain fields, but both ends of it ship in the same binary, and a message
without them still parses and simply carries no identity to correlate.

Three decisions worth a second opinion:

- **The compositor-restart watch is armed before KWin is known to be there,**
  which is the one thing the bridge does ahead of that check. It stays inside
  what #1430 asked for — a match rule is a subscription, not a claim: nothing is
  exported, no bus name is owned and nothing is written to disk until KWin has
  answered for itself. Arming it only after a successful install would have
  armed it only where it was least needed, since the session that most wants it
  is the one whose daemon started before the compositor.
- **Both of the compositor's application identifiers are carried, and either may
  be the one that matches.** They disagree for XWayland windows, and which of
  them the focused-app identity derives from is the compositor's business rather
  than something worth guessing at here.
- **The window-title comparison accepts a prefix in either direction,** because
  KWin appends its own suffixes to a caption (a window shortcut, a hostname, a
  marker when two windows share a title). An exact comparison would have
  permanently unoffset hints in any window carrying one. The cost is that two
  windows whose titles agree up to that marker are not told apart — which is
  already true of identical titles everywhere else in frame selection.

A drag is skipped while it is in progress rather than throttled, because the
compositor emits a geometry signal per frame and each one would be a message
sent off the compositor's own thread. That is the source of the mid-drag
limitation noted above.
