### PR TITLE
fix(logging): keep the daemon log per-user and out of its own content

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1533,6 +1533,17 @@ systemd user unit on Linux; where the Linux unit is written, what it contains,
 and what happens on a machine booted by another init system are in
 [LINUX_SETUP.md](LINUX_SETUP.md#systemd-user-service).
 
+The macOS agent leaves the daemon's standard output alone — the rotated log file
+already holds every log line — and sends its standard error to
+`~/Library/Logs/neru/daemon.err.log`, beside that log file, where a crash or a
+failure raised before the log file is open ends up. Both stay inside the user's
+own log directory; neither goes to a shared path.
+
+An agent installed by an earlier version wrote those two streams to `/tmp`
+instead, and installing over it is refused rather than silently rewritten. To
+move an existing one, run `neru services uninstall && neru services install`,
+then delete the files it left behind at `/tmp/neru.log` and `/tmp/neru.err.log`.
+
 `status` reports a machine where the service was never installed as exactly
 that, rather than failing.
 

--- a/internal/adapter/logger/logger_path.go
+++ b/internal/adapter/logger/logger_path.go
@@ -9,6 +9,20 @@ import (
 // defaultLogFilePath returns the platform default neru log file path when
 // [logging].log_file is empty.
 func defaultLogFilePath() (string, error) {
+	logDir, err := DefaultLogDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(logDir, "app.log"), nil
+}
+
+// DefaultLogDir returns the per-user directory neru writes its logs to. It is
+// exported because the daemon's log file is not the only thing that belongs
+// there: a service definition redirecting the daemon's stderr needs the same
+// directory, and a second spelling of it would be a second answer to where
+// neru's logs live.
+func DefaultLogDir() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
@@ -38,5 +52,5 @@ func defaultLogFilePath() (string, error) {
 		logDir = filepath.Join(stateHome, "neru", "log")
 	}
 
-	return filepath.Join(logDir, "app.log"), nil
+	return logDir, nil
 }

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -73,9 +73,12 @@ func (a *App) SetConfigField(ctx context.Context, key, value string) error {
 			"config set at runtime but failed to persist (the change will not survive a restart)")
 	}
 
+	// Only the key: it names a schema field. The value is what the user typed,
+	// and the log is not a place config content goes — the same rule the IPC
+	// controller states in handleConfigSetInMemory.
 	a.logger.Info("Config field updated at runtime",
 		zap.String("key", key),
-		zap.String("value", value),
+		zap.Int("value_length", len(value)),
 	)
 
 	return nil

--- a/internal/app/sequence/executor.go
+++ b/internal/app/sequence/executor.go
@@ -2,6 +2,7 @@ package sequence
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"strings"
 
@@ -341,11 +342,17 @@ func (e *Executor) shell(ctx context.Context, source, actionStr string) error {
 
 	commandOutput, commandErr := command.CombinedOutput()
 	if commandErr != nil {
+		// The command string and its output are the two things this must not
+		// write down: the command is config content, and the output is whatever
+		// the user's own shell printed. Their sizes and the exit code say as
+		// much about the failure as the log is entitled to know — matching the
+		// success path below, and the caller still receives the wrapped error.
 		e.logger.Error(
 			"exec step failed",
 			zap.String("source", source),
-			zap.String("cmd", cmdString),
-			zap.ByteString("output", commandOutput),
+			zap.Int("cmd_length", len(cmdString)),
+			zap.Int("output_bytes", len(commandOutput)),
+			zap.Int("exit_code", exitCodeOf(commandErr)),
 			zap.Error(commandErr),
 		)
 
@@ -360,6 +367,19 @@ func (e *Executor) shell(ctx context.Context, source, actionStr string) error {
 	)
 
 	return nil
+}
+
+// exitCodeOf reports the exit status behind a failed command, or -1 when the
+// command never ran far enough to have one (a missing shell, a timeout, a
+// signal). It exists so the failure log can be specific about *how* the step
+// failed without quoting anything the command said.
+func exitCodeOf(commandErr error) int {
+	var exitErr *exec.ExitError
+	if errors.As(commandErr, &exitErr) {
+		return exitErr.ExitCode()
+	}
+
+	return -1
 }
 
 // stepContext builds the context each step of a sequence runs under: the base

--- a/internal/architecture/daemon_log_test.go
+++ b/internal/architecture/daemon_log_test.go
@@ -1,0 +1,240 @@
+package architecture_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// visibleLogLevels are the zap logger methods that write at or above the
+// default threshold, which is info. A daemon logging at its defaults emits
+// every one of these, so what they carry reaches a file on disk on a machine
+// nobody configured.
+//
+// Debug is deliberately absent: it is opt-in, and the rule this file pins is
+// about what a default install writes down.
+var visibleLogLevels = map[string]bool{
+	"Info": true, "Warn": true, "Error": true,
+	"DPanic": true, "Panic": true, "Fatal": true,
+}
+
+// contentFieldNames are the zap field names that mean "the thing itself" rather
+// than a fact about it: a config value the user typed, a shell command line
+// from their configuration, or what that command printed. AGENTS.md forbids all
+// three — counts, durations, IDs and booleans are what a log is entitled to.
+//
+// The match is on the exact name, which is what leaves the correct idiom
+// spelling itself: cmd_length and output_bytes say the same thing about the
+// same data and pass, because a length is not the content.
+var contentFieldNames = map[string]bool{
+	"cmd": true, "command": true, "output": true, "value": true,
+}
+
+// TestNoVisibleLogFieldNamesConfigValuesOrCommandOutput pins the half of the
+// privacy contract a reviewer cannot hold on their own.
+//
+// Every field here was correct once. The failure path of an exec step logged
+// the command line and its combined output at Error while the success path
+// three lines below logged only their sizes, and two config-set paths logged
+// the value beside the key while the IPC controller beside them explained in a
+// comment why it must not. The regression is invisible in review precisely
+// because each site reads like helpful diagnostics.
+//
+// This reads the call, not the data: a field constructed elsewhere and passed
+// in by variable is not caught. That is the trade for a check with no false
+// positives — the shape it does catch is the shape every one of these
+// regressions took.
+func TestNoVisibleLogFieldNamesConfigValuesOrCommandOutput(t *testing.T) {
+	var offenders []string
+
+	fset := token.NewFileSet()
+	inspected := 0
+
+	for _, file := range goFiles(t) {
+		parsed, parseErr := parser.ParseFile(fset, file.absPath, nil, 0)
+		if parseErr != nil {
+			t.Fatalf("ParseFile(%s) error = %v", file.relPath, parseErr)
+		}
+
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			call, isCall := node.(*ast.CallExpr)
+			if !isCall {
+				return true
+			}
+
+			selector, isSelector := call.Fun.(*ast.SelectorExpr)
+			if !isSelector || !visibleLogLevels[selector.Sel.Name] {
+				return true
+			}
+
+			names := zapFieldNames(call.Args)
+			if len(names) == 0 {
+				return true
+			}
+
+			inspected++
+
+			for _, name := range names {
+				if !contentFieldNames[name] {
+					continue
+				}
+
+				offenders = append(offenders,
+					fset.Position(call.Pos()).String()+"\t"+
+						selector.Sel.Name+"("+strconv.Quote(name)+")")
+			}
+
+			return true
+		})
+	}
+
+	assertWalkedAtLeast(t, "log calls above debug level", inspected, bulkWalkFloor)
+
+	reportOffenders(t, offenders,
+		"log call names the content itself rather than a fact about it; "+
+			"log a length, a count or an exit code instead, and let the error "+
+			"returned to the caller carry the detail")
+}
+
+// outputRedirectMarkers are the ways this repository decides where the daemon's
+// standard output and standard error go: the two launchd plist keys, and the
+// detached launch the macOS installer offers. A file naming one of them is a
+// file that answers "where does the daemon's output land".
+var outputRedirectMarkers = []string{
+	"StandardOutPath", "StandardErrorPath", "nohup",
+}
+
+// sharedTempPaths are the directories every local user can read and write.
+// macOS mounts /tmp mode 1777 and shares it across users, unlike the per-user
+// $TMPDIR, so a log parked there is readable by anyone logged in and its name
+// is plantable by anyone who gets there first.
+var sharedTempPaths = []string{"/tmp/", "/var/tmp/"}
+
+// TestNoServiceDefinitionWritesDaemonOutputToASharedPath keeps the daemon's
+// output in the user's own log directory.
+//
+// The service definitions are written four times over — the plist the CLI
+// generates, the plist template shipped for a hand install, the installer
+// script's detached launch, and the Nix modules — so the answer to where a log
+// goes is only as good as the copy nobody remembered to change. This judges
+// every file that decides it, whatever language it is written in.
+//
+// A file that redirects nothing drops out of the subject set, which is the
+// intended behavior: it has no answer to be wrong about, and adding a redirect
+// back puts it under this rule again.
+func TestNoServiceDefinitionWritesDaemonOutputToASharedPath(t *testing.T) {
+	subjects := 0
+
+	walkRepoFiles(t, findRepoRoot(t), func(file repoFile) {
+		// This package's own files name the markers to describe the rule.
+		if file.dir == architecturePackageDir {
+			return
+		}
+
+		// A test file installs no service. One of them asserts that the plist
+		// it renders names no shared directory, which means quoting the
+		// directory — a subject set that judged it would be judging the rule's
+		// own statement of itself.
+		if strings.HasSuffix(file.name, "_test.go") {
+			return
+		}
+
+		// The walk hands over symlinks without following them, and one of them
+		// points at a directory (.claude/skills), which is not a file to read.
+		info, statErr := os.Lstat(file.abs)
+		if statErr != nil {
+			t.Fatalf("Lstat(%s) error = %v", file.rel, statErr)
+		}
+
+		if !info.Mode().IsRegular() {
+			return
+		}
+
+		content, readErr := os.ReadFile(file.abs)
+		if readErr != nil {
+			t.Fatalf("ReadFile(%s) error = %v", file.rel, readErr)
+		}
+
+		text := string(content)
+
+		if !containsAny(text, outputRedirectMarkers) {
+			return
+		}
+
+		subjects++
+
+		for _, shared := range sharedTempPaths {
+			if !strings.Contains(text, shared) {
+				continue
+			}
+
+			t.Errorf(
+				"%s decides where the daemon's output goes and names %s, which "+
+					"every local user can read and plant a symlink in; use the "+
+					"per-user log directory the logger already resolves",
+				file.rel, shared,
+			)
+		}
+	})
+
+	assertWalkedAtLeast(t, "files redirecting daemon output", subjects, serviceDefinitionFloor)
+}
+
+// serviceDefinitionFloor is the fewest files expected to redirect the daemon's
+// output. Four do today — the generated plist, the shipped template, the
+// installer script and the home-manager module — so three catches a check that
+// has stopped recognizing them without firing when one legitimately stops
+// redirecting.
+const serviceDefinitionFloor = 3
+
+// containsAny reports whether text contains any of the needles.
+func containsAny(text string, needles []string) bool {
+	for _, needle := range needles {
+		if strings.Contains(text, needle) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// zapFieldNames returns the field names of the zap.X("name", …) constructors
+// among args, which is how every structured log call in this tree is written.
+func zapFieldNames(args []ast.Expr) []string {
+	var names []string
+
+	for _, arg := range args {
+		call, isCall := arg.(*ast.CallExpr)
+		if !isCall || len(call.Args) == 0 {
+			continue
+		}
+
+		selector, isSelector := call.Fun.(*ast.SelectorExpr)
+		if !isSelector {
+			continue
+		}
+
+		pkg, isIdent := selector.X.(*ast.Ident)
+		if !isIdent || pkg.Name != "zap" {
+			continue
+		}
+
+		literal, isLiteral := call.Args[0].(*ast.BasicLit)
+		if !isLiteral || literal.Kind != token.STRING {
+			continue
+		}
+
+		name, unquoteErr := strconv.Unquote(literal.Value)
+		if unquoteErr != nil {
+			continue
+		}
+
+		names = append(names, name)
+	}
+
+	return names
+}

--- a/internal/architecture/doc.go
+++ b/internal/architecture/doc.go
@@ -27,6 +27,8 @@
 //     chain rather than recomputed at its reader.
 //   - config_example_test.go — the pairing between the config schema and the
 //     example TOML shipped with it.
+//   - daemon_log_test.go — the daemon's log carries facts rather than content,
+//     and every service definition sends its output to a per-user path.
 //   - darwin_entry_point_headers_test.go — every non-static Neru* entry point
 //     the darwin bridge defines is declared in its own subsystem's header.
 //   - dependency_boundary_test.go — the darwin One Rule: only darwin-tagged

--- a/internal/cli/services_darwin.go
+++ b/internal/cli/services_darwin.go
@@ -11,6 +11,8 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+
+	"github.com/y3owk1n/neru/internal/adapter/logger"
 )
 
 const (
@@ -18,6 +20,16 @@ const (
 	launchAgentsDir = "~/Library/LaunchAgents"
 	plistFile       = launchAgentsDir + "/" + serviceLabel + ".plist"
 )
+
+// daemonStderrFileName is the file the login agent's standard error is
+// redirected to, inside the per-user log directory the logger already owns.
+//
+// Standard output is deliberately not redirected: the logger's console core
+// writes every log line there, so a redirect would duplicate app.log into a
+// second, unrotated file. Standard error carries what app.log cannot — a panic,
+// a native crash, or a startup failure raised before the file sink exists — so
+// it is the half worth keeping.
+const daemonStderrFileName = "daemon.err.log"
 
 const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -34,10 +46,8 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <true/>
     <key>KeepAlive</key>
     <true/>
-    <key>StandardOutPath</key>
-    <string>/tmp/neru.log</string>
     <key>StandardErrorPath</key>
-    <string>/tmp/neru.err.log</string>
+    <string>NERU_STDERR_PATH</string>
     <key>ProcessType</key>
     <string>Interactive</string>
     <key>LimitLoadToSessionType</key>
@@ -60,6 +70,28 @@ var (
 	)
 	errPlistAlreadyExists = errors.New("plist file already exists")
 )
+
+// daemonStderrPath returns the absolute file the login agent's stderr is
+// redirected to. The plist is read by launchd, which expands nothing, so this
+// resolves the home directory rather than writing a "~" into it.
+func daemonStderrPath() (string, error) {
+	logDir, err := logger.DefaultLogDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(logDir, daemonStderrFileName), nil
+}
+
+// renderPlist fills the launchd agent template in with the two absolute paths
+// launchd cannot work out for itself: the binary to run, and the file its
+// standard error is appended to.
+func renderPlist(binPath, stderrPath string) string {
+	return strings.NewReplacer(
+		"NERU_BINARY_PATH", binPath,
+		"NERU_STDERR_PATH", stderrPath,
+	).Replace(plistTemplate)
+}
 
 func getBinaryPath() (string, error) {
 	execPath, err := os.Executable()
@@ -87,7 +119,21 @@ func installService() error {
 		return fmt.Errorf("failed to get binary path: %w", err)
 	}
 
-	plistContent := strings.ReplaceAll(plistTemplate, "NERU_BINARY_PATH", binPath)
+	// launchd opens the redirect itself, before neru runs, and it creates the
+	// file but never the directory holding it — so the directory has to exist
+	// by the time the agent is bootstrapped or the first launch's stderr, which
+	// is the launch most likely to fail, goes nowhere.
+	stderrPath, err := daemonStderrPath()
+	if err != nil {
+		return fmt.Errorf("failed to resolve the log directory: %w", err)
+	}
+
+	err = os.MkdirAll(filepath.Dir(stderrPath), logger.DefaultDirPerms)
+	if err != nil {
+		return fmt.Errorf("failed to create the log directory: %w", err)
+	}
+
+	plistContent := renderPlist(binPath, stderrPath)
 
 	expandedDir, err := expandPath(launchAgentsDir)
 	if err != nil {

--- a/internal/cli/services_darwin.go
+++ b/internal/cli/services_darwin.go
@@ -83,13 +83,20 @@ func daemonStderrPath() (string, error) {
 	return filepath.Join(logDir, daemonStderrFileName), nil
 }
 
+// plistTextEscaper escapes what cannot appear literally inside a plist
+// <string> element. A filesystem path is arbitrary text as far as XML is
+// concerned — a directory called "A&B" is perfectly legal on macOS — and an
+// unescaped one produces a plist launchctl refuses to load, leaving a file
+// behind that the next install then refuses to write over.
+var plistTextEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+
 // renderPlist fills the launchd agent template in with the two absolute paths
 // launchd cannot work out for itself: the binary to run, and the file its
 // standard error is appended to.
 func renderPlist(binPath, stderrPath string) string {
 	return strings.NewReplacer(
-		"NERU_BINARY_PATH", binPath,
-		"NERU_STDERR_PATH", stderrPath,
+		"NERU_BINARY_PATH", plistTextEscaper.Replace(binPath),
+		"NERU_STDERR_PATH", plistTextEscaper.Replace(stderrPath),
 	).Replace(plistTemplate)
 }
 

--- a/internal/cli/services_internal_darwin_test.go
+++ b/internal/cli/services_internal_darwin_test.go
@@ -1,0 +1,74 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDaemonStderrPath_ResolvesUnderTheUserOwnLogDirectory pins where the login
+// agent's standard error lands. launchd expands nothing it reads out of a
+// plist, so a "~" or a "$HOME" written into one is a literal directory name,
+// and the shared fallback a wrong answer used to reach is world-readable.
+func TestDaemonStderrPath_ResolvesUnderTheUserOwnLogDirectory(t *testing.T) {
+	home, homeErr := os.UserHomeDir()
+	if homeErr != nil {
+		t.Skipf("no home directory on this machine: %v", homeErr)
+	}
+
+	got, err := daemonStderrPath()
+	if err != nil {
+		t.Fatalf("daemonStderrPath() error = %v", err)
+	}
+
+	want := filepath.Join(home, "Library", "Logs", "neru", "daemon.err.log")
+	if got != want {
+		t.Errorf("daemonStderrPath() = %q, want %q", got, want)
+	}
+}
+
+// TestRenderPlist_SendsOutputOnlyToThePathItIsGiven pins the plist the agent is
+// installed from: the stderr redirect names the file it was handed, nothing
+// names a shared directory, and standard output is left unredirected, since the
+// rotated log file already holds every log line the console core writes there.
+func TestRenderPlist_SendsOutputOnlyToThePathItIsGiven(t *testing.T) {
+	const (
+		binPath    = "/Users/tester/bin/neru"
+		stderrPath = "/Users/tester/Library/Logs/neru/daemon.err.log"
+	)
+
+	plist := renderPlist(binPath, stderrPath)
+
+	testCases := []struct {
+		name    string
+		needle  string
+		present bool
+	}{
+		{name: "runs the resolved binary", needle: binPath, present: true},
+		{
+			name:    "redirects stderr to the given file",
+			needle:  "<key>StandardErrorPath</key>\n    <string>" + stderrPath + "</string>",
+			present: true,
+		},
+		{name: "leaves stdout unredirected", needle: "StandardOutPath", present: false},
+		{name: "names no shared temp directory", needle: "/tmp", present: false},
+		{name: "leaves no placeholder behind", needle: "NERU_", present: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if strings.Contains(plist, testCase.needle) != testCase.present {
+				t.Errorf(
+					"rendered plist contains %q = %v, want %v:\n%s",
+					testCase.needle,
+					!testCase.present,
+					testCase.present,
+					plist,
+				)
+			}
+		})
+	}
+}

--- a/internal/cli/services_internal_darwin_test.go
+++ b/internal/cli/services_internal_darwin_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"encoding/xml"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,6 +69,48 @@ func TestRenderPlist_SendsOutputOnlyToThePathItIsGiven(t *testing.T) {
 					testCase.present,
 					plist,
 				)
+			}
+		})
+	}
+}
+
+// TestRenderPlist_EscapesPathsThatAreNotValidXML keeps a legal directory name
+// from producing an illegal plist. Paths are arbitrary text — "A&B" is a
+// perfectly good directory on macOS — and launchctl refuses to load a plist
+// whose XML does not parse, after the file has already been written, so the
+// next install refuses too rather than replacing it.
+func TestRenderPlist_EscapesPathsThatAreNotValidXML(t *testing.T) {
+	testCases := []struct {
+		name       string
+		binPath    string
+		stderrPath string
+		want       string
+	}{
+		{
+			name:       "ampersand in the binary path",
+			binPath:    "/Users/tester/A&B/neru",
+			stderrPath: "/Users/tester/Library/Logs/neru/daemon.err.log",
+			want:       "<string>/Users/tester/A&amp;B/neru</string>",
+		},
+		{
+			name:       "angle brackets in the log path",
+			binPath:    "/Users/tester/bin/neru",
+			stderrPath: "/Users/tester/<logs>/daemon.err.log",
+			want:       "<string>/Users/tester/&lt;logs&gt;/daemon.err.log</string>",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			plist := renderPlist(testCase.binPath, testCase.stderrPath)
+
+			if !strings.Contains(plist, testCase.want) {
+				t.Errorf("rendered plist does not contain %q:\n%s", testCase.want, plist)
+			}
+
+			decodeErr := xml.Unmarshal([]byte(plist), new(any))
+			if decodeErr != nil {
+				t.Errorf("rendered plist is not well-formed XML: %v", decodeErr)
 			}
 		})
 	}

--- a/internal/config/loader/service.go
+++ b/internal/config/loader/service.go
@@ -580,9 +580,11 @@ func (s *Service) SaveOverrideField(key, value string) error {
 		return saveErr
 	}
 
+	// The key names a schema field, which is not the user's content; the value
+	// is, and a value can be an exec command line, so only its length is logged.
 	s.logger.Info("Config override persisted",
 		zap.String("key", key),
-		zap.String("value", value),
+		zap.Int("value_length", len(value)),
 		zap.String("override_path", overridePath))
 
 	return nil

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -85,8 +85,13 @@ in
           EnvironmentVariables = effectiveEnv;
           KeepAlive = cfg.launchd.keepAlive;
           RunAtLoad = true;
-          StandardOutPath = "/tmp/neru.log";
-          StandardErrorPath = "/tmp/neru.err.log";
+          # Neither stream is redirected. This agent is installed system-wide
+          # and runs for whichever user logs in, so no per-user log path can be
+          # written here at build time, and a shared one (/tmp) would put the
+          # daemon's output where every local user can read it. Neru writes its
+          # own rotated log to ~/Library/Logs/neru/app.log regardless; for a
+          # single-user machine that also wants crash output captured, use the
+          # home-manager module, which can name the user's own log directory.
           ProcessType = "Interactive";
           LimitLoadToSessionType = "Aqua";
           Nice = -10;

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -86,7 +86,8 @@ in
               status will be a non-zero number, for example:
               `-	1	org.nix-community.home.neru`
 
-            If the app fails to launch at all, check `cat /tmp/neru.err.log` for launch errors.
+            If the app fails to launch at all, check
+            `cat ~/Library/Logs/neru/daemon.err.log` for launch errors.
 
             For more detailed service status, run `launchctl print gui/$(id -u)/org.nix-community.home.neru`.
           '';
@@ -171,8 +172,18 @@ in
         EnvironmentVariables = effectiveEnv;
         RunAtLoad = true;
         KeepAlive = cfg.launchd.keepAlive;
-        StandardOutPath = "/tmp/neru.log";
-        StandardErrorPath = "/tmp/neru.err.log";
+        # Standard output is left alone: Neru's own rotated log file already
+        # holds every log line. Standard error goes beside it, in the user's own
+        # log directory rather than a shared one, for a crash or a failure
+        # raised before that file is open.
+        #
+        # launchd creates the file but never the directory holding it, and the
+        # directory is created by Neru itself on its first run — so on a machine
+        # that has never run Neru, the very first spawn has nowhere to redirect
+        # to and launchd drops its stderr. Every spawn after that one is
+        # captured. (`neru services install`, which writes its own agent, closes
+        # that gap by creating the directory before bootstrapping.)
+        StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/neru/daemon.err.log";
         ProcessType = "Interactive";
         LimitLoadToSessionType = "Aqua";
         Nice = -10;

--- a/resources/com.y3owk1n.neru.plist.template
+++ b/resources/com.y3owk1n.neru.plist.template
@@ -13,10 +13,14 @@
     <true/>
     <key>KeepAlive</key>
     <true/>
-    <key>StandardOutPath</key>
-    <string>/tmp/neru.log</string>
+    <!-- Standard output is not redirected: neru's own log file already holds
+         every log line, rotated, at ~/Library/Logs/neru/app.log. Standard error
+         catches what that file cannot — a crash, or a failure before the log
+         file is open — so it goes beside it. launchd expands nothing, so
+         NERU_STDERR_PATH must be replaced with an absolute path inside your own
+         home directory; never a shared one such as /tmp. -->
     <key>StandardErrorPath</key>
-    <string>/tmp/neru.err.log</string>
+    <string>NERU_STDERR_PATH</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -274,7 +274,7 @@ esac
 
 # If the login agent was installed it is already running Neru. Otherwise
 # nothing is running yet, so offer to launch the daemon once, detached so
-# it survives this shell (logs mirror the launchd agent's paths).
+# it survives this shell (output goes where the launchd agent's does).
 if [ "$service_installed" -eq 1 ]; then
     echo "Neru runs as a login agent and should be running now."
 else
@@ -287,8 +287,18 @@ else
             if "$neru_bin" status >/dev/null 2>&1; then
                 echo "Neru is already running."
             else
-                nohup "$neru_bin" launch >/tmp/neru.log 2>/tmp/neru.err.log &
-                echo "Launching Neru (logs: /tmp/neru.log)."
+                # Standard output is dropped: Neru's own rotated log file
+                # already holds every log line. Standard error is kept
+                # beside that file, for a crash or a failure raised before
+                # it is open — and dropped as well if the directory cannot
+                # be created, rather than failing an install over a log.
+                log_dir="$HOME/Library/Logs/neru"
+                err_log=/dev/null
+                if mkdir -p "$log_dir" 2>/dev/null; then
+                    err_log="$log_dir/daemon.err.log"
+                fi
+                nohup "$neru_bin" launch >/dev/null 2>>"$err_log" &
+                echo "Launching Neru (logs: $log_dir/app.log)."
             fi
             ;;
         *)


### PR DESCRIPTION
## Description

This PR moves the daemon's log output out of `/tmp` and into the user's own log
directory, and stops three log lines from writing down content instead of facts
about it.

On macOS the login agent used to send the daemon's standard output and standard
error to `/tmp/neru.log` and `/tmp/neru.err.log`. `/tmp` is shared between every
account on the machine, and the standard-output copy was a duplicate of the
rotated log file Neru already writes and documents. Standard output is now left
unredirected, and standard error goes to `~/Library/Logs/neru/daemon.err.log`,
beside `app.log`, so a crash or a startup failure raised before the log file is
open still lands somewhere readable. The plist the CLI generates, the template
shipped for a hand install, the macOS installer script and both Nix modules all
move together, and `neru services install` now creates the log directory before
launchd is asked to write into it.

Separately, three log fields carried the thing itself rather than a fact about
it: a failed `exec` sequence step logged the whole command line and its combined
output at error level, and the two config-set paths logged the value beside the
key at info level. Configuration values can be shell command lines, and the
output is whatever the user's own command printed — neither belongs in a log
file, per the logging rule in `AGENTS.md`. Those sites now log a length, a byte
count and an exit code; the error handed back to whoever ran the command is
unchanged, so no diagnostic detail is lost where it was actually being read.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [x] `fix` — Bug fix

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability changes; the launchd work is inside the existing `//go:build darwin` service file and the logger's path helper already covers all three platforms.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## User-facing surface

No config option, command or flag changes. What changes is where the macOS login
agent's output goes:

| | Before | After |
| --- | --- | --- |
| stdout | `/tmp/neru.log` | not redirected — `~/Library/Logs/neru/app.log` already holds every log line |
| stderr | `/tmp/neru.err.log` | `~/Library/Logs/neru/daemon.err.log` |

`neru services install` creates `~/Library/Logs/neru` itself, so a fresh install
captures its first launch. The nix-darwin module redirects neither stream: that
agent is installed system-wide and runs as whichever user logs in, so no per-user
path can be written into it at build time, and the shared one was the thing being
removed. The home-manager module names the user's own path.

## Potentially breaking

An agent installed by an earlier version keeps its old plist — installing over an
existing one is refused rather than silently rewritten, which is deliberate. A
user who wants the new location runs `neru services uninstall && neru services
install` and deletes the two files left in `/tmp`. `docs/CLI.md` now says so under
`neru services`. Anyone tailing `/tmp/neru.log` out of habit should tail
`~/Library/Logs/neru/app.log` instead, which is the path the troubleshooting docs
have always given.

## Additional Context

Two guardrails keep both halves from drifting back, since both regressions are
the kind that read like helpful diagnostics in review:

- no log call above debug level may name a field `value`, `output`, `cmd` or
  `command` — the correct substitutes (`cmd_length`, `output_bytes`) spell
  themselves, since a length is not the content;
- no file that decides where the daemon's output goes, in any language, may name
  a shared temp directory. A file that redirects nothing drops out of the subject
  set; adding a redirect back puts it under the rule again.

The `exec` step's debug-level log of the command string is untouched: debug is
opt-in, and this change is about what a default install writes down.

One thing found while writing the second path into the plist and fixed here too:
the paths were being substituted into the XML unescaped, so a binary living under
a directory called `A&B` — legal on macOS — produced a plist launchctl refuses to
load, after the file had already been written, which then made the next install
refuse as well. Both substitutions are escaped now.
