### PR TITLE
chore(deps): build with Go 1.26.6 to pick up the encoding/asn1 fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/y3owk1n/neru
 
 go 1.26.4
 
+toolchain go1.26.6
+
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/Microsoft/go-winio v0.6.2

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -243,9 +243,17 @@ else
       CGO_CFLAGS_ALLOW = "-fno-strict-overflow";
     };
 
-    # Allow Go to use any available toolchain
+    # Build with the toolchain nixpkgs ships, never a downloaded one. go.mod
+    # carries a `toolchain` line pointing at a Go patch release newer than
+    # nixpkgs has, so that everyone building with a network — contributors, CI,
+    # the release workflow — picks up the fixed standard library. This sandbox
+    # has no network, so honouring that line would fail the build outright
+    # rather than silently fall back. `local` ignores it and uses the nixpkgs
+    # Go, which still satisfies the `go` directive (the actual floor). Nix
+    # builds therefore track nixpkgs' Go patch level, as they always have, and
+    # pick the fixed standard library up when nixpkgs does.
     preBuild = ''
-      export GOTOOLCHAIN=auto
+      export GOTOOLCHAIN=local
     '';
 
     postInstall = ''


### PR DESCRIPTION
## Description

This PR builds Neru with Go 1.26.6, so the standard library it ships no longer
carries the unbounded-recursion flaw in ASN.1 parsing published as
[GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972). The vulnerability scan on
Linux turned red on every branch the moment that advisory was published — no
code changed, and the scan fetches the advisory database live. The macOS scan
stays green because the affected path is only reachable through the way Linux
loads certificate roots.

The new version goes in as a `toolchain` line rather than as a bump of the
minimum `go` directive. The floor stays exactly where it was, so anything that
has to build with an older Go keeps working — most importantly the Nix
from-source package, which builds with whatever Go nixpkgs carries and cannot
choose otherwise. Everywhere with a network — contributors, CI, and the release
workflow — now moves to 1.26.6 on its own.

The Nix build is told explicitly to use the toolchain nixpkgs gives it, since
its sandbox has no network and could not fetch a newer one; without that it
would fail outright rather than fall back. Nix source builds therefore keep
tracking nixpkgs' Go patch level, as they always have, and pick the fixed
standard library up when nixpkgs does.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality — N/A, there is no
      behaviour to test; the vulnerability scan is itself the check this change
      exists to satisfy
- [x] Documentation updated (if applicable) — N/A, the Nix packaging carries
      its own explanation in a comment, and the documented `go.mod` patch for
      Nix source users still applies verbatim because the `go` directive is
      unchanged
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

**Why not simply bump the `go` directive.** Go 1.26.6 has not reached nixpkgs.
The revision pinned in `flake.lock` ships 1.26.5, and so do `nixos-unstable`,
`nixpkgs-unstable` and `master` as of this PR — so updating the flake lock would
not help either. Raising the floor to 1.26.6 would therefore break the Nix
from-source build on every channel, since it builds without network access:
it would either reject the requirement outright or try to download a toolchain
it cannot reach. It would also invalidate the `go.mod` patch documented for Nix
source users in `docs/INSTALLATION.md`, which rewrites the `go` line by exact
text. Leaving the floor alone avoids both.

**Verification.** The failing Linux scan reproduces from a macOS host by
scanning with `GOOS=linux`, which is how the change was checked:

- before: `Vulnerability #1: GO-2026-5972 … Found in: encoding/asn1@go1.26.4`,
  reached from an `asn1.Unmarshal` call in the daemon's cleanup path
- after: `No vulnerabilities found.`

The scanner also now reports `Go: go1.26.6` where it previously reported
`go1.26.4`, confirming the toolchain switch reaches the exact command `just
vuln` runs. On the CI runner the switch happens twice over: `actions/setup-go`
v6 and later read the `toolchain` directive from `go.mod` in preference to the
`go` directive and install 1.26.6 directly, and even if it installed the older
one, Go itself would switch on the `toolchain` line before the scan ran.

**Two things worth a second look.** The Nix change was verified by building
`.#source` end to end locally, which succeeded — including the man-page
generation step that runs after the build, confirming the setting holds for the
whole derivation. An empty-cache, no-network probe separately confirmed the
previous `auto` setting would have failed once the `toolchain` line existed.
Separately,
`publish-artifacts.yml` hardcodes `go-version: "1.26.4"` in six places — those
runs now switch to 1.26.6 via the `toolchain` line rather than the pin, so
released binaries do get the fixed standard library, but the pins are stale and
misleading and are worth tidying in their own change.

**One caveat.** A contributor building with no network and a Go older than
1.26.6 will now get a toolchain-download error where the build previously
worked. Anyone in that position can set `GOTOOLCHAIN=local` to build against
their own Go, exactly as the Nix build does.
