### PR TITLE
fix(windows): keep the daemon alive across thousands of mode activations

### DIFF
--- a/internal/adapter/platform/windows/callbacks_integration_test.go
+++ b/internal/adapter/platform/windows/callbacks_integration_test.go
@@ -1,0 +1,191 @@
+//go:build integration && windows
+
+package windows
+
+import (
+	"syscall"
+	"testing"
+)
+
+// Real Win32 tests for the process-wide callback registrations.
+//
+// Go's runtime keys registered callbacks on the function value, never frees a
+// slot, and has a fixed cb_max = 2000 of them (runtime/zcallback_windows.go).
+// A path that registers one per call therefore ends the process on "too many
+// callback functions" — a runtime throw, unrecoverable — after enough mode
+// activations. These tests count the slots a workload consumes and require the
+// answer to be zero.
+//
+// They are in-package because the enumeration path they drive is unexported,
+// and integration-tagged because they call the live Win32 APIs.
+
+// callbackWorkloadRuns is how many times a workload is repeated inside a
+// measurement. The count only has to be large enough that "one per run" is
+// unmistakable next to "one for the process"; the measurement is exact, so
+// there is no need to approach the table's size and no reason to install two
+// thousand real keyboard hooks to prove it.
+const callbackWorkloadRuns = 20
+
+// newCallbackProbe registers one throwaway callback and returns its address.
+//
+// The closure captures tag so that each probe is a distinct function value:
+// the runtime returns the existing slot for a function value it has already
+// seen, and two identical non-capturing literals may share one static value.
+func newCallbackProbe(tag int) uintptr {
+	return syscall.NewCallback(func() uintptr {
+		return uintptr(tag)
+	})
+}
+
+// countCallbackRegistrations reports how many callback slots work consumed.
+//
+// It reads the one property the runtime exposes without an API: a registered
+// callback's address is its slot index into a single contiguous table, so
+// consecutive registrations sit a fixed stride apart. Two probes before the
+// workload measure that stride, a third after it measures the gap, and the
+// slots work took are the ones in between.
+//
+// A runtime that lays callbacks out some other way is skipped rather than
+// guessed at — a check that cannot measure must say so instead of passing.
+func countCallbackRegistrations(t *testing.T, work func()) int {
+	t.Helper()
+
+	first := newCallbackProbe(1)
+	second := newCallbackProbe(2)
+
+	if second <= first {
+		t.Skipf(
+			"skipping: callback addresses are not ascending (%#x then %#x), so this "+
+				"runtime's callback slots cannot be counted this way",
+			first, second,
+		)
+	}
+
+	stride := second - first
+
+	work()
+
+	third := newCallbackProbe(3)
+
+	if third <= second {
+		t.Fatalf(
+			"callback addresses stopped ascending (%#x then %#x); the slot count "+
+				"below would be meaningless",
+			second, third,
+		)
+	}
+
+	gap := third - second
+	if gap%stride != 0 {
+		t.Fatalf(
+			"callback addresses are %d apart after a stride of %d; the table is not "+
+				"the uniform layout this count assumes",
+			gap, stride,
+		)
+	}
+
+	return int(gap/stride) - 1
+}
+
+// TestEnumerateMonitors_RegistersOneCallbackForTheProcess holds the monitor
+// enumeration path to a single callback registration.
+//
+// enumerateMonitors is on the mode-activation path — activeScreenBounds,
+// screenBoundsByName, screenNames and NewOverlayWindow all reach it — so a
+// registration per pass was the shortest countdown of the two.
+//
+// The first pass outside the measurement is what registers that one callback.
+// The enumeration results are deliberately dropped: a headless or session-0
+// runner legitimately reports no monitors, and what is being counted is the
+// same either way.
+func TestEnumerateMonitors_RegistersOneCallbackForTheProcess(t *testing.T) {
+	_, _ = enumerateMonitors()
+
+	registered := countCallbackRegistrations(t, func() {
+		for range callbackWorkloadRuns {
+			_, _ = enumerateMonitors()
+		}
+	})
+
+	if registered != 0 {
+		t.Fatalf(
+			"%d enumeration passes registered %d callbacks; each one is a slot the "+
+				"process never gets back",
+			callbackWorkloadRuns, registered,
+		)
+	}
+}
+
+// TestEnumerateMonitors_DoesNotCarryStateBetweenPasses pins the cost of the
+// single callback: what it appends to is a package variable rather than a
+// per-call capture, so a pass that failed to install or clear it would hand the
+// caller the previous pass's monitors as well as its own.
+//
+// Two passes over an unchanged display therefore have to report the same count.
+func TestEnumerateMonitors_DoesNotCarryStateBetweenPasses(t *testing.T) {
+	first, err := enumerateMonitors()
+	if err != nil {
+		t.Skipf("skipping: no monitors to enumerate (%v)", err)
+	}
+
+	second, err := enumerateMonitors()
+	if err != nil {
+		t.Fatalf("second pass after a first that found %d monitors: %v", len(first), err)
+	}
+
+	if len(second) != len(first) {
+		t.Fatalf(
+			"consecutive passes reported %d then %d monitors; the shared collector is "+
+				"carrying state across passes",
+			len(first), len(second),
+		)
+	}
+}
+
+// TestStartKeyboardHook_RegistersOneCallbackForTheProcess holds the keyboard
+// hook to a single callback registration across install cycles.
+//
+// EventTap.Enable calls StartKeyboardHook on every enable cycle, so this is the
+// same countdown on the input path. Installing real hooks is what makes this
+// test worth having: it counts what the code path actually registers rather
+// than what the accessor returns.
+//
+// The hook's key callback returns false throughout, so every key seen while the
+// test runs is passed straight on to the rest of the system.
+func TestStartKeyboardHook_RegistersOneCallbackForTheProcess(t *testing.T) {
+	passThrough := func(string, bool) bool { return false }
+
+	warmUp, err := StartKeyboardHook(passThrough)
+	if err != nil {
+		t.Skipf("skipping: cannot install a keyboard hook here (%v)", err)
+	}
+
+	warmUp.Stop()
+
+	var installErr error
+
+	registered := countCallbackRegistrations(t, func() {
+		for range callbackWorkloadRuns {
+			hook, err := StartKeyboardHook(passThrough)
+			if err != nil {
+				installErr = err
+
+				return
+			}
+
+			hook.Stop()
+		}
+	})
+
+	if installErr != nil {
+		t.Fatalf("installing a keyboard hook after a successful first install: %v", installErr)
+	}
+
+	if registered != 0 {
+		t.Fatalf(
+			"%d install cycles registered %d callbacks; each one is a slot the process "+
+				"never gets back",
+			callbackWorkloadRuns, registered,
+		)
+	}
+}

--- a/internal/adapter/platform/windows/keyboard_hook.go
+++ b/internal/adapter/platform/windows/keyboard_hook.go
@@ -5,6 +5,7 @@ package windows
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -72,7 +73,24 @@ var (
 	procPostThreadMessageW  = user32.NewProc("PostThreadMessageW")
 	procGetCurrentThreadID  = kernel32.NewProc("GetCurrentThreadId")
 
-	activeKeyboardHook *KeyboardHook
+	// activeKeyboardHook is the hook keyboardHookProc dispatches to. It is
+	// atomic because the two sides never share a lock: run stores it under h.mu
+	// on the hook goroutine, and the hook procedure loads it on whichever
+	// thread Windows delivers the key event on.
+	activeKeyboardHook atomic.Pointer[KeyboardHook]
+
+	// keyboardHookProcPtr is the WH_KEYBOARD_LL procedure pointer
+	// SetWindowsHookExW is handed, allocated on first use and never again —
+	// for the reason monitorEnumProcPtr in win32.go carries in full: a callback
+	// slot is never freed and the process gets a fixed 2000 of them.
+	//
+	// StartKeyboardHook runs on every EventTap.Enable cycle, so a callback
+	// allocated there was spent on every mode activation. One procedure serves
+	// every hook because it carries no per-hook state: it reads
+	// activeKeyboardHook, which is whichever hook is currently installed.
+	keyboardHookProcPtr = sync.OnceValue(func() uintptr {
+		return syscall.NewCallback(keyboardHookProc)
+	})
 )
 
 var (
@@ -169,55 +187,58 @@ func (h *KeyboardHook) Stop() {
 	}
 }
 
-func (h *KeyboardHook) run() {
-	defer close(h.doneCh)
-
-	// lParam is typed unsafe.Pointer (not uintptr) so the KBDLLHOOKSTRUCT
-	// dereference is a Pointer->*T conversion, which keeps go vet's unsafeptr
-	// check happy. syscall.NewCallback accepts pointer-kind parameters.
-	hookProc := syscall.NewCallback(func(code int, wParam uintptr, lParam unsafe.Pointer) uintptr {
-		if code < 0 {
-			ret, _, _ := procCallNextHookEx.Call(0, uintptr(code), wParam, uintptr(lParam))
-
-			return ret
-		}
-
-		current := activeKeyboardHook
-		if current == nil || current.callback == nil {
-			ret, _, _ := procCallNextHookEx.Call(0, uintptr(code), wParam, uintptr(lParam))
-
-			return ret
-		}
-
-		kbd := (*kbdLLHookStruct)(lParam)
-
-		// Keys this process injected come back through this hook. Handing one
-		// to the callback would re-enter the mode handler from the hook
-		// thread, and the down/up pair a modified scroll holds reads as the
-		// user tapping that modifier — latching a sticky modifier nobody
-		// pressed. Only Neru's own injection is skipped (neruInjectedTag);
-		// another tool's synthetic input is still seen.
-		if kbd.dwExtraInfo == neruInjectedTag {
-			ret, _, _ := procCallNextHookEx.Call(0, uintptr(code), wParam, uintptr(lParam))
-
-			return ret
-		}
-
-		isUp := wParam == wmKeyUp || wParam == wmSysKeyUp || kbd.flags&llkhfUp != 0
-
-		key := hookKeyName(kbd.vkCode, isUp)
-		if key != "" && current.callback(key, isUp) {
-			return 1
-		}
-
+// keyboardHookProc is the WH_KEYBOARD_LL procedure Windows calls for every key
+// event, for whichever hook is currently installed.
+//
+// lParam is typed unsafe.Pointer (not uintptr) so the KBDLLHOOKSTRUCT
+// dereference is a Pointer->*T conversion, which keeps go vet's unsafeptr
+// check happy. syscall.NewCallback accepts pointer-kind parameters.
+func keyboardHookProc(code int, wParam uintptr, lParam unsafe.Pointer) uintptr {
+	if code < 0 {
 		ret, _, _ := procCallNextHookEx.Call(0, uintptr(code), wParam, uintptr(lParam))
 
 		return ret
-	})
+	}
+
+	current := activeKeyboardHook.Load()
+	if current == nil || current.callback == nil {
+		ret, _, _ := procCallNextHookEx.Call(0, uintptr(code), wParam, uintptr(lParam))
+
+		return ret
+	}
+
+	kbd := (*kbdLLHookStruct)(lParam)
+
+	// Keys this process injected come back through this hook. Handing one
+	// to the callback would re-enter the mode handler from the hook
+	// thread, and the down/up pair a modified scroll holds reads as the
+	// user tapping that modifier — latching a sticky modifier nobody
+	// pressed. Only Neru's own injection is skipped (neruInjectedTag);
+	// another tool's synthetic input is still seen.
+	if kbd.dwExtraInfo == neruInjectedTag {
+		ret, _, _ := procCallNextHookEx.Call(0, uintptr(code), wParam, uintptr(lParam))
+
+		return ret
+	}
+
+	isUp := wParam == wmKeyUp || wParam == wmSysKeyUp || kbd.flags&llkhfUp != 0
+
+	key := hookKeyName(kbd.vkCode, isUp)
+	if key != "" && current.callback(key, isUp) {
+		return 1
+	}
+
+	ret, _, _ := procCallNextHookEx.Call(0, uintptr(code), wParam, uintptr(lParam))
+
+	return ret
+}
+
+func (h *KeyboardHook) run() {
+	defer close(h.doneCh)
 
 	handle, _, _ := procSetWindowsHookExW.Call(
 		whKeyboardLL,
-		hookProc,
+		keyboardHookProcPtr(),
 		moduleHandle(),
 		0,
 	)
@@ -233,7 +254,7 @@ func (h *KeyboardHook) run() {
 	h.hook = handle
 	threadID, _, _ := procGetCurrentThreadID.Call()
 	h.threadID = uint32(threadID)
-	activeKeyboardHook = h
+	activeKeyboardHook.Store(h)
 	h.mu.Unlock()
 
 	// Signal successful install so StartKeyboardHook can return the hook.
@@ -246,9 +267,10 @@ func (h *KeyboardHook) run() {
 			h.hook = 0
 		}
 
-		if activeKeyboardHook == h {
-			activeKeyboardHook = nil
-		}
+		// Only this hook's own registration is cleared: a later hook may
+		// already have installed itself, and clearing unconditionally would
+		// leave that one receiving key events with nowhere to deliver them.
+		activeKeyboardHook.CompareAndSwap(h, nil)
 		h.mu.Unlock()
 	}()
 

--- a/internal/adapter/platform/windows/win32.go
+++ b/internal/adapter/platform/windows/win32.go
@@ -8,6 +8,7 @@ import (
 	"image"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"unsafe"
 
@@ -187,45 +188,115 @@ type monitorEnumState struct {
 	monitors []displayMonitor
 }
 
+var (
+	// monitorEnumMu serializes enumeration passes. It is held across the whole
+	// EnumDisplayMonitors call, which is what makes the single shared collector
+	// below safe: Windows invokes MONITORENUMPROC synchronously, on the
+	// goroutine that made the call, before the call returns.
+	//
+	// It is an ordinary non-reentrant mutex held across a syscall, so nothing
+	// reached from the callback may enumerate again. Nothing does today
+	// (getMonitorInfo and monitorFriendlyName are the only calls it makes), and
+	// a future caller that did would deadlock rather than misbehave quietly.
+	monitorEnumMu sync.Mutex
+
+	// monitorEnumTarget is where collectMonitor appends, installed by the pass
+	// holding monitorEnumMu. The collector lives here rather than in the
+	// callback's captures because the callback is allocated once for the
+	// process (monitorEnumProcPtr) and so cannot capture anything per-call.
+	monitorEnumTarget *monitorEnumState
+
+	// monitorEnumProcPtr is the MONITORENUMPROC pointer EnumDisplayMonitors is
+	// handed, allocated on first use and never again.
+	//
+	// Go's runtime keys registered callbacks on the function value and never
+	// frees a slot, and the table is a fixed cb_max = 2000 entries
+	// (runtime/zcallback_windows.go). Every distinct closure passed to
+	// syscall.NewCallback therefore burns one permanently. enumerateMonitors
+	// runs on repeated mode activations — activeScreenBounds,
+	// screenBoundsByName, screenNames and NewOverlayWindow all reach it — so a
+	// per-call closure made a long session a countdown to "too many callback
+	// functions", which is a runtime throw rather than a panic: unrecoverable,
+	// and it takes the daemon with it.
+	//
+	// Hoisting it also keeps the property the closure was written for: the
+	// per-call state never round-trips through the dwData uintptr, so there is
+	// no uintptr-to-pointer conversion for go vet's unsafeptr check to object
+	// to.
+	monitorEnumProcPtr = sync.OnceValue(func() uintptr {
+		return syscall.NewCallback(collectMonitor)
+	})
+)
+
+// collectMonitor is the MONITORENUMPROC Windows calls once per monitor. It
+// appends to whichever collector the enumeration pass installed.
+//
+// Returning 1 continues the enumeration: a monitor whose info cannot be read is
+// dropped rather than costing the caller the monitors after it. A nil target
+// cannot happen while the pass holds monitorEnumMu, and is treated the same way
+// rather than dereferenced.
+func collectMonitor(hMonitor uintptr, _ uintptr, _ uintptr, _ uintptr) uintptr {
+	if monitorEnumTarget == nil {
+		return 1
+	}
+
+	info, err := getMonitorInfo(windows.Handle(hMonitor))
+	if err != nil {
+		return 1
+	}
+
+	deviceName := windows.UTF16ToString(info.szDevice[:])
+	monitorEnumTarget.monitors = append(monitorEnumTarget.monitors, displayMonitor{
+		name:   monitorFriendlyName(deviceName),
+		bounds: rectToImage(info.rcMonitor),
+	})
+
+	return 1
+}
+
 func enumerateMonitors() ([]displayMonitor, error) {
+	monitors, err := runMonitorEnumeration()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(monitors) == 0 {
+		return nil, errNoMonitors
+	}
+
+	return monitors, nil
+}
+
+// runMonitorEnumeration performs one EnumDisplayMonitors pass and returns the
+// monitors it collected.
+//
+// Installing and clearing the shared collector is the whole reason this is its
+// own function: the lock and the target have to be released together and on
+// every path out, including a panic from the lazy proc lookup, and a deferred
+// pair here is what keeps that from being spread across the caller.
+func runMonitorEnumeration() ([]displayMonitor, error) {
 	state := &monitorEnumState{}
 
-	// The callback captures state directly, so there is no need to round-trip a
-	// pointer through dwData (which would trip govet's unsafeptr check).
-	callback := syscall.NewCallback(func(
-		hMonitor uintptr,
-		_ uintptr,
-		_ uintptr,
-		_ uintptr,
-	) uintptr {
-		info, err := getMonitorInfo(windows.Handle(hMonitor))
-		if err != nil {
-			return 1
-		}
+	monitorEnumMu.Lock()
 
-		deviceName := windows.UTF16ToString(info.szDevice[:])
-		state.monitors = append(state.monitors, displayMonitor{
-			name:   monitorFriendlyName(deviceName),
-			bounds: rectToImage(info.rcMonitor),
-		})
+	defer func() {
+		monitorEnumTarget = nil
 
-		return 1
-	})
+		monitorEnumMu.Unlock()
+	}()
+
+	monitorEnumTarget = state
 
 	ret, _, err := procEnumDisplayMonitors.Call(
 		0,
 		0,
-		callback,
+		monitorEnumProcPtr(),
 		0,
 	)
 
 	callErr := win32Bool(ret, err)
 	if callErr != nil {
 		return nil, fmt.Errorf("EnumDisplayMonitors: %w", callErr)
-	}
-
-	if len(state.monitors) == 0 {
-		return nil, errNoMonitors
 	}
 
 	return state.monitors, nil


### PR DESCRIPTION
## Description

This PR fixes the Windows daemon dying part-way through a long session. Two of
its internal paths asked the Go runtime for a fresh native callback every time
they ran — one on every mode activation, one on every keyboard capture cycle —
and the runtime hands out a fixed number of those for the life of a process and
never takes one back. Around the two-thousandth activation the process ran out
and stopped dead: not an error a user could see coming, and not something the
daemon could recover from.

Both paths now ask for their callback once and reuse it. There is no change to
behaviour, configuration, commands or output; the same work happens, it just
stops consuming a finite resource to do it. A session that used to end in a
hard stop now keeps going.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this changes the internals of existing `//go:build windows` files; no port surface and no new capability, so no stub gains or loses anything.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no capability status or
      user-facing surface changed, so nothing in `docs/` owns this.
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

The resource is Go's Windows callback table: registered callbacks are keyed on
the function value, a slot is never freed, and the table is a fixed 2000
entries. Passing a closure means a new function value each call, so each call
burned a slot permanently. Exhausting it is a runtime throw rather than a
panic — unrecoverable, which is why the failure mode was the whole daemon
going away rather than one mode failing.

The monitor-enumeration side needed its per-call state to move somewhere, since
a shared callback cannot capture anything. It is now a package variable
installed under a mutex held across the whole enumeration; Windows runs that
enumeration synchronously on the calling thread, so there is nothing to
interleave with. The obvious alternative — passing the state through the
enumeration's user-data parameter — is what the previous code was deliberately
written to avoid, because it needs an integer-to-pointer round trip that `go
vet`'s `unsafeptr` check rejects. That property is preserved.

The keyboard hook needed no such move: its procedure already dispatched through
the package-level "currently installed hook", so it is now a plain package-level
function. That variable was previously written under a mutex and read
unsynchronized from the hook thread — a data race the hoist made trivial to
close, so it is now an atomic pointer.

The regression tests count callback slots rather than waiting to run out of
them. Registrations sit at a fixed stride in one table, so two throwaway
registrations measure the stride, a third after the workload measures the gap,
and the difference is what the workload consumed. Repeated enumeration passes
and repeated real keyboard-hook installs must consume none. A runtime that laid
callbacks out differently would skip rather than pass quietly.

Verification: `just ci`, `just lint-cross` (Linux and Windows lint in Docker)
and `just build-windows` all pass on macOS, but none of them execute a line of
this change — everything here is Windows-only. The `test (windows-latest)` leg
is the real check, and the new tests are integration-tagged, so it is the
integration profile there that runs them. It came back green, and the
enumeration counter has no skip path short of a runtime that lays callbacks out
differently, so that leg genuinely exercised the fix.

