### PR TITLE
fix(linux): stop X11 hotkeys and the KDE geometry helper from sharing what they should not

### DIFF
--- a/internal/adapter/hotkeys/linux/x11_cgo.go
+++ b/internal/adapter/hotkeys/linux/x11_cgo.go
@@ -29,6 +29,23 @@ type x11HotkeyBinding struct {
 }
 
 type x11HotkeyState struct {
+	// displayMu serializes every Xlib call made on display.
+	//
+	// Xlib is thread-safe only when XInitThreads runs before the first
+	// XOpenDisplay, and nothing in this process calls it. Manager.mu guards the
+	// Go maps and says nothing about the connection, so without this lock a
+	// registration on a caller's goroutine and the poll loop on its own would
+	// be inside the same connection buffers at once: XPending flushes the
+	// output buffer and reads from the socket, which is exactly what the
+	// XGrabKey/XSelectInput/XFlush sequence beside it is doing.
+	//
+	// It is never held across a call that waits for a key. The loop polls with
+	// neru_hotkeys_pending and only calls XNextEvent when an event is already
+	// queued, so the longest a registration can wait behind it is one
+	// non-blocking read — holding it across a bare XNextEvent would wedge
+	// registration until the user pressed something.
+	displayMu sync.Mutex
+
 	display  *C.Display
 	root     C.Window
 	bindings map[ports.HotkeyID]x11HotkeyBinding
@@ -36,6 +53,100 @@ type x11HotkeyState struct {
 	stopCh   chan struct{} // signals runX11HotkeyLoop to exit
 	doneCh   chan struct{} // closed when runX11HotkeyLoop has exited
 	once     sync.Once
+}
+
+// x11IgnoredModifierMasks are the lock modifiers a grab has to be repeated
+// under, because the server reports them in a key event's state and a grab
+// naming a different state does not match: Lock is CapsLock, and Mod2 is where
+// NumLock conventionally sits.
+//
+// The set is stated once so a grab and the ungrab that undoes it cannot drift:
+// an ungrab that misses a mask leaves a hotkey grabbed after Neru forgot it.
+func x11IgnoredModifierMasks() [4]C.uint {
+	return [4]C.uint{0, C.Mod2Mask, C.LockMask, C.Mod2Mask | C.LockMask}
+}
+
+// grab resolves keyString against the connection's keymap and installs the
+// grabs for it, as one critical section.
+//
+// The resolve belongs inside the lock rather than beside it: XKeysymToKeycode
+// is an Xlib call on this same connection, so it is one of the calls being
+// serialized, not a pure computation that happens to precede them.
+func (s *x11HotkeyState) grab(keyString string) (x11HotkeyBinding, error) {
+	s.displayMu.Lock()
+	defer s.displayMu.Unlock()
+
+	keycode, modifiers, err := parseX11Hotkey(s.display, keyString)
+	if err != nil {
+		return x11HotkeyBinding{}, err
+	}
+
+	for _, mask := range x11IgnoredModifierMasks() {
+		C.XGrabKey(
+			s.display,
+			C.int(keycode),
+			modifiers|mask,
+			s.root,
+			C.True,
+			C.GrabModeAsync,
+			C.GrabModeAsync,
+		)
+	}
+
+	C.XSelectInput(s.display, s.root, C.KeyPressMask)
+	C.XFlush(s.display)
+
+	return x11HotkeyBinding{keycode: C.int(keycode), modifiers: modifiers}, nil
+}
+
+// ungrab releases the grabs grab installed for one binding.
+func (s *x11HotkeyState) ungrab(binding x11HotkeyBinding) {
+	s.displayMu.Lock()
+	defer s.displayMu.Unlock()
+
+	for _, mask := range x11IgnoredModifierMasks() {
+		C.XUngrabKey(
+			s.display,
+			binding.keycode,
+			binding.modifiers|mask,
+			s.root,
+		)
+	}
+
+	C.XFlush(s.display)
+}
+
+// nextEvent takes one queued event off the connection, reporting false when
+// none was waiting.
+//
+// The pending check and the read are one critical section because they are one
+// sequence: XPending answering "an event is queued" is only a fact about this
+// connection while nothing else is draining it, and an XNextEvent whose event
+// another thread has taken blocks until the next one arrives — with displayMu
+// held, which is the one way this lock could wedge registration.
+func (s *x11HotkeyState) nextEvent() (C.XEvent, bool) {
+	s.displayMu.Lock()
+	defer s.displayMu.Unlock()
+
+	var event C.XEvent
+
+	if C.neru_hotkeys_pending(s.display) == 0 {
+		return event, false
+	}
+
+	C.XNextEvent(s.display, &event)
+
+	return event, true
+}
+
+// closeDisplay tears down the connection. Callers must have stopped the poll
+// loop first — the lock orders this against a registration, not against a read
+// of a display that has been freed.
+func (s *x11HotkeyState) closeDisplay() {
+	s.displayMu.Lock()
+	defer s.displayMu.Unlock()
+
+	C.XCloseDisplay(s.display)
 }
 
 var x11States sync.Map
@@ -46,27 +157,13 @@ func (m *Manager) registerX11Hotkey(hotkeyID ports.HotkeyID, keyString string) e
 		return err
 	}
 
-	keycode, modifiers, parseErr := parseX11Hotkey(state.display, keyString)
-	if parseErr != nil {
-		return parseErr
+	binding, grabErr := state.grab(keyString)
+	if grabErr != nil {
+		return grabErr
 	}
 
-	for _, mask := range []C.uint{0, C.Mod2Mask, C.LockMask, C.Mod2Mask | C.LockMask} {
-		C.XGrabKey(
-			state.display,
-			C.int(keycode),
-			modifiers|mask,
-			state.root,
-			C.True,
-			C.GrabModeAsync,
-			C.GrabModeAsync,
-		)
-	}
-	C.XSelectInput(state.display, state.root, C.KeyPressMask)
-	C.XFlush(state.display)
-
-	state.bindings[hotkeyID] = x11HotkeyBinding{keycode: C.int(keycode), modifiers: modifiers}
-	state.ids[x11BindingKey(keycode, modifiers)] = hotkeyID
+	state.bindings[hotkeyID] = binding
+	state.ids[x11BindingKey(C.uint(binding.keycode), binding.modifiers)] = hotkeyID
 
 	return nil
 }
@@ -86,15 +183,7 @@ func (m *Manager) unregisterX11Hotkey(hotkeyID ports.HotkeyID) {
 		return
 	}
 
-	for _, mask := range []C.uint{0, C.Mod2Mask, C.LockMask, C.Mod2Mask | C.LockMask} {
-		C.XUngrabKey(
-			state.display,
-			binding.keycode,
-			binding.modifiers|mask,
-			state.root,
-		)
-	}
-	C.XFlush(state.display)
+	state.ungrab(binding)
 
 	delete(state.ids, x11BindingKey(C.uint(binding.keycode), binding.modifiers))
 	delete(state.bindings, hotkeyID)
@@ -120,7 +209,7 @@ func (m *Manager) unregisterAllX11Hotkeys() {
 		close(state.stopCh)
 		<-state.doneCh
 
-		C.XCloseDisplay(state.display)
+		state.closeDisplay()
 		x11States.Delete(m)
 	})
 }
@@ -135,6 +224,10 @@ func (m *Manager) ensureX11State() (*x11HotkeyState, error) {
 		return state, nil
 	}
 
+	// XOpenDisplay and the root-window read are the two Xlib calls here that do
+	// not go through displayMu, and the only ones that need not: they run
+	// before the state exists to lock, before it is published to x11States and
+	// before the poll loop that would share the connection is started.
 	display := C.XOpenDisplay(nil)
 	if display == nil {
 		return nil, derrors.New(
@@ -167,18 +260,19 @@ func (m *Manager) runX11HotkeyLoop(state *x11HotkeyState) {
 		default:
 		}
 
-		// Use XPending to check for queued events instead of calling the
-		// blocking XNextEvent directly. This allows the stop channel to be
-		// checked between iterations, preventing a goroutine leak and a
-		// use-after-free when unregisterAllX11Hotkeys closes the display.
-		if C.neru_hotkeys_pending(state.display) == 0 {
+		// nextEvent polls with XPending instead of calling the blocking
+		// XNextEvent directly. This allows the stop channel to be checked
+		// between iterations, preventing a goroutine leak and a
+		// use-after-free when unregisterAllX11Hotkeys closes the display —
+		// and it is what lets every Xlib call on this connection share one
+		// lock without a registration ever waiting on a keystroke.
+		event, hasEvent := state.nextEvent()
+		if !hasEvent {
 			time.Sleep(x11HotkeyPollInterval)
 
 			continue
 		}
 
-		var event C.XEvent
-		C.XNextEvent(state.display, &event)
 		if C.neru_xevent_type(&event) != C.KeyPress {
 			continue
 		}

--- a/internal/adapter/hotkeys/linux/x11_display_lock_test.go
+++ b/internal/adapter/hotkeys/linux/x11_display_lock_test.go
@@ -1,0 +1,459 @@
+//go:build linux
+
+package linux_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The X11 hotkey backend owns one Xlib connection and two goroutines that use
+// it: whichever one calls Register or Unregister, and the poll loop that reads
+// key events off it. Xlib is thread-safe only when XInitThreads runs before the
+// first XOpenDisplay, and nothing in this process calls it, so those two must
+// never be inside the connection at the same time. Manager.mu does not buy
+// that: it guards the Go maps, and the poll loop deliberately does not hold it
+// while reading the connection.
+//
+// The rule is therefore about a lock the compiler cannot see the need for, in
+// C calls no race detector watches, on a path that misbehaves as a corrupted
+// connection rather than as a crash at the call site. These tests are what
+// keeps it true.
+
+// x11DisplayCalls are the cgo entry points that speak on the hotkey connection.
+// Each takes the Display as an argument, and each therefore writes to or reads
+// from its buffers — including neru_hotkeys_pending, which is XPending, which
+// flushes the request buffer and reads the socket rather than merely peeking at
+// a counter.
+var x11DisplayCalls = map[string]struct{}{
+	"XCloseDisplay":            {},
+	"XFlush":                   {},
+	"XGrabKey":                 {},
+	"XKeysymToKeycode":         {},
+	"XNextEvent":               {},
+	"XOpenDisplay":             {},
+	"XSelectInput":             {},
+	"XUngrabKey":               {},
+	"neru_hotkeys_pending":     {},
+	"neru_hotkeys_root_window": {},
+}
+
+// x11ConnectionFreeCalls are the cgo calls that touch no connection: type
+// conversions, C memory, the keysym table (XStringToKeysym is a lookup in the
+// client's own static table and takes no Display), and the accessors that read
+// a field out of an XEvent already copied into Go memory.
+//
+// Anything not in this list and not in x11DisplayCalls fails the classification
+// test rather than being assumed harmless — that assumption is what a new
+// Xlib call would arrive on.
+var x11ConnectionFreeCalls = map[string]struct{}{
+	"CString":           {},
+	"XStringToKeysym":   {},
+	"free":              {},
+	"int":               {},
+	"neru_xevent_type":  {},
+	"neru_xkey_keycode": {},
+	"neru_xkey_state":   {},
+	"uint":              {},
+}
+
+// x11DisplayLockHolders are the functions allowed to call into the connection,
+// each of which must take displayMu for the length of its call sequence. They
+// are methods on x11HotkeyState rather than on Manager so that the lock and the
+// Display it protects are reached through the same receiver.
+var x11DisplayLockHolders = map[string]string{
+	"grab":         "resolves the keycode and installs the grabs as one sequence",
+	"ungrab":       "releases one binding's grabs and flushes them",
+	"nextEvent":    "pending-then-read is one sequence; a read another thread beat it to would block holding the lock",
+	"closeDisplay": "tears the connection down after the poll loop has exited",
+}
+
+// x11DisplayLockCallees are the helpers that speak on the connection without
+// taking the lock themselves because every caller already holds it. The claim
+// each entry makes is checked, not trusted:
+// TestEveryDisplayTouchingHelperIsCalledOnlyFromALockHolder fails on a call
+// site outside a holder.
+var x11DisplayLockCallees = map[string]string{
+	"parseX11Hotkey": "resolves a hotkey string to a keycode against this " +
+		"connection's keymap, from inside grab's critical section",
+}
+
+// x11DisplayLockExemptions are the functions that reach the connection without
+// the lock, with the reason each is sound. An entry here is a claim that no
+// second goroutine can be inside the connection at that moment.
+var x11DisplayLockExemptions = map[string]string{
+	"ensureX11State": "opens the connection and reads the root window before " +
+		"the state is published to x11States and before the poll loop starts, " +
+		"so there is no second user of the connection yet and no lock to take",
+}
+
+// x11HotkeySourceFile is the only file in this package permitted to speak on
+// the connection. Scanning the whole directory rather than this file alone is
+// what stops the rule being sidestepped by a second cgo file.
+const x11HotkeySourceFile = "x11_cgo.go"
+
+// TestEveryXlibCallOnTheHotkeyDisplayHoldsTheDisplayLock pins the serialization
+// itself: a call into the connection happens in a function that holds
+// displayMu, or in one of the exemptions above with its reason written down.
+func TestEveryXlibCallOnTheHotkeyDisplayHoldsTheDisplayLock(t *testing.T) {
+	// A walk that matched nothing would pass whatever the code did, so what it
+	// found is asserted alongside what it judged: a rename in the C bridge that
+	// emptied x11DisplayCalls would otherwise turn this green.
+	seen := 0
+
+	for _, file := range packageSourceFiles(t) {
+		base := filepath.Base(file.name)
+
+		for _, function := range file.functions {
+			displayCalls := function.cgoCallsMatching(x11DisplayCalls)
+			if len(displayCalls) == 0 {
+				continue
+			}
+
+			seen += len(displayCalls)
+
+			if base != x11HotkeySourceFile {
+				t.Errorf(
+					"%s: %s calls %s on the hotkey X11 connection; the connection "+
+						"is served from %s alone, so every call on it sits behind "+
+						"one displayMu",
+					base, function.name, strings.Join(displayCalls, ", "),
+					x11HotkeySourceFile,
+				)
+
+				continue
+			}
+
+			if _, exempt := x11DisplayLockExemptions[function.name]; exempt {
+				continue
+			}
+
+			if _, callee := x11DisplayLockCallees[function.name]; callee {
+				continue
+			}
+
+			if _, holder := x11DisplayLockHolders[function.name]; !holder {
+				t.Errorf(
+					"%s: %s calls %s on the hotkey X11 connection without holding "+
+						"displayMu; Xlib is not thread-safe here (no XInitThreads) "+
+						"and the poll loop is on the same connection, so route the "+
+						"call through an x11HotkeyState method that locks, or add "+
+						"an exemption saying why no other goroutine can be inside "+
+						"the connection here",
+					base, function.name, strings.Join(displayCalls, ", "),
+				)
+			}
+		}
+	}
+
+	if seen == 0 {
+		t.Errorf(
+			"no call in %s matched x11DisplayCalls; the rule cannot be checked "+
+				"against a list that names nothing the code calls",
+			x11HotkeySourceFile,
+		)
+	}
+}
+
+// TestEveryDisplayLockHolderStillTakesTheLock is the other half: a holder that
+// stops locking would leave the first test green, because it only asks which
+// function the call is in.
+//
+// It asks for the deferred unlock as well as the lock, and for the lock to come
+// before the first call on the connection. A holder that unlocked early, or
+// locked after its first call, would satisfy a bare "does it lock" and protect
+// nothing.
+func TestEveryDisplayLockHolderStillTakesTheLock(t *testing.T) {
+	found := map[string]bool{}
+
+	for _, file := range packageSourceFiles(t) {
+		if filepath.Base(file.name) != x11HotkeySourceFile {
+			continue
+		}
+
+		for _, function := range file.functions {
+			why, holder := x11DisplayLockHolders[function.name]
+			if !holder {
+				continue
+			}
+
+			found[function.name] = true
+
+			lock := strings.Index(function.source, "displayMu.Lock()")
+
+			if lock < 0 || !strings.Contains(function.source, "defer s.displayMu.Unlock()") {
+				t.Errorf(
+					"%s: %s is listed as a displayMu holder (%s) but does not take "+
+						"the lock and defer its release; every Xlib call on the "+
+						"hotkey connection is serialized on it",
+					x11HotkeySourceFile, function.name, why,
+				)
+
+				continue
+			}
+
+			for _, call := range function.cgoCallsMatching(x11DisplayCalls) {
+				if used := strings.Index(function.source, "C."+call); used >= 0 && used < lock {
+					t.Errorf(
+						"%s: %s calls C.%s before taking displayMu; the lock has to "+
+							"come first or it serializes nothing",
+						x11HotkeySourceFile, function.name, call,
+					)
+				}
+			}
+		}
+	}
+
+	for name, why := range x11DisplayLockHolders {
+		if !found[name] {
+			t.Errorf(
+				"%s is listed as a displayMu holder (%s) but no such function "+
+					"exists in %s; drop the entry or restore the function",
+				name, why, x11HotkeySourceFile,
+			)
+		}
+	}
+}
+
+// TestEveryDisplayLockExemptionIsStillReal keeps the one list that weakens the
+// rule from outliving what it excuses. An exemption for a function that no
+// longer exists, or that no longer touches the connection, is a hole nobody
+// meant to leave open — so the list can only shrink.
+func TestEveryDisplayLockExemptionIsStillReal(t *testing.T) {
+	touching := map[string]bool{}
+
+	for _, file := range packageSourceFiles(t) {
+		for _, function := range file.functions {
+			if len(function.cgoCallsMatching(x11DisplayCalls)) > 0 {
+				touching[function.name] = true
+			}
+		}
+	}
+
+	for name, why := range x11DisplayLockExemptions {
+		if !touching[name] {
+			t.Errorf(
+				"%s is excused from taking displayMu (%s) but no longer calls "+
+					"anything on the connection; drop the entry",
+				name, why,
+			)
+		}
+	}
+}
+
+// TestEveryDisplayTouchingHelperIsCalledOnlyFromALockHolder checks the claim
+// each x11DisplayLockCallees entry makes. A helper that speaks on the
+// connection is safe only for as long as nothing calls it from outside a
+// critical section, and that is a property of its call sites, not of the helper
+// — so a second caller is exactly the change this has to catch.
+func TestEveryDisplayTouchingHelperIsCalledOnlyFromALockHolder(t *testing.T) {
+	callSites := map[string]int{}
+
+	for _, file := range packageSourceFiles(t) {
+		for _, function := range file.functions {
+			for _, called := range function.calls {
+				why, tracked := x11DisplayLockCallees[called]
+				if !tracked {
+					continue
+				}
+
+				callSites[called]++
+
+				_, holder := x11DisplayLockHolders[function.name]
+				if holder || function.name == called {
+					continue
+				}
+
+				t.Errorf(
+					"%s: %s calls %s, which speaks on the hotkey X11 connection "+
+						"without taking displayMu (%s); either make this caller a "+
+						"lock holder or move the call inside one",
+					filepath.Base(file.name), function.name, called, why,
+				)
+			}
+		}
+	}
+
+	for name, why := range x11DisplayLockCallees {
+		if callSites[name] == 0 {
+			t.Errorf(
+				"%s is listed as a display-touching helper (%s) but nothing calls "+
+					"it; drop the entry so the list keeps describing the code",
+				name, why,
+			)
+		}
+	}
+}
+
+// TestEveryCgoCallInTheHotkeyPackageIsClassified refuses to let a new cgo call
+// arrive unclassified. Without it the rule would only cover the calls that
+// existed when it was written, and the next Xlib call added to this package
+// would be silently outside it.
+func TestEveryCgoCallInTheHotkeyPackageIsClassified(t *testing.T) {
+	for _, file := range packageSourceFiles(t) {
+		unknown := map[string]struct{}{}
+
+		for _, function := range file.functions {
+			for _, call := range function.cgoCalls {
+				_, display := x11DisplayCalls[call]
+				_, free := x11ConnectionFreeCalls[call]
+
+				if !display && !free {
+					unknown[call] = struct{}{}
+				}
+			}
+		}
+
+		for _, call := range sortedKeys(unknown) {
+			t.Errorf(
+				"%s: C.%s is neither in x11DisplayCalls nor in "+
+					"x11ConnectionFreeCalls; say which it is, because a call that "+
+					"takes the Display has to be made under displayMu",
+				filepath.Base(file.name), call,
+			)
+		}
+	}
+}
+
+// parsedFile is one package source file reduced to what these tests ask about.
+type parsedFile struct {
+	name      string
+	functions []parsedFunction
+}
+
+// parsedFunction is one function: its name, its source text (for the lock
+// check), every C.<name>(...) call it makes and every package-level function it
+// calls by plain name.
+type parsedFunction struct {
+	name     string
+	source   string
+	cgoCalls []string
+	calls    []string
+}
+
+// cgoCallsMatching returns the function's cgo calls that appear in want,
+// deduplicated and ordered so a failure message reads the same on every run.
+func (f parsedFunction) cgoCallsMatching(want map[string]struct{}) []string {
+	matched := map[string]struct{}{}
+
+	for _, call := range f.cgoCalls {
+		if _, ok := want[call]; ok {
+			matched[call] = struct{}{}
+		}
+	}
+
+	return sortedKeys(matched)
+}
+
+// packageSourceFiles parses this package's non-test Go sources regardless of
+// build tags. x11_cgo.go is behind linux && cgo, so a build without cgo would
+// otherwise leave the rule unchecked on the one file it is about.
+func packageSourceFiles(t *testing.T) []parsedFile {
+	t.Helper()
+
+	names, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("listing package sources: %v", err)
+	}
+
+	fileSet := token.NewFileSet()
+
+	var files []parsedFile
+
+	for _, name := range names {
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		contents, readErr := os.ReadFile(name)
+		if readErr != nil {
+			t.Fatalf("reading %s: %v", name, readErr)
+		}
+
+		parsed, parseErr := parser.ParseFile(fileSet, name, contents, parser.SkipObjectResolution)
+		if parseErr != nil {
+			t.Fatalf("parsing %s: %v", name, parseErr)
+		}
+
+		files = append(files, parsedFile{
+			name:      name,
+			functions: parseFunctions(fileSet, parsed, contents),
+		})
+	}
+
+	if len(files) == 0 {
+		t.Fatal("no package sources found; these rules are about this package's own files")
+	}
+
+	return files
+}
+
+func parseFunctions(fileSet *token.FileSet, file *ast.File, contents []byte) []parsedFunction {
+	var functions []parsedFunction
+
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Body == nil {
+			continue
+		}
+
+		start := fileSet.Position(function.Pos()).Offset
+		end := fileSet.Position(function.End()).Offset
+
+		cgoCalls, calls := callsIn(function)
+
+		functions = append(functions, parsedFunction{
+			name:     function.Name.Name,
+			source:   string(contents[start:end]),
+			cgoCalls: cgoCalls,
+			calls:    calls,
+		})
+	}
+
+	return functions
+}
+
+// callsIn collects a function body's C.<name>(...) calls and its plain
+// name(...) calls. Type conversions such as C.int(x) parse as calls too, which
+// is why the classification lists name them.
+func callsIn(function *ast.FuncDecl) ([]string, []string) {
+	var cgoCalls, calls []string
+
+	ast.Inspect(function.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		switch fun := call.Fun.(type) {
+		case *ast.Ident:
+			calls = append(calls, fun.Name)
+		case *ast.SelectorExpr:
+			pkg, isIdent := fun.X.(*ast.Ident)
+			if isIdent && pkg.Name == "C" {
+				cgoCalls = append(cgoCalls, fun.Sel.Name)
+			}
+		}
+
+		return true
+	})
+
+	return cgoCalls, calls
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}

--- a/internal/adapter/hotkeys/linux/x11_display_lock_test.go
+++ b/internal/adapter/hotkeys/linux/x11_display_lock_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package linux_test
 
 import (
@@ -25,6 +23,12 @@ import (
 // C calls no race detector watches, on a path that misbehaves as a corrupted
 // connection rather than as a crash at the call site. These tests are what
 // keeps it true.
+//
+// They read the sources instead of running them, and carry no build tag for
+// the same reason: the edit they exist to catch — a new Xlib call added to
+// x11_cgo.go — is made on the maintainer's macOS host, where neither the file
+// nor a Linux-tagged test compiles. A rule checked only on the CI leg is a rule
+// found broken later than it was written.
 
 // x11DisplayCalls are the cgo entry points that speak on the hotkey connection.
 // Each takes the Display as an argument, and each therefore writes to or reads

--- a/internal/adapter/platform/kwin/geometry.go
+++ b/internal/adapter/platform/kwin/geometry.go
@@ -31,6 +31,12 @@ const (
 	// The geometry script is only readable/writable by the owner.
 	scriptFileMode = 0o600
 
+	// scriptDirShared are the permission bits that would make the directory
+	// holding the script reachable by anyone but its owner. The script is code
+	// KWin executes, so the directory it is written into has to be private
+	// before the file's own mode means anything.
+	scriptDirShared = 0o077
+
 	// installRetries is how many further attempts the installer makes on its
 	// own after a failed one, and installRetryBackoff the wait before the
 	// first of them, doubling each time (~1s, 2s, 4s). The window being
@@ -50,6 +56,21 @@ const scriptFileName = "neru-kwin-geometry.js"
 // because "KWin never answered" and "no window is focused" are different
 // answers and only one of them should send a caller to the active screen.
 var errKWinAbsent = errors.New("org.kde.KWin is not on the session bus")
+
+// errNoRuntimeDir and errRuntimeDirNotPrivate are the two ways a session can
+// fail to offer somewhere the geometry script may live. They are separate
+// because a user fixes them differently: the first is a session started outside
+// logind, the second a runtime directory pointed somewhere it should not be.
+var (
+	errNoRuntimeDir = errors.New(
+		"XDG_RUNTIME_DIR is not set, so there is no private directory to load " +
+			"the KWin geometry script from",
+	)
+	errRuntimeDirNotPrivate = errors.New(
+		"XDG_RUNTIME_DIR is not a directory private to this user, so it is not " +
+			"somewhere the KWin geometry script may be loaded from",
+	)
+)
 
 // Window is what KWin last said about the focused window: where it is, and
 // which window it is.
@@ -465,14 +486,14 @@ func (g *Geometry) install() error {
 
 // installScript writes the KWin script to disk and loads + starts it.
 func (g *Geometry) installScript(conn *dbus.Conn) error {
-	dir := os.Getenv("XDG_RUNTIME_DIR")
-	if dir == "" {
-		dir = os.TempDir()
+	dir, dirErr := scriptDir()
+	if dirErr != nil {
+		return dirErr
 	}
 
 	path := filepath.Join(dir, scriptFileName)
 
-	writeErr := os.WriteFile(path, []byte(geometryScript), scriptFileMode)
+	writeErr := writeScript(path)
 	if writeErr != nil {
 		return writeErr
 	}
@@ -495,4 +516,97 @@ func (g *Geometry) installScript(conn *dbus.Conn) error {
 	}
 
 	return nil
+}
+
+// scriptDir resolves the directory the geometry script is loaded from, which
+// is $XDG_RUNTIME_DIR and nowhere else.
+//
+// It used to fall back to os.TempDir() when the variable was unset, which is
+// /tmp: a directory every user on the machine can write into, holding a file
+// with a fixed name, whose contents the compositor then executes. There is no
+// version of that which is safe to keep, and the answer to a session with no
+// runtime directory is to say so — a KDE session started by logind always has
+// one, so nothing that works today stops working, and a session that does not
+// have one gets the same loud, recorded reason as a session with no KWin.
+//
+// The mode is checked rather than assumed. The XDG base directory
+// specification requires $XDG_RUNTIME_DIR to be owned by the user and
+// accessible to nobody else, and logind creates it 0700, so the check is a
+// formality on every real session; what it catches is a runtime directory
+// pointed somewhere shared, which is the same exposure the fallback was.
+//
+// The mode is the whole of the check because ownership adds nothing a caller
+// could act on: a 0700 directory belonging to somebody else is one this
+// process cannot write into either, so the write below fails and says so. What
+// matters is that nobody else can write into the directory the compositor
+// loads from, and that is what the mode says.
+func scriptDir() (string, error) {
+	dir := os.Getenv("XDG_RUNTIME_DIR")
+	if dir == "" {
+		return "", errNoRuntimeDir
+	}
+
+	// Stat, not Lstat: a symlinked runtime directory is judged by what it
+	// resolves to, which is the directory the script would really land in.
+	info, err := os.Stat(dir)
+	if err != nil {
+		return "", fmt.Errorf("XDG_RUNTIME_DIR: %w", err)
+	}
+
+	if !info.IsDir() {
+		return "", fmt.Errorf("%w: %s is not a directory at all", errRuntimeDirNotPrivate, dir)
+	}
+
+	if info.Mode().Perm()&scriptDirShared != 0 {
+		return "", fmt.Errorf(
+			"%w: %s is mode %04o, wanted 0700",
+			errRuntimeDirNotPrivate, dir, info.Mode().Perm(),
+		)
+	}
+
+	return dir, nil
+}
+
+// writeScript puts the script at path by writing a fresh file beside it and
+// renaming it over whatever was there, the way the portal restore token is
+// written (internal/adapter/platform/linux/portal_restore_token.go).
+//
+// Two things follow from that which truncating in place does not give. The new
+// file carries this package's mode whatever an earlier version or a stray copy
+// left behind, instead of inheriting it; and the path only ever names a
+// complete script, so the loadScript that follows cannot hand KWin half of one
+// — which matters more here than for a token, because KWin executes what it
+// reads.
+func writeScript(path string) error {
+	// The temporary file is named after the script it will become, so a
+	// leftover is recognizable and two daemons racing to install cannot write
+	// over each other's half-written copy.
+	temp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*")
+	if err != nil {
+		return err
+	}
+
+	// From here on the temporary file must not be left behind on any path.
+	defer func() { _ = os.Remove(temp.Name()) }()
+
+	err = temp.Chmod(scriptFileMode)
+	if err != nil {
+		_ = temp.Close()
+
+		return err
+	}
+
+	_, err = temp.WriteString(geometryScript)
+	if err != nil {
+		_ = temp.Close()
+
+		return err
+	}
+
+	err = temp.Close()
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(temp.Name(), path)
 }

--- a/internal/adapter/platform/kwin/script_install_test.go
+++ b/internal/adapter/platform/kwin/script_install_test.go
@@ -1,0 +1,252 @@
+//go:build linux
+
+package kwin
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestScriptDir_RefusesAnythingButAPrivateRuntimeDirectory pins where the
+// geometry script is allowed to live.
+//
+// The script is code KWin executes, so the directory holding it decides who can
+// decide what runs inside the compositor. A fallback to os.TempDir() used to
+// cover an unset XDG_RUNTIME_DIR, which put a fixed-named executable script in
+// a directory every user on the machine can write to; refusing is the only
+// answer that is not a worse one.
+func TestScriptDir_RefusesAnythingButAPrivateRuntimeDirectory(t *testing.T) {
+	tests := []struct {
+		name string
+		// runtimeDir builds the value XDG_RUNTIME_DIR is set to. An empty
+		// string is the unset session, which is what the variable reads as
+		// when logind never made one.
+		runtimeDir func(t *testing.T) string
+		wantErr    error
+	}{
+		{
+			name:       "unset is refused rather than falling back to a shared directory",
+			runtimeDir: func(*testing.T) string { return "" },
+			wantErr:    errNoRuntimeDir,
+		},
+		{
+			name: "a private 0700 directory is what a logind session gives",
+			runtimeDir: func(t *testing.T) string {
+				t.Helper()
+
+				return privateDir(t)
+			},
+		},
+		{
+			name: "a group- or world-readable directory is refused",
+			runtimeDir: func(t *testing.T) string {
+				t.Helper()
+
+				dir := privateDir(t)
+				chmodForTest(t, dir, 0o755)
+
+				return dir
+			},
+			wantErr: errRuntimeDirNotPrivate,
+		},
+		{
+			name: "a directory only others can write is refused too",
+			runtimeDir: func(t *testing.T) string {
+				t.Helper()
+
+				dir := privateDir(t)
+				chmodForTest(t, dir, 0o702)
+
+				return dir
+			},
+			wantErr: errRuntimeDirNotPrivate,
+		},
+		{
+			name: "a path that is not a directory is refused",
+			runtimeDir: func(t *testing.T) string {
+				t.Helper()
+
+				path := filepath.Join(privateDir(t), "not-a-directory")
+				writeFileForTest(t, path, "", 0o600)
+
+				return path
+			},
+			wantErr: errRuntimeDirNotPrivate,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value := test.runtimeDir(t)
+			t.Setenv("XDG_RUNTIME_DIR", value)
+
+			dir, err := scriptDir()
+
+			if test.wantErr == nil {
+				if err != nil {
+					t.Fatalf("scriptDir() = %v, want the runtime directory", err)
+				}
+
+				if dir != value {
+					t.Fatalf("scriptDir() = %q, want %q", dir, value)
+				}
+
+				return
+			}
+
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("scriptDir() = (%q, %v), want %v", dir, err, test.wantErr)
+			}
+		})
+	}
+}
+
+// TestWriteScript_ReplacesWhateverWasThereWithAnOwnerOnlyFile pins the write
+// itself. Renaming a fresh file over the target is what keeps a stale copy's
+// permissions from being inherited, keeps a symlink from redirecting the write,
+// and keeps loadScript from ever being handed half a script.
+func TestWriteScript_ReplacesWhateverWasThereWithAnOwnerOnlyFile(t *testing.T) {
+	tests := []struct {
+		name string
+		// existing prepares whatever is already at the script's path.
+		existing func(t *testing.T, path string)
+		// verify checks anything beyond "the script is there, owner-only".
+		verify func(t *testing.T, dir string)
+	}{
+		{
+			name:     "a path with nothing at it",
+			existing: func(*testing.T, string) {},
+		},
+		{
+			name: "a stale copy left group- and world-readable",
+			existing: func(t *testing.T, path string) {
+				t.Helper()
+				writeFileForTest(t, path, "stale", 0o666)
+			},
+		},
+		{
+			name: "a symlink pointing at a file elsewhere",
+			existing: func(t *testing.T, path string) {
+				t.Helper()
+
+				target := filepath.Join(filepath.Dir(path), "elsewhere")
+				writeFileForTest(t, target, "not the script", 0o600)
+
+				err := os.Symlink(target, path)
+				if err != nil {
+					t.Fatalf("planting a symlink at the script path: %v", err)
+				}
+			},
+			verify: func(t *testing.T, dir string) {
+				t.Helper()
+
+				contents, err := os.ReadFile(filepath.Join(dir, "elsewhere"))
+				if err != nil {
+					t.Fatalf("reading the symlink's target: %v", err)
+				}
+
+				if string(contents) != "not the script" {
+					t.Errorf("the symlink's target was overwritten with the script; "+
+						"the write must replace the link, not follow it (target = %q)",
+						string(contents))
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := privateDir(t)
+			path := filepath.Join(dir, scriptFileName)
+
+			test.existing(t, path)
+
+			err := writeScript(path)
+			if err != nil {
+				t.Fatalf("writeScript() = %v, want the script written", err)
+			}
+
+			info, statErr := os.Lstat(path)
+			if statErr != nil {
+				t.Fatalf("stat of the written script: %v", statErr)
+			}
+
+			if info.Mode()&os.ModeSymlink != 0 {
+				t.Fatal("the script path is still a symlink; the write followed it " +
+					"instead of replacing it")
+			}
+
+			if info.Mode().Perm() != scriptFileMode {
+				t.Errorf("the written script is mode %04o, want %04o",
+					info.Mode().Perm(), scriptFileMode)
+			}
+
+			contents, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatalf("reading the written script: %v", readErr)
+			}
+
+			if string(contents) != geometryScript {
+				t.Error("the written script is not the geometry script")
+			}
+
+			if test.verify != nil {
+				test.verify(t, dir)
+			}
+
+			assertNoWriteLeftovers(t, dir)
+		})
+	}
+}
+
+// privateDir gives a directory with the mode logind gives XDG_RUNTIME_DIR.
+// t.TempDir already creates one, and the chmod says so out loud rather than
+// leaving the case resting on that.
+func privateDir(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	chmodForTest(t, dir, 0o700)
+
+	return dir
+}
+
+func chmodForTest(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+
+	err := os.Chmod(path, mode)
+	if err != nil {
+		t.Fatalf("chmod %04o on %s: %v", mode, filepath.Base(path), err)
+	}
+}
+
+func writeFileForTest(t *testing.T, path string, contents string, mode os.FileMode) {
+	t.Helper()
+
+	err := os.WriteFile(path, []byte(contents), mode)
+	if err != nil {
+		t.Fatalf("writing %s: %v", filepath.Base(path), err)
+	}
+}
+
+// assertNoWriteLeftovers fails when the write left its temporary file behind.
+// One leftover is harmless; one per install attempt, in a runtime directory
+// that lives as long as the session, is not, and the defer that removes it is
+// easy to lose in a later edit.
+func assertNoWriteLeftovers(t *testing.T, dir string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("listing the script directory: %v", err)
+	}
+
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "."+scriptFileName) {
+			t.Errorf("writeScript left %s behind", entry.Name())
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes two Linux problems that share a cause: something Neru owns was
being used by two parties at once without saying who goes first.

On X11, global hotkeys run over one connection to the display server, and two
goroutines were using it at the same time — whichever one registers or
unregisters a hotkey, and the one reading key presses off it. Xlib is not
thread-safe unless a program asks for it at startup, and Neru does not (the
native side deliberately gives each thread its own connection for exactly this
reason). This is not a rare window: the very first hotkey opens the connection
and starts the reader, so every hotkey registered after it — on startup, on a
config reload, and on a focus change with per-app bindings — was grabbing keys
on a connection somebody else was already reading. The symptom would be a
connection that stops delivering hotkeys, or the daemon dying on a protocol
error, and it would look random. Every call on that connection is now
serialized. Hotkey latency is unchanged: the reader still polls rather than
blocking, so a registration waits at most for one non-blocking check and never
for a keystroke.

On KDE, the geometry helper Neru asks KWin to run was written to the user's
private runtime directory, but fell back to the shared system temporary
directory when the session did not provide one. That fallback is gone — the
helper is now written to a private per-user directory or not at all, and a
session that has none records the same clear, retried reason as a session with
no KWin, instead of quietly using a worse location. The file is also replaced
atomically now, so KWin can never be handed a half-written copy. On a normal
KDE session, which always has a private runtime directory, nothing changes.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port or capability changes; both files already had their platform slot and their no-cgo twin
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, both are bug fixes within
      capabilities `docs/CROSS_PLATFORM.md` already records as supported, so no
      status changes
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

Because a macOS host cannot lint or run either of these files, this branch was
also checked with `just lint-cross` (linux/amd64 with CGO on, plus
windows/amd64) and the full `just test-linux` suite in a container with CGO on.
`just build-linux` needs a Linux-targeting CGO toolchain that this host does
not have; `lint-cross` compiles the same build and is the documented substitute.

The X11 half is pinned by a guardrail that parses the package rather than by a
runtime test, because the invariant is about C calls no race detector watches,
on a connection no test host has. It checks four things: a call on the
connection sits in a function that takes the lock, a lock holder still takes it
(and takes it before its first call), a helper reached from inside a critical
section has no caller outside one, and a newly added cgo call is classified
rather than assumed harmless. It was verified to fail when the lock is removed.

Two things were deliberately left alone. The runtime directory's mode is
checked but not its ownership: a directory belonging to someone else is one
this process cannot write into either, so the write fails and says so, and what
matters is that nobody else can write where the compositor reads. And the
atomic write repeats the shape of the portal restore token's write rather than
sharing it — the two live in different packages, and a shared helper for eight
lines would be the larger change.
