### PR TITLE
ci: pin third-party actions by commit and attest release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,12 @@ jobs:
                     libpipewire-0.3-dev
 
             # Install Devbox on macOS only
+            # Pinned by commit: a tag is a movable pointer, so `@v0.15.0` is a
+            # request rather than a statement about which code runs. Dependabot
+            # updates SHA pins that carry a version comment.
             - name: Install Devbox
               if: runner.os == 'macOS'
-              uses: jetify-com/devbox-install-action@v0.15.0
+              uses: jetify-com/devbox-install-action@8c6a66ed6273138b1915457069de78cb52fe3bd7 # v0.15.0
               with:
                   enable-cache: true
 
@@ -142,7 +145,7 @@ jobs:
             # Install just directly on Windows & Linux
             - name: Install just
               if: runner.os == 'Windows' || runner.os == 'Linux'
-              uses: extractions/setup-just@v4
+              uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
             # Run checks with Devbox on macOS
             - name: Run just lint

--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -17,14 +17,17 @@ jobs:
             # by ref: this job holds `id-token: write`, so whatever they resolve
             # to can mint an OIDC token and publish a flake as this repo. A tag
             # is a movable pointer and a branch is a moving one, so neither is a
-            # statement about which code runs. Dependabot's github-actions
-            # ecosystem updates SHA pins carrying a version comment.
+            # statement about which code runs. The one below carries a version
+            # comment, which is what lets Dependabot keep bumping it; the one
+            # after it cannot, for the reason given there.
             - uses: "DeterminateSystems/determinate-nix-action@61cbfe2efc2d4e7a8a6d56967c3c1058e846c858" # v3.21.9
             # flakehub-push has no maintained major tag: upstream's own README
             # says `@main` everywhere, and its newest release (v6, Jul 2025) is
             # 147 commits behind `main` and still declares `using: node20`.
             # Pinning v6 would be a year-long rollback, so this pins the commit
-            # `main` pointed at instead. Bump it deliberately, not on a whim.
+            # `main` pointed at instead. That has a cost: with no version in the
+            # comment, Dependabot cannot track this one, and may even offer v6
+            # as an "update". It is the pin to bump by hand.
             - uses: "DeterminateSystems/flakehub-push@abcff4fb351e63f852f5fb2b9af0ae4e69de07d4" # main as of 2026-07-29
               with:
                   name: "y3owk1n/neru"

--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -13,8 +13,19 @@ jobs:
             - uses: "actions/checkout@v7"
               with:
                   persist-credentials: false
-            - uses: "DeterminateSystems/determinate-nix-action@v3"
-            - uses: "DeterminateSystems/flakehub-push@main"
+            # Both third-party actions below are pinned by commit rather than
+            # by ref: this job holds `id-token: write`, so whatever they resolve
+            # to can mint an OIDC token and publish a flake as this repo. A tag
+            # is a movable pointer and a branch is a moving one, so neither is a
+            # statement about which code runs. Dependabot's github-actions
+            # ecosystem updates SHA pins carrying a version comment.
+            - uses: "DeterminateSystems/determinate-nix-action@61cbfe2efc2d4e7a8a6d56967c3c1058e846c858" # v3.21.9
+            # flakehub-push has no maintained major tag: upstream's own README
+            # says `@main` everywhere, and its newest release (v6, Jul 2025) is
+            # 147 commits behind `main` and still declares `using: node20`.
+            # Pinning v6 would be a year-long rollback, so this pins the commit
+            # `main` pointed at instead. Bump it deliberately, not on a whim.
+            - uses: "DeterminateSystems/flakehub-push@abcff4fb351e63f852f5fb2b9af0ae4e69de07d4" # main as of 2026-07-29
               with:
                   name: "y3owk1n/neru"
                   rolling: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,6 +87,15 @@ jobs:
 
     publish-nightly-artifacts:
         needs: prepare-nightly-release
+        # A called workflow can only narrow what its caller granted, so the
+        # build-provenance permissions publish-artifacts.yml declares have to be
+        # granted here too. Nightly zips are published for people to download,
+        # so they are attested on the same terms as a tagged release rather than
+        # on a second code path that only breaks when someone tries to verify.
+        permissions:
+            contents: write
+            id-token: write
+            attestations: write
         uses: ./.github/workflows/publish-artifacts.yml
         with:
             release_tag: ${{ needs.prepare-nightly-release.outputs.release_tag }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,11 +87,10 @@ jobs:
 
     publish-nightly-artifacts:
         needs: prepare-nightly-release
-        # A called workflow can only narrow what its caller granted, so the
-        # build-provenance permissions publish-artifacts.yml declares have to be
-        # granted here too. Nightly zips are published for people to download,
-        # so they are attested on the same terms as a tagged release rather than
-        # on a second code path that only breaks when someone tries to verify.
+        # Build-provenance permissions, required here because a called workflow
+        # can only narrow what its caller granted — see the header comment in
+        # publish-artifacts.yml. Nightly zips are published for people to
+        # download, so they are attested on the same terms as a tagged release.
         permissions:
             contents: write
             id-token: write

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -50,11 +50,12 @@ name: publish-artifacts
 #    `uses: ./.github/workflows/publish-artifacts.yml` — drop them there and
 #    signing here stops silently.
 #
-#  - Third-party actions are pinned by commit, not by tag: a tag is a movable
-#    pointer, and these jobs later hand the release token to `gh release
-#    upload`. Dependabot's github-actions ecosystem updates a SHA pin that
-#    carries a version comment, so the trailing `# vX.Y.Z` is load-bearing.
-#    actions/* stays tag-pinned, as it does everywhere else in this repo.
+#  - setup-just is pinned by commit, not by tag: a tag is a movable pointer, and
+#    these jobs later hand the release token to `gh release upload`.
+#    Dependabot's github-actions ecosystem updates a SHA pin that carries a
+#    version comment, so the trailing `# vX.Y.Z` is load-bearing. actions/*,
+#    googleapis/* and golangci/* are deliberately left tag-pinned across this
+#    repo — accepted residual risk, weighed against the update churn.
 #
 #  - The Go toolchain comes from go.mod, as it already does in ci.yml. The
 #    literal that used to sit here drifted: six jobs still said 1.26.4 after the
@@ -134,6 +135,13 @@ jobs:
             # The bare digest this used to emit could be fed to neither, so the
             # checksum a user downloaded had to be eyeballed. The -c line is the
             # assertion that the file we just wrote really is consumable.
+            #
+            # One file per artifact rather than one SHA256SUMS per release: the
+            # six jobs run on six runners in parallel and upload independently,
+            # so an aggregate would need a seventh job re-downloading all six —
+            # and for the `nightly` tag, which is clobbered on every push to
+            # main, an aggregate left half-updated by one failed leg is worse
+            # than none. Authenticity comes from the attestation either way.
             - name: Generate darwin arm64 checksum
               run: |
                   shasum -a 256 neru-darwin-arm64.zip > neru-darwin-arm64.zip.sha256

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -34,19 +34,46 @@ on:
 
 name: publish-artifacts
 
+# Three things below are repeated six times, once per target, so the reasoning
+# lives here instead of six times over:
+#
+#  - Every job attests its zip with actions/attest-build-provenance, so a
+#    download can be traced back to this workflow, this commit and this runner
+#    with `gh attestation verify <file> --repo y3owk1n/neru`. That is the
+#    property the .sha256 files never had: they are produced by the same job and
+#    uploaded with the same token as the binary they describe, so they prove the
+#    download was not corrupted, not that the build was ours. Attestation needs
+#    `id-token: write` (to sign) and `attestations: write` (to store), granted
+#    per job rather than workflow-wide. A reusable workflow can only narrow the
+#    permissions its caller granted, never widen them, so nightly.yml and
+#    release-please.yml must grant the same three on the job that says
+#    `uses: ./.github/workflows/publish-artifacts.yml` — drop them there and
+#    signing here stops silently.
+#
+#  - Third-party actions are pinned by commit, not by tag: a tag is a movable
+#    pointer, and these jobs later hand the release token to `gh release
+#    upload`. Dependabot's github-actions ecosystem updates a SHA pin that
+#    carries a version comment, so the trailing `# vX.Y.Z` is load-bearing.
+#    actions/* stays tag-pinned, as it does everywhere else in this repo.
+#
+#  - The Go toolchain comes from go.mod, as it already does in ci.yml. The
+#    literal that used to sit here drifted: six jobs still said 1.26.4 after the
+#    module had moved on, and nothing failed to say so.
 jobs:
     build-darwin-arm64-artifacts:
         runs-on: macos-15
         permissions:
-            contents: write
+            contents: write # gh release upload
+            id-token: write # attest-build-provenance: sign the provenance
+            attestations: write # attest-build-provenance: store it on the repo
         steps:
             - uses: actions/checkout@v7
 
             - uses: actions/setup-go@v7
               with:
-                  go-version: "1.26.4"
+                  go-version-file: "go.mod"
 
-            - uses: extractions/setup-just@v4
+            - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
               with:
                   just-version: "1.54.0"
 
@@ -103,10 +130,19 @@ jobs:
                   zip -r ../../neru-darwin-arm64.zip bin Neru.app share
                   cd ../..
 
+            # `hash  filename` — the format `shasum -c` and `sha256sum -c` read.
+            # The bare digest this used to emit could be fed to neither, so the
+            # checksum a user downloaded had to be eyeballed. The -c line is the
+            # assertion that the file we just wrote really is consumable.
             - name: Generate darwin arm64 checksum
               run: |
-                  shasum -a 256 neru-darwin-arm64.zip | awk '{print $1}' > neru-darwin-arm64.zip.sha256
-                  ls -l neru-darwin-arm64.zip neru-darwin-arm64.zip.sha256
+                  shasum -a 256 neru-darwin-arm64.zip > neru-darwin-arm64.zip.sha256
+                  shasum -a 256 -c neru-darwin-arm64.zip.sha256
+
+            - name: Attest darwin arm64 build provenance
+              uses: actions/attest-build-provenance@v4
+              with:
+                  subject-path: neru-darwin-arm64.zip
 
             - name: Upload darwin arm64 release artifacts
               env:
@@ -117,15 +153,17 @@ jobs:
     build-darwin-amd64-artifacts:
         runs-on: macos-15-intel
         permissions:
-            contents: write
+            contents: write # gh release upload
+            id-token: write # attest-build-provenance: sign the provenance
+            attestations: write # attest-build-provenance: store it on the repo
         steps:
             - uses: actions/checkout@v7
 
             - uses: actions/setup-go@v7
               with:
-                  go-version: "1.26.4"
+                  go-version-file: "go.mod"
 
-            - uses: extractions/setup-just@v4
+            - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
               with:
                   just-version: "1.54.0"
 
@@ -184,8 +222,13 @@ jobs:
 
             - name: Generate darwin amd64 checksum
               run: |
-                  shasum -a 256 neru-darwin-amd64.zip | awk '{print $1}' > neru-darwin-amd64.zip.sha256
-                  ls -l neru-darwin-amd64.zip neru-darwin-amd64.zip.sha256
+                  shasum -a 256 neru-darwin-amd64.zip > neru-darwin-amd64.zip.sha256
+                  shasum -a 256 -c neru-darwin-amd64.zip.sha256
+
+            - name: Attest darwin amd64 build provenance
+              uses: actions/attest-build-provenance@v4
+              with:
+                  subject-path: neru-darwin-amd64.zip
 
             - name: Upload darwin amd64 release artifacts
               env:
@@ -196,7 +239,9 @@ jobs:
     build-linux-amd64-artifacts:
         runs-on: ubuntu-latest
         permissions:
-            contents: write
+            contents: write # gh release upload
+            id-token: write # attest-build-provenance: sign the provenance
+            attestations: write # attest-build-provenance: store it on the repo
         steps:
             - uses: actions/checkout@v7
 
@@ -221,9 +266,9 @@ jobs:
 
             - uses: actions/setup-go@v7
               with:
-                  go-version: "1.26.4"
+                  go-version-file: "go.mod"
 
-            - uses: extractions/setup-just@v4
+            - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
               with:
                   just-version: "1.54.0"
 
@@ -247,8 +292,13 @@ jobs:
 
             - name: Generate linux amd64 checksum
               run: |
-                  sha256sum neru-linux-amd64.zip | awk '{print $1}' > neru-linux-amd64.zip.sha256
-                  ls -l neru-linux-amd64.zip neru-linux-amd64.zip.sha256
+                  sha256sum neru-linux-amd64.zip > neru-linux-amd64.zip.sha256
+                  sha256sum -c neru-linux-amd64.zip.sha256
+
+            - name: Attest linux amd64 build provenance
+              uses: actions/attest-build-provenance@v4
+              with:
+                  subject-path: neru-linux-amd64.zip
 
             - name: Upload linux amd64 release artifacts
               env:
@@ -259,7 +309,9 @@ jobs:
     build-linux-arm64-artifacts:
         runs-on: ubuntu-24.04-arm
         permissions:
-            contents: write
+            contents: write # gh release upload
+            id-token: write # attest-build-provenance: sign the provenance
+            attestations: write # attest-build-provenance: store it on the repo
         steps:
             - uses: actions/checkout@v7
 
@@ -284,9 +336,9 @@ jobs:
 
             - uses: actions/setup-go@v7
               with:
-                  go-version: "1.26.4"
+                  go-version-file: "go.mod"
 
-            - uses: extractions/setup-just@v4
+            - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
               with:
                   just-version: "1.54.0"
 
@@ -310,8 +362,13 @@ jobs:
 
             - name: Generate linux arm64 checksum
               run: |
-                  sha256sum neru-linux-arm64.zip | awk '{print $1}' > neru-linux-arm64.zip.sha256
-                  ls -l neru-linux-arm64.zip neru-linux-arm64.zip.sha256
+                  sha256sum neru-linux-arm64.zip > neru-linux-arm64.zip.sha256
+                  sha256sum -c neru-linux-arm64.zip.sha256
+
+            - name: Attest linux arm64 build provenance
+              uses: actions/attest-build-provenance@v4
+              with:
+                  subject-path: neru-linux-arm64.zip
 
             - name: Upload linux arm64 release artifacts
               env:
@@ -322,15 +379,17 @@ jobs:
     build-windows-amd64-artifacts:
         runs-on: windows-latest
         permissions:
-            contents: write
+            contents: write # gh release upload
+            id-token: write # attest-build-provenance: sign the provenance
+            attestations: write # attest-build-provenance: store it on the repo
         steps:
             - uses: actions/checkout@v7
 
             - uses: actions/setup-go@v7
               with:
-                  go-version: "1.26.4"
+                  go-version-file: "go.mod"
 
-            - uses: extractions/setup-just@v4
+            - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
               with:
                   just-version: "1.54.0"
 
@@ -350,11 +409,26 @@ jobs:
                   Copy-Item build/man/*.1 build/windows-amd64/share/man/man1/
                   Compress-Archive -Path build/windows-amd64/* -DestinationPath neru-windows-amd64.zip
 
+            # Set-Content would end the line with CRLF, and `sha256sum -c` folds
+            # that CR into the filename and then reports the file as missing —
+            # so the bytes are written explicitly, and the CR check below is the
+            # assertion rather than a hope.
             - name: Generate windows amd64 checksum
               shell: pwsh
               run: |
-                  $hash = (Get-FileHash neru-windows-amd64.zip -Algorithm SHA256).Hash.ToLower()
-                  Set-Content -Path neru-windows-amd64.zip.sha256 -Value $hash
+                  $name = "neru-windows-amd64.zip"
+                  $hash = (Get-FileHash $name -Algorithm SHA256).Hash.ToLower()
+                  $path = Join-Path $PWD "$name.sha256"
+                  [System.IO.File]::WriteAllText($path, "$hash  $name`n")
+                  if ([System.IO.File]::ReadAllBytes($path) -contains 13) {
+                      throw "checksum file contains a CR; sha256sum -c cannot read it"
+                  }
+                  Get-Content $path
+
+            - name: Attest windows amd64 build provenance
+              uses: actions/attest-build-provenance@v4
+              with:
+                  subject-path: neru-windows-amd64.zip
 
             - name: Upload windows amd64 release artifacts
               env:
@@ -365,15 +439,17 @@ jobs:
     build-windows-arm64-artifacts:
         runs-on: windows-latest
         permissions:
-            contents: write
+            contents: write # gh release upload
+            id-token: write # attest-build-provenance: sign the provenance
+            attestations: write # attest-build-provenance: store it on the repo
         steps:
             - uses: actions/checkout@v7
 
             - uses: actions/setup-go@v7
               with:
-                  go-version: "1.26.4"
+                  go-version-file: "go.mod"
 
-            - uses: extractions/setup-just@v4
+            - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
               with:
                   just-version: "1.54.0"
 
@@ -396,8 +472,19 @@ jobs:
             - name: Generate windows arm64 checksum
               shell: pwsh
               run: |
-                  $hash = (Get-FileHash neru-windows-arm64.zip -Algorithm SHA256).Hash.ToLower()
-                  Set-Content -Path neru-windows-arm64.zip.sha256 -Value $hash
+                  $name = "neru-windows-arm64.zip"
+                  $hash = (Get-FileHash $name -Algorithm SHA256).Hash.ToLower()
+                  $path = Join-Path $PWD "$name.sha256"
+                  [System.IO.File]::WriteAllText($path, "$hash  $name`n")
+                  if ([System.IO.File]::ReadAllBytes($path) -contains 13) {
+                      throw "checksum file contains a CR; sha256sum -c cannot read it"
+                  }
+                  Get-Content $path
+
+            - name: Attest windows arm64 build provenance
+              uses: actions/attest-build-provenance@v4
+              with:
+                  subject-path: neru-windows-arm64.zip
 
             - name: Upload windows arm64 release artifacts
               env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,6 +39,14 @@ jobs:
             - release-please
             - prepare-release-macos-version
         if: ${{ needs.release-please.outputs.release_created == 'true' }}
+        # A called workflow can only narrow what its caller granted, so the
+        # build-provenance permissions publish-artifacts.yml declares have to be
+        # granted here too. Scoped to this job rather than raised workflow-wide:
+        # the release-please job above has no business minting an OIDC token.
+        permissions:
+            contents: write
+            id-token: write
+            attestations: write
         uses: ./.github/workflows/publish-artifacts.yml
         with:
             release_tag: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,10 +39,11 @@ jobs:
             - release-please
             - prepare-release-macos-version
         if: ${{ needs.release-please.outputs.release_created == 'true' }}
-        # A called workflow can only narrow what its caller granted, so the
-        # build-provenance permissions publish-artifacts.yml declares have to be
-        # granted here too. Scoped to this job rather than raised workflow-wide:
-        # the release-please job above has no business minting an OIDC token.
+        # Build-provenance permissions, required here because a called workflow
+        # can only narrow what its caller granted — see the header comment in
+        # publish-artifacts.yml. Scoped to this job rather than raised
+        # workflow-wide: the release-please job above has no business minting an
+        # OIDC token.
         permissions:
             contents: write
             id-token: write

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Download the latest release for your OS from [GitHub Releases](https://github.co
 | Windows  | x86_64                | `neru-windows-amd64.zip` |
 | Windows  | ARM64                 | `neru-windows-arm64.zip` |
 
-Every archive is built by GitHub Actions and carries a signed build provenance
-attestation, so you can confirm the one you downloaded came from this repository
-before you unpack it:
+Archives are built by GitHub Actions, and those published from August 2026
+onwards carry a signed build provenance attestation, so you can confirm the one
+you downloaded came from this repository before you unpack it:
 
 ```bash
 gh attestation verify neru-darwin-arm64.zip --repo y3owk1n/neru

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ Download the latest release for your OS from [GitHub Releases](https://github.co
 | Windows  | x86_64                | `neru-windows-amd64.zip` |
 | Windows  | ARM64                 | `neru-windows-arm64.zip` |
 
+Every archive is built by GitHub Actions and carries a signed build provenance
+attestation, so you can confirm the one you downloaded came from this repository
+before you unpack it:
+
+```bash
+gh attestation verify neru-darwin-arm64.zip --repo y3owk1n/neru
+```
+
+Each archive also ships a `.sha256` file next to it, readable by `shasum -a 256 -c`
+(macOS) or `sha256sum -c` (Linux). That checks the download arrived intact; the
+attestation above is what checks where it came from.
+
 Extract the binary or executable and place it on your PATH.
 
 </details>


### PR DESCRIPTION
## Description

This PR pins the third-party GitHub Actions this project depends on to exact
commits, and makes every release archive carry a signed build provenance
attestation so a download can be traced back to the workflow, commit and runner
that produced it.

Nothing here is reachable from a pull request author — there is no
`pull_request_target`, `workflow_run` or `issue_comment` trigger anywhere, and
the artifact workflow is `workflow_call`-only behind a single-owner CODEOWNERS
gate. The exposure was upstream: a tag is a movable pointer and a branch is a
moving one, so an unpinned action is a standing agreement to run whatever that
third party publishes next. One reference was a branch outright.

Alongside that, the `.sha256` files shipped with each release were unusable: they
held a bare digest that neither `shasum -c` nor `sha256sum -c` can read. They now
hold `hash  filename`, and each build job verifies its own checksum file before
uploading it.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`) — N/A, no Go, Objective-C or C changed; `just ci`'s `fmt-check` still ran
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality — N/A, workflow files carry no Go test surface; what was verified instead is under Additional Context
- [x] Documentation updated (if applicable) — README's prebuilt-binaries section now says how to verify a download
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

### What each pin is, and why

| Action | Was | Now |
| :-- | :-- | :-- |
| `DeterminateSystems/flakehub-push` | `@main` — a **branch** | commit `abcff4f` |
| `DeterminateSystems/determinate-nix-action` | `@v3` | commit `61cbfe2` (`# v3.21.9`) |
| `extractions/setup-just` | `@v4` | commit `53165ef` (`# v4.0.0`) |
| `jetify-com/devbox-install-action` | `@v0.15.0` | commit `8c6a66e` (`# v0.15.0`) |

`actions/*`, `googleapis/*` and `golangci/*` stay tag-pinned — that is a
deliberate line, not an oversight. Every SHA above was resolved with
`gh api repos/<owner>/<repo>/commits/<ref>` and checked back the other way.

Two judgement calls worth a reviewer's attention:

- **`flakehub-push` is pinned to `main`'s commit, not to a release tag.**
  Upstream has no maintained major tag: its own README says `@main` in all nine
  usage examples, and the newest release (`v6`, Jul 2025) is 147 commits behind
  `main` and still declares `using: node20`. Pinning `v6` would have been a
  year-long rollback of the code this repo already runs, so this pins the commit
  the branch pointed at instead. Dependabot may propose `v6` as an "update"; that
  is the one pin worth bumping by hand.
- **`determinate-nix-action` was pinned even though nothing asked for it.** It
  sits in the same job as `flakehub-push`, from the same vendor, holding the same
  `id-token: write`. Pinning one and leaving the other movable would not have been
  a coherent state. Easy to drop from this PR if you disagree.

### Build provenance

Each of the six build jobs now runs `actions/attest-build-provenance` on its zip
between packaging and upload, so a failed attestation means nothing is published.
Users verify with:

```bash
gh attestation verify neru-darwin-arm64.zip --repo y3owk1n/neru
```

The permissions this needs (`id-token: write`, `attestations: write`) are added
at **job** level, not workflow level — and they had to be added in three places,
because a called workflow can only narrow what its caller granted, never widen
it. Both `nightly.yml` and `release-please.yml` therefore grant them on the job
that calls the artifact workflow. **Removing them from a caller silently disables
signing rather than failing the run**, which is the one sharp edge in this change.

Nightly builds are attested on the same terms as tagged releases. People do
download nightlies, and a second code path through the same reusable workflow
would only be discovered broken by someone trying to verify one.

### Checksums: per-artifact files, not a single `SHA256SUMS`

I kept the existing per-artifact `.sha256` assets and fixed their format, rather
than emitting one `SHA256SUMS` per release. The six jobs build on six different
runners in parallel and upload independently; there is no fan-in point, so a
single file would need a seventh job that re-downloads all six assets — and for
the `nightly` tag, which is clobbered on every push to `main`, a partially
updated aggregate file after one failed leg is a worse artifact than none. Asset
names also stay stable for anyone already fetching them. Authenticity is what the
attestation supplies; the sums file only ever owed integrity.

**Potentially breaking for a narrow audience:** any script that read a `.sha256`
asset as a bare digest (`test "$(cat x.sha256)" = ...`) will now see
`hash  filename` on that line. Nothing in this repo consumed the old format
(`nix/package.nix` carries its own hashes), and the new format is what the
standard checkers expect. `shasum -a 256 -c x.sha256` and `sha256sum -c
x.sha256` both work now; neither worked before.

### Go toolchain

`publish-artifacts.yml` hardcoded `go-version: "1.26.4"` in six places. Those now
read `go-version-file: "go.mod"`, as `ci.yml` already did, so there is one source
of truth. `go.mod` itself is untouched — this branch is rebased on top of #1525,
so the six release jobs now pick up `toolchain go1.26.6` from it instead of a
literal that had already gone stale.

### What was verified, and what could not be

Verified mechanically:

- `actionlint` v1.7.12 clean across all five workflows. A negative control
  confirmed it really validates both the `attestations` permission scope and
  `actions/attest-build-provenance@v4`'s input names — a clean run is evidence,
  not silence.
- Every pinned SHA resolved from its ref and checked back the other way.
- All six checksum steps were extracted verbatim from the YAML and executed —
  the two macOS legs, the two Linux legs against GNU coreutils, and both Windows
  legs on real PowerShell 7.6.4. Each output was accepted by `shasum -a 256 -c`
  *and* `sha256sum -c`, is a single LF-terminated line with the right digest and
  filename, and is rejected after a one-byte change to the archive. The CR guard
  in the PowerShell legs was separately shown to fire on a CRLF file, so it is
  not vacuous.
- Job permissions and step ordering audited programmatically from the parsed
  YAML: every upload is preceded by an attest step, and every remaining tag-pinned
  action is `actions/*`, `googleapis/*` or `golangci/*`.

Reasoned but **not** exercised, since the release workflow cannot be run here:

- That the granted permissions are sufficient in practice, and that
  reusable-workflow inheritance behaves as documented.
- That `actions/attest-build-provenance` succeeds on `macos-15-intel`,
  `ubuntu-24.04-arm` and `windows-latest`.
- That `go-version-file` resolves the same toolchain the literal did on all six
  runners.

The first release after this merges is the first real exercise of all three.
