### PR TITLE
chore: remove redundant comments across the codebase

### DIFF
--- a/internal/adapter/accessibility/adapter.go
+++ b/internal/adapter/accessibility/adapter.go
@@ -53,9 +53,7 @@ var elementSlicePool = sync.Pool{
 }
 
 // Adapter implements ports.AccessibilityPort by wrapping the ax.Client.
-// It converts between domain models and infrastructure types.
 type Adapter struct {
-	// logger for adapter.
 	logger               *zap.Logger
 	client               ax.Client
 	excludedBundles      map[string]bool
@@ -86,13 +84,11 @@ func NewAdapter(
 }
 
 // Logger returns the logger for the adapter.
-// It is used for testing mainly.
 func (a *Adapter) Logger() *zap.Logger {
 	return a.logger
 }
 
 // ClickableRoles returns the list of clickable roles.
-// It is used for testing mainly.
 func (a *Adapter) ClickableRoles() []string {
 	return a.clickableRoles
 }
@@ -179,7 +175,6 @@ func (a *Adapter) PerformAction(
 	element *element.Element,
 	actionType action.Type,
 ) error {
-	// Check context
 	select {
 	case <-ctx.Done():
 		return derrors.Wrap(ctx.Err(), derrors.CodeContextCanceled, "operation canceled")
@@ -283,8 +278,6 @@ func (a *Adapter) IsAppExcluded(_ context.Context, bundleID string) bool {
 }
 
 // ReleaseHeldButtons releases any mouse button this process still holds down.
-// The per-platform release lives in element_<os>.go; it is unexported because
-// only this adapter and the infra client may reach it.
 func (a *Adapter) ReleaseHeldButtons(ctx context.Context) error {
 	err := a.checkContext(ctx)
 	if err != nil {
@@ -356,16 +349,14 @@ func (a *Adapter) processClickableNodes(
 	clickableNodes []ax.Node,
 	filter ports.ElementFilter,
 ) ([]*element.Element, error) {
-	// Get pooled slice and reset it
 	elementsPtr, ok := elementSlicePool.Get().(*[]*element.Element)
 	if !ok {
 		s := make([]*element.Element, 0, TypicalElementCount)
 		elementsPtr = &s
 	}
 
-	elements := (*elementsPtr)[:0] // Reset to zero length but keep capacity
+	elements := (*elementsPtr)[:0]
 	defer func() {
-		// Clear references before returning to pool
 		for i := range elements {
 			elements[i] = nil
 		}
@@ -381,13 +372,11 @@ func (a *Adapter) processClickableNodes(
 		)
 	}()
 
-	// Concurrent processing for large number of nodes
 	if len(clickableNodes) > ConcurrentProcessingThreshold {
 		return a.processClickableNodesConcurrent(ctx, clickableNodes, filter)
 	}
 
 	for index, node := range clickableNodes {
-		// Check context periodically
 		if index%contextCheckInterval == 0 {
 			err := a.checkContext(ctx)
 			if err != nil {
@@ -418,7 +407,6 @@ func (a *Adapter) processClickableNodes(
 		}
 	}
 
-	// Make a copy to return since we're returning the pooled slice
 	result := make([]*element.Element, len(elements))
 	copy(result, elements)
 
@@ -432,9 +420,7 @@ func (a *Adapter) processClickableNodesConcurrent(
 	filter ports.ElementFilter,
 ) ([]*element.Element, error) {
 	numWorkers := min(
-		// Use available parallelism
 		runtime.GOMAXPROCS(0),
-		// Cap to avoid diminishing returns
 		maxConcurrentWorkers)
 
 	chunkSize := (len(nodes) + numWorkers - 1) / numWorkers
@@ -464,7 +450,6 @@ func (a *Adapter) processClickableNodesConcurrent(
 		go func(chunk []ax.Node) {
 			defer waitGroup.Done()
 
-			// Use local slice to avoid locking
 			localElements := make([]*element.Element, 0, len(chunk))
 
 			for idx, node := range chunk {
@@ -501,8 +486,6 @@ func (a *Adapter) processClickableNodesConcurrent(
 		close(results)
 	}()
 
-	// Collect results
-	// Pre-allocate based on input size estimate (conservative)
 	allElements := make([]*element.Element, 0, len(nodes)/EstimatedFilteringRatio)
 
 	for res := range results {

--- a/internal/adapter/accessibility/adapter_conversion.go
+++ b/internal/adapter/accessibility/adapter_conversion.go
@@ -12,16 +12,9 @@ func (a *Adapter) convertToDomainElement(node ax.Node) (*element.Element, error)
 		return nil, derrors.New(derrors.CodeInvalidInput, "node is nil")
 	}
 
-	// Create element ID from unique identifier
 	elementID := element.ID(node.ID())
-
-	// Get bounds
 	bounds := node.Bounds()
-
-	// Convert role
 	role := element.Role(node.Role())
-
-	// Determine if clickable
 	isClickable := node.IsClickable()
 
 	searchText := ""

--- a/internal/adapter/accessibility/adapter_filtering.go
+++ b/internal/adapter/accessibility/adapter_filtering.go
@@ -16,13 +16,11 @@ func (a *Adapter) MatchesFilter(
 	elem *element.Element,
 	filter ports.ElementFilter,
 ) bool {
-	// Check minimum size
 	bounds := elem.Bounds()
 	if bounds.Dx() < filter.MinSize.X || bounds.Dy() < filter.MinSize.Y {
 		return false
 	}
 
-	// Check role inclusion
 	if len(filter.Roles) > 0 {
 		found := slices.Contains(filter.Roles, elem.Role())
 		if !found {
@@ -30,14 +28,10 @@ func (a *Adapter) MatchesFilter(
 		}
 	}
 
-	// Check role exclusion
 	if slices.Contains(filter.ExcludeRoles, elem.Role()) {
 		return false
 	}
 
-	// Check title contains filter
-	// NOTE: filter.TitleContains is expected to be pre-lowercased by the caller (e.g. ClickableElements).
-	// Direct callers of MatchesFilter must also lowercase filter strings before passing them.
 	titleMatched := false
 	if filter.TitleContains != "" {
 		title := elem.Title()
@@ -47,7 +41,6 @@ func (a *Adapter) MatchesFilter(
 		}
 	}
 
-	// Check description contains filter
 	descMatched := false
 	if filter.DescriptionContains != "" {
 		description := elem.Description()
@@ -60,7 +53,6 @@ func (a *Adapter) MatchesFilter(
 		}
 	}
 
-	// Check value contains filter
 	valueMatched := false
 	if filter.ValueContains != "" {
 		value := textForFilter(elem)
@@ -70,7 +62,6 @@ func (a *Adapter) MatchesFilter(
 		}
 	}
 
-	// Check any of the additional text substrings match (OR logic)
 	textListMatched := false
 	if len(filter.TextContainsList) > 0 {
 		title := elem.Title()

--- a/internal/adapter/overlay/render/grid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/grid/overlay_darwin.go
@@ -370,7 +370,6 @@ func (o *Overlay) DrawGrid(grid *domainGrid.Grid, currentInput string, style Sty
 		runtime.ReadMemStats(&msBefore)
 	}
 
-	// Check if we can do incremental updates (always try if we have previous state)
 	o.gridStateMu.RLock()
 	canIncrementalUpdate := o.previousGrid != nil
 	o.gridStateMu.RUnlock()
@@ -582,7 +581,6 @@ func (o *Overlay) drawGridIncremental(
 		return false // No previous state to compare against
 	}
 
-	// Check if only the input changed (common case for typing)
 	if o.gridsAreStructurallyEqual(grid, previousGrid) && style == previousStyle {
 		// Only input changed - we can do incremental match updates
 		if currentInput != previousInput {
@@ -623,7 +621,6 @@ func (o *Overlay) gridsAreStructurallyEqual(a, b *domainGrid.Grid) bool {
 		return false
 	}
 
-	// Check if all cells have the same coordinates and bounds
 	for i, aCell := range aCells {
 		bCell := bCells[i]
 		if aCell.Coordinate() != bCell.Coordinate() ||

--- a/internal/adapter/overlay/render/hints/overlay_darwin.go
+++ b/internal/adapter/overlay/render/hints/overlay_darwin.go
@@ -410,7 +410,6 @@ func (o *Overlay) drawHintsInternal(hints []*Hint, style StyleMode, showArrow bo
 		}
 	}
 
-	// Check if we can do incremental updates
 	o.hintStateMu.RLock()
 	canIncrementalUpdate := len(o.previousHints) > 0
 	o.hintStateMu.RUnlock()
@@ -571,7 +570,6 @@ func (o *Overlay) drawHintsIncremental(
 		return false // No previous state to compare against
 	}
 
-	// Check if only the input changed (common case for typing)
 	if o.hintsAreStructurallyEqual(hints, previousHints) && style == previousStyle {
 		// Only input changed - we can do incremental match updates
 		if currentInput != previousInput {

--- a/internal/adapter/overlay/render/overlayutil/util.go
+++ b/internal/adapter/overlay/render/overlayutil/util.go
@@ -75,19 +75,16 @@ func releaseCallbackID(callbackID uint64) {
 
 	if !allocatedCallbackIDs[callbackID] {
 		allocatedCallbackIDsMu.Unlock()
-		// ID is not allocated, nothing to release
 		return
 	}
 
 	delete(allocatedCallbackIDs, callbackID)
 	allocatedCallbackIDsMu.Unlock()
 
-	// Remove from global registry
 	callbackManagerRegistryMu.Lock()
 	delete(callbackManagerRegistry, callbackID)
 	callbackManagerRegistryMu.Unlock()
 
-	// Return the ID to the free pool for reuse
 	freeCallbackIDsMu.Lock()
 
 	freeCallbackIDs = append(freeCallbackIDs, callbackID)
@@ -127,16 +124,11 @@ func CompleteGlobalCallback(callbackID uint64, expectedGeneration uint64) {
 		return
 	}
 
-	// Atomically remove the registry entry so no concurrent deferred release
-	// or new allocation can race with us on this callback ID.
 	delete(callbackManagerRegistry, callbackID)
 	callbackManagerRegistryMu.Unlock()
 
 	entry.manager.CompleteCallback(callbackID)
 
-	// Return the ID to the free pool. Since we already deleted the registry
-	// entry above, releaseCallbackID will skip the registry delete (no-op)
-	// but will still clear allocatedCallbackIDs and return the ID to the pool.
 	releaseCallbackID(callbackID)
 }
 
@@ -269,10 +261,7 @@ func (c *CallbackManager) CompleteCallback(callbackID uint64) {
 // This should be called when the overlay is being destroyed.
 // Safe to call multiple times - only executes cleanup once.
 func (c *CallbackManager) Cleanup() {
-	// Use sync.Once to ensure cleanup only happens once
-	// This prevents panic from double-close of the cancel channel
 	c.cleanupOnce.Do(func() {
-		// Close the cancel channel to stop all background goroutines
 		close(c.cancelCh)
 
 		// Snapshot and clear callbackMap under callbackMu first, then remove

--- a/internal/adapter/overlay/render/recursivegrid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/recursivegrid/overlay_darwin.go
@@ -31,9 +31,7 @@ import (
 
 //export recursiveGridResizeCompletionCallback
 func recursiveGridResizeCompletionCallback(context unsafe.Pointer) {
-	// Read callback context from the C-heap-allocated CallbackContext
 	ctx := *(*overlayutil.CallbackContext)(context)
-	// Free the C-allocated context now that we've copied the values
 	overlayutil.FreeCallbackContext(context)
 	overlayutil.CompleteGlobalCallback(ctx.CallbackID, ctx.Generation)
 }
@@ -304,7 +302,6 @@ func (o *Overlay) DrawRecursiveGrid(
 	dims = usableDims
 	keyCount := dims.CellCount()
 
-	// Validate keys length matches grid dimensions
 	keyRunes := []rune(keys)
 	if len(keyRunes) != keyCount {
 		o.logger.Warn(
@@ -316,7 +313,6 @@ func (o *Overlay) DrawRecursiveGrid(
 	// draw call so that freeLabelCache cannot free labels mid-draw.
 	o.drawMu.RLock()
 
-	// Compute cell positions using the shared helper (same as Divide()).
 	cellRects := recursivegrid.ComputeGridCells(bounds, dims)
 
 	cells := make([]C.GridCell, keyCount)
@@ -339,9 +335,6 @@ func (o *Overlay) DrawRecursiveGrid(
 		}
 	}
 
-	// Build sub-key preview labels.
-	// When a label char override is set, repeat it to match the grid cell count
-	// so the native renderer gets the expected number of labels.
 	subKeyLabel := style.SubKeyPreviewLabelChar()
 	if subKeyLabel != "" {
 		subKeyLabel = strings.Repeat(subKeyLabel, nextDims.CellCount())

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -40,7 +40,6 @@ func (a *App) SetConfigField(ctx context.Context, key, value string) error {
 		return err
 	}
 
-	// Validate the new config.
 	valErr := newCfg.Validate()
 	if valErr != nil {
 		a.restoreHotkeysAfterFailedReload()
@@ -48,7 +47,6 @@ func (a *App) SetConfigField(ctx context.Context, key, value string) error {
 		return derrors.Wrap(valErr, derrors.CodeInvalidConfig, "config-set validation")
 	}
 
-	// Update the config service (notifies watchers with the new config).
 	updateErr := a.configService.Update(newCfg, newWritten)
 	if updateErr != nil {
 		a.restoreHotkeysAfterFailedReload()
@@ -56,7 +54,6 @@ func (a *App) SetConfigField(ctx context.Context, key, value string) error {
 		return updateErr
 	}
 
-	// Build a LoadResult for the reconfiguration helpers.
 	loadResult := &config.LoadResult{
 		Config:     newCfg,
 		Written:    newWritten,

--- a/internal/app/getters.go
+++ b/internal/app/getters.go
@@ -132,7 +132,6 @@ func (a *App) IsOverlayHiddenForScreenShare() bool {
 
 // SetOverlayHiddenForScreenShare sets whether the overlay should be hidden from screen sharing.
 func (a *App) SetOverlayHiddenForScreenShare(hide bool) {
-	// Update app state (this will trigger callbacks)
 	a.appState.SetHiddenForScreenShare(hide)
 }
 

--- a/internal/app/ipcctrl/info.go
+++ b/internal/app/ipcctrl/info.go
@@ -131,7 +131,6 @@ func (h *InfoHandler) ResolveConfigPath() string {
 		return "using default config"
 	}
 
-	// Check if the config file actually exists
 	_, err := os.Stat(configPath)
 	if os.IsNotExist(err) {
 		return "using default config"

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -152,7 +152,6 @@ func (h *handlerState) activateRecursiveGridModeWithAction(activation modecmd.Ac
 
 // initializeRecursiveGridManager initializes the recursive-grid manager.
 func (h *handlerState) initializeRecursiveGridManager(screenBounds image.Rectangle) {
-	// Ensure recursiveGrid component is initialized
 	if h.recursiveGrid == nil {
 		h.recursiveGrid = &components.RecursiveGridComponent{
 			Context: &componentrecursivegrid.Context{},

--- a/internal/app/modes/validation.go
+++ b/internal/app/modes/validation.go
@@ -55,7 +55,6 @@ func (h *handlerState) validateModeActivation(
 		return derrors.Newf(derrors.CodeInvalidInput, "mode %s is disabled", modeName)
 	}
 
-	// Check if focused app is excluded
 	if bundleID != "" {
 		if h.actionService.IsAppExcluded(h.ctx, bundleID) {
 			return derrors.New(derrors.CodeInvalidInput, "focused app is excluded")

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -698,7 +698,6 @@ func TestHintService_Health(t *testing.T) {
 	ctx := context.Background()
 	health := service.Health(ctx)
 
-	// Check that health map has both keys
 	if len(health) != 2 {
 		t.Errorf("Health() returned %d entries, want 2", len(health))
 	}
@@ -711,7 +710,6 @@ func TestHintService_Health(t *testing.T) {
 		t.Error("Health() missing 'overlay' key")
 	}
 
-	// Check that overlay has error
 	if health["overlay"] == nil {
 		t.Error("Health() overlay should have error")
 	}

--- a/internal/cli/services_darwin.go
+++ b/internal/cli/services_darwin.go
@@ -116,7 +116,6 @@ func isServiceLoaded() bool {
 }
 
 func installService() error {
-	// Check if service is already loaded
 	if isServiceLoaded() {
 		return errServiceAlreadyLoaded
 	}
@@ -147,7 +146,6 @@ func installService() error {
 		return fmt.Errorf("failed to expand LaunchAgents path: %w", err)
 	}
 
-	// Check if plist already exists
 	expandedPlist := filepath.Join(expandedDir, serviceLabel+".plist")
 
 	_, statErr := os.Stat(expandedPlist)
@@ -159,7 +157,6 @@ func installService() error {
 		)
 	}
 
-	// Ensure directory exists
 	const dirPerm = 0o755
 
 	err = os.MkdirAll(expandedDir, dirPerm)
@@ -167,7 +164,6 @@ func installService() error {
 		return fmt.Errorf("failed to create LaunchAgents directory: %w", err)
 	}
 
-	// Write plist
 	const filePerm = 0o644
 
 	err = os.WriteFile(expandedPlist, []byte(plistContent), filePerm)

--- a/internal/config/loader/persistence.go
+++ b/internal/config/loader/persistence.go
@@ -116,7 +116,6 @@ func writeStringOrStringArrayMap(
 
 // Save writes the configuration to the specified path.
 func Save(cfg *config.Config, path string) error {
-	// Create directory if it doesn't exist
 	dir := filepath.Dir(path)
 
 	mkdirErr := os.MkdirAll(dir, config.DefaultDirPerms)
@@ -128,7 +127,6 @@ func Save(cfg *config.Config, path string) error {
 		)
 	}
 
-	// Create file
 	var closeErr error
 	// #nosec G304 -- Path is validated and controlled by the application
 	file, fileErr := os.Create(path)

--- a/internal/config/loader/service.go
+++ b/internal/config/loader/service.go
@@ -407,14 +407,12 @@ func (s *Service) GetConfigPath() string {
 
 // Reload reloads the configuration from the specified path.
 func (s *Service) Reload(ctx context.Context, path string) error {
-	// Load and validate new config
 	loadResult := s.LoadWithValidation(path)
 
 	if loadResult.ValidationError != nil {
 		return loadResult.ValidationError
 	}
 
-	// Update configuration atomically
 	s.mu.Lock()
 	s.config = loadResult.Config
 	s.written = loadResult.Written
@@ -423,7 +421,6 @@ func (s *Service) Reload(ctx context.Context, path string) error {
 	copy(watchers, s.watchers)
 	s.mu.Unlock()
 
-	// Notify watchers (outside the lock to avoid deadlock)
 	for _, watcher := range watchers {
 		if !safeSendConfig(watcher, loadResult.Config) {
 			s.logger.Debug("Watcher channel full, skipping notification")
@@ -431,7 +428,6 @@ func (s *Service) Reload(ctx context.Context, path string) error {
 			continue
 		}
 
-		// Check if context was canceled during send
 		select {
 		case <-ctx.Done():
 			return derrors.WrapContextCanceled(ctx, "notify config watchers")

--- a/internal/config/loader/set_field.go
+++ b/internal/config/loader/set_field.go
@@ -99,9 +99,12 @@ func derefStruct(field reflect.Value) reflect.Value {
 	return field
 }
 
-// many variants (Chan, Map, Func, etc.) that are never valid config field types.
+// setLeafValue handles only config-relevant reflect.Kind variants (String,
+// Int, Float, Bool, Slice, Struct); all others are unreachable in valid config
+// paths. The exhaustive linter is suppressed because adding every Kind would be
+// noise.
 //
-//nolint:exhaustive // Only config-relevant types are handled; reflect.Kind has
+//nolint:exhaustive
 func setLeafValue(field reflect.Value, value string) error {
 	field = derefStruct(field)
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -77,7 +77,6 @@ func (c *Config) ValidateWithWarnings(warnings *Warnings, written WrittenConfig)
 		return err
 	}
 
-	// Validate global hotkey app configs
 	err = validateHotkeysAppConfigs("app_configs", c.AppConfigs)
 	if err != nil {
 		return err

--- a/internal/domain/action/action_test.go
+++ b/internal/domain/action/action_test.go
@@ -171,7 +171,6 @@ func TestAllTypes(t *testing.T) {
 		t.Errorf("AllTypes() returned %d types, want 15", len(types))
 	}
 
-	// Check that all types are unique
 	seen := make(map[action.Type]bool)
 	for _, typ := range types {
 		if seen[typ] {
@@ -181,7 +180,6 @@ func TestAllTypes(t *testing.T) {
 		seen[typ] = true
 	}
 
-	// Check that all expected types are present
 	expected := []action.Type{
 		action.TypeLeftClick,
 		action.TypeRightClick,
@@ -208,7 +206,6 @@ func TestAllTypes(t *testing.T) {
 }
 
 func TestParseType_RoundTrip(t *testing.T) {
-	// Test that String() and ParseType() are inverses
 	for _, typ := range action.AllTypes() {
 		str := typ.String()
 
@@ -348,7 +345,6 @@ func TestKnownNames(t *testing.T) {
 		t.Errorf("KnownNames() returned %d names, want 15", len(names))
 	}
 
-	// Check that all names are unique
 	seen := make(map[action.Name]bool)
 	for _, name := range names {
 		if seen[name] {
@@ -358,7 +354,6 @@ func TestKnownNames(t *testing.T) {
 		seen[name] = true
 	}
 
-	// Check that all expected names are present
 	expected := []action.Name{
 		action.NameLeftClick,
 		action.NameRightClick,
@@ -387,7 +382,6 @@ func TestKnownNames(t *testing.T) {
 func TestSupportedNamesString(t *testing.T) {
 	str := action.SupportedNamesString()
 
-	// Should contain all action names
 	expectedNames := []string{
 		testLeftClick,
 		testRightClick,

--- a/internal/domain/grid/grid_test.go
+++ b/internal/domain/grid/grid_test.go
@@ -52,7 +52,6 @@ func TestGrid_CellByCoordinate(t *testing.T) {
 	logger := logger.Get()
 	grid := grid.NewGrid("ABC", image.Rect(0, 0, 300, 300), logger)
 
-	// Get a valid coordinate from the generated grid
 	cells := grid.AllCells()
 	if len(cells) == 0 {
 		t.Fatal("Expected cells to be generated")
@@ -263,14 +262,12 @@ func TestGrid_WithCustomLabels(t *testing.T) {
 	logger := logger.Get()
 	bounds := image.Rect(0, 0, 300, 300)
 
-	// Test with custom row and column labels
 	gridInstance := grid.NewGridWithLabels(testCharacters, "123", "XYZ", bounds, logger)
 
 	if gridInstance.Characters() != testCharacters {
 		t.Errorf("Characters() = %q, want %q", gridInstance.Characters(), testCharacters)
 	}
 
-	// Check ValidCharacters includes all used characters
 	validChars := gridInstance.ValidCharacters()
 
 	expectedChars := "ABC123XYZ"
@@ -280,13 +277,11 @@ func TestGrid_WithCustomLabels(t *testing.T) {
 		}
 	}
 
-	// Check that cells use the custom labels
 	cells := gridInstance.Cells()
 	if len(cells) == 0 {
 		t.Fatal("No cells generated")
 	}
 
-	// Check for unique coordinates
 	foundLabels := make(map[string]bool)
 	for _, cell := range cells {
 		if foundLabels[cell.Coordinate()] {
@@ -306,14 +301,12 @@ func TestGrid_CustomLabelsWithSymbols(t *testing.T) {
 	logger := logger.Get()
 	bounds := image.Rect(0, 0, 500, 500)
 
-	// Test with symbols in labels (like user's config)
 	characters := "AOEUIDHTNSPYFGKXBM"
 	rowLabels := "',.PYFGCRL/AOEUIDHTNS-;QJKXBMWVZ="
 	colLabels := "AOEUIDHTNS"
 
 	gridInstance := grid.NewGridWithLabels(characters, rowLabels, colLabels, bounds, logger)
 
-	// Check ValidCharacters includes symbols
 	validChars := gridInstance.ValidCharacters()
 
 	expectedSymbols := "',./-;=QJKXBMWVZPYFGCRL"
@@ -323,7 +316,6 @@ func TestGrid_CustomLabelsWithSymbols(t *testing.T) {
 		}
 	}
 
-	// Check cells have unique coordinates
 	cells := gridInstance.Cells()
 
 	coordMap := make(map[string]bool)
@@ -381,22 +373,18 @@ func TestGrid_HasCoordinatePrefix(t *testing.T) {
 	logger := logger.Get()
 	bounds := image.Rect(0, 0, 300, 300)
 
-	// Create first grid
 	grid1 := grid.NewGrid(testCharacters, bounds, logger)
 
-	// Test that prefixes work on the first grid
 	cells := grid1.Cells()
 	if len(cells) == 0 {
 		t.Fatal("Grid should have cells")
 	}
 
-	// Get a sample coordinate
 	sampleCoord := cells[0].Coordinate()
 	if len(sampleCoord) < 2 {
 		t.Fatalf("Expected coordinate length >= 2, got %d", len(sampleCoord))
 	}
 
-	// Test prefixes of the sample coordinate
 	for i := 1; i <= len(sampleCoord); i++ {
 		prefix := sampleCoord[:i]
 		if !grid1.HasCoordinatePrefix(prefix) {
@@ -408,15 +396,12 @@ func TestGrid_HasCoordinatePrefix(t *testing.T) {
 		}
 	}
 
-	// Test invalid prefix
 	if grid1.HasCoordinatePrefix("INVALID") {
 		t.Error("HasCoordinatePrefix should return false for invalid prefix")
 	}
 
-	// Create second grid with same parameters (should hit cache)
 	grid2 := grid.NewGrid(testCharacters, bounds, logger)
 
-	// Test that prefixes still work on the cached grid
 	for i := 1; i <= len(sampleCoord); i++ {
 		prefix := sampleCoord[:i]
 		if !grid2.HasCoordinatePrefix(prefix) {
@@ -428,7 +413,6 @@ func TestGrid_HasCoordinatePrefix(t *testing.T) {
 		}
 	}
 
-	// Test invalid prefix on cached grid
 	if grid2.HasCoordinatePrefix("INVALID") {
 		t.Error("HasCoordinatePrefix should return false for invalid prefix on cached grid")
 	}

--- a/internal/domain/grid/manager.go
+++ b/internal/domain/grid/manager.go
@@ -96,7 +96,6 @@ func (m *Manager) HandleInput(key string) (image.Point, bool) {
 
 	// Note: reset key already handled above (supports modifiers and single chars).
 
-	// Validate input key against grid characters
 	if !m.validateInputKey(upperKey) {
 		return image.Point{}, false
 	}
@@ -108,7 +107,6 @@ func (m *Manager) HandleInput(key string) (image.Point, bool) {
 		return m.handleLabelLengthReached()
 	}
 
-	// Update overlay to highlight matched cells
 	if m.onUpdate != nil {
 		m.onUpdate(false)
 	}

--- a/internal/domain/grid/manager_test.go
+++ b/internal/domain/grid/manager_test.go
@@ -13,30 +13,23 @@ import (
 func TestGridManager_RouterIntegration(t *testing.T) {
 	logger := logger.Get()
 
-	// Create a test grid
 	testGrid := grid.NewGrid("abcdefghijklmnopqrstuvwxyz", image.Rect(0, 0, 1000, 1000), logger)
 
-	// Create grid manager
 	gridManager := grid.NewManager(
 		testGrid,
 		domain.GridDimensions{Rows: 3, Cols: 3}, "asdf",
 		func(redraw bool) {
-			// Update callback
 		},
 		func(cell *grid.Cell) {
-			// Show sub callback
 		},
 		logger,
 	)
 
-	// Create grid router
 	gridRouter := grid.NewRouter(gridManager, logger)
 
 	t.Run("Grid routing workflow", func(t *testing.T) {
-		// Test typing "a" - should be valid input (4-char labels needed)
 		gridRouter.RouteKey("a")
 
-		// Test typing "s" - still not complete
 		result2 := gridRouter.RouteKey("s")
 
 		if result2.Complete() {
@@ -50,14 +43,12 @@ func TestGridManager_RouterIntegration(t *testing.T) {
 			t.Error("Expected not complete on three characters")
 		}
 
-		// Test typing "f" - should complete coordinate
 		result4 := gridRouter.RouteKey("f")
 
 		if !result4.Complete() {
 			t.Error("Expected complete on fourth character")
 		}
 
-		// Check target point
 		targetPoint := result4.TargetPoint()
 		if targetPoint.X == 0 || targetPoint.Y == 0 {
 			t.Error("Expected non-zero target point")
@@ -65,17 +56,13 @@ func TestGridManager_RouterIntegration(t *testing.T) {
 	})
 
 	t.Run("Grid manager input handling", func(t *testing.T) {
-		// Test input handling - this tests the grid manager's coordinate processing
-		// With subgrid enabled, single characters might complete selections
 		gridManager.HandleInput("a")
 
-		// Test tab key handling - should move to next subgrid
-		pointTab, completeTab := gridManager.HandleInput("\t") // Tab key
+		pointTab, completeTab := gridManager.HandleInput("\t")
 		if completeTab {
 			t.Logf("Tab completed selection at point: %v", pointTab)
 		}
 
-		// Test that we can handle multiple inputs
 		gridManager.HandleInput("s")
 		gridManager.HandleInput("d")
 		point4, _ := gridManager.HandleInput("f")
@@ -86,7 +73,6 @@ func TestGridManager_RouterIntegration(t *testing.T) {
 	})
 
 	t.Run("Grid escape and tab handling", func(t *testing.T) {
-		// Escape handling is now done by top-level custom hotkeys, not grid router.
 		result := gridRouter.RouteKey("escape")
 
 		if result.Complete() {
@@ -128,12 +114,10 @@ func TestManager_CurrentInput(t *testing.T) {
 		logger,
 	)
 
-	// Initially empty
 	if input := manager.CurrentInput(); input != "" {
 		t.Errorf("CurrentInput() = %q, want empty", input)
 	}
 
-	// After input
 	manager.HandleInput("A")
 
 	if input := manager.CurrentInput(); input != "A" {
@@ -143,7 +127,6 @@ func TestManager_CurrentInput(t *testing.T) {
 
 func TestManager_Reset(t *testing.T) {
 	logger := logger.Get()
-	// Use unique parameters to avoid cache conflicts
 	testGrid := grid.NewGrid("ABCD", image.Rect(0, 0, 50, 50), logger)
 
 	manager := grid.NewManager(
@@ -181,14 +164,12 @@ func TestManager_IgnoresNonSingleCharKey(t *testing.T) {
 		logger,
 	)
 
-	// Type a valid character
 	manager.HandleInput("A")
 
 	if manager.CurrentInput() != "A" {
 		t.Fatalf("expected input 'A' before reset, got %q", manager.CurrentInput())
 	}
 
-	// Multi-character key names are ignored by HandleInput.
 	point, complete := manager.HandleInput("Ctrl+R")
 	if complete {
 		t.Fatalf("multi-character key should not complete selection")
@@ -205,7 +186,6 @@ func TestManager_IgnoresNonSingleCharKey(t *testing.T) {
 
 func TestManager_AcceptsNonLetterCharacters(t *testing.T) {
 	logger := logger.Get()
-	// Create grid with only numbers and symbols
 	testGrid := grid.NewGrid("123!@", image.Rect(0, 0, 500, 500), logger)
 
 	manager := grid.NewManager(
@@ -217,7 +197,6 @@ func TestManager_AcceptsNonLetterCharacters(t *testing.T) {
 		logger,
 	)
 
-	// Test that numbers are accepted
 	_, complete := manager.HandleInput("1")
 	if complete {
 		t.Error("Expected not complete after single number")
@@ -229,7 +208,6 @@ func TestManager_AcceptsNonLetterCharacters(t *testing.T) {
 
 	manager.Reset()
 
-	// Test that symbols are accepted
 	_, complete2 := manager.HandleInput("!")
 	if complete2 {
 		t.Error("Expected not complete after single symbol")
@@ -246,7 +224,6 @@ func TestManager_CustomLabelsWithSymbols(t *testing.T) {
 	// Create grid with custom labels containing symbols
 	testGrid := grid.NewGridWithLabels("ABC", "',.PYF", "AOEU", image.Rect(0, 0, 300, 300), logger)
 
-	// Check that ValidCharacters includes the comma
 	validChars := testGrid.ValidCharacters()
 	if !strings.Contains(validChars, ",") {
 		t.Errorf("ValidCharacters() = %q, should contain ','", validChars)
@@ -261,7 +238,6 @@ func TestManager_CustomLabelsWithSymbols(t *testing.T) {
 		logger,
 	)
 
-	// Test that regular characters work
 	_, complete := manager.HandleInput("A")
 	if complete {
 		t.Error("Expected not complete after A")
@@ -271,19 +247,15 @@ func TestManager_CustomLabelsWithSymbols(t *testing.T) {
 		t.Errorf("CurrentInput() = %q, want 'A'", input)
 	}
 
-	// Test that symbols from row_labels are accepted only if they lead to valid coordinates
-	// Note: "," is now the reset key, so we use "." instead for testing symbols
 	_, complete = manager.HandleInput(".")
 	if complete {
 		t.Error("Expected not complete after period")
 	}
 
-	// Since "A." doesn't match any coordinate prefix, it should be rejected
 	if input := manager.CurrentInput(); input != "A" {
 		t.Errorf("CurrentInput() = %q, want 'A' (period should be rejected)", input)
 	}
 
-	// Test that a valid next character is accepted
 	_, complete = manager.HandleInput("A") // "AA" should match some coordinates
 	if complete {
 		t.Error("Expected not complete after AA")
@@ -293,25 +265,21 @@ func TestManager_CustomLabelsWithSymbols(t *testing.T) {
 		t.Errorf("CurrentInput() = %q, want 'AA'", input)
 	}
 
-	// Reset API should clear input.
 	manager.Reset()
 
 	if input := manager.CurrentInput(); input != "" {
 		t.Errorf("CurrentInput() = %q, want '' after reset", input)
 	}
 
-	// Test that invalid character is rejected (input stays empty after reset)
 	_, complete = manager.HandleInput("Z") // Z not in valid characters
 	if complete {
 		t.Error("Expected not complete for invalid character")
 	}
 
-	// Input should still be empty after reset + invalid char
 	if input := manager.CurrentInput(); input != "" {
 		t.Errorf("CurrentInput() = %q, want '' (input stays empty after reset)", input)
 	}
 
-	// Now test that a valid character after reset is accepted
 	_, complete = manager.HandleInput("A")
 	if complete {
 		t.Error("Expected not complete after A following reset")
@@ -381,7 +349,6 @@ func TestGridManager_ResetClearsInputAndFiresCallback(t *testing.T) {
 func TestManager_InputValidation(t *testing.T) {
 	logger := logger.Get()
 
-	// Create a simple grid with known coordinates: AA, AB, AC, BA, BB, BC, CA, CB, CC
 	testGrid := grid.NewGrid("ABC", image.Rect(0, 0, 100, 100), logger)
 	manager := grid.NewManager(
 		testGrid,
@@ -392,7 +359,6 @@ func TestManager_InputValidation(t *testing.T) {
 		logger,
 	)
 
-	// Test 1: Valid first character should be accepted
 	_, complete := manager.HandleInput("A")
 	if complete {
 		t.Error("Expected not complete after first character")
@@ -402,23 +368,19 @@ func TestManager_InputValidation(t *testing.T) {
 		t.Errorf("CurrentInput() = %q, want 'A'", input)
 	}
 
-	// Test 2: Valid second character that completes coordinate should enter subgrid
 	_, complete = manager.HandleInput("A") // "AA" is a valid coordinate - enters subgrid
 	if complete {
 		t.Error("Expected not complete after 'AA' (enters subgrid)")
 	}
-	// When entering subgrid, input is reset to ""
+
 	if input := manager.CurrentInput(); input != "" {
 		t.Errorf("CurrentInput() = %q, want '' (reset for subgrid)", input)
 	}
 
-	// Test 3: Invalid character that doesn't lead to matches should be rejected
 	manager.Reset() // Start fresh
 
-	// Put in a state where next character would be invalid
 	_, _ = manager.HandleInput("A")
 
-	// Try a character that doesn't continue any valid coordinate
 	invalidChar := "Z" // Z doesn't appear in any coordinate starting with A
 
 	_, complete = manager.HandleInput(invalidChar)

--- a/internal/domain/hint/alphabet_generator.go
+++ b/internal/domain/hint/alphabet_generator.go
@@ -141,7 +141,6 @@ func NewAlphabetGenerator(
 		)
 	}
 
-	// Build uppercase mapping and deduplicate characters
 	uppercaseRuneMap := make(map[rune]rune)
 
 	var (
@@ -173,12 +172,9 @@ func NewAlphabetGenerator(
 		)
 	}
 
-	// Calculate max hints: up to 3 chars
-	// Max capacity for fixed-length 3-char base-N encoding is N^3
 	n := charCount
 	maxHints := n * n * n
 
-	// Pre-cache single character strings
 	for _, r := range uppercaseChars {
 		if _, ok := singleCharCache.Load(r); !ok {
 			singleCharCache.Store(r, string(r))
@@ -203,7 +199,6 @@ func (g *AlphabetGenerator) Generate(
 		return nil, nil
 	}
 
-	// Check context cancellation
 	select {
 	case <-ctx.Done():
 		return nil, derrors.Wrap(ctx.Err(), derrors.CodeContextCanceled, "operation canceled")
@@ -211,10 +206,8 @@ func (g *AlphabetGenerator) Generate(
 	}
 
 	// Sort elements by position (top-to-bottom, left-to-right)
-	// Sort in-place if we can modify the input, otherwise copy
 	sorted := elements
 	if len(elements) > 0 {
-		// Create a copy to avoid modifying the input slice
 		sorted = make([]*element.Element, len(elements))
 		copy(sorted, elements)
 	}
@@ -235,10 +228,8 @@ func (g *AlphabetGenerator) Generate(
 
 	labels := g.generateLabels(len(sorted))
 
-	// Create hints
 	hints := make([]*Interface, len(sorted))
 	for index, element := range sorted {
-		// Use element center as hint position
 		position := element.Center()
 
 		hint, err := NewHint(labels[index], element, position)
@@ -368,7 +359,6 @@ func (g *AlphabetGenerator) generateLabels(count int) []string {
 		return nil
 	}
 
-	// Check bounded LRU cache first (key: "chars:direction:count")
 	cacheKey := g.uppercaseChars + ":" + g.labelDirection.String() + ":" + strconv.Itoa(count)
 
 	labelCacheMu.Lock()
@@ -381,7 +371,6 @@ func (g *AlphabetGenerator) generateLabels(count int) []string {
 	}
 	labelCacheMu.Unlock()
 
-	// Generate labels if not cached
 	labels := g.computeLabels(count)
 
 	// Store in bounded LRU cache for future use.

--- a/internal/domain/hint/hint_test.go
+++ b/internal/domain/hint/hint_test.go
@@ -240,7 +240,6 @@ func TestAlphabetGenerator_Generate(t *testing.T) {
 		t.Errorf("Generate() returned %d hints, want %d", len(hints), len(elements))
 	}
 
-	// Check that all labels are unique
 	seen := make(map[string]bool)
 	for _, hint := range hints {
 		if seen[hint.Label()] {
@@ -250,7 +249,6 @@ func TestAlphabetGenerator_Generate(t *testing.T) {
 		seen[hint.Label()] = true
 	}
 
-	// Check that all labels are uppercase
 	for _, hint := range hints {
 		label := hint.Label()
 		for _, r := range label {

--- a/internal/domain/hint/manager.go
+++ b/internal/domain/hint/manager.go
@@ -80,14 +80,11 @@ func (m *Manager) SetHints(hints *Collection) error {
 		return err
 	}
 
-	// Cancel any pending debounced updates
 	if m.debounceTimer != nil {
 		m.debounceTimer.Stop()
 		m.debounceTimer = nil
 	}
 
-	// Bump generation so any already-fired (but blocked) debounce goroutine
-	// will see a stale generation and skip its onUpdate call.
 	m.mu.Lock()
 	m.updateGen++
 	m.mu.Unlock()
@@ -95,14 +92,12 @@ func (m *Manager) SetHints(hints *Collection) error {
 	m.hints = hints
 	m.SetCurrentInput("")
 
-	// Reset cached count to match the full hint set
 	if hints != nil {
 		m.lastFilteredLen = len(hints.All())
 	} else {
 		m.lastFilteredLen = 0
 	}
 
-	// Trigger immediate update callback with all hints on initial set
 	if hints != nil {
 		m.mu.Lock()
 		callback := m.onUpdate
@@ -124,28 +119,23 @@ func (m *Manager) Reset() error {
 		return err
 	}
 
-	// Cancel any pending debounced updates
 	if m.debounceTimer != nil {
 		m.debounceTimer.Stop()
 		m.debounceTimer = nil
 	}
 
-	// Bump generation so any already-fired (but blocked) debounce goroutine
-	// will see a stale generation and skip its onUpdate call.
 	m.mu.Lock()
 	m.updateGen++
 	m.mu.Unlock()
 
 	m.SetCurrentInput("")
 
-	// Reset cached count to match the full hint set
 	if m.hints != nil {
 		m.lastFilteredLen = len(m.hints.All())
 	} else {
 		m.lastFilteredLen = 0
 	}
 
-	// Trigger immediate update callback with all hints
 	if m.hints != nil {
 		m.mu.Lock()
 		callback := m.onUpdate
@@ -201,14 +191,12 @@ func (m *Manager) HandleInput(key string) (*Interface, bool, error) {
 			zap.String("current_input", m.CurrentInput()))
 	}
 
-	// Ignore non-single-character keys
 	if len(key) != 1 {
 		return nil, false, nil
 	}
 
 	prevLen := m.lastFilteredLen
 
-	// Accumulate input (convert to uppercase to match hints)
 	m.SetCurrentInput(m.CurrentInput() + strings.ToUpper(key))
 
 	filtered := m.hints.FilterByPrefix(m.CurrentInput())
@@ -241,7 +229,6 @@ func (m *Manager) HandleInput(key string) (*Interface, bool, error) {
 		return nil, false, nil
 	}
 
-	// Update matched prefix for all filtered hints using cached buffer
 	if cap(m.cachedFilteredHints) < len(filtered) {
 		m.cachedFilteredHints = make([]*Interface, len(filtered))
 	} else {
@@ -252,22 +239,17 @@ func (m *Manager) HandleInput(key string) (*Interface, bool, error) {
 		m.cachedFilteredHints[i] = h.WithMatchedPrefix(m.CurrentInput())
 	}
 
-	// Check for exact match
 	if len(m.cachedFilteredHints) == 1 && m.cachedFilteredHints[0].Label() == m.CurrentInput() {
 		if m.Logger != nil {
 			m.Logger.Debug("Hint manager: Exact match found",
 				zap.String("label", m.cachedFilteredHints[0].Label()))
 		}
 
-		// Cancel any pending debounced update so it doesn't fire stale data
-		// after the caller acts on the match (e.g., exits hint mode).
 		if m.debounceTimer != nil {
 			m.debounceTimer.Stop()
 			m.debounceTimer = nil
 		}
 
-		// Bump generation so any already-fired (but blocked) debounce
-		// goroutine will see a stale generation and skip its callback.
 		m.mu.Lock()
 		m.updateGen++
 		m.mu.Unlock()
@@ -320,7 +302,6 @@ func (m *Manager) HandleBackspace() error {
 		prevLen := m.lastFilteredLen
 		m.SetCurrentInput(m.CurrentInput()[:len(m.CurrentInput())-1])
 
-		// Update overlay to show filtered hints with new prefix
 		if m.hints != nil {
 			filtered := m.hints.FilterByPrefix(m.CurrentInput())
 
@@ -391,14 +372,11 @@ func (m *Manager) immediateUpdate(hints []*Interface) error {
 		return err
 	}
 
-	// Cancel any pending debounced update so it doesn't fire stale data.
 	if m.debounceTimer != nil {
 		m.debounceTimer.Stop()
 		m.debounceTimer = nil
 	}
 
-	// Bump generation so any already-fired (but blocked) debounce goroutine
-	// will see a stale generation and skip its onUpdate call.
 	m.mu.Lock()
 	m.updateGen++
 
@@ -414,14 +392,10 @@ func (m *Manager) immediateUpdate(hints []*Interface) error {
 
 // debouncedUpdate schedules a debounced update of the overlay.
 func (m *Manager) debouncedUpdate(hints []*Interface) {
-	// Cancel any existing timer
 	if m.debounceTimer != nil {
 		m.debounceTimer.Stop()
 	}
 
-	// Bump generation and capture it for the closure. If a newer update
-	// (immediate or debounced) occurs before the timer fires, the captured
-	// generation will be stale and the callback will be skipped.
 	m.mu.Lock()
 	m.updateGen++
 	gen := m.updateGen
@@ -440,11 +414,6 @@ func (m *Manager) debouncedUpdate(hints []*Interface) {
 			defer m.externalMu.Unlock()
 		}
 
-		// Read callback and check generation under m.mu, then release
-		// before invoking the callback. This matches the pattern used by
-		// immediateUpdate, SetHints, and Reset — keeping the callback
-		// invocation outside m.mu prevents a deadlock if the callback
-		// ever re-enters a m.mu-protected method (e.g., SetUpdateCallback).
 		m.mu.Lock()
 
 		// A newer update (immediate or debounced) has occurred since this

--- a/internal/domain/recursivegrid/recursive_grid.go
+++ b/internal/domain/recursivegrid/recursive_grid.go
@@ -262,13 +262,9 @@ func (qg *RecursiveGrid) SelectCell(cell Cell) (image.Point, bool) {
 
 	selected := cells[idx]
 
-	// Compute center from the cell bounds before any state mutation.
 	center := rectCenter(selected)
 
 	if !qg.CanDivide() {
-		// The grid has bottomed out, so this cell is the final selection.
-		// Record it: currentBounds stays on the parent, so it is the only
-		// place the user's actual position is kept.
 		qg.finalCell = cell
 		qg.hasFinalCell = true
 
@@ -286,12 +282,10 @@ func (qg *RecursiveGrid) SelectCell(cell Cell) (image.Point, bool) {
 // CanDivide checks if the current bounds can be divided further.
 // Returns false when the cell would be smaller than minSize or maxDepth is reached.
 func (qg *RecursiveGrid) CanDivide() bool {
-	// Check depth limit
 	if qg.depth >= qg.maxDepth {
 		return false
 	}
 
-	// Check size constraints using the layout for the current depth
 	layout := qg.LayoutForDepth(qg.depth)
 	cellWidth := qg.currentBounds.Dx() / layout.GridCols
 	cellHeight := qg.currentBounds.Dy() / layout.GridRows
@@ -429,7 +423,6 @@ func divRound(numerator, denominator int) int {
 		return 0
 	}
 
-	// Handle negative results correctly: round toward nearest, not toward zero.
 	if (numerator < 0) != (denominator < 0) {
 		return (numerator - denominator/2) / denominator
 	}

--- a/internal/domain/recursivegrid/recursive_grid_test.go
+++ b/internal/domain/recursivegrid/recursive_grid_test.go
@@ -31,10 +31,8 @@ func TestDivide(t *testing.T) {
 
 	cells := grid.Divide()
 
-	// Verify 4 cells
 	assert.Len(t, cells, 4, "Should have 4 cells for 2x2 grid")
 
-	// Verify top-left cell
 	expectedTL := image.Rect(0, 0, 50, 50)
 	assert.Equal(
 		t,
@@ -43,7 +41,6 @@ func TestDivide(t *testing.T) {
 		"Top-left cell should be correct",
 	)
 
-	// Verify top-right cell
 	expectedTR := image.Rect(50, 0, 100, 50)
 	assert.Equal(
 		t,
@@ -52,7 +49,6 @@ func TestDivide(t *testing.T) {
 		"Top-right cell should be correct",
 	)
 
-	// Verify bottom-left cell
 	expectedBL := image.Rect(0, 50, 50, 100)
 	assert.Equal(
 		t,
@@ -61,7 +57,6 @@ func TestDivide(t *testing.T) {
 		"Bottom-left cell should be correct",
 	)
 
-	// Verify bottom-right cell
 	expectedBR := image.Rect(50, 50, 100, 100)
 	assert.Equal(
 		t,
@@ -89,10 +84,8 @@ func TestSelectCell(t *testing.T) {
 	assert.Equal(t, expectedCenter, center, "Center should be at (25, 25)")
 	assert.False(t, completed, "Should not be completed after first selection")
 
-	// Verify depth increased
 	assert.Equal(t, 1, grid.CurrentDepth(), "Depth should be 1")
 
-	// Verify bounds narrowed
 	expectedBounds := image.Rect(0, 0, 50, 50)
 	assert.Equal(
 		t,
@@ -121,7 +114,6 @@ func TestSelectCellCompletion(t *testing.T) {
 	// The user gets one more selection at this final depth.
 	center, completed := grid.SelectCell(recursivegrid.TopLeft)
 
-	// After selecting top-left, bounds are (0,0)-(25,25), center rounded to nearest pixel
 	expectedCenter := image.Point{X: 13, Y: 13}
 	assert.Equal(t, expectedCenter, center, "Center should be at (13, 13)")
 	assert.False(
@@ -130,12 +122,9 @@ func TestSelectCellCompletion(t *testing.T) {
 		"Should NOT be completed yet — user gets one more selection at final depth",
 	)
 
-	// Now at final depth (CanDivide is false), selecting a sub-cell completes
 	center2, completed2 := grid.SelectCell(recursivegrid.BottomRight)
 	assert.True(t, completed2, "Should be completed after selection at final depth")
 
-	// Cells are distributed contiguously: (0,0)-(13,13), (13,0)-(25,13),
-	// (0,13)-(13,25), (13,13)-(25,25). BottomRight cell is (13,13)-(25,25), center rounded.
 	expectedCenter2 := image.Point{X: 19, Y: 19}
 	assert.Equal(t, expectedCenter2, center2, "Center should be at (19, 19)")
 }

--- a/internal/ports/accessibility_test.go
+++ b/internal/ports/accessibility_test.go
@@ -48,7 +48,6 @@ func TestDefaultElementFilter(t *testing.T) {
 		t.Error("Expected IncludeScreenCapture to be false by default")
 	}
 
-	// Check that slices are initialized
 	if filter.Roles != nil {
 		t.Error("Expected Roles to be nil by default")
 	}
@@ -59,7 +58,6 @@ func TestDefaultElementFilter(t *testing.T) {
 }
 
 func TestElementFilterStruct(t *testing.T) {
-	// Test that we can create and modify an ElementFilter
 	filter := ports.ElementFilter{
 		Roles:                     []element.Role{element.RoleButton},
 		MinSize:                   image.Point{X: 10, Y: 10},


### PR DESCRIPTION
## Description

This PR removes redundant comments that merely restate what the adjacent code already communicates. Examples include "// Check context", "// Get pooled slice and reset it", "// Remove from global registry", "// Start new timer", and similar. Comments explaining non-obvious behaviour, edge cases, design decisions, or locking contracts are retained.

Also fixes two unused `//nolint:exhaustive` directives in `config/loader/set_field.go` that golangci-lint flagged, by reformatting them to the expected standalone-line form.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just lint` passes (0 issues)
- [x] `just build` succeeds
- [x] `just test-foundation` — the one pre-existing failure (`TestNoServiceDefinitionWritesDaemonOutputToASharedPath`) is unrelated to comment removal and fails on clean `main` as well
- [x] Documentation updated — N/A, no documentation changes
- [x] PR title is a conventional commit subject written for users

## Screenshots / Recordings

None.

## Additional Context

This is a comment-only cleanup: 28 files changed, 207 lines deleted, 8 lines inserted. No code behaviour changes. The changes span `adapter/accessibility`, `adapter/overlay`, `app/`, `cli/`, `config/loader`, `domain/`, and `ports/`. Each removed comment restated what the code already says (e.g., a comment saying "// Create file" above `os.Create`); comments explaining *why* something is done a particular way are kept.
