### PR TITLE
feat(grid): allow bounded coarse selection labels

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -182,7 +182,7 @@ generic_clickable_min_confidence = 0.5       # Minimum confidence for generic cl
 enabled = true
 characters = "abcdefghijklmnpqrstuvwxyz"    # Primary grid labels
 sublayer_keys = "abcdefghijklmnpqrstuvwxyz" # Subgrid labels, first 9 used (empty = infer from characters)
-max_label_length = 4                        # Maximum coarse grid label length (2–4)
+max_label_length = 4                        # Maximum coarse label length (2–4); 4 keeps the legacy automatic layout
 row_labels = ""                             # Custom row labels (empty = infer from characters)
 col_labels = ""                             # Custom column labels (empty = infer from characters)
 live_match_update = true                    # Highlight cells as you type

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -182,6 +182,7 @@ generic_clickable_min_confidence = 0.5       # Minimum confidence for generic cl
 enabled = true
 characters = "abcdefghijklmnpqrstuvwxyz"    # Primary grid labels
 sublayer_keys = "abcdefghijklmnpqrstuvwxyz" # Subgrid labels, first 9 used (empty = infer from characters)
+max_label_length = 4                        # Maximum coarse grid label length (2–4)
 row_labels = ""                             # Custom row labels (empty = infer from characters)
 col_labels = ""                             # Custom column labels (empty = infer from characters)
 live_match_update = true                    # Highlight cells as you type

--- a/configs/grid-only-config.toml
+++ b/configs/grid-only-config.toml
@@ -10,6 +10,7 @@ enabled = false
 [grid]
 enabled = true
 characters = "abcdefghijklmnpqrstuvwxyz"
+max_label_length = 4
 prewarm_enabled = true
 enable_gc = false
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1055,6 +1055,7 @@ Cursor behavior is chosen per invocation: `neru grid --cursor-selection-mode fol
 | `enabled`           | bool   | `true`                        | Enable/disable grid mode    |
 | `characters`        | string | `"abcdefghijklmnpqrstuvwxyz"` | Primary grid labels         |
 | `sublayer_keys`     | string | `"abcdefghijklmnpqrstuvwxyz"` | Subgrid labels; empty is resolved at load time to the characters the grid is labelled with, the same ones `row_labels` is inferred from. Only the first 9 are used — the subgrid is 3×3 |
+| `max_label_length`  | int    | `4`                           | Maximum coarse-grid label length (2–4). Lower values enlarge the coarse cells so the available labels still cover the screen; the following subgrid refinement remains one keypress |
 | `row_labels`        | string | `""`                          | Custom row labels; empty is resolved at load time to the labels inferred from `characters` |
 | `col_labels`        | string | `""`                          | Custom column labels; empty is resolved the same way as `row_labels`                       |
 | `live_match_update` | bool   | `true`                        | Highlight cells as you type |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1055,7 +1055,7 @@ Cursor behavior is chosen per invocation: `neru grid --cursor-selection-mode fol
 | `enabled`           | bool   | `true`                        | Enable/disable grid mode    |
 | `characters`        | string | `"abcdefghijklmnpqrstuvwxyz"` | Primary grid labels         |
 | `sublayer_keys`     | string | `"abcdefghijklmnpqrstuvwxyz"` | Subgrid labels; empty is resolved at load time to the characters the grid is labelled with, the same ones `row_labels` is inferred from. Only the first 9 are used — the subgrid is 3×3 |
-| `max_label_length`  | int    | `4`                           | Maximum coarse-grid label length (2–4). Lower values enlarge and rebalance the coarse grid so its cells stay near-square while covering the screen; the following subgrid refinement remains one keypress |
+| `max_label_length`  | int    | `4`                           | Maximum coarse-grid label length (2–4). The default preserves the legacy automatic 2–4-key layout. When a limit of 2 shortens an automatically longer label, the coarse grid is enlarged and spatially rebalanced while still covering the screen; the following subgrid refinement remains one keypress |
 | `row_labels`        | string | `""`                          | Custom row labels; empty is resolved at load time to the labels inferred from `characters` |
 | `col_labels`        | string | `""`                          | Custom column labels; empty is resolved the same way as `row_labels`                       |
 | `live_match_update` | bool   | `true`                        | Highlight cells as you type |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1055,7 +1055,7 @@ Cursor behavior is chosen per invocation: `neru grid --cursor-selection-mode fol
 | `enabled`           | bool   | `true`                        | Enable/disable grid mode    |
 | `characters`        | string | `"abcdefghijklmnpqrstuvwxyz"` | Primary grid labels         |
 | `sublayer_keys`     | string | `"abcdefghijklmnpqrstuvwxyz"` | Subgrid labels; empty is resolved at load time to the characters the grid is labelled with, the same ones `row_labels` is inferred from. Only the first 9 are used — the subgrid is 3×3 |
-| `max_label_length`  | int    | `4`                           | Maximum coarse-grid label length (2–4). Lower values enlarge the coarse cells so the available labels still cover the screen; the following subgrid refinement remains one keypress |
+| `max_label_length`  | int    | `4`                           | Maximum coarse-grid label length (2–4). Lower values enlarge and rebalance the coarse grid so its cells stay near-square while covering the screen; the following subgrid refinement remains one keypress |
 | `row_labels`        | string | `""`                          | Custom row labels; empty is resolved at load time to the labels inferred from `characters` |
 | `col_labels`        | string | `""`                          | Custom column labels; empty is resolved the same way as `row_labels`                       |
 | `live_match_update` | bool   | `true`                        | Highlight cells as you type |

--- a/internal/adapter/overlay/render/grid/overlay_darwin.go
+++ b/internal/adapter/overlay/render/grid/overlay_darwin.go
@@ -138,6 +138,24 @@ func getCommonGridSizes() []image.Rectangle {
 	}
 }
 
+func prewarm(config config.GridConfig) {
+	if !config.PrewarmEnabled {
+		return
+	}
+
+	options := domainGrid.Options{
+		Characters:     config.Characters,
+		RowLabels:      config.RowLabels,
+		ColLabels:      config.ColLabels,
+		MaxLabelLength: config.MaxLabelLength,
+	}
+	go func() {
+		for _, rect := range getCommonGridSizes() {
+			_ = domainGrid.NewGridWithOptions(options, rect, zap.NewNop())
+		}
+	}()
+}
+
 // NewOverlay creates a new grid overlay instance with its own window and prewarms common grid sizes.
 func NewOverlay(config config.GridConfig, logger *zap.Logger) (*Overlay, error) {
 	base, err := overlayutil.NewBaseOverlay(logger)
@@ -146,11 +164,7 @@ func NewOverlay(config config.GridConfig, logger *zap.Logger) (*Overlay, error) 
 	}
 	base.CallbackManager.SetComponent("grid")
 	initGridPools()
-	chars := config.Characters
-
-	if config.PrewarmEnabled {
-		go domainGrid.Prewarm(chars, getCommonGridSizes())
-	}
+	prewarm(config)
 
 	return &Overlay{
 		window:          C.OverlayWindow(base.Window),
@@ -169,11 +183,7 @@ func NewOverlayWithWindow(
 	windowPtr unsafe.Pointer,
 ) *Overlay {
 	initGridPools()
-	chars := config.Characters
-
-	if config.PrewarmEnabled {
-		go domainGrid.Prewarm(chars, getCommonGridSizes())
-	}
+	prewarm(config)
 	base := overlayutil.NewBaseOverlayWithWindow(logger, windowPtr)
 	base.CallbackManager.SetComponent("grid")
 

--- a/internal/app/components/types.go
+++ b/internal/app/components/types.go
@@ -60,16 +60,22 @@ func (g *GridComponent) UpdateConfig(cfg *config.Config, logger *zap.Logger) {
 				charactersChanged := newCharacters != oldGrid.Characters()
 				rowLabelsChanged := newRowLabels != oldGrid.RowLabels()
 				colLabelsChanged := newColLabels != oldGrid.ColLabels()
+				maxLabelLengthChanged := cfg.Grid.MaxLabelLength != oldGrid.MaxLabelLength()
 
-				if charactersChanged || rowLabelsChanged || colLabelsChanged {
+				if charactersChanged || rowLabelsChanged || colLabelsChanged ||
+					maxLabelLengthChanged {
 					logger.Debug("Recreating grid due to config changes",
 						zap.Bool("charactersChanged", charactersChanged),
 						zap.Bool("rowLabelsChanged", rowLabelsChanged),
-						zap.Bool("colLabelsChanged", colLabelsChanged))
-					newGrid := domainGrid.NewGridWithLabels(
-						characters,
-						cfg.Grid.RowLabels,
-						cfg.Grid.ColLabels,
+						zap.Bool("colLabelsChanged", colLabelsChanged),
+						zap.Bool("maxLabelLengthChanged", maxLabelLengthChanged))
+					newGrid := domainGrid.NewGridWithOptions(
+						domainGrid.Options{
+							Characters:     characters,
+							RowLabels:      cfg.Grid.RowLabels,
+							ColLabels:      cfg.Grid.ColLabels,
+							MaxLabelLength: cfg.Grid.MaxLabelLength,
+						},
 						oldGrid.Bounds(),
 						logger,
 					)

--- a/internal/app/components/types.go
+++ b/internal/app/components/types.go
@@ -70,12 +70,7 @@ func (g *GridComponent) UpdateConfig(cfg *config.Config, logger *zap.Logger) {
 						zap.Bool("colLabelsChanged", colLabelsChanged),
 						zap.Bool("maxLabelLengthChanged", maxLabelLengthChanged))
 					newGrid := domainGrid.NewGridWithOptions(
-						domainGrid.Options{
-							Characters:     characters,
-							RowLabels:      cfg.Grid.RowLabels,
-							ColLabels:      cfg.Grid.ColLabels,
-							MaxLabelLength: cfg.Grid.MaxLabelLength,
-						},
+						cfg.GridOptions(),
 						oldGrid.Bounds(),
 						logger,
 					)

--- a/internal/app/components/types_test.go
+++ b/internal/app/components/types_test.go
@@ -238,6 +238,7 @@ func TestGridComponent_UpdateConfig_RecreatesGridOnMaxLabelLengthChange(t *testi
 	}
 
 	component.UpdateConfig(cfg, zap.NewNop())
+
 	if component.Manager.Grid() != after {
 		t.Error("reloading an unchanged max_label_length rebuilt the grid")
 	}

--- a/internal/app/components/types_test.go
+++ b/internal/app/components/types_test.go
@@ -217,6 +217,32 @@ func TestGridComponent_UpdateConfig_RecreatedGridKeepsBounds(t *testing.T) {
 	}
 }
 
+// TestGridComponent_UpdateConfig_RecreatesGridOnMaxLabelLengthChange pins hot
+// reload for the geometry option: the manager must start using the new coarse
+// label bound immediately, and an unchanged follow-up reload must keep it.
+func TestGridComponent_UpdateConfig_RecreatesGridOnMaxLabelLengthChange(t *testing.T) {
+	component := newGridComponent(t, testCharacters, "", "")
+	before := component.Manager.Grid()
+
+	cfg := gridConfig(testCharacters, "", "")
+	cfg.Grid.MaxLabelLength = 2
+	component.UpdateConfig(cfg, zap.NewNop())
+
+	after := component.Manager.Grid()
+	if after == before {
+		t.Fatal("changing max_label_length did not recreate the grid")
+	}
+
+	if got := after.MaxLabelLength(); got != 2 {
+		t.Errorf("MaxLabelLength() = %d, want 2", got)
+	}
+
+	component.UpdateConfig(cfg, zap.NewNop())
+	if component.Manager.Grid() != after {
+		t.Error("reloading an unchanged max_label_length rebuilt the grid")
+	}
+}
+
 // TestGridComponent_UpdateConfig_DisabledGridIsLeftAlone makes sure a disabled
 // grid is not silently rebuilt behind the user's back.
 func TestGridComponent_UpdateConfig_DisabledGridIsLeftAlone(t *testing.T) {

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -120,12 +120,7 @@ func (h *handlerState) createGridInstance() *domainGrid.Grid {
 	normalizedBounds := geometry.NormalizeToLocalCoordinates(screenBounds)
 
 	gridInstance := domainGrid.NewGridWithOptions(
-		domainGrid.Options{
-			Characters:     h.config.GridCharacters(),
-			RowLabels:      h.config.Grid.RowLabels,
-			ColLabels:      h.config.Grid.ColLabels,
-			MaxLabelLength: h.config.Grid.MaxLabelLength,
-		},
+		h.config.GridOptions(),
 		normalizedBounds,
 		h.logger,
 	)
@@ -155,12 +150,7 @@ func (h *handlerState) initializeGridManager(gridInstance *domainGrid.Grid) {
 
 		bounds := image.Rect(0, 0, screenBounds.Dx(), screenBounds.Dy())
 		gridInstance = domainGrid.NewGridWithOptions(
-			domainGrid.Options{
-				Characters:     h.config.GridCharacters(),
-				RowLabels:      h.config.Grid.RowLabels,
-				ColLabels:      h.config.Grid.ColLabels,
-				MaxLabelLength: h.config.Grid.MaxLabelLength,
-			},
+			h.config.GridOptions(),
 			bounds,
 			h.logger,
 		)

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -119,10 +119,13 @@ func (h *handlerState) createGridInstance() *domainGrid.Grid {
 	// Normalize normalizedBounds to window-local coordinates using helper function
 	normalizedBounds := geometry.NormalizeToLocalCoordinates(screenBounds)
 
-	gridInstance := domainGrid.NewGridWithLabels(
-		h.config.GridCharacters(),
-		h.config.Grid.RowLabels,
-		h.config.Grid.ColLabels,
+	gridInstance := domainGrid.NewGridWithOptions(
+		domainGrid.Options{
+			Characters:     h.config.GridCharacters(),
+			RowLabels:      h.config.Grid.RowLabels,
+			ColLabels:      h.config.Grid.ColLabels,
+			MaxLabelLength: h.config.Grid.MaxLabelLength,
+		},
 		normalizedBounds,
 		h.logger,
 	)
@@ -151,10 +154,13 @@ func (h *handlerState) initializeGridManager(gridInstance *domainGrid.Grid) {
 		}
 
 		bounds := image.Rect(0, 0, screenBounds.Dx(), screenBounds.Dy())
-		gridInstance = domainGrid.NewGridWithLabels(
-			h.config.GridCharacters(),
-			h.config.Grid.RowLabels,
-			h.config.Grid.ColLabels,
+		gridInstance = domainGrid.NewGridWithOptions(
+			domainGrid.Options{
+				Characters:     h.config.GridCharacters(),
+				RowLabels:      h.config.Grid.RowLabels,
+				ColLabels:      h.config.Grid.ColLabels,
+				MaxLabelLength: h.config.Grid.MaxLabelLength,
+			},
 			bounds,
 			h.logger,
 		)

--- a/internal/app/modes/grid_labels_test.go
+++ b/internal/app/modes/grid_labels_test.go
@@ -95,6 +95,27 @@ func TestCreateGridInstance_UsesTheResolvedLabels(t *testing.T) {
 	}
 }
 
+// TestCreateGridInstance_UsesMaxLabelLength pins the mode-to-domain wiring for
+// the two-key coarse selection option.
+func TestCreateGridInstance_UsesMaxLabelLength(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.Enabled = true
+	cfg.Grid.Characters = "abcd"
+	cfg.Grid.MaxLabelLength = 2
+	cfg.ResolveGridLabels()
+
+	gridInstance := newGridLabelHandler(cfg).createGridInstance()
+	if got := gridInstance.MaxLabelLength(); got != 2 {
+		t.Fatalf("grid MaxLabelLength() = %d, want 2", got)
+	}
+
+	for _, cell := range gridInstance.Cells() {
+		if got := len(cell.Coordinate()); got > 2 {
+			t.Fatalf("coordinate %q has length %d, want at most 2", cell.Coordinate(), got)
+		}
+	}
+}
+
 // TestInitializeGridManager_FallbackGridUsesTheResolvedLabels covers the
 // defensive branch that builds its own grid when handed none. It reached for
 // grid.characters directly while the path above reached for the hint

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -320,12 +320,8 @@ func (h *handlerState) refreshGridForMonitorMove(targetBounds image.Rectangle) {
 	h.setScreenBounds(targetBounds)
 	normalizedBounds := geometry.NormalizeToLocalCoordinates(targetBounds)
 
-	gridInstance := domainGrid.NewGridWithLabels(
-		h.config.GridCharacters(),
-		h.config.Grid.RowLabels,
-		h.config.Grid.ColLabels,
-		normalizedBounds,
-		h.logger,
+	gridInstance := domainGrid.NewGridWithOptions(
+		h.config.GridOptions(), normalizedBounds, h.logger,
 	)
 	h.grid.Context.SetGridInstanceValue(gridInstance)
 

--- a/internal/app/simulation_journey_test.go
+++ b/internal/app/simulation_journey_test.go
@@ -1839,6 +1839,7 @@ const moveMonitorHotkey = "Primary+Shift+N"
 // the calls in between.
 func TestSimulation_MonitorMoveRedrawsTheModeOnTheNewDisplay(t *testing.T) {
 	cfg := simConfig()
+	cfg.Grid.MaxLabelLength = 2
 	cfg.Hotkeys.Bindings[moveMonitorHotkey] = []string{
 		"action move_monitor --name " + secondDisplayName,
 	}
@@ -1872,6 +1873,10 @@ func TestSimulation_MonitorMoveRedrawsTheModeOnTheNewDisplay(t *testing.T) {
 
 	if sim.app.CurrentMode() != domain.ModeGrid {
 		t.Fatalf("mode after monitor move = %v, want grid", sim.app.CurrentMode())
+	}
+
+	if got := sim.overlay.lastGrid().MaxLabelLength(); got != cfg.Grid.MaxLabelLength {
+		t.Errorf("grid label limit after monitor move = %d, want %d", got, cfg.Grid.MaxLabelLength)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -401,9 +401,10 @@ type GridUI struct {
 
 // GridConfig defines the visual and behavioral settings for grid mode.
 type GridConfig struct {
-	Enabled      bool   `json:"enabled"      toml:"enabled"`
-	Characters   string `json:"characters"   toml:"characters"`
-	SublayerKeys string `json:"sublayerKeys" toml:"sublayer_keys"`
+	Enabled        bool   `json:"enabled"        toml:"enabled"`
+	Characters     string `json:"characters"     toml:"characters"`
+	SublayerKeys   string `json:"sublayerKeys"   toml:"sublayer_keys"`
+	MaxLabelLength int    `json:"maxLabelLength" toml:"max_label_length"`
 	// Optional custom labels for rows and columns
 	// If not provided, labels will be inferred from characters
 	RowLabels       string `json:"rowLabels"       toml:"row_labels"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -508,8 +508,9 @@ func defaultGrid() GridConfig {
 		// the grid falls back to that same set when the configured characters
 		// cannot label anything. Two literals is what they were, and they
 		// drifted (see grid.DefaultCharacters).
-		Characters:   domainGrid.DefaultCharacters,
-		SublayerKeys: domainGrid.DefaultCharacters,
+		Characters:     domainGrid.DefaultCharacters,
+		SublayerKeys:   domainGrid.DefaultCharacters,
+		MaxLabelLength: domainGrid.DefaultMaxLabelLength,
 
 		// Empty is the meaning, not a missing default: "" tells the grid to
 		// infer its row and column labels from the characters it is drawn

--- a/internal/config/grid_labels.go
+++ b/internal/config/grid_labels.go
@@ -21,6 +21,16 @@ func (c *Config) GridCharacters() string {
 	return c.Grid.Characters
 }
 
+// GridOptions returns the resolved inputs used to construct a grid.
+func (c *Config) GridOptions() domainGrid.Options {
+	return domainGrid.Options{
+		Characters:     c.GridCharacters(),
+		RowLabels:      c.Grid.RowLabels,
+		ColLabels:      c.Grid.ColLabels,
+		MaxLabelLength: c.Grid.MaxLabelLength,
+	}
+}
+
 // inferredGridKeys is what an empty grid.row_labels, grid.col_labels or
 // grid.sublayer_keys settles to: the characters the grid is built from, in the
 // case they are drawn in, or a-z when that set is too small to label with.

--- a/internal/config/platform_support.go
+++ b/internal/config/platform_support.go
@@ -269,6 +269,7 @@ func PlatformSupport() parity.Declaration {
 			"grid.enabled",
 			"grid.characters",
 			"grid.sublayer_keys",
+			"grid.max_label_length",
 			"grid.row_labels",
 			"grid.col_labels",
 			"grid.ui.font_size",

--- a/internal/config/validators_boundary_test.go
+++ b/internal/config/validators_boundary_test.go
@@ -259,6 +259,40 @@ func TestConfig_VisionIntBoundaries(t *testing.T) {
 	runIntBounds(t, visionIntBounds())
 }
 
+// TestConfig_GridMaxLabelLengthBoundaries covers the default, a custom limit,
+// and both rejected sides of the grid coordinate formats the domain supports.
+func TestConfig_GridMaxLabelLengthBoundaries(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   int
+		wantErr bool
+	}{
+		{name: "default", value: config.DefaultConfig().Grid.MaxLabelLength},
+		{name: "two-key coarse selection", value: 2},
+		{name: "three-key coarse selection", value: 3},
+		{name: "below supported coordinate length", value: 1, wantErr: true},
+		{name: "above supported coordinate length", value: 5, wantErr: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := validBase(t)
+			cfg.Grid.MaxLabelLength = testCase.value
+
+			err := cfg.ValidateGrid(nil, config.WrittenConfig{})
+			if testCase.wantErr {
+				assertRejected(t, err, "grid.max_label_length", testCase.value)
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("grid.max_label_length = %d was rejected: %v", testCase.value, err)
+			}
+		})
+	}
+}
+
 // unitFloatBound describes a float field constrained to a 0..1 confidence or
 // ratio range. inclusiveZero distinguishes validateUnitFloat (accepts 0) from
 // validatePositiveUnitFloat (rejects 0) — mixing the two up would let a

--- a/internal/config/validators_grid.go
+++ b/internal/config/validators_grid.go
@@ -44,6 +44,16 @@ func (c *Config) ValidateGrid(warnings *Warnings, written WrittenConfig) error {
 		}
 	}
 
+	if c.Grid.MaxLabelLength < domainGrid.MinLabelLength ||
+		c.Grid.MaxLabelLength > domainGrid.DefaultMaxLabelLength {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"grid.max_label_length must be between %d and %d",
+			domainGrid.MinLabelLength,
+			domainGrid.DefaultMaxLabelLength,
+		)
+	}
+
 	err := validateColors([]colorField{
 		{c.Grid.UI.BackgroundColor, "grid.ui.background_color"},
 		{c.Grid.UI.TextColor, "grid.ui.text_color"},

--- a/internal/domain/grid/cache.go
+++ b/internal/domain/grid/cache.go
@@ -18,11 +18,12 @@ const (
 
 // CacheKey is a key for the grid cache.
 type CacheKey struct {
-	characters string
-	rowLabels  string
-	colLabels  string
-	width      int
-	height     int
+	characters     string
+	rowLabels      string
+	colLabels      string
+	maxLabelLength int
+	width          int
+	height         int
 }
 
 // CacheEntry is an entry in the grid cache.
@@ -53,7 +54,13 @@ func Prewarm(characters string, sizes []image.Rectangle) {
 	}
 
 	for _, rect := range sizes {
-		if _, ok := gridCache.get(characters, "", "", rect); ok {
+		if _, ok := gridCache.get(
+			characters,
+			"",
+			"",
+			DefaultMaxLabelLength,
+			rect,
+		); ok {
 			continue
 		}
 
@@ -73,14 +80,16 @@ func newCache(capacity int, ttl time.Duration) *Cache {
 
 func (c *Cache) get(
 	characters, rowLabels, colLabels string,
+	maxLabelLength int,
 	bounds image.Rectangle,
 ) ([]*Cell, bool) {
 	cacheKey := CacheKey{
-		characters: characters,
-		rowLabels:  rowLabels,
-		colLabels:  colLabels,
-		width:      bounds.Dx(),
-		height:     bounds.Dy(),
+		characters:     characters,
+		rowLabels:      rowLabels,
+		colLabels:      colLabels,
+		maxLabelLength: maxLabelLength,
+		width:          bounds.Dx(),
+		height:         bounds.Dy(),
 	}
 
 	c.mu.Lock()
@@ -111,15 +120,17 @@ func (c *Cache) get(
 
 func (c *Cache) put(
 	characters, rowLabels, colLabels string,
+	maxLabelLength int,
 	bounds image.Rectangle,
 	cells []*Cell,
 ) {
 	cacheKey := CacheKey{
-		characters: characters,
-		rowLabels:  rowLabels,
-		colLabels:  colLabels,
-		width:      bounds.Dx(),
-		height:     bounds.Dy(),
+		characters:     characters,
+		rowLabels:      rowLabels,
+		colLabels:      colLabels,
+		maxLabelLength: maxLabelLength,
+		width:          bounds.Dx(),
+		height:         bounds.Dy(),
 	}
 
 	c.mu.Lock()

--- a/internal/domain/grid/cache.go
+++ b/internal/domain/grid/cache.go
@@ -5,8 +5,6 @@ import (
 	"image"
 	"sync"
 	"time"
-
-	"go.uber.org/zap"
 )
 
 const (
@@ -46,17 +44,6 @@ var (
 	gridCache        = newCache(DefaultCacheSize, DefaultGridCacheTTL)
 	gridCacheEnabled = true
 )
-
-// Prewarm initializes the grid cache with commonly used grid sizes to improve startup performance.
-func Prewarm(characters string, sizes []image.Rectangle) {
-	if !gridCacheEnabled {
-		return
-	}
-
-	for _, rect := range sizes {
-		_ = NewGrid(characters, rect, zap.NewNop())
-	}
-}
 
 func newCacheKey(alpha gridAlphabet, maxLabelLength int, bounds image.Rectangle) CacheKey {
 	return CacheKey{

--- a/internal/domain/grid/cache.go
+++ b/internal/domain/grid/cache.go
@@ -54,18 +54,18 @@ func Prewarm(characters string, sizes []image.Rectangle) {
 	}
 
 	for _, rect := range sizes {
-		if _, ok := gridCache.get(
-			characters,
-			"",
-			"",
-			DefaultMaxLabelLength,
-			rect,
-		); ok {
-			continue
-		}
+		_ = NewGrid(characters, rect, zap.NewNop())
+	}
+}
 
-		grid := NewGrid(characters, rect, zap.NewNop())
-		_ = grid
+func newCacheKey(alpha gridAlphabet, maxLabelLength int, bounds image.Rectangle) CacheKey {
+	return CacheKey{
+		characters:     alpha.characters,
+		rowLabels:      string(alpha.rowChars),
+		colLabels:      string(alpha.colChars),
+		maxLabelLength: maxLabelLength,
+		width:          bounds.Dx(),
+		height:         bounds.Dy(),
 	}
 }
 
@@ -78,20 +78,7 @@ func newCache(capacity int, ttl time.Duration) *Cache {
 	}
 }
 
-func (c *Cache) get(
-	characters, rowLabels, colLabels string,
-	maxLabelLength int,
-	bounds image.Rectangle,
-) ([]*Cell, bool) {
-	cacheKey := CacheKey{
-		characters:     characters,
-		rowLabels:      rowLabels,
-		colLabels:      colLabels,
-		maxLabelLength: maxLabelLength,
-		width:          bounds.Dx(),
-		height:         bounds.Dy(),
-	}
-
+func (c *Cache) get(cacheKey CacheKey) ([]*Cell, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -118,21 +105,7 @@ func (c *Cache) get(
 	return nil, false
 }
 
-func (c *Cache) put(
-	characters, rowLabels, colLabels string,
-	maxLabelLength int,
-	bounds image.Rectangle,
-	cells []*Cell,
-) {
-	cacheKey := CacheKey{
-		characters:     characters,
-		rowLabels:      rowLabels,
-		colLabels:      colLabels,
-		maxLabelLength: maxLabelLength,
-		width:          bounds.Dx(),
-		height:         bounds.Dy(),
-	}
-
+func (c *Cache) put(cacheKey CacheKey, cells []*Cell) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/internal/domain/grid/cells.go
+++ b/internal/domain/grid/cells.go
@@ -11,16 +11,20 @@ import (
 // top to bottom, so labels sharing a prefix stay spatially grouped.
 func generateCellsWithRegions(
 	chars, rowChars, colChars []rune,
-	numChars, gridCols, gridRows, labelLength int,
+	plan gridPlan,
 	bounds image.Rectangle,
 	baseCellWidth, baseCellHeight, remainderWidth, remainderHeight int,
 	logger *zap.Logger,
 ) []*Cell {
+	numChars := len(chars)
+	gridCols := plan.dimensions.Cols
+	gridRows := plan.dimensions.Rows
+
 	logger.Debug("Generating cells with regions",
 		zap.Int("num_chars", numChars),
 		zap.Int("grid_cols", gridCols),
 		zap.Int("grid_rows", gridRows),
-		zap.Int("label_length", labelLength))
+		zap.Int("label_length", plan.labelLength))
 
 	// Clamp both dimensions into [1, Max]. Dimensions arrive as parameters, so
 	// a zero or negative count would otherwise reach the arithmetic below, and
@@ -50,20 +54,18 @@ func generateCellsWithRegions(
 
 	var cells []*Cell
 
-	regionCols, regionRows := regionSpan(rowChars, colChars, labelLength)
 	xStarts, yStarts := cellEdges(bounds, gridCols, gridRows,
 		baseCellWidth, baseCellHeight, remainderWidth, remainderHeight)
 
 	currentCol := 0
 	currentRow := 0
 	regionIndex := 0
-	maxRegions := numChars * numChars
 
-	for regionIndex < maxRegions && currentRow < gridRows {
-		regionChar1, regionChar2 := regionPrefix(chars, numChars, regionIndex, labelLength)
+	for regionIndex < plan.regionCount && currentRow < gridRows {
+		regionChar1, regionChar2 := regionPrefix(chars, numChars, regionIndex, plan.labelLength)
 
-		colsForRegion := gridMin(regionCols, gridCols-currentCol)
-		rowsForRegion := gridMin(regionRows, gridRows-currentRow)
+		colsForRegion := gridMin(plan.region.Cols, gridCols-currentCol)
+		rowsForRegion := gridMin(plan.region.Rows, gridRows-currentRow)
 
 		for rowIndex := range rowsForRegion {
 			for colIndex := range colsForRegion {
@@ -75,8 +77,8 @@ func generateCellsWithRegions(
 				}
 
 				coordinate := cellCoordinate(
-					labelLength, regionChar1, regionChar2,
-					colChars, rowChars, colIndex, rowIndex,
+					plan.labelLength, regionChar1, regionChar2,
+					colChars, rowChars, plan.region.Cols, colIndex, rowIndex,
 				)
 
 				// Distribute the remainder pixels across the leading cells.
@@ -123,15 +125,6 @@ func generateCellsWithRegions(
 	return cells
 }
 
-// regionSpan returns how many columns and rows one region covers.
-func regionSpan(rowChars, colChars []rune, labelLength int) (int, int) {
-	if labelLength == LabelLength2 {
-		return len(colChars), 1
-	}
-
-	return len(colChars), len(rowChars)
-}
-
 // regionPrefix returns the one or two characters naming a region.
 func regionPrefix(chars []rune, numChars, regionIndex, labelLength int) (rune, rune) {
 	if labelLength == LabelLength2 || labelLength == LabelLength3 {
@@ -141,13 +134,14 @@ func regionPrefix(chars []rune, numChars, regionIndex, labelLength int) (rune, r
 	return chars[regionIndex/numChars%numChars], chars[regionIndex%numChars]
 }
 
-// cellCoordinate builds one cell's label: the region prefix, then the column
-// character, then (for longer labels) the row character.
+// cellCoordinate builds one cell's label. A two-key region uses its second key
+// as a row-major local-cell index; longer labels retain their column and row
+// characters after the region prefix.
 func cellCoordinate(
 	labelLength int,
 	regionChar1, regionChar2 rune,
 	colChars, rowChars []rune,
-	colIndex, rowIndex int,
+	regionCols, colIndex, rowIndex int,
 ) string {
 	var stringBuilder strings.Builder
 
@@ -155,7 +149,8 @@ func cellCoordinate(
 	case LabelLength2:
 		stringBuilder.Grow(StringBuilderGrow2)
 		stringBuilder.WriteRune(regionChar1)
-		stringBuilder.WriteRune(colChars[colIndex%len(colChars)])
+		localIndex := rowIndex*regionCols + colIndex
+		stringBuilder.WriteRune(colChars[localIndex%len(colChars)])
 	case LabelLength3:
 		stringBuilder.Grow(StringBuilderGrow3)
 		stringBuilder.WriteRune(regionChar1)
@@ -203,25 +198,6 @@ func cellEdges(
 	return xStarts, yStarts
 }
 
-// regionShape returns how many columns and rows one region spans, and how many
-// distinct region prefixes the label scheme provides.
-//
-// These must agree with generateCellsWithRegions: it derives the same shape
-// from labelLength and bounds its loop by the same prefix count.
-func regionShape(numChars, numRowChars, numColChars, labelLength int) (int, int, int) {
-	switch labelLength {
-	case LabelLength2:
-		// One region character, and a region is a single row of columns.
-		return numColChars, 1, numChars
-	case LabelLength3:
-		// One region character spanning a full column-by-row block.
-		return numColChars, numRowChars, numChars
-	default:
-		// Two region characters, so the prefix space is squared.
-		return numColChars, numRowChars, numChars * numChars
-	}
-}
-
 // regionsNeeded returns how many regions it takes to cover a gridCols x
 // gridRows grid, counting a clipped edge region as a whole one because that is
 // how the fill loop consumes them.
@@ -243,12 +219,8 @@ func regionsNeeded(gridCols, gridRows, regionCols, regionRows int) int {
 // as close to the screen's aspect ratio as the prefix budget allows, and never
 // shrinks below the minimum usable grid.
 func fitToAvailableRegions(
-	gridCols, gridRows, numChars, numRowChars, numColChars, labelLength int,
+	gridCols, gridRows, regionCols, regionRows, availablePrefixes int,
 ) (int, int) {
-	regionCols, regionRows, availablePrefixes := regionShape(
-		numChars, numRowChars, numColChars, labelLength,
-	)
-
 	if regionCols < 1 || regionRows < 1 || availablePrefixes < 1 {
 		return gridCols, gridRows
 	}

--- a/internal/domain/grid/cells.go
+++ b/internal/domain/grid/cells.go
@@ -149,6 +149,7 @@ func cellCoordinate(
 	case LabelLength2:
 		stringBuilder.Grow(StringBuilderGrow2)
 		stringBuilder.WriteRune(regionChar1)
+
 		localIndex := rowIndex*regionCols + colIndex
 		stringBuilder.WriteRune(colChars[localIndex%len(colChars)])
 	case LabelLength3:

--- a/internal/domain/grid/cells_internal_test.go
+++ b/internal/domain/grid/cells_internal_test.go
@@ -39,7 +39,10 @@ func TestGenerateCellsWithRegions_SurvivesDegenerateDimensions(t *testing.T) {
 			cells := generateCellsWithRegions(
 				chars, chars, chars,
 				gridPlan{
-					dimensions:  domain.GridDimensions{Rows: testCase.gridRows, Cols: testCase.gridCols},
+					dimensions: domain.GridDimensions{
+						Rows: testCase.gridRows,
+						Cols: testCase.gridCols,
+					},
 					region:      domain.GridDimensions{Rows: 1, Cols: len(chars)},
 					labelLength: LabelLength2,
 					regionCount: len(chars),

--- a/internal/domain/grid/cells_internal_test.go
+++ b/internal/domain/grid/cells_internal_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/domain"
 )
 
 // This is a whitebox test — it calls the unexported generator directly, which
@@ -36,7 +38,12 @@ func TestGenerateCellsWithRegions_SurvivesDegenerateDimensions(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			cells := generateCellsWithRegions(
 				chars, chars, chars,
-				len(chars), testCase.gridCols, testCase.gridRows, LabelLength2,
+				gridPlan{
+					dimensions:  domain.GridDimensions{Rows: testCase.gridRows, Cols: testCase.gridCols},
+					region:      domain.GridDimensions{Rows: 1, Cols: len(chars)},
+					labelLength: LabelLength2,
+					regionCount: len(chars),
+				},
 				bounds,
 				10, 10, 0, 0,
 				zap.NewNop(),

--- a/internal/domain/grid/grid.go
+++ b/internal/domain/grid/grid.go
@@ -96,7 +96,7 @@ const (
 	MinLabelLength = LabelLength2
 
 	// DefaultMaxLabelLength preserves the grid's existing automatic 2–4 key
-	// coordinate selection when no explicit limit is supplied.
+	// coordinate selection and layout when no lower limit is supplied.
 	DefaultMaxLabelLength = LabelLength4
 
 	// CountsCapacity is the capacity for counts.
@@ -398,8 +398,9 @@ type gridPlan struct {
 }
 
 // planGridDimensions picks the column and row counts, label length and prefix
-// region shape for a screen. Two-key grids get a staged 2D layout so both keys
-// contribute to both axes; longer labels retain their existing region layout.
+// region shape for a screen. A two-key limit gets a staged 2D layout only when
+// it shortens the automatically selected label; an automatic two-key grid and
+// longer labels retain their existing region layouts.
 func planGridDimensions(
 	width, height int,
 	alpha gridAlphabet,
@@ -422,10 +423,15 @@ func planGridDimensions(
 	gridRows = gridMin(gridRows, MaxGridRows)
 
 	totalCells := gridRows * gridCols
-	labelLength := calculateLabelLength(totalCells, numChars, numRowChars, numColChars)
-	labelLength = gridMin(labelLength, maxLabelLength)
+	automaticLabelLength := calculateLabelLength(
+		totalCells,
+		numChars,
+		numRowChars,
+		numColChars,
+	)
+	labelLength := gridMin(automaticLabelLength, maxLabelLength)
 
-	if labelLength == LabelLength2 {
+	if labelLength == LabelLength2 && labelLength < automaticLabelLength {
 		return planTwoKeyGrid(
 			width,
 			height,
@@ -440,7 +446,14 @@ func planGridDimensions(
 	regionRows := len(alpha.rowChars)
 
 	maxPossibleCells := numChars * numColChars * numRowChars
-	if labelLength == LabelLength4 {
+	switch labelLength {
+	case LabelLength2:
+		// The original two-key format uses one prefix per horizontal row
+		// segment. Keep that layout whenever the maximum did not shorten the
+		// automatically selected label.
+		regionRows = 1
+		maxPossibleCells = numChars * numColChars
+	case LabelLength4:
 		maxPossibleCells *= numChars
 	}
 

--- a/internal/domain/grid/grid.go
+++ b/internal/domain/grid/grid.go
@@ -196,6 +196,7 @@ func NewGridWithOptions(options Options, bounds image.Rectangle, logger *zap.Log
 		zap.Int("bounds_height", bounds.Dy()))
 
 	alpha := newGridAlphabet(options.Characters, options.RowLabels, options.ColLabels)
+	cacheKey := newCacheKey(alpha, maxLabelLength, bounds)
 
 	width := bounds.Max.X - bounds.Min.X
 	height := bounds.Max.Y - bounds.Min.Y
@@ -205,13 +206,7 @@ func NewGridWithOptions(options Options, bounds image.Rectangle, logger *zap.Log
 		zap.Int("height", height))
 
 	if gridCacheEnabled {
-		if cells, ok := gridCache.get(
-			alpha.characters,
-			strings.ToUpper(options.RowLabels),
-			strings.ToUpper(options.ColLabels),
-			maxLabelLength,
-			bounds,
-		); ok {
+		if cells, ok := gridCache.get(cacheKey); ok {
 			logger.Debug("Grid cache hit", zap.Int("cell_count", len(cells)))
 
 			return newGridFromCells(alpha, maxLabelLength, bounds, cells)
@@ -240,26 +235,23 @@ func NewGridWithOptions(options Options, bounds image.Rectangle, logger *zap.Log
 	width = gridMin(width, MaxDisplayDimension)
 	height = gridMin(height, MaxDisplayDimension)
 
-	gridCols, gridRows, labelLength := planGridDimensions(
+	plan := planGridDimensions(
 		width,
 		height,
 		alpha,
 		maxLabelLength,
 	)
 
-	baseCellWidth := width / gridCols
-	baseCellHeight := height / gridRows
-	remainderWidth := width % gridCols
-	remainderHeight := height % gridRows
+	baseCellWidth := width / plan.dimensions.Cols
+	baseCellHeight := height / plan.dimensions.Rows
+	remainderWidth := width % plan.dimensions.Cols
+	remainderHeight := height % plan.dimensions.Rows
 
 	cells := generateCellsWithRegions(
 		alpha.chars,
 		alpha.rowChars,
 		alpha.colChars,
-		len(alpha.chars),
-		gridCols,
-		gridRows,
-		labelLength,
+		plan,
 		bounds,
 		baseCellWidth,
 		baseCellHeight,
@@ -270,19 +262,12 @@ func NewGridWithOptions(options Options, bounds image.Rectangle, logger *zap.Log
 
 	logger.Debug("Grid created successfully",
 		zap.Int("cell_count", len(cells)),
-		zap.Int("grid_cols", gridCols),
-		zap.Int("grid_rows", gridRows),
-		zap.Int("label_length", labelLength))
+		zap.Int("grid_cols", plan.dimensions.Cols),
+		zap.Int("grid_rows", plan.dimensions.Rows),
+		zap.Int("label_length", plan.labelLength))
 
 	if gridCacheEnabled {
-		gridCache.put(
-			alpha.characters,
-			strings.ToUpper(options.RowLabels),
-			strings.ToUpper(options.ColLabels),
-			maxLabelLength,
-			bounds,
-			cells,
-		)
+		gridCache.put(cacheKey, cells)
 		logger.Debug("Grid cache store", zap.Int("cell_count", len(cells)))
 	}
 
@@ -403,14 +388,23 @@ func newGridFromCells(
 	}
 }
 
-// planGridDimensions picks the column and row counts and the label length for a
-// screen, keeping cells as square as possible and never planning more cells
-// than the alphabet can label or the regions can reach.
+// gridPlan is the complete geometry the cell generator needs. region is the
+// rectangular group selected by the coordinate prefix.
+type gridPlan struct {
+	dimensions  domain.GridDimensions
+	region      domain.GridDimensions
+	labelLength int
+	regionCount int
+}
+
+// planGridDimensions picks the column and row counts, label length and prefix
+// region shape for a screen. Two-key grids get a staged 2D layout so both keys
+// contribute to both axes; longer labels retain their existing region layout.
 func planGridDimensions(
 	width, height int,
 	alpha gridAlphabet,
 	maxLabelLength int,
-) (int, int, int) {
+) gridPlan {
 	numChars := len(alpha.chars)
 	numRowChars := len(alpha.rowChars)
 	numColChars := len(alpha.colChars)
@@ -431,14 +425,22 @@ func planGridDimensions(
 	labelLength := calculateLabelLength(totalCells, numChars, numRowChars, numColChars)
 	labelLength = gridMin(labelLength, maxLabelLength)
 
-	var maxPossibleCells int
-	switch labelLength {
-	case LabelLength2:
-		maxPossibleCells = numChars * numColChars
-	case LabelLength3:
-		maxPossibleCells = numChars * numColChars * numRowChars
-	default:
-		maxPossibleCells = numChars * numChars * numColChars * numRowChars
+	if labelLength == LabelLength2 {
+		return planTwoKeyGrid(
+			width,
+			height,
+			gridCols,
+			gridRows,
+			numChars,
+			numColChars,
+		)
+	}
+
+	regionCols := len(alpha.colChars)
+	regionRows := len(alpha.rowChars)
+	maxPossibleCells := numChars * numColChars * numRowChars
+	if labelLength == LabelLength4 {
+		maxPossibleCells *= numChars
 	}
 
 	// Cap the grid to what the alphabet can label.
@@ -455,11 +457,25 @@ func planGridDimensions(
 	// leaving screen area with no cell at all (a 4-character set on 1000x3000
 	// lost the bottom ~430px). Shrink until the regions reach every cell; the
 	// default 25-character alphabet comes through untouched.
+	availablePrefixes := numChars
+	if labelLength == LabelLength4 {
+		availablePrefixes *= numChars
+	}
+
 	gridCols, gridRows = fitToAvailableRegions(
-		gridCols, gridRows, numChars, numRowChars, numColChars, labelLength,
+		gridCols,
+		gridRows,
+		regionCols,
+		regionRows,
+		availablePrefixes,
 	)
 
-	return gridCols, gridRows, labelLength
+	return gridPlan{
+		dimensions:  domain.GridDimensions{Rows: gridRows, Cols: gridCols},
+		region:      domain.GridDimensions{Rows: regionRows, Cols: regionCols},
+		labelLength: labelLength,
+		regionCount: availablePrefixes,
+	}
 }
 
 // normalizeMaxLabelLength gives the domain a safe zero value for callers that

--- a/internal/domain/grid/grid.go
+++ b/internal/domain/grid/grid.go
@@ -92,6 +92,13 @@ const (
 	// LabelLength4 is the label length 4.
 	LabelLength4 = 4
 
+	// MinLabelLength is the shortest coordinate format supported by the grid.
+	MinLabelLength = LabelLength2
+
+	// DefaultMaxLabelLength preserves the grid's existing automatic 2–4 key
+	// coordinate selection when no explicit limit is supplied.
+	DefaultMaxLabelLength = LabelLength4
+
 	// CountsCapacity is the capacity for counts.
 	CountsCapacity = 5
 
@@ -101,13 +108,14 @@ const (
 
 // Grid is a coordinate grid system for spatial navigation with optimized cell sizing.
 type Grid struct {
-	characters string          // Characters used for coordinates (e.g., "asdfghjkl")
-	rowChars   []rune          // Characters used for row labels
-	colChars   []rune          // Characters used for column labels
-	bounds     image.Rectangle // Screen bounds
-	cells      []*Cell         // All cells with 3-char coordinates
-	index      map[string]*Cell
-	prefixes   map[string]bool // Set of all coordinate prefixes for fast lookup
+	characters     string          // Characters used for coordinates (e.g., "asdfghjkl")
+	rowChars       []rune          // Characters used for row labels
+	colChars       []rune          // Characters used for column labels
+	maxLabelLength int             // Longest coordinate the planner may choose
+	bounds         image.Rectangle // Screen bounds
+	cells          []*Cell         // All cells with uniform-length coordinates
+	index          map[string]*Cell
+	prefixes       map[string]bool // Set of all coordinate prefixes for fast lookup
 }
 
 // Cell is a grid cell containing coordinate, bounds, and center point information.
@@ -143,7 +151,7 @@ func (c *Cell) Center() image.Point {
 //
 // Empty rowLabels or colLabels are inferred from characters.
 func NewGrid(characters string, bounds image.Rectangle, logger *zap.Logger) *Grid {
-	return NewGridWithLabels(characters, "", "", bounds, logger)
+	return NewGridWithOptions(Options{Characters: characters}, bounds, logger)
 }
 
 // NewGridWithLabels creates a grid with custom row and column labels.
@@ -153,20 +161,41 @@ func NewGridWithLabels(
 	bounds image.Rectangle,
 	logger *zap.Logger,
 ) *Grid {
+	return NewGridWithOptions(Options{
+		Characters: characters,
+		RowLabels:  rowLabels,
+		ColLabels:  colLabels,
+	}, bounds, logger)
+}
+
+// Options are the label inputs that affect a grid's geometry.
+type Options struct {
+	Characters     string
+	RowLabels      string
+	ColLabels      string
+	MaxLabelLength int
+}
+
+// NewGridWithOptions creates a grid from label options. MaxLabelLength limits
+// the coarse coordinate to 2–4 keypresses; zero keeps the default limit of 4.
+func NewGridWithOptions(options Options, bounds image.Rectangle, logger *zap.Logger) *Grid {
 	// Constructors in this tree accept a nil logger and fall back to a no-op
 	// rather than panicking on first use.
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 
+	maxLabelLength := normalizeMaxLabelLength(options.MaxLabelLength)
+
 	logger.Debug("Creating new grid",
-		zap.String("characters", characters),
-		zap.String("rowLabels", rowLabels),
-		zap.String("colLabels", colLabels),
+		zap.String("characters", options.Characters),
+		zap.String("rowLabels", options.RowLabels),
+		zap.String("colLabels", options.ColLabels),
+		zap.Int("max_label_length", maxLabelLength),
 		zap.Int("bounds_width", bounds.Dx()),
 		zap.Int("bounds_height", bounds.Dy()))
 
-	alpha := newGridAlphabet(characters, rowLabels, colLabels)
+	alpha := newGridAlphabet(options.Characters, options.RowLabels, options.ColLabels)
 
 	width := bounds.Max.X - bounds.Min.X
 	height := bounds.Max.Y - bounds.Min.Y
@@ -178,13 +207,14 @@ func NewGridWithLabels(
 	if gridCacheEnabled {
 		if cells, ok := gridCache.get(
 			alpha.characters,
-			strings.ToUpper(rowLabels),
-			strings.ToUpper(colLabels),
+			strings.ToUpper(options.RowLabels),
+			strings.ToUpper(options.ColLabels),
+			maxLabelLength,
 			bounds,
 		); ok {
 			logger.Debug("Grid cache hit", zap.Int("cell_count", len(cells)))
 
-			return newGridFromCells(alpha, bounds, cells)
+			return newGridFromCells(alpha, maxLabelLength, bounds, cells)
 		}
 
 		logger.Debug("Grid cache miss")
@@ -196,11 +226,12 @@ func NewGridWithLabels(
 			zap.Int("height", height))
 
 		return &Grid{
-			characters: alpha.characters,
-			bounds:     bounds,
-			cells:      []*Cell{},
-			index:      make(map[string]*Cell),
-			prefixes:   make(map[string]bool),
+			characters:     alpha.characters,
+			maxLabelLength: maxLabelLength,
+			bounds:         bounds,
+			cells:          []*Cell{},
+			index:          make(map[string]*Cell),
+			prefixes:       make(map[string]bool),
 		}
 	}
 
@@ -209,7 +240,12 @@ func NewGridWithLabels(
 	width = gridMin(width, MaxDisplayDimension)
 	height = gridMin(height, MaxDisplayDimension)
 
-	gridCols, gridRows, labelLength := planGridDimensions(width, height, alpha)
+	gridCols, gridRows, labelLength := planGridDimensions(
+		width,
+		height,
+		alpha,
+		maxLabelLength,
+	)
 
 	baseCellWidth := width / gridCols
 	baseCellHeight := height / gridRows
@@ -241,15 +277,16 @@ func NewGridWithLabels(
 	if gridCacheEnabled {
 		gridCache.put(
 			alpha.characters,
-			strings.ToUpper(rowLabels),
-			strings.ToUpper(colLabels),
+			strings.ToUpper(options.RowLabels),
+			strings.ToUpper(options.ColLabels),
+			maxLabelLength,
 			bounds,
 			cells,
 		)
 		logger.Debug("Grid cache store", zap.Int("cell_count", len(cells)))
 	}
 
-	return newGridFromCells(alpha, bounds, cells)
+	return newGridFromCells(alpha, maxLabelLength, bounds, cells)
 }
 
 // gridAlphabet is the normalized character sets a grid is labeled from.
@@ -343,27 +380,37 @@ func ResolveCharacters(characters string) string {
 }
 
 // newGridFromCells assembles a Grid and its lookup indexes from finished cells.
-func newGridFromCells(alpha gridAlphabet, bounds image.Rectangle, cells []*Cell) *Grid {
+func newGridFromCells(
+	alpha gridAlphabet,
+	maxLabelLength int,
+	bounds image.Rectangle,
+	cells []*Cell,
+) *Grid {
 	index := make(map[string]*Cell, len(cells))
 	for _, cell := range cells {
 		index[cell.Coordinate()] = cell
 	}
 
 	return &Grid{
-		characters: alpha.characters,
-		rowChars:   alpha.rowChars,
-		colChars:   alpha.colChars,
-		bounds:     bounds,
-		cells:      cells,
-		index:      index,
-		prefixes:   buildPrefixIndex(cells),
+		characters:     alpha.characters,
+		rowChars:       alpha.rowChars,
+		colChars:       alpha.colChars,
+		maxLabelLength: maxLabelLength,
+		bounds:         bounds,
+		cells:          cells,
+		index:          index,
+		prefixes:       buildPrefixIndex(cells),
 	}
 }
 
 // planGridDimensions picks the column and row counts and the label length for a
 // screen, keeping cells as square as possible and never planning more cells
 // than the alphabet can label or the regions can reach.
-func planGridDimensions(width, height int, alpha gridAlphabet) (int, int, int) {
+func planGridDimensions(
+	width, height int,
+	alpha gridAlphabet,
+	maxLabelLength int,
+) (int, int, int) {
 	numChars := len(alpha.chars)
 	numRowChars := len(alpha.rowChars)
 	numColChars := len(alpha.colChars)
@@ -382,6 +429,7 @@ func planGridDimensions(width, height int, alpha gridAlphabet) (int, int, int) {
 
 	totalCells := gridRows * gridCols
 	labelLength := calculateLabelLength(totalCells, numChars, numRowChars, numColChars)
+	labelLength = gridMin(labelLength, maxLabelLength)
 
 	var maxPossibleCells int
 	switch labelLength {
@@ -414,6 +462,17 @@ func planGridDimensions(width, height int, alpha gridAlphabet) (int, int, int) {
 	return gridCols, gridRows, labelLength
 }
 
+// normalizeMaxLabelLength gives the domain a safe zero value for callers that
+// do not come through config validation, then bounds malformed values so the
+// coordinate builder never receives a format it does not support.
+func normalizeMaxLabelLength(maxLabelLength int) int {
+	if maxLabelLength == 0 {
+		return DefaultMaxLabelLength
+	}
+
+	return gridMin(gridMax(maxLabelLength, MinLabelLength), DefaultMaxLabelLength)
+}
+
 // Characters returns the characters used for coordinates.
 func (g *Grid) Characters() string {
 	return g.characters
@@ -427,6 +486,11 @@ func (g *Grid) RowLabels() string {
 // ColLabels returns the column labels used for coordinates.
 func (g *Grid) ColLabels() string {
 	return string(g.colChars)
+}
+
+// MaxLabelLength returns the coarse-coordinate limit used to plan the grid.
+func (g *Grid) MaxLabelLength() int {
+	return g.maxLabelLength
 }
 
 // ValidCharacters returns all characters that can appear in grid coordinates.
@@ -464,7 +528,7 @@ func (g *Grid) Bounds() image.Rectangle {
 	return g.bounds
 }
 
-// Cells returns all cells with 3-char coordinates.
+// Cells returns all cells with uniform-length coordinates.
 func (g *Grid) Cells() []*Cell {
 	return g.cells
 }

--- a/internal/domain/grid/grid.go
+++ b/internal/domain/grid/grid.go
@@ -438,6 +438,7 @@ func planGridDimensions(
 
 	regionCols := len(alpha.colChars)
 	regionRows := len(alpha.rowChars)
+
 	maxPossibleCells := numChars * numColChars * numRowChars
 	if labelLength == LabelLength4 {
 		maxPossibleCells *= numChars

--- a/internal/domain/grid/grid_test.go
+++ b/internal/domain/grid/grid_test.go
@@ -379,19 +379,24 @@ func TestGrid_MaxLabelLengthCapsCoarseSelection(t *testing.T) {
 	bounds := image.Rect(0, 0, 1920, 1080)
 	log := logger.Get()
 
-	automatic := grid.NewGrid("abcd", bounds, log)
+	automatic := grid.NewGrid(grid.DefaultCharacters, bounds, log)
 	if got := len(automatic.Cells()[0].Coordinate()); got <= grid.LabelLength2 {
 		t.Fatalf("automatic label length = %d, want more than 2 for this fixture", got)
 	}
 
 	limited := grid.NewGridWithOptions(grid.Options{
-		Characters:     "abcd",
+		Characters:     grid.DefaultCharacters,
 		MaxLabelLength: grid.LabelLength2,
 	}, bounds, log)
 
 	for _, cell := range limited.Cells() {
 		if got := len(cell.Coordinate()); got != grid.LabelLength2 {
 			t.Fatalf("coordinate %q has length %d, want 2", cell.Coordinate(), got)
+		}
+
+		aspect := float64(cell.Bounds().Dx()) / float64(cell.Bounds().Dy())
+		if aspect < 0.9 || aspect > 1.1 {
+			t.Fatalf("cell %q aspect ratio = %.2f, want near-square", cell.Coordinate(), aspect)
 		}
 	}
 
@@ -403,6 +408,8 @@ func TestGrid_MaxLabelLengthCapsCoarseSelection(t *testing.T) {
 	if cell := limited.CellForPoint(bottomRight); cell == nil {
 		t.Fatalf("two-key grid does not cover bottom-right point %v", bottomRight)
 	}
+
+	assertGridPrefixesFormRectangles(t, limited.Cells())
 
 	var selected *grid.Cell
 	manager := grid.NewManager(
@@ -426,6 +433,43 @@ func TestGrid_MaxLabelLengthCapsCoarseSelection(t *testing.T) {
 
 	if _, complete := manager.HandleInput("a"); !complete {
 		t.Fatal("subgrid key did not complete the refined selection")
+	}
+}
+
+// assertGridPrefixesFormRectangles keeps the first key spatially meaningful:
+// every cell sharing it forms one solid coarse region rather than scattered
+// cells that merely happen to have square final geometry.
+func assertGridPrefixesFormRectangles(t *testing.T, cells []*grid.Cell) {
+	t.Helper()
+
+	type region struct {
+		bounds image.Rectangle
+		area   int
+	}
+
+	regions := make(map[byte]region)
+	for _, cell := range cells {
+		prefix := cell.Coordinate()[0]
+		current, exists := regions[prefix]
+		if !exists {
+			current.bounds = cell.Bounds()
+		} else {
+			current.bounds = current.bounds.Union(cell.Bounds())
+		}
+
+		current.area += cell.Bounds().Dx() * cell.Bounds().Dy()
+		regions[prefix] = current
+	}
+
+	for prefix, region := range regions {
+		if want := region.bounds.Dx() * region.bounds.Dy(); region.area != want {
+			t.Errorf(
+				"prefix %q covers %d pixels inside a %d-pixel bounding box; want one rectangle",
+				prefix,
+				region.area,
+				want,
+			)
+		}
 	}
 }
 

--- a/internal/domain/grid/grid_test.go
+++ b/internal/domain/grid/grid_test.go
@@ -401,7 +401,11 @@ func TestGrid_MaxLabelLengthCapsCoarseSelection(t *testing.T) {
 	}
 
 	if covered := assertCellsAbut(t, limited.Cells()); covered != bounds.Dx()*bounds.Dy() {
-		t.Fatalf("two-key cells cover %d pixels, want the full %d", covered, bounds.Dx()*bounds.Dy())
+		t.Fatalf(
+			"two-key cells cover %d pixels, want the full %d",
+			covered,
+			bounds.Dx()*bounds.Dy(),
+		)
 	}
 
 	bottomRight := image.Point{X: bounds.Max.X - 1, Y: bounds.Max.Y - 1}
@@ -412,6 +416,7 @@ func TestGrid_MaxLabelLengthCapsCoarseSelection(t *testing.T) {
 	assertGridPrefixesFormRectangles(t, limited.Cells())
 
 	var selected *grid.Cell
+
 	manager := grid.NewManager(
 		limited,
 		domain.GridDimensions{Rows: 3, Cols: 3},
@@ -450,6 +455,7 @@ func assertGridPrefixesFormRectangles(t *testing.T, cells []*grid.Cell) {
 	regions := make(map[byte]region)
 	for _, cell := range cells {
 		prefix := cell.Coordinate()[0]
+
 		current, exists := regions[prefix]
 		if !exists {
 			current.bounds = cell.Bounds()

--- a/internal/domain/grid/grid_test.go
+++ b/internal/domain/grid/grid_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/adapter/logger"
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/grid"
 )
 
@@ -366,6 +367,65 @@ func TestGrid_BackwardCompatibility(t *testing.T) {
 		}
 
 		coordMap[cell.Coordinate()] = true
+	}
+}
+
+// TestGrid_MaxLabelLengthCapsCoarseSelection pins the issue #1536 workflow:
+// the main region is selected in at most two keypresses, then the existing
+// subgrid supplies the local refinement key. The two grids deliberately share
+// every cache input except the label limit, so this also catches a cache key
+// that would return the old geometry after a config change.
+func TestGrid_MaxLabelLengthCapsCoarseSelection(t *testing.T) {
+	bounds := image.Rect(0, 0, 1920, 1080)
+	log := logger.Get()
+
+	automatic := grid.NewGrid("abcd", bounds, log)
+	if got := len(automatic.Cells()[0].Coordinate()); got <= grid.LabelLength2 {
+		t.Fatalf("automatic label length = %d, want more than 2 for this fixture", got)
+	}
+
+	limited := grid.NewGridWithOptions(grid.Options{
+		Characters:     "abcd",
+		MaxLabelLength: grid.LabelLength2,
+	}, bounds, log)
+
+	for _, cell := range limited.Cells() {
+		if got := len(cell.Coordinate()); got != grid.LabelLength2 {
+			t.Fatalf("coordinate %q has length %d, want 2", cell.Coordinate(), got)
+		}
+	}
+
+	if covered := assertCellsAbut(t, limited.Cells()); covered != bounds.Dx()*bounds.Dy() {
+		t.Fatalf("two-key cells cover %d pixels, want the full %d", covered, bounds.Dx()*bounds.Dy())
+	}
+
+	bottomRight := image.Point{X: bounds.Max.X - 1, Y: bounds.Max.Y - 1}
+	if cell := limited.CellForPoint(bottomRight); cell == nil {
+		t.Fatalf("two-key grid does not cover bottom-right point %v", bottomRight)
+	}
+
+	var selected *grid.Cell
+	manager := grid.NewManager(
+		limited,
+		domain.GridDimensions{Rows: 3, Cols: 3},
+		"asdfghjkl",
+		nil,
+		func(cell *grid.Cell) { selected = cell },
+		log,
+	)
+
+	for _, key := range limited.Cells()[0].Coordinate() {
+		if _, complete := manager.HandleInput(string(key)); complete {
+			t.Fatal("coarse selection completed before local refinement")
+		}
+	}
+
+	if selected == nil {
+		t.Fatal("two-key coordinate did not open the local refinement subgrid")
+	}
+
+	if _, complete := manager.HandleInput("a"); !complete {
+		t.Fatal("subgrid key did not complete the refined selection")
 	}
 }
 

--- a/internal/domain/grid/sizing.go
+++ b/internal/domain/grid/sizing.go
@@ -1,12 +1,105 @@
 package grid
 
-import "sync"
+import (
+	"math"
+	"sync"
+
+	"github.com/y3owk1n/neru/internal/domain"
+)
 
 // Candidate is a valid grid configuration.
 type Candidate struct {
 	cols, rows   int
 	cellW, cellH int
 	score        float64
+}
+
+// twoKeyCandidate is a staged two-key layout and the qualities used to rank it.
+type twoKeyCandidate struct {
+	plan           gridPlan
+	score          float64
+	cells          int
+	twoDimensional bool
+}
+
+// planTwoKeyGrid divides both keypresses into 2D stages. The first key selects
+// one rectangular region and the second selects a cell inside it, so the final
+// column/row counts are the products of the two stages.
+//
+// Candidates stay within the cell-size planner's target dimensions. Their
+// score balances square cells with using more available label pairs, matching
+// findValidGridConfigurations without forcing a one-row region that distorts
+// the final grid.
+func planTwoKeyGrid(
+	width, height, targetCols, targetRows, prefixKeys, localKeys int,
+) gridPlan {
+	prefixStages := keyStageLayouts(prefixKeys, targetCols, targetRows)
+	localStages := keyStageLayouts(localKeys, targetCols, targetRows)
+	targetCells := targetCols * targetRows
+	maxUsableCells := min(int64(targetCells), int64(prefixKeys)*int64(localKeys))
+
+	var best twoKeyCandidate
+	found := false
+
+	for _, prefix := range prefixStages {
+		for _, local := range localStages {
+			cols := prefix.Cols * local.Cols
+			rows := prefix.Rows * local.Rows
+			cells := cols * rows
+			if cols > targetCols || rows > targetRows || cells < MinCharactersLength {
+				continue
+			}
+
+			cellWidth := float64(width) / float64(cols)
+			cellHeight := float64(height) / float64(rows)
+			precisionPenalty := float64(maxUsableCells-int64(cells)) /
+				float64(maxUsableCells) * ScoreWeight
+			candidate := twoKeyCandidate{
+				plan: gridPlan{
+					dimensions:  domain.GridDimensions{Rows: rows, Cols: cols},
+					region:      local,
+					labelLength: LabelLength2,
+					regionCount: prefixKeys,
+				},
+				score:          math.Abs(cellWidth/cellHeight-1) + precisionPenalty,
+				cells:          cells,
+				twoDimensional: cols >= MinGridCols && rows >= MinGridRows,
+			}
+
+			if !found || betterTwoKeyCandidate(candidate, best) {
+				best = candidate
+				found = true
+			}
+		}
+	}
+
+	return best.plan
+}
+
+// keyStageLayouts returns every rectangular layout addressable by keyCount,
+// bounded by the final grid target so unused labels do not inflate the search.
+func keyStageLayouts(keyCount, maxCols, maxRows int) []domain.GridDimensions {
+	var layouts []domain.GridDimensions
+
+	for cols := 1; cols <= gridMin(keyCount, maxCols); cols++ {
+		rowsLimit := gridMin(keyCount/cols, maxRows)
+		for rows := 1; rows <= rowsLimit; rows++ {
+			layouts = append(layouts, domain.GridDimensions{Rows: rows, Cols: cols})
+		}
+	}
+
+	return layouts
+}
+
+func betterTwoKeyCandidate(candidate, current twoKeyCandidate) bool {
+	switch {
+	case candidate.twoDimensional != current.twoDimensional:
+		return candidate.twoDimensional
+	case candidate.score != current.score:
+		return candidate.score < current.score
+	default:
+		return candidate.cells > current.cells
+	}
 }
 
 // calculateOptimalCellSizes determines optimal cell size constraints based on screen characteristics.
@@ -117,10 +210,7 @@ func findValidGridConfigurations(width, height, minCellSize, maxCellSize int) []
 				// Calculate how square the cells are (aspect ratio deviation from 1.0)
 				cellAspect := float64(cellWidth) / float64(cellHeight)
 
-				aspectDiff := cellAspect - 1.0
-				if aspectDiff < 0 {
-					aspectDiff = -aspectDiff
-				}
+				aspectDiff := math.Abs(cellAspect - 1)
 
 				// Prefer configurations with more cells for finer precision
 				totalCells := float64(col * rowIndex)

--- a/internal/domain/grid/sizing.go
+++ b/internal/domain/grid/sizing.go
@@ -39,12 +39,14 @@ func planTwoKeyGrid(
 	maxUsableCells := min(int64(targetCells), int64(prefixKeys)*int64(localKeys))
 
 	var best twoKeyCandidate
+
 	found := false
 
 	for _, prefix := range prefixStages {
 		for _, local := range localStages {
 			cols := prefix.Cols * local.Cols
 			rows := prefix.Rows * local.Rows
+
 			cells := cols * rows
 			if cols > targetCols || rows > targetRows || cells < MinCharactersLength {
 				continue

--- a/internal/domain/grid/sizing_internal_test.go
+++ b/internal/domain/grid/sizing_internal_test.go
@@ -5,6 +5,34 @@ import (
 	"testing"
 )
 
+// TestPlanGridDimensions_DefaultLimitKeepsLegacyTwoKeyRegions pins the
+// compatibility promise of max_label_length = 4. When the automatic planner
+// already chooses two keys, the maximum has not bounded anything, so the
+// original one-row prefix regions must stay in use.
+func TestPlanGridDimensions_DefaultLimitKeepsLegacyTwoKeyRegions(t *testing.T) {
+	const characters = "abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*()-_=+"
+
+	alpha := newGridAlphabet(characters, "", "")
+	plan := planGridDimensions(1920, 1080, alpha, DefaultMaxLabelLength)
+
+	if plan.labelLength != LabelLength2 {
+		t.Fatalf("label length = %d, want the automatic two-key fixture", plan.labelLength)
+	}
+
+	if plan.region.Rows != 1 || plan.region.Cols != len(alpha.colChars) {
+		t.Errorf(
+			"region = %dx%d, want the legacy %dx1 region",
+			plan.region.Cols,
+			plan.region.Rows,
+			len(alpha.colChars),
+		)
+	}
+
+	if plan.regionCount != len(alpha.chars) {
+		t.Errorf("region count = %d, want %d", plan.regionCount, len(alpha.chars))
+	}
+}
+
 // TestPlanTwoKeyGrid_KeepsCellsNearSquareAcrossScreenShapes pins the reason
 // the two-stage planner exists: a two-key cap must not collapse a wide or tall
 // display into one-row prefix bands. Each stage stays within its own key budget

--- a/internal/domain/grid/sizing_internal_test.go
+++ b/internal/domain/grid/sizing_internal_test.go
@@ -1,0 +1,75 @@
+package grid
+
+import (
+	"math"
+	"testing"
+)
+
+// TestPlanTwoKeyGrid_KeepsCellsNearSquareAcrossScreenShapes pins the reason
+// the two-stage planner exists: a two-key cap must not collapse a wide or tall
+// display into one-row prefix bands. Each stage stays within its own key budget
+// and the combined layout stays inside the ordinary cell-size planner's target.
+func TestPlanTwoKeyGrid_KeepsCellsNearSquareAcrossScreenShapes(t *testing.T) {
+	tests := []struct {
+		name                   string
+		width, height          int
+		targetCols, targetRows int
+	}{
+		{name: "widescreen", width: 1920, height: 1080, targetCols: 64, targetRows: 36},
+		{name: "four by three", width: 1280, height: 960, targetCols: 42, targetRows: 32},
+		{name: "ultrawide", width: 5120, height: 1440, targetCols: 102, targetRows: 28},
+		{name: "portrait", width: 1080, height: 1920, targetCols: 36, targetRows: 64},
+	}
+
+	const keys = 25
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			plan := planTwoKeyGrid(
+				testCase.width,
+				testCase.height,
+				testCase.targetCols,
+				testCase.targetRows,
+				keys,
+				keys,
+			)
+			dimensions := plan.dimensions
+			region := plan.region
+
+			cellAspect := (float64(testCase.width) / float64(dimensions.Cols)) /
+				(float64(testCase.height) / float64(dimensions.Rows))
+			if diff := math.Abs(cellAspect - 1); diff > 0.1 {
+				t.Errorf("cell aspect ratio = %.3f, want within 10%% of square", cellAspect)
+			}
+
+			if dimensions.Cols > testCase.targetCols || dimensions.Rows > testCase.targetRows {
+				t.Errorf(
+					"plan = %dx%d, outside target %dx%d",
+					dimensions.Cols,
+					dimensions.Rows,
+					testCase.targetCols,
+					testCase.targetRows,
+				)
+			}
+
+			if localCells := region.CellCount(); localCells > keys {
+				t.Errorf("local region uses %d keys, only %d available", localCells, keys)
+			}
+
+			if dimensions.Cols%region.Cols != 0 || dimensions.Rows%region.Rows != 0 {
+				t.Fatalf(
+					"plan %dx%d is not tiled by its %dx%d regions",
+					dimensions.Cols,
+					dimensions.Rows,
+					region.Cols,
+					region.Rows,
+				)
+			}
+
+			regions := dimensions.Cols / region.Cols * (dimensions.Rows / region.Rows)
+			if regions > keys {
+				t.Errorf("plan uses %d prefix regions, only %d keys available", regions, keys)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR adds a configurable cap for coarse grid labels, allowing a large screen region to be selected in two or three keypresses before the existing one-key subgrid refinement. It automatically rebalances the coarse grid to cover the display with near-square cells, and keeps the selected limit through config reloads, monitor moves, and macOS cache prewarming.

### Configuration

`grid.max_label_length` accepts values from `2` to `4` and defaults to `4`. The default preserves existing behavior, so current configurations do not need changes. Lower values enlarge the coarse cells while retaining one-key local refinement.

## Related Issues

Closes #1536

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no platform contract was added
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`) — equivalent Go formatting and pinned lint checks passed; no native source changed
- [x] `just ci` passes — N/A, `just` is unavailable locally; the corresponding Go lint, vet, build, cross-platform compile, unit, race, integration, and vulnerability checks passed when run directly
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Screenshots / Recordings

The expected two-key coarse selection is illustrated in [issue #1536](https://github.com/y3owk1n/neru/issues/1536). The resulting geometry depends on display size and configured label characters; grid geometry and full mode-journey tests cover the behavior here.

## Additional Context

The default value preserves the prior automatic 2–4-key behavior. The cache key includes the configured limit, and monitor changes rebuild the grid with the full set of configured options.
