### PR TITLE
fix(windows): prevent overlay flashes when reopening

### DIFF
--- a/internal/adapter/platform/windows/overlay.go
+++ b/internal/adapter/platform/windows/overlay.go
@@ -358,6 +358,12 @@ func (o *OverlayWindow) Show() {
 			}
 		}
 
+		// A hidden layered window retains its last presented bitmap. Publish
+		// the current pixels before showing it, otherwise reopening briefly
+		// exposes the previous frame before Clear's transparent pixels and
+		// the new draw are presented.
+		o.flushPixels()
+
 		discardCall(procShowWindow.Call(uintptr(o.hwnd), swShowNoActivate))
 
 		const (
@@ -375,9 +381,6 @@ func (o *OverlayWindow) Show() {
 			swpNoActivate|swpShowWindow|swpNomove|swpNosize,
 		))
 		o.visible = true
-
-		// Force a flush on show so content is visible immediately.
-		o.flushPixels()
 	})
 }
 


### PR DESCRIPTION
## Description

This PR fixes intermittent overlay flashes when reopening the recursive grid on Windows. Previously, labels could briefly appear, disappear, and then return during a single activation.

The overlay now publishes its current pixels before becoming visible, preventing the previous session's frame from flashing on screen. Existing configuration and keybindings are unchanged.

## Related Issues

Closes #1544.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags — existing Windows build tag retained.
- [x] No darwin imports from untagged (shared) code — no imports or shared code changed.
- [x] Stub implementations added for other platforms — N/A, no interface or capability changes.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted — `gofmt` clean; repository formatting and lint checks pass.
- [x] `just ci` passes — full Windows host gate, including formatting, lint, vet, build, cross-platform checks, tests with the race detector, and vulnerability scan.
- [x] Tests added/updated for new or changed functionality — N/A for a new unit test: this defect is a transient native presentation frame, and the existing concrete Win32 calls have no injectable presentation seam. Existing overlay integration tests and a real-desktop pixel/event probe were run; details below.
- [x] Documentation updated — N/A, no configuration, command, or support-status changes.
- [x] PR title is a conventional commit subject written for users.

## Screenshots / Recordings

Actual desktop captures over a blank background, cropped to one label, enlarged 2x and played at one-quarter speed:

| Before: v1.51.0 | After: local fix |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/RainbowDashy/neru/3ffa93dda821dac6bcd7c0df40447749df55dd0b/before.gif) | ![After](https://raw.githubusercontent.com/RainbowDashy/neru/3ffa93dda821dac6bcd7c0df40447749df55dd0b/after.gif) |

These illustrate label stability, not an activation-latency benchmark. [Recording details](https://github.com/RainbowDashy/neru/blob/3ffa93dda821dac6bcd7c0df40447749df55dd0b/README.md).

## Additional Context

- A hidden layered window retains its last presented bitmap. `OverlayWindow.Show` previously called `ShowWindow` before `flushPixels`, allowing the retained bitmap to become visible before the cleared/current pixels were presented. This moves the existing flush ahead of showing the window; window creation, positioning, and UI-thread dispatch are unchanged.
- Reproduced on Windows 11 Home 25H2 (26200.8875) with official v1.51.0. The affected call order was also present on current main (`af2335f`), which this branch uses as its base.
- A local desktop probe observed label flashing in 4/6 activations before the fix and 0/14 after applying the same patch to v1.51.0. Routes included direct CLI activation, Ctrl+Shift+C, Ctrl+Shift+G, and repeated key-down events. These are local observations, not a guarantee across all systems.
- The [desktop probe and its configuration assumptions](https://github.com/RainbowDashy/neru/tree/98ae896a3d4b3a233ab99dddc53206502827ebfc) are available alongside the recordings, outside this code diff.
- Targeted Windows overlay integration tests passed. The Windows package also passed with `go test -race`. Platform boundary review found no actionable issues.
- A source-order assertion would merely mirror this change; detecting the original transient frame in an automated test would require native-call instrumentation or timing-sensitive desktop capture. This PR keeps that broader testing change out of the focused fix.
