### PR TITLE
fix(linux): report when scrolling falls back from uinput on wayland

### DIFF
--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -45,6 +45,7 @@ Host changes required before Neru runs correctly (not code changes):
 | 1   | Install [build dependencies](#build-dependencies)           | CGO backends and runtime libs         | All Linux | Yes                     |
 | 2   | Add user to `input` group: `sudo usermod -aG input "$USER"` | `evdev` keyboard capture **and Neru's own global hotkeys** on Wayland | Wayland | Yes (re-login required) |
 | 3   | Bind `neru <mode>` in compositor keybindings                | Only needed if you skip item 2        | Wayland   | Yes (user config)       |
+| 4   | Make `/dev/uinput` writable (udev rule below)               | Scroll injection through a uinput wheel; without it scrolling falls back to the compositor virtual pointer, which Chromium and Electron apps on Hyprland ignore. Also the fast path for `neru key` | Wayland | Yes (udev rule) |
 
 Notes:
 
@@ -55,6 +56,8 @@ Notes:
   the compositor only if you would rather not grant `/dev/input` access. See
   [Global hotkeys on Wayland](./LINUX_DESKTOPS.md#global-hotkeys-on-wayland).
 - Item 3 cannot be automated by a package; ship example snippets where helpful.
+- Item 4 is what `neru doctor` reports under `capability.scroll` when it is
+  missing, and the daemon warns once at the first scroll that falls back.
 
 ---
 
@@ -75,6 +78,30 @@ Log out and back in, then confirm `id` lists the `input` group.
 When capture works, Neru logs `Using Wayland evdev keyboard capture`. Without
 device access it falls back to overlay-focused capture; basic navigation still
 works but modified clicks may degrade.
+
+---
+
+## Wayland scroll injection permissions
+
+On Wayland, Neru scrolls through a virtual mouse wheel it creates on
+`/dev/uinput`, so the events enter the input stack below the compositor and
+reach every client like a physical wheel. Most distros ship that node as
+root-only (`crw-rw---- root root`). The `input` group from the previous section
+does not cover it; grant it with a udev rule:
+
+```bash
+echo 'KERNEL=="uinput", GROUP="input", MODE="0660"' | sudo tee /etc/udev/rules.d/99-neru-uinput.rules
+sudo udevadm control --reload && sudo udevadm trigger
+```
+
+Confirm with `ls -l /dev/uinput` (group `input`, mode `0660`) and restart the
+daemon. If the node is missing entirely, load the module: `sudo modprobe uinput`.
+
+Without it Neru still scrolls, through the compositor's virtual pointer, but
+that path is not honored by every client: Chromium and Electron apps on
+Hyprland scroll a few pixels and then stop. `neru doctor` reports the downgrade
+under `capability.scroll` with the open error, and the daemon logs one warning
+at the first scroll that falls back.
 
 ---
 

--- a/internal/adapter/accessibility/native/linux/element.go
+++ b/internal/adapter/accessibility/native/linux/element.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"os"
 	"slices"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -595,6 +596,8 @@ func scrollAtCursorNow(deltaX, deltaY int, modifiers action.Modifiers) error {
 			return nil
 		}
 
+		warnUinputScrollFallback()
+
 		return wlrootsScrollAtCursor(remainX, remainY, 0)
 	}
 
@@ -611,6 +614,26 @@ func scrollAtCursorNow(deltaX, deltaY int, modifiers action.Modifiers) error {
 	}
 
 	return nil
+}
+
+// uinputScrollFallbackOnce keeps the fallback warning to one line per
+// process: the condition is a session fact, and every scroll would repeat it.
+var uinputScrollFallbackOnce sync.Once
+
+// warnUinputScrollFallback says, once, that scrolling left the uinput wheel
+// for the compositor's virtual pointer and why. The two paths look the same
+// from the log otherwise, and only the virtual pointer one is ignored by
+// Chromium and Electron clients on Hyprland — which is how a user with a
+// root-only /dev/uinput reads as "scroll works in Firefox but not Discord".
+func warnUinputScrollFallback() {
+	uinputScrollFallbackOnce.Do(func() {
+		currentLogger().Warn(
+			"Scrolling through the wlroots virtual pointer instead of uinput; "+
+				"some clients ignore that path (grant write access to /dev/uinput, "+
+				"see docs/LINUX_SETUP.md)",
+			zap.Error(eventtaplinux.UinputScrollError()),
+		)
+	})
 }
 
 // hyprlandKeepsUinputScroll reports whether a modified scroll on this session

--- a/internal/adapter/accessibility/native/linux/element.go
+++ b/internal/adapter/accessibility/native/linux/element.go
@@ -542,6 +542,10 @@ func scrollAtCursorNow(deltaX, deltaY int, modifiers action.Modifiers) error {
 		// the compositor and client can process events incrementally.
 		const maxBatchEvents = 50
 
+		// fallbackCause is the uinput error that sends the rest of the scroll
+		// to the virtual pointer, for the one-time warning below.
+		var fallbackCause error
+
 		sendScaledScroll := func(axis int, delta int) int {
 			if delta == 0 {
 				return 0
@@ -571,6 +575,7 @@ func scrollAtCursorNow(deltaX, deltaY int, modifiers action.Modifiers) error {
 						// remaining delta is retried via wlroots virtual pointer
 						// fallback without double-counting already-sent notches.
 						remainingNotches += len(batch)
+						fallbackCause = err
 
 						break
 					}
@@ -596,7 +601,7 @@ func scrollAtCursorNow(deltaX, deltaY int, modifiers action.Modifiers) error {
 			return nil
 		}
 
-		warnUinputScrollFallback()
+		warnUinputScrollFallback(fallbackCause)
 
 		return wlrootsScrollAtCursor(remainX, remainY, 0)
 	}
@@ -625,13 +630,15 @@ var uinputScrollFallbackOnce sync.Once
 // from the log otherwise, and only the virtual pointer one is ignored by
 // Chromium and Electron clients on Hyprland — which is how a user with a
 // root-only /dev/uinput reads as "scroll works in Firefox but not Discord".
-func warnUinputScrollFallback() {
+// cause is the batch error that triggered it: the device creation failure,
+// reason included, or a write that failed after a good start.
+func warnUinputScrollFallback(cause error) {
 	uinputScrollFallbackOnce.Do(func() {
 		currentLogger().Warn(
 			"Scrolling through the wlroots virtual pointer instead of uinput; "+
 				"some clients ignore that path (grant write access to /dev/uinput, "+
 				"see docs/LINUX_SETUP.md)",
-			zap.Error(eventtaplinux.UinputScrollError()),
+			zap.Error(cause),
 		)
 	})
 }

--- a/internal/adapter/accessibility/native/linux/logger.go
+++ b/internal/adapter/accessibility/native/linux/logger.go
@@ -1,0 +1,37 @@
+//go:build linux
+
+package linux
+
+import (
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+// pkgLogger is the process-global logger for the Linux injection backends,
+// a slot beside configProvider for the same reason: the scroll path picks its
+// backend at call time, deep below any struct that carries a logger, and the
+// one thing worth saying from there is which backend it ended up on.
+var (
+	pkgLoggerMu sync.RWMutex
+	pkgLogger   = zap.NewNop()
+)
+
+// SetLogger installs the logger the Linux injection backends report through.
+// It is set once at daemon startup (see internal/app/runtime_config_linux.go).
+func SetLogger(logger *zap.Logger) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	pkgLoggerMu.Lock()
+	pkgLogger = logger.Named("accessibility.native")
+	pkgLoggerMu.Unlock()
+}
+
+func currentLogger() *zap.Logger {
+	pkgLoggerMu.RLock()
+	defer pkgLoggerMu.RUnlock()
+
+	return pkgLogger
+}

--- a/internal/adapter/eventtap/linux/evdev_scroll_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_scroll_cgo.go
@@ -71,15 +71,6 @@ func IsUinputScrollAvailable() bool {
 	return errUinputScroll == nil
 }
 
-// UinputScrollError reports why the uinput scroll device could not be
-// created, or nil when it is usable. The reason is what the scroll fallback
-// warning and `neru doctor` show the user.
-func UinputScrollError() error {
-	_, err := getUinputScrollFd()
-
-	return err
-}
-
 // ScrollDeviceScroll sends a scroll event via the uinput virtual device.
 func ScrollDeviceScroll(axis, value int) error {
 	scrollFd, err := getUinputScrollFd()

--- a/internal/adapter/eventtap/linux/evdev_scroll_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_scroll_cgo.go
@@ -38,11 +38,17 @@ var (
 var uinputScrollMu sync.Mutex
 
 func initUinputScroll() error {
-	var fd C.int
-	if C.neru_uinput_create_scroll(&fd) == 0 {
-		return fmt.Errorf("%w", errUinputScrollUnavailable)
+	var deviceFd C.int
+
+	created, errno := C.neru_uinput_create_scroll(&deviceFd)
+	if created == 0 {
+		// errno is the /dev/uinput open failure, which is what a user has to
+		// act on: "permission denied" means a udev rule or group, "no such
+		// file" means the uinput module is not loaded.
+		return fmt.Errorf("%w: /dev/uinput: %w", errUinputScrollUnavailable, errno)
 	}
-	uinputScrollFd = int(fd)
+
+	uinputScrollFd = int(deviceFd)
 
 	return nil
 }
@@ -63,6 +69,15 @@ func IsUinputScrollAvailable() bool {
 	_, _ = getUinputScrollFd()
 
 	return errUinputScroll == nil
+}
+
+// UinputScrollError reports why the uinput scroll device could not be
+// created, or nil when it is usable. The reason is what the scroll fallback
+// warning and `neru doctor` show the user.
+func UinputScrollError() error {
+	_, err := getUinputScrollFd()
+
+	return err
 }
 
 // ScrollDeviceScroll sends a scroll event via the uinput virtual device.

--- a/internal/adapter/eventtap/linux/tap_nocgo.go
+++ b/internal/adapter/eventtap/linux/tap_nocgo.go
@@ -48,11 +48,6 @@ func IsUinputScrollAvailable() bool {
 	return false
 }
 
-// UinputScrollError reports that uinput scroll injection is compiled out.
-func UinputScrollError() error {
-	return errUinputScrollNoCGO("uinput scroll")
-}
-
 // IsWaylandEvdevKeyboardActive is always false without CGO (no evdev grab).
 // IsWaylandEvdevKeyboardActive reports false: evdev capture needs cgo.
 func IsWaylandEvdevKeyboardActive() bool {

--- a/internal/adapter/eventtap/linux/tap_nocgo.go
+++ b/internal/adapter/eventtap/linux/tap_nocgo.go
@@ -48,6 +48,11 @@ func IsUinputScrollAvailable() bool {
 	return false
 }
 
+// UinputScrollError reports that uinput scroll injection is compiled out.
+func UinputScrollError() error {
+	return errUinputScrollNoCGO("uinput scroll")
+}
+
 // IsWaylandEvdevKeyboardActive is always false without CGO (no evdev grab).
 // IsWaylandEvdevKeyboardActive reports false: evdev capture needs cgo.
 func IsWaylandEvdevKeyboardActive() bool {

--- a/internal/adapter/platform/capability_contract_test.go
+++ b/internal/adapter/platform/capability_contract_test.go
@@ -263,6 +263,7 @@ func TestCapabilities_ProbeCoverageIsDocumented(t *testing.T) {
 	// device) or has only a mutating entry point, so it is checked by that
 	// subsystem's own tests instead of here.
 	uncovered := map[ports.CapabilityKey]string{
+		ports.CapabilityScroll:        "injects a real scroll into the focused app",
 		ports.CapabilityAccessibility: "needs an AX client fixture; covered by internal/adapter/accessibility",
 		ports.CapabilityOverlay:       "needs a live overlay manager; covered by internal/adapter/overlay",
 		ports.CapabilityNotifications: "only entry point displays UI to the user",

--- a/internal/adapter/platform/linux/evdev.c
+++ b/internal/adapter/platform/linux/evdev.c
@@ -156,6 +156,20 @@ int neru_uinput_create_scroll(int *out_fd) {
 	return 1;
 }
 
+/* Create the scroll wheel the way the scroll path does, then tear it down
+ * again. Opening the node alone is not the question `neru doctor` asks: the
+ * UI_SET_* and UI_DEV_CREATE ioctls can refuse on a node that opened. On
+ * failure errno is the same one neru_uinput_create_scroll leaves. */
+int neru_uinput_probe_scroll(void) {
+	int fd;
+	if (!neru_uinput_create_scroll(&fd)) {
+		return 0;
+	}
+	ioctl(fd, UI_DEV_DESTROY);
+	close(fd);
+	return 1;
+}
+
 int neru_uinput_scroll(int fd, int axis, int value) {
 	struct input_event ev;
 	memset(&ev, 0, sizeof(ev));

--- a/internal/adapter/platform/linux/evdev.c
+++ b/internal/adapter/platform/linux/evdev.c
@@ -95,33 +95,45 @@ int neru_evdev_get_pressed_keys(int fd, unsigned int *out_keys, int max_keys) {
 	return count;
 }
 
+/* Close fd without disturbing the errno the caller is about to report. */
+static void neru_uinput_fail(int fd) {
+	int saved = errno;
+	close(fd);
+	errno = saved;
+}
+
+/* On failure errno describes the /dev/uinput open (or the ioctl that
+ * refused), so the Go side can tell "permission denied" from "no such
+ * device" instead of reporting a bare "unavailable". */
 int neru_uinput_create_scroll(int *out_fd) {
 	int fd = open("/dev/uinput", O_RDWR);
 	if (fd < 0) {
+		int open_errno = errno;
 		fd = open("/dev/input/uinput", O_RDWR);
-	}
-	if (fd < 0) {
-		return 0;
+		if (fd < 0) {
+			errno = open_errno;
+			return 0;
+		}
 	}
 
 	if (ioctl(fd, UI_SET_EVBIT, EV_REL) < 0) {
-		close(fd);
+		neru_uinput_fail(fd);
 		return 0;
 	}
 	if (ioctl(fd, UI_SET_RELBIT, REL_WHEEL) < 0) {
-		close(fd);
+		neru_uinput_fail(fd);
 		return 0;
 	}
 	if (ioctl(fd, UI_SET_RELBIT, REL_HWHEEL) < 0) {
-		close(fd);
+		neru_uinput_fail(fd);
 		return 0;
 	}
 	if (ioctl(fd, UI_SET_RELBIT, REL_WHEEL_HI_RES) < 0) {
-		close(fd);
+		neru_uinput_fail(fd);
 		return 0;
 	}
 	if (ioctl(fd, UI_SET_RELBIT, REL_HWHEEL_HI_RES) < 0) {
-		close(fd);
+		neru_uinput_fail(fd);
 		return 0;
 	}
 
@@ -132,11 +144,11 @@ int neru_uinput_create_scroll(int *out_fd) {
 	usetup.id.product = 0x5678;
 	strcpy(usetup.name, "neru-scroll");
 	if (ioctl(fd, UI_DEV_SETUP, &usetup) < 0) {
-		close(fd);
+		neru_uinput_fail(fd);
 		return 0;
 	}
 	if (ioctl(fd, UI_DEV_CREATE) < 0) {
-		close(fd);
+		neru_uinput_fail(fd);
 		return 0;
 	}
 

--- a/internal/adapter/platform/linux/evdev.h
+++ b/internal/adapter/platform/linux/evdev.h
@@ -14,6 +14,7 @@ int neru_evdev_get_bustype(int fd);
 ssize_t neru_evdev_read_event(int fd, struct input_event *event);
 int neru_evdev_get_pressed_keys(int fd, unsigned int *out_keys, int max_keys);
 int neru_uinput_create_scroll(int *out_fd);
+int neru_uinput_probe_scroll(void);
 int neru_uinput_scroll(int fd, int axis, int value);
 int neru_uinput_scroll_batch(int fd, int axis, int *values, int count);
 int neru_uinput_create_keyboard(int *out_fd);

--- a/internal/adapter/platform/linux/scroll_capability_cgo.go
+++ b/internal/adapter/platform/linux/scroll_capability_cgo.go
@@ -1,0 +1,24 @@
+//go:build linux && cgo
+
+package linux
+
+/*
+#include "evdev.h"
+*/
+import "C"
+
+import "fmt"
+
+// uinputScrollDeviceError reports why the uinput scroll wheel cannot be
+// created, or nil when it can. It builds and destroys the same device the
+// scroll path uses, so a node that opens but refuses an ioctl is reported
+// too. The errno is the part a user acts on: "permission denied" means a
+// udev rule or group, "no such file" means the uinput module is not loaded.
+func uinputScrollDeviceError() error {
+	created, errno := C.neru_uinput_probe_scroll()
+	if created == 0 {
+		return fmt.Errorf("%s: %w", uinputDevicePath, errno)
+	}
+
+	return nil
+}

--- a/internal/adapter/platform/linux/scroll_capability_nocgo.go
+++ b/internal/adapter/platform/linux/scroll_capability_nocgo.go
@@ -1,0 +1,14 @@
+//go:build linux && !cgo
+
+package linux
+
+import "github.com/y3owk1n/neru/internal/derrors"
+
+// uinputScrollDeviceError reports that the uinput scroll wheel is compiled
+// out: the device is created through cgo.
+func uinputScrollDeviceError() error {
+	return derrors.New(
+		derrors.CodeNotSupported,
+		"uinput scroll device unavailable: this binary was built with CGO_ENABLED=0",
+	)
+}

--- a/internal/adapter/platform/linux/scroll_capability_test.go
+++ b/internal/adapter/platform/linux/scroll_capability_test.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package linux
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/ports"
+)
+
+// TestScrollCapability_UinputUnwritableNamesTheFix pins what `neru doctor`
+// prints when the uinput wheel cannot be opened: a downgrade rather than a
+// green row, carrying the open error and the device to make writable.
+func TestScrollCapability_UinputUnwritableNamesTheFix(t *testing.T) {
+	declared := ports.FeatureCapability{Status: ports.FeatureStatusSupported, Detail: "declared"}
+
+	tests := []struct {
+		name       string
+		uinputErr  error
+		wantStatus ports.FeatureStatus
+		wantDetail []string
+	}{
+		{
+			name:       "uinput writable keeps the declared capability",
+			uinputErr:  nil,
+			wantStatus: ports.FeatureStatusSupported,
+			wantDetail: []string{"declared"},
+		},
+		{
+			name:       "uinput unwritable downgrades with the reason and the device",
+			uinputErr:  &os.PathError{Op: "open", Path: uinputDevicePath, Err: os.ErrPermission},
+			wantStatus: ports.FeatureStatusStub,
+			wantDetail: []string{"permission denied", uinputDevicePath, "virtual pointer"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := scrollCapability(declared, testCase.uinputErr)
+
+			if got.Status != testCase.wantStatus {
+				t.Fatalf("Status = %q, want %q", got.Status, testCase.wantStatus)
+			}
+
+			for _, want := range testCase.wantDetail {
+				if !strings.Contains(got.Detail, want) {
+					t.Errorf("Detail %q does not mention %q", got.Detail, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/adapter/platform/linux/system_common.go
+++ b/internal/adapter/platform/linux/system_common.go
@@ -30,6 +30,10 @@ const (
 	// This package cannot import platform (the factory there imports this one),
 	// so the label is duplicated rather than referenced.
 	backendUnknown = "unknown"
+
+	// uinputDevicePath is the node the scroll wheel and key feed are created
+	// on; the legacy /dev/input/uinput location is tried after it.
+	uinputDevicePath = "/dev/uinput"
 )
 
 // SystemAdapter is a Linux system adapter.
@@ -123,7 +127,56 @@ func (s *SystemAdapter) Capabilities() ports.PlatformCapabilities {
 			return err
 		})
 
+	// Scroll on Wayland is the one capability whose fast path can be missing
+	// while the call still returns nil: the uinput wheel falls back to the
+	// compositor's virtual pointer, and Chromium and Electron clients on
+	// Hyprland ignore that stream. The probe is the open the wheel device does.
+	if s.backend == backendWaylandWlroots || s.backend == backendWaylandKDE {
+		capabilities.Scroll = scrollCapability(capabilities.Scroll, uinputScrollDeviceError())
+	}
+
 	return capabilities
+}
+
+// uinputScrollDeviceError reports whether this process can open the uinput
+// device the scroll path creates its wheel on, trying the same two nodes it
+// does. The first error is the one to show: the second node is a legacy
+// location that is absent on every current distro.
+func uinputScrollDeviceError() error {
+	var firstErr error
+
+	for _, path := range []string{uinputDevicePath, "/dev/input/uinput"} {
+		file, err := os.OpenFile(path, os.O_RDWR, 0)
+		if err == nil {
+			_ = file.Close()
+
+			return nil
+		}
+
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}
+
+// scrollCapability downgrades the declared scroll capability when the uinput
+// wheel device cannot be opened, naming the fix in the words the user reads
+// in `neru doctor`.
+func scrollCapability(declared ports.FeatureCapability, uinputErr error) ports.FeatureCapability {
+	if uinputErr == nil {
+		return declared
+	}
+
+	return ports.FeatureCapability{
+		Status: ports.FeatureStatusStub,
+		Detail: "scroll injection is falling back to the compositor virtual pointer, " +
+			"which Chromium and Electron apps on Hyprland ignore: " + uinputErr.Error() +
+			". Grant write access to " + uinputDevicePath + " (udev rule " +
+			`KERNEL=="uinput", GROUP="input", MODE="0660"` +
+			", then reload udev or reboot); see docs/LINUX_SETUP.md",
+	}
 }
 
 // xdgDir resolves an XDG base directory per the Base Directory spec: the

--- a/internal/adapter/platform/linux/system_common.go
+++ b/internal/adapter/platform/linux/system_common.go
@@ -32,7 +32,7 @@ const (
 	backendUnknown = "unknown"
 
 	// uinputDevicePath is the node the scroll wheel and key feed are created
-	// on; the legacy /dev/input/uinput location is tried after it.
+	// on, named in the words `neru doctor` prints.
 	uinputDevicePath = "/dev/uinput"
 )
 
@@ -130,35 +130,13 @@ func (s *SystemAdapter) Capabilities() ports.PlatformCapabilities {
 	// Scroll on Wayland is the one capability whose fast path can be missing
 	// while the call still returns nil: the uinput wheel falls back to the
 	// compositor's virtual pointer, and Chromium and Electron clients on
-	// Hyprland ignore that stream. The probe is the open the wheel device does.
+	// Hyprland ignore that stream. The probe creates and destroys the same
+	// wheel device, so every ioctl the real path runs is exercised.
 	if s.backend == backendWaylandWlroots || s.backend == backendWaylandKDE {
 		capabilities.Scroll = scrollCapability(capabilities.Scroll, uinputScrollDeviceError())
 	}
 
 	return capabilities
-}
-
-// uinputScrollDeviceError reports whether this process can open the uinput
-// device the scroll path creates its wheel on, trying the same two nodes it
-// does. The first error is the one to show: the second node is a legacy
-// location that is absent on every current distro.
-func uinputScrollDeviceError() error {
-	var firstErr error
-
-	for _, path := range []string{uinputDevicePath, "/dev/input/uinput"} {
-		file, err := os.OpenFile(path, os.O_RDWR, 0)
-		if err == nil {
-			_ = file.Close()
-
-			return nil
-		}
-
-		if firstErr == nil {
-			firstErr = err
-		}
-	}
-
-	return firstErr
 }
 
 // scrollCapability downgrades the declared scroll capability when the uinput

--- a/internal/app/ipcctrl/info_health.go
+++ b/internal/app/ipcctrl/info_health.go
@@ -191,6 +191,13 @@ func capabilitiesMap(capabilities ports.PlatformCapabilities) map[string]any {
 		out[string(ports.CapabilityNotifications)+detailSuffix] = detail
 	}
 
+	// Scroll gets the notification treatment: a Linux downgrade names the
+	// device the user has to make writable, which is the whole fix.
+	if detail := capabilities.Scroll.Detail; detail != "" &&
+		!capabilities.Scroll.Supported() {
+		out[string(ports.CapabilityScroll)+detailSuffix] = detail
+	}
+
 	// Focused-app inspection is the third, gated the same way, because the one
 	// thing a bare "stub" cannot say is that nothing is wrong. Linux probes it
 	// live, so a desktop with no window focused reports the same status as a

--- a/internal/app/runtime_config_darwin.go
+++ b/internal/app/runtime_config_darwin.go
@@ -3,10 +3,12 @@
 package app
 
 import (
+	"go.uber.org/zap"
+
 	"github.com/y3owk1n/neru/internal/adapter/platform/darwin"
 	"github.com/y3owk1n/neru/internal/config/loader"
 )
 
-func configurePlatformRuntimeConfigProviders(cfgService *loader.Service) {
+func configurePlatformRuntimeConfigProviders(cfgService *loader.Service, _ *zap.Logger) {
 	darwin.SetConfigProvider(cfgService)
 }

--- a/internal/app/runtime_config_linux.go
+++ b/internal/app/runtime_config_linux.go
@@ -3,15 +3,20 @@
 package app
 
 import (
+	"go.uber.org/zap"
+
 	nativelinux "github.com/y3owk1n/neru/internal/adapter/accessibility/native/linux"
 	"github.com/y3owk1n/neru/internal/adapter/platform/linux"
 	"github.com/y3owk1n/neru/internal/config/loader"
 )
 
-func configurePlatformRuntimeConfigProviders(cfgService *loader.Service) {
+func configurePlatformRuntimeConfigProviders(cfgService *loader.Service, logger *zap.Logger) {
 	linux.SetConfigProvider(cfgService)
 	// Scroll injection lives in the accessibility backend rather than in
 	// platform/linux, so smooth_scroll needs its own reader on that side of the
 	// boundary. On darwin both paths are in one package and one call does.
 	nativelinux.SetConfigProvider(cfgService)
+	// Same slot shape for the logger: the scroll path reports which backend
+	// it fell back to from below any struct that carries one.
+	nativelinux.SetLogger(logger)
 }

--- a/internal/app/runtime_config_other.go
+++ b/internal/app/runtime_config_other.go
@@ -2,6 +2,10 @@
 
 package app
 
-import "github.com/y3owk1n/neru/internal/config/loader"
+import (
+	"go.uber.org/zap"
 
-func configurePlatformRuntimeConfigProviders(_ *loader.Service) {}
+	"github.com/y3owk1n/neru/internal/config/loader"
+)
+
+func configurePlatformRuntimeConfigProviders(_ *loader.Service, _ *zap.Logger) {}

--- a/internal/app/runtime_config_windows.go
+++ b/internal/app/runtime_config_windows.go
@@ -2,6 +2,10 @@
 
 package app
 
-import "github.com/y3owk1n/neru/internal/config/loader"
+import (
+	"go.uber.org/zap"
 
-func configurePlatformRuntimeConfigProviders(_ *loader.Service) {}
+	"github.com/y3owk1n/neru/internal/config/loader"
+)
+
+func configurePlatformRuntimeConfigProviders(_ *loader.Service, _ *zap.Logger) {}

--- a/internal/app/startup_phases.go
+++ b/internal/app/startup_phases.go
@@ -91,7 +91,7 @@ func initializeServicesAndAdapters(app *App) error {
 
 	// Initialize config service
 	cfgService := app.newConfigService(logger)
-	configurePlatformRuntimeConfigProviders(cfgService)
+	configurePlatformRuntimeConfigProviders(cfgService, logger)
 
 	// Initialize adapters
 	// accAdapter is retained on the App because the focus-change path calls

--- a/internal/ports/capabilities.go
+++ b/internal/ports/capabilities.go
@@ -38,6 +38,8 @@ const (
 	CapabilityScreen CapabilityKey = "screen"
 	// CapabilityCursor covers cursor movement and position tracking.
 	CapabilityCursor CapabilityKey = "cursor"
+	// CapabilityScroll covers scroll injection at the cursor.
+	CapabilityScroll CapabilityKey = "scroll"
 	// CapabilityAccessibility covers clickable-element discovery.
 	CapabilityAccessibility CapabilityKey = "accessibility"
 	// CapabilityOverlay covers native overlay windows.
@@ -73,6 +75,7 @@ type PlatformCapabilities struct {
 	Process           FeatureCapability
 	Screen            FeatureCapability
 	Cursor            FeatureCapability
+	Scroll            FeatureCapability
 	Accessibility     FeatureCapability
 	Overlay           FeatureCapability
 	Notifications     FeatureCapability
@@ -108,6 +111,7 @@ func (c PlatformCapabilities) Entries() []CapabilityEntry {
 		{Key: CapabilityProcess, Field: "Process", FeatureCapability: c.Process},
 		{Key: CapabilityScreen, Field: "Screen", FeatureCapability: c.Screen},
 		{Key: CapabilityCursor, Field: "Cursor", FeatureCapability: c.Cursor},
+		{Key: CapabilityScroll, Field: "Scroll", FeatureCapability: c.Scroll},
 		{
 			Key:               CapabilityAccessibility,
 			Field:             "Accessibility",

--- a/internal/ports/capability_presets.go
+++ b/internal/ports/capability_presets.go
@@ -27,6 +27,9 @@ func DarwinCapabilities() PlatformCapabilities {
 		Cursor: supportedCapability(
 			"cursor movement and tracking available via Quartz events",
 		),
+		Scroll: supportedCapability(
+			"scroll injection via Quartz scroll-wheel events, both axes",
+		),
 		Accessibility: supportedCapability(
 			"macOS accessibility integration available via AXUIElement",
 		),
@@ -66,6 +69,15 @@ func LinuxCapabilities() PlatformCapabilities {
 		),
 		Cursor: supportedCapability(
 			"cursor movement/tracking available via XTest and Wayland virtual-pointer",
+		),
+		// Live-probed by the Linux SystemAdapter on Wayland, which downgrades
+		// this to a stub when /dev/uinput is not writable: the virtual-pointer
+		// fallback still scrolls most clients, but not Chromium or Electron on
+		// Hyprland. See linux.SystemAdapter.scrollCapability.
+		Scroll: supportedCapability(
+			"scroll injection via XTest (X11) or a uinput wheel device when " +
+				"/dev/uinput is writable (Wayland), falling back to the wlroots " +
+				"virtual pointer or libei (KDE)",
 		),
 		Accessibility: supportedCapability(
 			"clickable-element discovery via AT-SPI (D-Bus) tree walk; " +
@@ -158,6 +170,9 @@ func WindowsCapabilities() PlatformCapabilities {
 		),
 		Cursor: supportedCapability(
 			"cursor movement and tracking available via SetCursorPos/GetCursorPos",
+		),
+		Scroll: supportedCapability(
+			"scroll injection via SendInput mouse-wheel events, vertical only",
 		),
 		Accessibility: supportedCapability(
 			"clickable-element discovery available via UI Automation (initial coverage)",


### PR DESCRIPTION
## Description

This PR makes a silent scroll degradation on Linux Wayland visible. When the daemon cannot open `/dev/uinput`, scrolling falls back to the compositor's virtual pointer, and Chromium and Electron apps on Hyprland ignore that stream: scroll mode moves a few pixels and then stops, while Firefox keeps working. Nothing in the log or in `neru doctor` said so.

Now the daemon logs one warning at the first scroll that falls back, with the actual open error (for example `permission denied` rather than a bare "unavailable"). `neru doctor` gains a `scroll` capability row, live-probed on Wayland by opening the device, whose detail names the udev rule that fixes it. The Linux setup guide gets the matching install-time row and a section with the rule.

Scrolling itself is unchanged; this only reports what already happened. A missing `/dev/uinput` now turns the doctor row red on every Wayland session, including compositors where the fallback works, because the docs already list the device as required for scroll on wlroots and a green doctor is what hid this case.

## Related Issues

N/A

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

macOS and Windows only gain the static `scroll` capability declaration that every platform must carry.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

`just lint-cross` and `just test-linux` (the docker Linux runs with CGO on) also pass.

What `neru doctor` prints on an affected machine:

```
capability.scroll          stub
capability.scroll_detail   scroll injection is falling back to the compositor virtual pointer, which Chromium and Electron apps on Hyprland ignore: open /dev/uinput: permission denied. Grant write access to /dev/uinput (udev rule KERNEL=="uinput", GROUP="input", MODE="0660", then reload udev or reboot); see docs/LINUX_SETUP.md
```
