### PR TITLE
fix(linux): stop wayland scroll sending a second, reversed notch per press

### DIFF
--- a/internal/adapter/accessibility/native/linux/element.go
+++ b/internal/adapter/accessibility/native/linux/element.go
@@ -584,14 +584,7 @@ func scrollAtCursorNow(deltaX, deltaY int, modifiers action.Modifiers) error {
 				}
 			}
 
-			notchesSent := totalNotches - remainingNotches
-
-			pixelsSent := notchesSent * scrollScale
-			if delta > 0 {
-				return max(delta-pixelsSent, 0)
-			}
-
-			return min(delta+pixelsSent, 0)
+			return uinputScrollRemainder(delta, totalNotches, remainingNotches, scrollScale)
 		}
 
 		remainY := sendScaledScroll(uinputScrollAxisVertical, deltaY)
@@ -619,6 +612,50 @@ func scrollAtCursorNow(deltaX, deltaY int, modifiers action.Modifiers) error {
 	}
 
 	return nil
+}
+
+// uinputScrollRemainder is the part of a scroll the uinput wheel did not
+// send, in the caller's pixels, for the virtual pointer to finish.
+//
+// It is zero whenever every notch went out, even when the delta was not a
+// whole number of notches: a 50 px step is one 30 px notch, and the 20 px
+// left over is rounding, not a lost scroll. Handing it on used to add a
+// second, opposite-signed notch to every press on Hyprland, which Chromium
+// and Electron clients summed to nothing.
+func uinputScrollRemainder(delta, totalNotches, remainingNotches, scale int) int {
+	if remainingNotches == 0 {
+		return 0
+	}
+
+	pixelsSent := (totalNotches - remainingNotches) * scale
+	if delta > 0 {
+		return max(delta-pixelsSent, 0)
+	}
+
+	return min(delta+pixelsSent, 0)
+}
+
+// wlrootsScrollNotch is one wheel notch for the virtual pointer: the pixel
+// step and the discrete count, in the Wayland convention where positive is
+// down on the vertical axis and right on the horizontal one. The caller's
+// delta is positive-up on the vertical axis, so that axis flips both values
+// together; a discrete count that disagrees with the step makes a client
+// that reads axis_value120 scroll the opposite way from one that reads axis.
+func wlrootsScrollNotch(axis, delta, step int) (int, int) {
+	if delta < 0 {
+		step = -step
+	}
+
+	if axis == uinputScrollAxisVertical {
+		step = -step
+	}
+
+	disc := 1
+	if step < 0 {
+		disc = -1
+	}
+
+	return step, disc
 }
 
 // uinputScrollFallbackOnce keeps the fallback warning to one line per

--- a/internal/adapter/accessibility/native/linux/element_wayland_wlroots_cgo.go
+++ b/internal/adapter/accessibility/native/linux/element_wayland_wlroots_cgo.go
@@ -345,18 +345,7 @@ func wlrootsScrollAxis(axis int, delta int) error {
 		totalNotches = 1
 	}
 
-	negate := axis == 0
-
-	step := wlrootsScrollStep
-	if negate {
-		step = -step
-	}
-
-	disc := 1
-	if delta < 0 {
-		step = -step
-		disc = -disc
-	}
+	step, disc := wlrootsScrollNotch(axis, delta, wlrootsScrollStep)
 
 	deltas := make([]int, 0, wlrootsScrollMaxEvents)
 	discretes := make([]int, 0, wlrootsScrollMaxEvents)

--- a/internal/adapter/accessibility/native/linux/scroll_notch_test.go
+++ b/internal/adapter/accessibility/native/linux/scroll_notch_test.go
@@ -1,0 +1,80 @@
+//go:build linux
+
+package linux
+
+import "testing"
+
+// TestUinputScrollRemainder_WholeSendLeavesNothing is the Hyprland regression:
+// a default 50 px step is one 30 px notch, and the 20 px of rounding left over
+// must not go out again on the virtual pointer as a second notch.
+func TestUinputScrollRemainder_WholeSendLeavesNothing(t *testing.T) {
+	const scale = 30
+
+	tests := []struct {
+		name      string
+		delta     int
+		total     int
+		remaining int
+		want      int
+	}{
+		{name: "every notch sent, rounding left over", delta: -50, total: 1, remaining: 0, want: 0},
+		{name: "every notch sent, exact", delta: 60, total: 2, remaining: 0, want: 0},
+		{name: "nothing sent keeps the whole delta", delta: -50, total: 1, remaining: 1, want: -50},
+		{name: "half sent keeps the unsent half", delta: 120, total: 4, remaining: 2, want: 60},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := uinputScrollRemainder(testCase.delta, testCase.total, testCase.remaining, scale)
+			if got != testCase.want {
+				t.Fatalf("uinputScrollRemainder(%d, %d, %d) = %d, want %d",
+					testCase.delta, testCase.total, testCase.remaining, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestWlrootsScrollNotch_StepAndDiscreteAgree pins that the pixel step and
+// the discrete count a virtual-pointer notch carries point the same way on
+// both axes, so clients reading axis and clients reading axis_value120 scroll
+// in the same direction.
+func TestWlrootsScrollNotch_StepAndDiscreteAgree(t *testing.T) {
+	const step = 30
+
+	tests := []struct {
+		name     string
+		axis     int
+		delta    int
+		wantStep int
+		wantDisc int
+	}{
+		{
+			name: "vertical scroll down", axis: uinputScrollAxisVertical,
+			delta: -50, wantStep: step, wantDisc: 1,
+		},
+		{
+			name: "vertical scroll up", axis: uinputScrollAxisVertical,
+			delta: 50, wantStep: -step, wantDisc: -1,
+		},
+		{
+			name: "horizontal scroll right", axis: uinputScrollAxisHorizontal,
+			delta: 50, wantStep: step, wantDisc: 1,
+		},
+		{
+			name: "horizontal scroll left", axis: uinputScrollAxisHorizontal,
+			delta: -50, wantStep: -step, wantDisc: -1,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			gotStep, gotDisc := wlrootsScrollNotch(testCase.axis, testCase.delta, step)
+			if gotStep != testCase.wantStep || gotDisc != testCase.wantDisc {
+				t.Fatalf("wlrootsScrollNotch(%d, %d) = (%d, %d), want (%d, %d)",
+					testCase.axis, testCase.delta,
+					gotStep, gotDisc,
+					testCase.wantStep, testCase.wantDisc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes scroll mode on Wayland sending two wheel notches per keypress, the second one pointing the other way. Chromium and Electron apps (Discord, Helium) summed the pair to nothing, so `j`/`k` moved a sliver and then stopped, while Firefox kept scrolling. Reported from Hyprland; the code path is the same on every wlroots compositor.

Two things were wrong. The uinput wheel sends whole 30 px notches and hands whatever it did not send to the compositor's virtual pointer, but the leftover was computed from the pixel delta instead of from failed notches, so the default 50 px step always spilled 20 px of rounding into a whole extra notch. And the virtual-pointer sender flipped the pixel step on the vertical axis without flipping the discrete count, so that extra notch reported `axis +30` and `axis_value120 -120` in one frame.

Now nothing is handed on when every notch went out, and the discrete count follows the step's sign on both axes. A user's `wev` capture showed exactly the pair described above, once per press.

## Related Issues

None. Diagnosed from a Discord report; a `wev` log from the reporter confirmed the event pair.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new platform entry points
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no documented behavior changes
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

`just lint-cross` and `just test-linux` (the docker Linux runs with CGO on) also pass.

The reporter's `wev` capture, one keypress:

```
[wl_pointer] axis: time: 0; axis: 0 (vertical), value: 30.000000
[wl_pointer] axis_source: 0 (wheel)
[wl_pointer] axis_value120: axis: 0 (vertical), value120: -120
[wl_pointer] frame
[wl_pointer] axis: time: 8382277; axis: 0 (vertical), value: 15.000000
[wl_pointer] axis_source: 0 (wheel)
[wl_pointer] axis_value120: axis: 0 (vertical), value120: 120
[wl_pointer] frame
```

The first frame (time 0) is the virtual pointer's leftover notch with the disagreeing signs. The second is the uinput wheel through libinput. Both bugs are pinned by table tests on the two helpers the paths now share. The modified-scroll path on Hyprland and the smooth-scroll animator were not touched; a `scroll_step` that is a multiple of 30 was never affected, which is a quick way for a reporter to confirm the diagnosis on an unpatched build.
