### PR TITLE
feat(windows): publish display changes as screen-parameter events

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -170,7 +170,7 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | Capability                    | macOS                    | Linux X11              | Linux Wayland (wlroots)      | Linux Wayland (KDE)     | Windows                      |
 | ----------------------------- | ------------------------ | ---------------------- | ---------------------------- | ----------------------- | ---------------------------- |
 | **Screen bounds / enumeration** | ✅ Cocoa               | ✅ XRandR              | ✅ xdg-output                | ✅ xdg-output           | ✅ `EnumDisplayMonitors`     |
-| **Display hotplug events**    | ✅ screen-params notif.  | ✅ RandR event fd      | ✅ `wl_output` events        | ✅ `wl_output` events   | 🟡                           |
+| **Display hotplug events**    | ✅ screen-params notif.  | ✅ RandR event fd      | ✅ `wl_output` events        | ✅ `wl_output` events   | ✅ `WM_DISPLAYCHANGE`        |
 | **Focused app identity**      | ✅ NSWorkspace + AX      | ✅ `_NET_ACTIVE_WINDOW` / `WM_CLASS` | ⚠️ app_id only (see below) | ⚠️ app_id only     | ✅ `GetForegroundWindow`     |
 | **App watcher (focus change)**| ✅ NSWorkspace observer  | ✅ event-driven        | ✅ event-driven              | ✅ event-driven         | ✅ `SetWinEventHook`         |
 | **Keymap learns the focused app** | ✅ published by the watcher | ✅ published by the watcher | ✅ published by the watcher | ✅ published by the watcher | ✅ published by the watcher |
@@ -493,8 +493,13 @@ Control events remain macOS-only. Windows has a single API for it after all:
 through `SetWinEventHook` on a message-loop thread of its own, hands each new
 foreground HWND to a goroutine, and resolves it there to the **executable
 path** — the identity `GetForegroundWindow` already gives the focused app, so
-per-app configuration keys on one string however it is learned. Only
-activate and deactivate are emitted there; display hotplug is still a gap.
+per-app configuration keys on one string however it is learned. Display
+changes ride the same dispatch goroutine from a second source: a hidden
+top-level window on a pump thread of its own receives `WM_DISPLAYCHANGE` and
+`WM_DPICHANGED` (`platform/windows/display_watcher.go`) and coalesces them into
+one screen-parameters event, so a resolution or arrangement change re-lays-out
+the overlay as it does on macOS. Only activate, deactivate and screen-params
+are emitted there; launch, terminate and Mission Control stay macOS-only.
 
 **Global hotkeys on Wayland.** No Wayland protocol lets an ordinary client
 register a global hotkey, so Neru reads `/dev/input/event*` directly with a
@@ -869,7 +874,7 @@ important thing to know before touching overlay code:
 | **Always on top**     | `NSScreenSaverWindowLevel`               | `_NET_WM_STATE_ABOVE` + `MapRaised`    | overlay layer                                    | `HWND_TOPMOST`                     |
 | **Focus prevention**  | non-activating panel                     | `override_redirect=YES`                | controlled keyboard interactivity                | `WS_EX_NOACTIVATE`                 |
 | **HiDPI**             | dynamic `contentsScale` + backing-change callback | `Xft.dpi`, one global factor  | `wl_output` scale + `wp_fractional_scale_v1` / `wp_viewporter` | not explicit           |
-| **Multi-monitor**     | per-display clamping, screen-change tracking | all monitors enumerated, per-monitor render, live RandR hotplug | one `wl_surface` per output (max 16), live hotplug | cursor-screen tracking, separate indicator/sticky windows |
+| **Multi-monitor**     | per-display clamping, screen-change tracking | all monitors enumerated, per-monitor render, live RandR hotplug | one `wl_surface` per output (max 16), live hotplug | cursor-screen tracking, live `WM_DISPLAYCHANGE` hotplug, separate indicator/sticky windows |
 | **Buffers**           | layer-backed, OS-managed                 | single Cairo surface                   | triple-buffered SHM pool                         | single pixel buffer                |
 | **Rounded rects / borders** | NSBezierPath                       | Cairo arc path + stroke                | Cairo arc path + stroke                          | software SDF fill + multi-pass stroke |
 | **Text**              | NSFontManager                            | Cairo `select_font_face` / `show_text` | Cairo `select_font_face` / `show_text`           | GDI `CreateFontW` + `DrawTextW` + alpha composite |
@@ -1200,21 +1205,20 @@ working, which is exactly why the build exists.
 
 **Windows**
 
-1. Display hotplug — no screen-parameter change events
-2. Native notifications — no toast support
-3. UIA tree depth — shallow walk; complex apps under-report clickable elements
-4. Grid and recursive-grid transition animation — not implemented
-5. Grid virtual-pointer indicator — a no-op, while recursive grid draws it.
+1. Native notifications — no toast support
+2. UIA tree depth — shallow walk; complex apps under-report clickable elements
+3. Grid and recursive-grid transition animation — not implemented
+4. Grid virtual-pointer indicator — a no-op, while recursive grid draws it.
    `virtual_pointer.ui.*` is therefore partly inert here rather than wholly, so
    it stays declared everywhere and is tracked as this entry instead
-6. Smooth cursor and smooth scroll animation — not implemented
-7. Modifier passthrough and `PostModifierEvent` — no-ops
-8. Horizontal scroll — `ScrollAtCursor` ignores `deltaX`
-9. `monitor_select` mode — returns `CodeNotSupported`
-10. Font resolution — alias mapping only, no system font enumeration
-11. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
+5. Smooth cursor and smooth scroll animation — not implemented
+6. Modifier passthrough and `PostModifierEvent` — no-ops
+7. Horizontal scroll — `ScrollAtCursor` ignores `deltaX`
+8. `monitor_select` mode — returns `CodeNotSupported`
+9. Font resolution — alias mapping only, no system font enumeration
+10. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
     installs a launchd agent and Linux a systemd user unit
-12. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
+11. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
     every platform, but only the Unix client checks that for itself before
     connecting. A named pipe carries no ownership a client can read without
     opening it, so the Windows CLI trusts the name it derives from its own SID.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,8 +43,8 @@ The two largest open areas:
 - **Linux** — Wayland global hotkeys, which need `input`-group membership and a
   CGO build rather than missing code, and whose remaining work is failing
   loudly with the remedy.
-- **Windows** — display-hotplug events, which currently block monitor
-  tracking.
+- **Windows** — the remaining Known Gaps entries: notifications, UIA tree
+  depth, animations, horizontal scroll and `monitor_select`.
 
 GNOME Wayland remains unsupported; the daemon refuses to start there. Reviving
 it needs libei plus a GNOME Shell extension — see

--- a/internal/adapter/appwatcher/doc.go
+++ b/internal/adapter/appwatcher/doc.go
@@ -6,5 +6,5 @@
 // platform_other.go as the no-op fallback), so this package compiles on all
 // platforms. On macOS the events come from the Objective-C NSWorkspace
 // observer, on Linux from a compositor or X11 focus source, and on Windows
-// from an EVENT_SYSTEM_FOREGROUND hook.
+// from an EVENT_SYSTEM_FOREGROUND hook plus a hidden window's WM_DISPLAYCHANGE.
 package appwatcher

--- a/internal/adapter/appwatcher/platform_windows.go
+++ b/internal/adapter/appwatcher/platform_windows.go
@@ -21,6 +21,13 @@ import (
 // GetForegroundWindow resolves to for the focused app, so per-app
 // configuration keys on one string whichever way it is learned.
 //
+// Display changes take the same route from a second source: a hidden window
+// (winplatform.StartDisplayWatcher) receives WM_DISPLAYCHANGE and
+// WM_DPICHANGED on its own pump thread, offers a token to a one-slot channel,
+// and the dispatch goroutine turns it into HandleScreenParametersChanged —
+// the event macOS's screen-parameters notification and Linux's RandR fd
+// produce, so the app re-lays-out the overlay the same way on all three.
+//
 // globalWindowsWatcher is the process-wide backend, mirroring
 // globalLinuxWatcher. NewWatcher registers itself here via
 // platformRegisterWatcher.
@@ -32,6 +39,14 @@ var globalWindowsWatcher = &windowsAppWatcher{
 		}
 
 		return hook.Stop, nil
+	},
+	subscribeDisplay: func(callback func()) (func(), error) {
+		watcher, err := winplatform.StartDisplayWatcher(callback)
+		if err != nil {
+			return nil, err
+		}
+
+		return watcher.Stop, nil
 	},
 	foreground: func() uintptr {
 		hwnd, _ := winplatform.ForegroundWindowHandle()
@@ -47,6 +62,9 @@ type windowsAppWatcher struct {
 	// subscribe installs the foreground hook and returns its stop function;
 	// injectable for tests.
 	subscribe func(callback func(uintptr)) (func(), error)
+	// subscribeDisplay installs the display-change window and returns its stop
+	// function; injectable for tests.
+	subscribeDisplay func(callback func()) (func(), error)
 	// foreground samples the current foreground HWND once at start, so the
 	// keymap has a published app before the first switch.
 	foreground func() uintptr
@@ -58,7 +76,9 @@ type windowsAppWatcher struct {
 	watcher *Watcher
 	stopCh  chan struct{}
 	unhook  func()
-	wg      sync.WaitGroup
+	// unhookDisplay stops the display watcher; nil when it failed to install.
+	unhookDisplay func()
+	wg            sync.WaitGroup
 
 	// lastID and lastName are the most recently dispatched identity ("" means
 	// none focused). Owned by the dispatch goroutine, so they need no lock.
@@ -86,6 +106,7 @@ func (l *windowsAppWatcher) start() {
 	}
 
 	events := make(chan uintptr, 1)
+	displayEvents := make(chan struct{}, 1)
 	l.lastID, l.lastName = "", ""
 
 	unhook, err := l.subscribe(func(hwnd uintptr) { offer(events, hwnd) })
@@ -108,12 +129,24 @@ func (l *windowsAppWatcher) start() {
 	default:
 	}
 
+	// A display watcher that fails to install costs only hotplug: the
+	// foreground hook is already live and the overlay is still re-sized on
+	// each activation, so the watcher runs on without it and says so.
+	unhookDisplay, err := l.subscribeDisplay(func() { offerToken(displayEvents) })
+	if err != nil {
+		l.watcher.logger.Warn(
+			"App watcher: display-change window install failed; overlays follow display changes on the next activation only",
+			zap.Error(err),
+		)
+	}
+
 	l.unhook = unhook
+	l.unhookDisplay = unhookDisplay
 	l.stopCh = make(chan struct{})
 
 	l.wg.Add(1)
 
-	go l.loop(l.stopCh, events)
+	go l.loop(l.stopCh, events, displayEvents)
 }
 
 // stop unhooks first, so nothing offers after the loop is told to exit, then
@@ -127,12 +160,17 @@ func (l *windowsAppWatcher) stop() {
 		return
 	}
 
-	stopCh, unhook := l.stopCh, l.unhook
-	l.stopCh, l.unhook = nil, nil
+	stopCh, unhook, unhookDisplay := l.stopCh, l.unhook, l.unhookDisplay
+	l.stopCh, l.unhook, l.unhookDisplay = nil, nil, nil
 
 	l.mu.Unlock()
 
 	unhook()
+
+	if unhookDisplay != nil {
+		unhookDisplay()
+	}
+
 	close(stopCh)
 	l.wg.Wait()
 }
@@ -156,7 +194,22 @@ func offer(events chan uintptr, hwnd uintptr) {
 	}
 }
 
-func (l *windowsAppWatcher) loop(stopCh <-chan struct{}, events <-chan uintptr) {
+// offerToken is offer for the display channel: a burst of display messages
+// coalesces to a single pending refresh, because the refresh re-reads the
+// display and has nothing to learn from the count. It runs on the display
+// watcher's pump thread.
+func offerToken(events chan struct{}) {
+	select {
+	case events <- struct{}{}:
+	default:
+	}
+}
+
+func (l *windowsAppWatcher) loop(
+	stopCh <-chan struct{},
+	events <-chan uintptr,
+	displayEvents <-chan struct{},
+) {
 	defer l.wg.Done()
 
 	for {
@@ -165,6 +218,8 @@ func (l *windowsAppWatcher) loop(stopCh <-chan struct{}, events <-chan uintptr) 
 			return
 		case hwnd := <-events:
 			l.tick(hwnd)
+		case <-displayEvents:
+			l.watcher.HandleScreenParametersChanged()
 		}
 	}
 }

--- a/internal/adapter/appwatcher/platform_windows_test.go
+++ b/internal/adapter/appwatcher/platform_windows_test.go
@@ -12,6 +12,7 @@ import (
 const (
 	kindActivate   = "activate"
 	kindDeactivate = "deactivate"
+	kindScreen     = "screen"
 
 	hwndNotepad = uintptr(0x10)
 	hwndCode    = uintptr(0x20)
@@ -113,6 +114,41 @@ func (f *fakeHook) fire(hwnd uintptr) {
 	}
 }
 
+// fakeDisplayHook stands in for the hidden display-change window.
+type fakeDisplayHook struct {
+	mu       sync.Mutex
+	callback func()
+	unhooked bool
+	err      error
+}
+
+func (f *fakeDisplayHook) subscribe(callback func()) (func(), error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	f.mu.Lock()
+	f.callback = callback
+	f.mu.Unlock()
+
+	return func() {
+		f.mu.Lock()
+		f.unhooked = true
+		f.callback = nil
+		f.mu.Unlock()
+	}, nil
+}
+
+func (f *fakeDisplayHook) fire() {
+	f.mu.Lock()
+	callback := f.callback
+	f.mu.Unlock()
+
+	if callback != nil {
+		callback()
+	}
+}
+
 func identityFor(hwnd uintptr) (string, string, bool) {
 	switch hwnd {
 	case hwndNotepad:
@@ -125,16 +161,26 @@ func identityFor(hwnd uintptr) (string, string, bool) {
 }
 
 func newTestBackend(hook *fakeHook, foreground uintptr) (*windowsAppWatcher, *eventRecorder) {
+	return newTestBackendWithDisplay(hook, &fakeDisplayHook{}, foreground)
+}
+
+func newTestBackendWithDisplay(
+	hook *fakeHook,
+	display *fakeDisplayHook,
+	foreground uintptr,
+) (*windowsAppWatcher, *eventRecorder) {
 	watcher := NewWatcher(nil)
 	recorder := &eventRecorder{}
 
 	watcher.OnActivate(func(name, bundle string) { recorder.add(kindActivate, name, bundle) })
 	watcher.OnDeactivate(func(name, bundle string) { recorder.add(kindDeactivate, name, bundle) })
+	watcher.OnScreenParametersChanged(func() { recorder.add(kindScreen, "", "") })
 
 	backend := &windowsAppWatcher{
-		subscribe:  hook.subscribe,
-		foreground: func() uintptr { return foreground },
-		identity:   identityFor,
+		subscribe:        hook.subscribe,
+		subscribeDisplay: display.subscribe,
+		foreground:       func() uintptr { return foreground },
+		identity:         identityFor,
 	}
 	backend.register(watcher)
 
@@ -206,4 +252,38 @@ func TestWindowsAppWatcher_Start_HookFailureLeavesWatcherIdle(t *testing.T) {
 	backend.stop()
 
 	recorder.waitFor(t, nil)
+}
+
+func TestWindowsAppWatcher_Start_PublishesDisplayChanges(t *testing.T) {
+	display := &fakeDisplayHook{}
+	backend, recorder := newTestBackendWithDisplay(&fakeHook{}, display, hwndDesktop)
+
+	backend.start()
+	defer backend.stop()
+
+	display.fire()
+	recorder.waitFor(t, []watchEvent{{kindScreen, "", ""}})
+
+	backend.stop()
+
+	if !display.unhooked {
+		t.Fatal("stop did not stop the display watcher")
+	}
+
+	display.fire()
+	time.Sleep(20 * time.Millisecond)
+
+	recorder.waitFor(t, []watchEvent{{kindScreen, "", ""}})
+}
+
+func TestWindowsAppWatcher_Start_DisplayWatcherFailureKeepsForegroundLive(t *testing.T) {
+	hook := &fakeHook{}
+	display := &fakeDisplayHook{err: errHookInstall}
+	backend, recorder := newTestBackendWithDisplay(hook, display, hwndDesktop)
+
+	backend.start()
+	defer backend.stop()
+
+	hook.fire(hwndNotepad)
+	recorder.waitFor(t, []watchEvent{{kindActivate, nameNotepad, pathNotepad}})
 }

--- a/internal/adapter/platform/windows/display_watcher.go
+++ b/internal/adapter/platform/windows/display_watcher.go
@@ -1,0 +1,233 @@
+//go:build windows
+
+package windows
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Display-configuration change notifications via a hidden top-level window.
+//
+// Windows has no hook for display changes the way it has one for the
+// foreground window: WM_DISPLAYCHANGE is broadcast to every top-level window
+// when a resolution, arrangement or monitor set changes, and WM_DPICHANGED is
+// sent to a window whose monitor's DPI changes. Both need an HWND to land on,
+// so the watcher owns a hidden, never-shown popup window on a
+// runtime.LockOSThread pump of its own (doc.go). The keyboard hook's loop only
+// exists while a mode is active, and a display change with nothing open still
+// has to move the overlay for the next activation.
+//
+// The window procedure hands the change to the caller's callback and returns.
+// Everything the callback does is on the pump thread, so it must never block
+// or take a lock something on this thread could be waiting for.
+const (
+	wmDisplayChange = 0x007E
+	wmDPIChanged    = 0x02E0
+
+	displayWatcherClassName = "NeruDisplayWatcher"
+)
+
+var (
+	// activeDisplayWatcher is the watcher displayWndProc dispatches to, atomic
+	// for the reason activeForegroundWatcher is: the pump thread stores it and
+	// Windows calls the procedure on that same thread, but Stop reads it from
+	// the caller's goroutine.
+	activeDisplayWatcher atomic.Pointer[DisplayWatcher]
+
+	// displayWndProcPtr is allocated once for the process, never per watcher: a
+	// syscall.NewCallback slot is never freed and the process has a fixed 2000
+	// of them (see keyboardHookProcPtr).
+	displayWndProcPtr = sync.OnceValue(func() uintptr {
+		return syscall.NewCallback(displayWndProc)
+	})
+
+	displayClassOnce sync.Once
+	errDisplayClass  error
+)
+
+var (
+	errDisplayWatcherCallbackNil = errors.New("display watcher callback is nil")
+	errDisplayWindowCreateFailed = errors.New(
+		"CreateWindowExW failed: display watcher window not created",
+	)
+)
+
+// DisplayWatcher delivers display-configuration changes to a callback.
+type DisplayWatcher struct {
+	callback func()
+	hwnd     uintptr
+	threadID uint32
+	stopOnce sync.Once
+	doneCh   chan struct{}
+	startErr chan error
+}
+
+// StartDisplayWatcher creates a hidden window on a dedicated message-loop
+// thread and calls callback, on that thread, each time the window receives
+// WM_DISPLAYCHANGE or WM_DPICHANGED. It returns once the window exists, or the
+// creation error.
+func StartDisplayWatcher(callback func()) (*DisplayWatcher, error) {
+	if callback == nil {
+		return nil, errDisplayWatcherCallbackNil
+	}
+
+	watcher := &DisplayWatcher{
+		callback: callback,
+		doneCh:   make(chan struct{}),
+		startErr: make(chan error, 1),
+	}
+
+	go watcher.run()
+
+	// Every exit from run either sends the install error or closes startErr,
+	// so this receive is the whole handshake.
+	err := <-watcher.startErr
+	if err != nil {
+		return nil, err
+	}
+
+	return watcher, nil
+}
+
+// WindowHandle is the hidden window the watcher listens on. It exists so a
+// test can post the messages Windows would broadcast; nothing else needs it.
+func (w *DisplayWatcher) WindowHandle() uintptr {
+	return w.hwnd
+}
+
+// Stop destroys the window and waits for the pump thread to exit. No callback
+// fires after it returns. The join is unbounded for the reason
+// ForegroundWatcher.Stop's is: the callback contract forbids parking on a lock
+// the caller holds.
+func (w *DisplayWatcher) Stop() {
+	if w == nil {
+		return
+	}
+
+	w.stopOnce.Do(func() {
+		// threadID is written before startErr closes, and Start does not
+		// return the watcher before that, so it is always set here.
+		_, _, _ = procPostThreadMessageW.Call(uintptr(w.threadID), wmQuit, 0, 0)
+	})
+
+	<-w.doneCh
+}
+
+// displayWndProc is the WNDPROC for the watcher's window class. Only the two
+// display messages reach the callback; everything else is DefWindowProc's.
+func displayWndProc(hwnd uintptr, message uint32, wParam, lParam uintptr) uintptr {
+	if message == wmDisplayChange || message == wmDPIChanged {
+		if current := activeDisplayWatcher.Load(); current != nil && current.hwnd == hwnd {
+			current.callback()
+		}
+
+		return 0
+	}
+
+	ret, _, _ := procDefWindowProcW.Call(hwnd, uintptr(message), wParam, lParam)
+
+	return ret
+}
+
+func registerDisplayWatcherClass() error {
+	displayClassOnce.Do(func() {
+		className, err := windows.UTF16PtrFromString(displayWatcherClassName)
+		if err != nil {
+			errDisplayClass = err
+
+			return
+		}
+
+		class := wndClassEx{
+			cbSize:        uint32(unsafe.Sizeof(wndClassEx{})),
+			lpfnWndProc:   displayWndProcPtr(),
+			hInstance:     windows.Handle(moduleHandle()),
+			lpszClassName: className,
+		}
+
+		atom, _, err := procRegisterClassExW.Call(uintptr(unsafe.Pointer(&class)))
+		if atom == 0 {
+			errDisplayClass = fmt.Errorf("RegisterClassExW: %w", err)
+		}
+	})
+
+	return errDisplayClass
+}
+
+func (w *DisplayWatcher) run() {
+	runtime.LockOSThread()
+
+	defer runtime.UnlockOSThread()
+	defer close(w.doneCh)
+
+	err := registerDisplayWatcherClass()
+	if err != nil {
+		w.startErr <- err
+
+		return
+	}
+
+	className, err := windows.UTF16PtrFromString(displayWatcherClassName)
+	if err != nil {
+		w.startErr <- err
+
+		return
+	}
+
+	// A popup with no WS_VISIBLE is a top-level window that is never shown,
+	// which is exactly the set WM_DISPLAYCHANGE is broadcast to. A
+	// message-only window (HWND_MESSAGE parent) would not qualify.
+	hwnd, _, callErr := procCreateWindowExW.Call(
+		wsExToolWindow|wsExNoActivate,
+		uintptr(unsafe.Pointer(className)),
+		0,
+		wsPopup,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		moduleHandle(),
+		0,
+	)
+	if hwnd == 0 {
+		w.startErr <- fmt.Errorf("%w: %w", errDisplayWindowCreateFailed, callErr)
+
+		return
+	}
+
+	// CreateWindowExW is a user32 call, so this thread has a message queue
+	// from here on and Stop's PostThreadMessage cannot be lost.
+	threadID, _, _ := procGetCurrentThreadID.Call()
+	w.threadID = uint32(threadID)
+	w.hwnd = hwnd
+	activeDisplayWatcher.Store(w)
+
+	close(w.startErr)
+
+	defer func() {
+		activeDisplayWatcher.CompareAndSwap(w, nil)
+
+		discardCall(procDestroyWindow.Call(hwnd))
+	}()
+
+	var message msg
+	for {
+		ret, _, _ := procGetMessageW.Call(uintptr(unsafe.Pointer(&message)), 0, 0, 0)
+		if ret == 0 || int32(ret) == -1 {
+			return
+		}
+
+		_, _, _ = procTranslateMessage.Call(uintptr(unsafe.Pointer(&message)))
+		_, _, _ = procDispatchMessageW.Call(uintptr(unsafe.Pointer(&message)))
+	}
+}

--- a/internal/adapter/platform/windows/display_watcher_integration_test.go
+++ b/internal/adapter/platform/windows/display_watcher_integration_test.go
@@ -1,0 +1,71 @@
+//go:build integration && windows
+
+package windows
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Real Win32 test for the display watcher. Changing the display mode on a CI
+// runner is not an option, so the test posts the message Windows would
+// broadcast to the watcher's own hidden window and checks that it comes out
+// the callback.
+
+var procPostMessageW = user32.NewProc("PostMessageW")
+
+func waitForCount(t *testing.T, counter *atomic.Int32, want int32) {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+
+	for counter.Load() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("display change callbacks = %d, want at least %d", counter.Load(), want)
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestDisplayWatcher_ObservesDisplayChangePostedToHiddenWindow(t *testing.T) {
+	var fired atomic.Int32
+
+	watcher, err := StartDisplayWatcher(func() { fired.Add(1) })
+	if err != nil {
+		t.Skipf("skipping: StartDisplayWatcher requires an interactive desktop (%v)", err)
+	}
+
+	defer watcher.Stop()
+
+	hwnd := watcher.WindowHandle()
+
+	ret, _, callErr := procPostMessageW.Call(hwnd, wmDisplayChange, 32, 0)
+	if ret == 0 {
+		t.Fatalf("PostMessageW(WM_DISPLAYCHANGE): %v", callErr)
+	}
+
+	waitForCount(t, &fired, 1)
+
+	ret, _, callErr = procPostMessageW.Call(hwnd, wmDPIChanged, 0, 0)
+	if ret == 0 {
+		t.Fatalf("PostMessageW(WM_DPICHANGED): %v", callErr)
+	}
+
+	waitForCount(t, &fired, 2)
+
+	watcher.Stop()
+
+	before := fired.Load()
+
+	// The window is destroyed with the pump, so the post fails rather than
+	// reaching a callback; either way nothing may fire after Stop.
+	discardCall(procPostMessageW.Call(hwnd, wmDisplayChange, 32, 0))
+
+	time.Sleep(50 * time.Millisecond)
+
+	if fired.Load() != before {
+		t.Fatalf("callback fired after Stop: %d before, %d after", before, fired.Load())
+	}
+}

--- a/internal/adapter/platform/windows/display_watcher_integration_test.go
+++ b/internal/adapter/platform/windows/display_watcher_integration_test.go
@@ -11,12 +11,11 @@ import (
 // Real Win32 test for the display watcher. Changing the display mode on a CI
 // runner is not an option, so the test posts the message Windows would
 // broadcast to the watcher's own hidden window and checks that it comes out
-// the callback.
+// the callback. WM_DPICHANGED is not exercised: Windows validates it (it must
+// carry a RECT and only be sent, never posted) and a synthetic one does not
+// reach the window procedure.
 
-var (
-	procPostMessageW = user32.NewProc("PostMessageW")
-	procSendMessageW = user32.NewProc("SendMessageW")
-)
+var procPostMessageW = user32.NewProc("PostMessageW")
 
 func waitForCount(t *testing.T, counter *atomic.Int32, want int32) {
 	t.Helper()
@@ -50,12 +49,6 @@ func TestDisplayWatcher_ObservesDisplayChangePostedToHiddenWindow(t *testing.T) 
 	}
 
 	waitForCount(t, &fired, 1)
-
-	// WM_DPICHANGED carries a pointer and may only be sent, not posted; the
-	// send returns once the pump thread has run the window procedure.
-	discardCall(procSendMessageW.Call(hwnd, wmDPIChanged, 0, 0))
-
-	waitForCount(t, &fired, 2)
 
 	watcher.Stop()
 

--- a/internal/adapter/platform/windows/display_watcher_integration_test.go
+++ b/internal/adapter/platform/windows/display_watcher_integration_test.go
@@ -13,7 +13,10 @@ import (
 // broadcast to the watcher's own hidden window and checks that it comes out
 // the callback.
 
-var procPostMessageW = user32.NewProc("PostMessageW")
+var (
+	procPostMessageW = user32.NewProc("PostMessageW")
+	procSendMessageW = user32.NewProc("SendMessageW")
+)
 
 func waitForCount(t *testing.T, counter *atomic.Int32, want int32) {
 	t.Helper()
@@ -48,10 +51,9 @@ func TestDisplayWatcher_ObservesDisplayChangePostedToHiddenWindow(t *testing.T) 
 
 	waitForCount(t, &fired, 1)
 
-	ret, _, callErr = procPostMessageW.Call(hwnd, wmDPIChanged, 0, 0)
-	if ret == 0 {
-		t.Fatalf("PostMessageW(WM_DPICHANGED): %v", callErr)
-	}
+	// WM_DPICHANGED carries a pointer and may only be sent, not posted; the
+	// send returns once the pump thread has run the window procedure.
+	discardCall(procSendMessageW.Call(hwnd, wmDPIChanged, 0, 0))
 
 	waitForCount(t, &fired, 2)
 

--- a/internal/adapter/platform/windows/doc.go
+++ b/internal/adapter/platform/windows/doc.go
@@ -4,7 +4,7 @@
 // in adapter/accessibility/native/windows.
 //
 // Anything that talks to a thread-affine Win32 API (the keyboard hook,
-// RegisterHotKey, SetWinEventHook, message-only windows) runs its own
+// RegisterHotKey, SetWinEventHook, hidden message windows) runs its own
 // runtime.LockOSThread message loop; never call those APIs from an arbitrary
 // goroutine.
 //

--- a/internal/ports/capability_presets.go
+++ b/internal/ports/capability_presets.go
@@ -191,7 +191,8 @@ func WindowsCapabilities() PlatformCapabilities {
 		),
 		AppWatcher: supportedCapability(
 			"focused-app change detection keyed on the executable path, pushed by a " +
-				"SetWinEventHook EVENT_SYSTEM_FOREGROUND hook",
+				"SetWinEventHook EVENT_SYSTEM_FOREGROUND hook; display changes pushed by " +
+				"WM_DISPLAYCHANGE on a hidden window",
 		),
 		DarkModeDetection: supportedCapability(
 			"dark mode detection available via the Windows personalization registry " +


### PR DESCRIPTION
## Description

This PR adds display-change tracking on Windows. A resolution, arrangement or monitor change used to leave the overlay at its old bounds until the daemon restarted, because Windows produced none of the screen-parameter events macOS and Linux publish. Windows now listens for those changes on a hidden window of its own and publishes them through the same app-watcher path the other platforms use, so a mode that is open is re-laid-out on the spot and the next activation draws at the new bounds without a restart.

The Capability Matrix reads supported for display hotplug on Windows, the Known Gaps entry is removed, and the roadmap's Windows bullet now points at the remaining gaps. A burst of change notifications coalesces into one refresh. If the hidden window cannot be created the daemon warns and keeps running, with overlays following display changes on the next activation only.

## Related Issues

Closes #1553

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this fills an existing Windows slot; macOS and Linux already publish the event
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

The notification is delivered only to top-level windows, which is why a hidden popup window on a dedicated message-loop thread carries it rather than the keyboard hook's loop, which exists only while a mode is active. The callback on that thread does nothing but a non-blocking hand-off; the app-level refresh runs on the watcher's goroutine, the same shape as the Linux backend. Unit tests cover the dispatch through a fake window, and a Windows-only integration test posts the real message to the hidden window and observes the event. Windows-tagged code was linted and compiled cross-platform from macOS; the Windows tests themselves run on the Windows CI leg.
