### PR TITLE
feat(windows): walk the full UIA tree with a cached FindAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ on the app exposing an accessibility tree (GTK/Qt do; Chromium and Electron apps
 need `--force-renderer-accessibility`). Where that tree is too thin, Vision OCR
 is the fallback — tesseract, text only, and on KDE behind a one-time
 screen-sharing prompt, because KWin's only pixel source is the desktop portal.
-On **Windows**, UI Automation coverage is initial and the
-tree walk is shallow, per-app config does not re-apply when you change windows,
+On **Windows**, UI Automation reports the control view only,
+per-app config does not re-apply when you change windows,
 and the OCR fallback is `Windows.Media.Ocr`, text only, needing a language pack. **Linux requires X11 or Wayland on
 wlroots/KWin — GNOME Wayland is not supported**; use a GNOME X11 session.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -102,8 +102,8 @@ Accepted by every command.
 | [`docs`](#neru-docs)                                         | Open documentation in a browser | No  | macOS · Linux |
 
 ¹ Element discovery quality differs by platform: a full accessibility tree on
-macOS, an AT-SPI walk on Linux whose coverage depends on the application, and an
-initial shallow UI Automation walk on Windows. The `vision` strategy is the
+macOS, an AT-SPI walk on Linux whose coverage depends on the application, and a
+cached UI Automation walk of the control view on Windows. The `vision` strategy is the
 fallback where that tree is thin. See [Accessibility and hints](CROSS_PLATFORM.md#accessibility-and-hints).
 
 ² Two action subcommands are limited: `hide_cursor` and `show_cursor` are macOS

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -181,7 +181,7 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Modified scroll (`--modifier`)** | ✅ `CGEventSetFlags` on every chunk | ✅ XTest key hold ⁷ | ✅ virtual keyboard, uinput batch skipped (kept on Hyprland ⁹) | ✅ libei | ✅ `SendInput` key hold |
 | **Smooth cursor animation**   | ✅ (incl. relative, opt-in) | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ❌                        |
 | **Smooth scroll animation**   | ✅                       | ⚠️ whole notches only ³ | ✅ continuous virtual-pointer axis ³ (whole notches when modified on Hyprland ⁹) | ⚠️ libei scroll delta, unverified ³ | ❌       |
-| **Element discovery (hints)** | ✅ AXUIElement           | ⚠️ AT-SPI walk         | ⚠️ AT-SPI walk               | ⚠️ AT-SPI walk          | ⚠️ UIA, shallow tree         |
+| **Element discovery (hints)** | ✅ AXUIElement           | ⚠️ AT-SPI walk         | ⚠️ AT-SPI walk               | ⚠️ AT-SPI walk          | ⚠️ UIA, control view only    |
 | **Overlay**                   | ✅ NSPanel + CoreAnimation | ✅ X11 + Cairo       | ✅ layer-shell + Cairo       | ✅ layer-shell + Cairo  | ✅ layered HWND + GDI        |
 | **Global hotkeys**            | ✅ per-key CGEventTap    | ✅ `XGrabKey`          | ⚠️ passive evdev read        | ⚠️ passive evdev read   | ✅ `RegisterHotKey`          |
 | **Keyboard capture**          | ✅ CGEventTap            | ✅ `XGrabKeyboard`     | ✅ evdev grab (wl-keyboard fallback) | ✅ evdev grab   | ✅ `WH_KEYBOARD_LL`          |
@@ -780,8 +780,11 @@ macOS builds the richest tree by a wide margin: it walks multiple window and
 system sources, applies per-app strategy overrides, can fall back to the Vision
 framework for OCR-discovered targets, and deduplicates overlapping elements.
 Linux walks a single tree and has the OCR fallback beside it — tesseract, text
-only, selected with `hints.strategy = vision`. Windows walks a single tree with
-the same fallback beside it — `Windows.Media.Ocr`, text only.
+only, selected with `hints.strategy = vision`. Windows fetches the window's
+control-view tree in one cached UI Automation query, at any depth, with the
+same fallback beside it — `Windows.Media.Ocr`, text only. The ⚠️ there is the
+control view: an element a provider exposes only in the raw view is not a hint,
+and the answer is a role or filter default, never a per-app branch.
 
 **Linux is ⚠️, not a stub.** Hints genuinely work: `ATSPIClient` enables
 assistive-tech mode, finds the active frame, and walks it (`ClickableNodes`)
@@ -927,7 +930,7 @@ discovery rather than the mode itself.
 
 | Mode              | Feature                        | macOS                      | Linux                      | Windows                     |
 | ----------------- | ------------------------------ | -------------------------- | -------------------------- | --------------------------- |
-| **Hints**         | Element discovery              | ✅ full AX tree            | ⚠️ AT-SPI, toolkit-dependent | ⚠️ UIA, shallow tree      |
+| **Hints**         | Element discovery              | ✅ full AX tree            | ⚠️ AT-SPI, toolkit-dependent | ⚠️ UIA, control view only |
 | **Hints**         | `vision` strategy + per-app overrides | ✅                  | ⚠️ tesseract; text only, no rectangles | ⚠️ `Windows.Media.Ocr`; text only, no rectangles, no confidence |
 | **Hints**         | Menubar / dock elements        | ✅                         | 🟡                         | 🟡                          |
 | **Hints**         | Search input badge             | ✅                         | ✅ Cairo badge             | ✅                          |
@@ -1199,19 +1202,18 @@ working, which is exactly why the build exists.
 **Windows**
 
 1. Native notifications — no toast support
-2. UIA tree depth — shallow walk; complex apps under-report clickable elements
-3. Grid and recursive-grid transition animation — not implemented
-4. Grid virtual-pointer indicator — a no-op, while recursive grid draws it.
+2. Grid and recursive-grid transition animation — not implemented
+3. Grid virtual-pointer indicator — a no-op, while recursive grid draws it.
    `virtual_pointer.ui.*` is therefore partly inert here rather than wholly, so
    it stays declared everywhere and is tracked as this entry instead
-5. Smooth cursor and smooth scroll animation — not implemented
-6. Modifier passthrough and `PostModifierEvent` — no-ops
-7. Horizontal scroll — `ScrollAtCursor` ignores `deltaX`
-8. `monitor_select` mode — returns `CodeNotSupported`
-9. Font resolution — alias mapping only, no system font enumeration
-10. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
+4. Smooth cursor and smooth scroll animation — not implemented
+5. Modifier passthrough and `PostModifierEvent` — no-ops
+6. Horizontal scroll — `ScrollAtCursor` ignores `deltaX`
+7. `monitor_select` mode — returns `CodeNotSupported`
+8. Font resolution — alias mapping only, no system font enumeration
+9. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
     installs a launchd agent and Linux a systemd user unit
-11. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
+10. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
     every platform, but only the Unix client checks that for itself before
     connecting. A named pipe carries no ownership a client can read without
     opening it, so the Windows CLI trusts the name it derives from its own SID.

--- a/internal/adapter/accessibility/native/windows/automation.go
+++ b/internal/adapter/accessibility/native/windows/automation.go
@@ -15,8 +15,8 @@ import (
 )
 
 // Pure-Go IUIAutomation (COM) element discovery for the Windows hints mode.
-// Does not perform actions or build a deep cached tree; it returns a flat
-// list of on-screen, clickable controls for the given top-level window.
+// Does not perform actions; it returns a flat list of on-screen, clickable
+// controls at any depth under the given top-level window.
 //
 // roleUnknown is the AX-style role returned for UIA control types that neru
 // does not treat as clickable hint targets.
@@ -75,20 +75,41 @@ const (
 	vtRelease = 2
 
 	// IUIAutomation.
-	vtElementFromHandle   = 6
-	vtCreateTrueCondition = 21
+	vtElementFromHandle       = 6
+	vtGetControlViewCondition = 18
+	vtCreateCacheRequest      = 20
 
-	// IUIAutomationElement.
-	vtFindAll                     = 6
-	vtGetCurrentControlType       = 21
-	vtGetCurrentName              = 23
-	vtGetCurrentIsOffscreen       = 38
-	vtGetCurrentBoundingRectangle = 43
+	// IUIAutomationElement. Only the cached getters are called: every property
+	// the walk reads is fetched by the cache request, so a Current* getter
+	// would be a second cross-process call for data already in hand.
+	vtFindAllBuildCache          = 8
+	vtGetCachedControlType       = 53
+	vtGetCachedName              = 55
+	vtGetCachedIsOffscreen       = 70
+	vtGetCachedBoundingRectangle = 75
+
+	// IUIAutomationCacheRequest.
+	vtCacheAddProperty              = 3
+	vtCachePutTreeFilter            = 9
+	vtCachePutAutomationElementMode = 11
 
 	// IUIAutomationElementArray.
 	vtArrayGetLength  = 3
 	vtArrayGetElement = 4
 )
+
+// UIA property ids the cache request prefetches (UIA_*PropertyId).
+const (
+	propBoundingRectangle = 30001
+	propControlType       = 30003
+	propName              = 30005
+	propIsOffscreen       = 30022
+)
+
+// AutomationElementMode_None: cached elements carry only the requested
+// properties and no live reference back to the provider, which is all the
+// walk needs since every value is copied out before the array is released.
+const automationElementModeNone = 0
 
 // UI Automation control-type names referenced from more than one place.
 const (
@@ -98,6 +119,7 @@ const (
 	uiaControlCustom      = "Custom"
 	uiaControlSplitButton = "SplitButton"
 	uiaControlPane        = "Pane"
+	uiaControlCheckBox    = "CheckBox"
 )
 
 // controlTypeNames maps UI Automation CONTROLTYPEID values to the programmatic
@@ -110,7 +132,7 @@ const (
 var controlTypeNames = map[int32]string{
 	50000: uiaControlButton,
 	50001: "Calendar",
-	50002: "CheckBox",
+	50002: uiaControlCheckBox,
 	50003: "ComboBox",
 	50004: uiaControlEdit,
 	50005: uiaControlHyperlink,
@@ -151,7 +173,7 @@ var controlTypeNames = map[int32]string{
 	50040: "AppBar",
 }
 
-// winRect mirrors the Win32 RECT returned by get_CurrentBoundingRectangle.
+// winRect mirrors the Win32 RECT returned by get_CachedBoundingRectangle.
 type winRect struct {
 	left   int32
 	top    int32
@@ -241,19 +263,29 @@ func enumerateClickableElements(hwnd uintptr, keptRoles map[string]struct{}) []w
 
 	var condition unsafe.Pointer
 
-	hresult = comCall(automation, vtCreateTrueCondition, uintptr(unsafe.Pointer(&condition)))
+	hresult = comCall(automation, vtGetControlViewCondition, uintptr(unsafe.Pointer(&condition)))
 	if failed(hresult) || condition == nil {
 		return nil
 	}
 	defer comCall(condition, vtRelease)
 
+	cache := createCacheRequest(automation, condition)
+	if cache == nil {
+		return nil
+	}
+	defer comCall(cache, vtRelease)
+
 	var array unsafe.Pointer
 
+	// One cross-process round trip fetches the whole control-view subtree with
+	// every property the walk reads already attached, so depth costs nothing
+	// per node.
 	hresult = comCall(
 		root,
-		vtFindAll,
+		vtFindAllBuildCache,
 		uintptr(treeScopeDescendants),
 		uintptr(condition),
+		uintptr(cache),
 		uintptr(unsafe.Pointer(&array)),
 	)
 	if failed(hresult) || array == nil {
@@ -262,6 +294,35 @@ func enumerateClickableElements(hwnd uintptr, keptRoles map[string]struct{}) []w
 	defer comCall(array, vtRelease)
 
 	return collectArray(array, keptRoles)
+}
+
+// createCacheRequest builds the cache request FindAllBuildCache fills: the
+// four properties extractWinElement reads, filtered to the control view so
+// the provider never serializes raw-view scaffolding.
+func createCacheRequest(automation unsafe.Pointer, filter unsafe.Pointer) unsafe.Pointer {
+	var cache unsafe.Pointer
+
+	hresult := comCall(automation, vtCreateCacheRequest, uintptr(unsafe.Pointer(&cache)))
+	if failed(hresult) || cache == nil {
+		return nil
+	}
+
+	for _, property := range []uintptr{propControlType, propName, propBoundingRectangle, propIsOffscreen} {
+		if failed(comCall(cache, vtCacheAddProperty, property)) {
+			comCall(cache, vtRelease)
+
+			return nil
+		}
+	}
+
+	if failed(comCall(cache, vtCachePutTreeFilter, uintptr(filter))) ||
+		failed(comCall(cache, vtCachePutAutomationElementMode, automationElementModeNone)) {
+		comCall(cache, vtRelease)
+
+		return nil
+	}
+
+	return cache
 }
 
 // createAutomation creates the default IUIAutomation instance.
@@ -318,13 +379,13 @@ func collectArray(array unsafe.Pointer, keptRoles map[string]struct{}) []winElem
 // It returns ok=false for offscreen or zero-size controls, and for controls
 // whose role is not in keptRoles.
 //
-// Role selection happens here rather than downstream because UIA is queried
-// with a true condition: the whole subtree comes back, and rejecting an
-// element before its bounds and name are read saves three cross-process COM
-// calls per unwanted element.
+// Role selection happens here rather than downstream because the cache request
+// returns the whole control-view subtree: rejecting an element by role before
+// its bounds and name are decoded keeps the per-element work to one cached
+// read.
 func extractWinElement(element unsafe.Pointer, keptRoles map[string]struct{}) (winElement, bool) {
 	var controlType int32
-	if failed(comCall(element, vtGetCurrentControlType, uintptr(unsafe.Pointer(&controlType)))) {
+	if failed(comCall(element, vtGetCachedControlType, uintptr(unsafe.Pointer(&controlType)))) {
 		return winElement{}, false
 	}
 
@@ -340,13 +401,13 @@ func extractWinElement(element unsafe.Pointer, keptRoles map[string]struct{}) (w
 	}
 
 	var offscreen int32
-	if !failed(comCall(element, vtGetCurrentIsOffscreen, uintptr(unsafe.Pointer(&offscreen)))) &&
+	if !failed(comCall(element, vtGetCachedIsOffscreen, uintptr(unsafe.Pointer(&offscreen)))) &&
 		offscreen != 0 {
 		return winElement{}, false
 	}
 
 	var rect winRect
-	if failed(comCall(element, vtGetCurrentBoundingRectangle, uintptr(unsafe.Pointer(&rect)))) {
+	if failed(comCall(element, vtGetCachedBoundingRectangle, uintptr(unsafe.Pointer(&rect)))) {
 		return winElement{}, false
 	}
 
@@ -358,15 +419,15 @@ func extractWinElement(element unsafe.Pointer, keptRoles map[string]struct{}) (w
 	return winElement{
 		bounds:    bounds,
 		role:      role,
-		name:      currentName(element),
+		name:      cachedName(element),
 		clickable: true,
 	}, true
 }
 
-// currentName reads the element's name (BSTR) and frees it.
-func currentName(element unsafe.Pointer) string {
+// cachedName reads the element's cached name (BSTR) and frees it.
+func cachedName(element unsafe.Pointer) string {
 	var bstr *uint16
-	if failed(comCall(element, vtGetCurrentName, uintptr(unsafe.Pointer(&bstr)))) || bstr == nil {
+	if failed(comCall(element, vtGetCachedName, uintptr(unsafe.Pointer(&bstr)))) || bstr == nil {
 		return ""
 	}
 

--- a/internal/adapter/accessibility/native/windows/automation_test.go
+++ b/internal/adapter/accessibility/native/windows/automation_test.go
@@ -22,7 +22,7 @@ func TestControlTypeName(t *testing.T) {
 		wantKnown   bool
 	}{
 		{"button", 50000, uiaControlButton, true},
-		{"checkbox", 50002, "CheckBox", true},
+		{"checkbox", 50002, uiaControlCheckBox, true},
 		{"combobox", 50003, "ComboBox", true},
 		{"edit", 50004, uiaControlEdit, true},
 		{"hyperlink", 50005, uiaControlHyperlink, true},

--- a/internal/adapter/accessibility/native/windows/tree.go
+++ b/internal/adapter/accessibility/native/windows/tree.go
@@ -5,16 +5,19 @@ package windows
 import (
 	"context"
 	"image"
+	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/derrors"
 )
 
-// TreeNode is a node in the accessibility element hierarchy. On Windows
-// the tree is shallow: a root window node whose children are the flat list of
-// clickable controls discovered via UI Automation. Each node owns a unique
-// *Element so callers can use the pointer identity as a stable element ID.
+// TreeNode is a node in the accessibility element hierarchy. On Windows the
+// tree is flat: a root window node whose children are the clickable controls
+// UI Automation found at any depth below the window, in one cached query.
+// Each node owns a unique *Element so callers can use the pointer identity as
+// a stable element ID.
 type TreeNode struct {
 	element  *Element
 	info     *ElementInfo
@@ -96,6 +99,7 @@ func (n *TreeNode) Release(_ map[*Element]struct{}) {}
 type TreeOptions struct {
 	MaxDepth int
 	Bounds   image.Rectangle
+	logger   *zap.Logger
 	// Roles is the set of UIA control-type names to enumerate. An empty set
 	// falls back to the shipped defaults. It is applied during enumeration so
 	// unwanted controls are rejected before their properties are read.
@@ -103,12 +107,21 @@ type TreeOptions struct {
 }
 
 // DefaultTreeOptions returns the default tree options.
-func DefaultTreeOptions(_ *zap.Logger) TreeOptions { return TreeOptions{} }
+func DefaultTreeOptions(logger *zap.Logger) TreeOptions {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 
-// SetCache is a no-op on Windows (no native cache request).
+	return TreeOptions{logger: logger}
+}
+
+// SetCache is a no-op on Windows: the UIA cache request is built inside every
+// enumeration rather than handed in by the caller.
 func (o *TreeOptions) SetCache(_ any) {}
 
-// SetMaxDepth records the maximum tree depth.
+// SetMaxDepth records the maximum tree depth. The UIA query has no depth
+// knob (TreeScope_Descendants is all or nothing), so the value is recorded and
+// not applied; hints.max_depth is declared inert on Windows for that reason.
 func (o *TreeOptions) SetMaxDepth(depth int) { o.MaxDepth = depth }
 
 // SetBundleID is a no-op on Windows.
@@ -126,7 +139,12 @@ func (o *TreeOptions) SetRoles(roles map[string]struct{}) { o.Roles = roles }
 // BuildTree enumerates the clickable controls under the given window element
 // via UI Automation and returns a root node with one child per control. For
 // non-window elements (no HWND) it returns an empty root.
-func BuildTree(_ context.Context, root *Element, opts TreeOptions) (*TreeNode, error) {
+//
+// The UIA query is one blocking COM call and cannot be interrupted, so the
+// context is honored at its edges: a deadline that has already passed skips
+// the query, and one that passes during it discards the result rather than
+// handing stale elements to a caller that has stopped waiting.
+func BuildTree(ctx context.Context, root *Element, opts TreeOptions) (*TreeNode, error) {
 	if root == nil {
 		return &TreeNode{}, nil
 	}
@@ -142,7 +160,21 @@ func BuildTree(_ context.Context, root *Element, opts TreeOptions) (*TreeNode, e
 		return rootNode, nil
 	}
 
+	if ctx.Err() != nil {
+		return nil, derrors.WrapContextCanceled(ctx, "UIA tree build")
+	}
+
+	started := time.Now()
+
 	controls := enumerateClickableElements(root.hwnd, opts.Roles)
+
+	if ctx.Err() != nil {
+		return nil, derrors.WrapContextCanceled(ctx, "UIA tree build")
+	}
+
+	opts.logger.Debug("Built UIA tree",
+		zap.Int("count", len(controls)),
+		zap.Duration("duration", time.Since(started)))
 
 	children := make([]*TreeNode, 0, len(controls))
 

--- a/internal/adapter/accessibility/native/windows/tree_integration_test.go
+++ b/internal/adapter/accessibility/native/windows/tree_integration_test.go
@@ -1,0 +1,165 @@
+//go:build integration && windows
+
+package windows
+
+import (
+	"context"
+	"image"
+	"runtime"
+	"testing"
+	"time"
+	"unsafe"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/windows"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// Real UI Automation test against a fixture window this process owns. The
+// fixture nests a button inside a child pane so the walk has to reach depth
+// two below the window: a walk that only reads the window's direct children
+// reports three controls where four exist.
+//
+// The window and the query share one locked thread: Win32 controls answer the
+// MSAA proxy's WM_GETTEXT with SendMessage, which is synchronous on the
+// creating thread and would need a message pump from any other.
+
+var (
+	moduser32                = windows.NewLazySystemDLL("user32.dll")
+	modkernel32              = windows.NewLazySystemDLL("kernel32.dll")
+	procFixtureCreateWindowW = moduser32.NewProc("CreateWindowExW")
+	procFixtureDestroyWindow = moduser32.NewProc("DestroyWindow")
+	procFixtureModuleHandleW = modkernel32.NewProc("GetModuleHandleW")
+)
+
+const (
+	fixtureOverlappedWindow = 0x00CF0000
+	fixtureVisible          = 0x10000000
+	fixtureChild            = 0x40000000
+	fixtureCheckBox         = 0x2
+	fixtureUseDefault       = 0x80000000
+	fixtureWindowSize       = 320
+	fixtureControlSize      = 40
+
+	// fixtureDeadline is the budget hints mode gives element collection
+	// (modes.HintTimeout); the adapter cannot import modes, so the value is
+	// restated here.
+	fixtureDeadline = 5 * time.Second
+)
+
+func createFixtureWindow(
+	t *testing.T,
+	class, title string,
+	style uintptr,
+	origin image.Point,
+	width, height, parent uintptr,
+) uintptr {
+	t.Helper()
+
+	className, err := windows.UTF16PtrFromString(class)
+	if err != nil {
+		t.Fatalf("UTF16PtrFromString: %v", err)
+	}
+
+	windowName, err := windows.UTF16PtrFromString(title)
+	if err != nil {
+		t.Fatalf("UTF16PtrFromString: %v", err)
+	}
+
+	module, _, _ := procFixtureModuleHandleW.Call(0)
+
+	hwnd, _, callErr := procFixtureCreateWindowW.Call(
+		0,
+		uintptr(unsafe.Pointer(className)),
+		uintptr(unsafe.Pointer(windowName)),
+		style,
+		uintptr(origin.X),
+		uintptr(origin.Y),
+		width,
+		height,
+		parent,
+		0,
+		module,
+		0,
+	)
+	if hwnd == 0 {
+		if parent == 0 {
+			t.Skipf("skipping: CreateWindowExW requires an interactive desktop (%v)", callErr)
+		}
+
+		t.Fatalf("CreateWindowExW(%s): %v", class, callErr)
+	}
+
+	if parent == 0 {
+		t.Cleanup(func() { discardCall(procFixtureDestroyWindow.Call(hwnd)) })
+	}
+
+	return hwnd
+}
+
+func TestBuildTree_ReportsControlsNestedBelowTheWindow(t *testing.T) {
+	runtime.LockOSThread()
+
+	defer runtime.UnlockOSThread()
+
+	const child = fixtureChild | fixtureVisible
+
+	window := createFixtureWindow(t, "STATIC", "neru-uia-fixture",
+		fixtureOverlappedWindow|fixtureVisible,
+		image.Pt(fixtureUseDefault, fixtureUseDefault), fixtureWindowSize, fixtureWindowSize, 0)
+
+	createFixtureWindow(t, "BUTTON", "neru-fixture-button", child,
+		image.Pt(10, 10), fixtureControlSize*3, fixtureControlSize, window)
+	createFixtureWindow(t, "EDIT", "neru-fixture-edit", child,
+		image.Pt(10, 60), fixtureControlSize*3, fixtureControlSize, window)
+	createFixtureWindow(t, "BUTTON", "neru-fixture-checkbox", child|fixtureCheckBox,
+		image.Pt(10, 110), fixtureControlSize*3, fixtureControlSize, window)
+
+	pane := createFixtureWindow(t, "STATIC", "neru-fixture-pane", child,
+		image.Pt(10, 160), fixtureControlSize*4, fixtureControlSize*2, window)
+	createFixtureWindow(t, "BUTTON", "neru-fixture-nested-button", child,
+		image.Pt(10, 10), fixtureControlSize*3, fixtureControlSize, pane)
+
+	roles := map[string]struct{}{uiaControlButton: {}, uiaControlEdit: {}, uiaControlCheckBox: {}}
+
+	opts := DefaultTreeOptions(zap.NewNop())
+	opts.SetRoles(roles)
+
+	ctx, cancel := context.WithTimeout(context.Background(), fixtureDeadline)
+	defer cancel()
+
+	started := time.Now()
+
+	tree, err := BuildTree(ctx, &Element{hwnd: window}, opts)
+	if err != nil {
+		t.Fatalf("BuildTree took %v and failed: %v", time.Since(started), err)
+	}
+
+	hints := ProcessClickableNodes(tree, config.HintsConfig{})
+
+	want := map[string]bool{
+		"neru-fixture-button":        false,
+		"neru-fixture-edit":          false,
+		"neru-fixture-checkbox":      false,
+		"neru-fixture-nested-button": false,
+	}
+
+	for _, hint := range hints {
+		if _, known := want[hint.Info().Title()]; known {
+			want[hint.Info().Title()] = true
+		}
+	}
+
+	for title, seen := range want {
+		if !seen {
+			t.Errorf("hint for %q missing; got %d hints", title, len(hints))
+		}
+	}
+
+	if len(hints) != len(want) {
+		t.Errorf("got %d hints, want %d", len(hints), len(want))
+	}
+
+	t.Logf("built tree with %d hints in %v", len(hints), time.Since(started))
+}

--- a/internal/adapter/accessibility/native/windows/tree_integration_windows_test.go
+++ b/internal/adapter/accessibility/native/windows/tree_integration_windows_test.go
@@ -21,6 +21,11 @@ import (
 // two below the window: a walk that only reads the window's direct children
 // reports three controls where four exist.
 //
+// The window is a caption-less popup: an overlapped window's title bar adds
+// Minimize, Maximize and Close as Button hints of its own. Controls are
+// counted by role because a Win32 edit box takes its UIA Name from a
+// neighboring label rather than its own text.
+//
 // The window and the query share one locked thread: Win32 controls answer the
 // MSAA proxy's WM_GETTEXT with SendMessage, which is synchronous on the
 // creating thread and would need a message pump from any other.
@@ -34,13 +39,12 @@ var (
 )
 
 const (
-	fixtureOverlappedWindow = 0x00CF0000
-	fixtureVisible          = 0x10000000
-	fixtureChild            = 0x40000000
-	fixtureCheckBox         = 0x2
-	fixtureUseDefault       = 0x80000000
-	fixtureWindowSize       = 320
-	fixtureControlSize      = 40
+	fixturePopup       = 0x80000000
+	fixtureVisible     = 0x10000000
+	fixtureChild       = 0x40000000
+	fixtureCheckBox    = 0x2
+	fixtureWindowSize  = 320
+	fixtureControlSize = 40
 
 	// fixtureDeadline is the budget hints mode gives element collection
 	// (modes.HintTimeout); the adapter cannot import modes, so the value is
@@ -106,8 +110,8 @@ func TestBuildTree_ReportsControlsNestedBelowTheWindow(t *testing.T) {
 	const child = fixtureChild | fixtureVisible
 
 	window := createFixtureWindow(t, "STATIC", "neru-uia-fixture",
-		fixtureOverlappedWindow|fixtureVisible,
-		image.Pt(fixtureUseDefault, fixtureUseDefault), fixtureWindowSize, fixtureWindowSize, 0)
+		fixturePopup|fixtureVisible,
+		image.Pt(0, 0), fixtureWindowSize, fixtureWindowSize, 0)
 
 	createFixtureWindow(t, "BUTTON", "neru-fixture-button", child,
 		image.Pt(10, 10), fixtureControlSize*3, fixtureControlSize, window)
@@ -138,27 +142,26 @@ func TestBuildTree_ReportsControlsNestedBelowTheWindow(t *testing.T) {
 
 	hints := ProcessClickableNodes(tree, config.HintsConfig{})
 
-	want := map[string]bool{
-		"neru-fixture-button":        false,
-		"neru-fixture-edit":          false,
-		"neru-fixture-checkbox":      false,
-		"neru-fixture-nested-button": false,
-	}
+	want := map[string]int{uiaControlButton: 2, uiaControlCheckBox: 1, uiaControlEdit: 1}
+	got := make(map[string]int, len(want))
+	nested := false
 
 	for _, hint := range hints {
-		if _, known := want[hint.Info().Title()]; known {
-			want[hint.Info().Title()] = true
+		got[hint.Info().Role()]++
+
+		if hint.Info().Title() == "neru-fixture-nested-button" {
+			nested = true
 		}
 	}
 
-	for title, seen := range want {
-		if !seen {
-			t.Errorf("hint for %q missing; got %d hints", title, len(hints))
+	for role, count := range want {
+		if got[role] != count {
+			t.Errorf("%s hints = %d, want %d (all roles: %v)", role, got[role], count, got)
 		}
 	}
 
-	if len(hints) != len(want) {
-		t.Errorf("got %d hints, want %d", len(hints), len(want))
+	if !nested {
+		t.Errorf("the button nested inside the child pane was not reported; hints: %v", got)
 	}
 
 	t.Logf("built tree with %d hints in %v", len(hints), time.Since(started))


### PR DESCRIPTION
## Description

This PR makes Windows hints reach every clickable control in a window, however deep it sits, without paying a COM round trip per node.

The old walk already asked UIA for all descendants but then read four properties per element with four cross-process calls each, so a deep window was slow and complex apps came back thin. The walk now builds an `IUIAutomation` cache request carrying ControlType, Name, BoundingRectangle and IsOffscreen, filtered to the control view, and fetches the whole subtree in one `FindAllBuildCache` under `TreeScope_Descendants`. Per-element reads use the cached getters, which never leave the process.

`BuildTree` now honors the caller's context on both sides of the blocking COM call and logs the element count and duration at debug. Role pruning is unchanged: `hints.clickable_roles`, resolved through the `uia:` prefix. No per-app branches.

Docs: the Element discovery row of the Capability Matrix reads ⚠️ with the remaining limit named (control view only), the Known Gaps entry for UIA tree depth is removed, and the README and CLI reference no longer call the walk shallow.

**Honest limits on the acceptance criteria.** The new `integration && windows` test builds a fixture window with a button, an edit box, a checkbox and a button nested inside a child pane, and asserts all four come back as hints within the 5s hint deadline. It runs on the `windows-latest` leg via `test-integration-ci`. Chrome, VS Code and Explorer were not measured against a macOS fixture page in this PR: there is no Windows desktop in this development setup, and CI has none of those apps. The fixture proves depth and the cache path; the app-level comparison needs a hand run on a Windows box.

## Related Issues

Closes #1557

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

No new port or stub: the change is inside the existing Windows accessibility adapter.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

`just ci` and `just lint-cross` (windows/amd64, CGO off) are green on the macOS host. The Windows integration test has only run in CI.

## Additional Context

Vtable slots for `CreateCacheRequest`, `get_ControlViewCondition`, `FindAllBuildCache`, the `IUIAutomationCacheRequest` setters and the `get_Cached*` getters were counted from both the mingw-w64 `uiautomationclient.h` and Wine's `uiautomationclient.idl`; the two agree on every slot.

`hints.max_depth` stays declared inert on Windows: `TreeScope_Descendants` has no depth knob, and the option was already recorded without being read.
