### PR TITLE
feat(windows): modifier passthrough and PostModifierEvent

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -185,7 +185,7 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Overlay**                   | ✅ NSPanel + CoreAnimation | ✅ X11 + Cairo       | ✅ layer-shell + Cairo       | ✅ layer-shell + Cairo  | ✅ layered HWND + GDI        |
 | **Global hotkeys**            | ✅ per-key CGEventTap    | ✅ `XGrabKey`          | ⚠️ passive evdev read        | ⚠️ passive evdev read   | ✅ `RegisterHotKey`          |
 | **Keyboard capture**          | ✅ CGEventTap            | ✅ `XGrabKeyboard`     | ✅ evdev grab (wl-keyboard fallback) | ✅ evdev grab   | ✅ `WH_KEYBOARD_LL`          |
-| **Modifier passthrough**      | ✅                       | ❌                     | ✅ evdev backend only        | ✅ evdev backend only   | ❌                           |
+| **Modifier passthrough**      | ✅                       | ❌                     | ✅ evdev backend only        | ✅ evdev backend only   | ✅ `WH_KEYBOARD_LL` forwards or blocks per event |
 | **Dark mode detection**       | ✅ Cocoa appearance      | ✅ xdg appearance portal | ✅ xdg appearance portal   | ✅ kdeglobals + portal  | ✅ registry                  |
 | **Font resolution**           | ✅ NSFont                | ✅ fontconfig          | ✅ fontconfig                | ✅ fontconfig           | ⚠️ generic-alias map only ¹  |
 | **System tray**               | ✅ NSStatusItem ⁸        | ✅ D-Bus StatusNotifierItem ⁸ | ✅ StatusNotifierItem ⁸      | ✅ StatusNotifierItem ⁸ | ✅ Win32 notification area ⁸ |
@@ -670,8 +670,8 @@ left-most held button, since one event cannot describe more.
 | **Global hotkeys**    | Per-key CGEventTap     | `XGrabKey`              | Passive evdev read                       | `RegisterHotKey`        |
 | **CGO needed**        | Yes                    | Yes                     | Yes                                      | No                      |
 | **Press/release**     | ✅ separate callbacks  | ✅ KeyPress/KeyRelease  | ⚠️ press-only in some configs            | ✅ `WM_HOTKEY` flags    |
-| **Modifier passthrough** | ✅                  | ❌ grab is all-or-nothing | ✅ evdev only                          | ❌ no-op                |
-| **`PostModifierEvent`** | ✅                   | ✅                      | ✅ (`zwp_virtual_keyboard_v1`)           | ❌ no-op                |
+| **Modifier passthrough** | ✅                  | ❌ grab is all-or-nothing | ✅ evdev only                          | ✅ hook forwards per event |
+| **`PostModifierEvent`** | ✅                   | ✅                      | ✅ (`zwp_virtual_keyboard_v1`)           | ✅ `SendInput`          |
 | **Sticky modifiers**  | ✅                     | ✅                      | ✅                                       | ✅                      |
 | **Capture files**     | `eventtap/darwin/`     | `eventtap/linux/x11_cgo.go` | `eventtap/linux/wayland_cgo.go`, `evdev_cgo.go` | `eventtap/windows/` |
 | **Hotkey files**      | `hotkeys/darwin/`      | `hotkeys/linux/x11_cgo.go`  | `hotkeys/linux/manager.go` + `eventtap/linux/global_hotkey_cgo.go` ³ | `hotkeys/windows/` |
@@ -735,17 +735,20 @@ the key that *types* that character, and is the same reason XKB options like
 which physical key a `[hotkeys]` chord answers** — the one bearing that character
 on the active layout, in both places.
 
-**Modifier passthrough (Wayland evdev only).** While a mode is active Neru
-captures the keyboard exclusively, so shortcuts it does not bind (`Ctrl+C`,
-`Ctrl+Tab`) are normally swallowed. With `general.passthrough_unbounded_keys`,
-unbound Ctrl/Alt/Cmd chords are re-injected to the focused app instead. This
-works on the Wayland evdev backend because Neru holds `EVIOCGRAB` on the
-physical device but injects through a *separate* `zwp_virtual_keyboard_v1`,
-which bypasses that grab and reaches the app with no feedback loop (see
-`handleWaylandEvdevEvent` → `passthroughEvdevChord`). It is **not** available on
-X11 — an `XGrabKeyboard` routes Neru's own synthetic XTest events back to
-itself, and `XSendEvent` is ignored by most apps — nor on the rare wl-keyboard
-fallback, which has no injection path. Classification (blacklist,
+**Modifier passthrough (Wayland evdev, and Windows).** While a mode is active
+Neru captures the keyboard exclusively, so shortcuts it does not bind
+(`Ctrl+C`, `Ctrl+Tab`) are normally swallowed. With
+`general.passthrough_unbounded_keys`, unbound Ctrl/Alt/Cmd chords reach the
+focused app instead. This works on the Wayland evdev backend because Neru holds
+`EVIOCGRAB` on the physical device but injects through a *separate*
+`zwp_virtual_keyboard_v1`, which bypasses that grab and reaches the app with no
+feedback loop (see `handleWaylandEvdevEvent` → `passthroughEvdevChord`). It is
+**not** available on X11 — an `XGrabKeyboard` routes Neru's own synthetic XTest
+events back to itself, and `XSendEvent` is ignored by most apps — nor on the
+rare wl-keyboard fallback, which has no injection path. Windows needs no
+re-injection at all: a `WH_KEYBOARD_LL` hook forwards or blocks each event on
+its own, so an unbound chord is simply handed on as the real key event it is,
+and a bound one is blocked (`eventtap/windows/tap.go`, `handleKey`). Classification (blacklist,
 mode-intercepted keys, the mode's own hotkeys, and the global chords it falls
 back to — passed through, the user's own hotkey would reach the application in
 front of them and the fallback above would never see the key) and the
@@ -1037,9 +1040,6 @@ green in every cell while an option means nothing, which is exactly how
 | ---- | ---- | --- | --- | --- | --- |
 | `general.hide_overlay_in_screen_share` | option | ✅ | ❌ | ❌ | hiding the overlay from a screen share is an NSWindow sharing level, a Quartz concept with no X11, Wayland or Win32 counterpart |
 | `general.kb_layout_to_use` | option | ✅ | ❌ | ❌ | the keyboard layout is detected rather than chosen outside macOS |
-| `general.passthrough_unbounded_keys` | option | ✅ | ✅ | ❌ | unbound modifier chords reach the focused application on macOS and on the Wayland evdev tap; X11 cannot pass them through at all and Windows does not |
-| `general.passthrough_unbounded_keys_blacklist` | option | ✅ | ✅ | ❌ | unbound modifier chords reach the focused application on macOS and on the Wayland evdev tap; X11 cannot pass them through at all and Windows does not |
-| `general.should_exit_after_passthrough` | option | ✅ | ✅ | ❌ | unbound modifier chords reach the focused application on macOS and on the Wayland evdev tap; X11 cannot pass them through at all and Windows does not |
 | `hints.include_menubar_hints` | option | ✅ | ❌ | ❌ | the menu bar, the Dock, Notification Center, Stage Manager, picture-in-picture and the screen-capture chrome are macOS surfaces with no counterpart |
 | `hints.additional_menubar_hints_targets` | option | ✅ | ❌ | ❌ | the menu bar, the Dock, Notification Center, Stage Manager, picture-in-picture and the screen-capture chrome are macOS surfaces with no counterpart |
 | `hints.include_dock_hints` | option | ✅ | ❌ | ❌ | the menu bar, the Dock, Notification Center, Stage Manager, picture-in-picture and the screen-capture chrome are macOS surfaces with no counterpart |
@@ -1206,12 +1206,11 @@ working, which is exactly why the build exists.
    `virtual_pointer.ui.*` is therefore partly inert here rather than wholly, so
    it stays declared everywhere and is tracked as this entry instead
 4. Smooth cursor and smooth scroll animation — not implemented
-5. Modifier passthrough and `PostModifierEvent` — no-ops
-6. `monitor_select` mode — returns `CodeNotSupported`
-7. Font resolution — alias mapping only, no system font enumeration
-8. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
+5. `monitor_select` mode — returns `CodeNotSupported`
+6. Font resolution — alias mapping only, no system font enumeration
+7. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
    installs a launchd agent and Linux a systemd user unit
-9. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
+8. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
     every platform, but only the Unix client checks that for itself before
     connecting. A named pipe carries no ownership a client can read without
     opening it, so the Windows CLI trusts the name it derives from its own SID.

--- a/internal/adapter/eventtap/linux/tap.go
+++ b/internal/adapter/eventtap/linux/tap.go
@@ -3,7 +3,6 @@
 package linux
 
 import (
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -78,7 +77,7 @@ type EventTap struct {
 	// backend (handleWaylandEvdevEvent): with a virtual-keyboard injection path
 	// it can re-emit an unbound chord to the focused app. The X11 grab and the
 	// wl-keyboard fallback cannot re-inject selectively, so this stays inert
-	// there. Chords are stored canonicalized via canonicalChordForMatch.
+	// there. Chords are stored canonicalized via tap.CanonicalChord.
 	passthroughEnabled   bool
 	passthroughBlacklist map[string]struct{}
 	interceptedChords    map[string]struct{}
@@ -251,7 +250,7 @@ func (et *EventTap) SetHotkeys(hotkeys []string) {
 // unbound (the mode layer folds the active mode's own hotkeys into this list).
 // Only the Wayland evdev backend acts on it; see the struct field comment.
 func (et *EventTap) SetModifierPassthrough(enabled bool, blacklist []string) {
-	set := canonicalChordSet(blacklist)
+	set := tap.CanonicalChordSet(blacklist)
 
 	et.mu.Lock()
 	et.passthroughEnabled = enabled
@@ -262,7 +261,7 @@ func (et *EventTap) SetModifierPassthrough(enabled bool, blacklist []string) {
 // SetInterceptedModifierKeys records the modifier chords the active mode still
 // wants Neru to consume while passthrough is enabled.
 func (et *EventTap) SetInterceptedModifierKeys(keys []string) {
-	set := canonicalChordSet(keys)
+	set := tap.CanonicalChordSet(keys)
 
 	et.mu.Lock()
 	et.interceptedChords = set
@@ -275,74 +274,6 @@ func (et *EventTap) SetPassthroughCallback(cb tap.PassthroughCallback) {
 	defer et.mu.Unlock()
 
 	et.passthroughCallback = cb
-}
-
-// canonicalChordSet builds a lookup set of chords normalized via
-// canonicalChordForMatch so runtime lookups are independent of the order the
-// user wrote their hotkeys in.
-func canonicalChordSet(chords []string) map[string]struct{} {
-	set := make(map[string]struct{}, len(chords))
-
-	for _, chord := range chords {
-		if canonical := canonicalChordForMatch(chord); canonical != "" {
-			set[canonical] = struct{}{}
-		}
-	}
-
-	return set
-}
-
-// canonicalChordForMatch normalizes a modifier chord to a stable,
-// order-independent form for passthrough matching: aliases are resolved and
-// tokens lowercased via config.NormalizeKeyForComparison, then the modifiers
-// are re-emitted in the fixed shift+ctrl+alt+cmd order that
-// evdevModifierState.prefix() produces, with the base key last. Applying it to
-// both the configured blacklist/intercepted entries and the runtime evdev chord
-// makes lookups agree regardless of modifier ordering.
-func canonicalChordForMatch(chord string) string {
-	normalized := config.NormalizeKeyForComparison(strings.TrimSpace(chord))
-	if normalized == "" {
-		return ""
-	}
-
-	parts := strings.Split(normalized, "+")
-	base := strings.TrimSpace(parts[len(parts)-1])
-
-	var hasShift, hasCtrl, hasAlt, hasCmd bool
-
-	for _, part := range parts[:len(parts)-1] {
-		switch keyvocab.CanonicalModifier(part) {
-		case evdevModifierShift:
-			hasShift = true
-		case evdevModifierCtrl:
-			hasCtrl = true
-		case evdevModifierAlt:
-			hasAlt = true
-		case evdevModifierCmd:
-			hasCmd = true
-		}
-	}
-
-	var builder strings.Builder
-
-	for _, mod := range []struct {
-		held bool
-		name string
-	}{
-		{hasShift, evdevModifierShift},
-		{hasCtrl, evdevModifierCtrl},
-		{hasAlt, evdevModifierAlt},
-		{hasCmd, evdevModifierCmd},
-	} {
-		if mod.held {
-			builder.WriteString(mod.name)
-			builder.WriteByte('+')
-		}
-	}
-
-	builder.WriteString(base)
-
-	return builder.String()
 }
 
 // SetStickyModifierToggle enables/disables sticky modifier toggle.
@@ -519,7 +450,7 @@ func (et *EventTap) shouldPassthroughChord(chord string) bool {
 		return false
 	}
 
-	canonical := canonicalChordForMatch(chord)
+	canonical := tap.CanonicalChord(chord)
 
 	et.mu.RLock()
 	defer et.mu.RUnlock()

--- a/internal/adapter/eventtap/linux/tap_test.go
+++ b/internal/adapter/eventtap/linux/tap_test.go
@@ -151,40 +151,6 @@ func TestSyntheticModifierSuppressionConsumesOnce(t *testing.T) {
 	}
 }
 
-func TestCanonicalChordForMatchOrderIndependent(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{name: "single ctrl lowercased", in: chordCtrlC, want: "ctrl+c"},
-		{name: "cmd cased", in: "Cmd+C", want: "cmd+c"},
-		{name: "ctrl+shift order a", in: "ctrl+shift+t", want: chordShiftCtrl},
-		{name: "ctrl+shift order b", in: chordShiftCtrl, want: chordShiftCtrl},
-		{name: "all mods reordered", in: "cmd+alt+ctrl+shift+k", want: "shift+ctrl+alt+cmd+k"},
-		{name: "control alias", in: "control+a", want: "ctrl+a"},
-		{name: "plain key", in: "c", want: "c"},
-		{name: "empty", in: "", want: ""},
-	}
-
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			if got := canonicalChordForMatch(testCase.in); got != testCase.want {
-				t.Fatalf(
-					"canonicalChordForMatch(%q) = %q, want %q",
-					testCase.in,
-					got,
-					testCase.want,
-				)
-			}
-		})
-	}
-}
-
 func TestShouldPassthroughChord(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/eventtap/tap/chord.go
+++ b/internal/adapter/eventtap/tap/chord.go
@@ -1,0 +1,86 @@
+package tap
+
+import (
+	"strings"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
+)
+
+// The modifier names a canonical chord is spelled with, in the order they
+// appear.
+const (
+	modifierShift = "shift"
+	modifierCtrl  = "ctrl"
+	modifierAlt   = "alt"
+	modifierCmd   = "cmd"
+)
+
+// CanonicalChord normalizes a modifier chord to a stable, order-independent
+// form for passthrough matching: aliases are resolved and tokens lowercased via
+// config.NormalizeKeyForComparison, then the modifiers are re-emitted in a
+// fixed shift+ctrl+alt+cmd order with the base key last.
+//
+// Applying it to both the configured blacklist and intercepted entries and to
+// the chord a backend reads at runtime makes lookups agree regardless of the
+// order the user wrote their hotkeys in, or the order the backend assembles
+// modifiers in.
+func CanonicalChord(chord string) string {
+	normalized := config.NormalizeKeyForComparison(strings.TrimSpace(chord))
+	if normalized == "" {
+		return ""
+	}
+
+	parts := strings.Split(normalized, "+")
+	base := strings.TrimSpace(parts[len(parts)-1])
+
+	var hasShift, hasCtrl, hasAlt, hasCmd bool
+
+	for _, part := range parts[:len(parts)-1] {
+		switch keyvocab.CanonicalModifier(part) {
+		case modifierShift:
+			hasShift = true
+		case modifierCtrl:
+			hasCtrl = true
+		case modifierAlt:
+			hasAlt = true
+		case modifierCmd:
+			hasCmd = true
+		}
+	}
+
+	var builder strings.Builder
+
+	for _, mod := range []struct {
+		held bool
+		name string
+	}{
+		{hasShift, modifierShift},
+		{hasCtrl, modifierCtrl},
+		{hasAlt, modifierAlt},
+		{hasCmd, modifierCmd},
+	} {
+		if mod.held {
+			builder.WriteString(mod.name)
+			builder.WriteByte('+')
+		}
+	}
+
+	builder.WriteString(base)
+
+	return builder.String()
+}
+
+// CanonicalChordSet builds a lookup set of chords normalized via
+// CanonicalChord.
+func CanonicalChordSet(chords []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(chords))
+
+	for _, chord := range chords {
+		if canonical := CanonicalChord(chord); canonical != "" {
+			set[canonical] = struct{}{}
+		}
+	}
+
+	return set
+}

--- a/internal/adapter/eventtap/tap/chord_test.go
+++ b/internal/adapter/eventtap/tap/chord_test.go
@@ -1,0 +1,42 @@
+package tap
+
+import "testing"
+
+const (
+	chordCtrlC     = "Ctrl+c"
+	chordShiftCtrl = "shift+ctrl+t"
+)
+
+func TestCanonicalChord_OrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "single ctrl lowercased", in: chordCtrlC, want: "ctrl+c"},
+		{name: "cmd cased", in: "Cmd+C", want: "cmd+c"},
+		{name: "ctrl+shift order a", in: "ctrl+shift+t", want: chordShiftCtrl},
+		{name: "ctrl+shift order b", in: chordShiftCtrl, want: chordShiftCtrl},
+		{name: "all mods reordered", in: "cmd+alt+ctrl+shift+k", want: "shift+ctrl+alt+cmd+k"},
+		{name: "control alias", in: "control+a", want: "ctrl+a"},
+		{name: "plain key", in: "c", want: "c"},
+		{name: "empty", in: "", want: ""},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := CanonicalChord(testCase.in); got != testCase.want {
+				t.Fatalf(
+					"CanonicalChord(%q) = %q, want %q",
+					testCase.in,
+					got,
+					testCase.want,
+				)
+			}
+		})
+	}
+}

--- a/internal/adapter/eventtap/windows/tap.go
+++ b/internal/adapter/eventtap/windows/tap.go
@@ -4,7 +4,6 @@ package windows
 
 import (
 	"context"
-	"strings"
 	"sync"
 
 	"go.uber.org/zap"
@@ -25,6 +24,14 @@ type EventTap struct {
 	hotkeys              []string
 	stickyModifierToggle bool
 	enabled              bool
+
+	// Modifier passthrough state, populated by SetModifierPassthrough and
+	// SetInterceptedModifierKeys and read by handleKey. Chords are stored
+	// canonicalized via tap.CanonicalChord so the form the hook assembles a
+	// chord in matches the form the user wrote a hotkey in.
+	passthroughEnabled   bool
+	passthroughBlacklist map[string]struct{}
+	interceptedChords    map[string]struct{}
 
 	hook *winplatform.KeyboardHook
 }
@@ -102,11 +109,29 @@ func (et *EventTap) SetHotkeys(hotkeys []string) {
 	et.hotkeys = append([]string(nil), hotkeys...)
 }
 
-// SetModifierPassthrough sets modifier passthrough.
-func (et *EventTap) SetModifierPassthrough(_ bool, _ []string) {}
+// SetModifierPassthrough enables or disables modifier passthrough and records
+// the blacklist of chords Neru must keep consuming even when they are otherwise
+// unbound (the mode layer folds the active mode's own hotkeys into this list).
+func (et *EventTap) SetModifierPassthrough(enabled bool, blacklist []string) {
+	set := tap.CanonicalChordSet(blacklist)
 
-// SetInterceptedModifierKeys sets intercepted modifier keys.
-func (et *EventTap) SetInterceptedModifierKeys(_ []string) {}
+	et.mu.Lock()
+	defer et.mu.Unlock()
+
+	et.passthroughEnabled = enabled
+	et.passthroughBlacklist = set
+}
+
+// SetInterceptedModifierKeys records the modifier chords the active mode still
+// wants Neru to consume while passthrough is enabled.
+func (et *EventTap) SetInterceptedModifierKeys(keys []string) {
+	set := tap.CanonicalChordSet(keys)
+
+	et.mu.Lock()
+	defer et.mu.Unlock()
+
+	et.interceptedChords = set
+}
 
 // SetPassthroughCallback sets the passthrough callback.
 func (et *EventTap) SetPassthroughCallback(cb tap.PassthroughCallback) {
@@ -124,8 +149,21 @@ func (et *EventTap) SetStickyModifierToggle(enabled bool) {
 	et.stickyModifierToggle = enabled
 }
 
-// PostModifierEvent simulates a physical modifier key press or release.
-func (et *EventTap) PostModifierEvent(_ string, _ bool) {}
+// PostModifierEvent simulates a physical modifier key press or release. The
+// key goes out tagged as Neru's own, so the hook hands it on without reading
+// it as a modifier toggle; nothing has to be remembered here the way the X11
+// tap remembers its XTest events.
+func (et *EventTap) PostModifierEvent(modifier string, isDown bool) {
+	modifier = keyvocab.CanonicalModifier(modifier)
+	if modifier == "" {
+		return
+	}
+
+	err := winplatform.PostModifierKey(modifier, isDown)
+	if err != nil {
+		et.logger.Warn("Failed to post modifier event", zap.Error(err))
+	}
+}
 
 // SetKeyboardLayout sets the keyboard layout.
 func (et *EventTap) SetKeyboardLayout(_ string) bool { return true }
@@ -214,14 +252,12 @@ func (et *EventTap) handleKey(key string, isUp bool) bool {
 
 	normalized := keyvocab.NormalizeKey(key)
 
-	// Key-down with system-level modifiers (ctrl, alt, cmd) should pass through
-	// to the application so system shortcuts like Ctrl+C, Alt+Tab, Win+D still
-	// work while a mode is active. The mode handler still receives the key for
-	// hotkey matching.
-	lower := strings.ToLower(normalized)
-	if strings.Contains(lower, "ctrl+") || strings.Contains(lower, "alt+") ||
-		strings.Contains(lower, "cmd+") {
-		// Unless the chord is one RegisterHotKey owns. That mechanism keeps
+	// A chord carrying a system-level modifier (ctrl, alt, cmd) is either the
+	// application's or Neru's, never both: handing the event on and dispatching
+	// it too would run a mode binding and type into the window behind the
+	// overlay at once.
+	if config.HasPassthroughModifier(normalized) {
+		// A chord RegisterHotKey owns is handed back. That mechanism keeps
 		// firing while a mode is active and this hook runs ahead of it, so
 		// passing the key on without dispatching leaves exactly one of the two
 		// to run the binding. Dispatching as well would run it twice, because
@@ -230,17 +266,24 @@ func (et *EventTap) handleKey(key string, isUp bool) bool {
 		// and a double-run of "recursive_grid --toggle" exits the mode and
 		// re-enters it. macOS answers the same question the same way, in its own
 		// tap's hotkey check (platform/darwin/eventtap_darwin.m).
-		//
-		// Bare keys and Shift-only combos are deliberately not asked about: the
-		// tap consumes those below so a mode keeps every key it reads as input,
-		// and the handler's fallback leaves them alone for the same reason.
 		if et.isRegisteredHotkey(normalized) {
+			return false
+		}
+
+		// An unbound chord the user asked to have passed through reaches the
+		// application as the real key event it is. Unlike an evdev grab, a
+		// low-level hook forwards or blocks each event on its own, so nothing
+		// has to be replayed: the modifiers were forwarded when they went
+		// down, and the app reads them off the same keyboard state Neru does.
+		if et.shouldPassthroughChord(normalized) {
+			et.firePassthroughCallback()
+
 			return false
 		}
 
 		et.dispatchKey(normalized)
 
-		return false
+		return true
 	}
 
 	// Non-modifier key-down (single character, Shift+letter, named key like
@@ -250,6 +293,47 @@ func (et *EventTap) handleKey(key string, isUp bool) bool {
 	et.dispatchKey(normalized)
 
 	return true
+}
+
+// shouldPassthroughChord reports whether an unbound modifier chord should be
+// passed through to the focused application instead of consumed by Neru. It
+// mirrors the macOS event-tap decision: passthrough must be enabled and the
+// chord must be neither blacklisted nor in the mode's intercepted set. The
+// caller has already established that the chord carries Ctrl/Alt/Cmd;
+// shift-only chords stay usable inside modes.
+func (et *EventTap) shouldPassthroughChord(chord string) bool {
+	et.mu.RLock()
+	defer et.mu.RUnlock()
+
+	if !et.passthroughEnabled {
+		return false
+	}
+
+	canonical := tap.CanonicalChord(chord)
+
+	if _, ok := et.passthroughBlacklist[canonical]; ok {
+		return false
+	}
+
+	if _, ok := et.interceptedChords[canonical]; ok {
+		return false
+	}
+
+	return true
+}
+
+// firePassthroughCallback invokes the registered passthrough callback (if any)
+// on its own goroutine and without holding et.mu. The hook procedure runs on
+// the hook thread, where the mode handler's lock must not be taken: mode exit
+// stops the hook while holding it (see KeyboardHook.Stop).
+func (et *EventTap) firePassthroughCallback() {
+	et.mu.RLock()
+	callback := et.passthroughCallback
+	et.mu.RUnlock()
+
+	if callback != nil {
+		go callback()
+	}
 }
 
 func (et *EventTap) dispatchKey(key string) {

--- a/internal/adapter/eventtap/windows/tap_passthrough_test.go
+++ b/internal/adapter/eventtap/windows/tap_passthrough_test.go
@@ -1,0 +1,148 @@
+//go:build windows
+
+package windows
+
+// The hook either hands a chord to the application or dispatches it to Neru,
+// never both. Which of the two happens is decided from the passthrough state
+// the mode layer pushes down, in the same way the macOS tap decides it; deleting
+// that decision is silent everywhere except on a Windows desktop (ADR 0011).
+
+import (
+	"testing"
+	"time"
+)
+
+const chordCtrlC = "Ctrl+C"
+
+// routedKey drives handleKey for one key-down and reports where it went.
+func routedKey(t *testing.T, eventTap *EventTap, key string) ([]string, bool) {
+	t.Helper()
+
+	var dispatched []string
+
+	eventTap.SetHandler(func(key string) { dispatched = append(dispatched, key) })
+
+	consumed := eventTap.handleKey(key, false)
+
+	return dispatched, consumed
+}
+
+func TestEventTap_HandleKey_ConsumesAnUnboundChordWithPassthroughOff(t *testing.T) {
+	t.Parallel()
+
+	eventTap := NewEventTap(nil, nil)
+	eventTap.SetModifierPassthrough(false, nil)
+
+	dispatched, consumed := routedKey(t, eventTap, chordCtrlC)
+
+	if !consumed {
+		t.Error("Ctrl+C reached the application while a mode had the keyboard")
+	}
+
+	if len(dispatched) != 1 || dispatched[0] != "ctrl+c" {
+		t.Errorf("dispatched %v, want [ctrl+c]", dispatched)
+	}
+}
+
+func TestEventTap_HandleKey_PassesAnUnboundChordThrough(t *testing.T) {
+	t.Parallel()
+
+	eventTap := NewEventTap(nil, nil)
+	eventTap.SetModifierPassthrough(true, nil)
+
+	fired := make(chan struct{}, 1)
+	eventTap.SetPassthroughCallback(func() { fired <- struct{}{} })
+
+	dispatched, consumed := routedKey(t, eventTap, chordCtrlC)
+
+	if consumed {
+		t.Error("Ctrl+C was consumed with passthrough on")
+	}
+
+	if len(dispatched) != 0 {
+		t.Errorf("dispatched %v to Neru as well as passing it through", dispatched)
+	}
+
+	select {
+	case <-fired:
+	case <-time.After(time.Second):
+		t.Error("the passthrough callback never fired, so the mode cannot refresh after the chord")
+	}
+}
+
+func TestEventTap_HandleKey_KeepsAChordTheModeBinds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(*EventTap)
+	}{
+		{
+			name: "blacklisted, written in another modifier order",
+			setup: func(eventTap *EventTap) {
+				eventTap.SetModifierPassthrough(true, []string{"shift+ctrl+c"})
+			},
+		},
+		{
+			name: "intercepted by the mode",
+			setup: func(eventTap *EventTap) {
+				eventTap.SetModifierPassthrough(true, nil)
+				eventTap.SetInterceptedModifierKeys([]string{"Ctrl+Shift+C"})
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			eventTap := NewEventTap(nil, nil)
+			testCase.setup(eventTap)
+
+			dispatched, consumed := routedKey(t, eventTap, "Ctrl+Shift+C")
+
+			if !consumed || len(dispatched) != 1 {
+				t.Errorf(
+					"consumed=%v dispatched=%v, want the chord consumed and dispatched once",
+					consumed,
+					dispatched,
+				)
+			}
+		})
+	}
+}
+
+// Shift-only chords and bare keys are the mode's input, whatever passthrough
+// says: a hint label or a grid cell key is typed with them.
+func TestEventTap_HandleKey_ConsumesShiftOnlyChordsWithPassthroughOn(t *testing.T) {
+	t.Parallel()
+
+	eventTap := NewEventTap(nil, nil)
+	eventTap.SetModifierPassthrough(true, nil)
+
+	for _, key := range []string{"Shift+A", "a", "Return"} {
+		if _, consumed := routedKey(t, eventTap, key); !consumed {
+			t.Errorf("%q reached the application instead of the mode", key)
+		}
+	}
+}
+
+// A chord RegisterHotKey owns is handed back undispatched whether or not
+// passthrough is on, so exactly one of the two runs the binding.
+func TestEventTap_HandleKey_HandsARegisteredHotkeyBack(t *testing.T) {
+	t.Parallel()
+
+	eventTap := NewEventTap(nil, nil)
+	eventTap.SetHotkeys([]string{"Ctrl+G"})
+	eventTap.SetModifierPassthrough(false, nil)
+
+	dispatched, consumed := routedKey(t, eventTap, "Ctrl+G")
+
+	if consumed || len(dispatched) != 0 {
+		t.Errorf(
+			"consumed=%v dispatched=%v, want the chord left to RegisterHotKey",
+			consumed,
+			dispatched,
+		)
+	}
+}

--- a/internal/adapter/eventtap/windows/tap_passthrough_test.go
+++ b/internal/adapter/eventtap/windows/tap_passthrough_test.go
@@ -12,7 +12,8 @@ import (
 	"time"
 )
 
-const chordCtrlC = "Ctrl+C"
+// The hook spells a chord the way pressedModifierNames assembles it: lowercase.
+const chordCtrlC = "ctrl+c"
 
 // routedKey drives handleKey for one key-down and reports where it went.
 func routedKey(t *testing.T, eventTap *EventTap, key string) ([]string, bool) {
@@ -99,7 +100,7 @@ func TestEventTap_HandleKey_KeepsAChordTheModeBinds(t *testing.T) {
 			eventTap := NewEventTap(nil, nil)
 			testCase.setup(eventTap)
 
-			dispatched, consumed := routedKey(t, eventTap, "Ctrl+Shift+C")
+			dispatched, consumed := routedKey(t, eventTap, "ctrl+shift+c")
 
 			if !consumed || len(dispatched) != 1 {
 				t.Errorf(

--- a/internal/adapter/platform/windows/input.go
+++ b/internal/adapter/platform/windows/input.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"image"
-	"slices"
 	"unsafe"
 
 	"github.com/y3owk1n/neru/internal/domain/action"
@@ -252,26 +251,22 @@ func wheelEvents(deltaX, deltaY int) []wheelEvent {
 	return events
 }
 
-// ScrollWheel scrolls at the current cursor position on both axes, holding
-// modifiers down for the duration.
-//
-// A SendInput wheel event carries no modifier field — unlike a CGEvent, which
-// takes flags — so the only way to present a held ctrl is to press the real
-// key, wheel, and release it. Releasing only what this call pressed leaves a
-// modifier the user is physically holding untouched.
+// ScrollWheel scrolls at the current cursor position on both axes, presenting
+// exactly modifiers as held for the duration — see holdModifiers for why a
+// modifier the user is physically holding has to be suppressed rather than
+// merely not pressed.
 func ScrollWheel(deltaX, deltaY int, modifiers action.Modifiers) error {
 	events := wheelEvents(deltaX, deltaY)
 	if len(events) == 0 {
 		return nil
 	}
 
-	pressed, pressErr := pressModifiers(modifiers)
-	if pressErr != nil {
-		return pressErr
+	hold, err := holdModifiers(modifiers)
+	if err != nil {
+		return err
 	}
 
-	// Only what this call actually pressed, never the whole requested set.
-	defer releaseModifiers(pressed)
+	defer hold.release()
 
 	for _, event := range events {
 		err := sendMouseInput(event.flags, event.data)
@@ -281,74 +276,6 @@ func ScrollWheel(deltaX, deltaY int, modifiers action.Modifiers) error {
 	}
 
 	return nil
-}
-
-// modifierKeys lists the virtual-key code (keys.go) for each modifier bit, in
-// the order they are pressed. Release walks it backwards.
-var modifierKeys = []struct {
-	bit action.Modifiers
-	key uint16
-}{
-	{bit: action.ModShift, key: vkShift},
-	{bit: action.ModCtrl, key: vkControl},
-	{bit: action.ModAlt, key: vkMenu},
-	{bit: action.ModCmd, key: vkLWin},
-}
-
-// pressModifiers holds down every key in modifiers that is not already down,
-// and reports the set it actually pressed so the caller releases only that.
-// A key that fails releases what came before it, so a partial set is never
-// left latched.
-//
-// Skipping keys the user is already holding is the point, not an optimization.
-// A binding like "Ctrl+K" = "action scroll_up --modifier ctrl" fires with ctrl
-// physically down, and a key is one bit of OS state rather than a count: press
-// it a second time and our release afterwards tells every application the user
-// let go, while they are still holding it. Everything they type or click until
-// they release and press again would arrive unmodified.
-//
-// SendInput delivers these to Neru's own low-level keyboard hook, which runs
-// its callback inline on the hook thread and from there reaches the mode
-// handler's lock. neruInjectedTag is what stops that: keep it on every
-// synthesized key, or this becomes a call into the handler from whatever
-// goroutine is injecting.
-func pressModifiers(modifiers action.Modifiers) (action.Modifiers, error) {
-	var pressed action.Modifiers
-
-	for _, modifier := range modifierKeys {
-		if !modifiers.Has(modifier.bit) {
-			continue
-		}
-
-		if isVirtualKeyDown(uint32(modifier.key)) {
-			continue
-		}
-
-		err := sendKeyboardInput(modifier.key, false)
-		if err != nil {
-			releaseModifiers(pressed)
-
-			return 0, err
-		}
-
-		pressed |= modifier.bit
-	}
-
-	return pressed, nil
-}
-
-// releaseModifiers lets go of every key in modifiers, in reverse press order.
-// Callers pass what pressModifiers reported pressing, never the requested set,
-// so a key the user is holding is left alone.
-//
-// Errors are dropped: a release that fails has nothing better to try, and
-// reporting it would mask the outcome of the action it wraps.
-func releaseModifiers(modifiers action.Modifiers) {
-	for _, modifier := range slices.Backward(modifierKeys) {
-		if modifiers.Has(modifier.bit) {
-			_ = sendKeyboardInput(modifier.key, true)
-		}
-	}
 }
 
 // CurrentCursorPosition returns the current cursor location.

--- a/internal/adapter/platform/windows/modifiers.go
+++ b/internal/adapter/platform/windows/modifiers.go
@@ -5,6 +5,7 @@ package windows
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/y3owk1n/neru/internal/adapter/platform/modifierstate"
 	"github.com/y3owk1n/neru/internal/domain/action"
@@ -64,6 +65,15 @@ func heldModifierKeycodes() []uint32 {
 	return held
 }
 
+// modifierHoldMu serializes every hold from the read of the keyboard to the
+// release that undoes it. A hold reads process-wide keyboard state and then
+// changes it, so two overlapping ones — a mode action and an IPC action can run
+// on different goroutines — would each plan against the other's edits: the
+// first releases a user-held ctrl, the second reads it up and presses it, the
+// first then skips restoring it and the second releases it, and the user's
+// physically held ctrl reads up until they tap it again.
+var modifierHoldMu sync.Mutex
+
 // modifierHold is one injection's worth of falsified modifier state: what it
 // released so the injection would not carry it, and what it pressed so the
 // injection would.
@@ -93,7 +103,12 @@ type modifierHold struct {
 //
 // Every key this presses or releases carries neruInjectedTag, so the low-level
 // keyboard hook hands it on without reading it as the user tapping a modifier.
+//
+// The hold owns modifierHoldMu until release, on the success path and the
+// failure path alike.
 func holdModifiers(modifiers action.Modifiers) (modifierHold, error) {
+	modifierHoldMu.Lock()
+
 	hold := modifierHold{plan: modifierstate.PlanFor(modifierKeysFrom(isVirtualKeyDown), modifiers)}
 
 	for index, edit := range hold.plan.Suppress {
@@ -130,6 +145,8 @@ func holdModifiers(modifiers action.Modifiers) (modifierHold, error) {
 // Errors are dropped: a release that fails has nothing better to try, and
 // reporting it would mask the outcome of the action it wraps.
 func (h modifierHold) release() {
+	defer modifierHoldMu.Unlock()
+
 	for _, edit := range h.plan.Press {
 		_ = sendKeyboardInput(uint16(edit.Keycode), true)
 	}

--- a/internal/adapter/platform/windows/modifiers.go
+++ b/internal/adapter/platform/windows/modifiers.go
@@ -1,0 +1,172 @@
+//go:build windows
+
+package windows
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/y3owk1n/neru/internal/adapter/platform/modifierstate"
+	"github.com/y3owk1n/neru/internal/domain/action"
+)
+
+// windowsModifierKeys is every virtual key Neru treats as a modifier, canonical
+// key first for each one.
+//
+// Both sides of the keyboard are here because either of them presents the
+// modifier, so suppressing one and leaving the other down suppresses nothing.
+// The left key is canonical: it is what SendInput presses when Neru has to
+// present a modifier itself, and the generic VK_SHIFT / VK_CONTROL / VK_MENU
+// codes are deliberately absent, because GetAsyncKeyState answers them as
+// "either side" and a plan would then read one hold twice.
+var windowsModifierKeys = []struct {
+	key       uint16
+	modifier  action.Modifiers
+	canonical bool
+}{
+	{vkLShift, action.ModShift, true},
+	{vkRShift, action.ModShift, false},
+	{vkLControl, action.ModCtrl, true},
+	{vkRControl, action.ModCtrl, false},
+	{vkLMenu, action.ModAlt, true},
+	{vkRMenu, action.ModAlt, false},
+	{vkLWin, action.ModCmd, true},
+	{vkRWin, action.ModCmd, false},
+}
+
+// modifierKeysFrom reads every modifier key through down, which answers
+// whether a virtual key is held right now.
+func modifierKeysFrom(down func(vk uint32) bool) []modifierstate.Key {
+	keys := make([]modifierstate.Key, 0, len(windowsModifierKeys))
+
+	for _, key := range windowsModifierKeys {
+		keys = append(keys, modifierstate.Key{
+			Keycode:   uint32(key.key),
+			Modifier:  key.modifier,
+			Held:      down(uint32(key.key)),
+			Canonical: key.canonical,
+		})
+	}
+
+	return keys
+}
+
+// heldModifierKeycodes reports which modifier keys the keyboard holds right now.
+func heldModifierKeycodes() []uint32 {
+	var held []uint32
+
+	for _, key := range modifierKeysFrom(isVirtualKeyDown) {
+		if key.Held {
+			held = append(held, key.Keycode)
+		}
+	}
+
+	return held
+}
+
+// modifierHold is one injection's worth of falsified modifier state: what it
+// released so the injection would not carry it, and what it pressed so the
+// injection would.
+type modifierHold struct {
+	plan modifierstate.Plan
+}
+
+// holdModifiers makes the keyboard present exactly modifiers, and returns the
+// hold that undoes it.
+//
+// A SendInput wheel event carries no modifier field — unlike a CGEvent, which
+// takes flags — so whatever the keyboard holds rides along on every injected
+// event. A plain scroll_down bound to Ctrl+J arrives as ctrl+scroll, which most
+// applications read as zoom (#1483). The only way to present a set is to make
+// the keyboard actually hold it: release what is held and was not asked for,
+// press what was asked for and is not held, and undo both afterwards.
+//
+// A key already held that was asked for is left exactly as it is, because a key
+// is one bit of OS state rather than a count: pressing it a second time makes
+// the release afterwards tell every application the user let go while they are
+// still holding it.
+//
+// A key that fails to inject undoes what came before it, so a partial hold is
+// never left latched. The caller must release the hold on every path,
+// including failure: a modifier left released while the user is still holding
+// it drops that modifier from everything they do next.
+//
+// Every key this presses or releases carries neruInjectedTag, so the low-level
+// keyboard hook hands it on without reading it as the user tapping a modifier.
+func holdModifiers(modifiers action.Modifiers) (modifierHold, error) {
+	hold := modifierHold{plan: modifierstate.PlanFor(modifierKeysFrom(isVirtualKeyDown), modifiers)}
+
+	for index, edit := range hold.plan.Suppress {
+		err := sendKeyboardInput(uint16(edit.Keycode), true)
+		if err != nil {
+			hold.plan.Suppress = hold.plan.Suppress[:index]
+			hold.plan.Press = nil
+			hold.release()
+
+			return modifierHold{}, err
+		}
+	}
+
+	for index, edit := range hold.plan.Press {
+		err := sendKeyboardInput(uint16(edit.Keycode), false)
+		if err != nil {
+			hold.plan.Press = hold.plan.Press[:index]
+			hold.release()
+
+			return modifierHold{}, err
+		}
+	}
+
+	return hold, nil
+}
+
+// release lets go of what the hold pressed and presses back what it
+// suppressed, skipping any key that reads down again: something pressed it
+// after we let go, and a second press would leave a hold our release never
+// answers. A key the user let go of mid-injection reads up and is pressed back
+// regardless; the keyboard cannot tell that release from ours, and the window
+// is one synchronous injection wide.
+//
+// Errors are dropped: a release that fails has nothing better to try, and
+// reporting it would mask the outcome of the action it wraps.
+func (h modifierHold) release() {
+	for _, edit := range h.plan.Press {
+		_ = sendKeyboardInput(uint16(edit.Keycode), true)
+	}
+
+	if len(h.plan.Suppress) == 0 {
+		return
+	}
+
+	for _, edit := range h.plan.Restore(heldModifierKeycodes()) {
+		_ = sendKeyboardInput(uint16(edit.Keycode), false)
+	}
+}
+
+var errUnknownModifier = errors.New("unknown modifier")
+
+// PostModifierKey presses or releases the canonical key for one modifier, named
+// in Neru's vocabulary (shift, ctrl, alt, cmd), as if the user had.
+//
+// It is what the event tap's PostModifierEvent injects with: a sticky modifier
+// is a real key held on the user's behalf, and SendInput is the only way to
+// hold one. The event is tagged as Neru's own so the keyboard hook does not
+// read it back as a toggle.
+func PostModifierKey(modifier string, isDown bool) error {
+	var key uint16
+
+	switch modifier {
+	case modNameShift:
+		key = vkLShift
+	case modNameCtrl:
+		key = vkLControl
+	case modNameAlt:
+		key = vkLMenu
+	case modNameCmd:
+		key = vkLWin
+	default:
+		return fmt.Errorf("%w: %q", errUnknownModifier, modifier)
+	}
+
+	return sendKeyboardInput(key, !isDown)
+}

--- a/internal/adapter/platform/windows/modifiers_test.go
+++ b/internal/adapter/platform/windows/modifiers_test.go
@@ -1,0 +1,85 @@
+//go:build windows
+
+package windows
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/platform/modifierstate"
+	"github.com/y3owk1n/neru/internal/domain/action"
+)
+
+// keyboardHolding answers the key-state probe for a keyboard holding exactly
+// the given virtual keys.
+func keyboardHolding(keys ...uint16) func(uint32) bool {
+	return func(vk uint32) bool {
+		return slices.Contains(keys, uint16(vk))
+	}
+}
+
+func keycodes(edits []modifierstate.Edit) []uint32 {
+	codes := make([]uint32, 0, len(edits))
+	for _, edit := range edits {
+		codes = append(codes, edit.Keycode)
+	}
+
+	return codes
+}
+
+// A plain scroll bound to a ctrl chord has to release the ctrl the user is
+// holding for the length of the injection (#1483), and a modified scroll
+// fired with the modifier already down must not press it a second time.
+func TestModifierKeysFrom_PlansAgainstTheLiveKeyboard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		held         []uint16
+		requested    action.Modifiers
+		wantSuppress []uint32
+		wantPress    []uint32
+	}{
+		{
+			name:         "user-held ctrl is suppressed for a plain scroll",
+			held:         []uint16{vkLControl},
+			requested:    0,
+			wantSuppress: []uint32{vkLControl},
+		},
+		{
+			name:         "right-hand ctrl is suppressed too",
+			held:         []uint16{vkRControl},
+			requested:    0,
+			wantSuppress: []uint32{vkRControl},
+		},
+		{
+			name:      "held ctrl is left alone when asked for",
+			held:      []uint16{vkLControl},
+			requested: action.ModCtrl,
+		},
+		{
+			name:      "an unheld modifier is pressed on its canonical key",
+			requested: action.ModShift,
+			wantPress: []uint32{vkLShift},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			plan := modifierstate.PlanFor(
+				modifierKeysFrom(keyboardHolding(testCase.held...)),
+				testCase.requested,
+			)
+
+			if got := keycodes(plan.Suppress); !slices.Equal(got, testCase.wantSuppress) {
+				t.Errorf("Suppress = %#x, want %#x", got, testCase.wantSuppress)
+			}
+
+			if got := keycodes(plan.Press); !slices.Equal(got, testCase.wantPress) {
+				t.Errorf("Press = %#x, want %#x", got, testCase.wantPress)
+			}
+		})
+	}
+}

--- a/internal/config/platform_support.go
+++ b/internal/config/platform_support.go
@@ -27,9 +27,7 @@ const (
 	noteSmoothScroll = "the Windows scroll is injected in one step; macOS and Linux animate it, " +
 		"and on X11 the steps are whole wheel notches because X has no smaller scroll to send"
 	noteKeyboardLayout = "the keyboard layout is detected rather than chosen outside macOS"
-	notePassthrough    = "unbound modifier chords reach the focused application on macOS and " +
-		"on the Wayland evdev tap; X11 cannot pass them through at all and Windows does not"
-	noteMacOSSurfaces = "the menu bar, the Dock, Notification Center, Stage Manager, " +
+	noteMacOSSurfaces  = "the menu bar, the Dock, Notification Center, Stage Manager, " +
 		"picture-in-picture and the screen-capture chrome are macOS surfaces with no counterpart"
 	noteMissionControl = "Mission Control is a macOS concept, so the detection never fires " +
 		"and the hooks never run"
@@ -95,11 +93,6 @@ func PlatformSupport() parity.Declaration {
 		),
 		parity.On(parity.KindOption, darwinOnly, noteKeyboardLayout,
 			"general.kb_layout_to_use",
-		),
-		parity.On(parity.KindOption, darwinAndLinux, notePassthrough,
-			"general.passthrough_unbounded_keys",
-			"general.passthrough_unbounded_keys_blacklist",
-			"general.should_exit_after_passthrough",
 		),
 
 		parity.On(parity.KindOption, darwinOnly, noteMacOSSurfaces,
@@ -212,6 +205,15 @@ func PlatformSupport() parity.Declaration {
 			"hints.vision.link_min_width",
 			"hints.vision.image_min_size",
 			"hints.vision.checkbox_max_size",
+		),
+		// Unbound modifier chords reach the focused application on macOS, on
+		// the Wayland evdev tap and on Windows. X11 cannot pass them through
+		// at all, which is a display-server limit rather than a column: the
+		// blessed Linux stack is Wayland (Known Gaps, docs/CROSS_PLATFORM.md).
+		parity.Everywhere(parity.KindOption,
+			"general.passthrough_unbounded_keys",
+			"general.passthrough_unbounded_keys_blacklist",
+			"general.should_exit_after_passthrough",
 		),
 		parity.Everywhere(parity.KindOption,
 			"general.excluded_apps",

--- a/internal/ports/capability_presets.go
+++ b/internal/ports/capability_presets.go
@@ -187,7 +187,8 @@ func WindowsCapabilities() PlatformCapabilities {
 			"global hotkeys available via RegisterHotKey",
 		),
 		KeyboardEventTap: supportedCapability(
-			"keyboard event tap available via WH_KEYBOARD_LL hook",
+			"keyboard event tap available via WH_KEYBOARD_LL hook; unbound modifier " +
+				"shortcuts pass through to the focused application when asked to",
 		),
 		AppWatcher: supportedCapability(
 			"focused-app change detection keyed on the executable path, pushed by a " +


### PR DESCRIPTION
## Description

This PR makes modifier passthrough and `PostModifierEvent` real on Windows, and makes an injected scroll carry exactly the modifiers the action asked for.

**What changed**

- While a mode is open, the Windows tap now honours `general.passthrough_unbounded_keys`, its blacklist and the mode's own chords, and fires the passthrough callback, so `should_exit_after_passthrough` and the post-passthrough hint refresh work as on macOS.
- **Behaviour change:** an unbound Ctrl/Alt/Win chord (`Ctrl+C`, `Alt+Tab`, `Win+D`) is now consumed inside a mode unless `general.passthrough_unbounded_keys = true` (default `false`). Before, every such chord was forwarded to the application *and* dispatched to the mode at once. This is macOS parity.
- `PostModifierEvent` presses the canonical key through `SendInput`, tagged as Neru's own so the hook does not read it back as a sticky toggle.
- `ScrollWheel` presents exactly the requested modifiers through `platform/modifierstate`: a modifier the user is physically holding but the action did not ask for is released for the length of the injection and pressed back afterwards. A plain `scroll_down` bound to `Ctrl+J` no longer zooms.

**Why no SendInput replay.** The ticket assumed the hook swallows modifiers and asked for a replay around passthrough keys. It does not: a `WH_KEYBOARD_LL` hook forwards or blocks each event on its own, so an unbound chord is simply handed on as the real key event it is, with the real modifier state behind it. `docs/CROSS_PLATFORM.md` says so beside the Wayland explanation.

The first commit is a prefactor moving the order-independent chord canonicalizer out of the Linux tap into the shared `tap` package, unchanged, so both taps match blacklists the same way.

## Related Issues

Closes #1559
Relates to #1483

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — none needed; this replaces stubs
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a conventional commit subject written for users

## Additional Context

- Capability Matrix and Keyboard Capture tables read ✅ for Windows on modifier passthrough and `PostModifierEvent`; Known Gaps Windows entry "Modifier passthrough and `PostModifierEvent`" is removed and the list renumbered. The three `general.passthrough_*` options move to an everywhere declaration, so they leave the Platform Support Per Word table (the table is rebuilt by `just gensupportref`).
- The new Windows tests (`eventtap/windows/tap_passthrough_test.go`, `platform/windows/modifiers_test.go`) are `//go:build windows`, so they run only in the Windows CI job; `just check-cross` compiles them on other hosts. The passthrough journeys in `simulation_journey_test.go` are untagged and already run on Windows CI.
- Clicks on Windows still ignore their `modifiers` argument (`accessibility/native/windows/element.go`, `LeftClickAtPoint` and friends). Not touched here; it is a separate gap from the one this ticket names.
- One window the change opens, shared with the Linux backends: a user who releases a physically held Ctrl during the sub-millisecond scroll injection has it pressed back, and it reads held until their next tap. Restoring is the safer bias, since the opposite drops a held modifier from everything they type next.

