### PR TITLE
feat(windows): monitor_select mode

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -193,7 +193,7 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Native notifications**      | ✅ UNNotification        | ✅ `org.freedesktop.Notifications` | ✅ `org.freedesktop.Notifications` | ✅ `org.freedesktop.Notifications` | 🟡          |
 | **Secure input detection**    | ✅                       | ➖ always false        | ➖ always false              | ➖ always false         | ➖ always false              |
 | **System cursor hide**        | ✅ `CGDisplayHideCursor` | ➖                     | ➖                           | ➖                      | ➖                           |
-| **`monitor_select` mode**     | ✅ native panels         | ✅ Cairo panels        | ✅ Cairo panels              | ✅ Cairo panels         | 🟡 `CodeNotSupported`        |
+| **`monitor_select` mode**     | ✅ native panels         | ✅ Cairo panels        | ✅ Cairo panels              | ✅ Cairo panels         | ✅ layered panels            |
 | **Native hint-search field**  | ✅ NSTextField overlay   | 🟡 key-stream input ⁴  | 🟡 key-stream input ⁴        | 🟡 key-stream input ⁴   | 🟡 key-stream input ⁴        |
 | **Screen capture**            | ✅ ScreenCaptureKit      | ✅ `XGetImage`         | ✅ `wlr-screencopy`          | ⚠️ portal ScreenCast, consent ⁵ | ✅ `BitBlt` ⁵        |
 | **Vision / OCR detection**    | ✅ Vision framework      | ⚠️ tesseract, text only ⁶ | ⚠️ tesseract, text only ⁶ | ⚠️ tesseract, text only ⁶ | ⚠️ `Windows.Media.Ocr`, text only ⁶ |
@@ -906,7 +906,7 @@ important thing to know before touching overlay code:
 | **Always on top**     | `NSScreenSaverWindowLevel`               | `_NET_WM_STATE_ABOVE` + `MapRaised`    | overlay layer                                    | `HWND_TOPMOST`                     |
 | **Focus prevention**  | non-activating panel                     | `override_redirect=YES`                | controlled keyboard interactivity                | `WS_EX_NOACTIVATE`                 |
 | **HiDPI**             | dynamic `contentsScale` + backing-change callback | `Xft.dpi`, one global factor  | `wl_output` scale + `wp_fractional_scale_v1` / `wp_viewporter` | not explicit           |
-| **Multi-monitor**     | per-display clamping, screen-change tracking | all monitors enumerated, per-monitor render, live RandR hotplug | one `wl_surface` per output (max 16), live hotplug | cursor-screen tracking, live `WM_DISPLAYCHANGE` hotplug, separate indicator/sticky windows |
+| **Multi-monitor**     | per-display clamping, screen-change tracking | all monitors enumerated, per-monitor render, live RandR hotplug | one `wl_surface` per output (max 16), live hotplug | cursor-screen tracking, live `WM_DISPLAYCHANGE` hotplug, separate indicator/sticky windows, one panel window per display for monitor_select |
 | **Buffers**           | layer-backed, OS-managed                 | single Cairo surface                   | triple-buffered SHM pool                         | single pixel buffer                |
 | **Rounded rects / borders** | NSBezierPath                       | Cairo arc path + stroke                | Cairo arc path + stroke                          | software SDF fill + multi-pass stroke |
 | **Text**              | NSFontManager                            | Cairo `select_font_face` / `show_text` | Cairo `select_font_face` / `show_text`           | GDI `CreateFontW` + `DrawTextW` + alpha composite |
@@ -947,7 +947,7 @@ discovery rather than the mode itself.
 | **Recursive grid**| Virtual pointer indicator      | ✅                         | ✅                         | ✅                          |
 | **Recursive grid**| Sub-key preview                | ✅ mini-grid of next keys  | ✅ mini-grid of next keys  | ✅ mini-grid of next keys   |
 | **Scroll**        | Smooth scroll animation        | ✅                         | ✅ (X11: whole notches)    | ❌                          |
-| **Monitor select**| Whole mode                     | ✅ native panels           | ✅ Cairo panels            | 🟡 `CodeNotSupported`       |
+| **Monitor select**| Whole mode                     | ✅ native panels           | ✅ Cairo panels            | ✅ one layered window per display |
 
 Everything else is shared: multi-letter labels, label direction, hide-unmatched,
 split-word, interactive search *behavior* (only the on-screen badge differs),
@@ -1074,27 +1074,6 @@ green in every cell while an option means nothing, which is exactly how
 | `hints.vision.rectangle_max_aspect` | option | ✅ | ❌ | ❌ | rectangle detection has no OCR answer, so it stays macOS-only even where the vision strategy lands; that half is text-only |
 | `recursive_grid.animation.enabled` | option | ✅ | ✅ | ❌ | the Windows overlay backend has no grid transition animation |
 | `recursive_grid.animation.duration_ms` | option | ✅ | ✅ | ❌ | the Windows overlay backend has no grid transition animation |
-| `monitor_select.enabled` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.characters` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.font_size` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.font_family` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.border_radius` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.padding_x` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.padding_y` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.border_width` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.subtitle_font_size` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.subtitle_font_family` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.background_color` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.text_color` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.matched_text_color` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.border_color` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.backdrop_color` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `monitor_select.ui.subtitle_text_color` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `mode_indicator.monitor_select.enabled` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `mode_indicator.monitor_select.text` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `mode_indicator.monitor_select.background_color` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `mode_indicator.monitor_select.text_color` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
-| `mode_indicator.monitor_select.border_color` | option | ✅ | ✅ | ❌ | monitor_select needs the optional MonitorSelector overlay extension, which the Windows backend does not implement |
 | `smooth_cursor.move_mouse_enabled` | option | ✅ | ✅ | ❌ | cursor movement is not animated on Windows |
 | `smooth_cursor.steps` | option | ✅ | ✅ | ❌ | cursor movement is not animated on Windows |
 | `smooth_cursor.max_duration` | option | ✅ | ✅ | ❌ | cursor movement is not animated on Windows |
@@ -1206,11 +1185,10 @@ working, which is exactly why the build exists.
    `virtual_pointer.ui.*` is therefore partly inert here rather than wholly, so
    it stays declared everywhere and is tracked as this entry instead
 4. Smooth cursor and smooth scroll animation — not implemented
-5. `monitor_select` mode — returns `CodeNotSupported`
-6. Font resolution — alias mapping only, no system font enumeration
-7. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
+5. Font resolution — alias mapping only, no system font enumeration
+6. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
    installs a launchd agent and Linux a systemd user unit
-8. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
+7. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
     every platform, but only the Unix client checks that for itself before
     connecting. A named pipe carries no ownership a client can read without
     opening it, so the Windows CLI trusts the name it derives from its own SID.

--- a/internal/adapter/overlay/manager/manager.go
+++ b/internal/adapter/overlay/manager/manager.go
@@ -138,8 +138,8 @@ type MonitorSelectStyle struct {
 }
 
 // MonitorSelector is the optional extension a backend implements when it can
-// draw the monitor-select overlay. The darwin and Linux backends do; elsewhere
-// the mode reports CodeNotSupported.
+// draw the monitor-select overlay. Every shipped backend does; a backend
+// without it makes the mode report CodeNotSupported.
 type MonitorSelector interface {
 	DrawMonitorSelect(targets []MonitorSelectTarget, style MonitorSelectStyle) error
 	HideMonitorSelect()

--- a/internal/adapter/overlay/windows/manager.go
+++ b/internal/adapter/overlay/windows/manager.go
@@ -49,6 +49,10 @@ type Manager struct {
 
 	// mouseWin is a small dedicated layered window for mouse action indicators.
 	mouseWin *winplatform.OverlayWindow
+
+	// monitorWins are the monitor_select panels, one layered window per
+	// display, in target order (monitor_select.go).
+	monitorWins []*winplatform.OverlayWindow
 	// mouseActionCancel cancels any running mouse action animation.
 	mouseActionCancel context.CancelFunc
 }
@@ -206,6 +210,8 @@ func (m *Manager) Destroy() {
 		m.mouseWin.Destroy()
 		m.mouseWin = nil
 	}
+
+	m.destroyMonitorWindowsLocked()
 }
 
 // WindowPtr returns the native overlay window handle.

--- a/internal/adapter/overlay/windows/monitor_select.go
+++ b/internal/adapter/overlay/windows/monitor_select.go
@@ -176,9 +176,11 @@ func (m *Manager) DrawMonitorSelect(
 		subtitleRect = subtitleRect.Sub(target.Bounds.Min)
 
 		win.FillRoundedRect(panel, radius, background)
+
 		if borderWidth > 0 {
 			win.StrokeRoundedRect(panel, radius, border, borderWidth)
 		}
+
 		win.DrawTextCentered(target.Label, labelRect, style.FontFamily, labelFont, text)
 
 		if target.Subtitle != "" {

--- a/internal/adapter/overlay/windows/monitor_select.go
+++ b/internal/adapter/overlay/windows/monitor_select.go
@@ -136,7 +136,7 @@ func (m *Manager) DrawMonitorSelect(
 	border := badge.ParseHexARGB(style.BorderColor)
 	text := badge.ParseHexARGB(style.TextColor)
 	subtitleText := badge.ParseHexARGB(style.SubtitleTextColor)
-	borderWidth := float64(max(style.BorderWidth, 1))
+	borderWidth := float64(style.BorderWidth)
 	labelFont := monitorSelectFontOr(style.FontSize, monitorSelectDefaultFont)
 	subtitleFont := monitorSelectFontOr(style.SubtitleFontSize, monitorSelectDefaultSubFont)
 
@@ -176,7 +176,9 @@ func (m *Manager) DrawMonitorSelect(
 		subtitleRect = subtitleRect.Sub(target.Bounds.Min)
 
 		win.FillRoundedRect(panel, radius, background)
-		win.StrokeRoundedRect(panel, radius, border, borderWidth)
+		if borderWidth > 0 {
+			win.StrokeRoundedRect(panel, radius, border, borderWidth)
+		}
 		win.DrawTextCentered(target.Label, labelRect, style.FontFamily, labelFont, text)
 
 		if target.Subtitle != "" {

--- a/internal/adapter/overlay/windows/monitor_select.go
+++ b/internal/adapter/overlay/windows/monitor_select.go
@@ -1,0 +1,253 @@
+//go:build windows
+
+package windows
+
+import (
+	"image"
+	"math"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
+	winplatform "github.com/y3owk1n/neru/internal/adapter/platform/windows"
+)
+
+// Ensure the Windows manager implements the optional monitor-select extension.
+var _ manager.MonitorSelector = (*Manager)(nil)
+
+const (
+	// These mirror the macOS overlay (monitor_select_overlay_darwin.m) and the
+	// Linux Cairo panels so the picker looks the same on every platform: auto
+	// padding derived from the label font when the config uses the -1
+	// sentinel, a small label/subtitle gap, an 80% cap on panel size relative
+	// to the monitor, and default font sizes.
+	monitorSelectLabelGap       = 4
+	monitorSelectAutoPadXMin    = 24
+	monitorSelectAutoPadYMin    = 12
+	monitorSelectAutoPadXRatio  = 0.3
+	monitorSelectAutoPadYRatio  = 0.15
+	monitorSelectMaxFraction    = 0.8
+	monitorSelectMaxRadius      = 16.0
+	monitorSelectDefaultFont    = 96
+	monitorSelectDefaultSubFont = 18
+	monitorSelectHalfDivisor    = 2
+)
+
+// monitorSelectFontOr returns the configured font size, or a default when unset
+// (<= 0), matching the macOS overlay's fallbacks (96 label / 18 subtitle).
+func monitorSelectFontOr(value, fallback int) float64 {
+	if value <= 0 {
+		return float64(fallback)
+	}
+
+	return float64(value)
+}
+
+// monitorSelectPanelLayout computes, in global pixels, the panel rect centered
+// on the monitor, the label and subtitle text rects, and the corner radius.
+// It is the Linux layout at scale 1: the layered windows here are placed in
+// the physical pixels EnumDisplayMonitors reports, so there is no factor to
+// apply. Padding and radius honor the same "auto" (-1) config sentinels.
+func monitorSelectPanelLayout(
+	monitor image.Rectangle,
+	label, subtitle string,
+	style manager.MonitorSelectStyle,
+) (image.Rectangle, image.Rectangle, image.Rectangle, float64) {
+	labelFont := monitorSelectFontOr(style.FontSize, monitorSelectDefaultFont)
+	subFont := monitorSelectFontOr(style.SubtitleFontSize, monitorSelectDefaultSubFont)
+
+	padX := style.PaddingX
+	if style.PaddingX < 0 {
+		padX = max(monitorSelectAutoPadXMin, int(math.Round(labelFont*monitorSelectAutoPadXRatio)))
+	}
+
+	padY := style.PaddingY
+	if style.PaddingY < 0 {
+		padY = max(monitorSelectAutoPadYMin, int(math.Round(labelFont*monitorSelectAutoPadYRatio)))
+	}
+
+	labelW := badge.EstimateTextWidth(label, labelFont)
+	labelH := badge.EstimateTextHeight(labelFont)
+
+	subW, subH, gap := 0, 0, 0
+	if subtitle != "" {
+		subW = badge.EstimateTextWidth(subtitle, subFont)
+		subH = badge.EstimateTextHeight(subFont)
+		gap = monitorSelectLabelGap
+	}
+
+	panelW := max(labelW, subW) + padX*winPaddingMultiplier
+
+	panelH := labelH + padY*winPaddingMultiplier
+	if subtitle != "" {
+		panelH += subH + gap
+	}
+
+	panelW = min(panelW, int(float64(monitor.Dx())*monitorSelectMaxFraction))
+	panelH = min(panelH, int(float64(monitor.Dy())*monitorSelectMaxFraction))
+
+	center := image.Pt(
+		monitor.Min.X+monitor.Dx()/monitorSelectHalfDivisor,
+		monitor.Min.Y+monitor.Dy()/monitorSelectHalfDivisor,
+	)
+	panel := badge.CenteredOn(center, panelW, panelH)
+
+	radius := float64(style.BorderRadius)
+	if style.BorderRadius < 0 {
+		radius = math.Min(float64(panelH)/monitorSelectHalfDivisor, monitorSelectMaxRadius)
+	}
+
+	totalTextH := labelH
+	if subtitle != "" {
+		totalTextH += gap + subH
+	}
+
+	textTop := panel.Min.Y + (panelH-totalTextH)/monitorSelectHalfDivisor
+	labelRect := image.Rect(panel.Min.X, textTop, panel.Max.X, textTop+labelH)
+
+	subtitleRect := image.Rectangle{}
+	if subtitle != "" {
+		subTop := labelRect.Max.Y + gap
+		subtitleRect = image.Rect(panel.Min.X, subTop, panel.Max.X, subTop+subH)
+	}
+
+	return panel, labelRect, subtitleRect, radius
+}
+
+// DrawMonitorSelect renders one labeled panel per monitor for the interactive
+// monitor picker. Each target gets a layered window of its own covering that
+// monitor, the way macOS gives each display an NSPanel: the shared overlay is
+// sized to the active monitor only, and the picker has to reach every one.
+// Windows are kept between draws so a narrowing keystroke repaints in place,
+// and one left over from a display that went away is hidden rather than
+// destroyed, so the next draw with more targets does not recreate it.
+func (m *Manager) DrawMonitorSelect(
+	targets []manager.MonitorSelectTarget,
+	style manager.MonitorSelectStyle,
+) error {
+	m.renderMu.Lock()
+	defer m.renderMu.Unlock()
+
+	backdrop := badge.ParseHexARGB(style.BackdropColor)
+	hasBackdrop := strings.TrimSpace(style.BackdropColor) != ""
+	background := badge.ParseHexARGB(style.BackgroundColor)
+	border := badge.ParseHexARGB(style.BorderColor)
+	text := badge.ParseHexARGB(style.TextColor)
+	subtitleText := badge.ParseHexARGB(style.SubtitleTextColor)
+	borderWidth := float64(max(style.BorderWidth, 1))
+	labelFont := monitorSelectFontOr(style.FontSize, monitorSelectDefaultFont)
+	subtitleFont := monitorSelectFontOr(style.SubtitleFontSize, monitorSelectDefaultSubFont)
+
+	drawn := 0
+
+	for _, target := range targets {
+		if target.Bounds.Empty() {
+			continue
+		}
+
+		win, err := m.monitorWindowLocked(drawn, target.Bounds)
+		if err != nil {
+			// The adapter records a draw only when it succeeds, so a panel
+			// already shown here would outlive the refusal.
+			m.hideMonitorWindowsLocked()
+
+			return err
+		}
+
+		drawn++
+
+		// Every rect below is global; the window's own pixels start at the
+		// monitor's origin.
+		local := target.Bounds.Sub(target.Bounds.Min)
+
+		win.Clear()
+
+		if hasBackdrop {
+			win.FillRect(local, backdrop)
+		}
+
+		panel, labelRect, subtitleRect, radius := monitorSelectPanelLayout(
+			target.Bounds, target.Label, target.Subtitle, style,
+		)
+		panel = panel.Sub(target.Bounds.Min)
+		labelRect = labelRect.Sub(target.Bounds.Min)
+		subtitleRect = subtitleRect.Sub(target.Bounds.Min)
+
+		win.FillRoundedRect(panel, radius, background)
+		win.StrokeRoundedRect(panel, radius, border, borderWidth)
+		win.DrawTextCentered(target.Label, labelRect, style.FontFamily, labelFont, text)
+
+		if target.Subtitle != "" {
+			win.DrawTextCentered(
+				target.Subtitle, subtitleRect, style.SubtitleFontFamily, subtitleFont, subtitleText,
+			)
+		}
+
+		flushErr := win.Flush()
+		if flushErr != nil && m.logger != nil {
+			m.logger.Error("monitor_select panel flush failed", zap.Error(flushErr))
+		}
+
+		win.Show()
+	}
+
+	for _, win := range m.monitorWins[drawn:] {
+		win.Hide()
+	}
+
+	return nil
+}
+
+// monitorWindowLocked returns the panel window for the target at index,
+// covering bounds, creating or recreating it when there is none or the last
+// one is no longer healthy.
+func (m *Manager) monitorWindowLocked(
+	index int,
+	bounds image.Rectangle,
+) (*winplatform.OverlayWindow, error) {
+	if index < len(m.monitorWins) && m.monitorWins[index].Healthy() {
+		win := m.monitorWins[index]
+
+		return win, win.ResizeTo(bounds.Min.X, bounds.Min.Y, bounds.Dx(), bounds.Dy())
+	}
+
+	win, err := winplatform.NewOverlayWindowAt(bounds.Min.X, bounds.Min.Y, bounds.Dx(), bounds.Dy())
+	if err != nil {
+		return nil, err
+	}
+
+	if index < len(m.monitorWins) {
+		m.monitorWins[index].Destroy()
+		m.monitorWins[index] = win
+	} else {
+		m.monitorWins = append(m.monitorWins, win)
+	}
+
+	return win, nil
+}
+
+// HideMonitorSelect takes every panel window off the screen.
+func (m *Manager) HideMonitorSelect() {
+	m.renderMu.Lock()
+	defer m.renderMu.Unlock()
+
+	m.hideMonitorWindowsLocked()
+}
+
+func (m *Manager) hideMonitorWindowsLocked() {
+	for _, win := range m.monitorWins {
+		win.Hide()
+	}
+}
+
+// destroyMonitorWindowsLocked releases the panel windows. Called from Destroy
+// with renderMu held.
+func (m *Manager) destroyMonitorWindowsLocked() {
+	for _, win := range m.monitorWins {
+		win.Destroy()
+	}
+
+	m.monitorWins = nil
+}

--- a/internal/adapter/overlay/windows/monitor_select_test.go
+++ b/internal/adapter/overlay/windows/monitor_select_test.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package windows
+
+import (
+	"image"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+)
+
+func TestMonitorSelectPanelLayout_OddPanelWidthKeepsItsSize(t *testing.T) {
+	t.Parallel()
+
+	monitor := image.Rect(0, 0, 100, 100)
+	style := manager.MonitorSelectStyle{FontSize: 10}
+
+	panel, labelRect, subtitleRect, radius := monitorSelectPanelLayout(monitor, "A", "", style)
+
+	// Label 7 px wide, 14 px tall, no padding: a 7x14 panel centered on (50, 50).
+	if want := image.Rect(47, 43, 54, 57); panel != want {
+		t.Errorf("panel = %v, want %v", panel, want)
+	}
+
+	if want := image.Rect(47, 43, 54, 57); labelRect != want {
+		t.Errorf("label rect = %v, want %v", labelRect, want)
+	}
+
+	if !subtitleRect.Empty() {
+		t.Errorf("subtitle rect = %v, want empty", subtitleRect)
+	}
+
+	if radius != 0 {
+		t.Errorf("radius = %v, want 0", radius)
+	}
+}
+
+func TestMonitorSelectPanelLayout_PanelHangsOnItsOwnMonitor(t *testing.T) {
+	t.Parallel()
+
+	// A second display to the right of the first: the panel must land on it,
+	// not on the primary.
+	monitor := image.Rect(1920, 0, 3840, 1080)
+	style := manager.MonitorSelectStyle{FontSize: 10}
+
+	panel, labelRect, _, _ := monitorSelectPanelLayout(monitor, "A", "", style)
+
+	if want := image.Rect(2877, 533, 2884, 547); panel != want {
+		t.Errorf("panel = %v, want %v", panel, want)
+	}
+
+	if labelRect != panel {
+		t.Errorf("label rect = %v, want the panel %v", labelRect, panel)
+	}
+}

--- a/internal/config/platform_support.go
+++ b/internal/config/platform_support.go
@@ -21,10 +21,8 @@ const (
 	noteVisionRectangles = "rectangle detection has no OCR answer, so it stays macOS-only " +
 		"even where the vision strategy lands; that half is text-only"
 	noteRecursiveGridAnimation = "the Windows overlay backend has no grid transition animation"
-	noteMonitorSelect          = "monitor_select needs the optional MonitorSelector overlay " +
-		"extension, which the Windows backend does not implement"
-	noteSmoothCursor = "cursor movement is not animated on Windows"
-	noteSmoothScroll = "the Windows scroll is injected in one step; macOS and Linux animate it, " +
+	noteSmoothCursor           = "cursor movement is not animated on Windows"
+	noteSmoothScroll           = "the Windows scroll is injected in one step; macOS and Linux animate it, " +
 		"and on X11 the steps are whole wheel notches because X has no smaller scroll to send"
 	noteKeyboardLayout = "the keyboard layout is detected rather than chosen outside macOS"
 	noteMacOSSurfaces  = "the menu bar, the Dock, Notification Center, Stage Manager, " +
@@ -150,7 +148,7 @@ func PlatformSupport() parity.Declaration {
 			"recursive_grid.animation.duration_ms",
 		),
 
-		parity.On(parity.KindOption, darwinAndLinux, noteMonitorSelect,
+		parity.Everywhere(parity.KindOption,
 			"monitor_select.enabled",
 			"monitor_select.characters",
 			"monitor_select.ui.font_size",

--- a/internal/config/platform_support_test.go
+++ b/internal/config/platform_support_test.go
@@ -56,11 +56,6 @@ func TestPlatformSupport_DeclaresTheKnownNarrowColumns(t *testing.T) {
 			parity.Platforms{parity.Darwin, parity.Linux},
 		},
 		{
-			"monitor_select has no Windows overlay extension",
-			"monitor_select.enabled", "",
-			parity.Platforms{parity.Darwin, parity.Linux},
-		},
-		{
 			"smooth cursor is not animated on Windows",
 			"smooth_cursor.steps", "",
 			parity.Platforms{parity.Darwin, parity.Linux},
@@ -142,12 +137,6 @@ func TestInertWords_Options(t *testing.T) {
 			written: map[string]string{visionMinConfidence: "0.5"},
 			target:  parity.Windows,
 			want:    []string{visionMinConfidence},
-		},
-		{
-			name:    "a leaf below a color reports the color",
-			written: map[string]string{"monitor_select.ui.background_color.light": "#fff"},
-			target:  parity.Windows,
-			want:    []string{"monitor_select.ui.background_color"},
 		},
 		{
 			name:    "an option inert only on Windows is silent on Linux",


### PR DESCRIPTION
## Description

This PR adds the monitor_select mode on Windows. Activating it draws one labelled panel per display, centred on that display, with the optional backdrop, border and subtitle the macOS and Linux pickers draw, and typing a label moves the cursor to that monitor's centre. Until now the mode refused to activate on Windows and every `monitor_select.*` option was inert there.

Each panel is its own layered window covering its monitor, the way macOS gives each display a panel. The shared overlay window only ever covers the active monitor, so the picker cannot draw on it. Panel windows are kept between keystrokes and hidden when the mode exits, so narrowing the label repaints in place.

## Related Issues

Closes #1560

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this replaces the last stub: the extension is now implemented on every shipped backend
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Config and command changes

No option, command or flag is added, renamed or removed. Every `monitor_select.*` and `mode_indicator.monitor_select.*` option now does on Windows what it does on macOS and Linux, so a Windows config that already wrote them stops receiving the inert-option warning at load. Existing configs keep working.

## Screenshots / Recordings

Not captured: this was developed on macOS, where the Windows overlay cannot run. `just lint-cross` and the Windows test binaries compile clean, and CI runs the unit tests natively on `windows-latest`.

## Additional Context

The panel layout is the Linux Cairo layout at scale 1 and is pinned by the same test, so the three platforms share padding, size cap and radius rules. The panel window coordinates come straight from the display bounds the enumeration reports, which are already the global top-left pixels shared code uses.

Two parity-test cases went with the last narrow colour option: the case that pinned monitor_select to macOS and Linux, and the case that used its background colour as the example of a leaf below a colour reporting the colour. No narrow colour option remains to stand in for the latter.
