### PR TITLE
feat(windows): smooth cursor animation, including relative moves

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -179,7 +179,7 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Mouse buttons / drag**      | ✅ `CGEventPost`         | ✅ XTest ⁷             | ✅ `zwlr_virtual_pointer`    | ✅ libei                | ✅ `SendInput`               |
 | **Scroll injection**          | ✅ both axes             | ✅ both axes ⁷         | ✅ both axes (uinput + virtual pointer) | ✅ libei     | ✅ both axes                 |
 | **Modified scroll (`--modifier`)** | ✅ `CGEventSetFlags` on every chunk | ✅ XTest key hold ⁷ | ✅ virtual keyboard, uinput batch skipped (kept on Hyprland ⁹) | ✅ libei | ✅ `SendInput` key hold |
-| **Smooth cursor animation**   | ✅ (incl. relative, opt-in) | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ❌                        |
+| **Smooth cursor animation**   | ✅ (incl. relative, opt-in) | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in |
 | **Smooth scroll animation**   | ✅                       | ⚠️ whole notches only ³ | ✅ continuous virtual-pointer axis ³ (whole notches when modified on Hyprland ⁹) | ⚠️ libei scroll delta, unverified ³ | ❌       |
 | **Element discovery (hints)** | ✅ AXUIElement           | ⚠️ AT-SPI walk         | ⚠️ AT-SPI walk               | ⚠️ AT-SPI walk          | ⚠️ UIA, control view only    |
 | **Overlay**                   | ✅ NSPanel + CoreAnimation | ✅ X11 + Cairo       | ✅ layer-shell + Cairo       | ✅ layer-shell + Cairo  | ✅ DirectComposition + Direct2D (GDI fallback; windows/arm64 is GDI only ⁷) |
@@ -925,7 +925,7 @@ important thing to know before touching overlay code:
 | ---------------------------- | ------------------------------------ | ---------------------------------- | ---------------------------------- |
 | **Grid transition**          | NSTimer @120Hz, ease-in-out, full redraw | goroutine, ease-in-out @120fps  | goroutine, ease-in-out @120fps, presented on the UI thread |
 | **Mouse action indicator**   | `CABasicAnimation` (scale + opacity) | goroutine, scale + opacity @120fps | goroutine, cubic easing @60fps     |
-| **Smooth cursor**            | ✅ stepped linear interpolation      | ✅ stepped linear interpolation    | ❌                                 |
+| **Smooth cursor**            | ✅ stepped linear interpolation      | ✅ stepped linear interpolation    | ✅ stepped linear interpolation    |
 | **Smooth scroll**            | ✅ ease-out cubic                    | ❌                                 | ❌                                 |
 
 ---
@@ -1077,11 +1077,6 @@ green in every cell while an option means nothing, which is exactly how
 | `hints.vision.rectangle_min_size` | option | ✅ | ❌ | ❌ | rectangle detection has no OCR answer, so it stays macOS-only even where the vision strategy lands; that half is text-only |
 | `hints.vision.rectangle_min_aspect` | option | ✅ | ❌ | ❌ | rectangle detection has no OCR answer, so it stays macOS-only even where the vision strategy lands; that half is text-only |
 | `hints.vision.rectangle_max_aspect` | option | ✅ | ❌ | ❌ | rectangle detection has no OCR answer, so it stays macOS-only even where the vision strategy lands; that half is text-only |
-| `smooth_cursor.move_mouse_enabled` | option | ✅ | ✅ | ❌ | cursor movement is not animated on Windows |
-| `smooth_cursor.steps` | option | ✅ | ✅ | ❌ | cursor movement is not animated on Windows |
-| `smooth_cursor.max_duration` | option | ✅ | ✅ | ❌ | cursor movement is not animated on Windows |
-| `smooth_cursor.duration_per_pixel` | option | ✅ | ✅ | ❌ | cursor movement is not animated on Windows |
-| `smooth_cursor.relative_movement_duration` | option | ✅ | ✅ | ❌ | cursor movement is not animated on Windows |
 | `smooth_scroll.enabled` | option | ✅ | ✅ | ❌ | the Windows scroll is injected in one step; macOS and Linux animate it, and on X11 the steps are whole wheel notches because X has no smaller scroll to send |
 | `smooth_scroll.steps` | option | ✅ | ✅ | ❌ | the Windows scroll is injected in one step; macOS and Linux animate it, and on X11 the steps are whole wheel notches because X has no smaller scroll to send |
 | `smooth_scroll.max_duration` | option | ✅ | ✅ | ❌ | the Windows scroll is injected in one step; macOS and Linux animate it, and on X11 the steps are whole wheel notches because X has no smaller scroll to send |
@@ -1183,7 +1178,7 @@ working, which is exactly why the build exists.
 **Windows**
 
 1. Native notifications — no toast support
-2. Smooth cursor and smooth scroll animation — not implemented
+2. Smooth scroll animation — not implemented
 3. Font resolution — alias mapping only, no system font enumeration
 4. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
    installs a launchd agent and Linux a systemd user unit
@@ -1708,6 +1703,19 @@ Windows is one backend family with alpha-level support. Prefer:
 Do not introduce additional Windows backend naming until there is a real reason.
 See [Known Gaps](#known-gaps) for the current Windows to-do list — several
 entries there are well-scoped starter tasks.
+
+**Smooth cursor animation on Windows.** Off by default; opt in with
+`smooth_cursor.move_mouse_enabled`, the same `SmoothCursorConfig` macOS and
+Linux read. When enabled, `SystemAdapter.MoveCursorToPoint` routes through
+`smoothCursorAnimator`
+([mouse_animator.go](../internal/adapter/platform/windows/mouse_animator.go)),
+the Linux animator's shape with `SetCursorPos` as the sink: one worker
+goroutine samples `GetCursorPos` once per request, then steps toward the target
+by linear interpolation, coalescing so the latest target wins, and
+`WaitForCursorIdle` blocks until it settles. Relative (hjkl) moves extend the
+pending endpoint over the fixed per-move duration
+`smooth_cursor.relative_movement_duration`, clamped to the active screen, and
+position-dependent actions settle the in-flight animation before acting.
 
 ## CGO Guidance
 

--- a/internal/adapter/platform/windows/config_provider.go
+++ b/internal/adapter/platform/windows/config_provider.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package windows
+
+import (
+	"sync"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// configProvider is a process-global runtime config source for the Windows
+// system adapter, mirroring the darwin and linux config-provider slots. It is
+// set once at daemon startup (see internal/app/runtime_config_windows.go) and
+// read by the smooth cursor path. A nil provider (tests, or before wiring)
+// means "no config", so callers fall back to the direct, non-animated move.
+var (
+	configProviderMu sync.RWMutex
+	configProvider   config.Provider
+)
+
+// SetConfigProvider updates the runtime config provider used by the Windows
+// system adapter's smooth-cursor path.
+func SetConfigProvider(provider config.Provider) {
+	configProviderMu.Lock()
+	configProvider = provider
+	configProviderMu.Unlock()
+}
+
+// currentWindowsConfig returns the latest config snapshot, or nil when no
+// provider has been wired yet.
+func currentWindowsConfig() *config.Config {
+	configProviderMu.RLock()
+
+	provider := configProvider
+
+	configProviderMu.RUnlock()
+
+	if provider == nil {
+		return nil
+	}
+
+	return provider.Get()
+}

--- a/internal/adapter/platform/windows/mouse_animator.go
+++ b/internal/adapter/platform/windows/mouse_animator.go
@@ -1,0 +1,501 @@
+//go:build windows
+
+package windows
+
+import (
+	"context"
+	"image"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// The animation floor itself is not declared here: every smooth-cursor
+// animation is floored at config.MinSmoothCursorAnimationDuration, the same
+// constant ValidateSmoothCursor rejects a shorter relative_movement_duration
+// against, so the validator and the animator cannot disagree about what the
+// daemon will honor. The darwin and linux animators read it the same way.
+const (
+	// minCursorStepDelay is the shortest gap between injected steps — a
+	// scheduling floor on this animator's own timer, not a config value. No
+	// config option declares it and none derives from it (darwin likewise
+	// keeps its own minStepDelay local), so there is nothing here for a
+	// config change to desync from and it stays local.
+	minCursorStepDelay = 1 // ms
+	// defaultCursorSteps is the step count used when a caller passes none
+	// (<= 0). It equals config.DefaultSmoothCursorSteps today, and that is a
+	// coincidence rather than a derivation: both smooth-cursor call sites
+	// pass cfg.SmoothCursor.Steps, which ValidateSmoothCursor already
+	// requires to be >= 1, so no validated config can reach this fallback at
+	// all. It answers a different question — what step count to use for a
+	// caller that supplied a nonsense one — and moving the config default
+	// must not move it.
+	defaultCursorSteps = 10
+)
+
+// cursorAnimationDone is a once-closable completion signal shared with
+// WaitForCursorIdle. It mirrors the darwin animator's done channel so callers
+// can block until the cursor settles.
+type cursorAnimationDone struct {
+	ch   chan struct{}
+	once sync.Once
+}
+
+func newCursorAnimationDone() *cursorAnimationDone {
+	return &cursorAnimationDone{ch: make(chan struct{})}
+}
+
+func (d *cursorAnimationDone) close() {
+	if d == nil {
+		return
+	}
+
+	d.once.Do(func() {
+		close(d.ch)
+	})
+}
+
+// cursorRequest is a single "animate to end" target. It carries no completion
+// object of its own: completion is tracked per animation *session* (see
+// smoothCursorAnimator), so coalescing a superseded target never releases a
+// waiter early.
+type cursorRequest struct {
+	end              image.Point
+	steps            int
+	maxDuration      int
+	durationPerPixel float64
+	fixedDuration    int // when > 0, overrides the distance-derived duration
+}
+
+// smoothCursorAnimator glides the cursor toward a target, matching the darwin
+// animator: one worker goroutine, latest-target-wins, a completion channel
+// WaitForCursorIdle blocks on. Callers do not serialize cursor access, so a
+// direct move cancels an in-flight animation; stop() fences on injectSem so a
+// canceled tween can never land after the warp. Backend errors mid-animation
+// are dropped (darwin's native move cannot fail back to Go either); the direct
+// MoveCursorToPoint path still returns them.
+//
+// Completion is per session — every target arriving mid-session shares one
+// completion, so a waiter tracks the latest target rather than being released
+// when an intermediate one is superseded. pos and move are injected to keep
+// the Win32 calls out; pos samples once per request, so a bad GetCursorPos
+// read affects the glide path but never where the cursor lands.
+type smoothCursorAnimator struct {
+	pos  func() image.Point
+	move func(image.Point) error
+
+	mu     sync.Mutex
+	reqCh  chan cursorRequest
+	stopCh chan struct{}
+	done   *cursorAnimationDone // current session completion; nil only between stop() and the next session
+	busy   bool                 // a session is in progress (worker actively draining toward a target)
+
+	// pendingEnd is the target of the animation currently in flight. Relative
+	// moves extend it instead of restarting from the (possibly stale) cursor
+	// position, so no part of a delta is lost under key repeat.
+	pendingEnd image.Point
+	hasPending bool
+
+	// injectSem is a size-1 semaphore serializing actual backend injection (one
+	// step at a time) and is the ordering handoff to stop(): the worker holds it
+	// across each step and re-checks stopCh under it, so once stop() acquires it
+	// no canceled step is mid-flight and none will start. It is never held
+	// together with mu.
+	injectSem chan struct{}
+}
+
+func newSmoothCursorAnimator(
+	pos func() image.Point,
+	move func(image.Point) error,
+) *smoothCursorAnimator {
+	return &smoothCursorAnimator{
+		pos:       pos,
+		move:      move,
+		injectSem: make(chan struct{}, 1),
+	}
+}
+
+// stop cancels any in-flight animation and releases waiters. It is called on
+// the non-smooth move path so a direct warp always wins over a running tween.
+// It detaches the current worker via stopCh so a stale worker cannot mutate a
+// later session.
+func (a *smoothCursorAnimator) stop() {
+	a.mu.Lock()
+	stopCh := a.stopCh
+	done := a.done
+	a.reqCh = nil
+	a.stopCh = nil
+	a.done = nil
+	a.busy = false
+	a.hasPending = false
+
+	if stopCh != nil {
+		close(stopCh)
+	}
+	a.mu.Unlock()
+
+	done.close()
+
+	// Order a bypassed direct warp after any in-flight animation step. stopCh is
+	// already closed above, so once we hold injectSem: any step that was
+	// mid-injection has finished (it releases the token on the way out), and any
+	// step that has not yet injected will see the closed stopCh (in stepMove) and
+	// skip. The caller's subsequent moveCursorDirect therefore lands last.
+	a.injectSem <- struct{}{}
+
+	<-a.injectSem
+}
+
+// pendingTarget returns the endpoint of the animation currently in flight,
+// or ok == false when no animation is active.
+func (a *smoothCursorAnimator) pendingTarget() (image.Point, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.pendingEnd, a.hasPending
+}
+
+// settle finishes any in-flight animation immediately: the worker is canceled
+// and the cursor warps straight to the endpoint it was animating toward.
+// Position-dependent actions call this so an action firing mid-animation acts
+// at the point the user aimed for, without waiting the animation out. The
+// warp happens under injectSem — the same fence stop() uses — so a canceled
+// step can never land after it.
+func (a *smoothCursorAnimator) settle() {
+	a.mu.Lock()
+
+	if !a.hasPending {
+		a.mu.Unlock()
+
+		return
+	}
+
+	end := a.pendingEnd
+	stopCh := a.stopCh
+	done := a.done
+	a.reqCh = nil
+	a.stopCh = nil
+	a.done = nil
+	a.busy = false
+	a.hasPending = false
+
+	if stopCh != nil {
+		close(stopCh)
+	}
+	a.mu.Unlock()
+
+	done.close()
+
+	a.injectSem <- struct{}{}
+
+	_ = a.move(end)
+
+	<-a.injectSem
+}
+
+// stepMove injects one animation step while holding injectSem, re-checking
+// stopCh so a step cannot inject once the session is stopped. This, paired with
+// stop()'s injectSem barrier, guarantees a canceled tween never warps the cursor
+// after a bypassed direct move. It returns false when the step was skipped due
+// to stop.
+func (a *smoothCursorAnimator) stepMove(point image.Point, stopCh <-chan struct{}) bool {
+	a.injectSem <- struct{}{}
+	defer func() { <-a.injectSem }()
+
+	select {
+	case <-stopCh:
+		return false
+	default:
+	}
+
+	// Best-effort, matching darwin (whose native move cannot fail back to Go):
+	// a failed backend warp during the opt-in animation is not surfaced through
+	// WaitForCursorIdle. The direct MoveCursorToPoint path still returns backend
+	// errors synchronously.
+	_ = a.move(point)
+
+	return true
+}
+
+// wait blocks until the current session settles or ctx is canceled. It returns
+// immediately when no session is active, preserving the historical
+// "WaitForCursorIdle is a no-op on Windows" behavior for the non-smooth path.
+func (a *smoothCursorAnimator) wait(ctx context.Context) error {
+	a.mu.Lock()
+	done := a.done
+	a.mu.Unlock()
+
+	if done == nil {
+		return nil
+	}
+
+	select {
+	case <-done.ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// animateTo enqueues an animation toward end. A fresh session completion is
+// created only when the animator is idle; a target arriving mid-session joins
+// the running session so its waiter tracks the latest target.
+//
+// Worker start and enqueue happen under a.mu in one critical section. This is
+// what makes it safe against a concurrent stop(): a bypassed move can never
+// swap out the channel or kill the worker between "pick a channel" and "send",
+// so a request can never be stranded on an orphaned channel. Because every
+// producer holds the lock and the worker is the sole consumer of the size-1
+// buffer, the enqueue is always non-blocking.
+func (a *smoothCursorAnimator) animateTo(
+	end image.Point,
+	steps, maxDuration int,
+	durationPerPixel float64,
+) {
+	req := cursorRequest{
+		end:              end,
+		steps:            steps,
+		maxDuration:      maxDuration,
+		durationPerPixel: durationPerPixel,
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.submitLocked(req)
+}
+
+// animateRelativeBy animates a relative move with a fixed duration,
+// independent of the distance, so that cursor speed scales with the per-move
+// delta instead of collapsing to the constant velocity the
+// distance-proportional duration would produce.
+//
+// The base is the pending endpoint of the animation in flight (falling back
+// to the sampled cursor position), extended by delta and clamped by the
+// caller's clamp. Base computation, bookkeeping, and submission all happen
+// under one lock hold, so two concurrent relative movers compose their deltas
+// instead of one silently overwriting the other's endpoint.
+func (a *smoothCursorAnimator) animateRelativeBy(
+	delta image.Point,
+	clamp func(image.Point) image.Point,
+	steps int,
+	durationMs int,
+) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	base := a.pendingEnd
+	if !a.hasPending {
+		base = a.pos()
+	}
+
+	end := clamp(base.Add(delta))
+	if end == base {
+		// Nothing to animate: the delta was zero or the clamp ate it at a
+		// screen edge. The in-flight animation (if any) already targets base,
+		// so submitting would only cancel and restart it.
+		return
+	}
+
+	a.submitLocked(cursorRequest{
+		end:           end,
+		steps:         steps,
+		fixedDuration: durationMs,
+	})
+}
+
+// submitLocked records req as the pending animation target and hands it to
+// the worker, starting the worker and a fresh session completion when needed.
+// Callers must hold a.mu.
+func (a *smoothCursorAnimator) submitLocked(req cursorRequest) {
+	if a.reqCh == nil {
+		a.reqCh = make(chan cursorRequest, 1)
+		a.stopCh = make(chan struct{})
+
+		go a.run(a.reqCh, a.stopCh)
+	}
+
+	if !a.busy {
+		a.done = newCursorAnimationDone()
+		a.busy = true
+	}
+
+	a.pendingEnd = req.end
+	a.hasPending = true
+
+	a.enqueueLocked(req)
+}
+
+// enqueueLocked places req on the worker channel, coalescing so only the latest
+// target survives. The caller must hold a.mu.
+//
+// The buffer is size 1 and, under the lock, we are the only producer while the
+// worker is the only consumer (it removes, never adds). So after draining a
+// stale target the buffer is empty and the follow-up send cannot block. Targets
+// carry no completion object, so dropping a superseded one is a plain discard —
+// the shared session completion is untouched.
+func (a *smoothCursorAnimator) enqueueLocked(req cursorRequest) {
+	select {
+	case a.reqCh <- req:
+		return
+	default:
+	}
+
+	select {
+	case <-a.reqCh:
+	default:
+	}
+
+	select {
+	case a.reqCh <- req:
+	default:
+	}
+}
+
+func (a *smoothCursorAnimator) run(reqCh <-chan cursorRequest, stopCh <-chan struct{}) {
+	timer := time.NewTimer(time.Hour)
+
+	stopAndDrainTimer(timer)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		case req := <-reqCh:
+			a.runRequest(req, reqCh, stopCh, timer)
+		}
+	}
+}
+
+func (a *smoothCursorAnimator) runRequest(
+	req cursorRequest,
+	reqCh <-chan cursorRequest,
+	stopCh <-chan struct{},
+	timer *time.Timer,
+) {
+restart:
+	start := a.pos()
+
+	distance := math.Hypot(float64(req.end.X-start.X), float64(req.end.Y-start.Y))
+
+	duration := math.Min(float64(req.maxDuration), distance*req.durationPerPixel)
+	if req.fixedDuration > 0 {
+		duration = float64(req.fixedDuration)
+	}
+
+	if duration < config.MinSmoothCursorAnimationDuration {
+		duration = config.MinSmoothCursorAnimationDuration
+	}
+
+	actualSteps := req.steps
+	if actualSteps <= 0 {
+		actualSteps = defaultCursorSteps
+	}
+
+	maxSteps := max(int(duration/float64(minCursorStepDelay)), 1)
+	if actualSteps > maxSteps {
+		actualSteps = maxSteps
+	}
+
+	stepDelayMs := max(int(math.Round(duration/float64(actualSteps))), minCursorStepDelay)
+	stepDelay := time.Duration(stepDelayMs) * time.Millisecond
+
+	for step := 1; step <= actualSteps; step++ {
+		select {
+		case <-stopCh:
+			return
+		case nextReq := <-reqCh:
+			req = nextReq
+
+			goto restart
+		default:
+		}
+
+		progress := float64(step) / float64(actualSteps)
+		intermediate := image.Point{
+			X: int(float64(start.X) + float64(req.end.X-start.X)*progress),
+			Y: int(float64(start.Y) + float64(req.end.Y-start.Y)*progress),
+		}
+
+		if !a.stepMove(intermediate, stopCh) {
+			return
+		}
+
+		if step < actualSteps {
+			timer.Reset(stepDelay)
+
+			select {
+			case <-stopCh:
+				stopAndDrainTimer(timer)
+
+				return
+			case nextReq := <-reqCh:
+				stopAndDrainTimer(timer)
+
+				req = nextReq
+
+				goto restart
+			case <-timer.C:
+			}
+		}
+	}
+
+	// Target reached. Continue the same session if a newer target is already
+	// queued; otherwise the session ends.
+	next, ok := a.finishOrNext(reqCh, stopCh)
+	if ok {
+		req = next
+
+		goto restart
+	}
+}
+
+// finishOrNext, called after a target is reached, either hands back the next
+// queued target to continue the current session, or ends the session by closing
+// its completion (keeping a.done referencing the closed completion so a late
+// WaitForCursorIdle still sees "idle"). It no-ops when this worker has been
+// superseded by a stop()/restart, detected via stopCh identity, so a stale
+// worker never closes a newer session's completion.
+func (a *smoothCursorAnimator) finishOrNext(
+	reqCh <-chan cursorRequest,
+	stopCh <-chan struct{},
+) (cursorRequest, bool) {
+	a.mu.Lock()
+
+	if a.stopCh != stopCh {
+		a.mu.Unlock()
+
+		return cursorRequest{}, false
+	}
+
+	select {
+	case next := <-reqCh:
+		a.mu.Unlock()
+
+		return next, true
+	default:
+	}
+
+	done := a.done
+	a.busy = false
+	a.hasPending = false
+	a.mu.Unlock()
+
+	done.close()
+
+	return cursorRequest{}, false
+}
+
+// stopAndDrainTimer stops timer and clears any pending tick so the next Reset
+// starts clean.
+func stopAndDrainTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}

--- a/internal/adapter/platform/windows/mouse_animator_test.go
+++ b/internal/adapter/platform/windows/mouse_animator_test.go
@@ -1,0 +1,570 @@
+//go:build windows
+
+package windows
+
+import (
+	"context"
+	"image"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// recorder captures the moves an animator injects so tests can assert on the
+// glide path and final landing point without touching a real display server.
+type recorder struct {
+	mu    sync.Mutex
+	moves []image.Point
+	start image.Point
+}
+
+func (r *recorder) pos() image.Point {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.moves) > 0 {
+		return r.moves[len(r.moves)-1]
+	}
+
+	return r.start
+}
+
+func (r *recorder) move(p image.Point) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.moves = append(r.moves, p)
+
+	return nil
+}
+
+func (r *recorder) last() (image.Point, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.moves) == 0 {
+		return image.Point{}, false
+	}
+
+	return r.moves[len(r.moves)-1], true
+}
+
+func (r *recorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.moves)
+}
+
+func TestSmoothCursorAnimatorLandsOnTarget(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{start: image.Point{X: 0, Y: 0}}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	target := image.Point{X: 300, Y: 200}
+	animator.animateTo(target, 8, 60, 0.1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	last, ok := rec.last()
+	if !ok {
+		t.Fatal("expected at least one move to be injected")
+	}
+
+	if last != target {
+		t.Fatalf("cursor did not land on target: got %v want %v", last, target)
+	}
+
+	if rec.count() < 2 {
+		t.Fatalf("expected a stepped glide (>=2 moves), got %d", rec.count())
+	}
+}
+
+// TestSmoothCursorAnimatorFloorsShortAnimationsAtConfigMinimum pins the floor
+// this animator applies to config.MinSmoothCursorAnimationDuration — the same
+// constant ValidateSmoothCursor rejects a shorter relative_movement_duration
+// against, so the value the validator promises to honor is the value the
+// animator honors.
+//
+// It reads the floor back out of behavior rather than comparing constants: a
+// below-floor duration asked for in far more steps than the floor can schedule
+// collapses to one step per minCursorStepDelay of the floor, so the number of
+// injected moves *is* the floor. Move the config constant and this expectation
+// moves with it; re-introduce a local copy that disagrees and this fails.
+func TestSmoothCursorAnimatorFloorsShortAnimationsAtConfigMinimum(t *testing.T) {
+	t.Parallel()
+
+	wantSteps := config.MinSmoothCursorAnimationDuration / minCursorStepDelay
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	animator.animateRelativeBy(
+		image.Point{X: 4 * wantSteps, Y: 0},
+		func(point image.Point) image.Point { return point },
+		wantSteps*100,
+		1,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	if got := rec.count(); got != wantSteps {
+		t.Fatalf(
+			"injected %d steps for a below-floor animation, want %d "+
+				"(config.MinSmoothCursorAnimationDuration / minCursorStepDelay)",
+			got,
+			wantSteps,
+		)
+	}
+}
+
+func TestSmoothCursorAnimatorCoalescesToLatestTarget(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{start: image.Point{X: 0, Y: 0}}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	// Fire several requests back-to-back; only the last target must win.
+	animator.animateTo(image.Point{X: 100, Y: 100}, 10, 80, 0.5)
+	animator.animateTo(image.Point{X: 500, Y: 50}, 10, 80, 0.5)
+	final := image.Point{X: 640, Y: 480}
+	animator.animateTo(final, 10, 80, 0.5)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	last, ok := rec.last()
+	if !ok {
+		t.Fatal("expected at least one move to be injected")
+	}
+
+	if last != final {
+		t.Fatalf("coalesced animation landed on %v, want latest target %v", last, final)
+	}
+}
+
+func TestSmoothCursorAnimatorWaitReturnsWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	// No animation started: wait must return immediately, preserving the
+	// historical no-op WaitForCursorIdle behavior on the direct move path.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait on idle animator returned error: %v", err)
+	}
+
+	if rec.count() != 0 {
+		t.Fatalf("idle animator injected %d moves, want 0", rec.count())
+	}
+}
+
+// TestSmoothCursorAnimatorWaiterTracksSupersedingTarget guards the coalescing
+// race: a waiter that attaches while an earlier target animates must not be
+// released until the cursor reaches the *latest* target, even when the queued
+// target is superseded mid-flight. With per-request completion this waiter
+// returned early at the intermediate/previous position.
+func TestSmoothCursorAnimatorWaiterTracksSupersedingTarget(t *testing.T) {
+	t.Parallel()
+
+	// Slow the moves so the animation spans the follow-up enqueues.
+	rec := &recorder{start: image.Point{X: 0, Y: 0}}
+	slowMove := func(p image.Point) error {
+		time.Sleep(2 * time.Millisecond)
+
+		return rec.move(p)
+	}
+
+	animator := newSmoothCursorAnimator(rec.pos, slowMove)
+
+	final := image.Point{X: 900, Y: 900}
+
+	// Start a long first animation, then attach a waiter mid-flight.
+	animator.animateTo(image.Point{X: 120, Y: 120}, 20, 400, 1.0)
+
+	waitResult := make(chan error, 1)
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		waitResult <- animator.wait(ctx)
+	}()
+
+	// Supersede the target twice while the session is still animating.
+	time.Sleep(6 * time.Millisecond)
+	animator.animateTo(image.Point{X: 500, Y: 500}, 20, 400, 1.0)
+	time.Sleep(6 * time.Millisecond)
+	animator.animateTo(final, 20, 400, 1.0)
+
+	err := <-waitResult
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	last, ok := rec.last()
+	if !ok {
+		t.Fatal("expected at least one move to be injected")
+	}
+
+	if last != final {
+		t.Fatalf(
+			"waiter released before reaching the superseding target: got %v want %v",
+			last,
+			final,
+		)
+	}
+}
+
+// TestSmoothCursorAnimatorBestEffortOnMoveFailure documents that a failing
+// backend warp during the animation is best-effort (matching darwin): the
+// session still settles and WaitForCursorIdle returns without error.
+func TestSmoothCursorAnimatorBestEffortOnMoveFailure(t *testing.T) {
+	t.Parallel()
+
+	failingMove := func(_ image.Point) error {
+		return context.DeadlineExceeded // any non-nil error
+	}
+	pos := func() image.Point {
+		return image.Point{}
+	}
+
+	animator := newSmoothCursorAnimator(pos, failingMove)
+	animator.animateTo(image.Point{X: 400, Y: 400}, 8, 60, 0.1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("smooth-move failure must not surface through wait: got %v", err)
+	}
+}
+
+// TestSmoothCursorAnimatorStopFencesInflightStep verifies stop() does not
+// return while a backend injection step is in flight, and blocks any further
+// step from injecting. This is the ordering guarantee that lets a bypassed
+// direct warp (issued right after stop) land last instead of racing a stale
+// animation step.
+func TestSmoothCursorAnimatorStopFencesInflightStep(t *testing.T) {
+	t.Parallel()
+
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	var moveActive atomic.Bool
+
+	blockingMove := func(_ image.Point) error {
+		moveActive.Store(true)
+
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+
+		<-release
+		moveActive.Store(false)
+
+		return nil
+	}
+	pos := func() image.Point {
+		return image.Point{}
+	}
+
+	animator := newSmoothCursorAnimator(pos, blockingMove)
+	animator.animateTo(image.Point{X: 100, Y: 100}, 10, 200, 1.0)
+
+	<-entered // a backend step is now in flight, blocked in blockingMove
+
+	stopReturned := make(chan struct{})
+
+	go func() {
+		animator.stop()
+		close(stopReturned)
+	}()
+
+	// stop() must not return while the step is mid-injection.
+	select {
+	case <-stopReturned:
+		t.Fatal("stop returned while a backend move was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if !moveActive.Load() {
+		t.Fatal("expected the in-flight step to still be active")
+	}
+
+	close(release) // let the in-flight step finish
+
+	select {
+	case <-stopReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop did not return after the in-flight step completed")
+	}
+}
+
+// TestSmoothCursorAnimatorConcurrentStopAndAnimate guards the animateTo/stop
+// race: a bypassed move (stop) must never strand a smooth request on an
+// orphaned channel with an unclosed done. Run with -race. The test passes if it
+// completes without deadlocking on a wait that never returns.
+func TestSmoothCursorAnimatorConcurrentStopAndAnimate(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	var waitGroup sync.WaitGroup
+
+	for index := range 200 {
+		waitGroup.Add(2)
+
+		go func() {
+			defer waitGroup.Done()
+
+			animator.animateTo(image.Point{X: index, Y: index}, 6, 40, 0.2)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			err := animator.wait(ctx)
+			if err != nil {
+				t.Errorf("wait blocked or errored during concurrent stop: %v", err)
+			}
+		}()
+
+		go func() {
+			defer waitGroup.Done()
+
+			animator.stop()
+		}()
+	}
+
+	waitGroup.Wait()
+}
+
+func TestSmoothCursorAnimatorStopReleasesWaiter(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{start: image.Point{X: 0, Y: 0}}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	// Long animation so stop() interrupts it mid-flight.
+	animator.animateTo(image.Point{X: 5000, Y: 5000}, 200, 5000, 5.0)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		animator.stop()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait after stop returned error: %v", err)
+	}
+}
+
+// identityClamp passes points through unchanged, for tests that exercise
+// relative animation away from screen edges.
+func identityClamp(p image.Point) image.Point { return p }
+
+// TestSmoothCursorAnimatorPendingTargetLifecycle pins the pending-target
+// contract relative moves build on: the endpoint of the animation in flight
+// is visible while it is pending and gone once the animation is stopped.
+func TestSmoothCursorAnimatorPendingTargetLifecycle(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	if _, ok := animator.pendingTarget(); ok {
+		t.Fatal("pendingTarget() reported an animation before any was submitted")
+	}
+
+	// A slow glide so the session is still pending when we look.
+	target := image.Point{X: 400, Y: 300}
+	animator.animateTo(target, 10, 5000, 50)
+
+	got, ok := animator.pendingTarget()
+	if !ok || got != target {
+		t.Fatalf("pendingTarget() = %v, %v mid-animation, want %v, true", got, ok, target)
+	}
+
+	animator.stop()
+
+	if _, ok := animator.pendingTarget(); ok {
+		t.Fatal("pendingTarget() still reports an animation after stop()")
+	}
+}
+
+// TestSmoothCursorAnimatorRelativeLandsExactly pins that a relative move from
+// idle animates as a stepped glide and lands exactly on start+delta.
+func TestSmoothCursorAnimatorRelativeLandsExactly(t *testing.T) {
+	t.Parallel()
+
+	start := image.Point{X: 7, Y: 9}
+	rec := &recorder{start: start}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	delta := image.Point{X: 35, Y: -20}
+	animator.animateRelativeBy(delta, identityClamp, 5, 30)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	last, ok := rec.last()
+	if !ok {
+		t.Fatal("expected at least one move to be injected")
+	}
+
+	if want := start.Add(delta); last != want {
+		t.Fatalf("relative move landed on %v, want %v", last, want)
+	}
+
+	if rec.count() < 2 {
+		t.Fatalf("expected a stepped glide (>=2 moves), got %d", rec.count())
+	}
+}
+
+// TestSmoothCursorAnimatorRelativeExtendsPendingEndpoint pins the held-repeat
+// contract: a delta arriving mid-animation extends the pending endpoint
+// instead of restarting from the mid-glide position, and settle() warps
+// straight to the extended endpoint.
+func TestSmoothCursorAnimatorRelativeExtendsPendingEndpoint(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	// Long fixed durations so both deltas land in one pending session.
+	animator.animateRelativeBy(image.Point{X: 10, Y: 0}, identityClamp, 10, 5000)
+	animator.animateRelativeBy(image.Point{X: 15, Y: 5}, identityClamp, 10, 5000)
+
+	want := image.Point{X: 25, Y: 5}
+
+	if got, pending := animator.pendingTarget(); !pending || got != want {
+		t.Fatalf("pendingTarget() = %v, %v after two deltas, want %v, true", got, pending, want)
+	}
+
+	animator.settle()
+
+	if last, moved := rec.last(); !moved || last != want {
+		t.Fatalf("settle() warped to %v, %v, want %v, true", last, moved, want)
+	}
+
+	if _, pending := animator.pendingTarget(); pending {
+		t.Fatal("pendingTarget() still reports an animation after settle()")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait after settle returned error: %v", err)
+	}
+}
+
+// TestSmoothCursorAnimatorRelativeNoopKeepsAnimation pins the screen-edge
+// guard: a delta the clamp fully absorbs must not cancel and restart the
+// animation already heading to the pending endpoint.
+func TestSmoothCursorAnimatorRelativeNoopKeepsAnimation(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	end := image.Point{X: 50, Y: 0}
+	animator.animateRelativeBy(end, identityClamp, 10, 5000)
+
+	// Clamp everything back to the pending endpoint, as a screen edge would.
+	animator.animateRelativeBy(image.Point{X: 100, Y: 0}, func(image.Point) image.Point {
+		return end
+	}, 10, 5000)
+
+	got, ok := animator.pendingTarget()
+	if !ok || got != end {
+		t.Fatalf("pendingTarget() = %v, %v after clamped no-op, want %v, true", got, ok, end)
+	}
+
+	animator.stop()
+}
+
+// TestSmoothCursorAnimatorRelativeConcurrentDeltasCompose pins the
+// single-lock read-modify-write of animateRelativeBy: deltas from concurrent
+// movers must all end up in the final position, none silently overwritten.
+// The recorder's pos() returns the last landed point, so composition must
+// stay exact even across session boundaries.
+func TestSmoothCursorAnimatorRelativeConcurrentDeltasCompose(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	animator := newSmoothCursorAnimator(rec.pos, rec.move)
+
+	const movers = 8
+
+	const deltasPerMover = 25
+
+	var waitGroup sync.WaitGroup
+	for range movers {
+		waitGroup.Go(func() {
+			for range deltasPerMover {
+				animator.animateRelativeBy(image.Point{X: 1, Y: 0}, identityClamp, 2, 1)
+			}
+		})
+	}
+
+	waitGroup.Wait()
+
+	animator.settle()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := animator.wait(ctx)
+	if err != nil {
+		t.Fatalf("wait returned error: %v", err)
+	}
+
+	last, ok := rec.last()
+	if !ok {
+		t.Fatal("expected moves to be injected")
+	}
+
+	if want := movers * deltasPerMover; last.X != want {
+		t.Fatalf("final X = %d after %d concurrent unit deltas, want %d (lost deltas)",
+			last.X, want, want)
+	}
+}

--- a/internal/adapter/platform/windows/system.go
+++ b/internal/adapter/platform/windows/system.go
@@ -13,15 +13,24 @@ import (
 	"path/filepath"
 
 	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain/geometry"
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
 // SystemAdapter implements ports.SystemPort for Windows.
-type SystemAdapter struct{}
+type SystemAdapter struct {
+	cursorAnimator *smoothCursorAnimator
+}
 
 // NewSystemAdapter creates a new SystemAdapter.
 func NewSystemAdapter() *SystemAdapter {
-	return &SystemAdapter{}
+	adapter := &SystemAdapter{}
+	adapter.cursorAnimator = newSmoothCursorAnimator(
+		adapter.currentCursorPosition,
+		moveCursorTo,
+	)
+
+	return adapter
 }
 
 // PlatformLabel returns "windows".
@@ -173,21 +182,95 @@ func (s *SystemAdapter) FocusedWindowBounds(
 }
 
 // MoveCursorToPoint moves the mouse cursor to the specified point on Windows.
+//
+// When smooth cursor is enabled (config smooth_cursor.move_mouse_enabled) and
+// the caller has not requested a bypass, the move is animated by the shared
+// cursor animator, which steps SetCursorPos over time; callers that need the
+// cursor settled before acting pair this with WaitForCursorIdle. Otherwise
+// (bypass, disabled, or no config wired) it warps directly.
 func (s *SystemAdapter) MoveCursorToPoint(
 	ctx context.Context,
 	point image.Point,
-	_ bool,
+	bypassSmooth bool,
 ) error {
 	err := ctx.Err()
 	if err != nil {
 		return err
 	}
 
+	cfg := currentWindowsConfig()
+	if cfg != nil && cfg.SmoothCursor.MoveMouseEnabled && !bypassSmooth {
+		s.cursorAnimator.animateTo(
+			point,
+			cfg.SmoothCursor.Steps,
+			cfg.SmoothCursor.MaxDuration,
+			cfg.SmoothCursor.DurationPerPixel,
+		)
+
+		return nil
+	}
+
+	// Stop before warping: stop() drains the animator's injection mutex, so on
+	// return no animation step is in flight and none will start, and this warp
+	// lands last instead of racing a stale step back to an intermediate point.
+	s.cursorAnimator.stop()
+
 	return moveCursorTo(point)
 }
 
-// WaitForCursorIdle returns immediately on Windows until smooth cursor support exists.
+// MoveCursorBy applies a relative cursor move. With smooth cursor enabled
+// (smooth_cursor.move_mouse_enabled) the delta extends the animator's pending
+// endpoint, clamped to the active screen, and animates over the fixed
+// per-move duration smooth_cursor.relative_movement_duration, matching macOS.
+// Otherwise it reports handled == false so the caller keeps its
+// CursorPosition + MoveCursorToPoint fallback, the instant warp Windows always
+// used.
+func (s *SystemAdapter) MoveCursorBy(
+	ctx context.Context,
+	delta image.Point,
+) (bool, error) {
+	cfg := currentWindowsConfig()
+	if cfg == nil || !cfg.SmoothCursor.MoveMouseEnabled {
+		return false, nil
+	}
+
+	// Without bounds there is nothing to clamp against, so fall through to
+	// the caller's fallback, which clamps at the service layer.
+	bounds, err := s.ScreenBounds(ctx)
+	if err == nil {
+		s.cursorAnimator.animateRelativeBy(
+			delta,
+			func(point image.Point) image.Point {
+				return image.Point{
+					X: geometry.ClampInt(point.X, bounds.Min.X, max(bounds.Max.X-1, bounds.Min.X)),
+					Y: geometry.ClampInt(point.Y, bounds.Min.Y, max(bounds.Max.Y-1, bounds.Min.Y)),
+				}
+			},
+			cfg.SmoothCursor.Steps,
+			cfg.SmoothCursor.RelativeMovementDuration,
+		)
+
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// WaitForCursorIdle blocks until any in-flight smooth cursor animation settles,
+// or ctx is canceled. It returns immediately when no animation is active, the
+// common case on the direct (non-smooth) move path.
 func (s *SystemAdapter) WaitForCursorIdle(ctx context.Context) error {
+	return s.cursorAnimator.wait(ctx)
+}
+
+// SettleCursor finishes any in-flight cursor animation immediately: the
+// worker is stopped and the cursor warps straight to the endpoint it was
+// animating toward. Action paths call this before resolving their target
+// point from the cursor, so an action firing mid-animation acts at the point
+// the user aimed for without paying the animation's remaining duration.
+func (s *SystemAdapter) SettleCursor(ctx context.Context) error {
+	s.cursorAnimator.settle()
+
 	return nil
 }
 
@@ -252,5 +335,23 @@ func (s *SystemAdapter) RequestScreenCapturePermission(
 	return ports.ScreenCaptureGranted
 }
 
-// Ensure SystemAdapter implements ports.SystemPort.
-var _ ports.SystemPort = (*SystemAdapter)(nil)
+// currentCursorPosition returns the current cursor position for the animator,
+// collapsing the error to a zero point. The animator samples this once per
+// request to seed interpolation; a bad read only skews the glide path, never
+// the final landing point (the last step lands exactly on the target).
+func (s *SystemAdapter) currentCursorPosition() image.Point {
+	point, err := cursorPosition()
+	if err != nil {
+		return image.Point{}
+	}
+
+	return point
+}
+
+// Ensure SystemAdapter implements ports.SystemPort and its optional cursor
+// extensions.
+var (
+	_ ports.SystemPort          = (*SystemAdapter)(nil)
+	_ ports.RelativeCursorMover = (*SystemAdapter)(nil)
+	_ ports.CursorSettler       = (*SystemAdapter)(nil)
+)

--- a/internal/app/runtime_config_windows.go
+++ b/internal/app/runtime_config_windows.go
@@ -5,7 +5,10 @@ package app
 import (
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/adapter/platform/windows"
 	"github.com/y3owk1n/neru/internal/config/loader"
 )
 
-func configurePlatformRuntimeConfigProviders(_ *loader.Service, _ *zap.Logger) {}
+func configurePlatformRuntimeConfigProviders(cfgService *loader.Service, _ *zap.Logger) {
+	windows.SetConfigProvider(cfgService)
+}

--- a/internal/config/platform_support.go
+++ b/internal/config/platform_support.go
@@ -20,7 +20,6 @@ const (
 		"score each word"
 	noteVisionRectangles = "rectangle detection has no OCR answer, so it stays macOS-only " +
 		"even where the vision strategy lands; that half is text-only"
-	noteSmoothCursor = "cursor movement is not animated on Windows"
 	noteSmoothScroll = "the Windows scroll is injected in one step; macOS and Linux animate it, " +
 		"and on X11 the steps are whole wheel notches because X has no smaller scroll to send"
 	noteKeyboardLayout = "the keyboard layout is detected rather than chosen outside macOS"
@@ -171,7 +170,7 @@ func PlatformSupport() parity.Declaration {
 			"mode_indicator.monitor_select.border_color",
 		),
 
-		parity.On(parity.KindOption, darwinAndLinux, noteSmoothCursor,
+		parity.Everywhere(parity.KindOption,
 			"smooth_cursor.move_mouse_enabled",
 			"smooth_cursor.steps",
 			"smooth_cursor.max_duration",

--- a/internal/config/platform_support_test.go
+++ b/internal/config/platform_support_test.go
@@ -55,11 +55,6 @@ func TestPlatformSupport_DeclaresTheKnownNarrowColumns(t *testing.T) {
 			visionMinConfidence, "",
 			parity.Platforms{parity.Darwin, parity.Linux},
 		},
-		{
-			"smooth cursor is not animated on Windows",
-			"smooth_cursor.steps", "",
-			parity.Platforms{parity.Darwin, parity.Linux},
-		},
 	}
 
 	for _, test := range tests {
@@ -140,7 +135,7 @@ func TestInertWords_Options(t *testing.T) {
 		},
 		{
 			name:    "an option inert only on Windows is silent on Linux",
-			written: map[string]string{"smooth_cursor.steps": "20"},
+			written: map[string]string{smoothScrollEnabled: "true"},
 			target:  parity.Linux,
 			want:    nil,
 		},


### PR DESCRIPTION
## Description

This PR adds smooth cursor animation to Windows, including relative (hjkl) moves.

Set `smooth_cursor.move_mouse_enabled = true` and absolute moves (grid and recursive-grid cursor-follow, `move_mouse`, selection moves) glide through a stepped `SetCursorPos` animator with the same coalescing, latest-target-wins, settle and wait contract the macOS and Linux adapters carry. Relative moves extend the animation's pending endpoint over `smooth_cursor.relative_movement_duration`, clamped to the active screen, so a held key never loses part of a delta. Clicks and scrolls settle the in-flight animation first, so an action fired mid-glide lands where the user aimed.

The animator is the Linux `mouse_animator.go` shape with `SetCursorPos` as the sink, and its unit test mirrors the Linux one. The Windows adapter gains the config-provider slot the other two platforms already wire at daemon startup.

Off by default. Existing configs keep working; the five `smooth_cursor.*` options widen to every platform, so the load-time inert-word warning and the generated Platform Support Per Word table no longer list them for Windows. Capability Matrix, the animation table and Known Gaps (item 2 is now smooth scroll only) are updated.

## Related Issues

Closes #1563

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — none needed, this replaces the Windows stub; macOS and Linux already implement it
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [ ] `just ci` passes — ran the targeted slice on the host instead: `just lint`, `golangci-lint` under `GOOS=windows`, `go vet` under `GOOS=windows`, `just test-windows-compile`, and `go test` for `internal/config`, `internal/domain/parity`, `internal/architecture`, `internal/app`. The Windows animator test only runs on the Windows CI runner.
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

The animator is a per-adapter copy rather than a shared package, matching how Linux copied darwin. Extracting the pure-Go animator into a shared package would touch the Linux adapter and is out of scope for this ticket.
