### PR TITLE
feat(windows): smooth scroll animation

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -255,7 +255,9 @@ event is one notch by definition, and the XTEST pointer the server creates for
 valuator for the smooth XI2 path real devices use. Windows sits with Wayland:
 `MOUSEEVENTF_WHEEL` carries an integer count of `WHEEL_DELTA`/120ths, so the
 animator steps in 120ths of a notch, and a modifier is one real key held for
-the length of the animation, as on Linux.
+the length of the animation, as on Linux. Thirty pixels are one notch there,
+the figure X11 uses for its button clicks, and the animated and unanimated
+paths both send that fraction rather than rounding it to a detent.
 
 **So X11 animates in notches, and a scroll worth one notch is not animated at
 all.** The default `scroll.scroll_step` of 50 pixels is exactly one notch there,

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -180,7 +180,7 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Scroll injection**          | ✅ both axes             | ✅ both axes ⁷         | ✅ both axes (uinput + virtual pointer) | ✅ libei     | ✅ both axes                 |
 | **Modified scroll (`--modifier`)** | ✅ `CGEventSetFlags` on every chunk | ✅ XTest key hold ⁷ | ✅ virtual keyboard, uinput batch skipped (kept on Hyprland ⁹) | ✅ libei | ✅ `SendInput` key hold |
 | **Smooth cursor animation**   | ✅ (incl. relative, opt-in) | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in |
-| **Smooth scroll animation**   | ✅                       | ⚠️ whole notches only ³ | ✅ continuous virtual-pointer axis ³ (whole notches when modified on Hyprland ⁹) | ⚠️ libei scroll delta, unverified ³ | ❌       |
+| **Smooth scroll animation**   | ✅                       | ⚠️ whole notches only ³ | ✅ continuous virtual-pointer axis ³ (whole notches when modified on Hyprland ⁹) | ⚠️ libei scroll delta, unverified ³ | ✅ 120ths of a notch ³ |
 | **Element discovery (hints)** | ✅ AXUIElement           | ⚠️ AT-SPI walk         | ⚠️ AT-SPI walk               | ⚠️ AT-SPI walk          | ⚠️ UIA, control view only    |
 | **Overlay**                   | ✅ NSPanel + CoreAnimation | ✅ X11 + Cairo       | ✅ layer-shell + Cairo       | ✅ layer-shell + Cairo  | ✅ DirectComposition + Direct2D (GDI fallback; windows/arm64 is GDI only ⁷) |
 | **Global hotkeys**            | ✅ per-key CGEventTap    | ✅ `XGrabKey`          | ⚠️ passive evdev read        | ⚠️ passive evdev read   | ✅ `RegisterHotKey`          |
@@ -252,7 +252,10 @@ X11 has no such value to send: core scrolling is buttons 4 to 7 and a button
 event is one notch by definition, and the XTEST pointer the server creates for
 `XTestFakeButtonEvent` is allocated with two axes, `Rel X` and `Rel Y`
 (`CorePointerProc` in xorg-server's `dix/devices.c`), so it has no scroll
-valuator for the smooth XI2 path real devices use.
+valuator for the smooth XI2 path real devices use. Windows sits with Wayland:
+`MOUSEEVENTF_WHEEL` carries an integer count of `WHEEL_DELTA`/120ths, so the
+animator steps in 120ths of a notch, and a modifier is one real key held for
+the length of the animation, as on Linux.
 
 **So X11 animates in notches, and a scroll worth one notch is not animated at
 all.** The default `scroll.scroll_step` of 50 pixels is exactly one notch there,
@@ -926,7 +929,7 @@ important thing to know before touching overlay code:
 | **Grid transition**          | NSTimer @120Hz, ease-in-out, full redraw | goroutine, ease-in-out @120fps  | goroutine, ease-in-out @120fps, presented on the UI thread |
 | **Mouse action indicator**   | `CABasicAnimation` (scale + opacity) | goroutine, scale + opacity @120fps | goroutine, cubic easing @60fps     |
 | **Smooth cursor**            | ✅ stepped linear interpolation      | ✅ stepped linear interpolation    | ✅ stepped linear interpolation    |
-| **Smooth scroll**            | ✅ ease-out cubic                    | ❌                                 | ❌                                 |
+| **Smooth scroll**            | ✅ ease-out cubic                    | ✅ ease-out cubic                  | ✅ ease-out cubic, 120ths of a notch |
 
 ---
 
@@ -951,7 +954,7 @@ discovery rather than the mode itself.
 | **Recursive grid**| Transition animation           | ✅                         | ✅                         | ✅                          |
 | **Recursive grid**| Virtual pointer indicator      | ✅                         | ✅                         | ✅                          |
 | **Recursive grid**| Sub-key preview                | ✅ mini-grid of next keys  | ✅ mini-grid of next keys  | ✅ mini-grid of next keys   |
-| **Scroll**        | Smooth scroll animation        | ✅                         | ✅ (X11: whole notches)    | ❌                          |
+| **Scroll**        | Smooth scroll animation        | ✅                         | ✅ (X11: whole notches)    | ✅ (120ths of a notch)     |
 | **Monitor select**| Whole mode                     | ✅ native panels           | ✅ Cairo panels            | ✅ one layered window per display |
 
 Everything else is shared: multi-letter labels, label direction, hide-unmatched,
@@ -1077,10 +1080,6 @@ green in every cell while an option means nothing, which is exactly how
 | `hints.vision.rectangle_min_size` | option | ✅ | ❌ | ❌ | rectangle detection has no OCR answer, so it stays macOS-only even where the vision strategy lands; that half is text-only |
 | `hints.vision.rectangle_min_aspect` | option | ✅ | ❌ | ❌ | rectangle detection has no OCR answer, so it stays macOS-only even where the vision strategy lands; that half is text-only |
 | `hints.vision.rectangle_max_aspect` | option | ✅ | ❌ | ❌ | rectangle detection has no OCR answer, so it stays macOS-only even where the vision strategy lands; that half is text-only |
-| `smooth_scroll.enabled` | option | ✅ | ✅ | ❌ | the Windows scroll is injected in one step; macOS and Linux animate it, and on X11 the steps are whole wheel notches because X has no smaller scroll to send |
-| `smooth_scroll.steps` | option | ✅ | ✅ | ❌ | the Windows scroll is injected in one step; macOS and Linux animate it, and on X11 the steps are whole wheel notches because X has no smaller scroll to send |
-| `smooth_scroll.max_duration` | option | ✅ | ✅ | ❌ | the Windows scroll is injected in one step; macOS and Linux animate it, and on X11 the steps are whole wheel notches because X has no smaller scroll to send |
-| `smooth_scroll.duration_per_pixel` | option | ✅ | ✅ | ❌ | the Windows scroll is injected in one step; macOS and Linux animate it, and on X11 the steps are whole wheel notches because X has no smaller scroll to send |
 | `hide_cursor` | action | ✅ | ❌ | ❌ | a Wayland client may not hide another client's cursor, and the blessed Linux stack is Wayland; Windows has no equivalent either |
 | `show_cursor` | action | ✅ | ❌ | ❌ | a Wayland client may not hide another client's cursor, and the blessed Linux stack is Wayland; Windows has no equivalent either |
 | `feed` | action | ✅ | ✅ | ❌ | Windows has no key-injection path yet, so the key it would post is never sent; the key_feed capability reports stub to match |
@@ -1106,8 +1105,9 @@ Two entries left this table in ADR 0013 and neither is coming back.
 **Smooth scroll animation** was recorded as needing "a synthesizable continuous
 scroll event stream"; the spike found one on Wayland — a
 `zwlr_virtual_pointer_v1` axis event with no discrete step count, and libei's
-pixel-precise scroll delta on KWin — and it now animates on every Linux backend,
-with X11 limited to whole notches for the reason footnote ³ of the
+pixel-precise scroll delta on KWin — and it now animates on every Linux backend
+and on Windows, whose `MOUSEEVENTF_WHEEL` counts 120ths of a notch, with X11
+limited to whole notches for the reason footnote ³ of the
 [Capability Matrix](#capability-matrix) gives. A limit on one backend is not an
 exclusive: it is that backend's documented limit, which is what
 [ADR 0013](./adr/0013-parity-is-measured-in-words-not-subsystems.md) says the
@@ -1178,11 +1178,10 @@ working, which is exactly why the build exists.
 **Windows**
 
 1. Native notifications — no toast support
-2. Smooth scroll animation — not implemented
-3. Font resolution — alias mapping only, no system font enumeration
-4. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
+2. Font resolution — alias mapping only, no system font enumeration
+3. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
    installs a launchd agent and Linux a systemd user unit
-5. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
+4. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
     every platform, but only the Unix client checks that for itself before
     connecting. A named pipe carries no ownership a client can read without
     opening it, so the Windows CLI trusts the name it derives from its own SID.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,7 +44,7 @@ The two largest open areas:
   CGO build rather than missing code, and whose remaining work is failing
   loudly with the remedy.
 - **Windows** — the remaining Known Gaps entries: notifications, UIA tree
-  depth, animations and `monitor_select`.
+  depth and `monitor_select`.
 
 GNOME Wayland remains unsupported; the daemon refuses to start there. Reviving
 it needs libei plus a GNOME Shell extension — see

--- a/internal/adapter/platform/windows/input.go
+++ b/internal/adapter/platform/windows/input.go
@@ -39,6 +39,17 @@ const (
 	neruInjectedTag = 0x4E455255 // 'N','E','R','U'
 
 	wheelDelta = 120
+
+	// scrollPixelsPerNotch maps the pixel delta every caller sends to wheel
+	// notches. Linux uses the same figure for its X11 button clicks, so one
+	// scroll_step travels the same number of notches on both; before it the
+	// pixel count was sent as a notch count and one scroll_step of 50 pixels
+	// was fifty notches.
+	scrollPixelsPerNotch = 30
+	// wheelUnitsPerPixel is that mapping in mouseData units: WHEEL_DELTA is
+	// 120 per notch, so a pixel is four units and an application accumulates
+	// the fraction the way it does for a high-resolution wheel.
+	wheelUnitsPerPixel = wheelDelta / scrollPixelsPerNotch
 )
 
 // mouseInput and input mirror Win32 MOUSEINPUT/INPUT on 64-bit Windows (40 bytes).
@@ -225,14 +236,14 @@ type wheelEvent struct {
 	data  uint32
 }
 
-// wheelEvents turns a scroll delta into the wheel records SendInput needs,
-// one per axis that moves. Deltas follow Neru's shared convention: positive
-// deltaY scrolls up and positive deltaX scrolls left, which is what macOS
-// posts verbatim and what X11 maps to buttons 4 and 6. MOUSEEVENTF_WHEEL
+// wheelEvents turns a pixel scroll delta into the wheel records SendInput
+// needs, one per axis that moves. Deltas follow Neru's shared convention:
+// positive deltaY scrolls up and positive deltaX scrolls left, which is what
+// macOS posts verbatim and what X11 maps to buttons 4 and 6. MOUSEEVENTF_WHEEL
 // agrees on the vertical sign, but MOUSEEVENTF_HWHEEL reads positive as
 // right, so the horizontal component is negated.
 func wheelEvents(deltaX, deltaY int) []wheelEvent {
-	return wheelRecords(int32(deltaY)*wheelDelta, int32(-deltaX)*wheelDelta)
+	return wheelRecords(int32(deltaY)*wheelUnitsPerPixel, int32(-deltaX)*wheelUnitsPerPixel)
 }
 
 // wheelRecords is wheelEvents below the sign convention: vertical and

--- a/internal/adapter/platform/windows/input.go
+++ b/internal/adapter/platform/windows/input.go
@@ -232,20 +232,21 @@ type wheelEvent struct {
 // agrees on the vertical sign, but MOUSEEVENTF_HWHEEL reads positive as
 // right, so the horizontal component is negated.
 func wheelEvents(deltaX, deltaY int) []wheelEvent {
+	return wheelRecords(int32(deltaY)*wheelDelta, int32(-deltaX)*wheelDelta)
+}
+
+// wheelRecords is wheelEvents below the sign convention: vertical and
+// horizontal are already in WHEEL_DELTA units with Win32's signs, and a zero
+// axis sends nothing.
+func wheelRecords(vertical, horizontal int32) []wheelEvent {
 	var events []wheelEvent
 
-	if deltaY != 0 {
-		events = append(events, wheelEvent{
-			flags: mouseeventfWheel,
-			data:  uint32(int32(deltaY) * wheelDelta),
-		})
+	if vertical != 0 {
+		events = append(events, wheelEvent{flags: mouseeventfWheel, data: uint32(vertical)})
 	}
 
-	if deltaX != 0 {
-		events = append(events, wheelEvent{
-			flags: mouseeventfHWheel,
-			data:  uint32(int32(-deltaX) * wheelDelta),
-		})
+	if horizontal != 0 {
+		events = append(events, wheelEvent{flags: mouseeventfHWheel, data: uint32(horizontal)})
 	}
 
 	return events
@@ -255,12 +256,41 @@ func wheelEvents(deltaX, deltaY int) []wheelEvent {
 // exactly modifiers as held for the duration — see holdModifiers for why a
 // modifier the user is physically holding has to be suppressed rather than
 // merely not pressed.
+//
+// With smooth_scroll.enabled the scroll is handed to the animator instead and
+// arrives as a sequence of eased chunks, which is what the same setting does
+// on macOS and Linux. The chunks are integer 120ths of a notch, so unlike X11
+// the steps go below a wheel notch.
 func ScrollWheel(deltaX, deltaY int, modifiers action.Modifiers) error {
-	events := wheelEvents(deltaX, deltaY)
-	if len(events) == 0 {
+	if deltaX == 0 && deltaY == 0 {
 		return nil
 	}
 
+	cfg := currentWindowsConfig()
+	if cfg != nil && cfg.SmoothScroll.Enabled {
+		scrollAnim.animate(
+			deltaX,
+			deltaY,
+			modifiers,
+			cfg.SmoothScroll.Steps,
+			cfg.SmoothScroll.MaxDuration,
+			cfg.SmoothScroll.DurationPerPixel,
+		)
+
+		return nil
+	}
+
+	// A scroll arriving with the animation switched off must not be chased by
+	// chunks scheduled before the reload.
+	scrollAnim.stop()
+
+	return scrollWheelNow(deltaX, deltaY, modifiers)
+}
+
+// scrollWheelNow injects the whole scroll in one go, which is what every
+// caller got before smooth scroll existed and what a caller still gets with
+// it switched off.
+func scrollWheelNow(deltaX, deltaY int, modifiers action.Modifiers) error {
 	hold, err := holdModifiers(modifiers)
 	if err != nil {
 		return err
@@ -268,7 +298,7 @@ func ScrollWheel(deltaX, deltaY int, modifiers action.Modifiers) error {
 
 	defer hold.release()
 
-	for _, event := range events {
+	for _, event := range wheelEvents(deltaX, deltaY) {
 		err := sendMouseInput(event.flags, event.data)
 		if err != nil {
 			return err

--- a/internal/adapter/platform/windows/input_test.go
+++ b/internal/adapter/platform/windows/input_test.go
@@ -40,9 +40,16 @@ func TestSendInputStructLayout(t *testing.T) {
 }
 
 // notches converts a signed wheel count into the two's-complement mouseData
-// SendInput reads, the same way wheelEvents does.
+// SendInput reads, the same way wheelEvents does for a whole notch's worth of
+// pixels.
 func notches(count int) uint32 {
 	return uint32(int32(count) * wheelDelta)
+}
+
+// pixels converts a signed pixel delta into mouseData the same way
+// wheelEvents does: scrollPixelsPerNotch pixels are one notch.
+func pixels(count int) uint32 {
+	return uint32(int32(count) * wheelUnitsPerPixel)
 }
 
 // TestWheelEvents_NegatesHorizontalDelta pins the sign convention across the
@@ -60,24 +67,29 @@ func TestWheelEvents_NegatesHorizontalDelta(t *testing.T) {
 	}{
 		{name: "no movement sends nothing"},
 		{
-			name:   "scroll up is a positive wheel notch",
-			deltaY: 1,
+			name:   "a notch's worth of pixels up is one positive wheel notch",
+			deltaY: scrollPixelsPerNotch,
 			want:   []wheelEvent{{flags: mouseeventfWheel, data: notches(1)}},
 		},
 		{
+			name:   "a pixel is a fraction of a notch, not a notch",
+			deltaY: 1,
+			want:   []wheelEvent{{flags: mouseeventfWheel, data: pixels(1)}},
+		},
+		{
 			name:   "scroll left is a negative hwheel notch",
-			deltaX: 1,
+			deltaX: scrollPixelsPerNotch,
 			want:   []wheelEvent{{flags: mouseeventfHWheel, data: notches(-1)}},
 		},
 		{
 			name:   "scroll right is a positive hwheel notch",
-			deltaX: -2,
+			deltaX: -2 * scrollPixelsPerNotch,
 			want:   []wheelEvent{{flags: mouseeventfHWheel, data: notches(2)}},
 		},
 		{
 			name:   "both axes send vertical first",
-			deltaX: -1,
-			deltaY: -1,
+			deltaX: -scrollPixelsPerNotch,
+			deltaY: -scrollPixelsPerNotch,
 			want: []wheelEvent{
 				{flags: mouseeventfWheel, data: notches(-1)},
 				{flags: mouseeventfHWheel, data: notches(1)},

--- a/internal/adapter/platform/windows/keyboard_hook.go
+++ b/internal/adapter/platform/windows/keyboard_hook.go
@@ -223,6 +223,13 @@ func keyboardHookProc(code int, wParam uintptr, lParam unsafe.Pointer) uintptr {
 
 	isUp := wParam == wmKeyUp || wParam == wmSysKeyUp || kbd.flags&llkhfUp != 0
 
+	// A physical modifier release is what a modifier hold cannot read from
+	// the keyboard, so it is recorded here before the callback can consume
+	// the event.
+	if isUp && isModifierVirtualKey(kbd.vkCode) {
+		noteModifierReleased(kbd.vkCode)
+	}
+
 	key := hookKeyName(kbd.vkCode, isUp)
 	if key != "" && current.callback(key, isUp) {
 		return 1

--- a/internal/adapter/platform/windows/modifiers.go
+++ b/internal/adapter/platform/windows/modifiers.go
@@ -35,6 +35,17 @@ var windowsModifierKeys = []struct {
 	{vkRWin, action.ModCmd, false},
 }
 
+// isModifierVirtualKey reports whether vk is one of windowsModifierKeys.
+func isModifierVirtualKey(vk uint32) bool {
+	for _, key := range windowsModifierKeys {
+		if uint32(key.key) == vk {
+			return true
+		}
+	}
+
+	return false
+}
+
 // modifierKeysFrom reads every modifier key through down, which answers
 // whether a virtual key is held right now.
 func modifierKeysFrom(down func(vk uint32) bool) []modifierstate.Key {
@@ -74,6 +85,46 @@ func heldModifierKeycodes() []uint32 {
 // physically held ctrl reads up until they tap it again.
 var modifierHoldMu sync.Mutex
 
+// releasedDuringHold is the modifier keys the user physically let go of while
+// a hold was open, or nil when none is. The keyboard hook fills it and release
+// reads it, because the keyboard itself cannot answer the question: a key the
+// hold suppressed reads up whether the user is still holding it or not, and
+// pressing back one they released latches it with nothing to ever let go.
+// That window was one synchronous injection wide until the scroll animator
+// started holding modifiers for the length of an animation.
+var (
+	releasedDuringHoldMu sync.Mutex
+	releasedDuringHold   map[uint32]struct{}
+)
+
+// noteModifierReleased records a physical modifier key-up seen by the
+// keyboard hook. Outside a hold it records nothing.
+func noteModifierReleased(vk uint32) {
+	releasedDuringHoldMu.Lock()
+	defer releasedDuringHoldMu.Unlock()
+
+	if releasedDuringHold != nil {
+		releasedDuringHold[vk] = struct{}{}
+	}
+}
+
+func beginReleaseTracking() {
+	releasedDuringHoldMu.Lock()
+	defer releasedDuringHoldMu.Unlock()
+
+	releasedDuringHold = make(map[uint32]struct{})
+}
+
+func endReleaseTracking() map[uint32]struct{} {
+	releasedDuringHoldMu.Lock()
+	defer releasedDuringHoldMu.Unlock()
+
+	released := releasedDuringHold
+	releasedDuringHold = nil
+
+	return released
+}
+
 // modifierHold is one injection's worth of falsified modifier state: what it
 // released so the injection would not carry it, and what it pressed so the
 // injection would.
@@ -108,6 +159,7 @@ type modifierHold struct {
 // failure path alike.
 func holdModifiers(modifiers action.Modifiers) (modifierHold, error) {
 	modifierHoldMu.Lock()
+	beginReleaseTracking()
 
 	hold := modifierHold{plan: modifierstate.PlanFor(modifierKeysFrom(isVirtualKeyDown), modifiers)}
 
@@ -138,14 +190,16 @@ func holdModifiers(modifiers action.Modifiers) (modifierHold, error) {
 // release lets go of what the hold pressed and presses back what it
 // suppressed, skipping any key that reads down again: something pressed it
 // after we let go, and a second press would leave a hold our release never
-// answers. A key the user let go of mid-injection reads up and is pressed back
-// regardless; the keyboard cannot tell that release from ours, and the window
-// is one synchronous injection wide.
+// answers. A key the user let go of while the hold was open reads up exactly
+// as one we suppressed does, so the keyboard hook's record of physical
+// releases decides: one the user released stays up.
 //
 // Errors are dropped: a release that fails has nothing better to try, and
 // reporting it would mask the outcome of the action it wraps.
 func (h modifierHold) release() {
 	defer modifierHoldMu.Unlock()
+
+	released := endReleaseTracking()
 
 	for _, edit := range h.plan.Press {
 		_ = sendKeyboardInput(uint16(edit.Keycode), true)
@@ -156,6 +210,10 @@ func (h modifierHold) release() {
 	}
 
 	for _, edit := range h.plan.Restore(heldModifierKeycodes()) {
+		if _, userReleased := released[edit.Keycode]; userReleased {
+			continue
+		}
+
 		_ = sendKeyboardInput(uint16(edit.Keycode), false)
 	}
 }

--- a/internal/adapter/platform/windows/modifiers_test.go
+++ b/internal/adapter/platform/windows/modifiers_test.go
@@ -83,3 +83,27 @@ func TestModifierKeysFrom_PlansAgainstTheLiveKeyboard(t *testing.T) {
 		})
 	}
 }
+
+// TestNoteModifierReleased_RecordsOnlyWhileAHoldIsOpen pins the window a
+// physical release is remembered in: a key-up the hook sees between a hold's
+// open and its release is what keeps that key from being pressed back, and
+// one seen outside a hold means nothing.
+func TestNoteModifierReleased_RecordsOnlyWhileAHoldIsOpen(t *testing.T) {
+	noteModifierReleased(vkLShift)
+
+	if released := endReleaseTracking(); len(released) != 0 {
+		t.Fatalf("a release outside a hold was recorded: %v", released)
+	}
+
+	beginReleaseTracking()
+	noteModifierReleased(vkLShift)
+
+	released := endReleaseTracking()
+	if _, ok := released[vkLShift]; !ok || len(released) != 1 {
+		t.Fatalf("released = %v, want exactly left shift", released)
+	}
+
+	if again := endReleaseTracking(); again != nil {
+		t.Fatalf("the record survived its hold: %v", again)
+	}
+}

--- a/internal/adapter/platform/windows/scroll_animator.go
+++ b/internal/adapter/platform/windows/scroll_animator.go
@@ -27,12 +27,12 @@ const (
 	// so a direct caller cannot divide by zero.
 	defaultScrollSteps = 12
 	// scrollGranularity is the smallest distance a wheel event can carry, in
-	// the caller's units. The caller's delta is in notches (wheelEvents sends
-	// deltaY * WHEEL_DELTA) and MOUSEINPUT.mouseData is an integer count of
-	// WHEEL_DELTA/120ths, so a step can be as short as one 120th of a notch.
-	// That is what makes this animate below a notch the way Wayland does and
-	// X11 cannot.
-	scrollGranularity = 1.0 / wheelDelta
+	// the caller's pixels: MOUSEINPUT.mouseData is an integer count of
+	// WHEEL_DELTA/120ths and wheelUnitsPerPixel of them make a pixel, so a
+	// step can be as short as a quarter pixel, one 120th of a notch. That is
+	// what makes this animate below a notch the way Wayland does and X11
+	// cannot.
+	scrollGranularity = 1.0 / wheelUnitsPerPixel
 )
 
 // scrollSession is one animation's hold on the injection path.
@@ -68,8 +68,8 @@ func (s *sendInputScrollSession) inject(deltaX, deltaY float64) error {
 	// The same sign convention wheelEvents applies: positive deltaY is up and
 	// positive deltaX is left, and only the horizontal axis needs negating.
 	records := wheelRecords(
-		int32(math.Round(deltaY*wheelDelta)),
-		int32(math.Round(-deltaX*wheelDelta)),
+		int32(math.Round(deltaY*wheelUnitsPerPixel)),
+		int32(math.Round(-deltaX*wheelUnitsPerPixel)),
 	)
 
 	for _, event := range records {
@@ -91,8 +91,10 @@ func (s *sendInputScrollSession) close() {
 //
 // The curve is eased on the cumulative position and each chunk is the
 // difference between two positions on it, so rounding never accumulates: a
-// fraction of a 120th that one chunk cannot express stays in the difference
-// and goes out with a later chunk.
+// fraction of a wheel unit that one chunk cannot express stays in the
+// difference and goes out with a later chunk. The schedule is laid out in
+// whole wheel units and the last chunk takes whatever is left, so the steps
+// together travel exactly the units the delta rounds to.
 //
 // delta is a float rather than the integer the caller's action carries
 // because a request can arrive holding the undelivered remainder of the one
@@ -104,21 +106,25 @@ func scrollChunks(delta float64, steps int) []float64 {
 	}
 
 	chunks := make([]float64, steps)
-	if delta == 0 {
+
+	total := math.Round(delta * wheelUnitsPerPixel)
+	if total == 0 {
 		return chunks
 	}
 
 	var sent float64
 
-	for step := 1; step <= steps; step++ {
+	for step := 1; step < steps; step++ {
 		progress := float64(step) / float64(steps)
 		eased := 1 - math.Pow(1-progress, easeOutCubicExponent)
 
-		chunk := math.Trunc((delta*eased-sent)/scrollGranularity) * scrollGranularity
+		chunk := math.Trunc(total*eased - sent)
 
-		chunks[step-1] = chunk
+		chunks[step-1] = chunk * scrollGranularity
 		sent += chunk
 	}
+
+	chunks[steps-1] = (total - sent) * scrollGranularity
 
 	return chunks
 }
@@ -343,8 +349,13 @@ func (a *scrollAnimator) runOnce(
 
 	// Opening presses real modifier keys, so it takes the fence too: without
 	// it a worker starting here could press ctrl before a worker stopped a
-	// moment ago released it.
-	a.underFence(func() { session, err = a.begin(req.modifiers) }, nil)
+	// moment ago released it. It also checks stopCh under the fence, because
+	// a request the worker took just before stop() must not press a key the
+	// direct scroll that replaced it then has to wait out.
+	opened := a.underFence(func() { session, err = a.begin(req.modifiers) }, stopCh)
+	if !opened {
+		return scrollRequest{}, false
+	}
 
 	if err != nil {
 		// Reported the way the cursor animator reports a failed step, which

--- a/internal/adapter/platform/windows/scroll_animator.go
+++ b/internal/adapter/platform/windows/scroll_animator.go
@@ -1,0 +1,454 @@
+//go:build windows
+
+package windows
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/domain/action"
+)
+
+const (
+	// minScrollAnimationDuration floors the animation length in ms, at the
+	// number the darwin and linux animators floor at.
+	minScrollAnimationDuration = 10
+	// minScrollStepDelay is the shortest gap between injected steps, in ms. A
+	// scheduling floor on this animator's own timer rather than a config
+	// value, as minCursorStepDelay is for the cursor animator.
+	minScrollStepDelay = 1
+	// easeOutCubicExponent shapes the curve: fast at the start, settling at
+	// the end. It matches the other two animators, so one configuration
+	// produces the same shape everywhere.
+	easeOutCubicExponent = 3
+	// defaultScrollSteps answers a caller that supplied a nonsense step count
+	// (<= 0). ValidateSmoothScroll already requires steps >= 1, so it exists
+	// so a direct caller cannot divide by zero.
+	defaultScrollSteps = 12
+	// scrollGranularity is the smallest distance a wheel event can carry, in
+	// the caller's units. The caller's delta is in notches (wheelEvents sends
+	// deltaY * WHEEL_DELTA) and MOUSEINPUT.mouseData is an integer count of
+	// WHEEL_DELTA/120ths, so a step can be as short as one 120th of a notch.
+	// That is what makes this animate below a notch the way Wayland does and
+	// X11 cannot.
+	scrollGranularity = 1.0 / wheelDelta
+)
+
+// scrollSession is one animation's hold on the injection path.
+//
+// It exists because a modifier has to stay held across every step: a
+// ctrl-modified scroll is a real ctrl key pressed before the first chunk and
+// released after the last, and pressing it around each chunk would read to an
+// application as that many separate zoom gestures.
+type scrollSession interface {
+	// inject sends one chunk. Both deltas are exact multiples of
+	// scrollGranularity, so the conversion to wheel data does not round.
+	inject(deltaX, deltaY float64) error
+	// close releases whatever begin acquired.
+	close()
+}
+
+// sendInputScrollSession injects wheel events through SendInput with a
+// modifier hold open for the length of the animation.
+type sendInputScrollSession struct {
+	hold modifierHold
+}
+
+func newSendInputScrollSession(modifiers action.Modifiers) (scrollSession, error) {
+	hold, err := holdModifiers(modifiers)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sendInputScrollSession{hold: hold}, nil
+}
+
+func (s *sendInputScrollSession) inject(deltaX, deltaY float64) error {
+	// The same sign convention wheelEvents applies: positive deltaY is up and
+	// positive deltaX is left, and only the horizontal axis needs negating.
+	records := wheelRecords(
+		int32(math.Round(deltaY*wheelDelta)),
+		int32(math.Round(-deltaX*wheelDelta)),
+	)
+
+	for _, event := range records {
+		err := sendMouseInput(event.flags, event.data)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *sendInputScrollSession) close() {
+	s.hold.release()
+}
+
+// scrollChunks lays out one axis of an animated scroll: what each step should
+// inject so that the steps together travel the requested distance.
+//
+// The curve is eased on the cumulative position and each chunk is the
+// difference between two positions on it, so rounding never accumulates: a
+// fraction of a 120th that one chunk cannot express stays in the difference
+// and goes out with a later chunk.
+//
+// delta is a float rather than the integer the caller's action carries
+// because a request can arrive holding the undelivered remainder of the one
+// it preempted (see composeUndelivered), and that remainder is a position on
+// an eased curve.
+func scrollChunks(delta float64, steps int) []float64 {
+	if steps <= 0 {
+		steps = defaultScrollSteps
+	}
+
+	chunks := make([]float64, steps)
+	if delta == 0 {
+		return chunks
+	}
+
+	var sent float64
+
+	for step := 1; step <= steps; step++ {
+		progress := float64(step) / float64(steps)
+		eased := 1 - math.Pow(1-progress, easeOutCubicExponent)
+
+		chunk := math.Trunc((delta*eased-sent)/scrollGranularity) * scrollGranularity
+
+		chunks[step-1] = chunk
+		sent += chunk
+	}
+
+	return chunks
+}
+
+// scrollRequest is one animated scroll.
+//
+// The modifier set belongs to the request rather than to the animator,
+// because a request preempts whatever is in flight: a plain scroll_down
+// arriving mid-zoom cancels the zoom and finishes unmodified, which is what
+// the second binding asked for.
+type scrollRequest struct {
+	deltaX, deltaY   float64
+	modifiers        action.Modifiers
+	steps            int
+	maxDuration      int
+	durationPerPixel float64
+}
+
+// composeUndelivered folds the part of inflight that never went out — remX,
+// remY — into the request preempting it, but only when the two ask for the
+// same modifiers.
+//
+// Same modifiers is the held-repeat case: without this, every tick throws
+// away whatever the previous tick had not yet injected, and holding a scroll
+// key travels visibly less than the same number of discrete presses.
+// Different modifiers is the deliberate cancel scrollRequest documents, and
+// the remainder is dropped so the zoom's distance is not injected as a plain
+// scroll the user never asked for.
+func composeUndelivered(next, inflight scrollRequest, remX, remY float64) scrollRequest {
+	if next.modifiers != inflight.modifiers {
+		return next
+	}
+
+	next.deltaX += remX
+	next.deltaY += remY
+
+	return next
+}
+
+// scrollAnimator spreads a scroll over time on one worker goroutine, with the
+// latest request winning. It is the cursor animator's shape applied to the
+// wheel: the daemon has one scroll at a time, and a second one arriving
+// mid-animation replaces the first rather than queueing behind it.
+type scrollAnimator struct {
+	// begin opens a session. It is a field so a test can substitute one;
+	// production wires newSendInputScrollSession.
+	begin func(action.Modifiers) (scrollSession, error)
+
+	mu     sync.Mutex
+	reqCh  chan scrollRequest
+	stopCh chan struct{}
+
+	// injectSem is a size-1 semaphore the worker holds across opening a
+	// session, each injected chunk, and closing it, re-checking stopCh under
+	// it before injecting. It is the handoff to stop(): once stop() holds it,
+	// no chunk is mid-flight and none will start. A session holds real
+	// modifier keys down, so a stale worker's release is ordered against a
+	// later worker's press by the same token. It is never held together with
+	// mu.
+	injectSem chan struct{}
+}
+
+var scrollAnim = newScrollAnimator(newSendInputScrollSession)
+
+func newScrollAnimator(begin func(action.Modifiers) (scrollSession, error)) *scrollAnimator {
+	return &scrollAnimator{begin: begin, injectSem: make(chan struct{}, 1)}
+}
+
+// stop cancels any animation in flight. The unanimated path calls it so a
+// scroll that arrives with smooth scroll switched off is not still being
+// chased by chunks from before the reload.
+func (a *scrollAnimator) stop() {
+	a.mu.Lock()
+	stopCh := a.stopCh
+	a.reqCh = nil
+	a.stopCh = nil
+
+	if stopCh != nil {
+		close(stopCh)
+	}
+
+	a.mu.Unlock()
+
+	// Order whatever the caller does next after any chunk still in flight,
+	// so a canceled animation cannot land after the direct scroll that
+	// replaced it.
+	a.injectSem <- struct{}{}
+
+	<-a.injectSem
+}
+
+// animate hands a request to the worker, replacing any request already
+// queued.
+func (a *scrollAnimator) animate(
+	deltaX, deltaY int,
+	modifiers action.Modifiers,
+	steps int,
+	maxDuration int,
+	durationPerPixel float64,
+) {
+	req := scrollRequest{
+		deltaX:           float64(deltaX),
+		deltaY:           float64(deltaY),
+		modifiers:        modifiers,
+		steps:            steps,
+		maxDuration:      maxDuration,
+		durationPerPixel: durationPerPixel,
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.reqCh == nil {
+		a.reqCh = make(chan scrollRequest, 1)
+		a.stopCh = make(chan struct{})
+
+		go a.run(a.reqCh, a.stopCh)
+	}
+
+	a.enqueueLocked(req)
+}
+
+// enqueueLocked places req on the worker channel, folding in a request the
+// worker has not taken yet. The caller must hold a.mu.
+//
+// Under the lock we are the only producer and the worker is the only
+// consumer, so after draining the buffer is empty and the follow-up send
+// cannot block. A request still sitting in the buffer has had none of its
+// delta injected, so composeUndelivered folds all of it in.
+func (a *scrollAnimator) enqueueLocked(req scrollRequest) {
+	select {
+	case a.reqCh <- req:
+		return
+	default:
+	}
+
+	select {
+	case queued := <-a.reqCh:
+		req = composeUndelivered(req, queued, queued.deltaX, queued.deltaY)
+	default:
+	}
+
+	select {
+	case a.reqCh <- req:
+	default:
+	}
+}
+
+// underFence runs one native call while holding injectSem, so stop() can
+// order itself after it. When stopCh is non-nil the call is skipped if the
+// session was canceled while we waited for the token; it reports whether the
+// call ran.
+func (a *scrollAnimator) underFence(call func(), stopCh <-chan struct{}) bool {
+	a.injectSem <- struct{}{}
+	defer func() { <-a.injectSem }()
+
+	if stopCh != nil {
+		select {
+		case <-stopCh:
+			return false
+		default:
+		}
+	}
+
+	call()
+
+	return true
+}
+
+func (a *scrollAnimator) run(reqCh <-chan scrollRequest, stopCh <-chan struct{}) {
+	timer := time.NewTimer(time.Hour)
+
+	stopAndDrainTimer(timer)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		case req := <-reqCh:
+			a.runRequest(req, reqCh, stopCh, timer)
+		}
+	}
+}
+
+// runRequest animates one request to completion, or until a newer one
+// preempts it. The session is opened per request rather than per animator,
+// so a preempting request presses its own modifiers and the one it replaced
+// lets go of exactly what it pressed.
+func (a *scrollAnimator) runRequest(
+	req scrollRequest,
+	reqCh <-chan scrollRequest,
+	stopCh <-chan struct{},
+	timer *time.Timer,
+) {
+	for {
+		next, restart := a.runOnce(req, reqCh, stopCh, timer)
+		if !restart {
+			return
+		}
+
+		req = next
+	}
+}
+
+// runOnce plays one request's schedule. It reports the request that
+// preempted this one, if any.
+func (a *scrollAnimator) runOnce(
+	req scrollRequest,
+	reqCh <-chan scrollRequest,
+	stopCh <-chan struct{},
+	timer *time.Timer,
+) (scrollRequest, bool) {
+	if req.deltaX == 0 && req.deltaY == 0 {
+		return scrollRequest{}, false
+	}
+
+	var (
+		session scrollSession
+		err     error
+	)
+
+	// Opening presses real modifier keys, so it takes the fence too: without
+	// it a worker starting here could press ctrl before a worker stopped a
+	// moment ago released it.
+	a.underFence(func() { session, err = a.begin(req.modifiers) }, nil)
+
+	if err != nil {
+		// Reported the way the cursor animator reports a failed step, which
+		// is not at all: there is no caller left to return it to.
+		return scrollRequest{}, false
+	}
+
+	// Closing releases real modifier keys, so it goes out under the same
+	// fence as an injected chunk, and unconditionally, because a session left
+	// open leaves the key held.
+	defer a.underFence(session.close, nil)
+
+	steps, stepDelay := scrollScheduleTiming(req)
+
+	chunksX := scrollChunks(req.deltaX, steps)
+	chunksY := scrollChunks(req.deltaY, steps)
+
+	for step := range steps {
+		select {
+		case <-stopCh:
+			return scrollRequest{}, false
+		case next := <-reqCh:
+			// Chunks from step on have not gone out.
+			return composeUndelivered(
+				next, req, sumFrom(chunksX, step), sumFrom(chunksY, step),
+			), true
+		default:
+		}
+
+		if chunksX[step] != 0 || chunksY[step] != 0 {
+			var injectErr error
+
+			injected := a.underFence(func() {
+				injectErr = session.inject(chunksX[step], chunksY[step])
+			}, stopCh)
+
+			if !injected || injectErr != nil {
+				// Canceled, or SendInput went away mid-animation. Playing the
+				// remaining steps out would spend the whole duration failing
+				// once per step; the session is closed on the way out.
+				return scrollRequest{}, false
+			}
+		}
+
+		if step == steps-1 {
+			break
+		}
+
+		timer.Reset(stepDelay)
+
+		select {
+		case <-stopCh:
+			stopAndDrainTimer(timer)
+
+			return scrollRequest{}, false
+		case next := <-reqCh:
+			stopAndDrainTimer(timer)
+
+			// This chunk has gone out; the undelivered remainder starts at
+			// the next one.
+			return composeUndelivered(
+				next, req, sumFrom(chunksX, step+1), sumFrom(chunksY, step+1),
+			), true
+		case <-timer.C:
+		}
+	}
+
+	return scrollRequest{}, false
+}
+
+// sumFrom totals the chunks from index on: the part of a schedule that has
+// not been injected yet.
+func sumFrom(chunks []float64, from int) float64 {
+	var total float64
+
+	for _, chunk := range chunks[from:] {
+		total += chunk
+	}
+
+	return total
+}
+
+// scrollScheduleTiming turns a request's configuration into a step count and
+// the gap between steps, with the same arithmetic the darwin and linux
+// animators use so one configuration produces one animation everywhere.
+func scrollScheduleTiming(req scrollRequest) (int, time.Duration) {
+	magnitude := math.Hypot(req.deltaX, req.deltaY)
+
+	duration := math.Min(float64(req.maxDuration), magnitude*req.durationPerPixel)
+	if duration < minScrollAnimationDuration {
+		duration = minScrollAnimationDuration
+	}
+
+	steps := req.steps
+	if steps <= 0 {
+		steps = defaultScrollSteps
+	}
+
+	maxSteps := max(int(duration/float64(minScrollStepDelay)), 1)
+	if steps > maxSteps {
+		steps = maxSteps
+	}
+
+	stepDelayMs := max(int(math.Round(duration/float64(steps))), minScrollStepDelay)
+
+	return steps, time.Duration(stepDelayMs) * time.Millisecond
+}

--- a/internal/adapter/platform/windows/scroll_animator_test.go
+++ b/internal/adapter/platform/windows/scroll_animator_test.go
@@ -1,0 +1,306 @@
+//go:build windows
+
+package windows
+
+import (
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/domain/action"
+)
+
+type fakeScrollSession struct {
+	mu     sync.Mutex
+	chunks [][2]float64
+	closed bool
+}
+
+func (s *fakeScrollSession) inject(deltaX, deltaY float64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.chunks = append(s.chunks, [2]float64{deltaX, deltaY})
+
+	return nil
+}
+
+func (s *fakeScrollSession) close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.closed = true
+}
+
+func (s *fakeScrollSession) traveled() (float64, float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var totalX, totalY float64
+
+	for _, chunk := range s.chunks {
+		totalX += chunk[0]
+		totalY += chunk[1]
+	}
+
+	return totalX, totalY
+}
+
+func (s *fakeScrollSession) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.closed
+}
+
+func sumChunks(values []float64) float64 {
+	var total float64
+
+	for _, value := range values {
+		total += value
+	}
+
+	return total
+}
+
+func waitFor(t *testing.T, condition func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	t.Fatal("condition not met before the deadline")
+}
+
+// TestScrollChunks_TravelsTheRequestedDistance is the property the whole
+// animation rests on: switching smooth scroll on changes when a scroll
+// arrives, never how far it goes. Every chunk is a whole number of 120ths, so
+// the total is exact for any whole-notch delta.
+func TestScrollChunks_TravelsTheRequestedDistance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		delta float64
+		steps int
+	}{
+		{name: "one notch down", delta: -1, steps: 20},
+		{name: "half a page up", delta: 500, steps: 20},
+		{name: "a single step", delta: 300, steps: 1},
+		{name: "more steps than notches", delta: 7, steps: 64},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			chunks := scrollChunks(test.delta, test.steps)
+
+			if len(chunks) != test.steps {
+				t.Fatalf("got %d chunks, want %d", len(chunks), test.steps)
+			}
+
+			if got := sumChunks(chunks); math.Abs(got-test.delta) > 1e-9 {
+				t.Errorf("chunks total %v, want %v", got, test.delta)
+			}
+		})
+	}
+}
+
+// TestScrollChunks_EasesOutInWholeWheelUnits pins the shape and the unit at
+// once: the early chunks are the long ones, and every chunk converts to an
+// integer mouseData, which is what lets the steps go below a notch without
+// SendInput rounding them.
+func TestScrollChunks_EasesOutInWholeWheelUnits(t *testing.T) {
+	t.Parallel()
+
+	chunks := scrollChunks(-10, 12)
+
+	for index, chunk := range chunks {
+		if units := chunk * wheelDelta; math.Abs(units-math.Round(units)) > 1e-9 {
+			t.Errorf("chunk %d = %v notches, which is not a whole number of 120ths", index, chunk)
+		}
+
+		if index > 0 && math.Abs(chunk) > math.Abs(chunks[index-1])+1e-9 {
+			t.Fatalf("chunk %d (%v) is longer than chunk %d (%v); the curve is not easing out",
+				index, chunk, index-1, chunks[index-1])
+		}
+	}
+
+	if chunks[0] >= 0 || chunks[0] <= -10 {
+		t.Errorf("first chunk = %v, want a negative fraction of the -10 notch delta", chunks[0])
+	}
+}
+
+func TestScrollAnimator_Animate_TravelsTheWholeDistance(t *testing.T) {
+	t.Parallel()
+
+	session := &fakeScrollSession{}
+	animator := newScrollAnimator(
+		func(_ action.Modifiers) (scrollSession, error) { return session, nil },
+	)
+
+	t.Cleanup(animator.stop)
+
+	// Both axes at once: a scroll_right bound alongside a scroll_down has to
+	// arrive as one diagonal animation, not as one axis lost to the other.
+	animator.animate(120, -500, 0, 8, 40, 0.1)
+
+	waitFor(t, session.isClosed)
+
+	horizontal, vertical := session.traveled()
+	if vertical != -500 {
+		t.Errorf("the animation traveled %v vertically, want -500", vertical)
+	}
+
+	if horizontal != 120 {
+		t.Errorf("the animation traveled %v horizontally, want 120", horizontal)
+	}
+}
+
+// TestScrollAnimator_Animate_HoldsTheModifiersOfTheRequestThatIsRunning pins
+// the reason a session exists: the modifier is a real key, pressed once
+// before the animation and released once after it, not toggled around every
+// chunk.
+func TestScrollAnimator_Animate_HoldsTheModifiersOfTheRequestThatIsRunning(t *testing.T) {
+	t.Parallel()
+
+	session := &fakeScrollSession{}
+
+	var (
+		guard   sync.Mutex
+		opens   int
+		lastMod action.Modifiers
+	)
+
+	animator := newScrollAnimator(func(modifiers action.Modifiers) (scrollSession, error) {
+		guard.Lock()
+		opens++
+		lastMod = modifiers
+		guard.Unlock()
+
+		return session, nil
+	})
+
+	t.Cleanup(animator.stop)
+
+	animator.animate(0, -300, action.ModCtrl, 6, 30, 0.1)
+
+	waitFor(t, session.isClosed)
+
+	guard.Lock()
+	defer guard.Unlock()
+
+	if opens != 1 {
+		t.Errorf("the animation opened %d sessions, want exactly 1", opens)
+	}
+
+	if lastMod != action.ModCtrl {
+		t.Errorf("the session was opened with %v, want ctrl", lastMod)
+	}
+}
+
+// TestScrollAnimator_Stop_EndsTheAnimation is what the unanimated path relies
+// on after a reload switches the animation off: no chunk lands after stop()
+// returns, and the session's modifier hold is released.
+func TestScrollAnimator_Stop_EndsTheAnimation(t *testing.T) {
+	t.Parallel()
+
+	session := &fakeScrollSession{}
+	animator := newScrollAnimator(
+		func(_ action.Modifiers) (scrollSession, error) { return session, nil },
+	)
+
+	// Long enough that stop() lands mid-animation.
+	animator.animate(0, -1000, 0, 40, 400, 1.0)
+
+	waitFor(t, func() bool {
+		session.mu.Lock()
+		defer session.mu.Unlock()
+
+		return len(session.chunks) > 0
+	})
+
+	animator.stop()
+
+	waitFor(t, session.isClosed)
+
+	_, before := session.traveled()
+
+	time.Sleep(60 * time.Millisecond)
+
+	if _, after := session.traveled(); after != before {
+		t.Errorf("the animation traveled %v more after stop(); it should have ended", after-before)
+	}
+}
+
+// TestScrollAnimator_Animate_HeldRepeatTravelsAsFarAsDiscretePresses keeps a
+// held scroll key honest: each tick preempts the animation before it and
+// absorbs its undelivered remainder, so the run lands exactly where the same
+// number of discrete presses would.
+func TestScrollAnimator_Animate_HeldRepeatTravelsAsFarAsDiscretePresses(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ticks    = 10
+		halfPage = -500
+	)
+
+	session := &fakeScrollSession{}
+	animator := newScrollAnimator(
+		func(_ action.Modifiers) (scrollSession, error) { return session, nil },
+	)
+
+	t.Cleanup(animator.stop)
+
+	for range ticks {
+		animator.animate(0, halfPage, 0, 20, 200, 0.5)
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	want := float64(ticks * halfPage)
+
+	waitFor(t, func() bool {
+		_, vertical := session.traveled()
+
+		return math.Abs(vertical-want) < 1e-6
+	})
+}
+
+// TestScrollAnimator_Animate_DropsTheRemainderOnADifferentModifierSet is the
+// deliberate cancel: a plain scroll arriving mid-zoom finishes unmodified and
+// does not inherit the zoom's undelivered distance.
+func TestScrollAnimator_Animate_DropsTheRemainderOnADifferentModifierSet(t *testing.T) {
+	t.Parallel()
+
+	next := composeUndelivered(
+		scrollRequest{deltaY: -100},
+		scrollRequest{deltaY: -1000, modifiers: action.ModCtrl},
+		0, -700,
+	)
+
+	if next.deltaY != -100 {
+		t.Errorf(
+			"a plain scroll absorbed %v of a ctrl scroll's remainder, want none",
+			next.deltaY+100,
+		)
+	}
+
+	same := composeUndelivered(
+		scrollRequest{deltaY: -100},
+		scrollRequest{deltaY: -1000},
+		0, -700,
+	)
+
+	if same.deltaY != -800 {
+		t.Errorf("a same-modifier scroll carries %v, want -800", same.deltaY)
+	}
+}

--- a/internal/adapter/platform/windows/scroll_animator_test.go
+++ b/internal/adapter/platform/windows/scroll_animator_test.go
@@ -82,8 +82,8 @@ func waitFor(t *testing.T, condition func() bool) {
 
 // TestScrollChunks_TravelsTheRequestedDistance is the property the whole
 // animation rests on: switching smooth scroll on changes when a scroll
-// arrives, never how far it goes. Every chunk is a whole number of 120ths, so
-// the total is exact for any whole-notch delta.
+// arrives, never how far it goes. Every chunk is a whole number of wheel
+// units, so the total is exact for any whole-pixel delta.
 func TestScrollChunks_TravelsTheRequestedDistance(t *testing.T) {
 	t.Parallel()
 
@@ -92,10 +92,11 @@ func TestScrollChunks_TravelsTheRequestedDistance(t *testing.T) {
 		delta float64
 		steps int
 	}{
-		{name: "one notch down", delta: -1, steps: 20},
+		{name: "one line down", delta: -50, steps: 20},
 		{name: "half a page up", delta: 500, steps: 20},
 		{name: "a single step", delta: 300, steps: 1},
-		{name: "more steps than notches", delta: 7, steps: 64},
+		{name: "more steps than pixels", delta: 7, steps: 64},
+		{name: "a single pixel", delta: 1, steps: 12},
 	}
 
 	for _, test := range tests {
@@ -125,18 +126,24 @@ func TestScrollChunks_EasesOutInWholeWheelUnits(t *testing.T) {
 	chunks := scrollChunks(-10, 12)
 
 	for index, chunk := range chunks {
-		if units := chunk * wheelDelta; math.Abs(units-math.Round(units)) > 1e-9 {
-			t.Errorf("chunk %d = %v notches, which is not a whole number of 120ths", index, chunk)
+		if units := chunk * wheelUnitsPerPixel; math.Abs(units-math.Round(units)) > 1e-9 {
+			t.Errorf(
+				"chunk %d = %v pixels, which is not a whole number of wheel units",
+				index,
+				chunk,
+			)
 		}
 
-		if index > 0 && math.Abs(chunk) > math.Abs(chunks[index-1])+1e-9 {
+		// The last chunk carries whatever truncation left over, which can be
+		// one unit after a run of zeros; the curve is read from the rest.
+		if index > 0 && index < len(chunks)-1 && math.Abs(chunk) > math.Abs(chunks[index-1])+1e-9 {
 			t.Fatalf("chunk %d (%v) is longer than chunk %d (%v); the curve is not easing out",
 				index, chunk, index-1, chunks[index-1])
 		}
 	}
 
 	if chunks[0] >= 0 || chunks[0] <= -10 {
-		t.Errorf("first chunk = %v, want a negative fraction of the -10 notch delta", chunks[0])
+		t.Errorf("first chunk = %v, want a negative fraction of the -10 pixel delta", chunks[0])
 	}
 }
 

--- a/internal/config/platform_support.go
+++ b/internal/config/platform_support.go
@@ -20,8 +20,6 @@ const (
 		"score each word"
 	noteVisionRectangles = "rectangle detection has no OCR answer, so it stays macOS-only " +
 		"even where the vision strategy lands; that half is text-only"
-	noteSmoothScroll = "the Windows scroll is injected in one step; macOS and Linux animate it, " +
-		"and on X11 the steps are whole wheel notches because X has no smaller scroll to send"
 	noteKeyboardLayout = "the keyboard layout is detected rather than chosen outside macOS"
 	noteMacOSSurfaces  = "the menu bar, the Dock, Notification Center, Stage Manager, " +
 		"picture-in-picture and the screen-capture chrome are macOS surfaces with no counterpart"
@@ -178,7 +176,7 @@ func PlatformSupport() parity.Declaration {
 			"smooth_cursor.relative_movement_duration",
 		),
 
-		parity.On(parity.KindOption, darwinAndLinux, noteSmoothScroll,
+		parity.Everywhere(parity.KindOption,
 			"smooth_scroll.enabled",
 			"smooth_scroll.steps",
 			"smooth_scroll.max_duration",

--- a/internal/config/platform_support_test.go
+++ b/internal/config/platform_support_test.go
@@ -12,7 +12,6 @@ import (
 // cannot disagree about how one of them is spelled.
 const (
 	screenShareHide     = "general.hide_overlay_in_screen_share"
-	smoothScrollEnabled = "smooth_scroll.enabled"
 	hintsStrategy       = "hints.strategy"
 	hideCursorStep      = "action hide_cursor"
 	hideCursorAction    = "hide_cursor"
@@ -39,11 +38,6 @@ func TestPlatformSupport_DeclaresTheKnownNarrowColumns(t *testing.T) {
 			"hiding the overlay from a screen share is a Quartz concept",
 			screenShareHide, "",
 			parity.Platforms{parity.Darwin},
-		},
-		{
-			"smooth scroll animates on macOS and Linux, not Windows",
-			smoothScrollEnabled, "",
-			parity.Platforms{parity.Darwin, parity.Linux},
 		},
 		{
 			"rectangle detection has no OCR answer",
@@ -135,7 +129,7 @@ func TestInertWords_Options(t *testing.T) {
 		},
 		{
 			name:    "an option inert only on Windows is silent on Linux",
-			written: map[string]string{smoothScrollEnabled: "true"},
+			written: map[string]string{visionMinConfidence: "0.5"},
 			target:  parity.Linux,
 			want:    nil,
 		},


### PR DESCRIPTION
## Description

This PR animates scrolls on Windows when `smooth_scroll.enabled` is on, with the same ease-out curve macOS and Linux use.

`MOUSEEVENTF_WHEEL` takes an integer count of `WHEEL_DELTA`/120ths, so the animator steps in 120ths of a notch, which puts Windows with Wayland rather than X11 (whole notches only). A `--modifier` is one real key held for the length of the animation, released after the last chunk. Turning the option off mid-flight (reload) stops the running animation before the next direct scroll lands. `smooth_scroll.steps`, `max_duration` and `duration_per_pixel` mean on Windows exactly what they mean elsewhere, and existing configs keep working: the four options were inert on Windows and warned at load, now they apply.

Docs: the Capability Matrix and per-word support rows read ✅ for Windows with the 120ths granularity stated in footnote 3, the smooth scroll entry leaves the Windows Known Gaps list (the cursor animation half already landed in #1584), and the ROADMAP line no longer lists animations as a Windows gap.

## Related Issues

Closes #1564

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — none needed, this replaces the one-step Windows path with an implementation
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [ ] `just ci` passes — ran the targeted set instead: `just lint-cross`, `GOOS=windows go vet`, `GOOS=windows go test -c`, `just build-windows`, `go test ./internal/config/ ./internal/architecture/ ./internal/supportref/`. The new Windows animator tests compile on the host but only run on the `windows-latest` CI job.
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

The animator is a port of the Linux `scroll_animator.go` shape (one worker, latest request wins, held-repeat folds the undelivered remainder in, a different modifier set drops it). The schedule is laid out in whole wheel units with the last chunk taking the remainder, so an animated scroll travels exactly what a direct one does. There is no unit cap because the direct Windows path has none.

Two fixes found while testing on a Windows machine ride along, both on the same wheel path:

- **Scale.** The wheel path sent the caller's pixel delta as a notch count, so `scroll.scroll_step = 50` was fifty notches and one scroll traveled most of a page (since #1578). Thirty pixels are now one notch, the figure the Linux X11 path uses, and the fraction is sent as `WHEEL_DELTA`/120ths rather than rounded to a detent. Direct and animated paths scale the same way. A `scroll_step` under 30 pixels sends less than one `WHEEL_DELTA` per event, which an application that does not accumulate partial deltas will ignore.
- **Modifier hold.** The hold suppresses a physically held modifier and presses it back on release. With the animation holding for hundreds of milliseconds, a user who let go of shift during a `shift+g` `go_bottom` had shift pressed back with nothing to release it, which read as a sticky shift with no badge. The keyboard hook now records physical modifier key-ups while a hold is open and release skips those keys.
