### PR TITLE
feat(windows): native notifications via tray balloon tips

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -190,7 +190,7 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Font resolution**           | ✅ NSFont                | ✅ fontconfig          | ✅ fontconfig                | ✅ fontconfig           | ⚠️ generic-alias map only ¹  |
 | **System tray**               | ✅ NSStatusItem ⁸        | ✅ D-Bus StatusNotifierItem ⁸ | ✅ StatusNotifierItem ⁸      | ✅ StatusNotifierItem ⁸ | ✅ Win32 notification area ⁸ |
 | **Native alerts**             | ✅ NSAlert               | ⚠️ D-Bus, not modal    | ⚠️ D-Bus, not modal          | ⚠️ D-Bus, not modal     | ✅ `MessageBoxW`             |
-| **Native notifications**      | ✅ UNNotification        | ✅ `org.freedesktop.Notifications` | ✅ `org.freedesktop.Notifications` | ✅ `org.freedesktop.Notifications` | 🟡          |
+| **Native notifications**      | ✅ UNNotification        | ✅ `org.freedesktop.Notifications` | ✅ `org.freedesktop.Notifications` | ✅ `org.freedesktop.Notifications` | ✅ Tray balloon tips ⁸ |
 | **Secure input detection**    | ✅                       | ➖ always false        | ➖ always false              | ➖ always false         | ➖ always false              |
 | **System cursor hide**        | ✅ `CGDisplayHideCursor` | ➖                     | ➖                           | ➖                      | ➖                           |
 | **`monitor_select` mode**     | ✅ native panels         | ✅ Cairo panels        | ✅ Cairo panels              | ✅ Cairo panels         | ✅ layered panels            |
@@ -436,6 +436,15 @@ so the two can never drift apart. It is a color change rather than a
 translucency one on purpose: the icon bytes reach Win32 with straight alpha
 where GDI's icon path wants it premultiplied, so a faded tile would render at
 the host's discretion rather than ours.
+
+**Notifications on Windows are balloon tips on that same tray icon**, sent
+with `Shell_NotifyIcon` and `NIF_INFO`, which Windows 10 and 11 render as
+toasts. WinRT toasts need an AppUserModelID an unpackaged exe does not have,
+and the tray icon is one Neru already owns. The tray is therefore the anchor:
+with `systray.enabled = false` there is nothing to attach a tip to, so
+`ShowNotification` reports `CodeNotSupported` naming that reason and every
+caller logs it rather than dropping the message. Alerts are `MessageBoxW` and
+do not depend on the tray.
 
 **Hover text works everywhere and is the tray icon's**, not a menu item's:
 `NSStatusItem.toolTip`, the SNI `ToolTip` property, and `NOTIFYICONDATA.szTip`
@@ -1179,11 +1188,10 @@ working, which is exactly why the build exists.
 
 **Windows**
 
-1. Native notifications — no toast support
-2. Font resolution — alias mapping only, no system font enumeration
-3. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
+1. Font resolution — alias mapping only, no system font enumeration
+2. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
    installs a launchd agent and Linux a systemd user unit
-4. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
+3. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
     every platform, but only the Unix client checks that for itself before
     connecting. A named pipe carries no ownership a client can read without
     opening it, so the Windows CLI trusts the name it derives from its own SID.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,8 +43,8 @@ The two largest open areas:
 - **Linux** — Wayland global hotkeys, which need `input`-group membership and a
   CGO build rather than missing code, and whose remaining work is failing
   loudly with the remedy.
-- **Windows** — the remaining Known Gaps entries: notifications, UIA tree
-  depth and `monitor_select`.
+- **Windows** — the remaining Known Gaps entries: UIA tree depth and
+  `monitor_select`.
 
 GNOME Wayland remains unsupported; the daemon refuses to start there. Reviving
 it needs libei plus a GNOME Shell extension — see

--- a/internal/adapter/platform/profile.go
+++ b/internal/adapter/platform/profile.go
@@ -123,9 +123,10 @@ func ProfileFor(target OS) Profile {
 				Notes:     "Keep the first overlay implementation CGO-free if practical",
 			},
 			Notifications: BackendPlan{
-				Name:      "windows toast",
+				Name:      "tray balloon tips",
 				BuildMode: BuildModePureGo,
-				Notes:     "Toast APIs are expected to be reachable without CGO",
+				Notes: "Shell_NotifyIcon NIF_INFO on the tray icon, shown as toasts on " +
+					"Windows 10 and 11; needs the tray icon, no AppUserModelID",
 			},
 		}
 	case Unknown:

--- a/internal/adapter/platform/profile_test.go
+++ b/internal/adapter/platform/profile_test.go
@@ -64,7 +64,7 @@ func TestProfileFor(t *testing.T) {
 			wantKeyboardBuild: BuildModePureGo,
 			wantOverlay:       "layered win32 window",
 			wantOverlayBuild:  BuildModePureGo,
-			wantNotify:        "windows toast",
+			wantNotify:        "tray balloon tips",
 			wantNotifyBuild:   BuildModePureGo,
 		},
 	}

--- a/internal/adapter/platform/windows/system.go
+++ b/internal/adapter/platform/windows/system.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/y3owk1n/neru/internal/derrors"
+	wintray "github.com/y3owk1n/neru/internal/adapter/systray/windows"
 	"github.com/y3owk1n/neru/internal/domain/geometry"
 	"github.com/y3owk1n/neru/internal/ports"
 )
@@ -42,8 +42,22 @@ func (s *SystemAdapter) Health(ctx context.Context) error {
 }
 
 // Capabilities returns the current Windows capability surface.
+//
+// Notifications are balloon tips on the tray icon, so a daemon whose tray runs
+// headless downgrades the row live: the code path exists, but nothing will be
+// shown, and neru doctor should say so rather than repeat the static preset.
 func (s *SystemAdapter) Capabilities() ports.PlatformCapabilities {
-	return ports.WindowsCapabilities()
+	capabilities := ports.WindowsCapabilities()
+
+	if wintray.Headless() {
+		capabilities.Notifications = ports.FeatureCapability{
+			Status: ports.FeatureStatusStub,
+			Detail: "notifications are tray balloon tips and the tray icon is not " +
+				"shown; enable systray.enabled to see them",
+		}
+	}
+
+	return capabilities
 }
 
 // ConfigDir returns the Windows-specific configuration directory.
@@ -310,15 +324,11 @@ func (s *SystemAdapter) ShowAlert(_ context.Context, title, message string) erro
 	return nil
 }
 
-// ShowNotification reports CodeNotSupported on Windows: there is no toast
-// implementation yet, and the port carries an error precisely so a caller is
-// told the message was dropped rather than assuming it was shown.
-// TODO(windows): implement using Windows Toast Notifications API.
+// ShowNotification shows a balloon tip on the tray icon, which Windows 10 and
+// 11 render as a toast. The tray is the anchor, so with systray.enabled off the
+// call reports CodeNotSupported with that reason and the caller logs it.
 func (s *SystemAdapter) ShowNotification(_ context.Context, title, message string) error {
-	return derrors.New(
-		derrors.CodeNotSupported,
-		"ShowNotification not yet implemented on windows; target toast notifications",
-	)
+	return wintray.ShowBalloon(title, message)
 }
 
 // CheckScreenCapturePermission reports true: Windows does not gate screen capture

--- a/internal/adapter/platform/windows/system.go
+++ b/internal/adapter/platform/windows/system.go
@@ -43,17 +43,19 @@ func (s *SystemAdapter) Health(ctx context.Context) error {
 
 // Capabilities returns the current Windows capability surface.
 //
-// Notifications are balloon tips on the tray icon, so a daemon whose tray runs
-// headless downgrades the row live: the code path exists, but nothing will be
-// shown, and neru doctor should say so rather than repeat the static preset.
+// Notifications are balloon tips on the tray icon, so once this process has
+// started its tray loop the row follows whether the shell holds the icon: a
+// headless run or a failed registration downgrades it live with the reason,
+// and neru doctor says so rather than repeating the static preset. Before the
+// loop starts, and in a process that never runs one, the preset stands.
 func (s *SystemAdapter) Capabilities() ports.PlatformCapabilities {
 	capabilities := ports.WindowsCapabilities()
 
-	if wintray.Headless() {
+	started, shown := wintray.TrayState()
+	if started && !shown {
 		capabilities.Notifications = ports.FeatureCapability{
 			Status: ports.FeatureStatusStub,
-			Detail: "notifications are tray balloon tips and the tray icon is not " +
-				"shown; enable systray.enabled to see them",
+			Detail: wintray.NoTrayIconDetail(),
 		}
 	}
 

--- a/internal/adapter/systray/windows/systray.go
+++ b/internal/adapter/systray/windows/systray.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 
 	"github.com/y3owk1n/neru/internal/adapter/systray/icon"
+	"github.com/y3owk1n/neru/internal/derrors"
 )
 
 // Win32 notification-area (system tray) icon + popup menu via pure syscall.
@@ -41,6 +42,11 @@ const (
 	nifMessage = 0x0001
 	nifIcon    = 0x0002
 	nifTip     = 0x0004
+	nifInfo    = 0x0010
+
+	// niifNone: no stock glyph on the balloon; Windows 10 and 11 render the
+	// tip as a toast that already carries the tray icon.
+	niifNone = 0x0000
 
 	tpmRightButton = 0x0002
 	tpmReturnCmd   = 0x0100
@@ -126,6 +132,8 @@ type winMsg struct {
 	lPrivate uint32
 }
 
+// notifyIconData mirrors the full NOTIFYICONDATAW so cbSize selects the
+// Vista+ layout, which is what makes NIF_INFO balloon tips available.
 type notifyIconData struct {
 	cbSize           uint32
 	hWnd             uintptr
@@ -134,6 +142,14 @@ type notifyIconData struct {
 	uCallbackMessage uint32
 	hIcon            uintptr
 	szTip            [128]uint16
+	dwState          uint32
+	dwStateMask      uint32
+	szInfo           [256]uint16
+	uVersion         uint32
+	szInfoTitle      [64]uint16
+	dwInfoFlags      uint32
+	guidItem         [16]byte
+	hBalloonIcon     uintptr
 }
 
 type bitmapInfoHeader struct {
@@ -185,6 +201,7 @@ var (
 	trayMu          sync.Mutex
 	trayHWND        uintptr
 	trayThreadID    uint32
+	trayHeadless    bool
 	trayQuit        bool
 	trayIconHandle  uintptr
 	trayNID         notifyIconData
@@ -324,6 +341,7 @@ func runTray(withIcon bool, onReadyFunc, onExitFunc func()) {
 	}
 
 	trayThreadID = currentThreadID()
+	trayHeadless = !withIcon
 	trayMu.Unlock()
 
 	if withIcon {
@@ -430,6 +448,57 @@ func SetIcon(iconBytes []byte) {
 // rendered literally.
 func SetTemplateIcon(iconBytes []byte, template bool) {
 	SetIcon(iconBytes)
+}
+
+// Headless reports whether this process started its tray loop without an
+// icon (systray.enabled = false). It is false before the loop starts, so a
+// process that never runs a tray, such as the CLI, keeps the static capability
+// rather than reporting a tray it was never going to show.
+func Headless() bool {
+	trayMu.Lock()
+	defer trayMu.Unlock()
+
+	return trayHeadless
+}
+
+// ShowBalloon shows a balloon tip (a toast on Windows 10 and 11) anchored to
+// the tray icon. It is the Windows notification path: the shell renders
+// NIF_INFO tips for any icon in the notification area, with no AppUserModelID
+// or WinRT involved. Without a tray icon there is nothing to anchor to, so it
+// reports CodeNotSupported naming the reason rather than dropping the message.
+func ShowBalloon(title, message string) error {
+	trayMu.Lock()
+	defer trayMu.Unlock()
+
+	if trayHWND == 0 {
+		return derrors.New(
+			derrors.CodeNotSupported,
+			"notifications are tray balloon tips on Windows and the tray icon is "+
+				"not shown; enable systray.enabled to see them",
+		)
+	}
+
+	nid := notifyIconData{
+		cbSize:      uint32(unsafe.Sizeof(notifyIconData{})),
+		hWnd:        trayHWND,
+		uID:         trayNID.uID,
+		uFlags:      nifInfo,
+		dwInfoFlags: niifNone,
+	}
+	copyUTF16(nid.szInfoTitle[:], title)
+	// An empty szInfo removes the current balloon instead of showing one.
+	copyUTF16(nid.szInfo[:], message)
+
+	ret, _, err := procShellNotifyIconW.Call(nimModify, uintptr(unsafe.Pointer(&nid)))
+	if ret == 0 {
+		return derrors.Wrap(
+			err,
+			derrors.CodeActionFailed,
+			"Shell_NotifyIcon NIM_MODIFY balloon failed",
+		)
+	}
+
+	return nil
 }
 
 // AddMenuItem adds a top-level menu item to the tray menu.
@@ -850,15 +919,19 @@ func iconFromPNG(data []byte) uintptr {
 }
 
 func copyTip(nid *notifyIconData, tip string) {
-	runes := utf16FromString(tip)
+	copyUTF16(nid.szTip[:], tip)
+}
 
-	for i := range nid.szTip {
-		nid.szTip[i] = 0
-	}
+// copyUTF16 writes s into a fixed NOTIFYICONDATA text field, truncated to
+// leave the terminating NUL.
+func copyUTF16(dst []uint16, s string) {
+	runes := utf16FromString(s)
 
-	limit := min(len(runes), len(nid.szTip)-1)
+	clear(dst)
 
-	copy(nid.szTip[:limit], runes[:limit])
+	limit := min(len(runes), len(dst)-1)
+
+	copy(dst[:limit], runes[:limit])
 }
 
 func currentThreadID() uint32 {

--- a/internal/adapter/systray/windows/systray.go
+++ b/internal/adapter/systray/windows/systray.go
@@ -201,7 +201,8 @@ var (
 	trayMu          sync.Mutex
 	trayHWND        uintptr
 	trayThreadID    uint32
-	trayHeadless    bool
+	trayStarted     bool
+	trayIconShown   bool
 	trayQuit        bool
 	trayIconHandle  uintptr
 	trayNID         notifyIconData
@@ -341,7 +342,7 @@ func runTray(withIcon bool, onReadyFunc, onExitFunc func()) {
 	}
 
 	trayThreadID = currentThreadID()
-	trayHeadless = !withIcon
+	trayStarted = true
 	trayMu.Unlock()
 
 	if withIcon {
@@ -401,7 +402,7 @@ func SetTooltip(tooltip string) {
 
 	copyTip(&trayNID, tooltip)
 	trayNID.uFlags = nifMessage | nifIcon | nifTip
-	shellNotify(nimModify, &trayNID)
+	_ = shellNotify(nimModify, &trayNID)
 }
 
 // SetIcon replaces the tray icon with one built from the passed PNG bytes.
@@ -436,7 +437,7 @@ func SetIcon(iconBytes []byte) {
 	trayIconHandle = newIcon
 	trayNID.hIcon = newIcon
 	trayNID.uFlags = nifMessage | nifIcon | nifTip
-	shellNotify(nimModify, &trayNID)
+	_ = shellNotify(nimModify, &trayNID)
 
 	if oldIcon != 0 {
 		discardCall(procDestroyIcon.Call(oldIcon))
@@ -450,16 +451,25 @@ func SetTemplateIcon(iconBytes []byte, template bool) {
 	SetIcon(iconBytes)
 }
 
-// Headless reports whether this process started its tray loop without an
-// icon (systray.enabled = false). It is false before the loop starts, so a
-// process that never runs a tray, such as the CLI, keeps the static capability
-// rather than reporting a tray it was never going to show.
-func Headless() bool {
+// TrayState reports (started, shown): whether this process has started its tray loop and
+// whether the shell currently holds its icon. started is false in a process
+// that never runs a tray, such as the CLI, so a caller can tell "not shown"
+// from "not knowable here". shown tracks the NIM_ADD result, so a headless
+// run (systray.enabled = false) and a failed registration read the same.
+func TrayState() (bool, bool) {
 	trayMu.Lock()
 	defer trayMu.Unlock()
 
-	return trayHeadless
+	return trayStarted, trayIconShown
 }
+
+// noTrayIconDetail is the reason a notification cannot be shown without a
+// registered tray icon; the capability row carries the same words.
+const noTrayIconDetail = "notifications are tray balloon tips on Windows and the " +
+	"tray icon is not shown; enable systray.enabled to see them"
+
+// NoTrayIconDetail returns noTrayIconDetail for the capability row.
+func NoTrayIconDetail() string { return noTrayIconDetail }
 
 // ShowBalloon shows a balloon tip (a toast on Windows 10 and 11) anchored to
 // the tray icon. It is the Windows notification path: the shell renders
@@ -470,12 +480,8 @@ func ShowBalloon(title, message string) error {
 	trayMu.Lock()
 	defer trayMu.Unlock()
 
-	if trayHWND == 0 {
-		return derrors.New(
-			derrors.CodeNotSupported,
-			"notifications are tray balloon tips on Windows and the tray icon is "+
-				"not shown; enable systray.enabled to see them",
-		)
+	if !trayIconShown {
+		return derrors.New(derrors.CodeNotSupported, noTrayIconDetail)
 	}
 
 	nid := notifyIconData{
@@ -651,7 +657,7 @@ func addTrayIcon() {
 		hIcon:            icon,
 	}
 	copyTip(&trayNID, "Neru")
-	shellNotify(nimAdd, &trayNID)
+	trayIconShown = shellNotify(nimAdd, &trayNID)
 }
 
 func removeTrayIcon() {
@@ -662,7 +668,8 @@ func removeTrayIcon() {
 		return
 	}
 
-	shellNotify(nimDelete, &trayNID)
+	_ = shellNotify(nimDelete, &trayNID)
+	trayIconShown = false
 }
 
 // loadBrandIcon builds an HICON from the embedded brand PNG, falling back to
@@ -676,8 +683,11 @@ func loadBrandIcon() uintptr {
 	return icon
 }
 
-func shellNotify(message uint32, nid *notifyIconData) {
-	discardCall(procShellNotifyIconW.Call(uintptr(message), uintptr(unsafe.Pointer(nid))))
+// shellNotify reports whether the shell accepted the message.
+func shellNotify(message uint32, nid *notifyIconData) bool {
+	ret, _, _ := procShellNotifyIconW.Call(uintptr(message), uintptr(unsafe.Pointer(nid)))
+
+	return ret != 0
 }
 
 func pumpMessages() {

--- a/internal/ports/capability_presets.go
+++ b/internal/ports/capability_presets.go
@@ -180,8 +180,10 @@ func WindowsCapabilities() PlatformCapabilities {
 		Overlay: supportedCapability(
 			"native overlays available via DirectComposition + Direct2D (GDI fallback)",
 		),
-		Notifications: stubCapability(
-			"native notifications not implemented yet; target Windows toast notifications",
+		Notifications: supportedCapability(
+			"notifications shown as balloon tips on the tray icon (Shell_NotifyIcon " +
+				"NIF_INFO), rendered as toasts on Windows 10 and 11; they need " +
+				"systray.enabled, and alerts use MessageBoxW",
 		),
 		GlobalHotkeys: supportedCapability(
 			"global hotkeys available via RegisterHotKey",

--- a/internal/ports/capability_presets_test.go
+++ b/internal/ports/capability_presets_test.go
@@ -37,7 +37,7 @@ func TestNonDarwinCapabilities_ReportStubbedFeatures(t *testing.T) {
 		// Windows discovers them via UI Automation. Linux notifications go to
 		// the freedesktop notification daemon over the same session bus, so the
 		// preset is supported and the adapter downgrades it live when no daemon
-		// is running; Windows has no toast implementation at all.
+		// is running; Windows anchors balloon tips to the tray icon it owns.
 		{
 			name:                "linux",
 			capabilities:        ports.LinuxCapabilities(),
@@ -48,7 +48,7 @@ func TestNonDarwinCapabilities_ReportStubbedFeatures(t *testing.T) {
 			name:                "windows",
 			capabilities:        ports.WindowsCapabilities(),
 			accessibilityStatus: ports.FeatureStatusSupported,
-			notificationsStatus: ports.FeatureStatusStub,
+			notificationsStatus: ports.FeatureStatusSupported,
 		},
 	}
 


### PR DESCRIPTION
## Description

This PR adds native notifications on Windows. Every message that already reaches a macOS or Linux user as a notification (the tray's "version copied" confirmation, the vision-strategy-unavailable notice in hints, the monitor_select unsupported notice) now shows as a balloon tip anchored to Neru's tray icon, which Windows 10 and 11 render as a toast. No WinRT and no AppUserModelID registration, so it works for the unpackaged exe.

The tray icon is the anchor. With `systray.enabled = false` there is nothing to attach a tip to, so the call reports `CodeNotSupported` naming that reason and each caller logs it instead of dropping the message silently. Alerts are unchanged and keep using the native message box. `neru doctor` reports the notifications row as supported on Windows, and a running daemon whose tray is disabled downgrades that row live with the same reason, so doctor never claims a notification the session cannot show. Known Gaps loses its first Windows entry.

## Related Issues

Closes #1565

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this replaces the Windows stub; macOS and Linux already implement the port
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, ran the targeted subset instead: `just fmt`, `just lint-cross` (Linux and Windows), a `GOOS=windows` build, and the `ports`, `adapter/platform` and `architecture` test packages; CI runs the full set on all three hosts
- [x] Tests added/updated for new or changed functionality — the capability preset and profile expectations move from stub to supported; the balloon itself needs a real desktop session and has no unit-testable seam
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

Balloon tips over WinRT toasts is the decision recorded in the parent issue (#1551): toasts need an AppUserModelID that an unpackaged exe does not have, while the notification area already renders `NIF_INFO` tips for any icon it hosts. The tray's `NOTIFYICONDATA` mirror grows to the full Vista+ layout so the shell accepts the info fields; existing add, modify and delete calls pass the same larger size, which the shell treats as the current structure version.
