### PR TITLE
feat(windows): neru services via Task Scheduler

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -394,10 +394,13 @@ unconditionally and delegates to unexported helpers (`installService`,
 [services_darwin.go](../internal/cli/services_darwin.go) (`//go:build darwin`)
 drives `launchctl` and `.plist` files,
 [services_linux.go](../internal/cli/services_linux.go) (`//go:build linux`)
-drives `systemctl --user` and a unit file, and
-[services_other.go](../internal/cli/services_other.go)
-(`//go:build !darwin && !linux`) returns `CodeNotSupported`. Registration is
-shared, so a platform joining the set adds one file and no `init()`.
+drives `systemctl --user` and a unit file,
+[services_windows.go](../internal/cli/services_windows.go)
+(`//go:build windows`) drives the Task Scheduler COM API with an XML task
+definition, and [services_other.go](../internal/cli/services_other.go)
+(`//go:build !darwin && !linux && !windows`) returns `CodeNotSupported`.
+Registration is shared, so a platform joining the set adds one file and no
+`init()`.
 
 **`IsRunningFromAppBundle`** — [root.go](../internal/cli/root.go) delegates to
 a build-tagged implementation: [root_darwin.go](../internal/cli/root_darwin.go)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1509,11 +1509,12 @@ Manage Neru as a system service that starts on login.
 neru services install|uninstall|start|stop|restart|status
 ```
 
-**Platforms:** macOS, using a launchd user agent, and Linux, using a systemd
-user unit. Windows returns `ERR_NOT_SUPPORTED`. When Neru was installed through
-Nix, Homebrew, home-manager, or another package manager that manages the service
-itself, use that tool instead — on Linux, `install` and `uninstall` both refuse
-rather than touching a unit Neru did not write.
+**Platforms:** macOS, using a launchd user agent; Linux, using a systemd user
+unit; Windows, using a Task Scheduler task with a logon trigger. When Neru was
+installed through Nix, Homebrew, home-manager, or another package manager that
+manages the service itself, use that tool instead — on Linux and Windows,
+`install` and `uninstall` both refuse rather than touching a unit or task Neru
+did not write.
 
 | Subcommand  | Description                                |
 | ----------- | ------------------------------------------ |
@@ -1524,10 +1525,17 @@ rather than touching a unit Neru did not write.
 | `restart`   | Restart the service                         |
 | `status`    | Report whether the service is installed and running |
 
-The definition is a launchd plist in `~/Library/LaunchAgents` on macOS and a
-systemd user unit on Linux; where the Linux unit is written, what it contains,
-and what happens on a machine booted by another init system are in
+The definition is a launchd plist in `~/Library/LaunchAgents` on macOS, a
+systemd user unit on Linux, and a task named `\Neru` in the Task Scheduler root
+folder on Windows; where the Linux unit is written, what it contains, and what
+happens on a machine booted by another init system are in
 [LINUX_SETUP.md](LINUX_SETUP.md#systemd-user-service).
+
+The Windows task runs `neru launch` as the installing user with an interactive
+token, restarts it on failure, and carries no execution time limit, so the
+scheduler never stops the daemon on its own. `status` reads the scheduler's own
+task state (running, ready, queued, disabled), and `stop` ends the running
+instance the way `schtasks /End` would. No administrator rights are needed.
 
 The macOS agent leaves the daemon's standard output alone — the rotated log file
 already holds every log line — and sends its standard error to

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -198,7 +198,7 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Screen capture**            | ✅ ScreenCaptureKit      | ✅ `XGetImage`         | ✅ `wlr-screencopy`          | ⚠️ portal ScreenCast, consent ⁵ | ✅ `BitBlt` ⁵        |
 | **Vision / OCR detection**    | ✅ Vision framework      | ⚠️ tesseract, text only ⁶ | ⚠️ tesseract, text only ⁶ | ⚠️ tesseract, text only ⁶ | ⚠️ `Windows.Media.Ocr`, text only ⁶ |
 | **Key feed (`neru key`)**     | ✅ `CGEventPost`         | ✅ uinput               | ✅ uinput / virtual-keyboard | ✅ uinput               | 🟡 `CodeNotSupported`        |
-| **Service management (`neru services`)** | ✅ launchd user agent | ⚠️ systemd user unit only ² | ⚠️ systemd user unit only ² | ⚠️ systemd user unit only ² | 🟡 `CodeNotSupported` |
+| **Service management (`neru services`)** | ✅ launchd user agent | ⚠️ systemd user unit only ² | ⚠️ systemd user unit only ² | ⚠️ systemd user unit only ² | ✅ Task Scheduler logon task |
 
 ¹ macOS and Linux resolve font *families* through the OS (NSFont, fontconfig).
 Windows only maps the generic aliases `sans` / `serif` / `mono` to Segoe UI /
@@ -1189,9 +1189,7 @@ working, which is exactly why the build exists.
 **Windows**
 
 1. Font resolution — alias mapping only, no system font enumeration
-2. `neru services` — every subcommand returns `CodeNotSupported`, where macOS
-   installs a launchd agent and Linux a systemd user unit
-3. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
+2. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
     every platform, but only the Unix client checks that for itself before
     connecting. A named pipe carries no ownership a client can read without
     opening it, so the Windows CLI trusts the name it derives from its own SID.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -547,7 +547,8 @@ just install   # copies neru to ~/.local/bin, offers a systemd user service,
 # Windows (from Git Bash): build the exe, then install it
 just build-windows
 just install   # copies neru.exe under %LOCALAPPDATA%, and offers a user PATH entry,
-               # a Start Menu shortcut, and a login autostart entry
+               # a Start Menu shortcut, and a Task Scheduler logon task via
+               # `neru services install`
 ```
 
 `just install` refuses to run over a Homebrew or Nix-managed install and tells you
@@ -593,7 +594,8 @@ open -a Neru
 # Or CLI
 neru launch
 
-# Or install as launchd service for auto-startup
+# Or install as a login service for auto-startup: a launchd agent on macOS,
+# a systemd user unit on Linux, a Task Scheduler task on Windows
 neru services install
 ```
 
@@ -745,10 +747,13 @@ sudo gpasswd -d "$USER" input
 <summary>Windows (PowerShell)</summary>
 
 ```powershell
+# Stop and remove the Task Scheduler task (if installed); an install made
+# before `neru services` reached Windows used a Run key instead
+neru services uninstall
+Remove-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name Neru -ErrorAction SilentlyContinue
 Stop-Process -Name neru -Force -ErrorAction SilentlyContinue
 
-# Autostart and Start Menu shortcut
-Remove-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name Neru
+# Start Menu shortcut
 Remove-Item "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Neru.lnk"
 
 # Binary

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -9,16 +9,18 @@ import (
 // macOS: backed by a launchd user agent.
 // Linux: backed by a systemd user unit; other init systems return
 // CodeNotSupported.
+// Windows: backed by a Task Scheduler logon task for the current user.
 // Other platforms: stubbed and returns CodeNotSupported until implemented.
 var ServicesCmd = &cobra.Command{
 	Use:   "services",
-	Short: "Manage the Neru system service (macOS launchd, Linux systemd)",
+	Short: "Manage the Neru system service (launchd, systemd, Task Scheduler)",
 	Long: `Manage the Neru system service for automatic startup on login.
 
-On macOS this manages a launchd agent, and on Linux a systemd user unit
-ordered after graphical-session.target, so Neru starts automatically once
-your graphical session is up. Linux service management covers systemd
-only; other init systems report ERR_NOT_SUPPORTED.
+On macOS this manages a launchd agent, on Linux a systemd user unit
+ordered after graphical-session.target, and on Windows a Task Scheduler
+task with a logon trigger, so Neru starts automatically once your
+session is up. Linux service management covers systemd only; other init
+systems report ERR_NOT_SUPPORTED.
 
 Subcommands:
   install     Install and load the system service
@@ -33,7 +35,7 @@ Subcommands:
 var ServicesInstallCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install and load the system service",
-	Long:  `Install the Neru service so it starts automatically on login: a launchd plist loaded with launchctl on macOS, a systemd user unit enabled with systemctl --user on Linux.`,
+	Long:  `Install the Neru service so it starts automatically on login: a launchd plist loaded with launchctl on macOS, a systemd user unit enabled with systemctl --user on Linux, a Task Scheduler logon task on Windows.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := installService()
 		if err != nil {
@@ -50,7 +52,7 @@ var ServicesInstallCmd = &cobra.Command{
 var ServicesUninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Unload and remove the system service",
-	Long:  `Unload the Neru service and remove the file that describes it — the launchd plist on macOS, the systemd user unit on Linux. Neru will no longer start automatically on login.`,
+	Long:  `Unload the Neru service and remove what describes it — the launchd plist on macOS, the systemd user unit on Linux, the Task Scheduler task on Windows. Neru will no longer start automatically on login.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := uninstallService()
 		if err != nil {

--- a/internal/cli/services_integration_windows_test.go
+++ b/internal/cli/services_integration_windows_test.go
@@ -1,0 +1,109 @@
+//go:build integration && windows
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// testTaskPath is a task name no real install uses, so the round trip below
+// never touches a \Neru task the machine already has.
+func testTaskPath(t *testing.T) string {
+	t.Helper()
+
+	return fmt.Sprintf(`\NeruTest-%d`, os.Getpid())
+}
+
+// requireTaskScheduler skips when the scheduler cannot be reached at all,
+// which a locked-down session reports as an error on the very first call.
+func requireTaskScheduler(t *testing.T, path string) {
+	t.Helper()
+
+	status := statusServiceTask(path)
+	if strings.HasPrefix(status, "Service status unavailable") {
+		t.Skipf("skipping: %s", status)
+	}
+}
+
+// TestServiceTask_RoundTrip registers, inspects, drives and deletes a task on
+// the real scheduler, which is the only reader whose opinion of the XML counts.
+//
+// The action is this test binary with `launch` as its argument, which exits at
+// once, so the task's state after Run may already be back to ready; the
+// assertion is that Run was accepted, and that status reports an installed
+// task, not that a daemon stays up.
+func TestServiceTask_RoundTrip(t *testing.T) {
+	path := testTaskPath(t)
+	requireTaskScheduler(t, path)
+
+	t.Cleanup(func() { _ = uninstallServiceTask(path) })
+
+	if status := statusServiceTask(path); !strings.Contains(status, "not installed") {
+		t.Fatalf("statusServiceTask() before install = %q, want not installed", status)
+	}
+
+	err := installServiceTask(path)
+	if err != nil {
+		t.Fatalf("installServiceTask() error = %v", err)
+	}
+
+	err = installServiceTask(path)
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Errorf("second installServiceTask() error = %v, want %v", err, derrors.CodeInvalidInput)
+	}
+
+	status := statusServiceTask(path)
+	if !strings.HasPrefix(status, "Service installed: ") ||
+		!strings.Contains(status, "enabled at login") {
+		t.Errorf("statusServiceTask() after install = %q, want installed and enabled", status)
+	}
+
+	for _, step := range []struct {
+		name string
+		call func(string) error
+	}{
+		{name: "stop", call: func(p string) error { return driveServiceTask("stop", p, stopTask) }},
+		{name: "start", call: func(p string) error { return driveServiceTask("start", p, runTask) }},
+		{name: "restart", call: func(p string) error { return driveServiceTask("restart", p, restartTask) }},
+	} {
+		err = step.call(path)
+		if err != nil {
+			t.Errorf("%s error = %v", step.name, err)
+		}
+	}
+
+	err = uninstallServiceTask(path)
+	if err != nil {
+		t.Fatalf("uninstallServiceTask() error = %v", err)
+	}
+
+	if status := statusServiceTask(path); !strings.Contains(status, "not installed") {
+		t.Errorf("statusServiceTask() after uninstall = %q, want not installed", status)
+	}
+
+	err = uninstallServiceTask(path)
+	if err != nil {
+		t.Errorf("uninstallServiceTask() on nothing = %v, want nil", err)
+	}
+}
+
+// TestDriveServiceTask_RefusesWhenNothingIsInstalled pins that start, stop and
+// restart on a machine with no task say so rather than reporting success.
+func TestDriveServiceTask_RefusesWhenNothingIsInstalled(t *testing.T) {
+	path := testTaskPath(t)
+	requireTaskScheduler(t, path)
+
+	err := driveServiceTask("start", path, runTask)
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("driveServiceTask() error = %v, want %v", err, derrors.CodeInvalidInput)
+	}
+
+	if !strings.Contains(err.Error(), "neru services install") {
+		t.Errorf("driveServiceTask() message = %q, want it to name the next step", err.Error())
+	}
+}

--- a/internal/cli/services_internal_windows_test.go
+++ b/internal/cli/services_internal_windows_test.go
@@ -87,21 +87,33 @@ func TestDescribeServiceStatus_ReadsAsAStatementNotAnError(t *testing.T) {
 		{
 			name: "running and enabled",
 			state: serviceTaskState{
-				installed: true,
-				path:      serviceTaskPath,
-				state:     taskStateRunning,
-				enabled:   true,
+				installed:      true,
+				path:           serviceTaskPath,
+				state:          taskStateRunning,
+				enabled:        true,
+				triggerEnabled: true,
 			},
 			want: []string{"Service installed", taskWordRunning, "enabled at login"},
 		},
 		{
 			name: "ready but disabled",
 			state: serviceTaskState{
+				installed:      true,
+				path:           serviceTaskPath,
+				state:          taskStateReady,
+				triggerEnabled: true,
+			},
+			want: []string{taskWordReady, "disabled at login"},
+		},
+		{
+			name: "task enabled but its logon trigger switched off",
+			state: serviceTaskState{
 				installed: true,
 				path:      serviceTaskPath,
 				state:     taskStateReady,
+				enabled:   true,
 			},
-			want: []string{taskWordReady, "disabled at login"},
+			want: []string{"disabled at login"},
 		},
 	}
 
@@ -132,5 +144,39 @@ func TestNewBSTR_CarriesTheByteLengthPrefix(t *testing.T) {
 
 	if value.buf[2] != 'a' || value.buf[3] != 'b' || value.buf[4] != 0 {
 		t.Errorf("newBSTR(%q) text = %v, want a, b, NUL", "ab", value.buf[2:])
+	}
+}
+
+func TestLogonTriggerEnabled_ReadsTheTriggersOwnFlag(t *testing.T) {
+	testCases := []struct {
+		name string
+		xml  string
+		want bool
+	}{
+		{
+			name: "rendered template",
+			xml:  renderServiceTask(`C:\neru.exe`, "S-1-5-21-1"),
+			want: true,
+		},
+		{name: "no logon trigger", xml: "<Task><Triggers></Triggers></Task>", want: false},
+		{
+			name: "trigger switched off",
+			xml:  "<Task><Triggers><LogonTrigger><Enabled>false</Enabled></LogonTrigger></Triggers></Task>",
+			want: false,
+		},
+		{
+			name: "another trigger off, logon on",
+			xml: "<Task><Triggers><BootTrigger><Enabled>false</Enabled></BootTrigger>" +
+				"<LogonTrigger><Enabled>true</Enabled></LogonTrigger></Triggers></Task>",
+			want: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := logonTriggerEnabled(testCase.xml); got != testCase.want {
+				t.Errorf("logonTriggerEnabled() = %v, want %v", got, testCase.want)
+			}
+		})
 	}
 }

--- a/internal/cli/services_internal_windows_test.go
+++ b/internal/cli/services_internal_windows_test.go
@@ -1,0 +1,136 @@
+//go:build windows
+
+package cli
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+func TestRenderServiceTask_EscapesThePathAndNamesTheUser(t *testing.T) {
+	rendered := renderServiceTask(`C:\Program Files\A&B <x>\neru.exe`, "S-1-5-21-1-2-3-1001")
+
+	for _, want := range []string{
+		`<Command>C:\Program Files\A&amp;B &lt;x&gt;\neru.exe</Command>`,
+		`<Arguments>launch</Arguments>`,
+		`<UserId>S-1-5-21-1-2-3-1001</UserId>`,
+		`<LogonType>InteractiveToken</LogonType>`,
+		`<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>`,
+		serviceTaskMarker,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("renderServiceTask() lacks %q:\n%s", want, rendered)
+		}
+	}
+
+	if strings.Contains(rendered, "NERU_") {
+		t.Errorf("renderServiceTask() left a placeholder unfilled:\n%s", rendered)
+	}
+}
+
+func TestRenderServiceTask_IsWellFormedXML(t *testing.T) {
+	rendered := renderServiceTask(`C:\Users\tester\neru.exe`, "S-1-5-21-1-2-3-1001")
+
+	// The scheduler's schema is not checked here — the integration test
+	// registers the task with the scheduler itself — but a template that does
+	// not parse at all should fail somewhere cheaper than a real desktop.
+	var task struct {
+		XMLName xml.Name `xml:"Task"`
+	}
+
+	err := xml.Unmarshal([]byte(stripXMLDeclaration(rendered)), &task)
+	if err != nil {
+		t.Fatalf("renderServiceTask() is not well-formed XML: %v", err)
+	}
+}
+
+// stripXMLDeclaration drops the UTF-16 declaration, which is true of the BSTR
+// handed to the scheduler and false of the Go string a test parses.
+func stripXMLDeclaration(rendered string) string {
+	_, rest, _ := strings.Cut(rendered, "?>")
+
+	return rest
+}
+
+func TestTaskStateWord_UsesTheSchedulersOwnWords(t *testing.T) {
+	testCases := []struct {
+		state int32
+		want  string
+	}{
+		{state: taskStateRunning, want: "running"},
+		{state: taskStateReady, want: "ready (not running)"},
+		{state: taskStateQueued, want: "queued"},
+		{state: taskStateDisabled, want: "disabled"},
+		{state: taskStateUnknown, want: "unknown"},
+		{state: 99, want: taskWordUnknown},
+	}
+
+	for _, testCase := range testCases {
+		if got := taskStateWord(testCase.state); got != testCase.want {
+			t.Errorf("taskStateWord(%d) = %q, want %q", testCase.state, got, testCase.want)
+		}
+	}
+}
+
+func TestDescribeServiceStatus_ReadsAsAStatementNotAnError(t *testing.T) {
+	testCases := []struct {
+		name  string
+		state serviceTaskState
+		want  []string
+	}{
+		{
+			name:  "not installed names the path and the next step",
+			state: serviceTaskState{path: serviceTaskPath},
+			want:  []string{"not installed", `\Neru`, "neru services install"},
+		},
+		{
+			name: "running and enabled",
+			state: serviceTaskState{
+				installed: true,
+				path:      serviceTaskPath,
+				state:     taskStateRunning,
+				enabled:   true,
+			},
+			want: []string{"Service installed", taskWordRunning, "enabled at login"},
+		},
+		{
+			name: "ready but disabled",
+			state: serviceTaskState{
+				installed: true,
+				path:      serviceTaskPath,
+				state:     taskStateReady,
+			},
+			want: []string{taskWordReady, "disabled at login"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := describeServiceStatus(testCase.state)
+
+			for _, want := range testCase.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("describeServiceStatus() = %q, want it to contain %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestNewBSTR_CarriesTheByteLengthPrefix(t *testing.T) {
+	value, err := newBSTR("ab")
+	if err != nil {
+		t.Fatalf("newBSTR() error = %v", err)
+	}
+
+	// Two UTF-16 units of text are four bytes, excluding the terminator, and
+	// the prefix sits in the two units before the text the pointer aims at.
+	if got := uint32(value.buf[0]) | uint32(value.buf[1])<<16; got != 4 {
+		t.Errorf("newBSTR(%q) length prefix = %d, want 4", "ab", got)
+	}
+
+	if value.buf[2] != 'a' || value.buf[3] != 'b' || value.buf[4] != 0 {
+		t.Errorf("newBSTR(%q) text = %v, want a, b, NUL", "ab", value.buf[2:])
+	}
+}

--- a/internal/cli/services_other.go
+++ b/internal/cli/services_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !linux
+//go:build !darwin && !linux && !windows
 
 package cli
 
@@ -7,14 +7,15 @@ import (
 )
 
 // unsupportedServices is the one sentence every subcommand says on a platform
-// with no service manager behind it. macOS drives a launchd agent and Linux a
-// systemd user unit; nothing else does, so the refusal names both rather than
-// leaving a reader to guess which platform they are missing out on.
+// with no service manager behind it. macOS drives a launchd agent, Linux a
+// systemd user unit and Windows a Task Scheduler task; nothing else does, so
+// the refusal names all three rather than leaving a reader to guess which
+// platform they are missing out on.
 func unsupportedServices(action string) error {
 	return derrors.New(
 		derrors.CodeNotSupported,
-		"services "+action+" is supported on macOS (launchd) and Linux (systemd "+
-			"user units) only",
+		"services "+action+" is supported on macOS (launchd), Linux (systemd "+
+			"user units) and Windows (Task Scheduler) only",
 	)
 }
 

--- a/internal/cli/services_stub_contract_other_test.go
+++ b/internal/cli/services_stub_contract_other_test.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !linux
+//go:build !darwin && !linux && !windows
 
 package cli
 

--- a/internal/cli/services_windows.go
+++ b/internal/cli/services_windows.go
@@ -211,15 +211,17 @@ func guidMust(value string) windows.GUID {
 // variant is a VARIANT laid out for 64-bit Windows. Every VARIANT the
 // scheduler takes here is VT_EMPTY, and every one is passed by value, which on
 // x64 and ARM64 means a pointer to a copy: the struct is larger than a
-// register, so both ABIs pass it by reference.
+// register, so both ABIs pass it by reference. The copy lives in a variable
+// the caller owns across the call and keeps alive after it, so the collector
+// cannot take it back while COM reads it.
 type variant struct {
 	vt       uint16
 	reserved [3]uint16
 	value    [2]uintptr
 }
 
-func emptyVariant() uintptr {
-	return uintptr(unsafe.Pointer(new(variant)))
+func (v *variant) ptr() uintptr {
+	return uintptr(unsafe.Pointer(v))
 }
 
 // bstr is a BSTR built in Go memory for the scheduler to read: a four-byte
@@ -358,14 +360,18 @@ func withTaskFolder(body func(taskFolder) error) error {
 
 	// Connect(serverName, user, domain, password), all empty: the local
 	// machine as the current user.
+	var connectArgs [4]variant
+
 	hresult = comCall(
 		service,
 		vtServiceConnect,
-		emptyVariant(),
-		emptyVariant(),
-		emptyVariant(),
-		emptyVariant(),
+		connectArgs[0].ptr(),
+		connectArgs[1].ptr(),
+		connectArgs[2].ptr(),
+		connectArgs[3].ptr(),
 	)
+	runtime.KeepAlive(&connectArgs)
+
 	if failed(hresult) {
 		return hresultError("connect to the Task Scheduler service", hresult)
 	}
@@ -430,7 +436,12 @@ func (f taskFolder) registerTask(path, xml string) error {
 		return err
 	}
 
-	var task unsafe.Pointer
+	var (
+		task     unsafe.Pointer
+		userID   variant
+		password variant
+		sddl     variant
+	)
 
 	// RegisterTask(path, xmlText, flags, userId, password, logonType, sddl,
 	// ppTask). The user and password stay empty because the definition's own
@@ -441,14 +452,17 @@ func (f taskFolder) registerTask(path, xml string) error {
 		taskPath.ptr(),
 		definition.ptr(),
 		taskCreate,
-		emptyVariant(),
-		emptyVariant(),
+		userID.ptr(),
+		password.ptr(),
 		taskLogonInteractiveToken,
-		emptyVariant(),
+		sddl.ptr(),
 		uintptr(unsafe.Pointer(&task)),
 	)
 	runtime.KeepAlive(taskPath)
 	runtime.KeepAlive(definition)
+	runtime.KeepAlive(&userID)
+	runtime.KeepAlive(&password)
+	runtime.KeepAlive(&sddl)
 
 	if failed(hresult) {
 		return hresultError("register the Task Scheduler task "+path, hresult)
@@ -514,9 +528,14 @@ func taskXML(task unsafe.Pointer) (string, error) {
 // runTask is IRegisteredTask::Run, which starts an instance now regardless of
 // the trigger.
 func runTask(task unsafe.Pointer) error {
-	var running unsafe.Pointer
+	var (
+		running unsafe.Pointer
+		params  variant
+	)
 
-	hresult := comCall(task, vtTaskRun, emptyVariant(), uintptr(unsafe.Pointer(&running)))
+	hresult := comCall(task, vtTaskRun, params.ptr(), uintptr(unsafe.Pointer(&running)))
+	runtime.KeepAlive(&params)
+
 	if failed(hresult) {
 		return hresultError("start the task", hresult)
 	}
@@ -725,9 +744,27 @@ type serviceTaskState struct {
 	installed bool
 	// path is where Neru registers its task, whether or not it is there yet.
 	path string
-	// state is the scheduler's TASK_STATE, and enabled its Enabled flag.
-	state   int32
-	enabled bool
+	// state is the scheduler's TASK_STATE. enabled is the task's Enabled flag
+	// and triggerEnabled the logon trigger's own, which Task Scheduler's window
+	// lets a person switch off separately; both have to hold for the task to
+	// start at login.
+	state          int32
+	enabled        bool
+	triggerEnabled bool
+}
+
+// logonTriggerEnabled reads the logon trigger's enabled state out of a task
+// definition. A trigger with no <Enabled> element is enabled, and a task with
+// no logon trigger at all starts at login under no circumstances.
+func logonTriggerEnabled(xml string) bool {
+	_, trigger, found := strings.Cut(xml, "<LogonTrigger")
+	if !found {
+		return false
+	}
+
+	trigger, _, _ = strings.Cut(trigger, "</LogonTrigger>")
+
+	return !strings.Contains(trigger, "<Enabled>false</Enabled>")
 }
 
 // The scheduler's states in the words its own window uses, with "ready"
@@ -765,7 +802,7 @@ func describeServiceStatus(state serviceTaskState) string {
 	}
 
 	enabled := "enabled"
-	if !state.enabled {
+	if !state.enabled || !state.triggerEnabled {
 		enabled = taskWordDisabled
 	}
 
@@ -795,8 +832,18 @@ func statusServiceTask(path string) string {
 		}
 
 		state.enabled, err = taskEnabled(task)
+		if err != nil {
+			return err
+		}
 
-		return err
+		xml, err := taskXML(task)
+		if err != nil {
+			return err
+		}
+
+		state.triggerEnabled = logonTriggerEnabled(xml)
+
+		return nil
 	})
 	if err != nil {
 		return "Service status unavailable: " + err.Error()

--- a/internal/cli/services_windows.go
+++ b/internal/cli/services_windows.go
@@ -1,0 +1,810 @@
+//go:build windows
+
+package cli
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// Service management on Windows is a Task Scheduler task with a logon trigger,
+// registered for the current user. A Run key would start the daemon at login
+// too, but it cannot say whether the daemon is running, stop it, or start it
+// again — the four verbs besides install and uninstall — so the scheduler is
+// what gives `status`, `start`, `stop` and `restart` something real to mean.
+//
+// CGO is off on Windows, so the scheduler is driven through raw COM vtable
+// calls in the shape internal/adapter/accessibility/native/windows uses for UI
+// Automation. The task is described as XML and handed to
+// ITaskFolder::RegisterTask whole, which keeps the COM surface to three
+// objects: the service, its root folder, and the registered task.
+const (
+	// serviceTaskPath is the task's full path in the scheduler, which is also
+	// what a user types into `schtasks /TN` or finds in Task Scheduler's own
+	// window, so it stays the plain program name under the root folder.
+	serviceTaskPath = `\Neru`
+
+	// serviceTaskMarker is written into the task's description, and is the
+	// only positive evidence that a \Neru task is Neru's to stop and delete —
+	// a user or a deployment tool can register a task by the same name.
+	serviceTaskMarker = "Installed by `neru services install`"
+)
+
+// serviceTaskTemplate is the Task Scheduler definition Neru registers, in the
+// schema `schtasks /XML` and the Task Scheduler window both read.
+//
+// The logon trigger and the principal both name the current user, so the task
+// starts with that user's session and only that one. ExecutionTimeLimit PT0S
+// lifts the scheduler's default three-day limit on a running task, which would
+// otherwise kill the daemon on the fourth day. Priority 4 is the normal process
+// class with the main thread above normal; the scheduler's own default, 7, is
+// below-normal, and latency is the product. RestartOnFailure is the counterpart
+// of launchd's KeepAlive and systemd's Restart=on-failure.
+const serviceTaskTemplate = `<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>Neru keyboard-driven mouse replacement daemon. ` + serviceTaskMarker + `; Neru rewrites this task on install and deletes it on uninstall.</Description>
+    <URI>` + serviceTaskPath + `</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+      <UserId>NERU_USER_ID</UserId>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>NERU_USER_ID</UserId>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>false</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Priority>4</Priority>
+    <RestartOnFailure>
+      <Interval>PT1M</Interval>
+      <Count>3</Count>
+    </RestartOnFailure>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>NERU_BINARY_PATH</Command>
+      <Arguments>launch</Arguments>
+    </Exec>
+  </Actions>
+</Task>`
+
+// xmlTextEscaper escapes what cannot appear literally inside an XML element. A
+// directory called "A&B" is a legal place for neru.exe to live, and an
+// unescaped one is a task the scheduler refuses to register.
+var xmlTextEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+
+// renderServiceTask fills the task template with the binary that is installing
+// itself and the SID of the user it runs as.
+func renderServiceTask(binaryPath, userSID string) string {
+	return strings.NewReplacer(
+		"NERU_BINARY_PATH", xmlTextEscaper.Replace(binaryPath),
+		"NERU_USER_ID", xmlTextEscaper.Replace(userSID),
+	).Replace(serviceTaskTemplate)
+}
+
+// getBinaryPath resolves the running binary to a real path, because the task
+// outlives whatever PATH or link the install was run through.
+func getBinaryPath() (string, error) {
+	execPath, err := os.Executable()
+	if err != nil {
+		return "", derrors.Wrap(err, derrors.CodeConfigIOFailed, "failed to locate the neru binary")
+	}
+
+	resolved, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return "", derrors.Wrap(
+			err,
+			derrors.CodeConfigIOFailed,
+			"failed to resolve the neru binary path",
+		)
+	}
+
+	return resolved, nil
+}
+
+// currentUserSID is the principal the task runs as. The SID rather than the
+// account name, so a renamed account keeps its task.
+func currentUserSID() (string, error) {
+	current, err := user.Current()
+	if err != nil {
+		return "", derrors.Wrap(err, derrors.CodeInternal, "failed to look up the current user")
+	}
+
+	return current.Uid, nil
+}
+
+// COM plumbing for the Task Scheduler 2.0 API (taskschd.h).
+var (
+	modole32    = windows.NewLazySystemDLL("ole32.dll")
+	modoleaut32 = windows.NewLazySystemDLL("oleaut32.dll")
+
+	procCoInitializeEx   = modole32.NewProc("CoInitializeEx")
+	procCoUninitialize   = modole32.NewProc("CoUninitialize")
+	procCoCreateInstance = modole32.NewProc("CoCreateInstance")
+	procSysFreeString    = modoleaut32.NewProc("SysFreeString")
+
+	clsidTaskScheduler = guidMust("{0F87369F-A4E5-4CFC-BD3E-73E6154572DD}")
+	iidITaskService    = guidMust("{2FABA4C7-4DA9-4013-9697-20CC3FD40F85}")
+)
+
+const (
+	coinitMultithreaded = 0x0
+	clsctxInprocServer  = 0x1
+
+	hresultSOK         = 0
+	hresultSFalse      = 1
+	hresultChangedMode = 0x80010106 // RPC_E_CHANGED_MODE
+	hresultNotFound    = 0x80070002 // HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)
+
+	// TASK_CREATE refuses to replace a task that already exists, which install
+	// checks for itself first so it can say who owns the existing one.
+	taskCreate = 0x2
+	// TASK_LOGON_INTERACTIVE_TOKEN: run in the logged-on user's session, with
+	// the token of that session, which is the only one a desktop daemon can use.
+	taskLogonInteractiveToken = 0x3
+
+	// TASK_STATE values from get_State.
+	taskStateUnknown  = 0
+	taskStateDisabled = 1
+	taskStateQueued   = 2
+	taskStateReady    = 3
+	taskStateRunning  = 4
+
+	// Vtable slots. IUnknown holds 0–2 and IDispatch 3–6 on every interface
+	// here; the rest follow the order in taskschd.h.
+	vtRelease = 2
+
+	vtServiceGetFolder = 7
+	vtServiceConnect   = 10
+
+	vtFolderGetTask      = 13
+	vtFolderDeleteTask   = 15
+	vtFolderRegisterTask = 16
+
+	vtTaskGetState   = 9
+	vtTaskGetEnabled = 10
+	vtTaskRun        = 12
+	vtTaskGetXML     = 20
+	vtTaskStop       = 23
+)
+
+func guidMust(value string) windows.GUID {
+	guid, err := windows.GUIDFromString(value)
+	if err != nil {
+		panic(err)
+	}
+
+	return guid
+}
+
+// variant is a VARIANT laid out for 64-bit Windows. Every VARIANT the
+// scheduler takes here is VT_EMPTY, and every one is passed by value, which on
+// x64 and ARM64 means a pointer to a copy: the struct is larger than a
+// register, so both ABIs pass it by reference.
+type variant struct {
+	vt       uint16
+	reserved [3]uint16
+	value    [2]uintptr
+}
+
+func emptyVariant() uintptr {
+	return uintptr(unsafe.Pointer(new(variant)))
+}
+
+// bstr is a BSTR built in Go memory for the scheduler to read: a four-byte
+// length prefix, the UTF-16 text, and a NUL terminator, with the pointer
+// handed out aimed at the text. Every string that crosses into COM here is
+// copied by the callee before the call returns, so nothing needs SysAllocString
+// or a matching free; the buffer only has to stay alive across the call, which
+// is what the runtime.KeepAlive after each call is for.
+type bstr struct {
+	buf []uint16
+}
+
+const (
+	// bstrPrefixUnits is the four-byte length prefix measured in UTF-16 units.
+	bstrPrefixUnits = 2
+	utf16UnitBytes  = 2
+	bitsPerUint16   = 16
+)
+
+func newBSTR(value string) (bstr, error) {
+	chars, err := windows.UTF16FromString(value)
+	if err != nil {
+		return bstr{}, derrors.Wrap(
+			err,
+			derrors.CodeInvalidInput,
+			"failed to encode a string for the Task Scheduler",
+		)
+	}
+
+	byteLen := uint32(len(chars)-1) * utf16UnitBytes // excludes the terminator
+	buf := make([]uint16, bstrPrefixUnits+len(chars))
+	buf[0] = uint16(byteLen)
+	buf[1] = uint16(byteLen >> bitsPerUint16)
+	copy(buf[bstrPrefixUnits:], chars)
+
+	return bstr{buf: buf}, nil
+}
+
+func (b bstr) ptr() uintptr {
+	return uintptr(unsafe.Pointer(&b.buf[bstrPrefixUnits]))
+}
+
+// readBSTR copies a BSTR the scheduler allocated into a Go string and frees it.
+func readBSTR(value *uint16) string {
+	if value == nil {
+		return ""
+	}
+
+	text := windows.UTF16PtrToString(value)
+	discardCall(procSysFreeString.Call(uintptr(unsafe.Pointer(value))))
+
+	return text
+}
+
+// discardCall consumes a fire-and-forget COM call result; the release and
+// free calls it sinks have no actionable failure path.
+func discardCall(uintptr, uintptr, error) {}
+
+func comCall(this unsafe.Pointer, index int, args ...uintptr) uintptr {
+	vtbl := *(*unsafe.Pointer)(this)
+	method := *(*uintptr)(unsafe.Add(vtbl, uintptr(index)*unsafe.Sizeof(uintptr(0))))
+
+	full := make([]uintptr, 0, len(args)+1)
+	full = append(full, uintptr(this))
+	full = append(full, args...)
+
+	ret, _, _ := syscall.SyscallN(method, full...)
+
+	return ret
+}
+
+func failed(hresult uintptr) bool {
+	return int32(hresult) < 0
+}
+
+func release(object unsafe.Pointer) {
+	if object != nil {
+		comCall(object, vtRelease)
+	}
+}
+
+// hresultError turns a failed COM call into an error that quotes the system's
+// own explanation. FormatMessage knows the scheduler's SCHED_E_* codes as well
+// as the Win32 ones, so "The task XML is malformed" reaches the user rather
+// than a bare number — and the number is kept for the ones it does not know.
+func hresultError(attempt string, hresult uintptr) error {
+	return derrors.Newf(
+		derrors.CodeExecFailed,
+		"failed to %s: %s (HRESULT 0x%08X)",
+		attempt,
+		windows.Errno(uint32(hresult)).Error(),
+		uint32(hresult),
+	)
+}
+
+// taskFolder is a connected ITaskService's root folder, which every subcommand
+// works in. It lives only inside withTaskFolder, on one locked OS thread.
+type taskFolder struct {
+	folder unsafe.Pointer
+}
+
+// withTaskFolder connects to the scheduler and runs body against its root
+// folder. All COM work happens on a single locked OS thread — initialize,
+// create, connect, body, release — and nothing COM escapes the closure.
+func withTaskFolder(body func(taskFolder) error) error {
+	runtime.LockOSThread()
+
+	defer runtime.UnlockOSThread()
+
+	hresult, _, _ := procCoInitializeEx.Call(0, coinitMultithreaded)
+
+	// S_OK and S_FALSE mean this call owns initialization on the thread and
+	// must balance it with CoUninitialize. RPC_E_CHANGED_MODE means COM is
+	// already up in another mode; leave it alone.
+	switch uint32(hresult) {
+	case hresultSOK, hresultSFalse:
+		defer func() { discardCall(procCoUninitialize.Call()) }()
+	case hresultChangedMode:
+	default:
+		return hresultError("initialize COM", hresult)
+	}
+
+	var service unsafe.Pointer
+
+	hresult, _, _ = procCoCreateInstance.Call(
+		uintptr(unsafe.Pointer(&clsidTaskScheduler)),
+		0,
+		clsctxInprocServer,
+		uintptr(unsafe.Pointer(&iidITaskService)),
+		uintptr(unsafe.Pointer(&service)),
+	)
+	if failed(hresult) || service == nil {
+		return hresultError("create the Task Scheduler service", hresult)
+	}
+	defer release(service)
+
+	// Connect(serverName, user, domain, password), all empty: the local
+	// machine as the current user.
+	hresult = comCall(
+		service,
+		vtServiceConnect,
+		emptyVariant(),
+		emptyVariant(),
+		emptyVariant(),
+		emptyVariant(),
+	)
+	if failed(hresult) {
+		return hresultError("connect to the Task Scheduler service", hresult)
+	}
+
+	rootPath, err := newBSTR(`\`)
+	if err != nil {
+		return err
+	}
+
+	var folder unsafe.Pointer
+
+	hresult = comCall(
+		service,
+		vtServiceGetFolder,
+		rootPath.ptr(),
+		uintptr(unsafe.Pointer(&folder)),
+	)
+	runtime.KeepAlive(rootPath)
+
+	if failed(hresult) || folder == nil {
+		return hresultError("open the Task Scheduler root folder", hresult)
+	}
+	defer release(folder)
+
+	return body(taskFolder{folder: folder})
+}
+
+// getTask returns the registered task at path, and whether there is one. The
+// caller releases a found task.
+func (f taskFolder) getTask(path string) (unsafe.Pointer, bool, error) {
+	taskPath, err := newBSTR(path)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var task unsafe.Pointer
+
+	hresult := comCall(f.folder, vtFolderGetTask, taskPath.ptr(), uintptr(unsafe.Pointer(&task)))
+	runtime.KeepAlive(taskPath)
+
+	if uint32(hresult) == hresultNotFound {
+		return nil, false, nil
+	}
+
+	if failed(hresult) || task == nil {
+		return nil, false, hresultError("look up the Task Scheduler task "+path, hresult)
+	}
+
+	return task, true, nil
+}
+
+// registerTask registers a new task at path from its XML definition, refusing
+// to replace one that exists.
+func (f taskFolder) registerTask(path, xml string) error {
+	taskPath, err := newBSTR(path)
+	if err != nil {
+		return err
+	}
+
+	definition, err := newBSTR(xml)
+	if err != nil {
+		return err
+	}
+
+	var task unsafe.Pointer
+
+	// RegisterTask(path, xmlText, flags, userId, password, logonType, sddl,
+	// ppTask). The user and password stay empty because the definition's own
+	// principal names the user, and an interactive token needs no password.
+	hresult := comCall(
+		f.folder,
+		vtFolderRegisterTask,
+		taskPath.ptr(),
+		definition.ptr(),
+		taskCreate,
+		emptyVariant(),
+		emptyVariant(),
+		taskLogonInteractiveToken,
+		emptyVariant(),
+		uintptr(unsafe.Pointer(&task)),
+	)
+	runtime.KeepAlive(taskPath)
+	runtime.KeepAlive(definition)
+
+	if failed(hresult) {
+		return hresultError("register the Task Scheduler task "+path, hresult)
+	}
+
+	release(task)
+
+	return nil
+}
+
+func (f taskFolder) deleteTask(path string) error {
+	taskPath, err := newBSTR(path)
+	if err != nil {
+		return err
+	}
+
+	hresult := comCall(f.folder, vtFolderDeleteTask, taskPath.ptr(), 0)
+	runtime.KeepAlive(taskPath)
+
+	if failed(hresult) {
+		return hresultError("delete the Task Scheduler task "+path, hresult)
+	}
+
+	return nil
+}
+
+// taskState reads IRegisteredTask::get_State.
+func taskState(task unsafe.Pointer) (int32, error) {
+	var state int32
+
+	hresult := comCall(task, vtTaskGetState, uintptr(unsafe.Pointer(&state)))
+	if failed(hresult) {
+		return taskStateUnknown, hresultError("read the task state", hresult)
+	}
+
+	return state, nil
+}
+
+// taskEnabled reads IRegisteredTask::get_Enabled, a VARIANT_BOOL.
+func taskEnabled(task unsafe.Pointer) (bool, error) {
+	var enabled int16
+
+	hresult := comCall(task, vtTaskGetEnabled, uintptr(unsafe.Pointer(&enabled)))
+	if failed(hresult) {
+		return false, hresultError("read whether the task is enabled", hresult)
+	}
+
+	return enabled != 0, nil
+}
+
+// taskXML reads IRegisteredTask::get_Xml, the definition as registered.
+func taskXML(task unsafe.Pointer) (string, error) {
+	var xml *uint16
+
+	hresult := comCall(task, vtTaskGetXML, uintptr(unsafe.Pointer(&xml)))
+	if failed(hresult) {
+		return "", hresultError("read the task definition", hresult)
+	}
+
+	return readBSTR(xml), nil
+}
+
+// runTask is IRegisteredTask::Run, which starts an instance now regardless of
+// the trigger.
+func runTask(task unsafe.Pointer) error {
+	var running unsafe.Pointer
+
+	hresult := comCall(task, vtTaskRun, emptyVariant(), uintptr(unsafe.Pointer(&running)))
+	if failed(hresult) {
+		return hresultError("start the task", hresult)
+	}
+
+	release(running)
+
+	return nil
+}
+
+// stopTask is IRegisteredTask::Stop, which ends every running instance. It
+// succeeds on a task with no instance, so stop is idempotent.
+func stopTask(task unsafe.Pointer) error {
+	hresult := comCall(task, vtTaskStop, 0)
+	if failed(hresult) {
+		return hresultError("stop the task", hresult)
+	}
+
+	return nil
+}
+
+// requireOwnTask stops uninstall from stopping or deleting a \Neru task
+// somebody else registered: a deployment tool, or a user who set one up by
+// hand before this feature existed. The path says nothing about who wrote it,
+// so ownership is read out of the definition — the marker line Neru writes into
+// the description is the one thing only an install puts there.
+func requireOwnTask(task unsafe.Pointer, path string) error {
+	xml, err := taskXML(task)
+	if err != nil {
+		return err
+	}
+
+	if !strings.Contains(xml, serviceTaskMarker) {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"the Task Scheduler task %s carries no %q line in its description, so Neru "+
+				"did not register it; remove it in Task Scheduler or with `schtasks /Delete "+
+				"/TN Neru`, and `neru services install` will register Neru's own in its place",
+			path,
+			serviceTaskMarker,
+		)
+	}
+
+	return nil
+}
+
+func installServiceTask(path string) error {
+	binPath, err := getBinaryPath()
+	if err != nil {
+		return err
+	}
+
+	userSID, err := currentUserSID()
+	if err != nil {
+		return err
+	}
+
+	return withTaskFolder(func(folder taskFolder) error {
+		existing, found, err := folder.getTask(path)
+		if err != nil {
+			return err
+		}
+
+		if found {
+			release(existing)
+
+			return derrors.Newf(
+				derrors.CodeInvalidInput,
+				"a Task Scheduler task %s already exists; run `neru services uninstall` "+
+					"— or remove it in Task Scheduler if something else registered it — "+
+					"before installing again",
+				path,
+			)
+		}
+
+		err = folder.registerTask(path, renderServiceTask(binPath, userSID))
+		if err != nil {
+			return err
+		}
+
+		// Registered but never started is a task that blocks the next install
+		// and runs nothing until the next login, so a start failure undoes the
+		// registration, the way install on the other platforms undoes a unit
+		// systemd or launchd would not load.
+		task, found, err := folder.getTask(path)
+		if err != nil {
+			_ = folder.deleteTask(path)
+
+			return err
+		}
+
+		if !found {
+			_ = folder.deleteTask(path)
+
+			return derrors.New(
+				derrors.CodeInternal,
+				"the Task Scheduler task "+path+" was registered but cannot be found",
+			)
+		}
+
+		defer release(task)
+
+		err = runTask(task)
+		if err != nil {
+			_ = folder.deleteTask(path)
+
+			return err
+		}
+
+		return nil
+	})
+}
+
+func uninstallServiceTask(path string) error {
+	return withTaskFolder(func(folder taskFolder) error {
+		task, found, err := folder.getTask(path)
+		if err != nil {
+			return err
+		}
+
+		// Nothing to uninstall is not a failure.
+		if !found {
+			return nil
+		}
+
+		defer release(task)
+
+		err = requireOwnTask(task, path)
+		if err != nil {
+			return err
+		}
+
+		// Reported rather than swallowed: a stop that fails leaves the daemon
+		// running while the CLI would otherwise print success.
+		err = stopTask(task)
+		if err != nil {
+			return err
+		}
+
+		return folder.deleteTask(path)
+	})
+}
+
+// errNotInstalled is what start, stop and restart say when there is no task to
+// drive, which systemctl and launchctl each say in their own words.
+func errNotInstalled(action, path string) error {
+	return derrors.Newf(
+		derrors.CodeInvalidInput,
+		"services %s: no Task Scheduler task at %s — run `neru services install` first",
+		action,
+		path,
+	)
+}
+
+// driveServiceTask runs verb against the installed task, or refuses when there
+// is none.
+func driveServiceTask(action, path string, verb func(unsafe.Pointer) error) error {
+	return withTaskFolder(func(folder taskFolder) error {
+		task, found, err := folder.getTask(path)
+		if err != nil {
+			return err
+		}
+
+		if !found {
+			return errNotInstalled(action, path)
+		}
+
+		defer release(task)
+
+		return verb(task)
+	})
+}
+
+func restartTask(task unsafe.Pointer) error {
+	err := stopTask(task)
+	if err != nil {
+		return err
+	}
+
+	return runTask(task)
+}
+
+func installService() error {
+	return installServiceTask(serviceTaskPath)
+}
+
+func uninstallService() error {
+	return uninstallServiceTask(serviceTaskPath)
+}
+
+func startService() error {
+	return driveServiceTask("start", serviceTaskPath, runTask)
+}
+
+func stopService() error {
+	return driveServiceTask("stop", serviceTaskPath, stopTask)
+}
+
+func restartService() error {
+	return driveServiceTask("restart", serviceTaskPath, restartTask)
+}
+
+// serviceTaskState is everything `neru services status` reports, gathered
+// before any of it is put into words, so the wording can be tested without a
+// scheduler to ask.
+type serviceTaskState struct {
+	installed bool
+	// path is where Neru registers its task, whether or not it is there yet.
+	path string
+	// state is the scheduler's TASK_STATE, and enabled its Enabled flag.
+	state   int32
+	enabled bool
+}
+
+// The scheduler's states in the words its own window uses, with "ready"
+// glossed because to a person asking whether the daemon is up it means no.
+const (
+	taskWordRunning  = "running"
+	taskWordReady    = "ready (not running)"
+	taskWordQueued   = "queued"
+	taskWordDisabled = "disabled"
+	taskWordUnknown  = "unknown"
+)
+
+func taskStateWord(state int32) string {
+	switch state {
+	case taskStateRunning:
+		return taskWordRunning
+	case taskStateReady:
+		return taskWordReady
+	case taskStateQueued:
+		return taskWordQueued
+	case taskStateDisabled:
+		return taskWordDisabled
+	default:
+		return taskWordUnknown
+	}
+}
+
+// describeServiceStatus puts a gathered state into one line. A machine with no
+// task registered is an ordinary answer with the next step attached, not an
+// error.
+func describeServiceStatus(state serviceTaskState) string {
+	if !state.installed {
+		return "Service not installed: no Task Scheduler task at " + state.path +
+			" — run `neru services install` to create it"
+	}
+
+	enabled := "enabled"
+	if !state.enabled {
+		enabled = taskWordDisabled
+	}
+
+	return "Service installed: " + taskStateWord(state.state) + ", " + enabled + " at login"
+}
+
+func statusServiceTask(path string) string {
+	state := serviceTaskState{path: path}
+
+	err := withTaskFolder(func(folder taskFolder) error {
+		task, found, err := folder.getTask(path)
+		if err != nil {
+			return err
+		}
+
+		if !found {
+			return nil
+		}
+
+		defer release(task)
+
+		state.installed = true
+
+		state.state, err = taskState(task)
+		if err != nil {
+			return err
+		}
+
+		state.enabled, err = taskEnabled(task)
+
+		return err
+	})
+	if err != nil {
+		return "Service status unavailable: " + err.Error()
+	}
+
+	return describeServiceStatus(state)
+}
+
+func statusService() string {
+	return statusServiceTask(serviceTaskPath)
+}

--- a/scripts/install-windows.sh
+++ b/scripts/install-windows.sh
@@ -211,6 +211,17 @@ case "$run_reply" in
             echo "✓ Neru will start at login"
             echo "  Inspect with: neru services status"
             echo "  Remove later with: neru services uninstall"
+            # An installer before this one wrote a Run key for the same
+            # purpose; left in place it would launch a second daemon at
+            # every login, racing the task for the socket.
+            run_key="HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+            if MSYS2_ARG_CONV_EXCL='*' reg query "$run_key" /v Neru >/dev/null 2>&1; then
+                if MSYS2_ARG_CONV_EXCL='*' reg delete "$run_key" /v Neru /f >/dev/null 2>&1; then
+                    echo "✓ Removed the Run key entry an older installer wrote"
+                else
+                    echo "Could not remove the older Run key entry; delete 'Neru' from $run_key yourself, or Neru starts twice at login." >&2
+                fi
+            fi
         else
             echo "Could not register the login task; run 'neru services install' yourself." >&2
         fi

--- a/scripts/install-windows.sh
+++ b/scripts/install-windows.sh
@@ -53,10 +53,9 @@ run_ps() {
 
 # Minimal Windows install: a per-user binary, a Start Menu shortcut so Neru is
 # searchable from the taskbar like any other app, and optional autostart via
-# the registry Run key. Windows has no launchd or systemd and `neru services`
-# is macOS-only, so autostart is authored here, not by Neru. Runs under a bash
-# (e.g. Git Bash); `just` needs cygpath on PATH to translate the shebang, and
-# reg is called with MSYS2_ARG_CONV_EXCL so its /flags are not path-mangled.
+# `neru services install`, which registers a Task Scheduler logon task the way
+# the macOS installer loads a launchd agent. Runs under a bash (e.g. Git Bash);
+# `just` needs cygpath on PATH to translate the shebang.
 # Windows support is alpha (grid, recursive grid, scroll, hotkeys, mouse
 # injection, UIA); see docs/CROSS_PLATFORM.md.
 arch="$(uname -m)"
@@ -201,19 +200,19 @@ PS
         ;;
 esac
 
-# Step 4: autostart via the per-user Run key (no admin). Uses the full
-# exe path, so it does not depend on PATH.
+# Step 4: autostart via `neru services install`, run from the binary just
+# installed so the Task Scheduler task points at it whether or not PATH was
+# updated. No admin: the task runs as the current user with a logon trigger.
 echo "Step 4/4: Autostart"
-run_reply="$(ask "Start Neru at login (a registry Run entry)? [y/N] ")"
+run_reply="$(ask "Start Neru at login (a Task Scheduler task via 'neru services install')? [y/N] ")"
 case "$run_reply" in
     [Yy] | [Yy][Ee][Ss])
-        # MSYS2_ARG_CONV_EXCL='*' stops Git Bash from rewriting reg's
-        # /v /t /d /f flags (and the HKCU\... key) as POSIX paths.
-        if MSYS2_ARG_CONV_EXCL='*' reg add "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run" /v Neru /t REG_SZ /d "\"$win_dst_exe\" launch" /f >/dev/null 2>&1; then
+        if "$dst_exe" services install; then
             echo "✓ Neru will start at login"
-            echo "  Remove later with: MSYS2_ARG_CONV_EXCL='*' reg delete \"HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\" /v Neru /f"
+            echo "  Inspect with: neru services status"
+            echo "  Remove later with: neru services uninstall"
         else
-            echo "Could not write the Run key; add autostart manually." >&2
+            echo "Could not register the login task; run 'neru services install' yourself." >&2
         fi
         ;;
     *)

--- a/scripts/uninstall-windows.sh
+++ b/scripts/uninstall-windows.sh
@@ -104,16 +104,26 @@ else
 fi
 
 # Step 1: autostart. Removed first so a half-finished uninstall never leaves a
-# Run key pointing at a binary that is already gone.
+# login task pointing at a binary that is already gone. The task is Neru's own
+# to remove, through the binary about to be deleted; an install made before
+# `neru services` reached Windows wrote a Run key instead, so that is checked
+# for as well.
 echo "Step 1/5: Autostart"
+if [ -x "$dst_exe" ] && "$dst_exe" services status 2>/dev/null | grep -q '^Service installed'; then
+    if "$dst_exe" services uninstall >/dev/null 2>&1; then
+        echo "✓ Removed the Task Scheduler login task"
+    else
+        echo "Could not remove the login task; run 'neru services uninstall' yourself." >&2
+    fi
+else
+    echo "  No login task found"
+fi
 if MSYS2_ARG_CONV_EXCL='*' reg query "$run_key" /v Neru >/dev/null 2>&1; then
     if MSYS2_ARG_CONV_EXCL='*' reg delete "$run_key" /v Neru /f >/dev/null 2>&1; then
-        echo "✓ Removed the login autostart entry"
+        echo "✓ Removed the Run key entry an older installer wrote"
     else
         echo "Could not remove the Run key; delete 'Neru' from $run_key yourself." >&2
     fi
-else
-    echo "  No autostart entry found"
 fi
 
 # Step 2: Start Menu shortcut.

--- a/scripts/uninstall-windows.sh
+++ b/scripts/uninstall-windows.sh
@@ -113,7 +113,11 @@ if [ -x "$dst_exe" ] && "$dst_exe" services status 2>/dev/null | grep -q '^Servi
     if "$dst_exe" services uninstall >/dev/null 2>&1; then
         echo "✓ Removed the Task Scheduler login task"
     else
-        echo "Could not remove the login task; run 'neru services uninstall' yourself." >&2
+        # Stopping here keeps the binary the task points at, and with it the
+        # command that can still remove the task.
+        echo "Could not remove the login task, so nothing else was removed." >&2
+        echo "Run '$(win_path "$dst_exe")' services uninstall, or delete the task 'Neru' in Task Scheduler, then run 'just uninstall' again." >&2
+        exit 1
     fi
 else
     echo "  No login task found"


### PR DESCRIPTION
## Description

This PR makes `neru services` work on Windows through a Task Scheduler logon task.

`neru services install` registers a task named `\Neru` in the scheduler's root folder: a logon trigger for the current user, `neru launch` run with an interactive token, no execution time limit (the scheduler default would kill the daemon after three days), restart on failure, and normal process priority. It starts the task immediately, the way `enable --now` does on Linux. `uninstall` stops and deletes it, `start` / `stop` / `restart` drive the same task, and `status` reports the scheduler's own task state (running, ready, queued, disabled) plus whether it is enabled at login. No administrator rights are needed.

The scheduler is driven through the Task Scheduler 2.0 COM API with raw vtable calls, in the shape the UIA adapter already uses, since CGO is off on Windows. The task definition is XML passed to `ITaskFolder::RegisterTask` whole, so the COM surface stays at three objects. Uninstall refuses to touch a `\Neru` task whose description lacks the marker install writes, mirroring the Linux ownership check.

`just install` on Windows now offers `neru services install` for autostart instead of a Run key; `just uninstall` removes the task and cleans up a Run key from an older installer. `docs/INSTALLATION.md` describes the same path.

Not covered by this PR: the `install-linux.sh` header comment still says `neru services` is macOS-only. It is stale but outside this ticket.

## Related Issues

Closes #1566

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — `services_other.go` and its contract test now cover `!darwin && !linux && !windows`
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [ ] `just ci` passes — ran the targeted subset on the host instead: golangci-lint for the darwin, linux and windows targets of `internal/cli`, `go vet` and `go test -c` (unit and integration) with `GOOS=windows`, an arm64 Windows build, and `go test ./internal/cli/ ./internal/architecture/`. The Windows tests run for real on the `windows-latest` CI leg.
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

The ticket also asks that every `neru services` row in Platform Support Per Word read ✅ for Windows. That table is a projection of the option, mode-flag and action declarations and carries no rows for commands, so there was nothing to change there; the capability matrix row is the one that moved.

Tests: `services_internal_windows_test.go` pins the rendered XML, the status wording and the BSTR layout; `services_integration_windows_test.go` registers, drives and deletes a task under a `\NeruTest-<pid>` name on the real scheduler, so the XML is validated by the only reader whose opinion counts.

How to test by hand on Windows:

```
neru services status      # Service not installed: ...
neru services install
neru services status      # Service installed: running, enabled at login
schtasks /Query /TN Neru  # the same task, from the scheduler's side
neru services stop && neru services start && neru services restart
neru services uninstall
```
