### PR TITLE
feat(windows): resolve font families against installed fonts

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -187,7 +187,7 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Keyboard capture**          | ✅ CGEventTap            | ✅ `XGrabKeyboard`     | ✅ evdev grab (wl-keyboard fallback) | ✅ evdev grab   | ✅ `WH_KEYBOARD_LL`          |
 | **Modifier passthrough**      | ✅                       | ❌                     | ✅ evdev backend only        | ✅ evdev backend only   | ✅ `WH_KEYBOARD_LL` forwards or blocks per event |
 | **Dark mode detection**       | ✅ Cocoa appearance      | ✅ xdg appearance portal | ✅ xdg appearance portal   | ✅ kdeglobals + portal  | ✅ registry                  |
-| **Font resolution**           | ✅ NSFont                | ✅ fontconfig          | ✅ fontconfig                | ✅ fontconfig           | ⚠️ generic-alias map only ¹  |
+| **Font resolution**           | ✅ NSFont                | ✅ fontconfig          | ✅ fontconfig                | ✅ fontconfig           | ✅ GDI `EnumFontFamiliesExW` ¹ |
 | **System tray**               | ✅ NSStatusItem ⁸        | ✅ D-Bus StatusNotifierItem ⁸ | ✅ StatusNotifierItem ⁸      | ✅ StatusNotifierItem ⁸ | ✅ Win32 notification area ⁸ |
 | **Native alerts**             | ✅ NSAlert               | ⚠️ D-Bus, not modal    | ⚠️ D-Bus, not modal          | ⚠️ D-Bus, not modal     | ✅ `MessageBoxW`             |
 | **Native notifications**      | ✅ UNNotification        | ✅ `org.freedesktop.Notifications` | ✅ `org.freedesktop.Notifications` | ✅ `org.freedesktop.Notifications` | ✅ Tray balloon tips ⁸ |
@@ -200,26 +200,25 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Key feed (`neru key`)**     | ✅ `CGEventPost`         | ✅ uinput               | ✅ uinput / virtual-keyboard | ✅ uinput               | 🟡 `CodeNotSupported`        |
 | **Service management (`neru services`)** | ✅ launchd user agent | ⚠️ systemd user unit only ² | ⚠️ systemd user unit only ² | ⚠️ systemd user unit only ² | ✅ Task Scheduler logon task |
 
-¹ macOS and Linux resolve font *families* through the OS (NSFont, fontconfig).
-Windows only maps the generic aliases `sans` / `serif` / `mono` to Segoe UI /
-Cambria / Consolas and passes every other name straight to DirectWrite (GDI on
-the fallback surface) without checking it; an unavailable family falls back to
-whatever that renderer substitutes.
+¹ Every platform resolves font *families* through the OS: NSFont on macOS,
+fontconfig on Linux, GDI's `EnumFontFamiliesExW` on Windows.
 
 A family somebody named resolves to **that name**: the answer is the family the
-config asked for, not the family the platform would render in its place. The one
-exception is Linux with fontconfig, the only backend that can tell an installed
-family from a missing one — a missing one falls back to DejaVu Sans rather than
-to fontconfig's own substitution for the name, so `font_family = "Arial"`
-without Arial installed reports DejaVu Sans and not the Liberation Sans
+config asked for, not the family the platform would render in its place. The
+exception is a family the platform can see is missing, which the two backends
+that can tell an installed family from a missing one — Linux with fontconfig
+and Windows — send to the sans baseline rather than to the platform's own
+substitution for the name, so `font_family = "Arial"` without Arial installed
+reports DejaVu Sans on Linux and Segoe UI on Windows, not the Liberation Sans
 `fc-match Arial` names. It is the sans baseline whatever face the name asked
 for: the serif and mono baselines are what the `serif` and `mono` aliases
-resolve to, so a missing `Times New Roman` also lands on DejaVu Sans. Where the
-baseline is itself missing, fontconfig chooses that machine's generic, so the
-fallback is always a family it has. macOS, Windows, the non-CGO Linux build, and a CGO build whose
-fontconfig cannot be consulted at all check nothing: they hand the written name
-to NSFont / DirectWrite / Cairo, which substitute when the text is drawn — as Cairo does
-on Linux too, for whichever name it is given.
+resolve to, so a missing `Times New Roman` also lands on the sans one. Where the
+Linux baseline is itself missing, fontconfig chooses that machine's generic, so
+the fallback is always a family it has. Segoe UI ships with every supported
+Windows. macOS, the non-CGO Linux build, and a build whose fontconfig or GDI
+cannot be consulted at all check nothing: they hand the written name to NSFont
+/ DirectWrite / Cairo, which substitute when the text is drawn — as Cairo and
+DirectWrite do for whichever name they are given.
 
 Which names count as generic is the same on all three: `sans`, `sans serif`,
 `serif`, `mono`, `monospace` and the empty string, matched ignoring case,
@@ -1188,8 +1187,7 @@ working, which is exactly why the build exists.
 
 **Windows**
 
-1. Font resolution — alias mapping only, no system font enumeration
-2. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
+1. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
     every platform, but only the Unix client checks that for itself before
     connecting. A named pipe carries no ownership a client can read without
     opening it, so the Windows CLI trusts the name it derives from its own SID.

--- a/internal/adapter/platform/factory_windows.go
+++ b/internal/adapter/platform/factory_windows.go
@@ -13,7 +13,8 @@ func NewSystemPort() (ports.SystemPort, error) {
 }
 
 // NewFontResolver returns a Windows-backed FontResolver that maps generic
-// aliases to native Windows font families.
+// aliases to native Windows font families and checks the rest against the
+// fonts GDI has installed.
 func NewFontResolver() ports.FontResolver {
 	return windows.NewFontResolver()
 }

--- a/internal/adapter/platform/linux/font_nocgo.go
+++ b/internal/adapter/platform/linux/font_nocgo.go
@@ -9,8 +9,8 @@ import "github.com/y3owk1n/neru/internal/ports"
 // behave deterministically, and returns every other family as written — the
 // same answer the fontconfig build gives for a family that is installed. What
 // it cannot do is see that a family is missing, so nothing falls back to the
-// generic here; Cairo substitutes when the text is drawn, as it does for macOS
-// and Windows. CGO builds (the default) get the fontconfig adapter in
+// generic here; Cairo substitutes when the text is drawn, as NSFont does on
+// macOS. CGO builds (the default) get the fontconfig adapter in
 // font_cgo.go.
 func NewFontResolver() ports.FontResolver {
 	return &passthroughResolver{}

--- a/internal/adapter/platform/windows/font.go
+++ b/internal/adapter/platform/windows/font.go
@@ -3,6 +3,12 @@
 package windows
 
 import (
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
 	"github.com/y3owk1n/neru/internal/adapter/platform/fontcache"
 	"github.com/y3owk1n/neru/internal/adapter/platform/fontgeneric"
 	"github.com/y3owk1n/neru/internal/ports"
@@ -12,6 +18,11 @@ const (
 	defaultWindowsSans  = "Segoe UI"
 	defaultWindowsMono  = "Consolas"
 	defaultWindowsSerif = "Cambria"
+
+	// lfFaceSize is LF_FACESIZE: the LOGFONTW face-name field, terminator
+	// included.
+	lfFaceSize     = 32
+	defaultCharset = 1
 )
 
 // windowsFamilies is what the generic aliases mean on Windows.
@@ -21,11 +32,59 @@ var windowsFamilies = fontgeneric.Families{
 	Mono:  defaultWindowsMono,
 }
 
-// NewFontResolver returns a Windows-backed ports.FontResolver.
-func NewFontResolver() ports.FontResolver {
-	return &winFontResolver{cache: fontcache.New(windowsFamilies.Resolve)}
+// logFontW mirrors LOGFONTW; only lfCharSet and lfFaceName take part in an
+// EnumFontFamiliesExW query.
+type logFontW struct {
+	height         int32
+	width          int32
+	escapement     int32
+	orientation    int32
+	weight         int32
+	italic         byte
+	underline      byte
+	strikeOut      byte
+	charSet        byte
+	outPrecision   byte
+	clipPrecision  byte
+	quality        byte
+	pitchAndFamily byte
+	faceName       [lfFaceSize]uint16
 }
 
+var (
+	procEnumFontFamiliesExW = gdi32.NewProc("EnumFontFamiliesExW")
+
+	// fontEnumProcPtr is allocated once for the process (see
+	// displayWndProcPtr).
+	fontEnumProcPtr = sync.OnceValue(func() uintptr {
+		return syscall.NewCallback(fontEnumProc)
+	})
+
+	// fontEnumMu serializes enumerations so fontEnumFound belongs to one query
+	// at a time. The flag lives here rather than behind the LPARAM because a
+	// Go pointer smuggled through a uintptr may not survive the callback
+	// growing the stack.
+	fontEnumMu    sync.Mutex
+	fontEnumFound bool
+)
+
+// fontEnumProc is the FONTENUMPROCW EnumFontFamiliesExW calls once per
+// matching face. Being called at all is the answer, so it records that and
+// returns 0 to stop the enumeration.
+func fontEnumProc(_, _ uintptr, _ uint32, _ uintptr) uintptr {
+	fontEnumFound = true
+	return 0
+}
+
+// NewFontResolver returns a GDI-backed ports.FontResolver. Each family is
+// resolved on first use and cached for the lifetime of the process.
+func NewFontResolver() ports.FontResolver {
+	return &winFontResolver{cache: fontcache.New(resolveWindowsFamily)}
+}
+
+// winFontResolver implements ports.FontResolver. It maps generic aliases to
+// the Windows baseline families and asks GDI whether a user-supplied family
+// is installed, falling back to the sans baseline when it is not.
 type winFontResolver struct {
 	cache *fontcache.Resolver
 }
@@ -33,4 +92,70 @@ type winFontResolver struct {
 // Resolve implements ports.FontResolver.
 func (r *winFontResolver) Resolve(family string) string {
 	return r.cache.Resolve(family)
+}
+
+// resolveWindowsFamily maps the input to a concrete family and asks GDI
+// whether that family is installed: if it is, the answer is the name as
+// written, which is what ports.FontResolver promises. If it is not, the answer
+// is the sans baseline, the rule the fontconfig-backed Linux resolver follows.
+// When GDI cannot be consulted nothing can be verified, so the name passes
+// through as written and the text layer substitutes when it draws.
+func resolveWindowsFamily(family string) string {
+	mapped := windowsFamilies.Resolve(family)
+	if familyInstalled(mapped) == familyMissing {
+		return defaultWindowsSans
+	}
+
+	return mapped
+}
+
+// familyPresence is what GDI can say about a family. An unusable device
+// context is not the same answer as a family that is missing.
+type familyPresence int
+
+const (
+	familyUnknown familyPresence = iota
+	familyMissing
+	familyPresent
+)
+
+// familyInstalled asks GDI whether any installed face carries the given
+// family name. EnumFontFamiliesExW with a face name set enumerates only that
+// family, comparing names the way GDI does, ignoring case. A name GDI cannot
+// hold, longer than LOGFONTW allows, cannot be selected by GDI either and
+// counts as missing.
+func familyInstalled(family string) familyPresence {
+	name, err := windows.UTF16FromString(family)
+	if err != nil || len(name) > lfFaceSize {
+		return familyMissing
+	}
+
+	fontEnumMu.Lock()
+	defer fontEnumMu.Unlock()
+
+	hdc, _, _ := procCreateCompatibleDC.Call(0)
+	if hdc == 0 {
+		return familyUnknown
+	}
+
+	defer func() { discardCall(procDeleteDC.Call(hdc)) }()
+
+	logFont := logFontW{charSet: defaultCharset}
+	copy(logFont.faceName[:], name)
+
+	fontEnumFound = false
+
+	discardCall(procEnumFontFamiliesExW.Call(
+		hdc,
+		uintptr(unsafe.Pointer(&logFont)),
+		fontEnumProcPtr(),
+		0,
+		0,
+	))
+
+	if fontEnumFound {
+		return familyPresent
+	}
+
+	return familyMissing
 }

--- a/internal/adapter/platform/windows/font_test.go
+++ b/internal/adapter/platform/windows/font_test.go
@@ -4,6 +4,11 @@ package windows
 
 import "testing"
 
+const (
+	arial      = "Arial"
+	arialUpper = "ARIAL"
+)
+
 func TestWinFontResolver_GenericAliases(t *testing.T) {
 	// Which spellings count as generic is pinned by the shared parser
 	// (platform/fontgeneric); this pins what each generic means on Windows.
@@ -16,11 +21,9 @@ func TestWinFontResolver_GenericAliases(t *testing.T) {
 		"Monospace":  defaultWindowsMono,
 		"   mono   ": defaultWindowsMono,
 	}
-
 	for input, want := range cases {
 		t.Run(input, func(t *testing.T) {
 			fontResolver := NewFontResolver()
-
 			if got := fontResolver.Resolve(input); got != want {
 				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
 			}
@@ -28,20 +31,38 @@ func TestWinFontResolver_GenericAliases(t *testing.T) {
 	}
 }
 
-func TestWinFontResolver_NamedFamilyPassesThroughTrimmed(t *testing.T) {
-	// A family somebody named is handed to GDI as written, with only the
-	// surrounding whitespace removed; GDI substitutes if it is missing.
+func TestWinFontResolver_InstalledFamilyResolvesToItself(t *testing.T) {
+	// A family GDI has resolves to the name as written, surrounding whitespace
+	// removed and case kept. Arial and Courier New ship with every Windows.
 	cases := map[string]string{
-		"JetBrains Mono":    "JetBrains Mono",
-		"  Comic Sans MS  ": "Comic Sans MS",
+		arial:         arial,
+		arialUpper:    arialUpper,
+		"  Arial  ":   arial,
+		"Courier New": "Courier New",
 	}
-
 	for input, want := range cases {
 		t.Run(input, func(t *testing.T) {
 			fontResolver := NewFontResolver()
-
 			if got := fontResolver.Resolve(input); got != want {
 				t.Fatalf("Resolve(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestWinFontResolver_MissingFamilyFallsBackToSans(t *testing.T) {
+	// A family GDI does not have lands on the sans baseline whatever face the
+	// name suggests, the rule footnote 1 of docs/CROSS_PLATFORM.md states.
+	cases := []string{
+		"Neru Test Font That Does Not Exist",
+		"Neru Missing Serif",
+		"Neru Missing Mono",
+	}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			fontResolver := NewFontResolver()
+			if got := fontResolver.Resolve(input); got != defaultWindowsSans {
+				t.Fatalf("Resolve(%q) = %q, want %q", input, got, defaultWindowsSans)
 			}
 		})
 	}
@@ -51,12 +72,11 @@ func TestWinFontResolver_AnswersEachSpellingFromItsOwnName(t *testing.T) {
 	// Caching must not rewrite a caller's spelling; the shared rule is pinned
 	// on every CI leg in platform/fontcache, this pins that Windows uses it.
 	fontResolver := NewFontResolver()
-
-	if got := fontResolver.Resolve("Arial"); got != "Arial" {
-		t.Fatalf("Resolve(%q) = %q, want %q", "Arial", got, "Arial")
+	if got := fontResolver.Resolve(arial); got != arial {
+		t.Fatalf("Resolve(%q) = %q, want %q", arial, got, arial)
 	}
 
-	if got := fontResolver.Resolve("ARIAL"); got != "ARIAL" {
-		t.Fatalf("Resolve(%q) = %q, want %q", "ARIAL", got, "ARIAL")
+	if got := fontResolver.Resolve(arialUpper); got != arialUpper {
+		t.Fatalf("Resolve(%q) = %q, want %q", arialUpper, got, arialUpper)
 	}
 }

--- a/internal/ports/font.go
+++ b/internal/ports/font.go
@@ -20,9 +20,9 @@ type FontResolver interface {
 	//     the family the caller asked for, not the family the platform would
 	//     render in its place
 	//   - the one exception is a family the platform can see is not installed,
-	//     which falls back to the resolved generic family. Only the
-	//     fontconfig-backed Linux resolver can see that; macOS, Windows and
-	//     the non-CGO Linux build check nothing, pass the written name on, and
+	//     which falls back to the sans family. The fontconfig-backed Linux
+	//     resolver and the GDI-backed Windows one can see that; macOS and the
+	//     non-CGO Linux build check nothing, pass the written name on, and
 	//     leave substitution to the native text layer, which does it when the
 	//     text is drawn either way
 	Resolve(family string) string


### PR DESCRIPTION
## Description

This PR makes the Windows font resolver check a configured `font_family` against the fonts actually installed. Until now only the generic aliases (`sans`, `serif`, `mono`) were mapped, and every other name was handed to the renderer unchecked, so a family that was not installed rendered as whatever the renderer substituted and Neru could not tell an installed family from a missing one.

Now an installed family resolves to itself, exactly as written. A missing family falls back to Segoe UI, the same rule the fontconfig-backed Linux resolver follows for DejaVu Sans. If GDI cannot be consulted at all the name passes through unchanged and the text layer substitutes as before. Answers are remembered under the name as written, so what a name resolves to never depends on what was asked before it.

The Font resolution row of the Capability Matrix now reads ✅ for Windows, footnote 1 describes the shared rule, and the Windows entry under Known Gaps is gone.

## Related Issues

Closes #1567

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, this replaces a Windows-only passthrough; macOS and Linux resolvers are unchanged
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, ran the targeted subset instead: `just lint-cross`, `GOOS=windows go vet`, `just build-windows`, `just test-foundation`, and the platform, ports and architecture unit tests. The Windows-tagged font tests only run on the Windows CI leg.
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

The check uses `EnumFontFamiliesExW` with the face name set, which enumerates only that family and compares names case-insensitively, so being called back at all is the answer. A missing family of any face lands on the sans baseline, matching the documented Linux rule rather than picking a serif or mono baseline from the name. A family name longer than GDI can hold (31 characters) counts as missing, since GDI could not select it either.
