### PR TITLE
feat(windows): verify the named-pipe server owner before connecting

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,9 +73,9 @@ checks before serving a connection:
   that SID alone. There the kernel checks the descriptor before the connection
   is ever accepted, which is the same question asked earlier.
 
-`neru doctor` prints the endpoint in use. What each *client* can establish
-about the daemon before it connects differs by platform, and is a
-[Known Gap](CROSS_PLATFORM.md#known-gaps) rather than part of this shape.
+`neru doctor` prints the endpoint in use. On every platform the client also
+confirms, before sending anything, that the process serving the endpoint runs
+as this user.
 
 New user-facing behavior therefore usually needs three pieces: a CLI command
 (`internal/cli/`, registered in an `init()`), an IPC handler, and the

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -1187,15 +1187,7 @@ working, which is exactly why the build exists.
 
 **Windows**
 
-1. IPC endpoint, client side — the daemon's endpoint is scoped to one user on
-    every platform, but only the Unix client checks that for itself before
-    connecting. A named pipe carries no ownership a client can read without
-    opening it, so the Windows CLI trusts the name it derives from its own SID.
-    The same gap covers the upgrade path: a Unix CLI still reaches a daemon
-    left running on the previous endpoint and gets the version-mismatch message
-    asking for a restart, while on Windows the previous name is named in the
-    failure text rather than dialed, and an old daemon has to be stopped by
-    hand before `neru launch` starts a new one
+None.
 
 **macOS**
 
@@ -1706,8 +1698,7 @@ Windows is one backend family with alpha-level support. Prefer:
 - pure Go Win32 / COM bindings (via `x/sys/windows` or syscall) over CGO
 
 Do not introduce additional Windows backend naming until there is a real reason.
-See [Known Gaps](#known-gaps) for the current Windows to-do list — several
-entries there are well-scoped starter tasks.
+[Known Gaps](#known-gaps) lists any Windows work still open.
 
 **Smooth cursor animation on Windows.** Off by default; opt in with
 `smooth_cursor.move_mouse_enabled`, the same `SmoothCursorConfig` macOS and

--- a/internal/adapter/ipc/transport_windows.go
+++ b/internal/adapter/ipc/transport_windows.go
@@ -4,6 +4,8 @@ package ipc
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"net"
 	"sync"
 
@@ -26,11 +28,21 @@ const (
 
 	// legacyPipePath is the machine-wide name neru used before the endpoint was
 	// scoped to one user.
-	// It is never dialed — an unauthenticated name is exactly what the per-user
-	// name replaces — but it is what an older daemon is still listening on, so
-	// endpointHint mentions it when a connection fails.
+	//
+	// It is still dialed, but only when nothing answers on this user's own name,
+	// and the process serving it has to pass verifyPipeServer like any other.
+	// That is enough for an upgraded CLI to reach a daemon started by the older
+	// binary, so the version handshake can tell the user to restart it instead
+	// of the CLI reporting that nothing is running. Drop it once daemons
+	// predating the move are no longer a realistic thing to meet.
 	legacyPipePath = pipePrefix
 )
+
+// pipeHandle is the part of a go-winio pipe connection the server check needs:
+// the raw handle, to ask the kernel which process is on the other end.
+type pipeHandle interface {
+	Fd() uintptr
+}
 
 // pipeIdentity resolves this process's user SID once. It reads the current
 // process token, so it neither blocks nor depends on anything outside the
@@ -72,22 +84,17 @@ func daemonEndpointPath() string {
 }
 
 // clientEndpointPath returns the endpoint a CLI process should dial. Unlike the
-// Unix transport there is no search: a named pipe carries no ownership a client
-// can check before connecting, so the only name trusted is the one derived from
-// this user's own SID.
+// Unix transport there is no search here: a named pipe cannot be inspected
+// without opening it, so the fallback to the previous name lives in
+// dialEndpoint, where the open has already happened.
 func clientEndpointPath() string {
 	return daemonEndpointPath()
 }
 
-// endpointHint returns extra guidance for a failed connection.
-//
-// A daemon from before the move is still serving the machine-wide name, and
-// there is no safe way to detect that — probing it means handing a command to
-// whatever holds a name anyone can create. So the possibility is stated rather
-// than tested, and only on the path where connecting has already failed.
+// endpointHint returns extra guidance for a failed connection. The Windows
+// client falls back to the previous name on its own, so there is nothing to add.
 func endpointHint() string {
-	return "if you just upgraded, a daemon from the previous version may still " +
-		"be running on " + legacyPipePath + "; stop it and start neru again"
+	return ""
 }
 
 func listenEndpoint(ctx context.Context, path string) (net.Listener, error) {
@@ -116,8 +123,17 @@ func listenEndpoint(ctx context.Context, path string) (net.Listener, error) {
 	return listener, nil
 }
 
+// dialEndpoint opens path and hands back a connection only once the process
+// serving it is known to run as this user.
+//
+// Opening is safe to do first: go-winio dials at SECURITY_ANONYMOUS, so
+// whatever holds the name cannot impersonate the caller, and nothing is written
+// until verifyPipeServer has passed. When this user's own name has no server,
+// the previous machine-wide name is tried under the same check, so an old
+// daemon is reached and answers with the version mismatch rather than being
+// reported as absent.
 func dialEndpoint(ctx context.Context, dialer net.Dialer, path string) (net.Conn, error) {
-	_, sidErr := pipeIdentity()
+	sid, sidErr := pipeIdentity()
 	if sidErr != nil {
 		return nil, sidErr
 	}
@@ -129,7 +145,94 @@ func dialEndpoint(ctx context.Context, dialer net.Dialer, path string) (net.Conn
 		defer cancel()
 	}
 
-	return winio.DialPipeContext(ctx, path)
+	conn, dialErr := dialVerifiedPipe(ctx, path, sid)
+	if errors.Is(dialErr, fs.ErrNotExist) && path == daemonEndpointPath() {
+		legacyConn, legacyErr := dialVerifiedPipe(ctx, legacyPipePath, sid)
+		if legacyErr == nil {
+			return legacyConn, nil
+		}
+
+		// The failure reported is the one on the name the daemon should be
+		// on; a missing legacy pipe is the ordinary case, not news.
+	}
+
+	return conn, dialErr
+}
+
+// dialVerifiedPipe opens path and closes it again unless owner is serving it.
+func dialVerifiedPipe(ctx context.Context, path string, owner string) (net.Conn, error) {
+	conn, dialErr := winio.DialPipeContext(ctx, path)
+	if dialErr != nil {
+		return nil, dialErr
+	}
+
+	verifyErr := verifyPipeServer(conn, path, owner)
+	if verifyErr != nil {
+		_ = conn.Close()
+
+		return nil, verifyErr
+	}
+
+	return conn, nil
+}
+
+// verifyPipeServer reports whether the process on the server end of conn runs
+// as owner. Anything that stops the question being answered is a refusal: the
+// pipe name is the only thing the client chose, and a name is what another
+// account can take first.
+func verifyPipeServer(conn net.Conn, path string, owner string) error {
+	pipe, ok := conn.(pipeHandle)
+	if !ok {
+		return derrors.Newf(derrors.CodeIPCFailed, "cannot read the owner of %s", path)
+	}
+
+	serverSID, sidErr := pipeServerSID(windows.Handle(pipe.Fd()))
+	if sidErr != nil {
+		return derrors.Wrapf(sidErr, derrors.CodeIPCFailed, "cannot read the owner of %s", path)
+	}
+
+	if serverSID != owner {
+		return derrors.Newf(
+			derrors.CodeIPCFailed,
+			"%s belongs to %s rather than to this user",
+			path,
+			serverSID,
+		)
+	}
+
+	return nil
+}
+
+// pipeServerSID returns the string SID of the user running the process that
+// serves the pipe behind handle.
+func pipeServerSID(handle windows.Handle) (string, error) {
+	var pid uint32
+
+	pidErr := windows.GetNamedPipeServerProcessId(handle, &pid)
+	if pidErr != nil {
+		return "", pidErr
+	}
+
+	process, openErr := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+	if openErr != nil {
+		return "", openErr
+	}
+	defer func() { _ = windows.CloseHandle(process) }()
+
+	var token windows.Token
+
+	tokenErr := windows.OpenProcessToken(process, windows.TOKEN_QUERY, &token)
+	if tokenErr != nil {
+		return "", tokenErr
+	}
+	defer func() { _ = token.Close() }()
+
+	user, userErr := token.GetTokenUser()
+	if userErr != nil {
+		return "", userErr
+	}
+
+	return user.User.Sid.String(), nil
 }
 
 func cleanupEndpoint(_ string) error {

--- a/internal/adapter/ipc/transport_windows_internal_test.go
+++ b/internal/adapter/ipc/transport_windows_internal_test.go
@@ -3,8 +3,14 @@
 package ipc
 
 import (
+	"context"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/Microsoft/go-winio"
+	"go.uber.org/zap"
 )
 
 // The pipe namespace is machine-wide, so the endpoint name has to say which
@@ -78,5 +84,119 @@ func TestAuthorizePeer_DefersToThePipeSecurityDescriptor(t *testing.T) {
 	authErr := authorizePeer(nil)
 	if authErr != nil {
 		t.Fatalf("authorizePeer() error = %v, want the descriptor to have settled it", authErr)
+	}
+}
+
+// servePipe listens on path as this user and accepts connections until the
+// test ends, so a dial has something real on the other end to be checked.
+func servePipe(t *testing.T, path string) {
+	t.Helper()
+
+	listener, listenErr := listenEndpoint(context.Background(), path)
+	if listenErr != nil {
+		t.Fatalf("listenEndpoint(%s) error = %v", path, listenErr)
+	}
+
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+}
+
+// The name is the only thing the client chose, and a name is what another
+// account can take first. The process behind it has to be this user's before
+// a single byte goes out.
+func TestVerifyPipeServer_RefusesAPipeServedByAnotherUser(t *testing.T) {
+	t.Parallel()
+
+	sid, sidErr := pipeIdentity()
+	if sidErr != nil {
+		t.Fatalf("pipeIdentity() error = %v", sidErr)
+	}
+
+	path := pipePrefix + `-test-owner-` + strconv.Itoa(os.Getpid())
+	servePipe(t, path)
+
+	conn, dialErr := winio.DialPipeContext(context.Background(), path)
+	if dialErr != nil {
+		t.Fatalf("DialPipeContext(%s) error = %v", path, dialErr)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	// Only this user's own process can serve the pipe here, so "another user"
+	// is played by asking the check to expect someone else on the other end.
+	const otherUser = "S-1-5-21-1-2-3-1001"
+
+	refusal := verifyPipeServer(conn, path, otherUser)
+	if refusal == nil {
+		t.Fatal("verifyPipeServer() accepted a server that is not the expected user")
+	}
+
+	if !strings.Contains(refusal.Error(), "rather than to this user") {
+		t.Errorf("refusal = %q, want the message the Unix client gives", refusal)
+	}
+
+	if !strings.Contains(refusal.Error(), sid) {
+		t.Errorf("refusal = %q, want it to name the SID actually serving the pipe", refusal)
+	}
+
+	acceptErr := verifyPipeServer(conn, path, sid)
+	if acceptErr != nil {
+		t.Errorf("verifyPipeServer() error = %v for this user's own server", acceptErr)
+	}
+}
+
+// An upgraded CLI meeting a daemon started by the previous binary gets the
+// version-mismatch reply asking for a restart, the way the Unix client does,
+// rather than a connection failure naming the old pipe.
+//
+// Not parallel: it relies on nothing listening on this user's endpoint, and
+// the integration tests in this package bind exactly that.
+func TestDialEndpoint_ReachesAnOldDaemonOnThePreviousName(t *testing.T) {
+	listener, listenErr := listenEndpoint(context.Background(), legacyPipePath)
+	if listenErr != nil {
+		t.Fatalf("listenEndpoint(%s) error = %v", legacyPipePath, listenErr)
+	}
+
+	server := &Server{
+		listener:   listener,
+		logger:     zap.NewNop(),
+		socketPath: legacyPipePath,
+		handler: func(_ context.Context, _ Command) Response {
+			t.Error("the old daemon ran a command from a newer CLI")
+
+			return Response{Success: true, Code: CodeOK}
+		},
+	}
+
+	server.Start()
+
+	t.Cleanup(func() { _ = server.Stop() })
+
+	client := &Client{socketPath: daemonEndpointPath()}
+
+	response, sendErr := client.SendWithTimeout(
+		Command{Action: "ping", Version: "older"},
+		PingTimeout,
+	)
+	if sendErr != nil {
+		t.Fatalf("SendWithTimeout() error = %v, want the old daemon's reply", sendErr)
+	}
+
+	if response.Code != CodeVersionMismatch {
+		t.Fatalf("response code = %s, want %s", response.Code, CodeVersionMismatch)
+	}
+
+	if !strings.Contains(response.Message, "restart the neru daemon") {
+		t.Errorf("response message = %q, want it to ask for a restart", response.Message)
 	}
 }


### PR DESCRIPTION
## Description

This PR makes the Windows CLI check who is on the other end of the named pipe before it sends anything. The pipe namespace is machine-wide, so another account could create a pipe under the name the CLI derives from its own SID. The client now asks the kernel which process serves the pipe, reads that process's token user, and refuses with the same "belongs to ... rather than to this user" message the Unix client gives when the SID does not match. Anything that stops the question being answered is also a refusal.

It also fixes the upgrade path. When nothing answers on this user's own pipe name, the CLI dials the previous machine-wide name under the same ownership check, so a daemon left running by an older release replies with the version-mismatch message asking for a restart, the way it does on macOS and Linux. The connection-failure text no longer names the old pipe.

Known Gaps Windows entry 1 (the last one) is removed.

## Related Issues

Closes #1568

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, the Unix transport already does its own owner check and legacy fallback
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, ran the targeted subset instead (`just lint-cross`, `go vet`, `go test ./internal/adapter/ipc ./internal/architecture`); the change is confined to the Windows transport and CI runs the new tests natively on windows-latest
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

Opening the pipe before verifying is safe: go-winio dials at anonymous impersonation level, so whatever holds the name cannot act as the caller, and no bytes are written until the check passes. A foreign process on the old machine-wide name is closed silently and the CLI reports the ordinary "is it running?" failure for this user's own endpoint.

The legacy-name test is deliberately not parallel: it relies on nothing listening on this user's endpoint, which the integration tests in the same package bind.
