### PR TITLE
fix(app): guard observer hooks against a config reload racing startup

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -119,6 +119,10 @@ type App struct {
 	// Per-instance observer teardown and hooks, assigned by the platform
 	// setup functions and consumed by the shared entry points in
 	// observers.go. Closures keep platform types off this struct.
+	//
+	// observerMu guards the three: Run assigns them after the IPC server is
+	// already accepting a reload, and the reload path reads postReloadVerify.
+	observerMu        sync.Mutex
 	themeObserverStop func()
 	sleepObserverStop func()
 	postReloadVerify  func()

--- a/internal/app/observers.go
+++ b/internal/app/observers.go
@@ -10,34 +10,38 @@ package app
 // once. Platforms whose observer stops with the app context leave the field
 // nil, making this a no-op.
 func (a *App) stopThemeObserver() {
-	if a.themeObserverStop == nil {
-		return
-	}
-
+	a.observerMu.Lock()
 	stop := a.themeObserverStop
 	a.themeObserverStop = nil
+	a.observerMu.Unlock()
 
-	stop()
+	if stop != nil {
+		stop()
+	}
 }
 
 // stopSleepObserver runs this instance's sleep observer teardown, at most
 // once. Only Linux registers one; see setupSleepObserver.
 func (a *App) stopSleepObserver() {
-	if a.sleepObserverStop == nil {
-		return
-	}
-
+	a.observerMu.Lock()
 	stop := a.sleepObserverStop
 	a.sleepObserverStop = nil
+	a.observerMu.Unlock()
 
-	stop()
+	if stop != nil {
+		stop()
+	}
 }
 
 // schedulePostReloadVerification runs the platform's post-config-reload
 // health check, if any. Only Linux registers one: it verifies the evdev
 // hotkey listener actually came back after a reload.
 func (a *App) schedulePostReloadVerification() {
-	if a.postReloadVerify != nil {
-		a.postReloadVerify()
+	a.observerMu.Lock()
+	verify := a.postReloadVerify
+	a.observerMu.Unlock()
+
+	if verify != nil {
+		verify()
 	}
 }

--- a/internal/app/observers.go
+++ b/internal/app/observers.go
@@ -26,6 +26,10 @@ func (a *App) stopSleepObserver() {
 	a.observerMu.Lock()
 	stop := a.sleepObserverStop
 	a.sleepObserverStop = nil
+	// The check shares the observer's wait group, and the IPC server is still
+	// accepting a reload while this runs: one arriving now must find nothing
+	// to schedule rather than add to a group teardown is about to wait on.
+	a.postReloadVerify = nil
 	a.observerMu.Unlock()
 
 	if stop != nil {
@@ -36,12 +40,14 @@ func (a *App) stopSleepObserver() {
 // schedulePostReloadVerification runs the platform's post-config-reload
 // health check, if any. Only Linux registers one: it verifies the evdev
 // hotkey listener actually came back after a reload.
+//
+// The hook runs under the lock: it only starts a goroutine, and running it
+// there means it is never called after stopSleepObserver has cleared it.
 func (a *App) schedulePostReloadVerification() {
 	a.observerMu.Lock()
-	verify := a.postReloadVerify
-	a.observerMu.Unlock()
+	defer a.observerMu.Unlock()
 
-	if verify != nil {
-		verify()
+	if a.postReloadVerify != nil {
+		a.postReloadVerify()
 	}
 }

--- a/internal/app/simulation_journey_test.go
+++ b/internal/app/simulation_journey_test.go
@@ -2614,8 +2614,13 @@ func TestSimulation_FocusChangeMidModeRebindsTheKey(t *testing.T) {
 
 	sim.press(sharedKey)
 
-	sim.waitFor("a binding for the shared key to run", func() bool {
-		return sim.app.CurrentMode() != domain.ModeGrid
+	// A mode-to-mode switch runs off the keystroke on a goroutine and passes
+	// through idle on its way in, so idle is a moment in the transition rather
+	// than an answer: wait for whichever mode the binding opens.
+	sim.waitFor("a binding for the shared key to open a mode", func() bool {
+		mode := sim.app.CurrentMode()
+
+		return mode != domain.ModeGrid && mode != domain.ModeIdle
 	})
 
 	if got := sim.app.CurrentMode(); got != domain.ModeRecursiveGrid {

--- a/internal/app/sleep_handler_linux.go
+++ b/internal/app/sleep_handler_linux.go
@@ -59,6 +59,10 @@ func (a *App) setupSleepObserver() {
 	// reads it at call time, so the degraded no-bus path leaves it nil.
 	var dbusClose func() error
 
+	// Under observerMu: the IPC server is already live, so a reload can be
+	// reading postReloadVerify while Run is still in here.
+	a.observerMu.Lock()
+
 	a.sleepObserverStop = func() {
 		close(stopChan)
 
@@ -82,6 +86,8 @@ func (a *App) setupSleepObserver() {
 			}
 		})
 	}
+
+	a.observerMu.Unlock()
 
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {

--- a/internal/app/theme_observer_darwin.go
+++ b/internal/app/theme_observer_darwin.go
@@ -18,6 +18,9 @@ func (a *App) setupThemeObserver() {
 	})
 	darwin.StartThemeObserver()
 
+	a.observerMu.Lock()
+	defer a.observerMu.Unlock()
+
 	a.themeObserverStop = func() {
 		darwin.SetThemeChangeHandler(nil)
 		darwin.StopThemeObserver()

--- a/internal/app/theme_observer_linux.go
+++ b/internal/app/theme_observer_linux.go
@@ -54,6 +54,8 @@ func (a *App) setupThemeObserver() {
 	// reads it at call time, so the early polling fallbacks leave it nil.
 	var dbusClose func() error
 
+	a.observerMu.Lock()
+
 	a.themeObserverStop = func() {
 		close(stopChan)
 
@@ -63,6 +65,8 @@ func (a *App) setupThemeObserver() {
 
 		waitGroup.Wait()
 	}
+
+	a.observerMu.Unlock()
 
 	dialCtx, cancelDial := context.WithTimeout(a.ctx, themeBusDialTimeout)
 	defer cancelDial()


### PR DESCRIPTION
## Description

This PR fixes two tests that fail intermittently on main, one of them a real data race in the daemon.

On Linux, the daemon registers its sleep-observer teardown and post-reload health check after the IPC server is already accepting commands, so a config reload arriving during startup could read the hook while startup was still writing it. The race detector caught this in the reload-racing-activation simulation on the Ubuntu CI leg. The three observer hooks are now guarded by a mutex at every write and read.

The focus-change simulation waited for the mode to stop being grid and then asserted which mode replaced it. A mode-to-mode switch runs off the keystroke on a goroutine and passes through idle on its way in, so the wait could return during that moment and the assertion read idle. It now waits for whichever mode the binding opens.

The Windows foreground-watcher integration test also failed once on main with no events observed. That one is not addressed here: it could not be reproduced or explained from the source without a Windows desktop.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new capability; Windows registers no observer hooks and is unchanged
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, ran the targeted subset instead (`golangci-lint` for darwin, linux and windows targets, `go test -race` on the two simulations repeated, `go test ./internal/app`); the change is small and CI runs the full set on all three hosts
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing change
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch
