### PR TITLE
fix(windows): keep sticky modifiers out of global hotkey matching

### DIFF
--- a/internal/adapter/eventtap/windows/tap.go
+++ b/internal/adapter/eventtap/windows/tap.go
@@ -36,11 +36,12 @@ type EventTap struct {
 
 	// postedModifiers are the sticky modifiers PostModifierEvent is holding
 	// down; the hook reads them into every chord like a physical hold.
-	// heldModifiers counts the keys of each modifier the user's hands hold,
-	// from the hook's own modifier events (left and right count separately),
-	// so a modifier both posted and held stays in the chord.
+	// heldModifiers are the ones the user's hands hold, from the hook's own
+	// modifier events, so a modifier both posted and held stays in the chord.
+	// A set rather than a count: a held key autorepeats its key-down, and the
+	// left and right keys of one modifier are not told apart here.
 	postedModifiers map[string]struct{}
-	heldModifiers   map[string]int
+	heldModifiers   map[string]struct{}
 
 	hook *winplatform.KeyboardHook
 }
@@ -247,19 +248,17 @@ func (et *EventTap) noteHeldModifier(modifier string, isDown bool) {
 	et.mu.Lock()
 	defer et.mu.Unlock()
 
-	if isDown {
-		if et.heldModifiers == nil {
-			et.heldModifiers = make(map[string]int)
-		}
-
-		et.heldModifiers[modifier]++
+	if !isDown {
+		delete(et.heldModifiers, modifier)
 
 		return
 	}
 
-	if et.heldModifiers[modifier] > 0 {
-		et.heldModifiers[modifier]--
+	if et.heldModifiers == nil {
+		et.heldModifiers = make(map[string]struct{})
 	}
+
+	et.heldModifiers[modifier] = struct{}{}
 }
 
 // physicalChord returns chord without the modifiers only this tap holds, as
@@ -278,7 +277,10 @@ func (et *EventTap) physicalChord(chord string) string {
 	for i, part := range parts {
 		if i < len(parts)-1 {
 			mod := keyvocab.CanonicalModifier(part)
-			if _, posted := et.postedModifiers[mod]; posted && et.heldModifiers[mod] == 0 {
+			_, posted := et.postedModifiers[mod]
+			_, held := et.heldModifiers[mod]
+
+			if posted && !held {
 				continue
 			}
 		}

--- a/internal/adapter/eventtap/windows/tap.go
+++ b/internal/adapter/eventtap/windows/tap.go
@@ -4,6 +4,7 @@ package windows
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"go.uber.org/zap"
@@ -32,6 +33,10 @@ type EventTap struct {
 	passthroughEnabled   bool
 	passthroughBlacklist map[string]struct{}
 	interceptedChords    map[string]struct{}
+
+	// postedModifiers are the sticky modifiers PostModifierEvent is holding
+	// down; the hook reads them into every chord like a physical hold.
+	postedModifiers map[string]struct{}
 
 	hook *winplatform.KeyboardHook
 }
@@ -162,7 +167,11 @@ func (et *EventTap) PostModifierEvent(modifier string, isDown bool) {
 	err := winplatform.PostModifierKey(modifier, isDown)
 	if err != nil {
 		et.logger.Warn("Failed to post modifier event", zap.Error(err))
+
+		return
 	}
+
+	et.notePostedModifier(modifier, isDown)
 }
 
 // SetKeyboardLayout sets the keyboard layout.
@@ -206,6 +215,52 @@ func IsUinputScrollAvailable() bool {
 // IsWaylandEvdevKeyboardActive returns false on Windows (no evdev / Wayland).
 func IsWaylandEvdevKeyboardActive() bool {
 	return false
+}
+
+// notePostedModifier records a modifier this tap holds down (or released) on
+// the handler's behalf.
+func (et *EventTap) notePostedModifier(modifier string, isDown bool) {
+	et.mu.Lock()
+	defer et.mu.Unlock()
+
+	if isDown {
+		if et.postedModifiers == nil {
+			et.postedModifiers = make(map[string]struct{})
+		}
+
+		et.postedModifiers[modifier] = struct{}{}
+
+		return
+	}
+
+	delete(et.postedModifiers, modifier)
+}
+
+// physicalChord returns chord without the modifiers this tap posted itself,
+// as the user's hands pressed it.
+func (et *EventTap) physicalChord(chord string) string {
+	et.mu.RLock()
+	posted := et.postedModifiers
+	et.mu.RUnlock()
+
+	if len(posted) == 0 {
+		return chord
+	}
+
+	parts := strings.Split(chord, "+")
+	kept := parts[:0]
+
+	for i, part := range parts {
+		if i < len(parts)-1 {
+			if _, ok := posted[keyvocab.CanonicalModifier(part)]; ok {
+				continue
+			}
+		}
+
+		kept = append(kept, part)
+	}
+
+	return strings.Join(kept, "+")
 }
 
 // isRegisteredHotkey reports whether key is one of the chords registered as a
@@ -266,7 +321,14 @@ func (et *EventTap) handleKey(key string, isUp bool) bool {
 		// and a double-run of "recursive_grid --toggle" exits the mode and
 		// re-enters it. macOS answers the same question the same way, in its own
 		// tap's hotkey check (platform/darwin/eventtap_darwin.m).
-		if et.isRegisteredHotkey(normalized) {
+		//
+		// Only the chord the user physically pressed qualifies. A sticky
+		// modifier is held by this tap, so with Shift sticky a Ctrl+J press
+		// reads as Ctrl+Shift+J; handing that back would fire a Ctrl+Shift+J
+		// global hotkey the user never pressed. Sticky modifiers are for the
+		// next action, not for hotkeys, so the chord is consumed and dispatched
+		// instead, and the handler strips the sticky part before resolving it.
+		if et.physicalChord(normalized) == normalized && et.isRegisteredHotkey(normalized) {
 			return false
 		}
 

--- a/internal/adapter/eventtap/windows/tap.go
+++ b/internal/adapter/eventtap/windows/tap.go
@@ -36,10 +36,11 @@ type EventTap struct {
 
 	// postedModifiers are the sticky modifiers PostModifierEvent is holding
 	// down; the hook reads them into every chord like a physical hold.
-	// heldModifiers are the ones the user's hands hold, from the hook's own
-	// modifier events, so a modifier both posted and held stays in the chord.
+	// heldModifiers counts the keys of each modifier the user's hands hold,
+	// from the hook's own modifier events (left and right count separately),
+	// so a modifier both posted and held stays in the chord.
 	postedModifiers map[string]struct{}
-	heldModifiers   map[string]struct{}
+	heldModifiers   map[string]int
 
 	hook *winplatform.KeyboardHook
 }
@@ -228,7 +229,17 @@ func (et *EventTap) notePostedModifier(modifier string, isDown bool) {
 	et.mu.Lock()
 	defer et.mu.Unlock()
 
-	et.postedModifiers = setModifier(et.postedModifiers, modifier, isDown)
+	if !isDown {
+		delete(et.postedModifiers, modifier)
+
+		return
+	}
+
+	if et.postedModifiers == nil {
+		et.postedModifiers = make(map[string]struct{})
+	}
+
+	et.postedModifiers[modifier] = struct{}{}
 }
 
 // noteHeldModifier records a modifier the user pressed or released.
@@ -236,23 +247,19 @@ func (et *EventTap) noteHeldModifier(modifier string, isDown bool) {
 	et.mu.Lock()
 	defer et.mu.Unlock()
 
-	et.heldModifiers = setModifier(et.heldModifiers, modifier, isDown)
-}
+	if isDown {
+		if et.heldModifiers == nil {
+			et.heldModifiers = make(map[string]int)
+		}
 
-func setModifier(set map[string]struct{}, modifier string, isDown bool) map[string]struct{} {
-	if !isDown {
-		delete(set, modifier)
+		et.heldModifiers[modifier]++
 
-		return set
+		return
 	}
 
-	if set == nil {
-		set = make(map[string]struct{})
+	if et.heldModifiers[modifier] > 0 {
+		et.heldModifiers[modifier]--
 	}
-
-	set[modifier] = struct{}{}
-
-	return set
 }
 
 // physicalChord returns chord without the modifiers only this tap holds, as
@@ -271,10 +278,7 @@ func (et *EventTap) physicalChord(chord string) string {
 	for i, part := range parts {
 		if i < len(parts)-1 {
 			mod := keyvocab.CanonicalModifier(part)
-			_, posted := et.postedModifiers[mod]
-			_, held := et.heldModifiers[mod]
-
-			if posted && !held {
+			if _, posted := et.postedModifiers[mod]; posted && et.heldModifiers[mod] == 0 {
 				continue
 			}
 		}

--- a/internal/adapter/eventtap/windows/tap.go
+++ b/internal/adapter/eventtap/windows/tap.go
@@ -36,7 +36,10 @@ type EventTap struct {
 
 	// postedModifiers are the sticky modifiers PostModifierEvent is holding
 	// down; the hook reads them into every chord like a physical hold.
+	// heldModifiers are the ones the user's hands hold, from the hook's own
+	// modifier events, so a modifier both posted and held stays in the chord.
 	postedModifiers map[string]struct{}
+	heldModifiers   map[string]struct{}
 
 	hook *winplatform.KeyboardHook
 }
@@ -63,6 +66,7 @@ func (et *EventTap) Enable() {
 	}
 
 	et.enabled = true
+	et.heldModifiers = nil
 	et.mu.Unlock()
 
 	hook, err := winplatform.StartKeyboardHook(et.handleKey)
@@ -92,6 +96,7 @@ func (et *EventTap) Disable() {
 	hook := et.hook
 	et.hook = nil
 	et.enabled = false
+	et.heldModifiers = nil
 	et.mu.Unlock()
 
 	if hook != nil {
@@ -223,27 +228,40 @@ func (et *EventTap) notePostedModifier(modifier string, isDown bool) {
 	et.mu.Lock()
 	defer et.mu.Unlock()
 
-	if isDown {
-		if et.postedModifiers == nil {
-			et.postedModifiers = make(map[string]struct{})
-		}
-
-		et.postedModifiers[modifier] = struct{}{}
-
-		return
-	}
-
-	delete(et.postedModifiers, modifier)
+	et.postedModifiers = setModifier(et.postedModifiers, modifier, isDown)
 }
 
-// physicalChord returns chord without the modifiers this tap posted itself,
-// as the user's hands pressed it.
+// noteHeldModifier records a modifier the user pressed or released.
+func (et *EventTap) noteHeldModifier(modifier string, isDown bool) {
+	et.mu.Lock()
+	defer et.mu.Unlock()
+
+	et.heldModifiers = setModifier(et.heldModifiers, modifier, isDown)
+}
+
+func setModifier(set map[string]struct{}, modifier string, isDown bool) map[string]struct{} {
+	if !isDown {
+		delete(set, modifier)
+
+		return set
+	}
+
+	if set == nil {
+		set = make(map[string]struct{})
+	}
+
+	set[modifier] = struct{}{}
+
+	return set
+}
+
+// physicalChord returns chord without the modifiers only this tap holds, as
+// the user's hands pressed it.
 func (et *EventTap) physicalChord(chord string) string {
 	et.mu.RLock()
-	posted := et.postedModifiers
-	et.mu.RUnlock()
+	defer et.mu.RUnlock()
 
-	if len(posted) == 0 {
+	if len(et.postedModifiers) == 0 {
 		return chord
 	}
 
@@ -252,7 +270,11 @@ func (et *EventTap) physicalChord(chord string) string {
 
 	for i, part := range parts {
 		if i < len(parts)-1 {
-			if _, ok := posted[keyvocab.CanonicalModifier(part)]; ok {
+			mod := keyvocab.CanonicalModifier(part)
+			_, posted := et.postedModifiers[mod]
+			_, held := et.heldModifiers[mod]
+
+			if posted && !held {
 				continue
 			}
 		}
@@ -290,6 +312,8 @@ func (et *EventTap) handleKey(key string, isUp bool) bool {
 	}
 
 	if mod := keyvocab.CanonicalModifier(key); mod != "" {
+		et.noteHeldModifier(mod, !isUp)
+
 		if et.stickyToggleEnabled() {
 			et.dispatchKey(keyvocab.ModifierToggleEvent(mod, !isUp))
 		}

--- a/internal/adapter/eventtap/windows/tap_hotkey_test.go
+++ b/internal/adapter/eventtap/windows/tap_hotkey_test.go
@@ -97,6 +97,14 @@ func TestEventTap_HandleKey_StickyModifierDoesNotFireGlobalHotkey(t *testing.T) 
 		t.Fatal("physical Shift+Ctrl+J under sticky Shift was not handed to RegisterHotKey")
 	}
 
+	// Both Shift keys held, one released: the chord is still the user's.
+	tap.handleKey("Shift", false)
+	tap.handleKey("Shift", true)
+
+	if tap.handleKey("Ctrl+Shift+J", false) {
+		t.Fatal("releasing one of two held Shift keys dropped the physical chord")
+	}
+
 	tap.handleKey("Shift", true)
 
 	if !tap.handleKey("Ctrl+Shift+J", false) {

--- a/internal/adapter/eventtap/windows/tap_hotkey_test.go
+++ b/internal/adapter/eventtap/windows/tap_hotkey_test.go
@@ -97,14 +97,8 @@ func TestEventTap_HandleKey_StickyModifierDoesNotFireGlobalHotkey(t *testing.T) 
 		t.Fatal("physical Shift+Ctrl+J under sticky Shift was not handed to RegisterHotKey")
 	}
 
-	// Both Shift keys held, one released: the chord is still the user's.
+	// A held modifier autorepeats its key-down; one release still ends it.
 	tap.handleKey("Shift", false)
-	tap.handleKey("Shift", true)
-
-	if tap.handleKey("Ctrl+Shift+J", false) {
-		t.Fatal("releasing one of two held Shift keys dropped the physical chord")
-	}
-
 	tap.handleKey("Shift", true)
 
 	if !tap.handleKey("Ctrl+Shift+J", false) {

--- a/internal/adapter/eventtap/windows/tap_hotkey_test.go
+++ b/internal/adapter/eventtap/windows/tap_hotkey_test.go
@@ -68,3 +68,31 @@ func TestEventTap_SetHotkeys_ReplacesTheList(t *testing.T) {
 		t.Error("Ctrl+H is not treated as registered after the list was replaced")
 	}
 }
+
+// A sticky modifier is held by the tap itself, so the hook reads it into every
+// chord. A chord that only spells a registered hotkey because of that modifier
+// is the user's Ctrl+J, not their Ctrl+Shift+J, and stays with the mode.
+func TestEventTap_HandleKey_StickyModifierDoesNotFireGlobalHotkey(t *testing.T) {
+	t.Parallel()
+
+	var dispatched []string
+
+	tap := NewEventTap(func(key string) { dispatched = append(dispatched, key) }, nil)
+	tap.SetHotkeys([]string{"Ctrl+Shift+J"})
+	tap.notePostedModifier("shift", true)
+
+	if !tap.handleKey("Ctrl+Shift+J", false) {
+		t.Fatal("Ctrl+J with sticky Shift was handed to RegisterHotKey instead of consumed")
+	}
+
+	if len(dispatched) != 1 || dispatched[0] != "Ctrl+Shift+J" {
+		t.Fatalf("dispatched = %v, want the chord handed to the mode handler", dispatched)
+	}
+
+	// Releasing the sticky modifier restores the handoff for a physical press.
+	tap.notePostedModifier("shift", false)
+
+	if tap.handleKey("Ctrl+Shift+J", false) {
+		t.Fatal("physical Ctrl+Shift+J was consumed instead of handed to RegisterHotKey")
+	}
+}

--- a/internal/adapter/eventtap/windows/tap_hotkey_test.go
+++ b/internal/adapter/eventtap/windows/tap_hotkey_test.go
@@ -89,6 +89,20 @@ func TestEventTap_HandleKey_StickyModifierDoesNotFireGlobalHotkey(t *testing.T) 
 		t.Fatalf("dispatched = %v, want the chord handed to the mode handler", dispatched)
 	}
 
+	// The user pressing Shift as well makes it their chord again, even while
+	// the sticky one is still posted.
+	tap.handleKey("Shift", false)
+
+	if tap.handleKey("Ctrl+Shift+J", false) {
+		t.Fatal("physical Shift+Ctrl+J under sticky Shift was not handed to RegisterHotKey")
+	}
+
+	tap.handleKey("Shift", true)
+
+	if !tap.handleKey("Ctrl+Shift+J", false) {
+		t.Fatal("Ctrl+J after the physical Shift release was handed to RegisterHotKey")
+	}
+
 	// Releasing the sticky modifier restores the handoff for a physical press.
 	tap.notePostedModifier("shift", false)
 

--- a/internal/adapter/eventtap/windows/tap_hotkey_test.go
+++ b/internal/adapter/eventtap/windows/tap_hotkey_test.go
@@ -85,7 +85,7 @@ func TestEventTap_HandleKey_StickyModifierDoesNotFireGlobalHotkey(t *testing.T) 
 		t.Fatal("Ctrl+J with sticky Shift was handed to RegisterHotKey instead of consumed")
 	}
 
-	if len(dispatched) != 1 || dispatched[0] != "Ctrl+Shift+J" {
+	if len(dispatched) != 1 || dispatched[0] != "Ctrl+Shift+j" {
 		t.Fatalf("dispatched = %v, want the chord handed to the mode handler", dispatched)
 	}
 


### PR DESCRIPTION
## Description

This PR fixes global hotkeys firing on Windows when a sticky modifier is active. With a global `Ctrl+Shift+J` hotkey and Shift held sticky inside a mode, pressing `Ctrl+J` fired that hotkey, because Windows reads the sticky Shift into the chord exactly as if the user were holding it.

Sticky modifiers now apply only to the next action, never to hotkey matching. A chord that spells a registered hotkey only because of a sticky modifier is consumed by the mode instead of being handed to Windows, which matches the macOS behaviour. A physically pressed `Ctrl+Shift+J` still fires the hotkey as before.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, change is internal to the existing Windows tap
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, small Windows-only change; ran `just fmt-check`, `just lint`, `just lint-cross` (Windows lint) and `just check-cross` (Windows test compile) instead
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changed

- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

While a sticky modifier is held, a global hotkey that omits that modifier (for example `Ctrl+J` with Shift sticky) cannot fire through Windows either, since the OS sees Shift as down. That chord now reaches the mode handler, which strips the sticky modifier and resolves `Ctrl+J` through the mode and global tables, the same path macOS takes.
