### PR TITLE
docs(cross-platform): move Windows from Alpha to Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Built for the person who already remapped Caps Lock._
 
 **Free and open-source.** No subscription. No trial. No catch.
 
-|    macOS    |      Linux       |      Windows      |
-| :---------: | :--------------: | :---------------: |
-|  Stable ✅  | Beta — daily 🔵  | Alpha — try it 🟡 |
+|    macOS    |      Linux       |     Windows      |
+| :---------: | :--------------: | :--------------: |
+|  Stable ✅  | Beta — daily 🔵  | Beta — daily 🔵  |
 
-<sub>[What these mean](docs/CROSS_PLATFORM.md#what-the-labels-mean) — stable is fully featured, beta is good for daily driving, alpha is worth trying but not yet worth switching to.</sub>
+<sub>[What these mean](docs/CROSS_PLATFORM.md#what-the-labels-mean) — stable is fully featured and proven in use, beta is good for daily driving.</sub>
 
 </div>
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -77,23 +77,28 @@ Every claim behind these labels is enumerated in the
 [Capability Matrix](#capability-matrix) and [Known Gaps](#known-gaps). If a
 label and the matrix disagree, the matrix is right.
 
-**Linux parity is complete.** Every option, mode flag, action and command means
-on the blessed stack what it means on macOS, [Known Gaps](#known-gaps) carries
-no Linux entry, and the headless-sway job gates merges. That was the whole of
+**Linux and Windows parity is complete.** Every option, mode flag, action and
+command means on the blessed Linux stack and on Windows what it means on macOS,
+[Known Gaps](#known-gaps) carries no entry for either, and CI gates merges on
+both: the headless-sway job for Linux, the native `windows-latest` job for
+Windows. That was the whole of
 [ADR 0013](./adr/0013-parity-is-measured-in-words-not-subsystems.md)'s promise,
 and it is kept.
 
-**Linux stays Beta anyway**, because parity is a claim about coverage and
-Stable is a claim about reliability. Fourteen capabilities landed in a
-fortnight on a platform the maintainer does not daily-drive, each proven by a
-CI job rather than by use. Coverage is what a checklist can establish; that
-these hold up on a real compositor, under a real workload, over weeks of
-ordinary use, is not.
+**Both stay Beta anyway**, because parity is a claim about coverage and
+Stable is a claim about reliability. Fourteen Linux capabilities landed in a
+fortnight and seventeen Windows tickets in one push, on platforms the
+maintainer does not daily-drive, each proven by a CI job rather than by use.
+Coverage is what a checklist can establish; that these hold up on a real
+compositor or a real desktop, under a real workload, over weeks of ordinary
+use, is not.
 
-**Linux moves to Stable** after six consecutive releases in which no Linux-only
-bug is filed — one a macOS user would not also hit. Count bugs *filed* in that
-window rather than ones still open at the end of it: a bug found and fixed still
-happened, and it is evidence about the platform either way.
+**A Beta platform moves to Stable** after six consecutive releases in which no
+bug specific to it is filed — one a macOS user would not also hit. Count bugs
+*filed* in that window rather than ones still open at the end of it: a bug
+found and fixed still happened, and it is evidence about the platform either
+way. The rule is the same for Linux and Windows; only the label in the query
+changes.
 
 ```bash
 since=$(gh release view <tag-six-back> --json publishedAt --jq .publishedAt)
@@ -102,11 +107,11 @@ gh issue list --state all --label "platform: linux" --label bug \
 ```
 
 That query returns candidates, not an answer, and two things it cannot do a
-person must. It cannot tell a Linux-only bug from one macOS shares, so read what
-comes back and discount anything that is really a cross-platform bug wearing a
-platform label. And it sees only what was labelled — a Linux bug filed without
-`platform: linux` is invisible to it, so this is worth no more than the triage
-feeding it.
+person must. It cannot tell a platform-only bug from one macOS shares, so read
+what comes back and discount anything that is really a cross-platform bug
+wearing a platform label. And it sees only what was labelled — a Linux bug
+filed without `platform: linux`, or a Windows bug without `platform: windows`,
+is invisible to it, so this is worth no more than the triage feeding it.
 
 Reading an individual bug is a judgment; whether the label flips is not. That
 distinction is the whole point — see
@@ -116,7 +121,7 @@ distinction is the whole point — see
 
 | Aspect               | macOS (Darwin)              | Linux                                    | Windows                        |
 | -------------------- | --------------------------- | ---------------------------------------- | ------------------------------ |
-| **Status**           | **Stable**                  | **Beta**                                 | **Alpha**                      |
+| **Status**           | **Stable**                  | **Beta**                                 | **Beta**                       |
 | **Build tag**        | `darwin`                    | `linux`                                  | `windows`                      |
 | **CGO**              | Required (Objective-C)      | Per-backend; most Linux backends need it | Not used (pure Go Win32 / COM) |
 | **Primary modifier** | `Cmd`                       | `Ctrl`                                   | `Ctrl`                         |
@@ -1187,7 +1192,8 @@ working, which is exactly why the build exists.
 
 **Windows**
 
-None.
+None — parity is complete.
+[What the labels mean](#what-the-labels-mean) says why the label is still Beta.
 
 **macOS**
 
@@ -1692,7 +1698,9 @@ Per-DE decisions, measured protocol support, and known issues live in
 
 ## Windows Model
 
-Windows is one backend family with alpha-level support. Prefer:
+Windows is one backend family, Beta because parity is complete and proven by
+CI rather than by use; [What the labels mean](#what-the-labels-mean) carries
+the rule that moves it to Stable. Prefer:
 
 - `*_windows.go` as the implementation slot
 - pure Go Win32 / COM bindings (via `x/sys/windows` or syscall) over CGO

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -77,13 +77,18 @@ Every claim behind these labels is enumerated in the
 [Capability Matrix](#capability-matrix) and [Known Gaps](#known-gaps). If a
 label and the matrix disagree, the matrix is right.
 
-**Linux and Windows parity is complete.** Every option, mode flag, action and
-command means on the blessed Linux stack and on Windows what it means on macOS,
-[Known Gaps](#known-gaps) carries no entry for either, and CI gates merges on
-both: the headless-sway job for Linux, the native `windows-latest` job for
-Windows. That was the whole of
+**Linux parity is complete.** Every option, mode flag, action and command means
+on the blessed stack what it means on macOS, [Known Gaps](#known-gaps) carries
+no Linux entry, and the headless-sway job gates merges. That was the whole of
 [ADR 0013](./adr/0013-parity-is-measured-in-words-not-subsystems.md)'s promise,
 and it is kept.
+
+**Windows parity is one word short.** Every mode works, and every option, mode
+flag, action and command means what it means on macOS except the `feed` action
+and `neru key`, which have no key-injection path yet — Windows entry 1 under
+[Known Gaps](#known-gaps). The three `hints.vision.*_confidence` floors are
+inert there too, but as a stated boundary of the OCR engine rather than
+unbuilt work. The native `windows-latest` job gates merges.
 
 **Both stay Beta anyway**, because parity is a claim about coverage and
 Stable is a claim about reliability. Fourteen Linux capabilities landed in a
@@ -1192,8 +1197,16 @@ working, which is exactly why the build exists.
 
 **Windows**
 
-None — parity is complete.
-[What the labels mean](#what-the-labels-mean) says why the label is still Beta.
+1. Key feed — the `feed` action and `neru key` return `CodeNotSupported`
+   because `keyfeed_other.go` is the Windows slot; the target is `SendInput`
+   with `KEYBDINPUT` events, the call the pointer and modifier passthrough
+   already use ([#1593](https://github.com/y3owk1n/neru/issues/1593)).
+
+**Not a Windows gap**: the three `hints.vision.*_confidence` floors are inert
+because `Windows.Media.Ocr` reports no per-word confidence, so there is nothing
+for a floor to compare against — a boundary of the engine, not unbuilt work,
+in the same way X11 modifier passthrough is a boundary of the display server.
+[What the labels mean](#what-the-labels-mean) says why the label is Beta.
 
 **macOS**
 
@@ -1698,9 +1711,9 @@ Per-DE decisions, measured protocol support, and known issues live in
 
 ## Windows Model
 
-Windows is one backend family, Beta because parity is complete and proven by
-CI rather than by use; [What the labels mean](#what-the-labels-mean) carries
-the rule that moves it to Stable. Prefer:
+Windows is one backend family, Beta because every mode works and what is there
+is proven by CI rather than by use; [What the labels mean](#what-the-labels-mean)
+carries the rule that moves it to Stable. Prefer:
 
 - `*_windows.go` as the implementation slot
 - pure Go Win32 / COM bindings (via `x/sys/windows` or syscall) over CGO

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -28,7 +28,7 @@ This guide covers installation methods for Neru, with the most complete support 
 - **macOS**: 14.0 or later, plus Accessibility permission (granted during setup)
 - **Linux** (beta): X11 or a supported Wayland compositor — see
   [LINUX_SETUP.md](LINUX_SETUP.md) for host requirements per backend
-- **Windows** (alpha): Windows 10 or later; expect gaps — see the
+- **Windows** (beta): Windows 10 or later — see the
   [capability matrix](CROSS_PLATFORM.md#capability-matrix)
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,11 +28,12 @@ Work that is not tied to any one platform:
 
 Linux and Windows are both
 [beta](CROSS_PLATFORM.md#what-the-labels-mean) — good for daily driving, with
-parity complete on each. What moves either to Stable is the six-clean-releases
-rule written there, not a feature. Any gap that reappears is tracked as a
-numbered entry in [Known Gaps](CROSS_PLATFORM.md#known-gaps) — pick one from
-there rather than from a duplicate list here, so the status you read is the
-status the code reports.
+Linux parity complete and Windows one word short. What moves either to Stable
+is the six-clean-releases rule written there, not a feature. Every remaining
+item is tracked as a numbered entry in
+[Known Gaps](CROSS_PLATFORM.md#known-gaps) — pick one from there rather than
+from a duplicate list here, so the status you read is the status the code
+reports.
 
 What Linux owes macOS, and what it does not, is settled in
 [ADR 0013](adr/0013-parity-is-measured-in-words-not-subsystems.md): parity is a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,12 +26,13 @@ Work that is not tied to any one platform:
 
 ## Cross-platform foundations
 
-Linux is [beta and Windows alpha](CROSS_PLATFORM.md#what-the-labels-mean) —
-meaning Linux is good for daily driving, while Windows is worth trying but not
-yet worth switching to. Every remaining item is tracked as a numbered entry in
-[Known Gaps](CROSS_PLATFORM.md#known-gaps) — pick one from there rather than
-from a duplicate list here, so the status you read is the status the code
-reports.
+Linux and Windows are both
+[beta](CROSS_PLATFORM.md#what-the-labels-mean) — good for daily driving, with
+parity complete on each. What moves either to Stable is the six-clean-releases
+rule written there, not a feature. Any gap that reappears is tracked as a
+numbered entry in [Known Gaps](CROSS_PLATFORM.md#known-gaps) — pick one from
+there rather than from a duplicate list here, so the status you read is the
+status the code reports.
 
 What Linux owes macOS, and what it does not, is settled in
 [ADR 0013](adr/0013-parity-is-measured-in-words-not-subsystems.md): parity is a

--- a/scripts/install-windows.sh
+++ b/scripts/install-windows.sh
@@ -56,8 +56,7 @@ run_ps() {
 # `neru services install`, which registers a Task Scheduler logon task the way
 # the macOS installer loads a launchd agent. Runs under a bash (e.g. Git Bash);
 # `just` needs cygpath on PATH to translate the shebang.
-# Windows support is alpha (grid, recursive grid, scroll, hotkeys, mouse
-# injection, UIA); see docs/CROSS_PLATFORM.md.
+# Windows support is beta; see docs/CROSS_PLATFORM.md.
 arch="$(uname -m)"
 case "$arch" in
     aarch64 | arm64) arch=arm64 ;;
@@ -230,6 +229,5 @@ case "$run_reply" in
         echo "Skipped autostart. Start Neru with: neru launch"
         ;;
 esac
-echo "Windows support is alpha: worth trying, not yet worth switching to."
-echo "Hint coverage is incomplete and per-app config does not re-apply."
+echo "Windows support is beta: good for daily driving."
 echo "See docs/CROSS_PLATFORM.md for what works today."


### PR DESCRIPTION
## Description

This PR moves the Windows support label from Alpha to Beta everywhere the docs name it.

**What changed.** The status table in `docs/CROSS_PLATFORM.md`, the README support matrix, `docs/ROADMAP.md`, the requirements list in `docs/INSTALLATION.md`, the Windows Model section and the Windows installer's banner now say Beta. The label-definition paragraphs that explained why Linux stays Beta and how it reaches Stable now cover both Beta platforms, so the six-clean-releases rule is written once; the `gh issue list` query differs only in its `platform:` label. The Alpha definition stays, since it is vocabulary rather than a claim about any platform.

**Parity is stated honestly rather than as complete.** The support inventory still declares the `feed` action inert on Windows, so the Known Gaps list that read "None" was wrong before this PR. Key feed is now Windows gap 1, tracked by #1593, and the three `hints.vision.*_confidence` floors are recorded as a boundary of `Windows.Media.Ocr` rather than a gap. Beta still fits: the label's own definition allows "something is still missing".

**Why.** Every ticket under #1551 is merged, every mode works on Windows, and the Alpha definition ("hint coverage is incomplete and per-app config does not re-apply") no longer describes it.

## Related Issues

Closes #1569

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [x] `docs` — Documentation only

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`) — no Go or Objective-C touched
- [ ] `just ci` — skipped locally for a docs-only change; `go test ./internal/architecture/` (doc links, inventory, citations) passes, CI runs the full set
- [x] Tests added/updated — none needed, existing doc guardrails cover it
- [x] Documentation updated
- [x] PR title is a conventional commit subject written for users
