### PR TITLE
feat(windows): key feed via SendInput

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -83,12 +83,11 @@ no Linux entry, and the headless-sway job gates merges. That was the whole of
 [ADR 0013](./adr/0013-parity-is-measured-in-words-not-subsystems.md)'s promise,
 and it is kept.
 
-**Windows parity is one word short.** Every mode works, and every option, mode
-flag, action and command means what it means on macOS except the `feed` action
-and `neru key`, which have no key-injection path yet — Windows entry 1 under
-[Known Gaps](#known-gaps). The three `hints.vision.*_confidence` floors are
-inert there too, but as a stated boundary of the OCR engine rather than
-unbuilt work. The native `windows-latest` job gates merges.
+**Windows parity is complete too.** Every mode works, and every option, mode
+flag, action and command means what it means on macOS; [Known Gaps](#known-gaps)
+carries no Windows entry. The three `hints.vision.*_confidence` floors are
+inert there, but as a stated boundary of the OCR engine rather than unbuilt
+work. The native `windows-latest` job gates merges.
 
 **Both stay Beta anyway**, because parity is a claim about coverage and
 Stable is a claim about reliability. Fourteen Linux capabilities landed in a
@@ -207,7 +206,7 @@ that is what [Known Gaps](#known-gaps) tracks, per
 | **Native hint-search field**  | ✅ NSTextField overlay   | 🟡 key-stream input ⁴  | 🟡 key-stream input ⁴        | 🟡 key-stream input ⁴   | 🟡 key-stream input ⁴        |
 | **Screen capture**            | ✅ ScreenCaptureKit      | ✅ `XGetImage`         | ✅ `wlr-screencopy`          | ⚠️ portal ScreenCast, consent ⁵ | ✅ `BitBlt` ⁵        |
 | **Vision / OCR detection**    | ✅ Vision framework      | ⚠️ tesseract, text only ⁶ | ⚠️ tesseract, text only ⁶ | ⚠️ tesseract, text only ⁶ | ⚠️ `Windows.Media.Ocr`, text only ⁶ |
-| **Key feed (`neru key`)**     | ✅ `CGEventPost`         | ✅ uinput               | ✅ uinput / virtual-keyboard | ✅ uinput               | 🟡 `CodeNotSupported`        |
+| **Key feed (`neru key`)**     | ✅ `CGEventPost`         | ✅ uinput               | ✅ uinput / virtual-keyboard | ✅ uinput               | ✅ `SendInput`               |
 | **Service management (`neru services`)** | ✅ launchd user agent | ⚠️ systemd user unit only ² | ⚠️ systemd user unit only ² | ⚠️ systemd user unit only ² | ✅ Task Scheduler logon task |
 
 ¹ Every platform resolves font *families* through the OS: NSFont on macOS,
@@ -1102,7 +1101,6 @@ green in every cell while an option means nothing, which is exactly how
 | `hints.vision.rectangle_max_aspect` | option | ✅ | ❌ | ❌ | rectangle detection has no OCR answer, so it stays macOS-only even where the vision strategy lands; that half is text-only |
 | `hide_cursor` | action | ✅ | ❌ | ❌ | a Wayland client may not hide another client's cursor, and the blessed Linux stack is Wayland; Windows has no equivalent either |
 | `show_cursor` | action | ✅ | ❌ | ❌ | a Wayland client may not hide another client's cursor, and the blessed Linux stack is Wayland; Windows has no equivalent either |
-| `feed` | action | ✅ | ✅ | ❌ | Windows has no key-injection path yet, so the key it would post is never sent; the key_feed capability reports stub to match |
 
 <!-- END GENERATED PLATFORM SUPPORT -->
 
@@ -1197,10 +1195,8 @@ working, which is exactly why the build exists.
 
 **Windows**
 
-1. Key feed — the `feed` action and `neru key` return `CodeNotSupported`
-   because `keyfeed_other.go` is the Windows slot; the target is `SendInput`
-   with `KEYBDINPUT` events, the call the pointer and modifier passthrough
-   already use ([#1593](https://github.com/y3owk1n/neru/issues/1593)).
+None — parity is complete; the `feed` action and `neru key` inject through
+`SendInput`, the call the pointer and modifier passthrough already use.
 
 **Not a Windows gap**: the three `hints.vision.*_confidence` floors are inert
 because `Windows.Media.Ocr` reports no per-word confidence, so there is nothing

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,7 +28,7 @@ Work that is not tied to any one platform:
 
 Linux and Windows are both
 [beta](CROSS_PLATFORM.md#what-the-labels-mean) — good for daily driving, with
-Linux parity complete and Windows one word short. What moves either to Stable
+parity complete on both. What moves either to Stable
 is the six-clean-releases rule written there, not a feature. Every remaining
 item is tracked as a numbered entry in
 [Known Gaps](CROSS_PLATFORM.md#known-gaps) — pick one from there rather than

--- a/internal/adapter/keyfeed/doc.go
+++ b/internal/adapter/keyfeed/doc.go
@@ -7,5 +7,6 @@
 //
 // Platform slots: keyfeed_darwin.go (CGEventPost), keyfeed_linux.go (a uinput
 // virtual keyboard where /dev/uinput is writable, else zwp_virtual_keyboard_v1
-// on wlroots), and keyfeed_other.go, which returns CodeNotSupported.
+// on wlroots), keyfeed_windows.go (SendInput), and keyfeed_other.go, which
+// returns CodeNotSupported.
 package keyfeed

--- a/internal/adapter/keyfeed/keyfeed.go
+++ b/internal/adapter/keyfeed/keyfeed.go
@@ -15,7 +15,7 @@ import (
 //
 // Normalization is shared and lives here; only the final injection differs per
 // platform, behind the unexported postKey dispatch (keyfeed_darwin.go,
-// keyfeed_linux.go, keyfeed_other.go).
+// keyfeed_linux.go, keyfeed_windows.go, keyfeed_other.go).
 type Adapter struct {
 	logger *zap.Logger
 }

--- a/internal/adapter/keyfeed/keyfeed_other.go
+++ b/internal/adapter/keyfeed/keyfeed_other.go
@@ -1,16 +1,15 @@
-//go:build !darwin && !linux
+//go:build !darwin && !linux && !windows
 
 package keyfeed
 
 import "github.com/y3owk1n/neru/internal/derrors"
 
-// postKey reports that this platform has no key-injection path.
-//
-// Windows lands here today; the target is SendInput. The key_feed entry in
-// ports.PlatformCapabilities reports stub to match.
+// postKey reports that this platform has no key-injection path. No shipped
+// target lands here; the key_feed entry in ports.PlatformCapabilities reports
+// stub to match.
 func postKey(_ string) error {
 	return derrors.New(
 		derrors.CodeNotSupported,
-		"key feeding is only supported on macOS and Linux",
+		"key feeding is only supported on macOS, Linux and Windows",
 	)
 }

--- a/internal/adapter/keyfeed/keyfeed_windows.go
+++ b/internal/adapter/keyfeed/keyfeed_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package keyfeed
+
+import (
+	"github.com/y3owk1n/neru/internal/adapter/platform/windows"
+)
+
+// postKey injects an already-normalized key into the focused application via
+// SendInput. The events are tagged as Neru's own so the daemon's keyboard hook
+// ignores them.
+func postKey(normalized string) error {
+	return windows.FeedKey(normalized)
+}

--- a/internal/adapter/platform/windows/input.go
+++ b/internal/adapter/platform/windows/input.go
@@ -28,7 +28,8 @@ const (
 	mouseeventfHWheel     = 0x1000
 	mouseeventfAbsolute   = 0x8000
 
-	keyeventfKeyUp = 0x0002
+	keyeventfExtendedKey = 0x0001
+	keyeventfKeyUp       = 0x0002
 
 	// neruInjectedTag rides in dwExtraInfo on every keyboard event this
 	// process synthesizes, so the low-level keyboard hook can tell Neru's own
@@ -126,17 +127,29 @@ func sendMouseInput(flags uint32, data uint32) error {
 
 // sendKeyboardInput presses or releases one virtual key.
 func sendKeyboardInput(virtualKey uint16, isUp bool) error {
+	return sendKeyEvent(virtualKey, 0, keyUpFlag(isUp))
+}
+
+// sendKeyEvent posts one KEYBDINPUT record, tagged as Neru's own so the
+// keyboard hook does not read it back as the user typing.
+func sendKeyEvent(virtualKey uint16, scanCode uint16, flags uint32) error {
 	var event keyInput
 
 	event.inputType = inputKeyboard
 	event.ki.wVk = virtualKey
+	event.ki.wScan = scanCode
+	event.ki.dwFlags = flags
 	event.ki.dwExtraInfo = neruInjectedTag
 
+	return sendOneInput(unsafe.Pointer(&event), unsafe.Sizeof(event))
+}
+
+func keyUpFlag(isUp bool) uint32 {
 	if isUp {
-		event.ki.dwFlags = keyeventfKeyUp
+		return keyeventfKeyUp
 	}
 
-	return sendOneInput(unsafe.Pointer(&event), unsafe.Sizeof(event))
+	return 0
 }
 
 // MoveMouseTo moves the cursor to the given screen point.

--- a/internal/adapter/platform/windows/keyfeed.go
+++ b/internal/adapter/platform/windows/keyfeed.go
@@ -3,6 +3,7 @@
 package windows
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -55,19 +56,13 @@ func FeedKey(key string) error {
 	for _, modifier := range modifiers {
 		err = sendKeyboardInput(modifier, false)
 		if err != nil {
-			releaseKeys(pressed)
-
-			return wrapSendInput(err)
+			return wrapSendInput(errors.Join(err, releaseKeys(pressed)))
 		}
 
 		pressed = append(pressed, modifier)
 	}
 
-	err = tapKey(virtualKey)
-
-	releaseKeys(pressed)
-
-	return wrapSendInput(err)
+	return wrapSendInput(errors.Join(tapKey(virtualKey), releaseKeys(pressed)))
 }
 
 // tapKey presses and releases one key with its layout scan code.
@@ -87,13 +82,17 @@ func tapKey(virtualKey uint16) error {
 	return sendKeyEvent(virtualKey, uint16(scan), flags|keyeventfKeyUp)
 }
 
-// releaseKeys lifts modifiers in reverse press order. Failures are dropped:
-// a release that cannot be sent has no better fallback, and the caller is
-// already reporting the first error.
-func releaseKeys(keys []uint16) {
+// releaseKeys lifts modifiers in reverse press order. Every release is
+// attempted even after one fails, so a modifier is never left held because
+// an earlier one could not be lifted; the failures are joined.
+func releaseKeys(keys []uint16) error {
+	var errs []error
+
 	for _, key := range slices.Backward(keys) {
-		_ = sendKeyboardInput(key, true)
+		errs = append(errs, sendKeyboardInput(key, true))
 	}
+
+	return errors.Join(errs...)
 }
 
 func wrapSendInput(err error) error {
@@ -164,12 +163,13 @@ func feedModifierKey(token string) (uint16, error) {
 }
 
 // feedVirtualKey resolves a base key name to its virtual key plus the
-// modifiers the active layout needs to produce it. Named keys, letters and
-// digits carry none; any other single character asks VkKeyScan, which is the
-// only source that knows "!" is Shift+1 on US and Shift+8 on French.
+// modifiers the active layout needs to produce it. Named keys and letters
+// carry none; any other single character, digits included, asks VkKeyScan,
+// which is the only source that knows "1" is Shift+& on French and "!" is
+// Shift+1 on US.
 func feedVirtualKey(name string) (uint16, []uint16, bool) {
-	if keyRune, size := utf8.DecodeRuneInString(name); size == len(name) &&
-		!unicode.IsLetter(keyRune) && !unicode.IsDigit(keyRune) {
+	keyRune, size := utf8.DecodeRuneInString(name)
+	if size == len(name) && !unicode.IsLetter(keyRune) {
 		return virtualKeyWithLayoutModifiers(keyRune)
 	}
 

--- a/internal/adapter/platform/windows/keyfeed.go
+++ b/internal/adapter/platform/windows/keyfeed.go
@@ -1,0 +1,214 @@
+//go:build windows
+
+package windows
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// Key feed: typing a key into the focused application through SendInput.
+const (
+	// mapvkVkToVsc is MapVirtualKey's MAPVK_VK_TO_VSC mode: virtual key to
+	// scan code. Applications that read the scan code rather than the virtual
+	// key (games, some terminals) see nothing without it.
+	mapvkVkToVsc = 0
+
+	// VkKeyScan reports the modifiers a character needs on the active layout
+	// in its high byte.
+	vkKeyScanShift   = 0x01
+	vkKeyScanControl = 0x02
+	vkKeyScanAlt     = 0x04
+	// vkKeyScanStateShift moves that high byte down to the low one.
+	vkKeyScanStateShift = 8
+)
+
+// extendedVirtualKeys are the keys whose scan code carries the 0xE0 prefix.
+// Without KEYEVENTF_EXTENDEDKEY the navigation cluster arrives as its numpad
+// twin, so Home reads as numpad 7.
+var extendedVirtualKeys = map[uint16]bool{
+	vkPrior: true, vkNext: true, vkEnd: true, vkHome: true,
+	vkLeft: true, vkUp: true, vkRight: true, vkDown: true,
+	vkInsert: true, vkDelete: true,
+	vkLWin: true, vkRWin: true, vkRControl: true, vkRMenu: true,
+}
+
+// FeedKey presses and releases one key or chord in the focused application.
+//
+// key is the canonical form config.CanonicalHotkeyForPlatform produces on
+// Windows ("a", "Return", "Ctrl+Shift+Space"). Modifiers go down first, the
+// key is tapped, and the modifiers come up in reverse. A character that needs
+// Shift on the active layout ("!", "?") gets it added.
+func FeedKey(key string) error {
+	modifiers, virtualKey, err := parseFeedKey(key)
+	if err != nil {
+		return err
+	}
+
+	pressed := make([]uint16, 0, len(modifiers))
+
+	for _, modifier := range modifiers {
+		err = sendKeyboardInput(modifier, false)
+		if err != nil {
+			releaseKeys(pressed)
+
+			return wrapSendInput(err)
+		}
+
+		pressed = append(pressed, modifier)
+	}
+
+	err = tapKey(virtualKey)
+
+	releaseKeys(pressed)
+
+	return wrapSendInput(err)
+}
+
+// tapKey presses and releases one key with its layout scan code.
+func tapKey(virtualKey uint16) error {
+	scan, _, _ := procMapVirtualKeyW.Call(uintptr(virtualKey), mapvkVkToVsc)
+
+	var flags uint32
+	if extendedVirtualKeys[virtualKey] {
+		flags = keyeventfExtendedKey
+	}
+
+	err := sendKeyEvent(virtualKey, uint16(scan), flags)
+	if err != nil {
+		return err
+	}
+
+	return sendKeyEvent(virtualKey, uint16(scan), flags|keyeventfKeyUp)
+}
+
+// releaseKeys lifts modifiers in reverse press order. Failures are dropped:
+// a release that cannot be sent has no better fallback, and the caller is
+// already reporting the first error.
+func releaseKeys(keys []uint16) {
+	for _, key := range slices.Backward(keys) {
+		_ = sendKeyboardInput(key, true)
+	}
+}
+
+func wrapSendInput(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return derrors.Wrap(err, derrors.CodeActionFailed, "failed to post key event")
+}
+
+// parseFeedKey splits a canonical key string into the modifier keys to hold
+// and the virtual key to tap. Modifiers implied by the character on the
+// active layout are appended after the explicit ones, without duplicates.
+func parseFeedKey(key string) ([]uint16, uint16, error) {
+	parts := strings.Split(key, "+")
+
+	base := strings.TrimSpace(parts[len(parts)-1])
+	if base == "" {
+		return nil, 0, derrors.New(derrors.CodeInvalidInput, "key is required")
+	}
+
+	modifiers := make([]uint16, 0, len(parts))
+
+	for _, part := range parts[:len(parts)-1] {
+		modifier, err := feedModifierKey(part)
+		if err != nil {
+			return nil, 0, derrors.Wrapf(err, derrors.CodeInvalidInput, "key %q", key)
+		}
+
+		modifiers = appendModifier(modifiers, modifier)
+	}
+
+	virtualKey, implied, ok := feedVirtualKey(base)
+	if !ok {
+		return nil, 0, derrors.Newf(derrors.CodeInvalidInput, "unsupported key %q", base)
+	}
+
+	for _, modifier := range implied {
+		modifiers = appendModifier(modifiers, modifier)
+	}
+
+	return modifiers, virtualKey, nil
+}
+
+func appendModifier(modifiers []uint16, modifier uint16) []uint16 {
+	if slices.Contains(modifiers, modifier) {
+		return modifiers
+	}
+
+	return append(modifiers, modifier)
+}
+
+// feedModifierKey maps a modifier token to the canonical (left) key that
+// presents it, the same key PostModifierKey holds.
+func feedModifierKey(token string) (uint16, error) {
+	switch strings.ToLower(strings.TrimSpace(token)) {
+	case modNameCtrl, "control":
+		return vkLControl, nil
+	case modNameAlt, "option":
+		return vkLMenu, nil
+	case modNameShift:
+		return vkLShift, nil
+	case modNameCmd, "command", "win", "super", "meta":
+		return vkLWin, nil
+	default:
+		return 0, fmt.Errorf("%w: %s", errUnsupportedModifier, token)
+	}
+}
+
+// feedVirtualKey resolves a base key name to its virtual key plus the
+// modifiers the active layout needs to produce it. Named keys, letters and
+// digits carry none; any other single character asks VkKeyScan, which is the
+// only source that knows "!" is Shift+1 on US and Shift+8 on French.
+func feedVirtualKey(name string) (uint16, []uint16, bool) {
+	if keyRune, size := utf8.DecodeRuneInString(name); size == len(name) &&
+		!unicode.IsLetter(keyRune) && !unicode.IsDigit(keyRune) {
+		return virtualKeyWithLayoutModifiers(keyRune)
+	}
+
+	virtualKey, ok := nameToVirtualKey(name)
+	if !ok {
+		return 0, nil, false
+	}
+
+	return uint16(virtualKey), nil, true
+}
+
+func virtualKeyWithLayoutModifiers(keyRune rune) (uint16, []uint16, bool) {
+	ret, _, _ := procVkKeyScanW.Call(uintptr(keyRune))
+
+	scan := int16(ret)
+	if scan == -1 {
+		return 0, nil, false
+	}
+
+	virtualKey := uint16(scan) & byteMask
+	if virtualKey == 0 {
+		return 0, nil, false
+	}
+
+	state := (uint16(scan) >> vkKeyScanStateShift) & byteMask
+
+	var modifiers []uint16
+
+	if state&vkKeyScanShift != 0 {
+		modifiers = append(modifiers, vkLShift)
+	}
+
+	if state&vkKeyScanControl != 0 {
+		modifiers = append(modifiers, vkLControl)
+	}
+
+	if state&vkKeyScanAlt != 0 {
+		modifiers = append(modifiers, vkLMenu)
+	}
+
+	return virtualKey, modifiers, true
+}

--- a/internal/adapter/platform/windows/keyfeed_integration_test.go
+++ b/internal/adapter/platform/windows/keyfeed_integration_test.go
@@ -1,0 +1,178 @@
+//go:build integration && windows
+
+package windows
+
+import (
+	"runtime"
+	"testing"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Real Win32 test for FeedKey: a key fed through SendInput must arrive as
+// WM_KEYDOWN / WM_KEYUP in a window this process owns and holds in the
+// foreground. In-package because the message pump helpers are unexported.
+
+const (
+	keyFeedTestClass = "NeruKeyFeedTest"
+	homeKeyName      = "Home"
+	// keyFeedArrival bounds how long an injected key may take to reach the
+	// window's queue. SendInput is synchronous into the system queue, so a
+	// real arrival is milliseconds; the margin is for a loaded runner.
+	keyFeedArrival = 2 * time.Second
+	// extendedKeyBit is bit 24 of a WM_KEYDOWN lParam: the scan code carried
+	// the 0xE0 prefix.
+	extendedKeyBit = 1 << 24
+)
+
+var procSetFocus = user32.NewProc("SetFocus")
+
+func TestFeedKey_ArrivesInOwnedWindow(t *testing.T) {
+	runtime.LockOSThread()
+
+	defer runtime.UnlockOSThread()
+
+	hwnd := newForegroundTestWindow(t)
+
+	tests := []struct {
+		key        string
+		virtualKey uintptr
+		extended   bool
+	}{
+		{key: "a", virtualKey: 'A', extended: false},
+		{key: homeKeyName, virtualKey: vkHome, extended: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.key, func(t *testing.T) {
+			err := FeedKey(test.key)
+			if err != nil {
+				t.Fatalf("FeedKey(%q): %v", test.key, err)
+			}
+
+			down := awaitKeyMessages(t, hwnd, test.virtualKey)
+
+			extended := down&extendedKeyBit != 0
+			if extended != test.extended {
+				t.Fatalf(
+					"FeedKey(%q): extended flag = %v, want %v",
+					test.key,
+					extended,
+					test.extended,
+				)
+			}
+		})
+	}
+}
+
+// newForegroundTestWindow creates a plain top-level window and brings it to
+// the foreground, skipping when the session refuses foreground activation,
+// which is what a non-interactive window station does.
+func newForegroundTestWindow(t *testing.T) uintptr {
+	t.Helper()
+
+	className, err := windows.UTF16PtrFromString(keyFeedTestClass)
+	if err != nil {
+		t.Fatalf("UTF16PtrFromString: %v", err)
+	}
+
+	class := wndClassEx{
+		cbSize:        uint32(unsafe.Sizeof(wndClassEx{})),
+		lpfnWndProc:   procDefWindowProcW.Addr(),
+		hInstance:     windows.Handle(moduleHandle()),
+		lpszClassName: className,
+	}
+
+	atom, _, err := procRegisterClassExW.Call(uintptr(unsafe.Pointer(&class)))
+	if atom == 0 {
+		t.Skipf("skipping: RegisterClassExW: %v", err)
+	}
+
+	hwnd, _, err := procCreateWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(className)),
+		0,
+		wsOverlappedWindow|wsVisible,
+		100, 100, 200, 200,
+		0, 0, moduleHandle(), 0,
+	)
+	if hwnd == 0 {
+		t.Skipf("skipping: CreateWindowExW: %v", err)
+	}
+
+	t.Cleanup(func() { discardCall(procDestroyWindow.Call(hwnd)) })
+
+	discardCall(procSetForegroundWindow.Call(hwnd))
+	discardCall(procSetFocus.Call(hwnd))
+	drainWindowMessages(hwnd)
+
+	if uintptr(windows.GetForegroundWindow()) != hwnd {
+		t.Skip(
+			"skipping: the session refused foreground activation, so no window can receive input",
+		)
+	}
+
+	return hwnd
+}
+
+// awaitKeyMessages pumps the window's queue until WM_KEYUP for virtualKey
+// arrives, returning the WM_KEYDOWN lParam, and fails at the deadline.
+func awaitKeyMessages(t *testing.T, hwnd uintptr, virtualKey uintptr) uintptr {
+	t.Helper()
+
+	deadline := time.Now().Add(keyFeedArrival)
+
+	var (
+		downParam uintptr
+		sawDown   bool
+	)
+
+	for time.Now().Before(deadline) {
+		var message msg
+
+		ret, _, _ := procPeekMessageW.Call(uintptr(unsafe.Pointer(&message)), hwnd, 0, 0, pmRemove)
+		if ret == 0 {
+			time.Sleep(5 * time.Millisecond)
+
+			continue
+		}
+
+		switch {
+		case message.message == wmKeyDown && message.wParam == virtualKey:
+			downParam = message.lParam
+			sawDown = true
+		case message.message == wmKeyUp && message.wParam == virtualKey:
+			if !sawDown {
+				t.Fatal("WM_KEYUP arrived before WM_KEYDOWN")
+			}
+
+			return downParam
+		}
+
+		_, _, _ = procDispatchMessageW.Call(uintptr(unsafe.Pointer(&message)))
+	}
+
+	t.Fatalf(
+		"no WM_KEYUP for virtual key %#x within %v (WM_KEYDOWN seen: %v)",
+		virtualKey,
+		keyFeedArrival,
+		sawDown,
+	)
+
+	return 0
+}
+
+func drainWindowMessages(hwnd uintptr) {
+	for range maxMessagesPerPump {
+		var message msg
+
+		ret, _, _ := procPeekMessageW.Call(uintptr(unsafe.Pointer(&message)), hwnd, 0, 0, pmRemove)
+		if ret == 0 {
+			return
+		}
+
+		_, _, _ = procDispatchMessageW.Call(uintptr(unsafe.Pointer(&message)))
+	}
+}

--- a/internal/adapter/platform/windows/keyfeed_integration_test.go
+++ b/internal/adapter/platform/windows/keyfeed_integration_test.go
@@ -30,6 +30,9 @@ const (
 var procSetFocus = user32.NewProc("SetFocus")
 
 func TestFeedKey_ArrivesInOwnedWindow(t *testing.T) {
+	// The window, the injection and the pump must share one thread: a
+	// window's messages land on the queue of the thread that created it,
+	// and t.Run would move each case onto another goroutine.
 	runtime.LockOSThread()
 
 	defer runtime.UnlockOSThread()
@@ -46,24 +49,17 @@ func TestFeedKey_ArrivesInOwnedWindow(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.key, func(t *testing.T) {
-			err := FeedKey(test.key)
-			if err != nil {
-				t.Fatalf("FeedKey(%q): %v", test.key, err)
-			}
+		err := FeedKey(test.key)
+		if err != nil {
+			t.Fatalf("FeedKey(%q): %v", test.key, err)
+		}
 
-			down := awaitKeyMessages(t, hwnd, test.virtualKey)
+		down := awaitKeyMessages(t, hwnd, test.key, test.virtualKey)
 
-			extended := down&extendedKeyBit != 0
-			if extended != test.extended {
-				t.Fatalf(
-					"FeedKey(%q): extended flag = %v, want %v",
-					test.key,
-					extended,
-					test.extended,
-				)
-			}
-		})
+		extended := down&extendedKeyBit != 0
+		if extended != test.extended {
+			t.Fatalf("FeedKey(%q): extended flag = %v, want %v", test.key, extended, test.extended)
+		}
 	}
 }
 
@@ -119,7 +115,7 @@ func newForegroundTestWindow(t *testing.T) uintptr {
 
 // awaitKeyMessages pumps the window's queue until WM_KEYUP for virtualKey
 // arrives, returning the WM_KEYDOWN lParam, and fails at the deadline.
-func awaitKeyMessages(t *testing.T, hwnd uintptr, virtualKey uintptr) uintptr {
+func awaitKeyMessages(t *testing.T, hwnd uintptr, key string, virtualKey uintptr) uintptr {
 	t.Helper()
 
 	deadline := time.Now().Add(keyFeedArrival)
@@ -155,7 +151,8 @@ func awaitKeyMessages(t *testing.T, hwnd uintptr, virtualKey uintptr) uintptr {
 	}
 
 	t.Fatalf(
-		"no WM_KEYUP for virtual key %#x within %v (WM_KEYDOWN seen: %v)",
+		"FeedKey(%q): no WM_KEYUP for virtual key %#x within %v (WM_KEYDOWN seen: %v)",
+		key,
 		virtualKey,
 		keyFeedArrival,
 		sawDown,

--- a/internal/domain/action/platform_support.go
+++ b/internal/domain/action/platform_support.go
@@ -6,8 +6,6 @@ import "github.com/y3owk1n/neru/internal/domain/parity"
 const (
 	noteCursorVisibility = "a Wayland client may not hide another client's cursor, " +
 		"and the blessed Linux stack is Wayland; Windows has no equivalent either"
-	noteKeyFeed = "Windows has no key-injection path yet, so the key it would post is " +
-		"never sent; the key_feed capability reports stub to match"
 )
 
 // PlatformSupport declares, for every action name, the platforms on which
@@ -25,14 +23,8 @@ func PlatformSupport() parity.Declaration {
 			string(NameShowCursor),
 		),
 
-		parity.On(
-			parity.KindAction,
-			parity.Platforms{parity.Darwin, parity.Linux},
-			noteKeyFeed,
-			string(NameFeed),
-		),
-
 		parity.Everywhere(parity.KindAction,
+			string(NameFeed),
 			string(NameScrollLeft),
 			string(NameScrollRight),
 			string(NameLeftClick),

--- a/internal/ports/capability_presets.go
+++ b/internal/ports/capability_presets.go
@@ -210,9 +210,7 @@ func WindowsCapabilities() PlatformCapabilities {
 				"capture; text only, and it needs an OCR language pack for one of the " +
 				"account's languages",
 		),
-		KeyFeed: stubCapability(
-			"key injection not implemented yet; target SendInput",
-		),
+		KeyFeed: supportedCapability("key injection available via SendInput"),
 		Systray: supportedCapability(
 			"tray icon available via the Win32 notification area (Shell_NotifyIcon)",
 		),


### PR DESCRIPTION
## Description

This PR adds key injection on Windows, so the `feed` action and `neru key` type the requested key or chord into the focused application instead of returning "not supported". Modifiers are held first, the key is tapped with its layout scan code (navigation keys carry the extended-key flag so Home does not arrive as numpad 7), and modifiers are released in reverse. A character that needs Shift on the active layout, such as `!`, gets it added automatically.

The Windows capability report and the platform-support declaration now say `feed` works everywhere, and the Known Gaps entry for Windows is gone. The injected events carry the same self-tag the modifier passthrough uses, so the daemon's own keyboard hook ignores them.

## Related Issues

Closes #1593

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — the non-target fallback slot keeps returning it; Windows no longer matches it
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, targeted gate instead: `just fmt-check`, `just lint`, `just build`, `just check-cross`, a Windows-targeted `golangci-lint` run over the touched packages with the integration tag, and unit tests for `action`, `ports`, `architecture`, `keyfeed`, `supportref`; CI runs the full set on all three OSes
- [x] Tests added/updated for new or changed functionality — a Windows integration test feeds `a` and `Home` into a window the test owns and checks WM_KEYDOWN / WM_KEYUP arrive with the right extended flag; it skips when the session refuses foreground activation
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

The generated Platform Support Per Word table lists only words narrower than every platform, so `feed` leaving it is what "✅ on Windows" looks like there. The Capability Matrix row reads `SendInput` explicitly.

Delete is mapped to Backspace on Windows, matching the existing hotkey vocabulary rather than changing it here.
