### PR TITLE
fix(cli): present the Linux and Windows startup notice as beta status

### DIFF
--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -95,7 +95,7 @@ func printPlatformStartupNotice(platformLabel string) {
 
 	fmt.Fprintf(
 		os.Stderr,
-		"⚠️  Neru is running on %s. Run 'neru doctor' for platform capabilities.\n\n",
+		"Neru on %s is in beta. Run 'neru doctor' to see what is supported.\n\n",
 		platformLabel,
 	)
 }


### PR DESCRIPTION
## Description

This PR reworks the startup notice printed on Linux and Windows. It used to open with a warning emoji and read as an alert, even though both platforms are now in beta. It now reads as a plain status line:

```
Neru on Linux is in beta. Run 'neru doctor' to see what is supported.
```

Behaviour is otherwise unchanged. macOS still prints nothing.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, the notice lives in shared code gated at runtime
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new capability
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, ran `just fmt`, `just lint`, `go vet` and `go build` instead for a one-line string change
- [x] Tests added/updated for new or changed functionality — N/A, stderr wording only
- [x] Documentation updated (if applicable) — N/A, the wording is not documented anywhere
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch
