### PR TITLE
fix(hints): ask for screen-capture consent before the contour strategy runs

### DIFF
--- a/internal/app/modes/hints.go
+++ b/internal/app/modes/hints.go
@@ -310,10 +310,11 @@ func (h *handlerState) activateHintModeInternal(activation modecmd.Activation) {
 	h.startIndicatorPolling(domain.ModeHints)
 }
 
-// needsScreenCapturePermission reports whether the vision strategy is blocked
-// on the screen-recording permission.
+// needsScreenCapturePermission reports whether a screen-capture strategy is
+// blocked on the screen-recording permission. Vision and contour both read the
+// window's pixels, so both pay the gate. Axtree never touches the screen.
 func (h *handlerState) needsScreenCapturePermission(strategy string) bool {
-	if strategy != domain.StrategyVision {
+	if strategy != domain.StrategyVision && strategy != domain.StrategyContour {
 		return false
 	}
 

--- a/internal/app/modes/hints_permission_test.go
+++ b/internal/app/modes/hints_permission_test.go
@@ -64,13 +64,24 @@ func newVisionHintsHandler(
 	logger *zap.Logger,
 	shutdown func(),
 ) *Handler {
+	return newCaptureHintsHandler(domain.StrategyVision, systemMock, logger, shutdown)
+}
+
+// newCaptureHintsHandler builds a handler whose configured hint strategy is
+// strategy and whose screen-capture permission comes from systemMock.
+func newCaptureHintsHandler(
+	strategy string,
+	systemMock *portmocks.MockSystemPort,
+	logger *zap.Logger,
+	shutdown func(),
+) *Handler {
 	handler := newHandlerWithState(handlerState{
 		ctx:    context.Background(),
 		logger: logger,
 		config: &configpkg.Config{
 			Hints: configpkg.HintsConfig{
 				Enabled:  true,
-				Strategy: domain.StrategyVision,
+				Strategy: strategy,
 			},
 		},
 		appState:      state.NewAppState(),
@@ -119,6 +130,20 @@ func TestActivateMode_PermissionDialogDoesNotBlockOrHoldLock(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("quit consent never reached shutdown")
 	}
+}
+
+func TestActivateMode_ContourStrategyRequestsScreenCapturePermission(t *testing.T) {
+	modal := newPermissionModal()
+	handler := newCaptureHintsHandler(domain.StrategyContour, modal.system, zap.NewNop(), func() {})
+
+	// Contour reads the window's pixels just like vision does, so an
+	// activation without consent must raise the dialog instead of letting the
+	// capture fail under the mode handler's lock.
+	handler.ActivateMode(modecmd.Activation{Mode: domain.ModeHints})
+
+	modal.awaitOpen(t)
+
+	modal.consent <- ports.ScreenCaptureCanceled
 }
 
 func TestResumeHintActivationAfterPermission_DoesNotRepromptWhenCheckStillFails(t *testing.T) {


### PR DESCRIPTION
## Description

This PR fixes hints mode failing on KDE Plasma with the contour strategy. The one-time screen-sharing consent prompt was only raised for the vision strategy, so a contour activation went straight to a screen capture that no grant backed. The capture failed with "no screen-sharing consent has been granted to Neru yet" and a popup, and nothing ever asked the user for that consent. The same gap hid a missing Screen Recording permission on macOS.

Contour now pays the same permission preflight as vision: the first activation without consent shows the platform's prompt, and later activations reuse the stored grant. Users who hit this today can work around it by running hints once with `--strategy vision`, which stores the grant contour then reuses.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, shared mode-handler code only
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new port surface
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, one-condition change; ran gofmt, vet, golangci-lint on the package, and the app test tree including a `-race` pass of the permission tests
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, docs already describe the one-time KDE consent without naming a strategy
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users
