### PR TITLE
fix(windows): keep a stopped keyboard hook's WM_QUIT off other message pumps

### DIFF
--- a/internal/adapter/platform/windows/keyboard_hook.go
+++ b/internal/adapter/platform/windows/keyboard_hook.go
@@ -30,6 +30,7 @@ const (
 	wmQuit       = 0x0012
 	llkhfUp      = 0x0080
 	pmRemove     = 0x0001
+	pmNoRemove   = 0x0000
 )
 
 type kbdLLHookStruct struct {
@@ -156,8 +157,9 @@ func (h *KeyboardHook) Stop() {
 		// loop. Without this, Stop deadlocks on doneCh (the loop's own
 		// stopCh check only runs between GetMessage calls, which it never
 		// reaches while blocked). The in-loop stopCh check still covers a Stop
-		// that fires before the first GetMessage. The WM_QUIT that leaves queued
-		// dies with the locked thread (see run).
+		// that fires before the first GetMessage. The queue exists by then (run
+		// creates it before signaling readiness), and the WM_QUIT this leaves
+		// queued dies with the locked thread.
 		h.mu.Lock()
 		threadID := h.threadID
 		h.mu.Unlock()
@@ -268,6 +270,15 @@ func (h *KeyboardHook) run() {
 
 		return
 	}
+
+	// A thread gets a message queue on its first call that needs one, and
+	// PostThreadMessage to a thread without one fails. Stop posts WM_QUIT as
+	// soon as StartKeyboardHook returns, which can be before the loop's first
+	// GetMessage, so the queue is forced into existence here, ahead of the
+	// readiness signal. PeekMessage with PM_NOREMOVE is the documented way.
+	var probe msg
+
+	discardCall(procPeekMessageW.Call(uintptr(unsafe.Pointer(&probe)), 0, 0, 0, pmNoRemove))
 
 	h.mu.Lock()
 	h.hook = handle

--- a/internal/adapter/platform/windows/keyboard_hook.go
+++ b/internal/adapter/platform/windows/keyboard_hook.go
@@ -4,6 +4,7 @@ package windows
 
 import (
 	"errors"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -154,8 +155,9 @@ func (h *KeyboardHook) Stop() {
 		// WM_QUIT to the hook thread makes GetMessage return 0 and end the
 		// loop. Without this, Stop deadlocks on doneCh (the loop's own
 		// stopCh check only runs between GetMessage calls, which it never
-		// reaches while blocked). The in-loop check still covers the race
-		// where Stop fires before the first GetMessage.
+		// reaches while blocked). The in-loop stopCh check still covers a Stop
+		// that fires before the first GetMessage. The WM_QUIT that leaves queued
+		// dies with the locked thread (see run).
 		h.mu.Lock()
 		threadID := h.threadID
 		h.mu.Unlock()
@@ -241,6 +243,16 @@ func keyboardHookProc(code int, wParam uintptr, lParam unsafe.Pointer) uintptr {
 }
 
 func (h *KeyboardHook) run() {
+	// The hook and its message queue are thread-affine (doc.go), and the
+	// thread is deliberately never unlocked: a goroutine that exits while
+	// locked takes its OS thread down with it, queue included. Stop's WM_QUIT
+	// is consumed by the GetMessage it wakes, but a Stop that lands before the
+	// first GetMessage leaves it queued, and a thread handed back to the
+	// scheduler with a WM_QUIT in its queue ends the next message pump that
+	// runs on it. The display and foreground watchers lock whatever thread
+	// they start on and would exit before their first real message.
+	runtime.LockOSThread()
+
 	defer close(h.doneCh)
 
 	handle, _, _ := procSetWindowsHookExW.Call(
@@ -285,15 +297,6 @@ func (h *KeyboardHook) run() {
 	for {
 		select {
 		case <-h.stopCh:
-			if h.threadID != 0 {
-				_, _, _ = procPostThreadMessageW.Call(
-					uintptr(h.threadID),
-					wmQuit,
-					0,
-					0,
-				)
-			}
-
 			return
 		default:
 		}


### PR DESCRIPTION
## Description

This PR fixes a leak on Windows where stopping the keyboard hook could leave a quit message behind on a scheduler thread and silently end whichever message pump ran on that thread next. The hook's pump did not pin its OS thread and posted the quit message twice on stop, so one copy could outlive the pump. The display-change and foreground watchers pin whatever thread they start on, and when that thread carried a leftover quit their pump exited before receiving anything.

The hook's pump now pins its thread for its whole life and lets the thread die with it, queue included, and the loop no longer posts the second quit message. The visible effect is that display and focus change notifications can no longer stop arriving after a mode has been activated and left. In CI it is the intermittent `TestDisplayWatcher_ObservesDisplayChangePostedToHiddenWindow` failure, which posts to a window whose pump had already gone.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changes
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, one-file Windows change developed on macOS; ran `just lint-cross` (Linux and Windows lint) and `GOOS=windows go vet` with and without the integration tag, and CI's Windows job is the real check
- [x] Tests added/updated for new or changed functionality — N/A, the existing display watcher integration test is the regression test; the leak depends on scheduler thread reuse and cannot be forced deterministically from a test
- [x] Documentation updated (if applicable) — N/A
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

The cost is one OS thread created per hook start, which is per mode activation. That thread creation sits beside the hook install call it already makes, and the alternative of keeping the thread and reasoning about exact quit-message accounting depends on when Windows creates a thread's message queue, which is not something to bet a silent pump exit on.
