### PR TITLE
fix(linux): name keys by the character they type so Shift+Tab and PageUp bindings fire

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -761,7 +761,19 @@ every layout that is not `us`. Following the keymap is what makes a binding mean
 the key that *types* that character, and is the same reason XKB options like
 `ctrl:swapcaps` reach Neru's own bindings. **On a non-QWERTY layout this decides
 which physical key a `[hotkeys]` chord answers** — the one bearing that character
-on the active layout, in both places.
+on the active layout, in both places. The keysym is named by the **character it
+types** when it types one, and by keysym name only otherwise
+(`neru_xkb_keysym_name`,
+[wayland_keymap.c](../internal/adapter/platform/linux/wayland_keymap.c)) — the
+same rule the X11 tap applies. Shift has already chosen the level by the time a
+keysym exists, and the shifted level's *name* is not its character (`Shift+[`
+is `braceleft`, and a non-us layout runs to `sterling` and `adiaeresis`), so a
+hand-written name table could never be complete. The one named key XKB renames
+under Shift, `ISO_Left_Tab`, folds back to `Tab` on both backends, which is what
+lets the default `Shift+Tab` hint binding fire on Linux. The fold rows are keyed
+by the name libxkbcommon actually answers, which is the first one
+`xkbcommon-keysyms.h` lists for a keysym: the page keys are `Prior` and `Next`
+there, and a row keyed `Page_Up` was dead.
 
 **Modifier passthrough (Wayland evdev, and Windows).** While a mode is active
 Neru captures the keyboard exclusively, so shortcuts it does not bind

--- a/internal/adapter/eventtap/linux/evdev_keys_test.go
+++ b/internal/adapter/eventtap/linux/evdev_keys_test.go
@@ -83,8 +83,10 @@ func TestEvdevKeyNameFunctionKeysContiguous(t *testing.T) {
 // and each `keysym` records which keysym the keypad reports for that key with
 // NumLock off, so the `want` column can be checked against the fold table
 // neru_normalize_xkb_name applies to it
-// (internal/adapter/platform/linux/wayland_keymap.c). Every name below is
-// copied from that table; none is chosen here.
+// (internal/adapter/platform/linux/wayland_keymap.c). Every navigation name
+// below is copied from that table, and every operator is the character its
+// keysym types, which neru_xkb_keysym_name answers before the table; none is
+// chosen here.
 var keypadKeyNameCases = []struct {
 	name   string
 	keysym string
@@ -101,12 +103,12 @@ var keypadKeyNameCases = []struct {
 	// Dual-function, named for what they do with NumLock off.
 	{name: "KEY_KP7", keysym: "KP_Home", code: 71, want: evdevKeyNameHome},
 	{name: "KEY_KP8", keysym: "KP_Up", code: 72, want: evdevKeyNameUp},
-	{name: "KEY_KP9", keysym: "KP_Page_Up", code: 73, want: evdevKeyNamePageUp},
+	{name: "KEY_KP9", keysym: "KP_Prior", code: 73, want: evdevKeyNamePageUp},
 	{name: "KEY_KP4", keysym: "KP_Left", code: 75, want: evdevKeyNameLeft},
 	{name: "KEY_KP6", keysym: "KP_Right", code: 77, want: evdevKeyNameRight},
 	{name: "KEY_KP1", keysym: "KP_End", code: 79, want: evdevKeyNameEnd},
 	{name: "KEY_KP2", keysym: "KP_Down", code: 80, want: evdevKeyNameDown},
-	{name: "KEY_KP3", keysym: "KP_Page_Down", code: 81, want: evdevKeyNamePageDown},
+	{name: "KEY_KP3", keysym: "KP_Next", code: 81, want: evdevKeyNamePageDown},
 	{name: "KEY_KP0", keysym: "KP_Insert", code: 82, want: evdevKeyNameInsert},
 	{name: "KEY_KPDOT", keysym: "KP_Delete", code: 83, want: evdevKeyNameDelete},
 

--- a/internal/adapter/eventtap/linux/evdev_xkb_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_xkb_cgo.go
@@ -45,6 +45,18 @@ func (capture *waylandEvdevCapture) keyName(code uint16) string {
 	return evdevKeyName(code)
 }
 
+// xkbKeysymName names a state-resolved keysym by the rule keyName applies to a
+// scan code, without needing a keymap: the character it types, else the folded
+// keysym name. It exists so that rule can be pinned from a test.
+func xkbKeysymName(keysym uint32) string {
+	var buf [64]C.char
+	if C.neru_xkb_keysym_name(C.uint32_t(keysym), &buf[0], C.size_t(len(buf))) != 0 {
+		return ""
+	}
+
+	return C.GoString(&buf[0])
+}
+
 // modifierName returns the canonical evdev modifier name for the given scan code
 // as resolved by the XKB keymap, or empty string when the key is not a modifier.
 // When XKB remaps a physical modifier to a different function (e.g. ctrl:swapcaps

--- a/internal/adapter/eventtap/linux/evdev_xkb_keysym_test.go
+++ b/internal/adapter/eventtap/linux/evdev_xkb_keysym_test.go
@@ -68,7 +68,11 @@ func TestXkbKeysymName(t *testing.T) {
 		// onto the main-keyboard names; with NumLock on, characters.
 		{name: "keypad enter is return", keysym: xkbKeysymKPEnter, want: evdevKeyNameReturn},
 		{name: "keypad home folds to home", keysym: xkbKeysymKPHome, want: evdevKeyNameHome},
-		{name: "keypad page up folds to page up", keysym: xkbKeysymKPPrior, want: evdevKeyNamePageUp},
+		{
+			name:   "keypad page up folds to page up",
+			keysym: xkbKeysymKPPrior,
+			want:   evdevKeyNamePageUp,
+		},
 		{name: "keypad begin is its digit", keysym: xkbKeysymKPBegin, want: "5"},
 		{name: "keypad add is its character", keysym: xkbKeysymKPAdd, want: "+"},
 		{name: "keypad digit is its character", keysym: xkbKeysymKP7, want: "7"},

--- a/internal/adapter/eventtap/linux/evdev_xkb_keysym_test.go
+++ b/internal/adapter/eventtap/linux/evdev_xkb_keysym_test.go
@@ -1,0 +1,90 @@
+//go:build linux && cgo
+
+package linux
+
+import "testing"
+
+// XKB keysyms from xkbcommon-keysyms.h, the same frozen numbers as X11's. A
+// test file cannot use cgo, so they are pinned as literals; untyped constants
+// convert at the call site.
+const (
+	xkbKeysymSpace      = 0x0020 // XKB_KEY_space
+	xkbKeysymBraceLeft  = 0x007B // XKB_KEY_braceleft
+	xkbKeysymSemicolon  = 0x003B // XKB_KEY_semicolon
+	xkbKeysymUpperM     = 0x004D // XKB_KEY_M
+	xkbKeysymSterling   = 0x00A3 // XKB_KEY_sterling
+	xkbKeysymADiaeresis = 0x00E4 // XKB_KEY_adiaeresis
+	xkbKeysymCyrillicA  = 0x06C1 // XKB_KEY_Cyrillic_a
+	xkbKeysymBackSpace  = 0xFF08 // XKB_KEY_BackSpace
+	xkbKeysymTab        = 0xFF09 // XKB_KEY_Tab
+	xkbKeysymReturn     = 0xFF0D // XKB_KEY_Return
+	xkbKeysymPageUp     = 0xFF55 // XKB_KEY_Prior, listed before Page_Up
+	xkbKeysymDelete     = 0xFFFF // XKB_KEY_Delete
+	xkbKeysymKPEnter    = 0xFF8D // XKB_KEY_KP_Enter
+	xkbKeysymKPHome     = 0xFF95 // XKB_KEY_KP_Home
+	xkbKeysymKPPrior    = 0xFF9A // XKB_KEY_KP_Prior, listed before KP_Page_Up
+	xkbKeysymKPBegin    = 0xFF9D // XKB_KEY_KP_Begin
+	xkbKeysymKPAdd      = 0xFFAB // XKB_KEY_KP_Add
+	xkbKeysymKP7        = 0xFFB7 // XKB_KEY_KP_7
+	xkbKeysymISOLeftTab = 0xFE20 // XKB_KEY_ISO_Left_Tab
+	xkbKeysymDeadAcute  = 0xFE51 // XKB_KEY_dead_acute
+	xkbKeysymNoSymbol   = 0x0000 // XKB_KEY_NoSymbol
+)
+
+// TestXkbKeysymName pins the rule the evdev and Wayland readers name a key by,
+// which has to be the rule the X11 tap applies (x11BaseKeyName) or a binding
+// written once matches on one Linux backend and not the other. The names here
+// are the raw answer, before keyvocab.NormalizeKey folds case and named-key
+// spelling on the chord.
+func TestXkbKeysymName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		keysym uint32
+		want   string
+	}{
+		{name: "punctuation is its character", keysym: xkbKeysymSemicolon, want: ";"},
+		// The shifted level is a keysym of its own, and its *name* is not the
+		// character: "braceleft" matched nothing when it was the answer.
+		{name: "the shifted level is its character", keysym: xkbKeysymBraceLeft, want: "{"},
+		{name: "a letter keeps the case the level chose", keysym: xkbKeysymUpperM, want: "M"},
+		// Latin-1 and beyond: the character, as X11 answers, not "sterling".
+		{name: "a Latin-1 symbol is its character", keysym: xkbKeysymSterling, want: "£"},
+		{name: "an accented letter is its character", keysym: xkbKeysymADiaeresis, want: "ä"},
+		{name: "a non-Latin letter is its character", keysym: xkbKeysymCyrillicA, want: "а"},
+		// Shift+Tab: XKB calls the shifted Tab ISO_Left_Tab, and it is Tab.
+		{name: "shifted tab is tab", keysym: xkbKeysymISOLeftTab, want: evdevKeyNameTab},
+		{name: "tab", keysym: xkbKeysymTab, want: evdevKeyNameTab},
+		// Space types a character, and is still the named key.
+		{name: "space is named, not a blank", keysym: xkbKeysymSpace, want: "space"},
+		{name: "return", keysym: xkbKeysymReturn, want: evdevKeyNameReturn},
+		{name: "backspace", keysym: xkbKeysymBackSpace, want: "BackSpace"},
+		{name: "delete", keysym: xkbKeysymDelete, want: "Delete"},
+		// xkbcommon names this keysym Prior, not Page_Up, and the fold has to
+		// be keyed by the name it answers or PageUp never reaches a binding.
+		{name: "page up", keysym: xkbKeysymPageUp, want: evdevKeyNamePageUp},
+		// The keypad: with NumLock off it reports navigation keysyms that fold
+		// onto the main-keyboard names; with NumLock on, characters.
+		{name: "keypad enter is return", keysym: xkbKeysymKPEnter, want: evdevKeyNameReturn},
+		{name: "keypad home folds to home", keysym: xkbKeysymKPHome, want: evdevKeyNameHome},
+		{name: "keypad page up folds to page up", keysym: xkbKeysymKPPrior, want: evdevKeyNamePageUp},
+		{name: "keypad begin is its digit", keysym: xkbKeysymKPBegin, want: "5"},
+		{name: "keypad add is its character", keysym: xkbKeysymKPAdd, want: "+"},
+		{name: "keypad digit is its character", keysym: xkbKeysymKP7, want: "7"},
+		// Nothing typed and nothing Neru names: the keysym name, which no
+		// binding spells, rather than a blank that would be dropped silently.
+		{name: "a dead key keeps its name", keysym: xkbKeysymDeadAcute, want: "dead_acute"},
+		{name: "no symbol is no name", keysym: xkbKeysymNoSymbol, want: ""},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := xkbKeysymName(testCase.keysym); got != testCase.want {
+				t.Errorf("xkbKeysymName(%#x) = %q, want %q", testCase.keysym, got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/adapter/eventtap/linux/x11_cgo.go
+++ b/internal/adapter/eventtap/linux/x11_cgo.go
@@ -278,8 +278,10 @@ func x11KeysymName(keysym C.KeySym) string {
 		return evdevKeyNameReturn
 	case C.XK_space:
 		return "Space"
-	case C.XK_Tab:
-		return "Tab"
+	// XKB calls the Tab key ISO_Left_Tab once Shift has chosen the level. It
+	// is the same key, and a binding written Shift+Tab has to reach it.
+	case C.XK_Tab, C.XK_ISO_Left_Tab:
+		return evdevKeyNameTab
 	case C.XK_Escape:
 		return evdevKeyNameEscape
 	case C.XK_BackSpace:
@@ -299,9 +301,12 @@ func x11KeysymName(keysym C.KeySym) string {
 		return evdevKeyNameHome
 	case C.XK_End, C.XK_KP_End:
 		return evdevKeyNameEnd
-	case C.XK_Page_Up, C.XK_KP_Page_Up:
+	// Prior and Next are the page keys: the same keysyms as XK_Page_Up and
+	// XK_Page_Down, under the name xkbcommon lists first, which is how the
+	// Wayland fold table spells them.
+	case C.XK_Prior, C.XK_KP_Prior:
 		return evdevKeyNamePageUp
-	case C.XK_Page_Down, C.XK_KP_Page_Down:
+	case C.XK_Next, C.XK_KP_Next:
 		return evdevKeyNamePageDown
 	case C.XK_Insert, C.XK_KP_Insert:
 		return evdevKeyNameInsert

--- a/internal/adapter/eventtap/linux/x11_chord_test.go
+++ b/internal/adapter/eventtap/linux/x11_chord_test.go
@@ -14,14 +14,15 @@ import "testing"
 
 // X11 keysyms from X11/keysym.h, all frozen protocol numbers.
 const (
-	x11KeysymSpace     = 0x020  // XK_space
-	x11KeysymSemicolon = 0x03b  // XK_semicolon
-	x11KeysymColon     = 0x03a  // XK_colon
-	x11KeysymUpperG    = 0x047  // XK_G
-	x11KeysymLowerC    = 0x063  // XK_c
-	x11KeysymLowerG    = 0x067  // XK_g
-	x11KeysymReturnKey = 0xFF0D // XK_Return
-	x11KeysymCyrillicA = 0x6C1  // XK_Cyrillic_a — outside Latin-1
+	x11KeysymSpace      = 0x020  // XK_space
+	x11KeysymSemicolon  = 0x03b  // XK_semicolon
+	x11KeysymColon      = 0x03a  // XK_colon
+	x11KeysymUpperG     = 0x047  // XK_G
+	x11KeysymLowerC     = 0x063  // XK_c
+	x11KeysymLowerG     = 0x067  // XK_g
+	x11KeysymReturnKey  = 0xFF0D // XK_Return
+	x11KeysymCyrillicA  = 0x6C1  // XK_Cyrillic_a — outside Latin-1
+	x11KeysymISOLeftTab = 0xFE20 // XK_ISO_Left_Tab — what Shift+Tab resolves to
 )
 
 func TestX11BaseKeyName(t *testing.T) {
@@ -95,6 +96,14 @@ func TestX11ChordName(t *testing.T) {
 			mods:   linuxModifierState{shift: 1, ctrl: 1, alt: 1, cmd: 1},
 			keysym: x11KeysymLowerG,
 			want:   "Shift+Ctrl+Alt+Cmd+g",
+		},
+		{
+			// The server resolves Shift+Tab to a keysym of its own, and the
+			// chord has to be the one a config file writes.
+			name:   "shifted tab is Shift+Tab",
+			mods:   linuxModifierState{shift: 1},
+			keysym: x11KeysymISOLeftTab,
+			want:   "Shift+Tab",
 		},
 		{
 			// Unnamed and no string to fall back to: nothing to dispatch.

--- a/internal/adapter/eventtap/linux/x11_keys_test.go
+++ b/internal/adapter/eventtap/linux/x11_keys_test.go
@@ -11,8 +11,8 @@ import "testing"
 // the cgo parameter type at the call site.
 const (
 	x11KeysymHome     = 0xFF50 // XK_Home
-	x11KeysymPageUp   = 0xFF55 // XK_Page_Up / XK_Prior
-	x11KeysymPageDown = 0xFF56 // XK_Page_Down / XK_Next
+	x11KeysymPageUp   = 0xFF55 // XK_Prior / XK_Page_Up
+	x11KeysymPageDown = 0xFF56 // XK_Next / XK_Page_Down
 	x11KeysymEnd      = 0xFF57 // XK_End
 	x11KeysymInsert   = 0xFF63 // XK_Insert
 )
@@ -24,8 +24,8 @@ const (
 	x11KeysymKPUp       = 0xFF97 // XK_KP_Up
 	x11KeysymKPRight    = 0xFF98 // XK_KP_Right
 	x11KeysymKPDown     = 0xFF99 // XK_KP_Down
-	x11KeysymKPPageUp   = 0xFF9A // XK_KP_Page_Up / XK_KP_Prior
-	x11KeysymKPPageDown = 0xFF9B // XK_KP_Page_Down / XK_KP_Next
+	x11KeysymKPPageUp   = 0xFF9A // XK_KP_Prior / XK_KP_Page_Up
+	x11KeysymKPPageDown = 0xFF9B // XK_KP_Next / XK_KP_Page_Down
 	x11KeysymKPEnd      = 0xFF9C // XK_KP_End
 	x11KeysymKPBegin    = 0xFF9D // XK_KP_Begin
 	x11KeysymKPInsert   = 0xFF9E // XK_KP_Insert

--- a/internal/adapter/platform/linux/wayland_keymap.c
+++ b/internal/adapter/platform/linux/wayland_keymap.c
@@ -183,61 +183,47 @@ void neru_xkb_state_key(neru_xkb_state *state, uint16_t evdev_code, int is_press
 	xkb_state_update_key(state->state, (xkb_keycode_t)evdev_code + 8, is_press ? XKB_KEY_DOWN : XKB_KEY_UP);
 }
 
+// neru_normalize_xkb_name maps the keysym names that stand for a named key onto the
+// spelling Neru binds. Only keysyms with no character of their own reach this
+// table: everything printable was already named by its character in
+// neru_xkb_keysym_name, which is what keeps this list short.
+//
+// The keypad reports keysyms of its own while NumLock is off, and they mean the
+// same keys as their main-keyboard equivalents, so they fold onto the same
+// names. With NumLock on it reports KP_0 through KP_9 and the operators, which
+// carry a character and never get here. ISO_Left_Tab is what XKB calls the Tab
+// key once Shift has chosen the level: the same key, and a binding written
+// Shift+Tab has to reach it.
+//
+// The rows are keyed by the name xkb_keysym_get_name answers, which is the
+// first name xkbcommon-keysyms.h lists for a keysym and not always the
+// familiar one: the page keys are Prior and Next there, never Page_Up and
+// Page_Down. A row keyed by the alias is dead, which is how PageUp went
+// unmatched on this backend.
 static void neru_normalize_xkb_name(char *buf, size_t buf_size) {
 	static const struct {
 		const char *xkb;
 		const char *canon;
 	} table[] = {
-	    {"semicolon", ";"},
-	    {"colon", ":"},
-	    {"comma", ","},
-	    {"period", "."},
-	    {"slash", "/"},
-	    {"backslash", "\\"},
-	    {"apostrophe", "'"},
-	    {"grave", "`"},
-	    {"minus", "-"},
-	    {"equal", "="},
-	    {"bracketleft", "["},
-	    {"bracketright", "]"},
-	    {"less", "<"},
-	    {"greater", ">"},
-	    {"underscore", "_"},
-	    {"plus", "+"},
-	    {"asciitilde", "~"},
-	    {"exclam", "!"},
-	    {"at", "@"},
-	    {"numbersign", "#"},
-	    {"dollar", "$"},
-	    {"percent", "%"},
-	    {"asciicircum", "^"},
-	    {"ampersand", "&"},
-	    {"asterisk", "*"},
-	    {"parenleft", "("},
-	    {"parenright", ")"},
-	    {"question", "?"},
-	    {"quotedbl", "\""},
-	    {"bar", "|"},
-	    {"Page_Up", "PageUp"},
-	    {"Page_Down", "PageDown"},
-	    {"KP_Add", "+"},
-	    {"KP_Subtract", "-"},
-	    {"KP_Multiply", "*"},
-	    {"KP_Divide", "/"},
+	    // clang-format off: one row per line is what the pin in
+	    // internal/architecture/wayland_keypad_folds_test.go reads.
+	    {"ISO_Left_Tab", "Tab"},
+	    {"Prior", "PageUp"},
+	    {"Next", "PageDown"},
 	    {"KP_Enter", "Return"},
 	    {"KP_Delete", "Delete"},
 	    {"KP_Insert", "Insert"},
 	    {"KP_Home", "Home"},
 	    {"KP_End", "End"},
-	    {"KP_Page_Up", "PageUp"},
-	    {"KP_Page_Down", "PageDown"},
+	    {"KP_Prior", "PageUp"},
+	    {"KP_Next", "PageDown"},
 	    {"KP_Up", "Up"},
 	    {"KP_Down", "Down"},
 	    {"KP_Left", "Left"},
 	    {"KP_Right", "Right"},
 	    {"KP_Begin", "5"},
-	    {"KP_Decimal", "."},
 	    {"Caps_Lock", "CapsLock"},
+	    // clang-format on
 	};
 
 	for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); i++) {
@@ -249,21 +235,34 @@ static void neru_normalize_xkb_name(char *buf, size_t buf_size) {
 			return;
 		}
 	}
-	/* KP_0 through KP_9 */
-	size_t blen = strlen(buf);
-	if (blen == 4 && buf[0] == 'K' && buf[1] == 'P' && buf[2] == '_' && buf[3] >= '0' && buf[3] <= '9') {
-		buf[0] = buf[3];
-		buf[1] = '\0';
-	}
 }
 
-int neru_xkb_state_key_get_name(neru_xkb_state *state, uint16_t evdev_code, char *buf, size_t buf_size) {
-	if (!state || !state->state || !buf || buf_size == 0)
+// neru_xkb_keysym_name names a state-resolved keysym the way the X11 tap names
+// one: by the character it types when it types one, and by name otherwise.
+//
+// Character first is what makes the two Linux backends agree. Shift has already
+// chosen the level by the time a keysym exists, and the keysym name for the
+// shifted level is not the character: Shift+[ is "braceleft", and on a layout
+// that is not us the names run to "sterling" and "adiaeresis". A name table
+// written by hand can never be complete, and every key it misses is a binding
+// that matches on X11 and not here. Asking libxkbcommon for the character
+// covers every printable keysym at once, and only the keys with no character
+// (Tab, Return, the navigation keys, the keypad with NumLock off) go by name.
+//
+// Space is deliberately left to the name path: it is a named key ("Space"),
+// and a bare " " would be trimmed to nothing downstream. Control characters
+// (Tab, Return, BackSpace, Delete) have no printable form and take the same
+// path.
+int neru_xkb_keysym_name(uint32_t keysym, char *buf, size_t buf_size) {
+	if (!buf || buf_size == 0)
 		return -1;
 
-	xkb_keysym_t keysym = xkb_state_key_get_one_sym(state->state, (xkb_keycode_t)evdev_code + 8);
 	if (keysym == XKB_KEY_NoSymbol)
 		return -1;
+
+	int written = xkb_keysym_to_utf8(keysym, buf, buf_size);
+	if (written > 1 && (unsigned char)buf[0] > 0x20 && (unsigned char)buf[0] != 0x7f)
+		return 0;
 
 	xkb_keysym_get_name(keysym, buf, buf_size);
 	if (buf[0] == '\0')
@@ -274,6 +273,15 @@ int neru_xkb_state_key_get_name(neru_xkb_state *state, uint16_t evdev_code, char
 		return -1;
 
 	return 0;
+}
+
+int neru_xkb_state_key_get_name(neru_xkb_state *state, uint16_t evdev_code, char *buf, size_t buf_size) {
+	if (!state || !state->state || !buf || buf_size == 0)
+		return -1;
+
+	xkb_keysym_t keysym = xkb_state_key_get_one_sym(state->state, (xkb_keycode_t)evdev_code + 8);
+
+	return neru_xkb_keysym_name(keysym, buf, buf_size);
 }
 
 void neru_xkb_state_sync_leds(neru_xkb_state *state, int num_lock_on, int caps_lock_on) {

--- a/internal/adapter/platform/linux/wayland_keymap.h
+++ b/internal/adapter/platform/linux/wayland_keymap.h
@@ -22,6 +22,12 @@ void neru_xkb_state_key(neru_xkb_state *state, uint16_t evdev_code, int is_press
 // Returns 0 on success, -1 on failure.
 int neru_xkb_state_key_get_name(neru_xkb_state *state, uint16_t evdev_code, char *buf, size_t buf_size);
 
+// Name a state-resolved keysym: its character when it types one, else the
+// keysym name folded onto the spelling Neru binds. This is the rule
+// neru_xkb_state_key_get_name applies, exposed so it can be pinned without a
+// keymap. Returns 0 on success, -1 when the keysym has no name.
+int neru_xkb_keysym_name(uint32_t keysym, char *buf, size_t buf_size);
+
 void neru_xkb_state_sync_leds(neru_xkb_state *state, int num_lock_on, int caps_lock_on);
 
 #endif

--- a/internal/architecture/wayland_keypad_folds_test.go
+++ b/internal/architecture/wayland_keypad_folds_test.go
@@ -27,11 +27,16 @@ const (
 	// keypadFoldFunc is the C function that decides what a keysym is called.
 	keypadFoldFunc = "neru_normalize_xkb_name"
 
-	// keypadFoldTable is the literal inside it that spells the decision, and
-	// keypadFoldDigitRule is the name this pin gives the KP_0-KP_9 rule written
-	// below the table.
-	keypadFoldTable     = "table[]"
-	keypadFoldDigitRule = "the KP_0-KP_9 rule"
+	// keypadFoldTable is the literal inside it that spells the decision.
+	keypadFoldTable = "table[]"
+
+	// keypadCharacterFunc is the C function that names a keysym by the
+	// character it types before the fold table is consulted, and
+	// keypadCharacterRule is the name this pin gives that step. It is what
+	// makes KP_0 through KP_9, the keysyms the keypad reports with NumLock on,
+	// reach a binding as the bare digit the X11 tap answers for the same keys.
+	keypadCharacterFunc = "neru_xkb_keysym_name"
+	keypadCharacterRule = "the character-first rule"
 
 	// keypadEvdevTable is the fallback table the evdev tap and the global
 	// hotkey reader name a raw key code through, and keypadEvdevCases is the
@@ -92,6 +97,9 @@ type keypadFold struct {
 	// which is the key into the C table.
 	keysym string
 
+	// foldAbsent is why the C table carries no row for this keysym.
+	foldAbsent string
+
 	// evdevAbsent is why the evdev fallback names no key for this keysym.
 	evdevAbsent string
 
@@ -99,8 +107,16 @@ type keypadFold struct {
 	x11Absent string
 }
 
-// The two reasons a keypad keysym reaches no Go copy.
+// The reasons a keypad keysym reaches no table row, or no Go copy.
 const (
+	// characterNamesTheKeysym covers the keypad operators and KP_Decimal on
+	// the Wayland side: they type a character, so neru_xkb_keysym_name names
+	// them by it and the fold table is never consulted. A row for one of them
+	// would be dead, and this pin fails on it rather than holding the Go copies
+	// to a name the resolver never produces.
+	characterNamesTheKeysym = "the character-first rule names this keysym by the character " +
+		"it types, so it never reaches the fold table"
+
 	// xlookupAnswersWithACharacter covers the keysyms Xlib's XLookupString
 	// resolves to a character — the keypad operators and KP_Decimal, which the
 	// keypad reports only with NumLock on. Those reach x11KeyFromLookup through
@@ -135,17 +151,19 @@ const (
 // written down here — they are read out of the C source, which is the whole
 // point.
 //
-// KP_Decimal is excused from both copies, so what this pin buys for that one
-// row is presence and not agreement: no Go table spells the name the Wayland
-// keymap gives it, which makes it the one keypad row that is not a decision
-// made twice. Renaming it in the C source alone would pass, and saying so is
-// better than implying a check that is not there.
+// The keypad operators and KP_Decimal are excused from the table itself: they
+// type a character, and the character-first rule names them before the table
+// is read, on both Linux backends. What this pin buys for those five is that
+// the table does not grow a dead row for them; the name they reach a binding
+// as is libxkbcommon's answer, which no source in the tree spells and so
+// nothing here can hold a copy to. KP_Decimal is excused from the evdev copy
+// besides, and saying so is better than implying a check that is not there.
 func keypadFolds() []keypadFold {
 	return []keypadFold{
 		{keysym: "KP_Home"},
 		{keysym: "KP_End"},
-		{keysym: "KP_Page_Up"},
-		{keysym: "KP_Page_Down"},
+		{keysym: "KP_Prior"},
+		{keysym: "KP_Next"},
 		{keysym: "KP_Up"},
 		{keysym: "KP_Down"},
 		{keysym: "KP_Left"},
@@ -153,13 +171,30 @@ func keypadFolds() []keypadFold {
 		{keysym: "KP_Insert"},
 		{keysym: "KP_Delete"},
 		{keysym: "KP_Begin"},
-		{keysym: "KP_Add", x11Absent: xlookupAnswersWithACharacter},
-		{keysym: "KP_Subtract", x11Absent: xlookupAnswersWithACharacter},
-		{keysym: "KP_Multiply", x11Absent: xlookupAnswersWithACharacter},
-		{keysym: "KP_Divide", x11Absent: xlookupAnswersWithACharacter},
+		{
+			keysym:     "KP_Add",
+			foldAbsent: characterNamesTheKeysym,
+			x11Absent:  xlookupAnswersWithACharacter,
+		},
+		{
+			keysym:     "KP_Subtract",
+			foldAbsent: characterNamesTheKeysym,
+			x11Absent:  xlookupAnswersWithACharacter,
+		},
+		{
+			keysym:     "KP_Multiply",
+			foldAbsent: characterNamesTheKeysym,
+			x11Absent:  xlookupAnswersWithACharacter,
+		},
+		{
+			keysym:     "KP_Divide",
+			foldAbsent: characterNamesTheKeysym,
+			x11Absent:  xlookupAnswersWithACharacter,
+		},
 		{keysym: "KP_Enter", x11Absent: xlookupAnswersKeypadEnterLikeReturn},
 		{
 			keysym:      "KP_Decimal",
+			foldAbsent:  characterNamesTheKeysym,
 			evdevAbsent: numLockOnKeysym,
 			x11Absent:   xlookupAnswersWithACharacter,
 		},
@@ -175,11 +210,11 @@ func keypadFolds() []keypadFold {
 // longer carries fails too.
 //
 // The whole table is parsed and only its keypad rows are pinned, which is a
-// boundary rather than an oversight. The rest of it renames punctuation
-// keysyms, Page_Up and Page_Down, and Caps_Lock, and each would need a join
-// this one does not have: evdevKeyNames answers those by key code, and only for
-// the keypad does the tree say which keysym a code reports — that is what
-// keypadKeyNameCases is. Page_Up and Page_Down could be held to the X11 cascade
+// boundary rather than an oversight. The rest of it renames ISO_Left_Tab,
+// Prior and Next, and Caps_Lock, and each would need a join this one does not
+// have: evdevKeyNames answers those by key code, and only for the keypad does
+// the tree say which keysym a code reports — that is what keypadKeyNameCases
+// is. Prior and Next could be held to the X11 cascade
 // alone, since that side is keyed by keysym, and pinning one copy of two under
 // a heading that says "the keypad" is how a pin comes to claim more than it
 // holds. A row outside the keypad this pin cannot read is still reported,
@@ -318,9 +353,14 @@ func keypadDrifts(tree keypadCopies) []keypadDrift {
 			apply: keypadDriftIn(func(copies *keypadCopies) { copies.folds["KP_Separator"] = "," }),
 		},
 		{
-			name:  "the KP_0-KP_9 rule gone",
+			name:  "a dead row for a character-named keypad key",
 			where: keypadFoldSource,
-			apply: keypadDriftIn(func(copies *keypadCopies) { copies.foldsDigits = false }),
+			apply: keypadDriftIn(func(copies *keypadCopies) { copies.folds["KP_Add"] = "+" }),
+		},
+		{
+			name:  "the character-first rule gone",
+			where: keypadFoldSource,
+			apply: keypadDriftIn(func(copies *keypadCopies) { copies.namesByCharacter = false }),
 		},
 	}
 
@@ -495,6 +535,13 @@ func keypadUnreadableSources(t *testing.T, tree keypadSources) []keypadUnreadabl
 			sources: keypadDoctored(t, tree, keypadFoldSource, "} table[] = {", "} folds[] = {"),
 		},
 		{
+			name: "the character-first resolver renamed",
+			sources: keypadDoctored(t, tree, keypadFoldSource,
+				"int "+keypadCharacterFunc+"(uint32_t keysym, char *buf, size_t buf_size) {",
+				"int neru_xkb_keysym_spell(uint32_t keysym, char *buf, size_t buf_size) {",
+			),
+		},
+		{
 			name: "a fold row whose name is built at runtime",
 			sources: keypadDoctored(
 				t,
@@ -623,9 +670,9 @@ type keypadCopies struct {
 	// rewrites it to. It carries the whole table, keypad rows and all.
 	folds map[string]string
 
-	// foldsDigits records whether the rule below the table still turns KP_0
-	// through KP_9 into the bare digit.
-	foldsDigits bool
+	// namesByCharacter records whether the resolver still names a keysym by
+	// the character it types before it reads the table.
+	namesByCharacter bool
 
 	// evdevEntries is the keypad half of evdevKeyNames, in the order the table
 	// writes it.
@@ -666,12 +713,12 @@ type keypadEvdevCase struct {
 // clone copies every table, so a drift applied to one is not seen by the next.
 func (copies keypadCopies) clone() keypadCopies {
 	return keypadCopies{
-		folds:        maps.Clone(copies.folds),
-		foldsDigits:  copies.foldsDigits,
-		evdevEntries: slices.Clone(copies.evdevEntries),
-		evdevCases:   maps.Clone(copies.evdevCases),
-		x11Names:     maps.Clone(copies.x11Names),
-		x11Cases:     maps.Clone(copies.x11Cases),
+		folds:            maps.Clone(copies.folds),
+		namesByCharacter: copies.namesByCharacter,
+		evdevEntries:     slices.Clone(copies.evdevEntries),
+		evdevCases:       maps.Clone(copies.evdevCases),
+		x11Names:         maps.Clone(copies.x11Names),
+		x11Cases:         maps.Clone(copies.x11Cases),
 	}
 }
 
@@ -694,7 +741,7 @@ func keypadX11Problems(copies keypadCopies) []string {
 
 	for _, fold := range keypadFolds() {
 		canonical, folded := copies.folds[fold.keysym]
-		if !folded {
+		if !folded && fold.foldAbsent == "" {
 			continue
 		}
 
@@ -944,7 +991,16 @@ func keypadFoldTableProblems(copies keypadCopies) []string {
 	declared := keypadDeclaredKeysyms()
 
 	for _, fold := range keypadFolds() {
-		if _, folded := copies.folds[fold.keysym]; !folded {
+		_, folded := copies.folds[fold.keysym]
+
+		switch {
+		case fold.foldAbsent != "" && folded:
+			problems = append(problems, fmt.Sprintf(
+				"%s: %s has a row for %q, which keypadFolds() excuses it from (%s); "+
+					"that row never runs, so drop it or the excuse",
+				keypadFoldSource, keypadFoldTable, fold.keysym, fold.foldAbsent,
+			))
+		case fold.foldAbsent == "" && !folded:
 			problems = append(problems, fmt.Sprintf(
 				"%s: %s has no row for %q, which keypadFolds() declares; "+
 					"a keypad key the table stopped folding is one the Go copies still name",
@@ -963,13 +1019,13 @@ func keypadFoldTableProblems(copies keypadCopies) []string {
 		}
 	}
 
-	if !copies.foldsDigits {
+	if !copies.namesByCharacter {
 		problems = append(problems, fmt.Sprintf(
-			"%s: %s no longer turns KP_0 through KP_9 into the bare digit, "+
-				"or is written in a shape this pin does not read; those are the keysyms "+
-				"the keypad reports with NumLock on, and the bare digit is what the X11 "+
-				"tap answers for the same keys",
-			keypadFoldSource, keypadFoldDigitRule,
+			"%s: %s no longer names a keysym by the character it types ahead of "+
+				"the table, or is written in a shape this pin does not read; KP_0 "+
+				"through KP_9 are the keysyms the keypad reports with NumLock on, and "+
+				"the bare digit is what the X11 tap answers for the same keys",
+			keypadFoldSource, keypadCharacterRule,
 		))
 	}
 
@@ -992,20 +1048,24 @@ var (
 	)
 )
 
-// keypadDigitRuleFragments are the parts of the KP_0-KP_9 rule this pin reads,
-// in the order the C source writes them. Together they say: a name of exactly
-// four characters, beginning "KP_" and ending in a digit, becomes that digit
-// alone. The length guard is one of them — without it "KP_01" would be
-// truncated to "0", which is a different rule.
-var keypadDigitRuleFragments = []string{
-	`blen == 4`,
-	`buf[0] == 'K'`,
-	`buf[1] == 'P'`,
-	`buf[2] == '_'`,
-	`buf[3] >= '0'`,
-	`buf[3] <= '9'`,
-	`buf[0] = buf[3];`,
-	`buf[1] = '\0';`,
+// keypadCharacterFuncPattern finds the resolver the character-first rule lives
+// in, by the one signature this pin reads.
+var keypadCharacterFuncPattern = regexp.MustCompile(
+	`(?m)^int ` + keypadCharacterFunc + `\(uint32_t keysym, char \*buf, size_t buf_size\)[ \t]*\{`,
+)
+
+// keypadCharacterRuleFragments are the parts of the character-first rule this
+// pin reads, in the order the C source writes them. Together they say: ask
+// libxkbcommon for the character, keep it when it is printable and not a
+// space, and only then fall through to the name and the fold table. The two
+// guards are part of the rule — without them Tab would be named "\t" and Space
+// " ", neither of which a binding spells.
+var keypadCharacterRuleFragments = []string{
+	`xkb_keysym_to_utf8(keysym, buf, buf_size)`,
+	`> 0x20`,
+	`!= 0x7f`,
+	`xkb_keysym_get_name(keysym, buf, buf_size)`,
+	keypadFoldFunc + `(buf, buf_size)`,
 }
 
 // readKeypadCopies reads every copy out of the tree, failing the test when it
@@ -1064,12 +1124,22 @@ func parseKeypadCopies(sources keypadSources) (keypadCopies, string) {
 		return keypadCopies{}, keypadFoldSource + ": " + problem
 	}
 
-	folds, tail, problem := parseKeypadFoldTable(body)
+	folds, problem := parseKeypadFoldTable(body)
 	if problem != "" {
 		return keypadCopies{}, keypadFoldSource + ": " + problem
 	}
 
-	copies := keypadCopies{folds: folds, foldsDigits: keypadFoldsDigits(tail)}
+	resolver, problem := nativeRuleMethodBody(
+		sources[keypadFoldSource],
+		keypadCharacterFuncPattern,
+		keypadCharacterFunc,
+		"int "+keypadCharacterFunc+"(uint32_t keysym, char *buf, size_t buf_size) {",
+	)
+	if problem != "" {
+		return keypadCopies{}, keypadFoldSource + ": " + problem
+	}
+
+	copies := keypadCopies{folds: folds, namesByCharacter: keypadNamesByCharacter(resolver)}
 
 	evdev, problem := parseKeypadGoFile(keypadEvdevSource, sources[keypadEvdevSource])
 	if problem != "" {
@@ -1830,15 +1900,14 @@ func keypadGoNumberValue(value ast.Expr) (uint16, bool) {
 	return uint16(number), err == nil
 }
 
-// parseKeypadFoldTable reads the `{"KP_Home", "Home"},` rows of the fold table,
-// and returns what follows it in the function so the digit rule can be read
-// too. Every line inside the literal has to be a row, a comment or blank: a
-// line this pin cannot read is one it would otherwise skip past, which is how a
-// pin comes to cover less than it claims.
-func parseKeypadFoldTable(body string) (map[string]string, string, string) {
+// parseKeypadFoldTable reads the `{"KP_Home", "Home"},` rows of the fold table.
+// Every line inside the literal has to be a row, a comment or blank: a line this
+// pin cannot read is one it would otherwise skip past, which is how a pin comes
+// to cover less than it claims.
+func parseKeypadFoldTable(body string) (map[string]string, string) {
 	opening := keypadFoldTableOpeningPattern.FindStringIndex(body)
 	if opening == nil {
-		return nil, "", fmt.Sprintf(
+		return nil, fmt.Sprintf(
 			"no `} %s = {` literal to read the fold table from (renamed?)",
 			keypadFoldTable,
 		)
@@ -1848,7 +1917,7 @@ func parseKeypadFoldTable(body string) (map[string]string, string, string) {
 
 	closing := keypadFoldTableClosingPattern.FindStringIndex(rest)
 	if closing == nil {
-		return nil, "", fmt.Sprintf("the %s literal is never closed by `};`", keypadFoldTable)
+		return nil, fmt.Sprintf("the %s literal is never closed by `};`", keypadFoldTable)
 	}
 
 	folds := make(map[string]string)
@@ -1861,7 +1930,7 @@ func parseKeypadFoldTable(body string) (map[string]string, string, string) {
 
 		row := keypadFoldRowPattern.FindStringSubmatch(trimmed)
 		if row == nil {
-			return nil, "", fmt.Sprintf(
+			return nil, fmt.Sprintf(
 				"%s holds `%s`, which this pin does not read; it reads "+
 					"`{\"<keysym>\", \"<name>\"},` rows",
 				keypadFoldTable, trimmed,
@@ -1870,7 +1939,7 @@ func parseKeypadFoldTable(body string) (map[string]string, string, string) {
 
 		keysym, name, unquoted := unquoteKeypadFoldRow(row[1], row[2])
 		if !unquoted {
-			return nil, "", fmt.Sprintf(
+			return nil, fmt.Sprintf(
 				"%s holds `%s`, whose strings this pin cannot read",
 				keypadFoldTable, trimmed,
 			)
@@ -1880,7 +1949,7 @@ func parseKeypadFoldTable(body string) (map[string]string, string, string) {
 		// for the same keysym is dead code — and reading it would have this pin
 		// hold the Go copies to a name the keypad never produces.
 		if existing, folded := folds[keysym]; folded {
-			return nil, "", fmt.Sprintf(
+			return nil, fmt.Sprintf(
 				"%s folds %q twice, to %q and then to %q; "+
 					"the second row never runs",
 				keypadFoldTable, keysym, existing, name,
@@ -1891,10 +1960,10 @@ func parseKeypadFoldTable(body string) (map[string]string, string, string) {
 	}
 
 	if len(folds) == 0 {
-		return nil, "", "the " + keypadFoldTable + " literal is empty"
+		return nil, "the " + keypadFoldTable + " literal is empty"
 	}
 
-	return folds, rest[closing[1]:], ""
+	return folds, ""
 }
 
 // unquoteKeypadFoldRow reads the two C string literals of one row. C and Go
@@ -1914,17 +1983,21 @@ func unquoteKeypadFoldRow(keysymLiteral, nameLiteral string) (string, string, bo
 	return keysym, name, true
 }
 
-// keypadFoldsDigits reports whether the rule below the table still spells "a
-// KP_<digit> name becomes that digit". It is read as fragments rather than as a
-// whole line, because the rule is a C condition and a body rather than a table
-// row; what matters is that every part of it is there.
-func keypadFoldsDigits(tail string) bool {
-	collapsed := strings.Join(strings.Fields(tail), " ")
+// keypadNamesByCharacter reports whether the resolver still spells "a keysym
+// with a printable character is that character, and only otherwise its folded
+// name". It is read as fragments in order rather than as whole lines, because
+// the rule is a C condition and two calls rather than a table row; what matters
+// is that every part of it is there, and that the character comes first.
+func keypadNamesByCharacter(resolver string) bool {
+	rest := strings.Join(strings.Fields(resolver), " ")
 
-	for _, fragment := range keypadDigitRuleFragments {
-		if !strings.Contains(collapsed, fragment) {
+	for _, fragment := range keypadCharacterRuleFragments {
+		at := strings.Index(rest, fragment)
+		if at < 0 {
 			return false
 		}
+
+		rest = rest[at+len(fragment):]
 	}
 
 	return true


### PR DESCRIPTION
## Description

This PR fixes hint and hotkey bindings on Linux that could never fire because the key arrived under a name no config file spells. The default `Shift+Tab` hint binding was dead on every Linux backend: the shifted Tab is a keysym of its own, and both Linux readers named it "ISO_Left_Tab" on Wayland and dropped it outright on X11. The same gap hit `Shift+[` and `Shift+]` on Wayland, every symbol on a non-us layout that the hand-written name table did not list, and, it turned out, PageUp and PageDown on Wayland, because libxkbcommon spells those keysyms Prior and Next and the table was keyed by the alias.

The Wayland and evdev resolver now names a keysym by the character it types and falls back to a folded keysym name only for keys that type none, which is the rule the X11 tap already applied. Both backends now call the shifted Tab "Tab", and the fold table is keyed by the names libxkbcommon actually answers. A binding written once now matches the same physical key on Wayland and X11, on any layout.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port surface changes
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, Linux-only change developed on macOS; ran the two Linux packages' tests in the `just test-linux` Docker image, `just lint-cross`, the architecture guardrails, and a local build
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

The keypad guardrail in `internal/architecture` used to pin a KP_0-KP_9 digit fold below the table. That fold is gone, since digits now come from the character path, so the guardrail pins the character-first rule instead and declares the keypad operators as character-named, failing on a dead row for any of them. The keysym spellings were verified against libxkbcommon 1.7.0 in the Docker image: it names 0xff55 "Prior", 0xff9a "KP_Prior" and 0xfe20 "ISO_Left_Tab". Those are the first names the header lists for each keysym and do not vary by version.

Users who hit this today can work around it by binding `Shift+ISO_Left_Tab` on Wayland, but there is no workaround on X11.
