### PR TITLE
fix(linux): stop a modifier sticking after a Wayland mode launched from a compositor binding

### DIFF
--- a/cmd/neru/daemon_host_linux.go
+++ b/cmd/neru/daemon_host_linux.go
@@ -5,9 +5,12 @@ package main
 import (
 	"go.uber.org/zap"
 
+	eventtaplinux "github.com/y3owk1n/neru/internal/adapter/eventtap/linux"
+	"github.com/y3owk1n/neru/internal/adapter/platform"
 	"github.com/y3owk1n/neru/internal/adapter/platform/linux"
 	"github.com/y3owk1n/neru/internal/adapter/systray"
 	"github.com/y3owk1n/neru/internal/app"
+	"github.com/y3owk1n/neru/internal/derrors"
 )
 
 type linuxDaemonHost struct{}
@@ -21,6 +24,23 @@ func (linuxDaemonHost) Run(application *app.App) error {
 	// Cleanup is idempotent (sync.Once), so the duplicate call from OnExit is
 	// harmless. Mirrors the darwin/windows daemon hosts.
 	defer application.Cleanup()
+
+	// Hold the keyboards now, while nothing is pressed, rather than under the
+	// binding that launches the first mode (WarmEvdevProxy). Without cgo,
+	// /dev/input or /dev/uinput access the first mode says what it fell back to.
+	if platform.DetectLinuxBackend().IsWayland() {
+		logger := application.Logger()
+
+		go func() {
+			err := eventtaplinux.WarmEvdevProxy(logger)
+			if err != nil && !derrors.IsNotSupported(err) {
+				logger.Info(
+					"Wayland keyboard proxy unavailable at launch; modes will use the overlay's keyboard focus",
+					zap.Error(err),
+				)
+			}
+		}()
+	}
 
 	// On KDE/KWin, input is injected via libei through the RemoteDesktop
 	// portal, which shows a one-time consent prompt. Warm it up at startup (in

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -403,8 +403,12 @@ proxy, the one reader of `/dev/input/event*` that the in-mode capture also runs
 on ([global_hotkey_cgo.go](../internal/adapter/eventtap/linux/global_hotkey_cgo.go),
 [evdev_proxy_cgo.go](../internal/adapter/eventtap/linux/evdev_proxy_cgo.go),
 [ADR 0014](adr/0014-the-wayland-keyboard-is-a-proxy.md)). With `/dev/uinput`
-writable the proxy holds every keyboard and re-emits it through a uinput device
-of its own, so a matched chord is withheld from the focused app. Without it the
+writable the proxy holds every keyboard from daemon launch, whether or not
+`[hotkeys]` is set, and re-emits it through a uinput device of its own, so a
+matched chord is withheld from the focused app. It never keeps a keyboard that
+has a key down: a daemon or a remapper started from a compositor binding is
+held once the binding's modifier comes up, so no modifier is left stuck in the
+compositor's picture of the device. Without it the
 proxy reads passively, the chord matches all the same, and the app receives it
 too. The process needs read access to `/dev/input` (the `input` group) and a
 CGO build; a `CGO_ENABLED=0` build gets a stub whose `Start` reports

--- a/docs/adr/0014-the-wayland-keyboard-is-a-proxy.md
+++ b/docs/adr/0014-the-wayland-keyboard-is-a-proxy.md
@@ -40,6 +40,21 @@ either direction. Everything the old design carried to repair that picture —
 the pre-grab waits, `initialKeys`, the synthetic releases injected at shutdown,
 the passive listener's reconciliation — is deleted rather than rewritten.
 
+The invariant covers presses the proxy saw, so the proxy has to be there before
+the first one. It is built when the daemon starts, not by the first mode, and a
+device is never held with a key down: a keyboard found with a key down under a
+fresh grab (a daemon, or a remapper, launched from a compositor binding with the
+binding's modifier still held) is let go again at once and grabbed once it is
+idle, polled ten milliseconds apart. That wait is paid once per device, never
+per activation. It replaces the first version's seeds, which pushed a key found
+held as an already-forwarded press so its release would be re-emitted, and that
+was the second rejected option below in another guise: libinput drops a release
+for a key it never saw pressed on the proxy, the modifier stays down on the
+physical device, and on Hyprland, which merges modifier state across every
+keyboard, every key typed afterwards carried Super. It surfaced first for a
+kanata user on Hyprland with no `[hotkeys]`, where nothing built the proxy
+until a mode did, under the binding that launched it.
+
 It buys three more things the tap could not have. A matched hotkey chord is
 withheld, so the focused application never sees the activation chord, which is
 what every other platform's hotkey mechanism already does. Modifier passthrough

--- a/internal/adapter/eventtap/linux/evdev_capture_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_capture_cgo.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"go.uber.org/zap"
@@ -49,6 +50,14 @@ type waylandEvdevCapture struct {
 	// path; guarded by deviceMu like files.
 	devices map[*os.File]trackedDevice
 
+	// pending is the keyboards the constructor found with a key down, whose
+	// grab waits for them to go idle; startReaders launches those waits.
+	pending []string
+
+	// pendingGrabs counts the waits in flight, so a session asked for while a
+	// keyboard is still on its way in can be refused by name; deviceMu.
+	pendingGrabs int
+
 	// pointer is the pointer proxy, or nil until a grabbed keyboard needs one:
 	// the uinput mouse the relative motion and the buttons of a keyboard that
 	// carries them are re-emitted on. Created under deviceMu by whichever
@@ -78,8 +87,8 @@ type trackedDevice struct {
 }
 
 // newWaylandEvdevCapture opens every keyboard under /dev/input. With grab set,
-// each is taken exclusively on the way in and the keys the kernel reports held
-// on it are pushed as seed events, ahead of anything the device sends.
+// each is taken exclusively on the way in, and only while no key on it is down
+// (deviceBusy): a keyboard with a key held is grabbed once it goes idle.
 //
 // A device another process already holds (a key remapper such as kanata or keyd
 // grabs its input keyboards for its own lifetime) refuses the grab and is
@@ -104,12 +113,12 @@ func newWaylandEvdevCapture(logger *zap.Logger, grab bool) (*waylandEvdevCapture
 	}
 
 	for _, path := range paths {
-		if _, seeds, ok := capture.addDeviceLocked(path); ok {
-			capture.sendSeeds(seeds)
+		if _, outcome := capture.addDeviceLocked(path); outcome == deviceBusy {
+			capture.pending = append(capture.pending, path)
 		}
 	}
 
-	if len(capture.files) == 0 {
+	if len(capture.files) == 0 && len(capture.pending) == 0 {
 		logger.Warn(
 			"No keyboard /dev/input/event* devices could be opened initially; "+
 				"hotplug watcher will monitor for newly connected keyboard devices",
@@ -119,6 +128,7 @@ func newWaylandEvdevCapture(logger *zap.Logger, grab bool) (*waylandEvdevCapture
 		logger.Debug(
 			"Evdev capture created",
 			zap.Int("keyboard_devices", len(capture.files)),
+			zap.Int("keyboards_with_a_key_down", len(capture.pending)),
 			zap.Int("total_event_devices", len(paths)),
 			zap.Bool("grabbed", grab),
 		)
@@ -175,13 +185,27 @@ func (capture *waylandEvdevCapture) Close() {
 	})
 }
 
+// deviceOutcome is what addDeviceLocked made of a path.
+type deviceOutcome int
+
+const (
+	// deviceSkipped is a node that is not a keyboard this capture reads, or
+	// one it already has, or one another grabber owns.
+	deviceSkipped deviceOutcome = iota
+	// deviceAdopted is a keyboard now tracked, grabbed when the capture grabs.
+	deviceAdopted
+	// deviceBusy is a keyboard with a key down, which the capture will not
+	// hold: libinput keeps that key down until a release arrives on the same
+	// device, and a release re-emitted on the proxy is discarded as a release
+	// for a key never pressed there (ADR 0014). The device is grabbed once it
+	// is idle instead (waitIdle).
+	deviceBusy
+)
+
 // addDeviceLocked opens path and keeps it when it is a keyboard this capture
-// should read, answering the file and the keys the kernel reported held on it
-// at grab time. The caller holds deviceMu, or is the constructor before anyone
-// else can, and sends the seeds itself once it no longer holds the lock — the
-// proxy's run loop takes deviceMu too, so a send made under it could wait on
-// the one goroutine that would drain it.
-func (capture *waylandEvdevCapture) addDeviceLocked(path string) (*os.File, []uint16, bool) {
+// should read and no key on it is down. The caller holds deviceMu, or is the
+// constructor before anyone else can.
+func (capture *waylandEvdevCapture) addDeviceLocked(path string) (*os.File, deviceOutcome) {
 	// Read-write so the compositor's LED changes can be written back to the
 	// device; a node that only grants reading is still a keyboard to read.
 	file, openErr := os.OpenFile(path, os.O_RDWR, 0)
@@ -190,7 +214,7 @@ func (capture *waylandEvdevCapture) addDeviceLocked(path string) (*os.File, []ui
 	}
 
 	if openErr != nil {
-		return nil, nil, false
+		return nil, deviceSkipped
 	}
 
 	descriptor := C.int(file.Fd())
@@ -210,18 +234,16 @@ func (capture *waylandEvdevCapture) addDeviceLocked(path string) (*os.File, []ui
 		isNeruInjectionDevice(name) {
 		_ = file.Close()
 
-		return nil, nil, false
+		return nil, deviceSkipped
 	}
 
 	for _, tracked := range capture.files {
 		if tracked.Name() == path {
 			_ = file.Close()
 
-			return nil, nil, false
+			return nil, deviceSkipped
 		}
 	}
-
-	var seeds []uint16
 
 	if capture.grab {
 		if C.neru_evdev_grab(descriptor, 1) != 0 {
@@ -236,7 +258,7 @@ func (capture *waylandEvdevCapture) addDeviceLocked(path string) (*os.File, []ui
 
 			_ = file.Close()
 
-			return nil, nil, false
+			return nil, deviceSkipped
 		}
 
 		// A keyboard with relative motion on it is kept only once that motion
@@ -247,16 +269,25 @@ func (capture *waylandEvdevCapture) addDeviceLocked(path string) (*os.File, []ui
 			C.neru_evdev_grab(descriptor, 0)
 			_ = file.Close()
 
-			return nil, nil, false
+			return nil, deviceSkipped
 		}
 
-		seeds = heldKeys(descriptor)
+		// Asked under the grab, so no press can land between the answer and
+		// the grab; a key found down means the grab is let go again at once,
+		// and its release reaches the compositor as the press did.
+		held, heldErr := keysHeld(descriptor)
+		if held || heldErr != nil {
+			C.neru_evdev_grab(descriptor, 0)
+			_ = file.Close()
+
+			return nil, deviceBusy
+		}
 	}
 
 	capture.files = append(capture.files, file)
 	capture.devices[file] = trackedDevice{name: name}
 
-	return file, seeds, true
+	return file, deviceAdopted
 }
 
 // ensurePointerProxyLocked creates the pointer proxy if there is none yet and
@@ -294,49 +325,113 @@ func (capture *waylandEvdevCapture) ensurePointerProxyLocked(path string) bool {
 	return true
 }
 
-// heldKeys is every key the kernel reports down on fd, read right after the
-// grab so the compositor's picture of them can be honored (forwardRule.seed).
-func heldKeys(fd C.int) []uint16 {
+// keysHeld reports whether the kernel has any key down on fd. The error is a
+// device that cannot answer, which is one that is gone.
+func keysHeld(fd C.int) (bool, error) {
 	var bits [evdevKeyCodeCount / evdevBitsPerWord]C.ulong
-	if C.neru_evdev_get_key_state(fd, &bits[0], C.size_t(unsafe.Sizeof(bits))) != 0 {
-		return nil
+
+	result, err := C.neru_evdev_get_key_state(fd, &bits[0], C.size_t(unsafe.Sizeof(bits)))
+	if result != 0 {
+		return false, err
 	}
 
-	var codes []uint16
-
-	for code := range uint16(evdevKeyCodeCount) {
-		if bits[code/evdevBitsPerWord]&(1<<(code%evdevBitsPerWord)) != 0 {
-			codes = append(codes, code)
+	for _, word := range bits {
+		if word != 0 {
+			return true, nil
 		}
 	}
 
-	return codes
+	return false, nil
 }
 
-// sendSeeds pushes one seed event per held key. It has to run before the
-// device's reader starts, so the seeds reach the proxy ahead of the device's
-// first event.
-func (capture *waylandEvdevCapture) sendSeeds(codes []uint16) {
-	for _, code := range codes {
-		select {
-		case capture.events <- waylandEvdevEvent{eventType: evdevEventSeed, code: code}:
-		case <-capture.stopCh:
-			return
-		}
-	}
-}
-
-// startReaders launches reader goroutines for each captured keyboard device
-// and starts the inotify hotplug watcher for detecting device hotplug.
-// These goroutines run for the entire lifetime of the capture.
+// startReaders launches reader goroutines for each captured keyboard device,
+// the idle waits for the keyboards found with a key down, and the inotify
+// hotplug watcher. These goroutines run for the entire lifetime of the capture.
 func (capture *waylandEvdevCapture) startReaders() {
 	capture.deviceMu.Lock()
 	for _, file := range capture.files {
 		capture.startReader(file)
 	}
+
+	for _, path := range capture.pending {
+		capture.grabWhenIdleLocked(path, "")
+	}
+
+	capture.pending = nil
 	capture.deviceMu.Unlock()
 
 	capture.startHotplugWatcher()
+}
+
+// grabWhenIdleLocked starts the wait that grabs a busy keyboard once no key
+// on it is down. The caller holds deviceMu.
+func (capture *waylandEvdevCapture) grabWhenIdleLocked(path string, borrowedFor string) {
+	capture.pendingGrabs++
+
+	if capture.logger != nil {
+		capture.logger.Info(
+			"Keyboard has a key down; holding it once the key is released",
+			zap.String("device", path),
+		)
+	}
+
+	go capture.waitIdle(path, borrowedFor)
+}
+
+// waitIdle adopts path once the kernel reports no key down on it. It polls the
+// key state rather than reading the device, so it takes nothing from the
+// device's owner; the poll quantum is paid once per device, when a daemon or a
+// remapper is launched from a binding, and never per activation.
+func (capture *waylandEvdevCapture) waitIdle(path string, borrowedFor string) {
+	defer func() {
+		capture.deviceMu.Lock()
+		capture.pendingGrabs--
+		capture.deviceMu.Unlock()
+	}()
+
+	file, err := os.Open(path)
+	if err != nil {
+		return
+	}
+
+	defer func() { _ = file.Close() }()
+
+	descriptor := C.int(file.Fd())
+
+	ticker := time.NewTicker(waylandEvdevIdlePollInterval)
+	defer ticker.Stop()
+
+	for {
+		held, err := keysHeld(descriptor)
+		if err != nil {
+			return
+		}
+
+		if !held {
+			break
+		}
+
+		select {
+		case <-capture.stopCh:
+			return
+		case <-ticker.C:
+		}
+	}
+
+	capture.adopt(path, borrowedFor)
+}
+
+// pendingCount is how many keyboards are waiting to go idle before they are
+// grabbed.
+func (capture *waylandEvdevCapture) pendingCount() int {
+	if capture == nil {
+		return 0
+	}
+
+	capture.deviceMu.Lock()
+	defer capture.deviceMu.Unlock()
+
+	return capture.pendingGrabs
 }
 
 func (capture *waylandEvdevCapture) startReader(file *os.File) {

--- a/internal/adapter/eventtap/linux/evdev_capture_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_capture_cgo.go
@@ -384,18 +384,29 @@ func (capture *waylandEvdevCapture) grabWhenIdleLocked(path string, borrowedFor 
 	go capture.waitIdle(path, borrowedFor)
 }
 
-// waitIdle adopts path once the kernel reports no key down on it. It polls the
-// key state rather than reading the device, so it takes nothing from the
-// device's owner; the poll quantum is paid once per device, when a daemon or a
-// remapper is launched from a binding, and never per activation.
+// waitIdle adopts path once the kernel reports no key down on it. The wait is
+// forgotten before adopt runs, not deferred past it: a key pressed again in the
+// gap makes adopt register a replacement wait on the same path, which a
+// cleanup running afterwards would erase.
 func (capture *waylandEvdevCapture) waitIdle(path string, borrowedFor string) {
-	// Before adopt rather than deferred past it: a key pressed again in the
-	// gap makes adopt start a new wait, which the old one must not shadow.
-	defer capture.waitDone(path)
+	idle := capture.pollUntilIdle(path)
 
+	capture.waitDone(path)
+
+	if idle {
+		capture.adopt(path, borrowedFor)
+	}
+}
+
+// pollUntilIdle reports whether path reached a state with no key down. It
+// polls the key state rather than reading the device, so it takes nothing from
+// the device's owner; the poll quantum is paid once per device, when a daemon
+// or a remapper is launched from a binding, and never per activation. False
+// is a device that is gone, or a capture that is closing.
+func (capture *waylandEvdevCapture) pollUntilIdle(path string) bool {
 	file, err := os.Open(path)
 	if err != nil {
-		return
+		return false
 	}
 
 	defer func() { _ = file.Close() }()
@@ -408,26 +419,22 @@ func (capture *waylandEvdevCapture) waitIdle(path string, borrowedFor string) {
 	for {
 		held, err := keysHeld(descriptor)
 		if err != nil {
-			return
+			return false
 		}
 
 		if !held {
-			break
+			return true
 		}
 
 		select {
 		case <-capture.stopCh:
-			return
+			return false
 		case <-ticker.C:
 		}
 	}
-
-	capture.waitDone(path)
-	capture.adopt(path, borrowedFor)
 }
 
-// waitDone forgets the wait on path. Idempotent, so the deferred call after a
-// successful wait finds nothing to forget.
+// waitDone forgets the wait on path.
 func (capture *waylandEvdevCapture) waitDone(path string) {
 	capture.deviceMu.Lock()
 	delete(capture.pendingPaths, path)

--- a/internal/adapter/eventtap/linux/evdev_capture_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_capture_cgo.go
@@ -54,9 +54,10 @@ type waylandEvdevCapture struct {
 	// grab waits for them to go idle; startReaders launches those waits.
 	pending []string
 
-	// pendingGrabs counts the waits in flight, so a session asked for while a
-	// keyboard is still on its way in can be refused by name; deviceMu.
-	pendingGrabs int
+	// pendingPaths is the keyboards whose wait is in flight, so overlapping
+	// scans start one wait per keyboard and a session asked for while one is
+	// still on its way in can be refused by name; deviceMu.
+	pendingPaths map[string]struct{}
 
 	// pointer is the pointer proxy, or nil until a grabbed keyboard needs one:
 	// the uinput mouse the relative motion and the buttons of a keyboard that
@@ -103,13 +104,14 @@ func newWaylandEvdevCapture(logger *zap.Logger, grab bool) (*waylandEvdevCapture
 	}
 
 	capture := &waylandEvdevCapture{
-		files:     make([]*os.File, 0, len(paths)),
-		devices:   make(map[*os.File]trackedDevice),
-		events:    make(chan waylandEvdevEvent, waylandEvdevEventBufferSize),
-		logger:    logger,
-		grab:      grab,
-		stopCh:    make(chan struct{}),
-		inotifyFd: -1,
+		files:        make([]*os.File, 0, len(paths)),
+		devices:      make(map[*os.File]trackedDevice),
+		pendingPaths: make(map[string]struct{}),
+		events:       make(chan waylandEvdevEvent, waylandEvdevEventBufferSize),
+		logger:       logger,
+		grab:         grab,
+		stopCh:       make(chan struct{}),
+		inotifyFd:    -1,
 	}
 
 	for _, path := range paths {
@@ -364,9 +366,13 @@ func (capture *waylandEvdevCapture) startReaders() {
 }
 
 // grabWhenIdleLocked starts the wait that grabs a busy keyboard once no key
-// on it is down. The caller holds deviceMu.
+// on it is down, unless one is already waiting on it. The caller holds deviceMu.
 func (capture *waylandEvdevCapture) grabWhenIdleLocked(path string, borrowedFor string) {
-	capture.pendingGrabs++
+	if _, waiting := capture.pendingPaths[path]; waiting {
+		return
+	}
+
+	capture.pendingPaths[path] = struct{}{}
 
 	if capture.logger != nil {
 		capture.logger.Info(
@@ -383,11 +389,9 @@ func (capture *waylandEvdevCapture) grabWhenIdleLocked(path string, borrowedFor 
 // device's owner; the poll quantum is paid once per device, when a daemon or a
 // remapper is launched from a binding, and never per activation.
 func (capture *waylandEvdevCapture) waitIdle(path string, borrowedFor string) {
-	defer func() {
-		capture.deviceMu.Lock()
-		capture.pendingGrabs--
-		capture.deviceMu.Unlock()
-	}()
+	// Before adopt rather than deferred past it: a key pressed again in the
+	// gap makes adopt start a new wait, which the old one must not shadow.
+	defer capture.waitDone(path)
 
 	file, err := os.Open(path)
 	if err != nil {
@@ -418,7 +422,16 @@ func (capture *waylandEvdevCapture) waitIdle(path string, borrowedFor string) {
 		}
 	}
 
+	capture.waitDone(path)
 	capture.adopt(path, borrowedFor)
+}
+
+// waitDone forgets the wait on path. Idempotent, so the deferred call after a
+// successful wait finds nothing to forget.
+func (capture *waylandEvdevCapture) waitDone(path string) {
+	capture.deviceMu.Lock()
+	delete(capture.pendingPaths, path)
+	capture.deviceMu.Unlock()
 }
 
 // pendingCount is how many keyboards are waiting to go idle before they are
@@ -431,7 +444,7 @@ func (capture *waylandEvdevCapture) pendingCount() int {
 	capture.deviceMu.Lock()
 	defer capture.deviceMu.Unlock()
 
-	return capture.pendingGrabs
+	return len(capture.pendingPaths)
 }
 
 func (capture *waylandEvdevCapture) startReader(file *os.File) {

--- a/internal/adapter/eventtap/linux/evdev_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_cgo.go
@@ -23,6 +23,11 @@ const (
 	// rare and a stale name costs one mistyped binding, so this is slow; the
 	// same check runs at every mode start, where it is free.
 	waylandEvdevKeymapPollInterval = 2 * time.Second
+
+	// waylandEvdevIdlePollInterval is how often a keyboard found with a key
+	// down is asked whether the key has come up, so it can be grabbed. Paid
+	// once per device (waitIdle), never per activation.
+	waylandEvdevIdlePollInterval = 10 * time.Millisecond
 )
 
 // waylandEvdevKeyboardActive reports whether a mode session currently owns the
@@ -48,6 +53,10 @@ var (
 	errWaylandEvdevPassive      = errors.New(
 		"wayland evdev proxy is passive: /dev/uinput is not writable, so keys cannot be captured",
 	)
+	errWaylandEvdevGrabPending = errors.New(
+		"wayland evdev proxy holds no keyboard yet: every keyboard has a key down, " +
+			"and each is held once its key is released",
+	)
 )
 
 const waylandEvdevDeviceNameSize = 256
@@ -71,12 +80,6 @@ const (
 	evdevEventLed uint16 = 0x11
 
 	evdevSynReport uint16 = 0
-
-	// evdevEventSeed is not a kernel event type. A device layer pushes one per
-	// key the kernel reported down when it grabbed a device, ahead of that
-	// device's first real event, so the forward rule learns which releases it
-	// owes the compositor (forwardRule.seed).
-	evdevEventSeed uint16 = 0xffff
 )
 
 type waylandEvdevEvent struct {

--- a/internal/adapter/eventtap/linux/evdev_forward.go
+++ b/internal/adapter/eventtap/linux/evdev_forward.go
@@ -35,9 +35,9 @@ type forwardRule struct {
 	down [evdevKeyCodeCount]uint8
 }
 
-// seed counts code as down and forwarded without an event: the kernel reported
-// it held when its device was grabbed, so the compositor saw the press and is
-// owed the release.
+// seed counts code as down and forwarded without an event: the proxy re-emitted
+// the press itself (forwardWithheld), so the compositor saw it and is owed the
+// release.
 func (r *forwardRule) seed(code uint16) {
 	r.add(code)
 }

--- a/internal/adapter/eventtap/linux/evdev_hotplug_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_hotplug_cgo.go
@@ -189,9 +189,11 @@ func (capture *waylandEvdevCapture) rescan(vanished string) {
 
 // adopt takes path into the capture if it is a keyboard this capture should
 // read and is not tracked already, starts a reader for it, and answers the
-// device's name. borrowedFor names the vanished device a rescan is adopting on
-// behalf of, or is empty. Nothing is adopted once the capture is closing: a
-// reader started then would outlive the wait Close makes on the readers.
+// device's name. A keyboard with a key down is adopted once it is idle instead.
+// borrowedFor names the vanished device a rescan is adopting on behalf of, or
+// is empty. Nothing is adopted once the capture is closing: a reader started
+// then would outlive the wait Close makes on the readers, which is why the
+// reader is counted under the same lock the closing check takes.
 func (capture *waylandEvdevCapture) adopt(path string, borrowedFor string) (string, bool) {
 	capture.deviceMu.Lock()
 
@@ -203,8 +205,12 @@ func (capture *waylandEvdevCapture) adopt(path string, borrowedFor string) (stri
 	default:
 	}
 
-	file, seeds, ok := capture.addDeviceLocked(path)
-	if !ok {
+	file, outcome := capture.addDeviceLocked(path)
+	if outcome != deviceAdopted {
+		if outcome == deviceBusy {
+			capture.grabWhenIdleLocked(path, borrowedFor)
+		}
+
 		capture.deviceMu.Unlock()
 
 		return "", false
@@ -213,10 +219,8 @@ func (capture *waylandEvdevCapture) adopt(path string, borrowedFor string) (stri
 	device := capture.devices[file]
 	device.borrowedFor = borrowedFor
 	capture.devices[file] = device
-	capture.deviceMu.Unlock()
-
-	capture.sendSeeds(seeds)
 	capture.startReader(file)
+	capture.deviceMu.Unlock()
 
 	if capture.logger != nil {
 		capture.logger.Info(

--- a/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
@@ -107,6 +107,18 @@ func acquireEvdevProxy(logger *zap.Logger) (*evdevProxy, error) {
 	return proxy, nil
 }
 
+// WarmEvdevProxy builds the proxy at daemon start, so the keyboards are held
+// before any key that could be down at a mode's activation. Built lazily by the
+// first mode instead, the proxy met a user who launches modes from compositor
+// bindings with the binding's modifier still down at grab time: the device then
+// waits for that key to come up (waitIdle), and a session asked for inside the
+// wait is refused. The hotkey listener and the tap borrow the proxy afterwards.
+func WarmEvdevProxy(logger *zap.Logger) error {
+	_, err := acquireEvdevProxy(logger)
+
+	return err
+}
+
 func newEvdevProxy(logger *zap.Logger) (*evdevProxy, error) {
 	var uinputFd C.int = -1
 
@@ -193,6 +205,10 @@ func (p *evdevProxy) startSession(session *evdevSession) error {
 	}
 
 	if p.deviceCount() == 0 {
+		if p.capture.pendingCount() > 0 {
+			return errWaylandEvdevGrabPending
+		}
+
 		return errWaylandEvdevUnavailable
 	}
 
@@ -273,13 +289,6 @@ func (p *evdevProxy) refreshKeymap() {
 // echo of them would send each one round again.
 func (p *evdevProxy) handle(event waylandEvdevEvent) {
 	switch event.eventType {
-	case evdevEventSeed:
-		if isPointerButton(event.code) {
-			return
-		}
-
-		p.rule.seed(event.code)
-		p.trackGlobal(event.code, true)
 	case evdevEventKey:
 		if isPointerButton(event.code) {
 			if isMouseButton(event.code) {

--- a/internal/adapter/eventtap/linux/evdev_proxy_nocgo.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_nocgo.go
@@ -1,0 +1,18 @@
+//go:build linux && !cgo
+
+package linux
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+)
+
+// WarmEvdevProxy reports CodeNotSupported without cgo, which evdev needs: there
+// is no proxy to build, and the first mode says what it fell back to.
+func WarmEvdevProxy(_ *zap.Logger) error {
+	return derrors.New(
+		derrors.CodeNotSupported,
+		"Wayland keyboard capture requires CGO-enabled Linux builds",
+	)
+}

--- a/internal/adapter/eventtap/linux/evdev_proxy_test.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_test.go
@@ -120,7 +120,7 @@ func TestForwardRule_AReleaseGoesWhereItsPressWent(t *testing.T) {
 		{name: "idle: forwarded throughout", wantPress: true, wantRepeat: true, wantRelease: true},
 		{name: "capturing: withheld throughout", withholdPress: true},
 		{
-			name:   "a seeded key: the compositor saw the press, so it gets the release",
+			name:   "re-emitted by the proxy: the compositor saw the press, so it gets the release",
 			seeded: true, withholdPress: true, wantRepeat: true, wantRelease: true,
 		},
 	}
@@ -247,35 +247,6 @@ func TestEvdevProxy_MatchesTheChordEveryTime(t *testing.T) {
 				attempt,
 			)
 		}
-	}
-}
-
-// A key the kernel reported down when its device was grabbed had its press
-// seen by the compositor, so its release is owed there — and it is not a
-// chord's base key just because a modifier comes down after it.
-func TestEvdevProxy_SeededKeyReleasesToTheCompositor(t *testing.T) {
-	t.Parallel()
-
-	proxy := newTestProxy()
-	fired := bindTestChord(proxy)
-
-	proxy.handle(waylandEvdevEvent{eventType: evdevEventSeed, code: evdevKeySemicolon})
-	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValuePress))
-
-	if proxy.rule.repeat(evdevKeySemicolon) != true {
-		t.Error("a seeded key's repeat was withheld")
-	}
-
-	proxy.handle(keyEvent(evdevKeySemicolon, evdevValueRelease))
-
-	if proxy.rule.isDown(evdevKeySemicolon) {
-		t.Error("the seeded key is still down after its release")
-	}
-
-	select {
-	case <-fired:
-		t.Fatal("a seeded key's release matched the chord")
-	case <-time.After(50 * time.Millisecond):
 	}
 }
 
@@ -443,7 +414,6 @@ func TestEvdevProxy_PointerEventsAreNotKeys(t *testing.T) {
 	tap, keys := collectKeys(t)
 	beginSession(proxy, tap)
 
-	proxy.handle(waylandEvdevEvent{eventType: evdevEventSeed, code: btnLeft})
 	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValuePress))
 	proxy.handle(keyEvent(btnLeft, evdevValuePress))
 	proxy.handle(waylandEvdevEvent{eventType: evdevEventRel, code: 0, value: 3})

--- a/internal/adapter/eventtap/linux/global_hotkey_stub_contract_nocgo_test.go
+++ b/internal/adapter/eventtap/linux/global_hotkey_stub_contract_nocgo_test.go
@@ -76,3 +76,15 @@ func TestGlobalHotkeyListener_IsRunningStaysFalseAfterStart(t *testing.T) {
 		t.Errorf("DeviceCount() = %d without cgo, want 0", got)
 	}
 }
+
+// TestWarmEvdevProxy_ReportsNotSupportedWithoutCgo pins the launch-time
+// warm-up's stub. Its caller, the Linux daemon host, reads a nil as "the proxy
+// is up" and says nothing, so a stub answering nil would hide that no keyboard
+// is held until the first mode fell back.
+func TestWarmEvdevProxy_ReportsNotSupportedWithoutCgo(t *testing.T) {
+	err := WarmEvdevProxy(nil)
+	if !derrors.IsNotSupported(err) {
+		t.Errorf("WarmEvdevProxy returned %v (code %q), want CodeNotSupported",
+			err, derrors.GetCode(err))
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes keys acting as if a modifier were held after a Wayland mode was launched from a compositor binding.

The keyboard proxy used to be built by the first mode when no `[hotkeys]` were configured. A mode launched from a compositor binding arrives with the binding's modifier still down, so the proxy took its grab under that key. The compositor never saw the release on the device it saw the press on, and on Hyprland, which merges modifier state across every keyboard, every later key carried Super. With a key remapper such as kanata in front of the keyboard this was the only device the proxy could grab, so it hit every mode.

Now the daemon builds the proxy at launch on Wayland whether or not `[hotkeys]` is set, and it never keeps a grab on a keyboard that has a key down: it lets go and holds the keyboard once the key comes up, polled every 10 ms. That wait happens once per device, never per activation, so mode activation stays instant. A mode requested while every keyboard is still waiting to go idle falls back to the overlay's keyboard focus and the log says why.

## Related Issues

None. Reported on Hyprland with kanata, modes bound in the compositor.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — the no-cgo Linux build gets one; the launch-time warm-up is inside the Linux daemon host, so macOS and Windows need none
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, not run in full: the change is Linux-tagged Go and docs, so the gate run was `just fmt-check`, `just check-cross`, `just lint-cross` (0 issues), and `go vet`, `go build ./cmd/neru` and the `eventtap/linux` and `hotkeys/linux` tests inside the Linux CI container with CGO on
- [x] Tests added/updated for new or changed functionality — the two seed tests are removed with the seed path and the no-cgo contract test pins the new stub; the idle wait needs a real evdev device with a key down, which no container provides, so it is covered by the manual steps below
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users — this PR squash-merges, so the title is what Release Please ships in the changelog, not the commits on the branch

## Additional Context

The removed seed mechanism pushed a key found held at grab time as an already-forwarded press so its release would be re-emitted on the proxy. ADR 0014 had rejected exactly that ("grab immediately and forward the pre-held releases synthetically") because libinput keeps per-device key state and discards a release for a key it never saw pressed on that device. The ADR now records the idle-only grab and the launch-time build.

Behaviour change for compositor-binding users with `/dev/input` access: the daemon holds the keyboards from launch rather than from the first mode, which is what the lifetime proxy design intended.

How to test on a Wayland session with `/dev/input` and `/dev/uinput` access:

1. Launch the daemon from a terminal with nothing held. The log shows `Evdev keyboard proxy running` right after startup.
2. Launch it from a compositor binding while holding the modifier for a second. The log shows `Keyboard has a key down; holding it once the key is released`, then `New keyboard device detected and captured` on release.
3. Trigger a mode from a compositor binding, press Escape, then type in a terminal and use a compositor chord such as Super+Enter. Keys are normal and the chord fires.
4. With kanata or keyd: restart the remapper from a binding while the daemon runs, then repeat step 3.
