### PR TITLE
fix(windows): carry the action's modifiers on injected clicks and drags

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -163,9 +163,9 @@ answer.
 | **Keymap learns the focused app** | ✅ published by the watcher | ✅ published by the watcher | ✅ published by the watcher | ✅ published by the watcher | ✅ published by the watcher |
 | **Cursor position**           | ✅ `CGEventGetLocation`  | ✅ `XQueryPointer`     | ✅ `hyprctl` on Hyprland, else sync-surface cache | ✅ sync-surface cache | ✅ `GetCursorPos` |
 | **Cursor move**               | ✅ `CGEventPost` ([`postMouseMoveLocked`](../internal/adapter/platform/darwin/accessibility_mouse_darwin.m)) | ✅ XTest (`XTestFakeMotionEvent`) | ✅ `zwlr_virtual_pointer` | ✅ libei                | ✅ `SetCursorPos`            |
-| **Mouse buttons / drag**      | ✅ `CGEventPost`         | ✅ XTest ⁷             | ✅ `zwlr_virtual_pointer`    | ✅ libei                | ✅ `SendInput`               |
-| **Scroll injection**          | ✅ both axes             | ✅ both axes ⁷         | ✅ both axes (uinput, virtual-pointer fallback) | ✅ both axes (uinput, libei fallback) | ✅ both axes                 |
-| **Modified scroll (`--modifier`)** | ✅ `CGEventSetFlags` on every chunk | ✅ XTest key hold ⁷ | ✅ virtual keyboard + virtual pointer (uinput on Hyprland ⁹) | ✅ libei | ✅ `SendInput` key hold |
+| **Mouse buttons / drag**      | ✅ `CGEventPost`         | ✅ XTest ⁷             | ✅ `zwlr_virtual_pointer`    | ✅ libei                | ✅ `SendInput` ⁷             |
+| **Scroll injection**          | ✅ both axes             | ✅ both axes ⁷         | ✅ both axes (uinput, virtual-pointer fallback) | ✅ both axes (uinput, libei fallback) | ✅ both axes ⁷               |
+| **Modified scroll (`--modifier`)** | ✅ `CGEventSetFlags` on every chunk | ✅ XTest key hold ⁷ | ✅ virtual keyboard + virtual pointer (uinput on Hyprland ⁹) | ✅ libei | ✅ `SendInput` key hold ⁷ |
 | **Smooth cursor animation**   | ✅ (incl. relative, opt-in) | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in |
 | **Smooth scroll animation**   | ✅                       | ⚠️ whole notches only ³ | ✅ continuous axis ³ (whole notches when modified on Hyprland ⁹) | ⚠️ libei scroll delta, unverified ³ | ✅ 120ths of a notch ³ |
 | **Element discovery (hints)** | ✅ AXUIElement           | ⚠️ AT-SPI walk         | ⚠️ AT-SPI walk               | ⚠️ AT-SPI walk          | ⚠️ UIA, control view only    |
@@ -307,13 +307,16 @@ installs; without one `VisionPort.Health` and `DetectElements` report
 smallest whole factor that fits and the word boxes scaled back. Every word
 scores one.
 
-⁷ **X11 modifiers on injected input.** An X11 pointer event carries the
-modifiers the server records as **held**, so an injected click or scroll used to
-pick up whatever the user's hand was on: `Ctrl+J` bound to a plain
-`scroll_down` sent ctrl+scroll, which most applications read as zoom. Neru
-reads the live key state with `XQueryKeymap`, releases the modifiers the
-injection would otherwise falsify, presses the ones asked for, and undoes both
-when done, held across every chunk of an animated scroll. A modifier both held
+⁷ **Modifiers on injected input (X11 and Windows).** An X11 pointer event
+carries the modifiers the server records as **held**, and a `SendInput` mouse
+event carries whatever the keyboard holds, so an injected click or scroll used
+to pick up whatever the user's hand was on: `Ctrl+J` bound to a plain
+`scroll_down` sent ctrl+scroll, which most applications read as zoom, and a
+hotkey chord still held while a hint was chosen made the click a ctrl+click.
+Neru reads the live key state (`XQueryKeymap`, `GetAsyncKeyState`), releases
+the modifiers the injection would otherwise falsify, presses the ones asked
+for, and undoes both when done, held across every chunk of an animated
+scroll. A modifier both held
 and asked for is left alone. A drag holds that state for as long as the button
 is down: press and release are separate calls, and the release undoes what the
 press set up. Letting go of a modifier inside that window is not observed, and

--- a/internal/adapter/accessibility/native/windows/element.go
+++ b/internal/adapter/accessibility/native/windows/element.go
@@ -256,27 +256,27 @@ func MoveMouseToPoint(point image.Point, _ bool) {
 func LeftClickAtPoint(
 	point image.Point,
 	_ bool,
-	_ action.Modifiers,
+	modifiers action.Modifiers,
 ) error {
-	return winplatform.LeftClickAt(point)
+	return winplatform.ClickAt(point, action.ButtonLeft, modifiers)
 }
 
 // RightClickAtPoint clicks the mouse.
 func RightClickAtPoint(
 	point image.Point,
 	_ bool,
-	_ action.Modifiers,
+	modifiers action.Modifiers,
 ) error {
-	return winplatform.RightClickAt(point)
+	return winplatform.ClickAt(point, action.ButtonRight, modifiers)
 }
 
 // MiddleClickAtPoint clicks the mouse.
 func MiddleClickAtPoint(
 	point image.Point,
 	_ bool,
-	_ action.Modifiers,
+	modifiers action.Modifiers,
 ) error {
-	return winplatform.MiddleClickAt(point)
+	return winplatform.ClickAt(point, action.ButtonMiddle, modifiers)
 }
 
 // MouseDownAtPoint presses and holds the given mouse button at the point.
@@ -285,7 +285,7 @@ func MouseDownAtPoint(
 	button action.MouseButton,
 	modifiers action.Modifiers,
 ) error {
-	err := winplatform.MouseDown(point, button)
+	err := winplatform.MouseDown(point, button, modifiers)
 	if err != nil {
 		return err
 	}
@@ -299,9 +299,9 @@ func MouseDownAtPoint(
 func MouseUpAtPoint(
 	point image.Point,
 	button action.MouseButton,
-	_ action.Modifiers,
+	modifiers action.Modifiers,
 ) error {
-	err := winplatform.MouseUp(point, button)
+	err := winplatform.MouseUp(point, button, modifiers)
 	if err != nil {
 		return err
 	}

--- a/internal/adapter/platform/modifierstate/plan_test.go
+++ b/internal/adapter/platform/modifierstate/plan_test.go
@@ -65,6 +65,42 @@ func TestPlanFor_SuppressesAHeldModifierNobodyAskedFor(t *testing.T) {
 	}
 }
 
+// TestPlanFor_PresentsAClicksOwnModifiersOverAHeldHotkeyChord is the click
+// shape of the same bug: a hotkey chord still held while a hint is chosen
+// rides along on the injected click, so a shift+click asked for from a
+// Ctrl+Alt chord has to release both chord keys and press shift, and the
+// mouse-up that ends a drag undoes exactly that.
+func TestPlanFor_PresentsAClicksOwnModifiersOverAHeldHotkeyChord(t *testing.T) {
+	keys := []modifierstate.Key{
+		{Keycode: controlLeft, Modifier: action.ModCtrl, Held: true, Canonical: true},
+		{Keycode: altLeft, Modifier: action.ModAlt, Held: true, Canonical: true},
+		{Keycode: shiftLeft, Modifier: action.ModShift, Canonical: true},
+	}
+
+	plan := modifierstate.PlanFor(keys, action.ModShift)
+
+	if !equalEdits(plan.Suppress, edits(controlLeft, altLeft)) {
+		t.Fatalf(
+			"PlanFor suppressed %v, want the held chord keys %d and %d",
+			plan.Suppress,
+			controlLeft,
+			altLeft,
+		)
+	}
+
+	if !equalEdits(plan.Press, edits(shiftLeft)) {
+		t.Fatalf(
+			"PlanFor pressed %v, want the shift key %d the click asked for",
+			plan.Press,
+			shiftLeft,
+		)
+	}
+
+	if restore := plan.Restore(nil); !equalEdits(restore, edits(controlLeft, altLeft)) {
+		t.Fatalf("Restore = %v, want both chord keys pressed back after the click", restore)
+	}
+}
+
 // TestPlanFor_PressesOnlyWhatNothingIsAlreadyHolding pins the other half: a key
 // is one bit of keyboard state rather than a count, so pressing a modifier the
 // user is already holding means our release afterwards tells every application

--- a/internal/adapter/platform/windows/input.go
+++ b/internal/adapter/platform/windows/input.go
@@ -157,51 +157,6 @@ func MoveMouseTo(point image.Point) error {
 	return moveCursorTo(point)
 }
 
-// LeftClickAt performs a left click at the given point.
-func LeftClickAt(point image.Point) error {
-	err := moveCursorTo(point)
-	if err != nil {
-		return err
-	}
-
-	err = sendMouseInput(mouseeventfLeftDown, 0)
-	if err != nil {
-		return err
-	}
-
-	return sendMouseInput(mouseeventfLeftUp, 0)
-}
-
-// RightClickAt performs a right click at the given point.
-func RightClickAt(point image.Point) error {
-	err := moveCursorTo(point)
-	if err != nil {
-		return err
-	}
-
-	err = sendMouseInput(mouseeventfRightDown, 0)
-	if err != nil {
-		return err
-	}
-
-	return sendMouseInput(mouseeventfRightUp, 0)
-}
-
-// MiddleClickAt performs a middle click at the given point.
-func MiddleClickAt(point image.Point) error {
-	err := moveCursorTo(point)
-	if err != nil {
-		return err
-	}
-
-	err = sendMouseInput(mouseeventfMiddleDown, 0)
-	if err != nil {
-		return err
-	}
-
-	return sendMouseInput(mouseeventfMiddleUp, 0)
-}
-
 // buttonFlags holds the SendInput flags that press and release one mouse button.
 type buttonFlags struct {
 	down uint32
@@ -222,24 +177,72 @@ func flagsForButton(button action.MouseButton) buttonFlags {
 	}
 }
 
-// MouseDown presses the given button at the given point.
-func MouseDown(point image.Point, button action.MouseButton) error {
-	err := moveCursorTo(point)
+// ClickAt presses and releases the given button at the given point, with
+// exactly modifiers presented as held for both events. A SendInput button
+// event carries no modifier field any more than a wheel event does, so the
+// same hold scrollWheelNow takes is what keeps a hotkey chord still held while
+// a hint is chosen from turning the click into a ctrl+click.
+func ClickAt(point image.Point, button action.MouseButton, modifiers action.Modifiers) error {
+	hold, err := holdModifiers(modifiers)
 	if err != nil {
 		return err
 	}
 
-	return sendMouseInput(flagsForButton(button).down, 0)
+	defer hold.release()
+
+	flags := flagsForButton(button)
+
+	err = buttonEventAt(point, flags.down)
+	if err != nil {
+		return err
+	}
+
+	return sendMouseInput(flags.up, 0)
 }
 
-// MouseUp releases the given button at the given point.
-func MouseUp(point image.Point, button action.MouseButton) error {
+// buttonEventAt moves the cursor to point and posts one button event there.
+func buttonEventAt(point image.Point, flags uint32) error {
 	err := moveCursorTo(point)
 	if err != nil {
 		return err
 	}
 
-	return sendMouseInput(flagsForButton(button).up, 0)
+	return sendMouseInput(flags, 0)
+}
+
+// MouseDown presses the given button at the given point and keeps modifiers
+// presented until the matching MouseUp, so the drag in between carries them.
+// A press that fails undoes its own hold: no release is coming to do it.
+func MouseDown(point image.Point, button action.MouseButton, modifiers action.Modifiers) error {
+	hold, err := holdModifiers(modifiers)
+	if err != nil {
+		return err
+	}
+
+	err = buttonEventAt(point, flagsForButton(button).down)
+	if err != nil {
+		hold.release()
+
+		return err
+	}
+
+	hold.keepForRelease(button)
+
+	return nil
+}
+
+// MouseUp releases the given button at the given point, undoing the hold its
+// press kept, or presenting modifiers for the length of the release event
+// when no press of this process is behind it.
+func MouseUp(point image.Point, button action.MouseButton, modifiers action.Modifiers) error {
+	hold, err := resumeModifierHold(button, modifiers)
+	if err != nil {
+		return err
+	}
+
+	defer hold.release()
+
+	return buttonEventAt(point, flagsForButton(button).up)
 }
 
 // wheelEvent is one MOUSEEVENTF_WHEEL or MOUSEEVENTF_HWHEEL record, before

--- a/internal/adapter/platform/windows/modifiers.go
+++ b/internal/adapter/platform/windows/modifiers.go
@@ -218,6 +218,60 @@ func (h modifierHold) release() {
 	}
 }
 
+// windowsDragModifiers is the hold a mouse-down took, kept until the mouse-up
+// that ends the drag comes to undo it. Keys are action.MouseButton values.
+var windowsDragModifiers modifierstate.Stash
+
+// keepForRelease keeps this hold for the release of button to pick up, instead
+// of undoing it when the call that took it returns.
+//
+// A press has to keep presenting its modifiers for as long as the button is
+// down, because the drag in between is what carries them: releasing them at
+// the end of the press would make a shift+drag an unmodified one from the
+// first pixel of movement.
+//
+// What is kept is the plan alone. The lock and the record of physical releases
+// both go here, because a drag is as long as the user makes it and a scroll
+// fired mid-drag needs both for itself. That leaves the release with the same
+// bias X11's drag carries: a suppressed key the user lets go of mid-drag is
+// pressed back at the end and reads as held until they tap it once more,
+// which is safer than dropping a modifier they are still holding.
+func (h modifierHold) keepForRelease(button action.MouseButton) {
+	defer modifierHoldMu.Unlock()
+
+	endReleaseTracking()
+	windowsDragModifiers.Put(uint32(button), h.plan)
+}
+
+// resumeModifierHold picks up the hold the press of button kept, so its
+// release can undo it, and takes a fresh hold of modifiers when there was no
+// such press: a bare mouse-up action, or one whose press this process never
+// made.
+//
+// The keyboard is read once, by the press. What the release replays is the
+// press's plan rather than a fresh reading, so a modifier the user takes hold
+// of or lets go of mid-drag is presented on the release event as it was at the
+// press. Re-reading at the release would decide the drag's modifiers twice,
+// which is the one thing a drag cannot have.
+//
+// Like holdModifiers, the hold returned owns modifierHoldMu until release.
+func resumeModifierHold(
+	button action.MouseButton,
+	modifiers action.Modifiers,
+) (modifierHold, error) {
+	modifierHoldMu.Lock()
+
+	if plan, held := windowsDragModifiers.Take(uint32(button)); held {
+		beginReleaseTracking()
+
+		return modifierHold{plan: plan}, nil
+	}
+
+	modifierHoldMu.Unlock()
+
+	return holdModifiers(modifiers)
+}
+
 var errUnknownModifier = errors.New("unknown modifier")
 
 // PostModifierKey presses or releases the canonical key for one modifier, named

--- a/internal/adapter/platform/windows/modifiers_test.go
+++ b/internal/adapter/platform/windows/modifiers_test.go
@@ -107,3 +107,59 @@ func TestNoteModifierReleased_RecordsOnlyWhileAHoldIsOpen(t *testing.T) {
 		t.Fatalf("the record survived its hold: %v", again)
 	}
 }
+
+// A drag is two calls with the user's movement in between, so the hold the
+// press took has to reach the release intact: the same plan, with the lock and
+// the release record reopened for it, and let go of in between so a scroll
+// fired mid-drag can take them.
+func TestModifierHold_KeepForRelease_HandsThePlanToTheMatchingRelease(t *testing.T) {
+	plan := modifierstate.Plan{
+		Suppress: []modifierstate.Edit{{Keycode: vkLControl, Modifier: action.ModCtrl}},
+		Press:    []modifierstate.Edit{{Keycode: vkLShift, Modifier: action.ModShift}},
+	}
+
+	modifierHoldMu.Lock()
+	beginReleaseTracking()
+
+	modifierHold{plan: plan}.keepForRelease(action.ButtonLeft)
+
+	if !modifierHoldMu.TryLock() {
+		t.Fatal("keepForRelease kept the hold lock across the drag")
+	}
+
+	modifierHoldMu.Unlock()
+
+	noteModifierReleased(vkLControl)
+
+	if released := endReleaseTracking(); released != nil {
+		t.Fatalf("release tracking stayed open across the drag: %v", released)
+	}
+
+	resumed, err := resumeModifierHold(action.ButtonLeft, 0)
+	if err != nil {
+		t.Fatalf("resumeModifierHold: %v", err)
+	}
+
+	if !slices.Equal(keycodes(resumed.plan.Suppress), keycodes(plan.Suppress)) ||
+		!slices.Equal(keycodes(resumed.plan.Press), keycodes(plan.Press)) {
+		t.Fatalf("resumed plan = %+v, want the press's plan %+v", resumed.plan, plan)
+	}
+
+	if modifierHoldMu.TryLock() {
+		modifierHoldMu.Unlock()
+		t.Fatal("resumeModifierHold did not take the hold lock for the release")
+	}
+
+	noteModifierReleased(vkLControl)
+
+	released := endReleaseTracking()
+	modifierHoldMu.Unlock()
+
+	if _, ok := released[vkLControl]; !ok {
+		t.Fatalf("release tracking was not reopened for the release: %v", released)
+	}
+
+	if _, held := windowsDragModifiers.Take(uint32(action.ButtonLeft)); held {
+		t.Fatal("the press's plan survived its release")
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes injected clicks on Windows dropping the modifiers the action asked for. `neru action left_click --modifier shift`, a mode binding such as `"action left_click --modifier ctrl"`, and a sticky modifier merged into a click all produced a plain click, because the click path handed nothing on to the injection, while the scroll path already pressed the real keys around its wheel events.

Clicks, mouse-down and mouse-up now take the same modifier hold a modified scroll does: the keys asked for are pressed, any modifier the user is physically holding that the action did not ask for is released for the injection and pressed back afterwards, and the hold a mouse-down takes stays in place until the matching mouse-up so the drag in between carries it. That second half also closes a gap on its own: a hotkey chord still held while a hint was chosen used to land as a ctrl+click, since Windows was the only platform where a click inherited whatever the hand was on.

One deliberate limitation, the same one X11 drags carry: a suppressed modifier the user lets go of mid-drag is still pressed back when the drag ends and reads as held until they tap it once more. Restoring is the safer bias, since the opposite drops a modifier they are still holding.

## Related Issues

Closes #1605

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new port surface; the change stays inside the Windows adapter
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, small change; ran the targeted set instead: `just fmt`, `just lint`, `just check-cross`, `golangci-lint` under `GOOS=windows` on both Windows packages, and `go test` on `modifierstate` and `internal/architecture`, all green
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

Found by code inspection, not by running on Windows. The hold's lock and its record of physical key releases are let go of between the mouse-down and the mouse-up rather than held across the drag, so a scroll fired mid-drag can take them for itself instead of blocking; only the plan crosses that gap, through the same stash the X11 backend uses. A bare mouse-up with no press behind it presents the modifiers it was given for the length of its own event, as before.
