### PR TITLE
fix(scroll): apply a sticky modifier to scroll actions

### DIFF
--- a/internal/app/ipcctrl/actions_scroll.go
+++ b/internal/app/ipcctrl/actions_scroll.go
@@ -28,9 +28,7 @@ func (h *ActionsHandler) handleScrollAction(
 	}
 
 	// Scroll never reaches performTargetedAction, so it validates the flag
-	// combinations itself. Sticky modifiers are deliberately not merged in
-	// here: they are a click affordance, and a scroll that silently picked one
-	// up would zoom where the user asked to pan.
+	// combinations itself.
 	flagErrResp := validateActionFlags(actionName, parsed)
 	if flagErrResp != nil {
 		return *flagErrResp
@@ -39,6 +37,15 @@ func (h *ActionsHandler) handleScrollAction(
 	modifiers, modErr := action.ParseModifiers(parsed.modifierStr)
 	if modErr != nil {
 		return refuseAction(modErr.Error())
+	}
+
+	// A sticky modifier reaches a scroll the way it reaches a click: the user
+	// tapped it inside the mode and the indicator shows it, so a scroll that
+	// dropped it would pan where they asked to zoom. The chord they are
+	// physically holding is a different matter, and the backend's flag
+	// stamping or key hold keeps that off the event.
+	if h.modesHandler != nil {
+		modifiers |= h.modesHandler.StickyModifiers()
 	}
 
 	direction, amount, ok := scrollActionMapping(actionName)

--- a/internal/app/simulation_harness_test.go
+++ b/internal/app/simulation_harness_test.go
@@ -773,6 +773,7 @@ type simAXPort struct {
 	clicks         []simClick
 	elementActions []action.Type
 	scrolls        []image.Point
+	scrollMods     []action.Modifiers
 	releases       int
 
 	// focusedApp is which application the fixture desktop routes keystrokes
@@ -836,12 +837,13 @@ func (a *simAXPort) PerformActionAtPoint(
 func (a *simAXPort) Scroll(
 	_ context.Context,
 	deltaX, deltaY int,
-	_ action.Modifiers,
+	modifiers action.Modifiers,
 ) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
 	a.scrolls = append(a.scrolls, image.Point{X: deltaX, Y: deltaY})
+	a.scrollMods = append(a.scrollMods, modifiers)
 
 	return nil
 }
@@ -925,6 +927,18 @@ func (a *simAXPort) recordedScrolls() []image.Point {
 
 	out := make([]image.Point, len(a.scrolls))
 	copy(out, a.scrolls)
+
+	return out
+}
+
+// recordedScrollModifiers is the modifier set each recorded scroll carried,
+// in the same order as recordedScrolls.
+func (a *simAXPort) recordedScrollModifiers() []action.Modifiers {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	out := make([]action.Modifiers, len(a.scrollMods))
+	copy(out, a.scrollMods)
 
 	return out
 }

--- a/internal/app/simulation_journey_test.go
+++ b/internal/app/simulation_journey_test.go
@@ -1264,6 +1264,34 @@ func TestSimulation_StickyModifierClick(t *testing.T) {
 	}
 }
 
+// TestSimulation_StickyModifierScroll pins that a sticky modifier reaches a
+// scroll the way it reaches a click: tapping ctrl in scroll mode and then
+// scrolling is the user asking for a ctrl+scroll, which most applications read
+// as zoom, and the plain scroll that used to go out instead read as a broken
+// binding.
+func TestSimulation_StickyModifierScroll(t *testing.T) {
+	sim := newSimHarness(t, simConfig(), nil)
+
+	sim.pressHotkey(scrollHotkey)
+	sim.waitMode(domain.ModeScroll)
+
+	sim.press("__modifier_ctrl_down", "__modifier_ctrl_up")
+
+	sim.waitFor("sticky indicator drawn", func() bool {
+		return sim.overlay.stickyIndicatorDrawCount() > 0
+	})
+
+	// Sticky posts ctrl physically, so the scroll key arrives as a ctrl chord
+	// that Neru strips for binding resolution.
+	sim.press("Ctrl+j")
+
+	sim.waitFor("scroll recorded", func() bool { return len(sim.ax.recordedScrolls()) > 0 })
+
+	if mods := sim.ax.recordedScrollModifiers()[0]; !mods.Has(action.ModCtrl) {
+		t.Fatalf("expected the scroll to carry the sticky Ctrl modifier, got %v", mods)
+	}
+}
+
 // TestSimulation_HeldRepeatScroll covers held-key repeat: holding j keeps
 // scrolling on the configured interval, and the key release stops it.
 func TestSimulation_HeldRepeatScroll(t *testing.T) {


### PR DESCRIPTION
## Description

This PR makes a sticky modifier reach a scroll the way it already reaches a click. Tapping `ctrl` inside scroll mode showed the sticky indicator and then scrolled unmodified, on every platform, because the scroll path deliberately skipped sticky modifiers. That decision was made in #1449 to keep a scroll from zooming where the user asked to pan, but the case it guarded against is a physically held chord, which the backends already keep off the event by stamping flags on macOS and holding the real keys on X11 and Windows. A modifier the user tapped on purpose is the opposite case, and dropping it read as a broken binding.

Now a sticky `ctrl` followed by a scroll key goes out as a ctrl+scroll, which most applications read as zoom, and a sticky `shift` scrolls horizontally where the application maps it that way. Nothing changes for a scroll with no sticky modifier active, and `--modifier` on a scroll action behaves as before, with the sticky set merged in on top of it.

## Related Issues

None. Reverses the sticky-modifier exclusion stated in #1449; #1605 assumed sticky modifiers already reached a scroll.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, small change; ran `just fmt`, `golangci-lint` on the two touched packages, and `go test` on `internal/app`, `internal/app/ipcctrl` and `internal/app/modes`, all green
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, the sticky modifier docs already say the modifier applies to subsequent actions, which is now true of scroll too
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

Every backend already handles a sticky modifier that is also asked for, because clicks have merged them since sticky modifiers existed: macOS stamps the flags, X11 and Windows leave a held key that was asked for alone, and the Wayland virtual keyboard refcounts holders so the scroll's release does not let go of the sticky press. The simulation journey `TestSimulation_StickyModifierScroll` fails on `main` and passes here.
