### PR TITLE
test(ipc): stop the Windows pipe owner test hanging on listener close

### DIFF
--- a/internal/adapter/ipc/transport_windows_internal_test.go
+++ b/internal/adapter/ipc/transport_windows_internal_test.go
@@ -4,10 +4,12 @@ package ipc
 
 import (
 	"context"
+	"net"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Microsoft/go-winio"
 	"go.uber.org/zap"
@@ -87,8 +89,16 @@ func TestAuthorizePeer_DefersToThePipeSecurityDescriptor(t *testing.T) {
 	}
 }
 
-// servePipe listens on path as this user and accepts connections until the
-// test ends, so a dial has something real on the other end to be checked.
+// servePipe listens on path as this user and accepts the one connection the
+// test dials, so that dial has something real on the other end to be checked.
+//
+// The listener is closed only once that accept has returned. go-winio's
+// listener cannot be closed while an accept is still setting up: a Close that
+// lands between the accept's own closed check and its connect call hands the
+// accept an invalid-handle error instead of the closed one, the listener loops
+// back believing it is still open, and Close waits on it forever. Accepting in
+// a loop put a fresh accept in that window on every run, and one in a while
+// the cleanup hit it, seen as a ten-minute test timeout on Windows CI.
 func servePipe(t *testing.T, path string) {
 	t.Helper()
 
@@ -97,18 +107,27 @@ func servePipe(t *testing.T, path string) {
 		t.Fatalf("listenEndpoint(%s) error = %v", path, listenErr)
 	}
 
-	t.Cleanup(func() { _ = listener.Close() })
+	accepted := make(chan net.Conn, 1)
 
 	go func() {
-		for {
-			conn, acceptErr := listener.Accept()
-			if acceptErr != nil {
-				return
-			}
-
-			t.Cleanup(func() { _ = conn.Close() })
-		}
+		conn, _ := listener.Accept()
+		accepted <- conn
 	}()
+
+	t.Cleanup(func() {
+		// A test that never dialed leaves the accept pending on a connect
+		// issued long ago, which Close cancels cleanly; only a fresh accept
+		// is unsafe, and nothing issues one here.
+		select {
+		case conn := <-accepted:
+			if conn != nil {
+				_ = conn.Close()
+			}
+		case <-time.After(time.Second):
+		}
+
+		_ = listener.Close()
+	})
 }
 
 // The name is the only thing the client chose, and a name is what another


### PR DESCRIPTION
## Description

This PR fixes a Windows CI hang in the IPC package's named-pipe ownership test. About one run in a few, the test body finished and its cleanup then blocked forever closing the pipe listener, so the whole package ran into go test's ten-minute timeout and the Windows test job failed.

The test helper served the pipe with an accept loop, so a fresh accept was starting the instant the test's one connection was taken, and the cleanup's close could land inside it. go-winio's listener cannot be closed while an accept is still setting up: a close that lands between the accept's own closed check and its connect call hands the accept an invalid-handle error instead of the closed one, the listener loops back believing it is still open, and close waits on it forever. The helper now accepts exactly the one connection the test dials and closes the listener only once that accept has returned, which is the shape the test needed all along.

## Related Issues

None. First seen on the Windows test job of #1615, run 33974949224; that run was green on rerun.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, test helper only
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, a test-only change on a Windows-tagged file; ran `just fmt`, `go vet` and `golangci-lint` under `GOOS=windows` on the IPC package, and the Windows test job on this PR is the real run
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

The daemon's own shutdown closes its listener the same way, so it carries the same window: a CLI command connecting at the exact instant the daemon stops could leave the shutdown waiting on the listener. That is far narrower than the test's shape, where a fresh accept began on every run, and it is not changed here.

The goroutine dump from the failed attempt shows the listener routine parked at the top of its loop and the cleanup waiting on the listener's done channel, with no accept or connect goroutine left, which is the state described above.
