### PR TITLE
fix(linux): release forwarded keys on the proxy keyboard when it fails open

### DIFF
--- a/docs/adr/0014-the-wayland-keyboard-is-a-proxy.md
+++ b/docs/adr/0014-the-wayland-keyboard-is-a-proxy.md
@@ -145,8 +145,16 @@ it, so a hint label typed while Super is still coming up is the label.
   probe against a real kernel is
   `TestProxyNode_HeldByAnother_SeesAGrabFromAnotherFd`). The remapper's
   output returns to the compositor, so the user's keys and remaps work; what
-  is lost is capturing keys for a mode. The setup guide tells remapper users
-  to exclude the `neru-` devices instead.
+  is lost is capturing keys for a mode. Failing open is the one time the
+  proxy lets a keyboard go without waiting for it to be idle, so a key down
+  at that instant, whose press the proxy re-emitted, is released on the proxy
+  keyboard first (`releaseForwarded`, pinned by
+  `TestEvdevProxy_FailOpen_ReleasesEveryKeyItForwarded`): its physical
+  release goes to the physical device, whose libinput never saw the press
+  and drops it, and a key left down on the proxy would stay down for the
+  daemon's lifetime, a Super that Hyprland merged into every key typed
+  afterwards. The setup guide tells remapper users to exclude the `neru-`
+  devices instead.
 - A remapper's output keyboard also advertises relative motion and mouse
   buttons, so a key can move the pointer, and so does a receiver that exposes a
   mouse and a keyboard on one node. Grabbing such a device takes its motion, so

--- a/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
@@ -502,6 +502,12 @@ func (p *evdevProxy) emitPointer(event waylandEvdevEvent) {
 // emitKey re-emits a key event of the proxy's own making, with the sync report
 // that makes it a complete frame.
 func (p *evdevProxy) emitKey(code uint16, value int32) {
+	frame := keyFrame(code, value)
+	p.write(p.uinputFd, &frame[0], len(frame))
+}
+
+// keyFrame is one key event and the sync report that completes it.
+func keyFrame(code uint16, value int32) [2]C.struct_input_event {
 	var frame [2]C.struct_input_event
 	frame[0]._type = C.ushort(evdevEventKey)
 	frame[0].code = C.ushort(code)
@@ -509,7 +515,7 @@ func (p *evdevProxy) emitKey(code uint16, value int32) {
 	frame[1]._type = C.ushort(evdevEventSyn)
 	frame[1].code = C.ushort(evdevSynReport)
 
-	p.write(p.uinputFd, &frame[0], len(frame))
+	return frame
 }
 
 // write puts count events on one proxy device, whole. Anything less means the
@@ -542,6 +548,8 @@ func (p *evdevProxy) failOpen(err error) {
 		return
 	}
 
+	p.releaseForwarded()
+
 	p.capture.ungrabAll()
 
 	// The keys now reach the compositor as well, so a session reading them
@@ -569,6 +577,38 @@ func (p *evdevProxy) failOpen(err error) {
 			"mode keyboard capture is off until the daemon restarts",
 		zap.Error(err),
 	)
+}
+
+// releaseForwarded re-emits a release on the proxy keyboard for every key the
+// rule counts as forwarded and down, then zeroes the rule. Failing open is the
+// one time a keyboard is let go without waiting for it to be idle: a key down
+// at that instant had its press re-emitted here, and its release goes to the
+// physical device next, whose libinput never saw the press and drops it. Left
+// down on the proxy keyboard it would stay down for the daemon's lifetime, and
+// a compositor that merges modifiers across keyboards (Hyprland) would put
+// that Super on every key typed afterwards. Base keys go up before modifiers,
+// the way a chord is let go of. The writes bypass the forwarding flag, which
+// failOpen has cleared; on a proxy that stopped taking writes they fail as the
+// last one did, and there is nothing more to do for it.
+func (p *evdevProxy) releaseForwarded() {
+	var keys, modifiers []uint16
+
+	for code := range uint16(evdevKeyCodeCount) {
+		switch {
+		case !p.rule.isDown(code):
+		case p.capture.modifierName(code) != "":
+			modifiers = append(modifiers, code)
+		default:
+			keys = append(keys, code)
+		}
+	}
+
+	p.rule = forwardRule{}
+
+	for _, code := range append(keys, modifiers...) {
+		frame := keyFrame(code, evdevValueRelease)
+		C.neru_evdev_write_events(p.uinputFd, &frame[0], C.int(len(frame)))
+	}
 }
 
 // forwardWithheld hands a press the session had withheld to the compositor

--- a/internal/adapter/eventtap/linux/evdev_proxy_test.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_test.go
@@ -479,6 +479,39 @@ func TestEvdevProxy_FailOpenReleasesTheKeyboardsAndRefusesSessions(t *testing.T)
 	}
 }
 
+// A key down when the proxy fails open had its press re-emitted on the proxy
+// keyboard, and its release goes to the physical device next, where libinput
+// never saw the press: the proxy releases what it forwarded before it lets
+// the keyboards go, or the key stays down on the proxy for the daemon's life.
+func TestEvdevProxy_FailOpen_ReleasesEveryKeyItForwarded(t *testing.T) {
+	t.Parallel()
+
+	proxy := newTestProxy()
+
+	// The activation chord, forwarded: no session is capturing.
+	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValuePress))
+	proxy.handle(keyEvent(evdevKeyJ, evdevValuePress))
+
+	if !proxy.rule.isDown(evdevKeyLeftMeta) || !proxy.rule.isDown(evdevKeyJ) {
+		t.Fatal("the chord was not forwarded before the proxy failed open")
+	}
+
+	proxy.forwarding.Store(true)
+	proxy.capture.grab = true
+	proxy.failOpen(errWaylandEvdevProxyGrabbed)
+
+	for _, code := range []uint16{evdevKeyLeftMeta, evdevKeyJ} {
+		if proxy.rule.isDown(code) {
+			t.Errorf("key %d is still down on the proxy keyboard after it failed open", code)
+		}
+	}
+
+	// The physical releases that follow are the physical device's now.
+	if proxy.rule.release(evdevKeyJ) || proxy.rule.release(evdevKeyLeftMeta) {
+		t.Error("a release was forwarded for a key the fail-open already released")
+	}
+}
+
 // A keyboard yielded to a remapper is with the compositor until the remapper
 // claims it or it is taken back; a mode started meanwhile would get nothing
 // while its keys went to the focused app, so it is refused and falls back.


### PR DESCRIPTION
## Description

This PR stops a Wayland fail-open from leaving a held key, typically Super, stuck on the proxy keyboard for the rest of the daemon's life.

When the evdev proxy fails open (another process grabbed a `neru-` device, which a remapper's device auto-detect does, or a proxy write failed) it ungrabbed the physical keyboards at once, with no idle wait. A key physically down at that instant had its press re-emitted on `neru-keyboard-proxy`, and its release then went to the physical device, whose libinput never saw the press and dropped it. The proxy keyboard kept the key down until the daemon restarted, and Hyprland, which merges modifier state across keyboards, put that Super on every key typed afterwards. Because the probe runs every half second, whether a key was held at that moment was chance, which is why it showed up intermittently.

The proxy now releases every key the forward rule counts as forwarded and down before it lets the keyboards go, base keys before modifiers, and zeroes the rule so the physical releases that follow are not forwarded a second time.

## Related Issues

Follow-up to #1603 and #1604: an intermittent stuck Super reported on Hyprland with a compositor binding launching a mode.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

Only `evdev_proxy_cgo.go` changes, already `linux && cgo`; no port contract changes.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

`just ci` on the dev VM passes every recipe except one pre-existing, host-specific integration failure unrelated to this change: `TestFontconfigResolver_Resolve_MissingFamilyFallsBackToTheResolvedGeneric`, because this host's fontconfig substitutes Noto Sans for the generic.

## Additional Context

Reproduced and verified live on the niri VM with a virtual uinput keyboard so the real keyboard stayed out of it: press Super on the virtual keyboard (forwarded on the proxy), grab `neru-keyboard-proxy` from another process until the probe fails open, then read the proxy node's kernel key state with `EVIOCGKEY`.

| Step | Before | After |
|------|--------|-------|
| Super down on the proxy after the press | down | down |
| Proxy state once the probe failed open | down | up |
| Proxy state after the physical release | down (stuck) | up |

Unit coverage: `TestEvdevProxy_FailOpen_ReleasesEveryKeyItForwarded`. ADR 0014 records the consequence.

This is the one path found where the proxy can leave a key down; it is not proven to be every case of the Hyprland report, so the reporter's daemon log around the incident (the "Another process grabbed a neru proxy device" line) is still the thing to ask for.
