### PR TITLE
feat(hotkeys): repeat a held global hotkey on Linux and Windows

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -526,7 +526,7 @@ compositor infer the drag.
 | **In-mode capture**   | `CGEventTapCreate`     | `XGrabKeyboard`         | evdev proxy (lifetime `EVIOCGRAB` + uinput re-emit), wl-keyboard fallback | `WH_KEYBOARD_LL`        |
 | **Global hotkeys**    | Per-key CGEventTap     | `XGrabKey`              | Chord matcher on the evdev proxy         | `RegisterHotKey`        |
 | **CGO needed**        | Yes                    | Yes                     | Yes                                      | No                      |
-| **Press/release**     | ✅ separate callbacks  | ✅ KeyPress/KeyRelease  | ⚠️ press-only in some configs            | ✅ `WM_HOTKEY` flags    |
+| **Press/release**     | ✅ separate callbacks  | ✅ KeyPress/KeyRelease  | ✅ evdev press/release                   | ✅ press, then `GetAsyncKeyState` poll |
 | **Modifier passthrough** | ✅                  | ❌ grab is all-or-nothing | ✅ evdev only                          | ✅ hook forwards per event |
 | **`PostModifierEvent`** | ✅                   | ✅                      | ✅ (`zwp_virtual_keyboard_v1`)           | ✅ `SendInput`          |
 | **Sticky modifiers**  | ✅                     | ✅                      | ✅                                       | ✅                      |
@@ -536,6 +536,23 @@ compositor infer the drag.
 There is no separate Wayland hotkey file. The Wayland path lives in the common
 `hotkeys/linux/manager.go`, which delegates to the evdev listener in the
 eventtap package.
+
+**A held global hotkey.** Every manager implements `HotkeyReleaseRegistrar`,
+and reports a hold as one press and one release however long it lasts, which is
+what `[held_repeat]` repeats between. macOS folds autorepeat in the per-hotkey
+tap. The evdev proxy fires the release when the chord's key comes up, whether or
+not the modifier is still down by then. X11 asks the server for detectable
+autorepeat on both of its connections (`XkbSetDetectableAutoRepeat`), so a held
+key is repeated `KeyPress` events and one `KeyRelease` rather than the
+release/press pairs that would end the hold at the server's repeat rate; the
+in-mode tap needs the same, or the mode's own held repeat stops after its first
+tick. `RegisterHotKey` reports the press only, so the Windows registry registers
+with `MOD_NOREPEAT` and reads the key through `GetAsyncKeyState` every 10 ms
+from the `WM_HOTKEY` until it reads up. The poll runs only while a hotkey is
+held; the other source of releases, the `WH_KEYBOARD_LL` hook, sits on every
+keystroke for as long as it is installed, and installing it for the daemon's
+lifetime would put a hook procedure on the idle path to pay for a release only a
+held hotkey needs.
 
 **A global chord while a mode is active.** A `[hotkeys]` binding keeps working
 from inside a mode on macOS, Windows and Linux Wayland, and each gets there its

--- a/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
@@ -180,7 +180,7 @@ func newEvdevProxy(logger *zap.Logger) (*evdevProxy, error) {
 		done:          make(chan struct{}),
 		heldByAnother: (*proxyNode).heldByAnother,
 		heldHotkeys:   make(map[uint16]func()),
-		dispatch:      NewHotkeyDispatcher(logger),
+		dispatch:      NewHotkeyDispatcher(),
 	}
 
 	proxy.forwarding.Store(uinputFd >= 0)

--- a/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
@@ -66,7 +66,14 @@ type evdevProxy struct {
 	pointerNode   *proxyNode
 	heldByAnother func(*proxyNode) bool
 
-	bindings atomic.Pointer[map[string]func()]
+	bindings atomic.Pointer[map[string]hotkeyBinding]
+
+	// heldHotkeys is the release callback owed for each key whose press
+	// matched a chord and is still down, by key code. Owned by the run
+	// goroutine. It is what lets a binding repeat while its key is held: the
+	// press fires once, at match time, and the release fires when this key
+	// comes up, whichever consumer the events reached in between.
+	heldHotkeys map[uint16]func()
 
 	control chan proxyCommand
 	done    chan struct{}
@@ -78,6 +85,13 @@ type evdevProxy struct {
 type proxyCommand struct {
 	session *evdevSession
 	ack     chan struct{}
+}
+
+// hotkeyBinding is what the idle matcher fires for a chord: press when the
+// chord's key goes down, release (which may be nil) when that key comes up.
+type hotkeyBinding struct {
+	press   func()
+	release func()
 }
 
 var (
@@ -161,11 +175,12 @@ func newEvdevProxy(logger *zap.Logger) (*evdevProxy, error) {
 		control:       make(chan proxyCommand),
 		done:          make(chan struct{}),
 		heldByAnother: (*proxyNode).heldByAnother,
+		heldHotkeys:   make(map[uint16]func()),
 	}
 
 	proxy.forwarding.Store(uinputFd >= 0)
 
-	empty := map[string]func(){}
+	empty := map[string]hotkeyBinding{}
 	proxy.bindings.Store(&empty)
 
 	go proxy.run()
@@ -200,8 +215,8 @@ func (p *evdevProxy) alive() bool {
 
 // setBindings replaces the chords the idle matcher fires on. The map is read
 // on the run goroutine without a lock, so it is swapped whole and never edited.
-func (p *evdevProxy) setBindings(bindings map[string]func()) {
-	copied := make(map[string]func(), len(bindings))
+func (p *evdevProxy) setBindings(bindings map[string]hotkeyBinding) {
+	copied := make(map[string]hotkeyBinding, len(bindings))
 	maps.Copy(copied, bindings)
 
 	p.bindings.Store(&copied)
@@ -412,6 +427,7 @@ func (p *evdevProxy) handleKey(event waylandEvdevEvent) {
 	case evdevValueRelease:
 		p.capture.feedKey(code, false)
 		p.trackGlobal(code, false)
+		p.releaseHotkey(code)
 
 		forwarded := p.rule.release(code)
 		if forwarded {
@@ -439,7 +455,8 @@ func (p *evdevProxy) trackGlobal(code uint16, isDown bool) {
 }
 
 // matchHotkey fires the binding for the chord a press completes, if there is
-// one, and reports whether it did.
+// one, and reports whether it did. A press fires once per hold: the kernel
+// reports a held key as repeats, not presses, so none of those reach here.
 func (p *evdevProxy) matchHotkey(code uint16) bool {
 	bindings := *p.bindings.Load()
 	if len(bindings) == 0 {
@@ -456,16 +473,34 @@ func (p *evdevProxy) matchHotkey(code uint16) bool {
 		return false
 	}
 
-	callback := bindings[signature]
-	if callback == nil {
+	binding, bound := bindings[signature]
+	if !bound || binding.press == nil {
 		return false
 	}
 
 	p.logger.Debug("Global hotkey matched", zap.String("chord", signature))
 
-	go callback()
+	if binding.release != nil {
+		p.heldHotkeys[code] = binding.release
+	}
+
+	go binding.press()
 
 	return true
+}
+
+// releaseHotkey fires the release owed for a key whose press matched a chord.
+// It is keyed by the key alone, not the chord: the binder needs the release
+// whether or not the modifier is still down when the key comes up.
+func (p *evdevProxy) releaseHotkey(code uint16) {
+	release, held := p.heldHotkeys[code]
+	if !held {
+		return
+	}
+
+	delete(p.heldHotkeys, code)
+
+	go release()
 }
 
 // emit re-emits one event on the proxy keyboard.

--- a/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
@@ -75,6 +75,10 @@ type evdevProxy struct {
 	// comes up, whichever consumer the events reached in between.
 	heldHotkeys map[uint16]func()
 
+	// dispatch runs the matched bindings' callbacks, in order, off this
+	// goroutine.
+	dispatch *HotkeyDispatcher
+
 	control chan proxyCommand
 	done    chan struct{}
 }
@@ -176,6 +180,7 @@ func newEvdevProxy(logger *zap.Logger) (*evdevProxy, error) {
 		done:          make(chan struct{}),
 		heldByAnother: (*proxyNode).heldByAnother,
 		heldHotkeys:   make(map[uint16]func()),
+		dispatch:      NewHotkeyDispatcher(logger),
 	}
 
 	proxy.forwarding.Store(uinputFd >= 0)
@@ -484,7 +489,7 @@ func (p *evdevProxy) matchHotkey(code uint16) bool {
 		p.heldHotkeys[code] = binding.release
 	}
 
-	go binding.press()
+	p.dispatch.Dispatch(binding.press)
 
 	return true
 }
@@ -500,7 +505,7 @@ func (p *evdevProxy) releaseHotkey(code uint16) {
 
 	delete(p.heldHotkeys, code)
 
-	go release()
+	p.dispatch.Dispatch(release)
 }
 
 // emit re-emits one event on the proxy keyboard.

--- a/internal/adapter/eventtap/linux/evdev_proxy_test.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_test.go
@@ -39,7 +39,7 @@ func newTestProxy() *evdevProxy {
 	empty := map[string]hotkeyBinding{}
 	proxy.bindings.Store(&empty)
 	proxy.heldHotkeys = make(map[uint16]func())
-	proxy.dispatch = NewHotkeyDispatcher(nil)
+	proxy.dispatch = NewHotkeyDispatcher()
 
 	return proxy
 }

--- a/internal/adapter/eventtap/linux/evdev_proxy_test.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_test.go
@@ -36,8 +36,9 @@ func newTestProxy() *evdevProxy {
 		done:     make(chan struct{}),
 	}
 
-	empty := map[string]func(){}
+	empty := map[string]hotkeyBinding{}
 	proxy.bindings.Store(&empty)
+	proxy.heldHotkeys = make(map[uint16]func())
 
 	return proxy
 }
@@ -45,8 +46,8 @@ func newTestProxy() *evdevProxy {
 func bindTestChord(proxy *evdevProxy) chan struct{} {
 	fired := make(chan struct{}, 4)
 
-	proxy.setBindings(map[string]func(){
-		canonicalChordSignature(testChord): func() { fired <- struct{}{} },
+	proxy.setBindings(map[string]hotkeyBinding{
+		canonicalChordSignature(testChord): {press: func() { fired <- struct{}{} }},
 	})
 
 	return fired
@@ -186,6 +187,54 @@ func TestForwardRule_IgnoresCodesOutsideTheKeyRange(t *testing.T) {
 
 	if rule.isDown(evdevKeyCodeCount) {
 		t.Fatal("a code past KEY_MAX was recorded")
+	}
+}
+
+// A held chord is one press and one release to the binder, which is what lets
+// it repeat the binding for as long as the key is down: the kernel's repeats
+// fire nothing, and the release comes when the key comes up, whether or not
+// the modifier is still held by then.
+func TestEvdevProxy_AHeldChordFiresPressOnceAndReleaseWhenItsKeyComesUp(t *testing.T) {
+	t.Parallel()
+
+	proxy := newTestProxy()
+	pressed := make(chan struct{}, 4)
+	released := make(chan struct{}, 4)
+
+	proxy.setBindings(map[string]hotkeyBinding{
+		canonicalChordSignature(testChord): {
+			press:   func() { pressed <- struct{}{} },
+			release: func() { released <- struct{}{} },
+		},
+	})
+
+	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValuePress))
+	proxy.handle(keyEvent(evdevKeySemicolon, evdevValuePress))
+
+	if !waitFired(t, pressed) {
+		t.Fatal("the chord did not match")
+	}
+
+	proxy.handle(keyEvent(evdevKeySemicolon, evdevValueRepeat))
+	proxy.handle(keyEvent(evdevKeySemicolon, evdevValueRepeat))
+
+	select {
+	case <-pressed:
+		t.Fatal(
+			"a repeat fired the press again; the binder would restart its repeat from the delay",
+		)
+	case <-released:
+		t.Fatal("the release fired while the key was still down")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// The modifier comes up first, so the key's release is no longer the
+	// chord. The release is owed to the key, not the chord.
+	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValueRelease))
+	proxy.handle(keyEvent(evdevKeySemicolon, evdevValueRelease))
+
+	if !waitFired(t, released) {
+		t.Fatal("the key came up and no release fired; the binder would repeat forever")
 	}
 }
 
@@ -612,7 +661,7 @@ func TestGlobalHotkeyListener_StopDetachesTheBindings(t *testing.T) {
 
 	proxy := newTestProxy()
 	listener := NewGlobalHotkeyListener(nil)
-	listener.SetBinding(testChord, func() {})
+	listener.SetBinding(testChord, func() {}, nil)
 
 	listener.mu.Lock()
 	listener.proxy = proxy

--- a/internal/adapter/eventtap/linux/evdev_proxy_test.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_test.go
@@ -39,6 +39,7 @@ func newTestProxy() *evdevProxy {
 	empty := map[string]hotkeyBinding{}
 	proxy.bindings.Store(&empty)
 	proxy.heldHotkeys = make(map[uint16]func())
+	proxy.dispatch = NewHotkeyDispatcher(nil)
 
 	return proxy
 }

--- a/internal/adapter/eventtap/linux/global_hotkey_cgo.go
+++ b/internal/adapter/eventtap/linux/global_hotkey_cgo.go
@@ -20,7 +20,7 @@ type GlobalHotkeyListener struct {
 	logger *zap.Logger
 
 	mu       sync.Mutex
-	bindings map[string]func()
+	bindings map[string]hotkeyBinding
 	proxy    *evdevProxy
 	running  bool
 }
@@ -34,22 +34,23 @@ func NewGlobalHotkeyListener(logger *zap.Logger) *GlobalHotkeyListener {
 
 	return &GlobalHotkeyListener{
 		logger:   logger.Named("hotkeys.evdev"),
-		bindings: make(map[string]func()),
+		bindings: make(map[string]hotkeyBinding),
 	}
 }
 
-// SetBinding registers a callback for a chord string (e.g. "Ctrl+Shift+G").
-// Safe to call before or after Start.
-func (l *GlobalHotkeyListener) SetBinding(chord string, callback func()) {
+// SetBinding registers the callbacks for a chord string (e.g. "Ctrl+Shift+G"):
+// press when the chord's key goes down, release (nil for none) when it comes
+// up. Safe to call before or after Start.
+func (l *GlobalHotkeyListener) SetBinding(chord string, press, release func()) {
 	signature := canonicalChordSignature(chord)
-	if signature == "" || callback == nil {
+	if signature == "" || press == nil {
 		return
 	}
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	l.bindings[signature] = callback
+	l.bindings[signature] = hotkeyBinding{press: press, release: release}
 	l.publishLocked()
 }
 
@@ -58,7 +59,7 @@ func (l *GlobalHotkeyListener) ClearBindings() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	l.bindings = make(map[string]func())
+	l.bindings = make(map[string]hotkeyBinding)
 	l.publishLocked()
 }
 

--- a/internal/adapter/eventtap/linux/global_hotkey_nocgo.go
+++ b/internal/adapter/eventtap/linux/global_hotkey_nocgo.go
@@ -21,7 +21,7 @@ func NewGlobalHotkeyListener(_ *zap.Logger) *GlobalHotkeyListener {
 }
 
 // SetBinding is a no-op without cgo.
-func (l *GlobalHotkeyListener) SetBinding(_ string, _ func()) {}
+func (l *GlobalHotkeyListener) SetBinding(_ string, _, _ func()) {}
 
 // ClearBindings is a no-op without cgo.
 func (l *GlobalHotkeyListener) ClearBindings() {}

--- a/internal/adapter/eventtap/linux/hotkey_dispatch.go
+++ b/internal/adapter/eventtap/linux/hotkey_dispatch.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+package linux
+
+import "go.uber.org/zap"
+
+// hotkeyDispatchBufferSize bounds how many callbacks can wait on the
+// dispatcher. Two per hotkey is the most a hold produces; the rest is slack for
+// a handler that is briefly busy.
+const hotkeyDispatchBufferSize = 64
+
+// HotkeyDispatcher runs hotkey callbacks off the goroutine that reads key
+// events, one at a time, in the order they were queued.
+//
+// Off that goroutine because a callback takes the mode handler's lock, and the
+// handler waits on the reader while holding it (the proxy's session ack, the
+// X11 loop's exit), so running it inline could deadlock. In order because a
+// goroutine per callback has none: a release and the press that follows it
+// could run swapped, and the release would then cancel the repeat the new
+// press had just started, leaving a held key that stops repeating.
+type HotkeyDispatcher struct {
+	logger *zap.Logger
+	queue  chan func()
+}
+
+// NewHotkeyDispatcher starts a dispatcher.
+func NewHotkeyDispatcher(logger *zap.Logger) *HotkeyDispatcher {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	dispatcher := &HotkeyDispatcher{
+		logger: logger,
+		queue:  make(chan func(), hotkeyDispatchBufferSize),
+	}
+
+	go dispatcher.run()
+
+	return dispatcher
+}
+
+// Dispatch queues callback. It never blocks the reader: a full queue means the
+// handler is wedged, and the callback is dropped with a warning, as the taps
+// drop keys.
+func (d *HotkeyDispatcher) Dispatch(callback func()) {
+	select {
+	case d.queue <- callback:
+	default:
+		d.logger.Warn("Hotkey dispatch queue full, dropping callback")
+	}
+}
+
+// Stop ends the dispatcher once it has run what is queued. Only the reader
+// queues, so the owner calls this after the reader has exited; it does not
+// wait, because a queued callback may be waiting on a lock the owner holds.
+func (d *HotkeyDispatcher) Stop() {
+	close(d.queue)
+}
+
+func (d *HotkeyDispatcher) run() {
+	for callback := range d.queue {
+		callback()
+	}
+}

--- a/internal/adapter/eventtap/linux/hotkey_dispatch.go
+++ b/internal/adapter/eventtap/linux/hotkey_dispatch.go
@@ -2,12 +2,7 @@
 
 package linux
 
-import "go.uber.org/zap"
-
-// hotkeyDispatchBufferSize bounds how many callbacks can wait on the
-// dispatcher. Two per hotkey is the most a hold produces; the rest is slack for
-// a handler that is briefly busy.
-const hotkeyDispatchBufferSize = 64
+import "sync"
 
 // HotkeyDispatcher runs hotkey callbacks off the goroutine that reads key
 // events, one at a time, in the order they were queued.
@@ -18,47 +13,70 @@ const hotkeyDispatchBufferSize = 64
 // goroutine per callback has none: a release and the press that follows it
 // could run swapped, and the release would then cancel the repeat the new
 // press had just started, leaving a held key that stops repeating.
+//
+// The queue is unbounded rather than dropping under pressure, because a
+// release is the one thing that ends a held key's repeat: dropped, the repeat
+// would outlive the key. What queues is two callbacks per hotkey press, so
+// even a handler stuck for the length of a hold grows it by a few entries.
 type HotkeyDispatcher struct {
-	logger *zap.Logger
-	queue  chan func()
+	mu      sync.Mutex
+	ready   *sync.Cond
+	queue   []func()
+	stopped bool
 }
 
 // NewHotkeyDispatcher starts a dispatcher.
-func NewHotkeyDispatcher(logger *zap.Logger) *HotkeyDispatcher {
-	if logger == nil {
-		logger = zap.NewNop()
-	}
-
-	dispatcher := &HotkeyDispatcher{
-		logger: logger,
-		queue:  make(chan func(), hotkeyDispatchBufferSize),
-	}
+func NewHotkeyDispatcher() *HotkeyDispatcher {
+	dispatcher := &HotkeyDispatcher{}
+	dispatcher.ready = sync.NewCond(&dispatcher.mu)
 
 	go dispatcher.run()
 
 	return dispatcher
 }
 
-// Dispatch queues callback. It never blocks the reader: a full queue means the
-// handler is wedged, and the callback is dropped with a warning, as the taps
-// drop keys.
+// Dispatch queues callback. It never blocks the reader.
 func (d *HotkeyDispatcher) Dispatch(callback func()) {
-	select {
-	case d.queue <- callback:
-	default:
-		d.logger.Warn("Hotkey dispatch queue full, dropping callback")
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.stopped {
+		return
 	}
+
+	d.queue = append(d.queue, callback)
+	d.ready.Signal()
 }
 
-// Stop ends the dispatcher once it has run what is queued. Only the reader
-// queues, so the owner calls this after the reader has exited; it does not
-// wait, because a queued callback may be waiting on a lock the owner holds.
+// Stop ends the dispatcher once it has run what is queued. It does not wait,
+// because a queued callback may be waiting on a lock the owner holds.
 func (d *HotkeyDispatcher) Stop() {
-	close(d.queue)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.stopped = true
+	d.ready.Signal()
 }
 
 func (d *HotkeyDispatcher) run() {
-	for callback := range d.queue {
+	for {
+		d.mu.Lock()
+
+		for len(d.queue) == 0 && !d.stopped {
+			d.ready.Wait()
+		}
+
+		if len(d.queue) == 0 {
+			d.mu.Unlock()
+
+			return
+		}
+
+		callback := d.queue[0]
+		d.queue[0] = nil
+		d.queue = d.queue[1:]
+		d.mu.Unlock()
+
 		callback()
 	}
 }

--- a/internal/adapter/eventtap/linux/x11_cgo.go
+++ b/internal/adapter/eventtap/linux/x11_cgo.go
@@ -11,6 +11,7 @@ import "C"
 
 import (
 	"os"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -24,6 +25,10 @@ const (
 	x11KeyBufferSize   = 64
 	x11BitsPerByte     = 8
 )
+
+// x11AutorepeatWarned says the refusal once: runX11 opens a connection per
+// mode activation, and the server's answer does not change between them.
+var x11AutorepeatWarned sync.Once
 
 // x11QueryModifierState queries the X11 server for the current keyboard
 // state and returns a linuxModifierState counting any held modifier keys.
@@ -92,6 +97,15 @@ func (et *EventTap) runX11() {
 	}
 	defer C.neru_eventtap_close(display)
 
+	if C.neru_eventtap_set_detectable_autorepeat(display) == 0 {
+		x11AutorepeatWarned.Do(func() {
+			et.logger.Warn(
+				"X server does not support detectable autorepeat; a held key's " +
+					"repeat stops after its first tick",
+			)
+		})
+	}
+
 	if C.neru_eventtap_grab_keyboard(display) != C.GrabSuccess {
 		return
 	}
@@ -103,6 +117,13 @@ func (et *EventTap) runX11() {
 	// return true prematurely when only some of the held modifiers have
 	// been released — arming detection while others are still held.
 	modState := x11QueryModifierState(display)
+
+	// Keycodes down since the grab. With detectable autorepeat (set by
+	// neru_eventtap_open) a held key is repeated KeyPress events, and a
+	// modifier's repeats must not be counted as further presses: modState is
+	// a count, and one that never returns to zero never re-arms sticky
+	// detection.
+	down := make(map[C.uint]struct{})
 
 	for {
 		select {
@@ -124,6 +145,16 @@ func (et *EventTap) runX11() {
 		}
 
 		xkey := (*C.XKeyEvent)(unsafe.Pointer(&event))
+
+		_, wasDown := down[xkey.keycode]
+		repeat := eventType == C.KeyPress && wasDown
+
+		if eventType == C.KeyPress {
+			down[xkey.keycode] = struct{}{}
+		} else {
+			delete(down, xkey.keycode)
+		}
+
 		buffer := make([]C.char, x11KeyBufferSize)
 		var keysym C.KeySym
 		length := C.XLookupString(
@@ -135,6 +166,10 @@ func (et *EventTap) runX11() {
 		)
 
 		if modifier := x11ModifierName(keysym); modifier != "" {
+			if repeat {
+				continue
+			}
+
 			isDown := eventType == C.KeyPress
 			modState.update(modifier, isDown)
 

--- a/internal/adapter/eventtap/linux/x11_cgo.go
+++ b/internal/adapter/eventtap/linux/x11_cgo.go
@@ -100,8 +100,8 @@ func (et *EventTap) runX11() {
 	if C.neru_eventtap_set_detectable_autorepeat(display) == 0 {
 		x11AutorepeatWarned.Do(func() {
 			et.logger.Warn(
-				"X server does not support detectable autorepeat; a held key's " +
-					"repeat stops after its first tick",
+				"X server does not support detectable autorepeat; a held key repeats " +
+					"at the server's autorepeat rate instead of held_repeat's",
 			)
 		})
 	}

--- a/internal/adapter/hotkeys/linux/manager.go
+++ b/internal/adapter/hotkeys/linux/manager.go
@@ -16,9 +16,16 @@ import (
 
 const waylandStopTimeout = 3 * time.Second
 
+// hotkeyCallbacks is what one registration fires: press once when the chord
+// goes down, and release (nil for Register) once when its key comes up.
+type hotkeyCallbacks struct {
+	press   ports.HotkeyCallback
+	release ports.HotkeyCallback
+}
+
 // Manager handles the registration, unregistration, and dispatching of global hotkeys.
 type Manager struct {
-	callbacks map[ports.HotkeyID]ports.HotkeyCallback
+	callbacks map[ports.HotkeyID]hotkeyCallbacks
 	keys      map[ports.HotkeyID]string
 	logger    *zap.Logger
 	rawLogger *zap.Logger
@@ -46,7 +53,7 @@ func NewManager(logger *zap.Logger) *Manager {
 	}
 
 	mgr := &Manager{
-		callbacks: make(map[ports.HotkeyID]ports.HotkeyCallback),
+		callbacks: make(map[ports.HotkeyID]hotkeyCallbacks),
 		keys:      make(map[ports.HotkeyID]string),
 		logger:    logger.Named("hotkeys"),
 		rawLogger: logger,
@@ -61,17 +68,34 @@ func NewManager(logger *zap.Logger) *Manager {
 	return mgr
 }
 
-// Register adds a new global hotkey (Linux stub).
+// Register adds a new global hotkey that fires callback once per press.
 func (m *Manager) Register(
 	keyString string,
 	callback ports.HotkeyCallback,
+) (ports.HotkeyID, error) {
+	return m.RegisterWithRelease(keyString, callback, nil)
+}
+
+// Both backends see the key come up: the evdev proxy reads every release, and
+// an XGrabKey delivers KeyRelease to the grabbing client. The binder reaches
+// this by type assertion, so a signature drift would silently return every
+// hotkey to press-only instead of failing to compile.
+var _ ports.HotkeyReleaseRegistrar = (*Manager)(nil)
+
+// RegisterWithRelease adds a new global hotkey with press and optional release
+// callbacks. A held chord is one press and one release, however long it is
+// held: the backends report the hold as repeats, which fire nothing.
+func (m *Manager) RegisterWithRelease(
+	keyString string,
+	pressCallback ports.HotkeyCallback,
+	releaseCallback ports.HotkeyCallback,
 ) (ports.HotkeyID, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	hotkeyID := m.nextID
 	m.nextID++
-	m.callbacks[hotkeyID] = callback
+	m.callbacks[hotkeyID] = hotkeyCallbacks{press: pressCallback, release: releaseCallback}
 	m.keys[hotkeyID] = keyString
 
 	switch m.backend {
@@ -134,7 +158,7 @@ func (m *Manager) UnregisterAll() {
 		m.unregisterAllX11Hotkeys()
 	}
 
-	m.callbacks = make(map[ports.HotkeyID]ports.HotkeyCallback)
+	m.callbacks = make(map[ports.HotkeyID]hotkeyCallbacks)
 	m.keys = make(map[ports.HotkeyID]string)
 
 	if m.backend.IsWayland() {
@@ -189,7 +213,8 @@ func (m *Manager) rebuildWaylandBindings() {
 	m.waylandHotkeys.ClearBindings()
 
 	for id, key := range m.keys {
-		m.waylandHotkeys.SetBinding(key, m.callbacks[id])
+		callbacks := m.callbacks[id]
+		m.waylandHotkeys.SetBinding(key, callbacks.press, callbacks.release)
 	}
 }
 

--- a/internal/adapter/hotkeys/linux/x11_cgo.go
+++ b/internal/adapter/hotkeys/linux/x11_cgo.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unsafe"
 
+	eventtaplinux "github.com/y3owk1n/neru/internal/adapter/eventtap/linux"
 	_ "github.com/y3owk1n/neru/internal/adapter/platform/linux"
 	"github.com/y3owk1n/neru/internal/derrors"
 	"github.com/y3owk1n/neru/internal/domain/keyvocab"
@@ -50,11 +51,13 @@ type x11HotkeyState struct {
 	root     C.Window
 	bindings map[ports.HotkeyID]x11HotkeyBinding
 	ids      map[string]ports.HotkeyID
-	// held is owned by the poll loop, the only goroutine that reads key events.
-	held   x11HeldHotkeys
-	stopCh chan struct{} // signals runX11HotkeyLoop to exit
-	doneCh chan struct{} // closed when runX11HotkeyLoop has exited
-	once   sync.Once
+	// held is owned by the poll loop, the only goroutine that reads key events,
+	// and dispatch runs the callbacks it fires, in order, off it.
+	held     x11HeldHotkeys
+	dispatch *eventtaplinux.HotkeyDispatcher
+	stopCh   chan struct{} // signals runX11HotkeyLoop to exit
+	doneCh   chan struct{} // closed when runX11HotkeyLoop has exited
+	once     sync.Once
 }
 
 // x11IgnoredModifierMasks are the lock modifiers a grab has to be repeated
@@ -211,6 +214,7 @@ func (m *Manager) unregisterAllX11Hotkeys() {
 		close(state.stopCh)
 		<-state.doneCh
 
+		state.dispatch.Stop()
 		state.closeDisplay()
 		x11States.Delete(m)
 	})
@@ -247,7 +251,7 @@ func (m *Manager) ensureX11State() (*x11HotkeyState, error) {
 	if C.neru_hotkeys_set_detectable_autorepeat(display) == 0 {
 		m.logger.Warn(
 			"X server does not support detectable autorepeat; a held global hotkey " +
-				"fires once instead of repeating",
+				"repeats at the server's autorepeat rate instead of held_repeat's",
 		)
 	}
 
@@ -257,6 +261,7 @@ func (m *Manager) ensureX11State() (*x11HotkeyState, error) {
 		bindings: make(map[ports.HotkeyID]x11HotkeyBinding),
 		ids:      make(map[string]ports.HotkeyID),
 		held:     make(x11HeldHotkeys),
+		dispatch: eventtaplinux.NewHotkeyDispatcher(m.logger),
 		stopCh:   make(chan struct{}),
 		doneCh:   make(chan struct{}),
 	}
@@ -315,7 +320,7 @@ func (m *Manager) runX11HotkeyLoop(state *x11HotkeyState) {
 			}
 
 			if callbacks.press != nil {
-				go callbacks.press()
+				state.dispatch.Dispatch(callbacks.press)
 			}
 		case C.KeyRelease:
 			hotkeyID, wasDown := state.held.release(uint32(keycode))
@@ -328,7 +333,7 @@ func (m *Manager) runX11HotkeyLoop(state *x11HotkeyState) {
 			m.mu.RUnlock()
 
 			if release != nil {
-				go release()
+				state.dispatch.Dispatch(release)
 			}
 		}
 	}

--- a/internal/adapter/hotkeys/linux/x11_cgo.go
+++ b/internal/adapter/hotkeys/linux/x11_cgo.go
@@ -50,9 +50,11 @@ type x11HotkeyState struct {
 	root     C.Window
 	bindings map[ports.HotkeyID]x11HotkeyBinding
 	ids      map[string]ports.HotkeyID
-	stopCh   chan struct{} // signals runX11HotkeyLoop to exit
-	doneCh   chan struct{} // closed when runX11HotkeyLoop has exited
-	once     sync.Once
+	// held is owned by the poll loop, the only goroutine that reads key events.
+	held   x11HeldHotkeys
+	stopCh chan struct{} // signals runX11HotkeyLoop to exit
+	doneCh chan struct{} // closed when runX11HotkeyLoop has exited
+	once   sync.Once
 }
 
 // x11IgnoredModifierMasks are the lock modifiers a grab has to be repeated
@@ -93,7 +95,7 @@ func (s *x11HotkeyState) grab(keyString string) (x11HotkeyBinding, error) {
 		)
 	}
 
-	C.XSelectInput(s.display, s.root, C.KeyPressMask)
+	C.XSelectInput(s.display, s.root, C.KeyPressMask|C.KeyReleaseMask)
 	C.XFlush(s.display)
 
 	return x11HotkeyBinding{keycode: C.int(keycode), modifiers: modifiers}, nil
@@ -236,11 +238,25 @@ func (m *Manager) ensureX11State() (*x11HotkeyState, error) {
 		)
 	}
 
+	// A held key is otherwise reported as release/press pairs at the server's
+	// autorepeat rate, and every one of those releases would end the hold.
+	// With detectable autorepeat the hold is further KeyPress events and one
+	// KeyRelease when the key comes up, which is the edge the binder repeats
+	// on. Per connection, so the in-mode tap asks for the same on its own
+	// (platform/linux/x11_eventtap.c).
+	if C.neru_hotkeys_set_detectable_autorepeat(display) == 0 {
+		m.logger.Warn(
+			"X server does not support detectable autorepeat; a held global hotkey " +
+				"fires once instead of repeating",
+		)
+	}
+
 	state := &x11HotkeyState{
 		display:  display,
 		root:     C.neru_hotkeys_root_window(display),
 		bindings: make(map[ports.HotkeyID]x11HotkeyBinding),
 		ids:      make(map[string]ports.HotkeyID),
+		held:     make(x11HeldHotkeys),
 		stopCh:   make(chan struct{}),
 		doneCh:   make(chan struct{}),
 	}
@@ -273,30 +289,47 @@ func (m *Manager) runX11HotkeyLoop(state *x11HotkeyState) {
 			continue
 		}
 
-		if C.neru_xevent_type(&event) != C.KeyPress {
-			continue
-		}
-
 		keycode := C.neru_xkey_keycode(&event)
-		modifiers := C.neru_xkey_state(&event) &^ (C.Mod2Mask | C.LockMask)
 
-		// Hold m.mu while reading state.ids — Register/Unregister write
-		// to this map under the same lock, so an unguarded read here is a
-		// concurrent map read/write (runtime crash under the race detector).
-		// We also fetch the callback in the same critical section to avoid
-		// a second lock acquisition via callbackFor.
-		m.mu.RLock()
-		id, ok := state.ids[x11BindingKey(keycode, modifiers)]
+		switch C.neru_xevent_type(&event) {
+		case C.KeyPress:
+			modifiers := C.neru_xkey_state(&event) &^ (C.Mod2Mask | C.LockMask)
 
-		var callback ports.HotkeyCallback
-		if ok {
-			callback = m.callbacks[id]
-		}
+			// Hold m.mu while reading state.ids — Register/Unregister write
+			// to this map under the same lock, so an unguarded read here is a
+			// concurrent map read/write (runtime crash under the race
+			// detector). The callback is fetched in the same critical section
+			// to avoid a second lock acquisition.
+			m.mu.RLock()
+			hotkeyID, bound := state.ids[x11BindingKey(keycode, modifiers)]
 
-		m.mu.RUnlock()
+			var callbacks hotkeyCallbacks
+			if bound {
+				callbacks = m.callbacks[hotkeyID]
+			}
 
-		if callback != nil {
-			go callback()
+			m.mu.RUnlock()
+
+			if !bound || !state.held.press(uint32(keycode), hotkeyID) {
+				continue
+			}
+
+			if callbacks.press != nil {
+				go callbacks.press()
+			}
+		case C.KeyRelease:
+			hotkeyID, wasDown := state.held.release(uint32(keycode))
+			if !wasDown {
+				continue
+			}
+
+			m.mu.RLock()
+			release := m.callbacks[hotkeyID].release
+			m.mu.RUnlock()
+
+			if release != nil {
+				go release()
+			}
 		}
 	}
 }

--- a/internal/adapter/hotkeys/linux/x11_cgo.go
+++ b/internal/adapter/hotkeys/linux/x11_cgo.go
@@ -261,7 +261,7 @@ func (m *Manager) ensureX11State() (*x11HotkeyState, error) {
 		bindings: make(map[ports.HotkeyID]x11HotkeyBinding),
 		ids:      make(map[string]ports.HotkeyID),
 		held:     make(x11HeldHotkeys),
-		dispatch: eventtaplinux.NewHotkeyDispatcher(m.logger),
+		dispatch: eventtaplinux.NewHotkeyDispatcher(),
 		stopCh:   make(chan struct{}),
 		doneCh:   make(chan struct{}),
 	}

--- a/internal/adapter/hotkeys/linux/x11_display_lock_test.go
+++ b/internal/adapter/hotkeys/linux/x11_display_lock_test.go
@@ -46,6 +46,8 @@ var x11DisplayCalls = map[string]struct{}{
 	"XUngrabKey":               {},
 	"neru_hotkeys_pending":     {},
 	"neru_hotkeys_root_window": {},
+	// XkbSetDetectableAutoRepeat: a request on the connection.
+	"neru_hotkeys_set_detectable_autorepeat": {},
 }
 
 // x11ConnectionFreeCalls are the cgo calls that touch no connection: type
@@ -92,9 +94,10 @@ var x11DisplayLockCallees = map[string]string{
 // the lock, with the reason each is sound. An entry here is a claim that no
 // second goroutine can be inside the connection at that moment.
 var x11DisplayLockExemptions = map[string]string{
-	"ensureX11State": "opens the connection and reads the root window before " +
-		"the state is published to x11States and before the poll loop starts, " +
-		"so there is no second user of the connection yet and no lock to take",
+	"ensureX11State": "opens the connection, asks it for detectable autorepeat " +
+		"and reads the root window before the state is published to x11States " +
+		"and before the poll loop starts, so there is no second user of the " +
+		"connection yet and no lock to take",
 }
 
 // x11HotkeySourceFile is the only file in this package permitted to speak on

--- a/internal/adapter/hotkeys/linux/x11_held.go
+++ b/internal/adapter/hotkeys/linux/x11_held.go
@@ -1,0 +1,40 @@
+//go:build linux
+
+package linux
+
+import "github.com/y3owk1n/neru/internal/ports"
+
+// x11HeldHotkeys is the loop's record of which grabbed keys are down, by
+// keycode, so a hold is reported as one press and one release.
+//
+// Keyed by keycode alone, and not by the chord the grab named, because the
+// release has to be found when the modifier has already come up: the state on
+// that KeyRelease no longer spells the chord, and a lookup by chord would leave
+// the binder repeating a key nobody holds.
+type x11HeldHotkeys map[uint32]ports.HotkeyID
+
+// press records that a grabbed key went down and reports whether it is a new
+// hold. With detectable autorepeat the server reports a held key as further
+// KeyPress events with no release between; those answer false and fire nothing,
+// the way the macOS tap's `down` flag folds them.
+func (h x11HeldHotkeys) press(keycode uint32, id ports.HotkeyID) bool {
+	if _, down := h[keycode]; down {
+		return false
+	}
+
+	h[keycode] = id
+
+	return true
+}
+
+// release ends the hold on a keycode and returns the hotkey it belonged to.
+// A release for a key this never saw go down (held before the grab existed)
+// answers false.
+func (h x11HeldHotkeys) release(keycode uint32) (ports.HotkeyID, bool) {
+	id, down := h[keycode]
+	if down {
+		delete(h, keycode)
+	}
+
+	return id, down
+}

--- a/internal/adapter/hotkeys/linux/x11_held_test.go
+++ b/internal/adapter/hotkeys/linux/x11_held_test.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package linux
+
+import "testing"
+
+// A held hotkey reaches the binder as one press and one release. The server
+// reports the hold as repeated KeyPress events (detectable autorepeat), and
+// the release may arrive after the chord's modifier has come up.
+func TestX11HeldHotkeys_AHoldIsOnePressAndOneRelease(t *testing.T) {
+	t.Parallel()
+
+	const keycode = 47
+
+	held := x11HeldHotkeys{}
+
+	if !held.press(keycode, 1) {
+		t.Fatal("the first press was not reported as a new hold")
+	}
+
+	for range 3 {
+		if held.press(keycode, 1) {
+			t.Fatal(
+				"an autorepeat press was reported as a new hold; the binder would restart its repeat",
+			)
+		}
+	}
+
+	id, down := held.release(keycode)
+	if !down || id != 1 {
+		t.Fatalf("release = (%d, %v), want (1, true)", id, down)
+	}
+
+	if _, down := held.release(keycode); down {
+		t.Fatal("a second release found the key still down")
+	}
+
+	if !held.press(keycode, 1) {
+		t.Fatal("a press after the release was not a new hold")
+	}
+}

--- a/internal/adapter/hotkeys/windows/manager.go
+++ b/internal/adapter/hotkeys/windows/manager.go
@@ -46,10 +46,26 @@ func NewManager(logger *zap.Logger) *Manager {
 	}
 }
 
-// Register adds a new global hotkey.
+// Register adds a new global hotkey that fires callback once per press.
 func (m *Manager) Register(
 	keyString string,
 	callback ports.HotkeyCallback,
+) (ports.HotkeyID, error) {
+	return m.RegisterWithRelease(keyString, callback, nil)
+}
+
+// RegisterHotKey reports the press only; the registry finds the release by
+// polling the key's state while it is held (HotkeyRegistry.RegisterWithRelease).
+// The binder reaches this by type assertion, so a signature drift would
+// silently return every hotkey to press-only instead of failing to compile.
+var _ ports.HotkeyReleaseRegistrar = (*Manager)(nil)
+
+// RegisterWithRelease adds a new global hotkey with press and optional release
+// callbacks. A held chord is one press and one release, however long it is held.
+func (m *Manager) RegisterWithRelease(
+	keyString string,
+	pressCallback ports.HotkeyCallback,
+	releaseCallback ports.HotkeyCallback,
 ) (ports.HotkeyID, error) {
 	if m.registry == nil {
 		return 0, derrors.New(
@@ -64,12 +80,12 @@ func (m *Manager) Register(
 	hotkeyID := m.nextID
 	m.nextID++
 
-	nativeID, err := m.registry.Register(keyString, callback)
+	nativeID, err := m.registry.RegisterWithRelease(keyString, pressCallback, releaseCallback)
 	if err != nil {
 		return 0, derrors.Wrap(err, derrors.CodeHotkeyRegisterFailed, "failed to register hotkey")
 	}
 
-	m.callbacks[hotkeyID] = callback
+	m.callbacks[hotkeyID] = pressCallback
 	m.keys[hotkeyID] = keyString
 	m.nativeIDs[hotkeyID] = nativeID
 

--- a/internal/adapter/platform/linux/x11_eventtap.c
+++ b/internal/adapter/platform/linux/x11_eventtap.c
@@ -1,5 +1,6 @@
 #include "x11_eventtap.h"
 
+#include <X11/XKBlib.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/XTest.h>
@@ -8,6 +9,18 @@
 #include <string.h>
 
 Display *neru_eventtap_open(void) { return XOpenDisplay(NULL); }
+
+// A held key is otherwise reported as release/press pairs at the server's
+// autorepeat rate, and the tap turned each of those releases into a key-up
+// that ended the mode's own held repeat after its first tick. Detectable
+// autorepeat reports the hold as further KeyPress events and one KeyRelease,
+// so the key-up means the key came up. Per connection; the hotkey connection
+// asks for the same (x11_hotkeys.c). Returns 1 when the server honors it.
+int neru_eventtap_set_detectable_autorepeat(Display *display) {
+	Bool supported = False;
+	XkbSetDetectableAutoRepeat(display, True, &supported);
+	return supported ? 1 : 0;
+}
 
 void neru_eventtap_close(Display *display) {
 	if (display != NULL) {

--- a/internal/adapter/platform/linux/x11_eventtap.h
+++ b/internal/adapter/platform/linux/x11_eventtap.h
@@ -7,6 +7,7 @@
 
 Display *neru_eventtap_open(void);
 void neru_eventtap_close(Display *display);
+int neru_eventtap_set_detectable_autorepeat(Display *display);
 int neru_eventtap_grab_keyboard(Display *display);
 void neru_eventtap_ungrab_keyboard(Display *display);
 int neru_eventtap_pending(Display *display);

--- a/internal/adapter/platform/linux/x11_hotkeys.c
+++ b/internal/adapter/platform/linux/x11_hotkeys.c
@@ -1,10 +1,20 @@
 #include "x11_hotkeys.h"
 
+#include <X11/XKBlib.h>
 #include <X11/Xlib.h>
 #include <X11/keysym.h>
 #include <stdlib.h>
 
 Window neru_hotkeys_root_window(Display *display) { return RootWindow(display, DefaultScreen(display)); }
+
+// Asks the server to report a held key as repeated KeyPress events rather than
+// as release/press pairs. Returns 1 when the server honors it for this
+// connection, 0 otherwise.
+int neru_hotkeys_set_detectable_autorepeat(Display *display) {
+	Bool supported = False;
+	XkbSetDetectableAutoRepeat(display, True, &supported);
+	return supported ? 1 : 0;
+}
 
 int neru_hotkeys_pending(Display *display) { return XPending(display); }
 

--- a/internal/adapter/platform/linux/x11_hotkeys.h
+++ b/internal/adapter/platform/linux/x11_hotkeys.h
@@ -5,6 +5,7 @@
 #include <X11/Xutil.h>
 
 Window neru_hotkeys_root_window(Display *display);
+int neru_hotkeys_set_detectable_autorepeat(Display *display);
 int neru_hotkeys_pending(Display *display);
 int neru_xevent_type(XEvent *ev);
 unsigned int neru_xkey_keycode(XEvent *ev);

--- a/internal/adapter/platform/windows/hotkeys_native.go
+++ b/internal/adapter/platform/windows/hotkeys_native.go
@@ -18,6 +18,11 @@ import (
 const (
 	wmHotkey = 0x0312
 
+	// modNoRepeat is MOD_NOREPEAT: one WM_HOTKEY per press, however long the
+	// key is held, instead of one per autorepeat. The hold is reported by the
+	// release watcher instead, the way the macOS tap folds autorepeat.
+	modNoRepeat = 0x4000
+
 	hotkeyPollInterval   = 10 * time.Millisecond
 	hotkeyThreadReadyTTL = 2 * time.Second
 )
@@ -34,11 +39,18 @@ type hotkeyRegistration struct {
 	virtualKey uint32
 }
 
+// hotkeyCallbacks is what one registration fires: press on WM_HOTKEY, and
+// release (nil for Register) once the key reads up after it.
+type hotkeyCallbacks struct {
+	press   func()
+	release func()
+}
+
 type hotkeyRegisterRequest struct {
 	keyString  string
 	modifiers  uint32
 	virtualKey uint32
-	callback   func()
+	callbacks  hotkeyCallbacks
 	resp       chan hotkeyRegisterResponse
 }
 
@@ -53,8 +65,15 @@ type hotkeyUnregisterRequest struct {
 
 // HotkeyRegistry manages RegisterHotKey bindings on a dedicated message thread.
 type HotkeyRegistry struct {
-	mu           sync.Mutex
-	callbacks    map[int]func()
+	mu        sync.Mutex
+	callbacks map[int]hotkeyCallbacks
+	// held is the stop channel of the release watcher for each hotkey whose
+	// key is down, by registry id. A WM_HOTKEY for an id already here is the
+	// key still held and fires nothing.
+	held map[int]chan struct{}
+	// keyDown reads whether a virtual key is down right now; a test stands in
+	// for GetAsyncKeyState here.
+	keyDown      func(vk uint32) bool
 	threadDone   chan struct{}
 	threadStop   chan struct{}
 	registered   map[int]hotkeyRegistration
@@ -81,7 +100,9 @@ var (
 func GlobalHotkeyRegistry() (*HotkeyRegistry, error) {
 	globalHotkeyOnce.Do(func() {
 		registry := &HotkeyRegistry{
-			callbacks:    make(map[int]func()),
+			callbacks:    make(map[int]hotkeyCallbacks),
+			held:         make(map[int]chan struct{}),
+			keyDown:      isVirtualKeyDown,
 			registered:   make(map[int]hotkeyRegistration),
 			threadStop:   make(chan struct{}),
 			threadDone:   make(chan struct{}),
@@ -115,7 +136,21 @@ func (r *HotkeyRegistry) SetHotkeyRegistryLogger(logger *zap.Logger) {
 
 // Register binds a hotkey string to a callback and returns a registry id.
 func (r *HotkeyRegistry) Register(keyString string, callback func()) (int, error) {
-	if callback == nil {
+	return r.RegisterWithRelease(keyString, callback, nil)
+}
+
+// RegisterWithRelease binds a hotkey string to a press callback and an optional
+// release callback, and returns a registry id.
+//
+// RegisterHotKey reports the press only, so the release is found by reading
+// the key's state (GetAsyncKeyState) every hotkeyPollInterval from the
+// WM_HOTKEY until it reads up. The poll runs only while a hotkey is held, which
+// is why it is preferred over the other source of releases, the WH_KEYBOARD_LL
+// hook: that hook sits on every keystroke for as long as it is installed, and
+// installing it for the daemon's lifetime would put a hook procedure on the
+// idle path to pay for a release that only a held hotkey needs.
+func (r *HotkeyRegistry) RegisterWithRelease(keyString string, press, release func()) (int, error) {
+	if press == nil {
 		return 0, errHotkeyCallbackNil
 	}
 
@@ -135,7 +170,7 @@ func (r *HotkeyRegistry) Register(keyString string, callback func()) (int, error
 		keyString:  keyString,
 		modifiers:  mods,
 		virtualKey: virtualKey,
-		callback:   callback,
+		callbacks:  hotkeyCallbacks{press: press, release: release},
 		resp:       resp,
 	}
 
@@ -243,7 +278,7 @@ func (r *HotkeyRegistry) handleRegister(req hotkeyRegisterRequest) {
 	ret, _, regErr := procRegisterHotKey.Call(
 		0,
 		uintptr(hotkeyID),
-		uintptr(req.modifiers),
+		uintptr(req.modifiers|modNoRepeat),
 		uintptr(req.virtualKey),
 	)
 	if ret == 0 {
@@ -262,7 +297,7 @@ func (r *HotkeyRegistry) handleRegister(req hotkeyRegisterRequest) {
 		return
 	}
 
-	r.callbacks[hotkeyID] = req.callback
+	r.callbacks[hotkeyID] = req.callbacks
 	r.registered[hotkeyID] = hotkeyRegistration{
 		id:         hotkeyID,
 		keyString:  req.keyString,
@@ -288,25 +323,89 @@ func (r *HotkeyRegistry) handleUnregister(req hotkeyUnregisterRequest) {
 	discardCall(procUnregisterHotKey.Call(0, uintptr(req.id)))
 	delete(r.callbacks, req.id)
 	delete(r.registered, req.id)
+
+	// A hotkey unregistered while held owes no release: the binder stops every
+	// repeat before it unregisters.
+	if stop, held := r.held[req.id]; held {
+		close(stop)
+		delete(r.held, req.id)
+	}
 }
 
 func (r *HotkeyRegistry) handleHotkeyMessage(hotkeyID int) {
 	r.mu.Lock()
 	reg, hasReg := r.registered[hotkeyID]
-	callback := r.callbacks[hotkeyID]
+	callbacks := r.callbacks[hotkeyID]
+	_, held := r.held[hotkeyID]
+
+	var stop chan struct{}
+
+	if hasReg && !held && callbacks.release != nil {
+		stop = make(chan struct{})
+		r.held[hotkeyID] = stop
+	}
 	r.mu.Unlock()
 
-	if hasReg {
-		r.logger.Info(
-			"WM_HOTKEY received",
-			zap.String("key", reg.keyString),
-			zap.Int("id", hotkeyID),
-		)
-	} else {
+	if !hasReg {
 		r.logger.Warn("WM_HOTKEY received for unknown id", zap.Int("id", hotkeyID))
+
+		return
 	}
 
-	if callback != nil {
-		callback()
+	r.logger.Debug(
+		"WM_HOTKEY received",
+		zap.String("key", reg.keyString),
+		zap.Int("id", hotkeyID),
+	)
+
+	// The key is still down from the press that started the watcher, so this
+	// is an autorepeat MOD_NOREPEAT did not fold, and the hold is already
+	// being reported.
+	if held {
+		return
+	}
+
+	if callbacks.press != nil {
+		callbacks.press()
+	}
+
+	if stop != nil {
+		go r.watchRelease(hotkeyID, reg.virtualKey, stop, callbacks.release)
+	}
+}
+
+// watchRelease reads the key every hotkeyPollInterval until it is up, then
+// fires release, unless stop closes first (the hotkey was unregistered).
+func (r *HotkeyRegistry) watchRelease(
+	hotkeyID int,
+	virtualKey uint32,
+	stop chan struct{},
+	release func(),
+) {
+	ticker := time.NewTicker(hotkeyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+		}
+
+		if r.keyDown(virtualKey) {
+			continue
+		}
+
+		// The hold ends under the lock before release runs, so the next
+		// press's WM_HOTKEY finds the id free.
+		r.mu.Lock()
+		if r.held[hotkeyID] == stop {
+			delete(r.held, hotkeyID)
+		}
+		r.mu.Unlock()
+
+		release()
+
+		return
 	}
 }

--- a/internal/adapter/platform/windows/hotkeys_native.go
+++ b/internal/adapter/platform/windows/hotkeys_native.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -63,14 +64,26 @@ type hotkeyUnregisterRequest struct {
 	id int
 }
 
+// hotkeyHold is one press's release watcher. released is set the moment the
+// key reads up, and done is closed once the release callback has run (or the
+// watcher was stopped), so a WM_HOTKEY that arrives between the two is told
+// apart from an autorepeat and waits for the release to land before it is a
+// new press: delivered the other way round, the stale release would cancel the
+// repeat the new press had just started.
+type hotkeyHold struct {
+	stop     chan struct{}
+	done     chan struct{}
+	released atomic.Bool
+}
+
 // HotkeyRegistry manages RegisterHotKey bindings on a dedicated message thread.
 type HotkeyRegistry struct {
 	mu        sync.Mutex
 	callbacks map[int]hotkeyCallbacks
-	// held is the stop channel of the release watcher for each hotkey whose
-	// key is down, by registry id. A WM_HOTKEY for an id already here is the
-	// key still held and fires nothing.
-	held map[int]chan struct{}
+	// held is the release watcher for each hotkey whose key is down, by
+	// registry id. A WM_HOTKEY for an id already here is the key still held
+	// and fires nothing.
+	held map[int]*hotkeyHold
 	// keyDown reads whether a virtual key is down right now; a test stands in
 	// for GetAsyncKeyState here.
 	keyDown      func(vk uint32) bool
@@ -101,7 +114,7 @@ func GlobalHotkeyRegistry() (*HotkeyRegistry, error) {
 	globalHotkeyOnce.Do(func() {
 		registry := &HotkeyRegistry{
 			callbacks:    make(map[int]hotkeyCallbacks),
-			held:         make(map[int]chan struct{}),
+			held:         make(map[int]*hotkeyHold),
 			keyDown:      isVirtualKeyDown,
 			registered:   make(map[int]hotkeyRegistration),
 			threadStop:   make(chan struct{}),
@@ -326,8 +339,8 @@ func (r *HotkeyRegistry) handleUnregister(req hotkeyUnregisterRequest) {
 
 	// A hotkey unregistered while held owes no release: the binder stops every
 	// repeat before it unregisters.
-	if stop, held := r.held[req.id]; held {
-		close(stop)
+	if hold, held := r.held[req.id]; held {
+		close(hold.stop)
 		delete(r.held, req.id)
 	}
 }
@@ -336,14 +349,7 @@ func (r *HotkeyRegistry) handleHotkeyMessage(hotkeyID int) {
 	r.mu.Lock()
 	reg, hasReg := r.registered[hotkeyID]
 	callbacks := r.callbacks[hotkeyID]
-	_, held := r.held[hotkeyID]
-
-	var stop chan struct{}
-
-	if hasReg && !held && callbacks.release != nil {
-		stop = make(chan struct{})
-		r.held[hotkeyID] = stop
-	}
+	previous, held := r.held[hotkeyID]
 	r.mu.Unlock()
 
 	if !hasReg {
@@ -358,36 +364,55 @@ func (r *HotkeyRegistry) handleHotkeyMessage(hotkeyID int) {
 		zap.Int("id", hotkeyID),
 	)
 
-	// The key is still down from the press that started the watcher, so this
-	// is an autorepeat MOD_NOREPEAT did not fold, and the hold is already
-	// being reported.
 	if held {
-		return
+		// The key is still down from the press that started the watcher, so
+		// this is an autorepeat MOD_NOREPEAT did not fold, and the hold is
+		// already being reported.
+		if !previous.released.Load() {
+			return
+		}
+
+		// The key came up and went down again while its release was being
+		// delivered. The release lands first.
+		<-previous.done
+	}
+
+	var hold *hotkeyHold
+
+	if callbacks.release != nil {
+		hold = &hotkeyHold{stop: make(chan struct{}), done: make(chan struct{})}
+
+		r.mu.Lock()
+		r.held[hotkeyID] = hold
+		r.mu.Unlock()
 	}
 
 	if callbacks.press != nil {
 		callbacks.press()
 	}
 
-	if stop != nil {
-		go r.watchRelease(hotkeyID, reg.virtualKey, stop, callbacks.release)
+	if hold != nil {
+		go r.watchRelease(hotkeyID, reg.virtualKey, hold, callbacks.release)
 	}
 }
 
 // watchRelease reads the key every hotkeyPollInterval until it is up, then
-// fires release, unless stop closes first (the hotkey was unregistered).
+// fires release, unless the hold is stopped first (the hotkey was
+// unregistered).
 func (r *HotkeyRegistry) watchRelease(
 	hotkeyID int,
 	virtualKey uint32,
-	stop chan struct{},
+	hold *hotkeyHold,
 	release func(),
 ) {
+	defer close(hold.done)
+
 	ticker := time.NewTicker(hotkeyPollInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-stop:
+		case <-hold.stop:
 			return
 		case <-ticker.C:
 		}
@@ -396,15 +421,14 @@ func (r *HotkeyRegistry) watchRelease(
 			continue
 		}
 
-		// The hold ends under the lock before release runs, so the next
-		// press's WM_HOTKEY finds the id free.
+		hold.released.Store(true)
+		release()
+
 		r.mu.Lock()
-		if r.held[hotkeyID] == stop {
+		if r.held[hotkeyID] == hold {
 			delete(r.held, hotkeyID)
 		}
 		r.mu.Unlock()
-
-		release()
 
 		return
 	}

--- a/internal/adapter/platform/windows/hotkeys_native_test.go
+++ b/internal/adapter/platform/windows/hotkeys_native_test.go
@@ -1,0 +1,75 @@
+//go:build windows
+
+package windows
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// A held hotkey reaches the binder as one press and one release, which is what
+// lets it repeat the binding while the key is down. RegisterHotKey reports the
+// press only, so the release is read from the key's state after it.
+func TestHotkeyRegistry_AHeldHotkeyIsOnePressAndOneRelease(t *testing.T) {
+	t.Parallel()
+
+	const (
+		hotkeyID   = 1
+		virtualKey = 0x47
+	)
+
+	// The key reads down for the first two polls and up from the third.
+	polls := 0
+	registry := &HotkeyRegistry{
+		callbacks:  make(map[int]hotkeyCallbacks),
+		held:       make(map[int]chan struct{}),
+		registered: make(map[int]hotkeyRegistration),
+		logger:     zap.NewNop(),
+		keyDown: func(uint32) bool {
+			polls++
+
+			return polls <= 2
+		},
+	}
+
+	pressed := make(chan struct{}, 4)
+	released := make(chan struct{}, 4)
+
+	registry.registered[hotkeyID] = hotkeyRegistration{id: hotkeyID, virtualKey: virtualKey}
+	registry.callbacks[hotkeyID] = hotkeyCallbacks{
+		press:   func() { pressed <- struct{}{} },
+		release: func() { released <- struct{}{} },
+	}
+
+	registry.handleHotkeyMessage(hotkeyID)
+	// The autorepeat WM_HOTKEY of a key still held.
+	registry.handleHotkeyMessage(hotkeyID)
+
+	select {
+	case <-pressed:
+	default:
+		t.Fatal("the press did not fire")
+	}
+
+	select {
+	case <-pressed:
+		t.Fatal("a WM_HOTKEY while held fired the press again; the binder would restart its repeat")
+	default:
+	}
+
+	select {
+	case <-released:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the key read up and no release fired; the binder would repeat forever")
+	}
+
+	registry.mu.Lock()
+	_, held := registry.held[hotkeyID]
+	registry.mu.Unlock()
+
+	if held {
+		t.Fatal("the hold is still recorded after the release; the next press would fire nothing")
+	}
+}

--- a/internal/adapter/platform/windows/hotkeys_native_test.go
+++ b/internal/adapter/platform/windows/hotkeys_native_test.go
@@ -24,7 +24,7 @@ func TestHotkeyRegistry_AHeldHotkeyIsOnePressAndOneRelease(t *testing.T) {
 	polls := 0
 	registry := &HotkeyRegistry{
 		callbacks:  make(map[int]hotkeyCallbacks),
-		held:       make(map[int]chan struct{}),
+		held:       make(map[int]*hotkeyHold),
 		registered: make(map[int]hotkeyRegistration),
 		logger:     zap.NewNop(),
 		keyDown: func(uint32) bool {
@@ -65,11 +65,12 @@ func TestHotkeyRegistry_AHeldHotkeyIsOnePressAndOneRelease(t *testing.T) {
 		t.Fatal("the key read up and no release fired; the binder would repeat forever")
 	}
 
-	registry.mu.Lock()
-	_, held := registry.held[hotkeyID]
-	registry.mu.Unlock()
+	// The next press is a new hold, however soon it follows the release.
+	registry.handleHotkeyMessage(hotkeyID)
 
-	if held {
-		t.Fatal("the hold is still recorded after the release; the next press would fire nothing")
+	select {
+	case <-pressed:
+	default:
+		t.Fatal("a press after the release fired nothing")
 	}
 }

--- a/internal/app/keybinding/binder.go
+++ b/internal/app/keybinding/binder.go
@@ -100,9 +100,10 @@ func (b *Binder) registerHotkeys(bundleID string) {
 				},
 			)
 		} else {
-			// Backend without release events (currently Windows and Linux): held-key
-			// repeat is not possible, so a single mode-aware dispatch is the whole
-			// behavior.
+			// Backend without release events: held-key repeat is not possible, so
+			// a single mode-aware dispatch is the whole behavior. Every shipped
+			// manager reports releases; this is the fallback the port's optional
+			// extension rules require.
 			_, registerHotkeyErr = b.hotkeyManager.Register(bindKey, func() {
 				b.dispatchModeAwareHotkeyAsync(bindKey, bindActions)
 			})

--- a/internal/ports/hotkeys.go
+++ b/internal/ports/hotkeys.go
@@ -38,9 +38,13 @@ type HotkeyPort interface {
 //
 // The rules for optional extensions are in system.go and apply here too.
 //
-// Implemented by the macOS manager, whose per-hotkey CGEventTaps see both
-// edges. X11's XGrabKey and Win32's RegisterHotKey deliver press only, so those
-// backends do not implement it.
+// Implemented by all three managers, each from a different source: the macOS
+// per-hotkey CGEventTaps see both edges; on Linux the evdev proxy reads every
+// release and an XGrabKey delivers KeyRelease to the grabbing client; Win32's
+// RegisterHotKey reports the press only, so the Windows manager polls the
+// key's state while it is held. A hold is one press and one release however
+// long it lasts — autorepeat fires nothing — which is what held-key repeat
+// ([held_repeat]) is built on.
 //
 // Callers must fall back to Register — a press-only binding is a working
 // binding; only hold-to-activate behavior is lost.


### PR DESCRIPTION
## Description

This PR makes a held global hotkey repeat its action on Linux and Windows the way it already does on macOS. With `[held_repeat]` enabled, holding a `[hotkeys]` chord bound to a scroll, page, relative mouse move or cell move now repeats it at `interval_ms` after `initial_delay_ms`, with acceleration, on X11, on Wayland and on Windows. Before, both platforms ran the binding once per press and the seven `held_repeat.*` options were declared to work there without doing anything.

It also fixes in-mode held repeat on X11, which stopped after its first tick: the X server reported a held key as release/press pairs at its own autorepeat rate, and every one of those releases ended the repeat. Both X11 connections now ask for detectable autorepeat, so a key-up means the key came up.

## Related Issues

Closes #1608

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, the no-cgo Wayland listener stub keeps its existing loud `Start`; only its binding setter's signature changed
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, ran the targeted equivalent: `just fmt-check`, `just lint`, `just lint-cross` (Linux cgo and Windows golangci-lint in the CI container), `just check-cross`, `go build ./...`, `go vet` on the touched trees, the touched Linux packages' tests in the CI container with cgo on, and the host tests for keybinding, ports, config and architecture
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

Every hotkey manager now reports a hold as exactly one press and one release, however long it lasts, which is the contract the macOS per-hotkey tap already kept by folding autorepeat. Where each platform finds the release:

- **Wayland.** The evdev proxy already saw every release; the matcher now remembers which key's press matched a chord and fires the release when that key comes up, whether or not the modifier is still down by then.
- **X11.** A passive `XGrabKey` becomes an active grab on the press, and the release is reported to the grabbing client. The hotkey loop tracks held keycodes so autorepeat presses fire nothing, and looks the release up by keycode alone so a modifier released first does not lose it. If the server refuses detectable autorepeat (none since XKB), Neru warns once and a held hotkey fires once.
- **Windows.** `RegisterHotKey` reports the press only. The registry now registers with `MOD_NOREPEAT` and, from the `WM_HOTKEY`, reads the key through `GetAsyncKeyState` every 10 ms until it reads up. The poll runs only while a hotkey is held. The alternative, keeping the `WH_KEYBOARD_LL` hook installed for the daemon's lifetime, would put a hook procedure on every keystroke on the idle path to pay for a release only a held hotkey needs, which the latency rule argues against. A hotkey unregistered while held stops its poll without firing, since the binder cancels every repeat before it unregisters.

Side effect on Windows worth knowing: with `MOD_NOREPEAT`, holding a global hotkey that is not held-repeatable (a mode toggle, say) now fires it once rather than at the OS autorepeat rate, matching macOS and Linux. The per-keypress `WM_HOTKEY received` line also moved from info to debug.

Not manually tested on real X11, Wayland or Windows desktops; the release edge on each is pinned by a unit test that drives the matcher, the held-key tracker and the poll directly.
