### PR TITLE
fix(windows): stop the grid cells reappearing behind an open subgrid

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -782,7 +782,7 @@ discovery rather than the mode itself.
 | **Hints**         | Label arrow / tail             | ✅ NSBezierPath            | ✅ Cairo triangle          | ✅ sampled triangle, see below |
 | **Hints**         | Label placement                | ✅ top / center / bottom   | ✅ top / center / bottom   | ✅ top / center / bottom   |
 | **Grid**          | Virtual pointer indicator      | ✅                         | ✅                         | ✅                          |
-| **Grid**          | What an open subgrid shows     | ✅ the subgrid alone       | ✅ the subgrid alone       | ⚠️ the parent cells return under it on the next repaint |
+| **Grid**          | What an open subgrid shows     | ✅ the subgrid alone       | ✅ the subgrid alone       | ✅ the subgrid alone       |
 | **Recursive grid**| Transition animation           | ✅                         | ✅                         | ✅                          |
 | **Recursive grid**| Virtual pointer indicator      | ✅                         | ✅                         | ✅                          |
 | **Recursive grid**| Sub-key preview                | ✅ mini-grid of next keys  | ✅ mini-grid of next keys  | ✅ mini-grid of next keys   |

--- a/internal/adapter/overlay/windows/overlay.go
+++ b/internal/adapter/overlay/windows/overlay.go
@@ -308,7 +308,7 @@ func (o *winOverlay) ShowSubgrid(
 
 	o.currentSubgrid = cell
 	o.gridPointer = pointer
-	o.repaintSubgrid()
+	o.redrawGrid()
 }
 
 // SetGridPointer records where grid mode's pointer stand-in belongs and
@@ -321,11 +321,6 @@ func (o *winOverlay) ShowSubgrid(
 // repainted. The record is kept even when nothing can be painted yet, for the
 // same reason UpdateGridMatches keeps its prefix while the window is hidden:
 // the next Show reads it.
-//
-// With a subgrid open, the repaint is the subgrid's own: a full grid redraw
-// here would put the parent cells back under it, which is the repaint
-// docs/CROSS_PLATFORM.md already reports for a narrowing keystroke and one
-// this call has no reason to add to.
 func (o *winOverlay) SetGridPointer(pointer recursivegridcomponent.VirtualPointerState) {
 	if o == nil || pointer == o.gridPointer {
 		return
@@ -334,12 +329,6 @@ func (o *winOverlay) SetGridPointer(pointer recursivegridcomponent.VirtualPointe
 	o.gridPointer = pointer
 
 	if o.cachedGrid == nil || o.suppressDraw || o.window == nil || !o.window.Visible() {
-		return
-	}
-
-	if o.currentSubgrid != nil {
-		o.repaintSubgrid()
-
 		return
 	}
 
@@ -453,6 +442,21 @@ func (o *winOverlay) backendName() string {
 	return o.window.Backend()
 }
 
+// redrawGrid paints the grid surface as it currently stands, which is either
+// the subgrid one cell was opened into or the cells themselves, with the
+// pointer stand-in on whichever it is. It is the only answer to "what does
+// this surface show", so the open, a narrowing keystroke, a pointer move and
+// the hide-unmatched toggle's next repaint all arrive at the same screen.
+//
+// The subgrid is the whole surface while one is open (#1491, #1610). macOS
+// settles that: its ShowSubgrid (adapter/overlay/render/grid/overlay_darwin.go)
+// clears the overlay window and hands NeruDrawGridCells the nine subgrid cells,
+// and that bridge replaces the view's cell array rather than adding to it, so
+// the parent cells leave the reference platform's overlay for as long as the
+// subgrid is up. Linux agrees since #1491. The guard lives here rather than at
+// each caller because every repaint reaches this: a narrowing keystroke that
+// put the parent cells back under the subgrid changed what was on screen
+// without the user asking for it.
 func (o *winOverlay) redrawGrid() {
 	o.redrawGridWithoutFlush()
 	o.flushOverlay("grid")
@@ -481,6 +485,27 @@ func (o *winOverlay) redrawGridWithoutFlush() {
 
 	o.Clear()
 
+	if o.currentSubgrid != nil {
+		o.drawSubgrid(o.currentSubgrid.Bounds(), o.cachedStyle)
+	} else {
+		o.drawGridCells()
+	}
+
+	o.drawGridPointer(o.gridPointer)
+
+	if o.logger != nil {
+		o.logger.Debug(
+			"redraw complete",
+			zap.Int("cells", len(o.cachedGrid.AllCells())),
+			zap.Bool("subgrid", o.currentSubgrid != nil),
+			zap.Bool("healthy", o.window.Healthy()),
+		)
+	}
+}
+
+// drawGridCells paints every cell of the cached grid, marked against the
+// prefix typed so far and thinned by hide-unmatched.
+func (o *winOverlay) drawGridCells() {
 	style := o.cachedStyle
 	prefix := o.currentPrefix
 
@@ -515,20 +540,6 @@ func (o *winOverlay) redrawGridWithoutFlush() {
 			)
 		}
 	}
-
-	if o.currentSubgrid != nil {
-		o.drawSubgrid(o.currentSubgrid.Bounds(), style)
-	}
-
-	o.drawGridPointer(o.gridPointer)
-
-	if o.logger != nil {
-		o.logger.Debug(
-			"redraw complete",
-			zap.Int("cells", len(o.cachedGrid.AllCells())),
-			zap.Bool("healthy", o.window.Healthy()),
-		)
-	}
 }
 
 func (o *winOverlay) flushOverlay(context string) {
@@ -550,17 +561,10 @@ func (o *winOverlay) flushOverlay(context string) {
 	}
 }
 
-// repaintSubgrid paints the open subgrid and the pointer on it as the whole
-// surface (#1491). The keys it draws with were handed over by the manager
-// when the subgrid was opened, and the surface has not been rebuilt since:
-// only a manager draw rebuilds it, and every one of those syncs the keys.
-func (o *winOverlay) repaintSubgrid() {
-	o.Clear()
-	o.drawSubgrid(o.currentSubgrid.Bounds(), o.cachedStyle)
-	o.drawGridPointer(o.gridPointer)
-	o.flushOverlay("subgrid")
-}
-
+// drawSubgrid paints the finer grid inside one cell. The keys it draws with
+// were handed over by the manager when the subgrid was opened, and the
+// surface has not been rebuilt since: only a manager draw rebuilds it, and
+// every one of those syncs the keys.
 func (o *winOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Style) {
 	// The keys the subgrid is drawn with, which are the keys the mode layer
 	// selects on (internal/domain/grid/subgrid_keys.go).

--- a/internal/adapter/overlay/windows/overlay.go
+++ b/internal/adapter/overlay/windows/overlay.go
@@ -10,6 +10,7 @@ import (
 	"unsafe"
 
 	"go.uber.org/zap"
+	"golang.org/x/sys/windows"
 
 	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
 	gridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
@@ -26,8 +27,40 @@ const (
 	winSubgridFontScale = 0.7
 )
 
+// overlayWindow is the surface the grid overlay paints on: what winOverlay
+// asks of a winplatform.OverlayWindow, and nothing it does not. The concrete
+// window is the one implementation that ships; the tests in this package
+// stand a recording one in for it, because reaching the drawing code through
+// the real type means creating a layered HWND on an interactive desktop.
+type overlayWindow interface {
+	HWND() windows.HWND
+	Healthy() bool
+	Visible() bool
+	Bounds() image.Rectangle
+	Backend() string
+	Show()
+	Hide()
+	Clear()
+	ResizeToActiveScreen() error
+	Destroy()
+	FillRect(bounds image.Rectangle, color uint32)
+	StrokeRect(bounds image.Rectangle, color uint32, lineWidth float64)
+	FillRoundedRect(bounds image.Rectangle, radius float64, color uint32)
+	StrokeRoundedRect(bounds image.Rectangle, radius float64, color uint32, lineWidth float64)
+	FillTriangle(vertexA, vertexB, vertexC image.Point, color uint32)
+	DrawTextCentered(
+		text string,
+		bounds image.Rectangle,
+		fontFamily string,
+		fontSize float64,
+		color uint32,
+	)
+	DrawPointerGlyph(center image.Point, size int, char string, fontFamily string, color uint32)
+	Flush() error
+}
+
 type winOverlay struct {
-	window *winplatform.OverlayWindow
+	window overlayWindow
 	logger *zap.Logger
 	// renderMu is the manager's lock, which every draw here runs under; the
 	// transition goroutine takes it per frame (transition.go).

--- a/internal/adapter/overlay/windows/subgrid_test.go
+++ b/internal/adapter/overlay/windows/subgrid_test.go
@@ -1,0 +1,252 @@
+//go:build windows
+
+package windows
+
+import (
+	"image"
+	"slices"
+	"testing"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/windows"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+	gridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
+	recursivegridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/recursivegrid"
+	"github.com/y3owk1n/neru/internal/config"
+	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
+)
+
+// recordingWindow is an overlayWindow that paints nothing and remembers what
+// it was asked to paint. It stands in for the layered HWND so these tests need
+// no desktop, and it observes the grid overlay at the one boundary the window
+// sees. It is always healthy and on screen: every repaint under test is one
+// the real window would accept.
+type recordingWindow struct {
+	// texts is every string painted, in order, the pointer glyph included:
+	// the glyph is a label like any other on this surface, and a screen is
+	// the list of them.
+	texts []string
+	// rects is every rectangle filled or stroked, in order.
+	rects []image.Rectangle
+}
+
+func (w *recordingWindow) HWND() windows.HWND { return 0 }
+
+func (w *recordingWindow) Healthy() bool { return true }
+
+func (w *recordingWindow) Visible() bool { return true }
+
+func (w *recordingWindow) Bounds() image.Rectangle { return image.Rect(0, 0, 800, 600) }
+
+func (w *recordingWindow) Backend() string { return "recording" }
+
+func (w *recordingWindow) Show() {}
+
+func (w *recordingWindow) Hide() {}
+
+func (w *recordingWindow) Clear() {}
+
+func (w *recordingWindow) ResizeToActiveScreen() error { return nil }
+
+func (w *recordingWindow) Destroy() {}
+
+func (w *recordingWindow) FillRect(bounds image.Rectangle, _ uint32) {
+	w.rects = append(w.rects, bounds)
+}
+
+func (w *recordingWindow) StrokeRect(bounds image.Rectangle, _ uint32, _ float64) {
+	w.rects = append(w.rects, bounds)
+}
+
+func (w *recordingWindow) FillRoundedRect(bounds image.Rectangle, _ float64, _ uint32) {
+	w.rects = append(w.rects, bounds)
+}
+
+func (w *recordingWindow) StrokeRoundedRect(
+	bounds image.Rectangle,
+	_ float64,
+	_ uint32,
+	_ float64,
+) {
+	w.rects = append(w.rects, bounds)
+}
+
+func (w *recordingWindow) FillTriangle(_, _, _ image.Point, _ uint32) {}
+
+func (w *recordingWindow) DrawTextCentered(
+	text string,
+	_ image.Rectangle,
+	_ string,
+	_ float64,
+	_ uint32,
+) {
+	w.texts = append(w.texts, text)
+}
+
+func (w *recordingWindow) DrawPointerGlyph(_ image.Point, _ int, char string, _ string, _ uint32) {
+	w.texts = append(w.texts, char)
+}
+
+func (w *recordingWindow) Flush() error { return nil }
+
+// forget drops everything painted so far, so what a test asserts on is what
+// the call under test painted.
+func (w *recordingWindow) forget() {
+	w.texts = nil
+	w.rects = nil
+}
+
+// fixedTheme is a ThemeProvider that answers one mode.
+type fixedTheme bool
+
+func (t fixedTheme) IsDarkMode() bool { return bool(t) }
+
+// gridPointerAppearance is a pointer look no default could produce, so a draw
+// that reads it cannot be mistaken for a draw that fell back.
+var gridPointerAppearance = manager.PointerAppearance{
+	FillColor:  "#123456",
+	FontFamily: "Test Sans",
+	Char:       "✛",
+	FontSize:   20,
+}
+
+// subgridTestKeys is a key per cell of the subgrid every overlay draws. The
+// test below sets it on the surface directly because this manager is stood up
+// without render components, and a manager with none leaves the keys it was
+// last given alone (syncSublayerKeysLocked). The labels drawn from them are
+// upper-cased, as every grid label is.
+const subgridTestKeys = "abcdefghi"
+
+// gridPointerAt is the pointer standing at point, wearing the appearance above.
+func gridPointerAt(point image.Point) recursivegridcomponent.VirtualPointerState {
+	return recursivegridcomponent.VirtualPointerState{
+		Visible:   true,
+		Position:  point,
+		Size:      gridPointerAppearance.FontSize,
+		FillColor: gridPointerAppearance.FillColor,
+		Char:      gridPointerAppearance.Char,
+		FontName:  gridPointerAppearance.FontFamily,
+	}
+}
+
+// testGrid is a grid the size of the recording window, which is what a draw
+// and a subgrid open both take.
+func testGrid() *domainGrid.Grid {
+	return domainGrid.NewGrid("ab", image.Rect(0, 0, 800, 600), zap.NewNop())
+}
+
+// gridOnWindow stands a Manager up over a recording window, draws a labeled
+// grid on it and forgets everything that took, so what a test asserts on is
+// what the calls after it painted.
+func gridOnWindow(t *testing.T) (*Manager, *recordingWindow) {
+	t.Helper()
+
+	window := &recordingWindow{}
+	overlayManager := &Manager{Base: manager.NewBase(zap.NewNop())}
+	overlayManager.win = &winOverlay{window: window, renderMu: &overlayManager.renderMu}
+
+	style := gridcomponent.BuildStyle(config.DefaultConfig().Grid, fixedTheme(false))
+
+	err := overlayManager.DrawGrid(testGrid(), "", style)
+	if err != nil {
+		t.Fatalf("DrawGrid() error = %v", err)
+	}
+
+	window.forget()
+
+	return overlayManager, window
+}
+
+// TestWindowsOverlayManager_ShowSubgrid_IsWhatEveryRepaintAfterItDraws pins
+// what #1610 asks for, the way the Linux test of the same name pins #1491:
+// that the open shows the subgrid alone, which is the macOS answer, and that
+// every later repaint of the same surface shows exactly what the open left,
+// because nothing between them is anything the user typed. It used to hold
+// for the pointer's repaint and not for the narrowing one, which put the
+// parent cells back underneath the subgrid on the first keystroke after an
+// open, and hide-unmatched thinned those cells rather than removing them.
+//
+// wantSubgridOnly is a spelt-out screen, so an open that also drew the parent
+// cells fails even though every repaint after it agreed. Comparing the
+// rectangles themselves rather than counting them extends the second half to
+// geometry: a repaint that drew the subgrid somewhere else, or at another
+// size, fails too.
+func TestWindowsOverlayManager_ShowSubgrid_IsWhatEveryRepaintAfterItDraws(t *testing.T) {
+	t.Parallel()
+
+	// One label per subgridTestKeys character, and then the pointer stand-in
+	// that rides the same pass. A parent cell label ("AA" and its fifteen
+	// siblings) appearing anywhere in this list is the defect.
+	wantSubgridOnly := []string{
+		"A", "B", "C", "D", "E", "F", "G", "H", "I",
+		gridPointerAppearance.Char,
+	}
+
+	repaints := []struct {
+		name    string
+		repaint func(*Manager)
+	}{
+		{
+			name: "a narrowing keystroke",
+			repaint: func(overlayManager *Manager) {
+				overlayManager.UpdateGridMatches("a")
+			},
+		},
+		{
+			name: "the pointer moving",
+			repaint: func(overlayManager *Manager) {
+				overlayManager.DrawGridPointer(
+					manager.ModeGrid,
+					image.Pt(300, 300),
+					gridPointerAppearance,
+				)
+			},
+		},
+		{
+			// The toggle paints nothing by itself; the next repaint reads it.
+			name: "hide-unmatched toggled before a narrowing keystroke",
+			repaint: func(overlayManager *Manager) {
+				overlayManager.SetHideUnmatched(true)
+				overlayManager.UpdateGridMatches("a")
+			},
+		},
+	}
+
+	for _, testCase := range repaints {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			overlayManager, window := gridOnWindow(t)
+			overlayManager.win.sublayerKeys = subgridTestKeys
+
+			overlayManager.ShowSubgrid(
+				testGrid().AllCells()[0],
+				gridcomponent.Style{},
+				gridPointerAt(image.Pt(120, 240)),
+			)
+
+			opened := slices.Clone(window.texts)
+			openedRects := slices.Clone(window.rects)
+
+			if !slices.Equal(opened, wantSubgridOnly) {
+				t.Fatalf("the open painted %v, want %v, the subgrid and nothing under it",
+					opened, wantSubgridOnly)
+			}
+
+			window.forget()
+
+			testCase.repaint(overlayManager)
+
+			if !slices.Equal(window.texts, opened) {
+				t.Errorf("the repaint painted %v, want the %v the open left",
+					window.texts, opened)
+			}
+
+			if !slices.Equal(window.rects, openedRects) {
+				t.Errorf("the repaint drew %d rectangles, want the %d the open left, unmoved",
+					len(window.rects), len(openedRects))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes the main grid's cells reappearing behind an open subgrid on
Windows. Picking a cell showed the finer subgrid on its own, and the next
narrowing keystroke put every parent cell back underneath it, a screen the
user never asked for from a key that was supposed to change nothing. An open
subgrid is now the whole overlay for as long as it is open, whatever repaints
it: the open, a narrowing keystroke, a move of the pointer stand-in and the
next repaint after the hide-unmatched toggle all produce the same screen.

The reference behaviour is the one #1491 settled for Linux against macOS:
opening a subgrid on macOS clears the grid window and replaces its cell
array with the subgrid's nine cells, so nothing is behind an open subgrid
on the reference platform. Windows now agrees with both.

Deliberate limitation: this was written and gated on macOS, which cannot run
the Windows overlay package's tests. The new test compiles under
`just check-cross` here and runs on CI's `windows-latest` leg. It was not
run on a Windows desktop.

## Related Issues

Closes #1610

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) —
      every touched Go file is in the `//go:build windows` overlay package
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
      — N/A, the only import added is `golang.org/x/sys/windows`, in a
      windows-tagged file
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
      — N/A, no port method or capability changed
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [ ] `just ci` passes — not run in full; this change is small, so the
      targeted set ran instead: `just check-cross` (Windows vet plus every
      Windows test binary compiling), `golangci-lint` with `GOOS=windows` on
      the overlay package (clean), and `go test ./internal/architecture/`
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

**What changed structurally.** The Windows grid surface had two painters,
`redrawGrid` for the cells and `repaintSubgrid` for the subgrid, and the
narrowing keystroke used the wrong one. There is now one, `redrawGrid`,
which paints the subgrid alone while one is open and the cells otherwise,
with the pointer on either. `repaintSubgrid` is gone and `SetGridPointer`
no longer carries its own copy of the branch. Behaviour with no subgrid open
is untouched.

**The prefactor.** `winOverlay` held a concrete `*winplatform.OverlayWindow`,
so no unit test could reach the grid painting without a layered HWND on an
interactive desktop. The first commit puts an `overlayWindow` interface
between them, naming exactly the eighteen methods the overlay calls; the
shipped window satisfies it unchanged. That is what makes the test possible.

**The test.** `TestWindowsOverlayManager_ShowSubgrid_IsWhatEveryRepaintAfterItDraws`
mirrors the Linux test of the same shape. It pins that the open paints the
nine subgrid labels and the pointer and nothing else, then that a narrowing
keystroke, a pointer move, and a narrowing keystroke after the hide-unmatched
toggle each repaint exactly that, rectangles compared by geometry rather than
counted. Against `main` the narrowing and hide-unmatched subtests would fail
with the sixteen parent labels printed ahead of the nine subgrid ones, since
`UpdateGridMatches` went through the cell painter; the pointer subtest already
passed there, since #1492 routed it to the subgrid painter.

**One small behaviour change beside the fix.** `ShowSubgrid` now goes through
`redrawGrid`, which refuses to paint when no grid has been drawn and logs an
error. Before, it painted a subgrid with a zero style, which put nothing
visible on screen either. No caller opens a subgrid without a grid.

**Proposed `behaviours.md` entry.** With a subgrid open in grid mode, no
keystroke or pointer update brings the parent grid's cells back on any
platform; the subgrid is the whole overlay until it closes.
