### PR TITLE
docs(windows): app identity, the UIPI boundary and the stale vision clause

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -471,7 +471,7 @@ The `bundle_id` key selects which app an override applies to — for both `[[app
 
 On Linux, put the `WM_CLASS` or `app_id` in the `bundle_id` field. Matching is case-insensitive but exact — no globbing or partial matches.
 
-On Windows, put the executable path in the `bundle_id` field, and use a TOML literal string (`'C:\...'`) or double every backslash so the path survives parsing. The match is exact, so the same program installed somewhere else (a per-user install under `%LOCALAPPDATA%`, a portable copy) is a different identity and needs its own entry. Packaged apps from the Microsoft Store all present their window through `ApplicationFrameHost.exe`, so they share one identity and cannot be told apart today.
+On Windows, put the executable path in the `bundle_id` field, and use a TOML literal string (`'C:\...'`) or double every backslash so the path survives parsing. Matching is case-insensitive but otherwise exact, so the same program installed somewhere else (a per-user install under `%LOCALAPPDATA%`, a portable copy) is a different identity and needs its own entry. Packaged apps from the Microsoft Store all present their window through `ApplicationFrameHost.exe`, so they share one identity and cannot be told apart today.
 
 > **Heads up:** Linux identity strings vary by toolkit and distribution. GTK, Qt, Electron, and XWayland apps often report a `WM_CLASS`/`app_id` you would not guess (e.g. `Google-chrome`, `code`, `org.kde.konsole`). Always confirm with the commands above rather than assuming a reverse-DNS name.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -467,8 +467,11 @@ The `bundle_id` key selects which app an override applies to — for both `[[app
 | macOS | Bundle ID, reverse-DNS (e.g. `com.apple.Safari`) | `osascript -e 'id of app "Safari"'` |
 | Linux · X11 | Window `WM_CLASS` — the *class* field | `xprop WM_CLASS`, then click the window |
 | Linux · Wayland (wlroots: Sway/Hyprland/niri/COSMIC, and KWin/KDE) | Toplevel `app_id` | `swaymsg -t get_tree` (Sway), `hyprctl activewindow` (Hyprland), `niri msg windows` (niri), or your compositor's window inspector |
+| Windows | Full path of the focused window's executable (e.g. `C:\Program Files\Google\Chrome\Application\chrome.exe`) | Task Manager, Details tab, right-click the process, **Open file location**, or `(Get-Process chrome).Path` in PowerShell |
 
 On Linux, put the `WM_CLASS` or `app_id` in the `bundle_id` field. Matching is case-insensitive but exact — no globbing or partial matches.
+
+On Windows, put the executable path in the `bundle_id` field, and use a TOML literal string (`'C:\...'`) or double every backslash so the path survives parsing. The match is exact, so the same program installed somewhere else (a per-user install under `%LOCALAPPDATA%`, a portable copy) is a different identity and needs its own entry. Packaged apps from the Microsoft Store all present their window through `ApplicationFrameHost.exe`, so they share one identity and cannot be told apart today.
 
 > **Heads up:** Linux identity strings vary by toolkit and distribution. GTK, Qt, Electron, and XWayland apps often report a `WM_CLASS`/`app_id` you would not guess (e.g. `Google-chrome`, `code`, `org.kde.konsole`). Always confirm with the commands above rather than assuming a reverse-DNS name.
 
@@ -766,7 +769,7 @@ Explicit component colors override theme derivation. Omitted colors inherit from
 
 ## [hints]
 
-Labels clickable UI elements with short overlay labels. By default uses the platform accessibility tree (`axtree` strategy). Two screen-capture strategies exist for apps whose accessibility tree is too thin to hint from; both scan the focused window by default (`capture_scope` widens that to the whole screen), both add the system surfaces the `include_*` options ask for from the accessibility tree, and `vision` is not available on Windows, which has no text recognition engine yet:
+Labels clickable UI elements with short overlay labels. By default uses the platform accessibility tree (`axtree` strategy). Two screen-capture strategies exist for apps whose accessibility tree is too thin to hint from; both scan the focused window by default (`capture_scope` widens that to the whole screen), and both add the system surfaces the `include_*` options ask for from the accessibility tree:
 
 - `vision`: on-screen recognition. The Vision framework on macOS (text plus rectangles), tesseract OCR on Linux and `Windows.Media.Ocr` on Windows (text only). Detected text becomes the element's title, so hint search (`--search`) and `--split-word` work. Costs an ML or OCR pass per activation; Linux needs tesseract installed and Windows an OCR language pack.
 - `contour`: edge and contour analysis of the window pixels, an algorithm ported from [wl-kbptr](https://github.com/moverest/wl-kbptr). Finds anything with a visible outline (buttons, icons, toolbar items, text runs) in a few milliseconds with no external dependency. Elements carry no text, so search and word splitting do not apply, and `hints.vision.*` is not read.

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -1399,14 +1399,16 @@ COM bindings (via `x/sys/windows` or syscall) over CGO. Do not introduce
 additional Windows backend naming until there is a real reason.
 
 **Elevated windows are out of reach.** User Interface Privilege Isolation
-blocks `SendInput`, `SetCursorPos` and the `WH_KEYBOARD_LL` hook against a
-window running at a higher integrity level than the caller, and against the
-secure desktop a UAC prompt sits on. A Neru started from a normal shell, or by
-the task `neru services install` writes, therefore cannot click, move the
-cursor or see keystrokes while an elevated app (an installer, an admin
-terminal, Task Manager run as administrator) has focus. The global hotkey
-does not fire there, and a mode opened beforehand neither sees its keys nor
-lands its click. The remedy is to run Neru elevated too, and it costs
+stops `SendInput` from delivering to a window at a higher integrity level than
+the caller and withholds its keystrokes from the `WH_KEYBOARD_LL` hook, and the
+secure desktop a UAC prompt sits on is out of reach altogether. A Neru started
+from a normal shell, or by the task `neru services install` writes, still gets
+its global hotkeys (`RegisterHotKey` delivers them to Neru's own thread) and
+still moves the cursor (`SetCursorPos` is not subject to UIPI) while an
+elevated app (an installer, an admin terminal, Task Manager run as
+administrator) has focus, but the mode it opens cannot see the keys typed into
+it, which land in the elevated app instead, and every click, scroll and
+injected key is dropped. The remedy is to run Neru elevated too, and it costs
 something: the daemon then holds an administrator token while it watches every
 keystroke and screen element, the service task has to be edited to run with
 highest privileges since `neru services install` does not, and each manual

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -1398,6 +1398,20 @@ Stable. Prefer `*_windows.go` as the implementation slot and pure Go Win32 /
 COM bindings (via `x/sys/windows` or syscall) over CGO. Do not introduce
 additional Windows backend naming until there is a real reason.
 
+**Elevated windows are out of reach.** User Interface Privilege Isolation
+blocks `SendInput`, `SetCursorPos` and the `WH_KEYBOARD_LL` hook against a
+window running at a higher integrity level than the caller, and against the
+secure desktop a UAC prompt sits on. A Neru started from a normal shell, or by
+the task `neru services install` writes, therefore cannot click, move the
+cursor or see keystrokes while an elevated app (an installer, an admin
+terminal, Task Manager run as administrator) has focus. The global hotkey
+does not fire there, and a mode opened beforehand neither sees its keys nor
+lands its click. The remedy is to run Neru elevated too, and it costs
+something: the daemon then holds an administrator token while it watches every
+keystroke and screen element, the service task has to be edited to run with
+highest privileges since `neru services install` does not, and each manual
+launch asks for UAC consent. The secure desktop stays out of reach either way.
+
 **Smooth cursor animation on Windows** is the Linux animator's shape with
 `SetCursorPos` as the sink
 ([mouse_animator.go](../internal/adapter/platform/windows/mouse_animator.go)):


### PR DESCRIPTION
## Description

This PR fixes four places where the documentation said something the Windows build does not, found in the September parity audit.

The app-identity table now has a Windows row: `bundle_id` and `excluded_apps` match the focused window's full executable path, found through Task Manager or PowerShell. The prose says the match is exact, so a different install location is a different identity, that Store apps all share one identity through the application frame host and cannot be told apart yet, and how to write a backslash path in TOML. The hints introduction no longer claims the `vision` strategy is unavailable on Windows, which stopped being true when the Windows OCR engine landed. The Windows Model section gains one paragraph on the UIPI boundary: an unelevated Neru cannot click, move the cursor or see keys while an elevated app or a UAC prompt has focus, with the remedy of running Neru elevated and what that costs.

The ticket's fourth item, a Known Gaps entry for the grid subgrid repaint, is not needed: #1610 landed in #1622 and the Mode Coverage table already shows it fixed.

## Related Issues

Closes #1611

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, docs only
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule) — N/A, docs only
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, docs only
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`) — N/A, no code; `just fmt-check` passes
- [x] `just ci` passes — N/A, docs-only fast path: `just fmt-check`, `just lint` and `go test ./internal/architecture/` (the doc-link and doc-inventory guardrails) all pass on this host
- [x] Tests added/updated for new or changed functionality — N/A, docs only
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

The identity row describes what the Windows adapter already does: the path comes from the foreground window's process, so a packaged app's frame host is what it sees. The UIPI paragraph states the Win32 rule rather than anything Neru chose; the secure desktop stays out of reach even for an elevated Neru, and the paragraph says so.
