### PR TITLE
fix(hotkeys): bind Delete to the backspace key on Linux, as on macOS and Windows

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -359,6 +359,9 @@ right either way.
 | Navigation | `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown`, `Insert` (Linux and Windows only)   |
 | Function   | `F1`–`F24` (`F21`–`F24` on Linux and Windows only)                                                      |
 
+`Delete` and `Backspace` both name the backspace key, the one that erases to the
+left, on every platform. The forward-delete key has no hotkey name.
+
 See [CLI.md](CLI.md#neru-action-feed) for a full key reference with key codes and platform behavior.
 
 Multi-key sequences (e.g. `gg`, `ab`) are supported for per-mode hotkeys with a 500ms timeout.

--- a/internal/adapter/eventtap/linux/global_hotkey_cgo.go
+++ b/internal/adapter/eventtap/linux/global_hotkey_cgo.go
@@ -42,7 +42,7 @@ func NewGlobalHotkeyListener(logger *zap.Logger) *GlobalHotkeyListener {
 // press when the chord's key goes down, release (nil for none) when it comes
 // up. Safe to call before or after Start.
 func (l *GlobalHotkeyListener) SetBinding(chord string, press, release func()) {
-	signature := canonicalChordSignature(chord)
+	signature := canonicalBindingSignature(chord)
 	if signature == "" || press == nil {
 		return
 	}

--- a/internal/adapter/eventtap/linux/global_hotkey_keys.go
+++ b/internal/adapter/eventtap/linux/global_hotkey_keys.go
@@ -19,7 +19,23 @@ const (
 	canonicalKeyTab       = "tab"
 	canonicalKeyEscape    = "escape"
 	canonicalKeyBackspace = "backspace"
+
+	// canonicalKeyDelete is the spelling a configured "Delete" arrives as. It
+	// is a binding-side name only: canonicalBindingBaseKey folds it to
+	// canonicalKeyBackspace, so no stored chord ever carries it.
+	canonicalKeyDelete = "delete"
 )
+
+// canonicalBindingSignature is canonicalChordSignature for a chord read from
+// the config, the side that can spell "Delete". In [hotkeys] that name means
+// the backspace key on every platform — kVK_Delete on macOS, VK_BACK on
+// Windows, XK_BackSpace on X11 — so it is folded to the signature a press of
+// that key produces. A live press never takes this fold: the forward-delete
+// key keeps the "delete" signature, which no configured chord can carry, and
+// so matches nothing, as it does on the other platforms.
+func canonicalBindingSignature(chord string) string {
+	return chordSignature(chord, canonicalBindingBaseKey)
+}
 
 // canonicalChordSignature normalizes a chord such as "Ctrl+Shift+G" or the
 // evdev-decoded "Shift+Ctrl+g" into a stable signature like "ctrl+shift+g":
@@ -27,6 +43,12 @@ const (
 // This lets the config side and the live keyboard side match regardless of the
 // order or casing each produced.
 func canonicalChordSignature(chord string) string {
+	return chordSignature(chord, canonicalBaseKey)
+}
+
+// chordSignature is the normalization both signatures share; baseKey is how
+// the non-modifier key is spelled.
+func chordSignature(chord string, baseKey func(string) string) string {
 	chord = strings.TrimSpace(chord)
 	if chord == "" {
 		return ""
@@ -37,7 +59,7 @@ func canonicalChordSignature(chord string) string {
 		return ""
 	}
 
-	base := canonicalBaseKey(parts[len(parts)-1])
+	base := baseKey(parts[len(parts)-1])
 	if base == "" {
 		return ""
 	}
@@ -79,6 +101,17 @@ func canonicalModifierToken(token string) string {
 		return evdevModifierCmd
 	default:
 		return ""
+	}
+}
+
+// canonicalBindingBaseKey is canonicalBaseKey plus the fold
+// canonicalBindingSignature describes: "Delete" names the backspace key.
+func canonicalBindingBaseKey(base string) string {
+	switch strings.ToLower(strings.TrimSpace(base)) {
+	case canonicalKeyDelete:
+		return canonicalKeyBackspace
+	default:
+		return canonicalBaseKey(base)
 	}
 }
 

--- a/internal/adapter/eventtap/linux/global_hotkey_keys_test.go
+++ b/internal/adapter/eventtap/linux/global_hotkey_keys_test.go
@@ -42,3 +42,42 @@ func TestCanonicalChordSignatureMatchesAcrossSides(t *testing.T) {
 		t.Fatal("config and live spellings of Ctrl+Shift+G do not match")
 	}
 }
+
+// TestCanonicalBindingSignature_DeleteNamesTheBackspaceKey pins what a
+// configured "Delete" binds on the Wayland listener: the backspace key, as on
+// macOS and Windows and the X11 grab. The config side folds the name, and the
+// live side does not, so a press of the forward-delete key — which the
+// decoder also spells "Delete" — keeps a signature no configured chord carries.
+func TestCanonicalBindingSignature_DeleteNamesTheBackspaceKey(t *testing.T) {
+	const wantModifiedDelete = "ctrl+shift+" + canonicalKeyBackspace
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"config delete", evdevKeyNameDelete, canonicalKeyBackspace},
+		{"config delete with modifiers", "Ctrl+Shift+Delete", wantModifiedDelete},
+		{"config backspace", evdevKeyNameBackspace, canonicalKeyBackspace},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := canonicalBindingSignature(tc.in); got != tc.want {
+				t.Fatalf("canonicalBindingSignature(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	live := canonicalChordSignature(evdevKeyNameDelete)
+	if live == canonicalBindingSignature(evdevKeyNameDelete) {
+		t.Fatalf(
+			"a live forward-delete press canonicalizes to %q, the signature a configured Delete binds",
+			live,
+		)
+	}
+
+	if got := canonicalChordSignature(evdevKeyNameBackspace); got != canonicalKeyBackspace {
+		t.Fatalf("live backspace press canonicalizes to %q, want %q", got, canonicalKeyBackspace)
+	}
+}

--- a/internal/adapter/hotkeys/linux/x11_cgo.go
+++ b/internal/adapter/hotkeys/linux/x11_cgo.go
@@ -398,11 +398,14 @@ func parseX11Hotkey(display *C.Display, keyString string) (C.uint, C.uint, error
 // coincidence of spelling, not a contract.
 //
 // "Backspace" is the same story with a sharper edge: X11 spells it "BackSpace",
-// so it resolved through neither path, and the repair that suggests itself —
-// folding the name through the vocabulary's aliases — grabs the wrong physical
-// key, for the reason x11CanonicalKeyName below sets out. Delete and Insert are
-// mapped alongside it rather than left to their matching spellings, so a reader
-// sees the three editing keys and their distinct keysyms in one place.
+// so it resolved through neither path. "Delete" reaches the same keysym on
+// purpose: in [hotkeys] the name means the backspace key on every platform —
+// kVK_Delete on macOS, VK_BACK on Windows — and X11's own "Delete", the
+// forward-delete key, is what a config file would have grabbed here alone.
+// The forward-delete key has no hotkey name; one that all three platforms can
+// bind is the way to add it, not a Linux-only meaning for this one. Insert is
+// mapped alongside the pair rather than left to its matching spelling, so a
+// reader sees the editing keys in one place.
 //
 // The rest fall through to XStringToKeysym: punctuation, and F1-F24, where
 // X11's own name for the key is the name Neru writes. Those are pinned by test
@@ -429,10 +432,8 @@ func x11KeysymFor(key string) C.KeySym {
 		return C.XK_Tab
 	case keyvocab.KeyEscape:
 		return C.XK_Escape
-	case keyvocab.KeyBackspace:
+	case keyvocab.KeyBackspace, keyvocab.KeyDelete:
 		return C.XK_BackSpace
-	case keyvocab.KeyDelete:
-		return C.XK_Delete
 	case keyvocab.KeyInsert:
 		return C.XK_Insert
 	case keyvocab.KeyUp:
@@ -468,12 +469,13 @@ func x11KeysymFor(key string) C.KeySym {
 // strings reaching this adapter were already canonicalized — config's
 // CanonicalHotkeyForPlatform display-cases the base key without folding
 // aliases — and it is what a grab needs: a grab names a physical key, and the
-// vocabulary's aliases cross keys that X11 keeps apart. Folding "Backspace" to
-// "Delete" the way the taps do would resolve XK_Delete and grab the
-// forward-delete key for a binding written "Backspace". So a named key keeps
-// its own spelling here — "Enter" does not become "Return", though both are
-// mapped above — and only "esc", which the vocabulary deliberately keeps out of
-// the named-key set, resolves through its alias.
+// switch above is where each name is given one. Folding "Backspace" to
+// "Delete" the way the taps do and then handing "Delete" to XStringToKeysym
+// is how a binding written "Backspace" once grabbed the forward-delete key.
+// So a named key keeps its own spelling here — "Enter" does not become
+// "Return", though both are mapped above — and only "esc", which the
+// vocabulary deliberately keeps out of the named-key set, resolves through
+// its alias.
 func x11CanonicalKeyName(key string) string {
 	if display, isNamed := keyvocab.NamedKeyDisplay(key); isNamed {
 		return display

--- a/internal/adapter/hotkeys/linux/x11_keysym_test.go
+++ b/internal/adapter/hotkeys/linux/x11_keysym_test.go
@@ -33,7 +33,6 @@ const (
 	x11KeysymInsert    = 0xFF63 // XK_Insert
 	x11KeysymF1        = 0xFFBE // XK_F1
 	x11KeysymF24       = 0xFFD5 // XK_F24
-	x11KeysymDelete    = 0xFFFF // XK_Delete
 	x11KeysymJ         = 0x006A // XK_j
 )
 
@@ -73,10 +72,10 @@ func TestX11KeysymFor_NavigationKeys(t *testing.T) {
 // TestX11KeysymFor_EditingKeys pins Backspace, Delete and Insert, and pins them
 // together because the first two are the pair a hotkey can get wrong without
 // noticing. X11 spells the erase-left key "BackSpace", so Neru's "Backspace"
-// resolves only when the lookup maps it; and the vocabulary makes "Backspace"
-// an alias of "Delete", so a lookup that folded aliases would grab X11's
-// forward-delete key instead. Both spellings must reach their own keysym, and
-// neither may reach the other's.
+// resolves only when the lookup maps it; and X11 spells the forward-delete key
+// "Delete", so Neru's "Delete" — the backspace key, as on macOS and Windows —
+// resolves to the right key only when the lookup maps it too. Both spellings
+// must reach XK_BackSpace, and neither may reach XK_Delete.
 func TestX11KeysymFor_EditingKeys(t *testing.T) {
 	t.Parallel()
 
@@ -87,8 +86,8 @@ func TestX11KeysymFor_EditingKeys(t *testing.T) {
 	}{
 		{name: "backspace", key: keyvocab.KeyBackspace, want: x11KeysymBackSpace},
 		{name: "lowercased backspace", key: "backspace", want: x11KeysymBackSpace},
-		{name: "delete", key: keyvocab.KeyDelete, want: x11KeysymDelete},
-		{name: "lowercased delete", key: "delete", want: x11KeysymDelete},
+		{name: "delete", key: keyvocab.KeyDelete, want: x11KeysymBackSpace},
+		{name: "lowercased delete", key: "delete", want: x11KeysymBackSpace},
 		{name: "insert", key: keyvocab.KeyInsert, want: x11KeysymInsert},
 		{name: "lowercased insert", key: "insert", want: x11KeysymInsert},
 	}

--- a/internal/architecture/doc.go
+++ b/internal/architecture/doc.go
@@ -41,6 +41,9 @@
 //     by naming it, and every test name or test file it names resolves.
 //   - hint_placement_vocabulary_test.go — the hint placement vocabulary is the
 //     same on both sides of the Go/Objective-C boundary.
+//   - hotkey_delete_key_test.go — every platform's [hotkeys] table resolves
+//     "Delete" and "Backspace" to one physical key, the backspace key, so a
+//     config file binds the same key on all three.
 //   - justfile_doc_test.go — every recipe just --list shows declares its own
 //     one-line summary, rather than inheriting whichever line of the comment
 //     block above it just happens to read.

--- a/internal/architecture/hotkey_delete_key_test.go
+++ b/internal/architecture/hotkey_delete_key_test.go
@@ -1,0 +1,261 @@
+package architecture_test
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain/keyvocab"
+)
+
+// Where each platform turns the base key of a [hotkeys] chord into the
+// physical key it grabs. macOS is read through the parser in
+// named_key_tables_test.go; the other three are Go switches.
+const (
+	hotkeyKeyWindowsSource = "internal/adapter/platform/windows/keys.go"
+	hotkeyKeyWindowsFunc   = "nameToVirtualKey"
+
+	hotkeyKeyX11Source = "internal/adapter/hotkeys/linux/x11_cgo.go"
+	hotkeyKeyX11Func   = "x11KeysymFor"
+
+	// The Wayland listener spells a configured chord through two folds: the
+	// binding-side one, which is where "Delete" is given its meaning, and the
+	// one it shares with the live side.
+	hotkeyKeyEvdevSource      = "internal/adapter/eventtap/linux/global_hotkey_keys.go"
+	hotkeyKeyEvdevBindingFunc = "canonicalBindingBaseKey"
+	hotkeyKeyEvdevBaseFunc    = "canonicalBaseKey"
+
+	// hotkeyKeyVocabPackage and hotkeyKeyVocabPrefix are how a Go switch spells
+	// a named key when it compares against the vocabulary's declaration
+	// (keyvocab.KeyDelete) rather than a literal.
+	hotkeyKeyVocabPackage = "keyvocab"
+	hotkeyKeyVocabPrefix  = "Key"
+)
+
+// hotkeyKeyGoTable is one platform's Go-side lookup: the file, and the
+// functions whose switch cases spell it, searched in order.
+type hotkeyKeyGoTable struct {
+	platform string
+	source   string
+	funcs    []string
+}
+
+var hotkeyKeyGoTables = []hotkeyKeyGoTable{
+	{platform: osWindows, source: hotkeyKeyWindowsSource, funcs: []string{hotkeyKeyWindowsFunc}},
+	{platform: "linux/x11", source: hotkeyKeyX11Source, funcs: []string{hotkeyKeyX11Func}},
+	{
+		platform: "linux/wayland",
+		source:   hotkeyKeyEvdevSource,
+		funcs:    []string{hotkeyKeyEvdevBindingFunc, hotkeyKeyEvdevBaseFunc},
+	},
+}
+
+// TestEveryHotkeyTableBindsDeleteAndBackspaceToOneKey keeps a [hotkeys]
+// binding on "Delete" meaning the same physical key on every platform: the
+// backspace key, which is what "Backspace" binds and what macOS, the
+// reference, calls kVK_Delete. Inside a mode the two names are already one
+// key, by the vocabulary's alias; this pins the four hotkey tables, which
+// resolve names on their own, to the same answer.
+//
+// It reads each table as a map from the name a config writes to the symbol
+// the table returns for it, and asks that "delete" and "backspace" return the
+// same symbol. Which symbol is the platform's business.
+func TestEveryHotkeyTableBindsDeleteAndBackspaceToOneKey(t *testing.T) {
+	t.Parallel()
+
+	tables := map[string]map[string]string{
+		"darwin": lowercaseKeys(readDarwinNamedKeyTables(t).inbound),
+	}
+
+	for _, table := range hotkeyKeyGoTables {
+		tables[table.platform] = readHotkeyKeyGoTable(t, table)
+	}
+
+	deleteName := strings.ToLower(keyvocab.KeyDelete)
+	backspaceName := strings.ToLower(keyvocab.KeyBackspace)
+
+	for platform, table := range tables {
+		deleteSymbol, deleteKnown := table[deleteName]
+		backspaceSymbol, backspaceKnown := table[backspaceName]
+
+		switch {
+		case !deleteKnown || !backspaceKnown:
+			t.Errorf(
+				"%s: hotkey table resolves Delete=%t Backspace=%t; both names must reach a key",
+				platform, deleteKnown, backspaceKnown,
+			)
+		case deleteSymbol != backspaceSymbol:
+			t.Errorf(
+				"%s: a [hotkeys] Delete grabs %s and Backspace grabs %s; both must name the backspace key",
+				platform,
+				deleteSymbol,
+				backspaceSymbol,
+			)
+		}
+	}
+}
+
+// readHotkeyKeyGoTable reads one Go-side table: for every case in every
+// switch of the named functions, the name the case matches — lowercased, with
+// a literal, a file-level constant, or a keyvocab.Key* reference all read as
+// the name they spell — and the first expression the clause returns.
+func readHotkeyKeyGoTable(t *testing.T, table hotkeyKeyGoTable) map[string]string {
+	t.Helper()
+
+	fileSet := token.NewFileSet()
+	absPath := filepath.Join(findRepoRoot(t), filepath.FromSlash(table.source))
+	file := parseRepoGoFile(t, fileSet, absPath, table.source)
+	consts := stringConstants(file)
+
+	resolved := make(map[string]string)
+
+	for _, funcName := range table.funcs {
+		decl := funcDeclNamed(file, funcName)
+		if decl == nil {
+			t.Fatalf("%s: %s not found (renamed?)", table.source, funcName)
+		}
+
+		ast.Inspect(decl.Body, func(node ast.Node) bool {
+			clause, isClause := node.(*ast.CaseClause)
+			if !isClause {
+				return true
+			}
+
+			returned := firstReturnedExpr(clause.Body)
+			if returned == "" {
+				return true
+			}
+
+			for _, expr := range clause.List {
+				name, isName := hotkeyKeyCaseName(expr, consts)
+				if !isName {
+					continue
+				}
+
+				if _, seen := resolved[name]; !seen {
+					resolved[name] = returned
+				}
+			}
+
+			return true
+		})
+	}
+
+	return resolved
+}
+
+// hotkeyKeyCaseName reads the name one case expression matches. It answers for
+// string literals, file-level string constants, and keyvocab.Key* references;
+// anything else is not a named key and is skipped.
+func hotkeyKeyCaseName(expr ast.Expr, consts map[string]string) (string, bool) {
+	switch expr := expr.(type) {
+	case *ast.BasicLit:
+		if expr.Kind != token.STRING {
+			return "", false
+		}
+
+		value, err := strconv.Unquote(expr.Value)
+		if err != nil {
+			return "", false
+		}
+
+		return strings.ToLower(value), true
+	case *ast.Ident:
+		value, isConst := consts[expr.Name]
+		if !isConst {
+			return "", false
+		}
+
+		return strings.ToLower(value), true
+	case *ast.SelectorExpr:
+		pkg, isIdent := expr.X.(*ast.Ident)
+		if !isIdent || pkg.Name != hotkeyKeyVocabPackage ||
+			!strings.HasPrefix(expr.Sel.Name, hotkeyKeyVocabPrefix) {
+			return "", false
+		}
+
+		return strings.ToLower(strings.TrimPrefix(expr.Sel.Name, hotkeyKeyVocabPrefix)), true
+	default:
+		return "", false
+	}
+}
+
+// firstReturnedExpr renders the first result of the first return statement
+// among the given statements, or "" when there is none.
+func firstReturnedExpr(body []ast.Stmt) string {
+	for _, stmt := range body {
+		ret, isReturn := stmt.(*ast.ReturnStmt)
+		if isReturn && len(ret.Results) > 0 {
+			return types.ExprString(ret.Results[0])
+		}
+	}
+
+	return ""
+}
+
+// stringConstants collects the file-level constants declared with a string
+// literal, by name.
+func stringConstants(file *ast.File) map[string]string {
+	consts := make(map[string]string)
+
+	for _, decl := range file.Decls {
+		gen, isGen := decl.(*ast.GenDecl)
+		if !isGen || gen.Tok != token.CONST {
+			continue
+		}
+
+		for _, spec := range gen.Specs {
+			value, isValue := spec.(*ast.ValueSpec)
+			if !isValue {
+				continue
+			}
+
+			for i, name := range value.Names {
+				if i >= len(value.Values) {
+					break
+				}
+
+				lit, isLit := value.Values[i].(*ast.BasicLit)
+				if !isLit || lit.Kind != token.STRING {
+					continue
+				}
+
+				unquoted, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					continue
+				}
+
+				consts[name.Name] = unquoted
+			}
+		}
+	}
+
+	return consts
+}
+
+// funcDeclNamed finds a top-level function by name.
+func funcDeclNamed(file *ast.File, name string) *ast.FuncDecl {
+	for _, decl := range file.Decls {
+		fn, isFunc := decl.(*ast.FuncDecl)
+		if isFunc && fn.Recv == nil && fn.Name.Name == name {
+			return fn
+		}
+	}
+
+	return nil
+}
+
+// lowercaseKeys re-keys a name table by the lowercase name, which is how the
+// Go tables are read.
+func lowercaseKeys(table map[string]string) map[string]string {
+	lowered := make(map[string]string, len(table))
+	for name, symbol := range table {
+		lowered[strings.ToLower(name)] = symbol
+	}
+
+	return lowered
+}


### PR DESCRIPTION
## Description

This PR fixes a `[hotkeys]` binding on `Delete` grabbing the wrong physical key on Linux. macOS and Windows both resolve the name to the backspace key (Apple's name for it), but on Linux it resolved to forward delete on both backends, so the same config file meant two different keys. Linux now follows the reference: `Delete` in `[hotkeys]` binds the backspace key on X11 and on the Wayland evdev listener.

`Backspace` keeps working on both Linux backends (#1398 stays fixed). The forward-delete key has no hotkey name on any platform; a binding written `Delete` no longer fires on it on Linux, which matches what it never did on macOS or Windows. If forward delete is ever wanted as a hotkey, that is a new named key all three platforms can bind.

A new architecture guardrail pins every platform's hotkey table to resolving `Delete` and `Backspace` to one physical key, and `docs/CONFIGURATION.md` now says which key `Delete` names beside the named-key list.

## Related Issues

Closes #1612

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new port surface; the change is inside existing Linux adapters
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, ran the targeted equivalent instead: `just vet-cross`, golangci-lint on the touched packages (host and `GOOS=linux`), the architecture package on the host, and the two Linux packages plus the architecture package in the CI-equivalent Linux cgo container
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users — this PR squash-merges, so the title is what Release Please ships in the changelog, not the commits on the branch

## Potentially breaking on Linux

A Linux config that wrote `Delete` in `[hotkeys]` and relied on it firing on the forward-delete key loses that binding; it now fires on the backspace key, as it always did on macOS and Windows. There is no replacement name for forward delete. Existing configs otherwise keep working unchanged.

## Additional Context

On the Wayland listener the fold is applied only to the configured chord, not to the live key press, so the forward-delete key keeps a signature no config can spell and matches nothing. Folding both sides would have made both `Delete` and `Backspace` fire on two keys on Wayland alone.

The guardrail reads each platform's table as name-to-symbol and asks that `delete` and `backspace` return the same symbol. Which symbol is the platform's business, so a future change to any one table that splits the pair fails the test with the two symbols named.
