### PR TITLE
fix(linux): warn once when passthrough_unbounded_keys is set on the X11 backend

### DIFF
--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -79,6 +79,7 @@ func LaunchDaemon(configPath string) {
 		app.WithConfig(configResult.Config),
 		app.WithWrittenConfig(configResult.Written),
 		app.WithConfigPath(configResult.ConfigPath),
+		app.WithConfigWarnings(configResult.Warnings),
 	)
 	if appErr != nil {
 		fmt.Fprintf(os.Stderr, "Error creating app: %v\n", appErr)

--- a/cmd/neru/main.go
+++ b/cmd/neru/main.go
@@ -55,6 +55,13 @@ func LaunchDaemon(configPath string) {
 		zap.NewNop(),
 		newAlertProvider(systemPort),
 	)
+
+	// The display backend is a limit the platform column cannot say, so the
+	// root that knows the backend hands the loader the words it cannot honor.
+	if platform.CurrentProfile().DisplayServer == platform.DisplayServerX11 {
+		service = service.WithBackendInert(config.X11InertWords)
+	}
+
 	configResult := service.LoadWithValidation(configPath)
 
 	// If there's a validation error, show alert and exit

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -618,7 +618,11 @@ is physically holding, and each stays the compositor's until released
 (`evdevSession.handlePress` and `evdevProxy.forwardWithheld`). It is **not**
 available on X11 (an `XGrabKeyboard` routes Neru's own XTest events back to
 itself, and `XSendEvent` is ignored by most apps) nor on the rare wl-keyboard
-fallback, which has no injection path. Windows needs no re-injection: a
+fallback, which has no injection path. The platform column cannot say "Linux,
+except X11", so a configuration that turns passthrough on under X11 warns once
+at load, in the same voice as the parity warning, and `neru doctor` lists the
+option and its two dependents in its `platform_support` row
+(`config.X11InertWords`). Windows needs no re-injection: a
 `WH_KEYBOARD_LL` hook forwards or blocks each event on its own
 (`eventtap/windows/tap.go`, `handleKey`). Classification (blacklist,
 mode-intercepted keys, the mode's own hotkeys, and the global chords it falls

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -47,8 +47,11 @@ type App struct {
 	// handed to the config service so a later `neru config set` derives from
 	// what the user wrote rather than from what was derived for them.
 	writtenConfig *config.Config
-	ConfigPath    string
-	logger        *zap.Logger
+	// configWarnings are what the launch-time load found wrong but loadable,
+	// logged once the logger exists (WithConfigWarnings).
+	configWarnings []string
+	ConfigPath     string
+	logger         *zap.Logger
 
 	systemPort    ports.SystemPort
 	accessibility ports.AccessibilityPort

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -5,6 +5,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/neru/internal/adapter/platform"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/config/loader"
 	"github.com/y3owk1n/neru/internal/derrors"
@@ -15,9 +16,18 @@ import (
 // app was constructed with: the configuration to run on, and the one it was
 // derived from. Passing only the first leaves the service deriving from its own
 // output, which cannot re-infer — so the two travel together from here on.
+//
+// The backend limit is wired the same way main.go wires it for the first load,
+// so a hot reload warns about the same words the launch did.
 func (a *App) newConfigService(logger *zap.Logger) *loader.Service {
-	return loader.NewService(a.config, a.ConfigPath, logger, a.systemPort).
+	svc := loader.NewService(a.config, a.ConfigPath, logger, a.systemPort).
 		WithWritten(a.writtenConfig)
+
+	if platform.CurrentProfile().DisplayServer == platform.DisplayServerX11 {
+		svc = svc.WithBackendInert(config.X11InertWords)
+	}
+
+	return svc
 }
 
 // SetConfigField applies a single runtime config field change with full

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -37,6 +37,12 @@ func New(opts ...Option) (*App, error) {
 		app.logger = logger
 	}
 
+	// Under the same name and message the config service logs a reload's, so
+	// the two reads of the same file are one line to search for.
+	for _, warning := range app.configWarnings {
+		app.logger.Named("config").Warn("Configuration warning", zap.String("warning", warning))
+	}
+
 	// Initialize the rest of the application
 	return initializeApp(app)
 }

--- a/internal/app/options.go
+++ b/internal/app/options.go
@@ -36,6 +36,18 @@ func WithWrittenConfig(cfg *config.Config) Option {
 	}
 }
 
+// WithConfigWarnings carries the warnings the launch-time load found, for the
+// app to log once its logger exists. The load runs before there is a logger to
+// hand it, and a warning nobody prints is a warning nobody can act on (ADR
+// 0002); a hot reload logs its own through the config service.
+func WithConfigWarnings(warnings []string) Option {
+	return func(a *App) error {
+		a.configWarnings = warnings
+
+		return nil
+	}
+}
+
 // WithConfigPath sets the configuration file path.
 func WithConfigPath(path string) Option {
 	return func(a *App) error {

--- a/internal/cli/config_loader.go
+++ b/internal/cli/config_loader.go
@@ -1,0 +1,14 @@
+package cli
+
+import (
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/config/loader"
+)
+
+// clientConfigLoader builds the loader a client-side command reads the
+// configuration with: defaults, no daemon, no logger, no alert dialog. The
+// commands that judge a file (`config validate`, `doctor`, `roles explain`)
+// share it so they read the same file the same way.
+func clientConfigLoader() *loader.Service {
+	return loader.NewService(config.DefaultConfig(), "", nil, nil)
+}

--- a/internal/cli/config_loader.go
+++ b/internal/cli/config_loader.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"github.com/y3owk1n/neru/internal/adapter/platform"
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/config/loader"
 )
@@ -9,6 +10,15 @@ import (
 // configuration with: defaults, no daemon, no logger, no alert dialog. The
 // commands that judge a file (`config validate`, `doctor`, `roles explain`)
 // share it so they read the same file the same way.
+//
+// The backend limit is wired here as it is in the daemon's two roots, so
+// `config validate` and `doctor` warn about the same words the daemon does.
 func clientConfigLoader() *loader.Service {
-	return loader.NewService(config.DefaultConfig(), "", nil, nil)
+	svc := loader.NewService(config.DefaultConfig(), "", nil, nil)
+
+	if platform.CurrentProfile().DisplayServer == platform.DisplayServerX11 {
+		svc = svc.WithBackendInert(config.X11InertWords)
+	}
+
+	return svc
 }

--- a/internal/cli/config_validate.go
+++ b/internal/cli/config_validate.go
@@ -4,9 +4,6 @@ import (
 	"errors"
 
 	"github.com/spf13/cobra"
-
-	"github.com/y3owk1n/neru/internal/config"
-	"github.com/y3owk1n/neru/internal/config/loader"
 )
 
 // errConfigValidationFailed is returned when config validation fails.
@@ -34,7 +31,7 @@ func init() {
 }
 
 func runConfigValidate(cmd *cobra.Command) error {
-	svc := loader.NewService(config.DefaultConfig(), "", nil, nil)
+	svc := clientConfigLoader()
 
 	path := configPath
 	if path == "" {

--- a/internal/cli/doctor_platform_support.go
+++ b/internal/cli/doctor_platform_support.go
@@ -33,7 +33,8 @@ func doctorConfigLoad() *config.LoadResult {
 }
 
 // printPlatformSupportCheck reports the options, actions and mode flags this
-// configuration writes that do nothing on this platform.
+// configuration writes that do nothing on this platform or on the display
+// backend it is running.
 //
 // It never fails the doctor. An inert word is not a broken configuration — the
 // same file is meant to work on every platform, which is why writing one is a
@@ -61,7 +62,11 @@ func printPlatformSupportCheck(cmd *cobra.Command, loadResult *config.LoadResult
 		return
 	}
 
-	cmd.Printf("  ⚠️  %-24s %d %s nothing on %s (written and ignored; the daemon runs)\n",
+	// "This session" rather than the platform: the list carries the words the
+	// display backend cannot honor beside the ones the platform cannot, and
+	// passthrough on X11 does nothing here without doing nothing on Linux.
+	cmd.Printf(
+		"  ⚠️  %-24s %d %s nothing on this %s session (written and ignored; the daemon runs)\n",
 		platformSupportRow,
 		len(loadResult.Inert),
 		pluralSettingsDo(len(loadResult.Inert)),

--- a/internal/cli/doctor_platform_support.go
+++ b/internal/cli/doctor_platform_support.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/y3owk1n/neru/internal/config"
-	"github.com/y3owk1n/neru/internal/config/loader"
 	"github.com/y3owk1n/neru/internal/domain/parity"
 )
 
@@ -23,7 +22,7 @@ const platformSupportRow = "platform_support"
 // One load for all of them: two would be two chances to disagree about which
 // file is even being judged, and the load is what discovers that file.
 func doctorConfigLoad() *config.LoadResult {
-	svc := loader.NewService(config.DefaultConfig(), "", nil, nil)
+	svc := clientConfigLoader()
 
 	path := configPath
 	if path == "" {

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/y3owk1n/neru/internal/config"
-	"github.com/y3owk1n/neru/internal/config/loader"
 	"github.com/y3owk1n/neru/internal/domain/element"
 )
 
@@ -102,7 +101,7 @@ func runRolesList(cmd *cobra.Command) {
 
 // runRolesExplain resolves the loaded configuration and reports each entry.
 func runRolesExplain(cmd *cobra.Command) error {
-	svc := loader.NewService(config.DefaultConfig(), "", nil, nil)
+	svc := clientConfigLoader()
 
 	path := configPath
 	if path == "" {

--- a/internal/config/AGENTS.md
+++ b/internal/config/AGENTS.md
@@ -21,7 +21,7 @@ Adding or changing an option touches **five links every time, and up to four mor
 
 `held_repeat.accel_*` needed all four conditional links, which is how one option came to touch nine files — ten, since the platform column became a link of its own.
 
-Link 5 exempts nothing, and collapses one shape: a `Color` is declared at the field rather than at its `light` and `dark` leaves, because a Color is one option to whoever writes it.
+Link 5 exempts nothing, and collapses one shape: a `Color` is declared at the field rather than at its `light` and `dark` leaves, because a Color is one option to whoever writes it. The column is per OS and has no backend axis on purpose; the one limit finer than a column, passthrough on X11, is declared beside it as `X11InertWords` and injected into the loader by the roots that detect the backend (`loader.Service.WithBackendInert`). A second such limit is a reason to reconsider the axis, not to add a second function.
 
 **What the guardrails do not reach.** Links 2 and 3 exempt three shapes, and an option with one of them can skip both with nothing failing: the `light`/`dark` leaves under a `Color` (`ResolveThemeDefaults()` fills those), a collection that ships empty, and every field of a repeated table nobody ships entries for (`app_configs`, `layers`). The exemptions are structural and recomputed from the live defaults each run, and the named allowlist beside each is empty — adding to it is a decision that wants a written reason (ADR 0006). If your option is one of those shapes, the reviewer is the only check.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -627,9 +627,10 @@ type LoadResult struct {
 	Warnings []string
 
 	// Inert are the words the user's files write that do nothing on this
-	// platform, as [InertWords] found them. One of the warnings above says the
-	// same thing in a sentence; this is the same finding with its platform
-	// column and its reason still attached, which is what `neru doctor` prints
+	// platform, as [InertWords] found them, or on the display backend it is
+	// running, as [X11InertWords] found them. The warnings above say the same
+	// thing in a sentence; this is the same finding with its platform column
+	// and its reason still attached, which is what `neru doctor` prints
 	// (docs/adr/0013-parity-is-measured-in-words-not-subsystems.md).
 	Inert parity.Declaration
 }

--- a/internal/config/loader/load.go
+++ b/internal/config/loader/load.go
@@ -85,12 +85,17 @@ func (s *Service) LoadWithValidation(path string) *config.LoadResult {
 	// and past the merge a default nobody chose reads the same as a line
 	// somebody typed. A build for a platform no declaration has a column for
 	// claims nothing, so it warns about nothing.
+	writtenWords := writtenConfiguration(raw, overridePath)
+
 	if platform, known := parity.Current(); known {
-		result.Inert = warnInertWords(
-			warnings,
-			writtenConfiguration(raw, overridePath),
-			platform,
-		)
+		result.Inert = warnInertWords(warnings, writtenWords, platform)
+	}
+
+	// The backend's limit rides on the same list, one warning of its own: a
+	// column says where an option does anything, and X11 is not a column.
+	if s.backendInert != nil {
+		result.Inert = append(result.Inert,
+			warnBackendInert(warnings, s.backendInert(result.Config, writtenWords))...)
 	}
 
 	validateErr := result.Config.ValidateWithWarnings(warnings, config.AsWritten(written))

--- a/internal/config/loader/load_warnings_test.go
+++ b/internal/config/loader/load_warnings_test.go
@@ -181,9 +181,12 @@ characters = "ab c"
 
 // loadWithObservedLogger writes a config file, and an override file when one is
 // given, then loads them the way the daemon does with a logger that records.
+// The configure hooks stand in for what a composition root wires onto the
+// service before the load.
 func loadWithObservedLogger(
 	t *testing.T,
 	configTOML, overrideTOML string,
+	configure ...func(*loader.Service) *loader.Service,
 ) (*config.LoadResult, *observer.ObservedLogs) {
 	t.Helper()
 
@@ -208,7 +211,12 @@ func loadWithObservedLogger(
 
 	core, logs := observer.New(zap.WarnLevel)
 
-	result := loader.NewService(nil, path, zap.New(core), nil).LoadWithValidation(path)
+	svc := loader.NewService(nil, path, zap.New(core), nil)
+	for _, hook := range configure {
+		svc = hook(svc)
+	}
+
+	result := svc.LoadWithValidation(path)
 	if result == nil || result.Config == nil {
 		t.Fatalf("LoadWithValidation returned no config")
 	}

--- a/internal/config/loader/platform_support.go
+++ b/internal/config/loader/platform_support.go
@@ -55,6 +55,34 @@ func warnInertWords(
 	return inert
 }
 
+// warnBackendInert records one warning for everything a configuration writes
+// that the display backend this process runs under cannot honor, and hands the
+// findings back for the result to carry beside the platform-inert ones.
+//
+// One warning for the set, in the voice of warnInertWords, with the reason in
+// the sentence: the platform warning can defer its reasons to `neru doctor`
+// because there is one per word, while every word here shares the one note,
+// and a person on X11 reading "passthrough does nothing here" wants to know why
+// before they go and read anything else.
+func warnBackendInert(warnings *config.Warnings, inert parity.Declaration) parity.Declaration {
+	if len(inert) == 0 {
+		return nil
+	}
+
+	warnings.Addf(
+		"%d %s in this configuration %s nothing here and %s ignored: %s, because %s. "+
+			"They load and the daemon runs",
+		len(inert),
+		plural(len(inert), "setting", "settings"),
+		plural(len(inert), "does", "do"),
+		plural(len(inert), "is", "are"),
+		listInert(inert),
+		inert[0].Note,
+	)
+
+	return inert
+}
+
 // listInert names the findings, stopping at listedInertWords and counting the
 // rest.
 func listInert(inert parity.Declaration) string {

--- a/internal/config/loader/platform_support_test.go
+++ b/internal/config/loader/platform_support_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/config/loader"
 	"github.com/y3owk1n/neru/internal/domain/parity"
 )
 
@@ -162,5 +163,104 @@ hint_characters = ""
 				"running is the defaults",
 			result.Inert.Names(),
 		)
+	}
+}
+
+// passthroughConfigTOML turns modifier passthrough on and writes both of the
+// options that mean nothing without it, which is the whole set the X11 backend
+// cannot honor.
+const passthroughConfigTOML = `
+[general]
+passthrough_unbounded_keys = true
+should_exit_after_passthrough = true
+passthrough_unbounded_keys_blacklist = ["Ctrl+C"]
+`
+
+// passthroughOptions are the words the two tests below expect, in declaration
+// order.
+var passthroughOptions = []string{
+	"general.passthrough_unbounded_keys",
+	"general.passthrough_unbounded_keys_blacklist",
+	"general.should_exit_after_passthrough",
+}
+
+// onX11 stands in for the backend detection a composition root does: it wires
+// the X11 limit onto the loader the way main.go does when the display server
+// it detected is X11. Faked rather than detected so the sentence an X11 user is
+// shown can be read from any machine (#1613).
+func onX11(svc *loader.Service) *loader.Service {
+	return svc.WithBackendInert(config.X11InertWords)
+}
+
+// TestLoadWithValidation_WarnsOnceWhenTheX11BackendCannotPassThrough is the
+// load-time half of #1613: passthrough on the X11 backend is a word that means
+// nothing, and the file says so once, naming the options, the backend and why.
+func TestLoadWithValidation_WarnsOnceWhenTheX11BackendCannotPassThrough(t *testing.T) {
+	result, logs := loadWithObservedLogger(t, passthroughConfigTOML, "", onX11)
+
+	if result.ValidationError != nil {
+		t.Fatalf("passthrough on X11 was refused: %v", result.ValidationError)
+	}
+
+	for _, want := range passthroughOptions {
+		if !slices.Contains(result.Inert.Names(), want) {
+			t.Errorf("result.Inert = %v, want it to carry %s for `neru doctor`",
+				result.Inert.Names(), want)
+		}
+	}
+
+	var about []string
+
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "passthrough_unbounded_keys") {
+			about = append(about, warning)
+		}
+	}
+
+	if len(about) != 1 {
+		t.Fatalf("got %d warnings about passthrough, want exactly 1: %q", len(about), about)
+	}
+
+	for _, want := range append(
+		[]string{"3 settings", "X11", "XGrabKeyboard", "the daemon runs"},
+		passthroughOptions...,
+	) {
+		if !strings.Contains(about[0], want) {
+			t.Errorf("the warning %q does not mention %q", about[0], want)
+		}
+	}
+
+	if logged := countLogged(logs, "XGrabKeyboard"); logged != 1 {
+		t.Errorf("the X11 passthrough warning was logged %d times, want exactly 1", logged)
+	}
+
+	// A warning reports, it does not undo: the option stays as written for the
+	// day the same file is loaded under Wayland.
+	if !result.Config.General.PassthroughUnboundedKeys {
+		t.Error("passthrough_unbounded_keys was cleared, want it left as written")
+	}
+}
+
+// TestLoadWithValidation_SaysNothingAboutPassthroughOffX11 keeps the warning
+// off every backend that honors the option. No root wires the X11 limit under
+// Wayland, so the loader has nothing to say about passthrough there.
+func TestLoadWithValidation_SaysNothingAboutPassthroughOffX11(t *testing.T) {
+	result, logs := loadWithObservedLogger(t, passthroughConfigTOML, "")
+
+	for _, name := range passthroughOptions {
+		if slices.Contains(result.Inert.Names(), name) {
+			t.Errorf("result.Inert = %v names %s off X11, where the option works",
+				result.Inert.Names(), name)
+		}
+	}
+
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "passthrough_unbounded_keys") {
+			t.Errorf("result.Warnings carries %q off X11, want nothing about passthrough", warning)
+		}
+	}
+
+	if logged := countLogged(logs, "XGrabKeyboard"); logged != 0 {
+		t.Errorf("the X11 passthrough warning was logged %d times off X11, want 0", logged)
 	}
 }

--- a/internal/config/loader/service.go
+++ b/internal/config/loader/service.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain/parity"
 )
 
 // validateAppConfigsHotkeys validates hotkeys in app_configs sections from raw config.
@@ -241,6 +242,14 @@ type Service struct {
 	// LoadWithValidation. It is initialized from config.DefaultConfigForDecoding()
 	// in NewService, but can be overridden by tests via withDefaults.
 	defaults *config.Config
+
+	// backendInert reports the words a configuration writes that the display
+	// backend this process runs under cannot honor, a limit finer than the
+	// platform column InertWords judges by. Nil, the default, means the
+	// backend keeps every promise the column makes. It is injected rather than
+	// detected here, because the detector is an adapter and this package sits
+	// below the adapters; WithBackendInert says who supplies it.
+	backendInert func(*config.Config, config.Written) parity.Declaration
 }
 
 // NewService creates a new configuration service.
@@ -265,6 +274,19 @@ func NewService(
 		logger:        logger.Named("config"),
 		alertProvider: alertProvider,
 	}
+}
+
+// WithBackendInert names the words the display backend this process runs
+// under cannot honor, for LoadWithValidation to warn about beside the
+// platform-inert ones. The only one today is [config.X11InertWords], which the
+// composition roots pass when the detected backend is X11; a test passes it to
+// stand in for that detection.
+func (s *Service) WithBackendInert(
+	inert func(*config.Config, config.Written) parity.Declaration,
+) *Service {
+	s.backendInert = inert
+
+	return s
 }
 
 // WithDefaults sets the base defaults used by LoadWithValidation. This is

--- a/internal/config/platform_support.go
+++ b/internal/config/platform_support.go
@@ -204,11 +204,8 @@ func PlatformSupport() parity.Declaration {
 		// the Wayland evdev tap and on Windows. X11 cannot pass them through
 		// at all, which is a display-server limit rather than a column: the
 		// blessed Linux stack is Wayland (Known Gaps, docs/CROSS_PLATFORM.md).
-		parity.Everywhere(parity.KindOption,
-			"general.passthrough_unbounded_keys",
-			"general.passthrough_unbounded_keys_blacklist",
-			"general.should_exit_after_passthrough",
-		),
+		// X11InertWords is where that limit is said.
+		parity.Everywhere(parity.KindOption, passthroughOptions...),
 		parity.Everywhere(parity.KindOption,
 			"general.excluded_apps",
 			"general.exec_shell",
@@ -473,6 +470,62 @@ type Written struct {
 	Options map[string]string
 	// Steps are the action strings the files write, in no particular order.
 	Steps []string
+}
+
+// passthroughOptions are the options that mean nothing without modifier
+// passthrough, declared once so the column and the X11 limit below cannot
+// disagree about which they are.
+var passthroughOptions = []string{
+	"general.passthrough_unbounded_keys",
+	"general.passthrough_unbounded_keys_blacklist",
+	"general.should_exit_after_passthrough",
+}
+
+// noteX11Passthrough is why the X11 backend cannot honor the options above. It
+// is read by a user in a warning and in the doctor row, so it names the gap in
+// the display server's own words.
+const noteX11Passthrough = "the X11 backend cannot pass an unbound chord " +
+	"through: XGrabKeyboard is all-or-nothing and XSendEvent is ignored by most " +
+	"applications, so passthrough needs the Wayland evdev backend " +
+	"(Known Gaps, docs/CROSS_PLATFORM.md)"
+
+// X11InertWords reports the passthrough options a configuration writes that
+// the X11 backend cannot honor.
+//
+// The platform column is per OS and cannot say "Linux, except X11", and
+// teaching the declaration a backend axis is far too much machinery for one
+// row. So the one limit finer than a column is declared beside the column: the
+// same Word shape, the same Note, and the loader appends the findings to the
+// ones InertWords made, which is what gets them the same warning voice and the
+// same doctor row (#1613).
+//
+// It reads the loaded configuration for whether passthrough is on, because a
+// written bool arrives as a bare path with no value (Written.Options), and a
+// `passthrough_unbounded_keys = false` a user left in the file is not a promise
+// this backend is failing to keep. The dependents are reported only when they
+// were written: they are inert everywhere without passthrough, which is a
+// cross-field question and not this one.
+func X11InertWords(cfg *Config, written Written) parity.Declaration {
+	if !cfg.General.PassthroughUnboundedKeys {
+		return nil
+	}
+
+	var inert parity.Declaration
+
+	for _, name := range passthroughOptions {
+		if _, wrote := written.Options[name]; !wrote {
+			continue
+		}
+
+		inert = append(inert, parity.Word{
+			Kind:      parity.KindOption,
+			Name:      name,
+			Platforms: parity.AllPlatforms,
+			Note:      noteX11Passthrough,
+		})
+	}
+
+	return inert
 }
 
 // InertWords reports every word a configuration writes that does nothing on the

--- a/internal/config/platform_support_test.go
+++ b/internal/config/platform_support_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/y3owk1n/neru/internal/config"
@@ -85,6 +86,76 @@ func TestPlatformSupport_DeclaresTheOptionBehindAValue(t *testing.T) {
 	if !word.Platforms.Everywhere() {
 		t.Errorf("hints.strategy is declared as %v; the option is written everywhere, "+
 			"and only its vision value is not", word.Platforms)
+	}
+}
+
+// TestX11InertWords_ReportsWrittenPassthroughOnlyWhenItIsOn pins the one limit
+// finer than a platform column (#1613): the X11 backend cannot honor
+// passthrough, so the option and whichever dependents were written are
+// reported, and only while passthrough is actually on.
+func TestX11InertWords_ReportsWrittenPassthroughOnlyWhenItIsOn(t *testing.T) {
+	t.Parallel()
+
+	const (
+		passthrough = "general.passthrough_unbounded_keys"
+		blacklist   = "general.passthrough_unbounded_keys_blacklist"
+		exitAfter   = "general.should_exit_after_passthrough"
+	)
+
+	tests := []struct {
+		name    string
+		on      bool
+		written map[string]string
+		want    []string
+	}{
+		{
+			name:    "passthrough written off is not a promise X11 fails to keep",
+			on:      false,
+			written: map[string]string{passthrough: "", blacklist: ""},
+			want:    nil,
+		},
+		{
+			name:    "passthrough on is reported with the dependents that were written",
+			on:      true,
+			written: map[string]string{passthrough: "", blacklist: "", exitAfter: ""},
+			want:    []string{passthrough, blacklist, exitAfter},
+		},
+		{
+			name:    "a dependent nobody wrote is not reported",
+			on:      true,
+			written: map[string]string{passthrough: ""},
+			want:    []string{passthrough},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.DefaultConfig()
+			cfg.General.PassthroughUnboundedKeys = test.on
+
+			got := config.X11InertWords(cfg, config.Written{Options: test.written})
+			if names := got.Names(); !slices.Equal(names, test.want) {
+				t.Errorf(
+					"X11InertWords(on=%t, %v) = %v, want %v",
+					test.on,
+					test.written,
+					names,
+					test.want,
+				)
+			}
+
+			for _, word := range got {
+				if !strings.Contains(word.Note, "X11") {
+					t.Errorf(
+						"%s carries the note %q, want it to name the X11 backend",
+						word.Name,
+						word.Note,
+					)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

This PR makes a Linux X11 user hear, once, that `general.passthrough_unbounded_keys` does nothing on their display server.

The option is declared to work on Linux, and it does on the Wayland evdev backend. X11 cannot pass a chord through at all: `XGrabKeyboard` is all-or-nothing and `XSendEvent` is ignored by most applications. The X11 tap never consults the option, so turning it on did nothing and said nothing, which is exactly what the load-time parity warning exists to prevent.

**What changed for the user**

- On the X11 backend, a configuration that sets `passthrough_unbounded_keys = true` logs one warning at load naming the option, whichever of `passthrough_unbounded_keys_blacklist` and `should_exit_after_passthrough` were written, the backend, and the reason. One warning for the set, not three, in the same voice as the parity warning.
- `neru doctor` lists the same words in its `platform_support` row with the reason. `neru config validate` prints the warning.
- Wayland backends, macOS and Windows log nothing new. Existing configs keep working; a warning reports, it never refuses.
- The daemon now also logs the config warnings its launch-time load found. Before, that load ran with a no-op logger and nothing read its warnings, so every load-time warning, this one included, only surfaced on a hot reload or under `neru config validate`.

**How**

The platform column is per OS and cannot say "Linux, except X11", and a backend axis is too much machinery for one row. So the one limit finer than a column is declared beside it as `config.X11InertWords`, and the loader takes it through a new `Service.WithBackendInert` hook, since the backend detector is an adapter and the loader sits below the adapters. The three roots that build a loader (daemon launch, hot reload, the client-side CLI commands) wire it when the detected display server is X11. A prefactor commit gives the CLI commands one shared loader so that wiring lives in one place there.

## Related Issues

Closes #1613

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

No new build-tagged file. The backend check goes through `platform.CurrentProfile().DisplayServer`, which every OS answers.

## General Checklist

- [x] Code formatted (`just fmt`)
- [ ] `just ci` passes — ran the targeted subset instead: `golangci-lint`, `go vet` (host and `GOOS=linux`), and `go test` over `internal/config/...`, `internal/cli`, `internal/app`, `internal/architecture`. CI runs the full set.
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

- The unit test pins the warning against a fake X11 detection: the test wires `X11InertWords` onto the loader the way `main.go` does when it detects X11, so the sentence an X11 user sees is asserted from any machine.
- The launch-time logging in the last commit has no test of its own: the simulation harness builds the app from a fixed option list, and widening it for a two-line loop did not seem worth the seam. Say if you want it.
- The doctor row header now says "N settings do nothing on this linux session" rather than "on linux", since the list can carry an X11 word that works on Wayland. Greptile caught the earlier wording.
