### PR TITLE
fix(modes): click where a held-key glide left the cursor, not on the grid selection

### DIFF
--- a/internal/app/modes/key_dispatch.go
+++ b/internal/app/modes/key_dispatch.go
@@ -479,6 +479,13 @@ func (h *handlerState) startMotion(key string, actions []string) bool {
 		return false
 	}
 
+	// The discrete step would have gone through the IPC handler, which drops
+	// the mode's selection so a later click lands where the cursor went. The
+	// glide never gets there, so the selection is dropped here.
+	if tracker, ok := activeModeExtension[selectionTracker](h); ok {
+		tracker.ClearSelectionPoint()
+	}
+
 	h.motion.Press(motionKeyOf(key), dir, step)
 
 	return true

--- a/internal/app/simulation_journey_test.go
+++ b/internal/app/simulation_journey_test.go
@@ -1414,6 +1414,62 @@ func TestSimulation_HeldMotionDiagonal(t *testing.T) {
 	sim.waitMode(domain.ModeIdle)
 }
 
+// TestSimulation_HeldMotionDropsTheGridSelection pins that a held-key glide
+// leaves the click where the cursor went, not on the region the grid had
+// selected: select a region, glide away from it, click.
+func TestSimulation_HeldMotionDropsTheGridSelection(t *testing.T) {
+	cfg := simConfig()
+	cfg.HeldRepeat.Enabled = true
+
+	sim := newSimHarness(t, cfg, nil)
+
+	sim.pressHotkey(recursiveGridHotkey)
+	sim.waitMode(domain.ModeRecursiveGrid)
+
+	sim.waitFor("recursive grid drawn", func() bool {
+		_, ok := sim.overlay.lastRecursiveGridBounds()
+
+		return ok
+	})
+
+	movesBefore := sim.cursor.moveCount()
+
+	// "r" selects the top-left cell, which moves the cursor onto its center.
+	sim.press("r")
+
+	sim.waitFor("cursor moved onto the selected region", func() bool {
+		return sim.cursor.moveCount() > movesBefore
+	})
+
+	selected := sim.cursor.position()
+
+	sim.press("Right")
+
+	sim.waitFor("cursor glided right", func() bool {
+		return sim.cursor.position().X > selected.X
+	})
+
+	sim.press("__keyup_Right")
+
+	sim.press("Shift+L") // left_click
+
+	sim.waitFor("click recorded", func() bool {
+		return len(sim.ax.recordedClicks()) >= 1
+	})
+
+	got := sim.ax.recordedClicks()[0]
+	if got.action != action.TypeLeftClick {
+		t.Fatalf("expected a left click, got %+v", got)
+	}
+
+	if got.point.Y != selected.Y || got.point.X <= selected.X {
+		t.Fatalf("click at %v, expected to the right of the grid selection %v", got.point, selected)
+	}
+
+	sim.press("Escape")
+	sim.waitMode(domain.ModeIdle)
+}
+
 // TestSimulation_DragJourney covers the drag primitives: mouse down at the
 // cursor, arrow-key relative movement while holding, mouse up at the new
 // position.


### PR DESCRIPTION
## Description

This PR fixes clicks inside grid and recursive grid mode landing back on the selected cell after the cursor had been moved away with a held relative-move key.

Since the held-key glide shipped (#1626), a keybound relative move with `held_repeat.enabled` on no longer took the path that forgets the mode's selection. The selection survived the move, and a later `left_click` preferred it over the real cursor, so the click snapped back to the grid cell. The selection is now dropped as soon as a glide starts, matching what a discrete step always did, and the virtual pointer disappears with it.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, small change; ran `just fmt`, `golangci-lint run ./internal/app/...` and `go test ./internal/app/ ./internal/app/modes/` instead, all green
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changed
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

The new simulation journey selects a recursive grid region, glides right with a held key, releases it and clicks. It fails on `main` with the click at the region center and passes with this change.
