### PR TITLE
feat(modes): add support for user declared custom mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ neru hints          # trigger hints mode
 neru grid           # trigger grid mode
 neru recursive_grid # trigger recursive grid mode
 neru scroll         # trigger scroll mode
+neru mode window    # enter a mode you declared in config
 neru config reload  # hot-reload config without restarting
 neru status         # check daemon state and permissions
 ```

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -60,6 +60,22 @@ text = "#E8EEFF"
 # [hints.hotkeys]
 # "Enter" = "macro click_and_exit"
 
+# Declared modes — a keymap with a name and an indicator, no logic of its own.
+# Enter one with "mode <name>" from a hotkey, a sequence step, or `neru mode
+# <name>`. Escape returns to idle unless the mode rebinds it.
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#modes
+#
+# [modes.window]
+# indicator = "Window"
+#
+# [modes.window.hotkeys]
+# "h" = "exec yabai -m window --focus west"
+# "l" = "exec yabai -m window --focus east"
+# "s" = "scroll"
+#
+# [hotkeys]
+# "Primary+Shift+W" = "mode window"
+
 # Hint mode
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#hints
 [hints]

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -295,7 +295,7 @@ nothing.
 | `--modifier` |  | value | `hints` · `grid` · `recursive_grid` | Comma-separated modifier keys to hold during action (cmd, super, meta, shift, alt, option, ctrl) (requires --action) |
 | `--on-exit` |  | value, repeatable | `hints` · `grid` · `recursive_grid` | Step to run after the action is fulfilled and the mode exits (same syntax as hotkeys, e.g. 'action left_click' or 'exec notify-send done'). Repeat the flag to run several steps in order. Requires --action; not run on manual escape/idle |
 | `--repeat` | `-r` | none | `hints` · `grid` · `recursive_grid` | Re-activate mode after performing the action (requires --action) |
-| `--toggle` | `-t` | none | `hints` · `grid` · `recursive_grid` · `scroll` · `monitor_select` | Toggle mode on/off (exit to idle if already active) |
+| `--toggle` | `-t` | none | `hints` · `grid` · `recursive_grid` · `scroll` · `monitor_select` · `mode` | Toggle mode on/off (exit to idle if already active) |
 | `--search` | `-s` | none | `hints` | Show search input when the mode is activated |
 | `--hide-on-empty-search` |  | none | `hints` | Hide all hints when search query is empty (requires --search) |
 | `--role` |  | value, repeatable | `hints` | Filter by element role (comma-separated: button,link — the hints.clickable_roles vocabulary, see 'neru roles'). Repeat the flag to add more |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -19,7 +19,7 @@ The same content is available as manpages (`man neru`) after installation.
 - [Global flags](#global-flags)
 - [Command index](#command-index)
 - [Daemon lifecycle](#daemon-lifecycle) — `launch` · `start` · `stop` · `idle` · `status` · `doctor`
-- [Navigation modes](#navigation-modes) — `hints` · `grid` · `recursive_grid` · `scroll` · `monitor_select`
+- [Navigation modes](#navigation-modes) — `hints` · `grid` · `recursive_grid` · `scroll` · `monitor_select` · `mode`
 - [Actions](#actions) — `action` and its subcommands
 - [Sequences](#sequences) — `run` · `macro`
 - [Configuration commands](#configuration-commands) — `config`
@@ -90,6 +90,7 @@ Accepted by every command.
 | [`recursive_grid`](#neru-recursive_grid)                     | Recursive cell navigation       | Yes | All |
 | [`scroll`](#neru-scroll)                                     | Vim-style scrolling             | Yes | All |
 | [`monitor_select`](#neru-monitor_select)                     | Jump the cursor to a display    | Yes | macOS · Linux |
+| [`mode`](#neru-mode)                                         | Enter a mode declared in config | Yes | All |
 | [`action`](#actions)                                         | One-shot mouse/scroll/key input | Yes | All ² |
 | [`run`](#neru-run)                                           | Run several actions in order    | Yes | All |
 | [`macro`](#neru-macro)                                       | Run a named sequence from config | Yes | All |
@@ -189,7 +190,7 @@ Requires a running daemon.
 | Field    | Values                                                  |
 | -------- | ------------------------------------------------------- |
 | `Status` | `running`, `disabled`                                   |
-| `Mode`   | `idle`, `hints`, `grid`, `recursive_grid`, `scroll`, `monitor_select` |
+| `Mode`   | `idle`, `hints`, `grid`, `recursive_grid`, `scroll`, `monitor_select`, or the name of the open [declared mode](CONFIGURATION.md#modes) |
 
 **JSON output**
 
@@ -270,8 +271,8 @@ the check. The full set is
 
 # Navigation modes
 
-Modes take over the keyboard until you select a target or exit. All five
-require a running daemon.
+Modes take over the keyboard until you select a target or exit. Every mode
+command requires a running daemon.
 
 ## Mode flag reference
 
@@ -518,6 +519,35 @@ Labels come from `monitor_select.characters` (default `123456789`).
 ```bash
 neru monitor_select
 neru monitor_select --toggle
+```
+
+---
+
+## neru mode
+
+Enter a mode you declared under [`[modes.<name>]`](CONFIGURATION.md#modes).
+
+```
+neru mode <name> [flags]
+```
+
+A declared mode has no logic of its own: it captures the keyboard, shows its
+indicator, and answers every key from its own `[modes.<name>.hotkeys]` table.
+`Escape` returns to idle unless the table rebinds it. The same command is a
+binding step, `"mode <name>"`, from any hotkey table or macro.
+
+**Flags** — every flag listed for `mode` in the
+[mode flag reference](#mode-flag-reference): `--toggle` and nothing else, since
+a declared mode makes no selection.
+
+A name nothing declares is refused with `ERR_INVALID_INPUT`, the same way a
+binding into one is refused at load.
+
+**Examples**
+
+```bash
+neru mode window
+neru mode window --toggle
 ```
 
 ---
@@ -1631,8 +1661,9 @@ scripts are safe.
 ```
 
 `action` names either a mode command — `hints`, `grid`, `recursive_grid`,
-`scroll`, `monitor_select`, `idle` — or one of the standalone commands. `args`
-carries the same flags a user would type.
+`scroll`, `monitor_select`, `idle`, or `mode` with the declared name as the
+first entry of `args` — or one of the standalone commands. `args` carries the
+same flags a user would type.
 
 A mode command's flags are read exactly as the CLI reads them, and answered
 with the same message: an unknown flag, a flag the named mode does not accept,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -31,6 +31,7 @@ keeps its default. "The daemon" below means the process started by
 | Section                                       | Controls                                     |
 | --------------------------------------------- | -------------------------------------------- |
 | [`[macros]`](#macros)                         | Named action sequences reused across bindings |
+| [`[modes]`](#modes)                           | Modes you declare: a keymap and an indicator  |
 | [`[general]`](#general)                       | Global behaviour, passthrough, `exec` shell   |
 | [`[theme]`](#theme)                           | Base palette all components derive from       |
 | [`[hints]`](#hints)                           | Hints mode and element discovery              |
@@ -709,6 +710,70 @@ shares the same definition rather than keeping its own copy:
 ```bash
 neru macro window_click 100 70
 ```
+
+---
+
+## [modes]
+
+Modes you declare yourself. A declared mode has no logic of its own: it is a
+name, an indicator label, and a hotkey table. While it is open Neru captures
+the keyboard, shows the indicator, and answers every key from that table, the
+way [scroll mode](#scroll) does with its own. Use one as a layer: a set of
+bare-letter bindings that only mean something after you enter the mode.
+
+```toml
+[modes.window]
+indicator = "Window"            # mode-indicator text; "" hides it
+
+[modes.window.hotkeys]
+"h" = "exec yabai -m window --focus west"
+"l" = "exec yabai -m window --focus east"
+"f" = ["exec yabai -m window --toggle zoom-fullscreen", "idle"]
+"s" = "scroll"                  # mode-to-mode transition, like any other
+
+[hotkeys]
+"Primary+Shift+W" = "mode window"
+```
+
+**Entering one.** The step is `mode <name>`, from a global hotkey, a macro, a
+`run`, or the command line as [`neru mode <name>`](CLI.md#neru-mode). It
+accepts `--toggle` and nothing else: a declared mode makes no selection, so
+none of the selection flags apply. A step naming a mode that is not declared
+is refused at load, like a typo'd flag.
+
+**Leaving one.** `Escape` is bound to `idle` by default, as it is in every
+mode, and `"Escape" = "__disabled__"` removes it. Any binding whose steps end
+in `idle` or another mode leaves too. While the mode is open, an unbound
+Ctrl/Alt/Cmd chord falls back to `[hotkeys]` under the
+[usual precedence](#per-mode-hotkeys); an unbound bare key is swallowed, as
+in scroll mode.
+
+### Options
+
+| Option      | Type   | Default | Description                                                 |
+| ----------- | ------ | ------- | ----------------------------------------------------------- |
+| `indicator` | string | `""`    | [Mode indicator](#mode_indicator) text while the mode is open; empty hides it |
+| `hotkeys`   | map    | `{ "Escape" = "idle" }` | The mode's [hotkeys](#per-mode-hotkeys), merged over the default |
+
+The name is the table key: letters, digits, `_` and `-`, starting with a
+letter. A built-in mode's name (`hints`, `grid`, `recursive_grid`, `scroll`,
+`monitor_select`, `idle`) and the word `mode` are refused.
+
+### Per-App Config
+
+| Field       | Type   | Description                                           |
+| ----------- | ------ | ----------------------------------------------------- |
+| `bundle_id` | string | App bundle ID                                         |
+| `hotkeys`   | map    | [per-app hotkey overrides](#per-app-hotkey-overrides) |
+
+```toml
+[[modes.window.app_configs]]
+bundle_id = "com.apple.Safari"
+hotkeys = { "h" = "action scroll_left", "l" = "action scroll_right" }
+```
+
+The indicator's style comes from [`[mode_indicator.ui]`](#mode_indicator),
+shared with the built-in modes.
 
 ## [general]
 

--- a/internal/adapter/overlay/adapter.go
+++ b/internal/adapter/overlay/adapter.go
@@ -128,7 +128,9 @@ func (a *Adapter) ShowFrame(ctx context.Context, frame ports.Frame) error {
 // Linux the mode and sticky-modifier indicators are badges painted on that
 // surface: the shared window's visibility is theirs. Deciding otherwise would
 // encode macOS's one-window-per-indicator model in shared code and leave a
-// Linux user in scroll mode with no indicator after a monitor move.
+// Linux user in scroll mode with no indicator after a monitor move. A declared
+// mode draws nothing of its own either, and needs the window for the same
+// reason.
 //
 // Every mode is named rather than defaulted, so a mode added without an answer
 // here fails the `exhaustive` linter instead of silently inheriting one. The
@@ -139,7 +141,7 @@ func drawsOnSharedWindow(frame ports.Frame) bool {
 	case domain.ModeMonitorSelect:
 		return false
 	case domain.ModeHints, domain.ModeGrid, domain.ModeRecursiveGrid,
-		domain.ModeScroll, domain.ModeIdle:
+		domain.ModeScroll, domain.ModeCustom, domain.ModeIdle:
 		return true
 	}
 

--- a/internal/adapter/overlay/adapter.go
+++ b/internal/adapter/overlay/adapter.go
@@ -97,7 +97,7 @@ func (a *Adapter) ShowFrame(ctx context.Context, frame ports.Frame) error {
 		return err
 	}
 
-	mode, modeErr := overlayMode(frame.Mode())
+	mode, modeErr := frameSurface(frame)
 	if modeErr != nil {
 		return modeErr
 	}
@@ -371,6 +371,20 @@ func (a *Adapter) UpdateGridPointer(mode domain.Mode, pointer ports.GridPointer)
 		pointer.Position,
 		pointerAppearance(ResolvedStyle(a.styles).VirtualPointer),
 	)
+}
+
+// frameSurface names the overlay mode a frame is realized in.
+//
+// A declared mode's frame is the one case where the enum is not the name: every
+// declaration shares domain.ModeCustom, and the overlay tells them apart by the
+// declared name, which is what the indicator's label is looked up by. So the
+// surface is the name itself, and the built-in modes go through overlayMode.
+func frameSurface(frame ports.Frame) (Mode, error) {
+	if custom, isCustom := frame.(ports.CustomFrame); isCustom {
+		return Mode(custom.Name), nil
+	}
+
+	return overlayMode(frame.Mode())
 }
 
 // overlayMode translates a mode into the overlay's own name for it. The two

--- a/internal/adapter/overlay/manager/components.go
+++ b/internal/adapter/overlay/manager/components.go
@@ -100,7 +100,12 @@ func (b *Base) BuildComponents(spec ComponentSpec) (Components, error) {
 		}
 	}
 
-	modeIndicator, err := modeindicator.NewOverlay(cfg.ModeIndicator, spec.Theme, logger)
+	modeIndicator, err := modeindicator.NewOverlay(
+		cfg.ModeIndicator,
+		cfg.CustomModeIndicators(),
+		spec.Theme,
+		logger,
+	)
 	if err != nil {
 		logger.Warn("Failed to build the mode indicator overlay", zap.Error(err))
 	} else {
@@ -193,7 +198,7 @@ func (b *Base) ConfigureComponents(cfg *config.Config, pointer PointerAppearance
 	}
 
 	if overlay := b.modeIndicatorOverlay; overlay != nil {
-		overlay.SetConfig(cfg.ModeIndicator)
+		overlay.SetConfig(cfg.ModeIndicator, cfg.CustomModeIndicators())
 	}
 
 	if overlay := b.stickyModifiersOverlay; overlay != nil {

--- a/internal/adapter/overlay/render/modeindicator/custom.go
+++ b/internal/adapter/overlay/render/modeindicator/custom.go
@@ -1,0 +1,20 @@
+package modeindicator
+
+import "github.com/y3owk1n/neru/internal/config"
+
+// customModeConfig is the per-mode indicator config of a declared mode, or nil
+// for a name no declaration gave a label.
+//
+// A declared mode has no [mode_indicator.<name>] section: its text is the
+// declaration's, and its colors are left zero so every backend falls back to
+// [mode_indicator.ui] through the same override it applies to a built-in mode
+// without colors of its own. Enabled is what the non-darwin label resolution
+// checks, and a label that exists is one that is shown.
+func customModeConfig(customLabels map[string]string, mode string) *config.ModeIndicatorModeConfig {
+	label, declared := customLabels[mode]
+	if !declared {
+		return nil
+	}
+
+	return &config.ModeIndicatorModeConfig{Enabled: true, Text: label}
+}

--- a/internal/adapter/overlay/render/modeindicator/overlay_darwin.go
+++ b/internal/adapter/overlay/render/modeindicator/overlay_darwin.go
@@ -35,8 +35,12 @@ const (
 type Overlay struct {
 	window          C.OverlayWindow
 	indicatorConfig config.ModeIndicatorConfig
-	theme           config.ThemeProvider
-	logger          *zap.Logger
+	// customLabels is the indicator text of every declared mode that has one,
+	// by name. A declared mode has no per-mode section of its own: its label
+	// is the declaration's, and its colors are the shared UI defaults.
+	customLabels map[string]string
+	theme        config.ThemeProvider
+	logger       *zap.Logger
 
 	// styleCache holds cached C style strings for the currently drawn mode.
 	// It is shared across all modes and invalidated on mode change via
@@ -65,6 +69,7 @@ type Overlay struct {
 // NewOverlay creates a new mode indicator overlay instance with its own window.
 func NewOverlay(
 	indicatorCfg config.ModeIndicatorConfig,
+	customLabels map[string]string,
 	theme config.ThemeProvider,
 	logger *zap.Logger,
 ) (*Overlay, error) {
@@ -76,6 +81,7 @@ func NewOverlay(
 	return &Overlay{
 		window:          (C.OverlayWindow)(base.Window),
 		indicatorConfig: indicatorCfg,
+		customLabels:    customLabels,
 		theme:           theme,
 		logger:          logger,
 		styleCache:      base.StyleCache,
@@ -277,10 +283,15 @@ func (o *Overlay) DrawModeIndicator(mode string, xCoordinate, yCoordinate int) {
 	C.NeruDrawHints(o.window, &hint, 1, style)
 }
 
-// SetConfig sets the overlay configuration.
-func (o *Overlay) SetConfig(indicatorCfg config.ModeIndicatorConfig) {
+// SetConfig sets the overlay configuration, and the labels of the declared
+// modes alongside it.
+func (o *Overlay) SetConfig(
+	indicatorCfg config.ModeIndicatorConfig,
+	customLabels map[string]string,
+) {
 	o.configMu.Lock()
 	o.indicatorConfig = indicatorCfg
+	o.customLabels = customLabels
 	o.configMu.Unlock()
 	// Invalidate caches when config changes
 	o.freeAllCaches()
@@ -319,7 +330,7 @@ func (o *Overlay) resolveModeConfig(mode string) *config.ModeIndicatorModeConfig
 	case domain.ModeNameRecursiveGrid:
 		return &o.indicatorConfig.RecursiveGrid
 	default:
-		return nil
+		return customModeConfig(o.customLabels, mode)
 	}
 }
 

--- a/internal/adapter/overlay/render/modeindicator/overlay_other.go
+++ b/internal/adapter/overlay/render/modeindicator/overlay_other.go
@@ -17,19 +17,24 @@ import (
 // resolves the per-mode label both managers render.
 type Overlay struct {
 	indicatorConfig config.ModeIndicatorConfig
-	theme           config.ThemeProvider
-	logger          *zap.Logger
-	configMu        sync.RWMutex
+	// customLabels is the indicator text of every declared mode that has one,
+	// by name; see the darwin overlay for why it sits beside the config.
+	customLabels map[string]string
+	theme        config.ThemeProvider
+	logger       *zap.Logger
+	configMu     sync.RWMutex
 }
 
 // NewOverlay creates a new mode indicator overlay instance with its own window (non-darwin stub).
 func NewOverlay(
 	indicatorCfg config.ModeIndicatorConfig,
+	customLabels map[string]string,
 	theme config.ThemeProvider,
 	logger *zap.Logger,
 ) (*Overlay, error) {
 	return &Overlay{
 		indicatorConfig: indicatorCfg,
+		customLabels:    customLabels,
 		theme:           theme,
 		logger:          logger,
 	}, nil
@@ -60,17 +65,14 @@ func (o *Overlay) ResizeToActiveScreen() {}
 // Destroy destroys the mode indicator overlay (non-darwin stub).
 func (o *Overlay) Destroy() {}
 
-// SetConfig updates the indicator configuration (non-darwin stub).
-func (o *Overlay) SetConfig(cfg config.ModeIndicatorConfig) {
+// SetConfig updates the indicator configuration and the labels of the declared
+// modes (non-darwin stub).
+func (o *Overlay) SetConfig(cfg config.ModeIndicatorConfig, customLabels map[string]string) {
 	o.configMu.Lock()
 	defer o.configMu.Unlock()
 
 	o.indicatorConfig = cfg
-}
-
-// SetIndicatorConfig updates the indicator configuration (non-darwin stub).
-func (o *Overlay) SetIndicatorConfig(cfg config.ModeIndicatorConfig) {
-	o.SetConfig(cfg)
+	o.customLabels = customLabels
 }
 
 // IndicatorConfig returns the indicator configuration (non-darwin stub).
@@ -130,6 +132,6 @@ func (o *Overlay) resolveModeConfigLocked(mode string) *config.ModeIndicatorMode
 	case "recursive_grid":
 		return &o.indicatorConfig.RecursiveGrid
 	default:
-		return nil
+		return customModeConfig(o.customLabels, mode)
 	}
 }

--- a/internal/adapter/overlay/render/modeindicator/overlay_other_test.go
+++ b/internal/adapter/overlay/render/modeindicator/overlay_other_test.go
@@ -26,7 +26,7 @@ func TestOverlay_ResolveLabelText_Semantics(t *testing.T) {
 		},
 	}
 
-	overlay, err := modeindicator.NewOverlay(cfg, nil, nil)
+	overlay, err := modeindicator.NewOverlay(cfg, map[string]string{"window": "Window"}, nil, nil)
 	if err != nil {
 		t.Fatalf("NewOverlay returned error: %v", err)
 	}
@@ -40,6 +40,9 @@ func TestOverlay_ResolveLabelText_Semantics(t *testing.T) {
 		{name: "empty text falls back to mode name", mode: "grid", want: "grid"},
 		{name: "disabled mode draws nothing even with text", mode: "scroll", want: ""},
 		{name: "unknown mode draws nothing", mode: "bogus", want: ""},
+		// A declared mode is named by its declaration, and its label is the
+		// one the declaration gave it.
+		{name: "declared mode shows its declared label", mode: "window", want: "Window"},
 	}
 
 	for _, tc := range tests {
@@ -59,7 +62,7 @@ func TestOverlay_ResolveLabelText_Semantics(t *testing.T) {
 func TestOverlay_ResolveModeConfig_UnknownMode(t *testing.T) {
 	t.Parallel()
 
-	overlay, err := modeindicator.NewOverlay(config.ModeIndicatorConfig{}, nil, nil)
+	overlay, err := modeindicator.NewOverlay(config.ModeIndicatorConfig{}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewOverlay returned error: %v", err)
 	}

--- a/internal/adapter/overlay/render/modeindicator/overlay_stub_contract_other_test.go
+++ b/internal/adapter/overlay/render/modeindicator/overlay_stub_contract_other_test.go
@@ -27,7 +27,7 @@ import (
 func TestOverlay_DrawModeIndicatorReportsNotSupportedOffDarwin(t *testing.T) {
 	t.Parallel()
 
-	overlay, err := modeindicator.NewOverlay(config.DefaultConfig().ModeIndicator, nil, nil)
+	overlay, err := modeindicator.NewOverlay(config.DefaultConfig().ModeIndicator, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewOverlay returned error: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestOverlay_DrawModeIndicatorReportsNotSupportedOffDarwin(t *testing.T) {
 func TestOverlay_DrawModeIndicatorIsStableAcrossCalls(t *testing.T) {
 	t.Parallel()
 
-	overlay, err := modeindicator.NewOverlay(config.DefaultConfig().ModeIndicator, nil, nil)
+	overlay, err := modeindicator.NewOverlay(config.DefaultConfig().ModeIndicator, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewOverlay returned error: %v", err)
 	}

--- a/internal/app/ipcctrl/custom_mode_test.go
+++ b/internal/app/ipcctrl/custom_mode_test.go
@@ -1,0 +1,84 @@
+package ipcctrl_test
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/adapter/ipc"
+	"github.com/y3owk1n/neru/internal/app/ipcctrl"
+	"github.com/y3owk1n/neru/internal/app/services"
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/config/loader"
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/state"
+	portmocks "github.com/y3owk1n/neru/internal/ports/mocks"
+)
+
+// newDeclaredModeController builds a controller over a configuration that
+// declares one mode, so the custom mode command has something to enter.
+func newDeclaredModeController() (*ipcctrl.Controller, *state.AppState) {
+	cfg := config.DefaultConfig()
+	cfg.Modes = map[string]config.CustomModeConfig{
+		"window": {Hotkeys: config.DefaultCustomModeHotkeys()},
+	}
+
+	logger := zap.NewNop()
+	appState := state.NewAppState()
+	actionService := services.NewActionService(
+		&portmocks.MockAccessibilityPort{},
+		&portmocks.MockOverlayPort{},
+		&portmocks.MockSystemPort{},
+		logger,
+	)
+
+	return ipcctrl.New(ipcctrl.Deps{
+		ActionService: actionService,
+		ConfigService: loader.NewService(cfg, "", logger, nil),
+		AppState:      appState,
+		Config:        cfg,
+		Modes:         newTestModesHandler(cfg, logger, appState, actionService),
+		Logger:        logger,
+	}), appState
+}
+
+// TestHandleCommand_CustomModeCommandEntersADeclaredMode pins the wire shape
+// of "mode <name>": the name travels as the first argument, a declared one is
+// entered, and an undeclared one is refused in the grammar's words with the
+// code a script branches on.
+func TestHandleCommand_CustomModeCommandEntersADeclaredMode(t *testing.T) {
+	controller, appState := newDeclaredModeController()
+
+	resp := controller.HandleCommand(context.Background(), ipc.Command{
+		Action: domain.ModeNameCustom,
+		Args:   []string{"window"},
+	})
+	if !resp.Success {
+		t.Fatalf("mode window was refused: %s", resp.Message)
+	}
+
+	if resp.Message != "custom mode activated" {
+		t.Errorf("message = %q, want %q", resp.Message, "custom mode activated")
+	}
+
+	if got := appState.CurrentMode(); got != domain.ModeCustom {
+		t.Errorf("mode = %v after the command, want ModeCustom", got)
+	}
+
+	refused := controller.HandleCommand(context.Background(), ipc.Command{
+		Action: domain.ModeNameCustom,
+		Args:   []string{"nobody"},
+	})
+	if refused.Success {
+		t.Fatal("mode nobody was accepted; want a refusal")
+	}
+
+	if refused.Code != ipc.CodeInvalidInput {
+		t.Errorf("code = %q, want %q", refused.Code, ipc.CodeInvalidInput)
+	}
+
+	if want := `mode "nobody" is not declared; declare it as [modes.nobody]`; refused.Message != want {
+		t.Errorf("message = %q, want %q", refused.Message, want)
+	}
+}

--- a/internal/app/ipcctrl/handlers_test.go
+++ b/internal/app/ipcctrl/handlers_test.go
@@ -9,6 +9,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/neru/internal/adapter/ipc"
+	"github.com/y3owk1n/neru/internal/app/components"
+	"github.com/y3owk1n/neru/internal/app/components/scroll"
 	"github.com/y3owk1n/neru/internal/app/ipcctrl"
 	"github.com/y3owk1n/neru/internal/app/modes"
 	"github.com/y3owk1n/neru/internal/app/services"
@@ -39,6 +41,7 @@ func newTestModesHandler(
 		Logger:                logger,
 		AppState:              appState,
 		CursorState:           state.NewCursorState(),
+		ScrollComponent:       &components.ScrollComponent{Context: &scroll.Context{}},
 		ActionService:         actionService,
 		RefreshHotkeys:        func() {},
 		ExecuteActionSequence: func(string, []string) {},

--- a/internal/app/ipcctrl/info.go
+++ b/internal/app/ipcctrl/info.go
@@ -174,7 +174,7 @@ func (h *InfoHandler) handleStatus(_ context.Context, _ ipc.Command) ipc.Respons
 
 	status := map[string]any{
 		"enabled":                h.appState.IsEnabled(),
-		"mode":                   domain.ModeString(h.appState.CurrentMode()),
+		"mode":                   h.appState.ModeName(),
 		"config":                 configPath,
 		"hints_enabled":          cfg.Hints.Enabled,
 		"grid_enabled":           cfg.Grid.Enabled,

--- a/internal/app/ipcctrl/modes.go
+++ b/internal/app/ipcctrl/modes.go
@@ -54,6 +54,7 @@ var activationMessages = map[domain.Mode]string{
 	domain.ModeScroll:        "scroll mode activated",
 	domain.ModeMonitorSelect: "monitor_select mode activated",
 	domain.ModeIdle:          "idle mode activated",
+	domain.ModeCustom:        "custom mode activated",
 }
 
 // activationHandler answers a mode command by entering the mode it names.
@@ -73,6 +74,13 @@ func (h *ModesHandler) activationHandler(
 		activation, err := modecmd.Parse(mode, cmd.Args)
 		if err != nil {
 			return refusalFor(err)
+		}
+
+		// The grammar reads the declared name; whether anything declares it
+		// is the configuration's answer, and a caller is told here rather
+		// than by an activation that cannot report back.
+		if mode == domain.ModeCustom && !h.modes.DeclaresMode(activation.Name) {
+			return refusalFor(modecmd.NotDeclared(activation.Name))
 		}
 
 		h.modes.ActivateMode(activation)

--- a/internal/app/ipcctrl/modes_test.go
+++ b/internal/app/ipcctrl/modes_test.go
@@ -46,7 +46,7 @@ func newModeTestController() *ipcctrl.Controller {
 }
 
 // TestHandleCommand_EveryModeCommandReadsTheGrammar pins that no mode is an
-// exception. Each of the six answers a command it cannot read with a refusal
+// exception. Each of the seven answers a command it cannot read with a refusal
 // of its own rather than with "unknown command" or a silent success.
 func TestHandleCommand_EveryModeCommandReadsTheGrammar(t *testing.T) {
 	controller := newModeTestController()
@@ -58,6 +58,7 @@ func TestHandleCommand_EveryModeCommandReadsTheGrammar(t *testing.T) {
 		domain.ModeScroll,
 		domain.ModeMonitorSelect,
 		domain.ModeIdle,
+		domain.ModeCustom,
 	} {
 		name := domain.ModeString(mode)
 

--- a/internal/app/keybinding/binder.go
+++ b/internal/app/keybinding/binder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/y3owk1n/neru/internal/config"
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/action"
+	"github.com/y3owk1n/neru/internal/domain/modecmd"
 	"github.com/y3owk1n/neru/internal/ports"
 )
 
@@ -346,22 +347,14 @@ func ModifiersFromKey(key string) action.Modifiers {
 	return mods
 }
 
-// actionsContainModeSwitch reports whether any action in the list is a
-// mode-switch action (hints, grid, recursive_grid, scroll, monitor_select).
+// actionsContainModeSwitch reports whether any action in the list enters a
+// mode: a built-in one by its name, or a declared one by "mode <name>". Idle
+// is a mode command that leaves one, and does not count.
 func actionsContainModeSwitch(actions []string, cfg *config.Config) bool {
 	return anyBindingStep(actions, cfg, func(step string) bool {
-		// The action format is "<mode_name>" with optional args, so split
-		// to get just the mode name for comparison.
-		switch commandOf(step) {
-		case domain.ModeString(domain.ModeHints),
-			domain.ModeString(domain.ModeGrid),
-			domain.ModeString(domain.ModeRecursiveGrid),
-			domain.ModeString(domain.ModeScroll),
-			domain.ModeString(domain.ModeMonitorSelect):
-			return true
-		default:
-			return false
-		}
+		mode, isMode := modecmd.LookupMode(commandOf(step))
+
+		return isMode && mode != domain.ModeIdle
 	})
 }
 

--- a/internal/app/keybinding/binder_test.go
+++ b/internal/app/keybinding/binder_test.go
@@ -279,6 +279,20 @@ func TestBindingInspectionSeesModesInsideRun(t *testing.T) {
 			wantModeSwitch: true,
 		},
 		{
+			// A declared mode is entered by the mode word, so the chord that
+			// enters it has its modifiers suppressed like any other.
+			name:           "declared mode by the mode word",
+			actions:        []string{"mode window"},
+			wantModeSwitch: true,
+		},
+		{
+			// Idle is a mode command that leaves a mode, and nothing about the
+			// chord that left needs suppressing.
+			name:           "idle leaves rather than enters",
+			actions:        []string{"idle"},
+			wantModeSwitch: false,
+		},
+		{
 			name:           "mode inside run",
 			actions:        []string{"run 'action save_cursor_pos' '" + hintsStep + "'"},
 			wantModeSwitch: true,

--- a/internal/app/modes/custom_mode.go
+++ b/internal/app/modes/custom_mode.go
@@ -1,0 +1,149 @@
+package modes
+
+import (
+	"context"
+	"image"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/modecmd"
+	"github.com/y3owk1n/neru/internal/ports"
+)
+
+// Compile-time interface compliance checks: the core interface, then every
+// optional extension a declared mode opts into (extensions.go).
+var (
+	_ Mode                   = (*CustomMode)(nil)
+	_ hotkeyOverrideReporter = (*CustomMode)(nil)
+)
+
+// CustomMode implements the Mode interface for every mode the user declared
+// under [modes.<name>]. One implementation serves them all: a declared mode
+// has no logic of its own, so what tells one from another is the name on the
+// handler, which picks the keymap, the indicator label and the frame.
+//
+// It is scroll mode without the scrolling. It draws nothing, captures the
+// keyboard, answers every key from the settled keymap, and shows the mode
+// indicator with the label the declaration gave it.
+type CustomMode struct {
+	baseMode
+}
+
+// NewCustomMode creates the mode implementation every declared mode runs on.
+func NewCustomMode(handler *handlerState) *CustomMode {
+	return &CustomMode{
+		baseMode: newBaseMode(handler, domain.ModeCustom, "CustomMode"),
+	}
+}
+
+// Activate enters the declared mode the activation names.
+//
+// --toggle is the only flag a declared mode accepts, and the handler answers
+// that before a mode is reached. The name is checked against the
+// configuration here as well as at the IPC boundary, because an internal
+// caller can build an activation the grammar never saw.
+func (m *CustomMode) Activate(activation modecmd.Activation) {
+	m.handler.startCustomMode(activation.Name)
+}
+
+// HandleKey processes a key press within a declared mode. Nothing is done
+// here: a declared mode's keys are fully driven by its hotkey table.
+func (m *CustomMode) HandleKey(_ string) {}
+
+// RefreshForMonitorMove switches the overlay back to the declared mode on the
+// display the cursor landed on, for the reason scroll does: the indicators
+// naming the mode are painted on the shared surface on Linux.
+func (m *CustomMode) RefreshForMonitorMove(_ context.Context, _ image.Rectangle) {
+	m.handler.showFrame(m.handler.customFrame(), "refresh custom mode after monitor move")
+}
+
+// Exit tears the declared mode down. The name is cleared when the handler
+// leaves ModeCustom, in setAppMode, so a late reader still sees which
+// declaration the session was in until then.
+func (m *CustomMode) Exit() {
+	// Common cleanup takes the frame off the screen; stopping the poller
+	// first keeps a late tick from putting an indicator back.
+	m.handler.stopIndicatorPolling()
+	m.handler.stopHeldRepeat()
+
+	if m.handler.cursorState != nil {
+		m.handler.cursorState.Reset()
+	}
+}
+
+// HasAppHotkeyOverrides reports whether the declared mode's [[app_configs]]
+// binds any per-app hotkey. It is what lets the keymap settle without asking
+// which app is focused when no declaration cares.
+func (m *CustomMode) HasAppHotkeyOverrides() bool {
+	if m.handler.config == nil {
+		return false
+	}
+
+	return m.handler.config.Modes[m.handler.customModeName].HasAppHotkeyOverrides()
+}
+
+// startCustomMode enters the declared mode called name.
+//
+// It is scroll's activation with the name set before the mode is entered,
+// because entering the mode settles the keymap, and the keymap of a declared
+// mode is looked up by that name.
+//
+// Caller must hold h.mu.
+func (h *handlerState) startCustomMode(name string) {
+	if h.config == nil {
+		return
+	}
+
+	if _, declared := h.config.Modes[name]; !declared {
+		h.logger.Warn("Custom mode activation refused: mode is not declared",
+			zap.String("mode", name))
+
+		return
+	}
+
+	h.prepareForModeActivation()
+	h.cursorState.SkipNextRestore()
+
+	if h.appState.CurrentMode() != domain.ModeIdle {
+		h.cleanupForKeymapModeTransition()
+
+		h.logger.Debug("Transitioned to custom mode",
+			zap.String("from", h.CurrModeString()))
+	}
+
+	h.customModeName = name
+
+	h.enterMode(domain.ModeCustom)
+
+	// Entering a declared mode is a transition like entering scroll: the
+	// frame takes the previous mode's drawing off the shared surface and
+	// tells the overlay which mode the indicators are naming.
+	h.showFrame(h.customFrame(), "show custom mode overlay")
+	h.startIndicatorPolling(domain.ModeCustom)
+
+	h.logger.Info("Custom mode activated", zap.String("mode", name))
+}
+
+// customFrame is the frame of the declared mode the handler is in.
+//
+// Caller must hold h.mu.
+func (h *handlerState) customFrame() ports.CustomFrame {
+	return ports.CustomFrame{Name: h.customModeName}
+}
+
+// DeclaresMode reports whether the configuration declares a mode called name,
+// for the caller that has to refuse "mode <name>" before it reaches an
+// activation that cannot answer.
+func (h *Handler) DeclaresMode(name string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.config == nil {
+		return false
+	}
+
+	_, declared := h.config.Modes[name]
+
+	return declared
+}

--- a/internal/app/modes/custom_mode.go
+++ b/internal/app/modes/custom_mode.go
@@ -58,9 +58,9 @@ func (m *CustomMode) RefreshForMonitorMove(_ context.Context, _ image.Rectangle)
 	m.handler.showFrame(m.handler.customFrame(), "refresh custom mode after monitor move")
 }
 
-// Exit tears the declared mode down. The name is cleared when the handler
-// leaves ModeCustom, in setAppMode, so a late reader still sees which
-// declaration the session was in until then.
+// Exit tears the declared mode down. The name is cleared when the app state
+// leaves ModeCustom, so a late reader still sees which declaration the
+// session was in until then.
 func (m *CustomMode) Exit() {
 	// Common cleanup takes the frame off the screen; stopping the poller
 	// first keeps a late tick from putting an indicator back.
@@ -80,7 +80,7 @@ func (m *CustomMode) HasAppHotkeyOverrides() bool {
 		return false
 	}
 
-	return m.handler.config.Modes[m.handler.customModeName].HasAppHotkeyOverrides()
+	return m.handler.config.Modes[m.handler.appState.CustomModeName()].HasAppHotkeyOverrides()
 }
 
 // startCustomMode enters the declared mode called name.
@@ -112,7 +112,7 @@ func (h *handlerState) startCustomMode(name string) {
 			zap.String("from", h.CurrModeString()))
 	}
 
-	h.customModeName = name
+	h.appState.SetCustomModeName(name)
 
 	h.enterMode(domain.ModeCustom)
 
@@ -129,7 +129,7 @@ func (h *handlerState) startCustomMode(name string) {
 //
 // Caller must hold h.mu.
 func (h *handlerState) customFrame() ports.CustomFrame {
-	return ports.CustomFrame{Name: h.customModeName}
+	return ports.CustomFrame{Name: h.appState.CustomModeName()}
 }
 
 // DeclaresMode reports whether the configuration declares a mode called name,

--- a/internal/app/modes/custom_mode_test.go
+++ b/internal/app/modes/custom_mode_test.go
@@ -1,0 +1,184 @@
+package modes
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/app/components"
+	"github.com/y3owk1n/neru/internal/app/components/scroll"
+	configpkg "github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/modecmd"
+	"github.com/y3owk1n/neru/internal/domain/state"
+)
+
+// The declarations these cases enter.
+const (
+	declaredWindow = "window"
+	declaredTabs   = "tabs"
+	stepFocusWest  = "exec yabai -m window --focus west"
+	stepNextTab    = "action feed ctrl+tab"
+)
+
+// configDeclaring is a configuration declaring window and tabs, each with one
+// bare-letter binding over the default Escape.
+func configDeclaring() *configpkg.Config {
+	declare := func(key, step string) configpkg.CustomModeConfig {
+		table := configpkg.DefaultCustomModeHotkeys()
+		table[key] = configpkg.StringOrStringArray{step}
+
+		return configpkg.CustomModeConfig{Hotkeys: table}
+	}
+
+	return &configpkg.Config{
+		Modes: map[string]configpkg.CustomModeConfig{
+			declaredWindow: declare("h", stepFocusWest),
+			declaredTabs:   declare("n", stepNextTab),
+		},
+	}
+}
+
+// newCustomModeHandler builds a handler on the declared configuration that
+// records every sequence a key dispatches.
+func newCustomModeHandler(cfg *configpkg.Config) (*Handler, chan string) {
+	ran := make(chan string, 4)
+
+	handler := newHandlerWithState(handlerState{
+		ctx:           context.Background(),
+		config:        cfg,
+		logger:        zap.NewNop(),
+		appState:      state.NewAppState(),
+		cursorState:   state.NewCursorState(),
+		modifierState: state.NewModifierState(),
+		scroll:        &components.ScrollComponent{Context: &scroll.Context{}},
+		executeActionSequence: func(_ string, steps []string) {
+			for _, step := range steps {
+				ran <- step
+			}
+		},
+	})
+
+	return handler, ran
+}
+
+func activate(name string, toggle bool) modecmd.Activation {
+	activation := modecmd.Activation{Mode: domain.ModeCustom, Name: name}
+	if toggle {
+		activation.Toggle = new(true)
+	}
+
+	return activation
+}
+
+// TestCustomMode_Activate_EntersTheDeclaredModeAndAnswersItsKeys pins the
+// whole path a declared mode exists for: entering it by name settles that
+// declaration's keymap, a bound bare key runs its steps, the default Escape
+// binding leads out, and leaving clears the name.
+func TestCustomMode_Activate_EntersTheDeclaredModeAndAnswersItsKeys(t *testing.T) {
+	t.Parallel()
+
+	handler, ran := newCustomModeHandler(configDeclaring())
+
+	handler.ActivateMode(activate(declaredWindow, false))
+
+	if got := handler.appState.CurrentMode(); got != domain.ModeCustom {
+		t.Fatalf("mode = %v after activation, want ModeCustom", got)
+	}
+
+	if handler.customModeName != declaredWindow {
+		t.Fatalf("customModeName = %q, want %q", handler.customModeName, declaredWindow)
+	}
+
+	handler.HandleKeyPress("h")
+	waitForStep(t, ran, stepFocusWest)
+
+	handler.HandleKeyPress("Escape")
+	waitForStep(t, ran, configpkg.CmdIdle)
+
+	handler.ActivateMode(modecmd.Activation{Mode: domain.ModeIdle})
+
+	if got := handler.appState.CurrentMode(); got != domain.ModeIdle {
+		t.Fatalf("mode = %v after idle, want ModeIdle", got)
+	}
+
+	if handler.customModeName != "" {
+		t.Errorf("customModeName = %q after leaving, want it cleared", handler.customModeName)
+	}
+}
+
+// TestCustomMode_Activate_SwitchesBetweenDeclarations pins that two declared
+// modes are two modes even though they share one enum value: entering the
+// second from the first switches the keymap, and --toggle exits only when the
+// name matches the one already open.
+func TestCustomMode_Activate_SwitchesBetweenDeclarations(t *testing.T) {
+	t.Parallel()
+
+	handler, ran := newCustomModeHandler(configDeclaring())
+
+	handler.ActivateMode(activate(declaredWindow, false))
+	handler.ActivateMode(activate(declaredTabs, true))
+
+	if got := handler.appState.CurrentMode(); got != domain.ModeCustom {
+		t.Fatalf("toggling another declaration exited to %v, want a switch", got)
+	}
+
+	if handler.customModeName != declaredTabs {
+		t.Fatalf("customModeName = %q, want %q", handler.customModeName, declaredTabs)
+	}
+
+	handler.HandleKeyPress("n")
+	waitForStep(t, ran, stepNextTab)
+
+	handler.ActivateMode(activate(declaredTabs, true))
+
+	if got := handler.appState.CurrentMode(); got != domain.ModeIdle {
+		t.Fatalf("toggling the open declaration left the mode at %v, want idle", got)
+	}
+}
+
+// TestCustomMode_Activate_RefusesAnUndeclaredName pins that an activation the
+// grammar never saw cannot enter a mode nothing declares: the daemon stays
+// idle with the keyboard uncaptured rather than in a mode that answers nothing.
+func TestCustomMode_Activate_RefusesAnUndeclaredName(t *testing.T) {
+	t.Parallel()
+
+	handler, _ := newCustomModeHandler(configDeclaring())
+
+	handler.ActivateMode(activate("nobody", false))
+
+	if got := handler.appState.CurrentMode(); got != domain.ModeIdle {
+		t.Fatalf("mode = %v after an undeclared name, want idle", got)
+	}
+
+	if handler.DeclaresMode("nobody") || !handler.DeclaresMode(declaredWindow) {
+		t.Error("DeclaresMode() disagrees with the configuration")
+	}
+}
+
+// TestUpdateConfig_ExitsADeclaredModeTheReloadDropped pins the reload rule: a
+// mode the new configuration no longer declares has no keymap to settle, so
+// the session ends rather than leaving the keyboard captured.
+func TestUpdateConfig_ExitsADeclaredModeTheReloadDropped(t *testing.T) {
+	t.Parallel()
+
+	handler, _ := newCustomModeHandler(configDeclaring())
+
+	handler.ActivateMode(activate(declaredWindow, false))
+
+	kept := configDeclaring()
+	handler.UpdateConfig(kept)
+
+	if got := handler.appState.CurrentMode(); got != domain.ModeCustom {
+		t.Fatalf("a reload that keeps the declaration exited to %v", got)
+	}
+
+	dropped := configDeclaring()
+	delete(dropped.Modes, declaredWindow)
+	handler.UpdateConfig(dropped)
+
+	if got := handler.appState.CurrentMode(); got != domain.ModeIdle {
+		t.Fatalf("a reload that drops the declaration left the mode at %v, want idle", got)
+	}
+}

--- a/internal/app/modes/custom_mode_test.go
+++ b/internal/app/modes/custom_mode_test.go
@@ -87,8 +87,8 @@ func TestCustomMode_Activate_EntersTheDeclaredModeAndAnswersItsKeys(t *testing.T
 		t.Fatalf("mode = %v after activation, want ModeCustom", got)
 	}
 
-	if handler.customModeName != declaredWindow {
-		t.Fatalf("customModeName = %q, want %q", handler.customModeName, declaredWindow)
+	if handler.appState.CustomModeName() != declaredWindow {
+		t.Fatalf("customModeName = %q, want %q", handler.appState.CustomModeName(), declaredWindow)
 	}
 
 	handler.HandleKeyPress("h")
@@ -103,8 +103,11 @@ func TestCustomMode_Activate_EntersTheDeclaredModeAndAnswersItsKeys(t *testing.T
 		t.Fatalf("mode = %v after idle, want ModeIdle", got)
 	}
 
-	if handler.customModeName != "" {
-		t.Errorf("customModeName = %q after leaving, want it cleared", handler.customModeName)
+	if handler.appState.CustomModeName() != "" {
+		t.Errorf(
+			"customModeName = %q after leaving, want it cleared",
+			handler.appState.CustomModeName(),
+		)
 	}
 }
 
@@ -124,8 +127,8 @@ func TestCustomMode_Activate_SwitchesBetweenDeclarations(t *testing.T) {
 		t.Fatalf("toggling another declaration exited to %v, want a switch", got)
 	}
 
-	if handler.customModeName != declaredTabs {
-		t.Fatalf("customModeName = %q, want %q", handler.customModeName, declaredTabs)
+	if handler.appState.CustomModeName() != declaredTabs {
+		t.Fatalf("customModeName = %q, want %q", handler.appState.CustomModeName(), declaredTabs)
 	}
 
 	handler.HandleKeyPress("n")

--- a/internal/app/modes/extensions_test.go
+++ b/internal/app/modes/extensions_test.go
@@ -133,6 +133,9 @@ var modeExtensionMatrix = map[domain.Mode][]extensionName{
 		extensionInputEditing,
 		extensionThemeRefresh,
 	},
+	domain.ModeCustom: {
+		extensionHotkeyOverrides,
+	},
 }
 
 // TestModeExtensionMatrix pins what every registered mode does on every

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -164,12 +164,8 @@ type handlerState struct {
 	shutdown              func()
 	refreshHintsTimer     *time.Timer
 	modeSession           uint64
-	// customModeName is the declared mode a ModeCustom session is in, and
-	// empty outside one. It is what tells one declaration from another
-	// wherever the enum alone cannot: the keymap, the indicator, the frame.
-	customModeName    string
-	hotkeyLastKey     string
-	hotkeyLastKeyTime int64
+	hotkeyLastKey         string
+	hotkeyLastKeyTime     int64
 
 	textInput                  ports.TextInputPort
 	hintSearchTextInputActive  bool
@@ -416,7 +412,7 @@ func (h *Handler) ActivateMode(activation modecmd.Activation) {
 	// enum value, so there "already active" also means the same name: toggling
 	// one declared mode from inside another switches rather than exits.
 	if activation.Toggle != nil && *activation.Toggle && h.appState.CurrentMode() == mode &&
-		(mode != domain.ModeCustom || h.customModeName == activation.Name) {
+		(mode != domain.ModeCustom || h.appState.CustomModeName() == activation.Name) {
 		h.exitMode()
 
 		return
@@ -467,9 +463,10 @@ func (h *Handler) UpdateConfig(config *configpkg.Config) {
 	// to settle and no way out but this one, so the session ends here rather
 	// than leaving the keyboard captured by a mode that answers nothing.
 	if h.appState.CurrentMode() == domain.ModeCustom {
-		if _, declared := config.Modes[h.customModeName]; !declared {
+		name := h.appState.CustomModeName()
+		if _, declared := config.Modes[name]; !declared {
 			h.logger.Info("Custom mode exited: the reloaded configuration no longer declares it",
-				zap.String("mode", h.customModeName))
+				zap.String("mode", name))
 			h.exitMode()
 		}
 	}

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -351,6 +351,7 @@ func newModes(state *handlerState) map[domain.Mode]Mode {
 		domain.ModeScroll:        NewScrollMode(state),
 		domain.ModeRecursiveGrid: NewRecursiveGridMode(state),
 		domain.ModeMonitorSelect: NewMonitorSelectMode(state),
+		domain.ModeCustom:        NewCustomMode(state),
 	}
 }
 
@@ -411,8 +412,11 @@ func (h *Handler) ActivateMode(activation modecmd.Activation) {
 	mode := activation.Mode
 
 	// Toggle: if the mode is already active and --toggle was specified,
-	// exit to idle instead of re-activating
-	if activation.Toggle != nil && *activation.Toggle && h.appState.CurrentMode() == mode {
+	// exit to idle instead of re-activating. Every declared mode shares one
+	// enum value, so there "already active" also means the same name: toggling
+	// one declared mode from inside another switches rather than exits.
+	if activation.Toggle != nil && *activation.Toggle && h.appState.CurrentMode() == mode &&
+		(mode != domain.ModeCustom || h.customModeName == activation.Name) {
 		h.exitMode()
 
 		return
@@ -458,6 +462,17 @@ func (h *Handler) UpdateConfig(config *configpkg.Config) {
 	h.config = config
 
 	h.updateComponentConfigs(config)
+
+	// A declared mode the new configuration no longer declares has no keymap
+	// to settle and no way out but this one, so the session ends here rather
+	// than leaving the keyboard captured by a mode that answers nothing.
+	if h.appState.CurrentMode() == domain.ModeCustom {
+		if _, declared := config.Modes[h.customModeName]; !declared {
+			h.logger.Info("Custom mode exited: the reloaded configuration no longer declares it",
+				zap.String("mode", h.customModeName))
+			h.exitMode()
+		}
+	}
 
 	// Replacing the configuration replaces what is bound, and settling it here
 	// rather than on the next keystroke is what keeps the keystroke path unable

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -164,8 +164,12 @@ type handlerState struct {
 	shutdown              func()
 	refreshHintsTimer     *time.Timer
 	modeSession           uint64
-	hotkeyLastKey         string
-	hotkeyLastKeyTime     int64
+	// customModeName is the declared mode a ModeCustom session is in, and
+	// empty outside one. It is what tells one declaration from another
+	// wherever the enum alone cannot: the keymap, the indicator, the frame.
+	customModeName    string
+	hotkeyLastKey     string
+	hotkeyLastKeyTime int64
 
 	textInput                  ports.TextInputPort
 	hintSearchTextInputActive  bool

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -310,6 +310,10 @@ func (h *handlerState) modeIndicatorEnabled(mode domain.Mode) bool {
 		return h.config.ModeIndicator.RecursiveGrid.Enabled
 	case domain.ModeMonitorSelect:
 		return h.config.ModeIndicator.MonitorSelect.Enabled
+	case domain.ModeCustom:
+		// A declared mode has no enabled flag: its indicator is shown when it
+		// was given text, and an undeclared name reads the zero value.
+		return h.config.Modes[h.customModeName].Indicator != ""
 	default:
 		return false
 	}

--- a/internal/app/modes/indicator_polling.go
+++ b/internal/app/modes/indicator_polling.go
@@ -313,7 +313,7 @@ func (h *handlerState) modeIndicatorEnabled(mode domain.Mode) bool {
 	case domain.ModeCustom:
 		// A declared mode has no enabled flag: its indicator is shown when it
 		// was given text, and an undeclared name reads the zero value.
-		return h.config.Modes[h.customModeName].Indicator != ""
+		return h.config.Modes[h.appState.CustomModeName()].Indicator != ""
 	default:
 		return false
 	}

--- a/internal/app/modes/keymap.go
+++ b/internal/app/modes/keymap.go
@@ -206,7 +206,7 @@ func (h *handlerState) settleKeymaps() {
 func (h *handlerState) keymapInputs() keymapInputs {
 	inputs := keymapInputs{
 		mode:   h.appState.CurrentMode(),
-		name:   h.customModeName,
+		name:   h.appState.CustomModeName(),
 		config: h.config,
 	}
 

--- a/internal/app/modes/keymap.go
+++ b/internal/app/modes/keymap.go
@@ -96,7 +96,11 @@ func (h *Handler) PublishFocusedApp(focusedApp string) {
 // still the answer. It is comparable, so settling is one equality rather than
 // an invalidation flag per trigger.
 type keymapInputs struct {
-	mode   domain.Mode
+	mode domain.Mode
+	// name is the declared mode a ModeCustom session is in, and empty
+	// otherwise. Two declared modes share the enum value and bind different
+	// tables, so the name is part of what the keymap is settled for.
+	name   string
 	config *configpkg.Config
 	// focusedApp is the app whose overrides apply, and mustAsk says settling
 	// has to learn it from the platform because nothing published it. It stays
@@ -108,6 +112,16 @@ type keymapInputs struct {
 	// never asks again — see resolveFocusedApp.
 	focusedApp string
 	mustAsk    bool
+}
+
+// keymapModeName is the name the configuration files a mode's table under: the
+// mode's own for a built-in mode, the declared name for a custom one.
+func (inputs keymapInputs) keymapModeName() string {
+	if inputs.mode == domain.ModeCustom {
+		return inputs.name
+	}
+
+	return domain.ModeString(inputs.mode)
 }
 
 // settledKeymap returns the mode's own bindings in force, settling them first if
@@ -164,7 +178,7 @@ func (h *handlerState) settleKeymaps() {
 	if inputs.config != nil {
 		focusedApp := h.resolveFocusedApp(inputs)
 
-		h.keymap = inputs.config.ResolveKeymap(domain.ModeString(inputs.mode), focusedApp)
+		h.keymap = inputs.config.ResolveKeymap(inputs.keymapModeName(), focusedApp)
 
 		// Idle takes no fallback. Nothing is captured there, so the platform's
 		// own hotkey mechanism is what runs a global binding — and a key fed
@@ -192,6 +206,7 @@ func (h *handlerState) settleKeymaps() {
 func (h *handlerState) keymapInputs() keymapInputs {
 	inputs := keymapInputs{
 		mode:   h.appState.CurrentMode(),
+		name:   h.customModeName,
 		config: h.config,
 	}
 

--- a/internal/app/modes/mode_setup.go
+++ b/internal/app/modes/mode_setup.go
@@ -16,13 +16,6 @@ func (h *handlerState) setAppMode(mode domain.Mode) {
 	h.modeSession++
 	h.appState.SetMode(mode)
 
-	// The declared name belongs to a ModeCustom session and to nothing else.
-	// A declared mode sets it before entering, so it survives this call on
-	// the way in and is cleared on the way to any other mode.
-	if mode != domain.ModeCustom {
-		h.customModeName = ""
-	}
-
 	// Reset sticky modifier state before enabling detection for the new session.
 	// Activation-hotkey modifiers are suppressed explicitly by the hotkey path.
 	if h.modifierState != nil {

--- a/internal/app/modes/mode_setup.go
+++ b/internal/app/modes/mode_setup.go
@@ -16,6 +16,13 @@ func (h *handlerState) setAppMode(mode domain.Mode) {
 	h.modeSession++
 	h.appState.SetMode(mode)
 
+	// The declared name belongs to a ModeCustom session and to nothing else.
+	// A declared mode sets it before entering, so it survives this call on
+	// the way in and is cleared on the way to any other mode.
+	if mode != domain.ModeCustom {
+		h.customModeName = ""
+	}
+
 	// Reset sticky modifier state before enabling detection for the new session.
 	// Activation-hotkey modifiers are suppressed explicitly by the hotkey path.
 	if h.modifierState != nil {
@@ -40,11 +47,9 @@ func (h *handlerState) syncStickyModifierToggle(mode domain.Mode) {
 		return
 	}
 
-	isNavMode := mode == domain.ModeHints ||
-		mode == domain.ModeGrid ||
-		mode == domain.ModeRecursiveGrid ||
-		mode == domain.ModeScroll ||
-		mode == domain.ModeMonitorSelect
+	// Every mode but idle captures the keyboard, and sticky modifiers are a
+	// captured keyboard's to toggle.
+	isNavMode := mode != domain.ModeIdle
 
 	enabled := isNavMode && h.config != nil && h.config.StickyModifiers.Enabled
 

--- a/internal/app/modes/scroll.go
+++ b/internal/app/modes/scroll.go
@@ -18,43 +18,7 @@ func (h *handlerState) startInteractiveScroll() {
 	h.scroll.Context.Reset()
 
 	if h.appState.CurrentMode() != domain.ModeIdle {
-		// Mode-to-mode transition: clean up the current mode but keep the
-		// event tap enabled, for the reason exitModeForTransition states — this
-		// is where that dead window was first found, in the shape of missed
-		// scrolling keys when activating from grid mode.
-		//
-		// Scroll keeps a cleanup of its own rather than calling that helper,
-		// and the three differences are all deliberate: it does not clear the
-		// overlay frame (the ScrollFrame below replaces it, and clearing first
-		// is a wasted round trip on the backend where this mode is entered
-		// most), it does not pass through idle (nothing here can abandon the
-		// activation, so there is no state to be caught in), and it *does*
-		// reset the suppressed modifiers that performCommonCleanup deliberately
-		// keeps. Unify them only with an answer for that third one.
-		h.performModeSpecificCleanup()
-		h.stopHeldRepeat()
-
-		if h.refreshHintsTimer != nil {
-			h.refreshHintsTimer.Stop()
-			h.refreshHintsTimer = nil
-		}
-
-		h.hotkeyLastKey = ""
-		h.hotkeyLastKeyTime = 0
-		h.clearStickyModifiers()
-		h.releaseHeldButtons()
-
-		h.suppressedModifiers = 0
-		h.suppressedUntil = time.Time{}
-		h.cursorState.Reset()
-
-		if h.appState.HotkeyRefreshPending() {
-			h.appState.SetHotkeyRefreshPending(false)
-
-			if h.refreshHotkeys != nil {
-				go h.refreshHotkeys()
-			}
-		}
+		h.cleanupForKeymapModeTransition()
 
 		h.logger.Debug("Transitioned to scroll mode",
 			zap.String("from", h.CurrModeString()))
@@ -70,6 +34,49 @@ func (h *handlerState) startInteractiveScroll() {
 	h.showFrame(ports.ScrollFrame{}, "show scroll overlay")
 
 	h.logger.Info("Interactive scroll activated")
+}
+
+// cleanupForKeymapModeTransition cleans up the current mode on the way into a
+// mode that draws nothing and answers every key from its own table: scroll,
+// and every declared mode. The event tap stays enabled, for the reason
+// exitModeForTransition states — this is where that dead window was first
+// found, in the shape of missed scrolling keys when activating from grid mode.
+//
+// It is a cleanup of its own rather than a call to that helper, and the three
+// differences are all deliberate: it does not clear the overlay frame (the
+// frame shown next replaces it, and clearing first is a wasted round trip on
+// the backend where these modes are entered most), it does not pass through
+// idle (nothing here can abandon the activation, so there is no state to be
+// caught in), and it *does* reset the suppressed modifiers that
+// performCommonCleanup deliberately keeps. Unify them only with an answer for
+// that third one.
+//
+// Caller must hold h.mu.
+func (h *handlerState) cleanupForKeymapModeTransition() {
+	h.performModeSpecificCleanup()
+	h.stopHeldRepeat()
+
+	if h.refreshHintsTimer != nil {
+		h.refreshHintsTimer.Stop()
+		h.refreshHintsTimer = nil
+	}
+
+	h.hotkeyLastKey = ""
+	h.hotkeyLastKeyTime = 0
+	h.clearStickyModifiers()
+	h.releaseHeldButtons()
+
+	h.suppressedModifiers = 0
+	h.suppressedUntil = time.Time{}
+	h.cursorState.Reset()
+
+	if h.appState.HotkeyRefreshPending() {
+		h.appState.SetHotkeyRefreshPending(false)
+
+		if h.refreshHotkeys != nil {
+			go h.refreshHotkeys()
+		}
+	}
 }
 
 // handleGenericScrollKey intentionally does nothing.

--- a/internal/app/sequence/executor.go
+++ b/internal/app/sequence/executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/y3owk1n/neru/internal/derrors"
 	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/action"
+	"github.com/y3owk1n/neru/internal/domain/modecmd"
 )
 
 // CommandHandler dispatches one action step. It is the IPC controller's
@@ -279,15 +280,8 @@ func (e *Executor) action(ctx context.Context, source, actionStr string) error {
 	actionStr = actionParts[0]
 	params := actionParts[1:]
 
-	if e.suppressModifiers != nil {
-		switch actionStr {
-		case domain.ModeString(domain.ModeHints),
-			domain.ModeString(domain.ModeGrid),
-			domain.ModeString(domain.ModeRecursiveGrid),
-			domain.ModeString(domain.ModeScroll),
-			domain.ModeString(domain.ModeMonitorSelect):
-			e.suppressModifiers(source)
-		}
+	if e.suppressModifiers != nil && entersAMode(actionStr) {
+		e.suppressModifiers(source)
 	}
 
 	if e.commands == nil {
@@ -310,6 +304,15 @@ func (e *Executor) action(ctx context.Context, source, actionStr string) error {
 	)
 
 	return nil
+}
+
+// entersAMode reports whether a command word enters a mode, as opposed to
+// leaving one: idle is a mode command too, and the modifiers of the chord that
+// left need no suppressing.
+func entersAMode(word string) bool {
+	mode, isMode := modecmd.LookupMode(word)
+
+	return isMode && mode != domain.ModeIdle
 }
 
 // shell executes an "exec ..." step through the configured shell.

--- a/internal/app/simulation_custom_mode_test.go
+++ b/internal/app/simulation_custom_mode_test.go
@@ -1,0 +1,94 @@
+package app_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/domain"
+)
+
+// The declared mode these journeys enter, and the chord that enters it.
+const (
+	customModeHotkey = "Primary+Shift+W"
+	customModeName   = "window"
+)
+
+// simConfigDeclaringAMode is the simulated configuration with one declared
+// mode on top of the built-in ones: a label for the indicator, one bare key
+// bound to a scroll so the journey can see it land, and a global chord that
+// enters it by the mode word.
+func simConfigDeclaringAMode() *config.Config {
+	cfg := simConfig()
+
+	hotkeys := config.DefaultCustomModeHotkeys()
+	hotkeys["j"] = config.StringOrStringArray{"action scroll_down"}
+
+	cfg.Modes = map[string]config.CustomModeConfig{
+		customModeName: {Indicator: "Window", Hotkeys: hotkeys},
+	}
+	cfg.Hotkeys.Bindings[customModeHotkey] = []string{"mode " + customModeName}
+
+	return cfg
+}
+
+// TestSimulation_CustomModeJourney is the whole path a declared mode exists
+// for, as a user walks it: the global chord enters the mode, the indicator
+// names it, a bare key runs the step the declaration bound, and Escape leaves
+// with the indicator gone.
+func TestSimulation_CustomModeJourney(t *testing.T) {
+	sim := newSimHarness(t, simConfigDeclaringAMode(), nil)
+
+	sim.pressHotkey(customModeHotkey)
+	sim.waitMode(domain.ModeCustom)
+
+	sim.waitFor("mode indicator shown", func() bool {
+		visible, asked := sim.overlay.modeIndicatorVisibility()
+
+		return asked && visible
+	})
+
+	sim.press("j")
+	sim.waitFor("scroll recorded", func() bool { return len(sim.ax.recordedScrolls()) > 0 })
+
+	if scrolls := sim.ax.recordedScrolls(); scrolls[0].Y == 0 {
+		t.Fatalf("expected a vertical scroll for the declared 'j' binding, got %v", scrolls[0])
+	}
+
+	sim.press("Escape")
+	sim.waitMode(domain.ModeIdle)
+
+	sim.waitFor("mode indicator hidden", func() bool {
+		visible, asked := sim.overlay.modeIndicatorVisibility()
+
+		return asked && !visible
+	})
+
+	time.Sleep(4 * indicatorSettleWindow)
+
+	if visible, _ := sim.overlay.modeIndicatorVisibility(); visible {
+		t.Fatal("mode indicator was shown again after the declared mode exited")
+	}
+}
+
+// TestSimulation_CustomModeSwitchesToABuiltInMode pins that a declared mode
+// is a mode among the others: a step in its table enters scroll the way a
+// hotkey would, and the keyboard is handed over rather than given back.
+func TestSimulation_CustomModeSwitchesToABuiltInMode(t *testing.T) {
+	cfg := simConfigDeclaringAMode()
+
+	mode := cfg.Modes[customModeName]
+	mode.Hotkeys["s"] = config.StringOrStringArray{"scroll"}
+	cfg.Modes[customModeName] = mode
+
+	sim := newSimHarness(t, cfg, nil)
+
+	sim.pressHotkey(customModeHotkey)
+	sim.waitMode(domain.ModeCustom)
+
+	sim.press("s")
+	sim.waitMode(domain.ModeScroll)
+
+	sim.press("Escape")
+	sim.waitMode(domain.ModeIdle)
+}

--- a/internal/app/simulation_harness_test.go
+++ b/internal/app/simulation_harness_test.go
@@ -534,13 +534,13 @@ func (m *simOverlayPort) drawnModeNames() []string {
 	return names
 }
 
-// indicatorVisibility reports the visibility an indicator was last asked for,
+// modeIndicatorVisibility reports the visibility the mode indicator was last asked for,
 // and whether it was ever asked at all.
-func (m *simOverlayPort) indicatorVisibility(indicator ports.Indicator) (bool, bool) {
+func (m *simOverlayPort) modeIndicatorVisibility() (bool, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	visible, asked := m.indicatorVisible[indicator]
+	visible, asked := m.indicatorVisible[ports.ModeIndicator]
 
 	return visible, asked
 }

--- a/internal/app/simulation_journey_test.go
+++ b/internal/app/simulation_journey_test.go
@@ -535,7 +535,7 @@ func TestSimulation_ModeIndicatorDisappearsWhenModeExits(t *testing.T) {
 	sim.waitMode(domain.ModeScroll)
 
 	sim.waitFor("mode indicator shown", func() bool {
-		visible, asked := sim.overlay.indicatorVisibility(ports.ModeIndicator)
+		visible, asked := sim.overlay.modeIndicatorVisibility()
 
 		return asked && visible
 	})
@@ -544,7 +544,7 @@ func TestSimulation_ModeIndicatorDisappearsWhenModeExits(t *testing.T) {
 	sim.waitMode(domain.ModeIdle)
 
 	sim.waitFor("mode indicator hidden", func() bool {
-		visible, asked := sim.overlay.indicatorVisibility(ports.ModeIndicator)
+		visible, asked := sim.overlay.modeIndicatorVisibility()
 
 		return asked && !visible
 	})
@@ -553,7 +553,7 @@ func TestSimulation_ModeIndicatorDisappearsWhenModeExits(t *testing.T) {
 	// stopped before the indicator is hidden, and a late tick would show it.
 	time.Sleep(4 * indicatorSettleWindow)
 
-	if visible, _ := sim.overlay.indicatorVisibility(ports.ModeIndicator); visible {
+	if visible, _ := sim.overlay.modeIndicatorVisibility(); visible {
 		t.Fatal("mode indicator was shown again after the mode exited")
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -134,6 +134,7 @@ func TestCommandInitialization(t *testing.T) {
 		"toggle-scroll-invert":           false,
 		"recursive_grid":                 false,
 		"monitor_select":                 false,
+		"mode <name>":                    false,
 	}
 
 	for _, cmd := range cli.RootCmd.Commands() {

--- a/internal/cli/mode.go
+++ b/internal/cli/mode.go
@@ -1,0 +1,24 @@
+package cli
+
+import "github.com/y3owk1n/neru/internal/domain"
+
+// ModeCmd is the CLI command that enters a user-declared mode.
+var ModeCmd = BuildModeCommand(ModeConfig{
+	Mode:  domain.ModeCustom,
+	Short: "Enter a mode declared in your config",
+	Long: `Activate a mode you declared under [modes.<name>] in config.toml.
+
+A declared mode has no logic of its own: it captures the keyboard, shows its
+indicator, and answers every key from its own [modes.<name>.hotkeys] table.
+Escape returns to idle unless the table rebinds it.
+
+Examples:
+  neru mode window           Enter the mode declared as [modes.window]
+  neru mode window --toggle  Toggle it on/off`,
+})
+
+func init() {
+	ModeCmd.Use = domain.ModeNameCustom + " <name>"
+
+	RootCmd.AddCommand(ModeCmd)
+}

--- a/internal/cli/mode_command_builder_internal_test.go
+++ b/internal/cli/mode_command_builder_internal_test.go
@@ -19,7 +19,11 @@ const (
 	stepIdle           = "idle"
 )
 
-// modeCommands are the six commands the builder produces, each against the mode
+// strayArgument is what a user might type after a mode command, thinking it
+// asks for an action.
+const strayArgument = "left_click"
+
+// modeCommands are the seven commands the builder produces, each against the mode
 // it enters.
 //
 // Which flags each one offers is not asserted here: that the command line
@@ -34,6 +38,7 @@ func modeCommands() map[domain.Mode]*cobra.Command {
 		domain.ModeScroll:        ScrollCmd,
 		domain.ModeMonitorSelect: MonitorSelectCmd,
 		domain.ModeIdle:          IdleCmd,
+		domain.ModeCustom:        ModeCmd,
 	}
 }
 
@@ -47,7 +52,14 @@ func TestModeCommands_RefuseStrayArguments(t *testing.T) {
 		t.Run(domain.ModeString(mode), func(t *testing.T) {
 			t.Parallel()
 
-			err := cmd.Args(cmd, []string{"left_click"})
+			// The custom mode command takes the declared name and nothing
+			// after it, so its stray argument is a second one.
+			stray := []string{strayArgument}
+			if mode == domain.ModeCustom {
+				stray = []string{"window", strayArgument}
+			}
+
+			err := cmd.Args(cmd, stray)
 			if err == nil {
 				t.Error("a stray argument was accepted; want it refused rather than dropped")
 			}
@@ -242,7 +254,7 @@ func TestReadModeCommand_RefusesWhatTheGrammarRefuses(t *testing.T) {
 				t.Fatalf("ParseFlags(%v) error = %v", testCase.argv, parseErr)
 			}
 
-			_, err := readModeCommand(cmd, testCase.config)
+			_, err := readModeCommand(cmd, cmd.Flags().Args(), testCase.config)
 			if err == nil {
 				t.Fatalf("%v was accepted; want a refusal", testCase.argv)
 			}
@@ -275,7 +287,7 @@ func readTyped(t *testing.T, config ModeConfig, argv []string) modeRequest {
 		t.Fatalf("ParseFlags(%v) error = %v", argv, parseErr)
 	}
 
-	request, err := readModeCommand(cmd, config)
+	request, err := readModeCommand(cmd, cmd.Flags().Args(), config)
 	if err != nil {
 		t.Fatalf("readModeCommand(%v) error = %v", argv, err)
 	}

--- a/internal/cli/mode_commands.go
+++ b/internal/cli/mode_commands.go
@@ -67,10 +67,11 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 		Long:    config.Long,
 		// A mode command is its flags and nothing else. Refusing a stray
 		// argument is what stops "neru idle left_click" from looking like it
-		// asked for something.
-		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			request, err := readModeCommand(cmd, config)
+		// asked for something. The custom mode command is the exception by
+		// design: the one argument it takes is the declared mode it enters.
+		Args: modeArgs(config.Mode),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			request, err := readModeCommand(cmd, args, config)
 			if err != nil {
 				return err
 			}
@@ -89,6 +90,16 @@ func BuildModeCommand(config ModeConfig) *cobra.Command {
 	registerModeFlags(cmd, config)
 
 	return cmd
+}
+
+// modeArgs is the positional shape a mode command takes: none, except for the
+// custom mode command, whose single argument names the declared mode.
+func modeArgs(mode domain.Mode) cobra.PositionalArgs {
+	if mode == domain.ModeCustom {
+		return cobra.ExactArgs(1)
+	}
+
+	return cobra.NoArgs
 }
 
 // registerModeFlags offers exactly the flags the mode accepts, spelled and
@@ -139,10 +150,14 @@ type modeRequest struct {
 // grammar judges it, and the grammar writes it back out — so a command refused
 // on the wire is refused here in the same words, and one that travels is
 // spelled the way the daemon reads it.
-func readModeCommand(cmd *cobra.Command, config ModeConfig) (modeRequest, error) {
+func readModeCommand(cmd *cobra.Command, args []string, config ModeConfig) (modeRequest, error) {
 	activation, err := readActivation(cmd, config.Mode)
 	if err != nil {
 		return modeRequest{}, err
+	}
+
+	if config.Mode == domain.ModeCustom {
+		activation.Name = args[0]
 	}
 
 	probeWanted, err := probeRequested(cmd, config)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,6 +111,7 @@ type Config struct {
 	Theme           ThemeConfig                    `json:"theme"           toml:"theme"`
 	Hotkeys         HotkeysConfig                  `json:"hotkeys"         toml:"-"`
 	Macros          map[string]StringOrStringArray `json:"macros"          toml:"macros"`
+	Modes           map[string]CustomModeConfig    `json:"modes"           toml:"modes"`
 	Hints           HintsConfig                    `json:"hints"           toml:"hints"`
 	Grid            GridConfig                     `json:"grid"            toml:"grid"`
 	RecursiveGrid   RecursiveGridConfig            `json:"recursiveGrid"   toml:"recursive_grid"`
@@ -257,6 +258,25 @@ type ScrollConfig struct {
 	ScrollStepFull int `json:"scrollStepFull" toml:"scroll_step_full"`
 
 	InvertScroll bool `json:"invertScroll" toml:"invert_scroll"`
+
+	AppConfigs []AppConfig `json:"appConfigs" toml:"app_configs"`
+
+	Hotkeys map[string]StringOrStringArray `json:"hotkeys" toml:"-"`
+}
+
+// CustomModeConfig is one mode the user declared under [modes.<name>]: a mode
+// with no logic of its own, entered by "mode <name>", that captures the
+// keyboard and answers every key from its own hotkey table.
+//
+// The hotkey table is tagged toml:"-" like every mode's, and read from the raw
+// decode by the loader for the same reason; [DefaultCustomModeHotkeys] is what
+// a declared table merges over. Per-app overrides reuse AppConfig so the
+// same walk and the same __disabled__ sentinel apply, and the fields on it
+// that belong to hints or scroll are refused here as they are for grid.
+type CustomModeConfig struct {
+	// Indicator is the mode indicator's text while the mode is open. Empty
+	// hides the indicator.
+	Indicator string `json:"indicator" toml:"indicator"`
 
 	AppConfigs []AppConfig `json:"appConfigs" toml:"app_configs"`
 
@@ -648,7 +668,9 @@ func (c *Config) baseHotkeysForMode(modeName string) map[string]StringOrStringAr
 	case ModeNameMonitorSelect:
 		return c.MonitorSelect.Hotkeys
 	default:
-		return nil
+		// A name no built-in mode answers to is a declared one, or nothing:
+		// an undeclared name reads the zero value, whose table is nil.
+		return c.Modes[modeName].Hotkeys
 	}
 }
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -385,6 +385,16 @@ func defaultGeneral() GeneralConfig {
 	}
 }
 
+// DefaultCustomModeHotkeys is the table a declared mode's [modes.<name>.hotkeys]
+// merges over: Escape returns to idle, as it does in every built-in mode. A
+// mode declared with no table at all still gets it, so no declaration can be
+// entered and not left; `"Escape" = "__disabled__"` removes it on purpose.
+func DefaultCustomModeHotkeys() map[string]StringOrStringArray {
+	return map[string]StringOrStringArray{
+		KeyDisplayEscape: {CmdIdle},
+	}
+}
+
 func defaultHotkeys() HotkeysConfig {
 	return HotkeysConfig{
 		Bindings: map[string][]string{

--- a/internal/config/loader/custom_modes_test.go
+++ b/internal/config/loader/custom_modes_test.go
@@ -1,0 +1,183 @@
+package loader_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/config"
+	"github.com/y3owk1n/neru/internal/config/loader"
+)
+
+const declaredModesConfig = `
+[modes.window]
+indicator = "Window"
+
+[modes.window.hotkeys]
+"h" = "exec yabai -m window --focus west"
+"f" = ["exec yabai -m window --toggle zoom-fullscreen", "idle"]
+
+[[modes.window.app_configs]]
+bundle_id = "com.apple.Safari"
+hotkeys = { "h" = "action scroll_left" }
+
+[modes.silent]
+indicator = ""
+
+[modes.trapped]
+
+[modes.trapped.hotkeys]
+"Escape" = "__disabled__"
+"q" = "idle"
+
+[hotkeys]
+"Primary+Shift+W" = "mode window"
+`
+
+// TestLoad_ReadsDeclaredModesFromTheRawTable pins the loader's half of a
+// declaration: the hotkey table is tagged toml:"-" like every mode's, so it
+// has to be read from the raw decode, merged over the default Escape binding,
+// and given to a mode declared without a table at all.
+func TestLoad_ReadsDeclaredModesFromTheRawTable(t *testing.T) {
+	t.Parallel()
+
+	result := loadWithOverride(t, declaredModesConfig, "")
+	cfg := result.Config
+
+	window, declared := cfg.Modes["window"]
+	if !declared {
+		t.Fatal("modes.window was not loaded")
+	}
+
+	if window.Indicator != "Window" {
+		t.Errorf("modes.window.indicator = %q, want %q", window.Indicator, "Window")
+	}
+
+	if got := window.Hotkeys["h"]; len(got) != 1 || !strings.HasPrefix(got[0], "exec ") {
+		t.Errorf("modes.window.hotkeys.h = %v, want the exec step", got)
+	}
+
+	if got := window.Hotkeys["f"]; len(got) != 2 {
+		t.Errorf("modes.window.hotkeys.f = %v, want both steps", got)
+	}
+
+	if got := window.Hotkeys["Escape"]; len(got) != 1 || got[0] != config.CmdIdle {
+		t.Errorf("modes.window.hotkeys.Escape = %v, want the default idle binding", got)
+	}
+
+	if len(window.AppConfigs) != 1 || window.AppConfigs[0].BundleID != "com.apple.Safari" {
+		t.Errorf("modes.window.app_configs = %+v, want the one Safari entry", window.AppConfigs)
+	}
+
+	silent := cfg.Modes["silent"]
+	if got := silent.Hotkeys["Escape"]; len(got) != 1 || got[0] != config.CmdIdle {
+		t.Errorf("a mode declared without a table has Escape = %v, want the default", got)
+	}
+
+	trapped := cfg.Modes["trapped"]
+	if _, bound := trapped.Hotkeys["Escape"]; bound {
+		t.Error("__disabled__ left the default Escape binding in place")
+	}
+
+	if got := trapped.Hotkeys["q"]; len(got) != 1 || got[0] != config.CmdIdle {
+		t.Errorf("modes.trapped.hotkeys.q = %v, want idle", got)
+	}
+}
+
+// TestLoad_RefusesADeclaredModeItCannotLoad pins that the raw-table reading
+// reports a fault the way the built-in tables do, naming the declaration.
+func TestLoad_RefusesADeclaredModeItCannotLoad(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		toml string
+		want string
+	}{
+		{
+			name: "two keys that normalize to one chord",
+			toml: "[modes.window.hotkeys]\n\"escape\" = \"idle\"\n\"Escape\" = \"idle\"\n",
+			want: "modes.window.hotkeys",
+		},
+		{
+			name: "a binding into a mode nobody declared",
+			toml: "[hotkeys]\n\"Primary+Shift+W\" = \"mode window\"\n",
+			want: `mode "window" is not declared`,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			configPath := filepath.Join(t.TempDir(), "config.toml")
+
+			err := os.WriteFile(configPath, []byte(testCase.toml), 0o600)
+			if err != nil {
+				t.Fatalf("failed to write config: %v", err)
+			}
+
+			service := loader.NewService(config.DefaultConfig(), configPath, zap.NewNop(), nil)
+
+			result := service.LoadWithValidation(configPath)
+			if result.ValidationError == nil {
+				t.Fatal("LoadWithValidation() accepted a configuration it cannot run")
+			}
+
+			if got := result.ValidationError.Error(); !strings.Contains(got, testCase.want) {
+				t.Errorf("error = %q, want it to contain %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestSave_WritesDeclaredModeHotkeysTheLoaderReadsBack pins the persistence
+// half: the table the encoder skips is written by hand, under the declaration
+// it belongs to, in the shape the loader reads.
+func TestSave_WritesDeclaredModeHotkeysTheLoaderReadsBack(t *testing.T) {
+	t.Parallel()
+
+	loaded := loadWithOverride(t, declaredModesConfig, "").Config
+
+	savedPath := filepath.Join(t.TempDir(), "config.toml")
+
+	err := loader.Save(loaded, savedPath)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	service := loader.NewService(config.DefaultConfig(), savedPath, zap.NewNop(), nil)
+
+	result := service.LoadWithValidation(savedPath)
+	if result.ValidationError != nil {
+		t.Fatalf("the saved file does not load: %v", result.ValidationError)
+	}
+
+	for name, want := range loaded.Modes {
+		got, declared := result.Config.Modes[name]
+		if !declared {
+			t.Errorf("modes.%s was not saved", name)
+
+			continue
+		}
+
+		if len(got.Hotkeys) != len(want.Hotkeys) {
+			t.Errorf("modes.%s.hotkeys = %v after a save, want %v", name, got.Hotkeys, want.Hotkeys)
+		}
+
+		for key, steps := range want.Hotkeys {
+			if strings.Join(got.Hotkeys[key], "|") != strings.Join(steps, "|") {
+				t.Errorf(
+					"modes.%s.hotkeys.%s = %v after a save, want %v",
+					name,
+					key,
+					got.Hotkeys[key],
+					steps,
+				)
+			}
+		}
+	}
+}

--- a/internal/config/loader/custom_modes_test.go
+++ b/internal/config/loader/custom_modes_test.go
@@ -181,3 +181,57 @@ func TestSave_WritesDeclaredModeHotkeysTheLoaderReadsBack(t *testing.T) {
 		}
 	}
 }
+
+// TestLoad_ReadsDeclaredModeHotkeysFromTheOverrideFile pins the second file a
+// declaration can come from: the override `neru config set` writes is decoded
+// into the same toml:"-" field, so its tables have to be read from the raw
+// decode too. A mode both files declare gets the override merged over the
+// configuration's table, and a mode only the override declares is seeded with
+// the default Escape binding like any other.
+func TestLoad_ReadsDeclaredModeHotkeysFromTheOverrideFile(t *testing.T) {
+	t.Parallel()
+
+	override := `
+[modes.window.hotkeys]
+"h" = "action scroll_left"
+"k" = "action scroll_up"
+
+[modes.tabs]
+indicator = "Tabs"
+
+[modes.tabs.hotkeys]
+"n" = "action feed ctrl+tab"
+`
+
+	cfg := loadWithOverride(t, declaredModesConfig, override).Config
+
+	window := cfg.Modes["window"]
+	if got := window.Hotkeys["h"]; len(got) != 1 || got[0] != "action scroll_left" {
+		t.Errorf("modes.window.hotkeys.h = %v, want the override's step", got)
+	}
+
+	if got := window.Hotkeys["k"]; len(got) != 1 || got[0] != "action scroll_up" {
+		t.Errorf("modes.window.hotkeys.k = %v, want the override's added step", got)
+	}
+
+	if got := window.Hotkeys["f"]; len(got) != 2 {
+		t.Errorf("modes.window.hotkeys.f = %v, want the configuration's binding kept", got)
+	}
+
+	if got := window.Hotkeys["Escape"]; len(got) != 1 || got[0] != config.CmdIdle {
+		t.Errorf("modes.window.hotkeys.Escape = %v, want the default kept", got)
+	}
+
+	tabs, declared := cfg.Modes["tabs"]
+	if !declared {
+		t.Fatal("a mode declared only in the override was not loaded")
+	}
+
+	if got := tabs.Hotkeys["n"]; len(got) != 1 || got[0] != "action feed ctrl+tab" {
+		t.Errorf("modes.tabs.hotkeys.n = %v, want the override's step", got)
+	}
+
+	if got := tabs.Hotkeys["Escape"]; len(got) != 1 || got[0] != config.CmdIdle {
+		t.Errorf("modes.tabs.hotkeys.Escape = %v, want the default seeded", got)
+	}
+}

--- a/internal/config/loader/load.go
+++ b/internal/config/loader/load.go
@@ -419,12 +419,19 @@ func (s *Service) applyModeHotkeys(cfg *config.Config, raw map[string]any) error
 //
 // The typed decode has already filled cfg.Modes with every declaration, so
 // the walk is over those rather than the raw table: a mode declared with no
-// hotkeys of its own still gets the default.
+// hotkeys of its own still gets the default. It runs once per file that can
+// declare a mode — the configuration and then the override `neru config set`
+// writes — so a mode already given a table keeps it and the later file merges
+// over it, and a mode the later file is the first to declare is seeded there.
 func (s *Service) applyCustomModeHotkeys(cfg *config.Config, raw map[string]any) error {
 	modesRaw, _ := raw[modesKey].(map[string]any)
 
 	for name, mode := range cfg.Modes {
-		hotkeys := config.DefaultCustomModeHotkeys()
+		hotkeys := mode.Hotkeys
+		if hotkeys == nil {
+			hotkeys = config.DefaultCustomModeHotkeys()
+		}
+
 		target := modeHotkeyTarget{modeKey: modesKey + "." + name, dest: &hotkeys}
 
 		if modeRaw, isTable := modesRaw[name].(map[string]any); isTable {
@@ -576,6 +583,15 @@ func overrideFileToLayer(configPath string) string {
 func (s *Service) applyOverrideFile(cfg *config.Config, overridePath string) error {
 	s.logger.Info("Loading config overrides from", zap.String("path", overridePath))
 
+	// The typed decode below replaces the entry of every declared mode the
+	// override names, and the hotkey table on it is tagged toml:"-", so the
+	// table the configuration gave the mode would go with it. It is kept
+	// aside and put back before the override's own tables merge over it.
+	kept := make(map[string]map[string]config.StringOrStringArray, len(cfg.Modes))
+	for name, mode := range cfg.Modes {
+		kept[name] = mode.Hotkeys
+	}
+
 	_, decodeErr := toml.DecodeFile(overridePath, cfg)
 	if decodeErr != nil {
 		wrapped := derrors.WrapConfigFailed(decodeErr, "parse config override file")
@@ -587,5 +603,23 @@ func (s *Service) applyOverrideFile(cfg *config.Config, overridePath string) err
 		return wrapped
 	}
 
-	return nil
+	// A declared mode's hotkey table is tagged toml:"-" like every mode's, so
+	// the typed decode above dropped any the override wrote. They are read
+	// from the raw decode the way the configuration's are, over whatever the
+	// configuration already gave the mode.
+	for name, hotkeys := range kept {
+		if mode, declared := cfg.Modes[name]; declared {
+			mode.Hotkeys = hotkeys
+			cfg.Modes[name] = mode
+		}
+	}
+
+	var raw map[string]any
+
+	_, rawErr := toml.DecodeFile(overridePath, &raw)
+	if rawErr != nil {
+		return derrors.WrapConfigFailed(rawErr, "parse config override file")
+	}
+
+	return s.applyCustomModeHotkeys(cfg, raw)
 }

--- a/internal/config/loader/load.go
+++ b/internal/config/loader/load.go
@@ -16,6 +16,10 @@ import (
 // [hotkeys] as a nested table rather than a binding, so the merge skips it.
 const appConfigsKey = "app_configs"
 
+// modesKey names the table of user-declared modes, [modes.<name>], each of
+// which carries a hotkey table read the way the built-in modes' are.
+const modesKey = "modes"
+
 // LoadWithValidation turns a config file into the Config the daemon runs on.
 // It reports a rejection in the result rather than returning an error, so the
 // caller can keep running on the defaults and still tell the user what was
@@ -395,49 +399,73 @@ func modeHotkeyTargets(cfg *config.Config) []modeHotkeyTarget {
 // entry into an array, which means they must be read from the raw map here.
 func (s *Service) applyModeHotkeys(cfg *config.Config, raw map[string]any) error {
 	for _, target := range modeHotkeyTargets(cfg) {
-		table, present := modeHotkeyTable(raw, target.modeKey)
-		if !present {
+		modeRaw, isTable := raw[target.modeKey].(map[string]any)
+		if !isTable {
 			continue
 		}
 
-		if len(table) == 0 {
-			*target.dest = make(map[string]config.StringOrStringArray)
+		applyErr := s.applyModeHotkeyTable(target, modeRaw)
+		if applyErr != nil {
+			return applyErr
+		}
+	}
 
-			continue
+	return s.applyCustomModeHotkeys(cfg, raw)
+}
+
+// applyCustomModeHotkeys gives every declared mode its table: the default
+// Escape binding, with whatever [modes.<name>.hotkeys] the user wrote merged
+// over it by the rules the built-in tables follow.
+//
+// The typed decode has already filled cfg.Modes with every declaration, so
+// the walk is over those rather than the raw table: a mode declared with no
+// hotkeys of its own still gets the default.
+func (s *Service) applyCustomModeHotkeys(cfg *config.Config, raw map[string]any) error {
+	modesRaw, _ := raw[modesKey].(map[string]any)
+
+	for name, mode := range cfg.Modes {
+		hotkeys := config.DefaultCustomModeHotkeys()
+		target := modeHotkeyTarget{modeKey: modesKey + "." + name, dest: &hotkeys}
+
+		if modeRaw, isTable := modesRaw[name].(map[string]any); isTable {
+			applyErr := s.applyModeHotkeyTable(target, modeRaw)
+			if applyErr != nil {
+				return applyErr
+			}
 		}
 
-		duplicateErr := validateRawHotkeyTable(target.modeKey+".hotkeys", table)
-		if duplicateErr != nil {
-			s.logger.Warn("Duplicate normalized custom hotkey in config",
-				zap.String("mode", target.modeKey),
-				zap.Error(duplicateErr))
-
-			return duplicateErr
-		}
-
-		mergeErr := s.mergeModeHotkeys(target, table)
-		if mergeErr != nil {
-			return mergeErr
-		}
+		mode.Hotkeys = hotkeys
+		cfg.Modes[name] = mode
 	}
 
 	return nil
 }
 
-// modeHotkeyTable reaches [<mode>.hotkeys] in the raw decode. A non-table at
-// either level means no section to merge; the typed decode reports bad shapes.
-func modeHotkeyTable(raw map[string]any, modeKey string) (map[string]any, bool) {
-	modeRaw, isTable := raw[modeKey].(map[string]any)
-	if !isTable {
-		return nil, false
-	}
-
+// applyModeHotkeyTable merges one mode's raw "hotkeys" table over its
+// defaults. A missing table leaves the defaults alone, and an empty one
+// clears them, which is how a mode's bindings are switched off wholesale.
+func (s *Service) applyModeHotkeyTable(target modeHotkeyTarget, modeRaw map[string]any) error {
 	table, isTable := modeRaw["hotkeys"].(map[string]any)
 	if !isTable {
-		return nil, false
+		return nil
 	}
 
-	return table, true
+	if len(table) == 0 {
+		*target.dest = make(map[string]config.StringOrStringArray)
+
+		return nil
+	}
+
+	duplicateErr := validateRawHotkeyTable(target.modeKey+".hotkeys", table)
+	if duplicateErr != nil {
+		s.logger.Warn("Duplicate normalized custom hotkey in config",
+			zap.String("mode", target.modeKey),
+			zap.Error(duplicateErr))
+
+		return duplicateErr
+	}
+
+	return s.mergeModeHotkeys(target, table)
 }
 
 // mergeModeHotkeys lays one mode's entries over its defaults.
@@ -500,6 +528,22 @@ func (s *Service) validateNestedHotkeys(raw map[string]any) *config.LoadResult {
 		}
 
 		if result := validateAppConfigsHotkeys(s.logger, modeKey, modeRaw); result != nil {
+			return result
+		}
+	}
+
+	modesRaw, _ := raw[modesKey].(map[string]any)
+	for name, modeAny := range modesRaw {
+		modeRaw, isTable := modeAny.(map[string]any)
+		if !isTable {
+			continue
+		}
+
+		if result := validateAppConfigsHotkeys(
+			s.logger,
+			modesKey+"."+name,
+			modeRaw,
+		); result != nil {
 			return result
 		}
 	}

--- a/internal/config/loader/persistence.go
+++ b/internal/config/loader/persistence.go
@@ -2,9 +2,11 @@ package loader
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
@@ -202,6 +204,21 @@ func Save(cfg *config.Config, path string) error {
 	}
 	for _, section := range hotkeysSections {
 		err = writeStringOrStringArrayMap(file, section.header, section.hotkeys, section.defaults)
+		if err != nil {
+			return err
+		}
+	}
+
+	// A declared mode's table is written the same way, after the encoder has
+	// written the declaration it belongs under. Sorted, so two saves of the
+	// same configuration produce the same file.
+	for _, name := range slices.Sorted(maps.Keys(cfg.Modes)) {
+		err = writeStringOrStringArrayMap(
+			file,
+			modesKey+"."+name+".hotkeys",
+			cfg.Modes[name].Hotkeys,
+			config.DefaultCustomModeHotkeys(),
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/config/lookup.go
+++ b/internal/config/lookup.go
@@ -33,6 +33,8 @@ func (c *Config) HotkeysForModeAndApp(
 		appConfig = c.Scroll.AppConfigForBundleID(bundleID)
 	case ModeNameMonitorSelect:
 		return base
+	default:
+		appConfig = c.Modes[modeName].AppConfigForBundleID(bundleID)
 	}
 
 	if appConfig == nil || len(appConfig.Hotkeys) == 0 {
@@ -182,6 +184,35 @@ func (c *ScrollConfig) HasAppHotkeyOverrides() bool {
 	}
 
 	return false
+}
+
+// HasAppHotkeyOverrides reports whether any [[modes.<name>.app_configs]] entry
+// has a non-empty Hotkeys map. While it is false the focused app cannot change
+// what the mode binds, which is what lets the keymap settle without asking
+// the platform which app is focused.
+func (m CustomModeConfig) HasAppHotkeyOverrides() bool {
+	for idx := range m.AppConfigs {
+		if len(m.AppConfigs[idx].Hotkeys) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// AppConfigForBundleID returns the matching app config of a declared mode for
+// the given bundle ID, nil when none matches. Bundle ID matching is
+// case-insensitive after trimming whitespace, as it is for every mode.
+func (m CustomModeConfig) AppConfigForBundleID(bundleID string) *AppConfig {
+	lowerBundleID := strings.ToLower(strings.TrimSpace(bundleID))
+
+	for idx := range m.AppConfigs {
+		if strings.ToLower(strings.TrimSpace(m.AppConfigs[idx].BundleID)) == lowerBundleID {
+			return &m.AppConfigs[idx]
+		}
+	}
+
+	return nil
 }
 
 // AppConfigForBundleID returns the matching hints app config for the given bundle ID.

--- a/internal/config/lookup.go
+++ b/internal/config/lookup.go
@@ -186,6 +186,21 @@ func (c *ScrollConfig) HasAppHotkeyOverrides() bool {
 	return false
 }
 
+// CustomModeIndicators returns the indicator label of every declared mode, by
+// name, leaving out the ones declared with none: an absent name is what tells
+// the overlay to draw nothing.
+func (c *Config) CustomModeIndicators() map[string]string {
+	labels := make(map[string]string, len(c.Modes))
+
+	for name, mode := range c.Modes {
+		if mode.Indicator != "" {
+			labels[name] = mode.Indicator
+		}
+	}
+
+	return labels
+}
+
 // HasAppHotkeyOverrides reports whether any [[modes.<name>.app_configs]] entry
 // has a non-empty Hotkeys map. While it is false the focused app cannot change
 // what the mode binds, which is what lets the keymap settle without asking

--- a/internal/config/platform_support.go
+++ b/internal/config/platform_support.go
@@ -223,6 +223,7 @@ func PlatformSupport() parity.Declaration {
 			"theme.dark.text",
 
 			"macros",
+			"modes",
 
 			"hints.enabled",
 			"hints.strategy",

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -134,6 +134,13 @@ func (c *Config) ValidateWithWarnings(warnings *Warnings, written WrittenConfig)
 		return err
 	}
 
+	// Declared modes are checked before their tables are, so a fault in a
+	// table is reported against a mode already known to be well-formed.
+	err = c.ValidateCustomModes()
+	if err != nil {
+		return err
+	}
+
 	// Validate per-mode custom hotkeys
 	err = c.ValidateHotkeys()
 	if err != nil {

--- a/internal/config/validators_custom_modes.go
+++ b/internal/config/validators_custom_modes.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"maps"
+	"slices"
+
+	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain/modecmd"
+)
+
+// customModeField is the TOML path a declared mode is reported under.
+func customModeField(name string) string {
+	return "modes." + name
+}
+
+// ValidateCustomModes checks every [modes.<name>] declaration: that the name
+// is one a mode command can carry, that it is not a built-in mode's, and that
+// its per-app overrides are shaped like grid's, which is the mode that takes
+// no field of its own.
+//
+// The hotkey tables themselves are checked by ValidateHotkeys alongside the
+// built-in ones, and the steps in them by the binding walks that close the
+// ladder, so nothing about a binding is judged twice.
+func (c *Config) ValidateCustomModes() error {
+	for _, name := range slices.Sorted(maps.Keys(c.Modes)) {
+		if !modecmd.ValidModeName(name) {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%s: a mode name starts with a letter and continues with letters, digits, _ or -",
+				customModeField(name),
+			)
+		}
+
+		// A built-in mode's name is answered by the built-in mode wherever a
+		// name is looked up, so a declaration under it could never be
+		// entered. "idle" and "mode" are in the same lookup and refused for
+		// the same reason.
+		if _, builtIn := modecmd.LookupMode(name); builtIn {
+			return derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"%s: %q is a built-in mode command and cannot be declared",
+				customModeField(name),
+				name,
+			)
+		}
+
+		err := validateAppConfigsWithCallback(
+			customModeField(name),
+			c.Modes[name].AppConfigs,
+			rejectModeSpecificFields(customModeField(name)),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/config/validators_custom_modes_test.go
+++ b/internal/config/validators_custom_modes_test.go
@@ -1,0 +1,186 @@
+package config_test
+
+import (
+	"maps"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// The spellings the declarations below share.
+const (
+	declaredModeName = "window"
+	stepScroll       = "scroll"
+	stepScrollLeft   = "action scroll_left"
+)
+
+// A declared mode as a test writes it: the shape the loader produces, with the
+// default Escape binding already merged in.
+func declaredMode(hotkeys map[string]config.StringOrStringArray) config.CustomModeConfig {
+	table := config.DefaultCustomModeHotkeys()
+	maps.Copy(table, hotkeys)
+
+	return config.CustomModeConfig{Indicator: "Window", Hotkeys: table}
+}
+
+// TestValidateCustomModes_AcceptsADeclaredModeAndABindingIntoIt pins the
+// happy path end to end: a declaration, a binding that enters it, a step in
+// its table that leaves it, and a per-app override, all through the same
+// ladder a load runs.
+func TestValidateCustomModes_AcceptsADeclaredModeAndABindingIntoIt(t *testing.T) {
+	t.Parallel()
+
+	mode := declaredMode(map[string]config.StringOrStringArray{
+		"h": {"exec yabai -m window --focus west"},
+		"s": {stepScroll},
+	})
+	mode.AppConfigs = []config.AppConfig{{
+		BundleID: keymapTestApp,
+		Hotkeys:  map[string]config.StringOrStringArray{"h": {stepScrollLeft}},
+	}}
+
+	cfg := config.DefaultConfig()
+	cfg.Modes = map[string]config.CustomModeConfig{declaredModeName: mode}
+	cfg.Hotkeys.Bindings = map[string][]string{"Primary+Shift+W": {"mode window --toggle"}}
+
+	warnings := &config.Warnings{}
+
+	err := cfg.ValidateWithWarnings(warnings, config.WrittenConfig{})
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings() refused a well-formed declaration: %v", err)
+	}
+
+	if got := warnings.Messages(); len(got) > 0 {
+		t.Errorf("warnings = %q, want none", got)
+	}
+}
+
+// TestValidateCustomModes_RefusesWhatCouldNeverBeEntered pins the load-time
+// refusals: a name the grammar cannot carry, a name a built-in mode already
+// answers to, a binding into a mode nobody declared, and a per-app field that
+// belongs to another mode.
+func TestValidateCustomModes_RefusesWhatCouldNeverBeEntered(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		breakIt func(*config.Config)
+		want    string
+	}{
+		{
+			name: "a name the grammar cannot carry",
+			breakIt: func(cfg *config.Config) {
+				cfg.Modes = map[string]config.CustomModeConfig{"my mode": declaredMode(nil)}
+			},
+			want: "modes.my mode: a mode name starts with a letter",
+		},
+		{
+			name: "a built-in mode's name",
+			breakIt: func(cfg *config.Config) {
+				cfg.Modes = map[string]config.CustomModeConfig{stepScroll: declaredMode(nil)}
+			},
+			want: `modes.scroll: "scroll" is a built-in mode command`,
+		},
+		{
+			name: "the command word itself",
+			breakIt: func(cfg *config.Config) {
+				cfg.Modes = map[string]config.CustomModeConfig{"mode": declaredMode(nil)}
+			},
+			want: `modes.mode: "mode" is a built-in mode command`,
+		},
+		{
+			name: "a binding into a mode nobody declared",
+			breakIt: func(cfg *config.Config) {
+				cfg.Hotkeys.Bindings = map[string][]string{"w": {"mode window"}}
+			},
+			want: `hotkeys.w: mode "window" is not declared; declare it as [modes.window]`,
+		},
+		{
+			name: "a step in a declared mode's own table into an undeclared one",
+			breakIt: func(cfg *config.Config) {
+				cfg.Modes = map[string]config.CustomModeConfig{
+					declaredModeName: declaredMode(
+						map[string]config.StringOrStringArray{"t": {"mode tabs"}},
+					),
+				}
+			},
+			want: `modes.window.hotkeys.t: mode "tabs" is not declared`,
+		},
+		{
+			name: "a per-app field that belongs to hints",
+			breakIt: func(cfg *config.Config) {
+				mode := declaredMode(nil)
+				mode.AppConfigs = []config.AppConfig{
+					{BundleID: keymapTestApp, AdditionalClickable: []string{"button"}},
+				}
+				cfg.Modes = map[string]config.CustomModeConfig{declaredModeName: mode}
+			},
+			want: "modes.window.app_configs[0].additional_clickable_roles is only valid for hints mode",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.DefaultConfig()
+			testCase.breakIt(cfg)
+
+			warnings := &config.Warnings{}
+
+			err := cfg.ValidateWithWarnings(warnings, config.WrittenConfig{})
+			if err == nil {
+				t.Fatal("ValidateWithWarnings() accepted a declaration that could never be entered")
+			}
+
+			if got := err.Error(); !strings.Contains(got, testCase.want) {
+				t.Errorf("error = %q, want it to contain %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestConfig_HotkeysForModeAndApp_ReadsADeclaredMode pins the lookup a
+// keystroke settles against: the declared table by name, and the per-app
+// override merged over it, under the same rules the built-in modes follow.
+func TestConfig_HotkeysForModeAndApp_ReadsADeclaredMode(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultConfig()
+	mode := declaredMode(map[string]config.StringOrStringArray{"h": {"exec left"}})
+	mode.AppConfigs = []config.AppConfig{{
+		BundleID: keymapTestApp,
+		Hotkeys: map[string]config.StringOrStringArray{
+			"h":      {stepScrollLeft},
+			"Escape": {config.DisabledSentinel},
+		},
+	}}
+	cfg.Modes = map[string]config.CustomModeConfig{declaredModeName: mode}
+
+	base := cfg.HotkeysForModeAndApp(declaredModeName, "")
+	if got := base["h"]; len(got) != 1 || got[0] != "exec left" {
+		t.Errorf("base h = %v, want the declared step", got)
+	}
+
+	if got := base["Escape"]; len(got) != 1 || got[0] != config.CmdIdle {
+		t.Errorf("base Escape = %v, want the default idle binding", got)
+	}
+
+	overridden := cfg.HotkeysForModeAndApp(declaredModeName, "com.apple.safari")
+	if got := overridden["h"]; len(got) != 1 || got[0] != stepScrollLeft {
+		t.Errorf("overridden h = %v, want the per-app step", got)
+	}
+
+	if _, bound := overridden["Escape"]; bound {
+		t.Error("overridden Escape is still bound; want __disabled__ to remove it")
+	}
+
+	if !cfg.Modes[declaredModeName].HasAppHotkeyOverrides() {
+		t.Error("HasAppHotkeyOverrides() = false with a per-app table declared")
+	}
+
+	if got := cfg.HotkeysForModeAndApp("nobody", ""); got != nil {
+		t.Errorf("HotkeysForModeAndApp(nobody) = %v, want nil for an undeclared name", got)
+	}
+}

--- a/internal/config/validators_custom_modes_test.go
+++ b/internal/config/validators_custom_modes_test.go
@@ -108,6 +108,23 @@ func TestValidateCustomModes_RefusesWhatCouldNeverBeEntered(t *testing.T) {
 			want: `modes.window.hotkeys.t: mode "tabs" is not declared`,
 		},
 		{
+			// A step below the top level is still a step the daemon will run.
+			name: "an undeclared mode nested in a run",
+			breakIt: func(cfg *config.Config) {
+				cfg.Hotkeys.Bindings = map[string][]string{"w": {"run 'mode window'"}}
+			},
+			want: `hotkeys.w: mode "window" is not declared`,
+		},
+		{
+			name: "an undeclared mode in an --on-exit",
+			breakIt: func(cfg *config.Config) {
+				cfg.Hotkeys.Bindings = map[string][]string{
+					"w": {"hints --action left_click --on-exit 'mode window'"},
+				}
+			},
+			want: `hotkeys.w: mode "window" is not declared`,
+		},
+		{
 			name: "a per-app field that belongs to hints",
 			breakIt: func(cfg *config.Config) {
 				mode := declaredMode(nil)

--- a/internal/config/validators_hotkeys.go
+++ b/internal/config/validators_hotkeys.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -36,10 +37,6 @@ var validModifiers = map[string]bool{
 
 const minModifierComboParts = 2
 
-// builtInModeCount sizes the tables that list one entry per built-in mode
-// before the declared modes are appended.
-const builtInModeCount = 5
-
 func isValidModifier(mod string) bool {
 	return validModifiers[mod]
 }
@@ -51,16 +48,15 @@ func (c *Config) ValidateHotkeys() error {
 		table    map[string]StringOrStringArray
 	}
 
-	modeHotkeys := make([]modeTable, 0, builtInModeCount+len(c.Modes))
-	modeHotkeys = append(modeHotkeys,
-		modeTable{ModeNameHints, c.Hints.Hotkeys},
-		modeTable{ModeNameGrid, c.Grid.Hotkeys},
-		modeTable{ModeNameRecursiveGrid, c.RecursiveGrid.Hotkeys},
-		modeTable{ModeNameScroll, c.Scroll.Hotkeys},
+	modeHotkeys := slices.Grow([]modeTable{
+		{ModeNameHints, c.Hints.Hotkeys},
+		{ModeNameGrid, c.Grid.Hotkeys},
+		{ModeNameRecursiveGrid, c.RecursiveGrid.Hotkeys},
+		{ModeNameScroll, c.Scroll.Hotkeys},
 		// monitor_select binds keys like the other modes and dispatches them
 		// through the same executor, so its table is checked like theirs.
-		modeTable{ModeNameMonitorSelect, c.MonitorSelect.Hotkeys},
-	)
+		{ModeNameMonitorSelect, c.MonitorSelect.Hotkeys},
+	}, len(c.Modes))
 
 	for name, mode := range c.Modes {
 		modeHotkeys = append(modeHotkeys, modeTable{customModeField(name), mode.Hotkeys})
@@ -126,13 +122,12 @@ func (c *Config) checkHotkeysConflicts() error {
 		table    map[string]StringOrStringArray
 	}
 
-	modes := make([]modeTable, 0, builtInModeCount+len(c.Modes))
-	modes = append(modes,
-		modeTable{ModeNameHints, c.Hints.Hotkeys},
-		modeTable{ModeNameGrid, c.Grid.Hotkeys},
-		modeTable{ModeNameRecursiveGrid, c.RecursiveGrid.Hotkeys},
-		modeTable{ModeNameScroll, c.Scroll.Hotkeys},
-	)
+	modes := slices.Grow([]modeTable{
+		{ModeNameHints, c.Hints.Hotkeys},
+		{ModeNameGrid, c.Grid.Hotkeys},
+		{ModeNameRecursiveGrid, c.RecursiveGrid.Hotkeys},
+		{ModeNameScroll, c.Scroll.Hotkeys},
+	}, len(c.Modes))
 
 	for name, mode := range c.Modes {
 		modes = append(modes, modeTable{customModeField(name), mode.Hotkeys})

--- a/internal/config/validators_hotkeys.go
+++ b/internal/config/validators_hotkeys.go
@@ -36,23 +36,34 @@ var validModifiers = map[string]bool{
 
 const minModifierComboParts = 2
 
+// builtInModeCount sizes the tables that list one entry per built-in mode
+// before the declared modes are appended.
+const builtInModeCount = 5
+
 func isValidModifier(mod string) bool {
 	return validModifiers[mod]
 }
 
 // ValidateHotkeys validates per-mode hotkey syntax and actions.
 func (c *Config) ValidateHotkeys() error {
-	modeHotkeys := []struct {
+	type modeTable struct {
 		modeName string
 		table    map[string]StringOrStringArray
-	}{
-		{ModeNameHints, c.Hints.Hotkeys},
-		{ModeNameGrid, c.Grid.Hotkeys},
-		{ModeNameRecursiveGrid, c.RecursiveGrid.Hotkeys},
-		{ModeNameScroll, c.Scroll.Hotkeys},
+	}
+
+	modeHotkeys := make([]modeTable, 0, builtInModeCount+len(c.Modes))
+	modeHotkeys = append(modeHotkeys,
+		modeTable{ModeNameHints, c.Hints.Hotkeys},
+		modeTable{ModeNameGrid, c.Grid.Hotkeys},
+		modeTable{ModeNameRecursiveGrid, c.RecursiveGrid.Hotkeys},
+		modeTable{ModeNameScroll, c.Scroll.Hotkeys},
 		// monitor_select binds keys like the other modes and dispatches them
 		// through the same executor, so its table is checked like theirs.
-		{ModeNameMonitorSelect, c.MonitorSelect.Hotkeys},
+		modeTable{ModeNameMonitorSelect, c.MonitorSelect.Hotkeys},
+	)
+
+	for name, mode := range c.Modes {
+		modeHotkeys = append(modeHotkeys, modeTable{customModeField(name), mode.Hotkeys})
 	}
 
 	for _, mode := range modeHotkeys {
@@ -110,20 +121,45 @@ func validateHotkeyTable(fieldPrefix string, table map[string]StringOrStringArra
 }
 
 func (c *Config) checkHotkeysConflicts() error {
-	modes := []struct {
+	type modeTable struct {
 		modeName string
 		table    map[string]StringOrStringArray
-	}{
-		{ModeNameHints, c.Hints.Hotkeys},
-		{ModeNameGrid, c.Grid.Hotkeys},
-		{ModeNameRecursiveGrid, c.RecursiveGrid.Hotkeys},
-		{ModeNameScroll, c.Scroll.Hotkeys},
+	}
+
+	modes := make([]modeTable, 0, builtInModeCount+len(c.Modes))
+	modes = append(modes,
+		modeTable{ModeNameHints, c.Hints.Hotkeys},
+		modeTable{ModeNameGrid, c.Grid.Hotkeys},
+		modeTable{ModeNameRecursiveGrid, c.RecursiveGrid.Hotkeys},
+		modeTable{ModeNameScroll, c.Scroll.Hotkeys},
+	)
+
+	for name, mode := range c.Modes {
+		modes = append(modes, modeTable{customModeField(name), mode.Hotkeys})
 	}
 
 	for _, mode := range modes {
 		err := checkHotkeyConflicts(mode.modeName+".hotkeys", mode.table)
 		if err != nil {
 			return err
+		}
+	}
+
+	for name, mode := range c.Modes {
+		for idx, appConfig := range mode.AppConfigs {
+			err := checkHotkeyConflicts(
+				fmt.Sprintf(
+					"%s.hotkeys merged with %s.app_configs[%d] (%s)",
+					customModeField(name),
+					customModeField(name),
+					idx,
+					appConfig.BundleID,
+				),
+				c.HotkeysForModeAndApp(name, appConfig.BundleID),
+			)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/config/validators_macros.go
+++ b/internal/config/validators_macros.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/y3owk1n/neru/internal/derrors"
@@ -268,14 +270,30 @@ func (c *Config) modeBindingTables() []modeBindingTable {
 		{field: ModeNameMonitorSelect + ".hotkeys", table: c.MonitorSelect.Hotkeys},
 	}
 
-	appTables := []struct {
+	type appTable struct {
 		configs  []AppConfig
 		modeName string
-	}{
-		{configs: c.Hints.AppConfigs, modeName: ModeNameHints},
-		{configs: c.Grid.AppConfigs, modeName: ModeNameGrid},
-		{configs: c.RecursiveGrid.AppConfigs, modeName: ModeNameRecursiveGrid},
-		{configs: c.Scroll.AppConfigs, modeName: ModeNameScroll},
+	}
+
+	appTables := make([]appTable, 0, builtInModeCount+len(c.Modes))
+	appTables = append(appTables,
+		appTable{configs: c.Hints.AppConfigs, modeName: ModeNameHints},
+		appTable{configs: c.Grid.AppConfigs, modeName: ModeNameGrid},
+		appTable{configs: c.RecursiveGrid.AppConfigs, modeName: ModeNameRecursiveGrid},
+		appTable{configs: c.Scroll.AppConfigs, modeName: ModeNameScroll},
+	)
+
+	// Declared modes are walked in name order so a fault is reported at the
+	// same binding on every load.
+	for _, name := range slices.Sorted(maps.Keys(c.Modes)) {
+		tables = append(tables, modeBindingTable{
+			field: customModeField(name) + ".hotkeys",
+			table: c.Modes[name].Hotkeys,
+		})
+		appTables = append(appTables, appTable{
+			configs:  c.Modes[name].AppConfigs,
+			modeName: customModeField(name),
+		})
 	}
 
 	for _, mode := range appTables {

--- a/internal/config/validators_macros.go
+++ b/internal/config/validators_macros.go
@@ -112,11 +112,18 @@ func (c *Config) validateActionStep(field, step string, depth int) error {
 
 	// A nested step is a step: it has to name a real command, exactly like one
 	// written directly in the binding. Reaching it only through this walk is
-	// why a step inside a run or an --on-exit went unchecked before.
+	// why a step inside a run or an --on-exit went unchecked before. The
+	// declared mode a nested "mode <name>" enters is checked here for the
+	// same reason; a top-level one is checked by ValidateModeCommands.
 	if depth > 0 {
 		err := validateHotkeyActionString(step)
 		if err != nil {
 			return derrors.Wrapf(err, derrors.CodeInvalidConfig, "%s", field)
+		}
+
+		err = c.checkDeclaredMode(field, step)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -275,13 +282,12 @@ func (c *Config) modeBindingTables() []modeBindingTable {
 		modeName string
 	}
 
-	appTables := make([]appTable, 0, builtInModeCount+len(c.Modes))
-	appTables = append(appTables,
-		appTable{configs: c.Hints.AppConfigs, modeName: ModeNameHints},
-		appTable{configs: c.Grid.AppConfigs, modeName: ModeNameGrid},
-		appTable{configs: c.RecursiveGrid.AppConfigs, modeName: ModeNameRecursiveGrid},
-		appTable{configs: c.Scroll.AppConfigs, modeName: ModeNameScroll},
-	)
+	appTables := slices.Grow([]appTable{
+		{configs: c.Hints.AppConfigs, modeName: ModeNameHints},
+		{configs: c.Grid.AppConfigs, modeName: ModeNameGrid},
+		{configs: c.RecursiveGrid.AppConfigs, modeName: ModeNameRecursiveGrid},
+		{configs: c.Scroll.AppConfigs, modeName: ModeNameScroll},
+	}, len(c.Modes))
 
 	// Declared modes are walked in name order so a fault is reported at the
 	// same binding on every load.

--- a/internal/config/validators_modecmd.go
+++ b/internal/config/validators_modecmd.go
@@ -31,7 +31,7 @@ func (c *Config) ValidateModeCommands(warnings *Warnings) error {
 			return nil
 		}
 
-		reported, err := modecmd.Diagnose(mode, args)
+		activation, reported, err := modecmd.Diagnose(mode, args)
 		if err != nil {
 			return derrors.Newf(
 				derrors.CodeInvalidConfig,
@@ -39,6 +39,21 @@ func (c *Config) ValidateModeCommands(warnings *Warnings) error {
 				field,
 				derrors.Message(err),
 			)
+		}
+
+		// The grammar reads the name; only the configuration knows whether a
+		// mode by that name was declared. A binding that enters one that was
+		// not is a key that does nothing, so it is refused like a typo'd flag.
+		if mode == domain.ModeCustom {
+			if _, declared := c.Modes[activation.Name]; !declared {
+				return derrors.Newf(
+					derrors.CodeInvalidConfig,
+					"%s: mode %q is not declared; declare it as [modes.%s]",
+					field,
+					activation.Name,
+					activation.Name,
+				)
+			}
 		}
 
 		for _, warning := range reported {

--- a/internal/config/validators_modecmd.go
+++ b/internal/config/validators_modecmd.go
@@ -48,10 +48,9 @@ func (c *Config) ValidateModeCommands(warnings *Warnings) error {
 			if _, declared := c.Modes[activation.Name]; !declared {
 				return derrors.Newf(
 					derrors.CodeInvalidConfig,
-					"%s: mode %q is not declared; declare it as [modes.%s]",
+					"%s: %s",
 					field,
-					activation.Name,
-					activation.Name,
+					derrors.Message(modecmd.NotDeclared(activation.Name)),
 				)
 			}
 		}

--- a/internal/config/validators_modecmd.go
+++ b/internal/config/validators_modecmd.go
@@ -41,18 +41,9 @@ func (c *Config) ValidateModeCommands(warnings *Warnings) error {
 			)
 		}
 
-		// The grammar reads the name; only the configuration knows whether a
-		// mode by that name was declared. A binding that enters one that was
-		// not is a key that does nothing, so it is refused like a typo'd flag.
-		if mode == domain.ModeCustom {
-			if _, declared := c.Modes[activation.Name]; !declared {
-				return derrors.Newf(
-					derrors.CodeInvalidConfig,
-					"%s: %s",
-					field,
-					derrors.Message(modecmd.NotDeclared(activation.Name)),
-				)
-			}
+		err = c.refuseUndeclared(field, activation)
+		if err != nil {
+			return err
 		}
 
 		for _, warning := range reported {
@@ -61,6 +52,46 @@ func (c *Config) ValidateModeCommands(warnings *Warnings) error {
 
 		return nil
 	})
+}
+
+// checkDeclaredMode refuses a step that enters a declared mode nothing
+// declares, wherever the step sits: ValidateModeCommands reads the top-level
+// steps, and the binding walk hands the ones nested in a run or an --on-exit
+// here, so a typo'd name is reported at load at any depth.
+func (c *Config) checkDeclaredMode(field, step string) error {
+	mode, args, isModeCommand := parseModeCommand(step)
+	if !isModeCommand || mode != domain.ModeCustom {
+		return nil
+	}
+
+	activation, _, err := modecmd.Diagnose(mode, args)
+	if err != nil {
+		return derrors.Newf(derrors.CodeInvalidConfig, "%s: %s", field, derrors.Message(err))
+	}
+
+	return c.refuseUndeclared(field, activation)
+}
+
+// refuseUndeclared is the refusal for a custom activation naming a mode the
+// configuration does not declare. The grammar reads the name; only the
+// configuration knows whether anything declares it, and a binding into a
+// mode nothing declares is a key that does nothing, so it is refused like a
+// typo'd flag.
+func (c *Config) refuseUndeclared(field string, activation modecmd.Activation) error {
+	if activation.Mode != domain.ModeCustom {
+		return nil
+	}
+
+	if _, declared := c.Modes[activation.Name]; declared {
+		return nil
+	}
+
+	return derrors.Newf(
+		derrors.CodeInvalidConfig,
+		"%s: %s",
+		field,
+		derrors.Message(modecmd.NotDeclared(activation.Name)),
+	)
 }
 
 // parseModeCommand splits a step into the mode it enters and the arguments it

--- a/internal/domain/converters.go
+++ b/internal/domain/converters.go
@@ -10,6 +10,11 @@ const (
 	ModeNameScroll        = "scroll"
 	ModeNameRecursiveGrid = "recursive_grid"
 	ModeNameMonitorSelect = "monitor_select"
+	// ModeNameCustom is the command word that enters a user-declared mode:
+	// "mode <name>". It is the word wherever a built-in mode is called by its
+	// name, so the CLI command, the IPC action and the binding step all agree;
+	// the declared name travels beside it as the first argument.
+	ModeNameCustom = "mode"
 )
 
 // ModeString converts a Mode to its string representation.
@@ -27,6 +32,8 @@ func ModeString(mode Mode) string {
 		return ModeNameRecursiveGrid
 	case ModeMonitorSelect:
 		return ModeNameMonitorSelect
+	case ModeCustom:
+		return ModeNameCustom
 	default:
 		return UnknownMode
 	}

--- a/internal/domain/domain_constants.go
+++ b/internal/domain/domain_constants.go
@@ -22,6 +22,11 @@ const (
 	ModeRecursiveGrid
 	// ModeMonitorSelect is the interactive monitor selection mode.
 	ModeMonitorSelect
+	// ModeCustom is a mode the user declared in [modes.<name>]. It has no
+	// logic of its own: a keymap and an indicator label, and the declared
+	// name says which. One value serves every declared mode, so the switches
+	// that name a mode gain one arm rather than one per declaration.
+	ModeCustom
 )
 
 // IPC Commands.

--- a/internal/domain/modecmd/activation.go
+++ b/internal/domain/modecmd/activation.go
@@ -19,6 +19,11 @@ type Activation struct {
 	// Mode is the mode being entered. It decides which flags are accepted.
 	Mode domain.Mode
 
+	// Name is the declared mode a custom activation enters, the "window" in
+	// "mode window". It is empty for every built-in mode, and a custom
+	// activation without one is refused: the word alone names nothing.
+	Name string
+
 	// Action is the mouse button action to perform on the selection. Commas
 	// chain several, which is how a double-click is written.
 	Action *string

--- a/internal/domain/modecmd/custom_mode_test.go
+++ b/internal/domain/modecmd/custom_mode_test.go
@@ -1,0 +1,190 @@
+package modecmd_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/modecmd"
+)
+
+// The spellings a user-declared mode is entered with.
+const (
+	modeNameWindow = "window"
+	stepModeWindow = "mode window"
+)
+
+// TestParse_ReadsTheCustomModeName pins where the declared name is read from:
+// the first bare argument, in both shapes the wire carries. A binding writes
+// "mode window --toggle" and the CLI repeats the command word, and both have to
+// reach the same activation or a script and a binding would enter different
+// modes.
+func TestParse_ReadsTheCustomModeName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want modecmd.Activation
+	}{
+		{
+			name: "name alone",
+			args: []string{modeNameWindow},
+			want: modecmd.Activation{Mode: domain.ModeCustom, Name: modeNameWindow},
+		},
+		{
+			name: "name then a flag",
+			args: []string{modeNameWindow, argToggle},
+			want: modecmd.Activation{
+				Mode:   domain.ModeCustom,
+				Name:   modeNameWindow,
+				Toggle: new(true),
+			},
+		},
+		{
+			name: "flag then the name",
+			args: []string{argToggle, modeNameWindow},
+			want: modecmd.Activation{
+				Mode:   domain.ModeCustom,
+				Name:   modeNameWindow,
+				Toggle: new(true),
+			},
+		},
+		{
+			name: "the command word repeated, as the CLI sends it",
+			args: []string{domain.ModeNameCustom, modeNameWindow},
+			want: modecmd.Activation{Mode: domain.ModeCustom, Name: modeNameWindow},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := modecmd.Parse(domain.ModeCustom, testCase.args)
+			if err != nil {
+				t.Fatalf("Parse(%v) error = %v", testCase.args, err)
+			}
+
+			if !reflect.DeepEqual(got, testCase.want) {
+				t.Errorf("Parse(%v) = %+v, want %+v", testCase.args, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestParse_RefusesACustomActivationWithoutAName pins that the word alone
+// names nothing, and that a second bare word is a stray argument rather than a
+// positional action: a declared mode makes no selection to act on.
+func TestParse_RefusesACustomActivationWithoutAName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "no arguments",
+			args: nil,
+			want: "mode requires the name of a declared mode",
+		},
+		{
+			name: "only the command word",
+			args: []string{domain.ModeNameCustom},
+			want: "mode requires the name of a declared mode",
+		},
+		{
+			name: "a name no mode may have",
+			args: []string{"9lives"},
+			want: "a mode name starts with a letter",
+		},
+		{
+			name: "a second bare word",
+			args: []string{modeNameWindow, leftClick},
+			want: "unexpected argument: " + leftClick,
+		},
+		{
+			name: "a selection flag",
+			args: []string{modeNameWindow, argAction},
+			want: "mode does not accept --action",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := modecmd.Parse(domain.ModeCustom, testCase.args)
+			if err == nil {
+				t.Fatalf("Parse(%v) accepted the command; want a refusal", testCase.args)
+			}
+
+			if got := err.Error(); !strings.Contains(got, testCase.want) {
+				t.Errorf(
+					"Parse(%v) error = %q, want it to contain %q",
+					testCase.args,
+					got,
+					testCase.want,
+				)
+			}
+		})
+	}
+}
+
+// TestRoundTrip_CarriesTheCustomModeName pins the name through both trips:
+// rendered first, so that parsing the rendering finds it where a binding
+// would have written it.
+func TestRoundTrip_CarriesTheCustomModeName(t *testing.T) {
+	t.Parallel()
+
+	built := modecmd.Activation{Mode: domain.ModeCustom, Name: modeNameWindow, Toggle: new(true)}
+
+	rendered := modecmd.Render(built)
+	if len(rendered) == 0 || rendered[0] != modeNameWindow {
+		t.Fatalf("Render(%+v) = %v, want the name first", built, rendered)
+	}
+
+	parsed, err := modecmd.Parse(domain.ModeCustom, rendered)
+	if err != nil {
+		t.Fatalf("Parse(Render(%+v)) error = %v", built, err)
+	}
+
+	if !reflect.DeepEqual(built, parsed) {
+		t.Errorf("round trip changed the activation:\n want %+v\n  got %+v", built, parsed)
+	}
+}
+
+// TestValidate_RefusesANameOnABuiltInMode pins the other side of the rule: a
+// name on a built-in activation is dropped by the rendering, so accepting it
+// would let a caller build an activation that says one thing and sends another.
+func TestValidate_RefusesANameOnABuiltInMode(t *testing.T) {
+	t.Parallel()
+
+	err := modecmd.Validate(modecmd.Activation{Mode: domain.ModeHints, Name: modeNameWindow})
+	if err == nil {
+		t.Fatal("Validate() accepted a name on hints; want a refusal")
+	}
+
+	if got, want := err.Error(), "hints does not take a mode name"; !strings.Contains(got, want) {
+		t.Errorf("error = %q, want it to contain %q", got, want)
+	}
+}
+
+// TestLookupMode_RecognizesTheCustomCommandWord pins the word a binding step
+// is recognized by. The configuration decides whether "mode window" is a mode
+// command with this lookup, so the word has to be the one the daemon
+// dispatches on.
+func TestLookupMode_RecognizesTheCustomCommandWord(t *testing.T) {
+	t.Parallel()
+
+	mode, isMode := modecmd.LookupMode(strings.Fields(stepModeWindow)[0])
+	if !isMode || mode != domain.ModeCustom {
+		t.Fatalf("LookupMode(%q) = (%v, %v), want (ModeCustom, true)", stepModeWindow, mode, isMode)
+	}
+
+	if _, isMode := modecmd.LookupMode(modeNameWindow); isMode {
+		t.Errorf("LookupMode(%q) recognized a declared name as a command word", modeNameWindow)
+	}
+}

--- a/internal/domain/modecmd/diagnose.go
+++ b/internal/domain/modecmd/diagnose.go
@@ -17,17 +17,21 @@ import "github.com/y3owk1n/neru/internal/domain"
 // below is a refusal. The sentences are the same either way, so the same
 // mistake reads the same whether it was typed, sent over the socket, or found
 // in a binding.
-func Diagnose(mode domain.Mode, args []string) ([]error, error) {
+//
+// The activation is returned alongside, for the one question the grammar
+// cannot answer on its own: whether the declared mode a custom activation
+// names exists is the configuration's to know.
+func Diagnose(mode domain.Mode, args []string) (Activation, []error, error) {
 	activation, unsupported, err := read(mode, args)
 	if err != nil {
-		return nil, err
+		return Activation{}, nil, err
 	}
 
 	// A command holding both an unreadable value and an inert flag is
 	// unreadable: there is nothing left to weigh once it cannot run.
 	valueErr := validateValues(activation)
 	if valueErr != nil {
-		return nil, valueErr
+		return Activation{}, nil, valueErr
 	}
 
 	warnings := make([]error, 0, len(unsupported))
@@ -36,5 +40,5 @@ func Diagnose(mode domain.Mode, args []string) ([]error, error) {
 		warnings = append(warnings, notAccepted(mode, name))
 	}
 
-	return append(warnings, unmetDependencies(activation)...), nil
+	return activation, append(warnings, unmetDependencies(activation)...), nil
 }

--- a/internal/domain/modecmd/diagnose_test.go
+++ b/internal/domain/modecmd/diagnose_test.go
@@ -106,7 +106,7 @@ func TestDiagnose_WarnsAboutACommandThatStillRuns(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			warnings, err := modecmd.Diagnose(testCase.mode, testCase.args)
+			_, warnings, err := modecmd.Diagnose(testCase.mode, testCase.args)
 			if err != nil {
 				t.Fatalf("Diagnose(%v) refused the command: %v", testCase.args, err)
 			}
@@ -181,7 +181,7 @@ func TestDiagnose_RefusesACommandThatCouldNotRun(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			warnings, err := modecmd.Diagnose(testCase.mode, testCase.args)
+			_, warnings, err := modecmd.Diagnose(testCase.mode, testCase.args)
 			if err == nil {
 				t.Fatalf("Diagnose(%v) was accepted; want a refusal", testCase.args)
 			}
@@ -222,7 +222,7 @@ func TestDiagnose_AcceptsACleanCommand(t *testing.T) {
 		t.Run(domain.ModeString(testCase.mode), func(t *testing.T) {
 			t.Parallel()
 
-			warnings, err := modecmd.Diagnose(testCase.mode, testCase.args)
+			_, warnings, err := modecmd.Diagnose(testCase.mode, testCase.args)
 			if err != nil {
 				t.Fatalf("Diagnose(%v) refused a clean command: %v", testCase.args, err)
 			}
@@ -260,7 +260,7 @@ func TestDiagnose_SaysWhatParseSays(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			warnings, diagnoseErr := modecmd.Diagnose(testCase.mode, testCase.args)
+			_, warnings, diagnoseErr := modecmd.Diagnose(testCase.mode, testCase.args)
 
 			_, parseErr := modecmd.Parse(testCase.mode, testCase.args)
 			if parseErr == nil {

--- a/internal/domain/modecmd/flags.go
+++ b/internal/domain/modecmd/flags.go
@@ -1,6 +1,7 @@
 package modecmd
 
 import (
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -343,6 +344,7 @@ var (
 		domain.ModeRecursiveGrid,
 		domain.ModeScroll,
 		domain.ModeMonitorSelect,
+		domain.ModeCustom,
 	}
 
 	// hintsOnly are the flags that describe element detection, which only
@@ -366,6 +368,21 @@ var (
 // build failure.
 func Modes() []domain.Mode {
 	return slices.Clone(modes)
+}
+
+// modeNamePattern is what a declared mode may be called: the same identifier
+// shape a macro name takes, so a mode command is read by splitting on spaces
+// and the second token is the whole name.
+var modeNamePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
+
+// ValidModeName reports whether name may be used as a declared mode's name.
+//
+// It is exported for the configuration, which judges the keys of [modes] by
+// the same rule the grammar judges the argument of a mode command: a name one
+// accepts and the other refuses is a mode that can be declared and never
+// entered.
+func ValidModeName(name string) bool {
+	return modeNamePattern.MatchString(name)
 }
 
 // LookupMode returns the mode a command word names.

--- a/internal/domain/modecmd/parse.go
+++ b/internal/domain/modecmd/parse.go
@@ -82,6 +82,12 @@ func read(mode domain.Mode, args []string) (Activation, []Flag, error) {
 			// travel all the way to the mode as an unusable action name.
 			return Activation{}, nil, invalid(msgUnknownFlag + arg)
 
+		case mode == domain.ModeCustom && activation.Name == "":
+			// The first argument of a custom activation is the declared mode
+			// it enters, which is the one thing a bare word can mean there:
+			// a custom mode makes no selection, so it takes no action.
+			activation.Name = arg
+
 		case activation.Action == nil && accepts(FlagAction, mode):
 			// An argument matching no flag is the positional action, which is
 			// how "hints left_click" is written. Once an action is set there

--- a/internal/domain/modecmd/render.go
+++ b/internal/domain/modecmd/render.go
@@ -1,17 +1,27 @@
 package modecmd
 
+import (
+	"github.com/y3owk1n/neru/internal/domain"
+)
+
 // Render writes an activation back into the argument list that carries it.
 //
 // The mode's own name is left out: it names the request, and repeating it
 // inside the arguments is redundant. Parsing tolerates it because callers
-// modeled on the CLI's traffic send it, but nothing here writes it.
+// modeled on the CLI's traffic send it, but nothing here writes it. A custom
+// activation's declared name is written, and first: it is an argument of the
+// request rather than the name of it, and parsing reads it from that position.
 //
 // Rendering is the inverse of parsing over the whole table — parsing a
 // rendering returns the same activation. That is what lets a caller holding
 // typed flags hand them to the daemon as text without spelling any of them
 // itself.
 func Render(activation Activation) []string {
-	args := make([]string, 0, len(descriptors))
+	args := make([]string, 0, len(descriptors)+1)
+
+	if activation.Mode == domain.ModeCustom && activation.Name != "" {
+		args = append(args, activation.Name)
+	}
 
 	for _, descriptor := range descriptors {
 		args = append(args, descriptor.render(activation)...)

--- a/internal/domain/modecmd/validate.go
+++ b/internal/domain/modecmd/validate.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/y3owk1n/neru/internal/derrors"
+	"github.com/y3owk1n/neru/internal/domain"
 	"github.com/y3owk1n/neru/internal/domain/action"
 )
 
@@ -18,6 +19,9 @@ const (
 	msgModifierRequiresAction          = "--modifier requires --action"
 	msgHideOnEmptySearchRequiresSearch = "--hide-on-empty-search requires --search"
 	msgModifierEmpty                   = "modifier values cannot be empty"
+	msgNameRequired                    = "mode requires the name of a declared mode: mode <name>"
+	msgNameInvalid                     = "a mode name starts with a letter and continues with letters, digits, _ or -"
+	msgNameNotAccepted                 = " does not take a mode name; only mode <name> does"
 )
 
 // Validate applies every rule that needs more than one flag to judge: which
@@ -113,12 +117,40 @@ func unmetDependencies(activation Activation) []error {
 // an unmet dependency, nothing about the rest of the command can make one of
 // these mean anything.
 func validateValues(activation Activation) error {
+	nameErr := validateName(activation)
+	if nameErr != nil {
+		return nameErr
+	}
+
 	modifierErr := validateModifier(activation)
 	if modifierErr != nil {
 		return modifierErr
 	}
 
 	return validateAction(activation)
+}
+
+// validateName holds the declared name to the custom mode: required and
+// well-formed there, and refused anywhere else, where a name would be dropped
+// by the rendering and so could never have meant anything.
+func validateName(activation Activation) error {
+	if activation.Mode != domain.ModeCustom {
+		if activation.Name != "" {
+			return invalid(domain.ModeString(activation.Mode) + msgNameNotAccepted)
+		}
+
+		return nil
+	}
+
+	if activation.Name == "" {
+		return invalid(msgNameRequired)
+	}
+
+	if !ValidModeName(activation.Name) {
+		return invalid(msgNameInvalid)
+	}
+
+	return nil
 }
 
 // validateModifier refuses a --modifier value that names no modifier key. An

--- a/internal/domain/modecmd/validate.go
+++ b/internal/domain/modecmd/validate.go
@@ -224,6 +224,19 @@ func validateAction(activation Activation) error {
 	return nil
 }
 
+// NotDeclared is the refusal for a custom activation naming a mode the
+// configuration does not declare. The grammar cannot judge that itself, but it
+// owns the sentence, so a binding read at load and a command sent over the
+// socket are refused in the same words.
+func NotDeclared(name string) error {
+	return derrors.Newf(
+		derrors.CodeInvalidInput,
+		"mode %q is not declared; declare it as [modes.%s]",
+		name,
+		name,
+	)
+}
+
 // isTrue reads a presence-only flag: absent and false are the same answer.
 func isTrue(value *bool) bool {
 	return value != nil && *value

--- a/internal/domain/state/app_state.go
+++ b/internal/domain/state/app_state.go
@@ -26,6 +26,7 @@ type AppState struct {
 	// Core state
 	enabled              bool
 	currentMode          domain.Mode
+	customModeName       string
 	hiddenForScreenShare bool
 	scrollInverted       bool
 	modeExitReason       ModeExitReason
@@ -352,7 +353,47 @@ func (s *AppState) SetMode(mode domain.Mode) {
 		s.modeExitReasonValid = false
 	}
 
+	// The declared name belongs to a ModeCustom session and to nothing else:
+	// a declared mode names itself before entering, and any other mode
+	// clears it on the way in.
+	if mode != domain.ModeCustom {
+		s.customModeName = ""
+	}
+
 	s.currentMode = mode
+}
+
+// SetCustomModeName records which declared mode a ModeCustom session is in.
+// It is called before SetMode(ModeCustom), because entering the mode settles
+// the keymap and the keymap of a declared mode is looked up by this name.
+func (s *AppState) SetCustomModeName(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.customModeName = name
+}
+
+// CustomModeName returns the declared mode a ModeCustom session is in, and
+// the empty string outside one.
+func (s *AppState) CustomModeName() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.customModeName
+}
+
+// ModeName returns the current mode as a user reads it: a built-in mode's own
+// name, or the declared name of the custom mode that is open. It is what the
+// status report answers with, where "mode" alone would name nothing.
+func (s *AppState) ModeName() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.currentMode == domain.ModeCustom && s.customModeName != "" {
+		return s.customModeName
+	}
+
+	return domain.ModeString(s.currentMode)
 }
 
 // SetModeExitReason records how the current mode session exited. Must be

--- a/internal/domain/state/custom_mode_name_test.go
+++ b/internal/domain/state/custom_mode_name_test.go
@@ -1,0 +1,43 @@
+package state_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/neru/internal/domain"
+	"github.com/y3owk1n/neru/internal/domain/state"
+)
+
+// TestAppState_ModeName_NamesTheOpenDeclaredMode pins what a status report
+// says about a declared mode: the declaration's name while one is open, the
+// mode's own name otherwise, and the declared name gone the moment any other
+// mode is entered.
+func TestAppState_ModeName_NamesTheOpenDeclaredMode(t *testing.T) {
+	t.Parallel()
+
+	appState := state.NewAppState()
+
+	if got := appState.ModeName(); got != domain.ModeNameIdle {
+		t.Fatalf("ModeName() = %q at rest, want %q", got, domain.ModeNameIdle)
+	}
+
+	appState.SetCustomModeName("window")
+	appState.SetMode(domain.ModeCustom)
+
+	if got := appState.ModeName(); got != "window" {
+		t.Fatalf("ModeName() = %q in a declared mode, want %q", got, "window")
+	}
+
+	if got := appState.CustomModeName(); got != "window" {
+		t.Fatalf("CustomModeName() = %q, want %q", got, "window")
+	}
+
+	appState.SetMode(domain.ModeScroll)
+
+	if got := appState.CustomModeName(); got != "" {
+		t.Errorf("CustomModeName() = %q after entering scroll, want it cleared", got)
+	}
+
+	if got := appState.ModeName(); got != domain.ModeNameScroll {
+		t.Errorf("ModeName() = %q in scroll, want %q", got, domain.ModeNameScroll)
+	}
+}

--- a/internal/ports/overlay.go
+++ b/internal/ports/overlay.go
@@ -174,6 +174,23 @@ func (ScrollFrame) Mode() domain.Mode { return domain.ModeScroll }
 
 func (ScrollFrame) frame() {}
 
+// CustomFrame is the surface of a mode the user declared, which draws nothing
+// of its own for the reason ScrollFrame draws nothing: a declared mode is a
+// keymap the indicators report, not content.
+//
+// It carries the declared name because the overlay names its modes by name,
+// and the indicator's label is the declaration's to give. Mode() answers with
+// the one enum value every declared mode shares.
+type CustomFrame struct {
+	// Name is the declared mode, the "window" in [modes.window].
+	Name string
+}
+
+// Mode names the mode a custom frame draws.
+func (CustomFrame) Mode() domain.Mode { return domain.ModeCustom }
+
+func (CustomFrame) frame() {}
+
 // GridPointer is the pointer stand-in a grid surface draws where the selection
 // is, for a user who has told the cursor not to follow it. It carries position
 // only: how big it is and what color it is are Style, resolved by the overlay.


### PR DESCRIPTION
## Description

This PR adds user-declared modes. A mode declared in config.toml has no logic of its own: it captures the keyboard, shows the mode indicator with the label the declaration gave it, and answers every key from its own hotkey table. It is scroll mode without the scrolling, and it exists so a set of bare-letter bindings can live behind one leader chord as a layer, with a label on screen saying which layer is live.

Declared modes behave like the built-in ones everywhere a mode is a mode: a global chord, a macro or `neru mode <name>` enters one, `--toggle` leaves it, a step in its table can enter scroll or hints and hands the keyboard over rather than giving it back, an unbound Ctrl/Alt/Cmd chord falls back to the global table, and `neru status` reports the open declaration by name. Every declared mode gets `Escape = "idle"` by default so nobody can be trapped, and `__disabled__` removes it on purpose. A reload that drops the open declaration exits it. Per-app overrides are supported; a declaration without any never asks which app is focused.

## Related Issues

None. Discussion #766 is the motivating case: nine yabai macros on global chords that become bare letters behind one chord.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new port method; the indicator label is resolved through the shared path on all three managers
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Config and command changes

New config table `[modes.<name>]`. The name is the table key: letters, digits, `_` and `-`, starting with a letter. Built-in mode names and the word `mode` are refused at load. Existing configs keep working unchanged.

| Key | Type | Default | Meaning |
| --- | --- | --- | --- |
| `modes.<name>.indicator` | string | `""` | Mode indicator text while the mode is open; empty hides it |
| `modes.<name>.hotkeys` | table | `{ "Escape" = "idle" }` | The mode's bindings, merged over the default |
| `[[modes.<name>.app_configs]]` | table | none | Per-app overrides with `bundle_id` and `hotkeys`, like scroll's |

```toml
[modes.window]
indicator = "Window"

[modes.window.hotkeys]
"h" = "exec yabai -m window --focus west"
"f" = ["exec yabai -m window --toggle zoom-fullscreen", "idle"]
"s" = "scroll"

[hotkeys]
"Primary+Shift+W" = "mode window"
```

New binding step `mode <name>`, accepted wherever a mode command is (global hotkeys, mode tables, macros, `run`). It takes `--toggle` and no other flag. A step naming an undeclared mode is refused at load like a typo'd flag.

New command `neru mode <name> [--toggle]`, and the IPC action `mode` with the declared name as the first argument. `neru status` now reports the declared name in the `Mode` field while a declared mode is open.

## Additional Context

The four commits build on each other and each passes the tree on its own: grammar and config, the runtime and IPC, the CLI and docs, then the end-to-end journeys.

One `domain.Mode` value serves every declaration and the declared name travels beside it, so the existing mode switches gain one arm rather than the enum becoming a string. The overlay names a declared mode by its declared name, which is what the indicator label is looked up by on every backend. The deadlock and platform-boundary reviewers were run on the diff and reported nothing.
