### PR TITLE
fix(install): keep the PowerShell window open and respect the execution policy

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -118,7 +118,10 @@ that Wayland keyboard capture needs.
 
 On Windows it puts `neru.exe` under `%LOCALAPPDATA%\Programs\neru`, adds that
 directory to your user PATH, creates a Start Menu shortcut, and offers PowerShell
-completion in your profile and a Task Scheduler logon task.
+completion in your profile and a Task Scheduler logon task. Completion lives in
+your profile, which PowerShell will not load under the default `Restricted`
+execution policy, so the script offers to set `RemoteSigned` for your user
+account first and skips completion if you decline.
 
 When a login service is already registered, the script unloads it before it
 replaces the binary and registers it again afterwards. It refuses to run over a

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -95,6 +95,20 @@ export PATH="/usr/local/bin:$PATH"
 brew update && brew reinstall --cask neru
 ```
 
+**Windows: "profile.ps1 cannot be loaded because running scripts is disabled"**
+
+The installer added tab completion to your PowerShell profile, and the default
+`Restricted` execution policy blocks profiles along with every other script.
+Allow local scripts for your user account, then open a new window:
+
+```powershell
+Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+```
+
+Newer installer versions check the policy first and offer this before writing
+the profile. To drop the completion instead, delete the two lines under
+`# neru shell completion (managed by install.ps1)` in the profile.
+
 **Linux: "error while loading shared libraries: libtesseract.so.5"** (Fedora)
 
 Fedora names the library `libtesseract.so.5.5`. Add a compatibility symlink; see

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -56,6 +56,12 @@ $ghBase = "https://github.com/$repo"
 $apiBase = "https://api.github.com/repos/$repo"
 if ($env:NERU_YES -eq '1') { $Yes = $true }
 
+# Under `irm ... | iex` this script runs inside the user's session, where
+# `exit` would close their window. Early exits therefore throw a sentinel
+# that the driver at the bottom turns into a return, or into a real exit
+# code when the script was run as a file.
+function Stop-Installer([int]$Code) { throw "NERU_EXIT:$Code" }
+
 # ------------------------------------------------------------ presentation --
 
 $script:useColor = -not $env:NO_COLOR
@@ -91,14 +97,14 @@ function Restore-LoginTask {
         Write-Warn 'The login task was unloaded for the update and could not be restored. Run: neru services install'
     }
 }
-trap { Restore-LoginTask; break }
-
 function Fail([string]$Message) {
     Write-Host ''
     Write-Piece "  $([char]0x2717) $Message" 'Red'
     Restore-LoginTask
-    exit 1
+    Stop-Installer 1
 }
+
+function Invoke-NeruInstaller {
 
 # Ask returns $true when the user says yes. -Yes answers for them.
 function Ask([string]$Prompt) {
@@ -144,7 +150,7 @@ $arch = switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitect
 $asset = "neru-windows-$arch.zip"
 
 $installDir = Join-Path $env:LOCALAPPDATA 'Programs\neru'
-$exe = Join-Path $installDir 'neru.exe'
+$script:exe = Join-Path $installDir 'neru.exe'
 $manifest = Join-Path $installDir 'install-manifest'
 $shortcutPath = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\Neru.lnk'
 
@@ -259,7 +265,7 @@ if ($Uninstall) {
     if (-not (Test-Path $exe) -and -not (Test-Path $shortcutPath) -and -not (Test-UserPathEntry) -and -not (Test-ProfileCompletion)) {
         Write-Host ''
         Write-Host '  Nothing to uninstall.'
-        exit 0
+        Stop-Installer 0
     }
     Write-Step 'Removing Neru'
     Write-Note 'The login task, executable, PATH entry, Start Menu shortcut and completion go.'
@@ -271,7 +277,7 @@ if ($Uninstall) {
     if (-not (Ask 'Uninstall Neru?')) {
         Write-Host ''
         Write-Host '  Nothing changed.'
-        exit 0
+        Stop-Installer 0
     }
     $stopped = Stop-InstalledNeru
     if ($stopped.Service) { Write-Ok 'Login task removed' }
@@ -319,7 +325,7 @@ if ($Uninstall) {
     Write-Piece '  Neru is uninstalled.' 'Green'
     if (-not $Purge) { Write-Note 'Config, data and logs were kept. Rerun with -Uninstall -Purge to remove them.' }
     Write-Host ''
-    exit 0
+    Stop-Installer 0
 }
 
 # ----------------------------------------------------------------- channel --
@@ -354,7 +360,7 @@ if ($installedChannel -and $installedChannel -ne $Channel) {
     if (-not (Ask "Switch to $Channel`?")) {
         Write-Host ''
         Write-Host '  Nothing changed.'
-        exit 0
+        Stop-Installer 0
     }
 }
 
@@ -387,7 +393,7 @@ try {
             Write-Piece "  Neru $tag is already installed and up to date." 'Green'
             Write-Note 'Pass -Force to reinstall it anyway.'
             Write-Host ''
-            exit 0
+            Stop-Installer 0
         }
         $targetLabel = if ($Channel -eq 'nightly') { 'the latest nightly build' } else { "Neru $tag" }
 
@@ -496,7 +502,22 @@ if (-not $NoCompletions) {
     } else {
         Write-Step 'PowerShell completion'
         Write-Note "Tab completion loads from your profile: $profilePath"
-        if (Ask 'Add PowerShell tab completion for neru to your profile?') {
+        # A profile is a script, so a Restricted or AllSigned policy would
+        # block it and print an error at every new session. Offer the usual
+        # per-user policy first rather than plant that error.
+        $policy = Get-ExecutionPolicy
+        $policyOk = $policy -notin 'Restricted', 'AllSigned'
+        if (-not $policyOk) {
+            Write-Warn "Your execution policy is $policy, which stops PowerShell from loading a profile."
+            if (Ask 'Set it to RemoteSigned for your user account so local scripts and profiles run?') {
+                Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned -Force
+                $policyOk = $true
+                Write-Ok 'Execution policy set to RemoteSigned for your user'
+            } else {
+                Write-Info 'Skipped completion; the profile would not load under this policy.'
+            }
+        }
+        if ($policyOk -and (Ask 'Add PowerShell tab completion for neru to your profile?')) {
             New-Item -ItemType Directory -Force -Path (Split-Path -Parent $profilePath) | Out-Null
             Add-Content -Path $profilePath -Value "`n$marker`nif (Get-Command neru -ErrorAction SilentlyContinue) { neru completion powershell | Out-String | Invoke-Expression }"
             $completionState = 'added'
@@ -577,3 +598,23 @@ Write-Note 'Windows support is beta; see docs/CROSS_PLATFORM.md for what works t
 Write-Note "Manage the task with 'neru services status|stop|restart'. Rerun this script to update,"
 Write-Note 'add -Channel stable|nightly to switch, or -Uninstall to remove.'
 Write-Host ''
+}
+
+$exitCode = 0
+try {
+    Invoke-NeruInstaller
+} catch {
+    if ($_.Exception.Message -match '^NERU_EXIT:(\d+)$') {
+        $exitCode = [int]$Matches[1]
+    } else {
+        Write-Host ''
+        Write-Piece "  $([char]0x2717) Unexpected failure: $($_.Exception.Message)" 'Red'
+        Write-Note "  at $($_.InvocationInfo.PositionMessage -replace '\s+', ' ')"
+        Write-Note "Please report this with the lines above at $ghBase/issues."
+        Restore-LoginTask
+        $exitCode = 1
+    }
+}
+# Run as a file (-File, or just install) the exit code matters and exiting is
+# safe. Piped into iex there is no file, and exit would close the session.
+if ($MyInvocation.MyCommand.Path) { exit $exitCode }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -142,10 +142,14 @@ if ($From) {
 
 # ---------------------------------------------------------------- platform --
 
-$arch = switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
-    'Arm64' { 'arm64' }
-    'X64' { 'amd64' }
-    default { Fail "Unsupported architecture '$_' (releases ship amd64 and arm64)." }
+# PROCESSOR_ARCHITEW6432 names the real machine when this PowerShell runs
+# emulated (x86 Windows PowerShell on an ARM64 machine, say); the .NET
+# RuntimeInformation call is not reliable there under Windows PowerShell 5.1.
+$machine = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+$arch = switch ($machine) {
+    'ARM64' { 'arm64' }
+    'AMD64' { 'amd64' }
+    default { Fail "Unsupported architecture '$machine' (releases ship amd64 and arm64)." }
 }
 $asset = "neru-windows-$arch.zip"
 


### PR DESCRIPTION
## Description

This PR fixes two Windows problems found right after the installer shipped. Piped into `iex`, the script runs inside the user's own session, so every early exit, including "already up to date", closed the PowerShell window. Early exits now return instead, and a real exit code is only used when the script runs as a file. Separately, the completion step wrote a profile that the default `Restricted` execution policy then refused to load, so every new PowerShell window opened with an error. The installer now checks the policy first, offers to set `RemoteSigned` for the current user, and skips completion if declined.

The troubleshooting guide gains an entry for anyone who already has that profile error, with the one-line policy fix.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no Go changes
- [x] No darwin imports from untagged (shared) code — N/A, no Go changes
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no Go changes
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, PowerShell script and docs only; ran `just fmt-check && just lint` instead, both green
- [x] Tests added/updated for new or changed functionality — N/A, installer script; verified under pwsh as described below
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Commands and flags

No new flags. The completion step may now ask one extra question: whether to run `Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned`. Under `-Yes` it is accepted like every other prompt.

## Additional Context

Verified under pwsh here: run as a file, a validation failure exits 1; piped into `Invoke-Expression` or run through `[scriptblock]::Create`, the same failure and the exit-0 paths return control to the session. The Windows-only steps themselves were not run on a Windows host.
