### PR TITLE
fix(install): notice Nix launch agents and clean up the old installer's systemd unit

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -339,6 +339,46 @@ if existing_on_path="$(command -v neru 2>/dev/null)"; then
     esac
 fi
 
+# A nix-darwin or home-manager agent runs Neru straight from the store without
+# putting it on PATH, so look at the agents themselves: any Neru plist whose
+# program is not the binary this script installs belongs to another installer,
+# and registering ours beside it would start two daemons at login.
+if [ "$os" = darwin ] && [ "$uninstall" = 0 ]; then
+    for plist in "$HOME/Library/LaunchAgents/"*neru*.plist "/Library/LaunchAgents/"*neru*.plist "/Library/LaunchDaemons/"*neru*.plist; do
+        [ -e "$plist" ] || continue
+        agent_prog="$(/usr/libexec/PlistBuddy -c 'Print :ProgramArguments:0' "$plist" 2>/dev/null || true)"
+        [ -n "$agent_prog" ] && [ "$agent_prog" != "$neru_bin" ] || continue
+        warn "A Neru login agent is already registered by another installer."
+        note "plist:    $plist"
+        note "launches: $agent_prog"
+        case "$(basename "$plist")" in
+            org.nixos.* | org.nix-community.*) note "Remove Neru from your nix-darwin or home-manager config and rebuild, then retry." ;;
+            *) note "Remove it with 'neru services uninstall' using the neru it launches, then retry." ;;
+        esac
+        exit 1
+    done
+fi
+
+# The installer before this one wrote a plain systemd user unit without the
+# marker `neru services` looks for, so `services uninstall` refuses to touch
+# it. legacy_unit prints that unit's path when it exists and starts the
+# binary this script manages; it is removed here and, on update, replaced
+# by a unit `neru services install` owns.
+legacy_unit() {
+    local unit="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/neru.service"
+    [ "$os" = linux ] && [ -f "$unit" ] || return 1
+    grep -q 'Installed by .neru services install.' "$unit" && return 1
+    grep -q "^ExecStart=$neru_bin launch" "$unit" || return 1
+    printf '%s' "$unit"
+}
+remove_legacy_unit() {
+    local unit
+    unit="$(legacy_unit)" || return 1
+    systemctl --user disable --now neru.service >/dev/null 2>&1 || true
+    rm -f "$unit"
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+}
+
 installed_version=""
 installed_channel=""
 if [ -x "$neru_bin" ]; then
@@ -464,6 +504,7 @@ if [ "$uninstall" = 1 ]; then
         esac
         "$neru_bin" stop >/dev/null 2>&1 || true
     fi
+    if remove_legacy_unit; then ok "Removed the systemd unit the previous installer wrote"; fi
     if [ "$os" = darwin ]; then
         if [ -L "$link" ]; then
             $(sudo_for "$(dirname "$link")") rm -f "$link" && ok "Removed $link"
@@ -607,7 +648,11 @@ fi
 # mentioned at the end. `services status` always exits 0, so read its text.
 service_was_installed=0
 daemon_was_running=0
-if [ -x "$neru_bin" ]; then
+if remove_legacy_unit; then
+    service_was_installed=1
+    service_unloaded=1
+    info "Removed the systemd unit the previous installer wrote; a unit 'neru services' owns replaces it"
+elif [ -x "$neru_bin" ]; then
     case "$("$neru_bin" services status 2>/dev/null)" in
         "Service loaded"* | "Service installed"*)
             service_was_installed=1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -340,13 +340,17 @@ if existing_on_path="$(command -v neru 2>/dev/null)"; then
 fi
 
 # A nix-darwin or home-manager agent runs Neru straight from the store without
-# putting it on PATH, so look at the agents themselves: any Neru plist whose
-# program is not the binary this script installs belongs to another installer,
-# and registering ours beside it would start two daemons at login.
+# putting it on PATH, so look at the agents themselves. Every plist that
+# mentions neru is a candidate, whatever its filename; its program is the
+# Program key when present, else the first ProgramArguments entry. One that
+# runs anything but the binary this script installs belongs to another
+# installer, and registering ours beside it would start two daemons at login.
 if [ "$os" = darwin ] && [ "$uninstall" = 0 ]; then
-    for plist in "$HOME/Library/LaunchAgents/"*neru*.plist "/Library/LaunchAgents/"*neru*.plist "/Library/LaunchDaemons/"*neru*.plist; do
+    for plist in "$HOME/Library/LaunchAgents/"*.plist "/Library/LaunchAgents/"*.plist "/Library/LaunchDaemons/"*.plist; do
         [ -e "$plist" ] || continue
-        agent_prog="$(/usr/libexec/PlistBuddy -c 'Print :ProgramArguments:0' "$plist" 2>/dev/null || true)"
+        grep -qi neru "$plist" 2>/dev/null || continue
+        agent_prog="$(/usr/libexec/PlistBuddy -c 'Print :Program' "$plist" 2>/dev/null || true)"
+        [ -n "$agent_prog" ] || agent_prog="$(/usr/libexec/PlistBuddy -c 'Print :ProgramArguments:0' "$plist" 2>/dev/null || true)"
         [ -n "$agent_prog" ] && [ "$agent_prog" != "$neru_bin" ] || continue
         warn "A Neru login agent is already registered by another installer."
         note "plist:    $plist"
@@ -361,14 +365,15 @@ fi
 
 # The installer before this one wrote a plain systemd user unit without the
 # marker `neru services` looks for, so `services uninstall` refuses to touch
-# it. legacy_unit prints that unit's path when it exists and starts the
-# binary this script manages; it is removed here and, on update, replaced
-# by a unit `neru services install` owns.
+# it. legacy_unit prints that unit's path only when its contents are exactly
+# what that installer wrote for the binary this script manages; a unit the
+# user edited, even by one flag, is theirs and stays. It is removed here and,
+# on update, replaced by a unit `neru services install` owns.
 legacy_unit() {
     local unit="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/neru.service"
     [ "$os" = linux ] && [ -f "$unit" ] || return 1
-    grep -q 'Installed by .neru services install.' "$unit" && return 1
-    grep -q "^ExecStart=$neru_bin launch" "$unit" || return 1
+    printf '[Unit]\nDescription=Neru keyboard navigation daemon\nAfter=graphical-session.target\nPartOf=graphical-session.target\n\n[Service]\nExecStart=%s launch\nRestart=on-failure\nRestartSec=5\n\n[Install]\nWantedBy=graphical-session.target\n' "$neru_bin" |
+        cmp -s - "$unit" || return 1
     printf '%s' "$unit"
 }
 remove_legacy_unit() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -350,8 +350,16 @@ if [ "$os" = darwin ] && [ "$uninstall" = 0 ]; then
         [ -e "$plist" ] || continue
         grep -qi neru "$plist" 2>/dev/null || continue
         agent_prog="$(/usr/libexec/PlistBuddy -c 'Print :Program' "$plist" 2>/dev/null || true)"
-        [ -n "$agent_prog" ] || agent_prog="$(/usr/libexec/PlistBuddy -c 'Print :ProgramArguments:0' "$plist" 2>/dev/null || true)"
+        agent_args="$(/usr/libexec/PlistBuddy -c 'Print :ProgramArguments' "$plist" 2>/dev/null || true)"
+        [ -n "$agent_prog" ] || agent_prog="$(printf '%s\n' "$agent_args" | sed -n '2s/^ *//p')"
         [ -n "$agent_prog" ] && [ "$agent_prog" != "$neru_bin" ] || continue
+        # The agent must actually run a neru binary, directly or through a
+        # shell wrapper as nix-darwin does; the word in a label or log path
+        # of some unrelated agent is not a conflict.
+        case "$agent_prog $agent_args" in
+            *bin/neru | *bin/neru\ * | *bin/neru$'\n'* | *Neru.app/Contents/MacOS/neru*) ;;
+            *) continue ;;
+        esac
         warn "A Neru login agent is already registered by another installer."
         note "plist:    $plist"
         note "launches: $agent_prog"


### PR DESCRIPTION
## Description

This PR fixes two gaps in the installer for people coming from an older install. On macOS, a Neru login agent registered by nix-darwin or home-manager was only noticed when `neru` sat on PATH, and those agents run Neru straight from the store, so the installer could register a second agent and start two daemons at login. It now inspects the Neru launch agents themselves and refuses when one launches anything other than the binary it manages.

On Linux, the previous installer wrote a systemd unit without the marker `neru services` recognises, so `neru services uninstall` refused to touch it and an uninstall left an enabled unit pointing at a deleted binary. The installer now removes that unit on uninstall and, on update, replaces it with a unit `neru services` owns, so the service keeps working across the migration.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`) — N/A, no Go changes
- [x] No darwin imports from untagged (shared) code — N/A, no Go changes
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no Go changes
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, shell script only; ran `just fmt-check && just lint` instead, both green
- [x] Tests added/updated for new or changed functionality — N/A, installer script; verified as described below
- [x] Documentation updated (if applicable) — N/A, no user-facing interface change
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

Verified on macOS with a fake `org.nixos.neru.plist` in a sandboxed home: the installer refuses with the plist path, what it launches, and the nix-darwin hint. The Linux unit handling was exercised with a stubbed `systemctl`: an unmarked unit whose `ExecStart` names the managed binary is detected, disabled and deleted; a unit carrying the `neru services` marker is left to `neru services` itself. Not yet run on a real Linux host with the old unit in place.
