### PR TITLE
fix(linux): stop a mod hotkey chord opening the desktop launcher on Wayland

### DIFF
--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -344,9 +344,12 @@ match it when validating locally.
 **X11:** Hotkeys in `config.toml` work via `XGrabKey`.
 
 **Wayland:** Hotkeys in `config.toml` also work, through the evdev keyboard
-proxy, provided the daemon can read `/dev/input` (item 2 above). If you would
-rather not grant that access, bind `neru <mode>` in the compositor instead.
-Compositor examples:
+proxy, provided the daemon can read `/dev/input` (item 2 above). A chord on
+`Super` does not also fire the desktop's Super-alone shortcut (the KDE and
+GNOME launchers, a Hyprland `bindr`): Neru taps a symbol-less key in place of
+the chord's key so the compositor sees Super was not pressed alone. If you
+would rather not grant that access, bind `neru <mode>` in the compositor
+instead. Compositor examples:
 
 Sway (`~/.config/sway/config`):
 

--- a/docs/adr/0014-the-wayland-keyboard-is-a-proxy.md
+++ b/docs/adr/0014-the-wayland-keyboard-is-a-proxy.md
@@ -64,6 +64,18 @@ auto-repeat and nothing to unwind when the mode ends. And a mode never sees the
 activation chord's modifier, since the session counts only presses withheld for
 it, so a hint label typed while Super is still coming up is the label.
 
+Withholding has one side effect the tap never had, because the tap left the
+chord's key with the compositor. A modifier pressed and released with nothing
+between is a shortcut of its own: KWin and Mutter open the launcher on it, and
+a Hyprland release bind fires on it, each deciding "nothing between" by whether
+another key went down under the modifier. Neru keeps that key, so with
+`Super+;` bound the launcher opened on every activation. The proxy therefore
+taps `KEY_UNKNOWN` in the place of any non-modifier press it withholds under a
+held modifier (`cancelModifierShortcut`), a chord's key or a mode's. The code
+has no symbol in any xkb keymap, so no application acts on it, and it is a key
+pressed under the modifier all the same, which is all the compositor's check
+asks.
+
 ## Considered options
 
 - **Keep the on-demand grab and tune the waits.** Sharing one reader between

--- a/internal/adapter/eventtap/linux/evdev_keys.go
+++ b/internal/adapter/eventtap/linux/evdev_keys.go
@@ -109,18 +109,22 @@ const (
 	evdevKeyDelete     uint16 = 111
 	evdevKeyLeftMeta   uint16 = 125
 	evdevKeyRightMeta  uint16 = 126
-	evdevKeyF13        uint16 = 183
-	evdevKeyF14        uint16 = 184
-	evdevKeyF15        uint16 = 185
-	evdevKeyF16        uint16 = 186
-	evdevKeyF17        uint16 = 187
-	evdevKeyF18        uint16 = 188
-	evdevKeyF19        uint16 = 189
-	evdevKeyF20        uint16 = 190
-	evdevKeyF21        uint16 = 191
-	evdevKeyF22        uint16 = 192
-	evdevKeyF23        uint16 = 193
-	evdevKeyF24        uint16 = 194
+	// evdevKeyUnknown is KEY_UNKNOWN: a key code with no symbol in any xkb
+	// keymap, so nothing acts on it, which is what the proxy taps to cancel a
+	// compositor's modifier-only shortcut (cancelModifierShortcut).
+	evdevKeyUnknown uint16 = 240
+	evdevKeyF13     uint16 = 183
+	evdevKeyF14     uint16 = 184
+	evdevKeyF15     uint16 = 185
+	evdevKeyF16     uint16 = 186
+	evdevKeyF17     uint16 = 187
+	evdevKeyF18     uint16 = 188
+	evdevKeyF19     uint16 = 189
+	evdevKeyF20     uint16 = 190
+	evdevKeyF21     uint16 = 191
+	evdevKeyF22     uint16 = 192
+	evdevKeyF23     uint16 = 193
+	evdevKeyF24     uint16 = 194
 
 	evdevModifierShift = "shift"
 	evdevModifierCtrl  = "ctrl"

--- a/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
@@ -66,6 +66,10 @@ type evdevProxy struct {
 	pointerNode   *proxyNode
 	heldByAnother func(*proxyNode) bool
 
+	// emitted sees every key event the proxy makes up on its own, as opposed
+	// to one it re-emits: a test's record of what reached the compositor.
+	emitted func(code uint16, value int32)
+
 	bindings atomic.Pointer[map[string]hotkeyBinding]
 
 	// heldHotkeys is the release callback owed for each key whose press
@@ -415,6 +419,8 @@ func (p *evdevProxy) handleKey(event waylandEvdevEvent) {
 		forwarded := p.rule.press(code, withhold)
 		if forwarded {
 			p.emit(event)
+		} else if modifier == "" && !p.global.modifiers.allZero() {
+			p.cancelModifierShortcut()
 		}
 
 		if p.session != nil {
@@ -443,6 +449,19 @@ func (p *evdevProxy) handleKey(event waylandEvdevEvent) {
 			p.session.handleRelease(code, modifier, forwarded)
 		}
 	}
+}
+
+// cancelModifierShortcut stands in for a withheld press under a held modifier.
+// KWin and Mutter open the launcher on a modifier pressed and released alone,
+// and a Hyprland release bind does the same, and each of them calls the
+// modifier alone when no other key went down in between. The compositor saw
+// the modifier's press and will see its release; the key between them, Neru
+// kept. So it is given another: a tap of KEY_UNKNOWN, which carries no symbol
+// and reaches no application, and is a key pressed under the modifier all the
+// same.
+func (p *evdevProxy) cancelModifierShortcut() {
+	p.emitKey(evdevKeyUnknown, evdevValuePress)
+	p.emitKey(evdevKeyUnknown, evdevValueRelease)
 }
 
 // trackGlobal keeps the proxy's own picture of the keyboard, which is the
@@ -542,6 +561,10 @@ func (p *evdevProxy) emitPointer(event waylandEvdevEvent) {
 // emitKey re-emits a key event of the proxy's own making, with the sync report
 // that makes it a complete frame.
 func (p *evdevProxy) emitKey(code uint16, value int32) {
+	if p.emitted != nil {
+		p.emitted(code, value)
+	}
+
 	frame := keyFrame(code, value)
 	p.write(p.uinputFd, &frame[0], len(frame))
 }

--- a/internal/adapter/eventtap/linux/evdev_proxy_test.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_test.go
@@ -11,6 +11,7 @@ package linux
 import (
 	"errors"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -271,6 +272,111 @@ func TestEvdevProxy_MatchesAChordAndWithholdsIt(t *testing.T) {
 
 	if forwarded := proxy.rule.release(evdevKeyLeftMeta); !forwarded {
 		t.Error("the modifier's release was withheld after its press was forwarded")
+	}
+}
+
+// A modifier pressed and released with nothing between is a launcher shortcut
+// on KDE and GNOME and a release bind on Hyprland. The chord's key is what
+// would have been between, and the proxy keeps it, so it puts a symbol-less
+// tap there instead. A forwarded key is between already, and a key withheld
+// under no modifier has no shortcut to cancel.
+func TestEvdevProxy_AWithheldPressUnderAModifierCancelsTheModifierOnlyShortcut(t *testing.T) {
+	t.Parallel()
+
+	type emitted struct {
+		code  uint16
+		value int32
+	}
+
+	cancelTap := []emitted{{evdevKeyUnknown, evdevValuePress}, {evdevKeyUnknown, evdevValueRelease}}
+
+	tests := []struct {
+		name   string
+		events []waylandEvdevEvent
+		want   []emitted
+	}{
+		{
+			name: "hotkey chord under Super",
+			events: []waylandEvdevEvent{
+				keyEvent(evdevKeyLeftMeta, evdevValuePress),
+				keyEvent(evdevKeySemicolon, evdevValuePress),
+			},
+			want: cancelTap,
+		},
+		{
+			name: "unbound key under Super is forwarded",
+			events: []waylandEvdevEvent{
+				keyEvent(evdevKeyLeftMeta, evdevValuePress),
+				keyEvent(evdevKeyJ, evdevValuePress),
+			},
+			want: nil,
+		},
+		{
+			name: "Super alone",
+			events: []waylandEvdevEvent{
+				keyEvent(evdevKeyLeftMeta, evdevValuePress),
+				keyEvent(evdevKeyLeftMeta, evdevValueRelease),
+			},
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			proxy := newTestProxy()
+			bindTestChord(proxy)
+
+			var got []emitted
+
+			proxy.emitted = func(code uint16, value int32) {
+				got = append(got, emitted{code, value})
+			}
+
+			for _, event := range test.events {
+				proxy.handle(event)
+			}
+
+			if !slices.Equal(got, test.want) {
+				t.Fatalf("proxy emitted %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+// A mode's keys are withheld too, and one typed under a held modifier would
+// otherwise leave the modifier alone to the compositor when it comes up.
+func TestEvdevProxy_SessionKeyUnderAModifierCancelsTheModifierOnlyShortcut(t *testing.T) {
+	t.Parallel()
+
+	proxy := newTestProxy()
+	tap, _ := collectKeys(t)
+	beginSession(proxy, tap)
+
+	taps := 0
+
+	proxy.emitted = func(code uint16, _ int32) {
+		if code == evdevKeyUnknown {
+			taps++
+		}
+	}
+
+	proxy.handle(keyEvent(evdevKeyJ, evdevValuePress))
+	proxy.handle(keyEvent(evdevKeyJ, evdevValueRelease))
+
+	if taps != 0 {
+		t.Fatalf("a key withheld under no modifier emitted %d cancel events", taps)
+	}
+
+	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValuePress))
+	proxy.handle(keyEvent(evdevKeyJ, evdevValuePress))
+
+	if taps != 2 {
+		t.Fatalf(
+			"a key withheld under Super emitted %d cancel events, want a press and a release",
+			taps,
+		)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR stops a Super hotkey chord on Linux Wayland from also opening the desktop's launcher.

Two users hit it, one on KDE and one on Hyprland, both with `Super+;` bound to a mode. Since the lifetime keyboard proxy shipped (#1600), the proxy forwards Super's press and release to the compositor and keeps the `;` for Neru. From the compositor's side that is Super pressed and released with nothing in between. KWin and Mutter open the launcher on exactly that, and a Hyprland `bindr` on Super fires on it too. All three decide "nothing in between" by whether another key went down while Super was held. Before the proxy the compositor saw the `;` itself, which is why this is new.

The proxy now taps `KEY_UNKNOWN` in place of any non-modifier press it withholds under a held modifier. That covers a hotkey chord's key and a mode's keys typed while a modifier is still down. The code carries no symbol in any xkb keymap, so no application reacts to it, but it is a key pressed under the modifier as far as the compositor's check is concerned. A press the proxy forwards needs nothing, and a press withheld with no modifier held has no shortcut to cancel, so neither gets a tap.

I verified the KWin and Mutter behaviour from their shortcut filters. Hyprland's release-bind check I could not run here, so I would like the Hyprland reporter to confirm on a dev build before this is called done for them.

## Related Issues

Reported by users directly. No issue filed.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`). N/A here. No port changed, this lives inside the Wayland keyboard proxy.
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes. I ran the fast host slice (`fmt-check`, `lint`, `vet`, `check-cross`, architecture tests) and, because the host cannot compile the cgo proxy, `go test` with CGO on and `golangci-lint` for `internal/adapter/eventtap/linux` inside the `neru-linux-ci` container. Both green.
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable). ADR 0014 records the side effect and the tap. `docs/LINUX_SETUP.md` says a Super chord does not fire the Super-alone shortcut.
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

To check by hand, bind a mode to `Super+;` on KDE Plasma Wayland with the Meta launcher shortcut left at its default, press the chord, and confirm the mode opens and the launcher stays closed. Pressing and releasing Super on its own must still open the launcher. On Hyprland the same with a `bindr = SUPER, SUPER_L, exec, ...` line.
