### PR TITLE
fix(linux): place KDE screen-capture streams that carry no position

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -277,7 +277,13 @@ prompt is paid once: the grant is persisted with a restore token in
 `$XDG_STATE_HOME/neru/screen-cast.token`, and only the mode handler's
 permission preflight can raise the dialog, never a capture. Sources are
 requested as monitors with the cursor left out; windows are not asked for,
-because a window stream carries no position.
+because a window stream carries no position. A monitor stream carries one only
+on a Plasma that speaks screencasting v6, which no release up to 6.5 does.
+Every shipped Plasma names a size alone, so each stream is placed at capture
+time on the `wl_output` it belongs to, by KWin's `mapping_id` where the portal
+sends one and otherwise by size, pairing identical monitors off in announcement
+order. A stream nothing can place is taken to start at the origin, which is
+right for a single display.
 
 Capture is a **region** operation on every backend, and what comes back covers
 exactly the region asked for. A rectangle that leaves the screen, is

--- a/internal/adapter/platform/linux/portal_screencast.go
+++ b/internal/adapter/platform/linux/portal_screencast.go
@@ -374,6 +374,20 @@ func placeScreenCastStreams(
 
 	used := make([]bool, len(outputs))
 
+	// An output the portal already placed a stream on is spoken for, so a
+	// sized stream of the same shape cannot land on it too.
+	for _, stream := range placed {
+		if !stream.positioned {
+			continue
+		}
+
+		for i, output := range outputs {
+			if output.bounds == stream.bounds {
+				used[i] = true
+			}
+		}
+	}
+
 	claim := func(stream *screenCastStream, match func(screenCastOutput) bool) {
 		for i, output := range outputs {
 			if used[i] || !match(output) {

--- a/internal/adapter/platform/linux/portal_screencast.go
+++ b/internal/adapter/platform/linux/portal_screencast.go
@@ -5,6 +5,7 @@ package linux
 import (
 	"context"
 	"image"
+	"strings"
 
 	"github.com/godbus/dbus/v5"
 
@@ -61,9 +62,18 @@ type screenCastStream struct {
 	nodeID uint32
 	// bounds is the monitor's place in Neru's shared coordinate space: global
 	// origin, top-left, Y down, logical pixels. It is the zero rectangle when
-	// the portal named no position or size for the stream, which is the one
-	// case a region cannot be honored — see selectScreenCastStream.
+	// the portal named no size for the stream, which is the one case a region
+	// cannot be honored — see selectScreenCastStream.
 	bounds image.Rectangle
+	// positioned reports whether the portal itself said where the monitor
+	// sits. Every released Plasma (5.27 through 6.5) names only a size for a
+	// monitor stream. Position arrived with screencasting v6 on master. An
+	// unpositioned stream has bounds at the origin until placeScreenCastStreams
+	// finds the output it belongs to.
+	positioned bool
+	// mappingID is the output name a Plasma speaking screencasting v5 or later
+	// attaches to a monitor stream, and empty before that.
+	mappingID string
 }
 
 // screenCastGrant is one established ScreenCast grant: the monitors it streams,
@@ -273,27 +283,36 @@ func decodeScreenCastStreams(results map[string]dbus.Variant) []screenCastStream
 		}
 
 		properties, _ := entry[1].(map[string]dbus.Variant)
+		bounds, positioned := streamBounds(properties)
+		mappingID, _ := properties["mapping_id"].Value().(string)
 
 		streams = append(streams, screenCastStream{
-			nodeID: nodeID,
-			bounds: streamBounds(properties),
+			nodeID:     nodeID,
+			bounds:     bounds,
+			positioned: positioned,
+			mappingID:  mappingID,
 		})
 	}
 
 	return streams
 }
 
-// streamBounds turns a stream's position and size properties into a rectangle,
-// and reports the zero rectangle when either is absent or unreadable.
-func streamBounds(properties map[string]dbus.Variant) image.Rectangle {
-	originX, originY, hasPosition := portalIntPair(properties, "position")
+// streamBounds turns a stream's position and size properties into a rectangle
+// and reports whether the position was actually named. Without a size there is
+// no rectangle at all. Without a position the rectangle sits at the origin and
+// the caller decides where it really is.
+func streamBounds(properties map[string]dbus.Variant) (image.Rectangle, bool) {
 	width, height, hasSize := portalIntPair(properties, "size")
-
-	if !hasPosition || !hasSize || width <= 0 || height <= 0 {
-		return image.Rectangle{}
+	if !hasSize || width <= 0 || height <= 0 {
+		return image.Rectangle{}, false
 	}
 
-	return image.Rect(originX, originY, originX+width, originY+height)
+	originX, originY, hasPosition := portalIntPair(properties, "position")
+	if !hasPosition {
+		return image.Rect(0, 0, width, height), false
+	}
+
+	return image.Rect(originX, originY, originX+width, originY+height), true
 }
 
 // portalIntPair reads a D-Bus (ii) structure out of a property bag. godbus
@@ -320,6 +339,80 @@ func portalIntPair(properties map[string]dbus.Variant, key string) (int, int, bo
 	}
 
 	return int(first), int(second), true
+}
+
+// screenCastOutput is one output the compositor reports over wl_output: its
+// name (the connector, "DP-1" or "eDP-1") and its bounds in the shared space.
+type screenCastOutput struct {
+	name   string
+	bounds image.Rectangle
+}
+
+// placeScreenCastStreams gives every unpositioned stream a place on screen,
+// using the outputs the compositor itself reports over wl_output.
+//
+// Two things identify which monitor a stream is, tried in this order:
+//
+//   - mapping_id, which a Plasma speaking screencasting v5 or later sets to
+//     the output's name. It is exact, and it is absent on every Plasma
+//     released before that.
+//   - size. A monitor stream is a whole output, so its size is the output's
+//     size. Each output is used once, so two identical monitors that are both
+//     streamed pair off in the order the portal and the compositor list them,
+//     which is the same KWin order on both sides.
+//
+// A stream neither can place stays where it was decoded, at the origin, which
+// is right for the one monitor of a single-display session. Guessing there
+// beats refusing: the alternative is no hints at all on every Plasma release
+// that exists today.
+func placeScreenCastStreams(
+	streams []screenCastStream,
+	outputs []screenCastOutput,
+) []screenCastStream {
+	placed := make([]screenCastStream, len(streams))
+	copy(placed, streams)
+
+	used := make([]bool, len(outputs))
+
+	claim := func(stream *screenCastStream, match func(screenCastOutput) bool) {
+		for i, output := range outputs {
+			if used[i] || !match(output) {
+				continue
+			}
+
+			used[i] = true
+			stream.bounds = output.bounds
+			stream.positioned = true
+
+			return
+		}
+	}
+
+	// Named streams first, so an exact match is never pre-empted by a sized
+	// guess that happened to be listed earlier.
+	for i := range placed {
+		stream := &placed[i]
+		if stream.positioned || stream.bounds.Empty() || stream.mappingID == "" {
+			continue
+		}
+
+		claim(stream, func(output screenCastOutput) bool {
+			return strings.EqualFold(output.name, stream.mappingID)
+		})
+	}
+
+	for i := range placed {
+		stream := &placed[i]
+		if stream.positioned || stream.bounds.Empty() {
+			continue
+		}
+
+		claim(stream, func(output screenCastOutput) bool {
+			return output.bounds.Size() == stream.bounds.Size()
+		})
+	}
+
+	return placed
 }
 
 // selectScreenCastStream finds the streamed monitor that wholly contains region
@@ -362,7 +455,7 @@ func selectScreenCastStream(
 	if placed == 0 {
 		return screenCastStream{}, image.Rectangle{}, derrors.New(
 			derrors.CodeActionFailed,
-			"the ScreenCast portal named no geometry for the monitors it is "+
+			"the ScreenCast portal named no size for the monitors it is "+
 				"streaming, so a captured frame could not be placed on screen",
 		)
 	}

--- a/internal/adapter/platform/linux/portal_screencast_test.go
+++ b/internal/adapter/platform/linux/portal_screencast_test.go
@@ -13,13 +13,15 @@ import (
 	"github.com/y3owk1n/neru/internal/derrors"
 )
 
-// Two monitors side by side, the second one to the right of the first. The
-// shapes are the ones a real dual-head KDE session reports: logical position
-// and logical size, in the same global top-left space Neru uses everywhere.
+// Two monitors side by side, the second one to the right of the first, already
+// placed: logical position and logical size in the same global top-left space
+// Neru uses everywhere. This is what a Plasma that speaks screencasting v6
+// reports directly, and what placeScreenCastStreams produces for every
+// released Plasma, which names only a size.
 func twoMonitorStreams() []screenCastStream {
 	return []screenCastStream{
-		{nodeID: 41, bounds: image.Rect(0, 0, 1920, 1080)},
-		{nodeID: 42, bounds: image.Rect(1920, 0, 3840, 1080)},
+		{nodeID: 41, bounds: image.Rect(0, 0, 1920, 1080), positioned: true},
+		{nodeID: 42, bounds: image.Rect(1920, 0, 3840, 1080), positioned: true},
 	}
 }
 
@@ -77,10 +79,9 @@ func TestSelectScreenCastStream_RefusesARegionNoMonitorContains(t *testing.T) {
 }
 
 // TestSelectScreenCastStream_RefusesAStreamWithNoGeometry pins what happens
-// when the portal hands over a node but names no position or size for it.
-// Without geometry there is no way to say which pixels of the frame the
-// caller's rectangle is, so the capture refuses instead of guessing that the
-// stream starts at the origin.
+// when the portal hands over a node but names no size for it. Without a size
+// there is no way to say which pixels of the frame the caller's rectangle is,
+// so the capture refuses instead of guessing.
 func TestSelectScreenCastStream_RefusesAStreamWithNoGeometry(t *testing.T) {
 	streams := []screenCastStream{{nodeID: 7}}
 
@@ -89,8 +90,8 @@ func TestSelectScreenCastStream_RefusesAStreamWithNoGeometry(t *testing.T) {
 		t.Fatal("selectScreenCastStream() error = nil, want a refusal")
 	}
 
-	if !strings.Contains(err.Error(), "geometry") {
-		t.Errorf("error = %q, want it to name the missing geometry", err.Error())
+	if !strings.Contains(err.Error(), "no size") {
+		t.Errorf("error = %q, want it to name the missing size", err.Error())
 	}
 }
 
@@ -175,6 +176,156 @@ func portalStreamEntry(nodeID uint32, x, y, width, height int32) []any {
 	}
 }
 
+// portalSizedStreamEntry is the monitor stream every released Plasma (5.27
+// through 6.5) reports: a size and a source type, no position.
+func portalSizedStreamEntry(nodeID uint32, width, height int32, mappingID string) []any {
+	properties := map[string]dbus.Variant{
+		"size":        dbus.MakeVariant([]any{width, height}),
+		"source_type": dbus.MakeVariant(screenCastSourceMonitor),
+	}
+	if mappingID != "" {
+		properties["mapping_id"] = dbus.MakeVariant(mappingID)
+	}
+
+	return []any{nodeID, properties}
+}
+
+// The connector names KWin reports for two outputs, as mapping ids and as
+// wl_output names.
+const (
+	leftOutputName  = "DP-1"
+	rightOutputName = "DP-2"
+)
+
+// TestDecodeScreenCastStreams_KeepsASizedStreamWithoutAPosition is the shape
+// every released Plasma sends, and the one the first release of this backend
+// refused as "named no geometry": the size is kept at the origin, the stream
+// is marked unpositioned so it can be placed later, and a mapping id is read
+// when a newer Plasma attaches one.
+func TestDecodeScreenCastStreams_KeepsASizedStreamWithoutAPosition(t *testing.T) {
+	streams := decodeScreenCastStreams(portalStreamReply(
+		portalSizedStreamEntry(7, 1280, 800, ""),
+		portalSizedStreamEntry(8, 1920, 1080, leftOutputName),
+	))
+
+	want := []screenCastStream{
+		{nodeID: 7, bounds: image.Rect(0, 0, 1280, 800)},
+		{nodeID: 8, bounds: image.Rect(0, 0, 1920, 1080), mappingID: leftOutputName},
+	}
+	if len(streams) != len(want) {
+		t.Fatalf("decoded %+v, want %+v", streams, want)
+	}
+
+	for i := range want {
+		if streams[i] != want[i] {
+			t.Errorf("stream %d = %+v, want %+v", i, streams[i], want[i])
+		}
+	}
+}
+
+// TestPlaceScreenCastStreams_PlacesUnpositionedStreams is the whole reason
+// hints work on a released Plasma. It pins the placement rule case by case: a
+// mapping id wins over size, a size finds the one output of that size, two
+// identical outputs pair off in order, and a stream nothing can place stays
+// at the origin. A stream the portal positioned itself is never touched.
+func TestPlaceScreenCastStreams_PlacesUnpositionedStreams(t *testing.T) {
+	sized := func(nodeID uint32, w, h int) screenCastStream {
+		return screenCastStream{nodeID: nodeID, bounds: image.Rect(0, 0, w, h)}
+	}
+	placedAt := func(stream screenCastStream, bounds image.Rectangle) screenCastStream {
+		stream.bounds = bounds
+		stream.positioned = true
+
+		return stream
+	}
+
+	left := image.Rect(0, 0, 1920, 1080)
+	right := image.Rect(1920, 0, 3840, 1080)
+	wide := image.Rect(1920, 0, 4480, 1440)
+
+	tests := []struct {
+		name    string
+		streams []screenCastStream
+		outputs []screenCastOutput
+		want    []screenCastStream
+	}{
+		{
+			name:    "single monitor with no outputs listed stays at the origin",
+			streams: []screenCastStream{sized(7, 1280, 800)},
+			want:    []screenCastStream{sized(7, 1280, 800)},
+		},
+		{
+			name:    "different sizes find their own output",
+			streams: []screenCastStream{sized(41, 1920, 1080), sized(42, 2560, 1440)},
+			outputs: []screenCastOutput{{leftOutputName, left}, {rightOutputName, wide}},
+			want: []screenCastStream{
+				placedAt(sized(41, 1920, 1080), left),
+				placedAt(sized(42, 2560, 1440), wide),
+			},
+		},
+		{
+			name:    "identical monitors pair off in order",
+			streams: []screenCastStream{sized(41, 1920, 1080), sized(42, 1920, 1080)},
+			outputs: []screenCastOutput{{leftOutputName, left}, {rightOutputName, right}},
+			want: []screenCastStream{
+				placedAt(sized(41, 1920, 1080), left),
+				placedAt(sized(42, 1920, 1080), right),
+			},
+		},
+		{
+			name: "mapping id beats size and order",
+			streams: []screenCastStream{
+				{nodeID: 41, bounds: image.Rect(0, 0, 1920, 1080), mappingID: rightOutputName},
+				sized(42, 1920, 1080),
+			},
+			outputs: []screenCastOutput{{leftOutputName, left}, {rightOutputName, right}},
+			want: []screenCastStream{
+				{nodeID: 41, bounds: right, positioned: true, mappingID: rightOutputName},
+				placedAt(sized(42, 1920, 1080), left),
+			},
+		},
+		{
+			name: "a positioned stream is kept and its output not reused",
+			streams: []screenCastStream{
+				{nodeID: 41, bounds: right, positioned: true},
+				sized(42, 1920, 1080),
+			},
+			outputs: []screenCastOutput{{leftOutputName, left}, {rightOutputName, right}},
+			want: []screenCastStream{
+				{nodeID: 41, bounds: right, positioned: true},
+				placedAt(sized(42, 1920, 1080), left),
+			},
+		},
+		{
+			name:    "no output of that size stays at the origin",
+			streams: []screenCastStream{sized(41, 1280, 800)},
+			outputs: []screenCastOutput{{leftOutputName, left}},
+			want:    []screenCastStream{sized(41, 1280, 800)},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			input := make([]screenCastStream, len(testCase.streams))
+			copy(input, testCase.streams)
+
+			placed := placeScreenCastStreams(input, testCase.outputs)
+
+			for i := range testCase.want {
+				if placed[i] != testCase.want[i] {
+					t.Errorf("placed[%d] = %+v, want %+v", i, placed[i], testCase.want[i])
+				}
+			}
+
+			for i := range input {
+				if input[i] != testCase.streams[i] {
+					t.Errorf("placeScreenCastStreams mutated its input at %d", i)
+				}
+			}
+		})
+	}
+}
+
 // TestDecodeScreenCastStreams_ReadsEachMonitorsPlaceOnScreen is what makes a
 // captured frame placeable: the portal's position and size are the only source
 // for where a streamed monitor sits, and without them a crop could not be
@@ -198,7 +349,7 @@ func TestDecodeScreenCastStreams_ReadsEachMonitorsPlaceOnScreen(t *testing.T) {
 }
 
 // TestDecodeScreenCastStreams_KeepsAStreamWhoseGeometryIsMissing pins the
-// choice between two ways of being wrong. A stream the portal named no position
+// choice between two ways of being wrong. A stream the portal named no size
 // for is useless for placing a region, but dropping it would leave the caller
 // with an empty list and the sentence "this session streams no monitor", which
 // is a different problem with a different remedy. It is kept with zero bounds

--- a/internal/adapter/platform/linux/portal_screencast_test.go
+++ b/internal/adapter/platform/linux/portal_screencast_test.go
@@ -287,13 +287,13 @@ func TestPlaceScreenCastStreams_PlacesUnpositionedStreams(t *testing.T) {
 		{
 			name: "a positioned stream is kept and its output not reused",
 			streams: []screenCastStream{
-				{nodeID: 41, bounds: right, positioned: true},
+				{nodeID: 41, bounds: left, positioned: true},
 				sized(42, 1920, 1080),
 			},
 			outputs: []screenCastOutput{{leftOutputName, left}, {rightOutputName, right}},
 			want: []screenCastStream{
-				{nodeID: 41, bounds: right, positioned: true},
-				placedAt(sized(42, 1920, 1080), left),
+				{nodeID: 41, bounds: left, positioned: true},
+				placedAt(sized(42, 1920, 1080), right),
 			},
 		},
 		{

--- a/internal/adapter/platform/linux/screencapture_wayland_kde.go
+++ b/internal/adapter/platform/linux/screencapture_wayland_kde.go
@@ -166,7 +166,15 @@ func kdeCaptureRegion(ctx context.Context, region image.Rectangle) (*image.RGBA,
 		return nil, err
 	}
 
-	stream, local, err := selectScreenCastStream(state.grant.streams, region)
+	// Placement happens per capture rather than once per grant: outputs move
+	// and change between captures, and the grant outlives all of that. A
+	// compositor that will not list its outputs costs nothing here. The
+	// unpositioned streams stay at the origin, which is where a single
+	// monitor is anyway.
+	outputs, _ := wlrootsScreenOutputs()
+
+	stream, local, err := selectScreenCastStream(
+		placeScreenCastStreams(state.grant.streams, outputs), region)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/platform/linux/system_wayland_wlroots_cgo.go
+++ b/internal/adapter/platform/linux/system_wayland_wlroots_cgo.go
@@ -398,6 +398,25 @@ func wlrootsScreenBoundsByName(name string) (image.Rectangle, bool, error) {
 	return image.Rectangle{}, false, nil
 }
 
+// wlrootsScreenOutputs returns every connected output, named and placed in
+// the shared coordinate space, in the order the compositor announced them.
+func wlrootsScreenOutputs() ([]screenCastOutput, error) {
+	err := ensureWlrootsState()
+	if err != nil {
+		return nil, err
+	}
+
+	globalWlrootsState.mu.RLock()
+	defer globalWlrootsState.mu.RUnlock()
+
+	outputs := make([]screenCastOutput, 0, len(globalWlrootsState.screens))
+	for _, screen := range globalWlrootsState.screens {
+		outputs = append(outputs, screenCastOutput{name: screen.Name, bounds: screen.Bounds})
+	}
+
+	return outputs, nil
+}
+
 func wlrootsScreenNames() ([]string, error) {
 	err := ensureWlrootsState()
 	if err != nil {

--- a/internal/adapter/platform/linux/system_wayland_wlroots_nocgo.go
+++ b/internal/adapter/platform/linux/system_wayland_wlroots_nocgo.go
@@ -25,6 +25,13 @@ func wlrootsScreenBoundsByName(name string) (image.Rectangle, bool, error) {
 	)
 }
 
+func wlrootsScreenOutputs() ([]screenCastOutput, error) {
+	return nil, derrors.New(
+		derrors.CodeNotSupported,
+		"wlroots backend requires CGO-enabled Linux builds",
+	)
+}
+
 func wlrootsScreenNames() ([]string, error) {
 	return nil, derrors.New(
 		derrors.CodeNotSupported,


### PR DESCRIPTION
## Description

This PR fixes hints on KDE Plasma under Wayland, where contour detection failed on every activation with "the ScreenCast portal named no geometry for the monitors it is streaming" and no hints were drawn.

Neru required every stream the ScreenCast portal hands back to carry a position. No released Plasma sends one. Every version from 5.27 through 6.5 names only a size and a source type for a monitor stream, and KDE only added a position on its master branch in August 2026. So KDE capture could never place a frame, and hints depended entirely on AT-SPI, which returns nothing for terminals and many other apps.

A stream that arrives with a size but no position is now placed on the compositor's own output list at capture time. A newer Plasma that attaches an output name to the stream is matched by that name. Otherwise the stream is matched by size, with each output claimed once so two identical monitors that are both shared pair off in the order the compositor lists them. A stream nothing can place is taken to start at the origin, which is correct for a single display. Only a stream with no size at all is still refused.

## Related Issues

None. Reported by a Steam Deck user on Plasma Wayland.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — the new output lookup has a CGO-off stub; nothing new reaches macOS or Windows
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, ran the targeted set instead: `just fmt-check`, `just lint`, `just vet`, `just check-cross`, `just lint-cross`, and the Linux package tests with CGO on in the `test-linux` container. The change is confined to Linux-tagged files.
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

Verified against the xdg-desktop-portal-kde source on invent.kde.org: the `Plasma/5.27`, `6.2`, `6.3`, `6.4` and `6.5` branches build a monitor stream's properties from size and source type only. The position and output-name properties arrive with the screencasting v5 and v6 work on master.

Not tested on a live Plasma session here. The reporter's log shows a single 1280x800 display, which takes the origin path. Confirmation from them on the next build would be welcome.
