### PR TITLE
fix(linux): recognize labwc and the wlroots desktop tag

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -123,7 +123,7 @@ read from the environment a second time.
 | Backend                | Detected when                                                          | Status            |
 | ---------------------- | ---------------------------------------------------------------------- | ----------------- |
 | `x11`                  | `DISPLAY` set, no `WAYLAND_DISPLAY`                                    | Supported         |
-| `wayland-wlroots`      | Sway, Hyprland, niri, River, Wayfire, or unset `XDG_CURRENT_DESKTOP`   | Supported         |
+| `wayland-wlroots`      | Sway, Hyprland, niri, River, Wayfire, labwc, a `:wlroots` tag, or unset `XDG_CURRENT_DESKTOP` | Supported         |
 | `wayland-kde`          | `XDG_CURRENT_DESKTOP` contains `KDE`                                   | Supported         |
 | `wayland-cosmic`       | `XDG_CURRENT_DESKTOP` contains `COSMIC`                                | Supported         |
 | `wayland-gnome`        | `XDG_CURRENT_DESKTOP` contains `GNOME`                                 | **Not supported** |

--- a/docs/LINUX_DESKTOPS.md
+++ b/docs/LINUX_DESKTOPS.md
@@ -238,13 +238,13 @@ refresh.
 **Backend:** `wayland-wlroots`
 **Status:** Supported: Sway, Hyprland, niri, River, Wayfire, labwc
 
-Detection is by name for those six. Beyond them, any compositor that tags
-`XDG_CURRENT_DESKTOP` with `:wlroots` (the convention xdg-desktop-portal-wlr
-keys on, which labwc sets by default) or leaves the variable unset lands here
-too. That covers dwl, cage, SwayFX, scroll and most small wlroots
-compositors. Whether the session then works depends only on the protocols
-below being advertised, which
-[Checking compositor protocols](#checking-compositor-protocols) verifies in
+Detection is by name for those six. Two more routes land here. A compositor
+that tags `XDG_CURRENT_DESKTOP` with `:wlroots`, the convention
+xdg-desktop-portal-wlr keys on and labwc's default, and a compositor that
+leaves the variable unset. That covers dwl, cage, SwayFX, scroll and most
+small wlroots compositors. From there the only question is whether the
+compositor advertises the protocols below, and
+[Checking compositor protocols](#checking-compositor-protocols) answers it in
 one line.
 
 This is the reference Wayland path: `zwlr_layer_shell_v1` overlays with an

--- a/docs/LINUX_DESKTOPS.md
+++ b/docs/LINUX_DESKTOPS.md
@@ -236,7 +236,16 @@ refresh.
 ## wlroots compositors
 
 **Backend:** `wayland-wlroots`
-**Status:** Supported: Sway, Hyprland, niri, River, Wayfire
+**Status:** Supported: Sway, Hyprland, niri, River, Wayfire, labwc
+
+Detection is by name for those six. Beyond them, any compositor that tags
+`XDG_CURRENT_DESKTOP` with `:wlroots` (the convention xdg-desktop-portal-wlr
+keys on, which labwc sets by default) or leaves the variable unset lands here
+too. That covers dwl, cage, SwayFX, scroll and most small wlroots
+compositors. Whether the session then works depends only on the protocols
+below being advertised, which
+[Checking compositor protocols](#checking-compositor-protocols) verifies in
+one line.
 
 This is the reference Wayland path: `zwlr_layer_shell_v1` overlays with an
 empty `input_region` for click-through, `zwlr_virtual_pointer_v1` for pointer
@@ -253,8 +262,8 @@ Two behaviors are specific enough to note here:
   `hyprctl` instead.
 - **Per-compositor window origins.** niri, Sway, and Hyprland each expose
   focused-window geometry differently (`niri msg`, `swaymsg -t get_tree`,
-  `hyprctl -j activewindow`). River and Wayfire expose none, so hints there stay
-  window-relative. On niri, **tiled** windows, including a maximized column,
+  `hyprctl -j activewindow`). River, Wayfire and labwc expose none, so hints
+  there stay window-relative. On niri, **tiled** windows, including a maximized column,
   expose no on-screen position
   ([niri#2381](https://github.com/niri-wm/niri/issues/2381)), so hints are
   misaligned there. Details in
@@ -316,6 +325,11 @@ initialization phase rather than running in a degraded state.
 GNOME Shell uses private protocols instead of the wlr family: Mutter implements
 neither `wlr-layer-shell` (overlays) nor `wlr-foreign-toplevel-management`
 (focused app), and exposes no input-injection path Neru can use.
+
+The same applies to every desktop built on Mutter. Budgie identifies itself as
+GNOME and lands on this backend. Cinnamon (Muffin) and Pantheon (Gala) do not,
+so they resolve to `wayland-other` and are refused with the generic message,
+but the reason is identical.
 
 **Use a GNOME X11 session instead.** Everything works there through the `x11`
 backend.

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -31,16 +31,20 @@ Per-desktop-environment details and DE-specific known issues live in
 The backend is detected once at startup from `XDG_CURRENT_DESKTOP`,
 `WAYLAND_DISPLAY` and `DISPLAY`.
 
-| Compositor / session                 | Backend           | Status                                                                           |
-| ------------------------------------ | ----------------- | -------------------------------------------------------------------------------- |
-| Sway, Hyprland, niri, River, Wayfire | `wayland-wlroots` | Supported                                                                        |
-| KDE Plasma (Wayland)                 | `wayland-kde`     | Supported, see [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md#kde-plasma-wayland)       |
-| COSMIC (Wayland)                     | `wayland-cosmic`  | Supported, see [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md#cosmic-wayland)           |
-| X11 / XOrg, i3, GNOME on X11         | `x11`             | Supported                                                                        |
-| GNOME (Wayland)                      | `wayland-gnome`   | Not supported, see [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md#gnome-not-supported)  |
-| Any other Wayland compositor         | `wayland-other`   | Not supported, the daemon refuses to start                                       |
+| Compositor / session                                                  | Backend           | Status                                                                                  |
+| --------------------------------------------------------------------- | ----------------- | --------------------------------------------------------------------------------------- |
+| Sway, Hyprland, niri, River, Wayfire, labwc                            | `wayland-wlroots` | Supported                                                                               |
+| Any compositor tagging `XDG_CURRENT_DESKTOP` with `:wlroots`, or leaving it unset (dwl, cage, SwayFX, scroll, ...) | `wayland-wlroots` | Supported when it implements the wlroots protocols, see [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md#wlroots-compositors) |
+| KDE Plasma (Wayland)                                                  | `wayland-kde`     | Supported, see [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md#kde-plasma-wayland)              |
+| COSMIC (Wayland)                                                      | `wayland-cosmic`  | Supported, see [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md#cosmic-wayland)                  |
+| X11 / XOrg, i3, GNOME on X11                                          | `x11`             | Supported                                                                               |
+| GNOME (Wayland), and Mutter-based desktops such as Budgie             | `wayland-gnome`   | Not supported, see [LINUX_DESKTOPS.md](./LINUX_DESKTOPS.md#gnome-not-supported)         |
+| Cinnamon and Pantheon on Wayland, Weston, Mir shells (miracle-wm), any other compositor | `wayland-other`   | Not supported, the daemon refuses to start                                              |
 
-A Wayland session with `XDG_CURRENT_DESKTOP` unset is treated as wlroots.
+Cinnamon and Pantheon are Mutter-based too and lack layer-shell, so they are
+out for the same reason GNOME is. Mir implements every protocol the wlroots
+path needs but leaves each one for the shell to enable, and no Mir shell has
+been measured yet, so it is refused rather than guessed at.
 
 ---
 

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -42,9 +42,10 @@ The backend is detected once at startup from `XDG_CURRENT_DESKTOP`,
 | Cinnamon and Pantheon on Wayland, Weston, Mir shells (miracle-wm), any other compositor | `wayland-other`   | Not supported, the daemon refuses to start                                              |
 
 Cinnamon and Pantheon are Mutter-based too and lack layer-shell, so they are
-out for the same reason GNOME is. Mir implements every protocol the wlroots
-path needs but leaves each one for the shell to enable, and no Mir shell has
-been measured yet, so it is refused rather than guessed at.
+out for the same reason GNOME is. Mir is the interesting one. It implements
+every protocol the wlroots path needs but leaves each for the shell to
+enable, and nobody has measured a Mir shell yet, so Neru refuses rather than
+guesses.
 
 ---
 

--- a/internal/adapter/platform/backend_linux.go
+++ b/internal/adapter/platform/backend_linux.go
@@ -193,7 +193,12 @@ func detectLinuxBackendFromEnv(
 			strings.Contains(desktop, "HYPRLAND"),
 			strings.Contains(desktop, "NIRI"),
 			strings.Contains(desktop, "RIVER"),
-			strings.Contains(desktop, "WAYFIRE"):
+			strings.Contains(desktop, "WAYFIRE"),
+			strings.Contains(desktop, "LABWC"),
+			// The "<name>:wlroots" tag is how a wlroots compositor tells
+			// xdg-desktop-portal-wlr to serve it (labwc sets "labwc:wlroots"),
+			// so it answers the same question for compositors not named here.
+			strings.Contains(desktop, "WLROOTS"):
 			return BackendWaylandWlroots
 		default:
 			return BackendWaylandOther

--- a/internal/adapter/platform/backend_linux_test.go
+++ b/internal/adapter/platform/backend_linux_test.go
@@ -96,6 +96,12 @@ func TestDetectLinuxBackendFromEnv(t *testing.T) {
 			want:           BackendWaylandGNOME,
 		},
 		{
+			name:           "wayland labwc desktop named without its tag",
+			currentDesktop: "labwc",
+			waylandDisplay: waylandDisplay,
+			want:           BackendWaylandWlroots,
+		},
+		{
 			name:           "wayland labwc desktop carries the wlroots tag",
 			currentDesktop: "labwc:wlroots",
 			waylandDisplay: waylandDisplay,

--- a/internal/adapter/platform/backend_linux_test.go
+++ b/internal/adapter/platform/backend_linux_test.go
@@ -96,6 +96,18 @@ func TestDetectLinuxBackendFromEnv(t *testing.T) {
 			want:           BackendWaylandGNOME,
 		},
 		{
+			name:           "wayland labwc desktop carries the wlroots tag",
+			currentDesktop: "labwc:wlroots",
+			waylandDisplay: waylandDisplay,
+			want:           BackendWaylandWlroots,
+		},
+		{
+			name:           "wayland desktop tagged wlroots without a known name",
+			currentDesktop: "someshell:wlroots",
+			waylandDisplay: waylandDisplay,
+			want:           BackendWaylandWlroots,
+		},
+		{
 			name:           "wayland kde desktop",
 			currentDesktop: desktopKDE,
 			waylandDisplay: waylandDisplay,

--- a/internal/adapter/platform/factory_messages_linux.go
+++ b/internal/adapter/platform/factory_messages_linux.go
@@ -18,7 +18,7 @@ func unsupportedLinuxBackendError(backend LinuxBackend) error {
 	case BackendWaylandOther:
 		return derrors.Newf(
 			derrors.CodeNotSupported,
-			"neru does not recognize this Wayland compositor (XDG_CURRENT_DESKTOP=%q). Supported Wayland compositors are wlroots-based ones such as Sway, Hyprland, niri, and River, plus KDE Plasma and COSMIC. See docs/LINUX_SETUP.md.",
+			"neru does not recognize this Wayland compositor (XDG_CURRENT_DESKTOP=%q). Supported Wayland compositors are wlroots-based ones such as Sway, Hyprland, niri, River, Wayfire and labwc (or any that tags XDG_CURRENT_DESKTOP with :wlroots), plus KDE Plasma and COSMIC. See docs/LINUX_SETUP.md.",
 			os.Getenv("XDG_CURRENT_DESKTOP"),
 		)
 	case BackendUnknown:


### PR DESCRIPTION
## Description

This PR makes Neru start on labwc, and on any wlroots compositor that tags
`XDG_CURRENT_DESKTOP` with `:wlroots`. labwc sets `labwc:wlroots` by default,
and the detector only knew the five compositor names, so a labwc session
resolved to the unsupported `wayland-other` backend and the daemon refused to
start on a compositor that implements every protocol the wlroots path needs.

The `:wlroots` tag is the convention xdg-desktop-portal-wlr keys on, so
honoring it means a compositor that adopts it works without a Neru change.
Compositors that leave the variable unset already landed on wlroots.

The setup and desktop docs now say plainly which desktops are supported,
which reach the wlroots path by tag or by an unset variable, and which are
refused and why: the Mutter family (GNOME, Budgie, Cinnamon, Pantheon) has no
layer-shell, Weston neither, and Mir shells such as miracle-wm implement the
protocols but leave each for the shell to enable and none has been measured.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, detection only, no new port surface
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

Not run on a live labwc session. The change is confined to matching the
desktop name, and labwc's source sets `labwc:wlroots` unconditionally as its
default, so the remaining risk is a labwc build missing one of the wlroots
protocols, which the existing runtime probes report the same way they do on
any other wlroots compositor.
