### PR TITLE
fix(linux): keep the kde focused window current after the tray closes the bus

### DIFF
--- a/internal/adapter/platform/gnomeshell/bridge.go
+++ b/internal/adapter/platform/gnomeshell/bridge.go
@@ -82,7 +82,9 @@ type Bridge struct {
 	starting  bool
 	connected bool
 	warned    bool
-	watching  bool
+	// watched is the connection a serve loop is armed on, so a replacement
+	// connection gets its own loop even while the retired one winds down.
+	watched   *dbus.Conn
 	installed bool
 	// installHint is what the one install attempt did, kept so every later
 	// "absent" answer carries the next step, not only the attempt's own.
@@ -351,9 +353,8 @@ func (b *Bridge) connection() (*dbus.Conn, error) {
 }
 
 // connectionClosed is how a serve loop reports that its channel closed. It is
-// true, and the watch re-armed, only for the connection the bridge still
-// holds: a loop whose connection was replaced while it was busy must not reset
-// its successor's state.
+// true only for the connection the bridge still holds: a loop whose connection
+// was replaced while it was busy must not reset its successor's state.
 func (b *Bridge) connectionClosed(conn *dbus.Conn) bool {
 	b.startMu.Lock()
 	defer b.startMu.Unlock()
@@ -364,7 +365,6 @@ func (b *Bridge) connectionClosed(conn *dbus.Conn) bool {
 
 	b.conn = nil
 	b.connected = false
-	b.watching = false
 
 	return true
 }
@@ -386,8 +386,8 @@ func nameHasOwner(conn *dbus.Conn, name string) (bool, error) {
 // nothing is exported and nothing is written by it.
 func (b *Bridge) watch(conn *dbus.Conn) {
 	b.startMu.Lock()
-	already := b.watching
-	b.watching = true
+	already := b.watched == conn
+	b.watched = conn
 	b.startMu.Unlock()
 
 	if already {
@@ -434,6 +434,12 @@ func (b *Bridge) serve(conn *dbus.Conn, signals <-chan *dbus.Signal) {
 			}
 		}
 	}
+
+	b.startMu.Lock()
+	if b.watched == conn {
+		b.watched = nil
+	}
+	b.startMu.Unlock()
 
 	if !b.connectionClosed(conn) {
 		return

--- a/internal/adapter/platform/gnomeshell/bridge.go
+++ b/internal/adapter/platform/gnomeshell/bridge.go
@@ -346,9 +346,27 @@ func (b *Bridge) connection() (*dbus.Conn, error) {
 	}
 
 	b.conn = conn
-	b.watching = false
 
 	return conn, nil
+}
+
+// connectionClosed is how a serve loop reports that its channel closed. It is
+// true, and the watch re-armed, only for the connection the bridge still
+// holds: a loop whose connection was replaced while it was busy must not reset
+// its successor's state.
+func (b *Bridge) connectionClosed(conn *dbus.Conn) bool {
+	b.startMu.Lock()
+	defer b.startMu.Unlock()
+
+	if b.conn != conn {
+		return false
+	}
+
+	b.conn = nil
+	b.connected = false
+	b.watching = false
+
+	return true
 }
 
 func nameHasOwner(conn *dbus.Conn, name string) (bool, error) {
@@ -396,14 +414,14 @@ func (b *Bridge) watch(conn *dbus.Conn) {
 	signals := make(chan *dbus.Signal, signalBuffer)
 	conn.Signal(signals)
 
-	go b.serve(signals)
+	go b.serve(conn, signals)
 }
 
 // serve runs as long as the connection does. Every signal is checked by shape
 // rather than trusted to the match rules. The channel closing means the
 // connection went away, and a cache with no stream behind it is the stale
 // answer this bridge exists to end, so the bridge reconnects.
-func (b *Bridge) serve(signals <-chan *dbus.Signal) {
+func (b *Bridge) serve(conn *dbus.Conn, signals <-chan *dbus.Signal) {
 	for signal := range signals {
 		switch signal.Name {
 		case changedSignal:
@@ -417,17 +435,16 @@ func (b *Bridge) serve(signals <-chan *dbus.Signal) {
 		}
 	}
 
+	if !b.connectionClosed(conn) {
+		return
+	}
+
 	b.log().Debug("GNOME Shell bridge connection closed; reconnecting")
 
 	b.mu.Lock()
 	b.window, b.valid = Window{}, false
 	b.startErr = errNotConnected
 	b.mu.Unlock()
-
-	b.startMu.Lock()
-	b.connected = false
-	b.watching = false
-	b.startMu.Unlock()
 
 	b.EnsureStarted()
 }

--- a/internal/adapter/platform/kwin/geometry.go
+++ b/internal/adapter/platform/kwin/geometry.go
@@ -497,9 +497,9 @@ func (g *Geometry) install() error {
 }
 
 // connection returns the bridge's own bus connection, dialing one when there
-// is none or the last one was closed under it. A fresh connection carries no
-// watch, export or name, so the restart watch's claim is released with it and
-// install re-arms everything on the new one.
+// is none or the last one was closed under it. The watcher that owned the old
+// one releases the restart watch's claim on its way out (connectionClosed),
+// and install re-arms the watch, the export and the name on the new one.
 func (g *Geometry) connection() (*dbus.Conn, error) {
 	g.startMu.Lock()
 	defer g.startMu.Unlock()
@@ -514,9 +514,27 @@ func (g *Geometry) connection() (*dbus.Conn, error) {
 	}
 
 	g.conn = conn
-	g.watching.release()
 
 	return conn, nil
+}
+
+// connectionClosed is how a watcher reports that its channel closed. It is
+// true, and the watcher's claim released, only for the connection the bridge
+// still holds: a watcher whose connection was replaced while it was busy
+// handing over an owner change must not release the claim its successor took,
+// empty the successor's cache, or schedule a third install.
+func (g *Geometry) connectionClosed(conn *dbus.Conn) bool {
+	g.startMu.Lock()
+	defer g.startMu.Unlock()
+
+	if g.conn != conn {
+		return false
+	}
+
+	g.conn = nil
+	g.watching.release()
+
+	return true
 }
 
 // installScript writes the KWin script to disk and loads + starts it.

--- a/internal/adapter/platform/kwin/geometry.go
+++ b/internal/adapter/platform/kwin/geometry.go
@@ -57,6 +57,10 @@ const scriptFileName = "neru-kwin-geometry.js"
 // answers and only one of them should send a caller to the active screen.
 var errKWinAbsent = errors.New("org.kde.KWin is not on the session bus")
 
+// errBusClosed is the reason recorded when the bridge's connection went away
+// under it, until the reinstall it schedules says otherwise.
+var errBusClosed = errors.New("the session bus connection carrying the KWin bridge was closed")
+
 // errNoRuntimeDir and errRuntimeDirNotPrivate are the two ways a session can
 // fail to offer somewhere the geometry script may live. They are separate
 // because a user fixes them differently: the first is a session started outside
@@ -104,6 +108,14 @@ type Geometry struct {
 
 	// watching is the restart watch's one-shot claim (restart_watch.go).
 	watching claim
+
+	// conn is the bridge's own session-bus connection, dialed by connection.
+	// Not the process-wide dbus.SessionBus(): closing that closes every
+	// signal channel subscribed on it, and the tray closes it when its loop
+	// ends, which ended the restart watch silently and left the exported
+	// receiver on a dead connection with the last window still cached.
+	// Guarded by startMu.
+	conn *dbus.Conn
 
 	startMu   sync.Mutex
 	starting  bool
@@ -450,7 +462,7 @@ func (g *Geometry) recordAttempt(generation uint64, err error) {
 // ahead of that check on purpose — watchKWin says why it is not the same kind
 // of act.
 func (g *Geometry) install() error {
-	conn, err := dbus.SessionBus()
+	conn, err := g.connection()
 	if err != nil {
 		return fmt.Errorf("session bus: %w", err)
 	}
@@ -482,6 +494,29 @@ func (g *Geometry) install() error {
 	}
 
 	return g.installScript(conn)
+}
+
+// connection returns the bridge's own bus connection, dialing one when there
+// is none or the last one was closed under it. A fresh connection carries no
+// watch, export or name, so the restart watch's claim is released with it and
+// install re-arms everything on the new one.
+func (g *Geometry) connection() (*dbus.Conn, error) {
+	g.startMu.Lock()
+	defer g.startMu.Unlock()
+
+	if g.conn != nil && g.conn.Connected() {
+		return g.conn, nil
+	}
+
+	conn, err := dbus.ConnectSessionBus()
+	if err != nil {
+		return nil, err
+	}
+
+	g.conn = conn
+	g.watching.release()
+
+	return conn, nil
 }
 
 // installScript writes the KWin script to disk and loads + starts it.

--- a/internal/adapter/platform/kwin/geometry.go
+++ b/internal/adapter/platform/kwin/geometry.go
@@ -106,7 +106,7 @@ type Geometry struct {
 	// is set once and read from any goroutine.
 	logger atomic.Pointer[zap.Logger]
 
-	// watching is the restart watch's one-shot claim (restart_watch.go).
+	// watching is the restart watch's per-connection claim (restart_watch.go).
 	watching claim
 
 	// conn is the bridge's own session-bus connection, dialed by connection.
@@ -519,10 +519,11 @@ func (g *Geometry) connection() (*dbus.Conn, error) {
 }
 
 // connectionClosed is how a watcher reports that its channel closed. It is
-// true, and the watcher's claim released, only for the connection the bridge
-// still holds: a watcher whose connection was replaced while it was busy
-// handing over an owner change must not release the claim its successor took,
-// empty the successor's cache, or schedule a third install.
+// true only for the connection the bridge still holds: a watcher whose
+// connection was replaced while it was busy handing over an owner change must
+// not empty the successor's cache or schedule a third install. Its claim is
+// its own to release either way, and keyed by connection so releasing it
+// cannot touch the successor's.
 func (g *Geometry) connectionClosed(conn *dbus.Conn) bool {
 	g.startMu.Lock()
 	defer g.startMu.Unlock()
@@ -532,7 +533,6 @@ func (g *Geometry) connectionClosed(conn *dbus.Conn) bool {
 	}
 
 	g.conn = nil
-	g.watching.release()
 
 	return true
 }

--- a/internal/adapter/platform/kwin/geometry_test.go
+++ b/internal/adapter/platform/kwin/geometry_test.go
@@ -405,11 +405,11 @@ func TestShared_ReturnsOneBridge(t *testing.T) {
 	}
 }
 
-// TestGeometry_AClosedSignalChannelReinstalls pins what the bridge does when
-// the connection carrying its watch is closed under it: the cache empties, the
-// reason is recorded, and an install is scheduled on the spot rather than
-// waiting for a caller to notice a permanently stale window.
-func TestGeometry_AClosedSignalChannelReinstalls(t *testing.T) {
+// TestGeometry_ServeOwnerChanges_ReinstallsWhenTheChannelCloses pins what the
+// bridge does when the connection carrying its watch is closed under it: the
+// cache empties, the reason is recorded, and an install is scheduled on the
+// spot rather than waiting for a caller to notice a permanently stale window.
+func TestGeometry_ServeOwnerChanges_ReinstallsWhenTheChannelCloses(t *testing.T) {
 	geometry := newGeometry(nil)
 
 	installs := make(chan struct{}, 1)
@@ -427,7 +427,7 @@ func TestGeometry_AClosedSignalChannelReinstalls(t *testing.T) {
 	signals := make(chan *dbus.Signal)
 	close(signals)
 
-	geometry.serveOwnerChanges(signals)
+	geometry.serveOwnerChanges(nil, signals)
 
 	select {
 	case <-installs:
@@ -439,6 +439,39 @@ func TestGeometry_AClosedSignalChannelReinstalls(t *testing.T) {
 	if ok || err == nil {
 		t.Fatalf(
 			"Focused() after the channel closed = (ok=%v, err=%v), want the cache emptied with a reason",
+			ok,
+			err,
+		)
+	}
+}
+
+// TestGeometry_ServeOwnerChanges_IgnoresAReplacedConnection pins the other
+// half: a watcher whose connection the bridge has already replaced leaves the
+// successor's claim, cache and install alone when its own channel closes.
+func TestGeometry_ServeOwnerChanges_IgnoresAReplacedConnection(t *testing.T) {
+	geometry := newGeometry(nil)
+	geometry.installer = func() error {
+		t.Error("a retired watcher scheduled an install")
+
+		return nil
+	}
+
+	pushErr := geometry.UpdateActiveWindow("1,2,3,4,konsole,konsole,shell")
+	if pushErr != nil {
+		t.Fatal(pushErr)
+	}
+
+	geometry.conn = &dbus.Conn{}
+
+	signals := make(chan *dbus.Signal)
+	close(signals)
+
+	geometry.serveOwnerChanges(nil, signals)
+
+	_, ok, err := geometry.Focused()
+	if !ok || err != nil {
+		t.Fatalf(
+			"Focused() after a retired watcher's channel closed = (ok=%v, err=%v), want the cache untouched",
 			ok,
 			err,
 		)

--- a/internal/adapter/platform/kwin/geometry_test.go
+++ b/internal/adapter/platform/kwin/geometry_test.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"image"
 	"testing"
+	"time"
 
+	"github.com/godbus/dbus/v5"
 	"go.uber.org/zap"
 )
 
@@ -400,5 +402,45 @@ func TestShared_ReturnsOneBridge(t *testing.T) {
 
 	if first != second {
 		t.Fatal("Shared() handed out two caches; KDE geometry must have one source")
+	}
+}
+
+// TestGeometry_AClosedSignalChannelReinstalls pins what the bridge does when
+// the connection carrying its watch is closed under it: the cache empties, the
+// reason is recorded, and an install is scheduled on the spot rather than
+// waiting for a caller to notice a permanently stale window.
+func TestGeometry_AClosedSignalChannelReinstalls(t *testing.T) {
+	geometry := newGeometry(nil)
+
+	installs := make(chan struct{}, 1)
+	geometry.installer = func() error {
+		installs <- struct{}{}
+
+		return errKWinAbsent
+	}
+
+	pushErr := geometry.UpdateActiveWindow("1,2,3,4,konsole,konsole,shell")
+	if pushErr != nil {
+		t.Fatal(pushErr)
+	}
+
+	signals := make(chan *dbus.Signal)
+	close(signals)
+
+	geometry.serveOwnerChanges(signals)
+
+	select {
+	case <-installs:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no install attempt followed the closed channel")
+	}
+
+	_, ok, err := geometry.Focused()
+	if ok || err == nil {
+		t.Fatalf(
+			"Focused() after the channel closed = (ok=%v, err=%v), want the cache emptied with a reason",
+			ok,
+			err,
+		)
 	}
 }

--- a/internal/adapter/platform/kwin/restart_watch.go
+++ b/internal/adapter/platform/kwin/restart_watch.go
@@ -107,8 +107,11 @@ func (g *Geometry) watchKWin(conn *dbus.Conn) {
 	go g.serveOwnerChanges(signals)
 }
 
-// serveOwnerChanges runs for the daemon's life, which is the same life the
-// compositor it watches has.
+// serveOwnerChanges runs as long as the connection does. The channel closing
+// means the connection went away, and with it the watch, the exported
+// receiver and the owned name: a cache with no script able to feed it is the
+// stale answer this bridge exists to end, so it is emptied, the reason is
+// recorded, and a reinstall on a fresh connection is scheduled.
 func (g *Geometry) serveOwnerChanges(signals <-chan *dbus.Signal) {
 	for signal := range signals {
 		owner, ok := kwinOwnerFrom(signal)
@@ -118,6 +121,13 @@ func (g *Geometry) serveOwnerChanges(signals <-chan *dbus.Signal) {
 
 		g.kwinOwnerChanged(owner)
 	}
+
+	g.log().Debug("KWin bridge connection closed; reinstalling on a new one")
+
+	g.invalidate()
+	g.recordAttempt(g.forgetInstall(), errBusClosed)
+	g.watching.release()
+	g.EnsureStarted()
 }
 
 // kwinOwnerFrom reads a NameOwnerChanged for org.kde.KWin and returns its new

--- a/internal/adapter/platform/kwin/restart_watch.go
+++ b/internal/adapter/platform/kwin/restart_watch.go
@@ -35,34 +35,38 @@ const (
 	ownerSignalBuffer = 32
 )
 
-// claim is a one-shot flag: the first taker gets it and everyone after is told
-// no, until whoever holds it gives it back. It exists so setup that must happen
-// once cannot happen twice when two callers race, without each such flag
-// growing its own mutex and its own pair of methods.
+// claim is the restart watch's ownership, keyed by the connection the watch
+// was armed on. One connection gets one watcher: a second take for the same
+// connection is refused, while a replacement connection takes its own claim
+// even if the retired watcher has not exited yet, and a retired watcher
+// releasing on its way out releases only what it took.
 type claim struct {
 	mu   sync.Mutex
-	held bool
+	conn *dbus.Conn
 }
 
-// take reports whether the caller is the one that should do the work.
-func (c *claim) take() bool {
+// take reports whether the caller is the one that should arm the watch on conn.
+func (c *claim) take(conn *dbus.Conn) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.held {
+	if c.conn == conn {
 		return false
 	}
 
-	c.held = true
+	c.conn = conn
 
 	return true
 }
 
-// release hands the claim back, for a taker that could not finish.
-func (c *claim) release() {
+// release hands the claim back, for the taker of conn only.
+func (c *claim) release(conn *dbus.Conn) {
 	c.mu.Lock()
-	c.held = false
-	c.mu.Unlock()
+	defer c.mu.Unlock()
+
+	if c.conn == conn {
+		c.conn = nil
+	}
 }
 
 // watchKWin asks the bus to say when org.kde.KWin changes hands. Losing the
@@ -83,9 +87,9 @@ func (c *claim) release() {
 // claim. Nothing is exported, no name is owned, and nothing is written to disk
 // until KWin has answered for itself.
 //
-// The watch is armed once and outlives any number of restarts.
+// The watch is armed once per connection and outlives any number of restarts.
 func (g *Geometry) watchKWin(conn *dbus.Conn) {
-	if !g.watching.take() {
+	if !g.watching.take(conn) {
 		return
 	}
 
@@ -95,7 +99,7 @@ func (g *Geometry) watchKWin(conn *dbus.Conn) {
 		dbus.WithMatchArg(0, scriptingDest),
 	)
 	if matchErr != nil {
-		g.watching.release()
+		g.watching.release(conn)
 		g.log().Debug("KWin restart watch unavailable", zap.Error(matchErr))
 
 		return
@@ -121,6 +125,8 @@ func (g *Geometry) serveOwnerChanges(conn *dbus.Conn, signals <-chan *dbus.Signa
 
 		g.kwinOwnerChanged(owner)
 	}
+
+	g.watching.release(conn)
 
 	if !g.connectionClosed(conn) {
 		return

--- a/internal/adapter/platform/kwin/restart_watch.go
+++ b/internal/adapter/platform/kwin/restart_watch.go
@@ -104,7 +104,7 @@ func (g *Geometry) watchKWin(conn *dbus.Conn) {
 	signals := make(chan *dbus.Signal, ownerSignalBuffer)
 	conn.Signal(signals)
 
-	go g.serveOwnerChanges(signals)
+	go g.serveOwnerChanges(conn, signals)
 }
 
 // serveOwnerChanges runs as long as the connection does. The channel closing
@@ -112,7 +112,7 @@ func (g *Geometry) watchKWin(conn *dbus.Conn) {
 // receiver and the owned name: a cache with no script able to feed it is the
 // stale answer this bridge exists to end, so it is emptied, the reason is
 // recorded, and a reinstall on a fresh connection is scheduled.
-func (g *Geometry) serveOwnerChanges(signals <-chan *dbus.Signal) {
+func (g *Geometry) serveOwnerChanges(conn *dbus.Conn, signals <-chan *dbus.Signal) {
 	for signal := range signals {
 		owner, ok := kwinOwnerFrom(signal)
 		if !ok {
@@ -122,11 +122,14 @@ func (g *Geometry) serveOwnerChanges(signals <-chan *dbus.Signal) {
 		g.kwinOwnerChanged(owner)
 	}
 
+	if !g.connectionClosed(conn) {
+		return
+	}
+
 	g.log().Debug("KWin bridge connection closed; reinstalling on a new one")
 
 	g.invalidate()
 	g.recordAttempt(g.forgetInstall(), errBusClosed)
-	g.watching.release()
 	g.EnsureStarted()
 }
 

--- a/internal/adapter/platform/kwin/restart_watch_test.go
+++ b/internal/adapter/platform/kwin/restart_watch_test.go
@@ -245,24 +245,37 @@ func TestKWinOwnerFrom_ReadsOnlyKWinOwnerChanges(t *testing.T) {
 	}
 }
 
-// TestClaim_TakeAdmitsOneHolderAtATime pins what keeps the installer's retries
-// and every later reinstall from each adding a match rule and a goroutine that
-// live as long as the daemon does — while still letting an arming that failed
-// be tried again.
-func TestClaim_TakeAdmitsOneHolderAtATime(t *testing.T) {
+// TestClaim_TakeAdmitsOneHolderPerConnection pins what keeps the installer's
+// retries and every later reinstall from each adding a match rule and a
+// goroutine that live as long as the daemon does — while still letting an
+// arming that failed be tried again, and letting a replacement connection arm
+// its own watch while the retired one is still winding down.
+func TestClaim_TakeAdmitsOneHolderPerConnection(t *testing.T) {
 	var watching claim
 
-	if !watching.take() {
+	first, second := &dbus.Conn{}, &dbus.Conn{}
+
+	if !watching.take(first) {
 		t.Fatal("the first caller was not allowed to arm the restart watch")
 	}
 
-	if watching.take() {
-		t.Error("a second caller armed the restart watch again")
+	if watching.take(first) {
+		t.Error("a second caller armed the restart watch on the same connection again")
 	}
 
-	watching.release()
+	if !watching.take(second) {
+		t.Error("a replacement connection could not arm its watch while the old claim stood")
+	}
 
-	if !watching.take() {
+	watching.release(first)
+
+	if watching.take(second) {
+		t.Error("the retired watcher's release freed the replacement's claim")
+	}
+
+	watching.release(second)
+
+	if !watching.take(second) {
 		t.Error("a watch that could not be armed was never retried")
 	}
 }


### PR DESCRIPTION
## Description

This PR keeps the KWin geometry bridge alive after something else closes the shared session bus connection.

The bridge watched `org.kde.KWin`, exported its receiver and owned `org.neru.KWinBridge` on the process-wide `dbus.SessionBus()` connection. The system tray closes that connection when its loop ends, and the D-Bus library then closes every signal channel subscribed on it and drops the exported receiver. The bridge went quiet with the last window still cached and no log line: hints, `FocusedWindowBounds` and `neru action move_mouse --window` kept targeting whichever window was focused when the tray went away.

The bridge now dials a private connection nobody else can close. If its watch channel closes anyway, it empties the cache, records the reason, and reinstalls the script on a fresh connection, re-arming the watch, the export and the name.

This is the KDE half of the fix shipped for GNOME in #1638, where the same failure was reproduced and diagnosed. On KDE it triggers only when the tray loop ends, so a healthy Plasma session is not affected today, but the failure is silent when it does happen.

## Related Issues

Follow-up to #1638.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

`TestGeometry_AClosedSignalChannelReinstalls` drives the closed channel through the injectable installer and pins the three consequences: cache emptied, reason recorded, install scheduled. The KWin script itself and the `installScript` path are unchanged. Not exercised on a live Plasma session in this PR; the GNOME twin of the change was verified live in #1638. To reproduce on KDE, stop the StatusNotifier host so the tray loop ends, switch windows, and run `neru action move_mouse --window`.
