### PR TITLE
fix(linux): track windows already open when neru starts on wlroots

### DIFF
--- a/internal/adapter/platform/linux/wlroots_client.c
+++ b/internal/adapter/platform/linux/wlroots_client.c
@@ -1209,6 +1209,13 @@ static void neru_wlr_registry_global(
 	} else if (strcmp(interface, "zwlr_foreign_toplevel_manager_v1") == 0) {
 		c->toplevel_mgr =
 		    wl_registry_bind(registry, name, &zwlr_foreign_toplevel_manager_v1_interface, 3 < version ? 3 : version);
+		// The listener goes on before this handler returns. Binding makes the
+		// compositor replay a `toplevel` event for every existing window, and
+		// those arrive with the next roundtrip; a listener attached after it
+		// would miss every window already open, and the focus changes between
+		// them for the rest of the session (only windows opened later would be
+		// tracked at all).
+		zwlr_foreign_toplevel_manager_v1_add_listener(c->toplevel_mgr, &neru_wlr_manager_listener, c);
 	} else if (strcmp(interface, "ext_foreign_toplevel_list_v1") == 0) {
 		c->ext_toplevel_list_name = name;
 	} else if (strcmp(interface, "zcosmic_toplevel_info_v1") == 0 && version >= 2) {
@@ -1426,12 +1433,11 @@ NeruWlrootsClient *neru_wlr_connect(void) {
 	// and this is the case where the manager arrived after the capability.
 	neru_wlr_bind_relative_pointer(c);
 
-	// Subscribe to foreign-toplevel events. Binding the manager makes the
+	// The manager's listener was attached at bind time. Binding makes the
 	// compositor replay a `toplevel` event for every existing window; a
 	// roundtrip drains that initial burst (plus each handle's app_id/state/
 	// done) so the focused app_id is populated before the daemon needs it.
 	if (c->toplevel_mgr) {
-		zwlr_foreign_toplevel_manager_v1_add_listener(c->toplevel_mgr, &neru_wlr_manager_listener, c);
 		wl_display_roundtrip(c->display);
 	}
 


### PR DESCRIPTION
## Description

This PR makes Neru on wlroots compositors track the windows that were already open when the daemon started.

The wlroots client binds `zwlr_foreign_toplevel_manager_v1` inside the registry handler but attached its listener only after two more roundtrips. Binding makes the compositor replay a `toplevel` event for every existing window, and those events arrived in between with no listener attached, so the library dropped them. A daemon started with windows already open therefore never learned about any of them: switching focus between them produced no app-watcher event, per-app config never applied, and `neru doctor` reported no focused window. Windows opened after the daemon started were tracked normally, which is why a daemon autostarted at login looked fine and a daemon started by hand did not.

The listener is now attached at bind time, before the registry handler returns.

## Related Issues

None filed.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

Reproduced on Sway 1.11 with two windows open before `neru launch`: the app watcher logged no focus change at all, and a standalone client binding the same manager with its listener attached at bind time received every `toplevel`, `state` and `done` event Sway sent. After the fix the watcher logs foot, helium, foot across two `swaymsg focus` calls, and `neru doctor` reports the process capability as supported. The same behaviour reproduced on the commit before #1638, so it is not a regression from the GNOME work.

No unit test: the ordering lives inside the cgo client's connect sequence, and the repo's contract tests exercise it only through the desktop-driving integration tier. The COSMIC path is unaffected, since it attaches its listeners immediately after its own bind.
