### PR TITLE
fix(linux): pick the x11-focused window for hints instead of a chromium frame

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -690,13 +690,18 @@ toggle to force it. The result is a frame with a single empty child. Launch the
 app with `--force-renderer-accessibility`. Native GTK/Qt apps and Firefox need
 no flag. This is Chromium behavior, not a Neru limitation.
 
-**Picking the active frame on Wayland.** The AT-SPI `ACTIVE` state is
-unreliable on wlroots compositors (the focused window can report `ACTIVE=false`
-while background frames report `ACTIVE=true`), so Neru matches the AT-SPI frame
-against the compositor's focused **app_id** from
-`wlr-foreign-toplevel-management`, falling back to the `ACTIVE`/`SHOWING`
-heuristic on X11 or when no app_id is available (`findActiveFrame` in
-`atspi/scan.go`).
+**Picking the active frame.** The AT-SPI `ACTIVE` state cannot be trusted
+across applications. On wlroots compositors the focused window can report
+`ACTIVE=false` while background frames report `ACTIVE=true`. On X11,
+Chromium/Electron frames report `ACTIVE=true` whatever `_NET_ACTIVE_WINDOW`
+says. So Neru matches the AT-SPI frame against the focused window's identity
+instead. On Wayland that is the compositor's app_id and title from
+`wlr-foreign-toplevel-management`. On X11 it is the active window's WM_CLASS
+and `_NET_WM_NAME`. Both pairs are read as one snapshot
+(`linux.FocusedAppIdentity`). The `ACTIVE`/`SHOWING` heuristic is still the
+fallback when no identity is available (GNOME without the extension), and on
+X11 for an application whose AT-SPI name does not match its WM_CLASS
+(`findActiveFrame` in `atspi/scan.go`).
 
 **Window-origin offset on Wayland.** A Wayland client cannot know its own
 on-screen position, so AT-SPI reports element coordinates relative to the

--- a/internal/adapter/accessibility/atspi/client.go
+++ b/internal/adapter/accessibility/atspi/client.go
@@ -296,9 +296,10 @@ func (c *Client) ClickableNodes(
 
 	// Early-out: if focus already changed since this window was selected, the
 	// frame is stale, so skip the (subprocess-spawning) geometry query below and
-	// return nothing. When no focused app_id is available (X11/GNOME) there is
-	// nothing to compare, so the walk proceeds. The stability is re-checked after
-	// the geometry query to close the race window described there.
+	// return nothing. When no focused app_id is available (GNOME without the
+	// extension) there is nothing to compare, so the walk proceeds. The
+	// stability is re-checked after the geometry query to close the race window
+	// described there.
 	if !c.focusStableSince(win.focusedAppID, win.focusedTitle) {
 		return nil, nil
 	}

--- a/internal/adapter/accessibility/atspi/client_test.go
+++ b/internal/adapter/accessibility/atspi/client_test.go
@@ -96,6 +96,7 @@ func TestSelectFrame(t *testing.T) {
 	var (
 		fTitle  = accRef{Name: "focused-title"}
 		fShow   = accRef{Name: "focused-showing"}
+		fActive = accRef{Name: "focused-active"}
 		active  = accRef{Name: "active"}
 		activeA = accRef{Name: "active-any"}
 		showing = accRef{Name: "showing"}
@@ -178,7 +179,35 @@ func TestSelectFrame(t *testing.T) {
 			want: accRef{}, wantOK: false,
 		},
 		{
-			name: "no focused app_id (X11/GNOME) falls back to active+showing",
+			name: "X11 ambiguous siblings pick the focused app's own ACTIVE window",
+			cand: frameCandidates{
+				focusedShowingFrame: fShow, focusedShowingCount: 2,
+				focusedActiveFrame: fActive, focusedActiveCount: 1,
+				activeShowing: active, haveActiveShowing: true,
+				haveFocused: true, focusedActiveDisambiguates: true,
+			},
+			want: fActive, wantOK: true,
+		},
+		{
+			name: "X11 ambiguous siblings with no ACTIVE take the first showing sibling",
+			cand: frameCandidates{
+				focusedShowingFrame: fShow, focusedShowingCount: 2,
+				activeShowing: active, haveActiveShowing: true,
+				haveFocused: true, focusedActiveDisambiguates: true,
+			},
+			want: fShow, wantOK: true,
+		},
+		{
+			name: "X11 focused app with no frame never takes another app's ACTIVE frame",
+			cand: frameCandidates{
+				activeShowing: active, haveActiveShowing: true,
+				showingAny: showing, haveShowingAny: true,
+				haveFocused: true, focusedActiveDisambiguates: true,
+			},
+			want: accRef{}, wantOK: false,
+		},
+		{
+			name: "no focused app_id (GNOME without the extension) falls back to active+showing",
 			cand: frameCandidates{
 				activeShowing: active, haveActiveShowing: true,
 				activeAny: activeA, haveActiveAny: true,

--- a/internal/adapter/accessibility/atspi/client_test.go
+++ b/internal/adapter/accessibility/atspi/client_test.go
@@ -189,13 +189,23 @@ func TestSelectFrame(t *testing.T) {
 			want: fActive, wantOK: true,
 		},
 		{
-			name: "X11 ambiguous siblings with no ACTIVE take the first showing sibling",
+			name: "X11 ambiguous siblings with no ACTIVE return nothing (no sibling guess)",
 			cand: frameCandidates{
 				focusedShowingFrame: fShow, focusedShowingCount: 2,
 				activeShowing: active, haveActiveShowing: true,
 				haveFocused: true, focusedActiveDisambiguates: true,
 			},
-			want: fShow, wantOK: true,
+			want: accRef{}, wantOK: false,
+		},
+		{
+			name: "X11 ambiguous siblings with several ACTIVE return nothing (no sibling guess)",
+			cand: frameCandidates{
+				focusedShowingFrame: fShow, focusedShowingCount: 2,
+				focusedActiveFrame: fActive, focusedActiveCount: 2,
+				activeShowing: active, haveActiveShowing: true,
+				haveFocused: true, focusedActiveDisambiguates: true,
+			},
+			want: accRef{}, wantOK: false,
 		},
 		{
 			name: "X11 focused app with no frame never takes another app's ACTIVE frame",

--- a/internal/adapter/accessibility/atspi/events.go
+++ b/internal/adapter/accessibility/atspi/events.go
@@ -199,7 +199,7 @@ func (c *Client) recordActiveWindow(conn *dbus.Conn, frame accRef) {
 // the cache safe: a stale entry (focus moved without a window:activate) or a
 // missing one can never resolve to the wrong window.
 func (c *Client) activeWindowMatching(focusedAppID, focusedTitle string) (accRef, bool) {
-	// Without a compositor focus identity (X11/GNOME) there is nothing to
+	// Without a focus identity (GNOME without the extension) there is nothing to
 	// validate the cache against, so it cannot be trusted.
 	if focusedAppID == "" {
 		return accRef{}, false

--- a/internal/adapter/accessibility/atspi/scan.go
+++ b/internal/adapter/accessibility/atspi/scan.go
@@ -109,9 +109,9 @@ func (c *Client) findActiveFrame(
 
 	// On X11 the ACTIVE state can be trusted within one application but not
 	// across the bus, because Chromium/Electron frames advertise ACTIVE whatever
-	// _NET_ACTIVE_WINDOW says (#1644). So ACTIVE may pick among the focused
-	// app's own siblings, and the cross-application heuristic survives only for
-	// an app whose AT-SPI name does not match its WM_CLASS.
+	// _NET_ACTIVE_WINDOW says (#1644). So a single ACTIVE frame may pick among
+	// the focused app's own siblings, and the cross-application heuristic
+	// survives only for an app whose AT-SPI name does not match its WM_CLASS.
 	focusedActiveDisambiguates := backend == platform.BackendX11
 
 	apps := c.children(ctx, conn, root)
@@ -606,8 +606,8 @@ type frameCandidates struct {
 	activeStateIdentifiesFocus bool
 	// focusedActiveDisambiguates is true where ACTIVE can be trusted among one
 	// application's own windows but not across applications (X11). Ambiguous
-	// siblings resolve to the focused app's ACTIVE window, else its first
-	// showing one, and never to another application's frame.
+	// siblings resolve to the focused app's single ACTIVE window, never to a
+	// guess among them or to another application's frame.
 	focusedActiveDisambiguates bool
 }
 
@@ -641,14 +641,11 @@ func selectFrame(cand frameCandidates) (accRef, bool) {
 			return cand.activeAny, true
 		}
 
-		if cand.focusedActiveDisambiguates {
-			if cand.focusedActiveCount > 0 {
-				return cand.focusedActiveFrame, true
-			}
-
-			if cand.focusedShowingCount > 0 {
-				return cand.focusedShowingFrame, true
-			}
+		// X11: exactly one ACTIVE sibling of the focused app is that app's own
+		// answer. Zero or several would leave enumeration order to choose, and
+		// hints in the wrong sibling are worse than none.
+		if cand.focusedActiveDisambiguates && cand.focusedActiveCount == 1 {
+			return cand.focusedActiveFrame, true
 		}
 
 		return accRef{}, false

--- a/internal/adapter/accessibility/atspi/scan.go
+++ b/internal/adapter/accessibility/atspi/scan.go
@@ -65,13 +65,15 @@ func isNonTargetSurfaceApp(name string) bool {
 	}
 }
 
-// findActiveFrame locates the focused top-level window. On Wayland the
-// compositor's focused app_id is the signal to trust — AT-SPI's ACTIVE state
-// lies on wlroots compositors, marking background frames active — so an app_id
-// match beats the heuristic. Without one (X11, GNOME, no AT-SPI frame) the
-// order is ACTIVE+SHOWING, any ACTIVE, any SHOWING; and when an app_id matches
-// no application, that fallback runs only on KWin, where ACTIVE is reliable —
-// on wlroots it could pick a background surface, so hints just do not appear.
+// findActiveFrame locates the focused top-level window. The focused app_id is
+// the signal to trust: the compositor's toplevel on Wayland, the WM_CLASS of
+// _NET_ACTIVE_WINDOW on X11. AT-SPI's own ACTIVE state marks background frames
+// active on wlroots compositors and on Chromium/Electron frames under X11, so
+// an app_id match beats it. Without an app_id (GNOME without the extension, or
+// no AT-SPI frame) the order is ACTIVE+SHOWING, any ACTIVE, any SHOWING. When
+// an app_id matches no application, that fallback runs on KWin, where ACTIVE
+// is reliable, and on X11, where it is what X11 ran before it had an app_id.
+// On wlroots it could pick a background surface, so hints just do not appear.
 // focusedAppID/focusedTitle are one snapshot, so frame and stability check
 // agree.
 func (c *Client) findActiveFrame(
@@ -99,9 +101,18 @@ func (c *Client) findActiveFrame(
 	haveFocused := focusedAppID != ""
 	haveFocusedTitle := focusedTitle != ""
 
+	backend := platform.DetectLinuxBackend()
+
 	// The AT-SPI ACTIVE state reliably marks the compositor-focused window only
 	// on KWin/KDE; on wlroots it is set inconsistently across frames.
-	activeStateIdentifiesFocus := platform.DetectLinuxBackend() == platform.BackendWaylandKDE
+	activeStateIdentifiesFocus := backend == platform.BackendWaylandKDE
+
+	// On X11 the ACTIVE state can be trusted within one application but not
+	// across the bus, because Chromium/Electron frames advertise ACTIVE whatever
+	// _NET_ACTIVE_WINDOW says (#1644). So ACTIVE may pick among the focused
+	// app's own siblings, and the cross-application heuristic survives only for
+	// an app whose AT-SPI name does not match its WM_CLASS.
+	focusedActiveDisambiguates := backend == platform.BackendX11
 
 	apps := c.children(ctx, conn, root)
 
@@ -117,6 +128,12 @@ func (c *Client) findActiveFrame(
 	// below).
 	if haveFocused {
 		matches := c.findFocusedApps(ctx, conn, apps, focusedAppID)
+
+		c.logger.Debug("AT-SPI focused app probe",
+			zap.Int("apps", len(apps)),
+			zap.Int("matches", len(matches)),
+			zap.Bool("haveTitle", haveFocusedTitle))
+
 		if len(matches) > 0 {
 			metas := make([]appMeta, len(apps))
 			for index := range metas {
@@ -138,6 +155,11 @@ func (c *Client) findActiveFrame(
 			)
 			cand := mergeFrameScan(scans)
 
+			c.logger.Debug("AT-SPI focused app frames",
+				zap.Int("showing", cand.focusedShowingCount),
+				zap.Int("titleMatches", cand.focusedTitleCount),
+				zap.Int("active", cand.focusedActiveCount))
+
 			if cand.focusedTitleCount == 1 {
 				c.logFrameSelection(start, "focused-title", len(apps), scanned)
 
@@ -149,9 +171,28 @@ func (c *Client) findActiveFrame(
 
 				return cand.focusedShowingFrame, true
 			}
+
+			if focusedActiveDisambiguates {
+				cand.haveFocused = true
+				cand.focusedActiveDisambiguates = true
+
+				if frame, ok := selectFrame(cand); ok {
+					c.logFrameSelection(start, "focused-active", len(apps), scanned)
+
+					return frame, true
+				}
+			}
 		}
 
-		if !activeStateIdentifiesFocus {
+		switch {
+		case activeStateIdentifiesFocus:
+			// KWin/KDE: fall through to the cross-application ACTIVE fallback,
+			// which needs every app's frames.
+		case focusedActiveDisambiguates:
+			// X11: no AT-SPI application answered to the WM_CLASS, so the focus
+			// identity cannot narrow the scan. Drop it and run the old heuristic.
+			haveFocused = false
+		default:
 			// wlroots: the ACTIVE-state fallback is unreliable, so a focused app
 			// that cannot be uniquely resolved yields no frame — and there is no
 			// reason to scan the rest of the bus.
@@ -159,13 +200,11 @@ func (c *Client) findActiveFrame(
 
 			return accRef{}, false
 		}
-
-		// KWin/KDE: fall through to the cross-application ACTIVE fallback, which
-		// needs every app's frames.
 	}
 
-	// Full scan: no focused app_id (X11/GNOME), or KWin/KDE with a focused app
-	// that could not be uniquely resolved and needs the cross-app ACTIVE state.
+	// Full scan: no focused app_id (GNOME without the extension), an X11 focus
+	// no AT-SPI app answers to, or KWin/KDE with a focused app that could not be
+	// uniquely resolved and needs the cross-app ACTIVE state.
 	// This path names every app, so a wedged app can still cost one timeout — but
 	// it is reached only without a usable focused app_id, not on the wlroots hot
 	// path above.
@@ -488,6 +527,14 @@ func mergeFrameScan(scans []appFramesScan) frameCandidates {
 					cand.focusedShowingFrame = frame.ref
 				}
 
+				if frame.active {
+					cand.focusedActiveCount++
+
+					if cand.focusedActiveCount == 1 {
+						cand.focusedActiveFrame = frame.ref
+					}
+				}
+
 				if frame.titleMatches {
 					cand.focusedTitleCount++
 
@@ -537,6 +584,8 @@ type frameCandidates struct {
 	focusedTitleCount   int    // windows of the focused app matching that title
 	focusedShowingFrame accRef // first showing window of the focused app
 	focusedShowingCount int    // showing windows of the focused app
+	focusedActiveFrame  accRef // first ACTIVE showing window of the focused app
+	focusedActiveCount  int    // ACTIVE showing windows of the focused app
 
 	// Cross-application ACTIVE/SHOWING fallbacks (reliable only on KDE).
 	activeShowing     accRef
@@ -555,6 +604,11 @@ type frameCandidates struct {
 	// activeStateIdentifiesFocus is true only where the AT-SPI ACTIVE state
 	// reliably marks the focused window (KWin/KDE).
 	activeStateIdentifiesFocus bool
+	// focusedActiveDisambiguates is true where ACTIVE can be trusted among one
+	// application's own windows but not across applications (X11). Ambiguous
+	// siblings resolve to the focused app's ACTIVE window, else its first
+	// showing one, and never to another application's frame.
+	focusedActiveDisambiguates bool
 }
 
 // selectFrame chooses the focused frame from the ranked candidates. It is the
@@ -585,6 +639,16 @@ func selectFrame(cand frameCandidates) (accRef, bool) {
 
 		if cand.activeStateIdentifiesFocus && cand.haveActiveAny {
 			return cand.activeAny, true
+		}
+
+		if cand.focusedActiveDisambiguates {
+			if cand.focusedActiveCount > 0 {
+				return cand.focusedActiveFrame, true
+			}
+
+			if cand.focusedShowingCount > 0 {
+				return cand.focusedShowingFrame, true
+			}
 		}
 
 		return accRef{}, false

--- a/internal/adapter/platform/linux/system_focused_app.go
+++ b/internal/adapter/platform/linux/system_focused_app.go
@@ -30,15 +30,20 @@ func FocusedAppID(backend string) (string, bool) {
 
 // FocusedAppIdentity returns the focused window's app_id and title together,
 // read as one snapshot so they describe the same window, for the given
-// backend. The title disambiguates multiple windows of one application. The
-// bool is false where the backend has no live source: X11, an unknown
-// backend, nothing focused, or the GNOME extension not running.
+// backend. The title disambiguates multiple windows of one application. On
+// X11 the pair is the active window's WM_CLASS and _NET_WM_NAME, read over one
+// connection; on Wayland it is the toplevel's app_id and title. The bool is
+// false where there is no live source: an unknown backend, nothing focused,
+// the GNOME extension not running, or a CGO-disabled build on X11.
 func FocusedAppIdentity(backend string) (string, string, bool) {
-	if backend == backendWaylandGNOME {
+	switch backend {
+	case backendX11:
+		return x11FocusedAppIdentity()
+	case backendWaylandGNOME:
 		return gnomeFocusedAppIdentity()
+	default:
+		return WaylandFocusedAppIdentity()
 	}
-
-	return WaylandFocusedAppIdentity()
 }
 
 // gnomeFocusedAppIdentity reads the extension's cache. EnsureStarted is asked

--- a/internal/adapter/platform/linux/system_x11_cgo.go
+++ b/internal/adapter/platform/linux/system_x11_cgo.go
@@ -170,29 +170,50 @@ func x11WindowPIDQuery(display *C.Display, window C.Window, pid *C.ulong) x11Win
 // x11ActiveWindowQuery does that for both callers — this one just has one
 // honest answer for all of them.
 func x11FocusedAppID() (string, bool) {
+	appID, _, ok := x11FocusedAppIdentity()
+
+	return appID, ok
+}
+
+// x11FocusedAppIdentity reads the active window's WM_CLASS and title over one
+// display connection, so both describe the window _NET_ACTIVE_WINDOW named at
+// the moment of the read. Per-app configuration and the AT-SPI frame match are
+// keyed on the class. The title (_NET_WM_NAME, else WM_NAME) tells sibling
+// windows of one application apart, the job the xdg_toplevel title does on
+// Wayland. A window with a class but no title is still reported, with an empty
+// title, since a single showing window needs none.
+func x11FocusedAppIdentity() (string, string, bool) {
 	display, err := x11OpenDisplay()
 	if err != nil {
-		return "", false
+		return "", "", false
 	}
 	defer C.neru_x11_close_display(display)
 
 	window, result := x11ActiveWindowQuery(display)
 	if result != x11ActiveWindowFound {
-		return "", false
+		return "", "", false
 	}
 
 	className := C.neru_x11_get_window_class(display, window)
 	if className == nil {
-		return "", false
+		return "", "", false
 	}
 	defer C.free(unsafe.Pointer(className))
 
 	appID := C.GoString(className)
 	if appID == "" {
-		return "", false
+		return "", "", false
 	}
 
-	return appID, true
+	var title string
+
+	if cTitle := C.neru_x11_get_window_title(display, window); cTitle != nil {
+		title = C.GoString(cTitle)
+
+		C.free(unsafe.Pointer(cTitle))
+	}
+
+	return appID, title, true
 }
 
 var (

--- a/internal/adapter/platform/linux/system_x11_nocgo.go
+++ b/internal/adapter/platform/linux/system_x11_nocgo.go
@@ -35,6 +35,10 @@ func x11FocusedAppID() (string, bool) {
 	return "", false
 }
 
+func x11FocusedAppIdentity() (string, string, bool) {
+	return "", "", false
+}
+
 // x11FocusEventFD is unavailable without CGO — the focus monitor uses Xlib.
 // Callers fall back to polling.
 func x11FocusEventFD() (int, bool) {

--- a/internal/adapter/platform/linux/x11_system.c
+++ b/internal/adapter/platform/linux/x11_system.c
@@ -378,6 +378,69 @@ char *neru_x11_get_window_class(Display *display, Window window) {
 	return class_name;
 }
 
+// Titles longer than this many 32-bit units (16 KiB) are truncated. The
+// AT-SPI frame name Neru compares against is far shorter than that.
+#define NERU_X11_TITLE_MAX_LONGS 4096
+
+char *neru_x11_get_window_title(Display *display, Window window) {
+	if (window == 0) {
+		return NULL;
+	}
+
+	Atom property = XInternAtom(display, "_NET_WM_NAME", False);
+	Atom utf8 = XInternAtom(display, "UTF8_STRING", False);
+	Atom actual_type;
+	int actual_format;
+	unsigned long item_count;
+	unsigned long bytes_after;
+	unsigned char *data = NULL;
+
+	neru_x11_error_trap_begin(display);
+	int status = XGetWindowProperty(
+	    display, window, property, 0, NERU_X11_TITLE_MAX_LONGS, False, utf8, &actual_type, &actual_format, &item_count,
+	    &bytes_after, &data);
+	int trapped = neru_x11_error_trap_end(display);
+
+	if (trapped) {
+		// BadWindow: the window closed between the active-window read and this
+		// one. A window that is gone has no title to fall back to.
+		if (data != NULL) {
+			XFree(data);
+		}
+		return NULL;
+	}
+
+	char *title = NULL;
+	if (status == Success && actual_type == utf8 && actual_format == 8 && item_count > 0 && data != NULL) {
+		// XGetWindowProperty NUL-terminates the returned data; item_count is
+		// the byte length for an 8-bit property.
+		title = strndup((const char *)data, item_count);
+	}
+	if (data != NULL) {
+		XFree(data);
+	}
+	if (title != NULL) {
+		return title;
+	}
+
+	// Older toolkits set only the ICCCM WM_NAME (Latin-1 or COMPOUND_TEXT).
+	// XFetchName hands back its raw bytes. AT-SPI reports the same bytes for
+	// those windows, so the comparison still lines up.
+	char *wm_name = NULL;
+	neru_x11_error_trap_begin(display);
+	int got = XFetchName(display, window, &wm_name);
+	trapped = neru_x11_error_trap_end(display);
+
+	if (got != 0 && !trapped && wm_name != NULL && wm_name[0] != '\0') {
+		title = strdup(wm_name);
+	}
+	if (wm_name != NULL) {
+		XFree(wm_name);
+	}
+
+	return title;
+}
+
 NeruX11Monitor *neru_x11_get_monitors(Display *display, int *count) {
 	Window root = neru_x11_root_window(display);
 	int monitor_count = 0;

--- a/internal/adapter/platform/linux/x11_system.h
+++ b/internal/adapter/platform/linux/x11_system.h
@@ -61,6 +61,11 @@ int neru_x11_get_window_pid(Display *display, Window window, unsigned long *out)
 // WM_CLASS "class" field (res_class), or NULL when unavailable. The caller
 // owns the returned pointer and must free() it.
 char *neru_x11_get_window_class(Display *display, Window window);
+// neru_x11_get_window_title returns a heap-allocated copy of the window's
+// _NET_WM_NAME (UTF-8), falling back to the ICCCM WM_NAME when the EWMH
+// property is absent, or NULL when the window sets neither or has closed. The
+// caller owns the returned pointer and must free() it.
+char *neru_x11_get_window_title(Display *display, Window window);
 NeruX11Monitor *neru_x11_get_monitors(Display *display, int *count);
 void neru_x11_free_monitors(NeruX11Monitor *monitors, int count);
 


### PR DESCRIPTION
## Description

This PR makes hints on X11 select the window that actually has focus, so a running Chromium or Electron app no longer blanks hints in every other application.

On X11 the AT-SPI frame selector never received a focus identity and fell back to the cross-application `ACTIVE` state. Chromium and Electron frames advertise `ACTIVE` regardless of `_NET_ACTIVE_WINDOW`, so with one of them open the selector walked its near-empty tree and logged `No hints generated for action` in the focused app. The app watcher knew the right WM_CLASS the whole time.

The active window's WM_CLASS and `_NET_WM_NAME` are now read as one snapshot and handed to the selector, the same shape the Wayland app_id and title take. The focused app's frames are scanned first, the title tells sibling windows apart, and an ambiguous set resolves to the focused app's own `ACTIVE` window rather than another application's. The old cross-application heuristic remains only for an app whose AT-SPI name does not match its WM_CLASS, so nothing that worked before regresses. Selection drops from a full bus scan to one app scan.

Tested live on i3 with Firefox, a second Firefox window, VS Code, a Chromium-based browser, ghostty and Nautilus all open. Each picked its own frame by title in 3 to 16 ms where the full scan took 830 ms and picked the Chromium frame. Two Firefox windows were told apart by title. A window absent from the a11y bus still runs the old heuristic.

## Related Issues

Closes #1644

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

The CGO-disabled Linux build keeps the existing empty-identity stub, which the callers already treat as "no focus source".

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

Each X11 identity read opens a display connection, and a hints activation reads it up to three times (selection plus the two stability checks). That is sub-millisecond against a local server and is the one latency cost added.

Two debug lines in `findActiveFrame` now log the focused-app probe result and frame counts, numbers only, so a future report shows which branch ran.
